### PR TITLE
fix(security): scope status page subscriber lookup to its status page

### DIFF
--- a/Common/Server/API/StatusPageAPI.ts
+++ b/Common/Server/API/StatusPageAPI.ts
@@ -3853,9 +3853,19 @@ export default class StatusPageAPI extends BaseAPI<
         `Updating existing subscriber with ID: ${subscriberId} for status page with ID: ${objectId}`,
         getLogAttributesFromRequest(req as any),
       );
+      /*
+       * Scope the lookup to the status page in the route. This endpoint only
+       * checks read access on that status page, so without the statusPageId
+       * clause anyone holding a subscriber UUID could pass any status page they
+       * can read and edit a subscriber belonging to a different — possibly
+       * private — status page. A subscriber on another page must be
+       * indistinguishable from one that does not exist, so that the shared
+       * "Subscriber not found" below cannot be used to probe for valid UUIDs.
+       */
       statusPageSubscriber = await StatusPageSubscriberService.findOneBy({
         query: {
           _id: subscriberId.toString(),
+          statusPageId: objectId,
         },
         props: {
           isRoot: true,
@@ -3864,7 +3874,7 @@ export default class StatusPageAPI extends BaseAPI<
 
       if (!statusPageSubscriber) {
         logger.debug(
-          `Subscriber not found with ID: ${subscriberId}`,
+          `Subscriber not found with ID: ${subscriberId} on status page with ID: ${objectId}`,
           getLogAttributesFromRequest(req as any),
         );
         throw new BadDataException("Subscriber not found");

--- a/Common/Tests/Server/API/StatusPageSubscriberOwnership.test.ts
+++ b/Common/Tests/Server/API/StatusPageSubscriberOwnership.test.ts
@@ -1,0 +1,291 @@
+import StatusPage from "../../../Models/DatabaseModels/StatusPage";
+import StatusPageSubscriber from "../../../Models/DatabaseModels/StatusPageSubscriber";
+import StatusPageAPI from "../../../Server/API/StatusPageAPI";
+import StatusPageService from "../../../Server/Services/StatusPageService";
+import StatusPageSubscriberService from "../../../Server/Services/StatusPageSubscriberService";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import { mockRouter } from "./Helpers";
+import {
+  beforeAll,
+  beforeEach,
+  afterEach,
+  describe,
+  expect,
+  it,
+} from "@jest/globals";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEntityArrayResponse: jest.fn(),
+    sendJsonObjectResponse: jest.fn(),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendErrorResponse: jest.fn(),
+    setNoCacheHeaders: jest.fn(),
+  };
+});
+
+const UPDATE_SUBSCRIPTION_ROUTE: string =
+  "/status-page/update-subscription/:statusPageId/:subscriberId";
+const GET_SUBSCRIPTION_ROUTE: string =
+  "/status-page/get-subscription/:statusPageId/:subscriberId";
+
+/*
+ * The subscription endpoints authorize the caller against the status page named
+ * in the URL, but the subscriber is addressed by its own UUID. If the lookup is
+ * not also scoped to that status page, holding a subscriber UUID is enough to
+ * edit a subscriber belonging to any other status page — including a private
+ * one the caller cannot read. These routes are reachable without
+ * authentication (getUserMiddleware attaches a user but does not require one),
+ * so the scope on the query is the whole access control.
+ */
+
+describe("StatusPageAPI subscriber ownership", () => {
+  let victimStatusPageId: ObjectID;
+  let attackerStatusPageId: ObjectID;
+  let subscriberId: ObjectID;
+  let projectId: ObjectID;
+  let victimSubscriber: StatusPageSubscriber;
+  let mockResponse: ExpressResponse;
+  let nextFunction: NextFunction;
+
+  beforeAll(() => {
+    mockRouter.routes.length = 0;
+    new StatusPageAPI();
+  });
+
+  /*
+   * Stands in for the database: only returns the subscriber when the query
+   * actually scopes to the status page that owns it.
+   */
+  const findOneByFake: (findBy: {
+    query: JSONObject;
+  }) => Promise<StatusPageSubscriber | null> = (findBy: {
+    query: JSONObject;
+  }): Promise<StatusPageSubscriber | null> => {
+    const query: JSONObject = findBy.query;
+
+    if (query["_id"]?.toString() !== subscriberId.toString()) {
+      return Promise.resolve(null);
+    }
+
+    if (
+      query["statusPageId"] &&
+      query["statusPageId"].toString() !== victimStatusPageId.toString()
+    ) {
+      return Promise.resolve(null);
+    }
+
+    return Promise.resolve(victimSubscriber);
+  };
+
+  const callUpdateSubscription: (data: {
+    statusPageId: ObjectID;
+  }) => Promise<void> = async (data: {
+    statusPageId: ObjectID;
+  }): Promise<void> => {
+    const request: ExpressRequest = {
+      params: {
+        statusPageId: data.statusPageId.toString(),
+        subscriberId: subscriberId.toString(),
+      },
+      body: {
+        data: {
+          isUnsubscribed: true,
+          isSubscribedToAllResources: true,
+        },
+      },
+      query: {},
+      cookies: {},
+      headers: {},
+      socket: {},
+      ips: [],
+    } as unknown as ExpressRequest;
+
+    await mockRouter
+      .match("put", UPDATE_SUBSCRIPTION_ROUTE)
+      .handlerFunction(request, mockResponse, nextFunction);
+  };
+
+  const callGetSubscription: (data: {
+    statusPageId: ObjectID;
+  }) => Promise<void> = async (data: {
+    statusPageId: ObjectID;
+  }): Promise<void> => {
+    const request: ExpressRequest = {
+      params: {
+        statusPageId: data.statusPageId.toString(),
+        subscriberId: subscriberId.toString(),
+      },
+      body: { data: {} },
+      query: {},
+      cookies: {},
+      headers: {},
+      socket: {},
+      ips: [],
+    } as unknown as ExpressRequest;
+
+    await mockRouter
+      .match("post", GET_SUBSCRIPTION_ROUTE)
+      .handlerFunction(request, mockResponse, nextFunction);
+  };
+
+  const getThrownError: () => unknown = (): unknown => {
+    const calls: Array<Array<unknown>> = (nextFunction as jest.Mock).mock
+      .calls as Array<Array<unknown>>;
+
+    expect(calls.length).toBe(1);
+    return calls[0]![0];
+  };
+
+  const getSubscriberQuery: () => JSONObject = (): JSONObject => {
+    const calls: Array<Array<unknown>> = (
+      StatusPageSubscriberService.findOneBy as unknown as jest.Mock
+    ).mock.calls as Array<Array<unknown>>;
+
+    expect(calls.length).toBe(1);
+    return (calls[0]![0] as { query: JSONObject }).query;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    victimStatusPageId = ObjectID.generate();
+    attackerStatusPageId = ObjectID.generate();
+    subscriberId = ObjectID.generate();
+    projectId = ObjectID.generate();
+
+    victimSubscriber = new StatusPageSubscriber();
+    victimSubscriber.id = subscriberId;
+    victimSubscriber.statusPageId = victimStatusPageId;
+    victimSubscriber.projectId = projectId;
+    victimSubscriber.isUnsubscribed = false;
+
+    // The caller can read whichever status page they name in the URL.
+    jest
+      .spyOn(StatusPageService, "hasReadAccess")
+      .mockResolvedValue({ hasReadAccess: true });
+
+    jest
+      .spyOn(StatusPageService, "findOneBy")
+      .mockImplementation((findBy: any): Promise<StatusPage | null> => {
+        const statusPage: StatusPage = new StatusPage();
+        statusPage.id = new ObjectID(findBy.query["_id"].toString());
+        statusPage.projectId = projectId;
+        statusPage.showSubscriberPageOnStatusPage = true;
+        statusPage.allowSubscribersToChooseResources = true;
+        statusPage.allowSubscribersToChooseEventTypes = true;
+        return Promise.resolve(statusPage);
+      });
+
+    jest
+      .spyOn(StatusPageSubscriberService, "findOneBy")
+      .mockImplementation(findOneByFake as never);
+
+    jest
+      .spyOn(StatusPageSubscriberService, "updateOneById")
+      .mockResolvedValue(undefined as never);
+
+    jest
+      .spyOn(StatusPageSubscriberService, "create")
+      .mockResolvedValue(victimSubscriber as never);
+
+    mockResponse = {
+      cookie: jest.fn(),
+      send: jest.fn(),
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    } as unknown as ExpressResponse;
+    nextFunction = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("update-subscription", () => {
+    it("does not update a subscriber belonging to another status page", async () => {
+      await callUpdateSubscription({ statusPageId: attackerStatusPageId });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+      expect(StatusPageSubscriberService.updateOneById).not.toHaveBeenCalled();
+    });
+
+    it("scopes the subscriber lookup to the status page in the route", async () => {
+      await callUpdateSubscription({ statusPageId: attackerStatusPageId });
+
+      const query: JSONObject = getSubscriberQuery();
+      expect(query["statusPageId"]?.toString()).toBe(
+        attackerStatusPageId.toString(),
+      );
+      expect(query["_id"]?.toString()).toBe(subscriberId.toString());
+    });
+
+    it("reports a foreign subscriber exactly as a missing one, revealing nothing", async () => {
+      await callUpdateSubscription({ statusPageId: attackerStatusPageId });
+      const foreignError: unknown = getThrownError();
+
+      jest.clearAllMocks();
+      nextFunction = jest.fn();
+      subscriberId = ObjectID.generate(); // a UUID that exists nowhere
+      await callUpdateSubscription({ statusPageId: attackerStatusPageId });
+      const missingError: unknown = getThrownError();
+
+      expect((foreignError as BadDataException).message).toBe(
+        (missingError as BadDataException).message,
+      );
+    });
+
+    it("still updates a subscriber through its own status page", async () => {
+      await callUpdateSubscription({ statusPageId: victimStatusPageId });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(StatusPageSubscriberService.updateOneById).toHaveBeenCalledTimes(
+        1,
+      );
+
+      const updateArgs: { id: ObjectID; data: JSONObject } = (
+        StatusPageSubscriberService.updateOneById as unknown as jest.Mock
+      ).mock.calls[0]![0] as { id: ObjectID; data: JSONObject };
+      expect(updateArgs.id.toString()).toBe(subscriberId.toString());
+      expect(updateArgs.data["isUnsubscribed"]).toBe(true);
+    });
+  });
+
+  describe("get-subscription", () => {
+    it("does not read a subscriber belonging to another status page", async () => {
+      await callGetSubscription({ statusPageId: attackerStatusPageId });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+    });
+
+    it("scopes the subscriber lookup to the status page in the route", async () => {
+      await callGetSubscription({ statusPageId: attackerStatusPageId });
+
+      expect(getSubscriberQuery()["statusPageId"]?.toString()).toBe(
+        attackerStatusPageId.toString(),
+      );
+    });
+
+    it("still reads a subscriber through its own status page", async () => {
+      await callGetSubscription({ statusPageId: victimStatusPageId });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Fixes a broken object-level authorization (IDOR) bug in the status page subscription endpoints. This is the follow-up I flagged in #3101 and deliberately kept out of that PR — different bug class, different file.

## The problem

`subscribeToStatusPage` authorizes the caller against the status page named in the URL, then looks the subscriber up by its UUID alone:

```ts
findOneBy({ query: { _id: subscriberId.toString() }, props: { isRoot: true } })
```

Nothing ties that subscriber to the status page that was authorized. The route is registered with `UserMiddleware.getUserMiddleware`, which attaches a user when one is present but does **not** require authentication:

```
PUT /api/status-page/update-subscription/:statusPageId/:subscriberId
```

So anyone holding or guessing a subscriber UUID can pass any status page they can read — their own, or any public one — and edit a subscriber belonging to a different, possibly private, status page. The status page ID in the path is effectively ignored.

## Impact

The update persists `statusPageResources`, `isSubscribedToAllResources`, `statusPageEventTypes`, `isSubscribedToAllEventTypes`, and `isUnsubscribed`. In practice that means silently unsubscribing someone from outage notifications, or rewriting which resources and event types they hear about. It also sidesteps the `allowSubscribersToChooseResources` / `allowSubscribersToChooseEventTypes` restrictions, since those are only enforced on the create path (`!isUpdate`).

Two things that limit the blast radius, for accurate triage:

- `statusPageId` and `projectId` are reassigned in memory but are **not** in the `updateOneById` payload, so a subscriber cannot be migrated to another status page or project. Worth knowing this is only true by omission — adding either field to that payload later would turn this into a cross-tenant write.
- The sibling `get-subscription` handler was **already** scoped correctly, so this was not a data-disclosure bug. My note on #3101 said it allowed reading subscriber details; that part was wrong, and I've corrected it here.

## The fix

Add `statusPageId: objectId` to the lookup. A subscriber on another page now returns the same "Subscriber not found" as one that does not exist, so the error cannot be used to probe for valid subscriber UUIDs.

This does not affect the legitimate flow: unsubscribe links are built from the status page's own URL (`StatusPageSubscriberService.getUnsubscribeLink`) and the frontend reads `statusPageId` from the status page the user is browsing, so the two always match.

## Testing

7 new tests in `Common/Tests/Server/API/StatusPageSubscriberOwnership.test.ts`, driving the real routes through the existing `mockRouter` harness.

I verified they are genuine regression tests rather than tests that merely pass: with the fix reverted, the 3 update-subscription tests fail and the rest still pass. The `get-subscription` tests pass either way by design — that handler was already correct, so they exist to keep it that way.

Also ran all 34 `Tests/Server/API` suites: 604 tests pass. One suite (`DataSourceAPIRoutes`) fails to compile in my local environment for missing `pg`/`mysql2`/`mssql` type packages; I confirmed it fails identically on unmodified master, and that `tsc --noEmit` produces a byte-identical error list with and without my change. ESLint is clean on both changed files.
