### PR TITLE
fix(helm): stop the worker fleet pinning at maxReplicas on queue depth

### DIFF
--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -1568,8 +1568,13 @@ worker:
     enabled: false
     minReplicas: 1
     maxReplicas: 100
-    # Scale up when combined queue size (worker + workflow + telemetry + runbook) exceeds this threshold
-    queueSizeThreshold: 10
+    # /metrics/queue-size reports the GLOBAL queue total (worker + workflow +
+    # telemetry + runbook) and KEDA reads it as an AverageValue, so desired
+    # replicas = queueTotal / this value — it is a divisor over the fleet-wide
+    # total, not a per-pod trip point. The total counts delayed jobs, and every
+    # cron repeatable holds one, so it never falls to zero: set this high enough
+    # that the idle floor alone cannot pin the fleet at maxReplicas.
+    queueSizeThreshold: 25
     # Scale up when average CPU utilization exceeds this percentage (0 to disable).
     # If enabled, worker.resources.requests.cpu must also be set.
     targetCPUUtilizationPercentage: 0


### PR DESCRIPTION
## Problem

The worker ScaledObject's `metrics-api` trigger renders without a `metricType` ([`_helpers.tpl:1269-1276`](https://github.com/OneUptime/oneuptime/blob/master/HelmChart/Public/oneuptime/templates/_helpers.tpl#L1269-L1276)), so KEDA defaults it to `AverageValue`. But `/metrics/queue-size` returns the **fleet-wide queue total**, identical from every pod.

For an External metric with `AverageValue`, the HPA computes:

```
desiredReplicas = ceil(totalMetricValue / targetAverageValue)
```

There is no `currentReplicas` term. At a fixed queue depth, **adding pods cannot reduce the desired count** — only the queue draining can. The per-pod figure shown by `kubectl get hpa` is just `total / replicas`, computed for display; it isn't what drives the decision.

## Observed

On a test cluster running the worker split with a sustained backlog:

| | |
|---|---|
| steady-state queue | 1,800 – 4,900 (mean ~2,500) |
| implied desired at threshold 10 | `2500 / 10` = **250** |
| actual fleet | ran to the ceiling and stayed there |
| worker CPU at the time | **68%** against an 80% target |

The CPU trigger wanted to scale *down* while the queue trigger demanded 250 pods. The HPA takes the **max** across triggers, so the queue trigger always wins and the fleet pins at `maxReplicas` indefinitely.

## Change

Raise the worker default from 10 to 25, so the steady-state request stays within the default `maxReplicas: 100`:

| queue | threshold 10 | threshold 25 |
|---|---|---|
| 1,800 | 180 | 72 |
| 2,500 | 250 | **100** |
| 4,900 | 490 | 196 |

The comment is also rewritten. The old text — "Scale up when combined queue size ... exceeds this threshold" — describes a trip point, which is the wrong mental model for a divisor and led to the value being sized as if it were per-pod.

Scope is deliberately narrow: **only the worker default changes.** `app` (10), `runner` (5) and `probes` (10) are untouched, as are `minReplicas`/`maxReplicas` and all templates.

## Verification

- `helm lint HelmChart/Public/oneuptime` — passes
- `helm template ... --set worker.enabled=true --set worker.keda.enabled=true` renders the worker trigger as `targetValue: "25"`
- Rendered output re-checked to confirm app/runner/probe ScaledObjects keep their original values
- `values.schema.json` declares the key as bare `{"type": "integer"}` at all four sites, so `25` validates unchanged

## Follow-up (not in this PR)

This mitigates the symptom. The underlying cause is that the autoscaling signal counts work that no pod can drain — [`Queue.ts:554-561`](https://github.com/OneUptime/oneuptime/blob/master/Common/Server/Infrastructure/Queue.ts#L554-L561):

```ts
return waitingCount + activeCount + delayedCount;
```

`delayed` counts jobs scheduled for the future. Under BullMQ 5 every repeatable permanently holds one materialized delayed job for its next iteration, and there are **124 `RunCron` call sites**, plus one delayed job per tenant scheduled workflow. So an idle install reports a queue in the hundreds and the metric never reaches zero — a floor that grows with tenant count and that no amount of scaling can drain. That also explains the CPU/queue contradiction above: much of the reported backlog was never runnable.

The fix is a separate autoscaling-only metric of `waiting + active`. It is not bundled here because `getQueueSize()` has other consumers with different semantics — telemetry ingest uses it for 429 backpressure ([`OTelIngest.ts:275`](https://github.com/OneUptime/oneuptime/blob/master/App/FeatureSet/Telemetry/API/OTelIngest.ts#L275), [`IncomingRequest.ts:114`](https://github.com/OneUptime/oneuptime/blob/master/App/FeatureSet/Telemetry/API/IncomingRequestIngest/IncomingRequest.ts#L114)) — where counting delayed jobs may well be intended.

Worth noting separately: with `app.keda.enabled=true` the rendered `app` ScaledObject emits only a `cpu` trigger and no queue trigger at all, so `app.keda.queueSizeThreshold` appears to be inert. Left alone here.
