### PR TITLE
fix(compile): unbreak compile-dashboard on the saved-log-view update

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
@@ -1818,6 +1818,13 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
               await ModelAPI.updateById({
                 modelType: LogSavedView,
                 id: selectedSavedView.id,
+                /*
+                 * Every value here is JSON data, but a Query and a
+                 * TelemetrySavedViewTimeRange are declared as interfaces, so
+                 * neither carries the index signature JSONObject requires and
+                 * a direct cast does not compile. Hopping through unknown is
+                 * what the rest of this file does with the same shapes.
+                 */
                 data: JSONFunctions.serialize({
                   query: filterOptions,
                   timeRange: serializeSavedViewTimeRange(timeRange),
@@ -1825,7 +1832,7 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
                   sortField: sortField,
                   sortOrder: sortOrder,
                   pageSize: pageSize,
-                } as JSONObject) as JSONObject,
+                } as unknown as JSONObject) as JSONObject,
               });
 
               await fetchSavedViews();


### PR DESCRIPTION
`compile-dashboard` is the only job still failing in the **Compile** workflow on master. It has been red on every non-cancelled Compile run — the earlier ones were masked because `compile-app` was failing in the same workflow, and everything before that was cancelled by rapid pushes.

## The error

```
src/Components/Logs/LogsViewer.tsx(1821,47): error TS2352: Conversion of type
'{ query: FindWhere<Log>; timeRange: TelemetrySavedViewTimeRange; columns: string[];
  sortField: LogsTableSortField; sortOrder: SortOrder; pageSize: number; }'
to type 'JSONObject' may be a mistake because neither type sufficiently overlaps with the other.
  Property 'timeRange' is incompatible with index signature.
    Index signature for type 'string' is missing in type 'TelemetrySavedViewTimeRange'.
```

## Why

The values really are JSON — they go straight into `LogSavedView`'s JSONB columns, and `TelemetrySavedViewTimeRange` is nothing but `range: string` plus two optional ISO strings. But `Query` and `TelemetrySavedViewTimeRange` are declared as **interfaces**, and an interface carries no implicit index signature, so neither satisfies `JSONObject`'s `{ [key: string]: JSONValue }` and the direct cast is rejected.

## The fix

Hop through `unknown` — what the compiler itself recommends, and what this same file already does with the same shapes when reading a saved view back (lines 927, 946–947). The payload is unchanged; only the cast is.

The sibling Metrics and Traces viewers are unaffected — they build a typed `TelemetrySavedViewState` rather than casting a literal, which is why they compile today.

## Verification

- `npx tsc --noEmit` in `App/FeatureSet/Dashboard`: **1 error → 0**.
- prettier clean, eslint clean.
- For context, on master `b361555` the previous fix landed: **App Test is green**, and Compile's only remaining failure is this job.