### PR TITLE
fix(criteria): keep the attribute filter row when its Number value is cleared

### DIFF
--- a/Common/Tests/App/Dashboard/MonitorCriteriaAttributeFilter.test.tsx
+++ b/Common/Tests/App/Dashboard/MonitorCriteriaAttributeFilter.test.tsx
@@ -1,0 +1,574 @@
+/*
+ * The main entry, not "/extend-expect": the latter no longer ships type
+ * declarations, so every jest-dom matcher in this file fails to typecheck and
+ * the whole suite is skipped before a single assertion runs.
+ */
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React, { ReactElement } from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Both previews render a live telemetry viewer that lists logs/spans over the
+ * API. Nothing in this file is about the preview, and mounting the real one
+ * would only add network to a test that is about clicks.
+ */
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Monitor/LogMonitor/LogMonitorPreview",
+  () => {
+    return {
+      __esModule: true,
+      default: (): ReactElement => {
+        return <div data-testid="logs-preview" />;
+      },
+    };
+  },
+);
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Monitor/TraceMonitor/TraceMonitorPreview",
+  () => {
+    return {
+      __esModule: true,
+      default: (): ReactElement => {
+        return <div data-testid="spans-preview" />;
+      },
+    };
+  },
+);
+
+import LogMonitorStepForm from "../../../../App/FeatureSet/Dashboard/src/Components/Form/Monitor/LogMonitor/LogMonitorStepFrom";
+import TraceMonitorStepForm from "../../../../App/FeatureSet/Dashboard/src/Components/Form/Monitor/TraceMonitor/TraceMonitorStepForm";
+import MonitorStepLogMonitor, {
+  MonitorStepLogMonitorUtil,
+} from "../../../Types/Monitor/MonitorStepLogMonitor";
+import MonitorStepTraceMonitor, {
+  MonitorStepTraceMonitorUtil,
+} from "../../../Types/Monitor/MonitorStepTraceMonitor";
+import Modal from "../../../UI/Components/Modal/Modal";
+import BasicForm from "../../../UI/Components/Forms/BasicForm";
+import FormFieldSchemaType from "../../../UI/Components/Forms/Types/FormFieldSchemaType";
+
+/*
+ * Reported as: "when I try to filter the criteria by attributes it just closes
+ * the window". Monitor → Criteria → Edit Monitoring Criteria → Show Advanced
+ * Options → Add Filter by Attributes → click the Key box → pick a key off the
+ * suggestion list, and the whole Edit Monitor dialog disappears, taking the
+ * criteria the user was editing with it.
+ *
+ * Two separate defects reached that screen, and both are pinned here:
+ *
+ *   1. The suggestion list is portalled to document.body so the modal's scroll
+ *      container cannot clip it, and React dispatches synthetic events through
+ *      the React tree rather than the DOM tree. Picking an option therefore
+ *      bubbled into Modal's backdrop handler, which decided "outside" by asking
+ *      whether the panel DOM-contains the target — a portalled option never is.
+ *      Fixed in Modal (#3133); the mechanism is covered in
+ *      Common/Tests/UI/Components/ModalPortalDismissal.test.tsx. What was
+ *      missing was coverage of the surface the user actually reported, which is
+ *      this one: the criteria editor, where the autocomplete sits at the bottom
+ *      of a nested form inside a scrolled modal body.
+ *
+ *   2. Clearing a Number-typed attribute value deleted the array member rather
+ *      than emptying it, which dropped the row and then crashed the form on the
+ *      next render. Fixed in Dictionary; the row-level tests are in
+ *      Common/Tests/UI/Components/DictionaryAttributeFilterRow.test.tsx.
+ *
+ * The harness runs the real chain from the modal down: Modal → the outer
+ * BasicForm → the step form → its own nested BasicForm → FormField → Dictionary
+ * → AutocompleteTextInput. Faking any layer of that would lose the thing that
+ * made this a bug — the portal boundary between the option and the panel.
+ *
+ * Every pick fires mousedown *and* click. Modal only dismisses on a press that
+ * both starts and ends outside the panel, so a click-only test passes with the
+ * bug fully present.
+ */
+
+const ATTRIBUTE_KEYS: Array<string> = [
+  "{OriginalFormat}",
+  "Action",
+  "ActionId",
+  "ActionName",
+  "ActionType",
+  "AlreadyCancelled",
+];
+
+interface Recorder {
+  closeCount: number;
+  latestLogMonitor: MonitorStepLogMonitor | null;
+  latestTraceMonitor: MonitorStepTraceMonitor | null;
+}
+
+type NewRecorderFunction = () => Recorder;
+
+const newRecorder: NewRecorderFunction = (): Recorder => {
+  return { closeCount: 0, latestLogMonitor: null, latestTraceMonitor: null };
+};
+
+/*
+ * Mirrors the criteria editor: CardModelDetail puts the step form inside a
+ * ModelFormModal, so the step form's own BasicForm is nested inside the modal
+ * form. That nesting is load-bearing here — it is the shape the user was in.
+ */
+const LogHarness: React.FunctionComponent<{ recorder: Recorder }> = (props: {
+  recorder: Recorder;
+}): ReactElement => {
+  const [logMonitor, setLogMonitor] = React.useState<MonitorStepLogMonitor>(
+    MonitorStepLogMonitorUtil.getDefault(),
+  );
+
+  return (
+    <Modal
+      title="Edit Monitor"
+      onClose={() => {
+        props.recorder.closeCount++;
+      }}
+      onSubmit={() => {}}
+    >
+      <BasicForm
+        id="monitor-form"
+        hideSubmitButton={true}
+        initialValues={{}}
+        onSubmit={() => {}}
+        fields={[
+          {
+            field: { monitorSteps: true },
+            title: "Monitor Details",
+            fieldType: FormFieldSchemaType.CustomComponent,
+            getCustomElement: () => {
+              return (
+                <LogMonitorStepForm
+                  monitorStepLogMonitor={logMonitor}
+                  onMonitorStepLogMonitorChanged={(
+                    value: MonitorStepLogMonitor,
+                  ) => {
+                    props.recorder.latestLogMonitor = value;
+                    setLogMonitor(value);
+                  }}
+                  attributeKeys={ATTRIBUTE_KEYS}
+                  telemetryServices={[]}
+                  telemetryEntities={[]}
+                />
+              );
+            },
+          },
+        ]}
+      />
+    </Modal>
+  );
+};
+
+const TraceHarness: React.FunctionComponent<{ recorder: Recorder }> = (props: {
+  recorder: Recorder;
+}): ReactElement => {
+  const [traceMonitor, setTraceMonitor] =
+    React.useState<MonitorStepTraceMonitor>(
+      MonitorStepTraceMonitorUtil.getDefault(),
+    );
+
+  return (
+    <Modal
+      title="Edit Monitor"
+      onClose={() => {
+        props.recorder.closeCount++;
+      }}
+      onSubmit={() => {}}
+    >
+      <BasicForm
+        id="monitor-form"
+        hideSubmitButton={true}
+        initialValues={{}}
+        onSubmit={() => {}}
+        fields={[
+          {
+            field: { monitorSteps: true },
+            title: "Monitor Details",
+            fieldType: FormFieldSchemaType.CustomComponent,
+            getCustomElement: () => {
+              return (
+                <TraceMonitorStepForm
+                  monitorStepTraceMonitor={traceMonitor}
+                  onMonitorStepTraceMonitorChanged={(
+                    value: MonitorStepTraceMonitor,
+                  ) => {
+                    props.recorder.latestTraceMonitor = value;
+                    setTraceMonitor(value);
+                  }}
+                  attributeKeys={ATTRIBUTE_KEYS}
+                  telemetryServices={[]}
+                  telemetryEntities={[]}
+                />
+              );
+            },
+          },
+        ]}
+      />
+    </Modal>
+  );
+};
+
+/*
+ * AutocompleteTextInput and react-select both report role="combobox". The
+ * listbox each autocomplete owns is the only stable way to tell them apart.
+ */
+type AutocompleteInputsFunction = () => Array<HTMLInputElement>;
+
+const autocompleteInputs: AutocompleteInputsFunction =
+  (): Array<HTMLInputElement> => {
+    return Array.from(
+      document.querySelectorAll<HTMLInputElement>(
+        'input[aria-controls^="autocomplete-suggestions-"]',
+      ),
+    );
+  };
+
+type KeyInputFunction = () => HTMLInputElement;
+
+const keyInput: KeyInputFunction = (): HTMLInputElement => {
+  return autocompleteInputs().filter((input: HTMLInputElement) => {
+    return input.getAttribute("placeholder") !== "Value";
+  })[0]!;
+};
+
+type ValueInputFunction = () => HTMLInputElement;
+
+const valueInput: ValueInputFunction = (): HTMLInputElement => {
+  return autocompleteInputs().filter((input: HTMLInputElement) => {
+    return input.getAttribute("placeholder") === "Value";
+  })[0]!;
+};
+
+// A real pointer press is mousedown-then-click; Modal watches both ends.
+type PressFunction = (element: HTMLElement) => void;
+
+const press: PressFunction = (element: HTMLElement): void => {
+  fireEvent.mouseDown(element);
+  fireEvent.click(element);
+};
+
+/*
+ * The layer a user actually presses to dismiss is the one the panel is centred
+ * in; the tinted sheet behind it is aria-hidden and inert.
+ */
+type BackdropLayerFunction = () => HTMLElement;
+
+const backdropLayer: BackdropLayerFunction = (): HTMLElement => {
+  return screen.getByTestId("modal").parentElement!;
+};
+
+// Walks the video: open the advanced section, then add one attribute filter.
+type OpenAttributeFilterFunction = () => void;
+
+const openAttributeFilter: OpenAttributeFilterFunction = (): void => {
+  const showAdvanced: HTMLElement | null = screen.queryByText(
+    "Show Advanced Options",
+  );
+
+  if (showAdvanced) {
+    fireEvent.click(showAdvanced);
+  }
+
+  fireEvent.click(screen.getByText("Add Filter by Attributes"));
+};
+
+type RenderLogHarnessFunction = () => Recorder;
+
+const renderLogHarness: RenderLogHarnessFunction = (): Recorder => {
+  const recorder: Recorder = newRecorder();
+  render(<LogHarness recorder={recorder} />);
+  openAttributeFilter();
+  return recorder;
+};
+
+describe("Monitoring criteria — Filter by Attributes", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("the reported bug: picking a key must not close the modal", () => {
+    test("the suggestion list is portalled outside the modal panel", () => {
+      renderLogHarness();
+
+      fireEvent.focus(keyInput());
+
+      /*
+       * The precondition that made this a bug at all. If the menu ever stops
+       * being portalled, the Modal contract below is no longer what protects
+       * this screen — and this test says so before the others start passing
+       * for the wrong reason.
+       */
+      expect(
+        screen.getByTestId("modal").contains(screen.getByText("ActionName")),
+      ).toBe(false);
+    });
+
+    test("picking a suggested key leaves the modal open", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      press(screen.getByText("ActionName"));
+
+      expect(recorder.closeCount).toBe(0);
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+    });
+
+    test("picking a suggested key fills the row in", () => {
+      renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      press(screen.getByText("ActionName"));
+
+      expect(keyInput().value).toBe("ActionName");
+    });
+
+    test("the whole form the user filled in survives the pick", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      press(screen.getByText("ActionName"));
+
+      // Everything the modal was showing is still on screen.
+      expect(screen.getByText("Filter by Attributes")).toBeInTheDocument();
+      expect(screen.getByText("Log Severity")).toBeInTheDocument();
+      expect(recorder.closeCount).toBe(0);
+    });
+
+    test("the picked attribute reaches the monitor step", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      press(screen.getByText("ActionName"));
+      fireEvent.change(valueInput(), { target: { value: "checkout" } });
+
+      expect(recorder.latestLogMonitor?.attributes).toEqual({
+        ActionName: "checkout",
+      });
+      expect(recorder.closeCount).toBe(0);
+    });
+
+    test("picking a second key on a second row also leaves the modal open", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      press(screen.getByText("ActionName"));
+
+      fireEvent.click(screen.getByText("Add Filter by Attributes"));
+
+      const secondKeyInput: HTMLInputElement = autocompleteInputs().filter(
+        (input: HTMLInputElement) => {
+          return (
+            input.getAttribute("placeholder") !== "Value" && input.value === ""
+          );
+        },
+      )[0]!;
+
+      fireEvent.focus(secondKeyInput);
+      press(screen.getByText("ActionType"));
+
+      expect(recorder.closeCount).toBe(0);
+      expect(recorder.latestLogMonitor?.attributes).toEqual({
+        ActionName: "",
+        ActionType: "",
+      });
+    });
+
+    test("the same pick on the Traces criteria form leaves the modal open", () => {
+      const recorder: Recorder = newRecorder();
+      render(<TraceHarness recorder={recorder} />);
+      openAttributeFilter();
+
+      fireEvent.focus(keyInput());
+      press(screen.getByText("ActionName"));
+
+      expect(recorder.closeCount).toBe(0);
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+      expect(keyInput().value).toBe("ActionName");
+    });
+  });
+
+  describe("the rest of the row, from inside the modal", () => {
+    test("choosing a key with the keyboard leaves the modal open", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      fireEvent.keyDown(keyInput(), { key: "ArrowDown" });
+      fireEvent.keyDown(keyInput(), { key: "Enter" });
+
+      expect(recorder.closeCount).toBe(0);
+      expect(keyInput().value).toBe("{OriginalFormat}");
+    });
+
+    test("Enter with nothing highlighted does not close the modal", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      fireEvent.keyDown(keyInput(), { key: "Enter" });
+
+      expect(recorder.closeCount).toBe(0);
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+    });
+
+    test("Escape closes the suggestion list, not the modal", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      expect(document.querySelectorAll('[role="listbox"]')).toHaveLength(1);
+
+      fireEvent.keyDown(keyInput(), { key: "Escape" });
+
+      expect(document.querySelectorAll('[role="listbox"]')).toHaveLength(0);
+      expect(recorder.closeCount).toBe(0);
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+    });
+
+    test("a second Escape, with the list closed, does close the modal", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      fireEvent.keyDown(keyInput(), { key: "Escape" });
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      expect(recorder.closeCount).toBe(1);
+    });
+
+    test("typing a value keeps the modal open", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      press(screen.getByText("ActionName"));
+      fireEvent.change(valueInput(), { target: { value: "checkout" } });
+
+      expect(recorder.closeCount).toBe(0);
+      expect(valueInput().value).toBe("checkout");
+    });
+
+    test("deleting the row keeps the modal open", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      press(screen.getByText("ActionName"));
+
+      press(screen.getByTestId("delete-ActionName"));
+
+      expect(recorder.closeCount).toBe(0);
+      expect(autocompleteInputs()).toHaveLength(0);
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+    });
+  });
+
+  /*
+   * The second defect, seen from the screen it broke. A Number-typed row that
+   * had its value cleared used to vanish, and the next "Add Filter by
+   * Attributes" click rendered an `undefined` row and threw — which, inside a
+   * modal, is another way for the window to just go away.
+   */
+  describe("a Number-typed attribute value", () => {
+    type SwitchToNumberFunction = () => void;
+
+    const switchToNumber: SwitchToNumberFunction = (): void => {
+      /*
+       * The step form has dropdowns of its own above the filter list, so the
+       * type select has to be found relative to the row rather than by a
+       * position in the whole modal. Within a row the comboboxes run: key
+       * autocomplete, operator select, type select, value autocomplete.
+       */
+      const row: HTMLElement = keyInput().closest(
+        "div.flex.items-start",
+      ) as HTMLElement;
+      const typeSelect: HTMLElement =
+        row.querySelectorAll<HTMLElement>('[role="combobox"]')[2]!;
+
+      fireEvent.keyDown(typeSelect, { key: "ArrowDown" });
+      press(screen.getByText("Number"));
+    };
+
+    test("clearing it keeps the row and the modal", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      press(screen.getByText("ActionId"));
+      switchToNumber();
+
+      const numberInput: HTMLInputElement = document.querySelector(
+        'input[type="number"]',
+      ) as HTMLInputElement;
+      fireEvent.change(numberInput, { target: { value: "5" } });
+      expect(recorder.latestLogMonitor?.attributes).toEqual({ ActionId: 5 });
+
+      fireEvent.change(numberInput, { target: { value: "" } });
+
+      expect(keyInput().value).toBe("ActionId");
+      expect(recorder.latestLogMonitor?.attributes).toEqual({});
+      expect(recorder.closeCount).toBe(0);
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+    });
+
+    test("adding another row after clearing it does not blow the modal up", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      press(screen.getByText("ActionId"));
+      switchToNumber();
+
+      const numberInput: HTMLInputElement = document.querySelector(
+        'input[type="number"]',
+      ) as HTMLInputElement;
+      fireEvent.change(numberInput, { target: { value: "5" } });
+      fireEvent.change(numberInput, { target: { value: "" } });
+
+      // The click that used to throw on the very next render.
+      fireEvent.click(screen.getByText("Add Filter by Attributes"));
+
+      expect(recorder.closeCount).toBe(0);
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+      expect(screen.getByText("Filter by Attributes")).toBeInTheDocument();
+    });
+  });
+
+  /*
+   * The Modal fix narrows what counts as a backdrop press, so the far more
+   * common behaviour next to it has to be pinned just as hard on this screen —
+   * a criteria modal nobody can dismiss would be a worse bug than the one it
+   * replaced.
+   */
+  describe("the modal is still dismissable the ordinary way", () => {
+    test("a press on the backdrop closes it", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      press(backdropLayer());
+
+      expect(recorder.closeCount).toBe(1);
+    });
+
+    test("a press on the backdrop still closes it after a key was picked", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      press(screen.getByText("ActionName"));
+      expect(recorder.closeCount).toBe(0);
+
+      press(backdropLayer());
+
+      expect(recorder.closeCount).toBe(1);
+    });
+
+    test("the close button still closes it while the suggestion list is open", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      fireEvent.click(screen.getByTestId("close-button"));
+
+      expect(recorder.closeCount).toBe(1);
+    });
+
+    test("Cancel still closes it", () => {
+      const recorder: Recorder = renderLogHarness();
+
+      fireEvent.focus(keyInput());
+      press(screen.getByText("ActionName"));
+      fireEvent.click(screen.getByTestId("modal-footer-close-button"));
+
+      expect(recorder.closeCount).toBe(1);
+    });
+  });
+});

--- a/Common/Tests/UI/Components/DictionaryAttributeFilterRow.test.tsx
+++ b/Common/Tests/UI/Components/DictionaryAttributeFilterRow.test.tsx
@@ -1,0 +1,477 @@
+import DictionaryForm, {
+  ValueType,
+} from "../../../UI/Components/Dictionary/Dictionary";
+import { DictionaryEntryValue } from "../../../UI/Components/Dictionary/DictionaryFilterOperator";
+import Includes from "../../../Types/BaseDatabase/Includes";
+import IsNull from "../../../Types/BaseDatabase/IsNull";
+import Dictionary from "../../../Types/Dictionary";
+/*
+ * The main entry, not "/extend-expect": the latter no longer ships type
+ * declarations, so every jest-dom matcher in this file fails to typecheck and
+ * the whole suite is skipped before a single assertion runs.
+ */
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * DictionaryForm is what "Filter by Attributes" is made of: FormField renders
+ * it for every FormFieldSchemaType.Dictionary field, and the only two fields in
+ * the app with that type are the attribute filters on the Log and Trace monitor
+ * steps — the criteria editor. So a row that misbehaves here misbehaves in
+ * exactly one user-visible place, and that place is the monitoring criteria
+ * modal.
+ *
+ * These tests cover the row lifecycle a user actually walks through: add a row,
+ * pick a key off the suggestion list, choose an operator and a type, type a
+ * value, delete it again. The regressions they pin are the ones that used to
+ * take the criteria modal down with them; see the "clearing a Number value"
+ * block for the specific defect.
+ */
+
+const ATTRIBUTE_KEYS: Array<string> = [
+  "{OriginalFormat}",
+  "Action",
+  "ActionId",
+  "ActionName",
+  "ActionType",
+  "AlreadyCancelled",
+];
+
+const ADD_BUTTON_TITLE: string = "Add Filter by Attributes";
+
+/*
+ * AutocompleteTextInput and react-select both report role="combobox", so the
+ * only stable way to single out the hand-rolled ones is the listbox they own.
+ */
+type AutocompleteInputsFunction = () => Array<HTMLInputElement>;
+
+const autocompleteInputs: AutocompleteInputsFunction =
+  (): Array<HTMLInputElement> => {
+    return Array.from(
+      document.querySelectorAll<HTMLInputElement>(
+        'input[aria-controls^="autocomplete-suggestions-"]',
+      ),
+    );
+  };
+
+type KeyInputFunction = (rowIndex?: number) => HTMLInputElement;
+
+const keyInput: KeyInputFunction = (rowIndex: number = 0): HTMLInputElement => {
+  /*
+   * A Text row contributes two autocompletes (key and value) and a Number or
+   * Boolean row only one (the key), so rows cannot be indexed by a fixed
+   * stride. Walking the labelled columns instead survives either shape.
+   */
+  const keyInputs: Array<HTMLInputElement> = autocompleteInputs().filter(
+    (input: HTMLInputElement) => {
+      return input.getAttribute("placeholder") !== "Value";
+    },
+  );
+
+  return keyInputs[rowIndex]!;
+};
+
+type NumberInputsFunction = () => Array<HTMLInputElement>;
+
+const numberInputs: NumberInputsFunction = (): Array<HTMLInputElement> => {
+  return Array.from(
+    document.querySelectorAll<HTMLInputElement>('input[type="number"]'),
+  );
+};
+
+/*
+ * react-select opens on ArrowDown and its options are portalled to
+ * document.body, so they are reachable by role from `screen` but never from
+ * inside the form's own subtree.
+ */
+type SelectOptionFunction = (combobox: HTMLElement, optionText: string) => void;
+
+const selectOption: SelectOptionFunction = (
+  combobox: HTMLElement,
+  optionText: string,
+): void => {
+  fireEvent.keyDown(combobox, { key: "ArrowDown" });
+  const option: HTMLElement = screen.getByText(optionText);
+  fireEvent.mouseDown(option);
+  fireEvent.click(option);
+};
+
+type ComboboxesFunction = () => Array<HTMLElement>;
+
+const comboboxes: ComboboxesFunction = (): Array<HTMLElement> => {
+  return screen.getAllByRole("combobox");
+};
+
+/*
+ * Column order inside a row, with operators enabled: key autocomplete,
+ * operator select, type select, value. Only the two selects are react-select.
+ */
+type TypeSelectFunction = () => HTMLElement;
+
+const typeSelect: TypeSelectFunction = (): HTMLElement => {
+  return comboboxes()[2]!;
+};
+
+type OperatorSelectFunction = () => HTMLElement;
+
+const operatorSelect: OperatorSelectFunction = (): HTMLElement => {
+  return comboboxes()[1]!;
+};
+
+interface RenderResult {
+  emitted: Array<Dictionary<DictionaryEntryValue>>;
+  lastEmitted: () => Dictionary<DictionaryEntryValue> | undefined;
+}
+
+type RenderRowFunction = (
+  initialValue?: Dictionary<DictionaryEntryValue>,
+) => RenderResult;
+
+const renderDictionary: RenderRowFunction = (
+  initialValue?: Dictionary<DictionaryEntryValue>,
+): RenderResult => {
+  const emitted: Array<Dictionary<DictionaryEntryValue>> = [];
+
+  render(
+    <DictionaryForm
+      keys={ATTRIBUTE_KEYS}
+      enableOperators={true}
+      valueTypes={[ValueType.Text, ValueType.Number, ValueType.Boolean]}
+      addButtonSuffix="Filter by Attributes"
+      keyPlaceholder="Key"
+      valuePlaceholder="Value"
+      initialValue={initialValue || {}}
+      onChange={(value: Dictionary<DictionaryEntryValue>) => {
+        emitted.push(value);
+      }}
+    />,
+  );
+
+  return {
+    emitted: emitted,
+    lastEmitted: () => {
+      return emitted.length > 0 ? emitted[emitted.length - 1] : undefined;
+    },
+  };
+};
+
+type AddRowFunction = () => void;
+
+const addRow: AddRowFunction = (): void => {
+  fireEvent.click(screen.getByText(ADD_BUTTON_TITLE));
+};
+
+describe("Dictionary — the 'Filter by Attributes' row", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("picking a key off the suggestion list", () => {
+    test("adding a row renders an empty key, operator, type and value", () => {
+      renderDictionary();
+
+      expect(autocompleteInputs()).toHaveLength(0);
+
+      addRow();
+
+      expect(keyInput().value).toBe("");
+      expect(screen.getByText("Key")).toBeInTheDocument();
+      expect(screen.getByText("Operator")).toBeInTheDocument();
+      expect(screen.getByText("Type")).toBeInTheDocument();
+      expect(screen.getByText("Value")).toBeInTheDocument();
+    });
+
+    test("focusing the key input offers every known attribute key", () => {
+      renderDictionary();
+      addRow();
+
+      fireEvent.focus(keyInput());
+
+      ATTRIBUTE_KEYS.forEach((attributeKey: string) => {
+        expect(screen.getByText(attributeKey)).toBeInTheDocument();
+      });
+    });
+
+    test("picking a key fills the input and emits it", () => {
+      const rendered: RenderResult = renderDictionary();
+      addRow();
+
+      fireEvent.focus(keyInput());
+      fireEvent.mouseDown(screen.getByText("ActionName"));
+      fireEvent.click(screen.getByText("ActionName"));
+
+      expect(keyInput().value).toBe("ActionName");
+      expect(rendered.lastEmitted()).toEqual({ ActionName: "" });
+    });
+
+    test("typing narrows the suggestions to matching keys", () => {
+      renderDictionary();
+      addRow();
+
+      fireEvent.focus(keyInput());
+      fireEvent.change(keyInput(), { target: { value: "ActionN" } });
+
+      expect(screen.getByText("ActionName")).toBeInTheDocument();
+      expect(screen.queryByText("AlreadyCancelled")).not.toBeInTheDocument();
+    });
+
+    test("a key and a value round-trip into the emitted dictionary", () => {
+      const rendered: RenderResult = renderDictionary();
+      addRow();
+
+      fireEvent.focus(keyInput());
+      fireEvent.click(screen.getByText("ActionName"));
+
+      const valueInput: HTMLInputElement = autocompleteInputs().filter(
+        (input: HTMLInputElement) => {
+          return input.getAttribute("placeholder") === "Value";
+        },
+      )[0]!;
+      fireEvent.change(valueInput, { target: { value: "checkout" } });
+
+      expect(rendered.lastEmitted()).toEqual({ ActionName: "checkout" });
+    });
+  });
+
+  /*
+   * The regression this file exists for.
+   *
+   * The Number value input used to `delete newData[index]` when the box was
+   * emptied. Two things follow from deleting an array member rather than
+   * emptying it, and a user hit both in a row:
+   *
+   *   1. The row itself disappeared. Someone who cleared a number to retype it
+   *      watched the whole filter — key, operator and all — vanish.
+   *   2. `delete` leaves a *hole*, and `Array.prototype.map` skips holes while
+   *      the spread in `[...data, newItem]` materialises them as `undefined`.
+   *      So the next "Add Filter by Attributes" click rendered an `undefined`
+   *      row and threw `Cannot read properties of undefined (reading
+   *      'operator')`, taking the criteria modal down with it.
+   */
+  describe("clearing a Number value", () => {
+    type AddNumberRowFunction = () => void;
+
+    const addNumberRow: AddNumberRowFunction = (): void => {
+      addRow();
+      fireEvent.focus(keyInput());
+      fireEvent.click(screen.getByText("ActionId"));
+      selectOption(typeSelect(), "Number");
+    };
+
+    test("keeps the row instead of deleting it", () => {
+      renderDictionary();
+      addNumberRow();
+
+      fireEvent.change(numberInputs()[0]!, { target: { value: "5" } });
+      expect(numberInputs()).toHaveLength(1);
+
+      fireEvent.change(numberInputs()[0]!, { target: { value: "" } });
+
+      expect(numberInputs()).toHaveLength(1);
+      expect(keyInput().value).toBe("ActionId");
+    });
+
+    test("drops the key from the emitted dictionary", () => {
+      const rendered: RenderResult = renderDictionary();
+      addNumberRow();
+
+      fireEvent.change(numberInputs()[0]!, { target: { value: "5" } });
+      expect(rendered.lastEmitted()).toEqual({ ActionId: 5 });
+
+      fireEvent.change(numberInputs()[0]!, { target: { value: "" } });
+
+      expect(rendered.lastEmitted()).toEqual({});
+    });
+
+    test("does not stop the user retyping a number", () => {
+      const rendered: RenderResult = renderDictionary();
+      addNumberRow();
+
+      fireEvent.change(numberInputs()[0]!, { target: { value: "5" } });
+      fireEvent.change(numberInputs()[0]!, { target: { value: "" } });
+      fireEvent.change(numberInputs()[0]!, { target: { value: "42" } });
+
+      expect(rendered.lastEmitted()).toEqual({ ActionId: 42 });
+    });
+
+    test("leaves the form able to add another row", () => {
+      renderDictionary();
+      addNumberRow();
+
+      fireEvent.change(numberInputs()[0]!, { target: { value: "5" } });
+      fireEvent.change(numberInputs()[0]!, { target: { value: "" } });
+
+      // This is the click that used to render an `undefined` row and throw.
+      addRow();
+
+      expect(keyInput(0).value).toBe("ActionId");
+      expect(keyInput(1).value).toBe("");
+      expect(screen.getByText(ADD_BUTTON_TITLE)).toBeInTheDocument();
+    });
+
+    test("leaves the surviving row deletable", () => {
+      renderDictionary();
+      addNumberRow();
+
+      fireEvent.change(numberInputs()[0]!, { target: { value: "" } });
+
+      fireEvent.click(screen.getByTestId("delete-ActionId"));
+
+      expect(autocompleteInputs()).toHaveLength(0);
+    });
+  });
+
+  describe("switching the value type", () => {
+    test("an untouched Number row contributes nothing to the dictionary", () => {
+      const rendered: RenderResult = renderDictionary();
+      addRow();
+
+      fireEvent.focus(keyInput());
+      fireEvent.click(screen.getByText("ActionId"));
+      selectOption(typeSelect(), "Number");
+
+      /*
+       * Switching type blanks the value. Emitting `{ ActionId: "" }` would ship
+       * an empty string where the query expects a number.
+       */
+      expect(rendered.lastEmitted()).toEqual({});
+    });
+
+    test("a Boolean row emits a boolean", () => {
+      const rendered: RenderResult = renderDictionary();
+      addRow();
+
+      fireEvent.focus(keyInput());
+      fireEvent.click(screen.getByText("AlreadyCancelled"));
+      selectOption(typeSelect(), "Boolean");
+
+      expect(rendered.lastEmitted()).toEqual({ AlreadyCancelled: true });
+
+      selectOption(comboboxes()[3]!, "False");
+
+      expect(rendered.lastEmitted()).toEqual({ AlreadyCancelled: false });
+    });
+
+    test("going back to Text restores the value autocomplete", () => {
+      renderDictionary();
+      addRow();
+
+      fireEvent.focus(keyInput());
+      fireEvent.click(screen.getByText("ActionId"));
+
+      selectOption(typeSelect(), "Number");
+      expect(numberInputs()).toHaveLength(1);
+
+      selectOption(typeSelect(), "Text");
+      expect(numberInputs()).toHaveLength(0);
+      expect(keyInput().value).toBe("ActionId");
+    });
+  });
+
+  describe("operators", () => {
+    test("a value-less operator hides the value input and emits the operator", () => {
+      const rendered: RenderResult = renderDictionary();
+      addRow();
+
+      fireEvent.focus(keyInput());
+      fireEvent.click(screen.getByText("Action"));
+
+      selectOption(operatorSelect(), "is empty");
+
+      /*
+       * "is empty" has nothing to type into, so the value box is inert (the
+       * shared Input renders a disabled field as readOnly).
+       */
+      expect(
+        (screen.getByPlaceholderText("is empty") as HTMLInputElement).readOnly,
+      ).toBe(true);
+      expect(rendered.lastEmitted()!["Action"]).toBeInstanceOf(IsNull);
+    });
+
+    test("switching to a multi-value operator resets a scalar value", () => {
+      const rendered: RenderResult = renderDictionary();
+      addRow();
+
+      fireEvent.focus(keyInput());
+      fireEvent.click(screen.getByText("Action"));
+
+      const valueInput: HTMLInputElement = autocompleteInputs().filter(
+        (input: HTMLInputElement) => {
+          return input.getAttribute("placeholder") === "Value";
+        },
+      )[0]!;
+      fireEvent.change(valueInput, { target: { value: "checkout" } });
+      expect(rendered.lastEmitted()).toEqual({ Action: "checkout" });
+
+      selectOption(operatorSelect(), "is any of");
+
+      /*
+       * The scalar has to go: shipping "checkout" where the query now expects
+       * a list would be a stale value in the wrong shape.
+       */
+      const emittedValue: DictionaryEntryValue =
+        rendered.lastEmitted()!["Action"]!;
+      expect(emittedValue).toBeInstanceOf(Includes);
+      expect((emittedValue as Includes).values).toEqual([]);
+    });
+  });
+
+  describe("several rows", () => {
+    test("each row keeps its own key", () => {
+      const rendered: RenderResult = renderDictionary();
+
+      addRow();
+      fireEvent.focus(keyInput(0));
+      fireEvent.click(screen.getByText("Action"));
+
+      addRow();
+      fireEvent.focus(keyInput(1));
+      fireEvent.click(screen.getByText("ActionType"));
+
+      expect(keyInput(0).value).toBe("Action");
+      expect(keyInput(1).value).toBe("ActionType");
+      expect(rendered.lastEmitted()).toEqual({ Action: "", ActionType: "" });
+    });
+
+    test("deleting the first row leaves the second intact", () => {
+      const rendered: RenderResult = renderDictionary();
+
+      addRow();
+      fireEvent.focus(keyInput(0));
+      fireEvent.click(screen.getByText("Action"));
+
+      addRow();
+      fireEvent.focus(keyInput(1));
+      fireEvent.click(screen.getByText("ActionType"));
+
+      fireEvent.click(screen.getByTestId("delete-Action"));
+
+      expect(keyInput(0).value).toBe("ActionType");
+      expect(rendered.lastEmitted()).toEqual({ ActionType: "" });
+    });
+  });
+
+  describe("existing filters", () => {
+    test("an initial dictionary is rendered as rows", () => {
+      renderDictionary({ Action: "checkout", ActionId: 7 });
+
+      expect(keyInput(0).value).toBe("Action");
+      expect(keyInput(1).value).toBe("ActionId");
+      expect(numberInputs()[0]!.value).toBe("7");
+    });
+
+    test("clearing an existing Number filter keeps its row", () => {
+      const rendered: RenderResult = renderDictionary({
+        Action: "checkout",
+        ActionId: 7,
+      });
+
+      fireEvent.change(numberInputs()[0]!, { target: { value: "" } });
+
+      expect(keyInput(1).value).toBe("ActionId");
+      expect(rendered.lastEmitted()).toEqual({ Action: "checkout" });
+    });
+  });
+});

--- a/Common/UI/Components/Dictionary/Dictionary.tsx
+++ b/Common/UI/Components/Dictionary/Dictionary.tsx
@@ -164,7 +164,16 @@ const DictionaryForm: FunctionComponent<ComponentProps> = (
        * numeric/boolean inputs always represent equality.
        */
       if (item.type === ValueType.Number) {
-        result[item.key] = item.value as number;
+        /*
+         * An empty number box is a row the user is still filling in, not a
+         * filter for "". Leaving the key out of the result keeps it out of the
+         * query until an actual number is typed — which is what the value
+         * input used to achieve by deleting the row outright.
+         */
+        if (typeof item.value !== "number" || isNaN(item.value)) {
+          return;
+        }
+        result[item.key] = item.value;
         return;
       }
       if (item.type === ValueType.Boolean) {
@@ -495,12 +504,20 @@ const DictionaryForm: FunctionComponent<ComponentProps> = (
                     placeholder={props.valuePlaceholder}
                     onChange={(value: string) => {
                       const newData: Array<Item> = [...data];
+                      const parsedValue: number = parseInt(value);
 
-                      if (typeof value === "string" && value.length > 0) {
-                        newData[index]!.value = parseInt(value);
-                      } else {
-                        delete newData[index];
-                      }
+                      /*
+                       * Emptying the box empties this row's value — it does not
+                       * remove the row. `delete` on an array leaves a hole, so
+                       * clearing the number silently threw away the filter the
+                       * user was in the middle of writing, and the next
+                       * `[...data]` materialised that hole as `undefined` and
+                       * crashed the whole form on the following render.
+                       */
+                      newData[index]!.value =
+                        value.length > 0 && !isNaN(parsedValue)
+                          ? parsedValue
+                          : "";
 
                       setData(newData);
                       onDataChange(newData);


### PR DESCRIPTION
Reported as *"when I try to filter the criteria by attributes it just closes the window"*, with a screen recording of **Monitor → Criteria → Edit Monitoring Criteria → Show Advanced Options → Add Filter by Attributes → pick a suggested Key**, after which the whole Edit Monitor dialog disappears.

## What the recording shows, and where it stands

Frame-by-frame, the dialog is alive with the suggestion list open at t=6.30 and gone by t=6.45 — the pick itself dismissed it. That is the portalled-dropdown dismissal fixed in #3133: every dropdown portals its menu to `document.body` so a scroll container cannot clip it, React dispatches synthetic events through the React tree rather than the DOM tree, and Modal's backdrop handler therefore read a picked option as a click outside the panel.

The recording is timestamped ~3 hours *before* that fix landed, and the fix does hold on this screen — I reproduced the video's flow through the real component chain and it passes on `master`, then fails when the Modal guard is reverted. **So if you are still seeing the dialog vanish on a Text-typed key, you are on a build older than #3133.**

What was missing was coverage of the surface actually reported. #3133 covered the Modal contract and the Dashboard Variables modal; the criteria editor is the hardest instance of the same thing — the autocomplete sits at the bottom of a *nested* `BasicForm` inside a scrolled modal body, several layers below the panel that owns the backdrop handler. That flow is now pinned end to end.

## The bug this PR fixes

Auditing that flow turned up a second, still-live way for the same dialog to disappear. The Number value input cleared its row with `delete newData[index]`:

- `delete` on an array empties the slot but keeps the length, and `Array.prototype.map` skips holes — so clearing a number to retype it made the **whole filter row** (key, operator and all) silently disappear.
- The spread in `[...data, newItem]` does *not* skip holes, it materialises them as `undefined`. So the next **Add Filter by Attributes** click rendered an `undefined` row and threw `Cannot read properties of undefined (reading 'operator')`, taking the criteria modal down with it.

**Repro on master:** add an attribute filter → set Type to `Number` → type a value → clear it (row vanishes) → click **Add Filter by Attributes** (crash).

The fix empties the value instead of deleting the row, and leaves the key out of the emitted dictionary while the box is empty — the one thing the delete *was* right about, since `{ ActionId: "" }` is an empty string where the query wants a number. That also covers switching a row's type to Number, which blanks the value the same way and used to emit `""`.

`FormFieldSchemaType.Dictionary` is used by exactly two fields in the app — the Log and Trace monitor attribute filters — and every other `DictionaryForm` caller is Text-only, so the change is scoped to the reported feature.

## Tests

38 new tests across two files.

`Common/Tests/App/Dashboard/MonitorCriteriaAttributeFilter.test.tsx` (19) walks the video through the real chain — `Modal` → outer `BasicForm` → step form → its own nested `BasicForm` → `FormField` → `Dictionary` → `AutocompleteTextInput` — for the Logs *and* Traces criteria forms: the menu really is portalled outside the panel, picking a key by mouse or keyboard leaves the dialog up and the row filled, the attribute reaches the monitor step, Escape closes the list rather than the dialog, and backdrop/close/Cancel still dismiss it normally.

`Common/Tests/UI/Components/DictionaryAttributeFilterRow.test.tsx` (19) covers the row lifecycle: key suggestions, value round-trip, operators, type switching, several rows, existing filters, and the Number-clear regression above.

Every pick fires `mousedown` *and* `click`. Modal only dismisses on a press that both starts and ends outside the panel, so a click-only test passes with the dismissal bug fully present.

**Teeth check:** with both fixes reverted, 16 of the 38 fail — including *"picking a suggested key leaves the modal open"*.

## Verification

- 164 tests / 9 suites green (the two new files plus `ModalPortalDismissal`, `DashboardVariablesModal`, `Modal`, `AutocompleteTextInputMenu`, `DictionaryOfStrings`, `DictionaryFilterOperator`, `FilterModalOperatorMenu`)
- `Common` typecheck clean; eslint and prettier clean on the changed files