### PR TITLE
fix(files): make File.isPublic a real boolean so access gates work

### DIFF
--- a/Common/Models/DatabaseModels/DatabaseBaseModel/FileModel.ts
+++ b/Common/Models/DatabaseModels/DatabaseBaseModel/FileModel.ts
@@ -98,14 +98,13 @@ export default class FileModel extends BaseModel {
   @TableColumn({
     required: true,
     isDefaultValueColumn: true,
-    type: TableColumnType.Slug,
+    type: TableColumnType.Boolean,
     canReadOnRelationQuery: true,
   })
   @Column({
     nullable: false,
     default: true,
-    type: ColumnType.Slug,
-    length: ColumnLength.Slug,
+    type: ColumnType.Boolean,
   })
   public isPublic?: boolean = undefined;
 

--- a/Common/Server/API/FileAPI.ts
+++ b/Common/Server/API/FileAPI.ts
@@ -32,6 +32,17 @@ const isAuthenticatedRequest: (req: ExpressRequest) => boolean = (
   }
 };
 
+/*
+ * isPublic is a real boolean column, but this stays deliberately strict.
+ * It was created as a varchar, so every row held the STRING 'true'/'false'
+ * — and 'false' is truthy, which silently disabled both gates below. Treat
+ * anything that is not exactly `true` as private so a loose value can never
+ * re-open them.
+ */
+const isFilePublic: (file: File) => boolean = (file: File): boolean => {
+  return (file.isPublic as unknown) === true;
+};
+
 export default class FileAPI extends BaseAPI<File, FileServiceType> {
   public constructor() {
     super(File, FileService);
@@ -85,7 +96,7 @@ export default class FileAPI extends BaseAPI<File, FileServiceType> {
           );
         }
 
-        if (!file.isPublic && !isAuthenticatedRequest(req)) {
+        if (!isFilePublic(file) && !isAuthenticatedRequest(req)) {
           return Response.sendErrorResponse(
             req,
             res,
@@ -123,7 +134,7 @@ export default class FileAPI extends BaseAPI<File, FileServiceType> {
           },
         });
 
-        if (!file || !file.file || !file.fileType || !file.isPublic) {
+        if (!file || !file.file || !file.fileType || !isFilePublic(file)) {
           return Response.sendErrorResponse(
             req,
             res,

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786446545142-MigrationName.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786446545142-MigrationName.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MigrationName1786446545142 implements MigrationInterface {
+  public name = "MigrationName1786446545142";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    /*
+     * "File"."isPublic" backs a `boolean` field but was created as varchar,
+     * so every row holds the STRING 'true'/'false' and every server-side
+     * `!file.isPublic` gate was inert — 'false' is truthy in JS.
+     *
+     * Convert in place. TypeORM generates a DROP COLUMN + ADD COLUMN for
+     * this change, which would discard every stored value and re-default
+     * the whole table to public — the exact opposite of the fix.
+     */
+    await queryRunner.query(
+      `ALTER TABLE "File" ALTER COLUMN "isPublic" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "File" ALTER COLUMN "isPublic" TYPE boolean USING (lower("isPublic") IN ('true', 't', 'yes', 'y', '1'))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "File" ALTER COLUMN "isPublic" SET DEFAULT true`,
+    );
+
+    /*
+     * Probe and AI agent icons are the only consumers of the id-based
+     * image route, which serves public files only. Both upload through the
+     * file picker, which marks uploads private, so every icon attached
+     * before this migration would 404 once the gate starts working.
+     * ProbeService/AIAgentService now flip the icon public on attach; this
+     * backfills the rows attached before that hook existed.
+     */
+    await queryRunner.query(
+      `UPDATE "File" SET "isPublic" = true WHERE "_id" IN (SELECT "iconFileId" FROM "Probe" WHERE "iconFileId" IS NOT NULL UNION SELECT "iconFileId" FROM "AIAgent" WHERE "iconFileId" IS NOT NULL)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "File" ALTER COLUMN "isPublic" DROP DEFAULT`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "File" ALTER COLUMN "isPublic" TYPE character varying(100) USING (CASE WHEN "isPublic" THEN 'true' ELSE 'false' END)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "File" ALTER COLUMN "isPublic" SET DEFAULT true`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -512,6 +512,7 @@ import { AddInvestigationCodeFixRecommendation1786500000000 } from "./1786500000
 import { AddInvestigationAnalysisTldr1786600000000 } from "./1786600000000-AddInvestigationAnalysisTldr";
 import { DropProjectCallSMSConfigCredentialUniques1786700000000 } from "./1786700000000-DropProjectCallSMSConfigCredentialUniques";
 import { AddDataSourceTable1786303472848 } from "./1786303472848-AddDataSourceTable";
+import { MigrationName1786446545142 } from "./1786446545142-MigrationName";
 
 export default [
   InitialMigration,
@@ -1028,4 +1029,5 @@ export default [
   AddInvestigationAnalysisTldr1786600000000,
   DropProjectCallSMSConfigCredentialUniques1786700000000,
   AddDataSourceTable1786303472848,
+  MigrationName1786446545142,
 ];

--- a/Common/Server/Services/AIAgentService.ts
+++ b/Common/Server/Services/AIAgentService.ts
@@ -15,6 +15,7 @@ import AIAgentOwnerTeamService from "./AIAgentOwnerTeamService";
 import TeamMemberService from "./TeamMemberService";
 import BadDataException from "../../Types/Exception/BadDataException";
 import ProjectService from "./ProjectService";
+import FileService from "./FileService";
 import Dictionary from "../../Types/Dictionary";
 import OneUptimeDate from "../../Types/Date";
 import UserNotificationSettingService from "./UserNotificationSettingService";
@@ -172,6 +173,21 @@ export class Service extends DatabaseService<Model> {
     }
 
     return { createBy: createBy, carryForward: [] };
+  }
+
+  /*
+   * An AI agent icon is rendered by the id-based image route, which
+   * serves only public files. The file picker uploads it private, so
+   * attaching it to an agent is the point at which it becomes public.
+   */
+  @CaptureSpan()
+  protected override async onCreateSuccess(
+    _onCreate: OnCreate<Model>,
+    createdItem: Model,
+  ): Promise<Model> {
+    await FileService.makeFilePublic(createdItem.iconFileId);
+
+    return createdItem;
   }
 
   @CaptureSpan()
@@ -339,6 +355,10 @@ export class Service extends DatabaseService<Model> {
     onUpdate: OnUpdate<Model>,
     _updatedItemIds: Array<ObjectID>,
   ): Promise<OnUpdate<Model>> {
+    await FileService.makeFilePublic(
+      onUpdate.updateBy.data.iconFileId as ObjectID | undefined,
+    );
+
     if (
       onUpdate.carryForward &&
       onUpdate.carryForward.aiAgentsToNotifyOwners.length > 0

--- a/Common/Server/Services/FileService.ts
+++ b/Common/Server/Services/FileService.ts
@@ -6,7 +6,9 @@ import UpdateBy from "../Types/Database/UpdateBy";
 import DatabaseService from "./DatabaseService";
 import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException";
 import File from "../../Models/DatabaseModels/File";
+import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import logger from "../Utils/Logger";
 import crypto from "crypto";
 
 const generateImageAccessToken: () => string = (): string => {
@@ -54,6 +56,40 @@ export class Service extends DatabaseService<File> {
     }
 
     return { deleteBy, carryForward: null };
+  }
+
+  /*
+   * Marks a file as anonymously readable. Uploads from the file picker
+   * arrive private, so attaching one as an intentionally public asset
+   * (probe icon, AI agent icon) is the point at which it becomes public
+   * — those are served by the id-based image route, which serves only
+   * public files. Best-effort: a visibility sync failure must never fail
+   * the write the user actually asked for.
+   */
+  @CaptureSpan()
+  public async makeFilePublic(
+    fileId: ObjectID | undefined | null,
+  ): Promise<void> {
+    if (!fileId) {
+      return;
+    }
+
+    try {
+      await this.updateOneById({
+        id: fileId,
+        data: {
+          isPublic: true,
+        },
+        props: {
+          isRoot: true,
+          ignoreHooks: true,
+        },
+      });
+    } catch (err) {
+      logger.error(
+        `Failed to mark file ${fileId.toString()} public: ${String(err)}`,
+      );
+    }
   }
 
   @CaptureSpan()

--- a/Common/Server/Services/IncidentEpisodePublicNoteService.ts
+++ b/Common/Server/Services/IncidentEpisodePublicNoteService.ts
@@ -14,6 +14,7 @@ import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import StatusPageSubscriberNotificationStatus from "../../Types/StatusPage/StatusPageSubscriberNotificationStatus";
 import File from "../../Models/DatabaseModels/File";
 import FileAttachmentMarkdownUtil from "../Utils/FileAttachmentMarkdownUtil";
+import { syncIsPublicForMarkdownImages } from "../Utils/InlineImageAccessTokenSync";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -116,6 +117,17 @@ export class Service extends DatabaseService<Model> {
     const userId: ObjectID | null | undefined =
       createdItem.createdByUserId || createdItem.createdByUser?.id;
 
+    /*
+     * A public note is always rendered on the status page, so any inline
+     * image the markdown editor uploaded as private must flip to public
+     * for anonymous status page viewers to be able to render it.
+     */
+    await syncIsPublicForMarkdownImages(
+      createdItem.note,
+      true,
+      `incident episode public note ${createdItem.id?.toString()}`,
+    );
+
     const incidentEpisodeId: ObjectID = createdItem.incidentEpisodeId!;
     const projectId: ObjectID = createdItem.projectId!;
     const episodeNumberResult: {
@@ -184,6 +196,12 @@ ${(createdItem.note || "") + attachmentsMarkdown}
 
       for (const updatedItem of updatedItems) {
         const episode: IncidentEpisode = updatedItem.incidentEpisode!;
+
+        await syncIsPublicForMarkdownImages(
+          updatedItem.note,
+          true,
+          `incident episode public note ${updatedItem.id?.toString()}`,
+        );
 
         const attachmentsMarkdown: string = await this.getAttachmentsMarkdown(
           updatedItem.id!,

--- a/Common/Server/Services/IncidentPublicNoteService.ts
+++ b/Common/Server/Services/IncidentPublicNoteService.ts
@@ -14,6 +14,7 @@ import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import StatusPageSubscriberNotificationStatus from "../../Types/StatusPage/StatusPageSubscriberNotificationStatus";
 import File from "../../Models/DatabaseModels/File";
 import FileAttachmentMarkdownUtil from "../Utils/FileAttachmentMarkdownUtil";
+import { syncIsPublicForMarkdownImages } from "../Utils/InlineImageAccessTokenSync";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -116,6 +117,17 @@ export class Service extends DatabaseService<Model> {
     const userId: ObjectID | null | undefined =
       createdItem.createdByUserId || createdItem.createdByUser?.id;
 
+    /*
+     * A public note is always rendered on the status page, so any inline
+     * image the markdown editor uploaded as private must flip to public
+     * for anonymous status page viewers to be able to render it.
+     */
+    await syncIsPublicForMarkdownImages(
+      createdItem.note,
+      true,
+      `incident public note ${createdItem.id?.toString()}`,
+    );
+
     const incidentId: ObjectID = createdItem.incidentId!;
     const projectId: ObjectID = createdItem.projectId!;
     const incidentNumberResult: {
@@ -186,6 +198,12 @@ ${(createdItem.note || "") + attachmentsMarkdown}
 
       for (const updatedItem of updatedItems) {
         const incident: Incident = updatedItem.incident!;
+
+        await syncIsPublicForMarkdownImages(
+          updatedItem.note,
+          true,
+          `incident public note ${updatedItem.id?.toString()}`,
+        );
 
         const attachmentsMarkdown: string = await this.getAttachmentsMarkdown(
           updatedItem.id!,

--- a/Common/Server/Services/ProbeService.ts
+++ b/Common/Server/Services/ProbeService.ts
@@ -29,6 +29,7 @@ import DatabaseConfig from "../DatabaseConfig";
 import URL from "../../Types/API/URL";
 import UpdateBy from "../Types/Database/UpdateBy";
 import MonitorService from "./MonitorService";
+import FileService from "./FileService";
 import PushNotificationMessage from "../../Types/PushNotification/PushNotificationMessage";
 import PushNotificationUtil from "../Utils/PushNotificationUtil";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
@@ -436,6 +437,21 @@ export class Service extends DatabaseService<Model> {
   }
 
   /*
+   * A probe icon is rendered by the id-based image route, which serves
+   * only public files. The file picker uploads it private, so attaching
+   * it to a probe is the point at which it becomes public.
+   */
+  @CaptureSpan()
+  protected override async onCreateSuccess(
+    _onCreate: OnCreate<Model>,
+    createdItem: Model,
+  ): Promise<Model> {
+    await FileService.makeFilePublic(createdItem.iconFileId);
+
+    return createdItem;
+  }
+
+  /*
    * Only global probes and probes belonging to this project may be attached to
    * that project's monitors. Probe ids reach the server from the browser - the
    * monitor create form and the Monitor > Probes table both post them - so
@@ -625,6 +641,10 @@ export class Service extends DatabaseService<Model> {
     if (onUpdate.updateBy.data.key !== undefined) {
       await this.invalidateProbeAuthCache(updatedItemIds);
     }
+
+    await FileService.makeFilePublic(
+      onUpdate.updateBy.data.iconFileId as ObjectID | undefined,
+    );
 
     if (
       onUpdate.carryForward &&

--- a/Common/Server/Services/ScheduledMaintenancePublicNoteService.ts
+++ b/Common/Server/Services/ScheduledMaintenancePublicNoteService.ts
@@ -14,6 +14,7 @@ import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import StatusPageSubscriberNotificationStatus from "../../Types/StatusPage/StatusPageSubscriberNotificationStatus";
 import File from "../../Models/DatabaseModels/File";
 import FileAttachmentMarkdownUtil from "../Utils/FileAttachmentMarkdownUtil";
+import { syncIsPublicForMarkdownImages } from "../Utils/InlineImageAccessTokenSync";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -56,6 +57,17 @@ export class Service extends DatabaseService<Model> {
   ): Promise<Model> {
     const userId: ObjectID | null | undefined =
       createdItem.createdByUserId || createdItem.createdByUser?.id;
+
+    /*
+     * A public note is always rendered on the status page, so any inline
+     * image the markdown editor uploaded as private must flip to public
+     * for anonymous status page viewers to be able to render it.
+     */
+    await syncIsPublicForMarkdownImages(
+      createdItem.note,
+      true,
+      `scheduled maintenance public note ${createdItem.id?.toString()}`,
+    );
 
     const scheduledMaintenanceId: ObjectID =
       createdItem.scheduledMaintenanceId!;
@@ -128,6 +140,12 @@ ${(createdItem.note || "") + attachmentsMarkdown}
       for (const updatedItem of updatedItems) {
         const scheduledMaintenance: ScheduledMaintenance =
           updatedItem.scheduledMaintenance!;
+
+        await syncIsPublicForMarkdownImages(
+          updatedItem.note,
+          true,
+          `scheduled maintenance public note ${updatedItem.id?.toString()}`,
+        );
 
         const attachmentsMarkdown: string = await this.getAttachmentsMarkdown(
           updatedItem.id!,

--- a/Common/Server/Services/StatusPageAnnouncementService.ts
+++ b/Common/Server/Services/StatusPageAnnouncementService.ts
@@ -4,6 +4,10 @@ import CreateBy from "../Types/Database/CreateBy";
 import UpdateBy from "../Types/Database/UpdateBy";
 import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
 import StatusPageSubscriberNotificationStatus from "../../Types/StatusPage/StatusPageSubscriberNotificationStatus";
+import ObjectID from "../../Types/ObjectID";
+import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
+import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import { syncIsPublicForMarkdownImages } from "../Utils/InlineImageAccessTokenSync";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -50,6 +54,55 @@ export class Service extends DatabaseService<Model> {
       updateBy,
       carryForward: null,
     };
+  }
+
+  /*
+   * An announcement is always rendered on the status pages it is attached
+   * to, so any inline image the markdown editor uploaded as private must
+   * flip to public for anonymous status page viewers to render it.
+   */
+  @CaptureSpan()
+  public override async onCreateSuccess(
+    _onCreate: OnCreate<Model>,
+    createdItem: Model,
+  ): Promise<Model> {
+    await syncIsPublicForMarkdownImages(
+      createdItem.description,
+      true,
+      `status page announcement ${createdItem.id?.toString()}`,
+    );
+
+    return createdItem;
+  }
+
+  @CaptureSpan()
+  public override async onUpdateSuccess(
+    onUpdate: OnUpdate<Model>,
+    _updatedItemIds: Array<ObjectID>,
+  ): Promise<OnUpdate<Model>> {
+    if (onUpdate.updateBy.data.description) {
+      const updatedItems: Array<Model> = await this.findBy({
+        query: onUpdate.updateBy.query,
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+        select: {
+          description: true,
+        },
+      });
+
+      for (const updatedItem of updatedItems) {
+        await syncIsPublicForMarkdownImages(
+          updatedItem.description,
+          true,
+          `status page announcement ${updatedItem.id?.toString()}`,
+        );
+      }
+    }
+
+    return onUpdate;
   }
 }
 

--- a/Common/Server/Utils/InlineImageAccessTokenSync.ts
+++ b/Common/Server/Utils/InlineImageAccessTokenSync.ts
@@ -81,3 +81,26 @@ export const setIsPublicForMarkdownImages: (
     }
   }
 };
+
+/*
+ * Best-effort variant used by the publish paths (public notes,
+ * announcements). Failing to flip an inline image must never fail the
+ * write the user actually asked for, so errors are logged and swallowed.
+ */
+export const syncIsPublicForMarkdownImages: (
+  markdown: string | null | undefined,
+  isPublic: boolean,
+  context: string,
+) => Promise<void> = async (
+  markdown: string | null | undefined,
+  isPublic: boolean,
+  context: string,
+): Promise<void> => {
+  try {
+    await setIsPublicForMarkdownImages(markdown, isPublic);
+  } catch (err) {
+    logger.error(
+      `Failed to sync inline image visibility for ${context}: ${String(err)}`,
+    );
+  }
+};

--- a/Common/Tests/Server/API/FileAPIAccessControl.test.ts
+++ b/Common/Tests/Server/API/FileAPIAccessControl.test.ts
@@ -1,0 +1,316 @@
+import File from "../../../Models/DatabaseModels/File";
+import FileAPI from "../../../Server/API/FileAPI";
+import FileService from "../../../Server/Services/FileService";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import JSONWebToken from "../../../Server/Utils/JsonWebToken";
+import UserMiddleware from "../../../Server/Middleware/UserAuthorization";
+import Response from "../../../Server/Utils/Response";
+import MimeType from "../../../Types/File/MimeType";
+import ObjectID from "../../../Types/ObjectID";
+import { mockRouter } from "./Helpers";
+import { beforeAll, beforeEach, describe, expect, it } from "@jest/globals";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendFileResponse: jest.fn(),
+    sendErrorResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendEntityArrayResponse: jest.fn(),
+    sendJsonObjectResponse: jest.fn(),
+    sendEmptySuccessResponse: jest.fn(),
+  };
+});
+
+jest.mock("../../../Server/Services/FileService", () => {
+  return {
+    findOneBy: jest.fn(),
+    findOneById: jest.fn(),
+  };
+});
+
+jest.mock("../../../Server/Middleware/UserAuthorization", () => {
+  return {
+    getAccessTokenFromExpressRequest: jest.fn(),
+  };
+});
+
+jest.mock("../../../Server/Utils/JsonWebToken", () => {
+  return {
+    decode: jest.fn(),
+  };
+});
+
+const TOKEN_ROUTE: string = "/file/image/access-token/:token";
+const ID_ROUTE: string = "/file/image/:imageId";
+
+type BuildFileFunction = (isPublic: unknown) => File;
+
+/*
+ * The route only ever reads file/fileType/isPublic, and isPublic is
+ * deliberately typed loose here so the varchar-era value (the STRING
+ * "false") can be fed through the gate as well as a real boolean.
+ */
+const buildFile: BuildFileFunction = (isPublic: unknown): File => {
+  const file: File = new File();
+  file.file = Buffer.from("png-bytes");
+  file.fileType = MimeType.png;
+  (file as unknown as { isPublic: unknown }).isPublic = isPublic;
+  return file;
+};
+
+type CallRouteFunction = (
+  uri: string,
+  params: Record<string, string>,
+) => Promise<void>;
+
+const callRoute: CallRouteFunction = async (
+  uri: string,
+  params: Record<string, string>,
+): Promise<void> => {
+  const req: ExpressRequest = { params } as unknown as ExpressRequest;
+  const res: ExpressResponse = {} as ExpressResponse;
+  const next: NextFunction = (() => {}) as NextFunction;
+
+  await mockRouter.match("GET", uri).handlerFunction(req, res, next);
+};
+
+type SetAuthenticatedFunction = (isAuthenticated: boolean) => void;
+
+const setAuthenticated: SetAuthenticatedFunction = (
+  isAuthenticated: boolean,
+): void => {
+  (
+    UserMiddleware.getAccessTokenFromExpressRequest as unknown as jest.Mock
+  ).mockReturnValue(isAuthenticated ? "a-token" : undefined);
+  (JSONWebToken.decode as unknown as jest.Mock).mockReturnValue({
+    userId: isAuthenticated ? new ObjectID("user-id") : undefined,
+  });
+};
+
+describe("FileAPI access control", () => {
+  beforeAll(() => {
+    new FileAPI();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setAuthenticated(false);
+  });
+
+  describe("token route — anonymous callers", () => {
+    it("serves a public file", async () => {
+      (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue(
+        buildFile(true) as never,
+      );
+
+      await callRoute(TOKEN_ROUTE, { token: "abc123" });
+
+      expect(Response.sendFileResponse).toHaveBeenCalled();
+      expect(Response.sendErrorResponse).not.toHaveBeenCalled();
+    });
+
+    it("refuses a private file", async () => {
+      (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue(
+        buildFile(false) as never,
+      );
+
+      await callRoute(TOKEN_ROUTE, { token: "abc123" });
+
+      expect(Response.sendFileResponse).not.toHaveBeenCalled();
+      expect(Response.sendErrorResponse).toHaveBeenCalled();
+    });
+
+    /*
+     * Regression guard for the varchar bug: isPublic was persisted as a
+     * varchar, so a private file hydrated as the STRING "false", which is
+     * truthy — the gate below never fired and every inline image was served
+     * to anonymous callers. The column is a real boolean now; this pins the
+     * gate to a strict boolean check so a loose value cannot slip through.
+     */
+    it("refuses a file whose isPublic is the string 'false'", async () => {
+      (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue(
+        buildFile("false") as never,
+      );
+
+      await callRoute(TOKEN_ROUTE, { token: "abc123" });
+
+      expect(Response.sendFileResponse).not.toHaveBeenCalled();
+      expect(Response.sendErrorResponse).toHaveBeenCalled();
+    });
+
+    it("refuses when no file matches the token", async () => {
+      (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue(
+        null as never,
+      );
+
+      await callRoute(TOKEN_ROUTE, { token: "abc123" });
+
+      expect(Response.sendFileResponse).not.toHaveBeenCalled();
+      expect(Response.sendErrorResponse).toHaveBeenCalled();
+    });
+
+    it("refuses when the token param is missing", async () => {
+      await callRoute(TOKEN_ROUTE, {});
+
+      expect(FileService.findOneBy).not.toHaveBeenCalled();
+      expect(Response.sendErrorResponse).toHaveBeenCalled();
+    });
+
+    it("refuses a public row that carries no bytes", async () => {
+      const file: File = buildFile(true);
+      delete (file as Partial<File>).file;
+      (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue(
+        file as never,
+      );
+
+      await callRoute(TOKEN_ROUTE, { token: "abc123" });
+
+      expect(Response.sendFileResponse).not.toHaveBeenCalled();
+      expect(Response.sendErrorResponse).toHaveBeenCalled();
+    });
+
+    it("refuses a public row that carries no fileType", async () => {
+      const file: File = buildFile(true);
+      delete (file as Partial<File>).fileType;
+      (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue(
+        file as never,
+      );
+
+      await callRoute(TOKEN_ROUTE, { token: "abc123" });
+
+      expect(Response.sendFileResponse).not.toHaveBeenCalled();
+      expect(Response.sendErrorResponse).toHaveBeenCalled();
+    });
+  });
+
+  describe("token route — authenticated callers", () => {
+    it("serves a private file to a valid session", async () => {
+      setAuthenticated(true);
+      (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue(
+        buildFile(false) as never,
+      );
+
+      await callRoute(TOKEN_ROUTE, { token: "abc123" });
+
+      expect(Response.sendFileResponse).toHaveBeenCalled();
+      expect(Response.sendErrorResponse).not.toHaveBeenCalled();
+    });
+
+    it("refuses a private file when the session token has no userId", async () => {
+      (
+        UserMiddleware.getAccessTokenFromExpressRequest as unknown as jest.Mock
+      ).mockReturnValue("a-token");
+      (JSONWebToken.decode as unknown as jest.Mock).mockReturnValue({});
+      (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue(
+        buildFile(false) as never,
+      );
+
+      await callRoute(TOKEN_ROUTE, { token: "abc123" });
+
+      expect(Response.sendFileResponse).not.toHaveBeenCalled();
+      expect(Response.sendErrorResponse).toHaveBeenCalled();
+    });
+
+    it("refuses a private file when the session token fails verification", async () => {
+      (
+        UserMiddleware.getAccessTokenFromExpressRequest as unknown as jest.Mock
+      ).mockReturnValue("a-forged-token");
+      (JSONWebToken.decode as unknown as jest.Mock).mockImplementation(() => {
+        throw new Error("invalid signature");
+      });
+      (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue(
+        buildFile(false) as never,
+      );
+
+      await callRoute(TOKEN_ROUTE, { token: "abc123" });
+
+      expect(Response.sendFileResponse).not.toHaveBeenCalled();
+      expect(Response.sendErrorResponse).toHaveBeenCalled();
+    });
+  });
+
+  describe("legacy id route", () => {
+    it("serves a public file", async () => {
+      (FileService.findOneById as unknown as jest.Mock).mockResolvedValue(
+        buildFile(true) as never,
+      );
+
+      await callRoute(ID_ROUTE, {
+        imageId: "e7c4f2a1-0000-4000-8000-000000000000",
+      });
+
+      expect(Response.sendFileResponse).toHaveBeenCalled();
+      expect(Response.sendErrorResponse).not.toHaveBeenCalled();
+    });
+
+    it("refuses a private file", async () => {
+      (FileService.findOneById as unknown as jest.Mock).mockResolvedValue(
+        buildFile(false) as never,
+      );
+
+      await callRoute(ID_ROUTE, {
+        imageId: "e7c4f2a1-0000-4000-8000-000000000000",
+      });
+
+      expect(Response.sendFileResponse).not.toHaveBeenCalled();
+      expect(Response.sendErrorResponse).toHaveBeenCalled();
+    });
+
+    it("refuses a file whose isPublic is the string 'false'", async () => {
+      (FileService.findOneById as unknown as jest.Mock).mockResolvedValue(
+        buildFile("false") as never,
+      );
+
+      await callRoute(ID_ROUTE, {
+        imageId: "e7c4f2a1-0000-4000-8000-000000000000",
+      });
+
+      expect(Response.sendFileResponse).not.toHaveBeenCalled();
+      expect(Response.sendErrorResponse).toHaveBeenCalled();
+    });
+
+    /*
+     * This route is public-only by design — it addresses files by an
+     * enumerable ObjectID, so a session is deliberately NOT enough to reach a
+     * private file through it. Private inline images use the token route.
+     */
+    it("refuses a private file even to a valid session", async () => {
+      setAuthenticated(true);
+      (FileService.findOneById as unknown as jest.Mock).mockResolvedValue(
+        buildFile(false) as never,
+      );
+
+      await callRoute(ID_ROUTE, {
+        imageId: "e7c4f2a1-0000-4000-8000-000000000000",
+      });
+
+      expect(Response.sendFileResponse).not.toHaveBeenCalled();
+      expect(Response.sendErrorResponse).toHaveBeenCalled();
+    });
+
+    it("refuses when no file matches the id", async () => {
+      (FileService.findOneById as unknown as jest.Mock).mockResolvedValue(
+        null as never,
+      );
+
+      await callRoute(ID_ROUTE, {
+        imageId: "e7c4f2a1-0000-4000-8000-000000000000",
+      });
+
+      expect(Response.sendFileResponse).not.toHaveBeenCalled();
+      expect(Response.sendErrorResponse).toHaveBeenCalled();
+    });
+  });
+});

--- a/Common/Tests/Server/Services/FileIsPublicBooleanMigration.test.ts
+++ b/Common/Tests/Server/Services/FileIsPublicBooleanMigration.test.ts
@@ -1,0 +1,244 @@
+import { MigrationName1786446545142 } from "../../../Server/Infrastructure/Postgres/SchemaMigrations/1786446545142-MigrationName";
+import SchemaMigrations from "../../../Server/Infrastructure/Postgres/SchemaMigrations/Index";
+import FileModel from "../../../Models/DatabaseModels/DatabaseBaseModel/FileModel";
+import { getTableColumn } from "../../../Types/Database/TableColumn";
+import TableColumnType from "../../../Types/Database/TableColumnType";
+import ColumnType from "../../../Types/Database/ColumnType";
+import { describe, expect, test } from "@jest/globals";
+import { QueryRunner, getMetadataArgsStorage } from "typeorm";
+import { ColumnMetadataArgs } from "typeorm/metadata-args/ColumnMetadataArgs";
+
+/*
+ * "File"."isPublic" backs a `boolean` field but was created as varchar, so
+ * every row held the STRING 'true'/'false'. 'false' is truthy in JS, which
+ * silently disabled every server-side `!file.isPublic` gate. This migration
+ * converts the column to a real boolean.
+ *
+ * The failure mode these tests exist to prevent is regeneration: TypeORM's
+ * own output for this model change is DROP COLUMN + ADD COLUMN, which throws
+ * away every stored value and re-defaults the whole table to public — the
+ * exact opposite of the fix, and completely silent. So the SQL contract is
+ * pinned here rather than left to whatever the generator emits next time.
+ */
+
+const MIGRATION_TIMESTAMP: number = 1786446545142;
+const DROP_COLUMN_PATTERN: RegExp = /\bDROP COLUMN\b/i;
+const TO_BOOLEAN_PATTERN: RegExp = /ALTER COLUMN "isPublic" TYPE boolean/i;
+const TO_VARCHAR_PATTERN: RegExp =
+  /ALTER COLUMN "isPublic" TYPE character varying/i;
+const BACKFILL_PATTERN: RegExp = /^UPDATE "File"/i;
+
+type MakeQueryRunnerResult = {
+  runner: QueryRunner;
+  statements: Array<string>;
+};
+
+const makeQueryRunner: () => MakeQueryRunnerResult =
+  (): MakeQueryRunnerResult => {
+    const statements: Array<string> = [];
+
+    const query: (...args: Array<unknown>) => Promise<unknown> = (
+      ...args: Array<unknown>
+    ): Promise<unknown> => {
+      statements.push(String(args[0]));
+      return Promise.resolve(undefined);
+    };
+
+    return {
+      runner: { query } as unknown as QueryRunner,
+      statements,
+    };
+  };
+
+const indexOfMatch: (statements: Array<string>, pattern: RegExp) => number = (
+  statements: Array<string>,
+  pattern: RegExp,
+): number => {
+  return statements.findIndex((statement: string) => {
+    return pattern.test(statement);
+  });
+};
+
+describe("File.isPublic boolean migration - up SQL contract", () => {
+  test("never drops the column, which would discard every stored value", async () => {
+    const { runner, statements } = makeQueryRunner();
+
+    await new MigrationName1786446545142().up(runner);
+
+    expect(
+      statements.filter((statement: string) => {
+        return DROP_COLUMN_PATTERN.test(statement);
+      }),
+    ).toEqual([]);
+  });
+
+  test("converts the column in place to boolean", async () => {
+    const { runner, statements } = makeQueryRunner();
+
+    await new MigrationName1786446545142().up(runner);
+
+    const alterIndex: number = indexOfMatch(
+      statements,
+      /ALTER TABLE "File" ALTER COLUMN "isPublic" TYPE boolean/i,
+    );
+
+    expect(alterIndex).toBeGreaterThanOrEqual(0);
+  });
+
+  test("carries the existing strings across with a USING clause", async () => {
+    const { runner, statements } = makeQueryRunner();
+
+    await new MigrationName1786446545142().up(runner);
+
+    const conversion: string | undefined = statements.find(
+      (statement: string) => {
+        return TO_BOOLEAN_PATTERN.test(statement);
+      },
+    );
+
+    expect(conversion).toBeDefined();
+    expect(conversion).toMatch(/USING/i);
+    // The stored values are the strings written by the old varchar column.
+    expect(conversion).toMatch(/'true'/);
+  });
+
+  test("restores the default so new rows still default to public", async () => {
+    const { runner, statements } = makeQueryRunner();
+
+    await new MigrationName1786446545142().up(runner);
+
+    expect(
+      indexOfMatch(statements, /ALTER COLUMN "isPublic" SET DEFAULT true/i),
+    ).toBeGreaterThanOrEqual(0);
+  });
+
+  /*
+   * Probe and AI agent icons are the only readers of the id-based image
+   * route, which serves public files only. Both upload through the file
+   * picker, which marks uploads private — so without this backfill every
+   * icon attached before the migration 404s the moment the gate works.
+   */
+  test("backfills probe and AI agent icons to public", async () => {
+    const { runner, statements } = makeQueryRunner();
+
+    await new MigrationName1786446545142().up(runner);
+
+    const backfill: string | undefined = statements.find(
+      (statement: string) => {
+        return BACKFILL_PATTERN.test(statement);
+      },
+    );
+
+    expect(backfill).toBeDefined();
+    expect(backfill).toMatch(/"isPublic" = true/i);
+    expect(backfill).toMatch(/FROM "Probe"/i);
+    expect(backfill).toMatch(/FROM "AIAgent"/i);
+  });
+
+  test("backfills only after the column is a boolean", async () => {
+    const { runner, statements } = makeQueryRunner();
+
+    await new MigrationName1786446545142().up(runner);
+
+    const conversionIndex: number = indexOfMatch(
+      statements,
+      /ALTER COLUMN "isPublic" TYPE boolean/i,
+    );
+    const backfillIndex: number = indexOfMatch(statements, /^UPDATE "File"/i);
+
+    expect(conversionIndex).toBeGreaterThanOrEqual(0);
+    expect(backfillIndex).toBeGreaterThan(conversionIndex);
+  });
+});
+
+describe("File.isPublic boolean migration - down SQL contract", () => {
+  test("never drops the column", async () => {
+    const { runner, statements } = makeQueryRunner();
+
+    await new MigrationName1786446545142().down(runner);
+
+    expect(
+      statements.filter((statement: string) => {
+        return DROP_COLUMN_PATTERN.test(statement);
+      }),
+    ).toEqual([]);
+  });
+
+  test("converts back to varchar preserving true/false as strings", async () => {
+    const { runner, statements } = makeQueryRunner();
+
+    await new MigrationName1786446545142().down(runner);
+
+    const conversion: string | undefined = statements.find(
+      (statement: string) => {
+        return TO_VARCHAR_PATTERN.test(statement);
+      },
+    );
+
+    expect(conversion).toBeDefined();
+    expect(conversion).toMatch(/USING/i);
+    expect(conversion).toMatch(/'true'/);
+    expect(conversion).toMatch(/'false'/);
+  });
+});
+
+describe("File.isPublic boolean migration - registration", () => {
+  test("is registered exactly once", () => {
+    const occurrences: number = SchemaMigrations.filter(
+      (migration: unknown) => {
+        return migration === MigrationName1786446545142;
+      },
+    ).length;
+
+    expect(occurrences).toBe(1);
+  });
+
+  test("carries one consistent timestamp", () => {
+    const migration: MigrationName1786446545142 =
+      new MigrationName1786446545142();
+
+    expect(migration.name).toBe(`MigrationName${MIGRATION_TIMESTAMP}`);
+    expect(MigrationName1786446545142.name).toBe(
+      `MigrationName${MIGRATION_TIMESTAMP}`,
+    );
+  });
+});
+
+/*
+ * The migration only helps if the model agrees. If this column ever drifts
+ * back to a varchar type the schema-drift job would happily migrate it back
+ * and every isPublic gate would silently go dead again.
+ */
+describe("FileModel.isPublic column type", () => {
+  test("is declared as a boolean, not a string type", () => {
+    const columns: Array<ColumnMetadataArgs> =
+      getMetadataArgsStorage().columns.filter((column: ColumnMetadataArgs) => {
+        return (
+          column.propertyName === "isPublic" &&
+          (column.target as unknown) === FileModel
+        );
+      });
+
+    expect(columns).toHaveLength(1);
+    expect(columns[0]?.options.type).toBe(ColumnType.Boolean);
+    expect(columns[0]?.options.type).not.toBe(ColumnType.Slug);
+  });
+
+  test("declares a Boolean TableColumn so the API layer treats it as one", () => {
+    expect(getTableColumn(new FileModel(), "isPublic").type).toBe(
+      TableColumnType.Boolean,
+    );
+  });
+
+  test("has no varchar length, which only applies to string columns", () => {
+    const column: ColumnMetadataArgs | undefined =
+      getMetadataArgsStorage().columns.find((candidate: ColumnMetadataArgs) => {
+        return (
+          candidate.propertyName === "isPublic" &&
+          (candidate.target as unknown) === FileModel
+        );
+      });
+
+    expect(column?.options.length).toBeUndefined();
+  });
+});

--- a/Common/Tests/Server/Services/PublishTimeImageVisibility.test.ts
+++ b/Common/Tests/Server/Services/PublishTimeImageVisibility.test.ts
@@ -1,0 +1,450 @@
+import AIAgent from "../../../Models/DatabaseModels/AIAgent";
+import IncidentEpisodePublicNote from "../../../Models/DatabaseModels/IncidentEpisodePublicNote";
+import IncidentPublicNote from "../../../Models/DatabaseModels/IncidentPublicNote";
+import Probe from "../../../Models/DatabaseModels/Probe";
+import ScheduledMaintenancePublicNote from "../../../Models/DatabaseModels/ScheduledMaintenancePublicNote";
+import StatusPageAnnouncement from "../../../Models/DatabaseModels/StatusPageAnnouncement";
+import AIAgentService from "../../../Server/Services/AIAgentService";
+import FileService from "../../../Server/Services/FileService";
+import IncidentEpisodeFeedService from "../../../Server/Services/IncidentEpisodeFeedService";
+import IncidentEpisodePublicNoteService from "../../../Server/Services/IncidentEpisodePublicNoteService";
+import IncidentEpisodeService from "../../../Server/Services/IncidentEpisodeService";
+import IncidentFeedService from "../../../Server/Services/IncidentFeedService";
+import IncidentPublicNoteService from "../../../Server/Services/IncidentPublicNoteService";
+import IncidentService from "../../../Server/Services/IncidentService";
+import ProbeService from "../../../Server/Services/ProbeService";
+import ScheduledMaintenanceFeedService from "../../../Server/Services/ScheduledMaintenanceFeedService";
+import ScheduledMaintenancePublicNoteService from "../../../Server/Services/ScheduledMaintenancePublicNoteService";
+import ScheduledMaintenanceService from "../../../Server/Services/ScheduledMaintenanceService";
+import StatusPageAnnouncementService from "../../../Server/Services/StatusPageAnnouncementService";
+import URL from "../../../Types/API/URL";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * Inline images uploaded through the markdown editor arrive PRIVATE — that is
+ * what stops a private incident screenshot being readable by anyone holding
+ * the URL. They have to flip to public at exactly the moment their parent
+ * becomes visible on a status page, or every image in a published note 404s
+ * for the anonymous visitors the note was written for.
+ *
+ * These tests drive the real hooks and assert the flip lands on FileService,
+ * so they cover the whole chain (service hook -> sync util -> file write)
+ * rather than just "some function was called".
+ */
+
+const FILE_ID: string = "11111111-1111-4111-8111-111111111111";
+const ICON_FILE_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const TOKEN: string = "abc123def456";
+const NOTE_WITH_IMAGE: string = `Here is what broke: ![shot](https://example.com/file/image/access-token/${TOKEN})`;
+
+type CallHookFunction = (
+  service: unknown,
+  name: string,
+  ...args: Array<unknown>
+) => Promise<unknown>;
+
+// Calls a protected hook without widening the service's public surface.
+const callHook: CallHookFunction = (
+  service: unknown,
+  name: string,
+  ...args: Array<unknown>
+): Promise<unknown> => {
+  const hooks: Record<
+    string,
+    (...hookArgs: Array<unknown>) => Promise<unknown>
+  > = service as Record<
+    string,
+    (...hookArgs: Array<unknown>) => Promise<unknown>
+  >;
+
+  return hooks[name]!.apply(service, args);
+};
+
+type UpdatedFileIds = () => Array<string>;
+
+// Every file id the code under test flipped to public.
+const filesMadePublic: UpdatedFileIds = (): Array<string> => {
+  return (FileService.updateOneById as unknown as jest.Mock).mock.calls
+    .filter((call: Array<any>) => {
+      return call[0]?.data?.isPublic === true;
+    })
+    .map((call: Array<any>) => {
+      return String(call[0]?.id);
+    });
+};
+
+describe("publish-time inline image visibility", () => {
+  beforeEach(() => {
+    jest.spyOn(FileService, "findOneBy").mockResolvedValue({
+      _id: FILE_ID,
+    } as never);
+    jest
+      .spyOn(FileService, "updateOneById")
+      .mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("IncidentPublicNoteService", () => {
+    beforeEach(() => {
+      jest.spyOn(IncidentService, "getIncidentNumber").mockResolvedValue({
+        number: 1,
+        numberWithPrefix: "#1",
+      });
+      jest
+        .spyOn(IncidentService, "getIncidentLinkInDashboard")
+        .mockResolvedValue(URL.fromString("https://oneuptime.test/incident"));
+      jest
+        .spyOn(IncidentFeedService, "createIncidentFeedItem")
+        .mockResolvedValue(undefined as never);
+      jest
+        .spyOn(IncidentPublicNoteService, "findOneById")
+        .mockResolvedValue(null);
+    });
+
+    it("publishes inline images when a public note is created", async () => {
+      const note: IncidentPublicNote = new IncidentPublicNote();
+      note.id = new ObjectID("33333333-3333-4333-8333-333333333333");
+      note.incidentId = new ObjectID("44444444-4444-4444-8444-444444444444");
+      note.projectId = new ObjectID("55555555-5555-4555-8555-555555555555");
+      note.note = NOTE_WITH_IMAGE;
+
+      await callHook(IncidentPublicNoteService, "onCreateSuccess", {}, note);
+
+      expect(filesMadePublic()).toEqual([FILE_ID]);
+    });
+
+    it("publishes inline images when a public note is edited", async () => {
+      const note: IncidentPublicNote = new IncidentPublicNote();
+      note.id = new ObjectID("33333333-3333-4333-8333-333333333333");
+      note.incidentId = new ObjectID("44444444-4444-4444-8444-444444444444");
+      note.projectId = new ObjectID("55555555-5555-4555-8555-555555555555");
+      note.note = NOTE_WITH_IMAGE;
+      note.incident = {
+        id: new ObjectID("44444444-4444-4444-8444-444444444444"),
+        projectId: new ObjectID("55555555-5555-4555-8555-555555555555"),
+        incidentNumber: 1,
+      } as never;
+
+      jest.spyOn(IncidentPublicNoteService, "findBy").mockResolvedValue([note]);
+
+      await callHook(
+        IncidentPublicNoteService,
+        "onUpdateSuccess",
+        {
+          updateBy: {
+            query: {},
+            data: { note: NOTE_WITH_IMAGE },
+            props: { isRoot: true },
+          },
+        },
+        [],
+      );
+
+      expect(filesMadePublic()).toEqual([FILE_ID]);
+    });
+
+    it("does not touch any file when the note has no inline images", async () => {
+      const note: IncidentPublicNote = new IncidentPublicNote();
+      note.id = new ObjectID("33333333-3333-4333-8333-333333333333");
+      note.incidentId = new ObjectID("44444444-4444-4444-8444-444444444444");
+      note.projectId = new ObjectID("55555555-5555-4555-8555-555555555555");
+      note.note = "No screenshots on this one.";
+
+      await callHook(IncidentPublicNoteService, "onCreateSuccess", {}, note);
+
+      expect(FileService.updateOneById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("IncidentEpisodePublicNoteService", () => {
+    beforeEach(() => {
+      jest.spyOn(IncidentEpisodeService, "getEpisodeNumber").mockResolvedValue({
+        number: 1,
+        numberWithPrefix: "#1",
+      });
+      jest
+        .spyOn(IncidentEpisodeService, "getEpisodeLinkInDashboard")
+        .mockResolvedValue(URL.fromString("https://oneuptime.test/episode"));
+      jest
+        .spyOn(IncidentEpisodeFeedService, "createIncidentEpisodeFeedItem")
+        .mockResolvedValue(undefined as never);
+      jest
+        .spyOn(IncidentEpisodePublicNoteService, "findOneById")
+        .mockResolvedValue(null);
+    });
+
+    it("publishes inline images when a public note is created", async () => {
+      const note: IncidentEpisodePublicNote = new IncidentEpisodePublicNote();
+      note.id = new ObjectID("33333333-3333-4333-8333-333333333333");
+      note.incidentEpisodeId = new ObjectID(
+        "44444444-4444-4444-8444-444444444444",
+      );
+      note.projectId = new ObjectID("55555555-5555-4555-8555-555555555555");
+      note.note = NOTE_WITH_IMAGE;
+
+      await callHook(
+        IncidentEpisodePublicNoteService,
+        "onCreateSuccess",
+        {},
+        note,
+      );
+
+      expect(filesMadePublic()).toEqual([FILE_ID]);
+    });
+
+    it("publishes inline images when a public note is edited", async () => {
+      const note: IncidentEpisodePublicNote = new IncidentEpisodePublicNote();
+      note.id = new ObjectID("33333333-3333-4333-8333-333333333333");
+      note.incidentEpisodeId = new ObjectID(
+        "44444444-4444-4444-8444-444444444444",
+      );
+      note.projectId = new ObjectID("55555555-5555-4555-8555-555555555555");
+      note.note = NOTE_WITH_IMAGE;
+      note.incidentEpisode = {
+        id: new ObjectID("44444444-4444-4444-8444-444444444444"),
+        projectId: new ObjectID("55555555-5555-4555-8555-555555555555"),
+        episodeNumber: 1,
+      } as never;
+
+      jest
+        .spyOn(IncidentEpisodePublicNoteService, "findBy")
+        .mockResolvedValue([note]);
+
+      await callHook(
+        IncidentEpisodePublicNoteService,
+        "onUpdateSuccess",
+        {
+          updateBy: {
+            query: {},
+            data: { note: NOTE_WITH_IMAGE },
+            props: { isRoot: true },
+          },
+        },
+        [],
+      );
+
+      expect(filesMadePublic()).toEqual([FILE_ID]);
+    });
+  });
+
+  describe("ScheduledMaintenancePublicNoteService", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(ScheduledMaintenanceService, "getScheduledMaintenanceNumber")
+        .mockResolvedValue({ number: 1, numberWithPrefix: "#1" });
+      jest
+        .spyOn(
+          ScheduledMaintenanceService,
+          "getScheduledMaintenanceLinkInDashboard",
+        )
+        .mockResolvedValue(
+          URL.fromString("https://oneuptime.test/maintenance"),
+        );
+      jest
+        .spyOn(
+          ScheduledMaintenanceFeedService,
+          "createScheduledMaintenanceFeedItem",
+        )
+        .mockResolvedValue(undefined as never);
+      jest
+        .spyOn(ScheduledMaintenancePublicNoteService, "findOneById")
+        .mockResolvedValue(null);
+    });
+
+    it("publishes inline images when a public note is created", async () => {
+      const note: ScheduledMaintenancePublicNote =
+        new ScheduledMaintenancePublicNote();
+      note.id = new ObjectID("33333333-3333-4333-8333-333333333333");
+      note.scheduledMaintenanceId = new ObjectID(
+        "44444444-4444-4444-8444-444444444444",
+      );
+      note.projectId = new ObjectID("55555555-5555-4555-8555-555555555555");
+      note.note = NOTE_WITH_IMAGE;
+
+      await callHook(
+        ScheduledMaintenancePublicNoteService,
+        "onCreateSuccess",
+        {},
+        note,
+      );
+
+      expect(filesMadePublic()).toEqual([FILE_ID]);
+    });
+
+    it("publishes inline images when a public note is edited", async () => {
+      const note: ScheduledMaintenancePublicNote =
+        new ScheduledMaintenancePublicNote();
+      note.id = new ObjectID("33333333-3333-4333-8333-333333333333");
+      note.scheduledMaintenanceId = new ObjectID(
+        "44444444-4444-4444-8444-444444444444",
+      );
+      note.projectId = new ObjectID("55555555-5555-4555-8555-555555555555");
+      note.note = NOTE_WITH_IMAGE;
+      note.scheduledMaintenance = {
+        id: new ObjectID("44444444-4444-4444-8444-444444444444"),
+        projectId: new ObjectID("55555555-5555-4555-8555-555555555555"),
+        scheduledMaintenanceNumber: 1,
+      } as never;
+
+      jest
+        .spyOn(ScheduledMaintenancePublicNoteService, "findBy")
+        .mockResolvedValue([note]);
+
+      await callHook(
+        ScheduledMaintenancePublicNoteService,
+        "onUpdateSuccess",
+        {
+          updateBy: {
+            query: {},
+            data: { note: NOTE_WITH_IMAGE },
+            props: { isRoot: true },
+          },
+        },
+        [],
+      );
+
+      expect(filesMadePublic()).toEqual([FILE_ID]);
+    });
+  });
+
+  describe("StatusPageAnnouncementService", () => {
+    it("publishes inline images when an announcement is created", async () => {
+      const announcement: StatusPageAnnouncement = new StatusPageAnnouncement();
+      announcement.id = new ObjectID("33333333-3333-4333-8333-333333333333");
+      announcement.description = NOTE_WITH_IMAGE;
+
+      await callHook(
+        StatusPageAnnouncementService,
+        "onCreateSuccess",
+        {},
+        announcement,
+      );
+
+      expect(filesMadePublic()).toEqual([FILE_ID]);
+    });
+
+    it("publishes inline images when an announcement is edited", async () => {
+      const announcement: StatusPageAnnouncement = new StatusPageAnnouncement();
+      announcement.id = new ObjectID("33333333-3333-4333-8333-333333333333");
+      announcement.description = NOTE_WITH_IMAGE;
+
+      jest
+        .spyOn(StatusPageAnnouncementService, "findBy")
+        .mockResolvedValue([announcement]);
+
+      await callHook(
+        StatusPageAnnouncementService,
+        "onUpdateSuccess",
+        { updateBy: { query: {}, data: { description: NOTE_WITH_IMAGE } } },
+        [],
+      );
+
+      expect(filesMadePublic()).toEqual([FILE_ID]);
+    });
+
+    it("does not touch any file when the description has no inline images", async () => {
+      const announcement: StatusPageAnnouncement = new StatusPageAnnouncement();
+      announcement.id = new ObjectID("33333333-3333-4333-8333-333333333333");
+      announcement.description = "Scheduled work is now complete.";
+
+      await callHook(
+        StatusPageAnnouncementService,
+        "onCreateSuccess",
+        {},
+        announcement,
+      );
+
+      expect(FileService.updateOneById).not.toHaveBeenCalled();
+    });
+  });
+
+  /*
+   * Probe and AI agent icons are the only readers of the id-based image
+   * route, which serves public files only. They upload through the file
+   * picker, which marks uploads private — so attaching one has to publish it
+   * or the icon 404s.
+   */
+  describe("intentionally public icons", () => {
+    it("publishes a probe icon on create", async () => {
+      const probe: Probe = new Probe();
+      probe.id = new ObjectID("33333333-3333-4333-8333-333333333333");
+      probe.iconFileId = ICON_FILE_ID;
+
+      await callHook(ProbeService, "onCreateSuccess", {}, probe);
+
+      expect(filesMadePublic()).toEqual([ICON_FILE_ID.toString()]);
+    });
+
+    it("publishes a probe icon when it is swapped out", async () => {
+      await callHook(
+        ProbeService,
+        "onUpdateSuccess",
+        {
+          updateBy: { query: {}, data: { iconFileId: ICON_FILE_ID } },
+          carryForward: null,
+        },
+        [],
+      );
+
+      expect(filesMadePublic()).toEqual([ICON_FILE_ID.toString()]);
+    });
+
+    it("leaves files alone when a probe update does not touch the icon", async () => {
+      await callHook(
+        ProbeService,
+        "onUpdateSuccess",
+        {
+          updateBy: { query: {}, data: { name: "Renamed probe" } },
+          carryForward: null,
+        },
+        [],
+      );
+
+      expect(FileService.updateOneById).not.toHaveBeenCalled();
+    });
+
+    it("publishes an AI agent icon on create", async () => {
+      const agent: AIAgent = new AIAgent();
+      agent.id = new ObjectID("33333333-3333-4333-8333-333333333333");
+      agent.iconFileId = ICON_FILE_ID;
+
+      await callHook(AIAgentService, "onCreateSuccess", {}, agent);
+
+      expect(filesMadePublic()).toEqual([ICON_FILE_ID.toString()]);
+    });
+
+    it("publishes an AI agent icon when it is swapped out", async () => {
+      await callHook(
+        AIAgentService,
+        "onUpdateSuccess",
+        {
+          updateBy: { query: {}, data: { iconFileId: ICON_FILE_ID } },
+          carryForward: null,
+        },
+        [],
+      );
+
+      expect(filesMadePublic()).toEqual([ICON_FILE_ID.toString()]);
+    });
+
+    it("leaves files alone when an agent update does not touch the icon", async () => {
+      await callHook(
+        AIAgentService,
+        "onUpdateSuccess",
+        {
+          updateBy: { query: {}, data: { description: "Renamed" } },
+          carryForward: null,
+        },
+        [],
+      );
+
+      expect(FileService.updateOneById).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/InlineImageAccessTokenSync.test.ts
+++ b/Common/Tests/Server/Utils/InlineImageAccessTokenSync.test.ts
@@ -1,0 +1,202 @@
+import {
+  extractImageAccessTokens,
+  setIsPublicForMarkdownImages,
+  syncIsPublicForMarkdownImages,
+} from "../../../Server/Utils/InlineImageAccessTokenSync";
+import FileService from "../../../Server/Services/FileService";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+
+jest.mock("../../../Server/Services/FileService", () => {
+  return {
+    findOneBy: jest.fn(),
+    updateOneById: jest.fn(),
+  };
+});
+
+jest.mock("../../../Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    },
+  };
+});
+
+const urlFor: (token: string) => string = (token: string): string => {
+  return `https://example.com/file/image/access-token/${token}`;
+};
+
+describe("extractImageAccessTokens", () => {
+  it("returns nothing for empty, null or undefined markdown", () => {
+    expect(extractImageAccessTokens("")).toEqual([]);
+    expect(extractImageAccessTokens(null)).toEqual([]);
+    expect(extractImageAccessTokens(undefined)).toEqual([]);
+  });
+
+  it("returns nothing when the markdown has no inline images", () => {
+    expect(extractImageAccessTokens("Just some **notes** about the outage.")) //
+      .toEqual([]);
+  });
+
+  it("extracts a single token", () => {
+    expect(extractImageAccessTokens(`![shot](${urlFor("abc123")})`)).toEqual([
+      "abc123",
+    ]);
+  });
+
+  it("extracts every distinct token in the markdown", () => {
+    const markdown: string = `![a](${urlFor("aaa111")}) and ![b](${urlFor("bbb222")})`;
+
+    expect(extractImageAccessTokens(markdown)).toEqual(["aaa111", "bbb222"]);
+  });
+
+  it("de-duplicates a token referenced more than once", () => {
+    const markdown: string = `![a](${urlFor("aaa111")}) again ![a](${urlFor("aaa111")})`;
+
+    expect(extractImageAccessTokens(markdown)).toEqual(["aaa111"]);
+  });
+
+  it("ignores urls that are not access-token image urls", () => {
+    const markdown: string = `![logo](https://example.com/file/image/abc123) ![x](https://example.com/img.png)`;
+
+    expect(extractImageAccessTokens(markdown)).toEqual([]);
+  });
+
+  it("only matches hex tokens", () => {
+    expect(extractImageAccessTokens(`![a](${urlFor("zzzznothex")})`)).toEqual(
+      [],
+    );
+  });
+});
+
+describe("setIsPublicForMarkdownImages", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does nothing when the markdown has no inline images", async () => {
+    await setIsPublicForMarkdownImages("no images here", true);
+
+    expect(FileService.findOneBy).not.toHaveBeenCalled();
+    expect(FileService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  it("flips every referenced file to public", async () => {
+    (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue({
+      _id: "11111111-1111-1111-1111-111111111111",
+    } as never);
+
+    await setIsPublicForMarkdownImages(
+      `![a](${urlFor("aaa111")}) ![b](${urlFor("bbb222")})`,
+      true,
+    );
+
+    expect(FileService.updateOneById).toHaveBeenCalledTimes(2);
+    expect(
+      (FileService.updateOneById as unknown as jest.Mock).mock.calls[0]?.[0],
+    ).toMatchObject({
+      data: { isPublic: true },
+    });
+  });
+
+  it("flips files back to private when told to", async () => {
+    (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue({
+      _id: "11111111-1111-1111-1111-111111111111",
+    } as never);
+
+    await setIsPublicForMarkdownImages(`![a](${urlFor("aaa111")})`, false);
+
+    expect(
+      (FileService.updateOneById as unknown as jest.Mock).mock.calls[0]?.[0],
+    ).toMatchObject({
+      data: { isPublic: false },
+    });
+  });
+
+  it("skips tokens with no matching file", async () => {
+    (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue(
+      null as never,
+    );
+
+    await setIsPublicForMarkdownImages(`![a](${urlFor("aaa111")})`, true);
+
+    expect(FileService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  /*
+   * One unreadable file must not strand the rest of the note's images in the
+   * wrong visibility — a half-published note is worse than a slow one.
+   */
+  it("keeps going when one token fails", async () => {
+    (FileService.findOneBy as unknown as jest.Mock)
+      .mockRejectedValueOnce(new Error("db down") as never)
+      .mockResolvedValueOnce({
+        _id: "22222222-2222-2222-2222-222222222222",
+      } as never);
+
+    await setIsPublicForMarkdownImages(
+      `![a](${urlFor("aaa111")}) ![b](${urlFor("bbb222")})`,
+      true,
+    );
+
+    expect(FileService.updateOneById).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("syncIsPublicForMarkdownImages", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("flips images public like the unwrapped call", async () => {
+    (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue({
+      _id: "11111111-1111-1111-1111-111111111111",
+    } as never);
+
+    await syncIsPublicForMarkdownImages(
+      `![a](${urlFor("aaa111")})`,
+      true,
+      "test context",
+    );
+
+    expect(
+      (FileService.updateOneById as unknown as jest.Mock).mock.calls[0]?.[0],
+    ).toMatchObject({
+      data: { isPublic: true },
+    });
+  });
+
+  /*
+   * Visibility sync is best-effort by design: publishing a note must not fail
+   * because an image could not be flipped.
+   */
+  it("never throws, even when the markdown itself is unusable", async () => {
+    await expect(
+      syncIsPublicForMarkdownImages(
+        123 as unknown as string,
+        true,
+        "test context",
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("never throws when the update itself fails", async () => {
+    (FileService.findOneBy as unknown as jest.Mock).mockResolvedValue({
+      _id: "11111111-1111-1111-1111-111111111111",
+    } as never);
+    (FileService.updateOneById as unknown as jest.Mock).mockRejectedValue(
+      new Error("write failed") as never,
+    );
+
+    await expect(
+      syncIsPublicForMarkdownImages(
+        `![a](${urlFor("aaa111")})`,
+        true,
+        "test context",
+      ),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The bug

`File.isPublic` is declared `public isPublic?: boolean` but was created as a **varchar**, so every row holds the STRING `'true'`/`'false'`. `'false'` is truthy in JS, so both gates in `Common/Server/API/FileAPI.ts` were dead code:

- the token route's `if (!file.isPublic && !isAuthenticatedRequest(req))` never fired, so **every inline image was served to anonymous callers**;
- the legacy id route never rejected on `isPublic`.

Verified against the running dev stack **before** the change — a file with `isPublic='false'`:

| route | caller | before |
|---|---|---|
| `/file/image/access-token/:token` | anonymous | **200** |
| `/file/image/:id` | anonymous | **200** |

`FileService.onBeforeFind` was also worth checking. It injects `isPublic: true` into every non-root File query, comparing a boolean parameter against a varchar column. That one **does** work: node-postgres sends parameters untyped, so Postgres infers varchar and coerces `true` to `'true'`. (A *typed* boolean parameter errors — `operator does not exist: character varying = boolean` — but that is not how the driver sends it.) No change needed there, and it keeps working after the migration.

## Why this could not be fixed alone

Both upload paths — `FilePicker.tsx` and `MarkdownEditor.tsx` — create files with `isPublic = false`. Simply making the check work would 404 assets that are meant to be public. Tracing every consumer of the flag:

| asset | served by | gated by isPublic? |
|---|---|---|
| Inline markdown images | token route | yes |
| Probe icons, AI agent icons | legacy id route | yes — **would have broken** |
| Status page logo / favicon / cover | `StatusPageAPI` with `isRoot` | no |
| Note attachments | own attachment route with `isRoot` | no |

So the id-based route has exactly two readers, and both upload through the file picker.

## Changes

**Publish-time flip extended** — inline images now flip public on publish for the remaining status-page-visible content: `IncidentPublicNote`, `IncidentEpisodePublicNote`, `ScheduledMaintenancePublicNote`, `StatusPageAnnouncement`. Previously only incident post-mortems did this. Sync is best-effort via a new `syncIsPublicForMarkdownImages` wrapper — failing to flip an image must never fail the note write.

**Intentionally public icons** — `ProbeService` and `AIAgentService` flip the icon file public on attach, with a migration backfill for rows attached earlier.

**Migration** — converts the column in place. TypeORM generates `DROP COLUMN` + `ADD COLUMN` for this model change, which would **discard every stored value and silently re-default the whole table to public**. The migration instead uses a value-preserving `USING` cast, and the SQL contract is pinned by tests so a regeneration cannot reintroduce the destructive form.

**Defence in depth** — `FileAPI` now treats anything not exactly `true` as private, so a loose value can never re-open the gates.

## Verification

Migration exercised in a rolled-back transaction against the dev database: `'true'`→`t`, `'false'`→`f`, a private probe icon backfilled to `t`, all pre-existing rows preserved, and `down()` restoring the varchar strings.

Live truth table **after** applying the column change:

| route | caller | file | result |
|---|---|---|---|
| token | anonymous | private | **404** |
| token | anonymous | public | 200 |
| token | authenticated | private | 200 |
| legacy id | anonymous | private | **404** |
| legacy id | anonymous | public | 200 |
| status page logo / favicon | anonymous | private | 200 (correctly ungated) |

`npm run check-postgres-schema-drift` against a throwaway database: **No schema drift.** The dev database was restored to its pre-test state afterwards.

## Tests

59 new tests across 4 files:

- `FileAPIAccessControl.test.ts` (15) — the full gating truth table for both routes, including missing/forged/userless session tokens, and a regression guard that the string `"false"` is treated as private.
- `PublishTimeImageVisibility.test.ts` (16) — drives the real hooks on all six services and asserts the flip lands on `FileService`, covering the whole chain rather than just "a function was called".
- `FileIsPublicBooleanMigration.test.ts` (13) — pins the migration SQL contract (never `DROP COLUMN`, value-preserving `USING`, backfill ordered after the type change) plus model-level guards that the column stays a boolean.
- `InlineImageAccessTokenSync.test.ts` (15) — token extraction and the best-effort sync semantics.

## Note on scope

One residual gap, deliberately not addressed: an inline image is not flipped back to private when it is removed from a note or the note is deleted. It stays public after having been deliberately published, which is a much smaller exposure than the bug being fixed, and revoking correctly needs before/after diffing of note content. Happy to follow up separately if wanted.