### PR TITLE
fix(dashboard): bind public resource lists to stored widgets

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardAlertListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardAlertListComponent.tsx
@@ -123,7 +123,10 @@ const DashboardAlertListComponentElement: FunctionComponent<ComponentProps> = (
 
       const listResult: ListResult<Alert> = await ModelAPI.getList<Alert>({
         modelType: Alert,
-        requestOptions: DashboardResourceList.getRequestOptions("alert"),
+        requestOptions: DashboardResourceList.getRequestOptions("alert", {
+          componentId: props.componentId,
+          variables: props.variables,
+        }),
         query: query,
         limit: maxRows,
         skip: 0,
@@ -159,6 +162,8 @@ const DashboardAlertListComponentElement: FunctionComponent<ComponentProps> = (
     stateIdsKey,
     monitorIdsKey,
     labelIdsKey,
+    props.componentId,
+    props.variables,
   ]);
 
   useEffect(() => {

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardCephOsdListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardCephOsdListComponent.tsx
@@ -327,6 +327,7 @@ const DashboardCephOsdListComponentElement: FunctionComponent<
   return (
     <DashboardModelResourceListBase<CephResource>
       modelType={CephResource}
+      componentId={props.componentId}
       publicResourceType="ceph-resource"
       title={args.title}
       pluralLabel="OSDs"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardCephPoolListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardCephPoolListComponent.tsx
@@ -267,6 +267,7 @@ const DashboardCephPoolListComponentElement: FunctionComponent<
   return (
     <DashboardModelResourceListBase<CephResource>
       modelType={CephResource}
+      componentId={props.componentId}
       publicResourceType="ceph-resource"
       title={args.title}
       pluralLabel="pools"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerContainerListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerContainerListComponent.tsx
@@ -150,8 +150,13 @@ const DashboardDockerContainerListComponentElement: FunctionComponent<
       const listResult: ListResult<DockerResource> =
         await ModelAPI.getList<DockerResource>({
           modelType: DockerResource,
-          requestOptions:
-            DashboardResourceList.getRequestOptions("docker-container"),
+          requestOptions: DashboardResourceList.getRequestOptions(
+            "docker-container",
+            {
+              componentId: props.componentId,
+              variables: props.variables,
+            },
+          ),
           query: query,
           limit: maxRows,
           skip: 0,
@@ -179,7 +184,13 @@ const DashboardDockerContainerListComponentElement: FunctionComponent<
     }
 
     setIsLoading(false);
-  }, [maxRows, dockerHostIdsKey, imageNameKey, props.variables]);
+  }, [
+    maxRows,
+    dockerHostIdsKey,
+    imageNameKey,
+    props.variables,
+    props.componentId,
+  ]);
 
   useEffect(() => {
     fetchContainers();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerHostListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerHostListComponent.tsx
@@ -98,8 +98,13 @@ const DashboardDockerHostListComponentElement: FunctionComponent<
       const listResult: ListResult<DockerHost> =
         await ModelAPI.getList<DockerHost>({
           modelType: DockerHost,
-          requestOptions:
-            DashboardResourceList.getRequestOptions("docker-host"),
+          requestOptions: DashboardResourceList.getRequestOptions(
+            "docker-host",
+            {
+              componentId: props.componentId,
+              variables: props.variables,
+            },
+          ),
           query: query,
           limit: maxRows,
           skip: 0,
@@ -125,7 +130,7 @@ const DashboardDockerHostListComponentElement: FunctionComponent<
     }
 
     setIsLoading(false);
-  }, [maxRows, statusFilter, props.variables]);
+  }, [maxRows, statusFilter, props.variables, props.componentId]);
 
   useEffect(() => {
     fetchHosts();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerImageListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerImageListComponent.tsx
@@ -94,8 +94,13 @@ const DashboardDockerImageListComponentElement: FunctionComponent<
       const listResult: ListResult<DockerResource> =
         await ModelAPI.getList<DockerResource>({
           modelType: DockerResource,
-          requestOptions:
-            DashboardResourceList.getRequestOptions("docker-image"),
+          requestOptions: DashboardResourceList.getRequestOptions(
+            "docker-image",
+            {
+              componentId: props.componentId,
+              variables: props.variables,
+            },
+          ),
           query: query,
           limit: maxRows,
           skip: 0,
@@ -120,7 +125,13 @@ const DashboardDockerImageListComponentElement: FunctionComponent<
     }
 
     setIsLoading(false);
-  }, [maxRows, dockerHostIdsKey, nameSearchKey, props.variables]);
+  }, [
+    maxRows,
+    dockerHostIdsKey,
+    nameSearchKey,
+    props.variables,
+    props.componentId,
+  ]);
 
   useEffect(() => {
     fetchImages();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerNetworkListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerNetworkListComponent.tsx
@@ -75,8 +75,13 @@ const DashboardDockerNetworkListComponentElement: FunctionComponent<
       const listResult: ListResult<DockerResource> =
         await ModelAPI.getList<DockerResource>({
           modelType: DockerResource,
-          requestOptions:
-            DashboardResourceList.getRequestOptions("docker-network"),
+          requestOptions: DashboardResourceList.getRequestOptions(
+            "docker-network",
+            {
+              componentId: props.componentId,
+              variables: props.variables,
+            },
+          ),
           query: query,
           limit: maxRows,
           skip: 0,
@@ -101,7 +106,7 @@ const DashboardDockerNetworkListComponentElement: FunctionComponent<
     }
 
     setIsLoading(false);
-  }, [maxRows, dockerHostIdsKey]);
+  }, [maxRows, dockerHostIdsKey, props.componentId, props.variables]);
 
   useEffect(() => {
     fetchNetworks();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerSwarmNodeListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerSwarmNodeListComponent.tsx
@@ -250,6 +250,7 @@ const DashboardDockerSwarmNodeListComponentElement: FunctionComponent<
   return (
     <DashboardModelResourceListBase<DockerSwarmResource>
       modelType={DockerSwarmResource}
+      componentId={props.componentId}
       publicResourceType="docker-swarm-resource"
       title={args.title}
       pluralLabel="nodes"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerSwarmServiceListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerSwarmServiceListComponent.tsx
@@ -301,6 +301,7 @@ const DashboardDockerSwarmServiceListComponentElement: FunctionComponent<
   return (
     <DashboardModelResourceListBase<DockerSwarmResource>
       modelType={DockerSwarmResource}
+      componentId={props.componentId}
       publicResourceType="docker-swarm-resource"
       title={args.title}
       pluralLabel="services"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerVolumeListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardDockerVolumeListComponent.tsx
@@ -75,8 +75,13 @@ const DashboardDockerVolumeListComponentElement: FunctionComponent<
       const listResult: ListResult<DockerResource> =
         await ModelAPI.getList<DockerResource>({
           modelType: DockerResource,
-          requestOptions:
-            DashboardResourceList.getRequestOptions("docker-volume"),
+          requestOptions: DashboardResourceList.getRequestOptions(
+            "docker-volume",
+            {
+              componentId: props.componentId,
+              variables: props.variables,
+            },
+          ),
           query: query,
           limit: maxRows,
           skip: 0,
@@ -101,7 +106,7 @@ const DashboardDockerVolumeListComponentElement: FunctionComponent<
     }
 
     setIsLoading(false);
-  }, [maxRows, dockerHostIdsKey]);
+  }, [maxRows, dockerHostIdsKey, props.componentId, props.variables]);
 
   useEffect(() => {
     fetchVolumes();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardHostListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardHostListComponent.tsx
@@ -148,7 +148,10 @@ const DashboardHostListComponentElement: FunctionComponent<ComponentProps> = (
 
       const listResult: ListResult<Host> = await ModelAPI.getList<Host>({
         modelType: Host,
-        requestOptions: DashboardResourceList.getRequestOptions("host"),
+        requestOptions: DashboardResourceList.getRequestOptions("host", {
+          componentId: props.componentId,
+          variables: props.variables,
+        }),
         query: query,
         limit: maxRows,
         skip: 0,
@@ -175,7 +178,7 @@ const DashboardHostListComponentElement: FunctionComponent<ComponentProps> = (
     }
 
     setIsLoading(false);
-  }, [maxRows, statusFilter, osTypeFilter, props.variables]);
+  }, [maxRows, statusFilter, osTypeFilter, props.variables, props.componentId]);
 
   useEffect(() => {
     fetchHosts();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardIncidentListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardIncidentListComponent.tsx
@@ -124,7 +124,10 @@ const DashboardIncidentListComponentElement: FunctionComponent<
       const listResult: ListResult<Incident> = await ModelAPI.getList<Incident>(
         {
           modelType: Incident,
-          requestOptions: DashboardResourceList.getRequestOptions("incident"),
+          requestOptions: DashboardResourceList.getRequestOptions("incident", {
+            componentId: props.componentId,
+            variables: props.variables,
+          }),
           query: query,
           limit: maxRows,
           skip: 0,
@@ -161,6 +164,8 @@ const DashboardIncidentListComponentElement: FunctionComponent<
     stateIdsKey,
     monitorIdsKey,
     labelIdsKey,
+    props.componentId,
+    props.variables,
   ]);
 
   useEffect(() => {

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesCronJobListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesCronJobListComponent.tsx
@@ -99,6 +99,7 @@ const DashboardKubernetesCronJobListComponentElement: FunctionComponent<
 
   return (
     <DashboardKubernetesResourceListBase
+      componentId={props.componentId}
       title={args.title}
       pluralLabel="cronjobs"
       emptyMessage="No cron jobs found"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesDaemonSetListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesDaemonSetListComponent.tsx
@@ -99,6 +99,7 @@ const DashboardKubernetesDaemonSetListComponentElement: FunctionComponent<
 
   return (
     <DashboardKubernetesResourceListBase
+      componentId={props.componentId}
       title={args.title}
       pluralLabel="daemonsets"
       emptyMessage="No daemon sets found"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesDeploymentListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesDeploymentListComponent.tsx
@@ -99,6 +99,7 @@ const DashboardKubernetesDeploymentListComponentElement: FunctionComponent<
 
   return (
     <DashboardKubernetesResourceListBase
+      componentId={props.componentId}
       title={args.title}
       pluralLabel="deployments"
       emptyMessage="No deployments found"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesJobListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesJobListComponent.tsx
@@ -99,6 +99,7 @@ const DashboardKubernetesJobListComponentElement: FunctionComponent<
 
   return (
     <DashboardKubernetesResourceListBase
+      componentId={props.componentId}
       title={args.title}
       pluralLabel="jobs"
       emptyMessage="No jobs found"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesNamespaceListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesNamespaceListComponent.tsx
@@ -124,6 +124,7 @@ const DashboardKubernetesNamespaceListComponentElement: FunctionComponent<
 
   return (
     <DashboardKubernetesResourceListBase
+      componentId={props.componentId}
       title={args.title}
       pluralLabel="namespaces"
       emptyMessage="No namespaces found"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesNodeListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesNodeListComponent.tsx
@@ -177,6 +177,7 @@ const DashboardKubernetesNodeListComponentElement: FunctionComponent<
 
   return (
     <DashboardKubernetesResourceListBase
+      componentId={props.componentId}
       title={args.title}
       pluralLabel="nodes"
       emptyMessage="No nodes found"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesPodListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesPodListComponent.tsx
@@ -166,6 +166,7 @@ const DashboardKubernetesPodListComponentElement: FunctionComponent<
 
   return (
     <DashboardKubernetesResourceListBase
+      componentId={props.componentId}
       title={args.title}
       pluralLabel="pods"
       emptyMessage="No pods found"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesResourceListBase.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesResourceListBase.tsx
@@ -16,6 +16,7 @@ import Includes from "Common/Types/BaseDatabase/Includes";
 import Select from "Common/Types/BaseDatabase/Select";
 import DashboardVariable from "Common/Types/Dashboard/DashboardVariable";
 import { AttributeToColumnMap } from "Common/Utils/Dashboard/ModelQueryVariableInterpolation";
+import ObjectID from "Common/Types/ObjectID";
 
 /*
  * Thin Kubernetes wrapper around the shared, model-class-driven
@@ -27,6 +28,7 @@ import { AttributeToColumnMap } from "Common/Utils/Dashboard/ModelQueryVariableI
  * those props into the generic query / select / sort contract.
  */
 export interface KubernetesResourceListBaseProps {
+  componentId: ObjectID;
   title?: string | undefined;
   pluralLabel: string;
   emptyMessage: string;
@@ -114,6 +116,7 @@ const DashboardKubernetesResourceListBase: FunctionComponent<
   return (
     <DashboardModelResourceListBase<KubernetesResource>
       modelType={KubernetesResource}
+      componentId={props.componentId}
       publicResourceType="kubernetes-resource"
       title={props.title}
       pluralLabel={props.pluralLabel}

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesStatefulSetListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardKubernetesStatefulSetListComponent.tsx
@@ -99,6 +99,7 @@ const DashboardKubernetesStatefulSetListComponentElement: FunctionComponent<
 
   return (
     <DashboardKubernetesResourceListBase
+      componentId={props.componentId}
       title={args.title}
       pluralLabel="statefulsets"
       emptyMessage="No stateful sets found"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardLogStreamComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardLogStreamComponent.tsx
@@ -160,7 +160,10 @@ const DashboardLogStreamComponentElement: FunctionComponent<ComponentProps> = (
         sort: {
           time: SortOrder.Descending,
         },
-        requestOptions: DashboardResourceList.getRequestOptions("log"),
+        requestOptions: DashboardResourceList.getRequestOptions("log", {
+          componentId: props.componentId,
+          variables: props.variables,
+        }),
       });
 
       setLogs(listResult.data);
@@ -177,6 +180,7 @@ const DashboardLogStreamComponentElement: FunctionComponent<ComponentProps> = (
     attributeFilterQuery,
     maxRows,
     props.variables,
+    props.componentId,
   ]);
 
   useEffect(() => {

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardMonitorListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardMonitorListComponent.tsx
@@ -104,7 +104,10 @@ const DashboardMonitorListComponentElement: FunctionComponent<
 
       const listResult: ListResult<Monitor> = await ModelAPI.getList<Monitor>({
         modelType: Monitor,
-        requestOptions: DashboardResourceList.getRequestOptions("monitor"),
+        requestOptions: DashboardResourceList.getRequestOptions("monitor", {
+          componentId: props.componentId,
+          variables: props.variables,
+        }),
         query: query,
         limit: maxRows,
         skip: 0,
@@ -135,6 +138,8 @@ const DashboardMonitorListComponentElement: FunctionComponent<
     monitorStatusIdsKey,
     monitorTypesKey,
     labelIdsKey,
+    props.componentId,
+    props.variables,
   ]);
 
   useEffect(() => {

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardNetworkMapComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardNetworkMapComponent.tsx
@@ -200,8 +200,13 @@ const DashboardNetworkMapComponentElement: FunctionComponent<ComponentProps> = (
       const listResult: ListResult<NetworkSite> =
         await ModelAPI.getList<NetworkSite>({
           modelType: NetworkSite,
-          requestOptions:
-            DashboardResourceList.getRequestOptions("network-site"),
+          requestOptions: DashboardResourceList.getRequestOptions(
+            "network-site",
+            {
+              componentId: props.componentId,
+              variables: props.variables,
+            },
+          ),
           query: query,
           /*
            * One MORE than the cap, on purpose. Asking for exactly the cap
@@ -247,7 +252,13 @@ const DashboardNetworkMapComponentElement: FunctionComponent<ComponentProps> = (
     }
 
     setIsLoading(false);
-  }, [maxSites, statusFilter, networkSiteTypeIdsKey]);
+  }, [
+    maxSites,
+    statusFilter,
+    networkSiteTypeIdsKey,
+    props.componentId,
+    props.variables,
+  ]);
 
   useEffect(() => {
     fetchSites();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardPodmanContainerListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardPodmanContainerListComponent.tsx
@@ -150,8 +150,13 @@ const DashboardPodmanContainerListComponentElement: FunctionComponent<
       const listResult: ListResult<PodmanResource> =
         await ModelAPI.getList<PodmanResource>({
           modelType: PodmanResource,
-          requestOptions:
-            DashboardResourceList.getRequestOptions("podman-container"),
+          requestOptions: DashboardResourceList.getRequestOptions(
+            "podman-container",
+            {
+              componentId: props.componentId,
+              variables: props.variables,
+            },
+          ),
           query: query,
           limit: maxRows,
           skip: 0,
@@ -179,7 +184,13 @@ const DashboardPodmanContainerListComponentElement: FunctionComponent<
     }
 
     setIsLoading(false);
-  }, [maxRows, podmanHostIdsKey, imageNameKey, props.variables]);
+  }, [
+    maxRows,
+    podmanHostIdsKey,
+    imageNameKey,
+    props.variables,
+    props.componentId,
+  ]);
 
   useEffect(() => {
     fetchContainers();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardPodmanHostListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardPodmanHostListComponent.tsx
@@ -98,8 +98,13 @@ const DashboardPodmanHostListComponentElement: FunctionComponent<
       const listResult: ListResult<PodmanHost> =
         await ModelAPI.getList<PodmanHost>({
           modelType: PodmanHost,
-          requestOptions:
-            DashboardResourceList.getRequestOptions("podman-host"),
+          requestOptions: DashboardResourceList.getRequestOptions(
+            "podman-host",
+            {
+              componentId: props.componentId,
+              variables: props.variables,
+            },
+          ),
           query: query,
           limit: maxRows,
           skip: 0,
@@ -125,7 +130,7 @@ const DashboardPodmanHostListComponentElement: FunctionComponent<
     }
 
     setIsLoading(false);
-  }, [maxRows, statusFilter, props.variables]);
+  }, [maxRows, statusFilter, props.variables, props.componentId]);
 
   useEffect(() => {
     fetchHosts();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardPodmanImageListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardPodmanImageListComponent.tsx
@@ -94,8 +94,13 @@ const DashboardPodmanImageListComponentElement: FunctionComponent<
       const listResult: ListResult<PodmanResource> =
         await ModelAPI.getList<PodmanResource>({
           modelType: PodmanResource,
-          requestOptions:
-            DashboardResourceList.getRequestOptions("podman-image"),
+          requestOptions: DashboardResourceList.getRequestOptions(
+            "podman-image",
+            {
+              componentId: props.componentId,
+              variables: props.variables,
+            },
+          ),
           query: query,
           limit: maxRows,
           skip: 0,
@@ -120,7 +125,13 @@ const DashboardPodmanImageListComponentElement: FunctionComponent<
     }
 
     setIsLoading(false);
-  }, [maxRows, podmanHostIdsKey, nameSearchKey, props.variables]);
+  }, [
+    maxRows,
+    podmanHostIdsKey,
+    nameSearchKey,
+    props.variables,
+    props.componentId,
+  ]);
 
   useEffect(() => {
     fetchImages();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardPodmanNetworkListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardPodmanNetworkListComponent.tsx
@@ -75,8 +75,13 @@ const DashboardPodmanNetworkListComponentElement: FunctionComponent<
       const listResult: ListResult<PodmanResource> =
         await ModelAPI.getList<PodmanResource>({
           modelType: PodmanResource,
-          requestOptions:
-            DashboardResourceList.getRequestOptions("podman-network"),
+          requestOptions: DashboardResourceList.getRequestOptions(
+            "podman-network",
+            {
+              componentId: props.componentId,
+              variables: props.variables,
+            },
+          ),
           query: query,
           limit: maxRows,
           skip: 0,
@@ -101,7 +106,7 @@ const DashboardPodmanNetworkListComponentElement: FunctionComponent<
     }
 
     setIsLoading(false);
-  }, [maxRows, podmanHostIdsKey]);
+  }, [maxRows, podmanHostIdsKey, props.componentId, props.variables]);
 
   useEffect(() => {
     fetchNetworks();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardPodmanVolumeListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardPodmanVolumeListComponent.tsx
@@ -75,8 +75,13 @@ const DashboardPodmanVolumeListComponentElement: FunctionComponent<
       const listResult: ListResult<PodmanResource> =
         await ModelAPI.getList<PodmanResource>({
           modelType: PodmanResource,
-          requestOptions:
-            DashboardResourceList.getRequestOptions("podman-volume"),
+          requestOptions: DashboardResourceList.getRequestOptions(
+            "podman-volume",
+            {
+              componentId: props.componentId,
+              variables: props.variables,
+            },
+          ),
           query: query,
           limit: maxRows,
           skip: 0,
@@ -101,7 +106,7 @@ const DashboardPodmanVolumeListComponentElement: FunctionComponent<
     }
 
     setIsLoading(false);
-  }, [maxRows, podmanHostIdsKey]);
+  }, [maxRows, podmanHostIdsKey, props.componentId, props.variables]);
 
   useEffect(() => {
     fetchVolumes();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardProxmoxGuestListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardProxmoxGuestListComponent.tsx
@@ -257,6 +257,7 @@ const DashboardProxmoxGuestListComponentElement: FunctionComponent<
   return (
     <DashboardModelResourceListBase<ProxmoxResource>
       modelType={ProxmoxResource}
+      componentId={props.componentId}
       publicResourceType="proxmox-resource"
       title={args.title}
       pluralLabel="guests"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardProxmoxNodeListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardProxmoxNodeListComponent.tsx
@@ -243,6 +243,7 @@ const DashboardProxmoxNodeListComponentElement: FunctionComponent<
   return (
     <DashboardModelResourceListBase<ProxmoxResource>
       modelType={ProxmoxResource}
+      componentId={props.componentId}
       publicResourceType="proxmox-resource"
       title={args.title}
       pluralLabel="nodes"

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardTraceListComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardTraceListComponent.tsx
@@ -164,7 +164,10 @@ const DashboardTraceListComponentElement: FunctionComponent<ComponentProps> = (
           sort: {
             startTime: SortOrder.Descending,
           },
-          requestOptions: DashboardResourceList.getRequestOptions("span"),
+          requestOptions: DashboardResourceList.getRequestOptions("span", {
+            componentId: props.componentId,
+            variables: props.variables,
+          }),
         });
 
       setSpans(listResult.data);
@@ -174,7 +177,13 @@ const DashboardTraceListComponentElement: FunctionComponent<ComponentProps> = (
     }
 
     setIsLoading(false);
-  }, [props.dashboardStartAndEndDate, statusFilter, maxRows]);
+  }, [
+    props.dashboardStartAndEndDate,
+    statusFilter,
+    maxRows,
+    props.componentId,
+    props.variables,
+  ]);
 
   useEffect(() => {
     fetchTraces();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardResourceList.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardResourceList.ts
@@ -4,6 +4,9 @@ import {
   PublicDashboardContext,
 } from "./PublicDashboardContext";
 import URL from "Common/Types/API/URL";
+import ObjectID from "Common/Types/ObjectID";
+import DashboardVariable from "Common/Types/Dashboard/DashboardVariable";
+import { JSONArray, JSONObject } from "Common/Types/JSON";
 
 /*
  * Resource-type identifiers understood by the public
@@ -35,6 +38,12 @@ export type DashboardResourceType =
 
 export interface DashboardResourceRequestOptions {
   overrideRequestUrl: URL;
+  additionalRequestBody?: JSONObject | undefined;
+}
+
+export interface DashboardWidgetContext {
+  componentId: ObjectID;
+  variables?: Array<DashboardVariable> | undefined;
 }
 
 export default class DashboardResourceList {
@@ -57,6 +66,7 @@ export default class DashboardResourceList {
    */
   public static getRequestOptions(
     resourceType: DashboardResourceType,
+    widgetContext?: DashboardWidgetContext | undefined,
   ): DashboardResourceRequestOptions | undefined {
     const context: PublicDashboardContext | null = getPublicDashboardContext();
     if (!context) {
@@ -71,6 +81,30 @@ export default class DashboardResourceList {
       return undefined;
     }
 
-    return { overrideRequestUrl: url };
+    if (!widgetContext) {
+      return { overrideRequestUrl: url };
+    }
+
+    return {
+      overrideRequestUrl: url,
+      additionalRequestBody: {
+        componentId: widgetContext.componentId.toString(),
+        /*
+         * Send selections only. The public endpoint resolves each id against
+         * the dashboard's stored variables, including its trusted type and
+         * attribute key. An explicit empty string means All; null means the
+         * viewer did not provide a selection, so a stored default may apply.
+         */
+        variables: (widgetContext.variables || []).map(
+          (variable: DashboardVariable): JSONObject => {
+            return {
+              id: variable.id,
+              selectedValue: variable.selectedValue ?? null,
+              selectedValues: variable.selectedValues || [],
+            };
+          },
+        ) as JSONArray,
+      },
+    };
   }
 }

--- a/App/FeatureSet/Dashboard/src/Components/Infrastructure/DashboardModelResourceListBase.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Infrastructure/DashboardModelResourceListBase.tsx
@@ -36,6 +36,7 @@ export interface DashboardModelResourceListBaseProps<
   TBaseModel extends BaseModel,
 > {
   modelType: { new (): TBaseModel };
+  componentId: ObjectID;
   /*
    * Resource-type identifier for the public-dashboard list endpoint
    * (DashboardResourceList.getRequestOptions). Must be registered in
@@ -119,6 +120,10 @@ const DashboardModelResourceListBase: <TBaseModel extends BaseModel>(
           modelType: props.modelType,
           requestOptions: DashboardResourceList.getRequestOptions(
             props.publicResourceType,
+            {
+              componentId: props.componentId,
+              variables: props.variables,
+            },
           ),
           query: queryWithVariables,
           limit: props.maxRows,
@@ -136,6 +141,7 @@ const DashboardModelResourceListBase: <TBaseModel extends BaseModel>(
     setIsLoading(false);
   }, [
     props.modelType,
+    props.componentId,
     props.publicResourceType,
     props.maxRows,
     queryKey,

--- a/App/Tests/Dashboard/DashboardResourceList.test.ts
+++ b/App/Tests/Dashboard/DashboardResourceList.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import DashboardResourceList from "../../FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardResourceList";
+import {
+  PublicDashboardPostJSON,
+  setPublicDashboardContext,
+} from "../../FeatureSet/Dashboard/src/Components/Dashboard/Utils/PublicDashboardContext";
+import URL from "Common/Types/API/URL";
+import DashboardVariable, {
+  DashboardVariableType,
+} from "Common/Types/Dashboard/DashboardVariable";
+import ObjectID from "Common/Types/ObjectID";
+
+describe("DashboardResourceList request context", () => {
+  afterEach(() => {
+    setPublicDashboardContext(null);
+  });
+
+  test("leaves authenticated dashboard requests unchanged", () => {
+    expect(
+      DashboardResourceList.getRequestOptions("log", {
+        componentId: new ObjectID("component-id"),
+        variables: [],
+      }),
+    ).toBeUndefined();
+  });
+
+  test("sends only widget identity and viewer variable selections", () => {
+    setPublicDashboardContext({
+      dashboardId: new ObjectID("dashboard-id"),
+      apiUrl: URL.fromString("https://example.com/public-dashboard-api"),
+      postJSON: jest.fn<PublicDashboardPostJSON>(),
+    });
+
+    const variables: Array<DashboardVariable> = [
+      {
+        id: "all",
+        name: "Environment",
+        type: DashboardVariableType.TelemetryAttribute,
+        attributeKey: "deployment.environment.name",
+        selectedValue: "",
+      },
+      {
+        id: "unset",
+        name: "Cluster",
+        type: DashboardVariableType.TelemetryAttribute,
+        attributeKey: "k8s.cluster.name",
+        defaultValue: "production",
+      },
+      {
+        id: "many",
+        name: "Region",
+        type: DashboardVariableType.TelemetryAttribute,
+        attributeKey: "cloud.region",
+        selectedValues: ["eu-west-1", "eu-west-2"],
+        isMultiSelect: true,
+      },
+    ];
+
+    const componentId: ObjectID = new ObjectID("component-id");
+    const options: ReturnType<typeof DashboardResourceList.getRequestOptions> =
+      DashboardResourceList.getRequestOptions("log", {
+        componentId,
+        variables,
+      });
+
+    expect(options?.additionalRequestBody).toEqual({
+      componentId: "component-id",
+      variables: [
+        { id: "all", selectedValue: "", selectedValues: [] },
+        { id: "unset", selectedValue: null, selectedValues: [] },
+        {
+          id: "many",
+          selectedValue: null,
+          selectedValues: ["eu-west-1", "eu-west-2"],
+        },
+      ],
+    });
+  });
+});

--- a/App/Tests/Dashboard/NetworkMapWidgetInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkMapWidgetInvariants.test.ts
@@ -157,9 +157,16 @@ describe("Network Map widget data access", () => {
   });
 
   test("the public dashboard proxy reads the relation too", () => {
-    const api: string = readCommon("Server", "API", "DashboardAPI.ts");
+    const policy: string = readCommon(
+      "Server",
+      "Utils",
+      "Dashboard",
+      "PublicDashboardResourceListPolicy.ts",
+    );
     const entry: string =
-      api.split('"network-site": {')[1]?.split("}, host:")[0] || "";
+      policy
+        .split("case DashboardComponentType.NetworkMap:")[1]
+        ?.split("case DashboardComponentType.HostList:")[0] || "";
 
     expect(entry.length).toBeGreaterThan(0);
     expect(entry).toContain("networkSiteType: { name: true }");
@@ -220,8 +227,11 @@ describe("Network Map widget data access", () => {
    * registry. A mismatch is a runtime "Unsupported dashboard resource type".
    */
   test("routes through the public-dashboard resource proxy under a registered key", () => {
-    expect(readApp(...WIDGET)).toContain(
-      'DashboardResourceList.getRequestOptions("network-site")',
+    const widget: string = readApp(...WIDGET);
+
+    expect(widget).toContain("DashboardResourceList.getRequestOptions(");
+    expect(widget).toContain(
+      '"network-site", { componentId: props.componentId, variables: props.variables, }',
     );
     expect(
       readApp("Components", "Dashboard", "Utils", "DashboardResourceList.ts"),
@@ -242,19 +252,25 @@ describe("Network Map widget data access", () => {
   });
 
   /*
-   * allowedQueryKeys is the allowlist that stops the public endpoint from
-   * becoming a generic query API. The map draws a FLAT set of pins, so the
-   * tree shape (parentSiteId / materializedPath / depth) must not be
-   * filterable by an anonymous viewer — it is structure the map never shows.
+   * The server rebuilds the query from the exact stored Network Map widget.
+   * The map draws a FLAT set of pins, so the tree shape (parentSiteId /
+   * materializedPath / depth) must not enter that server-owned policy — it is
+   * structure the map never shows.
    */
   test("the public endpoint exposes no filter the map does not use", () => {
-    const api: string = readCommon("Server", "API", "DashboardAPI.ts");
-    const entry: string =
-      api.split('"network-site": {')[1]?.split("}, host:")[0] || "";
-
-    expect(entry).toContain(
-      'allowedQueryKeys: [ "networkSiteTypeId", "currentMonitorStatus", "currentMonitorStatusId", ]',
+    const policy: string = readCommon(
+      "Server",
+      "Utils",
+      "Dashboard",
+      "PublicDashboardResourceListPolicy.ts",
     );
+    const entry: string =
+      policy
+        .split("private static buildNetworkMapPolicy(")[1]
+        ?.split("private static buildHostPolicy(")[0] || "";
+
+    expect(entry).toContain('queryKey: "networkSiteTypeId"');
+    expect(entry).toContain('query["currentMonitorStatus"]');
 
     for (const forbidden of [
       "parentSiteId",
@@ -272,9 +288,16 @@ describe("Network Map widget data access", () => {
    * address or a description on a site is business data the map never draws.
    */
   test("the public select is limited to what the map actually paints", () => {
-    const api: string = readCommon("Server", "API", "DashboardAPI.ts");
+    const policy: string = readCommon(
+      "Server",
+      "Utils",
+      "Dashboard",
+      "PublicDashboardResourceListPolicy.ts",
+    );
     const entry: string =
-      api.split('"network-site": {')[1]?.split("}, host:")[0] || "";
+      policy
+        .split("case DashboardComponentType.NetworkMap:")[1]
+        ?.split("case DashboardComponentType.HostList:")[0] || "";
 
     for (const forbidden of [
       "address:",

--- a/Common/Server/API/DashboardAPI.ts
+++ b/Common/Server/API/DashboardAPI.ts
@@ -68,26 +68,24 @@ import SpanService from "../Services/SpanService";
 import LogService from "../Services/LogService";
 import DashboardComponentType from "../../Types/Dashboard/DashboardComponentType";
 import { DashboardVariableType } from "../../Types/Dashboard/DashboardVariable";
-import Includes from "../../Types/BaseDatabase/Includes";
+import PublicDashboardResourceListPolicy, {
+  PublicDashboardResourceListPolicyResult,
+} from "../Utils/Dashboard/PublicDashboardResourceListPolicy";
+import { applyIncidentSelfPrivacyFilter } from "../Utils/Incident/IncidentPrivacyFilter";
+import { applyAlertSelfPrivacyFilter } from "../Utils/Alert/AlertPrivacyFilter";
 
 /*
  * Registry of the non-metric widgets a public dashboard may render.
  *
- * Nothing on this endpoint is taken from the client except a narrow set of
- * filter values:
- *
- * - `select` is the FIXED set of columns the corresponding widget displays,
- *   so an anonymous viewer can only ever read these columns.
  * - `widgets` lists the dashboard widgets that render this resource, mapped
  *   to the `kind` each one shows (null when the model is not partitioned by
  *   kind). The dashboard must actually contain one of these widgets before
  *   the endpoint will serve the resource at all, and the query is pinned to
  *   the kinds those widgets render. Adding a widget to a public dashboard is
  *   therefore the owner's explicit — and only — opt-in to exposing this data.
- * - `allowedQueryKeys` is the set of columns the widget legitimately filters
- *   on. Every other key in the client-supplied query is dropped, so a public
- *   viewer cannot turn the endpoint into a generic query API over columns the
- *   widget never exposes.
+ * Query, select, sort and pagination policy are rebuilt from the exact stored
+ * widget by PublicDashboardResourceListPolicy. Client copies of those fields
+ * are never authoritative on this unauthenticated route.
  */
 interface PublicDashboardResourceConfig {
   modelType: { new (): BaseModel | AnalyticsDataModel };
@@ -95,11 +93,7 @@ interface PublicDashboardResourceConfig {
     findBy: (findBy: any) => Promise<Array<BaseModel | AnalyticsDataModel>>;
   };
   widgets: Partial<Record<DashboardComponentType, string | null>>;
-  allowedQueryKeys: Array<string>;
-  select: JSONObject;
 }
-
-const DEFAULT_DASHBOARD_RESOURCE_LIMIT: number = 100;
 
 const PUBLIC_DASHBOARD_RESOURCES: Record<
   string,
@@ -111,40 +105,12 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
     widgets: {
       [DashboardComponentType.IncidentList]: null,
     },
-    allowedQueryKeys: [
-      "currentIncidentState",
-      "currentIncidentStateId",
-      "incidentSeverityId",
-      "monitors",
-      "labels",
-    ],
-    select: {
-      _id: true,
-      title: true,
-      createdAt: true,
-      currentIncidentState: { name: true, color: true },
-      incidentSeverity: { name: true, color: true },
-    },
   },
   alert: {
     modelType: Alert,
     service: AlertService,
     widgets: {
       [DashboardComponentType.AlertList]: null,
-    },
-    allowedQueryKeys: [
-      "currentAlertState",
-      "currentAlertStateId",
-      "alertSeverityId",
-      "monitorId",
-      "labels",
-    ],
-    select: {
-      _id: true,
-      title: true,
-      createdAt: true,
-      currentAlertState: { name: true, color: true },
-      alertSeverity: { name: true, color: true },
     },
   },
   monitor: {
@@ -153,18 +119,6 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
     widgets: {
       [DashboardComponentType.MonitorList]: null,
     },
-    allowedQueryKeys: [
-      "currentMonitorStatus",
-      "currentMonitorStatusId",
-      "monitorType",
-      "labels",
-    ],
-    select: {
-      _id: true,
-      name: true,
-      monitorType: true,
-      currentMonitorStatus: { name: true, color: true },
-    },
   },
   "network-site": {
     modelType: NetworkSite,
@@ -172,59 +126,12 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
     widgets: {
       [DashboardComponentType.NetworkMap]: null,
     },
-    /*
-     * The map filters by site type and by whether the rolled-up status is
-     * operational — nothing else. Notably NOT `parentSiteId` or
-     * `materializedPath`: the widget draws a flat set of pins rather than
-     * walking a hierarchy, so exposing the tree shape here would hand an
-     * anonymous viewer a structure the map never shows them.
-     */
-    allowedQueryKeys: [
-      "networkSiteTypeId",
-      "currentMonitorStatus",
-      "currentMonitorStatusId",
-    ],
-    select: {
-      _id: true,
-      name: true,
-      /*
-       * The type NAME comes from the networkSiteType relation. NetworkSite
-       * .siteType is the deprecated pre-lookup-table string and is dropped
-       * in a follow-up PR, so it must not be read from new code.
-       */
-      networkSiteType: { name: true },
-      latitude: true,
-      longitude: true,
-      currentMonitorStatus: {
-        name: true,
-        color: true,
-        priority: true,
-        isOperationalState: true,
-      },
-    },
   },
   host: {
     modelType: Host,
     service: HostService,
     widgets: {
       [DashboardComponentType.HostList]: null,
-    },
-    allowedQueryKeys: [
-      "name",
-      "hostIdentifier",
-      "otelCollectorStatus",
-      "osType",
-    ],
-    select: {
-      _id: true,
-      name: true,
-      hostIdentifier: true,
-      otelCollectorStatus: true,
-      osType: true,
-      osVersion: true,
-      cpuCores: true,
-      totalMemoryBytes: true,
-      lastSeenAt: true,
     },
   },
   "kubernetes-resource": {
@@ -240,50 +147,12 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
       [DashboardComponentType.KubernetesJobList]: "Job",
       [DashboardComponentType.KubernetesCronJobList]: "CronJob",
     },
-    allowedQueryKeys: [
-      "kubernetesClusterId",
-      "namespaceKey",
-      "name",
-      "phase",
-      "isReady",
-    ],
-    select: {
-      _id: true,
-      name: true,
-      namespaceKey: true,
-      kind: true,
-      phase: true,
-      isReady: true,
-      hasMemoryPressure: true,
-      hasDiskPressure: true,
-      hasPidPressure: true,
-      containerCount: true,
-      latestCpuPercent: true,
-      latestMemoryBytes: true,
-      controllerDeploymentName: true,
-      controllerCronJobName: true,
-      resourceCreationTimestamp: true,
-      lastSeenAt: true,
-      kubernetesClusterId: true,
-      kubernetesCluster: { name: true },
-    },
   },
   "docker-host": {
     modelType: DockerHost,
     service: DockerHostService,
     widgets: {
       [DashboardComponentType.DockerHostList]: null,
-    },
-    allowedQueryKeys: ["name", "otelCollectorStatus"],
-    select: {
-      _id: true,
-      name: true,
-      otelCollectorStatus: true,
-      containersRunning: true,
-      containersStopped: true,
-      containersPaused: true,
-      osType: true,
-      osVersion: true,
     },
   },
   "docker-container": {
@@ -292,31 +161,12 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
     widgets: {
       [DashboardComponentType.DockerContainerList]: "Container",
     },
-    allowedQueryKeys: ["dockerHostId", "name", "imageName"],
-    select: {
-      _id: true,
-      name: true,
-      imageName: true,
-      state: true,
-      latestCpuPercent: true,
-      latestMemoryBytes: true,
-      dockerHostId: true,
-      dockerHost: { name: true },
-    },
   },
   "docker-image": {
     modelType: DockerResource,
     service: DockerResourceService,
     widgets: {
       [DashboardComponentType.DockerImageList]: "Image",
-    },
-    allowedQueryKeys: ["dockerHostId", "name"],
-    select: {
-      _id: true,
-      name: true,
-      containerId: true,
-      dockerHostId: true,
-      dockerHost: { name: true },
     },
   },
   "docker-network": {
@@ -325,28 +175,12 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
     widgets: {
       [DashboardComponentType.DockerNetworkList]: "Network",
     },
-    allowedQueryKeys: ["dockerHostId"],
-    select: {
-      _id: true,
-      name: true,
-      state: true,
-      dockerHostId: true,
-      dockerHost: { name: true },
-    },
   },
   "docker-volume": {
     modelType: DockerResource,
     service: DockerResourceService,
     widgets: {
       [DashboardComponentType.DockerVolumeList]: "Volume",
-    },
-    allowedQueryKeys: ["dockerHostId"],
-    select: {
-      _id: true,
-      name: true,
-      state: true,
-      dockerHostId: true,
-      dockerHost: { name: true },
     },
   },
   "podman-host": {
@@ -355,34 +189,12 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
     widgets: {
       [DashboardComponentType.PodmanHostList]: null,
     },
-    allowedQueryKeys: ["name", "otelCollectorStatus"],
-    select: {
-      _id: true,
-      name: true,
-      otelCollectorStatus: true,
-      containersRunning: true,
-      containersStopped: true,
-      containersPaused: true,
-      osType: true,
-      osVersion: true,
-    },
   },
   "podman-container": {
     modelType: PodmanResource,
     service: PodmanResourceService,
     widgets: {
       [DashboardComponentType.PodmanContainerList]: "Container",
-    },
-    allowedQueryKeys: ["podmanHostId", "name", "imageName"],
-    select: {
-      _id: true,
-      name: true,
-      imageName: true,
-      state: true,
-      latestCpuPercent: true,
-      latestMemoryBytes: true,
-      podmanHostId: true,
-      podmanHost: { name: true },
     },
   },
   "podman-image": {
@@ -391,14 +203,6 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
     widgets: {
       [DashboardComponentType.PodmanImageList]: "Image",
     },
-    allowedQueryKeys: ["podmanHostId", "name"],
-    select: {
-      _id: true,
-      name: true,
-      containerId: true,
-      podmanHostId: true,
-      podmanHost: { name: true },
-    },
   },
   "podman-network": {
     modelType: PodmanResource,
@@ -406,28 +210,12 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
     widgets: {
       [DashboardComponentType.PodmanNetworkList]: "Network",
     },
-    allowedQueryKeys: ["podmanHostId"],
-    select: {
-      _id: true,
-      name: true,
-      state: true,
-      podmanHostId: true,
-      podmanHost: { name: true },
-    },
   },
   "podman-volume": {
     modelType: PodmanResource,
     service: PodmanResourceService,
     widgets: {
       [DashboardComponentType.PodmanVolumeList]: "Volume",
-    },
-    allowedQueryKeys: ["podmanHostId"],
-    select: {
-      _id: true,
-      name: true,
-      state: true,
-      podmanHostId: true,
-      podmanHost: { name: true },
     },
   },
   "proxmox-resource": {
@@ -437,23 +225,6 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
       [DashboardComponentType.ProxmoxNodeList]: "Node",
       [DashboardComponentType.ProxmoxGuestList]: "Guest",
     },
-    allowedQueryKeys: ["proxmoxClusterId", "guestType", "isUp", "name"],
-    select: {
-      _id: true,
-      name: true,
-      externalId: true,
-      kind: true,
-      vmid: true,
-      guestType: true,
-      parentNodeName: true,
-      isUp: true,
-      haState: true,
-      latestCpuPercent: true,
-      latestMemoryPercent: true,
-      lastSeenAt: true,
-      proxmoxClusterId: true,
-      proxmoxCluster: { name: true },
-    },
   },
   "ceph-resource": {
     modelType: CephResource,
@@ -461,25 +232,6 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
     widgets: {
       [DashboardComponentType.CephOsdList]: "Osd",
       [DashboardComponentType.CephPoolList]: "Pool",
-    },
-    allowedQueryKeys: ["cephClusterId", "isUp", "isIn", "externalId"],
-    select: {
-      _id: true,
-      name: true,
-      externalId: true,
-      kind: true,
-      hostname: true,
-      deviceClass: true,
-      isUp: true,
-      isIn: true,
-      statBytes: true,
-      statBytesUsed: true,
-      storedBytes: true,
-      maxAvailBytes: true,
-      objects: true,
-      lastSeenAt: true,
-      cephClusterId: true,
-      cephCluster: { name: true },
     },
   },
   "docker-swarm-resource": {
@@ -489,30 +241,6 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
       [DashboardComponentType.DockerSwarmNodeList]: "Node",
       [DashboardComponentType.DockerSwarmServiceList]: "Service",
     },
-    allowedQueryKeys: [
-      "dockerSwarmClusterId",
-      "role",
-      "serviceMode",
-      "isReady",
-    ],
-    select: {
-      _id: true,
-      name: true,
-      externalId: true,
-      kind: true,
-      role: true,
-      state: true,
-      serviceMode: true,
-      desiredReplicas: true,
-      runningReplicas: true,
-      image: true,
-      isReady: true,
-      latestCpuPercent: true,
-      latestMemoryPercent: true,
-      lastSeenAt: true,
-      dockerSwarmClusterId: true,
-      dockerSwarmCluster: { name: true },
-    },
   },
   span: {
     modelType: Span,
@@ -520,33 +248,12 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
     widgets: {
       [DashboardComponentType.TraceList]: null,
     },
-    allowedQueryKeys: ["startTime", "statusCode"],
-    select: {
-      startTime: true,
-      name: true,
-      statusCode: true,
-      durationUnixNano: true,
-      traceId: true,
-      spanId: true,
-      kind: true,
-      primaryEntityId: true,
-    },
   },
   log: {
     modelType: Log,
     service: LogService,
     widgets: {
       [DashboardComponentType.LogStream]: null,
-    },
-    allowedQueryKeys: ["time", "severityText", "body", "attributes"],
-    select: {
-      time: true,
-      severityText: true,
-      body: true,
-      primaryEntityId: true,
-      traceId: true,
-      spanId: true,
-      attributes: true,
     },
   },
 };
@@ -1494,8 +1201,8 @@ export default class DashboardAPI extends BaseAPI<
      * Public resource lists for non-metric dashboard widgets (incident /
      * alert / monitor / trace / log / kubernetes / docker / host lists).
      *
-     * Each widget renders a fixed set of columns; the server pins the select
-     * to exactly those columns (see PUBLIC_DASHBOARD_RESOURCES) and forces the
+     * Each widget renders a fixed set of columns; the server-owned widget
+     * policy pins the select to exactly those columns and forces the
      * project scope to the dashboard's project, so a public viewer can only
      * read the data the widget was built to show, for this dashboard's
      * project. Authorization reuses DashboardService.hasReadAccess.
@@ -1926,119 +1633,130 @@ export default class DashboardAPI extends BaseAPI<
   }
 
   /*
-   * Walk a stored dashboard view config and collect every widget type it
-   * renders. Used to build an allowlist for the public resource-list
-   * endpoint so an anonymous viewer can only read the resources this
-   * dashboard was actually built to show — a dashboard with a monitor list
-   * on it must not double as a project-wide log or incident reader.
+   * Read only the real, top-level dashboard components. Recursively scanning
+   * arbitrary widget arguments would let a nested object carrying a
+   * `componentType` masquerade as a widget and become an authorization input.
    */
-  private static collectDashboardComponentTypes(
+  private static collectDashboardWidgets(
     dashboardViewConfig: unknown,
-  ): Set<string> {
-    const componentTypes: Set<string> = new Set<string>();
+  ): Array<JSONObject> {
+    if (
+      !dashboardViewConfig ||
+      typeof dashboardViewConfig !== "object" ||
+      Array.isArray(dashboardViewConfig)
+    ) {
+      return [];
+    }
 
-    const walk: (node: unknown) => void = (node: unknown): void => {
-      if (!node || typeof node !== "object") {
-        return;
+    const components: unknown = (
+      dashboardViewConfig as Record<string, unknown>
+    )["components"];
+
+    if (!Array.isArray(components)) {
+      return [];
+    }
+
+    return components.filter((component: unknown): component is JSONObject => {
+      return Boolean(
+        component && typeof component === "object" && !Array.isArray(component),
+      );
+    });
+  }
+
+  private static readDashboardWidgetComponentId(
+    widget: JSONObject,
+  ): string | null {
+    const componentId: unknown = widget["componentId"];
+
+    if (componentId instanceof ObjectID) {
+      return componentId.toString();
+    }
+
+    if (typeof componentId === "string" && componentId.length > 0) {
+      return componentId;
+    }
+
+    if (
+      componentId &&
+      typeof componentId === "object" &&
+      !Array.isArray(componentId)
+    ) {
+      const value: unknown = (componentId as Record<string, unknown>)["value"];
+
+      if (typeof value === "string" && value.length > 0) {
+        return value;
       }
+    }
 
-      if (Array.isArray(node)) {
-        for (const item of node) {
-          walk(item);
-        }
-        return;
-      }
-
-      const obj: Record<string, unknown> = node as Record<string, unknown>;
-
-      const componentType: unknown = obj["componentType"];
-      if (typeof componentType === "string" && componentType.length > 0) {
-        componentTypes.add(componentType);
-      }
-
-      for (const key of Object.keys(obj)) {
-        walk(obj[key]);
-      }
-    };
-
-    walk(dashboardViewConfig);
-
-    return componentTypes;
+    return null;
   }
 
   /*
-   * Reduce a client-supplied query to the filter keys the widget is allowed
-   * to narrow by. Anything else the client sends — a foreign projectId, a
-   * filter on a column the widget never renders, an operator on a secret
-   * column used as a blind oracle — is dropped rather than merged.
+   * Select the exact stored widget whose policy will be executed. A legacy
+   * caller may omit componentId only when there is exactly one matching
+   * widget, so two differently-filtered widgets are never conflated.
    */
-  private static sanitizePublicResourceQuery(data: {
-    query: unknown;
-    allowedQueryKeys: Array<string>;
+  private static selectPublicResourceWidget(data: {
+    dashboardViewConfig: unknown;
+    config: PublicDashboardResourceConfig;
+    requestedComponentId: unknown;
   }): JSONObject {
-    const { query, allowedQueryKeys } = data;
+    const matchingWidgets: Array<JSONObject> =
+      DashboardAPI.collectDashboardWidgets(data.dashboardViewConfig).filter(
+        (widget: JSONObject): boolean => {
+          const componentType: unknown = widget["componentType"];
 
-    const sanitized: Record<string, unknown> = {};
+          return (
+            typeof componentType === "string" &&
+            Object.prototype.hasOwnProperty.call(
+              data.config.widgets,
+              componentType,
+            )
+          );
+        },
+      );
 
-    if (!query || typeof query !== "object" || Array.isArray(query)) {
-      return sanitized as JSONObject;
+    if (matchingWidgets.length === 0) {
+      throw new BadDataException(
+        "This resource is not part of this dashboard.",
+      );
     }
 
-    const queryObject: Record<string, unknown> = query as Record<
-      string,
-      unknown
-    >;
-
-    for (const key of allowedQueryKeys) {
-      if (
-        Object.prototype.hasOwnProperty.call(queryObject, key) &&
-        queryObject[key] !== undefined
-      ) {
-        sanitized[key] = queryObject[key];
-      }
-    }
-
-    return sanitized as JSONObject;
-  }
-
-  /*
-   * Reduce a client-supplied sort to the columns the widget already renders
-   * (the registry's fixed select). Sorting by a column the viewer cannot see
-   * would otherwise order rows by a hidden value and leak it.
-   */
-  private static sanitizePublicResourceSort(data: {
-    sort: unknown;
-    select: JSONObject;
-  }): JSONObject {
-    const { sort, select } = data;
-
-    const sanitized: JSONObject = {};
-
-    if (!sort || typeof sort !== "object" || Array.isArray(sort)) {
-      return sanitized;
-    }
-
-    const sortObject: Record<string, unknown> = sort as Record<string, unknown>;
-
-    for (const key of Object.keys(sortObject)) {
-      // Only scalar columns of the fixed select are sortable.
-      if (select[key] !== true) {
-        continue;
+    if (
+      data.requestedComponentId === undefined ||
+      data.requestedComponentId === null
+    ) {
+      if (matchingWidgets.length === 1) {
+        return matchingWidgets[0] as JSONObject;
       }
 
-      const order: unknown = sortObject[key];
-
-      if (
-        typeof order === "string" &&
-        order.toUpperCase() === SortOrder.Descending
-      ) {
-        sanitized[key] = SortOrder.Descending;
-      } else {
-        sanitized[key] = SortOrder.Ascending;
-      }
+      throw new BadDataException(
+        "A componentId is required to read this resource from this dashboard.",
+      );
     }
 
-    return sanitized;
+    if (typeof data.requestedComponentId !== "string") {
+      throw new BadDataException("componentId must be a string UUID.");
+    }
+
+    ObjectID.validateUUID(data.requestedComponentId);
+
+    const selectedWidget: JSONObject | undefined = matchingWidgets.find(
+      (widget: JSONObject): boolean => {
+        return (
+          DashboardAPI.readDashboardWidgetComponentId(widget) ===
+          data.requestedComponentId
+        );
+      },
+    );
+
+    if (!selectedWidget) {
+      throw new BadDataException(
+        "This resource is not part of this dashboard.",
+      );
+    }
+
+    return selectedWidget;
   }
 
   /*
@@ -2087,117 +1805,66 @@ export default class DashboardAPI extends BaseAPI<
       throw new NotFoundException("Dashboard not found");
     }
 
-    /*
-     * Security: the dashboard must actually contain a widget that renders
-     * this resource. Without this check, knowing any public dashboard ID
-     * would be enough to read every resource type in its project — the
-     * dashboard's own widgets are the owner's opt-in, so they are the
-     * allowlist.
-     */
-    const dashboardComponentTypes: Set<string> =
-      DashboardAPI.collectDashboardComponentTypes(
-        dashboard.dashboardViewConfig,
-      );
+    const widget: JSONObject = DashboardAPI.selectPublicResourceWidget({
+      dashboardViewConfig: dashboard.dashboardViewConfig,
+      config,
+      requestedComponentId: req.body ? req.body["componentId"] : undefined,
+    });
 
-    const presentWidgets: Array<string> = Object.keys(config.widgets).filter(
-      (componentType: string) => {
-        return dashboardComponentTypes.has(componentType);
-      },
-    );
-
-    if (presentWidgets.length === 0) {
-      throw new BadDataException(
-        "This resource is not part of this dashboard.",
-      );
-    }
-
-    const clientQuery: JSONObject =
+    const requestedQuery: JSONObject =
       req.body && req.body["query"]
         ? (JSONFunctions.deserialize(
             req.body["query"] as JSONObject,
           ) as JSONObject)
         : {};
 
-    const query: JSONObject = DashboardAPI.sanitizePublicResourceQuery({
-      query: clientQuery,
-      allowedQueryKeys: config.allowedQueryKeys,
-    });
-
-    /*
-     * Security: pin to the dashboard's project; never trust a client-supplied
-     * projectId on a public, unauthenticated endpoint.
-     */
-    (query as Record<string, unknown>)["projectId"] = dashboard.projectId;
-
-    /*
-     * Models that pack several resource kinds into one table (Kubernetes,
-     * Docker, Podman, Proxmox, Ceph, Swarm) are constrained to the kinds the
-     * dashboard's widgets render, so a "volumes" widget cannot be used to
-     * list containers. A widget may pick one of those kinds; anything else is
-     * rejected, and a request that names no kind gets all of them.
-     */
-    const allowedKinds: Array<string> = presentWidgets
-      .map((componentType: string) => {
-        return config.widgets[componentType as DashboardComponentType];
-      })
-      .filter((kind: string | null | undefined): kind is string => {
-        return Boolean(kind);
+    const policy: PublicDashboardResourceListPolicyResult =
+      PublicDashboardResourceListPolicy.build({
+        widget,
+        dashboardViewConfig: dashboard.dashboardViewConfig,
+        requestedVariables: req.body ? req.body["variables"] : undefined,
+        requestedQuery,
       });
 
-    if (allowedKinds.length > 0) {
-      const requestedKind: unknown = (clientQuery as Record<string, unknown>)[
-        "kind"
-      ];
+    const requestedResourceType: string = req.params["resourceType"] as string;
 
-      if (requestedKind !== undefined && requestedKind !== null) {
-        if (
-          typeof requestedKind !== "string" ||
-          !allowedKinds.includes(requestedKind)
-        ) {
-          throw new BadDataException(
-            "This resource is not part of this dashboard.",
-          );
-        }
-
-        (query as Record<string, unknown>)["kind"] = requestedKind;
-      } else if (allowedKinds.length === 1) {
-        (query as Record<string, unknown>)["kind"] = allowedKinds[0];
-      } else {
-        (query as Record<string, unknown>)["kind"] = new Includes(allowedKinds);
-      }
+    if (policy.resourceType !== requestedResourceType) {
+      throw new BadDataException(
+        "This resource is not part of this dashboard.",
+      );
     }
 
-    const sort: JSONObject = DashboardAPI.sanitizePublicResourceSort({
-      sort:
-        req.body && req.body["sort"]
-          ? JSONFunctions.deserialize(req.body["sort"] as JSONObject)
-          : {},
-      select: config.select,
-    });
+    let query: JSONObject = {
+      ...policy.query,
+    };
 
-    const requestedLimit: number = req.query["limit"]
-      ? parseInt(req.query["limit"] as string, 10)
-      : DEFAULT_DASHBOARD_RESOURCE_LIMIT;
-    const limit: number = Math.min(
-      Number.isFinite(requestedLimit) && requestedLimit > 0
-        ? requestedLimit
-        : DEFAULT_DASHBOARD_RESOURCE_LIMIT,
-      LIMIT_PER_PROJECT,
-    );
+    /*
+     * IncidentService and AlertService normally apply privacy in their
+     * onBeforeFind hooks. The root read below intentionally bypasses those
+     * hooks' user context, so apply the anonymous form explicitly first:
+     * public dashboards may show public rows, never private tenant rows.
+     */
+    if (requestedResourceType === "incident") {
+      query = applyIncidentSelfPrivacyFilter(query, {});
+    } else if (requestedResourceType === "alert") {
+      query = applyAlertSelfPrivacyFilter(query, {});
+    }
 
-    const requestedSkip: number = req.query["skip"]
-      ? parseInt(req.query["skip"] as string, 10)
-      : 0;
-    const skip: number =
-      Number.isFinite(requestedSkip) && requestedSkip > 0 ? requestedSkip : 0;
+    /*
+     * Project scope is the final query invariant. Neither the request nor a
+     * future policy builder may redirect this root read to another project.
+     * Resource kind, where applicable, comes solely from the selected
+     * widget's policy query.
+     */
+    query["projectId"] = dashboard.projectId;
 
     const list: Array<BaseModel | AnalyticsDataModel> =
       await config.service.findBy({
         query: query,
-        select: config.select,
-        sort: sort,
-        limit: limit,
-        skip: skip,
+        select: policy.select,
+        sort: policy.sort,
+        limit: policy.limit,
+        skip: 0,
         props: {
           isRoot: true,
         },

--- a/Common/Server/Utils/Dashboard/PublicDashboardResourceListPolicy.ts
+++ b/Common/Server/Utils/Dashboard/PublicDashboardResourceListPolicy.ts
@@ -1,0 +1,1793 @@
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import Search from "../../../Types/BaseDatabase/Search";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import DashboardVariable, {
+  DashboardVariableType,
+} from "../../../Types/Dashboard/DashboardVariable";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject, JSONValue } from "../../../Types/JSON";
+import JSONFunctions from "../../../Types/JSONFunctions";
+import {
+  LogFilter,
+  queryStringToFilter,
+} from "../../../Types/Log/LogQueryToFilter";
+import DashboardModelQueryInterpolation, {
+  AttributeToColumnMap,
+} from "../../../Utils/Dashboard/ModelQueryVariableInterpolation";
+import DashboardVariableInterpolation from "../../../Utils/Dashboard/VariableInterpolation";
+
+export interface PublicDashboardResourceListPolicyResult {
+  resourceType: string;
+  query: JSONObject;
+  select: JSONObject;
+  sort: JSONObject;
+  limit: number;
+}
+
+export interface BuildPublicDashboardResourceListPolicyData {
+  widget: JSONObject;
+  dashboardViewConfig: unknown;
+  requestedVariables: unknown;
+  requestedQuery: unknown;
+}
+
+interface PolicyDraft {
+  resourceType: string;
+  query: Record<string, unknown>;
+  sort: JSONObject;
+  limit: number;
+  attributeToColumn?: AttributeToColumnMap | undefined;
+  interpolateAttributeMap?: boolean | undefined;
+}
+
+const DEFAULT_LIST_LIMIT: number = 25;
+const DEFAULT_TELEMETRY_LIMIT: number = 50;
+const DEFAULT_NETWORK_MAP_MAX_SITES: number = 250;
+
+/*
+ * These bounds are deliberately much smaller than the request-body limit.
+ * Variable values can become IN-list parameters, so a public request must not
+ * be able to turn one dashboard refresh into an unbounded query compilation.
+ */
+const MAX_REQUESTED_VARIABLES: number = 50;
+const MAX_SELECTED_VALUES_PER_VARIABLE: number = 100;
+const MAX_TOTAL_SELECTED_VALUES: number = 200;
+const MAX_VARIABLE_ID_LENGTH: number = 256;
+const MAX_VARIABLE_VALUE_LENGTH: number = 1024;
+
+const HOST_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  "host.name": "name",
+  "host.id": "hostIdentifier",
+  "resource.host.name": "name",
+  "resource.host.id": "hostIdentifier",
+};
+
+const CONTAINER_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  "container.name": "name",
+  "container.image.name": "imageName",
+};
+
+const IMAGE_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  "container.image.name": "name",
+};
+
+const HOST_NAME_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  "host.name": "name",
+};
+
+const KUBERNETES_POD_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  "k8s.pod.name": "name",
+  "k8s.namespace.name": "namespaceKey",
+  "resource.k8s.pod.name": "name",
+  "resource.k8s.namespace.name": "namespaceKey",
+};
+
+const KUBERNETES_NODE_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  "k8s.node.name": "name",
+  "resource.k8s.node.name": "name",
+};
+
+const KUBERNETES_NAMESPACE_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  "k8s.namespace.name": "name",
+  "resource.k8s.namespace.name": "name",
+};
+
+const KUBERNETES_DEPLOYMENT_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  "k8s.deployment.name": "name",
+  "k8s.namespace.name": "namespaceKey",
+  "resource.k8s.deployment.name": "name",
+  "resource.k8s.namespace.name": "namespaceKey",
+};
+
+const KUBERNETES_STATEFUL_SET_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  "k8s.statefulset.name": "name",
+  "k8s.namespace.name": "namespaceKey",
+  "resource.k8s.statefulset.name": "name",
+  "resource.k8s.namespace.name": "namespaceKey",
+};
+
+const KUBERNETES_DAEMON_SET_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  "k8s.daemonset.name": "name",
+  "k8s.namespace.name": "namespaceKey",
+  "resource.k8s.daemonset.name": "name",
+  "resource.k8s.namespace.name": "namespaceKey",
+};
+
+const KUBERNETES_JOB_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  "k8s.job.name": "name",
+  "k8s.namespace.name": "namespaceKey",
+  "resource.k8s.job.name": "name",
+  "resource.k8s.namespace.name": "namespaceKey",
+};
+
+const KUBERNETES_CRON_JOB_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  "k8s.cronjob.name": "name",
+  "k8s.namespace.name": "namespaceKey",
+  "resource.k8s.cronjob.name": "name",
+  "resource.k8s.namespace.name": "namespaceKey",
+};
+
+const PROXMOX_NODE_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  "pve.id": "name",
+};
+
+const CEPH_OSD_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  ceph_daemon: "externalId",
+};
+
+const CEPH_POOL_ATTRIBUTE_TO_COLUMN: AttributeToColumnMap = {
+  pool_id: "externalId",
+};
+
+/*
+ * Produces the complete server-owned policy for one already-selected public
+ * dashboard widget. No caller-supplied project, kind, filter, sort, or limit is
+ * copied. The route adds the dashboard's projectId after this policy returns.
+ */
+export default class PublicDashboardResourceListPolicy {
+  public static build(
+    data: BuildPublicDashboardResourceListPolicyData,
+  ): PublicDashboardResourceListPolicyResult {
+    const widget: Record<string, unknown> =
+      PublicDashboardResourceListPolicy.requireObject(
+        data.widget,
+        "Dashboard widget",
+      );
+    const argumentsObject: Record<string, unknown> =
+      PublicDashboardResourceListPolicy.requireObject(
+        widget["arguments"],
+        "Dashboard widget arguments",
+      );
+
+    const componentType: unknown = widget["componentType"];
+    if (typeof componentType !== "string" || componentType.length === 0) {
+      throw new BadDataException("Dashboard widget has no component type.");
+    }
+
+    const variables: Array<DashboardVariable> =
+      PublicDashboardResourceListPolicy.resolveDashboardVariableSelections({
+        dashboardViewConfig: data.dashboardViewConfig,
+        requestedVariables: data.requestedVariables,
+      });
+
+    const draft: PolicyDraft = PublicDashboardResourceListPolicy.buildDraft({
+      componentType: componentType as DashboardComponentType,
+      argumentsObject,
+      requestedQuery: data.requestedQuery,
+    });
+
+    let query: Record<string, unknown> = draft.query;
+
+    if (draft.attributeToColumn) {
+      query = DashboardModelQueryInterpolation.applyToQuery(
+        query,
+        variables,
+        draft.attributeToColumn,
+      );
+    }
+
+    if (draft.interpolateAttributeMap) {
+      const currentAttributes: unknown = query["attributes"];
+      const baseAttributes: Record<string, unknown> | undefined =
+        currentAttributes === undefined
+          ? undefined
+          : PublicDashboardResourceListPolicy.requireObject(
+              currentAttributes,
+              "Log attributes filter",
+            );
+      const interpolatedAttributes: Record<string, unknown> =
+        DashboardVariableInterpolation.applyToAttributes(
+          baseAttributes,
+          variables,
+        );
+
+      if (Object.keys(interpolatedAttributes).length > 0) {
+        query["attributes"] = interpolatedAttributes;
+      } else {
+        delete query["attributes"];
+      }
+    }
+
+    return {
+      resourceType: draft.resourceType,
+      query: query as JSONObject,
+      select: PublicDashboardResourceListPolicy.selectForComponent(
+        componentType as DashboardComponentType,
+      ),
+      sort: draft.sort,
+      limit: draft.limit,
+    };
+  }
+
+  /*
+   * Public list responses are projected to the fields consumed by the exact
+   * stored widget. Resource models shared by several widget kinds must never
+   * inherit a union of their siblings' fields.
+   */
+  private static selectForComponent(
+    componentType: DashboardComponentType,
+  ): JSONObject {
+    switch (componentType) {
+      case DashboardComponentType.IncidentList:
+        return {
+          _id: true,
+          title: true,
+          createdAt: true,
+          currentIncidentState: { name: true, color: true },
+          incidentSeverity: { name: true, color: true },
+        };
+      case DashboardComponentType.AlertList:
+        return {
+          _id: true,
+          title: true,
+          createdAt: true,
+          currentAlertState: { name: true, color: true },
+          alertSeverity: { name: true, color: true },
+        };
+      case DashboardComponentType.MonitorList:
+        return {
+          _id: true,
+          name: true,
+          monitorType: true,
+          currentMonitorStatus: { name: true, color: true },
+        };
+      case DashboardComponentType.NetworkMap:
+        return {
+          _id: true,
+          name: true,
+          networkSiteType: { name: true },
+          latitude: true,
+          longitude: true,
+          currentMonitorStatus: {
+            name: true,
+            color: true,
+            priority: true,
+            isOperationalState: true,
+          },
+        };
+      case DashboardComponentType.HostList:
+        return {
+          _id: true,
+          name: true,
+          otelCollectorStatus: true,
+          osType: true,
+          osVersion: true,
+          cpuCores: true,
+          totalMemoryBytes: true,
+          lastSeenAt: true,
+        };
+      case DashboardComponentType.KubernetesPodList:
+        return {
+          _id: true,
+          name: true,
+          namespaceKey: true,
+          phase: true,
+          kubernetesClusterId: true,
+          kubernetesCluster: { name: true },
+        };
+      case DashboardComponentType.KubernetesNodeList:
+        return {
+          _id: true,
+          name: true,
+          namespaceKey: true,
+          isReady: true,
+          hasMemoryPressure: true,
+          hasDiskPressure: true,
+          hasPidPressure: true,
+          kubernetesClusterId: true,
+          kubernetesCluster: { name: true },
+        };
+      case DashboardComponentType.KubernetesNamespaceList:
+        return {
+          _id: true,
+          name: true,
+          phase: true,
+          kubernetesClusterId: true,
+          kubernetesCluster: { name: true },
+        };
+      case DashboardComponentType.KubernetesDeploymentList:
+      case DashboardComponentType.KubernetesStatefulSetList:
+      case DashboardComponentType.KubernetesDaemonSetList:
+      case DashboardComponentType.KubernetesJobList:
+      case DashboardComponentType.KubernetesCronJobList:
+        return {
+          _id: true,
+          name: true,
+          namespaceKey: true,
+          isReady: true,
+          kubernetesClusterId: true,
+          kubernetesCluster: { name: true },
+        };
+      case DashboardComponentType.DockerHostList:
+      case DashboardComponentType.PodmanHostList:
+        return {
+          _id: true,
+          name: true,
+          otelCollectorStatus: true,
+          containersRunning: true,
+          containersStopped: true,
+          containersPaused: true,
+          osType: true,
+          osVersion: true,
+        };
+      case DashboardComponentType.DockerContainerList:
+        return {
+          _id: true,
+          name: true,
+          imageName: true,
+          state: true,
+          latestCpuPercent: true,
+          latestMemoryBytes: true,
+          dockerHostId: true,
+          dockerHost: { name: true },
+        };
+      case DashboardComponentType.DockerImageList:
+        return {
+          _id: true,
+          name: true,
+          containerId: true,
+          dockerHost: { name: true },
+        };
+      case DashboardComponentType.DockerNetworkList:
+      case DashboardComponentType.DockerVolumeList:
+        return {
+          _id: true,
+          name: true,
+          state: true,
+          dockerHost: { name: true },
+        };
+      case DashboardComponentType.PodmanContainerList:
+        return {
+          _id: true,
+          name: true,
+          imageName: true,
+          state: true,
+          latestCpuPercent: true,
+          latestMemoryBytes: true,
+          podmanHostId: true,
+          podmanHost: { name: true },
+        };
+      case DashboardComponentType.PodmanImageList:
+        return {
+          _id: true,
+          name: true,
+          containerId: true,
+          podmanHost: { name: true },
+        };
+      case DashboardComponentType.PodmanNetworkList:
+      case DashboardComponentType.PodmanVolumeList:
+        return {
+          _id: true,
+          name: true,
+          state: true,
+          podmanHost: { name: true },
+        };
+      case DashboardComponentType.ProxmoxNodeList:
+        return {
+          _id: true,
+          name: true,
+          externalId: true,
+          isUp: true,
+          latestCpuPercent: true,
+          latestMemoryPercent: true,
+          proxmoxClusterId: true,
+          proxmoxCluster: { name: true },
+        };
+      case DashboardComponentType.ProxmoxGuestList:
+        return {
+          _id: true,
+          name: true,
+          externalId: true,
+          vmid: true,
+          guestType: true,
+          parentNodeName: true,
+          isUp: true,
+          haState: true,
+          proxmoxClusterId: true,
+          proxmoxCluster: { name: true },
+        };
+      case DashboardComponentType.CephOsdList:
+        return {
+          _id: true,
+          name: true,
+          externalId: true,
+          hostname: true,
+          deviceClass: true,
+          isUp: true,
+          isIn: true,
+          statBytes: true,
+          statBytesUsed: true,
+          cephClusterId: true,
+          cephCluster: { name: true },
+        };
+      case DashboardComponentType.CephPoolList:
+        return {
+          _id: true,
+          name: true,
+          externalId: true,
+          storedBytes: true,
+          maxAvailBytes: true,
+          objects: true,
+          cephClusterId: true,
+          cephCluster: { name: true },
+        };
+      case DashboardComponentType.DockerSwarmNodeList:
+        return {
+          _id: true,
+          name: true,
+          externalId: true,
+          role: true,
+          state: true,
+          isReady: true,
+          latestCpuPercent: true,
+          latestMemoryPercent: true,
+          dockerSwarmClusterId: true,
+          dockerSwarmCluster: { name: true },
+        };
+      case DashboardComponentType.DockerSwarmServiceList:
+        return {
+          _id: true,
+          name: true,
+          externalId: true,
+          serviceMode: true,
+          desiredReplicas: true,
+          runningReplicas: true,
+          image: true,
+          isReady: true,
+          dockerSwarmClusterId: true,
+          dockerSwarmCluster: { name: true },
+        };
+      case DashboardComponentType.TraceList:
+        return {
+          startTime: true,
+          name: true,
+          statusCode: true,
+          durationUnixNano: true,
+        };
+      case DashboardComponentType.LogStream:
+        return {
+          time: true,
+          severityText: true,
+          body: true,
+        };
+      default:
+        throw new BadDataException(
+          "This dashboard widget cannot list public resources.",
+        );
+    }
+  }
+
+  private static buildDraft(data: {
+    componentType: DashboardComponentType;
+    argumentsObject: Record<string, unknown>;
+    requestedQuery: unknown;
+  }): PolicyDraft {
+    const { componentType, argumentsObject, requestedQuery } = data;
+
+    switch (componentType) {
+      case DashboardComponentType.IncidentList:
+        return PublicDashboardResourceListPolicy.buildIncidentPolicy(
+          argumentsObject,
+        );
+      case DashboardComponentType.AlertList:
+        return PublicDashboardResourceListPolicy.buildAlertPolicy(
+          argumentsObject,
+        );
+      case DashboardComponentType.MonitorList:
+        return PublicDashboardResourceListPolicy.buildMonitorPolicy(
+          argumentsObject,
+        );
+      case DashboardComponentType.NetworkMap:
+        return PublicDashboardResourceListPolicy.buildNetworkMapPolicy(
+          argumentsObject,
+        );
+      case DashboardComponentType.HostList:
+        return PublicDashboardResourceListPolicy.buildHostPolicy(
+          argumentsObject,
+        );
+      case DashboardComponentType.KubernetesPodList:
+        return PublicDashboardResourceListPolicy.buildKubernetesPolicy({
+          argumentsObject,
+          kind: "Pod",
+          attributeToColumn: KUBERNETES_POD_ATTRIBUTE_TO_COLUMN,
+          includeNamespaces: true,
+          componentType,
+        });
+      case DashboardComponentType.KubernetesNodeList:
+        return PublicDashboardResourceListPolicy.buildKubernetesPolicy({
+          argumentsObject,
+          kind: "Node",
+          attributeToColumn: KUBERNETES_NODE_ATTRIBUTE_TO_COLUMN,
+          includeNamespaces: false,
+          componentType,
+        });
+      case DashboardComponentType.KubernetesNamespaceList:
+        return PublicDashboardResourceListPolicy.buildKubernetesPolicy({
+          argumentsObject,
+          kind: "Namespace",
+          attributeToColumn: KUBERNETES_NAMESPACE_ATTRIBUTE_TO_COLUMN,
+          includeNamespaces: false,
+          componentType,
+        });
+      case DashboardComponentType.KubernetesDeploymentList:
+        return PublicDashboardResourceListPolicy.buildKubernetesPolicy({
+          argumentsObject,
+          kind: "Deployment",
+          attributeToColumn: KUBERNETES_DEPLOYMENT_ATTRIBUTE_TO_COLUMN,
+          includeNamespaces: true,
+          componentType,
+        });
+      case DashboardComponentType.KubernetesStatefulSetList:
+        return PublicDashboardResourceListPolicy.buildKubernetesPolicy({
+          argumentsObject,
+          kind: "StatefulSet",
+          attributeToColumn: KUBERNETES_STATEFUL_SET_ATTRIBUTE_TO_COLUMN,
+          includeNamespaces: true,
+          componentType,
+        });
+      case DashboardComponentType.KubernetesDaemonSetList:
+        return PublicDashboardResourceListPolicy.buildKubernetesPolicy({
+          argumentsObject,
+          kind: "DaemonSet",
+          attributeToColumn: KUBERNETES_DAEMON_SET_ATTRIBUTE_TO_COLUMN,
+          includeNamespaces: true,
+          componentType,
+        });
+      case DashboardComponentType.KubernetesJobList:
+        return PublicDashboardResourceListPolicy.buildKubernetesPolicy({
+          argumentsObject,
+          kind: "Job",
+          attributeToColumn: KUBERNETES_JOB_ATTRIBUTE_TO_COLUMN,
+          includeNamespaces: true,
+          componentType,
+        });
+      case DashboardComponentType.KubernetesCronJobList:
+        return PublicDashboardResourceListPolicy.buildKubernetesPolicy({
+          argumentsObject,
+          kind: "CronJob",
+          attributeToColumn: KUBERNETES_CRON_JOB_ATTRIBUTE_TO_COLUMN,
+          includeNamespaces: true,
+          componentType,
+        });
+      case DashboardComponentType.DockerHostList:
+        return PublicDashboardResourceListPolicy.buildContainerHostPolicy({
+          argumentsObject,
+          resourceType: "docker-host",
+        });
+      case DashboardComponentType.DockerContainerList:
+        return PublicDashboardResourceListPolicy.buildContainerPolicy({
+          argumentsObject,
+          resourceType: "docker-container",
+          hostIdKey: "dockerHostId",
+          storedHostIdsKey: "dockerHostIds",
+        });
+      case DashboardComponentType.DockerImageList:
+        return PublicDashboardResourceListPolicy.buildImagePolicy({
+          argumentsObject,
+          resourceType: "docker-image",
+          hostIdKey: "dockerHostId",
+          storedHostIdsKey: "dockerHostIds",
+        });
+      case DashboardComponentType.DockerNetworkList:
+        return PublicDashboardResourceListPolicy.buildContainerInventoryPolicy({
+          argumentsObject,
+          resourceType: "docker-network",
+          kind: "Network",
+          hostIdKey: "dockerHostId",
+          storedHostIdsKey: "dockerHostIds",
+        });
+      case DashboardComponentType.DockerVolumeList:
+        return PublicDashboardResourceListPolicy.buildContainerInventoryPolicy({
+          argumentsObject,
+          resourceType: "docker-volume",
+          kind: "Volume",
+          hostIdKey: "dockerHostId",
+          storedHostIdsKey: "dockerHostIds",
+        });
+      case DashboardComponentType.PodmanHostList:
+        return PublicDashboardResourceListPolicy.buildContainerHostPolicy({
+          argumentsObject,
+          resourceType: "podman-host",
+        });
+      case DashboardComponentType.PodmanContainerList:
+        return PublicDashboardResourceListPolicy.buildContainerPolicy({
+          argumentsObject,
+          resourceType: "podman-container",
+          hostIdKey: "podmanHostId",
+          storedHostIdsKey: "podmanHostIds",
+        });
+      case DashboardComponentType.PodmanImageList:
+        return PublicDashboardResourceListPolicy.buildImagePolicy({
+          argumentsObject,
+          resourceType: "podman-image",
+          hostIdKey: "podmanHostId",
+          storedHostIdsKey: "podmanHostIds",
+        });
+      case DashboardComponentType.PodmanNetworkList:
+        return PublicDashboardResourceListPolicy.buildContainerInventoryPolicy({
+          argumentsObject,
+          resourceType: "podman-network",
+          kind: "Network",
+          hostIdKey: "podmanHostId",
+          storedHostIdsKey: "podmanHostIds",
+        });
+      case DashboardComponentType.PodmanVolumeList:
+        return PublicDashboardResourceListPolicy.buildContainerInventoryPolicy({
+          argumentsObject,
+          resourceType: "podman-volume",
+          kind: "Volume",
+          hostIdKey: "podmanHostId",
+          storedHostIdsKey: "podmanHostIds",
+        });
+      case DashboardComponentType.ProxmoxNodeList:
+        return PublicDashboardResourceListPolicy.buildProxmoxNodePolicy(
+          argumentsObject,
+        );
+      case DashboardComponentType.ProxmoxGuestList:
+        return PublicDashboardResourceListPolicy.buildProxmoxGuestPolicy(
+          argumentsObject,
+        );
+      case DashboardComponentType.CephOsdList:
+        return PublicDashboardResourceListPolicy.buildCephOsdPolicy(
+          argumentsObject,
+        );
+      case DashboardComponentType.CephPoolList:
+        return PublicDashboardResourceListPolicy.buildCephPoolPolicy(
+          argumentsObject,
+        );
+      case DashboardComponentType.DockerSwarmNodeList:
+        return PublicDashboardResourceListPolicy.buildDockerSwarmNodePolicy(
+          argumentsObject,
+        );
+      case DashboardComponentType.DockerSwarmServiceList:
+        return PublicDashboardResourceListPolicy.buildDockerSwarmServicePolicy(
+          argumentsObject,
+        );
+      case DashboardComponentType.TraceList:
+        return PublicDashboardResourceListPolicy.buildTracePolicy({
+          argumentsObject,
+          requestedQuery,
+        });
+      case DashboardComponentType.LogStream:
+        return PublicDashboardResourceListPolicy.buildLogPolicy({
+          argumentsObject,
+          requestedQuery,
+        });
+      default:
+        throw new BadDataException(
+          `Unsupported public dashboard resource widget: ${componentType}`,
+        );
+    }
+  }
+
+  private static buildIncidentPolicy(
+    argumentsObject: Record<string, unknown>,
+  ): PolicyDraft {
+    const query: Record<string, unknown> = {};
+    const stateFilter: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "stateFilter",
+        ["unresolved", "resolved", "acknowledged"],
+      );
+
+    if (stateFilter === "unresolved") {
+      query["currentIncidentState"] = { isResolvedState: false };
+    } else if (stateFilter === "resolved") {
+      query["currentIncidentState"] = { isResolvedState: true };
+    } else if (stateFilter === "acknowledged") {
+      query["currentIncidentState"] = { isAcknowledgedState: true };
+    }
+
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "incidentSeverityId",
+      argumentsObject,
+      argumentKey: "severityIds",
+    });
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "currentIncidentStateId",
+      argumentsObject,
+      argumentKey: "stateIds",
+    });
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "monitors",
+      argumentsObject,
+      argumentKey: "monitorIds",
+    });
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "labels",
+      argumentsObject,
+      argumentKey: "labelIds",
+    });
+
+    return PublicDashboardResourceListPolicy.listDraft({
+      resourceType: "incident",
+      query,
+      sort: { createdAt: SortOrder.Descending },
+      argumentsObject,
+    });
+  }
+
+  private static buildAlertPolicy(
+    argumentsObject: Record<string, unknown>,
+  ): PolicyDraft {
+    const query: Record<string, unknown> = {};
+    const stateFilter: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "stateFilter",
+        ["unresolved", "resolved", "acknowledged"],
+      );
+
+    if (stateFilter === "unresolved") {
+      query["currentAlertState"] = { isResolvedState: false };
+    } else if (stateFilter === "resolved") {
+      query["currentAlertState"] = { isResolvedState: true };
+    } else if (stateFilter === "acknowledged") {
+      query["currentAlertState"] = { isAcknowledgedState: true };
+    }
+
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "alertSeverityId",
+      argumentsObject,
+      argumentKey: "severityIds",
+    });
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "currentAlertStateId",
+      argumentsObject,
+      argumentKey: "stateIds",
+    });
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "monitorId",
+      argumentsObject,
+      argumentKey: "monitorIds",
+    });
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "labels",
+      argumentsObject,
+      argumentKey: "labelIds",
+    });
+
+    return PublicDashboardResourceListPolicy.listDraft({
+      resourceType: "alert",
+      query,
+      sort: { createdAt: SortOrder.Descending },
+      argumentsObject,
+    });
+  }
+
+  private static buildMonitorPolicy(
+    argumentsObject: Record<string, unknown>,
+  ): PolicyDraft {
+    const query: Record<string, unknown> = {};
+    const statusFilter: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "statusFilter",
+        ["operational", "non-operational"],
+      );
+
+    if (statusFilter === "operational") {
+      query["currentMonitorStatus"] = { isOperationalState: true };
+    } else if (statusFilter === "non-operational") {
+      query["currentMonitorStatus"] = { isOperationalState: false };
+    }
+
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "currentMonitorStatusId",
+      argumentsObject,
+      argumentKey: "monitorStatusIds",
+    });
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "monitorType",
+      argumentsObject,
+      argumentKey: "monitorTypes",
+    });
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "labels",
+      argumentsObject,
+      argumentKey: "labelIds",
+    });
+
+    return PublicDashboardResourceListPolicy.listDraft({
+      resourceType: "monitor",
+      query,
+      sort: { name: SortOrder.Ascending },
+      argumentsObject,
+    });
+  }
+
+  private static buildNetworkMapPolicy(
+    argumentsObject: Record<string, unknown>,
+  ): PolicyDraft {
+    const query: Record<string, unknown> = {};
+    const statusFilter: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "statusFilter",
+        ["down", "operational"],
+      );
+
+    if (statusFilter === "down") {
+      query["currentMonitorStatus"] = { isOperationalState: false };
+    } else if (statusFilter === "operational") {
+      query["currentMonitorStatus"] = { isOperationalState: true };
+    }
+
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "networkSiteTypeId",
+      argumentsObject,
+      argumentKey: "networkSiteTypeIds",
+    });
+
+    const maxSites: number = PublicDashboardResourceListPolicy.storedLimit({
+      value: argumentsObject["maxSites"],
+      fallback: DEFAULT_NETWORK_MAP_MAX_SITES,
+      ceiling: LIMIT_PER_PROJECT - 1,
+    });
+
+    return {
+      resourceType: "network-site",
+      query,
+      sort: { name: SortOrder.Ascending },
+      // The map fetches one sentinel row to tell whether its display is capped.
+      limit: Math.min(maxSites + 1, LIMIT_PER_PROJECT),
+    };
+  }
+
+  private static buildHostPolicy(
+    argumentsObject: Record<string, unknown>,
+  ): PolicyDraft {
+    const query: Record<string, unknown> = {};
+    PublicDashboardResourceListPolicy.addCollectorStatusFilter(
+      query,
+      argumentsObject,
+    );
+
+    const osType: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "osTypeFilter",
+        ["linux", "darwin", "windows"],
+      );
+    if (osType) {
+      query["osType"] = osType;
+    }
+
+    return {
+      ...PublicDashboardResourceListPolicy.listDraft({
+        resourceType: "host",
+        query,
+        sort: { name: SortOrder.Ascending },
+        argumentsObject,
+      }),
+      attributeToColumn: HOST_ATTRIBUTE_TO_COLUMN,
+    };
+  }
+
+  private static buildKubernetesPolicy(data: {
+    argumentsObject: Record<string, unknown>;
+    kind: string;
+    attributeToColumn: AttributeToColumnMap;
+    includeNamespaces: boolean;
+    componentType: DashboardComponentType;
+  }): PolicyDraft {
+    const { argumentsObject } = data;
+    const query: Record<string, unknown> = { kind: data.kind };
+
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "kubernetesClusterId",
+      argumentsObject,
+      argumentKey: "kubernetesClusterIds",
+    });
+
+    if (data.includeNamespaces) {
+      const namespaces: string | undefined =
+        PublicDashboardResourceListPolicy.optionalString(
+          argumentsObject,
+          "namespaces",
+          true,
+        );
+      if (namespaces) {
+        const parsedNamespaces: Array<string> = namespaces
+          .split(",")
+          .map((namespace: string) => {
+            return namespace.trim();
+          })
+          .filter((namespace: string) => {
+            return namespace.length > 0;
+          });
+        if (parsedNamespaces.length > 0) {
+          query["namespaceKey"] = new Includes(parsedNamespaces);
+        }
+      }
+    }
+
+    if (data.componentType === DashboardComponentType.KubernetesPodList) {
+      PublicDashboardResourceListPolicy.addIncludesFromArgument({
+        query,
+        queryKey: "phase",
+        argumentsObject,
+        argumentKey: "podPhases",
+      });
+    }
+
+    if (data.componentType === DashboardComponentType.KubernetesNodeList) {
+      const readinessFilter: string | undefined =
+        PublicDashboardResourceListPolicy.optionalEnum(
+          argumentsObject,
+          "readinessFilter",
+          ["ready", "not-ready"],
+        );
+      if (readinessFilter === "ready") {
+        query["isReady"] = true;
+      } else if (readinessFilter === "not-ready") {
+        query["isReady"] = false;
+      }
+    }
+
+    return {
+      ...PublicDashboardResourceListPolicy.listDraft({
+        resourceType: "kubernetes-resource",
+        query,
+        sort: {
+          namespaceKey: SortOrder.Ascending,
+          name: SortOrder.Ascending,
+        },
+        argumentsObject,
+      }),
+      attributeToColumn: data.attributeToColumn,
+    };
+  }
+
+  private static buildContainerHostPolicy(data: {
+    argumentsObject: Record<string, unknown>;
+    resourceType: string;
+  }): PolicyDraft {
+    const query: Record<string, unknown> = {};
+    PublicDashboardResourceListPolicy.addCollectorStatusFilter(
+      query,
+      data.argumentsObject,
+    );
+
+    return {
+      ...PublicDashboardResourceListPolicy.listDraft({
+        resourceType: data.resourceType,
+        query,
+        sort: { name: SortOrder.Ascending },
+        argumentsObject: data.argumentsObject,
+      }),
+      attributeToColumn: HOST_NAME_ATTRIBUTE_TO_COLUMN,
+    };
+  }
+
+  private static buildContainerPolicy(data: {
+    argumentsObject: Record<string, unknown>;
+    resourceType: string;
+    hostIdKey: string;
+    storedHostIdsKey: string;
+  }): PolicyDraft {
+    const query: Record<string, unknown> = { kind: "Container" };
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: data.hostIdKey,
+      argumentsObject: data.argumentsObject,
+      argumentKey: data.storedHostIdsKey,
+    });
+
+    const imageName: string | undefined =
+      PublicDashboardResourceListPolicy.optionalString(
+        data.argumentsObject,
+        "imageName",
+        true,
+      );
+    if (imageName) {
+      query["imageName"] = new Search(imageName);
+    }
+
+    return {
+      ...PublicDashboardResourceListPolicy.listDraft({
+        resourceType: data.resourceType,
+        query,
+        sort: { name: SortOrder.Ascending },
+        argumentsObject: data.argumentsObject,
+      }),
+      attributeToColumn: CONTAINER_ATTRIBUTE_TO_COLUMN,
+    };
+  }
+
+  private static buildImagePolicy(data: {
+    argumentsObject: Record<string, unknown>;
+    resourceType: string;
+    hostIdKey: string;
+    storedHostIdsKey: string;
+  }): PolicyDraft {
+    const query: Record<string, unknown> = { kind: "Image" };
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: data.hostIdKey,
+      argumentsObject: data.argumentsObject,
+      argumentKey: data.storedHostIdsKey,
+    });
+
+    const nameSearch: string | undefined =
+      PublicDashboardResourceListPolicy.optionalString(
+        data.argumentsObject,
+        "nameSearch",
+        true,
+      );
+    if (nameSearch) {
+      query["name"] = new Search(nameSearch);
+    }
+
+    return {
+      ...PublicDashboardResourceListPolicy.listDraft({
+        resourceType: data.resourceType,
+        query,
+        sort: { name: SortOrder.Ascending },
+        argumentsObject: data.argumentsObject,
+      }),
+      attributeToColumn: IMAGE_ATTRIBUTE_TO_COLUMN,
+    };
+  }
+
+  private static buildContainerInventoryPolicy(data: {
+    argumentsObject: Record<string, unknown>;
+    resourceType: string;
+    kind: string;
+    hostIdKey: string;
+    storedHostIdsKey: string;
+  }): PolicyDraft {
+    const query: Record<string, unknown> = { kind: data.kind };
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: data.hostIdKey,
+      argumentsObject: data.argumentsObject,
+      argumentKey: data.storedHostIdsKey,
+    });
+
+    return PublicDashboardResourceListPolicy.listDraft({
+      resourceType: data.resourceType,
+      query,
+      sort: { name: SortOrder.Ascending },
+      argumentsObject: data.argumentsObject,
+    });
+  }
+
+  private static buildProxmoxNodePolicy(
+    argumentsObject: Record<string, unknown>,
+  ): PolicyDraft {
+    const query: Record<string, unknown> = { kind: "Node" };
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "proxmoxClusterId",
+      argumentsObject,
+      argumentKey: "proxmoxClusterIds",
+    });
+
+    const statusFilter: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "statusFilter",
+        ["online", "offline"],
+      );
+    if (statusFilter === "online") {
+      query["isUp"] = true;
+    } else if (statusFilter === "offline") {
+      query["isUp"] = false;
+    }
+
+    return {
+      ...PublicDashboardResourceListPolicy.listDraft({
+        resourceType: "proxmox-resource",
+        query,
+        sort: { name: SortOrder.Ascending },
+        argumentsObject,
+      }),
+      attributeToColumn: PROXMOX_NODE_ATTRIBUTE_TO_COLUMN,
+    };
+  }
+
+  private static buildProxmoxGuestPolicy(
+    argumentsObject: Record<string, unknown>,
+  ): PolicyDraft {
+    const query: Record<string, unknown> = { kind: "Guest" };
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "proxmoxClusterId",
+      argumentsObject,
+      argumentKey: "proxmoxClusterIds",
+    });
+
+    const guestType: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "guestTypeFilter",
+        ["qemu", "lxc"],
+      );
+    if (guestType) {
+      query["guestType"] = guestType;
+    }
+
+    const statusFilter: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "statusFilter",
+        ["running", "stopped"],
+      );
+    if (statusFilter === "running") {
+      query["isUp"] = true;
+    } else if (statusFilter === "stopped") {
+      query["isUp"] = false;
+    }
+
+    return PublicDashboardResourceListPolicy.listDraft({
+      resourceType: "proxmox-resource",
+      query,
+      sort: { name: SortOrder.Ascending },
+      argumentsObject,
+    });
+  }
+
+  private static buildCephOsdPolicy(
+    argumentsObject: Record<string, unknown>,
+  ): PolicyDraft {
+    const query: Record<string, unknown> = { kind: "Osd" };
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "cephClusterId",
+      argumentsObject,
+      argumentKey: "cephClusterIds",
+    });
+
+    const stateFilter: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "stateFilter",
+        ["up", "down", "out"],
+      );
+    if (stateFilter === "up") {
+      query["isUp"] = true;
+    } else if (stateFilter === "down") {
+      query["isUp"] = false;
+    } else if (stateFilter === "out") {
+      query["isIn"] = false;
+    }
+
+    return {
+      ...PublicDashboardResourceListPolicy.listDraft({
+        resourceType: "ceph-resource",
+        query,
+        sort: { externalId: SortOrder.Ascending },
+        argumentsObject,
+      }),
+      attributeToColumn: CEPH_OSD_ATTRIBUTE_TO_COLUMN,
+    };
+  }
+
+  private static buildCephPoolPolicy(
+    argumentsObject: Record<string, unknown>,
+  ): PolicyDraft {
+    const query: Record<string, unknown> = { kind: "Pool" };
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "cephClusterId",
+      argumentsObject,
+      argumentKey: "cephClusterIds",
+    });
+
+    return {
+      ...PublicDashboardResourceListPolicy.listDraft({
+        resourceType: "ceph-resource",
+        query,
+        sort: { name: SortOrder.Ascending },
+        argumentsObject,
+      }),
+      attributeToColumn: CEPH_POOL_ATTRIBUTE_TO_COLUMN,
+    };
+  }
+
+  private static buildDockerSwarmNodePolicy(
+    argumentsObject: Record<string, unknown>,
+  ): PolicyDraft {
+    const query: Record<string, unknown> = { kind: "Node" };
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "dockerSwarmClusterId",
+      argumentsObject,
+      argumentKey: "dockerSwarmClusterIds",
+    });
+
+    const role: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "roleFilter",
+        ["manager", "worker"],
+      );
+    if (role) {
+      query["role"] = role;
+    }
+
+    const statusFilter: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "statusFilter",
+        ["ready", "notready"],
+      );
+    if (statusFilter === "ready") {
+      query["isReady"] = true;
+    } else if (statusFilter === "notready") {
+      query["isReady"] = false;
+    }
+
+    return PublicDashboardResourceListPolicy.listDraft({
+      resourceType: "docker-swarm-resource",
+      query,
+      sort: { name: SortOrder.Ascending },
+      argumentsObject,
+    });
+  }
+
+  private static buildDockerSwarmServicePolicy(
+    argumentsObject: Record<string, unknown>,
+  ): PolicyDraft {
+    const query: Record<string, unknown> = { kind: "Service" };
+    PublicDashboardResourceListPolicy.addIncludesFromArgument({
+      query,
+      queryKey: "dockerSwarmClusterId",
+      argumentsObject,
+      argumentKey: "dockerSwarmClusterIds",
+    });
+
+    const serviceMode: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "serviceModeFilter",
+        ["replicated", "global"],
+      );
+    if (serviceMode) {
+      query["serviceMode"] = serviceMode;
+    }
+
+    const statusFilter: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "statusFilter",
+        ["converged", "notconverged"],
+      );
+    if (statusFilter === "converged") {
+      query["isReady"] = true;
+    } else if (statusFilter === "notconverged") {
+      query["isReady"] = false;
+    }
+
+    return PublicDashboardResourceListPolicy.listDraft({
+      resourceType: "docker-swarm-resource",
+      query,
+      sort: { name: SortOrder.Ascending },
+      argumentsObject,
+    });
+  }
+
+  private static buildTracePolicy(data: {
+    argumentsObject: Record<string, unknown>;
+    requestedQuery: unknown;
+  }): PolicyDraft {
+    const query: Record<string, unknown> = {
+      startTime: PublicDashboardResourceListPolicy.requiredTimeRange(
+        data.requestedQuery,
+        "startTime",
+      ),
+    };
+
+    const statusFilter: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        data.argumentsObject,
+        "statusFilter",
+        ["0", "1", "2"],
+      );
+    if (statusFilter !== undefined) {
+      query["statusCode"] = parseInt(statusFilter, 10);
+    }
+
+    return PublicDashboardResourceListPolicy.listDraft({
+      resourceType: "span",
+      query,
+      sort: { startTime: SortOrder.Descending },
+      argumentsObject: data.argumentsObject,
+      fallbackLimit: DEFAULT_TELEMETRY_LIMIT,
+    });
+  }
+
+  private static buildLogPolicy(data: {
+    argumentsObject: Record<string, unknown>;
+    requestedQuery: unknown;
+  }): PolicyDraft {
+    const query: Record<string, unknown> = {
+      time: PublicDashboardResourceListPolicy.requiredTimeRange(
+        data.requestedQuery,
+        "time",
+      ),
+    };
+
+    const severity: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        data.argumentsObject,
+        "severityFilter",
+        ["Trace", "Debug", "Information", "Warning", "Error", "Fatal"],
+      );
+    if (severity) {
+      query["severityText"] = severity;
+    }
+
+    const bodyContains: string | undefined =
+      PublicDashboardResourceListPolicy.optionalString(
+        data.argumentsObject,
+        "bodyContains",
+        true,
+      );
+    if (bodyContains) {
+      query["body"] = bodyContains;
+    }
+
+    const attributeFilterQuery: string | undefined =
+      PublicDashboardResourceListPolicy.optionalString(
+        data.argumentsObject,
+        "attributeFilterQuery",
+        true,
+      );
+    if (attributeFilterQuery) {
+      const parsedFilter: LogFilter = queryStringToFilter(attributeFilterQuery);
+      if (
+        parsedFilter.attributes &&
+        Object.keys(parsedFilter.attributes).length > 0
+      ) {
+        query["attributes"] = parsedFilter.attributes;
+      }
+    }
+
+    return {
+      ...PublicDashboardResourceListPolicy.listDraft({
+        resourceType: "log",
+        query,
+        sort: { time: SortOrder.Descending },
+        argumentsObject: data.argumentsObject,
+        fallbackLimit: DEFAULT_TELEMETRY_LIMIT,
+      }),
+      interpolateAttributeMap: true,
+    };
+  }
+
+  private static listDraft(data: {
+    resourceType: string;
+    query: Record<string, unknown>;
+    sort: JSONObject;
+    argumentsObject: Record<string, unknown>;
+    fallbackLimit?: number | undefined;
+  }): PolicyDraft {
+    return {
+      resourceType: data.resourceType,
+      query: data.query,
+      sort: data.sort,
+      limit: PublicDashboardResourceListPolicy.storedLimit({
+        value: data.argumentsObject["maxRows"],
+        fallback: data.fallbackLimit || DEFAULT_LIST_LIMIT,
+        ceiling: LIMIT_PER_PROJECT,
+      }),
+    };
+  }
+
+  private static addCollectorStatusFilter(
+    query: Record<string, unknown>,
+    argumentsObject: Record<string, unknown>,
+  ): void {
+    const statusFilter: string | undefined =
+      PublicDashboardResourceListPolicy.optionalEnum(
+        argumentsObject,
+        "statusFilter",
+        ["connected", "disconnected"],
+      );
+    if (statusFilter) {
+      query["otelCollectorStatus"] = statusFilter;
+    }
+  }
+
+  private static addIncludesFromArgument(data: {
+    query: Record<string, unknown>;
+    queryKey: string;
+    argumentsObject: Record<string, unknown>;
+    argumentKey: string;
+  }): void {
+    const values: Array<string> | undefined =
+      PublicDashboardResourceListPolicy.optionalStringArray(
+        data.argumentsObject,
+        data.argumentKey,
+      );
+    if (values && values.length > 0) {
+      data.query[data.queryKey] = new Includes(values);
+    }
+  }
+
+  private static optionalStringArray(
+    object: Record<string, unknown>,
+    key: string,
+  ): Array<string> | undefined {
+    const value: unknown = object[key];
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+    if (!Array.isArray(value)) {
+      throw new BadDataException(`Dashboard widget ${key} must be an array.`);
+    }
+
+    const values: Array<string> = [];
+    for (const item of value) {
+      if (typeof item !== "string" || item.length === 0) {
+        throw new BadDataException(
+          `Dashboard widget ${key} contains an invalid value.`,
+        );
+      }
+      values.push(item);
+    }
+    return values;
+  }
+
+  private static optionalString(
+    object: Record<string, unknown>,
+    key: string,
+    trim: boolean,
+  ): string | undefined {
+    const value: unknown = object[key];
+    if (value === undefined || value === null || value === "") {
+      return undefined;
+    }
+    if (typeof value !== "string") {
+      throw new BadDataException(`Dashboard widget ${key} must be a string.`);
+    }
+
+    const normalized: string = trim ? value.trim() : value;
+    return normalized.length > 0 ? normalized : undefined;
+  }
+
+  private static optionalEnum(
+    object: Record<string, unknown>,
+    key: string,
+    allowedValues: Array<string>,
+  ): string | undefined {
+    const value: unknown = object[key];
+    if (value === undefined || value === null || value === "") {
+      return undefined;
+    }
+    if (typeof value !== "string" || !allowedValues.includes(value)) {
+      throw new BadDataException(`Dashboard widget ${key} is invalid.`);
+    }
+    return value;
+  }
+
+  private static storedLimit(data: {
+    value: unknown;
+    fallback: number;
+    ceiling: number;
+  }): number {
+    const parsed: number = Number(
+      typeof data.value === "string" ? data.value.trim() : data.value,
+    );
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      return data.fallback;
+    }
+    return Math.min(Math.floor(parsed), data.ceiling);
+  }
+
+  private static requiredTimeRange(
+    requestedQuery: unknown,
+    key: "time" | "startTime",
+  ): InBetween<Date> {
+    const query: Record<string, unknown> =
+      PublicDashboardResourceListPolicy.requireObject(
+        requestedQuery,
+        "Public dashboard telemetry query",
+      );
+    if (!Object.prototype.hasOwnProperty.call(query, key)) {
+      throw new BadDataException(
+        `Public dashboard telemetry query requires ${key}.`,
+      );
+    }
+
+    const deserialized: JSONValue = JSONFunctions.deserializeValue(
+      query[key] as JSONValue,
+    );
+    if (!(deserialized instanceof InBetween)) {
+      throw new BadDataException(
+        `Public dashboard telemetry ${key} must be an InBetween range.`,
+      );
+    }
+
+    const start: Date = PublicDashboardResourceListPolicy.validDate(
+      deserialized.startValue,
+      key,
+    );
+    const end: Date = PublicDashboardResourceListPolicy.validDate(
+      deserialized.endValue,
+      key,
+    );
+    if (start.getTime() >= end.getTime()) {
+      throw new BadDataException(
+        `Public dashboard telemetry ${key} range is invalid.`,
+      );
+    }
+
+    return new InBetween<Date>(start, end);
+  }
+
+  private static validDate(value: unknown, key: string): Date {
+    if (value instanceof Date && Number.isFinite(value.getTime())) {
+      return new Date(value.getTime());
+    }
+    if (typeof value === "string" && value.length <= 128) {
+      const date: Date = new Date(value);
+      if (Number.isFinite(date.getTime())) {
+        return date;
+      }
+    }
+    throw new BadDataException(
+      `Public dashboard telemetry ${key} range contains an invalid date.`,
+    );
+  }
+
+  private static resolveDashboardVariableSelections(data: {
+    dashboardViewConfig: unknown;
+    requestedVariables: unknown;
+  }): Array<DashboardVariable> {
+    const dashboardViewConfig: Record<string, unknown> =
+      PublicDashboardResourceListPolicy.requireObject(
+        data.dashboardViewConfig,
+        "Dashboard view config",
+      );
+    const storedVariablesValue: unknown = dashboardViewConfig["variables"];
+    const storedVariables: Array<unknown> =
+      storedVariablesValue === undefined || storedVariablesValue === null
+        ? []
+        : Array.isArray(storedVariablesValue)
+          ? storedVariablesValue
+          : (() => {
+              throw new BadDataException(
+                "Dashboard view config variables must be an array.",
+              );
+            })();
+
+    const requestedSelections: Map<
+      string,
+      Record<string, unknown>
+    > = PublicDashboardResourceListPolicy.validateRequestedVariableSelections(
+      data.requestedVariables,
+    );
+    const variables: Array<DashboardVariable> = [];
+    const storedIds: Set<string> = new Set<string>();
+
+    for (const storedValue of storedVariables) {
+      const stored: Record<string, unknown> =
+        PublicDashboardResourceListPolicy.requireObject(
+          storedValue,
+          "Stored dashboard variable",
+        );
+      if (stored["type"] !== DashboardVariableType.TelemetryAttribute) {
+        continue;
+      }
+
+      const id: unknown = stored["id"];
+      const attributeKey: unknown = stored["attributeKey"];
+      if (
+        typeof id !== "string" ||
+        id.length === 0 ||
+        id.length > MAX_VARIABLE_ID_LENGTH ||
+        typeof attributeKey !== "string" ||
+        attributeKey.trim().length === 0 ||
+        attributeKey.length > MAX_VARIABLE_VALUE_LENGTH
+      ) {
+        throw new BadDataException("Stored dashboard variable is malformed.");
+      }
+      if (storedIds.has(id)) {
+        throw new BadDataException("Dashboard variable IDs must be unique.");
+      }
+      storedIds.add(id);
+
+      const isMultiSelect: unknown = stored["isMultiSelect"];
+      if (
+        isMultiSelect !== undefined &&
+        isMultiSelect !== null &&
+        typeof isMultiSelect !== "boolean"
+      ) {
+        throw new BadDataException("Stored dashboard variable is malformed.");
+      }
+
+      const defaultValue: unknown = stored["defaultValue"];
+      if (
+        defaultValue !== undefined &&
+        defaultValue !== null &&
+        (typeof defaultValue !== "string" ||
+          defaultValue.length > MAX_VARIABLE_VALUE_LENGTH)
+      ) {
+        throw new BadDataException("Stored dashboard variable is malformed.");
+      }
+
+      const selection: Record<string, unknown> | undefined =
+        requestedSelections.get(id);
+      const selectedValue: unknown = selection?.["selectedValue"];
+      const selectedValues: unknown = selection?.["selectedValues"];
+      const name: unknown = stored["name"];
+      const storedIsMultiSelect: boolean = isMultiSelect === true;
+
+      variables.push({
+        id,
+        name: typeof name === "string" ? name : "",
+        type: DashboardVariableType.TelemetryAttribute,
+        attributeKey: attributeKey.trim(),
+        isMultiSelect: storedIsMultiSelect,
+        defaultValue:
+          typeof defaultValue === "string" ? defaultValue : undefined,
+        selectedValue:
+          !storedIsMultiSelect && typeof selectedValue === "string"
+            ? selectedValue
+            : undefined,
+        selectedValues:
+          storedIsMultiSelect && Array.isArray(selectedValues)
+            ? (selectedValues as Array<string>)
+            : undefined,
+      });
+    }
+
+    return variables;
+  }
+
+  private static validateRequestedVariableSelections(
+    requestedVariables: unknown,
+  ): Map<string, Record<string, unknown>> {
+    const selections: Map<string, Record<string, unknown>> = new Map<
+      string,
+      Record<string, unknown>
+    >();
+    if (requestedVariables === undefined || requestedVariables === null) {
+      return selections;
+    }
+    if (!Array.isArray(requestedVariables)) {
+      throw new BadDataException(
+        "Public dashboard variable selections must be an array.",
+      );
+    }
+    if (requestedVariables.length > MAX_REQUESTED_VARIABLES) {
+      throw new BadDataException(
+        "Too many public dashboard variable selections.",
+      );
+    }
+
+    let totalSelectedValues: number = 0;
+    for (const requestedValue of requestedVariables) {
+      const requested: Record<string, unknown> =
+        PublicDashboardResourceListPolicy.requireObject(
+          requestedValue,
+          "Public dashboard variable selection",
+        );
+      const id: unknown = requested["id"];
+      if (
+        typeof id !== "string" ||
+        id.length === 0 ||
+        id.length > MAX_VARIABLE_ID_LENGTH
+      ) {
+        throw new BadDataException(
+          "Public dashboard variable selection has an invalid id.",
+        );
+      }
+      if (selections.has(id)) {
+        throw new BadDataException(
+          "Public dashboard variable selections contain a duplicate id.",
+        );
+      }
+
+      const selectedValue: unknown = requested["selectedValue"];
+      if (
+        selectedValue !== undefined &&
+        selectedValue !== null &&
+        (typeof selectedValue !== "string" ||
+          selectedValue.length > MAX_VARIABLE_VALUE_LENGTH)
+      ) {
+        throw new BadDataException(
+          "Public dashboard variable selection has an invalid value.",
+        );
+      }
+
+      const selectedValues: unknown = requested["selectedValues"];
+      if (
+        selectedValues !== undefined &&
+        selectedValues !== null &&
+        !Array.isArray(selectedValues)
+      ) {
+        throw new BadDataException(
+          "Public dashboard variable selection values must be an array.",
+        );
+      }
+      if (
+        Array.isArray(selectedValues) &&
+        selectedValues.length > MAX_SELECTED_VALUES_PER_VARIABLE
+      ) {
+        throw new BadDataException(
+          "Too many values in a public dashboard variable selection.",
+        );
+      }
+
+      if (Array.isArray(selectedValues)) {
+        totalSelectedValues += selectedValues.length;
+        if (totalSelectedValues > MAX_TOTAL_SELECTED_VALUES) {
+          throw new BadDataException(
+            "Too many public dashboard variable selection values.",
+          );
+        }
+        for (const value of selectedValues) {
+          if (
+            typeof value !== "string" ||
+            value.length > MAX_VARIABLE_VALUE_LENGTH
+          ) {
+            throw new BadDataException(
+              "Public dashboard variable selection has an invalid value.",
+            );
+          }
+        }
+      }
+
+      selections.set(id, {
+        selectedValue:
+          typeof selectedValue === "string" ? selectedValue : undefined,
+        selectedValues: Array.isArray(selectedValues)
+          ? (selectedValues as Array<string>)
+          : undefined,
+      });
+    }
+
+    return selections;
+  }
+
+  private static requireObject(
+    value: unknown,
+    label: string,
+  ): Record<string, unknown> {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new BadDataException(`${label} must be an object.`);
+    }
+    return value as Record<string, unknown>;
+  }
+}

--- a/Common/Tests/Server/API/DashboardPublicResourceListAPI.test.ts
+++ b/Common/Tests/Server/API/DashboardPublicResourceListAPI.test.ts
@@ -1,8 +1,8 @@
 import Dashboard from "../../../Models/DatabaseModels/Dashboard";
 import DashboardAPI from "../../../Server/API/DashboardAPI";
-import DashboardService from "../../../Server/Services/DashboardService";
 import AlertService from "../../../Server/Services/AlertService";
 import CephResourceService from "../../../Server/Services/CephResourceService";
+import DashboardService from "../../../Server/Services/DashboardService";
 import DockerHostService from "../../../Server/Services/DockerHostService";
 import DockerResourceService from "../../../Server/Services/DockerResourceService";
 import DockerSwarmResourceService from "../../../Server/Services/DockerSwarmResourceService";
@@ -16,20 +16,25 @@ import PodmanHostService from "../../../Server/Services/PodmanHostService";
 import PodmanResourceService from "../../../Server/Services/PodmanResourceService";
 import ProxmoxResourceService from "../../../Server/Services/ProxmoxResourceService";
 import SpanService from "../../../Server/Services/SpanService";
+import PublicDashboardResourceListPolicy, {
+  BuildPublicDashboardResourceListPolicyData,
+  PublicDashboardResourceListPolicyResult,
+} from "../../../Server/Utils/Dashboard/PublicDashboardResourceListPolicy";
 import {
   ExpressRequest,
   ExpressResponse,
   NextFunction,
 } from "../../../Server/Utils/Express";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
 import Includes from "../../../Types/BaseDatabase/Includes";
 import SortOrder from "../../../Types/BaseDatabase/SortOrder";
 import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
 import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
-import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import { DashboardVariableType } from "../../../Types/Dashboard/DashboardVariable";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import NotAuthenticatedException from "../../../Types/Exception/NotAuthenticatedException";
 import NotFoundException from "../../../Types/Exception/NotFoundException";
-import { JSONObject } from "../../../Types/JSON";
+import { JSONObject, JSONValue } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
 import { mockRouter } from "./Helpers";
 import {
@@ -40,6 +45,7 @@ import {
   expect,
   it,
 } from "@jest/globals";
+import { FindOperator } from "typeorm";
 
 jest.mock("../../../Server/Utils/Express", () => {
   return {
@@ -70,419 +76,221 @@ jest.mock("../../../Server/Utils/Response", () => {
 const RESOURCE_LIST_ROUTE: string =
   "/dashboard/resource-list/:dashboardId/:resourceType";
 
-/*
- * Structural view of the model services the registry lists through — just
- * enough to spy on findBy and read back the arguments the API handed it.
- */
 type ListService = {
   findBy: (findBy: never) => Promise<Array<unknown>>;
 };
 
-/*
- * Every public resource type, the widget that unlocks it, the `kind` that
- * widget renders, one filter the widget legitimately sends, one the widget
- * never sends (and which therefore must be dropped), a column of the fixed
- * select (sortable) and a column outside it (never sortable).
- */
-interface ResourceCase {
+interface BuiltWidget {
+  widget: JSONObject;
+  componentId: ObjectID;
+}
+
+interface BuildWidgetData {
+  componentType: DashboardComponentType;
+  argumentsObject?: JSONObject | undefined;
+  componentId?: ObjectID | undefined;
+  storedIdShape?: "object" | "string" | "serialized" | undefined;
+}
+
+interface CallRouteData {
+  resourceType: string;
+  body?: JSONObject | undefined;
+  query?: JSONObject | undefined;
+}
+
+interface ResourceRouteCase {
   resourceType: string;
   componentType: DashboardComponentType;
   service: ListService;
   kind: string | null;
-  allowedQueryKey: string;
-  forbiddenQueryKey: string;
-  selectColumn: string;
-  nonSelectColumn: string;
-  selectKeys: Array<string>;
 }
 
-const RESOURCE_CASES: Array<ResourceCase> = [
+const RESOURCE_ROUTE_CASES: Array<ResourceRouteCase> = [
   {
     resourceType: "incident",
     componentType: DashboardComponentType.IncidentList,
     service: IncidentService,
     kind: null,
-    allowedQueryKey: "incidentSeverityId",
-    forbiddenQueryKey: "description",
-    selectColumn: "createdAt",
-    nonSelectColumn: "description",
-    selectKeys: [
-      "_id",
-      "title",
-      "createdAt",
-      "currentIncidentState",
-      "incidentSeverity",
-    ],
   },
   {
     resourceType: "alert",
     componentType: DashboardComponentType.AlertList,
     service: AlertService,
     kind: null,
-    allowedQueryKey: "alertSeverityId",
-    forbiddenQueryKey: "description",
-    selectColumn: "createdAt",
-    nonSelectColumn: "description",
-    selectKeys: [
-      "_id",
-      "title",
-      "createdAt",
-      "currentAlertState",
-      "alertSeverity",
-    ],
   },
   {
     resourceType: "monitor",
     componentType: DashboardComponentType.MonitorList,
     service: MonitorService,
     kind: null,
-    allowedQueryKey: "monitorType",
-    forbiddenQueryKey: "monitorSteps",
-    selectColumn: "name",
-    nonSelectColumn: "monitorSteps",
-    selectKeys: ["_id", "name", "monitorType", "currentMonitorStatus"],
   },
   {
-    /*
-     * The Network Map draws a FLAT set of pins, so the hierarchy columns
-     * (parentSiteId, materializedPath, depth) are deliberately outside both
-     * the allowlist and the select — structure an anonymous viewer would be
-     * able to walk but the map never shows them.
-     */
     resourceType: "network-site",
     componentType: DashboardComponentType.NetworkMap,
     service: NetworkSiteService,
     kind: null,
-    allowedQueryKey: "networkSiteTypeId",
-    forbiddenQueryKey: "parentSiteId",
-    selectColumn: "name",
-    nonSelectColumn: "address",
-    selectKeys: [
-      "_id",
-      "name",
-      "networkSiteType",
-      "latitude",
-      "longitude",
-      "currentMonitorStatus",
-    ],
   },
   {
     resourceType: "host",
     componentType: DashboardComponentType.HostList,
     service: HostService,
     kind: null,
-    allowedQueryKey: "otelCollectorStatus",
-    forbiddenQueryKey: "createdAt",
-    selectColumn: "name",
-    nonSelectColumn: "createdAt",
-    selectKeys: [
-      "_id",
-      "name",
-      "hostIdentifier",
-      "otelCollectorStatus",
-      "osType",
-      "osVersion",
-      "cpuCores",
-      "totalMemoryBytes",
-      "lastSeenAt",
-    ],
   },
   {
     resourceType: "kubernetes-resource",
     componentType: DashboardComponentType.KubernetesPodList,
     service: KubernetesResourceService,
     kind: "Pod",
-    allowedQueryKey: "namespaceKey",
-    forbiddenQueryKey: "createdAt",
-    selectColumn: "name",
-    nonSelectColumn: "createdAt",
-    selectKeys: [
-      "_id",
-      "name",
-      "namespaceKey",
-      "kind",
-      "phase",
-      "isReady",
-      "hasMemoryPressure",
-      "hasDiskPressure",
-      "hasPidPressure",
-      "containerCount",
-      "latestCpuPercent",
-      "latestMemoryBytes",
-      "controllerDeploymentName",
-      "controllerCronJobName",
-      "resourceCreationTimestamp",
-      "lastSeenAt",
-      "kubernetesClusterId",
-      "kubernetesCluster",
-    ],
+  },
+  {
+    resourceType: "kubernetes-resource",
+    componentType: DashboardComponentType.KubernetesNodeList,
+    service: KubernetesResourceService,
+    kind: "Node",
+  },
+  {
+    resourceType: "kubernetes-resource",
+    componentType: DashboardComponentType.KubernetesNamespaceList,
+    service: KubernetesResourceService,
+    kind: "Namespace",
+  },
+  {
+    resourceType: "kubernetes-resource",
+    componentType: DashboardComponentType.KubernetesDeploymentList,
+    service: KubernetesResourceService,
+    kind: "Deployment",
+  },
+  {
+    resourceType: "kubernetes-resource",
+    componentType: DashboardComponentType.KubernetesStatefulSetList,
+    service: KubernetesResourceService,
+    kind: "StatefulSet",
+  },
+  {
+    resourceType: "kubernetes-resource",
+    componentType: DashboardComponentType.KubernetesDaemonSetList,
+    service: KubernetesResourceService,
+    kind: "DaemonSet",
+  },
+  {
+    resourceType: "kubernetes-resource",
+    componentType: DashboardComponentType.KubernetesJobList,
+    service: KubernetesResourceService,
+    kind: "Job",
+  },
+  {
+    resourceType: "kubernetes-resource",
+    componentType: DashboardComponentType.KubernetesCronJobList,
+    service: KubernetesResourceService,
+    kind: "CronJob",
   },
   {
     resourceType: "docker-host",
     componentType: DashboardComponentType.DockerHostList,
     service: DockerHostService,
     kind: null,
-    allowedQueryKey: "otelCollectorStatus",
-    forbiddenQueryKey: "createdAt",
-    selectColumn: "name",
-    nonSelectColumn: "createdAt",
-    selectKeys: [
-      "_id",
-      "name",
-      "otelCollectorStatus",
-      "containersRunning",
-      "containersStopped",
-      "containersPaused",
-      "osType",
-      "osVersion",
-    ],
   },
   {
     resourceType: "docker-container",
     componentType: DashboardComponentType.DockerContainerList,
     service: DockerResourceService,
     kind: "Container",
-    allowedQueryKey: "imageName",
-    forbiddenQueryKey: "createdAt",
-    selectColumn: "name",
-    nonSelectColumn: "createdAt",
-    selectKeys: [
-      "_id",
-      "name",
-      "imageName",
-      "state",
-      "latestCpuPercent",
-      "latestMemoryBytes",
-      "dockerHostId",
-      "dockerHost",
-    ],
   },
   {
     resourceType: "docker-image",
     componentType: DashboardComponentType.DockerImageList,
     service: DockerResourceService,
     kind: "Image",
-    allowedQueryKey: "dockerHostId",
-    forbiddenQueryKey: "state",
-    selectColumn: "name",
-    nonSelectColumn: "state",
-    selectKeys: ["_id", "name", "containerId", "dockerHostId", "dockerHost"],
   },
   {
     resourceType: "docker-network",
     componentType: DashboardComponentType.DockerNetworkList,
     service: DockerResourceService,
     kind: "Network",
-    allowedQueryKey: "dockerHostId",
-    forbiddenQueryKey: "imageName",
-    selectColumn: "name",
-    nonSelectColumn: "imageName",
-    selectKeys: ["_id", "name", "state", "dockerHostId", "dockerHost"],
   },
   {
     resourceType: "docker-volume",
     componentType: DashboardComponentType.DockerVolumeList,
     service: DockerResourceService,
     kind: "Volume",
-    allowedQueryKey: "dockerHostId",
-    forbiddenQueryKey: "imageName",
-    selectColumn: "name",
-    nonSelectColumn: "imageName",
-    selectKeys: ["_id", "name", "state", "dockerHostId", "dockerHost"],
   },
   {
     resourceType: "podman-host",
     componentType: DashboardComponentType.PodmanHostList,
     service: PodmanHostService,
     kind: null,
-    allowedQueryKey: "otelCollectorStatus",
-    forbiddenQueryKey: "createdAt",
-    selectColumn: "name",
-    nonSelectColumn: "createdAt",
-    selectKeys: [
-      "_id",
-      "name",
-      "otelCollectorStatus",
-      "containersRunning",
-      "containersStopped",
-      "containersPaused",
-      "osType",
-      "osVersion",
-    ],
   },
   {
     resourceType: "podman-container",
     componentType: DashboardComponentType.PodmanContainerList,
     service: PodmanResourceService,
     kind: "Container",
-    allowedQueryKey: "imageName",
-    forbiddenQueryKey: "createdAt",
-    selectColumn: "name",
-    nonSelectColumn: "createdAt",
-    selectKeys: [
-      "_id",
-      "name",
-      "imageName",
-      "state",
-      "latestCpuPercent",
-      "latestMemoryBytes",
-      "podmanHostId",
-      "podmanHost",
-    ],
   },
   {
     resourceType: "podman-image",
     componentType: DashboardComponentType.PodmanImageList,
     service: PodmanResourceService,
     kind: "Image",
-    allowedQueryKey: "podmanHostId",
-    forbiddenQueryKey: "state",
-    selectColumn: "name",
-    nonSelectColumn: "state",
-    selectKeys: ["_id", "name", "containerId", "podmanHostId", "podmanHost"],
   },
   {
     resourceType: "podman-network",
     componentType: DashboardComponentType.PodmanNetworkList,
     service: PodmanResourceService,
     kind: "Network",
-    allowedQueryKey: "podmanHostId",
-    forbiddenQueryKey: "imageName",
-    selectColumn: "name",
-    nonSelectColumn: "imageName",
-    selectKeys: ["_id", "name", "state", "podmanHostId", "podmanHost"],
   },
   {
     resourceType: "podman-volume",
     componentType: DashboardComponentType.PodmanVolumeList,
     service: PodmanResourceService,
     kind: "Volume",
-    allowedQueryKey: "podmanHostId",
-    forbiddenQueryKey: "imageName",
-    selectColumn: "name",
-    nonSelectColumn: "imageName",
-    selectKeys: ["_id", "name", "state", "podmanHostId", "podmanHost"],
   },
   {
     resourceType: "proxmox-resource",
     componentType: DashboardComponentType.ProxmoxNodeList,
     service: ProxmoxResourceService,
     kind: "Node",
-    allowedQueryKey: "proxmoxClusterId",
-    forbiddenQueryKey: "createdAt",
-    selectColumn: "name",
-    nonSelectColumn: "createdAt",
-    selectKeys: [
-      "_id",
-      "name",
-      "externalId",
-      "kind",
-      "vmid",
-      "guestType",
-      "parentNodeName",
-      "isUp",
-      "haState",
-      "latestCpuPercent",
-      "latestMemoryPercent",
-      "lastSeenAt",
-      "proxmoxClusterId",
-      "proxmoxCluster",
-    ],
+  },
+  {
+    resourceType: "proxmox-resource",
+    componentType: DashboardComponentType.ProxmoxGuestList,
+    service: ProxmoxResourceService,
+    kind: "Guest",
   },
   {
     resourceType: "ceph-resource",
     componentType: DashboardComponentType.CephOsdList,
     service: CephResourceService,
     kind: "Osd",
-    allowedQueryKey: "cephClusterId",
-    forbiddenQueryKey: "createdAt",
-    selectColumn: "externalId",
-    nonSelectColumn: "createdAt",
-    selectKeys: [
-      "_id",
-      "name",
-      "externalId",
-      "kind",
-      "hostname",
-      "deviceClass",
-      "isUp",
-      "isIn",
-      "statBytes",
-      "statBytesUsed",
-      "storedBytes",
-      "maxAvailBytes",
-      "objects",
-      "lastSeenAt",
-      "cephClusterId",
-      "cephCluster",
-    ],
+  },
+  {
+    resourceType: "ceph-resource",
+    componentType: DashboardComponentType.CephPoolList,
+    service: CephResourceService,
+    kind: "Pool",
   },
   {
     resourceType: "docker-swarm-resource",
     componentType: DashboardComponentType.DockerSwarmNodeList,
     service: DockerSwarmResourceService,
     kind: "Node",
-    allowedQueryKey: "role",
-    forbiddenQueryKey: "createdAt",
-    selectColumn: "name",
-    nonSelectColumn: "createdAt",
-    selectKeys: [
-      "_id",
-      "name",
-      "externalId",
-      "kind",
-      "role",
-      "state",
-      "serviceMode",
-      "desiredReplicas",
-      "runningReplicas",
-      "image",
-      "isReady",
-      "latestCpuPercent",
-      "latestMemoryPercent",
-      "lastSeenAt",
-      "dockerSwarmClusterId",
-      "dockerSwarmCluster",
-    ],
+  },
+  {
+    resourceType: "docker-swarm-resource",
+    componentType: DashboardComponentType.DockerSwarmServiceList,
+    service: DockerSwarmResourceService,
+    kind: "Service",
   },
   {
     resourceType: "span",
     componentType: DashboardComponentType.TraceList,
     service: SpanService,
     kind: null,
-    allowedQueryKey: "statusCode",
-    forbiddenQueryKey: "traceId",
-    selectColumn: "startTime",
-    nonSelectColumn: "attributes",
-    selectKeys: [
-      "startTime",
-      "name",
-      "statusCode",
-      "durationUnixNano",
-      "traceId",
-      "spanId",
-      "kind",
-      "primaryEntityId",
-    ],
   },
   {
     resourceType: "log",
     componentType: DashboardComponentType.LogStream,
     service: LogService,
     kind: null,
-    allowedQueryKey: "severityText",
-    forbiddenQueryKey: "traceId",
-    selectColumn: "time",
-    nonSelectColumn: "severityNumber",
-    selectKeys: [
-      "time",
-      "severityText",
-      "body",
-      "primaryEntityId",
-      "traceId",
-      "spanId",
-      "attributes",
-    ],
   },
 ];
 
@@ -516,54 +324,68 @@ describe("DashboardAPI public resource-list", () => {
     new DashboardAPI();
   });
 
-  type BuildViewConfigFunction = (
-    componentTypes: Array<string>,
-  ) => DashboardViewConfig;
+  const buildWidget: (data: BuildWidgetData) => BuiltWidget = (
+    data: BuildWidgetData,
+  ): BuiltWidget => {
+    const componentId: ObjectID = data.componentId || ObjectID.generate();
+    let storedComponentId: JSONValue = componentId;
 
-  const buildViewConfig: BuildViewConfigFunction = (
-    componentTypes: Array<string>,
-  ): DashboardViewConfig => {
+    if (data.storedIdShape === "string") {
+      storedComponentId = componentId.toString();
+    } else if (data.storedIdShape === "serialized") {
+      storedComponentId = componentId.toJSON();
+    }
+
     return {
+      componentId,
+      widget: {
+        _type: "DashboardComponent",
+        componentId: storedComponentId,
+        componentType: data.componentType,
+        topInDashboardUnits: 0,
+        leftInDashboardUnits: 0,
+        widthInDashboardUnits: 12,
+        heightInDashboardUnits: 6,
+        minWidthInDashboardUnits: 1,
+        minHeightInDashboardUnits: 1,
+        arguments: data.argumentsObject || {},
+      },
+    };
+  };
+
+  const setDashboardWidgets: (
+    widgets: Array<JSONObject>,
+    variables?: Array<JSONObject>,
+  ) => void = (
+    widgets: Array<JSONObject>,
+    variables?: Array<JSONObject>,
+  ): void => {
+    dashboard.dashboardViewConfig = {
       _type: "DashboardViewConfig",
       heightInDashboardUnits: 24,
-      components: componentTypes.map(
-        (componentType: string, index: number): JSONObject => {
-          return {
-            _type: "DashboardComponent",
-            componentId: ObjectID.generate().toString(),
-            componentType: componentType,
-            topInDashboardUnits: index,
-            leftInDashboardUnits: 0,
-            widthInDashboardUnits: 12,
-            heightInDashboardUnits: 6,
-            minWidthInDashboardUnits: 1,
-            minHeightInDashboardUnits: 1,
-            arguments: {},
-          };
-        },
-      ),
+      components: widgets,
+      ...(variables ? { variables } : {}),
     } as unknown as DashboardViewConfig;
   };
 
-  type SetDashboardWidgetsFunction = (componentTypes: Array<string>) => void;
+  const telemetryQuery: (resourceType: string) => JSONObject = (
+    resourceType: string,
+  ): JSONObject => {
+    const start: Date = new Date("2026-08-09T10:00:00.000Z");
+    const end: Date = new Date("2026-08-09T11:00:00.000Z");
 
-  const setDashboardWidgets: SetDashboardWidgetsFunction = (
-    componentTypes: Array<string>,
-  ): void => {
-    dashboard.dashboardViewConfig = buildViewConfig(componentTypes);
+    if (resourceType === "log") {
+      return { time: new InBetween<Date>(start, end).toJSON() };
+    }
+    if (resourceType === "span") {
+      return { startTime: new InBetween<Date>(start, end).toJSON() };
+    }
+    return {};
   };
 
-  type CallRouteFunction = (data: {
-    resourceType: string;
-    body?: JSONObject;
-    query?: JSONObject;
-  }) => Promise<void>;
-
-  const callRoute: CallRouteFunction = async (data: {
-    resourceType: string;
-    body?: JSONObject;
-    query?: JSONObject;
-  }): Promise<void> => {
+  const callRoute: (data: CallRouteData) => Promise<void> = async (
+    data: CallRouteData,
+  ): Promise<void> => {
     const request: ExpressRequest = {
       params: {
         dashboardId: dashboardId.toString(),
@@ -582,33 +404,25 @@ describe("DashboardAPI public resource-list", () => {
       .handlerFunction(request, mockResponse, nextFunction);
   };
 
-  type GetFindByArgsFunction = (service: ListService) => JSONObject;
-
-  const getFindByArgs: GetFindByArgsFunction = (
+  const getFindByArgs: (service: ListService) => JSONObject = (
     service: ListService,
   ): JSONObject => {
     const calls: Array<Array<unknown>> = (service.findBy as jest.Mock).mock
       .calls as Array<Array<unknown>>;
 
     expect(calls.length).toBe(1);
-
     return calls[0]![0] as JSONObject;
   };
 
-  type GetThrownErrorFunction = () => unknown;
-
-  const getThrownError: GetThrownErrorFunction = (): unknown => {
+  const getThrownError: () => unknown = (): unknown => {
     const calls: Array<Array<unknown>> = (nextFunction as jest.Mock).mock
       .calls as Array<Array<unknown>>;
 
     expect(calls.length).toBe(1);
-
     return calls[0]![0];
   };
 
-  type ExpectNothingListedFunction = () => void;
-
-  const expectNothingListed: ExpectNothingListedFunction = (): void => {
+  const expectNothingListed: () => void = (): void => {
     for (const service of ALL_SERVICES) {
       expect(service.findBy).not.toHaveBeenCalled();
     }
@@ -619,7 +433,6 @@ describe("DashboardAPI public resource-list", () => {
 
     dashboardId = ObjectID.generate();
     projectId = ObjectID.generate();
-
     dashboard = new Dashboard();
     dashboard.id = dashboardId;
     dashboard.projectId = projectId;
@@ -644,7 +457,6 @@ describe("DashboardAPI public resource-list", () => {
       json: jest.fn(),
       status: jest.fn().mockReturnThis(),
     } as unknown as ExpressResponse;
-
     nextFunction = jest.fn();
   });
 
@@ -652,662 +464,612 @@ describe("DashboardAPI public resource-list", () => {
     jest.restoreAllMocks();
   });
 
-  describe("widget allowlist (GHSA-qv79-j844-cc7m)", () => {
-    it("refuses to stream a project's logs from a dashboard that has no log widget", async () => {
-      // The advisory's proof of concept: a metrics-only public dashboard.
-      setDashboardWidgets([
-        DashboardComponentType.Chart,
-        DashboardComponentType.Text,
-      ]);
+  describe("exact widget authorization (GHSA-qv79-j844-cc7m)", () => {
+    it("serves every registered widget only through its own resource policy", async () => {
+      for (const routeCase of RESOURCE_ROUTE_CASES) {
+        jest.clearAllMocks();
+        const { widget, componentId } = buildWidget({
+          componentType: routeCase.componentType,
+        });
+        setDashboardWidgets([widget]);
+
+        await callRoute({
+          resourceType: routeCase.resourceType,
+          body: {
+            componentId: componentId.toString(),
+            query: telemetryQuery(routeCase.resourceType),
+          },
+        });
+
+        expect(nextFunction).not.toHaveBeenCalled();
+        const findByArgs: JSONObject = getFindByArgs(routeCase.service);
+        const query: JSONObject = findByArgs["query"] as JSONObject;
+
+        expect(query["projectId"]).toBe(projectId);
+        if (routeCase.kind) {
+          expect(query["kind"]).toBe(routeCase.kind);
+        }
+        const expectedSelect: JSONObject =
+          PublicDashboardResourceListPolicy.build({
+            widget,
+            dashboardViewConfig: dashboard.dashboardViewConfig,
+            requestedVariables: [],
+            requestedQuery: telemetryQuery(routeCase.resourceType),
+          }).select;
+        expect(findByArgs["select"]).toEqual(expectedSelect);
+        expect(findByArgs["skip"]).toBe(0);
+      }
+    });
+
+    it("does not return sibling-only Proxmox or Swarm fields", async () => {
+      const cases: Array<{
+        resourceType: string;
+        componentType: DashboardComponentType;
+        service: ListService;
+        included: string;
+        excluded: string;
+      }> = [
+        {
+          resourceType: "proxmox-resource",
+          componentType: DashboardComponentType.ProxmoxGuestList,
+          service: ProxmoxResourceService,
+          included: "vmid",
+          excluded: "latestCpuPercent",
+        },
+        {
+          resourceType: "proxmox-resource",
+          componentType: DashboardComponentType.ProxmoxNodeList,
+          service: ProxmoxResourceService,
+          included: "latestCpuPercent",
+          excluded: "vmid",
+        },
+        {
+          resourceType: "docker-swarm-resource",
+          componentType: DashboardComponentType.DockerSwarmServiceList,
+          service: DockerSwarmResourceService,
+          included: "desiredReplicas",
+          excluded: "latestCpuPercent",
+        },
+        {
+          resourceType: "docker-swarm-resource",
+          componentType: DashboardComponentType.DockerSwarmNodeList,
+          service: DockerSwarmResourceService,
+          included: "latestCpuPercent",
+          excluded: "desiredReplicas",
+        },
+      ];
+
+      for (const testCase of cases) {
+        jest.clearAllMocks();
+        const selectedWidget: BuiltWidget = buildWidget({
+          componentType: testCase.componentType,
+        });
+        setDashboardWidgets([selectedWidget.widget]);
+
+        await callRoute({
+          resourceType: testCase.resourceType,
+          body: { componentId: selectedWidget.componentId.toString() },
+        });
+
+        const select: JSONObject = getFindByArgs(testCase.service)[
+          "select"
+        ] as JSONObject;
+        expect(select[testCase.included]).toBe(true);
+        expect(select[testCase.excluded]).toBeUndefined();
+      }
+    });
+
+    it("fails closed when the dashboard has no matching top-level widget", async () => {
+      const monitor: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.MonitorList,
+        argumentsObject: {
+          nestedImpostor: buildWidget({
+            componentType: DashboardComponentType.LogStream,
+          }).widget,
+        },
+      });
+      setDashboardWidgets([monitor.widget]);
+
+      await callRoute({
+        resourceType: "log",
+        body: { query: telemetryQuery("log") },
+      });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+      expectNothingListed();
+    });
+
+    it("auto-binds only when exactly one widget matches the resource", async () => {
+      const log: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+        argumentsObject: { severityFilter: "Error" },
+      });
+      const monitor: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.MonitorList,
+      });
+      setDashboardWidgets([log.widget, monitor.widget]);
+
+      await callRoute({
+        resourceType: "log",
+        body: { query: telemetryQuery("log") },
+      });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(
+        (getFindByArgs(LogService)["query"] as JSONObject)["severityText"],
+      ).toBe("Error");
+    });
+
+    it("requires componentId when several matching widgets have different policies", async () => {
+      const first: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+        argumentsObject: { severityFilter: "Error" },
+      });
+      const second: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+        argumentsObject: { severityFilter: "Warning" },
+      });
+      setDashboardWidgets([first.widget, second.widget]);
+
+      await callRoute({
+        resourceType: "log",
+        body: { query: telemetryQuery("log") },
+      });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+      expectNothingListed();
+    });
+
+    it("uses the exact selected widget when several widgets share a resource", async () => {
+      const first: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+        argumentsObject: { severityFilter: "Error" },
+      });
+      const second: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+        argumentsObject: { severityFilter: "Warning" },
+      });
+      setDashboardWidgets([first.widget, second.widget]);
 
       await callRoute({
         resourceType: "log",
         body: {
+          componentId: second.componentId.toString(),
           query: {
-            severityText: "Error",
+            ...telemetryQuery("log"),
+            severityText: "Debug",
           },
         },
       });
 
-      const error: unknown = getThrownError();
+      const query: JSONObject = getFindByArgs(LogService)[
+        "query"
+      ] as JSONObject;
+      expect(query["severityText"]).toBe("Warning");
+    });
 
-      expect(error).toBeInstanceOf(BadDataException);
-      expect((error as BadDataException).message).toBe(
-        "This resource is not part of this dashboard.",
-      );
+    it("rejects a componentId belonging to a different resource", async () => {
+      const log: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+      });
+      const monitor: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.MonitorList,
+      });
+      setDashboardWidgets([log.widget, monitor.widget]);
+
+      await callRoute({
+        resourceType: "log",
+        body: {
+          componentId: monitor.componentId.toString(),
+          query: telemetryQuery("log"),
+        },
+      });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
       expectNothingListed();
     });
 
-    it("refuses to list incidents from a dashboard that only shows monitors", async () => {
-      setDashboardWidgets([DashboardComponentType.MonitorList]);
+    it("requires the requested componentId to be a string UUID", async () => {
+      const log: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+      });
+      setDashboardWidgets([log.widget]);
 
-      await callRoute({ resourceType: "incident" });
-
-      expect(getThrownError()).toBeInstanceOf(BadDataException);
-      expect(IncidentService.findBy).not.toHaveBeenCalled();
-    });
-
-    it("refuses every resource type on a dashboard with no widgets at all", async () => {
-      for (const resourceCase of RESOURCE_CASES) {
+      const invalidIds: Array<JSONValue> = [
+        42,
+        [],
+        {},
+        "not-a-uuid",
+        ObjectID.generate().toJSON(),
+      ];
+      for (const invalidId of invalidIds) {
         jest.clearAllMocks();
-        setDashboardWidgets([]);
-
-        await callRoute({ resourceType: resourceCase.resourceType });
+        await callRoute({
+          resourceType: "log",
+          body: {
+            componentId: invalidId,
+            query: telemetryQuery("log"),
+          },
+        });
 
         expect(getThrownError()).toBeInstanceOf(BadDataException);
         expectNothingListed();
       }
     });
 
-    it("refuses every resource type when the stored view config is missing or malformed", async () => {
+    it("matches legacy stored ObjectID, string, and serialized ID shapes", async () => {
+      const storedIdShapes: Array<"object" | "string" | "serialized"> = [
+        "object",
+        "string",
+        "serialized",
+      ];
+
+      for (const storedIdShape of storedIdShapes) {
+        jest.clearAllMocks();
+        const log: BuiltWidget = buildWidget({
+          componentType: DashboardComponentType.LogStream,
+          storedIdShape,
+        });
+        setDashboardWidgets([log.widget]);
+
+        await callRoute({
+          resourceType: "log",
+          body: {
+            componentId: log.componentId.toString(),
+            query: telemetryQuery("log"),
+          },
+        });
+
+        expect(nextFunction).not.toHaveBeenCalled();
+        expect(LogService.findBy).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it("rejects malformed view configs and unsupported resource types", async () => {
       const malformedConfigs: Array<unknown> = [
         null,
-        undefined,
         "not-an-object",
-        42,
         {},
         { components: null },
-        { components: "not-an-array" },
-        { components: [null, 7, "widget"] },
-        { components: [{ componentType: 123 }] },
-        { components: [{ componentType: "" }] },
+        { components: [null, 7, { componentType: 123 }] },
       ];
 
       for (const config of malformedConfigs) {
         jest.clearAllMocks();
         dashboard.dashboardViewConfig = config as DashboardViewConfig;
-
         await callRoute({ resourceType: "log" });
-
         expect(getThrownError()).toBeInstanceOf(BadDataException);
         expectNothingListed();
       }
-    });
 
-    it("serves each resource type once its own widget is on the dashboard", async () => {
-      for (const resourceCase of RESOURCE_CASES) {
-        jest.clearAllMocks();
-        setDashboardWidgets([resourceCase.componentType]);
-
-        await callRoute({ resourceType: resourceCase.resourceType });
-
-        expect(nextFunction).not.toHaveBeenCalled();
-        expect(resourceCase.service.findBy).toHaveBeenCalledTimes(1);
-      }
-    });
-
-    it("does not let one widget unlock a sibling resource served by the same model", async () => {
-      // A Docker volume list must not become a Docker container reader.
-      setDashboardWidgets([DashboardComponentType.DockerVolumeList]);
-
-      await callRoute({ resourceType: "docker-container" });
-
-      expect(getThrownError()).toBeInstanceOf(BadDataException);
-      expect(DockerResourceService.findBy).not.toHaveBeenCalled();
-    });
-
-    it("rejects a resource type that is not in the registry at all", async () => {
-      setDashboardWidgets([DashboardComponentType.LogStream]);
-
+      jest.clearAllMocks();
+      setDashboardWidgets([]);
       await callRoute({ resourceType: "user" });
-
-      const error: unknown = getThrownError();
-
-      expect(error).toBeInstanceOf(BadDataException);
-      expect((error as BadDataException).message).toBe(
-        "Unsupported dashboard resource type: user",
-      );
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
       expectNothingListed();
     });
   });
 
-  describe("authorization", () => {
-    it("rejects a dashboard that is not public before reading anything", async () => {
-      dashboard.isPublicDashboard = false;
-      setDashboardWidgets([DashboardComponentType.LogStream]);
+  describe("server-owned query policy", () => {
+    it("rebuilds log filters, sort, limit, skip, and select from stored policy", async () => {
+      const log: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+        argumentsObject: {
+          severityFilter: "Error",
+          bodyContains: "timeout",
+          attributeFilterQuery: "@service.name:api",
+          maxRows: 13,
+        },
+      });
+      setDashboardWidgets([log.widget]);
 
-      await callRoute({ resourceType: "log" });
+      await callRoute({
+        resourceType: "log",
+        body: {
+          componentId: log.componentId.toString(),
+          query: {
+            ...telemetryQuery("log"),
+            severityText: "Debug",
+            body: "",
+            attributes: {},
+            projectId: ObjectID.generate().toString(),
+          },
+          sort: { severityText: SortOrder.Ascending },
+          select: { severityNumber: true, password: true },
+          limit: 9999,
+          skip: 9999,
+        },
+        query: { limit: "9999", skip: "9999" },
+      });
 
-      expect(getThrownError()).toBeInstanceOf(NotAuthenticatedException);
+      const findByArgs: JSONObject = getFindByArgs(LogService);
+      const query: JSONObject = findByArgs["query"] as JSONObject;
+
+      expect(query["projectId"]).toBe(projectId);
+      expect(query["severityText"]).toBe("Error");
+      expect(query["body"]).toBe("timeout");
+      expect((query["attributes"] as JSONObject)["service.name"]).toBe("api");
+      expect(query["time"]).toBeInstanceOf(InBetween);
+      expect(findByArgs["sort"]).toEqual({
+        time: SortOrder.Descending,
+      });
+      expect(findByArgs["limit"]).toBe(13);
+      expect(findByArgs["skip"]).toBe(0);
+      expect(findByArgs["select"]).toEqual({
+        time: true,
+        severityText: true,
+        body: true,
+      });
+    });
+
+    it("does not let omitted or changed request filters widen stored incident policy", async () => {
+      const severityId: ObjectID = ObjectID.generate();
+      const incident: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.IncidentList,
+        argumentsObject: {
+          stateFilter: "unresolved",
+          severityIds: [severityId.toString()],
+          maxRows: 9,
+        },
+      });
+      setDashboardWidgets([incident.widget]);
+
+      await callRoute({
+        resourceType: "incident",
+        body: {
+          componentId: incident.componentId.toString(),
+          query: {
+            currentIncidentState: { isResolvedState: true },
+            incidentSeverityId: [],
+          },
+        },
+      });
+
+      const findByArgs: JSONObject = getFindByArgs(IncidentService);
+      const query: JSONObject = findByArgs["query"] as JSONObject;
+
+      expect(query["currentIncidentState"]).toEqual({
+        isResolvedState: false,
+      });
+      expect(query["incidentSeverityId"]).toBeInstanceOf(Includes);
+      expect((query["incidentSeverityId"] as Includes).values).toEqual([
+        severityId.toString(),
+      ]);
+      expect(findByArgs["sort"]).toEqual({
+        createdAt: SortOrder.Descending,
+      });
+      expect(findByArgs["limit"]).toBe(9);
+      expect(findByArgs["skip"]).toBe(0);
+    });
+
+    it("takes kind from the selected widget policy, not from the caller", async () => {
+      const pod: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.KubernetesPodList,
+      });
+      setDashboardWidgets([pod.widget]);
+
+      await callRoute({
+        resourceType: "kubernetes-resource",
+        body: {
+          componentId: pod.componentId.toString(),
+          query: { kind: "Node" },
+        },
+      });
+
+      const query: JSONObject = getFindByArgs(KubernetesResourceService)[
+        "query"
+      ] as JSONObject;
+      expect(query["kind"]).toBe("Pod");
+    });
+
+    it("passes only dynamic time and bounded variable selections into policy", async () => {
+      const buildSpy: ReturnType<typeof jest.spyOn> = jest.spyOn(
+        PublicDashboardResourceListPolicy,
+        "build",
+      );
+      const log: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+        argumentsObject: {
+          attributeFilterQuery: "@service.name:stored-service",
+        },
+      });
+      const variable: JSONObject = {
+        id: "service-variable",
+        name: "Service",
+        type: DashboardVariableType.TelemetryAttribute,
+        attributeKey: "service.name",
+        defaultValue: "default-service",
+      };
+      setDashboardWidgets([log.widget], [variable]);
+      const requestedVariables: Array<JSONObject> = [
+        {
+          id: "service-variable",
+          selectedValue: "checkout",
+          selectedValues: [],
+        },
+      ];
+
+      await callRoute({
+        resourceType: "log",
+        body: {
+          componentId: log.componentId.toString(),
+          query: telemetryQuery("log"),
+          variables: requestedVariables,
+        },
+      });
+
+      expect(buildSpy).toHaveBeenCalledTimes(1);
+      const policyInput: BuildPublicDashboardResourceListPolicyData =
+        buildSpy.mock.calls[0]![0];
+      expect(policyInput.widget).toBe(log.widget);
+      expect(policyInput.dashboardViewConfig).toBe(
+        dashboard.dashboardViewConfig,
+      );
+      expect(policyInput.requestedVariables).toEqual(requestedVariables);
+      expect((policyInput.requestedQuery as JSONObject)["time"]).toBeInstanceOf(
+        InBetween,
+      );
+
+      const query: JSONObject = getFindByArgs(LogService)[
+        "query"
+      ] as JSONObject;
+      expect((query["attributes"] as JSONObject)["service.name"]).toBe(
+        "checkout",
+      );
+    });
+
+    it("fails closed when a telemetry request omits its time range", async () => {
+      const log: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+      });
+      setDashboardWidgets([log.widget]);
+
+      await callRoute({
+        resourceType: "log",
+        body: { componentId: log.componentId.toString(), query: {} },
+      });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
       expectNothingListed();
     });
 
-    /*
-     * A missing dashboard never reaches the resource lookup: hasReadAccess
-     * fails closed first, so the viewer is told they have no access rather
-     * than whether the id exists.
-     */
-    it("rejects a dashboard that cannot be found", async () => {
-      setDashboardWidgets([DashboardComponentType.LogStream]);
+    it("rejects a policy result for any resource other than the URL resource", async () => {
+      const log: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+      });
+      setDashboardWidgets([log.widget]);
+      const mismatchedPolicy: PublicDashboardResourceListPolicyResult = {
+        resourceType: "monitor",
+        query: {},
+        select: {},
+        sort: {},
+        limit: 1,
+      };
+      jest
+        .spyOn(PublicDashboardResourceListPolicy, "build")
+        .mockReturnValue(mismatchedPolicy);
+
+      await callRoute({
+        resourceType: "log",
+        body: { componentId: log.componentId.toString() },
+      });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+      expectNothingListed();
+    });
+
+    it("pins projectId after policy construction", async () => {
+      const otherProjectId: ObjectID = ObjectID.generate();
+      const log: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+      });
+      setDashboardWidgets([log.widget]);
+      const policy: PublicDashboardResourceListPolicyResult = {
+        resourceType: "log",
+        query: { projectId: otherProjectId },
+        select: { time: true },
+        sort: { time: SortOrder.Descending },
+        limit: 7,
+      };
+      jest
+        .spyOn(PublicDashboardResourceListPolicy, "build")
+        .mockReturnValue(policy);
+
+      await callRoute({
+        resourceType: "log",
+        body: { componentId: log.componentId.toString() },
+      });
+
+      const query: JSONObject = getFindByArgs(LogService)[
+        "query"
+      ] as JSONObject;
+      expect(query["projectId"]).toBe(projectId);
+      expect(query["projectId"]).not.toBe(otherProjectId);
+    });
+  });
+
+  describe("public incident and alert privacy", () => {
+    it("adds anonymous privacy clauses before root incident and alert reads", async () => {
+      const privacyCases: Array<{
+        resourceType: "incident" | "alert";
+        componentType: DashboardComponentType;
+        service: ListService;
+      }> = [
+        {
+          resourceType: "incident",
+          componentType: DashboardComponentType.IncidentList,
+          service: IncidentService,
+        },
+        {
+          resourceType: "alert",
+          componentType: DashboardComponentType.AlertList,
+          service: AlertService,
+        },
+      ];
+
+      for (const privacyCase of privacyCases) {
+        jest.clearAllMocks();
+        const { widget, componentId } = buildWidget({
+          componentType: privacyCase.componentType,
+        });
+        setDashboardWidgets([widget]);
+
+        await callRoute({
+          resourceType: privacyCase.resourceType,
+          body: { componentId: componentId.toString() },
+        });
+
+        const findByArgs: JSONObject = getFindByArgs(privacyCase.service);
+        const query: JSONObject = findByArgs["query"] as JSONObject;
+        expect(query["isPrivate"]).toBeInstanceOf(FindOperator);
+        expect(query["projectId"]).toBe(projectId);
+        expect(findByArgs["props"]).toEqual({ isRoot: true });
+      }
+    });
+  });
+
+  describe("dashboard authorization", () => {
+    it("rejects a non-public or missing dashboard before listing", async () => {
+      const log: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+      });
+      setDashboardWidgets([log.widget]);
+      dashboard.isPublicDashboard = false;
+
+      await callRoute({
+        resourceType: "log",
+        body: {
+          componentId: log.componentId.toString(),
+          query: telemetryQuery("log"),
+        },
+      });
+      expect(getThrownError()).toBeInstanceOf(NotAuthenticatedException);
+      expectNothingListed();
+
+      jest.clearAllMocks();
       jest.spyOn(DashboardService, "findOneById").mockResolvedValue(null);
-
       await callRoute({ resourceType: "log" });
-
       expect(getThrownError()).toBeInstanceOf(NotAuthenticatedException);
       expectNothingListed();
     });
 
     it("rejects a dashboard with no project", async () => {
-      setDashboardWidgets([DashboardComponentType.LogStream]);
+      const log: BuiltWidget = buildWidget({
+        componentType: DashboardComponentType.LogStream,
+      });
+      setDashboardWidgets([log.widget]);
       delete dashboard.projectId;
 
-      await callRoute({ resourceType: "log" });
+      await callRoute({
+        resourceType: "log",
+        body: {
+          componentId: log.componentId.toString(),
+          query: telemetryQuery("log"),
+        },
+      });
 
       expect(getThrownError()).toBeInstanceOf(NotFoundException);
       expectNothingListed();
-    });
-  });
-
-  describe("project scoping", () => {
-    it("pins every resource type to the dashboard's own project", async () => {
-      for (const resourceCase of RESOURCE_CASES) {
-        jest.clearAllMocks();
-        setDashboardWidgets([resourceCase.componentType]);
-
-        await callRoute({ resourceType: resourceCase.resourceType });
-
-        const findByArgs: JSONObject = getFindByArgs(resourceCase.service);
-        const query: JSONObject = findByArgs["query"] as JSONObject;
-
-        expect(query["projectId"]).toBe(projectId);
-      }
-    });
-
-    it("ignores a client-supplied projectId pointing at another tenant", async () => {
-      const otherProjectId: ObjectID = ObjectID.generate();
-
-      setDashboardWidgets([DashboardComponentType.LogStream]);
-
-      await callRoute({
-        resourceType: "log",
-        body: {
-          query: {
-            projectId: otherProjectId.toString(),
-            severityText: "Error",
-          },
-        },
-      });
-
-      const query: JSONObject = getFindByArgs(LogService)[
-        "query"
-      ] as JSONObject;
-
-      expect(query["projectId"]).toBe(projectId);
-      expect(query["projectId"]).not.toBe(otherProjectId.toString());
-      expect(query["severityText"]).toBe("Error");
-    });
-  });
-
-  describe("query allowlist", () => {
-    it("keeps the widget's own filter and drops everything else", async () => {
-      for (const resourceCase of RESOURCE_CASES) {
-        jest.clearAllMocks();
-        setDashboardWidgets([resourceCase.componentType]);
-
-        await callRoute({
-          resourceType: resourceCase.resourceType,
-          body: {
-            query: {
-              [resourceCase.allowedQueryKey]: "allowed-value",
-              [resourceCase.forbiddenQueryKey]: "smuggled-value",
-              deletedAt: null,
-              password: "smuggled-value",
-            },
-          },
-        });
-
-        const query: JSONObject = getFindByArgs(resourceCase.service)[
-          "query"
-        ] as JSONObject;
-
-        expect(query[resourceCase.allowedQueryKey]).toBe("allowed-value");
-        expect(Object.keys(query)).not.toContain(
-          resourceCase.forbiddenQueryKey,
-        );
-        expect(Object.keys(query)).not.toContain("deletedAt");
-        expect(Object.keys(query)).not.toContain("password");
-      }
-    });
-
-    it("preserves deserialized query operators on allowed keys", async () => {
-      const severityIds: Array<string> = [
-        ObjectID.generate().toString(),
-        ObjectID.generate().toString(),
-      ];
-
-      setDashboardWidgets([DashboardComponentType.IncidentList]);
-
-      await callRoute({
-        resourceType: "incident",
-        body: {
-          query: {
-            incidentSeverityId: new Includes(severityIds).toJSON(),
-            currentIncidentState: {
-              isResolvedState: false,
-            },
-          },
-        },
-      });
-
-      const query: JSONObject = getFindByArgs(IncidentService)[
-        "query"
-      ] as JSONObject;
-
-      expect(query["incidentSeverityId"]).toBeInstanceOf(Includes);
-      expect((query["incidentSeverityId"] as Includes).values).toEqual(
-        severityIds,
-      );
-      expect(query["currentIncidentState"]).toEqual({
-        isResolvedState: false,
-      });
-    });
-
-    it("ignores a query that is not an object", async () => {
-      const badQueries: Array<unknown> = [
-        "severityText",
-        ["severityText"],
-        42,
-        true,
-      ];
-
-      for (const badQuery of badQueries) {
-        jest.clearAllMocks();
-        setDashboardWidgets([DashboardComponentType.LogStream]);
-
-        await callRoute({
-          resourceType: "log",
-          body: { query: badQuery as JSONObject },
-        });
-
-        expect(nextFunction).not.toHaveBeenCalled();
-
-        const query: JSONObject = getFindByArgs(LogService)[
-          "query"
-        ] as JSONObject;
-
-        expect(Object.keys(query)).toEqual(["projectId"]);
-      }
-    });
-
-    it("does not carry prototype-polluting keys into the query", async () => {
-      setDashboardWidgets([DashboardComponentType.LogStream]);
-
-      /*
-       * JSON.parse (like the Express body parser) makes "__proto__" a real
-       * own key rather than setting the prototype, which is how a pollution
-       * payload actually arrives.
-       */
-      const pollutedQuery: JSONObject = JSON.parse(
-        '{"__proto__":{"polluted":true},"constructor":{"polluted":true},"severityText":"Error"}',
-      ) as JSONObject;
-
-      await callRoute({
-        resourceType: "log",
-        body: { query: pollutedQuery },
-      });
-
-      const query: JSONObject = getFindByArgs(LogService)[
-        "query"
-      ] as JSONObject;
-
-      expect(Object.keys(query).sort()).toEqual(["projectId", "severityText"]);
-      expect(({} as Record<string, unknown>)["polluted"]).toBeUndefined();
-    });
-
-    it("sends no query at all when the body is empty", async () => {
-      setDashboardWidgets([DashboardComponentType.MonitorList]);
-
-      await callRoute({ resourceType: "monitor" });
-
-      const query: JSONObject = getFindByArgs(MonitorService)[
-        "query"
-      ] as JSONObject;
-
-      expect(query).toEqual({ projectId: projectId });
-    });
-  });
-
-  describe("kind pinning", () => {
-    it("pins the kind for every resource type whose model packs several kinds", async () => {
-      for (const resourceCase of RESOURCE_CASES) {
-        if (!resourceCase.kind) {
-          continue;
-        }
-
-        jest.clearAllMocks();
-        setDashboardWidgets([resourceCase.componentType]);
-
-        await callRoute({ resourceType: resourceCase.resourceType });
-
-        const query: JSONObject = getFindByArgs(resourceCase.service)[
-          "query"
-        ] as JSONObject;
-
-        expect(query["kind"]).toBe(resourceCase.kind);
-      }
-    });
-
-    it("rejects a kind the dashboard's widgets do not render", async () => {
-      setDashboardWidgets([DashboardComponentType.DockerVolumeList]);
-
-      await callRoute({
-        resourceType: "docker-volume",
-        body: {
-          query: {
-            kind: "Container",
-          },
-        },
-      });
-
-      const error: unknown = getThrownError();
-
-      expect(error).toBeInstanceOf(BadDataException);
-      expect((error as BadDataException).message).toBe(
-        "This resource is not part of this dashboard.",
-      );
-      expect(DockerResourceService.findBy).not.toHaveBeenCalled();
-    });
-
-    it("rejects a non-string kind", async () => {
-      setDashboardWidgets([DashboardComponentType.CephPoolList]);
-
-      await callRoute({
-        resourceType: "ceph-resource",
-        body: {
-          query: {
-            kind: { $ne: "Pool" },
-          },
-        },
-      });
-
-      expect(getThrownError()).toBeInstanceOf(BadDataException);
-      expect(CephResourceService.findBy).not.toHaveBeenCalled();
-    });
-
-    it("lets a widget pick its own kind when the dashboard renders several", async () => {
-      setDashboardWidgets([
-        DashboardComponentType.KubernetesPodList,
-        DashboardComponentType.KubernetesNodeList,
-      ]);
-
-      await callRoute({
-        resourceType: "kubernetes-resource",
-        body: {
-          query: {
-            kind: "Node",
-          },
-        },
-      });
-
-      const query: JSONObject = getFindByArgs(KubernetesResourceService)[
-        "query"
-      ] as JSONObject;
-
-      expect(query["kind"]).toBe("Node");
-    });
-
-    it("falls back to every kind the dashboard renders when none is named", async () => {
-      setDashboardWidgets([
-        DashboardComponentType.KubernetesPodList,
-        DashboardComponentType.KubernetesNodeList,
-      ]);
-
-      await callRoute({ resourceType: "kubernetes-resource" });
-
-      const query: JSONObject = getFindByArgs(KubernetesResourceService)[
-        "query"
-      ] as JSONObject;
-
-      expect(query["kind"]).toBeInstanceOf(Includes);
-      expect((query["kind"] as Includes).values).toEqual(["Pod", "Node"]);
-    });
-
-    it("still rejects a kind that no widget on a multi-widget dashboard renders", async () => {
-      setDashboardWidgets([
-        DashboardComponentType.KubernetesPodList,
-        DashboardComponentType.KubernetesNodeList,
-      ]);
-
-      await callRoute({
-        resourceType: "kubernetes-resource",
-        body: {
-          query: {
-            kind: "Namespace",
-          },
-        },
-      });
-
-      expect(getThrownError()).toBeInstanceOf(BadDataException);
-      expect(KubernetesResourceService.findBy).not.toHaveBeenCalled();
-    });
-
-    it("does not add a kind filter to models that have no kinds", async () => {
-      setDashboardWidgets([DashboardComponentType.LogStream]);
-
-      await callRoute({
-        resourceType: "log",
-        body: {
-          query: {
-            kind: "Volume",
-          },
-        },
-      });
-
-      const query: JSONObject = getFindByArgs(LogService)[
-        "query"
-      ] as JSONObject;
-
-      expect(Object.keys(query)).not.toContain("kind");
-    });
-  });
-
-  describe("fixed select", () => {
-    it("serves exactly the columns the widget renders, whatever the client asks for", async () => {
-      for (const resourceCase of RESOURCE_CASES) {
-        jest.clearAllMocks();
-        setDashboardWidgets([resourceCase.componentType]);
-
-        await callRoute({
-          resourceType: resourceCase.resourceType,
-          body: {
-            select: {
-              [resourceCase.nonSelectColumn]: true,
-              password: true,
-            },
-          },
-        });
-
-        const select: JSONObject = getFindByArgs(resourceCase.service)[
-          "select"
-        ] as JSONObject;
-
-        expect(Object.keys(select).sort()).toEqual(
-          [...resourceCase.selectKeys].sort(),
-        );
-        expect(select[resourceCase.selectColumn]).toBe(true);
-        expect(Object.keys(select)).not.toContain("password");
-      }
-    });
-
-    it("never exposes a log column the log stream widget does not render", async () => {
-      setDashboardWidgets([DashboardComponentType.LogStream]);
-
-      await callRoute({ resourceType: "log" });
-
-      const select: JSONObject = getFindByArgs(LogService)[
-        "select"
-      ] as JSONObject;
-
-      expect(select).toEqual({
-        time: true,
-        severityText: true,
-        body: true,
-        primaryEntityId: true,
-        traceId: true,
-        spanId: true,
-        attributes: true,
-      });
-    });
-  });
-
-  describe("sort allowlist", () => {
-    it("keeps a sort on a rendered column and normalizes the order", async () => {
-      setDashboardWidgets([DashboardComponentType.LogStream]);
-
-      await callRoute({
-        resourceType: "log",
-        body: {
-          sort: {
-            time: "DESC",
-          },
-        },
-      });
-
-      expect(getFindByArgs(LogService)["sort"]).toEqual({
-        time: SortOrder.Descending,
-      });
-    });
-
-    it("accepts a lower-case sort order", async () => {
-      setDashboardWidgets([DashboardComponentType.LogStream]);
-
-      await callRoute({
-        resourceType: "log",
-        body: {
-          sort: {
-            time: "desc",
-          },
-        },
-      });
-
-      expect(getFindByArgs(LogService)["sort"]).toEqual({
-        time: SortOrder.Descending,
-      });
-    });
-
-    it("falls back to ascending for an unrecognised sort order", async () => {
-      setDashboardWidgets([DashboardComponentType.LogStream]);
-
-      await callRoute({
-        resourceType: "log",
-        body: {
-          sort: {
-            time: { $gt: 1 },
-          },
-        },
-      });
-
-      expect(getFindByArgs(LogService)["sort"]).toEqual({
-        time: SortOrder.Ascending,
-      });
-    });
-
-    it("drops a sort on a column the viewer cannot see", async () => {
-      for (const resourceCase of RESOURCE_CASES) {
-        jest.clearAllMocks();
-        setDashboardWidgets([resourceCase.componentType]);
-
-        await callRoute({
-          resourceType: resourceCase.resourceType,
-          body: {
-            sort: {
-              [resourceCase.nonSelectColumn]: "DESC",
-              [resourceCase.selectColumn]: "DESC",
-            },
-          },
-        });
-
-        expect(getFindByArgs(resourceCase.service)["sort"]).toEqual({
-          [resourceCase.selectColumn]: SortOrder.Descending,
-        });
-      }
-    });
-
-    it("drops a sort on a related column that is only partially selected", async () => {
-      setDashboardWidgets([DashboardComponentType.IncidentList]);
-
-      await callRoute({
-        resourceType: "incident",
-        body: {
-          sort: {
-            currentIncidentState: "DESC",
-          },
-        },
-      });
-
-      expect(getFindByArgs(IncidentService)["sort"]).toEqual({});
-    });
-
-    it("ignores a sort that is not an object", async () => {
-      setDashboardWidgets([DashboardComponentType.LogStream]);
-
-      await callRoute({
-        resourceType: "log",
-        body: { sort: ["time"] as unknown as JSONObject },
-      });
-
-      expect(getFindByArgs(LogService)["sort"]).toEqual({});
-    });
-  });
-
-  describe("pagination", () => {
-    it("defaults to the dashboard resource limit", async () => {
-      setDashboardWidgets([DashboardComponentType.LogStream]);
-
-      await callRoute({ resourceType: "log" });
-
-      const findByArgs: JSONObject = getFindByArgs(LogService);
-
-      expect(findByArgs["limit"]).toBe(100);
-      expect(findByArgs["skip"]).toBe(0);
-    });
-
-    it("clamps an oversized limit to the per-project maximum", async () => {
-      setDashboardWidgets([DashboardComponentType.LogStream]);
-
-      await callRoute({
-        resourceType: "log",
-        query: { limit: "10000000" },
-      });
-
-      expect(getFindByArgs(LogService)["limit"]).toBe(LIMIT_PER_PROJECT);
-    });
-
-    it("falls back to the default for a nonsensical limit or skip", async () => {
-      const cases: Array<{ limit: string; skip: string }> = [
-        { limit: "-5", skip: "-5" },
-        { limit: "0", skip: "not-a-number" },
-        { limit: "not-a-number", skip: "0" },
-      ];
-
-      for (const testCase of cases) {
-        jest.clearAllMocks();
-        setDashboardWidgets([DashboardComponentType.LogStream]);
-
-        await callRoute({
-          resourceType: "log",
-          query: { limit: testCase.limit, skip: testCase.skip },
-        });
-
-        const findByArgs: JSONObject = getFindByArgs(LogService);
-
-        expect(findByArgs["limit"]).toBe(100);
-        expect(findByArgs["skip"]).toBe(0);
-      }
-    });
-
-    it("honours a sensible limit and skip", async () => {
-      setDashboardWidgets([DashboardComponentType.LogStream]);
-
-      await callRoute({
-        resourceType: "log",
-        query: { limit: "25", skip: "50" },
-      });
-
-      const findByArgs: JSONObject = getFindByArgs(LogService);
-
-      expect(findByArgs["limit"]).toBe(25);
-      expect(findByArgs["skip"]).toBe(50);
     });
   });
 });

--- a/Common/Tests/Server/Utils/Dashboard/PublicDashboardResourceListPolicy.test.ts
+++ b/Common/Tests/Server/Utils/Dashboard/PublicDashboardResourceListPolicy.test.ts
@@ -1,0 +1,857 @@
+import PublicDashboardResourceListPolicy, {
+  PublicDashboardResourceListPolicyResult,
+} from "../../../../Server/Utils/Dashboard/PublicDashboardResourceListPolicy";
+import InBetween from "../../../../Types/BaseDatabase/InBetween";
+import Includes from "../../../../Types/BaseDatabase/Includes";
+import Search from "../../../../Types/BaseDatabase/Search";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "../../../../Types/Database/LimitMax";
+import DashboardComponentType from "../../../../Types/Dashboard/DashboardComponentType";
+import { DashboardVariableType } from "../../../../Types/Dashboard/DashboardVariable";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../../Types/JSON";
+
+const RANGE_START: Date = new Date("2026-08-09T10:00:00.000Z");
+const RANGE_END: Date = new Date("2026-08-09T11:00:00.000Z");
+
+function range(): InBetween<Date> {
+  return new InBetween<Date>(RANGE_START, RANGE_END);
+}
+
+function widget(
+  componentType: DashboardComponentType,
+  argumentsObject: JSONObject = {},
+): JSONObject {
+  return {
+    componentType,
+    arguments: argumentsObject,
+  };
+}
+
+function build(data: {
+  componentType: DashboardComponentType;
+  argumentsObject?: JSONObject | undefined;
+  requestedQuery?: JSONObject | undefined;
+  requestedVariables?: Array<JSONObject> | undefined;
+  storedVariables?: Array<JSONObject> | undefined;
+}): PublicDashboardResourceListPolicyResult {
+  return PublicDashboardResourceListPolicy.build({
+    widget: widget(data.componentType, data.argumentsObject || {}),
+    dashboardViewConfig: {
+      components: [],
+      variables: data.storedVariables || [],
+    },
+    requestedVariables: data.requestedVariables || [],
+    requestedQuery: data.requestedQuery || {},
+  });
+}
+
+interface MappingCase {
+  name: string;
+  componentType: DashboardComponentType;
+  resourceType: string;
+  argumentsObject: JSONObject;
+  expectedQuery: JSONObject;
+  expectedSort: JSONObject;
+  expectedLimit: number;
+  requestedQuery?: JSONObject | undefined;
+}
+
+const MAPPING_CASES: Array<MappingCase> = [
+  {
+    name: "incident",
+    componentType: DashboardComponentType.IncidentList,
+    resourceType: "incident",
+    argumentsObject: {
+      maxRows: 11,
+      stateFilter: "resolved",
+      severityIds: ["severity"],
+      stateIds: ["state"],
+      monitorIds: ["monitor"],
+      labelIds: ["label"],
+    },
+    expectedQuery: {
+      currentIncidentState: { isResolvedState: true },
+      incidentSeverityId: new Includes(["severity"]),
+      currentIncidentStateId: new Includes(["state"]),
+      monitors: new Includes(["monitor"]),
+      labels: new Includes(["label"]),
+    },
+    expectedSort: { createdAt: SortOrder.Descending },
+    expectedLimit: 11,
+  },
+  {
+    name: "alert",
+    componentType: DashboardComponentType.AlertList,
+    resourceType: "alert",
+    argumentsObject: {
+      stateFilter: "acknowledged",
+      severityIds: ["severity"],
+      stateIds: ["state"],
+      monitorIds: ["monitor"],
+      labelIds: ["label"],
+    },
+    expectedQuery: {
+      currentAlertState: { isAcknowledgedState: true },
+      alertSeverityId: new Includes(["severity"]),
+      currentAlertStateId: new Includes(["state"]),
+      monitorId: new Includes(["monitor"]),
+      labels: new Includes(["label"]),
+    },
+    expectedSort: { createdAt: SortOrder.Descending },
+    expectedLimit: 25,
+  },
+  {
+    name: "monitor",
+    componentType: DashboardComponentType.MonitorList,
+    resourceType: "monitor",
+    argumentsObject: {
+      statusFilter: "non-operational",
+      monitorStatusIds: ["status"],
+      monitorTypes: ["Ping"],
+      labelIds: ["label"],
+    },
+    expectedQuery: {
+      currentMonitorStatus: { isOperationalState: false },
+      currentMonitorStatusId: new Includes(["status"]),
+      monitorType: new Includes(["Ping"]),
+      labels: new Includes(["label"]),
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "network map",
+    componentType: DashboardComponentType.NetworkMap,
+    resourceType: "network-site",
+    argumentsObject: {
+      maxSites: "7",
+      statusFilter: "down",
+      networkSiteTypeIds: ["store"],
+    },
+    expectedQuery: {
+      currentMonitorStatus: { isOperationalState: false },
+      networkSiteTypeId: new Includes(["store"]),
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 8,
+  },
+  {
+    name: "host",
+    componentType: DashboardComponentType.HostList,
+    resourceType: "host",
+    argumentsObject: {
+      statusFilter: "connected",
+      osTypeFilter: "linux",
+    },
+    expectedQuery: {
+      otelCollectorStatus: "connected",
+      osType: "linux",
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "kubernetes pod",
+    componentType: DashboardComponentType.KubernetesPodList,
+    resourceType: "kubernetes-resource",
+    argumentsObject: {
+      kubernetesClusterIds: ["cluster"],
+      namespaces: " default, oneuptime ",
+      podPhases: ["Running"],
+    },
+    expectedQuery: {
+      kind: "Pod",
+      kubernetesClusterId: new Includes(["cluster"]),
+      namespaceKey: new Includes(["default", "oneuptime"]),
+      phase: new Includes(["Running"]),
+    },
+    expectedSort: {
+      namespaceKey: SortOrder.Ascending,
+      name: SortOrder.Ascending,
+    },
+    expectedLimit: 25,
+  },
+  {
+    name: "kubernetes node",
+    componentType: DashboardComponentType.KubernetesNodeList,
+    resourceType: "kubernetes-resource",
+    argumentsObject: {
+      kubernetesClusterIds: ["cluster"],
+      readinessFilter: "not-ready",
+    },
+    expectedQuery: {
+      kind: "Node",
+      kubernetesClusterId: new Includes(["cluster"]),
+      isReady: false,
+    },
+    expectedSort: {
+      namespaceKey: SortOrder.Ascending,
+      name: SortOrder.Ascending,
+    },
+    expectedLimit: 25,
+  },
+  {
+    name: "kubernetes namespace",
+    componentType: DashboardComponentType.KubernetesNamespaceList,
+    resourceType: "kubernetes-resource",
+    argumentsObject: { kubernetesClusterIds: ["cluster"] },
+    expectedQuery: {
+      kind: "Namespace",
+      kubernetesClusterId: new Includes(["cluster"]),
+    },
+    expectedSort: {
+      namespaceKey: SortOrder.Ascending,
+      name: SortOrder.Ascending,
+    },
+    expectedLimit: 25,
+  },
+  ...[
+    {
+      name: "kubernetes deployment",
+      componentType: DashboardComponentType.KubernetesDeploymentList,
+      kind: "Deployment",
+    },
+    {
+      name: "kubernetes stateful set",
+      componentType: DashboardComponentType.KubernetesStatefulSetList,
+      kind: "StatefulSet",
+    },
+    {
+      name: "kubernetes daemon set",
+      componentType: DashboardComponentType.KubernetesDaemonSetList,
+      kind: "DaemonSet",
+    },
+    {
+      name: "kubernetes job",
+      componentType: DashboardComponentType.KubernetesJobList,
+      kind: "Job",
+    },
+    {
+      name: "kubernetes cron job",
+      componentType: DashboardComponentType.KubernetesCronJobList,
+      kind: "CronJob",
+    },
+  ].map(
+    (data: {
+      name: string;
+      componentType: DashboardComponentType;
+      kind: string;
+    }): MappingCase => {
+      return {
+        name: data.name,
+        componentType: data.componentType,
+        resourceType: "kubernetes-resource",
+        argumentsObject: {
+          kubernetesClusterIds: ["cluster"],
+          namespaces: "namespace",
+        },
+        expectedQuery: {
+          kind: data.kind,
+          kubernetesClusterId: new Includes(["cluster"]),
+          namespaceKey: new Includes(["namespace"]),
+        },
+        expectedSort: {
+          namespaceKey: SortOrder.Ascending,
+          name: SortOrder.Ascending,
+        },
+        expectedLimit: 25,
+      };
+    },
+  ),
+  {
+    name: "docker host",
+    componentType: DashboardComponentType.DockerHostList,
+    resourceType: "docker-host",
+    argumentsObject: { statusFilter: "disconnected" },
+    expectedQuery: { otelCollectorStatus: "disconnected" },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "docker container",
+    componentType: DashboardComponentType.DockerContainerList,
+    resourceType: "docker-container",
+    argumentsObject: {
+      dockerHostIds: ["host"],
+      imageName: " nginx ",
+    },
+    expectedQuery: {
+      kind: "Container",
+      dockerHostId: new Includes(["host"]),
+      imageName: new Search("nginx"),
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "docker image",
+    componentType: DashboardComponentType.DockerImageList,
+    resourceType: "docker-image",
+    argumentsObject: { dockerHostIds: ["host"], nameSearch: " api " },
+    expectedQuery: {
+      kind: "Image",
+      dockerHostId: new Includes(["host"]),
+      name: new Search("api"),
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "docker network",
+    componentType: DashboardComponentType.DockerNetworkList,
+    resourceType: "docker-network",
+    argumentsObject: { dockerHostIds: ["host"] },
+    expectedQuery: {
+      kind: "Network",
+      dockerHostId: new Includes(["host"]),
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "docker volume",
+    componentType: DashboardComponentType.DockerVolumeList,
+    resourceType: "docker-volume",
+    argumentsObject: { dockerHostIds: ["host"] },
+    expectedQuery: {
+      kind: "Volume",
+      dockerHostId: new Includes(["host"]),
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "podman host",
+    componentType: DashboardComponentType.PodmanHostList,
+    resourceType: "podman-host",
+    argumentsObject: { statusFilter: "connected" },
+    expectedQuery: { otelCollectorStatus: "connected" },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "podman container",
+    componentType: DashboardComponentType.PodmanContainerList,
+    resourceType: "podman-container",
+    argumentsObject: { podmanHostIds: ["host"], imageName: "redis" },
+    expectedQuery: {
+      kind: "Container",
+      podmanHostId: new Includes(["host"]),
+      imageName: new Search("redis"),
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "podman image",
+    componentType: DashboardComponentType.PodmanImageList,
+    resourceType: "podman-image",
+    argumentsObject: { podmanHostIds: ["host"], nameSearch: "worker" },
+    expectedQuery: {
+      kind: "Image",
+      podmanHostId: new Includes(["host"]),
+      name: new Search("worker"),
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "podman network",
+    componentType: DashboardComponentType.PodmanNetworkList,
+    resourceType: "podman-network",
+    argumentsObject: { podmanHostIds: ["host"] },
+    expectedQuery: {
+      kind: "Network",
+      podmanHostId: new Includes(["host"]),
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "podman volume",
+    componentType: DashboardComponentType.PodmanVolumeList,
+    resourceType: "podman-volume",
+    argumentsObject: { podmanHostIds: ["host"] },
+    expectedQuery: {
+      kind: "Volume",
+      podmanHostId: new Includes(["host"]),
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "proxmox node",
+    componentType: DashboardComponentType.ProxmoxNodeList,
+    resourceType: "proxmox-resource",
+    argumentsObject: {
+      proxmoxClusterIds: ["cluster"],
+      statusFilter: "offline",
+    },
+    expectedQuery: {
+      kind: "Node",
+      proxmoxClusterId: new Includes(["cluster"]),
+      isUp: false,
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "proxmox guest",
+    componentType: DashboardComponentType.ProxmoxGuestList,
+    resourceType: "proxmox-resource",
+    argumentsObject: {
+      proxmoxClusterIds: ["cluster"],
+      guestTypeFilter: "lxc",
+      statusFilter: "running",
+    },
+    expectedQuery: {
+      kind: "Guest",
+      proxmoxClusterId: new Includes(["cluster"]),
+      guestType: "lxc",
+      isUp: true,
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "ceph OSD",
+    componentType: DashboardComponentType.CephOsdList,
+    resourceType: "ceph-resource",
+    argumentsObject: { cephClusterIds: ["cluster"], stateFilter: "out" },
+    expectedQuery: {
+      kind: "Osd",
+      cephClusterId: new Includes(["cluster"]),
+      isIn: false,
+    },
+    expectedSort: { externalId: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "ceph pool",
+    componentType: DashboardComponentType.CephPoolList,
+    resourceType: "ceph-resource",
+    argumentsObject: { cephClusterIds: ["cluster"] },
+    expectedQuery: {
+      kind: "Pool",
+      cephClusterId: new Includes(["cluster"]),
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "docker swarm node",
+    componentType: DashboardComponentType.DockerSwarmNodeList,
+    resourceType: "docker-swarm-resource",
+    argumentsObject: {
+      dockerSwarmClusterIds: ["cluster"],
+      roleFilter: "manager",
+      statusFilter: "notready",
+    },
+    expectedQuery: {
+      kind: "Node",
+      dockerSwarmClusterId: new Includes(["cluster"]),
+      role: "manager",
+      isReady: false,
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "docker swarm service",
+    componentType: DashboardComponentType.DockerSwarmServiceList,
+    resourceType: "docker-swarm-resource",
+    argumentsObject: {
+      dockerSwarmClusterIds: ["cluster"],
+      serviceModeFilter: "global",
+      statusFilter: "converged",
+    },
+    expectedQuery: {
+      kind: "Service",
+      dockerSwarmClusterId: new Includes(["cluster"]),
+      serviceMode: "global",
+      isReady: true,
+    },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 25,
+  },
+  {
+    name: "trace list",
+    componentType: DashboardComponentType.TraceList,
+    resourceType: "span",
+    argumentsObject: { statusFilter: "2", maxRows: "31" },
+    requestedQuery: { startTime: range() },
+    expectedQuery: { startTime: range(), statusCode: 2 },
+    expectedSort: { startTime: SortOrder.Descending },
+    expectedLimit: 31,
+  },
+  {
+    name: "log stream",
+    componentType: DashboardComponentType.LogStream,
+    resourceType: "log",
+    argumentsObject: {
+      severityFilter: "Error",
+      bodyContains: " failed ",
+      attributeFilterQuery: "@service.name:api",
+    },
+    requestedQuery: { time: range() },
+    expectedQuery: {
+      time: range(),
+      severityText: "Error",
+      body: "failed",
+      attributes: { "service.name": "api" },
+    },
+    expectedSort: { time: SortOrder.Descending },
+    expectedLimit: 50,
+  },
+];
+
+describe("PublicDashboardResourceListPolicy", () => {
+  describe("component mappings", () => {
+    it.each(MAPPING_CASES)(
+      "builds the complete stored policy for $name",
+      (testCase: MappingCase) => {
+        const result: PublicDashboardResourceListPolicyResult = build({
+          componentType: testCase.componentType,
+          argumentsObject: testCase.argumentsObject,
+          requestedQuery: testCase.requestedQuery,
+        });
+
+        expect(result.resourceType).toBe(testCase.resourceType);
+        expect(result.query).toEqual(testCase.expectedQuery);
+        expect(result.select).toEqual(expect.any(Object));
+        expect(Object.keys(result.select).length).toBeGreaterThan(0);
+        expect(result.sort).toEqual(testCase.expectedSort);
+        expect(result.limit).toBe(testCase.expectedLimit);
+        expect(result.query["projectId"]).toBeUndefined();
+      },
+    );
+
+    it("keeps projections exact for widgets that share a resource model", () => {
+      const proxmoxNode: JSONObject = build({
+        componentType: DashboardComponentType.ProxmoxNodeList,
+      }).select;
+      const proxmoxGuest: JSONObject = build({
+        componentType: DashboardComponentType.ProxmoxGuestList,
+      }).select;
+      const swarmNode: JSONObject = build({
+        componentType: DashboardComponentType.DockerSwarmNodeList,
+      }).select;
+      const swarmService: JSONObject = build({
+        componentType: DashboardComponentType.DockerSwarmServiceList,
+      }).select;
+
+      expect(proxmoxNode["latestCpuPercent"]).toBe(true);
+      expect(proxmoxNode["vmid"]).toBeUndefined();
+      expect(proxmoxGuest["vmid"]).toBe(true);
+      expect(proxmoxGuest["latestCpuPercent"]).toBeUndefined();
+      expect(swarmNode["latestCpuPercent"]).toBe(true);
+      expect(swarmNode["desiredReplicas"]).toBeUndefined();
+      expect(swarmService["desiredReplicas"]).toBe(true);
+      expect(swarmService["latestCpuPercent"]).toBeUndefined();
+    });
+
+    it("does not expose sibling-only Kubernetes fields", () => {
+      const pod: JSONObject = build({
+        componentType: DashboardComponentType.KubernetesPodList,
+      }).select;
+      const node: JSONObject = build({
+        componentType: DashboardComponentType.KubernetesNodeList,
+      }).select;
+      const deployment: JSONObject = build({
+        componentType: DashboardComponentType.KubernetesDeploymentList,
+      }).select;
+
+      expect(pod["phase"]).toBe(true);
+      expect(pod["hasMemoryPressure"]).toBeUndefined();
+      expect(node["hasMemoryPressure"]).toBe(true);
+      expect(node["phase"]).toBeUndefined();
+      expect(deployment["isReady"]).toBe(true);
+      expect(deployment["phase"]).toBeUndefined();
+    });
+  });
+
+  describe("telemetry range ownership", () => {
+    it("copies only time from the log request and keeps stored filters", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.LogStream,
+        argumentsObject: { severityFilter: "Error", bodyContains: "stored" },
+        requestedQuery: {
+          time: range(),
+          severityText: "Debug",
+          body: "attacker",
+          attributes: { secret: "probe" },
+          projectId: "other-project",
+        },
+      });
+
+      expect(result.query).toEqual({
+        time: range(),
+        severityText: "Error",
+        body: "stored",
+      });
+    });
+
+    it("accepts a serialized InBetween range and canonicalizes its dates", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.LogStream,
+        requestedQuery: { time: range().toJSON() },
+      });
+
+      expect(result.query["time"]).toEqual(range());
+    });
+
+    it.each([
+      {},
+      { time: "not-a-range" },
+      { time: new InBetween("invalid", "still-invalid") },
+      { time: new InBetween(RANGE_START, RANGE_START) },
+      { time: new InBetween(RANGE_END, RANGE_START) },
+    ])(
+      "rejects an invalid or missing log time range",
+      (requestedQuery: unknown) => {
+        expect(() => {
+          return build({
+            componentType: DashboardComponentType.LogStream,
+            requestedQuery: requestedQuery as JSONObject,
+          });
+        }).toThrow(BadDataException);
+      },
+    );
+
+    it("requires a valid startTime range for spans", () => {
+      expect(() => {
+        return build({ componentType: DashboardComponentType.TraceList });
+      }).toThrow(BadDataException);
+
+      expect(
+        build({
+          componentType: DashboardComponentType.TraceList,
+          requestedQuery: { startTime: range(), time: "ignored" },
+        }).query,
+      ).toEqual({ startTime: range() });
+    });
+  });
+
+  describe("dashboard variables", () => {
+    const imageVariable: JSONObject = {
+      id: "image",
+      name: "Image",
+      type: DashboardVariableType.TelemetryAttribute,
+      attributeKey: "container.image.name",
+      defaultValue: "nginx",
+    };
+
+    it("uses a stored default when the requested scalar is null", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.DockerContainerList,
+        argumentsObject: { imageName: "stored-image" },
+        storedVariables: [imageVariable],
+        requestedVariables: [
+          { id: "image", selectedValue: null, selectedValues: [] },
+        ],
+      });
+
+      expect(result.query["imageName"]).toBe("nginx");
+    });
+
+    it("preserves an explicit empty scalar as All and removes the base filter", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.DockerContainerList,
+        argumentsObject: { imageName: "stored-image" },
+        storedVariables: [imageVariable],
+        requestedVariables: [
+          { id: "image", selectedValue: "", selectedValues: [] },
+        ],
+      });
+
+      expect(result.query).toEqual({ kind: "Container" });
+    });
+
+    it("applies bounded multi-select values through the shared interpolation", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.KubernetesPodList,
+        storedVariables: [
+          {
+            id: "namespace",
+            name: "Namespace",
+            type: DashboardVariableType.TelemetryAttribute,
+            attributeKey: "k8s.namespace.name",
+            isMultiSelect: true,
+          },
+        ],
+        requestedVariables: [
+          {
+            id: "namespace",
+            selectedValue: null,
+            selectedValues: ["prod", "staging"],
+          },
+        ],
+      });
+
+      expect(result.query["namespaceKey"]).toEqual(
+        new Includes(["prod", "staging"]),
+      );
+    });
+
+    it("ignores a forged scalar All value for a stored multi-select", () => {
+      const storedVariables: Array<JSONObject> = [
+        {
+          id: "namespace",
+          name: "Namespace",
+          type: DashboardVariableType.TelemetryAttribute,
+          attributeKey: "k8s.namespace.name",
+          isMultiSelect: true,
+          defaultValue: "production",
+        },
+      ];
+
+      const forgedScalar: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.KubernetesPodList,
+        storedVariables,
+        requestedVariables: [
+          {
+            id: "namespace",
+            selectedValue: "",
+            selectedValues: [],
+          },
+        ],
+      });
+      expect(forgedScalar.query["namespaceKey"]).toBe("production");
+
+      const compatiblePlaceholder: PublicDashboardResourceListPolicyResult =
+        build({
+          componentType: DashboardComponentType.KubernetesPodList,
+          storedVariables,
+          requestedVariables: [
+            {
+              id: "namespace",
+              selectedValue: null,
+              selectedValues: [],
+            },
+          ],
+        });
+      expect(compatiblePlaceholder.query["namespaceKey"]).toBe("production");
+    });
+
+    it("ignores stale multi-value input for a stored single-select", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.DockerContainerList,
+        storedVariables: [imageVariable],
+        requestedVariables: [
+          {
+            id: "image",
+            selectedValue: "redis",
+            selectedValues: ["nginx"],
+          },
+        ],
+      });
+
+      expect(result.query["imageName"]).toBe("redis");
+    });
+
+    it("applies log variables to stored attributes and supports explicit All", () => {
+      const storedVariables: Array<JSONObject> = [
+        {
+          id: "service",
+          name: "Service",
+          type: DashboardVariableType.TelemetryAttribute,
+          attributeKey: "service.name",
+          defaultValue: "worker",
+        },
+      ];
+
+      const withDefault: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.LogStream,
+        argumentsObject: { attributeFilterQuery: "@service.name:api" },
+        requestedQuery: { time: range() },
+        storedVariables,
+        requestedVariables: [
+          { id: "service", selectedValue: null, selectedValues: [] },
+        ],
+      });
+      expect(withDefault.query["attributes"]).toEqual({
+        "service.name": "worker",
+      });
+
+      const withAll: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.LogStream,
+        argumentsObject: { attributeFilterQuery: "@service.name:api" },
+        requestedQuery: { time: range() },
+        storedVariables,
+        requestedVariables: [
+          { id: "service", selectedValue: "", selectedValues: [] },
+        ],
+      });
+      expect(withAll.query["attributes"]).toBeUndefined();
+    });
+
+    it("rejects unbounded or malformed requested selections", () => {
+      const tooMany: Array<JSONObject> = Array.from(
+        { length: 51 },
+        (_value: unknown, index: number): JSONObject => {
+          return { id: `variable-${index}`, selectedValue: "value" };
+        },
+      );
+
+      expect(() => {
+        return build({
+          componentType: DashboardComponentType.IncidentList,
+          requestedVariables: tooMany,
+        });
+      }).toThrow(BadDataException);
+
+      expect(() => {
+        return build({
+          componentType: DashboardComponentType.IncidentList,
+          requestedVariables: [
+            { id: "variable", selectedValues: Array(101).fill("value") },
+          ],
+        });
+      }).toThrow(BadDataException);
+    });
+  });
+
+  describe("fixed limits and malformed widgets", () => {
+    it("clamps stored list and map limits to the project ceiling", () => {
+      expect(
+        build({
+          componentType: DashboardComponentType.MonitorList,
+          argumentsObject: { maxRows: LIMIT_PER_PROJECT + 100 },
+        }).limit,
+      ).toBe(LIMIT_PER_PROJECT);
+
+      expect(
+        build({
+          componentType: DashboardComponentType.NetworkMap,
+          argumentsObject: { maxSites: LIMIT_PER_PROJECT + 100 },
+        }).limit,
+      ).toBe(LIMIT_PER_PROJECT);
+    });
+
+    it("fails closed for unsupported and malformed components", () => {
+      expect(() => {
+        return build({ componentType: DashboardComponentType.Chart });
+      }).toThrow(BadDataException);
+
+      expect(() => {
+        return PublicDashboardResourceListPolicy.build({
+          widget: {
+            componentType: DashboardComponentType.IncidentList,
+            arguments: "invalid",
+          },
+          dashboardViewConfig: { components: [] },
+          requestedVariables: [],
+          requestedQuery: {},
+        });
+      }).toThrow(BadDataException);
+
+      expect(() => {
+        return build({
+          componentType: DashboardComponentType.IncidentList,
+          argumentsObject: { severityIds: "not-an-array" },
+        });
+      }).toThrow(BadDataException);
+    });
+  });
+});

--- a/Common/UI/Utils/API/RequestOptions.ts
+++ b/Common/UI/Utils/API/RequestOptions.ts
@@ -1,9 +1,16 @@
 import URL from "../../../Types/API/URL";
 import type { RequestOptions as CoreRequestOptions } from "../../../Utils/API";
 import Dictionary from "../../../Types/Dictionary";
+import { JSONObject } from "../../../Types/JSON";
 
 export default interface RequestOptions {
   requestHeaders?: Dictionary<string> | undefined;
   overrideRequestUrl?: URL | undefined;
   apiRequestOptions?: CoreRequestOptions | undefined;
+  /*
+   * Extra top-level fields merged into a list request body before the
+   * canonical query/select/sort/groupBy fields. This lets callers attach
+   * endpoint-specific context without being able to replace the list query.
+   */
+  additionalRequestBody?: JSONObject | undefined;
 }

--- a/Common/UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI.ts
+++ b/Common/UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI.ts
@@ -292,6 +292,7 @@ export default class ModelAPI {
         method: HTTPMethod.POST,
         url: apiUrl,
         data: {
+          ...(requestOptions?.additionalRequestBody || {}),
           query: JSONFunctions.serialize(query as JSONObject),
           select: JSONFunctions.serialize(select as JSONObject),
           sort: JSONFunctions.serialize(sort as JSONObject),

--- a/Common/UI/Utils/ModelAPI/ModelAPI.ts
+++ b/Common/UI/Utils/ModelAPI/ModelAPI.ts
@@ -238,6 +238,7 @@ export default class ModelAPI {
         method: HTTPMethod.POST,
         url: apiUrl,
         data: {
+          ...(data.requestOptions?.additionalRequestBody || {}),
           query: JSONFunctions.serialize(data.query as JSONObject),
           select: JSONFunctions.serialize(data.select as JSONObject),
           sort: JSONFunctions.serialize(data.sort as JSONObject),


### PR DESCRIPTION
## Summary

- bind every public dashboard resource-list request to one exact stored widget
- rebuild filters, resource kind, sort, pagination, and row limits from the stored dashboard configuration
- accept only bounded viewer-controlled time ranges and stored dashboard-variable selections
- use an exact least-privilege field projection for each of the 31 supported list widgets
- preserve public incident and alert privacy even though the underlying read runs with root transport permissions
- send the widget component ID and variable selections from the dashboard client

## Security context

[GHSA-qv79-j844-cc7m](https://github.com/OneUptime/oneuptime/security/advisories/GHSA-qv79-j844-cc7m) is a valid report. PR #2970 fixed the original cross-resource proof of concept by requiring a matching widget type. A matching filtered list widget could still be widened by omitting or replacing its stored filters, changing pagination, or receiving fields unioned from a sibling widget that shares the same model.

This change makes the exact stored widget configuration the server-owned authorization boundary. Requests without a component ID remain compatible only when exactly one matching widget exists; ambiguous requests fail closed.

## Validation

- public resource policy tests: 50 passed
- public resource API integration tests: 20 passed
- dashboard request/invariant tests: 24 passed
- changed-file ESLint: passed
- `Common` TypeScript compile: passed
- `App/FeatureSet/Dashboard` TypeScript compile: passed

