### PR TITLE
fix(identity): harden dashboard and status page master password hashing

### DIFF
--- a/Common/Models/DatabaseModels/Dashboard.ts
+++ b/Common/Models/DatabaseModels/Dashboard.ts
@@ -826,6 +826,7 @@ export default class Dashboard extends BaseModel {
     description:
       "Password required to unlock a public dashboard. This value is stored as a secure hash.",
     hashed: true,
+    hashSaltColumn: "masterPasswordSalt",
     type: TableColumnType.HashedString,
     placeholder: "Enter a new master password",
   })
@@ -836,6 +837,33 @@ export default class Dashboard extends BaseModel {
     transformer: HashedString.getDatabaseTransformer(),
   })
   public masterPassword?: HashedString = undefined;
+
+  /*
+   * Per-dashboard salt mixed into `masterPassword`. Written by the database
+   * write path on every master-password write and never exposed to API
+   * callers. Nullable so existing unsalted hashes can be verified and
+   * upgraded after a successful unlock.
+   */
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    title: "Master Password Salt",
+    description:
+      "Per-dashboard random salt mixed into this dashboard's master password hash.",
+    computed: true,
+    type: TableColumnType.ShortText,
+    hideColumnInDocumentation: true,
+  })
+  @Column({
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+    unique: false,
+    nullable: true,
+  })
+  public masterPasswordSalt?: string = undefined;
 
   @ColumnAccessControl({
     create: [

--- a/Common/Models/DatabaseModels/StatusPage.ts
+++ b/Common/Models/DatabaseModels/StatusPage.ts
@@ -1183,6 +1183,7 @@ export default class StatusPage extends BaseModel {
     description:
       "Password required to unlock a private status page. This value is stored as a secure hash.",
     hashed: true,
+    hashSaltColumn: "masterPasswordSalt",
     type: TableColumnType.HashedString,
     placeholder: "Enter a new master password",
   })
@@ -1193,6 +1194,33 @@ export default class StatusPage extends BaseModel {
     transformer: HashedString.getDatabaseTransformer(),
   })
   public masterPassword?: HashedString = undefined;
+
+  /*
+   * Per-status-page salt mixed into `masterPassword`. Written by the database
+   * write path on every master-password write and never exposed to API
+   * callers. Nullable so existing unsalted hashes can be verified and
+   * upgraded after a successful unlock.
+   */
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    title: "Master Password Salt",
+    description:
+      "Per-status-page random salt mixed into this status page's master password hash.",
+    computed: true,
+    type: TableColumnType.ShortText,
+    hideColumnInDocumentation: true,
+  })
+  @Column({
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+    unique: false,
+    nullable: true,
+  })
+  public masterPasswordSalt?: string = undefined;
 
   @ColumnAccessControl({
     create: [

--- a/Common/Server/API/DashboardAPI.ts
+++ b/Common/Server/API/DashboardAPI.ts
@@ -15,11 +15,9 @@ import Response from "../Utils/Response";
 import BaseAPI from "./BaseAPI";
 import BadDataException from "../../Types/Exception/BadDataException";
 import NotFoundException from "../../Types/Exception/NotFoundException";
-import HashedString from "../../Types/HashedString";
 import ObjectID from "../../Types/ObjectID";
 import Dashboard from "../../Models/DatabaseModels/Dashboard";
 import DashboardDomain from "../../Models/DatabaseModels/DashboardDomain";
-import { EncryptionSecret } from "../EnvironmentConfig";
 import { DASHBOARD_MASTER_PASSWORD_INVALID_MESSAGE } from "../../Types/Dashboard/MasterPassword";
 import NotAuthenticatedException from "../../Types/Exception/NotAuthenticatedException";
 import ForbiddenException from "../../Types/Exception/ForbiddenException";
@@ -1541,10 +1539,9 @@ export default class DashboardAPI extends BaseAPI<
             req.params["dashboardId"] as string,
           );
 
-          const password: string | undefined =
-            req.body && (req.body["password"] as string);
+          const password: unknown = req.body && req.body["password"];
 
-          if (!password) {
+          if (typeof password !== "string" || !password) {
             throw new BadDataException("Master password is required.");
           }
 
@@ -1556,6 +1553,7 @@ export default class DashboardAPI extends BaseAPI<
                 projectId: true,
                 enableMasterPassword: true,
                 masterPassword: true,
+                masterPasswordSalt: true,
                 isPublicDashboard: true,
               },
               props: {
@@ -1579,12 +1577,14 @@ export default class DashboardAPI extends BaseAPI<
             );
           }
 
-          const hashedInput: string = await HashedString.hashValue(
-            password,
-            EncryptionSecret,
-          );
+          const isMasterPasswordValid: boolean =
+            await DashboardService.verifyHashedColumnValue({
+              item: dashboard,
+              columnName: "masterPassword",
+              plainValue: password,
+            });
 
-          if (hashedInput !== dashboard.masterPassword.toString()) {
+          if (!isMasterPasswordValid) {
             throw new BadDataException(
               DASHBOARD_MASTER_PASSWORD_INVALID_MESSAGE,
             );

--- a/Common/Server/API/StatusPageAPI.ts
+++ b/Common/Server/API/StatusPageAPI.ts
@@ -53,7 +53,6 @@ import JSONFunctions from "../../Types/JSONFunctions";
 import ObjectID from "../../Types/ObjectID";
 import Phone from "../../Types/Phone";
 import PositiveNumber from "../../Types/PositiveNumber";
-import HashedString from "../../Types/HashedString";
 import AcmeChallenge from "../../Models/DatabaseModels/AcmeChallenge";
 import Incident from "../../Models/DatabaseModels/Incident";
 import IncidentEpisode from "../../Models/DatabaseModels/IncidentEpisode";
@@ -102,7 +101,6 @@ import Hostname from "../../Types/API/Hostname";
 import Protocol from "../../Types/API/Protocol";
 import DatabaseConfig from "../DatabaseConfig";
 import CookieUtil from "../Utils/Cookie";
-import { EncryptionSecret } from "../EnvironmentConfig";
 import { StatusPageApiRoute } from "../../ServiceRoute";
 import ProjectSmtpConfigService from "../Services/ProjectSmtpConfigService";
 import ForbiddenException from "../../Types/Exception/ForbiddenException";
@@ -943,10 +941,9 @@ export default class StatusPageAPI extends BaseAPI<
             req.params["statusPageId"] as string,
           );
 
-          const password: string | undefined =
-            req.body && (req.body["password"] as string);
+          const password: unknown = req.body && req.body["password"];
 
-          if (!password) {
+          if (typeof password !== "string" || !password) {
             throw new BadDataException("Master password is required.");
           }
 
@@ -958,6 +955,7 @@ export default class StatusPageAPI extends BaseAPI<
                 projectId: true,
                 enableMasterPassword: true,
                 masterPassword: true,
+                masterPasswordSalt: true,
                 isPublicStatusPage: true,
               },
               props: {
@@ -981,12 +979,14 @@ export default class StatusPageAPI extends BaseAPI<
             );
           }
 
-          const hashedInput: string = await HashedString.hashValue(
-            password,
-            EncryptionSecret,
-          );
+          const isMasterPasswordValid: boolean =
+            await StatusPageService.verifyHashedColumnValue({
+              item: statusPage,
+              columnName: "masterPassword",
+              plainValue: password,
+            });
 
-          if (hashedInput !== statusPage.masterPassword.toString()) {
+          if (!isMasterPasswordValid) {
             throw new BadDataException(MASTER_PASSWORD_INVALID_MESSAGE);
           }
 

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786400000000-AddMasterPasswordSalt.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786400000000-AddMasterPasswordSalt.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+type ScryptHashExistsResult = {
+  exists: boolean;
+};
+
+export class AddMasterPasswordSalt1786400000000 implements MigrationInterface {
+  public name = "AddMasterPasswordSalt1786400000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "StatusPage" ADD "masterPasswordSalt" character varying(100)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Dashboard" ADD "masterPasswordSalt" character varying(100)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const [dashboardResult] = (await queryRunner.query(
+      `SELECT EXISTS (SELECT 1 FROM "Dashboard" WHERE "masterPassword" LIKE 'scrypt$%') AS "exists"`,
+    )) as Array<ScryptHashExistsResult>;
+    const [statusPageResult] = (await queryRunner.query(
+      `SELECT EXISTS (SELECT 1 FROM "StatusPage" WHERE "masterPassword" LIKE 'scrypt$%') AS "exists"`,
+    )) as Array<ScryptHashExistsResult>;
+
+    if (dashboardResult?.exists || statusPageResult?.exists) {
+      throw new Error(
+        "Cannot remove master-password salt columns while scrypt master-password hashes exist.",
+      );
+    }
+
+    await queryRunner.query(
+      `ALTER TABLE "Dashboard" DROP COLUMN "masterPasswordSalt"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "StatusPage" DROP COLUMN "masterPasswordSalt"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -506,6 +506,7 @@ import { RestoreServiceLowerNameIndex1786100000000 } from "./1786100000000-Resto
 import { MigrationName1786101798351 } from "./1786101798351-MigrationName";
 import { RestoreDroppedUniqueIndexes1786200000000 } from "./1786200000000-RestoreDroppedUniqueIndexes";
 import { QuarantineUnboundGitHubInstallations1786300000000 } from "./1786300000000-QuarantineUnboundGitHubInstallations";
+import { AddMasterPasswordSalt1786400000000 } from "./1786400000000-AddMasterPasswordSalt";
 
 export default [
   InitialMigration,
@@ -1016,4 +1017,5 @@ export default [
   RestoreDroppedUniqueIndexes1786200000000,
   QuarantineUnboundGitHubInstallations1786300000000,
   MigrationName1786101798351,
+  AddMasterPasswordSalt1786400000000,
 ];

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -334,7 +334,8 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
    * generated — session refresh tokens and the like. They keep the fast
    * SHA-256 hash, which is the right tool for them: there is nothing to guess,
    * and they have to stay searchable by hash because that is how they are
-   * looked up.
+   * looked up. Every human-chosen credential, including dashboard and status
+   * page master passwords, declares a salt column and takes the scrypt path.
    *
    * The salt is written onto the SAME payload as the hash, so the pair can
    * never be persisted out of step with each other.
@@ -467,6 +468,10 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
               salt: newSalt,
             }),
             [saltColumnName]: newSalt,
+          } as unknown as PartialEntity<TBaseModel>,
+          expectedData: {
+            [data.columnName]: storedHash,
+            [saltColumnName]: salt,
           } as unknown as PartialEntity<TBaseModel>,
           skipUpdateDateColumn: true,
         });
@@ -2503,6 +2508,14 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
     id: ObjectID;
     data: PartialEntity<TBaseModel>;
     /*
+     * Optional compare-and-set guard. Every supplied property is added to
+     * the WHERE clause with null-safe equality, so the update is skipped if
+     * another writer changed the row after the caller read it. Password-hash
+     * upgrades use this to avoid overwriting a concurrently changed
+     * credential with a re-hash of the old password.
+     */
+    expectedData?: PartialEntity<TBaseModel>;
+    /*
      * Leave `updatedAt` untouched. For passive bookkeeping writes (liveness
      * timestamps, ingest health markers) where consumers key change
      * detection off updatedAt - e.g. the session replay configEpoch - a
@@ -2576,9 +2589,37 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
       metadata.primaryColumns[0]?.databaseName || "_id";
     params.push(input.id.toString());
 
+    const whereClauses: Array<string> = [
+      `"${primaryColumnName}" = $${params.length}`,
+    ];
+
+    for (const [propertyName, value] of Object.entries(
+      (input.expectedData || {}) as ObjectLiteral,
+    )) {
+      const column: ColumnMetadata | undefined =
+        metadata.findColumnWithPropertyName(propertyName);
+
+      if (!column) {
+        throw new BadDataException(
+          `updateColumnsByIdWithoutHooks: unknown expected column "${propertyName}" on "${metadata.tableName}"`,
+        );
+      }
+
+      if (typeof value === "function") {
+        throw new BadDataException(
+          `updateColumnsByIdWithoutHooks: SQL-expression expected values are not supported (column "${propertyName}"); pass a literal value.`,
+        );
+      }
+
+      params.push(driver.preparePersistentValue(value, column));
+      whereClauses.push(
+        `"${column.databaseName}" IS NOT DISTINCT FROM $${params.length}`,
+      );
+    }
+
     const sql: string = `UPDATE "${metadata.tableName}" SET ${setClauses.join(
       ", ",
-    )} WHERE "${primaryColumnName}" = $${params.length}`;
+    )} WHERE ${whereClauses.join(" AND ")}`;
 
     await repository.manager.query(sql, params);
   }

--- a/Common/Server/Utils/PasswordHash.ts
+++ b/Common/Server/Utils/PasswordHash.ts
@@ -241,9 +241,12 @@ export default class PasswordHash {
    *   salted SHA   `SHA256("v2:" + salt + ":" + secret + ":" + password)`.
    *   bare SHA     `SHA256(secret + password)`, from before salts existed.
    *
-   * The last two are told apart by whether the row has a salt, which is the
-   * same rule they were written under. Anything not carrying a recognised
-   * scheme prefix is one of them.
+   * Normally the last two are told apart by whether the row has a salt,
+   * which is the rule they were written under. During a rolling deployment,
+   * however, an old pod can write a bare SHA digest while leaving a new pod's
+   * salt behind. Anything without a recognised scheme prefix therefore tries
+   * the selected legacy scheme first and the bare scheme as a compatibility
+   * fallback.
    */
   public static async verify(data: {
     plainValue: string;
@@ -259,11 +262,32 @@ export default class PasswordHash {
     );
 
     if (!parsed) {
+      const matchesSelectedLegacyScheme: boolean =
+        await HashedString.verifyValue({
+          plainValue: data.plainValue,
+          hashedValue: data.storedValue,
+          encryptionSecret: EncryptionSecret,
+          salt: data.salt || null,
+        });
+
+      if (matchesSelectedLegacyScheme || !data.salt) {
+        return matchesSelectedLegacyScheme;
+      }
+
+      /*
+       * Rolling-deploy compatibility. A pod running the pre-salt write path
+       * can replace a password with the original bare SHA-256 digest while a
+       * salt written by a newer pod remains on the row. A bare digest carries
+       * no scheme marker, so trying only the salted-SHA construction would
+       * lock that resource out permanently. Fall back to the original scheme
+       * when a supplied salt does not match; the successful caller upgrades
+       * the row to scrypt immediately afterwards.
+       */
       return await HashedString.verifyValue({
         plainValue: data.plainValue,
         hashedValue: data.storedValue,
         encryptionSecret: EncryptionSecret,
-        salt: data.salt || null,
+        salt: null,
       });
     }
 

--- a/Common/Tests/Server/API/StatusPageMasterPasswordAPI.test.ts
+++ b/Common/Tests/Server/API/StatusPageMasterPasswordAPI.test.ts
@@ -1,23 +1,19 @@
-import Dashboard from "../../../Models/DatabaseModels/Dashboard";
-import DashboardAPI from "../../../Server/API/DashboardAPI";
+import StatusPage from "../../../Models/DatabaseModels/StatusPage";
+import StatusPageAPI from "../../../Server/API/StatusPageAPI";
 import { EncryptionSecret } from "../../../Server/EnvironmentConfig";
-import DashboardService from "../../../Server/Services/DashboardService";
+import StatusPageService from "../../../Server/Services/StatusPageService";
 import CookieUtil from "../../../Server/Utils/Cookie";
-import PasswordHash from "../../../Server/Utils/PasswordHash";
 import {
   ExpressRequest,
   ExpressResponse,
   NextFunction,
 } from "../../../Server/Utils/Express";
+import PasswordHash from "../../../Server/Utils/PasswordHash";
 import Response from "../../../Server/Utils/Response";
-import {
-  DASHBOARD_MASTER_PASSWORD_INVALID_MESSAGE,
-  DASHBOARD_MASTER_PASSWORD_REQUIRED_MESSAGE,
-} from "../../../Types/Dashboard/MasterPassword";
 import BadDataException from "../../../Types/Exception/BadDataException";
-import MasterPasswordRequiredException from "../../../Types/Exception/MasterPasswordRequiredException";
 import HashedString from "../../../Types/HashedString";
 import ObjectID from "../../../Types/ObjectID";
+import { MASTER_PASSWORD_INVALID_MESSAGE } from "../../../Types/StatusPage/MasterPassword";
 import { mockRouter } from "./Helpers";
 import {
   afterEach,
@@ -26,6 +22,7 @@ import {
   describe,
   expect,
   it,
+  jest,
 } from "@jest/globals";
 
 jest.mock("../../../Server/Utils/Express", () => {
@@ -54,42 +51,42 @@ jest.mock("../../../Server/Utils/Response", () => {
   };
 });
 
-describe("DashboardAPI master password", () => {
+describe("StatusPageAPI master password", () => {
   const password: string = "correct horse battery staple";
 
-  let dashboardId: ObjectID;
-  let dashboard: Dashboard;
+  let statusPageId: ObjectID;
+  let statusPage: StatusPage;
   let mockRequest: ExpressRequest;
   let mockResponse: ExpressResponse;
   let nextFunction: NextFunction;
 
   beforeAll(() => {
     mockRouter.routes.length = 0;
-    new DashboardAPI();
+    new StatusPageAPI();
   });
 
   beforeEach(async () => {
     jest.clearAllMocks();
 
-    dashboardId = ObjectID.generate();
-    dashboard = new Dashboard();
-    dashboard.id = dashboardId;
-    dashboard.isPublicDashboard = true;
-    dashboard.enableMasterPassword = true;
-    dashboard.masterPasswordSalt = PasswordHash.generateSalt();
-    dashboard.masterPassword = new HashedString(
+    statusPageId = ObjectID.generate();
+    statusPage = new StatusPage();
+    statusPage.id = statusPageId;
+    statusPage.isPublicStatusPage = false;
+    statusPage.enableMasterPassword = true;
+    statusPage.masterPasswordSalt = PasswordHash.generateSalt();
+    statusPage.masterPassword = new HashedString(
       await PasswordHash.hash({
         plainValue: password,
-        salt: dashboard.masterPasswordSalt,
+        salt: statusPage.masterPasswordSalt,
       }),
       true,
     );
 
-    jest.spyOn(DashboardService, "findOneById").mockResolvedValue(dashboard);
+    jest.spyOn(StatusPageService, "findOneById").mockResolvedValue(statusPage);
 
     mockRequest = {
       params: {
-        dashboardId: dashboardId.toString(),
+        statusPageId: statusPageId.toString(),
       },
       body: {
         password,
@@ -114,39 +111,9 @@ describe("DashboardAPI master password", () => {
     jest.restoreAllMocks();
   });
 
-  it("denies a protected public dashboard when no master-password cookie is present", async () => {
-    const result: Awaited<ReturnType<typeof DashboardService.hasReadAccess>> =
-      await DashboardService.hasReadAccess({
-        dashboardId,
-        req: mockRequest,
-      });
-
-    expect(result.hasReadAccess).toBe(false);
-    expect(result.error).toBeInstanceOf(MasterPasswordRequiredException);
-    expect(result.error?.message).toBe(
-      DASHBOARD_MASTER_PASSWORD_REQUIRED_MESSAGE,
-    );
-  });
-
-  it("fails closed when master-password protection is enabled without a stored password", async () => {
-    delete dashboard.masterPassword;
-
-    const result: Awaited<ReturnType<typeof DashboardService.hasReadAccess>> =
-      await DashboardService.hasReadAccess({
-        dashboardId,
-        req: mockRequest,
-      });
-
-    expect(result.hasReadAccess).toBe(false);
-    expect(result.error).toBeInstanceOf(MasterPasswordRequiredException);
-    expect(result.error?.message).toBe(
-      DASHBOARD_MASTER_PASSWORD_REQUIRED_MESSAGE,
-    );
-  });
-
-  it("issues a dashboard-scoped cookie for the correct password and unlocks only that dashboard", async () => {
+  it("issues a status-page-scoped cookie for the correct current scrypt password", async () => {
     await mockRouter
-      .match("post", "/dashboard/master-password/:dashboardId")
+      .match("post", "/status-page/master-password/:statusPageId")
       .handlerFunction(mockRequest, mockResponse, nextFunction);
 
     expect(nextFunction).not.toHaveBeenCalled();
@@ -162,9 +129,8 @@ describe("DashboardAPI master password", () => {
     const cookieToken: string = cookieCall[1] as string;
 
     expect(cookieName).toBe(
-      CookieUtil.getDashboardMasterPasswordKey(dashboardId),
+      CookieUtil.getStatusPageMasterPasswordKey(statusPageId),
     );
-    expect(cookieToken).toEqual(expect.any(String));
 
     const unlockedRequest: ExpressRequest = {
       cookies: {
@@ -175,47 +141,21 @@ describe("DashboardAPI master password", () => {
       ips: [],
     } as unknown as ExpressRequest;
 
-    const unlockedResult: Awaited<
-      ReturnType<typeof DashboardService.hasReadAccess>
-    > = await DashboardService.hasReadAccess({
-      dashboardId,
-      req: unlockedRequest,
-    });
-
-    expect(unlockedResult.hasReadAccess).toBe(true);
-    expect(unlockedResult.error).toBeUndefined();
-
-    const otherDashboardId: ObjectID = ObjectID.generate();
-    const copiedCookieRequest: ExpressRequest = {
-      cookies: {
-        [CookieUtil.getDashboardMasterPasswordKey(otherDashboardId)]:
-          cookieToken,
-      },
-      headers: {},
-      socket: {},
-      ips: [],
-    } as unknown as ExpressRequest;
-
-    const isolatedResult: Awaited<
-      ReturnType<typeof DashboardService.hasReadAccess>
-    > = await DashboardService.hasReadAccess({
-      dashboardId: otherDashboardId,
-      req: copiedCookieRequest,
-    });
-
-    expect(isolatedResult.hasReadAccess).toBe(false);
-    expect(isolatedResult.error).toBeInstanceOf(
-      MasterPasswordRequiredException,
-    );
+    await expect(
+      StatusPageService.hasReadAccess({
+        statusPageId,
+        req: unlockedRequest,
+      }),
+    ).resolves.toEqual({ hasReadAccess: true });
   });
 
-  it("verifies a current scrypt password without rewriting it", async () => {
+  it("does not rewrite a hash already using current scrypt parameters", async () => {
     const updateSpy: ReturnType<typeof jest.spyOn> = jest
-      .spyOn(DashboardService, "updateColumnsByIdWithoutHooks")
+      .spyOn(StatusPageService, "updateColumnsByIdWithoutHooks")
       .mockResolvedValue(undefined);
 
     await mockRouter
-      .match("post", "/dashboard/master-password/:dashboardId")
+      .match("post", "/status-page/master-password/:statusPageId")
       .handlerFunction(mockRequest, mockResponse, nextFunction);
 
     expect(nextFunction).not.toHaveBeenCalled();
@@ -227,16 +167,15 @@ describe("DashboardAPI master password", () => {
     mockRequest.body["password"] = "incorrect password";
 
     await mockRouter
-      .match("post", "/dashboard/master-password/:dashboardId")
+      .match("post", "/status-page/master-password/:statusPageId")
       .handlerFunction(mockRequest, mockResponse, nextFunction);
 
     expect(nextFunction).toHaveBeenCalledTimes(1);
-
     const error: unknown = (nextFunction as jest.Mock).mock.calls[0]?.[0];
 
     expect(error).toBeInstanceOf(BadDataException);
     expect((error as BadDataException).message).toBe(
-      DASHBOARD_MASTER_PASSWORD_INVALID_MESSAGE,
+      MASTER_PASSWORD_INVALID_MESSAGE,
     );
     expect(mockResponse.cookie).not.toHaveBeenCalled();
     expect(Response.sendEmptySuccessResponse).not.toHaveBeenCalled();
@@ -248,12 +187,12 @@ describe("DashboardAPI master password", () => {
       (mockRequest.body as Record<string, unknown>)["password"] =
         invalidPassword;
       const verifySpy: ReturnType<typeof jest.spyOn> = jest.spyOn(
-        DashboardService,
+        StatusPageService,
         "verifyHashedColumnValue",
       );
 
       await mockRouter
-        .match("post", "/dashboard/master-password/:dashboardId")
+        .match("post", "/status-page/master-password/:statusPageId")
         .handlerFunction(mockRequest, mockResponse, nextFunction);
 
       expect(nextFunction).toHaveBeenCalledTimes(1);
@@ -264,16 +203,16 @@ describe("DashboardAPI master password", () => {
         "Master password is required.",
       );
       expect(verifySpy).not.toHaveBeenCalled();
-      expect(DashboardService.findOneById).not.toHaveBeenCalled();
+      expect(StatusPageService.findOneById).not.toHaveBeenCalled();
       expect(mockResponse.cookie).not.toHaveBeenCalled();
     },
   );
 
-  it("uses this dashboard's selected salt when checking the password", async () => {
-    dashboard.masterPasswordSalt = PasswordHash.generateSalt();
+  it("uses this status page's selected salt when checking the password", async () => {
+    statusPage.masterPasswordSalt = PasswordHash.generateSalt();
 
     await mockRouter
-      .match("post", "/dashboard/master-password/:dashboardId")
+      .match("post", "/status-page/master-password/:statusPageId")
       .handlerFunction(mockRequest, mockResponse, nextFunction);
 
     expect(nextFunction).toHaveBeenCalledTimes(1);
@@ -281,17 +220,17 @@ describe("DashboardAPI master password", () => {
 
     expect(error).toBeInstanceOf(BadDataException);
     expect((error as BadDataException).message).toBe(
-      DASHBOARD_MASTER_PASSWORD_INVALID_MESSAGE,
+      MASTER_PASSWORD_INVALID_MESSAGE,
     );
     expect(mockResponse.cookie).not.toHaveBeenCalled();
   });
 
   it("selects the salt needed for verification but never exposes either credential column", async () => {
     await mockRouter
-      .match("post", "/dashboard/master-password/:dashboardId")
+      .match("post", "/status-page/master-password/:statusPageId")
       .handlerFunction(mockRequest, mockResponse, nextFunction);
 
-    expect(DashboardService.findOneById).toHaveBeenCalledWith(
+    expect(StatusPageService.findOneById).toHaveBeenCalledWith(
       expect.objectContaining({
         select: expect.objectContaining({
           masterPassword: true,
@@ -314,26 +253,26 @@ describe("DashboardAPI master password", () => {
 
     expect(serializedCookieArguments).not.toContain(password);
     expect(serializedCookieArguments).not.toContain(
-      dashboard.masterPassword!.toString(),
+      statusPage.masterPassword!.toString(),
     );
     expect(serializedCookieArguments).not.toContain(
-      dashboard.masterPasswordSalt,
+      statusPage.masterPasswordSalt,
     );
   });
 
   it("accepts a legacy unsalted SHA-256 password and upgrades it to scrypt", async () => {
-    dashboard.masterPassword = new HashedString(
+    statusPage.masterPassword = new HashedString(
       await HashedString.hashValue(password, EncryptionSecret),
       true,
     );
-    delete dashboard.masterPasswordSalt;
+    delete statusPage.masterPasswordSalt;
 
     const updateSpy: ReturnType<typeof jest.spyOn> = jest
-      .spyOn(DashboardService, "updateColumnsByIdWithoutHooks")
+      .spyOn(StatusPageService, "updateColumnsByIdWithoutHooks")
       .mockResolvedValue(undefined);
 
     await mockRouter
-      .match("post", "/dashboard/master-password/:dashboardId")
+      .match("post", "/status-page/master-password/:statusPageId")
       .handlerFunction(mockRequest, mockResponse, nextFunction);
 
     expect(nextFunction).not.toHaveBeenCalled();
@@ -352,7 +291,7 @@ describe("DashboardAPI master password", () => {
       skipUpdateDateColumn?: boolean;
     };
 
-    expect(update.id.toString()).toBe(dashboardId.toString());
+    expect(update.id.toString()).toBe(statusPageId.toString());
     expect(update.skipUpdateDateColumn).toBe(true);
     expect(update.data["masterPassword"]).toEqual(
       expect.stringMatching(/^scrypt\$/),
@@ -361,7 +300,7 @@ describe("DashboardAPI master password", () => {
       expect.stringMatching(/^[0-9a-f]{64}$/),
     );
     expect(update.expectedData).toEqual({
-      masterPassword: dashboard.masterPassword!.toString(),
+      masterPassword: statusPage.masterPassword!.toString(),
       masterPasswordSalt: null,
     });
     await expect(
@@ -374,19 +313,19 @@ describe("DashboardAPI master password", () => {
   });
 
   it("does not upgrade a legacy hash when the password is wrong", async () => {
-    dashboard.masterPassword = new HashedString(
+    statusPage.masterPassword = new HashedString(
       await HashedString.hashValue(password, EncryptionSecret),
       true,
     );
-    delete dashboard.masterPasswordSalt;
+    delete statusPage.masterPasswordSalt;
     mockRequest.body["password"] = "incorrect password";
 
     const updateSpy: ReturnType<typeof jest.spyOn> = jest
-      .spyOn(DashboardService, "updateColumnsByIdWithoutHooks")
+      .spyOn(StatusPageService, "updateColumnsByIdWithoutHooks")
       .mockResolvedValue(undefined);
 
     await mockRouter
-      .match("post", "/dashboard/master-password/:dashboardId")
+      .match("post", "/status-page/master-password/:statusPageId")
       .handlerFunction(mockRequest, mockResponse, nextFunction);
 
     expect(nextFunction).toHaveBeenCalledTimes(1);

--- a/Common/Tests/Server/Services/AddMasterPasswordSaltMigration.test.ts
+++ b/Common/Tests/Server/Services/AddMasterPasswordSaltMigration.test.ts
@@ -1,0 +1,280 @@
+import { AddMasterPasswordSalt1786400000000 } from "../../../Server/Infrastructure/Postgres/SchemaMigrations/1786400000000-AddMasterPasswordSalt";
+import SchemaMigrations from "../../../Server/Infrastructure/Postgres/SchemaMigrations/Index";
+import { describe, expect, test } from "@jest/globals";
+import { QueryRunner } from "typeorm";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Dashboard and status-page master passwords are upgraded from a legacy
+ * unsalted digest to salted scrypt after this migration runs. The salt column
+ * therefore has two unusual requirements:
+ *
+ *   - it must start nullable, because existing hashes have no salt until their
+ *     next successful verification; and
+ *   - it must not be removed while any scrypt hash remains, because a scrypt
+ *     hash cannot be verified without its per-row salt.
+ *
+ * These tests pin that SQL contract without requiring Postgres. In particular,
+ * the rollback tests model each table independently so a future edit cannot
+ * check one table, drop a column, and only then discover that the other table
+ * still contains scrypt credentials.
+ */
+
+const MIGRATION_TIMESTAMP: number = 1786400000000;
+const MIGRATION_FILENAME: string = "1786400000000-AddMasterPasswordSalt.ts";
+const DROP_COLUMN_PATTERN: RegExp = /\bDROP COLUMN\b/i;
+const SELECT_EXISTS_PATTERN: RegExp = /^SELECT EXISTS/i;
+const MIGRATION_PATH: string = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "Server",
+  "Infrastructure",
+  "Postgres",
+  "SchemaMigrations",
+  MIGRATION_FILENAME,
+);
+
+type TableWithMasterPassword = "Dashboard" | "StatusPage";
+
+type ExistingScryptRows = Record<TableWithMasterPassword, boolean>;
+
+const UNSAFE_ROLLBACK_CASES: Array<[string, ExistingScryptRows]> = [
+  ["Dashboard", { Dashboard: true, StatusPage: false }],
+  ["StatusPage", { Dashboard: false, StatusPage: true }],
+  ["both tables", { Dashboard: true, StatusPage: true }],
+];
+
+type MakeQueryRunnerResult = {
+  runner: QueryRunner;
+  statements: Array<string>;
+};
+
+const makeQueryRunner: (
+  existingScryptRows?: ExistingScryptRows,
+) => MakeQueryRunnerResult = (
+  existingScryptRows: ExistingScryptRows = {
+    Dashboard: false,
+    StatusPage: false,
+  },
+): MakeQueryRunnerResult => {
+  const statements: Array<string> = [];
+
+  const query: (...args: Array<unknown>) => Promise<unknown> = (
+    ...args: Array<unknown>
+  ): Promise<unknown> => {
+    const statement: string = String(args[0]);
+    statements.push(statement);
+
+    for (const table of ["Dashboard", "StatusPage"] as const) {
+      if (statement.includes(`FROM "${table}"`)) {
+        return Promise.resolve([{ exists: existingScryptRows[table] }]);
+      }
+    }
+
+    return Promise.resolve(undefined);
+  };
+
+  return {
+    runner: { query } as unknown as QueryRunner,
+    statements,
+  };
+};
+
+const dropsFrom: (statements: Array<string>) => Array<string> = (
+  statements: Array<string>,
+): Array<string> => {
+  return statements.filter((statement: string) => {
+    return DROP_COLUMN_PATTERN.test(statement);
+  });
+};
+
+const optionalTrailingTimestampFrom: (value: string) => number | null = (
+  value: string,
+): number | null => {
+  const timestamp: string | undefined = value.match(/(\d+)(?:\.ts)?$/)?.[1];
+
+  return timestamp ? Number(timestamp) : null;
+};
+
+const timestampFrom: (value: string) => number = (value: string): number => {
+  const timestamp: number | null = optionalTrailingTimestampFrom(value);
+
+  if (timestamp === null) {
+    throw new Error(`Expected a trailing migration timestamp in: ${value}`);
+  }
+
+  return timestamp;
+};
+
+const timestampFromFilename: (value: string) => number = (
+  value: string,
+): number => {
+  const match: RegExpMatchArray | null = value.match(/^(\d+)-/);
+
+  if (!match?.[1]) {
+    throw new Error(`Expected a leading migration timestamp in: ${value}`);
+  }
+
+  return Number(match[1]);
+};
+
+describe("AddMasterPasswordSalt1786400000000 - up SQL contract", () => {
+  test("adds only the dashboard and status-page salt columns", async () => {
+    const { runner, statements } = makeQueryRunner();
+
+    await new AddMasterPasswordSalt1786400000000().up(runner);
+
+    expect(statements).toEqual([
+      `ALTER TABLE "StatusPage" ADD "masterPasswordSalt" character varying(100)`,
+      `ALTER TABLE "Dashboard" ADD "masterPasswordSalt" character varying(100)`,
+    ]);
+  });
+
+  test("keeps both columns nullable and does not backfill a fake salt", async () => {
+    const { runner, statements } = makeQueryRunner();
+
+    await new AddMasterPasswordSalt1786400000000().up(runner);
+
+    expect(statements).toHaveLength(2);
+
+    for (const statement of statements) {
+      expect(statement).toMatch(
+        /^ALTER TABLE "(?:Dashboard|StatusPage)" ADD "masterPasswordSalt" character varying\(\d+\)$/,
+      );
+      expect(statement).not.toMatch(/NOT NULL/i);
+      expect(statement).not.toMatch(/DEFAULT/i);
+      expect(statement).not.toMatch(/\bUPDATE\b/i);
+      expect(statement).not.toMatch(/\bINSERT\b/i);
+    }
+  });
+
+  test("allocates enough space for the generated 64-character salts", async () => {
+    const { runner, statements } = makeQueryRunner();
+
+    await new AddMasterPasswordSalt1786400000000().up(runner);
+
+    for (const statement of statements) {
+      const width: RegExpMatchArray | null = statement.match(
+        /character varying\((\d+)\)/,
+      );
+
+      expect(width).not.toBeNull();
+      expect(Number(width?.[1])).toBeGreaterThanOrEqual(64);
+    }
+  });
+});
+
+describe("AddMasterPasswordSalt1786400000000 - safe rollback", () => {
+  test("checks both master-password tables before the first DROP", async () => {
+    const { runner, statements } = makeQueryRunner();
+
+    await new AddMasterPasswordSalt1786400000000().down(runner);
+
+    const firstDropIndex: number = statements.findIndex((statement: string) => {
+      return DROP_COLUMN_PATTERN.test(statement);
+    });
+    const dashboardCheckIndex: number = statements.findIndex(
+      (statement: string) => {
+        return (
+          statement.includes(`FROM "Dashboard"`) &&
+          statement.includes(`"masterPassword" LIKE 'scrypt$%'`)
+        );
+      },
+    );
+    const statusPageCheckIndex: number = statements.findIndex(
+      (statement: string) => {
+        return (
+          statement.includes(`FROM "StatusPage"`) &&
+          statement.includes(`"masterPassword" LIKE 'scrypt$%'`)
+        );
+      },
+    );
+
+    expect(dashboardCheckIndex).toBeGreaterThanOrEqual(0);
+    expect(statusPageCheckIndex).toBeGreaterThanOrEqual(0);
+    expect(firstDropIndex).toBeGreaterThan(dashboardCheckIndex);
+    expect(firstDropIndex).toBeGreaterThan(statusPageCheckIndex);
+  });
+
+  test.each(UNSAFE_ROLLBACK_CASES)(
+    "refuses to drop either salt when %s still has a scrypt hash",
+    async (_scenario: string, existingScryptRows: ExistingScryptRows) => {
+      const { runner, statements } = makeQueryRunner(existingScryptRows);
+
+      await expect(
+        new AddMasterPasswordSalt1786400000000().down(runner),
+      ).rejects.toThrow(
+        "Cannot remove master-password salt columns while scrypt master-password hashes exist.",
+      );
+
+      expect(dropsFrom(statements)).toEqual([]);
+      expect(
+        statements.filter((statement: string) => {
+          return SELECT_EXISTS_PATTERN.test(statement);
+        }),
+      ).toHaveLength(2);
+    },
+  );
+
+  test("drops both exact salt columns when neither table has scrypt hashes", async () => {
+    const { runner, statements } = makeQueryRunner();
+
+    await new AddMasterPasswordSalt1786400000000().down(runner);
+
+    expect(dropsFrom(statements)).toEqual([
+      `ALTER TABLE "Dashboard" DROP COLUMN "masterPasswordSalt"`,
+      `ALTER TABLE "StatusPage" DROP COLUMN "masterPasswordSalt"`,
+    ]);
+  });
+});
+
+describe("AddMasterPasswordSalt1786400000000 - identity and registration", () => {
+  test("filename, exported class, and TypeORM name carry one timestamp", () => {
+    const migration: AddMasterPasswordSalt1786400000000 =
+      new AddMasterPasswordSalt1786400000000();
+
+    expect(fs.existsSync(MIGRATION_PATH)).toBe(true);
+    expect(path.basename(MIGRATION_PATH)).toBe(MIGRATION_FILENAME);
+    expect(timestampFromFilename(MIGRATION_FILENAME)).toBe(MIGRATION_TIMESTAMP);
+    expect(timestampFrom(AddMasterPasswordSalt1786400000000.name)).toBe(
+      MIGRATION_TIMESTAMP,
+    );
+    expect(timestampFrom(migration.name)).toBe(MIGRATION_TIMESTAMP);
+    expect(migration.name).toBe("AddMasterPasswordSalt1786400000000");
+  });
+
+  test("is registered exactly once and is the final migration", () => {
+    const occurrences: number = SchemaMigrations.filter(
+      (migration: unknown) => {
+        return migration === AddMasterPasswordSalt1786400000000;
+      },
+    ).length;
+
+    expect(occurrences).toBe(1);
+    expect(SchemaMigrations[SchemaMigrations.length - 1]).toBe(
+      AddMasterPasswordSalt1786400000000,
+    );
+  });
+
+  test("has a timestamp strictly after every previously registered migration", () => {
+    const migrationIndex: number = SchemaMigrations.indexOf(
+      AddMasterPasswordSalt1786400000000,
+    );
+
+    expect(migrationIndex).toBe(SchemaMigrations.length - 1);
+
+    for (const earlierMigration of SchemaMigrations.slice(0, migrationIndex)) {
+      const earlierTimestamp: number | null = optionalTrailingTimestampFrom(
+        earlierMigration.name,
+      );
+
+      // The original `InitialMigration` is the sole pre-timestamp convention.
+      if (earlierTimestamp !== null) {
+        expect(earlierTimestamp).toBeLessThan(MIGRATION_TIMESTAMP);
+      }
+    }
+  });
+});

--- a/Common/Tests/Server/Services/DatabaseServicePerUserPasswordSalt.test.ts
+++ b/Common/Tests/Server/Services/DatabaseServicePerUserPasswordSalt.test.ts
@@ -1,13 +1,13 @@
 import UserService from "../../../Server/Services/UserService";
 import StatusPagePrivateUserService from "../../../Server/Services/StatusPagePrivateUserService";
-import DashboardService from "../../../Server/Services/DashboardService";
+import UserSessionService from "../../../Server/Services/UserSessionService";
 import ColumnPermissions from "../../../Server/Types/Database/Permissions/ColumnPermission";
 import DatabaseRequestType from "../../../Server/Types/BaseDatabase/DatabaseRequestType";
 import PasswordHash from "../../../Server/Utils/PasswordHash";
 import { EncryptionSecret } from "../../../Server/EnvironmentConfig";
 import User from "../../../Models/DatabaseModels/User";
 import StatusPagePrivateUser from "../../../Models/DatabaseModels/StatusPagePrivateUser";
-import Dashboard from "../../../Models/DatabaseModels/Dashboard";
+import UserSession from "../../../Models/DatabaseModels/UserSession";
 import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import { TableColumnMetadata } from "../../../Types/Database/TableColumn";
 import TableColumnType from "../../../Types/Database/TableColumnType";
@@ -33,8 +33,8 @@ import { afterEach, describe, expect, jest, test } from "@jest/globals";
  *   - a salt column that forgets `computed: true` breaks every non-root
  *     create of a row carrying a password, because the create permission
  *     check runs AFTER hashing and would reject a column nobody may write;
- *   - a hashed column with no declared salt column (session refresh tokens,
- *     master passwords) must keep hashing exactly as it always did;
+ *   - a hashed column with no declared salt column (session refresh tokens)
+ *     must keep hashing exactly as it always did;
  *   - an update that does not touch the password must not touch the salt,
  *     or every password in the affected rows stops verifying.
  *
@@ -355,56 +355,57 @@ describe("Update path — sanitizeCreateOrUpdate mints a per-record salt", () =>
   });
 });
 
-describe("Hashed columns that declare no salt column are untouched", () => {
-  test("a dashboard master password still uses the legacy unsalted digest", async () => {
-    /*
-     * Dashboard.masterPassword is `hashed: true` with no hashSaltColumn — a
-     * shared secret, not a per-user credential. Every master password
-     * already stored has to keep verifying, so this digest must not move.
-     */
-    const dashboard: Dashboard = new Dashboard();
-    dashboard.masterPassword = new HashedString("master-password");
+describe("High-entropy hashed columns remain searchable", () => {
+  test("a session refresh token keeps the fast deterministic SHA-256 digest", async () => {
+    const data: JSONObject = (await (
+      UserSessionService as unknown as {
+        sanitizeCreateOrUpdate: SanitizeFunction;
+      }
+    ).sanitizeCreateOrUpdate(
+      {
+        refreshToken: new HashedString("server-generated-refresh-token"),
+      },
+      { isRoot: true },
+    )) as JSONObject;
 
-    await (
-      DashboardService as unknown as { hash: HashFunction<Dashboard> }
-    ).hash(dashboard);
-
-    expect(dashboard.masterPassword!.toString()).toBe(
+    expect(data["refreshToken"]).toBe(
       CryptoJS.SHA256(
-        EncryptionSecret.toString() + "master-password",
+        EncryptionSecret.toString() + "server-generated-refresh-token",
       ).toString(),
     );
   });
 
-  test("no stray salt column is invented for it", async () => {
-    const dashboard: Dashboard = new Dashboard();
-    dashboard.masterPassword = new HashedString("master-password");
-
-    await (
-      DashboardService as unknown as { hash: HashFunction<Dashboard> }
-    ).hash(dashboard);
-
-    expect(
-      new Dashboard().getTableColumnMetadata("masterPassword").hashSaltColumn,
-    ).toBeUndefined();
-    expect(
-      (dashboard as unknown as JSONObject)["passwordSalt"],
-    ).toBeUndefined();
-  });
-
-  test("a bare string is still allowed on an unsalted hashed column", async () => {
-    // The desync guard is scoped to salted columns only.
+  test("refresh tokens do not declare or invent a password salt", async () => {
     const data: JSONObject = (await (
-      DashboardService as unknown as {
+      UserSessionService as unknown as {
         sanitizeCreateOrUpdate: SanitizeFunction;
       }
     ).sanitizeCreateOrUpdate(
-      { masterPassword: "a-raw-digest" },
+      {
+        refreshToken: new HashedString("server-generated-refresh-token"),
+      },
+      { isRoot: true },
+    )) as JSONObject;
+
+    expect(
+      new UserSession().getTableColumnMetadata("refreshToken").hashSaltColumn,
+    ).toBeUndefined();
+    expect(data["refreshTokenSalt"]).toBeUndefined();
+  });
+
+  test("a pre-hashed refresh-token digest remains accepted on update", async () => {
+    const data: JSONObject = (await (
+      UserSessionService as unknown as {
+        sanitizeCreateOrUpdate: SanitizeFunction;
+      }
+    ).sanitizeCreateOrUpdate(
+      { refreshToken: "a-raw-digest" },
       { isRoot: true },
       true,
     )) as JSONObject;
 
-    expect(data["masterPassword"]).toBe("a-raw-digest");
+    expect(data["refreshToken"]).toBe("a-raw-digest");
+    expect(data["refreshTokenSalt"]).toBeUndefined();
   });
 });
 
@@ -415,6 +416,7 @@ describe("Hashed columns that declare no salt column are untouched", () => {
 type UpdateColumnsInput = {
   id: ObjectID;
   data: JSONObject;
+  expectedData?: JSONObject;
   skipUpdateDateColumn?: boolean;
 };
 
@@ -597,6 +599,10 @@ describe("verifyHashedColumnValue — transparent upgrade of legacy hashes", () 
 
     expect(write.id.toString()).toBe(user._id);
     expect(write.data["passwordSalt"]).toMatch(/^[0-9a-f]{64}$/);
+    expect(write.expectedData).toEqual({
+      password: user.password!.toString(),
+      passwordSalt: null,
+    });
 
     // The written hash verifies under the written salt.
     await expect(
@@ -726,6 +732,10 @@ describe("verifyHashedColumnValue — transparent upgrade of legacy hashes", () 
 
     expect(captured).toHaveLength(1);
     expect(captured[0]!.data["password"]).toMatch(/^scrypt\$/);
+    expect(captured[0]!.expectedData).toEqual({
+      password: user.password!.toString(),
+      passwordSalt: salt,
+    });
     // A brand new salt, not the interim one it came in with.
     expect(captured[0]!.data["passwordSalt"]).not.toBe(salt);
   });

--- a/Common/Tests/Server/Services/DatabaseServiceUpdateColumnsWithoutHooks.test.ts
+++ b/Common/Tests/Server/Services/DatabaseServiceUpdateColumnsWithoutHooks.test.ts
@@ -125,4 +125,58 @@ describe("DatabaseService.updateColumnsByIdWithoutHooks", () => {
       APPLICATION_ID.toString(),
     );
   });
+
+  it("adds null-safe compare-and-set guards for expected values", async () => {
+    const newValue: Date = new Date("2026-08-07T10:00:00.000Z");
+    const oldValue: Date = new Date("2026-08-07T09:00:00.000Z");
+
+    await service.updateColumnsByIdWithoutHooks({
+      id: APPLICATION_ID,
+      data: { lastSeenAt: newValue },
+      expectedData: {
+        sessionReplayLastChunkReceivedAt: oldValue,
+        sessionReplayBudgetExceededAt: null,
+      },
+      skipUpdateDateColumn: true,
+    });
+
+    expect(captured).toEqual([
+      {
+        sql:
+          `UPDATE "RumApplication" SET "lastSeenAt" = $1 ` +
+          `WHERE "_id" = $2 ` +
+          `AND "sessionReplayLastChunkReceivedAt" IS NOT DISTINCT FROM $3 ` +
+          `AND "sessionReplayBudgetExceededAt" IS NOT DISTINCT FROM $4`,
+        params: [newValue, APPLICATION_ID.toString(), oldValue, null],
+      },
+    ]);
+  });
+
+  it("rejects unknown compare-and-set columns before issuing SQL", async () => {
+    await expect(
+      service.updateColumnsByIdWithoutHooks({
+        id: APPLICATION_ID,
+        data: { lastSeenAt: new Date() },
+        expectedData: { notAColumn: "value" } as never,
+      }),
+    ).rejects.toThrow('unknown expected column "notAColumn"');
+
+    expect(captured).toHaveLength(0);
+  });
+
+  it("rejects SQL expressions in compare-and-set values", async () => {
+    await expect(
+      service.updateColumnsByIdWithoutHooks({
+        id: APPLICATION_ID,
+        data: { lastSeenAt: new Date() },
+        expectedData: {
+          sessionReplayLastChunkReceivedAt: (() => {
+            return "NOW()";
+          }) as never,
+        },
+      }),
+    ).rejects.toThrow("SQL-expression expected values are not supported");
+
+    expect(captured).toHaveLength(0);
+  });
 });

--- a/Common/Tests/Server/Services/MasterPasswordScrypt.test.ts
+++ b/Common/Tests/Server/Services/MasterPasswordScrypt.test.ts
@@ -1,0 +1,548 @@
+import Dashboard from "../../../Models/DatabaseModels/Dashboard";
+import StatusPage from "../../../Models/DatabaseModels/StatusPage";
+import { EncryptionSecret } from "../../../Server/EnvironmentConfig";
+import DashboardService from "../../../Server/Services/DashboardService";
+import StatusPageService from "../../../Server/Services/StatusPageService";
+import DatabaseRequestType from "../../../Server/Types/BaseDatabase/DatabaseRequestType";
+import ColumnPermissions from "../../../Server/Types/Database/Permissions/ColumnPermission";
+import PasswordHash from "../../../Server/Utils/PasswordHash";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import ColumnLength from "../../../Types/Database/ColumnLength";
+import { TableColumnMetadata } from "../../../Types/Database/TableColumn";
+import TableColumnType from "../../../Types/Database/TableColumnType";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import HashedString from "../../../Types/HashedString";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import CryptoJS from "crypto-js";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Dashboard and status-page master passwords are human-chosen credentials,
+ * just like account passwords. They therefore need the same deliberately
+ * expensive password KDF, a unique salt per protected resource, and an
+ * opportunistic upgrade path for the SHA-256 digests written by older
+ * versions.
+ *
+ * These tests exercise the shared DatabaseService write and verification
+ * pipeline directly. No Postgres is needed: upgrade writes are captured by a
+ * stub so the hash/salt pair can be checked as one atomic payload.
+ */
+
+type ProtectedResource = Dashboard | StatusPage;
+
+type HashFunction<T> = (data: T) => Promise<T>;
+
+type SanitizeFunction = (
+  data: unknown,
+  props: DatabaseCommonInteractionProps,
+  isUpdate?: boolean,
+) => Promise<JSONObject>;
+
+type UpdateColumnsInput = {
+  id: ObjectID;
+  data: JSONObject;
+  expectedData?: JSONObject;
+  skipUpdateDateColumn?: boolean;
+};
+
+type ResourceService = {
+  hash: HashFunction<ProtectedResource>;
+  sanitizeCreateOrUpdate: SanitizeFunction;
+  verifyHashedColumnValue: (data: {
+    item: ProtectedResource;
+    columnName: string;
+    plainValue: string;
+  }) => Promise<boolean>;
+  updateColumnsByIdWithoutHooks: (input: UpdateColumnsInput) => Promise<void>;
+};
+
+const dashboardService: ResourceService =
+  DashboardService as unknown as ResourceService;
+const statusPageService: ResourceService =
+  StatusPageService as unknown as ResourceService;
+
+type ResourceCase = {
+  name: string;
+  model: Dashboard | StatusPage;
+  service: ResourceService;
+};
+
+type ResourceTestCase = {
+  name: string;
+  resource: ProtectedResource;
+  service: ResourceService;
+};
+
+type ResourcePairTestCase = {
+  name: string;
+  first: ProtectedResource;
+  second: ProtectedResource;
+  service: ResourceService;
+};
+
+const resourceCases: Array<ResourceCase> = [
+  {
+    name: "Dashboard",
+    model: new Dashboard(),
+    service: dashboardService,
+  },
+  {
+    name: "StatusPage",
+    model: new StatusPage(),
+    service: statusPageService,
+  },
+];
+
+const setPlainMasterPassword: (
+  resource: ProtectedResource,
+  password: string,
+) => void = (resource: ProtectedResource, password: string): void => {
+  resource.masterPassword = new HashedString(password);
+};
+
+const setStoredMasterPassword: (
+  resource: ProtectedResource,
+  hash: string,
+  salt?: string,
+) => void = (
+  resource: ProtectedResource,
+  hash: string,
+  salt?: string,
+): void => {
+  resource._id = ObjectID.generate().toString();
+  resource.masterPassword = new HashedString(hash, true);
+  resource.masterPasswordSalt = salt;
+};
+
+const makeCurrentResource: (data: {
+  resource: ProtectedResource;
+  password: string;
+}) => Promise<ProtectedResource> = async (data: {
+  resource: ProtectedResource;
+  password: string;
+}): Promise<ProtectedResource> => {
+  const salt: string = PasswordHash.generateSalt();
+
+  setStoredMasterPassword(
+    data.resource,
+    await PasswordHash.hash({
+      plainValue: data.password,
+      salt,
+    }),
+    salt,
+  );
+
+  return data.resource;
+};
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("Master-password model metadata", () => {
+  test.each(resourceCases)(
+    "$name.masterPassword declares masterPasswordSalt",
+    ({ model }: ResourceCase) => {
+      const metadata: TableColumnMetadata =
+        model.getTableColumnMetadata("masterPassword");
+
+      expect(metadata.hashed).toBe(true);
+      expect(metadata.hashSaltColumn).toBe("masterPasswordSalt");
+      expect(model.hasColumn("masterPasswordSalt")).toBe(true);
+    },
+  );
+
+  test.each(resourceCases)(
+    "$name.masterPasswordSalt is server-computed and API-inaccessible",
+    ({ model }: ResourceCase) => {
+      const metadata: TableColumnMetadata =
+        model.getTableColumnMetadata("masterPasswordSalt");
+      const accessControl: {
+        create?: Array<unknown>;
+        read?: Array<unknown>;
+        update?: Array<unknown>;
+      } = model.getColumnAccessControlFor("masterPasswordSalt") as {
+        create?: Array<unknown>;
+        read?: Array<unknown>;
+        update?: Array<unknown>;
+      };
+
+      expect(metadata.computed).toBe(true);
+      expect(metadata.type).toBe(TableColumnType.ShortText);
+      expect(accessControl.create).toEqual([]);
+      expect(accessControl.read).toEqual([]);
+      expect(accessControl.update).toEqual([]);
+    },
+  );
+
+  test("generated salts fit the declared database column", () => {
+    expect(PasswordHash.generateSalt()).toMatch(/^[0-9a-f]{64}$/);
+    expect(PasswordHash.generateSalt().length).toBeLessThanOrEqual(
+      ColumnLength.ShortText,
+    );
+  });
+
+  test.each(resourceCases)(
+    "$name computed salt survives create permission validation",
+    ({ model }: ResourceCase) => {
+      model.masterPasswordSalt = PasswordHash.generateSalt();
+
+      expect(() => {
+        ColumnPermissions.checkDataColumnPermissions(
+          model instanceof Dashboard ? Dashboard : StatusPage,
+          model,
+          {} as DatabaseCommonInteractionProps,
+          DatabaseRequestType.Create,
+        );
+      }).not.toThrow();
+    },
+  );
+
+  test.each(resourceCases)(
+    "$name rejects a caller-supplied salt on update",
+    ({ model }: ResourceCase) => {
+      model.masterPasswordSalt = PasswordHash.generateSalt();
+
+      expect(() => {
+        ColumnPermissions.checkDataColumnPermissions(
+          model instanceof Dashboard ? Dashboard : StatusPage,
+          model,
+          {} as DatabaseCommonInteractionProps,
+          DatabaseRequestType.Update,
+        );
+      }).toThrow("not allowed to update on masterPasswordSalt");
+    },
+  );
+});
+
+describe("Master-password create path", () => {
+  test.each([
+    {
+      name: "Dashboard",
+      resource: new Dashboard() as ProtectedResource,
+      service: dashboardService,
+    },
+    {
+      name: "StatusPage",
+      resource: new StatusPage() as ProtectedResource,
+      service: statusPageService,
+    },
+  ])(
+    "$name writes a salted scrypt hash instead of SHA-256",
+    async ({ resource, service }: ResourceTestCase) => {
+      setPlainMasterPassword(resource, "shared master password");
+
+      await service.hash(resource);
+
+      expect(resource.masterPasswordSalt).toMatch(/^[0-9a-f]{64}$/);
+      expect(resource.masterPassword!.toString()).toMatch(
+        /^scrypt\$N=\d+,r=\d+,p=\d+\$[0-9a-f]{64}$/,
+      );
+      expect(resource.masterPassword!.toString()).not.toBe(
+        CryptoJS.SHA256(
+          EncryptionSecret.toString() + "shared master password",
+        ).toString(),
+      );
+      await expect(
+        PasswordHash.verify({
+          plainValue: "shared master password",
+          storedValue: resource.masterPassword!.toString(),
+          salt: resource.masterPasswordSalt,
+        }),
+      ).resolves.toBe(true);
+    },
+  );
+
+  test.each([
+    {
+      name: "Dashboard",
+      first: new Dashboard() as ProtectedResource,
+      second: new Dashboard() as ProtectedResource,
+      service: dashboardService,
+    },
+    {
+      name: "StatusPage",
+      first: new StatusPage() as ProtectedResource,
+      second: new StatusPage() as ProtectedResource,
+      service: statusPageService,
+    },
+  ])(
+    "two $name resources with the same password get unique salts and hashes",
+    async ({ first, second, service }: ResourcePairTestCase) => {
+      setPlainMasterPassword(first, "same password");
+      setPlainMasterPassword(second, "same password");
+
+      await service.hash(first);
+      await service.hash(second);
+
+      expect(first.masterPasswordSalt).not.toBe(second.masterPasswordSalt);
+      expect(first.masterPassword!.toString()).not.toBe(
+        second.masterPassword!.toString(),
+      );
+    },
+  );
+});
+
+describe("Master-password update path", () => {
+  test.each(resourceCases)(
+    "$name password updates write a new scrypt hash and salt together",
+    async ({ service }: ResourceCase) => {
+      const result: JSONObject = await service.sanitizeCreateOrUpdate(
+        { masterPassword: new HashedString("replacement password") },
+        { isRoot: true },
+        true,
+      );
+
+      expect(result["masterPasswordSalt"]).toMatch(/^[0-9a-f]{64}$/);
+      expect(result["masterPassword"]).toMatch(/^scrypt\$/);
+      await expect(
+        PasswordHash.verify({
+          plainValue: "replacement password",
+          storedValue: result["masterPassword"] as string,
+          salt: result["masterPasswordSalt"] as string,
+        }),
+      ).resolves.toBe(true);
+    },
+  );
+
+  test.each(resourceCases)(
+    "$name unrelated updates do not rotate the master-password salt",
+    async ({ service }: ResourceCase) => {
+      const result: JSONObject = await service.sanitizeCreateOrUpdate(
+        { name: "Renamed resource" },
+        { isRoot: true },
+        true,
+      );
+
+      expect(result["masterPasswordSalt"]).toBeUndefined();
+      expect(Object.keys(result)).not.toContain("masterPasswordSalt");
+    },
+  );
+
+  test.each(resourceCases)(
+    "$name refuses a bare pre-hashed string that could desynchronise hash and salt",
+    async ({ service }: ResourceCase) => {
+      await expect(
+        service.sanitizeCreateOrUpdate(
+          { masterPassword: "pre-hashed-value" },
+          { isRoot: true },
+          true,
+        ),
+      ).rejects.toThrow("must be supplied as a HashedString");
+    },
+  );
+});
+
+describe("Master-password verification", () => {
+  test.each([
+    {
+      name: "Dashboard",
+      resource: new Dashboard() as ProtectedResource,
+      service: dashboardService,
+    },
+    {
+      name: "StatusPage",
+      resource: new StatusPage() as ProtectedResource,
+      service: statusPageService,
+    },
+  ])(
+    "$name accepts the right scrypt password and rejects the wrong one without rewriting",
+    async ({ resource, service }: ResourceTestCase) => {
+      await makeCurrentResource({ resource, password: "correct password" });
+      const update: jest.SpiedFunction<
+        ResourceService["updateColumnsByIdWithoutHooks"]
+      > = jest
+        .spyOn(service, "updateColumnsByIdWithoutHooks")
+        .mockResolvedValue(undefined);
+
+      await expect(
+        service.verifyHashedColumnValue({
+          item: resource,
+          columnName: "masterPassword",
+          plainValue: "correct password",
+        }),
+      ).resolves.toBe(true);
+      await expect(
+        service.verifyHashedColumnValue({
+          item: resource,
+          columnName: "masterPassword",
+          plainValue: "wrong password",
+        }),
+      ).resolves.toBe(false);
+
+      expect(update).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    {
+      name: "Dashboard",
+      resource: new Dashboard() as ProtectedResource,
+      service: dashboardService,
+    },
+    {
+      name: "StatusPage",
+      resource: new StatusPage() as ProtectedResource,
+      service: statusPageService,
+    },
+  ])(
+    "$name transparently upgrades a valid legacy SHA-256 password",
+    async ({ resource, service }: ResourceTestCase) => {
+      const legacyHash: string = await HashedString.hashValue(
+        "legacy password",
+        EncryptionSecret,
+      );
+      setStoredMasterPassword(resource, legacyHash);
+
+      const update: jest.SpiedFunction<
+        ResourceService["updateColumnsByIdWithoutHooks"]
+      > = jest
+        .spyOn(service, "updateColumnsByIdWithoutHooks")
+        .mockResolvedValue(undefined);
+
+      await expect(
+        service.verifyHashedColumnValue({
+          item: resource,
+          columnName: "masterPassword",
+          plainValue: "legacy password",
+        }),
+      ).resolves.toBe(true);
+
+      expect(update).toHaveBeenCalledTimes(1);
+      const write: UpdateColumnsInput = update.mock.calls[0]![0];
+
+      expect(write.id.toString()).toBe(resource._id);
+      expect(write.skipUpdateDateColumn).toBe(true);
+      expect(write.expectedData).toEqual({
+        masterPassword: legacyHash,
+        masterPasswordSalt: null,
+      });
+      expect(write.data["masterPasswordSalt"]).toMatch(/^[0-9a-f]{64}$/);
+      expect(write.data["masterPassword"]).toMatch(/^scrypt\$/);
+      await expect(
+        PasswordHash.verify({
+          plainValue: "legacy password",
+          storedValue: write.data["masterPassword"] as string,
+          salt: write.data["masterPasswordSalt"] as string,
+        }),
+      ).resolves.toBe(true);
+    },
+  );
+
+  test.each([
+    {
+      name: "Dashboard",
+      resource: new Dashboard() as ProtectedResource,
+      service: dashboardService,
+    },
+    {
+      name: "StatusPage",
+      resource: new StatusPage() as ProtectedResource,
+      service: statusPageService,
+    },
+  ])(
+    "$name repairs a bare legacy hash left beside a stale salt by an old pod",
+    async ({ resource, service }: ResourceTestCase) => {
+      const legacyHash: string = await HashedString.hashValue(
+        "rolling password",
+        EncryptionSecret,
+      );
+      const staleSalt: string = PasswordHash.generateSalt();
+      setStoredMasterPassword(resource, legacyHash, staleSalt);
+
+      const update: jest.SpiedFunction<
+        ResourceService["updateColumnsByIdWithoutHooks"]
+      > = jest
+        .spyOn(service, "updateColumnsByIdWithoutHooks")
+        .mockResolvedValue(undefined);
+
+      await expect(
+        service.verifyHashedColumnValue({
+          item: resource,
+          columnName: "masterPassword",
+          plainValue: "rolling password",
+        }),
+      ).resolves.toBe(true);
+
+      expect(update).toHaveBeenCalledTimes(1);
+      const write: UpdateColumnsInput = update.mock.calls[0]![0];
+
+      expect(write.expectedData).toEqual({
+        masterPassword: legacyHash,
+        masterPasswordSalt: staleSalt,
+      });
+      expect(write.data["masterPassword"]).toMatch(/^scrypt\$/);
+      expect(write.data["masterPasswordSalt"]).not.toBe(staleSalt);
+    },
+  );
+
+  test.each([
+    {
+      name: "Dashboard",
+      resource: new Dashboard() as ProtectedResource,
+      service: dashboardService,
+    },
+    {
+      name: "StatusPage",
+      resource: new StatusPage() as ProtectedResource,
+      service: statusPageService,
+    },
+  ])(
+    "$name never upgrades a legacy hash after a wrong password",
+    async ({ resource, service }: ResourceTestCase) => {
+      setStoredMasterPassword(
+        resource,
+        await HashedString.hashValue("legacy password", EncryptionSecret),
+      );
+
+      const update: jest.SpiedFunction<
+        ResourceService["updateColumnsByIdWithoutHooks"]
+      > = jest
+        .spyOn(service, "updateColumnsByIdWithoutHooks")
+        .mockResolvedValue(undefined);
+
+      await expect(
+        service.verifyHashedColumnValue({
+          item: resource,
+          columnName: "masterPassword",
+          plainValue: "wrong password",
+        }),
+      ).resolves.toBe(false);
+      expect(update).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    {
+      name: "Dashboard",
+      resource: new Dashboard() as ProtectedResource,
+      service: dashboardService,
+    },
+    {
+      name: "StatusPage",
+      resource: new StatusPage() as ProtectedResource,
+      service: statusPageService,
+    },
+  ])(
+    "$name fails closed when a scrypt hash is read without its salt",
+    async ({ resource, service }: ResourceTestCase) => {
+      const salt: string = PasswordHash.generateSalt();
+      setStoredMasterPassword(
+        resource,
+        await PasswordHash.hash({
+          plainValue: "correct password",
+          salt,
+        }),
+      );
+
+      await expect(
+        service.verifyHashedColumnValue({
+          item: resource,
+          columnName: "masterPassword",
+          plainValue: "correct password",
+        }),
+      ).rejects.toBeInstanceOf(BadDataException);
+    },
+  );
+});

--- a/Common/Tests/Server/Utils/PasswordHash.test.ts
+++ b/Common/Tests/Server/Utils/PasswordHash.test.ts
@@ -463,6 +463,36 @@ describe("PasswordHash.verify — the schemes that came before", () => {
       }),
     ).resolves.toBe(false);
   });
+
+  test("a bare legacy hash with a stale salt still verifies during a rolling deployment", async () => {
+    /*
+     * An old pod knows nothing about the salt column. If it changes a
+     * password after a new pod has already put a salt on the row, it writes
+     * the original bare digest and leaves that salt behind. New code must try
+     * the bare legacy scheme after the salted legacy scheme fails, then the
+     * caller upgrades the row to scrypt.
+     */
+    const legacy: string = await HashedString.hashValue(
+      "rolling-password",
+      EncryptionSecret,
+    );
+
+    await expect(
+      PasswordHash.verify({
+        plainValue: "rolling-password",
+        storedValue: legacy,
+        salt: SALT,
+      }),
+    ).resolves.toBe(true);
+
+    await expect(
+      PasswordHash.verify({
+        plainValue: "wrong-password",
+        storedValue: legacy,
+        salt: SALT,
+      }),
+    ).resolves.toBe(false);
+  });
 });
 
 describe("PasswordHash.verify — malformed stored values", () => {

--- a/Common/Types/HashedString.ts
+++ b/Common/Types/HashedString.ts
@@ -24,9 +24,10 @@ import { FindOperator } from "typeorm";
  *   salted    `SHA256("v2:" + salt + ":" + secret + ":" + value)`.
  *
  * Neither records its scheme in the digest — it is a bare hex SHA-256 either
- * way — so they are told apart by whether the row carries a salt. The "v2"
- * prefix and the separators exist for domain separation: without them a
- * crafted salt could make a salted input collide with an unsalted one.
+ * way — so callers normally select the scheme by whether the row carries a
+ * salt. PasswordHash also has a bare-hash fallback for rolling deployments,
+ * where an old pod can write the original scheme while leaving a newer salt
+ * behind. The "v2" prefix and separators exist for domain separation.
  */
 const SALTED_HASH_SCHEME_VERSION: string = "v2";
 


### PR DESCRIPTION
## What changed

- store dashboard and status-page master passwords with the shared peppered scrypt scheme and a random per-resource salt
- verify hashes through the constant-time password path and transparently upgrade legacy SHA-256 values after a successful unlock
- tolerate old pods leaving a bare legacy hash beside a newer salt during rolling deployments
- guard opportunistic rehashes with compare-and-set predicates so a concurrent password change cannot be overwritten
- add a generated Postgres migration with a rollback preflight that preserves salts whenever scrypt hashes exist
- reject non-string master-password request bodies before database lookup or verification

## Compatibility and rollout

Existing salt columns are nullable, so current SHA-256 rows continue to work. They are upgraded to scrypt only after the submitted password has been verified. New and changed master passwords use scrypt immediately.

The migration's `down()` checks both protected-resource tables before dropping either salt column and aborts if any scrypt hash remains, preventing an irreversible lockout.

## Validation

- `npm run fix` — passed
- `cd Common && npm run compile` — passed
- focused Jest coverage — **9 suites, 177 tests passed**
- `npm run generate-postgres-migration` — generated only the two intended nullable salt columns
- `npm run check-postgres-schema-drift` — the new migrations applied successfully and produced no master-password drift; the command still reports unrelated pre-existing drift in current `master` for AI fields on `Project`, `IncidentFeed`, and `AlertFeed`

The focused coverage includes create/update hashing, unique salts, current and legacy verification, transparent upgrades, wrong-password behavior, rolling-deployment compatibility, concurrent-write protection, API non-exposure, malformed inputs, exact migration registration, and safe/blocked rollback paths.