### PR TITLE
fix(ui): open a real modal for "Custom Range" in the time range picker

### DIFF
--- a/Common/Tests/UI/Components/CustomTimeRangeModal.test.tsx
+++ b/Common/Tests/UI/Components/CustomTimeRangeModal.test.tsx
@@ -1,0 +1,459 @@
+/** @timezone UTC */
+import CustomTimeRangeModal, {
+  QUICK_FILL_OPTIONS,
+  getCustomTimeRangeError,
+} from "../../../UI/Components/Date/CustomTimeRangeModal";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import OneUptimeDate from "../../../Types/Date";
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+const START: Date = new Date("2024-03-01T10:00:00.000Z");
+const END: Date = new Date("2024-03-01T13:00:00.000Z");
+
+interface RenderResult {
+  saved: Array<InBetween<Date>>;
+  closes: number;
+}
+
+function renderModalWith(
+  initialValue: InBetween<Date> | undefined,
+): RenderResult {
+  const result: RenderResult = { saved: [], closes: 0 };
+
+  render(
+    <CustomTimeRangeModal
+      initialValue={initialValue}
+      onClose={() => {
+        result.closes++;
+      }}
+      onSave={(value: InBetween<Date>) => {
+        result.saved.push(value);
+      }}
+    />,
+  );
+
+  return result;
+}
+
+function renderModal(
+  initialValue: InBetween<Date> = new InBetween<Date>(START, END),
+): RenderResult {
+  return renderModalWith(initialValue);
+}
+
+function getStartInput(): HTMLInputElement {
+  return screen.getByTestId("custom-time-range-start") as HTMLInputElement;
+}
+
+function getEndInput(): HTMLInputElement {
+  return screen.getByTestId("custom-time-range-end") as HTMLInputElement;
+}
+
+/*
+ * jsdom normalises a `datetime-local` value to minute precision, so the raw
+ * string a field reports back is not comparable to what the component wrote
+ * into it. Reading the instant it names is, and these tests use whole minutes.
+ */
+function getFieldDate(input: HTMLInputElement): Date {
+  return OneUptimeDate.fromDateTimeLocalString(input.value);
+}
+
+function getApplyButton(): HTMLButtonElement {
+  return screen.getByText("Apply").closest("button") as HTMLButtonElement;
+}
+
+function typeInto(input: HTMLInputElement, value: string): void {
+  fireEvent.change(input, { target: { value: value } });
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("getCustomTimeRangeError", () => {
+  test("asks for a start when there is none", () => {
+    expect(getCustomTimeRangeError(null, END)).toBe(
+      "Pick a start date and time.",
+    );
+  });
+
+  test("asks for an end when there is none", () => {
+    expect(getCustomTimeRangeError(START, null)).toBe(
+      "Pick an end date and time.",
+    );
+  });
+
+  test("asks for a start first when both ends are missing", () => {
+    expect(getCustomTimeRangeError(null, null)).toBe(
+      "Pick a start date and time.",
+    );
+  });
+
+  test("rejects an inverted range", () => {
+    expect(getCustomTimeRangeError(END, START)).toBe(
+      "The end must be after the start. Adjust either end of the range.",
+    );
+  });
+
+  test("rejects a zero-length range", () => {
+    expect(getCustomTimeRangeError(START, new Date(START))).not.toBe("");
+  });
+
+  test("accepts a range whose end is after its start", () => {
+    expect(getCustomTimeRangeError(START, END)).toBe("");
+  });
+});
+
+describe("CustomTimeRangeModal", () => {
+  describe("rendering", () => {
+    test("renders inside a modal dialog", () => {
+      renderModal();
+
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+      expect(screen.getByTestId("custom-time-range-modal")).toBeInTheDocument();
+    });
+
+    test("uses the default title and description", () => {
+      renderModal();
+
+      expect(screen.getByTestId("modal-title").textContent).toBe(
+        "Custom Time Range",
+      );
+      expect(screen.getByTestId("modal-description").textContent).toContain(
+        "exact start and end date",
+      );
+    });
+
+    test("lets the caller override the title and description", () => {
+      render(
+        <CustomTimeRangeModal
+          initialValue={new InBetween<Date>(START, END)}
+          title="Pick log window"
+          description="Only logs in this window are shown."
+          onClose={jest.fn()}
+          onSave={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId("modal-title").textContent).toBe(
+        "Pick log window",
+      );
+      expect(screen.getByTestId("modal-description").textContent).toBe(
+        "Only logs in this window are shown.",
+      );
+    });
+
+    test("seeds both fields from the initial value", () => {
+      renderModal();
+
+      expect(getFieldDate(getStartInput()).getTime()).toBe(START.getTime());
+      expect(getFieldDate(getEndInput()).getTime()).toBe(END.getTime());
+    });
+
+    test("renders both fields with seconds enabled", () => {
+      renderModal();
+
+      expect(getStartInput().getAttribute("step")).toBe("1");
+      expect(getEndInput().getAttribute("step")).toBe("1");
+    });
+
+    test("uses datetime-local fields so the browser supplies date and time", () => {
+      renderModal();
+
+      expect(getStartInput().getAttribute("type")).toBe("datetime-local");
+      expect(getEndInput().getAttribute("type")).toBe("datetime-local");
+    });
+
+    test("labels both fields", () => {
+      renderModal();
+
+      expect(getStartInput()).toBe(screen.getByLabelText("From"));
+      expect(getEndInput()).toBe(screen.getByLabelText("To"));
+    });
+
+    test("starts empty when no initial value is given", () => {
+      renderModalWith(undefined);
+
+      expect(getStartInput().value).toBe("");
+      expect(getEndInput().value).toBe("");
+    });
+
+    test("names the timezone the times are shown in", () => {
+      renderModal();
+
+      expect(
+        screen.getByText(
+          `Times are shown in ${OneUptimeDate.getCurrentTimezoneString()}.`,
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("summary", () => {
+    test("summarises a valid window", () => {
+      renderModal();
+
+      const summary: HTMLElement = screen.getByTestId(
+        "custom-time-range-summary",
+      );
+
+      expect(summary.textContent).toContain(
+        OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(
+          START,
+          false,
+          true,
+        ),
+      );
+      expect(summary.textContent).toContain(
+        OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(
+          END,
+          false,
+          true,
+        ),
+      );
+    });
+
+    test("shows the duration of the selected window", () => {
+      renderModal();
+
+      expect(
+        screen.getByTestId("custom-time-range-summary").textContent,
+      ).toContain("3 hours");
+    });
+
+    test("replaces the summary with an error when the window is invalid", () => {
+      renderModal(new InBetween<Date>(END, START));
+
+      expect(screen.queryByTestId("custom-time-range-summary")).toBeNull();
+      expect(screen.getByTestId("custom-time-range-error")).toBeInTheDocument();
+    });
+
+    test("announces the error to assistive technology", () => {
+      renderModal(new InBetween<Date>(END, START));
+
+      expect(
+        screen.getByTestId("custom-time-range-error").getAttribute("role"),
+      ).toBe("alert");
+    });
+
+    test("recomputes the summary as the user edits a field", () => {
+      renderModal();
+
+      typeInto(getEndInput(), "2024-03-01T11:00:00");
+
+      expect(
+        screen.getByTestId("custom-time-range-summary").textContent,
+      ).toContain("1 hour");
+    });
+  });
+
+  describe("quick fill", () => {
+    test("renders every quick fill option", () => {
+      renderModal();
+
+      for (const option of QUICK_FILL_OPTIONS) {
+        expect(screen.getByText(option.label)).toBeInTheDocument();
+      }
+    });
+
+    test("fills both ends of the range from a quick fill", () => {
+      renderModal();
+
+      fireEvent.click(screen.getByText("Last 24 hours"));
+
+      const start: Date = OneUptimeDate.fromDateTimeLocalString(
+        getStartInput().value,
+      );
+      const end: Date = OneUptimeDate.fromDateTimeLocalString(
+        getEndInput().value,
+      );
+
+      expect(OneUptimeDate.getDifferenceInMinutes(start, end)).toBe(60 * 24);
+    });
+
+    test("does not apply the range on its own", () => {
+      const result: RenderResult = renderModal();
+
+      fireEvent.click(screen.getByText("Last 7 days"));
+
+      expect(result.saved).toHaveLength(0);
+      expect(result.closes).toBe(0);
+    });
+
+    test("marks the matching quick fill as pressed", () => {
+      renderModal();
+
+      fireEvent.click(screen.getByText("Last 6 hours"));
+
+      expect(
+        screen.getByText("Last 6 hours").getAttribute("aria-pressed"),
+      ).toBe("true");
+      expect(screen.getByText("Last 1 hour").getAttribute("aria-pressed")).toBe(
+        "false",
+      );
+    });
+
+    test("leaves every quick fill unpressed for a window none of them match", () => {
+      // The seeded window is three hours, which is not an offered shortcut.
+      renderModal();
+
+      for (const option of QUICK_FILL_OPTIONS) {
+        expect(
+          screen.getByText(option.label).getAttribute("aria-pressed"),
+        ).toBe("false");
+      }
+    });
+
+    test("recovers from an invalid window", () => {
+      renderModal(new InBetween<Date>(END, START));
+
+      expect(getApplyButton().hasAttribute("disabled")).toBe(true);
+
+      fireEvent.click(screen.getByText("Last 1 hour"));
+
+      expect(getApplyButton().hasAttribute("disabled")).toBe(false);
+    });
+  });
+
+  describe("editing", () => {
+    test("keeps edits local until Apply is pressed", () => {
+      const result: RenderResult = renderModal();
+
+      typeInto(getStartInput(), "2024-03-01T09:00:00");
+      typeInto(getEndInput(), "2024-03-01T12:00:00");
+
+      /*
+       * The old inline editor pushed every keystroke straight at the parent,
+       * which re-queried the backend for half-typed dates.
+       */
+      expect(result.saved).toHaveLength(0);
+    });
+
+    test("applies the edited window", () => {
+      const result: RenderResult = renderModal();
+
+      typeInto(getStartInput(), "2024-03-01T09:30:00");
+      fireEvent.click(getApplyButton());
+
+      expect(result.saved).toHaveLength(1);
+      expect(
+        OneUptimeDate.toDateTimeLocalString(result.saved[0]!.startValue),
+      ).toBe("2024-03-01T09:30:00");
+      expect(
+        OneUptimeDate.toDateTimeLocalString(result.saved[0]!.endValue),
+      ).toBe(OneUptimeDate.toDateTimeLocalString(END));
+    });
+
+    test("hands back an InBetween of dates", () => {
+      const result: RenderResult = renderModal();
+
+      fireEvent.click(getApplyButton());
+
+      expect(result.saved[0]).toBeInstanceOf(InBetween);
+      expect(result.saved[0]!.startValue).toBeInstanceOf(Date);
+      expect(result.saved[0]!.endValue).toBeInstanceOf(Date);
+    });
+
+    test("treats a cleared field as missing", () => {
+      renderModal();
+
+      typeInto(getStartInput(), "");
+
+      expect(screen.getByTestId("custom-time-range-error").textContent).toBe(
+        "Pick a start date and time.",
+      );
+    });
+
+    test("re-enables Apply once a cleared field is filled back in", () => {
+      renderModal();
+
+      typeInto(getEndInput(), "");
+      expect(getApplyButton().hasAttribute("disabled")).toBe(true);
+
+      typeInto(getEndInput(), "2024-03-01T18:00:00");
+      expect(getApplyButton().hasAttribute("disabled")).toBe(false);
+    });
+
+    test("resolves typed wall-clock times in the configured timezone", () => {
+      const result: RenderResult = renderModal();
+
+      typeInto(getStartInput(), "2024-03-01T09:15:00");
+      typeInto(getEndInput(), "2024-03-01T09:45:00");
+      fireEvent.click(getApplyButton());
+
+      expect(result.saved[0]!.startValue.getTime()).toBe(
+        OneUptimeDate.fromDateTimeLocalString("2024-03-01T09:15:00").getTime(),
+      );
+      expect(result.saved[0]!.endValue.getTime()).toBe(
+        OneUptimeDate.fromDateTimeLocalString("2024-03-01T09:45:00").getTime(),
+      );
+    });
+  });
+
+  describe("apply and cancel", () => {
+    test("disables Apply while the range is inverted", () => {
+      renderModal();
+
+      typeInto(getEndInput(), "2024-03-01T08:00:00");
+
+      expect(getApplyButton().hasAttribute("disabled")).toBe(true);
+    });
+
+    test("does not save an invalid range even if Apply is invoked", () => {
+      const result: RenderResult = renderModal(new InBetween<Date>(END, START));
+
+      fireEvent.click(getApplyButton());
+
+      expect(result.saved).toHaveLength(0);
+    });
+
+    test("enables Apply for a valid seeded range", () => {
+      renderModal();
+
+      expect(getApplyButton().hasAttribute("disabled")).toBe(false);
+    });
+
+    test("closes without saving when Cancel is pressed", () => {
+      const result: RenderResult = renderModal();
+
+      fireEvent.click(screen.getByText("Cancel"));
+
+      expect(result.closes).toBe(1);
+      expect(result.saved).toHaveLength(0);
+    });
+
+    test("closes without saving when the close button is pressed", () => {
+      const result: RenderResult = renderModal();
+
+      fireEvent.click(screen.getByTestId("close-button"));
+
+      expect(result.closes).toBe(1);
+      expect(result.saved).toHaveLength(0);
+    });
+
+    test("closes without saving on Escape", () => {
+      const result: RenderResult = renderModal();
+
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(result.closes).toBe(1);
+      expect(result.saved).toHaveLength(0);
+    });
+
+    test("does not close itself when the range is applied", () => {
+      /*
+       * Teardown is the caller's job — it owns the mount, and closing here as
+       * well would fire onClose alongside onSave.
+       */
+      const result: RenderResult = renderModal();
+
+      fireEvent.click(getApplyButton());
+
+      expect(result.saved).toHaveLength(1);
+      expect(result.closes).toBe(0);
+    });
+  });
+});

--- a/Common/Tests/UI/Components/LogTimeRangePicker.test.tsx
+++ b/Common/Tests/UI/Components/LogTimeRangePicker.test.tsx
@@ -3,6 +3,7 @@ import LogTimeRangePicker, {
 } from "../../../UI/Components/LogsViewer/components/LogTimeRangePicker";
 import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
 import TimeRange from "../../../Types/Time/TimeRange";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
 import "@testing-library/jest-dom";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
@@ -134,5 +135,46 @@ describe("LogTimeRangePicker", () => {
     expect(
       dropdown.parentElement?.classList.contains("relative") ?? false,
     ).toBe(true);
+  });
+
+  test("keeps the date fields out of the narrow dropdown panel", () => {
+    const dropdown: HTMLElement = openDropdown({
+      range: TimeRange.CUSTOM,
+      startAndEndDate: new InBetween<Date>(
+        new Date("2024-01-01T00:00:00.000Z"),
+        new Date("2024-01-02T00:00:00.000Z"),
+      ),
+    });
+
+    expect(dropdown.querySelectorAll("input").length).toBe(0);
+  });
+
+  test("opens the custom range modal from the dropdown", () => {
+    openDropdown({ range: TimeRange.PAST_ONE_HOUR });
+
+    fireEvent.click(screen.getByTestId("log-time-range-picker-custom-option"));
+
+    expect(screen.getByTestId("custom-time-range-modal")).toBeInTheDocument();
+    expect(screen.queryByTestId(DROPDOWN_TEST_ID)).toBeNull();
+  });
+
+  test("applies a custom range picked in the modal", () => {
+    const emitted: Array<RangeStartAndEndDateTime> = [];
+    render(
+      <LogTimeRangePicker
+        value={{ range: TimeRange.PAST_ONE_HOUR }}
+        onChange={(value: RangeStartAndEndDateTime) => {
+          emitted.push(value);
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId(BUTTON_TEST_ID));
+    fireEvent.click(screen.getByTestId("log-time-range-picker-custom-option"));
+    fireEvent.click(screen.getByText("Apply"));
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]!.range).toBe(TimeRange.CUSTOM);
+    expect(emitted[0]!.startAndEndDate).toBeInstanceOf(InBetween);
   });
 });

--- a/Common/Tests/UI/Components/TelemetryTimeRangePicker.test.tsx
+++ b/Common/Tests/UI/Components/TelemetryTimeRangePicker.test.tsx
@@ -371,7 +371,12 @@ describe("TelemetryTimeRangePicker", () => {
       expect(optionLabels).toEqual(expectedLabels);
     });
 
-    test("renders the custom range editor when a custom range is active", () => {
+    test("keeps the date fields out of the narrow dropdown panel", () => {
+      /*
+       * Regression: the custom editor used to render two `datetime-local`
+       * fields inside the 288px panel. It now lives in a modal, so the panel
+       * itself stays a plain list of options.
+       */
       renderPicker({
         range: TimeRange.CUSTOM,
         startAndEndDate: new InBetween<Date>(
@@ -382,14 +387,11 @@ describe("TelemetryTimeRangePicker", () => {
 
       const dropdown: HTMLElement = openDropdown();
 
-      // The custom editor lives in the same panel, so alignment still applies.
       expect(hasClass(dropdown, "left-0")).toBe(true);
-      expect(dropdown.querySelectorAll("input").length).toBeGreaterThan(0);
+      expect(dropdown.querySelectorAll("input").length).toBe(0);
     });
 
-    test("keeps the taller custom panel inside the viewport near the right edge", () => {
-      stubTriggerRect(1310, 1430);
-
+    test("marks the custom entry as selected while a custom range is active", () => {
       renderPicker({
         range: TimeRange.CUSTOM,
         startAndEndDate: new InBetween<Date>(
@@ -398,7 +400,47 @@ describe("TelemetryTimeRangePicker", () => {
         ),
       });
 
-      expect(hasClass(openDropdown(), "right-0")).toBe(true);
+      openDropdown();
+
+      expect(
+        hasClass(
+          screen.getByTestId("telemetry-time-range-picker-custom-option"),
+          "text-indigo-700",
+        ),
+      ).toBe(true);
+    });
+
+    test("opens the custom range modal from the dropdown", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openDropdown();
+
+      fireEvent.click(
+        screen.getByTestId("telemetry-time-range-picker-custom-option"),
+      );
+
+      expect(screen.getByTestId("custom-time-range-modal")).toBeInTheDocument();
+      // The dropdown gets out of the way once the modal is up.
+      expect(screen.queryByTestId(DROPDOWN_TEST_ID)).toBeNull();
+    });
+
+    test("applies a custom range picked in the modal", () => {
+      const emitted: Array<RangeStartAndEndDateTime> = [];
+      renderPicker(
+        { range: TimeRange.PAST_ONE_HOUR },
+        (value: RangeStartAndEndDateTime) => {
+          emitted.push(value);
+        },
+      );
+      openDropdown();
+
+      fireEvent.click(
+        screen.getByTestId("telemetry-time-range-picker-custom-option"),
+      );
+      fireEvent.click(screen.getByText("Apply"));
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]!.range).toBe(TimeRange.CUSTOM);
+      expect(emitted[0]!.startAndEndDate).toBeInstanceOf(InBetween);
     });
   });
 });

--- a/Common/Tests/UI/Components/TimeRangePickerDropdown.test.tsx
+++ b/Common/Tests/UI/Components/TimeRangePickerDropdown.test.tsx
@@ -1,0 +1,325 @@
+/** @timezone UTC */
+import TimeRangePickerDropdown, {
+  CUSTOM_RANGE_OPTION_LABEL,
+  TIME_RANGE_PRESET_OPTIONS,
+  getTimeRangeButtonLabel,
+} from "../../../UI/Components/Date/TimeRangePickerDropdown";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import OneUptimeDate from "../../../Types/Date";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+const PREFIX: string = "test-range-picker";
+const DROPDOWN_WIDTH_IN_PX: number = 288;
+
+interface Harness {
+  emitted: Array<RangeStartAndEndDateTime>;
+}
+
+function renderPicker(value: RangeStartAndEndDateTime): Harness {
+  const harness: Harness = { emitted: [] };
+
+  render(
+    <TimeRangePickerDropdown
+      value={value}
+      onChange={(next: RangeStartAndEndDateTime) => {
+        harness.emitted.push(next);
+      }}
+      dataTestIdPrefix={PREFIX}
+      dropdownWidthInPx={DROPDOWN_WIDTH_IN_PX}
+    />,
+  );
+
+  return harness;
+}
+
+function openDropdown(): void {
+  fireEvent.click(screen.getByTestId(`${PREFIX}-button`));
+}
+
+function openCustomModal(): void {
+  openDropdown();
+  fireEvent.click(screen.getByTestId(`${PREFIX}-custom-option`));
+}
+
+function getStartInput(): HTMLInputElement {
+  return screen.getByTestId("custom-time-range-start") as HTMLInputElement;
+}
+
+function getEndInput(): HTMLInputElement {
+  return screen.getByTestId("custom-time-range-end") as HTMLInputElement;
+}
+
+/*
+ * jsdom normalises a `datetime-local` value to minute precision, so compare
+ * the instant a field names rather than the string it reports.
+ */
+function getFieldDate(input: HTMLInputElement): Date {
+  return OneUptimeDate.fromDateTimeLocalString(input.value);
+}
+
+function minutesBetweenFields(): number {
+  return OneUptimeDate.getDifferenceInMinutes(
+    getFieldDate(getStartInput()),
+    getFieldDate(getEndInput()),
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("getTimeRangeButtonLabel", () => {
+  test("uses the preset label for a preset range", () => {
+    expect(getTimeRangeButtonLabel({ range: TimeRange.PAST_THIRTY_MINS })).toBe(
+      "Past 30 Minutes",
+    );
+  });
+
+  test("falls back to the raw range when there is no preset label", () => {
+    expect(getTimeRangeButtonLabel({ range: TimeRange.CUSTOM })).toBe(
+      TimeRange.CUSTOM,
+    );
+  });
+
+  test("summarises a custom range as a start–end pair", () => {
+    const label: string = getTimeRangeButtonLabel({
+      range: TimeRange.CUSTOM,
+      startAndEndDate: new InBetween<Date>(
+        new Date("2024-03-01T10:00:00.000Z"),
+        new Date("2024-03-02T13:30:00.000Z"),
+      ),
+    });
+
+    expect(label).toBe("Mar 1, 10:00 – Mar 2, 13:30");
+  });
+});
+
+describe("TimeRangePickerDropdown", () => {
+  describe("test ids", () => {
+    test("namespaces every test id with the given prefix", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+
+      expect(screen.getByTestId(`${PREFIX}-button`)).toBeInTheDocument();
+
+      openDropdown();
+
+      expect(screen.getByTestId(`${PREFIX}-dropdown`)).toBeInTheDocument();
+      expect(screen.getByTestId(`${PREFIX}-custom-option`)).toBeInTheDocument();
+    });
+  });
+
+  describe("presets", () => {
+    test("lists every preset plus the custom entry", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openDropdown();
+
+      const labels: Array<string> = Array.from(
+        screen.getByTestId(`${PREFIX}-dropdown`).querySelectorAll("button"),
+      ).map((button: HTMLButtonElement): string => {
+        return (button.textContent || "").trim();
+      });
+
+      expect(labels).toEqual([
+        ...TIME_RANGE_PRESET_OPTIONS.map(
+          (option: { label: string }): string => {
+            return option.label;
+          },
+        ),
+        CUSTOM_RANGE_OPTION_LABEL,
+      ]);
+    });
+
+    test("emits a preset without any absolute window attached", () => {
+      const harness: Harness = renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openDropdown();
+
+      fireEvent.click(screen.getByText("Past 2 Days"));
+
+      expect(harness.emitted).toEqual([{ range: TimeRange.PAST_TWO_DAYS }]);
+    });
+
+    test("closes the dropdown after picking a preset", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openDropdown();
+
+      fireEvent.click(screen.getByText("Past 2 Days"));
+
+      expect(screen.queryByTestId(`${PREFIX}-dropdown`)).toBeNull();
+    });
+
+    test("switching back to a preset from a custom range drops the window", () => {
+      const harness: Harness = renderPicker({
+        range: TimeRange.CUSTOM,
+        startAndEndDate: new InBetween<Date>(
+          new Date("2024-03-01T10:00:00.000Z"),
+          new Date("2024-03-01T13:00:00.000Z"),
+        ),
+      });
+      openDropdown();
+
+      fireEvent.click(screen.getByText("Past 1 Hour"));
+
+      expect(harness.emitted).toEqual([{ range: TimeRange.PAST_ONE_HOUR }]);
+    });
+  });
+
+  describe("custom range modal", () => {
+    test("is not mounted until the custom entry is clicked", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openDropdown();
+
+      expect(screen.queryByTestId("custom-time-range-modal")).toBeNull();
+    });
+
+    test("opens on the custom entry and closes the dropdown behind it", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openCustomModal();
+
+      expect(screen.getByTestId("custom-time-range-modal")).toBeInTheDocument();
+      expect(screen.queryByTestId(`${PREFIX}-dropdown`)).toBeNull();
+    });
+
+    test("seeds from the absolute bounds of the selected preset", () => {
+      renderPicker({ range: TimeRange.PAST_THREE_HOURS });
+      openCustomModal();
+
+      expect(minutesBetweenFields()).toBe(180);
+    });
+
+    test("seeds from the active custom range when there is one", () => {
+      const start: Date = new Date("2024-03-01T10:00:00.000Z");
+      const end: Date = new Date("2024-03-01T13:00:00.000Z");
+
+      renderPicker({
+        range: TimeRange.CUSTOM,
+        startAndEndDate: new InBetween<Date>(start, end),
+      });
+      openCustomModal();
+
+      expect(getFieldDate(getStartInput()).getTime()).toBe(start.getTime());
+      expect(getFieldDate(getEndInput()).getTime()).toBe(end.getTime());
+    });
+
+    test("falls back to the preset bounds when a custom range has no window", () => {
+      renderPicker({ range: TimeRange.CUSTOM });
+      openCustomModal();
+
+      expect(getStartInput().value).not.toBe("");
+      expect(getEndInput().value).not.toBe("");
+    });
+
+    test("emits a custom range when the modal is applied", () => {
+      const harness: Harness = renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openCustomModal();
+
+      fireEvent.change(getStartInput(), {
+        target: { value: "2024-03-01T08:00:00" },
+      });
+      fireEvent.change(getEndInput(), {
+        target: { value: "2024-03-01T09:30:00" },
+      });
+      fireEvent.click(screen.getByText("Apply"));
+
+      expect(harness.emitted).toHaveLength(1);
+      expect(harness.emitted[0]!.range).toBe(TimeRange.CUSTOM);
+      expect(
+        OneUptimeDate.toDateTimeLocalString(
+          harness.emitted[0]!.startAndEndDate!.startValue,
+        ),
+      ).toBe("2024-03-01T08:00:00");
+      expect(
+        OneUptimeDate.toDateTimeLocalString(
+          harness.emitted[0]!.startAndEndDate!.endValue,
+        ),
+      ).toBe("2024-03-01T09:30:00");
+    });
+
+    test("unmounts the modal once a range is applied", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openCustomModal();
+
+      fireEvent.click(screen.getByText("Apply"));
+
+      expect(screen.queryByTestId("custom-time-range-modal")).toBeNull();
+    });
+
+    test("emits nothing when the modal is cancelled", () => {
+      const harness: Harness = renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openCustomModal();
+
+      fireEvent.change(getStartInput(), {
+        target: { value: "2024-03-01T08:00:00" },
+      });
+      fireEvent.click(screen.getByText("Cancel"));
+
+      expect(harness.emitted).toHaveLength(0);
+      expect(screen.queryByTestId("custom-time-range-modal")).toBeNull();
+    });
+
+    test("discards abandoned edits when reopened", () => {
+      renderPicker({
+        range: TimeRange.CUSTOM,
+        startAndEndDate: new InBetween<Date>(
+          new Date("2024-03-01T10:00:00.000Z"),
+          new Date("2024-03-01T13:00:00.000Z"),
+        ),
+      });
+
+      openCustomModal();
+      fireEvent.change(getStartInput(), {
+        target: { value: "2024-03-01T01:00:00" },
+      });
+      fireEvent.click(screen.getByText("Cancel"));
+
+      openCustomModal();
+
+      expect(getFieldDate(getStartInput()).getTime()).toBe(
+        new Date("2024-03-01T10:00:00.000Z").getTime(),
+      );
+    });
+
+    test("re-seeds from the preset selected since it was last opened", () => {
+      renderPicker({ range: TimeRange.PAST_THREE_HOURS });
+
+      openCustomModal();
+      expect(minutesBetweenFields()).toBe(180);
+      fireEvent.click(screen.getByText("Cancel"));
+
+      cleanup();
+      renderPicker({ range: TimeRange.PAST_ONE_DAY });
+      openCustomModal();
+
+      expect(minutesBetweenFields()).toBe(1440);
+    });
+  });
+
+  describe("click outside", () => {
+    test("closes the dropdown on an outside mousedown", () => {
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openDropdown();
+
+      fireEvent.mouseDown(document.body);
+
+      expect(screen.queryByTestId(`${PREFIX}-dropdown`)).toBeNull();
+    });
+
+    test("leaves the custom modal alone on an outside mousedown", () => {
+      /*
+       * The native date picker a `datetime-local` field opens renders outside
+       * this component. While the editor lived in the dropdown, clicking a day
+       * in that popup tore the whole panel down mid-edit.
+       */
+      renderPicker({ range: TimeRange.PAST_ONE_HOUR });
+      openCustomModal();
+
+      fireEvent.mouseDown(document.body);
+
+      expect(screen.getByTestId("custom-time-range-modal")).toBeInTheDocument();
+    });
+  });
+});

--- a/Common/UI/Components/Date/CustomTimeRangeModal.tsx
+++ b/Common/UI/Components/Date/CustomTimeRangeModal.tsx
@@ -1,0 +1,278 @@
+import React, { FunctionComponent, ReactElement, useId, useState } from "react";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import OneUptimeDate from "../../../Types/Date";
+import IconProp from "../../../Types/Icon/IconProp";
+import Icon from "../Icon/Icon";
+import Input, { InputType } from "../Input/Input";
+import Modal, { ModalWidth } from "../Modal/Modal";
+
+export interface ComponentProps {
+  /*
+   * Window the editor opens on. Callers seed this with the range currently in
+   * effect so switching to "custom" starts from what the user is looking at
+   * rather than from an empty form.
+   */
+  initialValue?: InBetween<Date> | undefined;
+  title?: string | undefined;
+  description?: string | undefined;
+  onClose: () => void;
+  onSave: (value: InBetween<Date>) => void;
+}
+
+export interface QuickFillOption {
+  label: string;
+  minutes: number;
+}
+
+/*
+ * Shortcuts that fill both ends of the form at once, anchored to now. They are
+ * a starting point for a hand-tuned window — picking one does not apply the
+ * range, so the user can still nudge either end before hitting Apply.
+ */
+export const QUICK_FILL_OPTIONS: Array<QuickFillOption> = [
+  { label: "Last 1 hour", minutes: 60 },
+  { label: "Last 6 hours", minutes: 60 * 6 },
+  { label: "Last 12 hours", minutes: 60 * 12 },
+  { label: "Last 24 hours", minutes: 60 * 24 },
+  { label: "Last 7 days", minutes: 60 * 24 * 7 },
+  { label: "Last 30 days", minutes: 60 * 24 * 30 },
+];
+
+export type CustomTimeRangeValidationError = string;
+
+/*
+ * Kept pure and exported so the rules the Apply button is gated on can be
+ * checked directly, and so callers share one definition of "valid window".
+ */
+export function getCustomTimeRangeError(
+  startDate: Date | null,
+  endDate: Date | null,
+): CustomTimeRangeValidationError {
+  if (!startDate) {
+    return "Pick a start date and time.";
+  }
+
+  if (!endDate) {
+    return "Pick an end date and time.";
+  }
+
+  if (!OneUptimeDate.isAfter(endDate, startDate)) {
+    return "The end must be after the start. Adjust either end of the range.";
+  }
+
+  return "";
+}
+
+const CustomTimeRangeModal: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [startDate, setStartDate] = useState<Date | null>(
+    props.initialValue?.startValue || null,
+  );
+  const [endDate, setEndDate] = useState<Date | null>(
+    props.initialValue?.endValue || null,
+  );
+  // Two pickers can sit on one page, so the field ids cannot be constants.
+  const startFieldId: string = useId();
+  const endFieldId: string = useId();
+
+  const error: CustomTimeRangeValidationError = getCustomTimeRangeError(
+    startDate,
+    endDate,
+  );
+  const isValid: boolean = error === "";
+
+  const durationText: string = isValid
+    ? OneUptimeDate.secondsToFormattedFriendlyTimeString(
+        OneUptimeDate.getDifferenceInSeconds(endDate!, startDate!),
+      ).trim()
+    : "";
+
+  const formatDateTime: (date: Date) => string = (date: Date): string => {
+    return OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(
+      date,
+      false,
+      true,
+    );
+  };
+
+  const onQuickFill: (minutes: number) => void = (minutes: number): void => {
+    const end: Date = OneUptimeDate.resetSecondsAndMilliseconds(
+      OneUptimeDate.getCurrentDate(),
+    );
+    setStartDate(OneUptimeDate.addRemoveMinutes(end, -minutes));
+    setEndDate(end);
+  };
+
+  /*
+   * `Input` reports a cleared date field as an empty string. Anything else is
+   * an ISO string the field has already resolved in the user's timezone.
+   */
+  const toDate: (changedValue: string | Date) => Date | null = (
+    changedValue: string | Date,
+  ): Date | null => {
+    if (!changedValue) {
+      return null;
+    }
+
+    return OneUptimeDate.fromString(changedValue as string);
+  };
+
+  const isQuickFillActive: (minutes: number) => boolean = (
+    minutes: number,
+  ): boolean => {
+    if (!startDate || !endDate) {
+      return false;
+    }
+
+    return OneUptimeDate.getDifferenceInMinutes(startDate, endDate) === minutes;
+  };
+
+  return (
+    <Modal
+      title={props.title || "Custom Time Range"}
+      description={
+        props.description ||
+        "Choose the exact start and end date & time of the data you want to see."
+      }
+      modalWidth={ModalWidth.Medium}
+      submitButtonText="Apply"
+      closeButtonText="Cancel"
+      disableSubmitButton={!isValid}
+      onClose={props.onClose}
+      onSubmit={() => {
+        if (!isValid) {
+          return;
+        }
+
+        props.onSave(new InBetween<Date>(startDate!, endDate!));
+      }}
+    >
+      <div data-testid="custom-time-range-modal" className="space-y-5">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+            Quick fill
+          </div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {QUICK_FILL_OPTIONS.map((option: QuickFillOption) => {
+              const isActive: boolean = isQuickFillActive(option.minutes);
+
+              return (
+                <button
+                  key={option.label}
+                  type="button"
+                  aria-pressed={isActive}
+                  onClick={() => {
+                    onQuickFill(option.minutes);
+                  }}
+                  className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                    isActive
+                      ? "border-indigo-200 bg-indigo-50 text-indigo-700"
+                      : "border-gray-200 bg-white text-gray-600 hover:border-gray-300 hover:bg-gray-50"
+                  }`}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="rounded-lg border border-gray-200 bg-gray-50/60 p-3">
+            <label
+              htmlFor={startFieldId}
+              className="flex items-center gap-1.5 text-sm font-medium text-gray-900"
+            >
+              <Icon
+                icon={IconProp.Calendar}
+                className="h-4 w-4 text-gray-400"
+              />
+              From
+            </label>
+            <Input
+              id={startFieldId}
+              dataTestId="custom-time-range-start"
+              type={InputType.DATETIME_LOCAL}
+              showSecondsForDateTime={true}
+              placeholder="Start date & time"
+              value={startDate || ""}
+              onChange={(changedValue: string | Date) => {
+                setStartDate(toDate(changedValue));
+              }}
+            />
+          </div>
+
+          <div className="rounded-lg border border-gray-200 bg-gray-50/60 p-3">
+            <label
+              htmlFor={endFieldId}
+              className="flex items-center gap-1.5 text-sm font-medium text-gray-900"
+            >
+              <Icon
+                icon={IconProp.Calendar}
+                className="h-4 w-4 text-gray-400"
+              />
+              To
+            </label>
+            <Input
+              id={endFieldId}
+              dataTestId="custom-time-range-end"
+              type={InputType.DATETIME_LOCAL}
+              showSecondsForDateTime={true}
+              placeholder="End date & time"
+              value={endDate || ""}
+              onChange={(changedValue: string | Date) => {
+                setEndDate(toDate(changedValue));
+              }}
+            />
+          </div>
+        </div>
+
+        {isValid ? (
+          <div
+            data-testid="custom-time-range-summary"
+            className="rounded-lg border border-gray-200 bg-white p-3"
+          >
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-gray-500">From</span>
+              <span className="font-medium text-gray-900">
+                {formatDateTime(startDate!)}
+              </span>
+            </div>
+            <div className="mt-2 flex items-center justify-between text-sm">
+              <span className="text-gray-500">To</span>
+              <span className="font-medium text-gray-900">
+                {formatDateTime(endDate!)}
+              </span>
+            </div>
+            <div className="mt-2 flex items-center justify-between border-t border-gray-100 pt-2 text-sm">
+              <span className="flex items-center gap-1.5 text-gray-500">
+                <Icon icon={IconProp.Clock} className="h-3.5 w-3.5" />
+                Duration
+              </span>
+              <span className="font-medium text-gray-900">{durationText}</span>
+            </div>
+          </div>
+        ) : (
+          <div
+            data-testid="custom-time-range-error"
+            role="alert"
+            className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+          >
+            <Icon
+              icon={IconProp.ErrorSolid}
+              className="mt-0.5 h-4 w-4 shrink-0 text-red-500"
+            />
+            <span>{error}</span>
+          </div>
+        )}
+
+        <div className="text-xs text-gray-400">
+          Times are shown in {OneUptimeDate.getCurrentTimezoneString()}.
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default CustomTimeRangeModal;

--- a/Common/UI/Components/Date/TimeRangePickerDropdown.tsx
+++ b/Common/UI/Components/Date/TimeRangePickerDropdown.tsx
@@ -1,0 +1,250 @@
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import IconProp from "../../../Types/Icon/IconProp";
+import RangeStartAndEndDateTime, {
+  RangeStartAndEndDateTimeUtil,
+} from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+import {
+  DropdownHorizontalAlignment,
+  getDropdownAlignmentClassName,
+  useDropdownHorizontalAlignment,
+} from "../../Utils/DropdownAlignment";
+import Icon from "../Icon/Icon";
+import CustomTimeRangeModal from "./CustomTimeRangeModal";
+
+export interface TimeRangePickerPresetOption {
+  range: TimeRange;
+  label: string;
+}
+
+export interface ComponentProps {
+  value: RangeStartAndEndDateTime;
+  onChange: (value: RangeStartAndEndDateTime) => void;
+  /*
+   * Prefix for the trigger and panel test ids, so each surface embedding this
+   * picker keeps the selector its own tests were written against.
+   */
+  dataTestIdPrefix: string;
+  dropdownWidthInPx: number;
+}
+
+export const CUSTOM_RANGE_OPTION_LABEL: string = "Custom Range...";
+
+// Preset options to show in the dropdown, ordered shortest window first.
+export const TIME_RANGE_PRESET_OPTIONS: Array<TimeRangePickerPresetOption> = [
+  { range: TimeRange.PAST_FIVE_MINS, label: "Past 5 Minutes" },
+  { range: TimeRange.PAST_FIFTEEN_MINS, label: "Past 15 Minutes" },
+  { range: TimeRange.PAST_THIRTY_MINS, label: "Past 30 Minutes" },
+  { range: TimeRange.PAST_ONE_HOUR, label: "Past 1 Hour" },
+  { range: TimeRange.PAST_TWO_HOURS, label: "Past 2 Hours" },
+  { range: TimeRange.PAST_THREE_HOURS, label: "Past 3 Hours" },
+  { range: TimeRange.PAST_ONE_DAY, label: "Past 1 Day" },
+  { range: TimeRange.PAST_TWO_DAYS, label: "Past 2 Days" },
+  { range: TimeRange.PAST_ONE_WEEK, label: "Past 1 Week" },
+  { range: TimeRange.PAST_TWO_WEEKS, label: "Past 2 Weeks" },
+  { range: TimeRange.PAST_ONE_MONTH, label: "Past 1 Month" },
+  { range: TimeRange.PAST_THREE_MONTHS, label: "Past 3 Months" },
+];
+
+function formatDateShort(date: Date): string {
+  const month: string = date.toLocaleString("en-US", { month: "short" });
+  const day: number = date.getDate();
+  const hours: string = date.getHours().toString().padStart(2, "0");
+  const minutes: string = date.getMinutes().toString().padStart(2, "0");
+  return `${month} ${day}, ${hours}:${minutes}`;
+}
+
+export function getTimeRangeButtonLabel(
+  value: RangeStartAndEndDateTime,
+): string {
+  if (value.range === TimeRange.CUSTOM && value.startAndEndDate) {
+    const start: string = formatDateShort(value.startAndEndDate.startValue);
+    const end: string = formatDateShort(value.startAndEndDate.endValue);
+    return `${start} – ${end}`;
+  }
+
+  const preset: TimeRangePickerPresetOption | undefined =
+    TIME_RANGE_PRESET_OPTIONS.find((opt: TimeRangePickerPresetOption) => {
+      return opt.range === value.range;
+    });
+  return preset ? preset.label : value.range;
+}
+
+const TimeRangePickerDropdown: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  /*
+   * The custom window is edited in a modal rather than inline in this panel.
+   * Two `datetime-local` fields never fitted the 288px dropdown, and the native
+   * calendar those fields open renders outside this container — so the
+   * click-outside handler below tore the panel down the moment a date was
+   * clicked, which is what made "Custom Range..." look broken.
+   */
+  const [customSeedValue, setCustomSeedValue] =
+    useState<InBetween<Date> | null>(null);
+  const containerRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(
+    null!,
+  );
+  const buttonRef: React.RefObject<HTMLButtonElement> =
+    useRef<HTMLButtonElement>(null!);
+  const dropdownRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(
+    null!,
+  );
+
+  const alignment: DropdownHorizontalAlignment = useDropdownHorizontalAlignment(
+    {
+      isOpen: isOpen,
+      anchorRef: buttonRef,
+      dropdownRef: dropdownRef,
+      dropdownWidthInPx: props.dropdownWidthInPx,
+    },
+  );
+
+  // Close on click outside
+  useEffect(() => {
+    const handleClickOutside: (e: MouseEvent) => void = (
+      e: MouseEvent,
+    ): void => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  const handlePresetSelect: (range: TimeRange) => void = useCallback(
+    (range: TimeRange): void => {
+      props.onChange({ range });
+      setIsOpen(false);
+    },
+    [props],
+  );
+
+  const openCustomModal: () => void = useCallback((): void => {
+    /*
+     * Seed the editor with the window currently on screen — the custom range
+     * if one is already applied, otherwise the absolute bounds of the selected
+     * preset, so the user edits what they are looking at.
+     */
+    setCustomSeedValue(
+      props.value.range === TimeRange.CUSTOM && props.value.startAndEndDate
+        ? props.value.startAndEndDate
+        : RangeStartAndEndDateTimeUtil.getStartAndEndDate(props.value),
+    );
+    setIsOpen(false);
+  }, [props.value]);
+
+  const buttonLabel: string = getTimeRangeButtonLabel(props.value);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        data-testid={`${props.dataTestIdPrefix}-button`}
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium shadow-sm transition-colors ${
+          isOpen
+            ? "border-indigo-300 bg-indigo-50 text-indigo-700"
+            : "border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50"
+        }`}
+        onClick={() => {
+          setIsOpen(!isOpen);
+        }}
+      >
+        <Icon icon={IconProp.Clock} className="h-3.5 w-3.5" />
+        <span>{buttonLabel}</span>
+        <Icon
+          icon={IconProp.ChevronDown}
+          className={`h-3 w-3 transition-transform ${isOpen ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {isOpen && (
+        <div
+          ref={dropdownRef}
+          data-testid={`${props.dataTestIdPrefix}-dropdown`}
+          data-align={alignment}
+          className={`absolute ${getDropdownAlignmentClassName(
+            alignment,
+          )} top-full z-50 mt-1 w-72 max-w-[calc(100vw-1rem)] rounded-lg border border-gray-200 bg-white shadow-lg`}
+        >
+          {/* Preset options */}
+          <div className="max-h-64 overflow-y-auto py-1">
+            {TIME_RANGE_PRESET_OPTIONS.map(
+              (option: TimeRangePickerPresetOption) => {
+                const isActive: boolean = props.value.range === option.range;
+
+                return (
+                  <button
+                    key={option.range}
+                    type="button"
+                    className={`flex w-full items-center px-3 py-1.5 text-left text-sm transition-colors ${
+                      isActive
+                        ? "bg-indigo-50 font-medium text-indigo-700"
+                        : "text-gray-700 hover:bg-gray-50"
+                    }`}
+                    onClick={() => {
+                      handlePresetSelect(option.range);
+                    }}
+                  >
+                    {option.label}
+                  </button>
+                );
+              },
+            )}
+
+            {/* Custom option — opens the editor in a modal */}
+            <button
+              type="button"
+              data-testid={`${props.dataTestIdPrefix}-custom-option`}
+              className={`flex w-full items-center px-3 py-1.5 text-left text-sm transition-colors ${
+                props.value.range === TimeRange.CUSTOM
+                  ? "bg-indigo-50 font-medium text-indigo-700"
+                  : "text-gray-700 hover:bg-gray-50"
+              }`}
+              onClick={openCustomModal}
+            >
+              {CUSTOM_RANGE_OPTION_LABEL}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {customSeedValue && (
+        <CustomTimeRangeModal
+          initialValue={customSeedValue}
+          onClose={() => {
+            setCustomSeedValue(null);
+          }}
+          onSave={(startAndEndDate: InBetween<Date>) => {
+            setCustomSeedValue(null);
+            props.onChange({
+              range: TimeRange.CUSTOM,
+              startAndEndDate: startAndEndDate,
+            });
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default TimeRangePickerDropdown;

--- a/Common/UI/Components/LogsViewer/components/LogTimeRangePicker.tsx
+++ b/Common/UI/Components/LogsViewer/components/LogTimeRangePicker.tsx
@@ -1,233 +1,28 @@
-import React, {
-  FunctionComponent,
-  ReactElement,
-  useState,
-  useRef,
-  useEffect,
-  useCallback,
-} from "react";
-import Icon from "../../Icon/Icon";
-import IconProp from "../../../../Types/Icon/IconProp";
+import React, { FunctionComponent, ReactElement } from "react";
 import RangeStartAndEndDateTime from "../../../../Types/Time/RangeStartAndEndDateTime";
-import TimeRange from "../../../../Types/Time/TimeRange";
-import InBetween from "../../../../Types/BaseDatabase/InBetween";
-import StartAndEndDate, {
-  StartAndEndDateType,
-} from "../../Date/StartAndEndDate";
-import {
-  DropdownHorizontalAlignment,
-  getDropdownAlignmentClassName,
-  useDropdownHorizontalAlignment,
-} from "../../../Utils/DropdownAlignment";
+import TimeRangePickerDropdown from "../../Date/TimeRangePickerDropdown";
 
 export interface LogTimeRangePickerProps {
   value: RangeStartAndEndDateTime;
   onChange: (value: RangeStartAndEndDateTime) => void;
 }
 
-// Matches the Tailwind `w-72` on the dropdown below (18rem).
+// Matches the Tailwind `w-72` on the rendered dropdown (18rem).
 export const LOG_TIME_RANGE_DROPDOWN_WIDTH_IN_PX: number = 288;
 
-// Preset options to show in the dropdown (ordered for log investigation use)
-const PRESET_OPTIONS: Array<{ range: TimeRange; label: string }> = [
-  { range: TimeRange.PAST_FIVE_MINS, label: "Past 5 Minutes" },
-  { range: TimeRange.PAST_FIFTEEN_MINS, label: "Past 15 Minutes" },
-  { range: TimeRange.PAST_THIRTY_MINS, label: "Past 30 Minutes" },
-  { range: TimeRange.PAST_ONE_HOUR, label: "Past 1 Hour" },
-  { range: TimeRange.PAST_TWO_HOURS, label: "Past 2 Hours" },
-  { range: TimeRange.PAST_THREE_HOURS, label: "Past 3 Hours" },
-  { range: TimeRange.PAST_ONE_DAY, label: "Past 1 Day" },
-  { range: TimeRange.PAST_TWO_DAYS, label: "Past 2 Days" },
-  { range: TimeRange.PAST_ONE_WEEK, label: "Past 1 Week" },
-  { range: TimeRange.PAST_TWO_WEEKS, label: "Past 2 Weeks" },
-  { range: TimeRange.PAST_ONE_MONTH, label: "Past 1 Month" },
-  { range: TimeRange.PAST_THREE_MONTHS, label: "Past 3 Months" },
-];
-
-function formatDateShort(date: Date): string {
-  const month: string = date.toLocaleString("en-US", { month: "short" });
-  const day: number = date.getDate();
-  const hours: string = date.getHours().toString().padStart(2, "0");
-  const minutes: string = date.getMinutes().toString().padStart(2, "0");
-  return `${month} ${day}, ${hours}:${minutes}`;
-}
-
-function getButtonLabel(value: RangeStartAndEndDateTime): string {
-  if (value.range === TimeRange.CUSTOM && value.startAndEndDate) {
-    const start: string = formatDateShort(value.startAndEndDate.startValue);
-    const end: string = formatDateShort(value.startAndEndDate.endValue);
-    return `${start} – ${end}`;
-  }
-
-  const preset: { range: TimeRange; label: string } | undefined =
-    PRESET_OPTIONS.find((opt: { range: TimeRange; label: string }) => {
-      return opt.range === value.range;
-    });
-  return preset ? preset.label : value.range;
-}
+export const LOG_TIME_RANGE_PICKER_TEST_ID_PREFIX: string =
+  "log-time-range-picker";
 
 const LogTimeRangePicker: FunctionComponent<LogTimeRangePickerProps> = (
   props: LogTimeRangePickerProps,
 ): ReactElement => {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [showCustom, setShowCustom] = useState<boolean>(
-    props.value.range === TimeRange.CUSTOM,
-  );
-  const containerRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(
-    null!,
-  );
-  const buttonRef: React.RefObject<HTMLButtonElement> =
-    useRef<HTMLButtonElement>(null!);
-  const dropdownRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(
-    null!,
-  );
-
-  const alignment: DropdownHorizontalAlignment = useDropdownHorizontalAlignment(
-    {
-      isOpen: isOpen,
-      anchorRef: buttonRef,
-      dropdownRef: dropdownRef,
-      dropdownWidthInPx: LOG_TIME_RANGE_DROPDOWN_WIDTH_IN_PX,
-    },
-  );
-
-  // Close on click outside
-  useEffect(() => {
-    const handleClickOutside: (e: MouseEvent) => void = (
-      e: MouseEvent,
-    ): void => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
-
-  // Sync showCustom when value changes externally (e.g., histogram drag)
-  useEffect(() => {
-    setShowCustom(props.value.range === TimeRange.CUSTOM);
-  }, [props.value.range]);
-
-  const handlePresetSelect: (range: TimeRange) => void = useCallback(
-    (range: TimeRange): void => {
-      props.onChange({ range });
-      setShowCustom(false);
-      setIsOpen(false);
-    },
-    [props],
-  );
-
-  const handleCustomDateChange: (dateRange: InBetween<Date> | null) => void =
-    useCallback(
-      (dateRange: InBetween<Date> | null): void => {
-        if (dateRange) {
-          props.onChange({
-            range: TimeRange.CUSTOM,
-            startAndEndDate: dateRange,
-          });
-        }
-      },
-      [props],
-    );
-
-  const buttonLabel: string = getButtonLabel(props.value);
-
   return (
-    <div ref={containerRef} className="relative">
-      <button
-        ref={buttonRef}
-        type="button"
-        data-testid="log-time-range-picker-button"
-        aria-haspopup="true"
-        aria-expanded={isOpen}
-        className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium shadow-sm transition-colors ${
-          isOpen
-            ? "border-indigo-300 bg-indigo-50 text-indigo-700"
-            : "border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50"
-        }`}
-        onClick={() => {
-          setIsOpen(!isOpen);
-        }}
-      >
-        <Icon icon={IconProp.Clock} className="h-3.5 w-3.5" />
-        <span>{buttonLabel}</span>
-        <Icon
-          icon={IconProp.ChevronDown}
-          className={`h-3 w-3 transition-transform ${isOpen ? "rotate-180" : ""}`}
-        />
-      </button>
-
-      {isOpen && (
-        <div
-          ref={dropdownRef}
-          data-testid="log-time-range-picker-dropdown"
-          data-align={alignment}
-          className={`absolute ${getDropdownAlignmentClassName(
-            alignment,
-          )} top-full z-50 mt-1 w-72 max-w-[calc(100vw-1rem)] rounded-lg border border-gray-200 bg-white shadow-lg`}
-        >
-          {/* Preset options */}
-          <div className="max-h-64 overflow-y-auto py-1">
-            {PRESET_OPTIONS.map(
-              (option: { range: TimeRange; label: string }) => {
-                const isActive: boolean = props.value.range === option.range;
-
-                return (
-                  <button
-                    key={option.range}
-                    type="button"
-                    className={`flex w-full items-center px-3 py-1.5 text-left text-sm transition-colors ${
-                      isActive
-                        ? "bg-indigo-50 font-medium text-indigo-700"
-                        : "text-gray-700 hover:bg-gray-50"
-                    }`}
-                    onClick={() => {
-                      handlePresetSelect(option.range);
-                    }}
-                  >
-                    {option.label}
-                  </button>
-                );
-              },
-            )}
-
-            {/* Custom option */}
-            <button
-              type="button"
-              className={`flex w-full items-center px-3 py-1.5 text-left text-sm transition-colors ${
-                props.value.range === TimeRange.CUSTOM
-                  ? "bg-indigo-50 font-medium text-indigo-700"
-                  : "text-gray-700 hover:bg-gray-50"
-              }`}
-              onClick={() => {
-                setShowCustom(true);
-              }}
-            >
-              Custom Range...
-            </button>
-          </div>
-
-          {/* Custom date inputs */}
-          {showCustom && (
-            <div className="border-t border-gray-100 p-3">
-              <StartAndEndDate
-                type={StartAndEndDateType.DateTime}
-                value={props.value.startAndEndDate}
-                hideTimeButtons={true}
-                onValueChanged={handleCustomDateChange}
-              />
-            </div>
-          )}
-        </div>
-      )}
-    </div>
+    <TimeRangePickerDropdown
+      value={props.value}
+      onChange={props.onChange}
+      dataTestIdPrefix={LOG_TIME_RANGE_PICKER_TEST_ID_PREFIX}
+      dropdownWidthInPx={LOG_TIME_RANGE_DROPDOWN_WIDTH_IN_PX}
+    />
   );
 };
 

--- a/Common/UI/Components/TelemetryViewer/components/TelemetryTimeRangePicker.tsx
+++ b/Common/UI/Components/TelemetryViewer/components/TelemetryTimeRangePicker.tsx
@@ -1,227 +1,28 @@
-import React, {
-  FunctionComponent,
-  ReactElement,
-  useState,
-  useRef,
-  useEffect,
-  useCallback,
-} from "react";
-import Icon from "../../Icon/Icon";
-import IconProp from "../../../../Types/Icon/IconProp";
+import React, { FunctionComponent, ReactElement } from "react";
 import RangeStartAndEndDateTime from "../../../../Types/Time/RangeStartAndEndDateTime";
-import TimeRange from "../../../../Types/Time/TimeRange";
-import InBetween from "../../../../Types/BaseDatabase/InBetween";
-import StartAndEndDate, {
-  StartAndEndDateType,
-} from "../../Date/StartAndEndDate";
-import {
-  DropdownHorizontalAlignment,
-  getDropdownAlignmentClassName,
-  useDropdownHorizontalAlignment,
-} from "../../../Utils/DropdownAlignment";
+import TimeRangePickerDropdown from "../../Date/TimeRangePickerDropdown";
 
 export interface TelemetryTimeRangePickerProps {
   value: RangeStartAndEndDateTime;
   onChange: (value: RangeStartAndEndDateTime) => void;
 }
 
-// Matches the Tailwind `w-72` on the dropdown below (18rem).
+// Matches the Tailwind `w-72` on the rendered dropdown (18rem).
 export const TIME_RANGE_DROPDOWN_WIDTH_IN_PX: number = 288;
 
-const PRESET_OPTIONS: Array<{ range: TimeRange; label: string }> = [
-  { range: TimeRange.PAST_FIVE_MINS, label: "Past 5 Minutes" },
-  { range: TimeRange.PAST_FIFTEEN_MINS, label: "Past 15 Minutes" },
-  { range: TimeRange.PAST_THIRTY_MINS, label: "Past 30 Minutes" },
-  { range: TimeRange.PAST_ONE_HOUR, label: "Past 1 Hour" },
-  { range: TimeRange.PAST_TWO_HOURS, label: "Past 2 Hours" },
-  { range: TimeRange.PAST_THREE_HOURS, label: "Past 3 Hours" },
-  { range: TimeRange.PAST_ONE_DAY, label: "Past 1 Day" },
-  { range: TimeRange.PAST_TWO_DAYS, label: "Past 2 Days" },
-  { range: TimeRange.PAST_ONE_WEEK, label: "Past 1 Week" },
-  { range: TimeRange.PAST_TWO_WEEKS, label: "Past 2 Weeks" },
-  { range: TimeRange.PAST_ONE_MONTH, label: "Past 1 Month" },
-  { range: TimeRange.PAST_THREE_MONTHS, label: "Past 3 Months" },
-];
-
-function formatDateShort(date: Date): string {
-  const month: string = date.toLocaleString("en-US", { month: "short" });
-  const day: number = date.getDate();
-  const hours: string = date.getHours().toString().padStart(2, "0");
-  const minutes: string = date.getMinutes().toString().padStart(2, "0");
-  return `${month} ${day}, ${hours}:${minutes}`;
-}
-
-function getButtonLabel(value: RangeStartAndEndDateTime): string {
-  if (value.range === TimeRange.CUSTOM && value.startAndEndDate) {
-    const start: string = formatDateShort(value.startAndEndDate.startValue);
-    const end: string = formatDateShort(value.startAndEndDate.endValue);
-    return `${start} – ${end}`;
-  }
-
-  const preset: { range: TimeRange; label: string } | undefined =
-    PRESET_OPTIONS.find((opt: { range: TimeRange; label: string }) => {
-      return opt.range === value.range;
-    });
-  return preset ? preset.label : value.range;
-}
+export const TELEMETRY_TIME_RANGE_PICKER_TEST_ID_PREFIX: string =
+  "telemetry-time-range-picker";
 
 const TelemetryTimeRangePicker: FunctionComponent<
   TelemetryTimeRangePickerProps
 > = (props: TelemetryTimeRangePickerProps): ReactElement => {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [showCustom, setShowCustom] = useState<boolean>(
-    props.value.range === TimeRange.CUSTOM,
-  );
-  const containerRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(
-    null!,
-  );
-  const buttonRef: React.RefObject<HTMLButtonElement> =
-    useRef<HTMLButtonElement>(null!);
-  const dropdownRef: React.RefObject<HTMLDivElement> = useRef<HTMLDivElement>(
-    null!,
-  );
-
-  const alignment: DropdownHorizontalAlignment = useDropdownHorizontalAlignment(
-    {
-      isOpen: isOpen,
-      anchorRef: buttonRef,
-      dropdownRef: dropdownRef,
-      dropdownWidthInPx: TIME_RANGE_DROPDOWN_WIDTH_IN_PX,
-    },
-  );
-
-  useEffect(() => {
-    const handleClickOutside: (e: MouseEvent) => void = (
-      e: MouseEvent,
-    ): void => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, []);
-
-  useEffect(() => {
-    setShowCustom(props.value.range === TimeRange.CUSTOM);
-  }, [props.value.range]);
-
-  const handlePresetSelect: (range: TimeRange) => void = useCallback(
-    (range: TimeRange): void => {
-      props.onChange({ range });
-      setShowCustom(false);
-      setIsOpen(false);
-    },
-    [props],
-  );
-
-  const handleCustomDateChange: (dateRange: InBetween<Date> | null) => void =
-    useCallback(
-      (dateRange: InBetween<Date> | null): void => {
-        if (dateRange) {
-          props.onChange({
-            range: TimeRange.CUSTOM,
-            startAndEndDate: dateRange,
-          });
-        }
-      },
-      [props],
-    );
-
-  const buttonLabel: string = getButtonLabel(props.value);
-
   return (
-    <div ref={containerRef} className="relative">
-      <button
-        ref={buttonRef}
-        type="button"
-        data-testid="telemetry-time-range-picker-button"
-        aria-haspopup="true"
-        aria-expanded={isOpen}
-        className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium shadow-sm transition-colors ${
-          isOpen
-            ? "border-indigo-300 bg-indigo-50 text-indigo-700"
-            : "border-gray-200 bg-white text-gray-700 hover:border-gray-300 hover:bg-gray-50"
-        }`}
-        onClick={() => {
-          setIsOpen(!isOpen);
-        }}
-      >
-        <Icon icon={IconProp.Clock} className="h-3.5 w-3.5" />
-        <span>{buttonLabel}</span>
-        <Icon
-          icon={IconProp.ChevronDown}
-          className={`h-3 w-3 transition-transform ${isOpen ? "rotate-180" : ""}`}
-        />
-      </button>
-
-      {isOpen && (
-        <div
-          ref={dropdownRef}
-          data-testid="telemetry-time-range-picker-dropdown"
-          data-align={alignment}
-          className={`absolute ${getDropdownAlignmentClassName(
-            alignment,
-          )} top-full z-50 mt-1 w-72 max-w-[calc(100vw-1rem)] rounded-lg border border-gray-200 bg-white shadow-lg`}
-        >
-          <div className="max-h-64 overflow-y-auto py-1">
-            {PRESET_OPTIONS.map(
-              (option: { range: TimeRange; label: string }) => {
-                const isActive: boolean = props.value.range === option.range;
-
-                return (
-                  <button
-                    key={option.range}
-                    type="button"
-                    className={`flex w-full items-center px-3 py-1.5 text-left text-sm transition-colors ${
-                      isActive
-                        ? "bg-indigo-50 font-medium text-indigo-700"
-                        : "text-gray-700 hover:bg-gray-50"
-                    }`}
-                    onClick={() => {
-                      handlePresetSelect(option.range);
-                    }}
-                  >
-                    {option.label}
-                  </button>
-                );
-              },
-            )}
-
-            <button
-              type="button"
-              className={`flex w-full items-center px-3 py-1.5 text-left text-sm transition-colors ${
-                props.value.range === TimeRange.CUSTOM
-                  ? "bg-indigo-50 font-medium text-indigo-700"
-                  : "text-gray-700 hover:bg-gray-50"
-              }`}
-              onClick={() => {
-                setShowCustom(true);
-              }}
-            >
-              Custom Range...
-            </button>
-          </div>
-
-          {showCustom && (
-            <div className="border-t border-gray-100 p-3">
-              <StartAndEndDate
-                type={StartAndEndDateType.DateTime}
-                value={props.value.startAndEndDate}
-                hideTimeButtons={true}
-                onValueChanged={handleCustomDateChange}
-              />
-            </div>
-          )}
-        </div>
-      )}
-    </div>
+    <TimeRangePickerDropdown
+      value={props.value}
+      onChange={props.onChange}
+      dataTestIdPrefix={TELEMETRY_TIME_RANGE_PICKER_TEST_ID_PREFIX}
+      dropdownWidthInPx={TIME_RANGE_DROPDOWN_WIDTH_IN_PX}
+    />
   );
 };
 


### PR DESCRIPTION
## The bug

On the metrics list page (and everywhere else the telemetry time range picker is used), clicking **Custom Range…** did nothing useful.

The custom editor rendered two `datetime-local` fields *inline inside the 288px dropdown panel*. Three things went wrong:

1. Two date+time fields never fitted in an 18rem panel — they were unusably cramped.
2. The native calendar popup those fields open renders **outside** the picker's container, so the panel's click-outside handler tore the whole dropdown down the moment you clicked a date.
3. There was no Apply step — every keystroke pushed a half-typed window straight at the parent, re-querying the backend mid-edit.

## The fix

**New `CustomTimeRangeModal`** — the custom window is now edited in a proper modal, seeded from whatever range is currently on screen (the active custom range, or the absolute bounds of the selected preset):

- Quick-fill chips: Last 1 hour / 6 hours / 12 hours / 24 hours / 7 days / 30 days
- Labelled **From** / **To** date+time fields with seconds, side by side on desktop, stacked on mobile
- Live summary: resolved From, To, and Duration
- Inline validation (`role="alert"`) for a missing or inverted range, with Apply gated on it
- A note naming the timezone the times are shown in
- Cancel / Apply — edits stay local until you hit Apply

**New shared `TimeRangePickerDropdown`.** `TelemetryTimeRangePicker` and `LogTimeRangePicker` were near-identical copies of the same ~230 lines, so both carried the bug. They're now thin wrappers over one shared component (each keeping its own test-id prefix and exported width constant), which fixes every embedding surface at once and stops them drifting apart again.

## Pages fixed

Everything that embeds either picker: metrics list + metric explorer + metrics dashboard, traces, logs (dashboard and viewer toolbar), exceptions, session replay, topology, and the Kubernetes / host / docker / podman / proxmox / Ceph / IoT / serverless / RUM / cloud / service overview pages.

I also checked the other date-range surfaces. `RangeStartAndEndDateView` (dashboard toolbar, SLO charts, network device, on-call time log, public dashboard) already opens its editor in a modal with an Apply gate, so it isn't affected. The always-visible start/end cards in `MetricView` and `LlmOverview` are a different control, not a "Custom" option, and are left alone.

## Tests

59 new tests across two suites, plus the two existing picker suites updated — **94 passing**.

- `CustomTimeRangeModal.test.tsx` — pure validation rules; seeding; field types/labels/steps; summary and duration; error state and its a11y role; quick fill (fills both ends, doesn't auto-apply, pressed state, recovers an invalid window); edits staying local until Apply; cleared fields; timezone resolution of typed wall-clock times; Apply/Cancel/close-button/Escape.
- `TimeRangePickerDropdown.test.tsx` — button labelling; preset list and emission; modal opens from the custom entry and closes the dropdown; seeding from preset vs. active custom range; apply/cancel/re-open discarding abandoned edits; and a regression test that an outside mousedown no longer kills the editor.
- Existing suites keep their dropdown-alignment coverage and gain assertions that the date fields are no longer in the narrow panel.

`npx tsc --noEmit` on Common and `eslint --fix` on the touched files both pass clean.

## Verification note

Verified through the test suites, not a running app — the local docker stack wasn't up in this environment (`localhost/dashboard` returned 502), so the modal has not been eyeballed in a browser.