### PR TITLE
fix(terraform): mark worker-written notification messages computed

### DIFF
--- a/Common/Models/DatabaseModels/Incident.ts
+++ b/Common/Models/DatabaseModels/Incident.ts
@@ -1715,6 +1715,7 @@ export default class Incident extends BaseModel {
     ],
   })
   @TableColumn({
+    computed: true,
     type: TableColumnType.VeryLongText,
     title: "Notification Status Message",
     description:
@@ -1802,6 +1803,7 @@ export default class Incident extends BaseModel {
     ],
   })
   @TableColumn({
+    computed: true,
     type: TableColumnType.VeryLongText,
     title: "Notification Status Message on Postmortem Published",
     description:

--- a/Common/Models/DatabaseModels/IncidentEpisode.ts
+++ b/Common/Models/DatabaseModels/IncidentEpisode.ts
@@ -1680,6 +1680,7 @@ export default class IncidentEpisode extends BaseModel {
     update: [],
   })
   @TableColumn({
+    computed: true,
     type: TableColumnType.VeryLongText,
     title: "Subscriber Notification Status Message",
     description:

--- a/Common/Models/DatabaseModels/IncidentEpisodePublicNote.ts
+++ b/Common/Models/DatabaseModels/IncidentEpisodePublicNote.ts
@@ -541,6 +541,7 @@ export default class IncidentEpisodePublicNote extends BaseModel {
     ],
   })
   @TableColumn({
+    computed: true,
     type: TableColumnType.VeryLongText,
     title: "Notification Status Message",
     description:

--- a/Common/Models/DatabaseModels/IncidentEpisodeStateTimeline.ts
+++ b/Common/Models/DatabaseModels/IncidentEpisodeStateTimeline.ts
@@ -695,6 +695,7 @@ export default class IncidentEpisodeStateTimeline extends BaseModel {
     update: [],
   })
   @TableColumn({
+    computed: true,
     type: TableColumnType.VeryLongText,
     title: "Subscriber Notification Status Message",
     description:

--- a/Common/Models/DatabaseModels/IncidentPublicNote.ts
+++ b/Common/Models/DatabaseModels/IncidentPublicNote.ts
@@ -544,6 +544,7 @@ export default class IncidentPublicNote extends BaseModel {
     ],
   })
   @TableColumn({
+    computed: true,
     type: TableColumnType.VeryLongText,
     title: "Notification Status Message",
     description:

--- a/Common/Models/DatabaseModels/IncidentStateTimeline.ts
+++ b/Common/Models/DatabaseModels/IncidentStateTimeline.ts
@@ -544,6 +544,7 @@ export default class IncidentStateTimeline extends BaseModel {
     ],
   })
   @TableColumn({
+    computed: true,
     type: TableColumnType.VeryLongText,
     title: "Notification Status Message",
     description:

--- a/Common/Models/DatabaseModels/ScheduledMaintenance.ts
+++ b/Common/Models/DatabaseModels/ScheduledMaintenance.ts
@@ -1426,6 +1426,7 @@ export default class ScheduledMaintenance extends BaseModel {
     ],
   })
   @TableColumn({
+    computed: true,
     type: TableColumnType.VeryLongText,
     title: "Notification Status Message On Event Scheduled",
     description:

--- a/Common/Models/DatabaseModels/ScheduledMaintenancePublicNote.ts
+++ b/Common/Models/DatabaseModels/ScheduledMaintenancePublicNote.ts
@@ -544,6 +544,7 @@ export default class ScheduledMaintenancePublicNote extends BaseModel {
     ],
   })
   @TableColumn({
+    computed: true,
     type: TableColumnType.VeryLongText,
     title: "Notification Status Message",
     description:

--- a/Common/Models/DatabaseModels/ScheduledMaintenanceStateTimeline.ts
+++ b/Common/Models/DatabaseModels/ScheduledMaintenanceStateTimeline.ts
@@ -541,6 +541,7 @@ export default class ScheduledMaintenanceStateTimeline extends BaseModel {
     ],
   })
   @TableColumn({
+    computed: true,
     type: TableColumnType.VeryLongText,
     title: "Notification Status Message",
     description:

--- a/Common/Models/DatabaseModels/StatusPageAnnouncement.ts
+++ b/Common/Models/DatabaseModels/StatusPageAnnouncement.ts
@@ -713,6 +713,7 @@ export default class StatusPageAnnouncement extends BaseModel {
     ],
   })
   @TableColumn({
+    computed: true,
     type: TableColumnType.VeryLongText,
     title: "Notification Status Message",
     description:


### PR DESCRIPTION
Fixes the intermittent **Terraform Provider E2E Tests** failure on master (run 31208440594, fixture `28-incident-crud`, `[update]` phase):

```
Error: Provider produced inconsistent result after apply
... .subscriber_notification_status_message: was null, but now
cty.StringVal("No monitors are attached to this incident. Skipping notifications to subscribers.")
```

## Root cause

`subscriberNotificationStatusMessage` is written by EVERY_MINUTE cron workers, but its `@TableColumn` lacked `computed: true` — while its sibling status enum `subscriberNotificationStatusOnIncidentCreated` has it.

Writable + readable ⇒ the generated provider marks the attribute `Optional+Computed` and attaches `UseStateForUnknown()`. In **terraform-plugin-framework v1.16.0** that modifier's guard changed from `req.StateValue.IsNull()` to `req.State.Raw.IsNull()`. On an *update* the resource state is non-null, so it now copies a **null attribute value** over the framework's "unknown" mark.

The attribute therefore plans as `null` instead of `(known after apply)`, and any worker write landing between the plan refresh and the provider's post-`Update` read-back is a plan violation. Every observed failure hit at **:00–:01 past the minute**, when the cron fires.

The control case is in the same log: `oneuptime_incident.visibility_settings` errored only on the postmortem field, not on `subscriber_notification_status_message`, because that one's state was already non-null — so the modifier pinned a real value and stayed consistent.

## Why it looked like a code regression but isn't

The passing and failing commits have **identical tree hashes** (`01231044a40a37248917b461a50459e5dd177917`) and started 3 seconds apart. Verified with `git rev-parse`. The defect is deterministic given its two preconditions; only the cron timing is chance, so it is roughly a 1-second window per 60-second period.

What *exposed* it was `5c71c4cfa9` (07-31), which added the `[update]` phase to the E2E suite. Before that there was no update apply.

## The fix

Add `computed: true` to all **11** such columns across **10** models. That drops them from the create/update schemas ([ModelSchema.ts:1122-1128](Common/Utils/Schema/ModelSchema.ts:1122)) and marks them readOnly in OpenAPI ([ModelSchema.ts:423-427](Common/Utils/Schema/ModelSchema.ts:423)), so the provider generates them Computed-only with no plan modifier and the cron write is accepted.

Applied across all of them — not just `Incident` — so the same flake cannot surface on `ScheduledMaintenance` (already observed once, on `oneuptime_scheduled_maintenance_event`) or any note/timeline model.

## Safety

- **No DB change, no migration** — `@Column` is untouched; `computed` is `TableColumn` metadata consumed only by schema generation.
- **Workers unaffected** — they write via `updateOneById` with `isRoot: true`, which does not validate against the create/update Zod schemas. Decisive in-tree proof: each worker writes this field in the *same call* as `subscriberNotificationStatusOnIncidentCreated`, a column that is **already** `computed: true` and works today.
- **API contract**: these fields become read-only. That is the intent — they are worker-written status text no client should set.

## Verification

- `tsc --noEmit` in `Common`: **0 errors**.
- `Tests/Models` + `Tests/Utils/Schema`: **201 passing**, including `PermissionCatalogueCoverage` which enumerates these columns.
- prettier clean, eslint clean.