### PR TITLE
refactor(dashboard): rebuild the AI Insights inbox and detail page

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightFactsList.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightFactsList.tsx
@@ -1,0 +1,52 @@
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon from "Common/UI/Components/Icon/Icon";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface InsightFact {
+  label: string;
+  icon: IconProp;
+  value: string | ReactElement;
+  // Absolute timestamp behind a relative one ("3 days ago"), shown on hover.
+  title?: string | undefined;
+}
+
+export interface ComponentProps {
+  facts: Array<InsightFact>;
+}
+
+/*
+ * The label/value rail on the insight detail page. Label left, value right,
+ * hairline between rows — the same shape a reader already knows from every
+ * other "details" sidebar, so nothing has to be decoded.
+ */
+const InsightFactsList: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  return (
+    <dl className="divide-y divide-gray-100">
+      {props.facts.map((fact: InsightFact, index: number) => {
+        return (
+          <div
+            key={index}
+            className="flex items-center justify-between gap-3 py-2.5 first:pt-0 last:pb-0"
+          >
+            <dt className="flex flex-shrink-0 items-center gap-1.5 text-sm text-gray-500">
+              <span className="flex-shrink-0 text-gray-400">
+                <Icon icon={fact.icon} className="h-3.5 w-3.5" />
+              </span>
+              {fact.label}
+            </dt>
+            <dd
+              className="min-w-0 truncate text-right text-sm font-medium text-gray-900"
+              title={fact.title}
+            >
+              {fact.value}
+            </dd>
+          </div>
+        );
+      })}
+    </dl>
+  );
+};
+
+export default InsightFactsList;

--- a/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightFilterBar.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightFilterBar.tsx
@@ -1,0 +1,163 @@
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon from "Common/UI/Components/Icon/Icon";
+import Input from "Common/UI/Components/Input/Input";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface InsightFilterOption {
+  label: string;
+  value: string;
+}
+
+export interface ComponentProps {
+  searchText: string;
+  onSearchTextChange: (value: string) => void;
+  typeOptions: Array<InsightFilterOption>;
+  typeValue: string;
+  onTypeChange: (value: string) => void;
+  severityOptions: Array<InsightFilterOption>;
+  severityValue: string;
+  onSeverityChange: (value: string) => void;
+  // The sentinel value a select carries when it is not filtering anything.
+  unfilteredValue: string;
+  hasActiveFilters: boolean;
+  onClearFilters: () => void;
+}
+
+type GetSelectClassNameFunction = (isFiltering: boolean) => string;
+
+/*
+ * A filtering select tints itself when it is actually narrowing the list —
+ * otherwise "Latency Regression" hides in a toolbar that looks idle and the
+ * empty list reads as "nothing found" rather than "nothing matches".
+ */
+const getSelectClassName: GetSelectClassNameFunction = (
+  isFiltering: boolean,
+): string => {
+  const base: string =
+    "h-9 w-full appearance-none rounded-lg border py-0 pl-3 pr-8 text-sm font-medium shadow-sm transition-colors focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 sm:w-auto";
+
+  if (isFiltering) {
+    return `${base} border-indigo-200 bg-indigo-50 text-indigo-700`;
+  }
+
+  return `${base} border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50`;
+};
+
+/*
+ * Search, type and severity in one bar. The status filter is not here — it
+ * lives on the count tiles above, which is what let this collapse from three
+ * wrapping rows of pills into a single row.
+ */
+const InsightFilterBar: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const isFilteringByType: boolean = props.typeValue !== props.unfilteredValue;
+  const isFilteringBySeverity: boolean =
+    props.severityValue !== props.unfilteredValue;
+
+  return (
+    <div className="flex flex-col gap-2 rounded-xl border border-gray-200 bg-white p-2 shadow-sm sm:flex-row sm:items-center">
+      <div className="relative min-w-0 flex-1">
+        <label htmlFor="ai-insight-search" className="sr-only">
+          Search insights
+        </label>
+        <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+          <Icon icon={IconProp.Search} className="h-4 w-4" />
+        </span>
+        <Input
+          id="ai-insight-search"
+          placeholder="Search insights by title..."
+          value={props.searchText}
+          onChange={props.onSearchTextChange}
+          outerDivClassName="relative w-full"
+          className="block w-full rounded-lg border border-transparent bg-transparent py-2 pl-9 pr-9 text-sm text-gray-900 placeholder-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+        />
+        {props.searchText ? (
+          <button
+            type="button"
+            aria-label="Clear search"
+            onClick={() => {
+              props.onSearchTextChange("");
+            }}
+            className="absolute right-2 top-1/2 inline-flex -translate-y-1/2 items-center justify-center rounded-md p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+          >
+            <Icon icon={IconProp.Close} className="h-4 w-4" />
+          </button>
+        ) : (
+          <></>
+        )}
+      </div>
+
+      <div className="hidden h-6 w-px flex-shrink-0 bg-gray-200 sm:block" />
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <div className="relative">
+          <select
+            aria-label="Filter by insight type"
+            value={props.typeValue}
+            onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+              props.onTypeChange(event.target.value);
+            }}
+            className={getSelectClassName(isFilteringByType)}
+          >
+            {props.typeOptions.map((option: InsightFilterOption) => {
+              return (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              );
+            })}
+          </select>
+          <span
+            className={`pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 ${
+              isFilteringByType ? "text-indigo-400" : "text-gray-400"
+            }`}
+          >
+            <Icon icon={IconProp.ChevronDown} className="h-4 w-4" />
+          </span>
+        </div>
+
+        <div className="relative">
+          <select
+            aria-label="Filter by severity"
+            value={props.severityValue}
+            onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+              props.onSeverityChange(event.target.value);
+            }}
+            className={getSelectClassName(isFilteringBySeverity)}
+          >
+            {props.severityOptions.map((option: InsightFilterOption) => {
+              return (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              );
+            })}
+          </select>
+          <span
+            className={`pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 ${
+              isFilteringBySeverity ? "text-indigo-400" : "text-gray-400"
+            }`}
+          >
+            <Icon icon={IconProp.ChevronDown} className="h-4 w-4" />
+          </span>
+        </div>
+
+        {props.hasActiveFilters ? (
+          <button
+            type="button"
+            onClick={props.onClearFilters}
+            className="inline-flex h-9 flex-shrink-0 items-center justify-center gap-1 rounded-lg px-2.5 text-sm font-medium text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700"
+          >
+            <Icon icon={IconProp.Close} className="h-4 w-4" />
+            Clear
+          </button>
+        ) : (
+          <></>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default InsightFilterBar;

--- a/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightListItem.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightListItem.tsx
@@ -1,0 +1,179 @@
+import PageMap from "../../Utils/PageMap";
+import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
+import {
+  getHumanVerdictElement,
+  getInsightTypeIcon,
+  getInsightTypeLabel,
+  getSeverityInlineElement,
+  getSeverityTileClasses,
+  getStatusElement,
+} from "./InsightPresentation";
+import AIInsight from "Common/Models/DatabaseModels/AIInsight";
+import Route from "Common/Types/API/Route";
+import OneUptimeDate from "Common/Types/Date";
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon from "Common/UI/Components/Icon/Icon";
+import Link from "Common/UI/Components/Link/Link";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  insight: AIInsight;
+}
+
+interface MetaItem {
+  element: ReactElement;
+  // Repeats a column that only the wide layout has room for.
+  isSmallScreenOnly?: boolean | undefined;
+}
+
+/*
+ * One row of the insights inbox.
+ *
+ * Wide screens get table-like alignment — status, detections and last-seen
+ * ride in fixed-width right-hand columns under the list's column header — so
+ * the eye can run straight down each of them. Below `lg` those columns have
+ * nowhere to go, so the same facts fold into the meta line under the title.
+ */
+const InsightListItem: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const insight: AIInsight = props.insight;
+
+  const viewRoute: Route = RouteUtil.populateRouteParams(
+    RouteMap[PageMap.AI_INSIGHT_VIEW] as Route,
+    { modelId: insight.id! },
+  );
+
+  const occurrenceCount: number = insight.occurrenceCount || 0;
+  const detectionsLabel: string =
+    occurrenceCount === 1 ? "1 detection" : `${occurrenceCount} detections`;
+
+  const lastSeenLabel: string = insight.lastSeenAt
+    ? OneUptimeDate.fromNow(insight.lastSeenAt)
+    : "";
+  const lastSeenTitle: string = insight.lastSeenAt
+    ? OneUptimeDate.getDateAsLocalFormattedString(insight.lastSeenAt)
+    : "";
+
+  const metaItems: Array<MetaItem> = [];
+
+  if (insight.severity) {
+    metaItems.push({ element: getSeverityInlineElement(insight.severity) });
+  }
+
+  if (insight.insightType) {
+    metaItems.push({
+      element: <span>{getInsightTypeLabel(insight.insightType)}</span>,
+    });
+  }
+
+  if (insight.serviceName) {
+    metaItems.push({
+      element: (
+        <span className="inline-flex min-w-0 items-center gap-1">
+          <span className="flex-shrink-0">
+            <Icon icon={IconProp.Cube} className="h-3.5 w-3.5" />
+          </span>
+          <span className="truncate">{insight.serviceName}</span>
+        </span>
+      ),
+    });
+  }
+
+  if (insight.humanVerdict) {
+    metaItems.push({ element: getHumanVerdictElement(insight.humanVerdict) });
+  }
+
+  if (insight.status) {
+    metaItems.push({
+      element: getStatusElement(insight.status),
+      isSmallScreenOnly: true,
+    });
+  }
+
+  if (occurrenceCount > 0) {
+    metaItems.push({
+      element: <span>{detectionsLabel}</span>,
+      isSmallScreenOnly: true,
+    });
+  }
+
+  if (lastSeenLabel) {
+    metaItems.push({
+      element: <span>{lastSeenLabel}</span>,
+      isSmallScreenOnly: true,
+    });
+  }
+
+  return (
+    <li>
+      <Link
+        to={viewRoute}
+        className="group flex items-center gap-4 px-4 py-3.5 transition-colors hover:bg-gray-50 focus:outline-none focus-visible:bg-indigo-50"
+      >
+        <span
+          className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg ${getSeverityTileClasses(
+            insight.severity,
+          )}`}
+        >
+          <Icon
+            icon={getInsightTypeIcon(insight.insightType)}
+            className="h-5 w-5"
+          />
+        </span>
+
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold text-gray-900 group-hover:text-indigo-600">
+            {insight.title}
+          </p>
+
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-gray-500">
+            {metaItems.map((item: MetaItem, index: number) => {
+              return (
+                <React.Fragment key={index}>
+                  {index > 0 ? (
+                    <span
+                      aria-hidden="true"
+                      className={`text-gray-300 ${
+                        item.isSmallScreenOnly ? "lg:hidden" : ""
+                      }`}
+                    >
+                      &bull;
+                    </span>
+                  ) : (
+                    <></>
+                  )}
+                  <span
+                    className={`inline-flex min-w-0 items-center ${
+                      item.isSmallScreenOnly ? "lg:hidden" : ""
+                    }`}
+                  >
+                    {item.element}
+                  </span>
+                </React.Fragment>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="hidden w-32 flex-shrink-0 lg:block">
+          {getStatusElement(insight.status)}
+        </div>
+        <div className="hidden w-24 flex-shrink-0 text-right text-sm tabular-nums text-gray-700 lg:block">
+          {occurrenceCount > 0 ? occurrenceCount : <span>&mdash;</span>}
+        </div>
+        <div
+          className="hidden w-36 flex-shrink-0 truncate text-right text-xs text-gray-500 lg:block"
+          title={lastSeenTitle}
+        >
+          {lastSeenLabel}
+        </div>
+        <span className="hidden flex-shrink-0 text-gray-300 transition-colors group-hover:text-indigo-500 lg:block">
+          <Icon icon={IconProp.ChevronRight} className="h-5 w-5" />
+        </span>
+      </Link>
+    </li>
+  );
+};
+
+export default InsightListItem;

--- a/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightListSkeleton.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightListSkeleton.tsx
@@ -1,0 +1,51 @@
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  rowCount: number;
+}
+
+/*
+ * Placeholder rows in the real row geometry. A centered spinner made the
+ * whole list jump into place on every filter change; this keeps the page
+ * height and the column rhythm steady while the request is in flight.
+ */
+const InsightListSkeleton: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const rows: Array<number> = Array.from(
+    { length: props.rowCount },
+    (_value: unknown, index: number) => {
+      return index;
+    },
+  );
+
+  return (
+    <ul className="divide-y divide-gray-100" aria-hidden="true">
+      {rows.map((row: number) => {
+        return (
+          <li key={row}>
+            <div className="flex animate-pulse items-center gap-4 px-4 py-3.5">
+              <div className="h-10 w-10 flex-shrink-0 rounded-lg bg-gray-100" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="h-3.5 w-2/5 rounded bg-gray-100" />
+                <div className="h-3 w-1/4 rounded bg-gray-100" />
+              </div>
+              <div className="hidden w-32 flex-shrink-0 lg:block">
+                <div className="h-5 w-24 rounded-full bg-gray-100" />
+              </div>
+              <div className="hidden w-24 flex-shrink-0 lg:block">
+                <div className="ml-auto h-3.5 w-8 rounded bg-gray-100" />
+              </div>
+              <div className="hidden w-36 flex-shrink-0 lg:block">
+                <div className="ml-auto h-3.5 w-20 rounded bg-gray-100" />
+              </div>
+              <div className="hidden w-5 flex-shrink-0 lg:block" />
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default InsightListSkeleton;

--- a/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightPanel.tsx
@@ -1,0 +1,49 @@
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon from "Common/UI/Components/Icon/Icon";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  title: string;
+  description?: string | undefined;
+  icon?: IconProp | undefined;
+  children: Array<ReactElement> | ReactElement;
+}
+
+/*
+ * A section of the insight detail page.
+ *
+ * The shared Card carries its own `mb-5`, which fights the grid gap once the
+ * detail page splits into a main column and a sidebar — some seams ended up
+ * 20px and some 40px. This is the same surface with the spacing left to the
+ * layout, plus a section glyph.
+ */
+const InsightPanel: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  return (
+    <section className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+      <div className="border-b border-gray-100 px-5 py-4">
+        <div className="flex items-center gap-2">
+          {props.icon ? (
+            <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md bg-gray-100 text-gray-500">
+              <Icon icon={props.icon} className="h-3.5 w-3.5" />
+            </span>
+          ) : (
+            <></>
+          )}
+          <h2 className="text-sm font-semibold text-gray-900">{props.title}</h2>
+        </div>
+        {props.description ? (
+          <p className="mt-1.5 text-sm leading-relaxed text-gray-500">
+            {props.description}
+          </p>
+        ) : (
+          <></>
+        )}
+      </div>
+      <div className="px-5 py-4">{props.children}</div>
+    </section>
+  );
+};
+
+export default InsightPanel;

--- a/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightPresentation.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightPresentation.tsx
@@ -1,0 +1,235 @@
+import AIInsightHumanVerdict from "Common/Types/AI/AIInsightHumanVerdict";
+import AIInsightSeverity from "Common/Types/AI/AIInsightSeverity";
+import AIInsightStatus from "Common/Types/AI/AIInsightStatus";
+import AIInsightType from "Common/Types/AI/AIInsightType";
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon from "Common/UI/Components/Icon/Icon";
+import React, { ReactElement } from "react";
+
+/*
+ * Everything that decides how an insight LOOKS lives here — one label, one
+ * glyph and one color per enum value — so the inbox list and the insight
+ * detail page can never drift apart.
+ */
+
+// Human labels for the wire-contract enum values (e.g. "NewException").
+export const INSIGHT_TYPE_LABELS: Record<AIInsightType, string> = {
+  [AIInsightType.NewException]: "New Exception",
+  [AIInsightType.ExceptionSpike]: "Exception Spike",
+  [AIInsightType.ErrorLogSpike]: "Error Log Spike",
+  [AIInsightType.TraceLatencyRegression]: "Latency Regression",
+  [AIInsightType.MetricDrift]: "Metric Drift",
+};
+
+// Human labels for the wire-contract status values (e.g. "ActionRequired").
+export const STATUS_LABELS: Record<AIInsightStatus, string> = {
+  [AIInsightStatus.Detected]: "Detected",
+  [AIInsightStatus.ActionRequired]: "Needs Attention",
+  [AIInsightStatus.FixOpened]: "Fix Opened",
+  [AIInsightStatus.Resolved]: "Resolved",
+  [AIInsightStatus.Dismissed]: "Dismissed",
+};
+
+const SEVERITY_BADGE_CLASSES: Record<AIInsightSeverity, string> = {
+  [AIInsightSeverity.High]: "bg-red-50 text-red-700 ring-red-600/20",
+  [AIInsightSeverity.Medium]: "bg-amber-50 text-amber-700 ring-amber-600/20",
+  [AIInsightSeverity.Low]: "bg-blue-50 text-blue-700 ring-blue-600/20",
+};
+
+// The inline (badge-less) severity used in the dense list rows.
+const SEVERITY_TEXT_CLASSES: Record<AIInsightSeverity, string> = {
+  [AIInsightSeverity.High]: "text-red-700",
+  [AIInsightSeverity.Medium]: "text-amber-700",
+  [AIInsightSeverity.Low]: "text-blue-700",
+};
+
+const SEVERITY_DOT_CLASSES: Record<AIInsightSeverity, string> = {
+  [AIInsightSeverity.High]: "bg-red-500",
+  [AIInsightSeverity.Medium]: "bg-amber-500",
+  [AIInsightSeverity.Low]: "bg-blue-500",
+};
+
+// The severity-tinted icon tile shown on each insight row.
+const SEVERITY_TILE_CLASSES: Record<AIInsightSeverity, string> = {
+  [AIInsightSeverity.High]: "bg-red-50 text-red-600",
+  [AIInsightSeverity.Medium]: "bg-amber-50 text-amber-600",
+  [AIInsightSeverity.Low]: "bg-blue-50 text-blue-600",
+};
+
+/*
+ * ActionRequired is the attention state, FixOpened means the AI agent is on
+ * it, the terminal human states are calm (green/gray), and Detected — a
+ * transient state the scanner routes out of in the same tick — stays gray.
+ */
+const STATUS_BADGE_CLASSES: Record<AIInsightStatus, string> = {
+  [AIInsightStatus.Detected]: "bg-gray-100 text-gray-600 ring-gray-500/20",
+  [AIInsightStatus.ActionRequired]:
+    "bg-orange-50 text-orange-700 ring-orange-600/20",
+  [AIInsightStatus.FixOpened]:
+    "bg-purple-50 text-purple-700 ring-purple-600/20",
+  [AIInsightStatus.Resolved]: "bg-green-50 text-green-700 ring-green-600/20",
+  [AIInsightStatus.Dismissed]: "bg-gray-100 text-gray-600 ring-gray-500/20",
+};
+
+const STATUS_DOT_CLASSES: Record<AIInsightStatus, string> = {
+  [AIInsightStatus.Detected]: "bg-gray-400",
+  [AIInsightStatus.ActionRequired]: "bg-orange-500",
+  [AIInsightStatus.FixOpened]: "bg-purple-500",
+  [AIInsightStatus.Resolved]: "bg-green-500",
+  [AIInsightStatus.Dismissed]: "bg-gray-400",
+};
+
+// Each detector gets its own glyph so a row is recognizable at a glance.
+const INSIGHT_TYPE_ICONS: Record<AIInsightType, IconProp> = {
+  [AIInsightType.NewException]: IconProp.Bug,
+  [AIInsightType.ExceptionSpike]: IconProp.Fire,
+  [AIInsightType.ErrorLogSpike]: IconProp.Logs,
+  [AIInsightType.TraceLatencyRegression]: IconProp.Clock,
+  [AIInsightType.MetricDrift]: IconProp.ArrowTrendingUp,
+};
+
+export function getInsightTypeLabel(
+  insightType: AIInsightType | undefined,
+): string {
+  if (!insightType) {
+    return "-";
+  }
+  return INSIGHT_TYPE_LABELS[insightType] || insightType;
+}
+
+export function getStatusLabel(status: AIInsightStatus | undefined): string {
+  if (!status) {
+    return "-";
+  }
+  return STATUS_LABELS[status] || status;
+}
+
+export function getInsightTypeIcon(
+  insightType: AIInsightType | undefined,
+): IconProp {
+  if (!insightType) {
+    return IconProp.LightBulb;
+  }
+  return INSIGHT_TYPE_ICONS[insightType] || IconProp.LightBulb;
+}
+
+export function getSeverityTileClasses(
+  severity: AIInsightSeverity | undefined,
+): string {
+  if (!severity) {
+    return "bg-gray-100 text-gray-500";
+  }
+  return SEVERITY_TILE_CLASSES[severity] || "bg-gray-100 text-gray-500";
+}
+
+export function getStatusDotClasses(status: AIInsightStatus): string {
+  return STATUS_DOT_CLASSES[status] || "bg-gray-400";
+}
+
+export function getInsightTypeElement(
+  insightType: AIInsightType | undefined,
+): ReactElement {
+  if (!insightType) {
+    return <></>;
+  }
+  return (
+    <span className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700 ring-1 ring-inset ring-indigo-600/20">
+      {getInsightTypeLabel(insightType)}
+    </span>
+  );
+}
+
+export function getSeverityElement(
+  severity: AIInsightSeverity | undefined,
+): ReactElement {
+  if (!severity) {
+    return <></>;
+  }
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
+        SEVERITY_BADGE_CLASSES[severity] ||
+        "bg-gray-100 text-gray-600 ring-gray-500/20"
+      }`}
+    >
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${
+          SEVERITY_DOT_CLASSES[severity] || "bg-gray-400"
+        }`}
+      />
+      {severity}
+    </span>
+  );
+}
+
+/*
+ * The list-row severity: a colored dot and the word, with no pill around it.
+ * A row already carries a status pill, and stacking a second pill next to it
+ * is what turned the old card list into badge soup.
+ */
+export function getSeverityInlineElement(
+  severity: AIInsightSeverity | undefined,
+): ReactElement {
+  if (!severity) {
+    return <></>;
+  }
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 font-medium ${
+        SEVERITY_TEXT_CLASSES[severity] || "text-gray-500"
+      }`}
+    >
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${
+          SEVERITY_DOT_CLASSES[severity] || "bg-gray-400"
+        }`}
+      />
+      {severity}
+    </span>
+  );
+}
+
+export function getStatusElement(
+  status: AIInsightStatus | undefined,
+): ReactElement {
+  if (!status) {
+    return <></>;
+  }
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
+        STATUS_BADGE_CLASSES[status] ||
+        "bg-gray-100 text-gray-600 ring-gray-500/20"
+      }`}
+    >
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${
+          STATUS_DOT_CLASSES[status] || "bg-gray-400"
+        }`}
+      />
+      {getStatusLabel(status)}
+    </span>
+  );
+}
+
+export function getHumanVerdictElement(
+  verdict: AIInsightHumanVerdict | undefined | null,
+): ReactElement {
+  if (verdict === AIInsightHumanVerdict.Confirmed) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
+        <Icon icon={IconProp.Check} className="h-3 w-3" />
+        Confirmed
+      </span>
+    );
+  }
+  if (verdict === AIInsightHumanVerdict.Dismissed) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/20">
+        <Icon icon={IconProp.Close} className="h-3 w-3" />
+        Dismissed
+      </span>
+    );
+  }
+  return <></>;
+}

--- a/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightStatusSummary.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIInsights/InsightStatusSummary.tsx
@@ -1,0 +1,71 @@
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface InsightStatusBucket {
+  label: string;
+  value: string;
+  dotClassName: string;
+  // null while the counts are still loading or when the count request failed.
+  count: number | null;
+}
+
+export interface ComponentProps {
+  buckets: Array<InsightStatusBucket>;
+  selectedValue: string;
+  isLoading: boolean;
+  onSelect: (value: string) => void;
+}
+
+/*
+ * The triage strip: how many insights sit in each lifecycle state, and the
+ * status filter itself. Two jobs in one control — a row of unlabeled filter
+ * pills told you nothing about the backlog it was filtering.
+ */
+const InsightStatusSummary: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  return (
+    <div
+      className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5"
+      role="radiogroup"
+      aria-label="Filter insights by status"
+    >
+      {props.buckets.map((bucket: InsightStatusBucket) => {
+        const isSelected: boolean = props.selectedValue === bucket.value;
+
+        return (
+          <button
+            key={bucket.value}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            onClick={() => {
+              props.onSelect(bucket.value);
+            }}
+            className={`group flex flex-col rounded-xl border px-4 py-3 text-left shadow-sm transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
+              isSelected
+                ? "border-indigo-200 bg-indigo-50 ring-1 ring-inset ring-indigo-200"
+                : "border-gray-200 bg-white hover:border-gray-300 hover:bg-gray-50"
+            }`}
+          >
+            <span className="flex items-center gap-1.5 text-xs font-medium text-gray-500">
+              <span
+                className={`h-1.5 w-1.5 flex-shrink-0 rounded-full ${bucket.dotClassName}`}
+              />
+              <span className="truncate">{bucket.label}</span>
+            </span>
+
+            {props.isLoading ? (
+              <span className="mt-1.5 h-6 w-10 animate-pulse rounded bg-gray-100" />
+            ) : (
+              <span className="mt-1.5 text-2xl font-semibold leading-none tracking-tight text-gray-900 tabular-nums">
+                {bucket.count === null ? "—" : bucket.count}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default InsightStatusSummary;

--- a/App/FeatureSet/Dashboard/src/Pages/AIInsights/Insights.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/AIInsights/Insights.tsx
@@ -13,9 +13,7 @@ import Route from "Common/Types/API/Route";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import Query from "Common/Types/BaseDatabase/Query";
 import Search from "Common/Types/BaseDatabase/Search";
-import OneUptimeDate from "Common/Types/Date";
 import AIInsight from "Common/Models/DatabaseModels/AIInsight";
-import AIInsightHumanVerdict from "Common/Types/AI/AIInsightHumanVerdict";
 import AIInsightSeverity from "Common/Types/AI/AIInsightSeverity";
 import AIInsightStatus from "Common/Types/AI/AIInsightStatus";
 import AIInsightType from "Common/Types/AI/AIInsightType";
@@ -24,237 +22,81 @@ import Button, {
   ButtonSize,
   ButtonStyleType,
 } from "Common/UI/Components/Button/Button";
-import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
 import EmptyState from "Common/UI/Components/EmptyState/EmptyState";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
-import FilterButtons, {
-  FilterButtonOption,
-} from "Common/UI/Components/FilterButtons/FilterButtons";
 import Icon from "Common/UI/Components/Icon/Icon";
-import Input from "Common/UI/Components/Input/Input";
-import Link from "Common/UI/Components/Link/Link";
 import API from "Common/UI/Utils/API/API";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import Navigation from "Common/UI/Utils/Navigation";
 import AIPlanGate from "../../Components/AI/AIPlanGate";
-
-// Human labels for the wire-contract enum values (e.g. "NewException").
-const INSIGHT_TYPE_LABELS: Record<AIInsightType, string> = {
-  [AIInsightType.NewException]: "New Exception",
-  [AIInsightType.ExceptionSpike]: "Exception Spike",
-  [AIInsightType.ErrorLogSpike]: "Error Log Spike",
-  [AIInsightType.TraceLatencyRegression]: "Latency Regression",
-  [AIInsightType.MetricDrift]: "Metric Drift",
-};
-
-// Human labels for the wire-contract status values (e.g. "ActionRequired").
-const STATUS_LABELS: Record<AIInsightStatus, string> = {
-  [AIInsightStatus.Detected]: "Detected",
-  [AIInsightStatus.ActionRequired]: "Needs Attention",
-  [AIInsightStatus.FixOpened]: "Fix Opened",
-  [AIInsightStatus.Resolved]: "Resolved",
-  [AIInsightStatus.Dismissed]: "Dismissed",
-};
-
-const SEVERITY_BADGE_CLASSES: Record<AIInsightSeverity, string> = {
-  [AIInsightSeverity.High]: "bg-red-50 text-red-700 ring-red-600/20",
-  [AIInsightSeverity.Medium]: "bg-amber-50 text-amber-700 ring-amber-600/20",
-  [AIInsightSeverity.Low]: "bg-blue-50 text-blue-700 ring-blue-600/20",
-};
-
-const SEVERITY_DOT_CLASSES: Record<AIInsightSeverity, string> = {
-  [AIInsightSeverity.High]: "bg-red-500",
-  [AIInsightSeverity.Medium]: "bg-amber-500",
-  [AIInsightSeverity.Low]: "bg-blue-500",
-};
-
-// The severity-tinted icon tile shown on each insight card.
-const SEVERITY_TILE_CLASSES: Record<AIInsightSeverity, string> = {
-  [AIInsightSeverity.High]: "bg-red-50 text-red-600",
-  [AIInsightSeverity.Medium]: "bg-amber-50 text-amber-600",
-  [AIInsightSeverity.Low]: "bg-blue-50 text-blue-600",
-};
-
-/*
- * ActionRequired is the attention state, FixOpened means the AI agent is on
- * it, the terminal human states are calm (green/gray), and Detected — a
- * transient state the scanner routes out of in the same tick — stays gray.
- */
-const STATUS_BADGE_CLASSES: Record<AIInsightStatus, string> = {
-  [AIInsightStatus.Detected]: "bg-gray-100 text-gray-600 ring-gray-500/20",
-  [AIInsightStatus.ActionRequired]:
-    "bg-orange-50 text-orange-700 ring-orange-600/20",
-  [AIInsightStatus.FixOpened]:
-    "bg-purple-50 text-purple-700 ring-purple-600/20",
-  [AIInsightStatus.Resolved]: "bg-green-50 text-green-700 ring-green-600/20",
-  [AIInsightStatus.Dismissed]: "bg-gray-100 text-gray-600 ring-gray-500/20",
-};
-
-const STATUS_DOT_CLASSES: Record<AIInsightStatus, string> = {
-  [AIInsightStatus.Detected]: "bg-gray-400",
-  [AIInsightStatus.ActionRequired]: "bg-orange-500",
-  [AIInsightStatus.FixOpened]: "bg-purple-500",
-  [AIInsightStatus.Resolved]: "bg-green-500",
-  [AIInsightStatus.Dismissed]: "bg-gray-400",
-};
-
-// Each detector gets its own glyph so a card is recognizable at a glance.
-const INSIGHT_TYPE_ICONS: Record<AIInsightType, IconProp> = {
-  [AIInsightType.NewException]: IconProp.Bug,
-  [AIInsightType.ExceptionSpike]: IconProp.Fire,
-  [AIInsightType.ErrorLogSpike]: IconProp.Logs,
-  [AIInsightType.TraceLatencyRegression]: IconProp.Clock,
-  [AIInsightType.MetricDrift]: IconProp.ArrowTrendingUp,
-};
-
-export function getInsightTypeLabel(
-  insightType: AIInsightType | undefined,
-): string {
-  if (!insightType) {
-    return "-";
-  }
-  return INSIGHT_TYPE_LABELS[insightType] || insightType;
-}
-
-export function getStatusLabel(status: AIInsightStatus | undefined): string {
-  if (!status) {
-    return "-";
-  }
-  return STATUS_LABELS[status] || status;
-}
-
-export function getInsightTypeIcon(
-  insightType: AIInsightType | undefined,
-): IconProp {
-  if (!insightType) {
-    return IconProp.LightBulb;
-  }
-  return INSIGHT_TYPE_ICONS[insightType] || IconProp.LightBulb;
-}
-
-export function getSeverityTileClasses(
-  severity: AIInsightSeverity | undefined,
-): string {
-  if (!severity) {
-    return "bg-gray-100 text-gray-500";
-  }
-  return SEVERITY_TILE_CLASSES[severity] || "bg-gray-100 text-gray-500";
-}
-
-export function getInsightTypeElement(
-  insightType: AIInsightType | undefined,
-): ReactElement {
-  if (!insightType) {
-    return <></>;
-  }
-  return (
-    <span className="inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700 ring-1 ring-inset ring-indigo-600/20">
-      {getInsightTypeLabel(insightType)}
-    </span>
-  );
-}
-
-export function getSeverityElement(
-  severity: AIInsightSeverity | undefined,
-): ReactElement {
-  if (!severity) {
-    return <></>;
-  }
-  return (
-    <span
-      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
-        SEVERITY_BADGE_CLASSES[severity] ||
-        "bg-gray-100 text-gray-600 ring-gray-500/20"
-      }`}
-    >
-      <span
-        className={`h-1.5 w-1.5 rounded-full ${
-          SEVERITY_DOT_CLASSES[severity] || "bg-gray-400"
-        }`}
-      />
-      {severity}
-    </span>
-  );
-}
-
-export function getStatusElement(
-  status: AIInsightStatus | undefined,
-): ReactElement {
-  if (!status) {
-    return <></>;
-  }
-  return (
-    <span
-      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
-        STATUS_BADGE_CLASSES[status] ||
-        "bg-gray-100 text-gray-600 ring-gray-500/20"
-      }`}
-    >
-      <span
-        className={`h-1.5 w-1.5 rounded-full ${
-          STATUS_DOT_CLASSES[status] || "bg-gray-400"
-        }`}
-      />
-      {getStatusLabel(status)}
-    </span>
-  );
-}
-
-export function getHumanVerdictElement(
-  verdict: AIInsightHumanVerdict | undefined | null,
-): ReactElement {
-  if (verdict === AIInsightHumanVerdict.Confirmed) {
-    return (
-      <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">
-        <Icon icon={IconProp.Check} className="h-3 w-3" />
-        Confirmed
-      </span>
-    );
-  }
-  if (verdict === AIInsightHumanVerdict.Dismissed) {
-    return (
-      <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/20">
-        <Icon icon={IconProp.Close} className="h-3 w-3" />
-        Dismissed
-      </span>
-    );
-  }
-  return <></>;
-}
+import InsightFilterBar, {
+  InsightFilterOption,
+} from "../../Components/AIInsights/InsightFilterBar";
+import InsightListItem from "../../Components/AIInsights/InsightListItem";
+import InsightListSkeleton from "../../Components/AIInsights/InsightListSkeleton";
+import InsightStatusSummary, {
+  InsightStatusBucket,
+} from "../../Components/AIInsights/InsightStatusSummary";
+import {
+  INSIGHT_TYPE_LABELS,
+  STATUS_LABELS,
+  getStatusDotClasses,
+} from "../../Components/AIInsights/InsightPresentation";
 
 const INSIGHTS_PER_PAGE: number = 20;
 
+const SKELETON_ROW_COUNT: number = 6;
+
 const ALL_FILTER_VALUE: string = "All";
 
-const STATUS_FILTER_OPTIONS: Array<FilterButtonOption> = [
-  { label: "All", value: ALL_FILTER_VALUE },
+interface StatusSummaryDefinition {
+  label: string;
+  value: string;
+  dotClassName: string;
+}
+
+/*
+ * The lifecycle states worth their own tile. Detected is deliberately absent:
+ * the scanner routes every insight out of it in the same tick, so a tile for
+ * it would read zero forever (those rows are still in the All total).
+ */
+const STATUS_SUMMARY_DEFINITIONS: Array<StatusSummaryDefinition> = [
+  {
+    label: "All insights",
+    value: ALL_FILTER_VALUE,
+    dotClassName: "bg-indigo-500",
+  },
   {
     label: STATUS_LABELS[AIInsightStatus.ActionRequired],
     value: AIInsightStatus.ActionRequired,
+    dotClassName: getStatusDotClasses(AIInsightStatus.ActionRequired),
   },
   {
     label: STATUS_LABELS[AIInsightStatus.FixOpened],
     value: AIInsightStatus.FixOpened,
+    dotClassName: getStatusDotClasses(AIInsightStatus.FixOpened),
   },
   {
     label: STATUS_LABELS[AIInsightStatus.Resolved],
     value: AIInsightStatus.Resolved,
+    dotClassName: getStatusDotClasses(AIInsightStatus.Resolved),
   },
   {
     label: STATUS_LABELS[AIInsightStatus.Dismissed],
     value: AIInsightStatus.Dismissed,
+    dotClassName: getStatusDotClasses(AIInsightStatus.Dismissed),
   },
 ];
 
-const SEVERITY_FILTER_OPTIONS: Array<FilterButtonOption> = [
-  { label: "Any Severity", value: ALL_FILTER_VALUE },
-  { label: "High", value: AIInsightSeverity.High },
-  { label: "Medium", value: AIInsightSeverity.Medium },
-  { label: "Low", value: AIInsightSeverity.Low },
+const SEVERITY_FILTER_OPTIONS: Array<InsightFilterOption> = [
+  { label: "Any severity", value: ALL_FILTER_VALUE },
+  { label: "High severity", value: AIInsightSeverity.High },
+  { label: "Medium severity", value: AIInsightSeverity.Medium },
+  { label: "Low severity", value: AIInsightSeverity.Low },
 ];
 
-const TYPE_FILTER_OPTIONS: Array<FilterButtonOption> = [
-  { label: "All Types", value: ALL_FILTER_VALUE },
+const TYPE_FILTER_OPTIONS: Array<InsightFilterOption> = [
+  { label: "All types", value: ALL_FILTER_VALUE },
   ...Object.values(AIInsightType).map((insightType: AIInsightType) => {
     return {
       label: INSIGHT_TYPE_LABELS[insightType],
@@ -286,10 +128,10 @@ const readFilterParam: ReadFilterParamFunction = (
 };
 
 /*
- * The AI insights inbox, rendered as cards instead of a table: each finding
- * reads like an inbox item — severity-tinted detector icon, badges, title
- * and the freshness/occurrence meta — with status and severity chip filters
- * and a title search on top.
+ * The AI insights inbox: a triage strip of per-status counts (which is also
+ * the status filter), one search/type/severity toolbar, and a single aligned
+ * list where every finding reads as title-first with its status, detection
+ * count and freshness in fixed right-hand columns.
  */
 const AIInsightsPage: FunctionComponent<
   PageComponentProps
@@ -305,9 +147,20 @@ const AIInsightsPage: FunctionComponent<
   const [error, setError] = useState<string | null>(null);
   /*
    * Append failures get their own inline error so a transient blip on Load
-   * More never unmounts the cards that already loaded.
+   * More never unmounts the rows that already loaded.
    */
   const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+
+  /*
+   * Per-status totals for the triage strip. null means "no numbers to show" —
+   * the counts are a nicety, so a failed count request quietly renders an
+   * em dash instead of taking the page down with it.
+   */
+  const [statusCounts, setStatusCounts] = useState<Record<
+    string,
+    number
+  > | null>(null);
+  const [isLoadingCounts, setIsLoadingCounts] = useState<boolean>(true);
 
   const [statusFilter, setStatusFilter] = useState<string>(() => {
     return readFilterParam("status", Object.values(AIInsightStatus));
@@ -353,6 +206,49 @@ const AIInsightsPage: FunctionComponent<
       debouncedSearchText,
   );
 
+  type ClearFiltersFunction = () => void;
+
+  const clearFilters: ClearFiltersFunction = (): void => {
+    setStatusFilter(ALL_FILTER_VALUE);
+    setSeverityFilter(ALL_FILTER_VALUE);
+    setTypeFilter(ALL_FILTER_VALUE);
+    setSearchText("");
+    setDebouncedSearchText("");
+  };
+
+  /*
+   * Everything except status, which the caller supplies — the triage strip
+   * needs the same query once per status bucket.
+   */
+  type BuildQueryFunction = (status: string | null) => Query<AIInsight>;
+
+  const buildQuery: BuildQueryFunction = useCallback(
+    (status: string | null): Query<AIInsight> => {
+      const query: Query<AIInsight> = {};
+
+      if (status) {
+        (query as Record<string, unknown>)["status"] = status;
+      }
+
+      if (severityFilter !== ALL_FILTER_VALUE) {
+        (query as Record<string, unknown>)["severity"] = severityFilter;
+      }
+
+      if (typeFilter !== ALL_FILTER_VALUE) {
+        (query as Record<string, unknown>)["insightType"] = typeFilter;
+      }
+
+      if (debouncedSearchText) {
+        (query as Record<string, unknown>)["title"] = new Search(
+          debouncedSearchText,
+        );
+      }
+
+      return query;
+    },
+    [severityFilter, typeFilter, debouncedSearchText],
+  );
+
   /*
    * Guards against out-of-order responses: a Load More issued just before a
    * filter change could otherwise land after the filter's fresh page and
@@ -360,6 +256,7 @@ const AIInsightsPage: FunctionComponent<
    * a ticket; only the latest ticket may write state.
    */
   const fetchGenerationRef: React.MutableRefObject<number> = useRef<number>(0);
+  const countGenerationRef: React.MutableRefObject<number> = useRef<number>(0);
 
   const fetchInsights: (options: {
     skip: number;
@@ -375,30 +272,12 @@ const AIInsightsPage: FunctionComponent<
       }
 
       try {
-        const query: Query<AIInsight> = {};
-
-        if (statusFilter !== ALL_FILTER_VALUE) {
-          (query as Record<string, unknown>)["status"] = statusFilter;
-        }
-
-        if (severityFilter !== ALL_FILTER_VALUE) {
-          (query as Record<string, unknown>)["severity"] = severityFilter;
-        }
-
-        if (typeFilter !== ALL_FILTER_VALUE) {
-          (query as Record<string, unknown>)["insightType"] = typeFilter;
-        }
-
-        if (debouncedSearchText) {
-          (query as Record<string, unknown>)["title"] = new Search(
-            debouncedSearchText,
-          );
-        }
-
         const result: ListResult<AIInsight> = await ModelAPI.getList<AIInsight>(
           {
             modelType: AIInsight,
-            query: query,
+            query: buildQuery(
+              statusFilter === ALL_FILTER_VALUE ? null : statusFilter,
+            ),
             limit: INSIGHTS_PER_PAGE,
             skip: options.skip,
             select: {
@@ -433,7 +312,7 @@ const AIInsightsPage: FunctionComponent<
            * De-duplicate by id: the list is offset-paginated on lastSeenAt,
            * which the scanner bumps on every re-detection, so a row already
            * on screen can slide back into the appended window. Without this
-           * the same card renders twice (with a duplicate React key).
+           * the same row renders twice (with a duplicate React key).
            */
           const seenIds: Set<string> = new Set(
             current.map((item: AIInsight) => {
@@ -464,8 +343,51 @@ const AIInsightsPage: FunctionComponent<
         }
       }
     },
-    [statusFilter, severityFilter, typeFilter, debouncedSearchText],
+    [buildQuery, statusFilter],
   );
+
+  const fetchStatusCounts: () => Promise<void> =
+    useCallback(async (): Promise<void> => {
+      const generation: number = ++countGenerationRef.current;
+      setIsLoadingCounts(true);
+
+      try {
+        const counts: Array<number> = await Promise.all(
+          STATUS_SUMMARY_DEFINITIONS.map(
+            (definition: StatusSummaryDefinition) => {
+              return ModelAPI.count<AIInsight>({
+                modelType: AIInsight,
+                query: buildQuery(
+                  definition.value === ALL_FILTER_VALUE
+                    ? null
+                    : definition.value,
+                ),
+              });
+            },
+          ),
+        );
+
+        if (generation !== countGenerationRef.current) {
+          return;
+        }
+
+        const nextCounts: Record<string, number> = {};
+        STATUS_SUMMARY_DEFINITIONS.forEach(
+          (definition: StatusSummaryDefinition, index: number) => {
+            nextCounts[definition.value] = counts[index] || 0;
+          },
+        );
+        setStatusCounts(nextCounts);
+      } catch {
+        if (generation === countGenerationRef.current) {
+          setStatusCounts(null);
+        }
+      } finally {
+        if (generation === countGenerationRef.current) {
+          setIsLoadingCounts(false);
+        }
+      }
+    }, [buildQuery]);
 
   useEffect(() => {
     fetchInsights({ skip: 0, append: false }).catch(() => {
@@ -473,84 +395,46 @@ const AIInsightsPage: FunctionComponent<
     });
   }, [fetchInsights]);
 
-  type GetInsightCardFunction = (item: AIInsight) => ReactElement;
+  // Counts do not depend on the status filter — that is what they label.
+  useEffect(() => {
+    fetchStatusCounts().catch(() => {
+      // handled inside fetchStatusCounts
+    });
+  }, [fetchStatusCounts]);
 
-  const getInsightCard: GetInsightCardFunction = (
-    item: AIInsight,
-  ): ReactElement => {
-    const viewRoute: Route = RouteUtil.populateRouteParams(
-      RouteMap[PageMap.AI_INSIGHT_VIEW] as Route,
-      { modelId: item.id! },
-    );
+  type RefreshFunction = () => void;
 
+  const refresh: RefreshFunction = (): void => {
+    fetchInsights({ skip: 0, append: false }).catch(() => {
+      // handled inside fetchInsights
+    });
+    fetchStatusCounts().catch(() => {
+      // handled inside fetchStatusCounts
+    });
+  };
+
+  const statusBuckets: Array<InsightStatusBucket> =
+    STATUS_SUMMARY_DEFINITIONS.map((definition: StatusSummaryDefinition) => {
+      return {
+        label: definition.label,
+        value: definition.value,
+        dotClassName: definition.dotClassName,
+        count: statusCounts ? statusCounts[definition.value] ?? null : null,
+      };
+    });
+
+  type GetListHeaderFunction = () => ReactElement;
+
+  // The column labels the wide layout's right-hand columns line up under.
+  const getListHeader: GetListHeaderFunction = (): ReactElement => {
     return (
-      <Link
-        key={item.id?.toString()}
-        to={viewRoute}
-        className="group block rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
-      >
-        <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition-all duration-150 group-hover:border-indigo-300 group-hover:shadow-md sm:p-5">
-          <div className="flex items-start gap-4">
-            <div
-              className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg ${getSeverityTileClasses(
-                item.severity,
-              )}`}
-            >
-              <Icon
-                icon={getInsightTypeIcon(item.insightType)}
-                className="h-5 w-5"
-              />
-            </div>
-
-            <div className="min-w-0 flex-1">
-              <div className="flex flex-wrap items-center gap-1.5">
-                {getInsightTypeElement(item.insightType)}
-                {getSeverityElement(item.severity)}
-                {getStatusElement(item.status)}
-                {getHumanVerdictElement(item.humanVerdict)}
-              </div>
-
-              <h3 className="mt-2 truncate text-sm font-semibold text-gray-900 group-hover:text-indigo-600">
-                {item.title}
-              </h3>
-
-              <div className="mt-1.5 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500">
-                {item.serviceName ? (
-                  <span className="inline-flex items-center gap-1">
-                    <Icon icon={IconProp.Cube} className="h-3.5 w-3.5" />
-                    {item.serviceName}
-                  </span>
-                ) : (
-                  <></>
-                )}
-                {item.lastSeenAt ? (
-                  <span className="inline-flex items-center gap-1">
-                    <Icon icon={IconProp.Clock} className="h-3.5 w-3.5" />
-                    Last seen {OneUptimeDate.fromNow(item.lastSeenAt)}
-                  </span>
-                ) : (
-                  <></>
-                )}
-                {item.occurrenceCount ? (
-                  <span className="inline-flex items-center gap-1">
-                    <Icon icon={IconProp.Refresh} className="h-3.5 w-3.5" />
-                    {item.occurrenceCount === 1
-                      ? "Detected once"
-                      : `Detected ${item.occurrenceCount} times`}
-                  </span>
-                ) : (
-                  <></>
-                )}
-              </div>
-            </div>
-
-            <Icon
-              icon={IconProp.ChevronRight}
-              className="mt-1 h-5 w-5 flex-shrink-0 text-gray-300 transition-colors group-hover:text-indigo-500"
-            />
-          </div>
-        </div>
-      </Link>
+      <div className="hidden items-center gap-4 border-b border-gray-100 bg-gray-50 px-4 py-2.5 text-xs font-medium uppercase tracking-wide text-gray-400 lg:flex">
+        <span className="flex-1">Insight</span>
+        <span className="w-32 flex-shrink-0">Status</span>
+        <span className="w-24 flex-shrink-0 text-right">Detections</span>
+        <span className="w-36 flex-shrink-0 text-right">Last seen</span>
+        <span className="w-5 flex-shrink-0" />
+      </div>
     );
   };
 
@@ -559,20 +443,16 @@ const AIInsightsPage: FunctionComponent<
   const getContent: GetContentFunction = (): ReactElement => {
     // Full-page error only when there is nothing loaded to keep on screen.
     if (error && insights.length === 0) {
-      return (
-        <ErrorMessage
-          message={error}
-          onRefreshClick={() => {
-            fetchInsights({ skip: 0, append: false }).catch(() => {
-              // handled inside fetchInsights
-            });
-          }}
-        />
-      );
+      return <ErrorMessage message={error} onRefreshClick={refresh} />;
     }
 
     if (isLoading) {
-      return <ComponentLoader />;
+      return (
+        <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+          {getListHeader()}
+          <InsightListSkeleton rowCount={SKELETON_ROW_COUNT} />
+        </div>
+      );
     }
 
     if (insights.length === 0 && !hasActiveFilters) {
@@ -604,29 +484,36 @@ const AIInsightsPage: FunctionComponent<
       );
     }
 
+    /*
+     * The no-match state stays inside the list frame (rather than using the
+     * tall shared EmptyState) so the filters above it do not jump when the
+     * result set empties out.
+     */
     if (insights.length === 0) {
       return (
-        <EmptyState
-          id="ai-insights-no-match"
-          icon={IconProp.Search}
-          showSolidBackground={true}
-          title="No insights match your filters"
-          description="Try changing the status or severity filters, or clearing your search."
-          footer={
-            <Button
-              title="Clear Filters"
-              icon={IconProp.Close}
-              buttonStyle={ButtonStyleType.OUTLINE}
-              onClick={() => {
-                setStatusFilter(ALL_FILTER_VALUE);
-                setSeverityFilter(ALL_FILTER_VALUE);
-                setTypeFilter(ALL_FILTER_VALUE);
-                setSearchText("");
-                setDebouncedSearchText("");
-              }}
-            />
-          }
-        />
+        <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div className="flex flex-col items-center px-6 py-16 text-center">
+            <span className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-400">
+              <Icon icon={IconProp.Search} className="h-6 w-6" />
+            </span>
+            <h3 className="mt-4 text-sm font-semibold text-gray-900">
+              No insights match your filters
+            </h3>
+            <p className="mt-1 max-w-sm text-sm text-gray-500">
+              Try a different status or severity, or clear your search to see
+              everything OneUptime AI has found.
+            </p>
+            <div className="mt-5">
+              <Button
+                title="Clear Filters"
+                icon={IconProp.Close}
+                buttonStyle={ButtonStyleType.OUTLINE}
+                buttonSize={ButtonSize.Small}
+                onClick={clearFilters}
+              />
+            </div>
+          </div>
+        </div>
       );
     }
 
@@ -640,51 +527,65 @@ const AIInsightsPage: FunctionComponent<
           <></>
         )}
 
-        {insights.map((item: AIInsight) => {
-          return getInsightCard(item);
-        })}
+        <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+          {getListHeader()}
 
-        <div className="flex flex-col items-center gap-2 pt-2">
-          {loadMoreError ? (
-            <p className="text-sm text-red-500">
-              Could not load more insights: {loadMoreError}
+          <ul className="divide-y divide-gray-100">
+            {insights.map((item: AIInsight) => {
+              return (
+                <InsightListItem key={item.id?.toString()} insight={item} />
+              );
+            })}
+          </ul>
+
+          <div className="flex flex-col items-center justify-between gap-3 border-t border-gray-100 bg-gray-50 px-4 py-3 sm:flex-row">
+            <p className="text-xs text-gray-500">
+              Showing{" "}
+              <span className="font-medium text-gray-700">
+                {insights.length}
+              </span>{" "}
+              of <span className="font-medium text-gray-700">{totalCount}</span>{" "}
+              {totalCount === 1 ? "insight" : "insights"}
             </p>
-          ) : (
-            <></>
-          )}
-          {insights.length < totalCount ? (
-            <Button
-              title="Load More"
-              icon={IconProp.ChevronDown}
-              buttonStyle={ButtonStyleType.OUTLINE}
-              buttonSize={ButtonSize.Small}
-              isLoading={isLoadingMore}
-              onClick={() => {
-                fetchInsights({ skip: insights.length, append: true }).catch(
-                  () => {
-                    // handled inside fetchInsights
-                  },
-                );
-              }}
-            />
-          ) : (
-            <></>
-          )}
-          <p className="text-xs text-gray-400">
-            Showing {insights.length} of {totalCount}{" "}
-            {totalCount === 1 ? "insight" : "insights"}
-          </p>
+
+            {insights.length < totalCount ? (
+              <Button
+                title="Load More"
+                icon={IconProp.ChevronDown}
+                buttonStyle={ButtonStyleType.OUTLINE}
+                buttonSize={ButtonSize.Small}
+                isLoading={isLoadingMore}
+                onClick={() => {
+                  fetchInsights({ skip: insights.length, append: true }).catch(
+                    () => {
+                      // handled inside fetchInsights
+                    },
+                  );
+                }}
+              />
+            ) : (
+              <></>
+            )}
+          </div>
         </div>
+
+        {loadMoreError ? (
+          <p className="text-center text-sm text-red-500">
+            Could not load more insights: {loadMoreError}
+          </p>
+        ) : (
+          <></>
+        )}
       </div>
     );
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
       <AIPlanGate />
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <p className="max-w-2xl text-sm text-gray-500">
+        <p className="max-w-3xl text-sm leading-6 text-gray-500">
           Proactive findings from OneUptime AI&apos;s deterministic telemetry
           sensors — new or spiking exceptions, error-log spikes, latency
           regressions and metric drift. Insights never page and never open
@@ -696,11 +597,7 @@ const AIInsightsPage: FunctionComponent<
             icon={IconProp.Refresh}
             buttonStyle={ButtonStyleType.OUTLINE}
             buttonSize={ButtonSize.Small}
-            onClick={() => {
-              fetchInsights({ skip: 0, append: false }).catch(() => {
-                // handled inside fetchInsights
-              });
-            }}
+            onClick={refresh}
           />
           <Button
             title="Settings"
@@ -714,45 +611,26 @@ const AIInsightsPage: FunctionComponent<
         </div>
       </div>
 
-      <div className="space-y-2">
-        <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-          <FilterButtons
-            className="flex-wrap"
-            options={STATUS_FILTER_OPTIONS}
-            selectedValue={statusFilter}
-            onSelect={(value: string) => {
-              setStatusFilter(value);
-            }}
-          />
-          <div className="w-full sm:w-64">
-            <Input
-              placeholder="Search insights..."
-              value={searchText}
-              onChange={(value: string) => {
-                setSearchText(value);
-              }}
-            />
-          </div>
-        </div>
-        <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-          <FilterButtons
-            className="flex-wrap"
-            options={TYPE_FILTER_OPTIONS}
-            selectedValue={typeFilter}
-            onSelect={(value: string) => {
-              setTypeFilter(value);
-            }}
-          />
-          <FilterButtons
-            className="flex-wrap"
-            options={SEVERITY_FILTER_OPTIONS}
-            selectedValue={severityFilter}
-            onSelect={(value: string) => {
-              setSeverityFilter(value);
-            }}
-          />
-        </div>
-      </div>
+      <InsightStatusSummary
+        buckets={statusBuckets}
+        selectedValue={statusFilter}
+        isLoading={isLoadingCounts}
+        onSelect={setStatusFilter}
+      />
+
+      <InsightFilterBar
+        searchText={searchText}
+        onSearchTextChange={setSearchText}
+        typeOptions={TYPE_FILTER_OPTIONS}
+        typeValue={typeFilter}
+        onTypeChange={setTypeFilter}
+        severityOptions={SEVERITY_FILTER_OPTIONS}
+        severityValue={severityFilter}
+        onSeverityChange={setSeverityFilter}
+        unfilteredValue={ALL_FILTER_VALUE}
+        hasActiveFilters={hasActiveFilters}
+        onClearFilters={clearFilters}
+      />
 
       {getContent()}
     </div>

--- a/App/FeatureSet/Dashboard/src/Pages/AIInsights/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/AIInsights/View/Index.tsx
@@ -8,7 +8,12 @@ import {
   getSeverityElement,
   getSeverityTileClasses,
   getStatusElement,
-} from "../Insights";
+  getStatusLabel,
+} from "../../../Components/AIInsights/InsightPresentation";
+import InsightFactsList, {
+  InsightFact,
+} from "../../../Components/AIInsights/InsightFactsList";
+import InsightPanel from "../../../Components/AIInsights/InsightPanel";
 import ChatActivityFeed from "../../../Components/AIChat/ChatActivityFeed";
 import AIRun from "Common/Models/DatabaseModels/AIRun";
 import AIRunEvent from "Common/Models/DatabaseModels/AIRunEvent";
@@ -31,7 +36,6 @@ import Button, {
   ButtonSize,
   ButtonStyleType,
 } from "Common/UI/Components/Button/Button";
-import Card from "Common/UI/Components/Card/Card";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import Icon from "Common/UI/Components/Icon/Icon";
 import PageLoader from "Common/UI/Components/Loader/PageLoader";
@@ -318,6 +322,11 @@ const AIInsightViewPage: FunctionComponent<
   );
   const isConfirmed: boolean = humanVerdict === AIInsightHumanVerdict.Confirmed;
 
+  /*
+   * The triage strip: a tinted panel rather than a bare colored line, so a
+   * run that is still working, one that finished and one that died are
+   * distinguishable at a glance and not just by reading the sentence.
+   */
   interface TriageStatusMeta {
     text: string;
     className: string;
@@ -326,7 +335,7 @@ const AIInsightViewPage: FunctionComponent<
 
   let triageStatusMeta: TriageStatusMeta = {
     text: "Triage did not finish",
-    className: "text-red-600",
+    className: "border-red-100 bg-red-50 text-red-700",
     icon: IconProp.Alert,
   };
   let isTriageFailed: boolean = true;
@@ -334,37 +343,30 @@ const AIInsightViewPage: FunctionComponent<
   if (triageRun?.status === AIRunStatus.Running) {
     triageStatusMeta = {
       text: "Triaging…",
-      className: "text-indigo-600",
+      className: "border-indigo-100 bg-indigo-50 text-indigo-700",
       icon: IconProp.Sparkles,
     };
     isTriageFailed = false;
   } else if (triageRun?.status === AIRunStatus.Queued) {
     triageStatusMeta = {
       text: "Queued — waiting for a worker…",
-      className: "text-indigo-600",
+      className: "border-indigo-100 bg-indigo-50 text-indigo-700",
       icon: IconProp.Sparkles,
     };
     isTriageFailed = false;
   } else if (triageRun?.status === AIRunStatus.Completed) {
     triageStatusMeta = {
       text: "Triage complete",
-      className: "text-green-600",
+      className: "border-green-100 bg-green-50 text-green-700",
       icon: IconProp.Check,
     };
     isTriageFailed = false;
   }
 
-  interface OverviewMetaItem {
-    label: string;
-    icon: IconProp;
-    value: string;
-    title?: string | undefined;
-  }
-
-  const metaItems: Array<OverviewMetaItem> = [];
+  const facts: Array<InsightFact> = [];
 
   if (insight.serviceName) {
-    metaItems.push({
+    facts.push({
       label: "Service",
       icon: IconProp.Cube,
       value: insight.serviceName,
@@ -372,32 +374,14 @@ const AIInsightViewPage: FunctionComponent<
   }
 
   if (insight.metricName) {
-    metaItems.push({
+    facts.push({
       label: "Metric",
       icon: IconProp.ChartBar,
       value: insight.metricName,
     });
   }
 
-  if (insight.firstSeenAt) {
-    metaItems.push({
-      label: "First Seen",
-      icon: IconProp.Clock,
-      value: OneUptimeDate.fromNow(insight.firstSeenAt),
-      title: OneUptimeDate.getDateAsLocalFormattedString(insight.firstSeenAt),
-    });
-  }
-
-  if (insight.lastSeenAt) {
-    metaItems.push({
-      label: "Last Seen",
-      icon: IconProp.Clock,
-      value: OneUptimeDate.fromNow(insight.lastSeenAt),
-      title: OneUptimeDate.getDateAsLocalFormattedString(insight.lastSeenAt),
-    });
-  }
-
-  metaItems.push({
+  facts.push({
     label: "Detections",
     icon: IconProp.Refresh,
     value:
@@ -406,15 +390,33 @@ const AIInsightViewPage: FunctionComponent<
         : `${insight.occurrenceCount || 0} times`,
   });
 
+  if (insight.firstSeenAt) {
+    facts.push({
+      label: "First seen",
+      icon: IconProp.Clock,
+      value: OneUptimeDate.fromNow(insight.firstSeenAt),
+      title: OneUptimeDate.getDateAsLocalFormattedString(insight.firstSeenAt),
+    });
+  }
+
+  if (insight.lastSeenAt) {
+    facts.push({
+      label: "Last seen",
+      icon: IconProp.Clock,
+      value: OneUptimeDate.fromNow(insight.lastSeenAt),
+      title: OneUptimeDate.getDateAsLocalFormattedString(insight.lastSeenAt),
+    });
+  }
+
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
       {/* Overview: what was found, where it stands, and the one-click actions. */}
-      <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
+      <section className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
         <div className="px-5 py-6 md:px-6">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div className="flex min-w-0 items-start gap-4">
-              <div
-                className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-lg ${getSeverityTileClasses(
+              <span
+                className={`flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl ${getSeverityTileClasses(
                   insight.severity,
                 )}`}
               >
@@ -422,17 +424,17 @@ const AIInsightViewPage: FunctionComponent<
                   icon={getInsightTypeIcon(insight.insightType)}
                   className="h-6 w-6"
                 />
-              </div>
+              </span>
               <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-1.5">
+                <h2 className="text-lg font-semibold leading-6 text-gray-900">
+                  {insight.title}
+                </h2>
+                <div className="mt-2 flex flex-wrap items-center gap-1.5">
                   {getInsightTypeElement(insight.insightType)}
                   {getSeverityElement(insight.severity)}
                   {getStatusElement(status || undefined)}
                   {getHumanVerdictElement(humanVerdict)}
                 </div>
-                <h2 className="mt-2 text-base font-semibold leading-6 text-gray-900">
-                  {insight.title}
-                </h2>
               </div>
             </div>
 
@@ -491,143 +493,151 @@ const AIInsightViewPage: FunctionComponent<
           ) : (
             <></>
           )}
+        </div>
 
-          <dl className="mt-5 grid grid-cols-2 gap-4 border-t border-gray-100 pt-5 sm:grid-cols-3 lg:grid-cols-5">
-            {metaItems.map((item: OverviewMetaItem, index: number) => {
-              return (
-                <div key={index} className="min-w-0">
-                  <dt className="flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-gray-400">
-                    <Icon icon={item.icon} className="h-3.5 w-3.5" />
-                    {item.label}
-                  </dt>
-                  <dd
-                    className="mt-1 truncate text-sm text-gray-900"
-                    title={item.title || item.value}
-                  >
-                    {item.value}
-                  </dd>
-                </div>
-              );
-            })}
-          </dl>
+        {/*
+         * A closed insight loses its action buttons, which on its own reads
+         * as a page that failed to render them — say why instead.
+         */}
+        <p className="border-t border-gray-100 bg-gray-50 px-5 py-3 text-xs text-gray-500 md:px-6">
+          {isTerminal
+            ? `This insight is closed as ${getStatusLabel(
+                status || undefined,
+              )}. Detectors never reopen a closed insight — a new occurrence files a new one.`
+            : "Confirm or dismiss to record whether this insight was worth surfacing — verdicts measure each detector's precision. Resolve it once it has been handled."}
+        </p>
+      </section>
 
-          {!isTerminal ? (
-            <p className="mt-4 text-xs text-gray-400">
-              Confirm or dismiss to record whether this insight was worth
-              surfacing — verdicts measure each detector&apos;s precision.
-              Resolve it once it has been handled.
-            </p>
+      {/*
+       * Two columns from xl up: the evidence and the AI's reasoning are prose
+       * and want a readable measure, not the full width of a 27" display,
+       * and the facts read better as a scannable rail beside them.
+       */}
+      <div className="grid grid-cols-1 gap-5 xl:grid-cols-3">
+        <div className="min-w-0 space-y-5 xl:col-span-2">
+          <InsightPanel
+            title="Evidence"
+            icon={IconProp.ClipboardDocumentCheck}
+            description="The deterministic evidence behind this insight — real counts, baselines and multipliers written by the detector at detect time. Not AI output."
+          >
+            {insight.detailMarkdown ? (
+              /*
+               * safeMode is mandatory here: the detectors interpolate raw
+               * telemetry into this markdown (NewExceptionDetector and
+               * ExceptionSpikeDetector push `exception.message` in verbatim,
+               * not even fenced), and an exception message is
+               * attacker-influenceable — anything that reaches an
+               * instrumented service can shape it. Without safeMode a message
+               * carrying `![](https://attacker/p.png)` becomes a zero-click
+               * tracking beacon that fires in a privileged member's browser,
+               * and `[click](https://attacker/…)` becomes a phishing link
+               * wearing our chrome. safeMode neutralizes links, images and
+               * mermaid on the PARSED tree, so no CommonMark syntax trick can
+               * smuggle either past the parser.
+               */
+              <MarkdownViewer text={insight.detailMarkdown} safeMode={true} />
+            ) : (
+              <p className="text-sm text-gray-500">No evidence was recorded.</p>
+            )}
+          </InsightPanel>
+
+          {triageRun || insight.triageSummaryMarkdown ? (
+            <InsightPanel
+              title="AI Triage"
+              icon={IconProp.Sparkles}
+              description="A budgeted, read-only AI analysis of this insight — probable root cause, blast radius and suggested action, with citations."
+            >
+              <div className="space-y-3">
+                {insight.triageSummaryMarkdown ? (
+                  /*
+                   * safeMode is mandatory here too: this summary is LLM output
+                   * produced from a prompt that embeds the insight's detail
+                   * markdown and the telemetry behind it, so it is
+                   * prompt-injectable — the model can be talked into emitting
+                   * an image or link the attacker chose. Same defense the AI
+                   * chat uses for the same reason
+                   * (Components/AIChat/SafeChatMarkdown).
+                   */
+                  <MarkdownViewer
+                    text={insight.triageSummaryMarkdown}
+                    safeMode={true}
+                  />
+                ) : (
+                  <div>
+                    <div
+                      className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium ${triageStatusMeta.className}`}
+                    >
+                      <span className="flex-shrink-0">
+                        <Icon
+                          icon={triageStatusMeta.icon}
+                          className="h-4 w-4"
+                        />
+                      </span>
+                      <span>{triageStatusMeta.text}</span>
+                      {isTriageActive ? (
+                        <span className="ml-auto inline-block h-2 w-2 animate-ping rounded-full bg-indigo-500" />
+                      ) : (
+                        <></>
+                      )}
+                    </div>
+                    {isTriageFailed && triageRun?.errorMessage ? (
+                      <p className="mt-2 text-xs text-red-500">
+                        {triageRun.errorMessage}
+                      </p>
+                    ) : (
+                      <></>
+                    )}
+                  </div>
+                )}
+
+                {triageEvents.length > 0 ? (
+                  <ChatActivityFeed
+                    events={triageEvents}
+                    title={isTriageActive ? "Triaging…" : "Activity"}
+                    showLiveIndicator={isTriageActive}
+                    maxVisibleSteps={MAX_VISIBLE_STEPS}
+                  />
+                ) : (
+                  <></>
+                )}
+              </div>
+            </InsightPanel>
+          ) : (
+            <></>
+          )}
+        </div>
+
+        <div className="min-w-0 space-y-5">
+          <InsightPanel title="Details" icon={IconProp.List}>
+            <InsightFactsList facts={facts} />
+          </InsightPanel>
+
+          {insight.fixAiRunId ? (
+            <InsightPanel
+              title="Fix Task"
+              icon={IconProp.Code}
+              description="OneUptime AI queued an agent task for this insight. Fix pull requests are always drafts and always human-reviewed."
+            >
+              {/*
+               * A real anchor (not a Button) so cmd/ctrl-click, middle-click
+               * and "open in new tab" work — Link always sets href.
+               */}
+              <Link
+                to={RouteUtil.populateRouteParams(
+                  RouteMap[PageMap.AI_AGENT_TASK_VIEW] as Route,
+                  { modelId: insight.fixAiRunId },
+                )}
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-500"
+              >
+                <span>View the fix task and pull request</span>
+                <Icon icon={IconProp.ArrowRight} className="h-4 w-4" />
+              </Link>
+            </InsightPanel>
           ) : (
             <></>
           )}
         </div>
       </div>
-
-      <Card
-        title="Evidence"
-        description="The deterministic evidence behind this insight — real counts, baselines and multipliers written by the detector at detect time. Not AI output."
-      >
-        {insight.detailMarkdown ? (
-          /*
-           * safeMode is mandatory here: the detectors interpolate raw
-           * telemetry into this markdown (NewExceptionDetector and
-           * ExceptionSpikeDetector push `exception.message` in verbatim, not
-           * even fenced), and an exception message is attacker-influenceable
-           * — anything that reaches an instrumented service can shape it.
-           * Without safeMode a message carrying `![](https://attacker/p.png)`
-           * becomes a zero-click tracking beacon that fires in a privileged
-           * member's browser, and `[click](https://attacker/…)` becomes a
-           * phishing link wearing our chrome. safeMode neutralizes links,
-           * images and mermaid on the PARSED tree, so no CommonMark syntax
-           * trick can smuggle either past the parser.
-           */
-          <MarkdownViewer text={insight.detailMarkdown} safeMode={true} />
-        ) : (
-          <p className="text-sm text-gray-500">No evidence was recorded.</p>
-        )}
-      </Card>
-
-      {triageRun || insight.triageSummaryMarkdown ? (
-        <Card
-          title="AI Triage"
-          description="A budgeted, read-only AI analysis of this insight — probable root cause, blast radius and suggested action, with citations."
-        >
-          <div className="space-y-3">
-            {insight.triageSummaryMarkdown ? (
-              /*
-               * safeMode is mandatory here too: this summary is LLM output
-               * produced from a prompt that embeds the insight's detail
-               * markdown and the telemetry behind it, so it is
-               * prompt-injectable — the model can be talked into emitting an
-               * image or link the attacker chose. Same defense the AI chat
-               * uses for the same reason (Components/AIChat/SafeChatMarkdown).
-               */
-              <MarkdownViewer
-                text={insight.triageSummaryMarkdown}
-                safeMode={true}
-              />
-            ) : (
-              <div>
-                <div
-                  className={`flex items-center gap-2 text-sm font-medium ${triageStatusMeta.className}`}
-                >
-                  <Icon icon={triageStatusMeta.icon} className="h-4 w-4" />
-                  <span>{triageStatusMeta.text}</span>
-                  {isTriageActive ? (
-                    <span className="ml-1 inline-block h-2 w-2 animate-ping rounded-full bg-indigo-500" />
-                  ) : (
-                    <></>
-                  )}
-                </div>
-                {isTriageFailed && triageRun?.errorMessage ? (
-                  <p className="mt-1 text-xs text-red-500">
-                    {triageRun.errorMessage}
-                  </p>
-                ) : (
-                  <></>
-                )}
-              </div>
-            )}
-
-            {triageEvents.length > 0 ? (
-              <ChatActivityFeed
-                events={triageEvents}
-                title={isTriageActive ? "Triaging…" : "Activity"}
-                showLiveIndicator={isTriageActive}
-                maxVisibleSteps={MAX_VISIBLE_STEPS}
-              />
-            ) : (
-              <></>
-            )}
-          </div>
-        </Card>
-      ) : (
-        <></>
-      )}
-
-      {insight.fixAiRunId ? (
-        <Card
-          title="Fix Task"
-          description="OneUptime AI queued an agent task for this insight. Fix pull requests are always drafts and always human-reviewed."
-        >
-          {/*
-           * A real anchor (not a Button) so cmd/ctrl-click, middle-click
-           * and "open in new tab" work — Link always sets href.
-           */}
-          <Link
-            to={RouteUtil.populateRouteParams(
-              RouteMap[PageMap.AI_AGENT_TASK_VIEW] as Route,
-              { modelId: insight.fixAiRunId },
-            )}
-            className="inline-flex items-center gap-1.5 text-sm font-medium text-indigo-600 hover:text-indigo-500"
-          >
-            <span>View the fix task and pull request</span>
-            <Icon icon={IconProp.ArrowRight} className="h-4 w-4" />
-          </Link>
-        </Card>
-      ) : (
-        <></>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Why

The AI Insights list was a column of tall floating cards. Each carried three
identical-looking pills (type, severity, status) stacked above a title and a
meta line, and left the right two thirds of the card empty on any normal
display. The badges repeated verbatim down the page, so they read as texture
rather than signal, and there was no way to tell how much of anything there
was. On top of that, three filter groups — status, type and severity — wrapped
across two rows of eleven pills with the search box wedged between them.

The detail page had the same problem in a different shape: prose (the
detector's evidence and the AI's triage output) stretched to the full width of
the window, under a five-column meta grid.

## The list

- **Status filtering moved onto count tiles** — All / Needs Attention / Fix
  Opened / Resolved / Dismissed. One control now answers both "what is the
  backlog?" and "show me that slice", which is what let the toolbar collapse
  from three wrapping pill rows into a single row: search, a type select and a
  severity select. A select tints itself while it is narrowing the list (so an
  empty result reads as "nothing matches", not "nothing found"), and a Clear
  button appears once anything is filtering.
- **Cards became one aligned list** under a column header. Title first and
  prominent, then a single meta line (severity as a dot and word, detector,
  service, verdict), with status, detection count and last-seen in fixed
  right-hand columns — so the eye can run down the titles on the left or the
  status column on the right. Below `lg` those columns fold back into the meta
  line.
- **Badges per row went from three-plus to one.** Severity is carried by the
  tinted detector tile plus a dot; the detector name is plain text. Status
  keeps its pill because it is the field people act on.
- **Skeleton rows replace the spinner**, in the real row geometry, so the page
  no longer collapses and jumps on every filter change. The no-match state now
  sits inside the list frame instead of the 26rem-tall shared `EmptyState`,
  which used to shove the filters up the page as the result set emptied.

## The detail page

- **Two columns from `xl` up**: evidence and AI triage keep a readable measure
  instead of spanning a 27" display, and the facts moved to a label/value rail
  beside them.
- The header **leads with the title** (it was under the badges) and gains a
  footer line that survives the terminal states — a closed insight loses its
  three action buttons, which on its own reads as a page that failed to render
  them.
- The triage state is a **tinted strip** rather than a line of colored text, so
  running, complete and failed are distinguishable without reading them.

## Shape

Everything that decides how an insight looks — one label, one glyph and one
color per enum value — now lives in
`Components/AIInsights/InsightPresentation.tsx`, which both pages import,
instead of the detail page importing six presentation helpers from the list
page.

## Risk

No data contract, query, route or permission changed. The only new requests are
the five parallel `ModelAPI.count` calls behind the tiles; they carry the same
severity/type/search query as the list so the two can never disagree, they are
not refetched when the status filter itself changes, and a failure renders an em
dash rather than taking the page down. `AIInsight` is already indexed on
`(projectId, status)`.

Light and dark were both checked against `Common/UI/Styles/Theme.css`, which
remaps light utility classes rather than using `dark:` variants — every class
used here is one that file already covers.
