### PR TITLE
fix(helm): stop generating secrets that externalSecrets already provides

### DIFF
--- a/.github/workflows/common-jobs.yaml
+++ b/.github/workflows/common-jobs.yaml
@@ -27,7 +27,27 @@ jobs:
         run: |
           helm lint ./HelmChart/Public/oneuptime
           helm lint ./HelmChart/Public/kubernetes-agent
-          
+
+  helm-unit-test:
+    runs-on: ubuntu-latest
+    env:
+      CI_PIPELINE_ID: ${{github.run_number}}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Install Helm
+        run: |
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+      - name: Install helm-unittest plugin
+        run: |
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.5.1
+      - name: Run Helm Chart unit tests
+        run: npm run test-helm-chart
+      - name: Show how to run these locally
+        if: ${{ failure() }}
+        run: echo "Install the plugin with 'helm plugin install https://github.com/helm-unittest/helm-unittest' and run 'npm run test-helm-chart'."
+
+
   js-lint:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/common-jobs.yaml
+++ b/.github/workflows/common-jobs.yaml
@@ -47,6 +47,23 @@ jobs:
         if: ${{ failure() }}
         run: echo "Install the plugin with 'helm plugin install https://github.com/helm-unittest/helm-unittest' and run 'npm run test-helm-chart'."
 
+  helm-secrets-lifecycle-test:
+    runs-on: ubuntu-latest
+    env:
+      CI_PIPELINE_ID: ${{github.run_number}}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Install Helm
+        run: |
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+      # Installs and upgrades the chart for real on a KinD cluster to cover the
+      # `lookup` recovery path in templates/secrets.yaml, which renders empty
+      # (and so cannot be asserted on) without an API server. No images are
+      # pulled: the release is installed without --wait and without hooks.
+      - name: Run Helm Chart secret lifecycle tests
+        run: bash ./HelmChart/Tests/secrets-lifecycle.sh
+
 
   js-lint:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,13 @@ Clickhouse migrations are written manually. Please write the migration code in D
 
 Please run "npm run fix" in root to fix all the lint issues. Please run "npm run compile" in projects that you made changes to make sure compile works.
 
+### Helm chart
+
+The chart lives in `HelmChart/Public/oneuptime`. It has cluster-free unit tests in
+`HelmChart/Public/oneuptime/tests` (helm-unittest). Install the plugin once with
+`helm plugin install https://github.com/helm-unittest/helm-unittest` and run them with
+`npm run test-helm-chart`. CI runs them in the "Common Jobs" workflow alongside `helm lint`.
+
 ### Project docs
 
 Internal roadmaps live in `Internal/Roadmap/` (see its README for the index).

--- a/HelmChart/Public/oneuptime/.helmignore
+++ b/HelmChart/Public/oneuptime/.helmignore
@@ -23,4 +23,7 @@
 .vscode/
 
 # Chart unit tests (helm-unittest) - not needed inside the packaged chart.
-tests/
+# The leading slash anchors this to the chart root: an unanchored `tests/`
+# matches by base name at any depth and would also drop templates/tests/,
+# silently removing the `helm test` hook Pod from the chart.
+/tests/

--- a/HelmChart/Public/oneuptime/.helmignore
+++ b/HelmChart/Public/oneuptime/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Chart unit tests (helm-unittest) - not needed inside the packaged chart.
+tests/

--- a/HelmChart/Public/oneuptime/docs/configuration.md
+++ b/HelmChart/Public/oneuptime/docs/configuration.md
@@ -42,10 +42,35 @@ in three ways, in this order of precedence:
 
 Keys served by `externalSecrets` are not written into the chart-managed
 `<release>-secrets` Secret at all — pods read them straight from your Secret, so
-`helm diff` no longer reports them as changing on every render. If you were
-already using `externalSecrets`, the first upgrade after this change drops the
-unused copies from `<release>-secrets`; nothing reads them, so the removal is
-safe.
+`helm diff` no longer reports them as changing on every render.
+
+If you were already using `externalSecrets` before this change, the copies the
+chart used to generate stay behind in the live `<release>-secrets` Secret: Helm
+patches the `stringData` field, and the API server has already folded the old
+values into `data`, so dropping a key from the template does not delete it from
+the object. Nothing reads them, so leaving them is harmless. To clear them out:
+
+```
+kubectl patch secret <release>-secrets -n <namespace> --type=json \
+  -p '[{"op":"remove","path":"/data/oneuptime-secret"},
+       {"op":"remove","path":"/data/encryption-secret"},
+       {"op":"remove","path":"/data/register-probe-key"}]'
+```
+
+Remove only the keys you actually serve via `externalSecrets`. Deleting them is
+not free: if you later drop the `externalSecrets` block, the chart generates a
+brand-new value for any key that is no longer in `<release>-secrets`, and a new
+`ENCRYPTION_SECRET` means existing encrypted data can no longer be read. Leaving
+the old copies in place is the safer default — an install that adopted
+`externalSecrets` after running on chart-managed secrets had to copy its
+`ENCRYPTION_SECRET` into its own Secret to keep its data readable, so the
+retained copy is the same value and switching back picks it up again.
+
+If your install used `externalSecrets` from day one, the retained copies are
+values no pod ever read, and neither keeping nor deleting them gives you a
+working fallback. Switch back by copying the real values out of your own Secret
+first — set them inline as `oneuptimeSecret` / `encryptionSecret` /
+`registerProbeKey`, or write them into `<release>-secrets` yourself.
 
 Example:
 

--- a/HelmChart/Public/oneuptime/docs/configuration.md
+++ b/HelmChart/Public/oneuptime/docs/configuration.md
@@ -20,6 +20,51 @@ up-to-date list see [`values.yaml`](../values.yaml).
 | `nodeEnvironment`  | Node environment. Leave as `production` unless doing local development.                          | `production`    |    |
 | `logLevel`         | One of `INFO`, `WARN`, `ERROR`, `DEBUG`.                                                         | `INFO`          |    |
 
+## Application secrets
+
+`ONEUPTIME_SECRET`, `ENCRYPTION_SECRET` and `REGISTER_PROBE_KEY` can be supplied
+in three ways, in this order of precedence:
+
+1. Inline, via `oneuptimeSecret` / `encryptionSecret` / `registerProbeKey`.
+2. From a Kubernetes Secret you manage yourself, via the `externalSecrets`
+   block below. Leave the inline values blank when you use this.
+3. Not at all — the chart then generates a random 32-character value into its
+   own `<release>-secrets` Secret on install and keeps it across upgrades.
+
+| Parameter                                              | Description                                                       | Default |
+|--------------------------------------------------------|-------------------------------------------------------------------|---------|
+| `externalSecrets.oneuptimeSecret.existingSecret.name`  | Name of an existing Secret holding `ONEUPTIME_SECRET`.             | `nil`   |
+| `externalSecrets.oneuptimeSecret.existingSecret.passwordKey` | Key inside that Secret.                                      | `nil`   |
+| `externalSecrets.encryptionSecret.existingSecret.name` | Name of an existing Secret holding `ENCRYPTION_SECRET`.            | `nil`   |
+| `externalSecrets.encryptionSecret.existingSecret.passwordKey` | Key inside that Secret.                                     | `nil`   |
+| `externalSecrets.registerProbeKey.existingSecret.name` | Name of an existing Secret holding `REGISTER_PROBE_KEY`.           | `nil`   |
+| `externalSecrets.registerProbeKey.existingSecret.passwordKey` | Key inside that Secret.                                     | `nil`   |
+
+Keys served by `externalSecrets` are not written into the chart-managed
+`<release>-secrets` Secret at all — pods read them straight from your Secret, so
+`helm diff` no longer reports them as changing on every render. If you were
+already using `externalSecrets`, the first upgrade after this change drops the
+unused copies from `<release>-secrets`; nothing reads them, so the removal is
+safe.
+
+Example:
+
+```yaml
+externalSecrets:
+  oneuptimeSecret:
+    existingSecret:
+      name: one-uptime
+      passwordKey: one-uptime-secret
+  encryptionSecret:
+    existingSecret:
+      name: one-uptime
+      passwordKey: encryption-secret
+  registerProbeKey:
+    existingSecret:
+      name: one-uptime
+      passwordKey: register-probe-key
+```
+
 ## Networking & ingress
 
 | Parameter                    | Description                                                          | Default        |

--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -336,11 +336,11 @@ GLOBAL_LLM_PROVIDER_API_KEY is rendered only when an API key is configured.
   {{- if $.Values.oneuptimeSecret }}
   value: {{ $.Values.oneuptimeSecret }}
   {{- else }}
-  {{- if $.Values.externalSecrets.oneuptimeSecret.existingSecret.name }}
+  {{- if ((($.Values.externalSecrets).oneuptimeSecret).existingSecret).name }}
   valueFrom:
     secretKeyRef:
-        name: {{ $.Values.externalSecrets.oneuptimeSecret.existingSecret.name }}
-        key: {{ $.Values.externalSecrets.oneuptimeSecret.existingSecret.passwordKey }}
+      name: {{ ((($.Values.externalSecrets).oneuptimeSecret).existingSecret).name }}
+      key: {{ ((($.Values.externalSecrets).oneuptimeSecret).existingSecret).passwordKey }}
   {{- else }}
   valueFrom:
     secretKeyRef:
@@ -355,11 +355,11 @@ GLOBAL_LLM_PROVIDER_API_KEY is rendered only when an API key is configured.
   {{- if $.Values.registerProbeKey }}
   value: {{ $.Values.registerProbeKey }}
   {{- else }}
-  {{- if $.Values.externalSecrets.registerProbeKey.existingSecret.name }}
+  {{- if ((($.Values.externalSecrets).registerProbeKey).existingSecret).name }}
   valueFrom:
     secretKeyRef:
-        name: {{ $.Values.externalSecrets.registerProbeKey.existingSecret.name }}
-        key: {{ $.Values.externalSecrets.registerProbeKey.existingSecret.passwordKey }}
+      name: {{ ((($.Values.externalSecrets).registerProbeKey).existingSecret).name }}
+      key: {{ ((($.Values.externalSecrets).registerProbeKey).existingSecret).passwordKey }}
   {{- else }}
   valueFrom:
     secretKeyRef:
@@ -447,11 +447,11 @@ GLOBAL_LLM_PROVIDER_API_KEY is rendered only when an API key is configured.
   {{- if $.Values.encryptionSecret }}
   value: {{ $.Values.encryptionSecret }}
   {{- else }}
-  {{- if $.Values.externalSecrets.encryptionSecret.existingSecret.name }}
+  {{- if ((($.Values.externalSecrets).encryptionSecret).existingSecret).name }}
   valueFrom:
     secretKeyRef:
-        name: {{ $.Values.externalSecrets.encryptionSecret.existingSecret.name }}
-        key: {{ $.Values.externalSecrets.encryptionSecret.existingSecret.passwordKey }}
+      name: {{ ((($.Values.externalSecrets).encryptionSecret).existingSecret).name }}
+      key: {{ ((($.Values.externalSecrets).encryptionSecret).existingSecret).passwordKey }}
   {{- else }}
   valueFrom:
     secretKeyRef:
@@ -1302,10 +1302,10 @@ metadata:
     meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 spec:
   secretTargetRef:
-    {{- if .Values.externalSecrets.oneuptimeSecret.existingSecret.name }}
+    {{- if (((.Values.externalSecrets).oneuptimeSecret).existingSecret).name }}
     - parameter: clusterkey
-      name: {{ .Values.externalSecrets.oneuptimeSecret.existingSecret.name }}
-      key: {{ .Values.externalSecrets.oneuptimeSecret.existingSecret.passwordKey }}
+      name: {{ (((.Values.externalSecrets).oneuptimeSecret).existingSecret).name }}
+      key: {{ (((.Values.externalSecrets).oneuptimeSecret).existingSecret).passwordKey }}
     {{- else }}
     - parameter: clusterkey
       name: {{ printf "%s-%s" .Release.Name "secrets" }}

--- a/HelmChart/Public/oneuptime/templates/secrets.yaml
+++ b/HelmChart/Public/oneuptime/templates/secrets.yaml
@@ -1,3 +1,22 @@
+{{- /*
+  Keys that are served by an externally managed Secret (the `externalSecrets`
+  block) must NOT be generated here. Every pod reads them straight from the
+  user's own Secret, so generating them anyway leaves unused random values in
+  the chart-managed Secret that get re-randomised on every render — which makes
+  `helm diff`/`helm upgrade` claim the secrets are about to be rotated.
+  See https://github.com/OneUptime/oneuptime/issues/3121
+  An explicit `.Values.<secret>` still wins over `externalSecrets`, because that
+  is the precedence the env helpers in _helpers.tpl use.
+*/ -}}
+{{- $externalOneuptimeSecret := ((($.Values.externalSecrets).oneuptimeSecret).existingSecret).name }}
+{{- $externalRegisterProbeKey := ((($.Values.externalSecrets).registerProbeKey).existingSecret).name }}
+{{- $externalEncryptionSecret := ((($.Values.externalSecrets).encryptionSecret).existingSecret).name }}
+{{- /*
+  Existing chart-managed Secret, looked up once. `lookup` returns an empty dict
+  on install (and on client-side dry runs), so guard every read with `default dict`
+  instead of dereferencing `.data` directly.
+*/ -}}
+{{- $existingSecretData := ((lookup "v1" "Secret" $.Release.Namespace (printf "%s-secrets" $.Release.Name)).data) | default dict }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,35 +33,45 @@ stringData:
 
   {{- if .Values.oneuptimeSecret }}
   oneuptime-secret: {{ .Values.oneuptimeSecret | quote }}
+  {{- else if not $externalOneuptimeSecret }}
+  {{- if (index $existingSecretData "oneuptime-secret") }}
+  oneuptime-secret: {{ index $existingSecretData "oneuptime-secret" | b64dec | quote }}
   {{- else }}
-  oneuptime-secret: {{ index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-secrets" $.Release.Name)).data "oneuptime-secret" | b64dec }}
+  oneuptime-secret: {{ randAlphaNum 32 | quote }}
+  {{- end }}
   {{- end }}
   {{- if .Values.registerProbeKey }}
   register-probe-key: {{ .Values.registerProbeKey | quote }}
-  {{- else if (index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-secrets" $.Release.Name)).data "register-probe-key") }}
-  register-probe-key: {{ index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-secrets" $.Release.Name)).data "register-probe-key" | b64dec }}
+  {{- else if not $externalRegisterProbeKey }}
+  {{- if (index $existingSecretData "register-probe-key") }}
+  register-probe-key: {{ index $existingSecretData "register-probe-key" | b64dec | quote }}
   {{- else }}
   register-probe-key: {{ randAlphaNum 32 | quote }}
   {{- end }}
+  {{- end }}
   {{- if .Values.encryptionSecret }}
   encryption-secret: {{ .Values.encryptionSecret | quote }}
+  {{- else if not $externalEncryptionSecret }}
+  {{- if (index $existingSecretData "encryption-secret") }}
+  encryption-secret: {{ index $existingSecretData "encryption-secret" | b64dec | quote }}
   {{- else }}
-  encryption-secret: {{ index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-secrets" $.Release.Name)).data "encryption-secret" | b64dec }}
+  encryption-secret: {{ randAlphaNum 32 | quote }}
+  {{- end }}
   {{- end }}
 
   {{- range $key, $val := $.Values.probes }}
   {{- if $val.key }}
   {{printf "probe-%s" $key}}: {{ $val.key | quote }}
-  {{- else if (index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-secrets" $.Release.Name)).data (printf "probe-%s" $key)) }}
-  {{printf "probe-%s" $key}}: {{ (index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-secrets" $.Release.Name)).data (printf "probe-%s" $key) | b64dec) }}
+  {{- else if (index $existingSecretData (printf "probe-%s" $key)) }}
+  {{printf "probe-%s" $key}}: {{ index $existingSecretData (printf "probe-%s" $key) | b64dec | quote }}
   {{- else }}
   {{printf "probe-%s" $key}}: {{ randAlphaNum 32 | quote }}
   {{- end }}
   {{- end }}
 
   {{- if and $.Values.runner.enabled (not $.Values.runner.key) }}
-  {{- if (index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-secrets" $.Release.Name)).data "runner-key") }}
-  runner-key: {{ (index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-secrets" $.Release.Name)).data "runner-key" | b64dec) }}
+  {{- if (index $existingSecretData "runner-key") }}
+  runner-key: {{ index $existingSecretData "runner-key" | b64dec | quote }}
   {{- else }}
   runner-key: {{ randAlphaNum 32 | quote }}
   {{- end }}
@@ -52,26 +81,25 @@ stringData:
 
   {{- if .Values.oneuptimeSecret }}
   oneuptime-secret: {{ .Values.oneuptimeSecret | quote }}
-  {{- else }}
+  {{- else if not $externalOneuptimeSecret }}
   oneuptime-secret: {{ randAlphaNum 32 | quote }}
   {{- end }}
   {{- if .Values.registerProbeKey }}
   register-probe-key: {{ .Values.registerProbeKey | quote }}
-  {{- else }}
+  {{- else if not $externalRegisterProbeKey }}
   register-probe-key: {{ randAlphaNum 32 | quote }}
   {{- end }}
   {{- if .Values.encryptionSecret }}
   encryption-secret: {{ .Values.encryptionSecret | quote }}
-  {{- else }}
+  {{- else if not $externalEncryptionSecret }}
   encryption-secret: {{ randAlphaNum 32 | quote }}
   {{- end }}
 
-  {{- $existingSecrets := (lookup "v1" "Secret" $.Release.Namespace (printf "%s-secrets" $.Release.Name)) }}
   {{- range $key, $val := $.Values.probes }}
   {{- if $val.key }}
   {{printf "probe-%s" $key}}: {{ $val.key | quote }}
-  {{- else if and $existingSecrets.data (index $existingSecrets.data (printf "probe-%s" $key)) }}
-  {{printf "probe-%s" $key}}: {{ index $existingSecrets.data (printf "probe-%s" $key) | b64dec }}
+  {{- else if (index $existingSecretData (printf "probe-%s" $key)) }}
+  {{printf "probe-%s" $key}}: {{ index $existingSecretData (printf "probe-%s" $key) | b64dec | quote }}
   {{- else }}
   {{printf "probe-%s" $key}}: {{ randAlphaNum 32 | quote }}
   {{- end }}
@@ -102,11 +130,12 @@ metadata:
 type: Opaque
 stringData:
   {{- if .Release.IsUpgrade }}
+  {{- $existingRedisSecretData := ((lookup "v1" "Secret" $.Release.Namespace (printf "%s-redis" $.Release.Name)).data) | default dict }}
   {{- if .Values.redis.auth.password }}
   redis-password: {{ .Values.redis.auth.password | quote }}
   {{- else }}
-  {{- if (index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-redis" $.Release.Name)).data "redis-password") }}
-  redis-password: {{ index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-redis" $.Release.Name)).data "redis-password" | b64dec }}
+  {{- if (index $existingRedisSecretData "redis-password") }}
+  redis-password: {{ index $existingRedisSecretData "redis-password" | b64dec | quote }}
   {{- else }}
   redis-password: {{ randAlphaNum 32 | quote }}
   {{- end }}
@@ -214,13 +243,14 @@ metadata:
 type: Opaque
 stringData:
   {{- if .Release.IsUpgrade }}
+  {{- $existingPostgresSecretData := ((lookup "v1" "Secret" $.Release.Namespace (printf "%s-postgresql" $.Release.Name)).data) | default dict }}
   {{- if .Values.postgresql.auth.postgresPassword }}
   postgres-password: {{ .Values.postgresql.auth.postgresPassword | quote }}
   {{- else if .Values.postgresql.auth.password }}
   postgres-password: {{ .Values.postgresql.auth.password | quote }}
   {{- else }}
-  {{- if (index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-postgresql" $.Release.Name)).data "postgres-password") }}
-  postgres-password: {{ index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-postgresql" $.Release.Name)).data "postgres-password" | b64dec }}
+  {{- if (index $existingPostgresSecretData "postgres-password") }}
+  postgres-password: {{ index $existingPostgresSecretData "postgres-password" | b64dec | quote }}
   {{- else }}
   postgres-password: {{ randAlphaNum 32 | quote }}
   {{- end }}
@@ -264,7 +294,7 @@ stringData:
   {{- $existing := (lookup "v1" "Secret" $.Release.Namespace (printf "%s-postgresql-cnpg-superuser" $.Release.Name)) }}
   {{- $existingPw := index (($existing).data | default dict) "password" }}
   {{- if $existingPw }}
-  password: {{ $existingPw | b64dec }}
+  password: {{ $existingPw | b64dec | quote }}
   {{- else }}
   password: {{ randAlphaNum 32 | quote }}
   {{- end }}
@@ -297,11 +327,12 @@ metadata:
 type: Opaque
 stringData:
   {{- if .Release.IsUpgrade }}
+  {{- $existingClickhouseSecretData := ((lookup "v1" "Secret" $.Release.Namespace (printf "%s-clickhouse" $.Release.Name)).data) | default dict }}
   {{- if .Values.clickhouse.auth.password }}
   admin-password: {{ .Values.clickhouse.auth.password | quote }}
   {{- else }}
-  {{- if (index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-clickhouse" $.Release.Name)).data "admin-password") }}
-  admin-password: {{ index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-clickhouse" $.Release.Name)).data "admin-password" | b64dec }}
+  {{- if (index $existingClickhouseSecretData "admin-password") }}
+  admin-password: {{ index $existingClickhouseSecretData "admin-password" | b64dec | quote }}
   {{- else }}
   admin-password: {{ randAlphaNum 32 | quote }}
   {{- end }}
@@ -335,11 +366,12 @@ metadata:
 type: Opaque
 stringData:
   {{- if .Release.IsUpgrade }}
+  {{- $existingAltinitySecretData := ((lookup "v1" "Secret" $.Release.Namespace (printf "%s-clickhouse-altinity" $.Release.Name)).data) | default dict }}
   {{- if $altinity.auth.password }}
   admin-password: {{ $altinity.auth.password | quote }}
   {{- else }}
-  {{- if (index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-clickhouse-altinity" $.Release.Name)).data "admin-password") }}
-  admin-password: {{ index (lookup "v1" "Secret" $.Release.Namespace (printf "%s-clickhouse-altinity" $.Release.Name)).data "admin-password" | b64dec }}
+  {{- if (index $existingAltinitySecretData "admin-password") }}
+  admin-password: {{ index $existingAltinitySecretData "admin-password" | b64dec | quote }}
   {{- else }}
   admin-password: {{ randAlphaNum 32 | quote }}
   {{- end }}

--- a/HelmChart/Public/oneuptime/tests/external-secrets-env_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/external-secrets-env_test.yaml
@@ -213,3 +213,97 @@ tests:
               secretKeyRef:
                 name: oneuptime-secrets
                 key: oneuptime-secret
+
+  # probe.yaml is the main REGISTER_PROBE_KEY consumer: probe pods use it to
+  # register themselves. It also reads probe-<name>, which the chart still owns.
+  - it: wires the probe to the external register-probe-key and the chart-owned probe key
+    templates:
+      - templates/probe.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      externalSecrets.registerProbeKey.existingSecret.name: one-uptime
+      externalSecrets.registerProbeKey.existingSecret.passwordKey: register-probe-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REGISTER_PROBE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: one-uptime
+                key: register-probe-key
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PROBE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: oneuptime-secrets
+                key: probe-one
+
+  - it: wires the runner to the external secrets and the chart-owned runner key
+    templates:
+      - templates/runner.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      runner.enabled: true
+      externalSecrets.oneuptimeSecret.existingSecret.name: one-uptime
+      externalSecrets.oneuptimeSecret.existingSecret.passwordKey: one-uptime-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ONEUPTIME_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: one-uptime
+                key: one-uptime-secret
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ONEUPTIME_RUNNER_KEY
+            valueFrom:
+              secretKeyRef:
+                name: oneuptime-secrets
+                key: runner-key
+
+  - it: wires the ingress gateway to the external encryption secret
+    templates:
+      - templates/nginx.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      externalSecrets.encryptionSecret.existingSecret.name: one-uptime
+      externalSecrets.encryptionSecret.existingSecret.passwordKey: encryption-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENCRYPTION_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: one-uptime
+                key: encryption-secret
+
+  - it: treats an empty existingSecret name as not configured
+    templates:
+      - templates/app.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      externalSecrets.oneuptimeSecret.existingSecret.name: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ONEUPTIME_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: oneuptime-secrets
+                key: oneuptime-secret

--- a/HelmChart/Public/oneuptime/tests/external-secrets-env_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/external-secrets-env_test.yaml
@@ -1,0 +1,215 @@
+# The other half of https://github.com/OneUptime/oneuptime/issues/3121: the
+# chart only gets to skip generating a key because every consumer reads it from
+# the user's own Secret instead. These tests pin that wiring down so the two
+# halves cannot drift apart.
+suite: externalSecrets env wiring
+release:
+  name: oneuptime
+  namespace: oneuptime
+tests:
+  - it: points ONEUPTIME_SECRET at the chart-managed secret by default
+    templates:
+      - templates/app.yaml
+    # app.yaml renders both a Service and a Deployment under the same name,
+    # so select the Deployment by kind.
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ONEUPTIME_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: oneuptime-secrets
+                key: oneuptime-secret
+
+  - it: points ONEUPTIME_SECRET at the external secret
+    templates:
+      - templates/app.yaml
+    # app.yaml renders both a Service and a Deployment under the same name,
+    # so select the Deployment by kind.
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      externalSecrets.oneuptimeSecret.existingSecret.name: one-uptime
+      externalSecrets.oneuptimeSecret.existingSecret.passwordKey: one-uptime-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ONEUPTIME_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: one-uptime
+                key: one-uptime-secret
+
+  - it: points ENCRYPTION_SECRET at the external secret
+    templates:
+      - templates/app.yaml
+    # app.yaml renders both a Service and a Deployment under the same name,
+    # so select the Deployment by kind.
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      externalSecrets.encryptionSecret.existingSecret.name: one-uptime
+      externalSecrets.encryptionSecret.existingSecret.passwordKey: encryption-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENCRYPTION_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: one-uptime
+                key: encryption-secret
+
+  - it: points REGISTER_PROBE_KEY at the external secret
+    templates:
+      - templates/app.yaml
+    # app.yaml renders both a Service and a Deployment under the same name,
+    # so select the Deployment by kind.
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      externalSecrets.registerProbeKey.existingSecret.name: one-uptime
+      externalSecrets.registerProbeKey.existingSecret.passwordKey: register-probe-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REGISTER_PROBE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: one-uptime
+                key: register-probe-key
+
+  - it: wires the worker to the external secrets too
+    templates:
+      - templates/worker.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      worker.enabled: true
+      externalSecrets.oneuptimeSecret.existingSecret.name: one-uptime
+      externalSecrets.oneuptimeSecret.existingSecret.passwordKey: one-uptime-secret
+      externalSecrets.encryptionSecret.existingSecret.name: one-uptime
+      externalSecrets.encryptionSecret.existingSecret.passwordKey: encryption-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ONEUPTIME_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: one-uptime
+                key: one-uptime-secret
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENCRYPTION_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: one-uptime
+                key: encryption-secret
+
+  - it: wires the migration job to the external encryption secret
+    templates:
+      - templates/migrate-job.yaml
+    documentSelector:
+      path: kind
+      value: Job
+    set:
+      externalSecrets.encryptionSecret.existingSecret.name: one-uptime
+      externalSecrets.encryptionSecret.existingSecret.passwordKey: encryption-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENCRYPTION_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: one-uptime
+                key: encryption-secret
+
+  - it: prefers an inline oneuptimeSecret over the external secret
+    templates:
+      - templates/app.yaml
+    # app.yaml renders both a Service and a Deployment under the same name,
+    # so select the Deployment by kind.
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      oneuptimeSecret: inline-oneuptime-secret
+      externalSecrets.oneuptimeSecret.existingSecret.name: one-uptime
+      externalSecrets.oneuptimeSecret.existingSecret.passwordKey: one-uptime-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ONEUPTIME_SECRET
+            value: inline-oneuptime-secret
+
+  - it: points the KEDA trigger auth at the chart-managed secret by default
+    templates:
+      - templates/keda-scaledobjects.yaml
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-app-trigger-auth
+    set:
+      keda.enabled: true
+      app.keda.enabled: true
+    asserts:
+      - isKind:
+          of: TriggerAuthentication
+      - contains:
+          path: spec.secretTargetRef
+          content:
+            parameter: clusterkey
+            name: oneuptime-secrets
+            key: oneuptime-secret
+
+  - it: points the KEDA trigger auth at the external secret
+    templates:
+      - templates/keda-scaledobjects.yaml
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-app-trigger-auth
+    set:
+      keda.enabled: true
+      app.keda.enabled: true
+      externalSecrets.oneuptimeSecret.existingSecret.name: one-uptime
+      externalSecrets.oneuptimeSecret.existingSecret.passwordKey: one-uptime-secret
+    asserts:
+      - contains:
+          path: spec.secretTargetRef
+          content:
+            parameter: clusterkey
+            name: one-uptime
+            key: one-uptime-secret
+
+  - it: renders when the externalSecrets block is removed entirely
+    templates:
+      - templates/app.yaml
+    # app.yaml renders both a Service and a Deployment under the same name,
+    # so select the Deployment by kind.
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      externalSecrets: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ONEUPTIME_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: oneuptime-secrets
+                key: oneuptime-secret

--- a/HelmChart/Public/oneuptime/tests/helm-test-hook_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/helm-test-hook_test.yaml
@@ -1,0 +1,39 @@
+# Guards templates/tests/test.yaml — the `helm test` hook Pod.
+#
+# It lives under templates/tests/, which is one base-name match away from the
+# chart-root tests/ directory this file sits in. .helmignore excludes the latter
+# with an ANCHORED `/tests/`; an unanchored `tests/` matches by base name at any
+# depth and silently drops the hook Pod from every render and every packaged
+# chart. helm-unittest loads the chart through the same ignore rules, so this
+# suite stops resolving its template the moment that happens.
+suite: helm test hook
+templates:
+  - templates/tests/test.yaml
+release:
+  name: oneuptime
+  namespace: oneuptime
+tests:
+  - it: renders the helm test hook pod
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Pod
+      - equal:
+          path: metadata.name
+          value: oneuptime-test
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: test
+      - equal:
+          path: spec.restartPolicy
+          value: Never
+
+  - it: points the status check at the configured host
+    set:
+      host: status.example.com
+      httpProtocol: https
+    asserts:
+      - matchRegex:
+          path: spec.containers[0].args[1]
+          pattern: "https://status\\.example\\.com"

--- a/HelmChart/Public/oneuptime/tests/secrets-external-secrets_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/secrets-external-secrets_test.yaml
@@ -1,0 +1,272 @@
+# Regression tests for https://github.com/OneUptime/oneuptime/issues/3121
+#
+# When a key is served by an externally managed Secret (the `externalSecrets`
+# block), the chart-managed `<release>-secrets` Secret must not carry its own
+# copy of that key. It used to generate one anyway with `randAlphaNum`, so every
+# `helm diff` / `helm upgrade` reported the secrets as being rotated even though
+# nothing consumed the generated values.
+suite: chart-managed secret vs externalSecrets
+templates:
+  - templates/secrets.yaml
+release:
+  name: oneuptime
+  namespace: oneuptime
+tests:
+  # ---------------------------------------------------------------------------
+  # Fresh install
+  # ---------------------------------------------------------------------------
+  - it: generates all three secrets by default on install
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    asserts:
+      - isKind:
+          of: Secret
+      - matchRegex:
+          path: stringData.oneuptime-secret
+          pattern: "^[a-zA-Z0-9]{32}$"
+      - matchRegex:
+          path: stringData.register-probe-key
+          pattern: "^[a-zA-Z0-9]{32}$"
+      - matchRegex:
+          path: stringData.encryption-secret
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  - it: keeps generating when externalSecrets is present but empty (chart defaults)
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      externalSecrets:
+        oneuptimeSecret:
+          existingSecret:
+            name: null
+            passwordKey: null
+        encryptionSecret:
+          existingSecret:
+            name: null
+            passwordKey: null
+        registerProbeKey:
+          existingSecret:
+            name: null
+            passwordKey: null
+    asserts:
+      - exists:
+          path: stringData.oneuptime-secret
+      - exists:
+          path: stringData.register-probe-key
+      - exists:
+          path: stringData.encryption-secret
+
+  - it: does not render the whole externalSecrets block being nil
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      externalSecrets: null
+    asserts:
+      - exists:
+          path: stringData.oneuptime-secret
+      - exists:
+          path: stringData.register-probe-key
+      - exists:
+          path: stringData.encryption-secret
+
+  - it: skips oneuptime-secret when it comes from an existing secret
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      externalSecrets.oneuptimeSecret.existingSecret.name: one-uptime
+      externalSecrets.oneuptimeSecret.existingSecret.passwordKey: one-uptime-secret
+    asserts:
+      - notExists:
+          path: stringData.oneuptime-secret
+      - exists:
+          path: stringData.register-probe-key
+      - exists:
+          path: stringData.encryption-secret
+
+  - it: skips encryption-secret when it comes from an existing secret
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      externalSecrets.encryptionSecret.existingSecret.name: one-uptime
+      externalSecrets.encryptionSecret.existingSecret.passwordKey: encryption-secret
+    asserts:
+      - notExists:
+          path: stringData.encryption-secret
+      - exists:
+          path: stringData.oneuptime-secret
+      - exists:
+          path: stringData.register-probe-key
+
+  - it: skips register-probe-key when it comes from an existing secret
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      externalSecrets.registerProbeKey.existingSecret.name: one-uptime
+      externalSecrets.registerProbeKey.existingSecret.passwordKey: register-probe-key
+    asserts:
+      - notExists:
+          path: stringData.register-probe-key
+      - exists:
+          path: stringData.oneuptime-secret
+      - exists:
+          path: stringData.encryption-secret
+
+  - it: skips every externally managed key when all three are external
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      externalSecrets.oneuptimeSecret.existingSecret.name: one-uptime
+      externalSecrets.oneuptimeSecret.existingSecret.passwordKey: one-uptime-secret
+      externalSecrets.encryptionSecret.existingSecret.name: one-uptime
+      externalSecrets.encryptionSecret.existingSecret.passwordKey: encryption-secret
+      externalSecrets.registerProbeKey.existingSecret.name: one-uptime
+      externalSecrets.registerProbeKey.existingSecret.passwordKey: register-probe-key
+    asserts:
+      - notExists:
+          path: stringData.oneuptime-secret
+      - notExists:
+          path: stringData.encryption-secret
+      - notExists:
+          path: stringData.register-probe-key
+      # Keys the chart still owns are untouched.
+      - matchRegex:
+          path: stringData.probe-one
+          pattern: "^[a-zA-Z0-9]{32}$"
+      - matchRegex:
+          path: stringData.runner-key
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  - it: renders a keyless secret when nothing is chart-managed
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      externalSecrets.oneuptimeSecret.existingSecret.name: one-uptime
+      externalSecrets.oneuptimeSecret.existingSecret.passwordKey: one-uptime-secret
+      externalSecrets.encryptionSecret.existingSecret.name: one-uptime
+      externalSecrets.encryptionSecret.existingSecret.passwordKey: encryption-secret
+      externalSecrets.registerProbeKey.existingSecret.name: one-uptime
+      externalSecrets.registerProbeKey.existingSecret.passwordKey: register-probe-key
+      probes: null
+      runner.enabled: false
+    asserts:
+      - isKind:
+          of: Secret
+      - isNullOrEmpty:
+          path: stringData
+
+  # ---------------------------------------------------------------------------
+  # Explicit inline values win over externalSecrets, matching the precedence the
+  # env helpers in _helpers.tpl use (`.Values.oneuptimeSecret` short-circuits the
+  # secretKeyRef entirely).
+  # ---------------------------------------------------------------------------
+  - it: prefers an inline value over an existing secret
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      oneuptimeSecret: inline-oneuptime-secret
+      registerProbeKey: inline-register-probe-key
+      encryptionSecret: inline-encryption-secret
+      externalSecrets.oneuptimeSecret.existingSecret.name: one-uptime
+      externalSecrets.oneuptimeSecret.existingSecret.passwordKey: one-uptime-secret
+      externalSecrets.encryptionSecret.existingSecret.name: one-uptime
+      externalSecrets.encryptionSecret.existingSecret.passwordKey: encryption-secret
+      externalSecrets.registerProbeKey.existingSecret.name: one-uptime
+      externalSecrets.registerProbeKey.existingSecret.passwordKey: register-probe-key
+    asserts:
+      - equal:
+          path: stringData.oneuptime-secret
+          value: inline-oneuptime-secret
+      - equal:
+          path: stringData.register-probe-key
+          value: inline-register-probe-key
+      - equal:
+          path: stringData.encryption-secret
+          value: inline-encryption-secret
+
+  # ---------------------------------------------------------------------------
+  # Upgrade path. `lookup` returns nothing while rendering without a cluster, so
+  # these exercise the "no previous value" fallbacks of the upgrade branch.
+  # ---------------------------------------------------------------------------
+  - it: generates all three secrets by default on upgrade
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    asserts:
+      - matchRegex:
+          path: stringData.oneuptime-secret
+          pattern: "^[a-zA-Z0-9]{32}$"
+      - matchRegex:
+          path: stringData.register-probe-key
+          pattern: "^[a-zA-Z0-9]{32}$"
+      - matchRegex:
+          path: stringData.encryption-secret
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  - it: skips every externally managed key on upgrade too
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    set:
+      externalSecrets.oneuptimeSecret.existingSecret.name: one-uptime
+      externalSecrets.oneuptimeSecret.existingSecret.passwordKey: one-uptime-secret
+      externalSecrets.encryptionSecret.existingSecret.name: one-uptime
+      externalSecrets.encryptionSecret.existingSecret.passwordKey: encryption-secret
+      externalSecrets.registerProbeKey.existingSecret.name: one-uptime
+      externalSecrets.registerProbeKey.existingSecret.passwordKey: register-probe-key
+    asserts:
+      - notExists:
+          path: stringData.oneuptime-secret
+      - notExists:
+          path: stringData.encryption-secret
+      - notExists:
+          path: stringData.register-probe-key
+      - exists:
+          path: stringData.probe-one
+      - exists:
+          path: stringData.runner-key
+
+  - it: prefers an inline value over an existing secret on upgrade
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    set:
+      oneuptimeSecret: inline-oneuptime-secret
+      encryptionSecret: inline-encryption-secret
+      registerProbeKey: inline-register-probe-key
+      externalSecrets.oneuptimeSecret.existingSecret.name: one-uptime
+      externalSecrets.oneuptimeSecret.existingSecret.passwordKey: one-uptime-secret
+      externalSecrets.encryptionSecret.existingSecret.name: one-uptime
+      externalSecrets.encryptionSecret.existingSecret.passwordKey: encryption-secret
+      externalSecrets.registerProbeKey.existingSecret.name: one-uptime
+      externalSecrets.registerProbeKey.existingSecret.passwordKey: register-probe-key
+    asserts:
+      - equal:
+          path: stringData.oneuptime-secret
+          value: inline-oneuptime-secret
+      - equal:
+          path: stringData.encryption-secret
+          value: inline-encryption-secret
+      - equal:
+          path: stringData.register-probe-key
+          value: inline-register-probe-key

--- a/HelmChart/Public/oneuptime/tests/secrets-external-secrets_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/secrets-external-secrets_test.yaml
@@ -270,3 +270,103 @@ tests:
       - equal:
           path: stringData.register-probe-key
           value: inline-register-probe-key
+
+  # ---------------------------------------------------------------------------
+  # Partial and hostile inputs
+  # ---------------------------------------------------------------------------
+  - it: renders when a single externalSecrets sub-key is nil
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    # The accessors are parenthesised three levels deep so a nil at ANY level is
+    # safe, not just a nil top-level block.
+    set:
+      externalSecrets:
+        oneuptimeSecret: null
+        encryptionSecret:
+          existingSecret: null
+        registerProbeKey:
+          existingSecret:
+            name: one-uptime
+            passwordKey: register-probe-key
+    asserts:
+      - exists:
+          path: stringData.oneuptime-secret
+      - exists:
+          path: stringData.encryption-secret
+      - notExists:
+          path: stringData.register-probe-key
+
+  # values.schema.json already forces these to be strings, so the risk is not the
+  # input type but the OUTPUT: emitted without `| quote` these render as a bare
+  # scalar that YAML reads back as an int/bool, and the API server rejects the
+  # Secret with "cannot unmarshal number into Go struct field ... stringData".
+  - it: emits an inline secret that YAML would coerce as a string
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      oneuptimeSecret: "1234567890"
+      encryptionSecret: "true"
+      registerProbeKey: "0123456"
+    asserts:
+      - equal:
+          path: stringData.oneuptime-secret
+          value: "1234567890"
+      - equal:
+          path: stringData.encryption-secret
+          value: "true"
+      - equal:
+          path: stringData.register-probe-key
+          value: "0123456"
+
+  - it: emits an inline secret containing YAML metacharacters verbatim
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      oneuptimeSecret: "abc # not-a-comment"
+      encryptionSecret: "key: value"
+      registerProbeKey: "*alias-looking"
+    asserts:
+      - equal:
+          path: stringData.oneuptime-secret
+          value: "abc # not-a-comment"
+      - equal:
+          path: stringData.encryption-secret
+          value: "key: value"
+      - equal:
+          path: stringData.register-probe-key
+          value: "*alias-looking"
+
+  - it: keeps generating probe and runner keys when all three app secrets are external
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    set:
+      runner.enabled: true
+      probes:
+        one:
+          name: Probe One
+        two:
+          name: Probe Two
+      externalSecrets.oneuptimeSecret.existingSecret.name: one-uptime
+      externalSecrets.oneuptimeSecret.existingSecret.passwordKey: one-uptime-secret
+      externalSecrets.encryptionSecret.existingSecret.name: one-uptime
+      externalSecrets.encryptionSecret.existingSecret.passwordKey: encryption-secret
+      externalSecrets.registerProbeKey.existingSecret.name: one-uptime
+      externalSecrets.registerProbeKey.existingSecret.passwordKey: register-probe-key
+    asserts:
+      - matchRegex:
+          path: stringData.probe-one
+          pattern: "^[a-zA-Z0-9]{32}$"
+      - matchRegex:
+          path: stringData.probe-two
+          pattern: "^[a-zA-Z0-9]{32}$"
+      - matchRegex:
+          path: stringData.runner-key
+          pattern: "^[a-zA-Z0-9]{32}$"

--- a/HelmChart/Public/oneuptime/tests/secrets-generation_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/secrets-generation_test.yaml
@@ -1,0 +1,316 @@
+# Everything the chart still generates for itself in templates/secrets.yaml.
+#
+# The upgrade cases matter as much as the install ones: `lookup` returns nothing
+# when the chart is rendered without a cluster (`helm template`, client-side dry
+# runs), so the upgrade branch has to fall back to a freshly generated value
+# instead of dereferencing a nil `.data` map.
+suite: chart-managed secret generation
+templates:
+  - templates/secrets.yaml
+release:
+  name: oneuptime
+  namespace: oneuptime
+tests:
+  # ---------------------------------------------------------------------------
+  # Probe keys
+  # ---------------------------------------------------------------------------
+  - it: generates a key for every probe
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      probes:
+        one:
+          name: Probe One
+        two:
+          name: Probe Two
+    asserts:
+      - matchRegex:
+          path: stringData.probe-one
+          pattern: "^[a-zA-Z0-9]{32}$"
+      - matchRegex:
+          path: stringData.probe-two
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  - it: uses an explicit probe key when given
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      probes.one.key: my-probe-key
+    asserts:
+      - equal:
+          path: stringData.probe-one
+          value: my-probe-key
+
+  - it: generates probe keys on upgrade as well
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    asserts:
+      - matchRegex:
+          path: stringData.probe-one
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  # ---------------------------------------------------------------------------
+  # Runner key
+  # ---------------------------------------------------------------------------
+  - it: generates a runner key when the runner is enabled
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      runner.enabled: true
+    asserts:
+      - matchRegex:
+          path: stringData.runner-key
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  - it: does not generate a runner key when the runner is disabled
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      runner.enabled: false
+    asserts:
+      - notExists:
+          path: stringData.runner-key
+
+  - it: does not generate a runner key when one is supplied
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    set:
+      runner.enabled: true
+      runner.key: my-runner-key
+    asserts:
+      - notExists:
+          path: stringData.runner-key
+
+  - it: generates a runner key on upgrade as well
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    set:
+      runner.enabled: true
+    asserts:
+      - matchRegex:
+          path: stringData.runner-key
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  # ---------------------------------------------------------------------------
+  # Redis
+  # ---------------------------------------------------------------------------
+  - it: generates a redis password on install
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-redis
+    asserts:
+      - matchRegex:
+          path: stringData.redis-password
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  - it: generates a redis password on upgrade without a cluster to look up
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-redis
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    asserts:
+      - matchRegex:
+          path: stringData.redis-password
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  - it: uses the supplied redis password
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-redis
+    set:
+      redis.auth.password: my-redis-password
+    asserts:
+      - equal:
+          path: stringData.redis-password
+          value: my-redis-password
+
+  # A default install renders exactly four secrets from this template:
+  # <release>-secrets, -redis, -postgresql and -clickhouse. The two tests below
+  # assert that pointing redis/clickhouse at an existing secret drops the
+  # corresponding chart-managed one, so update these counts together with the
+  # baseline if a new secret is added to templates/secrets.yaml.
+  - it: renders the four chart-managed secrets by default
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: does not create a redis secret when an existing one is referenced
+    set:
+      redis.auth.existingSecret.name: my-redis-secret
+      redis.auth.existingSecret.passwordKey: redis-password
+    asserts:
+      - hasDocuments:
+          count: 3
+      - documentSelector:
+          path: metadata.name
+          value: oneuptime-postgresql
+        isKind:
+          of: Secret
+
+  # ---------------------------------------------------------------------------
+  # Postgres (in-cluster StatefulSet flavour)
+  # ---------------------------------------------------------------------------
+  - it: generates a postgres password on install
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-postgresql
+    asserts:
+      - matchRegex:
+          path: stringData.postgres-password
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  - it: generates a postgres password on upgrade without a cluster to look up
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-postgresql
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    asserts:
+      - matchRegex:
+          path: stringData.postgres-password
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  - it: uses the supplied postgres password
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-postgresql
+    set:
+      postgresql.auth.postgresPassword: my-postgres-password
+    asserts:
+      - equal:
+          path: stringData.postgres-password
+          value: my-postgres-password
+
+  # ---------------------------------------------------------------------------
+  # Postgres (CloudNativePG operator flavour)
+  # ---------------------------------------------------------------------------
+  - it: generates a cnpg superuser password on upgrade without a cluster to look up
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-postgresql-cnpg-superuser
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    set:
+      postgresql.enabled: false
+      postgresOperator.cnpg.enabled: true
+    asserts:
+      - equal:
+          path: stringData.username
+          value: postgres
+      - matchRegex:
+          path: stringData.password
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  # ---------------------------------------------------------------------------
+  # ClickHouse
+  # ---------------------------------------------------------------------------
+  - it: generates a clickhouse password on install
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-clickhouse
+    asserts:
+      - matchRegex:
+          path: stringData.admin-password
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  - it: generates a clickhouse password on upgrade without a cluster to look up
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-clickhouse
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    asserts:
+      - matchRegex:
+          path: stringData.admin-password
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  - it: does not create a clickhouse secret when an existing one is referenced
+    set:
+      clickhouse.auth.existingSecret.name: my-clickhouse-secret
+      clickhouse.auth.existingSecret.passwordKey: admin-password
+    asserts:
+      - hasDocuments:
+          count: 3
+      - documentSelector:
+          path: metadata.name
+          value: oneuptime-redis
+        isKind:
+          of: Secret
+
+  - it: generates an altinity clickhouse password on upgrade without a cluster to look up
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-clickhouse-altinity
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    set:
+      clickhouseOperator.altinity.enabled: true
+    asserts:
+      - matchRegex:
+          path: stringData.admin-password
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  # ---------------------------------------------------------------------------
+  # External datastores
+  # ---------------------------------------------------------------------------
+  - it: writes the external postgres password into its own secret
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-external-postgres
+    set:
+      postgresql.enabled: false
+      externalPostgres.password: my-external-postgres-password
+    asserts:
+      - equal:
+          path: stringData.password
+          value: my-external-postgres-password
+
+  - it: writes the external redis password into its own secret
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-external-redis
+    set:
+      redis.enabled: false
+      externalRedis.password: my-external-redis-password
+    asserts:
+      - equal:
+          path: stringData.password
+          value: my-external-redis-password
+
+  - it: writes the external clickhouse password into its own secret
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-external-clickhouse
+    set:
+      clickhouse.enabled: false
+      externalClickhouse.password: my-external-clickhouse-password
+    asserts:
+      - equal:
+          path: stringData.password
+          value: my-external-clickhouse-password

--- a/HelmChart/Public/oneuptime/tests/secrets-generation_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/secrets-generation_test.yaml
@@ -151,7 +151,30 @@ tests:
     asserts:
       - hasDocuments:
           count: 4
+      - documentSelector:
+          path: metadata.name
+          value: oneuptime-secrets
+        isKind:
+          of: Secret
+      - documentSelector:
+          path: metadata.name
+          value: oneuptime-redis
+        isKind:
+          of: Secret
+      - documentSelector:
+          path: metadata.name
+          value: oneuptime-postgresql
+        isKind:
+          of: Secret
+      - documentSelector:
+          path: metadata.name
+          value: oneuptime-clickhouse
+        isKind:
+          of: Secret
 
+  # `hasDocuments: count` alone would pass if a DIFFERENT secret went missing, so
+  # each of these pins the count AND names every document that must still be
+  # there. Count + the full surviving set together prove which one disappeared.
   - it: does not create a redis secret when an existing one is referenced
     set:
       redis.auth.existingSecret.name: my-redis-secret
@@ -161,7 +184,17 @@ tests:
           count: 3
       - documentSelector:
           path: metadata.name
+          value: oneuptime-secrets
+        isKind:
+          of: Secret
+      - documentSelector:
+          path: metadata.name
           value: oneuptime-postgresql
+        isKind:
+          of: Secret
+      - documentSelector:
+          path: metadata.name
+          value: oneuptime-clickhouse
         isKind:
           of: Secret
 
@@ -257,7 +290,17 @@ tests:
           count: 3
       - documentSelector:
           path: metadata.name
+          value: oneuptime-secrets
+        isKind:
+          of: Secret
+      - documentSelector:
+          path: metadata.name
           value: oneuptime-redis
+        isKind:
+          of: Secret
+      - documentSelector:
+          path: metadata.name
+          value: oneuptime-postgresql
         isKind:
           of: Secret
 
@@ -314,3 +357,179 @@ tests:
       - equal:
           path: stringData.password
           value: my-external-clickhouse-password
+
+  # ---------------------------------------------------------------------------
+  # Branches that only the upgrade leg, or only a non-default flavour, reaches.
+  # Each `{{- if }}` in templates/secrets.yaml should be reachable from a test.
+  # ---------------------------------------------------------------------------
+  - it: honours an explicit probe key on upgrade
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    set:
+      probes.one.key: my-probe-key
+    asserts:
+      - equal:
+          path: stringData.probe-one
+          value: my-probe-key
+
+  - it: does not generate a runner key on upgrade when one is supplied
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    set:
+      runner.enabled: true
+      runner.key: my-runner-key
+    asserts:
+      - notExists:
+          path: stringData.runner-key
+
+  - it: does not generate a runner key on upgrade when the runner is disabled
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-secrets
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    set:
+      runner.enabled: false
+    asserts:
+      - notExists:
+          path: stringData.runner-key
+
+  - it: uses the supplied redis password on upgrade
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-redis
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    set:
+      redis.auth.password: my-redis-password
+    asserts:
+      - equal:
+          path: stringData.redis-password
+          value: my-redis-password
+
+  - it: uses the supplied postgres password on upgrade
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-postgresql
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    set:
+      postgresql.auth.postgresPassword: my-postgres-password
+    asserts:
+      - equal:
+          path: stringData.postgres-password
+          value: my-postgres-password
+
+  - it: uses the supplied clickhouse password on upgrade
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-clickhouse
+    release:
+      name: oneuptime
+      namespace: oneuptime
+      upgrade: true
+    set:
+      clickhouse.auth.password: my-clickhouse-password
+    asserts:
+      - equal:
+          path: stringData.admin-password
+          value: my-clickhouse-password
+
+  - it: generates a cnpg superuser password on install
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-postgresql-cnpg-superuser
+    set:
+      postgresql.enabled: false
+      postgresOperator.cnpg.enabled: true
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: type
+          value: kubernetes.io/basic-auth
+      - equal:
+          path: stringData.username
+          value: postgres
+      - matchRegex:
+          path: stringData.password
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  - it: uses the supplied cnpg superuser password
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-postgresql-cnpg-superuser
+    set:
+      postgresql.enabled: false
+      postgresOperator.cnpg.enabled: true
+      postgresOperator.cnpg.postgresPassword: my-cnpg-password
+    asserts:
+      - equal:
+          path: stringData.password
+          value: my-cnpg-password
+
+  - it: generates an altinity clickhouse password on install
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-clickhouse-altinity
+    set:
+      clickhouseOperator.altinity.enabled: true
+    asserts:
+      - matchRegex:
+          path: stringData.admin-password
+          pattern: "^[a-zA-Z0-9]{32}$"
+
+  - it: uses the supplied altinity clickhouse password
+    documentSelector:
+      path: metadata.name
+      value: oneuptime-clickhouse-altinity
+    set:
+      clickhouseOperator.altinity.enabled: true
+      clickhouseOperator.altinity.auth.password: my-altinity-password
+    asserts:
+      - equal:
+          path: stringData.admin-password
+          value: my-altinity-password
+
+  - it: drops the chart-managed redis secret when the in-cluster redis is disabled
+    set:
+      redis.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 4
+      - documentSelector:
+          path: metadata.name
+          value: oneuptime-secrets
+        isKind:
+          of: Secret
+      - documentSelector:
+          path: metadata.name
+          value: oneuptime-external-redis
+        isKind:
+          of: Secret
+      - documentSelector:
+          path: metadata.name
+          value: oneuptime-postgresql
+        isKind:
+          of: Secret
+      - documentSelector:
+          path: metadata.name
+          value: oneuptime-clickhouse
+        isKind:
+          of: Secret

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -45,7 +45,9 @@ encryptionSecret:
 ipWhitelist:
 
 # External Secrets
-# You need to leave blank oneuptimeSecret, encryptionSecret, and registerProbeKey to use this section
+# You need to leave blank oneuptimeSecret, encryptionSecret, and registerProbeKey to use this section.
+# Anything configured here is read straight from your own Secret: the chart does NOT
+# write a copy of it into the chart-managed `<release>-secrets` Secret.
 externalSecrets:
   oneuptimeSecret:
     existingSecret:

--- a/HelmChart/README.md
+++ b/HelmChart/README.md
@@ -13,8 +13,15 @@ helm plugin install https://github.com/helm-unittest/helm-unittest
 npm run test-helm-chart
 ```
 
-`HelmChart/Tests/index.sh` is the separate end-to-end job: it spins up a KinD
-cluster, installs the chart for real and waits for every pod to become ready.
+Two suites need a real API server and live in `HelmChart/Tests` instead:
+
+- `secrets-lifecycle.sh` — installs and upgrades the chart on a throwaway KinD
+  cluster to cover the `lookup` recovery path in `templates/secrets.yaml`
+  (an upgrade must not rotate a secret it already generated), which renders
+  empty and so cannot be asserted on without a cluster. It pulls no images and
+  also runs on every PR.
+- `index.sh` — the full end-to-end job: installs the chart for real and waits
+  for every pod to become ready.
 
 ## Database migration guides
 

--- a/HelmChart/README.md
+++ b/HelmChart/README.md
@@ -2,6 +2,20 @@
 
 [Read Docs here](Public/oneuptime/README.md)
 
+## Tests
+
+Chart unit tests live in [`Public/oneuptime/tests`](Public/oneuptime/tests) and
+run on every PR. They render the templates with `helm template` under the hood
+and assert on the result, so they need no cluster:
+
+```
+helm plugin install https://github.com/helm-unittest/helm-unittest
+npm run test-helm-chart
+```
+
+`HelmChart/Tests/index.sh` is the separate end-to-end job: it spins up a KinD
+cluster, installs the chart for real and waits for every pod to become ready.
+
 ## Database migration guides
 
 Moving an existing install from a standalone database to its bundled operator:

--- a/HelmChart/Tests/secrets-lifecycle.sh
+++ b/HelmChart/Tests/secrets-lifecycle.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cluster-backed lifecycle tests for the chart's Secret handling.
+#
+# The helm-unittest suites under HelmChart/Public/oneuptime/tests render without
+# a cluster, which means `lookup` always comes back empty and only the
+# "regenerate" leg of templates/secrets.yaml is ever exercised. The behaviour
+# that file exists to provide is the opposite one: an upgrade must NOT change a
+# secret it already generated. That needs a real API server, so it lives here.
+#
+# Covered:
+#   1. helm upgrade preserves every chart-generated secret byte for byte
+#      (the `lookup` -> `index $existingSecretData` recovery path).
+#   2. Values that YAML would mangle survive the recovery path (the `| quote`s).
+#   3. With externalSecrets configured, the chart-managed Secret carries no copy
+#      of those keys, and pods read them from the user's own Secret instead.
+#      https://github.com/OneUptime/oneuptime/issues/3121
+#   4. Switching back to chart-managed secrets does not rotate anything.
+#   5. The datastore secrets (redis / postgres / clickhouse) survive upgrades.
+#
+# No container images are pulled: the release is installed without --wait and
+# without hooks, so only the manifests have to apply.
+
+CLUSTER_NAME="${CLUSTER_NAME:-oneuptime-secrets-lifecycle}"
+NAMESPACE="${NAMESPACE:-oneuptime-secrets-test}"
+RELEASE="${RELEASE:-ou}"
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../Public/oneuptime" && pwd)"
+KEEP_CLUSTER="${KEEP_CLUSTER:-false}"
+
+FAILURES=0
+PASSES=0
+
+pass() {
+    PASSES=$((PASSES + 1))
+    echo "  PASS: $1"
+}
+
+fail() {
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $1"
+}
+
+assert_eq() {
+    # assert_eq <description> <expected> <actual>
+    if [ "$2" = "$3" ]; then
+        pass "$1"
+    else
+        fail "$1"
+        echo "        expected: [$2]"
+        echo "        actual:   [$3]"
+    fi
+}
+
+assert_absent() {
+    # assert_absent <description> <haystack> <needle>
+    if echo "$2" | grep -q -- "$3"; then
+        fail "$1 (found '$3')"
+    else
+        pass "$1"
+    fi
+}
+
+assert_present() {
+    # assert_present <description> <haystack> <needle>
+    if echo "$2" | grep -q -- "$3"; then
+        pass "$1"
+    else
+        fail "$1 (missing '$3')"
+    fi
+}
+
+# Reads one key out of a Secret and prints its decoded value. Prints nothing
+# when the key is absent.
+secret_value() {
+    # secret_value <secret-name> <key>
+    kubectl -n "$NAMESPACE" get secret "$1" -o "jsonpath={.data.$2}" 2>/dev/null | base64 --decode 2>/dev/null || true
+}
+
+secret_keys() {
+    # secret_keys <secret-name>
+    kubectl -n "$NAMESPACE" get secret "$1" -o jsonpath='{range $.data.*}{""}{end}{.data}' 2>/dev/null |
+        tr ',' '\n' | sed 's/[{}"]//g' | cut -d: -f1 | sed 's/^ *//' | sort
+}
+
+# Base values every helm command in this script shares. Keda is off so the
+# subchart CRDs are not needed; hooks are off so nothing waits on a Job.
+helm_args() {
+    echo "--namespace $NAMESPACE --no-hooks --set keda.enabled=false"
+}
+
+EXTERNAL_ARGS=(
+    --set externalSecrets.oneuptimeSecret.existingSecret.name=one-uptime
+    --set externalSecrets.oneuptimeSecret.existingSecret.passwordKey=one-uptime-secret
+    --set externalSecrets.encryptionSecret.existingSecret.name=one-uptime
+    --set externalSecrets.encryptionSecret.existingSecret.passwordKey=encryption-secret
+    --set externalSecrets.registerProbeKey.existingSecret.name=one-uptime
+    --set externalSecrets.registerProbeKey.existingSecret.passwordKey=register-probe-key
+)
+
+# Prints the chart-managed Secret document out of a rendered manifest. Written
+# without awk's `exit` on purpose: exiting mid-stream closes the pipe and, under
+# `set -o pipefail`, kills the whole script with a broken-pipe error.
+extract_chart_secret() {
+    awk -v n="  name: ${CHART_SECRET}" '
+        $0 == "---" { inblock = 0 }
+        $0 == n     { inblock = 1 }
+        inblock     { print }
+    '
+}
+
+cleanup() {
+    if [ "$KEEP_CLUSTER" = "true" ]; then
+        echo "KEEP_CLUSTER=true, leaving cluster ${CLUSTER_NAME} running."
+        return
+    fi
+    echo "Deleting KinD cluster ${CLUSTER_NAME}..."
+    kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "Chart: $CHART_DIR"
+
+if ! command -v kubectl >/dev/null 2>&1; then
+    echo "Installing kubectl..."
+    curl -sSL -o kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -sSL https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
+    sudo install -m 0755 kubectl /usr/local/bin/kubectl
+    rm -f kubectl
+fi
+
+if ! command -v kind >/dev/null 2>&1; then
+    echo "Installing kind..."
+    curl -sSL -o kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+    sudo install -m 0755 kind /usr/local/bin/kind
+    rm -f kind
+fi
+
+if ! command -v helm >/dev/null 2>&1; then
+    echo "Installing Helm..."
+    curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+fi
+
+if ! kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+    echo "Creating KinD cluster ${CLUSTER_NAME}..."
+    kind create cluster --name "$CLUSTER_NAME" --wait 180s
+fi
+kubectl config use-context "kind-${CLUSTER_NAME}" >/dev/null
+kubectl create namespace "$NAMESPACE" >/dev/null 2>&1 || true
+
+CHART_SECRET="${RELEASE}-secrets"
+
+echo
+echo "=== install ==="
+# shellcheck disable=SC2046
+helm install "$RELEASE" "$CHART_DIR" $(helm_args) >/dev/null
+echo "installed"
+
+ONEUPTIME_SECRET_0=$(secret_value "$CHART_SECRET" 'oneuptime-secret')
+ENCRYPTION_SECRET_0=$(secret_value "$CHART_SECRET" 'encryption-secret')
+REGISTER_PROBE_KEY_0=$(secret_value "$CHART_SECRET" 'register-probe-key')
+PROBE_KEY_0=$(secret_value "$CHART_SECRET" 'probe-one')
+RUNNER_KEY_0=$(secret_value "$CHART_SECRET" 'runner-key')
+REDIS_0=$(secret_value "${RELEASE}-redis" 'redis-password')
+POSTGRES_0=$(secret_value "${RELEASE}-postgresql" 'postgres-password')
+CLICKHOUSE_0=$(secret_value "${RELEASE}-clickhouse" 'admin-password')
+
+echo
+echo "=== 1. a fresh install generates every chart-managed secret ==="
+for pair in "oneuptime-secret:$ONEUPTIME_SECRET_0" "encryption-secret:$ENCRYPTION_SECRET_0" \
+    "register-probe-key:$REGISTER_PROBE_KEY_0" "probe-one:$PROBE_KEY_0" "runner-key:$RUNNER_KEY_0" \
+    "redis-password:$REDIS_0" "postgres-password:$POSTGRES_0" "admin-password:$CLICKHOUSE_0"; do
+    name="${pair%%:*}"
+    value="${pair#*:}"
+    if [ ${#value} -eq 32 ]; then
+        pass "$name generated (32 chars)"
+    else
+        fail "$name should be a 32 char generated value, got ${#value} chars"
+    fi
+done
+
+echo
+echo "=== 2. an upgrade preserves every chart-managed secret ==="
+# shellcheck disable=SC2046
+helm upgrade "$RELEASE" "$CHART_DIR" $(helm_args) >/dev/null
+assert_eq "oneuptime-secret unchanged" "$ONEUPTIME_SECRET_0" "$(secret_value "$CHART_SECRET" 'oneuptime-secret')"
+assert_eq "encryption-secret unchanged" "$ENCRYPTION_SECRET_0" "$(secret_value "$CHART_SECRET" 'encryption-secret')"
+assert_eq "register-probe-key unchanged" "$REGISTER_PROBE_KEY_0" "$(secret_value "$CHART_SECRET" 'register-probe-key')"
+assert_eq "probe-one unchanged" "$PROBE_KEY_0" "$(secret_value "$CHART_SECRET" 'probe-one')"
+assert_eq "runner-key unchanged" "$RUNNER_KEY_0" "$(secret_value "$CHART_SECRET" 'runner-key')"
+assert_eq "redis-password unchanged" "$REDIS_0" "$(secret_value "${RELEASE}-redis" 'redis-password')"
+assert_eq "postgres-password unchanged" "$POSTGRES_0" "$(secret_value "${RELEASE}-postgresql" 'postgres-password')"
+assert_eq "clickhouse admin-password unchanged" "$CLICKHOUSE_0" "$(secret_value "${RELEASE}-clickhouse" 'admin-password')"
+
+echo
+echo "=== 3. values YAML would mangle survive the recovery path ==="
+# Every one of these breaks or silently changes when a recovered value is
+# emitted into stringData unquoted.
+HOSTILE_ONEUPTIME='abc # not-a-comment'
+HOSTILE_ENCRYPTION='*alias-looking'
+HOSTILE_REGISTER='key: value'
+HOSTILE_PROBE='  padded  '
+HOSTILE_RUNNER='true'
+HOSTILE_REDIS='0123456789'
+patch_secret_value() {
+    # patch_secret_value <secret> <key> <raw value>
+    local encoded
+    encoded=$(printf '%s' "$3" | base64 | tr -d '\n')
+    kubectl -n "$NAMESPACE" patch secret "$1" --type=json \
+        -p "[{\"op\":\"replace\",\"path\":\"/data/$2\",\"value\":\"$encoded\"}]" >/dev/null
+}
+patch_secret_value "$CHART_SECRET" 'oneuptime-secret' "$HOSTILE_ONEUPTIME"
+patch_secret_value "$CHART_SECRET" 'encryption-secret' "$HOSTILE_ENCRYPTION"
+patch_secret_value "$CHART_SECRET" 'register-probe-key' "$HOSTILE_REGISTER"
+patch_secret_value "$CHART_SECRET" 'probe-one' "$HOSTILE_PROBE"
+patch_secret_value "$CHART_SECRET" 'runner-key' "$HOSTILE_RUNNER"
+patch_secret_value "${RELEASE}-redis" 'redis-password' "$HOSTILE_REDIS"
+
+# shellcheck disable=SC2046
+if helm upgrade "$RELEASE" "$CHART_DIR" $(helm_args) >/dev/null 2>/tmp/hostile-upgrade.log; then
+    pass "upgrade renders with YAML-hostile stored values"
+else
+    fail "upgrade failed on YAML-hostile stored values"
+    cat /tmp/hostile-upgrade.log
+fi
+assert_eq "'$HOSTILE_ONEUPTIME' round-trips" "$HOSTILE_ONEUPTIME" "$(secret_value "$CHART_SECRET" 'oneuptime-secret')"
+assert_eq "'$HOSTILE_ENCRYPTION' round-trips" "$HOSTILE_ENCRYPTION" "$(secret_value "$CHART_SECRET" 'encryption-secret')"
+assert_eq "'$HOSTILE_REGISTER' round-trips" "$HOSTILE_REGISTER" "$(secret_value "$CHART_SECRET" 'register-probe-key')"
+assert_eq "'$HOSTILE_PROBE' round-trips" "$HOSTILE_PROBE" "$(secret_value "$CHART_SECRET" 'probe-one')"
+assert_eq "'$HOSTILE_RUNNER' round-trips" "$HOSTILE_RUNNER" "$(secret_value "$CHART_SECRET" 'runner-key')"
+assert_eq "'$HOSTILE_REDIS' round-trips" "$HOSTILE_REDIS" "$(secret_value "${RELEASE}-redis" 'redis-password')"
+
+# Put the generated values back so the rest of the script reads normally.
+patch_secret_value "$CHART_SECRET" 'oneuptime-secret' "$ONEUPTIME_SECRET_0"
+patch_secret_value "$CHART_SECRET" 'encryption-secret' "$ENCRYPTION_SECRET_0"
+patch_secret_value "$CHART_SECRET" 'register-probe-key' "$REGISTER_PROBE_KEY_0"
+patch_secret_value "$CHART_SECRET" 'probe-one' "$PROBE_KEY_0"
+patch_secret_value "$CHART_SECRET" 'runner-key' "$RUNNER_KEY_0"
+patch_secret_value "${RELEASE}-redis" 'redis-password' "$REDIS_0"
+
+echo
+echo "=== 4. externalSecrets: the chart stops managing those keys (issue 3121) ==="
+# shellcheck disable=SC2046
+helm upgrade "$RELEASE" "$CHART_DIR" $(helm_args) "${EXTERNAL_ARGS[@]}" >/dev/null
+MANIFEST=$(helm get manifest "$RELEASE" -n "$NAMESPACE")
+CHART_SECRET_MANIFEST=$(echo "$MANIFEST" | extract_chart_secret)
+assert_absent "release manifest has no oneuptime-secret" "$CHART_SECRET_MANIFEST" "oneuptime-secret:"
+assert_absent "release manifest has no encryption-secret" "$CHART_SECRET_MANIFEST" "encryption-secret:"
+assert_absent "release manifest has no register-probe-key" "$CHART_SECRET_MANIFEST" "register-probe-key:"
+assert_present "release manifest still has probe-one" "$CHART_SECRET_MANIFEST" "probe-one:"
+assert_present "release manifest still has runner-key" "$CHART_SECRET_MANIFEST" "runner-key:"
+
+# Rendering the same release twice must produce an identical Secret: that is the
+# churn the issue reported.
+render_chart_secret() {
+    # shellcheck disable=SC2046
+    helm upgrade "$RELEASE" "$CHART_DIR" $(helm_args) "${EXTERNAL_ARGS[@]}" --dry-run 2>/dev/null |
+        extract_chart_secret |
+        grep -E 'oneuptime-secret:|encryption-secret:|register-probe-key:' || true
+}
+assert_eq "repeated renders emit no externally served key" "" "$(render_chart_secret)$(render_chart_secret)"
+
+# The pods have to be reading them from the user's Secret instead.
+APP_ENV=$(kubectl -n "$NAMESPACE" get deploy "${RELEASE}-app" -o json |
+    tr -d ' \n' | tr '}' '\n')
+assert_present "app ONEUPTIME_SECRET points at the external secret" "$APP_ENV" '"key":"one-uptime-secret","name":"one-uptime"'
+assert_present "app ENCRYPTION_SECRET points at the external secret" "$APP_ENV" '"key":"encryption-secret","name":"one-uptime"'
+assert_present "app REGISTER_PROBE_KEY points at the external secret" "$APP_ENV" '"key":"register-probe-key","name":"one-uptime"'
+PROBE_ENV=$(kubectl -n "$NAMESPACE" get deploy "${RELEASE}-probe-one" -o json | tr -d ' \n' | tr '}' '\n')
+assert_present "probe PROBE_KEY still points at the chart secret" "$PROBE_ENV" "\"key\":\"probe-one\",\"name\":\"${CHART_SECRET}\""
+
+# The chart still owns probe/runner keys, so they must not have been rotated.
+assert_eq "probe-one preserved while externalSecrets is on" "$PROBE_KEY_0" "$(secret_value "$CHART_SECRET" 'probe-one')"
+assert_eq "runner-key preserved while externalSecrets is on" "$RUNNER_KEY_0" "$(secret_value "$CHART_SECRET" 'runner-key')"
+
+echo
+echo "=== 5. switching back to chart-managed secrets rotates nothing ==="
+# shellcheck disable=SC2046
+helm upgrade "$RELEASE" "$CHART_DIR" $(helm_args) >/dev/null
+assert_eq "oneuptime-secret recovered" "$ONEUPTIME_SECRET_0" "$(secret_value "$CHART_SECRET" 'oneuptime-secret')"
+assert_eq "encryption-secret recovered" "$ENCRYPTION_SECRET_0" "$(secret_value "$CHART_SECRET" 'encryption-secret')"
+assert_eq "register-probe-key recovered" "$REGISTER_PROBE_KEY_0" "$(secret_value "$CHART_SECRET" 'register-probe-key')"
+APP_ENV=$(kubectl -n "$NAMESPACE" get deploy "${RELEASE}-app" -o json | tr -d ' \n' | tr '}' '\n')
+assert_present "app ONEUPTIME_SECRET points back at the chart secret" "$APP_ENV" "\"key\":\"oneuptime-secret\",\"name\":\"${CHART_SECRET}\""
+
+echo
+echo "=== 6. a fresh install with externalSecrets never generates the keys ==="
+helm uninstall "$RELEASE" -n "$NAMESPACE" >/dev/null 2>&1 || true
+kubectl -n "$NAMESPACE" delete secret "$CHART_SECRET" "${RELEASE}-redis" "${RELEASE}-postgresql" "${RELEASE}-clickhouse" >/dev/null 2>&1 || true
+# shellcheck disable=SC2046
+helm install "$RELEASE" "$CHART_DIR" $(helm_args) "${EXTERNAL_ARGS[@]}" >/dev/null
+KEYS=$(secret_keys "$CHART_SECRET")
+assert_absent "install does not create oneuptime-secret" "$KEYS" "oneuptime-secret"
+assert_absent "install does not create encryption-secret" "$KEYS" "encryption-secret"
+assert_absent "install does not create register-probe-key" "$KEYS" "register-probe-key"
+assert_present "install still creates probe-one" "$KEYS" "probe-one"
+assert_present "install still creates runner-key" "$KEYS" "runner-key"
+
+echo
+echo "======================================================================"
+echo "  ${PASSES} passed, ${FAILURES} failed"
+echo "======================================================================"
+[ "$FAILURES" -eq 0 ]

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "auth-prod": "gcloud container clusters get-credentials gke-prod-cluster --zone us-central1-a --project oneuptime-k8s",
         "deploy-test": "gcloud container clusters get-credentials gke-test-cluster --zone us-central1-a --project oneuptime-k8s && kubectl config use-context gke_oneuptime-k8s_us-central1-a_gke-test-cluster && helm upgrade oneuptime ./HelmChart/Public/oneuptime -f ./HelmChart/Public/oneuptime/values.yaml  -f ./HelmChart/Values/test.values.yaml",
         "template-deploy-test": "kubectl config use-context oneuptime-test && helm template  oneuptime ./HelmChart/Public/oneuptime -f ./HelmChart/Public/oneuptime/values.yaml  -f ./HelmChart/Values/test.values.yaml --debug",
+        "test-helm-chart": "helm unittest ./HelmChart/Public/oneuptime",
         "deploy-prod": "gcloud container clusters get-credentials gke-prod-cluster --zone us-central1-a --project oneuptime-k8s && kubectl config use-context gke_oneuptime-k8s_us-central1-a_gke-prod-cluster && helm upgrade oneuptime ./HelmChart/Public/oneuptime -f ./HelmChart/Public/oneuptime/values.yaml  -f ./HelmChart/Values/gke.prod.values.yaml",
         "generate-postgres-migration": "export $(grep -v '^#' config.env | xargs) && node --require ts-node/register ./node_modules/typeorm/cli.js migration:generate ./Common/Server/Infrastructure/Postgres/SchemaMigrations/MigrationName -d ./Common/Server/Infrastructure/Postgres/LocalMigrationGenerationDataSource.ts",
         "check-postgres-schema-drift": "bash ./Scripts/Postgres/CheckSchemaDrift.sh",


### PR DESCRIPTION
Fixes #3121

## Problem

`templates/secrets.yaml` generated `oneuptime-secret`, `register-probe-key` and `encryption-secret` into the chart-managed `<release>-secrets` Secret unconditionally — including when `externalSecrets.<key>.existingSecret.name` had already pointed every consumer at a user-managed Secret. Those values were never read, and since they come from `randAlphaNum` each render produced different ones, so every `helm diff` / `helm upgrade` reported the three secrets as being rotated.

Reproduced against `master` — rendering the same values twice with all three secrets external:

```
15,17c15,17
<   oneuptime-secret: "PlWxpCcRahyiQS0VSo79ngkmARN9IWQz"
<   register-probe-key: "h14taasvSJm3zFVzbH1wuvd2XJsDos3J"
<   encryption-secret: "dQur0RmMu1lu3btQCd2akGQl9NEew1cB"
---
>   oneuptime-secret: "RNzzS4za6djwFsw2CEOJCkgcWn1S9Ztw"
>   register-probe-key: "ot4ZomDLNBA7vSUPvxSY8hCRhfZGDHdX"
>   encryption-secret: "nTkSUZnqDvvdGLDu9WWoceK9HleMOzYV"
```

With this branch the same two renders are byte-identical.

## Fix

Skip the key entirely when `externalSecrets` serves it, on both the install and upgrade paths. An explicit `.Values.oneuptimeSecret` / `.Values.encryptionSecret` / `.Values.registerProbeKey` still wins over `externalSecrets`, matching the precedence the env helpers in `_helpers.tpl` already use.

Related robustness fixes in the same file, all reachable from this change:

- Each Secret now looks its previous self up **once** and guards `.data` with `default dict`. The upgrade branch dereferenced a nil `.data` map, so *any* client-side upgrade render hard-failed with `index of untyped nil` — `helm template --is-upgrade` on `master` errors outright.
- Values recovered from an existing Secret are now quoted. Unquoted, a stored value like `abc # x` was silently truncated to `abc`, and `key: value` was a YAML parse error.
- The `externalSecrets` reads in `_helpers.tpl` are nil-safe, so a values file with an empty `externalSecrets:` block renders instead of erroring with `nil pointer evaluating interface {}.encryptionSecret`.

## Verification on a real cluster

The change was re-checked end to end on a KinD cluster (k8s 1.30), not just by rendering:

- A real `helm upgrade` preserves all eight chart-generated secrets byte for byte.
- With `externalSecrets` set, the release manifest carries no copy of the three keys, and the live `app` Deployment reads them from `one-uptime` while the probe still reads `probe-one` from `<release>-secrets`.
- Switching back to chart-managed secrets rotates nothing.

One finding from that: **the stale copies are not removed from the live Secret.** Helm patches `stringData`, the API server has already folded the old values into `data`, so dropping a key from the template does not delete it from the object. An earlier revision of this PR claimed the opposite; `docs/configuration.md` now documents the real behaviour, the `kubectl patch` cleanup, and why keeping the copies is usually the safer choice.

## Tests

**66 helm-unittest tests**, four suites under `HelmChart/Public/oneuptime/tests`, no cluster needed:

- `secrets-external-secrets_test.yaml` — the regression itself: each key individually and all three together, install and upgrade, inline-value precedence, an empty `externalSecrets` block, `externalSecrets: null`, a nil at any single level of the accessor chain, and inline values that YAML would coerce (`"true"`, `"0123456"`) or mangle (`abc # x`, `key: value`, `*alias`).
- `external-secrets-env_test.yaml` — the other half of the contract: app / worker / probe / runner / nginx / migrate-job env and the KEDA `TriggerAuthentication` read from the external Secret, so the generator and its consumers cannot drift apart.
- `secrets-generation_test.yaml` — everything the chart still generates, install *and* upgrade: probe keys, runner key, redis / postgres / cnpg / clickhouse / altinity, and the external-datastore secrets.
- `helm-test-hook_test.yaml` — guards `templates/tests/test.yaml` (see below).

**44 cluster-backed assertions** in `HelmChart/Tests/secrets-lifecycle.sh`. The unit suites render without an API server, so `lookup` is always empty and only the "regenerate" leg of `secrets.yaml` is reachable — the behaviour the file exists to provide is the opposite one. This script installs and upgrades the chart for real on a throwaway KinD cluster (no images pulled: no `--wait`, no hooks) and asserts the preservation path, the `| quote` round-trip through six YAML-hostile stored values, the externalSecrets manifest and pod wiring, the switch-back, and a fresh install with `externalSecrets`.

Both run on every PR: `helm-unit-test` and `helm-secrets-lifecycle-test` in Common Jobs, next to `helm lint`.

```bash
npm run test-helm-chart
```

Verified the suites are not vacuous: against `master`'s templates 24 fail and 18 error.

## Self-review found and fixed one regression in this PR

The first revision added an unanchored `tests/` line to `.helmignore`. Helm matches an unanchored pattern by base name at any depth, so it also matched `templates/tests/` and silently dropped the chart's `helm test` hook Pod from every render and every packaged chart. Anchored to `/tests/`, and `helm-test-hook_test.yaml` now renders that template so it cannot go missing unnoticed again.

## Noted, not fixed here

- `templates/keda-scaledobjects.yaml` calls `oneuptime.kedaScaledObject` five times with no `---` between the includes, so each `TriggerAuthentication` is glued into the following `ScaledObject` document and only the last one survives. Pre-existing on `master`, unrelated to this issue.
- `existingSecret.name` without `passwordKey` renders an empty `secretKeyRef.key`, which the API server rejects. Identical on `master`, and the same gap exists for `redis.auth.existingSecret` and `clickhouse.auth.existingSecret` — a chart-wide convention gap rather than something this fix owns.
- `postgresql.auth.password` is referenced by `secrets.yaml` but rejected by `values.schema.json`, so those two branches are unreachable.
- `<release>-secrets` carries `helm.sh/resource-policy: keep`, so it survives `helm uninstall`. On the next install the chart recovers `probe-*` keys from it but *not* `oneuptime-secret` / `encryption-secret` / `register-probe-key`, so an uninstall/reinstall rotates `ENCRYPTION_SECRET` — and existing encrypted data stops being readable — while probe keys carry over. Byte-for-byte identical on `master`, and adopting a stale encryption secret on a fresh install is a real trade-off rather than an obvious bug, so it is a maintainer call.
