### PR TITLE
feat(analytics): measure self-serve revenue funnel

### DIFF
--- a/App/FeatureSet/Accounts/src/Pages/Register.tsx
+++ b/App/FeatureSet/Accounts/src/Pages/Register.tsx
@@ -3,6 +3,10 @@ import Route from "Common/Types/API/Route";
 import URL from "Common/Types/API/URL";
 import Dictionary from "Common/Types/Dictionary";
 import { JSONObject } from "Common/Types/JSON";
+import {
+  RevenueEventName,
+  RevenueFunnelStage,
+} from "Common/Types/Analytics/RevenueEvent";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import ModelForm, {
   FormType,
@@ -30,7 +34,7 @@ import Navigation from "Common/UI/Utils/Navigation";
 import UserUtil from "Common/UI/Utils/User";
 import Reseller from "Common/Models/DatabaseModels/Reseller";
 import User from "Common/Models/DatabaseModels/User";
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import useAsyncEffect from "use-async-effect";
 import { IsBillingEnabled } from "Common/Server/EnvironmentConfig";
@@ -40,6 +44,9 @@ const RegisterPage: () => JSX.Element = () => {
   const apiUrl: URL = SIGNUP_API_URL;
 
   const [initialValues, setInitialValues] = React.useState<JSONObject>({});
+
+  const hasCapturedSignupStart: React.MutableRefObject<boolean> =
+    useRef<boolean>(false);
 
   const [error, setError] = useState<string>("");
 
@@ -332,6 +339,13 @@ const RegisterPage: () => JSX.Element = () => {
               item: User,
               miscDataProps: JSONObject,
             ): Promise<User> => {
+              if (!hasCapturedSignupStart.current) {
+                UiAnalytics.captureRevenueEvent(
+                  RevenueEventName.SignupStarted,
+                  { funnel_stage: RevenueFunnelStage.Signup },
+                );
+                hasCapturedSignupStart.current = true;
+              }
               if (isCaptchaEnabled) {
                 const captchaToken: string | undefined = (
                   miscDataProps["captchaToken"] as string | undefined
@@ -396,7 +410,10 @@ const RegisterPage: () => JSX.Element = () => {
               if (value && value.email) {
                 UiAnalytics.userAuth(value.email);
                 UiAnalytics.capture("accounts/register");
-                UiAnalytics.capture("sign_up");
+                UiAnalytics.captureRevenueEvent(
+                  RevenueEventName.SignupCompleted,
+                  { funnel_stage: RevenueFunnelStage.Signup },
+                );
               }
 
               LoginUtil.login({

--- a/App/FeatureSet/Dashboard/src/Components/Header/ProjectPicker.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Header/ProjectPicker.tsx
@@ -13,6 +13,11 @@ import Toggle from "Common/UI/Components/Toggle/Toggle";
 import { BILLING_ENABLED, getAllEnvVars } from "Common/UI/Config";
 import { GetReactElementFunction } from "Common/UI/Types/FunctionTypes";
 import LocalStorage from "Common/UI/Utils/LocalStorage";
+import UiAnalytics from "Common/UI/Utils/Analytics";
+import {
+  RevenueEventName,
+  RevenueFunnelStage,
+} from "Common/Types/Analytics/RevenueEvent";
 import GlobalConfigUtil from "Common/UI/Utils/GlobalConfig";
 import User from "Common/UI/Utils/User";
 import Project from "Common/Models/DatabaseModels/Project";
@@ -268,6 +273,16 @@ const DashboardProjectPicker: FunctionComponent<ComponentProps> = (
           submitButtonText="Create Project"
           onSuccess={(project: Project | null) => {
             LocalStorage.removeItem("promoCode");
+            if (project) {
+              UiAnalytics.captureRevenueEvent(
+                RevenueEventName.WorkspaceCreated,
+                {
+                  funnel_stage: RevenueFunnelStage.Activation,
+                  project_id: project.id?.toString() || "",
+                  plan_id: project.paymentProviderPlanId || "",
+                },
+              );
+            }
             if (project && props.onProjectSelected) {
               props.onProjectSelected(project);
             }

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Create.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Create.tsx
@@ -66,6 +66,11 @@ import NetworkDeviceAlertPackUtil from "Common/Types/Monitor/SnmpMonitor/Network
 import Probe from "Common/Models/DatabaseModels/Probe";
 import Project from "Common/Models/DatabaseModels/Project";
 import ProjectUtil from "Common/UI/Utils/Project";
+import UiAnalytics from "Common/UI/Utils/Analytics";
+import {
+  RevenueEventName,
+  RevenueFunnelStage,
+} from "Common/Types/Analytics/RevenueEvent";
 import ProbeUtil from "../../Utils/Probe";
 import MonitorProbeSelectionUtil from "Common/Utils/Monitor/MonitorProbeSelectionUtil";
 
@@ -802,6 +807,16 @@ const MonitorCreate: FunctionComponent<
                 return item;
               }}
               onSuccess={(createdItem: Monitor) => {
+                UiAnalytics.captureRevenueEvent(
+                  RevenueEventName.MonitorCreated,
+                  {
+                    funnel_stage: RevenueFunnelStage.Activation,
+                    project_id:
+                      ProjectUtil.getCurrentProjectId()?.toString() || "",
+                    monitor_id: createdItem.id?.toString() || "",
+                    monitor_type: createdItem.monitorType || "",
+                  },
+                );
                 Navigation.navigate(
                   RouteUtil.populateRouteParams(
                     RouteUtil.populateRouteParams(

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/Billing.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/Billing.tsx
@@ -47,6 +47,10 @@ import {
 import { GetReactElementFunction } from "Common/UI/Types/FunctionTypes";
 import BaseAPI from "Common/UI/Utils/API/API";
 import UiAnalytics from "Common/UI/Utils/Analytics";
+import {
+  RevenueEventName,
+  RevenueFunnelStage,
+} from "Common/Types/Analytics/RevenueEvent";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import Navigation from "Common/UI/Utils/Navigation";
 import BillingPaymentMethod from "Common/Models/DatabaseModels/BillingPaymentMethod";
@@ -300,24 +304,32 @@ const Settings: FunctionComponent<ComponentProps> = (
           newPlanOrder > oldPlanOrder
         ) {
           // GA4/Google Ads friendly conversion event.
-          UiAnalytics.capture("subscription_upgraded", {
-            plan: newPlan?.getName() || "",
-            ...(newMonthlyAmountInUSD !== null
-              ? {
-                  value: newMonthlyAmountInUSD * seats,
-                  currency: "USD",
-                }
-              : {}),
-            is_paid_conversion: oldMonthlyAmountInUSD === 0 && newPlanIsPaid,
-          });
+          UiAnalytics.captureRevenueEvent(
+            RevenueEventName.SubscriptionUpgraded,
+            {
+              funnel_stage: RevenueFunnelStage.Revenue,
+              plan: newPlan?.getName() || "",
+              ...(newMonthlyAmountInUSD !== null
+                ? {
+                    value: newMonthlyAmountInUSD * seats,
+                    currency: "USD",
+                  }
+                : {}),
+              is_paid_conversion: oldMonthlyAmountInUSD === 0 && newPlanIsPaid,
+            },
+          );
         } else if (
           oldPlanOrder !== null &&
           newPlanOrder !== null &&
           newPlanOrder < oldPlanOrder
         ) {
-          UiAnalytics.capture("subscription_downgraded", {
-            plan: newPlan?.getName() || "",
-          });
+          UiAnalytics.captureRevenueEvent(
+            RevenueEventName.SubscriptionDowngraded,
+            {
+              funnel_stage: RevenueFunnelStage.Revenue,
+              plan: newPlan?.getName() || "",
+            },
+          );
         }
 
         setCurrentPlanId(newPlanId);

--- a/App/FeatureSet/Dashboard/src/Pages/Users/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Users/Index.tsx
@@ -46,6 +46,11 @@ import Search from "Common/Types/BaseDatabase/Search";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import Query from "Common/Types/BaseDatabase/Query";
 import ObjectID from "Common/Types/ObjectID";
+import UiAnalytics from "Common/UI/Utils/Analytics";
+import {
+  RevenueEventName,
+  RevenueFunnelStage,
+} from "Common/Types/Analytics/RevenueEvent";
 
 const Users: FunctionComponent<PageComponentProps> = (
   props: PageComponentProps,
@@ -398,6 +403,14 @@ const Users: FunctionComponent<PageComponentProps> = (
           submitButtonText="Invite"
           onSuccess={(teamMember: TeamMember | null) => {
             if (teamMember) {
+              UiAnalytics.captureRevenueEvent(
+                RevenueEventName.TeammateInvited,
+                {
+                  funnel_stage: RevenueFunnelStage.Collaboration,
+                  project_id:
+                    ProjectUtil.getCurrentProjectId()?.toString() || "",
+                },
+              );
               const userId: string =
                 teamMember.user?.id?.toString() ||
                 teamMember.userId?.toString() ||

--- a/Common/Tests/Utils/Analytics.test.ts
+++ b/Common/Tests/Utils/Analytics.test.ts
@@ -3,6 +3,11 @@ import { JSONObject } from "../../Types/JSON";
 import Analytics from "../../Utils/Analytics";
 import { describe, expect, it } from "@jest/globals";
 import posthog from "posthog-js";
+import {
+  REVENUE_EVENT_SCHEMA_VERSION,
+  RevenueEventName,
+  RevenueFunnelStage,
+} from "../../Types/Analytics/RevenueEvent";
 
 jest.mock("posthog-js", () => {
   return {
@@ -75,6 +80,24 @@ describe("Analytics Class", () => {
 
     analytics.capture(eventName, data);
     expect(posthog.capture).toHaveBeenCalledWith(eventName, data);
+  });
+
+  it("should capture a versioned revenue event", () => {
+    const analytics: Analytics = new Analytics(apiHost, apiKey);
+
+    analytics.captureRevenueEvent(RevenueEventName.WorkspaceCreated, {
+      funnel_stage: RevenueFunnelStage.Activation,
+      project_id: "project-123",
+    });
+
+    expect(posthog.capture).toHaveBeenCalledWith(
+      RevenueEventName.WorkspaceCreated,
+      {
+        funnel_stage: RevenueFunnelStage.Activation,
+        project_id: "project-123",
+        event_schema_version: REVENUE_EVENT_SCHEMA_VERSION,
+      },
+    );
   });
 
   it("should not capture an event if not initialized", () => {

--- a/Common/Types/Analytics/RevenueEvent.ts
+++ b/Common/Types/Analytics/RevenueEvent.ts
@@ -1,0 +1,31 @@
+import { JSONObject } from "../JSON";
+
+/**
+ * Stable, versioned events used to measure the self-serve revenue funnel.
+ *
+ * Event names are intentionally GA4-compatible snake_case. Additive property
+ * changes are safe; breaking semantic changes require a new schema version.
+ */
+export enum RevenueEventName {
+  SignupStarted = "signup_started",
+  SignupCompleted = "sign_up",
+  WorkspaceCreated = "workspace_created",
+  MonitorCreated = "monitor_created",
+  TeammateInvited = "teammate_invited",
+  SubscriptionUpgraded = "subscription_upgraded",
+  SubscriptionDowngraded = "subscription_downgraded",
+}
+
+export enum RevenueFunnelStage {
+  Acquisition = "acquisition",
+  Signup = "signup",
+  Activation = "activation",
+  Collaboration = "collaboration",
+  Revenue = "revenue",
+}
+
+export interface RevenueEventProperties extends JSONObject {
+  funnel_stage: RevenueFunnelStage;
+}
+
+export const REVENUE_EVENT_SCHEMA_VERSION: number = 1;

--- a/Common/Utils/Analytics.ts
+++ b/Common/Utils/Analytics.ts
@@ -1,6 +1,11 @@
 import Email from "../Types/Email";
 import { JSONObject } from "../Types/JSON";
 import posthog from "posthog-js";
+import {
+  REVENUE_EVENT_SCHEMA_VERSION,
+  RevenueEventName,
+  RevenueEventProperties,
+} from "../Types/Analytics/RevenueEvent";
 
 export default class Analytics {
   private _isInitialized: boolean = false;
@@ -30,6 +35,16 @@ export default class Analytics {
       return;
     }
     posthog.reset();
+  }
+
+  public captureRevenueEvent(
+    eventName: RevenueEventName,
+    data: RevenueEventProperties,
+  ): void {
+    this.capture(eventName, {
+      ...data,
+      event_schema_version: REVENUE_EVENT_SCHEMA_VERSION,
+    });
   }
 
   public capture(eventName: string, data?: JSONObject): void {

--- a/docs/analytics/revenue-funnel.md
+++ b/docs/analytics/revenue-funnel.md
@@ -1,0 +1,39 @@
+# Self-serve revenue funnel
+
+OneUptime emits the following stable events to both PostHog and the Google Tag
+Manager `dataLayer`. Event names and properties are defined in
+`Common/Types/Analytics/RevenueEvent.ts` and carry `event_schema_version`.
+
+| Stage         | Event                     | Meaning                                                                         |
+| ------------- | ------------------------- | ------------------------------------------------------------------------------- |
+| Signup        | `signup_started`          | A registration submission is attempted.                                         |
+| Signup        | `sign_up`                 | An account is successfully created.                                             |
+| Activation    | `workspace_created`       | A project/workspace is successfully created.                                    |
+| Activation    | `monitor_created`         | A monitor is successfully created.                                              |
+| Collaboration | `teammate_invited`        | A project invitation is successfully created.                                   |
+| Revenue       | `subscription_upgraded`   | A project moves to a higher plan. `is_paid_conversion` identifies free-to-paid. |
+| Revenue       | `subscription_downgraded` | A project moves to a lower plan.                                                |
+
+## GA4 setup
+
+In Google Tag Manager, create GA4 Event tags for these exact event names and
+forward the event properties. Mark `sign_up`, `workspace_created`,
+`monitor_created`, `teammate_invited`, and `subscription_upgraded` as key events
+as appropriate. Do not rename events in GTM: joins and historical comparisons
+depend on stable names.
+
+Recommended funnel:
+
+`signup_started` → `sign_up` → `workspace_created` → `monitor_created` →
+`teammate_invited` → `subscription_upgraded` (`is_paid_conversion = true`)
+
+Use `project_id` to correlate post-signup product events. Acquisition parameters
+are persisted on the User by registration (`utm*`, click IDs, and first-touch
+attribution); the warehouse/CRM join should use the authenticated user and
+project relationship rather than sending email addresses to GA4.
+
+## Safety
+
+Analytics is best-effort and must never block product workflows. Do not add
+email, name, phone, monitor URL, telemetry payloads, or other customer content
+to event properties.


### PR DESCRIPTION
## Summary
- add a typed, versioned self-serve revenue event contract shared by PostHog and GTM/GA4
- measure signup start/completion, workspace creation, first monitor creation, teammate invitation, and subscription upgrades/downgrades
- attach project, plan, monitor type, conversion value, and funnel-stage context without sending customer PII
- document the GA4/GTM setup and recommended funnel

## Why
We currently cannot connect acquisition to activation and paid conversion reliably. This gives us a stable product-side event spine for the core self-serve revenue journey.

## Validation
- `Common/Tests/Utils/Analytics.test.ts`: 9 tests passed
- focused ESLint passed for all changed TypeScript files
- Common TypeScript check passed
- `git diff --check` passed

## Deployment follow-up
GTM must create/forward tags for the documented exact event names and GA4 should mark the chosen milestones as key events. The code intentionally does not send email/name/phone/customer content to GA4.