### PR TITLE
fix(teams): stop guessing the project for a tenant, and preflight channel installs

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegration.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsIntegration.tsx
@@ -574,9 +574,15 @@ Pre-requisite:
    - Select the downloaded zip file
 3. **Install the app:**
    - Find "OneUptime" in your apps
-   - Click "Add" to install it for your team
+   - Click "Add" to install it for yourself
    - Grant the necessary permissions
-4. Once the app is installed, you can create workspace notification rules in OneUptime to send messages to your teams.
+4. **Add OneUptime to every team you want notifications in — this step is required.**
+   - In Microsoft Teams, click the "..." next to the **team name** (not the channel)
+   - Choose **Manage team → Apps → More apps**, find OneUptime and click **Add**
+   - Installing OneUptime for yourself or adding it to a chat does **not** let it post to that team's channels
+   - For a **private** channel, also open the channel → "..." → **Manage channel → Apps → Add an app**. A team install does not cover private channels
+   - Microsoft Teams does not allow bots in **shared** channels, so those cannot receive notifications
+5. Once the app is added to the team, you can create workspace notification rules in OneUptime to send messages to its channels.
 
 The zip file contains the app manifest and required icons for Teams installation.
               `}
@@ -623,9 +629,13 @@ The zip file contains the app manifest and required icons for Teams installation
 1. **Click the button above** to open the OneUptime app in the Microsoft Teams Store
 2. **Install the app:**
    - Click "Add" to install it for yourself
-   - Or click "Add to a team" to install it for your entire team
    - Grant the necessary permissions
-3. Once the app is installed, you can create workspace notification rules in OneUptime to send messages to your teams.
+3. **Add OneUptime to every team you want notifications in — this step is required.**
+   - Use **"Add to a team"** in the store dialog, or in Microsoft Teams click the "..." next to the **team name** (not the channel) and choose **Manage team → Apps → More apps**
+   - Installing OneUptime for yourself or adding it to a chat does **not** let it post to that team's channels
+   - For a **private** channel, also open the channel → "..." → **Manage channel → Apps → Add an app**. A team install does not cover private channels
+   - Microsoft Teams does not allow bots in **shared** channels, so those cannot receive notifications
+4. Once the app is added to the team, you can create workspace notification rules in OneUptime to send messages to its channels.
 
 ##### Alternative Installation:
 

--- a/App/FeatureSet/Docs/Content/en/self-hosted/microsoft-teams-integration.md
+++ b/App/FeatureSet/Docs/Content/en/self-hosted/microsoft-teams-integration.md
@@ -15,11 +15,13 @@ To integrate Microsoft Teams with your self-hosted OneUptime instance, you need 
 2. Navigate to "App registrations" and click "New registration"
 3. Fill out the registration form:
    - **Name:** oneuptime
-   - **Supported account types:** Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant)
+   - **Supported account types:** Accounts in this organizational directory only (Single tenant)
    - **Redirect URI:** Web - `https://your-oneuptime-domain.com/api/microsoft-teams/auth`
    - Please also add: `https://your-oneuptime-domain.com/api/microsoft-teams/admin-consent/callback`
 4. Click "Register"
 5. Note down the "Application (client) ID" - you'll need this later
+
+**Why single tenant:** a self-hosted OneUptime instance serves one organization, and its bot is registered against the single tenant you set in `MICROSOFT_TEAMS_APP_TENANT_ID` (Step 5). Registering the app as multitenant does not extend that, and it introduces a failure mode: guest / B2B users whose Microsoft home tenant differs from yours will reach the bot with their own tenant id, which OneUptime cannot map to your project. If you already registered a multitenant app it will keep working — just make sure `MICROSOFT_TEAMS_APP_TENANT_ID` is your own tenant, and expect guest accounts to need an account in your tenant to use the bot.
 
 ### Step 2: Configure App Permissions
 
@@ -101,7 +103,7 @@ If you are using Kubernetes with Helm, add these to your `values.yaml` file:
 microsoftTeamsApp:
   clientId: YOUR_TEAMS_APP_CLIENT_ID
   clientSecret: YOUR_TEAMS_APP_CLIENT_SECRET
-   tenantId: YOUR_MICROSOFT_TENANT_ID
+  tenantId: YOUR_MICROSOFT_TENANT_ID
 ```
 
 **Important:** Restart your OneUptime server after adding these environment variables so they take effect.
@@ -116,6 +118,21 @@ microsoftTeamsApp:
 6. Select "Upload for me or my teams"
 7. Upload the manifest zip file you downloaded earlier
 
+### Step 8: Add OneUptime to Each Team (Required)
+
+Uploading the manifest installs the app for **you**. It does **not** give the bot access to any team's channels. Microsoft only accepts messages into a team the app has been added to, so you must do this for every team you want notifications in:
+
+1. In Microsoft Teams, click the "..." next to the **team name** (not the channel name)
+2. Choose **Manage team** > **Apps** > **More apps**
+3. Find **OneUptime** and click **Add**
+
+Notes:
+
+- Installing OneUptime for yourself, or adding it to a chat, is a **different** installation. Neither one lets it post to a team's channels.
+- **Private channels** need the app installed into the channel itself: open the channel > "..." > **Manage channel** > **Apps** > **Add an app**. A team-level install does not cover private channels.
+- **Shared channels** cannot receive notifications at all — Microsoft Teams does not support bots in shared channels. OneUptime hides them from the channel picker.
+- If **Manage team > Apps > More apps** is empty or greyed out, your Teams app setup policy is blocking custom apps. Fix this in the Teams admin center under **Teams apps > Manage apps** and **Setup policies**.
+
 ## Troubleshooting
 
 If you encounter issues:
@@ -126,6 +143,32 @@ If you encounter issues:
 - Make sure the bot messaging endpoint is accessible from the internet
 - Verify that the bot is properly configured with the Teams channel
 - Check that the Teams app manifest has been uploaded successfully
+
+### "The OneUptime app is not installed in the Microsoft Teams team ..."
+
+The app was never added to that team (or, for a private channel, to that channel). Complete **Step 8** above. This is the most common cause of a failed test notification — OneUptime can list every channel in your tenant using Graph application permissions, but it can only *post* to teams the app is a member of.
+
+### "Sorry, I couldn't find your project configuration"
+
+The Microsoft tenant the bot activity came from is not the tenant connected to any OneUptime project. Check the tenant id in your server logs:
+
+```
+grep "Project auth not found for tenant ID" <your app logs>
+```
+
+Compare it with the tenant stored for the project:
+
+```sql
+SELECT "projectId", "workspaceProjectId"
+FROM "WorkspaceProjectAuthToken"
+WHERE "workspaceType" = 'MicrosoftTeams';
+```
+
+If they differ, the user messaging the bot is signed in to a different Microsoft tenant (commonly a guest / B2B account whose home tenant is not yours). Have them use an account in the connected tenant, or @mention the bot inside a channel of the connected team instead of a 1:1 chat.
+
+### "This Microsoft 365 organization is connected to more than one OneUptime project"
+
+Two or more OneUptime projects have connected the same Microsoft tenant. A bot message only carries a tenant id, so OneUptime cannot tell which project you mean and refuses rather than guessing. Disconnect Microsoft Teams from all but one project.
 
 ## Support
 

--- a/App/FeatureSet/Docs/Content/en/workspace-connections/microsoft-teams.md
+++ b/App/FeatureSet/Docs/Content/en/workspace-connections/microsoft-teams.md
@@ -12,10 +12,25 @@
    - Navigate to **Project Settings** > **Microsoft Teams** within your OneUptime project.
    - Follow the prompts to connect your Microsoft Teams account with the OneUptime project.
 
-3. **Configure Incident Notifications**
+3. **Add the OneUptime App to Each Team (Required)**
+
+   Connecting your account is not enough on its own. Microsoft only lets the OneUptime bot post into a team it has been added to, so do this for every team you want notifications in:
+
+   - In Microsoft Teams, click the "..." next to the **team name** (not the channel name).
+   - Choose **Manage team** > **Apps** > **More apps**, find **OneUptime** and click **Add**.
+
+   Notes:
+
+   - Installing OneUptime for yourself, or adding it to a chat, is a different installation and does not let it post to a team's channels.
+   - **Private channels** need the app added to the channel itself: open the channel > "..." > **Manage channel** > **Apps** > **Add an app**.
+   - **Shared channels** cannot receive notifications — Microsoft Teams does not support bots in shared channels.
+
+   If a test notification reports that the OneUptime app is not installed in the team, this is the step that was missed.
+
+4. **Configure Incident Notifications**
 
    - After connecting your Microsoft Teams account, go to **Incidents Page** > **Microsoft Teams**.
    - Add rules to send incident notifications to Microsoft Teams. For example, you can create a rule that posts messages to a Teams channel when an incident is created.
 
-4. **Configure Alerts and Scheduled Maintenance Notifications**
+5. **Configure Alerts and Scheduled Maintenance Notifications**
    - Similar rules can be applied to Alerts and Scheduled Maintenance by navigating to their respective pages and configuring the desired rules.

--- a/Common/Models/DatabaseModels/WorkspaceProjectAuthToken.ts
+++ b/Common/Models/DatabaseModels/WorkspaceProjectAuthToken.ts
@@ -36,6 +36,23 @@ export interface MicrosoftTeamsChat {
   addedAt?: string | undefined;
 }
 
+/*
+ * A team the OneUptime app has actually been installed into, captured from the
+ * bot's install / conversationUpdate events.
+ *
+ * Graph can list every team in the tenant with app-only permissions, but the
+ * Bot Framework will only accept a proactive post into a team the app is a
+ * roster member of. Listing a team is therefore NOT evidence that we can post
+ * to it — this record is, which is why channel sends check it before calling
+ * the Bot Framework.
+ */
+export interface MicrosoftTeamsInstalledTeam {
+  id: string; // Teams team (group) id.
+  name?: string | undefined;
+  serviceUrl?: string | undefined; // Bot Framework service URL captured on install. Required for GCC/DoD.
+  addedAt?: string | undefined;
+}
+
 export interface SlackMiscData extends MiscData {
   teamId: string;
   teamName: string;
@@ -59,9 +76,10 @@ export interface MicrosoftTeamsMiscData extends MiscData {
   lastAppTokenIssuedAt?: string;
   adminConsentGrantedAt?: string;
   adminConsentGrantedBy?: string;
-  availableTeams?: Record<string, MicrosoftTeamsTeam>;
+  availableTeams?: Record<string, MicrosoftTeamsTeam>; // keyed by team id. Every team Graph can see in the tenant.
   appAccessTokenExpiresAt?: string;
   availableChats?: Record<string, MicrosoftTeamsChat>; // keyed by chat id. Chats the OneUptime app has been added to.
+  installedTeams?: Record<string, MicrosoftTeamsInstalledTeam>; // keyed by team id. Teams the OneUptime app has been added to.
 }
 
 export type WorkspaceMiscData = SlackMiscData | MicrosoftTeamsMiscData;

--- a/Common/Server/API/MicrosoftTeamsAPI.ts
+++ b/Common/Server/API/MicrosoftTeamsAPI.ts
@@ -799,7 +799,12 @@ export default class MicrosoftTeamsAPI {
                     id: t["id"] as string,
                     name: (t["displayName"] as string) || "Unnamed Team",
                   };
-                  acc[team.name] = team;
+                  /*
+                   * Keyed by id, not display name — Teams allows duplicate
+                   * team names, and keying by name silently collapsed them so
+                   * only the last one of each name was selectable.
+                   */
+                  acc[team.id] = team;
                   return acc;
                 },
                 {} as Record<string, MicrosoftTeamsTeam>,

--- a/Common/Server/Services/WorkspaceNotificationRuleService.ts
+++ b/Common/Server/Services/WorkspaceNotificationRuleService.ts
@@ -309,6 +309,20 @@ export class Service extends DatabaseService<WorkspaceNotificationRule> {
 
             // Check for errors in the response
             if (res.errors && res.errors.length > 0) {
+              /*
+               * Record the failure before throwing. Test sends used to throw
+               * straight out of here, so a failed test left no trace in
+               * Notification Logs and support had no way to see what Microsoft
+               * or Slack actually said.
+               */
+              await this.logTestSendFailures({
+                projectId: data.projectId,
+                workspaceType: res.workspaceType,
+                errors: res.errors,
+                message: messageSummary,
+                userId: data.testByUserId,
+              });
+
               const errorMessages: Array<string> = res.errors.map(
                 (error: { channel: WorkspaceChannel; error: string }) => {
                   return `Channel ${error.channel.name}: ${error.error}`;
@@ -408,6 +422,20 @@ export class Service extends DatabaseService<WorkspaceNotificationRule> {
 
             // Check for errors in the response
             if (res.errors && res.errors.length > 0) {
+              /*
+               * Record the failure before throwing. Test sends used to throw
+               * straight out of here, so a failed test left no trace in
+               * Notification Logs and support had no way to see what Microsoft
+               * or Slack actually said.
+               */
+              await this.logTestSendFailures({
+                projectId: data.projectId,
+                workspaceType: res.workspaceType,
+                errors: res.errors,
+                message: messageSummary,
+                userId: data.testByUserId,
+              });
+
               const errorMessages: Array<string> = res.errors.map(
                 (error: { channel: WorkspaceChannel; error: string }) => {
                   return `Channel ${error.channel.name}: ${error.error}`;
@@ -536,6 +564,47 @@ export class Service extends DatabaseService<WorkspaceNotificationRule> {
         throw new BadDataException(
           "Cannot post message to chat. " + (err as Error)?.message,
         );
+      }
+    }
+  }
+
+  /*
+   * Persist per-destination failures from a test send so they show up in
+   * Settings > Notification Logs alongside real notification failures. Real
+   * sends already log; test sends threw before reaching any logging, which
+   * meant the one action an admin takes to diagnose a broken integration was
+   * also the only one that recorded nothing.
+   *
+   * Best-effort: a logging failure must never mask the underlying send error.
+   */
+  @CaptureSpan()
+  private async logTestSendFailures(data: {
+    projectId: ObjectID;
+    workspaceType: WorkspaceType;
+    errors: Array<{ channel: WorkspaceChannel; error: string }>;
+    message: string;
+    userId: ObjectID;
+  }): Promise<void> {
+    for (const error of data.errors) {
+      try {
+        const log: WorkspaceNotificationLog = new WorkspaceNotificationLog();
+        log.projectId = data.projectId;
+        log.workspaceType = data.workspaceType;
+        log.channelId = error.channel.id;
+        log.channelName = error.channel.name;
+        log.message = data.message;
+        log.status = WorkspaceNotificationStatus.Error;
+        log.statusMessage = error.error;
+        log.userId = data.userId;
+        log.actionType = WorkspaceNotificationActionType.SendMessage;
+
+        await WorkspaceNotificationLogService.create({
+          data: log,
+          props: { isRoot: true },
+        });
+      } catch (err) {
+        logger.error("Could not write test-send failure to notification log:");
+        logger.error(err);
       }
     }
   }

--- a/Common/Server/Services/WorkspaceProjectAuthTokenService.ts
+++ b/Common/Server/Services/WorkspaceProjectAuthTokenService.ts
@@ -1,5 +1,7 @@
 import ObjectID from "../../Types/ObjectID";
-import WorkspaceType from "../../Types/Workspace/WorkspaceType";
+import WorkspaceType, {
+  getWorkspaceTypeDisplayName,
+} from "../../Types/Workspace/WorkspaceType";
 import DatabaseService from "./DatabaseService";
 import Model, {
   WorkspaceMiscData,
@@ -7,6 +9,7 @@ import Model, {
 import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import logger from "../Utils/Logger";
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
@@ -112,11 +115,44 @@ export class Service extends DatabaseService<Model> {
       },
       select: {
         _id: true,
+        workspaceProjectId: true,
       },
       props: {
         isRoot: true,
       },
     });
+
+    /*
+     * A project stores exactly one workspace (one Microsoft tenant / one Slack
+     * team). Re-running the connect flow from a DIFFERENT workspace used to
+     * silently repoint the project, which breaks every existing notification
+     * rule and orphans the bot conversations captured under the old workspace —
+     * with no error and nothing in the logs.
+     *
+     * Refuse instead, and tell the admin to disconnect first if the change is
+     * deliberate.
+     */
+    if (
+      projectAuth &&
+      projectAuth.workspaceProjectId &&
+      projectAuth.workspaceProjectId !== data.workspaceProjectId
+    ) {
+      logger.error(
+        `Refusing to repoint ${data.workspaceType} for project ${data.projectId.toString()} from workspace ${projectAuth.workspaceProjectId} to ${data.workspaceProjectId}.`,
+        {
+          projectId: data.projectId.toString(),
+          workspaceType: data.workspaceType,
+        },
+      );
+
+      const workspaceName: string = getWorkspaceTypeDisplayName(
+        data.workspaceType,
+      );
+
+      throw new BadDataException(
+        `This OneUptime project is already connected to a different ${workspaceName} workspace. Disconnect the existing ${workspaceName} connection in Project Settings before connecting a new one.`,
+      );
+    }
 
     if (!projectAuth) {
       projectAuth = new Model();

--- a/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
+++ b/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
@@ -34,6 +34,7 @@ import SSRFProtection from "../../SSRFProtection";
 import WorkspaceProjectAuthToken, {
   MicrosoftTeamsChat,
   MicrosoftTeamsChatType,
+  MicrosoftTeamsInstalledTeam,
   MicrosoftTeamsMiscData,
 } from "../../../../Models/DatabaseModels/WorkspaceProjectAuthToken";
 import Incident from "../../../../Models/DatabaseModels/Incident";
@@ -110,6 +111,29 @@ import { AIChatCitation } from "../../../../Types/AI/AIChatTypes";
 
 // Microsoft Teams apps should always be single-tenant
 const MICROSOFT_TEAMS_APP_TYPE: string = "SingleTenant";
+
+/*
+ * Outcome of mapping a Microsoft tenant id to a OneUptime project.
+ *
+ * projectAuth is null both when nothing matched and when the tenant is
+ * connected to several projects — isAmbiguous distinguishes the two so callers
+ * can give the right remedy.
+ */
+export interface MicrosoftTeamsTenantResolution {
+  projectAuth: WorkspaceProjectAuthToken | null;
+  isAmbiguous: boolean;
+  candidateProjectIds: Array<ObjectID>;
+}
+
+/*
+ * Microsoft's wording when the Bot Framework refuses a proactive post because
+ * the app is not a member of the target conversation. Matched case-insensitively
+ * so we can replace it with something the admin can act on.
+ */
+const MICROSOFT_TEAMS_ROSTER_ERROR_FRAGMENTS: Array<string> = [
+  "not part of the conversation roster",
+  "bot is not part of the conversation",
+];
 
 // Maximum number of pages to fetch when paginating teams
 const MICROSOFT_TEAMS_MAX_PAGES: number = 500;
@@ -1083,6 +1107,7 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
           name: displayName,
           workspaceType: WorkspaceType.MicrosoftTeams,
           teamId: data.teamId,
+          membershipType: channelData["membershipType"] as string | undefined,
         };
         logger.debug(`Channel match found: ${JSON.stringify(foundChannel)}`);
         return foundChannel;
@@ -1153,6 +1178,17 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
       `Channel names: ${JSON.stringify(data.workspaceMessagePayload.channelNames)}`,
     );
 
+    /*
+     * Declared before destination resolution so that a destination we cannot
+     * even resolve is reported as an error. Silently skipping it made a
+     * typo'd or deleted channel look like a successful send.
+     */
+    const workspaceMessageResponse: WorkspaceSendMessageResponse = {
+      threads: [],
+      workspaceType: WorkspaceType.MicrosoftTeams,
+      errors: [],
+    };
+
     // Resolve channel names
     for (const channelName of data.workspaceMessagePayload.channelNames) {
       logger.debug(`Attempting to resolve channel name: ${channelName}`);
@@ -1178,6 +1214,15 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
         workspaceChannelsToPostTo.push(channel);
       } else {
         logger.warn(`Channel not found: ${channelName}`);
+        workspaceMessageResponse.errors!.push({
+          channel: {
+            id: "",
+            name: channelName,
+            workspaceType: WorkspaceType.MicrosoftTeams,
+            teamId: data.workspaceMessagePayload.teamId,
+          },
+          error: `Channel "${channelName}" was not found in this Microsoft Teams team. It may have been renamed or deleted.`,
+        });
       }
     }
 
@@ -1215,6 +1260,15 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
           },
         );
         logger.error(err);
+        workspaceMessageResponse.errors!.push({
+          channel: {
+            id: channelId,
+            name: channelId,
+            workspaceType: WorkspaceType.MicrosoftTeams,
+            teamId: data.workspaceMessagePayload.teamId,
+          },
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
     }
 
@@ -1223,12 +1277,6 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
       `Total channels to post to: ${workspaceChannelsToPostTo.length}`,
     );
     logger.debug(`Channels: ${JSON.stringify(workspaceChannelsToPostTo)}`);
-
-    const workspaceMessageResponse: WorkspaceSendMessageResponse = {
-      threads: [],
-      workspaceType: WorkspaceType.MicrosoftTeams,
-      errors: [],
-    };
 
     for (const channel of workspaceChannelsToPostTo) {
       try {
@@ -1419,6 +1467,43 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
 
       logger.debug(`Using bot ID: ${miscData.botId}`);
 
+      /*
+       * Bots cannot post to shared channels at all, so fail with the reason
+       * rather than letting Microsoft reject the send with a generic error.
+       */
+      if (data.workspaceChannel.membershipType === "shared") {
+        throw new BadDataException(
+          `"${data.workspaceChannel.name}" is a shared channel, and Microsoft Teams does not allow bots to post in shared channels. Please pick a standard or private channel instead.`,
+        );
+      }
+
+      /*
+       * Preflight: refuse before calling the Bot Framework when we know the
+       * app was never installed into this team. Channels are discovered with
+       * tenant-wide Graph application permissions, which see every team
+       * regardless of installation — so reaching this point proves nothing
+       * about whether we can actually post.
+       *
+       * installedTeams is only populated from install events, so an empty map
+       * means "we have not observed any installs" (for example on a workspace
+       * connected before this shipped), not "nothing is installed". Only
+       * enforce once we have at least one record, and let the Bot Framework
+       * error be translated below otherwise.
+       */
+      const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> =
+        miscData.installedTeams || {};
+      const installedTeam: MicrosoftTeamsInstalledTeam | undefined =
+        installedTeams[data.teamId];
+
+      if (Object.keys(installedTeams).length > 0 && !installedTeam) {
+        throw new BadDataException(
+          this.getBotNotInTeamMessage({
+            channelName: data.workspaceChannel.name,
+            membershipType: data.workspaceChannel.membershipType,
+          }),
+        );
+      }
+
       // Get Bot Framework adapter
       const adapter: CloudAdapter = this.getBotAdapter();
 
@@ -1436,7 +1521,13 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
           tenantId: tenantId,
         },
         channelId: "msteams",
-        serviceUrl: "https://smba.trafficmanager.net/teams/",
+        /*
+         * Fallback is the commercial-cloud global endpoint; the serviceUrl
+         * captured from the install event is preferred (required for GCC/DoD),
+         * matching what sendAdaptiveCardToChat already does.
+         */
+        serviceUrl:
+          installedTeam?.serviceUrl || "https://smba.trafficmanager.net/teams/",
       };
 
       logger.debug(
@@ -1483,8 +1574,57 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
         teamId: data.teamId,
       });
       logger.error(error);
+
+      /*
+       * Microsoft's roster rejection is meaningless to an admin ("The bot is
+       * not part of the conversation roster"). Replace it with the action that
+       * actually fixes it.
+       */
+      if (this.isBotNotInConversationRosterError(error)) {
+        throw new BadDataException(
+          this.getBotNotInTeamMessage({
+            channelName: data.workspaceChannel.name,
+            membershipType: data.workspaceChannel.membershipType,
+          }),
+        );
+      }
+
       throw error;
     }
+  }
+
+  /*
+   * True when an error is Microsoft's "bot is not in this conversation"
+   * rejection from a proactive Bot Framework send.
+   */
+  public static isBotNotInConversationRosterError(error: unknown): boolean {
+    const message: string = (
+      error instanceof Error ? error.message : String(error || "")
+    ).toLowerCase();
+
+    if (!message) {
+      return false;
+    }
+
+    return MICROSOFT_TEAMS_ROSTER_ERROR_FRAGMENTS.some((fragment: string) => {
+      return message.includes(fragment);
+    });
+  }
+
+  /*
+   * Actionable replacement for the roster error. Private channels need the app
+   * installed into the channel itself; a parent-team install does not cover
+   * them, so the two cases get different instructions.
+   */
+  public static getBotNotInTeamMessage(data: {
+    channelName: string;
+    membershipType?: string | undefined;
+  }): string {
+    if (data.membershipType === "private") {
+      return `The OneUptime app is not installed in the private channel "${data.channelName}". In Microsoft Teams, open the channel, click the "..." menu, then Manage channel > Apps > Add an app, and add OneUptime. Installing OneUptime in the parent team does not cover private channels.`;
+    }
+
+    return `The OneUptime app is not installed in the Microsoft Teams team that owns "${data.channelName}". In Microsoft Teams, click the "..." next to the team name, then Manage team > Apps > More apps, and add OneUptime. Installing OneUptime for yourself or in a chat is not the same as adding it to the team.`;
   }
 
   /*
@@ -1700,6 +1840,7 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
         name: channelData["displayName"] as string,
         workspaceType: WorkspaceType.MicrosoftTeams,
         teamId: data.teamId,
+        membershipType: channelData["membershipType"] as string | undefined,
       };
 
       logger.debug(`Channel info retrieved: ${JSON.stringify(channel)}`);
@@ -1914,10 +2055,27 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
     const channelsDict: Dictionary<WorkspaceChannel> = {};
 
     for (const channelData of channelsArray) {
+      const membershipType: string | undefined = channelData[
+        "membershipType"
+      ] as string | undefined;
+
+      /*
+       * Microsoft Teams does not support bots in shared channels, so offering
+       * one as a notification destination can only ever produce a failed send.
+       */
+      if (membershipType === "shared") {
+        logger.debug(
+          `Skipping shared channel ${channelData["displayName"]} — Teams does not support bots in shared channels.`,
+        );
+        continue;
+      }
+
       const channel: WorkspaceChannel = {
         id: channelData["id"] as string,
         name: channelData["displayName"] as string,
         workspaceType: WorkspaceType.MicrosoftTeams,
+        teamId: data.teamId,
+        membershipType: membershipType,
       };
       channelsDict[channel.id] = channel;
     }
@@ -2174,6 +2332,19 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
       });
     }
 
+    /*
+     * Same backfill for team installs. Teams the app was added to before we
+     * started recording installs fire no new install event, so an @mention in
+     * any channel of that team is the recovery path that makes proactive
+     * channel notifications work again.
+     */
+    if (messageConversationType === "channel") {
+      await this.captureTeamFromBotActivity({
+        activity: data.activity,
+        turnContext: data.turnContext,
+      });
+    }
+
     // If this is actually an Adaptive Card submit wrapped as a message, route to invoke handler
     if (
       (possibleActionValue["action"] as string) ||
@@ -2222,32 +2393,22 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
     }
 
     // Get project auth by tenant ID
-    const projectAuth: WorkspaceProjectAuthToken | null =
-      await WorkspaceProjectAuthTokenService.findOneBy({
-        query: {
-          workspaceType: WorkspaceType.MicrosoftTeams,
-          workspaceProjectId: tenantId,
-        },
-        select: {
-          projectId: true,
-          workspaceProjectId: true,
-        },
-        props: {
-          isRoot: true,
-        },
-      });
-
-    if (!projectAuth || !projectAuth.projectId) {
-      logger.error("Project auth not found for tenant ID: " + tenantId, {
+    const tenantResolution: MicrosoftTeamsTenantResolution =
+      await this.resolveProjectByTenantId({
         tenantId: tenantId,
       });
+
+    if (
+      !tenantResolution.projectAuth ||
+      !tenantResolution.projectAuth.projectId
+    ) {
       await data.turnContext.sendActivity(
-        "Sorry, I couldn't find your project configuration. Please try again later.",
+        this.getTenantResolutionFailureMessage(tenantResolution),
       );
       return;
     }
 
-    const projectId: ObjectID = projectAuth.projectId;
+    const projectId: ObjectID = tenantResolution.projectAuth.projectId;
     logger.debug(
       `Found project ID: ${projectId.toString()} for tenant ID: ${tenantId}`,
     );
@@ -3286,34 +3447,22 @@ All monitoring checks are passing normally.`;
         return;
       }
 
-      const projectAuth: WorkspaceProjectAuthToken | null =
-        await WorkspaceProjectAuthTokenService.findOneBy({
-          query: {
-            workspaceType: WorkspaceType.MicrosoftTeams,
-            workspaceProjectId: tenantId,
-          },
-          select: {
-            projectId: true,
-            authToken: true,
-            workspaceProjectId: true,
-          },
-          props: { isRoot: true },
+      const tenantResolution: MicrosoftTeamsTenantResolution =
+        await this.resolveProjectByTenantId({
+          tenantId: tenantId,
         });
 
-      if (!projectAuth || !projectAuth.projectId) {
-        logger.error(
-          "Project auth not found for invoke activity tenant: " + tenantId,
-          {
-            tenantId: tenantId,
-          },
-        );
+      if (
+        !tenantResolution.projectAuth ||
+        !tenantResolution.projectAuth.projectId
+      ) {
         await data.turnContext.sendActivity(
-          "Sorry, I couldn't find your project configuration.",
+          this.getTenantResolutionFailureMessage(tenantResolution),
         );
         return;
       }
 
-      const projectId: ObjectID = projectAuth.projectId;
+      const projectId: ObjectID = tenantResolution.projectAuth.projectId;
       const fromObj: JSONObject = ((data.activity["from"] as JSONObject) ||
         {}) as JSONObject;
       const teamsUserId: string | undefined =
@@ -3502,12 +3651,19 @@ All monitoring checks are passing normally.`;
         activity: data.activity,
         turnContext: data.turnContext,
       });
+      await this.captureTeamFromBotActivity({
+        activity: data.activity,
+        turnContext: data.turnContext,
+      });
       await this.sendWelcomeAdaptiveCard(data.turnContext);
     }
 
     if (botWasRemoved) {
       logger.debug("OneUptime bot was removed from a Teams conversation");
       await this.removeChatFromBotActivity({
+        activity: data.activity,
+      });
+      await this.removeTeamFromBotActivity({
         activity: data.activity,
       });
     }
@@ -3539,12 +3695,138 @@ All monitoring checks are passing normally.`;
         activity: data.activity,
         turnContext: data.turnContext,
       });
+      await this.captureTeamFromBotActivity({
+        activity: data.activity,
+        turnContext: data.turnContext,
+      });
     } else if (action === "remove" || action === "remove-upgrade") {
       logger.debug("OneUptime bot was uninstalled");
       await this.removeChatFromBotActivity({
         activity: data.activity,
       });
+      await this.removeTeamFromBotActivity({
+        activity: data.activity,
+      });
     }
+  }
+
+  /*
+   * Resolve the OneUptime project that owns a Microsoft tenant.
+   *
+   * Bot activities carry a tenant id and nothing else, so the tenant is the
+   * only key we can resolve a project by. A tenant may legitimately be
+   * connected to more than one OneUptime project (saveChatToProjectAuthTokens
+   * fans out for exactly that reason), and when that happens the tenant alone
+   * does NOT identify a project.
+   *
+   * Previously this was a bare findOneBy, which silently returned whichever
+   * row sorted first and served that project's incidents, alerts and AI
+   * assistant answers to anyone in the tenant — including users with no access
+   * to it. The bot's message path performs no per-user authorization, so
+   * picking arbitrarily is a cross-project disclosure. Refuse instead.
+   */
+  @CaptureSpan()
+  public static async resolveProjectByTenantId(data: {
+    tenantId: string;
+  }): Promise<MicrosoftTeamsTenantResolution> {
+    const projectAuths: Array<WorkspaceProjectAuthToken> =
+      await WorkspaceProjectAuthTokenService.findBy({
+        query: {
+          workspaceType: WorkspaceType.MicrosoftTeams,
+          workspaceProjectId: data.tenantId,
+        },
+        select: {
+          projectId: true,
+          authToken: true,
+          workspaceProjectId: true,
+          miscData: true,
+        },
+        limit: LIMIT_MAX,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      });
+
+    /*
+     * Ambiguity is about distinct PROJECTS, not rows. Two rows pointing at the
+     * same project are a data-integrity wart, not a question we cannot answer,
+     * so collapse them rather than refusing to serve that tenant forever.
+     */
+    const seenProjectIds: Set<string> = new Set<string>();
+    const usableProjectAuths: Array<WorkspaceProjectAuthToken> = [];
+
+    for (const projectAuth of projectAuths) {
+      if (!projectAuth.projectId) {
+        continue;
+      }
+
+      const projectIdString: string = projectAuth.projectId.toString();
+
+      if (seenProjectIds.has(projectIdString)) {
+        continue;
+      }
+
+      seenProjectIds.add(projectIdString);
+      usableProjectAuths.push(projectAuth);
+    }
+
+    if (usableProjectAuths.length === 0) {
+      logger.error("Project auth not found for tenant ID: " + data.tenantId, {
+        tenantId: data.tenantId,
+      });
+      return {
+        projectAuth: null,
+        isAmbiguous: false,
+        candidateProjectIds: [],
+      };
+    }
+
+    if (usableProjectAuths.length > 1) {
+      const candidateProjectIds: Array<ObjectID> = usableProjectAuths.map(
+        (projectAuth: WorkspaceProjectAuthToken) => {
+          return projectAuth.projectId!;
+        },
+      );
+
+      logger.error(
+        `Microsoft tenant ${data.tenantId} is connected to ${usableProjectAuths.length} OneUptime projects. Refusing to guess which one this bot activity belongs to.`,
+        {
+          tenantId: data.tenantId,
+          projectIds: candidateProjectIds
+            .map((projectId: ObjectID) => {
+              return projectId.toString();
+            })
+            .join(", "),
+        },
+      );
+
+      return {
+        projectAuth: null,
+        isAmbiguous: true,
+        candidateProjectIds: candidateProjectIds,
+      };
+    }
+
+    return {
+      projectAuth: usableProjectAuths[0]!,
+      isAmbiguous: false,
+      candidateProjectIds: [usableProjectAuths[0]!.projectId!],
+    };
+  }
+
+  /*
+   * User-facing text for a failed tenant resolution. The two cases need
+   * different remedies, so they must not share a message.
+   */
+  public static getTenantResolutionFailureMessage(
+    resolution: MicrosoftTeamsTenantResolution,
+  ): string {
+    if (resolution.isAmbiguous) {
+      return "This Microsoft 365 organization is connected to more than one OneUptime project, so I can't tell which one you mean. Please ask your OneUptime admin to disconnect Microsoft Teams from all but one project.";
+    }
+
+    return "Sorry, I couldn't find your project configuration. This usually means the Microsoft 365 organization you're messaging me from isn't the one connected to OneUptime. Please ask your OneUptime admin to check the Microsoft Teams integration in Project Settings.";
   }
 
   /*
@@ -3938,6 +4220,214 @@ All monitoring checks are passing normally.`;
 
     return (
       (projectAuth.miscData as MicrosoftTeamsMiscData).availableChats || {}
+    );
+  }
+
+  /*
+   * Record that the OneUptime app was installed into a team.
+   *
+   * Team installs arrive as conversationUpdate / installationUpdate activities
+   * whose conversation is a channel. captureChatFromBotActivity drops those
+   * (channels are not chats), so before this existed we threw away the only
+   * signal that tells us a proactive channel post will be accepted.
+   */
+  @CaptureSpan()
+  public static async captureTeamFromBotActivity(data: {
+    activity: JSONObject;
+    turnContext: TurnContext;
+  }): Promise<void> {
+    try {
+      const channelData: JSONObject =
+        (data.activity["channelData"] as JSONObject) || {};
+
+      const team: JSONObject | undefined = channelData["team"] as
+        | JSONObject
+        | undefined;
+
+      const teamId: string = (team?.["id"] as string) || "";
+
+      if (!teamId) {
+        // Not a team-scoped activity (personal or group chat). Nothing to do.
+        return;
+      }
+
+      const tenantId: string =
+        ((channelData["tenant"] as JSONObject)?.["id"] as string) || "";
+
+      if (!tenantId) {
+        logger.debug("No tenant id found on team activity. Skipping.");
+        return;
+      }
+
+      const installedTeam: MicrosoftTeamsInstalledTeam = {
+        id: teamId,
+        name: (team?.["name"] as string) || undefined,
+        serviceUrl:
+          (data.activity["serviceUrl"] as string) ||
+          data.turnContext.activity.serviceUrl ||
+          undefined,
+        addedAt: OneUptimeDate.getCurrentDate().toISOString(),
+      };
+
+      await this.saveTeamToProjectAuthTokens({
+        tenantId: tenantId,
+        team: installedTeam,
+      });
+
+      logger.debug(
+        `Captured Microsoft Teams team install ${teamId} for tenant ${tenantId}`,
+      );
+    } catch (err) {
+      logger.error("Error capturing Microsoft Teams team from bot activity:");
+      logger.error(err);
+    }
+  }
+
+  @CaptureSpan()
+  public static async removeTeamFromBotActivity(data: {
+    activity: JSONObject;
+  }): Promise<void> {
+    try {
+      const channelData: JSONObject =
+        (data.activity["channelData"] as JSONObject) || {};
+
+      const teamId: string =
+        ((channelData["team"] as JSONObject)?.["id"] as string) || "";
+      const tenantId: string =
+        ((channelData["tenant"] as JSONObject)?.["id"] as string) || "";
+
+      if (!teamId || !tenantId) {
+        return;
+      }
+
+      await this.removeTeamFromProjectAuthTokens({
+        tenantId: tenantId,
+        teamId: teamId,
+      });
+
+      logger.debug(
+        `Removed Microsoft Teams team install ${teamId} for tenant ${tenantId}`,
+      );
+    } catch (err) {
+      logger.error("Error removing Microsoft Teams team from bot activity:");
+      logger.error(err);
+    }
+  }
+
+  @CaptureSpan()
+  public static async saveTeamToProjectAuthTokens(data: {
+    tenantId: string;
+    team: MicrosoftTeamsInstalledTeam;
+  }): Promise<void> {
+    /*
+     * Same fan-out reasoning as saveChatToProjectAuthTokens: the install event
+     * does not say which project it belongs to, so record it on every project
+     * connected to this tenant.
+     */
+    const projectAuths: Array<WorkspaceProjectAuthToken> =
+      await WorkspaceProjectAuthTokenService.findBy({
+        query: {
+          workspaceType: WorkspaceType.MicrosoftTeams,
+          workspaceProjectId: data.tenantId,
+        },
+        select: {
+          _id: true,
+          miscData: true,
+        },
+        limit: LIMIT_MAX,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      });
+
+    for (const projectAuth of projectAuths) {
+      const miscData: MicrosoftTeamsMiscData = {
+        ...((projectAuth.miscData as MicrosoftTeamsMiscData) || {}),
+      } as MicrosoftTeamsMiscData;
+
+      miscData.installedTeams = {
+        ...(miscData.installedTeams || {}),
+        [data.team.id]: data.team,
+      };
+
+      await WorkspaceProjectAuthTokenService.updateOneById({
+        id: projectAuth.id!,
+        data: {
+          miscData: miscData,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+    }
+  }
+
+  @CaptureSpan()
+  public static async removeTeamFromProjectAuthTokens(data: {
+    tenantId: string;
+    teamId: string;
+  }): Promise<void> {
+    const projectAuths: Array<WorkspaceProjectAuthToken> =
+      await WorkspaceProjectAuthTokenService.findBy({
+        query: {
+          workspaceType: WorkspaceType.MicrosoftTeams,
+          workspaceProjectId: data.tenantId,
+        },
+        select: {
+          _id: true,
+          miscData: true,
+        },
+        limit: LIMIT_MAX,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      });
+
+    for (const projectAuth of projectAuths) {
+      const miscData: MicrosoftTeamsMiscData = {
+        ...((projectAuth.miscData as MicrosoftTeamsMiscData) || {}),
+      } as MicrosoftTeamsMiscData;
+
+      if (!miscData.installedTeams || !miscData.installedTeams[data.teamId]) {
+        continue;
+      }
+
+      const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> = {
+        ...miscData.installedTeams,
+      };
+      delete installedTeams[data.teamId];
+      miscData.installedTeams = installedTeams;
+
+      await WorkspaceProjectAuthTokenService.updateOneById({
+        id: projectAuth.id!,
+        data: {
+          miscData: miscData,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+    }
+  }
+
+  @CaptureSpan()
+  public static async getInstalledTeamsForProject(data: {
+    projectId: ObjectID;
+  }): Promise<Record<string, MicrosoftTeamsInstalledTeam>> {
+    const projectAuth: WorkspaceProjectAuthToken | null =
+      await WorkspaceProjectAuthTokenService.getProjectAuth({
+        projectId: data.projectId,
+        workspaceType: WorkspaceType.MicrosoftTeams,
+      });
+
+    if (!projectAuth || !projectAuth.miscData) {
+      return {};
+    }
+
+    return (
+      (projectAuth.miscData as MicrosoftTeamsMiscData).installedTeams || {}
     );
   }
 
@@ -4375,7 +4865,12 @@ All monitoring checks are passing normally.`;
               id: t["id"] as string,
               name: (t["displayName"] as string) || "Unnamed Team",
             };
-            acc[team.name] = team;
+            /*
+             * Keyed by id, not display name — Teams allows duplicate team
+             * names, and keying by name silently collapsed them so only the
+             * last one of each name was selectable.
+             */
+            acc[team.id] = team;
             return acc;
           },
           {} as Record<string, { id: string; name: string }>,

--- a/Common/Server/Utils/Workspace/WorkspaceBase.ts
+++ b/Common/Server/Utils/Workspace/WorkspaceBase.ts
@@ -43,6 +43,12 @@ export interface WorkspaceChannel {
   name: string;
   workspaceType: WorkspaceType;
   teamId?: string; // Required for Microsoft Teams
+  /*
+   * Microsoft Teams only: "standard" | "private" | "shared". Bots cannot post
+   * to shared channels at all, and a private channel needs the app installed
+   * into that channel specifically rather than into the parent team.
+   */
+  membershipType?: string | undefined;
 }
 
 export default class WorkspaceBase {

--- a/Common/Tests/Server/Services/WorkspaceProjectAuthTokenRepoint.test.ts
+++ b/Common/Tests/Server/Services/WorkspaceProjectAuthTokenRepoint.test.ts
@@ -1,0 +1,618 @@
+import { describe, expect, test, afterEach, beforeEach } from "@jest/globals";
+
+/*
+ * WorkspaceProjectAuthTokenService.refreshAuthToken — the workspace REPOINT
+ * guard.
+ *
+ * A OneUptime project stores exactly one workspace connection per workspace
+ * type: one Microsoft tenant, one Slack team. refreshAuthToken upserts on
+ * (projectId, workspaceType) and USED TO overwrite workspaceProjectId
+ * unconditionally, so re-running the connect flow while signed into a
+ * DIFFERENT Microsoft tenant (or a different Slack team) silently repointed
+ * the project. Every existing notification rule then aimed at channels/chats
+ * that no longer resolve, and every bot conversation captured under the old
+ * workspace was orphaned — with no error to the admin and nothing in the logs.
+ *
+ * The fix selects workspaceProjectId alongside _id and refuses the write when
+ * the stored workspace differs from the incoming one, telling the admin to
+ * disconnect the existing connection first.
+ *
+ * What is pinned here:
+ *
+ *   1. The happy paths still work: no row -> create with every field set and
+ *      nothing logged; matching workspaceProjectId -> updateOneById.
+ *   2. A MISMATCH throws BadDataException BEFORE any write — neither create
+ *      nor updateOneById may be reached — the message names the workspace type
+ *      and tells the admin to disconnect, and the log carries structured
+ *      context.
+ *   3. A stored row with no workspaceProjectId has nothing to protect and must
+ *      still update.
+ *   4. The guard is workspace-agnostic: Slack behaves exactly like Microsoft
+ *      Teams, and the lookup is scoped to (projectId, workspaceType) so the
+ *      two types cannot cross-fire.
+ *   5. THE SUBTLE REGRESSION: the findOneBy select must include
+ *      workspaceProjectId. Drop that one field and findOneBy hands back a row
+ *      whose workspaceProjectId is undefined, the guard never fires, and the
+ *      silent repoint is back. The findOneBy mock below HONOURS the select for
+ *      exactly this reason — it projects the stored row down to the columns
+ *      the caller asked for, the way the database does — so reverting either
+ *      half of the fix breaks the guard tests on BEHAVIOUR, not just the one
+ *      white-box assertion on the select object.
+ *   6. The pre-existing argument validation is unchanged, and rejects before
+ *      any database round trip.
+ *   7. One known limitation, documented deliberately rather than asserted as
+ *      desirable: the guard is TENANT-scoped, not team-scoped.
+ */
+
+import WorkspaceProjectAuthTokenService from "../../../Server/Services/WorkspaceProjectAuthTokenService";
+import WorkspaceProjectAuthToken, {
+  MicrosoftTeamsMiscData,
+  SlackMiscData,
+  WorkspaceMiscData,
+} from "../../../Models/DatabaseModels/WorkspaceProjectAuthToken";
+import WorkspaceType from "../../../Types/Workspace/WorkspaceType";
+import ObjectID from "../../../Types/ObjectID";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import Exception from "../../../Types/Exception/Exception";
+import logger from "../../../Server/Utils/Logger";
+
+const TEAMS_TENANT_A: string = "11111111-2222-3333-4444-555555555555";
+const TEAMS_TENANT_B: string = "99999999-8888-7777-6666-555555555555";
+const SLACK_TEAM_A: string = "T0AAAAAAA";
+const SLACK_TEAM_B: string = "T0BBBBBBB";
+
+let findOneBy: jest.SpyInstance;
+let create: jest.SpyInstance;
+let updateOneById: jest.SpyInstance;
+let loggerError: jest.SpyInstance;
+
+function teamsMiscData(
+  overrides?: Partial<MicrosoftTeamsMiscData>,
+): MicrosoftTeamsMiscData {
+  return {
+    tenantId: TEAMS_TENANT_A,
+    teamId: "team-1",
+    teamName: "Engineering",
+    botId: "bot-1",
+    ...(overrides || {}),
+  } as MicrosoftTeamsMiscData;
+}
+
+function slackMiscData(overrides?: Partial<SlackMiscData>): SlackMiscData {
+  return {
+    teamId: SLACK_TEAM_A,
+    teamName: "Acme",
+    botUserId: "U0BOT",
+    ...(overrides || {}),
+  } as SlackMiscData;
+}
+
+/*
+ * The full row as it sits in the database. What refreshAuthToken actually gets
+ * to see is decided by its own select — see mockStoredRow.
+ */
+type StoredRow = {
+  id: ObjectID;
+  projectId: ObjectID;
+  workspaceType: WorkspaceType;
+  authToken: string;
+  workspaceProjectId: string | undefined | null;
+  miscData: WorkspaceMiscData;
+};
+
+const SELECT_KEY_TO_ROW_KEY: Record<string, keyof StoredRow> = {
+  _id: "id",
+  id: "id",
+  projectId: "projectId",
+  workspaceType: "workspaceType",
+  authToken: "authToken",
+  workspaceProjectId: "workspaceProjectId",
+  miscData: "miscData",
+};
+
+function buildStoredRow(overrides?: Partial<StoredRow>): StoredRow {
+  return {
+    id: ObjectID.generate(),
+    projectId: ObjectID.generate(),
+    workspaceType: WorkspaceType.MicrosoftTeams,
+    authToken: "stored-token",
+    workspaceProjectId: TEAMS_TENANT_A,
+    miscData: teamsMiscData(),
+    ...(overrides || {}),
+  };
+}
+
+/*
+ * findOneBy hands back ONLY the columns the caller selected — so this
+ * projection is the whole point of the mock, not a nicety. A row that carried
+ * workspaceProjectId regardless of the select would keep the guard tests green
+ * even with `workspaceProjectId: true` deleted from production's select, which
+ * is precisely the regression this suite exists to catch.
+ */
+function projectOntoSelect(
+  row: StoredRow,
+  select: Record<string, boolean> | undefined,
+): WorkspaceProjectAuthToken {
+  const selected: Record<string, boolean> = select || {};
+  const projected: Record<string, unknown> = {};
+
+  for (const selectKey of Object.keys(selected)) {
+    if (!selected[selectKey]) {
+      continue;
+    }
+
+    const rowKey: keyof StoredRow | undefined =
+      SELECT_KEY_TO_ROW_KEY[selectKey];
+
+    if (!rowKey) {
+      continue;
+    }
+
+    projected[rowKey] = row[rowKey];
+  }
+
+  return projected as unknown as WorkspaceProjectAuthToken;
+}
+
+type FindOneByArgs = {
+  query: Record<string, unknown>;
+  select: Record<string, boolean> | undefined;
+  props: { isRoot: boolean };
+};
+
+function mockStoredRow(overrides?: Partial<StoredRow>): StoredRow {
+  const row: StoredRow = buildStoredRow(overrides);
+
+  findOneBy.mockImplementation(
+    async (
+      findBy: FindOneByArgs,
+    ): Promise<WorkspaceProjectAuthToken | null> => {
+      return projectOntoSelect(row, findBy.select);
+    },
+  );
+
+  return row;
+}
+
+type RefreshArgs = {
+  projectId: ObjectID;
+  workspaceType: WorkspaceType;
+  authToken: string;
+  workspaceProjectId: string;
+  miscData: WorkspaceMiscData;
+};
+
+function refreshArgs(overrides?: Partial<RefreshArgs>): RefreshArgs {
+  return {
+    projectId: ObjectID.generate(),
+    workspaceType: WorkspaceType.MicrosoftTeams,
+    authToken: "auth-token-1",
+    workspaceProjectId: TEAMS_TENANT_A,
+    miscData: teamsMiscData(),
+    ...(overrides || {}),
+  };
+}
+
+async function refresh(overrides?: Partial<RefreshArgs>): Promise<void> {
+  return await WorkspaceProjectAuthTokenService.refreshAuthToken(
+    refreshArgs(overrides),
+  );
+}
+
+async function captureError(fn: () => Promise<void>): Promise<Exception> {
+  try {
+    await fn();
+  } catch (err) {
+    return err as Exception;
+  }
+  throw new Error("Expected refreshAuthToken to throw, but it resolved.");
+}
+
+beforeEach(() => {
+  findOneBy = jest.spyOn(
+    WorkspaceProjectAuthTokenService,
+    "findOneBy",
+  ) as jest.SpyInstance;
+  create = jest.spyOn(
+    WorkspaceProjectAuthTokenService,
+    "create",
+  ) as jest.SpyInstance;
+  updateOneById = jest.spyOn(
+    WorkspaceProjectAuthTokenService,
+    "updateOneById",
+  ) as jest.SpyInstance;
+  loggerError = jest.spyOn(logger, "error") as jest.SpyInstance;
+
+  findOneBy.mockResolvedValue(null);
+  create.mockImplementation(
+    async (createBy: {
+      data: WorkspaceProjectAuthToken;
+    }): Promise<WorkspaceProjectAuthToken> => {
+      return createBy.data;
+    },
+  );
+  updateOneById.mockResolvedValue(1);
+  loggerError.mockImplementation((): void => {
+    return undefined;
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("WorkspaceProjectAuthTokenService.refreshAuthToken first connection", () => {
+  test("creates a row with every field set when the project has no connection", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+    const miscData: MicrosoftTeamsMiscData = teamsMiscData();
+
+    await refresh({
+      projectId: projectId,
+      workspaceType: WorkspaceType.MicrosoftTeams,
+      authToken: "brand-new-token",
+      workspaceProjectId: TEAMS_TENANT_A,
+      miscData: miscData,
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(updateOneById).not.toHaveBeenCalled();
+
+    const created: WorkspaceProjectAuthToken = create.mock.calls[0][0].data;
+    expect(created).toBeInstanceOf(WorkspaceProjectAuthToken);
+    expect(created.projectId?.toString()).toBe(projectId.toString());
+    expect(created.authToken).toBe("brand-new-token");
+    expect(created.workspaceType).toBe(WorkspaceType.MicrosoftTeams);
+    expect(created.workspaceProjectId).toBe(TEAMS_TENANT_A);
+    expect(created.miscData).toEqual(miscData);
+    expect(create.mock.calls[0][0].props).toEqual({ isRoot: true });
+
+    // A first connection repoints nothing, so the guard must stay quiet.
+    expect(loggerError).not.toHaveBeenCalled();
+  });
+});
+
+describe("WorkspaceProjectAuthTokenService.refreshAuthToken same workspace", () => {
+  test("updates the existing row when workspaceProjectId matches", async () => {
+    const miscData: MicrosoftTeamsMiscData = teamsMiscData({
+      teamName: "Renamed Team",
+    });
+    const row: StoredRow = mockStoredRow({
+      workspaceProjectId: TEAMS_TENANT_A,
+    });
+
+    await refresh({
+      authToken: "rotated-token",
+      workspaceProjectId: TEAMS_TENANT_A,
+      miscData: miscData,
+    });
+
+    expect(create).not.toHaveBeenCalled();
+    expect(updateOneById).toHaveBeenCalledTimes(1);
+
+    const updateArgs: {
+      id: ObjectID;
+      data: {
+        authToken: string;
+        workspaceProjectId: string;
+        miscData: WorkspaceMiscData;
+      };
+      props: { isRoot: boolean };
+    } = updateOneById.mock.calls[0][0];
+    expect(updateArgs.id.toString()).toBe(row.id.toString());
+    expect(updateArgs.data.authToken).toBe("rotated-token");
+    expect(updateArgs.data.workspaceProjectId).toBe(TEAMS_TENANT_A);
+    expect(updateArgs.data.miscData).toEqual(miscData);
+    expect(updateArgs.props).toEqual({ isRoot: true });
+    expect(loggerError).not.toHaveBeenCalled();
+  });
+});
+
+describe("WorkspaceProjectAuthTokenService.refreshAuthToken repoint guard", () => {
+  test("throws BadDataException when the stored workspace differs", async () => {
+    mockStoredRow({ workspaceProjectId: TEAMS_TENANT_A });
+
+    const error: Exception = await captureError(async (): Promise<void> => {
+      return await refresh({ workspaceProjectId: TEAMS_TENANT_B });
+    });
+
+    expect(error).toBeInstanceOf(BadDataException);
+  });
+
+  test("fires the guard BEFORE any write — no create, no update", async () => {
+    mockStoredRow({ workspaceProjectId: TEAMS_TENANT_A });
+
+    await captureError(async (): Promise<void> => {
+      return await refresh({ workspaceProjectId: TEAMS_TENANT_B });
+    });
+
+    expect(create).not.toHaveBeenCalled();
+    expect(updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("the message tells the admin to disconnect and names the workspace type", async () => {
+    mockStoredRow({ workspaceProjectId: TEAMS_TENANT_A });
+
+    const error: Exception = await captureError(async (): Promise<void> => {
+      return await refresh({
+        workspaceType: WorkspaceType.MicrosoftTeams,
+        workspaceProjectId: TEAMS_TENANT_B,
+      });
+    });
+
+    expect(error.message.toLowerCase()).toContain("disconnect");
+    /*
+     * The admin-facing display name, not the enum value: "Microsoft Teams",
+     * never "MicrosoftTeams".
+     */
+    expect(error.message).toContain("Microsoft Teams");
+    expect(error.message).not.toContain(WorkspaceType.MicrosoftTeams);
+  });
+
+  test("logs the refusal with structured project and workspace context", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+    mockStoredRow({ workspaceProjectId: TEAMS_TENANT_A });
+
+    await captureError(async (): Promise<void> => {
+      return await refresh({
+        projectId: projectId,
+        workspaceType: WorkspaceType.MicrosoftTeams,
+        workspaceProjectId: TEAMS_TENANT_B,
+      });
+    });
+
+    expect(loggerError).toHaveBeenCalledTimes(1);
+    expect(loggerError.mock.calls[0][1]).toEqual({
+      projectId: projectId.toString(),
+      workspaceType: WorkspaceType.MicrosoftTeams,
+    });
+  });
+
+  test("compares workspace ids exactly — a case difference is a different workspace", async () => {
+    /*
+     * The comparison is strict on purpose: a tenant id that arrives in a
+     * different case is not evidence that it is the same workspace, and
+     * refusing is the safe side of the trade.
+     */
+    mockStoredRow({ workspaceProjectId: SLACK_TEAM_A });
+
+    const error: Exception = await captureError(async (): Promise<void> => {
+      return await refresh({
+        workspaceType: WorkspaceType.Slack,
+        workspaceProjectId: SLACK_TEAM_A.toLowerCase(),
+        miscData: slackMiscData(),
+      });
+    });
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect(updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("a stored row with no workspaceProjectId updates instead of throwing", async () => {
+    /*
+     * Rows written before workspaceProjectId was populated have nothing to
+     * protect, so the guard must not strand them — the next connect adopts
+     * whatever workspace arrives.
+     */
+    mockStoredRow({ workspaceProjectId: null });
+
+    await expect(
+      refresh({ workspaceProjectId: TEAMS_TENANT_B }),
+    ).resolves.toBeUndefined();
+
+    expect(updateOneById).toHaveBeenCalledTimes(1);
+    expect(updateOneById.mock.calls[0][0].data.workspaceProjectId).toBe(
+      TEAMS_TENANT_B,
+    );
+    expect(create).not.toHaveBeenCalled();
+    expect(loggerError).not.toHaveBeenCalled();
+  });
+});
+
+describe("WorkspaceProjectAuthTokenService.refreshAuthToken guard scope", () => {
+  test("a different Teams TEAM in the SAME tenant is allowed and overwrites miscData", async () => {
+    /*
+     * DOCUMENTS CURRENT BEHAVIOUR, NOT DESIRED BEHAVIOUR.
+     *
+     * The guard is TENANT-scoped, not team-scoped: for Microsoft Teams,
+     * workspaceProjectId holds the tenant id, while the team the bot was
+     * actually installed into lives in miscData.teamId. Two different teams in
+     * one tenant are therefore indistinguishable to the guard, so this
+     * reconnect passes and replaces miscData wholesale — the old team id, name
+     * and bot id are gone, and anything captured under that team is orphaned
+     * exactly the way a cross-tenant repoint used to orphan things.
+     *
+     * If the guard is ever tightened to compare teams too, this is the test
+     * that should change.
+     */
+    const row: StoredRow = mockStoredRow({
+      workspaceProjectId: TEAMS_TENANT_A,
+      miscData: teamsMiscData({ teamId: "team-1", teamName: "Engineering" }),
+    });
+    const differentTeam: MicrosoftTeamsMiscData = teamsMiscData({
+      teamId: "team-2",
+      teamName: "Support",
+      botId: "bot-2",
+    });
+
+    await expect(
+      refresh({
+        workspaceProjectId: TEAMS_TENANT_A,
+        miscData: differentTeam,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(updateOneById).toHaveBeenCalledTimes(1);
+    expect(updateOneById.mock.calls[0][0].id.toString()).toBe(
+      row.id.toString(),
+    );
+    expect(updateOneById.mock.calls[0][0].data.miscData).toEqual(differentTeam);
+    expect(loggerError).not.toHaveBeenCalled();
+  });
+});
+
+describe("WorkspaceProjectAuthTokenService.refreshAuthToken across workspace types", () => {
+  test("Slack repoints are refused exactly like Microsoft Teams ones", async () => {
+    mockStoredRow({
+      workspaceType: WorkspaceType.Slack,
+      workspaceProjectId: SLACK_TEAM_A,
+    });
+
+    const error: Exception = await captureError(async (): Promise<void> => {
+      return await refresh({
+        workspaceType: WorkspaceType.Slack,
+        workspaceProjectId: SLACK_TEAM_B,
+        miscData: slackMiscData({ teamId: SLACK_TEAM_B }),
+      });
+    });
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect(error.message).toContain("Slack");
+    expect(error.message).not.toContain("Microsoft Teams");
+    expect(create).not.toHaveBeenCalled();
+    expect(updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("a Slack reconnect to the same team still updates", async () => {
+    mockStoredRow({
+      workspaceType: WorkspaceType.Slack,
+      workspaceProjectId: SLACK_TEAM_A,
+    });
+
+    await refresh({
+      workspaceType: WorkspaceType.Slack,
+      workspaceProjectId: SLACK_TEAM_A,
+      miscData: slackMiscData(),
+    });
+
+    expect(updateOneById).toHaveBeenCalledTimes(1);
+    expect(create).not.toHaveBeenCalled();
+  });
+});
+
+describe("WorkspaceProjectAuthTokenService.refreshAuthToken lookup", () => {
+  /*
+   * Without workspaceProjectId in the select, findOneBy returns a row whose
+   * workspaceProjectId is undefined and every repoint sails through as an
+   * update. The guard tests above already fail on behaviour if that happens
+   * (the findOneBy mock honours the select); this pins the cause directly so
+   * the failure is diagnosable rather than mysterious.
+   */
+  test("selects workspaceProjectId alongside _id so the guard can fire", async () => {
+    await refresh();
+
+    expect(findOneBy).toHaveBeenCalledTimes(1);
+    const select: { _id?: boolean; workspaceProjectId?: boolean } =
+      findOneBy.mock.calls[0][0].select;
+    expect(select.workspaceProjectId).toBe(true);
+    expect(select._id).toBe(true);
+  });
+
+  test("scopes the lookup to this project and this workspace type only", async () => {
+    /*
+     * A project connected to Microsoft Teams must still be able to connect
+     * Slack, so the row this guard compares against has to be the row for THIS
+     * workspace type — and the upsert has to key on nothing else, or a
+     * reconnect from a new workspace would find no row and create a duplicate
+     * instead of hitting the guard.
+     */
+    const projectId: ObjectID = ObjectID.generate();
+
+    await refresh({
+      projectId: projectId,
+      workspaceType: WorkspaceType.Slack,
+      workspaceProjectId: SLACK_TEAM_A,
+      miscData: slackMiscData(),
+    });
+
+    const query: { projectId: ObjectID; workspaceType: WorkspaceType } =
+      findOneBy.mock.calls[0][0].query;
+    expect(query.projectId.toString()).toBe(projectId.toString());
+    expect(query.workspaceType).toBe(WorkspaceType.Slack);
+    expect(Object.keys(query).sort()).toEqual(["projectId", "workspaceType"]);
+  });
+
+  test("reads with root props so the connect flow is not permission-scoped", async () => {
+    await refresh();
+
+    expect(findOneBy.mock.calls[0][0].props).toEqual({ isRoot: true });
+  });
+});
+
+describe("WorkspaceProjectAuthTokenService.refreshAuthToken argument validation", () => {
+  test("throws when projectId is missing", async () => {
+    const error: Exception = await captureError(async (): Promise<void> => {
+      return await WorkspaceProjectAuthTokenService.refreshAuthToken({
+        ...refreshArgs(),
+        projectId: undefined as unknown as ObjectID,
+      });
+    });
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect(error.message).toBe("projectId is required");
+    expect(findOneBy).not.toHaveBeenCalled();
+  });
+
+  test("throws when workspaceType is missing", async () => {
+    const error: Exception = await captureError(async (): Promise<void> => {
+      return await WorkspaceProjectAuthTokenService.refreshAuthToken({
+        ...refreshArgs(),
+        workspaceType: undefined as unknown as WorkspaceType,
+      });
+    });
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect(error.message).toBe("workspaceType is required");
+    expect(findOneBy).not.toHaveBeenCalled();
+  });
+
+  test("throws when authToken is missing", async () => {
+    const error: Exception = await captureError(async (): Promise<void> => {
+      return await WorkspaceProjectAuthTokenService.refreshAuthToken({
+        ...refreshArgs(),
+        authToken: "",
+      });
+    });
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect(error.message).toBe("authToken is required");
+    expect(findOneBy).not.toHaveBeenCalled();
+  });
+
+  test("throws when workspaceProjectId is missing", async () => {
+    const error: Exception = await captureError(async (): Promise<void> => {
+      return await WorkspaceProjectAuthTokenService.refreshAuthToken({
+        ...refreshArgs(),
+        workspaceProjectId: "",
+      });
+    });
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect(error.message).toBe("workspaceProjectId is required");
+    expect(findOneBy).not.toHaveBeenCalled();
+  });
+
+  test("throws when miscData is missing", async () => {
+    const error: Exception = await captureError(async (): Promise<void> => {
+      return await WorkspaceProjectAuthTokenService.refreshAuthToken({
+        ...refreshArgs(),
+        miscData: undefined as unknown as WorkspaceMiscData,
+      });
+    });
+
+    expect(error).toBeInstanceOf(BadDataException);
+    expect(error.message).toBe("miscData is required");
+    expect(findOneBy).not.toHaveBeenCalled();
+  });
+
+  test("validation rejects before any write is attempted", async () => {
+    await captureError(async (): Promise<void> => {
+      return await WorkspaceProjectAuthTokenService.refreshAuthToken({
+        ...refreshArgs(),
+        authToken: "",
+      });
+    });
+
+    expect(create).not.toHaveBeenCalled();
+    expect(updateOneById).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsChannelSend.test.ts
+++ b/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsChannelSend.test.ts
@@ -1,0 +1,1169 @@
+import { describe, expect, test, afterEach, beforeEach } from "@jest/globals";
+
+/*
+ * Tests for the Microsoft Teams CHANNEL delivery path in MicrosoftTeamsUtil.
+ *
+ * The bug these pin down: channels are DISCOVERED with tenant-wide Graph
+ * application permissions (which can see every team in the tenant) but are
+ * DELIVERED to over Bot Framework proactive messaging, which only accepts a
+ * post into a team the OneUptime app is actually installed in. So a channel
+ * could be picked in the dashboard, validate green, and then fail at send time
+ * with Microsoft's opaque "The bot is not part of the conversation roster."
+ *
+ * sendAdaptiveCardToChannel now:
+ * - refuses shared channels up front (bots cannot post in them at all),
+ * - preflights miscData.installedTeams and refuses before touching the Bot
+ *   Framework when the app was never installed into the target team — while
+ *   staying permissive for legacy workspaces whose install map is empty,
+ * - uses the serviceUrl captured on install (required for GCC/DoD) instead of
+ *   always assuming the commercial-cloud endpoint,
+ * - translates Microsoft's roster rejection into instructions an admin can act
+ *   on, and lets every other error through untouched.
+ *
+ * sendMessage now REPORTS destinations it cannot even resolve (an unknown
+ * channel name, a channel id whose lookup throws). Both used to be swallowed,
+ * so a typo'd or deleted channel reported a successful send.
+ */
+
+jest.mock("../../../../Server/EnvironmentConfig", () => {
+  return {
+    ...(jest.requireActual("../../../../Server/EnvironmentConfig") as Record<
+      string,
+      unknown
+    >),
+    MicrosoftTeamsAppClientId: "11111111-2222-3333-4444-555555555555",
+    MicrosoftTeamsAppClientSecret: "test-secret",
+    MicrosoftTeamsAppTenantId: "test-tenant",
+  };
+});
+
+/*
+ * Same botbuilder module factory as MicrosoftTeamsChats.test.ts — the repo-wide
+ * manual mock (Tests/__mocks__/botbuilder.js) does not expose TeamsInfo or
+ * MessageFactory.attachment, both of which these code paths use.
+ */
+jest.mock("botbuilder", () => {
+  return {
+    CloudAdapter: class CloudAdapter {},
+    ConfigurationBotFrameworkAuthentication: class ConfigurationBotFrameworkAuthentication {},
+    TeamsActivityHandler: class TeamsActivityHandler {},
+    TurnContext: class TurnContext {},
+    ActivityHandler: class ActivityHandler {},
+    MessageFactory: {
+      text: jest.fn(),
+      attachment: jest.fn((attachment: unknown) => {
+        return { type: "message", attachments: [attachment] };
+      }),
+    },
+    CardFactory: { heroCard: jest.fn() },
+    TeamsInfo: {
+      getMembers: jest.fn(),
+      getPagedMembers: jest.fn(),
+    },
+  };
+});
+
+import MicrosoftTeamsUtil from "../../../../Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams";
+import WorkspaceProjectAuthTokenService from "../../../../Server/Services/WorkspaceProjectAuthTokenService";
+import WorkspaceProjectAuthToken, {
+  MicrosoftTeamsInstalledTeam,
+  MicrosoftTeamsMiscData,
+} from "../../../../Models/DatabaseModels/WorkspaceProjectAuthToken";
+import WorkspaceType from "../../../../Types/Workspace/WorkspaceType";
+import ObjectID from "../../../../Types/ObjectID";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../../Types/JSON";
+import WorkspaceMessagePayload, {
+  WorkspacePayloadMarkdown,
+} from "../../../../Types/Workspace/WorkspaceMessagePayload";
+import {
+  WorkspaceChannel,
+  WorkspaceSendMessageResponse,
+  WorkspaceThread,
+} from "../../../../Server/Utils/Workspace/WorkspaceBase";
+import {
+  MessageFactory,
+  CardFactory,
+  TeamsInfo,
+  type ConversationReference,
+  type TurnContext,
+} from "botbuilder";
+
+const MOCK_APP_CLIENT_ID: string = "11111111-2222-3333-4444-555555555555";
+const TENANT_ID: string = "tenant-xyz";
+const TEAM_ID: string = "team-1";
+const CHANNEL_ID: string = "19:general@thread.tacv2";
+const DEFAULT_SERVICE_URL: string = "https://smba.trafficmanager.net/teams/";
+const GCC_SERVICE_URL: string = "https://smba.infra.gov.teams.microsoft.us/";
+const ROSTER_ERROR_TEXT: string =
+  "The bot is not part of the conversation roster.";
+
+const ADAPTIVE_CARD: JSONObject = {
+  type: "AdaptiveCard",
+  body: [],
+};
+
+type ProactiveCallback = (context: TurnContext) => Promise<void>;
+
+interface FakeBotAdapter {
+  capturedRefs: Array<ConversationReference>;
+  continueConversationAsync: jest.Mock;
+  getBotAdapterSpy: jest.SpyInstance;
+}
+
+function buildProjectAuthRow(data: {
+  id?: ObjectID | undefined;
+  workspaceProjectId?: string | undefined;
+  miscData?: MicrosoftTeamsMiscData | undefined;
+}): WorkspaceProjectAuthToken {
+  return {
+    id: data.id || ObjectID.generate(),
+    workspaceProjectId: data.workspaceProjectId,
+    miscData: data.miscData,
+  } as unknown as WorkspaceProjectAuthToken;
+}
+
+function baseMiscData(
+  overrides?: Partial<MicrosoftTeamsMiscData>,
+): MicrosoftTeamsMiscData {
+  return {
+    tenantId: TENANT_ID,
+    teamId: TEAM_ID,
+    teamName: "Engineering",
+    botId: "bot-1",
+    ...(overrides || {}),
+  } as MicrosoftTeamsMiscData;
+}
+
+function buildInstalledTeam(data: {
+  id: string;
+  name?: string | undefined;
+  serviceUrl?: string | undefined;
+}): MicrosoftTeamsInstalledTeam {
+  const installedTeam: MicrosoftTeamsInstalledTeam = {
+    id: data.id,
+    name: data.name || "Engineering",
+    addedAt: "2026-07-27T00:00:00.000Z",
+  };
+  if ("serviceUrl" in data) {
+    installedTeam.serviceUrl = data.serviceUrl;
+  }
+  return installedTeam;
+}
+
+function buildChannel(data?: {
+  id?: string | undefined;
+  name?: string | undefined;
+  membershipType?: string | undefined;
+  teamId?: string | undefined;
+}): WorkspaceChannel {
+  const channel: WorkspaceChannel = {
+    id: data?.id || CHANNEL_ID,
+    name: data?.name || "General",
+    workspaceType: WorkspaceType.MicrosoftTeams,
+    teamId: data?.teamId || TEAM_ID,
+  };
+  if (data && "membershipType" in data) {
+    channel.membershipType = data.membershipType;
+  }
+  return channel;
+}
+
+/*
+ * Mirrors installFakeBotAdapter from MicrosoftTeamsChats.test.ts, plus a way to
+ * make the adapter (or the proactive callback) reject so the roster-error
+ * translation can be exercised, and the raw jest.fn/spy so tests can assert the
+ * Bot Framework was never reached at all.
+ */
+function installFakeBotAdapter(options?: {
+  sendActivityResponse?: JSONObject | undefined;
+  adapterError?: unknown;
+  sendActivityError?: unknown;
+}): FakeBotAdapter {
+  const capturedRefs: Array<ConversationReference> = [];
+  const continueConversationAsync: jest.Mock = jest.fn(
+    async (
+      _appId: string,
+      ref: ConversationReference,
+      cb: ProactiveCallback,
+    ): Promise<void> => {
+      capturedRefs.push(ref);
+
+      if (options && "adapterError" in options) {
+        throw options.adapterError;
+      }
+
+      const fakeContext: TurnContext = {
+        sendActivity: async (): Promise<JSONObject | undefined> => {
+          if (options && "sendActivityError" in options) {
+            throw options.sendActivityError;
+          }
+          if (options && "sendActivityResponse" in options) {
+            return options.sendActivityResponse;
+          }
+          return { id: "msg-123" };
+        },
+      } as unknown as TurnContext;
+
+      await cb(fakeContext);
+    },
+  );
+
+  const fakeAdapter: unknown = {
+    continueConversationAsync: continueConversationAsync,
+  };
+
+  const getBotAdapterSpy: jest.SpyInstance = jest
+    .spyOn(MicrosoftTeamsUtil as any, "getBotAdapter")
+    .mockReturnValue(fakeAdapter);
+
+  return {
+    capturedRefs: capturedRefs,
+    continueConversationAsync: continueConversationAsync,
+    getBotAdapterSpy: getBotAdapterSpy,
+  };
+}
+
+function mockProjectAuth(data?: {
+  installedTeams?: Record<string, MicrosoftTeamsInstalledTeam> | undefined;
+  miscData?: MicrosoftTeamsMiscData | null | undefined;
+  workspaceProjectId?: string | undefined;
+}): jest.SpyInstance {
+  let miscData: MicrosoftTeamsMiscData | undefined = undefined;
+
+  if (data && "miscData" in data) {
+    miscData = data.miscData === null ? undefined : data.miscData;
+  } else if (data && data.installedTeams) {
+    miscData = baseMiscData({ installedTeams: data.installedTeams });
+  } else {
+    miscData = baseMiscData();
+  }
+
+  return jest
+    .spyOn(WorkspaceProjectAuthTokenService, "getProjectAuth")
+    .mockResolvedValue(
+      buildProjectAuthRow({
+        workspaceProjectId:
+          data && "workspaceProjectId" in data
+            ? data.workspaceProjectId
+            : TENANT_ID,
+        miscData: miscData,
+      }),
+    );
+}
+
+function sendCardToChannel(data?: {
+  workspaceChannel?: WorkspaceChannel | undefined;
+  teamId?: string | undefined;
+  projectId?: ObjectID | undefined;
+}): Promise<WorkspaceThread> {
+  return MicrosoftTeamsUtil.sendAdaptiveCardToChannel({
+    authToken: "auth-token",
+    teamId: data?.teamId || TEAM_ID,
+    workspaceChannel: data?.workspaceChannel || buildChannel(),
+    adaptiveCard: ADAPTIVE_CARD,
+    projectId: data?.projectId || ObjectID.generate(),
+  });
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+/*
+ * The botbuilder module mock's jest.fn()s are shared across tests — jest.spyOn
+ * on an existing mock returns the same function, so call history and
+ * mockResolvedValueOnce queues leak between tests unless reset here.
+ */
+beforeEach(() => {
+  (MessageFactory.text as jest.Mock).mockReset();
+  (MessageFactory.attachment as jest.Mock).mockReset();
+  (MessageFactory.attachment as jest.Mock).mockImplementation(
+    (attachment: unknown) => {
+      return { type: "message", attachments: [attachment] };
+    },
+  );
+  (CardFactory.heroCard as jest.Mock).mockReset();
+  (TeamsInfo.getMembers as jest.Mock).mockReset();
+  (TeamsInfo.getPagedMembers as jest.Mock).mockReset();
+});
+
+describe("MicrosoftTeamsUtil.isBotNotInConversationRosterError", () => {
+  test("matches Microsoft's exact roster rejection on an Error object", () => {
+    expect(
+      MicrosoftTeamsUtil.isBotNotInConversationRosterError(
+        new Error(ROSTER_ERROR_TEXT),
+      ),
+    ).toBe(true);
+  });
+
+  test("matches the shorter 'bot is not part of the conversation' phrasing", () => {
+    expect(
+      MicrosoftTeamsUtil.isBotNotInConversationRosterError(
+        new Error("The bot is not part of the conversation."),
+      ),
+    ).toBe(true);
+  });
+
+  test("matches a plain string error", () => {
+    expect(
+      MicrosoftTeamsUtil.isBotNotInConversationRosterError(
+        "The bot is not part of the conversation roster",
+      ),
+    ).toBe(true);
+  });
+
+  test("is case-insensitive", () => {
+    expect(
+      MicrosoftTeamsUtil.isBotNotInConversationRosterError(
+        new Error("THE BOT IS NOT PART OF THE CONVERSATION ROSTER"),
+      ),
+    ).toBe(true);
+    expect(
+      MicrosoftTeamsUtil.isBotNotInConversationRosterError(
+        new Error("Not Part Of The Conversation Roster"),
+      ),
+    ).toBe(true);
+  });
+
+  test("matches when the fragment is buried inside a larger Bot Framework payload", () => {
+    const wrapped: Error = new Error(
+      'BotFrameworkAdapter.sendActivity(): 403 ERROR {"error":{"code":"BotNotInConversationRoster","message":"The bot is not part of the conversation roster."}}',
+    );
+    expect(MicrosoftTeamsUtil.isBotNotInConversationRosterError(wrapped)).toBe(
+      true,
+    );
+  });
+
+  test("returns false for an unrelated error", () => {
+    expect(
+      MicrosoftTeamsUtil.isBotNotInConversationRosterError(
+        new Error("Request timed out"),
+      ),
+    ).toBe(false);
+  });
+
+  test("returns false for a partially-similar message that is not the roster error", () => {
+    expect(
+      MicrosoftTeamsUtil.isBotNotInConversationRosterError(
+        new Error("The user is not part of the team"),
+      ),
+    ).toBe(false);
+  });
+
+  test("returns false for null and undefined", () => {
+    expect(MicrosoftTeamsUtil.isBotNotInConversationRosterError(null)).toBe(
+      false,
+    );
+    expect(
+      MicrosoftTeamsUtil.isBotNotInConversationRosterError(undefined),
+    ).toBe(false);
+  });
+
+  test("returns false for an empty message", () => {
+    expect(MicrosoftTeamsUtil.isBotNotInConversationRosterError("")).toBe(
+      false,
+    );
+    expect(
+      MicrosoftTeamsUtil.isBotNotInConversationRosterError(new Error("")),
+    ).toBe(false);
+  });
+
+  test("returns false for an object with no usable message", () => {
+    expect(
+      MicrosoftTeamsUtil.isBotNotInConversationRosterError({ code: 403 }),
+    ).toBe(false);
+  });
+});
+
+describe("MicrosoftTeamsUtil.getBotNotInTeamMessage", () => {
+  test("private channels are told to install into the channel itself", () => {
+    const message: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: "Ops War Room",
+      membershipType: "private",
+    });
+
+    expect(message).toContain('private channel "Ops War Room"');
+    expect(message).toContain("Manage channel > Apps");
+    expect(message).toContain(
+      "Installing OneUptime in the parent team does not cover private channels.",
+    );
+    expect(message).not.toContain("Manage team");
+  });
+
+  test("standard channels are told to install into the parent team", () => {
+    const message: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: "General",
+      membershipType: "standard",
+    });
+
+    expect(message).toContain('team that owns "General"');
+    expect(message).toContain("Manage team > Apps > More apps");
+    expect(message).not.toContain("Manage channel");
+  });
+
+  test("an undefined membershipType falls back to the parent-team instructions", () => {
+    const message: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: "General",
+    });
+
+    expect(message).toContain("Manage team > Apps > More apps");
+    expect(message).not.toContain("Manage channel");
+  });
+
+  test("only the exact string 'private' selects the private-channel instructions", () => {
+    /*
+     * Graph returns membershipType lowercase, so the comparison is exact —
+     * pin it so nobody "helpfully" loosens it without thinking about Graph.
+     */
+    const message: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: "General",
+      membershipType: "Private",
+    });
+
+    expect(message).toContain("Manage team > Apps > More apps");
+  });
+
+  test("the two branches produce genuinely different instructions", () => {
+    const privateMessage: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: "Same Name",
+      membershipType: "private",
+    });
+    const teamMessage: string = MicrosoftTeamsUtil.getBotNotInTeamMessage({
+      channelName: "Same Name",
+      membershipType: "standard",
+    });
+
+    expect(privateMessage).not.toBe(teamMessage);
+    expect(privateMessage).toContain("Same Name");
+    expect(teamMessage).toContain("Same Name");
+  });
+});
+
+describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - shared channel refusal", () => {
+  test("a shared channel is refused with a reason, before any Bot Framework call", async () => {
+    mockProjectAuth();
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await expect(
+      sendCardToChannel({
+        workspaceChannel: buildChannel({
+          name: "Partner Sync",
+          membershipType: "shared",
+        }),
+      }),
+    ).rejects.toThrow(
+      new BadDataException(
+        '"Partner Sync" is a shared channel, and Microsoft Teams does not allow bots to post in shared channels. Please pick a standard or private channel instead.',
+      ),
+    );
+
+    expect(adapter.getBotAdapterSpy).not.toHaveBeenCalled();
+    expect(adapter.continueConversationAsync).not.toHaveBeenCalled();
+  });
+
+  test("the shared refusal is a BadDataException", async () => {
+    mockProjectAuth();
+    installFakeBotAdapter();
+
+    await expect(
+      sendCardToChannel({
+        workspaceChannel: buildChannel({ membershipType: "shared" }),
+      }),
+    ).rejects.toBeInstanceOf(BadDataException);
+  });
+
+  test("the shared refusal wins over the install preflight so the real reason is reported", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        "some-other-team": buildInstalledTeam({ id: "some-other-team" }),
+      },
+    });
+    installFakeBotAdapter();
+
+    await expect(
+      sendCardToChannel({
+        workspaceChannel: buildChannel({
+          name: "Partner Sync",
+          membershipType: "shared",
+        }),
+      }),
+    ).rejects.toThrow(/shared channel/);
+  });
+
+  test("standard channels are NOT refused", async () => {
+    mockProjectAuth();
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel({
+      workspaceChannel: buildChannel({ membershipType: "standard" }),
+    });
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("private channels are NOT refused (they only need a channel-level install)", async () => {
+    mockProjectAuth();
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel({
+      workspaceChannel: buildChannel({ membershipType: "private" }),
+    });
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("an undefined membershipType is NOT refused", async () => {
+    mockProjectAuth();
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel({
+      workspaceChannel: buildChannel({ membershipType: undefined }),
+    });
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("the shared comparison is exact: 'Shared' is not treated as shared", async () => {
+    /*
+     * Graph only ever returns lowercase "shared". This pins the current
+     * behavior so a future casing change in Graph is noticed here rather than
+     * in a customer's incident channel.
+     */
+    mockProjectAuth();
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel({
+      workspaceChannel: buildChannel({ membershipType: "Shared" }),
+    });
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - install preflight", () => {
+  test("installedTeams undefined (legacy workspace) does NOT block the send", async () => {
+    mockProjectAuth({ miscData: baseMiscData() });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    const thread: WorkspaceThread = await sendCardToChannel();
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+    expect(thread.threadId).toBe("msg-123");
+  });
+
+  test("an EMPTY installedTeams map does NOT block the send", async () => {
+    mockProjectAuth({ installedTeams: {} });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel();
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("installedTeams containing ONLY a different team refuses before the Bot Framework call", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        "team-2": buildInstalledTeam({ id: "team-2", name: "Marketing" }),
+      },
+    });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await expect(
+      sendCardToChannel({
+        teamId: TEAM_ID,
+        workspaceChannel: buildChannel({ name: "General" }),
+      }),
+    ).rejects.toThrow(
+      new BadDataException(
+        MicrosoftTeamsUtil.getBotNotInTeamMessage({ channelName: "General" }),
+      ),
+    );
+
+    expect(adapter.getBotAdapterSpy).not.toHaveBeenCalled();
+    expect(adapter.continueConversationAsync).not.toHaveBeenCalled();
+  });
+
+  test("installedTeams containing this team proceeds to the send", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        [TEAM_ID]: buildInstalledTeam({ id: TEAM_ID }),
+      },
+    });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel();
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("several installed teams, one of which is the target, proceeds", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        "team-0": buildInstalledTeam({ id: "team-0" }),
+        [TEAM_ID]: buildInstalledTeam({ id: TEAM_ID }),
+        "team-2": buildInstalledTeam({ id: "team-2" }),
+      },
+    });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel();
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("several installed teams, none of which is the target, refuses", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        "team-0": buildInstalledTeam({ id: "team-0" }),
+        "team-2": buildInstalledTeam({ id: "team-2" }),
+      },
+    });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await expect(sendCardToChannel({ teamId: TEAM_ID })).rejects.toThrow(
+      /is not installed in the Microsoft Teams team/,
+    );
+    expect(adapter.continueConversationAsync).not.toHaveBeenCalled();
+  });
+
+  test("the team id lookup is exact — a differently-cased key does not count as installed", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        "TEAM-1": buildInstalledTeam({ id: "TEAM-1" }),
+      },
+    });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await expect(sendCardToChannel({ teamId: "team-1" })).rejects.toThrow(
+      /is not installed in the Microsoft Teams team/,
+    );
+    expect(adapter.continueConversationAsync).not.toHaveBeenCalled();
+  });
+
+  test("the preflight refusal for a PRIVATE channel gives the channel-install instructions", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        "team-2": buildInstalledTeam({ id: "team-2" }),
+      },
+    });
+    installFakeBotAdapter();
+
+    await expect(
+      sendCardToChannel({
+        workspaceChannel: buildChannel({
+          name: "Ops War Room",
+          membershipType: "private",
+        }),
+      }),
+    ).rejects.toThrow(
+      new BadDataException(
+        MicrosoftTeamsUtil.getBotNotInTeamMessage({
+          channelName: "Ops War Room",
+          membershipType: "private",
+        }),
+      ),
+    );
+  });
+
+  test("the preflight refusal is a BadDataException", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        "team-2": buildInstalledTeam({ id: "team-2" }),
+      },
+    });
+    installFakeBotAdapter();
+
+    await expect(sendCardToChannel()).rejects.toBeInstanceOf(BadDataException);
+  });
+
+  test("the preflight never runs when the integration is missing entirely", async () => {
+    jest
+      .spyOn(WorkspaceProjectAuthTokenService, "getProjectAuth")
+      .mockResolvedValue(null);
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await expect(sendCardToChannel()).rejects.toThrow(
+      new BadDataException(
+        "Microsoft Teams integration not found for this project",
+      ),
+    );
+    expect(adapter.continueConversationAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - conversation reference", () => {
+  test("happy path builds the channel conversation reference the Bot Framework expects", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        [TEAM_ID]: buildInstalledTeam({ id: TEAM_ID }),
+      },
+    });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+    const channel: WorkspaceChannel = buildChannel({
+      id: "19:ops@thread.tacv2",
+      name: "Ops",
+      membershipType: "standard",
+    });
+
+    const thread: WorkspaceThread = await sendCardToChannel({
+      workspaceChannel: channel,
+    });
+
+    expect(adapter.capturedRefs).toHaveLength(1);
+    const ref: ConversationReference = adapter.capturedRefs[0]!;
+    expect(ref.conversation.id).toBe("19:ops@thread.tacv2");
+    expect(ref.conversation.name).toBe("Ops");
+    expect(ref.conversation.isGroup).toBe(true);
+    expect(ref.conversation.conversationType).toBe("channel");
+    expect(ref.conversation.tenantId).toBe(TENANT_ID);
+    expect(ref.channelId).toBe("msteams");
+    expect(ref.bot.id).toBe(MOCK_APP_CLIENT_ID);
+    expect(thread).toEqual({
+      channel: channel,
+      threadId: "msg-123",
+    });
+  });
+
+  test("the adaptive card is sent as an adaptive card attachment", async () => {
+    mockProjectAuth();
+    installFakeBotAdapter();
+
+    await sendCardToChannel();
+
+    expect(MessageFactory.attachment as jest.Mock).toHaveBeenCalledWith({
+      contentType: "application/vnd.microsoft.card.adaptive",
+      content: ADAPTIVE_CARD,
+    });
+  });
+
+  test("serviceUrl comes from the installed team record when it was captured", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        [TEAM_ID]: buildInstalledTeam({
+          id: TEAM_ID,
+          serviceUrl: GCC_SERVICE_URL,
+        }),
+      },
+    });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel({ teamId: TEAM_ID });
+
+    expect(adapter.capturedRefs[0]!.serviceUrl).toBe(GCC_SERVICE_URL);
+  });
+
+  test("serviceUrl falls back to the commercial cloud endpoint when installedTeams is undefined", async () => {
+    mockProjectAuth({ miscData: baseMiscData() });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel();
+
+    expect(adapter.capturedRefs[0]!.serviceUrl).toBe(DEFAULT_SERVICE_URL);
+  });
+
+  test("serviceUrl falls back when the installed team record has no serviceUrl", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        [TEAM_ID]: buildInstalledTeam({ id: TEAM_ID, serviceUrl: undefined }),
+      },
+    });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel({ teamId: TEAM_ID });
+
+    expect(adapter.capturedRefs[0]!.serviceUrl).toBe(DEFAULT_SERVICE_URL);
+  });
+
+  test("another team's serviceUrl is never borrowed for this team", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        [TEAM_ID]: buildInstalledTeam({ id: TEAM_ID, serviceUrl: undefined }),
+        "team-2": buildInstalledTeam({
+          id: "team-2",
+          serviceUrl: GCC_SERVICE_URL,
+        }),
+      },
+    });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel({ teamId: TEAM_ID });
+
+    expect(adapter.capturedRefs[0]!.serviceUrl).toBe(DEFAULT_SERVICE_URL);
+  });
+
+  test("the serviceUrl of the requested team is used even when several teams are installed", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        "team-0": buildInstalledTeam({
+          id: "team-0",
+          serviceUrl: "https://smba.trafficmanager.net/apac/",
+        }),
+        "team-2": buildInstalledTeam({
+          id: "team-2",
+          serviceUrl: GCC_SERVICE_URL,
+        }),
+      },
+    });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel({ teamId: "team-2" });
+
+    expect(adapter.capturedRefs[0]!.serviceUrl).toBe(GCC_SERVICE_URL);
+  });
+
+  test("threadId is an empty string when sendActivity returns nothing", async () => {
+    mockProjectAuth();
+    installFakeBotAdapter({ sendActivityResponse: undefined });
+
+    const thread: WorkspaceThread = await sendCardToChannel();
+
+    expect(thread.threadId).toBe("");
+  });
+});
+
+describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - roster error translation", () => {
+  test("Microsoft's roster rejection is replaced with the parent-team install instructions", async () => {
+    mockProjectAuth();
+    installFakeBotAdapter({ adapterError: new Error(ROSTER_ERROR_TEXT) });
+
+    await expect(
+      sendCardToChannel({
+        workspaceChannel: buildChannel({
+          name: "General",
+          membershipType: "standard",
+        }),
+      }),
+    ).rejects.toThrow(
+      new BadDataException(
+        MicrosoftTeamsUtil.getBotNotInTeamMessage({
+          channelName: "General",
+          membershipType: "standard",
+        }),
+      ),
+    );
+  });
+
+  test("the raw Microsoft text never reaches the caller", async () => {
+    mockProjectAuth();
+    installFakeBotAdapter({ adapterError: new Error(ROSTER_ERROR_TEXT) });
+
+    let thrown: unknown = undefined;
+    try {
+      await sendCardToChannel();
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(BadDataException);
+    expect((thrown as Error).message).not.toContain("conversation roster");
+    expect((thrown as Error).message).toContain("Manage team > Apps");
+  });
+
+  test("a roster rejection on a private channel gets the channel-install instructions", async () => {
+    mockProjectAuth();
+    installFakeBotAdapter({ adapterError: new Error(ROSTER_ERROR_TEXT) });
+
+    await expect(
+      sendCardToChannel({
+        workspaceChannel: buildChannel({
+          name: "Ops War Room",
+          membershipType: "private",
+        }),
+      }),
+    ).rejects.toThrow(
+      new BadDataException(
+        MicrosoftTeamsUtil.getBotNotInTeamMessage({
+          channelName: "Ops War Room",
+          membershipType: "private",
+        }),
+      ),
+    );
+  });
+
+  test("a roster rejection raised inside the proactive callback is translated too", async () => {
+    mockProjectAuth();
+    installFakeBotAdapter({
+      sendActivityError: new Error(ROSTER_ERROR_TEXT),
+    });
+
+    await expect(sendCardToChannel()).rejects.toThrow(
+      /is not installed in the Microsoft Teams team/,
+    );
+  });
+
+  test("a roster rejection thrown as a plain string is translated too", async () => {
+    mockProjectAuth();
+    installFakeBotAdapter({
+      adapterError: "The bot is not part of the conversation roster.",
+    });
+
+    await expect(sendCardToChannel()).rejects.toThrow(
+      /is not installed in the Microsoft Teams team/,
+    );
+  });
+
+  test("unrelated adapter errors propagate untouched", async () => {
+    mockProjectAuth();
+    const networkError: Error = new Error("socket hang up");
+    installFakeBotAdapter({ adapterError: networkError });
+
+    await expect(sendCardToChannel()).rejects.toBe(networkError);
+  });
+
+  test("a 429 throttling error is not disguised as an install problem", async () => {
+    mockProjectAuth();
+    const throttled: Error = new Error("429 Too Many Requests");
+    installFakeBotAdapter({ adapterError: throttled });
+
+    let thrown: unknown = undefined;
+    try {
+      await sendCardToChannel();
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBe(throttled);
+    expect((thrown as Error).message).not.toContain("Manage team");
+  });
+});
+
+describe("MicrosoftTeamsUtil.sendMessage - unresolvable channel destinations are reported", () => {
+  function buildChannelPayload(data?: {
+    channelNames?: Array<string> | undefined;
+    channelIds?: Array<string> | undefined;
+    teamId?: string | undefined;
+  }): WorkspaceMessagePayload {
+    const block: WorkspacePayloadMarkdown = {
+      _type: "WorkspacePayloadMarkdown",
+      text: "Incident created",
+    };
+    return {
+      _type: "WorkspaceMessagePayload",
+      channelNames: data?.channelNames || [],
+      channelIds: data?.channelIds || [],
+      messageBlocks: [block],
+      workspaceType: WorkspaceType.MicrosoftTeams,
+      teamId: data?.teamId || TEAM_ID,
+    };
+  }
+
+  function callSendMessage(
+    payload: WorkspaceMessagePayload,
+  ): Promise<WorkspaceSendMessageResponse> {
+    return MicrosoftTeamsUtil.sendMessage({
+      workspaceMessagePayload: payload,
+      authToken: "auth-token",
+      userId: "user-1",
+      projectId: ObjectID.generate(),
+    });
+  }
+
+  function mockSendCardToChannel(): jest.SpyInstance {
+    return jest
+      .spyOn(MicrosoftTeamsUtil, "sendAdaptiveCardToChannel")
+      .mockImplementation(
+        async (args: {
+          workspaceChannel: WorkspaceChannel;
+        }): Promise<WorkspaceThread> => {
+          return {
+            channel: args.workspaceChannel,
+            threadId: `thread-${args.workspaceChannel.id}`,
+          };
+        },
+      );
+  }
+
+  test("a channelName that does not resolve is reported as an error, not a silent success", async () => {
+    jest
+      .spyOn(MicrosoftTeamsUtil, "getWorkspaceChannelByName")
+      .mockResolvedValue(null);
+    const sendSpy: jest.SpyInstance = mockSendCardToChannel();
+
+    const response: WorkspaceSendMessageResponse = await callSendMessage(
+      buildChannelPayload({ channelNames: ["deleted-channel"] }),
+    );
+
+    expect(response.threads).toEqual([]);
+    expect(response.errors).toEqual([
+      {
+        channel: {
+          id: "",
+          name: "deleted-channel",
+          workspaceType: WorkspaceType.MicrosoftTeams,
+          teamId: TEAM_ID,
+        },
+        error:
+          'Channel "deleted-channel" was not found in this Microsoft Teams team. It may have been renamed or deleted.',
+      },
+    ]);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(response.workspaceType).toBe(WorkspaceType.MicrosoftTeams);
+  });
+
+  test("a channelName that resolves still sends and records no error", async () => {
+    const channel: WorkspaceChannel = buildChannel({ name: "general" });
+    jest
+      .spyOn(MicrosoftTeamsUtil, "getWorkspaceChannelByName")
+      .mockResolvedValue(channel);
+    const sendSpy: jest.SpyInstance = mockSendCardToChannel();
+
+    const response: WorkspaceSendMessageResponse = await callSendMessage(
+      buildChannelPayload({ channelNames: ["general"] }),
+    );
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(response.errors).toEqual([]);
+    expect(response.threads).toHaveLength(1);
+    expect(response.threads[0]?.channel.id).toBe(CHANNEL_ID);
+  });
+
+  test("a missing channel name does not stop the resolvable ones from sending", async () => {
+    const channel: WorkspaceChannel = buildChannel({ name: "general" });
+    jest
+      .spyOn(MicrosoftTeamsUtil, "getWorkspaceChannelByName")
+      .mockImplementation(
+        async (args: {
+          channelName: string;
+        }): Promise<WorkspaceChannel | null> => {
+          return args.channelName === "general" ? channel : null;
+        },
+      );
+    mockSendCardToChannel();
+
+    const response: WorkspaceSendMessageResponse = await callSendMessage(
+      buildChannelPayload({ channelNames: ["typoed", "general"] }),
+    );
+
+    expect(response.threads).toHaveLength(1);
+    expect(response.errors).toHaveLength(1);
+    expect(response.errors?.[0]?.channel.name).toBe("typoed");
+  });
+
+  test("every missing channel name gets its own error entry", async () => {
+    jest
+      .spyOn(MicrosoftTeamsUtil, "getWorkspaceChannelByName")
+      .mockResolvedValue(null);
+    mockSendCardToChannel();
+
+    const response: WorkspaceSendMessageResponse = await callSendMessage(
+      buildChannelPayload({ channelNames: ["gone-1", "gone-2"] }),
+    );
+
+    expect(response.threads).toEqual([]);
+    expect(response.errors).toHaveLength(2);
+    expect(response.errors?.[0]?.channel.name).toBe("gone-1");
+    expect(response.errors?.[1]?.channel.name).toBe("gone-2");
+  });
+
+  test("a channelId whose lookup throws is reported as an error instead of being swallowed", async () => {
+    jest
+      .spyOn(MicrosoftTeamsUtil, "getWorkspaceChannelFromChannelId")
+      .mockRejectedValue(new Error("Channel not found in team") as never);
+    const sendSpy: jest.SpyInstance = mockSendCardToChannel();
+
+    const response: WorkspaceSendMessageResponse = await callSendMessage(
+      buildChannelPayload({ channelIds: ["19:missing@thread.tacv2"] }),
+    );
+
+    expect(response.threads).toEqual([]);
+    expect(response.errors).toEqual([
+      {
+        channel: {
+          id: "19:missing@thread.tacv2",
+          name: "19:missing@thread.tacv2",
+          workspaceType: WorkspaceType.MicrosoftTeams,
+          teamId: TEAM_ID,
+        },
+        error: "Channel not found in team",
+      },
+    ]);
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+
+  test("a non-Error thrown by the channelId lookup is stringified into the error entry", async () => {
+    jest
+      .spyOn(MicrosoftTeamsUtil, "getWorkspaceChannelFromChannelId")
+      .mockRejectedValue("graph exploded" as never);
+    mockSendCardToChannel();
+
+    const response: WorkspaceSendMessageResponse = await callSendMessage(
+      buildChannelPayload({ channelIds: ["19:missing@thread.tacv2"] }),
+    );
+
+    expect(response.errors).toHaveLength(1);
+    expect(response.errors?.[0]?.error).toBe("graph exploded");
+  });
+
+  test("one failing channelId does not stop the other channelIds from sending", async () => {
+    const goodChannel: WorkspaceChannel = buildChannel({
+      id: "19:good@thread.tacv2",
+      name: "Good",
+    });
+    jest
+      .spyOn(MicrosoftTeamsUtil, "getWorkspaceChannelFromChannelId")
+      .mockImplementation(
+        async (args: { channelId: string }): Promise<WorkspaceChannel> => {
+          if (args.channelId === "19:bad@thread.tacv2") {
+            throw new Error("lookup failed");
+          }
+          return goodChannel;
+        },
+      );
+    mockSendCardToChannel();
+
+    const response: WorkspaceSendMessageResponse = await callSendMessage(
+      buildChannelPayload({
+        channelIds: ["19:bad@thread.tacv2", "19:good@thread.tacv2"],
+      }),
+    );
+
+    expect(response.threads).toHaveLength(1);
+    expect(response.threads[0]?.channel.id).toBe("19:good@thread.tacv2");
+    expect(response.errors).toHaveLength(1);
+    expect(response.errors?.[0]?.channel.id).toBe("19:bad@thread.tacv2");
+  });
+
+  test("no destinations at all produces an empty, error-free response", async () => {
+    const sendSpy: jest.SpyInstance = mockSendCardToChannel();
+
+    const response: WorkspaceSendMessageResponse = await callSendMessage(
+      buildChannelPayload(),
+    );
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(response.threads).toEqual([]);
+    expect(response.errors).toEqual([]);
+  });
+
+  test("the actionable install message from a failed send surfaces in response.errors", async () => {
+    const channel: WorkspaceChannel = buildChannel({
+      name: "General",
+      membershipType: "standard",
+    });
+    jest
+      .spyOn(MicrosoftTeamsUtil, "getWorkspaceChannelFromChannelId")
+      .mockResolvedValue(channel);
+    mockProjectAuth({
+      installedTeams: {
+        "team-2": buildInstalledTeam({ id: "team-2" }),
+      },
+    });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    const response: WorkspaceSendMessageResponse = await callSendMessage(
+      buildChannelPayload({ channelIds: [CHANNEL_ID] }),
+    );
+
+    expect(adapter.continueConversationAsync).not.toHaveBeenCalled();
+    expect(response.threads).toEqual([]);
+    expect(response.errors).toHaveLength(1);
+    expect(response.errors?.[0]?.channel).toEqual(channel);
+    expect(response.errors?.[0]?.error).toBe(
+      MicrosoftTeamsUtil.getBotNotInTeamMessage({
+        channelName: "General",
+        membershipType: "standard",
+      }),
+    );
+  });
+});

--- a/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsChannelsList.test.ts
+++ b/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsChannelsList.test.ts
@@ -136,6 +136,8 @@ describe("MicrosoftTeamsUtil.getAllWorkspaceChannels", () => {
       id: "19:general@thread.tacv2",
       name: "General",
       workspaceType: WorkspaceType.MicrosoftTeams,
+      teamId: TEAM_ID,
+      membershipType: undefined,
     });
   });
 

--- a/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsTeamInstalls.test.ts
+++ b/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsTeamInstalls.test.ts
@@ -1,0 +1,1605 @@
+import { describe, expect, test, afterEach, beforeEach } from "@jest/globals";
+
+/*
+ * Extensive tests for Microsoft Teams TEAM INSTALL capture in
+ * MicrosoftTeamsUtil.
+ *
+ * The bug being pinned: Microsoft tells us the OneUptime app was installed
+ * into a TEAM via conversationUpdate (bot in membersAdded) and
+ * installationUpdate (action add / add-upgrade). Both signals used to be
+ * routed only into captureChatFromBotActivity, which drops everything that is
+ * not a personal or groupChat conversation — so the team install was thrown
+ * away. Two things broke because of that:
+ *
+ * - we could not tell whether a proactive channel post would be accepted
+ *   (Graph can LIST every team in the tenant, but the Bot Framework only
+ *   accepts a post into a team the app is actually a roster member of), and
+ * - we lost the per-install serviceUrl, which GCC/DoD tenants need because
+ *   their Bot Framework endpoint is not the global one.
+ *
+ * Covered here:
+ *
+ * - captureTeamFromBotActivity / removeTeamFromBotActivity: the activity ->
+ *   MicrosoftTeamsInstalledTeam translation, including which fields are
+ *   required, the serviceUrl precedence, and the swallow-don't-throw contract.
+ * - saveTeamToProjectAuthTokens / removeTeamFromProjectAuthTokens: installs
+ *   are stored in miscData.installedTeams on EVERY WorkspaceProjectAuthToken
+ *   row whose workspaceProjectId equals the Teams tenant id.
+ * - getInstalledTeamsForProject: the read side of the install store.
+ * - handleConversationUpdateActivity / handleInstallationUpdateActivity /
+ *   handleBotMessageActivity: the wiring that must call BOTH the chat capture
+ *   and the team capture, which is exactly what was missing before.
+ */
+
+jest.mock("../../../../Server/EnvironmentConfig", () => {
+  return {
+    ...(jest.requireActual("../../../../Server/EnvironmentConfig") as Record<
+      string,
+      unknown
+    >),
+    MicrosoftTeamsAppClientId: "11111111-2222-3333-4444-555555555555",
+    MicrosoftTeamsAppClientSecret: "test-secret",
+    MicrosoftTeamsAppTenantId: "test-tenant",
+  };
+});
+
+/*
+ * Same botbuilder module factory as MicrosoftTeamsChats.test.ts — the
+ * repo-wide manual mock (Tests/__mocks__/botbuilder.js) does not expose
+ * TeamsInfo or MessageFactory.attachment, both of which MicrosoftTeams.ts
+ * touches at import time.
+ */
+jest.mock("botbuilder", () => {
+  return {
+    CloudAdapter: class CloudAdapter {},
+    ConfigurationBotFrameworkAuthentication: class ConfigurationBotFrameworkAuthentication {},
+    TeamsActivityHandler: class TeamsActivityHandler {},
+    TurnContext: class TurnContext {},
+    ActivityHandler: class ActivityHandler {},
+    MessageFactory: {
+      text: jest.fn(),
+      attachment: jest.fn((attachment: unknown) => {
+        return { type: "message", attachments: [attachment] };
+      }),
+    },
+    CardFactory: { heroCard: jest.fn() },
+    TeamsInfo: {
+      getMembers: jest.fn(),
+      getPagedMembers: jest.fn(),
+    },
+  };
+});
+
+import MicrosoftTeamsUtil, {
+  MicrosoftTeamsTenantResolution,
+} from "../../../../Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams";
+import WorkspaceProjectAuthTokenService from "../../../../Server/Services/WorkspaceProjectAuthTokenService";
+import WorkspaceProjectAuthToken, {
+  MicrosoftTeamsChat,
+  MicrosoftTeamsInstalledTeam,
+  MicrosoftTeamsMiscData,
+  MicrosoftTeamsTeam,
+} from "../../../../Models/DatabaseModels/WorkspaceProjectAuthToken";
+import WorkspaceType from "../../../../Types/Workspace/WorkspaceType";
+import ObjectID from "../../../../Types/ObjectID";
+import LIMIT_MAX from "../../../../Types/Database/LimitMax";
+import { JSONObject } from "../../../../Types/JSON";
+import { TeamsInfo, type TurnContext } from "botbuilder";
+
+const BOT_RECIPIENT_ID: string = "bot-recipient-id";
+const TURN_CONTEXT_SERVICE_URL: string =
+  "https://smba.trafficmanager.net/emea/";
+const ACTIVITY_SERVICE_URL: string = "https://smba.trafficmanager.net/amer/";
+const GCC_SERVICE_URL: string =
+  "https://smba.infra.gov.teams.microsoft.us/gov/";
+const TEAM_ID: string = "19:team-aaa@thread.tacv2";
+const TENANT_ID: string = "tenant-1";
+const ISO_TIMESTAMP: RegExp = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+interface UpdateOneByIdArgs {
+  id: ObjectID;
+  data: { miscData: MicrosoftTeamsMiscData };
+}
+
+function buildTurnContext(data?: {
+  serviceUrl?: string | undefined;
+  recipientId?: string | undefined;
+}): TurnContext {
+  return {
+    activity: {
+      recipient: { id: data?.recipientId || BOT_RECIPIENT_ID },
+      serviceUrl:
+        data && "serviceUrl" in data
+          ? data.serviceUrl
+          : TURN_CONTEXT_SERVICE_URL,
+      conversation: { id: "ctx-conversation-id" },
+    },
+    sendActivity: async (): Promise<undefined> => {
+      return undefined;
+    },
+  } as unknown as TurnContext;
+}
+
+function buildProjectAuthRow(data: {
+  id?: ObjectID | undefined;
+  workspaceProjectId?: string | undefined;
+  miscData?: MicrosoftTeamsMiscData | undefined;
+}): WorkspaceProjectAuthToken {
+  return {
+    id: data.id || ObjectID.generate(),
+    workspaceProjectId: data.workspaceProjectId,
+    miscData: data.miscData,
+  } as unknown as WorkspaceProjectAuthToken;
+}
+
+function baseMiscData(
+  overrides?: Partial<MicrosoftTeamsMiscData>,
+): MicrosoftTeamsMiscData {
+  return {
+    tenantId: "tenant-xyz",
+    teamId: "team-1",
+    teamName: "Engineering",
+    botId: "bot-1",
+    ...(overrides || {}),
+  } as MicrosoftTeamsMiscData;
+}
+
+function buildInstalledTeam(data?: {
+  id?: string | undefined;
+  name?: string | undefined;
+  serviceUrl?: string | undefined;
+}): MicrosoftTeamsInstalledTeam {
+  return {
+    id: data?.id || TEAM_ID,
+    name: data?.name || "Engineering",
+    serviceUrl:
+      data && "serviceUrl" in data ? data.serviceUrl : TURN_CONTEXT_SERVICE_URL,
+    addedAt: "2026-07-27T00:00:00.000Z",
+  };
+}
+
+function buildChat(data?: {
+  id?: string | undefined;
+  name?: string | undefined;
+}): MicrosoftTeamsChat {
+  return {
+    id: data?.id || "19:groupchat@thread.v2",
+    name: data?.name || "Alice, Bob",
+    chatType: "groupChat",
+    serviceUrl: TURN_CONTEXT_SERVICE_URL,
+    addedAt: "2026-07-27T00:00:00.000Z",
+  };
+}
+
+/*
+ * A team-scoped bot activity as Teams delivers it: the team id and tenant id
+ * live under channelData, never on the conversation object.
+ */
+function teamActivity(overrides?: JSONObject): JSONObject {
+  return {
+    channelData: {
+      team: { id: TEAM_ID, name: "Engineering" },
+      tenant: { id: TENANT_ID },
+      channel: { id: "19:general@thread.tacv2" },
+    },
+    conversation: {
+      conversationType: "channel",
+      id: "19:general@thread.tacv2",
+    },
+    serviceUrl: ACTIVITY_SERVICE_URL,
+    ...(overrides || {}),
+  };
+}
+
+function getUpdateArgs(
+  updateSpy: jest.SpyInstance,
+  callIndex: number,
+): UpdateOneByIdArgs {
+  return updateSpy.mock.calls[callIndex]?.[0] as unknown as UpdateOneByIdArgs;
+}
+
+/*
+ * Fan-out assertions must be anchored to the row they are about. Looking the
+ * call up by id (rather than by position) is what makes "row two got row one's
+ * miscData" a failure instead of a coincidence.
+ */
+function getUpdateArgsForId(
+  updateSpy: jest.SpyInstance,
+  id: ObjectID,
+): UpdateOneByIdArgs {
+  const calls: Array<Array<unknown>> = updateSpy.mock.calls as Array<
+    Array<unknown>
+  >;
+
+  for (const call of calls) {
+    const args: UpdateOneByIdArgs = call[0] as UpdateOneByIdArgs;
+
+    if (String(args.id) === id.toString()) {
+      return args;
+    }
+  }
+
+  throw new Error(`No updateOneById call was made for id ${id.toString()}`);
+}
+
+interface DistinctRowFixture {
+  id: ObjectID;
+  tenantId: string;
+  teamName: string;
+  botId: string;
+  existingTeam: MicrosoftTeamsInstalledTeam;
+  chat: MicrosoftTeamsChat;
+}
+
+/*
+ * Every fan-out row must be DISTINGUISHABLE from its siblings. If all rows are
+ * built from the same baseMiscData(), a bug that merges once and writes the
+ * same object to every row is invisible: each row's assertions pass against
+ * every other row's data. Each fixture therefore owns its scalars, its
+ * pre-existing installedTeams entry and its availableChats entry.
+ */
+function buildDistinctRowFixture(label: string): DistinctRowFixture {
+  return {
+    id: ObjectID.generate(),
+    tenantId: `tenant-${label}`,
+    teamName: `${label} team name`,
+    botId: `bot-${label}`,
+    existingTeam: buildInstalledTeam({
+      id: `19:${label}-existing@thread.tacv2`,
+      name: `${label} existing team`,
+      serviceUrl: `https://smba.trafficmanager.net/${label}/`,
+    }),
+    chat: buildChat({
+      id: `19:${label}-chat@thread.v2`,
+      name: `${label} chat`,
+    }),
+  };
+}
+
+function buildRowFromFixture(data: {
+  fixture: DistinctRowFixture;
+  installedTeams?: Record<string, MicrosoftTeamsInstalledTeam> | undefined;
+}): WorkspaceProjectAuthToken {
+  const overrides: Partial<MicrosoftTeamsMiscData> = {
+    tenantId: data.fixture.tenantId,
+    teamName: data.fixture.teamName,
+    botId: data.fixture.botId,
+    availableChats: { [data.fixture.chat.id]: data.fixture.chat },
+  };
+
+  if (data.installedTeams) {
+    overrides.installedTeams = data.installedTeams;
+  }
+
+  return buildProjectAuthRow({
+    id: data.fixture.id,
+    miscData: baseMiscData(overrides),
+  });
+}
+
+function getUpdatedIds(updateSpy: jest.SpyInstance): Array<string> {
+  const calls: Array<Array<unknown>> = updateSpy.mock.calls as Array<
+    Array<unknown>
+  >;
+  const ids: Array<string> = [];
+
+  for (const call of calls) {
+    ids.push(String((call[0] as UpdateOneByIdArgs).id));
+  }
+
+  return ids;
+}
+
+function buildRowsFromFixtures(data: {
+  fixtures: Array<DistinctRowFixture>;
+  sharedTeam?: MicrosoftTeamsInstalledTeam | undefined;
+}): Array<WorkspaceProjectAuthToken> {
+  const rows: Array<WorkspaceProjectAuthToken> = [];
+
+  for (const fixture of data.fixtures) {
+    const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> = {
+      [fixture.existingTeam.id]: fixture.existingTeam,
+    };
+
+    if (data.sharedTeam) {
+      installedTeams[data.sharedTeam.id] = data.sharedTeam;
+    }
+
+    rows.push(
+      buildRowFromFixture({
+        fixture: fixture,
+        installedTeams: installedTeams,
+      }),
+    );
+  }
+
+  return rows;
+}
+
+function fixtureIds(fixtures: Array<DistinctRowFixture>): Array<string> {
+  return fixtures.map((fixture: DistinctRowFixture): string => {
+    return fixture.id.toString();
+  });
+}
+
+function mockFindBy(rows: Array<WorkspaceProjectAuthToken>): jest.SpyInstance {
+  return jest
+    .spyOn(WorkspaceProjectAuthTokenService, "findBy")
+    .mockResolvedValue(rows);
+}
+
+function mockUpdateOneById(): jest.SpyInstance {
+  return jest
+    .spyOn(WorkspaceProjectAuthTokenService, "updateOneById")
+    .mockResolvedValue(undefined as never);
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+/*
+ * The botbuilder module mock's jest.fn()s are shared by every test in this
+ * file — jest.spyOn on an existing mock returns the same function, so call
+ * history and mockResolvedValueOnce queues leak between tests unless reset.
+ */
+beforeEach(() => {
+  (TeamsInfo.getPagedMembers as jest.Mock).mockReset();
+  (TeamsInfo.getMembers as jest.Mock).mockReset();
+});
+
+describe("MicrosoftTeamsUtil.captureTeamFromBotActivity", () => {
+  test("builds an installed team record from channelData and saves it under the tenant", async () => {
+    const saveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "saveTeamToProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamActivity(),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    const saveArgs: { tenantId: string; team: MicrosoftTeamsInstalledTeam } =
+      saveSpy.mock.calls[0]?.[0] as {
+        tenantId: string;
+        team: MicrosoftTeamsInstalledTeam;
+      };
+    expect(saveArgs.tenantId).toBe(TENANT_ID);
+    expect(saveArgs.team.id).toBe(TEAM_ID);
+    expect(saveArgs.team.name).toBe("Engineering");
+    expect(saveArgs.team.serviceUrl).toBe(ACTIVITY_SERVICE_URL);
+  });
+
+  test("addedAt is an ISO-8601 string", async () => {
+    const saveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "saveTeamToProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamActivity(),
+      turnContext: buildTurnContext(),
+    });
+
+    const team: MicrosoftTeamsInstalledTeam = (
+      saveSpy.mock.calls[0]?.[0] as { team: MicrosoftTeamsInstalledTeam }
+    ).team;
+    expect(typeof team.addedAt).toBe("string");
+    expect(team.addedAt).toMatch(ISO_TIMESTAMP);
+    expect(Number.isNaN(new Date(team.addedAt as string).getTime())).toBe(
+      false,
+    );
+  });
+
+  test("serviceUrl prefers the activity over the turn context", async () => {
+    const saveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "saveTeamToProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamActivity({ serviceUrl: GCC_SERVICE_URL }),
+      turnContext: buildTurnContext({ serviceUrl: TURN_CONTEXT_SERVICE_URL }),
+    });
+
+    const team: MicrosoftTeamsInstalledTeam = (
+      saveSpy.mock.calls[0]?.[0] as { team: MicrosoftTeamsInstalledTeam }
+    ).team;
+    expect(team.serviceUrl).toBe(GCC_SERVICE_URL);
+  });
+
+  test("serviceUrl falls back to the turn context when the activity has none", async () => {
+    const saveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "saveTeamToProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+    const activity: JSONObject = teamActivity();
+    delete activity["serviceUrl"];
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: activity,
+      turnContext: buildTurnContext({ serviceUrl: GCC_SERVICE_URL }),
+    });
+
+    const team: MicrosoftTeamsInstalledTeam = (
+      saveSpy.mock.calls[0]?.[0] as { team: MicrosoftTeamsInstalledTeam }
+    ).team;
+    expect(team.serviceUrl).toBe(GCC_SERVICE_URL);
+  });
+
+  test("serviceUrl is undefined when neither the activity nor the turn context has one", async () => {
+    const saveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "saveTeamToProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+    const activity: JSONObject = teamActivity();
+    delete activity["serviceUrl"];
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: activity,
+      turnContext: buildTurnContext({ serviceUrl: undefined }),
+    });
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    const team: MicrosoftTeamsInstalledTeam = (
+      saveSpy.mock.calls[0]?.[0] as { team: MicrosoftTeamsInstalledTeam }
+    ).team;
+    expect(team.serviceUrl).toBeUndefined();
+  });
+
+  test("team name absent leaves name undefined but still records the install", async () => {
+    const saveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "saveTeamToProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamActivity({
+        channelData: { team: { id: TEAM_ID }, tenant: { id: TENANT_ID } },
+      }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    const team: MicrosoftTeamsInstalledTeam = (
+      saveSpy.mock.calls[0]?.[0] as { team: MicrosoftTeamsInstalledTeam }
+    ).team;
+    expect(team.id).toBe(TEAM_ID);
+    expect(team.name).toBeUndefined();
+  });
+
+  test("an empty-string team name is normalized to undefined", async () => {
+    const saveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "saveTeamToProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamActivity({
+        channelData: {
+          team: { id: TEAM_ID, name: "" },
+          tenant: { id: TENANT_ID },
+        },
+      }),
+      turnContext: buildTurnContext(),
+    });
+
+    const team: MicrosoftTeamsInstalledTeam = (
+      saveSpy.mock.calls[0]?.[0] as { team: MicrosoftTeamsInstalledTeam }
+    ).team;
+    expect(team.name).toBeUndefined();
+  });
+
+  test("missing team id short-circuits before ANY database read", async () => {
+    const findBySpy: jest.SpyInstance = mockFindBy([]);
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamActivity({
+        channelData: { tenant: { id: TENANT_ID } },
+      }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(findBySpy).not.toHaveBeenCalled();
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  test("a personal chat activity (no channelData at all) is ignored without throwing", async () => {
+    const findBySpy: jest.SpyInstance = mockFindBy([]);
+
+    await expect(
+      MicrosoftTeamsUtil.captureTeamFromBotActivity({
+        activity: {
+          conversation: { conversationType: "personal", id: "a:1personal" },
+          serviceUrl: ACTIVITY_SERVICE_URL,
+        },
+        turnContext: buildTurnContext(),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(findBySpy).not.toHaveBeenCalled();
+  });
+
+  test("an empty-string team id is treated as missing", async () => {
+    const findBySpy: jest.SpyInstance = mockFindBy([]);
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamActivity({
+        channelData: { team: { id: "" }, tenant: { id: TENANT_ID } },
+      }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(findBySpy).not.toHaveBeenCalled();
+  });
+
+  test("missing tenant id records nothing (a team install we cannot attribute is useless)", async () => {
+    const saveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "saveTeamToProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamActivity({
+        channelData: { team: { id: TEAM_ID, name: "Engineering" } },
+      }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  test("an empty-string tenant id records nothing", async () => {
+    const saveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "saveTeamToProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamActivity({
+        channelData: { team: { id: TEAM_ID }, tenant: { id: "" } },
+      }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  test("a throwing save is swallowed, not propagated (a failed capture must never 500 the bot endpoint)", async () => {
+    jest
+      .spyOn(MicrosoftTeamsUtil, "saveTeamToProjectAuthTokens")
+      .mockRejectedValue(new Error("database is down") as never);
+
+    await expect(
+      MicrosoftTeamsUtil.captureTeamFromBotActivity({
+        activity: teamActivity(),
+        turnContext: buildTurnContext(),
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("MicrosoftTeamsUtil.removeTeamFromBotActivity", () => {
+  test("removes the team install for the tenant on the activity", async () => {
+    const removeSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "removeTeamFromProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+
+    await MicrosoftTeamsUtil.removeTeamFromBotActivity({
+      activity: teamActivity(),
+    });
+
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+    expect(removeSpy).toHaveBeenCalledWith({
+      tenantId: TENANT_ID,
+      teamId: TEAM_ID,
+    });
+  });
+
+  test("missing team id removes nothing", async () => {
+    const removeSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "removeTeamFromProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+
+    await MicrosoftTeamsUtil.removeTeamFromBotActivity({
+      activity: teamActivity({ channelData: { tenant: { id: TENANT_ID } } }),
+    });
+
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
+
+  test("missing tenant id removes nothing", async () => {
+    const removeSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "removeTeamFromProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+
+    await MicrosoftTeamsUtil.removeTeamFromBotActivity({
+      activity: teamActivity({ channelData: { team: { id: TEAM_ID } } }),
+    });
+
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
+
+  test("an activity with no channelData removes nothing and does not throw", async () => {
+    const removeSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "removeTeamFromProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+
+    await expect(
+      MicrosoftTeamsUtil.removeTeamFromBotActivity({ activity: {} }),
+    ).resolves.toBeUndefined();
+
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
+
+  test("a throwing removal is swallowed, not propagated", async () => {
+    jest
+      .spyOn(MicrosoftTeamsUtil, "removeTeamFromProjectAuthTokens")
+      .mockRejectedValue(new Error("database is down") as never);
+
+    await expect(
+      MicrosoftTeamsUtil.removeTeamFromBotActivity({
+        activity: teamActivity(),
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("MicrosoftTeamsUtil.saveTeamToProjectAuthTokens", () => {
+  test("queries project auth rows by MicrosoftTeams workspace type and tenant id", async () => {
+    const findBySpy: jest.SpyInstance = mockFindBy([]);
+
+    await MicrosoftTeamsUtil.saveTeamToProjectAuthTokens({
+      tenantId: "tenant-abc",
+      team: buildInstalledTeam(),
+    });
+
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+    expect(findBySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: {
+          workspaceType: WorkspaceType.MicrosoftTeams,
+          workspaceProjectId: "tenant-abc",
+        },
+        select: {
+          _id: true,
+          miscData: true,
+        },
+        limit: LIMIT_MAX,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      }),
+    );
+  });
+
+  test("fans out to EVERY project connected to the tenant, merging into each row's OWN miscData (3 rows -> 3 updates)", async () => {
+    /*
+     * Three rows that share nothing: different scalars, different pre-existing
+     * installedTeams and different availableChats. Merging once and writing the
+     * result to all three rows must fail here, not pass by symmetry.
+     */
+    const fixtures: Array<DistinctRowFixture> = [
+      buildDistinctRowFixture("row-one"),
+      buildDistinctRowFixture("row-two"),
+      buildDistinctRowFixture("row-three"),
+    ];
+    mockFindBy(buildRowsFromFixtures({ fixtures: fixtures }));
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    const team: MicrosoftTeamsInstalledTeam = buildInstalledTeam();
+    await MicrosoftTeamsUtil.saveTeamToProjectAuthTokens({
+      tenantId: "tenant-abc",
+      team: team,
+    });
+
+    expect(updateSpy).toHaveBeenCalledTimes(3);
+    expect(getUpdatedIds(updateSpy)).toEqual(fixtureIds(fixtures));
+
+    const savedObjects: Set<MicrosoftTeamsMiscData> =
+      new Set<MicrosoftTeamsMiscData>();
+
+    for (const fixture of fixtures) {
+      // Anchored on this row's id: a sibling's payload cannot stand in for it.
+      const savedMiscData: MicrosoftTeamsMiscData = getUpdateArgsForId(
+        updateSpy,
+        fixture.id,
+      ).data.miscData;
+      savedObjects.add(savedMiscData);
+
+      /*
+       * The new install is added on top of THIS row's install history. The
+       * exact-map comparison also proves no sibling's team leaked in.
+       */
+      expect(savedMiscData.installedTeams).toEqual({
+        [fixture.existingTeam.id]: fixture.existingTeam,
+        [team.id]: team,
+      });
+      // This row's chat store is untouched, and is not a sibling's chat store.
+      expect(savedMiscData.availableChats).toEqual({
+        [fixture.chat.id]: fixture.chat,
+      });
+      expect(savedMiscData.tenantId).toBe(fixture.tenantId);
+      expect(savedMiscData.teamName).toBe(fixture.teamName);
+      expect(savedMiscData.botId).toBe(fixture.botId);
+    }
+
+    /*
+     * Each row must be written a miscData object of its own — one shared object
+     * handed to all three updates is the exact defect this test guards.
+     */
+    expect(savedObjects.size).toBe(3);
+  });
+
+  test("updates are made with root props", async () => {
+    mockFindBy([buildProjectAuthRow({ miscData: baseMiscData() })]);
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    await MicrosoftTeamsUtil.saveTeamToProjectAuthTokens({
+      tenantId: "tenant-abc",
+      team: buildInstalledTeam(),
+    });
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ props: { isRoot: true } }),
+    );
+  });
+
+  test("merging an install preserves other miscData fields, availableChats and other installed teams", async () => {
+    const existingTeam: MicrosoftTeamsInstalledTeam = buildInstalledTeam({
+      id: "19:other-team@thread.tacv2",
+      name: "Support",
+    });
+    const existingChat: MicrosoftTeamsChat = buildChat();
+    mockFindBy([
+      buildProjectAuthRow({
+        miscData: baseMiscData({
+          appAccessToken: "token-abc",
+          adminConsentGranted: true,
+          availableChats: { [existingChat.id]: existingChat },
+          installedTeams: { [existingTeam.id]: existingTeam },
+        }),
+      }),
+    ]);
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    const newTeam: MicrosoftTeamsInstalledTeam = buildInstalledTeam();
+    await MicrosoftTeamsUtil.saveTeamToProjectAuthTokens({
+      tenantId: "tenant-abc",
+      team: newTeam,
+    });
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    const savedMiscData: MicrosoftTeamsMiscData = getUpdateArgs(updateSpy, 0)
+      .data.miscData;
+    expect(savedMiscData.tenantId).toBe("tenant-xyz");
+    expect(savedMiscData.teamId).toBe("team-1");
+    expect(savedMiscData.teamName).toBe("Engineering");
+    expect(savedMiscData.botId).toBe("bot-1");
+    expect(savedMiscData.appAccessToken).toBe("token-abc");
+    expect(savedMiscData.adminConsentGranted).toBe(true);
+    // The chat store must survive a team install untouched.
+    expect(savedMiscData.availableChats).toEqual({
+      [existingChat.id]: existingChat,
+    });
+    expect(savedMiscData.installedTeams).toEqual({
+      [existingTeam.id]: existingTeam,
+      [newTeam.id]: newTeam,
+    });
+  });
+
+  test("re-installing the same team id overwrites the stored record (upsert, keeps serviceUrl fresh)", async () => {
+    const staleTeam: MicrosoftTeamsInstalledTeam = buildInstalledTeam({
+      name: "Old name",
+      serviceUrl: "https://smba.trafficmanager.net/OLD/",
+    });
+    mockFindBy([
+      buildProjectAuthRow({
+        miscData: baseMiscData({
+          installedTeams: { [staleTeam.id]: staleTeam },
+        }),
+      }),
+    ]);
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    const freshTeam: MicrosoftTeamsInstalledTeam = buildInstalledTeam({
+      name: "New name",
+      serviceUrl: GCC_SERVICE_URL,
+    });
+    await MicrosoftTeamsUtil.saveTeamToProjectAuthTokens({
+      tenantId: "tenant-abc",
+      team: freshTeam,
+    });
+
+    const savedMiscData: MicrosoftTeamsMiscData = getUpdateArgs(updateSpy, 0)
+      .data.miscData;
+    expect(Object.keys(savedMiscData.installedTeams || {})).toHaveLength(1);
+    expect(savedMiscData.installedTeams?.[freshTeam.id]?.name).toBe("New name");
+    expect(savedMiscData.installedTeams?.[freshTeam.id]?.serviceUrl).toBe(
+      GCC_SERVICE_URL,
+    );
+  });
+
+  test("creates installedTeams when miscData is undefined", async () => {
+    mockFindBy([buildProjectAuthRow({ miscData: undefined })]);
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    const team: MicrosoftTeamsInstalledTeam = buildInstalledTeam();
+    await MicrosoftTeamsUtil.saveTeamToProjectAuthTokens({
+      tenantId: "tenant-abc",
+      team: team,
+    });
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(getUpdateArgs(updateSpy, 0).data.miscData.installedTeams).toEqual({
+      [team.id]: team,
+    });
+  });
+
+  test("creates installedTeams when the map is present but empty", async () => {
+    mockFindBy([
+      buildProjectAuthRow({
+        miscData: baseMiscData({ installedTeams: {} }),
+      }),
+    ]);
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    const team: MicrosoftTeamsInstalledTeam = buildInstalledTeam();
+    await MicrosoftTeamsUtil.saveTeamToProjectAuthTokens({
+      tenantId: "tenant-abc",
+      team: team,
+    });
+
+    expect(getUpdateArgs(updateSpy, 0).data.miscData.installedTeams).toEqual({
+      [team.id]: team,
+    });
+  });
+
+  test("no matching project auth rows -> no updates", async () => {
+    mockFindBy([]);
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    await MicrosoftTeamsUtil.saveTeamToProjectAuthTokens({
+      tenantId: "tenant-abc",
+      team: buildInstalledTeam(),
+    });
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not mutate the row's own miscData object", async () => {
+    const originalMiscData: MicrosoftTeamsMiscData = baseMiscData({
+      installedTeams: {},
+    });
+    mockFindBy([buildProjectAuthRow({ miscData: originalMiscData })]);
+    mockUpdateOneById();
+
+    await MicrosoftTeamsUtil.saveTeamToProjectAuthTokens({
+      tenantId: "tenant-abc",
+      team: buildInstalledTeam(),
+    });
+
+    expect(originalMiscData.installedTeams).toEqual({});
+  });
+});
+
+describe("MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens", () => {
+  test("queries project auth rows by MicrosoftTeams workspace type and tenant id", async () => {
+    const findBySpy: jest.SpyInstance = mockFindBy([]);
+
+    await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
+      tenantId: "tenant-abc",
+      teamId: TEAM_ID,
+    });
+
+    expect(findBySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: {
+          workspaceType: WorkspaceType.MicrosoftTeams,
+          workspaceProjectId: "tenant-abc",
+        },
+        limit: LIMIT_MAX,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      }),
+    );
+  });
+
+  test("removes only the target team and keeps the others", async () => {
+    const teamToRemove: MicrosoftTeamsInstalledTeam = buildInstalledTeam({
+      id: "19:remove@thread.tacv2",
+      name: "Removed",
+    });
+    const teamToKeep: MicrosoftTeamsInstalledTeam = buildInstalledTeam({
+      id: "19:keep@thread.tacv2",
+      name: "Kept",
+    });
+    mockFindBy([
+      buildProjectAuthRow({
+        miscData: baseMiscData({
+          installedTeams: {
+            [teamToRemove.id]: teamToRemove,
+            [teamToKeep.id]: teamToKeep,
+          },
+        }),
+      }),
+    ]);
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
+      tenantId: "tenant-abc",
+      teamId: teamToRemove.id,
+    });
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(getUpdateArgs(updateSpy, 0).data.miscData.installedTeams).toEqual({
+      [teamToKeep.id]: teamToKeep,
+    });
+  });
+
+  test("removal preserves the rest of miscData, including availableChats", async () => {
+    const team: MicrosoftTeamsInstalledTeam = buildInstalledTeam();
+    const chat: MicrosoftTeamsChat = buildChat();
+    mockFindBy([
+      buildProjectAuthRow({
+        miscData: baseMiscData({
+          appAccessToken: "token-abc",
+          availableChats: { [chat.id]: chat },
+          installedTeams: { [team.id]: team },
+        }),
+      }),
+    ]);
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
+      tenantId: "tenant-abc",
+      teamId: team.id,
+    });
+
+    const savedMiscData: MicrosoftTeamsMiscData = getUpdateArgs(updateSpy, 0)
+      .data.miscData;
+    expect(savedMiscData.installedTeams).toEqual({});
+    expect(savedMiscData.availableChats).toEqual({ [chat.id]: chat });
+    expect(savedMiscData.appAccessToken).toBe("token-abc");
+    expect(savedMiscData.botId).toBe("bot-1");
+  });
+
+  test("does not call updateOneById when the row does not have that team", async () => {
+    const otherTeam: MicrosoftTeamsInstalledTeam = buildInstalledTeam({
+      id: "19:other@thread.tacv2",
+    });
+    mockFindBy([
+      buildProjectAuthRow({
+        miscData: baseMiscData({
+          installedTeams: { [otherTeam.id]: otherTeam },
+        }),
+      }),
+    ]);
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
+      tenantId: "tenant-abc",
+      teamId: TEAM_ID,
+    });
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  test("rows with no installedTeams at all are skipped without an update", async () => {
+    mockFindBy([
+      buildProjectAuthRow({ miscData: baseMiscData() }),
+      buildProjectAuthRow({ miscData: undefined }),
+    ]);
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
+      tenantId: "tenant-abc",
+      teamId: TEAM_ID,
+    });
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  test("removes the team from every matching row, keeping each row's OWN remaining data (multi-row removal)", async () => {
+    const team: MicrosoftTeamsInstalledTeam = buildInstalledTeam();
+    /*
+     * Each row keeps a DIFFERENT second install alongside the shared target, so
+     * a removal that computes one miscData and writes it to every row cannot
+     * survive: row two would be handed row one's surviving team.
+     */
+    const fixtures: Array<DistinctRowFixture> = [
+      buildDistinctRowFixture("remove-row-one"),
+      buildDistinctRowFixture("remove-row-two"),
+      buildDistinctRowFixture("remove-row-three"),
+    ];
+    mockFindBy(buildRowsFromFixtures({ fixtures: fixtures, sharedTeam: team }));
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
+      tenantId: "tenant-abc",
+      teamId: team.id,
+    });
+
+    expect(updateSpy).toHaveBeenCalledTimes(3);
+    expect(getUpdatedIds(updateSpy)).toEqual(fixtureIds(fixtures));
+
+    const savedObjects: Set<MicrosoftTeamsMiscData> =
+      new Set<MicrosoftTeamsMiscData>();
+
+    for (const fixture of fixtures) {
+      const savedMiscData: MicrosoftTeamsMiscData = getUpdateArgsForId(
+        updateSpy,
+        fixture.id,
+      ).data.miscData;
+      savedObjects.add(savedMiscData);
+
+      // Only the target goes; this row's other install stays, siblings' do not.
+      expect(savedMiscData.installedTeams).toEqual({
+        [fixture.existingTeam.id]: fixture.existingTeam,
+      });
+      expect(savedMiscData.availableChats).toEqual({
+        [fixture.chat.id]: fixture.chat,
+      });
+      expect(savedMiscData.tenantId).toBe(fixture.tenantId);
+      expect(savedMiscData.teamName).toBe(fixture.teamName);
+      expect(savedMiscData.botId).toBe(fixture.botId);
+    }
+
+    expect(savedObjects.size).toBe(3);
+  });
+
+  test("only the rows that contain the team are updated, and that update carries that row's own miscData", async () => {
+    const team: MicrosoftTeamsInstalledTeam = buildInstalledTeam();
+    const noInstalledTeamsRow: DistinctRowFixture =
+      buildDistinctRowFixture("no-map-row");
+    const rowWithTeam: DistinctRowFixture =
+      buildDistinctRowFixture("has-team-row");
+    const emptyMapRow: DistinctRowFixture =
+      buildDistinctRowFixture("empty-map-row");
+    mockFindBy([
+      buildRowFromFixture({ fixture: noInstalledTeamsRow }),
+      buildRowFromFixture({
+        fixture: rowWithTeam,
+        installedTeams: {
+          [rowWithTeam.existingTeam.id]: rowWithTeam.existingTeam,
+          [team.id]: team,
+        },
+      }),
+      buildRowFromFixture({ fixture: emptyMapRow, installedTeams: {} }),
+    ]);
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
+      tenantId: "tenant-abc",
+      teamId: team.id,
+    });
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(String(getUpdateArgs(updateSpy, 0).id)).toBe(
+      rowWithTeam.id.toString(),
+    );
+    /*
+     * The one update must carry the matching row's data — not data assembled
+     * from a skipped neighbour that happened to be iterated first.
+     */
+    const savedMiscData: MicrosoftTeamsMiscData = getUpdateArgs(updateSpy, 0)
+      .data.miscData;
+    expect(savedMiscData.installedTeams).toEqual({
+      [rowWithTeam.existingTeam.id]: rowWithTeam.existingTeam,
+    });
+    expect(savedMiscData.availableChats).toEqual({
+      [rowWithTeam.chat.id]: rowWithTeam.chat,
+    });
+    expect(savedMiscData.tenantId).toBe(rowWithTeam.tenantId);
+    expect(savedMiscData.botId).toBe(rowWithTeam.botId);
+  });
+
+  test("team ids are matched case-sensitively (a different casing is a different team)", async () => {
+    const team: MicrosoftTeamsInstalledTeam = buildInstalledTeam({
+      id: "19:Team-AAA@thread.tacv2",
+    });
+    mockFindBy([
+      buildProjectAuthRow({
+        miscData: baseMiscData({ installedTeams: { [team.id]: team } }),
+      }),
+    ]);
+    const updateSpy: jest.SpyInstance = mockUpdateOneById();
+
+    await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
+      tenantId: "tenant-abc",
+      teamId: "19:team-aaa@thread.tacv2",
+    });
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not mutate the row's own installedTeams object", async () => {
+    const team: MicrosoftTeamsInstalledTeam = buildInstalledTeam();
+    const originalMiscData: MicrosoftTeamsMiscData = baseMiscData({
+      installedTeams: { [team.id]: team },
+    });
+    mockFindBy([buildProjectAuthRow({ miscData: originalMiscData })]);
+    mockUpdateOneById();
+
+    await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
+      tenantId: "tenant-abc",
+      teamId: team.id,
+    });
+
+    expect(originalMiscData.installedTeams).toEqual({ [team.id]: team });
+  });
+});
+
+describe("MicrosoftTeamsUtil.getInstalledTeamsForProject", () => {
+  test("returns empty object when there is no project auth", async () => {
+    jest
+      .spyOn(WorkspaceProjectAuthTokenService, "getProjectAuth")
+      .mockResolvedValue(null);
+
+    const teams: Record<string, MicrosoftTeamsInstalledTeam> =
+      await MicrosoftTeamsUtil.getInstalledTeamsForProject({
+        projectId: ObjectID.generate(),
+      });
+
+    expect(teams).toEqual({});
+  });
+
+  test("returns empty object when project auth has no miscData", async () => {
+    jest
+      .spyOn(WorkspaceProjectAuthTokenService, "getProjectAuth")
+      .mockResolvedValue(buildProjectAuthRow({ miscData: undefined }));
+
+    const teams: Record<string, MicrosoftTeamsInstalledTeam> =
+      await MicrosoftTeamsUtil.getInstalledTeamsForProject({
+        projectId: ObjectID.generate(),
+      });
+
+    expect(teams).toEqual({});
+  });
+
+  test("returns empty object when miscData has no installedTeams", async () => {
+    jest
+      .spyOn(WorkspaceProjectAuthTokenService, "getProjectAuth")
+      .mockResolvedValue(buildProjectAuthRow({ miscData: baseMiscData() }));
+
+    const teams: Record<string, MicrosoftTeamsInstalledTeam> =
+      await MicrosoftTeamsUtil.getInstalledTeamsForProject({
+        projectId: ObjectID.generate(),
+      });
+
+    expect(teams).toEqual({});
+  });
+
+  test("returns installedTeams when present, keyed by team id", async () => {
+    const teamOne: MicrosoftTeamsInstalledTeam = buildInstalledTeam();
+    const teamTwo: MicrosoftTeamsInstalledTeam = buildInstalledTeam({
+      id: "19:second@thread.tacv2",
+      name: "Support",
+      serviceUrl: GCC_SERVICE_URL,
+    });
+    jest
+      .spyOn(WorkspaceProjectAuthTokenService, "getProjectAuth")
+      .mockResolvedValue(
+        buildProjectAuthRow({
+          miscData: baseMiscData({
+            installedTeams: { [teamOne.id]: teamOne, [teamTwo.id]: teamTwo },
+          }),
+        }),
+      );
+
+    const teams: Record<string, MicrosoftTeamsInstalledTeam> =
+      await MicrosoftTeamsUtil.getInstalledTeamsForProject({
+        projectId: ObjectID.generate(),
+      });
+
+    expect(teams).toEqual({ [teamOne.id]: teamOne, [teamTwo.id]: teamTwo });
+    expect(teams[teamTwo.id]?.serviceUrl).toBe(GCC_SERVICE_URL);
+  });
+
+  test("does not confuse availableTeams (what Graph can see) with installedTeams (what we can post to)", async () => {
+    jest
+      .spyOn(WorkspaceProjectAuthTokenService, "getProjectAuth")
+      .mockResolvedValue(
+        buildProjectAuthRow({
+          miscData: baseMiscData({
+            availableTeams: {
+              "19:listed-only@thread.tacv2": {
+                id: "19:listed-only@thread.tacv2",
+                name: "Listed but not installed",
+              },
+            } as Record<string, MicrosoftTeamsTeam>,
+          }),
+        }),
+      );
+
+    const teams: Record<string, MicrosoftTeamsInstalledTeam> =
+      await MicrosoftTeamsUtil.getInstalledTeamsForProject({
+        projectId: ObjectID.generate(),
+      });
+
+    expect(teams).toEqual({});
+  });
+
+  test("looks up project auth by projectId and MicrosoftTeams workspace type", async () => {
+    const getProjectAuthSpy: jest.SpyInstance = jest
+      .spyOn(WorkspaceProjectAuthTokenService, "getProjectAuth")
+      .mockResolvedValue(null);
+    const projectId: ObjectID = ObjectID.generate();
+
+    await MicrosoftTeamsUtil.getInstalledTeamsForProject({
+      projectId: projectId,
+    });
+
+    expect(getProjectAuthSpy).toHaveBeenCalledWith({
+      projectId: projectId,
+      workspaceType: WorkspaceType.MicrosoftTeams,
+    });
+  });
+});
+
+interface WiringSpies {
+  captureChatSpy: jest.SpyInstance;
+  captureTeamSpy: jest.SpyInstance;
+  removeChatSpy: jest.SpyInstance;
+  removeTeamSpy: jest.SpyInstance;
+}
+
+/*
+ * Route-level spies: the wiring tests assert WHICH capture ran, not what it
+ * did internally, so both the chat and the team capture are stubbed out.
+ */
+function installWiringSpies(): WiringSpies {
+  return {
+    captureChatSpy: jest
+      .spyOn(MicrosoftTeamsUtil as any, "captureChatFromBotActivity")
+      .mockResolvedValue(undefined as never),
+    captureTeamSpy: jest
+      .spyOn(MicrosoftTeamsUtil, "captureTeamFromBotActivity")
+      .mockResolvedValue(undefined as never),
+    removeChatSpy: jest
+      .spyOn(MicrosoftTeamsUtil as any, "removeChatFromBotActivity")
+      .mockResolvedValue(undefined as never),
+    removeTeamSpy: jest
+      .spyOn(MicrosoftTeamsUtil, "removeTeamFromBotActivity")
+      .mockResolvedValue(undefined as never),
+  };
+}
+
+describe("MicrosoftTeamsUtil.handleConversationUpdateActivity - team install wiring", () => {
+  function installWelcomeSpy(): jest.SpyInstance {
+    return jest
+      .spyOn(MicrosoftTeamsUtil as any, "sendWelcomeAdaptiveCard")
+      .mockResolvedValue(undefined as never);
+  }
+
+  test("bot added to a team calls BOTH the chat capture and the team capture", async () => {
+    installWelcomeSpy();
+    const spies: WiringSpies = installWiringSpies();
+    const activity: JSONObject = teamActivity({
+      membersAdded: [{ id: BOT_RECIPIENT_ID }],
+    });
+    const turnContext: TurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleConversationUpdateActivity({
+      activity: activity,
+      turnContext: turnContext,
+    });
+
+    expect(spies.captureChatSpy).toHaveBeenCalledTimes(1);
+    expect(spies.captureTeamSpy).toHaveBeenCalledTimes(1);
+    expect(spies.captureTeamSpy).toHaveBeenCalledWith({
+      activity: activity,
+      turnContext: turnContext,
+    });
+    expect(spies.removeTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("bot removed from a team calls BOTH the chat removal and the team removal", async () => {
+    installWelcomeSpy();
+    const spies: WiringSpies = installWiringSpies();
+    const activity: JSONObject = teamActivity({
+      membersRemoved: [{ id: BOT_RECIPIENT_ID }],
+    });
+
+    await MicrosoftTeamsUtil.handleConversationUpdateActivity({
+      activity: activity,
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.removeChatSpy).toHaveBeenCalledTimes(1);
+    expect(spies.removeTeamSpy).toHaveBeenCalledTimes(1);
+    expect(spies.removeTeamSpy).toHaveBeenCalledWith({ activity: activity });
+    expect(spies.captureTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("a non-bot member added or removed touches neither capture", async () => {
+    installWelcomeSpy();
+    const spies: WiringSpies = installWiringSpies();
+
+    await MicrosoftTeamsUtil.handleConversationUpdateActivity({
+      activity: teamActivity({
+        membersAdded: [{ id: "some-human-user" }],
+        membersRemoved: [{ id: "another-human-user" }],
+      }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.captureChatSpy).not.toHaveBeenCalled();
+    expect(spies.captureTeamSpy).not.toHaveBeenCalled();
+    expect(spies.removeChatSpy).not.toHaveBeenCalled();
+    expect(spies.removeTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("a conversationUpdate with no member lists at all is a no-op", async () => {
+    installWelcomeSpy();
+    const spies: WiringSpies = installWiringSpies();
+
+    await MicrosoftTeamsUtil.handleConversationUpdateActivity({
+      activity: teamActivity(),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.captureTeamSpy).not.toHaveBeenCalled();
+    expect(spies.removeTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("bot added to a personal chat still runs the team capture (it self-filters on channelData.team)", async () => {
+    installWelcomeSpy();
+    const spies: WiringSpies = installWiringSpies();
+
+    await MicrosoftTeamsUtil.handleConversationUpdateActivity({
+      activity: {
+        membersAdded: [{ id: BOT_RECIPIENT_ID }],
+        conversation: { conversationType: "personal", id: "a:1personal" },
+        channelData: { tenant: { id: TENANT_ID } },
+        serviceUrl: ACTIVITY_SERVICE_URL,
+      },
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.captureChatSpy).toHaveBeenCalledTimes(1);
+    expect(spies.captureTeamSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("MicrosoftTeamsUtil.handleInstallationUpdateActivity - team install wiring", () => {
+  test("action 'add' captures BOTH the chat and the team", async () => {
+    const spies: WiringSpies = installWiringSpies();
+    const activity: JSONObject = teamActivity({ action: "add" });
+    const turnContext: TurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleInstallationUpdateActivity({
+      activity: activity,
+      turnContext: turnContext,
+    });
+
+    expect(spies.captureChatSpy).toHaveBeenCalledTimes(1);
+    expect(spies.captureTeamSpy).toHaveBeenCalledTimes(1);
+    expect(spies.captureTeamSpy).toHaveBeenCalledWith({
+      activity: activity,
+      turnContext: turnContext,
+    });
+  });
+
+  test("action 'add-upgrade' captures BOTH (manifest upgrade that re-adds the bot)", async () => {
+    const spies: WiringSpies = installWiringSpies();
+
+    await MicrosoftTeamsUtil.handleInstallationUpdateActivity({
+      activity: teamActivity({ action: "add-upgrade" }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.captureChatSpy).toHaveBeenCalledTimes(1);
+    expect(spies.captureTeamSpy).toHaveBeenCalledTimes(1);
+    expect(spies.removeTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("action 'remove' removes BOTH the chat and the team", async () => {
+    const spies: WiringSpies = installWiringSpies();
+    const activity: JSONObject = teamActivity({ action: "remove" });
+
+    await MicrosoftTeamsUtil.handleInstallationUpdateActivity({
+      activity: activity,
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.removeChatSpy).toHaveBeenCalledTimes(1);
+    expect(spies.removeTeamSpy).toHaveBeenCalledTimes(1);
+    expect(spies.removeTeamSpy).toHaveBeenCalledWith({ activity: activity });
+    expect(spies.captureTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("action 'remove-upgrade' removes BOTH", async () => {
+    const spies: WiringSpies = installWiringSpies();
+
+    await MicrosoftTeamsUtil.handleInstallationUpdateActivity({
+      activity: teamActivity({ action: "remove-upgrade" }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.removeChatSpy).toHaveBeenCalledTimes(1);
+    expect(spies.removeTeamSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("an unknown action does neither", async () => {
+    const spies: WiringSpies = installWiringSpies();
+
+    await MicrosoftTeamsUtil.handleInstallationUpdateActivity({
+      activity: teamActivity({ action: "something-else" }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.captureTeamSpy).not.toHaveBeenCalled();
+    expect(spies.removeTeamSpy).not.toHaveBeenCalled();
+    expect(spies.captureChatSpy).not.toHaveBeenCalled();
+    expect(spies.removeChatSpy).not.toHaveBeenCalled();
+  });
+
+  test("a missing action does neither", async () => {
+    const spies: WiringSpies = installWiringSpies();
+
+    await MicrosoftTeamsUtil.handleInstallationUpdateActivity({
+      activity: teamActivity(),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.captureTeamSpy).not.toHaveBeenCalled();
+    expect(spies.removeTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("the action match is case-sensitive ('Add' is not 'add')", async () => {
+    const spies: WiringSpies = installWiringSpies();
+
+    await MicrosoftTeamsUtil.handleInstallationUpdateActivity({
+      activity: teamActivity({ action: "Add" }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.captureTeamSpy).not.toHaveBeenCalled();
+    expect(spies.captureChatSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("MicrosoftTeamsUtil.handleBotMessageActivity - team install backfill wiring", () => {
+  /*
+   * Teams the app was added to before install capture shipped fire no new
+   * install event (a manifest version bump alone sends no installationUpdate
+   * per Microsoft docs), so an inbound channel message is the only recovery
+   * path. These activities carry no @mention, so the handler exits right
+   * after the backfill step.
+   */
+  function messageActivity(conversation: JSONObject): JSONObject {
+    return {
+      type: "message",
+      text: "hello there",
+      from: { id: "user-1", name: "Alice" },
+      recipient: { id: BOT_RECIPIENT_ID },
+      conversation: conversation,
+      channelData: {
+        team: { id: TEAM_ID, name: "Engineering" },
+        tenant: { id: TENANT_ID },
+      },
+      serviceUrl: ACTIVITY_SERVICE_URL,
+      entities: [],
+    };
+  }
+
+  test("a CHANNEL message backfills the team install and does not run the chat capture", async () => {
+    const spies: WiringSpies = installWiringSpies();
+    const activity: JSONObject = messageActivity({
+      conversationType: "channel",
+      id: "19:general@thread.tacv2",
+    });
+    const turnContext: TurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: activity,
+      turnContext: turnContext,
+    });
+
+    expect(spies.captureTeamSpy).toHaveBeenCalledTimes(1);
+    expect(spies.captureTeamSpy).toHaveBeenCalledWith({
+      activity: activity,
+      turnContext: turnContext,
+    });
+    expect(spies.captureChatSpy).not.toHaveBeenCalled();
+  });
+
+  test("a groupChat message runs the chat capture and NOT the team capture", async () => {
+    const spies: WiringSpies = installWiringSpies();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity({
+        conversationType: "groupChat",
+        id: "19:groupchat@thread.v2",
+      }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.captureChatSpy).toHaveBeenCalledTimes(1);
+    expect(spies.captureTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("a personal message runs the chat capture and NOT the team capture", async () => {
+    const spies: WiringSpies = installWiringSpies();
+    /*
+     * A personal message is a direct message, so the handler runs on past the
+     * backfill into tenant resolution. Stop it there — this test is only about
+     * which capture ran.
+     */
+    jest
+      .spyOn(MicrosoftTeamsUtil, "resolveProjectByTenantId")
+      .mockResolvedValue({
+        projectAuth: null,
+        isAmbiguous: false,
+        candidateProjectIds: [],
+      } as MicrosoftTeamsTenantResolution);
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity({
+        conversationType: "personal",
+        id: "a:1personal",
+      }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.captureChatSpy).toHaveBeenCalledTimes(1);
+    expect(spies.captureTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("a conversation with no conversationType triggers neither capture", async () => {
+    const spies: WiringSpies = installWiringSpies();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity({ id: "19:unknown@thread.tacv2" }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.captureChatSpy).not.toHaveBeenCalled();
+    expect(spies.captureTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("conversationType matching is case-sensitive ('Channel' is not 'channel')", async () => {
+    const spies: WiringSpies = installWiringSpies();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity({
+        conversationType: "Channel",
+        id: "19:general@thread.tacv2",
+      }),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.captureTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("the bot's own channel message triggers no backfill (loop guard runs first)", async () => {
+    const spies: WiringSpies = installWiringSpies();
+    const activity: JSONObject = messageActivity({
+      conversationType: "channel",
+      id: "19:general@thread.tacv2",
+    });
+    (activity["from"] as JSONObject)["id"] = BOT_RECIPIENT_ID;
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: activity,
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.captureTeamSpy).not.toHaveBeenCalled();
+    expect(spies.captureChatSpy).not.toHaveBeenCalled();
+  });
+
+  test("a message from a member flagged with the bot role triggers no backfill", async () => {
+    const spies: WiringSpies = installWiringSpies();
+    const activity: JSONObject = messageActivity({
+      conversationType: "channel",
+      id: "19:general@thread.tacv2",
+    });
+    (activity["from"] as JSONObject)["role"] = "bot";
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: activity,
+      turnContext: buildTurnContext(),
+    });
+
+    expect(spies.captureTeamSpy).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsTenantResolution.test.ts
+++ b/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsTenantResolution.test.ts
@@ -1,0 +1,1218 @@
+import { describe, expect, test, afterEach, beforeEach } from "@jest/globals";
+
+/*
+ * Tests for tenant -> project resolution in MicrosoftTeamsUtil.
+ *
+ * Bot Framework activities carry a Microsoft tenant id and nothing else, so
+ * the tenant is the only key the bot can resolve a OneUptime project by. A
+ * single tenant may legitimately be connected to several OneUptime projects
+ * (saveChatToProjectAuthTokens fans out across every matching row for exactly
+ * that reason).
+ *
+ * This used to be a bare
+ *   WorkspaceProjectAuthTokenService.findOneBy({ workspaceType, workspaceProjectId })
+ * with no projectId scope and no unique constraint behind it, so when a tenant
+ * was connected to two projects the bot silently served whichever row sorted
+ * first — its incidents, alerts and AI assistant answers — to anyone in the
+ * tenant. The bot message path performs no per-user authorization, so guessing
+ * is a cross-project data disclosure.
+ *
+ * The fix reads ALL matching rows (findBy + LIMIT_MAX) and refuses to guess:
+ *
+ * - resolveProjectByTenantId returns { projectAuth, isAmbiguous,
+ *   candidateProjectIds }; more than one usable PROJECT means projectAuth ===
+ *   null and isAmbiguous === true.
+ * - Rows with a falsy projectId are dropped, and rows repeating a projectId
+ *   already seen are collapsed, BEFORE the count is taken - so one good row
+ *   plus one orphaned row, or two rows for the same project, still resolve
+ *   cleanly.
+ * - getTenantResolutionFailureMessage gives the ambiguous case a different
+ *   remedy from the not-found case.
+ * - Both bot entry points (handleBotMessageActivity for typed messages and
+ *   handleBotInvokeActivity for adaptive-card clicks) go through it, and both
+ *   scope everything they read afterwards to the project it resolved.
+ *
+ * These tests fail if the code ever reverts to findOneBy, if either entry point
+ * starts serving a project it merely guessed at, or if a resolved tenant's
+ * downstream reads are scoped to any project other than the resolved one.
+ */
+
+jest.mock("../../../../Server/EnvironmentConfig", () => {
+  return {
+    ...(jest.requireActual("../../../../Server/EnvironmentConfig") as Record<
+      string,
+      unknown
+    >),
+    MicrosoftTeamsAppClientId: "11111111-2222-3333-4444-555555555555",
+    MicrosoftTeamsAppClientSecret: "test-secret",
+    MicrosoftTeamsAppTenantId: "test-tenant",
+  };
+});
+
+/*
+ * Same botbuilder module factory as MicrosoftTeamsChats.test.ts — the repo-wide
+ * manual mock does not expose everything MicrosoftTeams.ts touches at import
+ * time.
+ */
+jest.mock("botbuilder", () => {
+  return {
+    CloudAdapter: class CloudAdapter {},
+    ConfigurationBotFrameworkAuthentication: class ConfigurationBotFrameworkAuthentication {},
+    TeamsActivityHandler: class TeamsActivityHandler {},
+    TurnContext: class TurnContext {},
+    ActivityHandler: class ActivityHandler {},
+    MessageFactory: {
+      text: jest.fn(),
+      attachment: jest.fn(),
+    },
+    CardFactory: { heroCard: jest.fn() },
+    TeamsInfo: {
+      getMembers: jest.fn(),
+      getPagedMembers: jest.fn(),
+    },
+  };
+});
+
+import MicrosoftTeamsUtil, {
+  MicrosoftTeamsTenantResolution,
+} from "../../../../Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams";
+import MicrosoftTeamsAuthAction from "../../../../Server/Utils/Workspace/MicrosoftTeams/Actions/Auth";
+import WorkspaceProjectAuthTokenService from "../../../../Server/Services/WorkspaceProjectAuthTokenService";
+import WorkspaceProjectAuthToken from "../../../../Models/DatabaseModels/WorkspaceProjectAuthToken";
+import WorkspaceType from "../../../../Types/Workspace/WorkspaceType";
+import ObjectID from "../../../../Types/ObjectID";
+import LIMIT_MAX from "../../../../Types/Database/LimitMax";
+import { JSONObject } from "../../../../Types/JSON";
+import {
+  MessageFactory,
+  CardFactory,
+  TeamsInfo,
+  type TurnContext,
+} from "botbuilder";
+
+const TENANT_ID: string = "tenant-abc";
+const BOT_RECIPIENT_ID: string = "bot-recipient-id";
+const AAD_OBJECT_ID: string = "aad-object-id-1";
+const TURN_CONTEXT_SERVICE_URL: string =
+  "https://smba.trafficmanager.net/emea/";
+
+/*
+ * Distinguishing substrings of the two failure messages. Deliberately short so
+ * that copy edits to the surrounding sentence do not break these tests.
+ */
+const AMBIGUOUS_FRAGMENT: string = "more than one OneUptime project";
+const NOT_FOUND_FRAGMENT: string = "couldn't find your project configuration";
+const NO_TENANT_FRAGMENT: string = "couldn't identify your organization";
+const HELP_FRAGMENT: string = "Available Commands";
+
+interface CapturedFindByCall {
+  query: JSONObject;
+  select: JSONObject;
+  limit: number;
+  skip: number;
+  props: JSONObject;
+}
+
+interface FakeTurnContext {
+  turnContext: TurnContext;
+  sendActivity: jest.Mock;
+}
+
+function buildTurnContext(): FakeTurnContext {
+  const sendActivity: jest.Mock = jest.fn(async (): Promise<JSONObject> => {
+    return { id: "sent-message-id" };
+  });
+
+  const turnContext: TurnContext = {
+    activity: {
+      recipient: { id: BOT_RECIPIENT_ID },
+      serviceUrl: TURN_CONTEXT_SERVICE_URL,
+      conversation: { id: "ctx-conversation-id" },
+    },
+    sendActivity: sendActivity,
+  } as unknown as TurnContext;
+
+  return { turnContext: turnContext, sendActivity: sendActivity };
+}
+
+function buildProjectAuthRow(data?: {
+  projectId?: ObjectID | null | undefined;
+  workspaceProjectId?: string | undefined;
+  authToken?: string | undefined;
+}): WorkspaceProjectAuthToken {
+  return {
+    id: ObjectID.generate(),
+    projectId:
+      data && "projectId" in data ? data.projectId : ObjectID.generate(),
+    workspaceProjectId: data?.workspaceProjectId || TENANT_ID,
+    authToken: data?.authToken || "stored-auth-token",
+    miscData: { tenantId: TENANT_ID, teamId: "team-1", botId: "bot-1" },
+  } as unknown as WorkspaceProjectAuthToken;
+}
+
+function mockFindBy(rows: Array<WorkspaceProjectAuthToken>): jest.SpyInstance {
+  return jest
+    .spyOn(WorkspaceProjectAuthTokenService, "findBy")
+    .mockResolvedValue(rows);
+}
+
+/*
+ * findOneBy is what the vulnerable version used. It is stubbed (never left
+ * live) so that a regression cannot reach a real database, and asserted
+ * not-called so that a regression is caught rather than silently tolerated.
+ */
+function spyOnFindOneBy(): jest.SpyInstance {
+  return jest
+    .spyOn(WorkspaceProjectAuthTokenService, "findOneBy")
+    .mockResolvedValue(null);
+}
+
+/*
+ * The message path backfills captured chats before it resolves the tenant, and
+ * that backfill hits WorkspaceProjectAuthTokenService itself. Stub it out so
+ * findBy call counts belong to resolveProjectByTenantId alone.
+ */
+function stubChatCapture(): jest.SpyInstance {
+  return jest
+    .spyOn(MicrosoftTeamsUtil as any, "captureChatFromBotActivity")
+    .mockResolvedValue(undefined as never);
+}
+
+/*
+ * The readers the message path serves project data with are private statics,
+ * so they are spied through the class object. Stubbing them keeps the test off
+ * the database while capturing the one argument that matters: the project id
+ * the handler decided to scope the read to.
+ */
+function stubDownstreamReader(
+  methodName: string,
+  resolvedValue?: unknown,
+): jest.SpyInstance {
+  return jest
+    .spyOn(MicrosoftTeamsUtil as any, methodName)
+    .mockResolvedValue(resolvedValue as never);
+}
+
+function firstArgProjectId(spy: jest.SpyInstance): ObjectID {
+  return spy.mock.calls[0]?.[0] as ObjectID;
+}
+
+function messageActivity(data?: {
+  tenantId?: string | undefined;
+  omitTenant?: boolean | undefined;
+  text?: string | undefined;
+}): JSONObject {
+  const channelData: JSONObject = {};
+
+  if (!data?.omitTenant) {
+    channelData["tenant"] = { id: data?.tenantId || TENANT_ID };
+  }
+
+  return {
+    type: "message",
+    // "help" is answered from a constant, so the path needs no AI or DB mocks.
+    text: data?.text || "help",
+    from: { id: "user-1", name: "Alice", aadObjectId: AAD_OBJECT_ID },
+    recipient: { id: BOT_RECIPIENT_ID },
+    conversation: { conversationType: "personal", id: "19:personal@thread.v2" },
+    channelData: channelData,
+    serviceUrl: TURN_CONTEXT_SERVICE_URL,
+    entities: [],
+  };
+}
+
+function invokeActivity(data?: {
+  tenantId?: string | undefined;
+  omitTenant?: boolean | undefined;
+  omitAadObjectId?: boolean | undefined;
+}): JSONObject {
+  const channelData: JSONObject = {};
+
+  if (!data?.omitTenant) {
+    channelData["tenant"] = { id: data?.tenantId || TENANT_ID };
+  }
+
+  const from: JSONObject = { id: "user-1", name: "Alice" };
+
+  if (!data?.omitAadObjectId) {
+    from["aadObjectId"] = AAD_OBJECT_ID;
+  }
+
+  return {
+    type: "invoke",
+    name: "adaptiveCard/action",
+    value: { action: "unknown-card-action", actionValue: "some-id" },
+    from: from,
+    recipient: { id: BOT_RECIPIENT_ID },
+    conversation: { conversationType: "personal", id: "19:personal@thread.v2" },
+    channelData: channelData,
+    serviceUrl: TURN_CONTEXT_SERVICE_URL,
+  };
+}
+
+function sentTexts(sendActivity: jest.Mock): Array<string> {
+  return sendActivity.mock.calls.map((call: Array<unknown>) => {
+    return typeof call[0] === "string" ? call[0] : JSON.stringify(call[0]);
+  });
+}
+
+function joinedSentText(sendActivity: jest.Mock): string {
+  return sentTexts(sendActivity).join("\n");
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+/*
+ * The botbuilder module mock's jest.fn()s are shared across tests — jest.spyOn
+ * on an existing mock returns the same function, so call history and
+ * mockResolvedValueOnce queues leak between tests unless reset here.
+ */
+beforeEach(() => {
+  (MessageFactory.text as jest.Mock).mockReset();
+  (MessageFactory.attachment as jest.Mock).mockReset();
+  (CardFactory.heroCard as jest.Mock).mockReset();
+  (TeamsInfo.getMembers as jest.Mock).mockReset();
+  (TeamsInfo.getPagedMembers as jest.Mock).mockReset();
+});
+
+describe("MicrosoftTeamsUtil.resolveProjectByTenantId - row counting", () => {
+  test("zero matching rows resolves to no project and is NOT ambiguous", async () => {
+    mockFindBy([]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    expect(resolution.projectAuth).toBeNull();
+    expect(resolution.isAmbiguous).toBe(false);
+    expect(resolution.candidateProjectIds).toEqual([]);
+  });
+
+  test("exactly one matching row resolves to that row", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+    const row: WorkspaceProjectAuthToken = buildProjectAuthRow({
+      projectId: projectId,
+    });
+    mockFindBy([row]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    expect(resolution.projectAuth).toBe(row);
+    expect(resolution.isAmbiguous).toBe(false);
+    expect(resolution.candidateProjectIds).toHaveLength(1);
+    expect(resolution.candidateProjectIds[0]?.toString()).toBe(
+      projectId.toString(),
+    );
+  });
+
+  test("two rows for one tenant are ambiguous and resolve to NO project (the disclosure bug)", async () => {
+    const projectIdOne: ObjectID = ObjectID.generate();
+    const projectIdTwo: ObjectID = ObjectID.generate();
+    mockFindBy([
+      buildProjectAuthRow({ projectId: projectIdOne }),
+      buildProjectAuthRow({ projectId: projectIdTwo }),
+    ]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    // The old findOneBy returned the first row here — that is the regression.
+    expect(resolution.projectAuth).toBeNull();
+    expect(resolution.isAmbiguous).toBe(true);
+    expect(resolution.candidateProjectIds).toHaveLength(2);
+  });
+
+  test("three rows are ambiguous and list all three candidates", async () => {
+    const projectIds: Array<ObjectID> = [
+      ObjectID.generate(),
+      ObjectID.generate(),
+      ObjectID.generate(),
+    ];
+    mockFindBy(
+      projectIds.map((projectId: ObjectID) => {
+        return buildProjectAuthRow({ projectId: projectId });
+      }),
+    );
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    expect(resolution.projectAuth).toBeNull();
+    expect(resolution.isAmbiguous).toBe(true);
+    expect(resolution.candidateProjectIds).toHaveLength(3);
+  });
+
+  test("candidateProjectIds are the project ids, in the order the rows came back", async () => {
+    const projectIdOne: ObjectID = ObjectID.generate();
+    const projectIdTwo: ObjectID = ObjectID.generate();
+    mockFindBy([
+      buildProjectAuthRow({ projectId: projectIdOne }),
+      buildProjectAuthRow({ projectId: projectIdTwo }),
+    ]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    expect(
+      resolution.candidateProjectIds.map((projectId: ObjectID) => {
+        return projectId.toString();
+      }),
+    ).toEqual([projectIdOne.toString(), projectIdTwo.toString()]);
+  });
+});
+
+/*
+ * Ambiguity is a question about distinct PROJECTS, not about rows. Duplicate
+ * rows for the same project are a data-integrity wart (a re-install can leave
+ * one behind) and must not lock that tenant's bot out forever, so resolution
+ * de-duplicates by projectId BEFORE it counts.
+ */
+describe("MicrosoftTeamsUtil.resolveProjectByTenantId - de-duplication by projectId", () => {
+  test("two rows pointing at the SAME project resolve cleanly and are NOT ambiguous", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+    const firstRow: WorkspaceProjectAuthToken = buildProjectAuthRow({
+      projectId: projectId,
+    });
+    mockFindBy([
+      firstRow,
+      /*
+       * A separate ObjectID instance carrying the same value - de-duplication
+       * has to compare ids by value, not by object identity.
+       */
+      buildProjectAuthRow({ projectId: new ObjectID(projectId.toString()) }),
+    ]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    expect(resolution.projectAuth).toBe(firstRow);
+    expect(resolution.isAmbiguous).toBe(false);
+    expect(
+      resolution.candidateProjectIds.map((candidate: ObjectID) => {
+        return candidate.toString();
+      }),
+    ).toEqual([projectId.toString()]);
+  });
+
+  test("two otherwise-identical rows with DIFFERENT projects stay ambiguous - projectId is the only key", async () => {
+    const projectIdOne: ObjectID = ObjectID.generate();
+    const projectIdTwo: ObjectID = ObjectID.generate();
+    /*
+     * Everything except projectId matches, so a de-duplication keyed on the
+     * tenant or the auth token would collapse these into one and hand the user
+     * whichever project happened to sort first - the original disclosure bug.
+     */
+    mockFindBy([
+      buildProjectAuthRow({
+        projectId: projectIdOne,
+        workspaceProjectId: TENANT_ID,
+        authToken: "identical-auth-token",
+      }),
+      buildProjectAuthRow({
+        projectId: projectIdTwo,
+        workspaceProjectId: TENANT_ID,
+        authToken: "identical-auth-token",
+      }),
+    ]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    expect(resolution.projectAuth).toBeNull();
+    expect(resolution.isAmbiguous).toBe(true);
+    expect(
+      resolution.candidateProjectIds.map((candidate: ObjectID) => {
+        return candidate.toString();
+      }),
+    ).toEqual([projectIdOne.toString(), projectIdTwo.toString()]);
+  });
+
+  test("three rows collapsing to two distinct projects are still ambiguous with two candidates", async () => {
+    const projectIdOne: ObjectID = ObjectID.generate();
+    const projectIdTwo: ObjectID = ObjectID.generate();
+    mockFindBy([
+      buildProjectAuthRow({ projectId: projectIdOne }),
+      buildProjectAuthRow({ projectId: projectIdTwo }),
+      buildProjectAuthRow({ projectId: new ObjectID(projectIdOne.toString()) }),
+    ]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    expect(resolution.projectAuth).toBeNull();
+    expect(resolution.isAmbiguous).toBe(true);
+    // Three rows, two projects: the duplicate collapses, the conflict does not.
+    expect(
+      resolution.candidateProjectIds.map((candidate: ObjectID) => {
+        return candidate.toString();
+      }),
+    ).toEqual([projectIdOne.toString(), projectIdTwo.toString()]);
+  });
+
+  test("a duplicated project is served by the message path instead of refused", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+    stubChatCapture();
+    mockFindBy([
+      buildProjectAuthRow({ projectId: projectId }),
+      buildProjectAuthRow({ projectId: new ObjectID(projectId.toString()) }),
+    ]);
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity(),
+      turnContext: context.turnContext,
+    });
+
+    const sent: string = joinedSentText(context.sendActivity);
+    expect(sent).toContain(HELP_FRAGMENT);
+    expect(sent).not.toContain(AMBIGUOUS_FRAGMENT);
+    expect(sent).not.toContain(NOT_FOUND_FRAGMENT);
+  });
+});
+
+describe("MicrosoftTeamsUtil.resolveProjectByTenantId - unusable rows", () => {
+  test("a single row with an undefined projectId counts as not found, not ambiguous", async () => {
+    mockFindBy([buildProjectAuthRow({ projectId: undefined })]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    expect(resolution.projectAuth).toBeNull();
+    expect(resolution.isAmbiguous).toBe(false);
+    expect(resolution.candidateProjectIds).toEqual([]);
+  });
+
+  test("a single row with a null projectId counts as not found", async () => {
+    mockFindBy([buildProjectAuthRow({ projectId: null })]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    expect(resolution.projectAuth).toBeNull();
+    expect(resolution.isAmbiguous).toBe(false);
+    expect(resolution.candidateProjectIds).toEqual([]);
+  });
+
+  test("one usable row plus one projectId-less row resolves cleanly and is NOT ambiguous", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+    const usableRow: WorkspaceProjectAuthToken = buildProjectAuthRow({
+      projectId: projectId,
+    });
+    mockFindBy([buildProjectAuthRow({ projectId: undefined }), usableRow]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    // Filtering must happen BEFORE the count, otherwise this would be ambiguous.
+    expect(resolution.projectAuth).toBe(usableRow);
+    expect(resolution.isAmbiguous).toBe(false);
+    expect(
+      resolution.candidateProjectIds.map((candidate: ObjectID) => {
+        return candidate.toString();
+      }),
+    ).toEqual([projectId.toString()]);
+  });
+
+  test("the usable row wins regardless of which position it is in", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+    const usableRow: WorkspaceProjectAuthToken = buildProjectAuthRow({
+      projectId: projectId,
+    });
+    mockFindBy([
+      usableRow,
+      buildProjectAuthRow({ projectId: null }),
+      buildProjectAuthRow({ projectId: undefined }),
+    ]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    expect(resolution.projectAuth).toBe(usableRow);
+    expect(resolution.isAmbiguous).toBe(false);
+  });
+
+  test("only projectId-less rows count as not found even when there are several", async () => {
+    mockFindBy([
+      buildProjectAuthRow({ projectId: undefined }),
+      buildProjectAuthRow({ projectId: null }),
+    ]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    expect(resolution.projectAuth).toBeNull();
+    expect(resolution.isAmbiguous).toBe(false);
+    expect(resolution.candidateProjectIds).toEqual([]);
+  });
+
+  test("two usable rows plus an unusable one are still ambiguous with two candidates", async () => {
+    const projectIdOne: ObjectID = ObjectID.generate();
+    const projectIdTwo: ObjectID = ObjectID.generate();
+    mockFindBy([
+      buildProjectAuthRow({ projectId: projectIdOne }),
+      buildProjectAuthRow({ projectId: undefined }),
+      buildProjectAuthRow({ projectId: projectIdTwo }),
+    ]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: TENANT_ID,
+      });
+
+    expect(resolution.projectAuth).toBeNull();
+    expect(resolution.isAmbiguous).toBe(true);
+    expect(
+      resolution.candidateProjectIds.map((candidate: ObjectID) => {
+        return candidate.toString();
+      }),
+    ).toEqual([projectIdOne.toString(), projectIdTwo.toString()]);
+  });
+});
+
+describe("MicrosoftTeamsUtil.resolveProjectByTenantId - the query it issues", () => {
+  test("queries MicrosoftTeams rows whose workspaceProjectId is the tenant id, as root", async () => {
+    const findBySpy: jest.SpyInstance = mockFindBy([]);
+
+    await MicrosoftTeamsUtil.resolveProjectByTenantId({
+      tenantId: "tenant-under-test",
+    });
+
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+    const call: CapturedFindByCall = findBySpy.mock
+      .calls[0]?.[0] as CapturedFindByCall;
+    expect(call.query).toEqual({
+      workspaceType: WorkspaceType.MicrosoftTeams,
+      workspaceProjectId: "tenant-under-test",
+    });
+    expect(call.props).toEqual({ isRoot: true });
+  });
+
+  test("reads with LIMIT_MAX from offset 0 so a second connected project cannot hide behind the page size", async () => {
+    const findBySpy: jest.SpyInstance = mockFindBy([]);
+
+    await MicrosoftTeamsUtil.resolveProjectByTenantId({
+      tenantId: TENANT_ID,
+    });
+
+    const call: CapturedFindByCall = findBySpy.mock
+      .calls[0]?.[0] as CapturedFindByCall;
+    expect(call.limit).toBe(LIMIT_MAX);
+    expect(call.skip).toBe(0);
+  });
+
+  test("selects projectId so the caller can scope every downstream read", async () => {
+    const findBySpy: jest.SpyInstance = mockFindBy([]);
+
+    await MicrosoftTeamsUtil.resolveProjectByTenantId({
+      tenantId: TENANT_ID,
+    });
+
+    const call: CapturedFindByCall = findBySpy.mock
+      .calls[0]?.[0] as CapturedFindByCall;
+    expect(call.select["projectId"]).toBe(true);
+  });
+
+  test("uses findBy and NEVER findOneBy (findOneBy silently picked one of several projects)", async () => {
+    const findBySpy: jest.SpyInstance = mockFindBy([
+      buildProjectAuthRow(),
+      buildProjectAuthRow(),
+    ]);
+    const findOneBySpy: jest.SpyInstance = spyOnFindOneBy();
+
+    await MicrosoftTeamsUtil.resolveProjectByTenantId({
+      tenantId: TENANT_ID,
+    });
+
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+    expect(findOneBySpy).not.toHaveBeenCalled();
+  });
+
+  test("an empty tenant id is still queried literally (no accidental match-all)", async () => {
+    const findBySpy: jest.SpyInstance = mockFindBy([]);
+
+    const resolution: MicrosoftTeamsTenantResolution =
+      await MicrosoftTeamsUtil.resolveProjectByTenantId({
+        tenantId: "",
+      });
+
+    const call: CapturedFindByCall = findBySpy.mock
+      .calls[0]?.[0] as CapturedFindByCall;
+    expect(call.query["workspaceProjectId"]).toBe("");
+    expect(resolution.projectAuth).toBeNull();
+  });
+
+  test("a rejected findBy propagates instead of resolving to some project", async () => {
+    jest
+      .spyOn(WorkspaceProjectAuthTokenService, "findBy")
+      .mockRejectedValue(new Error("db is down") as never);
+
+    await expect(
+      MicrosoftTeamsUtil.resolveProjectByTenantId({ tenantId: TENANT_ID }),
+    ).rejects.toThrow("db is down");
+  });
+});
+
+describe("MicrosoftTeamsUtil.getTenantResolutionFailureMessage", () => {
+  function ambiguousResolution(): MicrosoftTeamsTenantResolution {
+    return {
+      projectAuth: null,
+      isAmbiguous: true,
+      candidateProjectIds: [ObjectID.generate(), ObjectID.generate()],
+    };
+  }
+
+  function notFoundResolution(): MicrosoftTeamsTenantResolution {
+    return {
+      projectAuth: null,
+      isAmbiguous: false,
+      candidateProjectIds: [],
+    };
+  }
+
+  test("the ambiguous and not-found cases produce different messages", () => {
+    const ambiguousMessage: string =
+      MicrosoftTeamsUtil.getTenantResolutionFailureMessage(
+        ambiguousResolution(),
+      );
+    const notFoundMessage: string =
+      MicrosoftTeamsUtil.getTenantResolutionFailureMessage(
+        notFoundResolution(),
+      );
+
+    expect(ambiguousMessage).not.toBe(notFoundMessage);
+  });
+
+  test("the ambiguous message says the organization is connected to more than one project", () => {
+    const message: string =
+      MicrosoftTeamsUtil.getTenantResolutionFailureMessage(
+        ambiguousResolution(),
+      );
+
+    expect(message).toContain(AMBIGUOUS_FRAGMENT);
+  });
+
+  test("the not-found message does not claim ambiguity", () => {
+    const message: string =
+      MicrosoftTeamsUtil.getTenantResolutionFailureMessage(
+        notFoundResolution(),
+      );
+
+    expect(message).toContain(NOT_FOUND_FRAGMENT);
+    expect(message).not.toContain(AMBIGUOUS_FRAGMENT);
+  });
+
+  test("neither message leaks project ids to the Teams user", () => {
+    const candidateProjectId: ObjectID = ObjectID.generate();
+    const message: string =
+      MicrosoftTeamsUtil.getTenantResolutionFailureMessage({
+        projectAuth: null,
+        isAmbiguous: true,
+        candidateProjectIds: [candidateProjectId],
+      });
+
+    expect(message).not.toContain(candidateProjectId.toString());
+  });
+});
+
+describe("MicrosoftTeamsUtil.handleBotMessageActivity - tenant resolution", () => {
+  beforeEach(() => {
+    stubChatCapture();
+  });
+
+  test("a tenant that maps to exactly one project proceeds and sends no failure message", async () => {
+    mockFindBy([buildProjectAuthRow()]);
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity(),
+      turnContext: context.turnContext,
+    });
+
+    const sent: string = joinedSentText(context.sendActivity);
+    expect(sent).toContain(HELP_FRAGMENT);
+    expect(sent).not.toContain(AMBIGUOUS_FRAGMENT);
+    expect(sent).not.toContain(NOT_FOUND_FRAGMENT);
+  });
+
+  test("a tenant with no rows replies with the not-found message and does not answer the command", async () => {
+    mockFindBy([]);
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity(),
+      turnContext: context.turnContext,
+    });
+
+    expect(context.sendActivity).toHaveBeenCalledTimes(1);
+    const sent: string = joinedSentText(context.sendActivity);
+    expect(sent).toContain(NOT_FOUND_FRAGMENT);
+    expect(sent).not.toContain(HELP_FRAGMENT);
+  });
+
+  test("a tenant connected to two projects replies with the AMBIGUOUS message and serves nothing", async () => {
+    mockFindBy([buildProjectAuthRow(), buildProjectAuthRow()]);
+    const findOneBySpy: jest.SpyInstance = spyOnFindOneBy();
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity(),
+      turnContext: context.turnContext,
+    });
+
+    expect(context.sendActivity).toHaveBeenCalledTimes(1);
+    const sent: string = joinedSentText(context.sendActivity);
+    expect(sent).toContain(AMBIGUOUS_FRAGMENT);
+    // Refusing must not look like "not connected" - the remedies differ.
+    expect(sent).not.toContain(NOT_FOUND_FRAGMENT);
+    // ...and the user must not get the other project's answer.
+    expect(sent).not.toContain(HELP_FRAGMENT);
+    expect(findOneBySpy).not.toHaveBeenCalled();
+  });
+
+  test("a tenant whose only row has no projectId replies with the not-found message", async () => {
+    mockFindBy([buildProjectAuthRow({ projectId: undefined })]);
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity(),
+      turnContext: context.turnContext,
+    });
+
+    const sent: string = joinedSentText(context.sendActivity);
+    expect(sent).toContain(NOT_FOUND_FRAGMENT);
+    expect(sent).not.toContain(HELP_FRAGMENT);
+  });
+
+  test("the tenant id from channelData is the one resolved", async () => {
+    const resolveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "resolveProjectByTenantId")
+      .mockResolvedValue({
+        projectAuth: buildProjectAuthRow(),
+        isAmbiguous: false,
+        candidateProjectIds: [ObjectID.generate()],
+      });
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity({ tenantId: "tenant-from-activity" }),
+      turnContext: context.turnContext,
+    });
+
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    expect(resolveSpy).toHaveBeenCalledWith({
+      tenantId: "tenant-from-activity",
+    });
+  });
+
+  test("a missing channelData.tenant.id replies about the organization and never resolves a tenant", async () => {
+    const resolveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "resolveProjectByTenantId")
+      .mockResolvedValue({
+        projectAuth: buildProjectAuthRow(),
+        isAmbiguous: false,
+        candidateProjectIds: [ObjectID.generate()],
+      });
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity({ omitTenant: true }),
+      turnContext: context.turnContext,
+    });
+
+    expect(resolveSpy).not.toHaveBeenCalled();
+    expect(context.sendActivity).toHaveBeenCalledTimes(1);
+    expect(joinedSentText(context.sendActivity)).toContain(NO_TENANT_FRAGMENT);
+  });
+});
+
+/*
+ * This is the disclosure vector itself.
+ *
+ * handleBotMessageActivity serves incidents, alerts, scheduled maintenance and
+ * AI assistant answers with NO per-user authorization at all - whoever is in
+ * the tenant gets whatever project the handler picked. So the project id it
+ * hands the downstream readers IS the entire access-control decision, and it
+ * must be exactly the projectId of the row resolveProjectByTenantId returned.
+ *
+ * Resolving the right tenant and then reading a different project's data would
+ * satisfy every other test in this file, which is why each reader is asserted
+ * on its own argument here.
+ */
+describe("MicrosoftTeamsUtil.handleBotMessageActivity - the resolved project scopes every downstream read", () => {
+  beforeEach(() => {
+    stubChatCapture();
+  });
+
+  test('"show active incidents" reads incidents for the RESOLVED project', async () => {
+    const projectAuth: WorkspaceProjectAuthToken = buildProjectAuthRow({
+      projectId: ObjectID.generate(),
+    });
+    mockFindBy([projectAuth]);
+    const readerSpy: jest.SpyInstance = stubDownstreamReader(
+      "getActiveIncidentsMessage",
+      "incidents-of-the-resolved-project",
+    );
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity({ text: "show active incidents" }),
+      turnContext: context.turnContext,
+    });
+
+    expect(readerSpy).toHaveBeenCalledTimes(1);
+    expect(firstArgProjectId(readerSpy).toString()).toBe(
+      projectAuth.projectId?.toString(),
+    );
+    // ...and the answer that came back is what the user was actually served.
+    expect(joinedSentText(context.sendActivity)).toContain(
+      "incidents-of-the-resolved-project",
+    );
+  });
+
+  test('"show active alerts" reads alerts for the RESOLVED project', async () => {
+    const projectAuth: WorkspaceProjectAuthToken = buildProjectAuthRow({
+      projectId: ObjectID.generate(),
+    });
+    mockFindBy([projectAuth]);
+    const readerSpy: jest.SpyInstance = stubDownstreamReader(
+      "getActiveAlertsMessage",
+      "alerts-of-the-resolved-project",
+    );
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity({ text: "show active alerts" }),
+      turnContext: context.turnContext,
+    });
+
+    expect(readerSpy).toHaveBeenCalledTimes(1);
+    expect(firstArgProjectId(readerSpy).toString()).toBe(
+      projectAuth.projectId?.toString(),
+    );
+    expect(joinedSentText(context.sendActivity)).toContain(
+      "alerts-of-the-resolved-project",
+    );
+  });
+
+  test('"show scheduled maintenance" reads maintenance for the RESOLVED project', async () => {
+    const projectAuth: WorkspaceProjectAuthToken = buildProjectAuthRow({
+      projectId: ObjectID.generate(),
+    });
+    mockFindBy([projectAuth]);
+    const readerSpy: jest.SpyInstance = stubDownstreamReader(
+      "getScheduledMaintenanceMessage",
+      "maintenance-of-the-resolved-project",
+    );
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity({ text: "show scheduled maintenance" }),
+      turnContext: context.turnContext,
+    });
+
+    expect(readerSpy).toHaveBeenCalledTimes(1);
+    expect(firstArgProjectId(readerSpy).toString()).toBe(
+      projectAuth.projectId?.toString(),
+    );
+    expect(joinedSentText(context.sendActivity)).toContain(
+      "maintenance-of-the-resolved-project",
+    );
+  });
+
+  test("a free-form question asks the AI assistant about the RESOLVED project", async () => {
+    const question: string = "why did checkout latency spike last night";
+    const projectAuth: WorkspaceProjectAuthToken = buildProjectAuthRow({
+      projectId: ObjectID.generate(),
+    });
+    mockFindBy([projectAuth]);
+    const answerSpy: jest.SpyInstance = stubDownstreamReader(
+      "answerObservabilityQuestion",
+    );
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity({ text: question }),
+      turnContext: context.turnContext,
+    });
+
+    expect(answerSpy).toHaveBeenCalledTimes(1);
+    const answerArgs: { projectId: ObjectID; question: string } = answerSpy.mock
+      .calls[0]?.[0] as { projectId: ObjectID; question: string };
+    expect(answerArgs.projectId.toString()).toBe(
+      projectAuth.projectId?.toString(),
+    );
+    expect(answerArgs.question).toBe(question);
+  });
+
+  test("an AMBIGUOUS tenant reaches NONE of the readers", async () => {
+    mockFindBy([buildProjectAuthRow(), buildProjectAuthRow()]);
+    const incidentsSpy: jest.SpyInstance = stubDownstreamReader(
+      "getActiveIncidentsMessage",
+      "incidents",
+    );
+    const alertsSpy: jest.SpyInstance = stubDownstreamReader(
+      "getActiveAlertsMessage",
+      "alerts",
+    );
+    const maintenanceSpy: jest.SpyInstance = stubDownstreamReader(
+      "getScheduledMaintenanceMessage",
+      "maintenance",
+    );
+    const answerSpy: jest.SpyInstance = stubDownstreamReader(
+      "answerObservabilityQuestion",
+    );
+
+    const commands: Array<string> = [
+      "show active incidents",
+      "show active alerts",
+      "show scheduled maintenance",
+      "why did checkout latency spike last night",
+    ];
+
+    for (const text of commands) {
+      const context: FakeTurnContext = buildTurnContext();
+
+      await MicrosoftTeamsUtil.handleBotMessageActivity({
+        activity: messageActivity({ text: text }),
+        turnContext: context.turnContext,
+      });
+
+      expect(joinedSentText(context.sendActivity)).toContain(
+        AMBIGUOUS_FRAGMENT,
+      );
+    }
+
+    // Refusing has to stop the read, not just change the reply.
+    expect(incidentsSpy).not.toHaveBeenCalled();
+    expect(alertsSpy).not.toHaveBeenCalled();
+    expect(maintenanceSpy).not.toHaveBeenCalled();
+    expect(answerSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("MicrosoftTeamsUtil.handleBotInvokeActivity - tenant resolution", () => {
+  test("the resolved project id is what the card click is authorized against", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+    mockFindBy([buildProjectAuthRow({ projectId: projectId })]);
+    const userLookupSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsAuthAction, "getOneUptimeUserIdFromTeamsUserId")
+      .mockResolvedValue(ObjectID.generate());
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotInvokeActivity({
+      activity: invokeActivity(),
+      turnContext: context.turnContext,
+    });
+
+    expect(userLookupSpy).toHaveBeenCalledTimes(1);
+    const lookupArgs: { teamsUserId: string; projectId: ObjectID } =
+      userLookupSpy.mock.calls[0]?.[0] as {
+        teamsUserId: string;
+        projectId: ObjectID;
+      };
+    expect(lookupArgs.teamsUserId).toBe(AAD_OBJECT_ID);
+    expect(lookupArgs.projectId.toString()).toBe(projectId.toString());
+  });
+
+  test("a tenant with no rows replies with the not-found message and never looks the user up", async () => {
+    mockFindBy([]);
+    const userLookupSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsAuthAction, "getOneUptimeUserIdFromTeamsUserId")
+      .mockResolvedValue(ObjectID.generate());
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotInvokeActivity({
+      activity: invokeActivity(),
+      turnContext: context.turnContext,
+    });
+
+    expect(context.sendActivity).toHaveBeenCalledTimes(1);
+    expect(joinedSentText(context.sendActivity)).toContain(NOT_FOUND_FRAGMENT);
+    expect(userLookupSpy).not.toHaveBeenCalled();
+  });
+
+  test("a tenant connected to two projects replies with the AMBIGUOUS message and never resolves a project", async () => {
+    mockFindBy([buildProjectAuthRow(), buildProjectAuthRow()]);
+    const findOneBySpy: jest.SpyInstance = spyOnFindOneBy();
+    const userLookupSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsAuthAction, "getOneUptimeUserIdFromTeamsUserId")
+      .mockResolvedValue(ObjectID.generate());
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotInvokeActivity({
+      activity: invokeActivity(),
+      turnContext: context.turnContext,
+    });
+
+    expect(context.sendActivity).toHaveBeenCalledTimes(1);
+    const sent: string = joinedSentText(context.sendActivity);
+    expect(sent).toContain(AMBIGUOUS_FRAGMENT);
+    expect(sent).not.toContain(NOT_FOUND_FRAGMENT);
+    expect(userLookupSpy).not.toHaveBeenCalled();
+    expect(findOneBySpy).not.toHaveBeenCalled();
+  });
+
+  test("a tenant whose only row has no projectId replies with the not-found message", async () => {
+    mockFindBy([buildProjectAuthRow({ projectId: null })]);
+    const userLookupSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsAuthAction, "getOneUptimeUserIdFromTeamsUserId")
+      .mockResolvedValue(ObjectID.generate());
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotInvokeActivity({
+      activity: invokeActivity(),
+      turnContext: context.turnContext,
+    });
+
+    expect(joinedSentText(context.sendActivity)).toContain(NOT_FOUND_FRAGMENT);
+    expect(userLookupSpy).not.toHaveBeenCalled();
+  });
+
+  test("the tenant id from channelData is the one resolved", async () => {
+    const resolveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "resolveProjectByTenantId")
+      .mockResolvedValue({
+        projectAuth: buildProjectAuthRow(),
+        isAmbiguous: false,
+        candidateProjectIds: [ObjectID.generate()],
+      });
+    jest
+      .spyOn(MicrosoftTeamsAuthAction, "getOneUptimeUserIdFromTeamsUserId")
+      .mockResolvedValue(ObjectID.generate());
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotInvokeActivity({
+      activity: invokeActivity({ tenantId: "tenant-from-invoke" }),
+      turnContext: context.turnContext,
+    });
+
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    expect(resolveSpy).toHaveBeenCalledWith({ tenantId: "tenant-from-invoke" });
+  });
+
+  test("a missing channelData.tenant.id replies about the organization and never resolves a tenant", async () => {
+    const resolveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "resolveProjectByTenantId")
+      .mockResolvedValue({
+        projectAuth: buildProjectAuthRow(),
+        isAmbiguous: false,
+        candidateProjectIds: [ObjectID.generate()],
+      });
+    const userLookupSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsAuthAction, "getOneUptimeUserIdFromTeamsUserId")
+      .mockResolvedValue(ObjectID.generate());
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotInvokeActivity({
+      activity: invokeActivity({ omitTenant: true }),
+      turnContext: context.turnContext,
+    });
+
+    expect(resolveSpy).not.toHaveBeenCalled();
+    expect(userLookupSpy).not.toHaveBeenCalled();
+    expect(context.sendActivity).toHaveBeenCalledTimes(1);
+    expect(joinedSentText(context.sendActivity)).toContain(NO_TENANT_FRAGMENT);
+  });
+
+  test("an empty channelData.tenant object is treated as a missing tenant id", async () => {
+    const resolveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "resolveProjectByTenantId")
+      .mockResolvedValue({
+        projectAuth: buildProjectAuthRow(),
+        isAmbiguous: false,
+        candidateProjectIds: [ObjectID.generate()],
+      });
+    const activity: JSONObject = invokeActivity();
+    (activity["channelData"] as JSONObject)["tenant"] = {};
+    const context: FakeTurnContext = buildTurnContext();
+
+    await MicrosoftTeamsUtil.handleBotInvokeActivity({
+      activity: activity,
+      turnContext: context.turnContext,
+    });
+
+    expect(resolveSpy).not.toHaveBeenCalled();
+    expect(joinedSentText(context.sendActivity)).toContain(NO_TENANT_FRAGMENT);
+  });
+});
+
+describe("MicrosoftTeamsUtil bot entry points - both go through resolveProjectByTenantId", () => {
+  test("the message path and the invoke path give the SAME ambiguous refusal", async () => {
+    mockFindBy([buildProjectAuthRow(), buildProjectAuthRow()]);
+    stubChatCapture();
+    jest
+      .spyOn(MicrosoftTeamsAuthAction, "getOneUptimeUserIdFromTeamsUserId")
+      .mockResolvedValue(ObjectID.generate());
+
+    const messageContext: FakeTurnContext = buildTurnContext();
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity(),
+      turnContext: messageContext.turnContext,
+    });
+
+    const invokeContext: FakeTurnContext = buildTurnContext();
+    await MicrosoftTeamsUtil.handleBotInvokeActivity({
+      activity: invokeActivity(),
+      turnContext: invokeContext.turnContext,
+    });
+
+    expect(joinedSentText(messageContext.sendActivity)).toBe(
+      joinedSentText(invokeContext.sendActivity),
+    );
+    expect(joinedSentText(invokeContext.sendActivity)).toContain(
+      AMBIGUOUS_FRAGMENT,
+    );
+  });
+
+  test("the message path and the invoke path give the SAME not-found refusal", async () => {
+    mockFindBy([]);
+    stubChatCapture();
+
+    const messageContext: FakeTurnContext = buildTurnContext();
+    await MicrosoftTeamsUtil.handleBotMessageActivity({
+      activity: messageActivity(),
+      turnContext: messageContext.turnContext,
+    });
+
+    const invokeContext: FakeTurnContext = buildTurnContext();
+    await MicrosoftTeamsUtil.handleBotInvokeActivity({
+      activity: invokeActivity(),
+      turnContext: invokeContext.turnContext,
+    });
+
+    expect(joinedSentText(messageContext.sendActivity)).toBe(
+      joinedSentText(invokeContext.sendActivity),
+    );
+    expect(joinedSentText(invokeContext.sendActivity)).toContain(
+      NOT_FOUND_FRAGMENT,
+    );
+  });
+});


### PR DESCRIPTION
Fixes two failures reported by a self-hosted customer, and the gaps behind them.

## `The bot is not part of the conversation roster`

Channels are discovered with tenant-wide Graph **application** permissions, which see every team in the tenant. Delivery goes through Bot Framework **proactive messaging**, which only accepts a post into a team the app is installed in. Nothing anywhere checked installation (`grep` for `installedApps` / `teamsAppInstallation` returned zero hits), so a channel could be selected, pass the `doesChannelExist` preflight, and only fail at send — with Microsoft's wording passed through raw to the admin.

- **Record team installs.** `conversationUpdate` / `installationUpdate` activities for a channel conversation were routed into `captureChatFromBotActivity`, which returns early for anything that is not a chat — so the only signal that a proactive post will be accepted was thrown away. They now also go to `captureTeamFromBotActivity`, persisting to `miscData.installedTeams` along with the per-install `serviceUrl` that GCC/DoD tenants need (the chat path already did this). An `@mention` in any channel backfills teams installed before this shipped, since a manifest version bump fires no new install event.
- **Preflight the send** against `installedTeams` — but only once at least one install has been observed, so workspaces connected before this keep working and fall through to the translation below.
- **Translate the roster error** into the action that fixes it, naming the team. Private channels get their own instructions, since a parent-team install does not cover them.
- **Shared channels** are filtered out of the picker and refused explicitly — Teams does not support bots in them at all.

## `Sorry, I couldn't find your project configuration`

The bot resolved a project from the tenant id with a bare `findOneBy` — no `projectId` in the query, no unique constraint on `workspaceProjectId`, falling back to `createdAt DESC`. One tenant connected to two projects meant the bot silently served whichever row sorted first.

The message path performs **no per-user authorization** (only the card-click path calls `getOneUptimeUserIdFromTeamsUserId`), so picking arbitrarily disclosed one project's incidents, alerts and AI assistant answers to anyone in the tenant.

- `resolveProjectByTenantId` loads every match, de-duplicates by project, and **refuses when more than one distinct project claims the tenant** rather than guessing. Not-found and ambiguous get different user-facing messages, since the remedies differ.
- `refreshAuthToken` refuses to repoint a project at a different workspace instead of silently overwriting it. That overwrite used to orphan every notification rule and captured conversation with no error and nothing in the logs. Verified all three `refreshAuthToken` callers pass the stored `workspaceProjectId`, so the guard cannot fire on the token-refresh path.

## Also

- **Test-rule failures are written to Notification Logs.** They threw before reaching any logging, so the one action an admin takes to diagnose a broken integration was also the only one that recorded nothing.
- **An unresolvable channel name was a silent `logger.warn`**, so a typo'd or deleted channel reported success. Now a reported error, as is a failed channel-id lookup.
- **`availableTeams` was keyed by display name**, so teams sharing a name collapsed to one and only the last was selectable. Keyed by id now (both call sites; all consumers use `Object.values`).
- **Docs and in-product setup never mentioned adding the app to each team** — the step that would have prevented this entirely. The correct copy existed but sat inside a `BILLING_ENABLED &&` block, so self-hosted admins only ever saw the weaker version. Added the step, the private/shared channel caveats, troubleshooting for both errors, and corrected the multitenant app-registration guidance, which contradicts the `SingleTenant` bot adapter we hardcode.

## Compatibility

No migration. `installedTeams` is additive on `miscData`, and the preflight is inert until an install is observed, so existing workspaces are unaffected until they re-install or message the bot in a channel.

The one intentional behaviour change is the ambiguity refusal: a tenant genuinely connected to two projects now gets a clear error instead of arbitrary results. That is the disclosure being closed.

## Tests

325 passing across 8 suites (was 121). Four new suites:

| Suite | Tests | Covers |
| --- | --- | --- |
| `MicrosoftTeamsTenantResolution.test.ts` | 45 | resolution, de-dup, ambiguity, and that the resolved project scopes every downstream read |
| `MicrosoftTeamsTeamInstalls.test.ts` | 61 | install capture, fan-out isolation across rows, event wiring |
| `MicrosoftTeamsChannelSend.test.ts` | 56 | shared-channel refusal, preflight, serviceUrl, error translation, send reporting |
| `WorkspaceProjectAuthTokenRepoint.test.ts` | 20 | the repoint guard |

Each suite was reviewed adversarially and hardened afterwards: mocks now honour `select` so reverting either half of the repoint fix fails behavioural tests rather than one white-box assertion; fan-out fixtures are distinct per row so a hoisted-merge mutation is caught; and tests that could not fail were removed rather than left as coverage theatre.
