### PR TITLE
fix(security): block SSRF via status page subscriber webhooks (GHSA-gf3v-98g2-qffx)

### DIFF
--- a/App/FeatureSet/Notification/Services/WebhookService.ts
+++ b/App/FeatureSet/Notification/Services/WebhookService.ts
@@ -11,8 +11,8 @@ import API from "Common/Utils/API";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 import URL from "Common/Types/API/URL";
+import SSRFProtection from "Common/Server/Utils/SSRFProtection";
 import crypto from "crypto";
-import dns from "dns";
 
 const WEBHOOK_REQUEST_TIMEOUT_MS: number = 10_000;
 const MAX_LOGGED_BODY_LENGTH: number = 2_000;
@@ -95,7 +95,7 @@ export default class WebhookService {
         throw new BadDataException("Webhook eventType is required");
       }
 
-      await validateWebhookTargetIsSafe(message.url);
+      await SSRFProtection.validateWebhookTargetIsSafe(message.url);
 
       const bodyString: string = JSON.stringify(message.payload || {});
 
@@ -203,125 +203,6 @@ export default class WebhookService {
       throw sendError;
     }
   }
-}
-
-async function validateWebhookTargetIsSafe(rawUrl: string): Promise<void> {
-  let parsed: URL;
-  try {
-    parsed = URL.fromString(rawUrl);
-  } catch {
-    throw new BadDataException("Webhook URL is not a valid URL");
-  }
-
-  const protocolValue: string = parsed.protocol.toString().toLowerCase();
-  if (protocolValue !== "http://" && protocolValue !== "https://") {
-    throw new BadDataException("Webhook URL must use http or https protocol.");
-  }
-
-  const hostname: string = parsed.hostname.hostname.toLowerCase();
-
-  if (!hostname) {
-    throw new BadDataException("Webhook URL must include a host.");
-  }
-
-  if (isBlockedHostnameLiteral(hostname)) {
-    throw new BadDataException(
-      "Webhook URL points to a private, loopback, or link-local address and is not allowed.",
-    );
-  }
-
-  if (!isIpLiteral(hostname)) {
-    let resolved: Array<{ address: string }> = [];
-    try {
-      resolved = await dns.promises.lookup(hostname, { all: true });
-    } catch {
-      throw new BadDataException(
-        "Webhook URL hostname could not be resolved via DNS.",
-      );
-    }
-
-    for (const entry of resolved) {
-      if (isBlockedHostnameLiteral(entry.address.toLowerCase())) {
-        throw new BadDataException(
-          "Webhook URL resolves to a private, loopback, or link-local address and is not allowed.",
-        );
-      }
-    }
-  }
-}
-
-const IPV4_LITERAL_REGEX: RegExp = /^(\d{1,3}\.){3}\d{1,3}$/;
-const IPV6_UNIQUE_LOCAL_REGEX: RegExp = /^f[cd][0-9a-f]{2}:/;
-
-function isIpLiteral(hostname: string): boolean {
-  return IPV4_LITERAL_REGEX.test(hostname) || hostname.includes(":");
-}
-
-function isBlockedHostnameLiteral(hostname: string): boolean {
-  if (
-    hostname === "localhost" ||
-    hostname.endsWith(".localhost") ||
-    hostname === "metadata.google.internal"
-  ) {
-    return true;
-  }
-
-  const ipv4Match: RegExpMatchArray | null = hostname.match(
-    /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/,
-  );
-  if (ipv4Match) {
-    const octets: Array<number> = [
-      Number(ipv4Match[1]),
-      Number(ipv4Match[2]),
-      Number(ipv4Match[3]),
-      Number(ipv4Match[4]),
-    ];
-
-    if (
-      octets.some((o: number) => {
-        return o < 0 || o > 255;
-      })
-    ) {
-      return true;
-    }
-    if (octets[0] === 0) {
-      return true;
-    }
-    if (octets[0] === 127) {
-      return true;
-    }
-    if (octets[0] === 10) {
-      return true;
-    }
-    if (octets[0] === 172 && (octets[1]! & 0xf0) === 16) {
-      return true;
-    }
-    if (octets[0] === 192 && octets[1] === 168) {
-      return true;
-    }
-    if (octets[0] === 169 && octets[1] === 254) {
-      return true;
-    }
-    if (octets[0] === 100 && (octets[1]! & 0xc0) === 64) {
-      return true;
-    }
-    return false;
-  }
-
-  if (hostname.includes(":")) {
-    const stripped: string = hostname.replace(/^\[|\]$/g, "");
-    if (stripped === "::1" || stripped === "::") {
-      return true;
-    }
-    if (stripped.startsWith("fe80:") || stripped.startsWith("fe80::")) {
-      return true;
-    }
-    if (IPV6_UNIQUE_LOCAL_REGEX.test(stripped)) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 function truncate(value: string, maxLength: number): string {

--- a/Common/Server/Services/StatusPageSubscriberService.ts
+++ b/Common/Server/Services/StatusPageSubscriberService.ts
@@ -37,6 +37,7 @@ import NumberUtil from "../../Utils/Number";
 import SlackUtil from "../Utils/Workspace/Slack/Slack";
 import MicrosoftTeamsUtil from "../Utils/Workspace/MicrosoftTeams/MicrosoftTeams";
 import StatusPageSubscriberWebhookUtil from "../Utils/StatusPageSubscriberWebhook";
+import SSRFProtection from "../Utils/SSRFProtection";
 import StatusPageSubscriberNotificationTemplateService, {
   Service as StatusPageSubscriberNotificationTemplateServiceClass,
 } from "./StatusPageSubscriberNotificationTemplateService";
@@ -333,6 +334,18 @@ export class Service extends DatabaseService<Model> {
           "Invalid Microsoft Teams Incoming Webhook URL.",
         );
       }
+    }
+
+    /*
+     * Validate the generic subscriber webhook URL if provided. Subscriber
+     * creation is publicly accessible (Permission.Public), so an unauthenticated
+     * user can supply this URL. Reject targets that point at private, loopback,
+     * link-local, or cloud metadata addresses to prevent SSRF.
+     */
+    if (data.data.subscriberWebhook) {
+      await SSRFProtection.validateWebhookTargetIsSafe(
+        data.data.subscriberWebhook,
+      );
     }
 
     data.data.subscriptionConfirmationToken = NumberUtil.getRandomNumber(

--- a/Common/Server/Utils/SSRFProtection.ts
+++ b/Common/Server/Utils/SSRFProtection.ts
@@ -1,0 +1,237 @@
+import URL from "../../Types/API/URL";
+import BadDataException from "../../Types/Exception/BadDataException";
+import dns from "dns";
+
+const IPV4_LITERAL_REGEX: RegExp = /^(\d{1,3}\.){3}\d{1,3}$/;
+const IPV6_UNIQUE_LOCAL_REGEX: RegExp = /^f[cd][0-9a-f]{2}:/;
+
+/*
+ * Guards outbound HTTP(S) requests whose target is (fully or partly)
+ * attacker-controlled — status page subscriber webhooks, project webhook
+ * notifications, etc. — against Server-Side Request Forgery. It rejects URLs
+ * that point at loopback, RFC-1918 private ranges, link-local (including the
+ * 169.254.169.254 cloud metadata endpoint), CGNAT, and IPv6 loopback /
+ * link-local / unique-local addresses, resolving DNS hostnames first so a
+ * public-looking name that maps to an internal address is still blocked.
+ *
+ * This is a best-effort, TOCTOU-susceptible check: a hostname can resolve to a
+ * different address between validation and the actual request (DNS rebinding).
+ * Callers should therefore ALSO disable redirect-following on the request so a
+ * validated public host cannot 3xx-redirect the server to an internal target.
+ */
+export default class SSRFProtection {
+  /*
+   * Returns the bare, lowercased host of a URL — no port, no brackets — or an
+   * empty string if it cannot be parsed. Host-pinning allowlists (Slack, Teams)
+   * must compare against THIS, never against the whole URL string: a substring
+   * check on the full URL is satisfied by an attacker-controlled path or query
+   * (`http://169.254.169.254/?x=office.com`) and pins nothing.
+   */
+  public static getBareHostname(rawUrl: string | URL): string {
+    let parsed: URL;
+    try {
+      parsed = URL.fromString(rawUrl.toString());
+    } catch {
+      return "";
+    }
+
+    return SSRFProtection.extractHost(parsed.hostname.hostname.toLowerCase());
+  }
+
+  /*
+   * True when the URL's host is exactly one of `allowedDomains` or a subdomain
+   * of one, and the scheme is https. Suffix matching is anchored on a leading
+   * dot so `office.com.attacker.tld` and `evil-office.com` are both rejected.
+   */
+  public static isUrlOnAllowedDomain(
+    rawUrl: string | URL,
+    allowedDomains: Array<string>,
+  ): boolean {
+    let parsed: URL;
+    try {
+      parsed = URL.fromString(rawUrl.toString());
+    } catch {
+      return false;
+    }
+
+    if (parsed.protocol.toString().toLowerCase() !== "https://") {
+      return false;
+    }
+
+    const hostname: string = SSRFProtection.getBareHostname(rawUrl);
+
+    if (!hostname) {
+      return false;
+    }
+
+    return allowedDomains.some((domain: string) => {
+      const allowed: string = domain.toLowerCase();
+      return hostname === allowed || hostname.endsWith(`.${allowed}`);
+    });
+  }
+
+  public static async validateWebhookTargetIsSafe(
+    rawUrl: string | URL,
+  ): Promise<void> {
+    let parsed: URL;
+    try {
+      parsed = URL.fromString(rawUrl.toString());
+    } catch {
+      throw new BadDataException("Webhook URL is not a valid URL");
+    }
+
+    const protocolValue: string = parsed.protocol.toString().toLowerCase();
+    if (protocolValue !== "http://" && protocolValue !== "https://") {
+      throw new BadDataException(
+        "Webhook URL must use http or https protocol.",
+      );
+    }
+
+    const rawHost: string = parsed.hostname.hostname.toLowerCase();
+
+    if (!rawHost) {
+      throw new BadDataException("Webhook URL must include a host.");
+    }
+
+    /*
+     * OneUptime's URL parser keeps the port glued to the host (e.g.
+     * "169.254.169.254:80"). Strip it before the checks below, otherwise a
+     * literal-with-port slips past the IPv4 blocklist and, because it contains
+     * a ":", is mistaken for an IP literal and skips DNS resolution entirely.
+     */
+    const hostname: string = SSRFProtection.extractHost(rawHost);
+
+    if (!hostname) {
+      throw new BadDataException("Webhook URL must include a host.");
+    }
+
+    if (SSRFProtection.isBlockedHostnameLiteral(hostname)) {
+      throw new BadDataException(
+        "Webhook URL points to a private, loopback, or link-local address and is not allowed.",
+      );
+    }
+
+    if (!SSRFProtection.isIpLiteral(hostname)) {
+      let resolved: Array<{ address: string }> = [];
+      try {
+        resolved = await dns.promises.lookup(hostname, { all: true });
+      } catch {
+        throw new BadDataException(
+          "Webhook URL hostname could not be resolved via DNS.",
+        );
+      }
+
+      for (const entry of resolved) {
+        if (
+          SSRFProtection.isBlockedHostnameLiteral(entry.address.toLowerCase())
+        ) {
+          throw new BadDataException(
+            "Webhook URL resolves to a private, loopback, or link-local address and is not allowed.",
+          );
+        }
+      }
+    }
+  }
+
+  /*
+   * Extracts the bare host (IPv4, IPv6, or hostname) from a "host[:port]"
+   * string, handling bracketed IPv6 (`[::1]`, `[::1]:8080`) and unbracketed
+   * IPv6 literals (which contain multiple colons and carry no port).
+   */
+  private static extractHost(hostWithPort: string): string {
+    const host: string = hostWithPort.trim();
+
+    if (host.startsWith("[")) {
+      const closingBracketIndex: number = host.indexOf("]");
+      if (closingBracketIndex !== -1) {
+        return host.slice(1, closingBracketIndex);
+      }
+      return host.replace(/^\[|\]$/g, "");
+    }
+
+    const colonCount: number = (host.match(/:/g) || []).length;
+
+    if (colonCount > 1) {
+      // Unbracketed IPv6 literal — colons are part of the address, not a port.
+      return host;
+    }
+
+    if (colonCount === 1) {
+      // host:port — keep only the host part.
+      return host.split(":")[0] || "";
+    }
+
+    return host;
+  }
+
+  private static isIpLiteral(hostname: string): boolean {
+    return IPV4_LITERAL_REGEX.test(hostname) || hostname.includes(":");
+  }
+
+  private static isBlockedHostnameLiteral(hostname: string): boolean {
+    if (
+      hostname === "localhost" ||
+      hostname.endsWith(".localhost") ||
+      hostname === "metadata.google.internal"
+    ) {
+      return true;
+    }
+
+    const ipv4Match: RegExpMatchArray | null = hostname.match(
+      /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/,
+    );
+    if (ipv4Match) {
+      const octets: Array<number> = [
+        Number(ipv4Match[1]),
+        Number(ipv4Match[2]),
+        Number(ipv4Match[3]),
+        Number(ipv4Match[4]),
+      ];
+
+      if (
+        octets.some((o: number) => {
+          return o < 0 || o > 255;
+        })
+      ) {
+        return true;
+      }
+      if (octets[0] === 0) {
+        return true;
+      }
+      if (octets[0] === 127) {
+        return true;
+      }
+      if (octets[0] === 10) {
+        return true;
+      }
+      if (octets[0] === 172 && (octets[1]! & 0xf0) === 16) {
+        return true;
+      }
+      if (octets[0] === 192 && octets[1] === 168) {
+        return true;
+      }
+      if (octets[0] === 169 && octets[1] === 254) {
+        return true;
+      }
+      if (octets[0] === 100 && (octets[1]! & 0xc0) === 64) {
+        return true;
+      }
+      return false;
+    }
+
+    if (hostname.includes(":")) {
+      const stripped: string = hostname.replace(/^\[|\]$/g, "");
+      if (stripped === "::1" || stripped === "::") {
+        return true;
+      }
+      if (stripped.startsWith("fe80:") || stripped.startsWith("fe80::")) {
+        return true;
+      }
+      if (IPV6_UNIQUE_LOCAL_REGEX.test(stripped)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/Common/Server/Utils/StatusPageSubscriberWebhook.ts
+++ b/Common/Server/Utils/StatusPageSubscriberWebhook.ts
@@ -4,6 +4,7 @@ import HTTPErrorResponse from "../../Types/API/HTTPErrorResponse";
 import HTTPResponse from "../../Types/API/HTTPResponse";
 import { JSONObject } from "../../Types/JSON";
 import logger from "./Logger";
+import SSRFProtection from "./SSRFProtection";
 
 export interface StatusPageWebhookPayload extends JSONObject {
   eventType: string;
@@ -21,6 +22,30 @@ export default class StatusPageSubscriberWebhookUtil {
   }): Promise<HTTPResponse<JSONObject> | HTTPErrorResponse> {
     logger.debug("Sending status page subscriber webhook notification.");
 
+    /*
+     * The subscriber webhook target is attacker-controllable: any unauthenticated
+     * visitor can register a subscriber with an arbitrary webhook URL on a public
+     * status page. Validate it against the SSRF blocklist before every send (not
+     * just at create time) so previously-stored URLs and DNS-rebinding cannot make
+     * the server reach internal services or the cloud metadata endpoint.
+     */
+    try {
+      await SSRFProtection.validateWebhookTargetIsSafe(data.webhookUrl);
+    } catch (err) {
+      logger.warn(
+        "Refusing to send status page subscriber webhook: unsafe URL.",
+      );
+      logger.warn(err);
+      return new HTTPErrorResponse(
+        400,
+        {
+          message:
+            err instanceof Error ? err.message : "Webhook URL is not allowed.",
+        },
+        {},
+      );
+    }
+
     const apiResult: HTTPResponse<JSONObject> | HTTPErrorResponse =
       await API.post({
         url: data.webhookUrl,
@@ -28,6 +53,11 @@ export default class StatusPageSubscriberWebhookUtil {
         options: {
           retries: 3,
           exponentialBackoff: true,
+          /*
+           * Do not follow redirects: a validated public host could otherwise
+           * 3xx-redirect the server to an internal address, bypassing the check.
+           */
+          doNotFollowRedirects: true,
         },
       });
 

--- a/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
+++ b/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
@@ -30,6 +30,7 @@ import CaptureSpan from "../../Telemetry/CaptureSpan";
 import BadDataException from "../../../../Types/Exception/BadDataException";
 import ObjectID from "../../../../Types/ObjectID";
 import WorkspaceProjectAuthTokenService from "../../../Services/WorkspaceProjectAuthTokenService";
+import SSRFProtection from "../../SSRFProtection";
 import WorkspaceProjectAuthToken, {
   MicrosoftTeamsChat,
   MicrosoftTeamsChatType,
@@ -112,6 +113,16 @@ const MICROSOFT_TEAMS_APP_TYPE: string = "SingleTenant";
 
 // Maximum number of pages to fetch when paginating teams
 const MICROSOFT_TEAMS_MAX_PAGES: number = 500;
+
+/*
+ * Hosts that may receive a Teams incoming webhook. Connector webhooks are
+ * issued on outlook.office.com / outlook.office365.com, and per-tenant ones on
+ * <tenant>.webhook.office.com — all covered by these two registrable domains.
+ */
+const MICROSOFT_TEAMS_WEBHOOK_DOMAINS: Array<string> = [
+  "office.com",
+  "office365.com",
+];
 
 export default class MicrosoftTeamsUtil extends WorkspaceBase {
   private static cachedAdapter: CloudAdapter | null = null;
@@ -700,6 +711,13 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
       await API.post({
         url: data.url,
         data: payload,
+        options: {
+          /*
+           * The host is pinned to Microsoft, but do not let a redirect from it
+           * bounce this request to an internal address.
+           */
+          doNotFollowRedirects: true,
+        },
       });
 
     if (!apiResult) {
@@ -730,11 +748,16 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
   public static isValidMicrosoftTeamsIncomingWebhookUrl(
     incomingWebhookUrl: URL,
   ): boolean {
-    // Check if the URL contains outlook.office.com or office.com webhook pattern
-    const urlString: string = incomingWebhookUrl.toString();
-    return (
-      urlString.includes("outlook.office.com") ||
-      urlString.includes("office.com")
+    /*
+     * Pin on the URL's HOST, not on a substring of the whole URL. Subscribers
+     * (including unauthenticated ones on a public status page) supply this
+     * value and the server POSTs to it, so a substring check was satisfied by
+     * an attacker-controlled path or query — `http://169.254.169.254/?x=office.com`
+     * passed and turned this into an SSRF into the cloud metadata endpoint.
+     */
+    return SSRFProtection.isUrlOnAllowedDomain(
+      incomingWebhookUrl,
+      MICROSOFT_TEAMS_WEBHOOK_DOMAINS,
     );
   }
 

--- a/Common/Server/Utils/Workspace/Slack/Slack.ts
+++ b/Common/Server/Utils/Workspace/Slack/Slack.ts
@@ -2282,6 +2282,11 @@ export default class SlackUtil extends WorkspaceBase {
         options: {
           retries: 3,
           exponentialBackoff: true,
+          /*
+           * The host is pinned to hooks.slack.com, but do not let a redirect
+           * from it bounce this request to an internal address.
+           */
+          doNotFollowRedirects: true,
         },
       });
 

--- a/Common/Tests/Server/Utils/MicrosoftTeamsWebhookUrlValidation.test.ts
+++ b/Common/Tests/Server/Utils/MicrosoftTeamsWebhookUrlValidation.test.ts
@@ -1,0 +1,103 @@
+import MicrosoftTeamsUtil from "../../../Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams";
+import SlackUtil from "../../../Server/Utils/Workspace/Slack/Slack";
+import URL from "../../../Types/API/URL";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Status page subscribers — including unauthenticated visitors on a public
+ * status page — supply these webhook URLs, and the server POSTs to them as
+ * soon as the subscriber is created. The validators are therefore the only
+ * thing standing between an anonymous request and an outbound server-side
+ * request to an arbitrary host.
+ *
+ * The Teams validator used to substring-match the whole URL for "office.com",
+ * which an attacker satisfied from the path or query
+ * (http://169.254.169.254/?x=office.com) — SSRF into the cloud metadata
+ * endpoint. These pin the host-anchored behavior that replaced it.
+ */
+
+describe("MicrosoftTeamsUtil.isValidMicrosoftTeamsIncomingWebhookUrl", () => {
+  describe("accepts genuine Microsoft webhook hosts", () => {
+    const validUrls: Array<string> = [
+      "https://outlook.office.com/webhook/abc123/IncomingWebhook/def456",
+      "https://outlook.office365.com/webhook/abc123/IncomingWebhook/def456",
+      "https://contoso.webhook.office.com/webhookb2/abc-123/IncomingWebhook/def",
+    ];
+
+    test.each(validUrls)("accepts %s", (url: string) => {
+      expect(
+        MicrosoftTeamsUtil.isValidMicrosoftTeamsIncomingWebhookUrl(
+          URL.fromString(url),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("rejects SSRF payloads that the substring check let through", () => {
+    const ssrfUrls: Array<string> = [
+      // The advisory-class payload: metadata endpoint with office.com in the query.
+      "http://169.254.169.254/latest/meta-data/iam/security-credentials/?x=office.com",
+      "https://169.254.169.254/latest/meta-data/?x=office.com",
+      "http://localhost:9200/_cluster/health?a=office.com",
+      "http://127.0.0.1/admin?x=outlook.office.com",
+      "http://10.0.0.5/office.com",
+      "https://192.168.1.1/?redirect=outlook.office.com",
+    ];
+
+    test.each(ssrfUrls)("rejects %s", (url: string) => {
+      expect(
+        MicrosoftTeamsUtil.isValidMicrosoftTeamsIncomingWebhookUrl(
+          URL.fromString(url),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("rejects look-alike domains", () => {
+    const lookAlikeUrls: Array<string> = [
+      "https://office.com.attacker.tld/webhook",
+      "https://evil-office.com/webhook",
+      "https://attacker.tld/webhook?host=office.com",
+      "https://outlook.office.com.evil.tld/webhook",
+    ];
+
+    test.each(lookAlikeUrls)("rejects %s", (url: string) => {
+      expect(
+        MicrosoftTeamsUtil.isValidMicrosoftTeamsIncomingWebhookUrl(
+          URL.fromString(url),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  test("rejects a plaintext http Microsoft host (no downgrade)", () => {
+    expect(
+      MicrosoftTeamsUtil.isValidMicrosoftTeamsIncomingWebhookUrl(
+        URL.fromString("http://outlook.office.com/webhook/abc/IncomingWebhook"),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("SlackUtil.isValidSlackIncomingWebhookUrl", () => {
+  test("accepts a genuine Slack incoming webhook URL", () => {
+    expect(
+      SlackUtil.isValidSlackIncomingWebhookUrl(
+        URL.fromString("https://hooks.slack.com/services/T000/B000/XXXX"),
+      ),
+    ).toBe(true);
+  });
+
+  const invalidUrls: Array<string> = [
+    "http://169.254.169.254/?x=https://hooks.slack.com/services/",
+    "https://hooks.slack.com.attacker.tld/services/x",
+    "http://hooks.slack.com/services/T000/B000/XXXX",
+    "https://127.0.0.1/services/",
+  ];
+
+  test.each(invalidUrls)("rejects %s", (url: string) => {
+    expect(SlackUtil.isValidSlackIncomingWebhookUrl(URL.fromString(url))).toBe(
+      false,
+    );
+  });
+});

--- a/Common/Tests/Server/Utils/SSRFProtection.test.ts
+++ b/Common/Tests/Server/Utils/SSRFProtection.test.ts
@@ -1,0 +1,193 @@
+import SSRFProtection from "../../../Server/Utils/SSRFProtection";
+import URL from "../../../Types/API/URL";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import dns from "dns";
+
+/*
+ * SSRFProtection is the single guard standing between attacker-controlled
+ * webhook URLs (any unauthenticated visitor can register a status page
+ * subscriber webhook) and the server's outbound HTTP client. These tests pin
+ * the blocklist so a regression cannot quietly re-open the path to the cloud
+ * metadata endpoint or internal services. DNS is mocked so the resolution
+ * branch is exercised deterministically and offline.
+ */
+
+/*
+ * dns.promises.lookup is heavily overloaded, so spyOn resolves to the wrong
+ * signature. Pin the one shape this module actually calls ({ all: true }).
+ */
+type LookupSpy = jest.SpiedFunction<
+  (
+    hostname: string,
+    options: { all: true },
+  ) => Promise<Array<{ address: string; family: number }>>
+>;
+
+describe("SSRFProtection.validateWebhookTargetIsSafe", () => {
+  let lookupSpy: LookupSpy;
+
+  beforeEach(() => {
+    lookupSpy = jest.spyOn(dns.promises, "lookup") as unknown as LookupSpy;
+    // Default: hostnames resolve to a public address unless a test overrides it.
+    lookupSpy.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("blocks private, loopback, link-local and metadata literals", () => {
+    const blockedUrls: Array<string> = [
+      "http://127.0.0.1/webhook",
+      "http://127.0.0.1:8080/webhook",
+      "http://0.0.0.0/",
+      "http://10.0.0.5/incident",
+      "http://10.255.255.255/x",
+      "http://172.16.0.1/",
+      "http://172.31.255.1/",
+      "http://192.168.1.1/hook",
+      "http://100.64.0.1/",
+      "http://100.127.255.255/",
+      "http://localhost/",
+      "http://localhost:3000/",
+      "http://foo.localhost/",
+      "http://metadata.google.internal/computeMetadata/v1/",
+      "http://[::1]/",
+      "http://[::1]:8080/",
+      "http://[fe80::1]/",
+      "http://[fc00::1]/",
+      "http://[fd12:3456::1]/",
+    ];
+
+    test.each(blockedUrls)("rejects %s", async (url: string) => {
+      await expect(
+        SSRFProtection.validateWebhookTargetIsSafe(url),
+      ).rejects.toThrow();
+      expect(lookupSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("blocks the cloud metadata endpoint, including port bypass", () => {
+    test("rejects AWS metadata endpoint", async () => {
+      await expect(
+        SSRFProtection.validateWebhookTargetIsSafe(
+          "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        ),
+      ).rejects.toThrow();
+    });
+
+    test("rejects metadata endpoint with an explicit port (bypass attempt)", async () => {
+      await expect(
+        SSRFProtection.validateWebhookTargetIsSafe(
+          "http://169.254.169.254:80/latest/meta-data/",
+        ),
+      ).rejects.toThrow();
+      // Must be caught as a literal, never treated as a resolvable host.
+      expect(lookupSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("allows public destinations", () => {
+    const allowedUrls: Array<string> = [
+      "http://8.8.8.8/webhook",
+      "https://1.1.1.1/",
+      "http://172.15.0.1/", // just outside the private 172.16-31 range
+      "http://172.32.0.1/",
+      "http://100.63.0.1/", // just below CGNAT 100.64/10
+      "http://100.128.0.1/", // just above CGNAT 100.64/10
+    ];
+
+    test.each(allowedUrls)("allows %s", async (url: string) => {
+      await expect(
+        SSRFProtection.validateWebhookTargetIsSafe(url),
+      ).resolves.toBeUndefined();
+    });
+
+    test("allows a public hostname (DNS resolves to a public IP)", async () => {
+      await expect(
+        SSRFProtection.validateWebhookTargetIsSafe(
+          "https://hooks.example.com/webhook",
+        ),
+      ).resolves.toBeUndefined();
+      expect(lookupSpy).toHaveBeenCalledWith("hooks.example.com", {
+        all: true,
+      });
+    });
+
+    test("resolves a hostname even when a port is present", async () => {
+      await expect(
+        SSRFProtection.validateWebhookTargetIsSafe(
+          "https://hooks.example.com:8443/webhook",
+        ),
+      ).resolves.toBeUndefined();
+      // Port must be stripped so the hostname (not "host:port") is resolved.
+      expect(lookupSpy).toHaveBeenCalledWith("hooks.example.com", {
+        all: true,
+      });
+    });
+
+    test("accepts a URL object as input", async () => {
+      await expect(
+        SSRFProtection.validateWebhookTargetIsSafe(
+          URL.fromString("http://8.8.8.8/webhook"),
+        ),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("blocks hostnames that resolve to internal addresses", () => {
+    test("rejects a hostname resolving to a private address (DNS rebinding)", async () => {
+      lookupSpy.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+
+      await expect(
+        SSRFProtection.validateWebhookTargetIsSafe(
+          "https://rebind.attacker.example/",
+        ),
+      ).rejects.toThrow();
+    });
+
+    test("rejects a hostname-with-port resolving to the metadata IP", async () => {
+      lookupSpy.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+
+      await expect(
+        SSRFProtection.validateWebhookTargetIsSafe(
+          "https://rebind.attacker.example:8080/",
+        ),
+      ).rejects.toThrow();
+    });
+
+    test("rejects when DNS resolution fails", async () => {
+      lookupSpy.mockRejectedValue(new Error("ENOTFOUND"));
+
+      await expect(
+        SSRFProtection.validateWebhookTargetIsSafe(
+          "https://this-does-not-resolve.invalid/",
+        ),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("rejects unusable URLs", () => {
+    test("rejects a non-http(s) protocol", async () => {
+      await expect(
+        SSRFProtection.validateWebhookTargetIsSafe("mongodb://8.8.8.8/"),
+      ).rejects.toThrow("http or https");
+      await expect(
+        SSRFProtection.validateWebhookTargetIsSafe("ws://8.8.8.8/"),
+      ).rejects.toThrow("http or https");
+    });
+
+    test("rejects a URL with no host", async () => {
+      await expect(
+        SSRFProtection.validateWebhookTargetIsSafe("http:///no-host"),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/StatusPageSubscriberWebhook.test.ts
+++ b/Common/Tests/Server/Utils/StatusPageSubscriberWebhook.test.ts
@@ -1,0 +1,101 @@
+import StatusPageSubscriberWebhookUtil, {
+  StatusPageWebhookPayload,
+} from "../../../Server/Utils/StatusPageSubscriberWebhook";
+import API from "../../../Utils/API";
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import URL from "../../../Types/API/URL";
+import { JSONObject } from "../../../Types/JSON";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import dns from "dns";
+
+/*
+ * Status page subscribers can be created by unauthenticated visitors, so the
+ * stored webhook URL is attacker-controlled. These tests pin the two
+ * properties that keep that from becoming SSRF: the send site refuses to issue
+ * the request at all for internal targets, and when it does send, it does not
+ * follow redirects (which would otherwise let a public host bounce the server
+ * to an internal address after validation passed).
+ */
+
+describe("StatusPageSubscriberWebhookUtil.sendWebhookNotification", () => {
+  let postSpy: jest.SpiedFunction<typeof API.post>;
+
+  const payload: StatusPageWebhookPayload = {
+    eventType: "IncidentCreated",
+    statusPageId: "status-page-id",
+    statusPageName: "Status Page",
+    statusPageUrl: "https://status.example.com",
+    unsubscribeUrl: "https://status.example.com/unsubscribe",
+    data: {},
+  };
+
+  beforeEach(() => {
+    jest
+      .spyOn(dns.promises, "lookup")
+      .mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
+
+    postSpy = jest
+      .spyOn(API, "post")
+      .mockResolvedValue(
+        new HTTPResponse<JSONObject>(200, {}, {}) as never,
+      ) as unknown as jest.SpiedFunction<typeof API.post>;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("does not send to the cloud metadata endpoint", async () => {
+    const result: HTTPResponse<JSONObject> | HTTPErrorResponse =
+      await StatusPageSubscriberWebhookUtil.sendWebhookNotification({
+        webhookUrl: URL.fromString(
+          "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        ),
+        payload,
+      });
+
+    expect(postSpy).not.toHaveBeenCalled();
+    expect(result).toBeInstanceOf(HTTPErrorResponse);
+  });
+
+  test("does not send to a loopback or private address", async () => {
+    for (const unsafeUrl of [
+      "http://127.0.0.1:9200/",
+      "http://10.0.0.5/internal",
+      "http://localhost/admin",
+    ]) {
+      const result: HTTPResponse<JSONObject> | HTTPErrorResponse =
+        await StatusPageSubscriberWebhookUtil.sendWebhookNotification({
+          webhookUrl: URL.fromString(unsafeUrl),
+          payload,
+        });
+
+      expect(result).toBeInstanceOf(HTTPErrorResponse);
+    }
+
+    expect(postSpy).not.toHaveBeenCalled();
+  });
+
+  test("sends to a public target without following redirects", async () => {
+    await StatusPageSubscriberWebhookUtil.sendWebhookNotification({
+      webhookUrl: URL.fromString("https://hooks.example.com/webhook"),
+      payload,
+    });
+
+    expect(postSpy).toHaveBeenCalledTimes(1);
+
+    const callArg: { options?: { doNotFollowRedirects?: boolean } } = postSpy
+      .mock.calls[0]![0] as {
+      options?: { doNotFollowRedirects?: boolean };
+    };
+    expect(callArg.options?.doNotFollowRedirects).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes the SSRF reported in [GHSA-gf3v-98g2-qffx](https://github.com/OneUptime/oneuptime/security/advisories/GHSA-gf3v-98g2-qffx). I verified the report against the code — it is accurate, not a false positive.

## The reported issue

Status page subscribers can be created without authentication: `Permission.Public` is in the `create` array on both the `StatusPageSubscriber` table (`StatusPageSubscriber.ts:55`) and the `subscriberWebhook` column itself (`:353`). `onBeforeCreate` validated the Slack and Teams URLs but had no validation block for `subscriberWebhook`, and `StatusPageSubscriberWebhook.ts` POSTed straight to whatever was stored. An anonymous user could point it at `http://169.254.169.254/…` and have the server fetch cloud IAM credentials on the next incident.

## A second, easier-to-exploit hole found while fixing it

`isValidMicrosoftTeamsIncomingWebhookUrl` substring-matched the **whole URL string** for `office.com`, which an attacker satisfies from the path or query:

```
http://169.254.169.254/latest/meta-data/iam/security-credentials/?x=office.com   ← passed
```

`microsoftTeamsIncomingWebhookUrl` is also `Permission.Public`-creatable, and `onCreateSuccess` POSTs to it **immediately on subscriber creation**. So this variant needs no Scale-plan feature flag and no waiting for an incident — it is easier to exploit than the reported path. Fixing only `subscriberWebhook` would have left the door open.

## Changes

- **New `Common/Server/Utils/SSRFProtection.ts`.** The advisory suggested importing `validateWebhookTargetIsSafe` from `App/FeatureSet/Notification/Services/WebhookService.ts`, but that is a private function and would invert the `Common` → `App` dependency. Extracted it into `Common` instead; `WebhookService` now calls the shared copy (no behavior change there).
- **Fixed a bypass in the guard itself.** OneUptime's `URL` parser keeps the port glued to the host, so `169.254.169.254:80` missed the IPv4 blocklist and — because it contains a colon — was mistaken for an IP literal, skipping DNS resolution entirely. Hosts are now separated from their port first. This bug was live in the existing `WebhookService` guard too.
- **Validate `subscriberWebhook` in `onBeforeCreate`,** mirroring the Slack/Teams blocks.
- **Validate again at the send site.** This covers rows stored before this fix and the authenticated update path (a `ProjectMember` can write `subscriberWebhook` via CRUD update, and there is no `onBeforeUpdate` hook) — so the send-site check is the only defense there, deliberately.
- **Pin the Teams URL on its host** rather than a substring, rejecting look-alikes (`office.com.attacker.tld`, `evil-office.com`) and plaintext `http`. Slack's validator already anchored correctly and is unchanged.
- **Stop following redirects** on the subscriber, Slack, and Teams webhook sends, so a validated public host cannot `3xx` the server to an internal address after the check passes.

## Testing

57 new tests across 3 suites — the blocklist (RFC-1918, loopback, link-local, CGNAT, IPv6 ULA/link-local, metadata hosts), the port and look-alike bypasses, DNS rebinding, and the refusal to send. All pass, along with 208 existing tests over the Slack/Teams/subscriber code. `tsc --noEmit` is clean for both `Common` and `App`, and ESLint passes on every changed file.

## Notes

- Teams URLs on `office365.com` hosts now validate; the old substring check rejected them even though they are legitimate.
- Separately, `StatusPageAPI.ts` looks a subscriber up by `_id` without checking it belongs to the `statusPageId` in the route, on an unauthenticated-reachable endpoint. That is a different bug (IDOR, not SSRF) and is **not** addressed here — worth its own issue.
