### PR TITLE
perf(telemetry): batch trace/log/metric ClickHouse inserts across jobs

### DIFF
--- a/App/FeatureSet/Telemetry/Jobs/TelemetryIngest/ProcessTelemetry.ts
+++ b/App/FeatureSet/Telemetry/Jobs/TelemetryIngest/ProcessTelemetry.ts
@@ -68,6 +68,69 @@ async function resolveOtelBody(
 }
 
 /*
+ * Which telemetry types run their job inside a runWithInsertDedup scope —
+ * and why the high-volume OTLP signals (traces / logs / metrics) do NOT.
+ *
+ * Inside the scope, every fan-in submission captures a deterministic
+ * "<jobId>:<table>:<chunk>" token and TelemetryFanInWriter inserts each
+ * tokened submission INDIVIDUALLY — one ClickHouse statement per submission.
+ * That preserves per-job retry idempotence (a retry re-issues byte-identical
+ * statements that content-hash dedup drops), but it also pins the statement
+ * rate to the job arrival rate: cross-job batching never merges
+ * differently-tokened rows, so at high trace/log/metric volume ClickHouse
+ * saturates on per-statement overhead (gunzip + parse + async-insert
+ * bookkeeping per statement) while the merged-insert machinery sits unused.
+ *
+ * So the high-volume signals — the reason the fan-in writer exists — run
+ * OUTSIDE the scope: their submissions are untokened, and the writer merges
+ * a whole flush window into ONE INSERT per table under a minted per-batch
+ * token (still stable across the writer's own retries, so transient-failure
+ * retries of the SAME batch never double-write).
+ *
+ * The accepted trade: a job that fails AFTER one of its merged inserts was
+ * accepted (multi-table job failing on a later table, stalled-job recovery
+ * after acks) re-processes into a differently-composed batch that content
+ * hashing cannot dedup, so those rows can land twice. Per-job tokens were
+ * never honored for async inserts anyway (ClickHouse #52018 — see the
+ * comment in Common/Server/Services/AnalyticsDatabaseService.ts); what
+ * actually deduped retries was content hashing of solo-statement bodies,
+ * which is precisely the one-statement-per-job pattern that saturates
+ * ClickHouse.
+ *
+ * Profiles / syslog / fluent-logs / Kubernetes-cost stay tokened: their
+ * statement rate is negligible, so their retry idempotence costs nothing
+ * to keep.
+ *
+ * The probe / server-monitor / incoming-request types are excluded
+ * deliberately: their inserts go through shared cross-job buffers
+ * (MonitorLogUtil / monitor metrics), where a flushed batch can mix
+ * rows from several jobs — a retry would then reuse a token for a
+ * differently-composed block and ClickHouse would drop it (tokens
+ * dedup by token, not content), losing other jobs' rows.
+ *
+ * SessionReplay is excluded for a different reason again, and must
+ * stay excluded: TelemetryFanInWriter.dispatchInsert inserts TOKENED
+ * submissions individually, one statement each, so adding replay here
+ * would produce one INSERT per chunk on the fattest table in the
+ * system. Untokened submissions merge into one batch per flush window
+ * instead. Replay gets its idempotency from the chunk table being a
+ * ReplacingMergeTree keyed on (projectId, sessionId, tabId,
+ * chunkIndex) plus LIMIT 1 BY chunkIndex at read time, so a
+ * re-delivered chunk collapses at merge rather than double-writing.
+ */
+const INSERT_DEDUP_TYPES: Array<TelemetryType> = [
+  TelemetryType.Profiles,
+  TelemetryType.Syslog,
+  TelemetryType.FluentLogs,
+  TelemetryType.KubernetesCostIngest,
+];
+
+// Exported for tests.
+export function shouldUseInsertDedup(telemetryType: TelemetryType): boolean {
+  return INSERT_DEDUP_TYPES.includes(telemetryType);
+}
+
+/*
  * Per-pod cap on how many replay jobs may be DECODING AND SCRUBBING at once.
  *
  * What this does deliver: a bound on concurrent gunzip + rrweb-tree walking,
@@ -142,45 +205,13 @@ if (DisableQueueWorkers) {
         job.data as TelemetryIngestJobData;
 
       /*
-       * For the telemetry signal types, every ClickHouse write carries a
-       * deterministic insert_deduplication_token derived from the BullMQ
-       * job id (stable across stalled-job recoveries and attempts-based
-       * retries), so a retry that re-processes the same payload is
-       * deduplicated server-side instead of double-writing rows. The
-       * services route rows through TelemetryFanInWriter, which captures
-       * the token from this ambient scope AT SUBMIT TIME and inserts each
-       * tokened submission individually under it — cross-job batching
-       * never merges differently-tokened rows, precisely so this guarantee
-       * survives. See runWithInsertDedup / nextInsertDedupToken in
-       * Common/Server/Utils/AnalyticsDatabase/InsertDedupContext and the
-       * dispatch logic in TelemetryFanInWriter.
-       *
-       * The probe / server-monitor / incoming-request types are excluded
-       * deliberately: their inserts go through shared cross-job buffers
-       * (MonitorLogUtil / monitor metrics), where a flushed batch can mix
-       * rows from several jobs — a retry would then reuse a token for a
-       * differently-composed block and ClickHouse would drop it (tokens
-       * dedup by token, not content), losing other jobs' rows.
-       *
-       * SessionReplay is excluded for a different reason again, and must
-       * stay excluded: TelemetryFanInWriter.dispatchInsert inserts TOKENED
-       * submissions individually, one statement each, so adding replay here
-       * would produce one INSERT per chunk on the fattest table in the
-       * system. Untokened submissions merge into one batch per flush window
-       * instead. Replay gets its idempotency from the chunk table being a
-       * ReplacingMergeTree keyed on (projectId, sessionId, tabId,
-       * chunkIndex) plus LIMIT 1 BY chunkIndex at read time, so a
-       * re-delivered chunk collapses at merge rather than double-writing.
+       * Whether this job's ClickHouse writes carry deterministic per-job
+       * insert_deduplication_tokens (inserted one statement per submission)
+       * or stay untokened so TelemetryFanInWriter merges them into fat
+       * cross-job INSERTs — see the policy comment on shouldUseInsertDedup
+       * above.
        */
-      const useInsertDedup: boolean = [
-        TelemetryType.Logs,
-        TelemetryType.Traces,
-        TelemetryType.Metrics,
-        TelemetryType.Profiles,
-        TelemetryType.Syslog,
-        TelemetryType.FluentLogs,
-        TelemetryType.KubernetesCostIngest,
-      ].includes(jobData.type);
+      const useInsertDedup: boolean = shouldUseInsertDedup(jobData.type);
 
       const dedupTokenBase: string = String(
         job.id ?? jobData.bodyKey ?? job.name,

--- a/App/Tests/Telemetry/ProcessTelemetryBatchedInserts.test.ts
+++ b/App/Tests/Telemetry/ProcessTelemetryBatchedInserts.test.ts
@@ -1,0 +1,493 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "@jest/globals";
+
+/*
+ * End-to-end proof of the batched-inserts architecture at the WORKER
+ * HANDLER level: BullMQ job -> ProcessTelemetry handler -> REAL
+ * OtelTracesIngestService / OtelLogsIngestService -> REAL shared
+ * TelemetryFanInWriter -> mocked ClickHouse insertJsonRows.
+ *
+ * What this covers that the sibling suites do not:
+ * - ProcessTelemetryInsertDedup.test.ts proves the handler opens no dedup
+ *   scope for high-volume signals, with the services mocked out.
+ * - TelemetryFanInIngest.test.ts proves the services merge submissions,
+ *   calling the services directly.
+ * - THIS suite proves the end-to-end claim of the change: N telemetry jobs
+ *   processed by the actual worker handler produce ONE ClickHouse INSERT
+ *   statement per table, all rows present, under a single minted per-batch
+ *   token — plus the failure semantics jobs rely on for retry safety
+ *   (merged-statement failure rejects every job in the batch and leaves
+ *   every staged body in Redis for the BullMQ retry to re-read).
+ *
+ * Job bodies are delivered through the mocked OtelPayloadDecoder keyed by
+ * bodyKey — the same seam the real worker uses to fetch the staged OTLP
+ * payload from Redis.
+ */
+
+let capturedHandler: ((job: unknown) => Promise<void>) | null = null;
+
+jest.mock("Common/Server/Infrastructure/QueueWorker", () => {
+  return {
+    __esModule: true,
+    default: {
+      getWorker: (
+        _name: unknown,
+        handler: (job: unknown) => Promise<void>,
+      ): void => {
+        capturedHandler = handler;
+      },
+    },
+  };
+});
+
+const deleteBody: jest.Mock = jest.fn();
+jest.mock("../../FeatureSet/Telemetry/Utils/TelemetryBodyStore", () => {
+  return {
+    __esModule: true,
+    default: { deleteBody, readBody: jest.fn(), storeBody: jest.fn() },
+  };
+});
+
+/*
+ * Bodies for decodeFromQueue, keyed by the job's bodyKey. Populated per
+ * test; the decode spy (see setupIngestMocks) is the same seam the real
+ * worker uses to pull the staged gzip/protobuf payload out of Redis and
+ * decode it. NOT a module mock: the default export is a class whose OTHER
+ * statics (e.g. getEntityRefsFromResource) the real trace service needs,
+ * and spreading a class drops its non-enumerable static methods.
+ */
+const bodiesByKey: Record<string, unknown> = {};
+
+jest.mock(
+  "isolated-vm",
+  () => {
+    const Isolate: jest.Mock = jest.fn();
+    const Reference: jest.Mock = jest.fn();
+    const Callback: jest.Mock = jest.fn();
+    const ExternalCopy: jest.Mock = jest
+      .fn()
+      .mockImplementation((value: unknown) => {
+        return {
+          copyInto: jest.fn(() => {
+            return value;
+          }),
+        };
+      });
+
+    return {
+      __esModule: true,
+      default: {
+        Isolate,
+        Reference,
+        Callback,
+        ExternalCopy,
+      },
+      Isolate,
+      Reference,
+      Callback,
+      ExternalCopy,
+    };
+  },
+  { virtual: true },
+);
+
+// Importing the module registers the worker via the mocked QueueWorker.
+import "../../FeatureSet/Telemetry/Jobs/TelemetryIngest/ProcessTelemetry";
+import OtelPayloadDecoder from "../../FeatureSet/Telemetry/Utils/OtelPayloadDecoder";
+import OtelTracesIngestService from "../../FeatureSet/Telemetry/Services/OtelTracesIngestService";
+import OtelLogsIngestService from "../../FeatureSet/Telemetry/Services/OtelLogsIngestService";
+import TraceDropFilterService from "../../FeatureSet/Telemetry/Services/TraceDropFilterService";
+import TraceScrubRuleService from "../../FeatureSet/Telemetry/Services/TraceScrubRuleService";
+import TracePipelineService from "../../FeatureSet/Telemetry/Services/TracePipelineService";
+import LogPipelineService from "../../FeatureSet/Telemetry/Services/LogPipelineService";
+import LogDropFilterService from "../../FeatureSet/Telemetry/Services/LogDropFilterService";
+import LogScrubRuleService from "../../FeatureSet/Telemetry/Services/LogScrubRuleService";
+import ExceptionUtil from "../../FeatureSet/Telemetry/Utils/Exception";
+import SpanService from "Common/Server/Services/SpanService";
+import LogService from "Common/Server/Services/LogService";
+import ExceptionInstanceService from "Common/Server/Services/ExceptionInstanceService";
+import TelemetryFanInWriter from "Common/Server/Utils/Telemetry/TelemetryFanInWriter";
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import ServiceType from "Common/Types/Telemetry/ServiceType";
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const SERVICE_ID: ObjectID = ObjectID.generate();
+const SERVICE_NAME: string = "batched-inserts-test-service";
+
+const TRACE_ID_HEX: string = "0af7651916cd43dd8448eb211c80319c";
+const SPAN_ID_HEX: string = "b7ad6b7169203331";
+
+/*
+ * Postgres-touching methods on the ingest services, mocked so the OTLP
+ * walk, row building, and the shared fan-in writer run for real without a
+ * database. Mirrors TelemetryFanInIngest.test.ts.
+ */
+const AUTO_DISCOVERY_METHODS_RETURNING_NULL: Array<string> = [
+  "autoDiscoverKubernetesCluster",
+  "autoDiscoverDockerHost",
+  "autoDiscoverPodmanHost",
+  "autoDiscoverProxmoxCluster",
+  "autoDiscoverCephCluster",
+  "autoDiscoverDockerSwarmCluster",
+  "autoDiscoverHost",
+  "autoDiscoverServerless",
+  "autoDiscoverCloudResource",
+  "autoDiscoverRum",
+];
+
+function setupIngestMocks(): void {
+  jest
+    .spyOn(OtelPayloadDecoder, "decodeFromQueue")
+    .mockImplementation(async (args: { bodyKey: string }): Promise<any> => {
+      return (bodiesByKey[args.bodyKey] ?? {}) as any;
+    });
+
+  for (const ingestService of [
+    OtelTracesIngestService,
+    OtelLogsIngestService,
+  ]) {
+    const service: Record<string, any> = ingestService as unknown as {
+      [key: string]: any;
+    };
+
+    for (const method of AUTO_DISCOVERY_METHODS_RETURNING_NULL) {
+      jest.spyOn(service, method).mockResolvedValue(null);
+    }
+
+    jest.spyOn(service, "resolveTelemetryResource").mockResolvedValue({
+      serviceName: SERVICE_NAME,
+      primaryEntityId: SERVICE_ID,
+      primaryEntityType: ServiceType.OpenTelemetry,
+      dataRententionInDays: 15,
+      serviceRetentionConfig: null,
+      serviceRetentionInDays: null,
+      projectRetentionConfig: null,
+      projectRetentionInDays: 15,
+    });
+  }
+
+  jest
+    .spyOn(TraceDropFilterService, "loadDropFilters")
+    .mockResolvedValue([] as any);
+  jest
+    .spyOn(TraceScrubRuleService, "loadScrubRules")
+    .mockResolvedValue([] as any);
+  jest
+    .spyOn(TracePipelineService, "loadPipelines")
+    .mockResolvedValue([] as any);
+  jest.spyOn(LogPipelineService, "loadPipelines").mockResolvedValue([] as any);
+  jest
+    .spyOn(LogDropFilterService, "loadDropFilters")
+    .mockResolvedValue([] as any);
+  jest
+    .spyOn(LogScrubRuleService, "loadScrubRules")
+    .mockResolvedValue([] as any);
+
+  jest
+    .spyOn(ExceptionUtil, "saveOrUpdateTelemetryExceptionsBatch")
+    .mockResolvedValue(undefined);
+}
+
+function makeSpan(name: string): JSONObject {
+  const nowNano: string = `${Date.now()}000000`;
+  return {
+    traceId: TRACE_ID_HEX,
+    spanId: SPAN_ID_HEX,
+    parentSpanId: "",
+    name: name,
+    kind: 2,
+    startTimeUnixNano: nowNano,
+    endTimeUnixNano: nowNano,
+    status: { code: 1 },
+    attributes: [{ key: "http.method", value: { stringValue: "GET" } }],
+    events: [],
+    links: [],
+  };
+}
+
+function tracesBody(spanNames: Array<string>): JSONObject {
+  return {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: SERVICE_NAME } },
+          ],
+        },
+        scopeSpans: [{ scope: {}, spans: spanNames.map(makeSpan) }],
+      },
+    ],
+  };
+}
+
+function logsBody(logBodies: Array<string>): JSONObject {
+  return {
+    resourceLogs: [
+      {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: SERVICE_NAME } },
+          ],
+        },
+        scopeLogs: [
+          {
+            scope: {},
+            logRecords: logBodies.map((body: string) => {
+              return {
+                timeUnixNano: `${Date.now()}000000`,
+                severityNumber: 9,
+                body: { stringValue: body },
+                attributes: [],
+              };
+            }),
+          },
+        ],
+      },
+    ],
+  };
+}
+
+let jobCounter: number = 0;
+
+function otelJob(data: {
+  type: "traces" | "logs";
+  productType: "Traces" | "Logs";
+  bodyKey: string;
+  body: JSONObject;
+}): unknown {
+  jobCounter++;
+  bodiesByKey[data.bodyKey] = data.body;
+  return {
+    id: `${data.type}-${PROJECT_ID.toString()}-${jobCounter}-x`,
+    name: "ProcessTelemetry",
+    data: {
+      type: data.type,
+      projectId: PROJECT_ID.toString(),
+      bodyKey: data.bodyKey,
+      bodyFormat: "json",
+      bodyEncoding: "none",
+      productType: data.productType,
+      requestHeaders: {},
+    },
+  };
+}
+
+function tracesJob(bodyKey: string, spanNames: Array<string>): unknown {
+  return otelJob({
+    type: "traces",
+    productType: "Traces",
+    bodyKey,
+    body: tracesBody(spanNames),
+  });
+}
+
+function logsJob(bodyKey: string, logBodies: Array<string>): unknown {
+  return otelJob({
+    type: "logs",
+    productType: "Logs",
+    bodyKey,
+    body: logsBody(logBodies),
+  });
+}
+
+function rowsAcrossCalls(spy: jest.SpyInstance): Array<JSONObject> {
+  const rows: Array<JSONObject> = [];
+  for (const call of spy.mock.calls) {
+    for (const row of call[0] as Array<JSONObject>) {
+      rows.push(row);
+    }
+  }
+  return rows;
+}
+
+function retryableClickHouseError(): Error {
+  // Duck-typed retryable code (202 = TOO_MANY_SIMULTANEOUS_QUERIES).
+  return Object.assign(new Error("Too many simultaneous queries."), {
+    code: "202",
+  });
+}
+
+describe("ProcessTelemetry handler — batched ClickHouse inserts end to end", () => {
+  let spanInsertSpy: jest.SpyInstance;
+  let logInsertSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    /*
+     * Real shared writer, tiny time-flush window: all jobs submitted within
+     * ~30ms share one flush, exactly the production path (where the window
+     * is 5s). maxBatchRows stays far above every payload here so flushes
+     * are timer-driven, never size-driven.
+     */
+    TelemetryFanInWriter.configure({
+      maxWaitMs: 30,
+      maxBatchRows: 10_000,
+      retryBaseDelayMs: 1,
+      retryMaxDelayMs: 5,
+    });
+  });
+
+  beforeEach(() => {
+    for (const key of Object.keys(bodiesByKey)) {
+      delete bodiesByKey[key];
+    }
+    deleteBody.mockClear();
+    setupIngestMocks();
+    spanInsertSpy = jest
+      .spyOn(SpanService, "insertJsonRows")
+      .mockResolvedValue(undefined);
+    logInsertSpy = jest
+      .spyOn(LogService, "insertJsonRows")
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(ExceptionInstanceService, "insertJsonRows")
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await TelemetryFanInWriter.flushAll();
+    jest.restoreAllMocks();
+  });
+
+  test("the worker handler was registered/captured", () => {
+    expect(typeof capturedHandler).toBe("function");
+  });
+
+  test("three concurrent trace jobs collapse into ONE INSERT statement carrying all rows under one minted token", async () => {
+    const jobs: Array<unknown> = [
+      tracesJob("telemetry:body:b1", ["j1s1", "j1s2", "j1s3", "j1s4", "j1s5"]),
+      tracesJob("telemetry:body:b2", ["j2s1", "j2s2", "j2s3", "j2s4", "j2s5"]),
+      tracesJob("telemetry:body:b3", ["j3s1", "j3s2", "j3s3", "j3s4", "j3s5"]),
+    ];
+
+    await Promise.all(
+      jobs.map((job: unknown) => {
+        return capturedHandler!(job);
+      }),
+    );
+
+    // The whole point of the change: one statement, not one per job.
+    expect(spanInsertSpy).toHaveBeenCalledTimes(1);
+
+    const rows: Array<JSONObject> = rowsAcrossCalls(spanInsertSpy);
+    expect(rows).toHaveLength(15);
+    const names: Set<unknown> = new Set(
+      rows.map((row: JSONObject) => {
+        return row["name"];
+      }),
+    );
+    for (const job of ["j1", "j2", "j3"]) {
+      for (let i: number = 1; i <= 5; i++) {
+        expect(names).toContain(`${job}s${i}`);
+      }
+    }
+
+    const options: { dedupToken?: string } | undefined = spanInsertSpy.mock
+      .calls[0]![1] as { dedupToken?: string } | undefined;
+    expect(options?.dedupToken).toMatch(/^fanin:SpanItemV3:/);
+
+    // Every job's staged body is reclaimed only after the shared ack.
+    expect(deleteBody).toHaveBeenCalledTimes(3);
+    for (const key of [
+      "telemetry:body:b1",
+      "telemetry:body:b2",
+      "telemetry:body:b3",
+    ]) {
+      expect(deleteBody).toHaveBeenCalledWith(key);
+    }
+  });
+
+  test("traces and logs jobs in the same window produce one statement per table", async () => {
+    const jobs: Array<unknown> = [
+      tracesJob("telemetry:body:t1", ["t1s1", "t1s2"]),
+      tracesJob("telemetry:body:t2", ["t2s1", "t2s2"]),
+      logsJob("telemetry:body:l1", ["log one", "log two"]),
+      logsJob("telemetry:body:l2", ["log three"]),
+    ];
+
+    await Promise.all(
+      jobs.map((job: unknown) => {
+        return capturedHandler!(job);
+      }),
+    );
+
+    expect(spanInsertSpy).toHaveBeenCalledTimes(1);
+    expect(rowsAcrossCalls(spanInsertSpy)).toHaveLength(4);
+
+    expect(logInsertSpy).toHaveBeenCalledTimes(1);
+    expect(rowsAcrossCalls(logInsertSpy)).toHaveLength(3);
+
+    expect(deleteBody).toHaveBeenCalledTimes(4);
+  });
+
+  test("a non-retryable merged-statement failure rejects EVERY job in the batch and leaves every staged body for the BullMQ retry", async () => {
+    spanInsertSpy.mockRejectedValue(
+      new Error("Code: 60. Table does not exist"),
+    );
+
+    const jobs: Array<unknown> = [
+      tracesJob("telemetry:body:f1", ["f1s1"]),
+      tracesJob("telemetry:body:f2", ["f2s1"]),
+      tracesJob("telemetry:body:f3", ["f3s1"]),
+    ];
+
+    const outcomes: Array<PromiseSettledResult<void>> =
+      await Promise.allSettled(
+        jobs.map((job: unknown) => {
+          return capturedHandler!(job) as Promise<void>;
+        }),
+      );
+
+    for (const outcome of outcomes) {
+      expect(outcome.status).toBe("rejected");
+    }
+
+    // Bodies must survive so each retry can re-read its payload.
+    expect(deleteBody).not.toHaveBeenCalled();
+  });
+
+  test("a retryable failure is retried inside the writer with the SAME minted token and stays invisible to the jobs", async () => {
+    spanInsertSpy
+      .mockRejectedValueOnce(retryableClickHouseError())
+      .mockResolvedValue(undefined);
+
+    const jobs: Array<unknown> = [
+      tracesJob("telemetry:body:r1", ["r1s1", "r1s2"]),
+      tracesJob("telemetry:body:r2", ["r2s1"]),
+    ];
+
+    // Jobs resolve despite the first attempt failing.
+    await Promise.all(
+      jobs.map((job: unknown) => {
+        return capturedHandler!(job);
+      }),
+    );
+
+    // Two attempts of the same merged statement: same rows, same token.
+    expect(spanInsertSpy).toHaveBeenCalledTimes(2);
+
+    const firstRows: Array<JSONObject> = spanInsertSpy.mock
+      .calls[0]![0] as Array<JSONObject>;
+    const secondRows: Array<JSONObject> = spanInsertSpy.mock
+      .calls[1]![0] as Array<JSONObject>;
+    expect(secondRows).toEqual(firstRows);
+    expect(firstRows).toHaveLength(3);
+
+    const firstToken: string | undefined = (
+      spanInsertSpy.mock.calls[0]![1] as { dedupToken?: string } | undefined
+    )?.dedupToken;
+    const secondToken: string | undefined = (
+      spanInsertSpy.mock.calls[1]![1] as { dedupToken?: string } | undefined
+    )?.dedupToken;
+    expect(firstToken).toMatch(/^fanin:SpanItemV3:/);
+    expect(secondToken).toBe(firstToken);
+
+    expect(deleteBody).toHaveBeenCalledTimes(2);
+  });
+});

--- a/App/Tests/Telemetry/ProcessTelemetryInsertDedup.test.ts
+++ b/App/Tests/Telemetry/ProcessTelemetryInsertDedup.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, test, beforeEach } from "@jest/globals";
+
+/*
+ * Coverage for the per-job insert-dedup policy on the telemetry worker:
+ *
+ * 1. The shouldUseInsertDedup matrix — high-volume OTLP signals (traces /
+ *    logs / metrics) never open a runWithInsertDedup scope, low-volume
+ *    fan-in types keep per-job tokens, and the buffer-sharing /
+ *    session-replay types never get them.
+ *
+ * 2. The handler wiring: a traces job must run OUTSIDE any dedup scope —
+ *    nextInsertDedupToken() returns undefined inside the ingest service,
+ *    which is what lets TelemetryFanInWriter merge submissions from many
+ *    jobs into one ClickHouse INSERT per table per flush window — while a
+ *    syslog job still observes deterministic "<jobId>:<table>:<chunk>"
+ *    tokens.
+ *
+ * Same harness as ProcessTelemetryBodyLifecycle.test.ts: capture the worker
+ * handler by mocking QueueWorker.getWorker and stub the ingest services; the
+ * insert-dedup AsyncLocalStorage context runs for real.
+ */
+
+let capturedHandler: ((job: unknown) => Promise<void>) | null = null;
+
+jest.mock("Common/Server/Infrastructure/QueueWorker", () => {
+  return {
+    __esModule: true,
+    default: {
+      getWorker: (
+        _name: unknown,
+        handler: (job: unknown) => Promise<void>,
+      ): void => {
+        capturedHandler = handler;
+      },
+    },
+  };
+});
+
+const processTracesFromQueue: jest.Mock = jest.fn();
+jest.mock("../../FeatureSet/Telemetry/Services/OtelTracesIngestService", () => {
+  return {
+    __esModule: true,
+    default: { processTracesFromQueue },
+  };
+});
+
+const processSyslogFromQueue: jest.Mock = jest.fn();
+jest.mock("../../FeatureSet/Telemetry/Services/SyslogIngestService", () => {
+  return {
+    __esModule: true,
+    default: { processSyslogFromQueue },
+  };
+});
+
+const deleteBody: jest.Mock = jest.fn();
+jest.mock("../../FeatureSet/Telemetry/Utils/TelemetryBodyStore", () => {
+  return {
+    __esModule: true,
+    default: { deleteBody, readBody: jest.fn(), storeBody: jest.fn() },
+  };
+});
+
+/*
+ * Keep the real module (its enums are imported elsewhere in the graph) but
+ * stub the decode so no real Redis/protobuf is needed.
+ */
+jest.mock("../../FeatureSet/Telemetry/Utils/OtelPayloadDecoder", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "../../FeatureSet/Telemetry/Utils/OtelPayloadDecoder",
+  );
+  return {
+    __esModule: true,
+    ...actual,
+    default: {
+      ...(actual["default"] as Record<string, unknown>),
+      decodeFromQueue: jest.fn().mockResolvedValue({ resourceSpans: [] }),
+    },
+  };
+});
+
+jest.mock(
+  "isolated-vm",
+  () => {
+    const Isolate: jest.Mock = jest.fn();
+    const Reference: jest.Mock = jest.fn();
+    const Callback: jest.Mock = jest.fn();
+    const ExternalCopy: jest.Mock = jest
+      .fn()
+      .mockImplementation((value: unknown) => {
+        return {
+          copyInto: jest.fn(() => {
+            return value;
+          }),
+        };
+      });
+
+    return {
+      __esModule: true,
+      default: {
+        Isolate,
+        Reference,
+        Callback,
+        ExternalCopy,
+      },
+      Isolate,
+      Reference,
+      Callback,
+      ExternalCopy,
+    };
+  },
+  { virtual: true },
+);
+
+// Importing the module registers the worker via the mocked QueueWorker.
+import { shouldUseInsertDedup } from "../../FeatureSet/Telemetry/Jobs/TelemetryIngest/ProcessTelemetry";
+import { TelemetryType } from "../../FeatureSet/Telemetry/Services/Queue/TelemetryQueueService";
+import { nextInsertDedupToken } from "Common/Server/Services/AnalyticsDatabaseService";
+
+const PROJECT_ID: string = "11111111-1111-1111-1111-111111111111";
+const TRACES_JOB_ID: string = `traces-${PROJECT_ID}-1-abc`;
+const SYSLOG_JOB_ID: string = `syslog-${PROJECT_ID}-2-def`;
+
+function tracesJob(): unknown {
+  return {
+    id: TRACES_JOB_ID,
+    name: "ProcessTelemetry",
+    data: {
+      type: "traces",
+      projectId: PROJECT_ID,
+      bodyKey: "telemetry:body:k1",
+      bodyFormat: "json",
+      bodyEncoding: "none",
+      productType: "Traces",
+      requestHeaders: {},
+    },
+  };
+}
+
+function syslogJob(): unknown {
+  return {
+    id: SYSLOG_JOB_ID,
+    name: "ProcessTelemetry",
+    data: {
+      type: "syslog",
+      projectId: PROJECT_ID,
+      requestBody: { message: "hello" },
+      requestHeaders: {},
+    },
+  };
+}
+
+describe("shouldUseInsertDedup — per-type policy matrix", () => {
+  const HIGH_VOLUME: Array<TelemetryType> = [
+    TelemetryType.Traces,
+    TelemetryType.Logs,
+    TelemetryType.Metrics,
+  ];
+
+  const ALWAYS_ON: Array<TelemetryType> = [
+    TelemetryType.Profiles,
+    TelemetryType.Syslog,
+    TelemetryType.FluentLogs,
+    TelemetryType.KubernetesCostIngest,
+  ];
+
+  const NEVER_ON: Array<TelemetryType> = [
+    TelemetryType.ProbeIngest,
+    TelemetryType.ServerMonitorIngest,
+    TelemetryType.IncomingRequestIngest,
+    TelemetryType.TelemetryMonitorEvaluation,
+    TelemetryType.SessionReplay,
+  ];
+
+  test("high-volume traces/logs/metrics never get per-job tokens, so their inserts merge across jobs", () => {
+    for (const type of HIGH_VOLUME) {
+      expect(shouldUseInsertDedup(type)).toBe(false);
+    }
+  });
+
+  test("low-volume fan-in types keep per-job tokens", () => {
+    for (const type of ALWAYS_ON) {
+      expect(shouldUseInsertDedup(type)).toBe(true);
+    }
+  });
+
+  test("buffer-sharing and session-replay types never get per-job tokens", () => {
+    for (const type of NEVER_ON) {
+      expect(shouldUseInsertDedup(type)).toBe(false);
+    }
+  });
+});
+
+describe("ProcessTelemetry handler — dedup scope wiring", () => {
+  beforeEach(() => {
+    processTracesFromQueue.mockReset();
+    processSyslogFromQueue.mockReset();
+    deleteBody.mockClear();
+  });
+
+  test("the worker handler was registered/captured", () => {
+    expect(typeof capturedHandler).toBe("function");
+  });
+
+  test("a traces job runs OUTSIDE any insert-dedup scope, so fan-in submissions stay untokened and merge across jobs", async () => {
+    let observedToken: string | undefined = "sentinel-not-called";
+
+    processTracesFromQueue.mockImplementationOnce(async (): Promise<void> => {
+      observedToken = nextInsertDedupToken("SpanItemV3");
+    });
+
+    await capturedHandler!(tracesJob());
+
+    expect(processTracesFromQueue).toHaveBeenCalledTimes(1);
+    expect(observedToken).toBeUndefined();
+  });
+
+  test("a syslog job still runs INSIDE a dedup scope with deterministic per-job tokens", async () => {
+    let observedToken: string | undefined = undefined;
+
+    processSyslogFromQueue.mockImplementationOnce(async (): Promise<void> => {
+      observedToken = nextInsertDedupToken("LogItemV3");
+    });
+
+    await capturedHandler!(syslogJob());
+
+    expect(processSyslogFromQueue).toHaveBeenCalledTimes(1);
+    expect(observedToken).toBe(`${SYSLOG_JOB_ID}:LogItemV3:0`);
+  });
+});

--- a/Common/Server/Services/AnalyticsDatabaseService.ts
+++ b/Common/Server/Services/AnalyticsDatabaseService.ts
@@ -175,10 +175,14 @@ export const MigrationExecuteOptions: ClickhouseExecuteOptions = {
  * TelemetryFanInWriter can consume deterministic tokens without an import
  * cycle. Re-exported here for existing callers.
  *
- * HTTP-path inserts run outside the context and are always fire-and-forget
- * (wait_for_async_insert=0) — flush waiting, when opted into via
- * TELEMETRY_WAIT_FOR_ASYNC_INSERT, is only affordable off the request
- * thread and therefore only applies to tokened (queue-job) inserts.
+ * The ack mode is independent of tokening: TELEMETRY_WAIT_FOR_ASYNC_INSERT
+ * (shouldWaitForAsyncInsert below) is applied to EVERY insertJsonRows call,
+ * with or without a dedup token. Whether a telemetry queue job's writes
+ * carry per-job tokens from this context is a separate policy decided in
+ * the worker: the high-volume signals (traces/logs/metrics) run untokened
+ * so the fan-in writer can merge them into cross-job INSERTs under minted
+ * per-batch tokens — see shouldUseInsertDedup in
+ * App/FeatureSet/Telemetry/Jobs/TelemetryIngest/ProcessTelemetry.ts.
  */
 export {
   runWithInsertDedup,

--- a/Common/Server/Utils/AnalyticsDatabase/InsertDedupContext.ts
+++ b/Common/Server/Utils/AnalyticsDatabase/InsertDedupContext.ts
@@ -2,8 +2,13 @@ import { AsyncLocalStorage } from "async_hooks";
 
 /**
  * Ambient context that makes ClickHouse inserts idempotent across queue
- * retries. The telemetry queue worker wraps each job in
- * `runWithInsertDedup(jobId, ...)`; token consumers then derive
+ * retries. The telemetry queue worker wraps ELIGIBLE jobs in
+ * `runWithInsertDedup(jobId, ...)` — the low-volume fan-in types only; the
+ * high-volume OTLP signals (traces/logs/metrics) deliberately run outside
+ * the scope so the fan-in writer can merge their submissions into cross-job
+ * INSERTs; see shouldUseInsertDedup in
+ * App/FeatureSet/Telemetry/Jobs/TelemetryIngest/ProcessTelemetry.ts. Token
+ * consumers then derive
  * `insert_deduplication_token = "<tokenBase>:<table>:<chunkIndex>"`, so a
  * stalled-job recovery or attempts-based retry that re-processes the same
  * payload re-issues byte-identical tokens and ClickHouse drops the duplicate

--- a/Common/Tests/Server/Utils/Telemetry/TelemetryFanInWriter.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/TelemetryFanInWriter.test.ts
@@ -828,6 +828,96 @@ describe("TelemetryFanInWriter", () => {
       expect(target.insertJsonRows).toHaveBeenCalledTimes(1);
       expect(callOptions(target, 0).clickhouseSettings).toBe(settingsFirst);
     });
+
+    /*
+     * The production shape after the batched-inserts change: one table can
+     * receive tokened submissions (low-volume signals like syslog, still
+     * inside runWithInsertDedup) and untokened ones (traces/logs/metrics)
+     * in the same flush window. Tokened submissions must keep per-job
+     * statement granularity; the untokened remainder must collapse into
+     * one minted-token statement.
+     */
+    test("mixed tokened/untokened batch: tokened submissions insert individually under their tokens, the untokened remainder merges under one minted token", async () => {
+      const target: TestTarget = makeTarget();
+      const writer: TelemetryFanInWriter = new TelemetryFanInWriter(
+        makeOptions({ maxBatchRows: 6, maxWaitMs: 60_000 }),
+      );
+
+      const tokenedFirst: FanInSubmitResult = await runWithInsertDedup(
+        "job-a",
+        () => {
+          return writer.submit(target, makeRows(2));
+        },
+      );
+      const untokened: FanInSubmitResult = await writer.submit(
+        target,
+        makeRows(2, 2),
+      );
+      // Reaching maxBatchRows (6) cuts and dispatches the batch.
+      const tokenedSecond: FanInSubmitResult = await runWithInsertDedup(
+        "job-b",
+        () => {
+          return writer.submit(target, makeRows(2, 4));
+        },
+      );
+
+      await Promise.all([
+        tokenedFirst.flushed,
+        untokened.flushed,
+        tokenedSecond.flushed,
+      ]);
+
+      /*
+       * Three statements: each tokened submission alone under its
+       * deterministic per-job token (in batch order), then the untokened
+       * remainder merged under a minted fanin: token.
+       */
+      expect(target.insertJsonRows).toHaveBeenCalledTimes(3);
+
+      expect(callOptions(target, 0).dedupToken).toBe("job-a:TestTable:0");
+      expect(rowSeqs(callRows(target, 0))).toEqual([0, 1]);
+
+      expect(callOptions(target, 1).dedupToken).toBe("job-b:TestTable:0");
+      expect(rowSeqs(callRows(target, 1))).toEqual([4, 5]);
+
+      expect(callOptions(target, 2).dedupToken).toMatch(/^fanin:TestTable:/);
+      expect(rowSeqs(callRows(target, 2))).toEqual([2, 3]);
+    });
+
+    test("mixed batch failure isolation: the merged untokened statement failing rejects only the untokened submissions; tokened ones in the same batch still succeed", async () => {
+      const target: TestTarget = makeTarget({
+        impl: async (
+          _rows: Array<JSONObject>,
+          options?: InsertRowsOptions,
+        ): Promise<void> => {
+          if (options?.dedupToken?.startsWith("fanin:")) {
+            // Non-retryable: plain error with no recognized code/message.
+            throw new Error("merged statement rejected");
+          }
+        },
+      });
+      const writer: TelemetryFanInWriter = new TelemetryFanInWriter(
+        makeOptions({ maxBatchRows: 4, maxWaitMs: 60_000 }),
+      );
+
+      const tokened: FanInSubmitResult = await runWithInsertDedup(
+        "job-a",
+        () => {
+          return writer.submit(target, makeRows(2));
+        },
+      );
+      const untokened: FanInSubmitResult = await writer.submit(
+        target,
+        makeRows(2, 2),
+      );
+
+      // The tokened submission's ack resolves even though its batch-mate failed.
+      await tokened.flushed;
+
+      const err: Error = await captureRejection(untokened.flushed);
+      expect(err).toBeInstanceOf(FanInInsertError);
+      expect(err.message).toContain("merged statement rejected");
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

On the test cluster, telemetry workers issue **one ClickHouse INSERT per queue job** (one ~512-span OTLP export each). Measured live: ~800–1,150 individual INSERT statements/s with ClickHouse burning **~34 cores** on per-statement overhead (gunzip + JSONEachRow parse + async-insert bookkeeping) — the end-of-pipe drain-rate ceiling that keeps 200 worker pods from ever draining the Telemetry queue. This is the P1 fix from the worker-efficiency audit.

Root cause: trace/log/metric jobs run inside `runWithInsertDedup`, so every fan-in submission carries a per-job `insert_deduplication_token`, and `TelemetryFanInWriter.dispatchInsert` deliberately inserts tokened submissions **individually** — the cross-job merging the fan-in writer was built for never engages for exactly the signals that need it.

## Change

- **Traces/logs/metrics jobs now run outside the dedup scope** (`shouldUseInsertDedup` in `ProcessTelemetry.ts`). Their submissions are untokened, so the existing writer path merges a whole flush window (default 5s / 100k rows) into **one INSERT per table** under a minted per-batch token that stays stable across the writer's own retries. Expected: **20–50× fewer statements** at current volumes; ClickHouse CPU drops accordingly.
- **Low-volume fan-in types keep per-job tokens** (profiles, syslog, fluent logs, Kubernetes cost) — their statement rate is negligible, so their retry idempotence is kept for free. Probe / server-monitor / incoming-request / session-replay behavior is unchanged.
- Updated the now-stale comments in `AnalyticsDatabaseService.ts` and `InsertDedupContext.ts` that tied ack mode / dedup scope to "every queue job".

There is no feature flag: batched inserts are the only architecture.

## Trade-off (deliberate, documented at `shouldUseInsertDedup`)

A job that fails **after** one of its merged inserts was accepted (multi-table job failing on a later table; stalled-job recovery after acks) can double-write those rows on retry — content hashing can't match a differently-composed batch. Two mitigating facts:
- Per-job tokens were **never honored for async inserts anyway** (ClickHouse #52018, per the existing comment in `AnalyticsDatabaseService.ts`); what actually deduped retries was content hashing of solo-statement bodies — precisely the one-statement-per-job pattern that saturates ClickHouse.
- Writer-level retries of the same batch (the common transient-failure case) reuse the same token and body, so they stay dedup-safe.

## Tests

**`ProcessTelemetryBatchedInserts.test.ts`** (new) — drives the **real worker handler** end to end (BullMQ job → `ProcessTelemetry` → real ingest services → real shared fan-in writer → mocked ClickHouse), proving the actual claim of the change:
- three concurrent trace jobs collapse into **one INSERT** carrying all 15 rows under a single minted `fanin:` token, with every staged body reclaimed after the shared ack;
- traces + logs in one window produce **one statement per table**;
- a non-retryable merged-statement failure **rejects every job in the batch** and leaves **every** staged body in Redis for the BullMQ retry;
- a retryable failure is retried in-writer with the **same token and rows**, invisible to the jobs.

**`ProcessTelemetryInsertDedup.test.ts`** (new) — policy matrix over all 12 telemetry types, plus handler wiring: a traces job observes **no** ambient token (submissions merge); a syslog job still observes `<jobId>:<table>:<chunk>`.

**`TelemetryFanInWriter.test.ts`** (extended) — the mixed tokened/untokened batch shape production now produces: tokened submissions keep per-job statement granularity while the untokened remainder merges under one minted token, and a merged-statement failure rejects only the untokened submissions while their tokened batch-mates still ack.

Verification: **475 tests / 34 suites** pass in App telemetry; **75** pass in Common's writer suite; `App` and `Common` compile clean; eslint clean; `helm lint` passes.
