### PR TITLE
perf(telemetry): Phase-1 worker-efficiency fixes from the ingest-path audit

### DIFF
--- a/App/API/Metrics.ts
+++ b/App/API/Metrics.ts
@@ -9,8 +9,11 @@ import AppQueueService from "../Services/Queue/AppQueueService";
 const router: ExpressRouter = Express.getRouter();
 
 /**
- * JSON metrics endpoint for KEDA autoscaling
- * Returns combined queue size (worker + workflow + telemetry) as JSON for KEDA metrics-api scaler
+ * JSON metrics endpoint for KEDA autoscaling.
+ * Returns the combined queue BACKLOG (waiting + delayed jobs across
+ * worker + workflow + telemetry + runbook) as JSON for the KEDA
+ * metrics-api scaler. Active jobs are excluded on purpose: they are
+ * capacity being served, not demand — see Queue.getQueueBacklogSize.
  */
 router.get(
   "/metrics/queue-size",
@@ -20,7 +23,7 @@ router.get(
     next: NextFunction,
   ): Promise<void> => {
     try {
-      const queueSize: number = await AppQueueService.getQueueSize();
+      const queueSize: number = await AppQueueService.getQueueBacklogSize();
 
       res.setHeader("Content-Type", "application/json");
       res.status(200).json({

--- a/App/FeatureSet/Telemetry/API/Metrics.ts
+++ b/App/FeatureSet/Telemetry/API/Metrics.ts
@@ -10,8 +10,10 @@ import TelemetryQueueService from "../Services/Queue/TelemetryQueueService";
 const router: ExpressRouter = Express.getRouter();
 
 /**
- * JSON metrics endpoint for KEDA autoscaling
- * Returns queue size as JSON for KEDA metrics-api scaler
+ * JSON metrics endpoint for KEDA autoscaling.
+ * Returns the Telemetry queue BACKLOG (waiting + delayed jobs) as JSON for
+ * the KEDA metrics-api scaler. Active jobs are excluded on purpose: they
+ * are capacity being served, not demand — see Queue.getQueueBacklogSize.
  */
 router.get(
   "/metrics/queue-size",
@@ -22,7 +24,8 @@ router.get(
     next: NextFunction,
   ): Promise<void> => {
     try {
-      const queueSize: number = await TelemetryQueueService.getQueueSize();
+      const queueSize: number =
+        await TelemetryQueueService.getQueueBacklogSize();
 
       res.setHeader("Content-Type", "application/json");
       res.status(200).json({

--- a/App/FeatureSet/Telemetry/Services/MetricPipelineRuleService.ts
+++ b/App/FeatureSet/Telemetry/Services/MetricPipelineRuleService.ts
@@ -26,6 +26,43 @@ const CACHE_TTL_MS: number = 60 * 1000; // 60 seconds
 const ruleCache: Map<string, CacheEntry> = new Map();
 
 /*
+ * Compiled-regex memo for MatchesRegex / DoesNotMatchRegex filters.
+ * applyRules runs per metric ROW, and RegExp construction (plus a warn log
+ * for invalid patterns) per row is exactly the per-record cost the 60s rule
+ * cache exists to avoid. Patterns are compiled once per process; an invalid
+ * pattern is stored as null and warned about once, not per datapoint. The
+ * size cap only guards against a pathological churn of distinct patterns —
+ * normal deployments hold one entry per configured regex rule.
+ */
+const REGEX_MEMO_MAX_ENTRIES: number = 1000;
+const compiledRegexByPattern: Map<string, RegExp | null> = new Map();
+
+function getCompiledRegex(pattern: string, ruleId: string): RegExp | null {
+  let regex: RegExp | null | undefined = compiledRegexByPattern.get(pattern);
+
+  if (regex === undefined) {
+    if (compiledRegexByPattern.size >= REGEX_MEMO_MAX_ENTRIES) {
+      compiledRegexByPattern.clear();
+    }
+
+    try {
+      regex = new RegExp(pattern);
+    } catch (err) {
+      logger.warn(
+        `Invalid regex "${pattern}" (first seen on MetricPipelineRule ${ruleId}; warned once per pattern — every rule using it treats the filter as non-matching): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      regex = null;
+    }
+
+    compiledRegexByPattern.set(pattern, regex);
+  }
+
+  return regex;
+}
+
+/*
  * Treat the metric row's attributes as a loose JSONObject. The ingest pipeline
  * builds rows with `attributes: JSONObject` and `attributeKeys: string[]`.
  */
@@ -114,18 +151,32 @@ export default class MetricPipelineRuleService {
 
     let current: MutableMetricRow | null = row;
 
+    /*
+     * Attribute-key bookkeeping is deferred: rule evaluation only reads the
+     * attributes map itself, never attributeKeys, so mutating rules mark the
+     * row dirty and the sorted key list is rebuilt ONCE after all rules ran
+     * instead of once per mutating rule per row.
+     */
+    const state: { attributeKeysDirty: boolean } = {
+      attributeKeysDirty: false,
+    };
+
     for (const rule of serviceRules) {
-      current = this.applyOne(current!, rule);
+      current = this.applyOne(current!, rule, state);
       if (current === null) {
         return null;
       }
     }
 
     for (const rule of rules.projectRules) {
-      current = this.applyOne(current!, rule);
+      current = this.applyOne(current!, rule, state);
       if (current === null) {
         return null;
       }
+    }
+
+    if (state.attributeKeysDirty && current) {
+      current.attributeKeys = Object.keys(this.getAttributes(current)).sort();
     }
 
     return current;
@@ -134,6 +185,7 @@ export default class MetricPipelineRuleService {
   private static applyOne(
     row: MutableMetricRow,
     rule: MetricPipelineRule,
+    state: { attributeKeysDirty: boolean },
   ): MutableMetricRow | null {
     const matched: boolean = this.matches(row, rule);
 
@@ -184,7 +236,7 @@ export default class MetricPipelineRuleService {
           attrs[to] = attrs[from] as JSONValue;
           delete attrs[from];
           row.attributes = attrs;
-          row.attributeKeys = Object.keys(attrs).sort();
+          state.attributeKeysDirty = true;
         }
         return row;
       }
@@ -197,7 +249,7 @@ export default class MetricPipelineRuleService {
         const attrs: JSONObject = this.getAttributes(row);
         attrs[key] = rule.addAttributeValue ?? "";
         row.attributes = attrs;
-        row.attributeKeys = Object.keys(attrs).sort();
+        state.attributeKeysDirty = true;
         return row;
       }
 
@@ -210,7 +262,7 @@ export default class MetricPipelineRuleService {
         if (Object.prototype.hasOwnProperty.call(attrs, key)) {
           delete attrs[key];
           row.attributes = attrs;
-          row.attributeKeys = Object.keys(attrs).sort();
+          state.attributeKeysDirty = true;
         }
         return row;
       }
@@ -376,21 +428,19 @@ export default class MetricPipelineRuleService {
         return actual.endsWith(expectedValue);
       case MetricPipelineRuleFilterConditionType.MatchesRegex:
       case MetricPipelineRuleFilterConditionType.DoesNotMatchRegex: {
-        try {
-          const re: RegExp = new RegExp(expectedValue);
-          const matched: boolean = re.test(actual);
-          return conditionType ===
-            MetricPipelineRuleFilterConditionType.MatchesRegex
-            ? matched
-            : !matched;
-        } catch (err) {
-          logger.warn(
-            `Invalid regex on MetricPipelineRule ${String(rule._id)}: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-          );
+        const re: RegExp | null = getCompiledRegex(
+          expectedValue,
+          String(rule._id),
+        );
+        if (!re) {
+          // Invalid pattern — warned once when first compiled.
           return false;
         }
+        const matched: boolean = re.test(actual);
+        return conditionType ===
+          MetricPipelineRuleFilterConditionType.MatchesRegex
+          ? matched
+          : !matched;
       }
       default:
         return false;
@@ -407,8 +457,9 @@ export default class MetricPipelineRuleService {
     return fresh;
   }
 
-  // Testing helper — clears the in-memory cache.
+  // Testing helper — clears the in-memory caches.
   public static clearCache(): void {
     ruleCache.clear();
+    compiledRegexByPattern.clear();
   }
 }

--- a/App/FeatureSet/Telemetry/Services/OtelIngestBaseService.ts
+++ b/App/FeatureSet/Telemetry/Services/OtelIngestBaseService.ts
@@ -195,7 +195,6 @@ export default abstract class OtelIngestBaseService {
    * the caller tags those with the projectId under ServiceType.Unknown
    * rather than synthesising a shared "Unknown Service" Service row.
    */
-  @CaptureSpan()
   protected static async getServiceNameFromAttributes(
     req: ExpressRequest,
     attributes: JSONArray,
@@ -649,7 +648,6 @@ export default abstract class OtelIngestBaseService {
     });
   }
 
-  @CaptureSpan()
   private static async getDockerServiceName(
     req: ExpressRequest,
     attributes: JSONArray,
@@ -731,7 +729,6 @@ export default abstract class OtelIngestBaseService {
     return null;
   }
 
-  @CaptureSpan()
   private static async getPodmanServiceName(
     req: ExpressRequest,
     attributes: JSONArray,
@@ -897,7 +894,6 @@ export default abstract class OtelIngestBaseService {
     return match[1];
   }
 
-  @CaptureSpan()
   protected static getClusterNameFromAttributes(
     attributes: JSONArray,
   ): string | null {
@@ -1011,7 +1007,6 @@ export default abstract class OtelIngestBaseService {
    * per-cluster inside `attachLabels` so steady-state ingest with
    * unchanged labels costs one in-memory cache lookup.
    */
-  @CaptureSpan()
   protected static async promoteOneuptimeLabelsToCluster(data: {
     projectId: ObjectID;
     kubernetesClusterId: ObjectID;
@@ -1050,7 +1045,6 @@ export default abstract class OtelIngestBaseService {
    * resource attribute (no upstream semconv exists) stamped by the
    * Proxmox Agent collector config from the PROXMOX_CLUSTER_NAME env.
    */
-  @CaptureSpan()
   protected static getProxmoxClusterNameFromAttributes(
     attributes: JSONArray,
   ): string | null {
@@ -1146,7 +1140,6 @@ export default abstract class OtelIngestBaseService {
    * Throttled per-cluster inside `attachLabels` so steady-state
    * ingest with unchanged labels costs one in-memory cache lookup.
    */
-  @CaptureSpan()
   protected static async promoteOneuptimeLabelsToProxmoxCluster(data: {
     projectId: ObjectID;
     proxmoxClusterId: ObjectID;
@@ -1187,7 +1180,6 @@ export default abstract class OtelIngestBaseService {
    * OTEL_RESOURCE_ATTRIBUTES). Some flattened forms prefix resource
    * attributes with `resource.`, so accept that alias too.
    */
-  @CaptureSpan()
   protected static getIoTFleetNameFromAttributes(
     attributes: JSONArray,
   ): string | null {
@@ -1286,7 +1278,6 @@ export default abstract class OtelIngestBaseService {
    * per-fleet inside `attachLabels` so steady-state ingest with
    * unchanged labels costs one in-memory cache lookup.
    */
-  @CaptureSpan()
   protected static async promoteOneuptimeLabelsToIoTFleet(data: {
     projectId: ObjectID;
     iotFleetId: ObjectID;
@@ -1326,7 +1317,6 @@ export default abstract class OtelIngestBaseService {
    * stamped by the Docker Swarm Agent collector config from the
    * DOCKER_SWARM_CLUSTER_NAME env.
    */
-  @CaptureSpan()
   protected static getDockerSwarmClusterNameFromAttributes(
     attributes: JSONArray,
   ): string | null {
@@ -1424,7 +1414,6 @@ export default abstract class OtelIngestBaseService {
    * project labels and attach them to the discovered Docker Swarm
    * cluster. Mirrors the Proxmox cluster label promotion.
    */
-  @CaptureSpan()
   protected static async promoteOneuptimeLabelsToDockerSwarmCluster(data: {
     projectId: ObjectID;
     dockerSwarmClusterId: ObjectID;
@@ -1463,7 +1452,6 @@ export default abstract class OtelIngestBaseService {
    * resource attribute (no upstream semconv exists) stamped by the
    * Ceph Agent collector config from the CEPH_CLUSTER_NAME env.
    */
-  @CaptureSpan()
   protected static getCephClusterNameFromAttributes(
     attributes: JSONArray,
   ): string | null {
@@ -1566,7 +1554,6 @@ export default abstract class OtelIngestBaseService {
    * per-cluster inside `attachLabels` so steady-state ingest with
    * unchanged labels costs one in-memory cache lookup.
    */
-  @CaptureSpan()
   protected static async promoteOneuptimeLabelsToCephCluster(data: {
     projectId: ObjectID;
     cephClusterId: ObjectID;
@@ -1772,7 +1759,6 @@ export default abstract class OtelIngestBaseService {
     }
   }
 
-  @CaptureSpan()
   protected static async promoteOneuptimeLabelsToServerlessFunction(data: {
     projectId: ObjectID;
     serverlessFunctionId: ObjectID;
@@ -1983,7 +1969,6 @@ export default abstract class OtelIngestBaseService {
     }
   }
 
-  @CaptureSpan()
   protected static async promoteOneuptimeLabelsToCloudResource(data: {
     projectId: ObjectID;
     cloudResourceId: ObjectID;
@@ -2160,7 +2145,6 @@ export default abstract class OtelIngestBaseService {
     }
   }
 
-  @CaptureSpan()
   protected static async promoteOneuptimeLabelsToRumApplication(data: {
     projectId: ObjectID;
     rumApplicationId: ObjectID;
@@ -2194,7 +2178,6 @@ export default abstract class OtelIngestBaseService {
     }
   }
 
-  @CaptureSpan()
   protected static getHostNameFromAttributes(
     attributes: JSONArray,
   ): string | null {
@@ -2277,7 +2260,6 @@ export default abstract class OtelIngestBaseService {
     }
   }
 
-  @CaptureSpan()
   protected static getStringAttribute(
     attributes: JSONArray,
     key: string,
@@ -2306,7 +2288,6 @@ export default abstract class OtelIngestBaseService {
    * Falls back to a single stringValue if the attribute uses that
    * shape (some SDKs flatten single-element arrays to a string).
    */
-  @CaptureSpan()
   protected static getStringArrayAttribute(
     attributes: JSONArray,
     key: string,
@@ -2341,7 +2322,6 @@ export default abstract class OtelIngestBaseService {
     return [];
   }
 
-  @CaptureSpan()
   protected static isDockerRuntime(attributes: JSONArray): boolean {
     for (const attribute of attributes) {
       if (
@@ -2355,7 +2335,6 @@ export default abstract class OtelIngestBaseService {
     return false;
   }
 
-  @CaptureSpan()
   protected static isPodmanRuntime(attributes: JSONArray): boolean {
     for (const attribute of attributes) {
       if (
@@ -2378,7 +2357,6 @@ export default abstract class OtelIngestBaseService {
    * auto-detecting hostname inside a pod don't create phantom
    * per-pod services.
    */
-  @CaptureSpan()
   protected static hasHostResourceSignal(attributes: JSONArray): boolean {
     return Boolean(
       this.getStringAttribute(attributes, "os.type") ||
@@ -2496,7 +2474,6 @@ export default abstract class OtelIngestBaseService {
    * inside `attachLabels` so steady-state ingest with unchanged
    * labels costs one in-memory cache lookup.
    */
-  @CaptureSpan()
   protected static async promoteOneuptimeLabelsToDockerHost(data: {
     projectId: ObjectID;
     dockerHostId: ObjectID;
@@ -2629,7 +2606,6 @@ export default abstract class OtelIngestBaseService {
    * inside `attachLabels` so steady-state ingest with unchanged
    * labels costs one in-memory cache lookup.
    */
-  @CaptureSpan()
   protected static async promoteOneuptimeLabelsToPodmanHost(data: {
     projectId: ObjectID;
     podmanHostId: ObjectID;
@@ -3168,7 +3144,6 @@ export default abstract class OtelIngestBaseService {
     return any ? sum : null;
   }
 
-  @CaptureSpan()
   protected static getServiceNameFromHeaders(
     req: ExpressRequest,
     defaultName: string = "Unknown Service",

--- a/App/FeatureSet/Telemetry/Services/OtelLogsIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/OtelLogsIngestService.ts
@@ -19,6 +19,11 @@ import Dictionary from "Common/Types/Dictionary";
 import ObjectID from "Common/Types/ObjectID";
 import LogSeverity from "Common/Types/Log/LogSeverity";
 import { resolveTelemetryRetentionInDays } from "Common/Types/Telemetry/TelemetryRetentionConfig";
+import {
+  IngestionStamp,
+  getIngestionStamp,
+  getRetentionDateDb,
+} from "Common/Server/Utils/Telemetry/IngestionTimestamp";
 import TelemetryUtil, {
   AttributeType,
 } from "Common/Server/Utils/Telemetry/Telemetry";
@@ -600,9 +605,14 @@ export default class OtelLogsIngestService extends OtelIngestBaseService {
                   const primaryEntityId: ObjectID =
                     serviceDictionary[serviceName]!.primaryEntityId!;
 
-                  let timeUnixNanoNumeric: number =
-                    OneUptimeDate.getCurrentDateAsUnixNano();
-                  let timeDate: Date = OneUptimeDate.getCurrentDate();
+                  /*
+                   * Assigned in every branch below — no eager current-time
+                   * pair here, since records normally carry their own
+                   * timeUnixNano and the fallback is only for records that
+                   * do not.
+                   */
+                  let timeUnixNanoNumeric: number;
+                  let timeDate: Date;
 
                   if (log["timeUnixNano"]) {
                     try {
@@ -892,9 +902,8 @@ export default class OtelLogsIngestService extends OtelIngestBaseService {
 
                   const logFlags: number = (log["flags"] as number) || 0;
 
-                  const ingestionDate: Date = OneUptimeDate.getCurrentDate();
-                  const ingestionTimestamp: string =
-                    OneUptimeDate.toClickhouseDateTime(ingestionDate);
+                  const ingestionStamp: IngestionStamp = getIngestionStamp();
+                  const ingestionTimestamp: string = ingestionStamp.db;
                   const logTimestamp: string =
                     OneUptimeDate.toClickhouseDateTime64(
                       timeDate,
@@ -915,8 +924,8 @@ export default class OtelLogsIngestService extends OtelIngestBaseService {
                         serviceMetadata.projectRetentionInDays,
                     },
                   );
-                  const retentionDate: Date = OneUptimeDate.addRemoveDays(
-                    ingestionDate,
+                  const retentionDateDb: string = getRetentionDateDb(
+                    ingestionStamp,
                     retentionDays,
                   );
 
@@ -948,8 +957,7 @@ export default class OtelLogsIngestService extends OtelIngestBaseService {
                       Math.trunc(observedTimeUnixNano).toString(),
                     droppedAttributesCount: droppedAttributesCount,
                     flags: logFlags,
-                    retentionDate:
-                      OneUptimeDate.toClickhouseDateTime(retentionDate),
+                    retentionDate: retentionDateDb,
                   };
 
                   // Drop filter check (before pipeline processing)
@@ -997,7 +1005,7 @@ export default class OtelLogsIngestService extends OtelIngestBaseService {
                         severityText,
                         timeDate,
                         timeUnixNano: timeUnixNanoNumeric,
-                        retentionDate,
+                        retentionDateDb,
                         dbExceptions,
                         pendingExceptionUpserts,
                       });
@@ -1362,7 +1370,8 @@ export default class OtelLogsIngestService extends OtelIngestBaseService {
     severityText: LogSeverity;
     timeDate: Date;
     timeUnixNano: number;
-    retentionDate: Date;
+    /** Already-formatted ClickHouse DateTime string of the log row's retention date. */
+    retentionDateDb: string;
     dbExceptions: Array<JSONObject>;
     pendingExceptionUpserts: Array<TelemetryExceptionPayload>;
   }): void {
@@ -1406,9 +1415,7 @@ export default class OtelLogsIngestService extends OtelIngestBaseService {
     const environment: string =
       (finalAttributes["resource.deployment.environment"] as string) || "";
 
-    const ingestionTimestamp: string = OneUptimeDate.toClickhouseDateTime(
-      OneUptimeDate.getCurrentDate(),
-    );
+    const ingestionTimestamp: string = getIngestionStamp().db;
     const exceptionAttributes: JSONObject = {
       "exception.source": "log",
       "log.severityText": String(data.severityText),
@@ -1439,7 +1446,7 @@ export default class OtelLogsIngestService extends OtelIngestBaseService {
       parsedFrames: extracted.parsedFrames || "[]",
       attributes: exceptionAttributes,
       attributeKeys: TelemetryUtil.getAttributeKeys(exceptionAttributes),
-      retentionDate: OneUptimeDate.toClickhouseDateTime(data.retentionDate),
+      retentionDate: data.retentionDateDb,
     });
 
     data.pendingExceptionUpserts.push({

--- a/App/FeatureSet/Telemetry/Services/OtelMetricsIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/OtelMetricsIngestService.ts
@@ -40,6 +40,11 @@ import MetricPipelineRuleService, {
 } from "./MetricPipelineRuleService";
 import OneUptimeDate from "Common/Types/Date";
 import { resolveTelemetryRetentionInDays } from "Common/Types/Telemetry/TelemetryRetentionConfig";
+import {
+  IngestionStamp,
+  getIngestionStamp,
+  getRetentionDateDb,
+} from "Common/Server/Utils/Telemetry/IngestionTimestamp";
 import MetricService from "Common/Server/Services/MetricService";
 import Text from "Common/Types/Text";
 import KubernetesResourceService, {
@@ -109,7 +114,6 @@ import TelemetryFanInWriter, {
 
 type MetricTimestamp = {
   nano: string;
-  iso: string;
   db: string;
   date: Date;
 };
@@ -3112,9 +3116,7 @@ export default class OtelMetricsIngestService extends OtelIngestBaseService {
     isMonotonic?: boolean;
     serviceMetadata: TelemetryServiceMetadata;
   }): JSONObject {
-    const ingestionDate: Date = OneUptimeDate.getCurrentDate();
-    const ingestionTimestamp: string =
-      OneUptimeDate.toClickhouseDateTime(ingestionDate);
+    const ingestionStamp: IngestionStamp = getIngestionStamp();
 
     const timeFields: MetricTimestamp = this.safeParseUnixNano(
       data.datapoint["timeUnixNano"] as string | number | undefined,
@@ -3267,14 +3269,10 @@ export default class OtelMetricsIngestService extends OtelIngestBaseService {
       projectConfig: data.serviceMetadata.projectRetentionConfig,
       projectRetentionInDays: data.serviceMetadata.projectRetentionInDays,
     });
-    const retentionDate: Date = OneUptimeDate.addRemoveDays(
-      ingestionDate,
-      retentionDays,
-    );
 
     const row: JSONObject = {
       _id: ObjectID.generateTimeOrdered().toString(),
-      createdAt: ingestionTimestamp,
+      createdAt: ingestionStamp.db,
       projectId: data.projectId.toString(),
       primaryEntityId: data.primaryEntityId.toString(),
       primaryEntityType: data.serviceMetadata.primaryEntityType,
@@ -3315,7 +3313,7 @@ export default class OtelMetricsIngestService extends OtelIngestBaseService {
       summaryValues: summaryValues,
       traceId: exemplarTraceAndSpanIds.traceId,
       spanId: exemplarTraceAndSpanIds.spanId,
-      retentionDate: OneUptimeDate.toClickhouseDateTime(retentionDate),
+      retentionDate: getRetentionDateDb(ingestionStamp, retentionDays),
     };
 
     if (startTimeFields) {
@@ -3409,7 +3407,13 @@ export default class OtelMetricsIngestService extends OtelIngestBaseService {
     value: string | number | undefined,
     context: string,
   ): MetricTimestamp {
-    let numericValue: number = OneUptimeDate.getCurrentDateAsUnixNano();
+    /*
+     * The current-time fallback is derived lazily: this runs per datapoint,
+     * and the common case (a valid timeUnixNano on the datapoint) used to
+     * pay a Date allocation + unix-nano conversion that was immediately
+     * overwritten.
+     */
+    let numericValue: number | null = null;
 
     if (value !== undefined && value !== null) {
       try {
@@ -3429,17 +3433,19 @@ export default class OtelMetricsIngestService extends OtelIngestBaseService {
         logger.warn(
           `Error processing ${context}: ${error instanceof Error ? error.message : String(error)}, using current time`,
         );
-        numericValue = OneUptimeDate.getCurrentDateAsUnixNano();
+        numericValue = null;
       }
     }
 
+    if (numericValue === null) {
+      numericValue = OneUptimeDate.getCurrentDateAsUnixNano();
+    }
+
     const date: Date = OneUptimeDate.fromUnixNano(numericValue);
-    const iso: string = OneUptimeDate.toString(date);
     const db: string = OneUptimeDate.toClickhouseDateTime(date);
 
     return {
       nano: Math.trunc(numericValue).toString(),
-      iso: iso,
       db: db,
       date: date,
     };

--- a/App/FeatureSet/Telemetry/Services/OtelTracesIngestService.ts
+++ b/App/FeatureSet/Telemetry/Services/OtelTracesIngestService.ts
@@ -8,6 +8,11 @@ import EventLoop from "Common/Server/Utils/EventLoop";
 import OtelPayloadDecoder from "../Utils/OtelPayloadDecoder";
 import OneUptimeDate from "Common/Types/Date";
 import { resolveTelemetryRetentionInDays } from "Common/Types/Telemetry/TelemetryRetentionConfig";
+import {
+  IngestionStamp,
+  getIngestionStamp,
+  getRetentionDateDb,
+} from "Common/Server/Utils/Telemetry/IngestionTimestamp";
 import BadRequestException from "Common/Types/Exception/BadRequestException";
 import {
   ExpressRequest,
@@ -1212,9 +1217,7 @@ export default class OtelTracesIngestService extends OtelIngestBaseService {
     llmFields: LlmSpanFields;
     serviceMetadata: TelemetryServiceMetadata;
   }): JSONObject {
-    const ingestionDate: Date = OneUptimeDate.getCurrentDate();
-    const ingestionTimestamp: string =
-      OneUptimeDate.toClickhouseDateTime(ingestionDate);
+    const ingestionStamp: IngestionStamp = getIngestionStamp();
     const retentionDays: number = resolveTelemetryRetentionInDays({
       pillar: "traces",
       bucketKey: data.statusCode,
@@ -1223,13 +1226,9 @@ export default class OtelTracesIngestService extends OtelIngestBaseService {
       projectConfig: data.serviceMetadata.projectRetentionConfig,
       projectRetentionInDays: data.serviceMetadata.projectRetentionInDays,
     });
-    const retentionDate: Date = OneUptimeDate.addRemoveDays(
-      ingestionDate,
-      retentionDays,
-    );
     return {
       _id: ObjectID.generateTimeOrdered().toString(),
-      createdAt: ingestionTimestamp,
+      createdAt: ingestionStamp.db,
       projectId: data.projectId.toString(),
       primaryEntityId: data.primaryEntityId.toString(),
       primaryEntityType: data.serviceMetadata.primaryEntityType,
@@ -1267,14 +1266,12 @@ export default class OtelTracesIngestService extends OtelIngestBaseService {
       llmOutputTokens: data.llmFields.llmOutputTokens,
       llmTotalTokens: data.llmFields.llmTotalTokens,
       llmCost: data.llmFields.llmCost,
-      retentionDate: OneUptimeDate.toClickhouseDateTime(retentionDate),
+      retentionDate: getRetentionDateDb(ingestionStamp, retentionDays),
     };
   }
 
   private static buildExceptionRow(data: ExceptionEventPayload): JSONObject {
-    const ingestionDate: Date = OneUptimeDate.getCurrentDate();
-    const ingestionTimestamp: string =
-      OneUptimeDate.toClickhouseDateTime(ingestionDate);
+    const ingestionStamp: IngestionStamp = getIngestionStamp();
     const retentionDays: number = resolveTelemetryRetentionInDays({
       pillar: "traces",
       bucketKey: data.spanStatusCode,
@@ -1283,15 +1280,11 @@ export default class OtelTracesIngestService extends OtelIngestBaseService {
       projectConfig: data.serviceMetadata.projectRetentionConfig,
       projectRetentionInDays: data.serviceMetadata.projectRetentionInDays,
     });
-    const retentionDate: Date = OneUptimeDate.addRemoveDays(
-      ingestionDate,
-      retentionDays,
-    );
     const attributes: JSONObject = data.attributes || {};
 
     return {
       _id: ObjectID.generateTimeOrdered().toString(),
-      createdAt: ingestionTimestamp,
+      createdAt: ingestionStamp.db,
       projectId: data.projectId.toString(),
       primaryEntityId: data.primaryEntityId.toString(),
       primaryEntityType: data.serviceMetadata.primaryEntityType,
@@ -1317,7 +1310,7 @@ export default class OtelTracesIngestService extends OtelIngestBaseService {
       parsedFrames: data.parsedFrames || "[]",
       attributes: attributes,
       attributeKeys: TelemetryUtil.getAttributeKeys(attributes),
-      retentionDate: OneUptimeDate.toClickhouseDateTime(retentionDate),
+      retentionDate: getRetentionDateDb(ingestionStamp, retentionDays),
     };
   }
 

--- a/App/FeatureSet/Telemetry/Services/Queue/TelemetryQueueService.ts
+++ b/App/FeatureSet/Telemetry/Services/Queue/TelemetryQueueService.ts
@@ -862,6 +862,19 @@ export default class TelemetryQueueService {
     return Queue.getQueueSize(QueueName.Telemetry);
   }
 
+  /*
+   * Telemetry queue BACKLOG (waiting + delayed) for autoscaling signals.
+   * Active jobs are excluded on purpose: telemetry jobs park in the active
+   * state for the fan-in writer's flush window while awaiting their
+   * ClickHouse ack, so counting them makes a scaler read busy-but-healthy
+   * capacity as demand — see Queue.getQueueBacklogSize. getQueueSize above
+   * stays active-inclusive for the ingest backpressure checks, where
+   * in-flight work genuinely counts against capacity.
+   */
+  public static async getQueueBacklogSize(): Promise<number> {
+    return Queue.getQueueBacklogSize(QueueName.Telemetry);
+  }
+
   public static async getQueueStats(): Promise<{
     waiting: number;
     active: number;

--- a/App/FeatureSet/Telemetry/Utils/LogFilterEvaluator.ts
+++ b/App/FeatureSet/Telemetry/Utils/LogFilterEvaluator.ts
@@ -446,13 +446,28 @@ function evaluateExpr(logRow: JSONObject, expr: FilterExpression): boolean {
         case "!=":
           return fieldVal !== comp.value;
         case "LIKE": {
-          const raw: string = String(comp.value);
           /*
-           * The UI labels this operator "contains", so a value without any
-           * `%` wildcard means substring match — not exact match. Only honor
-           * SQL LIKE semantics (`%` -> .*, `_` -> .) when the user explicitly
-           * uses `%` in the pattern.
+           * Use the forms compileExpr attached at filter-load time — this
+           * case runs once per record per rule, and rebuilding the RegExp
+           * (three escape passes + construction) per record is exactly the
+           * cost the two-stage compile design exists to avoid.
            */
+          if (comp.likeSubstring !== undefined) {
+            return fieldVal.toLowerCase().includes(comp.likeSubstring);
+          }
+          if (comp.likeRegex) {
+            return comp.likeRegex.test(fieldVal);
+          }
+
+          /*
+           * Uncompiled AST (the legacy evaluateFilter path, which parses a
+           * raw query string per call): mirror compileExpr's semantics
+           * inline. The UI labels this operator "contains", so a value
+           * without any `%` wildcard means substring match — not exact
+           * match. Only honor SQL LIKE semantics (`%` -> .*, `_` -> .) when
+           * the user explicitly uses `%` in the pattern.
+           */
+          const raw: string = String(comp.value);
           if (!raw.includes("%")) {
             return fieldVal.toLowerCase().includes(raw.toLowerCase());
           }

--- a/App/FeatureSet/Workers/API/Metrics.ts
+++ b/App/FeatureSet/Workers/API/Metrics.ts
@@ -9,8 +9,10 @@ import WorkerQueueService from "../Services/Queue/WorkerQueueService";
 const router: ExpressRouter = Express.getRouter();
 
 /**
- * JSON metrics endpoint for KEDA autoscaling
- * Returns queue size as JSON for KEDA metrics-api scaler
+ * JSON metrics endpoint for KEDA autoscaling.
+ * Returns the combined queue BACKLOG (waiting + delayed jobs) as JSON for
+ * the KEDA metrics-api scaler. Active jobs are excluded on purpose: they
+ * are capacity being served, not demand — see Queue.getQueueBacklogSize.
  */
 router.get(
   "/metrics/queue-size",
@@ -20,7 +22,7 @@ router.get(
     next: NextFunction,
   ): Promise<void> => {
     try {
-      const queueSize: number = await WorkerQueueService.getQueueSize();
+      const queueSize: number = await WorkerQueueService.getQueueBacklogSize();
 
       res.setHeader("Content-Type", "application/json");
       res.status(200).json({

--- a/App/FeatureSet/Workers/Services/Queue/WorkerQueueService.ts
+++ b/App/FeatureSet/Workers/Services/Queue/WorkerQueueService.ts
@@ -1,17 +1,24 @@
 import Queue, { QueueName } from "Common/Server/Infrastructure/Queue";
 
 export default class WorkerQueueService {
-  public static async getQueueSize(): Promise<number> {
+  /*
+   * Combined queue BACKLOG (waiting + delayed) across the queues the worker
+   * deployment drains. Feeds the /metrics/queue-size KEDA endpoint, so it
+   * must not count active jobs — see Queue.getQueueBacklogSize for why
+   * counting active work makes the autoscaler treat ack-parked telemetry
+   * jobs as demand and overscale the fleet.
+   */
+  public static async getQueueBacklogSize(): Promise<number> {
     const [workerSize, workflowSize, telemetrySize, runbookSize]: [
       number,
       number,
       number,
       number,
     ] = await Promise.all([
-      Queue.getQueueSize(QueueName.Worker),
-      Queue.getQueueSize(QueueName.Workflow),
-      Queue.getQueueSize(QueueName.Telemetry),
-      Queue.getQueueSize(QueueName.Runbook),
+      Queue.getQueueBacklogSize(QueueName.Worker),
+      Queue.getQueueBacklogSize(QueueName.Workflow),
+      Queue.getQueueBacklogSize(QueueName.Telemetry),
+      Queue.getQueueBacklogSize(QueueName.Runbook),
     ]);
     return workerSize + workflowSize + telemetrySize + runbookSize;
   }

--- a/App/Services/Queue/AppQueueService.ts
+++ b/App/Services/Queue/AppQueueService.ts
@@ -1,17 +1,24 @@
 import Queue, { QueueName } from "Common/Server/Infrastructure/Queue";
 
 export default class AppQueueService {
-  public static async getQueueSize(): Promise<number> {
+  /*
+   * Combined queue BACKLOG (waiting + delayed) across the queues this
+   * deployment drains. Feeds the /metrics/queue-size KEDA endpoint, so it
+   * must not count active jobs — see Queue.getQueueBacklogSize for why
+   * counting active work makes the autoscaler treat ack-parked telemetry
+   * jobs as demand and overscale the fleet.
+   */
+  public static async getQueueBacklogSize(): Promise<number> {
     const [workerSize, workflowSize, telemetrySize, runbookSize]: [
       number,
       number,
       number,
       number,
     ] = await Promise.all([
-      Queue.getQueueSize(QueueName.Worker),
-      Queue.getQueueSize(QueueName.Workflow),
-      Queue.getQueueSize(QueueName.Telemetry),
-      Queue.getQueueSize(QueueName.Runbook),
+      Queue.getQueueBacklogSize(QueueName.Worker),
+      Queue.getQueueBacklogSize(QueueName.Workflow),
+      Queue.getQueueBacklogSize(QueueName.Telemetry),
+      Queue.getQueueBacklogSize(QueueName.Runbook),
     ]);
     return workerSize + workflowSize + telemetrySize + runbookSize;
   }

--- a/App/Tests/Telemetry/LogFilterEvaluatorLikePrecompiled.test.ts
+++ b/App/Tests/Telemetry/LogFilterEvaluatorLikePrecompiled.test.ts
@@ -1,0 +1,188 @@
+import {
+  CompiledFilter,
+  compileFilter,
+  evaluateCompiledFilter,
+  evaluateFilter,
+} from "../../FeatureSet/Telemetry/Utils/LogFilterEvaluator";
+import { JSONObject } from "Common/Types/JSON";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Contract under test — the LIKE operator of the shared log/span filter
+ * evaluator (drop filters, pipeline filters, category processors).
+ *
+ * The evaluator is two-stage by design: compileFilter precomputes
+ * likeSubstring / likeRegex once per rule load, and the per-record
+ * evaluation must READ those precompiled forms instead of re-escaping the
+ * pattern and constructing a fresh RegExp per record — that rebuild in the
+ * hottest ingest loop is exactly what the compile stage exists to remove,
+ * and it regressed once already (the fields were populated but never read).
+ *
+ * The tampering tests are the mutation-proof guard: they overwrite the
+ * precompiled fields on a compiled AST and assert evaluation follows the
+ * tampered values. If someone reverts the evaluator to recompiling from the
+ * raw pattern, those tests fail immediately.
+ */
+
+function row(body: string, attributes?: JSONObject): JSONObject {
+  return {
+    body: body,
+    severityText: "Info",
+    attributes: attributes || {},
+  };
+}
+
+function compile(query: string): CompiledFilter {
+  return compileFilter(query);
+}
+
+describe("LIKE without % (contains semantics)", () => {
+  test("substring match is case-insensitive", () => {
+    const filter: CompiledFilter = compile("body LIKE 'health'");
+
+    expect(evaluateCompiledFilter(row("GET /HEALTHZ 200"), filter)).toBe(true);
+    expect(evaluateCompiledFilter(row("get /healthz 200"), filter)).toBe(true);
+    expect(evaluateCompiledFilter(row("GET /metrics 200"), filter)).toBe(false);
+  });
+
+  test("matches anywhere in the field, not only exact", () => {
+    const filter: CompiledFilter = compile("body LIKE 'time'");
+
+    expect(evaluateCompiledFilter(row("oneuptime worker"), filter)).toBe(true);
+    expect(evaluateCompiledFilter(row("time"), filter)).toBe(true);
+  });
+
+  test("empty pattern matches every record", () => {
+    const filter: CompiledFilter = compile("body LIKE ''");
+
+    expect(evaluateCompiledFilter(row("anything"), filter)).toBe(true);
+    expect(evaluateCompiledFilter(row(""), filter)).toBe(true);
+  });
+});
+
+describe("LIKE with % (SQL wildcard semantics)", () => {
+  test("anchored wildcard match", () => {
+    const filter: CompiledFilter = compile("body LIKE 'GET %'");
+
+    expect(evaluateCompiledFilter(row("GET /healthz"), filter)).toBe(true);
+    expect(evaluateCompiledFilter(row("POST GET /x"), filter)).toBe(false);
+  });
+
+  test("is case-insensitive", () => {
+    const filter: CompiledFilter = compile("body LIKE 'get %'");
+
+    expect(evaluateCompiledFilter(row("GET /healthz"), filter)).toBe(true);
+  });
+
+  test("underscore matches exactly one character when % makes it a wildcard pattern", () => {
+    // ^v..*$ — at least one character after 'v'.
+    const filter: CompiledFilter = compile("body LIKE 'v_%'");
+
+    expect(evaluateCompiledFilter(row("v1"), filter)).toBe(true);
+    expect(evaluateCompiledFilter(row("v12"), filter)).toBe(true);
+    expect(evaluateCompiledFilter(row("v"), filter)).toBe(false);
+  });
+
+  test("underscore stays a literal in contains mode (no %)", () => {
+    const filter: CompiledFilter = compile("body LIKE 'v_'");
+
+    expect(evaluateCompiledFilter(row("v_1"), filter)).toBe(true);
+    expect(evaluateCompiledFilter(row("v1"), filter)).toBe(false);
+  });
+
+  test("regex metacharacters in the pattern are escaped, not interpreted", () => {
+    // '.' must match a literal dot only — not any character.
+    const filter: CompiledFilter = compile("body LIKE 'api.oneuptime.com%'");
+
+    expect(
+      evaluateCompiledFilter(row("api.oneuptime.com/v1/logs"), filter),
+    ).toBe(true);
+    expect(
+      evaluateCompiledFilter(row("apiXoneuptimeXcom/v1/logs"), filter),
+    ).toBe(false);
+  });
+});
+
+describe("per-record evaluation reads the precompiled forms (mutation guard)", () => {
+  type LikeComparison = {
+    likeSubstring?: string;
+    likeRegex?: RegExp | null;
+  };
+
+  function comparisonOf(filter: CompiledFilter): LikeComparison {
+    return (filter as unknown as { expr: LikeComparison }).expr;
+  }
+
+  test("substring path uses comp.likeSubstring, not the raw pattern", () => {
+    const filter: CompiledFilter = compile("body LIKE 'original'");
+
+    // Sanity: compiled form behaves normally first.
+    expect(evaluateCompiledFilter(row("has original text"), filter)).toBe(true);
+
+    // Tamper with the precompiled substring; the raw value stays 'original'.
+    comparisonOf(filter).likeSubstring = "tampered";
+
+    expect(evaluateCompiledFilter(row("has original text"), filter)).toBe(
+      false,
+    );
+    expect(evaluateCompiledFilter(row("has tampered text"), filter)).toBe(true);
+  });
+
+  test("wildcard path uses comp.likeRegex, not a per-record rebuild", () => {
+    const filter: CompiledFilter = compile("body LIKE 'orig%'");
+
+    expect(evaluateCompiledFilter(row("original"), filter)).toBe(true);
+
+    // Tamper with the precompiled regex; the raw value still says 'orig%'.
+    comparisonOf(filter).likeRegex = /^tampered$/i;
+
+    expect(evaluateCompiledFilter(row("original"), filter)).toBe(false);
+    expect(evaluateCompiledFilter(row("TAMPERED"), filter)).toBe(true);
+  });
+});
+
+describe("legacy uncompiled path (evaluateFilter on a raw query)", () => {
+  test("contains semantics still work without precompilation", () => {
+    expect(evaluateFilter(row("GET /healthz 200"), "body LIKE 'health'")).toBe(
+      true,
+    );
+    expect(evaluateFilter(row("GET /metrics 200"), "body LIKE 'health'")).toBe(
+      false,
+    );
+  });
+
+  test("wildcard semantics still work without precompilation", () => {
+    expect(evaluateFilter(row("GET /healthz"), "body LIKE 'GET %'")).toBe(true);
+    expect(evaluateFilter(row("POST /healthz"), "body LIKE 'GET %'")).toBe(
+      false,
+    );
+  });
+
+  test("compiled and uncompiled evaluation agree", () => {
+    const queries: Array<string> = [
+      "body LIKE 'health'",
+      "body LIKE 'GET %'",
+      "body LIKE 'v_'",
+      "body LIKE 'api.oneuptime.com%'",
+      "body LIKE ''",
+    ];
+    const bodies: Array<string> = [
+      "GET /healthz",
+      "get /HEALTHZ",
+      "v1",
+      "v12",
+      "api.oneuptime.com/v1",
+      "apiXoneuptimeXcom/v1",
+      "",
+    ];
+
+    for (const query of queries) {
+      const compiled: CompiledFilter = compile(query);
+      for (const body of bodies) {
+        expect(evaluateCompiledFilter(row(body), compiled)).toBe(
+          evaluateFilter(row(body), query),
+        );
+      }
+    }
+  });
+});

--- a/App/Tests/Telemetry/MetricPipelineRegexCompile.test.ts
+++ b/App/Tests/Telemetry/MetricPipelineRegexCompile.test.ts
@@ -1,0 +1,464 @@
+/*
+ * These tests exercise applyRules/clearCache only — loadRules (the one
+ * Postgres touchpoint) is never called, so stub the DatabaseService module
+ * out before it drags the whole server-side service graph into the ts-jest
+ * compile.
+ */
+jest.mock("Common/Server/Services/DatabaseService", () => {
+  return {
+    __esModule: true,
+    default: class DatabaseServiceStub {},
+  };
+});
+
+import MetricPipelineRuleService, {
+  MetricRulesForProject,
+} from "../../FeatureSet/Telemetry/Services/MetricPipelineRuleService";
+import MetricPipelineRule from "Common/Models/DatabaseModels/MetricPipelineRule";
+import MetricPipelineRuleType from "Common/Types/Metrics/MetricPipelineRuleType";
+import {
+  MetricPipelineRuleFilterCheckOn,
+  MetricPipelineRuleFilterConditionType,
+} from "Common/Types/Metrics/MetricPipelineRuleFilterCondition";
+import logger from "Common/Server/Utils/Logger";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONObject } from "Common/Types/JSON";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Contract under test — regex handling and attribute-key bookkeeping in the
+ * metric pipeline rule engine, which runs per metric ROW on the ingest hot
+ * path.
+ *
+ * Regexes: a MatchesRegex / DoesNotMatchRegex filter used to construct its
+ * RegExp (and warn-log invalid patterns) on EVERY datapoint evaluation.
+ * Patterns are now compiled once per process and memoized; an invalid
+ * pattern is stored as null and warned about exactly once. The
+ * constructor-count test is the mutation guard for the memo.
+ *
+ * attributeKeys: mutating rules (Rename/Add/RemoveAttribute) used to re-sort
+ * the full key list per rule per row. The sort is now deferred and runs at
+ * most once per row, after all rules — these tests pin that the final
+ * attributeKeys is still correct (sorted, matching the attributes map) in
+ * every mutation scenario, including rule chains.
+ */
+
+function regexRule(data: {
+  conditionType: MetricPipelineRuleFilterConditionType;
+  pattern: string;
+  ruleType?: MetricPipelineRuleType;
+}): MetricPipelineRule {
+  const rule: MetricPipelineRule = new MetricPipelineRule();
+  rule.id = ObjectID.generate();
+  rule.ruleType = data.ruleType ?? MetricPipelineRuleType.Drop;
+  rule.filters = [
+    {
+      checkOn: MetricPipelineRuleFilterCheckOn.MetricName,
+      conditionType: data.conditionType,
+      value: data.pattern,
+    },
+  ];
+  return rule;
+}
+
+function attributeRule(data: {
+  ruleType: MetricPipelineRuleType;
+  addAttributeKey?: string;
+  addAttributeValue?: string;
+  renameFromKey?: string;
+  renameToKey?: string;
+}): MetricPipelineRule {
+  const rule: MetricPipelineRule = new MetricPipelineRule();
+  rule.id = ObjectID.generate();
+  rule.ruleType = data.ruleType;
+  rule.filters = []; // matches everything
+  if (data.addAttributeKey !== undefined) {
+    rule.addAttributeKey = data.addAttributeKey;
+  }
+  if (data.addAttributeValue !== undefined) {
+    rule.addAttributeValue = data.addAttributeValue;
+  }
+  if (data.renameFromKey !== undefined) {
+    rule.renameFromKey = data.renameFromKey;
+  }
+  if (data.renameToKey !== undefined) {
+    rule.renameToKey = data.renameToKey;
+  }
+  return rule;
+}
+
+function projectRules(
+  ...rules: Array<MetricPipelineRule>
+): MetricRulesForProject {
+  return { projectRules: rules, rulesByServiceId: new Map() };
+}
+
+/*
+ * Minimal structural view of a jest spy — the @jest/globals and @types/jest
+ * spy types disagree in this repo, so annotate with just the surface these
+ * tests read.
+ */
+type SpyLike = {
+  mock: { calls: Array<Array<unknown>> };
+  mockRestore: () => void;
+};
+
+function metricRow(name: string, attributes?: JSONObject): JSONObject {
+  const attrs: JSONObject = attributes ?? { region: "eu", zone: "a" };
+  return {
+    name: name,
+    attributes: attrs,
+    attributeKeys: Object.keys(attrs).sort(),
+  };
+}
+
+beforeEach(() => {
+  MetricPipelineRuleService.clearCache();
+  jest.restoreAllMocks();
+});
+
+describe("regex filters match correctly", () => {
+  test("MatchesRegex drops matching rows and keeps the rest", () => {
+    const rules: MetricRulesForProject = projectRules(
+      regexRule({
+        conditionType: MetricPipelineRuleFilterConditionType.MatchesRegex,
+        pattern: "^node_.*_seconds$",
+      }),
+    );
+
+    expect(
+      MetricPipelineRuleService.applyRules(
+        metricRow("node_cpu_seconds"),
+        undefined,
+        rules,
+      ),
+    ).toBeNull();
+    expect(
+      MetricPipelineRuleService.applyRules(
+        metricRow("http_requests_total"),
+        undefined,
+        rules,
+      ),
+    ).not.toBeNull();
+  });
+
+  test("DoesNotMatchRegex inverts the match", () => {
+    const rules: MetricRulesForProject = projectRules(
+      regexRule({
+        conditionType: MetricPipelineRuleFilterConditionType.DoesNotMatchRegex,
+        pattern: "^keep_",
+      }),
+    );
+
+    expect(
+      MetricPipelineRuleService.applyRules(
+        metricRow("keep_this"),
+        undefined,
+        rules,
+      ),
+    ).not.toBeNull();
+    expect(
+      MetricPipelineRuleService.applyRules(
+        metricRow("drop_this"),
+        undefined,
+        rules,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("regex compilation is memoized per pattern", () => {
+  test("RegExp is constructed once for N rows, not once per row", () => {
+    const pattern: string = "^memoized_pattern_[0-9]+$";
+    const rules: MetricRulesForProject = projectRules(
+      regexRule({
+        conditionType: MetricPipelineRuleFilterConditionType.MatchesRegex,
+        pattern: pattern,
+      }),
+    );
+
+    const regExpSpy: SpyLike = jest.spyOn(
+      globalThis,
+      "RegExp",
+    ) as unknown as SpyLike;
+
+    for (let i: number = 0; i < 200; i++) {
+      MetricPipelineRuleService.applyRules(
+        metricRow(`memoized_pattern_${i}`),
+        undefined,
+        rules,
+      );
+    }
+
+    const constructionsOfPattern: number = regExpSpy.mock.calls.filter(
+      (call: Array<unknown>) => {
+        return call[0] === pattern;
+      },
+    ).length;
+
+    expect(constructionsOfPattern).toBe(1);
+  });
+
+  test("an invalid pattern warns exactly once, not per row", () => {
+    const rules: MetricRulesForProject = projectRules(
+      regexRule({
+        conditionType: MetricPipelineRuleFilterConditionType.MatchesRegex,
+        pattern: "([unclosed",
+      }),
+    );
+
+    const warnSpy: SpyLike = jest
+      .spyOn(logger, "warn")
+      .mockImplementation(() => {
+        return undefined;
+      }) as unknown as SpyLike;
+
+    for (let i: number = 0; i < 100; i++) {
+      MetricPipelineRuleService.applyRules(
+        metricRow(`metric_${i}`),
+        undefined,
+        rules,
+      );
+    }
+
+    const invalidRegexWarnings: number = warnSpy.mock.calls.filter(
+      (call: Array<unknown>) => {
+        return String(call[0]).includes("Invalid regex");
+      },
+    ).length;
+    expect(invalidRegexWarnings).toBe(1);
+  });
+
+  test("an invalid pattern never matches (Drop rule keeps every row)", () => {
+    const rules: MetricRulesForProject = projectRules(
+      regexRule({
+        conditionType: MetricPipelineRuleFilterConditionType.MatchesRegex,
+        pattern: "([unclosed",
+      }),
+    );
+    jest.spyOn(logger, "warn").mockImplementation(() => {
+      return undefined;
+    });
+
+    expect(
+      MetricPipelineRuleService.applyRules(
+        metricRow("anything"),
+        undefined,
+        rules,
+      ),
+    ).not.toBeNull();
+  });
+
+  test("clearCache resets the memo so a fixed pattern recompiles", () => {
+    const pattern: string = "^after_clear$";
+    const rules: MetricRulesForProject = projectRules(
+      regexRule({
+        conditionType: MetricPipelineRuleFilterConditionType.MatchesRegex,
+        pattern: pattern,
+      }),
+    );
+
+    MetricPipelineRuleService.applyRules(
+      metricRow("after_clear"),
+      undefined,
+      rules,
+    );
+    MetricPipelineRuleService.clearCache();
+
+    const regExpSpy: SpyLike = jest.spyOn(
+      globalThis,
+      "RegExp",
+    ) as unknown as SpyLike;
+    MetricPipelineRuleService.applyRules(
+      metricRow("after_clear"),
+      undefined,
+      rules,
+    );
+
+    const constructionsOfPattern: number = regExpSpy.mock.calls.filter(
+      (call: Array<unknown>) => {
+        return call[0] === pattern;
+      },
+    ).length;
+    expect(constructionsOfPattern).toBe(1);
+  });
+});
+
+describe("attributeKeys stays correct with the deferred single re-sort", () => {
+  test("AddAttribute updates attributeKeys, sorted", () => {
+    const rules: MetricRulesForProject = projectRules(
+      attributeRule({
+        ruleType: MetricPipelineRuleType.AddAttribute,
+        addAttributeKey: "aaa_first",
+        addAttributeValue: "v",
+      }),
+    );
+
+    const result: JSONObject | null = MetricPipelineRuleService.applyRules(
+      metricRow("m", { region: "eu", zone: "a" }),
+      undefined,
+      rules,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!["attributeKeys"]).toEqual(["aaa_first", "region", "zone"]);
+  });
+
+  test("RemoveAttribute updates attributeKeys", () => {
+    const rules: MetricRulesForProject = projectRules(
+      attributeRule({
+        ruleType: MetricPipelineRuleType.RemoveAttribute,
+        addAttributeKey: "zone",
+      }),
+    );
+
+    const result: JSONObject | null = MetricPipelineRuleService.applyRules(
+      metricRow("m", { region: "eu", zone: "a" }),
+      undefined,
+      rules,
+    );
+
+    expect(result!["attributeKeys"]).toEqual(["region"]);
+  });
+
+  test("RenameAttribute updates attributeKeys", () => {
+    const rules: MetricRulesForProject = projectRules(
+      attributeRule({
+        ruleType: MetricPipelineRuleType.RenameAttribute,
+        renameFromKey: "zone",
+        renameToKey: "availability_zone",
+      }),
+    );
+
+    const result: JSONObject | null = MetricPipelineRuleService.applyRules(
+      metricRow("m", { region: "eu", zone: "a" }),
+      undefined,
+      rules,
+    );
+
+    expect(result!["attributeKeys"]).toEqual(["availability_zone", "region"]);
+    expect((result!["attributes"] as JSONObject)["availability_zone"]).toBe(
+      "a",
+    );
+    expect((result!["attributes"] as JSONObject)["zone"]).toBeUndefined();
+  });
+
+  test("a chain of mutating rules yields the final combined key set", () => {
+    const rules: MetricRulesForProject = projectRules(
+      attributeRule({
+        ruleType: MetricPipelineRuleType.AddAttribute,
+        addAttributeKey: "env",
+        addAttributeValue: "prod",
+      }),
+      attributeRule({
+        ruleType: MetricPipelineRuleType.RenameAttribute,
+        renameFromKey: "region",
+        renameToKey: "cloud_region",
+      }),
+      attributeRule({
+        ruleType: MetricPipelineRuleType.RemoveAttribute,
+        addAttributeKey: "zone",
+      }),
+    );
+
+    const result: JSONObject | null = MetricPipelineRuleService.applyRules(
+      metricRow("m", { region: "eu", zone: "a" }),
+      undefined,
+      rules,
+    );
+
+    expect(result!["attributeKeys"]).toEqual(["cloud_region", "env"]);
+    expect(Object.keys(result!["attributes"] as JSONObject).sort()).toEqual([
+      "cloud_region",
+      "env",
+    ]);
+  });
+
+  test("a chain of mutating rules re-sorts attributeKeys exactly once", () => {
+    const rules: MetricRulesForProject = projectRules(
+      attributeRule({
+        ruleType: MetricPipelineRuleType.AddAttribute,
+        addAttributeKey: "env",
+        addAttributeValue: "prod",
+      }),
+      attributeRule({
+        ruleType: MetricPipelineRuleType.RenameAttribute,
+        renameFromKey: "region",
+        renameToKey: "cloud_region",
+      }),
+      attributeRule({
+        ruleType: MetricPipelineRuleType.RemoveAttribute,
+        addAttributeKey: "zone",
+      }),
+    );
+
+    // Build the row before installing the spy — metricRow sorts once itself.
+    const row: JSONObject = metricRow("m", { region: "eu", zone: "a" });
+
+    const sortSpy: SpyLike = jest.spyOn(
+      Array.prototype,
+      "sort",
+    ) as unknown as SpyLike;
+
+    let result: JSONObject | null = null;
+    let sortCallCount: number = -1;
+    try {
+      result = MetricPipelineRuleService.applyRules(row, undefined, rules);
+      // Read before mockRestore — restoring resets the recorded calls.
+      sortCallCount = sortSpy.mock.calls.length;
+    } finally {
+      sortSpy.mockRestore();
+    }
+
+    /*
+     * Mutation guard for the deferred rebuild: three mutating rules used to
+     * mean three full key re-sorts per row; the dirty-flag design runs
+     * exactly one, after the last rule.
+     */
+    expect(sortCallCount).toBe(1);
+    expect(result!["attributeKeys"]).toEqual(["cloud_region", "env"]);
+  });
+
+  test("attributeKeys is untouched when no rule mutates attributes", () => {
+    const row: JSONObject = metricRow("m", { region: "eu" });
+    const originalKeys: unknown = row["attributeKeys"];
+
+    const rules: MetricRulesForProject = projectRules(
+      attributeRule({
+        ruleType: MetricPipelineRuleType.RenameMetric,
+        renameToKey: "renamed_metric",
+      }),
+    );
+
+    const result: JSONObject | null = MetricPipelineRuleService.applyRules(
+      row,
+      undefined,
+      rules,
+    );
+
+    expect(result!["name"]).toBe("renamed_metric");
+    // Same array instance: no pointless rebuild for non-attribute rules.
+    expect(result!["attributeKeys"]).toBe(originalKeys);
+  });
+
+  test("RedactAttribute changes the value but not the key set", () => {
+    const rules: MetricRulesForProject = projectRules(
+      attributeRule({
+        ruleType: MetricPipelineRuleType.RedactAttribute,
+        addAttributeKey: "region",
+      }),
+    );
+
+    const row: JSONObject = metricRow("m", { region: "eu" });
+    const originalKeys: unknown = row["attributeKeys"];
+
+    const result: JSONObject | null = MetricPipelineRuleService.applyRules(
+      row,
+      undefined,
+      rules,
+    );
+
+    expect((result!["attributes"] as JSONObject)["region"]).toBe("[REDACTED]");
+    expect(result!["attributeKeys"]).toBe(originalKeys);
+  });
+});

--- a/App/Tests/Telemetry/MetricRowIngestionStamp.test.ts
+++ b/App/Tests/Telemetry/MetricRowIngestionStamp.test.ts
@@ -1,0 +1,288 @@
+/*
+ * These tests exercise the pure row-building statics only — nothing here
+ * touches Postgres. Stub the DatabaseService base class out before the
+ * metrics service's import graph drags the whole server-side service layer
+ * (and its ts-jest compile surface) into the suite.
+ */
+jest.mock("Common/Server/Services/DatabaseService", () => {
+  return {
+    __esModule: true,
+    default: class DatabaseServiceStub {},
+  };
+});
+
+import OtelMetricsIngestService from "../../FeatureSet/Telemetry/Services/OtelMetricsIngestService";
+import { TelemetryServiceMetadata } from "Common/Server/Services/OpenTelemetryIngestService";
+import { MetricPointType } from "Common/Models/AnalyticsModels/Metric";
+import OneUptimeDate from "Common/Types/Date";
+import ServiceType from "Common/Types/Telemetry/ServiceType";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONObject } from "Common/Types/JSON";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * Contract under test — the wall-clock stamps on metric rows after the
+ * per-datapoint date derivation was replaced by the shared per-second
+ * ingestion-stamp memo.
+ *
+ * buildMetricRow used to call getCurrentDate + toClickhouseDateTime (and
+ * addRemoveDays + a second format for retention) for EVERY datapoint. It now
+ * reads the memoized stamp. The rows it emits must be indistinguishable from
+ * before: createdAt = ingest wall clock at second precision, retentionDate =
+ * createdAt + retentionDays, time fields still derived from the datapoint's
+ * own timeUnixNano. The same-second identity test pins the memo actually
+ * being used (mutation guard: reverting to per-row derivation with
+ * sub-second jitter would still pass equality-of-format, so we assert
+ * against the reference derivation from the frozen clock instead).
+ */
+
+/*
+ * Minimal structural view of a jest spy — the @jest/globals and @types/jest
+ * spy types disagree in this repo, so annotate with just the surface this
+ * test reads.
+ */
+type SpyLike = {
+  mock: { calls: Array<Array<unknown>> };
+  mockRestore: () => void;
+};
+
+type BuildMetricRowFn = (data: {
+  datapoint: JSONObject;
+  baseAttributes: JSONObject;
+  projectId: ObjectID;
+  primaryEntityId: ObjectID;
+  serviceName: string;
+  metricName: string;
+  metricPointType: MetricPointType;
+  serviceMetadata: TelemetryServiceMetadata;
+}) => JSONObject;
+
+const buildMetricRow: BuildMetricRowFn = (
+  OtelMetricsIngestService as unknown as {
+    buildMetricRow: BuildMetricRowFn;
+  }
+).buildMetricRow.bind(OtelMetricsIngestService);
+
+type SafeParseUnixNanoFn = (
+  value: string | number | undefined,
+  context: string,
+) => JSONObject;
+
+const safeParseUnixNano: SafeParseUnixNanoFn = (
+  OtelMetricsIngestService as unknown as {
+    safeParseUnixNano: SafeParseUnixNanoFn;
+  }
+).safeParseUnixNano.bind(OtelMetricsIngestService);
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const ENTITY_ID: ObjectID = ObjectID.generate();
+
+function serviceMetadata(retentionDays?: number): TelemetryServiceMetadata {
+  return {
+    serviceName: "test-service",
+    primaryEntityId: ENTITY_ID,
+    primaryEntityType: ServiceType.OpenTelemetry,
+    serviceRetentionInDays: retentionDays,
+  } as TelemetryServiceMetadata;
+}
+
+function buildRow(data?: {
+  retentionDays?: number;
+  timeUnixNano?: string;
+}): JSONObject {
+  return buildMetricRow({
+    datapoint: {
+      timeUnixNano: data?.timeUnixNano ?? `${Date.now()}000000`,
+      asInt: 1,
+      attributes: [],
+    },
+    baseAttributes: { "service.name": "test-service" },
+    projectId: PROJECT_ID,
+    primaryEntityId: ENTITY_ID,
+    serviceName: "test-service",
+    metricName: "test_metric",
+    metricPointType: MetricPointType.Gauge,
+    serviceMetadata: serviceMetadata(data?.retentionDays),
+  });
+}
+
+describe("buildMetricRow ingestion stamps", () => {
+  beforeEach(() => {
+    /*
+     * Fake Date only. The OpenTelemetry SDK in this suite's import graph
+     * pins global.performance as read-only, so sinon's default install
+     * (which also hijacks performance/hrtime/timers) throws.
+     */
+    jest.useFakeTimers({
+      doNotFake: [
+        "hrtime",
+        "nextTick",
+        "performance",
+        "queueMicrotask",
+        "requestAnimationFrame",
+        "cancelAnimationFrame",
+        "requestIdleCallback",
+        "cancelIdleCallback",
+        "setImmediate",
+        "clearImmediate",
+        "setInterval",
+        "clearInterval",
+        "setTimeout",
+        "clearTimeout",
+      ],
+    });
+    jest.setSystemTime(new Date("2026-08-10T14:30:45.678Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("createdAt is the ingest wall clock at second precision", () => {
+    const row: JSONObject = buildRow();
+
+    expect(row["createdAt"]).toBe("2026-08-10 14:30:45");
+  });
+
+  test("retentionDate = createdAt + serviceRetentionInDays", () => {
+    const row: JSONObject = buildRow({ retentionDays: 30 });
+
+    expect(row["retentionDate"]).toBe(
+      OneUptimeDate.toClickhouseDateTime(
+        OneUptimeDate.addRemoveDays(new Date("2026-08-10T14:30:45.000Z"), 30),
+      ),
+    );
+  });
+
+  test("retentionDate uses the 15-day hardcoded default when nothing configures it", () => {
+    const row: JSONObject = buildRow();
+
+    expect(row["retentionDate"]).toBe(
+      OneUptimeDate.toClickhouseDateTime(
+        OneUptimeDate.addRemoveDays(new Date("2026-08-10T14:30:45.000Z"), 15),
+      ),
+    );
+  });
+
+  test("rows built in the same second carry identical stamps", () => {
+    const first: JSONObject = buildRow({ retentionDays: 30 });
+    jest.setSystemTime(new Date("2026-08-10T14:30:45.999Z"));
+    const second: JSONObject = buildRow({ retentionDays: 30 });
+
+    expect(second["createdAt"]).toBe(first["createdAt"]);
+    expect(second["retentionDate"]).toBe(first["retentionDate"]);
+  });
+
+  test("stamps roll over across a second boundary", () => {
+    const first: JSONObject = buildRow();
+    jest.setSystemTime(new Date("2026-08-10T14:30:46.001Z"));
+    const second: JSONObject = buildRow();
+
+    expect(first["createdAt"]).toBe("2026-08-10 14:30:45");
+    expect(second["createdAt"]).toBe("2026-08-10 14:30:46");
+  });
+
+  test("distinct retention windows in the same second produce distinct dates", () => {
+    const short: JSONObject = buildRow({ retentionDays: 1 });
+    const long: JSONObject = buildRow({ retentionDays: 90 });
+
+    /*
+     * Derive expectations from the same addRemoveDays the row builder always
+     * used — it adds CALENDAR days in the process's local timezone, so a
+     * window that crosses a DST boundary is deliberately not a flat
+     * days*24h offset. The memo must preserve that behavior exactly.
+     */
+    const stampDate: Date = new Date("2026-08-10T14:30:45.000Z");
+    expect(short["retentionDate"]).toBe(
+      OneUptimeDate.toClickhouseDateTime(
+        OneUptimeDate.addRemoveDays(stampDate, 1),
+      ),
+    );
+    expect(long["retentionDate"]).toBe(
+      OneUptimeDate.toClickhouseDateTime(
+        OneUptimeDate.addRemoveDays(stampDate, 90),
+      ),
+    );
+    expect(short["retentionDate"]).not.toBe(long["retentionDate"]);
+  });
+
+  test("per-row stamp derivation is gone: a warm memo serves repeated rows", () => {
+    // Warm the (second, retention-window) memo before counting calls.
+    buildRow({ retentionDays: 30 });
+
+    const getCurrentDateSpy: SpyLike = jest.spyOn(
+      OneUptimeDate,
+      "getCurrentDate",
+    ) as unknown as SpyLike;
+    const addRemoveDaysSpy: SpyLike = jest.spyOn(
+      OneUptimeDate,
+      "addRemoveDays",
+    ) as unknown as SpyLike;
+    const formatSpy: SpyLike = jest.spyOn(
+      OneUptimeDate,
+      "toClickhouseDateTime",
+    ) as unknown as SpyLike;
+
+    try {
+      for (let i: number = 0; i < 50; i++) {
+        buildRow({ retentionDays: 30 });
+      }
+
+      /*
+       * The pre-memo code called getCurrentDate + addRemoveDays (plus two
+       * ClickHouse formats) for EVERY datapoint. With a warm memo none of
+       * that runs per row — the only per-row format left is the datapoint's
+       * own time field. Reverting to per-row derivation trips all three
+       * counts; this is the mutation guard the frozen-clock equality tests
+       * above cannot provide.
+       */
+      expect(getCurrentDateSpy.mock.calls.length).toBe(0);
+      expect(addRemoveDaysSpy.mock.calls.length).toBe(0);
+      expect(formatSpy.mock.calls.length).toBe(50);
+    } finally {
+      getCurrentDateSpy.mockRestore();
+      addRemoveDaysSpy.mockRestore();
+      formatSpy.mockRestore();
+    }
+  });
+
+  test("time fields still come from the datapoint's own timeUnixNano", () => {
+    // 2026-08-10T10:00:00.123456789Z as unix nanos.
+    const baseMs: number = Date.UTC(2026, 7, 10, 10, 0, 0, 0);
+    const nanoValue: string = `${(baseMs / 1000) * 1_000_000_000 + 123_456_789}`;
+
+    const row: JSONObject = buildRow({ timeUnixNano: nanoValue });
+
+    expect(row["time"]).toBe("2026-08-10 10:00:00");
+    expect(row["timeUnixNano"]).toBe(nanoValue);
+  });
+});
+
+describe("safeParseUnixNano after the unused iso removal", () => {
+  test("returns nano/db/date and no iso field", () => {
+    const ms: number = Date.UTC(2026, 7, 10, 10, 0, 0, 0);
+    const nano: number = ms * 1_000_000;
+
+    const parsed: JSONObject = safeParseUnixNano(nano, "test");
+
+    expect(parsed["nano"]).toBe(String(nano));
+    expect(parsed["db"]).toBe("2026-08-10 10:00:00");
+    expect(parsed["date"]).toBeInstanceOf(Date);
+    expect((parsed["date"] as Date).getTime()).toBe(ms);
+    expect(Object.prototype.hasOwnProperty.call(parsed, "iso")).toBe(false);
+  });
+
+  test("db string matches the shared ClickHouse formatter", () => {
+    const ms: number = Date.UTC(2025, 0, 15, 23, 59, 59, 500);
+    const parsed: JSONObject = safeParseUnixNano(ms * 1_000_000, "test");
+
+    expect(parsed["db"]).toBe(OneUptimeDate.toClickhouseDateTime(new Date(ms)));
+  });
+});

--- a/App/Tests/Telemetry/QueueBacklogMetric.test.ts
+++ b/App/Tests/Telemetry/QueueBacklogMetric.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Contract under test — the /metrics/queue-size aggregation services that
+ * feed the KEDA metrics-api scaler for the app and worker deployments.
+ *
+ * Both services must aggregate the BACKLOG (waiting + delayed) across the
+ * four drained queues via Queue.getQueueBacklogSize — never the
+ * active-inclusive Queue.getQueueSize. Counting active jobs made the scaler
+ * treat telemetry jobs parked on the fan-in flush ack as demand, so every
+ * new pod just parked more jobs and the fleet overscaled to
+ * jobRate x ackLatency. These tests pin the aggregation to the
+ * backlog-only source so the feedback loop cannot quietly come back.
+ */
+
+type JestMock = ReturnType<typeof jest.fn>;
+
+const getQueueBacklogSizeMock: JestMock = jest.fn();
+const getQueueSizeMock: JestMock = jest.fn();
+
+jest.mock("Common/Server/Infrastructure/Queue", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "Common/Server/Infrastructure/Queue",
+  ) as Record<string, unknown>;
+  return {
+    __esModule: true,
+    QueueName: actual["QueueName"],
+    QueueJob: actual["QueueJob"],
+    default: {
+      getQueueBacklogSize: (queueName: unknown): unknown => {
+        return getQueueBacklogSizeMock(queueName);
+      },
+      getQueueSize: (queueName: unknown): unknown => {
+        return getQueueSizeMock(queueName);
+      },
+    },
+  };
+});
+
+import { QueueName } from "Common/Server/Infrastructure/Queue";
+import AppQueueService from "../../Services/Queue/AppQueueService";
+import WorkerQueueService from "../../FeatureSet/Workers/Services/Queue/WorkerQueueService";
+import TelemetryQueueService from "../../FeatureSet/Telemetry/Services/Queue/TelemetryQueueService";
+
+const BACKLOG_BY_QUEUE: Record<string, number> = {
+  [QueueName.Worker]: 5,
+  [QueueName.Workflow]: 7,
+  [QueueName.Telemetry]: 11,
+  [QueueName.Runbook]: 2,
+};
+
+beforeEach(() => {
+  getQueueBacklogSizeMock.mockReset();
+  getQueueSizeMock.mockReset();
+  getQueueBacklogSizeMock.mockImplementation(async (queueName: unknown) => {
+    return BACKLOG_BY_QUEUE[queueName as string] ?? 0;
+  });
+});
+
+describe("AppQueueService.getQueueBacklogSize", () => {
+  test("sums the backlog of all four drained queues", async () => {
+    await expect(AppQueueService.getQueueBacklogSize()).resolves.toBe(25);
+  });
+
+  test("reads every queue exactly once, via the backlog-only counter", async () => {
+    await AppQueueService.getQueueBacklogSize();
+
+    const queried: Array<unknown> = getQueueBacklogSizeMock.mock.calls.map(
+      (call: Array<unknown>) => {
+        return call[0];
+      },
+    );
+    expect(queried.sort()).toEqual(
+      [
+        QueueName.Worker,
+        QueueName.Workflow,
+        QueueName.Telemetry,
+        QueueName.Runbook,
+      ].sort(),
+    );
+
+    // The active-inclusive counter must never back the scaling metric.
+    expect(getQueueSizeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("WorkerQueueService.getQueueBacklogSize", () => {
+  test("sums the backlog of all four drained queues", async () => {
+    await expect(WorkerQueueService.getQueueBacklogSize()).resolves.toBe(25);
+  });
+
+  test("never consults the active-inclusive queue size", async () => {
+    await WorkerQueueService.getQueueBacklogSize();
+    expect(getQueueSizeMock).not.toHaveBeenCalled();
+    expect(getQueueBacklogSizeMock).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe("TelemetryQueueService.getQueueBacklogSize", () => {
+  test("reports the Telemetry queue backlog only, never the active-inclusive size", async () => {
+    await expect(TelemetryQueueService.getQueueBacklogSize()).resolves.toBe(11);
+
+    expect(getQueueBacklogSizeMock).toHaveBeenCalledTimes(1);
+    expect(getQueueBacklogSizeMock).toHaveBeenCalledWith(QueueName.Telemetry);
+    expect(getQueueSizeMock).not.toHaveBeenCalled();
+  });
+});

--- a/App/Tests/Telemetry/QueueBacklogSize.test.ts
+++ b/App/Tests/Telemetry/QueueBacklogSize.test.ts
@@ -1,0 +1,130 @@
+import Queue, { QueueName } from "Common/Server/Infrastructure/Queue";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Contract under test — the queue-size numbers that feed autoscaling.
+ *
+ * getQueueBacklogSize is the KEDA scaling signal: it must count only jobs
+ * that still need a worker (waiting + delayed) and must NOT count active
+ * jobs. Telemetry jobs park in the active state for the fan-in writer's
+ * full flush window while awaiting their ClickHouse ack; counting them made
+ * the autoscaler read busy-but-healthy capacity as demand, so pod count
+ * converged on job rate x ack latency instead of real queue pressure.
+ *
+ * getQueueSize keeps the active-inclusive sum — it backs the ingest
+ * backpressure checks, where in-flight work genuinely counts against
+ * capacity — so both are pinned here to stop either from drifting into the
+ * other's semantics.
+ */
+
+type FakeCounts = {
+  waiting: number;
+  active: number;
+  delayed: number;
+  completed: number;
+  failed: number;
+};
+
+function fakeBullQueue(counts: FakeCounts): {
+  queue: unknown;
+  calls: Record<string, number>;
+} {
+  const calls: Record<string, number> = {};
+  const track: (name: string) => void = (name: string): void => {
+    calls[name] = (calls[name] || 0) + 1;
+  };
+
+  const queue: unknown = {
+    getWaitingCount: async (): Promise<number> => {
+      track("getWaitingCount");
+      return counts.waiting;
+    },
+    getActiveCount: async (): Promise<number> => {
+      track("getActiveCount");
+      return counts.active;
+    },
+    getDelayedCount: async (): Promise<number> => {
+      track("getDelayedCount");
+      return counts.delayed;
+    },
+    getCompletedCount: async (): Promise<number> => {
+      track("getCompletedCount");
+      return counts.completed;
+    },
+    getFailedCount: async (): Promise<number> => {
+      track("getFailedCount");
+      return counts.failed;
+    },
+  };
+
+  return { queue, calls };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("Queue.getQueueBacklogSize", () => {
+  test("counts waiting + delayed only", async () => {
+    const { queue } = fakeBullQueue({
+      waiting: 7,
+      active: 100,
+      delayed: 3,
+      completed: 500,
+      failed: 9,
+    });
+    jest.spyOn(Queue, "getQueue").mockReturnValue(queue as never);
+
+    await expect(Queue.getQueueBacklogSize(QueueName.Telemetry)).resolves.toBe(
+      10,
+    );
+  });
+
+  test("never queries the active count — active jobs are capacity, not demand", async () => {
+    const { queue, calls } = fakeBullQueue({
+      waiting: 1,
+      active: 99999,
+      delayed: 2,
+      completed: 0,
+      failed: 0,
+    });
+    jest.spyOn(Queue, "getQueue").mockReturnValue(queue as never);
+
+    await Queue.getQueueBacklogSize(QueueName.Telemetry);
+
+    expect(calls["getActiveCount"]).toBeUndefined();
+    expect(calls["getWaitingCount"]).toBe(1);
+    expect(calls["getDelayedCount"]).toBe(1);
+  });
+
+  test("a fleet saturated with parked-but-active jobs reports zero backlog", async () => {
+    // The exact regime that used to overscale: everything active, nothing waiting.
+    const { queue } = fakeBullQueue({
+      waiting: 0,
+      active: 4000,
+      delayed: 0,
+      completed: 0,
+      failed: 0,
+    });
+    jest.spyOn(Queue, "getQueue").mockReturnValue(queue as never);
+
+    await expect(Queue.getQueueBacklogSize(QueueName.Telemetry)).resolves.toBe(
+      0,
+    );
+  });
+});
+
+describe("Queue.getQueueSize (backpressure semantics, unchanged)", () => {
+  test("still counts waiting + active + delayed", async () => {
+    const { queue } = fakeBullQueue({
+      waiting: 7,
+      active: 100,
+      delayed: 3,
+      completed: 500,
+      failed: 9,
+    });
+    jest.spyOn(Queue, "getQueue").mockReturnValue(queue as never);
+
+    await expect(Queue.getQueueSize(QueueName.Telemetry)).resolves.toBe(110);
+  });
+});

--- a/Common/Server/Infrastructure/Queue.ts
+++ b/Common/Server/Infrastructure/Queue.ts
@@ -560,6 +560,32 @@ export default class Queue {
     return waitingCount + activeCount + delayedCount;
   }
 
+  /*
+   * Backlog = jobs still waiting for a worker (waiting + delayed), for
+   * autoscaling signals. ACTIVE jobs are deliberately excluded: they are
+   * already being served, so to a scaler they are capacity, not demand.
+   * Telemetry jobs in particular sit in the active state for the fan-in
+   * writer's full flush window (up to TELEMETRY_FANIN_MAX_WAIT_MS) while
+   * awaiting their ClickHouse ack, so a fleet scaled on an active-inclusive
+   * count converges on pod count = job rate x ack latency — every new pod
+   * just parks more jobs without shortening the flush window. Scaling on
+   * waiting + delayed only breaks that feedback loop. getQueueSize above
+   * keeps the active-inclusive sum for ingest backpressure checks, where
+   * in-flight work genuinely counts against capacity.
+   */
+  @CaptureSpan()
+  public static async getQueueBacklogSize(
+    queueName: QueueName,
+  ): Promise<number> {
+    const queue: BullQueue = this.getQueue(queueName);
+    const [waitingCount, delayedCount]: [number, number] = await Promise.all([
+      queue.getWaitingCount(),
+      queue.getDelayedCount(),
+    ]);
+
+    return waitingCount + delayedCount;
+  }
+
   @CaptureSpan()
   public static async getQueueStats(queueName: QueueName): Promise<{
     waiting: number;

--- a/Common/Server/Infrastructure/QueueWorker.ts
+++ b/Common/Server/Infrastructure/QueueWorker.ts
@@ -16,6 +16,7 @@ import Telemetry, {
 } from "../Utils/Telemetry";
 import Redis from "./Redis";
 import GracefulShutdown, { ShutdownPriority } from "../Utils/GracefulShutdown";
+import logger from "../Utils/Logger";
 
 export default class QueueWorker {
   @CaptureSpan()
@@ -118,6 +119,22 @@ export default class QueueWorker {
       ...(options.maxStalledCount !== undefined
         ? { maxStalledCount: options.maxStalledCount }
         : {}),
+    });
+
+    /*
+     * Always log job failures to the container log, independent of telemetry
+     * configuration. Error visibility used to ride on @CaptureSpan's
+     * exception path, but the decorator is a passthrough when no span
+     * exporter is installed — without this listener a job that throws on
+     * such a deployment lands in the Redis failed set with no log line.
+     */
+    worker.on("failed", (job: QueueJob | undefined, error: Error) => {
+      logger.error(
+        `Queue job failed: ${queueName}/${job?.name || "unknown"} (job ${
+          job?.id ?? "unknown"
+        })`,
+      );
+      logger.error(error);
     });
 
     /*

--- a/Common/Server/Utils/Telemetry.ts
+++ b/Common/Server/Utils/Telemetry.ts
@@ -102,6 +102,20 @@ export default class Telemetry {
 
   public static serviceName: string | null = null;
 
+  /*
+   * True only when init() installed a real OTLP span exporter. @CaptureSpan
+   * consults this to skip span creation entirely on deployments that never
+   * export traces — without an exporter the spans go nowhere, but the wrapper
+   * would still pay attribute flattening, span allocation, and an
+   * AsyncLocalStorage context switch on every decorated call, which includes
+   * hot ingest paths that run millions of times per minute.
+   */
+  private static spanExportEnabled: boolean = false;
+
+  public static isSpanExportEnabled(): boolean {
+    return this.spanExportEnabled;
+  }
+
   public static getHeaders(): Dictionary<string> {
     if (!process.env["OPENTELEMETRY_EXPORTER_OTLP_HEADERS"]) {
       return {};
@@ -192,6 +206,7 @@ export default class Telemetry {
           headers: headers,
           compression: CompressionAlgorithm.GZIP,
         }) as unknown as SpanExporter;
+        this.spanExportEnabled = true;
       }
 
       if (this.getOltpMetricsEndpoint() && hasHeaders) {

--- a/Common/Server/Utils/Telemetry/CaptureSpan.ts
+++ b/Common/Server/Utils/Telemetry/CaptureSpan.ts
@@ -38,35 +38,47 @@ function CaptureSpan(data?: {
       data?.name || `${className}.${propertyKey}`;
 
     descriptor.value = function (...args: any[]) {
-      if (DisableTelemetry) {
+      /*
+       * Skip the span machinery entirely when telemetry is disabled OR no
+       * span exporter is installed. Without an exporter the span is never
+       * shipped anywhere, but creating it still costs attribute flattening,
+       * a span allocation, and an AsyncLocalStorage context transition —
+       * decorated methods sit on ingest hot paths that run millions of
+       * times per minute, so this must be a plain method call there.
+       */
+      if (DisableTelemetry || !Telemetry.isSpanExportEnabled()) {
         return originalMethod.apply(this, args);
       }
 
-      let functionArguments: JSONObject = {};
+      /*
+       * Only pay for attribute flattening when there is something to
+       * flatten — the overwhelmingly common bare @CaptureSpan() form has
+       * neither captured arguments nor static attributes.
+       */
+      let spanAttributes: { [key: string]: any } | undefined = undefined;
 
-      if (data?.captureArguments) {
-        functionArguments = args.reduce(
-          (acc: { [key: string]: any }, arg: any, index: number) => {
-            acc[`arg${index}`] = arg;
-            return acc;
-          },
-          {},
-        );
-      }
+      if (data?.captureArguments || data?.attributes) {
+        let functionArguments: JSONObject = {};
 
-      const spanAttributes: { [key: string]: any } =
-        JSONFunctions.flattenObject({
+        if (data?.captureArguments) {
+          functionArguments = args.reduce(
+            (acc: { [key: string]: any }, arg: any, index: number) => {
+              acc[`arg${index}`] = arg;
+              return acc;
+            },
+            {},
+          );
+        }
+
+        spanAttributes = JSONFunctions.flattenObject({
           ...functionArguments,
           ...data?.attributes,
         }) as { [key: string]: any };
+      }
 
       return Telemetry.startActiveSpan({
         name: name,
-        options: {
-          attributes: {
-            ...spanAttributes,
-          },
-        },
+        options: spanAttributes ? { attributes: spanAttributes } : {},
         fn: (span: Span) => {
           let result: any = null;
           try {

--- a/Common/Server/Utils/Telemetry/IngestionTimestamp.ts
+++ b/Common/Server/Utils/Telemetry/IngestionTimestamp.ts
@@ -1,0 +1,75 @@
+import OneUptimeDate from "../../../Types/Date";
+
+/*
+ * Per-second memo for the wall-clock stamps every ingested telemetry row
+ * carries (createdAt and retentionDate, both stored with second
+ * granularity).
+ *
+ * The Otel logs / traces / metrics row builders used to derive these per
+ * row: a current-Date allocation, a ClickHouse DateTime format, a
+ * moment-based add-days, and a second format — for every log record, span,
+ * and metric datapoint. All of that output only changes once per second
+ * (createdAt has no sub-second component) and once per distinct retention
+ * window, so a burst of rows in the same second re-derived identical
+ * strings millions of times. This memo pays the derivation once per second
+ * (and once per retention window within that second) instead.
+ *
+ * Not thread-shared state to worry about: workers are single-threaded, and
+ * the memo is replaced wholesale when the second rolls over, so the map of
+ * retention strings can never grow past the number of distinct retention
+ * windows seen within one second.
+ */
+
+export interface IngestionStamp {
+  /** Current time truncated to the second the stamp was minted. */
+  date: Date;
+  /** ClickHouse DateTime string ("YYYY-MM-DD HH:mm:ss", UTC) of `date`. */
+  db: string;
+}
+
+type CachedStamp = IngestionStamp & {
+  epochSecond: number;
+  retentionDbByDays: Map<number, string>;
+};
+
+let cachedStamp: CachedStamp | null = null;
+
+export function getIngestionStamp(): IngestionStamp {
+  const epochSecond: number = Math.floor(Date.now() / 1000);
+
+  if (!cachedStamp || cachedStamp.epochSecond !== epochSecond) {
+    const date: Date = new Date(epochSecond * 1000);
+    cachedStamp = {
+      epochSecond: epochSecond,
+      date: date,
+      db: OneUptimeDate.toClickhouseDateTime(date),
+      retentionDbByDays: new Map<number, string>(),
+    };
+  }
+
+  return cachedStamp;
+}
+
+/*
+ * ClickHouse DateTime string for `stamp.date + retentionDays`, memoized per
+ * (stamp second, retention window). Must be called with a stamp obtained
+ * from getIngestionStamp() in the same row-building pass, so the retention
+ * date stays consistent with the row's createdAt.
+ */
+export function getRetentionDateDb(
+  stamp: IngestionStamp,
+  retentionDays: number,
+): string {
+  const cached: CachedStamp = stamp as CachedStamp;
+
+  let db: string | undefined = cached.retentionDbByDays?.get(retentionDays);
+
+  if (db === undefined) {
+    db = OneUptimeDate.toClickhouseDateTime(
+      OneUptimeDate.addRemoveDays(stamp.date, retentionDays),
+    );
+    cached.retentionDbByDays?.set(retentionDays, db);
+  }
+
+  return db;
+}

--- a/Common/Server/Utils/Telemetry/Telemetry.ts
+++ b/Common/Server/Utils/Telemetry/Telemetry.ts
@@ -451,7 +451,6 @@ export default class TelemetryUtil {
     };
   }
 
-  @CaptureSpan()
   public static getAttributes(data: {
     prefixKeysWithString: string;
     items: JSONArray;

--- a/Common/Tests/Types/DateClickhouseFormat.test.ts
+++ b/Common/Tests/Types/DateClickhouseFormat.test.ts
@@ -1,0 +1,192 @@
+import OneUptimeDate from "../../Types/Date";
+import moment from "moment-timezone";
+import { afterAll, describe, expect, test } from "@jest/globals";
+
+/*
+ * Run the whole suite in a non-UTC, DST-observing zone. Under TZ=UTC the
+ * local and UTC Date getters agree, so a getUTC* -> get* regression in the
+ * hand-rolled formatter would be invisible to every parity assertion below.
+ * America/New_York makes any local-getter mutation diverge from the
+ * moment-UTC oracle deterministically (including across DST transitions in
+ * the fuzz sweep). Node re-reads process.env.TZ on Date operations; the
+ * original value is restored afterAll so co-resident suites in the same
+ * worker keep the process default.
+ */
+const ORIGINAL_TZ: string | undefined = process.env["TZ"];
+process.env["TZ"] = "America/New_York";
+
+afterAll(() => {
+  if (ORIGINAL_TZ === undefined) {
+    delete process.env["TZ"];
+  } else {
+    process.env["TZ"] = ORIGINAL_TZ;
+  }
+});
+
+/*
+ * Contract under test — the ClickHouse DateTime formatters that stamp every
+ * ingested telemetry row (createdAt, time, retentionDate, startTime/endTime).
+ *
+ * These used to be moment(...).utc().format("YYYY-MM-DD HH:mm:ss"), which
+ * allocates a moment wrapper and parses a format-token string PER CALL — and
+ * they are called several times per log record / span / metric datapoint.
+ * They are now a hand-rolled UTC formatter. The replacement must be
+ * byte-identical to what moment produced, because these strings are written
+ * straight into ClickHouse DateTime columns and compared/parsed downstream.
+ *
+ * The parity tests below therefore compare the new implementation against a
+ * live moment call, not against hardcoded strings, across edge cases and a
+ * deterministic fuzz sweep.
+ */
+
+function momentReference(date: Date): string {
+  return moment(date).utc().format("YYYY-MM-DD HH:mm:ss");
+}
+
+describe("OneUptimeDate.toClickhouseDateTime", () => {
+  const edgeCases: Array<{ name: string; date: Date }> = [
+    { name: "unix epoch", date: new Date(0) },
+    { name: "one ms before epoch", date: new Date(-1) },
+    { name: "one second before epoch", date: new Date(-1000) },
+    {
+      name: "pre-1970 date",
+      date: new Date(Date.UTC(1955, 10, 5, 6, 15, 30, 123)),
+    },
+    {
+      name: "leap day",
+      date: new Date(Date.UTC(2024, 1, 29, 23, 59, 59, 999)),
+    },
+    {
+      name: "year rollover instant",
+      date: new Date(Date.UTC(2025, 11, 31, 23, 59, 59, 999)),
+    },
+    {
+      name: "first instant of a year",
+      date: new Date(Date.UTC(2026, 0, 1, 0, 0, 0, 0)),
+    },
+    {
+      name: "single-digit month/day/hour/minute/second",
+      date: new Date(Date.UTC(2026, 2, 4, 5, 6, 7, 8)),
+    },
+    {
+      name: "three-digit year pads to 4 digits",
+      date: new Date(Date.UTC(999, 0, 2, 3, 4, 5)),
+    },
+    {
+      name: "far future",
+      date: new Date(Date.UTC(2999, 11, 31, 12, 0, 0)),
+    },
+  ];
+
+  for (const { name, date } of edgeCases) {
+    test(`matches the moment implementation it replaced: ${name}`, () => {
+      expect(OneUptimeDate.toClickhouseDateTime(date)).toBe(
+        momentReference(date),
+      );
+    });
+  }
+
+  test("fuzz sweep: parity with moment across ±100 years", () => {
+    /*
+     * Deterministic LCG so a failure is reproducible. 2000 samples spread
+     * across ~200 years of epoch millis, including sub-second components.
+     */
+    let seed: number = 42;
+    const nextRandom: () => number = (): number => {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      return seed / 2147483648;
+    };
+
+    const hundredYearsMs: number = 100 * 365.25 * 24 * 3600 * 1000;
+
+    for (let i: number = 0; i < 2000; i++) {
+      const ms: number = Math.floor((nextRandom() * 2 - 1) * hundredYearsMs);
+      const date: Date = new Date(ms);
+      expect(OneUptimeDate.toClickhouseDateTime(date)).toBe(
+        momentReference(date),
+      );
+    }
+  });
+
+  test("accepts ISO string input like the moment version did", () => {
+    const iso: string = "2026-08-10T13:45:59.500Z";
+    expect(OneUptimeDate.toClickhouseDateTime(iso)).toBe(
+      momentReference(new Date(iso)),
+    );
+  });
+
+  test("keeps moment's 'Invalid date' sentinel for NaN dates", () => {
+    const invalid: Date = new Date(NaN);
+    expect(OneUptimeDate.toClickhouseDateTime(invalid)).toBe(
+      momentReference(invalid),
+    );
+    expect(OneUptimeDate.toClickhouseDateTime(invalid)).toBe("Invalid date");
+  });
+
+  test("output is always UTC regardless of process timezone", () => {
+    // 2026-06-15T00:30:00Z is a different calendar day in UTC-negative zones.
+    const date: Date = new Date(Date.UTC(2026, 5, 15, 0, 30, 0));
+    expect(OneUptimeDate.toClickhouseDateTime(date)).toBe(
+      "2026-06-15 00:30:00",
+    );
+  });
+});
+
+describe("OneUptimeDate.toClickhouseDateTime64", () => {
+  /*
+   * Nano timestamps arrive as JS numbers, so a modern epoch date times 1e6
+   * exceeds Number.MAX_SAFE_INTEGER and the sub-second digits are already
+   * imprecise before this function sees them (pre-existing caller
+   * behavior). Exercise the extraction arithmetic with early-epoch dates
+   * whose nano values are exactly representable.
+   */
+  test("extracts sub-second nanos from the unix-nano timestamp", () => {
+    const date: Date = new Date(Date.UTC(1970, 0, 20, 12, 0, 5, 0));
+    // 123456789 sub-second nanoseconds — exactly representable here.
+    const nano: number = date.getTime() * 1_000_000 + 123_456_789;
+    expect(OneUptimeDate.toClickhouseDateTime64(date, nano)).toBe(
+      "1970-01-20 12:00:05.123456789",
+    );
+  });
+
+  test("pads short sub-second nano fractions to 9 digits", () => {
+    const date: Date = new Date(Date.UTC(1970, 0, 20, 12, 0, 5, 0));
+    const nano: number = date.getTime() * 1_000_000 + 7;
+    expect(OneUptimeDate.toClickhouseDateTime64(date, nano)).toBe(
+      "1970-01-20 12:00:05.000000007",
+    );
+  });
+
+  test("falls back to Date milliseconds when nano timestamp is absent", () => {
+    const date: Date = new Date(Date.UTC(2026, 7, 10, 12, 0, 5, 123));
+    expect(OneUptimeDate.toClickhouseDateTime64(date)).toBe(
+      "2026-08-10 12:00:05.123000000",
+    );
+  });
+
+  test("falls back to Date milliseconds when nano timestamp is zero", () => {
+    // The implementation treats only nanoTimestamp > 0 as authoritative.
+    const date: Date = new Date(Date.UTC(2026, 7, 10, 12, 0, 5, 42));
+    expect(OneUptimeDate.toClickhouseDateTime64(date, 0)).toBe(
+      "2026-08-10 12:00:05.042000000",
+    );
+  });
+
+  test("base portion matches the moment implementation it replaced", () => {
+    const date: Date = new Date(Date.UTC(1999, 11, 31, 23, 59, 59, 999));
+    const formatted: string = OneUptimeDate.toClickhouseDateTime64(date);
+    expect(formatted.slice(0, 19)).toBe(momentReference(date));
+  });
+});
+
+describe("OneUptimeDate.getCurrentDate", () => {
+  test("returns the current wall-clock time as a plain Date", () => {
+    const before: number = Date.now();
+    const current: Date = OneUptimeDate.getCurrentDate();
+    const after: number = Date.now();
+
+    expect(current).toBeInstanceOf(Date);
+    expect(current.getTime()).toBeGreaterThanOrEqual(before);
+    expect(current.getTime()).toBeLessThanOrEqual(after);
+  });
+});

--- a/Common/Tests/Utils/Telemetry/CaptureSpanExportGating.test.ts
+++ b/Common/Tests/Utils/Telemetry/CaptureSpanExportGating.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, jest, test, beforeEach } from "@jest/globals";
+
+/*
+ * Contract under test — @CaptureSpan's export gating.
+ *
+ * The decorator wraps ~hundreds of methods, some of which sit on per-record
+ * telemetry ingest paths. It must be a plain method call (no span, no
+ * attribute flattening, no AsyncLocalStorage transition) whenever no span
+ * exporter is installed — spans that are never exported are pure overhead —
+ * and only build the attribute object when there is actually something to
+ * attach. When an exporter IS installed it must keep the full original
+ * behavior: named span, OK status on success, recorded exception + rethrow
+ * on failure, for both sync and async methods.
+ */
+
+type JestMock = ReturnType<typeof jest.fn>;
+
+type FakeSpan = {
+  setStatus: JestMock;
+  end: JestMock;
+};
+
+const fakeSpan: FakeSpan = {
+  setStatus: jest.fn(),
+  end: jest.fn(),
+};
+
+let spanExportEnabled: boolean = false;
+
+const startActiveSpanMock: JestMock = jest.fn((data: any) => {
+  return data.fn(fakeSpan);
+});
+const recordExceptionMock: JestMock = jest.fn();
+
+jest.mock("../../../Server/Utils/Telemetry", () => {
+  return {
+    __esModule: true,
+    default: {
+      isSpanExportEnabled: (): boolean => {
+        return spanExportEnabled;
+      },
+      startActiveSpan: (data: unknown): unknown => {
+        return startActiveSpanMock(data);
+      },
+      recordExceptionMarkSpanAsErrorAndEndSpan: (data: unknown): unknown => {
+        return recordExceptionMock(data);
+      },
+    },
+  };
+});
+
+jest.mock("../../../Server/EnvironmentConfig", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "../../../Server/EnvironmentConfig",
+  ) as Record<string, unknown>;
+  return {
+    ...actual,
+    DisableTelemetry: false,
+  };
+});
+
+import CaptureSpan from "../../../Server/Utils/Telemetry/CaptureSpan";
+
+/*
+ * Apply the decorator exactly the way TypeScript does for a static method,
+ * without relying on decorator syntax support in the test transform.
+ */
+function decorate(
+  data: Parameters<typeof CaptureSpan>[0] | undefined,
+  fn: (...args: Array<any>) => any,
+  methodName: string = "method",
+): (...args: Array<any>) => any {
+  class Host {}
+  const descriptor: TypedPropertyDescriptor<any> = { value: fn };
+  CaptureSpan(data)(Host, methodName, descriptor);
+  return descriptor.value;
+}
+
+beforeEach(() => {
+  spanExportEnabled = false;
+  startActiveSpanMock.mockClear();
+  recordExceptionMock.mockClear();
+  fakeSpan.setStatus.mockClear();
+  fakeSpan.end.mockClear();
+});
+
+describe("CaptureSpan with no span exporter installed", () => {
+  test("calls the original method directly and creates no span", () => {
+    const original: JestMock = jest.fn().mockReturnValue("result");
+    const wrapped: (...args: Array<any>) => any = decorate(undefined, original);
+
+    expect(wrapped("a", 1)).toBe("result");
+    expect(original).toHaveBeenCalledWith("a", 1);
+    expect(startActiveSpanMock).not.toHaveBeenCalled();
+  });
+
+  test("preserves `this` binding", () => {
+    const wrapped: (...args: Array<any>) => any = decorate(
+      undefined,
+      function (this: { value: number }): number {
+        return this.value;
+      },
+    );
+
+    expect(wrapped.call({ value: 42 })).toBe(42);
+  });
+
+  test("async results and rejections pass through untouched", async () => {
+    const wrappedOk: (...args: Array<any>) => any = decorate(
+      undefined,
+      async (): Promise<string> => {
+        return "async-result";
+      },
+    );
+    await expect(wrappedOk()).resolves.toBe("async-result");
+
+    const boom: Error = new Error("boom");
+    const wrappedFail: (...args: Array<any>) => any = decorate(
+      undefined,
+      async (): Promise<never> => {
+        throw boom;
+      },
+    );
+    await expect(wrappedFail()).rejects.toBe(boom);
+    expect(startActiveSpanMock).not.toHaveBeenCalled();
+  });
+
+  test("sync throws pass through untouched", () => {
+    const boom: Error = new Error("sync-boom");
+    const wrapped: (...args: Array<any>) => any = decorate(undefined, () => {
+      throw boom;
+    });
+
+    expect(() => {
+      return wrapped();
+    }).toThrow(boom);
+    expect(startActiveSpanMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("CaptureSpan with a span exporter installed", () => {
+  beforeEach(() => {
+    spanExportEnabled = true;
+  });
+
+  test("creates a span named Class.method and returns the result", () => {
+    const wrapped: (...args: Array<any>) => any = decorate(
+      undefined,
+      () => {
+        return "spanned";
+      },
+      "doWork",
+    );
+
+    expect(wrapped()).toBe("spanned");
+    expect(startActiveSpanMock).toHaveBeenCalledTimes(1);
+
+    const callData: any = startActiveSpanMock.mock.calls[0]![0];
+    expect(callData.name).toBe("Host.doWork");
+    expect(fakeSpan.setStatus).toHaveBeenCalledWith({ code: 1 }); // OK
+    expect(fakeSpan.end).toHaveBeenCalledTimes(1);
+  });
+
+  test("bare @CaptureSpan() attaches no attributes (flattening skipped)", () => {
+    const wrapped: (...args: Array<any>) => any = decorate(undefined, () => {
+      return "x";
+    });
+    wrapped("argument-that-must-not-be-captured");
+
+    const callData: any = startActiveSpanMock.mock.calls[0]![0];
+    expect(callData.options).toEqual({});
+  });
+
+  test("captureArguments flattens call arguments into span attributes", () => {
+    const wrapped: (...args: Array<any>) => any = decorate(
+      { captureArguments: true },
+      () => {
+        return "x";
+      },
+    );
+    wrapped("first", { nested: { key: "v" } });
+
+    const callData: any = startActiveSpanMock.mock.calls[0]![0];
+    expect(callData.options.attributes["arg0"]).toBe("first");
+    expect(callData.options.attributes["arg1.nested.key"]).toBe("v");
+  });
+
+  test("static attributes are attached", () => {
+    const wrapped: (...args: Array<any>) => any = decorate(
+      { attributes: { component: "test" } },
+      () => {
+        return "x";
+      },
+    );
+    wrapped();
+
+    const callData: any = startActiveSpanMock.mock.calls[0]![0];
+    expect(callData.options.attributes["component"]).toBe("test");
+  });
+
+  test("async success marks the span OK and ends it", async () => {
+    const wrapped: (...args: Array<any>) => any = decorate(
+      undefined,
+      async (): Promise<string> => {
+        return "ok";
+      },
+    );
+
+    await expect(wrapped()).resolves.toBe("ok");
+    expect(fakeSpan.setStatus).toHaveBeenCalledWith({ code: 1 });
+    expect(fakeSpan.end).toHaveBeenCalledTimes(1);
+  });
+
+  test("async failure records the exception, rethrows, and ends the span", async () => {
+    const boom: Error = new Error("async-span-boom");
+    const wrapped: (...args: Array<any>) => any = decorate(
+      undefined,
+      async (): Promise<never> => {
+        throw boom;
+      },
+    );
+
+    await expect(wrapped()).rejects.toBe(boom);
+    expect(recordExceptionMock).toHaveBeenCalledTimes(1);
+    expect(recordExceptionMock.mock.calls[0]![0]).toMatchObject({
+      exception: boom,
+    });
+    expect(fakeSpan.end).toHaveBeenCalledTimes(1);
+  });
+
+  test("sync failure records the exception and rethrows", () => {
+    const boom: Error = new Error("sync-span-boom");
+    const wrapped: (...args: Array<any>) => any = decorate(undefined, () => {
+      throw boom;
+    });
+
+    expect(() => {
+      return wrapped();
+    }).toThrow(boom);
+    expect(recordExceptionMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("export flag is consulted at call time, not decoration time", () => {
+  /*
+   * Decorators run at class-definition (import) time, long before
+   * Telemetry.init() installs an exporter and flips the flag. If the wrapper
+   * captured the flag when it was applied instead of reading it per call,
+   * every span in the process would be silently lost — decoration always
+   * happens while the flag is still false.
+   */
+  test("a method decorated before the exporter exists starts spanning once export turns on", () => {
+    const wrapped: (...args: Array<any>) => any = decorate(undefined, () => {
+      return "x";
+    });
+
+    expect(wrapped()).toBe("x");
+    expect(startActiveSpanMock).not.toHaveBeenCalled();
+
+    spanExportEnabled = true;
+    expect(wrapped()).toBe("x");
+    expect(startActiveSpanMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a method decorated while export was on drops to passthrough when it turns off", () => {
+    spanExportEnabled = true;
+    const wrapped: (...args: Array<any>) => any = decorate(undefined, () => {
+      return "y";
+    });
+
+    expect(wrapped()).toBe("y");
+    expect(startActiveSpanMock).toHaveBeenCalledTimes(1);
+
+    spanExportEnabled = false;
+    expect(wrapped()).toBe("y");
+    expect(startActiveSpanMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Telemetry.isSpanExportEnabled (real module)", () => {
+  test("defaults to false before init installs a trace exporter", () => {
+    const RealTelemetry: any = (
+      jest.requireActual("../../../Server/Utils/Telemetry") as any
+    ).default;
+
+    expect(RealTelemetry.isSpanExportEnabled()).toBe(false);
+  });
+});

--- a/Common/Tests/Utils/Telemetry/IngestionTimestamp.test.ts
+++ b/Common/Tests/Utils/Telemetry/IngestionTimestamp.test.ts
@@ -1,0 +1,170 @@
+import {
+  IngestionStamp,
+  getIngestionStamp,
+  getRetentionDateDb,
+} from "../../../Server/Utils/Telemetry/IngestionTimestamp";
+import OneUptimeDate from "../../../Types/Date";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * Minimal structural view of a jest spy — the @jest/globals and @types/jest
+ * spy types disagree in this repo, so annotate with just the surface this
+ * test reads.
+ */
+type SpyLike = {
+  mock: { calls: Array<Array<unknown>> };
+  mockRestore: () => void;
+};
+
+/*
+ * Contract under test — the per-second memo behind every ingested row's
+ * createdAt / retentionDate stamps.
+ *
+ * The Otel logs / traces / metrics row builders used to derive these per
+ * row (current Date + ClickHouse format + moment add-days + second format,
+ * per log record / span / metric datapoint). The memo must hand out values
+ * IDENTICAL to that per-row derivation — same second → same strings — and
+ * roll over crisply on the second boundary, or rows would carry stale
+ * createdAt / retention stamps.
+ */
+
+describe("getIngestionStamp", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("db string matches toClickhouseDateTime of the stamp's date", () => {
+    jest.setSystemTime(new Date("2026-08-10T13:45:59.700Z"));
+
+    const stamp: IngestionStamp = getIngestionStamp();
+
+    expect(stamp.db).toBe(OneUptimeDate.toClickhouseDateTime(stamp.date));
+    expect(stamp.db).toBe("2026-08-10 13:45:59");
+  });
+
+  test("date is truncated to the second", () => {
+    jest.setSystemTime(new Date("2026-08-10T13:45:59.999Z"));
+
+    const stamp: IngestionStamp = getIngestionStamp();
+
+    expect(stamp.date.getMilliseconds()).toBe(0);
+    expect(stamp.date.getTime()).toBe(
+      new Date("2026-08-10T13:45:59.000Z").getTime(),
+    );
+  });
+
+  test("same second returns the identical stamp object (memo hit)", () => {
+    jest.setSystemTime(new Date("2026-08-10T13:45:59.100Z"));
+    const first: IngestionStamp = getIngestionStamp();
+
+    jest.setSystemTime(new Date("2026-08-10T13:45:59.900Z"));
+    const second: IngestionStamp = getIngestionStamp();
+
+    expect(second).toBe(first);
+  });
+
+  test("rolls over when the second changes", () => {
+    jest.setSystemTime(new Date("2026-08-10T13:45:59.900Z"));
+    const first: IngestionStamp = getIngestionStamp();
+
+    jest.setSystemTime(new Date("2026-08-10T13:46:00.000Z"));
+    const second: IngestionStamp = getIngestionStamp();
+
+    expect(second).not.toBe(first);
+    expect(first.db).toBe("2026-08-10 13:45:59");
+    expect(second.db).toBe("2026-08-10 13:46:00");
+  });
+});
+
+describe("getRetentionDateDb", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-08-10T13:45:59.700Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("equals the per-row derivation it replaced (addRemoveDays + format)", () => {
+    const stamp: IngestionStamp = getIngestionStamp();
+
+    for (const days of [1, 15, 30, 90, 365]) {
+      expect(getRetentionDateDb(stamp, days)).toBe(
+        OneUptimeDate.toClickhouseDateTime(
+          OneUptimeDate.addRemoveDays(stamp.date, days),
+        ),
+      );
+    }
+  });
+
+  test("distinct retention windows produce distinct dates", () => {
+    const stamp: IngestionStamp = getIngestionStamp();
+
+    expect(getRetentionDateDb(stamp, 15)).toBe(
+      OneUptimeDate.toClickhouseDateTime(
+        OneUptimeDate.addRemoveDays(stamp.date, 15),
+      ),
+    );
+    expect(getRetentionDateDb(stamp, 30)).toBe(
+      OneUptimeDate.toClickhouseDateTime(
+        OneUptimeDate.addRemoveDays(stamp.date, 30),
+      ),
+    );
+    expect(getRetentionDateDb(stamp, 15)).not.toBe(
+      getRetentionDateDb(stamp, 30),
+    );
+  });
+
+  test("memoizes per retention window: addRemoveDays runs once per (second, days)", () => {
+    const stamp: IngestionStamp = getIngestionStamp();
+    const addRemoveDaysSpy: SpyLike = jest.spyOn(
+      OneUptimeDate,
+      "addRemoveDays",
+    ) as unknown as SpyLike;
+
+    const first: string = getRetentionDateDb(stamp, 15);
+    const callsAfterFirst: number = addRemoveDaysSpy.mock.calls.length;
+
+    for (let i: number = 0; i < 50; i++) {
+      expect(getRetentionDateDb(stamp, 15)).toBe(first);
+    }
+
+    expect(addRemoveDaysSpy.mock.calls.length).toBe(callsAfterFirst);
+    addRemoveDaysSpy.mockRestore();
+  });
+
+  test("stays consistent with the stamp's own second, not the current clock", () => {
+    const stamp: IngestionStamp = getIngestionStamp();
+    const expected: string = getRetentionDateDb(stamp, 15);
+
+    // Clock moves on; a held stamp must keep answering for ITS second.
+    jest.setSystemTime(new Date("2026-08-10T13:46:30.000Z"));
+
+    expect(getRetentionDateDb(stamp, 15)).toBe(expected);
+  });
+
+  test("computes correctly for a bare stamp that never went through the memo", () => {
+    const bareStamp: IngestionStamp = {
+      date: new Date("2026-01-01T00:00:00.000Z"),
+      db: "2026-01-01 00:00:00",
+    };
+
+    expect(getRetentionDateDb(bareStamp, 15)).toBe(
+      OneUptimeDate.toClickhouseDateTime(
+        OneUptimeDate.addRemoveDays(bareStamp.date, 15),
+      ),
+    );
+  });
+});

--- a/Common/Types/Date.ts
+++ b/Common/Types/Date.ts
@@ -476,7 +476,12 @@ export default class OneUptimeDate {
   }
 
   public static getCurrentDate(): Date {
-    return moment().toDate();
+    /*
+     * Not moment().toDate(): this is called on per-record telemetry ingest
+     * paths, and a moment wrapper allocation per call is pure overhead for
+     * what is exactly `new Date()`.
+     */
+    return new Date();
   }
 
   public static fromNow(date: Date): string {
@@ -2067,9 +2072,33 @@ export default class OneUptimeDate {
     return date;
   }
 
+  /*
+   * Hand-rolled UTC "YYYY-MM-DD HH:mm:ss" formatter. The two Clickhouse
+   * formatters below run several times per ingested log / span / metric
+   * datapoint — millions of calls per minute on a busy worker — and a
+   * moment() wrapper plus format-token parsing per call is roughly an order
+   * of magnitude more expensive than reading the UTC fields directly.
+   * Output is byte-identical to moment's, including the "Invalid date"
+   * sentinel for NaN dates.
+   */
+  private static formatUtcClickhouseDateTime(date: Date): string {
+    if (Number.isNaN(date.getTime())) {
+      return "Invalid date";
+    }
+
+    const year: string = String(date.getUTCFullYear()).padStart(4, "0");
+    const month: string = String(date.getUTCMonth() + 1).padStart(2, "0");
+    const day: string = String(date.getUTCDate()).padStart(2, "0");
+    const hours: string = String(date.getUTCHours()).padStart(2, "0");
+    const minutes: string = String(date.getUTCMinutes()).padStart(2, "0");
+    const seconds: string = String(date.getUTCSeconds()).padStart(2, "0");
+
+    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+  }
+
   public static toClickhouseDateTime(date: Date | string): string {
     const parsedDate: Date = this.fromString(date);
-    return moment(parsedDate).utc().format("YYYY-MM-DD HH:mm:ss");
+    return this.formatUtcClickhouseDateTime(parsedDate);
   }
 
   public static toClickhouseDateTime64(
@@ -2077,7 +2106,7 @@ export default class OneUptimeDate {
     nanoTimestamp?: number,
   ): string {
     const parsedDate: Date = this.fromString(date);
-    const base: string = moment(parsedDate).utc().format("YYYY-MM-DD HH:mm:ss");
+    const base: string = this.formatUtcClickhouseDateTime(parsedDate);
 
     let nanoFraction: string;
 

--- a/HelmChart/Public/oneuptime/templates/keda-scaledobjects.yaml
+++ b/HelmChart/Public/oneuptime/templates/keda-scaledobjects.yaml
@@ -18,7 +18,7 @@ KEDA ScaledObjects for various services
 {{- end }}
 
 {{/* App KEDA ScaledObject.
-     Combined (default) mode: scales on combined queue size (worker + workflow + telemetry + runbook).
+     Combined (default) mode: scales on combined queue backlog (waiting + delayed jobs across worker + workflow + telemetry + runbook).
      Split mode (worker.enabled): the worker deployment drains the queues, so the app must
      NOT scale on queue depth — its queue-size trigger is dropped and it scales on CPU/memory. */}}
 {{- if and .Values.keda.enabled .Values.app.enabled .Values.app.keda.enabled (not .Values.app.disableAutoscaler) (not .Values.deployment.disableDeployments) }}
@@ -42,7 +42,7 @@ KEDA ScaledObjects for various services
 {{- include "oneuptime.kedaScaledObject" $appKedaArgs }}
 {{- end }}
 
-{{/* Worker KEDA ScaledObject - scales the dedicated worker on combined queue size
+{{/* Worker KEDA ScaledObject - scales the dedicated worker on combined queue backlog (waiting + delayed)
      (worker + workflow + telemetry + runbook) plus optional CPU/memory utilization. KEDA scales
      to the max desired replicas across all triggers. */}}
 {{- if and .Values.keda.enabled .Values.worker.enabled .Values.worker.keda.enabled (not .Values.worker.disableAutoscaler) (not .Values.deployment.disableDeployments) }}

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -1478,7 +1478,7 @@ app:
     enabled: false
     minReplicas: 1
     maxReplicas: 100
-    # Scale up when combined queue size (worker + workflow + telemetry + runbook) exceeds this threshold
+    # Scale up when combined queue backlog (waiting + delayed jobs across worker + workflow + telemetry + runbook) exceeds this threshold
     queueSizeThreshold: 10
     # Scale up when average CPU utilization exceeds this percentage (0 to disable).
     # If enabled, app.resources.requests.cpu must also be set.
@@ -1568,12 +1568,17 @@ worker:
     enabled: false
     minReplicas: 1
     maxReplicas: 100
-    # /metrics/queue-size reports the GLOBAL queue total (worker + workflow +
-    # telemetry + runbook) and KEDA reads it as an AverageValue, so desired
-    # replicas = queueTotal / this value — it is a divisor over the fleet-wide
-    # total, not a per-pod trip point. The total counts delayed jobs, and every
-    # cron repeatable holds one, so it never falls to zero: set this high enough
-    # that the idle floor alone cannot pin the fleet at maxReplicas.
+    # /metrics/queue-size reports the GLOBAL queue backlog (waiting + delayed
+    # jobs across worker + workflow + telemetry + runbook) and KEDA reads it as
+    # an AverageValue, so desired replicas = backlog / this value — it is a
+    # divisor over the fleet-wide total, not a per-pod trip point. ACTIVE jobs
+    # are deliberately not counted: they are already being served, and telemetry
+    # jobs park in the active state for the fan-in writer's flush window while
+    # awaiting their ClickHouse ack, so counting them made the scaler read
+    # busy-but-healthy capacity as demand and overscale. The backlog still
+    # counts delayed jobs, and every cron repeatable holds one, so it never
+    # falls to zero: set this high enough that the idle floor alone cannot pin
+    # the fleet at maxReplicas.
     queueSizeThreshold: 25
     # Scale up when average CPU utilization exceeds this percentage (0 to disable).
     # If enabled, worker.resources.requests.cpu must also be set.


### PR DESCRIPTION
# perf(telemetry): Phase-1 worker-efficiency fixes from the ingest-path audit

Implements the "days"-tier roadmap items from the telemetry worker efficiency audit (multi-agent audit of the BullMQ → decode → transform → ClickHouse ingest path, run 2026-08-10 against `bea4f2ccfe`). The audit found the worker fleet scales out not because pods run out of CPU, but because the autoscaling metric counts parked jobs, and a large share of per-record CPU goes to self-instrumentation, moment.js, and per-row regex/date re-work. This PR lands the four highest-leverage fixes, each small and behavior-preserving.

## 1. KEDA scales on queue *backlog*, not queue *size*

Every high-volume telemetry job parks in the **active** state for the fan-in writer's full flush window (up to 5 s) while awaiting its ClickHouse ack. The `/metrics/queue-size` endpoints counted `waiting + active + delayed`, so the scaler read busy-but-healthy capacity as demand: the fleet converged on `jobRate × ackLatency` pods, and every new pod just parked more jobs — a positive feedback loop of idle pods.

- New `Queue.getQueueBacklogSize()` counts `waiting + delayed` only; `getQueueSize()` keeps the active-inclusive sum for ingest backpressure checks, where in-flight work genuinely counts against capacity.
- All three KEDA metrics endpoints converted: app (`App/API/Metrics.ts`), worker (`Workers/API/Metrics.ts`), and the telemetry-prefixed one (`Telemetry/API/Metrics.ts`).
- Helm chart comments updated to document the backlog semantics (no functional template change; thresholds unchanged).
- Priority is never set on enqueued jobs, so BullMQ v5's separate `prioritized` state cannot cause undercounting; cron repeatables still surface as `delayed`, preserving the documented idle floor.

## 2. `@CaptureSpan` exporter-gated; stripped from per-item helpers

The decorator previously built a full OTel span (attribute flattening, span allocation, AsyncLocalStorage context switch) on every call even when no exporter was installed — including `TelemetryUtil.getAttributes`, which runs per log record, span, span-event, and metric datapoint (~12 self-spans for a 10-event trace span, millions/min on a busy worker).

- `CaptureSpan` now short-circuits to a plain method call unless `Telemetry.isSpanExportEnabled()` (set by `init()` when a real OTLP span exporter is installed). The flag is consulted **at call time**, so spans appear the moment `init()` installs an exporter.
- Attribute flattening is skipped for the bare `@CaptureSpan()` form (no captured args, no static attributes) even when exporting.
- Removed `@CaptureSpan` from ~25 per-item helpers in `OtelIngestBaseService` and from `TelemetryUtil.getAttributes`, keeping spans at per-job/per-batch granularity.
- **Observability kept:** on non-exporting deployments the decorator's exception path used to be the only log line for some background-job failures. `QueueWorker` now attaches a `worker.on("failed")` listener that always logs failed jobs (queue, job name/id, error) to the container log, independent of telemetry configuration.

## 3. Per-row regex compilation removed from the hottest loops

- `LogFilterEvaluator`'s LIKE branch (shared by log and trace drop/pipeline filters) rebuilt its RegExp — three escape passes plus construction — per record, ignoring the `likeSubstring`/`likeRegex` fields that `compileExpr` had already populated. It now uses the precompiled forms, keeping the inline derivation only for uncompiled legacy ASTs.
- `MetricPipelineRuleService` compiled (and warn-logged invalid) regexes per metric datapoint. Patterns are now compiled once per process in a memo; an invalid pattern warns once (the message names the pattern and notes it applies to every rule using it) and is treated as non-matching.
- `attributeKeys` re-sorting by mutating pipeline rules is deferred: rules mark the row dirty and the sorted key list is rebuilt once per row after all rules ran, instead of once per mutating rule.

## 4. moment.js out of the timestamp hot path

- `toClickhouseDateTime`/`toClickhouseDateTime64` now use a hand-rolled UTC formatter (byte-identical output, including the `"Invalid date"` sentinel — pinned by a moment-oracle parity suite with a ±100-year fuzz sweep that runs under `TZ=America/New_York` so UTC-vs-local regressions can't hide). `getCurrentDate()` is `new Date()` instead of `moment().toDate()`.
- New `IngestionTimestamp` memo derives each row's `createdAt`/`retentionDate` strings once per second (and once per retention window within that second) instead of per log record / span / metric datapoint: previously a current-Date allocation, a ClickHouse format, a moment add-days, and a second format ran for every row.
- Dropped the `iso` field from metric timestamps — computed per datapoint, never read.

## Tests

Eight new suites (75 tests) pin the changes, with mutation guards for each optimization (call-count spies on `RegExp`/`sort`/date derivation, call-time flag flips for the exporter gate, warm-memo assertions), so quietly reverting any of them fails a test rather than a profile.

An adversarial multi-agent review (7 dimensions, every finding independently re-verified) ran over the final diff; all confirmed findings are addressed in this PR. `npm run compile` passes in App and Common; `npm run fix` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBmfRHY9RveCvWNhMo5z3n
