### PR TITLE
fix(ci): unbreak Common Test — 29 security tests were never running

### DIFF
--- a/Common/Tests/Server/Services/AddMasterPasswordSaltMigration.test.ts
+++ b/Common/Tests/Server/Services/AddMasterPasswordSaltMigration.test.ts
@@ -246,7 +246,13 @@ describe("AddMasterPasswordSalt1786400000000 - identity and registration", () =>
     expect(migration.name).toBe("AddMasterPasswordSalt1786400000000");
   });
 
-  test("is registered exactly once and is the final migration", () => {
+  /*
+   * Registration is the invariant that matters — an unregistered migration
+   * never runs. Being LAST is not: it was true the day this landed and every
+   * migration added since has appended after it, so pinning it here would
+   * fail the next person's unrelated PR rather than catch a real defect.
+   */
+  test("is registered exactly once", () => {
     const occurrences: number = SchemaMigrations.filter(
       (migration: unknown) => {
         return migration === AddMasterPasswordSalt1786400000000;
@@ -254,9 +260,6 @@ describe("AddMasterPasswordSalt1786400000000 - identity and registration", () =>
     ).length;
 
     expect(occurrences).toBe(1);
-    expect(SchemaMigrations[SchemaMigrations.length - 1]).toBe(
-      AddMasterPasswordSalt1786400000000,
-    );
   });
 
   test("has a timestamp strictly after every previously registered migration", () => {
@@ -264,7 +267,7 @@ describe("AddMasterPasswordSalt1786400000000 - identity and registration", () =>
       AddMasterPasswordSalt1786400000000,
     );
 
-    expect(migrationIndex).toBe(SchemaMigrations.length - 1);
+    expect(migrationIndex).toBeGreaterThan(-1);
 
     for (const earlierMigration of SchemaMigrations.slice(0, migrationIndex)) {
       const earlierTimestamp: number | null = optionalTrailingTimestampFrom(

--- a/Common/Tests/Server/Services/MasterPasswordScrypt.test.ts
+++ b/Common/Tests/Server/Services/MasterPasswordScrypt.test.ts
@@ -15,7 +15,15 @@ import HashedString from "../../../Types/HashedString";
 import { JSONObject } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
 import CryptoJS from "crypto-js";
-import { afterEach, describe, expect, jest, test } from "@jest/globals";
+/*
+ * `jest` is deliberately NOT imported from @jest/globals here. The value from
+ * that package is jest-mock's, whose spyOn returns SpyInstance<Fn>, while the
+ * `jest.SpiedFunction` used to annotate those spies below resolves to the
+ * global @types/jest namespace, where it means SpyInstance<ReturnType<Fn>,
+ * ArgsType<Fn>>. Mixing the two makes every annotated spy a type error. Every
+ * other suite in this tree uses the global jest for exactly this reason.
+ */
+import { afterEach, describe, expect, test } from "@jest/globals";
 
 /*
  * Dashboard and status-page master passwords are human-chosen credentials,
@@ -112,7 +120,18 @@ const setStoredMasterPassword: (
 ): void => {
   resource._id = ObjectID.generate().toString();
   resource.masterPassword = new HashedString(hash, true);
-  resource.masterPasswordSalt = salt;
+
+  /*
+   * Clear rather than assign undefined: exactOptionalPropertyTypes forbids
+   * writing undefined to an optional string, and these resources are shared
+   * across the test.each cases, so a salt left by an earlier case has to
+   * actually go away when this one asks for a legacy, saltless row.
+   */
+  if (salt === undefined) {
+    delete resource.masterPasswordSalt;
+  } else {
+    resource.masterPasswordSalt = salt;
+  }
 };
 
 const makeCurrentResource: (data: {


### PR DESCRIPTION
**Common Test** is red on master (`caeb2df`, run 31208441135). Two suites fail, both introduced by `579346c271` ("fix(identity): harden master password hashing").

## 1. `MasterPasswordScrypt.test.ts` — suite never ran at all

`Test suite failed to run`, 5 type errors, **0 tests executed**. Jest's tally counts a suite that fails to *load* as zero tests rather than as failures, so this reported nothing while covering nothing. Among the tests silently not running:

- `fails closed when a scrypt hash is read without its salt`
- `never upgrades a legacy hash after a wrong password`
- `refuses a bare pre-hashed string that could desynchronise hash and salt`

Two causes:

**a) `jest` imported from `@jest/globals` (4× TS2322).** That makes the *value* `jest.spyOn` jest-mock's, returning `SpyInstance<Fn>`. But the *type* `jest.SpiedFunction<Fn>` annotating those spies resolves to the global `@types/jest` namespace, where `SpiedFunction<T> = SpyInstance<ReturnType<T>, ArgsType<T>>`. Two different `SpyInstance` shapes, four type errors.

Every other suite in this tree (`GitHubGetFileContent.test.ts`, `CodeWriteTools.test.ts`) imports only `describe/expect/test/...` and relies on the global `jest`. This one now matches.

**b) `resource.masterPasswordSalt = salt` with `salt?: string` (TS2412).** `exactOptionalPropertyTypes` forbids writing `undefined` to an optional string.

Now `delete`s the property instead. That is **not** cosmetic — the resources are shared across the `test.each` cases, so the saltless legacy case at line 396 has to actually clear a salt an earlier case left behind. Assigning `undefined` and skipping the assignment are not equivalent here.

## 2. `AddMasterPasswordSaltMigration.test.ts` — a self-breaking assertion

It asserted its migration was the **last** entry in `SchemaMigrations`:

```
Expected: [Function AddMasterPasswordSalt1786400000000]
Received: [Function AddInvestigationCodeFixRecommendation1786500000000]
```

True the day it landed; two migrations have been appended since. This assertion fails on the *next* unrelated migration anyone adds — it catches contributors, not defects. Registration is the invariant worth pinning; being last is not.

The ordering test keeps its real check — every migration registered *before* this one has a smaller timestamp — and no longer demands the index be final.

## Verification

Both suites pass locally: **40 tests**, up from 11 run / 2 failed with 29 never executing.

prettier clean, eslint clean.