### PR TITLE
Show completed AI investigation reports

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/AI/InvestigationPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AI/InvestigationPanel.tsx
@@ -21,6 +21,7 @@ import Button, {
 import Card from "Common/UI/Components/Card/Card";
 import Icon from "Common/UI/Components/Icon/Icon";
 import Link from "Common/UI/Components/Link/Link";
+import MarkdownViewer from "Common/UI/Components/Markdown.tsx/MarkdownViewer";
 import React, {
   FunctionComponent,
   ReactElement,
@@ -39,12 +40,15 @@ export interface ComponentProps {
   subjectType: InvestigationSubjectType;
   subjectId: ObjectID;
   onStatusChange?: ((status: AIRunStatus | null) => void) | undefined;
+  onAnalysisAvailable?: (() => void) | undefined;
 }
 
 const POLL_INTERVAL_MS: number = 2500;
+const SETTLED_POLL_INTERVAL_MS: number = 30_000;
 /*
  * A new incident can render before its asynchronous AI run has been enqueued.
- * Retry briefly so queued work appears without polling old incidents forever.
+ * Retry briefly so queued work appears immediately, then fall back to the
+ * quieter settled cadence supported by the completed-report API.
  */
 const MAX_DISCOVERY_POLLS: number = 4;
 
@@ -53,26 +57,44 @@ const MAX_DISCOVERY_POLLS: number = 4;
  * view pages. It shows the autonomous investigation narrating its steps in
  * real time (reusing ChatActivityFeed over the run's AIRunEvents) and its
  * status. Renders nothing until an investigation exists for the subject, so
- * it's invisible for projects that haven't enabled AI. The full cited
- * root cause lands in the subject's timeline below; this panel is the
- * reasoning trail.
+ * it's invisible for projects that haven't enabled AI. Once complete, the
+ * published report becomes the primary content and the reasoning trail moves
+ * into a quiet disclosure.
  */
 const InvestigationPanel: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  const subjectType: InvestigationSubjectType = props.subjectType;
   const subjectIdString: string = props.subjectId.toString();
-  const subjectKey: string = `${props.subjectType}:${subjectIdString}`;
+  const subjectKey: string = `${subjectType}:${subjectIdString}`;
   const [runStatus, setRunStatus] = useState<AIRunStatus | null>(null);
+  const [runId, setRunId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [events, setEvents] = useState<Array<AIRunEvent>>([]);
+  const [analysisMarkdown, setAnalysisMarkdown] = useState<string | null>(null);
+  const [isAnalysisPending, setIsAnalysisPending] = useState<boolean>(false);
   const [stats, setStats] = useState<{
     toolCallCount: number;
     totalTokens: number;
   } | null>(null);
   const [hasLoadedOnce, setHasLoadedOnce] = useState<boolean>(false);
+  const [loadedSubjectKey, setLoadedSubjectKey] = useState<string | null>(null);
+  const [supportsSettledPolling, setSupportsSettledPolling] =
+    useState<boolean>(false);
   const signatureRef: React.MutableRefObject<string> = useRef<string>("");
-  const requestGenerationRef: React.MutableRefObject<number> =
+  const latestFetchRequestRef: React.MutableRefObject<number> =
     useRef<number>(0);
+  const activeSubjectKeyRef: React.MutableRefObject<string> =
+    useRef<string>(subjectKey);
+  const activeRunIdRef: React.MutableRefObject<string | null> = useRef<
+    string | null
+  >(null);
+  const loadedSubjectKeyRef: React.MutableRefObject<string | null> = useRef<
+    string | null
+  >(null);
+  const notifiedAnalysisRef: React.MutableRefObject<Set<string>> = useRef<
+    Set<string>
+  >(new Set<string>());
   const previousSubjectKeyRef: React.MutableRefObject<string | null> = useRef<
     string | null
   >(null);
@@ -82,6 +104,12 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
     props.onStatusChange,
   );
   onStatusChangeRef.current = props.onStatusChange;
+
+  /*
+   * Update during render so a response from the previous route can never
+   * commit between this render and the next effect.
+   */
+  activeSubjectKeyRef.current = subjectKey;
 
   // "Open Fix PR from this analysis" (the FixFromIncident recipe) state.
   const [isCreatingFixTask, setIsCreatingFixTask] = useState<boolean>(false);
@@ -101,25 +129,80 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
   const isSavingVerdictRef: React.MutableRefObject<boolean> =
     useRef<boolean>(false);
 
+  /*
+   * This component can survive route changes while the subject id changes.
+   * Clear subject-owned state before the next response arrives so actions,
+   * verdicts, and reports from the previous subject are never displayed on
+   * the new one. Incrementing the generation also invalidates any request
+   * that was already in flight for the old route.
+   */
+  useEffect(() => {
+    const isSubjectChange: boolean =
+      previousSubjectKeyRef.current !== null &&
+      previousSubjectKeyRef.current !== subjectKey;
+    previousSubjectKeyRef.current = subjectKey;
+
+    latestFetchRequestRef.current += 1;
+    signatureRef.current = "";
+    loadedSubjectKeyRef.current = null;
+    activeRunIdRef.current = null;
+    isSavingVerdictRef.current = false;
+
+    setRunStatus(null);
+    setRunId(null);
+    setErrorMessage(null);
+    setEvents([]);
+    setAnalysisMarkdown(null);
+    setIsAnalysisPending(false);
+    setStats(null);
+    setHasLoadedOnce(false);
+    setLoadedSubjectKey(null);
+    setSupportsSettledPolling(false);
+    setIsCreatingFixTask(false);
+    setFixTaskRunId(null);
+    setFixTaskError(null);
+    setHumanVerdict(null);
+    setIsSavingVerdict(false);
+    setVerdictError(null);
+    setIsChangingVerdict(false);
+
+    if (isSubjectChange) {
+      onStatusChangeRef.current?.(null);
+    }
+  }, [subjectKey]);
+
   const fetchData: () => Promise<void> =
     useCallback(async (): Promise<void> => {
-      const requestGeneration: number = requestGenerationRef.current;
+      const requestId: number = latestFetchRequestRef.current + 1;
+      latestFetchRequestRef.current = requestId;
+      const requestedSubjectKey: string = subjectKey;
+      const isLatestRequest: () => boolean = (): boolean => {
+        return (
+          requestId === latestFetchRequestRef.current &&
+          requestedSubjectKey === activeSubjectKeyRef.current
+        );
+      };
 
       try {
         const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
           await API.post<JSONObject>({
             url: URL.fromString(
-              APP_API_URL.toString() + `/ai-investigation/${props.subjectType}`,
+              APP_API_URL.toString() + `/ai-investigation/${subjectType}`,
             ),
-            data: { [`${props.subjectType}Id`]: subjectIdString },
+            data: { [`${subjectType}Id`]: subjectIdString },
             headers: ModelAPI.getCommonHeaders(),
           });
 
-        if (requestGeneration !== requestGenerationRef.current) {
+        if (!isLatestRequest()) {
           return;
         }
 
         if (response instanceof HTTPErrorResponse) {
+          if (loadedSubjectKeyRef.current !== requestedSubjectKey) {
+            setRunStatus(null);
+          }
+          loadedSubjectKeyRef.current = requestedSubjectKey;
+          setLoadedSubjectKey(requestedSubjectKey);
           setHasLoadedOnce(true);
           return;
         }
@@ -131,17 +214,61 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
 
         const status: AIRunStatus | null =
           (runJson?.["status"] as AIRunStatus | undefined) || null;
+        const nextRunId: string | null =
+          (runJson?.["_id"] as string | undefined) || null;
         const verdictFromServer: string | null =
           (runJson?.["humanVerdict"] as string | undefined) || null;
+        const analysisFromServer: string =
+          typeof data["analysisMarkdown"] === "string"
+            ? (data["analysisMarkdown"] as string).trim()
+            : "";
+        const nextAnalysisMarkdown: string | null = analysisFromServer || null;
+        const nextIsAnalysisPending: boolean =
+          data["isAnalysisPending"] === true;
+        const nextToolCallCount: number =
+          (runJson?.["toolCallCount"] as number | undefined) || 0;
+        const nextTotalTokens: number =
+          (runJson?.["totalTokens"] as number | undefined) || 0;
+        const nextErrorMessage: string | null =
+          (runJson?.["errorMessage"] as string | undefined) || null;
+        const nextSupportsSettledPolling: boolean =
+          Object.prototype.hasOwnProperty.call(data, "analysisMarkdown") ||
+          Object.prototype.hasOwnProperty.call(data, "isAnalysisPending");
 
-        // Skip re-render when nothing changed (status + event count + verdict).
-        const signature: string = `${status || "none"}:${eventsJson.length}:${verdictFromServer || "none"}`;
+        if (nextRunId !== activeRunIdRef.current) {
+          activeRunIdRef.current = nextRunId;
+          isSavingVerdictRef.current = false;
+          setIsCreatingFixTask(false);
+          setFixTaskRunId(null);
+          setFixTaskError(null);
+          setIsSavingVerdict(false);
+          setVerdictError(null);
+          setIsChangingVerdict(false);
+        }
+
+        /*
+         * The report can arrive after the run first becomes Completed, without
+         * changing the status or event count. Keep it in the signature so that
+         * completion race always produces a final render.
+         */
+        const signature: string = JSON.stringify([
+          status,
+          nextRunId,
+          eventsJson.length,
+          verdictFromServer,
+          nextErrorMessage,
+          nextToolCallCount,
+          nextTotalTokens,
+          nextAnalysisMarkdown,
+          nextIsAnalysisPending,
+        ]);
         if (signature !== signatureRef.current) {
           signatureRef.current = signature;
           setRunStatus(status);
-          setErrorMessage(
-            (runJson?.["errorMessage"] as string | undefined) || null,
-          );
+          setRunId(nextRunId);
+          setErrorMessage(nextErrorMessage);
+          setAnalysisMarkdown(nextAnalysisMarkdown);
+          setIsAnalysisPending(nextIsAnalysisPending);
           if (!isSavingVerdictRef.current) {
             setHumanVerdict(verdictFromServer);
           }
@@ -154,63 +281,43 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
           setStats(
             runJson
               ? {
-                  toolCallCount:
-                    (runJson["toolCallCount"] as number | undefined) || 0,
-                  totalTokens:
-                    (runJson["totalTokens"] as number | undefined) || 0,
+                  toolCallCount: nextToolCallCount,
+                  totalTokens: nextTotalTokens,
                 }
               : null,
           );
         }
 
+        loadedSubjectKeyRef.current = requestedSubjectKey;
+        setLoadedSubjectKey(requestedSubjectKey);
+        setSupportsSettledPolling(nextSupportsSettledPolling);
         setHasLoadedOnce(true);
       } catch {
-        // Best-effort panel — never surface an error here.
-        if (requestGeneration === requestGenerationRef.current) {
-          setHasLoadedOnce(true);
+        if (!isLatestRequest()) {
+          return;
         }
+
+        // Best-effort panel — never surface an error here.
+        if (loadedSubjectKeyRef.current !== requestedSubjectKey) {
+          setRunStatus(null);
+        }
+        loadedSubjectKeyRef.current = requestedSubjectKey;
+        setLoadedSubjectKey(requestedSubjectKey);
+        setHasLoadedOnce(true);
       }
-    }, [props.subjectType, subjectIdString]);
+    }, [subjectIdString, subjectKey, subjectType]);
 
   useEffect(() => {
-    const isSubjectChange: boolean =
-      previousSubjectKeyRef.current !== null &&
-      previousSubjectKeyRef.current !== subjectKey;
-    previousSubjectKeyRef.current = subjectKey;
-    requestGenerationRef.current += 1;
-    signatureRef.current = "";
-    setRunStatus(null);
-    setErrorMessage(null);
-    setEvents([]);
-    setStats(null);
-    setHasLoadedOnce(false);
-
-    if (isSubjectChange) {
-      onStatusChangeRef.current?.(null);
-      setIsCreatingFixTask(false);
-      setFixTaskRunId(null);
-      setFixTaskError(null);
-      setHumanVerdict(null);
-      setIsSavingVerdict(false);
-      setVerdictError(null);
-      setIsChangingVerdict(false);
-      isSavingVerdictRef.current = false;
-    }
-
     fetchData().catch(() => {
       // handled inside fetchData
     });
-
-    return () => {
-      requestGenerationRef.current += 1;
-    };
-  }, [fetchData, subjectKey]);
+  }, [fetchData]);
 
   useEffect(() => {
-    if (hasLoadedOnce) {
+    if (hasLoadedOnce && loadedSubjectKey === subjectKey) {
       onStatusChangeRef.current?.(runStatus);
     }
-  }, [hasLoadedOnce, runStatus]);
+  }, [hasLoadedOnce, loadedSubjectKey, runStatus, subjectKey]);
 
   /*
    * Human-triggered `code_fix`: enqueue a FixFromIncident task that takes
@@ -220,6 +327,14 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
    */
   const createFixTask: () => Promise<void> =
     useCallback(async (): Promise<void> => {
+      const requestedSubjectKey: string = subjectKey;
+      const requestedRunId: string | null = runId;
+
+      if (!requestedRunId) {
+        setFixTaskError("The investigation run could not be identified.");
+        return;
+      }
+
       setIsCreatingFixTask(true);
       setFixTaskError(null);
 
@@ -230,8 +345,9 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
               APP_API_URL.toString() + "/ai-investigation/create-fix-task",
             ),
             data: {
-              subjectType: props.subjectType,
-              subjectId: props.subjectId.toString(),
+              subjectType,
+              subjectId: subjectIdString,
+              aiRunId: requestedRunId,
             },
             headers: ModelAPI.getCommonHeaders(),
           });
@@ -240,17 +356,31 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
           throw response;
         }
 
+        if (
+          requestedSubjectKey !== activeSubjectKeyRef.current ||
+          requestedRunId !== activeRunIdRef.current
+        ) {
+          return;
+        }
+
         const aiRunId: string | undefined = (response.data as JSONObject)[
           "aiRunId"
         ] as string | undefined;
 
         setFixTaskRunId(aiRunId || null);
       } catch (err) {
+        if (
+          requestedSubjectKey !== activeSubjectKeyRef.current ||
+          requestedRunId !== activeRunIdRef.current
+        ) {
+          return;
+        }
+
         setFixTaskError(API.getFriendlyMessage(err));
       }
 
       setIsCreatingFixTask(false);
-    }, [props.subjectType, props.subjectId]);
+    }, [runId, subjectIdString, subjectKey, subjectType]);
 
   /*
    * Human verdict on a completed analysis ("Was this analysis correct?").
@@ -261,7 +391,14 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
   const submitVerdict: (verdict: InvestigationVerdict) => Promise<void> =
     useCallback(
       async (verdict: InvestigationVerdict): Promise<void> => {
+        const requestedSubjectKey: string = subjectKey;
+        const requestedRunId: string | null = runId;
         const previousVerdict: string | null = humanVerdict;
+
+        if (!requestedRunId) {
+          setVerdictError("The investigation run could not be identified.");
+          return;
+        }
 
         setIsSavingVerdict(true);
         isSavingVerdictRef.current = true;
@@ -276,8 +413,9 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
                 APP_API_URL.toString() + "/ai-investigation/verdict",
               ),
               data: {
-                subjectType: props.subjectType,
-                subjectId: props.subjectId.toString(),
+                subjectType,
+                subjectId: subjectIdString,
+                aiRunId: requestedRunId,
                 verdict: verdict,
               },
               headers: ModelAPI.getCommonHeaders(),
@@ -286,7 +424,27 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
           if (response instanceof HTTPErrorResponse) {
             throw response;
           }
+
+          if (
+            requestedSubjectKey !== activeSubjectKeyRef.current ||
+            requestedRunId !== activeRunIdRef.current
+          ) {
+            return;
+          }
+
+          /*
+           * Any GET that started before this mutation carries the old verdict.
+           * Invalidate it before releasing the optimistic-state guard.
+           */
+          latestFetchRequestRef.current += 1;
         } catch (err) {
+          if (
+            requestedSubjectKey !== activeSubjectKeyRef.current ||
+            requestedRunId !== activeRunIdRef.current
+          ) {
+            return;
+          }
+
           // Roll back the optimistic update.
           setHumanVerdict(previousVerdict);
           setVerdictError(API.getFriendlyMessage(err));
@@ -295,7 +453,7 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
         setIsSavingVerdict(false);
         isSavingVerdictRef.current = false;
       },
-      [props.subjectType, props.subjectId, humanVerdict],
+      [humanVerdict, runId, subjectIdString, subjectKey, subjectType],
     );
 
   const isRunning: boolean = runStatus === AIRunStatus.Running;
@@ -303,38 +461,72 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
   // Poll while the run can still make progress (queued runs get claimed).
   const isActive: boolean = isRunning || isQueued;
   const isDiscoveringRun: boolean = hasLoadedOnce && runStatus === null;
+  /*
+   * A run is marked Completed just before its report is posted to the feed.
+   * The server bounds this state, so this cannot poll forever after a failed
+   * or empty post-analysis step.
+   */
+  const shouldPoll: boolean = isActive || isAnalysisPending;
+  /*
+   * Keep a much quieter watch after settlement (and while no run exists), so
+   * a new investigation launched elsewhere appears without a page refresh.
+   * Active/finalizing runs and the first few no-run discovery checks retain
+   * the fast live cadence.
+   */
+  const nextPollDelayInMs: number | null = shouldPoll
+    ? POLL_INTERVAL_MS
+    : isDiscoveringRun
+      ? POLL_INTERVAL_MS
+      : hasLoadedOnce && supportsSettledPolling
+        ? SETTLED_POLL_INTERVAL_MS
+        : null;
 
   useEffect(() => {
-    if (!isActive && !isDiscoveringRun) {
+    if (nextPollDelayInMs === null) {
       return;
     }
 
-    let timeout: ReturnType<typeof setTimeout> | undefined;
     let isCancelled: boolean = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     let discoveryPollCount: number = 0;
 
-    const scheduleNextPoll: () => void = (): void => {
+    const pollAfterDelay: (delayInMs: number) => void = (
+      delayInMs: number,
+    ): void => {
       timeout = setTimeout(() => {
         fetchData()
-          .finally(() => {
-            if (isDiscoveringRun) {
-              discoveryPollCount += 1;
-            }
-
-            if (
-              !isCancelled &&
-              (!isDiscoveringRun || discoveryPollCount < MAX_DISCOVERY_POLLS)
-            ) {
-              scheduleNextPoll();
-            }
-          })
           .catch(() => {
             // handled inside fetchData
+          })
+          .finally(() => {
+            if (isCancelled) {
+              return;
+            }
+
+            if (isDiscoveringRun) {
+              discoveryPollCount += 1;
+
+              if (discoveryPollCount < MAX_DISCOVERY_POLLS) {
+                pollAfterDelay(POLL_INTERVAL_MS);
+                return;
+              }
+
+              if (supportsSettledPolling) {
+                pollAfterDelay(SETTLED_POLL_INTERVAL_MS);
+              }
+              return;
+            }
+
+            pollAfterDelay(nextPollDelayInMs);
           });
-      }, POLL_INTERVAL_MS);
+      }, delayInMs);
     };
 
-    scheduleNextPoll();
+    /*
+     * Schedule the next poll only after the previous response settles. Slow
+     * deployments therefore cannot invalidate every in-flight response.
+     */
+    pollAfterDelay(nextPollDelayInMs);
 
     return () => {
       isCancelled = true;
@@ -342,10 +534,42 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
         clearTimeout(timeout);
       }
     };
-  }, [isActive, isDiscoveringRun, fetchData]);
+  }, [fetchData, isDiscoveringRun, nextPollDelayInMs, supportsSettledPolling]);
+
+  /*
+   * The report's presence proves the matching RootCause feed item exists.
+   * Notify the host exactly once so an already-mounted incident/alert feed
+   * can refresh at the correct side of the completion race.
+   */
+  useEffect(() => {
+    if (
+      loadedSubjectKey !== subjectKey ||
+      runStatus !== AIRunStatus.Completed ||
+      !analysisMarkdown ||
+      !runId
+    ) {
+      return;
+    }
+
+    const notificationKey: string = `${subjectKey}:${runId}`;
+
+    if (notifiedAnalysisRef.current.has(notificationKey)) {
+      return;
+    }
+
+    notifiedAnalysisRef.current.add(notificationKey);
+    props.onAnalysisAvailable?.();
+  }, [
+    analysisMarkdown,
+    loadedSubjectKey,
+    props.onAnalysisAvailable,
+    runId,
+    runStatus,
+    subjectKey,
+  ]);
 
   // Nothing to show until an investigation exists for this subject.
-  if (!hasLoadedOnce || !runStatus) {
+  if (!hasLoadedOnce || loadedSubjectKey !== subjectKey || !runStatus) {
     return <></>;
   }
 
@@ -377,18 +601,40 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
     };
     isFailed = false;
   } else if (runStatus === AIRunStatus.Completed) {
-    statusMeta = {
-      text: "Investigation complete",
-      className: "text-green-600",
-      icon: IconProp.Check,
-    };
+    statusMeta = !supportsSettledPolling
+      ? {
+          text: "Investigation complete",
+          className: "text-green-600",
+          icon: IconProp.Check,
+        }
+      : isAnalysisPending
+        ? {
+            text: "Preparing investigation report…",
+            className: "text-indigo-600",
+            icon: IconProp.Sparkles,
+          }
+        : analysisMarkdown
+          ? {
+              text: "Investigation complete",
+              className: "text-green-600",
+              icon: IconProp.Check,
+            }
+          : {
+              text: "Investigation completed without a report",
+              className: "text-amber-600",
+              icon: IconProp.Info,
+            };
     isFailed = false;
   }
 
   return (
     <Card
       title="AI Investigation"
-      description={`OneUptime AI's live root-cause investigation for this ${props.subjectType}.`}
+      description={
+        runStatus === AIRunStatus.Completed
+          ? `OneUptime AI's root-cause report for this ${subjectType}.`
+          : `OneUptime AI's live root-cause investigation for this ${subjectType}.`
+      }
     >
       <div
         id={AI_INVESTIGATION_PANEL_ID}
@@ -402,7 +648,7 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
         >
           <Icon icon={statusMeta.icon} className="h-4 w-4" />
           <span>{statusMeta.text}</span>
-          {isActive ? (
+          {shouldPoll ? (
             <span className="ml-1 inline-block h-2 w-2 motion-safe:animate-ping rounded-full bg-indigo-500" />
           ) : (
             <></>
@@ -415,28 +661,128 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
           <></>
         )}
 
-        <div className="mt-3">
-          {events.length > 0 ? (
-            <ChatActivityFeed events={events} />
-          ) : (
-            <p className="text-sm text-gray-500">
-              {isActive
-                ? "Starting investigation…"
-                : "No investigation steps were recorded."}
-            </p>
-          )}
-        </div>
+        {runStatus === AIRunStatus.Completed ? (
+          <div className="mt-4">
+            {analysisMarkdown ? (
+              <section
+                aria-label="Investigation report"
+                className="overflow-hidden rounded-xl border border-indigo-100 bg-white shadow-sm"
+              >
+                <div className="flex items-start gap-3 border-b border-indigo-100 bg-indigo-50/60 px-5 py-4">
+                  <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-indigo-600">
+                    <Icon
+                      icon={IconProp.DocumentText}
+                      className="h-4.5 w-4.5 text-white"
+                    />
+                  </div>
+                  <div>
+                    <h3 className="text-sm font-semibold text-gray-900">
+                      Investigation report
+                    </h3>
+                    <p className="mt-0.5 text-xs leading-5 text-gray-500">
+                      Root cause, supporting evidence, and recommended next
+                      steps from this investigation.
+                    </p>
+                  </div>
+                </div>
+                <div className="px-5 py-5 text-sm text-gray-700">
+                  <MarkdownViewer text={analysisMarkdown} safeMode={true} />
+                </div>
+              </section>
+            ) : isAnalysisPending ? (
+              <div
+                role="status"
+                className="flex items-center gap-3 rounded-xl border border-indigo-100 bg-indigo-50/50 px-5 py-4"
+              >
+                <span className="h-4 w-4 flex-shrink-0 animate-spin rounded-full border-2 border-indigo-200 border-t-indigo-600" />
+                <div>
+                  <p className="text-sm font-medium text-gray-800">
+                    Preparing the final report
+                  </p>
+                  <p className="mt-0.5 text-xs text-gray-500">
+                    The investigation is complete. OneUptime AI is organizing
+                    the findings and evidence.
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-xl border border-amber-200 bg-amber-50 px-5 py-4">
+                <p className="text-sm font-medium text-amber-800">
+                  No investigation report was published.
+                </p>
+                <p className="mt-1 text-xs leading-5 text-amber-700">
+                  The run finished without a final analysis. Review the activity
+                  below for details.
+                </p>
+              </div>
+            )}
+
+            {events.length > 0 ? (
+              <details className="group mt-3 rounded-lg border border-gray-200 bg-gray-50/50">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-gray-600 hover:text-gray-900">
+                  <span className="flex items-center gap-2">
+                    <Icon
+                      icon={IconProp.Activity}
+                      className="h-4 w-4 text-gray-400"
+                    />
+                    Investigation activity
+                    <span className="text-xs font-normal text-gray-400">
+                      {events.length} event{events.length === 1 ? "" : "s"}
+                    </span>
+                  </span>
+                  <Icon
+                    icon={IconProp.ChevronDown}
+                    className="h-4 w-4 text-gray-400 transition-transform group-open:rotate-180"
+                  />
+                </summary>
+                <div className="border-t border-gray-200 px-4 py-4">
+                  <ChatActivityFeed
+                    events={events}
+                    title="Completed activity"
+                    showLiveIndicator={false}
+                    maxVisibleSteps={10}
+                  />
+                </div>
+              </details>
+            ) : (
+              <></>
+            )}
+          </div>
+        ) : (
+          <div className="mt-3">
+            {events.length > 0 ? (
+              <ChatActivityFeed
+                events={events}
+                title={isFailed ? "Investigation activity" : undefined}
+                showLiveIndicator={!isFailed}
+              />
+            ) : (
+              <p className="text-sm text-gray-500">
+                {isActive
+                  ? "Starting investigation…"
+                  : "No investigation steps were recorded."}
+              </p>
+            )}
+          </div>
+        )}
 
         {!isRunning && stats ? (
-          <p className="mt-3 text-xs text-gray-400">
-            {stats.toolCallCount} quer
-            {stats.toolCallCount === 1 ? "y" : "ies"} across your telemetry
-            {stats.totalTokens > 0
-              ? ` · ${stats.totalTokens.toLocaleString()} tokens`
-              : ""}
-            . The full cited root cause is in the {props.subjectType} timeline
-            below.
-          </p>
+          <div
+            aria-label="Investigation usage"
+            className="mt-3 flex flex-wrap items-center gap-2 text-xs text-gray-500"
+          >
+            <span className="rounded-full bg-gray-100 px-2.5 py-1">
+              {stats.toolCallCount} telemetry quer
+              {stats.toolCallCount === 1 ? "y" : "ies"}
+            </span>
+            {stats.totalTokens > 0 ? (
+              <span className="rounded-full bg-gray-100 px-2.5 py-1">
+                {stats.totalTokens.toLocaleString()} tokens
+              </span>
+            ) : (
+              <></>
+            )}
+          </div>
         ) : (
           <></>
         )}
@@ -450,151 +796,165 @@ const InvestigationPanel: FunctionComponent<ComponentProps> = (
           verdicts feed the AI's measured accuracy.
         */}
         {runStatus === AIRunStatus.Completed ? (
-          <div className="mt-4">
-            {fixTaskRunId ? (
-              <Alert
-                type={AlertType.SUCCESS}
-                strongTitle="Fix task created"
-                title={
-                  <span>
-                    AI will open a pull request from this analysis.{" "}
-                    <Link
-                      className="underline"
-                      to={RouteUtil.populateRouteParams(
-                        RouteMap[PageMap.AI_AGENT_TASK_VIEW] as Route,
-                        { modelId: fixTaskRunId },
-                      )}
-                    >
-                      View task progress
-                    </Link>
-                    .
-                  </span>
-                }
-              />
-            ) : (
-              <>
-                {fixTaskError ? (
+          <div className="mt-5 border-t border-gray-200 pt-5">
+            <div className="grid gap-5 lg:grid-cols-2 lg:gap-6">
+              <div>
+                <p className="text-sm font-medium text-gray-800">
+                  Act on this investigation
+                </p>
+                <p className="mb-3 mt-1 text-xs leading-5 text-gray-500">
+                  Create a draft fix pull request with this report as context.
+                </p>
+                {fixTaskRunId ? (
+                  <Alert
+                    type={AlertType.SUCCESS}
+                    strongTitle="Fix task created"
+                    title={
+                      <span>
+                        AI will open a pull request from this analysis.{" "}
+                        <Link
+                          className="underline"
+                          to={RouteUtil.populateRouteParams(
+                            RouteMap[PageMap.AI_AGENT_TASK_VIEW] as Route,
+                            { modelId: fixTaskRunId },
+                          )}
+                        >
+                          View task progress
+                        </Link>
+                        .
+                      </span>
+                    }
+                  />
+                ) : (
+                  <>
+                    {fixTaskError ? (
+                      <div className="mb-3">
+                        <Alert
+                          type={AlertType.DANGER}
+                          strongTitle="Could not create the fix task"
+                          title={
+                            <span>
+                              {fixTaskError}{" "}
+                              <Link
+                                className="underline"
+                                to={RouteUtil.populateRouteParams(
+                                  RouteMap[PageMap.AI_AGENT_TASKS] as Route,
+                                )}
+                              >
+                                View AI tasks
+                              </Link>
+                              .
+                            </span>
+                          }
+                        />
+                      </div>
+                    ) : (
+                      <></>
+                    )}
+                    <Button
+                      title="Open Fix PR from this analysis"
+                      icon={IconProp.Code}
+                      buttonStyle={ButtonStyleType.OUTLINE}
+                      buttonSize={ButtonSize.Small}
+                      isLoading={isCreatingFixTask}
+                      disabled={!analysisMarkdown}
+                      onClick={() => {
+                        createFixTask().catch(() => {
+                          // handled inside createFixTask
+                        });
+                      }}
+                    />
+                  </>
+                )}
+              </div>
+
+              {/*
+                A quiet human verdict on the analysis. The server returns
+                `humanVerdict` on every investigation payload, so the state
+                survives polling refreshes; the buttons update optimistically.
+              */}
+              <div className="lg:border-l lg:border-gray-200 lg:pl-6">
+                <p className="text-sm font-medium text-gray-800">
+                  Rate this investigation
+                </p>
+                <p className="mb-3 mt-1 text-xs leading-5 text-gray-500">
+                  Your verdict helps measure OneUptime AI&apos;s public
+                  accuracy.
+                </p>
+                {verdictError ? (
                   <div className="mb-3">
                     <Alert
                       type={AlertType.DANGER}
-                      strongTitle="Could not create the fix task"
-                      title={
-                        <span>
-                          {fixTaskError}{" "}
-                          <Link
-                            className="underline"
-                            to={RouteUtil.populateRouteParams(
-                              RouteMap[PageMap.AI_AGENT_TASKS] as Route,
-                            )}
-                          >
-                            View AI tasks
-                          </Link>
-                          .
-                        </span>
-                      }
+                      strongTitle="Could not save your verdict"
+                      title={verdictError}
                     />
                   </div>
                 ) : (
                   <></>
                 )}
-                <Button
-                  title="Open Fix PR from this analysis"
-                  icon={IconProp.Code}
-                  buttonStyle={ButtonStyleType.OUTLINE}
-                  buttonSize={ButtonSize.Small}
-                  isLoading={isCreatingFixTask}
-                  onClick={() => {
-                    createFixTask().catch(() => {
-                      // handled inside createFixTask
-                    });
-                  }}
-                />
-              </>
-            )}
-
-            {/*
-              A quiet human verdict on the analysis. The server returns
-              `humanVerdict` on every investigation payload, so the state
-              survives polling refreshes; the buttons update optimistically.
-            */}
-            <div className="mt-4">
-              {verdictError ? (
-                <div className="mb-3">
-                  <Alert
-                    type={AlertType.DANGER}
-                    strongTitle="Could not save your verdict"
-                    title={verdictError}
-                  />
-                </div>
-              ) : (
-                <></>
-              )}
-              {humanVerdict && !isChangingVerdict ? (
-                <div className="flex items-center gap-2">
-                  <span
-                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
-                      humanVerdict === "Confirmed"
-                        ? "bg-green-50 text-green-700"
-                        : "bg-gray-100 text-gray-600"
-                    }`}
-                  >
-                    <Icon
-                      icon={
+                {humanVerdict && !isChangingVerdict ? (
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
                         humanVerdict === "Confirmed"
-                          ? IconProp.Check
-                          : IconProp.Close
-                      }
-                      className="h-3 w-3"
-                    />
-                    <span>
-                      You{" "}
-                      {humanVerdict === "Confirmed" ? "confirmed" : "rejected"}{" "}
-                      this analysis
+                          ? "bg-green-50 text-green-700"
+                          : "bg-gray-100 text-gray-600"
+                      }`}
+                    >
+                      <Icon
+                        icon={
+                          humanVerdict === "Confirmed"
+                            ? IconProp.Check
+                            : IconProp.Close
+                        }
+                        className="h-3 w-3"
+                      />
+                      <span>
+                        You{" "}
+                        {humanVerdict === "Confirmed"
+                          ? "confirmed"
+                          : "rejected"}{" "}
+                        this analysis
+                      </span>
                     </span>
-                  </span>
-                  <Link
-                    className="cursor-pointer text-xs text-gray-400 underline"
-                    onClick={() => {
-                      setIsChangingVerdict(true);
-                    }}
-                  >
-                    Change
-                  </Link>
-                </div>
-              ) : (
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-sm text-gray-600">
-                    Was this analysis correct?
-                  </span>
-                  <Button
-                    title="Confirmed"
-                    icon={IconProp.Check}
-                    buttonStyle={ButtonStyleType.SUCCESS_OUTLINE}
-                    buttonSize={ButtonSize.Small}
-                    disabled={isSavingVerdict}
-                    onClick={() => {
-                      submitVerdict("Confirmed").catch(() => {
-                        // handled inside submitVerdict
-                      });
-                    }}
-                  />
-                  <Button
-                    title="Rejected"
-                    icon={IconProp.Close}
-                    buttonStyle={ButtonStyleType.HOVER_DANGER_OUTLINE}
-                    buttonSize={ButtonSize.Small}
-                    disabled={isSavingVerdict}
-                    onClick={() => {
-                      submitVerdict("Rejected").catch(() => {
-                        // handled inside submitVerdict
-                      });
-                    }}
-                  />
-                </div>
-              )}
-              <p className="mt-1.5 text-xs text-gray-400">
-                Verdicts train OneUptime AI&apos;s public accuracy score.
-              </p>
+                    <Link
+                      className="cursor-pointer text-xs text-gray-400 underline"
+                      onClick={() => {
+                        setIsChangingVerdict(true);
+                      }}
+                    >
+                      Change
+                    </Link>
+                  </div>
+                ) : (
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                      title="Confirmed"
+                      icon={IconProp.Check}
+                      buttonStyle={ButtonStyleType.SUCCESS_OUTLINE}
+                      buttonSize={ButtonSize.Small}
+                      disabled={isSavingVerdict || !analysisMarkdown}
+                      onClick={() => {
+                        submitVerdict("Confirmed").catch(() => {
+                          // handled inside submitVerdict
+                        });
+                      }}
+                    />
+                    <Button
+                      title="Rejected"
+                      icon={IconProp.Close}
+                      buttonStyle={ButtonStyleType.HOVER_DANGER_OUTLINE}
+                      buttonSize={ButtonSize.Small}
+                      disabled={isSavingVerdict || !analysisMarkdown}
+                      onClick={() => {
+                        submitVerdict("Rejected").catch(() => {
+                          // handled inside submitVerdict
+                        });
+                      }}
+                    />
+                  </div>
+                )}
+              </div>
             </div>
           </div>
         ) : (

--- a/App/FeatureSet/Dashboard/src/Components/Alert/AlertFeed.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Alert/AlertFeed.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent, ReactElement, useEffect } from "react";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+  useRef,
+} from "react";
 import ObjectID from "Common/Types/ObjectID";
 import Card from "Common/UI/Components/Card/Card";
 import Feed from "Common/UI/Components/Feed/Feed";
@@ -33,14 +38,22 @@ import RunbookPicker from "../Runbook/RunbookPicker";
 
 export interface ComponentProps {
   alertId: ObjectID;
+  refreshToken?: number | undefined;
 }
 
 const AlertFeedElement: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  const alertIdString: string = props.alertId.toString();
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>(undefined);
   const [feedItems, setFeedItems] = React.useState<FeedItemProps[]>([]);
+  const [loadedAlertId, setLoadedAlertId] = React.useState<string | null>(null);
+  const latestFetchRequestRef: React.MutableRefObject<number> =
+    useRef<number>(0);
+  const activeAlertIdRef: React.MutableRefObject<string> =
+    useRef<string>(alertIdString);
+  activeAlertIdRef.current = alertIdString;
   const [showOnCallPolicyModal, setShowOnCallPolicyModal] =
     React.useState<boolean>(false);
 
@@ -68,6 +81,13 @@ const AlertFeedElement: FunctionComponent<ComponentProps> = (
     alertFeed: AlertFeed,
   ): FeedItemProps => {
     let icon: IconProp = IconProp.Circle;
+    const isAIInvestigation: boolean = Boolean(
+      alertFeed.alertFeedEventType === AlertFeedEventType.RootCause &&
+        (alertFeed.aiRunId ||
+          alertFeed.feedInfoInMarkdown?.includes(
+            "AI — Automated Root Cause Analysis",
+          )),
+    );
 
     if (alertFeed.alertFeedEventType === AlertFeedEventType.AlertCreated) {
       icon = IconProp.Alert;
@@ -115,7 +135,7 @@ const AlertFeedElement: FunctionComponent<ComponentProps> = (
     }
 
     if (alertFeed.alertFeedEventType === AlertFeedEventType.RootCause) {
-      icon = IconProp.Cube;
+      icon = isAIInvestigation ? IconProp.Sparkles : IconProp.Cube;
     }
 
     if (alertFeed.alertFeedEventType === AlertFeedEventType.OwnerUserRemoved) {
@@ -158,10 +178,21 @@ const AlertFeedElement: FunctionComponent<ComponentProps> = (
       itemDateTime: alertFeed.postedAt || alertFeed.createdAt!,
       color: alertFeed.displayColor || Gray500,
       icon: icon,
+      safeMode: isAIInvestigation,
     };
   };
 
   const fetchItems: PromiseVoidFunction = async (): Promise<void> => {
+    const requestId: number = latestFetchRequestRef.current + 1;
+    latestFetchRequestRef.current = requestId;
+    const requestedAlertId: string = alertIdString;
+    const isLatestRequest: () => boolean = (): boolean => {
+      return (
+        requestId === latestFetchRequestRef.current &&
+        requestedAlertId === activeAlertIdRef.current
+      );
+    };
+
     setError("");
     setIsLoading(true);
     try {
@@ -175,6 +206,7 @@ const AlertFeedElement: FunctionComponent<ComponentProps> = (
           feedInfoInMarkdown: true,
           displayColor: true,
           createdAt: true,
+          aiRunId: true,
           user: {
             name: true,
             email: true,
@@ -190,12 +222,20 @@ const AlertFeedElement: FunctionComponent<ComponentProps> = (
         limit: LIMIT_PER_PROJECT,
       });
 
-      setFeedItems(getFeedItemsFromAlertFeeds(alertFeeds.data));
+      if (isLatestRequest()) {
+        setFeedItems(getFeedItemsFromAlertFeeds(alertFeeds.data));
+        setLoadedAlertId(requestedAlertId);
+      }
     } catch (err: unknown) {
-      setError(API.getFriendlyMessage(err as Exception));
+      if (isLatestRequest()) {
+        setError(API.getFriendlyMessage(err as Exception));
+        setLoadedAlertId(requestedAlertId);
+      }
     }
 
-    setIsLoading(false);
+    if (isLatestRequest()) {
+      setIsLoading(false);
+    }
   };
 
   useEffect(() => {
@@ -206,7 +246,9 @@ const AlertFeedElement: FunctionComponent<ComponentProps> = (
     fetchItems().catch((err: unknown) => {
       setError(API.getFriendlyMessage(err as Exception));
     });
-  }, [props.alertId]);
+  }, [alertIdString, props.refreshToken]);
+
+  const isCurrentFeedLoaded: boolean = loadedAlertId === alertIdString;
 
   return (
     <Card
@@ -264,9 +306,9 @@ const AlertFeedElement: FunctionComponent<ComponentProps> = (
       ]}
     >
       <div>
-        {isLoading && <ComponentLoader />}
-        {error && <ErrorMessage message={error} />}
-        {!isLoading && !error && (
+        {(isLoading || !isCurrentFeedLoaded) && <ComponentLoader />}
+        {isCurrentFeedLoaded && error && <ErrorMessage message={error} />}
+        {isCurrentFeedLoaded && !isLoading && !error && (
           <Feed
             items={feedItems}
             noItemsMessage="Looks like there are no items in this feed for this alert."

--- a/App/FeatureSet/Dashboard/src/Components/Incident/IncidentFeed.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Incident/IncidentFeed.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent, ReactElement, useEffect } from "react";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+  useRef,
+} from "react";
 import ObjectID from "Common/Types/ObjectID";
 import Card from "Common/UI/Components/Card/Card";
 import Feed from "Common/UI/Components/Feed/Feed";
@@ -35,14 +40,24 @@ import RunbookPicker from "../Runbook/RunbookPicker";
 
 export interface ComponentProps {
   incidentId: ObjectID;
+  refreshToken?: number | undefined;
 }
 
 const IncidentFeedElement: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  const incidentIdString: string = props.incidentId.toString();
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>(undefined);
   const [feedItems, setFeedItems] = React.useState<FeedItemProps[]>([]);
+  const [loadedIncidentId, setLoadedIncidentId] = React.useState<string | null>(
+    null,
+  );
+  const latestFetchRequestRef: React.MutableRefObject<number> =
+    useRef<number>(0);
+  const activeIncidentIdRef: React.MutableRefObject<string> =
+    useRef<string>(incidentIdString);
+  activeIncidentIdRef.current = incidentIdString;
   const [showOnCallPolicyModal, setShowOnCallPolicyModal] =
     React.useState<boolean>(false);
 
@@ -75,6 +90,13 @@ const IncidentFeedElement: FunctionComponent<ComponentProps> = (
     incidentFeed: IncidentFeed,
   ): FeedItemProps => {
     let icon: IconProp = IconProp.Circle;
+    const isAIInvestigation: boolean = Boolean(
+      incidentFeed.incidentFeedEventType === IncidentFeedEventType.RootCause &&
+        (incidentFeed.aiRunId ||
+          incidentFeed.feedInfoInMarkdown?.includes(
+            "AI — Automated Root Cause Analysis",
+          )),
+    );
 
     if (
       incidentFeed.incidentFeedEventType ===
@@ -154,7 +176,7 @@ const IncidentFeedElement: FunctionComponent<ComponentProps> = (
     if (
       incidentFeed.incidentFeedEventType === IncidentFeedEventType.RootCause
     ) {
-      icon = IconProp.Cube;
+      icon = isAIInvestigation ? IconProp.Sparkles : IconProp.Cube;
     }
 
     if (
@@ -213,10 +235,21 @@ const IncidentFeedElement: FunctionComponent<ComponentProps> = (
       itemDateTime: incidentFeed.postedAt || incidentFeed.createdAt!,
       color: incidentFeed.displayColor || Gray500,
       icon: icon,
+      safeMode: isAIInvestigation,
     };
   };
 
   const fetchItems: PromiseVoidFunction = async (): Promise<void> => {
+    const requestId: number = latestFetchRequestRef.current + 1;
+    latestFetchRequestRef.current = requestId;
+    const requestedIncidentId: string = incidentIdString;
+    const isLatestRequest: () => boolean = (): boolean => {
+      return (
+        requestId === latestFetchRequestRef.current &&
+        requestedIncidentId === activeIncidentIdRef.current
+      );
+    };
+
     setError("");
     setIsLoading(true);
     try {
@@ -230,6 +263,7 @@ const IncidentFeedElement: FunctionComponent<ComponentProps> = (
           feedInfoInMarkdown: true,
           displayColor: true,
           createdAt: true,
+          aiRunId: true,
           user: {
             name: true,
             email: true,
@@ -245,12 +279,20 @@ const IncidentFeedElement: FunctionComponent<ComponentProps> = (
         limit: LIMIT_PER_PROJECT,
       });
 
-      setFeedItems(getFeedItemsFromIncidentFeeds(incidentFeeds.data));
+      if (isLatestRequest()) {
+        setFeedItems(getFeedItemsFromIncidentFeeds(incidentFeeds.data));
+        setLoadedIncidentId(requestedIncidentId);
+      }
     } catch (err: unknown) {
-      setError(API.getFriendlyMessage(err as Exception));
+      if (isLatestRequest()) {
+        setError(API.getFriendlyMessage(err as Exception));
+        setLoadedIncidentId(requestedIncidentId);
+      }
     }
 
-    setIsLoading(false);
+    if (isLatestRequest()) {
+      setIsLoading(false);
+    }
   };
 
   useEffect(() => {
@@ -261,7 +303,9 @@ const IncidentFeedElement: FunctionComponent<ComponentProps> = (
     fetchItems().catch((err: unknown) => {
       setError(API.getFriendlyMessage(err as Exception));
     });
-  }, [props.incidentId]);
+  }, [incidentIdString, props.refreshToken]);
+
+  const isCurrentFeedLoaded: boolean = loadedIncidentId === incidentIdString;
 
   return (
     <Card
@@ -327,9 +371,9 @@ const IncidentFeedElement: FunctionComponent<ComponentProps> = (
       ]}
     >
       <div>
-        {isLoading && <ComponentLoader />}
-        {error && <ErrorMessage message={error} />}
-        {!isLoading && !error && (
+        {(isLoading || !isCurrentFeedLoaded) && <ComponentLoader />}
+        {isCurrentFeedLoaded && error && <ErrorMessage message={error} />}
+        {isCurrentFeedLoaded && !isLoading && !error && (
           <Feed
             items={feedItems}
             noItemsMessage="Looks like there are no items in this feed for this incident."

--- a/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
@@ -28,6 +28,7 @@ import React, {
   Fragment,
   FunctionComponent,
   ReactElement,
+  useCallback,
   useEffect,
   useState,
 } from "react";
@@ -112,6 +113,14 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
   const [alertStartedAt, setAlertStartedAt] = useState<Date | undefined>(
     undefined,
   );
+  const [feedRefreshToken, setFeedRefreshToken] = useState<number>(0);
+
+  const refreshFeedAfterAnalysisAvailable: () => void =
+    useCallback((): void => {
+      setFeedRefreshToken((currentToken: number): number => {
+        return currentToken + 1;
+      });
+    }, []);
 
   const fetchData: PromiseVoidFunction = async (): Promise<void> => {
     try {
@@ -523,9 +532,13 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
 
           <RemediationSuggestionCard alertId={modelId} hideIfEmpty={true} />
 
-          <InvestigationPanel subjectType="alert" subjectId={modelId} />
+          <InvestigationPanel
+            subjectType="alert"
+            subjectId={modelId}
+            onAnalysisAvailable={refreshFeedAfterAnalysisAvailable}
+          />
 
-          <AlertFeedElement alertId={modelId} />
+          <AlertFeedElement alertId={modelId} refreshToken={feedRefreshToken} />
         </div>
 
         <div className="min-w-0 xl:col-span-1">

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
@@ -154,6 +154,14 @@ const IncidentView: FunctionComponent<
       },
       [modelIdString],
     );
+  const [feedRefreshToken, setFeedRefreshToken] = useState<number>(0);
+
+  const refreshFeedAfterAnalysisAvailable: () => void =
+    useCallback((): void => {
+      setFeedRefreshToken((currentToken: number): number => {
+        return currentToken + 1;
+      });
+    }, []);
 
   const fetchData: PromiseVoidFunction = async (): Promise<void> => {
     try {
@@ -583,9 +591,13 @@ const IncidentView: FunctionComponent<
             subjectType="incident"
             subjectId={modelId}
             onStatusChange={onAIInvestigationStatusChange}
+            onAnalysisAvailable={refreshFeedAfterAnalysisAvailable}
           />
 
-          <IncidentFeedElement incidentId={modelId} />
+          <IncidentFeedElement
+            incidentId={modelId}
+            refreshToken={feedRefreshToken}
+          />
         </div>
 
         <div className="min-w-0 xl:col-span-1">

--- a/App/FeatureSet/Workers/Jobs/AIChat/TimeoutStuckRuns.ts
+++ b/App/FeatureSet/Workers/Jobs/AIChat/TimeoutStuckRuns.ts
@@ -49,6 +49,7 @@ RunCron(
         conversationId: true,
         runType: true,
         attemptCount: true,
+        lastHeartbeatAt: true,
         projectId: true,
         triggeredByIncidentId: true,
         triggeredByAlertId: true,
@@ -93,10 +94,11 @@ RunCron(
            * remediation (RCA-first ordering) must be released even when
            * the investigation died without retries left.
            */
-          const outcome: "requeued" | "stale" =
+          const outcome: "requeued" | "stale" | "noop" =
             await AIInvestigationQueue.requeueOrMarkStale({
               id: run.id!,
               attemptCount: run.attemptCount || 0,
+              lastHeartbeatAt: run.lastHeartbeatAt,
               runType: run.runType,
               projectId: run.projectId,
               triggeredByIncidentId: run.triggeredByIncidentId,

--- a/Common/Models/DatabaseModels/AlertFeed.ts
+++ b/Common/Models/DatabaseModels/AlertFeed.ts
@@ -93,6 +93,7 @@ export enum AlertFeedEventType {
     "Log of the entire alert state change. This is a log of all the alert state changes, public notes, more etc.",
 })
 @Index(["alertId", "postedAt"]) // Alert detail page: feed sorted by postedAt
+@Index(["alertId", "aiRunId"]) // Exact AI investigation result lookup
 export default class AlertFeed extends BaseModel {
   @ColumnAccessControl({
     create: [
@@ -250,6 +251,35 @@ export default class AlertFeed extends BaseModel {
     transformer: ObjectID.getDatabaseTransformer(),
   })
   public alertId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.AlertAdmin,
+      Permission.AlertMember,
+      Permission.AlertViewer,
+      Permission.ReadAlertFeed,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    required: false,
+    canReadOnRelationQuery: true,
+    title: "AI Run ID",
+    description:
+      "AI investigation run that produced this feed item when the event is a root cause.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public aiRunId?: ObjectID = undefined;
 
   @ColumnAccessControl({
     create: [

--- a/Common/Models/DatabaseModels/IncidentFeed.ts
+++ b/Common/Models/DatabaseModels/IncidentFeed.ts
@@ -93,6 +93,7 @@ export enum IncidentFeedEventType {
     "Log of the entire incident state change. This is a log of all the incident state changes, public notes, more etc.",
 })
 @Index(["incidentId", "postedAt"]) // Incident detail page: feed sorted by postedAt
+@Index(["incidentId", "aiRunId"]) // Exact AI investigation result lookup
 export default class IncidentFeed extends BaseModel {
   @ColumnAccessControl({
     create: [
@@ -252,6 +253,35 @@ export default class IncidentFeed extends BaseModel {
     transformer: ObjectID.getDatabaseTransformer(),
   })
   public incidentId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.IncidentAdmin,
+      Permission.IncidentMember,
+      Permission.IncidentViewer,
+      Permission.ReadIncidentFeed,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    required: false,
+    canReadOnRelationQuery: true,
+    title: "AI Run ID",
+    description:
+      "AI investigation run that produced this feed item when the event is a root cause.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public aiRunId?: ObjectID = undefined;
 
   @ColumnAccessControl({
     create: [

--- a/Common/Server/API/AIAgentDataAPI.ts
+++ b/Common/Server/API/AIAgentDataAPI.ts
@@ -7,8 +7,7 @@ import AIRunService from "../Services/AIRunService";
 import AIRunEventService from "../Services/AIRunEventService";
 import IncidentService from "../Services/IncidentService";
 import AlertService from "../Services/AlertService";
-import IncidentFeedService from "../Services/IncidentFeedService";
-import AlertFeedService from "../Services/AlertFeedService";
+import PostedRootCause from "../Utils/AI/SRE/PostedRootCause";
 import Express, {
   ExpressRequest,
   ExpressResponse,
@@ -27,12 +26,6 @@ import AIAgentTaskPullRequest from "../../Models/DatabaseModels/AIAgentTaskPullR
 import AIRun from "../../Models/DatabaseModels/AIRun";
 import Incident from "../../Models/DatabaseModels/Incident";
 import Alert from "../../Models/DatabaseModels/Alert";
-import IncidentFeed, {
-  IncidentFeedEventType,
-} from "../../Models/DatabaseModels/IncidentFeed";
-import AlertFeed, {
-  AlertFeedEventType,
-} from "../../Models/DatabaseModels/AlertFeed";
 import AIRunEventType from "../../Types/AI/AIRunEventType";
 import AIRunType from "../../Types/AI/AIRunType";
 import FixVerificationStatus from "../../Types/AI/FixVerificationStatus";
@@ -62,7 +55,6 @@ import {
   LLMToolCall,
   LLMToolDefinition,
 } from "../Utils/LLM/LLMService";
-import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import BadDataException from "../../Types/Exception/BadDataException";
 import { JSONObject } from "../../Types/JSON";
 import ObjectID from "../../Types/ObjectID";
@@ -864,7 +856,20 @@ export default class AIAgentDataAPI {
            * fine when the subject has no monitor.
            */
           let serviceName: string | null = null;
-          let analysisMarkdown: string | null = null;
+          let analysisMarkdown: string | null =
+            run.taskContext?.sourceInvestigationAnalysisMarkdown?.trim() ||
+            null;
+          const sourceInvestigationRunIdString: string | undefined =
+            run.taskContext?.sourceInvestigationRunId;
+
+          if (sourceInvestigationRunIdString) {
+            ObjectID.validateUUID(sourceInvestigationRunIdString);
+          }
+
+          const sourceInvestigationRunId: ObjectID | undefined =
+            sourceInvestigationRunIdString
+              ? new ObjectID(sourceInvestigationRunIdString)
+              : undefined;
 
           if (run.triggeredByIncidentId) {
             const incident: Incident | null = await IncidentService.findOneById(
@@ -900,24 +905,14 @@ export default class AIAgentDataAPI {
                 })
                 .filter(Boolean)[0] || null;
 
-            const feedItem: IncidentFeed | null =
-              await IncidentFeedService.findOneBy({
-                query: {
-                  incidentId: run.triggeredByIncidentId,
-                  incidentFeedEventType: IncidentFeedEventType.RootCause,
-                },
-                select: {
-                  feedInfoInMarkdown: true,
-                },
-                sort: {
-                  createdAt: SortOrder.Descending,
-                },
-                props: {
-                  isRoot: true,
-                },
-              });
-
-            analysisMarkdown = feedItem?.feedInfoInMarkdown || null;
+            if (!analysisMarkdown) {
+              analysisMarkdown = await PostedRootCause.getForIncident(
+                run.triggeredByIncidentId,
+                sourceInvestigationRunId
+                  ? { aiRunId: sourceInvestigationRunId }
+                  : undefined,
+              );
+            }
           } else {
             const alert: Alert | null = await AlertService.findOneById({
               id: run.triggeredByAlertId!,
@@ -945,25 +940,14 @@ export default class AIAgentDataAPI {
             subjectTitle = alert.title || "Untitled alert";
             serviceName = alert.monitor?.name || null;
 
-            const feedItem: AlertFeed | null = await AlertFeedService.findOneBy(
-              {
-                query: {
-                  alertId: run.triggeredByAlertId!,
-                  alertFeedEventType: AlertFeedEventType.RootCause,
-                },
-                select: {
-                  feedInfoInMarkdown: true,
-                },
-                sort: {
-                  createdAt: SortOrder.Descending,
-                },
-                props: {
-                  isRoot: true,
-                },
-              },
-            );
-
-            analysisMarkdown = feedItem?.feedInfoInMarkdown || null;
+            if (!analysisMarkdown) {
+              analysisMarkdown = await PostedRootCause.getForAlert(
+                run.triggeredByAlertId!,
+                sourceInvestigationRunId
+                  ? { aiRunId: sourceInvestigationRunId }
+                  : undefined,
+              );
+            }
           }
 
           if (!analysisMarkdown) {

--- a/Common/Server/API/AIInvestigationAPI.ts
+++ b/Common/Server/API/AIInvestigationAPI.ts
@@ -16,6 +16,8 @@ import Query from "../../Types/BaseDatabase/Query";
 import { JSONArray, JSONObject } from "../../Types/JSON";
 import AIRunType from "../../Types/AI/AIRunType";
 import AIRunHumanVerdict from "../../Types/AI/AIRunHumanVerdict";
+import AIRunStatus from "../../Types/AI/AIRunStatus";
+import AIRunEventType from "../../Types/AI/AIRunEventType";
 import AIRun from "../../Models/DatabaseModels/AIRun";
 import AIRunEvent from "../../Models/DatabaseModels/AIRunEvent";
 import Incident from "../../Models/DatabaseModels/Incident";
@@ -32,6 +34,7 @@ import SpanService from "../Services/SpanService";
 import FixFromIncidentTaskTrigger from "../Utils/AI/SRE/FixFromIncidentTaskTrigger";
 import FixPerformanceTaskTrigger from "../Utils/AI/SRE/FixPerformanceTaskTrigger";
 import TelemetryImprovementTaskTrigger from "../Utils/AI/SRE/TelemetryImprovementTaskTrigger";
+import PostedRootCause from "../Utils/AI/SRE/PostedRootCause";
 import CodeFixTaskType from "../../Types/AI/CodeFixTaskType";
 import { AnalyzableSpan } from "../Utils/AI/PerfEvidence/SpanTreeAnalyzer";
 
@@ -46,6 +49,69 @@ const router: ExpressRouter = Express.getRouter();
 const MAX_ANALYZED_TRACE_SPANS: number = 500;
 
 const MAX_EVENTS: number = 500;
+
+/*
+ * The run wins its Running -> Completed transition before it performs the
+ * confidence check and posts the RootCause feed item. A final RunCompleted or
+ * RunFailed event is emitted when that finalization settles; failures from
+ * retried attempts precede a later RunStarted. This upper bound is a crash
+ * failsafe and deliberately leaves ample margin above the bounded confidence
+ * classification deadline plus feed publication.
+ */
+export const ANALYSIS_FINALIZATION_TIMEOUT_MS: number = 10 * 60 * 1000;
+// Database/application clocks can differ briefly around the Completed write.
+export const ANALYSIS_COMPLETION_CLOCK_SKEW_MS: number = 60 * 1000;
+
+export function isAnalysisPendingForRun(data: {
+  run: AIRun;
+  events: Array<AIRunEvent>;
+  analysisMarkdown: string | null;
+  currentDate?: Date | undefined;
+}): boolean {
+  if (
+    data.run.status !== AIRunStatus.Completed ||
+    data.analysisMarkdown ||
+    !data.run.completedAt
+  ) {
+    return false;
+  }
+
+  /*
+   * A retried run retains RunFailed from earlier attempts. Only a settlement
+   * event emitted after the latest RunStarted belongs to the attempt that won
+   * the Completed transition; an older failure must not stop report polling.
+   * sendLatestInvestigation supplies events in sequence order.
+   */
+  let latestRunStartedIndex: number = -1;
+  data.events.forEach((event: AIRunEvent, index: number): void => {
+    if (event.eventType === AIRunEventType.RunStarted) {
+      latestRunStartedIndex = index;
+    }
+  });
+
+  const hasFinalizationEvent: boolean = data.events.some(
+    (event: AIRunEvent, index: number): boolean => {
+      return (
+        index > latestRunStartedIndex &&
+        (event.eventType === AIRunEventType.RunCompleted ||
+          event.eventType === AIRunEventType.RunFailed)
+      );
+    },
+  );
+
+  if (hasFinalizationEvent) {
+    return false;
+  }
+
+  const currentDate: Date = data.currentDate || new Date();
+  const millisecondsSinceCompletion: number =
+    currentDate.getTime() - data.run.completedAt.getTime();
+
+  return (
+    millisecondsSinceCompletion >= -ANALYSIS_COMPLETION_CLOCK_SKEW_MS &&
+    millisecondsSinceCompletion < ANALYSIS_FINALIZATION_TIMEOUT_MS
+  );
+}
 
 /*
  * Returns the latest AI investigation (the AIRun + its ordered
@@ -80,6 +146,10 @@ async function sendLatestInvestigation(
   req: ExpressRequest,
   res: ExpressResponse,
   runQuery: Query<AIRun>,
+  subject: {
+    incidentId?: ObjectID | undefined;
+    alertId?: ObjectID | undefined;
+  },
 ): Promise<void> {
   const runs: Array<AIRun> = await AIRunService.findBy({
     query: runQuery,
@@ -111,6 +181,8 @@ async function sendLatestInvestigation(
     Response.sendJsonObjectResponse(req, res, {
       run: null,
       events: [],
+      analysisMarkdown: null,
+      isAnalysisPending: false,
     });
     return;
   }
@@ -138,9 +210,32 @@ async function sendLatestInvestigation(
 
   const eventsJson: JSONArray = BaseModel.toJSONArray(events, AIRunEvent);
 
+  /*
+   * RootCause is the canonical persisted investigation result. The explicit
+   * aiRunId association is immune to application/database clock skew and to
+   * overlapping investigations posting out of order.
+   */
+  let analysisMarkdown: string | null = null;
+
+  if (run.status === AIRunStatus.Completed && run.completedAt) {
+    analysisMarkdown = await PostedRootCause.getForInvestigation({
+      ...subject,
+      aiRunId: run.id!,
+      runCompletedAt: run.completedAt,
+    });
+  }
+
+  const isAnalysisPending: boolean = isAnalysisPendingForRun({
+    run,
+    events,
+    analysisMarkdown,
+  });
+
   Response.sendJsonObjectResponse(req, res, {
     run: runJson || null,
     events: eventsJson,
+    analysisMarkdown,
+    isAnalysisPending,
   });
 }
 
@@ -178,10 +273,17 @@ router.post(
         );
       }
 
-      await sendLatestInvestigation(req, res, {
-        triggeredByIncidentId: incidentId,
-        runType: AIRunType.Investigation,
-      });
+      await sendLatestInvestigation(
+        req,
+        res,
+        {
+          triggeredByIncidentId: incidentId,
+          runType: AIRunType.Investigation,
+        },
+        {
+          incidentId,
+        },
+      );
       return;
     } catch (err) {
       next(err);
@@ -224,10 +326,17 @@ router.post(
         );
       }
 
-      await sendLatestInvestigation(req, res, {
-        triggeredByAlertId: alertId,
-        runType: AIRunType.Investigation,
-      });
+      await sendLatestInvestigation(
+        req,
+        res,
+        {
+          triggeredByAlertId: alertId,
+          runType: AIRunType.Investigation,
+        },
+        {
+          alertId,
+        },
+      );
       return;
     } catch (err) {
       next(err);
@@ -238,13 +347,13 @@ router.post(
 
 /*
  * Human verdict capture (Phase 2 measurement layer): one-click Confirm /
- * Reject on the investigation panel. Applies to the LATEST COMPLETED
- * investigation run for the subject; overwriting is allowed (a user may
+ * Reject on the investigation panel. Applies to the exact COMPLETED
+ * investigation run displayed to the user; overwriting is allowed (a user may
  * change their mind), and the request is rejected when no completed
  * investigation exists. The subject is access-checked under the USER's
  * permissions first (same idiom as the read routes above); the run itself is
  * written as root because investigation runs are system-authored.
- * Body: { subjectType: "incident" | "alert", subjectId,
+ * Body: { subjectType: "incident" | "alert", subjectId, aiRunId,
  * verdict: "Confirmed" | "Rejected" }. Response: { runId, verdict }.
  */
 router.post(
@@ -278,6 +387,17 @@ router.post(
 
       const subjectId: ObjectID = new ObjectID(subjectIdString);
 
+      const aiRunIdString: string | undefined = req.body["aiRunId"] as
+        | string
+        | undefined;
+
+      if (!aiRunIdString) {
+        throw new BadDataException("aiRunId is required.");
+      }
+
+      ObjectID.validateUUID(aiRunIdString);
+      const aiRunId: ObjectID = new ObjectID(aiRunIdString);
+
       const verdict: string | undefined = req.body["verdict"] as
         | string
         | undefined;
@@ -292,34 +412,42 @@ router.post(
       }
 
       // Access check under the USER's permissions (null when not allowed).
+      let projectId: ObjectID | undefined = undefined;
+
       if (subjectType === "incident") {
         const incident: Incident | null = await IncidentService.findOneById({
           id: subjectId,
-          select: { _id: true },
+          select: { _id: true, projectId: true },
           props,
         });
 
-        if (!incident) {
+        if (!incident || !incident.projectId) {
           throw new BadDataException(
             "Incident not found (or you do not have access to it).",
           );
         }
+
+        projectId = incident.projectId;
       } else {
         const alert: Alert | null = await AlertService.findOneById({
           id: subjectId,
-          select: { _id: true },
+          select: { _id: true, projectId: true },
           props,
         });
 
-        if (!alert) {
+        if (!alert || !alert.projectId) {
           throw new BadDataException(
             "Alert not found (or you do not have access to it).",
           );
         }
+
+        projectId = alert.projectId;
       }
 
       const result: { runId: ObjectID; verdict: AIRunHumanVerdict } =
-        await AIRunService.applyHumanVerdictToLatestInvestigation({
+        await AIRunService.applyHumanVerdictToInvestigation({
+          aiRunId,
+          projectId,
           ...(subjectType === "incident"
             ? { incidentId: subjectId }
             : { alertId: subjectId }),
@@ -346,7 +474,7 @@ router.post(
  * access-checked under the USER's permissions first (same idiom as the read
  * routes above); the trigger's gates (completed investigation, GitHub-App
  * repository, per-subject dedupe) fail early with a clear message.
- * Body: { subjectType: "incident" | "alert", subjectId }. Response:
+ * Body: { subjectType: "incident" | "alert", subjectId, aiRunId }. Response:
  * { aiRunId } — the Queued CodeFix run the agent worker will claim.
  */
 router.post(
@@ -379,6 +507,17 @@ router.post(
       }
 
       const subjectId: ObjectID = new ObjectID(subjectIdString);
+
+      const aiRunIdString: string | undefined = req.body["aiRunId"] as
+        | string
+        | undefined;
+
+      if (!aiRunIdString) {
+        throw new BadDataException("aiRunId is required.");
+      }
+
+      ObjectID.validateUUID(aiRunIdString);
+      const aiRunId: ObjectID = new ObjectID(aiRunIdString);
 
       // Access check under the USER's permissions (null when not allowed).
       let projectId: ObjectID | undefined = undefined;
@@ -419,6 +558,7 @@ router.post(
           ...(subjectType === "incident"
             ? { incidentId: subjectId }
             : { alertId: subjectId }),
+          investigationRunId: aiRunId,
           userId: props.userId!,
         });
 

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786105470826-MigrationName.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786105470826-MigrationName.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MigrationName1786105470826 implements MigrationInterface {
+  public name = "MigrationName1786105470826";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "IncidentFeed" ADD "aiRunId" uuid`);
+    await queryRunner.query(`ALTER TABLE "AlertFeed" ADD "aiRunId" uuid`);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_bae064a2cf9282fc2cca934d78" ON "IncidentFeed" ("incidentId", "aiRunId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_7da528b06c0ae8b2f1b6c9c848" ON "AlertFeed" ("alertId", "aiRunId") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_7da528b06c0ae8b2f1b6c9c848"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_bae064a2cf9282fc2cca934d78"`,
+    );
+    await queryRunner.query(`ALTER TABLE "AlertFeed" DROP COLUMN "aiRunId"`);
+    await queryRunner.query(`ALTER TABLE "IncidentFeed" DROP COLUMN "aiRunId"`);
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -504,6 +504,7 @@ import { WidenHashedStringColumnsForScrypt1786023262402 } from "./1786023262402-
 import { AddTimeRangeToLogSavedView1786096660558 } from "./1786096660558-AddTimeRangeToLogSavedView";
 import { RestoreServiceLowerNameIndex1786100000000 } from "./1786100000000-RestoreServiceLowerNameIndex";
 import { MigrationName1786101798351 } from "./1786101798351-MigrationName";
+import { MigrationName1786105470826 } from "./1786105470826-MigrationName";
 import { RestoreDroppedUniqueIndexes1786200000000 } from "./1786200000000-RestoreDroppedUniqueIndexes";
 import { QuarantineUnboundGitHubInstallations1786300000000 } from "./1786300000000-QuarantineUnboundGitHubInstallations";
 import { AddMasterPasswordSalt1786400000000 } from "./1786400000000-AddMasterPasswordSalt";
@@ -1018,4 +1019,5 @@ export default [
   QuarantineUnboundGitHubInstallations1786300000000,
   MigrationName1786101798351,
   AddMasterPasswordSalt1786400000000,
+  MigrationName1786105470826,
 ];

--- a/Common/Server/Services/AIRunService.ts
+++ b/Common/Server/Services/AIRunService.ts
@@ -52,8 +52,8 @@ export class Service extends DatabaseService<Model> {
   /*
    * A genuinely atomic status transition: one conditional UPDATE whose WHERE
    * carries the expected current status (and optionally the expected
-   * attemptCount). Returns the number of rows changed — 0 means another
-   * actor won the race.
+   * attemptCount / heartbeat snapshot). Returns the number of rows changed —
+   * 0 means another actor won the race or refreshed the heartbeat.
    *
    * This exists because updateOneBy is SELECT-then-save: two concurrent
    * callers can both observe the precondition and both write, so it cannot
@@ -65,6 +65,7 @@ export class Service extends DatabaseService<Model> {
     aiRunId: ObjectID;
     fromStatus: AIRunStatus;
     expectedAttemptCount?: number | undefined;
+    expectedLastHeartbeatAt?: Date | undefined;
     set: AIRunTransitionSet;
   }): Promise<number> {
     const queryBuilder: UpdateQueryBuilder<Model> = this.getRepository()
@@ -78,6 +79,12 @@ export class Service extends DatabaseService<Model> {
     if (data.expectedAttemptCount !== undefined) {
       queryBuilder.andWhere('"attemptCount" = :expectedAttemptCount', {
         expectedAttemptCount: data.expectedAttemptCount,
+      });
+    }
+
+    if (data.expectedLastHeartbeatAt !== undefined) {
+      queryBuilder.andWhere('"lastHeartbeatAt" = :expectedLastHeartbeatAt', {
+        expectedLastHeartbeatAt: data.expectedLastHeartbeatAt,
       });
     }
 
@@ -296,7 +303,7 @@ export class Service extends DatabaseService<Model> {
 
   /*
    * Measurement layer (Phase 2): record a human's one-click verdict
-   * (Confirmed / Rejected) on the LATEST COMPLETED investigation run for an
+   * (Confirmed / Rejected) on one exact COMPLETED investigation run for an
    * incident or alert. Overwriting an existing verdict is deliberate — a
    * user may change their mind; the verdict is per-run state, not an audit
    * trail. Throws when no completed investigation exists for the subject.
@@ -305,7 +312,9 @@ export class Service extends DatabaseService<Model> {
    * are system-authored, so the per-user privacy pin would hide them).
    */
   @CaptureSpan()
-  public async applyHumanVerdictToLatestInvestigation(data: {
+  public async applyHumanVerdictToInvestigation(data: {
+    aiRunId: ObjectID;
+    projectId: ObjectID;
     incidentId?: ObjectID | undefined;
     alertId?: ObjectID | undefined;
     verdict: AIRunHumanVerdict;
@@ -319,6 +328,8 @@ export class Service extends DatabaseService<Model> {
 
     const run: Model | null = await this.findOneBy({
       query: {
+        _id: data.aiRunId,
+        projectId: data.projectId,
         runType: AIRunType.Investigation,
         status: AIRunStatus.Completed,
         ...(data.incidentId
@@ -326,13 +337,12 @@ export class Service extends DatabaseService<Model> {
           : { triggeredByAlertId: data.alertId! }),
       },
       select: { _id: true },
-      sort: { createdAt: SortOrder.Descending },
       props: { isRoot: true },
     });
 
     if (!run || !run.id) {
       throw new BadDataException(
-        "No completed AI investigation exists for this subject yet — a verdict can only be recorded on a completed investigation.",
+        "The selected completed AI investigation does not exist for this subject — refresh the page before recording a verdict.",
       );
     }
 

--- a/Common/Server/Services/AlertFeedService.ts
+++ b/Common/Server/Services/AlertFeedService.ts
@@ -84,6 +84,7 @@ export class Service extends DatabaseService<Model> {
     displayColor?: Color | undefined;
     userId?: ObjectID | undefined;
     postedAt?: Date | undefined;
+    aiRunId?: ObjectID | undefined;
     workspaceNotification?:
       | {
           notifyUserId?: ObjectID | undefined; // this is oneuptime user id.
@@ -125,6 +126,10 @@ export class Service extends DatabaseService<Model> {
       alertFeed.feedInfoInMarkdown = data.feedInfoInMarkdown;
       alertFeed.alertFeedEventType = data.alertFeedEventType;
       alertFeed.projectId = data.projectId;
+
+      if (data.aiRunId) {
+        alertFeed.aiRunId = data.aiRunId;
+      }
 
       if (!data.postedAt) {
         alertFeed.postedAt = OneUptimeDate.getCurrentDate();

--- a/Common/Server/Services/IncidentFeedService.ts
+++ b/Common/Server/Services/IncidentFeedService.ts
@@ -84,6 +84,7 @@ export class Service extends DatabaseService<IncidentFeed> {
     displayColor?: Color | undefined;
     userId?: ObjectID | undefined;
     postedAt?: Date | undefined;
+    aiRunId?: ObjectID | undefined;
     // send notifificatin to slack and teams. This is optional
     workspaceNotification?:
       | {
@@ -130,6 +131,10 @@ export class Service extends DatabaseService<IncidentFeed> {
       incidentFeed.feedInfoInMarkdown = data.feedInfoInMarkdown;
       incidentFeed.incidentFeedEventType = data.incidentFeedEventType;
       incidentFeed.projectId = data.projectId;
+
+      if (data.aiRunId) {
+        incidentFeed.aiRunId = data.aiRunId;
+      }
 
       if (!data.postedAt) {
         incidentFeed.postedAt = OneUptimeDate.getCurrentDate();

--- a/Common/Server/Utils/AI/SRE/AIInvestigationEngine.ts
+++ b/Common/Server/Utils/AI/SRE/AIInvestigationEngine.ts
@@ -270,7 +270,7 @@ export default class AIInvestigationEngine {
        * EVERY step — a slow self-hosted LLM call can approach the sweeper's
        * timeout, so the heartbeat must be as frequent as we can make it.
        */
-      await this.touchHeartbeat(aiRunId);
+      await this.touchHeartbeat(aiRunId, data.attemptCount);
     };
 
     /*
@@ -316,6 +316,7 @@ export default class AIInvestigationEngine {
         {
           aiRunId,
           fromStatus: AIRunStatus.Running,
+          expectedAttemptCount: data.attemptCount,
           set: {
             status: AIRunStatus.Completed,
             completedAt: OneUptimeDate.getCurrentDate(),
@@ -336,13 +337,6 @@ export default class AIInvestigationEngine {
 
       settledAsCompleted = true;
 
-      await this.emitEvent({
-        projectId,
-        aiRunId,
-        sequence: sequence++,
-        eventType: AIRunEventType.RunCompleted,
-      });
-
       const analysis: string = (result.contentInMarkdown || "").trim();
 
       if (!analysis) {
@@ -354,6 +348,13 @@ export default class AIInvestigationEngine {
          * No analysis is still a settled run — the subject must not lose
          * its deferred remediation because the model had nothing to say.
          */
+        await this.emitEvent({
+          projectId,
+          aiRunId,
+          sequence: sequence++,
+          eventType: AIRunEventType.RunCompleted,
+        });
+
         await this.invokeOnSettled(request, aiRunId);
         return;
       }
@@ -390,6 +391,20 @@ export default class AIInvestigationEngine {
         result,
       });
 
+      /*
+       * RunCompleted is the durable publication-settlement signal, not just
+       * the earlier status CAS. The dashboard keeps polling a Completed run
+       * until either the matching report exists or this final event proves
+       * that finalization ended without one. If confidence/postAnalysis
+       * throws, the catch path emits RunFailed instead.
+       */
+      await this.emitEvent({
+        projectId,
+        aiRunId,
+        sequence: sequence++,
+        eventType: AIRunEventType.RunCompleted,
+      });
+
       logger.debug(
         `AI: investigation complete (run ${aiRunId.toString()}, confident=${confidence.confident} via ${confidence.source}, ${result.llmCallCount} LLM calls, ${result.toolCallCount} tools, ${result.totalTokens} tokens).`,
       );
@@ -399,13 +414,6 @@ export default class AIInvestigationEngine {
     } catch (error) {
       const message: string =
         error instanceof Error ? error.message : String(error);
-
-      await this.emitEvent({
-        projectId,
-        aiRunId,
-        sequence: sequence++,
-        eventType: AIRunEventType.RunFailed,
-      });
 
       /*
        * Hand the failure to the queue's retry policy: transient errors
@@ -434,7 +442,22 @@ export default class AIInvestigationEngine {
        * settled (the retry owns it), and "noop" without a won Completed
        * means another actor moved the run and owns settlement.
        */
-      if (settledAsCompleted || outcome === "finalized") {
+      const ownsTerminalOutcome: boolean =
+        settledAsCompleted || outcome === "finalized";
+
+      if (ownsTerminalOutcome) {
+        /*
+         * Emit terminal failure only after ownership is established. A stale
+         * or requeued attempt can finish after the retry's RunStarted; letting
+         * it append RunFailed would falsely look like the retry settled.
+         */
+        await this.emitEvent({
+          projectId,
+          aiRunId,
+          sequence: sequence++,
+          eventType: AIRunEventType.RunFailed,
+        });
+
         await this.invokeOnSettled(request, aiRunId);
       }
 
@@ -492,14 +515,19 @@ export default class AIInvestigationEngine {
   }
 
   // Refresh lastHeartbeatAt so a long-running investigation isn't swept as stale.
-  private static async touchHeartbeat(aiRunId: ObjectID): Promise<void> {
+  private static async touchHeartbeat(
+    aiRunId: ObjectID,
+    attemptCount: number,
+  ): Promise<void> {
     try {
-      await AIRunService.updateOneBy({
-        query: { _id: aiRunId.toString(), status: AIRunStatus.Running },
-        data: {
+      await AIRunService.attemptStatusTransition({
+        aiRunId,
+        fromStatus: AIRunStatus.Running,
+        expectedAttemptCount: attemptCount,
+        set: {
+          status: AIRunStatus.Running,
           lastHeartbeatAt: OneUptimeDate.getCurrentDate(),
-        } as never,
-        props: { isRoot: true },
+        },
       });
     } catch (error) {
       logger.error(`AI: heartbeat update failed: ${error}`);

--- a/Common/Server/Utils/AI/SRE/AlertInvestigationRunner.ts
+++ b/Common/Server/Utils/AI/SRE/AlertInvestigationRunner.ts
@@ -179,6 +179,7 @@ export default class AIAlertInvestigationRunner {
           await AlertFeedService.createAlertFeedItem({
             alertId,
             projectId,
+            aiRunId,
             alertFeedEventType: AlertFeedEventType.RootCause,
             displayColor: Blue500,
             feedInfoInMarkdown: postData.analysisMarkdown,
@@ -239,6 +240,8 @@ export default class AIAlertInvestigationRunner {
               {
                 projectId,
                 alertId,
+                investigationRunId: aiRunId,
+                analysisMarkdown: postData.analysisMarkdown,
               },
             );
           }

--- a/Common/Server/Utils/AI/SRE/ConfidenceSignal.ts
+++ b/Common/Server/Utils/AI/SRE/ConfidenceSignal.ts
@@ -73,6 +73,15 @@ import CaptureSpan from "../../Telemetry/CaptureSpan";
 export const CONFIDENCE_CLASSIFICATION_FEATURE: string =
   AI_CONFIDENCE_CLASSIFICATION_FEATURE;
 
+/*
+ * Classification is a one-token, best-effort control signal. Bound it to one
+ * provider attempt so report publication cannot inherit a provider's much
+ * longer retry budget; failures already degrade safely to classification-
+ * failed and the report is still published.
+ */
+export const CONFIDENCE_CLASSIFICATION_TIMEOUT_MS: number = 2 * 60 * 1000;
+export const CONFIDENCE_CLASSIFICATION_DEADLINE_MS: number = 5 * 60 * 1000;
+
 // Truncation cap keeps the classification call cheap and inside context limits.
 const MAX_ANALYSIS_CHARS: number = 8000;
 
@@ -261,41 +270,61 @@ export default class AIConfidenceSignal {
       return { confident: false, source: "deterministic-floor" };
     }
 
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+
     try {
-      const response: AILogResponse = await AIService.executeWithLogging({
-        projectId: data.projectId,
-        feature: CONFIDENCE_CLASSIFICATION_FEATURE,
-        aiRunId: data.aiRunId,
-        incidentId: data.incidentId,
-        alertId: data.alertId,
-        // The verdict drives control flow; no prompt previews in LlmLog.
-        storeContentPreviews: false,
-        temperature: 0,
-        maxTokens: 20,
-        messages: [
-          {
-            role: "system",
-            content: [
-              "You judge an AI incident investigation's own analysis.",
-              "Does this analysis assert a specific root cause with supporting evidence, or is it inconclusive?",
-              "Reply with exactly one token and nothing else:",
-              "CONFIDENT — the analysis asserts a specific root cause with supporting evidence.",
-              "INCONCLUSIVE — the analysis could not determine a cause, or asserts one without supporting evidence.",
-            ].join("\n"),
-          },
-          {
-            role: "user",
-            content: [
-              "AI investigation analysis:",
-              '"""',
-              data.analysisMarkdown.substring(0, MAX_ANALYSIS_CHARS),
-              '"""',
-              "",
-              "One token only: CONFIDENT or INCONCLUSIVE.",
-            ].join("\n"),
-          },
-        ],
-      });
+      const classification: Promise<AILogResponse> =
+        AIService.executeWithLogging({
+          projectId: data.projectId,
+          feature: CONFIDENCE_CLASSIFICATION_FEATURE,
+          aiRunId: data.aiRunId,
+          incidentId: data.incidentId,
+          alertId: data.alertId,
+          // The verdict drives control flow; no prompt previews in LlmLog.
+          storeContentPreviews: false,
+          temperature: 0,
+          maxTokens: 20,
+          requestTimeoutInMs: CONFIDENCE_CLASSIFICATION_TIMEOUT_MS,
+          requestRetries: 0,
+          messages: [
+            {
+              role: "system",
+              content: [
+                "You judge an AI incident investigation's own analysis.",
+                "Does this analysis assert a specific root cause with supporting evidence, or is it inconclusive?",
+                "Reply with exactly one token and nothing else:",
+                "CONFIDENT — the analysis asserts a specific root cause with supporting evidence.",
+                "INCONCLUSIVE — the analysis could not determine a cause, or asserts one without supporting evidence.",
+              ].join("\n"),
+            },
+            {
+              role: "user",
+              content: [
+                "AI investigation analysis:",
+                '"""',
+                data.analysisMarkdown.substring(0, MAX_ANALYSIS_CHARS),
+                '"""',
+                "",
+                "One token only: CONFIDENT or INCONCLUSIVE.",
+              ].join("\n"),
+            },
+          ],
+        });
+      const deadline: Promise<never> = new Promise<never>(
+        (_resolve: (value: never) => void, reject: (error: Error) => void) => {
+          deadlineTimer = setTimeout(() => {
+            reject(
+              new Error(
+                `Confidence classification exceeded ${CONFIDENCE_CLASSIFICATION_DEADLINE_MS}ms.`,
+              ),
+            );
+          }, CONFIDENCE_CLASSIFICATION_DEADLINE_MS);
+        },
+      );
+      const response: AILogResponse = await Promise.race([
+        classification,
+        deadline,
+      ]);
 
       const verdict: boolean | null = this.parseClassificationToken(
         response.content,
@@ -314,6 +343,10 @@ export default class AIConfidenceSignal {
         `AI confidence: classification call failed for run ${data.aiRunId.toString()} — per-consumer fail directions apply: ${error}`,
       );
       return { confident: false, source: "classification-failed" };
+    } finally {
+      if (deadlineTimer) {
+        clearTimeout(deadlineTimer);
+      }
     }
   }
 }

--- a/Common/Server/Utils/AI/SRE/FixFromIncidentTaskTrigger.ts
+++ b/Common/Server/Utils/AI/SRE/FixFromIncidentTaskTrigger.ts
@@ -9,6 +9,7 @@ import AIRunService from "../../../Services/AIRunService";
 import ProjectService from "../../../Services/ProjectService";
 import FixRunBudget, { FixRunBudgetDecision } from "../CodeFix/FixRunBudget";
 import SubjectCodeFixRun from "./SubjectCodeFixRun";
+import PostedRootCause from "./PostedRootCause";
 import logger from "../../Logger";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
 
@@ -69,6 +70,7 @@ export default class FixFromIncidentTaskTrigger {
   @CaptureSpan()
   public static async createFixTaskFromInvestigation(data: {
     projectId: ObjectID;
+    investigationRunId: ObjectID;
     incidentId?: ObjectID | undefined;
     alertId?: ObjectID | undefined;
     userId: ObjectID;
@@ -90,19 +92,35 @@ export default class FixFromIncidentTaskTrigger {
      */
     const completedInvestigation: AIRun | null = await AIRunService.findOneBy({
       query: {
+        _id: data.investigationRunId,
+        projectId: data.projectId,
         runType: AIRunType.Investigation,
         status: AIRunStatus.Completed,
         ...(data.incidentId
           ? { triggeredByIncidentId: data.incidentId }
           : { triggeredByAlertId: data.alertId! }),
       },
-      select: { _id: true },
+      select: { _id: true, completedAt: true },
       props: { isRoot: true },
     });
 
     if (!completedInvestigation) {
       throw new BadDataException(
         `No completed AI investigation exists for this ${subjectLabel} — the fix task uses the investigation's posted analysis as its context. Wait for the investigation to complete, or enable AI investigations in the AI settings.`,
+      );
+    }
+
+    const analysisMarkdown: string | null =
+      await PostedRootCause.getForInvestigation({
+        incidentId: data.incidentId,
+        alertId: data.alertId,
+        aiRunId: data.investigationRunId,
+        runCompletedAt: completedInvestigation.completedAt,
+      });
+
+    if (!analysisMarkdown) {
+      throw new BadDataException(
+        `No posted investigation analysis exists for this ${subjectLabel} and investigation run. Refresh the page and wait for the report to finish publishing before creating a fix task.`,
       );
     }
 
@@ -140,6 +158,10 @@ export default class FixFromIncidentTaskTrigger {
       incidentId: data.incidentId,
       alertId: data.alertId,
       userId: data.userId,
+      taskContext: {
+        sourceInvestigationRunId: data.investigationRunId.toString(),
+        sourceInvestigationAnalysisMarkdown: analysisMarkdown,
+      },
     });
   }
 
@@ -221,6 +243,8 @@ export default class FixFromIncidentTaskTrigger {
   @CaptureSpan()
   public static async autoEnqueueFromConfidentInvestigation(data: {
     projectId: ObjectID;
+    investigationRunId: ObjectID;
+    analysisMarkdown: string;
     incidentId?: ObjectID | undefined;
     alertId?: ObjectID | undefined;
   }): Promise<void> {
@@ -322,6 +346,10 @@ export default class FixFromIncidentTaskTrigger {
           taskType: CodeFixTaskType.FixFromIncident,
           incidentId: data.incidentId,
           alertId: data.alertId,
+          taskContext: {
+            sourceInvestigationRunId: data.investigationRunId.toString(),
+            sourceInvestigationAnalysisMarkdown: data.analysisMarkdown,
+          },
         });
 
       logger.debug(

--- a/Common/Server/Utils/AI/SRE/IncidentInvestigationRunner.ts
+++ b/Common/Server/Utils/AI/SRE/IncidentInvestigationRunner.ts
@@ -361,6 +361,7 @@ export default class AIIncidentInvestigationRunner {
           await IncidentFeedService.createIncidentFeedItem({
             incidentId,
             projectId,
+            aiRunId,
             incidentFeedEventType: IncidentFeedEventType.RootCause,
             displayColor: Blue500,
             feedInfoInMarkdown: postData.analysisMarkdown,
@@ -465,6 +466,8 @@ export default class AIIncidentInvestigationRunner {
               {
                 projectId,
                 incidentId,
+                investigationRunId: aiRunId,
+                analysisMarkdown: postData.analysisMarkdown,
               },
             );
           }

--- a/Common/Server/Utils/AI/SRE/InvestigationGrader.ts
+++ b/Common/Server/Utils/AI/SRE/InvestigationGrader.ts
@@ -146,6 +146,7 @@ export default class InvestigationGrader {
         select: {
           _id: true,
           autoGrade: true,
+          completedAt: true,
         },
         sort: { createdAt: SortOrder.Descending },
         props: { isRoot: true },
@@ -175,13 +176,16 @@ export default class InvestigationGrader {
       }
 
       /*
-       * The posted analysis: the latest RootCause feed item — the AI's
-       * postAnalysis is its only writer, and it is the only persisted copy
-       * of the analysis (the same source the fix recipes and the remediation
-       * planner read, through this one helper).
+       * The posted analysis owned by this exact run. A newer investigation or
+       * a human RootCause item may exist by resolution time; neither may be
+       * graded as though it came from the selected investigation.
        */
       const analysisMarkdown: string | null =
-        await PostedRootCause.getForIncident(incidentId);
+        await PostedRootCause.getForInvestigation({
+          incidentId,
+          aiRunId: run.id!,
+          runCompletedAt: run.completedAt,
+        });
 
       if (!analysisMarkdown) {
         logger.debug(

--- a/Common/Server/Utils/AI/SRE/InvestigationQueue.ts
+++ b/Common/Server/Utils/AI/SRE/InvestigationQueue.ts
@@ -415,6 +415,7 @@ export default class AIInvestigationQueue {
       const requeued: number = await AIRunService.attemptStatusTransition({
         aiRunId: data.aiRunId,
         fromStatus: AIRunStatus.Running,
+        expectedAttemptCount: data.attemptCount,
         set: {
           status: AIRunStatus.Queued,
           errorMessage: `Attempt ${data.attemptCount} failed and the run was requeued: ${truncatedMessage}`,
@@ -433,6 +434,7 @@ export default class AIInvestigationQueue {
     const finalized: number = await AIRunService.attemptStatusTransition({
       aiRunId: data.aiRunId,
       fromStatus: AIRunStatus.Running,
+      expectedAttemptCount: data.attemptCount,
       set: {
         status: AIRunStatus.Error,
         completedAt: OneUptimeDate.getCurrentDate(),
@@ -459,15 +461,18 @@ export default class AIInvestigationQueue {
   public static async requeueOrMarkStale(run: {
     id: ObjectID;
     attemptCount: number;
+    lastHeartbeatAt?: Date | undefined;
     runType?: AIRunType | undefined;
     projectId?: ObjectID | undefined;
     triggeredByIncidentId?: ObjectID | undefined;
     triggeredByAlertId?: ObjectID | undefined;
-  }): Promise<"requeued" | "stale"> {
+  }): Promise<"requeued" | "stale" | "noop"> {
     if ((run.attemptCount || 0) < MAX_INVESTIGATION_ATTEMPTS) {
       const requeued: number = await AIRunService.attemptStatusTransition({
         aiRunId: run.id,
         fromStatus: AIRunStatus.Running,
+        expectedAttemptCount: run.attemptCount,
+        expectedLastHeartbeatAt: run.lastHeartbeatAt,
         set: {
           status: AIRunStatus.Queued,
           errorMessage: `Attempt ${run.attemptCount} stopped reporting progress (the server processing it may have restarted) and the run was requeued.`,
@@ -482,6 +487,8 @@ export default class AIInvestigationQueue {
     const staled: number = await AIRunService.attemptStatusTransition({
       aiRunId: run.id,
       fromStatus: AIRunStatus.Running,
+      expectedAttemptCount: run.attemptCount,
+      expectedLastHeartbeatAt: run.lastHeartbeatAt,
       set: {
         status: AIRunStatus.Stale,
         completedAt: OneUptimeDate.getCurrentDate(),
@@ -496,9 +503,10 @@ export default class AIInvestigationQueue {
      */
     if (staled > 0) {
       await this.handOffSettledInvestigationToRemediation(run);
+      return "stale";
     }
 
-    return "stale";
+    return "noop";
   }
 
   /*
@@ -779,6 +787,7 @@ export default class AIInvestigationQueue {
         await AIRunService.attemptStatusTransition({
           aiRunId: run.id,
           fromStatus: AIRunStatus.Running,
+          expectedAttemptCount: attempt,
           set: {
             status: AIRunStatus.Error,
             completedAt: OneUptimeDate.getCurrentDate(),
@@ -807,6 +816,7 @@ export default class AIInvestigationQueue {
         await AIRunService.attemptStatusTransition({
           aiRunId: run.id,
           fromStatus: AIRunStatus.Running,
+          expectedAttemptCount: attempt,
           set: {
             status: AIRunStatus.Error,
             completedAt: OneUptimeDate.getCurrentDate(),
@@ -887,6 +897,7 @@ export default class AIInvestigationQueue {
     await AIRunService.attemptStatusTransition({
       aiRunId: run.id,
       fromStatus: AIRunStatus.Running,
+      expectedAttemptCount: attempt,
       set: {
         status: AIRunStatus.Error,
         completedAt: OneUptimeDate.getCurrentDate(),

--- a/Common/Server/Utils/AI/SRE/PostedRootCause.ts
+++ b/Common/Server/Utils/AI/SRE/PostedRootCause.ts
@@ -8,7 +8,25 @@ import AlertFeed, {
 } from "../../../../Models/DatabaseModels/AlertFeed";
 import ObjectID from "../../../../Types/ObjectID";
 import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import QueryHelper from "../../../Types/Database/QueryHelper";
 import CaptureSpan from "../../Telemetry/CaptureSpan";
+
+export const AI_ROOT_CAUSE_HEADING: string =
+  "AI — Automated Root Cause Analysis";
+
+export interface PostedRootCauseQueryOptions {
+  /* Exact ownership for newly posted AI investigation reports. */
+  aiRunId?: ObjectID | undefined;
+  /* Upgrade-only lookup for RootCause rows written before aiRunId existed. */
+  withoutAIRunId?: boolean | undefined;
+  /*
+   * A subject can be investigated more than once. When a caller is resolving
+   * the analysis for one particular run, it must not accidentally return a
+   * RootCause item posted by an older run while the new one is still being
+   * finalized.
+   */
+  createdAtOrAfter?: Date | undefined;
+}
 
 /*
  * The analysis an AI investigation posted for a subject.
@@ -20,14 +38,64 @@ import CaptureSpan from "../../Telemetry/CaptureSpan";
  * where the analysis lives moves one place.
  */
 export default class PostedRootCause {
+  /*
+   * Resolve one run's report exactly. A narrow compatibility path keeps
+   * reports written before aiRunId was deployed visible. Deployment time is
+   * not the migration file's build timestamp, so compatibility cannot use a
+   * wall-clock cutover. Instead, only null-associated rows posted after the
+   * run completed and carrying the server's branded AI heading qualify.
+   */
+  @CaptureSpan()
+  public static async getForInvestigation(data: {
+    incidentId?: ObjectID | undefined;
+    alertId?: ObjectID | undefined;
+    aiRunId: ObjectID;
+    runCompletedAt?: Date | undefined;
+  }): Promise<string | null> {
+    const exactAnalysis: string | null = await this.getForSubject({
+      incidentId: data.incidentId,
+      alertId: data.alertId,
+      aiRunId: data.aiRunId,
+    });
+
+    if (exactAnalysis) {
+      return exactAnalysis;
+    }
+
+    if (!data.runCompletedAt) {
+      return null;
+    }
+
+    const legacyAnalysis: string | null = await this.getForSubject({
+      incidentId: data.incidentId,
+      alertId: data.alertId,
+      withoutAIRunId: true,
+      createdAtOrAfter: data.runCompletedAt,
+    });
+
+    return legacyAnalysis?.includes(AI_ROOT_CAUSE_HEADING)
+      ? legacyAnalysis
+      : null;
+  }
+
   @CaptureSpan()
   public static async getForIncident(
     incidentId: ObjectID,
+    options?: PostedRootCauseQueryOptions | undefined,
   ): Promise<string | null> {
     const feedItem: IncidentFeed | null = await IncidentFeedService.findOneBy({
       query: {
         incidentId: incidentId,
         incidentFeedEventType: IncidentFeedEventType.RootCause,
+        ...(options?.aiRunId ? { aiRunId: options.aiRunId } : {}),
+        ...(options?.withoutAIRunId ? { aiRunId: QueryHelper.isNull() } : {}),
+        ...(options?.createdAtOrAfter
+          ? {
+              createdAt: QueryHelper.greaterThanEqualTo(
+                options.createdAtOrAfter,
+              ),
+            }
+          : {}),
       },
       select: {
         feedInfoInMarkdown: true,
@@ -44,11 +112,23 @@ export default class PostedRootCause {
   }
 
   @CaptureSpan()
-  public static async getForAlert(alertId: ObjectID): Promise<string | null> {
+  public static async getForAlert(
+    alertId: ObjectID,
+    options?: PostedRootCauseQueryOptions | undefined,
+  ): Promise<string | null> {
     const feedItem: AlertFeed | null = await AlertFeedService.findOneBy({
       query: {
         alertId: alertId,
         alertFeedEventType: AlertFeedEventType.RootCause,
+        ...(options?.aiRunId ? { aiRunId: options.aiRunId } : {}),
+        ...(options?.withoutAIRunId ? { aiRunId: QueryHelper.isNull() } : {}),
+        ...(options?.createdAtOrAfter
+          ? {
+              createdAt: QueryHelper.greaterThanEqualTo(
+                options.createdAtOrAfter,
+              ),
+            }
+          : {}),
       },
       select: {
         feedInfoInMarkdown: true,
@@ -68,13 +148,24 @@ export default class PostedRootCause {
   public static async getForSubject(data: {
     incidentId?: ObjectID | undefined;
     alertId?: ObjectID | undefined;
+    aiRunId?: ObjectID | undefined;
+    withoutAIRunId?: boolean | undefined;
+    createdAtOrAfter?: Date | undefined;
   }): Promise<string | null> {
     if (data.incidentId) {
-      return PostedRootCause.getForIncident(data.incidentId);
+      return PostedRootCause.getForIncident(data.incidentId, {
+        aiRunId: data.aiRunId,
+        withoutAIRunId: data.withoutAIRunId,
+        createdAtOrAfter: data.createdAtOrAfter,
+      });
     }
 
     if (data.alertId) {
-      return PostedRootCause.getForAlert(data.alertId);
+      return PostedRootCause.getForAlert(data.alertId, {
+        aiRunId: data.aiRunId,
+        withoutAIRunId: data.withoutAIRunId,
+        createdAtOrAfter: data.createdAtOrAfter,
+      });
     }
 
     return null;

--- a/Common/Tests/App/Dashboard/InvestigationFeedRefresh.test.tsx
+++ b/Common/Tests/App/Dashboard/InvestigationFeedRefresh.test.tsx
@@ -1,0 +1,480 @@
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * IncidentFeed and AlertFeed normally load once at page mount. An AI report is
+ * posted later, immediately after the investigation completes, so the parent
+ * page now changes refreshToken when InvestigationPanel sees that report.
+ * These tests pin both the refresh signal and the less obvious request race:
+ * an older mount-time response must never overwrite the refreshed feed.
+ */
+
+const getListMock: MockFunction = getJestMockFunction();
+const feedRenderMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+    },
+  };
+});
+
+/* Keep the test about feed state, not markdown parsing or timeline chrome. */
+jest.mock("../../../UI/Components/Feed/Feed", () => {
+  return {
+    __esModule: true,
+    default: (props: RenderedFeedProps): React.ReactElement => {
+      feedRenderMock(props);
+      return React.createElement(
+        "div",
+        { "data-testid": "rendered-feed" },
+        props.items.map((item: RenderedFeedItem): React.ReactElement => {
+          return React.createElement(
+            "div",
+            { key: item.key },
+            item.textInMarkdown,
+          );
+        }),
+      );
+    },
+  };
+});
+
+import AlertFeedElement from "../../../../App/FeatureSet/Dashboard/src/Components/Alert/AlertFeed";
+import IncidentFeedElement from "../../../../App/FeatureSet/Dashboard/src/Components/Incident/IncidentFeed";
+import AlertFeed, {
+  AlertFeedEventType,
+} from "../../../Models/DatabaseModels/AlertFeed";
+import IncidentFeed, {
+  IncidentFeedEventType,
+} from "../../../Models/DatabaseModels/IncidentFeed";
+import IconProp from "../../../Types/Icon/IconProp";
+import ObjectID from "../../../Types/ObjectID";
+
+interface RenderedFeedItem {
+  key: string;
+  textInMarkdown: string;
+  icon: IconProp;
+  safeMode?: boolean | undefined;
+}
+
+interface RenderedFeedProps {
+  items: Array<RenderedFeedItem>;
+  noItemsMessage: string;
+}
+
+interface ListResult<T> {
+  data: Array<T>;
+  count: number;
+  skip: number;
+  limit: number;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+interface FeedListRequest {
+  modelType: unknown;
+  query: Record<string, unknown>;
+  select: Record<string, unknown>;
+}
+
+const INCIDENT_ID: ObjectID = new ObjectID(
+  "66666666-6666-4666-8666-666666666666",
+);
+const ALERT_ID: ObjectID = new ObjectID("77777777-7777-4777-8777-777777777777");
+const NEXT_INCIDENT_ID: ObjectID = new ObjectID(
+  "abababab-abab-4bab-8bab-abababababab",
+);
+const NEXT_ALERT_ID: ObjectID = new ObjectID(
+  "cdcdcdcd-cdcd-4dcd-8dcd-cdcdcdcdcdcd",
+);
+const AI_RUN_ID: ObjectID = new ObjectID(
+  "12121212-1212-4212-8212-121212121212",
+);
+const POSTED_AT: Date = new Date("2026-08-07T11:00:00.000Z");
+const INCIDENT_ANALYSIS: string =
+  "## AI — Automated Root Cause Analysis\n\nThe incident was caused by connection exhaustion.";
+const ALERT_ANALYSIS: string =
+  "## AI — Automated Root Cause Analysis\n\nThe alert was caused by a failed dependency.";
+const ORDINARY_ROOT_CAUSE: string =
+  "## Root cause\n\nAn engineer identified a configuration regression.";
+
+function listResult<T>(data: Array<T>): ListResult<T> {
+  return {
+    data,
+    count: data.length,
+    skip: 0,
+    limit: 100,
+  };
+}
+
+function incidentAnalysisItem(): IncidentFeed {
+  const item: IncidentFeed = new IncidentFeed();
+  item.id = new ObjectID("88888888-8888-4888-8888-888888888888");
+  item.incidentId = INCIDENT_ID;
+  item.incidentFeedEventType = IncidentFeedEventType.RootCause;
+  item.aiRunId = AI_RUN_ID;
+  item.feedInfoInMarkdown = INCIDENT_ANALYSIS;
+  item.postedAt = POSTED_AT;
+  item.createdAt = POSTED_AT;
+  return item;
+}
+
+function alertAnalysisItem(): AlertFeed {
+  const item: AlertFeed = new AlertFeed();
+  item.id = new ObjectID("99999999-9999-4999-8999-999999999999");
+  item.alertId = ALERT_ID;
+  item.alertFeedEventType = AlertFeedEventType.RootCause;
+  item.aiRunId = AI_RUN_ID;
+  item.feedInfoInMarkdown = ALERT_ANALYSIS;
+  item.postedAt = POSTED_AT;
+  item.createdAt = POSTED_AT;
+  return item;
+}
+
+function nextIncidentAnalysisItem(): IncidentFeed {
+  const item: IncidentFeed = incidentAnalysisItem();
+  item.id = new ObjectID("dededede-dede-4ede-8ede-dededededede");
+  item.incidentId = NEXT_INCIDENT_ID;
+  item.feedInfoInMarkdown =
+    "## AI — Automated Root Cause Analysis\n\nThe next incident has its own report.";
+  return item;
+}
+
+function nextAlertAnalysisItem(): AlertFeed {
+  const item: AlertFeed = alertAnalysisItem();
+  item.id = new ObjectID("efefefef-efef-4fef-8fef-efefefefefef");
+  item.alertId = NEXT_ALERT_ID;
+  item.feedInfoInMarkdown =
+    "## AI — Automated Root Cause Analysis\n\nThe next alert has its own report.";
+  return item;
+}
+
+function ordinaryIncidentRootCauseItem(): IncidentFeed {
+  const item: IncidentFeed = incidentAnalysisItem();
+  item.id = new ObjectID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+  delete item.aiRunId;
+  item.feedInfoInMarkdown = ORDINARY_ROOT_CAUSE;
+  return item;
+}
+
+function ordinaryAlertRootCauseItem(): AlertFeed {
+  const item: AlertFeed = alertAnalysisItem();
+  item.id = new ObjectID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+  delete item.aiRunId;
+  item.feedInfoInMarkdown = ORDINARY_ROOT_CAUSE;
+  return item;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise: Promise<T> = new Promise<T>((resolve: (value: T) => void) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve: (value: T): void => {
+      resolvePromise!(value);
+    },
+  };
+}
+
+function incidentElement(refreshToken: number): React.ReactElement {
+  return (
+    <IncidentFeedElement incidentId={INCIDENT_ID} refreshToken={refreshToken} />
+  );
+}
+
+function alertElement(refreshToken: number): React.ReactElement {
+  return <AlertFeedElement alertId={ALERT_ID} refreshToken={refreshToken} />;
+}
+
+async function flush(): Promise<void> {
+  await act(async (): Promise<void> => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function resolveDeferred<T>(
+  deferred: Deferred<T>,
+  value: T,
+): Promise<void> {
+  await act(async (): Promise<void> => {
+    deferred.resolve(value);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function lastRenderedFeedProps(): RenderedFeedProps {
+  const calls: Array<Array<RenderedFeedProps>> = feedRenderMock.mock
+    .calls as Array<Array<RenderedFeedProps>>;
+  return calls[calls.length - 1]![0]!;
+}
+
+afterEach(() => {
+  cleanup();
+  getListMock.mockReset();
+  feedRenderMock.mockReset();
+});
+
+describe("investigation reports in incident and alert feeds", () => {
+  test("refreshToken makes the incident feed fetch and show the posted report", async () => {
+    getListMock
+      .mockResolvedValueOnce(listResult<IncidentFeed>([]) as never)
+      .mockResolvedValueOnce(
+        listResult<IncidentFeed>([incidentAnalysisItem()]) as never,
+      );
+
+    const view: ReturnType<typeof render> = render(incidentElement(0));
+
+    await waitFor((): void => {
+      expect(getListMock).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText(/connection exhaustion/)).toBeNull();
+
+    view.rerender(
+      <IncidentFeedElement
+        incidentId={new ObjectID(INCIDENT_ID.toString())}
+        refreshToken={1}
+      />,
+    );
+
+    await waitFor(
+      (): void => {
+        expect(screen.getByText(/connection exhaustion/)).toBeVisible();
+      },
+      { timeout: 10000 },
+    );
+    expect(getListMock).toHaveBeenCalledTimes(2);
+    expect(lastRenderedFeedProps().items[0]).toEqual(
+      expect.objectContaining({
+        icon: IconProp.Sparkles,
+        safeMode: true,
+      }),
+    );
+
+    const request: FeedListRequest = getListMock.mock
+      .calls[1]![0] as FeedListRequest;
+    expect(request.modelType).toBe(IncidentFeed);
+    expect(request.query).toEqual({ incidentId: INCIDENT_ID });
+    expect(request.select).toEqual(
+      expect.objectContaining({
+        feedInfoInMarkdown: true,
+        aiRunId: true,
+        incidentFeedEventType: true,
+      }),
+    );
+
+    view.rerender(incidentElement(1));
+    await flush();
+    expect(getListMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("refreshToken makes the alert feed fetch and show the posted report", async () => {
+    getListMock
+      .mockResolvedValueOnce(listResult<AlertFeed>([]) as never)
+      .mockResolvedValueOnce(
+        listResult<AlertFeed>([alertAnalysisItem()]) as never,
+      );
+
+    const view: ReturnType<typeof render> = render(alertElement(10));
+
+    await waitFor((): void => {
+      expect(getListMock).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText(/failed dependency/)).toBeNull();
+
+    view.rerender(
+      <AlertFeedElement
+        alertId={new ObjectID(ALERT_ID.toString())}
+        refreshToken={11}
+      />,
+    );
+
+    await waitFor(
+      (): void => {
+        expect(screen.getByText(/failed dependency/)).toBeVisible();
+      },
+      { timeout: 10000 },
+    );
+    expect(getListMock).toHaveBeenCalledTimes(2);
+    expect(lastRenderedFeedProps().items[0]).toEqual(
+      expect.objectContaining({
+        icon: IconProp.Sparkles,
+        safeMode: true,
+      }),
+    );
+
+    const request: FeedListRequest = getListMock.mock
+      .calls[1]![0] as FeedListRequest;
+    expect(request.modelType).toBe(AlertFeed);
+    expect(request.query).toEqual({ alertId: ALERT_ID });
+    expect(request.select).toEqual(
+      expect.objectContaining({
+        feedInfoInMarkdown: true,
+        aiRunId: true,
+        alertFeedEventType: true,
+      }),
+    );
+
+    view.rerender(alertElement(11));
+    await flush();
+    expect(getListMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("a late mount-time incident response cannot erase the refreshed report", async () => {
+    const initialRequest: Deferred<ListResult<IncidentFeed>> =
+      createDeferred<ListResult<IncidentFeed>>();
+    const refreshedRequest: Deferred<ListResult<IncidentFeed>> =
+      createDeferred<ListResult<IncidentFeed>>();
+
+    getListMock
+      .mockReturnValueOnce(initialRequest.promise as never)
+      .mockReturnValueOnce(refreshedRequest.promise as never);
+
+    const view: ReturnType<typeof render> = render(incidentElement(0));
+    await flush();
+    expect(getListMock).toHaveBeenCalledTimes(1);
+
+    view.rerender(incidentElement(1));
+    await flush();
+    expect(getListMock).toHaveBeenCalledTimes(2);
+
+    await resolveDeferred(
+      refreshedRequest,
+      listResult<IncidentFeed>([incidentAnalysisItem()]),
+    );
+    expect(screen.getByText(/connection exhaustion/)).toBeVisible();
+
+    /* The older empty result arrives last and must be ignored. */
+    await resolveDeferred(initialRequest, listResult<IncidentFeed>([]));
+    expect(screen.getByText(/connection exhaustion/)).toBeVisible();
+  });
+
+  test("a late mount-time alert response cannot erase the refreshed report", async () => {
+    const initialRequest: Deferred<ListResult<AlertFeed>> =
+      createDeferred<ListResult<AlertFeed>>();
+    const refreshedRequest: Deferred<ListResult<AlertFeed>> =
+      createDeferred<ListResult<AlertFeed>>();
+
+    getListMock
+      .mockReturnValueOnce(initialRequest.promise as never)
+      .mockReturnValueOnce(refreshedRequest.promise as never);
+
+    const view: ReturnType<typeof render> = render(alertElement(20));
+    await flush();
+    expect(getListMock).toHaveBeenCalledTimes(1);
+
+    view.rerender(alertElement(21));
+    await flush();
+    expect(getListMock).toHaveBeenCalledTimes(2);
+
+    await resolveDeferred(
+      refreshedRequest,
+      listResult<AlertFeed>([alertAnalysisItem()]),
+    );
+    expect(screen.getByText(/failed dependency/)).toBeVisible();
+
+    await resolveDeferred(initialRequest, listResult<AlertFeed>([]));
+    expect(screen.getByText(/failed dependency/)).toBeVisible();
+  });
+
+  test("subject navigation never paints the previous incident or alert feed", async () => {
+    const nextIncidentRequest: Deferred<ListResult<IncidentFeed>> =
+      createDeferred<ListResult<IncidentFeed>>();
+    getListMock
+      .mockResolvedValueOnce(
+        listResult<IncidentFeed>([incidentAnalysisItem()]) as never,
+      )
+      .mockReturnValueOnce(nextIncidentRequest.promise as never);
+
+    const incidentView: ReturnType<typeof render> = render(incidentElement(0));
+    expect(await screen.findByText(/connection exhaustion/)).toBeVisible();
+
+    incidentView.rerender(
+      <IncidentFeedElement incidentId={NEXT_INCIDENT_ID} refreshToken={0} />,
+    );
+    expect(screen.queryByText(/connection exhaustion/)).toBeNull();
+    await flush();
+    expect(getListMock).toHaveBeenCalledTimes(2);
+
+    await resolveDeferred(
+      nextIncidentRequest,
+      listResult<IncidentFeed>([nextIncidentAnalysisItem()]),
+    );
+    expect(screen.getByText(/next incident has its own report/)).toBeVisible();
+
+    incidentView.unmount();
+    getListMock.mockClear();
+
+    const nextAlertRequest: Deferred<ListResult<AlertFeed>> =
+      createDeferred<ListResult<AlertFeed>>();
+    getListMock
+      .mockResolvedValueOnce(
+        listResult<AlertFeed>([alertAnalysisItem()]) as never,
+      )
+      .mockReturnValueOnce(nextAlertRequest.promise as never);
+
+    const alertView: ReturnType<typeof render> = render(alertElement(0));
+    expect(await screen.findByText(/failed dependency/)).toBeVisible();
+
+    alertView.rerender(
+      <AlertFeedElement alertId={NEXT_ALERT_ID} refreshToken={0} />,
+    );
+    expect(screen.queryByText(/failed dependency/)).toBeNull();
+    await flush();
+    expect(getListMock).toHaveBeenCalledTimes(2);
+
+    await resolveDeferred(
+      nextAlertRequest,
+      listResult<AlertFeed>([nextAlertAnalysisItem()]),
+    );
+    expect(screen.getByText(/next alert has its own report/)).toBeVisible();
+  });
+
+  test("ordinary incident and alert root causes keep their standard rendering", async () => {
+    getListMock.mockResolvedValueOnce(
+      listResult<IncidentFeed>([ordinaryIncidentRootCauseItem()]) as never,
+    );
+
+    const incidentView: ReturnType<typeof render> = render(incidentElement(0));
+    expect(await screen.findByText(/configuration regression/)).toBeVisible();
+    expect(lastRenderedFeedProps().items[0]).toEqual(
+      expect.objectContaining({
+        icon: IconProp.Cube,
+        safeMode: false,
+      }),
+    );
+
+    incidentView.unmount();
+    getListMock.mockResolvedValueOnce(
+      listResult<AlertFeed>([ordinaryAlertRootCauseItem()]) as never,
+    );
+
+    render(alertElement(0));
+    expect(await screen.findByText(/configuration regression/)).toBeVisible();
+    expect(lastRenderedFeedProps().items[0]).toEqual(
+      expect.objectContaining({
+        icon: IconProp.Cube,
+        safeMode: false,
+      }),
+    );
+  });
+});

--- a/Common/Tests/App/Dashboard/InvestigationPanel.test.tsx
+++ b/Common/Tests/App/Dashboard/InvestigationPanel.test.tsx
@@ -1,0 +1,860 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import "@testing-library/jest-dom";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * InvestigationPanel is the hand-off between three independently changing
+ * pieces of state: the live AIRun, the RootCause feed item posted just after
+ * the run becomes Completed, and the already-mounted incident / alert feed.
+ * These tests deliberately drive the real React effects and timers because a
+ * static completed-state snapshot cannot catch the completion race that this
+ * component exists to bridge.
+ */
+
+const postMock: MockFunction = getJestMockFunction();
+const getFriendlyMessageMock: MockFunction = getJestMockFunction();
+const getCommonHeadersMock: MockFunction = getJestMockFunction();
+const markdownViewerMock: MockFunction = getJestMockFunction();
+const activityFeedMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      post: (...args: Array<any>) => {
+        return postMock(...args);
+      },
+      getFriendlyMessage: (...args: Array<any>) => {
+        return getFriendlyMessageMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCommonHeaders: (...args: Array<any>) => {
+        return getCommonHeadersMock(...args);
+      },
+    },
+  };
+});
+
+/*
+ * The Common Jest config replaces react-markdown with a text-only stand-in.
+ * Record MarkdownViewer's own props here so safeMode remains an asserted part
+ * of the contract rather than an implementation detail hidden by that mock.
+ */
+jest.mock("../../../UI/Components/Markdown.tsx/MarkdownViewer", () => {
+  return {
+    __esModule: true,
+    default: (props: MarkdownViewerProps): React.ReactElement => {
+      markdownViewerMock(props);
+      return React.createElement(
+        "div",
+        { "data-testid": "investigation-markdown" },
+        props.text,
+      );
+    },
+  };
+});
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/AIChat/ChatActivityFeed",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: ActivityFeedProps): React.ReactElement => {
+        activityFeedMock(props);
+        return React.createElement("div", {
+          "data-testid": "investigation-activity",
+        });
+      },
+    };
+  },
+);
+
+import InvestigationPanel, {
+  InvestigationSubjectType,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/AI/InvestigationPanel";
+import AIRunEvent from "../../../Models/DatabaseModels/AIRunEvent";
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import AIRunEventType from "../../../Types/AI/AIRunEventType";
+import AIRunStatus from "../../../Types/AI/AIRunStatus";
+import { JSONArray, JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+
+interface MarkdownViewerProps {
+  text: string;
+  safeMode?: boolean | undefined;
+}
+
+interface ActivityFeedProps {
+  events: Array<AIRunEvent>;
+  title?: string | undefined;
+  showLiveIndicator?: boolean | undefined;
+  maxVisibleSteps?: number | undefined;
+}
+
+interface InvestigationPayloadOptions {
+  status: AIRunStatus;
+  runId?: string | undefined;
+  events?: JSONArray | undefined;
+  analysisMarkdown?: string | null | undefined;
+  isAnalysisPending?: boolean | undefined;
+  errorMessage?: string | null | undefined;
+  toolCallCount?: number | undefined;
+  totalTokens?: number | undefined;
+  humanVerdict?: string | null | undefined;
+}
+
+interface ApiResponse {
+  data: JSONObject;
+}
+
+interface PostRequest {
+  url: { toString: () => string };
+  data: JSONObject;
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+const POLL_INTERVAL_MS: number = 2500;
+const SETTLED_POLL_INTERVAL_MS: number = 30_000;
+const RUN_ID: string = "11111111-1111-4111-8111-111111111111";
+const FIX_RUN_ID: string = "22222222-2222-4222-8222-222222222222";
+const INCIDENT_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const ALERT_ID: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+const EVENT_ID: string = "55555555-5555-4555-8555-555555555555";
+const ANALYSIS: string =
+  "## Root cause\n\nThe database connection pool was exhausted.";
+
+const activityEvent: JSONObject = {
+  _id: EVENT_ID,
+  sequence: 1,
+  eventType: AIRunEventType.ToolCallStarted,
+  toolName: "search_logs",
+  createdAt: new Date("2026-08-07T10:00:00.000Z"),
+};
+
+function investigationPayload(
+  options: InvestigationPayloadOptions,
+): JSONObject {
+  const run: JSONObject = {
+    _id: options.runId || RUN_ID,
+    status: options.status,
+    errorMessage: options.errorMessage ?? null,
+    toolCallCount: options.toolCallCount ?? 0,
+    totalTokens: options.totalTokens ?? 0,
+    humanVerdict: options.humanVerdict ?? null,
+  };
+
+  return {
+    run,
+    events: options.events || [],
+    analysisMarkdown: options.analysisMarkdown ?? null,
+    isAnalysisPending: options.isAnalysisPending === true,
+  };
+}
+
+function successfulResponse(payload: JSONObject): ApiResponse {
+  return { data: payload };
+}
+
+function noInvestigationResponse(): ApiResponse {
+  return {
+    data: {
+      run: null,
+      events: [],
+      analysisMarkdown: null,
+      isAnalysisPending: false,
+    },
+  };
+}
+
+function completedResponse(
+  overrides: Partial<InvestigationPayloadOptions> = {},
+): ApiResponse {
+  return successfulResponse(
+    investigationPayload({
+      status: AIRunStatus.Completed,
+      analysisMarkdown: ANALYSIS,
+      events: [activityEvent],
+      toolCallCount: 2,
+      totalTokens: 1234,
+      ...overrides,
+    }),
+  );
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise: Promise<T> = new Promise<T>((resolve: (value: T) => void) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve: (value: T): void => {
+      resolvePromise!(value);
+    },
+  };
+}
+
+function renderPanel(data?: {
+  subjectType?: InvestigationSubjectType | undefined;
+  subjectId?: ObjectID | undefined;
+  onAnalysisAvailable?: (() => void) | undefined;
+}): ReturnType<typeof render> {
+  return render(
+    <InvestigationPanel
+      subjectType={data?.subjectType || "incident"}
+      subjectId={data?.subjectId || INCIDENT_ID}
+      onAnalysisAvailable={data?.onAnalysisAvailable}
+    />,
+  );
+}
+
+/* Let the awaits inside fetchData and the following React effects settle. */
+async function flush(): Promise<void> {
+  await act(async (): Promise<void> => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function tick(milliseconds: number): Promise<void> {
+  await act(async (): Promise<void> => {
+    jest.advanceTimersByTime(milliseconds);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function resolveDeferred<T>(
+  deferred: Deferred<T>,
+  value: T,
+): Promise<void> {
+  await act(async (): Promise<void> => {
+    deferred.resolve(value);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function postRequestAt(index: number): PostRequest {
+  return postMock.mock.calls[index]![0] as PostRequest;
+}
+
+function lastActivityProps(): ActivityFeedProps {
+  const calls: Array<Array<ActivityFeedProps>> = activityFeedMock.mock
+    .calls as Array<Array<ActivityFeedProps>>;
+  return calls[calls.length - 1]![0]!;
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  getCommonHeadersMock.mockReturnValue({});
+  getFriendlyMessageMock.mockImplementation((error: unknown): string => {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "message" in error &&
+      typeof (error as { message?: unknown }).message === "string"
+    ) {
+      return (error as { message: string }).message;
+    }
+
+    return "Request failed";
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllTimers();
+  jest.useRealTimers();
+  postMock.mockReset();
+  getFriendlyMessageMock.mockReset();
+  getCommonHeadersMock.mockReset();
+  markdownViewerMock.mockReset();
+  activityFeedMock.mockReset();
+});
+
+describe("InvestigationPanel", () => {
+  test("renders nothing when this subject has no investigation", async () => {
+    postMock.mockResolvedValue(noInvestigationResponse() as never);
+
+    const { container } = renderPanel();
+    await flush();
+
+    expect(container).toBeEmptyDOMElement();
+    expect(jest.getTimerCount()).toBe(1);
+  });
+
+  test("shows live activity and requests the incident-specific endpoint", async () => {
+    postMock.mockResolvedValue(
+      successfulResponse(
+        investigationPayload({
+          status: AIRunStatus.Running,
+          events: [activityEvent],
+        }),
+      ) as never,
+    );
+
+    renderPanel();
+    await flush();
+
+    expect(screen.getByText("Investigating…")).toBeInTheDocument();
+    expect(screen.getByTestId("investigation-activity")).toBeInTheDocument();
+    expect(lastActivityProps().events).toHaveLength(1);
+    expect(lastActivityProps().showLiveIndicator).toBe(true);
+    expect(jest.getTimerCount()).toBe(1);
+
+    const request: PostRequest = postRequestAt(0);
+    expect(request.url.toString()).toContain("/ai-investigation/incident");
+    expect(request.data).toEqual({ incidentId: INCIDENT_ID.toString() });
+    expect(getCommonHeadersMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders a completed report safely and demotes activity to a non-live disclosure", async () => {
+    const onAnalysisAvailable: MockFunction = getJestMockFunction();
+    postMock.mockResolvedValue(completedResponse() as never);
+
+    renderPanel({ onAnalysisAvailable });
+    await flush();
+
+    expect(screen.getByText("Investigation complete")).toBeInTheDocument();
+    expect(screen.getByLabelText("Investigation report")).toBeInTheDocument();
+    expect(screen.getByTestId("investigation-markdown")).toHaveTextContent(
+      "The database connection pool was exhausted.",
+    );
+    expect(markdownViewerMock).toHaveBeenCalledWith({
+      text: ANALYSIS,
+      safeMode: true,
+    });
+
+    expect(screen.getByText("Investigation activity")).toBeInTheDocument();
+    expect(lastActivityProps()).toEqual(
+      expect.objectContaining({
+        title: "Completed activity",
+        showLiveIndicator: false,
+        maxVisibleSteps: 10,
+      }),
+    );
+
+    const usage: HTMLElement = screen.getByLabelText("Investigation usage");
+    expect(usage).toHaveTextContent("2 telemetry queries");
+    expect(usage).toHaveTextContent("1,234 tokens");
+    expect(
+      screen.getByRole("button", {
+        name: "Open Fix PR from this analysis",
+      }),
+    ).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Confirmed" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Rejected" })).toBeEnabled();
+    expect(onAnalysisAvailable).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(1);
+  });
+
+  test("keeps polling across Completed until the same run's report appears", async () => {
+    const onAnalysisAvailable: MockFunction = getJestMockFunction();
+    postMock
+      .mockResolvedValueOnce(
+        completedResponse({
+          analysisMarkdown: null,
+          isAnalysisPending: true,
+        }) as never,
+      )
+      .mockResolvedValueOnce(
+        completedResponse({
+          analysisMarkdown: ANALYSIS,
+          isAnalysisPending: false,
+        }) as never,
+      );
+
+    renderPanel({ onAnalysisAvailable });
+    await flush();
+
+    expect(screen.getByText("Preparing investigation report…")).toBeVisible();
+    expect(screen.getByText("Preparing the final report")).toBeVisible();
+    expect(screen.queryByTestId("investigation-markdown")).toBeNull();
+    expect(onAnalysisAvailable).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(1);
+
+    /*
+     * Status, run id and event count are deliberately unchanged. Only the
+     * report fields differ, which catches a signature that ignores the
+     * post-Completed payload transition.
+     */
+    await tick(POLL_INTERVAL_MS);
+
+    expect(screen.getByText("Investigation complete")).toBeVisible();
+    expect(screen.getByTestId("investigation-markdown")).toHaveTextContent(
+      "The database connection pool was exhausted.",
+    );
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(onAnalysisAvailable).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(1);
+
+    await tick(POLL_INTERVAL_MS * 4);
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(onAnalysisAvailable).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not start another same-subject poll while a slow poll is in flight", async () => {
+    const slowPoll: Deferred<ApiResponse> = createDeferred<ApiResponse>();
+    postMock
+      .mockResolvedValueOnce(
+        successfulResponse(
+          investigationPayload({ status: AIRunStatus.Running }),
+        ) as never,
+      )
+      .mockReturnValueOnce(slowPoll.promise as never)
+      .mockResolvedValue(completedResponse() as never);
+
+    const view: ReturnType<typeof render> = renderPanel();
+    await flush();
+    await tick(POLL_INTERVAL_MS);
+
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByText("Investigating…")).toBeVisible();
+
+    /*
+     * The real view pages construct a fresh ObjectID on every render. Its
+     * stable string identity must not recreate fetchData or overlap polling.
+     */
+    view.rerender(
+      <InvestigationPanel
+        subjectType="incident"
+        subjectId={new ObjectID(INCIDENT_ID.toString())}
+      />,
+    );
+    await flush();
+    expect(postMock).toHaveBeenCalledTimes(2);
+
+    /*
+     * The response takes longer than the polling period. It must remain the
+     * sole in-flight request instead of being invalidated by a newer poll.
+     */
+    await tick(POLL_INTERVAL_MS + 1);
+    expect(postMock).toHaveBeenCalledTimes(2);
+
+    await resolveDeferred(slowPoll, completedResponse());
+
+    expect(screen.getByText("Investigation complete")).toBeVisible();
+    expect(screen.getByTestId("investigation-markdown")).toHaveTextContent(
+      "The database connection pool was exhausted.",
+    );
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(jest.getTimerCount()).toBe(1);
+  });
+
+  test("ignores a previous subject response after route navigation", async () => {
+    const previousSubject: Deferred<ApiResponse> =
+      createDeferred<ApiResponse>();
+    postMock
+      .mockReturnValueOnce(previousSubject.promise as never)
+      .mockResolvedValueOnce(completedResponse() as never);
+
+    const view: ReturnType<typeof render> = renderPanel();
+    await flush();
+    expect(view.container).toBeEmptyDOMElement();
+
+    view.rerender(
+      <InvestigationPanel subjectType="alert" subjectId={ALERT_ID} />,
+    );
+    await flush();
+
+    expect(screen.getByText("Investigation complete")).toBeVisible();
+    expect(postRequestAt(1).data).toEqual({ alertId: ALERT_ID.toString() });
+
+    await resolveDeferred(
+      previousSubject,
+      successfulResponse(investigationPayload({ status: AIRunStatus.Running })),
+    );
+
+    expect(screen.getByText("Investigation complete")).toBeVisible();
+    expect(screen.queryByText("Investigating…")).toBeNull();
+  });
+
+  test("does not notify a new subject with the previous subject's report", async () => {
+    const nextSubject: Deferred<ApiResponse> = createDeferred<ApiResponse>();
+    const onAnalysisAvailable: MockFunction = getJestMockFunction();
+    const nextSubjectAnalysis: string =
+      "## Alert root cause\n\nThe upstream dependency rejected requests.";
+
+    postMock
+      .mockResolvedValueOnce(completedResponse() as never)
+      .mockReturnValueOnce(nextSubject.promise as never);
+
+    const view: ReturnType<typeof render> = renderPanel({
+      onAnalysisAvailable,
+    });
+    await flush();
+
+    expect(onAnalysisAvailable).toHaveBeenCalledTimes(1);
+    onAnalysisAvailable.mockClear();
+
+    view.rerender(
+      <InvestigationPanel
+        subjectType="alert"
+        subjectId={ALERT_ID}
+        onAnalysisAvailable={onAnalysisAvailable}
+      />,
+    );
+    await flush();
+
+    expect(view.container).toBeEmptyDOMElement();
+    expect(onAnalysisAvailable).not.toHaveBeenCalled();
+
+    await resolveDeferred(
+      nextSubject,
+      completedResponse({
+        runId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        analysisMarkdown: nextSubjectAnalysis,
+      }),
+    );
+
+    expect(screen.getByTestId("investigation-markdown")).toHaveTextContent(
+      "The upstream dependency rejected requests.",
+    );
+    expect(onAnalysisAvailable).toHaveBeenCalledTimes(1);
+    expect(postRequestAt(1).data).toEqual({ alertId: ALERT_ID.toString() });
+  });
+
+  test("shows the no-report outcome and disables analysis-only actions", async () => {
+    postMock.mockResolvedValue(
+      completedResponse({
+        analysisMarkdown: null,
+        isAnalysisPending: false,
+        events: [],
+        toolCallCount: 0,
+        totalTokens: 0,
+      }) as never,
+    );
+
+    renderPanel();
+    await flush();
+
+    expect(
+      screen.getByText("Investigation completed without a report"),
+    ).toBeVisible();
+    expect(
+      screen.getByText("No investigation report was published."),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", {
+        name: "Open Fix PR from this analysis",
+      }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Confirmed" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Rejected" })).toBeDisabled();
+    expect(jest.getTimerCount()).toBe(1);
+  });
+
+  test("shows a terminal failure without presenting completed actions", async () => {
+    postMock.mockResolvedValue(
+      successfulResponse(
+        investigationPayload({
+          status: AIRunStatus.Error,
+          errorMessage: "The model provider timed out.",
+          events: [activityEvent],
+        }),
+      ) as never,
+    );
+
+    renderPanel();
+    await flush();
+
+    expect(screen.getByText("Investigation did not finish")).toBeVisible();
+    expect(screen.getByText("The model provider timed out.")).toBeVisible();
+    expect(lastActivityProps()).toEqual(
+      expect.objectContaining({
+        title: "Investigation activity",
+        showLiveIndicator: false,
+      }),
+    );
+    expect(
+      screen.queryByRole("button", {
+        name: "Open Fix PR from this analysis",
+      }),
+    ).toBeNull();
+    expect(jest.getTimerCount()).toBe(1);
+  });
+
+  test("uses the alert endpoint and alert id for an alert investigation", async () => {
+    postMock.mockResolvedValue(
+      successfulResponse(
+        investigationPayload({ status: AIRunStatus.Running }),
+      ) as never,
+    );
+
+    renderPanel({ subjectType: "alert", subjectId: ALERT_ID });
+    await flush();
+
+    const request: PostRequest = postRequestAt(0);
+    expect(request.url.toString()).toContain("/ai-investigation/alert");
+    expect(request.data).toEqual({ alertId: ALERT_ID.toString() });
+  });
+
+  test("creates a fix task from the completed report", async () => {
+    postMock
+      .mockResolvedValueOnce(completedResponse() as never)
+      .mockResolvedValueOnce(
+        successfulResponse({ aiRunId: FIX_RUN_ID }) as never,
+      );
+
+    renderPanel();
+    await flush();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Open Fix PR from this analysis",
+      }),
+    );
+    await flush();
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Fix task created");
+    expect(screen.getByText("View task progress")).toBeVisible();
+    const request: PostRequest = postRequestAt(1);
+    expect(request.url.toString()).toContain(
+      "/ai-investigation/create-fix-task",
+    );
+    expect(request.data).toEqual({
+      subjectType: "incident",
+      subjectId: INCIDENT_ID.toString(),
+      aiRunId: RUN_ID,
+    });
+  });
+
+  test("clears a successful fix task when navigating to another completed subject", async () => {
+    const nextSubjectAnalysis: string =
+      "## Alert root cause\n\nA deployment removed the required credential.";
+    postMock
+      .mockResolvedValueOnce(completedResponse() as never)
+      .mockResolvedValueOnce(
+        successfulResponse({ aiRunId: FIX_RUN_ID }) as never,
+      )
+      .mockResolvedValueOnce(
+        completedResponse({
+          runId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          analysisMarkdown: nextSubjectAnalysis,
+        }) as never,
+      );
+
+    const view: ReturnType<typeof render> = renderPanel();
+    await flush();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Open Fix PR from this analysis",
+      }),
+    );
+    await flush();
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Fix task created");
+
+    view.rerender(
+      <InvestigationPanel subjectType="alert" subjectId={ALERT_ID} />,
+    );
+    await flush();
+
+    expect(screen.queryByText(/Fix task created/)).toBeNull();
+    expect(screen.getByTestId("investigation-markdown")).toHaveTextContent(
+      "A deployment removed the required credential.",
+    );
+    expect(
+      screen.getByRole("button", {
+        name: "Open Fix PR from this analysis",
+      }),
+    ).toBeEnabled();
+    expect(postRequestAt(2).data).toEqual({ alertId: ALERT_ID.toString() });
+  });
+
+  test("resets fix-task and verdict state when the same subject gets a new completed run", async () => {
+    const nextRunId: string = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    const nextRunAnalysis: string =
+      "## New root cause\n\nA later investigation found a certificate rollover.";
+    postMock
+      .mockResolvedValueOnce(
+        completedResponse({ isAnalysisPending: false }) as never,
+      )
+      .mockResolvedValueOnce(
+        successfulResponse({ aiRunId: FIX_RUN_ID }) as never,
+      )
+      .mockResolvedValueOnce(successfulResponse({}) as never)
+      .mockResolvedValueOnce(
+        completedResponse({
+          runId: nextRunId,
+          analysisMarkdown: nextRunAnalysis,
+          isAnalysisPending: false,
+        }) as never,
+      );
+
+    renderPanel();
+    await flush();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Open Fix PR from this analysis",
+      }),
+    );
+    await flush();
+    fireEvent.click(screen.getByRole("button", { name: "Confirmed" }));
+    await flush();
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Fix task created");
+    expect(screen.getByText(/You confirmed this analysis/)).toBeVisible();
+
+    await tick(SETTLED_POLL_INTERVAL_MS);
+
+    expect(screen.getByTestId("investigation-markdown")).toHaveTextContent(
+      "A later investigation found a certificate rollover.",
+    );
+    expect(screen.queryByText(/Fix task created/)).toBeNull();
+    expect(screen.queryByText(/You confirmed this analysis/)).toBeNull();
+    expect(
+      screen.getByRole("button", {
+        name: "Open Fix PR from this analysis",
+      }),
+    ).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Confirmed" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Rejected" })).toBeEnabled();
+    expect(postMock).toHaveBeenCalledTimes(4);
+    expect(jest.getTimerCount()).toBe(1);
+  });
+
+  test("keeps the fix action available and explains a rejected task request", async () => {
+    postMock
+      .mockResolvedValueOnce(completedResponse() as never)
+      .mockResolvedValueOnce(
+        new HTTPErrorResponse(
+          400,
+          { message: "No connected repository exists." },
+          {},
+        ) as never,
+      );
+
+    renderPanel();
+    await flush();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Open Fix PR from this analysis",
+      }),
+    );
+    await flush();
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Could not create the fix task",
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "No connected repository exists",
+    );
+    expect(
+      screen.getByRole("button", {
+        name: "Open Fix PR from this analysis",
+      }),
+    ).toBeEnabled();
+  });
+
+  test("persists a positive verdict and replaces the verdict buttons", async () => {
+    postMock
+      .mockResolvedValueOnce(completedResponse() as never)
+      .mockResolvedValueOnce(successfulResponse({}) as never);
+
+    renderPanel();
+    await flush();
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirmed" }));
+    await flush();
+
+    expect(screen.getByText(/You confirmed this analysis/)).toBeVisible();
+    const request: PostRequest = postRequestAt(1);
+    expect(request.url.toString()).toContain("/ai-investigation/verdict");
+    expect(request.data).toEqual({
+      subjectType: "incident",
+      subjectId: INCIDENT_ID.toString(),
+      aiRunId: RUN_ID,
+      verdict: "Confirmed",
+    });
+  });
+
+  test("a GET started before verdict save cannot overwrite the saved verdict", async () => {
+    const stalePoll: Deferred<ApiResponse> = createDeferred<ApiResponse>();
+    postMock
+      .mockResolvedValueOnce(completedResponse() as never)
+      .mockReturnValueOnce(stalePoll.promise as never)
+      .mockResolvedValueOnce(successfulResponse({}) as never);
+
+    renderPanel();
+    await flush();
+
+    await tick(SETTLED_POLL_INTERVAL_MS);
+    expect(postMock).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirmed" }));
+    await flush();
+    expect(screen.getByText(/You confirmed this analysis/)).toBeVisible();
+
+    await resolveDeferred(stalePoll, completedResponse({ humanVerdict: null }));
+
+    expect(screen.getByText(/You confirmed this analysis/)).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Confirmed" })).toBeNull();
+  });
+
+  test("rolls back an optimistic verdict when the save fails", async () => {
+    postMock
+      .mockResolvedValueOnce(completedResponse() as never)
+      .mockResolvedValueOnce(
+        new HTTPErrorResponse(
+          500,
+          { message: "Verdict storage is unavailable." },
+          {},
+        ) as never,
+      );
+
+    renderPanel();
+    await flush();
+
+    fireEvent.click(screen.getByRole("button", { name: "Rejected" }));
+    await flush();
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Could not save your verdict",
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Verdict storage is unavailable.",
+    );
+    expect(screen.queryByText(/You rejected this analysis/)).toBeNull();
+    expect(screen.getByRole("button", { name: "Rejected" })).toBeEnabled();
+  });
+});

--- a/Common/Tests/Server/API/AIAgentDataFixFromIncidentContext.test.ts
+++ b/Common/Tests/Server/API/AIAgentDataFixFromIncidentContext.test.ts
@@ -1,0 +1,299 @@
+import AIAgentDataAPI from "../../../Server/API/AIAgentDataAPI";
+import AIRunService from "../../../Server/Services/AIRunService";
+import AlertService from "../../../Server/Services/AlertService";
+import CodeRepositoryService from "../../../Server/Services/CodeRepositoryService";
+import IncidentService from "../../../Server/Services/IncidentService";
+import CodeFixAgentAuth, {
+  CodeFixAgentSource,
+} from "../../../Server/Utils/AI/CodeFix/CodeFixAgentAuth";
+import PostedRootCause from "../../../Server/Utils/AI/SRE/PostedRootCause";
+import Response from "../../../Server/Utils/Response";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import AIRun from "../../../Models/DatabaseModels/AIRun";
+import Alert from "../../../Models/DatabaseModels/Alert";
+import Incident from "../../../Models/DatabaseModels/Incident";
+import AIRunType from "../../../Types/AI/AIRunType";
+import CodeFixTaskType from "../../../Types/AI/CodeFixTaskType";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import { mockRouter } from "./Helpers";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "@jest/globals";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendJsonObjectResponse: jest.fn(),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendErrorResponse: jest.fn(),
+    redirect: jest.fn(),
+  };
+});
+
+const TASK_DETAILS_ROUTE: string =
+  "/ai-agent-data/get-instrumentation-task-details";
+
+describe("FixFromIncident task-details investigation context", () => {
+  let projectId: ObjectID;
+  let taskId: ObjectID;
+
+  beforeAll(() => {
+    mockRouter.routes.length = 0;
+    new AIAgentDataAPI();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    projectId = ObjectID.generate();
+    taskId = ObjectID.generate();
+
+    jest.spyOn(CodeFixAgentAuth, "resolveAgentIdentity").mockResolvedValue({
+      id: ObjectID.generate(),
+      projectId,
+      source: CodeFixAgentSource.AIAgent,
+    });
+    jest
+      .spyOn(CodeFixAgentAuth, "deniesAccessToProject")
+      .mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function fixRun(data: {
+    incidentId?: ObjectID | undefined;
+    alertId?: ObjectID | undefined;
+    sourceInvestigationRunId?: ObjectID | undefined;
+    sourceInvestigationAnalysisMarkdown?: string | undefined;
+  }): AIRun {
+    const run: AIRun = new AIRun();
+    run.id = taskId;
+    run.projectId = projectId;
+    run.runType = AIRunType.CodeFix;
+    run.codeFixTaskType = CodeFixTaskType.FixFromIncident;
+
+    if (data.incidentId) {
+      run.triggeredByIncidentId = data.incidentId;
+    }
+
+    if (data.alertId) {
+      run.triggeredByAlertId = data.alertId;
+    }
+
+    if (
+      data.sourceInvestigationRunId ||
+      data.sourceInvestigationAnalysisMarkdown
+    ) {
+      run.taskContext = {
+        ...(data.sourceInvestigationRunId
+          ? {
+              sourceInvestigationRunId:
+                data.sourceInvestigationRunId.toString(),
+            }
+          : {}),
+        ...(data.sourceInvestigationAnalysisMarkdown
+          ? {
+              sourceInvestigationAnalysisMarkdown:
+                data.sourceInvestigationAnalysisMarkdown,
+            }
+          : {}),
+      };
+    }
+
+    return run;
+  }
+
+  async function callRoute(): Promise<void> {
+    const req: ExpressRequest = {
+      params: {},
+      query: {},
+      body: {
+        aiAgentId: ObjectID.generate().toString(),
+        aiAgentKey: "agent-key",
+        taskId: taskId.toString(),
+      },
+      headers: {},
+    } as unknown as ExpressRequest;
+    const res: ExpressResponse = {} as ExpressResponse;
+    const next: NextFunction = jest.fn() as unknown as NextFunction;
+
+    await mockRouter
+      .match("POST", TASK_DETAILS_ROUTE)
+      .handlerFunction(req, res, next);
+  }
+
+  function jsonResponse(): JSONObject | undefined {
+    const sendJsonObjectResponse: jest.Mock =
+      Response.sendJsonObjectResponse as unknown as jest.Mock;
+
+    return sendJsonObjectResponse.mock.calls[0]?.[2] as JSONObject | undefined;
+  }
+
+  test("new incident task uses its frozen analysis without re-reading the feed", async () => {
+    const incidentId: ObjectID = ObjectID.generate();
+    const sourceInvestigationRunId: ObjectID = ObjectID.generate();
+    const frozenAnalysis: string = "# Frozen incident analysis";
+    jest.spyOn(AIRunService, "findOneById").mockResolvedValue(
+      fixRun({
+        incidentId,
+        sourceInvestigationRunId,
+        sourceInvestigationAnalysisMarkdown: frozenAnalysis,
+      }),
+    );
+
+    const incident: Incident = new Incident();
+    incident.title = "Database incident";
+    jest.spyOn(IncidentService, "findOneById").mockResolvedValue(incident);
+    const getForIncident: jest.SpyInstance = jest.spyOn(
+      PostedRootCause,
+      "getForIncident",
+    );
+    jest
+      .spyOn(CodeRepositoryService, "resolveRepositoryForException")
+      .mockResolvedValue(null);
+
+    await callRoute();
+
+    expect(getForIncident).not.toHaveBeenCalled();
+    expect(jsonResponse()).toEqual(
+      expect.objectContaining({
+        subjectType: "incident",
+        analysisMarkdown: frozenAnalysis,
+      }),
+    );
+  });
+
+  test("source-id-only incident task reads the exact investigation for upgrade compatibility", async () => {
+    const incidentId: ObjectID = ObjectID.generate();
+    const sourceInvestigationRunId: ObjectID = ObjectID.generate();
+    jest
+      .spyOn(AIRunService, "findOneById")
+      .mockResolvedValue(fixRun({ incidentId, sourceInvestigationRunId }));
+
+    const incident: Incident = new Incident();
+    incident.title = "Database incident";
+    jest.spyOn(IncidentService, "findOneById").mockResolvedValue(incident);
+    const getForIncident: jest.SpyInstance = jest
+      .spyOn(PostedRootCause, "getForIncident")
+      .mockResolvedValue(null);
+
+    await callRoute();
+
+    expect(getForIncident).toHaveBeenCalledWith(incidentId, {
+      aiRunId: sourceInvestigationRunId,
+    });
+  });
+
+  test("legacy incident task falls back to the unscoped subject analysis", async () => {
+    const incidentId: ObjectID = ObjectID.generate();
+    jest
+      .spyOn(AIRunService, "findOneById")
+      .mockResolvedValue(fixRun({ incidentId }));
+
+    const incident: Incident = new Incident();
+    incident.title = "Legacy incident";
+    jest.spyOn(IncidentService, "findOneById").mockResolvedValue(incident);
+    const getForIncident: jest.SpyInstance = jest
+      .spyOn(PostedRootCause, "getForIncident")
+      .mockResolvedValue(null);
+
+    await callRoute();
+
+    expect(getForIncident).toHaveBeenCalledTimes(1);
+    expect(getForIncident).toHaveBeenCalledWith(incidentId, undefined);
+  });
+
+  test("new alert task uses its frozen analysis without re-reading the feed", async () => {
+    const alertId: ObjectID = ObjectID.generate();
+    const sourceInvestigationRunId: ObjectID = ObjectID.generate();
+    const frozenAnalysis: string = "# Frozen alert analysis";
+    jest.spyOn(AIRunService, "findOneById").mockResolvedValue(
+      fixRun({
+        alertId,
+        sourceInvestigationRunId,
+        sourceInvestigationAnalysisMarkdown: frozenAnalysis,
+      }),
+    );
+
+    const alert: Alert = new Alert();
+    alert.title = "Latency alert";
+    jest.spyOn(AlertService, "findOneById").mockResolvedValue(alert);
+    const getForAlert: jest.SpyInstance = jest.spyOn(
+      PostedRootCause,
+      "getForAlert",
+    );
+    jest
+      .spyOn(CodeRepositoryService, "resolveRepositoryForException")
+      .mockResolvedValue(null);
+
+    await callRoute();
+
+    expect(getForAlert).not.toHaveBeenCalled();
+    expect(jsonResponse()).toEqual(
+      expect.objectContaining({
+        subjectType: "alert",
+        analysisMarkdown: frozenAnalysis,
+      }),
+    );
+  });
+
+  test("source-id-only alert task reads the exact investigation for upgrade compatibility", async () => {
+    const alertId: ObjectID = ObjectID.generate();
+    const sourceInvestigationRunId: ObjectID = ObjectID.generate();
+    jest
+      .spyOn(AIRunService, "findOneById")
+      .mockResolvedValue(fixRun({ alertId, sourceInvestigationRunId }));
+
+    const alert: Alert = new Alert();
+    alert.title = "Latency alert";
+    jest.spyOn(AlertService, "findOneById").mockResolvedValue(alert);
+    const getForAlert: jest.SpyInstance = jest
+      .spyOn(PostedRootCause, "getForAlert")
+      .mockResolvedValue(null);
+
+    await callRoute();
+
+    expect(getForAlert).toHaveBeenCalledWith(alertId, {
+      aiRunId: sourceInvestigationRunId,
+    });
+  });
+
+  test("legacy alert task falls back to the unscoped subject analysis", async () => {
+    const alertId: ObjectID = ObjectID.generate();
+    jest
+      .spyOn(AIRunService, "findOneById")
+      .mockResolvedValue(fixRun({ alertId }));
+
+    const alert: Alert = new Alert();
+    alert.title = "Legacy alert";
+    jest.spyOn(AlertService, "findOneById").mockResolvedValue(alert);
+    const getForAlert: jest.SpyInstance = jest
+      .spyOn(PostedRootCause, "getForAlert")
+      .mockResolvedValue(null);
+
+    await callRoute();
+
+    expect(getForAlert).toHaveBeenCalledTimes(1);
+    expect(getForAlert).toHaveBeenCalledWith(alertId, undefined);
+  });
+});

--- a/Common/Tests/Server/API/AIInvestigationAPI.test.ts
+++ b/Common/Tests/Server/API/AIInvestigationAPI.test.ts
@@ -1,0 +1,594 @@
+import { mockRouter } from "./Helpers";
+import {
+  ANALYSIS_COMPLETION_CLOCK_SKEW_MS,
+  ANALYSIS_FINALIZATION_TIMEOUT_MS,
+  isAnalysisPendingForRun,
+} from "../../../Server/API/AIInvestigationAPI";
+import CommonAPI from "../../../Server/API/CommonAPI";
+import AIRunEventService from "../../../Server/Services/AIRunEventService";
+import AIRunService from "../../../Server/Services/AIRunService";
+import AlertService from "../../../Server/Services/AlertService";
+import IncidentService from "../../../Server/Services/IncidentService";
+import PostedRootCause from "../../../Server/Utils/AI/SRE/PostedRootCause";
+import FixFromIncidentTaskTrigger from "../../../Server/Utils/AI/SRE/FixFromIncidentTaskTrigger";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import AIRun from "../../../Models/DatabaseModels/AIRun";
+import AIRunEvent from "../../../Models/DatabaseModels/AIRunEvent";
+import Alert from "../../../Models/DatabaseModels/Alert";
+import Incident from "../../../Models/DatabaseModels/Incident";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import AIRunEventType from "../../../Types/AI/AIRunEventType";
+import AIRunHumanVerdict from "../../../Types/AI/AIRunHumanVerdict";
+import AIRunStatus from "../../../Types/AI/AIRunStatus";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendJsonObjectResponse: jest.fn(),
+  };
+});
+
+const INCIDENT_ID: ObjectID = new ObjectID(
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+const ALERT_ID: ObjectID = new ObjectID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+const USER_ID: ObjectID = new ObjectID("cccccccc-cccc-4ccc-8ccc-cccccccccccc");
+const PROJECT_ID: ObjectID = new ObjectID(
+  "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+);
+
+const props: DatabaseCommonInteractionProps = {
+  userId: USER_ID,
+  tenantId: PROJECT_ID,
+} as DatabaseCommonInteractionProps;
+
+function investigationRun(data: {
+  status: AIRunStatus;
+  createdAt?: Date | undefined;
+  completedAt?: Date | undefined;
+}): AIRun {
+  const run: AIRun = new AIRun(
+    new ObjectID("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"),
+  );
+  run.status = data.status;
+  if (data.createdAt) {
+    run.createdAt = data.createdAt;
+  }
+  if (data.completedAt) {
+    run.completedAt = data.completedAt;
+  }
+  return run;
+}
+
+function investigationEvent(eventType: AIRunEventType): AIRunEvent {
+  const event: AIRunEvent = new AIRunEvent();
+  event.eventType = eventType;
+  return event;
+}
+
+function requestFor(body: JSONObject): ExpressRequest {
+  return {
+    body,
+  } as unknown as ExpressRequest;
+}
+
+function response(): ExpressResponse {
+  return {} as ExpressResponse;
+}
+
+function sentPayload(): JSONObject {
+  const send: jest.Mock =
+    Response.sendJsonObjectResponse as unknown as jest.Mock;
+  return send.mock.calls[0]![2] as JSONObject;
+}
+
+async function callIncidentRoute(data?: {
+  run?: AIRun | undefined;
+  events?: Array<AIRunEvent> | undefined;
+  analysisMarkdown?: string | null | undefined;
+}): Promise<void> {
+  const run: AIRun | undefined = data?.run;
+  jest.spyOn(AIRunService, "findBy").mockResolvedValue(run ? [run] : []);
+  jest
+    .spyOn(PostedRootCause, "getForInvestigation")
+    .mockResolvedValue(data?.analysisMarkdown ?? null);
+  jest.spyOn(AIRunEventService, "findBy").mockResolvedValue(data?.events || []);
+
+  const req: ExpressRequest = requestFor({
+    incidentId: INCIDENT_ID.toString(),
+  });
+  const res: ExpressResponse = response();
+  const next: ReturnType<typeof jest.fn> = jest.fn();
+
+  await mockRouter
+    .match("post", "/ai-investigation/incident")
+    .handlerFunction(req, res, next as unknown as NextFunction);
+}
+
+describe("AIInvestigationAPI latest-investigation payload", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .spyOn(CommonAPI, "getDatabaseCommonInteractionProps")
+      .mockResolvedValue(props);
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(new Incident(INCIDENT_ID));
+    jest
+      .spyOn(AlertService, "findOneById")
+      .mockResolvedValue(new Alert(ALERT_ID));
+    jest.spyOn(AIRunEventService, "findBy").mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns an explicit empty analysis state when no investigation exists", async () => {
+    await callIncidentRoute();
+
+    expect(sentPayload()).toEqual({
+      run: null,
+      events: [],
+      analysisMarkdown: null,
+      isAnalysisPending: false,
+    });
+    expect(PostedRootCause.getForInvestigation).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    AIRunStatus.Queued,
+    AIRunStatus.Running,
+    AIRunStatus.Error,
+    AIRunStatus.Cancelled,
+    AIRunStatus.Stale,
+  ])(
+    "does not read or report a final analysis for a %s run",
+    async (status: AIRunStatus) => {
+      await callIncidentRoute({
+        run: investigationRun({
+          status,
+          createdAt: new Date("2026-08-07T10:00:00.000Z"),
+          completedAt: new Date(),
+        }),
+      });
+
+      expect(PostedRootCause.getForInvestigation).not.toHaveBeenCalled();
+      expect(sentPayload()).toEqual(
+        expect.objectContaining({
+          analysisMarkdown: null,
+          isAnalysisPending: false,
+        }),
+      );
+    },
+  );
+
+  it("returns the completed run's exactly associated analysis", async () => {
+    const run: AIRun = investigationRun({
+      status: AIRunStatus.Completed,
+      createdAt: new Date("2026-08-07T09:55:00.000Z"),
+      completedAt: new Date("2026-08-07T10:00:00.000Z"),
+    });
+    await callIncidentRoute({
+      run,
+      analysisMarkdown:
+        "## Current investigation\nDatabase connections are exhausted.",
+    });
+
+    expect(PostedRootCause.getForInvestigation).toHaveBeenCalledWith({
+      incidentId: INCIDENT_ID,
+      aiRunId: run.id,
+      runCompletedAt: run.completedAt,
+    });
+    expect(sentPayload()).toEqual(
+      expect.objectContaining({
+        analysisMarkdown:
+          "## Current investigation\nDatabase connections are exhausted.",
+        isAnalysisPending: false,
+      }),
+    );
+  });
+
+  it("returns a branded pre-migration report through the null-associated legacy path", async () => {
+    const run: AIRun = investigationRun({
+      status: AIRunStatus.Completed,
+      createdAt: new Date("2026-08-08T09:55:00.000Z"),
+      completedAt: new Date("2026-08-08T10:00:00.000Z"),
+    });
+    const legacyReport: string =
+      "## AI — Automated Root Cause Analysis\n\nLegacy database evidence.";
+
+    await callIncidentRoute({
+      run,
+      events: [investigationEvent(AIRunEventType.RunCompleted)],
+      analysisMarkdown: legacyReport,
+    });
+
+    expect(PostedRootCause.getForInvestigation).toHaveBeenCalledWith({
+      incidentId: INCIDENT_ID,
+      aiRunId: run.id,
+      runCompletedAt: run.completedAt,
+    });
+    expect(sentPayload()).toEqual(
+      expect.objectContaining({
+        analysisMarkdown: legacyReport,
+        isAnalysisPending: false,
+      }),
+    );
+  });
+
+  it("reports a recent completed run as pending while its feed item is being posted", async () => {
+    await callIncidentRoute({
+      run: investigationRun({
+        status: AIRunStatus.Completed,
+        createdAt: new Date("2026-08-07T10:00:00.000Z"),
+        completedAt: new Date(Date.now() - 1000),
+      }),
+    });
+
+    expect(sentPayload()).toEqual(
+      expect.objectContaining({
+        analysisMarkdown: null,
+        isAnalysisPending: true,
+      }),
+    );
+  });
+
+  it("stops reporting pending after the finalization crash failsafe", async () => {
+    await callIncidentRoute({
+      run: investigationRun({
+        status: AIRunStatus.Completed,
+        createdAt: new Date("2026-08-07T10:00:00.000Z"),
+        completedAt: new Date(
+          Date.now() - ANALYSIS_FINALIZATION_TIMEOUT_MS - 1000,
+        ),
+      }),
+    });
+
+    expect(sentPayload()).toEqual(
+      expect.objectContaining({
+        analysisMarkdown: null,
+        isAnalysisPending: false,
+      }),
+    );
+  });
+
+  it("never falls back to an unscoped feed lookup when completedAt is absent", async () => {
+    await callIncidentRoute({
+      run: investigationRun({
+        status: AIRunStatus.Completed,
+        createdAt: new Date("2026-08-07T10:00:00.000Z"),
+      }),
+    });
+
+    expect(PostedRootCause.getForInvestigation).not.toHaveBeenCalled();
+    expect(sentPayload()).toEqual(
+      expect.objectContaining({
+        analysisMarkdown: null,
+        isAnalysisPending: false,
+      }),
+    );
+  });
+
+  it("uses the exact run association on the alert route", async () => {
+    const runCreatedAt: Date = new Date("2026-08-07T10:55:00.000Z");
+    const runCompletedAt: Date = new Date("2026-08-07T11:00:00.000Z");
+    const run: AIRun = investigationRun({
+      status: AIRunStatus.Completed,
+      createdAt: runCreatedAt,
+      completedAt: runCompletedAt,
+    });
+    jest.spyOn(AIRunService, "findBy").mockResolvedValue([run]);
+    jest
+      .spyOn(PostedRootCause, "getForInvestigation")
+      .mockResolvedValue("Alert investigation result");
+
+    const req: ExpressRequest = requestFor({ alertId: ALERT_ID.toString() });
+    const res: ExpressResponse = response();
+    const next: ReturnType<typeof jest.fn> = jest.fn();
+
+    await mockRouter
+      .match("post", "/ai-investigation/alert")
+      .handlerFunction(req, res, next as unknown as NextFunction);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(PostedRootCause.getForInvestigation).toHaveBeenCalledWith({
+      alertId: ALERT_ID,
+      aiRunId: run.id,
+      runCompletedAt: run.completedAt,
+    });
+    expect(sentPayload()).toEqual(
+      expect.objectContaining({
+        analysisMarkdown: "Alert investigation result",
+        isAnalysisPending: false,
+      }),
+    );
+  });
+
+  it("preserves the subject access check before reading a run or analysis", async () => {
+    jest.spyOn(IncidentService, "findOneById").mockResolvedValue(null);
+    jest.spyOn(AIRunService, "findBy").mockResolvedValue([]);
+    jest.spyOn(PostedRootCause, "getForInvestigation").mockResolvedValue(null);
+
+    const req: ExpressRequest = requestFor({
+      incidentId: INCIDENT_ID.toString(),
+    });
+    const res: ExpressResponse = response();
+    const next: ReturnType<typeof jest.fn> = jest.fn();
+
+    await mockRouter
+      .match("post", "/ai-investigation/incident")
+      .handlerFunction(req, res, next as unknown as NextFunction);
+
+    expect(next).toHaveBeenCalledWith(
+      new BadDataException(
+        "Incident not found (or you do not have access to it).",
+      ),
+    );
+    expect(AIRunService.findBy).not.toHaveBeenCalled();
+    expect(PostedRootCause.getForInvestigation).not.toHaveBeenCalled();
+    expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+  });
+});
+
+describe("AIInvestigationAPI run-scoped actions", () => {
+  const investigationRunId: ObjectID = new ObjectID(
+    "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+  );
+  const fixRunId: ObjectID = new ObjectID(
+    "ffffffff-ffff-4fff-8fff-ffffffffffff",
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .spyOn(CommonAPI, "getDatabaseCommonInteractionProps")
+      .mockResolvedValue(props);
+
+    const incident: Incident = new Incident(INCIDENT_ID);
+    incident.projectId = PROJECT_ID;
+    jest.spyOn(IncidentService, "findOneById").mockResolvedValue(incident);
+
+    const alert: Alert = new Alert(ALERT_ID);
+    alert.projectId = PROJECT_ID;
+    jest.spyOn(AlertService, "findOneById").mockResolvedValue(alert);
+    jest
+      .spyOn(AIRunService, "applyHumanVerdictToInvestigation")
+      .mockResolvedValue({
+        runId: investigationRunId,
+        verdict: AIRunHumanVerdict.Confirmed,
+      });
+    jest
+      .spyOn(FixFromIncidentTaskTrigger, "createFixTaskFromInvestigation")
+      .mockResolvedValue(new AIRun(fixRunId));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each(["/ai-investigation/verdict", "/ai-investigation/create-fix-task"])(
+    "rejects a malformed aiRunId on %s before any subject read",
+    async (path: string) => {
+      const req: ExpressRequest = requestFor({
+        subjectType: "incident",
+        subjectId: INCIDENT_ID.toString(),
+        aiRunId: "not-a-uuid",
+        verdict: AIRunHumanVerdict.Confirmed,
+      });
+      const next: ReturnType<typeof jest.fn> = jest.fn();
+
+      await mockRouter
+        .match("post", path)
+        .handlerFunction(req, response(), next as unknown as NextFunction);
+
+      expect(next).toHaveBeenCalledWith(expect.any(BadDataException));
+      expect(IncidentService.findOneById).not.toHaveBeenCalled();
+      expect(
+        AIRunService.applyHumanVerdictToInvestigation,
+      ).not.toHaveBeenCalled();
+      expect(
+        FixFromIncidentTaskTrigger.createFixTaskFromInvestigation,
+      ).not.toHaveBeenCalled();
+    },
+  );
+
+  it("records a verdict only against the displayed run and ACL-scoped project", async () => {
+    const req: ExpressRequest = requestFor({
+      subjectType: "incident",
+      subjectId: INCIDENT_ID.toString(),
+      aiRunId: investigationRunId.toString(),
+      verdict: AIRunHumanVerdict.Confirmed,
+    });
+    const next: ReturnType<typeof jest.fn> = jest.fn();
+
+    await mockRouter
+      .match("post", "/ai-investigation/verdict")
+      .handlerFunction(req, response(), next as unknown as NextFunction);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(AIRunService.applyHumanVerdictToInvestigation).toHaveBeenCalledWith({
+      aiRunId: investigationRunId,
+      projectId: PROJECT_ID,
+      incidentId: INCIDENT_ID,
+      verdict: AIRunHumanVerdict.Confirmed,
+      verdictByUserId: USER_ID,
+    });
+    expect(sentPayload()).toEqual({
+      runId: investigationRunId.toString(),
+      verdict: AIRunHumanVerdict.Confirmed,
+    });
+  });
+
+  it("creates an alert fix task from the displayed investigation run", async () => {
+    const req: ExpressRequest = requestFor({
+      subjectType: "alert",
+      subjectId: ALERT_ID.toString(),
+      aiRunId: investigationRunId.toString(),
+    });
+    const next: ReturnType<typeof jest.fn> = jest.fn();
+
+    await mockRouter
+      .match("post", "/ai-investigation/create-fix-task")
+      .handlerFunction(req, response(), next as unknown as NextFunction);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(
+      FixFromIncidentTaskTrigger.createFixTaskFromInvestigation,
+    ).toHaveBeenCalledWith({
+      projectId: PROJECT_ID,
+      alertId: ALERT_ID,
+      investigationRunId,
+      userId: USER_ID,
+    });
+    expect(sentPayload()).toEqual({ aiRunId: fixRunId.toString() });
+  });
+});
+
+describe("isAnalysisPendingForRun", () => {
+  const now: Date = new Date("2026-08-07T12:00:00.000Z");
+
+  it("is pending while a result-less completed run has no settlement event", () => {
+    expect(
+      isAnalysisPendingForRun({
+        run: investigationRun({
+          status: AIRunStatus.Completed,
+          completedAt: new Date(
+            now.getTime() - ANALYSIS_FINALIZATION_TIMEOUT_MS + 1,
+          ),
+        }),
+        events: [],
+        analysisMarkdown: null,
+        currentDate: now,
+      }),
+    ).toBe(true);
+  });
+
+  it("is no longer pending at the exact crash-failsafe boundary", () => {
+    expect(
+      isAnalysisPendingForRun({
+        run: investigationRun({
+          status: AIRunStatus.Completed,
+          completedAt: new Date(
+            now.getTime() - ANALYSIS_FINALIZATION_TIMEOUT_MS,
+          ),
+        }),
+        events: [],
+        analysisMarkdown: null,
+        currentDate: now,
+      }),
+    ).toBe(false);
+  });
+
+  it("is not pending once analysis exists", () => {
+    expect(
+      isAnalysisPendingForRun({
+        run: investigationRun({
+          status: AIRunStatus.Completed,
+          completedAt: now,
+        }),
+        events: [],
+        analysisMarkdown: "posted",
+        currentDate: now,
+      }),
+    ).toBe(false);
+  });
+
+  it("is not pending without a completion timestamp", () => {
+    expect(
+      isAnalysisPendingForRun({
+        run: investigationRun({ status: AIRunStatus.Completed }),
+        events: [],
+        analysisMarkdown: null,
+        currentDate: now,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores a RunFailed event from an earlier retried attempt", () => {
+    expect(
+      isAnalysisPendingForRun({
+        run: investigationRun({
+          status: AIRunStatus.Completed,
+          completedAt: new Date(now.getTime() - 1000),
+        }),
+        events: [
+          investigationEvent(AIRunEventType.RunFailed),
+          investigationEvent(AIRunEventType.RunStarted),
+        ],
+        analysisMarkdown: null,
+        currentDate: now,
+      }),
+    ).toBe(true);
+  });
+
+  it.each([AIRunEventType.RunCompleted, AIRunEventType.RunFailed])(
+    "is not pending once %s proves finalization settled",
+    (eventType: AIRunEventType) => {
+      expect(
+        isAnalysisPendingForRun({
+          run: investigationRun({
+            status: AIRunStatus.Completed,
+            completedAt: new Date(now.getTime() - 1000),
+          }),
+          events: [investigationEvent(eventType)],
+          analysisMarkdown: null,
+          currentDate: now,
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it("tolerates bounded future clock skew while report publication is pending", () => {
+    expect(
+      isAnalysisPendingForRun({
+        run: investigationRun({
+          status: AIRunStatus.Completed,
+          completedAt: new Date(now.getTime() + 1),
+        }),
+        events: [],
+        analysisMarkdown: null,
+        currentDate: now,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not poll indefinitely for a completion timestamp beyond the skew bound", () => {
+    expect(
+      isAnalysisPendingForRun({
+        run: investigationRun({
+          status: AIRunStatus.Completed,
+          completedAt: new Date(
+            now.getTime() + ANALYSIS_COMPLETION_CLOCK_SKEW_MS + 1,
+          ),
+        }),
+        events: [],
+        analysisMarkdown: null,
+        currentDate: now,
+      }),
+    ).toBe(false);
+  });
+});

--- a/Common/Tests/Server/Services/AIRunHumanVerdict.test.ts
+++ b/Common/Tests/Server/Services/AIRunHumanVerdict.test.ts
@@ -1,32 +1,30 @@
-import AIRunService from "../../../Server/Services/AIRunService";
 import AIRun from "../../../Models/DatabaseModels/AIRun";
-import AIRunType from "../../../Types/AI/AIRunType";
-import AIRunStatus from "../../../Types/AI/AIRunStatus";
+import AIRunService from "../../../Server/Services/AIRunService";
 import AIRunHumanVerdict from "../../../Types/AI/AIRunHumanVerdict";
+import AIRunStatus from "../../../Types/AI/AIRunStatus";
+import AIRunType from "../../../Types/AI/AIRunType";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import ObjectID from "../../../Types/ObjectID";
-import SortOrder from "../../../Types/BaseDatabase/SortOrder";
-import { describe, expect, test, afterEach } from "@jest/globals";
+import { afterEach, describe, expect, test } from "@jest/globals";
 
 /*
- * Human verdict capture (Phase 2 measurement layer): the one-click
- * Confirm / Reject on the investigation panel lands here, via
- * POST /ai-investigation/verdict → applyHumanVerdictToLatestInvestigation.
- * Contract under test: the verdict applies to the LATEST COMPLETED
- * investigation for the subject, rejects when none exists, stores
- * verdict + at + byUserId, and overwriting is allowed (a user may change
- * their mind — there is deliberately no "already has a verdict" guard).
+ * Human verdict capture: Confirm / Reject must update the exact completed
+ * investigation currently displayed by the client. The run, project, and
+ * subject ids are one combined database predicate so a stale or forged run id
+ * cannot put a verdict on another tenant's incident or alert investigation.
  */
 
 const incidentId: ObjectID = ObjectID.generate();
 const alertId: ObjectID = ObjectID.generate();
+const aiRunId: ObjectID = ObjectID.generate();
+const projectId: ObjectID = ObjectID.generate();
 const userId: ObjectID = ObjectID.generate();
 
-function fakeRun(): AIRun {
-  return { id: ObjectID.generate() } as unknown as AIRun;
+function fakeRun(id: ObjectID = aiRunId): AIRun {
+  return { id } as unknown as AIRun;
 }
 
-describe("AIRunService.applyHumanVerdictToLatestInvestigation", () => {
+describe("AIRunService.applyHumanVerdictToInvestigation", () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
@@ -35,7 +33,9 @@ describe("AIRunService.applyHumanVerdictToLatestInvestigation", () => {
     const findOneBy: jest.SpyInstance = jest.spyOn(AIRunService, "findOneBy");
 
     await expect(
-      AIRunService.applyHumanVerdictToLatestInvestigation({
+      AIRunService.applyHumanVerdictToInvestigation({
+        aiRunId,
+        projectId,
         verdict: AIRunHumanVerdict.Confirmed,
         verdictByUserId: userId,
       }),
@@ -44,7 +44,7 @@ describe("AIRunService.applyHumanVerdictToLatestInvestigation", () => {
     expect(findOneBy).not.toHaveBeenCalled();
   });
 
-  test("no completed investigation → reject with a clear message, nothing written", async () => {
+  test("an incident lookup requires the exact run, project, and subject", async () => {
     const findOneBy: jest.SpyInstance = jest
       .spyOn(AIRunService, "findOneBy")
       .mockResolvedValue(null);
@@ -54,58 +54,138 @@ describe("AIRunService.applyHumanVerdictToLatestInvestigation", () => {
     );
 
     await expect(
-      AIRunService.applyHumanVerdictToLatestInvestigation({
+      AIRunService.applyHumanVerdictToInvestigation({
+        aiRunId,
+        projectId,
         incidentId,
         verdict: AIRunHumanVerdict.Confirmed,
         verdictByUserId: userId,
       }),
-    ).rejects.toThrow(/No completed AI investigation/);
+    ).rejects.toThrow(/selected completed AI investigation does not exist/);
 
-    // The lookup must target the LATEST COMPLETED investigation.
+    expect(findOneBy).toHaveBeenCalledWith({
+      query: {
+        _id: aiRunId,
+        projectId,
+        runType: AIRunType.Investigation,
+        status: AIRunStatus.Completed,
+        triggeredByIncidentId: incidentId,
+      },
+      select: { _id: true },
+      props: { isRoot: true },
+    });
+    expect(updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("a run id that does not belong to the requested incident is rejected without a write", async () => {
+    const requestedIncidentId: ObjectID = ObjectID.generate();
+    const findOneBy: jest.SpyInstance = jest
+      .spyOn(AIRunService, "findOneBy")
+      .mockResolvedValue(null);
+    const updateOneById: jest.SpyInstance = jest.spyOn(
+      AIRunService,
+      "updateOneById",
+    );
+
+    await expect(
+      AIRunService.applyHumanVerdictToInvestigation({
+        aiRunId,
+        projectId,
+        incidentId: requestedIncidentId,
+        verdict: AIRunHumanVerdict.Rejected,
+        verdictByUserId: userId,
+      }),
+    ).rejects.toThrow(BadDataException);
+
     expect(findOneBy).toHaveBeenCalledWith(
       expect.objectContaining({
         query: expect.objectContaining({
-          runType: AIRunType.Investigation,
-          status: AIRunStatus.Completed,
-          triggeredByIncidentId: incidentId,
+          _id: aiRunId,
+          projectId,
+          triggeredByIncidentId: requestedIncidentId,
         }),
-        sort: expect.objectContaining({ createdAt: SortOrder.Descending }),
       }),
     );
     expect(updateOneById).not.toHaveBeenCalled();
   });
 
-  test("happy path (incident): stores verdict + at + byUserId on the run and returns {runId, verdict}", async () => {
+  test("a different run id for the requested incident is rejected without falling back to its latest run", async () => {
+    const requestedRunId: ObjectID = ObjectID.generate();
+    const findOneBy: jest.SpyInstance = jest
+      .spyOn(AIRunService, "findOneBy")
+      .mockResolvedValue(null);
+    const updateOneById: jest.SpyInstance = jest.spyOn(
+      AIRunService,
+      "updateOneById",
+    );
+
+    await expect(
+      AIRunService.applyHumanVerdictToInvestigation({
+        aiRunId: requestedRunId,
+        projectId,
+        incidentId,
+        verdict: AIRunHumanVerdict.Confirmed,
+        verdictByUserId: userId,
+      }),
+    ).rejects.toThrow(BadDataException);
+
+    expect(findOneBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          _id: requestedRunId,
+          projectId,
+          triggeredByIncidentId: incidentId,
+        }),
+      }),
+    );
+    expect(updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("incident happy path stores verdict metadata on the exact selected run", async () => {
     const run: AIRun = fakeRun();
-    jest.spyOn(AIRunService, "findOneBy").mockResolvedValue(run);
+    const findOneBy: jest.SpyInstance = jest
+      .spyOn(AIRunService, "findOneBy")
+      .mockResolvedValue(run);
     const updateOneById: jest.SpyInstance = jest
       .spyOn(AIRunService, "updateOneById")
       .mockResolvedValue(undefined as never);
 
     const result: { runId: ObjectID; verdict: AIRunHumanVerdict } =
-      await AIRunService.applyHumanVerdictToLatestInvestigation({
+      await AIRunService.applyHumanVerdictToInvestigation({
+        aiRunId,
+        projectId,
         incidentId,
         verdict: AIRunHumanVerdict.Confirmed,
         verdictByUserId: userId,
       });
 
-    expect(result.runId).toBe(run.id);
-    expect(result.verdict).toBe(AIRunHumanVerdict.Confirmed);
-
-    expect(updateOneById).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: run.id,
-        data: expect.objectContaining({
-          humanVerdict: AIRunHumanVerdict.Confirmed,
-          humanVerdictAt: expect.any(Date),
-          humanVerdictByUserId: userId,
-        }),
-        props: expect.objectContaining({ isRoot: true }),
-      }),
-    );
+    expect(findOneBy).toHaveBeenCalledWith({
+      query: {
+        _id: aiRunId,
+        projectId,
+        runType: AIRunType.Investigation,
+        status: AIRunStatus.Completed,
+        triggeredByIncidentId: incidentId,
+      },
+      select: { _id: true },
+      props: { isRoot: true },
+    });
+    expect(result).toEqual({
+      runId: run.id,
+      verdict: AIRunHumanVerdict.Confirmed,
+    });
+    expect(updateOneById).toHaveBeenCalledWith({
+      id: run.id,
+      data: {
+        humanVerdict: AIRunHumanVerdict.Confirmed,
+        humanVerdictAt: expect.any(Date),
+        humanVerdictByUserId: userId,
+      },
+      props: { isRoot: true },
+    });
   });
 
-  test("happy path (alert): the lookup keys on triggeredByAlertId", async () => {
+  test("alert happy path scopes the exact run to the alert and never adds incident scope", async () => {
     const run: AIRun = fakeRun();
     const findOneBy: jest.SpyInstance = jest
       .spyOn(AIRunService, "findOneBy")
@@ -114,27 +194,30 @@ describe("AIRunService.applyHumanVerdictToLatestInvestigation", () => {
       .spyOn(AIRunService, "updateOneById")
       .mockResolvedValue(undefined as never);
 
-    await AIRunService.applyHumanVerdictToLatestInvestigation({
+    await AIRunService.applyHumanVerdictToInvestigation({
+      aiRunId,
+      projectId,
       alertId,
       verdict: AIRunHumanVerdict.Rejected,
       verdictByUserId: userId,
     });
 
-    expect(findOneBy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({
-          runType: AIRunType.Investigation,
-          status: AIRunStatus.Completed,
-          triggeredByAlertId: alertId,
-        }),
-      }),
-    );
+    expect(findOneBy).toHaveBeenCalledWith({
+      query: {
+        _id: aiRunId,
+        projectId,
+        runType: AIRunType.Investigation,
+        status: AIRunStatus.Completed,
+        triggeredByAlertId: alertId,
+      },
+      select: { _id: true },
+      props: { isRoot: true },
+    });
   });
 
-  test("idempotent overwrite: a run that already carries a verdict is simply re-written", async () => {
-    // The service deliberately does NOT guard on an existing verdict.
+  test("an existing verdict can be overwritten on that same exact run", async () => {
     const run: AIRun = {
-      id: ObjectID.generate(),
+      id: aiRunId,
       humanVerdict: AIRunHumanVerdict.Confirmed,
     } as unknown as AIRun;
     jest.spyOn(AIRunService, "findOneBy").mockResolvedValue(run);
@@ -143,7 +226,9 @@ describe("AIRunService.applyHumanVerdictToLatestInvestigation", () => {
       .mockResolvedValue(undefined as never);
 
     const result: { runId: ObjectID; verdict: AIRunHumanVerdict } =
-      await AIRunService.applyHumanVerdictToLatestInvestigation({
+      await AIRunService.applyHumanVerdictToInvestigation({
+        aiRunId,
+        projectId,
         incidentId,
         verdict: AIRunHumanVerdict.Rejected,
         verdictByUserId: userId,
@@ -152,6 +237,7 @@ describe("AIRunService.applyHumanVerdictToLatestInvestigation", () => {
     expect(result.verdict).toBe(AIRunHumanVerdict.Rejected);
     expect(updateOneById).toHaveBeenCalledWith(
       expect.objectContaining({
+        id: aiRunId,
         data: expect.objectContaining({
           humanVerdict: AIRunHumanVerdict.Rejected,
         }),

--- a/Common/Tests/Server/Services/FeedAIRunAssociation.test.ts
+++ b/Common/Tests/Server/Services/FeedAIRunAssociation.test.ts
@@ -1,0 +1,125 @@
+import AlertFeed, {
+  AlertFeedEventType,
+} from "../../../Models/DatabaseModels/AlertFeed";
+import IncidentFeed, {
+  IncidentFeedEventType,
+} from "../../../Models/DatabaseModels/IncidentFeed";
+import AlertFeedService from "../../../Server/Services/AlertFeedService";
+import IncidentFeedService from "../../../Server/Services/IncidentFeedService";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import type { TableColumnMetadata } from "../../../Types/Database/TableColumn";
+import TableColumnType from "../../../Types/Database/TableColumnType";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import { getMetadataArgsStorage } from "typeorm";
+import type { ColumnMetadataArgs } from "typeorm/metadata-args/ColumnMetadataArgs";
+import type { IndexMetadataArgs } from "typeorm/metadata-args/IndexMetadataArgs";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+const INCIDENT_ID: ObjectID = new ObjectID(
+  "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+);
+const ALERT_ID: ObjectID = new ObjectID("cccccccc-cccc-4ccc-8ccc-cccccccccccc");
+const AI_RUN_ID: ObjectID = new ObjectID(
+  "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+);
+
+function expectRunAssociationMetadata(
+  model: IncidentFeed | AlertFeed,
+  target: typeof IncidentFeed | typeof AlertFeed,
+  subjectIdColumn: "incidentId" | "alertId",
+): void {
+  expect(model.getTableColumns().columns).toContain("aiRunId");
+
+  const tableColumn: TableColumnMetadata =
+    model.getTableColumnMetadata("aiRunId");
+  expect(tableColumn.type).toBe(TableColumnType.ObjectID);
+  expect(tableColumn.required).toBe(false);
+  expect(tableColumn.canReadOnRelationQuery).toBe(true);
+
+  const databaseColumn: ColumnMetadataArgs | undefined =
+    getMetadataArgsStorage().columns.find((column: ColumnMetadataArgs) => {
+      return column.target === target && column.propertyName === "aiRunId";
+    });
+  expect(databaseColumn?.options.nullable).toBe(true);
+
+  const hasExactLookupIndex: boolean = getMetadataArgsStorage().indices.some(
+    (index: IndexMetadataArgs): boolean => {
+      return (
+        index.target === target &&
+        Array.isArray(index.columns) &&
+        index.columns.length === 2 &&
+        index.columns[0] === subjectIdColumn &&
+        index.columns[1] === "aiRunId"
+      );
+    },
+  );
+  expect(hasExactLookupIndex).toBe(true);
+}
+
+describe("feed AI run association metadata", () => {
+  it("defines a nullable, exact-lookup-indexed incident feed association", () => {
+    expectRunAssociationMetadata(
+      new IncidentFeed(),
+      IncidentFeed,
+      "incidentId",
+    );
+  });
+
+  it("defines a nullable, exact-lookup-indexed alert feed association", () => {
+    expectRunAssociationMetadata(new AlertFeed(), AlertFeed, "alertId");
+  });
+});
+
+describe("feed service AI run persistence", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("copies aiRunId into the incident RootCause row", async () => {
+    jest
+      .spyOn(IncidentFeedService, "create")
+      .mockResolvedValue(new IncidentFeed());
+
+    await IncidentFeedService.createIncidentFeedItem({
+      incidentId: INCIDENT_ID,
+      projectId: PROJECT_ID,
+      aiRunId: AI_RUN_ID,
+      incidentFeedEventType: IncidentFeedEventType.RootCause,
+      feedInfoInMarkdown: "Incident analysis",
+    });
+
+    const createCall: CreateBy<IncidentFeed> = jest.mocked(
+      IncidentFeedService.create,
+    ).mock.calls[0]![0];
+    const createData: IncidentFeed = createCall.data;
+    expect(createData.aiRunId).toEqual(AI_RUN_ID);
+    expect(createData.incidentId).toEqual(INCIDENT_ID);
+    expect(createData.incidentFeedEventType).toBe(
+      IncidentFeedEventType.RootCause,
+    );
+    expect(createCall.props).toEqual({ isRoot: true });
+  });
+
+  it("copies aiRunId into the alert RootCause row", async () => {
+    jest.spyOn(AlertFeedService, "create").mockResolvedValue(new AlertFeed());
+
+    await AlertFeedService.createAlertFeedItem({
+      alertId: ALERT_ID,
+      projectId: PROJECT_ID,
+      aiRunId: AI_RUN_ID,
+      alertFeedEventType: AlertFeedEventType.RootCause,
+      feedInfoInMarkdown: "Alert analysis",
+    });
+
+    const createCall: CreateBy<AlertFeed> = jest.mocked(AlertFeedService.create)
+      .mock.calls[0]![0];
+    const createData: AlertFeed = createCall.data;
+    expect(createData.aiRunId).toEqual(AI_RUN_ID);
+    expect(createData.alertId).toEqual(ALERT_ID);
+    expect(createData.alertFeedEventType).toBe(AlertFeedEventType.RootCause);
+    expect(createCall.props).toEqual({ isRoot: true });
+  });
+});

--- a/Common/Tests/Server/Services/FixFromIncidentTaskTrigger.test.ts
+++ b/Common/Tests/Server/Services/FixFromIncidentTaskTrigger.test.ts
@@ -1,4 +1,5 @@
 import FixFromIncidentTaskTrigger from "../../../Server/Utils/AI/SRE/FixFromIncidentTaskTrigger";
+import PostedRootCause from "../../../Server/Utils/AI/SRE/PostedRootCause";
 import FixRunBudget from "../../../Server/Utils/AI/CodeFix/FixRunBudget";
 import CodeRepositoryService from "../../../Server/Services/CodeRepositoryService";
 import AIRunService from "../../../Server/Services/AIRunService";
@@ -27,15 +28,24 @@ const projectId: ObjectID = ObjectID.generate();
 const incidentId: ObjectID = ObjectID.generate();
 const alertId: ObjectID = ObjectID.generate();
 const userId: ObjectID = ObjectID.generate();
+const investigationRunId: ObjectID = ObjectID.generate();
+const investigationCompletedAt: Date = new Date("2026-08-07T12:00:00.000Z");
+const analysisMarkdown: string = "## Exact investigation report";
 
 function fakeRun(): AIRun {
-  return { id: ObjectID.generate() } as unknown as AIRun;
+  return {
+    id: ObjectID.generate(),
+    completedAt: investigationCompletedAt,
+  } as unknown as AIRun;
 }
 
 describe("FixFromIncidentTaskTrigger.createFixTaskFromInvestigation", () => {
   beforeEach(() => {
     // The daily fix-run budget has its own suite (FixRunBudget.test.ts).
     jest.spyOn(FixRunBudget, "assertWithinBudget").mockResolvedValue();
+    jest
+      .spyOn(PostedRootCause, "getForInvestigation")
+      .mockResolvedValue(analysisMarkdown);
   });
 
   afterEach(() => {
@@ -48,6 +58,7 @@ describe("FixFromIncidentTaskTrigger.createFixTaskFromInvestigation", () => {
     await expect(
       FixFromIncidentTaskTrigger.createFixTaskFromInvestigation({
         projectId,
+        investigationRunId,
         userId,
       }),
     ).rejects.toThrow(BadDataException);
@@ -61,6 +72,7 @@ describe("FixFromIncidentTaskTrigger.createFixTaskFromInvestigation", () => {
     await expect(
       FixFromIncidentTaskTrigger.createFixTaskFromInvestigation({
         projectId,
+        investigationRunId,
         incidentId,
         alertId,
         userId,
@@ -84,6 +96,7 @@ describe("FixFromIncidentTaskTrigger.createFixTaskFromInvestigation", () => {
     await expect(
       FixFromIncidentTaskTrigger.createFixTaskFromInvestigation({
         projectId,
+        investigationRunId,
         incidentId,
         userId,
       }),
@@ -92,12 +105,44 @@ describe("FixFromIncidentTaskTrigger.createFixTaskFromInvestigation", () => {
     expect(findOneBy).toHaveBeenCalledWith(
       expect.objectContaining({
         query: expect.objectContaining({
+          _id: investigationRunId,
+          projectId,
           runType: AIRunType.Investigation,
           status: AIRunStatus.Completed,
           triggeredByIncidentId: incidentId,
         }),
       }),
     );
+    expect(countBy).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test("the exact investigation must have a posted report before a task can be frozen", async () => {
+    jest.spyOn(AIRunService, "findOneBy").mockResolvedValue(fakeRun());
+    jest
+      .mocked(PostedRootCause.getForInvestigation)
+      .mockResolvedValueOnce(null);
+    const countBy: jest.SpyInstance = jest.spyOn(
+      CodeRepositoryService,
+      "countBy",
+    );
+    const create: jest.SpyInstance = jest.spyOn(AIRunService, "create");
+
+    await expect(
+      FixFromIncidentTaskTrigger.createFixTaskFromInvestigation({
+        projectId,
+        investigationRunId,
+        incidentId,
+        userId,
+      }),
+    ).rejects.toThrow(/No posted investigation analysis/);
+
+    expect(PostedRootCause.getForInvestigation).toHaveBeenCalledWith({
+      incidentId,
+      alertId: undefined,
+      aiRunId: investigationRunId,
+      runCompletedAt: investigationCompletedAt,
+    });
     expect(countBy).not.toHaveBeenCalled();
     expect(create).not.toHaveBeenCalled();
   });
@@ -112,6 +157,7 @@ describe("FixFromIncidentTaskTrigger.createFixTaskFromInvestigation", () => {
     await expect(
       FixFromIncidentTaskTrigger.createFixTaskFromInvestigation({
         projectId,
+        investigationRunId,
         incidentId,
         userId,
       }),
@@ -135,6 +181,7 @@ describe("FixFromIncidentTaskTrigger.createFixTaskFromInvestigation", () => {
     await expect(
       FixFromIncidentTaskTrigger.createFixTaskFromInvestigation({
         projectId,
+        investigationRunId,
         incidentId,
         userId,
       }),
@@ -163,6 +210,7 @@ describe("FixFromIncidentTaskTrigger.createFixTaskFromInvestigation", () => {
     await expect(
       FixFromIncidentTaskTrigger.createFixTaskFromInvestigation({
         projectId,
+        investigationRunId,
         incidentId,
         userId,
       }),
@@ -191,6 +239,7 @@ describe("FixFromIncidentTaskTrigger.createFixTaskFromInvestigation", () => {
     const run: AIRun =
       await FixFromIncidentTaskTrigger.createFixTaskFromInvestigation({
         projectId,
+        investigationRunId,
         incidentId,
         userId,
       });
@@ -221,6 +270,10 @@ describe("FixFromIncidentTaskTrigger.createFixTaskFromInvestigation", () => {
           codeFixTaskType: CodeFixTaskType.FixFromIncident,
           status: AIRunStatus.Queued,
           triggeredByIncidentId: incidentId,
+          taskContext: {
+            sourceInvestigationRunId: investigationRunId.toString(),
+            sourceInvestigationAnalysisMarkdown: analysisMarkdown,
+          },
           // Attribution: the user who clicked the button.
           userId: userId,
         }),
@@ -243,6 +296,7 @@ describe("FixFromIncidentTaskTrigger.createFixTaskFromInvestigation", () => {
 
     await FixFromIncidentTaskTrigger.createFixTaskFromInvestigation({
       projectId,
+      investigationRunId,
       alertId,
       userId,
     });
@@ -257,6 +311,8 @@ describe("FixFromIncidentTaskTrigger.createFixTaskFromInvestigation", () => {
       1,
       expect.objectContaining({
         query: expect.objectContaining({
+          _id: investigationRunId,
+          projectId,
           runType: AIRunType.Investigation,
           status: AIRunStatus.Completed,
           triggeredByAlertId: alertId,
@@ -269,6 +325,10 @@ describe("FixFromIncidentTaskTrigger.createFixTaskFromInvestigation", () => {
         data: expect.objectContaining({
           codeFixTaskType: CodeFixTaskType.FixFromIncident,
           triggeredByAlertId: alertId,
+          taskContext: {
+            sourceInvestigationRunId: investigationRunId.toString(),
+            sourceInvestigationAnalysisMarkdown: analysisMarkdown,
+          },
           userId: userId,
         }),
       }),

--- a/Common/Tests/Server/Utils/AI/AIConfidenceSignal.test.ts
+++ b/Common/Tests/Server/Utils/AI/AIConfidenceSignal.test.ts
@@ -1,4 +1,6 @@
 import AIConfidenceSignal, {
+  CONFIDENCE_CLASSIFICATION_DEADLINE_MS,
+  CONFIDENCE_CLASSIFICATION_TIMEOUT_MS,
   CONFIDENCE_CLASSIFICATION_FEATURE,
   ConfidenceSignal,
   EvidenceInput,
@@ -260,6 +262,7 @@ describe("AIConfidenceSignal.shouldAutoEnqueueCodeFixTask", () => {
 
 describe("AIConfidenceSignal.computeConfidenceSignal", () => {
   afterEach(() => {
+    jest.useRealTimers();
     jest.restoreAllMocks();
   });
 
@@ -319,6 +322,8 @@ describe("AIConfidenceSignal.computeConfidenceSignal", () => {
         storeContentPreviews: false,
         temperature: 0,
         maxTokens: 20,
+        requestTimeoutInMs: CONFIDENCE_CLASSIFICATION_TIMEOUT_MS,
+        requestRetries: 0,
       }),
     );
   });
@@ -337,6 +342,61 @@ describe("AIConfidenceSignal.computeConfidenceSignal", () => {
       });
 
     expect(signal).toEqual({ confident: false, source: "classification" });
+  });
+
+  test("a provider that never settles is bounded by the aggregate classification deadline", async () => {
+    jest.useFakeTimers();
+    jest
+      .spyOn(AIService, "executeWithLogging")
+      .mockReturnValue(new Promise<AILogResponse>(() => {}) as never);
+
+    const signal: Promise<ConfidenceSignal> =
+      AIConfidenceSignal.computeConfidenceSignal({
+        projectId,
+        aiRunId,
+        analysisMarkdown: "Evidence-backed analysis [C1].",
+        evidence: evidence({ citationCount: 1 }),
+      });
+
+    jest.advanceTimersByTime(CONFIDENCE_CLASSIFICATION_DEADLINE_MS);
+    await Promise.resolve();
+
+    await expect(signal).resolves.toEqual({
+      confident: false,
+      source: "classification-failed",
+    });
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  test("clears the aggregate deadline timer when the provider settles early", async () => {
+    jest.useFakeTimers();
+    const executeWithLogging: jest.SpyInstance = jest
+      .spyOn(AIService, "executeWithLogging")
+      .mockResolvedValue(fakeLlmResponse("CONFIDENT"));
+
+    await expect(
+      AIConfidenceSignal.computeConfidenceSignal({
+        projectId,
+        aiRunId,
+        analysisMarkdown: "Evidence-backed analysis [C1].",
+        evidence: evidence({ citationCount: 1 }),
+      }),
+    ).resolves.toEqual({ confident: true, source: "classification" });
+    expect(jest.getTimerCount()).toBe(0);
+
+    executeWithLogging.mockRejectedValue(new Error("provider unavailable"));
+    await expect(
+      AIConfidenceSignal.computeConfidenceSignal({
+        projectId,
+        aiRunId,
+        analysisMarkdown: "Evidence-backed analysis [C1].",
+        evidence: evidence({ citationCount: 1 }),
+      }),
+    ).resolves.toEqual({
+      confident: false,
+      source: "classification-failed",
+    });
+    expect(jest.getTimerCount()).toBe(0);
   });
 
   test("unparseable response (neither or both tokens) → classification-failed", async () => {

--- a/Common/Tests/Server/Utils/AI/AIInvestigationQueue.test.ts
+++ b/Common/Tests/Server/Utils/AI/AIInvestigationQueue.test.ts
@@ -448,7 +448,7 @@ describe("AIInvestigationQueue", () => {
   test("a heartbeat-stale run requeues while attempts remain", async () => {
     jest.spyOn(AIRunService, "attemptStatusTransition").mockResolvedValue(1);
 
-    const outcome: "requeued" | "stale" =
+    const outcome: "requeued" | "stale" | "noop" =
       await AIInvestigationQueue.requeueOrMarkStale({
         id: ObjectID.generate(),
         attemptCount: 1,
@@ -462,7 +462,7 @@ describe("AIInvestigationQueue", () => {
       .spyOn(AIRunService, "attemptStatusTransition")
       .mockResolvedValue(1);
 
-    const outcome: "requeued" | "stale" =
+    const outcome: "requeued" | "stale" | "noop" =
       await AIInvestigationQueue.requeueOrMarkStale({
         id: ObjectID.generate(),
         attemptCount: MAX_INVESTIGATION_ATTEMPTS,

--- a/Common/Tests/Server/Utils/AI/FixFromIncidentAutoTrigger.test.ts
+++ b/Common/Tests/Server/Utils/AI/FixFromIncidentAutoTrigger.test.ts
@@ -27,6 +27,8 @@ import { describe, expect, test, afterEach, beforeEach } from "@jest/globals";
 const projectId: ObjectID = ObjectID.generate();
 const incidentId: ObjectID = ObjectID.generate();
 const alertId: ObjectID = ObjectID.generate();
+const investigationRunId: ObjectID = ObjectID.generate();
+const analysisMarkdown: string = "## Frozen automatic investigation report";
 
 function fakeProject(data?: {
   enableAi?: boolean;
@@ -261,6 +263,8 @@ describe("FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation", () 
 
     await FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation({
       projectId,
+      investigationRunId,
+      analysisMarkdown,
     });
 
     expect(findProject).not.toHaveBeenCalled();
@@ -278,6 +282,8 @@ describe("FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation", () 
 
     await FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation({
       projectId,
+      investigationRunId,
+      analysisMarkdown,
       incidentId,
       alertId,
     });
@@ -298,6 +304,8 @@ describe("FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation", () 
 
     await FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation({
       projectId,
+      investigationRunId,
+      analysisMarkdown,
       incidentId,
     });
 
@@ -317,6 +325,8 @@ describe("FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation", () 
 
     await FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation({
       projectId,
+      investigationRunId,
+      analysisMarkdown,
       incidentId,
     });
 
@@ -337,6 +347,8 @@ describe("FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation", () 
     await expect(
       FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation({
         projectId,
+        investigationRunId,
+        analysisMarkdown,
         incidentId,
       }),
     ).resolves.toBeUndefined();
@@ -356,6 +368,8 @@ describe("FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation", () 
 
     await FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation({
       projectId,
+      investigationRunId,
+      analysisMarkdown,
       incidentId,
     });
 
@@ -376,6 +390,8 @@ describe("FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation", () 
 
     await FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation({
       projectId,
+      investigationRunId,
+      analysisMarkdown,
       incidentId,
     });
 
@@ -398,6 +414,10 @@ describe("FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation", () 
         projectId,
         taskType: CodeFixTaskType.FixFromIncident,
         incidentId,
+        taskContext: {
+          sourceInvestigationRunId: investigationRunId.toString(),
+          sourceInvestigationAnalysisMarkdown: analysisMarkdown,
+        },
       }),
     );
 
@@ -412,6 +432,8 @@ describe("FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation", () 
 
     await FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation({
       projectId,
+      investigationRunId,
+      analysisMarkdown,
       alertId,
     });
 
@@ -432,6 +454,10 @@ describe("FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation", () 
       expect.objectContaining({
         taskType: CodeFixTaskType.FixFromIncident,
         alertId,
+        taskContext: {
+          sourceInvestigationRunId: investigationRunId.toString(),
+          sourceInvestigationAnalysisMarkdown: analysisMarkdown,
+        },
       }),
     );
     expect(enqueue.mock.calls[0]![0]).not.toHaveProperty("userId");
@@ -444,6 +470,8 @@ describe("FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation", () 
     await expect(
       FixFromIncidentTaskTrigger.autoEnqueueFromConfidentInvestigation({
         projectId,
+        investigationRunId,
+        analysisMarkdown,
         incidentId,
       }),
     ).resolves.toBeUndefined();

--- a/Common/Tests/Server/Utils/AI/InvestigationGrader.test.ts
+++ b/Common/Tests/Server/Utils/AI/InvestigationGrader.test.ts
@@ -1,13 +1,12 @@
 import InvestigationGrader from "../../../../Server/Utils/AI/SRE/InvestigationGrader";
+import PostedRootCause from "../../../../Server/Utils/AI/SRE/PostedRootCause";
 import AIRunService from "../../../../Server/Services/AIRunService";
 import IncidentService from "../../../../Server/Services/IncidentService";
-import IncidentFeedService from "../../../../Server/Services/IncidentFeedService";
 import AIService, {
   AILogResponse,
 } from "../../../../Server/Services/AIService";
 import AIRun from "../../../../Models/DatabaseModels/AIRun";
 import Incident from "../../../../Models/DatabaseModels/Incident";
-import IncidentFeed from "../../../../Models/DatabaseModels/IncidentFeed";
 import AIRunAutoGrade from "../../../../Types/AI/AIRunAutoGrade";
 import ObjectID from "../../../../Types/ObjectID";
 import { describe, expect, test, afterEach } from "@jest/globals";
@@ -24,17 +23,18 @@ import { describe, expect, test, afterEach } from "@jest/globals";
 
 const incidentId: ObjectID = ObjectID.generate();
 const projectId: ObjectID = ObjectID.generate();
+const runCompletedAt: Date = new Date("2026-08-07T12:00:00.000Z");
 
 function fakeRun(autoGrade?: AIRunAutoGrade): AIRun {
-  return { id: ObjectID.generate(), autoGrade } as unknown as AIRun;
+  return {
+    id: ObjectID.generate(),
+    autoGrade,
+    completedAt: runCompletedAt,
+  } as unknown as AIRun;
 }
 
 function fakeIncident(rootCause?: string | undefined): Incident {
   return { id: incidentId, rootCause } as unknown as Incident;
-}
-
-function fakeFeedItem(markdown: string): IncidentFeed {
-  return { feedInfoInMarkdown: markdown } as unknown as IncidentFeed;
 }
 
 function fakeLlmResponse(content: string): AILogResponse {
@@ -221,11 +221,14 @@ describe("InvestigationGrader.gradeInvestigationOnResolve", () => {
   });
 
   test("no posted analysis (no RootCause feed item) → no LLM call", async () => {
-    jest.spyOn(AIRunService, "findOneBy").mockResolvedValue(fakeRun());
+    const run: AIRun = fakeRun();
+    jest.spyOn(AIRunService, "findOneBy").mockResolvedValue(run);
     jest
       .spyOn(IncidentService, "findOneById")
       .mockResolvedValue(fakeIncident("db down"));
-    jest.spyOn(IncidentFeedService, "findOneBy").mockResolvedValue(null);
+    const getForInvestigation: jest.SpyInstance = jest
+      .spyOn(PostedRootCause, "getForInvestigation")
+      .mockResolvedValue(null);
     const executeWithLogging: jest.SpyInstance = jest.spyOn(
       AIService,
       "executeWithLogging",
@@ -236,7 +239,54 @@ describe("InvestigationGrader.gradeInvestigationOnResolve", () => {
       projectId,
     });
 
+    expect(getForInvestigation).toHaveBeenCalledWith({
+      incidentId,
+      aiRunId: run.id,
+      runCompletedAt,
+    });
     expect(executeWithLogging).not.toHaveBeenCalled();
+  });
+
+  test("reads the report associated with the selected completed run exactly", async () => {
+    const run: AIRun = fakeRun();
+    const selectedAnalysis: string =
+      "## Selected investigation\nThe selected run found pool exhaustion.";
+    jest.spyOn(AIRunService, "findOneBy").mockResolvedValue(run);
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(fakeIncident("The connection pool was exhausted."));
+    const getForInvestigation: jest.SpyInstance = jest
+      .spyOn(PostedRootCause, "getForInvestigation")
+      .mockResolvedValue(selectedAnalysis);
+    const executeWithLogging: jest.SpyInstance = jest
+      .spyOn(AIService, "executeWithLogging")
+      .mockResolvedValue(fakeLlmResponse("MATCH"));
+    jest
+      .spyOn(AIRunService, "updateOneById")
+      .mockResolvedValue(undefined as never);
+
+    await InvestigationGrader.gradeInvestigationOnResolve({
+      incidentId,
+      projectId,
+    });
+
+    expect(getForInvestigation).toHaveBeenCalledTimes(1);
+    expect(getForInvestigation).toHaveBeenCalledWith({
+      incidentId,
+      aiRunId: run.id,
+      runCompletedAt,
+    });
+    expect(executeWithLogging).toHaveBeenCalledWith(
+      expect.objectContaining({
+        aiRunId: run.id,
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: "user",
+            content: expect.stringContaining(selectedAnalysis),
+          }),
+        ]),
+      }),
+    );
   });
 
   test("happy path: one budgeted, preview-less LLM call; grade + timestamp stored on the run", async () => {
@@ -246,10 +296,8 @@ describe("InvestigationGrader.gradeInvestigationOnResolve", () => {
       .spyOn(IncidentService, "findOneById")
       .mockResolvedValue(fakeIncident("The connection pool was exhausted."));
     jest
-      .spyOn(IncidentFeedService, "findOneBy")
-      .mockResolvedValue(
-        fakeFeedItem("## Analysis\nThe db connection pool ran dry."),
-      );
+      .spyOn(PostedRootCause, "getForInvestigation")
+      .mockResolvedValue("## Analysis\nThe db connection pool ran dry.");
     const executeWithLogging: jest.SpyInstance = jest
       .spyOn(AIService, "executeWithLogging")
       .mockResolvedValue(fakeLlmResponse("MATCH"));
@@ -297,8 +345,8 @@ describe("InvestigationGrader.gradeInvestigationOnResolve", () => {
       .spyOn(IncidentService, "findOneById")
       .mockResolvedValue(fakeIncident("db down"));
     jest
-      .spyOn(IncidentFeedService, "findOneBy")
-      .mockResolvedValue(fakeFeedItem("Analysis text."));
+      .spyOn(PostedRootCause, "getForInvestigation")
+      .mockResolvedValue("Analysis text.");
     jest
       .spyOn(AIService, "executeWithLogging")
       .mockResolvedValue(fakeLlmResponse("Either MATCH or MISMATCH."));
@@ -321,8 +369,8 @@ describe("InvestigationGrader.gradeInvestigationOnResolve", () => {
       .spyOn(IncidentService, "findOneById")
       .mockResolvedValue(fakeIncident("db down"));
     jest
-      .spyOn(IncidentFeedService, "findOneBy")
-      .mockResolvedValue(fakeFeedItem("Analysis text."));
+      .spyOn(PostedRootCause, "getForInvestigation")
+      .mockResolvedValue("Analysis text.");
     jest
       .spyOn(AIService, "executeWithLogging")
       .mockRejectedValue(new Error("provider down"));

--- a/Common/Tests/Server/Utils/AI/InvestigationSettlement.test.ts
+++ b/Common/Tests/Server/Utils/AI/InvestigationSettlement.test.ts
@@ -13,6 +13,7 @@ import AIRunService from "../../../../Server/Services/AIRunService";
 import AIRunEventService from "../../../../Server/Services/AIRunEventService";
 import AIRun from "../../../../Models/DatabaseModels/AIRun";
 import AIRunEvent from "../../../../Models/DatabaseModels/AIRunEvent";
+import AIRunEventType from "../../../../Types/AI/AIRunEventType";
 import AIRunType from "../../../../Types/AI/AIRunType";
 import AIRunStatus from "../../../../Types/AI/AIRunStatus";
 import ObjectID from "../../../../Types/ObjectID";
@@ -74,6 +75,7 @@ describe("AIInvestigationQueue.failOrRequeue — the settlement outcome", () => 
     expect(update).toHaveBeenCalledTimes(1);
     expect(update).toHaveBeenCalledWith(
       expect.objectContaining({
+        expectedAttemptCount: 1,
         set: expect.objectContaining({ status: AIRunStatus.Queued }),
       }),
     );
@@ -113,6 +115,7 @@ describe("AIInvestigationQueue.failOrRequeue — the settlement outcome", () => 
     expect(outcome).toBe("finalized");
     expect(update).toHaveBeenCalledWith(
       expect.objectContaining({
+        expectedAttemptCount: 1,
         set: expect.objectContaining({ status: AIRunStatus.Error }),
       }),
     );
@@ -158,7 +161,7 @@ describe("AIInvestigationQueue.requeueOrMarkStale — the terminal-stale hand-of
     const incidentId: ObjectID = ObjectID.generate();
     jest.spyOn(AIRunService, "attemptStatusTransition").mockResolvedValue(1);
 
-    const outcome: "requeued" | "stale" =
+    const outcome: "requeued" | "stale" | "noop" =
       await AIInvestigationQueue.requeueOrMarkStale({
         id: ObjectID.generate(),
         attemptCount: MAX_INVESTIGATION_ATTEMPTS,
@@ -175,18 +178,30 @@ describe("AIInvestigationQueue.requeueOrMarkStale — the terminal-stale hand-of
   });
 
   test("a requeued stale run is NOT settled — the retry owns it", async () => {
-    jest.spyOn(AIRunService, "attemptStatusTransition").mockResolvedValue(1);
+    const transition: jest.SpyInstance = jest
+      .spyOn(AIRunService, "attemptStatusTransition")
+      .mockResolvedValue(1);
+    const staleHeartbeat: Date = new Date("2026-08-07T12:00:00.000Z");
+    const runId: ObjectID = ObjectID.generate();
 
-    const outcome: "requeued" | "stale" =
+    const outcome: "requeued" | "stale" | "noop" =
       await AIInvestigationQueue.requeueOrMarkStale({
-        id: ObjectID.generate(),
+        id: runId,
         attemptCount: 1,
+        lastHeartbeatAt: staleHeartbeat,
         runType: AIRunType.Investigation,
         projectId: ObjectID.generate(),
         triggeredByIncidentId: ObjectID.generate(),
       });
 
     expect(outcome).toBe("requeued");
+    expect(transition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        aiRunId: runId,
+        expectedAttemptCount: 1,
+        expectedLastHeartbeatAt: staleHeartbeat,
+      }),
+    );
     expect(handoff).not.toHaveBeenCalled();
   });
 
@@ -208,14 +223,16 @@ describe("AIInvestigationQueue.requeueOrMarkStale — the terminal-stale hand-of
   test("a lost Stale transition does not hand off — the winning actor settles", async () => {
     jest.spyOn(AIRunService, "attemptStatusTransition").mockResolvedValue(0);
 
-    await AIInvestigationQueue.requeueOrMarkStale({
-      id: ObjectID.generate(),
-      attemptCount: MAX_INVESTIGATION_ATTEMPTS,
-      runType: AIRunType.Investigation,
-      projectId: ObjectID.generate(),
-      triggeredByIncidentId: ObjectID.generate(),
-    });
+    const outcome: "requeued" | "stale" | "noop" =
+      await AIInvestigationQueue.requeueOrMarkStale({
+        id: ObjectID.generate(),
+        attemptCount: MAX_INVESTIGATION_ATTEMPTS,
+        runType: AIRunType.Investigation,
+        projectId: ObjectID.generate(),
+        triggeredByIncidentId: ObjectID.generate(),
+      });
 
+    expect(outcome).toBe("noop");
     expect(handoff).not.toHaveBeenCalled();
   });
 });
@@ -335,6 +352,13 @@ describe("AIInvestigationEngine.executeRun — the onSettled contract", () => {
     });
   }
 
+  function emittedEventTypes(): Array<AIRunEventType> {
+    const create: jest.Mock = AIRunEventService.create as unknown as jest.Mock;
+    return create.mock.calls.map((call: Array<unknown>): AIRunEventType => {
+      return (call[0] as { data: AIRunEvent }).data.eventType!;
+    });
+  }
+
   beforeEach(() => {
     callOrder = [];
     postAnalysis = jest.fn(async (): Promise<void> => {
@@ -366,12 +390,23 @@ describe("AIInvestigationEngine.executeRun — the onSettled contract", () => {
       .spyOn(ObservabilityAssistant, "answerQuestion")
       .mockResolvedValue(makeResult());
     jest.spyOn(AIRunService, "attemptStatusTransition").mockResolvedValue(1);
+    postAnalysis.mockImplementation(async (): Promise<void> => {
+      expect(emittedEventTypes()).not.toContain(AIRunEventType.RunCompleted);
+      callOrder.push("postAnalysis");
+    });
 
     await executeRun();
 
     expect(postAnalysis).toHaveBeenCalledTimes(1);
     expect(onSettled).toHaveBeenCalledTimes(1);
     expect(callOrder).toEqual(["postAnalysis", "onSettled"]);
+    expect(emittedEventTypes()).toContain(AIRunEventType.RunCompleted);
+    expect(AIRunService.attemptStatusTransition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedAttemptCount: 1,
+        set: expect.objectContaining({ status: AIRunStatus.Completed }),
+      }),
+    );
   });
 
   test("carries the subject lane through the assistant and confidence calls", async () => {
@@ -420,6 +455,7 @@ describe("AIInvestigationEngine.executeRun — the onSettled contract", () => {
     expect(postAnalysis).not.toHaveBeenCalled();
     expect(confidence).not.toHaveBeenCalled();
     expect(onSettled).toHaveBeenCalledTimes(1);
+    expect(emittedEventTypes()).toContain(AIRunEventType.RunCompleted);
   });
 
   test("a lost Completed CAS neither posts nor settles — the winning attempt owns both", async () => {
@@ -446,6 +482,7 @@ describe("AIInvestigationEngine.executeRun — the onSettled contract", () => {
 
     expect(postAnalysis).not.toHaveBeenCalled();
     expect(onSettled).toHaveBeenCalledTimes(1);
+    expect(emittedEventTypes()).toContain(AIRunEventType.RunFailed);
   });
 
   test("an agent failure that was REQUEUED does not settle — the retry will", async () => {
@@ -459,6 +496,19 @@ describe("AIInvestigationEngine.executeRun — the onSettled contract", () => {
     await executeRun();
 
     expect(onSettled).not.toHaveBeenCalled();
+    expect(emittedEventTypes()).not.toContain(AIRunEventType.RunFailed);
+  });
+
+  test("a stale failing attempt that lost ownership emits no terminal event", async () => {
+    jest
+      .spyOn(ObservabilityAssistant, "answerQuestion")
+      .mockRejectedValue(new Error("stale attempt finished late"));
+    jest.spyOn(AIInvestigationQueue, "failOrRequeue").mockResolvedValue("noop");
+
+    await executeRun();
+
+    expect(onSettled).not.toHaveBeenCalled();
+    expect(emittedEventTypes()).not.toContain(AIRunEventType.RunFailed);
   });
 
   test("a postAnalysis failure after the WON Completed transition still settles", async () => {
@@ -475,6 +525,8 @@ describe("AIInvestigationEngine.executeRun — the onSettled contract", () => {
     await executeRun();
 
     expect(onSettled).toHaveBeenCalledTimes(1);
+    expect(emittedEventTypes()).not.toContain(AIRunEventType.RunCompleted);
+    expect(emittedEventTypes()).toContain(AIRunEventType.RunFailed);
   });
 
   test("an onSettled failure never rejects executeRun", async () => {

--- a/Common/Tests/Server/Utils/AI/PostedRootCause.test.ts
+++ b/Common/Tests/Server/Utils/AI/PostedRootCause.test.ts
@@ -10,6 +10,7 @@ import IncidentFeed, {
 import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
 import ObjectID from "../../../../Types/ObjectID";
 import { afterEach, describe, expect, it } from "@jest/globals";
+import { FindOperator } from "typeorm";
 
 /*
  * The one reader of the analysis an AI investigation posted.
@@ -31,6 +32,9 @@ const INCIDENT_ID: ObjectID = new ObjectID(
   "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
 );
 const ALERT_ID: ObjectID = new ObjectID("dddddddd-dddd-4ddd-8ddd-dddddddddddd");
+const AI_RUN_ID: ObjectID = new ObjectID(
+  "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+);
 
 function incidentFeedItem(markdown: string | null): IncidentFeed {
   return {
@@ -42,6 +46,23 @@ function alertFeedItem(markdown: string | null): AlertFeed {
   return {
     feedInfoInMarkdown: markdown,
   } as unknown as AlertFeed;
+}
+
+interface RawFindOperatorInternals {
+  _getSql: (columnName: string) => string;
+  _objectLiteralParameters: Record<string, unknown>;
+}
+
+function expectCreatedAtCutoff(
+  createdAtFilter: unknown,
+  expectedCutoff: Date,
+): void {
+  expect(createdAtFilter).toBeInstanceOf(FindOperator);
+
+  const raw: RawFindOperatorInternals =
+    createdAtFilter as RawFindOperatorInternals;
+  expect(raw._getSql("COLUMN")).toContain("COLUMN >=");
+  expect(Object.values(raw._objectLiteralParameters)).toEqual([expectedCutoff]);
 }
 
 describe("PostedRootCause.getForIncident", () => {
@@ -84,6 +105,73 @@ describe("PostedRootCause.getForIncident", () => {
           createdAt: SortOrder.Descending,
         }),
       }),
+    );
+    const query: Record<string, unknown> = find.mock.calls[0]![0]
+      .query as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(query, "createdAt")).toBe(
+      false,
+    );
+    expect(Object.prototype.hasOwnProperty.call(query, "aiRunId")).toBe(false);
+  });
+
+  it("can select the RootCause explicitly owned by one investigation run", async () => {
+    const find: jest.SpyInstance = jest
+      .spyOn(IncidentFeedService, "findOneBy")
+      .mockResolvedValue(null);
+
+    await PostedRootCause.getForIncident(INCIDENT_ID, {
+      aiRunId: AI_RUN_ID,
+    });
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          incidentId: INCIDENT_ID,
+          incidentFeedEventType: IncidentFeedEventType.RootCause,
+          aiRunId: AI_RUN_ID,
+        }),
+      }),
+    );
+  });
+
+  it("can restrict an upgrade lookup to rows without an AI run association", async () => {
+    const find: jest.SpyInstance = jest
+      .spyOn(IncidentFeedService, "findOneBy")
+      .mockResolvedValue(null);
+
+    await PostedRootCause.getForIncident(INCIDENT_ID, {
+      withoutAIRunId: true,
+    });
+
+    const aiRunIdFilter: unknown = find.mock.calls[0]![0].query.aiRunId;
+    expect(aiRunIdFilter).toBeInstanceOf(FindOperator);
+    expect(
+      (aiRunIdFilter as RawFindOperatorInternals)._getSql("COLUMN"),
+    ).toContain("COLUMN IS NULL");
+  });
+
+  it("can scope the RootCause item to feed rows created by this run", async () => {
+    const runCompletedAt: Date = new Date("2026-08-07T10:00:00.000Z");
+    const find: jest.SpyInstance = jest
+      .spyOn(IncidentFeedService, "findOneBy")
+      .mockResolvedValue(null);
+
+    await PostedRootCause.getForIncident(INCIDENT_ID, {
+      createdAtOrAfter: runCompletedAt,
+    });
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          incidentId: INCIDENT_ID,
+          incidentFeedEventType: IncidentFeedEventType.RootCause,
+          createdAt: expect.any(FindOperator),
+        }),
+      }),
+    );
+    expectCreatedAtCutoff(
+      find.mock.calls[0]![0].query.createdAt,
+      runCompletedAt,
     );
   });
 
@@ -166,6 +254,57 @@ describe("PostedRootCause.getForAlert", () => {
         }),
       }),
     );
+    const query: Record<string, unknown> = find.mock.calls[0]![0]
+      .query as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(query, "createdAt")).toBe(
+      false,
+    );
+    expect(Object.prototype.hasOwnProperty.call(query, "aiRunId")).toBe(false);
+  });
+
+  it("can select the RootCause explicitly owned by one alert investigation", async () => {
+    const find: jest.SpyInstance = jest
+      .spyOn(AlertFeedService, "findOneBy")
+      .mockResolvedValue(null);
+
+    await PostedRootCause.getForAlert(ALERT_ID, {
+      aiRunId: AI_RUN_ID,
+    });
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          alertId: ALERT_ID,
+          alertFeedEventType: AlertFeedEventType.RootCause,
+          aiRunId: AI_RUN_ID,
+        }),
+      }),
+    );
+  });
+
+  it("can scope the RootCause item to alert feed rows created by this run", async () => {
+    const runCompletedAt: Date = new Date("2026-08-07T11:00:00.000Z");
+    const find: jest.SpyInstance = jest
+      .spyOn(AlertFeedService, "findOneBy")
+      .mockResolvedValue(null);
+
+    await PostedRootCause.getForAlert(ALERT_ID, {
+      createdAtOrAfter: runCompletedAt,
+    });
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          alertId: ALERT_ID,
+          alertFeedEventType: AlertFeedEventType.RootCause,
+          createdAt: expect.any(FindOperator),
+        }),
+      }),
+    );
+    expectCreatedAtCutoff(
+      find.mock.calls[0]![0].query.createdAt,
+      runCompletedAt,
+    );
   });
 
   it("returns null when no analysis has been posted", async () => {
@@ -194,6 +333,43 @@ describe("PostedRootCause.getForSubject", () => {
     ).toBe("incident cause");
     expect(incidentFind).toHaveBeenCalledTimes(1);
     expect(alertFind).not.toHaveBeenCalled();
+  });
+
+  it("forwards the run boundary to the subject-specific reader", async () => {
+    const runCompletedAt: Date = new Date("2026-08-07T12:00:00.000Z");
+    const getForIncident: jest.SpyInstance = jest
+      .spyOn(PostedRootCause, "getForIncident")
+      .mockResolvedValue("current analysis");
+
+    expect(
+      await PostedRootCause.getForSubject({
+        incidentId: INCIDENT_ID,
+        createdAtOrAfter: runCompletedAt,
+      }),
+    ).toBe("current analysis");
+    expect(getForIncident).toHaveBeenCalledWith(INCIDENT_ID, {
+      aiRunId: undefined,
+      withoutAIRunId: undefined,
+      createdAtOrAfter: runCompletedAt,
+    });
+  });
+
+  it("forwards the exact run id to the subject-specific reader", async () => {
+    const getForAlert: jest.SpyInstance = jest
+      .spyOn(PostedRootCause, "getForAlert")
+      .mockResolvedValue("current alert analysis");
+
+    expect(
+      await PostedRootCause.getForSubject({
+        alertId: ALERT_ID,
+        aiRunId: AI_RUN_ID,
+      }),
+    ).toBe("current alert analysis");
+    expect(getForAlert).toHaveBeenCalledWith(ALERT_ID, {
+      aiRunId: AI_RUN_ID,
+      withoutAIRunId: undefined,
+      createdAtOrAfter: undefined,
+    });
   });
 
   it("reads the alert feed for an alert subject", async () => {
@@ -250,5 +426,83 @@ describe("PostedRootCause.getForSubject", () => {
     expect(await PostedRootCause.getForSubject({})).toBeNull();
     expect(incidentFind).not.toHaveBeenCalled();
     expect(alertFind).not.toHaveBeenCalled();
+  });
+});
+
+describe("PostedRootCause.getForInvestigation", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns the exact run-associated report without a legacy lookup", async () => {
+    const getForSubject: jest.SpyInstance = jest
+      .spyOn(PostedRootCause, "getForSubject")
+      .mockResolvedValue("exact report");
+
+    expect(
+      await PostedRootCause.getForInvestigation({
+        incidentId: INCIDENT_ID,
+        aiRunId: AI_RUN_ID,
+      }),
+    ).toBe("exact report");
+    expect(getForSubject).toHaveBeenCalledTimes(1);
+    expect(getForSubject).toHaveBeenCalledWith({
+      incidentId: INCIDENT_ID,
+      alertId: undefined,
+      aiRunId: AI_RUN_ID,
+    });
+  });
+
+  it("recovers a branded null-associated report across a deployment-safe upgrade window", async () => {
+    const runCompletedAt: Date = new Date("2026-08-08T10:00:00.000Z");
+    const legacyReport: string =
+      "## AI — Automated Root Cause Analysis\n\nHistorical evidence.";
+    const getForSubject: jest.SpyInstance = jest
+      .spyOn(PostedRootCause, "getForSubject")
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(legacyReport);
+
+    expect(
+      await PostedRootCause.getForInvestigation({
+        alertId: ALERT_ID,
+        aiRunId: AI_RUN_ID,
+        runCompletedAt,
+      }),
+    ).toBe(legacyReport);
+    expect(getForSubject).toHaveBeenNthCalledWith(2, {
+      incidentId: undefined,
+      alertId: ALERT_ID,
+      withoutAIRunId: true,
+      createdAtOrAfter: runCompletedAt,
+    });
+  });
+
+  it("rejects ordinary RootCause markdown from the legacy path", async () => {
+    jest
+      .spyOn(PostedRootCause, "getForSubject")
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce("## Root cause\n\nWritten by an engineer.");
+
+    expect(
+      await PostedRootCause.getForInvestigation({
+        incidentId: INCIDENT_ID,
+        aiRunId: AI_RUN_ID,
+        runCompletedAt: new Date("2026-08-08T10:00:00.000Z"),
+      }),
+    ).toBeNull();
+  });
+
+  it("never falls back to an unassociated row without a reliable completion boundary", async () => {
+    const getForSubject: jest.SpyInstance = jest
+      .spyOn(PostedRootCause, "getForSubject")
+      .mockResolvedValue(null);
+
+    expect(
+      await PostedRootCause.getForInvestigation({
+        incidentId: INCIDENT_ID,
+        aiRunId: AI_RUN_ID,
+      }),
+    ).toBeNull();
+    expect(getForSubject).toHaveBeenCalledTimes(1);
   });
 });

--- a/Common/Tests/UI/Components/FeedItemSafeMode.test.tsx
+++ b/Common/Tests/UI/Components/FeedItemSafeMode.test.tsx
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+const markdownViewerMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Components/Markdown.tsx/MarkdownViewer", () => {
+  return {
+    __esModule: true,
+    default: (props: MarkdownViewerProps): React.ReactElement => {
+      markdownViewerMock(props);
+      return React.createElement("div", {}, props.text);
+    },
+  };
+});
+
+jest.mock("../../../UI/Components/Modal/ConfirmModal", () => {
+  return {
+    __esModule: true,
+    default: (props: ConfirmModalProps): React.ReactElement => {
+      return React.createElement("div", { role: "dialog" }, props.description);
+    },
+  };
+});
+
+import FeedItem from "../../../UI/Components/Feed/FeedItem";
+import { Blue500 } from "../../../Types/BrandColors";
+import IconProp from "../../../Types/Icon/IconProp";
+
+interface MarkdownViewerProps {
+  text: string;
+  safeMode?: boolean | undefined;
+}
+
+interface ConfirmModalProps {
+  description: React.ReactElement;
+}
+
+afterEach(() => {
+  cleanup();
+  markdownViewerMock.mockReset();
+});
+
+describe("FeedItem safe markdown", () => {
+  test("applies safe mode to both the feed body and More Information modal", () => {
+    render(
+      <FeedItem
+        key="ai-root-cause"
+        textInMarkdown="[Primary link](https://example.com/primary)"
+        moreTextInMarkdown="![Secondary image](https://example.com/image.png)"
+        itemDateTime={new Date("2026-08-07T12:00:00.000Z")}
+        icon={IconProp.Sparkles}
+        color={Blue500}
+        safeMode={true}
+        isLastItem={true}
+      />,
+    );
+
+    expect(markdownViewerMock).toHaveBeenCalledWith({
+      text: "[Primary link](https://example.com/primary)",
+      safeMode: true,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "More Information" }));
+
+    expect(screen.getByRole("dialog")).toBeVisible();
+    expect(markdownViewerMock).toHaveBeenCalledWith({
+      text: "![Secondary image](https://example.com/image.png)",
+      safeMode: true,
+    });
+  });
+});

--- a/Common/Types/AI/CodeFixTaskContext.ts
+++ b/Common/Types/AI/CodeFixTaskContext.ts
@@ -75,6 +75,18 @@ export interface PerformanceCodeLocation {
 }
 
 export interface CodeFixTaskContext {
+  /*
+   * FixFromIncident: the exact investigation whose published RootCause is
+   * the task's context. This prevents a later re-investigation from changing
+   * the report between the user's click and the worker claiming the task.
+   */
+  sourceInvestigationRunId?: string | undefined;
+  /*
+   * Snapshot of that run's published analysis. Fix tasks can wait in the
+   * queue, so reading the feed again when the worker claims the task would
+   * let a later re-investigation silently change the requested fix.
+   */
+  sourceInvestigationAnalysisMarkdown?: string | undefined;
   // FixPerformance: the analyzed trace.
   traceId?: string | undefined;
   // Best-effort service attribution resolved from the trace's spans.

--- a/Common/UI/Components/Feed/FeedItem.tsx
+++ b/Common/UI/Components/Feed/FeedItem.tsx
@@ -24,6 +24,7 @@ export interface FeedItemProps {
   itemDateTime: Date;
   icon: IconProp;
   color: Color;
+  safeMode?: boolean | undefined;
 }
 
 export interface ComponentProps extends FeedItemProps {
@@ -43,7 +44,10 @@ const FeedItem: FunctionComponent<ComponentProps> = (
           title={`More Information`}
           description={
             <div>
-              <MarkdownViewer text={props.moreTextInMarkdown || ""} />
+              <MarkdownViewer
+                text={props.moreTextInMarkdown || ""}
+                safeMode={props.safeMode === true}
+              />
             </div>
           }
           isLoading={false}
@@ -123,7 +127,10 @@ const FeedItem: FunctionComponent<ComponentProps> = (
               <div className="mt-2 text-sm text-gray-700">
                 {props.textInMarkdown && (
                   <div>
-                    <MarkdownViewer text={props.textInMarkdown} />
+                    <MarkdownViewer
+                      text={props.textInMarkdown}
+                      safeMode={props.safeMode === true}
+                    />
                   </div>
                 )}
                 {props.element && <div>{props.element}</div>}


### PR DESCRIPTION
## Summary

- show the completed, cited AI investigation report directly in incident and alert views, with the execution activity collapsed and no misleading live indicator
- refresh incident and alert feeds when a report is published, render AI-authored root causes safely, and prevent stale or cross-subject feed responses
- associate each root-cause feed entry with its exact investigation run so verdicts, fix tasks, grading, and worker context cannot drift to a newer report
- harden finalization polling, retry ownership, stale-run settlement, and confidence-classification timeouts

## Verification

- `npm run fix` from the repository root
- Common and App/Workers TypeScript compiles
- Dashboard compile reaches an existing `master` error in unchanged `LogsViewer.tsx:1821` (`TelemetrySavedViewTimeRange` → `JSONObject`); the file is byte-identical to `origin/master`
- 20 focused Jest suites: 291 tests passed, including the merged investigation-header status/wiring coverage
- Postgres schema drift check: no drift
- Playwright visual QA of the completed investigation card and incident/alert feed presentation

## Database

- generated and registered a Postgres migration adding nullable `aiRunId` columns and subject/run indexes to incident and alert feed rows