### PR TITLE
fix(e2e): match the Labels combobox by its real accessible name

### DIFF
--- a/E2E/Tests/Dashboard/Helpers/Monitors.ts
+++ b/E2E/Tests/Dashboard/Helpers/Monitors.ts
@@ -162,9 +162,16 @@ const selectMonitorLabels: (data: {
   page: Page;
   labelNames?: Array<string> | undefined;
 }): Promise<void> => {
+  /*
+   * Anchored prefix, not an exact match: Labels is an optional field, and
+   * FieldLabel renders "(Optional)" inside the very <label> the combobox is
+   * aria-labelledby, so its accessible name is "Labels (Optional)". Anchoring
+   * still keeps this from matching some other combobox that merely ends in
+   * "Labels", and it keeps working if the field ever becomes required.
+   */
   const combo: Locator = data.page
     .locator(monitorCreateFormSelector)
-    .getByRole("combobox", { name: "Labels", exact: true });
+    .getByRole("combobox", { name: /^Labels\b/ });
   await combo.waitFor({ state: "visible", timeout: 30000 });
 
   for (const labelName of data.labelNames || []) {

--- a/E2E/Tests/Dashboard/MonitorProbeSelection.spec.ts
+++ b/E2E/Tests/Dashboard/MonitorProbeSelection.spec.ts
@@ -247,7 +247,8 @@ test.describe("Monitor probe selection", () => {
     // Step 4: Labels is always the final step; leave it empty here.
     await page.getByTestId(submitButtonTestId).click();
     await expect(
-      page.getByRole("combobox", { name: "Labels", exact: true }),
+      // "Labels (Optional)" is the rendered accessible name — match the prefix.
+      page.getByRole("combobox", { name: /^Labels\b/ }),
     ).toBeVisible({ timeout: 30000 });
     await page.getByTestId(submitButtonTestId).click();
 

--- a/E2E/Tests/Dashboard/MonitorProbeSummary.spec.ts
+++ b/E2E/Tests/Dashboard/MonitorProbeSummary.spec.ts
@@ -256,7 +256,8 @@ test.describe("Monitor summary probe picker", () => {
     // Step 4: Labels is always the final step; leave it empty here.
     await page.getByTestId(submitButtonTestId).click();
     await expect(
-      page.getByRole("combobox", { name: "Labels", exact: true }),
+      // "Labels (Optional)" is the rendered accessible name — match the prefix.
+      page.getByRole("combobox", { name: /^Labels\b/ }),
     ).toBeVisible({ timeout: 30000 });
     await page.getByTestId(submitButtonTestId).click();
 


### PR DESCRIPTION
The E2E suite (`test-e2e-test-saas` / `test-e2e-test-self-hosted` in test-release.yaml) is red on master: **9 failed / 138 passed / 21 skipped / 80 never ran** (maxFailures cutoff), run 31214249619.

## Root cause

Three locators wait for:

```ts
getByRole("combobox", { name: "Labels", exact: true })
```

But the Labels field is **optional**, and `FieldLabel` renders `(Optional)` *inside* the very `<label>` the combobox is `aria-labelledby`:

[FieldLabel.tsx:41-46](Common/UI/Components/Forms/Fields/FieldLabel.tsx:41) → [FormField.tsx:454-456](Common/UI/Components/Forms/Fields/FormField.tsx:454) → `EntityDropdown`'s `<input role="combobox" aria-labelledby=…>`

So the accessible name is **"Labels (Optional)"**, and `exact: true` on `"Labels"` can never match — in any run, on any machine.

Playwright's own ARIA snapshot from the CI artifact is decisive — `combobox "Labels (Optional)"` appears in **33 of the 34** `error-context.md` files:

```
- navigation "Progress":
    - listitem: Monitor Info / Criteria / Probes & Interval / Labels
- text: Labels (Optional) Team members with access to these labels...
- combobox "Labels (Optional)"
```

The wizard *does* reach the Labels step and the combobox *is* visible — only the name doesn't match.

## Why five unrelated-looking specs failed at once

`Monitors.ts:167` sits in the shared `createMonitor` helper and waits **unconditionally**, before the label loop. So every monitor-creation recipe blocked for 30s regardless of whether it wanted labels — taking down `CreateMonitors`, `MonitorIncidentOnCall`, `MonitorProbeSelection`, `MonitorProbeSummary` and `Slo` together.

## Neither flaky nor pre-existing

- **Not flaky.** Deterministic and permanent: identical failures in chromium *and* firefox, in *both* the saas and self-hosted jobs. A structural name mismatch, not timing. Re-running CI would never help.
- **Not pre-existing.** `ef7e283f9c` ("feat(monitor): add labels to create form") is **absent** from the last-green sha `881a5cc` (224 passed / 0 failed, 10h earlier) and **present** in the red HEAD. Verified with `git merge-base --is-ancestor`. It landed inside the cancel-in-progress window, so this was the first run that ever executed it.

## The fix

Match by anchored prefix `/^Labels\b/` rather than dropping exactness outright — it can't match some other combobox merely *ending* in "Labels", and it keeps working if the field ever becomes required.

The app is correct: every optional field renders "(Optional)". The fix belongs in the tests, not in `Create.tsx`.

## Verification

- E2E `tsc --noEmit`: **0 errors**.
- No other exact-name combobox locator remains anywhere in `E2E/Tests`.
- prettier clean, eslint clean.