### PR TITLE
feat(project): record deleted projects so we can ask customers why they left

### DIFF
--- a/App/FeatureSet/BaseAPI/Index.ts
+++ b/App/FeatureSet/BaseAPI/Index.ts
@@ -811,6 +811,9 @@ import ProjectSmtpConfigService, {
 import PromoCodeService, {
   Service as PromoCodeServiceType,
 } from "Common/Server/Services/PromoCodeService";
+import DeletedProjectService, {
+  Service as DeletedProjectServiceType,
+} from "Common/Server/Services/DeletedProjectService";
 import CodeRepositoryService, {
   Service as CodeRepositoryServiceType,
 } from "Common/Server/Services/CodeRepositoryService";
@@ -1215,6 +1218,7 @@ import ProjectCallSMSConfig from "Common/Models/DatabaseModels/ProjectCallSMSCon
 import ProjectSmtpConfig from "Common/Models/DatabaseModels/ProjectSmtpConfig";
 import ProjectUserProfile from "Common/Models/DatabaseModels/ProjectUserProfile";
 import PromoCode from "Common/Models/DatabaseModels/PromoCode";
+import DeletedProject from "Common/Models/DatabaseModels/DeletedProject";
 import CodeRepository from "Common/Models/DatabaseModels/CodeRepository";
 import Reseller from "Common/Models/DatabaseModels/Reseller";
 import ScheduledMaintenanceCustomField from "Common/Models/DatabaseModels/ScheduledMaintenanceCustomField";
@@ -4491,6 +4495,18 @@ const BaseAPIFeatureSet: FeatureSet = {
       new BaseAPI<PromoCode, PromoCodeServiceType>(
         PromoCode,
         PromoCodeService,
+      ).getRouter(),
+    );
+
+    /*
+     * Read/list of deleted projects for customer outreach
+     * (empty table ACLs — master admin only).
+     */
+    app.use(
+      `/${APP_NAME.toLocaleLowerCase()}`,
+      new BaseAPI<DeletedProject, DeletedProjectServiceType>(
+        DeletedProject,
+        DeletedProjectService,
       ).getRouter(),
     );
 

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/DangerZone.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/DangerZone.tsx
@@ -4,13 +4,22 @@ import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import PageComponentProps from "../PageComponentProps";
 import DashboardSideMenu from "./SideMenu";
 import Route from "Common/Types/API/Route";
+import URL from "Common/Types/API/URL";
+import { JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
 import Alert, { AlertType } from "Common/UI/Components/Alerts/Alert";
+import FieldLabelElement from "Common/UI/Components/Forms/Fields/FieldLabel";
 import ModelDelete from "Common/UI/Components/ModelDelete/ModelDelete";
 import Page from "Common/UI/Components/Page/Page";
+import TextArea from "Common/UI/Components/TextArea/TextArea";
+import { APP_API_URL, BILLING_ENABLED } from "Common/UI/Config";
+import API from "Common/UI/Utils/API/API";
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 import PermissionUtil from "Common/UI/Utils/Permission";
 import Project from "Common/Models/DatabaseModels/Project";
-import React, { FunctionComponent, ReactElement } from "react";
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import React, { FunctionComponent, ReactElement, useState } from "react";
 
 export interface ComponentProps extends PageComponentProps {
   onProjectDeleted: () => void;
@@ -19,6 +28,47 @@ export interface ComponentProps extends PageComponentProps {
 const Settings: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  const projectId: ObjectID = new ObjectID(
+    ProjectUtil.getCurrentProjectId()?.toString() || "",
+  );
+
+  /*
+   * Why the customer is leaving. Only asked on SaaS - there is nobody to
+   * follow up with on a self-hosted install, and nowhere it would be recorded.
+   */
+  const [deletionReason, setDeletionReason] = useState<string>("");
+
+  type DeleteProjectFunction = () => Promise<void>;
+
+  /*
+   * The generic DELETE has nowhere to carry the reason, so deletes go through
+   * the project's own endpoint instead. Permissions are unchanged - the server
+   * still runs the delete through the same permission checks.
+   */
+  const deleteProject: DeleteProjectFunction = async (): Promise<void> => {
+    const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+      await API.post({
+        url: URL.fromString(APP_API_URL.toString())
+          .addRoute(new Project().getCrudApiPath()!)
+          .addRoute(`/${projectId.toString()}/delete-project`),
+        data: {
+          data: {
+            deletionReason: deletionReason,
+          },
+        },
+        /*
+         * The tenantid header is what the server resolves this request's
+         * project permissions from - API.post does not add it the way
+         * ModelAPI does, and without it the delete is refused.
+         */
+        headers: ModelAPI.getCommonHeaders(),
+      });
+
+    if (response.isFailure()) {
+      throw response;
+    }
+  };
+
   return (
     <Page
       title={"Project Settings"}
@@ -50,8 +100,29 @@ const Settings: FunctionComponent<ComponentProps> = (
 
       <ModelDelete
         modelType={Project}
-        modelId={
-          new ObjectID(ProjectUtil.getCurrentProjectId()?.toString() || "")
+        modelId={projectId}
+        onDelete={deleteProject}
+        confirmationContent={
+          BILLING_ENABLED ? (
+            <div>
+              <FieldLabelElement
+                title="Why are you deleting this project?"
+                htmlFor="project-deletion-reason"
+                description="Optional. Telling us what went wrong helps us make OneUptime better."
+              />
+              <div className="mt-2">
+                <TextArea
+                  id="project-deletion-reason"
+                  dataTestId="project-deletion-reason"
+                  value={deletionReason}
+                  placeholder="It would be great to know why you're leaving..."
+                  onChange={(value: string) => {
+                    setDeletionReason(value);
+                  }}
+                />
+              </div>
+            </div>
+          ) : undefined
         }
         onDeleteSuccess={() => {
           ProjectUtil.clearCurrentProject();

--- a/Common/Models/DatabaseModels/DeletedProject.ts
+++ b/Common/Models/DatabaseModels/DeletedProject.ts
@@ -1,0 +1,595 @@
+import BaseModel from "./DatabaseBaseModel/DatabaseBaseModel";
+import User from "./User";
+import Route from "../../Types/API/Route";
+import SubscriptionStatus from "../../Types/Billing/SubscriptionStatus";
+import ColumnAccessControl from "../../Types/Database/AccessControl/ColumnAccessControl";
+import TableAccessControl from "../../Types/Database/AccessControl/TableAccessControl";
+import ColumnLength from "../../Types/Database/ColumnLength";
+import ColumnType from "../../Types/Database/ColumnType";
+import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
+import TableColumn from "../../Types/Database/TableColumn";
+import TableColumnType from "../../Types/Database/TableColumnType";
+import TableMetadata from "../../Types/Database/TableMetadata";
+import Email from "../../Types/Email";
+import IconProp from "../../Types/Icon/IconProp";
+import ObjectID from "../../Types/ObjectID";
+import Phone from "../../Types/Phone";
+import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
+
+/*
+ * Snapshot of a project taken at the moment it was deleted, kept so the team
+ * can follow up with the customer and understand why they left.
+ *
+ * Projects are hard-deleted (DatabaseService._deleteBy), so nothing about them
+ * survives the delete - this table is the only record that the project ever
+ * existed. That is also why the project columns below are a denormalised copy
+ * rather than a foreign key, and why the user columns keep the name, email and
+ * company alongside the (nullable) relation: the row has to stay readable
+ * after the user is gone too.
+ *
+ * Written by ProjectService's delete hooks on SaaS only (IsBillingEnabled).
+ * Master-admin only - empty access control arrays deny every project user, and
+ * root/master admin short-circuit the permission checks before they run.
+ */
+@TableAccessControl({
+  create: [],
+  read: [],
+  update: [],
+  delete: [],
+})
+@CrudApiEndpoint(new Route("/deleted-project"))
+@TableMetadata({
+  tableName: "DeletedProject",
+  singularName: "Deleted Project",
+  pluralName: "Deleted Projects",
+  icon: IconProp.Trash,
+  tableDescription:
+    "Record of projects that have been deleted, with the reason the customer gave, kept for customer outreach.",
+})
+@Entity({
+  name: "DeletedProject",
+})
+export default class DeletedProject extends BaseModel {
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @Index("idx_deleted_project_project_id")
+  @TableColumn({
+    required: true,
+    type: TableColumnType.ObjectID,
+    title: "Project ID",
+    description:
+      "ID of the project that was deleted. Not a relation - the project row no longer exists.",
+    example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  })
+  @Column({
+    nullable: false,
+    type: ColumnType.ObjectID,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public projectId?: ObjectID = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: true,
+    type: TableColumnType.ShortText,
+    title: "Project Name",
+    description: "Name the deleted project had.",
+    example: "My Awesome Project",
+  })
+  @Column({
+    nullable: false,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public projectName?: string = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Slug,
+    title: "Project Slug",
+    description: "Slug the deleted project had.",
+    example: "my-awesome-project",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Slug,
+    length: ColumnLength.Slug,
+  })
+  public projectSlug?: string | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Date,
+    title: "Project Created At",
+    description:
+      "When the deleted project was created. Together with Deleted At this gives the lifetime of the account.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Date,
+  })
+  public projectCreatedAt?: Date | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @Index("idx_deleted_project_project_deleted_at")
+  @TableColumn({
+    required: true,
+    type: TableColumnType.Date,
+    title: "Project Deleted At",
+    description: "When the project was deleted.",
+  })
+  @Column({
+    nullable: false,
+    type: ColumnType.Date,
+  })
+  public projectDeletedAt?: Date = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.VeryLongText,
+    title: "Deletion Reason",
+    description:
+      "Why the customer said they were deleting the project, as typed into the delete confirmation. Empty when the delete did not come from the dashboard or the customer skipped the question.",
+    example: "We consolidated onto a single project.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.VeryLongText,
+  })
+  public deletionReason?: string | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "projectDeletedByUserId",
+    type: TableColumnType.Entity,
+    modelType: User,
+    title: "Project Deleted by User",
+    description:
+      "Relation to the User who deleted the project (if a User deleted it).",
+    example: "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  })
+  @ManyToOne(
+    () => {
+      return User;
+    },
+    {
+      cascade: false,
+      eager: false,
+      nullable: true,
+      onDelete: "SET NULL",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({ name: "projectDeletedByUserId" })
+  public projectDeletedByUser?: User | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ObjectID,
+    title: "Project Deleted by User ID",
+    description:
+      "ID of the User who deleted the project (if a User deleted it).",
+    example: "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ObjectID,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public projectDeletedByUserId?: ObjectID | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Name,
+    title: "Project Deleted by User Name",
+    description:
+      "Name of the User who deleted the project, copied so it survives that user being deleted.",
+    example: "Jane Doe",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Name,
+    length: ColumnLength.Name,
+  })
+  public projectDeletedByUserName?: string | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Email,
+    title: "Project Deleted by User Email",
+    description:
+      "Email of the User who deleted the project. This is the address to reach out on.",
+    example: "jane@example.com",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Email,
+    length: ColumnLength.Email,
+    transformer: Email.getDatabaseTransformer(),
+  })
+  public projectDeletedByUserEmail?: Email | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "projectCreatedByUserId",
+    type: TableColumnType.Entity,
+    modelType: User,
+    title: "Project Created by User",
+    description:
+      "Relation to the User who created the project (if a User created it).",
+    example: "c3d4e5f6-a7b8-9012-cdef-123456789012",
+  })
+  @ManyToOne(
+    () => {
+      return User;
+    },
+    {
+      cascade: false,
+      eager: false,
+      nullable: true,
+      onDelete: "SET NULL",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({ name: "projectCreatedByUserId" })
+  public projectCreatedByUser?: User | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ObjectID,
+    title: "Project Created by User ID",
+    description:
+      "ID of the User who created the project (if a User created it).",
+    example: "c3d4e5f6-a7b8-9012-cdef-123456789012",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ObjectID,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public projectCreatedByUserId?: ObjectID | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Name,
+    title: "Project Created by User Name",
+    description:
+      "Name of the User who created the project, copied so it survives that user being deleted.",
+    example: "John Doe",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Name,
+    length: ColumnLength.Name,
+  })
+  public projectCreatedByUserName?: string | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Email,
+    title: "Project Created by User Email",
+    description: "Email of the User who created the project.",
+    example: "john@example.com",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Email,
+    length: ColumnLength.Email,
+    transformer: Email.getDatabaseTransformer(),
+  })
+  public projectCreatedByUserEmail?: Email | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    title: "Company Name",
+    description:
+      "Company the project belonged to, taken from the user who created the project and falling back to the user who deleted it.",
+    example: "Acme Inc.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public companyName?: string | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Phone,
+    title: "Company Phone Number",
+    description: "Phone number on file for the company, for outreach.",
+    example: "+1-555-555-5555",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Phone,
+    length: ColumnLength.Phone,
+    transformer: Phone.getDatabaseTransformer(),
+  })
+  public companyPhoneNumber?: Phone | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    title: "Company Size",
+    description: "Company size the customer selected when they signed up.",
+    example: "11-50 People",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public companySize?: string | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    title: "Job Role",
+    description: "Job role the customer selected when they signed up.",
+    example: "Engineering Manager",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public jobRole?: string | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    title: "Plan Name",
+    description: "Plan the project was on when it was deleted.",
+    example: "Growth",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public planName?: string | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    title: "Payment Provider Plan ID",
+    description: "Billing plan ID the project was subscribed to.",
+    example: "price_1234567890",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public paymentProviderPlanId?: string | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    title: "Payment Provider Customer ID",
+    description:
+      "Billing customer ID of the project, so the account can be looked up in the payment provider.",
+    example: "cus_1234567890",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public paymentProviderCustomerId?: string | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    title: "Payment Provider Subscription ID",
+    description: "Billing subscription ID of the project.",
+    example: "sub_1234567890",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public paymentProviderSubscriptionId?: string | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    title: "Payment Provider Subscription Status",
+    description:
+      "Status the billing subscription was in when the project was deleted.",
+    example: "active",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public paymentProviderSubscriptionStatus?: SubscriptionStatus | undefined =
+    undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Number,
+    title: "Payment Provider Subscription Seats",
+    description:
+      "Number of seats the project was billed for when it was deleted.",
+    example: "5",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Number,
+  })
+  public paymentProviderSubscriptionSeats?: number | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Date,
+    title: "Trial Ends At",
+    description: "When the project's trial ended, or was going to end.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Date,
+  })
+  public trialEndsAt?: Date | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Number,
+    title: "Active Monitor Count",
+    description:
+      "Number of active monitors the project had when it was deleted - a rough measure of how much the customer had invested in it.",
+    example: "12",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Number,
+  })
+  public activeMonitorCount?: number | undefined = undefined;
+
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.Boolean,
+    title: "Was Project Blocked",
+    description:
+      "Whether the project was blocked when it was deleted. Blocked projects are deleted for very different reasons than active ones.",
+    example: "false",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.Boolean,
+  })
+  public wasProjectBlocked?: boolean | undefined = undefined;
+}

--- a/Common/Models/DatabaseModels/Index.ts
+++ b/Common/Models/DatabaseModels/Index.ts
@@ -424,6 +424,7 @@ import ProjectSCIM from "./ProjectSCIM";
 import ProjectSCIMLog from "./ProjectSCIMLog";
 import StatusPageSCIMLog from "./StatusPageSCIMLog";
 import MarketingConversion from "./MarketingConversion";
+import DeletedProject from "./DeletedProject";
 
 const AllModelTypes: Array<{
   new (): BaseModel;
@@ -869,6 +870,7 @@ const AllModelTypes: Array<{
   RumSessionErasureRequest,
   RumSessionPin,
   MarketingConversion,
+  DeletedProject,
 ];
 
 const modelTypeMap: { [key: string]: { new (): BaseModel } } = {};

--- a/Common/Server/API/ProjectAPI.ts
+++ b/Common/Server/API/ProjectAPI.ts
@@ -17,6 +17,7 @@ import {
 import JSONWebToken from "../Utils/JsonWebToken";
 import Response from "../Utils/Response";
 import BaseAPI from "./BaseAPI";
+import CommonAPI from "./CommonAPI";
 import BillingService from "../Services/BillingService";
 import Errors from "../Utils/Errors";
 import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
@@ -30,6 +31,12 @@ import OneUptimeDate from "../../Types/Date";
 import Permission, { UserPermission } from "../../Types/Permission";
 import ObjectID from "../../Types/ObjectID";
 import { JSONObject, JSONValue } from "../../Types/JSON";
+
+/*
+ * The reason is free text a customer types into the delete confirmation. The
+ * column is unbounded text, so the cap is here.
+ */
+export const MAX_DELETION_REASON_LENGTH: number = 5000;
 
 export default class ProjectAPI extends BaseAPI<Project, ProjectServiceType> {
   public constructor() {
@@ -128,6 +135,76 @@ export default class ProjectAPI extends BaseAPI<Project, ProjectServiceType> {
           await ProjectService.changePlan({
             projectId: projectId,
             paymentProviderPlanId: paymentProviderPlanId,
+          });
+
+          return Response.sendEmptySuccessResponse(req, res);
+        } catch (err) {
+          next(err);
+        }
+      },
+    );
+
+    /*
+     * Deletes a project, carrying the reason the customer gave for deleting it.
+     * The plain DELETE /project/:id route still works and still records the
+     * deletion - this one exists only because a DELETE has nowhere to put the
+     * answer to "why are you deleting this project?".
+     *
+     * The delete itself goes through deleteOneById with the caller's own props,
+     * so ModelPermission enforces ProjectOwner / DeleteProject exactly as it
+     * does on the plain route.
+     */
+    this.router.post(
+      `${new this.entityType().getCrudApiPath()?.toString()}/:id/delete-project`,
+      UserMiddleware.getUserMiddleware,
+      async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+        try {
+          const idParam: string = req.params["id"] as string;
+          ObjectID.validateUUID(idParam);
+          const projectId: ObjectID = new ObjectID(idParam);
+
+          /*
+           * Same guard as change-plan: permissions are resolved for the
+           * authenticated tenant, so the project in the URL has to be that
+           * tenant or permissions on one project would authorize deleting
+           * another.
+           */
+          const tenantId: ObjectID | null = this.getTenantId(req);
+
+          if (!tenantId || tenantId.toString() !== projectId.toString()) {
+            throw new BadDataException(
+              "Project ID in the URL does not match the project the request is authenticated for",
+            );
+          }
+
+          const body: JSONObject = (req.body as JSONObject) || {};
+          const data: JSONObject = (body["data"] as JSONObject) || {};
+          const deletionReasonValue: JSONValue = data["deletionReason"];
+
+          let deletionReason: string | undefined = undefined;
+
+          if (typeof deletionReasonValue === "string") {
+            /*
+             * Free text from a form field. Bound what a client can store, and
+             * drop NUL bytes: Postgres rejects them in a text column, and the
+             * write that fails here is the audit record of a project that has
+             * already been deleted - there is no second chance at it.
+             */
+            const cleaned: string = deletionReasonValue
+              // eslint-disable-next-line no-control-regex
+              .replace(/\u0000/g, "")
+              .trim()
+              .substring(0, MAX_DELETION_REASON_LENGTH);
+
+            if (cleaned) {
+              deletionReason = cleaned;
+            }
+          }
+
+          await ProjectService.deleteOneById({
+            id: projectId,
+            deletionReason: deletionReason,
+            props: await CommonAPI.getDatabaseCommonInteractionProps(req),
           });
 
           return Response.sendEmptySuccessResponse(req, res);

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786461136170-AddDeletedProjectTable.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786461136170-AddDeletedProjectTable.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddDeletedProjectTable1786461136170 implements MigrationInterface {
+  public name: string = "AddDeletedProjectTable1786461136170";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "DeletedProject" ("_id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "version" integer NOT NULL, "projectId" uuid NOT NULL, "projectName" character varying(100) NOT NULL, "projectSlug" character varying(100), "projectCreatedAt" TIMESTAMP WITH TIME ZONE, "projectDeletedAt" TIMESTAMP WITH TIME ZONE NOT NULL, "deletionReason" text, "projectDeletedByUserId" uuid, "projectDeletedByUserName" character varying(50), "projectDeletedByUserEmail" character varying(100), "projectCreatedByUserId" uuid, "projectCreatedByUserName" character varying(50), "projectCreatedByUserEmail" character varying(100), "companyName" character varying(100), "companyPhoneNumber" character varying(30), "companySize" character varying(100), "jobRole" character varying(100), "planName" character varying(100), "paymentProviderPlanId" character varying(100), "paymentProviderCustomerId" character varying(100), "paymentProviderSubscriptionId" character varying(100), "paymentProviderSubscriptionStatus" character varying(100), "paymentProviderSubscriptionSeats" integer, "trialEndsAt" TIMESTAMP WITH TIME ZONE, "activeMonitorCount" integer, "wasProjectBlocked" boolean, CONSTRAINT "PK_bd397da7b51a8649b38c3c8b272" PRIMARY KEY ("_id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_deleted_project_project_id" ON "DeletedProject" ("projectId") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_deleted_project_project_deleted_at" ON "DeletedProject" ("projectDeletedAt") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "DeletedProject" ADD CONSTRAINT "FK_bb76f7ebe3ee418ffd79346f203" FOREIGN KEY ("projectDeletedByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "DeletedProject" ADD CONSTRAINT "FK_084492367421031e80cd0fdbf1e" FOREIGN KEY ("projectCreatedByUserId") REFERENCES "User"("_id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "DeletedProject" DROP CONSTRAINT "FK_084492367421031e80cd0fdbf1e"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "DeletedProject" DROP CONSTRAINT "FK_bb76f7ebe3ee418ffd79346f203"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_deleted_project_project_deleted_at"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_deleted_project_project_id"`,
+    );
+    await queryRunner.query(`DROP TABLE "DeletedProject"`);
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -514,6 +514,7 @@ import { DropProjectCallSMSConfigCredentialUniques1786700000000 } from "./178670
 import { AddDataSourceTable1786303472848 } from "./1786303472848-AddDataSourceTable";
 import { MigrationName1786446545142 } from "./1786446545142-MigrationName";
 import { AddMonitorDependency1786449497966 } from "./1786449497966-AddMonitorDependency";
+import { AddDeletedProjectTable1786461136170 } from "./1786461136170-AddDeletedProjectTable";
 
 export default [
   InitialMigration,
@@ -1032,4 +1033,5 @@ export default [
   AddDataSourceTable1786303472848,
   MigrationName1786446545142,
   AddMonitorDependency1786449497966,
+  AddDeletedProjectTable1786461136170,
 ];

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -1489,6 +1489,7 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
         _id: deleteById.id.toString(),
       } as any,
       deletedByUser: deleteById.deletedByUser,
+      deletionReason: deleteById.deletionReason,
       props: deleteById.props,
     });
   }

--- a/Common/Server/Services/DeletedProjectService.ts
+++ b/Common/Server/Services/DeletedProjectService.ts
@@ -1,0 +1,138 @@
+import { IsBillingEnabled } from "../EnvironmentConfig";
+import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import DatabaseService from "./DatabaseService";
+import UserService from "./UserService";
+import Model from "../../Models/DatabaseModels/DeletedProject";
+import Project from "../../Models/DatabaseModels/Project";
+import User from "../../Models/DatabaseModels/User";
+import OneUptimeDate from "../../Types/Date";
+import ObjectID from "../../Types/ObjectID";
+import Phone from "../../Types/Phone";
+
+export class Service extends DatabaseService<Model> {
+  public constructor() {
+    super(Model);
+  }
+
+  /*
+   * Records a project that has just been deleted so the team can follow up with
+   * the customer. The project row is already gone by the time this runs, so
+   * everything written here has to come from the snapshot the caller took
+   * before the delete (ProjectService.onBeforeDelete).
+   *
+   * SaaS only. Self-hosted installs have no one to reach out to, and the
+   * gate lives here rather than at the call site so every caller gets it.
+   *
+   * Returns the row it wrote, or null when logging was skipped.
+   */
+  @CaptureSpan()
+  public async logProjectDeletion(data: {
+    project: Project;
+    deletedByUserId?: ObjectID | undefined;
+    deletionReason?: string | undefined;
+  }): Promise<Model | null> {
+    if (!IsBillingEnabled) {
+      return null;
+    }
+
+    const project: Project = data.project;
+
+    if (!project.id) {
+      return null;
+    }
+
+    /*
+     * Who to reach out to. The user who deleted the project is usually also
+     * the one who created it - reuse the snapshot in that case instead of
+     * spending a query on it.
+     */
+    let deletedByUser: User | null = null;
+
+    if (data.deletedByUserId) {
+      if (
+        project.createdByUser &&
+        project.createdByUserId?.toString() === data.deletedByUserId.toString()
+      ) {
+        deletedByUser = project.createdByUser;
+      } else {
+        deletedByUser = await UserService.findOneById({
+          id: data.deletedByUserId,
+          select: {
+            _id: true,
+            name: true,
+            email: true,
+            companyName: true,
+            companyPhoneNumber: true,
+            companySize: true,
+            jobRole: true,
+          },
+          props: {
+            isRoot: true,
+          },
+        });
+      }
+    }
+
+    const createdByUser: User | undefined = project.createdByUser;
+
+    const deletedProject: Model = new Model();
+
+    deletedProject.projectId = project.id;
+    deletedProject.projectName = project.name || "";
+    deletedProject.projectSlug = project.slug;
+    deletedProject.projectCreatedAt = project.createdAt;
+    deletedProject.projectDeletedAt = OneUptimeDate.getCurrentDate();
+    deletedProject.deletionReason = data.deletionReason;
+
+    deletedProject.projectDeletedByUserId = data.deletedByUserId;
+    deletedProject.projectDeletedByUserName = deletedByUser?.name?.toString();
+    deletedProject.projectDeletedByUserEmail = deletedByUser?.email;
+
+    deletedProject.projectCreatedByUserId = project.createdByUserId;
+    deletedProject.projectCreatedByUserName = createdByUser?.name?.toString();
+    deletedProject.projectCreatedByUserEmail = createdByUser?.email;
+
+    /*
+     * Company details are collected at signup and hang off the User, so take
+     * them from whoever created the project and fall back to whoever deleted
+     * it - between the two there is usually one filled-in answer.
+     */
+    const companyName: string | undefined =
+      createdByUser?.companyName || deletedByUser?.companyName;
+    const companyPhoneNumber: Phone | undefined =
+      createdByUser?.companyPhoneNumber || deletedByUser?.companyPhoneNumber;
+    const companySize: string | undefined =
+      createdByUser?.companySize || deletedByUser?.companySize;
+    const jobRole: string | undefined =
+      createdByUser?.jobRole || deletedByUser?.jobRole;
+
+    deletedProject.companyName = companyName;
+    deletedProject.companyPhoneNumber = companyPhoneNumber;
+    deletedProject.companySize = companySize;
+    deletedProject.jobRole = jobRole;
+
+    deletedProject.planName = project.planName;
+    deletedProject.paymentProviderPlanId = project.paymentProviderPlanId;
+    deletedProject.paymentProviderCustomerId =
+      project.paymentProviderCustomerId;
+    deletedProject.paymentProviderSubscriptionId =
+      project.paymentProviderSubscriptionId;
+    deletedProject.paymentProviderSubscriptionStatus =
+      project.paymentProviderSubscriptionStatus;
+    deletedProject.paymentProviderSubscriptionSeats =
+      project.paymentProviderSubscriptionSeats;
+    deletedProject.trialEndsAt = project.trialEndsAt;
+
+    deletedProject.activeMonitorCount = project.currentActiveMonitorsCount;
+    deletedProject.wasProjectBlocked = project.isBlocked ?? false;
+
+    return await this.create({
+      data: deletedProject,
+      props: {
+        isRoot: true,
+      },
+    });
+  }
+}
+
+export default new Service();

--- a/Common/Server/Services/Index.ts
+++ b/Common/Server/Services/Index.ts
@@ -283,10 +283,12 @@ import NetworkFlowService from "./NetworkFlowService";
 import OnCallDutyPolicyTimeLogService from "./OnCallDutyPolicyTimeLogService";
 import ProjectSCIMLogService from "./ProjectSCIMLogService";
 import StatusPageSCIMLogService from "./StatusPageSCIMLogService";
+import DeletedProjectService from "./DeletedProjectService";
 
 const services: Array<BaseService> = [
   OnCallDutyPolicyTimeLogService,
   AcmeCertificateService,
+  DeletedProjectService,
   PromoCodeService,
   EnterpriseLicenseService,
   EnterpriseLicenseInstanceService,

--- a/Common/Server/Services/ProjectService.ts
+++ b/Common/Server/Services/ProjectService.ts
@@ -20,6 +20,7 @@ import SessionReplayGateCacheStore from "../Utils/SessionReplay/SessionReplayGat
 import AccessTokenService from "./AccessTokenService";
 import BillingService from "./BillingService";
 import DatabaseService from "./DatabaseService";
+import DeletedProjectService from "./DeletedProjectService";
 import IncidentSeverityService from "./IncidentSeverityService";
 import IncidentStateService from "./IncidentStateService";
 import IncidentRoleService from "./IncidentRoleService";
@@ -2095,6 +2096,12 @@ These are no longer recorded against the project and have to be cancelled by han
   protected override async onBeforeDelete(
     deleteBy: DeleteBy<Model>,
   ): Promise<OnDelete<Model>> {
+    /*
+     * Everything onDeleteSuccess needs has to be read here: projects are hard
+     * deleted, so by the time that hook runs there is nothing left to query.
+     * The extra columns beyond the billing ones are the snapshot that goes
+     * into DeletedProject for customer outreach.
+     */
     const projects: Array<Model> = await this.findBy({
       query: deleteBy.query,
       props: {
@@ -2107,11 +2114,24 @@ These are no longer recorded against the project and have to be cancelled by han
         paymentProviderSubscriptionId: true,
         paymentProviderMeteredSubscriptionId: true,
         name: true,
+        slug: true,
         createdAt: true,
         planName: true,
+        paymentProviderPlanId: true,
+        paymentProviderCustomerId: true,
+        paymentProviderSubscriptionStatus: true,
+        paymentProviderSubscriptionSeats: true,
+        trialEndsAt: true,
+        currentActiveMonitorsCount: true,
+        isBlocked: true,
+        createdByUserId: true,
         createdByUser: {
           name: true,
           email: true,
+          companyName: true,
+          companyPhoneNumber: true,
+          companySize: true,
+          jobRole: true,
         },
       },
     });
@@ -2122,8 +2142,45 @@ These are no longer recorded against the project and have to be cancelled by han
   @CaptureSpan()
   protected override async onDeleteSuccess(
     onDelete: OnDelete<Model>,
-    _itemIdsBeforeDelete: ObjectID[],
+    itemIdsBeforeDelete: ObjectID[],
   ): Promise<OnDelete<Model>> {
+    /*
+     * Record the deleted project first. Everything else in this hook can throw
+     * - Stripe in particular - and the customer we would want to follow up
+     * with is exactly the one whose deletion hit an error.
+     *
+     * Only the projects that were really deleted are recorded: onBeforeDelete
+     * snapshots everything the query matched, which is a superset once
+     * permissions narrow the delete.
+     */
+    const deletedProjectIds: Set<string> = new Set<string>(
+      itemIdsBeforeDelete.map((id: ObjectID) => {
+        return id.toString();
+      }),
+    );
+
+    for (const project of onDelete.carryForward) {
+      if (project.id && !deletedProjectIds.has(project.id.toString())) {
+        continue;
+      }
+
+      try {
+        await DeletedProjectService.logProjectDeletion({
+          project: project,
+          deletedByUserId:
+            onDelete.deleteBy.deletedByUser?.id ||
+            onDelete.deleteBy.props.userId,
+          deletionReason: onDelete.deleteBy.deletionReason,
+        });
+      } catch (err) {
+        /*
+         * The project is already gone. Failing the request now would tell the
+         * customer their delete did not work when it did.
+         */
+        logger.error(err);
+      }
+    }
+
     if (NotificationSlackWebhookOnDeleteProject) {
       for (const project of onDelete.carryForward) {
         let subscriptionStatus: SubscriptionStatus | null = null;

--- a/Common/Server/Types/Database/DeleteById.ts
+++ b/Common/Server/Types/Database/DeleteById.ts
@@ -5,5 +5,7 @@ import User from "../../../Models/DatabaseModels/User";
 export default interface DeleteById {
   id: ObjectID;
   deletedByUser?: User;
+  // See DeleteOneBy.deletionReason - passed straight through to the hooks.
+  deletionReason?: string | undefined;
   props: DatabaseCommonInteractionProps;
 }

--- a/Common/Server/Types/Database/DeleteOneBy.ts
+++ b/Common/Server/Types/Database/DeleteOneBy.ts
@@ -6,5 +6,11 @@ import User from "../../../Models/DatabaseModels/User";
 export default interface DeleteOneBy<TBaseModel extends BaseModel> {
   query: Query<TBaseModel>;
   deletedByUser?: User | undefined;
+  /*
+   * Free-text reason the caller gave for the delete. Never persisted on the
+   * row being deleted (it is about to be gone) - it rides through to the
+   * delete hooks, which are the last place that can record it anywhere.
+   */
+  deletionReason?: string | undefined;
   props: DatabaseCommonInteractionProps;
 }

--- a/Common/Tests/App/Dashboard/DangerZone.test.tsx
+++ b/Common/Tests/App/Dashboard/DangerZone.test.tsx
@@ -1,0 +1,334 @@
+import "@testing-library/jest-dom";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import API from "../../../UI/Utils/API/API";
+import ProjectUtil from "../../../UI/Utils/Project";
+import PermissionUtil from "../../../UI/Utils/Permission";
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import Route from "../../../Types/API/Route";
+import Dictionary from "../../../Types/Dictionary";
+import ObjectID from "../../../Types/ObjectID";
+import { JSONObject } from "../../../Types/JSON";
+import { getJestSpyOn } from "../../Spy";
+
+/*
+ * Settings > Danger Zone is where a customer deletes their project - the one
+ * moment OneUptime can ask why they are leaving, because a second later the
+ * project and every trace of the account are gone for good.
+ *
+ * The page is rendered for real down to the confirmation dialog. Page chrome
+ * (the layout shell and the side menu) is stubbed: both want a router this
+ * test has no use for, and neither has anything to do with deleting a project.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+
+interface MutableConfig {
+  billingEnabled: boolean;
+}
+
+const config: MutableConfig = { billingEnabled: true };
+
+(
+  globalThis as unknown as { __dangerZoneConfig: MutableConfig }
+).__dangerZoneConfig = config;
+
+/*
+ * BILLING_ENABLED is a module-scope const, so the two deployments have to be
+ * switchable per test rather than per file. defineProperty rather than a
+ * getter in the object literal: a literal getter is read once while the
+ * object is built, which would freeze the value at mock time.
+ */
+jest.mock("../../../UI/Config", () => {
+  const mocked: Record<string, unknown> = {
+    ...jest.requireActual("../../../UI/Config"),
+  };
+
+  Object.defineProperty(mocked, "BILLING_ENABLED", {
+    get: (): boolean => {
+      return Boolean(
+        (
+          globalThis as unknown as {
+            __dangerZoneConfig: MutableConfig | undefined;
+          }
+        ).__dangerZoneConfig?.billingEnabled,
+      );
+    },
+  });
+
+  return mocked;
+});
+
+jest.mock("../../../UI/Components/Page/Page", () => {
+  const react: typeof React = jest.requireActual("react");
+
+  return {
+    __esModule: true,
+    default: (props: { children?: React.ReactNode }) => {
+      return react.createElement("div", null, props.children);
+    },
+  };
+});
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Pages/Settings/SideMenu",
+  () => {
+    return {
+      __esModule: true,
+      default: () => {
+        return null;
+      },
+    };
+  },
+);
+
+/*
+ * Imported after the mocks above so the page picks them up - the module reads
+ * BILLING_ENABLED as soon as it renders.
+ */
+import DangerZone from "../../../../App/FeatureSet/Dashboard/src/Pages/Settings/DangerZone";
+
+interface PageCalls {
+  projectDeleted: number;
+}
+
+type RenderPageFunction = () => PageCalls;
+
+const renderPage: RenderPageFunction = (): PageCalls => {
+  const calls: PageCalls = { projectDeleted: 0 };
+
+  render(
+    <DangerZone
+      pageRoute={new Route("/settings/danger-zone")}
+      currentProject={null}
+      hasPaymentMethod={true}
+      onProjectDeleted={() => {
+        calls.projectDeleted = calls.projectDeleted + 1;
+      }}
+    />,
+  );
+
+  return calls;
+};
+
+type OpenConfirmationFunction = () => void;
+
+const openConfirmation: OpenConfirmationFunction = (): void => {
+  fireEvent.click(
+    screen.getByRole("button", { name: "Delete Project" }) as HTMLElement,
+  );
+};
+
+type ConfirmFunction = () => Promise<void>;
+
+/*
+ * The confirm button kicks off the delete request, so the state updates it
+ * causes land outside this tick - hence act rather than a bare click.
+ */
+const confirm: ConfirmFunction = async (): Promise<void> => {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+  });
+};
+
+type TypeReasonFunction = (reason: string) => void;
+
+const typeReason: TypeReasonFunction = (reason: string): void => {
+  fireEvent.change(screen.getByTestId("project-deletion-reason"), {
+    target: { value: reason },
+  });
+};
+
+describe("Settings > Danger Zone", () => {
+  let postCalls: Array<{
+    url: string;
+    data: JSONObject;
+    headers: Dictionary<string> | undefined;
+  }> = [];
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+
+    config.billingEnabled = true;
+    postCalls = [];
+
+    getJestSpyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(
+      PROJECT_ID,
+    );
+    getJestSpyOn(ProjectUtil, "clearCurrentProject").mockImplementation(
+      () => {},
+    );
+    getJestSpyOn(PermissionUtil, "clearProjectPermissions").mockImplementation(
+      () => {},
+    );
+
+    getJestSpyOn(API, "post").mockImplementation((data: any) => {
+      postCalls.push({
+        url: data.url.toString(),
+        data: data.data as JSONObject,
+        headers: data.headers as Dictionary<string> | undefined,
+      });
+
+      return Promise.resolve(new HTTPResponse<JSONObject>(200, {}, {}));
+    });
+  });
+
+  /*
+   * The server resolves which project's permissions this request carries from
+   * the tenantid header. API.post does not add it (ModelAPI does), so without
+   * it every delete from this page is refused - and the customer is told they
+   * are not allowed to delete their own project.
+   */
+  it("sends the project the request is authenticated for", async () => {
+    renderPage();
+    openConfirmation();
+    await confirm();
+
+    await waitFor(() => {
+      expect(postCalls).toHaveLength(1);
+    });
+
+    expect(postCalls[0]?.headers?.["tenantid"]).toBe(PROJECT_ID.toString());
+  });
+
+  it("warns that the deletion cannot be undone", () => {
+    renderPage();
+
+    expect(screen.getByText(/no way to recover/i)).toBeInTheDocument();
+  });
+
+  it("does not ask anything until the customer confirms they want to delete", () => {
+    renderPage();
+
+    expect(screen.queryByTestId("project-deletion-reason")).toBeNull();
+  });
+
+  it("asks why the customer is deleting the project", () => {
+    renderPage();
+    openConfirmation();
+
+    expect(
+      screen.getByText("Why are you deleting this project?"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("project-deletion-reason")).toBeInTheDocument();
+  });
+
+  it("sends the reason with the delete", async () => {
+    renderPage();
+    openConfirmation();
+    typeReason("Too expensive for our team");
+    await confirm();
+
+    await waitFor(() => {
+      expect(postCalls).toHaveLength(1);
+    });
+
+    expect(postCalls[0]?.url).toContain(
+      `/project/${PROJECT_ID.toString()}/delete-project`,
+    );
+    expect(postCalls[0]?.data).toEqual({
+      data: { deletionReason: "Too expensive for our team" },
+    });
+  });
+
+  /*
+   * Answering is optional. A customer who does not want to say why must still
+   * be able to delete their project.
+   */
+  it("still deletes the project when no reason is given", async () => {
+    const calls: PageCalls = renderPage();
+
+    openConfirmation();
+    await confirm();
+
+    await waitFor(() => {
+      expect(postCalls).toHaveLength(1);
+    });
+
+    expect(postCalls[0]?.data).toEqual({ data: { deletionReason: "" } });
+    expect(calls.projectDeleted).toBe(1);
+  });
+
+  it("clears the deleted project out of the session on success", async () => {
+    const calls: PageCalls = renderPage();
+
+    openConfirmation();
+    typeReason("Consolidating projects");
+    await confirm();
+
+    await waitFor(() => {
+      expect(calls.projectDeleted).toBe(1);
+    });
+
+    expect(ProjectUtil.clearCurrentProject).toHaveBeenCalled();
+    expect(PermissionUtil.clearProjectPermissions).toHaveBeenCalled();
+  });
+
+  /*
+   * The success handler navigates away from the project. Running it after a
+   * failed delete would leave the customer looking at a project they still
+   * have and cannot get back to.
+   */
+  it("does not clear the session when the delete is refused", async () => {
+    getJestSpyOn(API, "post").mockResolvedValue(
+      new HTTPErrorResponse(400, { message: "Delete not allowed" }, {}),
+    );
+
+    const calls: PageCalls = renderPage();
+
+    openConfirmation();
+    await confirm();
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete Error")).toBeInTheDocument();
+    });
+
+    expect(calls.projectDeleted).toBe(0);
+    expect(ProjectUtil.clearCurrentProject).not.toHaveBeenCalled();
+  });
+
+  /*
+   * Self-hosted installs have nobody to follow up with and nowhere to record
+   * an answer, so the question is not asked at all there.
+   */
+  describe("on a self-hosted install", () => {
+    beforeEach(() => {
+      config.billingEnabled = false;
+    });
+
+    it("does not ask why the project is being deleted", () => {
+      renderPage();
+      openConfirmation();
+
+      expect(screen.queryByTestId("project-deletion-reason")).toBeNull();
+      expect(
+        screen.queryByText("Why are you deleting this project?"),
+      ).toBeNull();
+    });
+
+    it("still deletes the project", async () => {
+      const calls: PageCalls = renderPage();
+
+      openConfirmation();
+      await confirm();
+
+      await waitFor(() => {
+        expect(calls.projectDeleted).toBe(1);
+      });
+
+      expect(postCalls[0]?.url).toContain(
+        `/project/${PROJECT_ID.toString()}/delete-project`,
+      );
+    });
+  });
+});

--- a/Common/Tests/Models/DatabaseModels/DeletedProjectModel.test.ts
+++ b/Common/Tests/Models/DatabaseModels/DeletedProjectModel.test.ts
@@ -1,0 +1,251 @@
+import Models from "../../../Models/DatabaseModels/Index";
+import DeletedProject from "../../../Models/DatabaseModels/DeletedProject";
+import Project from "../../../Models/DatabaseModels/Project";
+import User from "../../../Models/DatabaseModels/User";
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import Migrations from "../../../Server/Infrastructure/Postgres/SchemaMigrations/Index";
+import { ColumnAccessControl } from "../../../Types/BaseDatabase/AccessControl";
+import TableColumnType from "../../../Types/Database/TableColumnType";
+import Permission from "../../../Types/Permission";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * DeletedProject is the only record that a deleted project ever existed -
+ * projects are hard deleted, so anything this table does not carry is gone for
+ * good. These tests pin the two properties that cannot be observed from the
+ * service tests: that the snapshot is genuinely standalone (no relation to the
+ * row it describes), and that customer data in it is not reachable by ordinary
+ * project users.
+ */
+
+describe("DeletedProject model", () => {
+  const model: DeletedProject = new DeletedProject();
+
+  it("is registered in the model index, so its table is created", () => {
+    const isRegistered: boolean = Models.some(
+      (registered: { new (): BaseModel }) => {
+        return registered === DeletedProject;
+      },
+    );
+
+    expect(isRegistered).toBe(true);
+  });
+
+  it("is a global table, not scoped to the project it describes", () => {
+    /*
+     * A tenant column here would be a foreign key to Project, and Postgres
+     * would cascade the audit row away with the very project it records.
+     */
+    expect(model.getTenantColumn()).toBeFalsy();
+    expect(model.isTenantModel()).toBe(false);
+  });
+
+  it("is served from its own CRUD endpoint", () => {
+    expect(model.getCrudApiPath()?.toString()).toBe("/deleted-project");
+  });
+
+  it("uses its own table", () => {
+    expect(model.tableName).toBe("DeletedProject");
+  });
+
+  it("records the project identity, so a deleted project can still be identified", () => {
+    const columns: Array<string> = model.getTableColumns().columns;
+
+    for (const column of [
+      "projectId",
+      "projectName",
+      "projectSlug",
+      "projectCreatedAt",
+      "projectDeletedAt",
+    ]) {
+      expect(columns).toContain(column);
+    }
+  });
+
+  it("records who deleted the project and how to reach them", () => {
+    const columns: Array<string> = model.getTableColumns().columns;
+
+    for (const column of [
+      "projectDeletedByUserId",
+      "projectDeletedByUserName",
+      "projectDeletedByUserEmail",
+      "projectCreatedByUserId",
+      "projectCreatedByUserName",
+      "projectCreatedByUserEmail",
+      "companyName",
+      "companyPhoneNumber",
+      "companySize",
+      "jobRole",
+    ]) {
+      expect(columns).toContain(column);
+    }
+  });
+
+  it("records why the customer said they were leaving", () => {
+    expect(model.getTableColumns().columns).toContain("deletionReason");
+  });
+
+  it("stores the reason as unbounded text, so a long answer is not truncated", () => {
+    expect(model.getTableColumnMetadata("deletionReason").type).toBe(
+      TableColumnType.VeryLongText,
+    );
+  });
+
+  it("records what the customer was worth and how much they had built", () => {
+    const columns: Array<string> = model.getTableColumns().columns;
+
+    for (const column of [
+      "planName",
+      "paymentProviderPlanId",
+      "paymentProviderCustomerId",
+      "paymentProviderSubscriptionId",
+      "paymentProviderSubscriptionStatus",
+      "paymentProviderSubscriptionSeats",
+      "trialEndsAt",
+      "activeMonitorCount",
+      "wasProjectBlocked",
+    ]) {
+      expect(columns).toContain(column);
+    }
+  });
+
+  /*
+   * The project row is deleted before this one is written. A relation would
+   * have nothing to point at - which is why projectId is a plain uuid and the
+   * name, slug and dates are copied rather than joined.
+   */
+  it("keeps the project id as a plain column, not a relation to Project", () => {
+    expect(model.getTableColumnMetadata("projectId").type).toBe(
+      TableColumnType.ObjectID,
+    );
+    expect(model.getTableColumnMetadata("projectId").modelType).toBeUndefined();
+    expect(model.getTableColumns().columns).not.toContain("project");
+  });
+
+  it("requires the project id, name and deletion time on every row", () => {
+    expect(model.getTableColumnMetadata("projectId").required).toBe(true);
+    expect(model.getTableColumnMetadata("projectName").required).toBe(true);
+    expect(model.getTableColumnMetadata("projectDeletedAt").required).toBe(
+      true,
+    );
+  });
+
+  /*
+   * The user relations exist only so staff can jump to the account. They must
+   * be nullable and non-cascading: a user who later deletes their account must
+   * not take the record of the project deletion with them, which is also why
+   * the name and email are copied onto the row.
+   */
+  it("relates to the users involved without depending on them surviving", () => {
+    expect(model.getTableColumnMetadata("projectDeletedByUser").modelType).toBe(
+      User,
+    );
+    expect(model.getTableColumnMetadata("projectCreatedByUser").modelType).toBe(
+      User,
+    );
+    expect(model.getTableColumnMetadata("projectDeletedByUser").required).toBe(
+      undefined,
+    );
+  });
+
+  /*
+   * Every column carries names, emails and phone numbers of customers who have
+   * already left. Empty permission arrays are how this repo says "master admin
+   * only" - no user permission can intersect an empty list, and root and
+   * master admin bypass the check entirely.
+   */
+  it("cannot be read, written or deleted by any project user", () => {
+    expect(model.getCreatePermissions()).toEqual([]);
+    expect(model.getReadPermissions()).toEqual([]);
+    expect(model.getUpdatePermissions()).toEqual([]);
+    expect(model.getDeletePermissions()).toEqual([]);
+  });
+
+  it("locks down every single column, not just the table", () => {
+    const accessControl: Record<string, ColumnAccessControl> =
+      model.getColumnAccessControlForAllColumns();
+
+    /*
+     * _id and the timestamps come from the base model and carry no column
+     * access control of their own. Every column this model declares must have
+     * one - a column added without the decorator is the case worth catching,
+     * so its absence fails rather than being skipped.
+     */
+    const baseModelColumns: Array<string> = [
+      "_id",
+      "createdAt",
+      "updatedAt",
+      "deletedAt",
+      "version",
+    ];
+
+    const declaredColumns: Array<string> = model
+      .getTableColumns()
+      .columns.filter((columnName: string) => {
+        return !baseModelColumns.includes(columnName);
+      });
+
+    expect(declaredColumns.length).toBeGreaterThan(20);
+
+    for (const columnName of declaredColumns) {
+      const columnAccess: ColumnAccessControl | undefined =
+        accessControl[columnName];
+
+      expect(columnAccess).toBeDefined();
+      expect(columnAccess?.create).toEqual([]);
+      expect(columnAccess?.read).toEqual([]);
+      expect(columnAccess?.update).toEqual([]);
+    }
+  });
+
+  it("does not hand a project owner any permission over it", () => {
+    expect(model.getReadPermissions()).not.toContain(Permission.ProjectOwner);
+    expect(model.getReadPermissions()).not.toContain(Permission.ProjectAdmin);
+  });
+});
+
+describe("Project model - deletion snapshot source columns", () => {
+  const project: Project = new Project();
+
+  /*
+   * ProjectService.onBeforeDelete reads these off the project before it is
+   * deleted and DeletedProjectService copies them onto the audit row. If one
+   * is renamed the snapshot silently loses a field, so pin them here.
+   */
+  it("still has every column the deletion snapshot copies", () => {
+    const columns: Array<string> = project.getTableColumns().columns;
+
+    for (const column of [
+      "name",
+      "slug",
+      "planName",
+      "paymentProviderPlanId",
+      "paymentProviderCustomerId",
+      "paymentProviderSubscriptionId",
+      "paymentProviderSubscriptionStatus",
+      "paymentProviderSubscriptionSeats",
+      "trialEndsAt",
+      "currentActiveMonitorsCount",
+      "isBlocked",
+      "createdByUserId",
+    ]) {
+      expect(columns).toContain(column);
+    }
+  });
+});
+
+describe("DeletedProject migration", () => {
+  /*
+   * A migration that is not in this array never runs, so the table simply does
+   * not exist in a fresh database and every project delete logs an error.
+   */
+  it("is registered, so the table is actually created", () => {
+    const registeredNames: Array<string> = (
+      Migrations as unknown as Array<{ name: string }>
+    ).map((migration: { name: string }) => {
+      return migration.name;
+    });
+
+    expect(registeredNames).toContain("AddDeletedProjectTable1786461136170");
+  });
+});

--- a/Common/Tests/Server/API/ProjectAPI.test.ts
+++ b/Common/Tests/Server/API/ProjectAPI.test.ts
@@ -1,4 +1,6 @@
-import ProjectAPI from "../../../Server/API/ProjectAPI";
+import ProjectAPI, {
+  MAX_DELETION_REASON_LENGTH,
+} from "../../../Server/API/ProjectAPI";
 import MasterAdminAuthorization from "../../../Server/Middleware/MasterAdminAuthorization";
 import UserMiddleware from "../../../Server/Middleware/UserAuthorization";
 import JSONWebToken from "../../../Server/Utils/JsonWebToken";
@@ -484,6 +486,302 @@ describe("ProjectAPI", () => {
         .handlerFunction(mockRequest, mockResponse, nextFunction);
 
       expect(nextFunction).toHaveBeenCalledWith(serviceError);
+      expect(Response.sendEmptySuccessResponse).not.toHaveBeenCalled();
+    });
+  });
+
+  /*
+   * The delete confirmation in the dashboard asks why the customer is leaving,
+   * and a DELETE has nowhere to put the answer. This route is the same delete
+   * with a body - so the interesting cases are the ones where the body could
+   * be used to reach a project the caller is not authenticated for, or to
+   * store something the column was never sized for.
+   */
+  describe("POST /project/:id/delete-project", () => {
+    const tenantMismatchError: BadDataException = new BadDataException(
+      "Project ID in the URL does not match the project the request is authenticated for",
+    );
+
+    beforeEach(() => {
+      ProjectService.deleteOneById = jest.fn().mockResolvedValue(1);
+      /*
+       * getDatabaseCommonInteractionProps asks for the plan of the
+       * authenticated tenant when billing is on.
+       */
+      ProjectService.getCurrentPlan = jest.fn().mockResolvedValue({
+        plan: null,
+        isSubscriptionUnpaid: false,
+      });
+      mockRequest.headers = {};
+
+      /*
+       * Response is module-mocked once for the whole file, so its call log
+       * carries over from the suites above.
+       */
+      (Response.sendEmptySuccessResponse as jest.Mock).mockClear();
+    });
+
+    it("deletes the authenticated tenant's own project", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+
+      mockRequest.params = { id: projectId.toString() };
+      mockRequest.tenantId = projectId;
+      mockRequest.body = { data: { deletionReason: "We built our own" } };
+
+      await mockRouter
+        .match("post", "/project/:id/delete-project")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(ProjectService.deleteOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: projectId,
+          deletionReason: "We built our own",
+        }),
+      );
+      expect(Response.sendEmptySuccessResponse).toHaveBeenCalledWith(
+        mockRequest,
+        mockResponse,
+      );
+    });
+
+    /*
+     * Permissions are resolved for the authenticated tenant, so without this
+     * guard being an owner of one project would authorize deleting another.
+     */
+    it("refuses to delete a project the request is not authenticated for", async () => {
+      const victimProjectId: ObjectID = ObjectID.generate();
+      const attackerProjectId: ObjectID = ObjectID.generate();
+
+      mockRequest.params = { id: victimProjectId.toString() };
+      mockRequest.tenantId = attackerProjectId;
+      mockRequest.body = { data: { deletionReason: "not mine to delete" } };
+
+      await mockRouter
+        .match("post", "/project/:id/delete-project")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      expect(nextFunction).toHaveBeenCalledWith(tenantMismatchError);
+      expect(ProjectService.deleteOneById).not.toHaveBeenCalled();
+    });
+
+    it("refuses when the request has no authenticated tenant", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+
+      mockRequest.params = { id: projectId.toString() };
+      delete mockRequest.tenantId;
+      mockRequest.body = { data: { deletionReason: "anything" } };
+
+      await mockRouter
+        .match("post", "/project/:id/delete-project")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      expect(nextFunction).toHaveBeenCalledWith(tenantMismatchError);
+      expect(ProjectService.deleteOneById).not.toHaveBeenCalled();
+    });
+
+    it("rejects an id that is not a project id", async () => {
+      mockRequest.params = { id: "not-a-uuid" };
+      mockRequest.tenantId = ObjectID.generate();
+      mockRequest.body = { data: {} };
+
+      await mockRouter
+        .match("post", "/project/:id/delete-project")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      expect(nextFunction).toHaveBeenCalled();
+      expect(ProjectService.deleteOneById).not.toHaveBeenCalled();
+    });
+
+    /*
+     * The reason is optional: a customer who does not want to answer must
+     * still be able to delete their project.
+     */
+    it("deletes without a reason when none was given", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+
+      mockRequest.params = { id: projectId.toString() };
+      mockRequest.tenantId = projectId;
+      mockRequest.body = {};
+
+      await mockRouter
+        .match("post", "/project/:id/delete-project")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(ProjectService.deleteOneById).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: projectId,
+          deletionReason: undefined,
+        }),
+      );
+    });
+
+    it("treats a blank reason as no reason", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+
+      mockRequest.params = { id: projectId.toString() };
+      mockRequest.tenantId = projectId;
+      mockRequest.body = { data: { deletionReason: "   " } };
+
+      await mockRouter
+        .match("post", "/project/:id/delete-project")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      expect(ProjectService.deleteOneById).toHaveBeenCalledWith(
+        expect.objectContaining({ deletionReason: undefined }),
+      );
+    });
+
+    it("ignores a reason that is not text", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+
+      mockRequest.params = { id: projectId.toString() };
+      mockRequest.tenantId = projectId;
+      mockRequest.body = { data: { deletionReason: { $ne: null } } };
+
+      await mockRouter
+        .match("post", "/project/:id/delete-project")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(ProjectService.deleteOneById).toHaveBeenCalledWith(
+        expect.objectContaining({ deletionReason: undefined }),
+      );
+    });
+
+    /*
+     * Postgres rejects NUL bytes in a text column. The insert that would fail
+     * is the audit record of a project that has already been deleted, and
+     * there is no second chance at writing it - so they are dropped here.
+     */
+    it("strips NUL bytes the database would reject", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+
+      mockRequest.params = { id: projectId.toString() };
+      mockRequest.tenantId = projectId;
+      mockRequest.body = {
+        data: { deletionReason: "too\u0000 expensive\u0000" },
+      };
+
+      await mockRouter
+        .match("post", "/project/:id/delete-project")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      expect(ProjectService.deleteOneById).toHaveBeenCalledWith(
+        expect.objectContaining({ deletionReason: "too expensive" }),
+      );
+    });
+
+    it("treats a reason that is only NUL bytes as no reason", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+
+      mockRequest.params = { id: projectId.toString() };
+      mockRequest.tenantId = projectId;
+      mockRequest.body = { data: { deletionReason: "\u0000\u0000" } };
+
+      await mockRouter
+        .match("post", "/project/:id/delete-project")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(ProjectService.deleteOneById).toHaveBeenCalledWith(
+        expect.objectContaining({ deletionReason: undefined }),
+      );
+    });
+
+    it("trims the reason before storing it", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+
+      mockRequest.params = { id: projectId.toString() };
+      mockRequest.tenantId = projectId;
+      mockRequest.body = { data: { deletionReason: "  too expensive  " } };
+
+      await mockRouter
+        .match("post", "/project/:id/delete-project")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      expect(ProjectService.deleteOneById).toHaveBeenCalledWith(
+        expect.objectContaining({ deletionReason: "too expensive" }),
+      );
+    });
+
+    /*
+     * The column is unbounded text and the field is free text from a browser,
+     * so the only thing standing between a client and an arbitrarily large
+     * row is this cap.
+     */
+    it("caps how much free text a client can store", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+
+      mockRequest.params = { id: projectId.toString() };
+      mockRequest.tenantId = projectId;
+      mockRequest.body = {
+        data: { deletionReason: "a".repeat(MAX_DELETION_REASON_LENGTH + 500) },
+      };
+
+      await mockRouter
+        .match("post", "/project/:id/delete-project")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      const call: { deletionReason?: string } = (
+        ProjectService.deleteOneById as unknown as {
+          mock: { calls: Array<Array<{ deletionReason?: string }>> };
+        }
+      ).mock.calls[0]![0]!;
+
+      expect(call.deletionReason).toHaveLength(MAX_DELETION_REASON_LENGTH);
+    });
+
+    /*
+     * The delete goes through the ordinary permission-checked path with the
+     * caller's own props - the reason must not turn this into a privileged
+     * delete.
+     */
+    it("deletes as the caller, not as root", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+      const userId: ObjectID = ObjectID.generate();
+
+      mockRequest.params = { id: projectId.toString() };
+      mockRequest.tenantId = projectId;
+      mockRequest.userAuthorization = { userId: userId } as JSONWebTokenData;
+      mockRequest.body = { data: { deletionReason: "done with it" } };
+
+      await mockRouter
+        .match("post", "/project/:id/delete-project")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      const call: { props: { isRoot?: boolean; userId?: ObjectID } } = (
+        ProjectService.deleteOneById as unknown as {
+          mock: {
+            calls: Array<
+              Array<{ props: { isRoot?: boolean; userId?: ObjectID } }>
+            >;
+          };
+        }
+      ).mock.calls[0]![0]!;
+
+      expect(call.props.isRoot).toBeFalsy();
+      expect(call.props.userId).toBe(userId);
+    });
+
+    it("forwards a refused delete to next instead of reporting success", async () => {
+      const projectId: ObjectID = ObjectID.generate();
+      const notAllowed: BadDataException = new BadDataException(
+        "Delete on Project is not allowed",
+      );
+
+      ProjectService.deleteOneById = jest.fn().mockRejectedValue(notAllowed);
+
+      mockRequest.params = { id: projectId.toString() };
+      mockRequest.tenantId = projectId;
+      mockRequest.body = { data: { deletionReason: "nope" } };
+
+      await mockRouter
+        .match("post", "/project/:id/delete-project")
+        .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+      expect(nextFunction).toHaveBeenCalledWith(notAllowed);
       expect(Response.sendEmptySuccessResponse).not.toHaveBeenCalled();
     });
   });

--- a/Common/Tests/Server/Services/DatabaseServiceDeletionReason.test.ts
+++ b/Common/Tests/Server/Services/DatabaseServiceDeletionReason.test.ts
@@ -1,0 +1,123 @@
+import DatabaseService from "../../../Server/Services/DatabaseService";
+import ModelPermission from "../../../Server/Types/Database/Permissions/Index";
+import DeleteOneBy from "../../../Server/Types/Database/DeleteOneBy";
+import Probe from "../../../Models/DatabaseModels/Probe";
+import User from "../../../Models/DatabaseModels/User";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { getJestSpyOn } from "../../Spy";
+
+/*
+ * "Why are you deleting this?" is asked in the confirmation dialog, so the
+ * answer exists only for the length of the request that deletes the row. There
+ * is nowhere to persist it on the way down - the row is about to be gone - so
+ * it rides on the delete call itself and the hooks are the last place that can
+ * record it. This pins the one hop where it could quietly be dropped:
+ * deleteOneById rebuilding the delete as a query.
+ */
+
+const PROBE_ID: ObjectID = new ObjectID("550e8400-e29b-41d4-a716-446655440031");
+
+describe("DatabaseService.deleteOneById and the deletion reason", () => {
+  let service: DatabaseService<Probe>;
+  let deleteOneByCalls: Array<DeleteOneBy<Probe>> = [];
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+
+    service = new DatabaseService<Probe>(Probe);
+    deleteOneByCalls = [];
+
+    getJestSpyOn(
+      ModelPermission,
+      "checkDeletePermissionByModel",
+    ).mockResolvedValue(undefined as never);
+
+    getJestSpyOn(service, "deleteOneBy").mockImplementation((async (
+      deleteOneBy: DeleteOneBy<Probe>,
+    ) => {
+      deleteOneByCalls.push(deleteOneBy);
+      return 1;
+    }) as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("passes the reason on to the delete, where the hooks can see it", async () => {
+    await service.deleteOneById({
+      id: PROBE_ID,
+      deletionReason: "No longer needed",
+      props: { isRoot: true },
+    });
+
+    expect(deleteOneByCalls).toHaveLength(1);
+    expect(deleteOneByCalls[0]?.deletionReason).toBe("No longer needed");
+  });
+
+  it("deletes the row the id names", async () => {
+    await service.deleteOneById({
+      id: PROBE_ID,
+      deletionReason: "No longer needed",
+      props: { isRoot: true },
+    });
+
+    expect(deleteOneByCalls[0]?.query).toEqual({ _id: PROBE_ID.toString() });
+  });
+
+  it("leaves the reason unset when the caller did not give one", async () => {
+    await service.deleteOneById({
+      id: PROBE_ID,
+      props: { isRoot: true },
+    });
+
+    expect(deleteOneByCalls[0]?.deletionReason).toBeUndefined();
+  });
+
+  it("still carries the acting user alongside the reason", async () => {
+    const actor: User = new User();
+    actor._id = "550e8400-e29b-41d4-a716-446655440032";
+
+    await service.deleteOneById({
+      id: PROBE_ID,
+      deletedByUser: actor,
+      deletionReason: "Retiring this probe",
+      props: { isRoot: true },
+    });
+
+    expect(deleteOneByCalls[0]?.deletedByUser).toBe(actor);
+    expect(deleteOneByCalls[0]?.deletionReason).toBe("Retiring this probe");
+  });
+
+  /*
+   * The reason travels with the request, not the row: nothing about it may
+   * change who is allowed to delete what.
+   */
+  it("still checks delete permission before anything else", async () => {
+    await service.deleteOneById({
+      id: PROBE_ID,
+      deletionReason: "No longer needed",
+      props: { isRoot: false },
+    });
+
+    expect(ModelPermission.checkDeletePermissionByModel).toHaveBeenCalled();
+  });
+
+  it("does not delete anything when permission is refused", async () => {
+    getJestSpyOn(
+      ModelPermission,
+      "checkDeletePermissionByModel",
+    ).mockRejectedValue(new Error("not allowed") as never);
+
+    await expect(
+      service.deleteOneById({
+        id: PROBE_ID,
+        deletionReason: "No longer needed",
+        props: { isRoot: false },
+      }),
+    ).rejects.toThrow("not allowed");
+
+    expect(deleteOneByCalls).toHaveLength(0);
+  });
+});

--- a/Common/Tests/Server/Services/DeletedProjectService.test.ts
+++ b/Common/Tests/Server/Services/DeletedProjectService.test.ts
@@ -1,0 +1,415 @@
+import DeletedProjectService from "../../../Server/Services/DeletedProjectService";
+import UserService from "../../../Server/Services/UserService";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import DeletedProject from "../../../Models/DatabaseModels/DeletedProject";
+import Project from "../../../Models/DatabaseModels/Project";
+import User from "../../../Models/DatabaseModels/User";
+import { PlanType } from "../../../Types/Billing/SubscriptionPlan";
+import SubscriptionStatus from "../../../Types/Billing/SubscriptionStatus";
+import Email from "../../../Types/Email";
+import Name from "../../../Types/Name";
+import ObjectID from "../../../Types/ObjectID";
+import Phone from "../../../Types/Phone";
+import CompanySize from "../../../Types/Company/CompanySize";
+import JobRole from "../../../Types/Company/JobRole";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { getJestSpyOn } from "../../Spy";
+
+/*
+ * A project is hard deleted, so the snapshot this service writes is the only
+ * thing left of it. Anything it drops on the floor - the reason the customer
+ * gave, the address to reach them on, what they were paying - cannot be
+ * recovered afterwards, which is what every case below is about.
+ *
+ * Billing is on for this file: the audit trail exists so OneUptime can follow
+ * up with a SaaS customer. IsBillingEnabled is read at import time, so the
+ * self-hosted case needs its own module registry and lives in
+ * DeletedProjectServiceSelfHosted.test.ts.
+ */
+jest.mock("../../../Server/EnvironmentConfig", () => {
+  return {
+    ...jest.requireActual("../../../Server/EnvironmentConfig"),
+    IsBillingEnabled: true,
+  };
+});
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const CREATOR_USER_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const OTHER_USER_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+type MakeCreatorFunction = () => User;
+
+const makeCreator: MakeCreatorFunction = (): User => {
+  const user: User = new User();
+  user._id = CREATOR_USER_ID.toString();
+  user.name = new Name("Jane Creator");
+  user.email = new Email("jane@acme.com");
+  user.companyName = "Acme Inc.";
+  user.companyPhoneNumber = new Phone("+15555550100");
+  user.companySize = CompanySize.ElevenToFifty;
+  user.jobRole = JobRole.EngineeringManager;
+
+  return user;
+};
+
+type MakeProjectFunction = (overrides?: Partial<Project>) => Project;
+
+const makeProject: MakeProjectFunction = (
+  overrides?: Partial<Project>,
+): Project => {
+  const project: Project = new Project();
+  project._id = PROJECT_ID.toString();
+  project.name = "Acme Monitoring";
+  project.slug = "acme-monitoring";
+  project.createdAt = new Date("2024-01-01T00:00:00.000Z");
+  project.planName = PlanType.Growth;
+  project.paymentProviderPlanId = "price_growth";
+  project.paymentProviderCustomerId = "cus_123";
+  project.paymentProviderSubscriptionId = "sub_123";
+  project.paymentProviderSubscriptionStatus = SubscriptionStatus.Active;
+  project.paymentProviderSubscriptionSeats = 7;
+  project.trialEndsAt = new Date("2024-02-01T00:00:00.000Z");
+  project.currentActiveMonitorsCount = 12;
+  project.isBlocked = false;
+  project.createdByUserId = CREATOR_USER_ID;
+  project.createdByUser = makeCreator();
+
+  return Object.assign(project, overrides || {});
+};
+
+describe("DeletedProjectService.logProjectDeletion", () => {
+  let created: Array<CreateBy<DeletedProject>> = [];
+
+  beforeEach(() => {
+    created = [];
+
+    getJestSpyOn(DeletedProjectService, "create").mockImplementation((async (
+      createBy: CreateBy<DeletedProject>,
+    ) => {
+      created.push(createBy);
+      return createBy.data;
+    }) as never);
+
+    getJestSpyOn(UserService, "findOneById").mockResolvedValue(null as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("writes one row for the deleted project", async () => {
+    await DeletedProjectService.logProjectDeletion({
+      project: makeProject(),
+      deletedByUserId: CREATOR_USER_ID,
+      deletionReason: "We moved to a single project",
+    });
+
+    expect(created).toHaveLength(1);
+    expect(created[0]?.data.projectId?.toString()).toBe(PROJECT_ID.toString());
+    expect(created[0]?.data.projectName).toBe("Acme Monitoring");
+  });
+
+  /*
+   * The table has empty access control arrays, so nothing but a root write can
+   * ever land a row in it.
+   */
+  it("writes as root, because no user permission can write this table", async () => {
+    await DeletedProjectService.logProjectDeletion({
+      project: makeProject(),
+      deletedByUserId: CREATOR_USER_ID,
+    });
+
+    expect(created[0]?.props).toEqual({ isRoot: true });
+  });
+
+  it("keeps the reason the customer typed, which is the whole point", async () => {
+    await DeletedProjectService.logProjectDeletion({
+      project: makeProject(),
+      deletedByUserId: CREATOR_USER_ID,
+      deletionReason: "Too expensive for our team size",
+    });
+
+    expect(created[0]?.data.deletionReason).toBe(
+      "Too expensive for our team size",
+    );
+  });
+
+  it("still records the deletion when no reason was given", async () => {
+    await DeletedProjectService.logProjectDeletion({
+      project: makeProject(),
+      deletedByUserId: CREATOR_USER_ID,
+    });
+
+    expect(created).toHaveLength(1);
+    expect(created[0]?.data.deletionReason).toBeUndefined();
+  });
+
+  it("copies the project snapshot rather than relating to the deleted row", async () => {
+    await DeletedProjectService.logProjectDeletion({
+      project: makeProject(),
+      deletedByUserId: CREATOR_USER_ID,
+    });
+
+    const row: DeletedProject = created[0]!.data;
+
+    expect(row.projectSlug).toBe("acme-monitoring");
+    expect(row.projectCreatedAt).toEqual(new Date("2024-01-01T00:00:00.000Z"));
+    expect(row.planName).toBe("Growth");
+    expect(row.paymentProviderPlanId).toBe("price_growth");
+    expect(row.paymentProviderCustomerId).toBe("cus_123");
+    expect(row.paymentProviderSubscriptionId).toBe("sub_123");
+    expect(row.paymentProviderSubscriptionStatus).toBe(
+      SubscriptionStatus.Active,
+    );
+    expect(row.paymentProviderSubscriptionSeats).toBe(7);
+    expect(row.trialEndsAt).toEqual(new Date("2024-02-01T00:00:00.000Z"));
+    expect(row.activeMonitorCount).toBe(12);
+    expect(row.wasProjectBlocked).toBe(false);
+  });
+
+  it("stamps the time of the deletion", async () => {
+    const before: number = Date.now();
+
+    await DeletedProjectService.logProjectDeletion({
+      project: makeProject(),
+      deletedByUserId: CREATOR_USER_ID,
+    });
+
+    const deletedAt: Date | undefined = created[0]?.data.projectDeletedAt;
+
+    expect(deletedAt).toBeInstanceOf(Date);
+    expect(deletedAt!.getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  it("records that a blocked project was deleted, which is a different story", async () => {
+    await DeletedProjectService.logProjectDeletion({
+      project: makeProject({ isBlocked: true }),
+      deletedByUserId: CREATOR_USER_ID,
+    });
+
+    expect(created[0]?.data.wasProjectBlocked).toBe(true);
+  });
+
+  describe("who to reach out to", () => {
+    it("records the creator of the project", async () => {
+      await DeletedProjectService.logProjectDeletion({
+        project: makeProject(),
+        deletedByUserId: CREATOR_USER_ID,
+      });
+
+      const row: DeletedProject = created[0]!.data;
+
+      expect(row.projectCreatedByUserId?.toString()).toBe(
+        CREATOR_USER_ID.toString(),
+      );
+      expect(row.projectCreatedByUserName).toBe("Jane Creator");
+      expect(row.projectCreatedByUserEmail?.toString()).toBe("jane@acme.com");
+    });
+
+    /*
+     * The common case: the owner deletes their own project. Looking the same
+     * user up again would be a wasted query on a path that already did one.
+     */
+    it("does not re-query the user when the creator deleted their own project", async () => {
+      await DeletedProjectService.logProjectDeletion({
+        project: makeProject(),
+        deletedByUserId: CREATOR_USER_ID,
+      });
+
+      expect(UserService.findOneById).not.toHaveBeenCalled();
+      expect(created[0]?.data.projectDeletedByUserName).toBe("Jane Creator");
+      expect(created[0]?.data.projectDeletedByUserEmail?.toString()).toBe(
+        "jane@acme.com",
+      );
+    });
+
+    it("looks up the deleting user when it was not the creator", async () => {
+      const other: User = new User();
+      other._id = OTHER_USER_ID.toString();
+      other.name = new Name("Sam Admin");
+      other.email = new Email("sam@acme.com");
+
+      getJestSpyOn(UserService, "findOneById").mockResolvedValue(
+        other as never,
+      );
+
+      await DeletedProjectService.logProjectDeletion({
+        project: makeProject(),
+        deletedByUserId: OTHER_USER_ID,
+      });
+
+      expect(UserService.findOneById).toHaveBeenCalled();
+
+      const row: DeletedProject = created[0]!.data;
+
+      expect(row.projectDeletedByUserId?.toString()).toBe(
+        OTHER_USER_ID.toString(),
+      );
+      expect(row.projectDeletedByUserName).toBe("Sam Admin");
+      expect(row.projectDeletedByUserEmail?.toString()).toBe("sam@acme.com");
+      // The creator is still recorded separately.
+      expect(row.projectCreatedByUserName).toBe("Jane Creator");
+    });
+
+    /*
+     * API-key and root deletes have no acting user. The row is still worth
+     * writing - the project and its billing history are the interesting part.
+     */
+    it("records the deletion when no user is attached to it", async () => {
+      await DeletedProjectService.logProjectDeletion({
+        project: makeProject(),
+      });
+
+      expect(UserService.findOneById).not.toHaveBeenCalled();
+      expect(created).toHaveLength(1);
+      expect(created[0]?.data.projectDeletedByUserId).toBeUndefined();
+      expect(created[0]?.data.projectDeletedByUserName).toBeUndefined();
+    });
+
+    it("survives the deleting user no longer being findable", async () => {
+      getJestSpyOn(UserService, "findOneById").mockResolvedValue(null as never);
+
+      await DeletedProjectService.logProjectDeletion({
+        project: makeProject(),
+        deletedByUserId: OTHER_USER_ID,
+      });
+
+      expect(created).toHaveLength(1);
+      expect(created[0]?.data.projectDeletedByUserId?.toString()).toBe(
+        OTHER_USER_ID.toString(),
+      );
+      expect(created[0]?.data.projectDeletedByUserName).toBeUndefined();
+    });
+
+    it("records the deletion for a project whose creator is gone", async () => {
+      const project: Project = makeProject();
+      delete project.createdByUser;
+      delete project.createdByUserId;
+
+      await DeletedProjectService.logProjectDeletion({
+        project: project,
+        deletionReason: "No longer needed",
+      });
+
+      expect(created).toHaveLength(1);
+      expect(created[0]?.data.projectCreatedByUserName).toBeUndefined();
+      expect(created[0]?.data.deletionReason).toBe("No longer needed");
+    });
+  });
+
+  describe("company details", () => {
+    it("takes the company from the user who created the project", async () => {
+      await DeletedProjectService.logProjectDeletion({
+        project: makeProject(),
+        deletedByUserId: CREATOR_USER_ID,
+      });
+
+      const row: DeletedProject = created[0]!.data;
+
+      expect(row.companyName).toBe("Acme Inc.");
+      expect(row.companyPhoneNumber?.toString()).toBe("+15555550100");
+      expect(row.companySize).toBe(CompanySize.ElevenToFifty);
+      expect(row.jobRole).toBe(JobRole.EngineeringManager);
+    });
+
+    /*
+     * Company details are collected at signup, so an invited teammate often
+     * has none. Falling back keeps a usable answer on the row.
+     */
+    it("falls back to the deleting user when the creator has no company on file", async () => {
+      const project: Project = makeProject();
+      project.createdByUser = new User();
+      project.createdByUser._id = CREATOR_USER_ID.toString();
+      project.createdByUser.name = new Name("Jane Creator");
+
+      const deleter: User = new User();
+      deleter._id = OTHER_USER_ID.toString();
+      deleter.companyName = "Acme Subsidiary";
+      deleter.companyPhoneNumber = new Phone("+15555550199");
+      deleter.companySize = CompanySize.FiveHundredAndMore;
+      deleter.jobRole = JobRole.CTO;
+
+      getJestSpyOn(UserService, "findOneById").mockResolvedValue(
+        deleter as never,
+      );
+
+      await DeletedProjectService.logProjectDeletion({
+        project: project,
+        deletedByUserId: OTHER_USER_ID,
+      });
+
+      const row: DeletedProject = created[0]!.data;
+
+      expect(row.companyName).toBe("Acme Subsidiary");
+      expect(row.companyPhoneNumber?.toString()).toBe("+15555550199");
+      expect(row.companySize).toBe(CompanySize.FiveHundredAndMore);
+      expect(row.jobRole).toBe(JobRole.CTO);
+    });
+
+    it("prefers the creator's company over the deleting user's", async () => {
+      const deleter: User = new User();
+      deleter._id = OTHER_USER_ID.toString();
+      deleter.companyName = "Somewhere Else";
+
+      getJestSpyOn(UserService, "findOneById").mockResolvedValue(
+        deleter as never,
+      );
+
+      await DeletedProjectService.logProjectDeletion({
+        project: makeProject(),
+        deletedByUserId: OTHER_USER_ID,
+      });
+
+      expect(created[0]?.data.companyName).toBe("Acme Inc.");
+    });
+
+    it("writes the row even when nobody filled in a company", async () => {
+      const project: Project = makeProject();
+      project.createdByUser = new User();
+      project.createdByUser._id = CREATOR_USER_ID.toString();
+
+      await DeletedProjectService.logProjectDeletion({
+        project: project,
+        deletedByUserId: CREATOR_USER_ID,
+      });
+
+      expect(created).toHaveLength(1);
+      expect(created[0]?.data.companyName).toBeUndefined();
+    });
+  });
+
+  /*
+   * The project id is what makes the row identifiable at all. A project
+   * without one cannot have been in the database, so there is nothing to log.
+   */
+  it("does not write a row for a project with no id", async () => {
+    const project: Project = makeProject();
+    delete project._id;
+
+    const result: DeletedProject | null =
+      await DeletedProjectService.logProjectDeletion({
+        project: project,
+        deletedByUserId: CREATOR_USER_ID,
+      });
+
+    expect(result).toBeNull();
+    expect(created).toHaveLength(0);
+  });
+
+  it("returns the row it wrote", async () => {
+    const result: DeletedProject | null =
+      await DeletedProjectService.logProjectDeletion({
+        project: makeProject(),
+        deletedByUserId: CREATOR_USER_ID,
+      });
+
+    expect(result).not.toBeNull();
+    expect(result?.projectName).toBe("Acme Monitoring");
+  });
+});

--- a/Common/Tests/Server/Services/DeletedProjectServiceSelfHosted.test.ts
+++ b/Common/Tests/Server/Services/DeletedProjectServiceSelfHosted.test.ts
@@ -1,0 +1,70 @@
+import DeletedProjectService from "../../../Server/Services/DeletedProjectService";
+import UserService from "../../../Server/Services/UserService";
+import DeletedProject from "../../../Models/DatabaseModels/DeletedProject";
+import Project from "../../../Models/DatabaseModels/Project";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { getJestSpyOn } from "../../Spy";
+
+/*
+ * The deletion audit trail is for reaching out to SaaS customers who left.
+ * A self-hosted install has nobody to reach out to, and the operator deleting
+ * their own project has not agreed to OneUptime keeping a copy of who they
+ * are - so on IsBillingEnabled=false nothing is recorded at all.
+ *
+ * The flag is read at module scope, so this is a separate file from the
+ * billing-on suite rather than a case inside it.
+ */
+jest.mock("../../../Server/EnvironmentConfig", () => {
+  return {
+    ...jest.requireActual("../../../Server/EnvironmentConfig"),
+    IsBillingEnabled: false,
+  };
+});
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const USER_ID: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+
+describe("DeletedProjectService.logProjectDeletion on a self-hosted install", () => {
+  beforeEach(() => {
+    getJestSpyOn(DeletedProjectService, "create").mockResolvedValue(
+      new DeletedProject() as never,
+    );
+    getJestSpyOn(UserService, "findOneById").mockResolvedValue(null as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("does not record anything", async () => {
+    const project: Project = new Project();
+    project._id = PROJECT_ID.toString();
+    project.name = "Self Hosted Project";
+
+    const result: DeletedProject | null =
+      await DeletedProjectService.logProjectDeletion({
+        project: project,
+        deletedByUserId: USER_ID,
+        deletionReason: "Shutting down the instance",
+      });
+
+    expect(result).toBeNull();
+    expect(DeletedProjectService.create).not.toHaveBeenCalled();
+  });
+
+  it("does not go looking up the user either", async () => {
+    const project: Project = new Project();
+    project._id = PROJECT_ID.toString();
+    project.name = "Self Hosted Project";
+
+    await DeletedProjectService.logProjectDeletion({
+      project: project,
+      deletedByUserId: USER_ID,
+    });
+
+    expect(UserService.findOneById).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Services/ProjectServiceDeleteAudit.test.ts
+++ b/Common/Tests/Server/Services/ProjectServiceDeleteAudit.test.ts
@@ -1,0 +1,406 @@
+import ProjectService from "../../../Server/Services/ProjectService";
+import BillingService from "../../../Server/Services/BillingService";
+import DeletedProjectService from "../../../Server/Services/DeletedProjectService";
+import DeleteBy from "../../../Server/Types/Database/DeleteBy";
+import FindBy from "../../../Server/Types/Database/FindBy";
+import { OnDelete } from "../../../Server/Types/Database/Hooks";
+import Select from "../../../Server/Types/Database/Select";
+import logger from "../../../Server/Utils/Logger";
+import DeletedProject from "../../../Models/DatabaseModels/DeletedProject";
+import Project from "../../../Models/DatabaseModels/Project";
+import User from "../../../Models/DatabaseModels/User";
+import ObjectID from "../../../Types/ObjectID";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+import { getJestSpyOn } from "../../Spy";
+
+/*
+ * Deleting a project is the one moment OneUptime learns that a customer has
+ * left, and it is irreversible: the rows are hard deleted and every detail of
+ * the account goes with them. These tests pin the two things that make the
+ * DeletedProject record trustworthy - that onBeforeDelete reads the snapshot
+ * while the project still exists, and that onDeleteSuccess writes it before
+ * anything else in the hook can fail.
+ *
+ * Nothing below the service boundary runs: no database, no Stripe, no Slack.
+ */
+jest.mock("../../../Server/EnvironmentConfig", () => {
+  return {
+    ...jest.requireActual("../../../Server/EnvironmentConfig"),
+    IsBillingEnabled: true,
+
+    /*
+     * config.env may carry a real incoming webhook and onDeleteSuccess posts
+     * every project deletion to it. Blanked so the suite cannot post to Slack.
+     */
+    NotificationSlackWebhookOnDeleteProject: "",
+  };
+});
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const USER_ID: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+
+type MakeProjectFunction = (id?: ObjectID) => Project;
+
+const makeProject: MakeProjectFunction = (id?: ObjectID): Project => {
+  const project: Project = new Project();
+  project._id = (id || PROJECT_ID).toString();
+  project.name = "Acme Monitoring";
+  project.paymentProviderSubscriptionId = "sub_123";
+  project.paymentProviderMeteredSubscriptionId = "sub_metered_123";
+
+  return project;
+};
+
+type MakeDeleteByFunction = (
+  overrides?: Partial<DeleteBy<Project>>,
+) => DeleteBy<Project>;
+
+const makeDeleteBy: MakeDeleteByFunction = (
+  overrides?: Partial<DeleteBy<Project>>,
+): DeleteBy<Project> => {
+  return {
+    query: { _id: PROJECT_ID.toString() },
+    limit: 10,
+    skip: 0,
+    props: { isRoot: false, userId: USER_ID },
+    ...(overrides || {}),
+  } as DeleteBy<Project>;
+};
+
+/*
+ * onBeforeDelete and onDeleteSuccess are protected - DatabaseService is what
+ * calls them. Reaching them directly is the only way to test them without a
+ * database.
+ */
+type CallOnBeforeDeleteFunction = (
+  deleteBy: DeleteBy<Project>,
+) => Promise<OnDelete<Project>>;
+
+const callOnBeforeDelete: CallOnBeforeDeleteFunction = (
+  deleteBy: DeleteBy<Project>,
+): Promise<OnDelete<Project>> => {
+  return (
+    ProjectService as unknown as {
+      onBeforeDelete: (d: DeleteBy<Project>) => Promise<OnDelete<Project>>;
+    }
+  ).onBeforeDelete(deleteBy);
+};
+
+type CallOnDeleteSuccessFunction = (
+  onDelete: OnDelete<Project>,
+  deletedIds: Array<ObjectID>,
+) => Promise<OnDelete<Project>>;
+
+const callOnDeleteSuccess: CallOnDeleteSuccessFunction = (
+  onDelete: OnDelete<Project>,
+  deletedIds: Array<ObjectID>,
+): Promise<OnDelete<Project>> => {
+  return (
+    ProjectService as unknown as {
+      onDeleteSuccess: (
+        d: OnDelete<Project>,
+        ids: Array<ObjectID>,
+      ) => Promise<OnDelete<Project>>;
+    }
+  ).onDeleteSuccess(onDelete, deletedIds);
+};
+
+interface LoggedDeletion {
+  project: Project;
+  deletedByUserId?: ObjectID | undefined;
+  deletionReason?: string | undefined;
+}
+
+describe("ProjectService.onBeforeDelete", () => {
+  let findByCalls: Array<FindBy<Project>> = [];
+
+  beforeEach(() => {
+    findByCalls = [];
+
+    getJestSpyOn(ProjectService, "findBy").mockImplementation((async (
+      findBy: FindBy<Project>,
+    ) => {
+      findByCalls.push(findBy);
+      return [makeProject()];
+    }) as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("carries the projects forward, because they cannot be read after the delete", async () => {
+    const onDelete: OnDelete<Project> =
+      await callOnBeforeDelete(makeDeleteBy());
+
+    expect(onDelete.carryForward).toHaveLength(1);
+    expect(onDelete.carryForward[0].name).toBe("Acme Monitoring");
+  });
+
+  it("reads the projects the delete query matches, as root", async () => {
+    await callOnBeforeDelete(makeDeleteBy());
+
+    expect(findByCalls).toHaveLength(1);
+    expect(findByCalls[0]?.query).toEqual({ _id: PROJECT_ID.toString() });
+    expect(findByCalls[0]?.props).toEqual({ isRoot: true });
+  });
+
+  /*
+   * Every one of these columns ends up on the DeletedProject row. A column
+   * missing from this select is a column that is silently blank in the audit
+   * trail forever - there is no second chance to read it.
+   */
+  it("selects everything the deletion record needs", async () => {
+    await callOnBeforeDelete(makeDeleteBy());
+
+    const select: Select<Project> = findByCalls[0]!.select as Select<Project>;
+
+    for (const column of [
+      "name",
+      "slug",
+      "createdAt",
+      "planName",
+      "paymentProviderPlanId",
+      "paymentProviderCustomerId",
+      "paymentProviderSubscriptionId",
+      "paymentProviderSubscriptionStatus",
+      "paymentProviderSubscriptionSeats",
+      "trialEndsAt",
+      "currentActiveMonitorsCount",
+      "isBlocked",
+      "createdByUserId",
+    ]) {
+      expect(select).toHaveProperty(column, true);
+    }
+  });
+
+  it("selects the creator's contact and company details", async () => {
+    await callOnBeforeDelete(makeDeleteBy());
+
+    const select: Select<Project> = findByCalls[0]!.select as Select<Project>;
+
+    for (const column of [
+      "name",
+      "email",
+      "companyName",
+      "companyPhoneNumber",
+      "companySize",
+      "jobRole",
+    ]) {
+      expect(select["createdByUser"]).toHaveProperty(column, true);
+    }
+  });
+
+  it("still selects what cancelling the subscriptions needs", async () => {
+    await callOnBeforeDelete(makeDeleteBy());
+
+    const select: Select<Project> = findByCalls[0]!.select as Select<Project>;
+
+    expect(select).toHaveProperty("paymentProviderSubscriptionId", true);
+    expect(select).toHaveProperty("paymentProviderMeteredSubscriptionId", true);
+  });
+});
+
+describe("ProjectService.onDeleteSuccess", () => {
+  let logged: Array<LoggedDeletion> = [];
+
+  beforeEach(() => {
+    logged = [];
+
+    getJestSpyOn(
+      DeletedProjectService,
+      "logProjectDeletion",
+    ).mockImplementation((async (data: LoggedDeletion) => {
+      logged.push(data);
+      return new DeletedProject();
+    }) as never);
+
+    getJestSpyOn(BillingService, "cancelSubscription").mockResolvedValue(
+      undefined as never,
+    );
+    getJestSpyOn(BillingService, "getSubscriptionStatus").mockResolvedValue(
+      "canceled" as never,
+    );
+    getJestSpyOn(logger, "error").mockImplementation((() => {}) as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("records the project that was deleted", async () => {
+    await callOnDeleteSuccess(
+      { deleteBy: makeDeleteBy(), carryForward: [makeProject()] },
+      [PROJECT_ID],
+    );
+
+    expect(logged).toHaveLength(1);
+    expect(logged[0]?.project.name).toBe("Acme Monitoring");
+  });
+
+  it("records who deleted it", async () => {
+    await callOnDeleteSuccess(
+      { deleteBy: makeDeleteBy(), carryForward: [makeProject()] },
+      [PROJECT_ID],
+    );
+
+    expect(logged[0]?.deletedByUserId?.toString()).toBe(USER_ID.toString());
+  });
+
+  it("records why they said they were deleting it", async () => {
+    await callOnDeleteSuccess(
+      {
+        deleteBy: makeDeleteBy({
+          deletionReason: "Switching to a different tool",
+        }),
+        carryForward: [makeProject()],
+      },
+      [PROJECT_ID],
+    );
+
+    expect(logged[0]?.deletionReason).toBe("Switching to a different tool");
+  });
+
+  it("records the deletion even when no reason was given", async () => {
+    await callOnDeleteSuccess(
+      { deleteBy: makeDeleteBy(), carryForward: [makeProject()] },
+      [PROJECT_ID],
+    );
+
+    expect(logged).toHaveLength(1);
+    expect(logged[0]?.deletionReason).toBeUndefined();
+  });
+
+  /*
+   * deletedByUser is the caller-supplied actor and takes priority over the
+   * authenticated user - the same precedence every other delete hook uses.
+   */
+  it("prefers an explicitly supplied actor over the authenticated user", async () => {
+    const actorId: ObjectID = new ObjectID(
+      "55555555-5555-4555-8555-555555555555",
+    );
+    const actor: User = new User();
+    actor._id = actorId.toString();
+
+    await callOnDeleteSuccess(
+      {
+        deleteBy: makeDeleteBy({ deletedByUser: actor }),
+        carryForward: [makeProject()],
+      },
+      [PROJECT_ID],
+    );
+
+    expect(logged[0]?.deletedByUserId?.toString()).toBe(actorId.toString());
+  });
+
+  it("records every project when several are deleted at once", async () => {
+    await callOnDeleteSuccess(
+      {
+        deleteBy: makeDeleteBy(),
+        carryForward: [makeProject(), makeProject(OTHER_PROJECT_ID)],
+      },
+      [PROJECT_ID, OTHER_PROJECT_ID],
+    );
+
+    expect(logged).toHaveLength(2);
+  });
+
+  /*
+   * onBeforeDelete snapshots whatever the query matched. Permissions can then
+   * narrow the delete, so a project in the snapshot is not necessarily a
+   * project that was deleted - and recording one that still exists would send
+   * a "sorry you left" email to a live customer.
+   */
+  it("does not record a project that was not actually deleted", async () => {
+    await callOnDeleteSuccess(
+      {
+        deleteBy: makeDeleteBy(),
+        carryForward: [makeProject(), makeProject(OTHER_PROJECT_ID)],
+      },
+      [PROJECT_ID],
+    );
+
+    expect(logged).toHaveLength(1);
+    expect(logged[0]?.project.id?.toString()).toBe(PROJECT_ID.toString());
+  });
+
+  /*
+   * The project is already gone by the time this hook runs. Failing the
+   * request because the audit write failed would tell the customer their
+   * delete did not work when it did.
+   */
+  it("does not fail the delete when the audit write throws", async () => {
+    getJestSpyOn(DeletedProjectService, "logProjectDeletion").mockRejectedValue(
+      new Error("audit table unreachable") as never,
+    );
+
+    await expect(
+      callOnDeleteSuccess(
+        { deleteBy: makeDeleteBy(), carryForward: [makeProject()] },
+        [PROJECT_ID],
+      ),
+    ).resolves.toBeDefined();
+
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it("still cancels the subscription when the audit write throws", async () => {
+    getJestSpyOn(DeletedProjectService, "logProjectDeletion").mockRejectedValue(
+      new Error("audit table unreachable") as never,
+    );
+
+    await callOnDeleteSuccess(
+      { deleteBy: makeDeleteBy(), carryForward: [makeProject()] },
+      [PROJECT_ID],
+    );
+
+    expect(BillingService.cancelSubscription).toHaveBeenCalledWith("sub_123");
+  });
+
+  /*
+   * Ordering is the point: Stripe is a network call that can and does fail,
+   * and the customer whose cancellation errored is exactly the one worth
+   * following up with. Recording first means the row survives that failure.
+   */
+  it("records the deletion before it touches billing", async () => {
+    const callOrder: Array<string> = [];
+
+    getJestSpyOn(
+      DeletedProjectService,
+      "logProjectDeletion",
+    ).mockImplementation((async () => {
+      callOrder.push("audit");
+      return new DeletedProject();
+    }) as never);
+
+    getJestSpyOn(BillingService, "cancelSubscription").mockImplementation(
+      (async () => {
+        callOrder.push("billing");
+        throw new Error("stripe is down");
+      }) as never,
+    );
+
+    await expect(
+      callOnDeleteSuccess(
+        { deleteBy: makeDeleteBy(), carryForward: [makeProject()] },
+        [PROJECT_ID],
+      ),
+    ).rejects.toThrow("stripe is down");
+
+    expect(callOrder).toEqual(["audit", "billing"]);
+  });
+
+  it("records nothing when nothing was deleted", async () => {
+    await callOnDeleteSuccess(
+      { deleteBy: makeDeleteBy(), carryForward: [] },
+      [],
+    );
+
+    expect(logged).toHaveLength(0);
+  });
+});

--- a/Common/Tests/UI/Components/ModelDelete.test.tsx
+++ b/Common/Tests/UI/Components/ModelDelete.test.tsx
@@ -1,0 +1,214 @@
+import ModelDelete from "../../../UI/Components/ModelDelete/ModelDelete";
+import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
+import Project from "../../../Models/DatabaseModels/Project";
+import ObjectID from "../../../Types/ObjectID";
+import { describe, expect, it, beforeEach } from "@jest/globals";
+import { getJestSpyOn } from "../../Spy";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import React, { ReactElement } from "react";
+
+/*
+ * ModelDelete is the confirmation behind every "Delete <thing>" card in the
+ * product. Two things were added to it so the project delete can ask why the
+ * customer is leaving: content inside the confirmation, and a delete action
+ * the caller supplies. Both are optional, and the ~60 existing call sites pass
+ * neither - so the default path is pinned here just as hard as the new one.
+ */
+
+const MODEL_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+
+type RenderDeleteFunction = (props?: {
+  confirmationContent?: ReactElement | undefined;
+  onDelete?: (() => Promise<void>) | undefined;
+  onDeleteSuccess?: (() => void) | undefined;
+}) => void;
+
+const renderDelete: RenderDeleteFunction = (props?: {
+  confirmationContent?: ReactElement | undefined;
+  onDelete?: (() => Promise<void>) | undefined;
+  onDeleteSuccess?: (() => void) | undefined;
+}): void => {
+  render(
+    <ModelDelete
+      modelType={Project}
+      modelId={MODEL_ID}
+      onDeleteSuccess={props?.onDeleteSuccess || ((): void => {})}
+      {...(props?.confirmationContent
+        ? { confirmationContent: props.confirmationContent }
+        : {})}
+      {...(props?.onDelete ? { onDelete: props.onDelete } : {})}
+    />,
+  );
+};
+
+type OpenConfirmationFunction = () => void;
+
+const openConfirmation: OpenConfirmationFunction = (): void => {
+  // The card's own button - the card title has the same words but is a heading.
+  fireEvent.click(
+    screen.getByRole("button", { name: "Delete Project" }) as HTMLElement,
+  );
+};
+
+describe("ModelDelete", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("does not open the confirmation until the delete button is pressed", () => {
+    renderDelete();
+
+    expect(screen.queryByTestId("confirm-modal-description")).toBeNull();
+  });
+
+  it("asks for confirmation before deleting anything", async () => {
+    const deleteItem: jest.SpyInstance = getJestSpyOn(
+      ModelAPI,
+      "deleteItem",
+    ).mockResolvedValue(undefined);
+
+    renderDelete();
+    openConfirmation();
+
+    expect(screen.getByTestId("confirm-modal-description")).toBeInTheDocument();
+    expect(deleteItem).not.toHaveBeenCalled();
+  });
+
+  it("deletes the model by id when no custom delete is given", async () => {
+    const deleteItem: jest.SpyInstance = getJestSpyOn(
+      ModelAPI,
+      "deleteItem",
+    ).mockResolvedValue(undefined);
+
+    renderDelete();
+    openConfirmation();
+
+    fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+
+    await waitFor(() => {
+      expect(deleteItem).toHaveBeenCalledWith({
+        modelType: Project,
+        id: MODEL_ID,
+      });
+    });
+  });
+
+  it("renders the extra confirmation content inside the modal", () => {
+    renderDelete({
+      confirmationContent: (
+        <label data-testid="reason-field">
+          Why are you deleting this project?
+        </label>
+      ),
+    });
+
+    expect(screen.queryByTestId("reason-field")).toBeNull();
+
+    openConfirmation();
+
+    expect(screen.getByTestId("reason-field")).toBeInTheDocument();
+    expect(
+      screen.getByText("Why are you deleting this project?"),
+    ).toBeInTheDocument();
+    // The confirmation itself is still there.
+    expect(screen.getByTestId("confirm-modal-description")).toBeInTheDocument();
+  });
+
+  /*
+   * The project delete has to send the reason with it, which the generic
+   * DELETE cannot carry - so the caller supplies the whole request.
+   */
+  it("runs the caller's delete instead of the generic one", async () => {
+    const deleteItem: jest.SpyInstance = getJestSpyOn(
+      ModelAPI,
+      "deleteItem",
+    ).mockResolvedValue(undefined);
+
+    let customDeleteRan: boolean = false;
+
+    renderDelete({
+      onDelete: async (): Promise<void> => {
+        customDeleteRan = true;
+      },
+    });
+
+    openConfirmation();
+    fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+
+    await waitFor(() => {
+      expect(customDeleteRan).toBe(true);
+    });
+
+    expect(deleteItem).not.toHaveBeenCalled();
+  });
+
+  it("reports success after the caller's delete resolves", async () => {
+    let deletedSuccessfully: boolean = false;
+
+    renderDelete({
+      onDelete: async (): Promise<void> => {},
+      onDeleteSuccess: (): void => {
+        deletedSuccessfully = true;
+      },
+    });
+
+    openConfirmation();
+    fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+
+    await waitFor(() => {
+      expect(deletedSuccessfully).toBe(true);
+    });
+  });
+
+  /*
+   * A failed delete must not look like a successful one: the dashboard's
+   * success handler clears the current project and navigates away from it.
+   */
+  it("shows the error and does not report success when the delete fails", async () => {
+    let deletedSuccessfully: boolean = false;
+
+    renderDelete({
+      onDelete: async (): Promise<void> => {
+        throw new Error("Delete on Project is not allowed");
+      },
+      onDeleteSuccess: (): void => {
+        deletedSuccessfully = true;
+      },
+    });
+
+    openConfirmation();
+    fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete Error")).toBeInTheDocument();
+    });
+
+    expect(deletedSuccessfully).toBe(false);
+  });
+
+  it("closes the confirmation without deleting when it is dismissed", async () => {
+    const deleteItem: jest.SpyInstance = getJestSpyOn(
+      ModelAPI,
+      "deleteItem",
+    ).mockResolvedValue(undefined);
+
+    let customDeleteRan: boolean = false;
+
+    renderDelete({
+      onDelete: async (): Promise<void> => {
+        customDeleteRan = true;
+      },
+    });
+
+    openConfirmation();
+    fireEvent.click(screen.getByTestId("modal-footer-close-button"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("confirm-modal-description")).toBeNull();
+    });
+
+    expect(customDeleteRan).toBe(false);
+    expect(deleteItem).not.toHaveBeenCalled();
+  });
+});

--- a/Common/UI/Components/Modal/ConfirmModal.tsx
+++ b/Common/UI/Components/Modal/ConfirmModal.tsx
@@ -15,6 +15,8 @@ export interface ComponentProps {
   isLoading?: boolean;
   error?: string | undefined;
   disableSubmitButton?: boolean | undefined;
+  // Rendered under the description - for confirmations that also ask something.
+  children?: ReactElement | undefined;
 }
 
 const ConfirmModal: FunctionComponent<ComponentProps> = (
@@ -51,11 +53,14 @@ const ConfirmModal: FunctionComponent<ComponentProps> = (
        * a long confirmation two nested scrollbars, and the inner one clipped
        * the text well short of the space the modal had spare.
        */}
-      <div
-        data-testid="confirm-modal-description"
-        className="whitespace-pre-wrap break-words text-sm leading-6 text-gray-600"
-      >
-        {translatedDescription}
+      <div>
+        <div
+          data-testid="confirm-modal-description"
+          className="whitespace-pre-wrap break-words text-sm leading-6 text-gray-600"
+        >
+          {translatedDescription}
+        </div>
+        {props.children ? <div className="mt-4">{props.children}</div> : <></>}
       </div>
     </Modal>
   );

--- a/Common/UI/Components/ModelDelete/ModelDelete.tsx
+++ b/Common/UI/Components/ModelDelete/ModelDelete.tsx
@@ -14,6 +14,17 @@ export interface ComponentProps<TBaseModel extends BaseModel> {
   modelId: ObjectID;
   modelAPI?: typeof ModelAPI | undefined;
   onDeleteSuccess: () => void;
+  /*
+   * Extra content for the confirmation modal - a field to fill in before
+   * confirming, for example. State for it belongs to the caller.
+   */
+  confirmationContent?: ReactElement | undefined;
+  /*
+   * Replaces the delete request itself, for models whose delete needs more
+   * than an id (see confirmationContent). Throwing surfaces the error in the
+   * same dialog the default request uses.
+   */
+  onDelete?: (() => Promise<void>) | undefined;
 }
 
 const ModelDelete: <TBaseModel extends BaseModel>(
@@ -30,12 +41,16 @@ const ModelDelete: <TBaseModel extends BaseModel>(
   const deleteItem: PromiseVoidFunction = async (): Promise<void> => {
     setIsLoading(true);
     try {
-      const modelAPI: typeof ModelAPI = props.modelAPI || ModelAPI;
+      if (props.onDelete) {
+        await props.onDelete();
+      } else {
+        const modelAPI: typeof ModelAPI = props.modelAPI || ModelAPI;
 
-      await modelAPI.deleteItem<TBaseModel>({
-        modelType: props.modelType,
-        id: props.modelId,
-      });
+        await modelAPI.deleteItem<TBaseModel>({
+          modelType: props.modelType,
+          id: props.modelId,
+        });
+      }
       props.onDeleteSuccess?.();
     } catch (err) {
       setError(API.getFriendlyMessage(err));
@@ -76,7 +91,9 @@ const ModelDelete: <TBaseModel extends BaseModel>(
           }}
           submitButtonText={`Delete ${model.singularName}`}
           submitButtonType={ButtonStyleType.DANGER}
-        />
+        >
+          {props.confirmationContent}
+        </ConfirmModal>
       ) : (
         <></>
       )}


### PR DESCRIPTION
## What

A project delete is a hard delete — the row and everything hanging off it are gone the moment it runs, so a churned account leaves no trace beyond a Slack webhook nobody can query later. And nothing asked the customer *why* they were leaving, which is the one question worth asking at exactly that moment.

This adds a `DeletedProject` table, writes a snapshot to it on every project deletion (SaaS only), and asks for a reason in the delete confirmation.

## The table

`DeletedProject` — global, master-admin only (empty table/column ACLs, the same shape `InstanceHealthLog` / `MarketingConversion` / `PromoCode` use). It holds:

- **Identity** — project id (a plain uuid, not a relation: the project row no longer exists), name, slug, created at, deleted at
- **Who** — who deleted it and who created it, each with the name and email copied onto the row so it survives those users being deleted too
- **Company** — name, phone, size, job role, taken from the project creator and falling back to whoever deleted it
- **Why** — the free-text reason the customer gave
- **What they were worth** — plan name, payment provider plan/customer/subscription ids, subscription status, seats, trial end, active monitor count, and whether the project was blocked

## The reason

Asked for in the delete confirmation on Settings → Danger Zone. A `DELETE` has nowhere to carry it, so the page posts to a new `POST /project/:id/delete-project`.

That route is the *same* delete: it runs through `ProjectService.deleteOneById` with the caller's own props, so `ModelPermission` enforces `ProjectOwner` / `DeleteProject` exactly as before, and it keeps the tenant guard `change-plan` already uses so permissions on one project cannot authorize deleting another. The reason is trimmed, capped at 5000 characters, and stripped of NUL bytes Postgres would reject.

It reaches the delete hooks through a new `deletionReason` on `DeleteById`/`DeleteOneBy`, alongside the `deletedByUser` field that already rides the same path.

## Where the row is written

In `ProjectService`'s delete hooks, not in the new route — so **every** delete is recorded (API key, master admin, the plain `DELETE /project/:id`), not just the one the dashboard uses.

- `onBeforeDelete` widens its select: after the delete there is nothing left to read.
- `onDeleteSuccess` writes the record **first**, before the Slack post and the Stripe cancellation, because those can throw — and the customer whose cancellation errored is exactly the one worth following up with.
- Only ids that were really deleted are recorded (the pre-delete snapshot is a superset once permissions narrow the delete).
- A failure to write it is logged, not raised: the project is already gone, and failing the request would tell the customer their delete did not work when it did.

## SaaS only

`DeletedProjectService.logProjectDeletion` is a no-op when `IsBillingEnabled` is false, and the question is not asked in the UI when `BILLING_ENABLED` is false. A self-hosted install has nobody to reach out to.

## Shared components

`ModelDelete` gained two optional props — content to render inside the confirmation, and a delete action the caller supplies — and `ConfirmModal` gained optional `children`. The other ~60 `ModelDelete` call sites pass neither and are unaffected.

## Tests

112 tests across 9 suites:

- `DeletedProjectModel.test.ts` — the table is global (a tenant column would cascade the audit row away with the project it records), every column is locked down, the migration is registered
- `DeletedProjectService.test.ts` / `...SelfHosted.test.ts` — field mapping, company fallback, missing/deleted users, the billing gate
- `ProjectServiceDeleteAudit.test.ts` — the snapshot select, the actually-deleted filter, error tolerance, and that the record is written **before** billing is touched
- `DatabaseServiceDeletionReason.test.ts` — the reason survives `deleteOneById` rebuilding the delete as a query, and changes nothing about permissions
- `ProjectAPI.test.ts` — tenant guard, trimming, the cap, NUL bytes, non-string input, and that the delete runs as the caller rather than as root
- `ModelDelete.test.tsx` / `DangerZone.test.tsx` — the confirmation renders the field, sends the reason **and the `tenantid` header**, and does not clear the session when the delete is refused

An adversarial review of this branch caught one real bug before it shipped: the page originally used a raw `API.post`, which does not add the `tenantid` header the way `ModelAPI` does, so the new route's tenant guard would have rejected every delete from the dashboard. Fixed, with a test that asserts the header.

## Verification

- `npm run check-postgres-schema-drift` — clean, from an empty database through every registered migration (the migration was generated by TypeORM against a live Postgres, not hand-written)
- Full `Common` suite: 20387 passed. Full `App` suite: 6565 passed. The 6 failing `Common` suites are pre-existing local-environment gaps (`pg`/`@types/pg`, `mysql2`, `mssql`, `use-async-effect` not installed on this machine) in files this branch does not touch.
- `npm run fix` clean on every file in this change; `tsc --noEmit` clean for `Common` and `App`.