### PR TITLE
fix(status-page): put the Resource Groups card on the product's own controls

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Groups.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Groups.tsx
@@ -40,7 +40,10 @@ import React, {
 } from "react";
 import UptimePrecision from "Common/Types/StatusPage/UptimePrecision";
 import StatusPageGroupViewMode from "Common/Types/StatusPage/StatusPageGroupViewMode";
-import { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import Button, {
+  ButtonSize,
+  ButtonStyleType,
+} from "Common/UI/Components/Button/Button";
 import IconProp from "Common/Types/Icon/IconProp";
 import DropdownUtil from "Common/UI/Utils/Dropdown";
 import FormValues from "Common/UI/Components/Forms/Types/FormValues";
@@ -212,6 +215,19 @@ const StatusPageGroups: FunctionComponent<PageComponentProps> = (
     StatusPageGroupHierarchyViewUtil.getSummary({
       statusPageGroups: statusPageGroups,
     });
+
+  /*
+   * Whether "Expand All" still has anything to open. A status page with no
+   * nesting at all, or one that is already fully unfolded, would otherwise
+   * offer a button that does nothing when clicked.
+   */
+  const canExpandMore: boolean = Array.from(
+    StatusPageGroupHierarchyViewUtil.getExpandableGroupIds({
+      statusPageGroups: statusPageGroups,
+    }),
+  ).some((statusPageGroupId: string) => {
+    return !expandedGroupIds.has(statusPageGroupId);
+  });
 
   type ToggleExpandFunction = (statusPageGroupId: string) => void;
 
@@ -590,28 +606,48 @@ const StatusPageGroups: FunctionComponent<PageComponentProps> = (
     );
 
     /*
-     * An icon-only trigger, styled to sit flush with the Card's own buttons.
-     * MoreMenu's default trigger renders its `text` as a visible label, which
-     * would put "More group actions" across the header next to "Create Group".
+     * The search decides what the card is showing, so it belongs with the
+     * card's own controls rather than floating above the tree - the same slot
+     * a ModelTable puts its search in.
      */
-    const buttons: Array<CardButtonSchema | ReactElement> = [
-      <MoreMenu
-        key="status-page-groups-actions"
-        text="More group actions"
-        elementToBeShownInsteadOfButton={
-          <button
-            type="button"
-            aria-label="More group actions"
-            data-testid="status-page-groups-actions"
-            className="inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
-          >
-            <Icon icon={IconProp.More} className="h-4 w-4 text-gray-500" />
-          </button>
-        }
+    const searchElement: ReactElement = (
+      <div
+        key="status-page-groups-search-slot"
+        className="relative w-full sm:w-52 lg:w-64"
       >
-        {menuItems}
-      </MoreMenu>,
-    ];
+        {/* Placeholders are not accessible names, and this input has no visible label. */}
+        <label
+          htmlFor="status-page-groups-search-input"
+          id="status-page-groups-search-label"
+          className="sr-only"
+        >
+          Search groups by name
+        </label>
+        <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-gray-400">
+          <Icon icon={IconProp.Search} className="h-4 w-4" />
+        </span>
+        <Input
+          id="status-page-groups-search-input"
+          ariaLabelledby="status-page-groups-search-label"
+          type={InputType.TEXT}
+          placeholder="Search groups..."
+          value={searchText}
+          dataTestId="status-page-groups-search"
+          outerDivClassName="relative w-full"
+          className="block w-full rounded-md border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          onChange={(value: string) => {
+            setSearchText(value);
+          }}
+        />
+      </div>
+    );
+
+    const buttons: Array<CardButtonSchema | ReactElement> = [];
+
+    /* Nothing to search on a status page that has no groups yet. */
+    if (statusPageGroups.length > 0) {
+      buttons.push(searchElement);
+    }
 
     if (canCreate) {
       buttons.push({
@@ -625,6 +661,24 @@ const StatusPageGroups: FunctionComponent<PageComponentProps> = (
         },
       } as CardButtonSchema);
     }
+
+    /*
+     * MoreMenu's own trigger, rather than one styled by hand: the overflow menu
+     * on every other card in the product is this button, and a bordered pill
+     * with a circled-ellipsis glyph was the one thing in this header that
+     * belonged to no other page.
+     */
+    buttons.push(
+      <MoreMenu
+        key="status-page-groups-actions"
+        menuIcon={IconProp.EllipsisHorizontal}
+        text=""
+        ariaLabel="More group actions"
+        dataTestId="status-page-groups-actions"
+      >
+        {menuItems}
+      </MoreMenu>,
+    );
 
     return buttons;
   };
@@ -699,49 +753,38 @@ const StatusPageGroups: FunctionComponent<PageComponentProps> = (
 
     return (
       <div className="space-y-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <div className="relative w-full sm:max-w-xs">
-            <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-              <Icon icon={IconProp.Search} className="h-4 w-4 text-gray-400" />
-            </div>
-            <Input
-              type={InputType.TEXT}
-              placeholder="Search groups..."
-              value={searchText}
-              dataTestId="status-page-groups-search"
-              outerDivClassName="relative w-full"
-              className="block w-full rounded-md border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm placeholder-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-              onChange={(value: string) => {
-                setSearchText(value);
-              }}
-            />
-          </div>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <span
+            className="text-xs text-gray-500 tabular-nums"
+            data-testid="status-page-groups-summary"
+          >
+            {getSummaryLabel()}
+          </span>
 
-          <div className="flex items-center gap-2">
-            <span
-              className="text-xs text-gray-500 tabular-nums"
-              data-testid="status-page-groups-summary"
-            >
-              {getSummaryLabel()}
-            </span>
-            <button
-              type="button"
-              data-testid="status-page-groups-expand-all"
-              className="inline-flex h-8 items-center gap-1.5 whitespace-nowrap rounded-md border border-gray-200 bg-white px-2.5 text-xs font-medium text-gray-600 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+          {/*
+           * ButtonStyleType.NORMAL carries an md:ml-3 of its own, which fights
+           * this row's gap. Scoping the override to the container is how
+           * BaseModelTable settles the same argument in its header.
+           */}
+          <div className="flex flex-wrap items-center gap-2 [&_button]:md:ml-0">
+            <Button
+              title="Expand All"
+              icon={IconProp.ChevronDown}
+              buttonSize={ButtonSize.Small}
+              buttonStyle={ButtonStyleType.NORMAL}
+              disabled={!canExpandMore}
+              dataTestId="status-page-groups-expand-all"
               onClick={expandAll}
-            >
-              <Icon icon={IconProp.ChevronDown} className="h-3.5 w-3.5" />
-              Expand all
-            </button>
-            <button
-              type="button"
-              data-testid="status-page-groups-collapse-all"
-              className="inline-flex h-8 items-center gap-1.5 whitespace-nowrap rounded-md border border-gray-200 bg-white px-2.5 text-xs font-medium text-gray-600 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-50 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+            />
+            <Button
+              title="Collapse All"
+              icon={IconProp.ChevronRight}
+              buttonSize={ButtonSize.Small}
+              buttonStyle={ButtonStyleType.NORMAL}
+              disabled={expandedGroupIds.size === 0}
+              dataTestId="status-page-groups-collapse-all"
               onClick={collapseAll}
-            >
-              <Icon icon={IconProp.ChevronRight} className="h-3.5 w-3.5" />
-              Collapse all
-            </button>
+            />
           </div>
         </div>
 
@@ -761,7 +804,15 @@ const StatusPageGroups: FunctionComponent<PageComponentProps> = (
             />
           </div>
         ) : (
-          <div className="border-t border-gray-100 pt-2">
+          /*
+           * An inset panel, the way every comparable card in the product frames
+           * its rows. Deliberately not overflow-hidden: a row's overflow menu is
+           * absolutely positioned inside this box and would be clipped by it.
+           */
+          <div
+            className="rounded-xl border border-gray-200 bg-white p-2"
+            data-testid="status-page-groups-tree"
+          >
             <GroupHierarchy
               rows={rows}
               busyGroupId={busyGroupId}

--- a/Common/UI/Components/Button/Button.tsx
+++ b/Common/UI/Components/Button/Button.tsx
@@ -49,7 +49,7 @@ export interface ComponentProps {
   iconSize?: undefined | SizeProp;
   buttonStyle?: undefined | ButtonStyleType;
   buttonSize?: ButtonSize | undefined;
-  dataTestId?: string;
+  dataTestId?: string | undefined;
   className?: string | undefined;
   tooltip?: string | undefined;
   ariaLabel?: string | undefined;

--- a/Common/UI/Components/MoreMenu/MoreMenu.tsx
+++ b/Common/UI/Components/MoreMenu/MoreMenu.tsx
@@ -22,6 +22,15 @@ export interface ComponentProps {
   triggerClassName?: string | undefined;
   menuIcon?: IconProp | undefined;
   text?: string | undefined;
+  /*
+   * The trigger's accessible name, separately from `text`. The default trigger
+   * renders `text` as a visible label beside the icon, so an icon-only overflow
+   * menu has to pass `text=""` — which would otherwise leave every one of them
+   * called "More options" and tell a screen reader user nothing about which
+   * thing the menu belongs to.
+   */
+  ariaLabel?: string | undefined;
+  dataTestId?: string | undefined;
   isDisabled?: boolean | undefined;
 }
 
@@ -312,7 +321,10 @@ const MoreMenu: React.ForwardRefExoticComponent<
           disabled: isTriggerDisabled,
           "aria-disabled": isTriggerDisabled,
           "aria-label":
-            trigger.props["aria-label"] || props.text || "More options",
+            trigger.props["aria-label"] ||
+            props.ariaLabel ||
+            props.text ||
+            "More options",
           "aria-haspopup": "menu",
           "aria-expanded": isComponentVisible,
           "aria-controls": isComponentVisible ? menuId : undefined,
@@ -338,10 +350,11 @@ const MoreMenu: React.ForwardRefExoticComponent<
             title={props.text || ""}
             buttonStyle={ButtonStyleType.OUTLINE}
             disabled={props.isDisabled}
+            dataTestId={props.dataTestId}
             onClick={() => {
               setIsComponentVisible(!isDropdownVisible);
             }}
-            ariaLabel={props.text || "More options"}
+            ariaLabel={props.ariaLabel || props.text || "More options"}
             ariaExpanded={isComponentVisible}
             ariaHaspopup="menu"
             ariaControls={isComponentVisible ? menuId : undefined}
@@ -358,10 +371,11 @@ const MoreMenu: React.ForwardRefExoticComponent<
               type="button"
               className={props.triggerClassName}
               disabled={props.isDisabled}
+              data-testid={props.dataTestId}
               onClick={() => {
                 setIsComponentVisible(!isDropdownVisible);
               }}
-              aria-label={props.text || "More options"}
+              aria-label={props.ariaLabel || props.text || "More options"}
               aria-haspopup="menu"
               aria-expanded={isComponentVisible}
               aria-controls={isComponentVisible ? menuId : undefined}
@@ -383,7 +397,8 @@ const MoreMenu: React.ForwardRefExoticComponent<
               id={buttonId}
               role="button"
               tabIndex={props.isDisabled ? -1 : 0}
-              aria-label={props.text || undefined}
+              data-testid={props.dataTestId}
+              aria-label={props.ariaLabel || props.text || undefined}
               aria-haspopup="menu"
               aria-expanded={isComponentVisible}
               aria-controls={isComponentVisible ? menuId : undefined}

--- a/Common/UI/Components/MoreMenu/MoreMenuItem.tsx
+++ b/Common/UI/Components/MoreMenu/MoreMenuItem.tsx
@@ -16,9 +16,14 @@ const MoreMenuItem: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
   return (
+    /*
+     * A button shrink-wraps its content whatever its display type, so the width
+     * has to be set explicitly or the hover background stops at the end of the
+     * label instead of spanning the menu. 100% less the mx-1 on either side.
+     */
     <button
       type="button"
-      className={`group mx-1 flex items-center rounded-md px-3 py-2 text-left text-sm text-gray-700 transition-colors duration-100 enabled:cursor-pointer enabled:hover:bg-indigo-50 enabled:hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 ${props.className || ""}`}
+      className={`group mx-1 flex w-[calc(100%-0.5rem)] items-center rounded-md px-3 py-2 text-left text-sm text-gray-700 transition-colors duration-100 enabled:cursor-pointer enabled:hover:bg-indigo-50 enabled:hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 ${props.className || ""}`}
       role="menuitem"
       tabIndex={-1}
       disabled={props.isDisabled}

--- a/Common/UI/Components/StatusPage/GroupHierarchy.tsx
+++ b/Common/UI/Components/StatusPage/GroupHierarchy.tsx
@@ -1,7 +1,7 @@
-import Button, { ButtonSize, ButtonStyleType } from "../Button/Button";
 import Icon from "../Icon/Icon";
 import MoreMenu from "../MoreMenu/MoreMenu";
 import MoreMenuItem from "../MoreMenu/MoreMenuItem";
+import Tooltip from "../Tooltip/Tooltip";
 import IconProp from "../../../Types/Icon/IconProp";
 import StatusPageGroup from "../../../Models/DatabaseModels/StatusPageGroup";
 import StatusPageGroupViewMode from "../../../Types/StatusPage/StatusPageGroupViewMode";
@@ -65,6 +65,50 @@ const CONNECTOR_OFFSET_CLASS_NAME: string = "top-[18px]";
  */
 const INDENT_COLUMN_CLASS_NAME: string = "relative w-5 flex-shrink-0";
 const RAIL_CLASS_NAME: string = "absolute inset-y-0 left-2.5 w-px bg-gray-200";
+
+/*
+ * Every control on the right of a row is the same square with the same glyph
+ * size, hover and focus ring, because they read as one cluster and any drift
+ * between them is visible at a glance.
+ *
+ * They are native buttons rather than <Button buttonStyle={ICON} />: the
+ * overflow trigger has to be one - MoreMenu only enhances a custom trigger in
+ * place when it already is a native button - and ButtonStyleType.ICON cannot be
+ * talked into matching it from a className, because its padding, its 20px glyph
+ * and its indigo-500 offset focus ring are all baked into the style, and its
+ * own text-gray-600 beats an appended text-gray-400 (Tailwind orders utilities
+ * in the stylesheet, not in the class attribute).
+ */
+const ROW_ACTION_CLASS_NAME: string =
+  "flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 disabled:pointer-events-none disabled:opacity-40";
+
+interface RowActionButtonProps {
+  icon: IconProp;
+  tooltip: string;
+  ariaLabel: string;
+  dataTestId: string;
+  isDisabled: boolean;
+  onClick: () => void;
+}
+
+const RowActionButton: FunctionComponent<RowActionButtonProps> = (
+  props: RowActionButtonProps,
+): ReactElement => {
+  return (
+    <Tooltip text={props.tooltip}>
+      <button
+        type="button"
+        aria-label={props.ariaLabel}
+        data-testid={props.dataTestId}
+        disabled={props.isDisabled}
+        className={ROW_ACTION_CLASS_NAME}
+        onClick={props.onClick}
+      >
+        <Icon icon={props.icon} className="h-4 w-4" />
+      </button>
+    </Tooltip>
+  );
+};
 
 const GroupHierarchy: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
@@ -314,20 +358,16 @@ const GroupHierarchy: FunctionComponent<ComponentProps> = (
      */
     return (
       <div
-        className="-my-1 ml-auto flex flex-shrink-0 items-center gap-0.5 pl-2"
+        className="-my-1 ml-auto flex flex-shrink-0 items-center gap-1 pl-2"
         data-testid="status-page-group-hierarchy-actions"
       >
         {props.isCreateable && props.onAddSubGroup ? (
-          <Button
-            buttonSize={ButtonSize.Small}
-            buttonStyle={ButtonStyleType.ICON}
+          <RowActionButton
             icon={IconProp.FolderPlus}
-            title=""
             tooltip="Add a sub group inside this group"
             ariaLabel={`Add a sub group inside ${row.name || "this group"}`}
             dataTestId="status-page-group-hierarchy-add-sub-group"
-            disabled={isBusy}
-            className="text-gray-400 hover:bg-gray-200 hover:text-gray-700"
+            isDisabled={isBusy}
             onClick={() => {
               props.onAddSubGroup?.(row.statusPageGroup);
             }}
@@ -337,16 +377,12 @@ const GroupHierarchy: FunctionComponent<ComponentProps> = (
         )}
 
         {props.isEditable && props.onEdit ? (
-          <Button
-            buttonSize={ButtonSize.Small}
-            buttonStyle={ButtonStyleType.ICON}
+          <RowActionButton
             icon={IconProp.Edit}
-            title=""
             tooltip="Edit this group"
             ariaLabel={`Edit ${row.name || "this group"}`}
             dataTestId="status-page-group-hierarchy-edit"
-            disabled={isBusy}
-            className="text-gray-400 hover:bg-gray-200 hover:text-gray-700"
+            isDisabled={isBusy}
             onClick={() => {
               props.onEdit?.(row.statusPageGroup);
             }}
@@ -357,17 +393,15 @@ const GroupHierarchy: FunctionComponent<ComponentProps> = (
 
         {menuItems.length > 0 ? (
           <MoreMenu
-            text={`More actions for ${row.name || "this group"}`}
-            menuIcon={IconProp.More}
+            ariaLabel={`More actions for ${row.name || "this group"}`}
             isDisabled={isBusy}
             elementToBeShownInsteadOfButton={
               <button
                 type="button"
-                aria-label={`More actions for ${row.name || "this group"}`}
                 data-testid="status-page-group-hierarchy-more"
-                className="flex h-7 w-7 items-center justify-center rounded-md text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+                className={ROW_ACTION_CLASS_NAME}
               >
-                <Icon icon={IconProp.More} className="h-4 w-4" />
+                <Icon icon={IconProp.EllipsisHorizontal} className="h-4 w-4" />
               </button>
             }
           >
@@ -401,9 +435,9 @@ const GroupHierarchy: FunctionComponent<ComponentProps> = (
         data-group-id={row.id}
         data-search-match={row.isSearchMatch ? "true" : "false"}
         /*
-         * The row's own padding, against the container's negative margin, is
-         * what lets a hover highlight reach past the content column while the
-         * tree itself stays on the card's grid.
+         * The row's own padding is what lets a hover highlight reach past the
+         * content column, out to the padding of whatever panel the caller has
+         * put the tree in.
          */
         className={`group relative flex items-stretch rounded-lg px-2 transition-colors hover:bg-gray-50 ${
           isBusy ? "opacity-60" : ""
@@ -472,7 +506,6 @@ const GroupHierarchy: FunctionComponent<ComponentProps> = (
       role="tree"
       aria-label={props.ariaLabel || "Status page group hierarchy"}
       data-testid="status-page-group-hierarchy"
-      className="-mx-2"
     >
       {props.rows.map((row: StatusPageGroupHierarchyRow) => {
         return renderRow(row);


### PR DESCRIPTION
### Title of this pull request?

fix(status-page): put the Resource Groups card on the product's own controls

### Small Description?

Status Page › Groups drew every one of its controls by hand, and each had drifted from the thing it was imitating. This puts them back on the shared components.

**1. The search box moves into the card header.** It sat in the body, above the tree, where no other card in the product puts one — a `ModelTable`'s search lives in the header, beside the actions that decide what the card is showing. It also gains the `sr-only` label it never had, so it has an accessible name rather than a placeholder.

**2. The overflow menu is `MoreMenu`'s own trigger.** It was a bordered white pill wrapped around `IconProp.More` — which is three dots *inside a circle*, and at 16px reads as a smiley face. Every other card in the product gets its menu from `MoreMenu`'s default trigger with an `EllipsisHorizontal` glyph. This one now does too, which also puts it *after* the primary action rather than in front of it, the order `BaseModelTable` uses.

**3. The three controls on the right of a tree row become one component.** They were built three different ways: two `ButtonStyleType.ICON` buttons at roughly 36×28 with 20px glyphs, and a hand-rolled 28×28 square with a 16px one on a different focus ring. The `className` meant to quiet the first two never applied either — `ICON`'s own `text-gray-600` beats an appended `text-gray-400`, because Tailwind orders utilities in the stylesheet and not in the class attribute. All three are now one `RowActionButton` on one class string, so they cannot drift again.

**4. Expand all / Collapse all become `Button`s**, and they say when they have nothing to do: Expand All goes disabled once the hierarchy is fully open, Collapse All once it is fully closed.

Also: the tree is framed in an inset panel like every comparable card — deliberately **without** `overflow-hidden`, because a row's overflow menu is absolutely positioned inside that box and would be clipped by it.

#### One thing worth a reviewer's attention

The obvious move for (4) was to copy the sibling `Resources.tsx`, which styles the same pair of buttons with `ButtonStyleType.OUTLINE`. That style is dead: `btn-outline-secondary` and `background-very-light-Gray500-on-hover` appear nowhere in the repo outside `Button.tsx`, so `OUTLINE` renders as unstyled text with padding. These use `ButtonStyleType.NORMAL`, the same style as the card's own "Create Group". `Resources.tsx` is left alone here, but its Expand/Collapse buttons — and the ⋯ on every `ModelTable` card — are unstyled for the same reason, which is probably worth its own pass.

#### Shared components

- `MoreMenu` gains two additive props. `ariaLabel` names the trigger independently of `text`, which the default trigger renders as a *visible* label — so an icon-only menu no longer has to choose between printing a label across the card header and being announced as "More options" to a screen reader. `dataTestId` reaches the trigger in all four of its forms. Both default to `undefined`, so all 13 existing call sites are unchanged.
- `Button`'s `dataTestId` is widened from `string` to `string | undefined`, which `exactOptionalPropertyTypes` requires for the pass-through above. Type-only; no runtime change.

### Pull Request Checklist:

- [ ] Please make sure all jobs pass before requesting a review. _(CI has only just started on this push; the local suites below are green.)_
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

Behaviour is unchanged, so this rides on the existing suites rather than adding new ones. Run locally, all green:

- `Common/Tests/UI/Components/StatusPage/GroupHierarchy.test.tsx` — 55 tests. The strictest gate here: it pins each row control by `data-testid`, asserts the add/edit buttons are genuinely `disabled` while a reorder is in flight, and drives the row overflow menu.
- `Common/Tests/UI/Components/MoreMenu.test.tsx` — 43 tests, including the trigger's accessible name in each of its four rendering paths.
- `App/Tests/Dashboard/StatusPageGroupsPageInvariants.test.ts` — 60 tests. This one reads `Groups.tsx` as source text, so it is the thing that catches an accidental reordering of the search element's props.

Also clean: `tsc` over `Common`, `tsc` over `Groups.tsx`, eslint and prettier on all four files.

### Related Issue?

None — this came from a UI review of the card rather than a filed issue.

### Screenshots (if appropriate):

Verified before/after by rendering both versions of the card against the repo's own vendored Tailwind (`Common/Server/Static/Vendor/tailwind/tailwind-3.4.5.js`) plus `Theme.css`, at 1500px, 1280px and 700px. That is also how the dead `OUTLINE` style and the circled-ellipsis glyph were confirmed rather than assumed.

Header, before → after:

- `[ ⊙ ] [ + Create Group ]` with the search floating in the body below
- `[ 🔍 Search groups… ] [ + Create Group ] [ ⋯ ]`, matching a `ModelTable` card

Row actions, before → after: two dark 20px glyphs in wide boxes next to one faint 16px circled ellipsis → three identical 28×28 squares with 16px glyphs, one hover and one focus ring.
