### PR TITLE
fix(status-page): stop detail pages from loading forever when the item is missing

### DIFF
--- a/App/FeatureSet/StatusPage/src/Pages/Announcement/Detail.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Announcement/Detail.tsx
@@ -235,10 +235,18 @@ const Overview: FunctionComponent<PageComponentProps> = (
       const rawAnnouncements: JSONArray =
         (data["announcements"] as JSONArray) || [];
 
-      const announcement: StatusPageAnnouncement = BaseModel.fromJSONObject(
-        (rawAnnouncements[0] as JSONObject) || {},
-        StatusPageAnnouncement,
-      );
+      /*
+       * An empty response means this announcement is not on this status page. Keep it
+       * null - deserializing an empty object here yields a model with no data, which
+       * renders as a blank announcement instead of the empty state below.
+       */
+      const announcement: StatusPageAnnouncement | null =
+        rawAnnouncements.length > 0
+          ? BaseModel.fromJSONObject(
+              rawAnnouncements[0] as JSONObject,
+              StatusPageAnnouncement,
+            )
+          : null;
 
       const statusPageResources: Array<StatusPageResource> =
         BaseModel.fromJSONArray(
@@ -298,7 +306,11 @@ const Overview: FunctionComponent<PageComponentProps> = (
     return <ErrorMessage message={error} />;
   }
 
-  if (!parsedData) {
+  /*
+   * Only wait on parsedData when there is an announcement to parse, so that a missing
+   * announcement falls through to the empty state below instead of loading forever.
+   */
+  if (announcement && !parsedData) {
     return <PageLoader isVisible={true} />;
   }
 
@@ -333,7 +345,7 @@ const Overview: FunctionComponent<PageComponentProps> = (
         },
       ]}
     >
-      {announcement ? <EventItem {...parsedData} /> : <></>}
+      {announcement && parsedData ? <EventItem {...parsedData} /> : <></>}
       {!announcement ? (
         <EmptyState
           id="announcement-empty-state"

--- a/App/FeatureSet/StatusPage/src/Pages/Incidents/Detail.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/Incidents/Detail.tsx
@@ -676,6 +676,15 @@ const Detail: FunctionComponent<PageComponentProps> = (
 
       // First try to fetch as an incident
       let foundIncident: boolean = false;
+      let foundEpisode: boolean = false;
+
+      /*
+       * The incident lookup is allowed to fail because this id may belong to an
+       * episode instead. Hold on to the failure so we can surface it if the episode
+       * fallback below does not find anything either.
+       */
+      let incidentLookupError: unknown = null;
+
       try {
         const response: HTTPResponse<JSONObject> = await API.post<JSONObject>({
           url: URL.fromString(STATUS_PAGE_API_URL.toString()).addRoute(
@@ -731,9 +740,12 @@ const Detail: FunctionComponent<PageComponentProps> = (
               setIncidentStateTimelines(incidentStateTimelines);
             }
           }
+        } else {
+          incidentLookupError = response;
         }
-      } catch {
+      } catch (err) {
         // Incident not found, will try episode
+        incidentLookupError = err;
       }
 
       // If not found as incident, try as episode
@@ -769,6 +781,7 @@ const Detail: FunctionComponent<PageComponentProps> = (
               }
 
               if (episode && episode.id) {
+                foundEpisode = true;
                 setIsEpisode(true);
 
                 const episodePublicNotes: Array<IncidentEpisodePublicNote> =
@@ -803,8 +816,16 @@ const Detail: FunctionComponent<PageComponentProps> = (
             }
           }
         } catch {
-          // Episode not found either
+          /*
+           * Episode not found either. This is only a fallback lookup - it fails on
+           * every status page that has episodes turned off - so surfacing its error
+           * would be misleading. The empty state below covers this case.
+           */
         }
+      }
+
+      if (!foundIncident && !foundEpisode && incidentLookupError) {
+        throw incidentLookupError;
       }
 
       setIsLoading(false);
@@ -861,14 +882,19 @@ const Detail: FunctionComponent<PageComponentProps> = (
     return <ErrorMessage message={error} />;
   }
 
-  if (!parsedData) {
-    return <PageLoader isVisible={true} />;
-  }
-
   const pageTitle: string = isEpisode
     ? t("episodes.report")
     : t("incidents.report");
   const hasItem: boolean = isEpisode ? Boolean(episode) : Boolean(incident);
+
+  /*
+   * Only wait on parsedData when there is something to parse. If neither lookup found
+   * anything then parsedData never gets set, so falling through to the empty state
+   * below is what keeps this page from loading forever.
+   */
+  if (hasItem && !parsedData) {
+    return <PageLoader isVisible={true} />;
+  }
 
   return (
     <Page
@@ -901,7 +927,7 @@ const Detail: FunctionComponent<PageComponentProps> = (
         },
       ]}
     >
-      {hasItem ? <EventItem {...parsedData} /> : <></>}
+      {hasItem && parsedData ? <EventItem {...parsedData} /> : <></>}
       {!hasItem ? (
         <EmptyState
           id="item-empty-state"

--- a/App/FeatureSet/StatusPage/src/Pages/ScheduledEvent/Detail.tsx
+++ b/App/FeatureSet/StatusPage/src/Pages/ScheduledEvent/Detail.tsx
@@ -385,14 +385,21 @@ const Overview: FunctionComponent<PageComponentProps> = (
           ScheduledMaintenancePublicNote,
         );
 
-      const rawAnnouncements: JSONArray =
+      const rawScheduledMaintenanceEvents: JSONArray =
         (data["scheduledMaintenanceEvents"] as JSONArray) || [];
 
-      const scheduledMaintenanceEvent: ScheduledMaintenance =
-        BaseModel.fromJSONObject(
-          (rawAnnouncements[0] as JSONObject) || {},
-          ScheduledMaintenance,
-        );
+      /*
+       * An empty response means this event is not on this status page. Keep it null -
+       * deserializing an empty object here yields a model with no data, which renders
+       * as a blank event instead of the empty state below.
+       */
+      const scheduledMaintenanceEvent: ScheduledMaintenance | null =
+        rawScheduledMaintenanceEvents.length > 0
+          ? BaseModel.fromJSONObject(
+              rawScheduledMaintenanceEvents[0] as JSONObject,
+              ScheduledMaintenance,
+            )
+          : null;
       const scheduledMaintenanceStateTimelines: Array<ScheduledMaintenanceStateTimeline> =
         BaseModel.fromJSONArray(
           (data["scheduledMaintenanceStateTimelines"] as JSONArray) || [],
@@ -463,7 +470,11 @@ const Overview: FunctionComponent<PageComponentProps> = (
     return <ErrorMessage message={error} />;
   }
 
-  if (!parsedData) {
+  /*
+   * Only wait on parsedData when there is an event to parse, so that a missing event
+   * falls through to the empty state below instead of loading forever.
+   */
+  if (scheduledMaintenanceEvent && !parsedData) {
     return <PageLoader isVisible={true} />;
   }
 
@@ -498,7 +509,11 @@ const Overview: FunctionComponent<PageComponentProps> = (
         },
       ]}
     >
-      {scheduledMaintenanceEvent ? <EventItem {...parsedData} /> : <></>}
+      {scheduledMaintenanceEvent && parsedData ? (
+        <EventItem {...parsedData} />
+      ) : (
+        <></>
+      )}
       {!scheduledMaintenanceEvent ? (
         <EmptyState
           id="scheduled-event-empty-state"

--- a/Common/Tests/App/StatusPage/StatusPageDetailPagesNotFound.test.tsx
+++ b/Common/Tests/App/StatusPage/StatusPageDetailPagesNotFound.test.tsx
@@ -1,0 +1,308 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import React, { act } from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import AnnouncementDetail from "../../../../App/FeatureSet/StatusPage/src/Pages/Announcement/Detail";
+import IncidentDetail from "../../../../App/FeatureSet/StatusPage/src/Pages/Incidents/Detail";
+import ScheduledEventDetail from "../../../../App/FeatureSet/StatusPage/src/Pages/ScheduledEvent/Detail";
+import Route from "../../../Types/API/Route";
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import LocalStorage from "../../../UI/Utils/LocalStorage";
+import Navigation from "../../../UI/Utils/Navigation";
+
+const STATUS_PAGE_ID: string = "33333333-3333-4333-8333-333333333333";
+const ITEM_ID: string = "44444444-4444-4444-8444-444444444444";
+
+type PostResponse = HTTPResponse<JSONObject> | HTTPErrorResponse;
+type RespondToPostFunction = (url: string) => PostResponse;
+
+/*
+ * Each test swaps this out to describe what the status page API returns for the
+ * request the page under test makes.
+ */
+let mockRespondToPost: RespondToPostFunction = (): PostResponse => {
+  throw new Error("mockRespondToPost was not set by the test");
+};
+
+let mockLogoutCallCount: number = 0;
+
+// Logging out hits the network and navigates, neither of which belongs in this test.
+jest.mock("../../../../App/FeatureSet/StatusPage/src/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isLoggedIn: () => {
+        return true;
+      },
+      logout: () => {
+        mockLogoutCallCount++;
+        return Promise.resolve();
+      },
+    },
+  };
+});
+
+jest.mock("../../../../App/FeatureSet/StatusPage/src/Utils/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      post: (options: { url: { toString: () => string } }) => {
+        return Promise.resolve(mockRespondToPost(options.url.toString()));
+      },
+      getDefaultHeaders: () => {
+        return {};
+      },
+      getFriendlyMessage: (error: { message?: string }) => {
+        return error?.message || "Something went wrong";
+      },
+    },
+  };
+});
+
+/*
+ * The real page chrome renders breadcrumb links, which need a router. None of
+ * these tests are about the chrome, so keep it to a plain wrapper.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/StatusPage/src/Components/Page/Page",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: { children: React.ReactNode }) => {
+        return <div>{props.children}</div>;
+      },
+    };
+  },
+);
+
+type SuccessResponseFunction = (data: JSONObject) => HTTPResponse<JSONObject>;
+
+const successResponse: SuccessResponseFunction = (
+  data: JSONObject,
+): HTTPResponse<JSONObject> => {
+  return new HTTPResponse<JSONObject>(200, data, {});
+};
+
+type ErrorResponseFunction = (
+  statusCode: number,
+  message: string,
+) => HTTPErrorResponse;
+
+const errorResponse: ErrorResponseFunction = (
+  statusCode: number,
+  message: string,
+): HTTPErrorResponse => {
+  return new HTTPErrorResponse(statusCode, { message: message }, {});
+};
+
+type PageComponent = React.FunctionComponent<{
+  pageRoute: Route;
+  onLoadComplete: () => void;
+}>;
+
+type RenderPageFunction = (
+  Component: PageComponent,
+) => Promise<ReturnType<typeof render>>;
+
+/*
+ * These pages load themselves from an effect, so the render has to be flushed
+ * inside act() for the resulting state updates to be settled.
+ */
+const renderPage: RenderPageFunction = async (
+  Component: PageComponent,
+): Promise<ReturnType<typeof render>> => {
+  let result: ReturnType<typeof render> | null = null;
+
+  await act(async () => {
+    result = render(
+      <Component
+        pageRoute={new Route(`/incidents/${ITEM_ID}`)}
+        onLoadComplete={() => {}}
+      />,
+    );
+  });
+
+  return result!;
+};
+
+describe("Status page detail pages when the item is not available", () => {
+  const navigate: typeof Navigation.navigate = Navigation.navigate;
+
+  beforeEach(() => {
+    mockLogoutCallCount = 0;
+    localStorage.clear();
+    LocalStorage.setItem("statusPageId", new ObjectID(STATUS_PAGE_ID));
+    window.history.replaceState({}, "", `/incidents/${ITEM_ID}`);
+
+    // jsdom cannot leave the page, and it logs a noisy error when asked to.
+    Navigation.navigate = (): void => {};
+  });
+
+  afterEach(() => {
+    Navigation.navigate = navigate;
+    jest.clearAllMocks();
+  });
+
+  test("incident page shows the empty state when neither an incident nor an episode is found", async () => {
+    /*
+     * This is the production case that hung the page: the incident exists but has
+     * no monitors on this status page, so the API filters it out and returns an
+     * empty list with a 200.
+     */
+    mockRespondToPost = (url: string): PostResponse => {
+      if (url.includes("/incidents/")) {
+        return successResponse({
+          incidents: [],
+          incidentPublicNotes: [],
+          incidentStateTimelines: [],
+          statusPageResources: [],
+          monitorsInGroup: {},
+        });
+      }
+
+      // Most status pages have episodes turned off, so the fallback lookup fails.
+      return errorResponse(
+        400,
+        "Episodes are not enabled on this status page.",
+      );
+    };
+
+    const { container } = await renderPage(IncidentDetail);
+
+    await waitFor(() => {
+      expect(container.querySelector("#item-empty-state")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Incident not found on this status page."),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("bar-loader")).not.toBeInTheDocument();
+
+    // The episode fallback's error is an implementation detail. It must not leak.
+    expect(
+      screen.queryByText("Episodes are not enabled on this status page."),
+    ).not.toBeInTheDocument();
+  });
+
+  test("incident page surfaces the error when the incident lookup itself fails", async () => {
+    mockRespondToPost = (): PostResponse => {
+      return errorResponse(403, "This status page is not public.");
+    };
+
+    const { container } = await renderPage(IncidentDetail);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("This status page is not public."),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      container.querySelector("#item-empty-state"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("bar-loader")).not.toBeInTheDocument();
+  });
+
+  test("incident page logs the user out when the lookup comes back unauthorized", async () => {
+    // An expired session has to reach the auth check rather than read as "not found".
+    mockRespondToPost = (): PostResponse => {
+      return errorResponse(401, "Not authorized.");
+    };
+
+    await renderPage(IncidentDetail);
+
+    await waitFor(() => {
+      expect(mockLogoutCallCount).toBeGreaterThan(0);
+    });
+  });
+
+  test("incident page still renders the incident when one is found", async () => {
+    mockRespondToPost = (url: string): PostResponse => {
+      if (url.includes("/incidents/")) {
+        return successResponse({
+          incidents: [
+            {
+              _id: ITEM_ID,
+              title: "Checkout is degraded",
+            },
+          ],
+          incidentPublicNotes: [],
+          incidentStateTimelines: [],
+          statusPageResources: [],
+          monitorsInGroup: {},
+        });
+      }
+
+      throw new Error("The episode fallback should not be reached");
+    };
+
+    const { container } = await renderPage(IncidentDetail);
+
+    await waitFor(() => {
+      expect(screen.getByText("Checkout is degraded")).toBeInTheDocument();
+    });
+
+    expect(
+      container.querySelector("#item-empty-state"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("bar-loader")).not.toBeInTheDocument();
+  });
+
+  test("scheduled maintenance page shows the empty state when the event is not found", async () => {
+    mockRespondToPost = (): PostResponse => {
+      return successResponse({
+        scheduledMaintenanceEvents: [],
+        scheduledMaintenanceEventsPublicNotes: [],
+        scheduledMaintenanceStateTimelines: [],
+        statusPageResources: [],
+        monitorsInGroup: {},
+      });
+    };
+
+    const { container } = await renderPage(ScheduledEventDetail);
+
+    await waitFor(() => {
+      expect(
+        container.querySelector("#scheduled-event-empty-state"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("No scheduled event found for this status page."),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("bar-loader")).not.toBeInTheDocument();
+  });
+
+  test("announcement page shows the empty state when the announcement is not found", async () => {
+    mockRespondToPost = (): PostResponse => {
+      return successResponse({
+        announcements: [],
+        statusPageResources: [],
+        monitorsInGroup: {},
+      });
+    };
+
+    const { container } = await renderPage(AnnouncementDetail);
+
+    await waitFor(() => {
+      expect(
+        container.querySelector("#announcement-empty-state"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Announcement not found on this status page."),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("bar-loader")).not.toBeInTheDocument();
+  });
+});

--- a/Common/Tests/__mocks__/i18next-browser-languagedetector.js
+++ b/Common/Tests/__mocks__/i18next-browser-languagedetector.js
@@ -1,0 +1,21 @@
+"use strict";
+
+/*
+ * The real detector is only installed in the frontend feature sets. Tests that
+ * render status page components import Utils/i18n, which registers this plugin,
+ * so a minimal stand-in that always resolves to English is enough.
+ */
+class LanguageDetector {
+  init() {}
+
+  detect() {
+    return "en";
+  }
+
+  cacheUserLanguage() {}
+}
+
+LanguageDetector.type = "languageDetector";
+
+module.exports = LanguageDetector;
+module.exports.default = LanguageDetector;

--- a/Common/jest.config.json
+++ b/Common/jest.config.json
@@ -28,6 +28,7 @@
     "^react-dom/(.*)$": "<rootDir>/node_modules/react-dom/$1",
     "^react-router-dom$": "<rootDir>/node_modules/react-router-dom",
     "^react-i18next$": "<rootDir>/node_modules/react-i18next",
+    "^i18next-browser-languagedetector$": "<rootDir>/Tests/__mocks__/i18next-browser-languagedetector.js",
     "^react-markdown$": "<rootDir>/Tests/__mocks__/react-markdown.js",
     "^remark-gfm$": "<rootDir>/Tests/__mocks__/remark-gfm.js",
     "^react-syntax-highlighter$": "<rootDir>/Tests/__mocks__/react-syntax-highlighter.js",


### PR DESCRIPTION
### Title of this pull request?

fix(status-page): stop detail pages from loading forever when the item is missing

### Small Description?

The status page **Incident Report** page rendered a spinner indefinitely whenever the incident could not be found. A real customer (status.loopsubscriptions.com) hit this and reported "incident report is not showing up" with no error shown.

**Root cause.** `fetchItem()` POSTs to `/incidents/{statusPageId}/{incidentId}` and, on failure, falls back to `/episodes/{...}`. If neither resolves, `setIsLoading(false)` runs with `incident`, `episode` and `error` all null. The `useEffect` only sets `parsedData` when one of them is truthy, so it stays null — and the render guard `if (!parsedData) { return <PageLoader isVisible={true} /> }` then shows the spinner on every subsequent render. The `EmptyState` further down the render body was unreachable dead code.

This is reachable in production: `StatusPageAPI.getIncidents()` filters incidents by `monitors: monitorsOnStatusPage`, so an incident with no monitors attached (or whose monitors are not resources on that status page) comes back as an empty list with a **200**, and the page hangs.

**Two things were broken, not one.** `API.post` *returns* an `HTTPErrorResponse` for HTTP errors rather than throwing (`Common/Utils/API.ts`), so the two `catch {}` blocks only ever caught network-level failures. A 401/403 fell straight through the `if (response.isSuccess())` check and hung the page identically — and never reached `StatusPageUtil.checkIfTheUserIsAuthenticated`, so an expired session on a private status page could not redirect to login.

**What changed**

`App/FeatureSet/StatusPage/src/Pages/Incidents/Detail.tsx`
- The `!parsedData` guard now only returns `PageLoader` when there *is* an item to parse, so the "nothing found" case falls through to the `EmptyState` that was already there.
- The incident lookup's failure — thrown *or* returned as a non-success response — is captured and rethrown when the episode fallback also finds nothing, restoring the auth check and the `ErrorMessage` path. The episode fallback's own error stays swallowed on purpose: it fails with "Episodes are not enabled on this status page" on every status page with episodes turned off, so surfacing it would be actively misleading.

`App/FeatureSet/StatusPage/src/Pages/ScheduledEvent/Detail.tsx` and `App/FeatureSet/StatusPage/src/Pages/Announcement/Detail.tsx` had the same hole in a different shape: `BaseModel.fromJSONObject({}, …)` returns an empty-but-truthy model, so an empty response rendered a **blank event card** and their `EmptyState` branches were dead code too. Both now keep the model `null` when the response is empty and use the same render guard.

**Notes for the reviewer**

- No new copy. The existing i18n keys (`incidents.notFound` → "Incident not found on this status page.") are already present in all 16 locales.
- There is no separate episode detail page; episodes render through this same component's `isEpisode` branch, so they are covered.
- `Common/jest.config.json` gains a `moduleNameMapper` entry plus a `Tests/__mocks__/i18next-browser-languagedetector.js` stub. That package is only installed in the frontend feature sets, so without it any test that renders a status page component fails to resolve it.
- **Not changed, and worth a decision:** server-side, `getIncidents()` still filters by monitors, so the customer's incident remains invisible on that status page. It now says so plainly instead of spinning, but if an incident explicitly attached to a status page should show regardless of its monitors, that is a separate fix in `Common/Server/API/StatusPageAPI.ts`.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

Verification run locally:
- `tsc --noEmit` on the StatusPage feature set — clean
- eslint on all four changed source/test files — clean
- `Tests/App/StatusPage` — 6 suites, 62 tests, all passing
- The new tests were confirmed to catch the bug: with the source fixes stashed, 5 of the 6 fail; the "still renders the incident when one is found" case passes both ways, so the fix is not over-correcting.

### Related Issue?

None filed — reported directly by a customer (status.loopsubscriptions.com).

### Screenshots (if appropriate):

N/A — the change swaps a permanent loading spinner for the empty state that the page already defined.
