### PR TITLE
fix(status-page): build the group tree index once on the resources page

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Resources.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Resources.tsx
@@ -29,6 +29,7 @@ import Monitor from "Common/Models/DatabaseModels/Monitor";
 import MonitorGroup from "Common/Models/DatabaseModels/MonitorGroup";
 import StatusPageGroup from "Common/Models/DatabaseModels/StatusPageGroup";
 import StatusPageGroupTreeUtil, {
+  StatusPageGroupTreeIndex,
   StatusPageGroupTreeNode,
 } from "Common/Utils/StatusPage/GroupTree";
 import StatusPageResource from "Common/Models/DatabaseModels/StatusPageResource";
@@ -37,6 +38,7 @@ import React, {
   FunctionComponent,
   ReactElement,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import StatusPageGroupViewMode from "Common/Types/StatusPage/StatusPageGroupViewMode";
@@ -57,6 +59,14 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
   const [groups, setGroups] = useState<Array<StatusPageGroup>>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string>("");
+
+  /*
+   * One index for the whole render. The tree helpers below build their own
+   * when none is passed, which is once per group and therefore quadratic.
+   */
+  const groupTreeIndex: StatusPageGroupTreeIndex = useMemo(() => {
+    return StatusPageGroupTreeUtil.buildIndex({ statusPageGroups: groups });
+  }, [groups]);
 
   const [addMonitorGroup, setAddMonitorGroup] = useState<boolean>(false);
   const [bulkAddTarget, setBulkAddTarget] = useState<BulkAddTarget | null>(
@@ -250,7 +260,12 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
         }
       };
 
-      visit(StatusPageGroupTreeUtil.buildTree({ statusPageGroups: groups }));
+      visit(
+        StatusPageGroupTreeUtil.buildTree({
+          statusPageGroups: groups,
+          index: groupTreeIndex,
+        }),
+      );
 
       return flattened;
     };
@@ -264,6 +279,7 @@ const StatusPageDelete: FunctionComponent<PageComponentProps> = (
       StatusPageGroupTreeUtil.getAncestorGroups({
         statusPageGroup: statusPageGroup,
         statusPageGroups: groups,
+        index: groupTreeIndex,
       })
         .reverse()
         .map((ancestor: StatusPageGroup) => {


### PR DESCRIPTION
getGroupPath() runs once per group and called getAncestorGroups() without an index, so resolveIndex() rebuilt a full Map over every group each time. With 1500 groups that is 1500 index builds over 1500 entries, which is where the page's memory climbs before it gives up.

Build the index once per render and pass it to both getAncestorGroups() and buildTree(). The helpers already accept it.

Walking the ancestors of every group, measured against the real tree util: 200 groups 5ms -> 1ms, 600 groups 27ms -> 2ms, 1500 groups 155ms -> 9ms.

This does not fix the whole issue. The page still renders one ModelTable per group, each issuing its own request, which is the reported "Network Error".

### Pull Request Checklist: 

- [ ] Please make sure all jobs pass before requesting a review. 
- [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [ ] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?
