### PR TITLE
test: expand unit + E2E coverage (recording-rule DSL, enterprise seat counting, notification rules, App health)

### DIFF
--- a/Common/Tests/Types/Workspace/NotificationRules/NotificationRuleUtil.test.ts
+++ b/Common/Tests/Types/Workspace/NotificationRules/NotificationRuleUtil.test.ts
@@ -1,0 +1,304 @@
+import FilterCondition from "../../../../Types/Filter/FilterCondition";
+import NotificationRuleCondition, {
+  ConditionType,
+  NotificationRuleConditionCheckOn,
+} from "../../../../Types/Workspace/NotificationRules/NotificationRuleCondition";
+import IncidentNotificationRule from "../../../../Types/Workspace/NotificationRules/NotificationRuleTypes/IncidentNotificationRule";
+import { WorkspaceNotificationRuleUtil } from "../../../../Types/Workspace/NotificationRules/NotificationRuleUtil";
+
+type RuleValues = {
+  [key in NotificationRuleConditionCheckOn]: string | Array<string> | undefined;
+};
+
+// Build a minimal rule object; isRuleMatching only reads filters + filterCondition.
+function rule(
+  filterCondition: FilterCondition,
+  filters: Array<NotificationRuleCondition>,
+): IncidentNotificationRule {
+  return {
+    filterCondition,
+    filters,
+  } as unknown as IncidentNotificationRule;
+}
+
+// Convenience: a single-filter rule that always uses ALL so one filter decides.
+function singleFilter(
+  checkOn: NotificationRuleConditionCheckOn,
+  conditionType: ConditionType | undefined,
+  value: string | Array<string> | undefined,
+): IncidentNotificationRule {
+  return rule(FilterCondition.All, [{ checkOn, conditionType, value }]);
+}
+
+function matches(
+  notificationRule: IncidentNotificationRule,
+  values: Partial<RuleValues>,
+): boolean {
+  return WorkspaceNotificationRuleUtil.isRuleMatching({
+    notificationRule,
+    values: values as RuleValues,
+  });
+}
+
+const CHECK: NotificationRuleConditionCheckOn =
+  NotificationRuleConditionCheckOn.IncidentTitle;
+const SEV: NotificationRuleConditionCheckOn =
+  NotificationRuleConditionCheckOn.IncidentSeverity;
+
+describe("WorkspaceNotificationRuleUtil.isRuleMatching", () => {
+  describe("filter list semantics", () => {
+    test("matches by default when there are no filters", () => {
+      expect(matches(rule(FilterCondition.All, []), {})).toBe(true);
+      expect(matches(rule(FilterCondition.Any, []), {})).toBe(true);
+    });
+
+    test("skips filters that have no condition type", () => {
+      // Only filter has no condition -> under ALL it is skipped, rule matches.
+      const r: IncidentNotificationRule = singleFilter(
+        CHECK,
+        undefined,
+        "anything",
+      );
+      expect(matches(r, { [CHECK]: "Down" })).toBe(true);
+    });
+
+    test("ALL requires every filter to match", () => {
+      const r: IncidentNotificationRule = rule(FilterCondition.All, [
+        { checkOn: CHECK, conditionType: ConditionType.EqualTo, value: "Down" },
+        {
+          checkOn: SEV,
+          conditionType: ConditionType.EqualTo,
+          value: "Critical",
+        },
+      ]);
+      expect(matches(r, { [CHECK]: "Down", [SEV]: "Critical" })).toBe(true);
+      expect(matches(r, { [CHECK]: "Down", [SEV]: "Low" })).toBe(false);
+    });
+
+    test("ANY matches when at least one filter matches", () => {
+      const r: IncidentNotificationRule = rule(FilterCondition.Any, [
+        { checkOn: CHECK, conditionType: ConditionType.EqualTo, value: "Down" },
+        {
+          checkOn: SEV,
+          conditionType: ConditionType.EqualTo,
+          value: "Critical",
+        },
+      ]);
+      expect(matches(r, { [CHECK]: "Up", [SEV]: "Critical" })).toBe(true);
+      expect(matches(r, { [CHECK]: "Up", [SEV]: "Low" })).toBe(false);
+    });
+
+    test("returns false for an unrecognized filter condition", () => {
+      const r: IncidentNotificationRule = rule(
+        "Nonsense" as unknown as FilterCondition,
+        [{ checkOn: CHECK, conditionType: ConditionType.EqualTo, value: "x" }],
+      );
+      expect(matches(r, { [CHECK]: "x" })).toBe(false);
+    });
+  });
+
+  describe("undefined handling", () => {
+    test("does not match when the observed value is undefined", () => {
+      const r: IncidentNotificationRule = singleFilter(
+        CHECK,
+        ConditionType.EqualTo,
+        "Down",
+      );
+      expect(matches(r, {})).toBe(false);
+    });
+
+    test("does not match when the filter value is undefined", () => {
+      const r: IncidentNotificationRule = singleFilter(
+        CHECK,
+        ConditionType.EqualTo,
+        undefined,
+      );
+      expect(matches(r, { [CHECK]: "Down" })).toBe(false);
+    });
+  });
+
+  describe("EqualTo / NotEqualTo", () => {
+    test("compares numeric strings as numbers", () => {
+      expect(
+        matches(singleFilter(CHECK, ConditionType.EqualTo, "5.0"), {
+          [CHECK]: "5",
+        }),
+      ).toBe(true);
+    });
+
+    test("compares non-numeric strings literally", () => {
+      expect(
+        matches(singleFilter(CHECK, ConditionType.EqualTo, "Down"), {
+          [CHECK]: "Down",
+        }),
+      ).toBe(true);
+      expect(
+        matches(singleFilter(CHECK, ConditionType.EqualTo, "Down"), {
+          [CHECK]: "up",
+        }),
+      ).toBe(false);
+    });
+
+    test("NotEqualTo is the inverse for scalars", () => {
+      expect(
+        matches(singleFilter(CHECK, ConditionType.NotEqualTo, "Down"), {
+          [CHECK]: "Up",
+        }),
+      ).toBe(true);
+      expect(
+        matches(singleFilter(CHECK, ConditionType.NotEqualTo, "Down"), {
+          [CHECK]: "Down",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("numeric comparisons", () => {
+    test("GreaterThan / LessThan", () => {
+      expect(
+        matches(singleFilter(SEV, ConditionType.GreaterThan, "3"), {
+          [SEV]: "5",
+        }),
+      ).toBe(true);
+      expect(
+        matches(singleFilter(SEV, ConditionType.GreaterThan, "5"), {
+          [SEV]: "5",
+        }),
+      ).toBe(false);
+      expect(
+        matches(singleFilter(SEV, ConditionType.LessThan, "5"), {
+          [SEV]: "3",
+        }),
+      ).toBe(true);
+    });
+
+    test("GreaterThanOrEqualTo / LessThanOrEqualTo include equality", () => {
+      expect(
+        matches(singleFilter(SEV, ConditionType.GreaterThanOrEqualTo, "5"), {
+          [SEV]: "5",
+        }),
+      ).toBe(true);
+      expect(
+        matches(singleFilter(SEV, ConditionType.LessThanOrEqualTo, "5"), {
+          [SEV]: "5",
+        }),
+      ).toBe(true);
+      expect(
+        matches(singleFilter(SEV, ConditionType.LessThanOrEqualTo, "5"), {
+          [SEV]: "6",
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe("substring conditions", () => {
+    test("Contains / ContainsAny", () => {
+      expect(
+        matches(singleFilter(CHECK, ConditionType.Contains, "base"), {
+          [CHECK]: "database is down",
+        }),
+      ).toBe(true);
+      expect(
+        matches(singleFilter(CHECK, ConditionType.Contains, "network"), {
+          [CHECK]: "database is down",
+        }),
+      ).toBe(false);
+    });
+
+    test("NotContains", () => {
+      expect(
+        matches(singleFilter(CHECK, ConditionType.NotContains, "network"), {
+          [CHECK]: "database is down",
+        }),
+      ).toBe(true);
+      expect(
+        matches(singleFilter(CHECK, ConditionType.NotContains, "base"), {
+          [CHECK]: "database is down",
+        }),
+      ).toBe(false);
+    });
+
+    test("StartsWith / EndsWith", () => {
+      expect(
+        matches(singleFilter(CHECK, ConditionType.StartsWith, "data"), {
+          [CHECK]: "database down",
+        }),
+      ).toBe(true);
+      expect(
+        matches(singleFilter(CHECK, ConditionType.EndsWith, "down"), {
+          [CHECK]: "database down",
+        }),
+      ).toBe(true);
+      expect(
+        matches(singleFilter(CHECK, ConditionType.EndsWith, "up"), {
+          [CHECK]: "database down",
+        }),
+      ).toBe(false);
+    });
+
+    test("ContainsAll requires every filter value to be present somewhere", () => {
+      const labels: NotificationRuleConditionCheckOn =
+        NotificationRuleConditionCheckOn.IncidentLabels;
+      expect(
+        matches(
+          singleFilter(labels, ConditionType.ContainsAll, ["prod", "db"]),
+          { [labels]: ["prod-cluster", "db-primary"] },
+        ),
+      ).toBe(true);
+      expect(
+        matches(
+          singleFilter(labels, ConditionType.ContainsAll, ["prod", "cache"]),
+          { [labels]: ["prod-cluster", "db-primary"] },
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("emptiness and boolean conditions", () => {
+    test("IsEmpty / IsNotEmpty for strings", () => {
+      expect(
+        matches(singleFilter(CHECK, ConditionType.IsEmpty, "ignored"), {
+          [CHECK]: "",
+        }),
+      ).toBe(true);
+      expect(
+        matches(singleFilter(CHECK, ConditionType.IsNotEmpty, "ignored"), {
+          [CHECK]: "something",
+        }),
+      ).toBe(true);
+    });
+
+    test("IsEmpty / IsNotEmpty for arrays", () => {
+      const labels: NotificationRuleConditionCheckOn =
+        NotificationRuleConditionCheckOn.IncidentLabels;
+      expect(
+        matches(singleFilter(labels, ConditionType.IsEmpty, "ignored"), {
+          [labels]: [],
+        }),
+      ).toBe(true);
+      expect(
+        matches(singleFilter(labels, ConditionType.IsNotEmpty, "ignored"), {
+          [labels]: ["prod"],
+        }),
+      ).toBe(true);
+    });
+
+    test("True / False match the literal string value", () => {
+      expect(
+        matches(singleFilter(CHECK, ConditionType.True, "ignored"), {
+          [CHECK]: "true",
+        }),
+      ).toBe(true);
+      expect(
+        matches(singleFilter(CHECK, ConditionType.True, "ignored"), {
+          [CHECK]: "false",
+        }),
+      ).toBe(false);
+      expect(
+        matches(singleFilter(CHECK, ConditionType.False, "ignored"), {
+          [CHECK]: "false",
+        }),
+      ).toBe(true);
+    });
+  });
+});

--- a/Common/Tests/Utils/EnterpriseLicense/EnterpriseLicenseUsage.test.ts
+++ b/Common/Tests/Utils/EnterpriseLicense/EnterpriseLicenseUsage.test.ts
@@ -1,0 +1,296 @@
+import OneUptimeDate from "../../../Types/Date";
+import EnterpriseLicenseUsageUtil, {
+  EnterpriseLicenseInstanceUsage,
+} from "../../../Utils/EnterpriseLicense/EnterpriseLicenseUsage";
+
+// A 64-char lowercase hex digest, parameterized so tests can make distinct ones.
+function hash(seed: string): string {
+  const base: string = seed.toLowerCase().replace(/[^a-f0-9]/g, "0");
+  return (base + "0".repeat(64)).substring(0, 64);
+}
+
+describe("EnterpriseLicenseUsageUtil", () => {
+  const now: Date = OneUptimeDate.getCurrentDate();
+
+  describe("maskLicenseKey", () => {
+    test("fully masks short keys", () => {
+      expect(EnterpriseLicenseUsageUtil.maskLicenseKey("")).toBe("••••••••");
+      expect(EnterpriseLicenseUsageUtil.maskLicenseKey("12345678")).toBe(
+        "••••••••",
+      );
+    });
+
+    test("keeps the first and last four characters of a long key", () => {
+      expect(
+        EnterpriseLicenseUsageUtil.maskLicenseKey("ABCD12345678WXYZ"),
+      ).toBe("ABCD••••WXYZ");
+    });
+
+    test("masks a nine-character key (just over the threshold)", () => {
+      // length 9 > 8, so first 4 + mask + last 4, overlapping middle dropped.
+      expect(EnterpriseLicenseUsageUtil.maskLicenseKey("123456789")).toBe(
+        "1234••••6789",
+      );
+    });
+  });
+
+  describe("sanitizeMasterAdminEmails", () => {
+    test("returns an empty array for non-array input", () => {
+      expect(
+        EnterpriseLicenseUsageUtil.sanitizeMasterAdminEmails(null),
+      ).toEqual([]);
+      expect(
+        EnterpriseLicenseUsageUtil.sanitizeMasterAdminEmails("a@b.com"),
+      ).toEqual([]);
+      expect(
+        EnterpriseLicenseUsageUtil.sanitizeMasterAdminEmails(undefined),
+      ).toEqual([]);
+    });
+
+    test("lowercases and trims email-shaped strings", () => {
+      expect(
+        EnterpriseLicenseUsageUtil.sanitizeMasterAdminEmails([
+          "  Admin@Example.COM ",
+        ]),
+      ).toEqual(["admin@example.com"]);
+    });
+
+    test("deduplicates after normalization", () => {
+      expect(
+        EnterpriseLicenseUsageUtil.sanitizeMasterAdminEmails([
+          "a@b.com",
+          "A@B.com",
+          "a@b.com",
+        ]),
+      ).toEqual(["a@b.com"]);
+    });
+
+    test("drops non-strings and non-email-shaped values", () => {
+      expect(
+        EnterpriseLicenseUsageUtil.sanitizeMasterAdminEmails([
+          "valid@x.io",
+          123,
+          "not-an-email",
+          "no@dot",
+          "",
+          "   ",
+          null,
+          { email: "x@y.com" },
+        ]),
+      ).toEqual(["valid@x.io"]);
+    });
+
+    test("rejects an over-long address", () => {
+      const longLocal: string = "a".repeat(320);
+      expect(
+        EnterpriseLicenseUsageUtil.sanitizeMasterAdminEmails([
+          `${longLocal}@x.com`,
+        ]),
+      ).toEqual([]);
+    });
+
+    test("caps the list at maxMasterAdminEmailsPerInstance", () => {
+      const many: Array<string> = [];
+      for (let i: number = 0; i < 120; i++) {
+        many.push(`user${i}@example.com`);
+      }
+      const result: Array<string> =
+        EnterpriseLicenseUsageUtil.sanitizeMasterAdminEmails(many);
+      expect(result).toHaveLength(
+        EnterpriseLicenseUsageUtil.maxMasterAdminEmailsPerInstance,
+      );
+    });
+  });
+
+  describe("sanitizeUserEmailHashes", () => {
+    test("returns an empty array for non-array input", () => {
+      expect(EnterpriseLicenseUsageUtil.sanitizeUserEmailHashes({})).toEqual(
+        [],
+      );
+    });
+
+    test("keeps valid 64-char hex digests and lowercases them", () => {
+      const upper: string = hash("abc").toUpperCase();
+      expect(
+        EnterpriseLicenseUsageUtil.sanitizeUserEmailHashes([upper]),
+      ).toEqual([upper.toLowerCase()]);
+    });
+
+    test("rejects strings that are not 64-char hex", () => {
+      expect(
+        EnterpriseLicenseUsageUtil.sanitizeUserEmailHashes([
+          "tooshort",
+          "g".repeat(64), // non-hex character
+          hash("valid"),
+          "0".repeat(63), // one char short
+          "0".repeat(65), // one char long
+          42,
+        ]),
+      ).toEqual([hash("valid")]);
+    });
+
+    test("deduplicates hashes", () => {
+      const h: string = hash("dup");
+      expect(
+        EnterpriseLicenseUsageUtil.sanitizeUserEmailHashes([h, h, h]),
+      ).toEqual([h]);
+    });
+  });
+
+  describe("isInstanceCountedTowardsUsage", () => {
+    test("excludes instances that never reported", () => {
+      expect(
+        EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage({}, now),
+      ).toBe(false);
+    });
+
+    test("includes a recently reporting instance", () => {
+      const instance: EnterpriseLicenseInstanceUsage = {
+        lastReportedAt: OneUptimeDate.addRemoveDays(now, -5),
+      };
+      expect(
+        EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(instance, now),
+      ).toBe(true);
+    });
+
+    test("excludes a stale instance", () => {
+      const instance: EnterpriseLicenseInstanceUsage = {
+        lastReportedAt: OneUptimeDate.addRemoveDays(now, -40),
+      };
+      expect(
+        EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(instance, now),
+      ).toBe(false);
+    });
+
+    test("treats the freshness boundary as inclusive", () => {
+      // staleBefore == now - InstanceUsageFreshnessInDays; equal timestamps count.
+      const boundary: Date = OneUptimeDate.addRemoveDays(
+        now,
+        -EnterpriseLicenseUsageUtil.InstanceUsageFreshnessInDays,
+      );
+      expect(
+        EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+          { lastReportedAt: boundary },
+          now,
+        ),
+      ).toBe(true);
+
+      // One second past the boundary drops out.
+      const justStale: Date = OneUptimeDate.addRemoveSeconds(boundary, -1);
+      expect(
+        EnterpriseLicenseUsageUtil.isInstanceCountedTowardsUsage(
+          { lastReportedAt: justStale },
+          now,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("getUniqueUserCount", () => {
+    const fresh: (
+      partial: Partial<EnterpriseLicenseInstanceUsage>,
+    ) => EnterpriseLicenseInstanceUsage = (
+      partial: Partial<EnterpriseLicenseInstanceUsage>,
+    ): EnterpriseLicenseInstanceUsage => {
+      return {
+        lastReportedAt: OneUptimeDate.addRemoveDays(now, -1),
+        ...partial,
+      };
+    };
+
+    test("returns 0 when there are no instances", () => {
+      expect(EnterpriseLicenseUsageUtil.getUniqueUserCount([], now)).toBe(0);
+    });
+
+    test("counts the union of hashes across instances (dedup)", () => {
+      const a: string = hash("aaa");
+      const b: string = hash("bbb");
+      const c: string = hash("ccc");
+      const instances: Array<EnterpriseLicenseInstanceUsage> = [
+        fresh({ userEmailHashes: [a, b] }),
+        fresh({ userEmailHashes: [b, c] }),
+      ];
+      // a, b, c -> 3 unique
+      expect(
+        EnterpriseLicenseUsageUtil.getUniqueUserCount(instances, now),
+      ).toBe(3);
+    });
+
+    test("ignores stale instances", () => {
+      const a: string = hash("aaa");
+      const instances: Array<EnterpriseLicenseInstanceUsage> = [
+        fresh({ userEmailHashes: [a] }),
+        {
+          lastReportedAt: OneUptimeDate.addRemoveDays(now, -60),
+          userEmailHashes: [hash("stale1"), hash("stale2")],
+        },
+      ];
+      expect(
+        EnterpriseLicenseUsageUtil.getUniqueUserCount(instances, now),
+      ).toBe(1);
+    });
+
+    test("adds plain user counts from instances without hashes", () => {
+      const instances: Array<EnterpriseLicenseInstanceUsage> = [
+        fresh({ userEmailHashes: [hash("x")] }),
+        fresh({ userCount: 7 }),
+      ];
+      // 1 hashed + 7 uncounted-by-hash = 8
+      expect(
+        EnterpriseLicenseUsageUtil.getUniqueUserCount(instances, now),
+      ).toBe(8);
+    });
+
+    test("counts hash overflow when userCount exceeds the hash list length", () => {
+      const instances: Array<EnterpriseLicenseInstanceUsage> = [
+        fresh({ userEmailHashes: [hash("a"), hash("b")], userCount: 10 }),
+      ];
+      // 2 unique hashes + (10 - 2) overflow = 10
+      expect(
+        EnterpriseLicenseUsageUtil.getUniqueUserCount(instances, now),
+      ).toBe(10);
+    });
+
+    test("does not subtract when userCount is below the hash count", () => {
+      const instances: Array<EnterpriseLicenseInstanceUsage> = [
+        fresh({
+          userEmailHashes: [hash("a"), hash("b"), hash("c")],
+          userCount: 1,
+        }),
+      ];
+      // userCount < hashes: overflow branch not taken, 3 unique hashes stand.
+      expect(
+        EnterpriseLicenseUsageUtil.getUniqueUserCount(instances, now),
+      ).toBe(3);
+    });
+
+    test("ignores userCount of zero or missing on hashless instances", () => {
+      const instances: Array<EnterpriseLicenseInstanceUsage> = [
+        fresh({ userCount: 0 }),
+        fresh({}),
+      ];
+      expect(
+        EnterpriseLicenseUsageUtil.getUniqueUserCount(instances, now),
+      ).toBe(0);
+    });
+
+    test("combines hashed, hashless and overflow across a realistic mix", () => {
+      const shared: string = hash("shared");
+      const instances: Array<EnterpriseLicenseInstanceUsage> = [
+        fresh({ userEmailHashes: [shared, hash("p1")], userCount: 2 }),
+        fresh({ userEmailHashes: [shared, hash("p2")], userCount: 5 }), // 2 hashes, 3 overflow
+        fresh({ userCount: 4 }), // hashless, +4
+        { lastReportedAt: undefined, userCount: 1000 }, // never reported, ignored
+      ];
+      /*
+       * unique hashes: shared, p1, p2 = 3
+       * overflow from second instance: 5 - 2 = 3
+       * hashless: 4
+       * total = 3 + 3 + 4 = 10
+       */
+      expect(
+        EnterpriseLicenseUsageUtil.getUniqueUserCount(instances, now),
+      ).toBe(10);
+    });
+  });
+});

--- a/Common/Tests/Utils/Metrics/RecordingRuleExpression.test.ts
+++ b/Common/Tests/Utils/Metrics/RecordingRuleExpression.test.ts
@@ -1,0 +1,348 @@
+import {
+  Node,
+  ParseError,
+  ParseResult,
+  Token,
+  ValidateResult,
+  evaluate,
+  parse,
+  tokenize,
+  validate,
+} from "../../../Utils/Metrics/RecordingRuleExpression";
+
+// Parse `expression` and return the AST, failing the test if it did not parse.
+function parseOk(expression: string): Node {
+  const result: ParseResult | ParseError = parse(expression);
+  if (!result.ok) {
+    throw new Error(
+      `Expected "${expression}" to parse but got error: ${
+        (result as ParseError).error
+      }`,
+    );
+  }
+  return result.ast;
+}
+
+// Parse + evaluate in one step for the common "does the math work" assertions.
+function evalExpr(
+  expression: string,
+  bindings: Record<string, number> = {},
+): number | null {
+  return evaluate(parseOk(expression), bindings);
+}
+
+describe("RecordingRuleExpression", () => {
+  describe("tokenize", () => {
+    test("returns an empty token list for empty input", () => {
+      expect(tokenize("")).toEqual([]);
+    });
+
+    test("skips all whitespace flavors", () => {
+      const tokens: Array<Token> | ParseError = tokenize(" \t\n\r 1 ");
+      expect(Array.isArray(tokens)).toBe(true);
+      expect(tokens as Array<Token>).toHaveLength(1);
+      expect((tokens as Array<Token>)[0]).toMatchObject({
+        type: "number",
+        value: "1",
+      });
+    });
+
+    test("tokenizes each operator and paren with its position", () => {
+      const tokens: Array<Token> = tokenize("1+2*3-(4/5)") as Array<Token>;
+      expect(
+        tokens.map((t: Token) => {
+          return t.type;
+        }),
+      ).toEqual([
+        "number",
+        "op",
+        "number",
+        "op",
+        "number",
+        "op",
+        "lparen",
+        "number",
+        "op",
+        "number",
+        "rparen",
+      ]);
+      // Positions must point back to the original string.
+      expect(tokens[6]).toMatchObject({ type: "lparen", pos: 6 });
+      expect(tokens[10]).toMatchObject({ type: "rparen", pos: 10 });
+    });
+
+    test("tokenizes integers and decimals including a trailing dot", () => {
+      const t1: Array<Token> = tokenize("42") as Array<Token>;
+      expect(t1[0]).toMatchObject({ type: "number", value: "42" });
+
+      const t2: Array<Token> = tokenize("3.14") as Array<Token>;
+      expect(t2[0]).toMatchObject({ type: "number", value: "3.14" });
+
+      const t3: Array<Token> = tokenize("5.") as Array<Token>;
+      expect(t3[0]).toMatchObject({ type: "number", value: "5." });
+    });
+
+    test("tokenizes identifiers with underscores and digits", () => {
+      const tokens: Array<Token> = tokenize("_foo bar123 A") as Array<Token>;
+      expect(
+        tokens.map((t: Token) => {
+          return t.value;
+        }),
+      ).toEqual(["_foo", "bar123", "A"]);
+      expect(
+        tokens.every((t: Token) => {
+          return t.type === "ident";
+        }),
+      ).toBe(true);
+    });
+
+    test("does not let an identifier start with a digit", () => {
+      // "1abc" -> number "1" then ident "abc"
+      const tokens: Array<Token> = tokenize("1abc") as Array<Token>;
+      expect(
+        tokens.map((t: Token) => {
+          return [t.type, t.value];
+        }),
+      ).toEqual([
+        ["number", "1"],
+        ["ident", "abc"],
+      ]);
+    });
+
+    test("returns a ParseError with position on an unexpected character", () => {
+      const result: Array<Token> | ParseError = tokenize("1 @ 2");
+      expect(Array.isArray(result)).toBe(false);
+      const err: ParseError = result as ParseError;
+      expect(err.ok).toBe(false);
+      expect(err.position).toBe(2);
+      expect(err.error).toContain("@");
+    });
+  });
+
+  describe("parse", () => {
+    test("parses a single number", () => {
+      expect(parseOk("7")).toEqual({ type: "num", value: 7 });
+    });
+
+    test("parses a single identifier and reports it", () => {
+      const result: ParseResult = parse("cpu") as ParseResult;
+      expect(result.ok).toBe(true);
+      expect(result.ast).toEqual({ type: "ident", name: "cpu" });
+      expect(result.identifiers).toEqual(["cpu"]);
+    });
+
+    test("deduplicates identifiers in the report", () => {
+      const result: ParseResult = parse("a + a + b") as ParseResult;
+      expect(result.identifiers.sort()).toEqual(["a", "b"]);
+    });
+
+    test("gives * and / higher precedence than + and -", () => {
+      const ast: Node = parseOk("2 + 3 * 4");
+      expect(ast).toEqual({
+        type: "binary",
+        op: "+",
+        left: { type: "num", value: 2 },
+        right: {
+          type: "binary",
+          op: "*",
+          left: { type: "num", value: 3 },
+          right: { type: "num", value: 4 },
+        },
+      });
+    });
+
+    test("is left-associative for same-precedence operators", () => {
+      // 10 - 3 - 2 parses as (10 - 3) - 2, not 10 - (3 - 2)
+      const ast: Node = parseOk("10 - 3 - 2");
+      expect(ast).toMatchObject({
+        type: "binary",
+        op: "-",
+        left: {
+          type: "binary",
+          op: "-",
+          left: { type: "num", value: 10 },
+          right: { type: "num", value: 3 },
+        },
+        right: { type: "num", value: 2 },
+      });
+    });
+
+    test("parses parentheses to override precedence", () => {
+      const ast: Node = parseOk("(2 + 3) * 4");
+      expect(ast).toMatchObject({
+        type: "binary",
+        op: "*",
+        left: { type: "binary", op: "+" },
+        right: { type: "num", value: 4 },
+      });
+    });
+
+    test("parses unary minus", () => {
+      expect(parseOk("-5")).toEqual({
+        type: "unary",
+        op: "-",
+        operand: { type: "num", value: 5 },
+      });
+    });
+
+    test("parses a minus directly followed by a unary minus", () => {
+      const ast: Node = parseOk("2 - -3");
+      expect(ast).toEqual({
+        type: "binary",
+        op: "-",
+        left: { type: "num", value: 2 },
+        right: {
+          type: "unary",
+          op: "-",
+          operand: { type: "num", value: 3 },
+        },
+      });
+    });
+
+    test("errors on empty input", () => {
+      const result: ParseResult | ParseError = parse("");
+      expect(result.ok).toBe(false);
+      expect((result as ParseError).error).toContain("Unexpected end");
+    });
+
+    test("errors on a dangling operator", () => {
+      const result: ParseResult | ParseError = parse("1 +");
+      expect(result.ok).toBe(false);
+    });
+
+    test("errors on a missing closing paren", () => {
+      const result: ParseResult | ParseError = parse("(1 + 2");
+      expect(result.ok).toBe(false);
+      expect((result as ParseError).error).toContain(")");
+    });
+
+    test("errors on stray trailing tokens", () => {
+      const result: ParseResult | ParseError = parse("2 3");
+      expect(result.ok).toBe(false);
+      expect((result as ParseError).error).toContain("Unexpected token");
+    });
+
+    test("propagates a tokenizer error", () => {
+      const result: ParseResult | ParseError = parse("1 $ 2");
+      expect(result.ok).toBe(false);
+      expect((result as ParseError).position).toBe(2);
+    });
+
+    test("rejects a numeric literal too large to be finite", () => {
+      const huge: string = "9".repeat(400);
+      const result: ParseResult | ParseError = parse(huge);
+      expect(result.ok).toBe(false);
+      expect((result as ParseError).error).toContain("Invalid number");
+    });
+
+    test("rejects excessively deep nesting instead of overflowing the stack", () => {
+      const deep: string = "(".repeat(60) + "1" + ")".repeat(60);
+      const result: ParseResult | ParseError = parse(deep);
+      expect(result.ok).toBe(false);
+      expect((result as ParseError).error).toContain("too deep");
+    });
+
+    test("accepts nesting within the depth limit", () => {
+      const ok: string = "(".repeat(10) + "1" + ")".repeat(10);
+      expect(parse(ok).ok).toBe(true);
+    });
+  });
+
+  describe("evaluate", () => {
+    test("evaluates basic arithmetic honoring precedence", () => {
+      expect(evalExpr("2 + 3 * 4")).toBe(14);
+      expect(evalExpr("(2 + 3) * 4")).toBe(20);
+      expect(evalExpr("10 - 3 - 2")).toBe(5);
+      expect(evalExpr("10 / 2 / 5")).toBe(1);
+    });
+
+    test("evaluates unary minus", () => {
+      expect(evalExpr("-5 + 2")).toBe(-3);
+      expect(evalExpr("2 * -3")).toBe(-6);
+      expect(evalExpr("2 - -3")).toBe(5);
+    });
+
+    test("evaluates decimals", () => {
+      expect(evalExpr("3.5 * 2")).toBe(7);
+      expect(evalExpr("5.")).toBe(5);
+    });
+
+    test("resolves identifiers from bindings", () => {
+      expect(evalExpr("cpu + mem", { cpu: 30, mem: 12 })).toBe(42);
+      expect(evalExpr("total / count", { total: 100, count: 4 })).toBe(25);
+    });
+
+    test("returns null for a missing binding", () => {
+      expect(evalExpr("cpu + mem", { cpu: 30 })).toBeNull();
+    });
+
+    test("returns null when a binding is not a finite number", () => {
+      const ast: Node = parseOk("x + 1");
+      expect(evaluate(ast, { x: Number.NaN })).toBeNull();
+      expect(evaluate(ast, { x: Number.POSITIVE_INFINITY })).toBeNull();
+      // Non-number value coerced through the untyped record.
+      expect(evaluate(ast, { x: undefined as unknown as number })).toBeNull();
+    });
+
+    test("does not treat inherited properties as bindings", () => {
+      const ast: Node = parseOk("toString");
+      // "toString" exists on the prototype but not as an own property.
+      expect(evaluate(ast, {})).toBeNull();
+    });
+
+    test("returns null on division by zero", () => {
+      expect(evalExpr("5 / 0")).toBeNull();
+      expect(evalExpr("1 / (2 - 2)")).toBeNull();
+    });
+
+    test("returns null when an intermediate result is null", () => {
+      // Missing binding poisons the whole expression.
+      expect(evalExpr("(a / b) + 1", { a: 1, b: 0 })).toBeNull();
+      expect(evalExpr("missing * 0", {})).toBeNull();
+    });
+
+    test("returns null when arithmetic overflows to infinity", () => {
+      const ast: Node = parseOk("a * b");
+      expect(evaluate(ast, { a: 1e308, b: 1e308 })).toBeNull();
+    });
+
+    test("allows dividing zero by a nonzero number", () => {
+      expect(evalExpr("0 / 5")).toBe(0);
+    });
+  });
+
+  describe("validate", () => {
+    test("accepts an expression whose identifiers are all allowed", () => {
+      expect(validate("cpu + mem", ["cpu", "mem"])).toEqual({ ok: true });
+    });
+
+    test("accepts an expression with no identifiers", () => {
+      expect(validate("1 + 2 * 3", [])).toEqual({ ok: true });
+    });
+
+    test("rejects and lists unknown identifiers", () => {
+      const result: ValidateResult = validate("cpu + disk", ["cpu", "mem"]);
+      expect(result.ok).toBe(false);
+      expect(result.unknownIdentifiers).toEqual(["disk"]);
+      expect(result.error).toContain("disk");
+    });
+
+    test("reports every unknown identifier", () => {
+      const result: ValidateResult = validate("a + b + c", ["a"]);
+      expect(result.ok).toBe(false);
+      expect((result.unknownIdentifiers ?? []).sort()).toEqual(["b", "c"]);
+    });
+
+    test("surfaces a parse error with position instead of an identifier error", () => {
+      const result: ValidateResult = validate("cpu +", ["cpu"]);
+      expect(result.ok).toBe(false);
+      expect(result.unknownIdentifiers).toBeUndefined();
+    });
+
+    test("propagates the tokenizer error position", () => {
+      const result: ValidateResult = validate("cpu @ mem", ["cpu", "mem"]);
+      expect(result.ok).toBe(false);
+      expect(result.position).toBe(4);
+    });
+  });
+});

--- a/E2E/Tests/App/AppShallowHealthEndpoints.spec.ts
+++ b/E2E/Tests/App/AppShallowHealthEndpoints.spec.ts
@@ -1,0 +1,89 @@
+import { BASE_URL } from "../../Config";
+import { APIResponse, Page, expect, test } from "@playwright/test";
+import URL from "Common/Types/API/URL";
+
+/*
+ * Shallow health-endpoint checks for the App service, addressed through the
+ * unconditional "/api" route.
+ *
+ * The sibling HealthEndpoints.spec.ts / HealthEndpointConsistency.spec.ts /
+ * StatusCheck.spec.ts suites all probe the ROOT paths — /status, /status/ready
+ * and /status/live. But nginx's catch-all `location /`
+ * (Nginx/default.conf.template) proxies the root to the *Home* service when
+ * BILLING_ENABLED=true (the SaaS CI stack, docker-compose.billing.yml) and only
+ * to *App* otherwise. So in a billing deployment those root-path suites are
+ * actually exercising Home's probes, and the App's own shallow /status,
+ * /status/ready and /status/live handlers (StatusAPI in
+ * Common/Server/API/StatusAPI.ts, wired in App/Index.ts) are never asserted
+ * directly by any E2E test.
+ *
+ * This suite closes that gap by using the "/api" prefix, which — exactly as
+ * DeepHealthEndpoints.spec.ts documents for the deep per-datastore routes — is
+ * unconditional in nginx and always proxies to App. Common/Server/API/Index.ts
+ * mounts StatusAPI at both `/${appName}` and `/`, and App/Index.ts sets
+ * appName = "api", so /api/status, /api/status/ready and /api/status/live reach
+ * the App's own shallow probes in BOTH deployment modes. A regression that
+ * broke App's readiness/liveness contract (a changed body, a non-JSON error
+ * page, a dropped route) would slip past the root-path suites in the billing
+ * stack but is caught here.
+ *
+ * Robustness: the deploy's readiness gate (Tests/Scripts/status-check.sh)
+ * blocks on /dashboard, which nginx proxies to App unconditionally, so by the
+ * time this suite runs the App is already answering. A failure here is a real
+ * contract regression, not a warm-up race.
+ */
+
+const APP_SHALLOW_HEALTH_ROUTES: Array<string> = [
+  "/api/status", // App status
+  "/api/status/ready", // App readiness probe
+  "/api/status/live", // App liveness probe
+];
+
+const POLL_COUNT: number = 3;
+
+test.describe("App shallow health endpoints (via /api) return well-formed JSON", () => {
+  for (const route of APP_SHALLOW_HEALTH_ROUTES) {
+    test(`${route} responds 200 with a stable { status: "ok" } JSON body`, async ({
+      page,
+    }: {
+      page: Page;
+    }) => {
+      page.setDefaultNavigationTimeout(120000); // 2 minutes
+
+      const endpoint: string = URL.fromString(BASE_URL.toString())
+        .addRoute(route)
+        .toString();
+
+      const bodies: Array<string> = [];
+
+      for (let attempt: number = 0; attempt < POLL_COUNT; attempt++) {
+        const response: APIResponse = await page.request.get(endpoint);
+
+        // App probe must answer with a success status code.
+        expect(response.status()).toBeGreaterThanOrEqual(200);
+        expect(response.status()).toBeLessThan(300);
+
+        /*
+         * Served as JSON, not an HTML error page: a 500 page that happened to
+         * embed "ok" would not carry an application/json content-type and would
+         * not parse below.
+         */
+        const contentType: string | null = response.headers()["content-type"]
+          ? response.headers()["content-type"]!
+          : null;
+        expect(contentType).not.toBeNull();
+        expect(contentType!.toLowerCase()).toContain("application/json");
+
+        // Body parses as JSON and carries exactly status: "ok".
+        const body: unknown = await response.json();
+        expect(body).toMatchObject({ status: "ok" });
+
+        bodies.push(JSON.stringify(body));
+      }
+
+      // The probe must not flap between polls — the deploy healthchecks poll it.
+      const distinctBodies: Set<string> = new Set(bodies);
+      expect(distinctBodies.size).toBe(1);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Automated daily-master-build run. **All CI jobs on the current master HEAD (merge #3094) are green** — the earlier "cancelled" runs were superseded by newer pushes (normal CI concurrency), not real failures. So there were no failing jobs to fix; this PR delivers the "write a lot more tests" part of the task.

Adds 84 new unit tests (3 suites) for previously-untested pure-logic modules, plus one new E2E spec closing a real gap.

### Unit tests (Common)
- **`Utils/Metrics/RecordingRuleExpression`** (40 tests) — exhaustive coverage of the recording-rule expression DSL: tokenizer (numbers, decimals, identifiers, operators, bad chars), recursive-descent parser (operator precedence, left-associativity, unary minus, parentheses, error cases, numeric-overflow literal rejection, deep-nesting guard), evaluator (division-by-zero → null, missing/non-finite bindings → null, overflow → null, prototype-pollution safety), and `validate` (unknown-identifier reporting, parse-error propagation).
- **`Utils/EnterpriseLicense/EnterpriseLicenseUsage`** (25 tests) — license-key masking, master-admin-email and email-hash sanitization (normalization, dedup, size caps, format rejection), instance freshness boundary (inclusive), and unique seat counting including the hash-overflow accounting path.
- **`Types/Workspace/NotificationRules/NotificationRuleUtil`** (19 tests) — `isRuleMatching` across every `ConditionType` (EqualTo/NotEqualTo numeric+string, ordering comparisons, Contains/NotContains, StartsWith/EndsWith, ContainsAll, IsEmpty/IsNotEmpty, True/False) and both `All`/`Any` filter-condition semantics, plus undefined-value handling and no-filters default.

### E2E test
- **`E2E/Tests/App/AppShallowHealthEndpoints.spec.ts`** — the existing health suites probe the **root** `/status*` paths, which nginx routes to the **Home** service in the billing CI stack, so App's own shallow readiness/liveness probes are never asserted directly there. This spec hits them through the unconditional `/api` route (the same approach `DeepHealthEndpoints.spec.ts` documents for the deep per-datastore routes), verifying a stable `{ status: "ok" }` JSON contract in both deployment modes.

## Verification
- All 3 Common suites pass locally: **84/84 green**.
- `tsc --noEmit` on Common: clean.
- `tsc --noEmit` on E2E: clean.
- Prettier + ESLint: clean on all four files.

No production code changed — additive tests only.