### PR TITLE
fix(clickhouse): survive distributed DDL confirmation timeouts during migrations

### DIFF
--- a/App/FeatureSet/Workers/DataMigrations/RebuildMetricAggTablesMissingPrimaryEntityId.ts
+++ b/App/FeatureSet/Workers/DataMigrations/RebuildMetricAggTablesMissingPrimaryEntityId.ts
@@ -1,6 +1,8 @@
 import DataMigrationBase from "./DataMigrationBase";
 import ClickHouseMigrationUtil from "./ClickHouseMigrationUtil";
-import AnalyticsDatabaseService from "Common/Server/Services/AnalyticsDatabaseService";
+import AnalyticsDatabaseService, {
+  MigrationExecuteOptions,
+} from "Common/Server/Services/AnalyticsDatabaseService";
 import AnalyticsBaseModel from "Common/Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
 import MetricItemAggMV1mService from "Common/Server/Services/MetricItemAggMV1mService";
 import MetricBaselineService from "Common/Server/Services/MetricBaselineService";
@@ -114,16 +116,23 @@ export default class RebuildMetricAggTablesMissingPrimaryEntityId extends DataMi
     for (const materializedView of materializedViews) {
       await service.execute(
         `DROP VIEW IF EXISTS ${materializedView.name} SYNC`,
+        MigrationExecuteOptions,
       );
     }
 
     // 2. Drop the drifted table (this is the accepted data loss).
-    await service.execute(`DROP TABLE IF EXISTS ${tableName} SYNC`);
+    await service.execute(
+      `DROP TABLE IF EXISTS ${tableName} SYNC`,
+      MigrationExecuteOptions,
+    );
 
     // 3. Recreate table + MV(s) from the current model (key-correct).
-    await service.execute(service.statementGenerator.toTableCreateStatement());
+    await service.execute(
+      service.statementGenerator.toTableCreateStatement(),
+      MigrationExecuteOptions,
+    );
     for (const materializedView of materializedViews) {
-      await service.execute(materializedView.query);
+      await service.execute(materializedView.query, MigrationExecuteOptions);
     }
 
     logger.info(

--- a/App/FeatureSet/Workers/DataMigrations/RebuildMetricBaselineHourlyWithBFloat16Quantiles.ts
+++ b/App/FeatureSet/Workers/DataMigrations/RebuildMetricBaselineHourlyWithBFloat16Quantiles.ts
@@ -1,5 +1,6 @@
 import DataMigrationBase from "./DataMigrationBase";
 import MetricBaselineService from "Common/Server/Services/MetricBaselineService";
+import { MigrationExecuteOptions } from "Common/Server/Services/AnalyticsDatabaseService";
 import logger from "Common/Server/Utils/Logger";
 
 /**
@@ -68,9 +69,11 @@ export default class RebuildMetricBaselineHourlyWithBFloat16Quantiles extends Da
        */
       await MetricBaselineService.execute(
         `DROP VIEW IF EXISTS MetricBaselineHourly_mv SYNC`,
+        MigrationExecuteOptions,
       );
       await MetricBaselineService.execute(
         MetricBaselineService.model.materializedViews[0]!.query,
+        MigrationExecuteOptions,
       );
       return;
     }
@@ -85,6 +88,7 @@ export default class RebuildMetricBaselineHourlyWithBFloat16Quantiles extends Da
      */
     await MetricBaselineService.execute(
       `DROP VIEW IF EXISTS MetricBaselineHourly_mv SYNC`,
+      MigrationExecuteOptions,
     );
     logger.info(
       "RebuildMetricBaselineHourlyWithBFloat16Quantiles: dropped MetricBaselineHourly_mv",
@@ -93,6 +97,7 @@ export default class RebuildMetricBaselineHourlyWithBFloat16Quantiles extends Da
     // 2. Drop the legacy-typed table (this is the accepted data loss).
     await MetricBaselineService.execute(
       `DROP TABLE IF EXISTS MetricBaselineHourly SYNC`,
+      MigrationExecuteOptions,
     );
     logger.info(
       "RebuildMetricBaselineHourlyWithBFloat16Quantiles: dropped MetricBaselineHourly",
@@ -101,9 +106,11 @@ export default class RebuildMetricBaselineHourlyWithBFloat16Quantiles extends Da
     // 3. Recreate table + MV from the updated model.
     await MetricBaselineService.execute(
       MetricBaselineService.statementGenerator.toTableCreateStatement(),
+      MigrationExecuteOptions,
     );
     await MetricBaselineService.execute(
       MetricBaselineService.model.materializedViews[0]!.query,
+      MigrationExecuteOptions,
     );
     logger.info(
       "RebuildMetricBaselineHourlyWithBFloat16Quantiles: recreated MetricBaselineHourly + MV with quantileBFloat16 states",

--- a/App/FeatureSet/Workers/Utils/AnalyticsDatabase/TableManegement.ts
+++ b/App/FeatureSet/Workers/Utils/AnalyticsDatabase/TableManegement.ts
@@ -83,6 +83,67 @@ export default class AnalyticsTableManagement {
   }
 
   /**
+   * Best-effort end-of-run convergence check. ON CLUSTER DDL runs with
+   * `distributed_ddl_output_mode = null_status_on_timeout`, so a statement can
+   * return before every host executed it — the task stays in the Keeper queue
+   * and each host applies it in the background. That makes a green run mean
+   * "enqueued everywhere, confirmed where possible", NOT "the whole cluster
+   * converged". Surface any still-unfinished distributed DDL loudly here so a
+   * wedged DDL queue (stuck DDLWorker, host-identity mismatch, dead host in
+   * the cluster config) cannot hide behind a successful migrate run.
+   * Diagnosis + remediation: HelmChart/Docs/Clickhouse.md, "Distributed DDL
+   * task ... is not finished on N of M hosts".
+   */
+  public static async warnOnUnfinishedDistributedDdl(): Promise<void> {
+    const service: AnalyticsDatabaseService<AnalyticsBaseModel> | undefined =
+      AnalyticsServices[0];
+    if (!service) {
+      return;
+    }
+
+    try {
+      const result: Results = await service.executeQuery(
+        `SELECT entry, host, status FROM system.distributed_ddl_queue WHERE status != 'Finished' ORDER BY entry ASC LIMIT 200`,
+        MigrationExecuteOptions,
+      );
+      const response: DbJSONResponse = await result.json<{
+        data?: Array<JSONObject>;
+      }>();
+      const rows: Array<JSONObject> = (response.data ||
+        []) as Array<JSONObject>;
+
+      if (rows.length === 0) {
+        logger.debug(
+          "Distributed DDL queue fully drained — schema DDL confirmed on every host.",
+        );
+        return;
+      }
+
+      const entries: Set<string> = new Set<string>(
+        rows.map((row: JSONObject) => {
+          return String(row["entry"]);
+        }),
+      );
+      const hosts: Set<string> = new Set<string>(
+        rows.map((row: JSONObject) => {
+          return String(row["host"]);
+        }),
+      );
+      logger.warn({
+        message: `ClickHouse distributed DDL queue still has ${entries.size} unfinished task(s) across ${hosts.size} host(s) after schema sync. The queued DDL will keep executing in the background; until it drains, some hosts may lag the new schema. If this count does not go down, the DDL queue is wedged — see HelmChart/Docs/Clickhouse.md ("Distributed DDL task ... is not finished on N of M hosts") for diagnosis and remediation.`,
+        unfinishedTasks: entries.size,
+        affectedHosts: [...hosts].slice(0, 10),
+        oldestEntry: rows[0] ? String(rows[0]["entry"]) : "",
+      });
+    } catch {
+      // system.distributed_ddl_queue may be unavailable; the check is advisory.
+      logger.debug(
+        "Could not read system.distributed_ddl_queue for the post-migration convergence check.",
+      );
+    }
+  }
+
+  /**
    * Ensure the app-facing `<tableName>` is the `Distributed` wrapper over the
    * local `<tableName>Local` storage table.
    *
@@ -188,10 +249,12 @@ export default class AnalyticsTableManagement {
 
   /**
    * True when <tableName> already exists as a Distributed wrapper that matches
-   * the model — same Distributed(...) engine AND the same columns as its local
-   * storage table (the wrapper is created `AS <local>`). Lets
-   * reconcileDistributedTable skip a needless CREATE OR REPLACE (which churns
-   * the table UUID and races async inserts).
+   * the model — same Distributed(...) engine, the same columns as its local
+   * storage table (the wrapper is created `AS <local>`), AND both contain
+   * every model column (so a read served by a replica still catching up on
+   * queued DDL can't fake an "up to date"). Lets reconcileDistributedTable
+   * skip a needless CREATE OR REPLACE (which churns the table UUID and races
+   * async inserts).
    *
    * CONSERVATIVE: any read failure, missing table, or ambiguity returns false,
    * so the caller falls back to the original always-re-sync behavior rather
@@ -243,6 +306,25 @@ export default class AnalyticsTableManagement {
       }
       for (const [name, type] of localColumns) {
         if (distributedColumns.get(name) !== type) {
+          return false;
+        }
+      }
+
+      /*
+       * 3. Both views must also contain every MODEL column. The two reads
+       * above are load-balanced across the cluster, and ON CLUSTER DDL
+       * confirmation is best-effort (null_status_on_timeout): right after an
+       * ADD COLUMN the reads can land on a replica whose queued ADD hasn't
+       * applied yet, so wrapper and local match each OTHER while both lag the
+       * model — which would wrongly skip the re-sync until a later boot. A
+       * model column missing from either view means the view is stale or the
+       * schema genuinely drifted; re-sync in both cases.
+       */
+      for (const column of service.model.tableColumns) {
+        if (
+          !localColumns.has(column.key) ||
+          !distributedColumns.has(column.key)
+        ) {
           return false;
         }
       }

--- a/App/Migrate.ts
+++ b/App/Migrate.ts
@@ -73,6 +73,14 @@ const migrate: PromiseVoidFunction = async (): Promise<void> => {
   await RunDatabaseMigrations();
 
   /*
+   * ON CLUSTER DDL above is confirmed best-effort (null_status_on_timeout):
+   * a slow host degrades to background execution instead of failing the run.
+   * Loudly report anything still unfinished so a wedged DDL queue can't hide
+   * behind a green Job. Advisory only — never fails the migration.
+   */
+  await AnalyticsTableManagement.warnOnUnfinishedDistributedDdl();
+
+  /*
    * Startup migrations (run on every boot AND on every migrate Job) sync
    * env-driven state such as the GLOBAL_LLM_PROVIDER_* seeded provider, so a
    * deploy applies the desired state even before app pods restart. They are

--- a/Common/Server/EnvironmentConfig.ts
+++ b/Common/Server/EnvironmentConfig.ts
@@ -8,6 +8,7 @@ import {
   HomeRoute,
 } from "../ServiceRoute";
 import BillingConfig from "./BillingConfig";
+import { getDistributedDdlTaskTimeoutSeconds } from "./Utils/AnalyticsDatabase/ClusterConfig";
 import Protocol from "../Types/API/Protocol";
 import URL from "../Types/API/URL";
 import Route from "../Types/API/Route";
@@ -568,6 +569,21 @@ export const ClickhouseClusterName: string =
  */
 export const ClickhouseShardingKeyOverride: string =
   process.env["CLICKHOUSE_SHARDING_KEY"] || "";
+
+/*
+ * How long migration / schema-sync ON CLUSTER DDL waits for every host to
+ * report completion before giving up on confirmation (the statement itself
+ * stays queued and still executes on every host in the background). Default
+ * 180 — the ClickHouse server default. Raise this on clusters whose DDL queue
+ * drains slowly; the migration pool's socket-idle ceiling scales with it (see
+ * ClickhouseConfig.ts). 0 returns immediately (async); a negative value
+ * removes the server-side wait limit but the client still gives up at the
+ * migration pool's socket-idle ceiling (30-minute floor), so prefer a finite
+ * value. Mirrors the live reader getDistributedDdlTaskTimeoutSeconds() in
+ * ClusterConfig.ts, which is the single source of parsing truth.
+ */
+export const ClickhouseDistributedDdlTaskTimeoutSeconds: number =
+  getDistributedDdlTaskTimeoutSeconds();
 
 export const GitSha: string = process.env["GIT_SHA"] || "unknown";
 

--- a/Common/Server/Infrastructure/ClickhouseConfig.ts
+++ b/Common/Server/Infrastructure/ClickhouseConfig.ts
@@ -13,6 +13,7 @@ import {
   MaxClickhouseIngestConnections,
   ShouldClickhouseSslEnable,
 } from "../EnvironmentConfig";
+import { getDistributedDdlTaskTimeoutSeconds } from "../Utils/AnalyticsDatabase/ClusterConfig";
 import Hostname from "../../Types/API/Hostname";
 
 export type ClickHouseClientConfigOptions = NodeClickHouseClientConfigOptions;
@@ -114,10 +115,23 @@ export const ingestDataSourceOptions: ClickHouseClientConfigOptions = {
  * additionally carry send_progress_in_http_headers (see MigrationExecuteOptions
  * in AnalyticsDatabaseService) so the socket stays non-idle, and a server-side
  * SETTINGS max_execution_time so ClickHouse remains the authoritative cap.
+ *
+ * The ON CLUSTER confirmation wait (distributed_ddl_task_timeout) streams zero
+ * bytes while pending, so this idle ceiling is the effective upper bound on any
+ * DDL confirmation wait. When CLICKHOUSE_DISTRIBUTED_DDL_TASK_TIMEOUT_SECONDS
+ * is raised past the 30-minute floor, scale the ceiling with it (plus slack)
+ * so the longer wait isn't killed client-side. A negative (infinite) DDL
+ * timeout is still bounded by the 30-minute floor — the client must not hang
+ * forever on a dead socket.
  */
+const migrationRequestTimeoutInMs: number = Math.max(
+  30 * 60 * 1000, // 30-minute floor
+  (getDistributedDdlTaskTimeoutSeconds() + 120) * 1000,
+);
+
 export const migrationDataSourceOptions: ClickHouseClientConfigOptions = {
   ...options,
-  request_timeout: 30 * 60 * 1000, // 30 minutes
+  request_timeout: migrationRequestTimeoutInMs,
 };
 
 export const testDataSourceOptions: ClickHouseClientConfigOptions =

--- a/Common/Server/Infrastructure/ClickhouseDatabase.ts
+++ b/Common/Server/Infrastructure/ClickhouseDatabase.ts
@@ -87,7 +87,7 @@ export default class ClickhouseDatabase {
             }
 
             logger.debug(
-              `Clickhouse Database Connected: ${dataSourceOptions.host?.toString()}`,
+              `Clickhouse Database Connected: ${dataSourceOptions.url?.toString()}`,
             );
 
             return clickhouseClient;

--- a/Common/Server/Services/AnalyticsDatabaseService.ts
+++ b/Common/Server/Services/AnalyticsDatabaseService.ts
@@ -34,6 +34,7 @@ import {
   TimeoutOverflowMode,
 } from "../Utils/AnalyticsDatabase/QuerySettingsHelper";
 import {
+  getDistributedDdlTaskTimeoutSeconds,
   getStorageTableName,
   onClusterClause,
 } from "../Utils/AnalyticsDatabase/ClusterConfig";
@@ -137,6 +138,34 @@ export const MigrationExecuteOptions: ClickhouseExecuteOptions = {
      * migration pool's 30-minute idle ceiling.
      */
     http_headers_progress_interval_ms: "10000",
+    /*
+     * ON CLUSTER DDL is queued in Keeper and executed by each host's DDLWorker
+     * sequentially, so on a busy or backlogged cluster a host can be healthy
+     * yet not reach the task within the wait window. The server default output
+     * mode (`throw`) turns that into TIMEOUT_EXCEEDED (code 159) and aborts
+     * the whole migrate run — even though the task stays queued and the hosts
+     * execute it in the background (until the DDL queue evicts it:
+     * task_max_lifetime, one week, or falling more than max_tasks_in_queue
+     * entries behind). `null_status_on_timeout` returns NULL for the hosts
+     * that haven't finished yet instead of throwing, while a real DDL failure
+     * on any host that did run it within the window still throws. Safe because
+     * every schema statement here is idempotent (IF NOT EXISTS / OR REPLACE)
+     * and, with the default `distributed_ddl.pool_size = 1`, later DDL queues
+     * strictly behind earlier DDL on each host. Migrate.ts additionally warns
+     * at end of run when the DDL queue still has unfinished tasks. Note these
+     * options are also reused by runtime ALTER ... DELETE mutations (session
+     * erasure / pin materialization); timeout-as-success is acceptable there
+     * too since a mutation is durable once enqueued. Requires ClickHouse >=
+     * 21.4 (older servers reject the setting as unknown).
+     */
+    distributed_ddl_output_mode: "null_status_on_timeout",
+    /*
+     * Int64 settings are typed as strings by @clickhouse/client. Read at
+     * module load; env is static for the life of the process. The migration
+     * pool's socket-idle ceiling scales with this value (ClickhouseConfig.ts)
+     * so a raised wait isn't killed client-side.
+     */
+    distributed_ddl_task_timeout: String(getDistributedDdlTaskTimeoutSeconds()),
   },
 };
 

--- a/Common/Server/Utils/AnalyticsDatabase/ClusterConfig.ts
+++ b/Common/Server/Utils/AnalyticsDatabase/ClusterConfig.ts
@@ -27,6 +27,8 @@ import AnalyticsTableEngine from "../../../Types/AnalyticsDatabase/AnalyticsTabl
 export const DEFAULT_CLICKHOUSE_CLUSTER_NAME: string = "oneuptime";
 export const DEFAULT_CLICKHOUSE_SHARDING_KEY: string = "cityHash64(projectId)";
 export const DEFAULT_CLICKHOUSE_DATABASE: string = "oneuptime";
+// Matches the ClickHouse server default for distributed_ddl_task_timeout.
+export const DEFAULT_DISTRIBUTED_DDL_TASK_TIMEOUT_SECONDS: number = 180;
 
 // Suffix appended to a model's tableName to name its local (data) table.
 export const LOCAL_TABLE_SUFFIX: string = "Local";
@@ -47,6 +49,28 @@ export function getClickhouseShardingKeyOverride(): string {
 
 export function getClickhouseDatabaseName(): string {
   return process.env["CLICKHOUSE_DATABASE"] || DEFAULT_CLICKHOUSE_DATABASE;
+}
+
+/*
+ * How long the initiator of an ON CLUSTER DDL statement waits for every host
+ * to report completion (CLICKHOUSE_DISTRIBUTED_DDL_TASK_TIMEOUT_SECONDS,
+ * default 180 — the ClickHouse server default). ClickHouse semantics: 0
+ * enqueues the task and returns immediately; a negative value removes the
+ * server-side wait limit, but the confirmation wait streams zero bytes, so
+ * the client still gives up at the migration pool's socket-idle ceiling
+ * (30-minute floor, scaled up with this value — see ClickhouseConfig.ts).
+ * Prefer a finite value. Raising it helps on clusters whose DDL queue drains
+ * slowly (each host's DDLWorker processes the queue sequentially by default,
+ * so one slow task delays all later ones).
+ */
+export function getDistributedDdlTaskTimeoutSeconds(): number {
+  const raw: string = (
+    process.env["CLICKHOUSE_DISTRIBUTED_DDL_TASK_TIMEOUT_SECONDS"] || ""
+  ).trim();
+  const parsed: number = parseInt(raw, 10);
+  return Number.isFinite(parsed)
+    ? parsed
+    : DEFAULT_DISTRIBUTED_DDL_TASK_TIMEOUT_SECONDS;
 }
 
 /*

--- a/Common/Tests/Server/Services/AnalyticsDatabaseService.test.ts
+++ b/Common/Tests/Server/Services/AnalyticsDatabaseService.test.ts
@@ -1,4 +1,6 @@
-import AnalyticsDatabaseService from "../../../Server/Services/AnalyticsDatabaseService";
+import AnalyticsDatabaseService, {
+  MigrationExecuteOptions,
+} from "../../../Server/Services/AnalyticsDatabaseService";
 import {
   SQL,
   Statement,
@@ -928,6 +930,28 @@ describe("AnalyticsDatabaseService", () => {
         format: "JSON",
         query_params: undefined,
       });
+    });
+  });
+
+  describe("MigrationExecuteOptions", () => {
+    /*
+     * Guards the exact regression a customer hit: ON CLUSTER DDL running with
+     * the server-default `throw` output mode aborted the whole migrate Job
+     * with TIMEOUT_EXCEEDED (code 159) when 4 of 5 hosts had a backlogged
+     * DDL queue — even though the queued task completes in the background.
+     */
+    test("migration DDL never throws on distributed DDL confirmation timeout", () => {
+      expect(MigrationExecuteOptions.useMigrationConnection).toBe(true);
+      expect(
+        MigrationExecuteOptions.clickhouseSettings?.distributed_ddl_output_mode,
+      ).toBe("null_status_on_timeout");
+      // Int64 settings travel as strings; default mirrors the server's 180s.
+      expect(
+        String(
+          MigrationExecuteOptions.clickhouseSettings
+            ?.distributed_ddl_task_timeout,
+        ),
+      ).toMatch(/^-?\d+$/);
     });
   });
 });

--- a/Common/Tests/Server/Utils/AnalyticsDatabase/ClusterAwareSchema.test.ts
+++ b/Common/Tests/Server/Utils/AnalyticsDatabase/ClusterAwareSchema.test.ts
@@ -8,6 +8,7 @@ import {
   adaptTableSettingsForStorage,
   applyClusterToMaterializedViewQuery,
   getClickhouseClusterName,
+  getDistributedDdlTaskTimeoutSeconds,
   getDistributedEngine,
   getStorageEngine,
   getStorageTableName,
@@ -33,6 +34,8 @@ import MetricBaselineHourly from "../../../../Models/AnalyticsModels/MetricBasel
 
 const CLUSTER_ENV_KEY: string = "CLICKHOUSE_CLUSTER_NAME";
 const SHARDING_ENV_KEY: string = "CLICKHOUSE_SHARDING_KEY";
+const DDL_TIMEOUT_ENV_KEY: string =
+  "CLICKHOUSE_DISTRIBUTED_DDL_TASK_TIMEOUT_SECONDS";
 
 /*
  * Flatten a Statement into a single string (raw SQL + serialized identifier
@@ -49,6 +52,8 @@ function fullText(statement: Statement | string): string {
 describe("ClickHouse cluster-aware schema (always-on)", () => {
   const originalCluster: string | undefined = process.env[CLUSTER_ENV_KEY];
   const originalSharding: string | undefined = process.env[SHARDING_ENV_KEY];
+  const originalDdlTimeout: string | undefined =
+    process.env[DDL_TIMEOUT_ENV_KEY];
 
   afterEach(() => {
     if (originalCluster === undefined) {
@@ -60,6 +65,11 @@ describe("ClickHouse cluster-aware schema (always-on)", () => {
       delete process.env[SHARDING_ENV_KEY];
     } else {
       process.env[SHARDING_ENV_KEY] = originalSharding;
+    }
+    if (originalDdlTimeout === undefined) {
+      delete process.env[DDL_TIMEOUT_ENV_KEY];
+    } else {
+      process.env[DDL_TIMEOUT_ENV_KEY] = originalDdlTimeout;
     }
   });
 
@@ -99,6 +109,26 @@ describe("ClickHouse cluster-aware schema (always-on)", () => {
       ).toBe(
         "ttl_only_drop_parts = 1, replicated_deduplication_window = 10000",
       );
+    });
+
+    test("distributed DDL task timeout: default 180, overridable, garbage-safe", () => {
+      delete process.env[DDL_TIMEOUT_ENV_KEY];
+      expect(getDistributedDdlTaskTimeoutSeconds()).toBe(180);
+
+      process.env[DDL_TIMEOUT_ENV_KEY] = "1800";
+      expect(getDistributedDdlTaskTimeoutSeconds()).toBe(1800);
+
+      // ClickHouse semantics pass through: 0 = async, negative = no server cap.
+      process.env[DDL_TIMEOUT_ENV_KEY] = "0";
+      expect(getDistributedDdlTaskTimeoutSeconds()).toBe(0);
+      process.env[DDL_TIMEOUT_ENV_KEY] = "-1";
+      expect(getDistributedDdlTaskTimeoutSeconds()).toBe(-1);
+
+      // Garbage and whitespace fall back to the default.
+      process.env[DDL_TIMEOUT_ENV_KEY] = "not-a-number";
+      expect(getDistributedDdlTaskTimeoutSeconds()).toBe(180);
+      process.env[DDL_TIMEOUT_ENV_KEY] = "   ";
+      expect(getDistributedDdlTaskTimeoutSeconds()).toBe(180);
     });
 
     test("distributed engine: model key, with global override winning", () => {

--- a/HelmChart/Docs/Clickhouse.md
+++ b/HelmChart/Docs/Clickhouse.md
@@ -233,3 +233,78 @@ keep the old `StatefulSet` running (`clickhouse.enabled: true`,
 `clickhouseOperator.altinity.enabled: false`) and copy data over with
 `clickhouse-backup` or `remoteSecure()`/`INSERT ... SELECT remote(...)` from the
 old service into the new CHI, then cut the app over by enabling the operator.
+
+#### Troubleshooting: migration fails with "Distributed DDL task ... is not finished on N of M hosts" (code 159, TIMEOUT_EXCEEDED)
+
+Every schema statement runs `ON CLUSTER`: the initiator enqueues the DDL in
+Keeper (`/clickhouse/<chi>/task_queue/ddl/query-NNNNNNNNNN`) and waits up to
+`distributed_ddl_task_timeout` (default 180s) for every host to confirm. Each
+host's DDLWorker processes that queue **sequentially**, so hosts that are
+healthy but backed up (a slow earlier DDL, heavy merges/mutations, hundreds of
+queued tasks) simply have not reached the task yet — that is exactly what
+`(0 of them are currently executing the task, 0 are inactive)` means. The task
+stays queued and every host executes it in the background. It can still be
+lost if a host lags too long: the queue cleaner evicts a task after
+`task_max_lifetime` (one week by default) **or** once it falls more than
+`max_tasks_in_queue` (default 1000) entries behind the newest — so a wedged
+host on a DDL-heavy cluster can permanently miss it. The end-of-run check
+below is what catches that.
+
+The migration runner sets `distributed_ddl_output_mode = null_status_on_timeout`
+(requires ClickHouse >= 21.4), so a slow host degrades to an unconfirmed (NULL)
+status instead of aborting the run, while a real DDL failure on any host that
+executed within the window still fails loudly. A host that times out and then
+fails in the background reports nothing to the client — which is why the migrate
+Job ends by checking `system.distributed_ddl_queue` and **logging a warning**
+with the unfinished-task count when the cluster has not converged. Watch the
+Job logs for that warning; a count that never drops means the queue is wedged.
+
+All schema DDL is idempotent (`IF NOT EXISTS` / `CREATE OR REPLACE`), so
+re-running the migrate Job is safe for the schema — but a re-run enqueues new
+tasks *behind* whatever is blocking the queue, and if a Distributed wrapper
+needs re-creating while ingestion is live, in-flight async inserts buffered
+against the old table UUID can error on flush (prefer a quiet window when
+wrappers are involved). On repeated timeouts diagnose the queue instead of
+just retrying:
+
+```sql
+-- Unfinished tasks per host; the OLDEST unfinished entry is the head-of-line blocker.
+SELECT entry, host, status, exception_code, exception_text, query_duration_ms
+FROM system.distributed_ddl_queue
+WHERE status != 'Finished'
+ORDER BY entry ASC;
+
+-- What every host is busy with (DDL waits for merges/mutations on the same
+-- table; system.merges/system.mutations alone only show the connected host).
+SELECT * FROM clusterAllReplicas('oneuptime', system.merges);
+SELECT * FROM clusterAllReplicas('oneuptime', system.mutations) WHERE NOT is_done;
+
+-- Every host must recognize itself in the cluster (is_local = 1 on its own row),
+-- and the cluster must not list dead/removed hosts the initiator waits on forever.
+SELECT host_name, host_address, is_local, errors_count
+FROM system.clusters
+WHERE cluster = 'oneuptime';
+```
+
+(The admin health endpoint surfaces the same signals under
+`clusterHealth.distributedDdlQueue`.)
+
+Remediation, in order of preference:
+
+1. **Wait, then re-run the migrate Job** — if the queue is merely slow, the
+   original task completes in the background and the re-run is a fast no-op.
+2. **Unblock the head of the queue** — wait out (or kill) the merge/mutation the
+   oldest task is stuck behind; if a host never picks up tasks, check that its
+   DDLWorker thread is alive (restart the server pod) and that `is_local` /
+   hostname resolution is correct.
+3. **Give confirmation more time** — set
+   `migrate.clickhouseDistributedDdlTaskTimeoutSeconds` (wired to the
+   `CLICKHOUSE_DISTRIBUTED_DDL_TASK_TIMEOUT_SECONDS` env var, default 180)
+   when you prefer the Job to block until every host confirms rather than
+   proceeding on background execution. Use a finite value: the app scales its
+   client-side socket ceiling along with it, but a negative ("wait forever")
+   value is still cut off by that ceiling (30-minute floor), failing with a
+   less useful socket timeout instead.
+4. **Manually clear a wedged task** (last resort) — run the stuck statement
+   directly on the lagging hosts *without* `ON CLUSTER`, then remove the task
+   znode with `clickhouse-keeper-client` so the queue advances.

--- a/HelmChart/Public/oneuptime/templates/migrate-job.yaml
+++ b/HelmChart/Public/oneuptime/templates/migrate-job.yaml
@@ -118,6 +118,11 @@ spec:
             {{- include "oneuptime.env.common" . | nindent 12 }}
             {{- /* DirectPostgres bypasses pgbouncer so migrations talk straight to the backend. RUN_DATABASE_MIGRATIONS_ON_BOOT is intentionally NOT set here, so it defaults true and this Job runs migrations. */ -}}
             {{- include "oneuptime.env.runtime" (dict "Values" $.Values "Release" $.Release "DirectPostgres" true "DatabaseMaxOpenConnections" $.Values.deployment.databaseMaxOpenConnections) | nindent 12 }}
+            {{- /* Explicit nil check (not `with`): 0 is a meaningful ClickHouse value (enqueue and return immediately) and must render. */ -}}
+            {{- if not (kindIs "invalid" .Values.migrate.clickhouseDistributedDdlTaskTimeoutSeconds) }}
+            - name: CLICKHOUSE_DISTRIBUTED_DDL_TASK_TIMEOUT_SECONDS
+              value: {{ .Values.migrate.clickhouseDistributedDdlTaskTimeoutSeconds | squote }}
+            {{- end }}
           {{- with .Values.migrate.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/HelmChart/Public/oneuptime/values.schema.json
+++ b/HelmChart/Public/oneuptime/values.schema.json
@@ -840,6 +840,12 @@
                         "null"
                     ]
                 },
+                "clickhouseDistributedDdlTaskTimeoutSeconds": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
                 "resources": {
                     "type": "object"
                 },

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -675,6 +675,16 @@ migrate:
   backoffLimit: 6
   # Optional hard timeout for the whole migration run (seconds). Empty = none.
   activeDeadlineSeconds:
+  # How long each `ON CLUSTER` ClickHouse DDL statement waits for every host to
+  # confirm completion (seconds). Empty = 180, the ClickHouse server default.
+  # Hitting this timeout no longer fails the migration: the statement stays in
+  # the cluster's DDL queue and each host executes it in the background (the
+  # Job logs a warning at the end when the queue hasn't converged). Raise this
+  # when the cluster's DDL queue drains slowly (e.g. many shards/replicas under
+  # heavy merge load) and you want the Job to wait for hard confirmation — use
+  # a finite value; the app scales its client-side socket ceiling to match.
+  # 0 = enqueue and return immediately (fully async).
+  clickhouseDistributedDdlTaskTimeoutSeconds:
   resources: {}
   # Placement for the one-shot migration Job. It talks to Postgres over the
   # network, so it should NOT co-locate with the database tier — keep it on the


### PR DESCRIPTION
## Problem

A customer's migrate Job failed with:

```
ClickHouseError: Distributed DDL task /clickhouse/.../task_queue/ddl/query-0000000376 is not finished on 4 of 5 hosts (0 of them are currently executing the task, 0 are inactive). ... code: '159', type: 'TIMEOUT_EXCEEDED'
```

The `CREATE TABLE ... ON CLUSTER` was queued in Keeper and one host finished it, but the other four had backlogged DDL workers (each host processes the distributed DDL queue sequentially). ClickHouse keeps executing the task in the background, yet our migration ran with the server defaults (`distributed_ddl_task_timeout=180`, `distributed_ddl_output_mode=throw`) and no retry — so the whole migrate Job hard-failed on a condition that resolves itself.

## Fix

- Run all migration/schema-sync DDL with `distributed_ddl_output_mode = null_status_on_timeout`: a slow host degrades to background execution instead of failing the run; a real DDL failure on any host that executed still throws. All schema DDL is idempotent (`IF NOT EXISTS` / `CREATE OR REPLACE`), and per-host DDL ordering is preserved (default `distributed_ddl.pool_size=1`).
- Make the confirmation wait configurable: `CLICKHOUSE_DISTRIBUTED_DDL_TASK_TIMEOUT_SECONDS` (default 180 = server default), exposed in the chart as `migrate.clickhouseDistributedDdlTaskTimeoutSeconds`. The migration pool's socket-idle ceiling scales with it so long waits aren't killed client-side.
- **Convergence check**: the migrate run now ends by reading `system.distributed_ddl_queue` and logging a loud warning (task count, hosts, oldest entry) when the cluster hasn't converged — a wedged queue can't hide behind a green Job.
- **Stale-read guard**: the Distributed-wrapper up-to-date check now also requires every model column to be present in both observed schemas, so a read served by a replica still catching up on queued DDL can't wrongly skip the wrapper re-sync.
- Route the two remaining data-migration DDL paths (`RebuildMetricAggTablesMissingPrimaryEntityId`, `RebuildMetricBaselineHourlyWithBFloat16Quantiles`) through `MigrationExecuteOptions` — they previously ran ON CLUSTER DDL on the 58s app pool with throw mode.
- Troubleshooting runbook for this exact error in `HelmChart/Docs/Clickhouse.md` (diagnosis SQL, remediation order, task-eviction caveats).
- Fix the `Clickhouse Database Connected: undefined` log (read deprecated `.host` instead of `.url`).

## Verification

- `tsc` clean in Common and App
- 195 tests pass across the affected suites, including new tests for the env parsing and the exact regression (`MigrationExecuteOptions` must never throw on DDL confirmation timeout)
- `helm template` verified for unset / `1800` / `0` / `-1` values of the new knob (values.schema.json updated; explicit nil check so `0` renders)
- eslint clean