### PR TITLE
fix(helm): pin every oneuptime chart pod to Linux nodes

### DIFF
--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -918,6 +918,32 @@ spec:
 {{- end }}
 
 
+{{/*
+Pod nodeSelector with the Linux-only pin merged in.
+
+Every image this chart deploys — the OneUptime services as well as the
+bundled postgres, redis, clickhouse, pgbouncer, kubectl and vLLM images —
+is built for linux only. On mixed-OS clusters (e.g. AKS with Windows node
+pools) an unpinned pod spec can be scheduled onto a Windows node, where the
+image pull can never succeed and the pod sits in ImagePullBackOff forever.
+The kubelet labels every node with kubernetes.io/os (stable since
+Kubernetes 1.14), so requiring "linux" is always safe.
+
+Takes the workload's user-configured nodeSelector map (or an empty dict when
+the workload has no such knob). User-supplied keys win on conflict.
+
+Usage (the include is nindent-ed under the `nodeSelector:` key):
+  nodeSelector:
+    {{`{{- include "oneuptime.nodeSelector" .Values.app.nodeSelector | nindent 8 }}`}}
+*/}}
+{{- define "oneuptime.nodeSelector" -}}
+{{- /* mergeOverwrite, not merge: sprig merge won't let a zero value ("")
+     in the user map displace the pin, breaking last-writer-wins. The
+     dest dict is a fresh literal, so .Values is never mutated. */ -}}
+{{- toYaml (mergeOverwrite (dict "kubernetes.io/os" "linux") (. | default dict)) -}}
+{{- end }}
+
+
 {{- define "oneuptime.deployment" }}
 apiVersion: apps/v1
 kind: Deployment
@@ -974,13 +1000,8 @@ spec:
       {{- if $.Values.tolerations }}
       tolerations: {{- $.Values.tolerations | toYaml | nindent 8 }}
       {{- end }}
-      {{- if $.NodeSelector }}
       nodeSelector:
-        {{- toYaml $.NodeSelector | nindent 8 }}
-      {{- else if $.Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml $.Values.nodeSelector | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" ($.NodeSelector | default $.Values.nodeSelector) | nindent 8 }}
       {{- if $.Volumes }}
       volumes:
       {{- range $key, $val := $.Volumes }}

--- a/HelmChart/Public/oneuptime/templates/app.yaml
+++ b/HelmChart/Public/oneuptime/templates/app.yaml
@@ -60,13 +60,8 @@ spec:
       {{- if $.Values.tolerations }}
       tolerations: {{- $.Values.tolerations | toYaml | nindent 8 }}
       {{- end }}
-      {{- if $.Values.app.nodeSelector }}
       nodeSelector:
-        {{- toYaml $.Values.app.nodeSelector | nindent 8 }}
-      {{- else if $.Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml $.Values.nodeSelector | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" ($.Values.app.nodeSelector | default $.Values.nodeSelector) | nindent 8 }}
       containers:
         - image: {{ include "oneuptime.image" (dict "Values" $.Values "ServiceName" "app") }}
           name: {{ printf "%s-%s" $.Release.Name "app"  }}

--- a/HelmChart/Public/oneuptime/templates/cleanup-cron-job.yaml
+++ b/HelmChart/Public/oneuptime/templates/cleanup-cron-job.yaml
@@ -23,6 +23,8 @@ spec:
       template:
         spec:
           serviceAccountName: cleanup-service-account
+          nodeSelector:
+            {{- include "oneuptime.nodeSelector" (dict) | nindent 12 }}
           containers:
           - name: cleanup
             image: bitnami/kubectl:latest
@@ -73,6 +75,8 @@ spec:
       template:
         spec:
           serviceAccountName: cleanup-service-account
+          nodeSelector:
+            {{- include "oneuptime.nodeSelector" (dict) | nindent 12 }}
           containers:
           - name: cleanup
             image: bitnami/kubectl:latest

--- a/HelmChart/Public/oneuptime/templates/clickhouse-altinity-chi.yaml
+++ b/HelmChart/Public/oneuptime/templates/clickhouse-altinity-chi.yaml
@@ -90,10 +90,8 @@ spec:
     podTemplates:
       - name: clickhouse-pod-template
         spec:
-          {{- with $altinity.nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- include "oneuptime.nodeSelector" $altinity.nodeSelector | nindent 12 }}
           {{- with $altinity.affinity }}
           affinity:
             {{- toYaml . | nindent 12 }}

--- a/HelmChart/Public/oneuptime/templates/clickhouse-keeper.yaml
+++ b/HelmChart/Public/oneuptime/templates/clickhouse-keeper.yaml
@@ -156,10 +156,8 @@ spec:
         app.kubernetes.io/part-of: oneuptime
         app.kubernetes.io/managed-by: Helm
     spec:
-      {{- with $keeper.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" $keeper.nodeSelector | nindent 8 }}
       {{- if $keeper.affinity }}
       affinity:
         {{- toYaml $keeper.affinity | nindent 8 }}

--- a/HelmChart/Public/oneuptime/templates/clickhouse-statefulset.yaml
+++ b/HelmChart/Public/oneuptime/templates/clickhouse-statefulset.yaml
@@ -37,10 +37,8 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/clickhouse-configmap.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ .Release.Name }}-clickhouse
-      {{- with .Values.clickhouse.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" .Values.clickhouse.nodeSelector | nindent 8 }}
       {{- with .Values.clickhouse.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/HelmChart/Public/oneuptime/templates/e2e-cron.yml
+++ b/HelmChart/Public/oneuptime/templates/e2e-cron.yml
@@ -19,13 +19,8 @@ spec:
     spec:
       template:
         spec:
-          {{- if $.Values.cronJobs.e2e.nodeSelector }}
           nodeSelector:
-            {{- toYaml $.Values.cronJobs.e2e.nodeSelector | nindent 12 }}
-          {{- else if $.Values.nodeSelector }}
-          nodeSelector:
-            {{- toYaml $.Values.nodeSelector | nindent 12 }}
-          {{- end }}
+            {{- include "oneuptime.nodeSelector" ($.Values.cronJobs.e2e.nodeSelector | default $.Values.nodeSelector) | nindent 12 }}
           containers:
           - name: e2e-cron
             image: {{ include "oneuptime.image" (dict "Values" $.Values "ServiceName" "e2e") }}

--- a/HelmChart/Public/oneuptime/templates/home.yaml
+++ b/HelmChart/Public/oneuptime/templates/home.yaml
@@ -58,13 +58,8 @@ spec:
       {{- if $.Values.tolerations }}
       tolerations: {{- $.Values.tolerations | toYaml | nindent 8 }}
       {{- end }}
-      {{- if $.Values.home.nodeSelector }}
       nodeSelector:
-        {{- toYaml $.Values.home.nodeSelector | nindent 8 }}
-      {{- else if $.Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml $.Values.nodeSelector | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" ($.Values.home.nodeSelector | default $.Values.nodeSelector) | nindent 8 }}
       containers:
         - image: {{ include "oneuptime.image" (dict "Values" $.Values "ServiceName" "home") }}
           name: {{ printf "%s-%s" $.Release.Name "home"  }}

--- a/HelmChart/Public/oneuptime/templates/migrate-job.yaml
+++ b/HelmChart/Public/oneuptime/templates/migrate-job.yaml
@@ -64,10 +64,8 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
-      {{- with .Values.migrate.nodeSelector | default .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" (.Values.migrate.nodeSelector | default .Values.nodeSelector) | nindent 8 }}
       {{- with .Values.migrate.tolerations | default .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/HelmChart/Public/oneuptime/templates/nginx.yaml
+++ b/HelmChart/Public/oneuptime/templates/nginx.yaml
@@ -75,13 +75,8 @@ spec:
       {{- if $.Values.tolerations }}
       tolerations: {{- $.Values.tolerations | toYaml | nindent 8 }}
       {{- end }}
-      {{- if $.Values.nginx.nodeSelector }}
       nodeSelector:
-        {{- toYaml $.Values.nginx.nodeSelector | nindent 8 }}
-      {{- else if $.Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml $.Values.nodeSelector | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" ($.Values.nginx.nodeSelector | default $.Values.nodeSelector) | nindent 8 }}
       {{- if and $.Values.nginx.sysctlTuning $.Values.nginx.sysctlTuning.enabled }}
       # Widen the ephemeral source-port range and enable TIME_WAIT reuse so the
       # ingress never runs out of local ports while proxying the ingest and

--- a/HelmChart/Public/oneuptime/templates/pgbouncer.yaml
+++ b/HelmChart/Public/oneuptime/templates/pgbouncer.yaml
@@ -100,10 +100,8 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.pgbouncer.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" .Values.pgbouncer.nodeSelector | nindent 8 }}
       {{- with .Values.pgbouncer.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/HelmChart/Public/oneuptime/templates/postgresql-cnpg-cluster.yaml
+++ b/HelmChart/Public/oneuptime/templates/postgresql-cnpg-cluster.yaml
@@ -76,12 +76,9 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 
-  {{- if or $cnpg.nodeSelector $cnpg.tolerations $cnpg.affinity }}
   affinity:
-    {{- with $cnpg.nodeSelector }}
     nodeSelector:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+      {{- include "oneuptime.nodeSelector" $cnpg.nodeSelector | nindent 6 }}
     {{- with $cnpg.tolerations }}
     tolerations:
       {{- toYaml . | nindent 6 }}
@@ -89,5 +86,4 @@ spec:
     {{- with $cnpg.affinity }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- end }}
 {{- end }}

--- a/HelmChart/Public/oneuptime/templates/postgresql-statefulset.yaml
+++ b/HelmChart/Public/oneuptime/templates/postgresql-statefulset.yaml
@@ -31,10 +31,8 @@ spec:
         checksum/postgresql-config: {{ include (print $.Template.BasePath "/postgresql-primary-configmap.yaml") . | sha256sum }}
         checksum/postgresql-hba: {{ include (print $.Template.BasePath "/postgresql-primary-hba-configmap.yaml") . | sha256sum }}
     spec:
-      {{- with .Values.postgresql.primary.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" .Values.postgresql.primary.nodeSelector | nindent 8 }}
       {{- with .Values.postgresql.primary.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/HelmChart/Public/oneuptime/templates/probe.yaml
+++ b/HelmChart/Public/oneuptime/templates/probe.yaml
@@ -79,13 +79,8 @@ spec:
       {{- if $.Values.tolerations }}
       tolerations: {{- $.Values.tolerations | toYaml | nindent 8 }}
       {{- end }}
-      {{- if $val.nodeSelector }}
       nodeSelector:
-        {{- toYaml $val.nodeSelector | nindent 8 }}
-      {{- else if $.Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml $.Values.nodeSelector | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" ($val.nodeSelector | default $.Values.nodeSelector) | nindent 8 }}
       containers:
         - image: {{ include "oneuptime.image" (dict "Values" $.Values "ServiceName" "probe") }}
           name: {{ printf "%s-%s" $.Release.Name (printf "probe-%s" $key)  }}

--- a/HelmChart/Public/oneuptime/templates/redis-statefulset.yaml
+++ b/HelmChart/Public/oneuptime/templates/redis-statefulset.yaml
@@ -26,10 +26,8 @@ spec:
         app.kubernetes.io/component: redis
         appname: oneuptime
     spec:
-      {{- with .Values.redis.master.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" .Values.redis.master.nodeSelector | nindent 8 }}
       {{- with .Values.redis.master.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/HelmChart/Public/oneuptime/templates/runner.yaml
+++ b/HelmChart/Public/oneuptime/templates/runner.yaml
@@ -57,13 +57,8 @@ spec:
       {{- if $.Values.tolerations }}
       tolerations: {{- $.Values.tolerations | toYaml | nindent 8 }}
       {{- end }}
-      {{- if $.Values.runner.nodeSelector }}
       nodeSelector:
-        {{- toYaml $.Values.runner.nodeSelector | nindent 8 }}
-      {{- else if $.Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml $.Values.nodeSelector | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" ($.Values.runner.nodeSelector | default $.Values.nodeSelector) | nindent 8 }}
       containers:
         - image: {{ include "oneuptime.image" (dict "Values" $.Values "ServiceName" "runner") }}
           name: {{ printf "%s-%s" $.Release.Name "runner" }}

--- a/HelmChart/Public/oneuptime/templates/telemetry-writer.yaml
+++ b/HelmChart/Public/oneuptime/templates/telemetry-writer.yaml
@@ -80,13 +80,8 @@ spec:
       {{- if $.Values.tolerations }}
       tolerations: {{- $.Values.tolerations | toYaml | nindent 8 }}
       {{- end }}
-      {{- if $.Values.telemetryWriter.nodeSelector }}
       nodeSelector:
-        {{- toYaml $.Values.telemetryWriter.nodeSelector | nindent 8 }}
-      {{- else if $.Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml $.Values.nodeSelector | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" ($.Values.telemetryWriter.nodeSelector | default $.Values.nodeSelector) | nindent 8 }}
       containers:
         - image: {{ include "oneuptime.image" (dict "Values" $.Values "ServiceName" "telemetry-writer" "ImageName" "app") }}
           name: {{ printf "%s-%s" $.Release.Name "telemetry-writer"  }}

--- a/HelmChart/Public/oneuptime/templates/tests/test.yaml
+++ b/HelmChart/Public/oneuptime/templates/tests/test.yaml
@@ -5,6 +5,8 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  nodeSelector:
+    {{- include "oneuptime.nodeSelector" (dict) | nindent 4 }}
   containers:
     - name: oneptime-test
       imagePullPolicy: {{ $.Values.image.pullPolicy }}

--- a/HelmChart/Public/oneuptime/templates/vllm.yaml
+++ b/HelmChart/Public/oneuptime/templates/vllm.yaml
@@ -72,10 +72,8 @@ spec:
       {{- if .Values.vllm.runtimeClassName }}
       runtimeClassName: {{ .Values.vllm.runtimeClassName }}
       {{- end }}
-      {{- with .Values.vllm.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" .Values.vllm.nodeSelector | nindent 8 }}
       {{- with .Values.vllm.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/HelmChart/Public/oneuptime/templates/worker.yaml
+++ b/HelmChart/Public/oneuptime/templates/worker.yaml
@@ -68,13 +68,8 @@ spec:
       {{- if $.Values.tolerations }}
       tolerations: {{- $.Values.tolerations | toYaml | nindent 8 }}
       {{- end }}
-      {{- if $.Values.worker.nodeSelector }}
       nodeSelector:
-        {{- toYaml $.Values.worker.nodeSelector | nindent 8 }}
-      {{- else if $.Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml $.Values.nodeSelector | nindent 8 }}
-      {{- end }}
+        {{- include "oneuptime.nodeSelector" ($.Values.worker.nodeSelector | default $.Values.nodeSelector) | nindent 8 }}
       containers:
         - image: {{ include "oneuptime.image" (dict "Values" $.Values "ServiceName" "worker" "ImageName" "app") }}
           name: {{ printf "%s-%s" $.Release.Name "worker"  }}


### PR DESCRIPTION
## Summary

Applies the same fix that #3057 made to `HelmChart/Public/kubernetes-agent` to the main `HelmChart/Public/oneuptime` server chart.

With default values, 9 of the 12 rendered workloads carried no `kubernetes.io/os` nodeSelector (only the KEDA subchart pins linux upstream). On clusters with untainted Windows node pools (common on AKS), those pods can be scheduled onto Windows nodes and sit in `ImagePullBackOff` forever, since every image is linux-only.

- Adds a shared `oneuptime.nodeSelector` helper: `toYaml (mergeOverwrite (dict "kubernetes.io/os" "linux") (. | default dict))` — merges the linux pin into the workload's configured nodeSelector, with user-set keys (including zero values and the os key itself) winning on conflict.
- Includes it in every pod-creating template: all Deployments (app, nginx, probe, runner, home, worker, telemetry-writer, pgbouncer, vllm, test-server via the shared deployment helper), StatefulSets (redis, clickhouse, clickhouse-keeper, postgresql), the migrate Job, the e2e and cleanup CronJobs, the helm-test Pod, the Altinity ClickHouseInstallation pod template, and the CNPG Cluster affinity.
- Existing precedence is preserved (per-workload `nodeSelector` else chart-wide `nodeSelector` where that fallback existed) — the only change is the merged-in linux pin.

## Verification

- `helm lint` passes.
- Rendered with defaults (9 first-party PodSpecs), with all optional workloads enabled (worker/home/telemetry-writer/vllm/e2e/cleanup/test-server/pgbouncer — 18 PodSpecs), and in operator mode (Altinity CHI + keeper, CNPG cluster): every rendered PodSpec carries `kubernetes.io/os: linux`.
- Precedence checks: `--set-json 'app.nodeSelector={"kubernetes.io/os":"windows"}'` renders `windows` (user wins); `--set-json 'nginx.nodeSelector={"disktype":"ssd"}'` renders both keys; chart-wide `nodeSelector` still merges in where it previously applied.