### PR TITLE
fix: harden outbound webhook targets against SSRF

### DIFF
--- a/App/FeatureSet/Notification/Services/WebhookService.ts
+++ b/App/FeatureSet/Notification/Services/WebhookService.ts
@@ -11,8 +11,12 @@ import API from "Common/Utils/API";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 import URL from "Common/Types/API/URL";
+import {
+  createSafeWebhookRequestAgents,
+  SafeWebhookRequestAgents,
+  validateWebhookTargetIsSafe,
+} from "Common/Server/Utils/WebhookTargetSafety";
 import crypto from "crypto";
-import dns from "dns";
 
 const WEBHOOK_REQUEST_TIMEOUT_MS: number = 10_000;
 const MAX_LOGGED_BODY_LENGTH: number = 2_000;
@@ -96,6 +100,8 @@ export default class WebhookService {
       }
 
       await validateWebhookTargetIsSafe(message.url);
+      const safeRequestAgents: SafeWebhookRequestAgents =
+        createSafeWebhookRequestAgents();
 
       const bodyString: string = JSON.stringify(message.payload || {});
 
@@ -131,6 +137,9 @@ export default class WebhookService {
           options: {
             timeout: WEBHOOK_REQUEST_TIMEOUT_MS,
             doNotFollowRedirects: true,
+            doNotUseProxy: true,
+            httpAgent: safeRequestAgents.httpAgent,
+            httpsAgent: safeRequestAgents.httpsAgent,
           },
         });
 
@@ -203,125 +212,6 @@ export default class WebhookService {
       throw sendError;
     }
   }
-}
-
-async function validateWebhookTargetIsSafe(rawUrl: string): Promise<void> {
-  let parsed: URL;
-  try {
-    parsed = URL.fromString(rawUrl);
-  } catch {
-    throw new BadDataException("Webhook URL is not a valid URL");
-  }
-
-  const protocolValue: string = parsed.protocol.toString().toLowerCase();
-  if (protocolValue !== "http://" && protocolValue !== "https://") {
-    throw new BadDataException("Webhook URL must use http or https protocol.");
-  }
-
-  const hostname: string = parsed.hostname.hostname.toLowerCase();
-
-  if (!hostname) {
-    throw new BadDataException("Webhook URL must include a host.");
-  }
-
-  if (isBlockedHostnameLiteral(hostname)) {
-    throw new BadDataException(
-      "Webhook URL points to a private, loopback, or link-local address and is not allowed.",
-    );
-  }
-
-  if (!isIpLiteral(hostname)) {
-    let resolved: Array<{ address: string }> = [];
-    try {
-      resolved = await dns.promises.lookup(hostname, { all: true });
-    } catch {
-      throw new BadDataException(
-        "Webhook URL hostname could not be resolved via DNS.",
-      );
-    }
-
-    for (const entry of resolved) {
-      if (isBlockedHostnameLiteral(entry.address.toLowerCase())) {
-        throw new BadDataException(
-          "Webhook URL resolves to a private, loopback, or link-local address and is not allowed.",
-        );
-      }
-    }
-  }
-}
-
-const IPV4_LITERAL_REGEX: RegExp = /^(\d{1,3}\.){3}\d{1,3}$/;
-const IPV6_UNIQUE_LOCAL_REGEX: RegExp = /^f[cd][0-9a-f]{2}:/;
-
-function isIpLiteral(hostname: string): boolean {
-  return IPV4_LITERAL_REGEX.test(hostname) || hostname.includes(":");
-}
-
-function isBlockedHostnameLiteral(hostname: string): boolean {
-  if (
-    hostname === "localhost" ||
-    hostname.endsWith(".localhost") ||
-    hostname === "metadata.google.internal"
-  ) {
-    return true;
-  }
-
-  const ipv4Match: RegExpMatchArray | null = hostname.match(
-    /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/,
-  );
-  if (ipv4Match) {
-    const octets: Array<number> = [
-      Number(ipv4Match[1]),
-      Number(ipv4Match[2]),
-      Number(ipv4Match[3]),
-      Number(ipv4Match[4]),
-    ];
-
-    if (
-      octets.some((o: number) => {
-        return o < 0 || o > 255;
-      })
-    ) {
-      return true;
-    }
-    if (octets[0] === 0) {
-      return true;
-    }
-    if (octets[0] === 127) {
-      return true;
-    }
-    if (octets[0] === 10) {
-      return true;
-    }
-    if (octets[0] === 172 && (octets[1]! & 0xf0) === 16) {
-      return true;
-    }
-    if (octets[0] === 192 && octets[1] === 168) {
-      return true;
-    }
-    if (octets[0] === 169 && octets[1] === 254) {
-      return true;
-    }
-    if (octets[0] === 100 && (octets[1]! & 0xc0) === 64) {
-      return true;
-    }
-    return false;
-  }
-
-  if (hostname.includes(":")) {
-    const stripped: string = hostname.replace(/^\[|\]$/g, "");
-    if (stripped === "::1" || stripped === "::") {
-      return true;
-    }
-    if (stripped.startsWith("fe80:") || stripped.startsWith("fe80::")) {
-      return true;
-    }
-    if (IPV6_UNIQUE_LOCAL_REGEX.test(stripped)) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 function truncate(value: string, maxLength: number): string {

--- a/Common/Server/Services/StatusPageSubscriberService.ts
+++ b/Common/Server/Services/StatusPageSubscriberService.ts
@@ -37,6 +37,7 @@ import NumberUtil from "../../Utils/Number";
 import SlackUtil from "../Utils/Workspace/Slack/Slack";
 import MicrosoftTeamsUtil from "../Utils/Workspace/MicrosoftTeams/MicrosoftTeams";
 import StatusPageSubscriberWebhookUtil from "../Utils/StatusPageSubscriberWebhook";
+import { validateWebhookTargetIsSafe } from "../Utils/WebhookTargetSafety";
 import StatusPageSubscriberNotificationTemplateService, {
   Service as StatusPageSubscriberNotificationTemplateServiceClass,
 } from "./StatusPageSubscriberNotificationTemplateService";
@@ -71,6 +72,10 @@ export class Service extends DatabaseService<Model> {
         statusPageId: data.data.statusPageId?.toString(),
       } as LogAttributes);
       throw new BadDataException("Project ID is required.");
+    }
+
+    if (data.data.subscriberWebhook) {
+      await validateWebhookTargetIsSafe(data.data.subscriberWebhook.toString());
     }
 
     const projectId: ObjectID = data.data.projectId;

--- a/Common/Server/Services/UserWebhookService.ts
+++ b/Common/Server/Services/UserWebhookService.ts
@@ -6,9 +6,9 @@ import UserNotificationRuleService from "./UserNotificationRuleService";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
 import Model from "../../Models/DatabaseModels/UserWebhook";
-import URL from "../../Types/API/URL";
 import logger from "../Utils/Logger";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import { validateWebhookTargetIsSafe } from "../Utils/WebhookTargetSafety";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -27,7 +27,7 @@ export class Service extends DatabaseService<Model> {
       throw new BadDataException("Webhook name is required");
     }
 
-    this.validateWebhookUrl(createBy.data.webhookUrl);
+    await validateWebhookTargetIsSafe(createBy.data.webhookUrl);
 
     return {
       createBy,
@@ -96,113 +96,6 @@ export class Service extends DatabaseService<Model> {
       carryForward: null,
     };
   }
-
-  private validateWebhookUrl(rawUrl: string): void {
-    let parsed: URL;
-    try {
-      parsed = URL.fromString(rawUrl);
-    } catch {
-      throw new BadDataException("Webhook URL is not a valid URL");
-    }
-
-    const protocolValue: string = parsed.protocol.toString().toLowerCase();
-    if (protocolValue !== "http://" && protocolValue !== "https://") {
-      throw new BadDataException(
-        "Webhook URL must use http or https protocol.",
-      );
-    }
-
-    const hostname: string = parsed.hostname.hostname.toLowerCase();
-
-    if (!hostname) {
-      throw new BadDataException("Webhook URL must include a host.");
-    }
-
-    if (isBlockedHostnameLiteral(hostname)) {
-      throw new BadDataException(
-        "Webhook URL points to a private, loopback, or link-local address and is not allowed.",
-      );
-    }
-  }
 }
-
-function isBlockedHostnameLiteral(hostname: string): boolean {
-  if (
-    hostname === "localhost" ||
-    hostname.endsWith(".localhost") ||
-    hostname === "metadata.google.internal"
-  ) {
-    return true;
-  }
-
-  // IPv4 literal check
-  const ipv4Match: RegExpMatchArray | null = hostname.match(
-    /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/,
-  );
-  if (ipv4Match) {
-    const octets: Array<number> = [
-      Number(ipv4Match[1]),
-      Number(ipv4Match[2]),
-      Number(ipv4Match[3]),
-      Number(ipv4Match[4]),
-    ];
-
-    if (
-      octets.some((o: number) => {
-        return o < 0 || o > 255;
-      })
-    ) {
-      return true;
-    }
-
-    // 0.0.0.0/8
-    if (octets[0] === 0) {
-      return true;
-    }
-    // 127.0.0.0/8 loopback
-    if (octets[0] === 127) {
-      return true;
-    }
-    // 10.0.0.0/8
-    if (octets[0] === 10) {
-      return true;
-    }
-    // 172.16.0.0/12
-    if (octets[0] === 172 && (octets[1]! & 0xf0) === 16) {
-      return true;
-    }
-    // 192.168.0.0/16
-    if (octets[0] === 192 && octets[1] === 168) {
-      return true;
-    }
-    // 169.254.0.0/16 link-local (incl. cloud metadata)
-    if (octets[0] === 169 && octets[1] === 254) {
-      return true;
-    }
-    // 100.64.0.0/10 carrier-grade NAT
-    if (octets[0] === 100 && (octets[1]! & 0xc0) === 64) {
-      return true;
-    }
-    return false;
-  }
-
-  // IPv6 literal — block loopback, link-local, unique-local
-  if (hostname.includes(":")) {
-    const stripped: string = hostname.replace(/^\[|\]$/g, "");
-    if (stripped === "::1" || stripped === "::") {
-      return true;
-    }
-    if (stripped.startsWith("fe80:") || stripped.startsWith("fe80::")) {
-      return true;
-    }
-    if (IPV6_UNIQUE_LOCAL_REGEX.test(stripped)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-const IPV6_UNIQUE_LOCAL_REGEX: RegExp = /^f[cd][0-9a-f]{2}:/;
 
 export default new Service();

--- a/Common/Server/Utils/StatusPageSubscriberWebhook.ts
+++ b/Common/Server/Utils/StatusPageSubscriberWebhook.ts
@@ -4,6 +4,13 @@ import HTTPErrorResponse from "../../Types/API/HTTPErrorResponse";
 import HTTPResponse from "../../Types/API/HTTPResponse";
 import { JSONObject } from "../../Types/JSON";
 import logger from "./Logger";
+import {
+  createSafeWebhookRequestAgents,
+  SafeWebhookRequestAgents,
+  validateWebhookTargetIsSafe,
+} from "./WebhookTargetSafety";
+
+const WEBHOOK_REQUEST_TIMEOUT_MS: number = 10_000;
 
 export interface StatusPageWebhookPayload extends JSONObject {
   eventType: string;
@@ -21,6 +28,10 @@ export default class StatusPageSubscriberWebhookUtil {
   }): Promise<HTTPResponse<JSONObject> | HTTPErrorResponse> {
     logger.debug("Sending status page subscriber webhook notification.");
 
+    await validateWebhookTargetIsSafe(data.webhookUrl.toString());
+    const safeRequestAgents: SafeWebhookRequestAgents =
+      createSafeWebhookRequestAgents();
+
     const apiResult: HTTPResponse<JSONObject> | HTTPErrorResponse =
       await API.post({
         url: data.webhookUrl,
@@ -28,6 +39,11 @@ export default class StatusPageSubscriberWebhookUtil {
         options: {
           retries: 3,
           exponentialBackoff: true,
+          timeout: WEBHOOK_REQUEST_TIMEOUT_MS,
+          doNotFollowRedirects: true,
+          doNotUseProxy: true,
+          httpAgent: safeRequestAgents.httpAgent,
+          httpsAgent: safeRequestAgents.httpsAgent,
         },
       });
 

--- a/Common/Server/Utils/WebhookTargetSafety.ts
+++ b/Common/Server/Utils/WebhookTargetSafety.ts
@@ -1,0 +1,278 @@
+import BadDataException from "../../Types/Exception/BadDataException";
+import dns from "dns";
+import http from "http";
+import https from "https";
+import { isIP, type LookupFunction } from "net";
+
+export interface SafeWebhookRequestAgents {
+  httpAgent: http.Agent;
+  httpsAgent: https.Agent;
+}
+
+export async function validateWebhookTargetIsSafe(
+  rawUrl: string,
+): Promise<void> {
+  const hostname: string = getValidatedWebhookHostname(rawUrl);
+
+  if (isIP(hostname)) {
+    assertPublicIpAddress(hostname);
+    return;
+  }
+
+  let resolvedAddresses: Array<dns.LookupAddress> = [];
+  try {
+    resolvedAddresses = await dns.promises.lookup(hostname, { all: true });
+  } catch {
+    throw new BadDataException(
+      "Webhook URL hostname could not be resolved via DNS.",
+    );
+  }
+
+  assertResolvedAddressesAreSafe(resolvedAddresses);
+}
+
+export function createSafeWebhookRequestAgents(): SafeWebhookRequestAgents {
+  return {
+    httpAgent: new http.Agent({ lookup: safeWebhookLookup }),
+    httpsAgent: new https.Agent({ lookup: safeWebhookLookup }),
+  };
+}
+
+const safeWebhookLookup: LookupFunction = (
+  hostname: string,
+  options: dns.LookupOptions,
+  callback: (
+    error: NodeJS.ErrnoException | null,
+    address: string | Array<dns.LookupAddress>,
+    family?: number,
+  ) => void,
+): void => {
+  const normalizedHostname: string = normalizeHostname(hostname);
+
+  if (isIP(normalizedHostname)) {
+    try {
+      assertPublicIpAddress(normalizedHostname);
+      callback(null, normalizedHostname, isIP(normalizedHostname));
+    } catch (error) {
+      callback(toLookupError(error), "", 0);
+    }
+    return;
+  }
+
+  dns.lookup(
+    normalizedHostname,
+    {
+      ...options,
+      all: true,
+    },
+    (
+      error: NodeJS.ErrnoException | null,
+      addresses: Array<dns.LookupAddress>,
+    ): void => {
+      if (error) {
+        callback(error, [], 0);
+        return;
+      }
+
+      try {
+        assertResolvedAddressesAreSafe(addresses);
+      } catch (lookupError) {
+        callback(toLookupError(lookupError), [], 0);
+        return;
+      }
+
+      if (options.all) {
+        callback(null, addresses);
+        return;
+      }
+
+      const firstAddress: dns.LookupAddress | undefined = addresses[0];
+      if (!firstAddress) {
+        callback(
+          createLookupError("Webhook URL hostname did not resolve."),
+          "",
+          0,
+        );
+        return;
+      }
+
+      callback(null, firstAddress.address, firstAddress.family);
+    },
+  );
+};
+
+function getValidatedWebhookHostname(rawUrl: string): string {
+  let parsedUrl: globalThis.URL;
+  try {
+    parsedUrl = new globalThis.URL(rawUrl);
+  } catch {
+    throw new BadDataException("Webhook URL is not a valid URL");
+  }
+
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new BadDataException("Webhook URL must use http or https protocol.");
+  }
+
+  const hostname: string = normalizeHostname(parsedUrl.hostname);
+
+  if (!hostname) {
+    throw new BadDataException("Webhook URL must include a host.");
+  }
+
+  if (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname === "metadata.google.internal"
+  ) {
+    throw new BadDataException(
+      "Webhook URL points to a private, loopback, or link-local address and is not allowed.",
+    );
+  }
+
+  return hostname;
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/\.$/, "");
+}
+
+function assertResolvedAddressesAreSafe(
+  addresses: Array<dns.LookupAddress>,
+): void {
+  if (addresses.length === 0) {
+    throw new BadDataException("Webhook URL hostname did not resolve.");
+  }
+
+  for (const entry of addresses) {
+    assertPublicIpAddress(normalizeHostname(entry.address));
+  }
+}
+
+function assertPublicIpAddress(address: string): void {
+  const family: number = isIP(address);
+
+  if (
+    family === 0 ||
+    (family === 4 && isBlockedIpv4Address(address)) ||
+    (family === 6 && isBlockedIpv6Address(address))
+  ) {
+    throw new BadDataException(
+      "Webhook URL points to a private, loopback, link-local, or reserved address and is not allowed.",
+    );
+  }
+}
+
+function isBlockedIpv4Address(address: string): boolean {
+  const octets: Array<number> = address.split(".").map((value: string) => {
+    return Number(value);
+  });
+  const first: number = octets[0] as number;
+  const second: number = octets[1] as number;
+  const third: number = octets[2] as number;
+
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 0 && third === 0) ||
+    (first === 192 && second === 0 && third === 2) ||
+    (first === 192 && second === 168) ||
+    (first === 198 && (second === 18 || second === 19)) ||
+    (first === 198 && second === 51 && third === 100) ||
+    (first === 203 && second === 0 && third === 113) ||
+    first >= 224
+  );
+}
+
+function isBlockedIpv6Address(address: string): boolean {
+  const words: Array<number> | null = parseIpv6Words(address);
+
+  if (!words) {
+    return true;
+  }
+
+  const isIpv4Mapped: boolean =
+    words.slice(0, 5).every((word: number) => {
+      return word === 0;
+    }) && words[5] === 0xffff;
+
+  if (isIpv4Mapped) {
+    const mappedIpv4Address: string = [
+      (words[6] as number) >> 8,
+      (words[6] as number) & 0xff,
+      (words[7] as number) >> 8,
+      (words[7] as number) & 0xff,
+    ].join(".");
+
+    return isBlockedIpv4Address(mappedIpv4Address);
+  }
+
+  /*
+   * Publicly routable IPv6 unicast space is 2000::/3. Everything outside
+   * that range is local, reserved, multicast, or otherwise non-global.
+   */
+  return ((words[0] as number) & 0xe000) !== 0x2000;
+}
+
+function parseIpv6Words(address: string): Array<number> | null {
+  const halves: Array<string> = address.split("::");
+  if (halves.length > 2) {
+    return null;
+  }
+
+  const left: Array<string> = halves[0] ? halves[0].split(":") : [];
+  const right: Array<string> = halves[1] ? halves[1].split(":") : [];
+  const missingWords: number = 8 - left.length - right.length;
+
+  if (
+    missingWords < 0 ||
+    (halves.length === 1 && missingWords !== 0) ||
+    (halves.length === 2 && missingWords < 1)
+  ) {
+    return null;
+  }
+
+  const wordStrings: Array<string> = [
+    ...left,
+    ...Array<string>(missingWords).fill("0"),
+    ...right,
+  ];
+
+  const words: Array<number> = wordStrings.map((word: string) => {
+    return Number.parseInt(word, 16);
+  });
+
+  if (
+    words.length !== 8 ||
+    words.some((word: number) => {
+      return !Number.isInteger(word) || word < 0 || word > 0xffff;
+    })
+  ) {
+    return null;
+  }
+
+  return words;
+}
+
+function toLookupError(error: unknown): NodeJS.ErrnoException {
+  if (error instanceof Error) {
+    const lookupError: NodeJS.ErrnoException = error;
+    lookupError.code = "EACCES";
+    return lookupError;
+  }
+
+  return createLookupError("Unsafe webhook target.");
+}
+
+function createLookupError(message: string): NodeJS.ErrnoException {
+  const error: NodeJS.ErrnoException = new Error(message);
+  error.code = "EACCES";
+  return error;
+}

--- a/Common/Tests/Server/Utils/WebhookTargetSafety.test.ts
+++ b/Common/Tests/Server/Utils/WebhookTargetSafety.test.ts
@@ -1,0 +1,206 @@
+import {
+  createSafeWebhookRequestAgents,
+  SafeWebhookRequestAgents,
+  validateWebhookTargetIsSafe,
+} from "../../../Server/Utils/WebhookTargetSafety";
+import StatusPageSubscriberWebhookUtil from "../../../Server/Utils/StatusPageSubscriberWebhook";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import URL from "../../../Types/API/URL";
+import API from "../../../Utils/API";
+import dns from "dns";
+import http from "http";
+import https from "https";
+import type { LookupFunction } from "net";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+describe("WebhookTargetSafety", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test.each([
+    "http://127.0.0.1/webhook",
+    "http://127.0.0.1:3000/webhook",
+    "http://2130706433/webhook",
+    "http://0x7f000001/webhook",
+    "http://0177.0.0.1/webhook",
+    "http://10.0.0.1/webhook",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://192.168.1.1/webhook",
+    "http://localhost/webhook",
+    "http://metadata.google.internal/computeMetadata/v1/",
+    "http://[::]/webhook",
+    "http://[::1]/webhook",
+    "http://[::ffff:127.0.0.1]/webhook",
+    "http://[fc00::1]/webhook",
+    "http://[febf::1]/webhook",
+    "file:///etc/passwd",
+  ])("rejects non-public webhook target %s", async (target: string) => {
+    await expect(validateWebhookTargetIsSafe(target)).rejects.toThrow(
+      /not allowed|http or https/,
+    );
+  });
+
+  test("rejects a hostname when any DNS answer is private", async () => {
+    jest.spyOn(dns.promises, "lookup").mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "10.0.0.5", family: 4 },
+    ] as never);
+
+    await expect(
+      validateWebhookTargetIsSafe("https://webhook.example/notify"),
+    ).rejects.toThrow(/not allowed/);
+  });
+
+  test("allows a public HTTPS target with a port", async () => {
+    jest.spyOn(dns.promises, "lookup").mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+    ] as never);
+
+    await expect(
+      validateWebhookTargetIsSafe("https://webhook.example:8443/notify"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("creates guarded HTTP and HTTPS request agents", () => {
+    const agents: SafeWebhookRequestAgents = createSafeWebhookRequestAgents();
+
+    expect(agents.httpAgent).toBeInstanceOf(http.Agent);
+    expect(agents.httpsAgent).toBeInstanceOf(https.Agent);
+  });
+
+  test("rejects a private address returned during the connection lookup", async () => {
+    jest
+      .spyOn(dns.promises, "lookup")
+      .mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
+
+    await expect(
+      validateWebhookTargetIsSafe("https://rebind.example/webhook"),
+    ).resolves.toBeUndefined();
+
+    const lookupImplementation: (
+      hostname: string,
+      options: dns.LookupAllOptions,
+      callback: (
+        error: NodeJS.ErrnoException | null,
+        addresses: Array<dns.LookupAddress>,
+      ) => void,
+    ) => void = (
+      _hostname: string,
+      _options: dns.LookupAllOptions,
+      callback: (
+        error: NodeJS.ErrnoException | null,
+        addresses: Array<dns.LookupAddress>,
+      ) => void,
+    ): void => {
+      callback(null, [{ address: "10.0.0.5", family: 4 }]);
+    };
+
+    jest
+      .spyOn(dns, "lookup")
+      .mockImplementation(lookupImplementation as unknown as typeof dns.lookup);
+
+    const agents: SafeWebhookRequestAgents = createSafeWebhookRequestAgents();
+
+    await expect(
+      runAgentLookup(agents.httpAgent, "rebind.example"),
+    ).rejects.toMatchObject({ code: "EACCES" });
+  });
+
+  test("does not dispatch an unsafe stored status-page subscriber webhook", async () => {
+    jest.spyOn(API, "post");
+
+    await expect(
+      StatusPageSubscriberWebhookUtil.sendWebhookNotification({
+        webhookUrl: URL.fromString("http://169.254.169.254/latest/meta-data/"),
+        payload: {
+          eventType: "Incident",
+          statusPageId: "status-page-id",
+          statusPageName: "Status Page",
+          statusPageUrl: "https://status.example.com",
+          unsubscribeUrl: "https://status.example.com/unsubscribe",
+          data: {},
+        },
+      }),
+    ).rejects.toThrow(/not allowed/);
+
+    expect(API.post).not.toHaveBeenCalled();
+  });
+
+  test("sends a public target with guarded request options", async () => {
+    jest
+      .spyOn(dns.promises, "lookup")
+      .mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
+    jest
+      .spyOn(API, "post")
+      .mockResolvedValue(new HTTPResponse(200, {}, {}) as never);
+
+    await StatusPageSubscriberWebhookUtil.sendWebhookNotification({
+      webhookUrl: URL.fromString("https://webhook.example/events"),
+      payload: {
+        eventType: "Incident",
+        statusPageId: "status-page-id",
+        statusPageName: "Status Page",
+        statusPageUrl: "https://status.example.com",
+        unsubscribeUrl: "https://status.example.com/unsubscribe",
+        data: {},
+      },
+    });
+
+    expect(API.post).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          timeout: 10_000,
+          doNotFollowRedirects: true,
+          doNotUseProxy: true,
+          httpAgent: expect.any(http.Agent),
+          httpsAgent: expect.any(https.Agent),
+        }),
+      }),
+    );
+  });
+});
+
+function runAgentLookup(
+  agent: http.Agent,
+  hostname: string,
+): Promise<{ address: string | Array<dns.LookupAddress>; family?: number }> {
+  const lookup: LookupFunction | undefined = (
+    agent as unknown as { options: { lookup?: LookupFunction | undefined } }
+  ).options.lookup;
+
+  if (!lookup) {
+    throw new Error("Guarded webhook agent does not have a lookup function.");
+  }
+
+  return new Promise(
+    (
+      resolve: (result: {
+        address: string | Array<dns.LookupAddress>;
+        family?: number;
+      }) => void,
+      reject: (error: NodeJS.ErrnoException) => void,
+    ): void => {
+      lookup(
+        hostname,
+        { all: false },
+        (
+          error: NodeJS.ErrnoException | null,
+          address: string | Array<dns.LookupAddress>,
+          family?: number,
+        ): void => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve({
+            address,
+            ...(family !== undefined ? { family } : {}),
+          });
+        },
+      );
+    },
+  );
+}

--- a/Common/Tests/Utils/API.test.ts
+++ b/Common/Tests/Utils/API.test.ts
@@ -20,6 +20,8 @@ import axios, {
   AxiosStatic,
   Method,
 } from "axios";
+import http from "http";
+import https from "https";
 
 const DEFAULT_HEADERS: Headers = {
   "Access-Control-Allow-Origin": "*",
@@ -505,6 +507,40 @@ describe("API instance properties", () => {
 });
 
 describe("API.fetch with options", () => {
+  test("should apply guarded network request options", async () => {
+    mockedAxios.mockResolvedValueOnce(
+      createAxiosResponse({ data: responseData }),
+    );
+
+    const httpAgent: http.Agent = new http.Agent();
+    const httpsAgent: https.Agent = new https.Agent();
+
+    await API.fetch({
+      method: HTTPMethod.POST,
+      url: new URL(Protocol.HTTPS, "webhook.example", new Route("events")),
+      data: requestData,
+      options: {
+        timeout: 10_000,
+        doNotFollowRedirects: true,
+        doNotUseProxy: true,
+        httpAgent,
+        httpsAgent,
+      },
+    });
+
+    expect(mockedAxios).toHaveBeenLastCalledWith({
+      method: "POST",
+      url: "https://webhook.example/events",
+      headers: DEFAULT_HEADERS,
+      data: requestData,
+      timeout: 10_000,
+      maxRedirects: 0,
+      proxy: false,
+      httpAgent,
+      httpsAgent,
+    });
+  });
+
   test("should make request with query parameters", async () => {
     mockedAxios.mockResolvedValueOnce(
       createAxiosResponse({ data: responseData }),

--- a/Common/Utils/API.ts
+++ b/Common/Utils/API.ts
@@ -53,6 +53,7 @@ export interface RequestOptions {
   exponentialBackoff?: boolean | undefined;
   timeout?: number | undefined;
   doNotFollowRedirects?: boolean | undefined;
+  doNotUseProxy?: boolean | undefined;
   // Per-request proxy agent support (Probe supplies these instead of mutating global axios defaults)
   httpAgent?: HttpAgent | undefined;
   httpsAgent?: HttpsAgent | undefined;
@@ -440,6 +441,10 @@ export default class API {
 
           if (options?.doNotFollowRedirects) {
             axiosOptions.maxRedirects = 0;
+          }
+
+          if (options?.doNotUseProxy) {
+            axiosOptions.proxy = false;
           }
 
           // Attach proxy agents per request if provided (avoids global side-effects)


### PR DESCRIPTION
## Summary

Closes the blind SSRF path reported in GHSA-gf3v-98g2-qffx and hardens the other outbound webhook paths that shared weaker validation.

## What changed

- add one server-side webhook target validator using the native WHATWG URL parser
- reject non-HTTP(S), local, private, link-local, reserved, and unsafe IPv4/IPv6 targets, including unusual IPv4 spellings and IPv4-mapped IPv6
- validate DNS answers before accepting a webhook and again during the socket lookup to prevent DNS rebinding
- validate status-page subscriber webhooks before persistence and before every dispatch, covering existing stored rows
- disable redirects and environment-proxy routing, and enforce a 10-second timeout for status-page webhook delivery
- reuse the same protection for notification and user webhook flows

## Why

The advisory's sample endpoint and some impact claims are inaccurate, but the underlying issue is real: the public status-page subscription flow can accept a webhook URL and immediately cause a server-side POST to it.

## Validation

- `npm run fix`
- `cd Common && npm run compile`
- `cd App && npm run compile` (with branch-local `Common` resolution and a raised Node heap for this worktree)
- 49 focused Jest tests across `WebhookTargetSafety.test.ts` and `API.test.ts`

The focused tests cover private and loopback literals with ports, non-canonical IPv4 encodings, IPv6 and IPv4-mapped IPv6, mixed DNS answers, DNS rebinding at connection time, legacy stored webhook rejection, redirects/proxy/timeout options, and allowed public destinations.
