### PR TITLE
test(common): add coverage for infrastructure metric catalogs

### DIFF
--- a/Common/Tests/Types/Monitor/CephMetricCatalog.test.ts
+++ b/Common/Tests/Types/Monitor/CephMetricCatalog.test.ts
@@ -1,0 +1,104 @@
+import {
+  CephMetricCategory,
+  CephMetricDefinition,
+  getAllCephMetricCategories,
+  getAllCephMetrics,
+  getCephMetricById,
+  getCephMetricByMetricName,
+  getCephMetricsByCategory,
+} from "../../../Types/Monitor/CephMetricCatalog";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import { describe, expect, test } from "@jest/globals";
+
+describe("CephMetricCatalog", () => {
+  const allMetrics: Array<CephMetricDefinition> = getAllCephMetrics();
+  const allCategories: Array<CephMetricCategory> = getAllCephMetricCategories();
+  const validAggregations: Array<string> = Object.values(AggregationType);
+
+  test("returns a non-empty catalog", () => {
+    expect(Array.isArray(allMetrics)).toBe(true);
+    expect(allMetrics.length).toBeGreaterThan(0);
+  });
+
+  test("every metric definition has all required non-empty fields", () => {
+    for (const metric of allMetrics) {
+      expect(typeof metric.id).toBe("string");
+      expect(metric.id.length).toBeGreaterThan(0);
+      expect(metric.friendlyName.length).toBeGreaterThan(0);
+      expect(metric.description.length).toBeGreaterThan(0);
+      expect(metric.metricName.length).toBeGreaterThan(0);
+      expect(metric.category.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every metric uses a valid aggregation type", () => {
+    for (const metric of allMetrics) {
+      expect(validAggregations).toContain(metric.defaultAggregation);
+    }
+  });
+
+  test("metric ids are unique", () => {
+    const ids: Array<string> = allMetrics.map((m: CephMetricDefinition) => {
+      return m.id;
+    });
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("metric names are unique", () => {
+    const names: Array<string> = allMetrics.map((m: CephMetricDefinition) => {
+      return m.metricName;
+    });
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("every metric category is a declared category", () => {
+    for (const metric of allMetrics) {
+      expect(allCategories).toContain(metric.category);
+    }
+  });
+
+  test("declared categories are unique and non-empty", () => {
+    expect(allCategories.length).toBeGreaterThan(0);
+    expect(new Set(allCategories).size).toBe(allCategories.length);
+  });
+
+  test("every declared category has at least one metric", () => {
+    for (const category of allCategories) {
+      expect(getCephMetricsByCategory(category).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("getCephMetricsByCategory returns only metrics of that category", () => {
+    for (const category of allCategories) {
+      for (const metric of getCephMetricsByCategory(category)) {
+        expect(metric.category).toBe(category);
+      }
+    }
+  });
+
+  test("getCephMetricById round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getCephMetricById(metric.id)).toEqual(metric);
+    }
+  });
+
+  test("getCephMetricById returns undefined for an unknown id", () => {
+    expect(getCephMetricById("does-not-exist")).toBeUndefined();
+    expect(getCephMetricById("")).toBeUndefined();
+  });
+
+  test("getCephMetricByMetricName round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getCephMetricByMetricName(metric.metricName)).toEqual(metric);
+    }
+  });
+
+  test("getCephMetricByMetricName returns undefined for an unknown name", () => {
+    expect(getCephMetricByMetricName("nope.nope.nope")).toBeUndefined();
+  });
+
+  test("known metrics are present", () => {
+    expect(getCephMetricByMetricName("ceph_health_status")).toBeDefined();
+    expect(getCephMetricByMetricName("ceph_health_detail")).toBeDefined();
+  });
+});

--- a/Common/Tests/Types/Monitor/DockerMetricCatalog.test.ts
+++ b/Common/Tests/Types/Monitor/DockerMetricCatalog.test.ts
@@ -1,0 +1,109 @@
+import {
+  DockerMetricCategory,
+  DockerMetricDefinition,
+  getAllDockerMetricCategories,
+  getAllDockerMetrics,
+  getDockerMetricById,
+  getDockerMetricByMetricName,
+  getDockerMetricsByCategory,
+} from "../../../Types/Monitor/DockerMetricCatalog";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import { describe, expect, test } from "@jest/globals";
+
+describe("DockerMetricCatalog", () => {
+  const allMetrics: Array<DockerMetricDefinition> = getAllDockerMetrics();
+  const allCategories: Array<DockerMetricCategory> =
+    getAllDockerMetricCategories();
+  const validAggregations: Array<string> = Object.values(AggregationType);
+
+  test("returns a non-empty catalog", () => {
+    expect(Array.isArray(allMetrics)).toBe(true);
+    expect(allMetrics.length).toBeGreaterThan(0);
+  });
+
+  test("every metric definition has all required non-empty fields", () => {
+    for (const metric of allMetrics) {
+      expect(typeof metric.id).toBe("string");
+      expect(metric.id.length).toBeGreaterThan(0);
+      expect(metric.friendlyName.length).toBeGreaterThan(0);
+      expect(metric.description.length).toBeGreaterThan(0);
+      expect(metric.metricName.length).toBeGreaterThan(0);
+      expect(metric.category.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every metric uses a valid aggregation type", () => {
+    for (const metric of allMetrics) {
+      expect(validAggregations).toContain(metric.defaultAggregation);
+    }
+  });
+
+  test("metric ids are unique", () => {
+    const ids: Array<string> = allMetrics.map((m: DockerMetricDefinition) => {
+      return m.id;
+    });
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("metric names are unique", () => {
+    const names: Array<string> = allMetrics.map((m: DockerMetricDefinition) => {
+      return m.metricName;
+    });
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("every metric category is a declared category", () => {
+    for (const metric of allMetrics) {
+      expect(allCategories).toContain(metric.category);
+    }
+  });
+
+  test("declared categories are unique and non-empty", () => {
+    expect(allCategories.length).toBeGreaterThan(0);
+    expect(new Set(allCategories).size).toBe(allCategories.length);
+  });
+
+  test("every declared category has at least one metric", () => {
+    for (const category of allCategories) {
+      expect(getDockerMetricsByCategory(category).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("getDockerMetricsByCategory returns only metrics of that category", () => {
+    for (const category of allCategories) {
+      for (const metric of getDockerMetricsByCategory(category)) {
+        expect(metric.category).toBe(category);
+      }
+    }
+  });
+
+  test("getDockerMetricById round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getDockerMetricById(metric.id)).toEqual(metric);
+    }
+  });
+
+  test("getDockerMetricById returns undefined for an unknown id", () => {
+    expect(getDockerMetricById("does-not-exist")).toBeUndefined();
+    expect(getDockerMetricById("")).toBeUndefined();
+  });
+
+  test("getDockerMetricByMetricName round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getDockerMetricByMetricName(metric.metricName)).toEqual(metric);
+    }
+  });
+
+  test("getDockerMetricByMetricName returns undefined for an unknown name", () => {
+    expect(getDockerMetricByMetricName("nope.nope.nope")).toBeUndefined();
+  });
+
+  test("known metrics are present", () => {
+    expect(
+      getDockerMetricByMetricName("container.cpu.usage.total"),
+    ).toBeDefined();
+    expect(
+      getDockerMetricByMetricName("container.cpu.utilization"),
+    ).toBeDefined();
+  });
+});

--- a/Common/Tests/Types/Monitor/DockerSwarmMetricCatalog.test.ts
+++ b/Common/Tests/Types/Monitor/DockerSwarmMetricCatalog.test.ts
@@ -1,0 +1,118 @@
+import {
+  DockerSwarmMetricCategory,
+  DockerSwarmMetricDefinition,
+  getAllDockerSwarmMetricCategories,
+  getAllDockerSwarmMetrics,
+  getDockerSwarmMetricById,
+  getDockerSwarmMetricByMetricName,
+  getDockerSwarmMetricsByCategory,
+} from "../../../Types/Monitor/DockerSwarmMetricCatalog";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import { describe, expect, test } from "@jest/globals";
+
+describe("DockerSwarmMetricCatalog", () => {
+  const allMetrics: Array<DockerSwarmMetricDefinition> =
+    getAllDockerSwarmMetrics();
+  const allCategories: Array<DockerSwarmMetricCategory> =
+    getAllDockerSwarmMetricCategories();
+  const validAggregations: Array<string> = Object.values(AggregationType);
+
+  test("returns a non-empty catalog", () => {
+    expect(Array.isArray(allMetrics)).toBe(true);
+    expect(allMetrics.length).toBeGreaterThan(0);
+  });
+
+  test("every metric definition has all required non-empty fields", () => {
+    for (const metric of allMetrics) {
+      expect(typeof metric.id).toBe("string");
+      expect(metric.id.length).toBeGreaterThan(0);
+      expect(metric.friendlyName.length).toBeGreaterThan(0);
+      expect(metric.description.length).toBeGreaterThan(0);
+      expect(metric.metricName.length).toBeGreaterThan(0);
+      expect(metric.category.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every metric uses a valid aggregation type", () => {
+    for (const metric of allMetrics) {
+      expect(validAggregations).toContain(metric.defaultAggregation);
+    }
+  });
+
+  test("metric ids are unique", () => {
+    const ids: Array<string> = allMetrics.map(
+      (m: DockerSwarmMetricDefinition) => {
+        return m.id;
+      },
+    );
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("metric names are unique", () => {
+    const names: Array<string> = allMetrics.map(
+      (m: DockerSwarmMetricDefinition) => {
+        return m.metricName;
+      },
+    );
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("every metric category is a declared category", () => {
+    for (const metric of allMetrics) {
+      expect(allCategories).toContain(metric.category);
+    }
+  });
+
+  test("declared categories are unique and non-empty", () => {
+    expect(allCategories.length).toBeGreaterThan(0);
+    expect(new Set(allCategories).size).toBe(allCategories.length);
+  });
+
+  test("every declared category has at least one metric", () => {
+    for (const category of allCategories) {
+      expect(getDockerSwarmMetricsByCategory(category).length).toBeGreaterThan(
+        0,
+      );
+    }
+  });
+
+  test("getDockerSwarmMetricsByCategory returns only metrics of that category", () => {
+    for (const category of allCategories) {
+      for (const metric of getDockerSwarmMetricsByCategory(category)) {
+        expect(metric.category).toBe(category);
+      }
+    }
+  });
+
+  test("getDockerSwarmMetricById round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getDockerSwarmMetricById(metric.id)).toEqual(metric);
+    }
+  });
+
+  test("getDockerSwarmMetricById returns undefined for an unknown id", () => {
+    expect(getDockerSwarmMetricById("does-not-exist")).toBeUndefined();
+    expect(getDockerSwarmMetricById("")).toBeUndefined();
+  });
+
+  test("getDockerSwarmMetricByMetricName round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getDockerSwarmMetricByMetricName(metric.metricName)).toEqual(
+        metric,
+      );
+    }
+  });
+
+  test("getDockerSwarmMetricByMetricName returns undefined for an unknown name", () => {
+    expect(getDockerSwarmMetricByMetricName("nope.nope.nope")).toBeUndefined();
+  });
+
+  test("known metrics are present", () => {
+    expect(
+      getDockerSwarmMetricByMetricName("container.cpu.utilization"),
+    ).toBeDefined();
+    expect(
+      getDockerSwarmMetricByMetricName("container.memory.usage.total"),
+    ).toBeDefined();
+  });
+});

--- a/Common/Tests/Types/Monitor/HostMetricCatalog.test.ts
+++ b/Common/Tests/Types/Monitor/HostMetricCatalog.test.ts
@@ -1,0 +1,104 @@
+import {
+  HostMetricCategory,
+  HostMetricDefinition,
+  getAllHostMetricCategories,
+  getAllHostMetrics,
+  getHostMetricById,
+  getHostMetricByMetricName,
+  getHostMetricsByCategory,
+} from "../../../Types/Monitor/HostMetricCatalog";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import { describe, expect, test } from "@jest/globals";
+
+describe("HostMetricCatalog", () => {
+  const allMetrics: Array<HostMetricDefinition> = getAllHostMetrics();
+  const allCategories: Array<HostMetricCategory> = getAllHostMetricCategories();
+  const validAggregations: Array<string> = Object.values(AggregationType);
+
+  test("returns a non-empty catalog", () => {
+    expect(Array.isArray(allMetrics)).toBe(true);
+    expect(allMetrics.length).toBeGreaterThan(0);
+  });
+
+  test("every metric definition has all required non-empty fields", () => {
+    for (const metric of allMetrics) {
+      expect(typeof metric.id).toBe("string");
+      expect(metric.id.length).toBeGreaterThan(0);
+      expect(metric.friendlyName.length).toBeGreaterThan(0);
+      expect(metric.description.length).toBeGreaterThan(0);
+      expect(metric.metricName.length).toBeGreaterThan(0);
+      expect(metric.category.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every metric uses a valid aggregation type", () => {
+    for (const metric of allMetrics) {
+      expect(validAggregations).toContain(metric.defaultAggregation);
+    }
+  });
+
+  test("metric ids are unique", () => {
+    const ids: Array<string> = allMetrics.map((m: HostMetricDefinition) => {
+      return m.id;
+    });
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("metric names are unique", () => {
+    const names: Array<string> = allMetrics.map((m: HostMetricDefinition) => {
+      return m.metricName;
+    });
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("every metric category is a declared category", () => {
+    for (const metric of allMetrics) {
+      expect(allCategories).toContain(metric.category);
+    }
+  });
+
+  test("declared categories are unique and non-empty", () => {
+    expect(allCategories.length).toBeGreaterThan(0);
+    expect(new Set(allCategories).size).toBe(allCategories.length);
+  });
+
+  test("every declared category has at least one metric", () => {
+    for (const category of allCategories) {
+      expect(getHostMetricsByCategory(category).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("getHostMetricsByCategory returns only metrics of that category", () => {
+    for (const category of allCategories) {
+      for (const metric of getHostMetricsByCategory(category)) {
+        expect(metric.category).toBe(category);
+      }
+    }
+  });
+
+  test("getHostMetricById round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getHostMetricById(metric.id)).toEqual(metric);
+    }
+  });
+
+  test("getHostMetricById returns undefined for an unknown id", () => {
+    expect(getHostMetricById("does-not-exist")).toBeUndefined();
+    expect(getHostMetricById("")).toBeUndefined();
+  });
+
+  test("getHostMetricByMetricName round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getHostMetricByMetricName(metric.metricName)).toEqual(metric);
+    }
+  });
+
+  test("getHostMetricByMetricName returns undefined for an unknown name", () => {
+    expect(getHostMetricByMetricName("nope.nope")).toBeUndefined();
+  });
+
+  test("known host metrics are present", () => {
+    expect(getHostMetricByMetricName("system.cpu.utilization")).toBeDefined();
+    expect(getHostMetricByMetricName("system.memory.usage")).toBeDefined();
+  });
+});

--- a/Common/Tests/Types/Monitor/IotMetricCatalog.test.ts
+++ b/Common/Tests/Types/Monitor/IotMetricCatalog.test.ts
@@ -1,0 +1,104 @@
+import {
+  IoTMetricCategory,
+  IoTMetricDefinition,
+  getAllIoTMetricCategories,
+  getAllIoTMetrics,
+  getIoTMetricById,
+  getIoTMetricByMetricName,
+  getIoTMetricsByCategory,
+} from "../../../Types/Monitor/IotMetricCatalog";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import { describe, expect, test } from "@jest/globals";
+
+describe("IotMetricCatalog", () => {
+  const allMetrics: Array<IoTMetricDefinition> = getAllIoTMetrics();
+  const allCategories: Array<IoTMetricCategory> = getAllIoTMetricCategories();
+  const validAggregations: Array<string> = Object.values(AggregationType);
+
+  test("returns a non-empty catalog", () => {
+    expect(Array.isArray(allMetrics)).toBe(true);
+    expect(allMetrics.length).toBeGreaterThan(0);
+  });
+
+  test("every metric definition has all required non-empty fields", () => {
+    for (const metric of allMetrics) {
+      expect(typeof metric.id).toBe("string");
+      expect(metric.id.length).toBeGreaterThan(0);
+      expect(metric.friendlyName.length).toBeGreaterThan(0);
+      expect(metric.description.length).toBeGreaterThan(0);
+      expect(metric.metricName.length).toBeGreaterThan(0);
+      expect(metric.category.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every metric uses a valid aggregation type", () => {
+    for (const metric of allMetrics) {
+      expect(validAggregations).toContain(metric.defaultAggregation);
+    }
+  });
+
+  test("metric ids are unique", () => {
+    const ids: Array<string> = allMetrics.map((m: IoTMetricDefinition) => {
+      return m.id;
+    });
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("metric names are unique", () => {
+    const names: Array<string> = allMetrics.map((m: IoTMetricDefinition) => {
+      return m.metricName;
+    });
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("every metric category is a declared category", () => {
+    for (const metric of allMetrics) {
+      expect(allCategories).toContain(metric.category);
+    }
+  });
+
+  test("declared categories are unique and non-empty", () => {
+    expect(allCategories.length).toBeGreaterThan(0);
+    expect(new Set(allCategories).size).toBe(allCategories.length);
+  });
+
+  test("every declared category has at least one metric", () => {
+    for (const category of allCategories) {
+      expect(getIoTMetricsByCategory(category).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("getIoTMetricsByCategory returns only metrics of that category", () => {
+    for (const category of allCategories) {
+      for (const metric of getIoTMetricsByCategory(category)) {
+        expect(metric.category).toBe(category);
+      }
+    }
+  });
+
+  test("getIoTMetricById round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getIoTMetricById(metric.id)).toEqual(metric);
+    }
+  });
+
+  test("getIoTMetricById returns undefined for an unknown id", () => {
+    expect(getIoTMetricById("does-not-exist")).toBeUndefined();
+    expect(getIoTMetricById("")).toBeUndefined();
+  });
+
+  test("getIoTMetricByMetricName round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getIoTMetricByMetricName(metric.metricName)).toEqual(metric);
+    }
+  });
+
+  test("getIoTMetricByMetricName returns undefined for an unknown name", () => {
+    expect(getIoTMetricByMetricName("nope.nope.nope")).toBeUndefined();
+  });
+
+  test("known metrics are present", () => {
+    expect(getIoTMetricByMetricName("iot_device_up")).toBeDefined();
+    expect(getIoTMetricByMetricName("iot_battery_percent")).toBeDefined();
+  });
+});

--- a/Common/Tests/Types/Monitor/KubernetesMetricCatalog.test.ts
+++ b/Common/Tests/Types/Monitor/KubernetesMetricCatalog.test.ts
@@ -1,0 +1,118 @@
+import {
+  KubernetesMetricCategory,
+  KubernetesMetricDefinition,
+  getAllKubernetesMetricCategories,
+  getAllKubernetesMetrics,
+  getKubernetesMetricById,
+  getKubernetesMetricByMetricName,
+  getKubernetesMetricsByCategory,
+} from "../../../Types/Monitor/KubernetesMetricCatalog";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import { describe, expect, test } from "@jest/globals";
+
+describe("KubernetesMetricCatalog", () => {
+  const allMetrics: Array<KubernetesMetricDefinition> =
+    getAllKubernetesMetrics();
+  const allCategories: Array<KubernetesMetricCategory> =
+    getAllKubernetesMetricCategories();
+  const validAggregations: Array<string> = Object.values(AggregationType);
+
+  test("returns a non-empty catalog", () => {
+    expect(Array.isArray(allMetrics)).toBe(true);
+    expect(allMetrics.length).toBeGreaterThan(0);
+  });
+
+  test("every metric definition has all required non-empty fields", () => {
+    for (const metric of allMetrics) {
+      expect(typeof metric.id).toBe("string");
+      expect(metric.id.length).toBeGreaterThan(0);
+      expect(metric.friendlyName.length).toBeGreaterThan(0);
+      expect(metric.description.length).toBeGreaterThan(0);
+      expect(metric.metricName.length).toBeGreaterThan(0);
+      expect(metric.category.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every metric uses a valid aggregation type", () => {
+    for (const metric of allMetrics) {
+      expect(validAggregations).toContain(metric.defaultAggregation);
+    }
+  });
+
+  test("metric ids are unique", () => {
+    const ids: Array<string> = allMetrics.map(
+      (m: KubernetesMetricDefinition) => {
+        return m.id;
+      },
+    );
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("metric names are unique", () => {
+    const names: Array<string> = allMetrics.map(
+      (m: KubernetesMetricDefinition) => {
+        return m.metricName;
+      },
+    );
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("every metric category is a declared category", () => {
+    for (const metric of allMetrics) {
+      expect(allCategories).toContain(metric.category);
+    }
+  });
+
+  test("declared categories are unique and non-empty", () => {
+    expect(allCategories.length).toBeGreaterThan(0);
+    expect(new Set(allCategories).size).toBe(allCategories.length);
+  });
+
+  test("every declared category has at least one metric", () => {
+    for (const category of allCategories) {
+      expect(getKubernetesMetricsByCategory(category).length).toBeGreaterThan(
+        0,
+      );
+    }
+  });
+
+  test("getKubernetesMetricsByCategory returns only metrics of that category", () => {
+    for (const category of allCategories) {
+      for (const metric of getKubernetesMetricsByCategory(category)) {
+        expect(metric.category).toBe(category);
+      }
+    }
+  });
+
+  test("getKubernetesMetricById round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getKubernetesMetricById(metric.id)).toEqual(metric);
+    }
+  });
+
+  test("getKubernetesMetricById returns undefined for an unknown id", () => {
+    expect(getKubernetesMetricById("does-not-exist")).toBeUndefined();
+    expect(getKubernetesMetricById("")).toBeUndefined();
+  });
+
+  test("getKubernetesMetricByMetricName round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getKubernetesMetricByMetricName(metric.metricName)).toEqual(
+        metric,
+      );
+    }
+  });
+
+  test("getKubernetesMetricByMetricName returns undefined for an unknown name", () => {
+    expect(getKubernetesMetricByMetricName("nope.nope.nope")).toBeUndefined();
+  });
+
+  test("known metrics are present", () => {
+    expect(
+      getKubernetesMetricByMetricName("k8s.pod.cpu.utilization"),
+    ).toBeDefined();
+    expect(
+      getKubernetesMetricByMetricName("k8s.pod.memory.usage"),
+    ).toBeDefined();
+  });
+});

--- a/Common/Tests/Types/Monitor/PodmanMetricCatalog.test.ts
+++ b/Common/Tests/Types/Monitor/PodmanMetricCatalog.test.ts
@@ -1,0 +1,109 @@
+import {
+  PodmanMetricCategory,
+  PodmanMetricDefinition,
+  getAllPodmanMetricCategories,
+  getAllPodmanMetrics,
+  getPodmanMetricById,
+  getPodmanMetricByMetricName,
+  getPodmanMetricsByCategory,
+} from "../../../Types/Monitor/PodmanMetricCatalog";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import { describe, expect, test } from "@jest/globals";
+
+describe("PodmanMetricCatalog", () => {
+  const allMetrics: Array<PodmanMetricDefinition> = getAllPodmanMetrics();
+  const allCategories: Array<PodmanMetricCategory> =
+    getAllPodmanMetricCategories();
+  const validAggregations: Array<string> = Object.values(AggregationType);
+
+  test("returns a non-empty catalog", () => {
+    expect(Array.isArray(allMetrics)).toBe(true);
+    expect(allMetrics.length).toBeGreaterThan(0);
+  });
+
+  test("every metric definition has all required non-empty fields", () => {
+    for (const metric of allMetrics) {
+      expect(typeof metric.id).toBe("string");
+      expect(metric.id.length).toBeGreaterThan(0);
+      expect(metric.friendlyName.length).toBeGreaterThan(0);
+      expect(metric.description.length).toBeGreaterThan(0);
+      expect(metric.metricName.length).toBeGreaterThan(0);
+      expect(metric.category.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every metric uses a valid aggregation type", () => {
+    for (const metric of allMetrics) {
+      expect(validAggregations).toContain(metric.defaultAggregation);
+    }
+  });
+
+  test("metric ids are unique", () => {
+    const ids: Array<string> = allMetrics.map((m: PodmanMetricDefinition) => {
+      return m.id;
+    });
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("metric names are unique", () => {
+    const names: Array<string> = allMetrics.map((m: PodmanMetricDefinition) => {
+      return m.metricName;
+    });
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("every metric category is a declared category", () => {
+    for (const metric of allMetrics) {
+      expect(allCategories).toContain(metric.category);
+    }
+  });
+
+  test("declared categories are unique and non-empty", () => {
+    expect(allCategories.length).toBeGreaterThan(0);
+    expect(new Set(allCategories).size).toBe(allCategories.length);
+  });
+
+  test("every declared category has at least one metric", () => {
+    for (const category of allCategories) {
+      expect(getPodmanMetricsByCategory(category).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("getPodmanMetricsByCategory returns only metrics of that category", () => {
+    for (const category of allCategories) {
+      for (const metric of getPodmanMetricsByCategory(category)) {
+        expect(metric.category).toBe(category);
+      }
+    }
+  });
+
+  test("getPodmanMetricById round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getPodmanMetricById(metric.id)).toEqual(metric);
+    }
+  });
+
+  test("getPodmanMetricById returns undefined for an unknown id", () => {
+    expect(getPodmanMetricById("does-not-exist")).toBeUndefined();
+    expect(getPodmanMetricById("")).toBeUndefined();
+  });
+
+  test("getPodmanMetricByMetricName round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getPodmanMetricByMetricName(metric.metricName)).toEqual(metric);
+    }
+  });
+
+  test("getPodmanMetricByMetricName returns undefined for an unknown name", () => {
+    expect(getPodmanMetricByMetricName("nope.nope.nope")).toBeUndefined();
+  });
+
+  test("known metrics are present", () => {
+    expect(
+      getPodmanMetricByMetricName("container.cpu.usage.total"),
+    ).toBeDefined();
+    expect(
+      getPodmanMetricByMetricName("container.cpu.utilization"),
+    ).toBeDefined();
+  });
+});

--- a/Common/Tests/Types/Monitor/ProxmoxMetricCatalog.test.ts
+++ b/Common/Tests/Types/Monitor/ProxmoxMetricCatalog.test.ts
@@ -1,0 +1,107 @@
+import {
+  ProxmoxMetricCategory,
+  ProxmoxMetricDefinition,
+  getAllProxmoxMetricCategories,
+  getAllProxmoxMetrics,
+  getProxmoxMetricById,
+  getProxmoxMetricByMetricName,
+  getProxmoxMetricsByCategory,
+} from "../../../Types/Monitor/ProxmoxMetricCatalog";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import { describe, expect, test } from "@jest/globals";
+
+describe("ProxmoxMetricCatalog", () => {
+  const allMetrics: Array<ProxmoxMetricDefinition> = getAllProxmoxMetrics();
+  const allCategories: Array<ProxmoxMetricCategory> =
+    getAllProxmoxMetricCategories();
+  const validAggregations: Array<string> = Object.values(AggregationType);
+
+  test("returns a non-empty catalog", () => {
+    expect(Array.isArray(allMetrics)).toBe(true);
+    expect(allMetrics.length).toBeGreaterThan(0);
+  });
+
+  test("every metric definition has all required non-empty fields", () => {
+    for (const metric of allMetrics) {
+      expect(typeof metric.id).toBe("string");
+      expect(metric.id.length).toBeGreaterThan(0);
+      expect(metric.friendlyName.length).toBeGreaterThan(0);
+      expect(metric.description.length).toBeGreaterThan(0);
+      expect(metric.metricName.length).toBeGreaterThan(0);
+      expect(metric.category.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("every metric uses a valid aggregation type", () => {
+    for (const metric of allMetrics) {
+      expect(validAggregations).toContain(metric.defaultAggregation);
+    }
+  });
+
+  test("metric ids are unique", () => {
+    const ids: Array<string> = allMetrics.map((m: ProxmoxMetricDefinition) => {
+      return m.id;
+    });
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("metric names are unique", () => {
+    const names: Array<string> = allMetrics.map(
+      (m: ProxmoxMetricDefinition) => {
+        return m.metricName;
+      },
+    );
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("every metric category is a declared category", () => {
+    for (const metric of allMetrics) {
+      expect(allCategories).toContain(metric.category);
+    }
+  });
+
+  test("declared categories are unique and non-empty", () => {
+    expect(allCategories.length).toBeGreaterThan(0);
+    expect(new Set(allCategories).size).toBe(allCategories.length);
+  });
+
+  test("every declared category has at least one metric", () => {
+    for (const category of allCategories) {
+      expect(getProxmoxMetricsByCategory(category).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("getProxmoxMetricsByCategory returns only metrics of that category", () => {
+    for (const category of allCategories) {
+      for (const metric of getProxmoxMetricsByCategory(category)) {
+        expect(metric.category).toBe(category);
+      }
+    }
+  });
+
+  test("getProxmoxMetricById round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getProxmoxMetricById(metric.id)).toEqual(metric);
+    }
+  });
+
+  test("getProxmoxMetricById returns undefined for an unknown id", () => {
+    expect(getProxmoxMetricById("does-not-exist")).toBeUndefined();
+    expect(getProxmoxMetricById("")).toBeUndefined();
+  });
+
+  test("getProxmoxMetricByMetricName round-trips every metric", () => {
+    for (const metric of allMetrics) {
+      expect(getProxmoxMetricByMetricName(metric.metricName)).toEqual(metric);
+    }
+  });
+
+  test("getProxmoxMetricByMetricName returns undefined for an unknown name", () => {
+    expect(getProxmoxMetricByMetricName("nope.nope.nope")).toBeUndefined();
+  });
+
+  test("known metrics are present", () => {
+    expect(getProxmoxMetricByMetricName("pve_up")).toBeDefined();
+    expect(getProxmoxMetricByMetricName("pve_uptime_seconds")).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit-test coverage for the 8 previously-untested infrastructure metric catalogs under `Common/Types/Monitor/`:

- `HostMetricCatalog`
- `CephMetricCatalog`
- `DockerMetricCatalog`
- `DockerSwarmMetricCatalog`
- `IotMetricCatalog`
- `KubernetesMetricCatalog`
- `PodmanMetricCatalog`
- `ProxmoxMetricCatalog`

## What each suite verifies

- Catalog is non-empty and every definition has all required non-empty fields.
- Every metric uses a valid `AggregationType`.
- Metric `id`s and `metricName`s are unique (guards against copy/paste duplicates when new metrics are added).
- Every metric's `category` is one of the declared categories, and every declared category has at least one metric (catches a category union / catalog drift on both sides).
- `getById` / `getByMetricName` round-trip every metric and return `undefined` for unknown keys.
- `getByCategory` returns only metrics of the requested category.

**112 tests across 8 suites, all passing locally.** `npm run fix` (eslint) and `tsc --noEmit` are clean.

Context: master is currently fully green; this PR only adds tests and touches no production code.

🤖 Generated as part of the daily master maintenance task.