### PR TITLE
Add native AWS Bedrock LLM provider

### DIFF
--- a/Common/Models/DatabaseModels/LlmProvider.ts
+++ b/Common/Models/DatabaseModels/LlmProvider.ts
@@ -191,7 +191,7 @@ export default class LlmProvider extends BaseModel {
     type: TableColumnType.ShortText,
     title: "LLM Type",
     description:
-      "The type of LLM provider (OpenAI, Azure OpenAI, Anthropic, Groq, Mistral, Ollama, OpenAICompatible, etc.)",
+      "The type of LLM provider (OpenAI, Azure OpenAI, Anthropic, AWS Bedrock, Groq, Mistral, Ollama, OpenAICompatible, etc.)",
   })
   @Column({
     nullable: false,
@@ -224,7 +224,7 @@ export default class LlmProvider extends BaseModel {
     type: TableColumnType.LongText,
     title: "API Key",
     description:
-      "The API key for the LLM provider. Required for OpenAI, Azure OpenAI, Anthropic, Groq, and Mistral.",
+      "The API key for the LLM provider. Required for OpenAI, Azure OpenAI, Anthropic, Groq, and Mistral. For AWS Bedrock, use accessKeyId:secretAccessKey[:sessionToken], or leave blank to use AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY from the runtime environment.",
     encrypted: true,
   })
   @Column({
@@ -257,7 +257,7 @@ export default class LlmProvider extends BaseModel {
     type: TableColumnType.ShortText,
     title: "Model Name",
     description:
-      "The name of the model to use (e.g., gpt-4, claude-3-opus, llama2).",
+      "The name of the model to use (e.g., gpt-4, claude-3-opus, anthropic.claude-3-5-sonnet-20240620-v1:0, llama2).",
   })
   @Column({
     nullable: true,
@@ -290,7 +290,7 @@ export default class LlmProvider extends BaseModel {
     type: TableColumnType.ShortURL,
     title: "Base URL",
     description:
-      "The base URL for the LLM API. Required for Azure OpenAI and Ollama, optional for others.",
+      "The base URL for the LLM API. Required for Azure OpenAI and Ollama, optional for others. For AWS Bedrock, use a Bedrock Runtime endpoint to choose a region.",
   })
   @Column({
     nullable: true,

--- a/Common/Models/DatabaseModels/LlmProvider.ts
+++ b/Common/Models/DatabaseModels/LlmProvider.ts
@@ -224,7 +224,7 @@ export default class LlmProvider extends BaseModel {
     type: TableColumnType.LongText,
     title: "API Key",
     description:
-      "The API key for the LLM provider. Required for OpenAI, Azure OpenAI, Anthropic, Groq, and Mistral. For AWS Bedrock, use accessKeyId:secretAccessKey[:sessionToken], or leave blank to use AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY from the runtime environment.",
+      "The API key for the LLM provider. Required for OpenAI, Azure OpenAI, Anthropic, Groq, and Mistral. For AWS Bedrock, use accessKeyId:secretAccessKey[:sessionToken], or leave blank to use AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or IRSA web identity credentials from the runtime environment.",
     encrypted: true,
   })
   @Column({

--- a/Common/Models/DatabaseModels/LlmProvider.ts
+++ b/Common/Models/DatabaseModels/LlmProvider.ts
@@ -257,7 +257,7 @@ export default class LlmProvider extends BaseModel {
     type: TableColumnType.ShortText,
     title: "Model Name",
     description:
-      "The name of the model to use (e.g., gpt-4, claude-3-opus, anthropic.claude-3-5-sonnet-20240620-v1:0, llama2).",
+      "The name of the model to use. For AWS Bedrock, use any Converse-compatible Bedrock model ID, inference profile ID, or ARN.",
   })
   @Column({
     nullable: true,

--- a/Common/Server/Utils/LLM/LLMService.ts
+++ b/Common/Server/Utils/LLM/LLMService.ts
@@ -1495,8 +1495,13 @@ export default class LLMService {
     config: LLMProviderConfig;
     request: LLMCompletionRequest;
   }): BedrockRequestTarget {
-    const modelName: string =
-      data.config.modelName || "anthropic.claude-3-5-sonnet-20240620-v1:0";
+    const modelName: string | undefined = data.config.modelName?.trim();
+
+    if (!modelName) {
+      throw new BadDataException(
+        "Model Name is required for AWS Bedrock. Use any Bedrock Converse-compatible model ID, inference profile ID, or ARN.",
+      );
+    }
 
     const additionalParams: JSONObject | undefined =
       data.request.additionalParams;

--- a/Common/Server/Utils/LLM/LLMService.ts
+++ b/Common/Server/Utils/LLM/LLMService.ts
@@ -8,6 +8,7 @@ import API from "../../../Utils/API";
 import LlmType from "../../../Types/LLM/LlmType";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import crypto from "crypto";
+import fs from "fs/promises";
 import logger, { LogAttributes } from "../Logger";
 import CaptureSpan from "../Telemetry/CaptureSpan";
 
@@ -91,6 +92,11 @@ interface BedrockCredentials {
   accessKeyId: string;
   secretAccessKey: string;
   sessionToken?: string | undefined;
+}
+
+interface BedrockWebIdentityCredentialsCacheEntry {
+  credentials: BedrockCredentials;
+  expiresAt: number;
 }
 
 interface BedrockRequestTarget {
@@ -221,6 +227,14 @@ export default class LLMService {
   private static readonly MAX_ADAPTATION_CACHE_ENTRIES: number = 500;
 
   private static readonly ADAPTATION_CACHE_TTL_IN_MS: number = 60 * 60 * 1000;
+
+  private static readonly BEDROCK_WEB_IDENTITY_CREDENTIAL_REFRESH_WINDOW_IN_MS: number =
+    5 * 60 * 1000;
+
+  private static readonly bedrockWebIdentityCredentialsCache: Map<
+    string,
+    BedrockWebIdentityCredentialsCacheEntry
+  > = new Map();
 
   private static getAdaptationCacheKey(
     config: LLMProviderConfig,
@@ -1320,9 +1334,117 @@ export default class LLMService {
     };
   }
 
-  private static getBedrockCredentials(
+  private static decodeXmlText(value: string): string {
+    return value
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&apos;/g, "'")
+      .replace(/&amp;/g, "&");
+  }
+
+  private static getXmlText(xml: string, tagName: string): string | undefined {
+    const match: RegExpMatchArray | null = xml.match(
+      new RegExp(`<${tagName}>([\\s\\S]*?)</${tagName}>`),
+    );
+
+    return match?.[1] ? this.decodeXmlText(match[1]) : undefined;
+  }
+
+  private static async getBedrockWebIdentityCredentials(
+    region: string,
+  ): Promise<BedrockCredentials | undefined> {
+    const roleArn: string | undefined = process.env["AWS_ROLE_ARN"];
+    const tokenFile: string | undefined =
+      process.env["AWS_WEB_IDENTITY_TOKEN_FILE"];
+
+    if (!roleArn || !tokenFile) {
+      return undefined;
+    }
+
+    const sessionName: string =
+      process.env["AWS_ROLE_SESSION_NAME"] ||
+      `oneuptime-bedrock-${process.pid}`;
+    const cacheKey: string = `${roleArn}|${tokenFile}|${sessionName}|${region}`;
+    const cached: BedrockWebIdentityCredentialsCacheEntry | undefined =
+      this.bedrockWebIdentityCredentialsCache.get(cacheKey);
+
+    if (
+      cached &&
+      cached.expiresAt - Date.now() >
+        this.BEDROCK_WEB_IDENTITY_CREDENTIAL_REFRESH_WINDOW_IN_MS
+    ) {
+      return cached.credentials;
+    }
+
+    const webIdentityToken: string = (
+      await fs.readFile(tokenFile, "utf8")
+    ).trim();
+    const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
+      await API.post<JSONObject>({
+        url: URL.fromString(`https://sts.${region}.amazonaws.com/`),
+        data: {
+          Action: "AssumeRoleWithWebIdentity",
+          Version: "2011-06-15",
+          RoleArn: roleArn,
+          RoleSessionName: sessionName,
+          WebIdentityToken: webIdentityToken,
+        },
+        headers: {
+          Accept: "application/xml",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        options: {
+          retries: 2,
+          exponentialBackoff: true,
+          timeout: 120000,
+        },
+      });
+
+    if (response instanceof HTTPErrorResponse) {
+      this.throwProviderHTTPError({
+        providerName: "AWS STS",
+        response,
+        logAttributes: { llmType: LlmType.Bedrock },
+      });
+    }
+
+    const xml: string = String(response.jsonData);
+    const accessKeyId: string | undefined = this.getXmlText(xml, "AccessKeyId");
+    const secretAccessKey: string | undefined = this.getXmlText(
+      xml,
+      "SecretAccessKey",
+    );
+    const sessionToken: string | undefined = this.getXmlText(
+      xml,
+      "SessionToken",
+    );
+    const expiration: string | undefined = this.getXmlText(xml, "Expiration");
+
+    if (!accessKeyId || !secretAccessKey || !sessionToken || !expiration) {
+      throw new BadDataException(
+        "AWS STS AssumeRoleWithWebIdentity response did not include temporary credentials.",
+      );
+    }
+
+    const credentials: BedrockCredentials = {
+      accessKeyId: accessKeyId,
+      secretAccessKey: secretAccessKey,
+      sessionToken: sessionToken,
+    };
+
+    this.bedrockWebIdentityCredentialsCache.set(cacheKey, {
+      credentials: credentials,
+      expiresAt: new Date(expiration).getTime(),
+    });
+
+    return credentials;
+  }
+
+  private static async getBedrockCredentials(
     config: LLMProviderConfig,
-  ): BedrockCredentials {
+    region: string,
+  ): Promise<BedrockCredentials> {
     const configuredCredentials: string | undefined = config.apiKey?.trim();
 
     if (configuredCredentials) {
@@ -1350,8 +1472,15 @@ export default class LLMService {
       process.env["AWS_SECRET_ACCESS_KEY"];
 
     if (!accessKeyId || !secretAccessKey) {
+      const webIdentityCredentials: BedrockCredentials | undefined =
+        await this.getBedrockWebIdentityCredentials(region);
+
+      if (webIdentityCredentials) {
+        return webIdentityCredentials;
+      }
+
       throw new BadDataException(
-        "AWS Bedrock credentials are required. Set the encrypted API Key to accessKeyId:secretAccessKey[:sessionToken], or provide AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in the runtime environment.",
+        "AWS Bedrock credentials are required. Set the encrypted API Key to accessKeyId:secretAccessKey[:sessionToken], provide AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or configure AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE for IRSA.",
       );
     }
 
@@ -1725,7 +1854,10 @@ export default class LLMService {
       config: config,
       request: request,
     });
-    const credentials: BedrockCredentials = this.getBedrockCredentials(config);
+    const credentials: BedrockCredentials = await this.getBedrockCredentials(
+      config,
+      target.region,
+    );
     const body: JSONObject = this.buildBedrockRequestBody(request);
     const bodyString: string = JSON.stringify(body);
     const requestUrl: string = `${target.endpoint}/model/${encodeURIComponent(

--- a/Common/Server/Utils/LLM/LLMService.ts
+++ b/Common/Server/Utils/LLM/LLMService.ts
@@ -7,6 +7,7 @@ import JSONFunctions from "../../../Types/JSONFunctions";
 import API from "../../../Utils/API";
 import LlmType from "../../../Types/LLM/LlmType";
 import BadDataException from "../../../Types/Exception/BadDataException";
+import crypto from "crypto";
 import logger, { LogAttributes } from "../Logger";
 import CaptureSpan from "../Telemetry/CaptureSpan";
 
@@ -84,6 +85,18 @@ export interface LLMProviderConfig {
   apiKey?: string;
   baseUrl?: string;
   modelName?: string;
+}
+
+interface BedrockCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string | undefined;
+}
+
+interface BedrockRequestTarget {
+  endpoint: string;
+  region: string;
+  modelName: string;
 }
 
 /**
@@ -298,6 +311,8 @@ export default class LLMService {
         return await this.getAzureOpenAICompletion(config, request);
       case LlmType.Anthropic:
         return await this.getAnthropicCompletion(config, request);
+      case LlmType.Bedrock:
+        return await this.getBedrockCompletion(config, request);
       case LlmType.Ollama:
         return await this.getOllamaCompletion(config, request);
       default:
@@ -1305,6 +1320,452 @@ export default class LLMService {
     };
   }
 
+  private static getBedrockCredentials(
+    config: LLMProviderConfig,
+  ): BedrockCredentials {
+    const configuredCredentials: string | undefined = config.apiKey?.trim();
+
+    if (configuredCredentials) {
+      const parts: Array<string> = configuredCredentials.split(":");
+      const accessKeyId: string | undefined = parts[0];
+      const secretAccessKey: string | undefined = parts[1];
+      const sessionToken: string | undefined =
+        parts.length > 2 ? parts.slice(2).join(":") : undefined;
+
+      if (!accessKeyId || !secretAccessKey) {
+        throw new BadDataException(
+          "AWS Bedrock API key must be accessKeyId:secretAccessKey[:sessionToken]",
+        );
+      }
+
+      return {
+        accessKeyId: accessKeyId,
+        secretAccessKey: secretAccessKey,
+        sessionToken: sessionToken || undefined,
+      };
+    }
+
+    const accessKeyId: string | undefined = process.env["AWS_ACCESS_KEY_ID"];
+    const secretAccessKey: string | undefined =
+      process.env["AWS_SECRET_ACCESS_KEY"];
+
+    if (!accessKeyId || !secretAccessKey) {
+      throw new BadDataException(
+        "AWS Bedrock credentials are required. Set the encrypted API Key to accessKeyId:secretAccessKey[:sessionToken], or provide AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in the runtime environment.",
+      );
+    }
+
+    return {
+      accessKeyId: accessKeyId,
+      secretAccessKey: secretAccessKey,
+      sessionToken: process.env["AWS_SESSION_TOKEN"] || undefined,
+    };
+  }
+
+  private static getBedrockRequestTarget(data: {
+    config: LLMProviderConfig;
+    request: LLMCompletionRequest;
+  }): BedrockRequestTarget {
+    const modelName: string =
+      data.config.modelName || "anthropic.claude-3-5-sonnet-20240620-v1:0";
+
+    const additionalParams: JSONObject | undefined =
+      data.request.additionalParams;
+    const regionOverride: unknown = additionalParams?.["region"];
+    let region: string =
+      (typeof regionOverride === "string" && regionOverride.trim()) ||
+      process.env["AWS_REGION"] ||
+      process.env["AWS_DEFAULT_REGION"] ||
+      "us-east-1";
+
+    let endpoint: string = `https://bedrock-runtime.${region}.amazonaws.com`;
+    const configuredBaseUrl: string | undefined = data.config.baseUrl?.trim();
+
+    if (configuredBaseUrl) {
+      endpoint = configuredBaseUrl.replace(/\/+$/, "");
+
+      const host: string = new globalThis.URL(endpoint).host;
+      const regionMatch: RegExpMatchArray | null = host.match(
+        /^bedrock-runtime[.-]([a-z0-9-]+)\.amazonaws\.com(?:\.cn)?$/i,
+      );
+
+      if (regionMatch?.[1]) {
+        region = regionMatch[1];
+      }
+    }
+
+    return {
+      endpoint: endpoint,
+      region: region,
+      modelName: modelName,
+    };
+  }
+
+  private static toBedrockMessages(messages: Array<LLMMessage>): {
+    system: Array<JSONObject>;
+    messages: Array<JSONObject>;
+  } {
+    const system: Array<JSONObject> = [];
+    const bedrockMessages: Array<JSONObject> = [];
+
+    const appendMessage: (role: string, content: Array<JSONObject>) => void = (
+      role: string,
+      content: Array<JSONObject>,
+    ): void => {
+      if (content.length === 0) {
+        return;
+      }
+
+      const previousMessage: JSONObject | undefined =
+        bedrockMessages[bedrockMessages.length - 1];
+
+      if (
+        previousMessage &&
+        previousMessage["role"] === role &&
+        Array.isArray(previousMessage["content"])
+      ) {
+        (previousMessage["content"] as Array<JSONObject>).push(...content);
+        return;
+      }
+
+      bedrockMessages.push({
+        role: role,
+        content: content,
+      });
+    };
+
+    for (const message of messages) {
+      if (message.role === "system") {
+        if (message.content) {
+          system.push({ text: message.content });
+        }
+        continue;
+      }
+
+      if (message.role === "tool") {
+        appendMessage("user", [
+          {
+            toolResult: {
+              toolUseId: message.toolCallId || "",
+              content: [{ text: message.content }],
+            },
+          },
+        ]);
+        continue;
+      }
+
+      const content: Array<JSONObject> = [];
+
+      if (message.content) {
+        content.push({ text: message.content });
+      }
+
+      if (message.role === "assistant" && message.toolCalls?.length) {
+        for (const toolCall of message.toolCalls) {
+          content.push({
+            toolUse: {
+              toolUseId: toolCall.id,
+              name: toolCall.name,
+              input: toolCall.arguments,
+            },
+          });
+        }
+      }
+
+      appendMessage(message.role, content);
+    }
+
+    return {
+      system: system,
+      messages: bedrockMessages,
+    };
+  }
+
+  private static buildBedrockRequestBody(
+    request: LLMCompletionRequest,
+  ): JSONObject {
+    const convertedMessages: {
+      system: Array<JSONObject>;
+      messages: Array<JSONObject>;
+    } = this.toBedrockMessages(request.messages);
+
+    const inferenceConfig: JSONObject = {
+      temperature: request.temperature ?? 0.7,
+    };
+
+    if (request.maxTokens) {
+      inferenceConfig["maxTokens"] = request.maxTokens;
+    }
+
+    const requestData: JSONObject = {
+      messages: convertedMessages.messages,
+      inferenceConfig: inferenceConfig,
+    };
+
+    if (convertedMessages.system.length > 0) {
+      requestData["system"] = convertedMessages.system;
+    }
+
+    if (request.tools && request.tools.length > 0) {
+      requestData["toolConfig"] = {
+        tools: request.tools.map((tool: LLMToolDefinition) => {
+          return {
+            toolSpec: {
+              name: tool.name,
+              description: tool.description,
+              inputSchema: {
+                json: tool.inputSchema,
+              },
+            },
+          };
+        }),
+      };
+    }
+
+    const additionalParams: JSONObject | undefined = request.additionalParams;
+
+    const configuredInferenceConfig: unknown =
+      additionalParams?.["inferenceConfig"];
+    if (
+      configuredInferenceConfig &&
+      typeof configuredInferenceConfig === "object" &&
+      !Array.isArray(configuredInferenceConfig)
+    ) {
+      Object.assign(
+        requestData["inferenceConfig"] as JSONObject,
+        configuredInferenceConfig as JSONObject,
+      );
+    }
+
+    const additionalModelRequestFields: unknown =
+      additionalParams?.["additionalModelRequestFields"];
+    if (
+      additionalModelRequestFields &&
+      typeof additionalModelRequestFields === "object" &&
+      !Array.isArray(additionalModelRequestFields)
+    ) {
+      requestData["additionalModelRequestFields"] =
+        additionalModelRequestFields as JSONObject;
+    }
+
+    return requestData;
+  }
+
+  private static sha256Hex(value: string): string {
+    return crypto.createHash("sha256").update(value, "utf8").digest("hex");
+  }
+
+  private static hmacSha256(key: crypto.BinaryLike, value: string): Buffer {
+    return crypto.createHmac("sha256", key).update(value, "utf8").digest();
+  }
+  private static bufferAsBinaryLike(buffer: Buffer): crypto.BinaryLike {
+    // Node accepts Buffer; this cast avoids @types/node's Buffer/Uint8Array mismatch.
+    return buffer as unknown as crypto.BinaryLike;
+  }
+
+  private static getBedrockSignatureHeaders(data: {
+    credentials: BedrockCredentials;
+    method: string;
+    requestUrl: string;
+    region: string;
+    body: string;
+  }): Headers {
+    const now: Date = new Date();
+    const amzDate: string = now.toISOString().replace(/[:-]|\.\d{3}/g, "");
+    const dateStamp: string = amzDate.slice(0, 8);
+    const url: globalThis.URL = new globalThis.URL(data.requestUrl);
+    const payloadHash: string = this.sha256Hex(data.body);
+
+    const canonicalHeaderValues: Record<string, string> = {
+      "content-type": "application/json",
+      host: url.host,
+      "x-amz-content-sha256": payloadHash,
+      "x-amz-date": amzDate,
+    };
+
+    if (data.credentials.sessionToken) {
+      canonicalHeaderValues["x-amz-security-token"] =
+        data.credentials.sessionToken;
+    }
+
+    const signedHeaderNames: Array<string> = Object.keys(
+      canonicalHeaderValues,
+    ).sort();
+    const canonicalHeaders: string = signedHeaderNames
+      .map((name: string) => {
+        return `${name}:${canonicalHeaderValues[name]!.trim()}\n`;
+      })
+      .join("");
+    const signedHeaders: string = signedHeaderNames.join(";");
+    const canonicalRequest: string = [
+      data.method,
+      url.pathname,
+      url.searchParams.toString(),
+      canonicalHeaders,
+      signedHeaders,
+      payloadHash,
+    ].join("\n");
+    const credentialScope: string = `${dateStamp}/${data.region}/bedrock/aws4_request`;
+    const stringToSign: string = [
+      "AWS4-HMAC-SHA256",
+      amzDate,
+      credentialScope,
+      this.sha256Hex(canonicalRequest),
+    ].join("\n");
+
+    const dateKey: Buffer = this.hmacSha256(
+      `AWS4${data.credentials.secretAccessKey}`,
+      dateStamp,
+    );
+    const regionKey: Buffer = this.hmacSha256(
+      this.bufferAsBinaryLike(dateKey),
+      data.region,
+    );
+    const serviceKey: Buffer = this.hmacSha256(
+      this.bufferAsBinaryLike(regionKey),
+      "bedrock",
+    );
+    const signingKey: Buffer = this.hmacSha256(
+      this.bufferAsBinaryLike(serviceKey),
+      "aws4_request",
+    );
+    const signature: string = crypto
+      .createHmac("sha256", this.bufferAsBinaryLike(signingKey))
+      .update(stringToSign, "utf8")
+      .digest("hex");
+
+    return {
+      "Content-Type": "application/json",
+      Host: url.host,
+      "X-Amz-Content-Sha256": payloadHash,
+      "X-Amz-Date": amzDate,
+      ...(data.credentials.sessionToken
+        ? { "X-Amz-Security-Token": data.credentials.sessionToken }
+        : {}),
+      Authorization: `AWS4-HMAC-SHA256 Credential=${data.credentials.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+    };
+  }
+
+  private static parseBedrockResponse(
+    jsonData: JSONObject,
+  ): LLMCompletionResponse {
+    const output: JSONObject | undefined = jsonData["output"] as
+      | JSONObject
+      | undefined;
+    const message: JSONObject | undefined = output?.["message"] as
+      | JSONObject
+      | undefined;
+    const content: Array<JSONObject> | undefined = message?.["content"] as
+      | Array<JSONObject>
+      | undefined;
+
+    if (!content || content.length === 0) {
+      throw new BadDataException("No response from AWS Bedrock");
+    }
+
+    const textContent: string = content
+      .filter((block: JSONObject) => {
+        return typeof block["text"] === "string";
+      })
+      .map((block: JSONObject) => {
+        return block["text"] as string;
+      })
+      .join("");
+
+    const toolCalls: Array<LLMToolCall> = content
+      .filter((block: JSONObject) => {
+        return Boolean(block["toolUse"]);
+      })
+      .map((block: JSONObject, index: number) => {
+        const toolUse: JSONObject = block["toolUse"] as JSONObject;
+        const input: unknown = toolUse["input"];
+
+        return {
+          id: (toolUse["toolUseId"] as string) || `tool_call_${index}`,
+          name: (toolUse["name"] as string) || "",
+          arguments:
+            input && typeof input === "object" && !Array.isArray(input)
+              ? (input as JSONObject)
+              : {},
+        };
+      });
+
+    if (!textContent && toolCalls.length === 0) {
+      throw new BadDataException("No text content in AWS Bedrock response");
+    }
+
+    const usage: JSONObject | undefined = jsonData["usage"] as
+      | JSONObject
+      | undefined;
+    const promptTokens: number = (usage?.["inputTokens"] as number) || 0;
+    const completionTokens: number = (usage?.["outputTokens"] as number) || 0;
+
+    return {
+      content: textContent,
+      toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+      stopReason: jsonData["stopReason"] === "tool_use" ? "tool_use" : "stop",
+      usage: usage
+        ? {
+            promptTokens: promptTokens,
+            completionTokens: completionTokens,
+            totalTokens:
+              (usage["totalTokens"] as number) ||
+              promptTokens + completionTokens,
+          }
+        : undefined,
+    };
+  }
+
+  @CaptureSpan()
+  private static async getBedrockCompletion(
+    config: LLMProviderConfig,
+    request: LLMCompletionRequest,
+  ): Promise<LLMCompletionResponse> {
+    const target: BedrockRequestTarget = this.getBedrockRequestTarget({
+      config: config,
+      request: request,
+    });
+    const credentials: BedrockCredentials = this.getBedrockCredentials(config);
+    const body: JSONObject = this.buildBedrockRequestBody(request);
+    const bodyString: string = JSON.stringify(body);
+    const requestUrl: string = `${target.endpoint}/model/${encodeURIComponent(
+      target.modelName,
+    )}/converse`;
+
+    const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
+      await API.post<JSONObject>({
+        url: URL.fromString(requestUrl),
+        data: body,
+        headers: this.getBedrockSignatureHeaders({
+          credentials: credentials,
+          method: "POST",
+          requestUrl: requestUrl,
+          region: target.region,
+          body: bodyString,
+        }),
+        options: {
+          retries: request.requestRetries ?? 2,
+          exponentialBackoff: true,
+          timeout: request.requestTimeoutInMs ?? 120000,
+        },
+      });
+
+    const bedrockLogAttributes: LogAttributes = {
+      llmType: config.llmType,
+      modelName: target.modelName,
+    };
+
+    if (response instanceof HTTPErrorResponse) {
+      this.throwProviderHTTPError({
+        providerName: "AWS Bedrock",
+        response,
+        logAttributes: bedrockLogAttributes,
+        includeProviderErrorDetails: request.includeProviderErrorDetails,
+      });
+    }
+
+    return this.parseBedrockResponse(response.jsonData as JSONObject);
+  }
   /*
    * Ollama native /api/chat. Deliberately NOT routed through the
    * OpenAI-compatible branch: Ollama deployments are keyless by design and

--- a/Common/Tests/Server/Utils/AI/LLMServiceRequestPolicy.test.ts
+++ b/Common/Tests/Server/Utils/AI/LLMServiceRequestPolicy.test.ts
@@ -7,6 +7,7 @@ import LlmType from "../../../../Types/LLM/LlmType";
 import LLMService, {
   LLMProviderConfig,
 } from "../../../../Server/Utils/LLM/LLMService";
+import fs from "fs/promises";
 import { afterEach, describe, expect, test } from "@jest/globals";
 
 type PostSpy = ReturnType<typeof jest.spyOn>;
@@ -149,6 +150,91 @@ describe("LLMService request timeout and retry policy", () => {
       );
     },
   );
+
+  test("AWS Bedrock uses IRSA web identity credentials when no static key is configured", async () => {
+    const savedEnv: Record<string, string | undefined> = {
+      AWS_ACCESS_KEY_ID: process.env["AWS_ACCESS_KEY_ID"],
+      AWS_SECRET_ACCESS_KEY: process.env["AWS_SECRET_ACCESS_KEY"],
+      AWS_SESSION_TOKEN: process.env["AWS_SESSION_TOKEN"],
+      AWS_ROLE_ARN: process.env["AWS_ROLE_ARN"],
+      AWS_WEB_IDENTITY_TOKEN_FILE: process.env["AWS_WEB_IDENTITY_TOKEN_FILE"],
+      AWS_ROLE_SESSION_NAME: process.env["AWS_ROLE_SESSION_NAME"],
+    };
+
+    delete process.env["AWS_ACCESS_KEY_ID"];
+    delete process.env["AWS_SECRET_ACCESS_KEY"];
+    delete process.env["AWS_SESSION_TOKEN"];
+    process.env["AWS_ROLE_ARN"] =
+      "arn:aws:iam::123456789012:role/OneUptimeBedrockServiceAccount";
+    process.env["AWS_WEB_IDENTITY_TOKEN_FILE"] =
+      "/var/run/secrets/eks.amazonaws.com/serviceaccount/token";
+    process.env["AWS_ROLE_SESSION_NAME"] = "oneuptime-test";
+
+    jest.spyOn(fs, "readFile").mockResolvedValue("web-identity-token");
+
+    const postSpy: PostSpy = jest
+      .spyOn(API, "post")
+      .mockResolvedValueOnce({
+        jsonData: `
+          <AssumeRoleWithWebIdentityResponse>
+            <AssumeRoleWithWebIdentityResult>
+              <Credentials>
+                <AccessKeyId>ASIATEMP</AccessKeyId>
+                <SecretAccessKey>temp-secret</SecretAccessKey>
+                <SessionToken>temp-token</SessionToken>
+                <Expiration>2099-01-01T00:00:00Z</Expiration>
+              </Credentials>
+            </AssumeRoleWithWebIdentityResult>
+          </AssumeRoleWithWebIdentityResponse>
+        `,
+      } as unknown as HTTPResponse<JSONObject>)
+      .mockResolvedValueOnce({
+        jsonData: providerCases[3]!.response,
+      } as unknown as HTTPResponse<JSONObject>) as PostSpy;
+
+    try {
+      await LLMService.getCompletion({
+        llmProviderConfig: {
+          llmType: LlmType.Bedrock,
+          baseUrl: "https://bedrock-runtime.ap-northeast-2.amazonaws.com",
+          modelName: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        },
+        messages: [{ role: "user", content: "hello" }],
+      });
+
+      expect(postSpy).toHaveBeenCalledTimes(2);
+      expect(postSpy.mock.calls[0]![0]).toEqual(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            Action: "AssumeRoleWithWebIdentity",
+            RoleArn:
+              "arn:aws:iam::123456789012:role/OneUptimeBedrockServiceAccount",
+            RoleSessionName: "oneuptime-test",
+            WebIdentityToken: "web-identity-token",
+          }),
+          headers: expect.objectContaining({
+            "Content-Type": "application/x-www-form-urlencoded",
+          }),
+        }),
+      );
+      expect(postSpy.mock.calls[1]![0]).toEqual(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "X-Amz-Security-Token": "temp-token",
+            Authorization: expect.stringContaining("Credential=ASIATEMP/"),
+          }),
+        }),
+      );
+    } finally {
+      for (const [key, value] of Object.entries(savedEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+  });
 
   test("protected OpenAI-compatible requests cannot have workflow-owned fields overridden", async () => {
     const postSpy: PostSpy = mockPost(providerCases[0]!.response);

--- a/Common/Tests/Server/Utils/AI/LLMServiceRequestPolicy.test.ts
+++ b/Common/Tests/Server/Utils/AI/LLMServiceRequestPolicy.test.ts
@@ -62,6 +62,21 @@ const providerCases: Array<ProviderCase> = [
     defaultTimeoutInMs: 120_000,
   },
   {
+    name: "AWS Bedrock",
+    config: {
+      llmType: LlmType.Bedrock,
+      apiKey: "AKIATEST:secret",
+      baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      modelName: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    },
+    response: {
+      output: { message: { content: [{ text: "ok" }] } },
+      stopReason: "end_turn",
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+    },
+    defaultTimeoutInMs: 120_000,
+  },
+  {
     name: "Ollama",
     config: {
       llmType: LlmType.Ollama,

--- a/Common/Tests/Server/Utils/AI/LLMServiceToolCalling.test.ts
+++ b/Common/Tests/Server/Utils/AI/LLMServiceToolCalling.test.ts
@@ -210,7 +210,7 @@ describe("LLMService tool calling — AWS Bedrock", () => {
         llmType: LlmType.Bedrock,
         apiKey: "AKIATEST:secret",
         baseUrl: "https://bedrock-runtime.us-west-2.amazonaws.com",
-        modelName: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelName: "meta.llama3-1-70b-instruct-v1:0",
       },
       messages: [
         { role: "system", content: "be helpful" },
@@ -226,10 +226,14 @@ describe("LLMService tool calling — AWS Bedrock", () => {
       maxTokens: 1024,
     });
 
-    const request: { data: JSONObject; headers: Record<string, string> } = spy
-      .mock.calls[0]![0] as {
+    const request: {
       data: JSONObject;
       headers: Record<string, string>;
+      url: unknown;
+    } = spy.mock.calls[0]![0] as {
+      data: JSONObject;
+      headers: Record<string, string>;
+      url: unknown;
     };
 
     expect(request.data["system"]).toHaveLength(1);
@@ -242,12 +246,28 @@ describe("LLMService tool calling — AWS Bedrock", () => {
     );
     expect(request.headers["Authorization"]).toContain("/us-west-2/bedrock/");
     expect(request.headers["X-Amz-Date"]).toBeDefined();
+    expect(String(request.url)).toContain(
+      encodeURIComponent("meta.llama3-1-70b-instruct-v1:0"),
+    );
 
     expect(response.content).toBe("checking");
     expect(response.stopReason).toBe("tool_use");
     expect(response.toolCalls).toHaveLength(1);
     expect(response.toolCalls![0]!.arguments).toEqual({ metricName: "cpu" });
     expect(response.usage!.totalTokens).toBe(30);
+  });
+
+  test("requires callers to choose the Bedrock model id", async () => {
+    await expect(
+      LLMService.getCompletion({
+        llmProviderConfig: {
+          llmType: LlmType.Bedrock,
+          apiKey: "AKIATEST:secret",
+          baseUrl: "https://bedrock-runtime.us-west-2.amazonaws.com",
+        },
+        messages: [{ role: "user", content: "hello" }],
+      }),
+    ).rejects.toThrow("Model Name is required for AWS Bedrock");
   });
 });
 

--- a/Common/Tests/Server/Utils/AI/LLMServiceToolCalling.test.ts
+++ b/Common/Tests/Server/Utils/AI/LLMServiceToolCalling.test.ts
@@ -184,6 +184,73 @@ describe("LLMService tool calling — Anthropic", () => {
   });
 });
 
+describe("LLMService tool calling — AWS Bedrock", () => {
+  test("signs Converse requests and parses toolUse blocks", async () => {
+    const spy: PostSpy = mockPostResponse({
+      output: {
+        message: {
+          content: [
+            { text: "checking" },
+            {
+              toolUse: {
+                toolUseId: "toolu_1",
+                name: "query_metrics",
+                input: { metricName: "cpu" },
+              },
+            },
+          ],
+        },
+      },
+      stopReason: "tool_use",
+      usage: { inputTokens: 20, outputTokens: 10, totalTokens: 30 },
+    });
+
+    const response: LLMCompletionResponse = await LLMService.getCompletion({
+      llmProviderConfig: {
+        llmType: LlmType.Bedrock,
+        apiKey: "AKIATEST:secret",
+        baseUrl: "https://bedrock-runtime.us-west-2.amazonaws.com",
+        modelName: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      },
+      messages: [
+        { role: "system", content: "be helpful" },
+        { role: "user", content: "cpu usage?" },
+      ],
+      tools: [
+        {
+          name: "query_metrics",
+          description: "query metrics",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+      maxTokens: 1024,
+    });
+
+    const request: { data: JSONObject; headers: Record<string, string> } = spy
+      .mock.calls[0]![0] as {
+      data: JSONObject;
+      headers: Record<string, string>;
+    };
+
+    expect(request.data["system"]).toHaveLength(1);
+    expect((request.data["inferenceConfig"] as JSONObject)["maxTokens"]).toBe(
+      1024,
+    );
+    expect((request.data["toolConfig"] as JSONObject)["tools"]).toHaveLength(1);
+    expect(request.headers["Authorization"]).toContain(
+      "Credential=AKIATEST/20",
+    );
+    expect(request.headers["Authorization"]).toContain("/us-west-2/bedrock/");
+    expect(request.headers["X-Amz-Date"]).toBeDefined();
+
+    expect(response.content).toBe("checking");
+    expect(response.stopReason).toBe("tool_use");
+    expect(response.toolCalls).toHaveLength(1);
+    expect(response.toolCalls![0]!.arguments).toEqual({ metricName: "cpu" });
+    expect(response.usage!.totalTokens).toBe(30);
+  });
+});
+
 describe("LLMService tool calling — Ollama", () => {
   test("works without an API key and parses object tool arguments", async () => {
     const spy: PostSpy = mockPostResponse({

--- a/Common/Types/LLM/LlmType.ts
+++ b/Common/Types/LLM/LlmType.ts
@@ -5,6 +5,7 @@ enum LlmType {
   Groq = "Groq",
   Mistral = "Mistral",
   Ollama = "Ollama",
+  Bedrock = "Bedrock",
   /*
    * Generic OpenAI-compatible servers (vLLM, LocalAI, LM Studio, text-gen-webui,
    * etc.) that speak the OpenAI /chat/completions wire format but are typically

--- a/Common/UI/Utils/LlmTypeDropdownOptions.ts
+++ b/Common/UI/Utils/LlmTypeDropdownOptions.ts
@@ -28,6 +28,10 @@ const LlmTypeDropdownOptions: Array<DropdownOption> = [
     value: LlmType.Mistral,
   },
   {
+    label: "AWS Bedrock",
+    value: LlmType.Bedrock,
+  },
+  {
     label: "Ollama",
     value: LlmType.Ollama,
   },


### PR DESCRIPTION
## Summary
- Add AWS Bedrock as a native LLM provider option
- Implement Bedrock Converse request/response conversion, tool calling, usage parsing, and SigV4 signing without adding the AWS SDK
- Require operators to set the Bedrock model name explicitly; any Bedrock Converse-compatible model ID, inference profile ID, or ARN can be used
- Add IRSA web identity credential fallback via STS AssumeRoleWithWebIdentity when static AWS keys are not configured
- Update provider API key/model guidance and add Bedrock request policy/tool-calling coverage

## Verification
- npm run fix
- cd Common && npm run test-file -- Tests/Server/Utils/AI/LLMServiceToolCalling.test.ts
- cd Common && npm run test-file -- Tests/Server/Utils/AI/LLMServiceRequestPolicy.test.ts
- cd Common && npm run compile attempted on a clean branch from current upstream master; it failed on existing Buffer typing errors in Common/Server/API/TelemetryAPI.ts and Common/Server/Utils/PasswordHash.ts before this PR's Bedrock path was exercised