### PR TITLE
fix(security): close the 10 remaining SSRF sinks outside the workflow engine

### DIFF
--- a/App/FeatureSet/Identity/Utils/OIDC.ts
+++ b/App/FeatureSet/Identity/Utils/OIDC.ts
@@ -3,7 +3,87 @@ import Email from "Common/Types/Email";
 import Name from "Common/Types/Name";
 import BadRequestException from "Common/Types/Exception/BadRequestException";
 import { JSONObject } from "Common/Types/JSON";
-import { Issuer, Client, generators, TokenSet } from "openid-client";
+import { Issuer, Client, custom, generators, TokenSet } from "openid-client";
+import DataSourceEgressGuard, {
+  AddressVerdict,
+  EgressLookupFunction,
+} from "Common/Server/Utils/DataSource/EgressGuard";
+import BadDataException from "Common/Types/Exception/BadDataException";
+import net, { LookupFunction } from "net";
+
+const OIDC_EGRESS_LABEL: string = "OIDC provider";
+
+/*
+ * Put the egress guard on every socket openid-client opens.
+ *
+ * Validating discoveryURL on its own would be theatre: Issuer.discover fetches
+ * a document from that URL and then adopts the authorization_endpoint,
+ * token_endpoint, userinfo_endpoint and jwks_uri IT declares. Those are the
+ * URLs that carry the client secret and the access token, and they are chosen
+ * by the fetched document — that is, by whoever controls the tenant-writable
+ * discovery URL. A guard has to sit where the connection is made, not where
+ * the first URL is configured.
+ *
+ * It takes two hooks, because they cover different hosts:
+ *
+ *  - `lookup` is where a HOSTNAME is resolved. setHttpOptionsDefaults is
+ *    process-wide and openid-client passes lookup straight to https.request,
+ *    so every discovery, token, userinfo and JWKS request resolves through the
+ *    guard and then connects to the address that was actually checked, with no
+ *    rebind window in between.
+ *
+ *  - a literal IP never reaches `lookup` at all — Node skips resolution when
+ *    the host is already an address — so "http://169.254.169.254/..." would
+ *    sail straight past a lookup-only guard. custom.http_options runs per
+ *    request with the parsed URL in hand, which is where those are caught.
+ *
+ * Private ranges stay reachable on self-hosted installs, where the identity
+ * provider is often on the same private network; loopback, link-local and the
+ * rest are refused everywhere.
+ */
+const egressGuardedLookup: EgressLookupFunction =
+  DataSourceEgressGuard.createGuardedLookup({
+    targetLabel: OIDC_EGRESS_LABEL,
+  });
+
+custom.setHttpOptionsDefaults({
+  lookup: egressGuardedLookup as unknown as LookupFunction,
+});
+
+type HttpOptionsHook = (
+  url: globalThis.URL,
+  options: Record<string, unknown>,
+) => Record<string, unknown>;
+
+const guardLiteralHost: HttpOptionsHook = (
+  url: globalThis.URL,
+  options: Record<string, unknown>,
+): Record<string, unknown> => {
+  const host: string = url.hostname.replace(/^\[|\]$/g, "");
+
+  // A name — `lookup` validates it, with DNS, when the socket opens.
+  if (net.isIP(host) === 0) {
+    return options;
+  }
+
+  const verdict: AddressVerdict = DataSourceEgressGuard.checkAddress(host);
+
+  if (verdict.blocked) {
+    throw new BadDataException(
+      `${OIDC_EGRESS_LABEL} host ${host} is not allowed: ${verdict.reason}.`,
+    );
+  }
+
+  return options;
+};
+
+/*
+ * The hook is read off whichever object made the request, so it has to be
+ * installed on each: the Issuer class for discovery, the issuer instance for
+ * JWKS, and the client for the token and userinfo calls.
+ */
+(Issuer as unknown as Record<symbol, HttpOptionsHook>)[custom.http_options] =
+  guardLiteralHost;
 
 export interface OidcClientConfig {
   discoveryURL: URL;
@@ -26,12 +106,27 @@ export default class OIDCUtil {
       config.discoveryURL.toString(),
     );
 
-    return new issuer.Client({
+    // JWKS fetches go through the issuer instance, not the class.
+    (issuer as unknown as Record<symbol, HttpOptionsHook>)[
+      custom.http_options
+    ] = guardLiteralHost;
+
+    const client: Client = new issuer.Client({
       client_id: config.clientId,
       client_secret: config.clientSecret,
       redirect_uris: [config.redirectUri.toString()],
       response_types: ["code"],
     });
+
+    /*
+     * Token and userinfo go through the client — and their URLs came out of
+     * the discovery document, so this is the hook that matters most.
+     */
+    (client as unknown as Record<symbol, HttpOptionsHook>)[
+      custom.http_options
+    ] = guardLiteralHost;
+
+    return client;
   }
 
   public static generateAuthorizationUrl(data: {
@@ -103,8 +198,14 @@ export default class OIDCUtil {
     // If email/name not in ID token claims, fall back to userinfo endpoint.
     if (!emailValue || !nameValue) {
       try {
+        /*
+         * Pass the TokenSet, not the bare access_token string. openid-client
+         * only applies the token_type and the DPoP/at_hash checks tied to the
+         * issued token when it is handed the whole set; with a raw string it
+         * falls back to a plain Bearer request.
+         */
         const userInfo: JSONObject = (await data.client.userinfo(
-          tokenSet.access_token!,
+          tokenSet,
         )) as unknown as JSONObject;
 
         if (!emailValue) {

--- a/App/FeatureSet/Notification/API/SMTPConfig.ts
+++ b/App/FeatureSet/Notification/API/SMTPConfig.ts
@@ -22,6 +22,8 @@ import logger, {
 import Response from "Common/Server/Utils/Response";
 import UserMiddleware from "Common/Server/Middleware/UserAuthorization";
 import ProjectSmtpConfig from "Common/Models/DatabaseModels/ProjectSmtpConfig";
+import CommonAPI from "Common/Server/API/CommonAPI";
+import DatabaseCommonInteractionProps from "Common/Types/BaseDatabase/DatabaseCommonInteractionProps";
 
 const router: ExpressRouter = Express.getRouter();
 
@@ -36,6 +38,21 @@ router.post(
       const smtpConfigId: ObjectID = new ObjectID(
         body["smtpConfigId"] as string,
       );
+
+      /*
+       * The lookup below runs as root so it can read the SMTP secrets, which
+       * means the id in the body is otherwise honoured whoever it belongs to:
+       * any authenticated user could name another project's config id and have
+       * the server connect to that project's mail server (and, with a
+       * hostile-but-valid config, learn whether it works). Establish which
+       * project the caller is authorized for first, then confirm the config
+       * they named is actually in it.
+       */
+      const props: DatabaseCommonInteractionProps =
+        await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+      const projectId: ObjectID =
+        CommonAPI.assertAuthenticatedProjectMember(props);
 
       const config: ProjectSmtpConfig | null =
         await ProjectSMTPConfigService.findOneById({
@@ -72,6 +89,11 @@ router.post(
           ),
         );
       }
+
+      CommonAPI.assertResourceBelongsToProject({
+        resourceProjectId: config.projectId,
+        projectId: projectId,
+      });
 
       const toEmail: Email = new Email(body["toEmail"] as string);
 

--- a/App/FeatureSet/Notification/Services/MailService.ts
+++ b/App/FeatureSet/Notification/Services/MailService.ts
@@ -29,6 +29,7 @@ import LocalCache from "Common/Server/Infrastructure/LocalCache";
 import EmailLogService from "Common/Server/Services/EmailLogService";
 import UserOnCallLogTimelineService from "Common/Server/Services/UserOnCallLogTimelineService";
 import logger from "Common/Server/Utils/Logger";
+import DataSourceEgressGuard from "Common/Server/Utils/DataSource/EgressGuard";
 import AppMetrics from "Common/Server/Utils/Telemetry/AppMetrics";
 import EmailLog from "Common/Models/DatabaseModels/EmailLog";
 import { EmailServerType } from "Common/Models/DatabaseModels/GlobalConfig";
@@ -39,8 +40,11 @@ import SMTPTransport from "nodemailer/lib/smtp-transport";
 import Path from "path";
 import * as tls from "tls";
 
-// Connection pool for email transporters
-class TransporterPool {
+/*
+ * Connection pool for email transporters
+ * Exported so the SSRF guard on tenant-supplied SMTP hosts can be tested.
+ */
+export class TransporterPool {
   private static pools: Map<string, Transporter> = new Map();
   private static semaphore: Map<string, number> = new Map();
   private static readonly MAX_CONCURRENT_CONNECTIONS = 100;
@@ -98,10 +102,49 @@ class TransporterPool {
     return `${host}:${portNumber}:${username}:${mode}:${authType}`;
   }
 
+  /*
+   * Validate the SMTP host of a PROJECT-supplied mail server before dialing
+   * it.
+   *
+   * hostname/port on ProjectSmtpConfig are free text, and nodemailer reports
+   * what it found on the socket — "Invalid greeting. response=<raw bytes>" —
+   * which MailService stores in EmailLog.statusMessage and shows to the
+   * project. That turns "send a test email" into an internal port scanner
+   * with banner disclosure, so it has to be checked on every connection
+   * rather than on write: rows configured before this existed are still in
+   * the database.
+   *
+   * The GLOBAL mail server is exempt. It is operator-configured, not
+   * tenant-configured (EmailServer.id is set only for project configs), and
+   * pointing it at an internal relay is a normal self-hosted deployment.
+   */
+  private static async assertMailServerHostIsAllowed(
+    emailServer: EmailServer,
+  ): Promise<void> {
+    if (!emailServer.id) {
+      return;
+    }
+
+    if (!emailServer.host) {
+      return;
+    }
+
+    /*
+     * .hostname, not .toString(): the latter re-appends the port, and the
+     * guard resolves what it is given.
+     */
+    await DataSourceEgressGuard.assertHostnameAllowed(
+      emailServer.host.hostname,
+      { targetLabel: "SMTP server" },
+    );
+  }
+
   public static async getTransporter(
     emailServer: EmailServer,
     options: { timeout?: number | undefined },
   ): Promise<Transporter> {
+    await this.assertMailServerHostIsAllowed(emailServer);
+
     /*
      * For OAuth, we need to create a new transporter each time to get fresh tokens
      * The access token has a limited lifetime and needs to be refreshed

--- a/App/FeatureSet/Notification/Services/SMTPOAuthService.ts
+++ b/App/FeatureSet/Notification/Services/SMTPOAuthService.ts
@@ -5,6 +5,7 @@ import { JSONObject } from "Common/Types/JSON";
 import URL from "Common/Types/API/URL";
 import OAuthProviderType from "Common/Types/Email/OAuthProviderType";
 import JSONWebToken from "Common/Server/Utils/JsonWebToken";
+import DataSourceEgressGuard from "Common/Server/Utils/DataSource/EgressGuard";
 
 interface OAuthTokenResponse {
   access_token: string;
@@ -118,6 +119,22 @@ export default class SMTPOAuthService {
     url: string,
     options: RequestInit,
   ): Promise<Response> {
+    /*
+     * tokenUrl comes straight off ProjectSmtpConfig, which any project member
+     * can write, and this request carries the OAuth client_id/client_secret in
+     * its body. The response — status and body — is echoed back through
+     * POST /api/notification/smtp-config/test, so an unvalidated target is a
+     * credential exfiltration channel and a read-capable probe of the internal
+     * network at the same time.
+     *
+     * A self-hosted install may legitimately run its identity provider inside
+     * its own network, so this is the egress guard rather than the flat
+     * private-range ban.
+     */
+    await DataSourceEgressGuard.assertUrlAllowed(url, {
+      targetLabel: "OAuth token URL",
+    });
+
     const controller: AbortController = new AbortController();
     const timeoutId: ReturnType<typeof setTimeout> = setTimeout(() => {
       controller.abort();
@@ -126,6 +143,12 @@ export default class SMTPOAuthService {
     try {
       const response: Response = await fetch(url, {
         ...options,
+        /*
+         * node's fetch follows redirects by default, which would let a
+         * validated host 3xx the credentials on to one that was never
+         * checked. "manual" surfaces the 3xx as a response instead.
+         */
+        redirect: "manual",
         signal: controller.signal,
       });
       return response;

--- a/App/FeatureSet/Runbook/Services/StepExecutors.ts
+++ b/App/FeatureSet/Runbook/Services/StepExecutors.ts
@@ -22,6 +22,7 @@ import RunnerJobService, {
 import RunnerJobStatus from "Common/Types/Runbook/RunnerJobStatus";
 import RunnerJob from "Common/Models/DatabaseModels/RunnerJob";
 import { RunbookStepExecutionState } from "Common/Types/Runbook/RunbookStepExecution";
+import DataSourceEgressGuard from "Common/Server/Utils/DataSource/EgressGuard";
 
 export interface StepRunResult {
   success: boolean;
@@ -243,12 +244,33 @@ export async function runHttpStep(step: RunbookStep): Promise<StepRunResult> {
   }
 
   try {
+    /*
+     * url/method/headers/body come verbatim out of the Runbook's steps JSON,
+     * and the output builder below copies the full status, headers and body
+     * into RunbookExecution.stepExecutions — readable by any project member.
+     * Unguarded, that is a fully attacker-shaped request into whatever network
+     * the Worker runs in, with the response handed straight back (an
+     * attacker-chosen method plus headers is all IMDSv2 asks for).
+     *
+     * So: validate the target and pin the addresses it resolved to, and refuse
+     * redirects — pinning covers only the host that was validated, so a 3xx
+     * would walk around it. maxRedirects rather than doNotFollowRedirects
+     * because this is raw axios, not Common's API wrapper.
+     */
+    const { httpAgent, httpsAgent } =
+      await DataSourceEgressGuard.assertUrlAllowedAndPin(config.url || "", {
+        targetLabel: "Runbook HTTP step",
+      });
+
     const response: AxiosResponse = await axios.request({
       url: config.url,
       method: config.method,
       headers,
       data: parsedBody,
       timeout,
+      maxRedirects: 0,
+      httpAgent,
+      httpsAgent,
       validateStatus: () => {
         return true;
       },

--- a/App/Tests/Identity/OIDC.test.ts
+++ b/App/Tests/Identity/OIDC.test.ts
@@ -34,7 +34,25 @@ import {
 import URL from "Common/Types/API/URL";
 import { JSONObject } from "Common/Types/JSON";
 import { afterEach, describe, expect, test } from "@jest/globals";
-import { Client } from "openid-client";
+import { Client, Issuer, custom } from "openid-client";
+import dns from "dns";
+
+/*
+ * Importing OIDCUtil installs an SSRF egress guard on every openid-client
+ * request: a DNS lookup that refuses loopback, and a per-request hook that
+ * refuses loopback IP literals. This suite's entire design is a real provider
+ * on a 127.0.0.1 socket, so it opts out of both — the guard has its own
+ * coverage in OidcEgressGuard.test.ts. Later defaults win, so this has to run
+ * after the import above.
+ */
+custom.setHttpOptionsDefaults({ lookup: dns.lookup });
+
+function removeEgressGuardHook(target: unknown): void {
+  delete (target as Record<symbol, unknown>)[custom.http_options];
+}
+
+// Discovery reads the hook off the Issuer class.
+removeEgressGuardHook(Issuer);
 
 const CLIENT_ID: string = "0oa1b2c3d4E5F6G7h8i9";
 const CLIENT_SECRET: string = "sUpErSeCrEtClientValue-0123456789";
@@ -72,13 +90,22 @@ async function startIdp(options: StartIdpOptions = {}): Promise<TestIdp> {
 }
 
 async function createClientFor(idp: TestIdp): Promise<Client> {
-  return OIDCUtil.createClient({
+  const client: Client = await OIDCUtil.createClient({
     discoveryURL: URL.fromString(idp.issuerUrl),
     clientId: CLIENT_ID,
     clientSecret: CLIENT_SECRET,
     redirectUri: URL.fromString(REDIRECT_URI),
     scopes: DEFAULT_SCOPES,
   });
+
+  /*
+   * createClient re-installs the hook on the client (token, userinfo) and on
+   * the issuer instance (JWKS); this suite's provider is on loopback.
+   */
+  removeEgressGuardHook(client);
+  removeEgressGuardHook(client.issuer);
+
+  return client;
 }
 
 interface CallbackOverrides {

--- a/App/Tests/Identity/OidcEgressGuard.test.ts
+++ b/App/Tests/Identity/OidcEgressGuard.test.ts
@@ -1,0 +1,114 @@
+import OIDCUtil from "../../FeatureSet/Identity/Utils/OIDC";
+import { TestIdp, startTestIdp } from "./OidcTestIdp";
+import URL from "Common/Types/API/URL";
+import { afterEach, describe, expect, test } from "@jest/globals";
+import dns from "dns";
+
+const CLIENT_ID: string = "0oa1b2c3d4E5F6G7h8i9";
+
+/*
+ * OIDC's discoveryURL is tenant-writable, and pinning that one URL fixes
+ * nothing: Issuer.discover fetches a document and then adopts the
+ * authorization_endpoint, token_endpoint, userinfo_endpoint and jwks_uri THAT
+ * DOCUMENT declares. Those are the requests that carry the client secret and
+ * the access token, and their hosts are chosen by whoever controls the
+ * discovery document. So the guard has to sit on the socket, not on the
+ * configured URL — OIDC.ts installs it as openid-client's DNS lookup, which
+ * covers every request the library makes regardless of which URL it picked.
+ *
+ * Unlike OIDC.test.ts, this file deliberately does NOT restore the stock
+ * resolver: the loopback provider it starts is the thing that must be
+ * refused.
+ */
+
+let idp: TestIdp | undefined = undefined;
+
+afterEach(async () => {
+  jest.restoreAllMocks();
+
+  if (idp) {
+    await idp.close();
+    idp = undefined;
+  }
+});
+
+describe("OIDC discovery is guarded at the socket", () => {
+  test("refuses to discover an issuer on loopback", async () => {
+    idp = await startTestIdp({ clientId: CLIENT_ID });
+
+    /*
+     * Without the guard this resolves: the provider is real and serving a
+     * valid discovery document on 127.0.0.1.
+     */
+    await expect(
+      OIDCUtil.createClient({
+        discoveryURL: URL.fromString(
+          `${idp.issuerUrl}/.well-known/openid-configuration`,
+        ),
+        clientId: CLIENT_ID,
+        clientSecret: "client-secret",
+        redirectUri: URL.fromString("https://oneuptime.example.com/callback"),
+        scopes: "openid email profile",
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("refuses a hostname that resolves to loopback", async () => {
+    idp = await startTestIdp({ clientId: CLIENT_ID });
+
+    const port: string = idp.issuerUrl.split(":")[2] || "";
+
+    // The rebinding shape: a public-looking name, an internal answer.
+    jest
+      .spyOn(dns.promises, "lookup")
+      .mockResolvedValue([
+        { address: "127.0.0.1", family: 4 },
+      ] as unknown as never);
+
+    await expect(
+      OIDCUtil.createClient({
+        discoveryURL: URL.fromString(
+          `http://idp.attacker.example:${port}/.well-known/openid-configuration`,
+        ),
+        clientId: CLIENT_ID,
+        clientSecret: "client-secret",
+        redirectUri: URL.fromString("https://oneuptime.example.com/callback"),
+        scopes: "openid email profile",
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("refuses the cloud metadata endpoint as a discovery URL", async () => {
+    await expect(
+      OIDCUtil.createClient({
+        discoveryURL: URL.fromString(
+          "http://169.254.169.254/latest/meta-data/",
+        ),
+        clientId: CLIENT_ID,
+        clientSecret: "client-secret",
+        redirectUri: URL.fromString("https://oneuptime.example.com/callback"),
+        scopes: "openid email profile",
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("the rejection is the guard's, not a connection error", async () => {
+    idp = await startTestIdp({ clientId: CLIENT_ID });
+
+    /*
+     * The provider is up and serving, so a failure here can only come from
+     * the lookup refusing to hand back a loopback address.
+     */
+    await expect(
+      OIDCUtil.createClient({
+        discoveryURL: URL.fromString(
+          `${idp.issuerUrl}/.well-known/openid-configuration`,
+        ),
+        clientId: CLIENT_ID,
+        clientSecret: "client-secret",
+        redirectUri: URL.fromString("https://oneuptime.example.com/callback"),
+        scopes: "openid email profile",
+      }),
+    ).rejects.toThrow(/loopback|not allowed/);
+  });
+});

--- a/App/Tests/Notification/SmtpEgressGuard.test.ts
+++ b/App/Tests/Notification/SmtpEgressGuard.test.ts
@@ -1,0 +1,236 @@
+import SMTPOAuthService from "../../FeatureSet/Notification/Services/SMTPOAuthService";
+import { TransporterPool } from "../../FeatureSet/Notification/Services/MailService";
+import Hostname from "Common/Types/API/Hostname";
+import URL from "Common/Types/API/URL";
+import Email from "Common/Types/Email";
+import EmailServer from "Common/Types/Email/EmailServer";
+import OAuthProviderType from "Common/Types/Email/OAuthProviderType";
+import SMTPAuthenticationType from "Common/Types/Email/SMTPAuthenticationType";
+import ObjectID from "Common/Types/ObjectID";
+import Port from "Common/Types/Port";
+import GlobalCache from "Common/Server/Infrastructure/GlobalCache";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import dns from "dns";
+import nodemailer from "nodemailer";
+
+/*
+ * Two tenant-controlled SMTP sinks, both reachable from ProjectSmtpConfig,
+ * which any project member can write:
+ *
+ *  - tokenUrl, which SMTPOAuthService POSTs the OAuth client_id and
+ *    client_secret to, and whose response body is echoed back through
+ *    POST /api/notification/smtp-config/test. Unvalidated, that is credential
+ *    exfiltration plus a read-capable probe of the internal network — and node
+ *    fetch follows redirects by default, so validating the first hop is not
+ *    enough on its own.
+ *
+ *  - hostname/port, which nodemailer dials and then reports on: its "Invalid
+ *    greeting. response=<raw bytes>" lands in EmailLog.statusMessage and is
+ *    shown to the project, which is an internal port scanner with banner
+ *    disclosure.
+ *
+ * DNS is mocked throughout so nothing here touches the network.
+ */
+
+type LookupSpy = jest.SpiedFunction<
+  (
+    hostname: string,
+    options: { all: true },
+  ) => Promise<Array<{ address: string; family: number }>>
+>;
+
+let lookupSpy: LookupSpy;
+let fetchSpy: jest.SpyInstance;
+
+function makeOAuthConfig(tokenUrl: string): {
+  clientId: string;
+  clientSecret: string;
+  tokenUrl: URL;
+  scope: string;
+  username: string;
+  providerType: OAuthProviderType;
+} {
+  return {
+    clientId: "client-id",
+    clientSecret: "client-secret",
+    tokenUrl: URL.fromString(tokenUrl),
+    scope: "https://outlook.office365.com/.default",
+    username: "sender@example.com",
+    providerType: OAuthProviderType.ClientCredentials,
+  };
+}
+
+beforeEach(() => {
+  lookupSpy = jest.spyOn(dns.promises, "lookup") as unknown as LookupSpy;
+
+  lookupSpy.mockImplementation((hostname: string) => {
+    if (hostname === "localhost") {
+      return Promise.resolve([{ address: "127.0.0.1", family: 4 }]);
+    }
+
+    return Promise.resolve([{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  // The token cache must miss so every call reaches the network path.
+  jest.spyOn(GlobalCache, "getJSONObject").mockResolvedValue(null);
+  jest.spyOn(GlobalCache, "setJSON").mockResolvedValue(undefined as never);
+
+  fetchSpy = jest.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => {
+      return Promise.resolve({
+        access_token: "token",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+    },
+    text: () => {
+      return Promise.resolve("");
+    },
+  } as unknown as Response);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("SMTP OAuth token URL is guarded", () => {
+  const blockedTokenUrls: Array<string> = [
+    "http://127.0.0.1:8080/token",
+    "http://localhost:8080/token",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://169.254.169.254:80/token",
+    "http://[::1]:8080/token",
+    "http://0.0.0.0/token",
+  ];
+
+  test.each(blockedTokenUrls)(
+    "never sends the client secret to %s",
+    async (tokenUrl: string) => {
+      await expect(
+        SMTPOAuthService.getAccessToken(makeOAuthConfig(tokenUrl)),
+      ).rejects.toThrow();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  test("a hostname that resolves to the metadata address is refused", async () => {
+    lookupSpy.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+
+    await expect(
+      SMTPOAuthService.getAccessToken(
+        makeOAuthConfig("https://login.attacker.example/token"),
+      ),
+    ).rejects.toThrow();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("a public token URL is fetched with redirects set to manual", async () => {
+    const token: string = await SMTPOAuthService.getAccessToken(
+      makeOAuthConfig("https://login.microsoftonline.com/tenant/oauth2/token"),
+    );
+
+    expect(token).toBe("token");
+    expect(fetchSpy).toHaveBeenCalled();
+
+    const requestInit: RequestInit = fetchSpy.mock.calls[0]![1] as RequestInit;
+
+    /*
+     * Without this, a validated host can 3xx the credentials onward to one
+     * that was never checked.
+     */
+    expect(requestInit.redirect).toBe("manual");
+  });
+
+  test("the JWT Bearer flow is guarded on the same path", async () => {
+    await expect(
+      SMTPOAuthService.getAccessToken({
+        ...makeOAuthConfig("http://169.254.169.254/token"),
+        providerType: OAuthProviderType.JWTBearer,
+        clientSecret:
+          "-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----",
+      }),
+    ).rejects.toThrow();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("custom SMTP hosts are guarded before nodemailer dials them", () => {
+  function makeProjectEmailServer(host: string): EmailServer {
+    return {
+      // An id means "this came from a project's ProjectSmtpConfig".
+      id: new ObjectID("smtp-config-1"),
+      host: new Hostname(host),
+      port: new Port(25),
+      username: "user",
+      password: "pass",
+      fromEmail: new Email("noreply@example.com"),
+      fromName: "OneUptime",
+      secure: false,
+      authType: SMTPAuthenticationType.UsernamePassword,
+    };
+  }
+
+  let createTransportSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    createTransportSpy = jest
+      .spyOn(nodemailer, "createTransport")
+      .mockReturnValue({
+        sendMail: () => {
+          return Promise.resolve({});
+        },
+        close: () => {
+          return undefined;
+        },
+      } as never);
+  });
+
+  const blockedHosts: Array<string> = [
+    "127.0.0.1",
+    "localhost",
+    "169.254.169.254",
+    "0.0.0.0",
+  ];
+
+  test.each(blockedHosts)(
+    "refuses to build a transporter for %s",
+    async (host: string) => {
+      await expect(
+        TransporterPool.getTransporter(makeProjectEmailServer(host), {}),
+      ).rejects.toThrow();
+
+      expect(createTransportSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  test("a public mail server is still allowed", async () => {
+    await expect(
+      TransporterPool.getTransporter(
+        makeProjectEmailServer("smtp.sendgrid.net"),
+        {},
+      ),
+    ).resolves.toBeDefined();
+
+    expect(createTransportSpy).toHaveBeenCalled();
+  });
+
+  test("the operator's global mail server is exempt", async () => {
+    /*
+     * No id — this is the deployment's own SMTP config, not a tenant's. A
+     * self-hosted install pointing it at an internal relay is normal.
+     */
+    const globalServer: EmailServer = makeProjectEmailServer("127.0.0.1");
+    delete (globalServer as { id?: ObjectID | undefined }).id;
+
+    await expect(
+      TransporterPool.getTransporter(globalServer, {}),
+    ).resolves.toBeDefined();
+
+    expect(createTransportSpy).toHaveBeenCalled();
+  });
+});

--- a/App/Tests/Runbook/RunbookHttpStepSSRF.test.ts
+++ b/App/Tests/Runbook/RunbookHttpStepSSRF.test.ts
@@ -1,0 +1,227 @@
+import axios from "axios";
+import RunbookStepType from "Common/Types/Runbook/RunbookStepType";
+import {
+  HttpRequestStepConfig,
+  RunbookStep,
+} from "Common/Types/Runbook/RunbookStep";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+import dns from "dns";
+import {
+  runHttpStep,
+  StepRunResult,
+} from "../../FeatureSet/Runbook/Services/StepExecutors";
+
+/*
+ * A Runbook HTTP step's url, method, headers and body come verbatim out of the
+ * Runbook's steps JSON column, and the step's output builder writes the full
+ * status, headers and body of the response into
+ * RunbookExecution.stepExecutions — which any project member can read. That is
+ * a fully attacker-shaped request into the Worker's network with the answer
+ * handed back, and an attacker-chosen method plus headers is exactly what
+ * IMDSv2 asks for.
+ *
+ * These tests assert no socket is opened for an internal target, that the
+ * checked address is pinned into the one that is opened, and that redirects
+ * are refused (raw axios, so maxRedirects rather than the API wrapper's
+ * doNotFollowRedirects).
+ */
+
+type LookupSpy = jest.SpiedFunction<
+  (
+    hostname: string,
+    options: { all: true },
+  ) => Promise<Array<{ address: string; family: number }>>
+>;
+
+let lookupSpy: LookupSpy;
+let requestSpy: jest.SpyInstance;
+
+function makeHttpStep(
+  config: Partial<HttpRequestStepConfig> = {},
+): RunbookStep {
+  return {
+    id: "s1",
+    order: 0,
+    type: RunbookStepType.HttpRequest,
+    title: "Call API",
+    config: {
+      url: "https://api.example.com/health",
+      method: "GET",
+      ...config,
+    } as HttpRequestStepConfig,
+  };
+}
+
+beforeEach(() => {
+  lookupSpy = jest.spyOn(dns.promises, "lookup") as unknown as LookupSpy;
+
+  // Stand in for getaddrinfo, so the tests are deterministic and offline.
+  lookupSpy.mockImplementation((hostname: string) => {
+    if (hostname === "localhost") {
+      return Promise.resolve([{ address: "127.0.0.1", family: 4 }]);
+    }
+
+    return Promise.resolve([{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  requestSpy = jest.spyOn(axios, "request").mockResolvedValue({
+    status: 200,
+    statusText: "OK",
+    headers: {},
+    data: "",
+  } as never);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("runHttpStep refuses internal targets", () => {
+  const blockedUrls: Array<string> = [
+    "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+    "http://169.254.169.254:80/latest/meta-data/",
+    "http://127.0.0.1:9200/_search",
+    "http://localhost:9200/_search",
+    "http://0.0.0.0:8080/",
+    "http://[::1]:8080/",
+    "http://[0:0:0:0:0:ffff:127.0.0.1]:8080/",
+  ];
+
+  test.each(blockedUrls)("never opens a socket for %s", async (url: string) => {
+    const result: StepRunResult = await runHttpStep(makeHttpStep({ url }));
+
+    expect(result.success).toBe(false);
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  test("the IMDSv2 shape is blocked even with an attacker-chosen method and headers", async () => {
+    const result: StepRunResult = await runHttpStep(
+      makeHttpStep({
+        url: "http://169.254.169.254/latest/api/token",
+        method: "PUT",
+        headersJson: JSON.stringify({
+          "X-aws-ec2-metadata-token-ttl-seconds": "21600",
+        }),
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  test("a hostname that resolves to the metadata address is blocked", async () => {
+    lookupSpy.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+
+    const result: StepRunResult = await runHttpStep(
+      makeHttpStep({
+        url: "https://rebind.attacker.example/latest/meta-data/",
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  test("a blocked step fails as a step result, not an unhandled throw", async () => {
+    const result: StepRunResult = await runHttpStep(
+      makeHttpStep({ url: "http://169.254.169.254/" }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.output).toBe("");
+    expect(result.errorMessage).toContain("not allowed");
+  });
+
+  test("an empty URL is rejected rather than dialed", async () => {
+    const result: StepRunResult = await runHttpStep(makeHttpStep({ url: "" }));
+
+    expect(result.success).toBe(false);
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  test("a non-http scheme is rejected", async () => {
+    const result: StepRunResult = await runHttpStep(
+      makeHttpStep({ url: "file:///etc/passwd" }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("runHttpStep pins and refuses redirects for allowed targets", () => {
+  test("a public target is dialed with maxRedirects 0 and pinned agents", async () => {
+    const result: StepRunResult = await runHttpStep(makeHttpStep());
+
+    expect(result.success).toBe(true);
+
+    const config: Record<string, unknown> = requestSpy.mock
+      .calls[0]![0] as Record<string, unknown>;
+
+    expect(config["maxRedirects"]).toBe(0);
+    expect(config["httpAgent"]).toBeDefined();
+    expect(config["httpsAgent"]).toBeDefined();
+  });
+
+  test("the pinned agent dials the address the guard validated", async () => {
+    await runHttpStep(makeHttpStep());
+
+    const config: Record<string, unknown> = requestSpy.mock
+      .calls[0]![0] as Record<string, unknown>;
+
+    const lookup: (
+      hostname: string,
+      lookupOptions: { all?: boolean },
+      callback: (error: Error | null, address: string) => void,
+    ) => void = (
+      config["httpsAgent"] as unknown as {
+        options: {
+          lookup: (
+            hostname: string,
+            lookupOptions: { all?: boolean },
+            callback: (error: Error | null, address: string) => void,
+          ) => void;
+        };
+      }
+    ).options.lookup;
+
+    const dialed: string = await new Promise((resolve: (v: string) => void) => {
+      lookup(
+        "api.example.com",
+        { all: false },
+        (_error: Error | null, address: string) => {
+          resolve(address);
+        },
+      );
+    });
+
+    expect(dialed).toBe("93.184.216.34");
+  });
+
+  test("a self-hosted private target is still reachable by default", async () => {
+    lookupSpy.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+
+    const result: StepRunResult = await runHttpStep(
+      makeHttpStep({ url: "http://internal-api.corp/health" }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(requestSpy).toHaveBeenCalled();
+  });
+
+  test("but not when the install opts into SaaS policy", async () => {
+    lookupSpy.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+    process.env["DATA_SOURCE_BLOCK_PRIVATE_ADDRESSES"] = "true";
+
+    try {
+      const result: StepRunResult = await runHttpStep(
+        makeHttpStep({ url: "http://internal-api.corp/health" }),
+      );
+
+      expect(result.success).toBe(false);
+      expect(requestSpy).not.toHaveBeenCalled();
+    } finally {
+      delete process.env["DATA_SOURCE_BLOCK_PRIVATE_ADDRESSES"];
+    }
+  });
+});

--- a/App/Tests/Runbook/StepExecutors.test.ts
+++ b/App/Tests/Runbook/StepExecutors.test.ts
@@ -19,6 +19,7 @@ import {
   MIN_AGENT_CLAIM_TIMEOUT_IN_MS,
   MIN_STEP_EXECUTION_TIMEOUT_IN_MS,
 } from "Common/Types/Runbook/RunbookStepTimeout";
+import DataSourceEgressGuard from "Common/Server/Utils/DataSource/EgressGuard";
 import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
 import {
   runBashStep,
@@ -28,6 +29,25 @@ import {
   StepExecutionContext,
   StepRunResult,
 } from "../../FeatureSet/Runbook/Services/StepExecutors";
+
+/*
+ * runHttpStep validates and pins its target through the SSRF egress guard
+ * before dialing. These tests are about step semantics, not egress policy, so
+ * the guard is stubbed to keep them offline — the policy itself is covered by
+ * RunbookHttpStepSSRF.test.ts.
+ */
+beforeEach(() => {
+  jest
+    .spyOn(DataSourceEgressGuard, "assertUrlAllowedAndPin")
+    .mockImplementation((urlString: string) => {
+      return Promise.resolve({
+        url: new globalThis.URL(urlString),
+        addresses: [{ address: "93.184.216.34", family: 4 }],
+        httpAgent: undefined as never,
+        httpsAgent: undefined as never,
+      });
+    });
+});
 
 function makeCtx(): StepExecutionContext {
   return {

--- a/Common/Server/Services/DashboardDomainService.ts
+++ b/Common/Server/Services/DashboardDomainService.ts
@@ -1,18 +1,17 @@
 import CreateBy from "../Types/Database/CreateBy";
 import DeleteBy from "../Types/Database/DeleteBy";
-import { OnCreate, OnDelete } from "../Types/Database/Hooks";
+import UpdateBy from "../Types/Database/UpdateBy";
+import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
 import GreenlockUtil from "../Utils/Greenlock/Greenlock";
 import logger, { LogAttributes } from "../Utils/Logger";
 import DatabaseService from "./DatabaseService";
 import DomainService from "./DomainService";
 import HTTPErrorResponse from "../../Types/API/HTTPErrorResponse";
 import HTTPResponse from "../../Types/API/HTTPResponse";
-import URL from "../../Types/API/URL";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
 import { JSONObject } from "../../Types/JSON";
 import ObjectID from "../../Types/ObjectID";
-import API from "../../Utils/API";
 import AcmeCertificate from "../../Models/DatabaseModels/AcmeCertificate";
 import DomainModel from "../../Models/DatabaseModels/Domain";
 import DashboardDomain from "../../Models/DatabaseModels/DashboardDomain";
@@ -22,9 +21,58 @@ import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import { DashboardCNameRecord } from "../EnvironmentConfig";
 import Domain from "../Types/Domain";
 
+const DASHBOARD_DOMAIN_EGRESS_LABEL: string = "Dashboard domain";
+
 export class Service extends DatabaseService<DashboardDomain> {
   public constructor() {
     super(DashboardDomain);
+  }
+
+  /*
+   * Normalize a submitted subdomain and reject anything that is not a plain
+   * DNS label chain.
+   *
+   * fullDomain is built as `${subdomain}.${baseDomain}` and then interpolated
+   * into "https://" + fullDomain + "/dashboard-api/..." — and URL parsing
+   * treats everything before the first "/" as the host. Without this check a
+   * subdomain of "169.254.169.254/latest/meta-data/#" hands an attacker the
+   * host, the port and the path of a request the certificate cron then makes
+   * unattended, every 15 minutes, from inside the cluster.
+   */
+  private static normalizeAndValidateSubdomain(
+    subdomain: string | undefined,
+  ): string {
+    const normalized: string = subdomain?.trim().toLowerCase() || "";
+
+    // "@" is the documented way to ask for the root domain.
+    if (normalized === "" || normalized === "@") {
+      return "";
+    }
+
+    if (!Domain.isValidSubdomain(normalized)) {
+      throw new BadDataException(
+        `Subdomain ${normalized} is not valid. Use a plain subdomain such as "dashboard" — schemes, ports, paths and "/" are not allowed.`,
+      );
+    }
+
+    return normalized;
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<DashboardDomain>,
+  ): Promise<OnUpdate<DashboardDomain>> {
+    /*
+     * Create-time validation alone leaves the value editable afterwards —
+     * subdomain is ProjectMember-updatable.
+     */
+    if (updateBy.data.subdomain !== undefined) {
+      updateBy.data.subdomain = Service.normalizeAndValidateSubdomain(
+        updateBy.data.subdomain as string,
+      );
+    }
+
+    return { updateBy, carryForward: null };
   }
 
   @CaptureSpan()
@@ -48,14 +96,11 @@ export class Service extends DatabaseService<DashboardDomain> {
       );
     }
 
-    let normalizedSubdomain: string =
-      createBy.data.subdomain?.trim().toLowerCase() || "";
+    createBy.data.subdomain = Service.normalizeAndValidateSubdomain(
+      createBy.data.subdomain,
+    );
 
-    if (normalizedSubdomain === "@") {
-      normalizedSubdomain = "";
-    }
-
-    createBy.data.subdomain = normalizedSubdomain;
+    const normalizedSubdomain: string = createBy.data.subdomain;
 
     if (domain) {
       const baseDomain: string =
@@ -230,13 +275,13 @@ export class Service extends DatabaseService<DashboardDomain> {
   ): Promise<boolean> {
     try {
       const result: HTTPErrorResponse | HTTPResponse<JSONObject> =
-        await API.get({
-          url: URL.fromString(
+        await Domain.getForDomainVerification({
+          url:
             "https://" +
-              fulldomain +
-              "/dashboard-api/cname-verification/" +
-              token,
-          ),
+            fulldomain +
+            "/dashboard-api/cname-verification/" +
+            token,
+          targetLabel: DASHBOARD_DOMAIN_EGRESS_LABEL,
         });
 
       if (result.isFailure()) {
@@ -317,13 +362,13 @@ export class Service extends DatabaseService<DashboardDomain> {
 
       try {
         const result: HTTPErrorResponse | HTTPResponse<JSONObject> =
-          await API.get({
-            url: URL.fromString(
+          await Domain.getForDomainVerification({
+            url:
               "http://" +
-                fullDomain +
-                "/dashboard-api/cname-verification/" +
-                token,
-            ),
+              fullDomain +
+              "/dashboard-api/cname-verification/" +
+              token,
+            targetLabel: DASHBOARD_DOMAIN_EGRESS_LABEL,
           });
 
         logger.debug("CNAME verification result", {
@@ -348,13 +393,13 @@ export class Service extends DatabaseService<DashboardDomain> {
 
       try {
         const resultHttps: HTTPErrorResponse | HTTPResponse<JSONObject> =
-          await API.get({
-            url: URL.fromString(
+          await Domain.getForDomainVerification({
+            url:
               "https://" +
-                fullDomain +
-                "/dashboard-api/cname-verification/" +
-                token,
-            ),
+              fullDomain +
+              "/dashboard-api/cname-verification/" +
+              token,
+            targetLabel: DASHBOARD_DOMAIN_EGRESS_LABEL,
           });
 
         logger.debug("CNAME verification result for https", {

--- a/Common/Server/Services/PushNotificationService.ts
+++ b/Common/Server/Services/PushNotificationService.ts
@@ -27,6 +27,25 @@ import PushNotificationLog from "../../Models/DatabaseModels/PushNotificationLog
 import PushNotificationLogService from "./PushNotificationLogService";
 import PushStatus from "../../Types/PushNotification/PushStatus";
 
+/*
+ * The push services the browsers actually use. A Web Push subscription is a
+ * JSON blob supplied by the client and stored verbatim in UserPush.deviceToken;
+ * web-push then dials whatever host:port its "endpoint" names. Nothing else is
+ * a legitimate destination, so this is an allowlist rather than a blocklist —
+ * there is no self-hosted deployment of a browser push service to accommodate.
+ *
+ * Matching is on the registrable host (exact, or a subdomain) and https only,
+ * which covers the real endpoints: updates.push.services.mozilla.com,
+ * web.push.apple.com, and the regional *.notify.windows.com hosts.
+ */
+const ALLOWED_WEB_PUSH_HOSTS: Array<string> = [
+  "push.services.mozilla.com",
+  "fcm.googleapis.com",
+  "android.googleapis.com",
+  "notify.windows.com",
+  "push.apple.com",
+];
+
 export interface PushNotificationOptions {
   projectId?: ObjectID | undefined;
   isSensitive?: boolean;
@@ -267,6 +286,54 @@ export default class PushNotificationService {
     }
   }
 
+  /*
+   * Refuse to hand web-push an endpoint that is not one of the browser push
+   * services. The subscription JSON is client-supplied, so without this the
+   * endpoint is a free choice of host and port for a POST the server makes
+   * with its own credentials — the usual internal-service and metadata
+   * targets included.
+   */
+  public static assertWebPushEndpointIsAllowed(endpoint: unknown): void {
+    if (!endpoint || typeof endpoint !== "string") {
+      throw new Error(
+        "Web push subscription is missing its endpoint and cannot be delivered.",
+      );
+    }
+
+    /*
+     * Parsed with the WHATWG parser deliberately: that is the parser web-push
+     * itself uses, so what is checked here is exactly what gets dialed. Going
+     * through OneUptime's URL type instead would introduce a differential —
+     * it reads "https://push.apple.com:80@evil.com/" as host push.apple.com,
+     * while WHATWG (correctly) reads userinfo push.apple.com:80 and host
+     * evil.com.
+     */
+    let parsed: globalThis.URL;
+    try {
+      parsed = new globalThis.URL(endpoint);
+    } catch {
+      throw new Error("Web push subscription endpoint is not a valid URL.");
+    }
+
+    if (parsed.protocol !== "https:") {
+      throw new Error("Web push subscription endpoint must use https.");
+    }
+
+    const host: string = parsed.hostname.toLowerCase();
+
+    const isAllowed: boolean = ALLOWED_WEB_PUSH_HOSTS.some(
+      (allowedHost: string) => {
+        return host === allowedHost || host.endsWith(`.${allowedHost}`);
+      },
+    );
+
+    if (!isAllowed) {
+      throw new Error(
+        `Web push subscription endpoint ${host} is not a recognised browser push service and will not be contacted.`,
+      );
+    }
+  }
+
   private static async sendWebPushNotification(
     deviceToken: string,
     message: PushNotificationMessage,
@@ -306,6 +373,10 @@ export default class PushNotificationService {
         logger.error(`Failed to parse device token: ${parseError}`);
         throw new Error(`Invalid device token format: ${parseError}`);
       }
+
+      PushNotificationService.assertWebPushEndpointIsAllowed(
+        subscriptionObject?.endpoint,
+      );
 
       const result: webpush.SendResult = await webpush.sendNotification(
         subscriptionObject,

--- a/Common/Server/Services/StatusPageDomainService.ts
+++ b/Common/Server/Services/StatusPageDomainService.ts
@@ -1,18 +1,17 @@
 import CreateBy from "../Types/Database/CreateBy";
 import DeleteBy from "../Types/Database/DeleteBy";
-import { OnCreate, OnDelete } from "../Types/Database/Hooks";
+import UpdateBy from "../Types/Database/UpdateBy";
+import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
 import GreenlockUtil from "../Utils/Greenlock/Greenlock";
 import logger, { LogAttributes } from "../Utils/Logger";
 import DatabaseService from "./DatabaseService";
 import DomainService from "./DomainService";
 import HTTPErrorResponse from "../../Types/API/HTTPErrorResponse";
 import HTTPResponse from "../../Types/API/HTTPResponse";
-import URL from "../../Types/API/URL";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
 import { JSONObject } from "../../Types/JSON";
 import ObjectID from "../../Types/ObjectID";
-import API from "../../Utils/API";
 import AcmeCertificate from "../../Models/DatabaseModels/AcmeCertificate";
 import DomainModel from "../../Models/DatabaseModels/Domain";
 import StatusPageDomain from "../../Models/DatabaseModels/StatusPageDomain";
@@ -22,9 +21,58 @@ import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import { StatusPageCNameRecord } from "../EnvironmentConfig";
 import Domain from "../Types/Domain";
 
+const STATUS_PAGE_DOMAIN_EGRESS_LABEL: string = "Status page domain";
+
 export class Service extends DatabaseService<StatusPageDomain> {
   public constructor() {
     super(StatusPageDomain);
+  }
+
+  /*
+   * Normalize a submitted subdomain and reject anything that is not a plain
+   * DNS label chain.
+   *
+   * fullDomain is built as `${subdomain}.${baseDomain}` and then interpolated
+   * into "https://" + fullDomain + "/status-page-api/..." — and URL parsing
+   * treats everything before the first "/" as the host. Without this check a
+   * subdomain of "169.254.169.254/latest/meta-data/#" hands an attacker the
+   * host, the port and the path of a request the certificate cron then makes
+   * unattended, every 15 minutes, from inside the cluster.
+   */
+  private static normalizeAndValidateSubdomain(
+    subdomain: string | undefined,
+  ): string {
+    const normalized: string = subdomain?.trim().toLowerCase() || "";
+
+    // "@" is the documented way to ask for the root domain.
+    if (normalized === "" || normalized === "@") {
+      return "";
+    }
+
+    if (!Domain.isValidSubdomain(normalized)) {
+      throw new BadDataException(
+        `Subdomain ${normalized} is not valid. Use a plain subdomain such as "status" — schemes, ports, paths and "/" are not allowed.`,
+      );
+    }
+
+    return normalized;
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<StatusPageDomain>,
+  ): Promise<OnUpdate<StatusPageDomain>> {
+    /*
+     * Create-time validation alone leaves the value editable afterwards —
+     * subdomain is ProjectMember-updatable.
+     */
+    if (updateBy.data.subdomain !== undefined) {
+      updateBy.data.subdomain = Service.normalizeAndValidateSubdomain(
+        updateBy.data.subdomain as string,
+      );
+    }
+
+    return { updateBy, carryForward: null };
   }
 
   @CaptureSpan()
@@ -48,14 +96,11 @@ export class Service extends DatabaseService<StatusPageDomain> {
       );
     }
 
-    let normalizedSubdomain: string =
-      createBy.data.subdomain?.trim().toLowerCase() || "";
+    createBy.data.subdomain = Service.normalizeAndValidateSubdomain(
+      createBy.data.subdomain,
+    );
 
-    if (normalizedSubdomain === "@") {
-      normalizedSubdomain = "";
-    }
-
-    createBy.data.subdomain = normalizedSubdomain;
+    const normalizedSubdomain: string = createBy.data.subdomain;
 
     if (domain) {
       const baseDomain: string =
@@ -231,13 +276,13 @@ export class Service extends DatabaseService<StatusPageDomain> {
   ): Promise<boolean> {
     try {
       const result: HTTPErrorResponse | HTTPResponse<JSONObject> =
-        await API.get({
-          url: URL.fromString(
+        await Domain.getForDomainVerification({
+          url:
             "https://" +
-              fulldomain +
-              "/status-page-api/cname-verification/" +
-              token,
-          ),
+            fulldomain +
+            "/status-page-api/cname-verification/" +
+            token,
+          targetLabel: STATUS_PAGE_DOMAIN_EGRESS_LABEL,
         });
 
       if (result.isFailure()) {
@@ -320,13 +365,13 @@ export class Service extends DatabaseService<StatusPageDomain> {
 
       try {
         const result: HTTPErrorResponse | HTTPResponse<JSONObject> =
-          await API.get({
-            url: URL.fromString(
+          await Domain.getForDomainVerification({
+            url:
               "http://" +
-                fullDomain +
-                "/status-page-api/cname-verification/" +
-                token,
-            ),
+              fullDomain +
+              "/status-page-api/cname-verification/" +
+              token,
+            targetLabel: STATUS_PAGE_DOMAIN_EGRESS_LABEL,
           });
 
         logger.debug("CNAME verification result", {
@@ -353,13 +398,13 @@ export class Service extends DatabaseService<StatusPageDomain> {
 
       try {
         const resultHttps: HTTPErrorResponse | HTTPResponse<JSONObject> =
-          await API.get({
-            url: URL.fromString(
+          await Domain.getForDomainVerification({
+            url:
               "https://" +
-                fullDomain +
-                "/status-page-api/cname-verification/" +
-                token,
-            ),
+              fullDomain +
+              "/status-page-api/cname-verification/" +
+              token,
+            targetLabel: STATUS_PAGE_DOMAIN_EGRESS_LABEL,
           });
 
         logger.debug("CNAME verification result for https", {

--- a/Common/Server/Services/UserWebhookService.ts
+++ b/Common/Server/Services/UserWebhookService.ts
@@ -1,6 +1,7 @@
 import CreateBy from "../Types/Database/CreateBy";
 import DeleteBy from "../Types/Database/DeleteBy";
-import { OnCreate, OnDelete } from "../Types/Database/Hooks";
+import UpdateBy from "../Types/Database/UpdateBy";
+import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
 import DatabaseService from "./DatabaseService";
 import UserNotificationRuleService from "./UserNotificationRuleService";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
@@ -8,7 +9,18 @@ import BadDataException from "../../Types/Exception/BadDataException";
 import Model from "../../Models/DatabaseModels/UserWebhook";
 import URL from "../../Types/API/URL";
 import logger from "../Utils/Logger";
+import SSRFProtection from "../Utils/SSRFProtection";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+
+/*
+ * URL validation here used to be a hand-rolled copy of the SSRF blocklist that
+ * had drifted weaker than the original (it compared the host with the port
+ * still attached, and never resolved DNS). Everything that actually sends one
+ * of these webhooks goes through WebhookService, which calls
+ * SSRFProtection.validateWebhookTargetIsSafe — so the copy bought nothing and
+ * would have been read as "this is checked". Both hooks now call the same
+ * guard the sender does, which fails the write early instead of at delivery.
+ */
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -27,10 +39,30 @@ export class Service extends DatabaseService<Model> {
       throw new BadDataException("Webhook name is required");
     }
 
-    this.validateWebhookUrl(createBy.data.webhookUrl);
+    await SSRFProtection.validateWebhookTargetIsSafe(createBy.data.webhookUrl);
 
     return {
       createBy,
+      carryForward: null,
+    };
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    /*
+     * Create-time validation on its own is not a control: the URL is
+     * editable afterwards.
+     */
+    const webhookUrl: unknown = updateBy.data.webhookUrl;
+
+    if (typeof webhookUrl === "string" || webhookUrl instanceof URL) {
+      await SSRFProtection.validateWebhookTargetIsSafe(webhookUrl);
+    }
+
+    return {
+      updateBy,
       carryForward: null,
     };
   }
@@ -96,113 +128,6 @@ export class Service extends DatabaseService<Model> {
       carryForward: null,
     };
   }
-
-  private validateWebhookUrl(rawUrl: string): void {
-    let parsed: URL;
-    try {
-      parsed = URL.fromString(rawUrl);
-    } catch {
-      throw new BadDataException("Webhook URL is not a valid URL");
-    }
-
-    const protocolValue: string = parsed.protocol.toString().toLowerCase();
-    if (protocolValue !== "http://" && protocolValue !== "https://") {
-      throw new BadDataException(
-        "Webhook URL must use http or https protocol.",
-      );
-    }
-
-    const hostname: string = parsed.hostname.hostname.toLowerCase();
-
-    if (!hostname) {
-      throw new BadDataException("Webhook URL must include a host.");
-    }
-
-    if (isBlockedHostnameLiteral(hostname)) {
-      throw new BadDataException(
-        "Webhook URL points to a private, loopback, or link-local address and is not allowed.",
-      );
-    }
-  }
 }
-
-function isBlockedHostnameLiteral(hostname: string): boolean {
-  if (
-    hostname === "localhost" ||
-    hostname.endsWith(".localhost") ||
-    hostname === "metadata.google.internal"
-  ) {
-    return true;
-  }
-
-  // IPv4 literal check
-  const ipv4Match: RegExpMatchArray | null = hostname.match(
-    /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/,
-  );
-  if (ipv4Match) {
-    const octets: Array<number> = [
-      Number(ipv4Match[1]),
-      Number(ipv4Match[2]),
-      Number(ipv4Match[3]),
-      Number(ipv4Match[4]),
-    ];
-
-    if (
-      octets.some((o: number) => {
-        return o < 0 || o > 255;
-      })
-    ) {
-      return true;
-    }
-
-    // 0.0.0.0/8
-    if (octets[0] === 0) {
-      return true;
-    }
-    // 127.0.0.0/8 loopback
-    if (octets[0] === 127) {
-      return true;
-    }
-    // 10.0.0.0/8
-    if (octets[0] === 10) {
-      return true;
-    }
-    // 172.16.0.0/12
-    if (octets[0] === 172 && (octets[1]! & 0xf0) === 16) {
-      return true;
-    }
-    // 192.168.0.0/16
-    if (octets[0] === 192 && octets[1] === 168) {
-      return true;
-    }
-    // 169.254.0.0/16 link-local (incl. cloud metadata)
-    if (octets[0] === 169 && octets[1] === 254) {
-      return true;
-    }
-    // 100.64.0.0/10 carrier-grade NAT
-    if (octets[0] === 100 && (octets[1]! & 0xc0) === 64) {
-      return true;
-    }
-    return false;
-  }
-
-  // IPv6 literal — block loopback, link-local, unique-local
-  if (hostname.includes(":")) {
-    const stripped: string = hostname.replace(/^\[|\]$/g, "");
-    if (stripped === "::1" || stripped === "::") {
-      return true;
-    }
-    if (stripped.startsWith("fe80:") || stripped.startsWith("fe80::")) {
-      return true;
-    }
-    if (IPV6_UNIQUE_LOCAL_REGEX.test(stripped)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-const IPV6_UNIQUE_LOCAL_REGEX: RegExp = /^f[cd][0-9a-f]{2}:/;
 
 export default new Service();

--- a/Common/Server/Types/Domain.ts
+++ b/Common/Server/Types/Domain.ts
@@ -4,8 +4,49 @@ import { PromiseRejectErrorFunction } from "../../Types/FunctionTypes";
 import dns from "dns";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import BadDataException from "../../Types/Exception/BadDataException";
+import HTTPErrorResponse from "../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../Types/API/HTTPResponse";
+import { JSONObject } from "../../Types/JSON";
+import URL from "../../Types/API/URL";
+import API from "../../Utils/API";
+import DataSourceEgressGuard from "../Utils/DataSource/EgressGuard";
 
 export default class Domain extends DomainCommon {
+  /*
+   * GET a domain-verification URL built from a tenant-supplied domain.
+   *
+   * Both the status page and the dashboard build these URLs by interpolating
+   * a customer domain into a string, and the certificate cron re-fetches them
+   * unattended every 15 minutes — so the target has to be validated on every
+   * call, not just when the row was written. The address that was validated
+   * is pinned into the socket, and redirects are refused so a 3xx cannot
+   * bounce the request to a host that was never checked. (The callers try
+   * http first and https second, so the ordinary http→https redirect a
+   * customer proxy emits is still covered by the https attempt.)
+   *
+   * Private ranges stay reachable on self-hosted installs, where a status page
+   * domain legitimately resolves inside the corporate network.
+   */
+  @CaptureSpan()
+  public static async getForDomainVerification(data: {
+    url: string;
+    targetLabel: string;
+  }): Promise<HTTPErrorResponse | HTTPResponse<JSONObject>> {
+    const { httpAgent, httpsAgent } =
+      await DataSourceEgressGuard.assertUrlAllowedAndPin(data.url, {
+        targetLabel: data.targetLabel,
+      });
+
+    return API.get<JSONObject>({
+      url: URL.fromString(data.url),
+      options: {
+        doNotFollowRedirects: true,
+        httpAgent,
+        httpsAgent,
+      },
+    });
+  }
+
   @CaptureSpan()
   public static getCnameRecords(data: { domain: string }): Promise<string[]> {
     return new Promise(

--- a/Common/Server/Utils/DataSource/EgressGuard.ts
+++ b/Common/Server/Utils/DataSource/EgressGuard.ts
@@ -1,16 +1,27 @@
 import dns from "dns";
+import http from "http";
+import https from "https";
 import net from "net";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import { IsBillingEnabled } from "../../EnvironmentConfig";
 
 /*
- * SSRF egress guard for external Data Source connections.
+ * SSRF egress guard for outbound connections whose target is chosen by a
+ * tenant.
  *
- * Data Sources let project members point OneUptime at arbitrary
- * hosts — which would otherwise turn the API server into an authenticated
- * request proxy into whatever network it runs in (cloud metadata endpoints,
- * internal services, sibling tenants' infrastructure). Every connector must
- * validate its target through this guard before opening a socket.
+ * It started life guarding external Data Source connections — hence the
+ * file's home — but the same policy now covers every sink where a project
+ * member picks the host and a self-hosted install may legitimately point at
+ * something internal: LLM providers (self-hosted Ollama/vLLM), SMTP OAuth
+ * token endpoints, status page / dashboard domain verification, OIDC
+ * discovery and Runbook HTTP steps. Sinks that can only ever be third-party
+ * SaaS (Slack, Teams, subscriber webhooks) use SSRFProtection instead, which
+ * blocks private ranges unconditionally.
+ *
+ * Without a guard these turn the API server into an authenticated request
+ * proxy into whatever network it runs in (cloud metadata endpoints, internal
+ * services, sibling tenants' infrastructure). Every caller must validate its
+ * target through this guard before opening a socket.
  *
  * Policy:
  *  - ALWAYS blocked, in every deployment: loopback, link-local (cloud
@@ -51,7 +62,37 @@ export interface EgressGuardOptions {
   blockPrivateAddresses?: boolean | undefined;
   // Test seam for DNS. Undefined ⇒ dns.promises.lookup with a timeout.
   resolveFunction?: EgressResolveFunction | undefined;
+  /*
+   * Noun used in error messages so a rejection names the thing the user was
+   * actually configuring ("LLM provider host ... is not allowed"). Defaults
+   * to "Data source".
+   */
+  targetLabel?: string | undefined;
 }
+
+export interface PinnedAgents {
+  httpAgent: http.Agent;
+  httpsAgent: https.Agent;
+}
+
+/*
+ * dns.lookup's shape, as http.Agent / net.Socket call it. Declared locally
+ * rather than pulled from @types/node because the real declaration is a heavy
+ * overload set and every consumer here uses exactly this one shape.
+ */
+export type EgressLookupCallback = (
+  error: NodeJS.ErrnoException | null,
+  address: string | Array<{ address: string; family: number }>,
+  family?: number,
+) => void;
+
+export type EgressLookupFunction = (
+  hostname: string,
+  options: { all?: boolean | undefined; family?: number | undefined },
+  callback: EgressLookupCallback,
+) => void;
+
+const DEFAULT_TARGET_LABEL: string = "Data source";
 
 export interface AddressVerdict {
   blocked: boolean;
@@ -352,8 +393,10 @@ export default class DataSourceEgressGuard {
     hostname: string,
     options?: EgressGuardOptions,
   ): Promise<Array<ResolvedAddress>> {
+    const label: string = options?.targetLabel || DEFAULT_TARGET_LABEL;
+
     if (!hostname) {
-      throw new BadDataException("Data source host is required.");
+      throw new BadDataException(`${label} host is required.`);
     }
 
     // Literal [::1] style hosts arrive with brackets from URL parsing.
@@ -363,7 +406,7 @@ export default class DataSourceEgressGuard {
       const verdict: AddressVerdict = this.checkAddress(bareHostname, options);
       if (verdict.blocked) {
         throw new BadDataException(
-          `Data source host ${bareHostname} is not allowed: ${verdict.reason}.`,
+          `${label} host ${bareHostname} is not allowed: ${verdict.reason}.`,
         );
       }
       return [{ address: bareHostname, family: net.isIP(bareHostname) }];
@@ -380,7 +423,7 @@ export default class DataSourceEgressGuard {
       addresses = await resolveFunction(bareHostname);
     } catch (error) {
       throw new BadDataException(
-        `Could not resolve data source host ${bareHostname}: ${
+        `Could not resolve ${label.toLowerCase()} host ${bareHostname}: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
@@ -388,7 +431,7 @@ export default class DataSourceEgressGuard {
 
     if (addresses.length === 0) {
       throw new BadDataException(
-        `Could not resolve data source host ${bareHostname}.`,
+        `Could not resolve ${label.toLowerCase()} host ${bareHostname}.`,
       );
     }
 
@@ -399,7 +442,7 @@ export default class DataSourceEgressGuard {
       );
       if (verdict.blocked) {
         throw new BadDataException(
-          `Data source host ${bareHostname} resolves to ${resolved.address}, which is not allowed: ${verdict.reason}.`,
+          `${label} host ${bareHostname} resolves to ${resolved.address}, which is not allowed: ${verdict.reason}.`,
         );
       }
     }
@@ -416,20 +459,24 @@ export default class DataSourceEgressGuard {
     urlString: string,
     options?: EgressGuardOptions,
   ): Promise<{ url: URL; addresses: Array<ResolvedAddress> }> {
+    const label: string = options?.targetLabel || DEFAULT_TARGET_LABEL;
+
     if (!urlString) {
-      throw new BadDataException("Data source URL is required.");
+      throw new BadDataException(`${label} URL is required.`);
     }
 
     let url: URL;
     try {
       url = new URL(urlString);
     } catch {
-      throw new BadDataException(`Invalid data source URL: ${urlString}`);
+      throw new BadDataException(
+        `Invalid ${label.toLowerCase()} URL: ${urlString}`,
+      );
     }
 
     if (url.protocol !== "http:" && url.protocol !== "https:") {
       throw new BadDataException(
-        `Data source URL must use http or https (got ${url.protocol.replace(
+        `${label} URL must use http or https (got ${url.protocol.replace(
           ":",
           "",
         )}).`,
@@ -442,5 +489,111 @@ export default class DataSourceEgressGuard {
     );
 
     return { url, addresses };
+  }
+
+  /*
+   * A dns.lookup-shaped function that always answers with the already
+   * validated addresses. Handing this to an http(s).Agent makes the address
+   * that was checked the address that gets dialed, closing the DNS-rebind
+   * window between validation and connect. TLS still verifies against the
+   * original hostname because SNI is taken from the URL, not from here.
+   */
+  public static createPinnedLookup(
+    addresses: Array<ResolvedAddress>,
+  ): EgressLookupFunction {
+    return (
+      _hostname: string,
+      lookupOptions: { all?: boolean | undefined },
+      callback: EgressLookupCallback,
+    ): void => {
+      if (lookupOptions && lookupOptions.all) {
+        callback(
+          null,
+          addresses.map((resolved: ResolvedAddress) => {
+            return { address: resolved.address, family: resolved.family };
+          }),
+        );
+        return;
+      }
+
+      const first: ResolvedAddress = addresses[0]!;
+      callback(null, first.address, first.family);
+    };
+  }
+
+  // http/https agent pair that dials only the given validated addresses.
+  public static createPinnedAgents(
+    addresses: Array<ResolvedAddress>,
+  ): PinnedAgents {
+    const lookup: EgressLookupFunction = this.createPinnedLookup(addresses);
+
+    return {
+      httpAgent: new http.Agent({ lookup: lookup as never }),
+      httpsAgent: new https.Agent({ lookup: lookup as never }),
+    };
+  }
+
+  /*
+   * Validate a URL and return agents pinned to what it resolved to — the
+   * one-call form for HTTP callers. Pair with maxRedirects 0 /
+   * doNotFollowRedirects: pinning only covers the host that was validated, so
+   * a 3xx to an unvalidated host would otherwise walk straight around it.
+   */
+  public static async assertUrlAllowedAndPin(
+    urlString: string,
+    options?: EgressGuardOptions,
+  ): Promise<{ url: URL; addresses: Array<ResolvedAddress> } & PinnedAgents> {
+    const { url, addresses } = await this.assertUrlAllowed(urlString, options);
+
+    return { url, addresses, ...this.createPinnedAgents(addresses) };
+  }
+
+  /*
+   * A dns.lookup-shaped function that validates every hostname it is asked
+   * about and then answers with the addresses it just checked.
+   *
+   * For libraries that build their own request URLs from documents they
+   * fetched (openid-client adopts token_endpoint/userinfo_endpoint/jwks_uri
+   * from the discovery document), pre-validating the one URL we know about
+   * fixes nothing. Installing this as the library's lookup puts the guard on
+   * every socket the library opens, whichever URL it decided to call.
+   */
+  public static createGuardedLookup(
+    options?: EgressGuardOptions,
+  ): EgressLookupFunction {
+    return (
+      hostname: string,
+      lookupOptions: { all?: boolean | undefined; family?: number | undefined },
+      callback: EgressLookupCallback,
+    ): void => {
+      this.assertHostnameAllowed(hostname, options)
+        .then((addresses: Array<ResolvedAddress>) => {
+          const wantedFamily: number | undefined =
+            lookupOptions && lookupOptions.family
+              ? lookupOptions.family
+              : undefined;
+
+          const usable: Array<ResolvedAddress> =
+            wantedFamily === 4 || wantedFamily === 6
+              ? addresses.filter((resolved: ResolvedAddress) => {
+                  return resolved.family === wantedFamily;
+                })
+              : addresses;
+
+          if (usable.length === 0) {
+            const error: NodeJS.ErrnoException = new Error(
+              `No IPv${wantedFamily} address for ${hostname}`,
+            );
+            error.code = "ENOTFOUND";
+            callback(error, "");
+            return;
+          }
+
+          this.createPinnedLookup(usable)(hostname, lookupOptions, callback);
+        })
+        .catch((error: Error) => {
+          callback(error as NodeJS.ErrnoException, "");
+        });
+    };
   }
 }

--- a/Common/Server/Utils/DataSource/HttpFetch.ts
+++ b/Common/Server/Utils/DataSource/HttpFetch.ts
@@ -1,5 +1,3 @@
-import http from "http";
-import https from "https";
 import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
 import API from "../../../Utils/API";
 import Dictionary from "../../../Types/Dictionary";
@@ -8,10 +6,7 @@ import {
   DATA_SOURCE_MAX_RESPONSE_SIZE_IN_BYTES,
   DATA_SOURCE_QUERY_TIMEOUT_IN_MS,
 } from "../../../Types/DataSource/DataSourceLimits";
-import DataSourceEgressGuard, {
-  EgressGuardOptions,
-  ResolvedAddress,
-} from "./EgressGuard";
+import DataSourceEgressGuard, { EgressGuardOptions } from "./EgressGuard";
 import { DataSourceConnectionSettings } from "./Types";
 
 /*
@@ -54,12 +49,6 @@ export interface DataSourceHttpResponse {
   bodyJson: unknown;
 }
 
-type LookupCallback = (
-  error: NodeJS.ErrnoException | null,
-  address: string | Array<{ address: string; family: number }>,
-  family?: number,
-) => void;
-
 export default class DataSourceHttpFetch {
   /*
    * Standard auth headers for a data source: Bearer token wins, else HTTP
@@ -92,44 +81,16 @@ export default class DataSourceHttpFetch {
   public static async fetch(
     request: DataSourceHttpRequest,
   ): Promise<DataSourceHttpResponse> {
-    const { url, addresses } = await DataSourceEgressGuard.assertUrlAllowed(
-      request.url,
-      request.egressOptions,
-    );
-
     /*
      * Pin the validated addresses: whatever getaddrinfo said at validation
      * time is what the socket dials, even if DNS answers differently a
      * millisecond later.
      */
-    const pinnedLookup: (
-      hostname: string,
-      options: { all?: boolean },
-      callback: LookupCallback,
-    ) => void = (
-      _hostname: string,
-      options: { all?: boolean },
-      callback: LookupCallback,
-    ): void => {
-      const first: ResolvedAddress = addresses[0]!;
-      if (options && options.all) {
-        callback(
-          null,
-          addresses.map((resolved: ResolvedAddress) => {
-            return { address: resolved.address, family: resolved.family };
-          }),
-        );
-        return;
-      }
-      callback(null, first.address, first.family);
-    };
-
-    const httpAgent: http.Agent = new http.Agent({
-      lookup: pinnedLookup as never,
-    });
-    const httpsAgent: https.Agent = new https.Agent({
-      lookup: pinnedLookup as never,
-    });
+    const { url, httpAgent, httpsAgent } =
+      await DataSourceEgressGuard.assertUrlAllowedAndPin(
+        request.url,
+        request.egressOptions,
+      );
 
     const headers: Dictionary<string> = { ...(request.headers || {}) };
 

--- a/Common/Server/Utils/LLM/LLMService.ts
+++ b/Common/Server/Utils/LLM/LLMService.ts
@@ -4,11 +4,12 @@ import Headers from "../../../Types/API/Headers";
 import URL from "../../../Types/API/URL";
 import { JSONArray, JSONObject } from "../../../Types/JSON";
 import JSONFunctions from "../../../Types/JSONFunctions";
-import API from "../../../Utils/API";
+import API, { RequestOptions } from "../../../Utils/API";
 import LlmType from "../../../Types/LLM/LlmType";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import logger, { LogAttributes } from "../Logger";
 import CaptureSpan from "../Telemetry/CaptureSpan";
+import DataSourceEgressGuard from "../DataSource/EgressGuard";
 
 export interface LLMToolDefinition {
   name: string;
@@ -653,6 +654,38 @@ export default class LLMService {
    * the offending parameter in the 400 — one parameter per response, hence the
    * loop.
    */
+  /*
+   * Request options for a call to a tenant-configured LLM endpoint.
+   *
+   * LlmProvider.baseUrl is writable by any project member while reading the
+   * apiKey is Owner/Admin-only, so an unguarded request lets a member repoint
+   * a provider at a host they control and collect the decrypted key out of the
+   * auth header — and, because provider error bodies are reflected back
+   * through the LLM provider API, use the same lever as a blind-free read
+   * primitive against the internal network.
+   *
+   * The address the guard checked is pinned into the socket, and redirects are
+   * refused: pinning covers only the validated host, so a 3xx would walk
+   * around it. Private ranges stay reachable on self-hosted installs, because
+   * a self-hosted Ollama on 10.x is the documented deployment.
+   */
+  private static async buildGuardedRequestOptions(
+    requestUrl: string,
+    options: RequestOptions,
+  ): Promise<RequestOptions> {
+    const { httpAgent, httpsAgent } =
+      await DataSourceEgressGuard.assertUrlAllowedAndPin(requestUrl, {
+        targetLabel: "LLM provider",
+      });
+
+    return {
+      ...options,
+      doNotFollowRedirects: true,
+      httpAgent,
+      httpsAgent,
+    };
+  }
+
   private static async postOpenAIChatCompletion(data: {
     requestUrl: string;
     headers: Headers;
@@ -674,6 +707,18 @@ export default class LLMService {
      */
     const attemptedTokenLimitParams: Set<TokenLimitParam> = new Set();
 
+    /*
+     * Validated once, before the first request: the adaptation loop below
+     * re-posts to the same URL, so re-resolving per attempt would only add
+     * DNS round trips (and a rebind window between them).
+     */
+    const requestOptions: RequestOptions =
+      await this.buildGuardedRequestOptions(data.requestUrl, {
+        retries: data.request.requestRetries ?? 2,
+        exponentialBackoff: true,
+        timeout: data.request.requestTimeoutInMs ?? 120000,
+      });
+
     const post: () => Promise<
       HTTPResponse<JSONObject> | HTTPErrorResponse
     > = (): Promise<HTTPResponse<JSONObject> | HTTPErrorResponse> => {
@@ -693,11 +738,7 @@ export default class LLMService {
         url: URL.fromString(data.requestUrl),
         data: body,
         headers: data.headers,
-        options: {
-          retries: data.request.requestRetries ?? 2,
-          exponentialBackoff: true,
-          timeout: data.request.requestTimeoutInMs ?? 120000,
-        },
+        options: requestOptions,
       });
     };
 
@@ -1214,20 +1255,22 @@ export default class LLMService {
       requestData["tools"] = anthropicTools;
     }
 
+    const anthropicRequestUrl: string = `${baseUrl}/messages`;
+
     const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
       await API.post<JSONObject>({
-        url: URL.fromString(`${baseUrl}/messages`),
+        url: URL.fromString(anthropicRequestUrl),
         data: requestData,
         headers: {
           "x-api-key": config.apiKey,
           "anthropic-version": "2023-06-01",
           "Content-Type": "application/json",
         },
-        options: {
+        options: await this.buildGuardedRequestOptions(anthropicRequestUrl, {
           retries: request.requestRetries ?? 2,
           exponentialBackoff: true,
           timeout: request.requestTimeoutInMs ?? 120000,
-        },
+        }),
       });
 
     const anthropicLogAttributes: LogAttributes = {
@@ -1355,18 +1398,20 @@ export default class LLMService {
       requestData["tools"] = this.toOpenAITools(request.tools);
     }
 
+    const ollamaRequestUrl: string = `${config.baseUrl}/api/chat`;
+
     const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
       await API.post<JSONObject>({
-        url: URL.fromString(`${config.baseUrl}/api/chat`),
+        url: URL.fromString(ollamaRequestUrl),
         data: requestData,
         headers: {
           "Content-Type": "application/json",
         },
-        options: {
+        options: await this.buildGuardedRequestOptions(ollamaRequestUrl, {
           retries: request.requestRetries ?? 2,
           exponentialBackoff: true,
           timeout: request.requestTimeoutInMs ?? 300000, // Ollama may be slower
-        },
+        }),
       });
 
     const ollamaLogAttributes: LogAttributes = {

--- a/Common/Tests/Server/Services/DomainSubdomainHooks.test.ts
+++ b/Common/Tests/Server/Services/DomainSubdomainHooks.test.ts
@@ -1,0 +1,94 @@
+import StatusPageDomainService from "../../../Server/Services/StatusPageDomainService";
+import DashboardDomainService from "../../../Server/Services/DashboardDomainService";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Subdomain validation is only a control if it is actually wired into BOTH
+ * hooks. subdomain is ProjectMember-updatable, so create-time validation on
+ * its own leaves the value editable straight afterwards. These tests call the
+ * hooks directly — no database is touched, because the update hook only
+ * inspects the payload.
+ */
+
+interface SubdomainUpdate {
+  data: { subdomain?: string | undefined };
+}
+
+type CallOnBeforeUpdate = (
+  service: unknown,
+  update: SubdomainUpdate,
+) => Promise<SubdomainUpdate>;
+
+const callOnBeforeUpdate: CallOnBeforeUpdate = async (
+  service: unknown,
+  update: SubdomainUpdate,
+): Promise<SubdomainUpdate> => {
+  const result: { updateBy: SubdomainUpdate } = await (
+    service as {
+      onBeforeUpdate: (u: SubdomainUpdate) => Promise<{
+        updateBy: SubdomainUpdate;
+      }>;
+    }
+  ).onBeforeUpdate(update);
+
+  return result.updateBy;
+};
+
+const services: Array<[string, unknown]> = [
+  ["StatusPageDomainService", StatusPageDomainService],
+  ["DashboardDomainService", DashboardDomainService],
+];
+
+describe.each(services)(
+  "%s.onBeforeUpdate",
+  (_name: string, service: unknown) => {
+    test("rejects a subdomain carrying a path and a fragment", async () => {
+      await expect(
+        callOnBeforeUpdate(service, {
+          data: { subdomain: "169.254.169.254/latest/meta-data/#" },
+        }),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    test("rejects a subdomain carrying a scheme", async () => {
+      await expect(
+        callOnBeforeUpdate(service, {
+          data: { subdomain: "http://169.254.169.254" },
+        }),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    test("rejects a subdomain carrying a port", async () => {
+      await expect(
+        callOnBeforeUpdate(service, {
+          data: { subdomain: "169.254.169.254:80" },
+        }),
+      ).rejects.toThrow(BadDataException);
+    });
+
+    test("accepts and normalizes an ordinary subdomain", async () => {
+      const updated: SubdomainUpdate = await callOnBeforeUpdate(service, {
+        data: { subdomain: "  STATUS  " },
+      });
+
+      expect(updated.data.subdomain).toBe("status");
+    });
+
+    test("treats @ as the apex", async () => {
+      const updated: SubdomainUpdate = await callOnBeforeUpdate(service, {
+        data: { subdomain: "@" },
+      });
+
+      expect(updated.data.subdomain).toBe("");
+    });
+
+    test("leaves an update that does not touch the subdomain alone", async () => {
+      const updated: SubdomainUpdate = await callOnBeforeUpdate(service, {
+        data: {},
+      });
+
+      expect(updated.data.subdomain).toBeUndefined();
+    });
+  },
+);

--- a/Common/Tests/Server/Services/UserWebhookSSRF.test.ts
+++ b/Common/Tests/Server/Services/UserWebhookSSRF.test.ts
@@ -1,0 +1,174 @@
+import UserWebhookService from "../../../Server/Services/UserWebhookService";
+import SSRFProtection from "../../../Server/Utils/SSRFProtection";
+import URL from "../../../Types/API/URL";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import dns from "dns";
+
+/*
+ * UserWebhookService used to carry its own copy of the SSRF blocklist, and the
+ * copy had drifted weaker than the original: it compared the host with the
+ * port still attached (so "169.254.169.254:80" slipped through), never
+ * resolved DNS, and only ran on create. Nothing depended on it — every sender
+ * goes through WebhookService, which calls the real guard — but a weakened
+ * lookalike reads as "this is checked".
+ *
+ * These tests assert both hooks now call the canonical guard, including the
+ * cases the local copy got wrong.
+ */
+
+type LookupSpy = jest.SpiedFunction<
+  (
+    hostname: string,
+    options: { all: true },
+  ) => Promise<Array<{ address: string; family: number }>>
+>;
+
+interface WebhookCreate {
+  data: { webhookUrl?: URL | undefined; name?: string | undefined };
+}
+
+interface WebhookUpdate {
+  data: { webhookUrl?: URL | undefined };
+}
+
+type CallCreate = (create: WebhookCreate) => Promise<unknown>;
+
+const callOnBeforeCreate: CallCreate = (
+  create: WebhookCreate,
+): Promise<unknown> => {
+  return (
+    UserWebhookService as unknown as {
+      onBeforeCreate: (c: WebhookCreate) => Promise<unknown>;
+    }
+  ).onBeforeCreate(create);
+};
+
+type CallUpdate = (update: WebhookUpdate) => Promise<unknown>;
+
+const callOnBeforeUpdate: CallUpdate = (
+  update: WebhookUpdate,
+): Promise<unknown> => {
+  return (
+    UserWebhookService as unknown as {
+      onBeforeUpdate: (u: WebhookUpdate) => Promise<unknown>;
+    }
+  ).onBeforeUpdate(update);
+};
+
+let lookupSpy: LookupSpy;
+
+beforeEach(() => {
+  lookupSpy = jest.spyOn(dns.promises, "lookup") as unknown as LookupSpy;
+  lookupSpy.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("UserWebhookService no longer carries its own SSRF check", () => {
+  test("the weakened local helper is gone", () => {
+    expect(
+      (UserWebhookService as unknown as { validateWebhookUrl?: unknown })
+        .validateWebhookUrl,
+    ).toBeUndefined();
+  });
+
+  test("onBeforeCreate delegates to SSRFProtection", async () => {
+    const guardSpy: ReturnType<typeof jest.spyOn> = jest.spyOn(
+      SSRFProtection,
+      "validateWebhookTargetIsSafe",
+    );
+
+    await callOnBeforeCreate({
+      data: {
+        webhookUrl: URL.fromString("https://hooks.example.com/x"),
+        name: "test",
+      },
+    });
+
+    expect(guardSpy).toHaveBeenCalled();
+  });
+});
+
+describe("UserWebhookService rejects internal webhook URLs on create", () => {
+  const blockedUrls: Array<string> = [
+    "http://127.0.0.1/webhook",
+    "http://169.254.169.254/latest/meta-data/",
+    // The port-glue case the local copy let through.
+    "http://169.254.169.254:80/latest/meta-data/",
+    "http://localhost:3000/webhook",
+    "http://10.0.0.5/webhook",
+    "http://[::1]/webhook",
+  ];
+
+  test.each(blockedUrls)("rejects %s", async (rawUrl: string) => {
+    await expect(
+      callOnBeforeCreate({
+        data: { webhookUrl: URL.fromString(rawUrl), name: "test" },
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("rejects a public hostname that resolves to an internal address", async () => {
+    // The DNS branch the local copy never had.
+    lookupSpy.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+
+    await expect(
+      callOnBeforeCreate({
+        data: {
+          webhookUrl: URL.fromString("https://rebind.attacker.example/x"),
+          name: "test",
+        },
+      }),
+    ).rejects.toThrow();
+  });
+
+  test("allows a public webhook URL", async () => {
+    await expect(
+      callOnBeforeCreate({
+        data: {
+          webhookUrl: URL.fromString("https://hooks.example.com/x"),
+          name: "test",
+        },
+      }),
+    ).resolves.toBeDefined();
+  });
+});
+
+describe("UserWebhookService validates on update too", () => {
+  const blockedUrls: Array<string> = [
+    "http://127.0.0.1/webhook",
+    "http://169.254.169.254:80/latest/meta-data/",
+    "http://10.0.0.5/webhook",
+  ];
+
+  test.each(blockedUrls)(
+    "rejects an update repointing the webhook at %s",
+    async (rawUrl: string) => {
+      await expect(
+        callOnBeforeUpdate({ data: { webhookUrl: URL.fromString(rawUrl) } }),
+      ).rejects.toThrow();
+    },
+  );
+
+  test("allows an update to a public URL", async () => {
+    await expect(
+      callOnBeforeUpdate({
+        data: { webhookUrl: URL.fromString("https://hooks.example.com/x") },
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  test("leaves an update that does not touch the URL alone", async () => {
+    await expect(callOnBeforeUpdate({ data: {} })).resolves.toBeDefined();
+    expect(lookupSpy).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Services/WebPushEndpointAllowlist.test.ts
+++ b/Common/Tests/Server/Services/WebPushEndpointAllowlist.test.ts
@@ -1,0 +1,133 @@
+import PushNotificationService from "../../../Server/Services/PushNotificationService";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * A Web Push subscription is a JSON blob the browser hands the client, which
+ * OneUptime stores verbatim in UserPush.deviceToken and later passes to
+ * web-push. web-push POSTs to whatever "endpoint" names — host, port and path
+ * — so an attacker who can register a device controls the destination of a
+ * request the server makes from inside its own network.
+ *
+ * Only the browser vendors' push services are legitimate destinations, so the
+ * check is an allowlist. It parses with the WHATWG parser on purpose: that is
+ * the parser web-push uses, so what is validated is what gets dialed.
+ */
+
+type Assert = (endpoint: unknown) => void;
+
+const assertAllowed: Assert = (endpoint: unknown): void => {
+  PushNotificationService.assertWebPushEndpointIsAllowed(endpoint);
+};
+
+describe("Web push endpoint allowlist accepts the real push services", () => {
+  const allowedEndpoints: Array<string> = [
+    "https://updates.push.services.mozilla.com/wpush/v2/gAAAAA",
+    "https://push.services.mozilla.com/wpush/v2/gAAAAA",
+    "https://fcm.googleapis.com/fcm/send/abc123",
+    "https://fcm.googleapis.com/wp/abc123",
+    "https://android.googleapis.com/gcm/send/abc123",
+    "https://web.push.apple.com/QLtc-abc123",
+    "https://par02p.notify.windows.com/w/?token=abc",
+    "https://notify.windows.com/w/?token=abc",
+  ];
+
+  test.each(allowedEndpoints)("allows %s", (endpoint: string) => {
+    expect(() => {
+      return assertAllowed(endpoint);
+    }).not.toThrow();
+  });
+});
+
+describe("Web push endpoint allowlist blocks internal targets", () => {
+  const blockedEndpoints: Array<string> = [
+    "http://127.0.0.1:8080/push",
+    "https://127.0.0.1:8080/push",
+    "http://169.254.169.254/latest/meta-data/",
+    "https://169.254.169.254/latest/meta-data/",
+    "http://localhost:9200/_search",
+    "https://10.0.0.5/internal",
+    "https://[::1]/push",
+    "https://metadata.google.internal/computeMetadata/v1/",
+  ];
+
+  test.each(blockedEndpoints)("blocks %s", (endpoint: string) => {
+    expect(() => {
+      return assertAllowed(endpoint);
+    }).toThrow();
+  });
+});
+
+describe("Web push endpoint allowlist resists lookalike hosts", () => {
+  const lookalikes: Array<string> = [
+    // Suffix matching must be anchored on a dot.
+    "https://evilfcm.googleapis.com/fcm/send/x",
+    "https://notfcm.googleapis.com/fcm/send/x",
+    // The allowed name as a prefix of an attacker's domain.
+    "https://fcm.googleapis.com.attacker.example/fcm/send/x",
+    "https://push.apple.com.attacker.example/x",
+    // The allowed name in the path or the query, not the host.
+    "https://attacker.example/fcm.googleapis.com",
+    "https://attacker.example/?x=https://fcm.googleapis.com",
+    // The allowed name as userinfo — the classic parser differential.
+    "https://fcm.googleapis.com@attacker.example/x",
+    "https://push.apple.com:443@attacker.example/x",
+    "https://fcm.googleapis.com:80@169.254.169.254/latest/meta-data/",
+  ];
+
+  test.each(lookalikes)("blocks %s", (endpoint: string) => {
+    expect(() => {
+      return assertAllowed(endpoint);
+    }).toThrow();
+  });
+
+  test("a userinfo lookalike is refused because the real host is read", () => {
+    /*
+     * Guard against a regression to a parser that splits on ":" before "@":
+     * that reads the host as "push.apple.com" while the socket goes to
+     * 169.254.169.254.
+     */
+    expect(() => {
+      return assertAllowed(
+        "https://push.apple.com:80@169.254.169.254/latest/meta-data/",
+      );
+    }).toThrow("169.254.169.254");
+  });
+});
+
+describe("Web push endpoint allowlist rejects unusable endpoints", () => {
+  test("requires https", () => {
+    expect(() => {
+      return assertAllowed("http://fcm.googleapis.com/fcm/send/x");
+    }).toThrow("https");
+  });
+
+  test("rejects a non-http scheme", () => {
+    expect(() => {
+      return assertAllowed("file:///etc/passwd");
+    }).toThrow();
+
+    expect(() => {
+      return assertAllowed("gopher://fcm.googleapis.com/x");
+    }).toThrow();
+  });
+
+  test("rejects a missing or non-string endpoint", () => {
+    expect(() => {
+      return assertAllowed(undefined);
+    }).toThrow();
+
+    expect(() => {
+      return assertAllowed("");
+    }).toThrow();
+
+    expect(() => {
+      return assertAllowed({ endpoint: "https://fcm.googleapis.com/x" });
+    }).toThrow();
+  });
+
+  test("rejects an unparseable endpoint", () => {
+    expect(() => {
+      return assertAllowed("not a url");
+    }).toThrow();
+  });
+});

--- a/Common/Tests/Server/Utils/AI/LLMServiceBaseUrl.test.ts
+++ b/Common/Tests/Server/Utils/AI/LLMServiceBaseUrl.test.ts
@@ -4,6 +4,7 @@ import URL from "../../../../Types/API/URL";
 import { JSONObject } from "../../../../Types/JSON";
 import LlmType from "../../../../Types/LLM/LlmType";
 import LLMService from "../../../../Server/Utils/LLM/LLMService";
+import DataSourceEgressGuard from "../../../../Server/Utils/DataSource/EgressGuard";
 import { afterEach, describe, expect, jest, test } from "@jest/globals";
 
 /*
@@ -14,7 +15,27 @@ import { afterEach, describe, expect, jest, test } from "@jest/globals";
  * we hand to URL.fromString for a range of configured base URLs.
  */
 
+/*
+ * These tests are about URL shaping, not egress policy: the hosts below are
+ * deliberately unresolvable placeholders. Stub the SSRF guard so no DNS is
+ * attempted — LLMService now validates and pins every provider URL before
+ * posting, which is covered by LLMServiceEgressGuard.test.ts.
+ */
+function mockEgressGuardAllows(): void {
+  jest
+    .spyOn(DataSourceEgressGuard, "assertUrlAllowedAndPin")
+    .mockImplementation((urlString: string) => {
+      return Promise.resolve({
+        url: new globalThis.URL(urlString),
+        addresses: [{ address: "93.184.216.34", family: 4 }],
+        httpAgent: undefined as never,
+        httpsAgent: undefined as never,
+      });
+    });
+}
+
 function mockPostSuccess(): void {
+  mockEgressGuardAllows();
   jest.spyOn(API, "post").mockResolvedValue({
     jsonData: {
       choices: [{ message: { content: "ok" } }],

--- a/Common/Tests/Server/Utils/AI/LLMServiceBaseUrl.test.ts
+++ b/Common/Tests/Server/Utils/AI/LLMServiceBaseUrl.test.ts
@@ -4,7 +4,7 @@ import URL from "../../../../Types/API/URL";
 import { JSONObject } from "../../../../Types/JSON";
 import LlmType from "../../../../Types/LLM/LlmType";
 import LLMService from "../../../../Server/Utils/LLM/LLMService";
-import DataSourceEgressGuard from "../../../../Server/Utils/DataSource/EgressGuard";
+import stubLLMEgressGuard from "./StubLLMEgressGuard";
 import { afterEach, describe, expect, jest, test } from "@jest/globals";
 
 /*
@@ -15,27 +15,9 @@ import { afterEach, describe, expect, jest, test } from "@jest/globals";
  * we hand to URL.fromString for a range of configured base URLs.
  */
 
-/*
- * These tests are about URL shaping, not egress policy: the hosts below are
- * deliberately unresolvable placeholders. Stub the SSRF guard so no DNS is
- * attempted — LLMService now validates and pins every provider URL before
- * posting, which is covered by LLMServiceEgressGuard.test.ts.
- */
-function mockEgressGuardAllows(): void {
-  jest
-    .spyOn(DataSourceEgressGuard, "assertUrlAllowedAndPin")
-    .mockImplementation((urlString: string) => {
-      return Promise.resolve({
-        url: new globalThis.URL(urlString),
-        addresses: [{ address: "93.184.216.34", family: 4 }],
-        httpAgent: undefined as never,
-        httpsAgent: undefined as never,
-      });
-    });
-}
-
 function mockPostSuccess(): void {
-  mockEgressGuardAllows();
+  // Placeholder hosts; egress policy is covered by LLMServiceEgressGuard.test.ts.
+  stubLLMEgressGuard();
   jest.spyOn(API, "post").mockResolvedValue({
     jsonData: {
       choices: [{ message: { content: "ok" } }],

--- a/Common/Tests/Server/Utils/AI/LLMServiceEgressGuard.test.ts
+++ b/Common/Tests/Server/Utils/AI/LLMServiceEgressGuard.test.ts
@@ -1,0 +1,315 @@
+import API, { RequestOptions } from "../../../../Utils/API";
+import HTTPResponse from "../../../../Types/API/HTTPResponse";
+import { JSONObject } from "../../../../Types/JSON";
+import LlmType from "../../../../Types/LLM/LlmType";
+import LLMService from "../../../../Server/Utils/LLM/LLMService";
+import DataSourceEgressGuard, {
+  EgressResolveFunction,
+  ResolvedAddress,
+} from "../../../../Server/Utils/DataSource/EgressGuard";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import dns from "dns";
+
+/*
+ * LlmProvider.baseUrl is writable by any ProjectMember, while reading the
+ * provider's apiKey is restricted to Owner/Admin. So an unguarded outbound
+ * request is a privilege escalation with two payouts: the decrypted key goes
+ * out in the auth header of a request to a host the member chose, and the
+ * provider's error body is reflected back through the LLM provider API, which
+ * turns the same lever into a read primitive against the internal network.
+ *
+ * These tests assert that no request leaves for an internal address, that the
+ * checked address is pinned into the socket, and that redirects are refused.
+ * DNS is mocked so they are deterministic and offline.
+ */
+
+type LookupSpy = jest.SpiedFunction<
+  (
+    hostname: string,
+    options: { all: true },
+  ) => Promise<Array<{ address: string; family: number }>>
+>;
+
+let lookupSpy: LookupSpy;
+
+// Every API.post the service made, so tests can assert on "never sent".
+const postCalls: Array<{ options?: RequestOptions | undefined }> = [];
+
+function mockPostSuccess(): void {
+  jest.spyOn(API, "post").mockImplementation(((options: {
+    options?: RequestOptions | undefined;
+  }) => {
+    postCalls.push(options);
+
+    return Promise.resolve({
+      jsonData: {
+        choices: [{ message: { content: "ok" } }],
+        content: [{ type: "text", text: "ok" }],
+        message: { content: "ok" },
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    } as unknown as HTTPResponse<JSONObject>);
+  }) as never);
+}
+
+function lastPostOptions(): RequestOptions {
+  return postCalls[postCalls.length - 1]!.options as RequestOptions;
+}
+
+beforeEach(() => {
+  postCalls.length = 0;
+  lookupSpy = jest.spyOn(dns.promises, "lookup") as unknown as LookupSpy;
+
+  /*
+   * Stand in for getaddrinfo: "localhost" is loopback, everything else is a
+   * public address. Individual tests override this to model rebinding.
+   */
+  lookupSpy.mockImplementation((hostname: string) => {
+    if (hostname === "localhost") {
+      return Promise.resolve([{ address: "127.0.0.1", family: 4 }]);
+    }
+
+    return Promise.resolve([{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  mockPostSuccess();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("LLMService refuses internal LLM provider base URLs", () => {
+  const blockedBaseUrls: Array<string> = [
+    "http://127.0.0.1:11434",
+    "http://localhost:11434",
+    "http://169.254.169.254",
+    "http://169.254.169.254:80",
+    "http://[::1]:11434",
+    "http://0.0.0.0:11434",
+  ];
+
+  test.each(blockedBaseUrls)(
+    "OpenAI-compatible provider at %s never posts",
+    async (baseUrl: string) => {
+      await expect(
+        LLMService.getCompletion({
+          llmProviderConfig: {
+            llmType: LlmType.OpenAICompatible,
+            apiKey: "sk-secret",
+            modelName: "some-model",
+            baseUrl,
+          },
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      ).rejects.toThrow();
+
+      expect(postCalls).toHaveLength(0);
+    },
+  );
+
+  test("Ollama provider at a loopback base URL never posts", async () => {
+    await expect(
+      LLMService.getCompletion({
+        llmProviderConfig: {
+          llmType: LlmType.Ollama,
+          modelName: "llama2",
+          baseUrl: "http://127.0.0.1:11434",
+        },
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    ).rejects.toThrow();
+
+    expect(postCalls).toHaveLength(0);
+  });
+
+  test("Anthropic provider repointed at the metadata endpoint never posts", async () => {
+    await expect(
+      LLMService.getCompletion({
+        llmProviderConfig: {
+          llmType: LlmType.Anthropic,
+          apiKey: "sk-ant-secret",
+          modelName: "claude-sonnet-4-20250514",
+          baseUrl: "http://169.254.169.254/latest",
+        },
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    ).rejects.toThrow();
+
+    expect(postCalls).toHaveLength(0);
+  });
+
+  test("Azure provider repointed at loopback never posts", async () => {
+    await expect(
+      LLMService.getCompletion({
+        llmProviderConfig: {
+          llmType: LlmType.AzureOpenAI,
+          apiKey: "azure-secret",
+          modelName: "gpt-4o",
+          baseUrl: "http://127.0.0.1/openai/deployments/gpt-4o",
+        },
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    ).rejects.toThrow();
+
+    expect(postCalls).toHaveLength(0);
+  });
+
+  test("a public hostname that resolves to a private address never posts", async () => {
+    // The DNS-rebinding shape: the name looks fine, the answer does not.
+    lookupSpy.mockResolvedValue([{ address: "10.0.0.5", family: 4 }]);
+
+    /*
+     * Private ranges are only blocked under SaaS policy; this is the
+     * documented switch that turns it on for a self-hosted install.
+     */
+    process.env["DATA_SOURCE_BLOCK_PRIVATE_ADDRESSES"] = "true";
+
+    try {
+      await expect(
+        LLMService.getCompletion({
+          llmProviderConfig: {
+            llmType: LlmType.OpenAICompatible,
+            apiKey: "sk-secret",
+            modelName: "some-model",
+            baseUrl: "https://ollama.attacker.example/v1",
+          },
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      ).rejects.toThrow();
+    } finally {
+      delete process.env["DATA_SOURCE_BLOCK_PRIVATE_ADDRESSES"];
+    }
+
+    expect(postCalls).toHaveLength(0);
+  });
+});
+
+describe("LLMService pins and refuses redirects on allowed providers", () => {
+  test("a public provider posts with redirects disabled and pinned agents", async () => {
+    await LLMService.getCompletion({
+      llmProviderConfig: {
+        llmType: LlmType.OpenAICompatible,
+        apiKey: "sk-secret",
+        modelName: "some-model",
+        baseUrl: "https://gateway.example.com/v1",
+      },
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    const options: RequestOptions = lastPostOptions();
+
+    expect(options.doNotFollowRedirects).toBe(true);
+    expect(options.httpAgent).toBeDefined();
+    expect(options.httpsAgent).toBeDefined();
+  });
+
+  test("the pinned agent dials the address that was validated", async () => {
+    lookupSpy.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+
+    await LLMService.getCompletion({
+      llmProviderConfig: {
+        llmType: LlmType.Anthropic,
+        apiKey: "sk-ant-secret",
+        modelName: "claude-sonnet-4-20250514",
+        baseUrl: "https://api.anthropic.com/v1",
+      },
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    const options: RequestOptions = lastPostOptions();
+
+    const lookup: (
+      hostname: string,
+      lookupOptions: { all?: boolean },
+      callback: (error: Error | null, address: string, family?: number) => void,
+    ) => void = (
+      options.httpsAgent as unknown as {
+        options: {
+          lookup: (
+            hostname: string,
+            lookupOptions: { all?: boolean },
+            callback: (
+              error: Error | null,
+              address: string,
+              family?: number,
+            ) => void,
+          ) => void;
+        };
+      }
+    ).options.lookup;
+
+    const dialed: string = await new Promise((resolve: (v: string) => void) => {
+      lookup(
+        "api.anthropic.com",
+        { all: false },
+        (_error: Error | null, address: string) => {
+          resolve(address);
+        },
+      );
+    });
+
+    expect(dialed).toBe("93.184.216.34");
+  });
+
+  test("the guard resolves once per completion, not once per retry", async () => {
+    /*
+     * postOpenAIChatCompletion re-posts when the provider rejects a generation
+     * parameter. Re-resolving per attempt would add a fresh rebind window
+     * between attempts.
+     */
+    await LLMService.getCompletion({
+      llmProviderConfig: {
+        llmType: LlmType.OpenAICompatible,
+        apiKey: "sk-secret",
+        modelName: "some-model",
+        baseUrl: "https://gateway.example.com/v1",
+      },
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(lookupSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("DataSourceEgressGuard self-hosted policy for LLM providers", () => {
+  const resolveToPrivate: EgressResolveFunction = (): Promise<
+    Array<ResolvedAddress>
+  > => {
+    return Promise.resolve([{ address: "10.0.0.5", family: 4 }]);
+  };
+
+  test("a self-hosted Ollama on a private address is still reachable", async () => {
+    // The documented deployment: blockPrivateAddresses off (no billing).
+    await expect(
+      DataSourceEgressGuard.assertUrlAllowed("http://ollama.internal:11434", {
+        blockPrivateAddresses: false,
+        resolveFunction: resolveToPrivate,
+        targetLabel: "LLM provider",
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  test("but loopback and link-local are blocked even self-hosted", async () => {
+    await expect(
+      DataSourceEgressGuard.assertUrlAllowed("http://127.0.0.1:11434", {
+        blockPrivateAddresses: false,
+        targetLabel: "LLM provider",
+      }),
+    ).rejects.toThrow();
+
+    await expect(
+      DataSourceEgressGuard.assertUrlAllowed("http://169.254.169.254/", {
+        blockPrivateAddresses: false,
+        targetLabel: "LLM provider",
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/Common/Tests/Server/Utils/AI/LLMServiceModelCompatibility.test.ts
+++ b/Common/Tests/Server/Utils/AI/LLMServiceModelCompatibility.test.ts
@@ -1,4 +1,5 @@
 import API from "../../../../Utils/API";
+import stubLLMEgressGuard from "./StubLLMEgressGuard";
 import logger from "../../../../Server/Utils/Logger";
 import HTTPErrorResponse from "../../../../Types/API/HTTPErrorResponse";
 import HTTPResponse from "../../../../Types/API/HTTPResponse";
@@ -90,6 +91,8 @@ function bodyOf(spy: PostSpy, callIndex: number): JSONObject {
 }
 
 beforeEach(() => {
+  // These hosts are placeholders; the SSRF guard is covered elsewhere.
+  stubLLMEgressGuard();
   LLMService.clearRequestAdaptationCache();
   jest.spyOn(logger, "debug").mockImplementation((): void => {});
   jest.spyOn(logger, "error").mockImplementation((): void => {});

--- a/Common/Tests/Server/Utils/AI/LLMServiceRequestPolicy.test.ts
+++ b/Common/Tests/Server/Utils/AI/LLMServiceRequestPolicy.test.ts
@@ -7,7 +7,8 @@ import LlmType from "../../../../Types/LLM/LlmType";
 import LLMService, {
   LLMProviderConfig,
 } from "../../../../Server/Utils/LLM/LLMService";
-import { afterEach, describe, expect, test } from "@jest/globals";
+import stubLLMEgressGuard from "./StubLLMEgressGuard";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
 
 type PostSpy = ReturnType<typeof jest.spyOn>;
 
@@ -83,6 +84,11 @@ function mockPost(response: JSONObject): PostSpy {
   } as unknown as HTTPResponse<JSONObject>) as PostSpy;
 }
 
+// These hosts are placeholders; the SSRF guard is covered elsewhere.
+beforeEach(() => {
+  stubLLMEgressGuard();
+});
+
 afterEach(() => {
   jest.restoreAllMocks();
 });
@@ -103,11 +109,16 @@ describe("LLMService request timeout and retry policy", () => {
       expect(postSpy).toHaveBeenCalledTimes(1);
       expect(postSpy.mock.calls[0]![0]).toEqual(
         expect.objectContaining({
-          options: {
+          options: expect.objectContaining({
             retries: 0,
             exponentialBackoff: true,
             timeout: 12_345,
-          },
+            /*
+             * Every provider request also carries the SSRF guard's
+             * settings — the policy above must not displace them.
+             */
+            doNotFollowRedirects: true,
+          }),
         }),
       );
     },
@@ -125,11 +136,12 @@ describe("LLMService request timeout and retry policy", () => {
 
       expect(postSpy.mock.calls[0]![0]).toEqual(
         expect.objectContaining({
-          options: {
+          options: expect.objectContaining({
             retries: 2,
             exponentialBackoff: true,
             timeout: defaultTimeoutInMs,
-          },
+            doNotFollowRedirects: true,
+          }),
         }),
       );
     },

--- a/Common/Tests/Server/Utils/AI/LLMServiceToolCalling.test.ts
+++ b/Common/Tests/Server/Utils/AI/LLMServiceToolCalling.test.ts
@@ -5,7 +5,15 @@ import LlmType from "../../../../Types/LLM/LlmType";
 import LLMService, {
   LLMCompletionResponse,
 } from "../../../../Server/Utils/LLM/LLMService";
-import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import stubLLMEgressGuard from "./StubLLMEgressGuard";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
 
 type PostSpy = ReturnType<typeof jest.spyOn>;
 
@@ -14,6 +22,11 @@ function mockPostResponse(jsonData: JSONObject): PostSpy {
     jsonData,
   } as unknown as HTTPResponse<JSONObject>) as PostSpy;
 }
+
+// These hosts are placeholders; the SSRF guard is covered elsewhere.
+beforeEach(() => {
+  stubLLMEgressGuard();
+});
 
 afterEach(() => {
   jest.restoreAllMocks();

--- a/Common/Tests/Server/Utils/AI/StubLLMEgressGuard.ts
+++ b/Common/Tests/Server/Utils/AI/StubLLMEgressGuard.ts
@@ -1,0 +1,25 @@
+import DataSourceEgressGuard from "../../../../Server/Utils/DataSource/EgressGuard";
+import { jest } from "@jest/globals";
+
+/*
+ * LLMService validates and pins every provider URL through the SSRF egress
+ * guard before posting, which means a real DNS lookup for whatever host the
+ * test configured. The suites that are about request SHAPE rather than egress
+ * policy use unresolvable placeholder hosts ("http://host:8000"), so they stub
+ * the guard and stay offline.
+ *
+ * Call this from a beforeEach, before the API.post stub. Egress policy itself
+ * is covered by LLMServiceEgressGuard.test.ts, which does NOT stub it.
+ */
+export default function stubLLMEgressGuard(): void {
+  jest
+    .spyOn(DataSourceEgressGuard, "assertUrlAllowedAndPin")
+    .mockImplementation((urlString: string) => {
+      return Promise.resolve({
+        url: new globalThis.URL(urlString),
+        addresses: [{ address: "93.184.216.34", family: 4 }],
+        httpAgent: undefined as never,
+        httpsAgent: undefined as never,
+      });
+    });
+}

--- a/Common/Tests/Server/Utils/DataSource/EgressGuardPinning.test.ts
+++ b/Common/Tests/Server/Utils/DataSource/EgressGuardPinning.test.ts
@@ -1,0 +1,330 @@
+import DataSourceEgressGuard, {
+  EgressLookupFunction,
+  EgressResolveFunction,
+  PinnedAgents,
+  ResolvedAddress,
+} from "../../../../Server/Utils/DataSource/EgressGuard";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The egress guard is only half a control on its own: validating an address
+ * and then letting the socket re-resolve the hostname leaves a DNS-rebind
+ * window, and a redirect walks around the check entirely. These tests pin the
+ * two pieces that close the first half — the pinned lookup handed to an
+ * http.Agent, and the guarded lookup handed to libraries that build their own
+ * URLs — plus the message labelling that lets one guard serve several
+ * subsystems.
+ *
+ * DNS is injected everywhere, so nothing here touches the network.
+ */
+
+type ResolverFor = (addresses: Array<ResolvedAddress>) => EgressResolveFunction;
+
+const resolverFor: ResolverFor = (
+  addresses: Array<ResolvedAddress>,
+): EgressResolveFunction => {
+  return (): Promise<Array<ResolvedAddress>> => {
+    return Promise.resolve(addresses);
+  };
+};
+
+interface LookupResult {
+  error: NodeJS.ErrnoException | null;
+  address: string | Array<{ address: string; family: number }>;
+  family?: number | undefined;
+}
+
+type CallLookup = (
+  lookup: EgressLookupFunction,
+  hostname: string,
+  options: { all?: boolean | undefined; family?: number | undefined },
+) => Promise<LookupResult>;
+
+const callLookup: CallLookup = (
+  lookup: EgressLookupFunction,
+  hostname: string,
+  options: { all?: boolean | undefined; family?: number | undefined },
+): Promise<LookupResult> => {
+  return new Promise((resolve: (value: LookupResult) => void) => {
+    lookup(
+      hostname,
+      options,
+      (
+        error: NodeJS.ErrnoException | null,
+        address: string | Array<{ address: string; family: number }>,
+        family?: number,
+      ) => {
+        resolve({ error, address, family });
+      },
+    );
+  });
+};
+
+describe("DataSourceEgressGuard.createPinnedLookup", () => {
+  const addresses: Array<ResolvedAddress> = [
+    { address: "93.184.216.34", family: 4 },
+    { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+  ];
+
+  test("answers with every validated address when all is set", async () => {
+    const lookup: EgressLookupFunction =
+      DataSourceEgressGuard.createPinnedLookup(addresses);
+
+    const result: LookupResult = await callLookup(lookup, "anything.example", {
+      all: true,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.address).toEqual([
+      { address: "93.184.216.34", family: 4 },
+      { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+    ]);
+  });
+
+  test("answers with the first validated address when all is not set", async () => {
+    const lookup: EgressLookupFunction =
+      DataSourceEgressGuard.createPinnedLookup(addresses);
+
+    const result: LookupResult = await callLookup(lookup, "anything.example", {
+      all: false,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.address).toBe("93.184.216.34");
+    expect(result.family).toBe(4);
+  });
+
+  test("ignores the hostname it is asked about — the pin is the point", async () => {
+    /*
+     * This is the anti-rebind property: once validated, the socket dials the
+     * checked address no matter what DNS would say a millisecond later.
+     */
+    const lookup: EgressLookupFunction =
+      DataSourceEgressGuard.createPinnedLookup([
+        { address: "93.184.216.34", family: 4 },
+      ]);
+
+    const result: LookupResult = await callLookup(
+      lookup,
+      "rebind.attacker.example",
+      { all: false },
+    );
+
+    expect(result.address).toBe("93.184.216.34");
+  });
+});
+
+describe("DataSourceEgressGuard.createPinnedAgents", () => {
+  test("builds http and https agents that both carry the pinned lookup", async () => {
+    const agents: PinnedAgents = DataSourceEgressGuard.createPinnedAgents([
+      { address: "93.184.216.34", family: 4 },
+    ]);
+
+    const httpLookup: EgressLookupFunction = (
+      agents.httpAgent as unknown as {
+        options: { lookup: EgressLookupFunction };
+      }
+    ).options.lookup;
+    const httpsLookup: EgressLookupFunction = (
+      agents.httpsAgent as unknown as {
+        options: { lookup: EgressLookupFunction };
+      }
+    ).options.lookup;
+
+    expect(typeof httpLookup).toBe("function");
+    expect(typeof httpsLookup).toBe("function");
+
+    await expect(
+      callLookup(httpLookup, "example.com", { all: false }),
+    ).resolves.toMatchObject({ address: "93.184.216.34" });
+    await expect(
+      callLookup(httpsLookup, "example.com", { all: false }),
+    ).resolves.toMatchObject({ address: "93.184.216.34" });
+  });
+});
+
+describe("DataSourceEgressGuard.assertUrlAllowedAndPin", () => {
+  test("returns agents pinned to the validated address", async () => {
+    const result: { addresses: Array<ResolvedAddress> } & PinnedAgents =
+      await DataSourceEgressGuard.assertUrlAllowedAndPin(
+        "https://provider.example.com/v1",
+        {
+          blockPrivateAddresses: true,
+          resolveFunction: resolverFor([
+            { address: "93.184.216.34", family: 4 },
+          ]),
+        },
+      );
+
+    expect(result.addresses).toEqual([{ address: "93.184.216.34", family: 4 }]);
+    expect(result.httpAgent).toBeDefined();
+    expect(result.httpsAgent).toBeDefined();
+  });
+
+  test("rejects the metadata endpoint before any agent is built", async () => {
+    await expect(
+      DataSourceEgressGuard.assertUrlAllowedAndPin(
+        "http://169.254.169.254/latest/meta-data/",
+        { blockPrivateAddresses: true },
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  test("rejects a hostname that resolves to loopback", async () => {
+    await expect(
+      DataSourceEgressGuard.assertUrlAllowedAndPin("https://rebind.example/", {
+        blockPrivateAddresses: true,
+        resolveFunction: resolverFor([{ address: "127.0.0.1", family: 4 }]),
+      }),
+    ).rejects.toThrow(BadDataException);
+  });
+});
+
+describe("DataSourceEgressGuard.createGuardedLookup", () => {
+  test("passes through the validated addresses for an allowed host", async () => {
+    const lookup: EgressLookupFunction =
+      DataSourceEgressGuard.createGuardedLookup({
+        blockPrivateAddresses: true,
+        resolveFunction: resolverFor([{ address: "93.184.216.34", family: 4 }]),
+      });
+
+    const result: LookupResult = await callLookup(lookup, "idp.example.com", {
+      all: false,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.address).toBe("93.184.216.34");
+    expect(result.family).toBe(4);
+  });
+
+  test("errors instead of connecting when the host resolves to link-local", async () => {
+    /*
+     * This is the property that makes the OIDC fix work: openid-client picks
+     * the endpoint URLs out of a document the tenant controls, so the block
+     * has to happen at connect time, for whatever host it decided on.
+     */
+    const lookup: EgressLookupFunction =
+      DataSourceEgressGuard.createGuardedLookup({
+        blockPrivateAddresses: true,
+        resolveFunction: resolverFor([
+          { address: "169.254.169.254", family: 4 },
+        ]),
+      });
+
+    const result: LookupResult = await callLookup(
+      lookup,
+      "token-endpoint.attacker.example",
+      { all: false },
+    );
+
+    expect(result.error).toBeInstanceOf(BadDataException);
+    expect(result.error?.message).toContain("link-local");
+  });
+
+  test("errors for a literal loopback host", async () => {
+    const lookup: EgressLookupFunction =
+      DataSourceEgressGuard.createGuardedLookup({
+        blockPrivateAddresses: true,
+      });
+
+    const result: LookupResult = await callLookup(lookup, "127.0.0.1", {
+      all: false,
+    });
+
+    expect(result.error).toBeInstanceOf(BadDataException);
+  });
+
+  test("filters to the requested address family", async () => {
+    const lookup: EgressLookupFunction =
+      DataSourceEgressGuard.createGuardedLookup({
+        blockPrivateAddresses: true,
+        resolveFunction: resolverFor([
+          { address: "93.184.216.34", family: 4 },
+          { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+        ]),
+      });
+
+    const result: LookupResult = await callLookup(lookup, "idp.example.com", {
+      all: false,
+      family: 6,
+    });
+
+    expect(result.error).toBeNull();
+    expect(result.address).toBe("2606:2800:220:1:248:1893:25c8:1946");
+    expect(result.family).toBe(6);
+  });
+
+  test("reports ENOTFOUND when no address matches the requested family", async () => {
+    const lookup: EgressLookupFunction =
+      DataSourceEgressGuard.createGuardedLookup({
+        blockPrivateAddresses: true,
+        resolveFunction: resolverFor([{ address: "93.184.216.34", family: 4 }]),
+      });
+
+    const result: LookupResult = await callLookup(lookup, "idp.example.com", {
+      all: false,
+      family: 6,
+    });
+
+    expect(result.error?.code).toBe("ENOTFOUND");
+  });
+
+  test("a mixed answer is refused outright — one bad record poisons the set", async () => {
+    const lookup: EgressLookupFunction =
+      DataSourceEgressGuard.createGuardedLookup({
+        blockPrivateAddresses: true,
+        resolveFunction: resolverFor([
+          { address: "93.184.216.34", family: 4 },
+          { address: "10.0.0.5", family: 4 },
+        ]),
+      });
+
+    const result: LookupResult = await callLookup(lookup, "idp.example.com", {
+      all: true,
+    });
+
+    expect(result.error).toBeInstanceOf(BadDataException);
+  });
+});
+
+describe("DataSourceEgressGuard error labelling", () => {
+  test("defaults to the data source wording", async () => {
+    await expect(
+      DataSourceEgressGuard.assertHostnameAllowed("127.0.0.1", {
+        blockPrivateAddresses: true,
+      }),
+    ).rejects.toThrow("Data source host 127.0.0.1 is not allowed");
+  });
+
+  test("names the subsystem when one is given", async () => {
+    await expect(
+      DataSourceEgressGuard.assertHostnameAllowed("127.0.0.1", {
+        blockPrivateAddresses: true,
+        targetLabel: "LLM provider",
+      }),
+    ).rejects.toThrow("LLM provider host 127.0.0.1 is not allowed");
+  });
+
+  test("names the subsystem for a resolved-address rejection too", async () => {
+    await expect(
+      DataSourceEgressGuard.assertHostnameAllowed("ollama.attacker.example", {
+        blockPrivateAddresses: true,
+        targetLabel: "LLM provider",
+        resolveFunction: resolverFor([
+          { address: "169.254.169.254", family: 4 },
+        ]),
+      }),
+    ).rejects.toThrow(
+      "LLM provider host ollama.attacker.example resolves to 169.254.169.254",
+    );
+  });
+
+  test("names the subsystem for a bad scheme", async () => {
+    await expect(
+      DataSourceEgressGuard.assertUrlAllowed("file:///etc/passwd", {
+        targetLabel: "OAuth token URL",
+      }),
+    ).rejects.toThrow("OAuth token URL URL must use http or https");
+  });
+});

--- a/Common/Tests/Types/API/HostnameAuthorityParsing.test.ts
+++ b/Common/Tests/Types/API/HostnameAuthorityParsing.test.ts
@@ -1,0 +1,144 @@
+import Hostname from "../../../Types/API/Hostname";
+import URL from "../../../Types/API/URL";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Hostname used to validate with a character allowlist that happened to
+ * include "/", "?", "#" and "@". Anything that stores a Hostname and later
+ * interpolates it into a URL therefore inherited control of the host, port
+ * AND path of the resulting request — which is how a status page subdomain of
+ * "169.254.169.254/latest/meta-data/#" became a request to the cloud metadata
+ * endpoint. These tests pin the structural rules that replaced it, and the
+ * matching fix in URL.fromString, which used to leave a query string glued to
+ * the host.
+ */
+
+describe("Hostname.isValid accepts real hosts", () => {
+  const validHostnames: Array<string> = [
+    "localhost",
+    "localhost:5000",
+    "example.com",
+    "status.example.com",
+    "deep.sub.domain.example.com",
+    "example.com.",
+    "EXAMPLE.com",
+    "my-host.internal",
+    "host_with_underscore.internal",
+    "_dmarc.example.com",
+    "1.2.3.4",
+    "1.2.3.4:8080",
+    "smtp.example.com:587",
+    "[::1]",
+    "[::1]:8080",
+    "[2606:2800:220:1:248:1893:25c8:1946]:443",
+    "::1",
+    "2606:2800:220:1:248:1893:25c8:1946",
+    // Userinfo is still accepted: it is already in customers' stored URLs.
+    "user:token@hooks.example.com",
+    "user@hooks.example.com",
+    "user:token@hooks.example.com:8443",
+  ];
+
+  test.each(validHostnames)("accepts %s", (hostname: string) => {
+    expect(Hostname.isValid(hostname)).toBe(true);
+  });
+});
+
+describe("Hostname.isValid rejects smuggled paths, queries and fragments", () => {
+  const invalidHostnames: Array<string> = [
+    // The status page / dashboard subdomain injection.
+    "169.254.169.254/latest/meta-data/#",
+    "169.254.169.254/latest/meta-data/#.example.com",
+    "example.com/../../etc/passwd",
+    "example.com/path",
+    "example.com?query=1",
+    "example.com#fragment",
+    "example.com:8080/path",
+    // Junk the old character allowlist waved through.
+    "example.com;evil",
+    "example.com,evil",
+    "exa mple.com",
+    "undefined undefined",
+    "localhost 5000",
+    "",
+    "   ",
+    // A port that is not a port.
+    "example.com:notaport",
+    "example.com:80:90",
+    // Hyphen placement.
+    "-example.com",
+    "example-.com",
+    // Userinfo may not itself carry a path or a second authority.
+    "user@evil.com/@example.com",
+    "user@example.com?x=1",
+  ];
+
+  test.each(invalidHostnames)("rejects %s", (hostname: string) => {
+    expect(Hostname.isValid(hostname)).toBe(false);
+  });
+
+  test("the constructor throws rather than storing a smuggled value", () => {
+    expect(() => {
+      return new Hostname("169.254.169.254/latest/meta-data/#");
+    }).toThrow(BadDataException);
+  });
+});
+
+describe("URL.fromString keeps the authority separate from the rest", () => {
+  test("a query string on a path-less URL does not end up in the host", () => {
+    const url: URL = URL.fromString("https://hooks.example.com?token=abc");
+
+    expect(url.hostname.hostname).toBe("hooks.example.com");
+    expect(url.getQueryParam("token")).toBe("abc");
+  });
+
+  test("a fragment on a path-less URL does not end up in the host", () => {
+    const url: URL = URL.fromString("https://hooks.example.com#section");
+
+    expect(url.hostname.hostname).toBe("hooks.example.com");
+  });
+
+  test("a path still parses as a route", () => {
+    const url: URL = URL.fromString("https://hooks.example.com/a/b?x=1");
+
+    expect(url.hostname.hostname).toBe("hooks.example.com");
+    expect(url.route.toString()).toBe("a/b");
+    expect(url.getQueryParam("x")).toBe("1");
+    expect(url.toString()).toBe("https://hooks.example.com/a/b?x=1");
+  });
+
+  test("a host with a port survives", () => {
+    const url: URL = URL.fromString("http://localhost:5000/api/test");
+
+    expect(url.hostname.toString()).toBe("localhost:5000");
+    expect(url.toString()).toBe("http://localhost:5000/api/test");
+  });
+
+  test("a mailto address is parsed as an email, not as a host", () => {
+    const url: URL = URL.fromString("mailto:support@oneuptime.com");
+
+    expect(url.email.toString()).toBe("support@oneuptime.com");
+    expect(url.toString()).toBe("mailto:support@oneuptime.com");
+  });
+
+  test("a mailto address with a subject does not go through the host validator", () => {
+    const url: URL = URL.fromString(
+      "mailto:support@oneuptime.com?subject=Hello",
+    );
+
+    expect(url.email.toString()).toBe("support@oneuptime.com");
+    expect(url.getQueryParam("subject")).toBe("Hello");
+  });
+
+  test("a webhook URL with basic-auth credentials still round-trips", () => {
+    /*
+     * These are already in customers' databases. Rejecting them here would
+     * fail on read, not just on write.
+     */
+    const url: URL = URL.fromString("https://user:token@hooks.example.com/x");
+
+    expect(url.hostname.hostname).toBe("user:token@hooks.example.com");
+    expect(url.toString()).toBe("https://user:token@hooks.example.com/x");
+  });
+});

--- a/Common/Tests/Types/API/HostnameAuthorityParsing.test.ts
+++ b/Common/Tests/Types/API/HostnameAuthorityParsing.test.ts
@@ -108,6 +108,19 @@ describe("URL.fromString keeps the authority separate from the rest", () => {
     expect(url.toString()).toBe("https://hooks.example.com/a/b?x=1");
   });
 
+  test("an upper-case scheme is stripped, not left in the authority", () => {
+    /*
+     * Schemes are case-insensitive. Matching the literal lower-case prefix
+     * left "HTTPS://" in place, so the authority read as "HTTPS:" — which
+     * the old permissive host check waved through and the structural one
+     * (correctly) refuses, turning a valid webhook URL into an error.
+     */
+    const url: URL = URL.fromString("HTTPS://hooks.example.com/webhook");
+
+    expect(url.hostname.hostname).toBe("hooks.example.com");
+    expect(url.protocol.toString()).toBe("https://");
+  });
+
   test("a host with a port survives", () => {
     const url: URL = URL.fromString("http://localhost:5000/api/test");
 

--- a/Common/Tests/Types/DomainSubdomainValidation.test.ts
+++ b/Common/Tests/Types/DomainSubdomainValidation.test.ts
@@ -1,0 +1,90 @@
+import Domain from "../../Types/Domain";
+import URL from "../../Types/API/URL";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * StatusPageDomain.subdomain and DashboardDomain.subdomain are ShortText that
+ * used to be trimmed and lower-cased and nothing else. Both services build
+ * fullDomain as `${subdomain}.${baseDomain}` and then interpolate it into
+ * "https://" + fullDomain + "/status-page-api/...", which the certificate
+ * cron fetches unattended every 15 minutes. Because URL parsing takes
+ * everything before the first "/" as the host, a subdomain carrying a "/"
+ * gave an attacker the host, the port and the path of that request.
+ */
+
+describe("Domain.isValidSubdomain accepts ordinary subdomains", () => {
+  const valid: Array<string> = [
+    "status",
+    "dashboard",
+    "status-page",
+    "eu-west-1",
+    "a",
+    "status.eu",
+    "deep.nested.label",
+    "s1",
+    "1status",
+  ];
+
+  test.each(valid)("accepts %s", (subdomain: string) => {
+    expect(Domain.isValidSubdomain(subdomain)).toBe(true);
+  });
+});
+
+describe("Domain.isValidSubdomain rejects anything that is not a DNS label", () => {
+  const invalid: Array<string> = [
+    // The metadata-endpoint injection this exists to stop.
+    "169.254.169.254/latest/meta-data/#",
+    "169.254.169.254/latest/meta-data/iam/security-credentials/#",
+    "status/../../admin",
+    "status/path",
+    // Scheme, port, credentials, query, fragment.
+    "http://169.254.169.254",
+    "169.254.169.254:80",
+    "user@169.254.169.254",
+    "status?x=1",
+    "status#frag",
+    "status\\evil",
+    // Structural junk.
+    "-status",
+    "status-",
+    "sta tus",
+    "",
+    "@",
+    ".",
+    "status..double",
+    ".status",
+    "status.",
+  ];
+
+  test.each(invalid)("rejects %s", (subdomain: string) => {
+    expect(Domain.isValidSubdomain(subdomain)).toBe(false);
+  });
+
+  test("rejects a label longer than 63 characters", () => {
+    expect(Domain.isValidSubdomain("a".repeat(63))).toBe(true);
+    expect(Domain.isValidSubdomain("a".repeat(64))).toBe(false);
+  });
+});
+
+describe("the injection this blocks, end to end", () => {
+  test("an unvalidated subdomain would have redirected the cert check to metadata", () => {
+    /*
+     * Demonstrates why a subdomain check is the fix rather than trusting the
+     * URL builder: with the malicious label in place, the host of the
+     * resulting URL is the metadata endpoint and the base domain has been
+     * demoted into the path.
+     */
+    const maliciousSubdomain: string = "169.254.169.254/latest/meta-data/#";
+    const baseDomain: string = "example.com";
+    const fullDomain: string = `${maliciousSubdomain}.${baseDomain}`;
+
+    const url: URL = URL.fromString(
+      "https://" + fullDomain + "/status-page-api/cname-verification/token",
+    );
+
+    expect(url.hostname.hostname).toBe("169.254.169.254");
+
+    // And the validator refuses to let that subdomain be stored at all.
+    expect(Domain.isValidSubdomain(maliciousSubdomain)).toBe(false);
+  });
+});

--- a/Common/Types/API/Hostname.ts
+++ b/Common/Types/API/Hostname.ts
@@ -5,6 +5,27 @@ import Port from "../Port";
 import Typeof from "../Typeof";
 import { FindOperator } from "typeorm";
 
+/*
+ * A chain of DNS labels (which also covers IPv4 literals). Labels are
+ * alphanumeric plus "-" and "_", may not start or end with "-", and are
+ * capped at 63 characters; a single trailing dot (the fully-qualified form)
+ * is allowed. "_" is permitted because internal and service-discovery names
+ * use it and it is not a URL delimiter.
+ */
+const HOST_REGEX: RegExp =
+  /^[a-zA-Z0-9_](?:[a-zA-Z0-9_-]{0,61}[a-zA-Z0-9_])?(?:\.[a-zA-Z0-9_](?:[a-zA-Z0-9_-]{0,61}[a-zA-Z0-9_])?)*\.?$/;
+
+/*
+ * Anything that is not a URL delimiter. The point is not to validate
+ * credentials, it is to make sure userinfo cannot smuggle a path, a query, a
+ * fragment or a second authority past the host check.
+ */
+const USER_INFO_REGEX: RegExp = /^[^@/?#\s[\]]*$/;
+
+const IPV6_CHARS_REGEX: RegExp = /^[0-9a-fA-F:.]+$/;
+
+const PORT_REGEX: RegExp = /^\d{1,5}$/;
+
 export default class Hostname extends DatabaseProperty {
   private _route: string = "";
   public get hostname(): string {
@@ -31,13 +52,80 @@ export default class Hostname extends DatabaseProperty {
     }
   }
 
+  /*
+   * True when the value is a usable authority: an optional "userinfo@"
+   * prefix, a host (DNS name, IPv4, or IPv6 literal) and an optional ":port".
+   *
+   * The old check was a character allowlist that permitted "/", "?", "#" and
+   * "@" anywhere, which made "169.254.169.254/latest/meta-data/#" a valid
+   * Hostname. Anything that stores a Hostname and later interpolates it into
+   * a URL therefore inherited full control of the host, port and path of the
+   * resulting request. Structure, not a charset, is what rules that out.
+   *
+   * Userinfo is still accepted because "https://user:token@host/path" is a
+   * real thing customers put in webhook URLs, and those values are already in
+   * the database — rejecting them here would fail on read, not just on write.
+   * Callers that need the bare host must not split this string themselves;
+   * SSRFProtection.getBareHostname exists for that.
+   */
   public static isValid(value: string): boolean {
-    const re: RegExp = /^[a-zA-Z-\d!#$&'*+,/:;=?@[\].]*$/;
-    const isValid: boolean = re.test(value);
-    if (!isValid) {
+    const authorityWithUserInfo: string = value.trim();
+
+    /*
+     * 253 for a DNS name, plus room for ":65535" and a userinfo prefix.
+     * A bound here also keeps the label regex from being handed something
+     * pathological.
+     */
+    if (!authorityWithUserInfo || authorityWithUserInfo.length > 512) {
       return false;
     }
-    return true;
+
+    /*
+     * Split on the LAST "@": userinfo may itself contain "@" percent-encoded
+     * or not, and everything after the final one is the authority.
+     */
+    const atIndex: number = authorityWithUserInfo.lastIndexOf("@");
+
+    if (atIndex !== -1) {
+      const userInfo: string = authorityWithUserInfo.substring(0, atIndex);
+      if (!USER_INFO_REGEX.test(userInfo)) {
+        return false;
+      }
+    }
+
+    const authority: string = authorityWithUserInfo.substring(atIndex + 1);
+
+    if (!authority) {
+      return false;
+    }
+
+    // Bracketed IPv6, with or without a port: "[::1]", "[::1]:8080".
+    const bracketedIpv6Match: RegExpMatchArray | null = authority.match(
+      /^\[([0-9a-fA-F:.]+)\](?::(\d{1,5}))?$/,
+    );
+    if (bracketedIpv6Match) {
+      return true;
+    }
+
+    /*
+     * Unbracketed IPv6 literal. Two or more colons cannot be a "host:port",
+     * so the colons must be part of the address itself.
+     */
+    if ((authority.match(/:/g) || []).length > 1) {
+      return IPV6_CHARS_REGEX.test(authority);
+    }
+
+    const colonIndex: number = authority.indexOf(":");
+    const host: string =
+      colonIndex === -1 ? authority : authority.substring(0, colonIndex);
+    const port: string =
+      colonIndex === -1 ? "" : authority.substring(colonIndex + 1);
+
+    if (colonIndex !== -1 && !PORT_REGEX.test(port)) {
+      return false;
+    }
+
+    return HOST_REGEX.test(host);
   }
 
   public constructor(hostname: string, port?: Port | string | number) {

--- a/Common/Types/API/URL.ts
+++ b/Common/Types/API/URL.ts
@@ -159,9 +159,28 @@ export default class URL extends DatabaseProperty {
     if (url.startsWith("mailto:")) {
       protocol = Protocol.MAIL;
       url = url.replace("mailto:", "");
+
+      /*
+       * Hand the bare address to the constructor so it is recognised as an
+       * Email. Routing it through Hostname instead would ask a host validator
+       * to accept an email address — and "?subject=..." along with it.
+       */
+      const address: string = url.split("?")[0] || "";
+      const mailQueryString: string = url.split("?")[1] || "";
+
+      return new URL(protocol, address, undefined, mailQueryString);
     }
 
-    const hostname: Hostname = new Hostname(url.split("/")[0] || "");
+    /*
+     * The authority ends at the first "/", "?" or "#". Splitting on "/" alone
+     * left the query and fragment glued to the host for URLs with no path
+     * ("https://host?token=x" parsed to a host of "host?token=x"), which both
+     * round-tripped wrong and handed anything that later interpolated the
+     * host a way to smuggle a path.
+     */
+    const authority: string = (url.split("/")[0] || "").split(/[?#]/)[0] || "";
+
+    const hostname: Hostname = new Hostname(authority);
 
     let route: Route | undefined;
 

--- a/Common/Types/API/URL.ts
+++ b/Common/Types/API/URL.ts
@@ -131,35 +131,34 @@ export default class URL extends DatabaseProperty {
   public static fromString(url: string): URL {
     let protocol: Protocol = Protocol.HTTPS;
 
-    if (url.startsWith("https://")) {
-      protocol = Protocol.HTTPS;
-      url = url.replace("https://", "");
+    /*
+     * Schemes are case-insensitive (RFC 3986), so match on a lower-cased
+     * copy and strip by length. Matching the literal prefix left "HTTPS://"
+     * in place, which then read as an authority of "HTTPS:".
+     *
+     * Longest-first: "https://" has to be tested before "http://", and only
+     * the first match is stripped.
+     */
+    const schemePrefixes: Array<[string, Protocol]> = [
+      ["https://", Protocol.HTTPS],
+      ["http://", Protocol.HTTP],
+      ["wss://", Protocol.WSS],
+      ["ws://", Protocol.WS],
+      ["mongodb://", Protocol.MONGO_DB],
+      ["mailto:", Protocol.MAIL],
+    ];
+
+    const lowerCasedUrl: string = url.toLowerCase();
+
+    for (const [prefix, prefixProtocol] of schemePrefixes) {
+      if (lowerCasedUrl.startsWith(prefix)) {
+        protocol = prefixProtocol;
+        url = url.substring(prefix.length);
+        break;
+      }
     }
 
-    if (url.startsWith("http://")) {
-      protocol = Protocol.HTTP;
-      url = url.replace("http://", "");
-    }
-
-    if (url.startsWith("wss://")) {
-      protocol = Protocol.WSS;
-      url = url.replace("wss://", "");
-    }
-
-    if (url.startsWith("ws://")) {
-      protocol = Protocol.WS;
-      url = url.replace("ws://", "");
-    }
-
-    if (url.startsWith("mongodb://")) {
-      protocol = Protocol.MONGO_DB;
-      url = url.replace("mongodb://", "");
-    }
-
-    if (url.startsWith("mailto:")) {
-      protocol = Protocol.MAIL;
-      url = url.replace("mailto:", "");
-
+    if (protocol === Protocol.MAIL) {
       /*
        * Hand the bare address to the constructor so it is recognised as an
        * Email. Routing it through Hostname instead would ask a host validator

--- a/Common/Types/Domain.ts
+++ b/Common/Types/Domain.ts
@@ -67,6 +67,32 @@ export default class Domain extends DatabaseProperty {
     return domainRegex.test(domain);
   }
 
+  /**
+   * Validates a subdomain: one or more DNS labels, no scheme, no port, no
+   * path, no userinfo.
+   *
+   * This is a security control, not a nicety. A subdomain is concatenated
+   * with a verified base domain to build fullDomain, and fullDomain is
+   * interpolated into a URL that the certificate-provisioning cron fetches
+   * unattended. URL parsing takes everything before the first "/" as the
+   * host, so a subdomain of "169.254.169.254/latest/meta-data/#" yields a URL
+   * whose host, port and path are all attacker-chosen. Restricting the value
+   * to DNS labels removes the ability to smuggle any of those.
+   *
+   * The empty string is NOT valid here: callers use "" (or "@") to mean the
+   * apex and must check for that before calling.
+   */
+  public static isValidSubdomain(subdomain: string): boolean {
+    if (!subdomain || subdomain.length > 253) {
+      return false;
+    }
+
+    const subdomainRegex: RegExp =
+      /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+    return subdomainRegex.test(subdomain);
+  }
+
   public constructor(domain: string) {
     super();
     this.domain = domain;

--- a/Runner/Services/RunbookExecutor.ts
+++ b/Runner/Services/RunbookExecutor.ts
@@ -102,7 +102,12 @@ function runBashLocally(data: {
 /*
  * JavaScript runs inside the same isolated-vm sandbox the server used to use,
  * but now on the agent's machine rather than on the OneUptime Worker. The
- * sandbox blocks fs/network/process access and is killed at the timeout.
+ * isolate has no fs or process access and is killed at the timeout.
+ *
+ * It is NOT a network sandbox: the host deliberately bridges an HTTP client
+ * into the isolate, so a script can reach anything the agent's machine can
+ * reach. Run agents where you would run any other operator-authored automation
+ * — the trust boundary is the Runbook author, not the isolate.
  */
 async function runJavaScriptLocally(data: {
   script: string;


### PR DESCRIPTION
### Title of this pull request?

fix(security): close the 10 remaining SSRF sinks outside the workflow engine

### Small Description?

Follow-up to #3118 (GHSA-v5xh-rw9h-77fv), which fixed the workflow engine, the chat components, the isolated-vm axios bridge and `SSRFProtection` itself. A codebase-wide audit alongside it confirmed 10 further sinks; this PR closes all of them. Nothing from #3118 is redone here — there is no file overlap.

Two guards already exist, and each sink uses the one that matches whether an internal target is ever legitimate:

- **`SSRFProtection.validateWebhookTargetIsSafe`** — third-party SaaS endpoints, where private addresses are never legitimate.
- **`DataSourceEgressGuard`** — sinks where a self-hosted install genuinely targets internal hosts. It validates *resolved addresses* and pins them into the socket lookup. Loopback, link-local (169.254.169.254), unspecified, multicast and reserved are blocked everywhere; RFC-1918 is blocked only when `IsBillingEnabled` or `DATA_SOURCE_BLOCK_PRIVATE_ADDRESSES=true`.

#### What changed, by commit

| Commit | Finding | |
|---|---|---|
| `a2ecc4b` | — | shared: `EgressGuard` gains `targetLabel`, `createPinnedLookup` / `createPinnedAgents` / `assertUrlAllowedAndPin` (lifted from `HttpFetch`), and `createGuardedLookup` |
| `4678d5a` | 1, 10 | Runbook HTTP step; corrected the Runner's false "the sandbox blocks network access" comment |
| `46efcff` | 3 | LLM provider `baseUrl` — all four sinks |
| `0c082b9` | 4 | status page + dashboard domain verification |
| `2a7f742` | 5 | OIDC discovery |
| `e1cc0b2` | 6 | web push endpoint allowlist |
| `9665d9c` | 2, 7 | SMTP OAuth token URL, custom SMTP host, plus a smtp-config tenancy hole |
| `ba2cd02` | 8, 9 | `Hostname` structural validation; deleted a weakened local SSRF copy |
| `781dd8c` | — | follow-on: case-insensitive scheme in `URL.fromString` |
| `8cad1d4` | — | follow-on: shared egress stub for the LLM suites |

**Highest impact.** The Runbook HTTP step took `url`, `method`, `headers` and `body` verbatim from the `Runbook.steps` JSON column with `validateStatus: () => true`, and wrote the full status, headers and body into `RunbookExecution.stepExecutions` — readable by any `ProjectMember`. An attacker-chosen method plus headers is exactly what IMDSv2 asks for. Separately, `LlmProvider.baseUrl` is `ProjectMember`-writable while reading `apiKey` is Owner/Admin-only, so repointing a provider exfiltrated the decrypted key out of the auth header — and provider error bodies are reflected back through `LlmProviderAPI`, making the same lever a read primitive against the internal network.

#### Three things a reviewer should know

1. **The OIDC fix needs two hooks, not one.** Pinning `discoveryURL` alone fixes nothing: `Issuer.discover` adopts `token_endpoint` / `userinfo_endpoint` / `jwks_uri` from the fetched document, so the guard has to sit on the socket. `custom.setHttpOptionsDefaults({lookup})` covers hostnames — but a **literal IP never reaches `lookup` at all**, because Node skips resolution when the host is already an address, so `http://169.254.169.254/...` sailed straight past a lookup-only guard. `custom.http_options` now does a synchronous literal check, installed on the Issuer class (discovery), the issuer instance (JWKS) and the client (token, userinfo). This was caught by the new tests, not by inspection.

2. **`Hostname` still accepts userinfo, deliberately.** `Hostname.isValid` was a character allowlist permitting `/`, `?`, `#` and `@` anywhere, which is the root cause behind the subdomain injection in finding 4 — it is now a structural check (optional userinfo, host, optional port). Userinfo stays allowed because `https://user:token@host/path` is a real thing customers put in webhook URLs and those rows are already in the database; rejecting them would fail on **read**, not just on write. `SSRFProtection.getBareHostname` remains the only correct way to extract a bare host. `URL.fromString` needed the matching fix — it took the authority as everything before the first `/`, leaving the query glued to the host for path-less URLs (`https://host?token=x` parsed to a host of `host?token=x`).

3. **Two deliberate behaviour changes.** Domain verification now refuses redirects, so `isSSLProvisioned` will report false for a domain whose https endpoint redirects (the CNAME check is unaffected — it tries http, then https). And the operator's **global** SMTP server is exempt from the host guard: it is operator-configured rather than tenant-configured (`EmailServer.id` is set only for project configs), and pointing it at an internal relay is a normal self-hosted deployment.

Not done, and flagged rather than assumed: finding 1 also suggested dispatching the HTTP step to the customer Runner like the other step types. That is a behavioural change that would break runbooks with no agent configured, so it is left for a separate decision.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

**Testing.** 10 new test files plus 4 adapted. Full suites all green locally: Common 932 suites / 20,133 tests, App 244 / 6,565, Probe 37 / 854, Runner 14 / 194. `tsc` clean in Common, App, Runner and Probe; eslint clean on every changed file.

Every new test was verified to **fail against the unfixed source** (stashed, then re-run): Runbook 15/17 behavioural failures, OIDC loopback discovery *succeeds* unfixed, `Hostname` accepts all 18 smuggling cases, the UserWebhook update path is unguarded.

Two test-side notes. `App/Tests/Identity/OIDC.test.ts` now explicitly opts out of the guard — its whole design is a real OpenID provider on a loopback socket, which the guard correctly refuses; the guard has its own coverage in `OidcEgressGuard.test.ts`. And merging master into this branch before opening the PR surfaced a real interaction with #3118: `URL.fromString` only stripped lowercase schemes, so `HTTPS://host/x` left an authority of `HTTPS:` — harmless under the old permissive regex, rejected under the strict one, which broke #3118's scheme tests. Fixed in `781dd8c`.

### Related Issue?

Follows up the codebase-wide SSRF audit run alongside #3118 (GHSA-v5xh-rw9h-77fv).

### Screenshots (if appropriate):

N/A — no user-visible UI changes.
