### PR TITLE
fix(incident): show telemetry previews at the snapshot time, not the past hour

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionInstanceTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Exceptions/ExceptionInstanceTable.tsx
@@ -18,6 +18,15 @@ export interface ComponentProps {
   title: string;
   description: string;
   query: Query<ExceptionInstance>;
+  // Rendered in the card header, e.g. the snapshot window an incident is scoped to.
+  rightElement?: ReactElement | undefined;
+  /*
+   * Set by hosts that pin the query to a fixed window (incident / alert
+   * previews). Without it the table restores a "Time" filter from the URL on
+   * mount, which replaces the pinned window with an unrelated one and gives no
+   * sign it happened.
+   */
+  disableUrlState?: boolean | undefined;
 }
 
 const ExceptionInstanceTable: FunctionComponent<ComponentProps> = (
@@ -49,9 +58,11 @@ const ExceptionInstanceTable: FunctionComponent<ComponentProps> = (
       isCreateable={false}
       isViewable={false}
       userPreferencesKey="exception-instance-table"
+      disableUrlState={props.disableUrlState}
       cardProps={{
         title: props.title,
         description: props.description,
+        rightElement: props.rightElement,
       }}
       query={computedQuery}
       sortBy="time"

--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
@@ -68,6 +68,8 @@ import RangeStartAndEndDateTime, {
 } from "Common/Types/Time/RangeStartAndEndDateTime";
 import TimeRange from "Common/Types/Time/TimeRange";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
+import TelemetryType from "Common/Types/Telemetry/TelemetryType";
 import { writeTelemetryViewerUrlState } from "../../Utils/TelemetryViewerUrlState";
 
 export interface ComponentProps {
@@ -357,15 +359,48 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
     return readInitialUrlState(effectiveDefaultPageSize);
   }, [props.syncUrlState, effectiveDefaultPageSize]);
 
+  /*
+   * A caller that puts an explicit `time` window on logQuery is describing a
+   * moment, not a filter — the incident and alert pages pass the window the
+   * monitor actually evaluated over when it opened the event. Adopt it as the
+   * picker's value so the whole viewer (list, histogram, facets) is anchored
+   * there. Without this the viewer silently re-stamps its rolling default over
+   * the window, and an incident from last Tuesday renders the past hour of
+   * unrelated logs under the heading "Logs for this incident".
+   *
+   * Resolved as CUSTOM, so live polling and preset re-anchoring leave it alone.
+   * Null for every caller that passes no window (the resource log pages), which
+   * keeps the historical PAST_ONE_HOUR default for them.
+   */
+  const pinnedTimeRange: RangeStartAndEndDateTime | null = useMemo(() => {
+    return TelemetryQueryTimeRange.getPinnedRangeForQuery(
+      props.logQuery,
+      TelemetryType.Log,
+    );
+  }, [props.logQuery]);
+
+  /*
+   * Resolved once, on mount, and shared by the two states below so the log
+   * list and the picker cannot start out describing different windows. Held in
+   * state rather than a memo because it is a seed: later renders must not
+   * recompute it, or a caller rebuilding its query would keep yanking the user
+   * back to the pin. The props-sync effect below is what follows a genuinely
+   * new window.
+   */
+  const [initialTimeRange] = useState<RangeStartAndEndDateTime>(() => {
+    return (
+      pinnedTimeRange ||
+      initialUrlState?.timeRange || { range: TimeRange.PAST_ONE_HOUR }
+    );
+  });
+
   const [logs, setLogs] = useState<Array<Log>>([]);
   const [error, setError] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [filterOptions, setFilterOptions] = useState<Query<Log>>(() => {
     const base: Query<Log> = buildBaseQuery(props);
-    const initialRange: RangeStartAndEndDateTime =
-      initialUrlState?.timeRange || { range: TimeRange.PAST_ONE_HOUR };
     const defaultRange: InBetween<Date> =
-      RangeStartAndEndDateTimeUtil.getStartAndEndDate(initialRange);
+      RangeStartAndEndDateTimeUtil.getStartAndEndDate(initialTimeRange);
     (base as any).time = new InBetween<Date>(
       defaultRange.startValue,
       defaultRange.endValue,
@@ -424,14 +459,35 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
   >(initialUrlState?.facetFilters || new Map());
 
   // Time range state — single source of truth for histogram, facets, and log query
-  const [timeRange, setTimeRange] = useState<RangeStartAndEndDateTime>(
-    initialUrlState?.timeRange || { range: TimeRange.PAST_ONE_HOUR },
-  );
+  const [timeRange, setTimeRange] =
+    useState<RangeStartAndEndDateTime>(initialTimeRange);
 
   useEffect(() => {
     const base: Query<Log> = buildBaseQuery(props);
+
+    /*
+     * A new pinned window means the caller is describing a different moment
+     * (the incident page re-fetching), so follow it rather than re-stamping
+     * the window the user is currently looking at. With no pinned window this
+     * keeps the user's current picker value, as before.
+     */
+    const nextTimeRange: RangeStartAndEndDateTime =
+      pinnedTimeRange || timeRange;
+
+    /*
+     * Compare by value, not identity. A host that rebuilds its query object on
+     * every render hands us an equal-but-new window each time; setting state
+     * from it unconditionally would re-render, rebuild, and loop.
+     */
+    if (
+      pinnedTimeRange &&
+      !TelemetryQueryTimeRange.isSameRange(pinnedTimeRange, timeRange)
+    ) {
+      setTimeRange(pinnedTimeRange);
+    }
+
     const dateRange: InBetween<Date> =
-      RangeStartAndEndDateTimeUtil.getStartAndEndDate(timeRange);
+      RangeStartAndEndDateTimeUtil.getStartAndEndDate(nextTimeRange);
     (base as any).time = new InBetween<Date>(
       dateRange.startValue,
       dateRange.endValue,
@@ -941,6 +997,16 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
 
     hasAppliedInitialSavedView.current = true;
 
+    /*
+     * A pinned window came from the host, not from the user browsing logs, and
+     * a saved view carries its own time range — auto-applying the project
+     * default here would move an incident's preview off the moment it is
+     * about. The user can still pick a saved view by hand.
+     */
+    if (pinnedTimeRange) {
+      return;
+    }
+
     const defaultSavedView: LogSavedView | undefined = savedViews.find(
       (savedView: LogSavedView) => {
         return Boolean(savedView.isDefault);
@@ -950,7 +1016,7 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
     if (defaultSavedView) {
       applySavedView(defaultSavedView);
     }
-  }, [applySavedView, isSavedViewLoading, savedViews]);
+  }, [applySavedView, isSavedViewLoading, savedViews, pinnedTimeRange]);
 
   useEffect(() => {
     if (!selectedSavedViewId) {

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricCharts.tsx
@@ -50,6 +50,7 @@ import MetricUtil, {
   sanitizeAttributeFilters,
 } from "./Utils/Metrics";
 import InBetween from "Common/Types/BaseDatabase/InBetween";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
 import Navigation from "Common/UI/Utils/Navigation";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import PageMap from "../../Utils/PageMap";
@@ -1239,14 +1240,17 @@ const MetricCharts: FunctionComponent<ComponentProps> = (
    * re-runs only when the time window, metric set, or filters actually
    * change.
    */
-  const startMs: number | undefined =
-    props.metricViewData.startAndEndDate?.startValue instanceof Date
-      ? (props.metricViewData.startAndEndDate.startValue as Date).getTime()
-      : undefined;
-  const endMs: number | undefined =
-    props.metricViewData.startAndEndDate?.endValue instanceof Date
-      ? (props.metricViewData.startAndEndDate.endValue as Date).getTime()
-      : undefined;
+  /*
+   * Resolved through the shared coercion rather than `instanceof Date`: a
+   * window restored from a stored incident/alert snapshot holds ISO strings,
+   * and testing the class left startMs/endMs undefined there — which made the
+   * effect below bail, so exemplar drill-down dots never appeared on the one
+   * surface where jumping from a spike to the causing trace matters most.
+   */
+  const exemplarWindow: InBetween<Date> | null =
+    TelemetryQueryTimeRange.toDateWindow(props.metricViewData.startAndEndDate);
+  const startMs: number | undefined = exemplarWindow?.startValue.getTime();
+  const endMs: number | undefined = exemplarWindow?.endValue.getTime();
 
   interface ExemplarTarget {
     key: string;

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricView.tsx
@@ -37,6 +37,7 @@ import Icon from "Common/UI/Components/Icon/Icon";
 import AggregationInterval from "Common/Types/BaseDatabase/AggregationInterval";
 import AggregationIntervalUtil from "Common/Types/BaseDatabase/AggregationIntervalUtil";
 import ObjectID from "Common/Types/ObjectID";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
 import ChartTimeReferenceLineProps from "Common/UI/Components/Charts/Types/TimeReferenceLineProps";
 import ChartReferenceRegionProps from "Common/UI/Components/Charts/Types/ReferenceRegionProps";
 
@@ -100,14 +101,18 @@ const getAlignedWindowForData: (data: MetricViewData) => {
   effectiveData: MetricViewData;
   aggregationInterval: AggregationInterval | undefined;
 } => {
-  const start: Date | undefined = data.startAndEndDate?.startValue as
-    | Date
-    | undefined;
-  const end: Date | undefined = data.startAndEndDate?.endValue as
-    | Date
-    | undefined;
+  /*
+   * Not `instanceof Date`: a window loaded from a stored incident/alert
+   * snapshot comes back as an InBetween holding ISO strings, because operator
+   * bounds are not tagged for rehydration on the JSON round trip. Testing the
+   * class directly made this whole function a no-op on exactly the pages that
+   * most need a stable, aligned window.
+   */
+  const window: InBetween<Date> | null = TelemetryQueryTimeRange.toDateWindow(
+    data.startAndEndDate,
+  );
 
-  if (!(start instanceof Date) || !(end instanceof Date)) {
+  if (!window) {
     return { effectiveData: data, aggregationInterval: undefined };
   }
 
@@ -116,8 +121,8 @@ const getAlignedWindowForData: (data: MetricViewData) => {
     endDate: Date;
     interval: AggregationInterval;
   } = AggregationIntervalUtil.getIntervalAlignedWindow({
-    startDate: start,
-    endDate: end,
+    startDate: window.startValue,
+    endDate: window.endValue,
   });
 
   return {

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/LogMonitor/LogMonitorPreview.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/LogMonitor/LogMonitorPreview.tsx
@@ -19,7 +19,25 @@ const LogMonitorPreview: FunctionComponent<ComponentProps> = (
     if (!props.monitorStepLogMonitor) {
       return {};
     }
-    return MonitorStepLogMonitorUtil.toQuery(props.monitorStepLogMonitor);
+
+    const query: Query<Log> = MonitorStepLogMonitorUtil.toQuery(
+      props.monitorStepLogMonitor,
+    );
+
+    /*
+     * Drop the evaluation window. toQuery() stamps `now - lastXSecondsOfLogs
+     * .. now`, resolved once when the form renders, and the viewer now honours
+     * an explicit window by pinning its picker to it. Pinning is right for an
+     * incident — that window is the moment being investigated — but wrong
+     * here: this preview exists to help someone tune filters, and a window
+     * frozen at "the 60 seconds before I opened this form" empties out a
+     * minute later and reads as "my filter matches nothing". Leaving it off
+     * keeps the viewer's own rolling range, which is what this preview has
+     * always shown.
+     */
+    delete (query as Record<string, unknown>)["time"];
+
+    return query;
   };
 
   const [logQuery, setLogQuery] = React.useState<Query<Log>>(refreshQuery());

--- a/App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetrySnapshotWindowAlert.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetrySnapshotWindowAlert.tsx
@@ -1,0 +1,42 @@
+import ColorSwatch from "Common/Types/ColorSwatch";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import OneUptimeDate from "Common/Types/Date";
+import IconProp from "Common/Types/Icon/IconProp";
+import HeaderAlert, {
+  HeaderAlertType,
+} from "Common/UI/Components/HeaderAlert/HeaderAlert";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  // The window the monitor evaluated over. Renders nothing when absent.
+  window: InBetween<Date> | null | undefined;
+}
+
+/*
+ * Clock badge naming the telemetry snapshot an incident or alert preview is
+ * showing. Every preview on those pages is scoped to the window the monitor
+ * evaluated over, not to "now" — without a badge saying so, a card of logs
+ * from last Tuesday is indistinguishable from a live tail, which is exactly
+ * the confusion this exists to remove.
+ */
+const TelemetrySnapshotWindowAlert: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  if (!props.window) {
+    return <></>;
+  }
+
+  return (
+    <HeaderAlert
+      icon={IconProp.Clock}
+      onClick={() => {
+        // Informational only — there is nowhere to navigate to.
+      }}
+      title={OneUptimeDate.getInBetweenDatesAsFormattedString(props.window)}
+      alertType={HeaderAlertType.INFO}
+      colorSwatch={ColorSwatch.Blue}
+    />
+  );
+};
+
+export default TelemetrySnapshotWindowAlert;

--- a/App/FeatureSet/Dashboard/src/Components/Traces/TraceTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Traces/TraceTable.tsx
@@ -44,6 +44,15 @@ export interface ComponentProps {
   spanQuery?: Query<Span> | undefined;
   isMinimalTable?: boolean | undefined;
   noItemsMessage?: string | undefined;
+  // Rendered in the card header, e.g. the snapshot window an incident is scoped to.
+  rightElement?: ReactElement | undefined;
+  /*
+   * Set by hosts that pin the query to a fixed window (incident / alert
+   * previews). Without it the table restores a "Seen At" filter from the URL
+   * on mount, which replaces the pinned window with an unrelated one and gives
+   * no sign it happened.
+   */
+  disableUrlState?: boolean | undefined;
   onFetchSuccess?:
     | ((data: Array<Span>, totalCount: number) => void)
     | undefined;
@@ -294,6 +303,7 @@ const TraceTable: FunctionComponent<ComponentProps> = (
       <div className="rounded">
         <AnalyticsModelTable<Span>
           userPreferencesKey="trace-table"
+          disableUrlState={props.disableUrlState}
           disablePagination={props.isMinimalTable}
           modelType={Span}
           id="traces-table"
@@ -310,6 +320,7 @@ const TraceTable: FunctionComponent<ComponentProps> = (
               : {
                   title: cardContent.title,
                   description: cardContent.description,
+                  rightElement: props.rightElement,
                 }
           }
           query={getQueryForActiveTab}

--- a/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
@@ -54,11 +54,10 @@ import { TelemetryQuery } from "Common/Types/Telemetry/TelemetryQuery";
 import MetricView from "../../../Components/Metrics/MetricView";
 import MetricViewData from "Common/Types/Metrics/MetricViewData";
 import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";
-import HeaderAlert, {
-  HeaderAlertType,
-} from "Common/UI/Components/HeaderAlert/HeaderAlert";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
+import TelemetrySnapshotWindowAlert from "../../../Components/Telemetry/TelemetrySnapshotWindowAlert";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
 import IconProp from "Common/Types/Icon/IconProp";
-import ColorSwatch from "Common/Types/ColorSwatch";
 import AlertFeedElement from "../../../Components/Alert/AlertFeed";
 import InvestigationPanel from "../../../Components/AI/InvestigationPanel";
 import EventStatTile from "../../../Components/EventView/EventStatTile";
@@ -96,6 +95,13 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
   const [telemetryQuery, setTelemetryQuery] = useState<TelemetryQuery | null>(
     null,
   );
+  /*
+   * The window the monitor evaluated over when it raised this alert. Every
+   * telemetry preview below is scoped to it, and each card shows it, so a
+   * snapshot from days ago can't be mistaken for a live view.
+   */
+  const [telemetrySnapshotWindow, setTelemetrySnapshotWindow] =
+    useState<InBetween<Date> | null>(null);
 
   const [severity, setSeverity] = useState<
     { name: string; color: Color } | undefined
@@ -172,7 +178,20 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
         telemetryQuery = JSONFunctions.deserialize(
           alert?.telemetryQuery as any,
         ) as any;
+
+        /*
+         * Rebuild the window's Date bounds. The stored blob round-trips
+         * through JSON, which leaves InBetween holding ISO strings even though
+         * its type says Date — and the metric chart gates bucket alignment and
+         * exemplar fetching on `instanceof Date`, so both stay switched off
+         * here until the bounds are real Dates again.
+         */
+        telemetryQuery = TelemetryQueryTimeRange.hydrate(telemetryQuery);
       }
+
+      setTelemetrySnapshotWindow(
+        TelemetryQueryTimeRange.getSnapshotWindow(telemetryQuery),
+      );
 
       /*
        * The stored telemetryQuery is the monitor's whole-evaluation view:
@@ -366,6 +385,18 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
     getResolvedState()?._id?.toString(),
   );
 
+  /*
+   * Built once and shared by all four preview cards. Resolved to `undefined`
+   * rather than an element that renders nothing, because Card decides whether
+   * to lay out its right-hand column from the PRESENCE of rightElement — an
+   * element returning an empty fragment is still truthy, and would leave an
+   * empty block and a shifted title on incidents that stored no window.
+   */
+  const snapshotWindowAlert: ReactElement | undefined =
+    telemetrySnapshotWindow ? (
+      <TelemetrySnapshotWindowAlert window={telemetrySnapshotWindow} />
+    ) : undefined;
+
   return (
     <Fragment>
       <div className="mb-5">
@@ -415,7 +446,11 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
             telemetryQuery.telemetryType === TelemetryType.Log &&
             telemetryQuery.telemetryQuery && (
               <div>
-                <Card title={"Logs"} description={"Logs for this alert."}>
+                <Card
+                  title={"Logs"}
+                  description={"Logs for this alert."}
+                  rightElement={snapshotWindowAlert}
+                >
                   <DashboardLogsViewer
                     id="logs-preview"
                     logQuery={telemetryQuery.telemetryQuery as Query<Log>}
@@ -432,6 +467,9 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
               <div>
                 <TraceTable
                   spanQuery={telemetryQuery.telemetryQuery as Query<Span>}
+                  rightElement={snapshotWindowAlert}
+                  // Pinned to the snapshot; a URL-restored filter must not replace it.
+                  disableUrlState={true}
                 />
               </div>
             )}
@@ -446,23 +484,7 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
                     ? `Metrics for this alert, scoped to the affected series (${seriesSummary}).`
                     : "Metrics for this alert."
                 }
-                rightElement={
-                  telemetryQuery.metricViewData.startAndEndDate ? (
-                    <HeaderAlert
-                      icon={IconProp.Clock}
-                      onClick={() => {
-                        // do nothing!
-                      }}
-                      title={OneUptimeDate.getInBetweenDatesAsFormattedString(
-                        telemetryQuery.metricViewData.startAndEndDate,
-                      )}
-                      alertType={HeaderAlertType.INFO}
-                      colorSwatch={ColorSwatch.Blue}
-                    />
-                  ) : (
-                    <></>
-                  )
-                }
+                rightElement={snapshotWindowAlert}
               >
                 <MetricView
                   data={telemetryQuery.metricViewData}
@@ -487,6 +509,9 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
                 query={
                   telemetryQuery.telemetryQuery as Query<ExceptionInstance>
                 }
+                rightElement={snapshotWindowAlert}
+                // Pinned to the snapshot; a URL-restored filter must not replace it.
+                disableUrlState={true}
               />
             )}
 

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
@@ -43,11 +43,10 @@ import { TelemetryQuery } from "Common/Types/Telemetry/TelemetryQuery";
 import MetricView from "../../../Components/Metrics/MetricView";
 import MetricViewData from "Common/Types/Metrics/MetricViewData";
 import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
+import TelemetrySnapshotWindowAlert from "../../../Components/Telemetry/TelemetrySnapshotWindowAlert";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
 import IconProp from "Common/Types/Icon/IconProp";
-import HeaderAlert, {
-  HeaderAlertType,
-} from "Common/UI/Components/HeaderAlert/HeaderAlert";
-import ColorSwatch from "Common/Types/ColorSwatch";
 import IncidentFeedElement from "../../../Components/Incident/IncidentFeed";
 import InvestigationPanel from "../../../Components/AI/InvestigationPanel";
 import EntityRunbooks from "../../../Components/Runbook/EntityRunbooks";
@@ -95,6 +94,13 @@ const IncidentView: FunctionComponent<
   const [telemetryQuery, setTelemetryQuery] = useState<TelemetryQuery | null>(
     null,
   );
+  /*
+   * The window the monitor evaluated over when it opened this incident. Every
+   * telemetry preview below is scoped to it, and each card shows it, so a
+   * snapshot from days ago can't be mistaken for a live view.
+   */
+  const [telemetrySnapshotWindow, setTelemetrySnapshotWindow] =
+    useState<InBetween<Date> | null>(null);
   /*
    * "host.name = prod-01" when a grouped metric monitor opened this
    * incident for one series. Empty for whole-monitor incidents.
@@ -177,7 +183,20 @@ const IncidentView: FunctionComponent<
         telemetryQuery = JSONFunctions.deserialize(
           incident?.telemetryQuery as any,
         ) as any;
+
+        /*
+         * Rebuild the window's Date bounds. The stored blob round-trips
+         * through JSON, which leaves InBetween holding ISO strings even though
+         * its type says Date — and the metric chart gates bucket alignment and
+         * exemplar fetching on `instanceof Date`, so both stay switched off
+         * here until the bounds are real Dates again.
+         */
+        telemetryQuery = TelemetryQueryTimeRange.hydrate(telemetryQuery);
       }
+
+      setTelemetrySnapshotWindow(
+        TelemetryQueryTimeRange.getSnapshotWindow(telemetryQuery),
+      );
 
       /*
        * The stored telemetryQuery is the monitor's whole-evaluation view:
@@ -384,6 +403,18 @@ const IncidentView: FunctionComponent<
     getResolvedState()?._id?.toString(),
   );
 
+  /*
+   * Built once and shared by all four preview cards. Resolved to `undefined`
+   * rather than an element that renders nothing, because Card decides whether
+   * to lay out its right-hand column from the PRESENCE of rightElement — an
+   * element returning an empty fragment is still truthy, and would leave an
+   * empty block and a shifted title on incidents that stored no window.
+   */
+  const snapshotWindowAlert: ReactElement | undefined =
+    telemetrySnapshotWindow ? (
+      <TelemetrySnapshotWindowAlert window={telemetrySnapshotWindow} />
+    ) : undefined;
+
   return (
     <Fragment>
       <div className="mb-5">
@@ -433,7 +464,11 @@ const IncidentView: FunctionComponent<
             telemetryQuery.telemetryType === TelemetryType.Log &&
             telemetryQuery.telemetryQuery && (
               <div>
-                <Card title={"Logs"} description={"Logs for this incident."}>
+                <Card
+                  title={"Logs"}
+                  description={"Logs for this incident."}
+                  rightElement={snapshotWindowAlert}
+                >
                   <DashboardLogsViewer
                     id="logs-preview"
                     logQuery={telemetryQuery.telemetryQuery as Query<Log>}
@@ -450,6 +485,9 @@ const IncidentView: FunctionComponent<
               <div>
                 <TraceTable
                   spanQuery={telemetryQuery.telemetryQuery as Query<Span>}
+                  rightElement={snapshotWindowAlert}
+                  // Pinned to the snapshot; a URL-restored filter must not replace it.
+                  disableUrlState={true}
                 />
               </div>
             )}
@@ -464,23 +502,7 @@ const IncidentView: FunctionComponent<
                     ? `Metrics related to this incident, scoped to the affected series (${seriesSummary}).`
                     : "Metrics related to this incident."
                 }
-                rightElement={
-                  telemetryQuery.metricViewData.startAndEndDate ? (
-                    <HeaderAlert
-                      icon={IconProp.Clock}
-                      onClick={() => {
-                        // do nothing!
-                      }}
-                      title={OneUptimeDate.getInBetweenDatesAsFormattedString(
-                        telemetryQuery.metricViewData.startAndEndDate,
-                      )}
-                      alertType={HeaderAlertType.INFO}
-                      colorSwatch={ColorSwatch.Blue}
-                    />
-                  ) : (
-                    <></>
-                  )
-                }
+                rightElement={snapshotWindowAlert}
               >
                 <MetricView
                   data={telemetryQuery.metricViewData}
@@ -505,6 +527,9 @@ const IncidentView: FunctionComponent<
                 query={
                   telemetryQuery.telemetryQuery as Query<ExceptionInstance>
                 }
+                rightElement={snapshotWindowAlert}
+                // Pinned to the snapshot; a URL-restored filter must not replace it.
+                disableUrlState={true}
               />
             )}
 

--- a/App/Tests/Dashboard/IncidentMetricSeriesScope.test.ts
+++ b/App/Tests/Dashboard/IncidentMetricSeriesScope.test.ts
@@ -8,6 +8,10 @@ import JSONFunctions from "Common/Types/JSONFunctions";
 import MetricQueryConfigData from "Common/Types/Metrics/MetricQueryConfigData";
 import MetricViewData from "Common/Types/Metrics/MetricViewData";
 import MetricSeriesScope from "Common/Utils/Metrics/MetricSeriesScope";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
+import TelemetryType from "Common/Types/Telemetry/TelemetryType";
+import { TelemetryQuery } from "Common/Types/Telemetry/TelemetryQuery";
 
 /*
  * A metric monitor grouped by an attribute (host.name, pod, device) opens
@@ -209,17 +213,23 @@ describe("the monitor-level metrics preview stays unscoped", () => {
  * are the fragile part of that round trip.
  */
 describe("the narrowing survives the stored-JSON round trip", () => {
+  const WINDOW_START: Date = new Date("2024-05-01T10:00:00.000Z");
+  const WINDOW_END: Date = new Date("2024-05-01T11:00:00.000Z");
+
   function buildStoredTelemetryQuery(input: {
     groupByAttributeKeys: Array<string>;
   }): JSONObject {
     const metricViewData: JSONObject = {
-      startAndEndDate: {
-        _type: "InBetween",
-        value: {
-          startValue: "2024-05-01T10:00:00.000Z",
-          endValue: "2024-05-01T11:00:00.000Z",
-        },
-      },
+      /*
+       * Built from a real InBetween and pushed through the worker's own
+       * serializer rather than hand-written. A previous hand-written fixture
+       * nested the bounds under `value:`, but InBetween.toJSON emits them
+       * FLAT — so it deserialized to `new InBetween(undefined, undefined)` and
+       * every assertion about the window below passed against an empty object.
+       */
+      startAndEndDate: JSONFunctions.anyObjectToJSONObject(
+        new InBetween<Date>(WINDOW_START, WINDOW_END),
+      ),
       queryConfigs: [
         {
           id: "query-1",
@@ -283,8 +293,54 @@ describe("the narrowing survives the stored-JSON round trip", () => {
     expect(getAttributes(scoped?.queryConfigs[0])).toEqual({
       "resource.host.name": "prod-01",
     });
-    // The window the monitor evaluated over must come through untouched.
+
+    /*
+     * The window the monitor evaluated over must come through untouched --
+     * asserted by VALUE, not just by reference. A reference check alone passes
+     * even when both sides are an empty InBetween, which is how this stopped
+     * checking anything.
+     */
     expect(scoped?.startAndEndDate).toBe(metricViewData.startAndEndDate);
+    expect(scoped?.startAndEndDate?.startValue).toBeDefined();
+    expect(new Date(scoped!.startAndEndDate!.startValue).getTime()).toBe(
+      WINDOW_START.getTime(),
+    );
+    expect(new Date(scoped!.startAndEndDate!.endValue).getTime()).toBe(
+      WINDOW_END.getTime(),
+    );
+  });
+
+  test("the restored window has string bounds until it is hydrated", () => {
+    /*
+     * Pins the trap that made the incident metric card silently lose bucket
+     * alignment and exemplar dots: the stored window comes back as a real
+     * InBetween whose bounds are ISO strings, so every downstream
+     * `instanceof Date` guard quietly did nothing. The pages now run
+     * TelemetryQueryTimeRange.hydrate to undo it.
+     */
+    const deserialized: JSONObject = JSONFunctions.deserialize(
+      buildStoredTelemetryQuery({ groupByAttributeKeys: [] }),
+    );
+
+    const restored: MetricViewData = deserialized[
+      "metricViewData"
+    ] as unknown as MetricViewData;
+
+    expect(restored.startAndEndDate).toBeInstanceOf(InBetween);
+    expect(restored.startAndEndDate!.startValue).not.toBeInstanceOf(Date);
+
+    const hydrated: TelemetryQuery | null = TelemetryQueryTimeRange.hydrate({
+      telemetryType: TelemetryType.Metric,
+      telemetryQuery: null,
+      metricViewData: restored,
+    });
+
+    expect(
+      hydrated!.metricViewData!.startAndEndDate!.startValue,
+    ).toBeInstanceOf(Date);
+    expect(
+      hydrated!.metricViewData!.startAndEndDate!.startValue.getTime(),
+    ).toBe(WINDOW_START.getTime());
   });
 
   test("an unset label round-trips through serialize/deserialize as IsNull", () => {

--- a/App/Tests/Dashboard/TelemetryPreviewSnapshotWindow.test.ts
+++ b/App/Tests/Dashboard/TelemetryPreviewSnapshotWindow.test.ts
@@ -1,0 +1,442 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import Log from "Common/Models/AnalyticsModels/Log";
+import Query from "Common/Types/BaseDatabase/Query";
+import { JSONObject } from "Common/Types/JSON";
+import JSONFunctions from "Common/Types/JSONFunctions";
+import { MonitorStepLogMonitorUtil } from "Common/Types/Monitor/MonitorStepLogMonitor";
+import TelemetryType from "Common/Types/Telemetry/TelemetryType";
+import RangeStartAndEndDateTime, {
+  RangeStartAndEndDateTimeUtil,
+} from "Common/Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "Common/Types/Time/TimeRange";
+import TelemetryQueryTimeRange from "Common/Utils/Telemetry/TelemetryQueryTimeRange";
+
+/*
+ * A telemetry monitor stamps the window it evaluated over onto the query it
+ * stores on the incident/alert row, and the preview cards on those pages are
+ * meant to render that exact window. The logs viewer did not: it copied the
+ * stored query and then unconditionally re-stamped `time` with a rolling
+ * "past 1 hour", from six separate places (the state initializer, the
+ * props-sync effect, the facet rebuild, clear-all-filters, and the histogram
+ * and facet fetches, which read the picker state rather than the query). So an
+ * incident from last Tuesday rendered the last hour of unrelated logs under
+ * "Logs for this incident", with the picker reading "Past 1 Hour".
+ *
+ * The fix seeds the viewer's time-range state from the query's window, which
+ * every one of those six surfaces derives from. The decision itself is pure
+ * and unit-tested in Common/Tests/Utils/Telemetry/TelemetryQueryTimeRange.test.ts;
+ * this file covers the two things that test cannot reach:
+ *
+ *   1. the behaviour the seeding must produce, exercised against a real
+ *      monitor evaluation (no renderer needed), and
+ *   2. the component wiring, pinned by reading the sources — the App suite
+ *      runs in plain Node with no renderer, the same constraint that
+ *      IncidentMetricSeriesScope.test.ts works around the same way. Sources are
+ *      comment-stripped and whitespace-squashed first so a prettier re-wrap
+ *      cannot turn a real regression check into a red herring.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/gm, " ");
+}
+
+function readSource(...relativeParts: Array<string>): string {
+  return squash(
+    stripComments(
+      fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8"),
+    ),
+  );
+}
+
+const LOGS_VIEWER: string = readSource("Components", "Logs", "LogsViewer.tsx");
+const LOG_MONITOR_PREVIEW: string = readSource(
+  "Components",
+  "Monitor",
+  "LogMonitor",
+  "LogMonitorPreview.tsx",
+);
+const INCIDENT_VIEW: string = readSource(
+  "Pages",
+  "Incidents",
+  "View",
+  "Index.tsx",
+);
+const ALERT_VIEW: string = readSource("Pages", "Alerts", "View", "Index.tsx");
+const METRIC_VIEW: string = readSource(
+  "Components",
+  "Metrics",
+  "MetricView.tsx",
+);
+const METRIC_CHARTS: string = readSource(
+  "Components",
+  "Metrics",
+  "MetricCharts.tsx",
+);
+const TRACE_TABLE: string = readSource(
+  "Components",
+  "Traces",
+  "TraceTable.tsx",
+);
+const EXCEPTION_TABLE: string = readSource(
+  "Components",
+  "Exceptions",
+  "ExceptionInstanceTable.tsx",
+);
+
+describe("a stored log monitor window resolves to a pinned picker range", () => {
+  /*
+   * End-to-end over the real production path — build the query the way the
+   * worker does, persist it the way the worker does, restore it the way the
+   * incident page does — then assert the value the viewer seeds its picker
+   * with. This is the behaviour the four clobber sites used to destroy.
+   */
+  function restoreStoredLogQuery(lastXSecondsOfLogs: number): Query<Log> {
+    const evaluated: Query<Log> = MonitorStepLogMonitorUtil.toQuery({
+      ...MonitorStepLogMonitorUtil.getDefault(),
+      body: "OutOfMemory",
+      lastXSecondsOfLogs: lastXSecondsOfLogs,
+    });
+
+    return JSONFunctions.deserialize(
+      JSONFunctions.anyObjectToJSONObject(evaluated),
+    ) as unknown as Query<Log>;
+  }
+
+  test("pins to the monitor's window rather than the past hour", () => {
+    const stored: Query<Log> = restoreStoredLogQuery(60);
+
+    const pinned: RangeStartAndEndDateTime | null =
+      TelemetryQueryTimeRange.getPinnedRangeForQuery(stored, TelemetryType.Log);
+
+    expect(pinned).not.toBeNull();
+    expect(pinned!.range).toBe(TimeRange.CUSTOM);
+    expect(pinned!.range).not.toBe(TimeRange.PAST_ONE_HOUR);
+
+    const resolved: InBetween<Date> =
+      RangeStartAndEndDateTimeUtil.getStartAndEndDate(pinned!);
+
+    // A 60s monitor window must stay 60s, not widen to the 1h default.
+    expect(resolved.endValue.getTime() - resolved.startValue.getTime()).toBe(
+      60 * 1000,
+    );
+  });
+
+  test("the pinned window does not slide as the clock moves", () => {
+    /*
+     * The property that makes the whole thing work. Every downstream request
+     * (log list, histogram, facets) re-resolves the picker state. A relative
+     * range would re-anchor to "now" on each call and walk away from the
+     * incident; CUSTOM must resolve to the monitor's own instants every time.
+     *
+     * Asserted against the window stored on the query, NOT by comparing two
+     * resolutions to each other: getStartAndEndDate returns the very same
+     * InBetween reference for a CUSTOM range, so a self-comparison is
+     * `x.getTime() === x.getTime()` and stays green even if the range silently
+     * became relative.
+     */
+    const stored: Query<Log> = restoreStoredLogQuery(300);
+
+    const evaluated: InBetween<Date> | null =
+      TelemetryQueryTimeRange.getQueryWindow(stored, TelemetryType.Log);
+
+    const pinned: RangeStartAndEndDateTime | null =
+      TelemetryQueryTimeRange.getPinnedRangeForQuery(stored, TelemetryType.Log);
+
+    const resolved: InBetween<Date> =
+      RangeStartAndEndDateTimeUtil.getStartAndEndDate(pinned!);
+
+    expect(resolved.startValue.getTime()).toBe(evaluated!.startValue.getTime());
+    expect(resolved.endValue.getTime()).toBe(evaluated!.endValue.getTime());
+
+    /*
+     * And it is not the rolling default wearing the monitor's clothes: a
+     * relative range would resolve to a 1h span anchored on now, so pin the
+     * width too. 300s vs 3600s makes this deterministic rather than a
+     * millisecond race.
+     */
+    expect(resolved.endValue.getTime() - resolved.startValue.getTime()).toBe(
+      300 * 1000,
+    );
+
+    const rollingHour: InBetween<Date> =
+      RangeStartAndEndDateTimeUtil.getStartAndEndDate({
+        range: TimeRange.PAST_ONE_HOUR,
+      });
+
+    expect(
+      rollingHour.endValue.getTime() - rollingHour.startValue.getTime(),
+    ).not.toBe(resolved.endValue.getTime() - resolved.startValue.getTime());
+  });
+
+  test("the pinned bounds are Dates, which the facets request requires", () => {
+    // fetchFacets calls .toISOString() on these directly; a string would throw.
+    const stored: Query<Log> = restoreStoredLogQuery(60);
+
+    const resolved: InBetween<Date> =
+      RangeStartAndEndDateTimeUtil.getStartAndEndDate(
+        TelemetryQueryTimeRange.getPinnedRangeForQuery(
+          stored,
+          TelemetryType.Log,
+        )!,
+      );
+
+    expect(resolved.startValue).toBeInstanceOf(Date);
+    expect(() => {
+      return resolved.startValue.toISOString();
+    }).not.toThrow();
+  });
+
+  test("a query with no window pins nothing, so other hosts keep their default", () => {
+    /*
+     * Backwards compatibility, and the reason the resource log pages
+     * (Host / Docker / Kubernetes / ...) are untouched by this change: they
+     * pass a logQuery with no `time`, so there is nothing to pin.
+     */
+    const noWindow: Query<Log> = restoreStoredLogQuery(0);
+
+    expect((noWindow as JSONObject)["time"]).toBeUndefined();
+    expect(
+      TelemetryQueryTimeRange.getPinnedRangeForQuery(
+        noWindow,
+        TelemetryType.Log,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("the logs viewer seeds its time range from the query's window", () => {
+  test("derives a pinned range from props.logQuery", () => {
+    expect(LOGS_VIEWER).toContain(
+      "TelemetryQueryTimeRange.getPinnedRangeForQuery( props.logQuery, TelemetryType.Log, )",
+    );
+  });
+
+  test("both the query state and the picker state start from the same seed", () => {
+    /*
+     * The two used to be seeded independently — filterOptions from the URL or
+     * PAST_ONE_HOUR, the picker from PAST_ONE_HOUR — which is how the list and
+     * the histogram could end up describing different windows.
+     */
+    expect(LOGS_VIEWER).toContain(
+      "RangeStartAndEndDateTimeUtil.getStartAndEndDate(initialTimeRange)",
+    );
+    expect(LOGS_VIEWER).toContain(
+      "useState<RangeStartAndEndDateTime>(initialTimeRange)",
+    );
+  });
+
+  test("the pinned range wins over the rolling default in the seed", () => {
+    expect(LOGS_VIEWER).toContain(
+      "pinnedTimeRange || initialUrlState?.timeRange || { range: TimeRange.PAST_ONE_HOUR }",
+    );
+  });
+
+  test("no seed site stamps the rolling default unconditionally any more", () => {
+    /*
+     * The original defect, in one assertion: the initializer resolved
+     * `initialUrlState?.timeRange || { range: TimeRange.PAST_ONE_HOUR }` inline
+     * and stamped it over whatever the caller passed.
+     */
+    expect(LOGS_VIEWER).not.toContain(
+      "const initialRange: RangeStartAndEndDateTime = initialUrlState?.timeRange || { range: TimeRange.PAST_ONE_HOUR };",
+    );
+  });
+
+  test("the props-sync effect follows a new pinned window instead of overwriting it", () => {
+    expect(LOGS_VIEWER).toContain(
+      "const nextTimeRange: RangeStartAndEndDateTime = pinnedTimeRange || timeRange;",
+    );
+    expect(LOGS_VIEWER).toContain(
+      "RangeStartAndEndDateTimeUtil.getStartAndEndDate(nextTimeRange)",
+    );
+  });
+
+  test("the effect compares windows by value, so an equal-but-new query cannot loop", () => {
+    expect(LOGS_VIEWER).toContain(
+      "!TelemetryQueryTimeRange.isSameRange(pinnedTimeRange, timeRange)",
+    );
+  });
+
+  test("interacting with facets or clearing filters re-derives from the picker state", () => {
+    /*
+     * The other two of the four sites that used to stamp the rolling default.
+     * Neither needed changing — both rebuild the window from `timeRange`, which
+     * now holds the pin — but that is exactly why they need pinning down: if
+     * either ever resolved its own window again, clicking a facet chip or
+     * "Clear all filters" inside an incident would silently jump the preview
+     * back to the past hour.
+     */
+    const fromPickerState: string =
+      "const dateRange: InBetween<Date> = RangeStartAndEndDateTimeUtil.getStartAndEndDate(timeRange);";
+
+    // rebuildFilterOptionsFromFacets — behind facet include/exclude and search chips.
+    expect(LOGS_VIEWER).toContain(
+      `const updatedFilter: Query<Log> = buildBaseQuery(props); ${fromPickerState}`,
+    );
+
+    // handleClearAllFilters.
+    expect(LOGS_VIEWER).toContain(
+      `setAppliedFacetFilters(new Map()); const base: Query<Log> = buildBaseQuery(props); ${fromPickerState}`,
+    );
+  });
+
+  test("the histogram and facet fetches still read the picker state", () => {
+    /*
+     * Not incidental — it is why seeding one value fixes all three surfaces.
+     * If either fetch ever grew its own window resolution, the counts under an
+     * incident would silently drift back to describing the past hour.
+     */
+    expect(LOGS_VIEWER).toContain(
+      "buildLogsHistogramRequest({ timeRange: timeRange,",
+    );
+    expect(LOGS_VIEWER).toContain(
+      "const dateRange: InBetween<Date> = RangeStartAndEndDateTimeUtil.getStartAndEndDate(timeRange); const requestData: JSONObject = { startTime: dateRange.startValue.toISOString(), endTime: dateRange.endValue.toISOString(),",
+    );
+  });
+
+  test("a pinned window suppresses the auto-applied default saved view", () => {
+    /*
+     * A saved view carries its own time range and would move an embedded
+     * preview off the moment it is about.
+     */
+    expect(LOGS_VIEWER).toContain("if (pinnedTimeRange) { return; }");
+  });
+});
+
+describe("the monitor step's logs preview keeps its rolling window", () => {
+  test("drops the evaluation window before handing the query to the viewer", () => {
+    /*
+     * Deliberate: pinning is right for an incident, but this preview exists to
+     * help someone tune filters, and a 60-second window frozen at the instant
+     * the form opened empties out a minute later. Dropping it keeps exactly
+     * the behaviour this preview has always had.
+     */
+    expect(LOG_MONITOR_PREVIEW).toContain(
+      'delete (query as Record<string, unknown>)["time"];',
+    );
+  });
+});
+
+describe("the incident and alert pages rebuild the window's Date bounds", () => {
+  test.each([
+    ["incident", INCIDENT_VIEW],
+    ["alert", ALERT_VIEW],
+  ])(
+    "%s page hydrates the deserialized telemetryQuery",
+    (_name: string, source: string) => {
+      expect(source).toContain(
+        "telemetryQuery = TelemetryQueryTimeRange.hydrate(telemetryQuery);",
+      );
+    },
+  );
+
+  test.each([
+    ["incident", INCIDENT_VIEW],
+    ["alert", ALERT_VIEW],
+  ])(
+    "%s page resolves the snapshot window for display",
+    (_name: string, source: string) => {
+      expect(source).toContain(
+        "setTelemetrySnapshotWindow( TelemetryQueryTimeRange.getSnapshotWindow(telemetryQuery), )",
+      );
+    },
+  );
+
+  test.each([
+    ["incident", INCIDENT_VIEW],
+    ["alert", ALERT_VIEW],
+  ])(
+    "%s page shows the window on all four preview cards, not just metrics",
+    (_name: string, source: string) => {
+      /*
+       * The log card's absence of any window indicator is what made the bug
+       * invisible: with nothing on screen claiming a window, rolling
+       * past-1-hour rows read as the incident's own rows.
+       */
+      const occurrences: number = source.split(
+        "rightElement={snapshotWindowAlert}",
+      ).length;
+
+      // Logs, traces, metrics, exceptions.
+      expect(occurrences - 1).toBe(4);
+    },
+  );
+
+  test.each([
+    ["incident", INCIDENT_VIEW],
+    ["alert", ALERT_VIEW],
+  ])(
+    "%s page passes undefined, not an empty element, when no window was stored",
+    (_name: string, source: string) => {
+      /*
+       * Card lays out its right-hand column based on the PRESENCE of
+       * rightElement. An element that renders an empty fragment is still
+       * truthy, so handing one over for an incident with no stored window
+       * leaves an empty block and shifts the title.
+       */
+      expect(source).toContain(
+        "const snapshotWindowAlert: ReactElement | undefined = telemetrySnapshotWindow ?",
+      );
+      expect(source).toContain(": undefined;");
+    },
+  );
+
+  test.each([
+    ["incident", INCIDENT_VIEW],
+    ["alert", ALERT_VIEW],
+  ])(
+    "%s page stops the trace and exception tables restoring a filter over the pin",
+    (_name: string, source: string) => {
+      expect(source.split("disableUrlState={true}").length - 1).toBe(2);
+    },
+  );
+});
+
+describe("the tables and charts accept the pinned window", () => {
+  test("trace and exception tables forward a header element and can opt out of URL state", () => {
+    for (const source of [TRACE_TABLE, EXCEPTION_TABLE]) {
+      expect(source).toContain("rightElement?: ReactElement | undefined;");
+      expect(source).toContain("disableUrlState?: boolean | undefined;");
+      expect(source).toContain("disableUrlState={props.disableUrlState}");
+    }
+  });
+
+  test("the metric chart no longer gates alignment on instanceof Date", () => {
+    /*
+     * A restored window's bounds are ISO strings, so this guard made
+     * bucket-grid alignment a no-op on every incident and alert page.
+     */
+    expect(METRIC_VIEW).toContain(
+      "TelemetryQueryTimeRange.toDateWindow( data.startAndEndDate, )",
+    );
+    expect(METRIC_VIEW).not.toContain(
+      "if (!(start instanceof Date) || !(end instanceof Date))",
+    );
+  });
+
+  test("exemplar fetching no longer gates on instanceof Date", () => {
+    // Same string-vs-Date trap; it left startMs/endMs undefined and the effect bailed.
+    expect(METRIC_CHARTS).toContain(
+      "const startMs: number | undefined = exemplarWindow?.startValue.getTime();",
+    );
+    expect(METRIC_CHARTS).not.toContain(
+      "props.metricViewData.startAndEndDate?.startValue instanceof Date",
+    );
+  });
+});

--- a/Common/Tests/UI/Telemetry/TelemetrySnapshotWindowAlert.test.tsx
+++ b/Common/Tests/UI/Telemetry/TelemetrySnapshotWindowAlert.test.tsx
@@ -1,0 +1,91 @@
+import "@testing-library/jest-dom/extend-expect";
+import { render, RenderResult } from "@testing-library/react";
+/*
+ * The Dashboard has its own copy of react, so a component imported from there
+ * would otherwise call hooks on a DIFFERENT React instance than the one
+ * react-dom renders with. Common's jest moduleNameMapper pins react and
+ * react-dom to this project's single copy for every importer, which is what
+ * makes importing Dashboard source from here work (same arrangement as
+ * Common/Tests/UI/Rum/ReplayStage.test.tsx).
+ */
+import * as React from "react";
+import { describe, expect, it } from "@jest/globals";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import OneUptimeDate from "../../../Types/Date";
+import TelemetrySnapshotWindowAlert from "../../../../App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetrySnapshotWindowAlert";
+
+/*
+ * The badge that tells someone reading an incident WHICH slice of time the
+ * telemetry cards below are showing. Its absence on the log card is a large
+ * part of why the rolling-window bug went unnoticed for so long: with nothing
+ * on screen claiming a window, an hour of unrelated logs read as the
+ * incident's own logs.
+ *
+ * Two behaviours matter and neither is reachable from a pure test: that it
+ * renders the stored window, and that it renders NOTHING when there is no
+ * window — the backwards-compatible path for incidents created before monitors
+ * stamped one, where a badge would be worse than no badge.
+ */
+describe("TelemetrySnapshotWindowAlert", () => {
+  const START_DATE: Date = new Date("2026-08-04T10:00:00.000Z");
+  const END_DATE: Date = new Date("2026-08-04T10:01:00.000Z");
+
+  it("renders the snapshot window", () => {
+    const result: RenderResult = render(
+      <TelemetrySnapshotWindowAlert
+        window={new InBetween<Date>(START_DATE, END_DATE)}
+      />,
+    );
+
+    /*
+     * Assert against the app's own formatter rather than a hard-coded string:
+     * the output is timezone- and 12/24h-preference dependent, and pinning a
+     * literal here would make this test a clock/locale trap rather than a
+     * check that the window reaches the screen.
+     */
+    const expected: string = OneUptimeDate.getInBetweenDatesAsFormattedString(
+      new InBetween<Date>(START_DATE, END_DATE),
+    );
+
+    expect(result.container.textContent).toContain(expected);
+
+    // Both edges are named, not just the start.
+    expect(expected).toContain(" - ");
+  });
+
+  it("renders nothing when the incident stored no window", () => {
+    for (const value of [null, undefined]) {
+      const result: RenderResult = render(
+        <TelemetrySnapshotWindowAlert window={value} />,
+      );
+
+      expect(result.container.textContent).toBe("");
+      result.unmount();
+    }
+  });
+
+  it("renders a window restored from storage, whose bounds are ISO strings", () => {
+    /*
+     * The shape the incident page actually holds if hydration were ever
+     * skipped. The formatter normalizes strings, so the badge must still show
+     * real dates rather than "Invalid Date".
+     */
+    const result: RenderResult = render(
+      <TelemetrySnapshotWindowAlert
+        window={
+          new InBetween<Date>(
+            START_DATE.toISOString() as unknown as Date,
+            END_DATE.toISOString() as unknown as Date,
+          )
+        }
+      />,
+    );
+
+    expect(result.container.textContent).not.toContain("Invalid Date");
+    expect(result.container.textContent).toContain(
+      OneUptimeDate.getInBetweenDatesAsFormattedString(
+        new InBetween<Date>(START_DATE, END_DATE),
+      ),
+    );
+  });
+});

--- a/Common/Tests/Utils/Telemetry/TelemetryQueryTimeRange.test.ts
+++ b/Common/Tests/Utils/Telemetry/TelemetryQueryTimeRange.test.ts
@@ -1,0 +1,825 @@
+import ExceptionInstance from "../../../Models/AnalyticsModels/ExceptionInstance";
+import Log from "../../../Models/AnalyticsModels/Log";
+import Span from "../../../Models/AnalyticsModels/Span";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import Query from "../../../Types/BaseDatabase/Query";
+import Search from "../../../Types/BaseDatabase/Search";
+import { JSONObject } from "../../../Types/JSON";
+import JSONFunctions from "../../../Types/JSONFunctions";
+import LogSeverity from "../../../Types/Log/LogSeverity";
+import MetricViewData from "../../../Types/Metrics/MetricViewData";
+import { MonitorStepExceptionMonitorUtil } from "../../../Types/Monitor/MonitorStepExceptionMonitor";
+import { MonitorStepLogMonitorUtil } from "../../../Types/Monitor/MonitorStepLogMonitor";
+import { MonitorStepTraceMonitorUtil } from "../../../Types/Monitor/MonitorStepTraceMonitor";
+import { TelemetryQuery } from "../../../Types/Telemetry/TelemetryQuery";
+import TelemetryType from "../../../Types/Telemetry/TelemetryType";
+import RangeStartAndEndDateTime, {
+  RangeStartAndEndDateTimeUtil,
+} from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+import TelemetryQueryTimeRange from "../../../Utils/Telemetry/TelemetryQueryTimeRange";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * When a telemetry monitor opens an incident it stamps the window it just
+ * evaluated over onto the query it stores on the row. The incident page is
+ * supposed to render that exact window — "the logs at the moment this fired" —
+ * but the logs viewer was substituting a rolling "past 1 hour" over it, so an
+ * incident from last Tuesday showed the last hour of unrelated traffic under
+ * the heading "Logs for this incident".
+ *
+ * The root cause that let it go unnoticed for so long is in these tests'
+ * crosshairs: the window survives storage by VALUE but not by TYPE. It is
+ * persisted through JSON.stringify, which calls InBetween.toJSON() and then
+ * flattens each Date bound to an ISO string; InBetween.fromJSON hands those
+ * strings straight to the constructor. So a restored window is a real
+ * InBetween whose `startValue` is a `string`, even though the type says Date —
+ * and every consumer guarding on `instanceof Date` silently did nothing.
+ *
+ * These tests pin both halves: the coercion itself, and the full
+ * monitor -> store -> load round trip that produces the awkward shape.
+ */
+describe("TelemetryQueryTimeRange", () => {
+  const START_ISO: string = "2026-08-04T10:00:00.000Z";
+  const END_ISO: string = "2026-08-04T10:01:00.000Z";
+  const START_DATE: Date = new Date(START_ISO);
+  const END_DATE: Date = new Date(END_ISO);
+
+  describe("toDateWindow", () => {
+    test("returns Date bounds unchanged when they are already Dates", () => {
+      const window: InBetween<Date> | null =
+        TelemetryQueryTimeRange.toDateWindow(
+          new InBetween<Date>(START_DATE, END_DATE),
+        );
+
+      expect(window).not.toBeNull();
+      expect(window!.startValue).toBeInstanceOf(Date);
+      expect(window!.startValue.getTime()).toBe(START_DATE.getTime());
+      expect(window!.endValue.getTime()).toBe(END_DATE.getTime());
+    });
+
+    test("hands back the same instance when nothing needs coercing", () => {
+      /*
+       * Identity is the signal callers use to decide whether anything changed;
+       * an equal-but-fresh object would churn React state on every load.
+       */
+      const already: InBetween<Date> = new InBetween<Date>(
+        START_DATE,
+        END_DATE,
+      );
+
+      expect(TelemetryQueryTimeRange.toDateWindow(already)).toBe(already);
+    });
+
+    test("coerces ISO string bounds back to Dates — the shape storage actually returns", () => {
+      /*
+       * This is the exact value InBetween.fromJSON produces for a stored
+       * window: the right class, the wrong bound type.
+       */
+      const restored: InBetween<Date> = new InBetween<Date>(
+        START_ISO as unknown as Date,
+        END_ISO as unknown as Date,
+      );
+
+      expect(restored.startValue).not.toBeInstanceOf(Date);
+
+      const window: InBetween<Date> | null =
+        TelemetryQueryTimeRange.toDateWindow(restored);
+
+      expect(window!.startValue).toBeInstanceOf(Date);
+      expect(window!.endValue).toBeInstanceOf(Date);
+      expect(window!.startValue.toISOString()).toBe(START_ISO);
+      expect(window!.endValue.toISOString()).toBe(END_ISO);
+    });
+
+    test("coerces epoch-number bounds", () => {
+      const window: InBetween<Date> | null =
+        TelemetryQueryTimeRange.toDateWindow(
+          new InBetween<Date>(
+            START_DATE.getTime() as unknown as Date,
+            END_DATE.getTime() as unknown as Date,
+          ),
+        );
+
+      expect(window!.startValue.getTime()).toBe(START_DATE.getTime());
+      expect(window!.endValue.getTime()).toBe(END_DATE.getTime());
+    });
+
+    test("accepts the plain tagged object, for callers that skipped deserialize", () => {
+      const window: InBetween<Date> | null =
+        TelemetryQueryTimeRange.toDateWindow({
+          _type: "InBetween",
+          startValue: START_ISO,
+          endValue: END_ISO,
+        });
+
+      expect(window!.startValue.getTime()).toBe(START_DATE.getTime());
+      expect(window!.endValue.getTime()).toBe(END_DATE.getTime());
+    });
+
+    test("returns null for absent, non-object and untagged values", () => {
+      expect(TelemetryQueryTimeRange.toDateWindow(null)).toBeNull();
+      expect(TelemetryQueryTimeRange.toDateWindow(undefined)).toBeNull();
+      expect(TelemetryQueryTimeRange.toDateWindow(START_ISO)).toBeNull();
+      expect(TelemetryQueryTimeRange.toDateWindow(12345)).toBeNull();
+      expect(
+        TelemetryQueryTimeRange.toDateWindow({
+          startValue: START_ISO,
+          endValue: END_ISO,
+        }),
+      ).toBeNull();
+      // A different operator must not be mistaken for a window.
+      expect(
+        TelemetryQueryTimeRange.toDateWindow(new Search("boom")),
+      ).toBeNull();
+    });
+
+    test("returns null when either bound is unparseable, rather than an Invalid Date", () => {
+      expect(
+        TelemetryQueryTimeRange.toDateWindow(
+          new InBetween<Date>("not-a-date" as unknown as Date, END_DATE),
+        ),
+      ).toBeNull();
+      expect(
+        TelemetryQueryTimeRange.toDateWindow(
+          new InBetween<Date>(START_DATE, "" as unknown as Date),
+        ),
+      ).toBeNull();
+      expect(
+        TelemetryQueryTimeRange.toDateWindow(
+          new InBetween<Date>(
+            START_DATE,
+            new Date("nonsense") as unknown as Date,
+          ),
+        ),
+      ).toBeNull();
+      expect(
+        TelemetryQueryTimeRange.toDateWindow({
+          _type: "InBetween",
+          startValue: null,
+          endValue: END_ISO,
+        }),
+      ).toBeNull();
+    });
+
+    test("preserves an inverted window instead of falling back", () => {
+      /*
+       * A start after the end is a server-side bug. Rendering it makes that
+       * visible; quietly reverting to a rolling default would reintroduce the
+       * exact failure this whole helper exists to stop — unrelated data shown
+       * under an incident's heading with nothing to indicate it.
+       */
+      const window: InBetween<Date> | null =
+        TelemetryQueryTimeRange.toDateWindow(
+          new InBetween<Date>(END_DATE, START_DATE),
+        );
+
+      expect(window!.startValue.getTime()).toBe(END_DATE.getTime());
+      expect(window!.endValue.getTime()).toBe(START_DATE.getTime());
+    });
+  });
+
+  describe("getWindowFieldName", () => {
+    test("maps each telemetry type to the field its monitor stamps", () => {
+      expect(
+        TelemetryQueryTimeRange.getWindowFieldName(TelemetryType.Log),
+      ).toBe("time");
+      expect(
+        TelemetryQueryTimeRange.getWindowFieldName(TelemetryType.Exception),
+      ).toBe("time");
+      expect(
+        TelemetryQueryTimeRange.getWindowFieldName(TelemetryType.Trace),
+      ).toBe("startTime");
+    });
+
+    test("returns null for types that carry no query window", () => {
+      expect(
+        TelemetryQueryTimeRange.getWindowFieldName(TelemetryType.Metric),
+      ).toBeNull();
+      expect(
+        TelemetryQueryTimeRange.getWindowFieldName(TelemetryType.Profile),
+      ).toBeNull();
+      expect(TelemetryQueryTimeRange.getWindowFieldName(undefined)).toBeNull();
+    });
+  });
+
+  describe("getQueryWindow", () => {
+    test("reads the field named by the telemetry type", () => {
+      const spanQuery: JSONObject = {
+        startTime: new InBetween<Date>(START_DATE, END_DATE),
+      };
+
+      expect(
+        TelemetryQueryTimeRange.getQueryWindow(
+          spanQuery,
+          TelemetryType.Trace,
+        )!.startValue.getTime(),
+      ).toBe(START_DATE.getTime());
+
+      // Spans keep theirs on startTime, so looking for `time` must find nothing.
+      expect(
+        TelemetryQueryTimeRange.getQueryWindow(spanQuery, TelemetryType.Log),
+      ).toBeNull();
+    });
+
+    test("tries both known fields when the type is unknown", () => {
+      expect(
+        TelemetryQueryTimeRange.getQueryWindow({
+          time: new InBetween<Date>(START_DATE, END_DATE),
+        }),
+      ).not.toBeNull();
+
+      expect(
+        TelemetryQueryTimeRange.getQueryWindow({
+          startTime: new InBetween<Date>(START_DATE, END_DATE),
+        }),
+      ).not.toBeNull();
+    });
+
+    test("returns null for an empty or absent query, and for a query with no window", () => {
+      expect(TelemetryQueryTimeRange.getQueryWindow(null)).toBeNull();
+      expect(TelemetryQueryTimeRange.getQueryWindow(undefined)).toBeNull();
+      expect(TelemetryQueryTimeRange.getQueryWindow({})).toBeNull();
+      expect(
+        TelemetryQueryTimeRange.getQueryWindow({
+          body: new Search("boom"),
+          severityText: new Includes([LogSeverity.Error]),
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("round trip from a real monitor evaluation", () => {
+    /*
+     * The regression that matters. These walk the actual production path —
+     * build the query the way the worker does, persist it the way the worker
+     * does, restore it the way the page does — instead of hand-writing a
+     * fixture of what that is assumed to look like. A hand-written fixture is
+     * how the previous attempt at covering this drifted into asserting
+     * nothing.
+     */
+    type StoreAndRestoreFunction = (query: JSONObject) => JSONObject;
+
+    const storeAndRestore: StoreAndRestoreFunction = (
+      query: JSONObject,
+    ): JSONObject => {
+      // Exactly what the worker writes, then what the client reads back.
+      const stored: JSONObject = JSONFunctions.anyObjectToJSONObject(query);
+
+      return JSONFunctions.deserialize(stored);
+    };
+
+    test("log monitor: the stored window is flat ISO strings, and is recovered as Dates", () => {
+      const query: Query<Log> = MonitorStepLogMonitorUtil.toQuery({
+        ...MonitorStepLogMonitorUtil.getDefault(),
+        body: "boom",
+        lastXSecondsOfLogs: 60,
+      });
+
+      const evaluated: InBetween<Date> = (query as JSONObject)[
+        "time"
+      ] as InBetween<Date>;
+      expect(evaluated.startValue).toBeInstanceOf(Date);
+
+      const stored: JSONObject = JSONFunctions.anyObjectToJSONObject(query);
+
+      /*
+       * Pin the on-disk shape. It is FLAT — `{_type, startValue, endValue}`,
+       * with no `value` wrapper and no `{_type:"DateTime"}` tagging of the
+       * bounds. Any fixture that models it otherwise deserializes to an empty
+       * InBetween and silently asserts nothing.
+       */
+      expect(stored["time"]).toEqual({
+        _type: "InBetween",
+        startValue: evaluated.startValue.toISOString(),
+        endValue: evaluated.endValue.toISOString(),
+      });
+
+      const restored: JSONObject = JSONFunctions.deserialize(stored);
+      const restoredWindow: InBetween<Date> = restored[
+        "time"
+      ] as InBetween<Date>;
+
+      // The class survives; the bound type does not. This is the whole trap.
+      expect(restoredWindow).toBeInstanceOf(InBetween);
+      expect(typeof restoredWindow.startValue).toBe("string");
+
+      const recovered: InBetween<Date> | null =
+        TelemetryQueryTimeRange.getQueryWindow(restored, TelemetryType.Log);
+
+      expect(recovered!.startValue).toBeInstanceOf(Date);
+      expect(recovered!.startValue.getTime()).toBe(
+        evaluated.startValue.getTime(),
+      );
+      expect(recovered!.endValue.getTime()).toBe(evaluated.endValue.getTime());
+    });
+
+    test("log monitor: the window is exactly lastXSecondsOfLogs wide", () => {
+      const query: Query<Log> = MonitorStepLogMonitorUtil.toQuery({
+        ...MonitorStepLogMonitorUtil.getDefault(),
+        lastXSecondsOfLogs: 300,
+      });
+
+      const window: InBetween<Date> | null =
+        TelemetryQueryTimeRange.getQueryWindow(
+          storeAndRestore(query as JSONObject),
+          TelemetryType.Log,
+        );
+
+      expect(window!.endValue.getTime() - window!.startValue.getTime()).toBe(
+        300 * 1000,
+      );
+    });
+
+    test("trace monitor: the window round-trips off startTime", () => {
+      const query: Query<Span> = MonitorStepTraceMonitorUtil.toQuery({
+        ...MonitorStepTraceMonitorUtil.getDefault(),
+        lastXSecondsOfSpans: 120,
+      });
+
+      const evaluated: InBetween<Date> = (query as JSONObject)[
+        "startTime"
+      ] as InBetween<Date>;
+
+      const window: InBetween<Date> | null =
+        TelemetryQueryTimeRange.getQueryWindow(
+          storeAndRestore(query as JSONObject),
+          TelemetryType.Trace,
+        );
+
+      expect(window!.startValue).toBeInstanceOf(Date);
+      expect(window!.startValue.getTime()).toBe(evaluated.startValue.getTime());
+      expect(window!.endValue.getTime() - window!.startValue.getTime()).toBe(
+        120 * 1000,
+      );
+    });
+
+    test("exception monitor: the window round-trips off time", () => {
+      const query: Query<ExceptionInstance> =
+        MonitorStepExceptionMonitorUtil.toAnalyticsQuery({
+          ...MonitorStepExceptionMonitorUtil.getDefault(),
+          lastXSecondsOfExceptions: 90,
+        });
+
+      const window: InBetween<Date> | null =
+        TelemetryQueryTimeRange.getQueryWindow(
+          storeAndRestore(query as JSONObject),
+          TelemetryType.Exception,
+        );
+
+      expect(window!.startValue).toBeInstanceOf(Date);
+      expect(window!.endValue.getTime() - window!.startValue.getTime()).toBe(
+        90 * 1000,
+      );
+    });
+
+    test("a monitor configured with no window stores none, and none is recovered", () => {
+      // Backwards compatibility: older incidents, and monitors with the window off.
+      const query: Query<Log> = MonitorStepLogMonitorUtil.toQuery({
+        ...MonitorStepLogMonitorUtil.getDefault(),
+        body: "boom",
+        lastXSecondsOfLogs: 0,
+      });
+
+      expect((query as JSONObject)["time"]).toBeUndefined();
+
+      expect(
+        TelemetryQueryTimeRange.getQueryWindow(
+          storeAndRestore(query as JSONObject),
+          TelemetryType.Log,
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe("getSnapshotWindow", () => {
+    test("finds the window for each telemetry type", () => {
+      const logWindow: InBetween<Date> | null =
+        TelemetryQueryTimeRange.getSnapshotWindow({
+          telemetryType: TelemetryType.Log,
+          telemetryQuery: {
+            time: new InBetween<Date>(
+              START_ISO as unknown as Date,
+              END_ISO as unknown as Date,
+            ),
+          } as Query<Log>,
+          metricViewData: null,
+        });
+      expect(logWindow!.startValue.getTime()).toBe(START_DATE.getTime());
+
+      const traceWindow: InBetween<Date> | null =
+        TelemetryQueryTimeRange.getSnapshotWindow({
+          telemetryType: TelemetryType.Trace,
+          telemetryQuery: {
+            startTime: new InBetween<Date>(
+              START_ISO as unknown as Date,
+              END_ISO as unknown as Date,
+            ),
+          } as Query<Span>,
+          metricViewData: null,
+        });
+      expect(traceWindow!.startValue.getTime()).toBe(START_DATE.getTime());
+
+      const exceptionWindow: InBetween<Date> | null =
+        TelemetryQueryTimeRange.getSnapshotWindow({
+          telemetryType: TelemetryType.Exception,
+          telemetryQuery: {
+            time: new InBetween<Date>(
+              START_ISO as unknown as Date,
+              END_ISO as unknown as Date,
+            ),
+          } as Query<ExceptionInstance>,
+          metricViewData: null,
+        });
+      expect(exceptionWindow!.startValue.getTime()).toBe(START_DATE.getTime());
+
+      const metricWindow: InBetween<Date> | null =
+        TelemetryQueryTimeRange.getSnapshotWindow({
+          telemetryType: TelemetryType.Metric,
+          telemetryQuery: null,
+          metricViewData: {
+            startAndEndDate: new InBetween<Date>(
+              START_ISO as unknown as Date,
+              END_ISO as unknown as Date,
+            ),
+            queryConfigs: [],
+            formulaConfigs: [],
+          } as MetricViewData,
+        });
+      expect(metricWindow!.startValue).toBeInstanceOf(Date);
+      expect(metricWindow!.startValue.getTime()).toBe(START_DATE.getTime());
+    });
+
+    test("returns null for no telemetry query and for one carrying no window", () => {
+      expect(TelemetryQueryTimeRange.getSnapshotWindow(null)).toBeNull();
+      expect(TelemetryQueryTimeRange.getSnapshotWindow(undefined)).toBeNull();
+      expect(
+        TelemetryQueryTimeRange.getSnapshotWindow({
+          telemetryType: TelemetryType.Log,
+          telemetryQuery: { body: new Search("boom") } as Query<Log>,
+          metricViewData: null,
+        }),
+      ).toBeNull();
+      expect(
+        TelemetryQueryTimeRange.getSnapshotWindow({
+          telemetryType: TelemetryType.Metric,
+          telemetryQuery: null,
+          metricViewData: {
+            startAndEndDate: null,
+            queryConfigs: [],
+            formulaConfigs: [],
+          } as MetricViewData,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe("toRangeStartAndEndDateTime / getPinnedRangeForQuery", () => {
+    test("resolves to CUSTOM so the window cannot re-anchor to now", () => {
+      const range: RangeStartAndEndDateTime | null =
+        TelemetryQueryTimeRange.toRangeStartAndEndDateTime(
+          new InBetween<Date>(START_DATE, END_DATE),
+        );
+
+      expect(range!.range).toBe(TimeRange.CUSTOM);
+      expect(range!.startAndEndDate!.startValue.getTime()).toBe(
+        START_DATE.getTime(),
+      );
+    });
+
+    test("survives the picker's own resolution unchanged", () => {
+      /*
+       * The property the whole fix rests on: the logs viewer stores this value
+       * as picker state and every downstream request (list, histogram, facets)
+       * re-resolves it through RangeStartAndEndDateTimeUtil. A relative range
+       * would slide to "now" on each of those calls; CUSTOM must come back
+       * byte-identical every time.
+       */
+      const range: RangeStartAndEndDateTime | null =
+        TelemetryQueryTimeRange.toRangeStartAndEndDateTime(
+          new InBetween<Date>(START_DATE, END_DATE),
+        );
+
+      const resolved: InBetween<Date> =
+        RangeStartAndEndDateTimeUtil.getStartAndEndDate(range!);
+
+      expect(resolved.startValue.getTime()).toBe(START_DATE.getTime());
+      expect(resolved.endValue.getTime()).toBe(END_DATE.getTime());
+
+      // And again — resolving twice must not move it.
+      const resolvedAgain: InBetween<Date> =
+        RangeStartAndEndDateTimeUtil.getStartAndEndDate(range!);
+      expect(resolvedAgain.startValue.getTime()).toBe(START_DATE.getTime());
+    });
+
+    test("resolved bounds are real Dates, which downstream callers require", () => {
+      /*
+       * The facets request calls `.toISOString()` on these bounds directly. A
+       * string-valued bound would throw, so coercion is load-bearing, not
+       * cosmetic.
+       */
+      const range: RangeStartAndEndDateTime | null =
+        TelemetryQueryTimeRange.getPinnedRangeForQuery(
+          {
+            time: new InBetween<Date>(
+              START_ISO as unknown as Date,
+              END_ISO as unknown as Date,
+            ),
+          },
+          TelemetryType.Log,
+        );
+
+      const resolved: InBetween<Date> =
+        RangeStartAndEndDateTimeUtil.getStartAndEndDate(range!);
+
+      expect(() => {
+        return resolved.startValue.toISOString();
+      }).not.toThrow();
+      expect(resolved.startValue.toISOString()).toBe(START_ISO);
+    });
+
+    test("returns null when there is nothing to pin, so hosts keep their own default", () => {
+      expect(
+        TelemetryQueryTimeRange.toRangeStartAndEndDateTime(null),
+      ).toBeNull();
+      expect(
+        TelemetryQueryTimeRange.getPinnedRangeForQuery({}, TelemetryType.Log),
+      ).toBeNull();
+      expect(
+        TelemetryQueryTimeRange.getPinnedRangeForQuery(
+          undefined,
+          TelemetryType.Log,
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe("isSameRange", () => {
+    test("compares by value, not identity", () => {
+      const a: RangeStartAndEndDateTime = {
+        range: TimeRange.CUSTOM,
+        startAndEndDate: new InBetween<Date>(START_DATE, END_DATE),
+      };
+      const b: RangeStartAndEndDateTime = {
+        range: TimeRange.CUSTOM,
+        startAndEndDate: new InBetween<Date>(
+          new Date(START_ISO),
+          new Date(END_ISO),
+        ),
+      };
+
+      expect(a.startAndEndDate).not.toBe(b.startAndEndDate);
+      expect(TelemetryQueryTimeRange.isSameRange(a, b)).toBe(true);
+    });
+
+    test("treats string-valued and Date-valued bounds for the same instant as equal", () => {
+      // A host rebuilding its query from stored JSON must not look like a change.
+      expect(
+        TelemetryQueryTimeRange.isSameRange(
+          {
+            range: TimeRange.CUSTOM,
+            startAndEndDate: new InBetween<Date>(START_DATE, END_DATE),
+          },
+          {
+            range: TimeRange.CUSTOM,
+            startAndEndDate: new InBetween<Date>(
+              START_ISO as unknown as Date,
+              END_ISO as unknown as Date,
+            ),
+          },
+        ),
+      ).toBe(true);
+    });
+
+    test("detects a different window and a different range kind", () => {
+      const base: RangeStartAndEndDateTime = {
+        range: TimeRange.CUSTOM,
+        startAndEndDate: new InBetween<Date>(START_DATE, END_DATE),
+      };
+
+      expect(
+        TelemetryQueryTimeRange.isSameRange(base, {
+          range: TimeRange.CUSTOM,
+          startAndEndDate: new InBetween<Date>(
+            START_DATE,
+            new Date("2026-08-04T10:05:00.000Z"),
+          ),
+        }),
+      ).toBe(false);
+
+      expect(
+        TelemetryQueryTimeRange.isSameRange(base, {
+          range: TimeRange.PAST_ONE_HOUR,
+        }),
+      ).toBe(false);
+    });
+
+    test("handles absent values", () => {
+      expect(TelemetryQueryTimeRange.isSameRange(null, null)).toBe(true);
+      expect(TelemetryQueryTimeRange.isSameRange(undefined, null)).toBe(true);
+      expect(
+        TelemetryQueryTimeRange.isSameRange(null, {
+          range: TimeRange.PAST_ONE_HOUR,
+        }),
+      ).toBe(false);
+      expect(
+        TelemetryQueryTimeRange.isSameRange(
+          { range: TimeRange.PAST_ONE_HOUR },
+          { range: TimeRange.PAST_ONE_HOUR },
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("hydrate", () => {
+    test("gives the metric view real Date bounds", () => {
+      /*
+       * The metric chart gates bucket-grid alignment and exemplar fetching on
+       * `instanceof Date`. Until this runs, both are switched off on every
+       * incident and alert page.
+       */
+      const telemetryQuery: TelemetryQuery = {
+        telemetryType: TelemetryType.Metric,
+        telemetryQuery: null,
+        metricViewData: {
+          startAndEndDate: new InBetween<Date>(
+            START_ISO as unknown as Date,
+            END_ISO as unknown as Date,
+          ),
+          queryConfigs: [],
+          formulaConfigs: [],
+          rangeToken: undefined,
+        } as MetricViewData,
+      };
+
+      const hydrated: TelemetryQuery | null =
+        TelemetryQueryTimeRange.hydrate(telemetryQuery);
+
+      expect(
+        hydrated!.metricViewData!.startAndEndDate!.startValue,
+      ).toBeInstanceOf(Date);
+      expect(
+        hydrated!.metricViewData!.startAndEndDate!.startValue.getTime(),
+      ).toBe(START_DATE.getTime());
+      expect(
+        hydrated!.metricViewData!.startAndEndDate!.endValue.getTime(),
+      ).toBe(END_DATE.getTime());
+    });
+
+    test("gives log, trace and exception queries real Date bounds on the right field", () => {
+      const log: TelemetryQuery | null = TelemetryQueryTimeRange.hydrate({
+        telemetryType: TelemetryType.Log,
+        telemetryQuery: {
+          time: new InBetween<Date>(
+            START_ISO as unknown as Date,
+            END_ISO as unknown as Date,
+          ),
+        } as Query<Log>,
+        metricViewData: null,
+      });
+      expect(
+        ((log!.telemetryQuery as JSONObject)["time"] as InBetween<Date>)
+          .startValue,
+      ).toBeInstanceOf(Date);
+
+      const trace: TelemetryQuery | null = TelemetryQueryTimeRange.hydrate({
+        telemetryType: TelemetryType.Trace,
+        telemetryQuery: {
+          startTime: new InBetween<Date>(
+            START_ISO as unknown as Date,
+            END_ISO as unknown as Date,
+          ),
+        } as Query<Span>,
+        metricViewData: null,
+      });
+      expect(
+        ((trace!.telemetryQuery as JSONObject)["startTime"] as InBetween<Date>)
+          .startValue,
+      ).toBeInstanceOf(Date);
+
+      const exception: TelemetryQuery | null = TelemetryQueryTimeRange.hydrate({
+        telemetryType: TelemetryType.Exception,
+        telemetryQuery: {
+          time: new InBetween<Date>(
+            START_ISO as unknown as Date,
+            END_ISO as unknown as Date,
+          ),
+        } as Query<ExceptionInstance>,
+        metricViewData: null,
+      });
+      expect(
+        ((exception!.telemetryQuery as JSONObject)["time"] as InBetween<Date>)
+          .startValue,
+      ).toBeInstanceOf(Date);
+    });
+
+    test("leaves every other filter on the query untouched", () => {
+      const body: Search<string> = new Search("boom");
+      const severity: Includes = new Includes([LogSeverity.Error]);
+
+      const hydrated: TelemetryQuery | null = TelemetryQueryTimeRange.hydrate({
+        telemetryType: TelemetryType.Log,
+        telemetryQuery: {
+          body: body,
+          severityText: severity,
+          time: new InBetween<Date>(
+            START_ISO as unknown as Date,
+            END_ISO as unknown as Date,
+          ),
+        } as unknown as Query<Log>,
+        metricViewData: null,
+      });
+
+      const query: JSONObject = hydrated!.telemetryQuery as JSONObject;
+      expect(query["body"]).toBe(body);
+      expect(query["severityText"]).toBe(severity);
+    });
+
+    test("leaves the rest of the metric view untouched, including rangeToken", () => {
+      const queryConfigs: MetricViewData["queryConfigs"] = [];
+      const metricViewData: MetricViewData = {
+        startAndEndDate: new InBetween<Date>(
+          START_ISO as unknown as Date,
+          END_ISO as unknown as Date,
+        ),
+        queryConfigs: queryConfigs,
+        formulaConfigs: [],
+        rangeToken: TimeRange.PAST_ONE_HOUR,
+      };
+
+      const hydrated: TelemetryQuery | null = TelemetryQueryTimeRange.hydrate({
+        telemetryType: TelemetryType.Metric,
+        telemetryQuery: null,
+        metricViewData: metricViewData,
+      });
+
+      expect(hydrated!.metricViewData!.queryConfigs).toBe(queryConfigs);
+      expect(hydrated!.metricViewData!.rangeToken).toBe(
+        TimeRange.PAST_ONE_HOUR,
+      );
+    });
+
+    test("returns the same reference when there is nothing to fix", () => {
+      /*
+       * React hosts call this on every load; handing back a fresh-but-equal
+       * object would churn state and refetch.
+       */
+      const alreadyDates: TelemetryQuery = {
+        telemetryType: TelemetryType.Log,
+        telemetryQuery: {
+          time: new InBetween<Date>(START_DATE, END_DATE),
+        } as Query<Log>,
+        metricViewData: null,
+      };
+      expect(TelemetryQueryTimeRange.hydrate(alreadyDates)).toBe(alreadyDates);
+
+      const noWindow: TelemetryQuery = {
+        telemetryType: TelemetryType.Log,
+        telemetryQuery: { body: new Search("boom") } as Query<Log>,
+        metricViewData: null,
+      };
+      expect(TelemetryQueryTimeRange.hydrate(noWindow)).toBe(noWindow);
+    });
+
+    test("returns null for no telemetry query", () => {
+      expect(TelemetryQueryTimeRange.hydrate(null)).toBeNull();
+      expect(TelemetryQueryTimeRange.hydrate(undefined)).toBeNull();
+    });
+
+    test("hydrating a stored blob end to end yields a chart-ready window", () => {
+      // The full production path for a metric incident, in one assertion chain.
+      const evaluated: InBetween<Date> = new InBetween<Date>(
+        START_DATE,
+        END_DATE,
+      );
+
+      const restored: TelemetryQuery = JSONFunctions.deserialize(
+        JSONFunctions.anyObjectToJSONObject({
+          telemetryType: TelemetryType.Metric,
+          telemetryQuery: null,
+          metricViewData: {
+            startAndEndDate: evaluated,
+            queryConfigs: [],
+            formulaConfigs: [],
+          },
+        }),
+      ) as unknown as TelemetryQuery;
+
+      // Before hydration the guard downstream would reject this.
+      expect(
+        restored.metricViewData!.startAndEndDate!.startValue,
+      ).not.toBeInstanceOf(Date);
+
+      const hydrated: TelemetryQuery | null =
+        TelemetryQueryTimeRange.hydrate(restored);
+
+      expect(
+        hydrated!.metricViewData!.startAndEndDate!.startValue,
+      ).toBeInstanceOf(Date);
+      expect(
+        hydrated!.metricViewData!.startAndEndDate!.startValue.getTime(),
+      ).toBe(START_DATE.getTime());
+    });
+  });
+});

--- a/Common/Utils/Telemetry/TelemetryQueryTimeRange.ts
+++ b/Common/Utils/Telemetry/TelemetryQueryTimeRange.ts
@@ -1,0 +1,334 @@
+import InBetween from "../../Types/BaseDatabase/InBetween";
+import Query from "../../Types/BaseDatabase/Query";
+import { JSONObject, ObjectType } from "../../Types/JSON";
+import MetricViewData from "../../Types/Metrics/MetricViewData";
+import { TelemetryQuery } from "../../Types/Telemetry/TelemetryQuery";
+import TelemetryType from "../../Types/Telemetry/TelemetryType";
+import RangeStartAndEndDateTime from "../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../Types/Time/TimeRange";
+
+/*
+ * The snapshot window that a telemetry monitor evaluated over is stamped onto
+ * the query it stores on the Incident / Alert row: logs and exceptions carry
+ * it as `time`, spans as `startTime`, metrics as `metricViewData.startAndEndDate`.
+ *
+ * Two things make that window awkward to consume on the client.
+ *
+ * 1. It does not survive the store/load round trip as Dates. The blob is
+ *    persisted through `JSON.stringify`, which calls `InBetween.toJSON()` and
+ *    then flattens each bound to an ISO string. On the way back
+ *    `InBetween.fromJSON()` reconstructs the operator but hands those strings
+ *    to the constructor untouched, so `startValue` is a `string` even though
+ *    the static type says `Date`. Anything guarding on `instanceof Date`
+ *    silently no-ops on an incident page.
+ *
+ * 2. Viewers that own a time-range picker (the logs viewer) need the window as
+ *    a `RangeStartAndEndDateTime`, not as a query filter, because the picker
+ *    state — not the query — is what drives the histogram and facet requests.
+ *
+ * These helpers are the single place that knows both shapes. They are pure so
+ * they can be unit tested without mounting a viewer.
+ */
+export default class TelemetryQueryTimeRange {
+  /*
+   * Field on the telemetry query that carries the snapshot window, per type.
+   * Metrics keep theirs on metricViewData instead, and profiles do not store a
+   * query at all, so both return null.
+   */
+  public static getWindowFieldName(
+    telemetryType: TelemetryType | undefined | null,
+  ): string | null {
+    if (telemetryType === TelemetryType.Log) {
+      return "time";
+    }
+
+    if (telemetryType === TelemetryType.Exception) {
+      return "time";
+    }
+
+    if (telemetryType === TelemetryType.Trace) {
+      return "startTime";
+    }
+
+    return null;
+  }
+
+  /*
+   * Coerce a stored window into an InBetween whose bounds are real Dates.
+   *
+   * Accepts an `InBetween` instance (bounds may be Dates, ISO strings or epoch
+   * numbers, depending on whether the value was just built or came back from
+   * storage) and the plain `{ _type: "InBetween", startValue, endValue }`
+   * object that a caller sees when it skipped `JSONFunctions.deserialize`.
+   *
+   * Returns null for anything unparseable so callers can fall back to their own
+   * default. An inverted window (start after end) is returned as-is rather than
+   * rejected: it renders as a visibly odd range the user can see and report,
+   * which beats silently swapping back to a rolling default that shows
+   * unrelated data under an incident's heading.
+   */
+  public static toDateWindow(value: unknown): InBetween<Date> | null {
+    if (!value || typeof value !== "object") {
+      return null;
+    }
+
+    let rawStart: unknown = undefined;
+    let rawEnd: unknown = undefined;
+
+    if (value instanceof InBetween) {
+      /*
+       * Already in the target shape — hand back the same instance rather than
+       * an equal copy. Callers use identity to decide whether anything changed,
+       * and a fresh-but-equal object would churn React state on every load.
+       */
+      if (
+        this.toDate(value.startValue) === value.startValue &&
+        this.toDate(value.endValue) === value.endValue
+      ) {
+        return value as InBetween<Date>;
+      }
+
+      rawStart = value.startValue;
+      rawEnd = value.endValue;
+    } else if ((value as JSONObject)["_type"] === ObjectType.InBetween) {
+      rawStart = (value as JSONObject)["startValue"];
+      rawEnd = (value as JSONObject)["endValue"];
+    } else {
+      return null;
+    }
+
+    const startDate: Date | null = this.toDate(rawStart);
+    const endDate: Date | null = this.toDate(rawEnd);
+
+    if (!startDate || !endDate) {
+      return null;
+    }
+
+    return new InBetween<Date>(startDate, endDate);
+  }
+
+  private static toDate(value: unknown): Date | null {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? null : value;
+    }
+
+    if (typeof value !== "string" && typeof value !== "number") {
+      return null;
+    }
+
+    /*
+     * `new Date("")` is the current time, not an Invalid Date, so an empty
+     * bound would silently become "now" and quietly widen the window instead
+     * of being reported as missing.
+     */
+    if (typeof value === "string" && value.trim() === "") {
+      return null;
+    }
+
+    const parsed: Date = new Date(value);
+
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  /*
+   * Pull the snapshot window out of a telemetry query record, whatever its
+   * telemetry type. Returns null when the monitor stored no window (older
+   * incidents, or a log monitor configured with no lastXSecondsOfLogs).
+   */
+  public static getSnapshotWindow(
+    telemetryQuery: TelemetryQuery | null | undefined,
+  ): InBetween<Date> | null {
+    if (!telemetryQuery) {
+      return null;
+    }
+
+    if (telemetryQuery.metricViewData) {
+      const metricWindow: InBetween<Date> | null = this.toDateWindow(
+        telemetryQuery.metricViewData.startAndEndDate,
+      );
+
+      if (metricWindow) {
+        return metricWindow;
+      }
+    }
+
+    return this.getQueryWindow(
+      telemetryQuery.telemetryQuery,
+      telemetryQuery.telemetryType,
+    );
+  }
+
+  /*
+   * Same, for a bare query. `telemetryType` picks the field to read; when it is
+   * unknown both known field names are tried so a caller holding only a query
+   * (e.g. the logs viewer, which is handed a Query<Log> and nothing else) still
+   * finds the window.
+   */
+  public static getQueryWindow(
+    query: Query<Record<string, unknown>> | JSONObject | null | undefined,
+    telemetryType?: TelemetryType | undefined,
+  ): InBetween<Date> | null {
+    if (!query) {
+      return null;
+    }
+
+    const fieldName: string | null = this.getWindowFieldName(telemetryType);
+    const fieldNames: Array<string> = fieldName
+      ? [fieldName]
+      : ["time", "startTime"];
+
+    for (const candidate of fieldNames) {
+      const window: InBetween<Date> | null = this.toDateWindow(
+        (query as JSONObject)[candidate],
+      );
+
+      if (window) {
+        return window;
+      }
+    }
+
+    return null;
+  }
+
+  /*
+   * Present a snapshot window as a picker value. Always CUSTOM: the window is
+   * an absolute instant in the past, so it must never re-anchor to "now" the
+   * way a relative range like "Past 1 Hour" does.
+   */
+  public static toRangeStartAndEndDateTime(
+    window: InBetween<Date> | null | undefined,
+  ): RangeStartAndEndDateTime | null {
+    if (!window) {
+      return null;
+    }
+
+    return {
+      range: TimeRange.CUSTOM,
+      startAndEndDate: window,
+    };
+  }
+
+  /*
+   * Convenience for viewers: resolve the pinned picker value for a query, or
+   * null when the query carries no window and the viewer should keep its own
+   * rolling default.
+   */
+  public static getPinnedRangeForQuery(
+    query: Query<Record<string, unknown>> | JSONObject | null | undefined,
+    telemetryType?: TelemetryType | undefined,
+  ): RangeStartAndEndDateTime | null {
+    return this.toRangeStartAndEndDateTime(
+      this.getQueryWindow(query, telemetryType),
+    );
+  }
+
+  /*
+   * Value equality for two picker values. Hosts that rebuild their query on
+   * every render produce an equal-but-new window each time, so state updates
+   * have to be gated on the value rather than on object identity or a
+   * re-render loop follows.
+   */
+  public static isSameRange(
+    a: RangeStartAndEndDateTime | null | undefined,
+    b: RangeStartAndEndDateTime | null | undefined,
+  ): boolean {
+    if (!a || !b) {
+      return !a && !b;
+    }
+
+    if (a.range !== b.range) {
+      return false;
+    }
+
+    const aWindow: InBetween<Date> | null = this.toDateWindow(
+      a.startAndEndDate,
+    );
+    const bWindow: InBetween<Date> | null = this.toDateWindow(
+      b.startAndEndDate,
+    );
+
+    if (!aWindow || !bWindow) {
+      return !aWindow && !bWindow;
+    }
+
+    return (
+      aWindow.startValue.getTime() === bWindow.startValue.getTime() &&
+      aWindow.endValue.getTime() === bWindow.endValue.getTime()
+    );
+  }
+
+  /*
+   * Rewrite a stored telemetry query so every window bound is a real Date.
+   *
+   * Consumers downstream gate real behaviour on `instanceof Date` — the metric
+   * chart skips aggregation-bucket alignment and never fetches exemplars when
+   * the bounds are strings — so hydrating once at the page's deserialize
+   * boundary is what makes those paths work on an incident.
+   *
+   * Returns the input unchanged (same reference) when there is nothing to fix,
+   * so callers can hydrate unconditionally without churning React state.
+   */
+  public static hydrate(
+    telemetryQuery: TelemetryQuery | null | undefined,
+  ): TelemetryQuery | null {
+    if (!telemetryQuery) {
+      return null;
+    }
+
+    let didChange: boolean = false;
+
+    let metricViewData: MetricViewData | null =
+      telemetryQuery.metricViewData || null;
+
+    if (metricViewData) {
+      const metricWindow: InBetween<Date> | null = this.toDateWindow(
+        metricViewData.startAndEndDate,
+      );
+
+      if (metricWindow && metricWindow !== metricViewData.startAndEndDate) {
+        metricViewData = {
+          ...metricViewData,
+          startAndEndDate: metricWindow,
+        };
+        didChange = true;
+      }
+    }
+
+    let query: TelemetryQuery["telemetryQuery"] =
+      telemetryQuery.telemetryQuery || null;
+
+    if (query) {
+      const fieldName: string | null = this.getWindowFieldName(
+        telemetryQuery.telemetryType,
+      );
+
+      if (fieldName) {
+        const window: InBetween<Date> | null = this.toDateWindow(
+          (query as JSONObject)[fieldName],
+        );
+
+        if (window && window !== (query as JSONObject)[fieldName]) {
+          query = {
+            ...(query as JSONObject),
+            [fieldName]: window,
+          } as TelemetryQuery["telemetryQuery"];
+          didChange = true;
+        }
+      }
+    }
+
+    if (!didChange) {
+      return telemetryQuery;
+    }
+
+    return {
+      ...telemetryQuery,
+      telemetryQuery: query,
+      metricViewData: metricViewData,
+    };
+  }
+}


### PR DESCRIPTION
## The bug

A telemetry monitor stamps the window it evaluated over onto the query it stores on the Incident/Alert row. The **log preview threw that away** and substituted a rolling "past 1 hour" — so an incident from last Tuesday rendered the last hour of unrelated logs under *"Logs for this incident"*, with the time picker reading "Past 1 Hour".

## Why it happened

`DashboardLogsViewer` keeps two representations of the window:

- `filterOptions.time` — drives the log list
- a `timeRange` picker state — drives the histogram, the facet counts, and the picker's own label

`buildBaseQuery` faithfully copied the caller's window into the first, and **six** sites then re-derived it from the second — which was only ever seeded from the URL or the `PAST_ONE_HOUR` literal, never from props.

Seeding that state from the query's own window fixes all six at once: the list, the histogram, the facets, the facet rebuild, clear-all-filters, and the picker label. It resolves as `CUSTOM`, so live polling and preset re-anchoring leave it alone, and the user can still widen it. A pinned window also suppresses the auto-applied default saved view, which carries a time range of its own.

## Per telemetry type

| | Queried the right window? | Said so? |
|---|---|---|
| **Logs** | ❌ discarded — **the reported bug** | ❌ → ✅ |
| **Traces** | ✅ already correct | ❌ → ✅ |
| **Exceptions** | ✅ already correct | ❌ → ✅ |
| **Metrics** | ✅ already correct | ✅ already |

Traces and exceptions already queried the right window but never showed it, and a "Seen At"/"Time" filter restored from the URL could silently replace it. Both tables now take the window badge and opt out of URL filter state on these pages.

## The second defect: the window loses its type in storage

The stored blob round-trips through `JSON.stringify`, which calls `InBetween.toJSON()` and flattens each `Date` bound to an ISO string; `InBetween.fromJSON` hands those strings back untouched. So a restored window is a real `InBetween` **whose bounds are strings**, despite the type saying `Date`.

Every consumer guarding on `instanceof Date` therefore silently no-opped on incident and alert pages — the metric chart skipped aggregation-bucket alignment and never fetched exemplar (trace drill-down) dots. The pages now rebuild the Date bounds at the deserialize boundary, and both guards go through the shared coercion.

No data migration or wire-format change: every existing row already carries a usable window to the millisecond.

## Deliberate non-change

The monitor step's **Logs Preview** keeps its rolling window. Pinning is right for an incident, but a 60-second window frozen at the instant the form opened empties out a minute later and reads as *"my filter matches nothing"*. This preserves today's behaviour exactly.

## Tests

- **35** unit tests for the new pure helper (`Common/Utils/Telemetry/TelemetryQueryTimeRange.ts`), built on the real monitor → store → load round trip rather than a hand-written fixture
- **27** behaviour + wiring tests for the viewer and the pages
- **3** render tests for the window badge, including the backwards-compat "no window stored" branch
- Repairs a **previously vacuous** fixture in `IncidentMetricSeriesScope.test.ts` that nested `InBetween` bounds under `value:` when the real shape is flat — it deserialized to `new InBetween(undefined, undefined)` and asserted nothing, which is why this went unnoticed

Verified by mutation testing: reverting `LogsViewer.tsx` to master fails 7 tests; making the pinned range relative again fails 2.

`tsc --noEmit` clean in App and Common; eslint clean; 1488 Common and 3916 App Dashboard tests pass with no regressions.

## Known issues left out of scope

- `Common/UI/Components/Charts/Utils/XAxis.ts` has four sub-minute precision tiers the server can never fill (`AggregationInterval`'s finest tier is `Minute`), so a 60-second metric window can render a sparse chart. Separate bug, wider blast radius.
- Seeding `BaseModelTable`'s `filterData` from `props.query` would make a pinned window visible as a filter chip. Touches every table in the product.
- The monitor Logs Preview showing ~60× more logs than the monitor counts makes threshold sizing misleading. Fixing it properly needs a live-sliding window, not a frozen one.