### PR TITLE
fix(security): stop serving user-supplied Content-Type on file responses

### DIFF
--- a/Common/Server/API/FileAPI.ts
+++ b/Common/Server/API/FileAPI.ts
@@ -85,6 +85,7 @@ export default class FileAPI extends BaseAPI<File, FileServiceType> {
             file: true,
             fileType: true,
             isPublic: true,
+            name: true,
           },
         });
 
@@ -131,6 +132,7 @@ export default class FileAPI extends BaseAPI<File, FileServiceType> {
             file: true,
             fileType: true,
             isPublic: true,
+            name: true,
           },
         });
 

--- a/Common/Server/API/StatusPageAPI.ts
+++ b/Common/Server/API/StatusPageAPI.ts
@@ -113,6 +113,23 @@ import StatusPageSubscriberNotificationTemplateService, {
   Service as StatusPageSubscriberNotificationTemplateServiceClass,
 } from "../Services/StatusPageSubscriberNotificationTemplateService";
 
+type EscapeXmlFunction = (text: string) => string;
+
+/*
+ * The status badge is hand-built SVG served as image/svg+xml, and SVG is a
+ * document - anything interpolated into it is markup, not text. A monitor
+ * status named `</text><script>...` would otherwise run on the status page
+ * origin for anyone who opens the badge URL directly.
+ */
+const escapeXml: EscapeXmlFunction = (text: string): string => {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+};
+
 type ResolveStatusPageIdOrThrowFunction = (
   statusPageIdOrDomain: string,
 ) => Promise<ObjectID>;
@@ -531,9 +548,12 @@ export default class StatusPageAPI extends BaseAPI<
             });
 
           // Generate SVG badge
-          const statusName: string = overallStatus?.name || "Unknown";
-          const statusColor: string =
-            overallStatus?.color?.toString() || "#808080";
+          const statusName: string = escapeXml(
+            overallStatus?.name || "Unknown",
+          );
+          const statusColor: string = escapeXml(
+            overallStatus?.color?.toString() || "#808080",
+          );
 
           const svg: string = `<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">
   <linearGradient id="b" x2="0" y2="100%">
@@ -558,6 +578,17 @@ export default class StatusPageAPI extends BaseAPI<
 
           res.setHeader("Content-Type", "image/svg+xml");
           res.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+          /*
+           * The badge is only ever loaded through <img>, which ignores both of
+           * these. They exist for the case where someone opens the badge URL
+           * as a top-level document, where the SVG would otherwise be a
+           * scriptable document on this origin.
+           */
+          res.setHeader("X-Content-Type-Options", "nosniff");
+          res.setHeader(
+            "Content-Security-Policy",
+            "sandbox; script-src 'none'; object-src 'none'",
+          );
           return res.send(svg);
         } catch (err) {
           logger.error(err, getLogAttributesFromRequest(req as any));

--- a/Common/Server/Services/FileService.ts
+++ b/Common/Server/Services/FileService.ts
@@ -4,8 +4,10 @@ import FindBy from "../Types/Database/FindBy";
 import { OnCreate, OnDelete, OnFind, OnUpdate } from "../Types/Database/Hooks";
 import UpdateBy from "../Types/Database/UpdateBy";
 import DatabaseService from "./DatabaseService";
+import BadDataException from "../../Types/Exception/BadDataException";
 import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException";
 import File from "../../Models/DatabaseModels/File";
+import MimeType from "../../Types/File/MimeType";
 import ObjectID from "../../Types/ObjectID";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger from "../Utils/Logger";
@@ -14,6 +16,17 @@ import crypto from "crypto";
 const generateImageAccessToken: () => string = (): string => {
   return crypto.randomBytes(32).toString("hex");
 };
+
+/*
+ * fileType is declared as MimeType but persisted as a varchar, so the enum
+ * buys nothing at runtime - the API will happily store "text/html" if a client
+ * asks for it. Response.sendFileResponse refuses to echo an unknown type back,
+ * but keeping junk out of the column in the first place means the stored row
+ * matches what we are willing to serve.
+ */
+const ALLOWED_MIME_TYPES: Set<string> = new Set<string>(
+  Object.values(MimeType),
+);
 
 export class Service extends DatabaseService<File> {
   public constructor() {
@@ -24,6 +37,18 @@ export class Service extends DatabaseService<File> {
   protected override async onBeforeCreate(
     createBy: CreateBy<File>,
   ): Promise<OnCreate<File>> {
+    const fileType: string = (createBy.data.fileType || "")
+      .trim()
+      .toLowerCase();
+
+    if (!ALLOWED_MIME_TYPES.has(fileType)) {
+      throw new BadDataException(
+        "This file type is not supported. Please upload a supported file type.",
+      );
+    }
+
+    createBy.data.fileType = fileType as MimeType;
+
     /*
      * Always generate an unguessable access token server-side. The token
      * is the only safe way to address an inline-uploaded image in

--- a/Common/Server/Utils/Response.ts
+++ b/Common/Server/Utils/Response.ts
@@ -21,10 +21,62 @@ import Dictionary from "../../Types/Dictionary";
 import Exception from "../../Types/Exception/Exception";
 import { JSONArray, JSONObject } from "../../Types/JSON";
 import ListData from "../../Types/ListData";
+import MimeType from "../../Types/File/MimeType";
 import PositiveNumber from "../../Types/PositiveNumber";
 import Route from "../../Types/API/Route";
 import CaptureSpan from "./Telemetry/CaptureSpan";
 import { IsBillingEnabled } from "../EnvironmentConfig";
+
+/*
+ * Raster image types, which is to say the types that cannot carry script and
+ * are therefore safe both to echo back verbatim and to render in our own
+ * origin. An SVG is not here on purpose: it is a document, not a picture, and
+ * a PDF is not here either because it gets its own scripting engine.
+ *
+ * The list is deliberately wider than the MimeType enum. Until November 2025
+ * (62d74c1d84) the file picker stored the browser's own MIME string verbatim,
+ * so installs upgrading through this change hold rows with values that never
+ * appeared in the enum - "image/vnd.microsoft.icon" from a favicon upload,
+ * "image/jpg" from assorted tools. Collapsing those to octet-stream would stop
+ * every one of those avatars and logos from rendering, because nosniff means
+ * an <img> cannot recover from a type it was given wrongly.
+ */
+const SAFE_IMAGE_MIME_TYPES: Set<string> = new Set<string>([
+  MimeType.png,
+  // MimeType.jpg is the same string as MimeType.jpeg, so it is covered.
+  MimeType.jpeg,
+  MimeType.gif,
+  MimeType.webp,
+  MimeType.ico,
+  MimeType.bmp,
+  MimeType.tiff,
+  MimeType.avif,
+  MimeType.heic,
+  "image/jpg",
+  "image/pjpeg",
+  "image/vnd.microsoft.icon",
+  "image/x-ms-bmp",
+]);
+
+/*
+ * `fileType` is a plain varchar filled in from the upload request body, so by
+ * the time a file is served back it holds whatever string the uploader chose -
+ * the MimeType enum is a compile-time type and is erased at runtime. Echoing
+ * that string back as Content-Type is what turns "upload an image" into "run
+ * script on the dashboard origin", because /api, /file and /dashboard are the
+ * same origin. Only types we actually recognise get echoed back.
+ *
+ * Note this read-side list is wider than the one FileService enforces on
+ * upload: new rows are held to the canonical enum, old rows only have to be
+ * servable.
+ */
+const ALLOWED_MIME_TYPES: Set<string> = new Set<string>([
+  ...Object.values(MimeType),
+  ...SAFE_IMAGE_MIME_TYPES,
+]);
+
+// What an unrecognised fileType degrades to: opaque bytes, never a document.
+const FALLBACK_MIME_TYPE: string = "application/octet-stream";
 
 export default class Response {
   @CaptureSpan()
@@ -67,21 +119,105 @@ export default class Response {
     oneUptimeResponse.status(statusCode).send(body);
   }
 
+  /*
+   * Reduce a stored fileType to something safe to hand back as Content-Type.
+   * Anything we do not recognise - a made-up string, "text/html", a row
+   * written before uploads were validated - becomes opaque bytes.
+   */
+  public static getSafeFileType(fileType: string | undefined | null): string {
+    const normalizedFileType: string = (fileType || "").trim().toLowerCase();
+
+    if (ALLOWED_MIME_TYPES.has(normalizedFileType)) {
+      return normalizedFileType;
+    }
+
+    return FALLBACK_MIME_TYPE;
+  }
+
+  /*
+   * The filename goes into a response header, so it gets the same treatment as
+   * the MIME string: no quotes, no CR/LF, nothing that could split the header.
+   * This is the ASCII fallback only - see getContentDisposition, which pairs it
+   * with an encoded copy so a non-Latin name is not reduced to underscores.
+   */
+  public static getSafeFileName(name: string | undefined | null): string {
+    const safeFileName: string = (name || "")
+      .replace(/[^a-zA-Z0-9._-]/g, "_")
+      .slice(0, 100);
+
+    return safeFileName || "download";
+  }
+
+  /*
+   * RFC 6266: `filename` carries an ASCII-safe fallback for old clients and
+   * `filename*` carries the real name percent-encoded, so "月次レポート.pdf"
+   * downloads under its own name instead of as a row of underscores. Both are
+   * escaped, so neither can close the quoted string or inject a header.
+   */
+  public static getContentDisposition(
+    disposition: "inline" | "attachment",
+    name: string | undefined | null,
+  ): string {
+    const fileName: string = (name || "").trim().slice(0, 100) || "download";
+
+    /*
+     * encodeURIComponent leaves !'()* alone and RFC 5987's attr-char does not
+     * allow them - single quote especially, since it delimits the value.
+     */
+    const encodedFileName: string = encodeURIComponent(fileName).replace(
+      /['()*!]/g,
+      (character: string): string => {
+        return `%${character.charCodeAt(0).toString(16).toUpperCase()}`;
+      },
+    );
+
+    return `${disposition}; filename="${Response.getSafeFileName(fileName)}"; filename*=UTF-8''${encodedFileName}`;
+  }
+
   @CaptureSpan()
   public static async sendFileResponse(
     _req: ExpressRequest | ExpressRequest,
     res: ExpressResponse,
     file: FileModel,
   ): Promise<void> {
-    /** Create read stream */
-
     const oneUptimeResponse: OneUptimeResponse = res as OneUptimeResponse;
 
-    /** Set the proper content type */
-    oneUptimeResponse.set("Content-Type", file.fileType);
+    const fileType: string = Response.getSafeFileType(file.fileType);
+
+    oneUptimeResponse.set("Content-Type", fileType);
+
+    /*
+     * Belt and braces for the types we do echo back. nosniff stops the browser
+     * from guessing its way to a different type; the CSP gives the response an
+     * opaque origin with no scripting even if it is opened as a top-level
+     * document, so a crafted file cannot reach dashboard cookies; and nothing
+     * we serve here is ever meant to be framed.
+     */
+    oneUptimeResponse.set("X-Content-Type-Options", "nosniff");
+    oneUptimeResponse.set(
+      "Content-Security-Policy",
+      "sandbox; script-src 'none'; object-src 'none'; frame-ancestors 'none'",
+    );
+    oneUptimeResponse.set("X-Frame-Options", "DENY");
+
+    /*
+     * Inline is reserved for raster images, which cannot execute anything.
+     * Everything else - SVG, PDF, office docs, whatever an older row happens
+     * to hold - downloads instead of rendering. This is deliberately not an
+     * SVG ban: <img> and <link rel="icon"> ignore Content-Disposition, so
+     * status page logos, favicons and avatars still render. The only
+     * behaviour that changes is a top-level navigation to the file URL, and
+     * that is exactly the navigation an XSS payload needs.
+     */
+    oneUptimeResponse.set(
+      "Content-Disposition",
+      Response.getContentDisposition(
+        SAFE_IMAGE_MIME_TYPES.has(fileType) ? "inline" : "attachment",
+        file.name,
+      ),
+    );
+
     oneUptimeResponse.status(200);
-    /** Return response */
-    // readstream.pipe(res);
 
     oneUptimeResponse.send(file.file);
   }

--- a/Common/Server/Utils/StartServer.ts
+++ b/Common/Server/Utils/StartServer.ts
@@ -127,6 +127,14 @@ const setDefaultHeaders: RequestHandler = (
 
   res.header("Access-Control-Expose-Headers", CORS_EXPOSED_HEADERS.join(", "));
 
+  /*
+   * Content sniffing turns "the server declared a boring type" into "the
+   * browser guessed an interesting one", which is how an upload becomes a
+   * document. nginx sets this on the static app locations but not on /api or
+   * /file, so set it here for everything the app itself serves.
+   */
+  res.header("X-Content-Type-Options", "nosniff");
+
   next();
 };
 

--- a/Common/Tests/Server/Services/FileServiceMimeType.test.ts
+++ b/Common/Tests/Server/Services/FileServiceMimeType.test.ts
@@ -1,0 +1,89 @@
+import FileService from "../../../Server/Services/FileService";
+import File from "../../../Models/DatabaseModels/File";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import { OnCreate } from "../../../Server/Types/Database/Hooks";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import MimeType from "../../../Types/File/MimeType";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * fileType is declared as MimeType but persisted as a varchar, so the enum is
+ * gone by the time a request reaches the database - POST /api/file would store
+ * whatever string the client asked for, including "text/html". Response.ts
+ * refuses to echo an unknown type back, but this hook is what keeps the column
+ * matching the set of types we are actually willing to serve
+ * (GHSA-rrqw-5vj9-m9xg).
+ *
+ * No database - onBeforeCreate is called directly.
+ */
+
+type OnBeforeCreateFunction = (
+  createBy: CreateBy<File>,
+) => Promise<OnCreate<File>>;
+
+const onBeforeCreate: OnBeforeCreateFunction = (
+  createBy: CreateBy<File>,
+): Promise<OnCreate<File>> => {
+  return (
+    FileService as unknown as { onBeforeCreate: OnBeforeCreateFunction }
+  ).onBeforeCreate(createBy);
+};
+
+function createByWithFileType(fileType: string | undefined): CreateBy<File> {
+  const file: File = new File();
+  file.name = "upload";
+  file.file = Buffer.from("bytes");
+  file.fileType = fileType as MimeType;
+
+  return { data: file, props: { isRoot: true } } as CreateBy<File>;
+}
+
+describe("FileService.onBeforeCreate fileType validation", () => {
+  it("rejects a MIME type that is not a known type", async () => {
+    await expect(
+      onBeforeCreate(createByWithFileType("text/html")),
+    ).rejects.toThrow(BadDataException);
+
+    await expect(
+      onBeforeCreate(createByWithFileType("not-a-mime-type")),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("rejects a missing MIME type instead of storing an empty one", async () => {
+    await expect(
+      onBeforeCreate(createByWithFileType(undefined)),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("accepts the types the file picker actually produces", async () => {
+    for (const fileType of [
+      MimeType.png,
+      MimeType.jpeg,
+      MimeType.svg,
+      MimeType.pdf,
+      MimeType.txt,
+    ]) {
+      const result: OnCreate<File> = await onBeforeCreate(
+        createByWithFileType(fileType),
+      );
+
+      expect(result.createBy.data.fileType).toBe(fileType);
+    }
+  });
+
+  it("normalises casing and whitespace so the stored value is comparable", async () => {
+    const result: OnCreate<File> = await onBeforeCreate(
+      createByWithFileType("  IMAGE/PNG  "),
+    );
+
+    expect(result.createBy.data.fileType).toBe(MimeType.png);
+  });
+
+  it("still generates the image access token for an accepted upload", async () => {
+    const result: OnCreate<File> = await onBeforeCreate(
+      createByWithFileType(MimeType.png),
+    );
+
+    expect(result.createBy.data.imageAccessToken).toHaveLength(64);
+  });
+});

--- a/Common/Tests/Server/Utils/ResponseSendFileResponse.test.ts
+++ b/Common/Tests/Server/Utils/ResponseSendFileResponse.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { ExpressRequest, ExpressResponse } from "../../../Server/Utils/Express";
+import FileModel from "../../../Models/DatabaseModels/DatabaseBaseModel/FileModel";
+import MimeType from "../../../Types/File/MimeType";
+import ResponseUtil from "../../../Server/Utils/Response";
+
+/*
+ * sendFileResponse hands stored bytes back to a browser, and the type it
+ * declares them as used to come straight from the upload request. Because
+ * /api, /file and /dashboard are one origin, "image/svg+xml" plus a <script>
+ * element was enough to run script against dashboard cookies (GHSA-rrqw-5vj9-m9xg).
+ *
+ * The rule these tests pin down: a browser may render raster images inline and
+ * nothing else, it may never sniff, and it may never treat one of these
+ * responses as a scriptable document of ours.
+ */
+
+interface CapturedResponse {
+  headers: Record<string, string>;
+  statusCode: number | null;
+  body: unknown;
+}
+
+describe("Response.sendFileResponse", () => {
+  let captured: CapturedResponse;
+  let response: ExpressResponse;
+
+  beforeEach(() => {
+    captured = { headers: {}, statusCode: null, body: undefined };
+
+    response = {
+      set: (key: string, value: string): void => {
+        captured.headers[key] = value;
+      },
+      status: (code: number): void => {
+        captured.statusCode = code;
+      },
+      send: (body: unknown): void => {
+        captured.body = body;
+      },
+    } as unknown as ExpressResponse;
+  });
+
+  type SendFileFunction = (file: Partial<FileModel>) => Promise<void>;
+
+  const sendFile: SendFileFunction = async (
+    file: Partial<FileModel>,
+  ): Promise<void> => {
+    await ResponseUtil.sendFileResponse(
+      {} as ExpressRequest,
+      response,
+      file as FileModel,
+    );
+  };
+
+  test("renders a png inline and still forbids sniffing", async () => {
+    await sendFile({
+      fileType: MimeType.png,
+      file: Buffer.from("png-bytes"),
+      name: "logo.png",
+    });
+
+    expect(captured.headers["Content-Type"]).toBe("image/png");
+    expect(captured.headers["Content-Disposition"]).toContain("inline");
+    expect(captured.headers["X-Content-Type-Options"]).toBe("nosniff");
+    expect(captured.statusCode).toBe(200);
+  });
+
+  test("still serves image types written before the picker normalised them", async () => {
+    /*
+     * Until Nov 2025 the file picker stored the browser's MIME string as-is,
+     * so upgrading installs hold rows like this. Collapsing them to
+     * octet-stream would blank every one of those avatars, because nosniff
+     * means an <img> cannot recover from a wrong type.
+     */
+    for (const legacyType of [
+      "image/vnd.microsoft.icon",
+      "image/jpg",
+      "image/x-ms-bmp",
+    ]) {
+      await sendFile({
+        fileType: legacyType as MimeType,
+        file: Buffer.from("bytes"),
+        name: "avatar",
+      });
+
+      expect(captured.headers["Content-Type"]).toBe(legacyType);
+      expect(captured.headers["Content-Disposition"]).toContain("inline");
+    }
+  });
+
+  test("serves svg as a download rather than a document", async () => {
+    /*
+     * The type is preserved on purpose - <img> and <link rel="icon"> ignore
+     * Content-Disposition, so status page logos and favicons keep rendering.
+     * What changes is a top-level navigation to the URL, which is the only way
+     * script inside an SVG ever runs.
+     */
+    await sendFile({
+      fileType: MimeType.svg,
+      file: Buffer.from("<svg><script>alert(1)</script></svg>"),
+      name: "logo.svg",
+    });
+
+    expect(captured.headers["Content-Type"]).toBe("image/svg+xml");
+    expect(captured.headers["Content-Disposition"]).toContain("attachment");
+    expect(captured.headers["Content-Disposition"]).toContain(
+      'filename="logo.svg"',
+    );
+  });
+
+  test("refuses to echo back a type it does not recognise", async () => {
+    // text/html is not in MimeType at all, so it can only be a hand-crafted row.
+    await sendFile({
+      fileType: "text/html" as MimeType,
+      file: Buffer.from("<script>alert(1)</script>"),
+      name: "poc",
+    });
+
+    expect(captured.headers["Content-Type"]).toBe("application/octet-stream");
+    expect(captured.headers["Content-Disposition"]).toContain("attachment");
+  });
+
+  test("degrades junk and empty types to opaque bytes", async () => {
+    await sendFile({
+      fileType: "not-a-mime-type" as MimeType,
+      file: Buffer.from("bytes"),
+    });
+
+    expect(captured.headers["Content-Type"]).toBe("application/octet-stream");
+
+    await sendFile({ file: Buffer.from("bytes") });
+
+    expect(captured.headers["Content-Type"]).toBe("application/octet-stream");
+  });
+
+  test("neutralises a document-shaped response on every path", async () => {
+    for (const fileType of [MimeType.png, MimeType.svg, MimeType.pdf]) {
+      await sendFile({ fileType, file: Buffer.from("bytes"), name: "f" });
+
+      expect(captured.headers["X-Content-Type-Options"]).toBe("nosniff");
+      expect(captured.headers["X-Frame-Options"]).toBe("DENY");
+      expect(captured.headers["Content-Security-Policy"]).toContain("sandbox");
+      expect(captured.headers["Content-Security-Policy"]).toContain(
+        "script-src 'none'",
+      );
+    }
+  });
+
+  test("a crafted filename cannot break out of the header", async () => {
+    await sendFile({
+      fileType: MimeType.pdf,
+      file: Buffer.from("bytes"),
+      name: 'evil".pdf\r\nSet-Cookie: a=b',
+    });
+
+    const disposition: string | undefined =
+      captured.headers["Content-Disposition"];
+
+    expect(disposition).toBeDefined();
+    expect(disposition).not.toContain("\r");
+    expect(disposition).not.toContain("\n");
+    // The only quotes left are the two the header itself uses.
+    expect(disposition?.match(/"/g)).toHaveLength(2);
+    expect(disposition).toContain('filename="evil_.pdf__Set-Cookie__a_b"');
+  });
+
+  test("keeps a non-ASCII filename instead of reducing it to underscores", async () => {
+    await sendFile({
+      fileType: MimeType.pdf,
+      file: Buffer.from("bytes"),
+      name: "月次レポート.pdf",
+    });
+
+    const disposition: string | undefined =
+      captured.headers["Content-Disposition"];
+
+    // ASCII fallback for old clients, real name for everyone else.
+    expect(disposition).toContain('filename="______.pdf"');
+    expect(disposition).toContain(
+      `filename*=UTF-8''${encodeURIComponent("月次レポート.pdf")}`,
+    );
+  });
+
+  test("falls back to a generic filename when the row has no name", async () => {
+    await sendFile({ fileType: MimeType.pdf, file: Buffer.from("bytes") });
+
+    expect(captured.headers["Content-Disposition"]).toContain(
+      'filename="download"',
+    );
+  });
+});

--- a/Common/Types/File/MimeType.ts
+++ b/Common/Types/File/MimeType.ts
@@ -8,6 +8,17 @@ enum MimeType {
   svg = "image/svg+xml",
   gif = "image/gif",
   webp = "image/webp",
+  /*
+   * Raster formats a browser or an API client can legitimately report but the
+   * file picker never names. Listed so those uploads are not rejected outright
+   * now that FileService validates fileType against this enum, and so rows
+   * written before the picker normalised types are still servable.
+   */
+  ico = "image/x-icon",
+  bmp = "image/bmp",
+  tiff = "image/tiff",
+  avif = "image/avif",
+  heic = "image/heic",
   pdf = "application/pdf",
   doc = "application/msword",
   docx = "application/vnd.openxmlformats-officedocument.wordprocessingml.document",


### PR DESCRIPTION
Fixes GHSA-rrqw-5vj9-m9xg.

## The problem

`Response.sendFileResponse` set `Content-Type` from `file.fileType` verbatim:

```ts
oneUptimeResponse.set("Content-Type", file.fileType);
oneUptimeResponse.send(file.file);
```

`fileType` is declared `MimeType` but persisted as a `varchar(100)`, so the enum is erased at runtime and nothing validated it on upload. Any authenticated principal can create a `File` row (including the lowest-privilege project API key), and `/api`, `/file` and `/dashboard` are sibling locations in the same nginx server block — same origin. There was no `nosniff`, no `Content-Disposition` and no CSP anywhere in the stack.

Two things worth calling out beyond the report:

- The code is unchanged from the initial commit through current `master` (12.0.6), not just the versions named in the advisory.
- `GET /api/user/profile-picture/:userId` has no auth middleware and queries with `isRoot: true`, so the resulting URL is reachable unauthenticated.

## The fix

All 19 file-serving call sites funnel through `sendFileResponse`, so that is where this lives.

- **Content-Type is allow-listed.** Unrecognised values — a made-up string, `text/html`, a row written before the picker normalised types — degrade to `application/octet-stream` rather than being echoed back.
- **`nosniff`, a sandbox CSP and `X-Frame-Options: DENY` on every file response.** `sandbox` gives the response an opaque origin with no scripting, so even a document opened directly cannot reach dashboard cookies.
- **`Content-Disposition: inline` only for raster images**; everything else downloads.
- **Filenames follow RFC 6266** (`filename` + `filename*`), so a crafted name cannot split the header and a non-ASCII name still survives.

Alongside it: `FileService.onBeforeCreate` now rejects a `fileType` outside the enum, `setDefaultHeaders` sets `nosniff` globally, and the status page badge escapes the monitor status name it interpolates into hand-built SVG — a second, independent injection that never touches `sendFileResponse`.

## This is deliberately not an SVG ban

SVG upload is a shipped, documented feature (it is in the `ImageFile` picker's accept list and in the docs across 16 locales). `<img>` and `<link rel="icon">` ignore `Content-Disposition`, so status page logos, favicons, avatars and inline markdown images all keep rendering. The only behaviour that changes is a **top-level navigation** to a file URL — which is exactly the navigation script inside an SVG needs in order to run.

The read-side allow-list is intentionally wider than the one enforced on upload: until #62d74c1d84 the picker stored the browser's own MIME string verbatim, so existing installs hold rows like `image/vnd.microsoft.icon`. New rows are held to the canonical enum; old rows only have to stay servable.

## Testing

Adds the first coverage for either path — 14 tests across two suites, covering the allow-list, the disposition split, header injection via the filename, legacy rows, and the upload-time rejection. 59 adjacent existing tests still pass.

## Known follow-up, not in this PR

`File.isPublic` is declared `boolean` but stored as `character varying(100)`, so a private file reads back as the truthy string `"false"` and both `isPublic` gates in `FileAPI` are inert. I implemented the fix and backed it out: both upload components set `isPublic = false`, so making the check work would 404 every UI-uploaded file until `setIsPublicForMarkdownImages` is extended past its single current caller. That needs its own change plus a migration.

## Note for reviewers

`FileService` now returns 400 for an upload whose `fileType` is outside the enum. That is a behaviour change for any API client sending a non-enum type and should go in the release notes.