### PR TITLE
Fix port monitor connection phase timings

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorMetrics.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorMetrics.tsx
@@ -53,7 +53,10 @@ function resolveSeriesTitle(args: GetSeriesResolverArgs): ChartSeries {
   const { data, monitorType, monitorMetricType, probes } = args;
 
   const fallback: ChartSeries = {
-    title: MonitorMetricTypeUtil.getTitleByMonitorMetricType(monitorMetricType),
+    title: MonitorMetricTypeUtil.getTitleByMonitorMetricType(
+      monitorMetricType,
+      monitorType,
+    ),
   };
 
   if (!data) {
@@ -167,18 +170,19 @@ const MonitorMetricsElement: FunctionComponent<ComponentProps> = (
           return {
             metricAliasData: {
               metricVariable: monitorMetricType,
-              title:
-                MonitorMetricTypeUtil.getTitleByMonitorMetricType(
-                  monitorMetricType,
-                ),
+              title: MonitorMetricTypeUtil.getTitleByMonitorMetricType(
+                monitorMetricType,
+                monitorType,
+              ),
               description:
                 MonitorMetricTypeUtil.getDescriptionByMonitorMetricType(
                   monitorMetricType,
+                  monitorType,
                 ),
-              legend:
-                MonitorMetricTypeUtil.getLegendByMonitorMetricType(
-                  monitorMetricType,
-                ),
+              legend: MonitorMetricTypeUtil.getLegendByMonitorMetricType(
+                monitorMetricType,
+                monitorType,
+              ),
               legendUnit:
                 MonitorMetricTypeUtil.getLegendUnitByMonitorMetricType(
                   monitorMetricType,

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/PortMonitorView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/PortMonitorView.tsx
@@ -1,0 +1,130 @@
+import OneUptimeDate from "Common/Types/Date";
+import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
+import ProbeMonitorResponse from "Common/Types/Probe/ProbeMonitorResponse";
+import InfoCard from "Common/UI/Components/InfoCard/InfoCard";
+import React, { FunctionComponent, ReactElement } from "react";
+import NetworkPathView from "./NetworkPathView";
+import PortTimingsView from "./PortTimingsView";
+import ProbeAttemptsView from "./ProbeAttemptsView";
+
+export interface ComponentProps {
+  probeMonitorResponse: ProbeMonitorResponse;
+  probeName?: string | undefined;
+}
+
+const formatDurationInMs: (durationInMs: number | undefined) => string = (
+  durationInMs: number | undefined,
+): string => {
+  if (durationInMs === undefined) {
+    return "-";
+  }
+
+  return `${Math.round(durationInMs * 100) / 100} ms`;
+};
+
+const PortMonitorView: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const response: ProbeMonitorResponse = props.probeMonitorResponse;
+  const destination: string = response.monitorDestination?.toString() || "";
+  const destinationPort: string =
+    response.monitorDestinationPort?.toString() || "";
+  const probeAttempts: Array<ProbeAttempt> = response.probeAttempts || [];
+  const totalAttempts: number = response.totalAttempts ?? probeAttempts.length;
+  const hadRetries: boolean = totalAttempts > 1;
+  const hasErrorDetails: boolean = Boolean(response.requestFailedDetails);
+
+  return (
+    <div className="space-y-5">
+      <div className="flex space-x-3">
+        <InfoCard
+          className="w-full shadow-none border-2 border-gray-100 "
+          title="Hostname or IP address"
+          value={
+            `${destination}${destinationPort ? `:${destinationPort}` : ""}` ||
+            "-"
+          }
+        />
+      </div>
+      <div className="flex space-x-3">
+        <InfoCard
+          className="w-1/4 shadow-none border-2 border-gray-100 "
+          title="Probe"
+          value={props.probeName || "-"}
+        />
+        <InfoCard
+          className="w-1/4 shadow-none border-2 border-gray-100 "
+          title="Status"
+          value={response.isOnline ? "Online" : "Offline"}
+        />
+        <InfoCard
+          className="w-1/4 shadow-none border-2 border-gray-100 "
+          title="Total Connection Time (DNS + TCP)"
+          value={formatDurationInMs(response.responseTimeInMs)}
+        />
+        <InfoCard
+          className="w-1/4 shadow-none border-2 border-gray-100 "
+          title="Monitored At"
+          value={
+            response.monitoredAt
+              ? OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(
+                  response.monitoredAt,
+                )
+              : "-"
+          }
+        />
+      </div>
+
+      {response.portTimings && (
+        <PortTimingsView portTimings={response.portTimings} />
+      )}
+
+      {response.failureCause && (
+        <div className="flex space-x-3">
+          <InfoCard
+            className="w-full shadow-none border-2 border-gray-100 "
+            title="Error"
+            value={response.failureCause.toString() || "-"}
+          />
+        </div>
+      )}
+
+      {hasErrorDetails && (
+        <div className="space-y-3">
+          <div className="flex space-x-3">
+            <InfoCard
+              className="w-1/2 shadow-none border-2 border-gray-100 "
+              title="Failed At"
+              value={response.requestFailedDetails?.failedPhase || "-"}
+            />
+            <InfoCard
+              className="w-1/2 shadow-none border-2 border-gray-100 "
+              title="Error Code"
+              value={response.requestFailedDetails?.errorCode || "-"}
+            />
+          </div>
+          <div className="flex space-x-3">
+            <InfoCard
+              className="w-full shadow-none border-2 border-gray-100 "
+              title="Error Details"
+              value={response.requestFailedDetails?.errorDescription || "-"}
+            />
+          </div>
+        </div>
+      )}
+
+      {response.networkPathTrace && (
+        <NetworkPathView networkPathTrace={response.networkPathTrace} />
+      )}
+
+      {hadRetries && (
+        <ProbeAttemptsView
+          attempts={probeAttempts}
+          totalAttempts={totalAttempts}
+        />
+      )}
+    </div>
+  );
+};
+
+export default PortMonitorView;

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/PortTimingsView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/PortTimingsView.tsx
@@ -1,0 +1,96 @@
+import PortMonitorTimings from "Common/Types/Monitor/PortMonitor/PortMonitorTimings";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  portTimings: PortMonitorTimings;
+}
+
+interface ConnectionPhase {
+  label: string;
+  valueInMs: number;
+  colorClassName: string;
+}
+
+const formatDurationInMs: (durationInMs: number) => string = (
+  durationInMs: number,
+): string => {
+  return `${Math.round(durationInMs * 100) / 100} ms`;
+};
+
+/*
+ * A compact waterfall for a Port check. The total remains in the summary
+ * card because it is the stable responseTimeInMs value used by existing
+ * charts and criteria; this view explains how DNS and TCP contributed to it.
+ */
+const PortTimingsView: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement | null => {
+  const timings: PortMonitorTimings = props.portTimings;
+
+  const phases: Array<ConnectionPhase> = [
+    {
+      label: "DNS Lookup",
+      valueInMs: timings.dnsLookupInMs ?? -1,
+      colorClassName: "bg-indigo-400",
+    },
+    {
+      label: "TCP Connect",
+      valueInMs: timings.tcpConnectInMs ?? -1,
+      colorClassName: "bg-sky-400",
+    },
+  ].filter((phase: ConnectionPhase) => {
+    return phase.valueInMs >= 0;
+  });
+
+  if (phases.length === 0) {
+    return null;
+  }
+
+  const measuredPhasesTotalInMs: number = phases.reduce(
+    (sum: number, phase: ConnectionPhase) => {
+      return sum + phase.valueInMs;
+    },
+    0,
+  );
+  const totalConnectionInMs: number =
+    timings.totalConnectionInMs !== undefined &&
+    timings.totalConnectionInMs >= measuredPhasesTotalInMs
+      ? timings.totalConnectionInMs
+      : measuredPhasesTotalInMs;
+
+  return (
+    <div className="rounded-md border-2 border-gray-100 p-4">
+      <div className="text-sm font-medium text-gray-900 mb-1">
+        Connection Phase Breakdown
+      </div>
+      <div className="text-xs text-gray-500 mb-3">
+        Time spent resolving the target and establishing the TCP connection.
+      </div>
+      <div className="space-y-2">
+        {phases.map((phase: ConnectionPhase) => {
+          const percent: number =
+            totalConnectionInMs > 0
+              ? (phase.valueInMs / totalConnectionInMs) * 100
+              : 0;
+
+          return (
+            <div key={phase.label} className="flex items-center text-sm">
+              <div className="w-32 shrink-0 text-gray-700">{phase.label}</div>
+              <div className="flex-1 mx-2">
+                <div
+                  className={`h-3 rounded ${phase.colorClassName}`}
+                  style={{ width: `${Math.max(percent, 1)}%` }}
+                ></div>
+              </div>
+              <div className="w-24 shrink-0 text-right text-gray-700 font-mono">
+                {formatDurationInMs(phase.valueInMs)}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default PortTimingsView;

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SummaryInfo.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SummaryInfo.tsx
@@ -2,6 +2,7 @@ import ServerMonitorResponse from "Common/Types/Monitor/ServerMonitor/ServerMoni
 import IncomingRequestMonitorView from "./IncomingRequestMonitorSummaryView";
 import IncomingEmailMonitorSummaryView from "./IncomingEmailMonitorSummaryView";
 import PingMonitorView from "./PingMonitorView";
+import PortMonitorView from "./PortMonitorView";
 import SSLCertificateMonitorView from "./SSLCertificateMonitorView";
 import ServerMonitorSummaryView from "./ServerMonitorView";
 import SyntheticMonitorView from "./SyntheticMonitorView";
@@ -89,11 +90,19 @@ const SummaryInfo: FunctionComponent<ComponentProps> = (
 
     if (
       props.monitorType === MonitorType.Ping ||
-      props.monitorType === MonitorType.IP ||
-      props.monitorType === MonitorType.Port
+      props.monitorType === MonitorType.IP
     ) {
       summaryComponent = (
         <PingMonitorView
+          probeMonitorResponse={probeMonitorResponse}
+          probeName={props.probeName}
+        />
+      );
+    }
+
+    if (props.monitorType === MonitorType.Port) {
+      summaryComponent = (
+        <PortMonitorView
           probeMonitorResponse={probeMonitorResponse}
           probeName={props.probeName}
         />

--- a/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
@@ -49,7 +49,9 @@ export default class CriteriaFilterUtil {
 
     const isMilliseconds: boolean =
       criteriaFilter?.checkOn === CheckOn.ResponseTime ||
-      criteriaFilter?.checkOn === CheckOn.Jitter;
+      criteriaFilter?.checkOn === CheckOn.Jitter ||
+      criteriaFilter?.checkOn === CheckOn.PortDnsLookupTime ||
+      criteriaFilter?.checkOn === CheckOn.PortTcpConnectTime;
 
     // check evaluation over time values.
     if (
@@ -205,13 +207,26 @@ export default class CriteriaFilterUtil {
     }
 
     if (monitorType === MonitorType.Port) {
-      options = options.filter((i: DropdownOption) => {
-        return (
-          i.value === CheckOn.IsOnline ||
-          i.value === CheckOn.ResponseTime ||
-          i.value === CheckOn.IsRequestTimeout
-        );
-      });
+      options = options
+        .filter((i: DropdownOption) => {
+          return (
+            i.value === CheckOn.IsOnline ||
+            i.value === CheckOn.ResponseTime ||
+            i.value === CheckOn.PortDnsLookupTime ||
+            i.value === CheckOn.PortTcpConnectTime ||
+            i.value === CheckOn.IsRequestTimeout
+          );
+        })
+        .map((i: DropdownOption) => {
+          if (i.value === CheckOn.ResponseTime) {
+            return {
+              ...i,
+              label: "Total Connection Time (DNS + TCP) (in ms)",
+            };
+          }
+
+          return i;
+        });
     }
 
     if (monitorType === MonitorType.Server) {
@@ -432,7 +447,9 @@ export default class CriteriaFilterUtil {
       checkOn === CheckOn.ResponseTime ||
       checkOn === CheckOn.ExecutionTime ||
       checkOn === CheckOn.PacketLossPercent ||
-      checkOn === CheckOn.Jitter
+      checkOn === CheckOn.Jitter ||
+      checkOn === CheckOn.PortDnsLookupTime ||
+      checkOn === CheckOn.PortTcpConnectTime
     ) {
       options = options.filter((i: DropdownOption) => {
         return (
@@ -961,6 +978,13 @@ export default class CriteriaFilterUtil {
 
     if (checkOn === CheckOn.ResponseTime) {
       return "5000";
+    }
+
+    if (
+      checkOn === CheckOn.PortDnsLookupTime ||
+      checkOn === CheckOn.PortTcpConnectTime
+    ) {
+      return "1000";
     }
 
     if (checkOn === CheckOn.PacketLossPercent) {

--- a/App/FeatureSet/Docs/Content/en/monitor/incident-alert-templating.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/incident-alert-templating.md
@@ -51,12 +51,12 @@ The following monitor types support dynamic templating with their respective var
 
 ### Port Monitors
 
-| Variable           | Description                                       | Type      |
-| ------------------ | ------------------------------------------------- | --------- |
-| `isOnline`         | Whether the port is considered online/accessible. | `boolean` |
-| `responseTimeInMs` | The connection response time in milliseconds.     | `number`  |
-| `failureCause`     | The reason for failure if the port check failed.  | `string`  |
-| `isTimeout`        | Whether the port connection timed out.            | `boolean` |
+| Variable           | Description                                                             | Type      |
+| ------------------ | ----------------------------------------------------------------------- | --------- |
+| `isOnline`         | Whether the port is considered online/accessible.                       | `boolean` |
+| `responseTimeInMs` | Total connection time (DNS lookup plus TCP connection) in milliseconds. | `number`  |
+| `failureCause`     | The reason for failure if the port check failed.                        | `string`  |
+| `isTimeout`        | Whether the port connection timed out.                                  | `boolean` |
 
 ### IP Monitors
 
@@ -350,7 +350,7 @@ Ping failed for target: {{failureCause}} ({{responseTimeInMs}}ms)
 ```
 Port connectivity issue
 Target port status: {{isOnline}}
-Response time: {{responseTimeInMs}}ms
+Total connection time (DNS + TCP): {{responseTimeInMs}}ms
 Failure cause: {{failureCause}}
 ```
 

--- a/App/FeatureSet/Docs/Content/en/monitor/port-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/port-monitor.md
@@ -1,13 +1,13 @@
 # Port Monitor
 
-Port monitoring allows you to monitor the availability of specific TCP or UDP ports on a host. OneUptime periodically attempts to connect to the specified port and checks whether it is open and responsive.
+Port monitoring allows you to monitor the availability of a specific TCP port on a host. OneUptime periodically attempts to establish a TCP connection to the specified port and checks whether it is open and responsive.
 
 ## Overview
 
 Port monitors test whether a specific network port is accepting connections. This enables you to:
 
 - Monitor service availability on specific ports
-- Track port response times
+- Track total connection time, including DNS lookup and TCP connection setup
 - Verify that services like databases, mail servers, and application servers are running
 - Detect service outages before they impact users
 
@@ -40,17 +40,30 @@ Enter the port number to monitor (1–65535). Common examples:
 | 6379  | Redis      |
 | 27017 | MongoDB    |
 
+## Connection Timing
+
+For a hostname target, OneUptime measures the port check in two phases:
+
+1. **DNS Lookup** — time from the start of the check until the first TCP connection attempt begins.
+2. **TCP Connect** — time from the first TCP connection attempt until a connection succeeds. This includes the time spent trying another address when IPv6/IPv4 fallback is needed.
+
+The **Total Connection Time (DNS + TCP)** is measured from the start of the check until the TCP connection succeeds. It is also retained as the port monitor's existing response-time value, so current criteria, alerts, and historical charts continue to use the same field.
+
+When the target is an IP address, no DNS lookup is required, so the DNS phase is omitted. Older check results collected before phase timing was available show only the total connection time.
+
 ## Monitoring Criteria
 
 You can configure criteria to determine when your port is considered online, degraded, or offline based on:
 
 ### Available Check Types
 
-| Check Type            | Description                                        |
-| --------------------- | -------------------------------------------------- |
-| Is Online             | Whether the port is open and accepting connections |
-| Response Time (in ms) | Time to establish a connection in milliseconds     |
-| Is Request Timeout    | Whether the connection attempt timed out           |
+| Check Type                    | Description                                                                         |
+| ----------------------------- | ----------------------------------------------------------------------------------- |
+| Is Online                     | Whether the port is open and accepting connections                                  |
+| Total Connection Time (DNS + TCP) (in ms) | Total connection time, including DNS lookup when the target is a hostname |
+| Port DNS Lookup Time (in ms)  | DNS lookup time before the first TCP attempt; unavailable when the target is an IP  |
+| Port TCP Connect Time (in ms) | Time from the first TCP attempt until a connection succeeds, including IP fallback  |
+| Is Request Timeout            | Whether the DNS lookup or TCP connection attempt exceeded the configured time limit |
 
 ### Filter Types
 
@@ -59,15 +72,15 @@ For **Is Online** and **Is Request Timeout**:
 - **True** — Condition is true
 - **False** — Condition is false
 
-For **Response Time**:
+For **Total Connection Time (DNS + TCP)**, **Port DNS Lookup Time**, and **Port TCP Connect Time**:
 
 - **Greater Than** — Response time exceeds a threshold
 - **Less Than** — Response time is below a threshold
 - **Greater Than or Equal To** — Response time is at or above a threshold
 - **Less Than or Equal To** — Response time is at or below a threshold
-- **Equal To** — Response time matches exactly
-- **Not Equal To** — Response time does not match
 - **Evaluate Over Time** — Evaluate using aggregation (Average, Sum, Maximum, Minimum, All Values, Any Value) over a time window
+
+DNS lookup criteria have no value to evaluate when the target is already an IP address. Use the total or TCP connection time for criteria that must work with both hostnames and IP addresses.
 
 ### Example Criteria
 
@@ -76,14 +89,26 @@ For **Response Time**:
 - **Check On**: Is Online
 - **Filter Type**: False
 
-#### Alert if connection time exceeds 500ms
+#### Alert if total connection time exceeds 500ms
 
-- **Check On**: Response Time (in ms)
+- **Check On**: Total Connection Time (DNS + TCP) (in ms)
 - **Filter Type**: Greater Than
 - **Value**: 500
 
-#### Mark as degraded if connection is slow
+#### Mark as degraded if the total connection is slow
 
-- **Check On**: Response Time (in ms)
+- **Check On**: Total Connection Time (DNS + TCP) (in ms)
 - **Filter Type**: Greater Than
 - **Value**: 200
+
+#### Alert if DNS lookup is slow
+
+- **Check On**: Port DNS Lookup Time (in ms)
+- **Filter Type**: Greater Than
+- **Value**: 100
+
+#### Alert if TCP connection setup is slow
+
+- **Check On**: Port TCP Connect Time (in ms)
+- **Filter Type**: Greater Than
+- **Value**: 250

--- a/Common/Server/Utils/Monitor/Criteria/APIRequestCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/APIRequestCriteria.ts
@@ -88,6 +88,35 @@ export default class APIRequestCriteria {
       });
     }
 
+    if (
+      input.criteriaFilter.checkOn === CheckOn.PortDnsLookupTime ||
+      input.criteriaFilter.checkOn === CheckOn.PortTcpConnectTime
+    ) {
+      const portTimings: ProbeMonitorResponse["portTimings"] = (
+        input.dataToProcess as ProbeMonitorResponse
+      ).portTimings;
+
+      const currentValue: number | undefined =
+        input.criteriaFilter.checkOn === CheckOn.PortDnsLookupTime
+          ? portTimings?.dnsLookupInMs
+          : portTimings?.tcpConnectInMs;
+
+      const value: Array<number> | number | undefined =
+        (overTimeValue as Array<number> | number | undefined) ?? currentValue;
+
+      if (value === undefined) {
+        return null;
+      }
+
+      threshold = CompareCriteria.convertToNumber(threshold);
+
+      return CompareCriteria.compareCriteriaNumbers({
+        value: value,
+        threshold: threshold as number,
+        criteriaFilter: input.criteriaFilter,
+      });
+    }
+
     // check packet loss (Ping/IP monitors with multi-packet checks)
     if (input.criteriaFilter.checkOn === CheckOn.PacketLossPercent) {
       const packetLossPercent: number | undefined = (

--- a/Common/Server/Utils/Monitor/MonitorMetricUtil.ts
+++ b/Common/Server/Utils/Monitor/MonitorMetricUtil.ts
@@ -17,6 +17,7 @@ import CapturedMetric from "../../../Types/Monitor/CustomCodeMonitor/CapturedMet
 import HttpPhaseTimings from "../../../Types/Monitor/HttpPhaseTimings";
 import MonitorMetricType from "../../../Types/Monitor/MonitorMetricType";
 import PingMonitorResponse from "../../../Types/Monitor/PingMonitor/PingMonitorResponse";
+import PortMonitorTimings from "../../../Types/Monitor/PortMonitor/PortMonitorTimings";
 import SnmpInterface from "../../../Types/Monitor/SnmpMonitor/SnmpInterface";
 import { SnmpOidResponse } from "../../../Types/Monitor/SnmpMonitor/SnmpMonitorResponse";
 import ProbeMonitorResponse from "../../../Types/Probe/ProbeMonitorResponse";
@@ -1073,6 +1074,51 @@ export default class MonitorMetricUtil {
           metricName: MonitorMetricType.DownloadTime,
           value: httpTimings.downloadInMs,
           description: "Response download time for this monitor",
+        },
+      ];
+
+      for (const phaseMetric of phaseMetrics) {
+        await this.pushMonitorMetric({
+          projectId: data.projectId,
+          monitorId: data.monitorId,
+          monitorName: data.monitorName,
+          probeName: data.probeName,
+          metricName: phaseMetric.metricName,
+          value: phaseMetric.value,
+          description: phaseMetric.description,
+          unit: "ms",
+          extraAttributes: extraAttributes,
+          metricRows: metricRows,
+          metricNameServiceNameMap: metricNameServiceNameMap,
+        });
+      }
+    }
+
+    const portTimings: PortMonitorTimings | undefined = (
+      data.dataToProcess as ProbeMonitorResponse
+    ).portTimings;
+
+    if (portTimings) {
+      const extraAttributes: JSONObject = {
+        probeId: (
+          data.dataToProcess as ProbeMonitorResponse
+        ).probeId.toString(),
+      };
+
+      const phaseMetrics: Array<{
+        metricName: MonitorMetricType;
+        value: number | undefined;
+        description: string;
+      }> = [
+        {
+          metricName: MonitorMetricType.PortDnsLookupTime,
+          value: portTimings.dnsLookupInMs,
+          description: "DNS lookup time for this Port monitor",
+        },
+        {
+          metricName: MonitorMetricType.PortTcpConnectTime,
+          value: portTimings.tcpConnectInMs,
+          description: "TCP connect time for this Port monitor",
         },
       ];
 

--- a/Common/Tests/App/Dashboard/PortMonitorCriteriaFilter.test.ts
+++ b/Common/Tests/App/Dashboard/PortMonitorCriteriaFilter.test.ts
@@ -1,0 +1,93 @@
+import CriteriaFilterUtil from "../../../../App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter";
+import {
+  CheckOn,
+  CriteriaFilter,
+  FilterType,
+} from "../../../Types/Monitor/CriteriaFilter";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import { DropdownOption } from "../../../UI/Components/Dropdown/Dropdown";
+import FilterCondition from "../../../Types/Filter/FilterCondition";
+import { describe, expect, test } from "@jest/globals";
+
+function values(options: Array<DropdownOption>): Array<string> {
+  return options.map((option: DropdownOption) => {
+    return option.value.toString();
+  });
+}
+
+describe("Dashboard Port timing criteria", () => {
+  test("offers DNS and TCP phase thresholds for Port monitors", () => {
+    expect(
+      values(
+        CriteriaFilterUtil.getCheckOnOptionsByMonitorType(MonitorType.Port),
+      ),
+    ).toEqual([
+      CheckOn.ResponseTime,
+      CheckOn.PortDnsLookupTime,
+      CheckOn.PortTcpConnectTime,
+      CheckOn.IsOnline,
+      CheckOn.IsRequestTimeout,
+    ]);
+  });
+
+  test("labels the persisted response-time criterion as total connection time", () => {
+    const responseTimeOption: DropdownOption | undefined =
+      CriteriaFilterUtil.getCheckOnOptionsByMonitorType(MonitorType.Port).find(
+        (option: DropdownOption) => {
+          return option.value === CheckOn.ResponseTime;
+        },
+      );
+
+    expect(responseTimeOption).toEqual({
+      label: "Total Connection Time (DNS + TCP) (in ms)",
+      value: CheckOn.ResponseTime,
+    });
+  });
+
+  test("does not expose Port phase thresholds on Website monitors", () => {
+    const websiteOptions: Array<string> = values(
+      CriteriaFilterUtil.getCheckOnOptionsByMonitorType(MonitorType.Website),
+    );
+
+    expect(websiteOptions).not.toContain(CheckOn.PortDnsLookupTime);
+    expect(websiteOptions).not.toContain(CheckOn.PortTcpConnectTime);
+  });
+
+  test.each([CheckOn.PortDnsLookupTime, CheckOn.PortTcpConnectTime])(
+    "%s supports numeric threshold comparisons",
+    (checkOn: CheckOn) => {
+      expect(
+        values(CriteriaFilterUtil.getFilterTypeOptionsByCheckOn(checkOn)),
+      ).toEqual([
+        FilterType.GreaterThan,
+        FilterType.LessThan,
+        FilterType.GreaterThanOrEqualTo,
+        FilterType.LessThanOrEqualTo,
+      ]);
+    },
+  );
+
+  test.each([CheckOn.PortDnsLookupTime, CheckOn.PortTcpConnectTime])(
+    "%s gets a millisecond threshold placeholder",
+    (checkOn: CheckOn) => {
+      expect(
+        CriteriaFilterUtil.getFilterTypePlaceholderValueByCheckOn({
+          monitorType: MonitorType.Port,
+          checkOn: checkOn,
+        }),
+      ).toBe("1000");
+    },
+  );
+
+  test("renders the threshold with a millisecond suffix", () => {
+    const filter: CriteriaFilter = {
+      checkOn: CheckOn.PortTcpConnectTime,
+      filterType: FilterType.GreaterThan,
+      value: 125,
+    };
+
+    expect(
+      CriteriaFilterUtil.translateFilterToText(filter, FilterCondition.All),
+    ).toContain("125ms");
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/Criteria/APIRequestCriteriaPortTimings.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/APIRequestCriteriaPortTimings.test.ts
@@ -1,0 +1,212 @@
+import APIRequestCriteria from "../../../../../Server/Utils/Monitor/Criteria/APIRequestCriteria";
+import EvaluateOverTime from "../../../../../Server/Utils/Monitor/Criteria/EvaluateOverTime";
+import {
+  CheckOn,
+  CriteriaFilter,
+  EvaluateOverTimeType,
+  FilterType,
+} from "../../../../../Types/Monitor/CriteriaFilter";
+import PortMonitorTimings from "../../../../../Types/Monitor/PortMonitor/PortMonitorTimings";
+import ProbeMonitorResponse from "../../../../../Types/Probe/ProbeMonitorResponse";
+import ObjectID from "../../../../../Types/ObjectID";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+function buildResponse(portTimings?: PortMonitorTimings): ProbeMonitorResponse {
+  return {
+    projectId: ObjectID.generate(),
+    monitorId: ObjectID.generate(),
+    monitorStepId: ObjectID.generate(),
+    probeId: ObjectID.generate(),
+    failureCause: "",
+    monitoredAt: new Date(),
+    portTimings: portTimings,
+  };
+}
+
+function criteria(input: {
+  checkOn: CheckOn.PortDnsLookupTime | CheckOn.PortTcpConnectTime;
+  filterType?: FilterType;
+  value: number | string;
+  evaluateOverTime?: boolean;
+}): CriteriaFilter {
+  return {
+    checkOn: input.checkOn,
+    filterType: input.filterType || FilterType.GreaterThan,
+    value: input.value,
+    evaluateOverTime: input.evaluateOverTime,
+    evaluateOverTimeOptions: input.evaluateOverTime
+      ? {
+          timeValueInMinutes: 5,
+          evaluateOverTimeType: EvaluateOverTimeType.Average,
+        }
+      : undefined,
+  };
+}
+
+async function evaluate(
+  response: ProbeMonitorResponse,
+  criteriaFilter: CriteriaFilter,
+): Promise<string | null> {
+  return APIRequestCriteria.isMonitorInstanceCriteriaFilterMet({
+    dataToProcess: response,
+    criteriaFilter: criteriaFilter,
+  });
+}
+
+describe("APIRequestCriteria Port connection phase timings", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("evaluates the current DNS lookup duration", async () => {
+    const result: string | null = await evaluate(
+      buildResponse({
+        dnsLookupInMs: 151,
+        tcpConnectInMs: 25,
+        totalConnectionInMs: 176,
+      }),
+      criteria({ checkOn: CheckOn.PortDnsLookupTime, value: "150" }),
+    );
+
+    expect(result).toContain(CheckOn.PortDnsLookupTime);
+  });
+
+  test("returns null when the current DNS lookup duration is below the threshold", async () => {
+    const result: string | null = await evaluate(
+      buildResponse({
+        dnsLookupInMs: 149,
+        tcpConnectInMs: 25,
+        totalConnectionInMs: 174,
+      }),
+      criteria({ checkOn: CheckOn.PortDnsLookupTime, value: 150 }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("evaluates the current TCP connect duration independently of DNS", async () => {
+    const result: string | null = await evaluate(
+      buildResponse({
+        dnsLookupInMs: 300,
+        tcpConnectInMs: 75,
+        totalConnectionInMs: 375,
+      }),
+      criteria({
+        checkOn: CheckOn.PortTcpConnectTime,
+        filterType: FilterType.GreaterThanOrEqualTo,
+        value: 75,
+      }),
+    );
+
+    expect(result).toContain(CheckOn.PortTcpConnectTime);
+  });
+
+  test("treats an absent DNS phase on an IP-literal destination as no data", async () => {
+    const result: string | null = await evaluate(
+      buildResponse({ tcpConnectInMs: 20, totalConnectionInMs: 20 }),
+      criteria({
+        checkOn: CheckOn.PortDnsLookupTime,
+        filterType: FilterType.LessThan,
+        value: 100,
+      }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("treats an absent TCP phase on a failed pre-connect check as no data", async () => {
+    const result: string | null = await evaluate(
+      buildResponse({ dnsLookupInMs: 100, totalConnectionInMs: 100 }),
+      criteria({ checkOn: CheckOn.PortTcpConnectTime, value: 10 }),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("preserves a legitimate zero-millisecond phase", async () => {
+    const result: string | null = await evaluate(
+      buildResponse({
+        dnsLookupInMs: 0,
+        tcpConnectInMs: 0,
+        totalConnectionInMs: 0,
+      }),
+      criteria({
+        checkOn: CheckOn.PortDnsLookupTime,
+        filterType: FilterType.LessThan,
+        value: 1,
+      }),
+    );
+
+    expect(result).not.toBeNull();
+  });
+
+  test("uses an evaluate-over-time aggregate instead of the current phase", async () => {
+    const overTimeSpy: jest.SpiedFunction<
+      typeof EvaluateOverTime.getValueOverTime
+    > = jest.spyOn(EvaluateOverTime, "getValueOverTime").mockResolvedValue(250);
+
+    const response: ProbeMonitorResponse = buildResponse({
+      dnsLookupInMs: 5,
+      tcpConnectInMs: 10,
+      totalConnectionInMs: 15,
+    });
+    const result: string | null = await evaluate(
+      response,
+      criteria({
+        checkOn: CheckOn.PortDnsLookupTime,
+        value: 200,
+        evaluateOverTime: true,
+      }),
+    );
+
+    expect(result).not.toBeNull();
+    expect(overTimeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: response.projectId,
+        monitorId: response.monitorId,
+        metricType: CheckOn.PortDnsLookupTime,
+      }),
+    );
+  });
+
+  test("does not replace a zero evaluate-over-time aggregate with the current value", async () => {
+    jest.spyOn(EvaluateOverTime, "getValueOverTime").mockResolvedValue(0);
+
+    const result: string | null = await evaluate(
+      buildResponse({
+        dnsLookupInMs: 500,
+        tcpConnectInMs: 10,
+        totalConnectionInMs: 510,
+      }),
+      criteria({
+        checkOn: CheckOn.PortDnsLookupTime,
+        filterType: FilterType.LessThan,
+        value: 1,
+        evaluateOverTime: true,
+      }),
+    );
+
+    expect(result).not.toBeNull();
+  });
+
+  test("falls back to the current phase if the history query fails", async () => {
+    jest
+      .spyOn(EvaluateOverTime, "getValueOverTime")
+      .mockRejectedValue(new Error("history unavailable"));
+
+    const result: string | null = await evaluate(
+      buildResponse({
+        dnsLookupInMs: 1,
+        tcpConnectInMs: 250,
+        totalConnectionInMs: 251,
+      }),
+      criteria({
+        checkOn: CheckOn.PortTcpConnectTime,
+        value: 200,
+        evaluateOverTime: true,
+      }),
+    );
+
+    expect(result).not.toBeNull();
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/Criteria/APIRequestCriteriaPortTimings.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/APIRequestCriteriaPortTimings.test.ts
@@ -141,9 +141,9 @@ describe("APIRequestCriteria Port connection phase timings", () => {
   });
 
   test("uses an evaluate-over-time aggregate instead of the current phase", async () => {
-    const overTimeSpy: jest.SpiedFunction<
-      typeof EvaluateOverTime.getValueOverTime
-    > = jest.spyOn(EvaluateOverTime, "getValueOverTime").mockResolvedValue(250);
+    const overTimeSpy: ReturnType<typeof jest.spyOn> = jest
+      .spyOn(EvaluateOverTime, "getValueOverTime")
+      .mockResolvedValue(250);
 
     const response: ProbeMonitorResponse = buildResponse({
       dnsLookupInMs: 5,

--- a/Common/Tests/Server/Utils/Monitor/MonitorMetricUtilPortTimings.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorMetricUtilPortTimings.test.ts
@@ -1,0 +1,243 @@
+import MetricType from "../../../../Models/DatabaseModels/MetricType";
+import GlobalConfigService from "../../../../Server/Services/GlobalConfigService";
+import MetricService from "../../../../Server/Services/MetricService";
+import MonitorMetricUtil from "../../../../Server/Utils/Monitor/MonitorMetricUtil";
+import TelemetryUtil from "../../../../Server/Utils/Telemetry/Telemetry";
+import Dictionary from "../../../../Types/Dictionary";
+import { JSONObject } from "../../../../Types/JSON";
+import MonitorMetricType from "../../../../Types/Monitor/MonitorMetricType";
+import PortMonitorTimings from "../../../../Types/Monitor/PortMonitor/PortMonitorTimings";
+import ObjectID from "../../../../Types/ObjectID";
+import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const MONITOR_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const PROBE_ID: ObjectID = new ObjectID("33333333-3333-4333-8333-333333333333");
+
+function buildResponse(input: {
+  portTimings?: PortMonitorTimings;
+  responseTimeInMs?: number;
+  includeHttpTimings?: boolean;
+}): ProbeMonitorResponse {
+  return {
+    projectId: PROJECT_ID,
+    monitorId: MONITOR_ID,
+    monitorStepId: ObjectID.generate(),
+    probeId: PROBE_ID,
+    failureCause: "",
+    monitoredAt: new Date("2026-08-07T12:00:00.000Z"),
+    portTimings: input.portTimings,
+    responseTimeInMs: input.responseTimeInMs,
+    httpTimings: input.includeHttpTimings
+      ? { dnsLookupInMs: 11, tcpConnectInMs: 22 }
+      : undefined,
+  };
+}
+
+describe("MonitorMetricUtil Port connection phase persistence", () => {
+  let insertedRows: Array<JSONObject>;
+  let indexedMaps: Array<Dictionary<MetricType>>;
+
+  beforeEach(() => {
+    insertedRows = [];
+    indexedMaps = [];
+
+    jest
+      .spyOn(GlobalConfigService, "findOneBy")
+      .mockResolvedValue(null as never);
+    jest
+      .spyOn(MetricService, "insertJsonRows")
+      .mockImplementation(async (rows: Array<JSONObject>): Promise<void> => {
+        insertedRows.push(...rows);
+      });
+    jest
+      .spyOn(TelemetryUtil, "indexMetricNameServiceNameMap")
+      .mockImplementation(
+        async (data: {
+          projectId: ObjectID;
+          metricNameServiceNameMap: Dictionary<MetricType>;
+        }): Promise<void> => {
+          indexedMaps.push(data.metricNameServiceNameMap);
+        },
+      );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  async function save(response: ProbeMonitorResponse): Promise<void> {
+    await MonitorMetricUtil.saveMonitorMetrics({
+      monitorId: MONITOR_ID,
+      projectId: PROJECT_ID,
+      dataToProcess: response,
+      monitorName: "Database Port",
+      probeName: "London Probe",
+    });
+  }
+
+  function rowByName(name: MonitorMetricType): JSONObject | undefined {
+    return insertedRows.find((row: JSONObject) => {
+      return row["name"] === name;
+    });
+  }
+
+  test("persists DNS and TCP phases under Port-specific metric names", async () => {
+    await save(
+      buildResponse({
+        portTimings: {
+          dnsLookupInMs: 120,
+          tcpConnectInMs: 35,
+          totalConnectionInMs: 155,
+        },
+      }),
+    );
+
+    expect(insertedRows).toHaveLength(2);
+    expect(rowByName(MonitorMetricType.PortDnsLookupTime)?.["value"]).toBe(120);
+    expect(rowByName(MonitorMetricType.PortTcpConnectTime)?.["value"]).toBe(35);
+    expect(rowByName(MonitorMetricType.DnsLookupTime)).toBeUndefined();
+    expect(rowByName(MonitorMetricType.TcpConnectTime)).toBeUndefined();
+  });
+
+  test("adds monitor and probe identity to every phase row", async () => {
+    await save(
+      buildResponse({
+        portTimings: {
+          dnsLookupInMs: 10,
+          tcpConnectInMs: 20,
+          totalConnectionInMs: 30,
+        },
+      }),
+    );
+
+    for (const row of insertedRows) {
+      expect(row["primaryEntityId"]).toBe(MONITOR_ID.toString());
+      expect(row["projectId"]).toBe(PROJECT_ID.toString());
+      expect(row["attributes"]).toEqual(
+        expect.objectContaining({
+          monitorId: MONITOR_ID.toString(),
+          projectId: PROJECT_ID.toString(),
+          probeId: PROBE_ID.toString(),
+          monitorName: "Database Port",
+          probeName: "London Probe",
+        }),
+      );
+    }
+  });
+
+  test("registers both Port phase metric types with millisecond units", async () => {
+    await save(
+      buildResponse({
+        portTimings: {
+          dnsLookupInMs: 10,
+          tcpConnectInMs: 20,
+          totalConnectionInMs: 30,
+        },
+      }),
+    );
+
+    expect(indexedMaps).toHaveLength(1);
+    const metricMap: Dictionary<MetricType> = indexedMaps[0]!;
+    expect(metricMap[MonitorMetricType.PortDnsLookupTime]?.unit).toBe("ms");
+    expect(metricMap[MonitorMetricType.PortTcpConnectTime]?.unit).toBe("ms");
+    expect(
+      metricMap[MonitorMetricType.PortDnsLookupTime]?.description,
+    ).toContain("DNS lookup");
+    expect(
+      metricMap[MonitorMetricType.PortTcpConnectTime]?.description,
+    ).toContain("TCP connect");
+  });
+
+  test("keeps total connection time in the existing ResponseTime metric", async () => {
+    await save(
+      buildResponse({
+        responseTimeInMs: 155,
+        portTimings: {
+          dnsLookupInMs: 120,
+          tcpConnectInMs: 35,
+          totalConnectionInMs: 155,
+        },
+      }),
+    );
+
+    expect(rowByName(MonitorMetricType.ResponseTime)?.["value"]).toBe(155);
+    expect(
+      insertedRows.some((row: JSONObject) => {
+        return String(row["name"]).includes("port.total");
+      }),
+    ).toBe(false);
+  });
+
+  test("omits DNS for an IP literal while still persisting TCP", async () => {
+    await save(
+      buildResponse({
+        portTimings: { tcpConnectInMs: 18, totalConnectionInMs: 18 },
+      }),
+    );
+
+    expect(rowByName(MonitorMetricType.PortDnsLookupTime)).toBeUndefined();
+    expect(rowByName(MonitorMetricType.PortTcpConnectTime)?.["value"]).toBe(18);
+  });
+
+  test("persists legitimate zero-millisecond phases", async () => {
+    await save(
+      buildResponse({
+        portTimings: {
+          dnsLookupInMs: 0,
+          tcpConnectInMs: 0,
+          totalConnectionInMs: 0,
+        },
+      }),
+    );
+
+    expect(rowByName(MonitorMetricType.PortDnsLookupTime)?.["value"]).toBe(0);
+    expect(rowByName(MonitorMetricType.PortTcpConnectTime)?.["value"]).toBe(0);
+  });
+
+  test("skips absent and non-finite phase data", async () => {
+    await save(
+      buildResponse({
+        portTimings: {
+          dnsLookupInMs: Number.NaN,
+          tcpConnectInMs: Number.POSITIVE_INFINITY,
+          totalConnectionInMs: 100,
+        },
+      }),
+    );
+
+    expect(insertedRows).toEqual([]);
+    expect(MetricService.insertJsonRows).not.toHaveBeenCalled();
+    expect(indexedMaps).toEqual([{}]);
+  });
+
+  test("keeps HTTP and Port phase series distinct when both payloads are present", async () => {
+    await save(
+      buildResponse({
+        includeHttpTimings: true,
+        portTimings: {
+          dnsLookupInMs: 33,
+          tcpConnectInMs: 44,
+          totalConnectionInMs: 77,
+        },
+      }),
+    );
+
+    expect(rowByName(MonitorMetricType.DnsLookupTime)?.["value"]).toBe(11);
+    expect(rowByName(MonitorMetricType.TcpConnectTime)?.["value"]).toBe(22);
+    expect(rowByName(MonitorMetricType.PortDnsLookupTime)?.["value"]).toBe(33);
+    expect(rowByName(MonitorMetricType.PortTcpConnectTime)?.["value"]).toBe(44);
+  });
+});

--- a/Common/Tests/Types/Monitor/CriteriaFilter.test.ts
+++ b/Common/Tests/Types/Monitor/CriteriaFilter.test.ts
@@ -270,6 +270,8 @@ describe("CriteriaFilterUtil", () => {
     test.each([
       CheckOn.ResponseStatusCode,
       CheckOn.ResponseTime,
+      CheckOn.PortDnsLookupTime,
+      CheckOn.PortTcpConnectTime,
       CheckOn.CPUUsagePercent,
       CheckOn.MemoryUsagePercent,
       CheckOn.IsOnline,
@@ -290,6 +292,8 @@ describe("CriteriaFilterUtil", () => {
     test.each([
       CheckOn.ResponseStatusCode,
       CheckOn.ResponseTime,
+      CheckOn.PortDnsLookupTime,
+      CheckOn.PortTcpConnectTime,
       CheckOn.DiskUsagePercent,
       CheckOn.CPUUsagePercent,
       CheckOn.MemoryUsagePercent,

--- a/Common/Tests/UI/Monitor/PortMonitorView.test.tsx
+++ b/Common/Tests/UI/Monitor/PortMonitorView.test.tsx
@@ -1,0 +1,237 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "@jest/globals";
+import * as React from "react";
+import Hostname from "../../../Types/API/Hostname";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+import Port from "../../../Types/Port";
+import ProbeMonitorResponse from "../../../Types/Probe/ProbeMonitorResponse";
+import { RequestFailedPhase } from "../../../Types/Probe/RequestFailedDetails";
+import SummaryInfo from "../../../../App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SummaryInfo";
+
+const MONITORED_AT: Date = new Date("2026-08-07T12:30:00.000Z");
+
+function buildResponse(
+  overrides: Partial<ProbeMonitorResponse> = {},
+): ProbeMonitorResponse {
+  return {
+    projectId: new ObjectID("11111111-1111-4111-8111-111111111111"),
+    monitorId: new ObjectID("22222222-2222-4222-8222-222222222222"),
+    monitorStepId: new ObjectID("33333333-3333-4333-8333-333333333333"),
+    probeId: new ObjectID("44444444-4444-4444-8444-444444444444"),
+    monitorDestination: new Hostname("db.example.com"),
+    monitorDestinationPort: new Port(5432),
+    isOnline: true,
+    responseTimeInMs: 31.27,
+    failureCause: "",
+    monitoredAt: MONITORED_AT,
+    ...overrides,
+  };
+}
+
+function renderSummary(
+  monitorType: MonitorType,
+  response: ProbeMonitorResponse,
+): void {
+  render(
+    <SummaryInfo
+      monitorType={monitorType}
+      probeMonitorResponses={[response]}
+      probeName="London Probe"
+    />,
+  );
+}
+
+describe("Port monitor summary", () => {
+  it("labels the existing response time as the DNS plus TCP total", () => {
+    renderSummary(
+      MonitorType.Port,
+      buildResponse({
+        portTimings: {
+          dnsLookupInMs: 8.12,
+          tcpConnectInMs: 23.15,
+          totalConnectionInMs: 31.27,
+        },
+      }),
+    );
+
+    expect(screen.getByText("db.example.com:5432")).toBeInTheDocument();
+    expect(
+      screen.getByText("Total Connection Time (DNS + TCP)"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("31.27 ms")).toBeInTheDocument();
+    expect(screen.queryByText("Response Time (in ms)")).not.toBeInTheDocument();
+  });
+
+  it("shows the measured DNS and TCP phases", () => {
+    renderSummary(
+      MonitorType.Port,
+      buildResponse({
+        portTimings: {
+          dnsLookupInMs: 8.123,
+          tcpConnectInMs: 23.147,
+          totalConnectionInMs: 31.27,
+        },
+      }),
+    );
+
+    expect(screen.getByText("Connection Phase Breakdown")).toBeInTheDocument();
+    expect(screen.getByText("DNS Lookup")).toBeInTheDocument();
+    expect(screen.getByText("8.12 ms")).toBeInTheDocument();
+    expect(screen.getByText("TCP Connect")).toBeInTheDocument();
+    expect(screen.getByText("23.15 ms")).toBeInTheDocument();
+  });
+
+  it("omits DNS for an IP target while retaining the TCP phase", () => {
+    renderSummary(
+      MonitorType.Port,
+      buildResponse({
+        monitorDestination: new Hostname("192.0.2.10"),
+        responseTimeInMs: 4.25,
+        portTimings: {
+          tcpConnectInMs: 4.25,
+          totalConnectionInMs: 4.25,
+        },
+      }),
+    );
+
+    expect(screen.getByText("192.0.2.10:5432")).toBeInTheDocument();
+    expect(screen.queryByText("DNS Lookup")).not.toBeInTheDocument();
+    expect(screen.getByText("TCP Connect")).toBeInTheDocument();
+  });
+
+  it("renders valid zero-duration measurements instead of missing data", () => {
+    renderSummary(
+      MonitorType.Port,
+      buildResponse({
+        responseTimeInMs: 0,
+        portTimings: {
+          dnsLookupInMs: 0,
+          tcpConnectInMs: 0,
+          totalConnectionInMs: 0,
+        },
+      }),
+    );
+
+    expect(screen.getAllByText("0 ms")).toHaveLength(3);
+  });
+
+  it("does not invent a missing TCP duration after a DNS-only failure", () => {
+    renderSummary(
+      MonitorType.Port,
+      buildResponse({
+        isOnline: false,
+        responseTimeInMs: 19,
+        failureCause: "DNS lookup failed",
+        portTimings: {
+          dnsLookupInMs: 19,
+          totalConnectionInMs: 19,
+        },
+      }),
+    );
+
+    expect(screen.getByText("DNS Lookup")).toBeInTheDocument();
+    expect(screen.queryByText("TCP Connect")).not.toBeInTheDocument();
+  });
+
+  it("keeps older results useful when no phase timings were recorded", () => {
+    renderSummary(MonitorType.Port, buildResponse());
+
+    expect(
+      screen.getByText("Total Connection Time (DNS + TCP)"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("31.27 ms")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Connection Phase Breakdown"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses the compatibility response time for the displayed total", () => {
+    renderSummary(
+      MonitorType.Port,
+      buildResponse({
+        responseTimeInMs: 25,
+        portTimings: {
+          dnsLookupInMs: 5,
+          tcpConnectInMs: 20,
+          totalConnectionInMs: 999,
+        },
+      }),
+    );
+
+    expect(screen.getByText("25 ms")).toBeInTheDocument();
+    expect(screen.queryByText("999 ms")).not.toBeInTheDocument();
+  });
+
+  it("retains failure details and retry evidence in the dedicated view", () => {
+    renderSummary(
+      MonitorType.Port,
+      buildResponse({
+        isOnline: false,
+        failureCause: "Connection refused",
+        requestFailedDetails: {
+          failedPhase: RequestFailedPhase.TCPConnection,
+          errorCode: "ECONNREFUSED",
+          errorDescription: "The target rejected the TCP connection.",
+        },
+        probeAttempts: [
+          {
+            attemptNumber: 1,
+            attemptedAt: MONITORED_AT,
+            responseReceivedAt: MONITORED_AT,
+            responseTimeInMs: 11,
+            isOnline: false,
+            failureCause: "Connection refused",
+          },
+          {
+            attemptNumber: 2,
+            attemptedAt: MONITORED_AT,
+            responseReceivedAt: MONITORED_AT,
+            responseTimeInMs: 12,
+            isOnline: false,
+            failureCause: "Connection refused",
+          },
+        ],
+        totalAttempts: 2,
+      }),
+    );
+
+    expect(screen.getByText("Offline")).toBeInTheDocument();
+    expect(screen.getAllByText("Connection refused").length).toBeGreaterThan(0);
+    expect(screen.getByText("TCP Connection")).toBeInTheDocument();
+    expect(screen.getByText("ECONNREFUSED")).toBeInTheDocument();
+    expect(
+      screen.getByText("The target rejected the TCP connection."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Retry Attempts")).toBeInTheDocument();
+    expect(screen.getByText("Attempt 1/2")).toBeInTheDocument();
+    expect(screen.getByText("Attempt 2/2")).toBeInTheDocument();
+  });
+});
+
+describe("Ping and IP summaries", () => {
+  it.each([MonitorType.Ping, MonitorType.IP])(
+    "keeps %s on the existing Ping view",
+    (monitorType: MonitorType) => {
+      renderSummary(
+        monitorType,
+        buildResponse({
+          portTimings: {
+            dnsLookupInMs: 8,
+            tcpConnectInMs: 23,
+            totalConnectionInMs: 31,
+          },
+        }),
+      );
+
+      expect(screen.getByText("Response Time (in ms)")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Total Connection Time (DNS + TCP)"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Connection Phase Breakdown"),
+      ).not.toBeInTheDocument();
+    },
+  );
+});

--- a/Common/Tests/Utils/Monitor/MonitorMetricType.test.ts
+++ b/Common/Tests/Utils/Monitor/MonitorMetricType.test.ts
@@ -37,6 +37,16 @@ describe("getAggregationTypeByMonitorMetricType", () => {
         MonitorMetricType.IsOnline,
       ),
     ).toBe(AggregationType.Min);
+    expect(
+      MonitorMetricTypeUtil.getAggregationTypeByMonitorMetricType(
+        MonitorMetricType.PortDnsLookupTime,
+      ),
+    ).toBe(AggregationType.Avg);
+    expect(
+      MonitorMetricTypeUtil.getAggregationTypeByMonitorMetricType(
+        MonitorMetricType.PortTcpConnectTime,
+      ),
+    ).toBe(AggregationType.Avg);
   });
 
   test("cumulative byte/op counters aggregate with Max (latest-in-bucket)", () => {
@@ -70,6 +80,16 @@ describe("getMonitorMeticTypeByCheckOn", () => {
         CheckOn.CPUIoWaitPercent,
       ),
     ).toBe(MonitorMetricType.CPUTimeIoWaitPercent);
+    expect(
+      MonitorMetricTypeUtil.getMonitorMeticTypeByCheckOn(
+        CheckOn.PortDnsLookupTime,
+      ),
+    ).toBe(MonitorMetricType.PortDnsLookupTime);
+    expect(
+      MonitorMetricTypeUtil.getMonitorMeticTypeByCheckOn(
+        CheckOn.PortTcpConnectTime,
+      ),
+    ).toBe(MonitorMetricType.PortTcpConnectTime);
   });
 
   test("throws for a CheckOn without a metric mapping", () => {
@@ -113,6 +133,34 @@ describe("getMonitorMetricTypesByMonitorType", () => {
       );
     expect(ping).toContain(MonitorMetricType.PacketLossPercent);
     expect(ping).toContain(MonitorMetricType.Jitter);
+  });
+
+  test("Port exposes total connection time and its Port-specific phases", () => {
+    expect(
+      MonitorMetricTypeUtil.getMonitorMetricTypesByMonitorType(
+        MonitorType.Port,
+      ),
+    ).toEqual([
+      MonitorMetricType.IsOnline,
+      MonitorMetricType.ResponseTime,
+      MonitorMetricType.PortDnsLookupTime,
+      MonitorMetricType.PortTcpConnectTime,
+    ]);
+  });
+
+  test("Port phase metrics do not alias the HTTP phase metric names", () => {
+    expect(MonitorMetricType.PortDnsLookupTime).toBe(
+      "oneuptime.monitor.port.dns.lookup.time",
+    );
+    expect(MonitorMetricType.PortTcpConnectTime).toBe(
+      "oneuptime.monitor.port.tcp.connect.time",
+    );
+    expect(MonitorMetricType.PortDnsLookupTime).not.toBe(
+      MonitorMetricType.DnsLookupTime,
+    );
+    expect(MonitorMetricType.PortTcpConnectTime).not.toBe(
+      MonitorMetricType.TcpConnectTime,
+    );
   });
 
   test("a monitor type with no metrics returns an empty list", () => {
@@ -187,6 +235,75 @@ describe("display metadata", () => {
         MonitorMetricType.ResponseStatusCode,
       ),
     ).toBe("");
+    expect(
+      MonitorMetricTypeUtil.getLegendUnitByMonitorMetricType(
+        MonitorMetricType.PortDnsLookupTime,
+      ),
+    ).toBe("ms");
+    expect(
+      MonitorMetricTypeUtil.getLegendUnitByMonitorMetricType(
+        MonitorMetricType.PortTcpConnectTime,
+      ),
+    ).toBe("ms");
+  });
+
+  test("Port phase metrics have distinct user-facing metadata", () => {
+    expect(
+      MonitorMetricTypeUtil.getTitleByMonitorMetricType(
+        MonitorMetricType.PortDnsLookupTime,
+      ),
+    ).toBe("Port DNS Lookup Time");
+    expect(
+      MonitorMetricTypeUtil.getTitleByMonitorMetricType(
+        MonitorMetricType.PortTcpConnectTime,
+      ),
+    ).toBe("Port TCP Connect Time");
+    expect(
+      MonitorMetricTypeUtil.getDescriptionByMonitorMetricType(
+        MonitorMetricType.PortDnsLookupTime,
+      ),
+    ).toContain("IP address");
+    expect(
+      MonitorMetricTypeUtil.getDescriptionByMonitorMetricType(
+        MonitorMetricType.PortTcpConnectTime,
+      ),
+    ).toContain("IPv6/IPv4 fallback");
+  });
+
+  test("contextualizes the existing response-time metric for Port charts", () => {
+    expect(
+      MonitorMetricTypeUtil.getTitleByMonitorMetricType(
+        MonitorMetricType.ResponseTime,
+        MonitorType.Port,
+      ),
+    ).toBe("Total Connection Time (DNS + TCP)");
+    expect(
+      MonitorMetricTypeUtil.getLegendByMonitorMetricType(
+        MonitorMetricType.ResponseTime,
+        MonitorType.Port,
+      ),
+    ).toBe("Total Connection Time (DNS + TCP)");
+    expect(
+      MonitorMetricTypeUtil.getDescriptionByMonitorMetricType(
+        MonitorMetricType.ResponseTime,
+        MonitorType.Port,
+      ),
+    ).toContain("resolving the hostname");
+  });
+
+  test("keeps response-time metadata unchanged outside Port charts", () => {
+    expect(
+      MonitorMetricTypeUtil.getTitleByMonitorMetricType(
+        MonitorMetricType.ResponseTime,
+        MonitorType.Website,
+      ),
+    ).toBe("Response Time");
+    expect(
+      MonitorMetricTypeUtil.getDescriptionByMonitorMetricType(
+        MonitorMetricType.ResponseTime,
+        MonitorType.Website,
+      ),
+    ).toContain("server to respond to a request");
   });
 });
 

--- a/Common/Types/Monitor/CriteriaFilter.ts
+++ b/Common/Types/Monitor/CriteriaFilter.ts
@@ -5,6 +5,8 @@ export enum CheckOn {
   ResponseTime = "Response Time (in ms)",
   PacketLossPercent = "Packet Loss (in %)",
   Jitter = "Jitter (in ms)",
+  PortDnsLookupTime = "Port DNS Lookup Time (in ms)",
+  PortTcpConnectTime = "Port TCP Connect Time (in ms)",
   ResponseStatusCode = "Response Status Code",
   ResponseHeader = "Response Header",
   ResponseHeaderValue = "Response Header Value",
@@ -399,6 +401,8 @@ export class CriteriaFilterUtil {
       checkOn === CheckOn.ResponseTime ||
       checkOn === CheckOn.PacketLossPercent ||
       checkOn === CheckOn.Jitter ||
+      checkOn === CheckOn.PortDnsLookupTime ||
+      checkOn === CheckOn.PortTcpConnectTime ||
       checkOn === CheckOn.DiskUsagePercent ||
       checkOn === CheckOn.CPUUsagePercent ||
       checkOn === CheckOn.MemoryUsagePercent ||

--- a/Common/Types/Monitor/MonitorMetricType.ts
+++ b/Common/Types/Monitor/MonitorMetricType.ts
@@ -25,6 +25,14 @@ enum MonitorMetricType {
   DownloadTime = "oneuptime.monitor.http.download.time",
 
   /*
+   * Port-monitor connection phases. These intentionally use a Port-specific
+   * namespace instead of the HTTP phase metrics above: Port TCP timing can
+   * include automatic address-family fallback and has no HTTP request phase.
+   */
+  PortDnsLookupTime = "oneuptime.monitor.port.dns.lookup.time",
+  PortTcpConnectTime = "oneuptime.monitor.port.tcp.connect.time",
+
+  /*
    * Per-interface SNMP metrics. Emitted when interface monitoring is enabled
    * on an SNMP monitor; one series per interface (interfaceName attribute).
    */

--- a/Common/Types/Monitor/PortMonitor/PortMonitorTimings.ts
+++ b/Common/Types/Monitor/PortMonitor/PortMonitorTimings.ts
@@ -1,0 +1,10 @@
+/*
+ * Per-phase breakdown of a Port monitor connection, in milliseconds. DNS is
+ * absent when the destination is already an IP address. Fields are optional
+ * so partial timing evidence can be represented when a connection fails.
+ */
+export default interface PortMonitorTimings {
+  dnsLookupInMs?: number | undefined;
+  tcpConnectInMs?: number | undefined;
+  totalConnectionInMs?: number | undefined;
+}

--- a/Common/Types/Probe/ProbeMonitorResponse.ts
+++ b/Common/Types/Probe/ProbeMonitorResponse.ts
@@ -17,6 +17,7 @@ import ExternalStatusPageMonitorResponse from "../Monitor/ExternalStatusPageMoni
 import HttpPhaseTimings from "../Monitor/HttpPhaseTimings";
 import MonitorEvaluationSummary from "../Monitor/MonitorEvaluationSummary";
 import NetworkPathTrace from "../Monitor/NetworkMonitor/NetworkPathTrace";
+import PortMonitorTimings from "../Monitor/PortMonitor/PortMonitorTimings";
 import ObjectID from "../ObjectID";
 import Port from "../Port";
 import ProbeAttempt from "./ProbeAttempt";
@@ -58,6 +59,11 @@ export default interface ProbeMonitorResponse {
    * checks. Absent when the request went through a proxy.
    */
   httpTimings?: HttpPhaseTimings | undefined;
+  /*
+   * DNS / TCP / total connection timing for Port checks. DNS is absent for
+   * IP literals. Also present when Ping/IP checks use the Port fallback.
+   */
+  portTimings?: PortMonitorTimings | undefined;
   dnsResponse?: DnsMonitorResponse | undefined;
   domainResponse?: DomainMonitorResponse | undefined;
   dnssecResponse?: DnssecMonitorResponse | undefined;

--- a/Common/Utils/Monitor/MonitorMetricType.ts
+++ b/Common/Utils/Monitor/MonitorMetricType.ts
@@ -42,6 +42,8 @@ class MonitorMetricTypeUtil {
       case MonitorMetricType.TlsHandshakeTime:
       case MonitorMetricType.TimeToFirstByte:
       case MonitorMetricType.DownloadTime:
+      case MonitorMetricType.PortDnsLookupTime:
+      case MonitorMetricType.PortTcpConnectTime:
         return AggregationType.Avg;
       case MonitorMetricType.SnmpInterfaceOperStatus:
         return AggregationType.Min;
@@ -101,6 +103,10 @@ class MonitorMetricTypeUtil {
         return MonitorMetricType.PacketLossPercent;
       case CheckOn.Jitter:
         return MonitorMetricType.Jitter;
+      case CheckOn.PortDnsLookupTime:
+        return MonitorMetricType.PortDnsLookupTime;
+      case CheckOn.PortTcpConnectTime:
+        return MonitorMetricType.PortTcpConnectTime;
       case CheckOn.ResponseStatusCode:
         return MonitorMetricType.ResponseStatusCode;
       case CheckOn.IsOnline:
@@ -205,6 +211,16 @@ class MonitorMetricTypeUtil {
       ];
     }
 
+    if (monitorType === MonitorType.Port) {
+      return [
+        MonitorMetricType.IsOnline,
+        // Kept as the backwards-compatible total connection duration.
+        MonitorMetricType.ResponseTime,
+        MonitorMetricType.PortDnsLookupTime,
+        MonitorMetricType.PortTcpConnectTime,
+      ];
+    }
+
     if (monitorType === MonitorType.NetworkDevice) {
       return [
         MonitorMetricType.IsOnline,
@@ -218,7 +234,6 @@ class MonitorMetricTypeUtil {
     }
 
     if (
-      monitorType === MonitorType.Port ||
       monitorType === MonitorType.DNS ||
       monitorType === MonitorType.DNSSEC ||
       monitorType === MonitorType.Domain ||
@@ -344,7 +359,15 @@ class MonitorMetricTypeUtil {
 
   public static getTitleByMonitorMetricType(
     monitorMetricType: MonitorMetricType,
+    monitorType?: MonitorType | undefined,
   ): string {
+    if (
+      monitorType === MonitorType.Port &&
+      monitorMetricType === MonitorMetricType.ResponseTime
+    ) {
+      return "Total Connection Time (DNS + TCP)";
+    }
+
     switch (monitorMetricType) {
       case MonitorMetricType.ResponseTime:
         return "Response Time";
@@ -374,6 +397,10 @@ class MonitorMetricTypeUtil {
         return "Time to First Byte";
       case MonitorMetricType.DownloadTime:
         return "Download Time";
+      case MonitorMetricType.PortDnsLookupTime:
+        return "Port DNS Lookup Time";
+      case MonitorMetricType.PortTcpConnectTime:
+        return "Port TCP Connect Time";
       case MonitorMetricType.SnmpInterfaceOperStatus:
         return "Interface Status";
       case MonitorMetricType.SnmpInterfaceInBitsPerSecond:
@@ -439,13 +466,14 @@ class MonitorMetricTypeUtil {
 
   public static getLegendByMonitorMetricType(
     monitorMetricType: MonitorMetricType,
+    monitorType?: MonitorType | undefined,
   ): string {
     /*
      * Legend labels default to the title, which also matches the existing behavior
      * for every metric type. Keeping this as a separate function preserves the
      * option to diverge later (e.g. shorter legend labels for dense charts).
      */
-    return this.getTitleByMonitorMetricType(monitorMetricType);
+    return this.getTitleByMonitorMetricType(monitorMetricType, monitorType);
   }
 
   public static getLegendUnitByMonitorMetricType(
@@ -475,6 +503,8 @@ class MonitorMetricTypeUtil {
       case MonitorMetricType.TlsHandshakeTime:
       case MonitorMetricType.TimeToFirstByte:
       case MonitorMetricType.DownloadTime:
+      case MonitorMetricType.PortDnsLookupTime:
+      case MonitorMetricType.PortTcpConnectTime:
         return "ms";
       case MonitorMetricType.SnmpInterfaceOperStatus:
         return "";
@@ -525,7 +555,15 @@ class MonitorMetricTypeUtil {
 
   public static getDescriptionByMonitorMetricType(
     monitorMetricType: MonitorMetricType,
+    monitorType?: MonitorType | undefined,
   ): string {
+    if (
+      monitorType === MonitorType.Port &&
+      monitorMetricType === MonitorMetricType.ResponseTime
+    ) {
+      return "Total time spent resolving the hostname (when needed) and establishing the TCP connection.";
+    }
+
     switch (monitorMetricType) {
       case MonitorMetricType.ResponseTime:
         return "Response time is the time taken for a server to respond to a request. It is the sum of the time spent waiting to establish the connection, the time spent waiting for the request to be processed, and the time spent waiting for the response to be sent.";
@@ -555,6 +593,10 @@ class MonitorMetricTypeUtil {
         return "Time from the end of connection setup until the first byte of the response arrived — the server-side processing time.";
       case MonitorMetricType.DownloadTime:
         return "Time spent receiving the response body after the first byte arrived.";
+      case MonitorMetricType.PortDnsLookupTime:
+        return "Time from starting a Port check until its first TCP connection attempt. It is absent when the destination is already an IP address.";
+      case MonitorMetricType.PortTcpConnectTime:
+        return "Time from the first TCP connection attempt until a connection succeeds, including any automatic IPv6/IPv4 fallback attempts.";
       case MonitorMetricType.SnmpInterfaceOperStatus:
         return "Operational status of each interface: 1 when up, 0 when down. Interfaces that are administratively disabled also report 0.";
       case MonitorMetricType.SnmpInterfaceInBitsPerSecond:

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/PortMonitor.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/PortMonitor.test.ts
@@ -1,0 +1,749 @@
+// Set required env vars before importing PortMonitor (through Register/Config).
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+jest.mock("../../../../Utils/OnlineCheck", () => {
+  return {
+    __esModule: true,
+    default: {
+      canProbeMonitorPortMonitors: jest.fn(async (): Promise<boolean> => {
+        return true;
+      }),
+    },
+  };
+});
+
+jest.mock("../../../../Services/Register", () => {
+  return {
+    __esModule: true,
+    default: {
+      isPingMonitoringEnabled: jest.fn(async (): Promise<boolean> => {
+        return true;
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+jest.mock("net", () => {
+  const actualNet: typeof import("net") = jest.requireActual(
+    "net",
+  ) as typeof import("net");
+  const actualEvents: typeof import("events") = jest.requireActual(
+    "events",
+  ) as typeof import("events");
+  const EventEmitterConstructor: typeof import("events").EventEmitter =
+    actualEvents.EventEmitter;
+
+  type SocketScenario = (socket: InstanceType<typeof MockSocket>) => void;
+
+  const scenarios: Array<SocketScenario> = [];
+  const sockets: Array<InstanceType<typeof MockSocket>> = [];
+
+  class MockSocket extends EventEmitterConstructor {
+    public readonly connectCalls: Array<{ port: number; host: string }> = [];
+    public destroyCallCount: number = 0;
+
+    public constructor() {
+      super();
+      sockets.push(this);
+    }
+
+    public connect(port: number, host: string): this {
+      this.connectCalls.push({ port, host });
+
+      const scenario: SocketScenario | undefined = scenarios.shift();
+      if (!scenario) {
+        throw new Error("No mock socket scenario was queued");
+      }
+
+      scenario(this);
+      return this;
+    }
+
+    public destroy(): this {
+      this.destroyCallCount++;
+      return this;
+    }
+  }
+
+  return {
+    __esModule: true,
+    default: {
+      ...actualNet,
+      Socket: MockSocket,
+      queueSocketScenario: (scenario: SocketScenario): void => {
+        scenarios.push(scenario);
+      },
+      getMockSockets: (): Array<InstanceType<typeof MockSocket>> => {
+        return sockets;
+      },
+      resetMockSockets: (): void => {
+        scenarios.length = 0;
+        sockets.length = 0;
+      },
+    },
+  };
+});
+
+import Hostname from "Common/Types/API/Hostname";
+import IPv4 from "Common/Types/IP/IPv4";
+import IPv6 from "Common/Types/IP/IPv6";
+import Port from "Common/Types/Port";
+import PositiveNumber from "Common/Types/PositiveNumber";
+import { RequestFailedPhase } from "Common/Types/Probe/RequestFailedDetails";
+import Sleep from "Common/Types/Sleep";
+import net from "net";
+import Register from "../../../../Services/Register";
+import PortMonitor, {
+  PortMonitorResponse,
+} from "../../../../Utils/Monitors/MonitorTypes/PortMonitor";
+import { EventEmitter } from "events";
+
+interface MockSocket extends EventEmitter {
+  connectCalls: Array<{ port: number; host: string }>;
+  destroyCallCount: number;
+}
+
+interface ControllableNet {
+  queueSocketScenario: (scenario: (socket: MockSocket) => void) => void;
+  getMockSockets: () => Array<MockSocket>;
+  resetMockSockets: () => void;
+}
+
+interface ErrorWithCode extends Error {
+  code: string;
+}
+
+const controllableNet: ControllableNet = net as unknown as ControllableNet;
+const ipLiterals: Array<[IPv4 | IPv6, string]> = [
+  [new IPv4("192.0.2.25"), "192.0.2.25"],
+  [new IPv6("2001:db8::25"), "2001:db8::25"],
+];
+
+const flushPromises: () => Promise<void> = async (): Promise<void> => {
+  for (let index: number = 0; index < 8; index++) {
+    await Promise.resolve();
+  }
+};
+
+const advanceTime: (milliseconds: number) => Promise<void> = async (
+  milliseconds: number,
+): Promise<void> => {
+  jest.advanceTimersByTime(milliseconds);
+  await flushPromises();
+};
+
+const nodeError: (code: string, message: string) => ErrorWithCode = (
+  code: string,
+  message: string,
+): ErrorWithCode => {
+  return Object.assign(new Error(message), { code });
+};
+
+describe("PortMonitor phase timings", () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ doNotFake: ["performance"] });
+    controllableNet.resetMockSockets();
+    jest.spyOn(Register, "isPingMonitoringEnabled").mockResolvedValue(true);
+    jest.spyOn(Sleep, "sleep").mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  test("measures hostname DNS through the first connection attempt and TCP through connect", async () => {
+    controllableNet.queueSocketScenario((socket: MockSocket): void => {
+      setTimeout(() => {
+        socket.emit("lookup", null, "2001:db8::1", 6, "example.com");
+      }, 30);
+      setTimeout(() => {
+        socket.emit("lookup", null, "192.0.2.10", 4, "example.com");
+      }, 40);
+      setTimeout(() => {
+        socket.emit("connectionAttempt", "2001:db8::1", 443, 6);
+      }, 50);
+      setTimeout(() => {
+        socket.emit("connect");
+      }, 90);
+    });
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("example.com"),
+      new Port(443),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(500),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await advanceTime(90);
+    const result: PortMonitorResponse | null = await resultPromise;
+
+    expect(result).toMatchObject({
+      isOnline: true,
+      failureCause: "",
+      totalAttempts: 1,
+      portTimings: {
+        dnsLookupInMs: 50,
+        tcpConnectInMs: 40,
+        totalConnectionInMs: 90,
+      },
+    });
+    expect(result?.responseTimeInMS?.toNumber()).toBe(90);
+    expect(result?.probeAttempts?.[0]?.responseTimeInMs).toBe(90);
+    expect(controllableNet.getMockSockets()[0]?.connectCalls).toEqual([
+      { port: 443, host: "example.com" },
+    ]);
+  });
+
+  test.each(ipLiterals)(
+    "omits DNS for the IP literal %s",
+    async (destination: IPv4 | IPv6, hostAddress: string) => {
+      controllableNet.queueSocketScenario((socket: MockSocket): void => {
+        setTimeout(() => {
+          socket.emit("connectionAttempt", hostAddress, 8080, 4);
+        }, 5);
+        setTimeout(() => {
+          socket.emit("connect");
+        }, 25);
+      });
+
+      const resultPromise: Promise<PortMonitorResponse | null> =
+        PortMonitor.ping(destination, new Port(8080), {
+          retry: 1,
+          timeout: new PositiveNumber(100),
+          isOnlineCheckRequest: true,
+        });
+
+      await advanceTime(25);
+      const result: PortMonitorResponse | null = await resultPromise;
+
+      expect(result?.responseTimeInMS?.toNumber()).toBe(25);
+      expect(result?.portTimings).toEqual({
+        tcpConnectInMs: 20,
+        totalConnectionInMs: 25,
+      });
+      expect(result?.portTimings).not.toHaveProperty("dnsLookupInMs");
+    },
+  );
+
+  test("includes IPv6-to-IPv4 fallback in TCP connection time", async () => {
+    controllableNet.queueSocketScenario((socket: MockSocket): void => {
+      setTimeout(() => {
+        socket.emit("connectionAttempt", "2001:db8::10", 443, 6);
+      }, 20);
+      setTimeout(() => {
+        socket.emit(
+          "connectionAttemptFailed",
+          "2001:db8::10",
+          443,
+          6,
+          nodeError("ENETUNREACH", "connect ENETUNREACH 2001:db8::10"),
+        );
+      }, 45);
+      setTimeout(() => {
+        socket.emit("connectionAttempt", "192.0.2.10", 443, 4);
+      }, 55);
+      setTimeout(() => {
+        socket.emit("connect");
+      }, 85);
+    });
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("dual-stack.example"),
+      new Port(443),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(200),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await advanceTime(85);
+    const result: PortMonitorResponse | null = await resultPromise;
+
+    expect(result?.portTimings).toEqual({
+      dnsLookupInMs: 20,
+      tcpConnectInMs: 65,
+      totalConnectionInMs: 85,
+    });
+  });
+
+  test("uses hostname lookup as the TCP start when a single address skips connectionAttempt", async () => {
+    controllableNet.queueSocketScenario((socket: MockSocket): void => {
+      setTimeout(() => {
+        socket.emit("lookup", null, "192.0.2.20", 4, "single-address.example");
+      }, 15);
+      setTimeout(() => {
+        socket.emit("connect");
+      }, 35);
+    });
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("single-address.example"),
+      new Port(80),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(100),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await advanceTime(35);
+    const result: PortMonitorResponse | null = await resultPromise;
+
+    expect(result?.portTimings).toEqual({
+      dnsLookupInMs: 15,
+      tcpConnectInMs: 20,
+      totalConnectionInMs: 35,
+    });
+  });
+
+  test("falls back defensively when connect has neither lookup nor connectionAttempt", async () => {
+    controllableNet.queueSocketScenario((socket: MockSocket): void => {
+      setTimeout(() => {
+        socket.emit("connect");
+      }, 35);
+    });
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("eventless-runtime.example"),
+      new Port(80),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(100),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await advanceTime(35);
+    const result: PortMonitorResponse | null = await resultPromise;
+
+    expect(result?.portTimings).toEqual({
+      tcpConnectInMs: 35,
+      totalConnectionInMs: 35,
+    });
+  });
+
+  test("uses one absolute deadline that includes hostname resolution", async () => {
+    controllableNet.queueSocketScenario((socket: MockSocket): void => {
+      setTimeout(() => {
+        socket.emit("lookup", null, "192.0.2.30", 4, "slow-dns.example");
+      }, 80);
+      setTimeout(() => {
+        socket.emit("connectionAttempt", "192.0.2.30", 443, 4);
+      }, 120);
+      setTimeout(() => {
+        socket.emit("connect");
+      }, 140);
+    });
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("slow-dns.example"),
+      new Port(443),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(100),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await advanceTime(100);
+    const result: PortMonitorResponse | null = await resultPromise;
+
+    expect(result).toMatchObject({
+      isOnline: false,
+      isTimeout: true,
+      totalAttempts: 1,
+      requestFailedDetails: {
+        failedPhase: RequestFailedPhase.RequestTimeout,
+      },
+    });
+    expect(result?.responseTimeInMS).toBeUndefined();
+    expect(result?.portTimings).toBeUndefined();
+    expect(result?.probeAttempts?.[0]?.responseTimeInMs).toBe(100);
+  });
+
+  test("marks a native socket ETIMEDOUT error as a timeout", async () => {
+    controllableNet.queueSocketScenario((socket: MockSocket): void => {
+      setTimeout(() => {
+        socket.emit(
+          "error",
+          nodeError("ETIMEDOUT", "connect ETIMEDOUT 192.0.2.35:443"),
+        );
+      }, 30);
+    });
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("socket-timeout.example"),
+      new Port(443),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(100),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await advanceTime(30);
+    const result: PortMonitorResponse | null = await resultPromise;
+
+    expect(result).toMatchObject({
+      isOnline: false,
+      isTimeout: true,
+      requestFailedDetails: {
+        failedPhase: RequestFailedPhase.RequestTimeout,
+        errorCode: "ETIMEDOUT",
+      },
+    });
+  });
+
+  test("marks a representative AggregateError ETIMEDOUT child as a timeout", async () => {
+    const aggregateError: Error & { errors: Array<ErrorWithCode> } =
+      Object.assign(new Error("All connection attempts failed"), {
+        name: "AggregateError",
+        errors: [
+          nodeError("ETIMEDOUT", "connect ETIMEDOUT 192.0.2.36:443"),
+          nodeError("ENETUNREACH", "connect ENETUNREACH 2001:db8::36:443"),
+        ],
+      });
+
+    controllableNet.queueSocketScenario((socket: MockSocket): void => {
+      setTimeout(() => {
+        socket.emit("error", aggregateError);
+      }, 30);
+    });
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("aggregate-timeout.example"),
+      new Port(443),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(100),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await advanceTime(30);
+    const result: PortMonitorResponse | null = await resultPromise;
+
+    expect(result).toMatchObject({
+      isOnline: false,
+      isTimeout: true,
+      requestFailedDetails: {
+        failedPhase: RequestFailedPhase.RequestTimeout,
+        errorCode: "ETIMEDOUT",
+      },
+    });
+  });
+
+  test("settles once and ignores a late connect after the deadline", async () => {
+    controllableNet.queueSocketScenario((socket: MockSocket): void => {
+      setTimeout(() => {
+        socket.emit("connectionAttempt", "192.0.2.40", 80, 4);
+      }, 20);
+      setTimeout(() => {
+        socket.emit("connect");
+      }, 150);
+    });
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("late.example"),
+      new Port(80),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(100),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await advanceTime(100);
+    const result: PortMonitorResponse | null = await resultPromise;
+    const socket: MockSocket | undefined = controllableNet.getMockSockets()[0];
+
+    expect(result?.isOnline).toBe(false);
+    expect(result?.isTimeout).toBe(true);
+    expect(socket?.destroyCallCount).toBe(1);
+    expect(socket?.listenerCount("lookup")).toBe(0);
+    expect(socket?.listenerCount("connect")).toBe(0);
+    expect(socket?.listenerCount("connectionAttempt")).toBe(0);
+    expect(socket?.listenerCount("error")).toBe(0);
+
+    await advanceTime(50);
+
+    expect(result?.isOnline).toBe(false);
+    expect(result?.portTimings).toBeUndefined();
+    expect(socket?.destroyCallCount).toBe(1);
+  });
+
+  test("classifies a DNS resolution failure", async () => {
+    controllableNet.queueSocketScenario((socket: MockSocket): void => {
+      setTimeout(() => {
+        socket.emit(
+          "lookup",
+          nodeError(
+            "ENOTFOUND",
+            "getaddrinfo ENOTFOUND does-not-exist.example",
+          ),
+          undefined,
+          undefined,
+          "does-not-exist.example",
+        );
+      }, 20);
+      setTimeout(() => {
+        socket.emit(
+          "error",
+          nodeError(
+            "ENOTFOUND",
+            "getaddrinfo ENOTFOUND does-not-exist.example",
+          ),
+        );
+      }, 30);
+    });
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("does-not-exist.example"),
+      new Port(443),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(100),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await advanceTime(30);
+    const result: PortMonitorResponse | null = await resultPromise;
+
+    expect(result).toMatchObject({
+      isOnline: false,
+      isTimeout: false,
+      requestFailedDetails: {
+        failedPhase: RequestFailedPhase.DNSResolution,
+        errorCode: "ENOTFOUND",
+      },
+    });
+    expect(result?.failureCause).toContain("ENOTFOUND");
+  });
+
+  test("reports structural AggregateError attempts without string matching", async () => {
+    const aggregateError: Error & { errors: Array<ErrorWithCode> } =
+      Object.assign(new Error("All connection attempts failed"), {
+        name: "AggregateError",
+        errors: [
+          nodeError("ECONNREFUSED", "connect ECONNREFUSED 192.0.2.50:443"),
+          nodeError("ENETUNREACH", "connect ENETUNREACH 2001:db8::50:443"),
+        ],
+      });
+
+    controllableNet.queueSocketScenario((socket: MockSocket): void => {
+      setTimeout(() => {
+        socket.emit("error", aggregateError);
+      }, 40);
+    });
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("unreachable.example"),
+      new Port(443),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(100),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await advanceTime(40);
+    const result: PortMonitorResponse | null = await resultPromise;
+
+    expect(result).toMatchObject({
+      isOnline: false,
+      isTimeout: false,
+      requestFailedDetails: {
+        failedPhase: RequestFailedPhase.TCPConnection,
+        errorCode: "ECONNREFUSED",
+      },
+    });
+    expect(result?.failureCause).toContain(
+      "AggregateError (all connection attempts failed)",
+    );
+    expect(result?.failureCause).toContain("ECONNREFUSED");
+    expect(result?.failureCause).toContain("ENETUNREACH");
+  });
+
+  test("cleans up an absolute deadline when connect throws synchronously", async () => {
+    controllableNet.queueSocketScenario((): void => {
+      throw nodeError("EINVAL", "connect EINVAL");
+    });
+
+    const result: PortMonitorResponse | null = await PortMonitor.ping(
+      new Hostname("invalid.example"),
+      new Port(443),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(100),
+        isOnlineCheckRequest: true,
+      },
+    );
+    const socket: MockSocket | undefined = controllableNet.getMockSockets()[0];
+
+    expect(result?.isOnline).toBe(false);
+    expect(result?.isTimeout).toBe(false);
+    expect(socket?.destroyCallCount).toBe(1);
+  });
+
+  test("records failed attempts and returns timings from the successful retry", async () => {
+    controllableNet.queueSocketScenario((socket: MockSocket): void => {
+      setTimeout(() => {
+        socket.emit(
+          "error",
+          nodeError("ECONNREFUSED", "connect ECONNREFUSED 192.0.2.60:80"),
+        );
+      }, 15);
+    });
+    controllableNet.queueSocketScenario((socket: MockSocket): void => {
+      setTimeout(() => {
+        socket.emit("connectionAttempt", "192.0.2.61", 80, 4);
+      }, 10);
+      setTimeout(() => {
+        socket.emit("connect");
+      }, 30);
+    });
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("retry.example"),
+      new Port(80),
+      {
+        retry: 2,
+        timeout: new PositiveNumber(100),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await advanceTime(15);
+    await advanceTime(30);
+    const result: PortMonitorResponse | null = await resultPromise;
+
+    expect(Sleep.sleep).toHaveBeenCalledTimes(1);
+    expect(result?.totalAttempts).toBe(2);
+    expect(result?.probeAttempts).toMatchObject([
+      {
+        attemptNumber: 1,
+        responseTimeInMs: 15,
+        isOnline: false,
+        failureCause: expect.stringContaining("ECONNREFUSED"),
+      },
+      {
+        attemptNumber: 2,
+        responseTimeInMs: 30,
+        isOnline: true,
+      },
+    ]);
+    expect(result?.responseTimeInMS?.toNumber()).toBe(30);
+    expect(result?.portTimings).toEqual({
+      dnsLookupInMs: 10,
+      tcpConnectInMs: 20,
+      totalConnectionInMs: 30,
+    });
+  });
+
+  test("preserves the narrow port-25 online-on-timeout policy", async () => {
+    jest.spyOn(Register, "isPingMonitoringEnabled").mockResolvedValue(false);
+    controllableNet.queueSocketScenario((): void => {});
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("smtp.example"),
+      new Port(25),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(50),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await flushPromises();
+    await advanceTime(50);
+    const result: PortMonitorResponse | null = await resultPromise;
+
+    expect(Register.isPingMonitoringEnabled).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      isOnline: true,
+      failureCause: "",
+      totalAttempts: 1,
+    });
+    expect(result?.isTimeout).toBeUndefined();
+    expect(result?.responseTimeInMS?.toNumber()).toBe(50);
+    expect(result?.portTimings).toBeUndefined();
+  });
+
+  test("treats port 25 as an ordinary offline timeout when the policy is disabled", async () => {
+    controllableNet.queueSocketScenario((): void => {});
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("smtp.example"),
+      new Port(25),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(50),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await flushPromises();
+    await advanceTime(50);
+    const result: PortMonitorResponse | null = await resultPromise;
+
+    expect(result).toMatchObject({
+      isOnline: false,
+      isTimeout: true,
+      totalAttempts: 1,
+    });
+  });
+
+  test("honors a port embedded in a hostname without pre-resolving it", async () => {
+    controllableNet.queueSocketScenario((socket: MockSocket): void => {
+      setTimeout(() => {
+        socket.emit("connectionAttempt", "192.0.2.70", 8443, 4);
+      }, 10);
+      setTimeout(() => {
+        socket.emit("connect");
+      }, 20);
+    });
+
+    const resultPromise: Promise<PortMonitorResponse | null> = PortMonitor.ping(
+      new Hostname("override.example", new Port(8443)),
+      new Port(443),
+      {
+        retry: 1,
+        timeout: new PositiveNumber(100),
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    await advanceTime(20);
+    await resultPromise;
+
+    expect(controllableNet.getMockSockets()[0]?.connectCalls).toEqual([
+      { port: 8443, host: "override.example" },
+    ]);
+  });
+});

--- a/Probe/Utils/Monitors/Monitor.ts
+++ b/Probe/Utils/Monitors/Monitor.ts
@@ -384,6 +384,8 @@ export default class MonitorUtil {
         result.failureCause = response.failureCause;
         result.probeAttempts = response.probeAttempts;
         result.totalAttempts = response.totalAttempts;
+        result.portTimings = response.portTimings;
+        result.requestFailedDetails = response.requestFailedDetails;
       } else {
         const response: PingResponse | null = await PingMonitor.ping(
           monitorStep.data?.monitorDestination,
@@ -445,6 +447,8 @@ export default class MonitorUtil {
       result.isTimeout = response.isTimeout;
       result.probeAttempts = response.probeAttempts;
       result.totalAttempts = response.totalAttempts;
+      result.portTimings = response.portTimings;
+      result.requestFailedDetails = response.requestFailedDetails;
     }
 
     /*

--- a/Probe/Utils/Monitors/MonitorTypes/PortMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/PortMonitor.ts
@@ -3,19 +3,21 @@ import Hostname from "Common/Types/API/Hostname";
 import URL from "Common/Types/API/URL";
 import BadDataException from "Common/Types/Exception/BadDataException";
 import UnableToReachServer from "Common/Types/Exception/UnableToReachServer";
-import { PromiseRejectErrorFunction } from "Common/Types/FunctionTypes";
 import IPv4 from "Common/Types/IP/IPv4";
 import IPv6 from "Common/Types/IP/IPv6";
+import PortMonitorTimings from "Common/Types/Monitor/PortMonitor/PortMonitorTimings";
 import ObjectID from "Common/Types/ObjectID";
 import Port from "Common/Types/Port";
 import PositiveNumber from "Common/Types/PositiveNumber";
 import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
+import RequestFailedDetails, {
+  RequestFailedPhase,
+} from "Common/Types/Probe/RequestFailedDetails";
 import Sleep from "Common/Types/Sleep";
 import logger from "Common/Server/Utils/Logger";
 import net from "net";
 import Register from "../../../Services/Register";
 
-// TODO - make sure it works for the IPV6
 export interface PortMonitorResponse {
   isOnline: boolean;
   responseTimeInMS?: PositiveNumber | undefined;
@@ -23,6 +25,8 @@ export interface PortMonitorResponse {
   isTimeout?: boolean | undefined;
   probeAttempts?: Array<ProbeAttempt> | undefined;
   totalAttempts?: number | undefined;
+  portTimings?: PortMonitorTimings | undefined;
+  requestFailedDetails?: RequestFailedDetails | undefined;
 }
 
 export interface PingOptions {
@@ -34,6 +38,157 @@ export interface PingOptions {
   attempts?: Array<ProbeAttempt> | undefined;
 }
 
+interface PortConnectionResult {
+  responseTimeInMS: PositiveNumber;
+  portTimings?: PortMonitorTimings | undefined;
+}
+
+interface ErrorWithCode extends Error {
+  code?: string | undefined;
+}
+
+interface StructuralAggregateError extends Error {
+  errors: Array<unknown>;
+}
+
+const durationInMilliseconds: (start: bigint, end: bigint) => number = (
+  start: bigint,
+  end: bigint,
+): number => {
+  return Math.max(0, Math.ceil(Number(end - start) / 1000000));
+};
+
+const normalizeError: (error: unknown) => Error = (error: unknown): Error => {
+  return error instanceof Error ? error : new Error(String(error));
+};
+
+const isStructuralAggregateError: (
+  error: unknown,
+) => error is StructuralAggregateError = (
+  error: unknown,
+): error is StructuralAggregateError => {
+  return (
+    error instanceof Error &&
+    error.name === "AggregateError" &&
+    Array.isArray((error as Partial<StructuralAggregateError>).errors)
+  );
+};
+
+const describeError: (error: unknown) => string = (error: unknown): string => {
+  if (!isStructuralAggregateError(error)) {
+    if (!(error instanceof Error)) {
+      return String(error);
+    }
+
+    const description: string = error.toString();
+    const errorCode: string | undefined = (error as ErrorWithCode).code;
+
+    return errorCode && !description.includes(errorCode)
+      ? `${description} (${errorCode})`
+      : description;
+  }
+
+  const attemptFailures: Array<string> = error.errors.map(
+    (attemptError: unknown): string => {
+      return describeError(attemptError);
+    },
+  );
+  const attemptFailureDescription: string = attemptFailures.length
+    ? ` Attempts: ${attemptFailures.join("; ")}`
+    : "";
+
+  return (
+    "Request failed with AggregateError (all connection attempts failed). " +
+    `${error.toString()}.${attemptFailureDescription}`
+  );
+};
+
+const getRepresentativeError: (error: unknown) => unknown = (
+  error: unknown,
+): unknown => {
+  if (isStructuralAggregateError(error) && error.errors.length > 0) {
+    return getRepresentativeError(error.errors[0]);
+  }
+
+  return error;
+};
+
+const getErrorCode: (error: unknown) => string | undefined = (
+  error: unknown,
+): string | undefined => {
+  return error instanceof Error ? (error as ErrorWithCode).code : undefined;
+};
+
+const getRequestFailedDetails: (error: unknown) => RequestFailedDetails = (
+  error: unknown,
+): RequestFailedDetails => {
+  const representativeError: unknown = getRepresentativeError(error);
+  const errorCode: string | undefined = getErrorCode(representativeError);
+  const rawErrorMessage: string = describeError(error);
+  const lowerMessage: string = describeError(representativeError).toLowerCase();
+
+  if (
+    errorCode === "ENOTFOUND" ||
+    errorCode === "EAI_AGAIN" ||
+    errorCode === "EAI_FAIL" ||
+    lowerMessage.includes("enotfound") ||
+    lowerMessage.includes("getaddrinfo")
+  ) {
+    return {
+      failedPhase: RequestFailedPhase.DNSResolution,
+      errorCode: errorCode || "ENOTFOUND",
+      errorDescription:
+        "DNS resolution failed before a TCP connection could be attempted.",
+      rawErrorMessage,
+    };
+  }
+
+  if (
+    error instanceof UnableToReachServer ||
+    errorCode === "ETIMEDOUT" ||
+    lowerMessage.includes("timeout") ||
+    lowerMessage.includes("timed out")
+  ) {
+    return {
+      failedPhase: RequestFailedPhase.RequestTimeout,
+      errorCode: errorCode || "TIMEOUT",
+      errorDescription:
+        "The DNS and TCP connection attempt did not finish before the deadline.",
+      rawErrorMessage,
+    };
+  }
+
+  const tcpErrorCodes: Set<string> = new Set([
+    "ECONNABORTED",
+    "ECONNREFUSED",
+    "ECONNRESET",
+    "EHOSTUNREACH",
+    "ENETDOWN",
+    "ENETUNREACH",
+    "EPIPE",
+  ]);
+
+  if (
+    (errorCode !== undefined && tcpErrorCodes.has(errorCode)) ||
+    lowerMessage.includes("connect")
+  ) {
+    return {
+      failedPhase: RequestFailedPhase.TCPConnection,
+      errorCode,
+      errorDescription:
+        "TCP connection establishment failed before the port could be reached.",
+      rawErrorMessage,
+    };
+  }
+
+  return {
+    failedPhase: RequestFailedPhase.NetworkError,
+    errorCode,
+    errorDescription: "The port check failed because of a network error.",
+    rawErrorMessage,
+  };
+};
+
 export default class PortMonitor {
   public static async ping(
     host: Hostname | IPv4 | IPv6 | URL,
@@ -44,7 +199,7 @@ export default class PortMonitor {
       pingOptions = {};
     }
 
-    if (pingOptions?.currentRetryCount === undefined) {
+    if (pingOptions.currentRetryCount === undefined) {
       pingOptions.currentRetryCount = 1;
     }
 
@@ -73,110 +228,216 @@ export default class PortMonitor {
       throw new BadDataException("Port is not specified");
     }
 
+    const portNumber: number = port.toNumber();
+    const timeout: number = pingOptions.timeout?.toNumber() || 5000;
+    const destinationIsIpAddress: boolean = net.isIP(hostAddress) !== 0;
+
+    /*
+     * Some cloud providers block outbound SMTP. Keep the existing narrow
+     * policy that treats a port-25 deadline as online when ICMP monitoring is
+     * unavailable. The policy method is async, so it must be resolved before
+     * the attempt starts; calling it as a boolean would never activate it.
+     */
+    const treatPort25TimeoutAsOnline: boolean =
+      portNumber === 25 && !(await Register.isPingMonitoringEnabled());
+
     logger.debug(
-      `Pinging host: ${pingOptions?.monitorId?.toString()}  ${hostAddress}:${port.toString()} - Retry: ${
-        pingOptions?.currentRetryCount
+      `Pinging host: ${pingOptions.monitorId?.toString()}  ${hostAddress}:${port.toString()} - Retry: ${
+        pingOptions.currentRetryCount
       }`,
     );
 
     const attemptedAt: Date = new Date();
+    const attemptStartedAtNs: bigint = process.hrtime.bigint();
+
     try {
-      // Ping a host with port
-
-      const promiseResult: Promise<PositiveNumber> = new Promise(
+      const connectionResult: PortConnectionResult = await new Promise(
         (
-          resolve: (responseTimeInMS: PositiveNumber) => void,
-          reject: PromiseRejectErrorFunction,
-        ) => {
-          const startTime: [number, number] = process.hrtime();
-
+          resolve: (result: PortConnectionResult) => void,
+          reject: (error: Error) => void,
+        ): void => {
           const socket: net.Socket = new net.Socket();
+          let firstSuccessfulLookupAtNs: bigint | undefined = undefined;
+          let firstConnectionAttemptAtNs: bigint | undefined = undefined;
+          let deadlineTimer: NodeJS.Timeout | undefined = undefined;
+          let hasSettled: boolean = false;
 
-          const timeout: number = pingOptions?.timeout?.toNumber() || 5000;
+          const removeListeners: () => void = (): void => {
+            socket.removeListener("lookup", onLookup);
+            socket.removeListener("connectionAttempt", onConnectionAttempt);
+            socket.removeListener("connect", onConnect);
+            socket.removeListener("error", onError);
+          };
 
-          socket.setTimeout(timeout);
+          const finish: () => void = (): void => {
+            if (deadlineTimer) {
+              clearTimeout(deadlineTimer);
+              deadlineTimer = undefined;
+            }
 
-          if (!port) {
-            throw new BadDataException("Port is not specified");
-          }
+            removeListeners();
+            socket.destroy();
+          };
 
-          let hasPromiseResolved: boolean = false;
+          const resolveOnce: (result: PortConnectionResult) => void = (
+            result: PortConnectionResult,
+          ): void => {
+            if (hasSettled) {
+              return;
+            }
 
-          socket.connect(port.toNumber(), hostAddress, () => {
-            const endTime: [number, number] = process.hrtime(startTime);
+            hasSettled = true;
+            finish();
+            resolve(result);
+          };
+
+          const rejectOnce: (error: Error) => void = (error: Error): void => {
+            if (hasSettled) {
+              return;
+            }
+
+            hasSettled = true;
+            finish();
+            reject(error);
+          };
+
+          const onConnectionAttempt: () => void = (): void => {
+            if (hasSettled || firstConnectionAttemptAtNs !== undefined) {
+              return;
+            }
+
+            firstConnectionAttemptAtNs = process.hrtime.bigint();
+          };
+
+          const onLookup: (error: Error | null) => void = (
+            error: Error | null,
+          ): void => {
+            if (
+              hasSettled ||
+              destinationIsIpAddress ||
+              error ||
+              firstSuccessfulLookupAtNs !== undefined
+            ) {
+              return;
+            }
+
+            /*
+             * Node can skip connectionAttempt when lookup returns only one
+             * address. Retain the first successful lookup as the TCP-start
+             * fallback, while allowing connectionAttempt to supersede it for
+             * multi-address family selection and fallback.
+             *
+             * A lookup error is intentionally left for the socket's error
+             * event to settle so the native error and code remain intact.
+             */
+            firstSuccessfulLookupAtNs = process.hrtime.bigint();
+          };
+
+          const onConnect: () => void = (): void => {
+            if (hasSettled) {
+              return;
+            }
+
+            const connectedAtNs: bigint = process.hrtime.bigint();
+            const totalConnectionInMs: number = durationInMilliseconds(
+              attemptStartedAtNs,
+              connectedAtNs,
+            );
+            const tcpStartedAtNs: bigint =
+              firstConnectionAttemptAtNs ??
+              firstSuccessfulLookupAtNs ??
+              attemptStartedAtNs;
+            const portTimings: PortMonitorTimings = {
+              tcpConnectInMs: durationInMilliseconds(
+                tcpStartedAtNs,
+                connectedAtNs,
+              ),
+              totalConnectionInMs,
+            };
+
+            const dnsCompletedAtNs: bigint | undefined =
+              firstConnectionAttemptAtNs ?? firstSuccessfulLookupAtNs;
+
+            if (!destinationIsIpAddress && dnsCompletedAtNs !== undefined) {
+              portTimings.dnsLookupInMs = durationInMilliseconds(
+                attemptStartedAtNs,
+                dnsCompletedAtNs,
+              );
+            }
+
             const responseTimeInMS: PositiveNumber = new PositiveNumber(
-              Math.ceil((endTime[0] * 1000000000 + endTime[1]) / 1000000),
+              totalConnectionInMs,
             );
 
             logger.debug(
-              `Pinging host ${pingOptions?.monitorId?.toString()} ${hostAddress}:${port!.toString()} success: Response Time ${responseTimeInMS} ms`,
+              `Pinging host ${pingOptions?.monitorId?.toString()} ${hostAddress}:${port.toString()} success: Response Time ${responseTimeInMS} ms`,
             );
 
-            socket.destroy(); // Close the connection after success
-            if (!hasPromiseResolved) {
-              resolve(responseTimeInMS);
-            }
+            resolveOnce({
+              responseTimeInMS,
+              portTimings,
+            });
+          };
 
-            hasPromiseResolved = true;
-            return;
-          });
+          const onError: (error: Error) => void = (error: Error): void => {
+            logger.debug(`Could not connect to: ${host}:${port}`);
+            rejectOnce(error);
+          };
 
-          socket.on("timeout", () => {
-            socket.destroy();
+          const onDeadline: () => void = (): void => {
             logger.debug("Ping timeout");
 
-            if (!hasPromiseResolved) {
-              /*
-               * this could mean port 25 is blocked by the cloud provider and is timing out but is actually online.
-               * so we will return isOnline as true
-               */
-              if (
-                !Register.isPingMonitoringEnabled() &&
-                port.toNumber() === 25
-              ) {
-                logger.debug(
-                  "Ping monitoring is disabled because this is deployed in the cloud",
-                );
-                resolve(new PositiveNumber(timeout));
-              } else {
-                reject(new UnableToReachServer("Ping timeout"));
-              }
+            if (treatPort25TimeoutAsOnline) {
+              logger.debug(
+                "Ping monitoring is disabled because this is deployed in the cloud",
+              );
+              resolveOnce({
+                responseTimeInMS: new PositiveNumber(timeout),
+              });
+              return;
             }
 
-            hasPromiseResolved = true;
-            return;
-          });
+            rejectOnce(new UnableToReachServer("Ping timeout"));
+          };
 
-          socket.on("error", (error: Error) => {
-            socket.destroy();
-            logger.debug("Could not connect to: " + host + ":" + port);
+          socket.on("lookup", onLookup);
+          socket.once("connectionAttempt", onConnectionAttempt);
+          socket.once("connect", onConnect);
+          socket.once("error", onError);
 
-            if (!hasPromiseResolved) {
-              reject(error);
-            }
+          /*
+           * This is an absolute attempt deadline, not an idle socket timer.
+           * It starts before connect() begins hostname resolution and covers
+           * DNS plus every address-family connection attempt together.
+           */
+          deadlineTimer = setTimeout(onDeadline, timeout);
 
-            hasPromiseResolved = true;
-            return;
-          });
+          try {
+            /*
+             * Let Node resolve the hostname and retain its automatic family
+             * selection/fallback. Pre-resolving and connecting to one address
+             * would lose that behavior.
+             */
+            socket.connect(portNumber, hostAddress);
+          } catch (error: unknown) {
+            rejectOnce(normalizeError(error));
+          }
         },
       );
 
-      const responseTimeInMS: PositiveNumber =
-        (await promiseResult) as PositiveNumber;
       const responseReceivedAt: Date = new Date();
 
-      pingOptions.attempts!.push({
+      pingOptions.attempts.push({
         attemptNumber: pingOptions.currentRetryCount,
         attemptedAt,
         responseReceivedAt,
-        responseTimeInMs: responseTimeInMS.toNumber(),
+        responseTimeInMs: connectionResult.responseTimeInMS.toNumber(),
         isOnline: true,
       });
 
       // if response time is greater than 10 seconds then give it one more try
-
       if (
-        responseTimeInMS.toNumber() > 10000 &&
+        connectionResult.responseTimeInMS.toNumber() > 10000 &&
         pingOptions.currentRetryCount < (pingOptions.retry || 5)
       ) {
         pingOptions.currentRetryCount++;
@@ -186,38 +447,33 @@ export default class PortMonitor {
 
       return {
         isOnline: true,
-        responseTimeInMS: responseTimeInMS,
+        responseTimeInMS: connectionResult.responseTimeInMS,
         failureCause: "",
         probeAttempts: pingOptions.attempts,
-        totalAttempts: pingOptions.attempts!.length,
+        totalAttempts: pingOptions.attempts.length,
+        portTimings: connectionResult.portTimings,
       };
-    } catch (err: unknown) {
+    } catch (error: unknown) {
+      const failedAtNs: bigint = process.hrtime.bigint();
+      const err: Error = normalizeError(error);
+      const failureCause: string = describeError(err);
+
       logger.debug(
-        `Pinging host ${pingOptions?.monitorId?.toString()} ${hostAddress}:${port.toString()} error: `,
+        `Pinging host ${pingOptions.monitorId?.toString()} ${hostAddress}:${port.toString()} error: `,
       );
-
       logger.debug(err);
-
-      if (!pingOptions) {
-        pingOptions = {};
-      }
-
-      if (!pingOptions.currentRetryCount) {
-        pingOptions.currentRetryCount = 0;
-      }
-
-      if (!pingOptions.attempts) {
-        pingOptions.attempts = [];
-      }
 
       const responseReceivedAt: Date = new Date();
       pingOptions.attempts.push({
         attemptNumber: pingOptions.currentRetryCount || 1,
         attemptedAt,
         responseReceivedAt,
-        responseTimeInMs: responseReceivedAt.getTime() - attemptedAt.getTime(),
+        responseTimeInMs: durationInMilliseconds(
+          attemptStartedAtNs,
+          failedAtNs,
+        ),
         isOnline: false,
-        failureCause: (err as any).toString(),
+        failureCause,
       });
 
       if (pingOptions.currentRetryCount < (pingOptions.retry || 5)) {
@@ -230,43 +486,24 @@ export default class PortMonitor {
       if (!pingOptions.isOnlineCheckRequest) {
         if (!(await OnlineCheck.canProbeMonitorPortMonitors())) {
           logger.error(
-            `PortMonitor Monitor - Probe is not online. Cannot ping ${pingOptions?.monitorId?.toString()} ${host.toString()} - ERROR: ${err}`,
+            `PortMonitor Monitor - Probe is not online. Cannot ping ${pingOptions.monitorId?.toString()} ${host.toString()} - ERROR: ${err}`,
           );
           return null;
         }
       }
 
+      const requestFailedDetails: RequestFailedDetails =
+        getRequestFailedDetails(err);
       const isTimeout: boolean =
-        err instanceof UnableToReachServer &&
-        (err as UnableToReachServer).message === "Ping timeout";
-
-      if (isTimeout) {
-        return {
-          isOnline: true,
-          failureCause: (err as any).toString(),
-          isTimeout: true,
-          probeAttempts: pingOptions.attempts,
-          totalAttempts: pingOptions.attempts.length,
-        };
-      }
-
-      // if AggregateError is thrown, it means that the request failed
-      if ((err as any).toString().includes("AggregateError")) {
-        return {
-          isOnline: false,
-          isTimeout: false,
-          failureCause:
-            "Request failed with AggregateError (all connection attempts failed). " +
-            (err as any).toString(),
-          probeAttempts: pingOptions.attempts,
-          totalAttempts: pingOptions.attempts.length,
-        };
-      }
+        (err instanceof UnableToReachServer &&
+          err.message === "Ping timeout") ||
+        requestFailedDetails.failedPhase === RequestFailedPhase.RequestTimeout;
 
       return {
         isOnline: false,
-        isTimeout: false,
-        failureCause: (err as any).toString(),
+        isTimeout,
+        failureCause,
+        requestFailedDetails,
         probeAttempts: pingOptions.attempts,
         totalAttempts: pingOptions.attempts.length,
       };


### PR DESCRIPTION
## What changed

- Keep the existing `responseTimeInMs` value as total connection time for alert and chart compatibility, and add a `portTimings` breakdown for DNS lookup, TCP connect, and total connection time.
- Measure TCP from the first actual connection attempt while retaining a successful DNS lookup fallback for Node runtimes/hosts that skip that event. Node remains responsible for resolution and automatic IPv6/IPv4 fallback.
- Use a monotonic clock and one absolute per-attempt deadline covering DNS and all TCP attempts.
- Emit Port-specific DNS/TCP metrics, add current and evaluate-over-time criteria, and expose them in Port charts.
- Add a dedicated Port summary with an explicit “Total Connection Time (DNS + TCP)” label and phase waterfall.
- Make ordinary Port timeouts offline, classify native `ETIMEDOUT` consistently, retain structural aggregate failure details, and preserve the existing port-25 cloud policy.
- Document the timing semantics, criteria, IP-literal behavior, and compatibility behavior.

No database migration is required.

## Validation

- `npm run fix`
- `npm run compile` in `Common`
- `npm run compile` in `Probe`
- `npm run compile` in `App/FeatureSet/Dashboard`
- 17 deterministic Port socket timing/failure tests
- 116 metric metadata and criteria tests
- 25 Port metric persistence and evaluation tests
- 10 Port summary rendering tests

Closes #3047