### PR TITLE
perf(telemetry): worker_threads decode pool (on by default, adaptive) + streamed ClickHouse insert bodies

### DIFF
--- a/App/FeatureSet/Telemetry/Config.ts
+++ b/App/FeatureSet/Telemetry/Config.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_SESSION_REPLAY_MAX_BYTES_PER_PROJECT_PER_DAY } from "Common/Types/Rum/SessionReplay";
+import CpuCount from "Common/Server/Utils/CpuCount";
 
 let concurrency: string | number = process.env["TELEMETRY_CONCURRENCY"] || 100;
 
@@ -33,9 +34,12 @@ const parseBatchSize: ParseBatchSizeFunction = (
 /*
  * Like parseBatchSize, but 0 is a VALID value rather than "fall back to
  * the default". Needed for knobs where 0 is a meaningful setting —
- * TELEMETRY_DECODE_THREADS uses 0 for "pool disabled" (which is also
- * its default), so the strictly-positive parser above would make the
- * feature impossible to turn off explicitly.
+ * TELEMETRY_DECODE_THREADS uses 0 for "pool hard-disabled", so the
+ * strictly-positive parser above would make the feature impossible to
+ * turn off explicitly. Invalid values (negatives, garbage) fall back to
+ * the DEFAULT, which for TELEMETRY_DECODE_THREADS is the adaptive count
+ * below — deliberately NOT 0, because an operator typo in an override
+ * must not silently disable a default-on subsystem.
  */
 type ParseNonNegativeSizeFunction = (
   envKey: string,
@@ -66,16 +70,44 @@ const parseNonNegativeSize: ParseNonNegativeSizeFunction = (
  * toJSON for OTel ingest payloads off the main event loop (see
  * Utils/DecodeThreadPool.ts).
  *
- * Defaults to 0 = DISABLED: with 0 threads the pool never starts and
- * OtelPayloadDecoder decodes inline on the main thread — exactly the
- * pre-pool behavior. The feature is opt-in per deployment because
- * worker threads cost real memory (each thread is a full V8 isolate
- * with its own ts-node + protobufjs load) and only pay off on pods that
- * actually see large payloads.
+ * DEFAULT (env unset): ADAPTIVE — clamp(effectiveCpuCount - 1, 0, 4):
+ *
+ *   effective CPUs   decode threads
+ *   1                0  (pool off — inline decode, the pre-pool behavior;
+ *                        a 1-CPU pod has no spare core to give)
+ *   2                1
+ *   3                2
+ *   4                3
+ *   >= 5             4  (cap)
+ *
+ * One core is always reserved for the main event loop (the pool exists
+ * to PROTECT the loop; letting decode threads compete with it for the
+ * last core would recreate the very throttling it prevents). The cap of
+ * 4 bounds per-pod memory: each thread is a full V8 isolate with its
+ * own ts-node + protobufjs load, so the pool costs real RSS per thread.
+ *
+ * effectiveCpuCount is CGROUP-AWARE (Common/Server/Utils/CpuCount):
+ * Node's os.availableParallelism()/os.cpus() report HOST cores, but a
+ * Kubernetes pod under a CPU limit only gets quota/period of that —
+ * sizing from the host count would oversubscribe a small pod on a big
+ * node.
+ *
+ * Threads spawn LAZILY on the first payload that qualifies for the pool
+ * (>= TELEMETRY_DECODE_MIN_PAYLOAD_BYTES), so idle and non-telemetry
+ * deployments pay nothing for this default being on.
+ *
+ * An explicit env value always wins: 0 hard-disables the pool, a
+ * positive integer pins the exact thread count. Invalid values fall
+ * back to the ADAPTIVE default (see parseNonNegativeSize's comment).
  */
+const ADAPTIVE_DECODE_THREADS: number = Math.min(
+  4,
+  Math.max(0, CpuCount.getEffectiveCpuCount() - 1),
+);
+
 export const TELEMETRY_DECODE_THREADS: number = parseNonNegativeSize(
   "TELEMETRY_DECODE_THREADS",
-  0,
+  ADAPTIVE_DECODE_THREADS,
 );
 
 /*

--- a/App/FeatureSet/Telemetry/Config.ts
+++ b/App/FeatureSet/Telemetry/Config.ts
@@ -30,6 +30,71 @@ const parseBatchSize: ParseBatchSizeFunction = (
   return parsed;
 };
 
+/*
+ * Like parseBatchSize, but 0 is a VALID value rather than "fall back to
+ * the default". Needed for knobs where 0 is a meaningful setting —
+ * TELEMETRY_DECODE_THREADS uses 0 for "pool disabled" (which is also
+ * its default), so the strictly-positive parser above would make the
+ * feature impossible to turn off explicitly.
+ */
+type ParseNonNegativeSizeFunction = (
+  envKey: string,
+  defaultValue: number,
+) => number;
+
+const parseNonNegativeSize: ParseNonNegativeSizeFunction = (
+  envKey: string,
+  defaultValue: number,
+): number => {
+  const value: string | undefined = process.env[envKey];
+
+  if (!value) {
+    return defaultValue;
+  }
+
+  const parsed: number = parseInt(value, 10);
+
+  if (isNaN(parsed) || parsed < 0) {
+    return defaultValue;
+  }
+
+  return parsed;
+};
+
+/*
+ * Size of the worker-thread pool that runs gunzip + protobuf decode +
+ * toJSON for OTel ingest payloads off the main event loop (see
+ * Utils/DecodeThreadPool.ts).
+ *
+ * Defaults to 0 = DISABLED: with 0 threads the pool never starts and
+ * OtelPayloadDecoder decodes inline on the main thread — exactly the
+ * pre-pool behavior. The feature is opt-in per deployment because
+ * worker threads cost real memory (each thread is a full V8 isolate
+ * with its own ts-node + protobufjs load) and only pay off on pods that
+ * actually see large payloads.
+ */
+export const TELEMETRY_DECODE_THREADS: number = parseNonNegativeSize(
+  "TELEMETRY_DECODE_THREADS",
+  0,
+);
+
+/*
+ * Payloads smaller than this (in raw bytes, as stored — i.e. still
+ * compressed when the sender gzipped) are decoded inline even when the
+ * pool is enabled: below roughly this size the fixed cost of the
+ * thread handoff (one payload memcpy on the main thread + structured
+ * clone of the decoded JSON on the way back + scheduling latency)
+ * exceeds the decode CPU we would be moving off-loop. 8 KiB is a
+ * judgment default, not a measured constant — it is env-overridable so
+ * deployments can tune the crossover for their traffic shape. 0 means
+ * "no minimum, route everything to the pool" (useful for testing),
+ * which is why this uses the 0-permitting parser.
+ */
+export const TELEMETRY_DECODE_MIN_PAYLOAD_BYTES: number = parseNonNegativeSize(
+  "TELEMETRY_DECODE_MIN_PAYLOAD_BYTES",
+  8192,
+);
+
 export const TELEMETRY_LOG_FLUSH_BATCH_SIZE: number = parseBatchSize(
   "TELEMETRY_LOG_FLUSH_BATCH_SIZE",
   1000,

--- a/App/FeatureSet/Telemetry/Utils/DecodeThreadPool.ts
+++ b/App/FeatureSet/Telemetry/Utils/DecodeThreadPool.ts
@@ -24,9 +24,13 @@ import { TELEMETRY_DECODE_THREADS } from "../Config";
  * CPU onto worker_threads so the main loop only pays a memcpy + message
  * hop per payload.
  *
- * SHIPPED DISABLED: TELEMETRY_DECODE_THREADS defaults to 0, in which
- * case this pool never starts a thread and decodeFromQueue takes the
- * inline path — byte-for-byte the pre-pool behavior.
+ * ENABLED BY DEFAULT, ADAPTIVELY SIZED: TELEMETRY_DECODE_THREADS
+ * defaults to clamp(effectiveCpuCount - 1, 0, 4), cgroup-aware — see
+ * Config.ts for the full sizing table and rationale. On a 1-effective-
+ * CPU pod (or with an explicit TELEMETRY_DECODE_THREADS=0, the hard-off
+ * switch) that resolves to 0: the pool never starts a thread and
+ * decodeFromQueue takes the inline path — byte-for-byte the pre-pool
+ * behavior.
  *
  * Runtime/loading model: the app runs through ts-node in BOTH dev and
  * prod (nodemon dev exec and the prod `npm start` both `-r ts-node/
@@ -621,10 +625,11 @@ export class TelemetryDecodeThreadPool {
 /*
  * Process-wide facade: the lazy singleton that production code
  * (OtelPayloadDecoder.decodeFromQueue) talks to. Sized by
- * TELEMETRY_DECODE_THREADS; with the default of 0 the singleton is
- * never constructed and no thread ever starts. Tests construct
- * TelemetryDecodeThreadPool instances directly instead, so they control
- * pool size without touching env/Config.
+ * TELEMETRY_DECODE_THREADS (adaptive by default — see Config.ts); when
+ * that resolves to 0 (a 1-effective-CPU pod, or an explicit 0) the
+ * singleton is never constructed and no thread ever starts. Tests
+ * construct TelemetryDecodeThreadPool instances directly instead, so
+ * they control pool size without touching env/Config.
  */
 export default class DecodeThreadPool {
   private static instance: TelemetryDecodeThreadPool | null = null;
@@ -652,7 +657,7 @@ export default class DecodeThreadPool {
     if (!this.isEnabled()) {
       return Promise.reject(
         buildRetryableError(
-          "pool is disabled (TELEMETRY_DECODE_THREADS=0); caller should have routed inline",
+          "pool is disabled (TELEMETRY_DECODE_THREADS resolved to 0); caller should have routed inline",
         ),
       );
     }

--- a/App/FeatureSet/Telemetry/Utils/DecodeThreadPool.ts
+++ b/App/FeatureSet/Telemetry/Utils/DecodeThreadPool.ts
@@ -1,0 +1,708 @@
+import { Worker } from "worker_threads";
+import path from "path";
+import { JSONObject } from "Common/Types/JSON";
+import ProductType from "Common/Types/MeteredPlan/ProductType";
+import logger from "Common/Server/Utils/Logger";
+import GracefulShutdown, {
+  ShutdownPriority,
+} from "Common/Server/Utils/GracefulShutdown";
+import { OtelPayloadEncoding, OtelPayloadFormat } from "./OtelDecode";
+import {
+  DecodeRequestMessage,
+  DecodeResponseMessage,
+} from "./DecodeWorkerThread";
+import { TELEMETRY_DECODE_THREADS } from "../Config";
+
+/*
+ * Worker-thread pool for OTel payload decoding.
+ *
+ * gunzip inflate + protobuf decode + `.toJSON()` of a large telemetry
+ * batch is tens-to-hundreds of milliseconds of UNBROKEN synchronous CPU
+ * on the BullMQ worker's event loop. With TELEMETRY_CONCURRENCY jobs in
+ * flight that sync burn serializes everything else on the loop (queue
+ * heartbeats, Redis pings, fan-in flush timers). This pool moves that
+ * CPU onto worker_threads so the main loop only pays a memcpy + message
+ * hop per payload.
+ *
+ * SHIPPED DISABLED: TELEMETRY_DECODE_THREADS defaults to 0, in which
+ * case this pool never starts a thread and decodeFromQueue takes the
+ * inline path — byte-for-byte the pre-pool behavior.
+ *
+ * Runtime/loading model: the app runs through ts-node in BOTH dev and
+ * prod (nodemon dev exec and the prod `npm start` both `-r ts-node/
+ * register`), so the worker entry is the DecodeWorkerThread.ts SOURCE
+ * file, loaded with an explicit `-r ts-node/register/transpile-only`
+ * in execArgv. Explicit rather than inherited, because the spawning
+ * process is not always ts-node-registered (jest/ts-jest is not) — the
+ * explicit execArgv is what lets tests spawn REAL threads. Note that
+ * `--no-node-snapshot` (which the main process runs with) is NOT passed:
+ * Node rejects it in worker execArgv ("invalid execArgv flags") because
+ * it is a process-level flag; workers share the main process's snapshot
+ * state anyway.
+ *
+ * Concurrency/backpressure model: one in-flight request per thread and
+ * a FIFO pending queue with NO cap of its own — outstanding decode
+ * requests are already bounded by TELEMETRY_CONCURRENCY (the BullMQ
+ * worker concurrency, 100 by default), because each request belongs to
+ * exactly one in-flight job.
+ */
+
+export interface DecodeInput {
+  productType: ProductType;
+  format: OtelPayloadFormat;
+  encoding: OtelPayloadEncoding;
+  body: Buffer;
+}
+
+export interface DecodeThreadPoolStats {
+  threadsAlive: number;
+  inFlight: number;
+  queued: number;
+  healthy: boolean;
+}
+
+export interface DecodeThreadPoolOptions {
+  threadCount: number;
+  /*
+   * Failure-guard knobs. Overridable primarily for tests; production
+   * uses the defaults below.
+   */
+  maxConsecutiveThreadFailures?: number;
+  threadFailureWindowMs?: number;
+  unhealthyCooldownMs?: number;
+  shutdownDrainTimeoutMs?: number;
+}
+
+interface PendingRequest {
+  id: number;
+  message: DecodeRequestMessage;
+  transferList: Array<ArrayBuffer>;
+  resolve: (result: JSONObject) => void;
+  reject: (error: Error) => void;
+}
+
+interface PoolThread {
+  worker: Worker;
+  inFlightRequest: PendingRequest | null;
+}
+
+/*
+ * Every rejection this pool emits is RETRYABLE BY DESIGN: the caller is
+ * a BullMQ job handler, and any error thrown from a job triggers the
+ * queue's normal retry/backoff — on the retry the routing layer
+ * re-evaluates pool health and falls back to the inline decoder if the
+ * pool has been marked unhealthy in the meantime. The stable prefix
+ * makes these rejections greppable in job-failure logs.
+ */
+const RETRYABLE_MESSAGE_PREFIX: string = "TelemetryDecodeThreadPool";
+
+function buildRetryableError(detail: string): Error {
+  return new Error(
+    `${RETRYABLE_MESSAGE_PREFIX}: ${detail} (the job queue will retry this job; the retry decodes inline if the pool is unavailable)`,
+  );
+}
+
+export class TelemetryDecodeThreadPool {
+  private options: Required<DecodeThreadPoolOptions>;
+  private threads: Array<PoolThread> = [];
+  private pendingQueue: Array<PendingRequest> = [];
+  /*
+   * Monotonic id counter for request/response correlation. A plain
+   * counter (not Date.now()) because two requests dispatched in the
+   * same millisecond must never share an id.
+   */
+  private nextRequestId: number = 1;
+  private shuttingDown: boolean = false;
+  private healthy: boolean = true;
+  private consecutiveThreadFailures: number = 0;
+  private lastThreadFailureAtMs: number = 0;
+  private unhealthyUntilMs: number = 0;
+
+  public constructor(options: DecodeThreadPoolOptions) {
+    if (options.threadCount <= 0) {
+      throw new Error(
+        "TelemetryDecodeThreadPool: threadCount must be > 0 (a disabled pool is simply never constructed)",
+      );
+    }
+
+    this.options = {
+      threadCount: options.threadCount,
+      /*
+       * Respawn-storm guard defaults: 5 thread failures within a
+       * rolling 30s window (e.g. the worker entry file failing to
+       * compile, or threads OOMing instantly) marks the pool unhealthy
+       * for 60s. While unhealthy, isAccepting() is false, so the
+       * routing layer decodes inline — degraded latency, but ingest
+       * keeps flowing instead of burning CPU on spawn/crash cycles.
+       */
+      maxConsecutiveThreadFailures: options.maxConsecutiveThreadFailures ?? 5,
+      threadFailureWindowMs: options.threadFailureWindowMs ?? 30_000,
+      unhealthyCooldownMs: options.unhealthyCooldownMs ?? 60_000,
+      /*
+       * Shutdown drain budget. Must stay comfortably under
+       * GracefulShutdown's 10s per-handler timeout.
+       */
+      shutdownDrainTimeoutMs: options.shutdownDrainTimeoutMs ?? 5_000,
+    };
+  }
+
+  /*
+   * Whether this pool should be handed new work. False while shutting
+   * down and while in the unhealthy cooldown; flips back to true (with
+   * counters reset and threads respawned lazily) once the cooldown
+   * elapses and the next decode() arrives.
+   */
+  public isAccepting(): boolean {
+    if (this.shuttingDown) {
+      return false;
+    }
+    if (this.healthy) {
+      return true;
+    }
+    return Date.now() >= this.unhealthyUntilMs;
+  }
+
+  public decode(input: DecodeInput): Promise<JSONObject> {
+    if (this.shuttingDown) {
+      return Promise.reject(buildRetryableError("pool is shutting down"));
+    }
+
+    if (!this.healthy) {
+      if (Date.now() < this.unhealthyUntilMs) {
+        /*
+         * Callers are expected to check isAccepting() before calling,
+         * but the state can flip between check and call — reject
+         * (retryably) rather than queue onto a pool with no threads.
+         */
+        return Promise.reject(
+          buildRetryableError("pool is unhealthy (in cooldown)"),
+        );
+      }
+      // Cooldown elapsed — recover: reset counters, respawn below.
+      this.healthy = true;
+      this.consecutiveThreadFailures = 0;
+    }
+
+    this.ensureThreadsSpawned();
+
+    if (this.threads.length === 0) {
+      // ensureThreadsSpawned failed synchronously and marked us unhealthy.
+      return Promise.reject(
+        buildRetryableError("no decode threads could be spawned"),
+      );
+    }
+
+    /*
+     * Copy the payload into a FRESH ArrayBuffer and transfer that.
+     *
+     * WHY THE COPY: transferring detaches the ENTIRE underlying
+     * ArrayBuffer, and the caller's Buffer is not guaranteed to own its
+     * ArrayBuffer — ioredis result Buffers (and any Buffer.allocUnsafe
+     * product) can be views on Node's shared Buffer pool slab, so
+     * transferring `input.body.buffer` would detach unrelated data that
+     * happens to live on the same slab (and corrupt the caller's Buffer
+     * besides). One explicit memcpy on the main thread is the price of
+     * a zero-copy handoff into the worker; the decode itself (the
+     * expensive part) then runs entirely off-loop.
+     */
+    const transferable: ArrayBuffer = new ArrayBuffer(input.body.length);
+    new Uint8Array(transferable).set(input.body as unknown as Uint8Array);
+
+    const requestId: number = this.nextRequestId;
+    this.nextRequestId += 1;
+
+    return new Promise<JSONObject>(
+      (
+        resolve: (result: JSONObject) => void,
+        reject: (error: Error) => void,
+      ) => {
+        const request: PendingRequest = {
+          id: requestId,
+          message: {
+            id: requestId,
+            productType: input.productType,
+            format: input.format,
+            encoding: input.encoding,
+            payload: transferable,
+          },
+          transferList: [transferable],
+          resolve: resolve,
+          reject: reject,
+        };
+
+        // FIFO admission: enqueue at the tail, pump dispatches from the head.
+        this.pendingQueue.push(request);
+        this.pump();
+      },
+    );
+  }
+
+  public getStats(): DecodeThreadPoolStats {
+    return {
+      threadsAlive: this.threads.length,
+      inFlight: this.threads.filter((thread: PoolThread) => {
+        return thread.inFlightRequest !== null;
+      }).length,
+      queued: this.pendingQueue.length,
+      healthy: this.healthy,
+    };
+  }
+
+  /*
+   * Test hook: expose the live Worker handles so lifecycle tests can
+   * kill a busy thread with worker.terminate() and assert the pool's
+   * reject-and-respawn behavior. Not for production use.
+   */
+  public getWorkerThreadsForTesting(): Array<Worker> {
+    return this.threads.map((thread: PoolThread) => {
+      return thread.worker;
+    });
+  }
+
+  /*
+   * Graceful shutdown: stop accepting, give in-flight decodes a short
+   * drain window (they feed jobs that the Workers tier is still
+   * draining — see the priority-tier discussion in DecodeThreadPool's
+   * facade below), then terminate every thread. Idempotent.
+   */
+  public async shutdown(): Promise<void> {
+    if (this.shuttingDown) {
+      return;
+    }
+    this.shuttingDown = true;
+
+    /*
+     * Queued-but-not-dispatched requests will never run — reject them
+     * now (retryably) instead of leaving their jobs to hang into the
+     * BullMQ lock timeout.
+     */
+    const queuedRequests: Array<PendingRequest> = this.pendingQueue;
+    this.pendingQueue = [];
+    for (const request of queuedRequests) {
+      request.reject(buildRetryableError("pool shut down before dispatch"));
+    }
+
+    // Brief drain: let dispatched decodes finish feeding their jobs.
+    const drainDeadlineMs: number =
+      Date.now() + this.options.shutdownDrainTimeoutMs;
+    while (this.getStats().inFlight > 0 && Date.now() < drainDeadlineMs) {
+      await new Promise<void>((resolve: () => void) => {
+        setTimeout(resolve, 25);
+      });
+    }
+
+    /*
+     * Detach the thread records BEFORE terminating so the 'exit'
+     * handlers see an already-emptied pool and do not count these
+     * deliberate terminations as failures (or attempt respawns).
+     */
+    const threadsToTerminate: Array<PoolThread> = this.threads;
+    this.threads = [];
+
+    for (const thread of threadsToTerminate) {
+      if (thread.inFlightRequest) {
+        thread.inFlightRequest.reject(
+          buildRetryableError("decode was still in flight at shutdown"),
+        );
+        thread.inFlightRequest = null;
+      }
+    }
+
+    await Promise.all(
+      threadsToTerminate.map((thread: PoolThread) => {
+        return thread.worker.terminate().catch((err: Error) => {
+          logger.warn("TelemetryDecodeThreadPool: terminate() failed:");
+          logger.warn(err);
+        });
+      }),
+    );
+  }
+
+  /*
+   * Spawn up to threadCount threads. Idempotent — called on every
+   * decode() so a pool recovering from cooldown (or one that lost a
+   * thread to a synchronous spawn failure) heals lazily.
+   */
+  private ensureThreadsSpawned(): void {
+    while (
+      this.threads.length < this.options.threadCount &&
+      this.healthy &&
+      !this.shuttingDown
+    ) {
+      this.spawnThread();
+    }
+  }
+
+  private spawnThread(): void {
+    /*
+     * The worker entry lives next to this file. Under ts-node and
+     * ts-jest, __filename is the .ts source path, so the entry is the
+     * .ts file and needs the ts-node register hook; if this code is
+     * ever run precompiled (__filename ends in .js), spawn the compiled
+     * neighbor with no extra execArgv instead.
+     */
+    const entryExtension: string = path.extname(__filename);
+    const workerEntryPath: string = path.join(
+      __dirname,
+      `DecodeWorkerThread${entryExtension}`,
+    );
+
+    /*
+     * require.resolve rather than the bare "ts-node/register/..."
+     * specifier: node resolves `--require` relative to the process
+     * CWD, which is the App directory in every normal run but is not
+     * something a library should depend on. Resolving from THIS file's
+     * location pins it to App/node_modules/ts-node regardless of CWD.
+     */
+    const execArgv: Array<string> =
+      entryExtension === ".ts"
+        ? ["-r", require.resolve("ts-node/register/transpile-only")]
+        : [];
+
+    /*
+     * TS_NODE_PROJECT pins the worker's ts-node to App's tsconfig for
+     * the same CWD-independence reason (ts-node searches from CWD by
+     * default). __dirname is App/FeatureSet/Telemetry/Utils, so App's
+     * root is three levels up.
+     */
+    const appTsconfigPath: string = path.resolve(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "tsconfig.json",
+    );
+
+    try {
+      const worker: Worker = new Worker(workerEntryPath, {
+        execArgv: execArgv,
+        env: {
+          ...process.env,
+          TS_NODE_PROJECT: appTsconfigPath,
+        },
+      });
+
+      const thread: PoolThread = {
+        worker: worker,
+        inFlightRequest: null,
+      };
+
+      worker.on("message", (response: DecodeResponseMessage) => {
+        this.onThreadMessage(thread, response);
+      });
+      worker.on("error", (error: Error) => {
+        this.onThreadFailure(thread, `thread error: ${error.message}`);
+      });
+      worker.on("exit", (code: number) => {
+        this.onThreadFailure(thread, `thread exited with code ${code}`);
+      });
+
+      this.threads.push(thread);
+    } catch (err) {
+      /*
+       * A synchronous Worker-constructor failure (bad execArgv, missing
+       * entry file) will fail identically on every attempt — do NOT
+       * retry in a loop here. Route it through the same failure counter
+       * as async thread deaths; repeated failures trip the unhealthy
+       * breaker below and callers fall back inline.
+       */
+      logger.error("TelemetryDecodeThreadPool: failed to spawn thread:");
+      logger.error(err);
+      this.recordThreadFailure();
+      if (this.healthy) {
+        /*
+         * Not tripped yet, but spawning is clearly broken right now —
+         * mark unhealthy immediately rather than letting every decode()
+         * call re-attempt a doomed synchronous spawn loop.
+         */
+        this.markUnhealthy("worker thread spawn failed synchronously");
+      }
+    }
+  }
+
+  private onThreadMessage(
+    thread: PoolThread,
+    response: DecodeResponseMessage,
+  ): void {
+    const request: PendingRequest | null = thread.inFlightRequest;
+
+    if (!request || request.id !== response.id) {
+      /*
+       * Protocol violation — a response we have no matching request
+       * for. Should be impossible with one in-flight per thread and
+       * monotonic ids; log loudly, and if something WAS in flight on
+       * this thread, fail it (retryably) rather than leaving its job
+       * to hang until the BullMQ lock timeout.
+       */
+      logger.error(
+        `TelemetryDecodeThreadPool: response id ${response.id} does not match in-flight request ${request ? request.id : "<none>"}. Dropping response.`,
+      );
+      if (request) {
+        thread.inFlightRequest = null;
+        request.reject(
+          buildRetryableError("request/response id correlation lost"),
+        );
+        this.pump();
+      }
+      return;
+    }
+
+    thread.inFlightRequest = null;
+
+    /*
+     * Any well-formed response — success OR a per-message decode error
+     * — proves the thread itself is alive and orderly, so it resets the
+     * consecutive-failure breaker.
+     */
+    this.consecutiveThreadFailures = 0;
+
+    if (response.ok) {
+      request.resolve(response.result);
+    } else {
+      /*
+       * Per-message failure (malformed gzip/protobuf/JSON): reject ONLY
+       * this request with the worker's error; the thread stays in the
+       * pool. Mirrors what the inline decoder would have thrown.
+       */
+      const error: Error = new Error(response.errorMessage);
+      if (response.errorStack) {
+        error.stack = response.errorStack;
+      }
+      request.reject(error);
+    }
+
+    this.pump();
+  }
+
+  /*
+   * A thread died ('error' or unexpected 'exit'). Rejects ONLY that
+   * thread's in-flight request (retryably — the job layer retries),
+   * respawns a replacement, and trips the unhealthy breaker if deaths
+   * keep coming.
+   *
+   * 'error' and 'exit' both fire for one crash; the first call removes
+   * the thread record from `this.threads`, so the second (and any exit
+   * from a deliberate terminate() in shutdown/markUnhealthy) finds the
+   * record already gone and returns without double-handling.
+   */
+  private onThreadFailure(thread: PoolThread, detail: string): void {
+    const threadIndex: number = this.threads.indexOf(thread);
+    if (threadIndex < 0) {
+      return; // Already handled, or a deliberate termination.
+    }
+    this.threads.splice(threadIndex, 1);
+
+    const request: PendingRequest | null = thread.inFlightRequest;
+    thread.inFlightRequest = null;
+    if (request) {
+      request.reject(
+        buildRetryableError(`decode aborted by thread death (${detail})`),
+      );
+    }
+
+    logger.warn(`TelemetryDecodeThreadPool: ${detail}.`);
+
+    this.recordThreadFailure();
+    if (
+      this.consecutiveThreadFailures >=
+      this.options.maxConsecutiveThreadFailures
+    ) {
+      this.markUnhealthy(
+        `${this.consecutiveThreadFailures} thread failures within ${this.options.threadFailureWindowMs}ms`,
+      );
+      return;
+    }
+
+    if (!this.shuttingDown) {
+      // Respawn a replacement and keep draining the queue.
+      this.ensureThreadsSpawned();
+      this.pump();
+    }
+  }
+
+  /*
+   * Rolling-window consecutive-failure counter: failures further apart
+   * than the window are treated as isolated (counter restarts), so an
+   * occasional crash every few minutes never trips the breaker — only
+   * a rapid crash loop does.
+   */
+  private recordThreadFailure(): void {
+    const nowMs: number = Date.now();
+    if (
+      nowMs - this.lastThreadFailureAtMs >
+      this.options.threadFailureWindowMs
+    ) {
+      this.consecutiveThreadFailures = 0;
+    }
+    this.lastThreadFailureAtMs = nowMs;
+    this.consecutiveThreadFailures += 1;
+  }
+
+  /*
+   * Trip the breaker: reject everything (retryably), tear down any
+   * surviving threads, and refuse work until the cooldown elapses.
+   * Logged ONCE per transition — this runs during crash loops, and a
+   * log line per crashed spawn would itself be a storm.
+   */
+  private markUnhealthy(reason: string): void {
+    if (!this.healthy) {
+      return;
+    }
+    this.healthy = false;
+    this.unhealthyUntilMs = Date.now() + this.options.unhealthyCooldownMs;
+
+    logger.error(
+      `TelemetryDecodeThreadPool: marking pool UNHEALTHY (${reason}). Falling back to inline decoding for ${this.options.unhealthyCooldownMs}ms.`,
+    );
+
+    const queuedRequests: Array<PendingRequest> = this.pendingQueue;
+    this.pendingQueue = [];
+    for (const request of queuedRequests) {
+      request.reject(buildRetryableError(`pool marked unhealthy (${reason})`));
+    }
+
+    const threadsToTerminate: Array<PoolThread> = this.threads;
+    this.threads = []; // Exit handlers of terminated threads become no-ops.
+    for (const thread of threadsToTerminate) {
+      if (thread.inFlightRequest) {
+        thread.inFlightRequest.reject(
+          buildRetryableError(`pool marked unhealthy (${reason})`),
+        );
+        thread.inFlightRequest = null;
+      }
+      thread.worker.terminate().catch((err: Error) => {
+        logger.warn("TelemetryDecodeThreadPool: terminate() failed:");
+        logger.warn(err);
+      });
+    }
+  }
+
+  /*
+   * Dispatch loop: hand the head of the FIFO queue to each idle thread.
+   * Runs after every enqueue, completion, and respawn; one in-flight
+   * request per thread, always.
+   */
+  private pump(): void {
+    if (this.shuttingDown) {
+      return;
+    }
+
+    for (const thread of this.threads) {
+      if (this.pendingQueue.length === 0) {
+        return;
+      }
+      if (thread.inFlightRequest !== null) {
+        continue;
+      }
+
+      const request: PendingRequest =
+        this.pendingQueue.shift() as PendingRequest;
+      thread.inFlightRequest = request;
+
+      try {
+        thread.worker.postMessage(request.message, request.transferList);
+      } catch (err) {
+        /*
+         * postMessage can throw synchronously (e.g. the ArrayBuffer was
+         * somehow already detached). That is a per-request failure, not
+         * a thread failure.
+         */
+        thread.inFlightRequest = null;
+        const error: Error =
+          err instanceof Error ? err : new Error(String(err));
+        request.reject(
+          buildRetryableError(`failed to dispatch to thread: ${error.message}`),
+        );
+      }
+    }
+  }
+}
+
+/*
+ * Process-wide facade: the lazy singleton that production code
+ * (OtelPayloadDecoder.decodeFromQueue) talks to. Sized by
+ * TELEMETRY_DECODE_THREADS; with the default of 0 the singleton is
+ * never constructed and no thread ever starts. Tests construct
+ * TelemetryDecodeThreadPool instances directly instead, so they control
+ * pool size without touching env/Config.
+ */
+export default class DecodeThreadPool {
+  private static instance: TelemetryDecodeThreadPool | null = null;
+
+  public static isEnabled(): boolean {
+    return TELEMETRY_DECODE_THREADS > 0;
+  }
+
+  /*
+   * The routing gate for decodeFromQueue: enabled AND (not yet started,
+   * which means the first decode will lazily start it) or started-and-
+   * accepting (healthy / out of cooldown, not shutting down).
+   */
+  public static isAvailable(): boolean {
+    if (!this.isEnabled()) {
+      return false;
+    }
+    if (!this.instance) {
+      return true;
+    }
+    return this.instance.isAccepting();
+  }
+
+  public static decode(input: DecodeInput): Promise<JSONObject> {
+    if (!this.isEnabled()) {
+      return Promise.reject(
+        buildRetryableError(
+          "pool is disabled (TELEMETRY_DECODE_THREADS=0); caller should have routed inline",
+        ),
+      );
+    }
+
+    if (!this.instance) {
+      this.instance = new TelemetryDecodeThreadPool({
+        threadCount: TELEMETRY_DECODE_THREADS,
+      });
+
+      /*
+       * Shutdown tier choice — Buffers (30), NOT Workers (20):
+       * GracefulShutdown runs tiers in ascending order, and the Workers
+       * tier (20) is where the BullMQ workers stop pulling NEW jobs and
+       * finish their in-flight ones — in-flight jobs may be awaiting a
+       * decode from this pool, so the pool must still be serving while
+       * tier 20 drains. Buffers (30) runs after that drain completes,
+       * alongside the write-buffer flushes (e.g. TelemetryFanInWriter),
+       * which consume decode OUTPUT but never call the pool — so by
+       * this tier the pool should be idle, and shutdown() only has to
+       * cover the stragglers (brief drain, then terminate). Registered
+       * here (first construction) rather than at module load so that
+       * merely importing this module never installs signal handlers.
+       */
+      GracefulShutdown.registerHandler(
+        "TelemetryDecodeThreadPool",
+        ShutdownPriority.Buffers,
+        async () => {
+          if (this.instance) {
+            await this.instance.shutdown();
+          }
+        },
+      );
+
+      logger.info(
+        `TelemetryDecodeThreadPool: enabled with ${TELEMETRY_DECODE_THREADS} thread(s).`,
+      );
+    }
+
+    return this.instance.decode(input);
+  }
+
+  public static getStats(): DecodeThreadPoolStats {
+    if (!this.instance) {
+      return {
+        threadsAlive: 0,
+        inFlight: 0,
+        queued: 0,
+        healthy: this.isEnabled(),
+      };
+    }
+    return this.instance.getStats();
+  }
+}

--- a/App/FeatureSet/Telemetry/Utils/DecodeWorkerThread.ts
+++ b/App/FeatureSet/Telemetry/Utils/DecodeWorkerThread.ts
@@ -1,0 +1,106 @@
+import { isMainThread, parentPort, MessagePort } from "worker_threads";
+import OtelDecode, {
+  OtelPayloadEncoding,
+  OtelPayloadFormat,
+} from "./OtelDecode";
+import { JSONObject } from "Common/Types/JSON";
+import ProductType from "Common/Types/MeteredPlan/ProductType";
+
+/*
+ * Worker-thread entry point for the telemetry decode pool.
+ *
+ * DecodeThreadPool spawns this FILE (the .ts source — the app runs
+ * through ts-node in both dev and prod, so the worker is loaded with
+ * `-r ts-node/register/transpile-only` in execArgv) and speaks a tiny
+ * id-correlated request/response protocol over `parentPort`:
+ *
+ *   request:  { id, productType, format, encoding, payload: ArrayBuffer }
+ *   response: { id, ok: true, result }
+ *           | { id, ok: false, errorMessage, errorStack }
+ *
+ * The payload arrives as a TRANSFERRED ArrayBuffer (zero-copy handoff —
+ * the pool already paid the one defensive memcpy on the main thread, see
+ * DecodeThreadPool for why). `Buffer.from(arrayBuffer)` below wraps it
+ * in a Buffer VIEW over the same memory without copying, so the thread
+ * adds no allocation of its own before decoding.
+ *
+ * Failure model: a malformed payload (bad gzip stream, truncated
+ * protobuf, invalid JSON) is a PER-MESSAGE failure — it must reject
+ * that one request, never kill the thread. Every message is therefore
+ * wrapped in try/catch and answered with an ok:false response carrying
+ * the error text; the pool re-throws it to the caller and the thread
+ * lives on to serve the next request. Only a genuinely unexpected crash
+ * (OOM, a bug outside the catch) surfaces as a thread 'error'/'exit',
+ * which the pool handles by rejecting that thread's in-flight request
+ * and respawning.
+ *
+ * Import discipline: only node builtins + OtelDecode (+ type-only
+ * imports, elided at emit). This file runs in a fresh thread with its
+ * own module registry — importing any infrastructure module here would
+ * open per-thread datastore connections. Don't.
+ */
+
+export interface DecodeRequestMessage {
+  id: number;
+  productType: ProductType;
+  format: OtelPayloadFormat;
+  encoding: OtelPayloadEncoding;
+  payload: ArrayBuffer;
+}
+
+export type DecodeResponseMessage =
+  | { id: number; ok: true; result: JSONObject }
+  | {
+      id: number;
+      ok: false;
+      errorMessage: string;
+      errorStack: string | undefined;
+    };
+
+async function handleDecodeRequest(
+  port: MessagePort,
+  message: DecodeRequestMessage,
+): Promise<void> {
+  try {
+    /*
+     * Zero-copy: Buffer.from(ArrayBuffer) creates a view over the
+     * transferred memory, not a copy.
+     */
+    const body: Buffer = Buffer.from(message.payload);
+
+    const result: JSONObject = await OtelDecode.decodeBody({
+      productType: message.productType,
+      format: message.format,
+      encoding: message.encoding,
+      body: body,
+    });
+
+    const response: DecodeResponseMessage = {
+      id: message.id,
+      ok: true,
+      result: result,
+    };
+    port.postMessage(response);
+  } catch (err) {
+    const error: Error = err instanceof Error ? err : new Error(String(err));
+    const response: DecodeResponseMessage = {
+      id: message.id,
+      ok: false,
+      errorMessage: error.message,
+      errorStack: error.stack,
+    };
+    port.postMessage(response);
+  }
+}
+
+/*
+ * Guarded so that an accidental import of this file on the MAIN thread
+ * (e.g. for the message types above, or by a test) is completely inert:
+ * no listener is attached and nothing runs.
+ */
+if (!isMainThread && parentPort) {
+  const port: MessagePort = parentPort;
+  port.on("message", (message: DecodeRequestMessage): void => {
+    void handleDecodeRequest(port, message);
+  });
+}

--- a/App/FeatureSet/Telemetry/Utils/OtelDecode.ts
+++ b/App/FeatureSet/Telemetry/Utils/OtelDecode.ts
@@ -1,0 +1,166 @@
+import protobuf from "protobufjs";
+import path from "path";
+import zlib from "zlib";
+import { promisify } from "util";
+import { JSONObject } from "Common/Types/JSON";
+import ProductType from "Common/Types/MeteredPlan/ProductType";
+
+/*
+ * Pure OTel payload decoding: gunzip + protobuf decode + `.toJSON()`
+ * (or JSON.parse for OTLP/JSON), with zero infrastructure attached.
+ *
+ * This module is extracted from OtelPayloadDecoder so that the SAME
+ * decode implementation has exactly two call sites:
+ *
+ *   1. Inline on the main thread (OtelPayloadDecoder.decodeFromQueue,
+ *      the default path — byte-for-byte the pre-extraction behavior), and
+ *   2. Inside a worker thread (DecodeWorkerThread), where the decode
+ *      pool moves the sync CPU burn (gunzip inflate + protobuf decode
+ *      + toJSON of multi-MB batches) off the worker process's main
+ *      event loop.
+ *
+ * CRITICAL CONSTRAINT: every worker thread imports this module
+ * standalone, so this module (and everything it transitively imports)
+ * must NOT import TelemetryBodyStore, Redis, Postgres, Config, the
+ * exporter-wired logger, or any other infrastructure — a thread must
+ * never open datastore connections or start telemetry just to decode
+ * bytes. The import closure here is intentionally only:
+ *
+ *   - protobufjs (pure JS),
+ *   - node builtins (path / zlib / util),
+ *   - Common/Types/MeteredPlan/ProductType (a dependency-free enum),
+ *   - Common/Types/JSON (type-only — elided at emit).
+ *
+ * Keep it that way when editing.
+ */
+
+const PROTO_DIR: string = path.resolve(
+  __dirname,
+  "..",
+  "ProtoFiles",
+  "OTel",
+  "v1",
+);
+
+const LogsProto: protobuf.Root = protobuf.loadSync(
+  path.join(PROTO_DIR, "logs.proto"),
+);
+const TracesProto: protobuf.Root = protobuf.loadSync(
+  path.join(PROTO_DIR, "traces.proto"),
+);
+const MetricsProto: protobuf.Root = protobuf.loadSync(
+  path.join(PROTO_DIR, "metrics.proto"),
+);
+const ProfilesProto: protobuf.Root = protobuf.loadSync(
+  path.join(PROTO_DIR, "profiles.proto"),
+);
+
+const LogsData: protobuf.Type = LogsProto.lookupType("LogsData");
+const TracesData: protobuf.Type = TracesProto.lookupType("TracesData");
+const MetricsData: protobuf.Type = MetricsProto.lookupType("MetricsData");
+const ProfilesData: protobuf.Type = ProfilesProto.lookupType("ProfilesData");
+
+/*
+ * `zlib.gunzip` accepts a Node Buffer directly (Buffer IS a Uint8Array
+ * subclass at runtime), so the raw payload Buffer read from Redis is passed
+ * straight through — wrapping it in `new Uint8Array(raw)` first would
+ * allocate and memcpy the entire payload (tens of MB for large batches)
+ * per job for no behavioural difference. The `as unknown as` cast is
+ * forced by TypeScript 5.7+ generic typed arrays: our pinned @types/node
+ * declares `Buffer.slice()` in a way that no longer structurally matches
+ * the lib `Uint8Array`, so `Buffer` fails to assign to `zlib.InputType`
+ * at the type level even though it is valid at runtime (same workaround
+ * as the promisified gunzip in SessionReplayIngestService).
+ *
+ * Async (callback-based) gunzip is deliberately kept even for the
+ * worker-thread call site: a worker thread has its own event loop, so
+ * the async form costs nothing there, and sharing one implementation
+ * keeps the two call sites byte-identical.
+ */
+export const gunzipAsync: (buffer: Buffer | Uint8Array) => Promise<Buffer> =
+  promisify(zlib.gunzip) as unknown as (
+    buffer: Buffer | Uint8Array,
+  ) => Promise<Buffer>;
+
+export enum OtelPayloadFormat {
+  Protobuf = "protobuf",
+  Json = "json",
+}
+
+export type OtelPayloadEncoding = "gzip" | "none";
+
+export interface OtelDecodeInput {
+  productType: ProductType;
+  format: OtelPayloadFormat;
+  encoding: OtelPayloadEncoding;
+  body: Buffer;
+}
+
+function protoTypeForProduct(productType: ProductType): protobuf.Type | null {
+  switch (productType) {
+    case ProductType.Traces:
+      return TracesData;
+    case ProductType.Logs:
+      return LogsData;
+    case ProductType.Metrics:
+      return MetricsData;
+    case ProductType.Profiles:
+      return ProfilesData;
+    default:
+      return null;
+  }
+}
+
+export default class OtelDecode {
+  /*
+   * Decode a raw OTel payload Buffer into a plain JS object matching
+   * the OTel data model (resourceSpans / resourceLogs / resourceMetrics
+   * / resourceProfiles). This is the whole CPU-bound part of the job:
+   * gunzip-if-needed, then JSON.parse or protobuf decode + toJSON.
+   *
+   * Behavior (including thrown error messages) is preserved verbatim
+   * from the pre-extraction OtelPayloadDecoder.decodeFromQueue — the
+   * queue layer's failure text and retry semantics must not change
+   * just because the code moved. That is why the "no proto type" error
+   * below still says "OtelPayloadDecoder:".
+   */
+  public static async decodeBody(input: OtelDecodeInput): Promise<JSONObject> {
+    let raw: Buffer = input.body;
+
+    if (input.encoding === "gzip") {
+      raw = await gunzipAsync(raw);
+    }
+
+    if (input.format === OtelPayloadFormat.Json) {
+      return JSON.parse(raw.toString("utf-8")) as JSONObject;
+    }
+
+    const protoType: protobuf.Type | null = protoTypeForProduct(
+      input.productType,
+    );
+    if (!protoType) {
+      throw new Error(
+        `OtelPayloadDecoder: no proto type for product ${input.productType}`,
+      );
+    }
+
+    /*
+     * Mirror the previous middleware behavior: decode the protobuf
+     * message and then `.toJSON()` it into a plain JS object that
+     * downstream code already consumes (resourceSpans / resourceLogs
+     * / resourceMetrics / resourceProfiles).
+     *
+     * The Buffer is handed to `decode` as-is: protobufjs' `Reader.create`
+     * has a dedicated Buffer fast path (BufferReader), so copying the
+     * payload into a fresh Uint8Array first would only add an extra
+     * full-payload allocation + memcpy per job. The `as unknown as`
+     * cast is type-level only — Buffer IS a Uint8Array at runtime, but
+     * our pinned @types/node predates TypeScript 5.7's generic typed
+     * arrays and no longer structurally satisfies the lib `Uint8Array`.
+     */
+    const message: protobuf.Message<Record<string, unknown>> = protoType.decode(
+      raw as unknown as Uint8Array,
+    );
+    return message.toJSON() as JSONObject;
+  }
+}

--- a/App/FeatureSet/Telemetry/Utils/OtelPayloadDecoder.ts
+++ b/App/FeatureSet/Telemetry/Utils/OtelPayloadDecoder.ts
@@ -1,13 +1,16 @@
-import protobuf from "protobufjs";
-import path from "path";
-import zlib from "zlib";
-import { promisify } from "util";
 import { JSONObject } from "Common/Types/JSON";
 import ProductType from "Common/Types/MeteredPlan/ProductType";
 import TelemetryEntity, {
   ResourceEntityRef,
 } from "Common/Server/Utils/Telemetry/TelemetryEntity";
 import TelemetryBodyStore from "./TelemetryBodyStore";
+import OtelDecode, {
+  OtelPayloadEncoding,
+  OtelPayloadFormat,
+  gunzipAsync,
+} from "./OtelDecode";
+import DecodeThreadPool from "./DecodeThreadPool";
+import { TELEMETRY_DECODE_MIN_PAYLOAD_BYTES } from "../Config";
 
 /*
  * Shared OTel protobuf decoders. We previously decoded payloads inside
@@ -16,72 +19,17 @@ import TelemetryBodyStore from "./TelemetryBodyStore";
  * spent 50-150ms of unbroken sync CPU on protobuf decode + toJSON).
  * Decoding now happens in the BullMQ worker — both sides import this
  * module so the proto definitions only load once per process.
+ *
+ * The decode implementation itself (proto roots, gunzip, decode +
+ * toJSON) lives in OtelDecode.ts so the decode worker threads can
+ * import it without dragging in TelemetryBodyStore/Redis; this module
+ * keeps the queue-facing orchestration (body fetch + pool-vs-inline
+ * routing) and re-exports the decode module's public surface so
+ * existing importers are unaffected.
  */
 
-const PROTO_DIR: string = path.resolve(
-  __dirname,
-  "..",
-  "ProtoFiles",
-  "OTel",
-  "v1",
-);
-
-const LogsProto: protobuf.Root = protobuf.loadSync(
-  path.join(PROTO_DIR, "logs.proto"),
-);
-const TracesProto: protobuf.Root = protobuf.loadSync(
-  path.join(PROTO_DIR, "traces.proto"),
-);
-const MetricsProto: protobuf.Root = protobuf.loadSync(
-  path.join(PROTO_DIR, "metrics.proto"),
-);
-const ProfilesProto: protobuf.Root = protobuf.loadSync(
-  path.join(PROTO_DIR, "profiles.proto"),
-);
-
-const LogsData: protobuf.Type = LogsProto.lookupType("LogsData");
-const TracesData: protobuf.Type = TracesProto.lookupType("TracesData");
-const MetricsData: protobuf.Type = MetricsProto.lookupType("MetricsData");
-const ProfilesData: protobuf.Type = ProfilesProto.lookupType("ProfilesData");
-
-/*
- * `zlib.gunzip` accepts a Node Buffer directly (Buffer IS a Uint8Array
- * subclass at runtime), so the raw payload Buffer read from Redis is passed
- * straight through — wrapping it in `new Uint8Array(raw)` first would
- * allocate and memcpy the entire payload (tens of MB for large batches)
- * per job for no behavioural difference. The `as unknown as` cast is
- * forced by TypeScript 5.7+ generic typed arrays: our pinned @types/node
- * declares `Buffer.slice()` in a way that no longer structurally matches
- * the lib `Uint8Array`, so `Buffer` fails to assign to `zlib.InputType`
- * at the type level even though it is valid at runtime (same workaround
- * as the promisified gunzip in SessionReplayIngestService).
- */
-export const gunzipAsync: (buffer: Buffer | Uint8Array) => Promise<Buffer> =
-  promisify(zlib.gunzip) as unknown as (
-    buffer: Buffer | Uint8Array,
-  ) => Promise<Buffer>;
-
-export enum OtelPayloadFormat {
-  Protobuf = "protobuf",
-  Json = "json",
-}
-
-export type OtelPayloadEncoding = "gzip" | "none";
-
-function protoTypeForProduct(productType: ProductType): protobuf.Type | null {
-  switch (productType) {
-    case ProductType.Traces:
-      return TracesData;
-    case ProductType.Logs:
-      return LogsData;
-    case ProductType.Metrics:
-      return MetricsData;
-    case ProductType.Profiles:
-      return ProfilesData;
-    default:
-      return null;
-  }
-}
+export { gunzipAsync, OtelPayloadFormat };
+export type { OtelPayloadEncoding };
 
 export default class OtelPayloadDecoder {
   /*
@@ -98,6 +46,17 @@ export default class OtelPayloadDecoder {
    * consumer treats an empty `resourceLogs` / `resourceSpans`
    * / `resourceMetrics` as "nothing to ingest" and skips the
    * batch, which is the correct behaviour for a lost body.
+   *
+   * The Redis read stays HERE on the main thread (the ioredis client
+   * is not shareable across threads); only the CPU-bound decode is
+   * routed. Routing: when the decode thread pool is enabled AND
+   * accepting AND the raw payload is at least
+   * TELEMETRY_DECODE_MIN_PAYLOAD_BYTES, the decode runs on a pool
+   * thread; otherwise it runs inline via OtelDecode.decodeBody — the
+   * SAME implementation the threads execute, so the two paths cannot
+   * drift. With the default TELEMETRY_DECODE_THREADS=0 every payload
+   * takes the inline path, which is byte-for-byte the pre-pool
+   * behavior.
    */
   public static async decodeFromQueue(input: {
     productType: ProductType;
@@ -109,47 +68,37 @@ export default class OtelPayloadDecoder {
       throw new Error("OtelPayloadDecoder: bodyKey is required");
     }
 
-    let raw: Buffer | null = await TelemetryBodyStore.readBody(input.bodyKey);
+    const raw: Buffer | null = await TelemetryBodyStore.readBody(input.bodyKey);
     if (!raw) {
       // Body expired (TTL) before the worker got to it — nothing to decode.
       return {} as JSONObject;
     }
 
-    if (input.encoding === "gzip") {
-      raw = await gunzipAsync(raw);
+    if (
+      DecodeThreadPool.isAvailable() &&
+      raw.length >= TELEMETRY_DECODE_MIN_PAYLOAD_BYTES
+    ) {
+      /*
+       * Pool path. A pool rejection (thread death, shutdown races) is
+       * deliberately NOT caught here: the pool's errors are retryable
+       * by the BullMQ job layer, and the retry re-evaluates
+       * isAvailable() — a pool that marked itself unhealthy in the
+       * meantime routes the retry inline.
+       */
+      return DecodeThreadPool.decode({
+        productType: input.productType,
+        format: input.format,
+        encoding: input.encoding,
+        body: raw,
+      });
     }
 
-    if (input.format === OtelPayloadFormat.Json) {
-      return JSON.parse(raw.toString("utf-8")) as JSONObject;
-    }
-
-    const protoType: protobuf.Type | null = protoTypeForProduct(
-      input.productType,
-    );
-    if (!protoType) {
-      throw new Error(
-        `OtelPayloadDecoder: no proto type for product ${input.productType}`,
-      );
-    }
-
-    /*
-     * Mirror the previous middleware behavior: decode the protobuf
-     * message and then `.toJSON()` it into a plain JS object that
-     * downstream code already consumes (resourceSpans / resourceLogs
-     * / resourceMetrics / resourceProfiles).
-     *
-     * The Buffer is handed to `decode` as-is: protobufjs' `Reader.create`
-     * has a dedicated Buffer fast path (BufferReader), so copying the
-     * payload into a fresh Uint8Array first would only add an extra
-     * full-payload allocation + memcpy per job. The `as unknown as`
-     * cast is type-level only — Buffer IS a Uint8Array at runtime, but
-     * our pinned @types/node predates TypeScript 5.7's generic typed
-     * arrays and no longer structurally satisfies the lib `Uint8Array`.
-     */
-    const message: protobuf.Message<Record<string, unknown>> = protoType.decode(
-      raw as unknown as Uint8Array,
-    );
-    return message.toJSON() as JSONObject;
+    return OtelDecode.decodeBody({
+      productType: input.productType,
+      format: input.format,
+      encoding: input.encoding,
+      body: raw,
+    });
   }
 
   /**

--- a/App/FeatureSet/Telemetry/Utils/OtelPayloadDecoder.ts
+++ b/App/FeatureSet/Telemetry/Utils/OtelPayloadDecoder.ts
@@ -54,8 +54,10 @@ export default class OtelPayloadDecoder {
    * TELEMETRY_DECODE_MIN_PAYLOAD_BYTES, the decode runs on a pool
    * thread; otherwise it runs inline via OtelDecode.decodeBody — the
    * SAME implementation the threads execute, so the two paths cannot
-   * drift. With the default TELEMETRY_DECODE_THREADS=0 every payload
-   * takes the inline path, which is byte-for-byte the pre-pool
+   * drift. The pool is enabled by default with an adaptive, cgroup-
+   * aware thread count (see Config.ts); when TELEMETRY_DECODE_THREADS
+   * resolves to 0 (a 1-effective-CPU pod, or an explicit 0) every
+   * payload takes the inline path, which is byte-for-byte the pre-pool
    * behavior.
    */
   public static async decodeFromQueue(input: {

--- a/App/Tests/Telemetry/DecodeThreadPool.test.ts
+++ b/App/Tests/Telemetry/DecodeThreadPool.test.ts
@@ -1,0 +1,693 @@
+import { describe, expect, test, afterAll, beforeAll } from "@jest/globals";
+import path from "path";
+import protobuf from "protobufjs";
+import { Worker } from "worker_threads";
+import { TelemetryDecodeThreadPool } from "../../FeatureSet/Telemetry/Utils/DecodeThreadPool";
+import OtelDecode, {
+  OtelPayloadFormat,
+} from "../../FeatureSet/Telemetry/Utils/OtelDecode";
+import { JSONObject } from "Common/Types/JSON";
+import ProductType from "Common/Types/MeteredPlan/ProductType";
+
+/*
+ * Pool mechanics with REAL worker threads: scheduling (one in-flight
+ * per thread, FIFO admission), id correlation under interleaving,
+ * per-request error propagation, thread-death recovery, the unhealthy
+ * breaker, source-Buffer safety, and shutdown.
+ *
+ * Thread budget: spawning a ts-node worker costs real seconds, so this
+ * file reuses ONE shared size-2 pool for the concurrency/correctness
+ * tests and spins up two deliberately tiny (size-1) pools only where a
+ * test must kill or wedge a specific thread. Pool sizes are hard-capped
+ * at 2 throughout.
+ */
+
+const PROTO_DIR: string = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Telemetry",
+  "ProtoFiles",
+  "OTel",
+  "v1",
+);
+
+const LogsDataType: protobuf.Type = protobuf
+  .loadSync(path.join(PROTO_DIR, "logs.proto"))
+  .lookupType("LogsData");
+
+/*
+ * Distinct payload per request: the log body carries the marker, so a
+ * cross-wired response (an id-correlation bug) would surface as the
+ * WRONG marker coming back for a request — which is exactly what the
+ * concurrency test asserts against.
+ */
+function makeLogsPayload(marker: string): JSONObject {
+  return {
+    resourceLogs: [
+      {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: `svc-${marker}` } },
+          ],
+        },
+        scopeLogs: [
+          {
+            scope: { name: "pool-test" },
+            logRecords: [
+              {
+                timeUnixNano: "1700000000000000000",
+                severityText: "INFO",
+                body: { stringValue: `payload-${marker}` },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/*
+ * A payload big enough that its decode is reliably still in flight when
+ * the test terminates the worker one synchronous statement later.
+ */
+function makeLargeLogsPayload(recordCount: number): JSONObject {
+  const logRecords: Array<JSONObject> = [];
+  for (let i: number = 0; i < recordCount; i++) {
+    logRecords.push({
+      timeUnixNano: "1700000000000000000",
+      severityText: "INFO",
+      body: { stringValue: `bulk log line ${i} ${"x".repeat(120)}` },
+    });
+  }
+  return {
+    resourceLogs: [
+      {
+        resource: {
+          attributes: [
+            { key: "service.name", value: { stringValue: "bulk-service" } },
+          ],
+        },
+        scopeLogs: [{ scope: { name: "bulk" }, logRecords: logRecords }],
+      },
+    ],
+  };
+}
+
+function encodeLogs(payload: JSONObject): Buffer {
+  const message: protobuf.Message<Record<string, unknown>> =
+    LogsDataType.fromObject(payload);
+  return Buffer.from(LogsDataType.encode(message).finish());
+}
+
+/*
+ * Race a decode promise against a short timer: resolves to the
+ * rejection Error if the promise rejected, "resolved" if it fulfilled,
+ * or "pending" if it settled neither way within timeoutMs. A
+ * still-pending promise is the hung-job failure mode the shutdown/
+ * breaker tests below exist to rule out — every outstanding decode must
+ * SETTLE when the pool shuts down or trips its breaker, or the owning
+ * BullMQ job would hang until its lock timeout.
+ */
+function settlementWithin(
+  promise: Promise<JSONObject>,
+  timeoutMs: number,
+): Promise<Error | "resolved" | "pending"> {
+  return new Promise<Error | "resolved" | "pending">(
+    (resolve: (outcome: Error | "resolved" | "pending") => void) => {
+      const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
+        resolve("pending");
+      }, timeoutMs);
+      promise.then(
+        () => {
+          clearTimeout(timer);
+          resolve("resolved");
+        },
+        (error: Error) => {
+          clearTimeout(timer);
+          resolve(error);
+        },
+      );
+    },
+  );
+}
+
+const sharedPool: TelemetryDecodeThreadPool = new TelemetryDecodeThreadPool({
+  threadCount: 2,
+});
+
+const poolsToShutDown: Array<TelemetryDecodeThreadPool> = [sharedPool];
+
+afterAll(async () => {
+  /*
+   * Terminate every thread this file spawned — leaked workers would
+   * keep the jest process alive and trip --detectOpenHandles.
+   */
+  await Promise.all(
+    poolsToShutDown.map((pool: TelemetryDecodeThreadPool) => {
+      return pool.shutdown();
+    }),
+  );
+});
+
+describe("DecodeThreadPool — scheduling and id correlation (shared size-2 pool)", () => {
+  test("6 concurrent decodes: never more than 2 in flight, and every response matches ITS request", async () => {
+    const markers: Array<string> = ["a", "b", "c", "d", "e", "f"];
+    const payloads: Array<JSONObject> = markers.map((marker: string) => {
+      return makeLogsPayload(marker);
+    });
+    const buffers: Array<Buffer> = payloads.map((payload: JSONObject) => {
+      return encodeLogs(payload);
+    });
+
+    const promises: Array<Promise<JSONObject>> = buffers.map(
+      (buffer: Buffer) => {
+        return sharedPool.decode({
+          productType: ProductType.Logs,
+          format: OtelPayloadFormat.Protobuf,
+          encoding: "none",
+          body: buffer,
+        });
+      },
+    );
+
+    /*
+     * decode() dispatches synchronously (enqueue + pump before the
+     * promise is returned), so right here exactly 2 requests must be on
+     * threads and 4 must be queued — this pins one-in-flight-per-thread
+     * and FIFO admission at the same time.
+     */
+    const statsAfterDispatch: {
+      threadsAlive: number;
+      inFlight: number;
+      queued: number;
+      healthy: boolean;
+    } = sharedPool.getStats();
+    expect(statsAfterDispatch.threadsAlive).toBe(2);
+    expect(statsAfterDispatch.inFlight).toBe(2);
+    expect(statsAfterDispatch.queued).toBe(4);
+
+    // Sample stats throughout the drain: in-flight must never exceed 2.
+    const inFlightSamples: Array<number> = [];
+    const samplePoller: ReturnType<typeof setInterval> = setInterval(() => {
+      inFlightSamples.push(sharedPool.getStats().inFlight);
+    }, 2);
+
+    let results: Array<JSONObject>;
+    try {
+      results = await Promise.all(promises);
+    } finally {
+      clearInterval(samplePoller);
+    }
+
+    for (const sample of inFlightSamples) {
+      expect(sample).toBeLessThanOrEqual(2);
+    }
+
+    /*
+     * Each response deep-equals the payload of the request it answers —
+     * under interleaving across 2 threads this fails if ids ever
+     * cross-correlate.
+     */
+    for (let i: number = 0; i < markers.length; i++) {
+      expect(results[i]).toEqual(payloads[i]);
+    }
+
+    const statsAfterDrain: { inFlight: number; queued: number } =
+      sharedPool.getStats();
+    expect(statsAfterDrain.inFlight).toBe(0);
+    expect(statsAfterDrain.queued).toBe(0);
+  }, 60000);
+
+  test("a malformed payload rejects ONLY that request; the pool stays healthy and keeps decoding", async () => {
+    await expect(
+      sharedPool.decode({
+        productType: ProductType.Logs,
+        format: OtelPayloadFormat.Protobuf,
+        encoding: "gzip",
+        body: Buffer.from("this is not gzip", "utf-8"),
+      }),
+    ).rejects.toThrow(/incorrect header check|unknown compression method/);
+
+    expect(sharedPool.getStats().healthy).toBe(true);
+    expect(sharedPool.getStats().threadsAlive).toBe(2);
+
+    const payload: JSONObject = makeLogsPayload("after-error");
+    const decoded: JSONObject = await sharedPool.decode({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: encodeLogs(payload),
+    });
+    expect(decoded).toEqual(payload);
+  }, 60000);
+
+  test("the caller's Buffer is copied, not transferred: it stays intact and usable after dispatch", async () => {
+    const payload: JSONObject = makeLogsPayload("buffer-safety");
+    const body: Buffer = encodeLogs(payload);
+    const pristineCopy: Buffer = Buffer.from(
+      new Uint8Array(body as unknown as Uint8Array),
+    );
+
+    const poolResult: JSONObject = await sharedPool.decode({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: body,
+    });
+    expect(poolResult).toEqual(payload);
+
+    /*
+     * Byte-identical to the pre-dispatch copy: a transfer of the
+     * caller's own ArrayBuffer would have detached it (length 0) or —
+     * for a Buffer-pool-slab view — corrupted unrelated memory.
+     */
+    expect(body.length).toBe(pristineCopy.length);
+    expect(body.equals(pristineCopy as unknown as Uint8Array)).toBe(true);
+
+    // Still usable: the SAME Buffer decodes inline to the same result.
+    const inlineResult: JSONObject = await OtelDecode.decodeBody({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: body,
+    });
+    expect(inlineResult).toEqual(poolResult);
+  }, 60000);
+
+  test("a nonzero-byteOffset Buffer view (ioredis-style slab view) decodes identically to inline, and the slab stays untouched", async () => {
+    const payload: JSONObject = makeLogsPayload("slab-view");
+    const encoded: Buffer = encodeLogs(payload);
+
+    /*
+     * Production bodies come from ioredis, whose reply Buffers are
+     * routinely nonzero-offset VIEWS over a shared read slab. Model
+     * that exactly: a large sentinel-filled backing Buffer with the
+     * real payload written at offset 1024, and the decode input a
+     * subarray view over just the payload bytes.
+     */
+    const backing: Buffer = Buffer.alloc(64 * 1024, 0xee);
+    backing.set(encoded as unknown as Uint8Array, 1024);
+    const view: Buffer = backing.subarray(1024, 1024 + encoded.length);
+
+    /*
+     * Fixture preconditions: if a future refactor hands the pool a
+     * zero-offset or non-shared Buffer here, this test would silently
+     * stop covering the whole-slab copy/transfer bug — fail loudly
+     * instead.
+     */
+    expect(view.byteOffset).not.toBe(0);
+    expect(view.buffer.byteLength).toBeGreaterThan(view.length);
+
+    const slabSnapshot: Buffer = Buffer.from(
+      new Uint8Array(backing as unknown as Uint8Array),
+    );
+
+    /*
+     * The pool's copy-then-transfer site must copy exactly the VIEW's
+     * bytes. The classic bug is copying (or transferring) the entire
+     * underlying ArrayBuffer, which would hand the worker 1024 bytes of
+     * sentinel garbage ahead of the payload — or detach/corrupt slab
+     * memory the caller still owns.
+     */
+    const poolResult: JSONObject = await sharedPool.decode({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: view,
+    });
+
+    const inlineResult: JSONObject = await OtelDecode.decodeBody({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: view,
+    });
+
+    expect(poolResult).toEqual(inlineResult);
+    expect(poolResult).toEqual(payload);
+
+    /*
+     * Byte-identical slab: pins the bytes OUTSIDE the view (a whole-
+     * slab transfer would have detached them, a stray write would have
+     * clobbered the sentinel) as well as the view bytes themselves.
+     */
+    expect(backing.length).toBe(slabSnapshot.length);
+    expect(backing.equals(slabSnapshot as unknown as Uint8Array)).toBe(true);
+  }, 60000);
+});
+
+describe("DecodeThreadPool — thread death and recovery (dedicated size-1 pool)", () => {
+  const lifecyclePool: TelemetryDecodeThreadPool =
+    new TelemetryDecodeThreadPool({
+      threadCount: 1,
+    });
+
+  beforeAll(() => {
+    poolsToShutDown.push(lifecyclePool);
+  });
+
+  test("terminating a busy thread rejects ONLY its in-flight request, then the pool respawns and recovers", async () => {
+    const largeBody: Buffer = encodeLogs(makeLargeLogsPayload(5000));
+
+    const doomedDecode: Promise<JSONObject> = lifecyclePool.decode({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: largeBody,
+    });
+
+    /*
+     * Kill the (only) thread while the request is in flight. On a
+     * fresh pool the worker is still compiling under ts-node at this
+     * point, so the request is deterministically unanswered.
+     */
+    const workers: Array<Worker> = lifecyclePool.getWorkerThreadsForTesting();
+    expect(workers.length).toBe(1);
+    await (workers[0] as Worker).terminate();
+
+    await expect(doomedDecode).rejects.toThrow(
+      /TelemetryDecodeThreadPool.*thread death/,
+    );
+
+    /*
+     * One isolated death must NOT trip the breaker: the pool respawned
+     * a replacement and the next decode succeeds on it.
+     */
+    expect(lifecyclePool.getStats().healthy).toBe(true);
+    expect(lifecyclePool.getStats().threadsAlive).toBe(1);
+
+    const payload: JSONObject = makeLogsPayload("post-respawn");
+    const decoded: JSONObject = await lifecyclePool.decode({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: encodeLogs(payload),
+    });
+    expect(decoded).toEqual(payload);
+  }, 60000);
+
+  test("FIFO on a single thread: requests complete in submission order", async () => {
+    const completionOrder: Array<number> = [];
+    const markers: Array<string> = ["first", "second", "third"];
+
+    const promises: Array<Promise<void>> = markers.map(
+      (marker: string, index: number) => {
+        return lifecyclePool
+          .decode({
+            productType: ProductType.Logs,
+            format: OtelPayloadFormat.Protobuf,
+            encoding: "none",
+            body: encodeLogs(makeLogsPayload(marker)),
+          })
+          .then((decoded: JSONObject) => {
+            completionOrder.push(index);
+            expect(decoded).toEqual(makeLogsPayload(marker));
+          });
+      },
+    );
+
+    await Promise.all(promises);
+
+    // One thread + FIFO queue => strict submission order.
+    expect(completionOrder).toEqual([0, 1, 2]);
+  }, 60000);
+
+  test("shutdown terminates the threads and refuses further work", async () => {
+    await lifecyclePool.shutdown();
+
+    expect(lifecyclePool.getStats().threadsAlive).toBe(0);
+    expect(lifecyclePool.getStats().inFlight).toBe(0);
+    expect(lifecyclePool.isAccepting()).toBe(false);
+
+    await expect(
+      lifecyclePool.decode({
+        productType: ProductType.Logs,
+        format: OtelPayloadFormat.Protobuf,
+        encoding: "none",
+        body: encodeLogs(makeLogsPayload("too-late")),
+      }),
+    ).rejects.toThrow(/shutting down/);
+  }, 60000);
+});
+
+describe("DecodeThreadPool — unhealthy breaker (dedicated size-1 pool, trip threshold 1)", () => {
+  const breakerPool: TelemetryDecodeThreadPool = new TelemetryDecodeThreadPool({
+    threadCount: 1,
+    /*
+     * Trip on the FIRST failure so the test doesn't need to stage a
+     * crash loop; the cooldown is long enough that the pool stays
+     * unhealthy for the rest of the test.
+     */
+    maxConsecutiveThreadFailures: 1,
+    unhealthyCooldownMs: 5 * 60 * 1000,
+  });
+
+  beforeAll(() => {
+    poolsToShutDown.push(breakerPool);
+  });
+
+  test("hitting the failure threshold marks the pool unhealthy and rejects new work until cooldown", async () => {
+    const doomedDecode: Promise<JSONObject> = breakerPool.decode({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: encodeLogs(makeLargeLogsPayload(5000)),
+    });
+
+    const workers: Array<Worker> = breakerPool.getWorkerThreadsForTesting();
+    expect(workers.length).toBe(1);
+    await (workers[0] as Worker).terminate();
+
+    await expect(doomedDecode).rejects.toThrow(/TelemetryDecodeThreadPool/);
+
+    // Threshold 1 => the single death tripped the breaker.
+    expect(breakerPool.getStats().healthy).toBe(false);
+    expect(breakerPool.getStats().threadsAlive).toBe(0);
+    expect(breakerPool.isAccepting()).toBe(false);
+
+    /*
+     * While unhealthy (in cooldown), decode() rejects retryably instead
+     * of queueing onto a pool with no threads — the routing layer sees
+     * isAccepting() === false and decodes inline instead.
+     */
+    await expect(
+      breakerPool.decode({
+        productType: ProductType.Logs,
+        format: OtelPayloadFormat.Protobuf,
+        encoding: "none",
+        body: encodeLogs(makeLogsPayload("while-unhealthy")),
+      }),
+    ).rejects.toThrow(/unhealthy/);
+  }, 60000);
+});
+
+describe("DecodeThreadPool — breaker heals after cooldown (dedicated size-1 pool, 200ms cooldown)", () => {
+  const healingPool: TelemetryDecodeThreadPool = new TelemetryDecodeThreadPool({
+    threadCount: 1,
+    /*
+     * Trip on the FIRST failure (as in the breaker suite above), but
+     * with a cooldown short enough that this test can wait it out and
+     * exercise the recovery path the 5-minute-cooldown suite never
+     * reaches.
+     */
+    maxConsecutiveThreadFailures: 1,
+    unhealthyCooldownMs: 200,
+  });
+
+  beforeAll(() => {
+    poolsToShutDown.push(healingPool);
+  });
+
+  test("after the cooldown elapses the pool accepts again, lazily respawns, and decodes successfully", async () => {
+    const doomedDecode: Promise<JSONObject> = healingPool.decode({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: encodeLogs(makeLargeLogsPayload(5000)),
+    });
+
+    const workers: Array<Worker> = healingPool.getWorkerThreadsForTesting();
+    expect(workers.length).toBe(1);
+    await (workers[0] as Worker).terminate();
+
+    await expect(doomedDecode).rejects.toThrow(/TelemetryDecodeThreadPool/);
+
+    // Threshold 1 => the single death tripped the breaker.
+    expect(healingPool.getStats().healthy).toBe(false);
+    expect(healingPool.getStats().threadsAlive).toBe(0);
+    expect(healingPool.isAccepting()).toBe(false);
+
+    // Wait comfortably past the 200ms cooldown.
+    await new Promise<void>((resolve: () => void) => {
+      setTimeout(resolve, 350);
+    });
+
+    /*
+     * Cooldown elapsed: the pool advertises itself as accepting again,
+     * but recovery is LAZY — no thread respawns (and `healthy` stays
+     * false) until the next decode() actually arrives.
+     */
+    expect(healingPool.isAccepting()).toBe(true);
+    expect(healingPool.getStats().healthy).toBe(false);
+    expect(healingPool.getStats().threadsAlive).toBe(0);
+
+    const payload: JSONObject = makeLogsPayload("post-cooldown");
+    const decoded: JSONObject = await healingPool.decode({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: encodeLogs(payload),
+    });
+    expect(decoded).toEqual(payload);
+
+    // The decode reset the breaker and respawned exactly one thread.
+    expect(healingPool.getStats().healthy).toBe(true);
+    expect(healingPool.getStats().threadsAlive).toBe(1);
+  }, 60000);
+});
+
+describe("DecodeThreadPool — no hung promises at shutdown (dedicated size-1 pool, zero drain budget)", () => {
+  const shutdownPool: TelemetryDecodeThreadPool = new TelemetryDecodeThreadPool(
+    {
+      threadCount: 1,
+      /*
+       * Zero drain budget: shutdown() must not wait for the in-flight
+       * decode — it rejects it immediately, which is exactly the path
+       * under test.
+       */
+      shutdownDrainTimeoutMs: 0,
+    },
+  );
+
+  beforeAll(() => {
+    poolsToShutDown.push(shutdownPool);
+  });
+
+  test("shutdown() with in-flight AND queued work settles every outstanding promise as a retryable rejection", async () => {
+    /*
+     * Occupy the single thread (on a fresh pool the worker is still
+     * compiling under ts-node, so this is deterministically in flight)
+     * and queue two more requests behind it.
+     */
+    const inFlightDecode: Promise<JSONObject> = shutdownPool.decode({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: encodeLogs(makeLargeLogsPayload(5000)),
+    });
+    const queuedDecodes: Array<Promise<JSONObject>> = ["q1", "q2"].map(
+      (marker: string) => {
+        return shutdownPool.decode({
+          productType: ProductType.Logs,
+          format: OtelPayloadFormat.Protobuf,
+          encoding: "none",
+          body: encodeLogs(makeLogsPayload(marker)),
+        });
+      },
+    );
+
+    expect(shutdownPool.getStats().inFlight).toBe(1);
+    expect(shutdownPool.getStats().queued).toBe(2);
+
+    // Probes attached BEFORE shutdown so no rejection is ever unobserved.
+    const probes: Array<Promise<Error | "resolved" | "pending">> = [
+      inFlightDecode,
+      ...queuedDecodes,
+    ].map((promise: Promise<JSONObject>) => {
+      return settlementWithin(promise, 2000);
+    });
+
+    await shutdownPool.shutdown();
+
+    const outcomes: Array<Error | "resolved" | "pending"> =
+      await Promise.all(probes);
+
+    // ALL THREE must settle as rejections — "pending" is a hung job.
+    for (const outcome of outcomes) {
+      expect(outcome).toBeInstanceOf(Error);
+      expect((outcome as Error).message).toMatch(/^TelemetryDecodeThreadPool/);
+    }
+    expect((outcomes[0] as Error).message).toMatch(
+      /still in flight at shutdown/,
+    );
+    expect((outcomes[1] as Error).message).toMatch(/shut down before dispatch/);
+    expect((outcomes[2] as Error).message).toMatch(/shut down before dispatch/);
+
+    expect(shutdownPool.getStats().threadsAlive).toBe(0);
+    expect(shutdownPool.getStats().inFlight).toBe(0);
+    expect(shutdownPool.getStats().queued).toBe(0);
+    expect(shutdownPool.isAccepting()).toBe(false);
+  }, 60000);
+});
+
+describe("DecodeThreadPool — no hung promises on breaker trip with queued work (dedicated size-1 pool, trip threshold 1)", () => {
+  const trippedQueuePool: TelemetryDecodeThreadPool =
+    new TelemetryDecodeThreadPool({
+      threadCount: 1,
+      maxConsecutiveThreadFailures: 1,
+      unhealthyCooldownMs: 5 * 60 * 1000,
+    });
+
+  beforeAll(() => {
+    poolsToShutDown.push(trippedQueuePool);
+  });
+
+  test("terminating the busy thread rejects the in-flight request AND both queued requests — none stranded", async () => {
+    const inFlightDecode: Promise<JSONObject> = trippedQueuePool.decode({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: encodeLogs(makeLargeLogsPayload(5000)),
+    });
+    const queuedDecodes: Array<Promise<JSONObject>> = ["q1", "q2"].map(
+      (marker: string) => {
+        return trippedQueuePool.decode({
+          productType: ProductType.Logs,
+          format: OtelPayloadFormat.Protobuf,
+          encoding: "none",
+          body: encodeLogs(makeLogsPayload(marker)),
+        });
+      },
+    );
+
+    expect(trippedQueuePool.getStats().inFlight).toBe(1);
+    expect(trippedQueuePool.getStats().queued).toBe(2);
+
+    const probes: Array<Promise<Error | "resolved" | "pending">> = [
+      inFlightDecode,
+      ...queuedDecodes,
+    ].map((promise: Promise<JSONObject>) => {
+      return settlementWithin(promise, 5000);
+    });
+
+    const workers: Array<Worker> =
+      trippedQueuePool.getWorkerThreadsForTesting();
+    expect(workers.length).toBe(1);
+    await (workers[0] as Worker).terminate();
+
+    const outcomes: Array<Error | "resolved" | "pending"> =
+      await Promise.all(probes);
+
+    /*
+     * The thread death rejects the in-flight request; tripping the
+     * breaker (threshold 1) must then reject the queued requests too,
+     * not leave them stranded on a pool with no threads.
+     */
+    for (const outcome of outcomes) {
+      expect(outcome).toBeInstanceOf(Error);
+      expect((outcome as Error).message).toMatch(/^TelemetryDecodeThreadPool/);
+    }
+    expect((outcomes[0] as Error).message).toMatch(/thread death/);
+    expect((outcomes[1] as Error).message).toMatch(/unhealthy/);
+    expect((outcomes[2] as Error).message).toMatch(/unhealthy/);
+
+    expect(trippedQueuePool.getStats().healthy).toBe(false);
+    expect(trippedQueuePool.getStats().threadsAlive).toBe(0);
+    expect(trippedQueuePool.getStats().inFlight).toBe(0);
+    expect(trippedQueuePool.getStats().queued).toBe(0);
+    expect(trippedQueuePool.isAccepting()).toBe(false);
+  }, 60000);
+});

--- a/App/Tests/Telemetry/DecodeWorkerThreadEquivalence.test.ts
+++ b/App/Tests/Telemetry/DecodeWorkerThreadEquivalence.test.ts
@@ -1,0 +1,410 @@
+import { describe, expect, test, beforeAll, afterAll } from "@jest/globals";
+import path from "path";
+import protobuf from "protobufjs";
+import zlib from "zlib";
+import { Worker } from "worker_threads";
+import OtelDecode, {
+  OtelPayloadEncoding,
+  OtelPayloadFormat,
+} from "../../FeatureSet/Telemetry/Utils/OtelDecode";
+import {
+  DecodeRequestMessage,
+  DecodeResponseMessage,
+} from "../../FeatureSet/Telemetry/Utils/DecodeWorkerThread";
+import { JSONObject } from "Common/Types/JSON";
+import ProductType from "Common/Types/MeteredPlan/ProductType";
+
+/*
+ * THE core guarantee of the decode thread pool: a REAL worker thread
+ * running DecodeWorkerThread.ts returns results deep-equal to the
+ * inline OtelDecode.decodeBody, across the full product × format ×
+ * encoding matrix. If this holds, routing a payload to the pool can
+ * never change what downstream consumers see.
+ *
+ * The worker is spawned exactly the way DecodeThreadPool spawns it:
+ * the .ts entry file with `-r ts-node/register/transpile-only` in
+ * execArgv — explicitly, because THIS spawning process (jest/ts-jest)
+ * has no ts-node registered. (`--no-node-snapshot` is deliberately
+ * absent: Node rejects process-level flags in worker execArgv.)
+ *
+ * One worker is spawned in beforeAll and reused by every test in the
+ * file — a ts-node thread spawn costs seconds, so per-test spawns
+ * would blow the suite budget for no extra coverage.
+ */
+
+const WORKER_ENTRY_PATH: string = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Telemetry",
+  "Utils",
+  "DecodeWorkerThread.ts",
+);
+
+const APP_TSCONFIG_PATH: string = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "tsconfig.json",
+);
+
+const PROTO_DIR: string = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Telemetry",
+  "ProtoFiles",
+  "OTel",
+  "v1",
+);
+
+const LogsDataType: protobuf.Type = protobuf
+  .loadSync(path.join(PROTO_DIR, "logs.proto"))
+  .lookupType("LogsData");
+const TracesDataType: protobuf.Type = protobuf
+  .loadSync(path.join(PROTO_DIR, "traces.proto"))
+  .lookupType("TracesData");
+const MetricsDataType: protobuf.Type = protobuf
+  .loadSync(path.join(PROTO_DIR, "metrics.proto"))
+  .lookupType("MetricsData");
+
+const TRACE_ID_BASE64: string = Buffer.from([
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+]).toString("base64");
+const SPAN_ID_BASE64: string = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]).toString(
+  "base64",
+);
+
+const logsPayload: JSONObject = {
+  resourceLogs: [
+    {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "checkout-service" } },
+        ],
+      },
+      scopeLogs: [
+        {
+          scope: { name: "manual-instrumentation", version: "1.2.3" },
+          logRecords: [
+            {
+              timeUnixNano: "1700000000000000000",
+              severityNumber: "SEVERITY_NUMBER_INFO",
+              severityText: "INFO",
+              body: { stringValue: "payment accepted — naïve check ✓" },
+              traceId: TRACE_ID_BASE64,
+              spanId: SPAN_ID_BASE64,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const tracesPayload: JSONObject = {
+  resourceSpans: [
+    {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "api-gateway" } },
+        ],
+      },
+      scopeSpans: [
+        {
+          scope: { name: "http-server-instrumentation" },
+          spans: [
+            {
+              traceId: TRACE_ID_BASE64,
+              spanId: SPAN_ID_BASE64,
+              name: "GET /status",
+              kind: "SPAN_KIND_SERVER",
+              startTimeUnixNano: "1700000000000000000",
+              endTimeUnixNano: "1700000001000000000",
+              attributes: [
+                { key: "http.status_code", value: { intValue: "200" } },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const metricsPayload: JSONObject = {
+  resourceMetrics: [
+    {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "telemetry-worker" } },
+        ],
+      },
+      scopeMetrics: [
+        {
+          scope: { name: "queue-metrics" },
+          metrics: [
+            {
+              name: "queue.size",
+              unit: "1",
+              gauge: {
+                dataPoints: [
+                  { timeUnixNano: "1700000000000000000", asInt: "42" },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function encodeProtoFixture(
+  protoType: protobuf.Type,
+  plainPayload: JSONObject,
+): Buffer {
+  const message: protobuf.Message<Record<string, unknown>> =
+    protoType.fromObject(plainPayload);
+  return Buffer.from(protoType.encode(message).finish());
+}
+
+function gzipCompress(buffer: Buffer): Buffer {
+  // Cast: pinned @types/node Buffer vs TS 5.7+ generic typed arrays.
+  return zlib.gzipSync(buffer as unknown as Uint8Array);
+}
+
+let worker: Worker;
+let nextRequestId: number = 1;
+
+/*
+ * Send one decode request to the real worker and await its
+ * id-correlated response. Copies the body into a fresh ArrayBuffer and
+ * transfers it — the same handoff DecodeThreadPool performs.
+ */
+function decodeViaWorkerThread(input: {
+  productType: ProductType;
+  format: OtelPayloadFormat;
+  encoding: OtelPayloadEncoding;
+  body: Buffer;
+}): Promise<DecodeResponseMessage> {
+  const requestId: number = nextRequestId;
+  nextRequestId += 1;
+
+  const transferable: ArrayBuffer = new ArrayBuffer(input.body.length);
+  new Uint8Array(transferable).set(input.body as unknown as Uint8Array);
+
+  const message: DecodeRequestMessage = {
+    id: requestId,
+    productType: input.productType,
+    format: input.format,
+    encoding: input.encoding,
+    payload: transferable,
+  };
+
+  return new Promise<DecodeResponseMessage>(
+    (
+      resolve: (response: DecodeResponseMessage) => void,
+      reject: (error: Error) => void,
+    ) => {
+      const onMessage: (response: DecodeResponseMessage) => void = (
+        response: DecodeResponseMessage,
+      ): void => {
+        if (response.id !== requestId) {
+          return; // Another test's late response; not ours.
+        }
+        worker.off("message", onMessage);
+        worker.off("error", onError);
+        resolve(response);
+      };
+      const onError: (error: Error) => void = (error: Error): void => {
+        worker.off("message", onMessage);
+        worker.off("error", onError);
+        reject(error);
+      };
+      worker.on("message", onMessage);
+      worker.on("error", onError);
+      worker.postMessage(message, [transferable]);
+    },
+  );
+}
+
+beforeAll(() => {
+  worker = new Worker(WORKER_ENTRY_PATH, {
+    execArgv: ["-r", require.resolve("ts-node/register/transpile-only")],
+    env: {
+      ...process.env,
+      TS_NODE_PROJECT: APP_TSCONFIG_PATH,
+    },
+  });
+});
+
+afterAll(async () => {
+  await worker.terminate();
+});
+
+interface MatrixCase {
+  label: string;
+  productType: ProductType;
+  format: OtelPayloadFormat;
+  encoding: OtelPayloadEncoding;
+  body: Buffer;
+}
+
+function buildMatrix(): Array<MatrixCase> {
+  const products: Array<{
+    label: string;
+    productType: ProductType;
+    protoType: protobuf.Type;
+    jsonPayload: JSONObject;
+  }> = [
+    {
+      label: "logs",
+      productType: ProductType.Logs,
+      protoType: LogsDataType,
+      jsonPayload: logsPayload,
+    },
+    {
+      label: "traces",
+      productType: ProductType.Traces,
+      protoType: TracesDataType,
+      jsonPayload: tracesPayload,
+    },
+    {
+      label: "metrics",
+      productType: ProductType.Metrics,
+      protoType: MetricsDataType,
+      jsonPayload: metricsPayload,
+    },
+  ];
+
+  const matrix: Array<MatrixCase> = [];
+  for (const product of products) {
+    const protoBuffer: Buffer = encodeProtoFixture(
+      product.protoType,
+      product.jsonPayload,
+    );
+    const jsonBuffer: Buffer = Buffer.from(
+      JSON.stringify(product.jsonPayload),
+      "utf-8",
+    );
+
+    matrix.push({
+      label: `${product.label} protobuf none`,
+      productType: product.productType,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: protoBuffer,
+    });
+    matrix.push({
+      label: `${product.label} protobuf gzip`,
+      productType: product.productType,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "gzip",
+      body: gzipCompress(protoBuffer),
+    });
+    matrix.push({
+      label: `${product.label} json none`,
+      productType: product.productType,
+      format: OtelPayloadFormat.Json,
+      encoding: "none",
+      body: jsonBuffer,
+    });
+    matrix.push({
+      label: `${product.label} json gzip`,
+      productType: product.productType,
+      format: OtelPayloadFormat.Json,
+      encoding: "gzip",
+      body: gzipCompress(jsonBuffer),
+    });
+  }
+  return matrix;
+}
+
+describe("DecodeWorkerThread — equivalence with inline OtelDecode.decodeBody", () => {
+  test("the full product × format × encoding matrix decodes identically in-thread and inline", async () => {
+    const matrix: Array<MatrixCase> = buildMatrix();
+    expect(matrix.length).toBe(12);
+
+    for (const matrixCase of matrix) {
+      const inlineResult: JSONObject = await OtelDecode.decodeBody({
+        productType: matrixCase.productType,
+        format: matrixCase.format,
+        encoding: matrixCase.encoding,
+        body: matrixCase.body,
+      });
+
+      const threadResponse: DecodeResponseMessage = await decodeViaWorkerThread(
+        {
+          productType: matrixCase.productType,
+          format: matrixCase.format,
+          encoding: matrixCase.encoding,
+          body: matrixCase.body,
+        },
+      );
+
+      if (!threadResponse.ok) {
+        throw new Error(
+          `worker decode failed for ${matrixCase.label}: ${threadResponse.errorMessage}`,
+        );
+      }
+      expect(threadResponse.result).toEqual(inlineResult);
+    }
+  }, 60000);
+
+  test("malformed payload answers ok:false with the error text — and the thread survives", async () => {
+    const malformedResponse: DecodeResponseMessage =
+      await decodeViaWorkerThread({
+        productType: ProductType.Logs,
+        format: OtelPayloadFormat.Protobuf,
+        encoding: "gzip",
+        body: Buffer.from("not gzip at all", "utf-8"),
+      });
+
+    expect(malformedResponse.ok).toBe(false);
+    if (malformedResponse.ok) {
+      throw new Error("expected an ok:false response");
+    }
+    expect(malformedResponse.errorMessage).toMatch(
+      /incorrect header check|unknown compression method/,
+    );
+
+    /*
+     * The per-message failure must NOT have killed the thread: the very
+     * same worker decodes the next payload successfully.
+     */
+    const followUpBody: Buffer = encodeProtoFixture(LogsDataType, logsPayload);
+    const followUpResponse: DecodeResponseMessage = await decodeViaWorkerThread(
+      {
+        productType: ProductType.Logs,
+        format: OtelPayloadFormat.Protobuf,
+        encoding: "none",
+        body: followUpBody,
+      },
+    );
+
+    if (!followUpResponse.ok) {
+      throw new Error(
+        `follow-up decode failed: ${followUpResponse.errorMessage}`,
+      );
+    }
+    expect(followUpResponse.result).toEqual(logsPayload);
+  }, 60000);
+
+  test("the 'no proto type' error crosses the thread boundary verbatim", async () => {
+    const response: DecodeResponseMessage = await decodeViaWorkerThread({
+      productType: ProductType.SessionReplay,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: Buffer.alloc(0),
+    });
+
+    expect(response.ok).toBe(false);
+    if (response.ok) {
+      throw new Error("expected an ok:false response");
+    }
+    expect(response.errorMessage).toMatch(/OtelPayloadDecoder: no proto type/);
+  }, 60000);
+});

--- a/App/Tests/Telemetry/OtelDecodeUnit.test.ts
+++ b/App/Tests/Telemetry/OtelDecodeUnit.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, test, beforeAll } from "@jest/globals";
+import path from "path";
+import protobuf from "protobufjs";
+import zlib from "zlib";
+import OtelDecode, {
+  OtelPayloadFormat,
+  gunzipAsync,
+} from "../../FeatureSet/Telemetry/Utils/OtelDecode";
+import { JSONObject } from "Common/Types/JSON";
+import ProductType from "Common/Types/MeteredPlan/ProductType";
+
+/*
+ * Unit tests for the pure decode module (OtelDecode.decodeBody), which
+ * is the ONE decode implementation shared by the inline path
+ * (OtelPayloadDecoder.decodeFromQueue) and the worker-thread path
+ * (DecodeWorkerThread). The matrix here — every product × format ×
+ * encoding — is the same one DecodeWorkerThreadEquivalence.test.ts
+ * replays through a real thread; together they pin "one
+ * implementation, two call sites" to identical observable behavior.
+ *
+ * Fixtures are real OTel protobuf messages encoded with the actual
+ * proto files shipped in ProtoFiles/OTel/v1 — no hand-rolled bytes
+ * (same approach as OtelPayloadDecoderBufferPassthrough.test.ts).
+ */
+
+const PROTO_DIR: string = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Telemetry",
+  "ProtoFiles",
+  "OTel",
+  "v1",
+);
+
+const LogsDataType: protobuf.Type = protobuf
+  .loadSync(path.join(PROTO_DIR, "logs.proto"))
+  .lookupType("LogsData");
+const TracesDataType: protobuf.Type = protobuf
+  .loadSync(path.join(PROTO_DIR, "traces.proto"))
+  .lookupType("TracesData");
+const MetricsDataType: protobuf.Type = protobuf
+  .loadSync(path.join(PROTO_DIR, "metrics.proto"))
+  .lookupType("MetricsData");
+
+/*
+ * Fixture payloads in protobufjs `toJSON()` canonical form (longs as
+ * strings, enums as names, bytes as base64) so a full fromObject ->
+ * encode -> decode -> toJSON round-trip reproduces them verbatim.
+ */
+const TRACE_ID_BASE64: string = Buffer.from([
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+]).toString("base64");
+const SPAN_ID_BASE64: string = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]).toString(
+  "base64",
+);
+
+const logsPayload: JSONObject = {
+  resourceLogs: [
+    {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "checkout-service" } },
+        ],
+      },
+      scopeLogs: [
+        {
+          scope: { name: "manual-instrumentation", version: "1.2.3" },
+          logRecords: [
+            {
+              timeUnixNano: "1700000000000000000",
+              severityNumber: "SEVERITY_NUMBER_INFO",
+              severityText: "INFO",
+              body: { stringValue: "payment accepted — naïve check ✓" },
+              traceId: TRACE_ID_BASE64,
+              spanId: SPAN_ID_BASE64,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const tracesPayload: JSONObject = {
+  resourceSpans: [
+    {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "api-gateway" } },
+        ],
+      },
+      scopeSpans: [
+        {
+          scope: { name: "http-server-instrumentation" },
+          spans: [
+            {
+              traceId: TRACE_ID_BASE64,
+              spanId: SPAN_ID_BASE64,
+              name: "GET /status",
+              kind: "SPAN_KIND_SERVER",
+              startTimeUnixNano: "1700000000000000000",
+              endTimeUnixNano: "1700000001000000000",
+              attributes: [
+                { key: "http.status_code", value: { intValue: "200" } },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const metricsPayload: JSONObject = {
+  resourceMetrics: [
+    {
+      resource: {
+        attributes: [
+          { key: "service.name", value: { stringValue: "telemetry-worker" } },
+        ],
+      },
+      scopeMetrics: [
+        {
+          scope: { name: "queue-metrics" },
+          metrics: [
+            {
+              name: "queue.size",
+              unit: "1",
+              gauge: {
+                dataPoints: [
+                  { timeUnixNano: "1700000000000000000", asInt: "42" },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function encodeProtoFixture(
+  protoType: protobuf.Type,
+  plainPayload: JSONObject,
+): Buffer {
+  const message: protobuf.Message<Record<string, unknown>> =
+    protoType.fromObject(plainPayload);
+  return Buffer.from(protoType.encode(message).finish());
+}
+
+/*
+ * The `as unknown as` cast is type-level only: with TypeScript 5.7+
+ * generic typed arrays, the pinned @types/node's `Buffer` no longer
+ * structurally satisfies `zlib.InputType` even though a Buffer is a
+ * valid zlib input at runtime (same workaround OtelDecode documents).
+ */
+function gzipCompress(buffer: Buffer): Buffer {
+  return zlib.gzipSync(buffer as unknown as Uint8Array);
+}
+
+interface MatrixFixture {
+  label: string;
+  productType: ProductType;
+  protoBuffer: Buffer;
+  jsonPayload: JSONObject;
+}
+
+let matrixFixtures: Array<MatrixFixture> = [];
+
+beforeAll(() => {
+  matrixFixtures = [
+    {
+      label: "logs",
+      productType: ProductType.Logs,
+      protoBuffer: encodeProtoFixture(LogsDataType, logsPayload),
+      jsonPayload: logsPayload,
+    },
+    {
+      label: "traces",
+      productType: ProductType.Traces,
+      protoBuffer: encodeProtoFixture(TracesDataType, tracesPayload),
+      jsonPayload: tracesPayload,
+    },
+    {
+      label: "metrics",
+      productType: ProductType.Metrics,
+      protoBuffer: encodeProtoFixture(MetricsDataType, metricsPayload),
+      jsonPayload: metricsPayload,
+    },
+  ];
+});
+
+describe("OtelDecode.decodeBody — fixture matrix (product × format × encoding)", () => {
+  test("protobuf + none: every product decodes to its canonical OTel JSON", async () => {
+    for (const fixture of matrixFixtures) {
+      const decoded: JSONObject = await OtelDecode.decodeBody({
+        productType: fixture.productType,
+        format: OtelPayloadFormat.Protobuf,
+        encoding: "none",
+        body: fixture.protoBuffer,
+      });
+      expect(decoded).toEqual(fixture.jsonPayload);
+    }
+  });
+
+  test("protobuf + gzip: every product inflates then decodes identically", async () => {
+    for (const fixture of matrixFixtures) {
+      const decoded: JSONObject = await OtelDecode.decodeBody({
+        productType: fixture.productType,
+        format: OtelPayloadFormat.Protobuf,
+        encoding: "gzip",
+        body: gzipCompress(fixture.protoBuffer),
+      });
+      expect(decoded).toEqual(fixture.jsonPayload);
+    }
+  });
+
+  test("json + none: every product parses the raw UTF-8 body", async () => {
+    for (const fixture of matrixFixtures) {
+      const decoded: JSONObject = await OtelDecode.decodeBody({
+        productType: fixture.productType,
+        format: OtelPayloadFormat.Json,
+        encoding: "none",
+        body: Buffer.from(JSON.stringify(fixture.jsonPayload), "utf-8"),
+      });
+      expect(decoded).toEqual(fixture.jsonPayload);
+    }
+  });
+
+  test("json + gzip: every product inflates then parses identically", async () => {
+    for (const fixture of matrixFixtures) {
+      const decoded: JSONObject = await OtelDecode.decodeBody({
+        productType: fixture.productType,
+        format: OtelPayloadFormat.Json,
+        encoding: "gzip",
+        body: gzipCompress(
+          Buffer.from(JSON.stringify(fixture.jsonPayload), "utf-8"),
+        ),
+      });
+      expect(decoded).toEqual(fixture.jsonPayload);
+    }
+  });
+});
+
+describe("OtelDecode.decodeBody — error and edge cases", () => {
+  test("malformed protobuf throws", async () => {
+    /*
+     * 0x08 declares "field 1, varint" and then the payload ends —
+     * protobufjs' reader runs off the end of the buffer.
+     */
+    await expect(
+      OtelDecode.decodeBody({
+        productType: ProductType.Logs,
+        format: OtelPayloadFormat.Protobuf,
+        encoding: "none",
+        body: Buffer.from([0x08]),
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("malformed gzip throws", async () => {
+    await expect(
+      OtelDecode.decodeBody({
+        productType: ProductType.Logs,
+        format: OtelPayloadFormat.Protobuf,
+        encoding: "gzip",
+        body: Buffer.from("definitely not a gzip stream", "utf-8"),
+      }),
+    ).rejects.toThrow(/incorrect header check|unknown compression method/);
+  });
+
+  test("malformed JSON throws", async () => {
+    await expect(
+      OtelDecode.decodeBody({
+        productType: ProductType.Logs,
+        format: OtelPayloadFormat.Json,
+        encoding: "none",
+        body: Buffer.from("{not json", "utf-8"),
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("empty protobuf body decodes to {} (an empty message is valid)", async () => {
+    const decoded: JSONObject = await OtelDecode.decodeBody({
+      productType: ProductType.Profiles,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "none",
+      body: Buffer.alloc(0),
+    });
+    expect(decoded).toEqual({});
+  });
+
+  test("empty JSON body throws (empty string is not valid JSON)", async () => {
+    await expect(
+      OtelDecode.decodeBody({
+        productType: ProductType.Logs,
+        format: OtelPayloadFormat.Json,
+        encoding: "none",
+        body: Buffer.alloc(0),
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("protobuf format with a product that has no proto type throws the preserved message", async () => {
+    await expect(
+      OtelDecode.decodeBody({
+        productType: ProductType.SessionReplay,
+        format: OtelPayloadFormat.Protobuf,
+        encoding: "none",
+        body: Buffer.from([]),
+      }),
+    ).rejects.toThrow(/OtelPayloadDecoder: no proto type/);
+  });
+
+  test("json format ignores productType entirely (no proto lookup, no throw)", async () => {
+    const decoded: JSONObject = await OtelDecode.decodeBody({
+      productType: ProductType.SessionReplay,
+      format: OtelPayloadFormat.Json,
+      encoding: "none",
+      body: Buffer.from(JSON.stringify({ events: [] }), "utf-8"),
+    });
+    expect(decoded).toEqual({ events: [] });
+  });
+
+  test("exported gunzipAsync round-trips (export preserved for existing importers)", async () => {
+    const original: Buffer = Buffer.from("hello otel decode", "utf-8");
+    const inflated: Buffer = await gunzipAsync(gzipCompress(original));
+    expect(inflated.toString("utf-8")).toBe("hello otel decode");
+  });
+});

--- a/App/Tests/Telemetry/OtelPayloadDecoderRouting.test.ts
+++ b/App/Tests/Telemetry/OtelPayloadDecoderRouting.test.ts
@@ -3,13 +3,21 @@ import { describe, expect, test, afterEach } from "@jest/globals";
 /*
  * decodeFromQueue routing: pool-vs-inline decision making, with
  * TelemetryBodyStore mocked (in-memory) and the REAL DecodeThreadPool
- * module spied on — no actual threads are spawned here (the default
- * TELEMETRY_DECODE_THREADS=0 keeps the singleton unconstructed, and
- * the pool-path test stubs decode() with an inline delegate).
+ * module spied on — no actual threads are spawned here: every test
+ * that could reach the pool either stubs decode() with an inline
+ * delegate or mocks isAvailable() to false. (That mocking is REQUIRED
+ * now, not a convenience: the pool is ENABLED BY DEFAULT with an
+ * adaptive thread count, so on a multi-CPU test machine an unmocked
+ * isAvailable() is true and a call-through decode() would spawn real
+ * threads.)
  *
  * What is pinned:
- *   - pool disabled (the DEFAULT — this suite runs with no decode env
- *     vars set) => inline decode, pool never touched;
+ *   - the DEFAULT contract: with no decode env vars set, TELEMETRY_
+ *     DECODE_THREADS resolves adaptively (clamp(effectiveCpus-1, 0, 4),
+ *     cgroup-aware) and isEnabled() follows it — enabled whenever the
+ *     adaptive count is > 0;
+ *   - pool unavailable (resolved to 0 threads / unhealthy / cooldown)
+ *     => inline decode, pool's decode never touched;
  *   - pool available but payload below TELEMETRY_DECODE_MIN_PAYLOAD_
  *     BYTES => inline;
  *   - pool available and payload at/above the threshold => pool;
@@ -38,7 +46,11 @@ import OtelDecode from "../../FeatureSet/Telemetry/Utils/OtelDecode";
 import DecodeThreadPool, {
   DecodeInput,
 } from "../../FeatureSet/Telemetry/Utils/DecodeThreadPool";
-import { TELEMETRY_DECODE_MIN_PAYLOAD_BYTES } from "../../FeatureSet/Telemetry/Config";
+import {
+  TELEMETRY_DECODE_MIN_PAYLOAD_BYTES,
+  TELEMETRY_DECODE_THREADS,
+} from "../../FeatureSet/Telemetry/Config";
+import CpuCount from "Common/Server/Utils/CpuCount";
 import { JSONObject } from "Common/Types/JSON";
 import ProductType from "Common/Types/MeteredPlan/ProductType";
 
@@ -112,12 +124,32 @@ function makeJsonBodyOfExactSize(totalBytes: number): Buffer {
 }
 
 describe("OtelPayloadDecoder.decodeFromQueue — pool/inline routing", () => {
-  test("this suite runs with the pool DISABLED by default (TELEMETRY_DECODE_THREADS=0)", () => {
-    expect(DecodeThreadPool.isEnabled()).toBe(false);
-    expect(DecodeThreadPool.isAvailable()).toBe(false);
+  test("DEFAULT contract: unset env resolves adaptively (clamp(effectiveCpus-1, 0, 4)) and isEnabled() follows it", () => {
+    /*
+     * This suite imports the REAL Config (no isolated reload), so the
+     * adaptive-equality half only holds when the machine running the
+     * tests has not exported an explicit TELEMETRY_DECODE_THREADS —
+     * which is the case for `npm test` (config.env sets none). The
+     * isEnabled()-follows-the-resolved-value half holds either way.
+     */
+    if (process.env["TELEMETRY_DECODE_THREADS"] === undefined) {
+      const adaptiveExpected: number = Math.min(
+        4,
+        Math.max(0, CpuCount.getEffectiveCpuCount() - 1),
+      );
+      expect(TELEMETRY_DECODE_THREADS).toBe(adaptiveExpected);
+    }
+    expect(DecodeThreadPool.isEnabled()).toBe(TELEMETRY_DECODE_THREADS > 0);
   });
 
-  test("pool disabled: a large payload decodes inline and the pool is never touched", async () => {
+  test("pool unavailable (resolved to 0 threads, or unhealthy): a large payload decodes inline and the pool's decode is never touched", async () => {
+    /*
+     * isAvailable() is pinned false explicitly: with the default now
+     * adaptive, its natural value here depends on the test machine's
+     * CPU count. False is what a 1-effective-CPU pod (or an explicit
+     * TELEMETRY_DECODE_THREADS=0) resolves to.
+     */
+    spyOnStatic(DecodeThreadPool, "isAvailable").mockReturnValue(false);
     const decodeSpy: SpyLike = spyOnStatic(DecodeThreadPool, "decode");
     const largeBody: Buffer = makeJsonBodyOfExactSize(
       TELEMETRY_DECODE_MIN_PAYLOAD_BYTES + 1000,

--- a/App/Tests/Telemetry/OtelPayloadDecoderRouting.test.ts
+++ b/App/Tests/Telemetry/OtelPayloadDecoderRouting.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, test, afterEach } from "@jest/globals";
+
+/*
+ * decodeFromQueue routing: pool-vs-inline decision making, with
+ * TelemetryBodyStore mocked (in-memory) and the REAL DecodeThreadPool
+ * module spied on — no actual threads are spawned here (the default
+ * TELEMETRY_DECODE_THREADS=0 keeps the singleton unconstructed, and
+ * the pool-path test stubs decode() with an inline delegate).
+ *
+ * What is pinned:
+ *   - pool disabled (the DEFAULT — this suite runs with no decode env
+ *     vars set) => inline decode, pool never touched;
+ *   - pool available but payload below TELEMETRY_DECODE_MIN_PAYLOAD_
+ *     BYTES => inline;
+ *   - pool available and payload at/above the threshold => pool;
+ *   - pool unavailable (unhealthy/cooldown) => inline fallback with a
+ *     result identical to the pool path;
+ *   - missing body (TTL expired) => {} without consulting the pool.
+ */
+
+const mockBodyStoreBackingMap: Map<string, Buffer> = new Map();
+
+jest.mock("../../FeatureSet/Telemetry/Utils/TelemetryBodyStore", () => {
+  return {
+    __esModule: true,
+    default: {
+      readBody: (bodyKey: string): Promise<Buffer | null> => {
+        return Promise.resolve(mockBodyStoreBackingMap.get(bodyKey) || null);
+      },
+    },
+  };
+});
+
+import OtelPayloadDecoder, {
+  OtelPayloadFormat,
+} from "../../FeatureSet/Telemetry/Utils/OtelPayloadDecoder";
+import OtelDecode from "../../FeatureSet/Telemetry/Utils/OtelDecode";
+import DecodeThreadPool, {
+  DecodeInput,
+} from "../../FeatureSet/Telemetry/Utils/DecodeThreadPool";
+import { TELEMETRY_DECODE_MIN_PAYLOAD_BYTES } from "../../FeatureSet/Telemetry/Config";
+import { JSONObject } from "Common/Types/JSON";
+import ProductType from "Common/Types/MeteredPlan/ProductType";
+
+/*
+ * Minimal structural spy type — the pinned jest 28 typings fight
+ * jest.spyOn on static methods, so tests here follow the SpyLike
+ * pattern used by OtelPayloadDecoderBufferPassthrough.test.ts.
+ */
+type SpyLike = {
+  mock: {
+    calls: Array<Array<unknown>>;
+  };
+  mockImplementation: (
+    implementation: (...args: Array<never>) => unknown,
+  ) => SpyLike;
+  mockReturnValue: (value: unknown) => SpyLike;
+  mockRestore: () => void;
+};
+
+let activeSpies: Array<SpyLike> = [];
+
+function spyOnStatic(target: unknown, methodName: string): SpyLike {
+  const spy: SpyLike = jest.spyOn(
+    target as never,
+    methodName as never,
+  ) as unknown as SpyLike;
+  activeSpies.push(spy);
+  return spy;
+}
+
+afterEach(() => {
+  for (const spy of activeSpies) {
+    spy.mockRestore();
+  }
+  activeSpies = [];
+  mockBodyStoreBackingMap.clear();
+});
+
+let bodyKeyCounter: number = 0;
+
+function storeBody(buffer: Buffer): string {
+  bodyKeyCounter += 1;
+  const bodyKey: string = `telemetry:body:routing-${bodyKeyCounter}`;
+  mockBodyStoreBackingMap.set(bodyKey, buffer);
+  return bodyKey;
+}
+
+/*
+ * JSON payloads sized around the routing threshold. The routing
+ * comparison is on the RAW stored length, so the fixtures are built to
+ * exact byte sizes: `{"pad":"aa...a"}` with a computed pad length.
+ */
+function makeJsonBodyOfExactSize(totalBytes: number): Buffer {
+  const envelopeOverhead: number = Buffer.byteLength('{"pad":""}', "utf-8");
+  const padLength: number = totalBytes - envelopeOverhead;
+  if (padLength < 0) {
+    throw new Error(
+      `cannot build a JSON body smaller than ${envelopeOverhead} bytes`,
+    );
+  }
+  const body: Buffer = Buffer.from(
+    JSON.stringify({ pad: "a".repeat(padLength) }),
+    "utf-8",
+  );
+  if (body.length !== totalBytes) {
+    throw new Error(
+      `fixture bug: built ${body.length} bytes, wanted ${totalBytes}`,
+    );
+  }
+  return body;
+}
+
+describe("OtelPayloadDecoder.decodeFromQueue — pool/inline routing", () => {
+  test("this suite runs with the pool DISABLED by default (TELEMETRY_DECODE_THREADS=0)", () => {
+    expect(DecodeThreadPool.isEnabled()).toBe(false);
+    expect(DecodeThreadPool.isAvailable()).toBe(false);
+  });
+
+  test("pool disabled: a large payload decodes inline and the pool is never touched", async () => {
+    const decodeSpy: SpyLike = spyOnStatic(DecodeThreadPool, "decode");
+    const largeBody: Buffer = makeJsonBodyOfExactSize(
+      TELEMETRY_DECODE_MIN_PAYLOAD_BYTES + 1000,
+    );
+    const bodyKey: string = storeBody(largeBody);
+
+    const decoded: JSONObject = await OtelPayloadDecoder.decodeFromQueue({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Json,
+      encoding: "none",
+      bodyKey: bodyKey,
+    });
+
+    expect(decoded).toEqual(JSON.parse(largeBody.toString("utf-8")));
+    expect(decodeSpy.mock.calls.length).toBe(0);
+  });
+
+  test("pool available + payload below threshold: decodes inline", async () => {
+    spyOnStatic(DecodeThreadPool, "isAvailable").mockReturnValue(true);
+    const decodeSpy: SpyLike = spyOnStatic(DecodeThreadPool, "decode");
+
+    const smallBody: Buffer = makeJsonBodyOfExactSize(
+      TELEMETRY_DECODE_MIN_PAYLOAD_BYTES - 1,
+    );
+    const bodyKey: string = storeBody(smallBody);
+
+    const decoded: JSONObject = await OtelPayloadDecoder.decodeFromQueue({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Json,
+      encoding: "none",
+      bodyKey: bodyKey,
+    });
+
+    expect(decoded).toEqual(JSON.parse(smallBody.toString("utf-8")));
+    expect(decodeSpy.mock.calls.length).toBe(0);
+  });
+
+  test("pool available + payload AT the threshold (boundary, >=): routes to the pool", async () => {
+    spyOnStatic(DecodeThreadPool, "isAvailable").mockReturnValue(true);
+    const decodeSpy: SpyLike = spyOnStatic(
+      DecodeThreadPool,
+      "decode",
+    ).mockImplementation((input: DecodeInput) => {
+      // Delegate to the shared implementation, as a real thread would.
+      return OtelDecode.decodeBody(input);
+    });
+
+    const boundaryBody: Buffer = makeJsonBodyOfExactSize(
+      TELEMETRY_DECODE_MIN_PAYLOAD_BYTES,
+    );
+    const bodyKey: string = storeBody(boundaryBody);
+
+    const decoded: JSONObject = await OtelPayloadDecoder.decodeFromQueue({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Json,
+      encoding: "none",
+      bodyKey: bodyKey,
+    });
+
+    expect(decoded).toEqual(JSON.parse(boundaryBody.toString("utf-8")));
+    expect(decodeSpy.mock.calls.length).toBe(1);
+  });
+
+  test("pool available + payload above threshold: routes to the pool with the raw body", async () => {
+    spyOnStatic(DecodeThreadPool, "isAvailable").mockReturnValue(true);
+    const decodeSpy: SpyLike = spyOnStatic(
+      DecodeThreadPool,
+      "decode",
+    ).mockImplementation((input: DecodeInput) => {
+      return OtelDecode.decodeBody(input);
+    });
+
+    const largeBody: Buffer = makeJsonBodyOfExactSize(
+      TELEMETRY_DECODE_MIN_PAYLOAD_BYTES + 5000,
+    );
+    const bodyKey: string = storeBody(largeBody);
+
+    const decoded: JSONObject = await OtelPayloadDecoder.decodeFromQueue({
+      productType: ProductType.Traces,
+      format: OtelPayloadFormat.Json,
+      encoding: "none",
+      bodyKey: bodyKey,
+    });
+
+    expect(decoded).toEqual(JSON.parse(largeBody.toString("utf-8")));
+    expect(decodeSpy.mock.calls.length).toBe(1);
+
+    // The pool receives the EXACT Buffer read from the body store.
+    const poolInput: DecodeInput = decodeSpy.mock.calls[0]?.[0] as DecodeInput;
+    expect(poolInput.body).toBe(largeBody);
+    expect(poolInput.productType).toBe(ProductType.Traces);
+    expect(poolInput.format).toBe(OtelPayloadFormat.Json);
+    expect(poolInput.encoding).toBe("none");
+  });
+
+  test("pool unavailable (unhealthy/cooldown): inline fallback returns the identical result", async () => {
+    /*
+     * First, what the pool path WOULD have produced (decode delegates
+     * to the shared implementation)...
+     */
+    const largeBody: Buffer = makeJsonBodyOfExactSize(
+      TELEMETRY_DECODE_MIN_PAYLOAD_BYTES + 2000,
+    );
+
+    const availableSpy: SpyLike = spyOnStatic(
+      DecodeThreadPool,
+      "isAvailable",
+    ).mockReturnValue(true);
+    const decodeSpy: SpyLike = spyOnStatic(
+      DecodeThreadPool,
+      "decode",
+    ).mockImplementation((input: DecodeInput) => {
+      return OtelDecode.decodeBody(input);
+    });
+
+    const pooledResult: JSONObject = await OtelPayloadDecoder.decodeFromQueue({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Json,
+      encoding: "none",
+      bodyKey: storeBody(largeBody),
+    });
+    expect(decodeSpy.mock.calls.length).toBe(1);
+
+    // ...then the same payload with the pool marked unavailable.
+    availableSpy.mockReturnValue(false);
+
+    const inlineResult: JSONObject = await OtelPayloadDecoder.decodeFromQueue({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Json,
+      encoding: "none",
+      bodyKey: storeBody(largeBody),
+    });
+
+    // No second pool call, and byte-identical output.
+    expect(decodeSpy.mock.calls.length).toBe(1);
+    expect(inlineResult).toEqual(pooledResult);
+  });
+
+  test("missing body (TTL expired) returns {} without consulting the pool", async () => {
+    const availableSpy: SpyLike = spyOnStatic(DecodeThreadPool, "isAvailable");
+    const decodeSpy: SpyLike = spyOnStatic(DecodeThreadPool, "decode");
+
+    const decoded: JSONObject = await OtelPayloadDecoder.decodeFromQueue({
+      productType: ProductType.Logs,
+      format: OtelPayloadFormat.Protobuf,
+      encoding: "gzip",
+      bodyKey: "telemetry:body:never-stored",
+    });
+
+    expect(decoded).toEqual({});
+    expect(availableSpy.mock.calls.length).toBe(0);
+    expect(decodeSpy.mock.calls.length).toBe(0);
+  });
+
+  test("empty bodyKey still throws (unchanged contract)", async () => {
+    await expect(
+      OtelPayloadDecoder.decodeFromQueue({
+        productType: ProductType.Logs,
+        format: OtelPayloadFormat.Protobuf,
+        encoding: "none",
+        bodyKey: "",
+      }),
+    ).rejects.toThrow(/bodyKey is required/);
+  });
+});

--- a/App/Tests/Telemetry/ProcessTelemetryBatchedInserts.test.ts
+++ b/App/Tests/Telemetry/ProcessTelemetryBatchedInserts.test.ts
@@ -29,6 +29,27 @@ import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
  * ProcessTelemetry.ts fails every substantive test in this file.
  */
 
+/*
+ * PasswordHash has a pre-existing TS5.9 ts-jest compile error (crypto
+ * BinaryLike vs Buffer) and is pulled in transitively through the service
+ * layer. Nothing password-related is under test here, so the module is
+ * replaced WITH A FACTORY — an automock would still require (and
+ * type-check) the real file. Same workaround as the other suites in this
+ * directory.
+ */
+jest.mock("Common/Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
 let capturedHandler: ((job: unknown) => Promise<void>) | null = null;
 
 jest.mock("Common/Server/Infrastructure/QueueWorker", () => {

--- a/App/Tests/Telemetry/TelemetryDecodeConfig.test.ts
+++ b/App/Tests/Telemetry/TelemetryDecodeConfig.test.ts
@@ -1,18 +1,28 @@
 import { describe, expect, test } from "@jest/globals";
+import CpuCount from "Common/Server/Utils/CpuCount";
 
 /*
  * Env parsing for the decode thread pool knobs:
  *
- *   - TELEMETRY_DECODE_THREADS: default 0 (pool DISABLED — the
- *     load-bearing default: shipping this feature must not change any
- *     deployment's behavior until it is explicitly opted into), 0 is a
- *     VALID explicit value (the strictly-positive parseBatchSize would
- *     have made "off" unexpressable), negatives/garbage fall back.
+ *   - TELEMETRY_DECODE_THREADS: default ADAPTIVE — the pool is ENABLED
+ *     BY DEFAULT, sized clamp(effectiveCpuCount - 1, 0, 4) where
+ *     effectiveCpuCount is cgroup-aware (Common/Server/Utils/CpuCount).
+ *     One core stays reserved for the event loop, so a 1-effective-CPU
+ *     pod adapts to 0 threads (pool off, inline decode — no regression
+ *     for the smallest pods). 0 is a VALID explicit value and is the
+ *     hard-off switch (the strictly-positive parseBatchSize would have
+ *     made "off" unexpressable); a positive value pins the count;
+ *     negatives/garbage fall back to the ADAPTIVE default — NOT to 0 —
+ *     so an operator typo cannot silently disable a default-on
+ *     subsystem.
  *   - TELEMETRY_DECODE_MIN_PAYLOAD_BYTES: default 8192, 0 valid
  *     ("no minimum, route everything"), negatives/garbage fall back.
  *
  * The config module reads env at import time, so each case re-imports
  * it in isolation (same pattern as ClickhouseKeepAliveOptions.test.ts).
+ * The adaptive cases inject a fake CpuCount via jest.doMock inside the
+ * isolated registry, which makes the CPU-dependent expectations
+ * deterministic on any test machine.
  */
 
 type TelemetryConfigModule = {
@@ -57,52 +67,141 @@ function withEnv<T>(
 
 function loadConfig(
   env: Record<string, string | undefined>,
+  options?: {
+    /*
+     * When provided, the isolated registry gets a fake CpuCount whose
+     * getEffectiveCpuCount returns exactly this value — the adaptive-
+     * default cases would otherwise depend on the test machine's (and
+     * its cgroup's) real CPU count.
+     */
+    effectiveCpuCount?: number;
+  },
 ): TelemetryConfigModule {
   let loaded: TelemetryConfigModule | undefined = undefined;
 
   jest.isolateModules(() => {
-    withEnv(env, () => {
-      /* eslint-disable @typescript-eslint/no-var-requires */
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      loaded = require("../../FeatureSet/Telemetry/Config");
-      /* eslint-enable @typescript-eslint/no-var-requires */
-    });
+    if (options?.effectiveCpuCount !== undefined) {
+      jest.doMock("Common/Server/Utils/CpuCount", () => {
+        return {
+          __esModule: true,
+          default: {
+            getEffectiveCpuCount: (): number => {
+              return options.effectiveCpuCount as number;
+            },
+          },
+        };
+      });
+    }
+
+    try {
+      withEnv(env, () => {
+        /* eslint-disable @typescript-eslint/no-var-requires */
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        loaded = require("../../FeatureSet/Telemetry/Config");
+        /* eslint-enable @typescript-eslint/no-var-requires */
+      });
+    } finally {
+      if (options?.effectiveCpuCount !== undefined) {
+        // Keep the mock scoped to THIS isolated load only.
+        jest.dontMock("Common/Server/Utils/CpuCount");
+      }
+    }
   });
 
   return loaded!;
 }
 
 describe("TELEMETRY_DECODE_THREADS parsing", () => {
-  test("defaults to 0 (pool disabled) when unset", () => {
-    const config: TelemetryConfigModule = loadConfig({});
+  describe("unset -> adaptive default: clamp(effectiveCpuCount - 1, 0, 4)", () => {
+    /*
+     * The full clamp table. 1 CPU -> 0 is the load-bearing row: the
+     * smallest pods keep the exact pre-pool inline behavior; the >= 5
+     * rows pin the memory-bounding cap of 4.
+     */
+    const clampTable: Array<{ cpus: number; threads: number }> = [
+      { cpus: 1, threads: 0 },
+      { cpus: 2, threads: 1 },
+      { cpus: 3, threads: 2 },
+      { cpus: 4, threads: 3 },
+      { cpus: 5, threads: 4 },
+      { cpus: 8, threads: 4 },
+      { cpus: 64, threads: 4 },
+    ];
+
+    for (const row of clampTable) {
+      test(`${row.cpus} effective CPU(s) -> ${row.threads} thread(s)`, () => {
+        const config: TelemetryConfigModule = loadConfig(
+          {},
+          { effectiveCpuCount: row.cpus },
+        );
+        expect(config.TELEMETRY_DECODE_THREADS).toBe(row.threads);
+      });
+    }
+
+    test("unlimited cgroup (real CpuCount, no mock) -> min(4, hostCpus - 1)", () => {
+      /*
+       * Same computation Config.ts performs, fed from the REAL utility
+       * on this machine — pins that the config actually consults
+       * CpuCount rather than some other CPU source. (On an unlimited /
+       * non-cgroup machine getEffectiveCpuCount() is the host
+       * parallelism, so the expectation is min(4, host - 1).)
+       */
+      const expected: number = Math.min(
+        4,
+        Math.max(0, CpuCount.getEffectiveCpuCount() - 1),
+      );
+      const config: TelemetryConfigModule = loadConfig({});
+      expect(config.TELEMETRY_DECODE_THREADS).toBe(expected);
+    });
+  });
+
+  test("a valid positive override pins the count (beats the adaptive default)", () => {
+    const config: TelemetryConfigModule = loadConfig(
+      {
+        TELEMETRY_DECODE_THREADS: "6",
+      },
+      { effectiveCpuCount: 2 },
+    );
+    expect(config.TELEMETRY_DECODE_THREADS).toBe(6);
+  });
+
+  test("an explicit 0 hard-disables — even on a many-CPU machine", () => {
+    const config: TelemetryConfigModule = loadConfig(
+      {
+        TELEMETRY_DECODE_THREADS: "0",
+      },
+      { effectiveCpuCount: 8 },
+    );
     expect(config.TELEMETRY_DECODE_THREADS).toBe(0);
   });
 
-  test("a valid positive override is honored", () => {
-    const config: TelemetryConfigModule = loadConfig({
-      TELEMETRY_DECODE_THREADS: "4",
-    });
+  test("a negative value falls back to the ADAPTIVE default (not 0)", () => {
+    const config: TelemetryConfigModule = loadConfig(
+      {
+        TELEMETRY_DECODE_THREADS: "-2",
+      },
+      { effectiveCpuCount: 8 },
+    );
     expect(config.TELEMETRY_DECODE_THREADS).toBe(4);
   });
 
-  test("an explicit 0 is accepted (NOT treated as invalid-falls-back)", () => {
-    const config: TelemetryConfigModule = loadConfig({
-      TELEMETRY_DECODE_THREADS: "0",
-    });
-    expect(config.TELEMETRY_DECODE_THREADS).toBe(0);
+  test("a non-numeric value falls back to the ADAPTIVE default (not 0)", () => {
+    const config: TelemetryConfigModule = loadConfig(
+      {
+        TELEMETRY_DECODE_THREADS: "many",
+      },
+      { effectiveCpuCount: 3 },
+    );
+    expect(config.TELEMETRY_DECODE_THREADS).toBe(2);
   });
 
-  test("a negative value falls back to the default", () => {
-    const config: TelemetryConfigModule = loadConfig({
-      TELEMETRY_DECODE_THREADS: "-2",
-    });
-    expect(config.TELEMETRY_DECODE_THREADS).toBe(0);
-  });
-
-  test("a non-numeric value falls back to the default", () => {
-    const config: TelemetryConfigModule = loadConfig({
-      TELEMETRY_DECODE_THREADS: "many",
-    });
+  test("invalid on a 1-CPU pod still resolves to 0 (adaptive, pool off)", () => {
+    const config: TelemetryConfigModule = loadConfig(
+      {
+        TELEMETRY_DECODE_THREADS: "garbage",
+      },
+      { effectiveCpuCount: 1 },
+    );
     expect(config.TELEMETRY_DECODE_THREADS).toBe(0);
   });
 });

--- a/App/Tests/Telemetry/TelemetryDecodeConfig.test.ts
+++ b/App/Tests/Telemetry/TelemetryDecodeConfig.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Env parsing for the decode thread pool knobs:
+ *
+ *   - TELEMETRY_DECODE_THREADS: default 0 (pool DISABLED — the
+ *     load-bearing default: shipping this feature must not change any
+ *     deployment's behavior until it is explicitly opted into), 0 is a
+ *     VALID explicit value (the strictly-positive parseBatchSize would
+ *     have made "off" unexpressable), negatives/garbage fall back.
+ *   - TELEMETRY_DECODE_MIN_PAYLOAD_BYTES: default 8192, 0 valid
+ *     ("no minimum, route everything"), negatives/garbage fall back.
+ *
+ * The config module reads env at import time, so each case re-imports
+ * it in isolation (same pattern as ClickhouseKeepAliveOptions.test.ts).
+ */
+
+type TelemetryConfigModule = {
+  TELEMETRY_DECODE_THREADS: number;
+  TELEMETRY_DECODE_MIN_PAYLOAD_BYTES: number;
+};
+
+const CONFIG_ENV_KEYS: Array<string> = [
+  "TELEMETRY_DECODE_THREADS",
+  "TELEMETRY_DECODE_MIN_PAYLOAD_BYTES",
+];
+
+function withEnv<T>(
+  env: Record<string, string | undefined>,
+  callback: () => T,
+): T {
+  const previous: Record<string, string | undefined> = {};
+  for (const key of CONFIG_ENV_KEYS) {
+    previous[key] = process.env[key];
+    delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return callback();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+function loadConfig(
+  env: Record<string, string | undefined>,
+): TelemetryConfigModule {
+  let loaded: TelemetryConfigModule | undefined = undefined;
+
+  jest.isolateModules(() => {
+    withEnv(env, () => {
+      /* eslint-disable @typescript-eslint/no-var-requires */
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      loaded = require("../../FeatureSet/Telemetry/Config");
+      /* eslint-enable @typescript-eslint/no-var-requires */
+    });
+  });
+
+  return loaded!;
+}
+
+describe("TELEMETRY_DECODE_THREADS parsing", () => {
+  test("defaults to 0 (pool disabled) when unset", () => {
+    const config: TelemetryConfigModule = loadConfig({});
+    expect(config.TELEMETRY_DECODE_THREADS).toBe(0);
+  });
+
+  test("a valid positive override is honored", () => {
+    const config: TelemetryConfigModule = loadConfig({
+      TELEMETRY_DECODE_THREADS: "4",
+    });
+    expect(config.TELEMETRY_DECODE_THREADS).toBe(4);
+  });
+
+  test("an explicit 0 is accepted (NOT treated as invalid-falls-back)", () => {
+    const config: TelemetryConfigModule = loadConfig({
+      TELEMETRY_DECODE_THREADS: "0",
+    });
+    expect(config.TELEMETRY_DECODE_THREADS).toBe(0);
+  });
+
+  test("a negative value falls back to the default", () => {
+    const config: TelemetryConfigModule = loadConfig({
+      TELEMETRY_DECODE_THREADS: "-2",
+    });
+    expect(config.TELEMETRY_DECODE_THREADS).toBe(0);
+  });
+
+  test("a non-numeric value falls back to the default", () => {
+    const config: TelemetryConfigModule = loadConfig({
+      TELEMETRY_DECODE_THREADS: "many",
+    });
+    expect(config.TELEMETRY_DECODE_THREADS).toBe(0);
+  });
+});
+
+describe("TELEMETRY_DECODE_MIN_PAYLOAD_BYTES parsing", () => {
+  test("defaults to 8192 when unset", () => {
+    const config: TelemetryConfigModule = loadConfig({});
+    expect(config.TELEMETRY_DECODE_MIN_PAYLOAD_BYTES).toBe(8192);
+  });
+
+  test("a valid override is honored", () => {
+    const config: TelemetryConfigModule = loadConfig({
+      TELEMETRY_DECODE_MIN_PAYLOAD_BYTES: "65536",
+    });
+    expect(config.TELEMETRY_DECODE_MIN_PAYLOAD_BYTES).toBe(65536);
+  });
+
+  test("an explicit 0 is accepted (route everything to the pool)", () => {
+    const config: TelemetryConfigModule = loadConfig({
+      TELEMETRY_DECODE_MIN_PAYLOAD_BYTES: "0",
+    });
+    expect(config.TELEMETRY_DECODE_MIN_PAYLOAD_BYTES).toBe(0);
+  });
+
+  test("a negative value falls back to the default", () => {
+    const config: TelemetryConfigModule = loadConfig({
+      TELEMETRY_DECODE_MIN_PAYLOAD_BYTES: "-8192",
+    });
+    expect(config.TELEMETRY_DECODE_MIN_PAYLOAD_BYTES).toBe(8192);
+  });
+
+  test("a non-numeric value falls back to the default", () => {
+    const config: TelemetryConfigModule = loadConfig({
+      TELEMETRY_DECODE_MIN_PAYLOAD_BYTES: "big",
+    });
+    expect(config.TELEMETRY_DECODE_MIN_PAYLOAD_BYTES).toBe(8192);
+  });
+
+  test("both knobs parse independently in one load", () => {
+    const config: TelemetryConfigModule = loadConfig({
+      TELEMETRY_DECODE_THREADS: "2",
+      TELEMETRY_DECODE_MIN_PAYLOAD_BYTES: "1024",
+    });
+    expect(config.TELEMETRY_DECODE_THREADS).toBe(2);
+    expect(config.TELEMETRY_DECODE_MIN_PAYLOAD_BYTES).toBe(1024);
+  });
+});

--- a/App/Tests/Telemetry/TelemetryFanInIngest.test.ts
+++ b/App/Tests/Telemetry/TelemetryFanInIngest.test.ts
@@ -32,6 +32,27 @@ import {
 } from "@jest/globals";
 
 /*
+ * PasswordHash has a pre-existing TS5.9 ts-jest compile error (crypto
+ * BinaryLike vs Buffer) and is pulled in transitively through the service
+ * layer. Nothing password-related is under test here, so the module is
+ * replaced WITH A FACTORY — an automock would still require (and
+ * type-check) the real file. Same workaround as the other suites in this
+ * directory.
+ */
+jest.mock("Common/Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
+/*
  * End-to-end integration tests for the telemetry ingest paths through the
  * shared fan-in writer: OTLP JSON body -> processTracesFromQueue /
  * processLogsFromQueue -> TelemetryFanInWriter (the REAL default writer

--- a/Common/Server/Services/AnalyticsDatabaseService.ts
+++ b/Common/Server/Services/AnalyticsDatabaseService.ts
@@ -67,7 +67,7 @@ import PositiveNumber from "../../Types/PositiveNumber";
 import Text from "../../Types/Text";
 import Typeof from "../../Types/Typeof";
 import API from "../../Utils/API";
-import { Stream } from "node:stream";
+import { Readable, Stream } from "node:stream";
 import AggregateBy, {
   AggregateUtil,
 } from "../Types/AnalyticsDatabase/AggregateBy";
@@ -211,6 +211,38 @@ export function shouldWaitForAsyncInsert(): boolean {
   return raw === "true" || raw === "1";
 }
 
+/*
+ * Streamed ClickHouse insert bodies (default ON).
+ *
+ * With a plain array, @clickhouse/client's encoder does
+ * `values.map(encodeJSON).join('')` — materializing the ENTIRE insert body
+ * as one in-memory string before the HTTP request starts. For a fan-in
+ * flush of 100k telemetry rows that is a 100MB+ transient allocation (on
+ * top of the rows array itself, plus the gzip output since request
+ * compression is enabled) and one long unbroken synchronous stringify
+ * burst on the event loop. Passing an object-mode Readable instead makes
+ * the client encode each row lazily with socket/gzip backpressure.
+ *
+ * Why default-on is safe: the client's encoder (dist/utils/encoder.js)
+ * pipes every value yielded by an object-mode stream through the SAME
+ * `encodeJSON` used for array elements, so the wire bytes are identical by
+ * construction. The HTTP framing does not change either — the client never
+ * sets Content-Length (the body is always piped through gzip into the
+ * request), so inserts already used chunked transfer encoding with the
+ * array path; only the chunk granularity changes.
+ *
+ * Why the flag exists: a pure rollback hatch. If some proxy / LB /
+ * ClickHouse edge in a deployment misbehaves with the finer-grained
+ * chunked upload (or a client upgrade changes stream semantics), set
+ * CLICKHOUSE_STREAMED_INSERTS=false to restore the array path verbatim
+ * without a code change. Read per call (not at module load) following the
+ * `!== "false"` idiom of the other hot-path switches, so tests and running
+ * processes can flip it.
+ */
+export function shouldStreamClickhouseInserts(): boolean {
+  return process.env["CLICKHOUSE_STREAMED_INSERTS"] !== "false";
+}
+
 export default class AnalyticsDatabaseService<
   TBaseModel extends AnalyticsBaseModel,
 > extends BaseService {
@@ -331,10 +363,33 @@ export default class AnalyticsDatabaseService<
       };
     }
 
+    /*
+     * Insert body: an object-mode Readable over `rows` (see
+     * shouldStreamClickhouseInserts for why, and for the rollback hatch).
+     *
+     * The stream MUST be constructed fresh on every invocation, inside this
+     * method: TelemetryFanInWriter.insertGroupWithRetry retries this method
+     * with the SAME rows array and the SAME dedup token, and a Readable is
+     * single-use — a stream hoisted out of the call would arrive exhausted
+     * (or errored) on the retry and silently insert nothing.
+     *
+     * Readable.from(rows) iterates the existing array lazily — no copy.
+     * That deferred iteration is safe because rows are stable after
+     * submission: TelemetryFanInWriter.submit() takes ownership of the
+     * caller's array (callers must not mutate it afterwards, per its
+     * contract) and insertGroupWithRetry passes a private array it copied
+     * the group's rows into, which nothing mutates across attempts. Direct
+     * (non-fan-in) callers hand over their array and do not touch it while
+     * awaiting this method.
+     */
+    const values: Array<JSONObject> | Readable = shouldStreamClickhouseInserts()
+      ? Readable.from(rows)
+      : rows;
+
     try {
       await client.insert({
         table: tableName,
-        values: rows,
+        values: values,
         format: "JSONEachRow",
         clickhouse_settings: clickhouseSettings,
       });

--- a/Common/Server/Utils/CpuCount.ts
+++ b/Common/Server/Utils/CpuCount.ts
@@ -1,0 +1,189 @@
+import fs from "fs";
+import os from "os";
+
+/*
+ * Effective CPU count for THIS process — cgroup-aware.
+ *
+ * Node's os.availableParallelism() / os.cpus() report the HOST's cores.
+ * Inside a Kubernetes pod (or any cgroup-limited container) that number
+ * is a lie for sizing purposes: a pod with `limits.cpu: "2"` on a
+ * 64-core node sees 64 from Node but is throttled to 2 cores of actual
+ * runtime by the CFS quota. Anything that sizes a thread/worker pool
+ * from the host count therefore oversubscribes small pods on big nodes
+ * — more threads means more context switching and more memory for LESS
+ * throughput once the quota kicks in.
+ *
+ * This helper answers "how many cores can this process actually burn?"
+ * by preferring the cgroup CPU quota over the host count:
+ *
+ *   1. cgroup v2: /sys/fs/cgroup/cpu.max, containing "<quota> <period>"
+ *      in microseconds, or "max <period>" when unlimited. (cgroup v2 is
+ *      the default on all current Kubernetes/containerd and systemd
+ *      hosts.)
+ *   2. cgroup v1: /sys/fs/cgroup/cpu/cpu.cfs_quota_us and
+ *      cpu.cfs_period_us; quota -1 means unlimited. (Older hosts.)
+ *   3. Host fallback: os.availableParallelism() (os.cpus().length on
+ *      Node versions that predate it) when there is no readable limit —
+ *      bare metal, macOS/Windows dev machines, or an unlimited cgroup.
+ *
+ * A limited quota is converted with ceil(quota / period): a pod limited
+ * to 2.5 CPUs can genuinely run 3 threads' worth of bursts, and ceil
+ * also guarantees the result is never rounded down to 0 for fractional
+ * limits (0.5 CPU -> 1).
+ *
+ * Guarantees:
+ *   - NEVER throws. Absent files (non-Linux, no cgroups), unreadable
+ *     files, and garbage contents all fall through to the next source;
+ *     if everything fails the answer is 1 — the most conservative value
+ *     (callers sizing "extra" capacity from it will size zero extra).
+ *   - Always returns an integer >= 1.
+ *
+ * The file/host reads are injectable so unit tests can exercise every
+ * branch deterministically on any machine (see EffectiveCpuCountReads).
+ */
+
+export type ReadFileUtf8Function = (filePath: string) => string;
+export type HostParallelismFunction = () => number;
+
+export interface EffectiveCpuCountReads {
+  /*
+   * Must behave like fs.readFileSync(path, "utf-8"): return the file's
+   * contents, or THROW when the file is absent/unreadable.
+   */
+  readFileUtf8?: ReadFileUtf8Function;
+  // Must behave like os.availableParallelism(): the host's core count.
+  hostParallelism?: HostParallelismFunction;
+}
+
+const CGROUP_V2_CPU_MAX_PATH: string = "/sys/fs/cgroup/cpu.max";
+const CGROUP_V1_CPU_QUOTA_PATH: string =
+  "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
+const CGROUP_V1_CPU_PERIOD_PATH: string =
+  "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
+
+export default class CpuCount {
+  public static getEffectiveCpuCount(reads?: EffectiveCpuCountReads): number {
+    /*
+     * Outer guard: this function is used to compute config DEFAULTS at
+     * module load, where an exception would take the whole process down
+     * — so even a throwing injected override must not escape.
+     */
+    try {
+      const readFileUtf8: ReadFileUtf8Function =
+        reads?.readFileUtf8 ||
+        ((filePath: string): string => {
+          return fs.readFileSync(filePath, "utf-8");
+        });
+
+      const cgroupLimit: number | null = this.readCgroupCpuLimit(readFileUtf8);
+      if (cgroupLimit !== null) {
+        return cgroupLimit;
+      }
+
+      const hostParallelism: HostParallelismFunction =
+        reads?.hostParallelism || CpuCount.defaultHostParallelism;
+
+      return this.sanitizeCount(hostParallelism());
+    } catch {
+      return 1;
+    }
+  }
+
+  /*
+   * The cgroup quota, as a whole number of CPUs — or null when there is
+   * no limit to honor (unlimited, files absent, or contents garbage),
+   * in which case the caller falls back to the host count.
+   */
+  private static readCgroupCpuLimit(
+    readFileUtf8: ReadFileUtf8Function,
+  ): number | null {
+    // cgroup v2 first — it is what current container runtimes use.
+    let v2Content: string | null = null;
+    try {
+      v2Content = readFileUtf8(CGROUP_V2_CPU_MAX_PATH);
+    } catch {
+      v2Content = null; // File absent: not a v2 host (or not Linux).
+    }
+
+    if (v2Content !== null) {
+      const tokens: Array<string> = v2Content.trim().split(/\s+/);
+      if (tokens[0] === "max") {
+        /*
+         * Explicitly unlimited. The v2 file existing means the v2
+         * hierarchy governs this process, so do NOT consult the v1
+         * files — go straight to the host count.
+         */
+        return null;
+      }
+      const quotaUs: number = Number(tokens[0]);
+      const periodUs: number = Number(tokens[1]);
+      if (
+        Number.isFinite(quotaUs) &&
+        Number.isFinite(periodUs) &&
+        quotaUs > 0 &&
+        periodUs > 0
+      ) {
+        return Math.max(1, Math.ceil(quotaUs / periodUs));
+      }
+      /*
+       * Garbage v2 contents: fall through and give v1 a chance rather
+       * than trusting a file we could not parse.
+       */
+    }
+
+    // cgroup v1 (older hosts).
+    let quotaUs: number = NaN;
+    try {
+      quotaUs = Number(readFileUtf8(CGROUP_V1_CPU_QUOTA_PATH).trim());
+    } catch {
+      return null; // File absent/unreadable: no v1 limit either.
+    }
+
+    if (!Number.isFinite(quotaUs) || quotaUs <= 0) {
+      // -1 is v1's documented "unlimited"; garbage is treated the same.
+      return null;
+    }
+
+    let periodUs: number = NaN;
+    try {
+      periodUs = Number(readFileUtf8(CGROUP_V1_CPU_PERIOD_PATH).trim());
+    } catch {
+      return null;
+    }
+
+    if (!Number.isFinite(periodUs) || periodUs <= 0) {
+      /*
+       * A positive quota with an unreadable period cannot be converted
+       * to a CPU count — never guess a period; fall back to the host.
+       */
+      return null;
+    }
+
+    return Math.max(1, Math.ceil(quotaUs / periodUs));
+  }
+
+  private static defaultHostParallelism(): number {
+    /*
+     * availableParallelism() (Node >= 18.14) already accounts for
+     * process CPU affinity masks; cpus().length is the fallback for
+     * older runtimes. Accessed through a structural type because the
+     * repo's pinned @types/node predates the API even though the
+     * runtime Node has it — a plain os.availableParallelism reference
+     * fails to compile.
+     */
+    const osModule: typeof os & { availableParallelism?: () => number } =
+      os as typeof os & { availableParallelism?: () => number };
+    if (typeof osModule.availableParallelism === "function") {
+      return osModule.availableParallelism();
+    }
+    return os.cpus().length;
+  }
+
+  // Clamp anything odd (NaN, 0, negatives, floats) to an integer >= 1.
+  private static sanitizeCount(count: number): number {
+    if (!Number.isFinite(count) || count < 1) {
+      return 1;
+    }
+    return Math.floor(count);
+  }
+}

--- a/Common/Tests/Server/Services/AnalyticsDatabaseServiceStreamedInsertLive.test.ts
+++ b/Common/Tests/Server/Services/AnalyticsDatabaseServiceStreamedInsertLive.test.ts
@@ -1,0 +1,279 @@
+import AnalyticsDatabaseService from "../../../Server/Services/AnalyticsDatabaseService";
+import "../TestingUtils/Init";
+import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
+import Route from "../../../Types/API/Route";
+import AnalyticsTableEngine from "../../../Types/AnalyticsDatabase/AnalyticsTableEngine";
+import AnalyticsTableColumn from "../../../Types/AnalyticsDatabase/TableColumn";
+import TableColumnType from "../../../Types/AnalyticsDatabase/TableColumnType";
+import { JSONObject } from "../../../Types/JSON";
+import { createClient, ClickHouseClient } from "@clickhouse/client";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * GUARDED LIVE INTEGRATION TEST for the streamed ClickHouse insert path
+ * (CLICKHOUSE_STREAMED_INSERTS, see AnalyticsDatabaseService.insertJsonRows).
+ *
+ * It probes a small set of plausible dev endpoints (explicit
+ * CLICKHOUSE_TEST_URL override, the config.env host/port as exported by
+ * `npm test`, and the docker-compose.dev.yml host port mappings) with an
+ * authenticated SELECT 1. When none is reachable the test logs a warning
+ * and passes vacuously — it must never flake a machine without the dev
+ * stack. When one IS reachable it exercises the REAL production code path:
+ * insertJsonRows with a fresh object-mode Readable body (chunked HTTP
+ * upload through gzip) into a temp table, then reads the rows back and
+ * compares. wait_for_async_insert is forced to 1 via the caller-settings
+ * merge so the read-back is deterministic (and the merge path itself gets
+ * live coverage).
+ */
+
+const LIVE_TABLE_NAME: string = `StreamInsertLiveTest_${Date.now()}_${Math.floor(
+  Math.random() * 100000,
+)}`;
+
+type LiveCandidate = {
+  url: string;
+  username: string;
+  password: string;
+  database: string;
+};
+
+/*
+ * Best-effort read of repo-root config.env (four directories above this
+ * test file) for local runs launched without `npm test`'s env export.
+ * Returns an empty map when the file is absent (e.g. CI).
+ */
+function readConfigEnv(): Record<string, string> {
+  const configEnvPath: string = path.join(
+    __dirname,
+    "../../../../config.env",
+  );
+  const result: Record<string, string> = {};
+  try {
+    if (!fs.existsSync(configEnvPath)) {
+      return result;
+    }
+    const content: string = fs.readFileSync(configEnvPath, "utf8");
+    for (const line of content.split("\n")) {
+      const trimmed: string = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) {
+        continue;
+      }
+      const eq: number = trimmed.indexOf("=");
+      if (eq <= 0) {
+        continue;
+      }
+      result[trimmed.substring(0, eq)] = trimmed.substring(eq + 1);
+    }
+  } catch {
+    // Unreadable config.env is the same as no config.env.
+  }
+  return result;
+}
+
+function buildCandidates(): Array<LiveCandidate> {
+  const configEnv: Record<string, string> = readConfigEnv();
+  const username: string =
+    process.env["CLICKHOUSE_USER"] || configEnv["CLICKHOUSE_USER"] || "default";
+  const password: string =
+    process.env["CLICKHOUSE_PASSWORD"] || configEnv["CLICKHOUSE_PASSWORD"] || "";
+  const database: string =
+    process.env["CLICKHOUSE_DATABASE"] ||
+    configEnv["CLICKHOUSE_DATABASE"] ||
+    "default";
+
+  const candidates: Array<LiveCandidate> = [];
+
+  // Explicit override wins (used e.g. against a throwaway container).
+  if (process.env["CLICKHOUSE_TEST_URL"]) {
+    candidates.push({
+      url: process.env["CLICKHOUSE_TEST_URL"] as string,
+      username: process.env["CLICKHOUSE_TEST_USER"] || "default",
+      password: process.env["CLICKHOUSE_TEST_PASSWORD"] || "",
+      database: process.env["CLICKHOUSE_TEST_DATABASE"] || "default",
+    });
+  }
+
+  // config.env host/port — resolves when running inside the compose network.
+  const host: string | undefined =
+    process.env["CLICKHOUSE_HOST"] || configEnv["CLICKHOUSE_HOST"];
+  const port: string =
+    process.env["CLICKHOUSE_PORT"] || configEnv["CLICKHOUSE_PORT"] || "8123";
+  if (host) {
+    candidates.push({
+      url: `http://${host}:${port}`,
+      username,
+      password,
+      database,
+    });
+  }
+
+  // docker-compose.dev.yml maps clickhouse 8123 -> host 8189.
+  candidates.push({
+    url: "http://localhost:8189",
+    username,
+    password,
+    database,
+  });
+  candidates.push({
+    url: "http://localhost:8123",
+    username,
+    password,
+    database,
+  });
+
+  return candidates;
+}
+
+/*
+ * Returns a connected client for the first candidate that answers an
+ * authenticated SELECT 1, or null when none does. The probe uses a short
+ * request_timeout so an unreachable stack fails fast instead of hanging
+ * the suite.
+ */
+async function findLiveClickhouse(): Promise<{
+  client: ClickHouseClient;
+  candidate: LiveCandidate;
+} | null> {
+  for (const candidate of buildCandidates()) {
+    const client: ClickHouseClient = createClient({
+      url: candidate.url,
+      username: candidate.username,
+      password: candidate.password,
+      database: candidate.database,
+      request_timeout: 3000,
+      /*
+       * The suite runs under the repo's jsdom-based test environment,
+       * whose setTimeout returns a handle without .unref(). The client's
+       * keep-alive idle-socket TTL is the one code path that calls
+       * .unref(), so keep-alive stays off here (irrelevant for a
+       * single-request test).
+       */
+      keep_alive: { enabled: false },
+    });
+    try {
+      await client.query({ query: "SELECT 1", format: "JSON" });
+      return { client, candidate };
+    } catch {
+      await client.close().catch(() => {
+        // Probe cleanup only.
+      });
+    }
+  }
+  return null;
+}
+
+describe("AnalyticsDatabaseService streamed insert (live ClickHouse, guarded)", () => {
+  class LiveStreamModel extends AnalyticsBaseModel {
+    public constructor() {
+      super({
+        tableName: LIVE_TABLE_NAME,
+        singularName: "<singular-name>",
+        pluralName: "<plural-name>",
+        tableColumns: [
+          new AnalyticsTableColumn({
+            key: "a",
+            title: "<title>",
+            description: "<description>",
+            required: true,
+            type: TableColumnType.Text,
+          }),
+        ],
+        crudApiPath: new Route("route"),
+        primaryKeys: ["a"],
+        sortKeys: ["a"],
+        partitionKey: "a",
+        tableEngine: AnalyticsTableEngine.MergeTree,
+      });
+    }
+  }
+
+  test(
+    "streamed insertJsonRows lands rows in a temp table and reads them back",
+    async () => {
+      const live: {
+        client: ClickHouseClient;
+        candidate: LiveCandidate;
+      } | null = await findLiveClickhouse();
+
+      if (!live) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "Skipping live streamed-insert test: no reachable ClickHouse " +
+            "(set CLICKHOUSE_TEST_URL or start the dev compose stack).",
+        );
+        return;
+      }
+
+      const savedStreamFlag: string | undefined =
+        process.env["CLICKHOUSE_STREAMED_INSERTS"];
+      delete process.env["CLICKHOUSE_STREAMED_INSERTS"]; // default = streamed
+
+      try {
+        await live.client.command({
+          query:
+            `CREATE TABLE IF NOT EXISTS ${LIVE_TABLE_NAME} ` +
+            `(a String, n Int64) ENGINE = MergeTree ORDER BY n`,
+        });
+
+        const service: AnalyticsDatabaseService<LiveStreamModel> =
+          new AnalyticsDatabaseService({ modelType: LiveStreamModel });
+        // Route the production insert path at the live client.
+        (
+          service as unknown as { ingestDatabaseClient: ClickHouseClient }
+        ).ingestDatabaseClient = live.client;
+
+        const rows: Array<JSONObject> = [
+          { a: 'plain "quoted" text', n: 1 },
+          { a: "unicode ♥ / newline\\n literal", n: 2 },
+          { a: "third row", n: 3 },
+        ];
+
+        await service.insertJsonRows(rows, {
+          dedupToken: `live-test:${LIVE_TABLE_NAME}:0`,
+          /*
+           * Force ack-after-flush so the SELECT below deterministically
+           * sees the rows (default fire-and-forget acks on buffer accept).
+           * Also live-covers the caller clickhouseSettings merge.
+           */
+          clickhouseSettings: { wait_for_async_insert: 1 },
+        });
+
+        const result: { json: () => Promise<unknown> } = await live.client.query(
+          {
+            query: `SELECT a, n FROM ${LIVE_TABLE_NAME} ORDER BY n`,
+            format: "JSON",
+          },
+        );
+        const payload: { data?: Array<{ a: string; n: number | string }> } =
+          (await result.json()) as {
+            data?: Array<{ a: string; n: number | string }>;
+          };
+
+        expect(payload.data).toBeDefined();
+        expect(payload.data).toHaveLength(rows.length);
+        for (let i: number = 0; i < rows.length; i++) {
+          expect(payload.data![i]!.a).toBe(rows[i]!["a"]);
+          // Int64 may arrive quoted or not depending on server settings.
+          expect(String(payload.data![i]!.n)).toBe(String(rows[i]!["n"]));
+        }
+      } finally {
+        if (savedStreamFlag === undefined) {
+          delete process.env["CLICKHOUSE_STREAMED_INSERTS"];
+        } else {
+          process.env["CLICKHOUSE_STREAMED_INSERTS"] = savedStreamFlag;
+        }
+        await live.client
+          .command({ query: `DROP TABLE IF EXISTS ${LIVE_TABLE_NAME}` })
+          .catch(() => {
+            // Best-effort cleanup.
+          });
+        await live.client.close().catch(() => {
+          // Best-effort cleanup.
+        });
+      }
+    },
+    30000,
+  );
+});

--- a/Common/Tests/Server/Services/AnalyticsDatabaseServiceStreamedInserts.test.ts
+++ b/Common/Tests/Server/Services/AnalyticsDatabaseServiceStreamedInserts.test.ts
@@ -1,0 +1,369 @@
+import AnalyticsDatabaseService, {
+  runWithInsertDedup,
+  shouldStreamClickhouseInserts,
+} from "../../../Server/Services/AnalyticsDatabaseService";
+import logger from "../../../Server/Utils/Logger";
+import "../TestingUtils/Init";
+import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
+import Route from "../../../Types/API/Route";
+import AnalyticsTableEngine from "../../../Types/AnalyticsDatabase/AnalyticsTableEngine";
+import AnalyticsTableColumn from "../../../Types/AnalyticsDatabase/TableColumn";
+import TableColumnType from "../../../Types/AnalyticsDatabase/TableColumnType";
+import { JSONObject } from "../../../Types/JSON";
+import { Readable } from "node:stream";
+// Vendored client internals: the exact encoder client.insert() runs values
+// through. Used to prove wire-byte equivalence of stream vs array inputs.
+import { NodeValuesEncoder } from "@clickhouse/client/dist/utils/encoder";
+import {
+  describe,
+  expect,
+  beforeEach,
+  afterEach,
+  test,
+  jest,
+} from "@jest/globals";
+
+/*
+ * Streamed ClickHouse insert bodies (CLICKHOUSE_STREAMED_INSERTS).
+ *
+ * insertJsonRows used to pass the raw rows array to @clickhouse/client,
+ * whose encoder materializes the entire insert body as one in-memory
+ * string. It now passes a fresh object-mode Readable over the SAME array
+ * (no copy) unless CLICKHOUSE_STREAMED_INSERTS=false restores the array
+ * path. These tests pin:
+ *  - values-mode selection per flag state (default/on -> stream, off -> array),
+ *  - row-level equivalence (same object references, same order),
+ *  - encoder-level byte equivalence via the vendored NodeValuesEncoder,
+ *  - per-invocation stream freshness (the fan-in writer retries with the
+ *    same rows array; each attempt must get a NEW consumable stream),
+ *  - settings passthrough (dedup token, async_insert, wait_for_async_insert,
+ *    caller merge) unchanged in both modes,
+ *  - the empty-rows early return and error propagation in both modes.
+ */
+
+type CapturedInsertCall = {
+  table: string;
+  values: Array<JSONObject> | Readable;
+  format: string;
+  clickhouse_settings: JSONObject;
+};
+
+describe("AnalyticsDatabaseService streamed insert bodies", () => {
+  class StreamTestModel extends AnalyticsBaseModel {
+    public constructor() {
+      super({
+        tableName: "StreamInsertTestTable",
+        singularName: "<singular-name>",
+        pluralName: "<plural-name>",
+        tableColumns: [
+          new AnalyticsTableColumn({
+            key: "column_ObjectID",
+            title: "<title>",
+            description: "<description>",
+            required: true,
+            type: TableColumnType.ObjectID,
+          }),
+        ],
+        crudApiPath: new Route("route"),
+        primaryKeys: ["column_ObjectID"],
+        sortKeys: ["column_ObjectID"],
+        partitionKey: "column_ObjectID",
+        tableEngine: AnalyticsTableEngine.MergeTree,
+      });
+    }
+  }
+
+  let service: AnalyticsDatabaseService<StreamTestModel>;
+  // Untyped mock (matches the sibling suite's idiom) — @types/jest and
+  // @jest/globals disagree on Mock's generic arity in this repo's versions.
+  let insertMock: ReturnType<typeof jest.fn>;
+  let savedStreamFlag: string | undefined;
+  let savedWaitFlag: string | undefined;
+
+  // Distinct object references so identity assertions are meaningful.
+  const makeRows: () => Array<JSONObject> = (): Array<JSONObject> => {
+    return [
+      { a: 1, text: "first" },
+      { b: "two", when: "2026-01-01 00:00:00" },
+      { c: { nested: true, list: [1, 2, 3] } },
+    ];
+  };
+
+  const lastInsertCall: () => CapturedInsertCall = (): CapturedInsertCall => {
+    expect(insertMock.mock.calls.length).toBeGreaterThan(0);
+    return insertMock.mock.calls[insertMock.mock.calls.length - 1]![0] as
+      unknown as CapturedInsertCall;
+  };
+
+  const consumeStream: (stream: Readable) => Promise<Array<unknown>> = async (
+    stream: Readable,
+  ): Promise<Array<unknown>> => {
+    const out: Array<unknown> = [];
+    for await (const value of stream) {
+      out.push(value);
+    }
+    return out;
+  };
+
+  beforeEach(() => {
+    savedStreamFlag = process.env["CLICKHOUSE_STREAMED_INSERTS"];
+    savedWaitFlag = process.env["TELEMETRY_WAIT_FOR_ASYNC_INSERT"];
+    delete process.env["CLICKHOUSE_STREAMED_INSERTS"];
+    delete process.env["TELEMETRY_WAIT_FOR_ASYNC_INSERT"];
+
+    service = new AnalyticsDatabaseService({
+      modelType: StreamTestModel,
+    });
+    insertMock = jest.fn((): Promise<void> => {
+      return Promise.resolve();
+    });
+    const serviceWithClient: { ingestDatabaseClient: unknown } =
+      service as unknown as { ingestDatabaseClient: unknown };
+    serviceWithClient.ingestDatabaseClient = { insert: insertMock };
+
+    jest.spyOn(logger, "debug").mockImplementation(() => {
+      return undefined!;
+    });
+    jest.spyOn(logger, "error").mockImplementation(() => {
+      return undefined!;
+    });
+  });
+
+  afterEach(() => {
+    if (savedStreamFlag === undefined) {
+      delete process.env["CLICKHOUSE_STREAMED_INSERTS"];
+    } else {
+      process.env["CLICKHOUSE_STREAMED_INSERTS"] = savedStreamFlag;
+    }
+    if (savedWaitFlag === undefined) {
+      delete process.env["TELEMETRY_WAIT_FOR_ASYNC_INSERT"];
+    } else {
+      process.env["TELEMETRY_WAIT_FOR_ASYNC_INSERT"] = savedWaitFlag;
+    }
+    jest.restoreAllMocks();
+  });
+
+  describe("flag handling", () => {
+    test("default (env unset) enables streaming", () => {
+      expect(shouldStreamClickhouseInserts()).toBe(true);
+    });
+
+    test("explicit 'true' enables streaming", () => {
+      process.env["CLICKHOUSE_STREAMED_INSERTS"] = "true";
+      expect(shouldStreamClickhouseInserts()).toBe(true);
+    });
+
+    test("only the literal 'false' disables streaming", () => {
+      process.env["CLICKHOUSE_STREAMED_INSERTS"] = "false";
+      expect(shouldStreamClickhouseInserts()).toBe(false);
+    });
+  });
+
+  describe("values mode", () => {
+    test("default: values is a fresh object-mode Readable over the rows", async () => {
+      const rows: Array<JSONObject> = makeRows();
+
+      await service.insertJsonRows(rows);
+
+      const call: CapturedInsertCall = lastInsertCall();
+      expect(call.table).toBe("StreamInsertTestTable");
+      expect(call.format).toBe("JSONEachRow");
+      expect(call.values).toBeInstanceOf(Readable);
+      expect((call.values as Readable).readableObjectMode).toBe(true);
+    });
+
+    test("flag on ('true'): values is a Readable", async () => {
+      process.env["CLICKHOUSE_STREAMED_INSERTS"] = "true";
+
+      await service.insertJsonRows(makeRows());
+
+      expect(lastInsertCall().values).toBeInstanceOf(Readable);
+    });
+
+    test("flag off ('false'): values is the plain rows array (reference identity)", async () => {
+      process.env["CLICKHOUSE_STREAMED_INSERTS"] = "false";
+      const rows: Array<JSONObject> = makeRows();
+
+      await service.insertJsonRows(rows);
+
+      const call: CapturedInsertCall = lastInsertCall();
+      // The exact same array object, not a copy.
+      expect(call.values).toBe(rows);
+    });
+  });
+
+  describe("equivalence with the array path", () => {
+    test("consuming the stream yields exactly the array's row objects, in order, by reference", async () => {
+      const rows: Array<JSONObject> = makeRows();
+
+      await service.insertJsonRows(rows);
+
+      const streamed: Array<unknown> = await consumeStream(
+        lastInsertCall().values as Readable,
+      );
+
+      expect(streamed).toHaveLength(rows.length);
+      // Reference identity per element: the stream wraps the array, no copies.
+      for (let i: number = 0; i < rows.length; i++) {
+        expect(streamed[i]).toBe(rows[i]);
+      }
+      expect(streamed).toStrictEqual(rows);
+    });
+
+    test("the vendored client encoder produces byte-identical output for stream vs array input", async () => {
+      /*
+       * Run BOTH values shapes through the actual NodeValuesEncoder that
+       * client.insert() uses. The stream result is itself a stream of
+       * encoded chunks; joined, it must equal the array path's single
+       * joined string — this is the "wire bytes are identical by
+       * construction" claim, proven against the vendored code.
+       */
+      const rows: Array<JSONObject> = makeRows();
+      const encoder: NodeValuesEncoder = new NodeValuesEncoder();
+
+      const arrayEncoded: string | Readable = encoder.encodeValues(
+        rows,
+        "JSONEachRow",
+      ) as string;
+      expect(typeof arrayEncoded).toBe("string");
+
+      const streamEncoded: Readable = encoder.encodeValues(
+        Readable.from(makeRows()),
+        "JSONEachRow",
+      ) as Readable;
+      const chunks: Array<unknown> = await consumeStream(streamEncoded);
+      expect(chunks.join("")).toBe(arrayEncoded);
+    });
+  });
+
+  describe("per-attempt stream freshness (fan-in retry contract)", () => {
+    test("two calls with the same rows array each get a NEW fully-consumable stream", async () => {
+      /*
+       * TelemetryFanInWriter.insertGroupWithRetry retries insertJsonRows
+       * with the SAME rows array and the SAME dedup token. A stream is
+       * single-use, so the second attempt must receive a brand new one —
+       * not the first attempt's exhausted (or errored) stream.
+       */
+      const rows: Array<JSONObject> = makeRows();
+
+      await service.insertJsonRows(rows, { dedupToken: "job:tbl:0" });
+      const firstStream: Readable = lastInsertCall().values as Readable;
+      const firstConsumed: Array<unknown> = await consumeStream(firstStream);
+
+      await service.insertJsonRows(rows, { dedupToken: "job:tbl:0" });
+      const secondStream: Readable = lastInsertCall().values as Readable;
+
+      expect(insertMock).toHaveBeenCalledTimes(2);
+      expect(secondStream).not.toBe(firstStream);
+
+      const secondConsumed: Array<unknown> = await consumeStream(secondStream);
+      expect(firstConsumed).toStrictEqual(rows);
+      expect(secondConsumed).toStrictEqual(rows);
+      for (let i: number = 0; i < rows.length; i++) {
+        expect(secondConsumed[i]).toBe(rows[i]);
+      }
+    });
+  });
+
+  describe.each([
+    ["streamed (default)", undefined],
+    ["array (flag off)", "false"],
+  ] as Array<[string, string | undefined]>)(
+    "settings passthrough — %s mode",
+    (_label: string, flagValue: string | undefined) => {
+      beforeEach(() => {
+        if (flagValue === undefined) {
+          delete process.env["CLICKHOUSE_STREAMED_INSERTS"];
+        } else {
+          process.env["CLICKHOUSE_STREAMED_INSERTS"] = flagValue;
+        }
+      });
+
+      test("explicit dedup token pins the exact settings object", async () => {
+        await service.insertJsonRows(makeRows(), {
+          dedupToken: "job-1:StreamInsertTestTable:0",
+        });
+
+        expect(lastInsertCall().clickhouse_settings).toStrictEqual({
+          async_insert: 1,
+          wait_for_async_insert: 0,
+          async_insert_deduplicate: 1,
+          insert_deduplication_token: "job-1:StreamInsertTestTable:0",
+        });
+      });
+
+      test("no token and no ambient context pins the exact tokenless settings object", async () => {
+        await service.insertJsonRows(makeRows());
+
+        expect(lastInsertCall().clickhouse_settings).toStrictEqual({
+          async_insert: 1,
+          wait_for_async_insert: 0,
+        });
+      });
+
+      test("ambient runWithInsertDedup context derives the deterministic token", async () => {
+        await runWithInsertDedup("ambient-job", async (): Promise<void> => {
+          await service.insertJsonRows(makeRows());
+        });
+
+        expect(lastInsertCall().clickhouse_settings).toStrictEqual({
+          async_insert: 1,
+          wait_for_async_insert: 0,
+          async_insert_deduplicate: 1,
+          insert_deduplication_token: "ambient-job:StreamInsertTestTable:0",
+        });
+      });
+
+      test("TELEMETRY_WAIT_FOR_ASYNC_INSERT=true flips wait_for_async_insert", async () => {
+        process.env["TELEMETRY_WAIT_FOR_ASYNC_INSERT"] = "true";
+
+        await service.insertJsonRows(makeRows(), { dedupToken: "t" });
+
+        expect(lastInsertCall().clickhouse_settings).toStrictEqual({
+          async_insert: 1,
+          wait_for_async_insert: 1,
+          async_insert_deduplicate: 1,
+          insert_deduplication_token: "t",
+        });
+      });
+
+      test("caller clickhouseSettings merge last and win", async () => {
+        await service.insertJsonRows(makeRows(), {
+          dedupToken: "tok",
+          clickhouseSettings: {
+            wait_for_async_insert: 1,
+            max_insert_block_size: "1048576",
+          },
+        });
+
+        expect(lastInsertCall().clickhouse_settings).toStrictEqual({
+          async_insert: 1,
+          wait_for_async_insert: 1, // caller override wins over the default 0
+          async_insert_deduplicate: 1,
+          insert_deduplication_token: "tok",
+          max_insert_block_size: "1048576",
+        });
+      });
+
+      test("empty rows: resolves without calling the client", async () => {
+        await service.insertJsonRows([]);
+        await service.insertJsonRows(
+          undefined as unknown as Array<JSONObject>,
+        );
+
+        expect(insertMock).not.toHaveBeenCalled();
+      });
+
+      test("client rejection propagates the same error instance", async () => {
+        const failure: Error = new Error("Timeout error.");
+        insertMock.mockImplementationOnce((): Promise<void> => {
+          return Promise.reject(failure);
+        });
+
+        await expect(service.insertJsonRows(makeRows())).rejects.toBe(failure);
+        // The existing failure log must still fire.
+        expect(logger.error).toHaveBeenCalled();
+      });
+    },
+  );
+});

--- a/Common/Tests/Server/Utils/CpuCount.test.ts
+++ b/Common/Tests/Server/Utils/CpuCount.test.ts
@@ -1,0 +1,193 @@
+import CpuCount, {
+  EffectiveCpuCountReads,
+} from "../../../Server/Utils/CpuCount";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * CpuCount.getEffectiveCpuCount is used to compute config DEFAULTS at
+ * module load (the telemetry decode thread pool sizes itself from it),
+ * so its contract has two load-bearing halves:
+ *
+ *   - it must prefer the cgroup CPU quota over the host core count,
+ *     because inside a Kubernetes pod the host count is a lie for
+ *     sizing purposes (a 2-CPU-limited pod on a 64-core node sees 64
+ *     from Node), and
+ *   - it must NEVER throw and always return an integer >= 1, because a
+ *     throw here would take the process down during import.
+ *
+ * Every branch is exercised through the injectable reads, so these
+ * tests are deterministic on any machine — including ones that ARE
+ * inside a cgroup.
+ */
+
+const V2_PATH: string = "/sys/fs/cgroup/cpu.max";
+const V1_QUOTA_PATH: string = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us";
+const V1_PERIOD_PATH: string = "/sys/fs/cgroup/cpu/cpu.cfs_period_us";
+
+/*
+ * Simulated filesystem: paths present in `files` return their contents;
+ * everything else throws, exactly like fs.readFileSync on ENOENT.
+ */
+function makeReads(
+  files: Record<string, string>,
+  hostParallelism: number = 16,
+): EffectiveCpuCountReads {
+  return {
+    readFileUtf8: (filePath: string): string => {
+      if (Object.prototype.hasOwnProperty.call(files, filePath)) {
+        return files[filePath] as string;
+      }
+      throw new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+    },
+    hostParallelism: (): number => {
+      return hostParallelism;
+    },
+  };
+}
+
+describe("CpuCount.getEffectiveCpuCount — cgroup v2", () => {
+  test("a v2 quota wins over the host count: '200000 100000' -> 2", () => {
+    expect(
+      CpuCount.getEffectiveCpuCount(makeReads({ [V2_PATH]: "200000 100000" })),
+    ).toBe(2);
+  });
+
+  test("fractional quotas round UP (never down to 0): '50000 100000' -> 1, '250000 100000' -> 3", () => {
+    expect(
+      CpuCount.getEffectiveCpuCount(makeReads({ [V2_PATH]: "50000 100000" })),
+    ).toBe(1);
+    expect(
+      CpuCount.getEffectiveCpuCount(makeReads({ [V2_PATH]: "250000 100000" })),
+    ).toBe(3);
+  });
+
+  test("trailing newline (how the kernel actually serves the file) parses fine", () => {
+    expect(
+      CpuCount.getEffectiveCpuCount(
+        makeReads({ [V2_PATH]: "400000 100000\n" }),
+      ),
+    ).toBe(4);
+  });
+
+  test("'max <period>' (unlimited) falls back to the host count", () => {
+    expect(
+      CpuCount.getEffectiveCpuCount(
+        makeReads({ [V2_PATH]: "max 100000" }, 12),
+      ),
+    ).toBe(12);
+  });
+
+  test("an unlimited v2 hierarchy does NOT consult v1 files", () => {
+    /*
+     * If the v2 file exists, the v2 hierarchy governs — stale/foreign
+     * v1 files on the same box must not override "unlimited".
+     */
+    expect(
+      CpuCount.getEffectiveCpuCount(
+        makeReads(
+          {
+            [V2_PATH]: "max 100000",
+            [V1_QUOTA_PATH]: "100000",
+            [V1_PERIOD_PATH]: "100000",
+          },
+          8,
+        ),
+      ),
+    ).toBe(8);
+  });
+
+  test("garbage v2 contents fall through to v1 rather than being trusted", () => {
+    expect(
+      CpuCount.getEffectiveCpuCount(
+        makeReads(
+          {
+            [V2_PATH]: "bananas",
+            [V1_QUOTA_PATH]: "200000",
+            [V1_PERIOD_PATH]: "100000",
+          },
+          16,
+        ),
+      ),
+    ).toBe(2);
+  });
+});
+
+describe("CpuCount.getEffectiveCpuCount — cgroup v1", () => {
+  test("a v1 quota/period pair is honored: 300000/100000 -> 3", () => {
+    expect(
+      CpuCount.getEffectiveCpuCount(
+        makeReads(
+          { [V1_QUOTA_PATH]: "300000\n", [V1_PERIOD_PATH]: "100000\n" },
+          16,
+        ),
+      ),
+    ).toBe(3);
+  });
+
+  test("quota -1 (v1's 'unlimited') falls back to the host count", () => {
+    expect(
+      CpuCount.getEffectiveCpuCount(
+        makeReads(
+          { [V1_QUOTA_PATH]: "-1", [V1_PERIOD_PATH]: "100000" },
+          10,
+        ),
+      ),
+    ).toBe(10);
+  });
+
+  test("a readable quota with an unreadable period falls back (never guess a period)", () => {
+    expect(
+      CpuCount.getEffectiveCpuCount(makeReads({ [V1_QUOTA_PATH]: "200000" }, 6)),
+    ).toBe(6);
+  });
+
+  test("garbage v1 contents fall back to the host count", () => {
+    expect(
+      CpuCount.getEffectiveCpuCount(
+        makeReads(
+          { [V1_QUOTA_PATH]: "not-a-number", [V1_PERIOD_PATH]: "100000" },
+          7,
+        ),
+      ),
+    ).toBe(7);
+  });
+});
+
+describe("CpuCount.getEffectiveCpuCount — fallbacks and the never-throw guarantee", () => {
+  test("no cgroup files at all (macOS/Windows/bare Linux): host count", () => {
+    expect(CpuCount.getEffectiveCpuCount(makeReads({}, 8))).toBe(8);
+  });
+
+  test("a nonsensical host count is clamped to >= 1", () => {
+    expect(CpuCount.getEffectiveCpuCount(makeReads({}, 0))).toBe(1);
+    expect(CpuCount.getEffectiveCpuCount(makeReads({}, -3))).toBe(1);
+    expect(CpuCount.getEffectiveCpuCount(makeReads({}, NaN))).toBe(1);
+  });
+
+  test("a fractional host count is floored (integers only)", () => {
+    expect(CpuCount.getEffectiveCpuCount(makeReads({}, 6.9))).toBe(6);
+  });
+
+  test("even a THROWING host-parallelism read cannot escape: returns 1", () => {
+    expect(
+      CpuCount.getEffectiveCpuCount({
+        readFileUtf8: (): string => {
+          throw new Error("ENOENT");
+        },
+        hostParallelism: (): number => {
+          throw new Error("os is broken");
+        },
+      }),
+    ).toBe(1);
+  });
+
+  test("with no overrides (real fs + real os) it still returns an integer >= 1", () => {
+    /*
+     * Environment-dependent by nature, so only the invariants are
+     * pinned — this is the exact call Config.ts makes at import time.
+     */
+    const count: number = CpuCount.getEffectiveCpuCount();
+    expect(Number.isInteger(count)).toBe(true);
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/HelmChart/Public/oneuptime/templates/app.yaml
+++ b/HelmChart/Public/oneuptime/templates/app.yaml
@@ -124,13 +124,19 @@ spec:
               value: {{ $.Values.app.enableProfiling | quote }}
             - name: TELEMETRY_CONCURRENCY
               value: {{ $.Values.app.telemetryConcurrency | default 100 | squote }}
-            # Worker-thread pool for OTel payload decode (0 = disabled/inline,
-            # the code default — see App/FeatureSet/Telemetry/Config.ts).
+            # Worker-thread pool for OTel payload decode. Rendered ONLY when the
+            # operator sets a value: unset defers to the code's adaptive,
+            # cgroup-aware default of clamp(effectiveCpus - 1, 0, 4) — see
+            # App/FeatureSet/Telemetry/Config.ts. Explicit 0 hard-disables
+            # (inline decode). Nil check (not `with`/`default`): 0 is a
+            # meaningful value and must render.
             # Mirrored on the worker deployment; this copy matters on the
             # default topology (worker.enabled=false), where the app pods
             # consume the telemetry queue and therefore run the decode.
+            {{- if not (kindIs "invalid" $.Values.app.telemetryDecodeThreads) }}
             - name: TELEMETRY_DECODE_THREADS
-              value: {{ $.Values.app.telemetryDecodeThreads | default 0 | squote }}
+              value: {{ $.Values.app.telemetryDecodeThreads | squote }}
+            {{- end }}
             # Fan-in telemetry writer knobs (defaults match the code —
             # Common/Server/Utils/Telemetry/TelemetryFanInWriter.ts). Fleet-wide
             # ClickHouse insert concurrency is replicas x maxConcurrentInserts.

--- a/HelmChart/Public/oneuptime/templates/app.yaml
+++ b/HelmChart/Public/oneuptime/templates/app.yaml
@@ -124,6 +124,13 @@ spec:
               value: {{ $.Values.app.enableProfiling | quote }}
             - name: TELEMETRY_CONCURRENCY
               value: {{ $.Values.app.telemetryConcurrency | default 100 | squote }}
+            # Worker-thread pool for OTel payload decode (0 = disabled/inline,
+            # the code default — see App/FeatureSet/Telemetry/Config.ts).
+            # Mirrored on the worker deployment; this copy matters on the
+            # default topology (worker.enabled=false), where the app pods
+            # consume the telemetry queue and therefore run the decode.
+            - name: TELEMETRY_DECODE_THREADS
+              value: {{ $.Values.app.telemetryDecodeThreads | default 0 | squote }}
             # Fan-in telemetry writer knobs (defaults match the code —
             # Common/Server/Utils/Telemetry/TelemetryFanInWriter.ts). Fleet-wide
             # ClickHouse insert concurrency is replicas x maxConcurrentInserts.

--- a/HelmChart/Public/oneuptime/templates/worker.yaml
+++ b/HelmChart/Public/oneuptime/templates/worker.yaml
@@ -134,6 +134,10 @@ spec:
               value: {{ $.Values.worker.enableProfiling | quote }}
             - name: TELEMETRY_CONCURRENCY
               value: {{ $.Values.worker.telemetryConcurrency | default 100 | squote }}
+            # Worker-thread pool for OTel payload decode (0 = disabled/inline,
+            # the code default — see App/FeatureSet/Telemetry/Config.ts).
+            - name: TELEMETRY_DECODE_THREADS
+              value: {{ $.Values.worker.telemetryDecodeThreads | default 0 | squote }}
             # Fan-in telemetry writer knobs (defaults match the code —
             # Common/Server/Utils/Telemetry/TelemetryFanInWriter.ts). Fleet-wide
             # ClickHouse insert concurrency is replicas x maxConcurrentInserts.

--- a/HelmChart/Public/oneuptime/templates/worker.yaml
+++ b/HelmChart/Public/oneuptime/templates/worker.yaml
@@ -134,10 +134,16 @@ spec:
               value: {{ $.Values.worker.enableProfiling | quote }}
             - name: TELEMETRY_CONCURRENCY
               value: {{ $.Values.worker.telemetryConcurrency | default 100 | squote }}
-            # Worker-thread pool for OTel payload decode (0 = disabled/inline,
-            # the code default — see App/FeatureSet/Telemetry/Config.ts).
+            # Worker-thread pool for OTel payload decode. Rendered ONLY when the
+            # operator sets a value: unset defers to the code's adaptive,
+            # cgroup-aware default of clamp(effectiveCpus - 1, 0, 4) — see
+            # App/FeatureSet/Telemetry/Config.ts. Explicit 0 hard-disables
+            # (inline decode). Nil check (not `with`/`default`): 0 is a
+            # meaningful value and must render.
+            {{- if not (kindIs "invalid" $.Values.worker.telemetryDecodeThreads) }}
             - name: TELEMETRY_DECODE_THREADS
-              value: {{ $.Values.worker.telemetryDecodeThreads | default 0 | squote }}
+              value: {{ $.Values.worker.telemetryDecodeThreads | squote }}
+            {{- end }}
             # Fan-in telemetry writer knobs (defaults match the code —
             # Common/Server/Utils/Telemetry/TelemetryFanInWriter.ts). Fleet-wide
             # ClickHouse insert concurrency is replicas x maxConcurrentInserts.

--- a/HelmChart/Public/oneuptime/values.schema.json
+++ b/HelmChart/Public/oneuptime/values.schema.json
@@ -2623,6 +2623,13 @@
                 "telemetryConcurrency": {
                     "type": "integer"
                 },
+                "telemetryDecodeThreads": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "minimum": 0
+                },
                 "telemetryFanInMaxBatchRows": {
                     "type": "integer",
                     "minimum": 1
@@ -2811,6 +2818,13 @@
                 },
                 "telemetryConcurrency": {
                     "type": "integer"
+                },
+                "telemetryDecodeThreads": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "minimum": 0
                 },
                 "telemetryFanInMaxBatchRows": {
                     "type": "integer",

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -1421,6 +1421,11 @@ app:
   workerConcurrency: 100
   # Max concurrent telemetry ingestion jobs processed by each pod
   telemetryConcurrency: 100
+  # Worker-thread pool for OTel payload decode (gunzip + protobuf decode) so
+  # large payloads no longer serialize on the pod's single event loop.
+  # 0 = disabled (decode inline, the historical behavior). When enabling,
+  # raise the pod's CPU request/limit to cover the extra threads.
+  telemetryDecodeThreads: 0
   # Fan-in telemetry writer (per pod). Batches all telemetry ClickHouse inserts
   # into a handful of large INSERTs so pods can scale horizontally without
   # exploding ClickHouse insert concurrency. Defaults match the code
@@ -1522,6 +1527,11 @@ worker:
   # Max concurrent telemetry ingestion jobs processed by each worker pod.
   # This is the telemetry hot path; tune it together with pod CPU/memory.
   telemetryConcurrency: 100
+  # Worker-thread pool for OTel payload decode (gunzip + protobuf decode) so
+  # large payloads no longer serialize on the pod's single event loop.
+  # 0 = disabled (decode inline, the historical behavior). When enabling,
+  # raise the pod's CPU request/limit to cover the extra threads.
+  telemetryDecodeThreads: 0
   # Fan-in telemetry writer (per pod). Batches all telemetry ClickHouse inserts
   # into a handful of large INSERTs so worker replicas can scale horizontally
   # without exploding ClickHouse insert concurrency. Defaults match the code

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -1423,9 +1423,15 @@ app:
   telemetryConcurrency: 100
   # Worker-thread pool for OTel payload decode (gunzip + protobuf decode) so
   # large payloads no longer serialize on the pod's single event loop.
-  # 0 = disabled (decode inline, the historical behavior). When enabling,
-  # raise the pod's CPU request/limit to cover the extra threads.
-  telemetryDecodeThreads: 0
+  # LEAVE UNSET (the default) for the adaptive size: the code picks
+  # clamp(effectiveCpus - 1, 0, 4), where effectiveCpus honours the pod's
+  # cgroup CPU limit — a 1-CPU pod runs 0 threads (inline decode, the
+  # historical behavior) and larger pods always keep one core free for the
+  # event loop. Threads spawn lazily on the first large payload, so idle
+  # deployments pay nothing. Set 0 to hard-disable the pool, or a positive
+  # count to pin the size (each thread is a full V8 isolate — budget memory
+  # accordingly), e.g.:
+  # telemetryDecodeThreads: 2
   # Fan-in telemetry writer (per pod). Batches all telemetry ClickHouse inserts
   # into a handful of large INSERTs so pods can scale horizontally without
   # exploding ClickHouse insert concurrency. Defaults match the code
@@ -1529,9 +1535,15 @@ worker:
   telemetryConcurrency: 100
   # Worker-thread pool for OTel payload decode (gunzip + protobuf decode) so
   # large payloads no longer serialize on the pod's single event loop.
-  # 0 = disabled (decode inline, the historical behavior). When enabling,
-  # raise the pod's CPU request/limit to cover the extra threads.
-  telemetryDecodeThreads: 0
+  # LEAVE UNSET (the default) for the adaptive size: the code picks
+  # clamp(effectiveCpus - 1, 0, 4), where effectiveCpus honours the pod's
+  # cgroup CPU limit — a 1-CPU pod runs 0 threads (inline decode, the
+  # historical behavior) and larger pods always keep one core free for the
+  # event loop. Threads spawn lazily on the first large payload, so idle
+  # deployments pay nothing. Set 0 to hard-disable the pool, or a positive
+  # count to pin the size (each thread is a full V8 isolate — budget memory
+  # accordingly), e.g.:
+  # telemetryDecodeThreads: 2
   # Fan-in telemetry writer (per pod). Batches all telemetry ClickHouse inserts
   # into a handful of large INSERTs so worker replicas can scale horizontally
   # without exploding ClickHouse insert concurrency. Defaults match the code


### PR DESCRIPTION
## What

Two coupled efficiency changes for the telemetry ingest path:

1. **A `worker_threads` decode pool** moves the worker's heaviest synchronous CPU — gunzip + protobuf decode + `toJSON()` — off the single event loop, so one pod uses multiple cores for decode instead of interleaving jobs on one thread. **Enabled by default with adaptive sizing**: unset `TELEMETRY_DECODE_THREADS` resolves to `clamp(effectiveCPUs − 1, 0, 4)`, where effective CPUs honor the pod's **cgroup quota** (v2 `cpu.max`, v1 `cfs_quota_us`, fallback `os.availableParallelism`). A 1-CPU pod stays at 0 threads — inline decode, byte-for-byte the historical path, no throttling regression. Explicit values always win; `0` is a hard kill switch.
2. **Streamed ClickHouse insert bodies** (default on; `CLICKHOUSE_STREAMED_INSERTS=false` to disable): `insertJsonRows` hands the client a fresh per-invocation object-mode `Readable` instead of a rows array, so the client encodes incrementally with socket/gzip backpressure instead of materializing the entire body as one string (~100MB+ transient per 100k-row flush) in one long stringify burst. Wire bytes are byte-identical (same `encodeJSON` path in the client — proven in tests against the vendored encoder). Covers both the worker-direct path and the telemetry-writer tier.

## Design highlights

- **Pure decode module** (`OtelDecode.ts`) with an infra-free import closure (verified by require-cache dump) shared by the inline path and the thread entry — one implementation, two call sites.
- **Resilient pool** (`DecodeThreadPool.ts`): FIFO, one in-flight per thread, copy-then-transfer ArrayBuffer handoff (ioredis reply Buffers are slab views; the copy respects `byteOffset`/`length`, pinned by a slab-view regression test), thread-death → retryable rejection + respawn, circuit breaker (5 failures/30s → 60s cooldown) degrading to inline decode, shutdown that settles every pending promise.
- **Spawning**: App runs via ts-node in dev *and* prod, so threads load the `.ts` entry with explicit ts-node registration — validated in all three runtimes (nodemon dev replica end-to-end, prod image inputs, jest real-thread suites).
- **Retry-safe streams**: the fan-in writer retries inserts with the same rows + same dedup token; the stream is constructed fresh inside `insertJsonRows` per attempt, so retries never see a consumed stream.
- **Helm**: `telemetryDecodeThreads` exposed on both `app` and `worker` deployments (app pods consume the telemetry queue on the default `worker.enabled=false` topology); env renders only when explicitly set so charts defer to the adaptive default. Also fixes a latent `values.schema.json` gap (`additionalProperties: false` would have rejected anyone setting the knob).

## Safety nets for default-on

Threads spawn lazily on the first ≥8 KiB OTel payload (idle/non-telemetry pods pay nothing); 1-effective-CPU pods resolve to 0 threads; a broken pool trips the breaker and degrades to the pre-pool inline path; all pool rejections are BullMQ-retryable; `TELEMETRY_DECODE_THREADS=0` and `CLICKHOUSE_STREAMED_INSERTS=false` are no-deploy kill switches. When raising thread counts, raise the pod CPU request/limit to match; each thread is a V8+ts-node isolate — budget RSS accordingly.

## Testing

102 tests across 9 suites (8 new), real worker threads where it matters, `--detectOpenHandles` clean:
- inline-vs-thread equivalence over the product × format × encoding matrix (real proto encodings); nonzero-`byteOffset` slab-view decode
- pool mechanics: ≤N in flight, id correlation, terminate-mid-decode → reject + respawn + recover, breaker trip *and* heal-after-cooldown, no-hung-promise shutdown with queued work
- streamed inserts: byte-identity against the vendored encoder, per-attempt stream freshness, settings/dedup-token passthrough pinned in both modes, error propagation, plus a guarded live integration test (verified against a real ClickHouse 26.7)
- `CpuCount` cgroup parsing (v2/v1/fallback/garbage/never-throws) and the adaptive clamp table; routing and config contracts

No new compile errors vs the master baseline. Both change sets adversarially reviewed by multi-lens agent passes with per-finding refuters; final review: **zero confirmed findings** (earlier rounds' findings — Helm app-pod exposure, schema gap, three test gaps — are all fixed in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1ioPKzqvWG9umQPpCryE2
