### PR TITLE
fix(workers): guard metricViewConfig before dereferencing queryConfigs in telemetry monitor evaluation

### DIFF
--- a/App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts
+++ b/App/FeatureSet/Workers/Jobs/TelemetryMonitor/MonitorTelemetryMonitor.ts
@@ -1157,6 +1157,10 @@ export const monitorMetric: MonitorMetricFunction = async (data: {
     throw new BadDataException("Metric config is missing");
   }
 
+  if (!metricMonitorConfig.metricViewConfig) {
+    throw new BadDataException("Metric monitor metric view config is missing");
+  }
+
   const startAndEndDate: InBetween<Date> =
     RollingTimeUtil.convertToStartAndEndDate(
       metricMonitorConfig.rollingTime || RollingTime.Past1Minute,
@@ -1480,6 +1484,12 @@ const monitorKubernetes: MonitorKubernetesFunction = async (data: {
     throw new BadDataException("Kubernetes monitor config is missing");
   }
 
+  if (!kubernetesMonitorConfig.metricViewConfig) {
+    throw new BadDataException(
+      "Kubernetes monitor metric view config is missing",
+    );
+  }
+
   const startAndEndDate: InBetween<Date> =
     RollingTimeUtil.convertToStartAndEndDate(
       kubernetesMonitorConfig.rollingTime || RollingTime.Past1Minute,
@@ -1799,6 +1809,10 @@ const monitorDocker: MonitorDockerFunction = async (data: {
     throw new BadDataException("Docker monitor config is missing");
   }
 
+  if (!dockerMonitorConfig.metricViewConfig) {
+    throw new BadDataException("Docker monitor metric view config is missing");
+  }
+
   const startAndEndDate: InBetween<Date> =
     RollingTimeUtil.convertToStartAndEndDate(
       dockerMonitorConfig.rollingTime || RollingTime.Past1Minute,
@@ -1979,6 +1993,10 @@ const monitorHost: MonitorHostFunction = async (data: {
 
   if (!hostMonitorConfig) {
     throw new BadDataException("Host monitor config is missing");
+  }
+
+  if (!hostMonitorConfig.metricViewConfig) {
+    throw new BadDataException("Host monitor metric view config is missing");
   }
 
   const startAndEndDate: InBetween<Date> =
@@ -2170,6 +2188,10 @@ const monitorPodman: MonitorPodmanFunction = async (data: {
     throw new BadDataException("Podman monitor config is missing");
   }
 
+  if (!podmanMonitorConfig.metricViewConfig) {
+    throw new BadDataException("Podman monitor metric view config is missing");
+  }
+
   const startAndEndDate: InBetween<Date> =
     RollingTimeUtil.convertToStartAndEndDate(
       podmanMonitorConfig.rollingTime || RollingTime.Past1Minute,
@@ -2350,6 +2372,12 @@ const monitorProxmox: MonitorProxmoxFunction = async (data: {
 
   if (!proxmoxMonitorConfig) {
     throw new BadDataException("Proxmox monitor config is missing");
+  }
+
+  if (!proxmoxMonitorConfig.metricViewConfig) {
+    throw new BadDataException(
+      "Proxmox monitor metric view config is missing",
+    );
   }
 
   const startAndEndDate: InBetween<Date> =
@@ -2648,6 +2676,10 @@ const monitorIoT: MonitorIoTFunction = async (data: {
     throw new BadDataException("IoT monitor config is missing");
   }
 
+  if (!iotMonitorConfig.metricViewConfig) {
+    throw new BadDataException("IoT monitor metric view config is missing");
+  }
+
   const startAndEndDate: InBetween<Date> =
     RollingTimeUtil.convertToStartAndEndDate(
       iotMonitorConfig.rollingTime || RollingTime.Past1Minute,
@@ -2865,6 +2897,12 @@ const monitorDockerSwarm: MonitorDockerSwarmFunction = async (data: {
 
   if (!dockerSwarmMonitorConfig) {
     throw new BadDataException("Docker Swarm monitor config is missing");
+  }
+
+  if (!dockerSwarmMonitorConfig.metricViewConfig) {
+    throw new BadDataException(
+      "Docker Swarm monitor metric view config is missing",
+    );
   }
 
   const startAndEndDate: InBetween<Date> =
@@ -3161,6 +3199,10 @@ const monitorCeph: MonitorCephFunction = async (data: {
 
   if (!cephMonitorConfig) {
     throw new BadDataException("Ceph monitor config is missing");
+  }
+
+  if (!cephMonitorConfig.metricViewConfig) {
+    throw new BadDataException("Ceph monitor metric view config is missing");
   }
 
   const startAndEndDate: InBetween<Date> =


### PR DESCRIPTION
## Summary
- Every monitor-type handler in `MonitorTelemetryMonitor.ts` (Metric, Kubernetes, Docker, Host, Podman, Proxmox, IoT, Docker Swarm, Ceph) null-checks the top-level monitor step config, then immediately dereferences `config.metricViewConfig.queryConfigs` without checking that `metricViewConfig` itself is present.
- A monitor whose step data is missing `metricViewConfig` (e.g. saved mid-flow before a template/form finished populating it) throws an unhandled `TypeError: Cannot read properties of undefined (reading 'queryConfigs')` on every evaluation attempt.
- Because the job throws instead of completing, it gets re-queued indefinitely. In our deployment this kept queue-size-based KEDA autoscaling metrics permanently inflated, driving worker replicas toward the configured max while never actually draining the backlog, since the "backlog" was a job that could never succeed.
- This adds the same missing-config guard already used for the top-level config to `metricViewConfig` in all 9 affected handlers, so a malformed monitor throws a clean `BadDataException` instead of crashing and retrying forever.

## Root cause (observed in production)
We hit this with monitor records shaped like `{ "cephMonitor": { "clusterIdentifier": "..." } }` — no `resourceFilters`, `metricViewConfig`, or `rollingTime` — created via a template/onboarding flow that appears to save the step data before the rest of the form is filled in. Every scheduled evaluation of that monitor crashed identically, and since the worker treats a thrown job as "needs retry," it never stopped retrying. This happened simultaneously across all 9 vulnerable monitor types (each project had one `[Template] X Monitor` per type), producing a sustained, artificial load signal that scaled workers to near their configured ceiling.

## Fix
Minimal, mechanical, no behavior change for well-formed monitors — just fails fast with a clear error instead of throwing a raw `TypeError` for malformed ones.

## Test plan
- [x] `npx tsc --noEmit` on the `App` workspace shows no new errors introduced by this change (pre-existing unrelated errors in the workspace are untouched)
- [ ] Would appreciate maintainer guidance on whether there's an existing unit test suite for `MonitorTelemetryMonitor.ts` this should extend — happy to add a case per handler exercising a monitor step with `metricViewConfig` unset if pointed at the right test file.