### PR TITLE
fix(call-sms-config): let two configs share Twilio credentials (#3020)

### DIFF
--- a/Common/Models/DatabaseModels/ProjectCallSMSConfig.ts
+++ b/Common/Models/DatabaseModels/ProjectCallSMSConfig.ts
@@ -413,11 +413,18 @@ export default class ProjectCallSMSConfig extends BaseModel {
     description: "Account SID for your Twilio Account",
     example: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
   })
+  /*
+   * NOT unique. One Twilio account legitimately backs more than one config —
+   * a project splitting SMS and Voice across two numbers on the same account,
+   * or two projects on a shared instance using the same account. A global
+   * UNIQUE here made the second such config fail with a bare 500 (issue #3020),
+   * across the tenant boundary as well as within a project.
+   */
   @Column({
     type: ColumnType.ShortText,
     length: ColumnLength.ShortText,
     nullable: true,
-    unique: true,
+    unique: false,
   })
   public twilioAccountSID?: string = undefined;
 
@@ -449,11 +456,12 @@ export default class ProjectCallSMSConfig extends BaseModel {
     description: "Auth Token for your Twilio Account",
     example: "your-twilio-auth-token",
   })
+  /* NOT unique, for the same reason as twilioAccountSID above. */
   @Column({
     type: ColumnType.ShortText,
     length: ColumnLength.ShortText,
     nullable: true,
-    unique: true,
+    unique: false,
   })
   public twilioAuthToken?: string = undefined;
 

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786700000000-DropProjectCallSMSConfigCredentialUniques.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786700000000-DropProjectCallSMSConfigCredentialUniques.ts
@@ -1,0 +1,76 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * Drops the global UNIQUE constraints on ProjectCallSMSConfig's Twilio
+ * credentials. Generated with `npm run generate-postgres-migration` after
+ * flipping both columns to `unique: false`; the statements are the generator's,
+ * renumbered to sort last and given IF EXISTS (see below).
+ *
+ * WHY THEY WERE WRONG
+ *
+ * ProjectCallSMSConfig is tenant-scoped (@TenantColumn("projectId")) and
+ * inherently multi-row: a project has as many configs as it has Twilio
+ * setups. The constraints came from the InitialMigration, where this table's
+ * columns were modelled on GlobalConfig — a singleton table whose every column
+ * carries a pointless `unique: true`. On a singleton that is harmless. Here it
+ * meant no two rows anywhere in the instance could share a Twilio account.
+ *
+ * That is not a constraint anybody wants:
+ *
+ *   - One Twilio account, two numbers. Poland (and several other countries)
+ *     requires a Local number for Voice and a Mobile number for SMS, so a
+ *     single project legitimately needs two configs on one account. This is
+ *     what issue #3020 was reported against.
+ *   - Two projects, one account. On a shared instance the FIRST project to
+ *     save a given account SID locked every other project out of it, across
+ *     the tenant boundary — one tenant could deny another the use of its own
+ *     Twilio credentials, and neither could see why.
+ *
+ * Both surfaced the same way: Postgres raised unique_violation (23505),
+ * which is not a OneUptime Exception, so it fell through to the generic
+ * handler and reached the client as a bare 500 `{"error":"Server Error"}`
+ * with nothing to act on.
+ *
+ * NOT REPLACED WITH A NARROWER UNIQUE
+ *
+ * There is no uniqueness to restore at any scope. Reusing one account across
+ * configs is the supported case, not an accident to be guarded against. Config
+ * identity is `name`, which is already unique per project via
+ * @UniqueColumnBy("projectId"). After this migration ProjectCallSMSConfig has
+ * no UNIQUE constraint on any credential column, which matches every other
+ * tenant-scoped table: theirs are all on slugs, keys and tokens — identifiers
+ * that really are global.
+ *
+ * IF EXISTS
+ *
+ * Self-hosted operators hit by #3020 were told in the issue thread that the
+ * workaround is to drop the constraint by hand. IF EXISTS keeps this migration
+ * from failing on those databases. down() cannot be made safe the same way: it
+ * will fail if duplicates exist by then, which is correct — silently
+ * hard-deleting a project's Twilio config to make room for a constraint would
+ * be worse than a failed rollback.
+ */
+export class DropProjectCallSMSConfigCredentialUniques1786700000000
+  implements MigrationInterface
+{
+  public name: string =
+    "DropProjectCallSMSConfigCredentialUniques1786700000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "ProjectCallSMSConfig" DROP CONSTRAINT IF EXISTS "UQ_0886139eac04ad49627e446d477"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ProjectCallSMSConfig" DROP CONSTRAINT IF EXISTS "UQ_2eb1a240d549a7701b6e82d2f94"`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "ProjectCallSMSConfig" ADD CONSTRAINT "UQ_2eb1a240d549a7701b6e82d2f94" UNIQUE ("twilioAuthToken")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "ProjectCallSMSConfig" ADD CONSTRAINT "UQ_0886139eac04ad49627e446d477" UNIQUE ("twilioAccountSID")`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -510,6 +510,7 @@ import { QuarantineUnboundGitHubInstallations1786300000000 } from "./17863000000
 import { AddMasterPasswordSalt1786400000000 } from "./1786400000000-AddMasterPasswordSalt";
 import { AddInvestigationCodeFixRecommendation1786500000000 } from "./1786500000000-AddInvestigationCodeFixRecommendation";
 import { AddInvestigationAnalysisTldr1786600000000 } from "./1786600000000-AddInvestigationAnalysisTldr";
+import { DropProjectCallSMSConfigCredentialUniques1786700000000 } from "./1786700000000-DropProjectCallSMSConfigCredentialUniques";
 
 export default [
   InitialMigration,
@@ -1024,4 +1025,5 @@ export default [
   MigrationName1786105470826,
   AddInvestigationCodeFixRecommendation1786500000000,
   AddInvestigationAnalysisTldr1786600000000,
+  DropProjectCallSMSConfigCredentialUniques1786700000000,
 ];

--- a/Common/Server/Services/RumSessionPinService.ts
+++ b/Common/Server/Services/RumSessionPinService.ts
@@ -6,36 +6,22 @@ import OneUptimeDate from "../../Types/Date";
 import CreateBy from "../Types/Database/CreateBy";
 import { OnCreate } from "../Types/Database/Hooks";
 import QueryHelper from "../Types/Database/QueryHelper";
+import PostgresErrorTranslator from "../Utils/Database/PostgresErrorTranslator";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
-
-/* Postgres unique_violation. https://www.postgresql.org/docs/current/errcodes-appendix.html */
-const UNIQUE_VIOLATION: string = "23505";
 
 type IsUniqueViolationFunction = (error: unknown) => boolean;
 
 /*
- * TypeORM wraps driver failures in QueryFailedError, which hoists the pg
- * fields onto itself but also keeps the original under `driverError`.
- * Check both rather than assuming which one carries the code.
+ * Detection lives in PostgresErrorTranslator because DatabaseService.create
+ * runs every failure through it before rethrowing, so what lands in the catch
+ * below is a BadDataException carrying the SQLSTATE — not the raw
+ * QueryFailedError. A local `code === "23505"` check would silently stop
+ * matching and take the race recovery with it.
  */
 const isUniqueViolation: IsUniqueViolationFunction = (
   error: unknown,
 ): boolean => {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-
-  if ((error as { code?: string | undefined }).code === UNIQUE_VIOLATION) {
-    return true;
-  }
-
-  const driverError: unknown = (error as { driverError?: unknown }).driverError;
-
-  return Boolean(
-    driverError &&
-      typeof driverError === "object" &&
-      (driverError as { code?: string | undefined }).code === UNIQUE_VIOLATION,
-  );
+  return PostgresErrorTranslator.isUniqueViolation(error);
 };
 
 /*

--- a/Common/Server/Utils/Database/PostgresErrorTranslator.ts
+++ b/Common/Server/Utils/Database/PostgresErrorTranslator.ts
@@ -6,6 +6,7 @@ import Exception from "../../../Types/Exception/Exception";
  * https://www.postgresql.org/docs/current/errcodes-appendix.html
  */
 const FOREIGN_KEY_VIOLATION: string = "23503";
+const UNIQUE_VIOLATION: string = "23505";
 
 /*
  * TypeORM reports driver failures as QueryFailedError, which does not extend
@@ -25,48 +26,34 @@ interface PostgresDriverError {
   detail?: string | undefined;
 }
 
+/*
+ * The SQLSTATE that produced a translated exception, recorded on the exception
+ * itself. `Exception.code` is the OneUptime ExceptionCode (a number), so the
+ * driver code needs a field of its own — without it, translation is one-way and
+ * a caller that recovers from one specific failure can no longer tell which
+ * failure it got. RumSessionPinService is exactly that caller: it turns a
+ * unique violation on (projectId, rumApplicationId, sessionId) into an
+ * idempotent "already pinned" instead of an error the user has to interpret.
+ */
+export interface TranslatedPostgresException extends Exception {
+  postgresErrorCode?: string | undefined;
+}
+
 export default class PostgresErrorTranslator {
   public static translate(error: unknown): unknown {
     const driverError: PostgresDriverError | null =
       this.getPostgresDriverError(error);
 
-    if (!driverError || driverError.code !== FOREIGN_KEY_VIOLATION) {
+    if (!driverError) {
       return error;
     }
 
-    const detail: string = driverError.detail || "";
-
-    /*
-     * DELETE blocked by a child row:
-     *   Key (_id)=(...) is still referenced from table "MonitorStatusTimeline".
-     */
-    if (detail.includes("is still referenced from table")) {
-      const referencingTable: string =
-        this.getTableNameFromDetail(detail) || driverError.table || "";
-
-      return new BadDataException(
-        referencingTable
-          ? `This item cannot be deleted because ${this.humanizeTableName(
-              referencingTable,
-            )} records still reference it. Please delete those records first, and then try again.`
-          : "This item cannot be deleted because other records still reference it. Please delete those records first, and then try again.",
-      );
+    if (driverError.code === FOREIGN_KEY_VIOLATION) {
+      return this.translateForeignKeyViolation(error, driverError);
     }
 
-    /*
-     * INSERT/UPDATE pointing at a row that does not exist:
-     *   Key (monitorStatusId)=(...) is not present in table "MonitorStatus".
-     */
-    if (detail.includes("is not present in table")) {
-      const referencedTable: string = this.getTableNameFromDetail(detail) || "";
-
-      return new BadDataException(
-        referencedTable
-          ? `This request references ${this.humanizeTableName(
-              referencedTable,
-            )} that does not exist. Please check the request and try again.`
-          : "This request references an item that does not exist. Please check the request and try again.",
-      );
+    if (driverError.code === UNIQUE_VIOLATION) {
+      return this.translateUniqueViolation(error, driverError);
     }
 
     return error;
@@ -78,6 +65,138 @@ export default class PostgresErrorTranslator {
    */
   public static translateException(error: Exception): Exception {
     return this.translate(error) as Exception;
+  }
+
+  /*
+   * True for a unique violation whether or not it has been through translate().
+   * Callers that recover from a duplicate must use this rather than checking
+   * `code === "23505"` themselves: by the time a service's own catch block sees
+   * an error thrown out of DatabaseService, it has already been translated.
+   */
+  public static isUniqueViolation(error: unknown): boolean {
+    if (!error || typeof error !== "object") {
+      return false;
+    }
+
+    if (
+      (error as TranslatedPostgresException).postgresErrorCode ===
+      UNIQUE_VIOLATION
+    ) {
+      return true;
+    }
+
+    const driverError: PostgresDriverError | null =
+      this.getPostgresDriverError(error);
+
+    return driverError?.code === UNIQUE_VIOLATION;
+  }
+
+  private static translateForeignKeyViolation(
+    error: unknown,
+    driverError: PostgresDriverError,
+  ): unknown {
+    const detail: string = driverError.detail || "";
+
+    /*
+     * DELETE blocked by a child row:
+     *   Key (_id)=(...) is still referenced from table "MonitorStatusTimeline".
+     */
+    if (detail.includes("is still referenced from table")) {
+      const referencingTable: string =
+        this.getTableNameFromDetail(detail) || driverError.table || "";
+
+      return this.tag(
+        new BadDataException(
+          referencingTable
+            ? `This item cannot be deleted because ${this.humanizeTableName(
+                referencingTable,
+              )} records still reference it. Please delete those records first, and then try again.`
+            : "This item cannot be deleted because other records still reference it. Please delete those records first, and then try again.",
+        ),
+        driverError,
+      );
+    }
+
+    /*
+     * INSERT/UPDATE pointing at a row that does not exist:
+     *   Key (monitorStatusId)=(...) is not present in table "MonitorStatus".
+     */
+    if (detail.includes("is not present in table")) {
+      const referencedTable: string = this.getTableNameFromDetail(detail) || "";
+
+      return this.tag(
+        new BadDataException(
+          referencedTable
+            ? `This request references ${this.humanizeTableName(
+                referencedTable,
+              )} that does not exist. Please check the request and try again.`
+            : "This request references an item that does not exist. Please check the request and try again.",
+        ),
+        driverError,
+      );
+    }
+
+    return error;
+  }
+
+  /*
+   * INSERT/UPDATE colliding with an existing row:
+   *   Key ("twilioAccountSID")=(AC123...) already exists.
+   *
+   * The column names go into the message because they tell the user which
+   * field to change. The values do not: they are another row's data, and that
+   * row may well belong to a different project (issue #3020 was reported
+   * against exactly such a cross-tenant collision).
+   */
+  private static translateUniqueViolation(
+    error: unknown,
+    driverError: PostgresDriverError,
+  ): unknown {
+    const detail: string = driverError.detail || "";
+
+    if (!detail.includes("already exists")) {
+      return error;
+    }
+
+    const columns: Array<string> = this.getColumnNamesFromDetail(detail);
+    const subject: string = driverError.table
+      ? `A ${this.humanizeTableName(driverError.table)}`
+      : "A record";
+
+    if (columns.length === 0) {
+      return this.tag(
+        new BadDataException(
+          `${subject} with these values already exists. Please use different values and try again.`,
+        ),
+        driverError,
+      );
+    }
+
+    const fields: string = columns
+      .map((column: string): string => {
+        return this.humanizeColumnName(column);
+      })
+      .join(", ");
+
+    return this.tag(
+      new BadDataException(
+        columns.length === 1
+          ? `${subject} with this ${fields} already exists. Please use a different value and try again.`
+          : `${subject} with the same ${fields} already exists. Please use different values and try again.`,
+      ),
+      driverError,
+    );
+  }
+
+  /* Records the SQLSTATE on the translated exception. See the interface above. */
+  private static tag(
+    exception: BadDataException,
+    driverError: PostgresDriverError,
+  ): BadDataException {
+    (exception as TranslatedPostgresException).postgresErrorCode =
+      driverError.code;
+
+    return exception;
   }
 
   private static getPostgresDriverError(
@@ -118,6 +237,32 @@ export default class PostgresErrorTranslator {
   }
 
   /*
+   * `Key ("twilioAccountSID")=(AC1)...` -> ["twilioAccountSID"]
+   * `Key (slug)=(acme)...`              -> ["slug"]
+   * `Key (a, "b")=(1, 2)...`            -> ["a", "b"]
+   *
+   * Postgres quotes an identifier only when it needs to, so both forms turn up
+   * in the same database. Anchored on the leading `Key (` so the value list
+   * that follows cannot be mistaken for the column list.
+   */
+  private static getColumnNamesFromDetail(detail: string): Array<string> {
+    const match: RegExpMatchArray | null = detail.match(/^Key \(([^)]*)\)=/);
+
+    if (!match || !match[1]) {
+      return [];
+    }
+
+    return match[1]
+      .split(",")
+      .map((column: string): string => {
+        return column.trim().replace(/^"(.*)"$/, "$1");
+      })
+      .filter((column: string): boolean => {
+        return column.length > 0;
+      });
+  }
+
+  /*
    * "MonitorStatusTimeline" -> "Monitor Status Timeline". Table names are the
    * PascalCase model names, so this reads well enough to put in front of a
    * user without maintaining a lookup table of display names.
@@ -127,5 +272,15 @@ export default class PostgresErrorTranslator {
       .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
       .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
       .trim();
+  }
+
+  /*
+   * "twilioAccountSID" -> "Twilio Account SID". Same split as table names, but
+   * columns are camelCase so the first letter needs capitalising too.
+   */
+  private static humanizeColumnName(columnName: string): string {
+    const humanized: string = this.humanizeTableName(columnName);
+
+    return humanized.charAt(0).toUpperCase() + humanized.slice(1);
   }
 }

--- a/Common/Tests/Server/Services/ProjectCallSMSConfigCredentialUniqueness.test.ts
+++ b/Common/Tests/Server/Services/ProjectCallSMSConfigCredentialUniqueness.test.ts
@@ -1,0 +1,305 @@
+import ProjectCallSMSConfig from "../../../Models/DatabaseModels/ProjectCallSMSConfig";
+import InitialMigration from "../../../Server/Infrastructure/Postgres/SchemaMigrations/1717605043663-InitialMigration";
+import { DropProjectCallSMSConfigCredentialUniques1786700000000 } from "../../../Server/Infrastructure/Postgres/SchemaMigrations/1786700000000-DropProjectCallSMSConfigCredentialUniques";
+import SchemaMigrations from "../../../Server/Infrastructure/Postgres/SchemaMigrations/Index";
+import { QueryRunner, getMetadataArgsStorage } from "typeorm";
+import type { ColumnMetadataArgs } from "typeorm/metadata-args/ColumnMetadataArgs";
+import { describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Issue #3020: POST/PUT /api/call-sms-config answered 500 {"error":"Server
+ * Error"} the moment a second config was given Twilio credentials that another
+ * row already held.
+ *
+ * ProjectCallSMSConfig's columns were modelled on GlobalConfig, a SINGLETON
+ * table whose every column carries a pointless `unique: true`. Copied onto a
+ * tenant-scoped, inherently multi-row table, that became a global UNIQUE on
+ * twilioAccountSID and twilioAuthToken — no two rows anywhere in the instance
+ * could share a Twilio account. Two legitimate setups were then impossible:
+ *
+ *   1. One account, two numbers. Poland requires a Local number for Voice and
+ *      a Mobile number for SMS, so one project needs two configs on one
+ *      account. This is what the issue was filed against.
+ *   2. Two projects, one account — the first project to save an account SID
+ *      locked every other tenant out of it, and neither could see why.
+ *
+ * Two things must hold for the fix, and a regression in either one puts the
+ * 500 straight back:
+ *   1. neither credential column declares `unique: true` (a `unique: true`
+ *      here is what makes schema:generate re-ADD the constraint as "drift"),
+ *   2. the migration drops both constraints AND is registered in
+ *      SchemaMigrations/Index.ts — an unregistered migration never runs, so
+ *      every existing database keeps the constraint.
+ *
+ * Pure metadata/mocks — no Postgres connection anywhere.
+ */
+
+const CREDENTIAL_COLUMNS: Array<string> = [
+  "twilioAccountSID",
+  "twilioAuthToken",
+];
+
+const ACCOUNT_SID_CONSTRAINT: string = "UQ_0886139eac04ad49627e446d477";
+const AUTH_TOKEN_CONSTRAINT: string = "UQ_2eb1a240d549a7701b6e82d2f94";
+
+function columnArgs(propertyName: string): ColumnMetadataArgs {
+  const args: ColumnMetadataArgs | undefined = getMetadataArgsStorage()
+    .columns.filter((column: ColumnMetadataArgs) => {
+      return column.target === ProjectCallSMSConfig;
+    })
+    .find((column: ColumnMetadataArgs) => {
+      return column.propertyName === propertyName;
+    });
+
+  if (!args) {
+    throw new Error(
+      `ProjectCallSMSConfig.${propertyName} has no TypeORM @Column metadata`,
+    );
+  }
+
+  return args;
+}
+
+function makeQueryRunner(): {
+  runner: QueryRunner;
+  query: jest.Mock;
+} {
+  const query: jest.Mock = jest.fn(() => {
+    return Promise.resolve(undefined);
+  }) as unknown as jest.Mock;
+
+  /*
+   * InitialMigration short-circuits when it finds a "File" table, so that its
+   * CREATE TABLEs are not replayed over an existing database. Undefined means
+   * "empty database", which is the path that actually emits the SQL.
+   */
+  const getTable: jest.Mock = jest.fn(() => {
+    return Promise.resolve(undefined);
+  }) as unknown as jest.Mock;
+
+  return { runner: { query, getTable } as unknown as QueryRunner, query };
+}
+
+function executedSql(query: jest.Mock): Array<string> {
+  return query.mock.calls.map((call: Array<unknown>) => {
+    return String(call[0]);
+  });
+}
+
+describe("ProjectCallSMSConfig credential columns", () => {
+  test.each(CREDENTIAL_COLUMNS)(
+    "%s is not declared unique — a Twilio account can back more than one config",
+    (propertyName: string) => {
+      expect(columnArgs(propertyName).options.unique).toBe(false);
+    },
+  );
+
+  test.each(CREDENTIAL_COLUMNS)(
+    "%s is still nullable, so a config may exist before credentials are entered",
+    (propertyName: string) => {
+      expect(columnArgs(propertyName).options.nullable).toBe(true);
+    },
+  );
+
+  test("twilioPrimaryPhoneNumber is not unique either — two projects can share a number", () => {
+    expect(columnArgs("twilioPrimaryPhoneNumber").options.unique).toBe(false);
+  });
+
+  test("no column on this table declares unique: true at all", () => {
+    /*
+     * The whole class of bug, not just the two columns the issue happened to
+     * name. Config identity is `name`, which is unique PER PROJECT through
+     * @UniqueColumnBy("projectId") — an app-level check, not a DB constraint.
+     * Nothing on a tenant-scoped provider-credential table should ever be
+     * globally unique, so the correct count is zero.
+     */
+    const uniqueColumns: Array<string> = getMetadataArgsStorage()
+      .columns.filter((column: ColumnMetadataArgs) => {
+        return (
+          column.target === ProjectCallSMSConfig &&
+          column.options.unique === true
+        );
+      })
+      .map((column: ColumnMetadataArgs) => {
+        return column.propertyName;
+      });
+
+    expect(uniqueColumns).toEqual([]);
+  });
+
+  test("the columns are wide enough for real Twilio credentials", () => {
+    /*
+     * Guards the alternative explanation for the reported 500. A live account
+     * SID is 34 characters and an auth token 32, so truncation was never the
+     * cause — but if these ever narrowed below that, the same endpoint would
+     * start answering 500 again for an entirely different reason.
+     */
+    for (const propertyName of CREDENTIAL_COLUMNS) {
+      expect(Number(columnArgs(propertyName).options.length)).toBeGreaterThan(
+        34,
+      );
+    }
+  });
+});
+
+describe("DropProjectCallSMSConfigCredentialUniques migration", () => {
+  test("up() drops both credential constraints", async () => {
+    const { runner, query } = makeQueryRunner();
+
+    await new DropProjectCallSMSConfigCredentialUniques1786700000000().up(
+      runner,
+    );
+
+    const sql: Array<string> = executedSql(query);
+
+    expect(sql).toHaveLength(2);
+    expect(sql[0]).toContain(ACCOUNT_SID_CONSTRAINT);
+    expect(sql[1]).toContain(AUTH_TOKEN_CONSTRAINT);
+
+    for (const statement of sql) {
+      expect(statement).toContain(`ALTER TABLE "ProjectCallSMSConfig"`);
+      expect(statement).toContain("DROP CONSTRAINT");
+    }
+  });
+
+  test("up() drops nothing else — no drift statements smuggled in", () => {
+    /*
+     * An autogenerated migration emits every difference it finds, so a
+     * regenerated file can quietly carry unrelated ALTERs. Both statements
+     * must be DROP CONSTRAINT against this one table.
+     */
+    const { runner, query } = makeQueryRunner();
+
+    return new DropProjectCallSMSConfigCredentialUniques1786700000000()
+      .up(runner)
+      .then(() => {
+        for (const statement of executedSql(query)) {
+          expect(statement).not.toContain("ADD");
+          expect(statement).not.toContain("DROP COLUMN");
+          expect(statement).not.toMatch(
+            /ALTER TABLE "(?!ProjectCallSMSConfig)/,
+          );
+        }
+      });
+  });
+
+  test("up() is idempotent — IF EXISTS, so a hand-dropped constraint does not fail the deploy", async () => {
+    /*
+     * Self-hosted operators hit by #3020 were told the workaround is to drop
+     * the constraint by hand. Without IF EXISTS this migration would abort on
+     * exactly the databases that most needed it.
+     */
+    const { runner, query } = makeQueryRunner();
+
+    await new DropProjectCallSMSConfigCredentialUniques1786700000000().up(
+      runner,
+    );
+
+    for (const statement of executedSql(query)) {
+      expect(statement).toContain("DROP CONSTRAINT IF EXISTS");
+    }
+  });
+
+  test("down() restores both constraints on the original columns", async () => {
+    const { runner, query } = makeQueryRunner();
+
+    await new DropProjectCallSMSConfigCredentialUniques1786700000000().down(
+      runner,
+    );
+
+    const sql: Array<string> = executedSql(query);
+
+    expect(sql).toHaveLength(2);
+    expect(sql.join("\n")).toContain(
+      `ADD CONSTRAINT "${AUTH_TOKEN_CONSTRAINT}" UNIQUE ("twilioAuthToken")`,
+    );
+    expect(sql.join("\n")).toContain(
+      `ADD CONSTRAINT "${ACCOUNT_SID_CONSTRAINT}" UNIQUE ("twilioAccountSID")`,
+    );
+  });
+
+  test("down() reuses the original constraint names, so up() can drop them again", async () => {
+    /*
+     * A rollback that invented new names would leave the next roll-forward
+     * dropping constraints that no longer exist and leaving the real ones in
+     * place — the bug would survive its own fix.
+     */
+    const upRunner: {
+      runner: QueryRunner;
+      query: jest.Mock;
+    } = makeQueryRunner();
+    const downRunner: {
+      runner: QueryRunner;
+      query: jest.Mock;
+    } = makeQueryRunner();
+    const migration: DropProjectCallSMSConfigCredentialUniques1786700000000 =
+      new DropProjectCallSMSConfigCredentialUniques1786700000000();
+
+    await migration.up(upRunner.runner);
+    await migration.down(downRunner.runner);
+
+    for (const constraint of [ACCOUNT_SID_CONSTRAINT, AUTH_TOKEN_CONSTRAINT]) {
+      expect(executedSql(upRunner.query).join("\n")).toContain(constraint);
+      expect(executedSql(downRunner.query).join("\n")).toContain(constraint);
+    }
+  });
+
+  test("targets the constraint names the InitialMigration actually created", () => {
+    /*
+     * The names are opaque TypeORM hashes. If they were mistyped, up() would
+     * silently drop nothing (IF EXISTS makes that a no-op rather than an
+     * error) and every database would keep the constraint. Pin them against
+     * the CREATE TABLE that introduced them.
+     */
+    const { runner, query } = makeQueryRunner();
+
+    return new InitialMigration().up(runner).then(() => {
+      const createTable: string | undefined = executedSql(query).find(
+        (statement: string) => {
+          return statement.includes(`CREATE TABLE "ProjectCallSMSConfig"`);
+        },
+      );
+
+      expect(createTable).toBeDefined();
+      expect(createTable).toContain(
+        `CONSTRAINT "${ACCOUNT_SID_CONSTRAINT}" UNIQUE ("twilioAccountSID")`,
+      );
+      expect(createTable).toContain(
+        `CONSTRAINT "${AUTH_TOKEN_CONSTRAINT}" UNIQUE ("twilioAuthToken")`,
+      );
+    });
+  });
+
+  test("is registered in SchemaMigrations/Index.ts", () => {
+    expect(SchemaMigrations).toContain(
+      DropProjectCallSMSConfigCredentialUniques1786700000000,
+    );
+  });
+
+  test("is registered exactly once", () => {
+    const occurrences: number = SchemaMigrations.filter(
+      (migration: unknown) => {
+        return (
+          migration === DropProjectCallSMSConfigCredentialUniques1786700000000
+        );
+      },
+    ).length;
+
+    expect(occurrences).toBe(1);
+  });
+
+  test("runs after the migration that created the constraints", () => {
+    /*
+     * TypeORM executes registered migrations in array order. Dropping a
+     * constraint before the CREATE TABLE that declares it is a no-op that
+     * leaves the constraint in place once the table finally arrives.
+     */
+    const createIndex: number = SchemaMigrations.indexOf(InitialMigration);
+    const dropIndex: number = SchemaMigrations.indexOf(
+      DropProjectCallSMSConfigCredentialUniques1786700000000,
+    );
+
+    expect(createIndex).toBeGreaterThanOrEqual(0);
+    expect(dropIndex).toBeGreaterThan(createIndex);
+  });
+});

--- a/Common/Tests/Server/Services/RumSessionPinUniqueViolationRecovery.test.ts
+++ b/Common/Tests/Server/Services/RumSessionPinUniqueViolationRecovery.test.ts
@@ -1,0 +1,163 @@
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import RumSessionPinService from "../../../Server/Services/RumSessionPinService";
+import PostgresErrorTranslator from "../../../Server/Utils/Database/PostgresErrorTranslator";
+import RumSessionPin from "../../../Models/DatabaseModels/RumSessionPin";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * Collateral guard for the issue #3020 fix.
+ *
+ * That fix taught PostgresErrorTranslator to turn a Postgres unique_violation
+ * (23505) into a BadDataException, so a duplicate reaches the client as a 400
+ * naming the field instead of a bare 500 "Server Error".
+ *
+ * RumSessionPinService is the one caller that RECOVERS from a unique violation
+ * rather than reporting it: pinning an already-pinned recording returns the
+ * existing pin instead of erroring, and the catch block closes the race between
+ * two concurrent pins. It used to detect the violation with a local
+ * `code === "23505"` check — which stopped matching the moment translation
+ * happened, because DatabaseService.create runs every failure through the
+ * translator BEFORE rethrowing. The error arriving in that catch is a
+ * BadDataException whose `code` is the numeric ExceptionCode, not a SQLSTATE.
+ *
+ * These tests pin the recovery to the translated shape, so translating more
+ * SQLSTATEs later cannot silently turn "already pinned" back into an error.
+ *
+ * DatabaseService.prototype.create is spied so super.create() is observable
+ * without a database.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "00000000-0000-4000-8000-000000000001",
+);
+const RUM_APPLICATION_ID: ObjectID = new ObjectID(
+  "00000000-0000-4000-8000-000000000002",
+);
+const SESSION_ID: string = "session-abc";
+
+/* The error DatabaseService.create actually throws after translation. */
+function translatedUniqueViolation(): unknown {
+  return PostgresErrorTranslator.translate({
+    message:
+      'duplicate key value violates unique constraint "IDX_rum_session_pin_session"',
+    code: "23505",
+    table: "RumSessionPin",
+    detail:
+      'Key ("projectId", "rumApplicationId", "sessionId")=(00000000-0000-4000-8000-000000000001, 00000000-0000-4000-8000-000000000002, session-abc) already exists.',
+  });
+}
+
+function createBy(): CreateBy<RumSessionPin> {
+  const data: RumSessionPin = new RumSessionPin();
+  data.projectId = PROJECT_ID;
+  data.rumApplicationId = RUM_APPLICATION_ID;
+  data.sessionId = SESSION_ID;
+
+  return { data, props: { isRoot: true } } as CreateBy<RumSessionPin>;
+}
+
+function existingPin(): RumSessionPin {
+  const pin: RumSessionPin = new RumSessionPin();
+  pin._id = "00000000-0000-4000-8000-000000000003";
+  pin.projectId = PROJECT_ID;
+  pin.rumApplicationId = RUM_APPLICATION_ID;
+  pin.sessionId = SESSION_ID;
+
+  return pin;
+}
+
+describe("RumSessionPinService recovery from a translated unique violation", () => {
+  let createSpy: jest.SpyInstance;
+  let getPinSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    createSpy = jest.spyOn(DatabaseService.prototype, "create");
+    getPinSpy = jest.spyOn(RumSessionPinService, "getPinForSession");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("the error thrown by create() really is translated, not raw", () => {
+    /*
+     * Guards the premise. If this stopped being a BadDataException the rest of
+     * these tests would be exercising a shape that no longer occurs.
+     */
+    expect(translatedUniqueViolation()).toBeInstanceOf(BadDataException);
+  });
+
+  test("a raced duplicate pin returns the existing pin instead of throwing", async () => {
+    const pin: RumSessionPin = existingPin();
+
+    /* Pre-check finds nothing; the racing request wins; the retry finds it. */
+    getPinSpy
+      .mockResolvedValueOnce(null as never)
+      .mockResolvedValueOnce(pin as never);
+    createSpy.mockRejectedValueOnce(translatedUniqueViolation() as never);
+
+    await expect(RumSessionPinService.create(createBy())).resolves.toBe(pin);
+  });
+
+  test("the recovery is what returns it — create() was really attempted", async () => {
+    const pin: RumSessionPin = existingPin();
+
+    getPinSpy
+      .mockResolvedValueOnce(null as never)
+      .mockResolvedValueOnce(pin as never);
+    createSpy.mockRejectedValueOnce(translatedUniqueViolation() as never);
+
+    await RumSessionPinService.create(createBy());
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(getPinSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("a unique violation with nothing to recover still surfaces", async () => {
+    /*
+     * If the row genuinely is not there, swallowing the error would report a
+     * pin that does not exist.
+     */
+    const error: unknown = translatedUniqueViolation();
+
+    getPinSpy.mockResolvedValue(null as never);
+    createSpy.mockRejectedValueOnce(error as never);
+
+    await expect(RumSessionPinService.create(createBy())).rejects.toBe(error);
+  });
+
+  test("an unrelated failure is rethrown untouched, not treated as a duplicate", async () => {
+    const error: BadDataException = new BadDataException("something else");
+
+    getPinSpy.mockResolvedValue(null as never);
+    createSpy.mockRejectedValueOnce(error as never);
+
+    await expect(RumSessionPinService.create(createBy())).rejects.toBe(error);
+    expect(getPinSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("a translated FOREIGN KEY violation is not mistaken for a duplicate", async () => {
+    /*
+     * Both SQLSTATEs now translate to a BadDataException, so the recovery can
+     * no longer key off the exception type — only off the recorded SQLSTATE.
+     */
+    const error: unknown = PostgresErrorTranslator.translate({
+      message: "insert violates foreign key constraint",
+      code: "23503",
+      table: "RumSessionPin",
+      detail:
+        'Key (rumApplicationId)=(00000000-0000-4000-8000-000000000002) is not present in table "RumApplication".',
+    });
+
+    expect(error).toBeInstanceOf(BadDataException);
+
+    getPinSpy.mockResolvedValue(null as never);
+    createSpy.mockRejectedValueOnce(error as never);
+
+    await expect(RumSessionPinService.create(createBy())).rejects.toBe(error);
+    expect(getPinSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Common/Tests/Server/Utils/Database/PostgresErrorTranslator.test.ts
+++ b/Common/Tests/Server/Utils/Database/PostgresErrorTranslator.test.ts
@@ -1,4 +1,6 @@
-import PostgresErrorTranslator from "../../../../Server/Utils/Database/PostgresErrorTranslator";
+import PostgresErrorTranslator, {
+  TranslatedPostgresException,
+} from "../../../../Server/Utils/Database/PostgresErrorTranslator";
 import BadDataException from "../../../../Types/Exception/BadDataException";
 import Exception from "../../../../Types/Exception/Exception";
 import { describe, expect, it } from "@jest/globals";
@@ -7,7 +9,9 @@ import { describe, expect, it } from "@jest/globals";
  * Contract under test: TypeORM's QueryFailedError is not an Exception, so it
  * used to fall through StartServer's generic handler and reach the client as a
  * bare 500 "Server Error" — which is exactly what deleting a project hit when
- * another project's MonitorStatusTimeline rows still referenced its statuses.
+ * another project's MonitorStatusTimeline rows still referenced its statuses,
+ * and what issue #3020 hit when a second ProjectCallSMSConfig was given Twilio
+ * credentials another row already held.
  *
  * The translator turns the actionable Postgres failures into a
  * BadDataException (400) and leaves everything else untouched.
@@ -30,6 +34,22 @@ const foreignKeyDeleteError: () => FakeQueryFailedError =
       table: "MonitorStatusTimeline",
       detail:
         'Key (_id)=(cfc2f04f-79cb-4344-8c54-dafe5e3a290c) is still referenced from table "MonitorStatusTimeline".',
+    };
+  };
+
+/*
+ * The literal failure from issue #3020: PUT /api/call-sms-config setting a
+ * Twilio account SID that another ProjectCallSMSConfig row already carried.
+ */
+const twilioAccountSidCollision: () => FakeQueryFailedError =
+  (): FakeQueryFailedError => {
+    return {
+      message:
+        'duplicate key value violates unique constraint "UQ_0886139eac04ad49627e446d477"',
+      code: "23505",
+      table: "ProjectCallSMSConfig",
+      detail:
+        'Key ("twilioAccountSID")=(AC-redacted-sid-that-must-not-leak) already exists.',
     };
   };
 
@@ -86,17 +106,218 @@ describe("PostgresErrorTranslator", () => {
     });
   });
 
-  describe("errors it should not touch", () => {
-    it("passes through a non-foreign-key Postgres error unchanged", () => {
-      const uniqueViolation: FakeQueryFailedError = {
+  describe("unique violation (issue #3020)", () => {
+    it("translates to a BadDataException naming the table and the column", () => {
+      const translated: unknown = PostgresErrorTranslator.translate(
+        twilioAccountSidCollision(),
+      );
+
+      expect(translated).toBeInstanceOf(BadDataException);
+      expect((translated as Exception).message).toBe(
+        "A Project Call SMS Config with this Twilio Account SID already exists. Please use a different value and try again.",
+      );
+    });
+
+    it("is a 400, not the bare 500 the issue reported", () => {
+      /*
+       * The whole point: the reporter saw `{"error":"Server Error"}` with no
+       * indication of which field was at fault.
+       */
+      const translated: unknown = PostgresErrorTranslator.translate(
+        twilioAccountSidCollision(),
+      );
+
+      expect((translated as Exception).message).not.toBe("Server Error");
+      expect(translated).toBeInstanceOf(BadDataException);
+    });
+
+    it("does not leak the colliding value — it may belong to another project", () => {
+      const translated: unknown = PostgresErrorTranslator.translate(
+        twilioAccountSidCollision(),
+      );
+
+      expect((translated as Exception).message).not.toContain(
+        "AC-redacted-sid-that-must-not-leak",
+      );
+    });
+
+    it("handles an unquoted column name", () => {
+      const translated: unknown = PostgresErrorTranslator.translate({
         message: "duplicate key value violates unique constraint",
         code: "23505",
         table: "Project",
         detail: "Key (slug)=(acme) already exists.",
+      });
+
+      expect((translated as Exception).message).toBe(
+        "A Project with this Slug already exists. Please use a different value and try again.",
+      );
+    });
+
+    it("handles a composite key, listing every column", () => {
+      const translated: unknown = PostgresErrorTranslator.translate({
+        message: "duplicate key value violates unique constraint",
+        code: "23505",
+        table: "NetworkInterface",
+        detail:
+          'Key ("networkDeviceId", "interfaceIndex")=(cfc2f04f-79cb-4344-8c54-dafe5e3a290c, 3) already exists.',
+      });
+
+      expect((translated as Exception).message).toBe(
+        "A Network Interface with the same Network Device Id, Interface Index already exists. Please use different values and try again.",
+      );
+    });
+
+    it("does not mistake the value list for the column list", () => {
+      /*
+       * `Key (a)=(b) already exists` has two parenthesised groups. Reading the
+       * wrong one would put another row's data in the message.
+       */
+      const translated: unknown = PostgresErrorTranslator.translate({
+        message: "duplicate key value violates unique constraint",
+        code: "23505",
+        table: "Project",
+        detail: "Key (slug)=(secret-customer-name) already exists.",
+      });
+
+      expect((translated as Exception).message).not.toContain(
+        "secret-customer-name",
+      );
+    });
+
+    it("reads the pg fields off driverError when the wrapper has no code", () => {
+      const translated: unknown = PostgresErrorTranslator.translate({
+        message: "wrapped",
+        driverError: twilioAccountSidCollision(),
+      });
+
+      expect(translated).toBeInstanceOf(BadDataException);
+      expect((translated as Exception).message).toContain("Twilio Account SID");
+    });
+
+    it("falls back to a generic message when the table is unknown", () => {
+      const translated: unknown = PostgresErrorTranslator.translate({
+        message: "duplicate key value violates unique constraint",
+        code: "23505",
+        detail: 'Key ("twilioAccountSID")=(AC123) already exists.',
+      });
+
+      expect((translated as Exception).message).toBe(
+        "A record with this Twilio Account SID already exists. Please use a different value and try again.",
+      );
+    });
+
+    it("falls back to a generic message when the columns cannot be parsed", () => {
+      const translated: unknown = PostgresErrorTranslator.translate({
+        message: "duplicate key value violates unique constraint",
+        code: "23505",
+        table: "Project",
+        detail: "some shape of detail we have not seen already exists.",
+      });
+
+      expect(translated).toBeInstanceOf(BadDataException);
+      expect((translated as Exception).message).toBe(
+        "A Project with these values already exists. Please use different values and try again.",
+      );
+    });
+
+    it("passes through a 23505 with no detail at all", () => {
+      /*
+       * Without DETAIL there is nothing actionable to say, so a bare 500 is
+       * still more honest than inventing a field name.
+       */
+      const noDetail: FakeQueryFailedError = {
+        message: "duplicate key value violates unique constraint",
+        code: "23505",
+        table: "Project",
       };
 
-      expect(PostgresErrorTranslator.translate(uniqueViolation)).toBe(
-        uniqueViolation,
+      expect(PostgresErrorTranslator.translate(noDetail)).toBe(noDetail);
+    });
+  });
+
+  describe("isUniqueViolation", () => {
+    it("recognises a raw QueryFailedError", () => {
+      expect(
+        PostgresErrorTranslator.isUniqueViolation(twilioAccountSidCollision()),
+      ).toBe(true);
+    });
+
+    it("recognises one wrapped under driverError", () => {
+      expect(
+        PostgresErrorTranslator.isUniqueViolation({
+          message: "wrapped",
+          driverError: twilioAccountSidCollision(),
+        }),
+      ).toBe(true);
+    });
+
+    it("still recognises it AFTER translation", () => {
+      /*
+       * The reason this method exists. DatabaseService.create runs every
+       * failure through the translator before rethrowing, so a service's own
+       * catch block never sees the raw error. RumSessionPinService recovers
+       * from a duplicate pin by returning the existing row; a local
+       * `code === "23505"` check there would have started silently returning
+       * false the moment 23505 became translatable, turning an idempotent
+       * "already pinned" back into an error.
+       */
+      const translated: unknown = PostgresErrorTranslator.translate(
+        twilioAccountSidCollision(),
+      );
+
+      expect(translated).toBeInstanceOf(BadDataException);
+      expect(PostgresErrorTranslator.isUniqueViolation(translated)).toBe(true);
+    });
+
+    it("records the SQLSTATE on the translated exception", () => {
+      const translated: TranslatedPostgresException =
+        PostgresErrorTranslator.translate(
+          twilioAccountSidCollision(),
+        ) as TranslatedPostgresException;
+
+      expect(translated.postgresErrorCode).toBe("23505");
+    });
+
+    it("does not confuse a foreign key violation for a unique one", () => {
+      const translated: unknown = PostgresErrorTranslator.translate(
+        foreignKeyDeleteError(),
+      );
+
+      expect(PostgresErrorTranslator.isUniqueViolation(translated)).toBe(false);
+      expect(
+        PostgresErrorTranslator.isUniqueViolation(foreignKeyDeleteError()),
+      ).toBe(false);
+    });
+
+    it("does not confuse Exception.code for a SQLSTATE", () => {
+      /*
+       * Exception.code is the numeric ExceptionCode, an entirely different
+       * namespace from Postgres SQLSTATEs.
+       */
+      expect(
+        PostgresErrorTranslator.isUniqueViolation(new BadDataException("Nope")),
+      ).toBe(false);
+    });
+
+    it("is false for null and non-objects", () => {
+      expect(PostgresErrorTranslator.isUniqueViolation(null)).toBe(false);
+      expect(PostgresErrorTranslator.isUniqueViolation(undefined)).toBe(false);
+      expect(PostgresErrorTranslator.isUniqueViolation("23505")).toBe(false);
+    });
+  });
+
+  describe("errors it should not touch", () => {
+    it("passes through an unrecognised Postgres error unchanged", () => {
+      const notNullViolation: FakeQueryFailedError = {
+        message: 'null value in column "name" violates not-null constraint',
+        code: "23502",
+        table: "Project",
+        detail: "Failing row contains (null).",
+      };
+
+      expect(PostgresErrorTranslator.translate(notNullViolation)).toBe(
+        notNullViolation,
       );
     });
 


### PR DESCRIPTION
Fixes #3020.

## The bug is real, and it is a schema bug

`POST`/`PUT /api/call-sms-config` returns `500 {"error":"Server Error"}` whenever a config is given Twilio credentials that another row already holds.

The reporter guessed at "a live Twilio validation call that throws on success". There is no such call — `ProjectCallSMSConfigService` overrides only `onBeforeCreate`/`onBeforeUpdate`/`onBeforeDelete`, and none of them touch Twilio's API. The cause is two global `UNIQUE` constraints:

```sql
CONSTRAINT "UQ_0886139eac04ad49627e446d477" UNIQUE ("twilioAccountSID"),
CONSTRAINT "UQ_2eb1a240d549a7701b6e82d2f94" UNIQUE ("twilioAuthToken")
```

`ProjectCallSMSConfig`'s columns were modelled on `GlobalConfig` — a **singleton** table whose every column carries a pointless `unique: true`. On a singleton that is harmless. Copied onto a tenant-scoped, inherently multi-row table it means no two rows *anywhere on the instance* may share a Twilio account. Postgres raises `unique_violation` (23505); `QueryFailedError` is not a OneUptime `Exception`, so it falls through `StartServer`'s generic handler as a bare 500.

That explains every symptom in the report, including the two that looked mysterious:

| Reported behaviour | Why |
|---|---|
| Placeholder creds save fine | nothing else holds that value |
| Re-saving the *same* real creds on the row that owns them works | a row does not collide with itself |
| `twilioPrimaryPhoneNumber`-only and `isProjectDefault`-only updates work | neither column is constrained |
| Every fresh record 500s on real creds | the first config already owns them |

### Reproduced, then verified fixed

Against a real migrated database, before the change:

```
UPDATE "ProjectCallSMSConfig" SET "twilioAccountSID"='AC…01', "twilioAuthToken"='…' WHERE name='repro-b';
ERROR:  duplicate key value violates unique constraint "UQ_0886139eac04ad49627e446d477"
```

…while the same-value and phone-number-only updates returned `UPDATE 1`, exactly as reported.

## Impact beyond the report

The constraint is **not** scoped to a project, so on a shared instance the first project to save an account SID locks every other tenant out of it — one tenant denying another the use of its own Twilio credentials, with no visible reason on either side.

## The fix

Drop both constraints and flip the columns to `unique: false`. Migration `1741955752685` already removed the identical constraint from `twilioPrimaryPhoneNumber` back in March 2025; these two were simply missed. This finishes that job.

Nothing narrower replaces them. Reusing one Twilio account across configs is the *supported* case — Poland (and others) require a Local number for Voice and a Mobile number for SMS, which is precisely the reporter's setup. Config identity is `name`, already unique per project via `@UniqueColumnBy("projectId")`. No code looks a config up by these columns; every read is by id or `projectId`, so no lookup depended on the uniqueness. After this change `ProjectCallSMSConfig` has no `UNIQUE` on any credential column, matching every other tenant-scoped table — theirs are all on slugs, keys and tokens, identifiers that really are global.

`up()` uses `DROP CONSTRAINT IF EXISTS`: operators hit by this were told to drop the constraint by hand, and the migration must not abort on the databases that most needed it.

## Also: the missing error detail

The issue's second complaint — *"No error detail is surfaced to the client (`{"error":"Server Error"}` only)"* — is fixed too. `PostgresErrorTranslator` already existed for exactly this purpose but handled only foreign-key violations; 23505 was explicitly passed through. It now translates unique violations into a 400 naming the field:

> A Project Call SMS Config with this Twilio Account SID already exists. Please use a different value and try again.

Column names go in the message; **values do not** — the colliding row may belong to another project.

One caller had to move with it. `RumSessionPinService` *recovers* from a unique violation to make pinning idempotent, and detected it with a local `code === "23505"` check. Since `DatabaseService.create` runs failures through the translator *before* rethrowing, that check would have silently stopped matching — turning "already pinned" back into an error. It now shares the translator's detection, which reads the SQLSTATE recorded on the translated exception.

## Verification

- **Schema drift check** (the CI gate) on a database migrated from empty: *"No schema drift. The database matches the entities."*
- Both constraints confirmed gone from the resulting schema.
- End-to-end on that schema: the exact `PUT` from the issue succeeds, as do two configs in one project on one Twilio account and two projects on one Twilio account.
- `npx tsc --noEmit` in `Common` clean; eslint clean.
- **375 tests across 23 suites pass** (`Migration|RumSession|PostgresError|ProjectCallSMS|DatabaseService`).

## Tests

47 new/updated tests in three files:

- `ProjectCallSMSConfigCredentialUniqueness.test.ts` (16) — neither column declares `unique: true`; *no* column on the table does; columns stay nullable and wide enough for real 34-char SIDs (ruling out truncation as an alternative cause); `up()` drops exactly the two constraints and nothing else; `IF EXISTS` is present; `down()` restores them under the same names; the names are pinned against the `CREATE TABLE` that introduced them, so a typo cannot make `up()` a silent no-op; registered exactly once and ordered after the migration that created them.
- `PostgresErrorTranslator.test.ts` (25) — quoted and unquoted column names, composite keys, `driverError` wrapping, missing table, unparseable and absent detail; that the colliding value never reaches the message; that the value list is not mistaken for the column list; and the full `isUniqueViolation` contract including "still true after translation" and "`Exception.code` is not a SQLSTATE".
- `RumSessionPinUniqueViolationRecovery.test.ts` (6) — the idempotent-pin recovery survives translation, and a translated *foreign-key* violation is not mistaken for a duplicate now that both produce a `BadDataException`.

## Note for self-hosted operators

Existing databases keep the constraints until this migration runs; it runs automatically on boot.
