### PR TITLE
fix(discovery): stop the ICMP pre-sweep silencing whole subnets

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveryScanOutcome.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveryScanOutcome.ts
@@ -1,0 +1,99 @@
+import NetworkDeviceDiscoveryScan, {
+  DiscoveredNetworkDevice,
+} from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+
+/*
+ * Pure, react-free reading of "what did this discovery scan actually find".
+ *
+ * The Discovery page used to render one number, respondedHostCount, as
+ * "N of M hosts". That number counts SNMP responders ONLY, so a sweep of a
+ * live subnet where nothing answered SNMP rendered as "0 of 254 hosts" —
+ * visually identical to a sweep of empty address space, and identical again
+ * to a subnet the probe cannot route to. Operators had no way to tell the
+ * three apart, and the probe's own explanation of the sweep (statusMessage)
+ * was fetched by the page and then never rendered at all.
+ *
+ * The rules for turning a scan row into something an operator can act on live
+ * here rather than inside the component so they can be imported (and
+ * unit-tested) in a plain Node/TypeScript environment, same as
+ * DiscoveryImportEligibility and DeviceStatusUtil.
+ */
+
+export interface DiscoveryScanOutcome {
+  /*
+   * "12 of 254 hosts", or null when the scan has not reported yet (Pending /
+   * In Progress) and there is nothing honest to show.
+   */
+  respondedHostSummary: string | null;
+  /*
+   * Hosts the sweep found alive that did not answer SNMP. Shown alongside the
+   * responder count so a zero is never mistaken for an empty network.
+   */
+  pingOnlyHostCount: number;
+  /*
+   * The probe's account of the sweep — which cases it hit (ICMP filtered,
+   * credentials rejected, nothing reachable at all) and what to check. Null
+   * when the probe sent none, e.g. rows written by an older probe.
+   */
+  explanation: string | null;
+}
+
+/*
+ * The scan's discovered hosts, defensively. The column is jsonb written from
+ * the probe's payload, so a row from a future/older probe (or a hand-edited
+ * one) can hold anything; treat a non-array as no results rather than letting
+ * the page throw while rendering a table cell.
+ */
+export function getDiscoveredHosts(
+  scan: NetworkDeviceDiscoveryScan | null | undefined,
+): Array<DiscoveredNetworkDevice> {
+  const raw: unknown = scan?.discoveredDevices;
+
+  if (!raw || !Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw as Array<DiscoveredNetworkDevice>;
+}
+
+/**
+ * Hosts that answered ICMP but not SNMP.
+ *
+ * Only an EXPLICIT snmpReachable === false counts, matching
+ * isImportableDiscoveredHost: scans stored before the field existed carry
+ * undefined and every host on them answered SNMP, so legacy rows must not be
+ * retroactively reported as ping-only.
+ */
+export function countPingOnlyHosts(
+  scan: NetworkDeviceDiscoveryScan | null | undefined,
+): number {
+  return getDiscoveredHosts(scan).filter((host: DiscoveredNetworkDevice) => {
+    return host.snmpReachable === false;
+  }).length;
+}
+
+/**
+ * Everything the scans list needs to render one row's result cell.
+ *
+ * A scan that has not reported yet gets a null summary rather than "0 of ?
+ * hosts": zero responders is a finding, and claiming it before the probe has
+ * answered is the same false negative in a different place.
+ */
+export function summarizeDiscoveryScan(
+  scan: NetworkDeviceDiscoveryScan | null | undefined,
+): DiscoveryScanOutcome {
+  const respondedHostCount: number | undefined | null =
+    scan?.respondedHostCount;
+
+  const hasReported: boolean =
+    respondedHostCount !== undefined && respondedHostCount !== null;
+
+  return {
+    respondedHostSummary: hasReported
+      ? `${respondedHostCount} of ${scan?.scannedHostCount ?? "?"} hosts`
+      : null,
+    pingOnlyHostCount: countPingOnlyHosts(scan),
+    // Empty string is "no explanation", not an explanation.
+    explanation: scan?.statusMessage || null,
+  };
+}

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -30,6 +30,10 @@ import ProjectUtil from "Common/UI/Utils/Project";
 import ScanTargetUtil from "Common/Utils/NetworkDiscovery/ScanTargetUtil";
 import { getSnmpConfigFormFields } from "./SnmpConfigFormFields";
 import { isImportableDiscoveredHost } from "../../Components/NetworkDevice/DiscoveryImportEligibility";
+import {
+  DiscoveryScanOutcome,
+  summarizeDiscoveryScan,
+} from "../../Components/NetworkDevice/DiscoveryScanOutcome";
 import React, {
   Fragment,
   FunctionComponent,
@@ -457,12 +461,37 @@ const NetworkDeviceDiscovery: FunctionComponent<
                 return <span className="text-sm text-gray-400">—</span>;
               }
 
+              /*
+               * The count is SNMP responders only, so "0 of 254" on its own
+               * reads as "there is nothing on this subnet" even when the sweep
+               * found live hosts that simply did not answer SNMP. Both extra
+               * lines below exist to keep a zero from being mistaken for an
+               * empty network: the ping-only tally, and the probe's own
+               * explanation of the sweep — which was already being stored and
+               * fetched, and was simply never rendered anywhere.
+               */
+              const outcome: DiscoveryScanOutcome =
+                summarizeDiscoveryScan(item);
+
               return (
-                <span className="text-sm text-gray-900">
-                  {`${item.respondedHostCount} of ${
-                    item.scannedHostCount ?? "?"
-                  } hosts`}
-                </span>
+                <div>
+                  <div className="text-sm text-gray-900">
+                    {outcome.respondedHostSummary}
+                  </div>
+                  {outcome.pingOnlyHostCount > 0 && (
+                    <div className="text-xs text-gray-500">
+                      {`+ ${outcome.pingOnlyHostCount} alive without SNMP`}
+                    </div>
+                  )}
+                  {outcome.explanation && (
+                    <div
+                      className="text-xs text-gray-500 mt-1 max-w-md"
+                      title={outcome.explanation}
+                    >
+                      {outcome.explanation}
+                    </div>
+                  )}
+                </div>
               );
             },
           },
@@ -556,7 +585,14 @@ const NetworkDeviceDiscovery: FunctionComponent<
           title="Review Discovered Devices"
           description={`Hosts that responded in ${
             scanToReview.cidr || "the scanned address range"
-          }. Select the ones you want to import as Network Devices — hosts without SNMP cannot be imported.`}
+          }. Select the ones you want to import as Network Devices — hosts without SNMP cannot be imported.${
+            /*
+             * The probe's summary of the sweep. Most valuable precisely when
+             * this list is empty, which is the one case where the operator
+             * otherwise has nothing at all to go on.
+             */
+            scanToReview.statusMessage ? ` ${scanToReview.statusMessage}` : ""
+          }`}
           modalWidth={ModalWidth.Medium}
           isLoading={isImporting}
           error={importError || undefined}

--- a/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
+++ b/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
@@ -31,6 +31,17 @@ const router: ExpressRouter = Express.getRouter();
 const MINIMUM_RESCAN_INTERVAL_IN_MINUTES: number = 15;
 
 /*
+ * NetworkDeviceDiscoveryScan.statusMessage is a varchar(500). The probe's
+ * summary now carries diagnostics (the ICMP-filtered fallback, the most common
+ * SNMP error verbatim) and the clamp note below is appended on top of it, so
+ * the combined string is no longer trivially short. An over-long value does
+ * not truncate in Postgres — it throws, which would fail this whole write and
+ * leave a finished scan sitting In Progress until the reaper picks it up. Cut
+ * it here instead: a clipped explanation beats a lost result.
+ */
+const MAX_STATUS_MESSAGE_LENGTH: number = 500;
+
+/*
  * Hands the requesting probe its pending subnet-discovery scans and marks
  * them In Progress so they aren't claimed twice. The probe executes each
  * scan locally (it's inside the target network) and reports back below.
@@ -292,6 +303,17 @@ router.post(
 
         completed["nextScanAt"] =
           OneUptimeDate.getSomeMinutesAfter(intervalInMinutes);
+      }
+
+      // Last stop before the write — every append above has happened by now.
+      const statusMessage: string | undefined = completed["statusMessage"] as
+        | string
+        | undefined;
+      if (statusMessage && statusMessage.length > MAX_STATUS_MESSAGE_LENGTH) {
+        completed["statusMessage"] = statusMessage.substring(
+          0,
+          MAX_STATUS_MESSAGE_LENGTH,
+        );
       }
 
       await NetworkDeviceDiscoveryScanService.updateOneById({

--- a/App/Tests/Dashboard/DiscoveryScanOutcome.test.ts
+++ b/App/Tests/Dashboard/DiscoveryScanOutcome.test.ts
@@ -1,0 +1,242 @@
+import {
+  DiscoveryScanOutcome,
+  countPingOnlyHosts,
+  getDiscoveredHosts,
+  summarizeDiscoveryScan,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveryScanOutcome";
+import NetworkDeviceDiscoveryScan, {
+  DiscoveredNetworkDevice,
+} from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The Discovery scans list is where "SNMP Discovery Scan finds 0 of N hosts"
+ * is diagnosed or not diagnosed. Before this, the cell rendered one number —
+ * respondedHostCount, which counts SNMP responders only — so all of these
+ * looked exactly the same to an operator:
+ *
+ *   - an empty /24 with nothing on it
+ *   - a /24 the probe has no route to
+ *   - a /24 where ICMP is filtered, so every SNMP probe was skipped
+ *   - a /24 full of devices that rejected the scan's credentials
+ *
+ * and the probe's own explanation of the sweep was fetched by the page and
+ * dropped on the floor. These tests pin the reading of a scan row that keeps
+ * those cases distinguishable.
+ */
+
+function makeScan(
+  overrides?: Partial<NetworkDeviceDiscoveryScan>,
+): NetworkDeviceDiscoveryScan {
+  return {
+    cidr: "10.244.102.0/24",
+    status: "Completed",
+    respondedHostCount: 0,
+    scannedHostCount: 254,
+    discoveredDevices: [],
+    ...overrides,
+  } as unknown as NetworkDeviceDiscoveryScan;
+}
+
+function host(
+  overrides: Partial<DiscoveredNetworkDevice>,
+): DiscoveredNetworkDevice {
+  return { ipAddress: "10.0.0.1", ...overrides } as DiscoveredNetworkDevice;
+}
+
+describe("getDiscoveredHosts", () => {
+  test("returns the stored hosts", () => {
+    const hosts: Array<DiscoveredNetworkDevice> = [
+      host({ ipAddress: "10.0.0.5", snmpReachable: true }),
+    ];
+
+    expect(getDiscoveredHosts(makeScan({ discoveredDevices: hosts }))).toEqual(
+      hosts,
+    );
+  });
+
+  test("an unreported scan has no hosts", () => {
+    expect(
+      getDiscoveredHosts(makeScan({ discoveredDevices: undefined } as never)),
+    ).toEqual([]);
+  });
+
+  test("null and undefined scans are empty rather than a throw", () => {
+    expect(getDiscoveredHosts(null)).toEqual([]);
+    expect(getDiscoveredHosts(undefined)).toEqual([]);
+  });
+
+  /*
+   * discoveredDevices is a jsonb column fed straight from a probe payload, so
+   * a row written by a different probe version (or by hand) can hold a
+   * non-array. Rendering a table cell must not be the thing that discovers
+   * that.
+   */
+  test("a non-array column value is treated as no results, not a crash", () => {
+    for (const badValue of [{}, "hosts", 7, true]) {
+      expect(
+        getDiscoveredHosts(makeScan({ discoveredDevices: badValue as never })),
+      ).toEqual([]);
+    }
+  });
+});
+
+describe("countPingOnlyHosts", () => {
+  test("counts hosts that answered ICMP but not SNMP", () => {
+    const scan: NetworkDeviceDiscoveryScan = makeScan({
+      discoveredDevices: [
+        host({ ipAddress: "10.0.0.1", snmpReachable: false }),
+        host({ ipAddress: "10.0.0.2", snmpReachable: true }),
+        host({ ipAddress: "10.0.0.3", snmpReachable: false }),
+      ],
+    });
+
+    expect(countPingOnlyHosts(scan)).toBe(2);
+  });
+
+  /*
+   * Same rule as isImportableDiscoveredHost: scans stored before the field
+   * existed carry undefined, and every host on those scans answered SNMP.
+   * Counting them as ping-only would invent a "+ N alive without SNMP" line
+   * on historical scans that never had one.
+   */
+  test("legacy hosts with no snmpReachable field are not ping-only", () => {
+    const scan: NetworkDeviceDiscoveryScan = makeScan({
+      discoveredDevices: [
+        host({ ipAddress: "10.0.0.1" }),
+        host({ ipAddress: "10.0.0.2" }),
+      ],
+    });
+
+    expect(countPingOnlyHosts(scan)).toBe(0);
+  });
+
+  test("a sweep that found nothing has no ping-only hosts", () => {
+    expect(countPingOnlyHosts(makeScan())).toBe(0);
+  });
+});
+
+describe("summarizeDiscoveryScan — the responder summary", () => {
+  test("renders responders over hosts swept", () => {
+    const outcome: DiscoveryScanOutcome = summarizeDiscoveryScan(
+      makeScan({ respondedHostCount: 12, scannedHostCount: 254 }),
+    );
+
+    expect(outcome.respondedHostSummary).toBe("12 of 254 hosts");
+  });
+
+  /*
+   * Zero responders is a finding and must render as one — this is literally
+   * the cell in the bug report.
+   */
+  test("zero responders still renders a summary", () => {
+    expect(
+      summarizeDiscoveryScan(makeScan({ respondedHostCount: 0 }))
+        .respondedHostSummary,
+    ).toBe("0 of 254 hosts");
+  });
+
+  test("a scan that has not reported yet gets no summary at all", () => {
+    expect(
+      summarizeDiscoveryScan(
+        makeScan({
+          status: "In Progress",
+          respondedHostCount: undefined,
+        } as never),
+      ).respondedHostSummary,
+    ).toBeNull();
+
+    expect(
+      summarizeDiscoveryScan(makeScan({ respondedHostCount: null } as never))
+        .respondedHostSummary,
+    ).toBeNull();
+  });
+
+  test("an unknown sweep size is marked unknown rather than guessed", () => {
+    expect(
+      summarizeDiscoveryScan(
+        makeScan({
+          respondedHostCount: 3,
+          scannedHostCount: undefined,
+        } as never),
+      ).respondedHostSummary,
+    ).toBe("3 of ? hosts");
+  });
+
+  test("null and undefined scans summarize to nothing", () => {
+    expect(summarizeDiscoveryScan(null).respondedHostSummary).toBeNull();
+    expect(summarizeDiscoveryScan(undefined).respondedHostSummary).toBeNull();
+  });
+});
+
+describe("summarizeDiscoveryScan — keeping a zero from reading as an empty network", () => {
+  /*
+   * The case the bug report screenshots show: the responder count is 0, but
+   * the sweep did find live hosts. Without the second line the operator
+   * concludes the subnet is empty and stops looking.
+   */
+  test("surfaces live-but-unmanaged hosts behind a zero responder count", () => {
+    const outcome: DiscoveryScanOutcome = summarizeDiscoveryScan(
+      makeScan({
+        respondedHostCount: 0,
+        discoveredDevices: [
+          host({ ipAddress: "10.244.102.11", snmpReachable: false }),
+          host({ ipAddress: "10.244.102.12", snmpReachable: false }),
+        ],
+      }),
+    );
+
+    expect(outcome.respondedHostSummary).toBe("0 of 254 hosts");
+    expect(outcome.pingOnlyHostCount).toBe(2);
+  });
+
+  test("a genuinely empty sweep reports zero of both", () => {
+    const outcome: DiscoveryScanOutcome = summarizeDiscoveryScan(makeScan());
+
+    expect(outcome.respondedHostSummary).toBe("0 of 254 hosts");
+    expect(outcome.pingOnlyHostCount).toBe(0);
+  });
+});
+
+describe("summarizeDiscoveryScan — the probe's explanation", () => {
+  /*
+   * statusMessage was already being written by the probe, stored by the
+   * server and selected by the page. It was simply never rendered, which is
+   * why a scan reporting zero came with no reason attached.
+   */
+  test("carries the probe's status message through", () => {
+    expect(
+      summarizeDiscoveryScan(
+        makeScan({
+          statusMessage:
+            "Swept 254 hosts: 0 answered ICMP ping, 0 answered SNMP.",
+        }),
+      ).explanation,
+    ).toBe("Swept 254 hosts: 0 answered ICMP ping, 0 answered SNMP.");
+  });
+
+  test("a failed scan's reason is an explanation like any other", () => {
+    expect(
+      summarizeDiscoveryScan(
+        makeScan({
+          status: "Failed",
+          statusMessage:
+            'SNMP v3 privacy protocol "aes-256" is not a recognized value.',
+        }),
+      ).explanation,
+    ).toContain("not a recognized value");
+  });
+
+  test("an empty message is no explanation, not an empty one", () => {
+    expect(
+      summarizeDiscoveryScan(makeScan({ statusMessage: "" })).explanation,
+    ).toBeNull();
+  });
+
+  test("a scan from an older probe simply has no explanation", () => {
+    expect(
+      summarizeDiscoveryScan(makeScan({ statusMessage: undefined } as never))
+        .explanation,
+    ).toBeNull();
+  });
+});

--- a/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
+++ b/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
@@ -664,6 +664,51 @@ describe("POST /probe/discovery-scan/result", () => {
     );
   });
 
+  /*
+   * statusMessage is a varchar(500). Postgres rejects an over-long value
+   * rather than truncating it, and that rejection would fail this write —
+   * losing the sweep's results and leaving a finished scan In Progress until
+   * the stale-scan reaper notices. Clip instead.
+   */
+  test("an over-long status message is clipped instead of failing the write", async () => {
+    scanService.findOneBy.mockResolvedValue(makeFoundScan() as never);
+
+    await callResultEndpoint(
+      makeRequest({
+        probeId,
+        body: {
+          scanId: scanId.toString(),
+          statusMessage: "S".repeat(900),
+          discoveredDevices: [],
+        },
+      }),
+    );
+
+    const message: string = lastUpdateData()["statusMessage"] as string;
+    expect(message).toHaveLength(500);
+    // Still the probe's message, just shorter.
+    expect(message.startsWith("SSS")).toBe(true);
+  });
+
+  test("a message that fits is stored verbatim", async () => {
+    scanService.findOneBy.mockResolvedValue(makeFoundScan() as never);
+
+    await callResultEndpoint(
+      makeRequest({
+        probeId,
+        body: {
+          scanId: scanId.toString(),
+          statusMessage: "Swept 254 hosts: 12 answered ICMP ping.",
+          discoveredDevices: [],
+        },
+      }),
+    );
+
+    expect(lastUpdateData()["statusMessage"]).toBe(
+      "Swept 254 hosts: 12 answered ICMP ping.",
+    );
+  });
+
   test("a one-time scan gets no nextScanAt", async () => {
     scanService.findOneBy.mockResolvedValue(makeFoundScan() as never);
 

--- a/Common/Utils/NetworkDiscovery/ScanTargetUtil.ts
+++ b/Common/Utils/NetworkDiscovery/ScanTargetUtil.ts
@@ -63,12 +63,14 @@ export class ScanTargetUtil {
    *
    * The number is a wall-clock budget, not a memory one. SubnetScanner runs 32
    * workers; a dead host costs ~1s (the ICMP pre-sweep timeout), or ~2s when
-   * the pre-sweep is unavailable and every host is SNMP-probed directly. At
-   * this ceiling that is ~17 minutes with the pre-sweep and ~34 minutes
-   * without — both comfortably inside the 2-hour window after which the server
-   * declares an In Progress scan abandoned (Workers/Jobs/
-   * NetworkDeviceDiscovery/RequeueRecurringScans.ts) and safely above the
-   * 15-minute minimum rescan interval for recurring scans.
+   * every host is SNMP-probed directly. At this ceiling that is ~17 minutes
+   * for a sweep the ICMP gate resolves, ~34 minutes when the pre-sweep is
+   * unavailable, and ~51 minutes in the worst case — an ICMP pass that finds
+   * no SNMP responder, so every address is re-probed over SNMP as well (see
+   * the ICMP-filtered fallback in SubnetScanner.scan). All three sit inside
+   * the 2-hour window after which the server declares an In Progress scan
+   * abandoned (Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts)
+   * and above the 15-minute minimum rescan interval for recurring scans.
    *
    * It is also still a real abuse guard: a /17 in CIDR terms. Anything larger
    * (a /16 sweep, an unbounded 10.*.*.* octet range) is rejected at write time

--- a/Probe/Jobs/Discovery/FetchScans.ts
+++ b/Probe/Jobs/Discovery/FetchScans.ts
@@ -2,7 +2,7 @@ import { PROBE_INGEST_URL } from "../../Config";
 import ProbeAPIRequest from "../../Utils/ProbeAPIRequest";
 import SubnetScanner, {
   DiscoveredHost,
-  SubnetScanResult,
+  type SubnetScanResult,
 } from "../../Utils/Discovery/SubnetScanner";
 import BaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
@@ -86,6 +86,72 @@ export function buildSnmpV3Auth(
     privProtocol: SnmpPrivProtocolUtil.parse(scan.snmpV3PrivProtocol),
     privKey: scan.snmpV3PrivKey || undefined,
   };
+}
+
+/*
+ * The operator-facing summary of one sweep.
+ *
+ * Exported for tests: every "the scan found nothing" support case is decided
+ * by whether this sentence names the reason, so its content is asserted
+ * rather than left to chance.
+ */
+export function buildScanStatusMessage(
+  scanResult: SubnetScanResult,
+  snmpResponderCount: number,
+): string {
+  const parts: Array<string> = [];
+
+  if (scanResult.respondedToPingCount !== undefined) {
+    parts.push(
+      `Swept ${scanResult.scannedHostCount} hosts: ` +
+        `${scanResult.respondedToPingCount} answered ICMP ping, ` +
+        `${snmpResponderCount} answered SNMP.`,
+    );
+  } else {
+    parts.push(
+      `Swept ${scanResult.scannedHostCount} hosts via SNMP ` +
+        `(ICMP pre-sweep unavailable on this probe): ` +
+        `${snmpResponderCount} answered SNMP.`,
+    );
+  }
+
+  /*
+   * Say so when the ICMP gate was overridden. Otherwise the scan looks like
+   * it took the fast path, and the operator has no hint that echo is being
+   * dropped on the segment they are scanning.
+   */
+  if ((scanResult.icmpFilteredFallbackHostCount || 0) > 0) {
+    parts.push(
+      `No host answered SNMP among those that replied to ICMP, so all ` +
+        `${scanResult.icmpFilteredFallbackHostCount} ICMP-silent hosts were probed over SNMP as well ` +
+        `(ICMP is likely filtered on this network).`,
+    );
+  }
+
+  /*
+   * The actionable half. A device that returns "Authentication failure" is
+   * reachable and speaking SNMP — the scan's credentials are simply wrong for
+   * it, which is a completely different fix from "the probe cannot see this
+   * subnet", and until now both showed up as an empty result.
+   */
+  const snmpErrorHostCount: number = scanResult.snmpErrorHostCount || 0;
+
+  if (snmpErrorHostCount > 0 && scanResult.mostCommonSnmpError) {
+    parts.push(
+      `${snmpErrorHostCount} host(s) replied with an SNMP error rather than silence; ` +
+        `most common: ${scanResult.mostCommonSnmpError}`,
+    );
+  }
+
+  if (snmpResponderCount === 0 && snmpErrorHostCount === 0) {
+    const port: number = scanResult.scannedPort || 161;
+    parts.push(
+      `Nothing answered SNMP on port ${port}. Check that this probe can reach the range, ` +
+        `that UDP/${port} is permitted to it, and that the devices' SNMP ACL allows the probe's IP address.`,
+    );
+  }
+
+  return parts.join(" ");
 }
 
 /*
@@ -217,18 +283,20 @@ export async function runScan(scan: NetworkDeviceDiscoveryScan): Promise<void> {
   ).length;
 
   /*
-   * The scan model has no column for the ICMP pre-sweep count, so it rides
+   * The scan model has no column for the sweep's diagnostics, so they ride
    * along in statusMessage (which the ingest endpoint already accepts)
-   * instead of a payload field the server would silently drop.
+   * instead of payload fields the server would silently drop.
+   *
+   * This is the only explanation an operator gets for a scan that found
+   * nothing, so it has to distinguish the cases that look identical in the
+   * "0 of 254 hosts" column: an empty subnet, a subnet the probe cannot
+   * reach, a subnet where ICMP is filtered, and a subnet full of devices
+   * that rejected the scan's credentials.
    */
-  const statusMessage: string =
-    scanResult.respondedToPingCount !== undefined
-      ? `Swept ${scanResult.scannedHostCount} hosts: ` +
-        `${scanResult.respondedToPingCount} answered ICMP ping, ` +
-        `${snmpResponderCount} answered SNMP.`
-      : `Swept ${scanResult.scannedHostCount} hosts via SNMP ` +
-        `(ICMP pre-sweep unavailable on this probe): ` +
-        `${snmpResponderCount} answered SNMP.`;
+  const statusMessage: string = buildScanStatusMessage(
+    scanResult,
+    snmpResponderCount,
+  );
 
   /*
    * The RESULT UPLOAD failing must NOT trigger the success:false report

--- a/Probe/Tests/Jobs/Discovery/DiscoveryScanEndToEnd.test.ts
+++ b/Probe/Tests/Jobs/Discovery/DiscoveryScanEndToEnd.test.ts
@@ -1,0 +1,283 @@
+// Set required env vars before importing modules that pull in Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.example.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONObject } from "Common/Types/JSON";
+import API from "Common/Utils/API";
+import SubnetScanner from "../../../Utils/Discovery/SubnetScanner";
+import SnmpMonitor from "../../../Utils/Monitors/MonitorTypes/SnmpMonitor";
+import MonitorStepSnmpMonitor from "Common/Types/Monitor/MonitorStepSnmpMonitor";
+import { runScan } from "../../../Jobs/Discovery/FetchScans";
+
+/*
+ * github.com/OneUptime/oneuptime/issues/3078, end to end.
+ *
+ * Everything below the network is real: the actual SubnetScanner sweeps the
+ * actual target, the actual runScan assembles the actual report. Only the two
+ * things that would touch a wire are stubbed — ICMP echo and the SNMP probe —
+ * so these tests describe a network rather than a set of return values, and a
+ * regression anywhere between "the segment drops echo" and "what the operator
+ * reads in the scans list" fails here.
+ */
+
+const scanId: ObjectID = ObjectID.generate();
+
+function makeScan(overrides?: JSONObject): NetworkDeviceDiscoveryScan {
+  return {
+    id: scanId,
+    // Six addresses: 10.244.102.1 .. 10.244.102.6.
+    cidr: "10.244.102.0/29",
+    snmpVersion: "V3",
+    snmpV3Username: "WBNOC",
+    snmpV3SecurityLevel: "authPriv",
+    snmpV3AuthProtocol: "sha",
+    snmpV3AuthKey: "auth-passphrase",
+    snmpV3PrivProtocol: "des",
+    snmpV3PrivKey: "priv-passphrase",
+    snmpPort: 161,
+    ...overrides,
+  } as unknown as NetworkDeviceDiscoveryScan;
+}
+
+// eslint-disable-next-line @typescript-eslint/typedef
+let fetchSpy = jest.spyOn(API, "fetch");
+
+beforeEach(() => {
+  fetchSpy = jest.spyOn(API, "fetch").mockResolvedValue({ data: [] } as never);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function reportedResult(): JSONObject {
+  const call: Array<unknown> = fetchSpy.mock.calls[0] as Array<unknown>;
+  return (call[0] as JSONObject)["data"] as JSONObject;
+}
+
+function reportedDevices(): Array<JSONObject> {
+  return (reportedResult()["discoveredDevices"] as Array<JSONObject>) || [];
+}
+
+function reportedMessage(): string {
+  return String(reportedResult()["statusMessage"] || "");
+}
+
+/*
+ * A network where echo is dropped at the firewall but UDP/161 is permitted to
+ * the NMS — the ordinary shape of a management VLAN, and the shape that used
+ * to scan as a confident zero.
+ */
+function networkWhereIcmpIsFilteredAndSnmpWorks(
+  snmpSpeakers: Array<string>,
+): void {
+  jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(false);
+  jest
+    .spyOn(SnmpMonitor, "probeSystemInfo")
+    .mockImplementation(async (config: MonitorStepSnmpMonitor) => {
+      if (snmpSpeakers.includes(config.hostname || "")) {
+        return { sysName: `sw-${config.hostname}`, sysDescr: "Cisco IOS" };
+      }
+      return null;
+    });
+}
+
+describe("discovery on a subnet where ICMP is filtered", () => {
+  test("the devices are found and reported, not silently dropped", async () => {
+    networkWhereIcmpIsFilteredAndSnmpWorks(["10.244.102.2", "10.244.102.5"]);
+
+    await runScan(makeScan());
+
+    const devices: Array<JSONObject> = reportedDevices();
+    expect(
+      devices.map((device: JSONObject) => {
+        return device["ipAddress"];
+      }),
+    ).toEqual(["10.244.102.2", "10.244.102.5"]);
+    expect(devices[0]!["sysName"]).toBe("sw-10.244.102.2");
+    expect(devices[0]!["snmpReachable"]).toBe(true);
+  });
+
+  test("the report is a success with the full sweep size", async () => {
+    networkWhereIcmpIsFilteredAndSnmpWorks(["10.244.102.2"]);
+
+    await runScan(makeScan());
+
+    expect(reportedResult()["success"]).toBe(true);
+    expect(reportedResult()["scannedHostCount"]).toBe(6);
+  });
+
+  test("the status message tells the operator ICMP is being filtered", async () => {
+    networkWhereIcmpIsFilteredAndSnmpWorks(["10.244.102.2"]);
+
+    await runScan(makeScan());
+
+    expect(reportedMessage()).toContain("0 answered ICMP ping");
+    expect(reportedMessage()).toContain("1 answered SNMP");
+    expect(reportedMessage()).toContain("ICMP is likely filtered");
+  });
+});
+
+describe("discovery on a subnet whose devices reject the credentials", () => {
+  /*
+   * The other half of the reported symptom. Every host answers, every host
+   * refuses the v3 user — which used to be indistinguishable from an empty
+   * subnet because the errors were swallowed by a debug log.
+   */
+  test("names the rejection instead of reporting an empty subnet", async () => {
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(true);
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockImplementation(
+        async (
+          _config: MonitorStepSnmpMonitor,
+          onError?: ((error: unknown) => void) | undefined,
+        ) => {
+          onError?.(new Error("Authentication failure"));
+          return null;
+        },
+      );
+
+    await runScan(makeScan());
+
+    expect(reportedMessage()).toContain("6 host(s) replied with an SNMP error");
+    expect(reportedMessage()).toContain("Authentication failure");
+    // The hosts are alive, so they are still reported — just not importable.
+    expect(reportedDevices()).toHaveLength(6);
+    expect(reportedDevices()[0]!["snmpReachable"]).toBe(false);
+  });
+
+  test("both problems at once are both reported", async () => {
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(false);
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockImplementation(
+        async (
+          _config: MonitorStepSnmpMonitor,
+          onError?: ((error: unknown) => void) | undefined,
+        ) => {
+          onError?.(new Error("Unknown user name"));
+          return null;
+        },
+      );
+
+    await runScan(makeScan());
+
+    expect(reportedMessage()).toContain("ICMP is likely filtered");
+    expect(reportedMessage()).toContain("Unknown user name");
+  });
+});
+
+describe("discovery on a subnet the probe cannot reach at all", () => {
+  /*
+   * Nothing replies to anything. There is no error to quote, so the message
+   * has to be the checklist — otherwise the operator's only output is a zero.
+   */
+  test("says what to check rather than just reporting nothing", async () => {
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(false);
+    jest.spyOn(SnmpMonitor, "probeSystemInfo").mockResolvedValue(null);
+
+    await runScan(makeScan());
+
+    expect(reportedDevices()).toHaveLength(0);
+    expect(reportedMessage()).toContain("Nothing answered SNMP on port 161");
+    expect(reportedMessage()).toContain("SNMP ACL allows the probe's IP");
+  });
+
+  test("names a non-default port when the scan used one", async () => {
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(false);
+    jest.spyOn(SnmpMonitor, "probeSystemInfo").mockResolvedValue(null);
+
+    await runScan(makeScan({ snmpPort: 1610 }));
+
+    expect(reportedMessage()).toContain("port 1610");
+  });
+});
+
+describe("discovery on a healthy subnet", () => {
+  /*
+   * The fast path must stay fast: when echo works and devices answer, the
+   * hosts that did not reply to ICMP are never SNMP-probed at all.
+   */
+  test("skips SNMP for ICMP-silent hosts and keeps the summary short", async () => {
+    const probed: Array<string> = [];
+
+    jest
+      .spyOn(SubnetScanner, "isHostAliveByPing")
+      .mockImplementation(async (host: string) => {
+        return ["10.244.102.2", "10.244.102.3"].includes(host);
+      });
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockImplementation(async (config: MonitorStepSnmpMonitor) => {
+        probed.push(config.hostname || "");
+        return { sysName: `sw-${config.hostname}` };
+      });
+
+    await runScan(makeScan());
+
+    expect([...probed].sort()).toEqual(["10.244.102.2", "10.244.102.3"]);
+    expect(reportedMessage()).toBe(
+      "Swept 6 hosts: 2 answered ICMP ping, 2 answered SNMP.",
+    );
+  });
+
+  test("mixed SNMP and ping-only hosts are both reported, and told apart", async () => {
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(true);
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockImplementation(async (config: MonitorStepSnmpMonitor) => {
+        return config.hostname === "10.244.102.4"
+          ? { sysName: "sw-core" }
+          : null;
+      });
+
+    await runScan(makeScan());
+
+    const devices: Array<JSONObject> = reportedDevices();
+    expect(devices).toHaveLength(6);
+    expect(
+      devices.filter((device: JSONObject) => {
+        return device["snmpReachable"] === true;
+      }),
+    ).toHaveLength(1);
+    expect(reportedMessage()).toBe(
+      "Swept 6 hosts: 6 answered ICMP ping, 1 answered SNMP.",
+    );
+  });
+});
+
+describe("a sweep that cannot run at all", () => {
+  /*
+   * Unrelated to reachability: a scan-wide misconfiguration must fail the
+   * scan up front rather than sweep with the wrong settings and report a
+   * confident zero.
+   */
+  test("an unreadable v3 privacy protocol fails the scan with its reason", async () => {
+    await runScan(makeScan({ snmpV3PrivProtocol: "aes-256-gcm" }));
+
+    expect(reportedResult()["success"]).toBe(false);
+    expect(String(reportedResult()["statusMessage"])).toContain("aes-256-gcm");
+    expect(reportedResult()["discoveredDevices"]).toEqual([]);
+  });
+
+  test("a target that is too large fails rather than sweeping a subset", async () => {
+    await runScan(makeScan({ cidr: "10.0.0.0/8" }));
+
+    expect(reportedResult()["success"]).toBe(false);
+    expect(String(reportedResult()["statusMessage"])).toContain(
+      "exceeding the",
+    );
+  });
+});

--- a/Probe/Tests/Jobs/Discovery/DiscoveryScanStatusMessage.test.ts
+++ b/Probe/Tests/Jobs/Discovery/DiscoveryScanStatusMessage.test.ts
@@ -1,0 +1,302 @@
+// Set required env vars before importing modules that pull in Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.example.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+
+import { buildScanStatusMessage } from "../../../Jobs/Discovery/FetchScans";
+import { SubnetScanResult } from "../../../Utils/Discovery/SubnetScanner";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The scan's status message is the entire diagnosis surface for a discovery
+ * sweep. Four completely different situations all render as "0 of N hosts" in
+ * the scans list:
+ *
+ *   1. the address range really is empty
+ *   2. the probe cannot route to the range at all
+ *   3. ICMP is filtered on the segment, so the pre-sweep saw nothing alive
+ *   4. the devices are there and answered, but rejected the credentials
+ *
+ * Nothing else in the product distinguishes them, so each branch below is
+ * asserted rather than left to whatever the string happens to say.
+ */
+
+// statusMessage is a varchar(500); Postgres throws rather than truncating.
+const STATUS_MESSAGE_COLUMN_LENGTH: number = 500;
+
+function makeResult(overrides?: Partial<SubnetScanResult>): SubnetScanResult {
+  return {
+    discoveredHosts: [],
+    scannedHostCount: 254,
+    scannedPort: 161,
+    respondedToPingCount: 0,
+    snmpErrorHostCount: 0,
+    mostCommonSnmpError: undefined,
+    icmpFilteredFallbackHostCount: 0,
+    ...overrides,
+  } as SubnetScanResult;
+}
+
+describe("buildScanStatusMessage — the headline", () => {
+  test("reports the ICMP and SNMP tallies when the pre-sweep ran", () => {
+    const message: string = buildScanStatusMessage(
+      makeResult({ respondedToPingCount: 12 }),
+      3,
+    );
+
+    expect(message).toContain(
+      "Swept 254 hosts: 12 answered ICMP ping, 3 answered SNMP.",
+    );
+  });
+
+  /*
+   * A count from a sweep that only half ran would be a lie, so SubnetScanner
+   * reports undefined and the message must say why there is no ICMP number
+   * rather than printing "undefined answered ICMP ping".
+   */
+  test("says the pre-sweep was unavailable instead of printing a missing count", () => {
+    const message: string = buildScanStatusMessage(
+      makeResult({ respondedToPingCount: undefined }),
+      3,
+    );
+
+    expect(message).toContain("ICMP pre-sweep unavailable on this probe");
+    expect(message).toContain("3 answered SNMP.");
+    expect(message).not.toContain("undefined");
+  });
+
+  test("a zero ICMP count is reported, not omitted", () => {
+    expect(
+      buildScanStatusMessage(makeResult({ respondedToPingCount: 0 }), 0),
+    ).toContain("0 answered ICMP ping, 0 answered SNMP.");
+  });
+});
+
+describe("buildScanStatusMessage — the ICMP-filtered subnet", () => {
+  /*
+   * This is the reported bug. A management VLAN that drops echo but permits
+   * UDP/161 used to scan as a confident zero. The scanner now re-probes the
+   * ICMP-silent hosts; the message has to say that happened, or the operator
+   * still has no idea echo is being dropped on that segment.
+   */
+  test("names the override and points at ICMP filtering", () => {
+    const message: string = buildScanStatusMessage(
+      makeResult({
+        respondedToPingCount: 0,
+        icmpFilteredFallbackHostCount: 254,
+      }),
+      0,
+    );
+
+    expect(message).toContain("254 ICMP-silent hosts were probed over SNMP");
+    expect(message).toContain("ICMP is likely filtered on this network");
+  });
+
+  test("still names it when the fallback is what found the devices", () => {
+    const message: string = buildScanStatusMessage(
+      makeResult({
+        respondedToPingCount: 0,
+        icmpFilteredFallbackHostCount: 254,
+      }),
+      7,
+    );
+
+    expect(message).toContain("7 answered SNMP.");
+    expect(message).toContain("ICMP is likely filtered on this network");
+  });
+
+  test("stays quiet on a sweep the ICMP gate resolved normally", () => {
+    const message: string = buildScanStatusMessage(
+      makeResult({
+        respondedToPingCount: 12,
+        icmpFilteredFallbackHostCount: 0,
+      }),
+      3,
+    );
+
+    expect(message).not.toContain("ICMP-silent");
+    expect(message).not.toContain("likely filtered");
+  });
+});
+
+describe("buildScanStatusMessage — credentials rejected", () => {
+  /*
+   * A device answering "Authentication failure" is reachable and speaking
+   * SNMP; the scan's credentials are simply wrong for it. That is a different
+   * fix from "the probe cannot see this subnet", and both used to render as
+   * an empty result.
+   */
+  test("counts the rejections and quotes the most common one", () => {
+    const message: string = buildScanStatusMessage(
+      makeResult({
+        snmpErrorHostCount: 11,
+        mostCommonSnmpError: "Authentication failure",
+      }),
+      0,
+    );
+
+    expect(message).toContain("11 host(s) replied with an SNMP error");
+    expect(message).toContain("most common: Authentication failure");
+  });
+
+  test("a rejection tally without a message says nothing rather than 'undefined'", () => {
+    const message: string = buildScanStatusMessage(
+      makeResult({ snmpErrorHostCount: 4, mostCommonSnmpError: undefined }),
+      0,
+    );
+
+    expect(message).not.toContain("undefined");
+    expect(message).not.toContain("replied with an SNMP error");
+  });
+
+  test("reports rejections even on a sweep that also found devices", () => {
+    const message: string = buildScanStatusMessage(
+      makeResult({
+        respondedToPingCount: 20,
+        snmpErrorHostCount: 5,
+        mostCommonSnmpError: "Unknown user name",
+      }),
+      15,
+    );
+
+    expect(message).toContain("15 answered SNMP.");
+    expect(message).toContain("most common: Unknown user name");
+  });
+});
+
+describe("buildScanStatusMessage — nothing answered at all", () => {
+  /*
+   * Silence everywhere means the probe never got a reply of any kind. There
+   * is no error to quote, so the message has to be the checklist instead —
+   * otherwise the only output is a bare zero.
+   */
+  test("names the port and what to check", () => {
+    const message: string = buildScanStatusMessage(makeResult(), 0);
+
+    expect(message).toContain("Nothing answered SNMP on port 161");
+    expect(message).toContain("this probe can reach the range");
+    expect(message).toContain("UDP/161 is permitted");
+    expect(message).toContain("SNMP ACL allows the probe's IP address");
+  });
+
+  test("names the non-default port a scan actually used", () => {
+    const message: string = buildScanStatusMessage(
+      makeResult({ scannedPort: 1610 }),
+      0,
+    );
+
+    expect(message).toContain("Nothing answered SNMP on port 1610");
+    expect(message).toContain("UDP/1610");
+  });
+
+  /*
+   * Defensive: a result from an older probe carries no scannedPort. Naming
+   * "port undefined" in the one message meant to tell an operator what to
+   * check would be worse than useless.
+   */
+  test("falls back to the SNMP default when the probe sent no port", () => {
+    const message: string = buildScanStatusMessage(
+      makeResult({ scannedPort: undefined } as never),
+      0,
+    );
+
+    expect(message).toContain("port 161");
+    expect(message).not.toContain("undefined");
+  });
+
+  test("gives way to the concrete error when there is one", () => {
+    const message: string = buildScanStatusMessage(
+      makeResult({
+        snmpErrorHostCount: 2,
+        mostCommonSnmpError: "Authentication failure",
+      }),
+      0,
+    );
+
+    // The rejection is the diagnosis; the generic checklist would only dilute it.
+    expect(message).not.toContain("Nothing answered SNMP on port");
+  });
+
+  test("stays away from a sweep that found devices", () => {
+    expect(
+      buildScanStatusMessage(makeResult({ respondedToPingCount: 12 }), 1),
+    ).not.toContain("Nothing answered SNMP on port");
+  });
+});
+
+describe("buildScanStatusMessage — fits the column it is stored in", () => {
+  /*
+   * The message goes into a varchar(500). Postgres rejects an over-long value
+   * rather than truncating it, and that rejection fails the whole result
+   * write — losing the sweep's hosts and stranding the scan In Progress. The
+   * server clips defensively too, but the probe must not depend on that.
+   */
+  test("the worst realistic combination still fits", () => {
+    const message: string = buildScanStatusMessage(
+      makeResult({
+        scannedHostCount: 32768,
+        respondedToPingCount: 32768,
+        icmpFilteredFallbackHostCount: 32768,
+        snmpErrorHostCount: 32768,
+        // The scanner's own excerpt cap for a quoted SNMP error.
+        mostCommonSnmpError: "E".repeat(120),
+      }),
+      32768,
+    );
+
+    expect(message.length).toBeLessThanOrEqual(STATUS_MESSAGE_COLUMN_LENGTH);
+  });
+
+  test("every single-branch message is comfortably short", () => {
+    const results: Array<SubnetScanResult> = [
+      makeResult(),
+      makeResult({ respondedToPingCount: undefined }),
+      makeResult({ icmpFilteredFallbackHostCount: 32768 }),
+      makeResult({
+        snmpErrorHostCount: 32768,
+        mostCommonSnmpError: "E".repeat(120),
+      }),
+    ];
+
+    for (const result of results) {
+      expect(buildScanStatusMessage(result, 0).length).toBeLessThanOrEqual(
+        STATUS_MESSAGE_COLUMN_LENGTH,
+      );
+    }
+  });
+});
+
+describe("buildScanStatusMessage — results from an older probe", () => {
+  /*
+   * A probe is upgraded independently of the server it reports to, so the
+   * server-side builder has to survive a payload with none of the new fields
+   * rather than emitting "undefined" into the operator's only diagnostic.
+   */
+  test("a legacy result still produces the headline and nothing bogus", () => {
+    const legacy: SubnetScanResult = {
+      discoveredHosts: [],
+      scannedHostCount: 254,
+      respondedToPingCount: 12,
+    } as unknown as SubnetScanResult;
+
+    const message: string = buildScanStatusMessage(legacy, 3);
+
+    expect(message).toBe(
+      "Swept 254 hosts: 12 answered ICMP ping, 3 answered SNMP.",
+    );
+    expect(message).not.toContain("undefined");
+    expect(message).not.toContain("NaN");
+  });
+
+  test("a legacy result that found nothing still gets the checklist", () => {
+    const legacy: SubnetScanResult = {
+      discoveredHosts: [],
+      scannedHostCount: 254,
+      respondedToPingCount: 0,
+    } as unknown as SubnetScanResult;
+
+    expect(buildScanStatusMessage(legacy, 0)).toContain(
+      "Nothing answered SNMP on port 161",
+    );
+  });
+});

--- a/Probe/Tests/Jobs/Discovery/FetchScansLifecycle.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansLifecycle.test.ts
@@ -216,6 +216,98 @@ describe("runScan — a successful sweep", () => {
     );
   });
 
+  /*
+   * A sweep that finds nothing is the hardest discovery outcome to debug: an
+   * empty subnet, an unroutable one, one where ICMP is filtered, and one full
+   * of devices rejecting the scan's credentials all render as "0 of N hosts".
+   * The status message is the only place those are told apart, so its content
+   * is asserted rather than left to chance.
+   */
+  test("says so when the ICMP gate was overridden because nothing answered SNMP", async () => {
+    scanSpy.mockResolvedValue(
+      makeScanResult({
+        discoveredHosts: [],
+        respondedToPingCount: 3,
+        icmpFilteredFallbackHostCount: 251,
+      }) as never,
+    );
+
+    await runScan(makeScan());
+
+    const message: string = fetchCalls()[0]!.body["statusMessage"] as string;
+    expect(message).toContain("251 ICMP-silent hosts were probed over SNMP");
+    expect(message).toContain("ICMP is likely filtered");
+  });
+
+  test("names the SNMP error when hosts answered but rejected the credentials", async () => {
+    scanSpy.mockResolvedValue(
+      makeScanResult({
+        discoveredHosts: [],
+        snmpErrorHostCount: 7,
+        mostCommonSnmpError: "Authentication failure",
+      }) as never,
+    );
+
+    await runScan(makeScan());
+
+    const message: string = fetchCalls()[0]!.body["statusMessage"] as string;
+    expect(message).toContain("7 host(s) replied with an SNMP error");
+    expect(message).toContain("Authentication failure");
+  });
+
+  test("tells the operator what to check when nothing answered at all", async () => {
+    scanSpy.mockResolvedValue(
+      makeScanResult({
+        discoveredHosts: [],
+        respondedToPingCount: 0,
+        snmpErrorHostCount: 0,
+        scannedPort: 161,
+      }) as never,
+    );
+
+    await runScan(makeScan());
+
+    const message: string = fetchCalls()[0]!.body["statusMessage"] as string;
+    expect(message).toContain("Nothing answered SNMP on port 161");
+    expect(message).toContain("UDP/161");
+    expect(message).toContain("SNMP ACL");
+  });
+
+  /*
+   * statusMessage is a varchar(500) and Postgres throws rather than truncates,
+   * which would fail the result write and strand a finished scan In Progress.
+   * The server clips defensively too, but the probe must not rely on that.
+   */
+  test("the summary stays within the statusMessage column even at its worst", async () => {
+    scanSpy.mockResolvedValue(
+      makeScanResult({
+        discoveredHosts: [],
+        scannedHostCount: 32768,
+        respondedToPingCount: 32768,
+        icmpFilteredFallbackHostCount: 32768,
+        snmpErrorHostCount: 32768,
+        mostCommonSnmpError: "E".repeat(120),
+      }) as never,
+    );
+
+    await runScan(makeScan());
+
+    const message: string = fetchCalls()[0]!.body["statusMessage"] as string;
+    expect(message.length).toBeLessThanOrEqual(500);
+  });
+
+  test("a sweep that found devices stays a one-line summary", async () => {
+    scanSpy.mockResolvedValue(
+      makeScanResult({ snmpErrorHostCount: 0 }) as never,
+    );
+
+    await runScan(makeScan());
+
+    expect(fetchCalls()[0]!.body["statusMessage"]).toBe(
+      "Swept 254 hosts: 12 answered ICMP ping, 1 answered SNMP.",
+    );
+  });
+
   test("builds v3 credentials from the scan's flattened snmpV3 columns", async () => {
     await runScan(
       makeScan({

--- a/Probe/Tests/Utils/Discovery/SubnetScanner.test.ts
+++ b/Probe/Tests/Utils/Discovery/SubnetScanner.test.ts
@@ -541,18 +541,202 @@ describe("SubnetScanner ping-only host recording", () => {
     expect(result.discoveredHosts).toEqual([]);
   });
 
-  it("does not record ping-dead hosts at all", async () => {
+  /*
+   * The ICMP-silent hosts are re-probed (see the fallback tests below), but a
+   * host that answered neither ICMP nor SNMP is still not a discovery: there
+   * is no evidence anything is at that address.
+   */
+  it("does not record hosts that answered neither ICMP nor SNMP", async () => {
     jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(false);
-    // eslint-disable-next-line @typescript-eslint/typedef
-    const probeSpy = jest
-      .spyOn(SnmpMonitor, "probeSystemInfo")
-      .mockResolvedValue(null);
+    jest.spyOn(SnmpMonitor, "probeSystemInfo").mockResolvedValue(null);
 
     const result: Awaited<ReturnType<typeof SubnetScanner.scan>> =
       await SubnetScanner.scan({ cidr: TINY_CIDR });
 
     expect(result.discoveredHosts).toEqual([]);
-    expect(probeSpy).not.toHaveBeenCalled();
+  });
+});
+
+/*
+ * The regression this suite exists for.
+ *
+ * Gating SNMP on an ICMP reply is only an optimisation, and it silently
+ * deletes an entire subnet's worth of devices when echo is filtered — the
+ * normal configuration for a firewalled management VLAN, where UDP/161 is
+ * open to the NMS and ICMP is not. The symptom is a scan that reports
+ * "Completed, 0 of 254 hosts" on one VLAN while an adjacent VLAN that permits
+ * echo scans perfectly, with nothing anywhere to say why.
+ */
+describe("SubnetScanner ICMP-filtered subnet fallback", () => {
+  // A /29 sweeps six hosts: 10.0.0.1 .. 10.0.0.6.
+  const SMALL_CIDR: string = "10.0.0.0/29";
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("SNMP-probes ICMP-silent hosts when the ICMP-alive ones yield no SNMP responder", async () => {
+    const probed: Array<string> = [];
+
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(false);
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockImplementation(async (config: MonitorStepSnmpMonitor) => {
+        probed.push(config.hostname || "");
+        // Only this one device speaks SNMP; ICMP is filtered for all of them.
+        if (config.hostname === "10.0.0.4") {
+          return { sysName: "core-sw1", sysDescr: "Cisco IOS" };
+        }
+        return null;
+      });
+
+    const result: Awaited<ReturnType<typeof SubnetScanner.scan>> =
+      await SubnetScanner.scan({ cidr: SMALL_CIDR });
+
+    // Every address was SNMP-probed despite answering no ping at all.
+    expect([...probed].sort()).toEqual([
+      "10.0.0.1",
+      "10.0.0.2",
+      "10.0.0.3",
+      "10.0.0.4",
+      "10.0.0.5",
+      "10.0.0.6",
+    ]);
+    // The device that used to be invisible is now discovered.
+    expect(result.discoveredHosts).toEqual([
+      {
+        ipAddress: "10.0.0.4",
+        sysName: "core-sw1",
+        sysDescr: "Cisco IOS",
+        snmpReachable: true,
+      },
+    ]);
+    expect(result.respondedToPingCount).toBe(0);
+    expect(result.icmpFilteredFallbackHostCount).toBe(6);
+  });
+
+  it("keeps the fast path when the ICMP-alive hosts do answer SNMP", async () => {
+    const probed: Array<string> = [];
+
+    jest
+      .spyOn(SubnetScanner, "isHostAliveByPing")
+      .mockImplementation(async (host: string) => {
+        return host === "10.0.0.2";
+      });
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockImplementation(async (config: MonitorStepSnmpMonitor) => {
+        probed.push(config.hostname || "");
+        return { sysName: "sw1" };
+      });
+
+    const result: Awaited<ReturnType<typeof SubnetScanner.scan>> =
+      await SubnetScanner.scan({ cidr: SMALL_CIDR });
+
+    // One SNMP responder is enough: the other five keep their skipped 2s.
+    expect(probed).toEqual(["10.0.0.2"]);
+    expect(result.icmpFilteredFallbackHostCount).toBe(0);
+  });
+
+  it("does not re-probe hosts the first pass already covered", async () => {
+    const probed: Array<string> = [];
+
+    // Pre-sweep broken: the first pass already probes every host.
+    jest
+      .spyOn(SubnetScanner, "isHostAliveByPing")
+      .mockRejectedValue(new Error("ICMP sockets require elevated privileges"));
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockImplementation(async (config: MonitorStepSnmpMonitor) => {
+        probed.push(config.hostname || "");
+        return null;
+      });
+
+    const result: Awaited<ReturnType<typeof SubnetScanner.scan>> =
+      await SubnetScanner.scan({ cidr: SMALL_CIDR });
+
+    expect(probed).toHaveLength(6);
+    expect(new Set(probed).size).toBe(6);
+    expect(result.icmpFilteredFallbackHostCount).toBe(0);
+  });
+});
+
+/*
+ * "Returned null" used to cover both "nothing is at this address" (a timeout)
+ * and "the agent refused these credentials" (an auth failure). One credential
+ * set is applied to the whole sweep, so a single wrong v3 key blanks every
+ * host — and the scan reported a clean zero with no way to tell that apart
+ * from an empty subnet.
+ */
+describe("SubnetScanner SNMP error reporting", () => {
+  const TINY_CIDR: string = "10.0.0.0/31";
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function mockSnmpFailingWith(message: string): void {
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockImplementation(
+        async (
+          _config: MonitorStepSnmpMonitor,
+          onError?: ((error: unknown) => void) | undefined,
+        ) => {
+          onError?.(new Error(message));
+          return null;
+        },
+      );
+  }
+
+  it("counts and names the SNMP error hosts answered with", async () => {
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(true);
+    mockSnmpFailingWith("Authentication failure");
+
+    const result: Awaited<ReturnType<typeof SubnetScanner.scan>> =
+      await SubnetScanner.scan({ cidr: TINY_CIDR });
+
+    expect(result.snmpErrorHostCount).toBe(2);
+    expect(result.mostCommonSnmpError).toBe("Authentication failure");
+  });
+
+  it("ignores timeouts — an empty address is not a diagnosis", async () => {
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(true);
+    mockSnmpFailingWith("Request timed out");
+
+    const result: Awaited<ReturnType<typeof SubnetScanner.scan>> =
+      await SubnetScanner.scan({ cidr: TINY_CIDR });
+
+    expect(result.snmpErrorHostCount).toBe(0);
+    expect(result.mostCommonSnmpError).toBeUndefined();
+  });
+
+  it("reports the most frequent error when hosts fail in different ways", async () => {
+    jest.spyOn(SubnetScanner, "isHostAliveByPing").mockResolvedValue(true);
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockImplementation(
+        async (
+          config: MonitorStepSnmpMonitor,
+          onError?: ((error: unknown) => void) | undefined,
+        ) => {
+          onError?.(
+            new Error(
+              config.hostname === "10.0.0.1"
+                ? "connect ECONNREFUSED"
+                : "Unknown user name",
+            ),
+          );
+          return null;
+        },
+      );
+
+    const result: Awaited<ReturnType<typeof SubnetScanner.scan>> =
+      await SubnetScanner.scan({ cidr: "10.0.0.0/29" });
+
+    expect(result.snmpErrorHostCount).toBe(6);
+    // Five of six hosts, versus one ECONNREFUSED.
+    expect(result.mostCommonSnmpError).toBe("Unknown user name");
   });
 
   it("a throwing SNMP probe records the ping-alive host as SNMP-unreachable", async () => {

--- a/Probe/Tests/Utils/Discovery/SubnetScannerIcmpFallback.test.ts
+++ b/Probe/Tests/Utils/Discovery/SubnetScannerIcmpFallback.test.ts
@@ -1,0 +1,595 @@
+// Set required env vars before importing modules that pull in Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import SubnetScanner, {
+  DiscoveredHost,
+  SubnetScanResult,
+} from "../../../Utils/Discovery/SubnetScanner";
+import SnmpMonitor from "../../../Utils/Monitors/MonitorTypes/SnmpMonitor";
+import MonitorStepSnmpMonitor from "Common/Types/Monitor/MonitorStepSnmpMonitor";
+import SnmpVersion from "Common/Types/Monitor/SnmpMonitor/SnmpVersion";
+import SnmpSecurityLevel from "Common/Types/Monitor/SnmpMonitor/SnmpSecurityLevel";
+import SnmpAuthProtocol from "Common/Types/Monitor/SnmpMonitor/SnmpAuthProtocol";
+import SnmpV3Auth from "Common/Types/Monitor/SnmpMonitor/SnmpV3Auth";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * github.com/OneUptime/oneuptime/issues/3078 — "SNMP Discovery Scan finds
+ * 0 of N hosts for some subnet ranges while identical scans on other ranges
+ * succeed".
+ *
+ * The ICMP pre-sweep was a hard gate: a host that did not answer an echo
+ * request was never SNMP-probed at all. That is only an optimisation, and it
+ * is wrong in exactly the place it matters most — a firewalled management
+ * VLAN routinely drops echo while permitting UDP/161 from the NMS, and
+ * Windows hosts block echo by default. On such a segment every address looks
+ * dead, every SNMP probe is skipped, and the scan reports a confident
+ * "Completed, 0 of 254" that is indistinguishable from empty address space,
+ * while an adjacent VLAN that happens to permit echo scans perfectly.
+ *
+ * The rule these tests pin: the ICMP gate may make a sweep faster, but it may
+ * never be the reason a sweep finds nothing.
+ */
+
+// A /29 sweeps six hosts: 10.0.0.1 .. 10.0.0.6.
+const SIX_HOSTS: string = "10.0.0.0/29";
+const ALL_SIX: Array<string> = [
+  "10.0.0.1",
+  "10.0.0.2",
+  "10.0.0.3",
+  "10.0.0.4",
+  "10.0.0.5",
+  "10.0.0.6",
+];
+
+type ProbeRecorder = {
+  hosts: Array<string>;
+  configs: Array<MonitorStepSnmpMonitor>;
+};
+
+/*
+ * Records every host handed to the SNMP layer, answering for the hosts in
+ * `snmpSpeakers` and staying silent for the rest.
+ */
+function recordProbes(snmpSpeakers: Array<string> = []): ProbeRecorder {
+  const recorder: ProbeRecorder = { hosts: [], configs: [] };
+
+  jest
+    .spyOn(SnmpMonitor, "probeSystemInfo")
+    .mockImplementation(async (config: MonitorStepSnmpMonitor) => {
+      recorder.hosts.push(config.hostname || "");
+      recorder.configs.push(config);
+
+      if (snmpSpeakers.includes(config.hostname || "")) {
+        return { sysName: `device-${config.hostname}` };
+      }
+
+      return null;
+    });
+
+  return recorder;
+}
+
+function mockPingAlive(aliveHosts: Array<string>): void {
+  jest
+    .spyOn(SubnetScanner, "isHostAliveByPing")
+    .mockImplementation(async (host: string) => {
+      return aliveHosts.includes(host);
+    });
+}
+
+function discoveredAddresses(result: SubnetScanResult): Array<string> {
+  return result.discoveredHosts.map((host: DiscoveredHost) => {
+    return host.ipAddress;
+  });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("SubnetScanner — an entirely ICMP-filtered subnet", () => {
+  /*
+   * The reported scenario, reduced: the devices are there and answer SNMP,
+   * but the segment drops echo. This used to return zero hosts.
+   */
+  it("finds the SNMP devices even though not one address answered ICMP", async () => {
+    mockPingAlive([]);
+    const recorder: ProbeRecorder = recordProbes(["10.0.0.4", "10.0.0.5"]);
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect([...recorder.hosts].sort()).toEqual(ALL_SIX);
+    expect(discoveredAddresses(result)).toEqual(["10.0.0.4", "10.0.0.5"]);
+    expect(result.respondedToPingCount).toBe(0);
+    expect(result.icmpFilteredFallbackHostCount).toBe(6);
+  });
+
+  it("counts the fallback devices as SNMP-reachable, so they are importable", async () => {
+    mockPingAlive([]);
+    recordProbes(["10.0.0.4"]);
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.discoveredHosts).toEqual([
+      {
+        ipAddress: "10.0.0.4",
+        sysName: "device-10.0.0.4",
+        sysDescr: undefined,
+        snmpReachable: true,
+      },
+    ]);
+  });
+
+  it("still reports the full sweep size, not just the re-probed part", async () => {
+    mockPingAlive([]);
+    recordProbes([]);
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.scannedHostCount).toBe(6);
+  });
+
+  /*
+   * A subnet that really is empty must still come back empty. The fallback
+   * buys correctness on filtered segments; it must not invent hosts on quiet
+   * ones.
+   */
+  it("an address that answered neither ICMP nor SNMP is still not a discovery", async () => {
+    mockPingAlive([]);
+    recordProbes([]);
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.discoveredHosts).toEqual([]);
+    expect(result.icmpFilteredFallbackHostCount).toBe(6);
+  });
+});
+
+describe("SubnetScanner — a partially ICMP-filtered subnet", () => {
+  /*
+   * The nastier real-world shape: a couple of hosts answer echo but none of
+   * them speak SNMP, while the switches that do speak SNMP sit behind the
+   * filter. The gated pass finds nothing, so the skipped hosts get their
+   * chance.
+   */
+  it("re-probes the ICMP-silent hosts when the ICMP-alive ones answer no SNMP", async () => {
+    mockPingAlive(["10.0.0.1", "10.0.0.2"]);
+    const recorder: ProbeRecorder = recordProbes(["10.0.0.6"]);
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    // First pass: the two ping-alive hosts. Then the four it skipped.
+    expect(recorder.hosts.slice(0, 2).sort()).toEqual(["10.0.0.1", "10.0.0.2"]);
+    expect([...recorder.hosts].sort()).toEqual(ALL_SIX);
+    expect(result.icmpFilteredFallbackHostCount).toBe(4);
+  });
+
+  it("keeps the ping-only hosts alongside whatever the fallback finds", async () => {
+    mockPingAlive(["10.0.0.1", "10.0.0.2"]);
+    recordProbes(["10.0.0.6"]);
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.discoveredHosts).toEqual([
+      { ipAddress: "10.0.0.1", snmpReachable: false },
+      { ipAddress: "10.0.0.2", snmpReachable: false },
+      {
+        ipAddress: "10.0.0.6",
+        sysName: "device-10.0.0.6",
+        sysDescr: undefined,
+        snmpReachable: true,
+      },
+    ]);
+  });
+
+  it("reports the ICMP count from the pre-sweep, not from the fallback", async () => {
+    mockPingAlive(["10.0.0.1", "10.0.0.2"]);
+    recordProbes(["10.0.0.6"]);
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    // Two answered echo; the fallback probing four more does not change that.
+    expect(result.respondedToPingCount).toBe(2);
+  });
+
+  /*
+   * Results are sorted by address, and the fallback appends out of order —
+   * a host discovered in the second pass can sort before one from the first.
+   */
+  it("returns hosts in ascending address order across both passes", async () => {
+    mockPingAlive(["10.0.0.6"]);
+    recordProbes(["10.0.0.2", "10.0.0.4"]);
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(discoveredAddresses(result)).toEqual([
+      "10.0.0.2",
+      "10.0.0.4",
+      "10.0.0.6",
+    ]);
+  });
+});
+
+describe("SubnetScanner — when the fallback must NOT run", () => {
+  /*
+   * The whole point of the pre-sweep is skipping SNMP's 2s timeout on dead
+   * addresses. One SNMP responder proves the gate is working on this segment,
+   * so the skipped hosts stay skipped.
+   */
+  it("stays on the fast path as soon as one host answers SNMP", async () => {
+    mockPingAlive(["10.0.0.2"]);
+    const recorder: ProbeRecorder = recordProbes(["10.0.0.2"]);
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(recorder.hosts).toEqual(["10.0.0.2"]);
+    expect(result.icmpFilteredFallbackHostCount).toBe(0);
+  });
+
+  it("does not re-probe when the pre-sweep was unavailable and everything was probed already", async () => {
+    jest
+      .spyOn(SubnetScanner, "isHostAliveByPing")
+      .mockRejectedValue(new Error("ICMP sockets require elevated privileges"));
+    const recorder: ProbeRecorder = recordProbes([]);
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(recorder.hosts).toHaveLength(6);
+    expect(new Set(recorder.hosts).size).toBe(6);
+    expect(result.icmpFilteredFallbackHostCount).toBe(0);
+    // A count from a sweep that never ran would be a lie.
+    expect(result.respondedToPingCount).toBeUndefined();
+  });
+
+  it("does not re-probe when every host was ping-alive and already probed", async () => {
+    mockPingAlive(ALL_SIX);
+    const recorder: ProbeRecorder = recordProbes([]);
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(recorder.hosts).toHaveLength(6);
+    expect(result.icmpFilteredFallbackHostCount).toBe(0);
+  });
+
+  it("never probes the same address twice", async () => {
+    mockPingAlive(["10.0.0.3"]);
+    const recorder: ProbeRecorder = recordProbes([]);
+
+    await SubnetScanner.scan({ cidr: SIX_HOSTS });
+
+    expect(recorder.hosts).toHaveLength(6);
+    expect(new Set(recorder.hosts).size).toBe(6);
+  });
+});
+
+describe("SubnetScanner — the fallback pass is a real scan, not a degraded one", () => {
+  const V3_AUTH: SnmpV3Auth = {
+    securityLevel: SnmpSecurityLevel.AuthPriv,
+    username: "WBNOC",
+    authProtocol: SnmpAuthProtocol.SHA,
+    authKey: "auth-passphrase",
+  } as SnmpV3Auth;
+
+  it("carries the scan's credentials, version and port into every re-probe", async () => {
+    mockPingAlive([]);
+    const recorder: ProbeRecorder = recordProbes([]);
+
+    await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+      snmpVersion: "V3",
+      snmpV3Auth: V3_AUTH,
+      snmpPort: 1610,
+    });
+
+    expect(recorder.configs).toHaveLength(6);
+    for (const config of recorder.configs) {
+      expect(config.snmpVersion).toBe(SnmpVersion.V3);
+      expect(config.snmpV3Auth).toEqual(V3_AUTH);
+      expect(config.port).toBe(1610);
+      // Discovery never retries: one 2s attempt per address, per pass.
+      expect(config.retries).toBe(0);
+      expect(config.timeout).toBe(2000);
+    }
+  });
+
+  it("reports the port it actually probed", async () => {
+    mockPingAlive([]);
+    recordProbes([]);
+
+    const custom: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+      snmpPort: 1610,
+    });
+    expect(custom.scannedPort).toBe(1610);
+
+    const standard: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+    expect(standard.scannedPort).toBe(161);
+  });
+
+  /*
+   * Sweeping a whole subnet at once exhausts sockets, and the fallback can
+   * double the number of probes a scan issues — so it has to obey the same
+   * wave size as the first pass.
+   */
+  it("keeps both passes inside the concurrency limit", async () => {
+    const inFlight: { now: number; peak: number } = { now: 0, peak: 0 };
+
+    mockPingAlive([]);
+    jest.spyOn(SnmpMonitor, "probeSystemInfo").mockImplementation(async () => {
+      inFlight.now++;
+      inFlight.peak = Math.max(inFlight.peak, inFlight.now);
+      await new Promise((resolve: (value: void) => void) => {
+        setTimeout(resolve, 1);
+      });
+      inFlight.now--;
+      return null;
+    });
+
+    // 126 hosts, well past the 32-worker wave size.
+    await SubnetScanner.scan({ cidr: "10.0.0.0/25" });
+
+    expect(inFlight.peak).toBeGreaterThan(1);
+    expect(inFlight.peak).toBeLessThanOrEqual(32);
+  });
+
+  it("pings every address in the target before probing any of them", async () => {
+    const pinged: Array<string> = [];
+
+    jest
+      .spyOn(SubnetScanner, "isHostAliveByPing")
+      .mockImplementation(async (host: string) => {
+        pinged.push(host);
+        return false;
+      });
+    recordProbes([]);
+
+    await SubnetScanner.scan({ cidr: SIX_HOSTS });
+
+    expect([...pinged].sort()).toEqual(ALL_SIX);
+  });
+});
+
+/*
+ * "Returned null" covered both "nothing is at this address" and "the agent
+ * refused these credentials". One credential set is applied to every host in
+ * a sweep, so a single wrong v3 key blanks all 254 results — and the scan
+ * reported a clean zero with nothing to distinguish it from empty space.
+ */
+describe("SubnetScanner — SNMP errors are evidence, not noise", () => {
+  function mockSnmpErroring(messageFor: (host: string) => string | null): void {
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockImplementation(
+        async (
+          config: MonitorStepSnmpMonitor,
+          onError?: ((error: unknown) => void) | undefined,
+        ) => {
+          const message: string | null = messageFor(config.hostname || "");
+          if (message !== null) {
+            onError?.(new Error(message));
+          }
+          return null;
+        },
+      );
+  }
+
+  it("counts a rejection from every host and names it", async () => {
+    mockPingAlive(ALL_SIX);
+    mockSnmpErroring(() => {
+      return "Authentication failure";
+    });
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.snmpErrorHostCount).toBe(6);
+    expect(result.mostCommonSnmpError).toBe("Authentication failure");
+  });
+
+  it("ignores timeouts — most addresses in a sweep are empty", async () => {
+    mockPingAlive(ALL_SIX);
+    mockSnmpErroring(() => {
+      return "Request timed out";
+    });
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.snmpErrorHostCount).toBe(0);
+    expect(result.mostCommonSnmpError).toBeUndefined();
+  });
+
+  it("recognises timeout wording in any case or phrasing", async () => {
+    mockPingAlive(ALL_SIX);
+    mockSnmpErroring((host: string) => {
+      return host === "10.0.0.1"
+        ? "Request TIMED OUT after 2000ms"
+        : "socket Timeout";
+    });
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.snmpErrorHostCount).toBe(0);
+  });
+
+  it("picks the error the most hosts gave", async () => {
+    mockPingAlive(ALL_SIX);
+    mockSnmpErroring((host: string) => {
+      return host === "10.0.0.1" ? "connect ECONNREFUSED" : "Unknown user name";
+    });
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.snmpErrorHostCount).toBe(6);
+    expect(result.mostCommonSnmpError).toBe("Unknown user name");
+  });
+
+  it("counts a mix of timeouts and rejections as rejections only", async () => {
+    mockPingAlive(ALL_SIX);
+    mockSnmpErroring((host: string) => {
+      return ["10.0.0.1", "10.0.0.2"].includes(host)
+        ? "Authentication failure"
+        : "Request timed out";
+    });
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.snmpErrorHostCount).toBe(2);
+    expect(result.mostCommonSnmpError).toBe("Authentication failure");
+  });
+
+  /*
+   * The message is quoted into a varchar(500) status column, so a device that
+   * returns a novel-length error cannot be allowed to blow the write.
+   */
+  it("keeps only the head of an enormous error message", async () => {
+    mockPingAlive(ALL_SIX);
+    mockSnmpErroring(() => {
+      return `AUTH${"x".repeat(5000)}`;
+    });
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.mostCommonSnmpError).toHaveLength(120);
+    expect(result.mostCommonSnmpError?.startsWith("AUTH")).toBe(true);
+  });
+
+  it("ignores an error that carries no message at all", async () => {
+    mockPingAlive(ALL_SIX);
+    mockSnmpErroring(() => {
+      return "   ";
+    });
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.snmpErrorHostCount).toBe(0);
+  });
+
+  it("handles a thrown value that is not an Error", async () => {
+    mockPingAlive(ALL_SIX);
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockImplementation(
+        async (
+          _config: MonitorStepSnmpMonitor,
+          onError?: ((error: unknown) => void) | undefined,
+        ) => {
+          onError?.("usmStatsUnknownEngineIDs");
+          return null;
+        },
+      );
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.snmpErrorHostCount).toBe(6);
+    expect(result.mostCommonSnmpError).toBe("usmStatsUnknownEngineIDs");
+  });
+
+  it("counts a probe that rejected outright, not only one that reported", async () => {
+    mockPingAlive(ALL_SIX);
+    jest
+      .spyOn(SnmpMonitor, "probeSystemInfo")
+      .mockRejectedValue(new Error("unexpected decode failure"));
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.snmpErrorHostCount).toBe(6);
+    expect(result.mostCommonSnmpError).toBe("unexpected decode failure");
+  });
+
+  /*
+   * The combination from the bug report: echo filtered AND the credentials
+   * refused. Both facts have to survive to the status message, because they
+   * are two different fixes.
+   */
+  it("collects rejections from the fallback pass too", async () => {
+    mockPingAlive([]);
+    mockSnmpErroring(() => {
+      return "Authentication failure";
+    });
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.icmpFilteredFallbackHostCount).toBe(6);
+    expect(result.snmpErrorHostCount).toBe(6);
+    expect(result.mostCommonSnmpError).toBe("Authentication failure");
+  });
+
+  /*
+   * A rejection proves an SNMP agent is there, but not that the ADDRESS is
+   * live in a way discovery can import — the host list stays evidence-based
+   * (ICMP reply or an SNMP answer), so a rejection alone does not create a
+   * phantom device row.
+   */
+  it("does not turn a rejection into a discovered host on its own", async () => {
+    mockPingAlive([]);
+    mockSnmpErroring(() => {
+      return "Authentication failure";
+    });
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.discoveredHosts).toEqual([]);
+  });
+
+  it("records a ping-alive host that rejected the credentials as SNMP-unreachable", async () => {
+    mockPingAlive(["10.0.0.3"]);
+    mockSnmpErroring(() => {
+      return "Authentication failure";
+    });
+
+    const result: SubnetScanResult = await SubnetScanner.scan({
+      cidr: SIX_HOSTS,
+    });
+
+    expect(result.discoveredHosts).toEqual([
+      { ipAddress: "10.0.0.3", snmpReachable: false },
+    ]);
+  });
+});

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/SnmpMonitorProbeSystemInfo.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/SnmpMonitorProbeSystemInfo.test.ts
@@ -1,0 +1,290 @@
+// Set required env vars before importing modules that pull in Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import MonitorStepSnmpMonitor from "Common/Types/Monitor/MonitorStepSnmpMonitor";
+import SnmpVersion from "Common/Types/Monitor/SnmpMonitor/SnmpVersion";
+import SnmpSecurityLevel from "Common/Types/Monitor/SnmpMonitor/SnmpSecurityLevel";
+import SnmpAuthProtocol from "Common/Types/Monitor/SnmpMonitor/SnmpAuthProtocol";
+import SnmpSystemInfo from "Common/Types/Monitor/SnmpMonitor/SnmpSystemInfo";
+
+/*
+ * A fake net-snmp session whose `get` is scripted per test, so the probe's
+ * behaviour on an agent that answers, times out, or actively refuses can be
+ * exercised without a UDP socket. Only the session factories are mocked; the
+ * real module still supplies the protocol constants and isVarbindError.
+ */
+type SessionScript = {
+  error: Error | null;
+  varbinds: Array<unknown> | undefined;
+};
+
+const sessionScript: SessionScript = { error: null, varbinds: undefined };
+
+/*
+ * A sweep opens one session per address, so leaking them exhausts the probe's
+ * sockets long before a /24 finishes. Counted with a plain object rather than
+ * jest.fn() so the mock factory below can close over it without dragging
+ * jest's generic Mock typing into the module scope.
+ */
+const sessionCloses: { count: number } = { count: 0 };
+
+jest.mock("net-snmp", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "net-snmp",
+  ) as Record<string, unknown>;
+
+  const makeSession: () => Record<string, unknown> = () => {
+    return {
+      on: jest.fn(),
+      close: (): void => {
+        sessionCloses.count++;
+      },
+      get: (
+        _oids: Array<string>,
+        callback: (
+          error: Error | null,
+          varbinds: Array<unknown> | undefined,
+        ) => void,
+      ): void => {
+        callback(sessionScript.error, sessionScript.varbinds);
+      },
+    };
+  };
+
+  return {
+    ...actual,
+    createSession: jest.fn(makeSession),
+    createV3Session: jest.fn(makeSession),
+  };
+});
+
+import snmp from "net-snmp";
+import SnmpMonitor from "../../../../Utils/Monitors/MonitorTypes/SnmpMonitor";
+
+function buildConfig(
+  overrides?: Partial<MonitorStepSnmpMonitor>,
+): MonitorStepSnmpMonitor {
+  return {
+    snmpVersion: SnmpVersion.V2c,
+    hostname: "10.244.102.11",
+    port: 161,
+    communityString: "public",
+    oids: [],
+    timeout: 2000,
+    retries: 0,
+    ...overrides,
+  } as MonitorStepSnmpMonitor;
+}
+
+// The six system-group scalars readSystemInfo asks for, in order.
+function systemGroupVarbinds(): Array<unknown> {
+  return [
+    {
+      oid: "1.3.6.1.2.1.1.1.0",
+      type: snmp.ObjectType.OctetString,
+      value: Buffer.from("Cisco IOS"),
+    },
+    {
+      oid: "1.3.6.1.2.1.1.2.0",
+      type: snmp.ObjectType.OID,
+      value: "1.3.6.1.4.1.9.1.1",
+    },
+    { oid: "1.3.6.1.2.1.1.3.0", type: snmp.ObjectType.TimeTicks, value: 12345 },
+    {
+      oid: "1.3.6.1.2.1.1.4.0",
+      type: snmp.ObjectType.OctetString,
+      value: Buffer.from("noc@example.com"),
+    },
+    {
+      oid: "1.3.6.1.2.1.1.5.0",
+      type: snmp.ObjectType.OctetString,
+      value: Buffer.from("core-sw1"),
+    },
+    {
+      oid: "1.3.6.1.2.1.1.6.0",
+      type: snmp.ObjectType.OctetString,
+      value: Buffer.from("Rack 3"),
+    },
+  ];
+}
+
+beforeEach(() => {
+  sessionScript.error = null;
+  sessionScript.varbinds = systemGroupVarbinds();
+  sessionCloses.count = 0;
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("SnmpMonitor.probeSystemInfo — a host that answers", () => {
+  test("returns the system identity discovery imports devices from", async () => {
+    const info: SnmpSystemInfo | null =
+      await SnmpMonitor.probeSystemInfo(buildConfig());
+
+    expect(info?.sysName).toBe("core-sw1");
+    expect(info?.sysDescr).toBe("Cisco IOS");
+  });
+
+  test("reports no error for a host that answered", async () => {
+    const errors: Array<unknown> = [];
+
+    await SnmpMonitor.probeSystemInfo(buildConfig(), (err: unknown) => {
+      errors.push(err);
+    });
+
+    expect(errors).toEqual([]);
+  });
+
+  test("closes the session — a subnet sweep opens one per address", async () => {
+    await SnmpMonitor.probeSystemInfo(buildConfig());
+
+    expect(sessionCloses.count).toBe(1);
+  });
+});
+
+/*
+ * The seam this whole fix hangs on. probeSystemInfo returns null for BOTH
+ * "nothing is at this address" and "the agent refused these credentials",
+ * and a discovery sweep applies one credential set to every host — so a
+ * single wrong v3 key used to blank all 254 results and report a clean zero,
+ * indistinguishable from an empty subnet.
+ */
+describe("SnmpMonitor.probeSystemInfo — surfacing why a host did not answer", () => {
+  test("hands an authentication failure to the caller instead of swallowing it", async () => {
+    sessionScript.error = new Error("Authentication failure");
+    sessionScript.varbinds = undefined;
+
+    const errors: Array<unknown> = [];
+    const info: SnmpSystemInfo | null = await SnmpMonitor.probeSystemInfo(
+      buildConfig(),
+      (err: unknown) => {
+        errors.push(err);
+      },
+    );
+
+    // The return contract is unchanged: still null, never a throw.
+    expect(info).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe("Authentication failure");
+  });
+
+  test("a timeout reaches the caller too — classifying it is the caller's job", async () => {
+    sessionScript.error = new Error("Request timed out");
+    sessionScript.varbinds = undefined;
+
+    const errors: Array<unknown> = [];
+    await SnmpMonitor.probeSystemInfo(buildConfig(), (err: unknown) => {
+      errors.push(err);
+    });
+
+    expect((errors[0] as Error).message).toBe("Request timed out");
+  });
+
+  test("a response with no varbinds is an error, not a silent empty device", async () => {
+    sessionScript.error = null;
+    sessionScript.varbinds = undefined;
+
+    const errors: Array<unknown> = [];
+    const info: SnmpSystemInfo | null = await SnmpMonitor.probeSystemInfo(
+      buildConfig(),
+      (err: unknown) => {
+        errors.push(err);
+      },
+    );
+
+    expect(info).toBeNull();
+    expect(errors).toHaveLength(1);
+  });
+
+  test("still closes the session when the read failed", async () => {
+    sessionScript.error = new Error("Unknown user name");
+    sessionScript.varbinds = undefined;
+
+    await SnmpMonitor.probeSystemInfo(buildConfig());
+
+    expect(sessionCloses.count).toBe(1);
+  });
+
+  /*
+   * A scan-wide misconfiguration throws while the session is being built, so
+   * it never reaches the read. Without this branch it would look like one
+   * more quiet address — on every host in the sweep.
+   */
+  test("a configuration that cannot even open a session is reported, not silently null", async () => {
+    const errors: Array<unknown> = [];
+
+    const info: SnmpSystemInfo | null = await SnmpMonitor.probeSystemInfo(
+      buildConfig({
+        snmpVersion: SnmpVersion.V3,
+        // v3 selected with no credentials at all.
+        snmpV3Auth: undefined,
+      }),
+      (err: unknown) => {
+        errors.push(err);
+      },
+    );
+
+    expect(info).toBeNull();
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toContain(
+      "no v3 credentials (username) are configured",
+    );
+    // Nothing was opened, so nothing must be closed.
+    expect(sessionCloses.count).toBe(0);
+  });
+
+  test("an unrecognized v3 auth protocol is reported rather than quietly downgraded", async () => {
+    const errors: Array<unknown> = [];
+
+    await SnmpMonitor.probeSystemInfo(
+      buildConfig({
+        snmpVersion: SnmpVersion.V3,
+        snmpV3Auth: {
+          securityLevel: SnmpSecurityLevel.AuthNoPriv,
+          username: "WBNOC",
+          authProtocol: "sha-3" as SnmpAuthProtocol,
+          authKey: "auth-passphrase",
+        },
+      }),
+      (err: unknown) => {
+        errors.push(err);
+      },
+    );
+
+    expect((errors[0] as Error).message).toContain("not a recognized value");
+  });
+});
+
+/*
+ * The callback is optional so the existing contract is untouched for callers
+ * that do not want it.
+ */
+describe("SnmpMonitor.probeSystemInfo — callers that pass no callback", () => {
+  test("a failing read is still just null, with no throw", async () => {
+    sessionScript.error = new Error("Authentication failure");
+    sessionScript.varbinds = undefined;
+
+    await expect(
+      SnmpMonitor.probeSystemInfo(buildConfig()),
+    ).resolves.toBeNull();
+  });
+
+  test("an unopenable session is still just null, with no throw", async () => {
+    await expect(
+      SnmpMonitor.probeSystemInfo(
+        buildConfig({ snmpVersion: SnmpVersion.V3, snmpV3Auth: undefined }),
+      ),
+    ).resolves.toBeNull();
+  });
+});

--- a/Probe/Utils/Discovery/SubnetScanner.ts
+++ b/Probe/Utils/Discovery/SubnetScanner.ts
@@ -40,12 +40,36 @@ export interface SubnetScanResult {
    */
   discoveredHosts: Array<DiscoveredHost>;
   scannedHostCount: number;
+  // The UDP port every host was probed on, so the summary can name it.
+  scannedPort: number;
   /*
    * Hosts that answered the ICMP pre-sweep. undefined when the pre-sweep
    * could not run (e.g. no ping binary / ICMP privileges) and every host was
    * SNMP-probed directly, so a partial count is never reported as a real one.
    */
   respondedToPingCount?: number | undefined;
+  /*
+   * Hosts whose SNMP probe failed with something OTHER than a timeout — an
+   * authentication failure, an unknown v3 user, a refused port, no route.
+   * A timeout is the ordinary "nothing at this address" answer and is not
+   * counted; everything else is evidence the operator can act on, and used
+   * to be swallowed by a debug-level log inside a sweep that then reported
+   * a clean zero.
+   */
+  snmpErrorHostCount: number;
+  /*
+   * The most frequent of those errors, verbatim, so the scan can say
+   * "0 answered SNMP ... most common error: Authentication failure" instead
+   * of leaving the operator to guess between a wrong credential, a blocked
+   * port and an empty subnet.
+   */
+  mostCommonSnmpError?: string | undefined;
+  /*
+   * How many ICMP-silent hosts were SNMP-probed anyway because the pre-sweep
+   * produced no SNMP responders at all. Non-zero means the sweep hit the
+   * ICMP-filtered-subnet path described in scan().
+   */
+  icmpFilteredFallbackHostCount: number;
 }
 
 // Sweeping the whole subnet at once would exhaust sockets; probe in waves.
@@ -57,6 +81,13 @@ const CONCURRENCY: number = 32;
  * the cost the pre-sweep exists to avoid.
  */
 const PING_TIMEOUT_IN_SECONDS: number = 1;
+
+/*
+ * How much of an SNMP error message is kept for the scan's status summary.
+ * See describeSnmpError — the summary lands in a varchar(500) column, so the
+ * quoted error has to leave room for the rest of the sentence.
+ */
+const SNMP_ERROR_EXCERPT_LENGTH: number = 120;
 
 export default class SubnetScanner {
   public static async scan(
@@ -86,109 +117,178 @@ export default class SubnetScanner {
       throw new Error("Scan target expands to no addresses: " + config.cidr);
     }
 
-    const discoveredHosts: Array<DiscoveredHost> = [];
-    let cursor: number = 0;
-
     /*
-     * ICMP pre-sweep state, shared across workers. Best-effort: the first
-     * infrastructure failure (ping binary missing, ICMP socket privileges —
-     * an error, not a clean "host down") flips the flag and every remaining
-     * host is SNMP-probed directly, exactly as before the pre-sweep existed.
+     * ICMP pre-sweep state. Best-effort: the first infrastructure failure
+     * (ping binary missing, ICMP socket privileges — an error, not a clean
+     * "host down") flips the flag and every host is SNMP-probed directly,
+     * exactly as before the pre-sweep existed.
      */
     let isPingSweepAvailable: boolean = true;
-    let respondedToPingCount: number = 0;
+    const pingAliveHosts: Set<string> = new Set<string>();
 
-    const worker: () => Promise<void> = async (): Promise<void> => {
-      while (cursor < hosts.length) {
-        const host: string = hosts[cursor++]!;
-
-        /*
-         * Per-host, so a host confirmed alive by ICMP stays known-alive
-         * even if the pre-sweep breaks for a later host on this worker.
-         */
-        let isAliveByPing: boolean = false;
-
-        if (isPingSweepAvailable) {
-          try {
-            isAliveByPing = await SubnetScanner.isHostAliveByPing(host);
-          } catch (pingErr) {
-            /*
-             * A rejection means pinging itself failed (a dead host resolves
-             * cleanly with alive=false). Disable the pre-sweep for the rest
-             * of the scan and fall through to SNMP for this host too.
-             */
-            isPingSweepAvailable = false;
-            logger.warn(
-              "Discovery ICMP pre-sweep unavailable (" +
-                pingErr +
-                "). Falling back to SNMP-probing every host.",
-            );
-          }
-
-          if (isPingSweepAvailable) {
-            if (!isAliveByPing) {
-              // Host did not answer ICMP — skip the 2s SNMP timeout.
-              continue;
-            }
-            respondedToPingCount++;
-          }
+    // Phase 1 — ICMP pre-sweep across the whole target.
+    await SubnetScanner.runConcurrently(
+      hosts,
+      async (host: string): Promise<void> => {
+        if (!isPingSweepAvailable) {
+          return;
         }
-
-        const snmpConfig: MonitorStepSnmpMonitor = {
-          /*
-           * Parse, don't cast: the stored version is the dropdown key
-           * ("V1"/"V2c"/"V3") while SnmpMonitor branches on the enum value
-           * ("1"/"2c"/"3"). A bare cast leaves "V3" unequal to SnmpVersion.V3,
-           * so the session would silently downgrade to v2c. parse() normalizes
-           * both spellings (and defaults to V2c when unset).
-           */
-          snmpVersion: SnmpVersionUtil.parse(config.snmpVersion),
-          hostname: host,
-          port: config.snmpPort || 161,
-          communityString: config.snmpCommunityString || "public",
-          snmpV3Auth: config.snmpV3Auth,
-          oids: [],
-          timeout: 2000,
-          retries: 0,
-        };
-
-        let systemInfo: {
-          sysDescr?: string | undefined;
-          sysName?: string | undefined;
-        } | null = null;
 
         try {
-          systemInfo = await SnmpMonitor.probeSystemInfo(snmpConfig);
-        } catch (err) {
-          logger.debug("Discovery probe error for " + host + ": " + err);
-        }
-
-        if (systemInfo) {
-          discoveredHosts.push({
-            ipAddress: host,
-            sysName: systemInfo.sysName,
-            sysDescr: systemInfo.sysDescr,
-            snmpReachable: true,
-          });
-        } else if (isAliveByPing) {
+          if (await SubnetScanner.isHostAliveByPing(host)) {
+            pingAliveHosts.add(host);
+          }
+        } catch (pingErr) {
           /*
-           * Answered ICMP but not SNMP: a real host without (readable)
-           * SNMP. Record it instead of discarding it — the scan's job is
-           * to surface what is on the subnet, not only what is manageable.
+           * A rejection means pinging itself failed (a dead host resolves
+           * cleanly with alive=false). Disable the pre-sweep for the rest of
+           * the scan; hosts already confirmed alive stay known-alive.
            */
-          discoveredHosts.push({
-            ipAddress: host,
-            snmpReachable: false,
-          });
+          isPingSweepAvailable = false;
+          logger.warn(
+            "Discovery ICMP pre-sweep unavailable (" +
+              pingErr +
+              "). Falling back to SNMP-probing every host.",
+          );
         }
+      },
+    );
+
+    // Phase 2 — SNMP probe, plus the phase 3 fallback below.
+    const snmpPort: number = config.snmpPort || 161;
+    const discoveredHosts: Array<DiscoveredHost> = [];
+    const probedHosts: Set<string> = new Set<string>();
+    const snmpErrorCounts: Map<string, number> = new Map<string, number>();
+    let snmpResponderCount: number = 0;
+    let snmpErrorHostCount: number = 0;
+
+    const probeHost: (host: string) => Promise<void> = async (
+      host: string,
+    ): Promise<void> => {
+      probedHosts.add(host);
+
+      const snmpConfig: MonitorStepSnmpMonitor = {
+        /*
+         * Parse, don't cast: the stored version is the dropdown key
+         * ("V1"/"V2c"/"V3") while SnmpMonitor branches on the enum value
+         * ("1"/"2c"/"3"). A bare cast leaves "V3" unequal to SnmpVersion.V3,
+         * so the session would silently downgrade to v2c. parse() normalizes
+         * both spellings (and defaults to V2c when unset).
+         */
+        snmpVersion: SnmpVersionUtil.parse(config.snmpVersion),
+        hostname: host,
+        port: snmpPort,
+        communityString: config.snmpCommunityString || "public",
+        snmpV3Auth: config.snmpV3Auth,
+        oids: [],
+        timeout: 2000,
+        retries: 0,
+      };
+
+      let systemInfo: {
+        sysDescr?: string | undefined;
+        sysName?: string | undefined;
+      } | null = null;
+
+      /*
+       * Anything the SNMP layer failed with that is NOT a timeout. A timeout
+       * is the ordinary answer for an empty address; an auth failure, an
+       * unknown v3 user, a refused port or an unreachable network is a
+       * diagnosis, and reporting nothing but "0 found" for a whole subnet of
+       * them is what makes this class of misconfiguration unfindable.
+       *
+       * Held on an object rather than in a bare `let` so the assignment made
+       * inside the callback below is not erased by control-flow narrowing.
+       */
+      const probeFailure: { message?: string | undefined } = {};
+
+      try {
+        systemInfo = await SnmpMonitor.probeSystemInfo(
+          snmpConfig,
+          (probeError: unknown) => {
+            probeFailure.message = SubnetScanner.describeSnmpError(probeError);
+          },
+        );
+      } catch (err) {
+        logger.debug("Discovery probe error for " + host + ": " + err);
+        probeFailure.message = SubnetScanner.describeSnmpError(err);
+      }
+
+      if (systemInfo) {
+        snmpResponderCount++;
+        discoveredHosts.push({
+          ipAddress: host,
+          sysName: systemInfo.sysName,
+          sysDescr: systemInfo.sysDescr,
+          snmpReachable: true,
+        });
+        return;
+      }
+
+      const snmpError: string | undefined = probeFailure.message;
+
+      if (snmpError) {
+        snmpErrorHostCount++;
+        snmpErrorCounts.set(
+          snmpError,
+          (snmpErrorCounts.get(snmpError) || 0) + 1,
+        );
+      }
+
+      if (pingAliveHosts.has(host)) {
+        /*
+         * Answered ICMP but not SNMP: a real host without (readable) SNMP.
+         * Record it instead of discarding it — the scan's job is to surface
+         * what is on the subnet, not only what is manageable. Hosts that never
+         * answered ICMP are NOT recorded: without that evidence "no SNMP
+         * answer" cannot be told apart from "no host", and every dead address
+         * would become a phantom endpoint.
+         */
+        discoveredHosts.push({
+          ipAddress: host,
+          snmpReachable: false,
+        });
       }
     };
 
-    const workers: Array<Promise<void>> = [];
-    for (let i: number = 0; i < Math.min(CONCURRENCY, hosts.length); i++) {
-      workers.push(worker());
+    const firstPassHosts: Array<string> = isPingSweepAvailable
+      ? hosts.filter((host: string) => {
+          return pingAliveHosts.has(host);
+        })
+      : hosts;
+
+    await SubnetScanner.runConcurrently(firstPassHosts, probeHost);
+
+    /*
+     * Phase 3 — the ICMP gate must never be able to silence a subnet.
+     *
+     * Skipping SNMP for ICMP-silent hosts is only an optimisation, and it is
+     * wrong exactly where it matters most: management VLANs behind a firewall
+     * routinely drop echo while permitting UDP/161 from the NMS, and Windows
+     * hosts block echo by default. On such a segment every host looks dead,
+     * every SNMP probe is skipped, and the scan reports a confident "0 of 254"
+     * that is indistinguishable from an empty subnet — while an adjacent VLAN
+     * that happens to permit echo scans perfectly.
+     *
+     * So when the gated pass finds NO SNMP responder at all, re-probe the
+     * hosts it skipped. The cost lands only on scans that would otherwise have
+     * returned nothing, and it buys back the entire ICMP-filtered case.
+     */
+    let icmpFilteredFallbackHostCount: number = 0;
+
+    if (isPingSweepAvailable && snmpResponderCount === 0) {
+      const skippedHosts: Array<string> = hosts.filter((host: string) => {
+        return !probedHosts.has(host);
+      });
+
+      if (skippedHosts.length > 0) {
+        icmpFilteredFallbackHostCount = skippedHosts.length;
+        logger.warn(
+          `Discovery sweep of ${config.cidr} found no SNMP responder among the ${firstPassHosts.length} host(s) that answered ICMP. Re-probing the ${skippedHosts.length} ICMP-silent host(s) over SNMP in case ICMP is filtered on this network.`,
+        );
+        await SubnetScanner.runConcurrently(skippedHosts, probeHost);
+      }
     }
-    await Promise.all(workers);
 
     discoveredHosts.sort((a: DiscoveredHost, b: DiscoveredHost) => {
       return (
@@ -201,15 +301,96 @@ export default class SubnetScanner {
       discoveredHosts: discoveredHosts,
       // Full sweep size — hosts skipped by the ICMP gate still count as scanned.
       scannedHostCount: hosts.length,
+      scannedPort: snmpPort,
       /*
        * Only meaningful when the pre-sweep ran for the whole scan. If it was
        * disabled partway through, the count covers an unknown subset of the
        * subnet, so report nothing rather than a misleading number.
        */
       respondedToPingCount: isPingSweepAvailable
-        ? respondedToPingCount
+        ? pingAliveHosts.size
         : undefined,
+      snmpErrorHostCount: snmpErrorHostCount,
+      mostCommonSnmpError: SubnetScanner.getMostCommonError(snmpErrorCounts),
+      icmpFilteredFallbackHostCount: icmpFilteredFallbackHostCount,
     };
+  }
+
+  /*
+   * Runs `work` over `items` with at most CONCURRENCY in flight. Sweeping a
+   * whole subnet at once would exhaust sockets (and, for the ICMP pass, fork a
+   * ping process per address), so probe in waves.
+   */
+  private static async runConcurrently(
+    items: Array<string>,
+    work: (item: string) => Promise<void>,
+  ): Promise<void> {
+    let cursor: number = 0;
+
+    const worker: () => Promise<void> = async (): Promise<void> => {
+      while (cursor < items.length) {
+        await work(items[cursor++]!);
+      }
+    };
+
+    const workers: Array<Promise<void>> = [];
+    for (let i: number = 0; i < Math.min(CONCURRENCY, items.length); i++) {
+      workers.push(worker());
+    }
+
+    await Promise.all(workers);
+  }
+
+  /*
+   * Turns an SNMP probe failure into a line worth showing the operator, or
+   * undefined when it carries no information.
+   *
+   * Timeouts are dropped: in a subnet sweep most addresses are empty and
+   * answer nothing, so counting those would drown the signal. What survives —
+   * "Authentication failure", "Unknown user name", "Unsupported security
+   * level", EHOSTUNREACH, ECONNREFUSED — each means the probe got somewhere
+   * and was turned away, which is precisely what a scan reporting zero hosts
+   * needs to say.
+   */
+  private static describeSnmpError(error: unknown): string | undefined {
+    const message: string = (
+      (error as Error | undefined)?.message || String(error ?? "")
+    ).trim();
+
+    if (!message) {
+      return undefined;
+    }
+
+    const lowerCased: string = message.toLowerCase();
+    if (lowerCased.includes("timeout") || lowerCased.includes("timed out")) {
+      return undefined;
+    }
+
+    /*
+     * Bounded: this is quoted into the scan's statusMessage, which is a
+     * varchar(500). The interesting part of every SNMP error ("Authentication
+     * failure", "Unknown user name", "connect ECONNREFUSED 10.0.0.1:161") is
+     * at the front, so a head excerpt loses nothing that matters.
+     */
+    return message.length > SNMP_ERROR_EXCERPT_LENGTH
+      ? message.substring(0, SNMP_ERROR_EXCERPT_LENGTH)
+      : message;
+  }
+
+  private static getMostCommonError(
+    errorCounts: Map<string, number>,
+  ): string | undefined {
+    let mostCommon: string | undefined = undefined;
+    let highestCount: number = 0;
+
+    for (const [message, count] of errorCounts) {
+      if (count > highestCount) {
+        mostCommon = message;
+        highestCount = count;
+      }
+    }
+
+    return mostCommon;
   }
 
   /*

--- a/Probe/Utils/Monitors/MonitorTypes/SnmpMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/SnmpMonitor.ts
@@ -423,15 +423,39 @@ export default class SnmpMonitor {
    * Single-host system-group probe used by subnet discovery. Returns null
    * when the host does not answer SNMP within the timeout — the normal
    * case for most addresses in a swept subnet, so no retries and no logs.
+   *
+   * `onError` exists because "returned null" covers two very different
+   * things: an address with nothing on it (a timeout) and an address whose
+   * agent actively refused us (bad v3 credentials, unknown user, wrong
+   * security level, refused port). Collapsing both into null is what let a
+   * whole subnet of credential rejections be reported as a clean "0 hosts
+   * found". The callback hands the caller the failure it would otherwise
+   * never see; the return value is unchanged, so callers that do not care
+   * keep the old behaviour.
    */
   public static async probeSystemInfo(
     config: MonitorStepSnmpMonitor,
+    onError?: ((error: unknown) => void) | undefined,
   ): Promise<SnmpSystemInfo | null> {
-    const session: snmp.Session = SnmpMonitor.createSnmpSession(config, {});
+    let session: snmp.Session;
+
+    try {
+      session = SnmpMonitor.createSnmpSession(config, {});
+    } catch (err) {
+      /*
+       * Session construction itself throws for an unusable configuration —
+       * v3 selected with no username, an unrecognized auth/priv protocol.
+       * That is a scan-wide misconfiguration, not a quiet host, so it must
+       * reach onError rather than look like one more silent address.
+       */
+      onError?.(err);
+      return null;
+    }
 
     try {
       return await SnmpMonitor.readSystemInfo(session);
-    } catch {
+    } catch (err) {
+      onError?.(err);
       return null;
     } finally {
       session.close();


### PR DESCRIPTION
Fixes #3078.

## Why the scan found nothing

Nothing in the code treats `10.244.x` differently from `10.243.x`, so the difference is environmental — but the product turned that environmental difference into a **silent, undiagnosable zero**, and one design choice actively manufactured false negatives.

**The ICMP pre-sweep was a hard gate.** `SubnetScanner` pinged each address first and, if it got no echo reply, `continue`d — the host was *never* SNMP-probed. That is only an optimisation, and it is wrong exactly where it matters most: a firewalled management VLAN routinely drops echo while permitting UDP/161 from the NMS, and Windows hosts block echo by default. On such a segment every address looks dead, every SNMP probe is skipped, and the sweep reports a confident `Completed / 0 of 254` that is indistinguishable from empty address space — while an adjacent VLAN that permits echo scans perfectly. That matches the report exactly, including the targeted `10.244.101-102.11` scan returning `0 of 2` against a device known to have SNMPv3 enabled.

Three things then made it impossible to see:

- **SNMP errors were swallowed.** `probeSystemInfo` returned `null` for both "nothing is at this address" (a timeout) and "the agent refused these credentials". One credential set covers the whole sweep, so a single wrong v3 key blanks all 254 hosts and reports a clean zero.
- **The one diagnostic that existed was never rendered.** The probe already composed `Swept 254 hosts: 0 answered ICMP ping, 0 answered SNMP.`, the server stored it in `statusMessage`, and the Discovery page *selected that column* — then never displayed it.
- **"Responded Hosts" counts SNMP responders only**, so a subnet with 40 live hosts and 0 SNMP answers rendered identically to an empty one.

(The reporter's build is ≥12.0.0, so it contains both the ICMP gate and the existing SNMPv3 DES-on-OpenSSL-3 fix — DES is not a factor here.)

## What this changes

**Probe — the ICMP gate can no longer silence a subnet.** The sweep now runs in phases: ICMP pre-sweep → SNMP-probe the ICMP-alive hosts → and when that pass finds **no SNMP responder at all**, re-probe every address it skipped. The extra cost lands only on scans that would otherwise have returned nothing; the fast path is untouched whenever anything answers. Worst-case wall clock at `MAX_SCAN_HOSTS` goes from ~34 min to ~51 min, still inside the 2-hour abandoned-scan window (comment in `ScanTargetUtil` updated).

**Probe — SNMP failures are surfaced, not swallowed.** `probeSystemInfo` takes an optional `onError` callback, including for failures thrown while the session is being built (v3 with no username, an unrecognized auth/priv protocol — scan-wide misconfigurations that previously looked like one more quiet address, on every host). The scanner tallies non-timeout errors and reports the most common one verbatim. `Authentication failure` means the device is reachable and speaking SNMP — a completely different fix from "the probe can't see this subnet".

**Probe — the status message names the reason.** It now distinguishes an ICMP-filtered segment, rejected credentials, and nothing-reachable-at-all, and when a sweep is completely silent it names the port and what to check (routing, UDP/161, the devices' SNMP ACL).

**Dashboard — the diagnostic is actually shown.** The scans list renders the status message and a `+ N alive without SNMP` line beneath the responder count; the Review Results modal carries the message too. The reading of a scan row moved into a pure `DiscoveryScanOutcome` helper so it is unit-testable in the repo's node test environment.

**Both — the message can't break the write.** `statusMessage` is a `varchar(500)` and Postgres *throws* rather than truncating. The probe bounds its message, and the ingest endpoint clips defensively after the rescan-clamp note is appended — otherwise an over-long value would fail the whole result write and strand a finished scan In Progress.

## Tests

188 tests across the changed paths, all green.

| Suite | Covers |
| --- | --- |
| `Probe/Tests/Utils/Discovery/SubnetScannerIcmpFallback.test.ts` (28) | Fully and partially ICMP-filtered subnets; when the fallback must **not** run (a responder exists, pre-sweep unavailable, everything already probed); no address probed twice; ordering across both passes; credentials/version/port/timeout/retries carried into the re-probe; concurrency cap held across both passes; error tallying — timeouts ignored in any casing, most-common selection, 120-char excerpt cap, non-`Error` throws, rejections during the fallback pass, and the rule that a rejection alone does not create a phantom host |
| `Probe/Tests/Jobs/Discovery/DiscoveryScanEndToEnd.test.ts` (11) | Real `SubnetScanner` + real `runScan`, with only ICMP and the SNMP probe stubbed: an ICMP-filtered subnet, one whose devices reject the credentials, both at once, one that is unreachable, a healthy one (fast path preserved), and scan-wide misconfigurations that must fail up front |
| `Probe/Tests/Jobs/Discovery/DiscoveryScanStatusMessage.test.ts` (18) | Every branch and combination of the summary, the non-default port, results from an older probe (no `undefined`/`NaN` leaking), and that the worst realistic message fits the 500-char column |
| `Probe/Tests/Utils/Monitors/MonitorTypes/SnmpMonitorProbeSystemInfo.test.ts` (11) | The `onError` seam against a scripted net-snmp session: auth failures, timeouts, empty varbinds, session-construction failures, session close on every path, and unchanged behaviour for callers passing no callback |
| `App/Tests/Dashboard/DiscoveryScanOutcome.test.ts` (20) | The scans-list reading: zero-vs-empty, ping-only tallies, legacy rows with no `snmpReachable`, unreported scans, and a non-array `discoveredDevices` column not crashing a table cell |
| `Probe/Tests/Utils/Discovery/SubnetScanner.test.ts`, `FetchScansLifecycle.test.ts`, `ProbeIngestDiscoveryScan.test.ts` | Extended in place; one test that encoded the old ICMP-gate behaviour was rewritten to the new contract |

`Probe`, `App` and `Common` all type-check clean and ESLint passes. The dashboard change is verified by type-check, lint and the extracted-helper tests — exercising it in a browser needs the full stack with seeded scan rows, which I did not stand up.
