### PR TITLE
fix(security): enforce owner scope for current-user records

### DIFF
--- a/Common/Models/DatabaseModels/User.ts
+++ b/Common/Models/DatabaseModels/User.ts
@@ -6,6 +6,7 @@ import JobRole from "../../Types/Company/JobRole";
 import AllowAccessIfSubscriptionIsUnpaid from "../../Types/Database/AccessControl/AllowAccessIfSubscriptionIsUnpaid";
 import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccessControl";
 import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
+import AllowUserQueryWithoutTenant from "../../Types/Database/AllowUserQueryWithoutTenant";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
@@ -48,6 +49,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   icon: IconProp.User,
   tableDescription: "A signed up or invited OneUptime user.",
 })
+@AllowUserQueryWithoutTenant(true)
 @CurrentUserCanAccessRecordBy("_id")
 class User extends UserModel {
   @ColumnAccessControl({

--- a/Common/Models/DatabaseModels/UserOnCallLog.ts
+++ b/Common/Models/DatabaseModels/UserOnCallLog.ts
@@ -18,6 +18,7 @@ import CanAccessIfCanReadOn from "../../Types/Database/CanAccessIfCanReadOn";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
+import CurrentUserCanAccessRecordBy from "../../Types/Database/CurrentUserCanAccessRecordBy";
 import EnableDocumentation from "../../Types/Database/EnableDocumentation";
 import TableColumn from "../../Types/Database/TableColumn";
 import TableColumnType from "../../Types/Database/TableColumnType";
@@ -36,6 +37,7 @@ import Alert from "./Alert";
 
 @EnableDocumentation()
 @CanAccessIfCanReadOn("onCallDutyPolicy")
+@CurrentUserCanAccessRecordBy("userId")
 @TenantColumn("projectId")
 @TableBillingAccessControl({
   create: PlanType.Growth,

--- a/Common/Models/DatabaseModels/UserOnCallLogTimeline.ts
+++ b/Common/Models/DatabaseModels/UserOnCallLogTimeline.ts
@@ -29,6 +29,7 @@ import CanAccessIfCanReadOn from "../../Types/Database/CanAccessIfCanReadOn";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
+import CurrentUserCanAccessRecordBy from "../../Types/Database/CurrentUserCanAccessRecordBy";
 import EnableDocumentation from "../../Types/Database/EnableDocumentation";
 import TableColumn from "../../Types/Database/TableColumn";
 import TableColumnType from "../../Types/Database/TableColumnType";
@@ -49,6 +50,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 })
 @EnableDocumentation()
 @CanAccessIfCanReadOn("onCallDutyPolicy")
+@CurrentUserCanAccessRecordBy("userId")
 @TenantColumn("projectId")
 @TableAccessControl({
   create: [],

--- a/Common/Models/DatabaseModels/UserSession.ts
+++ b/Common/Models/DatabaseModels/UserSession.ts
@@ -4,6 +4,7 @@ import Route from "../../Types/API/Route";
 import AllowAccessIfSubscriptionIsUnpaid from "../../Types/Database/AccessControl/AllowAccessIfSubscriptionIsUnpaid";
 import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccessControl";
 import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
+import AllowUserQueryWithoutTenant from "../../Types/Database/AllowUserQueryWithoutTenant";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
@@ -41,6 +42,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   tableDescription:
     "Active user sessions with refresh tokens and device metadata for enhanced authentication security.",
 })
+@AllowUserQueryWithoutTenant(true)
 @CurrentUserCanAccessRecordBy("userId")
 class UserSession extends BaseModel {
   @ColumnAccessControl({

--- a/Common/Models/DatabaseModels/UserTotpAuth.ts
+++ b/Common/Models/DatabaseModels/UserTotpAuth.ts
@@ -4,6 +4,7 @@ import Route from "../../Types/API/Route";
 import AllowAccessIfSubscriptionIsUnpaid from "../../Types/Database/AccessControl/AllowAccessIfSubscriptionIsUnpaid";
 import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccessControl";
 import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
+import AllowUserQueryWithoutTenant from "../../Types/Database/AllowUserQueryWithoutTenant";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
@@ -38,6 +39,7 @@ import { Column, Entity, JoinColumn, ManyToOne } from "typeorm";
   icon: IconProp.ShieldCheck,
   tableDescription: "TOTP Authentication for users",
 })
+@AllowUserQueryWithoutTenant(true)
 @CurrentUserCanAccessRecordBy("userId")
 class UserTotpAuth extends BaseModel {
   @ColumnAccessControl({
@@ -98,7 +100,7 @@ class UserTotpAuth extends BaseModel {
   @ColumnAccessControl({
     create: [Permission.CurrentUser],
     read: [Permission.CurrentUser],
-    update: [Permission.CurrentUser],
+    update: [],
   })
   @TableColumn({
     type: TableColumnType.Boolean,
@@ -163,9 +165,9 @@ class UserTotpAuth extends BaseModel {
   public deletedByUserId?: ObjectID = undefined;
 
   @ColumnAccessControl({
-    create: [Permission.CurrentUser],
+    create: [],
     read: [Permission.CurrentUser],
-    update: [Permission.CurrentUser],
+    update: [],
   })
   @TableColumn({
     manyToOneRelationColumn: "userId",
@@ -191,7 +193,7 @@ class UserTotpAuth extends BaseModel {
   @ColumnAccessControl({
     create: [Permission.CurrentUser],
     read: [Permission.CurrentUser],
-    update: [Permission.CurrentUser],
+    update: [],
   })
   @TableColumn({
     type: TableColumnType.ObjectID,

--- a/Common/Models/DatabaseModels/UserWebAuthn.ts
+++ b/Common/Models/DatabaseModels/UserWebAuthn.ts
@@ -4,6 +4,7 @@ import Route from "../../Types/API/Route";
 import AllowAccessIfSubscriptionIsUnpaid from "../../Types/Database/AccessControl/AllowAccessIfSubscriptionIsUnpaid";
 import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccessControl";
 import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
+import AllowUserQueryWithoutTenant from "../../Types/Database/AllowUserQueryWithoutTenant";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
@@ -38,6 +39,7 @@ import { Column, Entity, JoinColumn, ManyToOne } from "typeorm";
   icon: IconProp.ShieldCheck,
   tableDescription: "WebAuthn credentials for users (security keys)",
 })
+@AllowUserQueryWithoutTenant(true)
 @CurrentUserCanAccessRecordBy("userId")
 class UserWebAuthn extends BaseModel {
   @ColumnAccessControl({
@@ -198,9 +200,9 @@ class UserWebAuthn extends BaseModel {
   public deletedByUserId?: ObjectID = undefined;
 
   @ColumnAccessControl({
-    create: [Permission.CurrentUser],
+    create: [],
     read: [Permission.CurrentUser],
-    update: [Permission.CurrentUser],
+    update: [],
   })
   @TableColumn({
     manyToOneRelationColumn: "userId",
@@ -226,7 +228,7 @@ class UserWebAuthn extends BaseModel {
   @ColumnAccessControl({
     create: [Permission.CurrentUser],
     read: [Permission.CurrentUser],
-    update: [Permission.CurrentUser],
+    update: [],
   })
   @TableColumn({
     type: TableColumnType.ObjectID,

--- a/Common/Server/Services/UserService.ts
+++ b/Common/Server/Services/UserService.ts
@@ -267,9 +267,7 @@ export class Service extends DatabaseService<Model> {
           _id: true,
           email: true,
         },
-        props: {
-          isRoot: true,
-        },
+        props: updateBy.props,
         limit: LIMIT_MAX,
         skip: 0,
       });
@@ -286,9 +284,7 @@ export class Service extends DatabaseService<Model> {
           _id: true,
           email: true,
         },
-        props: {
-          isRoot: true,
-        },
+        props: updateBy.props,
         limit: LIMIT_MAX,
         skip: 0,
       });
@@ -343,9 +339,7 @@ export class Service extends DatabaseService<Model> {
       select: {
         _id: true,
       },
-      props: {
-        isRoot: true,
-      },
+      props: deleteBy.props,
       limit: LIMIT_MAX,
       skip: 0,
     });

--- a/Common/Server/Types/Database/Permissions/BasePermission.ts
+++ b/Common/Server/Types/Database/Permissions/BasePermission.ts
@@ -32,6 +32,13 @@ export default class BasePermission {
     props: DatabaseCommonInteractionProps,
     type: DatabaseRequestType,
   ): Promise<CheckPermissionBaseInterface<TBaseModel>> {
+    /*
+     * Permission checks add predicates and QueryUtil serializes values in
+     * place. Callers such as BaseAPI intentionally reuse the original query
+     * for list and count, so work on a fresh top-level object.
+     */
+    query = { ...query };
+
     const model: BaseModel = new modelType();
 
     if (props.isRoot || props.isMasterAdmin) {

--- a/Common/Server/Types/Database/Permissions/DeletePermission.ts
+++ b/Common/Server/Types/Database/Permissions/DeletePermission.ts
@@ -34,6 +34,8 @@ export default class DeletePermission {
     query: Query<TBaseModel>,
     props: DatabaseCommonInteractionProps,
   ): Promise<Query<TBaseModel>> {
+    query = { ...query };
+
     if (props.isRoot || props.isMasterAdmin) {
       query = await PermissionUtil.addTenantScopeToQueryAsRoot(
         modelType,

--- a/Common/Server/Types/Database/Permissions/ReadPermission.ts
+++ b/Common/Server/Types/Database/Permissions/ReadPermission.ts
@@ -29,6 +29,9 @@ export default class ReadPermission {
     select: Select<TBaseModel> | null,
     props: DatabaseCommonInteractionProps,
   ): Promise<CheckReadPermissionType<TBaseModel>> {
+    // Block and base permission checks both add predicates to the query.
+    query = { ...query };
+
     // check block permission first.
     await this.checkReadBlockPermission(modelType, query, props);
 

--- a/Common/Server/Types/Database/Permissions/TenantPermission.ts
+++ b/Common/Server/Types/Database/Permissions/TenantPermission.ts
@@ -45,6 +45,40 @@ export default class TenantPermission {
       );
     }
 
+    const isAccessGrantedOnlyByCurrentUser: boolean =
+      TenantPermission.isAccessGrantedOnlyByCurrentUser(modelType, props, type);
+    const userColumn: string | null = model.getUserColumn();
+
+    /*
+     * CurrentUser is an auto-granted permission, not a tenant-wide role. A
+     * query operation that relies on it must declare an ownership column so
+     * the permission can be converted into a row predicate.
+     */
+    if (
+      isAccessGrantedOnlyByCurrentUser &&
+      type !== DatabaseRequestType.Create &&
+      !userColumn
+    ) {
+      throw new NotAuthorizedException(
+        `Current user scope is not configured for ${model.singularName}.`,
+      );
+    }
+
+    const shouldScopeQueryByCurrentUser: boolean =
+      isAccessGrantedOnlyByCurrentUser && Boolean(userColumn);
+
+    /*
+     * API keys and other non-user callers can carry the auto-granted
+     * CurrentUser permission without having a userId. Such a grant can never
+     * be converted into an ownership filter, so reject it instead of running
+     * the caller's query without a user scope.
+     */
+    if (shouldScopeQueryByCurrentUser && !props.userId) {
+      throw new NotAuthorizedException(
+        `A user session is required to ${type} ${model.singularName}.`,
+      );
+    }
+
     // If this model has a tenantColumn, and request has tenantId, and is multiTenantQuery null then add tenantId to query.
     if (tenantColumn && props.tenantId && !props.isMultiTenantRequest) {
       (query as any)[tenantColumn] = props.tenantId;
@@ -56,13 +90,12 @@ export default class TenantPermission {
        * row in the project (CVE-class issue when CurrentUser appears in a
        * model's delete/update list alongside admin permissions).
        */
-      if (
-        TenantPermission.shouldScopeQueryByCurrentUser(modelType, props, type)
-      ) {
-        const userColumn: string | null = model.getUserColumn();
-        if (userColumn) {
-          (query as any)[userColumn] = props.userId;
-        }
+      if (shouldScopeQueryByCurrentUser) {
+        TenantPermission.addCurrentUserScopeToQuery(
+          model,
+          query,
+          props.userId as ObjectID,
+        );
       }
     }
     // if model allows user query without tenant, and user column is present, and userId is present, then add userId to query.
@@ -71,7 +104,7 @@ export default class TenantPermission {
       model.getUserColumn() &&
       props.userId
     ) {
-      (query as any)[model.getUserColumn() as string] = props.userId;
+      TenantPermission.addCurrentUserScopeToQuery(model, query, props.userId);
     } else if (
       tenantColumn &&
       props.userGlobalAccessPermission &&
@@ -114,6 +147,7 @@ export default class TenantPermission {
       }
 
       let lastException: Error | null = null;
+      const queryForEachProject: Query<TBaseModel> = { ...query };
 
       for (const projectId of projectIDs) {
         if (!props.userId) {
@@ -124,7 +158,7 @@ export default class TenantPermission {
           const checkBasePermissions: CheckPermissionBaseInterface<TBaseModel> =
             await BasePermission.checkPermissions(
               modelType,
-              query,
+              { ...queryForEachProject },
               select,
               {
                 ...props,
@@ -154,7 +188,64 @@ export default class TenantPermission {
       return queries as any;
     }
 
+    /*
+     * A model that relies on CurrentUser must resolve that permission to the
+     * requester's exact ownership column. This catches missing decorators and
+     * prevents a future model misconfiguration from silently becoming an
+     * instance-wide query.
+     */
+    if (shouldScopeQueryByCurrentUser) {
+      const scopedUserId: unknown = (query as any)[userColumn as string];
+
+      if (
+        !TenantPermission.isExactUserScope(scopedUserId) ||
+        scopedUserId.toString() !== (props.userId as ObjectID).toString()
+      ) {
+        throw new NotAuthorizedException(
+          `Current user scope could not be applied to ${model.singularName}.`,
+        );
+      }
+    }
+
     return query;
+  }
+
+  /**
+   * Add the authenticated user's ownership predicate without redirecting an
+   * operation that explicitly targeted another user. Rejecting a conflict is
+   * important because service hooks run before the final permission check;
+   * silently replacing the target would let a hook inspect one row and the
+   * database operation mutate a different one.
+   */
+  private static addCurrentUserScopeToQuery<TBaseModel extends BaseModel>(
+    model: BaseModel,
+    query: Query<TBaseModel>,
+    userId: ObjectID,
+  ): void {
+    const userColumn: string = model.getUserColumn() as string;
+    const existingUserScope: unknown = (query as any)[userColumn];
+
+    if (
+      existingUserScope !== undefined &&
+      (!TenantPermission.isExactUserScope(existingUserScope) ||
+        existingUserScope.toString() !== userId.toString())
+    ) {
+      throw new NotAuthorizedException(
+        `You do not have permission to access another user's ${model.singularName}.`,
+      );
+    }
+
+    (query as any)[userColumn] = userId;
+  }
+
+  /**
+   * Ownership filters must be exact scalar ids. Query operators such as
+   * NotEqual stringify to their wrapped id as well, so comparing only their
+   * string value would allow a broad hook query to masquerade as an exact
+   * current-user predicate.
+   */
+  private static isExactUserScope(value: unknown): value is string | ObjectID {
+    return typeof value === "string" || value instanceof ObjectID;
   }
 
   /**
@@ -162,17 +253,11 @@ export default class TenantPermission {
    * check for this op is Permission.CurrentUser. In that case the query must
    * be restricted to rows the user owns (via the model's user column).
    */
-  private static shouldScopeQueryByCurrentUser<TBaseModel extends BaseModel>(
+  private static isAccessGrantedOnlyByCurrentUser<TBaseModel extends BaseModel>(
     modelType: { new (): TBaseModel },
     props: DatabaseCommonInteractionProps,
     type: DatabaseRequestType,
   ): boolean {
-    const model: BaseModel = new modelType();
-
-    if (!model.getUserColumn() || !props.userId) {
-      return false;
-    }
-
     const modelPermissions: Array<Permission> =
       TablePermission.getTablePermission(modelType, type);
 

--- a/Common/Tests/Server/Types/Database/Permissions/TenantPermission.test.ts
+++ b/Common/Tests/Server/Types/Database/Permissions/TenantPermission.test.ts
@@ -1,0 +1,358 @@
+import User from "../../../../../Models/DatabaseModels/User";
+import UserOnCallLog from "../../../../../Models/DatabaseModels/UserOnCallLog";
+import UserOnCallLogTimeline from "../../../../../Models/DatabaseModels/UserOnCallLogTimeline";
+import UserSession from "../../../../../Models/DatabaseModels/UserSession";
+import UserTotpAuth from "../../../../../Models/DatabaseModels/UserTotpAuth";
+import UserWebAuthn from "../../../../../Models/DatabaseModels/UserWebAuthn";
+import BaseModel from "../../../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import UserService from "../../../../../Server/Services/UserService";
+import DatabaseRequestType from "../../../../../Server/Types/BaseDatabase/DatabaseRequestType";
+import DeleteBy from "../../../../../Server/Types/Database/DeleteBy";
+import BasePermission from "../../../../../Server/Types/Database/Permissions/BasePermission";
+import TenantPermission from "../../../../../Server/Types/Database/Permissions/TenantPermission";
+import Query from "../../../../../Server/Types/Database/Query";
+import UpdateBy from "../../../../../Server/Types/Database/UpdateBy";
+import NotEqual from "../../../../../Types/BaseDatabase/NotEqual";
+import DatabaseCommonInteractionProps from "../../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import ColumnAccessControl from "../../../../../Types/Database/AccessControl/ColumnAccessControl";
+import TableAccessControl from "../../../../../Types/Database/AccessControl/TableAccessControl";
+import CurrentUserCanAccessRecordBy from "../../../../../Types/Database/CurrentUserCanAccessRecordBy";
+import TableColumn from "../../../../../Types/Database/TableColumn";
+import TableColumnType from "../../../../../Types/Database/TableColumnType";
+import TenantColumn from "../../../../../Types/Database/TenantColumn";
+import NotAuthorizedException from "../../../../../Types/Exception/NotAuthorizedException";
+import ObjectID from "../../../../../Types/ObjectID";
+import Permission from "../../../../../Types/Permission";
+import UserType from "../../../../../Types/UserType";
+
+@TableAccessControl({
+  create: [Permission.CurrentUser],
+  read: [Permission.CurrentUser],
+  update: [Permission.CurrentUser],
+  delete: [Permission.CurrentUser],
+})
+@CurrentUserCanAccessRecordBy("userId")
+class MisconfiguredCurrentUserModel extends BaseModel {}
+
+@TableAccessControl({
+  create: [Permission.CurrentUser],
+  read: [Permission.CurrentUser],
+  update: [Permission.CurrentUser],
+  delete: [Permission.CurrentUser],
+})
+class MissingCurrentUserScopeModel extends BaseModel {}
+
+@TableAccessControl({
+  create: [Permission.CurrentUser],
+  read: [Permission.CurrentUser, Permission.ProjectAdmin],
+  update: [Permission.CurrentUser],
+  delete: [Permission.CurrentUser],
+})
+@CurrentUserCanAccessRecordBy("userId")
+@TenantColumn("projectId")
+class TenantScopedCurrentUserModel extends BaseModel {
+  @ColumnAccessControl({
+    create: [],
+    read: [Permission.CurrentUser, Permission.ProjectAdmin],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    title: "Project ID",
+  })
+  public projectId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [Permission.CurrentUser, Permission.ProjectAdmin],
+    update: [],
+  })
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    title: "User ID",
+  })
+  public userId?: ObjectID = undefined;
+}
+
+describe("TenantPermission current-user ownership scope", () => {
+  const userId: ObjectID = ObjectID.generate();
+  const victimUserId: ObjectID = ObjectID.generate();
+
+  function makeUserProps(): DatabaseCommonInteractionProps {
+    return {
+      userId,
+    };
+  }
+
+  it.each([UserTotpAuth, UserWebAuthn, UserSession])(
+    "scopes %p queries to the authenticated user's records",
+    async (modelType: { new (): BaseModel }) => {
+      for (const requestType of [
+        DatabaseRequestType.Read,
+        DatabaseRequestType.Update,
+        DatabaseRequestType.Delete,
+      ]) {
+        const query: Query<BaseModel> =
+          await TenantPermission.addTenantScopeToQuery(
+            modelType,
+            {},
+            null,
+            makeUserProps(),
+            requestType,
+          );
+
+        expect((query as any).userId?.toString()).toBe(userId.toString());
+      }
+    },
+  );
+
+  it.each([UserTotpAuth, UserWebAuthn, UserSession])(
+    "rejects %p operations that explicitly target another user",
+    async (modelType: { new (): BaseModel }) => {
+      for (const requestType of [
+        DatabaseRequestType.Read,
+        DatabaseRequestType.Update,
+        DatabaseRequestType.Delete,
+      ]) {
+        await expect(
+          TenantPermission.addTenantScopeToQuery(
+            modelType,
+            { userId: victimUserId } as any,
+            null,
+            makeUserProps(),
+            requestType,
+          ),
+        ).rejects.toThrow(NotAuthorizedException);
+      }
+    },
+  );
+
+  it("rejects CurrentUser access when a non-user caller has no user identity", async () => {
+    const apiKeyProps: DatabaseCommonInteractionProps = {
+      userType: UserType.API,
+      userGlobalAccessPermission: {
+        projectIds: [ObjectID.generate()],
+        globalPermissions: [
+          Permission.Public,
+          Permission.User,
+          Permission.CurrentUser,
+        ],
+        _type: "UserGlobalAccessPermission",
+      },
+    };
+
+    await expect(
+      BasePermission.checkPermissions(
+        UserTotpAuth,
+        {},
+        null,
+        apiKeyProps,
+        DatabaseRequestType.Read,
+      ),
+    ).rejects.toThrow(NotAuthorizedException);
+  });
+
+  it("fails closed when a CurrentUser model resolves no ownership filter", async () => {
+    await expect(
+      TenantPermission.addTenantScopeToQuery(
+        MisconfiguredCurrentUserModel,
+        {},
+        null,
+        makeUserProps(),
+        DatabaseRequestType.Read,
+      ),
+    ).rejects.toThrow(NotAuthorizedException);
+  });
+
+  it("fails closed when CurrentUser ownership metadata is missing", async () => {
+    await expect(
+      TenantPermission.addTenantScopeToQuery(
+        MissingCurrentUserScopeModel,
+        {},
+        null,
+        makeUserProps(),
+        DatabaseRequestType.Read,
+      ),
+    ).rejects.toThrow(NotAuthorizedException);
+  });
+
+  it("keeps User reads scoped to the authenticated user's primary key", async () => {
+    const query: Query<User> = await TenantPermission.addTenantScopeToQuery(
+      User,
+      {},
+      null,
+      makeUserProps(),
+      DatabaseRequestType.Read,
+    );
+
+    expect((query as any)._id?.toString()).toBe(userId.toString());
+  });
+
+  it("rejects query operators that disguise a broad ownership filter", async () => {
+    await expect(
+      TenantPermission.addTenantScopeToQuery(
+        User,
+        { _id: new NotEqual<string>(userId.toString()) },
+        null,
+        makeUserProps(),
+        DatabaseRequestType.Update,
+      ),
+    ).rejects.toThrow(NotAuthorizedException);
+  });
+
+  it("rejects deleting another User instead of redirecting the delete", async () => {
+    await expect(
+      TenantPermission.addTenantScopeToQuery(
+        User,
+        { _id: victimUserId },
+        null,
+        makeUserProps(),
+        DatabaseRequestType.Delete,
+      ),
+    ).rejects.toThrow(NotAuthorizedException);
+  });
+
+  it("allows deleting the authenticated User's own record", async () => {
+    const deleteQuery: Query<User> =
+      await TenantPermission.addTenantScopeToQuery(
+        User,
+        { _id: userId },
+        null,
+        makeUserProps(),
+        DatabaseRequestType.Delete,
+      );
+
+    expect((deleteQuery as any)._id?.toString()).toBe(userId.toString());
+  });
+
+  it.each([UserOnCallLog, UserOnCallLogTimeline])(
+    "scopes %p reads to the current user within the tenant",
+    async (modelType: { new (): BaseModel }) => {
+      const projectId: ObjectID = ObjectID.generate();
+      const query: Query<BaseModel> =
+        await TenantPermission.addTenantScopeToQuery(
+          modelType,
+          {},
+          null,
+          { ...makeUserProps(), tenantId: projectId },
+          DatabaseRequestType.Read,
+        );
+
+      expect((query as any).projectId?.toString()).toBe(projectId.toString());
+      expect((query as any).userId?.toString()).toBe(userId.toString());
+    },
+  );
+
+  it("does not mutate a query reused for list and count permission checks", async () => {
+    const reusedQuery: Query<UserTotpAuth> = {};
+
+    await BasePermission.checkPermissions(
+      UserTotpAuth,
+      reusedQuery,
+      null,
+      makeUserProps(),
+      DatabaseRequestType.Read,
+    );
+    await expect(
+      BasePermission.checkPermissions(
+        UserTotpAuth,
+        reusedQuery,
+        null,
+        makeUserProps(),
+        DatabaseRequestType.Read,
+      ),
+    ).resolves.toBeDefined();
+
+    expect(reusedQuery).toEqual({});
+  });
+
+  it("isolates CurrentUser scope for every project in a multi-tenant query", async () => {
+    const currentUserProjectId: ObjectID = ObjectID.generate();
+    const adminProjectId: ObjectID = ObjectID.generate();
+
+    for (const projectIds of [
+      [currentUserProjectId, adminProjectId],
+      [adminProjectId, currentUserProjectId],
+    ]) {
+      const queries: Array<Record<string, unknown>> =
+        (await TenantPermission.addTenantScopeToQuery(
+          TenantScopedCurrentUserModel,
+          {},
+          null,
+          {
+            userId,
+            userGlobalAccessPermission: {
+              projectIds,
+              globalPermissions: [Permission.Public, Permission.CurrentUser],
+              _type: "UserGlobalAccessPermission",
+            },
+            userTenantAccessPermission: {
+              [adminProjectId.toString()]: {
+                projectId: adminProjectId,
+                permissions: [
+                  {
+                    permission: Permission.ProjectAdmin,
+                    labelIds: [],
+                    isBlockPermission: false,
+                    _type: "UserPermission",
+                  },
+                ],
+                _type: "UserTenantAccessPermission",
+              },
+            },
+          },
+          DatabaseRequestType.Read,
+        )) as unknown as Array<Record<string, unknown>>;
+
+      expect(queries).toHaveLength(2);
+      expect(
+        queries[projectIds.indexOf(currentUserProjectId)]?.["userId"],
+      ).toBeDefined();
+      expect(
+        queries[projectIds.indexOf(adminProjectId)]?.["userId"],
+      ).toBeUndefined();
+    }
+  });
+
+  it("rejects a cross-user delete before UserService inspects memberships", async () => {
+    await expect(
+      (UserService as any).onBeforeDelete({
+        query: { _id: victimUserId },
+        props: makeUserProps(),
+        limit: 1,
+        skip: 0,
+      } as DeleteBy<User>),
+    ).rejects.toThrow(NotAuthorizedException);
+  });
+
+  it("rejects broad update operators before UserService runs user hooks", async () => {
+    await expect(
+      (UserService as any).onBeforeUpdate({
+        query: { _id: new NotEqual<string>(userId.toString()) },
+        data: { password: "new-password" },
+        props: makeUserProps(),
+        limit: 1,
+        skip: 0,
+      } as unknown as UpdateBy<User>),
+    ).rejects.toThrow(NotAuthorizedException);
+  });
+});
+
+describe("two-factor credential ownership columns", () => {
+  it("prevents TOTP ownership and verification from being changed via CRUD", () => {
+    const model: UserTotpAuth = new UserTotpAuth();
+
+    expect(model.getColumnAccessControlFor("user")?.update).toEqual([]);
+    expect(model.getColumnAccessControlFor("user")?.create).toEqual([]);
+    expect(model.getColumnAccessControlFor("userId")?.update).toEqual([]);
+    expect(model.getColumnAccessControlFor("isVerified")?.update).toEqual([]);
+  });
+
+  it("prevents WebAuthn ownership from being changed via CRUD", () => {
+    const model: UserWebAuthn = new UserWebAuthn();
+
+    expect(model.getColumnAccessControlFor("user")?.update).toEqual([]);
+    expect(model.getColumnAccessControlFor("user")?.create).toEqual([]);
+    expect(model.getColumnAccessControlFor("userId")?.update).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Scope TOTP, WebAuthn, and session records to the authenticated owner, and fail closed when a `CurrentUser` grant cannot resolve to a user identity or ownership column.
- Make two-factor ownership and TOTP verification fields immutable through generic CRUD, preventing credential reassignment, nested relation injection, and self-verification.
- Apply the same owner metadata to user notification logs and run User update/delete hook lookups with the caller's authorization instead of root access.
- Preserve list/count query reuse and mixed-role multi-project queries by isolating permission-query mutation.

## Security impact

This confirms and fixes [GHSA-9q6r-9h5m-572w](https://github.com/OneUptime/oneuptime/security/advisories/GHSA-9q6r-9h5m-572w). Before this patch, an authenticated user could issue unscoped CRUD queries against TOTP and WebAuthn records. That exposed TOTP enrollment URIs (including the usable secret and account email) and allowed cross-user updates/deletes. The current master/12.0.5 code was also affected.

The TOTP enrollment URI remains readable to its now-enforced owner because the existing enrollment UI requires it; cross-user access is denied centrally.

## Validation

- `npm run fix`
- `cd Common && npm run compile`
- `cd Common && node node_modules/.bin/jest --runInBand Tests/Server/Types/Database/Permissions/TenantPermission.test.ts --detectOpenHandles --forceExit` — 21/21 tests passed
- `git diff --check`
