### PR TITLE
fix(security): block SSRF from the workflow engine (GHSA-v5xh-rw9h-77fv)

### DIFF
--- a/Common/Server/Types/Workflow/Components/API/Delete.ts
+++ b/Common/Server/Types/Workflow/Components/API/Delete.ts
@@ -37,7 +37,7 @@ export default class ApiDelete extends ComponentCode {
     options: RunOptions,
   ): Promise<RunReturnType> {
     const result: { args: JSONObject; successPort: Port; errorPort: Port } =
-      ApiComponentUtils.sanitizeArgs(this.getMetadata(), args, options);
+      await ApiComponentUtils.sanitizeArgs(this.getMetadata(), args, options);
 
     let apiResult: HTTPResponse<JSONObject> | HTTPErrorResponse | null = null;
 
@@ -46,6 +46,7 @@ export default class ApiDelete extends ComponentCode {
         url: args["url"] as URL,
         data: args["request-body"] as JSONObject,
         headers: args["request-headers"] as Dictionary<string>,
+        options: ApiComponentUtils.requestOptions,
       });
 
       /*

--- a/Common/Server/Types/Workflow/Components/API/Get.ts
+++ b/Common/Server/Types/Workflow/Components/API/Get.ts
@@ -37,7 +37,7 @@ export default class ApiGet extends ComponentCode {
     options: RunOptions,
   ): Promise<RunReturnType> {
     const result: { args: JSONObject; successPort: Port; errorPort: Port } =
-      ApiComponentUtils.sanitizeArgs(this.getMetadata(), args, options);
+      await ApiComponentUtils.sanitizeArgs(this.getMetadata(), args, options);
 
     let apiResult: HTTPResponse<JSONObject> | HTTPErrorResponse | null = null;
 
@@ -46,6 +46,7 @@ export default class ApiGet extends ComponentCode {
         url: args["url"] as URL,
         data: args["request-body"] as JSONObject,
         headers: args["request-headers"] as Dictionary<string>,
+        options: ApiComponentUtils.requestOptions,
       });
 
       /*

--- a/Common/Server/Types/Workflow/Components/API/Patch.ts
+++ b/Common/Server/Types/Workflow/Components/API/Patch.ts
@@ -37,7 +37,7 @@ export default class ApiPut extends ComponentCode {
     options: RunOptions,
   ): Promise<RunReturnType> {
     const result: { args: JSONObject; successPort: Port; errorPort: Port } =
-      ApiComponentUtils.sanitizeArgs(this.getMetadata(), args, options);
+      await ApiComponentUtils.sanitizeArgs(this.getMetadata(), args, options);
 
     let apiResult: HTTPResponse<JSONObject> | HTTPErrorResponse | null = null;
 
@@ -46,6 +46,7 @@ export default class ApiPut extends ComponentCode {
         url: args["url"] as URL,
         data: args["request-body"] as JSONObject,
         headers: args["request-headers"] as Dictionary<string>,
+        options: ApiComponentUtils.requestOptions,
       });
 
       /*

--- a/Common/Server/Types/Workflow/Components/API/Post.ts
+++ b/Common/Server/Types/Workflow/Components/API/Post.ts
@@ -38,7 +38,7 @@ export default class ApiPost extends ComponentCode {
     options: RunOptions,
   ): Promise<RunReturnType> {
     const result: { args: JSONObject; successPort: Port; errorPort: Port } =
-      ApiComponentUtils.sanitizeArgs(this.getMetadata(), args, options);
+      await ApiComponentUtils.sanitizeArgs(this.getMetadata(), args, options);
 
     let apiResult: HTTPResponse<JSONObject> | HTTPErrorResponse | null = null;
 
@@ -77,6 +77,7 @@ export default class ApiPost extends ComponentCode {
         url: args["url"] as URL,
         data: args["request-body"] as JSONObject,
         headers: args["request-headers"] as Dictionary<string>,
+        options: ApiComponentUtils.requestOptions,
       });
 
       logger.debug("API Post Component is done.", workflowLogAttributes);

--- a/Common/Server/Types/Workflow/Components/API/Put.ts
+++ b/Common/Server/Types/Workflow/Components/API/Put.ts
@@ -37,7 +37,7 @@ export default class ApiPut extends ComponentCode {
     options: RunOptions,
   ): Promise<RunReturnType> {
     const result: { args: JSONObject; successPort: Port; errorPort: Port } =
-      ApiComponentUtils.sanitizeArgs(this.getMetadata(), args, options);
+      await ApiComponentUtils.sanitizeArgs(this.getMetadata(), args, options);
 
     let apiResult: HTTPResponse<JSONObject> | HTTPErrorResponse | null = null;
 
@@ -46,6 +46,7 @@ export default class ApiPut extends ComponentCode {
         url: args["url"] as URL,
         data: args["request-body"] as JSONObject,
         headers: args["request-headers"] as Dictionary<string>,
+        options: ApiComponentUtils.requestOptions,
       });
 
       /*

--- a/Common/Server/Types/Workflow/Components/API/Utils.ts
+++ b/Common/Server/Types/Workflow/Components/API/Utils.ts
@@ -3,14 +3,27 @@ import HTTPErrorResponse from "../../../../../Types/API/HTTPErrorResponse";
 import HTTPResponse from "../../../../../Types/API/HTTPResponse";
 import URL from "../../../../../Types/API/URL";
 import BadDataException from "../../../../../Types/Exception/BadDataException";
+import Exception from "../../../../../Types/Exception/Exception";
 import { JSONObject } from "../../../../../Types/JSON";
 import JSONFunctions from "../../../../../Types/JSONFunctions";
 import ComponentMetadata, {
   Port,
 } from "../../../../../Types/Workflow/Component";
+import { RequestOptions } from "../../../../../Utils/API";
+import SSRFProtection from "../../../../Utils/SSRFProtection";
 import CaptureSpan from "../../../../Utils/Telemetry/CaptureSpan";
 
 export class ApiComponentUtils {
+  /*
+   * Every API component sends its request with these. Redirects MUST stay off:
+   * sanitizeArgs validates the URL before the request is dispatched, and a
+   * validated public host that answers 302 -> http://169.254.169.254/ would
+   * otherwise walk the server straight past that check.
+   */
+  public static readonly requestOptions: RequestOptions = {
+    doNotFollowRedirects: true,
+  };
+
   @CaptureSpan()
   public static getReturnValues(
     response: HTTPResponse<JSONObject> | HTTPErrorResponse,
@@ -33,11 +46,11 @@ export class ApiComponentUtils {
   }
 
   @CaptureSpan()
-  public static sanitizeArgs(
+  public static async sanitizeArgs(
     metadata: ComponentMetadata,
     args: JSONObject,
     options: RunOptions,
-  ): { args: JSONObject; successPort: Port; errorPort: Port } {
+  ): Promise<{ args: JSONObject; successPort: Port; errorPort: Port }> {
     const successPort: Port | undefined = metadata.outPorts.find((p: Port) => {
       return p.id === "success";
     });
@@ -75,6 +88,32 @@ export class ApiComponentUtils {
 
     if (args["url"] && typeof args["url"] !== "string") {
       throw options.onError(new BadDataException("URL is not type of string"));
+    }
+
+    /*
+     * The URL is authored by whoever built the workflow - i.e. any member of
+     * any project - and the request goes out from the server, which sits
+     * inside the cluster and next to the cloud metadata endpoint. Without this
+     * check the API components are an authenticated request proxy into the
+     * private network: GET http://169.254.169.254/latest/meta-data/iam/... and
+     * the credentials come back in the component's "response-body" return
+     * value, in plain sight in the workflow log. Resolve and blocklist the
+     * target the same way outbound webhooks already do.
+     *
+     * Validate the RAW string, before URL.fromString - that parser defaults an
+     * unrecognized scheme to https, so "file:///etc/passwd" would reach the
+     * check already rewritten as host "file".
+     */
+    try {
+      await SSRFProtection.validateWebhookTargetIsSafe(args["url"] as string);
+    } catch (err) {
+      throw options.onError(
+        new BadDataException(
+          err instanceof Exception
+            ? err.message
+            : "URL points to an address that is not allowed.",
+        ),
+      );
     }
 
     args["url"] = URL.fromString(args["url"] as string);

--- a/Common/Server/Types/Workflow/Components/Discord/SendMessageToChannel.ts
+++ b/Common/Server/Types/Workflow/Components/Discord/SendMessageToChannel.ts
@@ -1,4 +1,7 @@
 import ComponentCode, { RunOptions, RunReturnType } from "../../ComponentCode";
+import IncomingWebhookUtils, {
+  DISCORD_WEBHOOK_DOMAINS,
+} from "../IncomingWebhookUtils";
 import HTTPErrorResponse from "../../../../../Types/API/HTTPErrorResponse";
 import HTTPResponse from "../../../../../Types/API/HTTPResponse";
 import URL from "../../../../../Types/API/URL";
@@ -59,15 +62,12 @@ export default class SendMessageToChannel extends ComponentCode {
       throw options.onError(new BadDataException("Discord message not found"));
     }
 
-    if (!args["webhook-url"]) {
-      throw options.onError(
-        new BadDataException("Discord Webhook URL not found"),
-      );
-    }
-
-    args["webhook-url"] = URL.fromString(
-      args["webhook-url"]?.toString() as string,
-    );
+    args["webhook-url"] = IncomingWebhookUtils.getPinnedWebhookUrl({
+      args,
+      options,
+      allowedDomains: DISCORD_WEBHOOK_DOMAINS,
+      vendorName: "Discord",
+    });
 
     let apiResult: HTTPResponse<JSONObject> | HTTPErrorResponse | null = null;
 
@@ -77,6 +77,13 @@ export default class SendMessageToChannel extends ComponentCode {
         url: args["webhook-url"] as URL,
         data: {
           content: args["text"] as string,
+        },
+        /*
+         * The host is pinned above; following a redirect would hand the
+         * destination back to whoever controls that host.
+         */
+        options: {
+          doNotFollowRedirects: true,
         },
       });
 

--- a/Common/Server/Types/Workflow/Components/IncomingWebhookUtils.ts
+++ b/Common/Server/Types/Workflow/Components/IncomingWebhookUtils.ts
@@ -1,0 +1,66 @@
+import { RunOptions } from "../ComponentCode";
+import URL from "../../../../Types/API/URL";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../../Types/JSON";
+import SSRFProtection from "../../../Utils/SSRFProtection";
+
+/*
+ * The Slack / Discord / Microsoft Teams workflow components each take a
+ * free-text "webhook-url" argument off the workflow graph, which any project
+ * member can author and which can additionally be templated from trigger data.
+ * They then POST to it from the API server - the same SSRF primitive that
+ * GHSA-v5xh-rw9h-77fv reported against the API components.
+ *
+ * These are chat webhooks, so unlike the generic API components there is a
+ * vendor host to pin to, and a pin is strictly better than a blocklist: it
+ * cannot be walked around with DNS rebinding, an alternate IP notation, or a
+ * redirect. Nothing legitimate is lost - a self-hosted OneUptime still posts to
+ * hooks.slack.com like everyone else.
+ */
+
+export const DISCORD_WEBHOOK_DOMAINS: Array<string> = [
+  "discord.com",
+  "discordapp.com",
+];
+
+export class IncomingWebhookUtils {
+  /*
+   * Reads the component's "webhook-url" argument, requires it to be on one of
+   * `allowedDomains`, and returns it parsed. Throws through options.onError so
+   * the workflow stops with a message the author can act on.
+   *
+   * Validates the RAW string: URL.fromString defaults an unrecognized scheme to
+   * https, so converting first would let "gopher://..." arrive looking clean.
+   */
+  public static getPinnedWebhookUrl(data: {
+    args: JSONObject;
+    options: RunOptions;
+    allowedDomains: Array<string>;
+    vendorName: string;
+  }): URL {
+    const rawUrl: unknown = data.args["webhook-url"];
+
+    if (!rawUrl) {
+      throw data.options.onError(
+        new BadDataException(`${data.vendorName} Webhook URL not found`),
+      );
+    }
+
+    if (
+      !SSRFProtection.isUrlOnAllowedDomain(
+        rawUrl.toString(),
+        data.allowedDomains,
+      )
+    ) {
+      throw data.options.onError(
+        new BadDataException(
+          `${data.vendorName} Webhook URL must be an https URL on ${data.allowedDomains.join(" or ")}.`,
+        ),
+      );
+    }
+
+    return URL.fromString(rawUrl.toString());
+  }
+}
+
+export default IncomingWebhookUtils;

--- a/Common/Server/Types/Workflow/Components/MicrosoftTeams/SendMessageToChannel.ts
+++ b/Common/Server/Types/Workflow/Components/MicrosoftTeams/SendMessageToChannel.ts
@@ -1,4 +1,6 @@
 import ComponentCode, { RunOptions, RunReturnType } from "../../ComponentCode";
+import IncomingWebhookUtils from "../IncomingWebhookUtils";
+import { MICROSOFT_TEAMS_WEBHOOK_DOMAINS } from "../../../../Utils/Workspace/MicrosoftTeams/MicrosoftTeams";
 import HTTPErrorResponse from "../../../../../Types/API/HTTPErrorResponse";
 import HTTPResponse from "../../../../../Types/API/HTTPResponse";
 import URL from "../../../../../Types/API/URL";
@@ -60,15 +62,12 @@ export default class SendMessageToChannel extends ComponentCode {
       );
     }
 
-    if (!args["webhook-url"]) {
-      throw options.onError(
-        new BadDataException("Microsoft teams Webhook URL not found"),
-      );
-    }
-
-    args["webhook-url"] = URL.fromString(
-      args["webhook-url"]?.toString() as string,
-    );
+    args["webhook-url"] = IncomingWebhookUtils.getPinnedWebhookUrl({
+      args,
+      options,
+      allowedDomains: MICROSOFT_TEAMS_WEBHOOK_DOMAINS,
+      vendorName: "Microsoft Teams",
+    });
 
     let apiResult: HTTPResponse<JSONObject> | HTTPErrorResponse | null = null;
 
@@ -99,6 +98,13 @@ export default class SendMessageToChannel extends ComponentCode {
               },
             },
           ],
+        },
+        /*
+         * The host is pinned above; following a redirect would hand the
+         * destination back to whoever controls that host.
+         */
+        options: {
+          doNotFollowRedirects: true,
         },
       });
 

--- a/Common/Server/Types/Workflow/Components/Slack/SendMessageToChannel.ts
+++ b/Common/Server/Types/Workflow/Components/Slack/SendMessageToChannel.ts
@@ -65,6 +65,23 @@ export default class SendMessageToChannel extends ComponentCode {
       );
     }
 
+    /*
+     * Pin the target to Slack's own incoming-webhook endpoint. Without this the
+     * component POSTs from the API server to any URL a workflow author types -
+     * the SSRF reported as GHSA-v5xh-rw9h-77fv against the API components.
+     */
+    if (
+      !SlackUtil.isValidSlackIncomingWebhookUrl(
+        args["webhook-url"]?.toString() as string,
+      )
+    ) {
+      throw options.onError(
+        new BadDataException(
+          "Slack Webhook URL must start with https://hooks.slack.com/services/",
+        ),
+      );
+    }
+
     args["webhook-url"] = URL.fromString(
       args["webhook-url"]?.toString() as string,
     );

--- a/Common/Server/Utils/SSRFProtection.ts
+++ b/Common/Server/Utils/SSRFProtection.ts
@@ -1,9 +1,7 @@
 import URL from "../../Types/API/URL";
 import BadDataException from "../../Types/Exception/BadDataException";
 import dns from "dns";
-
-const IPV4_LITERAL_REGEX: RegExp = /^(\d{1,3}\.){3}\d{1,3}$/;
-const IPV6_UNIQUE_LOCAL_REGEX: RegExp = /^f[cd][0-9a-f]{2}:/;
+import net from "net";
 
 /*
  * Guards outbound HTTP(S) requests whose target is (fully or partly)
@@ -28,14 +26,23 @@ export default class SSRFProtection {
    * (`http://169.254.169.254/?x=office.com`) and pins nothing.
    */
   public static getBareHostname(rawUrl: string | URL): string {
-    let parsed: URL;
+    /*
+     * WHATWG, not URL.fromString. OneUptime's parser takes everything before
+     * the first "/" as the authority and never terminates at "?" or "#", so it
+     * reads "https://169.254.169.254#.office.com" as the host
+     * "169.254.169.254#.office.com" - which ends with ".office.com" and
+     * satisfied the allowlist, while axios re-parsed the same string per WHATWG
+     * and dialled 169.254.169.254. A pin is only worth anything if it parses
+     * the host the same way the HTTP client will.
+     */
+    let parsed: globalThis.URL;
     try {
-      parsed = URL.fromString(rawUrl.toString());
+      parsed = new globalThis.URL(rawUrl.toString());
     } catch {
       return "";
     }
 
-    return SSRFProtection.extractHost(parsed.hostname.hostname.toLowerCase());
+    return SSRFProtection.extractHost(parsed.hostname.toLowerCase());
   }
 
   /*
@@ -47,14 +54,15 @@ export default class SSRFProtection {
     rawUrl: string | URL,
     allowedDomains: Array<string>,
   ): boolean {
-    let parsed: URL;
+    let parsed: globalThis.URL;
     try {
-      parsed = URL.fromString(rawUrl.toString());
+      parsed = new globalThis.URL(rawUrl.toString());
     } catch {
       return false;
     }
 
-    if (parsed.protocol.toString().toLowerCase() !== "https://") {
+    // Scheme and host must come from the SAME parser, or they can disagree.
+    if (parsed.protocol.toLowerCase() !== "https:") {
       return false;
     }
 
@@ -73,6 +81,30 @@ export default class SSRFProtection {
   public static async validateWebhookTargetIsSafe(
     rawUrl: string | URL,
   ): Promise<void> {
+    /*
+     * URL.fromString only knows http/https/ws/wss/mongodb/mailto and silently
+     * DEFAULTS anything else to https - "file:///etc/passwd" comes back as
+     * host "file", not as a file: URL - so the protocol check below never sees
+     * the scheme the caller actually wrote. Read it off the raw string first.
+     *
+     * The ":" must be followed by "/" or this would treat the host in a
+     * scheme-less "example.com:8080/hook" as a scheme and reject it.
+     */
+    const schemeMatch: RegExpMatchArray | null = rawUrl
+      .toString()
+      .trim()
+      .match(/^([a-z][a-z0-9+.-]*):\//i);
+
+    if (
+      schemeMatch &&
+      schemeMatch[1] &&
+      !["http", "https"].includes(schemeMatch[1].toLowerCase())
+    ) {
+      throw new BadDataException(
+        "Webhook URL must use http or https protocol.",
+      );
+    }
+
     let parsed: URL;
     try {
       parsed = URL.fromString(rawUrl.toString());
@@ -164,72 +196,253 @@ export default class SSRFProtection {
     return host;
   }
 
+  /*
+   * An IP literal needs no DNS lookup - but "looks like it has a colon" is not
+   * the same question, and getting it wrong is a bypass in both directions.
+   * net.isIP is the authority: it rejects "2852039166" and "0177.0.0.1"
+   * (which then go to DNS, where getaddrinfo decodes them and the resolved
+   * address gets checked) and accepts every real IPv6 spelling.
+   */
   private static isIpLiteral(hostname: string): boolean {
-    return IPV4_LITERAL_REGEX.test(hostname) || hostname.includes(":");
+    return net.isIP(SSRFProtection.stripZoneId(hostname)) !== 0;
+  }
+
+  private static stripZoneId(address: string): string {
+    const zoneIndex: number = address.indexOf("%");
+    return zoneIndex === -1 ? address : address.substring(0, zoneIndex);
+  }
+
+  /*
+   * Expands an IPv6 address into its eight 16-bit groups, folding an embedded
+   * IPv4 tail ("::ffff:127.0.0.1") into two hex groups on the way, so that
+   * every spelling of one address produces one canonical answer. Returns null
+   * if the address is not parseable as IPv6.
+   *
+   * This exists because the checks below CANNOT be string prefix matches:
+   * "::1", "0:0:0:0:0:0:0:1" and "0000:...:0001" are the same host, and
+   * "::ffff:169.254.169.254" is the cloud metadata endpoint wearing a hat.
+   */
+  private static expandIpv6(address: string): Array<number> | null {
+    let ip: string = SSRFProtection.stripZoneId(address.toLowerCase());
+
+    if (net.isIPv6(ip) === false) {
+      return null;
+    }
+
+    // Fold a dotted-quad tail into the two hex groups it stands for.
+    const lastColonIndex: number = ip.lastIndexOf(":");
+    const tail: string = ip.substring(lastColonIndex + 1);
+    if (tail.includes(".")) {
+      if (net.isIPv4(tail) === false) {
+        return null;
+      }
+      const octets: Array<number> = tail.split(".").map((part: string) => {
+        return parseInt(part, 10);
+      });
+      const high: string = (
+        ((octets[0] as number) << 8) |
+        (octets[1] as number)
+      ).toString(16);
+      const low: string = (
+        ((octets[2] as number) << 8) |
+        (octets[3] as number)
+      ).toString(16);
+      ip = `${ip.substring(0, lastColonIndex)}:${high}:${low}`;
+    }
+
+    const halves: Array<string> = ip.split("::");
+    if (halves.length > 2) {
+      return null;
+    }
+
+    const head: Array<string> =
+      halves[0] === undefined || halves[0] === "" ? [] : halves[0].split(":");
+    const rear: Array<string> =
+      halves.length === 2 && halves[1] !== undefined && halves[1] !== ""
+        ? halves[1].split(":")
+        : [];
+
+    let groups: Array<string>;
+    if (halves.length === 2) {
+      const zeroFill: number = 8 - head.length - rear.length;
+      if (zeroFill < 0) {
+        return null;
+      }
+      groups = [...head, ...new Array(zeroFill).fill("0"), ...rear];
+    } else {
+      groups = head;
+    }
+
+    if (groups.length !== 8) {
+      return null;
+    }
+
+    const parsed: Array<number> = groups.map((group: string) => {
+      return parseInt(group || "0", 16);
+    });
+
+    if (
+      parsed.some((group: number) => {
+        return Number.isNaN(group) || group < 0 || group > 0xffff;
+      })
+    ) {
+      return null;
+    }
+
+    return parsed;
+  }
+
+  /*
+   * True when an IPv6 literal points somewhere the server must never be made
+   * to reach. Ranges, not spellings: loopback, unspecified, link-local
+   * (fe80::/10), unique-local (fc00::/7) and multicast (ff00::/8), plus the
+   * three ways IPv6 can carry an IPv4 destination - IPv4-mapped
+   * (::ffff:0:0/96), IPv4-compatible (::/96) and the NAT64 well-known prefix
+   * (64:ff9b::/96) - which are handed to the IPv4 blocklist.
+   */
+  private static isBlockedIpv6(address: string): boolean {
+    const groups: Array<number> | null = SSRFProtection.expandIpv6(address);
+
+    if (!groups) {
+      // Not parseable as IPv6; the caller's other checks decide.
+      return false;
+    }
+
+    const isZeroThrough: (endExclusive: number) => boolean = (
+      endExclusive: number,
+    ): boolean => {
+      return groups.slice(0, endExclusive).every((group: number) => {
+        return group === 0;
+      });
+    };
+
+    const embeddedIpv4: () => string = (): string => {
+      const high: number = groups[6] as number;
+      const low: number = groups[7] as number;
+      return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+    };
+
+    // ::  — unspecified. Connecting here lands on the local host.
+    if (isZeroThrough(8)) {
+      return true;
+    }
+
+    // ::1 — loopback.
+    if (isZeroThrough(7) && groups[7] === 1) {
+      return true;
+    }
+
+    // ::ffff:0:0/96 — IPv4-mapped.
+    if (isZeroThrough(5) && groups[5] === 0xffff) {
+      return SSRFProtection.isBlockedIpv4(embeddedIpv4());
+    }
+
+    // 64:ff9b::/96 — NAT64 well-known prefix.
+    if (
+      groups[0] === 0x0064 &&
+      groups[1] === 0xff9b &&
+      groups[2] === 0 &&
+      groups[3] === 0 &&
+      groups[4] === 0 &&
+      groups[5] === 0
+    ) {
+      return SSRFProtection.isBlockedIpv4(embeddedIpv4());
+    }
+
+    // ::/96 — IPv4-compatible (deprecated, still routable by some stacks).
+    if (isZeroThrough(6)) {
+      return SSRFProtection.isBlockedIpv4(embeddedIpv4());
+    }
+
+    const first: number = groups[0] as number;
+
+    // fe80::/10 — link-local.
+    if ((first & 0xffc0) === 0xfe80) {
+      return true;
+    }
+
+    // fc00::/7 — unique-local.
+    if ((first & 0xfe00) === 0xfc00) {
+      return true;
+    }
+
+    // fec0::/10 — site-local. Deprecated by RFC 3879, still routed on some networks.
+    if ((first & 0xffc0) === 0xfec0) {
+      return true;
+    }
+
+    // ff00::/8 — multicast.
+    if ((first & 0xff00) === 0xff00) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private static isBlockedIpv4(address: string): boolean {
+    const octets: Array<number> = address.split(".").map((part: string) => {
+      return Number(part);
+    });
+
+    if (
+      octets.length !== 4 ||
+      octets.some((octet: number) => {
+        return Number.isNaN(octet) || octet < 0 || octet > 255;
+      })
+    ) {
+      return true;
+    }
+
+    const [first, second] = octets as [number, number, number, number];
+
+    if (first === 0) {
+      return true; // 0.0.0.0/8 — "this host".
+    }
+    if (first === 127) {
+      return true; // loopback
+    }
+    if (first === 10) {
+      return true; // RFC-1918
+    }
+    if (first === 172 && (second & 0xf0) === 16) {
+      return true; // RFC-1918 172.16/12
+    }
+    if (first === 192 && second === 168) {
+      return true; // RFC-1918
+    }
+    if (first === 169 && second === 254) {
+      return true; // link-local, incl. the 169.254.169.254 metadata endpoint
+    }
+    if (first === 100 && (second & 0xc0) === 64) {
+      return true; // CGNAT 100.64/10
+    }
+    if (first >= 224) {
+      return true; // multicast, reserved, and 255.255.255.255
+    }
+
+    return false;
   }
 
   private static isBlockedHostnameLiteral(hostname: string): boolean {
     if (
       hostname === "localhost" ||
+      hostname === "localhost." ||
       hostname.endsWith(".localhost") ||
       hostname === "metadata.google.internal"
     ) {
       return true;
     }
 
-    const ipv4Match: RegExpMatchArray | null = hostname.match(
-      /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/,
+    const address: string = SSRFProtection.stripZoneId(
+      hostname.replace(/^\[|\]$/g, ""),
     );
-    if (ipv4Match) {
-      const octets: Array<number> = [
-        Number(ipv4Match[1]),
-        Number(ipv4Match[2]),
-        Number(ipv4Match[3]),
-        Number(ipv4Match[4]),
-      ];
 
-      if (
-        octets.some((o: number) => {
-          return o < 0 || o > 255;
-        })
-      ) {
-        return true;
-      }
-      if (octets[0] === 0) {
-        return true;
-      }
-      if (octets[0] === 127) {
-        return true;
-      }
-      if (octets[0] === 10) {
-        return true;
-      }
-      if (octets[0] === 172 && (octets[1]! & 0xf0) === 16) {
-        return true;
-      }
-      if (octets[0] === 192 && octets[1] === 168) {
-        return true;
-      }
-      if (octets[0] === 169 && octets[1] === 254) {
-        return true;
-      }
-      if (octets[0] === 100 && (octets[1]! & 0xc0) === 64) {
-        return true;
-      }
-      return false;
+    if (net.isIPv4(address)) {
+      return SSRFProtection.isBlockedIpv4(address);
     }
 
-    if (hostname.includes(":")) {
-      const stripped: string = hostname.replace(/^\[|\]$/g, "");
-      if (stripped === "::1" || stripped === "::") {
-        return true;
-      }
-      if (stripped.startsWith("fe80:") || stripped.startsWith("fe80::")) {
-        return true;
-      }
-      if (IPV6_UNIQUE_LOCAL_REGEX.test(stripped)) {
-        return true;
-      }
+    if (net.isIPv6(address)) {
+      return SSRFProtection.isBlockedIpv6(address);
     }
 
     return false;

--- a/Common/Server/Utils/VM/VMRunner.ts
+++ b/Common/Server/Utils/VM/VMRunner.ts
@@ -10,6 +10,7 @@ import CaptureSpan from "../Telemetry/CaptureSpan";
 import Dictionary from "../../../Types/Dictionary";
 import GenericObject from "../../../Types/GenericObject";
 import vm, { Context } from "vm";
+import SSRFProtection from "../SSRFProtection";
 
 /**
  * Symbol used to retrieve the real (unwrapped) target from a sandbox proxy.
@@ -356,6 +357,49 @@ function unwrapProxy<T>(value: T): T {
 }
 
 export default class VMRunner {
+  /*
+   * Works out which URL the sandbox's axios call will actually dial, so the
+   * SSRF check and the request agree on the destination. axios accepts the
+   * target three different ways - a positional url, config.url on a
+   * `request()` call, and a relative url resolved against config.baseURL - and
+   * a check that only looked at the positional argument would miss two of them.
+   *
+   * Anything that does not end up an absolute http(s) URL is rejected rather
+   * than guessed at.
+   */
+  private static resolveEffectiveRequestUrl(data: {
+    method: string;
+    url: string;
+    config?: JSONObject | undefined;
+  }): string {
+    const baseUrl: string =
+      typeof data.config?.["baseURL"] === "string"
+        ? (data.config["baseURL"] as string)
+        : "";
+
+    let target: string = data.url || "";
+
+    if (data.method === "request" || !target) {
+      const configUrl: unknown = data.config?.["url"];
+      target = typeof configUrl === "string" ? configUrl : target;
+    }
+
+    let absolute: string = target;
+
+    if (!/^https?:\/\//i.test(absolute)) {
+      if (!baseUrl) {
+        throw new Error("Request URL must be an absolute http or https URL.");
+      }
+      absolute = `${baseUrl.replace(/\/+$/, "")}/${absolute.replace(/^\/+/, "")}`;
+    }
+
+    if (!/^https?:\/\//i.test(absolute)) {
+      throw new Error("Request URL must be an absolute http or https URL.");
+    }
+
+    return absolute;
+  }
+
   @CaptureSpan()
   public static async runCodeInNodeVM(data: {
     code: string;
@@ -730,7 +774,7 @@ export default class VMRunner {
             hasBody && arg1 ? (JSON.parse(arg1) as JSONObject) : undefined;
 
           const configStr: string | undefined = hasBody ? arg2 : arg1;
-          const config: JSONObject | undefined = configStr
+          let config: JSONObject | undefined = configStr
             ? (JSON.parse(configStr) as JSONObject)
             : undefined;
 
@@ -782,6 +826,47 @@ export default class VMRunner {
             }
             return plain;
           };
+
+          /*
+           * SSRF guard (GHSA-v5xh-rw9h-77fv).
+           *
+           * This bridge hands the host process's real axios to code the user
+           * wrote - the Custom JavaScript workflow component documents "you can
+           * use axios module" - so without a check here it is a strictly more
+           * capable version of the hole that was reported against the API
+           * components: arbitrary method, headers and body against the internal
+           * network, with the full response marshalled back into the sandbox
+           * and on into the workflow log.
+           *
+           * It has to live on THIS side of the isolate boundary. The
+           * sandbox-side axios shim is attacker-editable - user code can simply
+           * redefine it - so a check there guards nothing.
+           */
+          const effectiveUrl: string = VMRunner.resolveEffectiveRequestUrl({
+            method,
+            url,
+            config,
+          });
+
+          await SSRFProtection.validateWebhookTargetIsSafe(effectiveUrl);
+
+          /*
+           * The URL that was just validated has to be the URL that gets
+           * dialled. Each of these would otherwise steer the connection
+           * somewhere else entirely, past the check above:
+           *   proxy      - sends the request to an arbitrary host:port
+           *   socketPath - connects to a unix socket (/var/run/docker.sock)
+           *   transport / adapter - replaces the transport wholesale
+           * and a redirect would let a validated public host nominate an
+           * internal one on the second hop.
+           */
+          const safeConfig: JSONObject = config || {};
+          delete safeConfig["proxy"];
+          delete safeConfig["socketPath"];
+          delete safeConfig["transport"];
+          delete safeConfig["adapter"];
+          safeConfig["maxRedirects"] = 0;
+          config = safeConfig;
 
           try {
             let response: AxiosResponse;

--- a/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
+++ b/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
@@ -119,7 +119,7 @@ const MICROSOFT_TEAMS_MAX_PAGES: number = 500;
  * issued on outlook.office.com / outlook.office365.com, and per-tenant ones on
  * <tenant>.webhook.office.com — all covered by these two registrable domains.
  */
-const MICROSOFT_TEAMS_WEBHOOK_DOMAINS: Array<string> = [
+export const MICROSOFT_TEAMS_WEBHOOK_DOMAINS: Array<string> = [
   "office.com",
   "office365.com",
 ];
@@ -703,6 +703,17 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
   }): Promise<HTTPResponse<JSONObject> | HTTPErrorResponse> {
     logger.debug("Sending message to Teams channel via incoming webhook:");
     logger.debug(data);
+
+    /*
+     * Enforced at the sink, not only at the callers: this URL reaches here from
+     * workflow arguments and from status page subscribers, and a caller that
+     * forgets the pin is an SSRF from the API server.
+     */
+    if (!MicrosoftTeamsUtil.isValidMicrosoftTeamsIncomingWebhookUrl(data.url)) {
+      throw new BadDataException(
+        `Microsoft Teams Webhook URL must be an https URL on ${MICROSOFT_TEAMS_WEBHOOK_DOMAINS.join(" or ")}.`,
+      );
+    }
 
     // Build a structured MessageCard from markdown for better rendering in Teams
     const payload: JSONObject = this.buildMessageCardFromMarkdown(data.text);

--- a/Common/Server/Utils/Workspace/Slack/Slack.ts
+++ b/Common/Server/Utils/Workspace/Slack/Slack.ts
@@ -33,12 +33,24 @@ import CaptureSpan from "../../Telemetry/CaptureSpan";
 import BadDataException from "../../../../Types/Exception/BadDataException";
 import ObjectID from "../../../../Types/ObjectID";
 import WorkspaceProjectAuthTokenService from "../../../Services/WorkspaceProjectAuthTokenService";
+import SSRFProtection from "../../SSRFProtection";
 
 export default class SlackUtil extends WorkspaceBase {
   public static isValidSlackIncomingWebhookUrl(
-    incomingWebhookUrl: URL,
+    incomingWebhookUrl: URL | string,
   ): boolean {
-    // check if the URL starts with https://hooks.slack.com/services/
+    /*
+     * Host AND path prefix. The host check is what stops SSRF; the "/services/"
+     * prefix is what makes this tighter than a bare domain pin. Both are read
+     * off the WHATWG parser via getBareHostname, so a "#"/"?" in the string
+     * cannot make an attacker host look like a Slack one.
+     */
+    if (
+      SSRFProtection.getBareHostname(incomingWebhookUrl) !== "hooks.slack.com"
+    ) {
+      return false;
+    }
+
     return incomingWebhookUrl
       .toString()
       .startsWith("https://hooks.slack.com/services/");
@@ -2264,6 +2276,17 @@ export default class SlackUtil extends WorkspaceBase {
       {} as LogAttributes,
     );
     logger.debug(data, {} as LogAttributes);
+
+    /*
+     * Enforced at the sink, not only at the callers: this URL reaches here from
+     * workflow arguments and from status page subscribers, and a caller that
+     * forgets the pin is an SSRF from the API server.
+     */
+    if (!SlackUtil.isValidSlackIncomingWebhookUrl(data.url)) {
+      throw new BadDataException(
+        "Slack Webhook URL must start with https://hooks.slack.com/services/",
+      );
+    }
 
     const apiResult: HTTPResponse<JSONObject> | HTTPErrorResponse | null =
       await API.post({

--- a/Common/Tests/Server/Types/Workflow/Components/ApiComponentErrorPort.test.ts
+++ b/Common/Tests/Server/Types/Workflow/Components/ApiComponentErrorPort.test.ts
@@ -15,7 +15,8 @@ import { JSONObject } from "../../../../../Types/JSON";
 import ObjectID from "../../../../../Types/ObjectID";
 import ComponentID from "../../../../../Types/Workflow/ComponentID";
 import API from "../../../../../Utils/API";
-import { beforeEach, describe, expect, test } from "@jest/globals";
+import { afterAll, beforeEach, describe, expect, test } from "@jest/globals";
+import dns from "dns";
 
 /*
  * The default export of Utils/API is the only thing these components talk to,
@@ -141,8 +142,25 @@ const apiComponents: Array<[string, ApiMethodName, ComponentFactory, string]> =
     ],
   ];
 
+/*
+ * sanitizeArgs now runs the URL through SSRFProtection, which resolves the
+ * hostname. Pin the lookup to a public address so these tests stay offline and
+ * deterministic - what they are about is port routing, not the blocklist.
+ */
+const lookupSpy: jest.SpiedFunction<
+  (
+    hostname: string,
+    options: { all: true },
+  ) => Promise<Array<{ address: string; family: number }>>
+> = jest.spyOn(dns.promises, "lookup") as never;
+
 beforeEach(() => {
   jest.clearAllMocks();
+  lookupSpy.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
 });
 
 describe.each(apiComponents)(
@@ -219,10 +237,12 @@ describe.each(apiComponents)(
         url: URL;
         data: JSONObject;
         headers: JSONObject;
+        options: { doNotFollowRedirects?: boolean };
       } = getApiMock(apiMethodName).mock.calls[0]![0] as {
         url: URL;
         data: JSONObject;
         headers: JSONObject;
+        options: { doNotFollowRedirects?: boolean };
       };
       expect(request.url.toString()).toBe(TEST_URL);
       expect(request.data).toEqual({
@@ -230,6 +250,11 @@ describe.each(apiComponents)(
         name: "Airflow-Token",
       });
       expect(request.headers).toEqual({ apikey: "a-project-api-key" });
+      /*
+       * Redirects have to stay off, or the SSRF check sanitizeArgs just did is
+       * worth nothing: a public host can 302 the server to an internal one.
+       */
+      expect(request.options.doNotFollowRedirects).toBe(true);
     });
 
     test("routes a thrown transport error to the error port with an error message", async () => {

--- a/Common/Tests/Server/Types/Workflow/Components/ApiComponentSsrf.test.ts
+++ b/Common/Tests/Server/Types/Workflow/Components/ApiComponentSsrf.test.ts
@@ -1,0 +1,215 @@
+import ApiDelete from "../../../../../Server/Types/Workflow/Components/API/Delete";
+import ApiGet from "../../../../../Server/Types/Workflow/Components/API/Get";
+import ApiPatch from "../../../../../Server/Types/Workflow/Components/API/Patch";
+import ApiPost from "../../../../../Server/Types/Workflow/Components/API/Post";
+import ApiPut from "../../../../../Server/Types/Workflow/Components/API/Put";
+import ComponentCode, {
+  RunOptions,
+} from "../../../../../Server/Types/Workflow/ComponentCode";
+import HTTPResponse from "../../../../../Types/API/HTTPResponse";
+import Exception from "../../../../../Types/Exception/Exception";
+import { JSONObject } from "../../../../../Types/JSON";
+import ObjectID from "../../../../../Types/ObjectID";
+import API from "../../../../../Utils/API";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import dns from "dns";
+
+/*
+ * GHSA-v5xh-rw9h-77fv: the API workflow components sent a request to whatever
+ * URL the workflow author typed in, with no blocklist. Any member of any
+ * project could point one at http://169.254.169.254/latest/meta-data/ and read
+ * the cloud instance credentials straight out of the component's
+ * "response-body" return value, or sweep the cluster's internal services by
+ * watching the status codes.
+ *
+ * These tests pin the guard at the one place all five verbs share
+ * (ApiComponentUtils.sanitizeArgs) - for every verb, so a new component cannot
+ * be added that quietly skips it.
+ */
+
+jest.mock("../../../../../Utils/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      get: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      patch: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+});
+
+type ApiMethodName = "get" | "post" | "put" | "patch" | "delete";
+
+type LookupSpy = jest.SpiedFunction<
+  (
+    hostname: string,
+    options: { all: true },
+  ) => Promise<Array<{ address: string; family: number }>>
+>;
+
+const apiComponents: Array<[string, ApiMethodName, () => ComponentCode]> = [
+  [
+    "Get",
+    "get",
+    (): ComponentCode => {
+      return new ApiGet();
+    },
+  ],
+  [
+    "Post",
+    "post",
+    (): ComponentCode => {
+      return new ApiPost();
+    },
+  ],
+  [
+    "Put",
+    "put",
+    (): ComponentCode => {
+      return new ApiPut();
+    },
+  ],
+  [
+    "Patch",
+    "patch",
+    (): ComponentCode => {
+      return new ApiPatch();
+    },
+  ],
+  [
+    "Delete",
+    "delete",
+    (): ComponentCode => {
+      return new ApiDelete();
+    },
+  ],
+];
+
+function makeOptions(): RunOptions {
+  return {
+    log: jest.fn() as RunOptions["log"],
+    workflowLogId: ObjectID.generate(),
+    workflowId: ObjectID.generate(),
+    projectId: ObjectID.generate(),
+    onError: ((exception: Exception): Exception => {
+      return exception;
+    }) as RunOptions["onError"],
+    executeWorkflow: async (): Promise<void> => {},
+  };
+}
+
+function getApiMock(apiMethodName: ApiMethodName): jest.Mock {
+  return API[apiMethodName] as unknown as jest.Mock;
+}
+
+let lookupSpy: LookupSpy;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  lookupSpy = jest.spyOn(dns.promises, "lookup") as unknown as LookupSpy;
+  lookupSpy.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe.each(apiComponents)(
+  "API %s workflow component SSRF guard",
+  (
+    _label: string,
+    apiMethodName: ApiMethodName,
+    createComponent: () => ComponentCode,
+  ) => {
+    const blockedUrls: Array<[string, string]> = [
+      ["cloud metadata endpoint", "http://169.254.169.254/latest/meta-data/"],
+      [
+        "cloud metadata endpoint on an explicit port",
+        "http://169.254.169.254:80/latest/meta-data/",
+      ],
+      ["GCP metadata by name", "http://metadata.google.internal/"],
+      ["loopback", "http://127.0.0.1:8080/admin"],
+      ["localhost", "http://localhost:3000/api/status"],
+      ["RFC-1918 10/8", "http://10.0.0.5/internal"],
+      ["RFC-1918 172.16/12", "http://172.16.4.1/internal"],
+      ["RFC-1918 192.168/16", "http://192.168.1.1/router"],
+      ["CGNAT", "http://100.64.0.1/"],
+      ["IPv6 loopback", "http://[::1]:9200/_cluster/health"],
+      ["IPv6 link-local", "http://[fe80::1]/"],
+      ["IPv6 unique-local", "http://[fd00::1]/"],
+      ["the unspecified address", "http://0.0.0.0/"],
+    ];
+
+    test.each(blockedUrls)(
+      "refuses to request %s and never reaches the HTTP client",
+      async (_reason: string, url: string) => {
+        await expect(
+          createComponent().run({ url }, makeOptions()),
+        ).rejects.toThrow();
+
+        expect(getApiMock(apiMethodName)).not.toHaveBeenCalled();
+      },
+    );
+
+    test("refuses a public hostname that resolves to an internal address", async () => {
+      // The DNS-rebinding shape: the name looks fine, the answer does not.
+      lookupSpy.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+
+      await expect(
+        createComponent().run(
+          { url: "https://metadata.attacker.example/latest/meta-data/" },
+          makeOptions(),
+        ),
+      ).rejects.toThrow();
+
+      expect(getApiMock(apiMethodName)).not.toHaveBeenCalled();
+    });
+
+    test("refuses a non-http scheme", async () => {
+      await expect(
+        createComponent().run({ url: "file:///etc/passwd" }, makeOptions()),
+      ).rejects.toThrow();
+
+      expect(getApiMock(apiMethodName)).not.toHaveBeenCalled();
+    });
+
+    test("still allows an ordinary public URL", async () => {
+      getApiMock(apiMethodName).mockResolvedValue(
+        new HTTPResponse<JSONObject>(200, { ok: true }, {}),
+      );
+
+      const result: { returnValues: JSONObject } = await createComponent().run(
+        { url: "https://api.example.com/v1/deploy" },
+        makeOptions(),
+      );
+
+      expect(getApiMock(apiMethodName)).toHaveBeenCalledTimes(1);
+      expect(result.returnValues["response-status"]).toBe(200);
+    });
+
+    test("sends the allowed request with redirects turned off", async () => {
+      getApiMock(apiMethodName).mockResolvedValue(
+        new HTTPResponse<JSONObject>(200, { ok: true }, {}),
+      );
+
+      await createComponent().run(
+        { url: "https://api.example.com/v1/deploy" },
+        makeOptions(),
+      );
+
+      const request: { options?: { doNotFollowRedirects?: boolean } } =
+        getApiMock(apiMethodName).mock.calls[0]![0] as {
+          options?: { doNotFollowRedirects?: boolean };
+        };
+
+      /*
+       * Validating the URL is only half the fix. Following a 3xx would let a
+       * host that passes the blocklist hand the server an internal address
+       * afterwards, which is the same vulnerability one hop later.
+       */
+      expect(request.options?.doNotFollowRedirects).toBe(true);
+    });
+  },
+);

--- a/Common/Tests/Server/Types/Workflow/Components/ChatWebhookComponents.test.ts
+++ b/Common/Tests/Server/Types/Workflow/Components/ChatWebhookComponents.test.ts
@@ -1,0 +1,256 @@
+import DiscordSendMessage from "../../../../../Server/Types/Workflow/Components/Discord/SendMessageToChannel";
+import MicrosoftTeamsSendMessage from "../../../../../Server/Types/Workflow/Components/MicrosoftTeams/SendMessageToChannel";
+import SlackSendMessage from "../../../../../Server/Types/Workflow/Components/Slack/SendMessageToChannel";
+import ComponentCode, {
+  RunOptions,
+} from "../../../../../Server/Types/Workflow/ComponentCode";
+import HTTPResponse from "../../../../../Types/API/HTTPResponse";
+import Exception from "../../../../../Types/Exception/Exception";
+import { JSONObject } from "../../../../../Types/JSON";
+import ObjectID from "../../../../../Types/ObjectID";
+import API from "../../../../../Utils/API";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * The Slack / Discord / Microsoft Teams workflow components take a free-text
+ * "webhook-url" argument and POST to it from the API server, with no check —
+ * the same SSRF GHSA-v5xh-rw9h-77fv reported against the API components, one
+ * component over. Because these are chat webhooks there is a real vendor host
+ * to pin to, which is stronger than a blocklist: a pin cannot be walked around
+ * with DNS rebinding, an alternate IP notation, or a redirect.
+ *
+ * Slack's and Teams' pins already existed but were only ever called from the
+ * status page subscriber path; Discord had none at all.
+ */
+
+jest.mock("../../../../../Utils/API", () => {
+  return {
+    __esModule: true,
+    default: { post: jest.fn() },
+  };
+});
+
+/*
+ * Slack posts through SlackUtil rather than calling API.post itself. That
+ * module pulls in the workspace stack, so stub it down to the one method the
+ * component uses — the pin under test lives in the component and in the
+ * (separately tested) util, not in the transport.
+ */
+jest.mock("../../../../../Server/Utils/Workspace/Slack/Slack", () => {
+  const actual: { default: { isValidSlackIncomingWebhookUrl: unknown } } =
+    jest.requireActual("../../../../../Server/Utils/Workspace/Slack/Slack");
+  return {
+    __esModule: true,
+    default: {
+      isValidSlackIncomingWebhookUrl:
+        actual.default.isValidSlackIncomingWebhookUrl,
+      sendMessageToChannelViaIncomingWebhook: jest.fn(),
+    },
+  };
+});
+
+import SlackUtil from "../../../../../Server/Utils/Workspace/Slack/Slack";
+
+function makeOptions(): RunOptions {
+  return {
+    log: jest.fn() as RunOptions["log"],
+    workflowLogId: ObjectID.generate(),
+    workflowId: ObjectID.generate(),
+    projectId: ObjectID.generate(),
+    onError: ((exception: Exception): Exception => {
+      return exception;
+    }) as RunOptions["onError"],
+    executeWorkflow: async (): Promise<void> => {},
+  };
+}
+
+const apiPostMock: jest.Mock = API.post as unknown as jest.Mock;
+const slackSendMock: jest.Mock =
+  SlackUtil.sendMessageToChannelViaIncomingWebhook as unknown as jest.Mock;
+
+/*
+ * Every one of these is a place the request must not go. They cover the shapes
+ * the guard has to survive: raw internal literals, a URL whose PATH or QUERY
+ * mentions the vendor domain, a host that merely ends in something similar, and
+ * the "#"/"?" parser trick that made "https://169.254.169.254#.office.com" look
+ * like a Microsoft host to OneUptime's own URL parser while axios dialled the
+ * metadata endpoint.
+ */
+function unsafeUrlsFor(vendorDomain: string): Array<[string, string]> {
+  return [
+    ["the cloud metadata endpoint", "http://169.254.169.254/latest/meta-data/"],
+    ["loopback", "http://127.0.0.1:8080/"],
+    ["localhost", "http://localhost/hook"],
+    ["an RFC-1918 address", "http://10.0.0.5/hook"],
+    [
+      "an internal host with the vendor domain in the query",
+      `http://169.254.169.254/?x=${vendorDomain}`,
+    ],
+    [
+      "an internal host with the vendor domain in a fragment",
+      `https://169.254.169.254#.${vendorDomain}`,
+    ],
+    [
+      "an internal host with the vendor domain in the path",
+      `http://10.0.0.5/${vendorDomain}/webhook`,
+    ],
+    ["a lookalike suffix domain", `https://evil-${vendorDomain}/webhook`],
+    ["a subdomain-of-attacker domain", `https://${vendorDomain}.evil.tld/hook`],
+    ["plain http on the real vendor host", `http://${vendorDomain}/webhook`],
+  ];
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Discord SendMessageToChannel — webhook URL pin", () => {
+  test.each(unsafeUrlsFor("discord.com"))(
+    "refuses %s and never sends",
+    async (_label: string, url: string) => {
+      await expect(
+        new DiscordSendMessage().run(
+          { text: "hi", "webhook-url": url },
+          makeOptions(),
+        ),
+      ).rejects.toThrow();
+      expect(apiPostMock).not.toHaveBeenCalled();
+    },
+  );
+
+  test("sends to a genuine Discord webhook, with redirects off", async () => {
+    apiPostMock.mockResolvedValue(new HTTPResponse<JSONObject>(200, {}, {}));
+
+    await new DiscordSendMessage().run(
+      {
+        text: "hi",
+        "webhook-url": "https://discord.com/api/webhooks/123/abcdef",
+      },
+      makeOptions(),
+    );
+
+    expect(apiPostMock).toHaveBeenCalledTimes(1);
+    const request: { options?: { doNotFollowRedirects?: boolean } } =
+      apiPostMock.mock.calls[0]![0] as {
+        options?: { doNotFollowRedirects?: boolean };
+      };
+    expect(request.options?.doNotFollowRedirects).toBe(true);
+  });
+
+  test("accepts the discordapp.com alias", async () => {
+    apiPostMock.mockResolvedValue(new HTTPResponse<JSONObject>(200, {}, {}));
+
+    await new DiscordSendMessage().run(
+      {
+        text: "hi",
+        "webhook-url": "https://discordapp.com/api/webhooks/123/abcdef",
+      },
+      makeOptions(),
+    );
+
+    expect(apiPostMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Microsoft Teams SendMessageToChannel — webhook URL pin", () => {
+  test.each(unsafeUrlsFor("office.com"))(
+    "refuses %s and never sends",
+    async (_label: string, url: string) => {
+      await expect(
+        new MicrosoftTeamsSendMessage().run(
+          { text: "hi", "webhook-url": url },
+          makeOptions(),
+        ),
+      ).rejects.toThrow();
+      expect(apiPostMock).not.toHaveBeenCalled();
+    },
+  );
+
+  test("sends to a genuine Teams webhook, with redirects off", async () => {
+    apiPostMock.mockResolvedValue(new HTTPResponse<JSONObject>(200, {}, {}));
+
+    await new MicrosoftTeamsSendMessage().run(
+      {
+        text: "hi",
+        "webhook-url": "https://outlook.office.com/webhook/abc/IncomingWebhook",
+      },
+      makeOptions(),
+    );
+
+    expect(apiPostMock).toHaveBeenCalledTimes(1);
+    const request: { options?: { doNotFollowRedirects?: boolean } } =
+      apiPostMock.mock.calls[0]![0] as {
+        options?: { doNotFollowRedirects?: boolean };
+      };
+    expect(request.options?.doNotFollowRedirects).toBe(true);
+  });
+});
+
+describe("Slack SendMessageToChannel — webhook URL pin", () => {
+  test.each(unsafeUrlsFor("slack.com"))(
+    "refuses %s and never sends",
+    async (_label: string, url: string) => {
+      await expect(
+        new SlackSendMessage().run(
+          { text: "hi", "webhook-url": url },
+          makeOptions(),
+        ),
+      ).rejects.toThrow();
+      expect(slackSendMock).not.toHaveBeenCalled();
+    },
+  );
+
+  test("refuses a Slack host without the /services/ path prefix", async () => {
+    await expect(
+      new SlackSendMessage().run(
+        { text: "hi", "webhook-url": "https://hooks.slack.com/evil" },
+        makeOptions(),
+      ),
+    ).rejects.toThrow();
+    expect(slackSendMock).not.toHaveBeenCalled();
+  });
+
+  test("sends to a genuine Slack incoming webhook", async () => {
+    slackSendMock.mockResolvedValue(new HTTPResponse<JSONObject>(200, {}, {}));
+
+    await new SlackSendMessage().run(
+      {
+        text: "hi",
+        "webhook-url": "https://hooks.slack.com/services/T000/B000/XXXX",
+      },
+      makeOptions(),
+    );
+
+    expect(slackSendMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("every chat component rejects a missing URL", () => {
+  const components: Array<[string, () => ComponentCode]> = [
+    [
+      "Discord",
+      (): ComponentCode => {
+        return new DiscordSendMessage();
+      },
+    ],
+    [
+      "MicrosoftTeams",
+      (): ComponentCode => {
+        return new MicrosoftTeamsSendMessage();
+      },
+    ],
+    [
+      "Slack",
+      (): ComponentCode => {
+        return new SlackSendMessage();
+      },
+    ],
+  ];
+
+  test.each(components)(
+    "%s",
+    async (_label: string, make: () => ComponentCode) => {
+      await expect(make().run({ text: "hi" }, makeOptions())).rejects.toThrow();
+    },
+  );
+});

--- a/Common/Tests/Server/Utils/SSRFProtectionBypasses.test.ts
+++ b/Common/Tests/Server/Utils/SSRFProtectionBypasses.test.ts
@@ -1,0 +1,406 @@
+import SSRFProtection from "../../../Server/Utils/SSRFProtection";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import dns from "dns";
+
+/*
+ * The blocklist in SSRFProtection used to compare SPELLINGS - "::1", a "fe80:"
+ * prefix, a dotted-quad regex - and anything containing a colon skipped DNS
+ * resolution entirely. Between those two facts, every one of the addresses in
+ * "equivalent spellings" below reached the network: "::ffff:169.254.169.254"
+ * is the AWS metadata endpoint written as IPv6, and a dual-stack Linux host
+ * connects to it happily.
+ *
+ * These tests are organised by BYPASS CLASS rather than by URL, because the
+ * property that matters is that one address has one verdict no matter how it
+ * is written. They cover the guard used by workflow API components
+ * (GHSA-v5xh-rw9h-77fv), project webhooks, and status page subscriber
+ * webhooks (GHSA-gf3v-98g2-qffx).
+ */
+
+type LookupSpy = jest.SpiedFunction<
+  (
+    hostname: string,
+    options: { all: true },
+  ) => Promise<Array<{ address: string; family: number }>>
+>;
+
+let lookupSpy: LookupSpy;
+
+beforeEach(() => {
+  lookupSpy = jest.spyOn(dns.promises, "lookup") as unknown as LookupSpy;
+  lookupSpy.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+async function isBlocked(url: string): Promise<boolean> {
+  try {
+    await SSRFProtection.validateWebhookTargetIsSafe(url);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe("SSRFProtection — IPv4-mapped and IPv4-embedding IPv6", () => {
+  const blocked: Array<[string, string]> = [
+    ["AWS metadata, IPv4-mapped", "http://[::ffff:169.254.169.254]/latest/"],
+    ["AWS metadata, mapped in hex", "http://[::ffff:a9fe:a9fe]/latest/"],
+    ["loopback, IPv4-mapped", "http://[::ffff:127.0.0.1]/"],
+    ["loopback, mapped in hex", "http://[::ffff:7f00:1]/"],
+    ["RFC-1918, IPv4-mapped", "http://[::ffff:10.0.0.1]/"],
+    ["RFC-1918, IPv4-mapped with port", "http://[::ffff:192.168.1.1]:8080/"],
+    ["CGNAT, IPv4-mapped", "http://[::ffff:100.64.0.1]/"],
+    ["loopback, IPv4-compatible", "http://[::127.0.0.1]/"],
+    ["metadata, IPv4-compatible", "http://[::169.254.169.254]/"],
+    ["metadata via NAT64 prefix", "http://[64:ff9b::169.254.169.254]/"],
+    ["loopback via NAT64 prefix", "http://[64:ff9b::127.0.0.1]/"],
+  ];
+
+  test.each(blocked)("blocks %s", async (_label: string, url: string) => {
+    expect(await isBlocked(url)).toBe(true);
+    // Literals must be decided without a DNS round trip.
+    expect(lookupSpy).not.toHaveBeenCalled();
+  });
+
+  const allowed: Array<[string, string]> = [
+    ["a public address, IPv4-mapped", "http://[::ffff:8.8.8.8]/"],
+    ["a public address via NAT64", "http://[64:ff9b::8.8.8.8]/"],
+  ];
+
+  test.each(allowed)("allows %s", async (_label: string, url: string) => {
+    expect(await isBlocked(url)).toBe(false);
+  });
+});
+
+describe("SSRFProtection — equivalent spellings of one address", () => {
+  const loopbackSpellings: Array<string> = [
+    "http://[::1]/",
+    "http://[::1]:8080/",
+    "http://[0:0:0:0:0:0:0:1]/",
+    "http://[0000:0000:0000:0000:0000:0000:0000:0001]/",
+    "http://[0:0:0::1]/",
+    "http://[::0001]/",
+  ];
+
+  test.each(loopbackSpellings)(
+    "blocks IPv6 loopback written as %s",
+    async (url: string) => {
+      expect(await isBlocked(url)).toBe(true);
+    },
+  );
+
+  const unspecifiedSpellings: Array<string> = [
+    "http://[::]/",
+    "http://[::0]/",
+    "http://[0:0:0:0:0:0:0:0]/",
+    "http://[0000:0000:0000:0000:0000:0000:0000:0000]/",
+  ];
+
+  test.each(unspecifiedSpellings)(
+    "blocks the unspecified address written as %s",
+    async (url: string) => {
+      expect(await isBlocked(url)).toBe(true);
+    },
+  );
+
+  const linkLocalSpellings: Array<string> = [
+    "http://[fe80::1]/",
+    "http://[fe80:0:0:0:0:0:0:1]/",
+    "http://[FE80::1]/",
+    "http://[febf::1]/", // top of the fe80::/10 range
+    "http://[fe80::1%25eth0]/", // percent-encoded zone id
+  ];
+
+  test.each(linkLocalSpellings)(
+    "blocks IPv6 link-local written as %s",
+    async (url: string) => {
+      expect(await isBlocked(url)).toBe(true);
+    },
+  );
+});
+
+describe("SSRFProtection — remaining internal IPv6 ranges", () => {
+  const blocked: Array<[string, string]> = [
+    ["unique-local fc00::/7 (low)", "http://[fc00::1]/"],
+    ["unique-local fc00::/7 (high)", "http://[fdff::1]/"],
+    ["unique-local, common ULA", "http://[fd12:3456:789a::1]/"],
+    ["site-local fec0::/10", "http://[fec0::1]/"],
+    ["multicast all-nodes", "http://[ff02::1]/"],
+    ["multicast ff00::/8", "http://[ff00::1]/"],
+  ];
+
+  test.each(blocked)("blocks %s", async (_label: string, url: string) => {
+    expect(await isBlocked(url)).toBe(true);
+  });
+
+  const allowed: Array<[string, string]> = [
+    ["Cloudflare public resolver", "http://[2606:4700:4700::1111]/"],
+    ["Google public resolver", "http://[2001:4860:4860::8888]/"],
+    ["a public 2000::/3 address with a port", "http://[2606:4700::1]:8443/"],
+  ];
+
+  test.each(allowed)(
+    "allows public IPv6 %s",
+    async (_label: string, url: string) => {
+      expect(await isBlocked(url)).toBe(false);
+    },
+  );
+});
+
+describe("SSRFProtection — IPv4 ranges", () => {
+  const blocked: Array<string> = [
+    "http://0.0.0.0/",
+    "http://0.1.2.3/",
+    "http://127.0.0.1/",
+    "http://127.255.255.254/",
+    "http://10.0.0.1/",
+    "http://172.16.0.1/",
+    "http://172.31.255.254/",
+    "http://192.168.0.1/",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://169.254.169.254:80/latest/meta-data/",
+    "http://100.64.0.1/",
+    "http://100.127.255.254/",
+    "http://224.0.0.1/", // multicast
+    "http://255.255.255.255/", // broadcast
+  ];
+
+  test.each(blocked)("blocks %s", async (url: string) => {
+    expect(await isBlocked(url)).toBe(true);
+    expect(lookupSpy).not.toHaveBeenCalled();
+  });
+
+  const allowed: Array<string> = [
+    "http://8.8.8.8/",
+    "https://1.1.1.1/",
+    "http://172.15.255.255/",
+    "http://172.32.0.1/",
+    "http://100.63.255.255/",
+    "http://100.128.0.1/",
+    "http://223.255.255.255/",
+  ];
+
+  test.each(allowed)("allows %s", async (url: string) => {
+    expect(await isBlocked(url)).toBe(false);
+  });
+});
+
+describe("SSRFProtection — alternate IPv4 notations resolve before they are judged", () => {
+  /*
+   * net.isIP rejects these, so they are not treated as literals - they go to
+   * DNS, where getaddrinfo decodes the notation, and the ADDRESS IT RETURNS is
+   * what gets checked. That is the property under test: the guard never has to
+   * understand decimal or octal IPv4 itself.
+   */
+  const notations: Array<[string, string]> = [
+    ["decimal", "http://2852039166/"],
+    ["octal", "http://0177.0.0.1/"],
+    ["hex", "http://0x7f000001/"],
+    ["short form", "http://127.1/"],
+  ];
+
+  test.each(notations)(
+    "blocks %s notation once resolved",
+    async (_label: string, url: string) => {
+      lookupSpy.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+      expect(await isBlocked(url)).toBe(true);
+      expect(lookupSpy).toHaveBeenCalled();
+    },
+  );
+});
+
+describe("SSRFProtection — DNS answers are judged, not just hostnames", () => {
+  test("blocks a public name that resolves to the metadata endpoint", async () => {
+    lookupSpy.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+    expect(await isBlocked("https://harmless.example.com/hook")).toBe(true);
+  });
+
+  test("blocks a public name that resolves to an internal IPv6 address", async () => {
+    lookupSpy.mockResolvedValue([{ address: "::1", family: 6 }]);
+    expect(await isBlocked("https://harmless.example.com/hook")).toBe(true);
+  });
+
+  test("blocks a public name that resolves to an IPv4-mapped internal address", async () => {
+    lookupSpy.mockResolvedValue([
+      { address: "::ffff:169.254.169.254", family: 6 },
+    ]);
+    expect(await isBlocked("https://harmless.example.com/hook")).toBe(true);
+  });
+
+  test("blocks when only ONE of several answers is internal", async () => {
+    lookupSpy.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "8.8.8.8", family: 4 },
+      { address: "10.1.2.3", family: 4 },
+    ]);
+    expect(await isBlocked("https://round-robin.example.com/hook")).toBe(true);
+  });
+
+  test("blocks when DNS resolution fails outright", async () => {
+    lookupSpy.mockRejectedValue(new Error("ENOTFOUND"));
+    expect(await isBlocked("https://nope.invalid/hook")).toBe(true);
+  });
+
+  test("allows a name whose every answer is public", async () => {
+    lookupSpy.mockResolvedValue([
+      { address: "93.184.216.34", family: 4 },
+      { address: "2606:4700:4700::1111", family: 6 },
+    ]);
+    expect(await isBlocked("https://hooks.example.com/hook")).toBe(false);
+  });
+});
+
+describe("SSRFProtection — hostname forms of internal targets", () => {
+  const blocked: Array<string> = [
+    "http://localhost/",
+    "http://localhost:3000/",
+    "http://localhost./",
+    "http://api.localhost/",
+    "http://metadata.google.internal/computeMetadata/v1/",
+  ];
+
+  test.each(blocked)("blocks %s", async (url: string) => {
+    expect(await isBlocked(url)).toBe(true);
+    expect(lookupSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("SSRFProtection — scheme handling", () => {
+  /*
+   * URL.fromString silently defaults an unrecognized scheme to https, so the
+   * scheme has to be read off the raw string or "file:///etc/passwd" arrives
+   * at the blocklist already rewritten as the host "file".
+   */
+  const blockedSchemes: Array<string> = [
+    "file:///etc/passwd",
+    "gopher://127.0.0.1:6379/_SET%20x%20y",
+    "ftp://internal.example.com/",
+    "dict://127.0.0.1:11211/stat",
+    "ldap://127.0.0.1:389/",
+    "jar://127.0.0.1/",
+    "mongodb://8.8.8.8/",
+    "ws://8.8.8.8/",
+    "wss://8.8.8.8/",
+  ];
+
+  test.each(blockedSchemes)("rejects %s", async (url: string) => {
+    expect(await isBlocked(url)).toBe(true);
+  });
+
+  test("rejects a URL with no host", async () => {
+    expect(await isBlocked("http:///no-host")).toBe(true);
+  });
+
+  test("rejects a protocol-relative URL", async () => {
+    expect(await isBlocked("//evil.example.com/hook")).toBe(true);
+  });
+
+  test("still accepts a scheme-less host:port, which is not a scheme", async () => {
+    expect(await isBlocked("hooks.example.com:8443/webhook")).toBe(false);
+  });
+
+  test.each(["http", "https", "HTTP", "HTTPS"])(
+    "accepts the %s scheme",
+    async (scheme: string) => {
+      expect(await isBlocked(`${scheme}://hooks.example.com/webhook`)).toBe(
+        false,
+      );
+    },
+  );
+});
+
+describe("SSRFProtection — host extraction helpers", () => {
+  test("getBareHostname strips scheme, port, path and query", () => {
+    expect(
+      SSRFProtection.getBareHostname(
+        "https://hooks.slack.com:443/services/x?a=b",
+      ),
+    ).toBe("hooks.slack.com");
+  });
+
+  test("getBareHostname unwraps a bracketed IPv6 literal", () => {
+    expect(SSRFProtection.getBareHostname("http://[::1]:8080/x")).toBe("::1");
+  });
+
+  /*
+   * The allowlist has to parse the host the way axios will. OneUptime's own
+   * URL.fromString takes everything before the first "/" as the authority and
+   * never stops at "?" or "#", so it read the host of
+   * "https://169.254.169.254#.office.com" as "169.254.169.254#.office.com" -
+   * which ends with ".office.com" and passed the Teams pin, while the request
+   * went to 169.254.169.254. Reachable by unauthenticated status page
+   * subscribers.
+   */
+  const parserDifferentials: Array<[string, string]> = [
+    ["fragment", "https://169.254.169.254#.office.com"],
+    ["query", "https://169.254.169.254?.office.com"],
+    ["fragment after a public host", "https://evil.example.com#.office.com"],
+    ["query after a public host", "https://evil.example.com?.office.com"],
+    ["fragment with a path", "https://evil.example.com#.office.com/webhook"],
+    ["userinfo", "https://outlook.office.com@evil.example.com/webhook"],
+  ];
+
+  test.each(parserDifferentials)(
+    "isUrlOnAllowedDomain is not fooled by a %s",
+    (_label: string, url: string) => {
+      expect(SSRFProtection.isUrlOnAllowedDomain(url, ["office.com"])).toBe(
+        false,
+      );
+    },
+  );
+
+  test.each(parserDifferentials)(
+    "getBareHostname agrees with the WHATWG parser on a %s",
+    (_label: string, url: string) => {
+      expect(SSRFProtection.getBareHostname(url)).toBe(
+        new globalThis.URL(url).hostname.toLowerCase(),
+      );
+    },
+  );
+
+  test("isUrlOnAllowedDomain pins on the host, not on a substring of the URL", () => {
+    // The classic break: an attacker-controlled path that contains the domain.
+    expect(
+      SSRFProtection.isUrlOnAllowedDomain(
+        "https://169.254.169.254/?x=hooks.slack.com",
+        ["hooks.slack.com"],
+      ),
+    ).toBe(false);
+  });
+
+  test("isUrlOnAllowedDomain anchors suffix matching on a dot", () => {
+    expect(
+      SSRFProtection.isUrlOnAllowedDomain("https://evil-slack.com/x", [
+        "slack.com",
+      ]),
+    ).toBe(false);
+    expect(
+      SSRFProtection.isUrlOnAllowedDomain("https://slack.com.evil.tld/x", [
+        "slack.com",
+      ]),
+    ).toBe(false);
+    expect(
+      SSRFProtection.isUrlOnAllowedDomain("https://hooks.slack.com/x", [
+        "slack.com",
+      ]),
+    ).toBe(true);
+  });
+
+  test("isUrlOnAllowedDomain requires https", () => {
+    expect(
+      SSRFProtection.isUrlOnAllowedDomain("http://hooks.slack.com/x", [
+        "slack.com",
+      ]),
+    ).toBe(false);
+  });
+});

--- a/Common/Tests/Server/Utils/VM/VMRunnerSsrf.test.ts
+++ b/Common/Tests/Server/Utils/VM/VMRunnerSsrf.test.ts
@@ -1,0 +1,156 @@
+import VMRunner from "../../../../Server/Utils/VM/VMRunner";
+import ReturnResult from "../../../../Types/IsolatedVM/ReturnResult";
+import { describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * GHSA-v5xh-rw9h-77fv fixed the API workflow components, but the Custom
+ * JavaScript component hands user-authored code the HOST process's axios
+ * (VMRunner bridges it into the isolate as `_axiosRef`), and the component docs
+ * say "you can use axios module". That is the same SSRF with more capability:
+ * arbitrary method, headers and body, with the response marshalled back to the
+ * author. Guarding only the API components would have been theatre.
+ *
+ * These tests drive the REAL isolate, so they prove the guard from the position
+ * an attacker actually occupies - inside the sandbox - rather than by calling a
+ * helper directly. Nothing here needs a network: every assertion is that the
+ * request was refused before a socket was opened.
+ */
+
+jest.setTimeout(60000);
+
+async function runInSandbox(code: string): Promise<ReturnResult> {
+  return VMRunner.runCodeInSandbox({
+    code,
+    options: { timeout: 15000 },
+  });
+}
+
+/*
+ * The sandbox surfaces a rejected request as a thrown error. Either the promise
+ * rejects or the returned result carries the message - accept both, and assert
+ * on the SSRF wording so a mere "connection refused" cannot pass for a block.
+ */
+async function errorFromSandbox(code: string): Promise<string> {
+  try {
+    const result: ReturnResult = await runInSandbox(code);
+    return JSON.stringify(result.returnValue ?? result.logMessages ?? "");
+  } catch (err) {
+    return (err as Error).message || String(err);
+  }
+}
+
+const REFUSAL: RegExp =
+  /not allowed|private, loopback, or link-local|absolute http|could not be resolved/i;
+
+describe("VMRunner sandbox axios bridge — SSRF guard", () => {
+  const internalTargets: Array<[string, string]> = [
+    ["AWS metadata endpoint", "http://169.254.169.254/latest/meta-data/"],
+    [
+      "AWS metadata credentials path",
+      "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+    ],
+    ["GCP metadata by name", "http://metadata.google.internal/"],
+    ["loopback", "http://127.0.0.1:8080/"],
+    ["localhost", "http://localhost:9200/_cluster/health"],
+    ["RFC-1918", "http://10.0.0.5/internal"],
+    ["IPv6 loopback", "http://[::1]:5432/"],
+    ["IPv4-mapped metadata endpoint", "http://[::ffff:169.254.169.254]/"],
+  ];
+
+  test.each(internalTargets)(
+    "refuses axios.get to the %s",
+    async (_label: string, url: string) => {
+      const message: string = await errorFromSandbox(
+        `return await axios.get(${JSON.stringify(url)});`,
+      );
+      expect(message).toMatch(REFUSAL);
+    },
+  );
+
+  test.each(internalTargets)(
+    "refuses axios.post to the %s",
+    async (_label: string, url: string) => {
+      const message: string = await errorFromSandbox(
+        `return await axios.post(${JSON.stringify(url)}, { a: 1 });`,
+      );
+      expect(message).toMatch(REFUSAL);
+    },
+  );
+
+  test("refuses axios.request, where the URL lives in the config", async () => {
+    const message: string = await errorFromSandbox(
+      `return await axios.request({ method: 'get', url: 'http://169.254.169.254/latest/meta-data/' });`,
+    );
+    expect(message).toMatch(REFUSAL);
+  });
+
+  test("refuses a target assembled from baseURL and a relative path", async () => {
+    // The positional url is harmless on its own; baseURL is where it goes.
+    const message: string = await errorFromSandbox(
+      `return await axios.get('/latest/meta-data/', { baseURL: 'http://169.254.169.254' });`,
+    );
+    expect(message).toMatch(REFUSAL);
+  });
+
+  test("refuses a baseURL-only request()", async () => {
+    const message: string = await errorFromSandbox(
+      `return await axios.request({ method: 'get', baseURL: 'http://127.0.0.1:8080', url: '/admin' });`,
+    );
+    expect(message).toMatch(REFUSAL);
+  });
+
+  test.each(["head", "options", "put", "patch", "delete"])(
+    "refuses axios.%s to an internal address",
+    async (method: string) => {
+      const call: string =
+        method === "put" || method === "patch"
+          ? `axios.${method}('http://169.254.169.254/', {})`
+          : `axios.${method}('http://169.254.169.254/')`;
+      const message: string = await errorFromSandbox(`return await ${call};`);
+      expect(message).toMatch(REFUSAL);
+    },
+  );
+
+  test("refuses a non-http scheme", async () => {
+    const message: string = await errorFromSandbox(
+      `return await axios.get('file:///etc/passwd');`,
+    );
+    expect(message).toMatch(REFUSAL);
+  });
+
+  test("refuses a relative URL with no baseURL rather than guessing", async () => {
+    const message: string = await errorFromSandbox(
+      `return await axios.get('/latest/meta-data/');`,
+    );
+    expect(message).toMatch(REFUSAL);
+  });
+
+  /*
+   * A proxy or a unix socket steers the connection somewhere the validated URL
+   * never named — /var/run/docker.sock being the memorable one — so the guard
+   * strips them rather than trusting the URL alone.
+   */
+  test("a proxy in the config cannot steer a public URL at an internal host", async () => {
+    /*
+     * A public IP literal (no DNS) with a 1ms timeout, so this settles offline
+     * and instantly. The point is only that the metadata endpoint named in
+     * `proxy` is never what gets dialled.
+     */
+    const message: string = await errorFromSandbox(
+      `try { return await axios.get('http://8.8.8.8/', { timeout: 1, proxy: { host: '169.254.169.254', port: 80 } }); } catch (e) { return 'threw: ' + e.message; }`,
+    );
+    expect(message).not.toMatch(/169\.254\.169\.254/);
+  });
+
+  test("still lets an ordinary public URL past the guard", async () => {
+    /*
+     * 8.8.8.8 is never actually reached - the 1ms timeout sees to that. The
+     * assertion is that the failure is a TRANSPORT failure, not the SSRF guard,
+     * i.e. the block above is not simply refusing everything.
+     */
+    const message: string = await errorFromSandbox(
+      `try { return await axios.get('http://8.8.8.8/', { timeout: 1 }); } catch (e) { return 'threw: ' + e.message; }`,
+    );
+    expect(message).not.toMatch(REFUSAL);
+  });
+});


### PR DESCRIPTION
Fixes **GHSA-v5xh-rw9h-77fv** (CWE-918, CVSS 7.7, reported by @de3erve).

## The bug

Any member of any project could point a workflow at an arbitrary URL and make the API server fetch it. The server sits inside the cluster, next to the cloud metadata endpoint, and the response comes back in the component's `response-body` return value — visible in the workflow log. That makes it a **full-read** SSRF, not a blind one:

```
GET http://169.254.169.254/latest/meta-data/iam/security-credentials/
```

returns the instance credentials to the attacker.

The advisory's second half — status page subscriber webhooks — was already fixed in 8becbf5038 (GHSA-gf3v-98g2-qffx). This PR covers the workflow engine, plus the guard both fixes depend on.

## What's fixed

### 1. API components — the reported issue
`ApiComponentUtils.sanitizeArgs` only checked that the URL *parsed*. It now runs `SSRFProtection.validateWebhookTargetIsSafe` first — the same guard outbound webhooks already use — and all five verbs send with `doNotFollowRedirects`, without which the check is worth nothing one hop later.

### 2. Slack / Discord / Microsoft Teams components — same hole, one component over
Same free-text `webhook-url`, same missing check. Fixing only the API components would have left the door open.

These have a real vendor host to pin to, which is strictly better than a blocklist — a pin survives DNS rebinding, alternate IP notations, and redirects. Slack's and Teams' pins **already existed** but their only caller was the status page subscriber path; Discord had none at all. The pins are now also enforced inside the two send helpers, so a future caller can't skip them.

### 3. The isolated-vm sandbox — the one that would have made this theatre
The Custom JavaScript component hands user code the **host process's axios**; the component docs say *"you can use axios module"*. Guarding the API components while leaving this open would have fixed nothing.

The host-side bridge now resolves the effective target — positional `url`, `config.url`, and `baseURL` joins all count — validates it, forces `maxRedirects: 0`, and drops caller-supplied `proxy` / `socketPath` / `transport` / `adapter`. Each of those would otherwise steer the connection somewhere the validated URL never named (`socketPath` reaching `/var/run/docker.sock` being the memorable one). The check lives on the **host** side of the isolate boundary — the sandbox-side axios shim is attacker-editable, so a check there guards nothing.

This also covers the other sandbox entry points (monitor criteria, If/Else) for free.

## `SSRFProtection` was porous

This matters beyond this advisory: it's the guard backing the already-shipped webhook fix. It compared *spellings* rather than addresses, and treated "contains a colon" as "is an IP literal" — which skipped DNS resolution entirely. Eight bypasses, all reproduced against the real code before fixing:

| URL | What it reaches |
|---|---|
| `http://[::ffff:169.254.169.254]/` | the metadata endpoint, as IPv6 |
| `http://[::ffff:7f00:1]/` | loopback, mapped in hex |
| `http://[0:0:0:0:0:0:0:1]/` | loopback, written out |
| `http://[::0]/` | the unspecified address |

Classification now works on parsed addresses via `net.isIP`, with IPv6 expanded to its eight groups so every spelling of one address gets one verdict, and IPv4-mapped / IPv4-compatible / NAT64 forms handed to the IPv4 blocklist. Alternate IPv4 notations (`2852039166`, `0177.0.0.1`) deliberately fall through to DNS, where `getaddrinfo` decodes them and the resolved address is what gets checked.

Two more holes in the same file:

- **Allowlist parser differential** — `getBareHostname` used OneUptime's URL parser, which doesn't stop at `#` or `?`. `https://169.254.169.254#.office.com` therefore ended with `.office.com` and satisfied the Teams pin, while axios re-parsed per WHATWG and dialled the metadata endpoint. **Reachable by an unauthenticated status page subscriber.** It reads the host off the WHATWG parser now — the same one the HTTP client uses.
- **Scheme coercion** — `URL.fromString` silently defaults an unknown scheme to https, so the protocol check never saw `file:///etc/passwd` (it arrived rewritten as host `file`). The scheme is read off the raw string first.

## Tests

402 tests across the guard, the five API components, the three chat components, and the sandbox. **32 of the new guard tests fail against the previous implementation** — they're pinning real regressions, not restating the code.

The sandbox tests drive the **real isolate**, so they prove the guard from where an attacker actually stands rather than by calling a helper directly. Everything is offline: each assertion is that the request was refused before a socket opened.

Full `Common` suite: 19,816 tests, all passing. (One unrelated on-call timing test flaked under CPU contention during the run and passes in isolation.)

## Reviewer note — please sanity-check this trade-off

The API components use `validateWebhookTargetIsSafe`, which blocks **all** RFC-1918. That's what the advisory recommends and it matches the existing webhook pattern, but it means **a self-hosted install can no longer use an API workflow component against an internal service on 10.x**.

`DataSourceEgressGuard` already encodes the other option: always block loopback/link-local/metadata, block private ranges only when billing is enabled or `DATA_SOURCE_BLOCK_PRIVATE_ADDRESSES=true`. Say the word and I'll switch the API components over — the metadata endpoint stays blocked either way.

## Out of scope — a broader audit found more

A full sweep for SSRF sinks turned up **10 further issues in other subsystems**, adversarially verified, that this PR deliberately does not touch (Runbook HTTP step, custom SMTP OAuth token URL, LLM provider `baseUrl`, status page / dashboard custom-domain verification, OIDC discovery, web push endpoints, custom SMTP host). Several are High. I'll write them up separately rather than make a security fix unreviewable.
