### PR TITLE
Show AI investigation status in incident header

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/AI/AIInvestigationHeaderStatus.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AI/AIInvestigationHeaderStatus.tsx
@@ -1,0 +1,130 @@
+import AIRunStatus from "Common/Types/AI/AIRunStatus";
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon from "Common/UI/Components/Icon/Icon";
+import React, { FunctionComponent, ReactElement } from "react";
+import {
+  AI_INVESTIGATION_PANEL_ID,
+  isActiveAIInvestigationStatus,
+} from "./AIInvestigationStatus";
+
+export interface ComponentProps {
+  status: AIRunStatus;
+  onViewProgress: () => void;
+}
+
+export interface LiveRegionProps {
+  status: AIRunStatus | null | undefined;
+}
+
+export const getAIInvestigationStatusCopy: (status: AIRunStatus) => {
+  title: string;
+  description: string;
+} = (
+  status: AIRunStatus,
+): {
+  title: string;
+  description: string;
+} => {
+  if (status === AIRunStatus.Running) {
+    return {
+      title: "AI is investigating",
+      description: "Reviewing telemetry and tracing the likely root cause.",
+    };
+  }
+
+  return {
+    title: "AI investigation queued",
+    description:
+      "Waiting for an AI worker. Telemetry review will begin automatically.",
+  };
+};
+
+export const AIInvestigationStatusLiveRegion: FunctionComponent<
+  LiveRegionProps
+> = (props: LiveRegionProps): ReactElement => {
+  let announcement: string = "";
+
+  if (isActiveAIInvestigationStatus(props.status)) {
+    const copy: { title: string; description: string } =
+      getAIInvestigationStatusCopy(props.status!);
+    announcement = `${copy.title}. ${copy.description}`;
+  }
+
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="sr-only"
+    >
+      {announcement}
+    </span>
+  );
+};
+
+/*
+ * A deliberately prominent, but compact, live status for an incident header.
+ * The full event trail remains in InvestigationPanel; this tells responders
+ * that work is happening without making them hunt for that card.
+ */
+const AIInvestigationHeaderStatus: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  if (!isActiveAIInvestigationStatus(props.status)) {
+    return <></>;
+  }
+
+  const isRunning: boolean = props.status === AIRunStatus.Running;
+  const copy: { title: string; description: string } =
+    getAIInvestigationStatusCopy(props.status);
+
+  return (
+    <div className="relative overflow-hidden rounded-lg border border-indigo-200 bg-gradient-to-r from-indigo-50 via-white to-violet-50 px-3.5 py-3 shadow-sm">
+      <div
+        aria-hidden="true"
+        className="absolute inset-y-0 left-0 w-1 bg-indigo-500"
+      />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-center gap-3">
+          <span
+            aria-hidden="true"
+            className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-indigo-600 text-white shadow-sm"
+          >
+            <Icon icon={IconProp.Sparkles} className="h-4 w-4" />
+            <span className="absolute -right-0.5 -top-0.5 flex h-2.5 w-2.5">
+              {isRunning ? (
+                <span className="absolute inline-flex h-full w-full motion-safe:animate-ping rounded-full bg-indigo-400 opacity-75" />
+              ) : (
+                <></>
+              )}
+              <span className="relative inline-flex h-2.5 w-2.5 rounded-full border-2 border-white bg-indigo-500" />
+            </span>
+          </span>
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-indigo-950">
+              {copy.title}
+            </p>
+            <p className="mt-0.5 text-xs leading-5 text-indigo-700">
+              {copy.description}
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={props.onViewProgress}
+          aria-controls={AI_INVESTIGATION_PANEL_ID}
+          aria-label="View live AI investigation progress"
+          className="group inline-flex shrink-0 items-center justify-center gap-1.5 self-start rounded-md px-2.5 py-1.5 text-xs font-semibold text-indigo-700 transition-colors hover:bg-indigo-100 hover:text-indigo-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 sm:self-auto"
+        >
+          View live progress
+          <Icon
+            icon={IconProp.ChevronDown}
+            className="h-3.5 w-3.5 transition-transform motion-safe:group-hover:translate-y-0.5"
+          />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AIInvestigationHeaderStatus;

--- a/App/FeatureSet/Dashboard/src/Components/AI/AIInvestigationStatus.ts
+++ b/App/FeatureSet/Dashboard/src/Components/AI/AIInvestigationStatus.ts
@@ -1,0 +1,29 @@
+import AIRunStatus from "Common/Types/AI/AIRunStatus";
+
+export const AI_INVESTIGATION_PANEL_ID: string = "ai-investigation";
+
+export const isActiveAIInvestigationStatus: (
+  status: AIRunStatus | null | undefined,
+) => boolean = (status: AIRunStatus | null | undefined): boolean => {
+  return status === AIRunStatus.Queued || status === AIRunStatus.Running;
+};
+
+export const scrollToAIInvestigationPanel: () => void = (): void => {
+  const investigationPanel: HTMLElement | null = document.getElementById(
+    AI_INVESTIGATION_PANEL_ID,
+  );
+
+  if (!investigationPanel) {
+    return;
+  }
+
+  const prefersReducedMotion: boolean =
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  investigationPanel.scrollIntoView({
+    behavior: prefersReducedMotion ? "auto" : "smooth",
+    block: "start",
+  });
+  investigationPanel.focus({ preventScroll: true });
+};

--- a/App/FeatureSet/Dashboard/src/Components/AI/InvestigationPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AI/InvestigationPanel.tsx
@@ -29,6 +29,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { AI_INVESTIGATION_PANEL_ID } from "./AIInvestigationStatus";
 
 export type InvestigationSubjectType = "incident" | "alert";
 
@@ -37,9 +38,15 @@ export type InvestigationVerdict = "Confirmed" | "Rejected";
 export interface ComponentProps {
   subjectType: InvestigationSubjectType;
   subjectId: ObjectID;
+  onStatusChange?: ((status: AIRunStatus | null) => void) | undefined;
 }
 
 const POLL_INTERVAL_MS: number = 2500;
+/*
+ * A new incident can render before its asynchronous AI run has been enqueued.
+ * Retry briefly so queued work appears without polling old incidents forever.
+ */
+const MAX_DISCOVERY_POLLS: number = 4;
 
 /*
  * the AI's live "watch it think" panel, shared by the incident and alert
@@ -53,7 +60,9 @@ const POLL_INTERVAL_MS: number = 2500;
 const InvestigationPanel: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const [runStatus, setRunStatus] = useState<string | null>(null);
+  const subjectIdString: string = props.subjectId.toString();
+  const subjectKey: string = `${props.subjectType}:${subjectIdString}`;
+  const [runStatus, setRunStatus] = useState<AIRunStatus | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [events, setEvents] = useState<Array<AIRunEvent>>([]);
   const [stats, setStats] = useState<{
@@ -62,6 +71,17 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
   } | null>(null);
   const [hasLoadedOnce, setHasLoadedOnce] = useState<boolean>(false);
   const signatureRef: React.MutableRefObject<string> = useRef<string>("");
+  const requestGenerationRef: React.MutableRefObject<number> =
+    useRef<number>(0);
+  const previousSubjectKeyRef: React.MutableRefObject<string | null> = useRef<
+    string | null
+  >(null);
+  const onStatusChangeRef: React.MutableRefObject<
+    ((status: AIRunStatus | null) => void) | undefined
+  > = useRef<((status: AIRunStatus | null) => void) | undefined>(
+    props.onStatusChange,
+  );
+  onStatusChangeRef.current = props.onStatusChange;
 
   // "Open Fix PR from this analysis" (the FixFromIncident recipe) state.
   const [isCreatingFixTask, setIsCreatingFixTask] = useState<boolean>(false);
@@ -83,15 +103,21 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
 
   const fetchData: () => Promise<void> =
     useCallback(async (): Promise<void> => {
+      const requestGeneration: number = requestGenerationRef.current;
+
       try {
         const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
           await API.post<JSONObject>({
             url: URL.fromString(
               APP_API_URL.toString() + `/ai-investigation/${props.subjectType}`,
             ),
-            data: { [`${props.subjectType}Id`]: props.subjectId.toString() },
+            data: { [`${props.subjectType}Id`]: subjectIdString },
             headers: ModelAPI.getCommonHeaders(),
           });
+
+        if (requestGeneration !== requestGenerationRef.current) {
+          return;
+        }
 
         if (response instanceof HTTPErrorResponse) {
           setHasLoadedOnce(true);
@@ -103,8 +129,8 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
           (data["run"] as JSONObject | null) || null;
         const eventsJson: JSONArray = (data["events"] as JSONArray) || [];
 
-        const status: string | null =
-          (runJson?.["status"] as string | undefined) || null;
+        const status: AIRunStatus | null =
+          (runJson?.["status"] as AIRunStatus | undefined) || null;
         const verdictFromServer: string | null =
           (runJson?.["humanVerdict"] as string | undefined) || null;
 
@@ -140,15 +166,51 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
         setHasLoadedOnce(true);
       } catch {
         // Best-effort panel — never surface an error here.
-        setHasLoadedOnce(true);
+        if (requestGeneration === requestGenerationRef.current) {
+          setHasLoadedOnce(true);
+        }
       }
-    }, [props.subjectType, props.subjectId]);
+    }, [props.subjectType, subjectIdString]);
 
   useEffect(() => {
+    const isSubjectChange: boolean =
+      previousSubjectKeyRef.current !== null &&
+      previousSubjectKeyRef.current !== subjectKey;
+    previousSubjectKeyRef.current = subjectKey;
+    requestGenerationRef.current += 1;
+    signatureRef.current = "";
+    setRunStatus(null);
+    setErrorMessage(null);
+    setEvents([]);
+    setStats(null);
+    setHasLoadedOnce(false);
+
+    if (isSubjectChange) {
+      onStatusChangeRef.current?.(null);
+      setIsCreatingFixTask(false);
+      setFixTaskRunId(null);
+      setFixTaskError(null);
+      setHumanVerdict(null);
+      setIsSavingVerdict(false);
+      setVerdictError(null);
+      setIsChangingVerdict(false);
+      isSavingVerdictRef.current = false;
+    }
+
     fetchData().catch(() => {
       // handled inside fetchData
     });
-  }, [fetchData]);
+
+    return () => {
+      requestGenerationRef.current += 1;
+    };
+  }, [fetchData, subjectKey]);
+
+  useEffect(() => {
+    if (hasLoadedOnce) {
+      onStatusChangeRef.current?.(runStatus);
+    }
+  }, [hasLoadedOnce, runStatus]);
 
   /*
    * Human-triggered `code_fix`: enqueue a FixFromIncident task that takes
@@ -240,22 +302,47 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
   const isQueued: boolean = runStatus === AIRunStatus.Queued;
   // Poll while the run can still make progress (queued runs get claimed).
   const isActive: boolean = isRunning || isQueued;
+  const isDiscoveringRun: boolean = hasLoadedOnce && runStatus === null;
 
   useEffect(() => {
-    if (!isActive) {
+    if (!isActive && !isDiscoveringRun) {
       return;
     }
 
-    const interval: ReturnType<typeof setInterval> = setInterval(() => {
-      fetchData().catch(() => {
-        // handled inside fetchData
-      });
-    }, POLL_INTERVAL_MS);
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let isCancelled: boolean = false;
+    let discoveryPollCount: number = 0;
+
+    const scheduleNextPoll: () => void = (): void => {
+      timeout = setTimeout(() => {
+        fetchData()
+          .finally(() => {
+            if (isDiscoveringRun) {
+              discoveryPollCount += 1;
+            }
+
+            if (
+              !isCancelled &&
+              (!isDiscoveringRun || discoveryPollCount < MAX_DISCOVERY_POLLS)
+            ) {
+              scheduleNextPoll();
+            }
+          })
+          .catch(() => {
+            // handled inside fetchData
+          });
+      }, POLL_INTERVAL_MS);
+    };
+
+    scheduleNextPoll();
 
     return () => {
-      return clearInterval(interval);
+      isCancelled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
     };
-  }, [isActive, fetchData]);
+  }, [isActive, isDiscoveringRun, fetchData]);
 
   // Nothing to show until an investigation exists for this subject.
   if (!hasLoadedOnce || !runStatus) {
@@ -303,14 +390,20 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
       title="AI Investigation"
       description={`OneUptime AI's live root-cause investigation for this ${props.subjectType}.`}
     >
-      <div className="-mt-4">
+      <div
+        id={AI_INVESTIGATION_PANEL_ID}
+        tabIndex={-1}
+        role="region"
+        aria-label="AI Investigation"
+        className="-mt-4 scroll-mt-32 outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+      >
         <div
           className={`flex items-center gap-2 text-sm font-medium ${statusMeta.className}`}
         >
           <Icon icon={statusMeta.icon} className="h-4 w-4" />
           <span>{statusMeta.text}</span>
           {isActive ? (
-            <span className="ml-1 inline-block h-2 w-2 animate-ping rounded-full bg-indigo-500" />
+            <span className="ml-1 inline-block h-2 w-2 motion-safe:animate-ping rounded-full bg-indigo-500" />
           ) : (
             <></>
           )}

--- a/App/FeatureSet/Dashboard/src/Components/EventView/EventStatusPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/EventView/EventStatusPanel.tsx
@@ -52,6 +52,8 @@ export interface ComponentProps {
   onStateSelect?: ((stateId: string) => void) | undefined;
   moreMenuTitle?: string | undefined;
   isDisabled?: boolean | undefined;
+  /* Optional full-width context shown inside the titled header card. */
+  headerNotice?: ReactElement | undefined;
 }
 
 const EventStatusPanel: FunctionComponent<ComponentProps> = (
@@ -337,6 +339,9 @@ const EventStatusPanel: FunctionComponent<ComponentProps> = (
             <div className="mt-3 flex flex-wrap items-center gap-2.5">
               {metaItems}
             </div>
+          )}
+          {props.headerNotice && (
+            <div className="mt-3">{props.headerNotice}</div>
           )}
         </div>
       ) : (

--- a/App/FeatureSet/Dashboard/src/Components/Incident/ChangeState.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Incident/ChangeState.tsx
@@ -30,6 +30,14 @@ import EventStatusPanel, {
 } from "../EventView/EventStatusPanel";
 import IncidentNoteTemplate from "Common/Models/DatabaseModels/IncidentNoteTemplate";
 import FormValues from "Common/UI/Components/Forms/Types/FormValues";
+import AIRunStatus from "Common/Types/AI/AIRunStatus";
+import AIInvestigationHeaderStatus, {
+  AIInvestigationStatusLiveRegion,
+} from "../AI/AIInvestigationHeaderStatus";
+import {
+  isActiveAIInvestigationStatus,
+  scrollToAIInvestigationPanel,
+} from "../AI/AIInvestigationStatus";
 
 export interface ComponentProps {
   incidentId: ObjectID;
@@ -39,6 +47,7 @@ export interface ComponentProps {
   eventStartsAt?: Date | undefined;
   severity?: { name: string; color: Color } | undefined;
   isPrivate?: boolean | undefined;
+  aiInvestigationStatus?: AIRunStatus | null | undefined;
 }
 
 const ChangeIncidentState: FunctionComponent<ComponentProps> = (
@@ -319,6 +328,7 @@ const ChangeIncidentState: FunctionComponent<ComponentProps> = (
 
   return (
     <>
+      <AIInvestigationStatusLiveRegion status={props.aiInvestigationStatus} />
       <EventStatusPanel
         states={incidentStates.map((state: IncidentState): EventStateItem => {
           return {
@@ -338,6 +348,14 @@ const ChangeIncidentState: FunctionComponent<ComponentProps> = (
         actions={actions}
         onActionClick={openModalForState}
         onStateSelect={openModalForState}
+        headerNotice={
+          isActiveAIInvestigationStatus(props.aiInvestigationStatus) ? (
+            <AIInvestigationHeaderStatus
+              status={props.aiInvestigationStatus!}
+              onViewProgress={scrollToAIInvestigationPanel}
+            />
+          ) : undefined
+        }
       />
 
       {showModal && (

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
@@ -30,6 +30,7 @@ import React, {
   Fragment,
   FunctionComponent,
   ReactElement,
+  useCallback,
   useEffect,
   useState,
 } from "react";
@@ -77,11 +78,18 @@ import LiveDuration from "../../../Components/EventView/LiveDuration";
 import { getEventEndDateForCurrentState } from "../../../Utils/EventDuration";
 import OverviewCustomFields from "../../../Components/CustomFields/OverviewCustomFields";
 import IncidentCustomField from "Common/Models/DatabaseModels/IncidentCustomField";
+import AIRunStatus from "Common/Types/AI/AIRunStatus";
+
+interface AIInvestigationStatusState {
+  subjectId: string;
+  status: AIRunStatus | null;
+}
 
 const IncidentView: FunctionComponent<
   PageComponentProps
 > = (): ReactElement => {
   const modelId: ObjectID = Navigation.getLastParamAsObjectID();
+  const modelIdString: string = modelId.toString();
 
   const [incidentStateTimeline, setIncidentStateTimeline] = useState<
     IncidentStateTimeline[]
@@ -117,6 +125,35 @@ const IncidentView: FunctionComponent<
   const [severity, setSeverity] = useState<
     { name: string; color: Color } | undefined
   >(undefined);
+  const [aiInvestigationStatus, setAIInvestigationStatus] =
+    useState<AIInvestigationStatusState>({
+      subjectId: modelIdString,
+      status: null,
+    });
+  const currentAIInvestigationStatus: AIRunStatus | null =
+    aiInvestigationStatus.subjectId === modelIdString
+      ? aiInvestigationStatus.status
+      : null;
+  const onAIInvestigationStatusChange: (status: AIRunStatus | null) => void =
+    useCallback(
+      (status: AIRunStatus | null): void => {
+        setAIInvestigationStatus(
+          (
+            currentStatus: AIInvestigationStatusState,
+          ): AIInvestigationStatusState => {
+            if (
+              currentStatus.subjectId === modelIdString &&
+              currentStatus.status === status
+            ) {
+              return currentStatus;
+            }
+
+            return { subjectId: modelIdString, status: status };
+          },
+        );
+      },
+      [modelIdString],
+    );
 
   const fetchData: PromiseVoidFunction = async (): Promise<void> => {
     try {
@@ -425,6 +462,7 @@ const IncidentView: FunctionComponent<
           eventStartsAt={durationStartDate}
           severity={severity}
           isPrivate={isPrivate}
+          aiInvestigationStatus={currentAIInvestigationStatus}
           onActionComplete={async () => {
             await fetchData();
           }}
@@ -541,7 +579,11 @@ const IncidentView: FunctionComponent<
 
           <RemediationSuggestionCard incidentId={modelId} hideIfEmpty={true} />
 
-          <InvestigationPanel subjectType="incident" subjectId={modelId} />
+          <InvestigationPanel
+            subjectType="incident"
+            subjectId={modelId}
+            onStatusChange={onAIInvestigationStatusChange}
+          />
 
           <IncidentFeedElement incidentId={modelId} />
         </div>

--- a/App/Tests/Dashboard/AIInvestigationHeaderWiring.test.ts
+++ b/App/Tests/Dashboard/AIInvestigationHeaderWiring.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+type ReadSourceFunction = (...relativeParts: Array<string>) => string;
+
+const readSource: ReadSourceFunction = (
+  ...relativeParts: Array<string>
+): string => {
+  return fs
+    .readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/.*$/gm, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+};
+
+const INCIDENT_VIEW: string = readSource(
+  "Pages",
+  "Incidents",
+  "View",
+  "Index.tsx",
+);
+const CHANGE_INCIDENT_STATE: string = readSource(
+  "Components",
+  "Incident",
+  "ChangeState.tsx",
+);
+const EVENT_STATUS_PANEL: string = readSource(
+  "Components",
+  "EventView",
+  "EventStatusPanel.tsx",
+);
+const INVESTIGATION_PANEL: string = readSource(
+  "Components",
+  "AI",
+  "InvestigationPanel.tsx",
+);
+
+describe("incident AI investigation header wiring", () => {
+  test("lifts status from the existing investigation panel poller", () => {
+    expect(INCIDENT_VIEW).toContain(
+      "onStatusChange={onAIInvestigationStatusChange}",
+    );
+    expect(INCIDENT_VIEW).toContain(
+      "aiInvestigationStatus={currentAIInvestigationStatus}",
+    );
+    expect(INCIDENT_VIEW).toContain(
+      "aiInvestigationStatus.subjectId === modelIdString",
+    );
+  });
+
+  test("does not add another investigation request to the incident page", () => {
+    expect(INCIDENT_VIEW).not.toContain("/ai-investigation/incident");
+    expect(INCIDENT_VIEW).not.toContain("setInterval");
+  });
+
+  test("shows the notice only for an active investigation", () => {
+    expect(CHANGE_INCIDENT_STATE).toContain(
+      "isActiveAIInvestigationStatus(props.aiInvestigationStatus)",
+    );
+    expect(CHANGE_INCIDENT_STATE).toContain("<AIInvestigationHeaderStatus");
+    expect(CHANGE_INCIDENT_STATE).toContain(
+      "onViewProgress={scrollToAIInvestigationPanel}",
+    );
+    expect(CHANGE_INCIDENT_STATE).toContain("<AIInvestigationStatusLiveRegion");
+  });
+
+  test("puts the notice inside the shared titled header card", () => {
+    expect(CHANGE_INCIDENT_STATE).toContain("headerNotice={");
+    expect(EVENT_STATUS_PANEL).toContain("props.headerNotice &&");
+    expect(EVENT_STATUS_PANEL).toContain(
+      '<div className="mt-3">{props.headerNotice}</div>',
+    );
+  });
+
+  test("reuses one stable, focusable target for the progress action", () => {
+    expect(INVESTIGATION_PANEL).toContain("id={AI_INVESTIGATION_PANEL_ID}");
+    expect(INVESTIGATION_PANEL).toContain("tabIndex={-1}");
+    expect(INVESTIGATION_PANEL).toContain('aria-label="AI Investigation"');
+  });
+
+  test("keeps polling and status ownership in InvestigationPanel", () => {
+    expect(INVESTIGATION_PANEL).toContain(
+      "const isActive: boolean = isRunning || isQueued",
+    );
+    expect(INVESTIGATION_PANEL).toContain("setTimeout(() =>");
+    expect(INVESTIGATION_PANEL).not.toContain("setInterval(() =>");
+    expect(INVESTIGATION_PANEL).toContain(
+      "onStatusChangeRef.current?.(runStatus)",
+    );
+    expect(INVESTIGATION_PANEL).toContain(
+      "const subjectIdString: string = props.subjectId.toString()",
+    );
+  });
+});

--- a/Common/Tests/App/Dashboard/AIInvestigationHeaderStatus.test.tsx
+++ b/Common/Tests/App/Dashboard/AIInvestigationHeaderStatus.test.tsx
@@ -1,0 +1,251 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import "@testing-library/jest-dom";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import AIInvestigationHeaderStatus, {
+  AIInvestigationStatusLiveRegion,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/AI/AIInvestigationHeaderStatus";
+import {
+  AI_INVESTIGATION_PANEL_ID,
+  isActiveAIInvestigationStatus,
+  scrollToAIInvestigationPanel,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/AI/AIInvestigationStatus";
+import AIRunStatus from "../../../Types/AI/AIRunStatus";
+
+const ACTIVE_STATUSES: Array<AIRunStatus> = [
+  AIRunStatus.Queued,
+  AIRunStatus.Running,
+];
+
+const INACTIVE_STATUSES: Array<AIRunStatus> = Object.values(AIRunStatus).filter(
+  (status: AIRunStatus) => {
+    return !ACTIVE_STATUSES.includes(status);
+  },
+);
+
+type SetReducedMotionFunction = (matches: boolean) => void;
+
+const setReducedMotion: SetReducedMotionFunction = (matches: boolean): void => {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: jest.fn().mockReturnValue({ matches: matches }),
+  });
+};
+
+afterEach(() => {
+  cleanup();
+  document.getElementById(AI_INVESTIGATION_PANEL_ID)?.remove();
+});
+
+beforeEach(() => {
+  setReducedMotion(false);
+});
+
+describe("AIInvestigationHeaderStatus", () => {
+  test.each(Object.values(AIRunStatus))(
+    "classifies %s without leaving a new status unaccounted for",
+    (status: AIRunStatus) => {
+      expect(isActiveAIInvestigationStatus(status)).toBe(
+        ACTIVE_STATUSES.includes(status),
+      );
+    },
+  );
+
+  test("treats a missing status as inactive", () => {
+    expect(isActiveAIInvestigationStatus(null)).toBe(false);
+    expect(isActiveAIInvestigationStatus(undefined)).toBe(false);
+  });
+
+  test("makes a running investigation obvious", () => {
+    render(
+      <AIInvestigationHeaderStatus
+        status={AIRunStatus.Running}
+        onViewProgress={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("AI is investigating")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Reviewing telemetry and tracing the likely root cause.",
+      ),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  test("uses honest queued copy before investigation work has begun", () => {
+    render(
+      <AIInvestigationHeaderStatus
+        status={AIRunStatus.Queued}
+        onViewProgress={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("AI investigation queued")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Waiting for an AI worker. Telemetry review will begin automatically.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("AI is investigating")).not.toBeInTheDocument();
+  });
+
+  test("only animates when AI is actively investigating", () => {
+    const { container, rerender } = render(
+      <AIInvestigationHeaderStatus
+        status={AIRunStatus.Running}
+        onViewProgress={() => {}}
+      />,
+    );
+
+    expect(container.innerHTML).toContain("motion-safe:animate-ping");
+    expect(container.innerHTML).not.toContain(" animate-ping ");
+
+    rerender(
+      <AIInvestigationHeaderStatus
+        status={AIRunStatus.Queued}
+        onViewProgress={() => {}}
+      />,
+    );
+
+    expect(container.innerHTML).not.toContain("motion-safe:animate-ping");
+  });
+
+  test.each(INACTIVE_STATUSES)(
+    "renders no stale header notice for %s",
+    (status: AIRunStatus) => {
+      const { container } = render(
+        <AIInvestigationHeaderStatus
+          status={status}
+          onViewProgress={() => {}}
+        />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    },
+  );
+
+  test("exposes a native progress button tied to the full investigation panel", async () => {
+    const onViewProgress: MockFunction = getJestMockFunction();
+    render(
+      <AIInvestigationHeaderStatus
+        status={AIRunStatus.Running}
+        onViewProgress={onViewProgress}
+      />,
+    );
+
+    const button: HTMLButtonElement = screen.getByRole("button", {
+      name: "View live AI investigation progress",
+    });
+
+    expect(button).toHaveAttribute("type", "button");
+    expect(button).toHaveAttribute("aria-controls", AI_INVESTIGATION_PANEL_ID);
+
+    await userEvent.click(button);
+    button.focus();
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard(" ");
+
+    expect(onViewProgress).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("AIInvestigationStatusLiveRegion", () => {
+  test("stays mounted and announces active status transitions without the CTA", () => {
+    const { rerender } = render(
+      <AIInvestigationStatusLiveRegion status={null} />,
+    );
+    const liveStatus: HTMLElement = screen.getByRole("status");
+
+    expect(liveStatus).toHaveAttribute("aria-live", "polite");
+    expect(liveStatus).toHaveAttribute("aria-atomic", "true");
+    expect(liveStatus).toHaveClass("sr-only");
+    expect(liveStatus).toBeEmptyDOMElement();
+
+    rerender(<AIInvestigationStatusLiveRegion status={AIRunStatus.Queued} />);
+    expect(liveStatus).toHaveTextContent(
+      "AI investigation queued. Waiting for an AI worker. Telemetry review will begin automatically.",
+    );
+    expect(liveStatus).not.toHaveTextContent("View live progress");
+
+    rerender(<AIInvestigationStatusLiveRegion status={AIRunStatus.Running} />);
+    expect(liveStatus).toHaveTextContent(
+      "AI is investigating. Reviewing telemetry and tracing the likely root cause.",
+    );
+
+    rerender(
+      <AIInvestigationStatusLiveRegion status={AIRunStatus.Completed} />,
+    );
+    expect(liveStatus).toBeEmptyDOMElement();
+  });
+});
+
+describe("scrollToAIInvestigationPanel", () => {
+  type AddTargetFunction = () => {
+    target: HTMLElement;
+    scrollIntoView: MockFunction;
+    focus: MockFunction;
+  };
+
+  const addTarget: AddTargetFunction = () => {
+    const target: HTMLElement = document.createElement("section");
+    target.id = AI_INVESTIGATION_PANEL_ID;
+    target.tabIndex = -1;
+
+    const scrollIntoView: MockFunction = getJestMockFunction();
+    const focus: MockFunction = getJestMockFunction();
+    Object.defineProperty(target, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    Object.defineProperty(target, "focus", {
+      configurable: true,
+      value: focus,
+    });
+    document.body.appendChild(target);
+
+    return { target, scrollIntoView, focus };
+  };
+
+  test("smoothly scrolls to and focuses the detailed investigation", () => {
+    const { scrollIntoView, focus } = addTarget();
+
+    scrollToAIInvestigationPanel();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    });
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+  });
+
+  test("honors reduced-motion preferences", () => {
+    setReducedMotion(true);
+    const { scrollIntoView, focus } = addTarget();
+
+    scrollToAIInvestigationPanel();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "auto",
+      block: "start",
+    });
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  test("is a safe no-op before a panel exists", () => {
+    expect(() => {
+      scrollToAIInvestigationPanel();
+    }).not.toThrow();
+  });
+});

--- a/Common/Tests/App/Dashboard/EventStatusPanel.test.tsx
+++ b/Common/Tests/App/Dashboard/EventStatusPanel.test.tsx
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import EventStatusPanel from "../../../../App/FeatureSet/Dashboard/src/Components/EventView/EventStatusPanel";
+import { Black, Red500 } from "../../../Types/BrandColors";
+import Color from "../../../Types/Color";
+import IconProp from "../../../Types/Icon/IconProp";
+import { ButtonStyleType } from "../../../UI/Components/Button/Button";
+
+const CREATED: Color = new Color("#6366f1");
+const ACKNOWLEDGED: Color = new Color("#22c55e");
+
+describe("EventStatusPanel header notice", () => {
+  test("renders a notice inside the titled header card", () => {
+    render(
+      <EventStatusPanel
+        title="Database latency"
+        identifier="INC-42"
+        states={[]}
+        actions={[]}
+        onActionClick={() => {}}
+        headerNotice={
+          <div data-testid="header-notice">AI is investigating</div>
+        }
+      />,
+    );
+
+    const notice: HTMLElement = screen.getByTestId("header-notice");
+    expect(notice).toHaveTextContent("AI is investigating");
+    expect(notice.parentElement).toHaveClass("mt-3");
+    expect(screen.getByText("Database latency")).toBeInTheDocument();
+    expect(screen.getByText("INC-42")).toBeInTheDocument();
+  });
+
+  test("adds no empty notice spacing when the optional content is absent", () => {
+    const { container } = render(
+      <EventStatusPanel
+        title="Database latency"
+        states={[]}
+        actions={[]}
+        onActionClick={() => {}}
+      />,
+    );
+
+    expect(container.querySelector(".mt-3")).toBeNull();
+  });
+
+  test("keeps existing metadata, state progress, and actions intact beside the notice", () => {
+    const onActionClick: MockFunction = getJestMockFunction();
+    render(
+      <EventStatusPanel
+        title="Database latency"
+        states={[
+          { id: "created", name: "Created", color: CREATED },
+          {
+            id: "acknowledged",
+            name: "Acknowledged",
+            color: ACKNOWLEDGED,
+          },
+        ]}
+        currentStateId="created"
+        severity={{ name: "Critical", color: Red500 }}
+        isPrivate={true}
+        durationPrefix="Ongoing for"
+        durationStartsAt={new Date("2026-08-07T10:00:00.000Z")}
+        durationEndsAt={new Date("2026-08-07T10:05:00.000Z")}
+        actions={[
+          {
+            stateId: "acknowledged",
+            label: "Acknowledge",
+            icon: IconProp.Check,
+            buttonStyle: ButtonStyleType.PRIMARY,
+          },
+        ]}
+        onActionClick={onActionClick}
+        headerNotice={
+          <div data-testid="header-notice">AI is investigating</div>
+        }
+      />,
+    );
+
+    expect(screen.getAllByText("Created").length).toBeGreaterThan(0);
+    expect(screen.getByText("Acknowledged")).toBeInTheDocument();
+    expect(screen.getByText("Critical")).toBeInTheDocument();
+    expect(screen.getByText("Private")).toBeInTheDocument();
+    expect(screen.getByText("Ongoing for")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Acknowledge" }));
+    expect(onActionClick).toHaveBeenCalledWith("acknowledged");
+  });
+
+  test("leaves compact consumers unchanged", () => {
+    render(
+      <EventStatusPanel
+        identifier="#7"
+        states={[{ id: "created", name: "Created", color: Black }]}
+        currentStateId="created"
+        actions={[]}
+        onActionClick={() => {}}
+        headerNotice={
+          <div data-testid="header-notice">AI is investigating</div>
+        }
+      />,
+    );
+
+    expect(screen.getByText("#7")).toBeInTheDocument();
+    expect(screen.getByText("Created")).toBeInTheDocument();
+    expect(screen.queryByTestId("header-notice")).not.toBeInTheDocument();
+  });
+});

--- a/Common/Tests/App/Dashboard/InvestigationPanelStatus.test.tsx
+++ b/Common/Tests/App/Dashboard/InvestigationPanelStatus.test.tsx
@@ -1,0 +1,500 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import React, { act } from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+const postMock: MockFunction = getJestMockFunction();
+const getCommonHeadersMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      post: (...args: Array<any>) => {
+        return postMock(...args);
+      },
+      getFriendlyMessage: () => {
+        return "Request failed";
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCommonHeaders: (...args: Array<any>) => {
+        return getCommonHeadersMock(...args);
+      },
+    },
+  };
+});
+
+import InvestigationPanel from "../../../../App/FeatureSet/Dashboard/src/Components/AI/InvestigationPanel";
+import { AI_INVESTIGATION_PANEL_ID } from "../../../../App/FeatureSet/Dashboard/src/Components/AI/AIInvestigationStatus";
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import AIRunStatus from "../../../Types/AI/AIRunStatus";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+
+const SUBJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const SECOND_SUBJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const POLL_INTERVAL_MS: number = 2500;
+
+type InvestigationResponseFunction = (
+  status: AIRunStatus | null,
+) => HTTPResponse<JSONObject>;
+
+const investigationResponse: InvestigationResponseFunction = (
+  status: AIRunStatus | null,
+): HTTPResponse<JSONObject> => {
+  return new HTTPResponse<JSONObject>(
+    200,
+    {
+      run: status
+        ? {
+            status: status,
+            toolCallCount: 0,
+            totalTokens: 0,
+          }
+        : null,
+      events: [],
+    },
+    {},
+  );
+};
+
+type AdvanceFunction = () => void;
+
+const advance: AdvanceFunction = (): void => {
+  act(() => {
+    jest.advanceTimersByTime(POLL_INTERVAL_MS);
+  });
+};
+
+beforeEach(() => {
+  postMock.mockReset();
+  getCommonHeadersMock.mockReset();
+  getCommonHeadersMock.mockReturnValue({ tenantid: "project-id" });
+});
+
+afterEach(() => {
+  cleanup();
+  jest.useRealTimers();
+});
+
+describe("InvestigationPanel status reporting", () => {
+  test("reports a running investigation and uses the existing incident endpoint", async () => {
+    const onStatusChange: MockFunction = getJestMockFunction();
+    postMock.mockResolvedValue(investigationResponse(AIRunStatus.Running));
+
+    const { container } = render(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={SUBJECT_ID}
+        onStatusChange={onStatusChange}
+      />,
+    );
+
+    expect(await screen.findByText("Investigating…")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenLastCalledWith(AIRunStatus.Running);
+    });
+
+    const request: any = postMock.mock.calls[0]?.[0];
+    expect(request.url.toString()).toContain("/ai-investigation/incident");
+    expect(request.data).toEqual({ incidentId: SUBJECT_ID.toString() });
+    expect(request.headers).toEqual({ tenantid: "project-id" });
+
+    const panel: HTMLElement = screen.getByRole("region", {
+      name: "AI Investigation",
+    });
+    expect(panel).toHaveAttribute("id", AI_INVESTIGATION_PANEL_ID);
+    expect(panel).toHaveAttribute("tabindex", "-1");
+    expect(container.innerHTML).toContain("motion-safe:animate-ping");
+  });
+
+  test("reports null only after a successful response confirms no run exists", async () => {
+    const onStatusChange: MockFunction = getJestMockFunction();
+    let resolveRequest: ((response: HTTPResponse<JSONObject>) => void) | null =
+      null;
+    postMock.mockReturnValue(
+      new Promise<HTTPResponse<JSONObject>>(
+        (resolve: (response: HTTPResponse<JSONObject>) => void) => {
+          resolveRequest = resolve;
+        },
+      ),
+    );
+
+    const { container } = render(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={SUBJECT_ID}
+        onStatusChange={onStatusChange}
+      />,
+    );
+
+    expect(onStatusChange).not.toHaveBeenCalled();
+
+    resolveRequest!(investigationResponse(null));
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onStatusChange).toHaveBeenCalledWith(null);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("discovers an AI run that is enqueued after the incident page loads", async () => {
+    jest.useFakeTimers();
+    const onStatusChange: MockFunction = getJestMockFunction();
+    postMock
+      .mockResolvedValueOnce(investigationResponse(null))
+      .mockResolvedValueOnce(investigationResponse(AIRunStatus.Queued));
+
+    render(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={SUBJECT_ID}
+        onStatusChange={onStatusChange}
+      />,
+    );
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenLastCalledWith(null);
+    });
+    expect(jest.getTimerCount()).toBe(1);
+
+    advance();
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenLastCalledWith(AIRunStatus.Queued);
+    });
+
+    expect(screen.getByText(/Queued/)).toBeInTheDocument();
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(jest.getTimerCount()).toBe(1);
+  });
+
+  test("stops discovery polling when no AI run appears", async () => {
+    jest.useFakeTimers();
+    const onStatusChange: MockFunction = getJestMockFunction();
+    postMock.mockResolvedValue(investigationResponse(null));
+
+    render(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={SUBJECT_ID}
+        onStatusChange={onStatusChange}
+      />,
+    );
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenLastCalledWith(null);
+    });
+
+    for (
+      let expectedRequestCount: number = 2;
+      expectedRequestCount <= 5;
+      expectedRequestCount++
+    ) {
+      advance();
+      await waitFor(() => {
+        expect(postMock).toHaveBeenCalledTimes(expectedRequestCount);
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+
+    expect(jest.getTimerCount()).toBe(0);
+    advance();
+    expect(postMock).toHaveBeenCalledTimes(5);
+  });
+
+  test("follows queued to running to completed and stops polling at the terminal state", async () => {
+    jest.useFakeTimers();
+    const onStatusChange: MockFunction = getJestMockFunction();
+    postMock
+      .mockResolvedValueOnce(investigationResponse(AIRunStatus.Queued))
+      .mockResolvedValueOnce(investigationResponse(AIRunStatus.Running))
+      .mockResolvedValueOnce(investigationResponse(AIRunStatus.Completed));
+
+    render(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={SUBJECT_ID}
+        onStatusChange={onStatusChange}
+      />,
+    );
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenLastCalledWith(AIRunStatus.Queued);
+    });
+    expect(screen.getByText(/Queued/)).toBeInTheDocument();
+    expect(jest.getTimerCount()).toBe(1);
+
+    advance();
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenLastCalledWith(AIRunStatus.Running);
+    });
+    expect(screen.getByText("Investigating…")).toBeInTheDocument();
+    expect(jest.getTimerCount()).toBe(1);
+
+    advance();
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenLastCalledWith(AIRunStatus.Completed);
+    });
+    expect(screen.getByText("Investigation complete")).toBeInTheDocument();
+    expect(jest.getTimerCount()).toBe(0);
+
+    advance();
+    expect(postMock).toHaveBeenCalledTimes(3);
+  });
+
+  test("does not start a poller for an already completed investigation", async () => {
+    jest.useFakeTimers();
+    postMock.mockResolvedValue(investigationResponse(AIRunStatus.Completed));
+
+    render(
+      <InvestigationPanel subjectType="incident" subjectId={SUBJECT_ID} />,
+    );
+    expect(
+      await screen.findByText("Investigation complete"),
+    ).toBeInTheDocument();
+    expect(jest.getTimerCount()).toBe(0);
+    advance();
+    expect(postMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("clears its active timer when the panel unmounts", async () => {
+    jest.useFakeTimers();
+    postMock.mockResolvedValue(investigationResponse(AIRunStatus.Running));
+
+    const { unmount } = render(
+      <InvestigationPanel subjectType="incident" subjectId={SUBJECT_ID} />,
+    );
+    expect(await screen.findByText("Investigating…")).toBeInTheDocument();
+    expect(jest.getTimerCount()).toBe(1);
+
+    unmount();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test("degrades silently when the initial request fails", async () => {
+    const onStatusChange: MockFunction = getJestMockFunction();
+    postMock.mockResolvedValue(
+      new HTTPErrorResponse(500, { message: "boom" }, {}),
+    );
+
+    const { container } = render(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={SUBJECT_ID}
+        onStatusChange={onStatusChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenCalledWith(null);
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("preserves the last active status through a transient polling failure", async () => {
+    jest.useFakeTimers();
+    const onStatusChange: MockFunction = getJestMockFunction();
+    postMock
+      .mockResolvedValueOnce(investigationResponse(AIRunStatus.Running))
+      .mockResolvedValueOnce(
+        new HTTPErrorResponse(503, { message: "try again" }, {}),
+      );
+
+    render(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={SUBJECT_ID}
+        onStatusChange={onStatusChange}
+      />,
+    );
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenLastCalledWith(AIRunStatus.Running);
+    });
+
+    advance();
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledTimes(2);
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onStatusChange).toHaveBeenLastCalledWith(AIRunStatus.Running);
+    expect(onStatusChange).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Investigating…")).toBeInTheDocument();
+    expect(jest.getTimerCount()).toBe(1);
+  });
+
+  test("does not refetch when the same subject is passed as a new ObjectID instance", async () => {
+    const onStatusChange: MockFunction = getJestMockFunction();
+    postMock.mockResolvedValue(investigationResponse(AIRunStatus.Completed));
+
+    const { rerender } = render(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={SUBJECT_ID}
+        onStatusChange={onStatusChange}
+      />,
+    );
+    expect(
+      await screen.findByText("Investigation complete"),
+    ).toBeInTheDocument();
+
+    rerender(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={new ObjectID(SUBJECT_ID.toString())}
+        onStatusChange={onStatusChange}
+      />,
+    );
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(onStatusChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("clears an old active investigation when the subject changes and the new request fails", async () => {
+    const onStatusChange: MockFunction = getJestMockFunction();
+    postMock
+      .mockResolvedValueOnce(investigationResponse(AIRunStatus.Running))
+      .mockResolvedValueOnce(
+        new HTTPErrorResponse(503, { message: "try again" }, {}),
+      );
+
+    const { container, rerender } = render(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={SUBJECT_ID}
+        onStatusChange={onStatusChange}
+      />,
+    );
+    expect(await screen.findByText("Investigating…")).toBeInTheDocument();
+
+    rerender(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={SECOND_SUBJECT_ID}
+        onStatusChange={onStatusChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+      expect(onStatusChange).toHaveBeenLastCalledWith(null);
+    });
+    expect(postMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("ignores a late response from the previous subject", async () => {
+    const onStatusChange: MockFunction = getJestMockFunction();
+    let resolveFirstSubject:
+      | ((response: HTTPResponse<JSONObject>) => void)
+      | null = null;
+
+    postMock.mockImplementation((request: any) => {
+      if (request.data.incidentId === SUBJECT_ID.toString()) {
+        return new Promise<HTTPResponse<JSONObject>>(
+          (resolve: (response: HTTPResponse<JSONObject>) => void) => {
+            resolveFirstSubject = resolve;
+          },
+        );
+      }
+
+      return Promise.resolve(investigationResponse(AIRunStatus.Completed));
+    });
+
+    const { rerender } = render(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={SUBJECT_ID}
+        onStatusChange={onStatusChange}
+      />,
+    );
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={SECOND_SUBJECT_ID}
+        onStatusChange={onStatusChange}
+      />,
+    );
+    expect(
+      await screen.findByText("Investigation complete"),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenLastCalledWith(AIRunStatus.Completed);
+    });
+
+    resolveFirstSubject!(investigationResponse(AIRunStatus.Running));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(screen.getByText("Investigation complete")).toBeInTheDocument();
+    expect(screen.queryByText("Investigating…")).not.toBeInTheDocument();
+    expect(onStatusChange).not.toHaveBeenCalledWith(AIRunStatus.Running);
+    expect(onStatusChange).toHaveBeenLastCalledWith(AIRunStatus.Completed);
+  });
+
+  test("waits for an in-flight poll before scheduling another one", async () => {
+    jest.useFakeTimers();
+    const onStatusChange: MockFunction = getJestMockFunction();
+    let resolvePoll: ((response: HTTPResponse<JSONObject>) => void) | null =
+      null;
+    postMock
+      .mockResolvedValueOnce(investigationResponse(AIRunStatus.Running))
+      .mockReturnValueOnce(
+        new Promise<HTTPResponse<JSONObject>>(
+          (resolve: (response: HTTPResponse<JSONObject>) => void) => {
+            resolvePoll = resolve;
+          },
+        ),
+      );
+
+    render(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={SUBJECT_ID}
+        onStatusChange={onStatusChange}
+      />,
+    );
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenLastCalledWith(AIRunStatus.Running);
+    });
+
+    advance();
+    await waitFor(() => {
+      expect(postMock).toHaveBeenCalledTimes(2);
+    });
+    expect(jest.getTimerCount()).toBe(0);
+
+    advance();
+    expect(postMock).toHaveBeenCalledTimes(2);
+
+    resolvePoll!(investigationResponse(AIRunStatus.Completed));
+    await waitFor(() => {
+      expect(onStatusChange).toHaveBeenLastCalledWith(AIRunStatus.Completed);
+    });
+
+    expect(screen.getByText("Investigation complete")).toBeInTheDocument();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## What changed

- Added a prominent, responsive indigo status banner to the incident header for queued and running AI investigations.
- Added a keyboard-accessible “View live progress” action that scrolls to and focuses the existing investigation card while respecting reduced-motion preferences.
- Reused the investigation card’s existing request lifecycle instead of adding a second API poller.
- Added reliable screen-reader announcements, motion-safe activity indicators, and active-only status copy.
- Hardened investigation polling against equivalent `ObjectID` rerenders, subject changes, late responses, overlapping polls, transient errors, and the short delay between incident creation and AI-run enqueue.
- Added a bounded discovery window so a newly created incident can still surface a run that appears just after the first request, without polling old incidents indefinitely.

## Why

Responders could only tell that AI was working after scrolling down to the AI Investigation card. The incident header had no access to the run status, and a page opened immediately after incident creation could also fetch before the asynchronous AI run existed.

## User impact

Responders now see AI activity immediately in the incident overview, understand whether work is queued or underway, and can jump directly to live progress. Completed, failed, cancelled, and absent investigations do not leave stale header noise.

## Validation

- 40 focused Common component/lifecycle/accessibility tests pass.
- 6 focused App wiring tests pass.
- Common TypeScript compilation passes.
- ESLint passes for every changed production and test file.
- Responsive visual QA passed at desktop and mobile widths; the progress action scrolls and focuses the target correctly.
- Dashboard compilation reaches an existing `master` error in `LogsViewer.tsx:1821` (`TelemetrySavedViewTimeRange` to `JSONObject`), unrelated to this branch.