### PR TITLE
fix(dashboard): show every monitor type's step config on the criteria page

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSteps/MonitorStep.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSteps/MonitorStep.tsx
@@ -1,8 +1,8 @@
 import MonitorCriteriaElement from "./MonitorCriteria";
+import MonitorStepMetricPreview from "./MonitorStepMetricPreview";
 import MonitorCriteria from "Common/Types/Monitor/MonitorCriteria";
-import MonitorStep, { MonitorStepType } from "Common/Types/Monitor/MonitorStep";
+import MonitorStep from "Common/Types/Monitor/MonitorStep";
 import MonitorType from "Common/Types/Monitor/MonitorType";
-import DomainLookupMethod from "Common/Types/Monitor/DomainMonitor/DomainLookupMethod";
 import Detail from "Common/UI/Components/Detail/Detail";
 import Field from "Common/UI/Components/Detail/Field";
 import FieldLabelElement from "Common/UI/Components/Forms/Fields/FieldLabel";
@@ -21,7 +21,7 @@ import React, {
 import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
 import ErrorMessage from "Common/UI/Components/ErrorMessage/ErrorMessage";
 import Service from "Common/Models/DatabaseModels/Service";
-import { JSONObject } from "Common/Types/JSON";
+import NetworkDevice from "Common/Models/DatabaseModels/NetworkDevice";
 import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
 import ListResult from "Common/Types/BaseDatabase/ListResult";
 import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
@@ -30,16 +30,18 @@ import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import API from "Common/UI/Utils/API/API";
 import Includes from "Common/Types/BaseDatabase/Includes";
-import OneUptimeDate from "Common/Types/Date";
 import ServicesElement from "../../Service/ServiceElements";
-import { SpanStatus } from "Common/Models/AnalyticsModels/Span";
 import ObjectID from "Common/Types/ObjectID";
-import SpanUtil from "../../../Utils/SpanUtil";
 import AlertSeverity from "Common/Models/DatabaseModels/AlertSeverity";
 import Label from "Common/Models/DatabaseModels/Label";
 import Team from "Common/Models/DatabaseModels/Team";
 import User from "Common/Models/DatabaseModels/User";
 import IncidentRole from "Common/Models/DatabaseModels/IncidentRole";
+import MonitorStepViewModel, {
+  MonitorStepViewRow,
+  MonitorStepViewValue,
+  MonitorStepViewValueType,
+} from "../../../Utils/MonitorStepViewModel";
 
 export interface ComponentProps {
   monitorStatusOptions: Array<MonitorStatus>;
@@ -54,71 +56,102 @@ export interface ComponentProps {
   incidentRoleOptions: Array<IncidentRole>;
 }
 
-export interface LogMonitorStepView {
-  body: string | undefined;
-  severityTexts: Array<string> | undefined;
-  attributes: JSONObject | undefined;
-  telemetryServices: Array<Service> | undefined;
-  lastXSecondsOfLogs: number | undefined;
-}
+type MonitorStepDetailItem = Record<string, MonitorStepViewValue>;
 
-export interface TraceMonitorStepView {
-  spanName: string | undefined;
-  spanStatuses: Array<SpanStatus> | undefined;
-  attributes: JSONObject | undefined;
-  telemetryServices: Array<Service> | undefined;
-  lastXSecondsOfSpans: number | undefined;
-}
+const fieldTypeByValueType: Record<MonitorStepViewValueType, FieldType> = {
+  [MonitorStepViewValueType.Text]: FieldType.Text,
+  [MonitorStepViewValueType.Number]: FieldType.Number,
+  [MonitorStepViewValueType.Port]: FieldType.Port,
+  [MonitorStepViewValueType.Boolean]: FieldType.Boolean,
+  [MonitorStepViewValueType.ArrayOfText]: FieldType.ArrayOfText,
+  [MonitorStepViewValueType.DictionaryOfStrings]: FieldType.DictionaryOfStrings,
+  [MonitorStepViewValueType.JSON]: FieldType.JSON,
+  [MonitorStepViewValueType.JavaScript]: FieldType.JavaScript,
+  [MonitorStepViewValueType.Code]: FieldType.Code,
+  // Both are resolved to a model by this component and rendered as elements.
+  [MonitorStepViewValueType.TelemetryServices]: FieldType.Element,
+  [MonitorStepViewValueType.NetworkDevice]: FieldType.Text,
+};
+
+const getTelemetryServiceIds: (
+  rows: Array<MonitorStepViewRow>,
+) => Array<string> = (rows: Array<MonitorStepViewRow>): Array<string> => {
+  const ids: Array<string> = [];
+
+  for (const row of rows) {
+    if (row.valueType !== MonitorStepViewValueType.TelemetryServices) {
+      continue;
+    }
+
+    for (const id of (row.value as Array<string> | undefined) || []) {
+      if (id && !ids.includes(id)) {
+        ids.push(id);
+      }
+    }
+  }
+
+  return ids;
+};
+
+const getNetworkDeviceId: (
+  rows: Array<MonitorStepViewRow>,
+) => string | undefined = (
+  rows: Array<MonitorStepViewRow>,
+): string | undefined => {
+  for (const row of rows) {
+    if (
+      row.valueType === MonitorStepViewValueType.NetworkDevice &&
+      typeof row.value === "string" &&
+      row.value
+    ) {
+      return row.value;
+    }
+  }
+
+  return undefined;
+};
 
 const MonitorStepElement: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  /*
+   * The single source of truth for what this page shows. Every monitor type
+   * goes through it, so a type can no longer fall through to a blank
+   * section the way it used to when this was a chain of if/else branches.
+   */
+  const rows: Array<MonitorStepViewRow> = MonitorStepViewModel.getRows({
+    monitorStep: props.monitorStep,
+    monitorType: props.monitorType,
+  });
+
+  const telemetryServiceIds: Array<string> = getTelemetryServiceIds(rows);
+  const networkDeviceId: string | undefined = getNetworkDeviceId(rows);
+
+  /*
+   * Most monitor types reference nothing outside the step, so they must not
+   * pay for a fetch — or flash a loader — on the way in.
+   */
+  const hasReferencesToResolve: boolean =
+    telemetryServiceIds.length > 0 || Boolean(networkDeviceId);
+
+  /*
+   * The effect keys off this joined string rather than the array itself:
+   * `rows` is rebuilt on every render, so array identity would refetch
+   * forever.
+   */
+  const telemetryServiceIdsKey: string = telemetryServiceIds.join(",");
+
+  const [isLoading, setIsLoading] = useState<boolean>(hasReferencesToResolve);
   const [error, setError] = useState<string | undefined>(undefined);
-  const [telemetryServices, setServices] = useState<Array<Service> | undefined>(
-    undefined,
-  );
-
-  // this field is used for most monitor types
-  let fields: Array<Field<MonitorStepType>> = [];
-  let logFields: Array<Field<LogMonitorStepView>> = [];
-  let traceFields: Array<Field<TraceMonitorStepView>> = [];
-
-  const traceMonitorDetailView: TraceMonitorStepView = {
-    spanName: undefined,
-    spanStatuses: undefined,
-    attributes: undefined,
-    telemetryServices: undefined,
-    lastXSecondsOfSpans: undefined,
-  };
-
-  const logMonitorDetailView: LogMonitorStepView = {
-    body: undefined,
-    severityTexts: undefined,
-    attributes: undefined,
-    telemetryServices: undefined,
-    lastXSecondsOfLogs: undefined,
-  };
+  const [telemetryServices, setServices] = useState<Array<Service>>([]);
+  const [networkDeviceName, setNetworkDeviceName] = useState<
+    string | undefined
+  >(undefined);
 
   const fetchServices: PromiseVoidFunction = async (): Promise<void> => {
-    let telemetryServiceIds: Array<ObjectID> = [];
-
-    // if the monitor is a log monitor
-    if (
-      props.monitorStep.data?.logMonitor &&
-      props.monitorType === MonitorType.Logs
-    ) {
-      telemetryServiceIds =
-        props.monitorStep.data?.logMonitor?.telemetryServiceIds || [];
-    }
-
-    // if the monitor is a trace monitor
-    if (
-      props.monitorStep.data?.traceMonitor &&
-      props.monitorType === MonitorType.Traces
-    ) {
-      telemetryServiceIds =
-        props.monitorStep.data?.traceMonitor?.telemetryServiceIds || [];
+    if (telemetryServiceIds.length === 0) {
+      setServices([]);
+      return;
     }
 
     const telemetryServicesResult: ListResult<Service> =
@@ -126,7 +159,11 @@ const MonitorStepElement: FunctionComponent<ComponentProps> = (
         modelType: Service,
         query: {
           projectId: ProjectUtil.getCurrentProjectId()!,
-          _id: new Includes(telemetryServiceIds),
+          _id: new Includes(
+            telemetryServiceIds.map((id: string) => {
+              return new ObjectID(id);
+            }),
+          ),
         },
         limit: LIMIT_PER_PROJECT,
         skip: 0,
@@ -147,15 +184,31 @@ const MonitorStepElement: FunctionComponent<ComponentProps> = (
     setServices(telemetryServicesResult.data);
   };
 
+  const fetchNetworkDevice: PromiseVoidFunction = async (): Promise<void> => {
+    if (!networkDeviceId) {
+      setNetworkDeviceName(undefined);
+      return;
+    }
+
+    const networkDevice: NetworkDevice | null =
+      await ModelAPI.getItem<NetworkDevice>({
+        modelType: NetworkDevice,
+        id: new ObjectID(networkDeviceId),
+        select: {
+          name: true,
+        },
+      });
+
+    setNetworkDeviceName(networkDevice?.name || undefined);
+  };
+
   const loadComponent: PromiseVoidFunction = async (): Promise<void> => {
     setIsLoading(true);
+    setError(undefined);
+
     try {
-      if (
-        props.monitorType === MonitorType.Logs ||
-        props.monitorType === MonitorType.Traces
-      ) {
-        await fetchServices();
-      }
+      await fetchServices();
+      await fetchNetworkDevice();
     } catch (err) {
       setError(API.getFriendlyErrorMessage(err as Error));
     }
@@ -164,8 +217,15 @@ const MonitorStepElement: FunctionComponent<ComponentProps> = (
   };
 
   useEffect(() => {
+    if (!hasReferencesToResolve) {
+      setServices([]);
+      setNetworkDeviceName(undefined);
+      setIsLoading(false);
+      return;
+    }
+
     loadComponent();
-  }, [props.monitorType]);
+  }, [props.monitorType, telemetryServiceIdsKey, networkDeviceId]);
 
   if (isLoading) {
     return <ComponentLoader />;
@@ -175,520 +235,90 @@ const MonitorStepElement: FunctionComponent<ComponentProps> = (
     return <ErrorMessage message={error} />;
   }
 
-  if (props.monitorType === MonitorType.API) {
-    fields = [
-      {
-        key: "monitorDestination",
-        title: "API URL",
-        description: "URL of the API you want to monitor.",
-        fieldType: FieldType.Text,
-        placeholder: "No data entered",
-      },
-      {
-        key: "requestType",
-        title: "Request Type",
-        description: "Whats the type of the API request?",
-        fieldType: FieldType.Text,
-        placeholder: "No data entered",
-      },
-      {
-        key: "requestBody",
-        title: "Request Body",
-        description: "Request Body to send, if any.",
-        fieldType: FieldType.JSON,
-        placeholder: "No data entered",
-      },
-      {
-        key: "requestHeaders",
-        title: "Request Headers",
-        description: "Request Headers to send, if any.",
-        fieldType: FieldType.DictionaryOfStrings,
-        placeholder: "No data entered",
-      },
-      {
-        key: "doNotFollowRedirects",
-        title: "Do Not Follow Redirects",
-        description: "When set, we will not follow redirects.",
-        fieldType: FieldType.Boolean,
-        placeholder: "No",
-      },
-      {
-        key: "allowSelfSignedCertificates",
-        title: "Allow Self-Signed Certificates",
-        description:
-          "When set, TLS certificate validation is skipped (self-signed or untrusted certificates are accepted).",
-        fieldType: FieldType.Boolean,
-        placeholder: "No",
-      },
-    ];
-  } else if (props.monitorType === MonitorType.Website) {
-    fields = [
-      {
-        key: "monitorDestination",
-        title: "Website URL",
-        description: "URL of the website you want to monitor.",
-        fieldType: FieldType.Text,
-        placeholder: "No data entered",
-      },
-      {
-        key: "doNotFollowRedirects",
-        title: "Do Not Follow Redirects",
-        description: "Do not follow redirects.",
-        fieldType: FieldType.Boolean,
-        placeholder: "No",
-      },
-      {
-        key: "allowSelfSignedCertificates",
-        title: "Allow Self-Signed Certificates",
-        description:
-          "When set, TLS certificate validation is skipped (self-signed or untrusted certificates are accepted).",
-        fieldType: FieldType.Boolean,
-        placeholder: "No",
-      },
-    ];
-  } else if (props.monitorType === MonitorType.Ping) {
-    fields = [
-      {
-        key: "monitorDestination",
-        title: "Ping Hostname or IP Address",
-        description:
-          "Hostname or IP Address of the resource you would like us to ping.",
-        fieldType: FieldType.Text,
-        placeholder: "No data entered",
-      },
-    ];
-  } else if (props.monitorType === MonitorType.Port) {
-    fields = [
-      {
-        key: "monitorDestination",
-        title: "Ping Hostname or IP Address",
-        description:
-          "Hostname or IP Address of the resource you would like us to ping.",
-        fieldType: FieldType.Text,
-        placeholder: "No data entered",
-      },
-      {
-        key: "monitorDestinationPort",
-        title: "Port",
-        description: "Port of the resource you would like us to ping.",
-        fieldType: FieldType.Port,
-        placeholder: "No port entered",
-      },
-    ];
-  } else if (props.monitorType === MonitorType.IP) {
-    fields = [
-      {
-        key: "monitorDestination",
-        title: "IP Address",
-        description: "IP Address of the resource you would like us to ping.",
-        fieldType: FieldType.Text,
-        placeholder: "No data entered",
-      },
-    ];
-  } else if (props.monitorType === MonitorType.CustomJavaScriptCode) {
-    fields = [
-      {
-        key: "customCode",
-        title: "JavaScript Code",
-        description: "JavaScript code to run.",
-        fieldType: FieldType.JavaScript,
-        placeholder: "No data entered",
-      },
-    ];
-  } else if (props.monitorType === MonitorType.SyntheticMonitor) {
-    fields = [
-      {
-        key: "customCode",
-        title: "JavaScript Code",
-        description: "JavaScript code to run.",
-        fieldType: FieldType.JavaScript,
-        placeholder: "No data entered",
-      },
-      {
-        key: "browserTypes",
-        title: "Browser Types",
-        description: "Browser types to run the synthetic monitor on.",
-        fieldType: FieldType.ArrayOfText,
-        placeholder: "No data entered",
-      },
-      {
-        key: "screenSizeTypes",
-        title: "Screen Size Types",
-        description: "Screen size types to run the synthetic monitor on.",
-        fieldType: FieldType.ArrayOfText,
-        placeholder: "No data entered",
-      },
-      {
-        key: "retryCountOnError",
-        title: "Retry Count on Error",
-        description:
-          "Number of times to retry the synthetic monitor if it fails.",
-        fieldType: FieldType.Number,
-        placeholder: "0",
-      },
-    ];
-  } else if (props.monitorType === MonitorType.Domain) {
-    fields = [
-      {
-        key: "domainMonitor",
-        title: "Domain Name",
-        description: "The domain name whose registration is being monitored.",
-        fieldType: FieldType.Element,
-        placeholder: "No data entered",
-        getElement: (item: MonitorStepType): ReactElement => {
-          const domainMonitor: any = item.domainMonitor;
-          return <p>{domainMonitor?.domainName || "-"}</p>;
-        },
-      },
-      {
-        key: "domainMonitor",
-        title: "Lookup Method",
-        description: "The protocol used to read domain registration data.",
-        fieldType: FieldType.Element,
-        placeholder: "No data entered",
-        getElement: (item: MonitorStepType): ReactElement => {
-          const domainMonitor: any = item.domainMonitor;
-          return (
-            <p>{domainMonitor?.lookupMethod || DomainLookupMethod.Auto}</p>
-          );
-        },
-      },
-    ];
-  } else if (props.monitorType === MonitorType.DNSSEC) {
-    fields = [
-      {
-        key: "dnssecMonitor",
-        title: "Zone",
-        description: "The zone being validated end-to-end via DNSSEC.",
-        fieldType: FieldType.Element,
-        placeholder: "No data entered",
-        getElement: (item: MonitorStepType): ReactElement => {
-          const dnssecMonitor: any = item.dnssecMonitor;
-          return <p>{dnssecMonitor?.domainName || "-"}</p>;
-        },
-      },
-      {
-        key: "dnssecMonitor",
-        title: "Resolvers",
-        description: "Validating resolvers queried for AD/SERVFAIL behavior.",
-        fieldType: FieldType.Element,
-        placeholder: "No data entered",
-        getElement: (item: MonitorStepType): ReactElement => {
-          const dnssecMonitor: any = item.dnssecMonitor;
-          const resolvers: Array<string> = dnssecMonitor?.resolvers || [];
-          return <p>{resolvers.length > 0 ? resolvers.join(", ") : "-"}</p>;
-        },
-      },
-    ];
-  } else if (props.monitorType === MonitorType.SQLQuery) {
-    fields = [
-      {
-        key: "sqlMonitor",
-        title: "Database",
-        description: "The database this monitor connects to.",
-        fieldType: FieldType.Element,
-        placeholder: "No data entered",
-        getElement: (item: MonitorStepType): ReactElement => {
-          const sqlMonitor: any = item.sqlMonitor;
-          if (!sqlMonitor?.host) {
-            return <p>-</p>;
-          }
-          return (
-            <p>{`${sqlMonitor.databaseType} · ${sqlMonitor.host}:${sqlMonitor.port}/${sqlMonitor.databaseName}`}</p>
-          );
-        },
-      },
-      {
-        key: "sqlMonitor",
-        title: "Query",
-        description: "The read-only SQL query this monitor runs.",
-        fieldType: FieldType.Element,
-        placeholder: "No data entered",
-        getElement: (item: MonitorStepType): ReactElement => {
-          const sqlMonitor: any = item.sqlMonitor;
-          return (
-            <p className="font-mono text-sm break-all">
-              {sqlMonitor?.query || "-"}
-            </p>
-          );
-        },
-      },
-    ];
-  } else if (props.monitorType === MonitorType.ExternalStatusPage) {
-    fields = [
-      {
-        key: "externalStatusPageMonitor",
-        title: "Status Page URL",
-        description: "The URL of the external status page being monitored.",
-        fieldType: FieldType.Element,
-        placeholder: "No data entered",
-        getElement: (item: MonitorStepType): ReactElement => {
-          const externalStatusPageMonitor: any = item.externalStatusPageMonitor;
-          return <p>{externalStatusPageMonitor?.statusPageUrl || "-"}</p>;
-        },
-      },
-      {
-        key: "externalStatusPageMonitor",
-        title: "Provider",
-        description: "How OneUptime reads this status page.",
-        fieldType: FieldType.Element,
-        placeholder: "Auto",
-        getElement: (item: MonitorStepType): ReactElement => {
-          const externalStatusPageMonitor: any = item.externalStatusPageMonitor;
-          return <p>{externalStatusPageMonitor?.provider || "Auto"}</p>;
-        },
-      },
-      {
-        key: "externalStatusPageMonitor",
-        title: "Component Group Filter",
-        description:
-          "If set, only components in this group are monitored and incidents elsewhere are ignored.",
-        fieldType: FieldType.Element,
-        placeholder: "All groups",
-        getElement: (item: MonitorStepType): ReactElement => {
-          const externalStatusPageMonitor: any = item.externalStatusPageMonitor;
-          return (
-            <p>
-              {externalStatusPageMonitor?.componentGroupName || "All groups"}
-            </p>
-          );
-        },
-      },
-      {
-        key: "externalStatusPageMonitor",
-        title: "Component Name Filter",
-        description: "If set, only this specific component will be monitored.",
-        fieldType: FieldType.Element,
-        placeholder: "All components",
-        getElement: (item: MonitorStepType): ReactElement => {
-          const externalStatusPageMonitor: any = item.externalStatusPageMonitor;
-          return (
-            <p>
-              {externalStatusPageMonitor?.componentName || "All components"}
-            </p>
-          );
-        },
-      },
-    ];
-  } else if (props.monitorType === MonitorType.Logs) {
-    logFields = [];
+  const item: MonitorStepDetailItem = {};
+  const fields: Array<Field<MonitorStepDetailItem>> = [];
 
-    if (props.monitorStep.data?.logMonitor?.body) {
-      logMonitorDetailView.body = props.monitorStep.data?.logMonitor?.body;
+  for (const row of rows) {
+    if (row.valueType === MonitorStepViewValueType.TelemetryServices) {
+      const ids: Array<string> = (row.value as Array<string> | undefined) || [];
 
-      logFields.push({
-        key: "body",
-        title: "Filter Log Message",
-        description: "Filter by log message with this text:",
-        fieldType: FieldType.Text,
-        placeholder: "No log message entered",
-      });
-    }
-
-    if (props.monitorStep.data?.logMonitor?.lastXSecondsOfLogs) {
-      logMonitorDetailView.lastXSecondsOfLogs =
-        props.monitorStep.data?.logMonitor?.lastXSecondsOfLogs;
-
-      logFields.push({
-        key: "lastXSecondsOfLogs",
-        title: "Monitor logs for the last (time)",
-        description: "How many seconds of logs to monitor.",
-        fieldType: FieldType.Element,
-        placeholder: "1 minute",
-        getElement: (item: LogMonitorStepView): ReactElement => {
-          return (
-            <p>
-              {OneUptimeDate.convertSecondsToDaysHoursMinutesAndSeconds(
-                item.lastXSecondsOfLogs || 0,
-              )}
-            </p>
-          );
+      const services: Array<Service> = telemetryServices.filter(
+        (service: Service) => {
+          return ids.includes(service.id?.toString() || "");
         },
-      });
-    }
+      );
 
-    if (props.monitorStep.data?.logMonitor?.severityTexts) {
-      logMonitorDetailView.severityTexts =
-        props.monitorStep.data?.logMonitor?.severityTexts;
+      item[row.key] = ids;
 
-      logFields.push({
-        key: "severityTexts",
-        title: "Log Severity",
-        description: "Severity of the logs to monitor.",
-        fieldType: FieldType.ArrayOfText,
-        placeholder: "No severity entered",
-      });
-    }
-
-    if (
-      props.monitorStep.data?.logMonitor?.attributes &&
-      Object.keys(props.monitorStep.data?.logMonitor?.attributes).length > 0
-    ) {
-      logMonitorDetailView.attributes =
-        props.monitorStep.data?.logMonitor?.attributes;
-
-      logFields.push({
-        key: "attributes",
-        title: "Log Attributes",
-        description: "Attributes of the logs to monitor.",
-        fieldType: FieldType.JSON,
-        placeholder: "No attributes entered",
-      });
-    }
-
-    if (
-      props.monitorStep.data?.logMonitor?.telemetryServiceIds &&
-      props.monitorStep.data?.logMonitor?.telemetryServiceIds.length > 0 &&
-      telemetryServices &&
-      telemetryServices.length > 0
-    ) {
-      logMonitorDetailView.telemetryServices = telemetryServices; // set the telemetry services
-
-      logFields.push({
-        key: "telemetryServices",
-        title: "Telemetry Services",
-        description: "Telemetry services to monitor.",
+      fields.push({
+        key: row.key,
+        title: row.title,
+        description: row.description,
         fieldType: FieldType.Element,
-        placeholder: "No telemetry services entered",
+        placeholder: row.placeholder,
         getElement: (): ReactElement => {
-          return <ServicesElement services={telemetryServices} />;
+          return <ServicesElement services={services} />;
         },
       });
-    }
-  } else if (props.monitorType === MonitorType.Traces) {
-    traceFields = [];
 
-    if (props.monitorStep.data?.traceMonitor?.spanName) {
-      traceMonitorDetailView.spanName =
-        props.monitorStep.data?.traceMonitor?.spanName;
-
-      traceFields.push({
-        key: "spanName",
-        title: "Filter Span Name",
-        description: "Filter by span name with this text:",
-        fieldType: FieldType.Text,
-        placeholder: "No span name entered",
-      });
+      continue;
     }
 
-    if (props.monitorStep.data?.traceMonitor?.lastXSecondsOfSpans) {
-      traceMonitorDetailView.lastXSecondsOfSpans =
-        props.monitorStep.data?.traceMonitor?.lastXSecondsOfSpans;
+    /*
+     * A device that has since been deleted resolves to no name; showing the
+     * stored id then beats showing nothing, because it is what the criteria
+     * are still pointed at.
+     */
+    item[row.key] =
+      row.valueType === MonitorStepViewValueType.NetworkDevice
+        ? networkDeviceName || row.value
+        : row.value;
 
-      traceFields.push({
-        key: "lastXSecondsOfSpans",
-        title: "Monitor spans for the last (time)",
-        description: "How many seconds of spans to monitor.",
-        fieldType: FieldType.Element,
-        placeholder: "1 minute",
-        getElement: (item: TraceMonitorStepView): ReactElement => {
-          return (
-            <p>
-              {OneUptimeDate.convertSecondsToDaysHoursMinutesAndSeconds(
-                item.lastXSecondsOfSpans || 0,
-              )}
-            </p>
-          );
-        },
-      });
-    }
-
-    if (props.monitorStep.data?.traceMonitor?.spanStatuses) {
-      traceMonitorDetailView.spanStatuses =
-        props.monitorStep.data?.traceMonitor?.spanStatuses;
-
-      traceFields.push({
-        key: "spanStatuses",
-        title: "Span Status",
-        description: "Status of the spans to monitor.",
-        fieldType: FieldType.Element,
-        getElement: (item: TraceMonitorStepView): ReactElement => {
-          return (
-            <p>
-              {item.spanStatuses
-                ?.map((status: SpanStatus) => {
-                  return SpanUtil.getSpanStatusText(status);
-                })
-                .join(", ")}
-            </p>
-          );
-        },
-        placeholder: "No span status entered. All statuses will be monitored.",
-      });
-    }
-
-    if (
-      props.monitorStep.data?.traceMonitor?.attributes &&
-      Object.keys(props.monitorStep.data?.traceMonitor?.attributes).length > 0
-    ) {
-      traceMonitorDetailView.attributes =
-        props.monitorStep.data?.traceMonitor?.attributes;
-
-      traceFields.push({
-        key: "attributes",
-        title: "Span Attributes",
-        description: "Attributes of the spans to monitor.",
-        fieldType: FieldType.JSON,
-        placeholder: "No attributes entered",
-      });
-    }
-
-    if (
-      props.monitorStep.data?.traceMonitor?.telemetryServiceIds &&
-      props.monitorStep.data?.traceMonitor?.telemetryServiceIds.length > 0 &&
-      telemetryServices &&
-      telemetryServices.length > 0
-    ) {
-      traceMonitorDetailView.telemetryServices = telemetryServices; // set the telemetry services
-
-      traceFields.push({
-        key: "telemetryServices",
-        title: "Telemetry Services",
-        description: "Telemetry services to monitor.",
-        fieldType: FieldType.Element,
-        placeholder: "No telemetry services entered",
-        getElement: (): ReactElement => {
-          return <ServicesElement services={telemetryServices} />;
-        },
-      });
-    }
+    fields.push({
+      key: row.key,
+      title: row.title,
+      description: row.description,
+      fieldType: fieldTypeByValueType[row.valueType],
+      placeholder: row.placeholder,
+    });
   }
+
+  const showMetricPreview: boolean = MonitorStepViewModel.hasMetricPreview(
+    props.monitorType,
+  );
 
   return (
     <div className="mt-5">
-      <FieldLabelElement
-        title={"Monitor Details"}
-        description={
-          "Here are the details of the request we will send to monitor your resource status."
-        }
-        required={true}
-        isHeading={true}
-      />
-      <div className="mt-5">
-        {fields && fields.length > 0 && (
-          <Detail<MonitorStepType>
-            id={"monitor-step"}
-            item={props.monitorStep.data!}
-            fields={fields}
+      {fields.length > 0 && (
+        <div data-testid="monitor-step-details">
+          <FieldLabelElement
+            title={"Monitor Details"}
+            description={
+              "Here are the details of the request we will send to monitor your resource status."
+            }
+            required={true}
+            isHeading={true}
           />
-        )}
-        {logFields && logFields.length > 0 && (
-          <Detail<LogMonitorStepView>
-            id={"monitor-logs"}
-            item={logMonitorDetailView}
-            fields={logFields}
-          />
-        )}
-        {traceFields && traceFields.length > 0 && (
-          <Detail<TraceMonitorStepView>
-            id={"monitor-traces"}
-            item={traceMonitorDetailView}
-            fields={traceFields}
-          />
-        )}
-      </div>
+          <div className="mt-5">
+            <Detail<MonitorStepDetailItem>
+              id={"monitor-step"}
+              item={item}
+              fields={fields}
+            />
+          </div>
+        </div>
+      )}
 
-      <HorizontalRule />
+      {showMetricPreview && (
+        <MonitorStepMetricPreview
+          metricsViewConfig={MonitorStepViewModel.getMetricsViewConfig(
+            props.monitorStep,
+          )}
+          rollingTime={MonitorStepViewModel.getRollingTime(props.monitorStep)}
+        />
+      )}
+
+      {fields.length > 0 && <HorizontalRule />}
 
       <div className="mt-5">
         <FieldLabelElement

--- a/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSteps/MonitorStepMetricPreview.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSteps/MonitorStepMetricPreview.tsx
@@ -1,0 +1,68 @@
+import MetricView from "../../Metrics/MetricView";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import MetricsViewConfig from "Common/Types/Metrics/MetricsViewConfig";
+import RollingTime from "Common/Types/RollingTime/RollingTime";
+import RollingTimeUtil from "Common/Types/RollingTime/RollingTimeUtil";
+import FieldLabelElement from "Common/UI/Components/Forms/Fields/FieldLabel";
+import React, { FunctionComponent, ReactElement, useEffect } from "react";
+
+export interface ComponentProps {
+  metricsViewConfig: MetricsViewConfig;
+  rollingTime: RollingTime | undefined;
+}
+
+/*
+ * The read-only twin of the chart the edit modal shows while you pick
+ * metrics. Kept in its own file so the criteria page can render "what this
+ * monitor is actually watching" without the viewer component taking on the
+ * metric explorer's fetch machinery.
+ */
+const MonitorStepMetricPreview: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const rollingTime: RollingTime = props.rollingTime || RollingTime.Past1Minute;
+
+  /*
+   * Held in state, not derived on every render: MetricView refetches
+   * whenever the start/end instants change, and a window computed inline
+   * would be a new pair of Dates on each pass — an endless refetch loop.
+   */
+  const [startAndEndDate, setStartAndEndDate] =
+    React.useState<InBetween<Date> | null>(null);
+
+  useEffect(() => {
+    setStartAndEndDate(RollingTimeUtil.convertToStartAndEndDate(rollingTime));
+  }, [rollingTime]);
+
+  if (props.metricsViewConfig.queryConfigs.length === 0) {
+    return <></>;
+  }
+
+  return (
+    <div className="mt-5" data-testid="monitor-step-metric-preview">
+      <FieldLabelElement
+        title="Metric Preview"
+        description={`The metrics this monitor evaluates, over the ${rollingTime.toLowerCase()}.`}
+      />
+      <div className="mt-3">
+        <MetricView
+          hideQueryElements={true}
+          hideStartAndEndDate={true}
+          hideCardInCharts={true}
+          disableChartZoom={true}
+          chartCssClass="rounded-lg border border-gray-200 shadow-sm"
+          data={{
+            startAndEndDate: startAndEndDate,
+            queryConfigs: props.metricsViewConfig.queryConfigs,
+            formulaConfigs: props.metricsViewConfig.formulaConfigs,
+          }}
+          onChange={() => {
+            // Read-only preview. Nothing here is editable.
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default MonitorStepMetricPreview;

--- a/App/FeatureSet/Dashboard/src/Utils/MonitorStepViewModel.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/MonitorStepViewModel.ts
@@ -1,0 +1,1558 @@
+import { SpanStatus } from "Common/Models/AnalyticsModels/Span";
+import OneUptimeDate from "Common/Types/Date";
+import Dictionary from "Common/Types/Dictionary";
+import { JSONObject } from "Common/Types/JSON";
+import MetricFormulaConfigData from "Common/Types/Metrics/MetricFormulaConfigData";
+import MetricQueryConfigData from "Common/Types/Metrics/MetricQueryConfigData";
+import MetricsViewConfig from "Common/Types/Metrics/MetricsViewConfig";
+import DomainLookupMethod from "Common/Types/Monitor/DomainMonitor/DomainLookupMethod";
+import MonitorStep, { MonitorStepType } from "Common/Types/Monitor/MonitorStep";
+import MonitorType from "Common/Types/Monitor/MonitorType";
+import RollingTime from "Common/Types/RollingTime/RollingTime";
+
+/*
+ * WHY THIS FILE EXISTS
+ *
+ * The monitor "Criteria" page renders a read-only view of the monitor step
+ * next to the criteria. That view used to be a chain of `if (monitorType ===
+ * ...)` branches inside the viewer component, and it only covered a third of
+ * the monitor types we ship. For every other type — Metrics, all nine
+ * infrastructure/telemetry types, DNS, Exceptions, Network Device, SSL
+ * Certificate — the branch chain fell through, the field list stayed empty,
+ * and the page showed a "Monitor Details" heading with nothing under it. The
+ * configuration was there, and the edit modal showed it; the page just never
+ * had a branch that could render it.
+ *
+ * Adding branches to a component is how it got that way, so the mapping from
+ * "monitor step" to "what the page shows" lives here instead: a pure function
+ * over plain data with no React, no fetches and no rendering, which the test
+ * suite can hold to every monitor type at once.
+ *
+ * Rows carry a `valueType` rather than a UI FieldType so this file never
+ * imports from the component layer. The viewer translates them.
+ */
+
+export enum MonitorStepViewValueType {
+  Text = "Text",
+  Number = "Number",
+  Port = "Port",
+  Boolean = "Boolean",
+  ArrayOfText = "ArrayOfText",
+  DictionaryOfStrings = "DictionaryOfStrings",
+  JSON = "JSON",
+  JavaScript = "JavaScript",
+  Code = "Code",
+  /*
+   * Value is an array of telemetry service id strings. The viewer resolves
+   * them to service names/colors — this module stays free of API calls.
+   */
+  TelemetryServices = "TelemetryServices",
+  // Value is a single network device id string, resolved the same way.
+  NetworkDevice = "NetworkDevice",
+}
+
+export type MonitorStepViewValue =
+  | string
+  | number
+  | boolean
+  | Array<string>
+  | Dictionary<string>
+  | JSONObject
+  | undefined;
+
+export interface MonitorStepViewRow {
+  key: string;
+  title: string;
+  description: string;
+  valueType: MonitorStepViewValueType;
+  value: MonitorStepViewValue;
+  // Shown by the viewer when `value` is empty.
+  placeholder: string;
+}
+
+type OptionalRow = MonitorStepViewRow | null;
+
+/*
+ * An empty value means "nothing configured". Rows built through
+ * `optional()` are dropped in that case so a Kubernetes monitor scoped to a
+ * whole cluster doesn't render five blank filter rows; rows built directly
+ * are always kept so a missing destination shows its placeholder instead of
+ * silently vanishing.
+ */
+const isEmptyValue: (value: MonitorStepViewValue) => boolean = (
+  value: MonitorStepViewValue,
+): boolean => {
+  if (value === undefined || value === null || value === "") {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (typeof value === "object") {
+    return Object.keys(value).length === 0;
+  }
+
+  return false;
+};
+
+const optional: (row: MonitorStepViewRow) => OptionalRow = (
+  row: MonitorStepViewRow,
+): OptionalRow => {
+  if (isEmptyValue(row.value)) {
+    return null;
+  }
+
+  return row;
+};
+
+const compact: (rows: Array<OptionalRow>) => Array<MonitorStepViewRow> = (
+  rows: Array<OptionalRow>,
+): Array<MonitorStepViewRow> => {
+  return rows.filter((row: OptionalRow): row is MonitorStepViewRow => {
+    return row !== null;
+  });
+};
+
+const toText: (value: unknown) => string | undefined = (
+  value: unknown,
+): string | undefined => {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+
+  return String(value);
+};
+
+const toMilliseconds: (value: number | undefined) => string | undefined = (
+  value: number | undefined,
+): string | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  return `${value} ms`;
+};
+
+const toDuration: (seconds: number | undefined) => string | undefined = (
+  seconds: number | undefined,
+): string | undefined => {
+  if (!seconds) {
+    return undefined;
+  }
+
+  return OneUptimeDate.convertSecondsToDaysHoursMinutesAndSeconds(seconds);
+};
+
+/*
+ * Span statuses are persisted as the OTel numeric codes. "0" tells an
+ * operator nothing, so they are named here rather than printed raw.
+ */
+const toSpanStatusText: (status: SpanStatus) => string = (
+  status: SpanStatus,
+): string => {
+  switch (status) {
+    case SpanStatus.Ok:
+      return "Ok";
+    case SpanStatus.Error:
+      return "Error";
+    default:
+      return "Unset";
+  }
+};
+
+const safeMetricsViewConfig: (
+  config: MetricsViewConfig | undefined | null,
+) => MetricsViewConfig = (
+  config: MetricsViewConfig | undefined | null,
+): MetricsViewConfig => {
+  return {
+    queryConfigs: Array.isArray(config?.queryConfigs)
+      ? (config.queryConfigs as Array<MetricQueryConfigData>)
+      : [],
+    formulaConfigs: Array.isArray(config?.formulaConfigs)
+      ? (config.formulaConfigs as Array<MetricFormulaConfigData>)
+      : [],
+  };
+};
+
+export default class MonitorStepViewModel {
+  /**
+   * The metric view every metric-backed monitor type keeps under its own
+   * step shape. Mirrors MonitorStep.getMetricsViewConfig but always returns
+   * a renderable config rather than undefined.
+   */
+  public static getMetricsViewConfig(
+    monitorStep: MonitorStep | undefined,
+  ): MetricsViewConfig {
+    return safeMetricsViewConfig(MonitorStep.getMetricsViewConfig(monitorStep));
+  }
+
+  /**
+   * The rolling window a metric-backed monitor evaluates over. Each
+   * telemetry step shape carries its own copy, so this reads whichever one
+   * the step has.
+   */
+  public static getRollingTime(
+    monitorStep: MonitorStep | undefined,
+  ): RollingTime | undefined {
+    const data: MonitorStepType | undefined = monitorStep?.data;
+
+    if (!data) {
+      return undefined;
+    }
+
+    return (
+      data.metricMonitor?.rollingTime ||
+      data.iotMonitor?.rollingTime ||
+      data.kubernetesMonitor?.rollingTime ||
+      data.dockerMonitor?.rollingTime ||
+      data.dockerSwarmMonitor?.rollingTime ||
+      data.hostMonitor?.rollingTime ||
+      data.podmanMonitor?.rollingTime ||
+      data.proxmoxMonitor?.rollingTime ||
+      data.cephMonitor?.rollingTime
+    );
+  }
+
+  /**
+   * True when the monitor type's configuration is a metric view, and the
+   * page should therefore render a live chart preview of it.
+   */
+  public static hasMetricPreview(monitorType: MonitorType): boolean {
+    return [
+      MonitorType.Metrics,
+      MonitorType.Kubernetes,
+      MonitorType.Docker,
+      MonitorType.Host,
+      MonitorType.Podman,
+      MonitorType.Proxmox,
+      MonitorType.DockerSwarm,
+      MonitorType.Ceph,
+      MonitorType.IoTDevice,
+    ].includes(monitorType);
+  }
+
+  /**
+   * Human-readable one-liners for the metrics a step queries, e.g.
+   * "CPU Usage (container.cpu.usage · Avg)". Used both for the detail row
+   * and by tests as the contract for "the page names the metric".
+   */
+  public static getMetricQueryTitles(
+    metricsViewConfig: MetricsViewConfig | undefined,
+  ): Array<string> {
+    const config: MetricsViewConfig = safeMetricsViewConfig(metricsViewConfig);
+
+    return config.queryConfigs
+      .map((queryConfig: MetricQueryConfigData): string => {
+        const metricName: string =
+          toText(queryConfig.metricQueryData?.filterData?.metricName) || "";
+
+        const aggregation: string =
+          toText(queryConfig.metricQueryData?.filterData?.aggegationType) || "";
+
+        const alias: string =
+          toText(queryConfig.metricAliasData?.title) ||
+          toText(queryConfig.metricAliasData?.legend) ||
+          "";
+
+        const core: string = aggregation
+          ? `${metricName} · ${aggregation}`
+          : metricName;
+
+        if (!core) {
+          return alias;
+        }
+
+        return alias ? `${alias} (${core})` : core;
+      })
+      .filter((title: string) => {
+        return title.length > 0;
+      });
+  }
+
+  /**
+   * Formula expressions defined alongside the queries, e.g. "a / b * 100".
+   */
+  public static getMetricFormulaTitles(
+    metricsViewConfig: MetricsViewConfig | undefined,
+  ): Array<string> {
+    const config: MetricsViewConfig = safeMetricsViewConfig(metricsViewConfig);
+
+    return config.formulaConfigs
+      .map((formulaConfig: MetricFormulaConfigData): string => {
+        const formula: string =
+          toText(formulaConfig.metricFormulaData?.metricFormula) || "";
+
+        const alias: string =
+          toText(formulaConfig.metricAliasData?.title) ||
+          toText(formulaConfig.metricAliasData?.metricVariable) ||
+          "";
+
+        if (!formula) {
+          return "";
+        }
+
+        return alias ? `${alias} (${formula})` : formula;
+      })
+      .filter((title: string) => {
+        return title.length > 0;
+      });
+  }
+
+  /**
+   * Attribute keys the step groups its series by — the difference between
+   * one incident for the fleet and one incident per host.
+   */
+  public static getMetricGroupByKeys(
+    metricsViewConfig: MetricsViewConfig | undefined,
+  ): Array<string> {
+    const config: MetricsViewConfig = safeMetricsViewConfig(metricsViewConfig);
+
+    const keys: Array<string> = [];
+
+    for (const queryConfig of config.queryConfigs) {
+      for (const key of queryConfig.metricQueryData?.groupByAttributeKeys ||
+        []) {
+        if (key && !keys.includes(key)) {
+          keys.push(key);
+        }
+      }
+    }
+
+    return keys;
+  }
+
+  /**
+   * Every row the monitor step view should show, in display order, for the
+   * given monitor type. An empty array means the type has no step
+   * configuration at all (Manual, Server, Incoming Request/Email) and the
+   * viewer should not render the section.
+   */
+  public static getRows(input: {
+    monitorStep: MonitorStep | undefined;
+    monitorType: MonitorType;
+  }): Array<MonitorStepViewRow> {
+    const data: MonitorStepType | undefined = input.monitorStep?.data;
+
+    if (!data) {
+      return [];
+    }
+
+    const monitorType: MonitorType = input.monitorType;
+
+    switch (monitorType) {
+      case MonitorType.API:
+        return MonitorStepViewModel.getApiRows(data);
+      case MonitorType.Website:
+        return MonitorStepViewModel.getWebsiteRows(data);
+      case MonitorType.Ping:
+      case MonitorType.IP:
+        return MonitorStepViewModel.getPingRows(data, monitorType);
+      case MonitorType.Port:
+        return MonitorStepViewModel.getPortRows(data);
+      case MonitorType.SSLCertificate:
+        return MonitorStepViewModel.getSslCertificateRows(data);
+      case MonitorType.CustomJavaScriptCode:
+        return MonitorStepViewModel.getCustomCodeRows(data);
+      case MonitorType.SyntheticMonitor:
+        return MonitorStepViewModel.getSyntheticRows(data);
+      case MonitorType.Domain:
+        return MonitorStepViewModel.getDomainRows(data);
+      case MonitorType.DNS:
+        return MonitorStepViewModel.getDnsRows(data);
+      case MonitorType.DNSSEC:
+        return MonitorStepViewModel.getDnssecRows(data);
+      case MonitorType.SQLQuery:
+        return MonitorStepViewModel.getSqlRows(data);
+      case MonitorType.ExternalStatusPage:
+        return MonitorStepViewModel.getExternalStatusPageRows(data);
+      case MonitorType.Logs:
+        return MonitorStepViewModel.getLogRows(data);
+      case MonitorType.Traces:
+        return MonitorStepViewModel.getTraceRows(data);
+      case MonitorType.Exceptions:
+        return MonitorStepViewModel.getExceptionRows(data);
+      case MonitorType.NetworkDevice:
+        return MonitorStepViewModel.getNetworkDeviceRows(data);
+      case MonitorType.Metrics:
+        return MonitorStepViewModel.getMetricRows(data);
+      case MonitorType.Kubernetes:
+        return MonitorStepViewModel.getKubernetesRows(data);
+      case MonitorType.Docker:
+        return MonitorStepViewModel.getDockerRows(data);
+      case MonitorType.Podman:
+        return MonitorStepViewModel.getPodmanRows(data);
+      case MonitorType.Host:
+        return MonitorStepViewModel.getHostRows(data);
+      case MonitorType.Proxmox:
+        return MonitorStepViewModel.getProxmoxRows(data);
+      case MonitorType.DockerSwarm:
+        return MonitorStepViewModel.getDockerSwarmRows(data);
+      case MonitorType.Ceph:
+        return MonitorStepViewModel.getCephRows(data);
+      case MonitorType.IoTDevice:
+        return MonitorStepViewModel.getIoTRows(data);
+      default:
+        // Manual, Server, Incoming Request/Email, Profiles: no step config.
+        return [];
+    }
+  }
+
+  private static getDestinationRow(
+    data: MonitorStepType,
+    title: string,
+    description: string,
+  ): MonitorStepViewRow {
+    return {
+      key: "monitorDestination",
+      title: title,
+      description: description,
+      valueType: MonitorStepViewValueType.Text,
+      value: toText(data.monitorDestination?.toString()),
+      placeholder: "No data entered",
+    };
+  }
+
+  /*
+   * Per-step overrides on probe monitors. Both are optional and fall back to
+   * platform defaults, so they only earn a row when the user set them.
+   */
+  private static getTimeoutAndRetryRows(
+    data: MonitorStepType,
+  ): Array<OptionalRow> {
+    return [
+      optional({
+        key: "requestTimeoutInMs",
+        title: "Request Timeout",
+        description: "How long we wait for a response before failing a check.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toMilliseconds(data.requestTimeoutInMs),
+        placeholder: "Default",
+      }),
+      optional({
+        key: "retryCount",
+        title: "Retry Count",
+        description: "How many times we retry a failed check.",
+        valueType: MonitorStepViewValueType.Number,
+        value: data.retryCount,
+        placeholder: "Default",
+      }),
+    ];
+  }
+
+  /*
+   * mTLS material is a secret. The page confirms whether one is configured
+   * and never renders the certificate, the key or the passphrase.
+   */
+  private static getMutualTlsRows(data: MonitorStepType): Array<OptionalRow> {
+    const hasCertificate: boolean = Boolean(
+      data.tlsClientCertificate && data.tlsClientCertificate.trim(),
+    );
+
+    return [
+      optional({
+        key: "tlsClientCertificate",
+        title: "Client Certificate (mTLS)",
+        description:
+          "A client certificate is configured for this check. The certificate and key are never displayed.",
+        valueType: MonitorStepViewValueType.Text,
+        value: hasCertificate ? "Configured" : undefined,
+        placeholder: "Not configured",
+      }),
+    ];
+  }
+
+  private static getApiRows(data: MonitorStepType): Array<MonitorStepViewRow> {
+    return compact([
+      MonitorStepViewModel.getDestinationRow(
+        data,
+        "API URL",
+        "URL of the API you want to monitor.",
+      ),
+      {
+        key: "requestType",
+        title: "Request Type",
+        description: "Whats the type of the API request?",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(data.requestType),
+        placeholder: "No data entered",
+      },
+      {
+        key: "requestBody",
+        title: "Request Body",
+        description: "Request Body to send, if any.",
+        valueType: MonitorStepViewValueType.JSON,
+        value: data.requestBody,
+        placeholder: "No data entered",
+      },
+      {
+        key: "requestHeaders",
+        title: "Request Headers",
+        description: "Request Headers to send, if any.",
+        valueType: MonitorStepViewValueType.DictionaryOfStrings,
+        value: data.requestHeaders,
+        placeholder: "No data entered",
+      },
+      {
+        key: "doNotFollowRedirects",
+        title: "Do Not Follow Redirects",
+        description: "When set, we will not follow redirects.",
+        valueType: MonitorStepViewValueType.Boolean,
+        value: Boolean(data.doNotFollowRedirects),
+        placeholder: "No",
+      },
+      {
+        key: "allowSelfSignedCertificates",
+        title: "Allow Self-Signed Certificates",
+        description:
+          "When set, TLS certificate validation is skipped (self-signed or untrusted certificates are accepted).",
+        valueType: MonitorStepViewValueType.Boolean,
+        value: Boolean(data.allowSelfSignedCertificates),
+        placeholder: "No",
+      },
+      ...MonitorStepViewModel.getMutualTlsRows(data),
+      ...MonitorStepViewModel.getTimeoutAndRetryRows(data),
+    ]);
+  }
+
+  private static getWebsiteRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    return compact([
+      MonitorStepViewModel.getDestinationRow(
+        data,
+        "Website URL",
+        "URL of the website you want to monitor.",
+      ),
+      {
+        key: "doNotFollowRedirects",
+        title: "Do Not Follow Redirects",
+        description: "Do not follow redirects.",
+        valueType: MonitorStepViewValueType.Boolean,
+        value: Boolean(data.doNotFollowRedirects),
+        placeholder: "No",
+      },
+      {
+        key: "allowSelfSignedCertificates",
+        title: "Allow Self-Signed Certificates",
+        description:
+          "When set, TLS certificate validation is skipped (self-signed or untrusted certificates are accepted).",
+        valueType: MonitorStepViewValueType.Boolean,
+        value: Boolean(data.allowSelfSignedCertificates),
+        placeholder: "No",
+      },
+      ...MonitorStepViewModel.getMutualTlsRows(data),
+      ...MonitorStepViewModel.getTimeoutAndRetryRows(data),
+    ]);
+  }
+
+  private static getPingRows(
+    data: MonitorStepType,
+    monitorType: MonitorType,
+  ): Array<MonitorStepViewRow> {
+    const isIp: boolean = monitorType === MonitorType.IP;
+
+    return compact([
+      MonitorStepViewModel.getDestinationRow(
+        data,
+        isIp ? "IP Address" : "Ping Hostname or IP Address",
+        isIp
+          ? "IP Address of the resource you would like us to ping."
+          : "Hostname or IP Address of the resource you would like us to ping.",
+      ),
+      ...MonitorStepViewModel.getTimeoutAndRetryRows(data),
+    ]);
+  }
+
+  private static getPortRows(data: MonitorStepType): Array<MonitorStepViewRow> {
+    return compact([
+      MonitorStepViewModel.getDestinationRow(
+        data,
+        "Ping Hostname or IP Address",
+        "Hostname or IP Address of the resource you would like us to ping.",
+      ),
+      {
+        key: "monitorDestinationPort",
+        title: "Port",
+        description: "Port of the resource you would like us to ping.",
+        valueType: MonitorStepViewValueType.Port,
+        value: toText(data.monitorDestinationPort?.toString()),
+        placeholder: "No port entered",
+      },
+      ...MonitorStepViewModel.getTimeoutAndRetryRows(data),
+    ]);
+  }
+
+  private static getSslCertificateRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    return compact([
+      MonitorStepViewModel.getDestinationRow(
+        data,
+        "Website URL",
+        "URL whose SSL certificate we monitor.",
+      ),
+      ...MonitorStepViewModel.getTimeoutAndRetryRows(data),
+    ]);
+  }
+
+  private static getCustomCodeRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    return compact([
+      {
+        key: "customCode",
+        title: "JavaScript Code",
+        description: "JavaScript code to run.",
+        valueType: MonitorStepViewValueType.JavaScript,
+        value: data.customCode,
+        placeholder: "No data entered",
+      },
+    ]);
+  }
+
+  private static getSyntheticRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    return compact([
+      {
+        key: "customCode",
+        title: "JavaScript Code",
+        description: "JavaScript code to run.",
+        valueType: MonitorStepViewValueType.JavaScript,
+        value: data.customCode,
+        placeholder: "No data entered",
+      },
+      {
+        key: "browserTypes",
+        title: "Browser Types",
+        description: "Browser types to run the synthetic monitor on.",
+        valueType: MonitorStepViewValueType.ArrayOfText,
+        value: (data.browserTypes || []).map((browserType: string) => {
+          return String(browserType);
+        }),
+        placeholder: "No data entered",
+      },
+      {
+        key: "screenSizeTypes",
+        title: "Screen Size Types",
+        description: "Screen size types to run the synthetic monitor on.",
+        valueType: MonitorStepViewValueType.ArrayOfText,
+        value: (data.screenSizeTypes || []).map((screenSizeType: string) => {
+          return String(screenSizeType);
+        }),
+        placeholder: "No data entered",
+      },
+      {
+        key: "retryCountOnError",
+        title: "Retry Count on Error",
+        description:
+          "Number of times to retry the synthetic monitor if it fails.",
+        valueType: MonitorStepViewValueType.Number,
+        value: data.retryCountOnError,
+        placeholder: "0",
+      },
+    ]);
+  }
+
+  private static getDomainRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    return compact([
+      {
+        key: "domainName",
+        title: "Domain Name",
+        description: "The domain name whose registration is being monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(data.domainMonitor?.domainName),
+        placeholder: "No data entered",
+      },
+      {
+        key: "lookupMethod",
+        title: "Lookup Method",
+        description: "The protocol used to read domain registration data.",
+        valueType: MonitorStepViewValueType.Text,
+        value:
+          toText(data.domainMonitor?.lookupMethod) || DomainLookupMethod.Auto,
+        placeholder: "No data entered",
+      },
+      optional({
+        key: "domainTimeout",
+        title: "Lookup Timeout",
+        description: "How long we wait for the registry to answer.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toMilliseconds(data.domainMonitor?.timeout),
+        placeholder: "Default",
+      }),
+      optional({
+        key: "domainRetries",
+        title: "Retries",
+        description: "How many times we retry a failed lookup.",
+        valueType: MonitorStepViewValueType.Number,
+        value: data.domainMonitor?.retries,
+        placeholder: "Default",
+      }),
+    ]);
+  }
+
+  private static getDnsRows(data: MonitorStepType): Array<MonitorStepViewRow> {
+    return compact([
+      {
+        key: "queryName",
+        title: "Domain Name",
+        description: "The name we resolve on every check.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(data.dnsMonitor?.queryName),
+        placeholder: "No data entered",
+      },
+      {
+        key: "recordType",
+        title: "Record Type",
+        description: "The DNS record type we query for.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(data.dnsMonitor?.recordType),
+        placeholder: "No data entered",
+      },
+      {
+        key: "dnsServer",
+        title: "DNS Server",
+        description: "The resolver we send the query to.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(data.dnsMonitor?.hostname),
+        placeholder: "System default resolver",
+      },
+      optional({
+        key: "dnsPort",
+        title: "DNS Server Port",
+        description: "The port the resolver listens on.",
+        valueType: MonitorStepViewValueType.Port,
+        value: toText(data.dnsMonitor?.port),
+        placeholder: "53",
+      }),
+      optional({
+        key: "dnsTimeout",
+        title: "Query Timeout",
+        description: "How long we wait for the resolver to answer.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toMilliseconds(data.dnsMonitor?.timeout),
+        placeholder: "Default",
+      }),
+      optional({
+        key: "dnsRetries",
+        title: "Retries",
+        description: "How many times we retry a failed query.",
+        valueType: MonitorStepViewValueType.Number,
+        value: data.dnsMonitor?.retries,
+        placeholder: "Default",
+      }),
+    ]);
+  }
+
+  private static getDnssecRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    return compact([
+      {
+        key: "dnssecDomainName",
+        title: "Zone",
+        description: "The zone being validated end-to-end via DNSSEC.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(data.dnssecMonitor?.domainName),
+        placeholder: "No data entered",
+      },
+      {
+        key: "dnssecResolvers",
+        title: "Resolvers",
+        description: "Validating resolvers queried for AD/SERVFAIL behavior.",
+        valueType: MonitorStepViewValueType.ArrayOfText,
+        value: data.dnssecMonitor?.resolvers || [],
+        placeholder: "No data entered",
+      },
+      optional({
+        key: "checkNameserverConsistency",
+        title: "Check Nameserver Consistency",
+        description:
+          "When set, primary and secondary nameservers must agree on the zone's records.",
+        valueType: MonitorStepViewValueType.Boolean,
+        value: data.dnssecMonitor?.checkNameserverConsistency,
+        placeholder: "No",
+      }),
+      optional({
+        key: "signatureExpiryWarningDays",
+        title: "Signature Expiry Warning (days)",
+        description:
+          "How many days before an RRSIG expires we start warning about it.",
+        valueType: MonitorStepViewValueType.Number,
+        value: data.dnssecMonitor?.signatureExpiryWarningDays,
+        placeholder: "Default",
+      }),
+    ]);
+  }
+
+  private static getSqlRows(data: MonitorStepType): Array<MonitorStepViewRow> {
+    const sqlMonitor: MonitorStepType["sqlMonitor"] = data.sqlMonitor;
+
+    const database: string | undefined = sqlMonitor?.host
+      ? `${sqlMonitor.databaseType} · ${sqlMonitor.host}:${sqlMonitor.port}/${sqlMonitor.databaseName}`
+      : undefined;
+
+    return compact([
+      {
+        key: "sqlDatabase",
+        title: "Database",
+        description: "The database this monitor connects to.",
+        valueType: MonitorStepViewValueType.Text,
+        value: database,
+        placeholder: "No data entered",
+      },
+      {
+        key: "sqlQuery",
+        title: "Query",
+        description: "The read-only SQL query this monitor runs.",
+        valueType: MonitorStepViewValueType.Code,
+        value: toText(sqlMonitor?.query),
+        placeholder: "No data entered",
+      },
+      optional({
+        key: "sqlUsername",
+        title: "Username",
+        description: "The database user this monitor connects as.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(sqlMonitor?.username),
+        placeholder: "No data entered",
+      }),
+      optional({
+        key: "sqlWindowsAuthentication",
+        title: "Windows Integrated Authentication",
+        description:
+          "When set, the probe authenticates as the identity it runs under instead of using a username and password.",
+        valueType: MonitorStepViewValueType.Boolean,
+        value: sqlMonitor?.useWindowsIntegratedAuthentication,
+        placeholder: "No",
+      }),
+      optional({
+        key: "sqlUseSsl",
+        title: "Use SSL",
+        description: "Whether the connection to the database is encrypted.",
+        valueType: MonitorStepViewValueType.Boolean,
+        value: sqlMonitor?.useSsl,
+        placeholder: "No",
+      }),
+      optional({
+        key: "sqlStatementTimeoutInMs",
+        title: "Statement Timeout",
+        description: "How long the query may run before it is cancelled.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toMilliseconds(sqlMonitor?.statementTimeoutInMs),
+        placeholder: "Default",
+      }),
+      optional({
+        key: "sqlMaxRows",
+        title: "Max Rows",
+        description: "Upper bound on rows read back from the database.",
+        valueType: MonitorStepViewValueType.Number,
+        value: sqlMonitor?.maxRows,
+        placeholder: "Default",
+      }),
+    ]);
+  }
+
+  private static getExternalStatusPageRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    return compact([
+      {
+        key: "statusPageUrl",
+        title: "Status Page URL",
+        description: "The URL of the external status page being monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(data.externalStatusPageMonitor?.statusPageUrl),
+        placeholder: "No data entered",
+      },
+      {
+        key: "statusPageProvider",
+        title: "Provider",
+        description: "How OneUptime reads this status page.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(data.externalStatusPageMonitor?.provider) || "Auto",
+        placeholder: "Auto",
+      },
+      {
+        key: "componentGroupName",
+        title: "Component Group Filter",
+        description:
+          "If set, only components in this group are monitored and incidents elsewhere are ignored.",
+        valueType: MonitorStepViewValueType.Text,
+        value:
+          toText(data.externalStatusPageMonitor?.componentGroupName) ||
+          "All groups",
+        placeholder: "All groups",
+      },
+      {
+        key: "componentName",
+        title: "Component Name Filter",
+        description: "If set, only this specific component will be monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value:
+          toText(data.externalStatusPageMonitor?.componentName) ||
+          "All components",
+        placeholder: "All components",
+      },
+    ]);
+  }
+
+  private static getLogRows(data: MonitorStepType): Array<MonitorStepViewRow> {
+    const logMonitor: MonitorStepType["logMonitor"] = data.logMonitor;
+
+    return compact([
+      optional({
+        key: "logBody",
+        title: "Filter Log Message",
+        description: "Filter by log message with this text:",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(logMonitor?.body),
+        placeholder: "No log message entered",
+      }),
+      optional({
+        key: "lastXSecondsOfLogs",
+        title: "Monitor logs for the last (time)",
+        description: "How many seconds of logs to monitor.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toDuration(logMonitor?.lastXSecondsOfLogs),
+        placeholder: "1 minute",
+      }),
+      optional({
+        key: "severityTexts",
+        title: "Log Severity",
+        description: "Severity of the logs to monitor.",
+        valueType: MonitorStepViewValueType.ArrayOfText,
+        value: (logMonitor?.severityTexts || []).map((severity: string) => {
+          return String(severity);
+        }),
+        placeholder: "No severity entered",
+      }),
+      optional({
+        key: "logAttributes",
+        title: "Log Attributes",
+        description: "Attributes of the logs to monitor.",
+        valueType: MonitorStepViewValueType.JSON,
+        value: logMonitor?.attributes as JSONObject | undefined,
+        placeholder: "No attributes entered",
+      }),
+      optional({
+        key: "logEntityKeys",
+        title: "Telemetry Entities",
+        description: "Hosts, pods or containers this monitor is scoped to.",
+        valueType: MonitorStepViewValueType.ArrayOfText,
+        value: logMonitor?.entityKeys || [],
+        placeholder: "No entities entered",
+      }),
+      optional({
+        key: "logTelemetryServices",
+        title: "Telemetry Services",
+        description: "Telemetry services to monitor.",
+        valueType: MonitorStepViewValueType.TelemetryServices,
+        value: (logMonitor?.telemetryServiceIds || []).map(
+          (serviceId: { toString: () => string }) => {
+            return serviceId.toString();
+          },
+        ),
+        placeholder: "No telemetry services entered",
+      }),
+    ]);
+  }
+
+  private static getTraceRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    const traceMonitor: MonitorStepType["traceMonitor"] = data.traceMonitor;
+
+    return compact([
+      optional({
+        key: "spanName",
+        title: "Filter Span Name",
+        description: "Filter by span name with this text:",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(traceMonitor?.spanName),
+        placeholder: "No span name entered",
+      }),
+      optional({
+        key: "lastXSecondsOfSpans",
+        title: "Monitor spans for the last (time)",
+        description: "How many seconds of spans to monitor.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toDuration(traceMonitor?.lastXSecondsOfSpans),
+        placeholder: "1 minute",
+      }),
+      optional({
+        key: "spanStatuses",
+        title: "Span Status",
+        description: "Status of the spans to monitor.",
+        valueType: MonitorStepViewValueType.ArrayOfText,
+        value: (traceMonitor?.spanStatuses || []).map((status: SpanStatus) => {
+          return toSpanStatusText(status);
+        }),
+        placeholder: "No span status entered. All statuses will be monitored.",
+      }),
+      optional({
+        key: "spanAttributes",
+        title: "Span Attributes",
+        description: "Attributes of the spans to monitor.",
+        valueType: MonitorStepViewValueType.JSON,
+        value: traceMonitor?.attributes as JSONObject | undefined,
+        placeholder: "No attributes entered",
+      }),
+      optional({
+        key: "traceEntityKeys",
+        title: "Telemetry Entities",
+        description: "Hosts, pods or containers this monitor is scoped to.",
+        valueType: MonitorStepViewValueType.ArrayOfText,
+        value: traceMonitor?.entityKeys || [],
+        placeholder: "No entities entered",
+      }),
+      optional({
+        key: "traceTelemetryServices",
+        title: "Telemetry Services",
+        description: "Telemetry services to monitor.",
+        valueType: MonitorStepViewValueType.TelemetryServices,
+        value: (traceMonitor?.telemetryServiceIds || []).map(
+          (serviceId: { toString: () => string }) => {
+            return serviceId.toString();
+          },
+        ),
+        placeholder: "No telemetry services entered",
+      }),
+    ]);
+  }
+
+  private static getExceptionRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    const exceptionMonitor: MonitorStepType["exceptionMonitor"] =
+      data.exceptionMonitor;
+
+    return compact([
+      optional({
+        key: "exceptionMessage",
+        title: "Filter Exception Message",
+        description: "Filter by exception message with this text:",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(exceptionMonitor?.message),
+        placeholder: "No message entered",
+      }),
+      optional({
+        key: "exceptionTypes",
+        title: "Exception Types",
+        description: "Exception types this monitor watches.",
+        valueType: MonitorStepViewValueType.ArrayOfText,
+        value: exceptionMonitor?.exceptionTypes || [],
+        placeholder: "All exception types",
+      }),
+      {
+        key: "lastXSecondsOfExceptions",
+        title: "Monitor exceptions for the last (time)",
+        description: "How much of the exception history each check reads.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toDuration(exceptionMonitor?.lastXSecondsOfExceptions),
+        placeholder: "1 minute",
+      },
+      {
+        key: "includeResolved",
+        title: "Include Resolved Exceptions",
+        description:
+          "Whether resolved exceptions still count towards criteria.",
+        valueType: MonitorStepViewValueType.Boolean,
+        value: Boolean(exceptionMonitor?.includeResolved),
+        placeholder: "No",
+      },
+      {
+        key: "includeArchived",
+        title: "Include Archived Exceptions",
+        description:
+          "Whether archived exceptions still count towards criteria.",
+        valueType: MonitorStepViewValueType.Boolean,
+        value: Boolean(exceptionMonitor?.includeArchived),
+        placeholder: "No",
+      },
+      optional({
+        key: "exceptionEntityKeys",
+        title: "Telemetry Entities",
+        description: "Hosts, pods or containers this monitor is scoped to.",
+        valueType: MonitorStepViewValueType.ArrayOfText,
+        value: exceptionMonitor?.entityKeys || [],
+        placeholder: "No entities entered",
+      }),
+      optional({
+        key: "exceptionTelemetryServices",
+        title: "Telemetry Services",
+        description: "Telemetry services to monitor.",
+        valueType: MonitorStepViewValueType.TelemetryServices,
+        value: (exceptionMonitor?.telemetryServiceIds || []).map(
+          (serviceId: { toString: () => string }) => {
+            return serviceId.toString();
+          },
+        ),
+        placeholder: "No telemetry services entered",
+      }),
+    ]);
+  }
+
+  private static getNetworkDeviceRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    return compact([
+      {
+        key: "networkDeviceId",
+        title: "Network Device",
+        description:
+          "The registered network device this monitor alerts on. Polling, credentials and health OIDs are configured on the device itself.",
+        valueType: MonitorStepViewValueType.NetworkDevice,
+        value: toText(data.networkDeviceMonitor?.networkDeviceId),
+        placeholder: "No network device selected",
+      },
+    ]);
+  }
+
+  /*
+   * Shared tail for every metric-backed monitor type: what is queried, how
+   * it is grouped, and over which window. The chart preview the viewer
+   * renders below the rows comes from the same config.
+   */
+  private static getMetricConfigRows(
+    data: MonitorStepType,
+    monitorStepData: {
+      metricViewConfig?: MetricsViewConfig | undefined;
+      rollingTime?: RollingTime | undefined;
+    },
+  ): Array<OptionalRow> {
+    const metricsViewConfig: MetricsViewConfig = safeMetricsViewConfig(
+      monitorStepData.metricViewConfig,
+    );
+
+    return [
+      {
+        key: "metricNames",
+        title: "Metrics",
+        description: "The metrics this monitor queries on every check.",
+        valueType: MonitorStepViewValueType.ArrayOfText,
+        value: MonitorStepViewModel.getMetricQueryTitles(metricsViewConfig),
+        placeholder: "No metrics selected",
+      },
+      optional({
+        key: "metricFormulas",
+        title: "Formulas",
+        description: "Formulas evaluated over the queried metrics.",
+        valueType: MonitorStepViewValueType.ArrayOfText,
+        value: MonitorStepViewModel.getMetricFormulaTitles(metricsViewConfig),
+        placeholder: "No formulas",
+      }),
+      optional({
+        key: "metricGroupBy",
+        title: "Group By",
+        description:
+          "Attributes the series are split by — the monitor evaluates criteria per group.",
+        valueType: MonitorStepViewValueType.ArrayOfText,
+        value: MonitorStepViewModel.getMetricGroupByKeys(metricsViewConfig),
+        placeholder: "Not grouped",
+      }),
+      {
+        key: "rollingTime",
+        title: "Time Range",
+        description: "The rolling window each check evaluates over.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(monitorStepData.rollingTime),
+        placeholder: RollingTime.Past1Minute,
+      },
+      optional({
+        key: "metricTelemetryServices",
+        title: "Telemetry Services",
+        description: "Telemetry services this monitor is scoped to.",
+        valueType: MonitorStepViewValueType.TelemetryServices,
+        value: (data.metricMonitor?.telemetryServiceIds || []).map(
+          (serviceId: { toString: () => string }) => {
+            return serviceId.toString();
+          },
+        ),
+        placeholder: "All services",
+      }),
+    ];
+  }
+
+  private static getMetricRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    return compact([
+      ...MonitorStepViewModel.getMetricConfigRows(data, {
+        metricViewConfig: data.metricMonitor?.metricViewConfig,
+        rollingTime: data.metricMonitor?.rollingTime,
+      }),
+    ]);
+  }
+
+  private static getKubernetesRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    const kubernetesMonitor: MonitorStepType["kubernetesMonitor"] =
+      data.kubernetesMonitor;
+
+    return compact([
+      {
+        key: "clusterIdentifier",
+        title: "Cluster",
+        description: "The Kubernetes cluster this monitor watches.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(kubernetesMonitor?.clusterIdentifier),
+        placeholder: "No cluster selected",
+      },
+      {
+        key: "resourceScope",
+        title: "Resource Scope",
+        description: "The level of the cluster this monitor evaluates.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(kubernetesMonitor?.resourceScope),
+        placeholder: "Cluster",
+      },
+      optional({
+        key: "namespace",
+        title: "Namespace",
+        description: "Only resources in this namespace are monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(kubernetesMonitor?.resourceFilters?.namespace),
+        placeholder: "All namespaces",
+      }),
+      optional({
+        key: "workloadType",
+        title: "Workload Type",
+        description: "Only workloads of this kind are monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(kubernetesMonitor?.resourceFilters?.workloadType),
+        placeholder: "All workload types",
+      }),
+      optional({
+        key: "workloadName",
+        title: "Workload Name",
+        description: "Only this workload is monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(kubernetesMonitor?.resourceFilters?.workloadName),
+        placeholder: "All workloads",
+      }),
+      optional({
+        key: "nodeName",
+        title: "Node Name",
+        description: "Only this node is monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(kubernetesMonitor?.resourceFilters?.nodeName),
+        placeholder: "All nodes",
+      }),
+      optional({
+        key: "podName",
+        title: "Pod Name",
+        description: "Only this pod is monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(kubernetesMonitor?.resourceFilters?.podName),
+        placeholder: "All pods",
+      }),
+      ...MonitorStepViewModel.getMetricConfigRows(data, {
+        metricViewConfig: kubernetesMonitor?.metricViewConfig,
+        rollingTime: kubernetesMonitor?.rollingTime,
+      }),
+    ]);
+  }
+
+  private static getDockerRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    const dockerMonitor: MonitorStepType["dockerMonitor"] = data.dockerMonitor;
+
+    return compact([
+      {
+        key: "hostIdentifier",
+        title: "Docker Host",
+        description: "The Docker host this monitor watches.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(dockerMonitor?.hostIdentifier),
+        placeholder: "No host selected",
+      },
+      optional({
+        key: "containerName",
+        title: "Container Name",
+        description: "Only this container is monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(dockerMonitor?.containerFilters?.containerName),
+        placeholder: "All containers",
+      }),
+      optional({
+        key: "containerImage",
+        title: "Container Image",
+        description: "Only containers running this image are monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(dockerMonitor?.containerFilters?.containerImage),
+        placeholder: "All images",
+      }),
+      optional({
+        key: "containerHostName",
+        title: "Host Name",
+        description: "Only containers on this host are monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(dockerMonitor?.containerFilters?.hostName),
+        placeholder: "All hosts",
+      }),
+      ...MonitorStepViewModel.getMetricConfigRows(data, {
+        metricViewConfig: dockerMonitor?.metricViewConfig,
+        rollingTime: dockerMonitor?.rollingTime,
+      }),
+    ]);
+  }
+
+  private static getPodmanRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    const podmanMonitor: MonitorStepType["podmanMonitor"] = data.podmanMonitor;
+
+    return compact([
+      {
+        key: "hostIdentifier",
+        title: "Podman Host",
+        description: "The Podman host this monitor watches.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(podmanMonitor?.hostIdentifier),
+        placeholder: "No host selected",
+      },
+      optional({
+        key: "containerName",
+        title: "Container Name",
+        description: "Only this container is monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(podmanMonitor?.containerFilters?.containerName),
+        placeholder: "All containers",
+      }),
+      optional({
+        key: "containerImage",
+        title: "Container Image",
+        description: "Only containers running this image are monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(podmanMonitor?.containerFilters?.containerImage),
+        placeholder: "All images",
+      }),
+      optional({
+        key: "containerHostName",
+        title: "Host Name",
+        description: "Only containers on this host are monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(podmanMonitor?.containerFilters?.hostName),
+        placeholder: "All hosts",
+      }),
+      ...MonitorStepViewModel.getMetricConfigRows(data, {
+        metricViewConfig: podmanMonitor?.metricViewConfig,
+        rollingTime: podmanMonitor?.rollingTime,
+      }),
+    ]);
+  }
+
+  private static getHostRows(data: MonitorStepType): Array<MonitorStepViewRow> {
+    const hostMonitor: MonitorStepType["hostMonitor"] = data.hostMonitor;
+
+    return compact([
+      {
+        key: "hostIdentifier",
+        title: "Host",
+        description: "The host this monitor watches.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(hostMonitor?.hostIdentifier),
+        placeholder: "No host selected",
+      },
+      ...MonitorStepViewModel.getMetricConfigRows(data, {
+        metricViewConfig: hostMonitor?.metricViewConfig,
+        rollingTime: hostMonitor?.rollingTime,
+      }),
+    ]);
+  }
+
+  private static getProxmoxRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    const proxmoxMonitor: MonitorStepType["proxmoxMonitor"] =
+      data.proxmoxMonitor;
+
+    return compact([
+      {
+        key: "clusterIdentifier",
+        title: "Cluster",
+        description: "The Proxmox VE cluster this monitor watches.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(proxmoxMonitor?.clusterIdentifier),
+        placeholder: "No cluster selected",
+      },
+      optional({
+        key: "proxmoxScope",
+        title: "Resource Scope",
+        description: "The level of the cluster this monitor evaluates.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(proxmoxMonitor?.resourceFilters?.scope),
+        placeholder: "Whole cluster",
+      }),
+      optional({
+        key: "proxmoxNodeName",
+        title: "Node Name",
+        description: "Only this node's own series are monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(proxmoxMonitor?.resourceFilters?.nodeName),
+        placeholder: "All nodes",
+      }),
+      optional({
+        key: "proxmoxGuestId",
+        title: "Guest",
+        description: "Only this guest (VM or container) is monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(proxmoxMonitor?.resourceFilters?.guestId),
+        placeholder: "All guests",
+      }),
+      optional({
+        key: "proxmoxPveId",
+        title: "Resource Id",
+        description: "Only the resource with this Proxmox id is monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(proxmoxMonitor?.resourceFilters?.pveId),
+        placeholder: "All resources",
+      }),
+      ...MonitorStepViewModel.getMetricConfigRows(data, {
+        metricViewConfig: proxmoxMonitor?.metricViewConfig,
+        rollingTime: proxmoxMonitor?.rollingTime,
+      }),
+    ]);
+  }
+
+  private static getDockerSwarmRows(
+    data: MonitorStepType,
+  ): Array<MonitorStepViewRow> {
+    const dockerSwarmMonitor: MonitorStepType["dockerSwarmMonitor"] =
+      data.dockerSwarmMonitor;
+
+    return compact([
+      {
+        key: "clusterIdentifier",
+        title: "Cluster",
+        description: "The Docker Swarm cluster this monitor watches.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(dockerSwarmMonitor?.clusterIdentifier),
+        placeholder: "No cluster selected",
+      },
+      optional({
+        key: "swarmServiceName",
+        title: "Service Name",
+        description: "Only this Swarm service's tasks are monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(dockerSwarmMonitor?.resourceFilters?.serviceName),
+        placeholder: "All services",
+      }),
+      optional({
+        key: "swarmNodeName",
+        title: "Node Name",
+        description: "Only containers on this Swarm node are monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(dockerSwarmMonitor?.resourceFilters?.nodeName),
+        placeholder: "All nodes",
+      }),
+      optional({
+        key: "swarmContainerName",
+        title: "Container Name",
+        description: "Only this task's container is monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(dockerSwarmMonitor?.resourceFilters?.containerName),
+        placeholder: "All containers",
+      }),
+      optional({
+        key: "swarmContainerImage",
+        title: "Container Image",
+        description: "Only tasks running this image are monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(dockerSwarmMonitor?.resourceFilters?.containerImage),
+        placeholder: "All images",
+      }),
+      ...MonitorStepViewModel.getMetricConfigRows(data, {
+        metricViewConfig: dockerSwarmMonitor?.metricViewConfig,
+        rollingTime: dockerSwarmMonitor?.rollingTime,
+      }),
+    ]);
+  }
+
+  private static getCephRows(data: MonitorStepType): Array<MonitorStepViewRow> {
+    const cephMonitor: MonitorStepType["cephMonitor"] = data.cephMonitor;
+
+    return compact([
+      {
+        key: "clusterIdentifier",
+        title: "Cluster",
+        description: "The Ceph cluster this monitor watches.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(cephMonitor?.clusterIdentifier),
+        placeholder: "No cluster selected",
+      },
+      optional({
+        key: "cephOsdId",
+        title: "OSD",
+        description: "Only this OSD daemon is monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(cephMonitor?.resourceFilters?.osdId),
+        placeholder: "All OSDs",
+      }),
+      optional({
+        key: "cephPoolId",
+        title: "Pool Id",
+        description: "Only this pool is monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(cephMonitor?.resourceFilters?.poolId),
+        placeholder: "All pools",
+      }),
+      ...MonitorStepViewModel.getMetricConfigRows(data, {
+        metricViewConfig: cephMonitor?.metricViewConfig,
+        rollingTime: cephMonitor?.rollingTime,
+      }),
+    ]);
+  }
+
+  private static getIoTRows(data: MonitorStepType): Array<MonitorStepViewRow> {
+    const iotMonitor: MonitorStepType["iotMonitor"] = data.iotMonitor;
+
+    return compact([
+      {
+        key: "fleetIdentifier",
+        title: "Fleet",
+        description: "The IoT fleet this monitor watches.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(iotMonitor?.fleetIdentifier),
+        placeholder: "No fleet selected",
+      },
+      optional({
+        key: "iotScope",
+        title: "Resource Scope",
+        description: "The level of the fleet this monitor evaluates.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(iotMonitor?.resourceFilters?.scope),
+        placeholder: "Whole fleet",
+      }),
+      optional({
+        key: "iotDeviceId",
+        title: "Device Id",
+        description: "Only this device is monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(iotMonitor?.resourceFilters?.deviceId),
+        placeholder: "All devices",
+      }),
+      optional({
+        key: "iotDeviceType",
+        title: "Device Type",
+        description: "Only devices of this type are monitored.",
+        valueType: MonitorStepViewValueType.Text,
+        value: toText(iotMonitor?.resourceFilters?.deviceType),
+        placeholder: "All device types",
+      }),
+      ...MonitorStepViewModel.getMetricConfigRows(data, {
+        metricViewConfig: iotMonitor?.metricViewConfig,
+        rollingTime: iotMonitor?.rollingTime,
+      }),
+    ]);
+  }
+}

--- a/App/Tests/Dashboard/MonitorStepViewModel.test.ts
+++ b/App/Tests/Dashboard/MonitorStepViewModel.test.ts
@@ -1,0 +1,1045 @@
+import { describe, expect, it } from "@jest/globals";
+import { SpanStatus } from "Common/Models/AnalyticsModels/Span";
+import Hostname from "Common/Types/API/Hostname";
+import HTTPMethod from "Common/Types/API/HTTPMethod";
+import URL from "Common/Types/API/URL";
+import AggregationType from "Common/Types/BaseDatabase/AggregationType";
+import IP from "Common/Types/IP/IP";
+import LogSeverity from "Common/Types/Log/LogSeverity";
+import MetricsViewConfig from "Common/Types/Metrics/MetricsViewConfig";
+import DnsRecordType from "Common/Types/Monitor/DnsMonitor/DnsRecordType";
+import DomainLookupMethod from "Common/Types/Monitor/DomainMonitor/DomainLookupMethod";
+import ExternalStatusPageProviderType from "Common/Types/Monitor/ExternalStatusPageProviderType";
+import MonitorStep, { MonitorStepType } from "Common/Types/Monitor/MonitorStep";
+import { IoTResourceScope } from "Common/Types/Monitor/MonitorStepIoTMonitor";
+import { KubernetesResourceScope } from "Common/Types/Monitor/MonitorStepKubernetesMonitor";
+import { ProxmoxResourceScope } from "Common/Types/Monitor/MonitorStepProxmoxMonitor";
+import MonitorType, {
+  MonitorTypeHelper,
+} from "Common/Types/Monitor/MonitorType";
+import SqlDatabaseType from "Common/Types/Monitor/SqlDatabaseType";
+import BrowserType from "Common/Types/Monitor/SyntheticMonitors/BrowserType";
+import ScreenSizeType from "Common/Types/Monitor/SyntheticMonitors/ScreenSizeType";
+import ObjectID from "Common/Types/ObjectID";
+import Port from "Common/Types/Port";
+import RollingTime from "Common/Types/RollingTime/RollingTime";
+import MonitorStepViewModel, {
+  MonitorStepViewRow,
+  MonitorStepViewValueType,
+} from "../../FeatureSet/Dashboard/src/Utils/MonitorStepViewModel";
+
+/*
+ * WHAT THIS FILE PROTECTS
+ *
+ * The monitor "Criteria" page renders the step configuration above the
+ * criteria. Before MonitorStepViewModel existed, that rendering was an
+ * if/else chain in the viewer component covering roughly a third of the
+ * monitor types we ship. Every other type — Metrics, the nine
+ * infrastructure/telemetry types, DNS, Exceptions, Network Device, SSL
+ * Certificate — fell off the end of the chain and rendered NOTHING: the
+ * page showed a "Monitor Details" heading with empty space under it while
+ * the edit modal showed the full configuration.
+ *
+ * The failure was silent in the worst way. Nothing threw, nothing warned;
+ * a monitor type shipped, its form was built, and the read-only view of it
+ * simply never existed. Adding a type is the moment the gap opens, and
+ * nothing about adding a type forces anyone to look at the viewer.
+ *
+ * So the central test here is `getRows` over EVERY active monitor type at
+ * once: a type either produces rows, or it is on the explicit list of types
+ * that genuinely have no step configuration. There is no third outcome, and
+ * a new monitor type cannot quietly become one.
+ */
+
+/*
+ * Monitor types with no per-step configuration at all. Manual monitors
+ * cannot be checked; Server, Incoming Request and Incoming Email are pushed
+ * TO us, so there is nothing to configure about the request we send; the
+ * Profiles picker is deliberately unbuilt (see MonitorTypeHelper). Anything
+ * else showing zero rows is the bug this file exists to catch.
+ */
+const MONITOR_TYPES_WITHOUT_STEP_CONFIG: Array<MonitorType> = [
+  MonitorType.Manual,
+  MonitorType.Server,
+  MonitorType.IncomingRequest,
+  MonitorType.IncomingEmail,
+  MonitorType.Profiles,
+];
+
+const METRIC_VIEW_CONFIG: MetricsViewConfig = {
+  queryConfigs: [
+    {
+      metricAliasData: {
+        metricVariable: "a",
+        title: "CPU Usage",
+        description: undefined,
+        legend: undefined,
+        legendUnit: undefined,
+      },
+      metricQueryData: {
+        filterData: {
+          metricName: "container.cpu.usage",
+          aggegationType: AggregationType.Avg,
+        },
+        groupByAttributeKeys: ["host.name"],
+      },
+    },
+    {
+      metricQueryData: {
+        filterData: {
+          metricName: "container.memory.usage",
+          aggegationType: AggregationType.Max,
+        },
+      },
+    },
+  ],
+  formulaConfigs: [
+    {
+      metricAliasData: {
+        metricVariable: "c",
+        title: "CPU Percent",
+        description: undefined,
+        legend: undefined,
+        legendUnit: undefined,
+      },
+      metricFormulaData: {
+        metricFormula: "a * 100",
+      },
+    },
+  ],
+};
+
+function buildStep(data: Partial<MonitorStepType>): MonitorStep {
+  const monitorStep: MonitorStep = new MonitorStep();
+
+  monitorStep.data = {
+    ...(monitorStep.data as MonitorStepType),
+    ...data,
+  } as MonitorStepType;
+
+  return monitorStep;
+}
+
+/*
+ * A fully-configured step for every monitor type that has one. Used by the
+ * coverage test below and by the per-type assertions.
+ */
+function buildStepForMonitorType(monitorType: MonitorType): MonitorStep {
+  switch (monitorType) {
+    case MonitorType.API:
+      return buildStep({
+        monitorDestination: URL.fromString("https://api.example.com/health"),
+        requestType: HTTPMethod.POST,
+        requestBody: '{"ping":true}',
+        requestHeaders: { Authorization: "Bearer token" },
+        doNotFollowRedirects: true,
+        allowSelfSignedCertificates: true,
+        requestTimeoutInMs: 5000,
+        retryCount: 2,
+      });
+    case MonitorType.Website:
+      return buildStep({
+        monitorDestination: URL.fromString("https://example.com"),
+        doNotFollowRedirects: false,
+      });
+    case MonitorType.Ping:
+      return buildStep({
+        monitorDestination: new Hostname("ping.example.com"),
+      });
+    case MonitorType.IP:
+      return buildStep({ monitorDestination: new IP("10.0.0.4") });
+    case MonitorType.Port:
+      return buildStep({
+        monitorDestination: new Hostname("db.example.com"),
+        monitorDestinationPort: new Port(5432),
+      });
+    case MonitorType.SSLCertificate:
+      return buildStep({
+        monitorDestination: URL.fromString("https://secure.example.com"),
+      });
+    case MonitorType.CustomJavaScriptCode:
+      return buildStep({ customCode: "return { data: 1 };" });
+    case MonitorType.SyntheticMonitor:
+      return buildStep({
+        customCode: "await page.goto('https://example.com');",
+        browserTypes: [BrowserType.Chromium],
+        screenSizeTypes: [ScreenSizeType.Desktop],
+        retryCountOnError: 2,
+      });
+    case MonitorType.Domain:
+      return buildStep({
+        domainMonitor: {
+          domainName: "example.com",
+          lookupMethod: DomainLookupMethod.Auto,
+          timeout: 10000,
+          retries: 3,
+        },
+      });
+    case MonitorType.DNS:
+      return buildStep({
+        dnsMonitor: {
+          queryName: "example.com",
+          recordType: DnsRecordType.A,
+          hostname: "8.8.8.8",
+          port: 53,
+          timeout: 5000,
+          retries: 3,
+        },
+      });
+    case MonitorType.DNSSEC:
+      return buildStep({
+        dnssecMonitor: {
+          domainName: "example.com",
+          resolvers: ["1.1.1.1", "8.8.8.8"],
+          checkNameserverConsistency: true,
+          signatureExpiryWarningDays: 7,
+          timeout: 10000,
+          retries: 3,
+        },
+      });
+    case MonitorType.SQLQuery:
+      return buildStep({
+        sqlMonitor: {
+          databaseType: SqlDatabaseType.PostgreSQL,
+          host: "db.example.com",
+          port: 5432,
+          databaseName: "orders",
+          username: "readonly",
+          password: "super-secret-password",
+          useWindowsIntegratedAuthentication: false,
+          useSsl: true,
+          rejectUnauthorizedSsl: true,
+          query: "SELECT count(*) FROM orders;",
+          connectionTimeoutInMs: 10000,
+          statementTimeoutInMs: 15000,
+          maxRows: 100,
+        },
+      });
+    case MonitorType.ExternalStatusPage:
+      return buildStep({
+        externalStatusPageMonitor: {
+          statusPageUrl: "https://status.example.com",
+          provider: ExternalStatusPageProviderType.Auto,
+          componentGroupName: "APIs",
+          componentName: "Checkout API",
+          timeout: 10000,
+          retries: 3,
+        },
+      });
+    case MonitorType.Logs:
+      return buildStep({
+        logMonitor: {
+          attributes: { "service.name": "checkout" },
+          body: "timeout",
+          severityTexts: [LogSeverity.Error],
+          telemetryServiceIds: [
+            new ObjectID("11111111-1111-4111-8111-111111111111"),
+          ],
+          entityKeys: ["host:web-1"],
+          lastXSecondsOfLogs: 300,
+        },
+      });
+    case MonitorType.Traces:
+      return buildStep({
+        traceMonitor: {
+          attributes: { "http.route": "/checkout" },
+          spanStatuses: [SpanStatus.Error],
+          telemetryServiceIds: [
+            new ObjectID("22222222-2222-4222-8222-222222222222"),
+          ],
+          entityKeys: ["pod:checkout-1"],
+          lastXSecondsOfSpans: 120,
+          spanName: "POST /checkout",
+        },
+      });
+    case MonitorType.Exceptions:
+      return buildStep({
+        exceptionMonitor: {
+          telemetryServiceIds: [
+            new ObjectID("33333333-3333-4333-8333-333333333333"),
+          ],
+          entityKeys: ["container:api"],
+          exceptionTypes: ["TypeError"],
+          message: "undefined is not a function",
+          includeResolved: true,
+          includeArchived: false,
+          lastXSecondsOfExceptions: 600,
+        },
+      });
+    case MonitorType.NetworkDevice:
+      return buildStep({
+        networkDeviceMonitor: {
+          networkDeviceId: "44444444-4444-4444-8444-444444444444",
+          monitorInterfaces: true,
+          collectEndpoints: false,
+          oids: [],
+        },
+      });
+    case MonitorType.Metrics:
+      return buildStep({
+        metricMonitor: {
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past30Minutes,
+          telemetryServiceIds: [
+            new ObjectID("55555555-5555-4555-8555-555555555555"),
+          ],
+        },
+      });
+    case MonitorType.Kubernetes:
+      return buildStep({
+        kubernetesMonitor: {
+          clusterIdentifier: "prod-cluster",
+          resourceScope: KubernetesResourceScope.Workload,
+          resourceFilters: {
+            namespace: "payments",
+            workloadType: "deployment",
+            workloadName: "checkout",
+          },
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past5Minutes,
+        },
+      });
+    case MonitorType.Docker:
+      return buildStep({
+        dockerMonitor: {
+          hostIdentifier: "docker-host-1",
+          containerFilters: {
+            containerName: "checkout",
+            containerImage: "checkout:latest",
+          },
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past5Minutes,
+        },
+      });
+    case MonitorType.Podman:
+      return buildStep({
+        podmanMonitor: {
+          hostIdentifier: "podman-host-1",
+          containerFilters: { containerName: "billing" },
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past5Minutes,
+        },
+      });
+    case MonitorType.Host:
+      return buildStep({
+        hostMonitor: {
+          hostIdentifier: "web-1",
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past15Minutes,
+        },
+      });
+    case MonitorType.Proxmox:
+      return buildStep({
+        proxmoxMonitor: {
+          clusterIdentifier: "pve-cluster",
+          resourceFilters: {
+            scope: ProxmoxResourceScope.Guest,
+            guestId: "qemu/100",
+          },
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past1Hour,
+        },
+      });
+    case MonitorType.DockerSwarm:
+      return buildStep({
+        dockerSwarmMonitor: {
+          clusterIdentifier: "swarm-cluster",
+          resourceFilters: { serviceName: "api", nodeName: "swarm-node-2" },
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past5Minutes,
+        },
+      });
+    case MonitorType.Ceph:
+      return buildStep({
+        cephMonitor: {
+          clusterIdentifier: "ceph-cluster",
+          resourceFilters: { osdId: "osd.3", poolId: "2" },
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past5Minutes,
+        },
+      });
+    case MonitorType.IoTDevice:
+      return buildStep({
+        iotMonitor: {
+          fleetIdentifier: "fleet-a",
+          resourceFilters: {
+            scope: IoTResourceScope.Device,
+            deviceId: "device-9",
+            deviceType: "sensor",
+          },
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past10Minutes,
+        },
+      });
+    default:
+      return buildStep({});
+  }
+}
+
+function getRows(monitorType: MonitorType): Array<MonitorStepViewRow> {
+  return MonitorStepViewModel.getRows({
+    monitorStep: buildStepForMonitorType(monitorType),
+    monitorType: monitorType,
+  });
+}
+
+function getRow(
+  monitorType: MonitorType,
+  key: string,
+): MonitorStepViewRow | undefined {
+  return getRows(monitorType).find((row: MonitorStepViewRow) => {
+    return row.key === key;
+  });
+}
+
+function getRowTitles(monitorType: MonitorType): Array<string> {
+  return getRows(monitorType).map((row: MonitorStepViewRow) => {
+    return row.title;
+  });
+}
+
+describe("MonitorStepViewModel.getRows — coverage across monitor types", () => {
+  it.each(
+    MonitorTypeHelper.getActiveMonitorTypes().filter(
+      (monitorType: MonitorType) => {
+        return !MONITOR_TYPES_WITHOUT_STEP_CONFIG.includes(monitorType);
+      },
+    ),
+  )(
+    "renders at least one configuration row for %s monitors",
+    (monitorType: MonitorType) => {
+      const rows: Array<MonitorStepViewRow> = getRows(monitorType);
+
+      expect(rows.length).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(MONITOR_TYPES_WITHOUT_STEP_CONFIG)(
+    "renders no configuration rows for %s monitors, which have no step config",
+    (monitorType: MonitorType) => {
+      expect(
+        MonitorStepViewModel.getRows({
+          monitorStep: buildStep({}),
+          monitorType: monitorType,
+        }),
+      ).toEqual([]);
+    },
+  );
+
+  it("gives every row a unique key so Detail cannot collapse two rows into one", () => {
+    for (const monitorType of MonitorTypeHelper.getActiveMonitorTypes()) {
+      const keys: Array<string> = getRows(monitorType).map(
+        (row: MonitorStepViewRow) => {
+          return row.key;
+        },
+      );
+
+      expect(new Set(keys).size).toBe(keys.length);
+    }
+  });
+
+  it("gives every row a title, a description and a placeholder", () => {
+    for (const monitorType of MonitorTypeHelper.getActiveMonitorTypes()) {
+      for (const row of getRows(monitorType)) {
+        expect(row.title.length).toBeGreaterThan(0);
+        expect(row.description.length).toBeGreaterThan(0);
+        expect(row.placeholder.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("returns no rows when the step carries no data at all", () => {
+    const emptyStep: MonitorStep = new MonitorStep();
+    emptyStep.data = undefined;
+
+    expect(
+      MonitorStepViewModel.getRows({
+        monitorStep: emptyStep,
+        monitorType: MonitorType.API,
+      }),
+    ).toEqual([]);
+
+    expect(
+      MonitorStepViewModel.getRows({
+        monitorStep: undefined,
+        monitorType: MonitorType.API,
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("MonitorStepViewModel.getRows — probe monitors", () => {
+  it("shows the API destination, method, body and headers", () => {
+    expect(getRow(MonitorType.API, "monitorDestination")?.value).toBe(
+      "https://api.example.com/health",
+    );
+    expect(getRow(MonitorType.API, "requestType")?.value).toBe(HTTPMethod.POST);
+    expect(getRow(MonitorType.API, "requestBody")?.value).toBe('{"ping":true}');
+    expect(getRow(MonitorType.API, "requestHeaders")?.value).toEqual({
+      Authorization: "Bearer token",
+    });
+  });
+
+  it("shows per-step timeout and retry overrides only when the user set them", () => {
+    expect(getRow(MonitorType.API, "requestTimeoutInMs")?.value).toBe(
+      "5000 ms",
+    );
+    expect(getRow(MonitorType.API, "retryCount")?.value).toBe(2);
+
+    const withoutOverrides: Array<MonitorStepViewRow> =
+      MonitorStepViewModel.getRows({
+        monitorStep: buildStep({
+          monitorDestination: URL.fromString("https://example.com"),
+        }),
+        monitorType: MonitorType.API,
+      });
+
+    expect(
+      withoutOverrides.find((row: MonitorStepViewRow) => {
+        return row.key === "requestTimeoutInMs";
+      }),
+    ).toBeUndefined();
+  });
+
+  it("shows the port monitor's destination and port", () => {
+    expect(getRow(MonitorType.Port, "monitorDestination")?.value).toBe(
+      "db.example.com",
+    );
+    expect(getRow(MonitorType.Port, "monitorDestinationPort")?.value).toBe(
+      "5432",
+    );
+  });
+
+  it("shows the SSL certificate monitor's destination, which used to render nothing", () => {
+    expect(
+      getRow(MonitorType.SSLCertificate, "monitorDestination")?.value,
+    ).toBe(
+      // URL.toString() renders the root path explicitly.
+      "https://secure.example.com/",
+    );
+  });
+
+  it("labels the IP monitor's destination as an IP address", () => {
+    expect(getRow(MonitorType.IP, "monitorDestination")?.title).toBe(
+      "IP Address",
+    );
+    expect(getRow(MonitorType.IP, "monitorDestination")?.value).toBe(
+      "10.0.0.4",
+    );
+  });
+
+  it("renders a destination row with a placeholder rather than dropping it when unset", () => {
+    const rows: Array<MonitorStepViewRow> = MonitorStepViewModel.getRows({
+      monitorStep: buildStep({}),
+      monitorType: MonitorType.Ping,
+    });
+
+    const destination: MonitorStepViewRow | undefined = rows.find(
+      (row: MonitorStepViewRow) => {
+        return row.key === "monitorDestination";
+      },
+    );
+
+    expect(destination).toBeDefined();
+    expect(destination?.value).toBeUndefined();
+    expect(destination?.placeholder).toBe("No data entered");
+  });
+
+  it("confirms mTLS is configured without ever exposing the certificate", () => {
+    const rows: Array<MonitorStepViewRow> = MonitorStepViewModel.getRows({
+      monitorStep: buildStep({
+        monitorDestination: URL.fromString("https://mtls.example.com"),
+        tlsClientCertificate: "-----BEGIN CERTIFICATE-----SECRET",
+        tlsClientKey: "-----BEGIN PRIVATE KEY-----SECRET",
+        tlsClientKeyPassphrase: "passphrase",
+      }),
+      monitorType: MonitorType.API,
+    });
+
+    const certificateRow: MonitorStepViewRow | undefined = rows.find(
+      (row: MonitorStepViewRow) => {
+        return row.key === "tlsClientCertificate";
+      },
+    );
+
+    expect(certificateRow?.value).toBe("Configured");
+
+    const serialized: string = JSON.stringify(rows);
+    expect(serialized).not.toContain("BEGIN CERTIFICATE");
+    expect(serialized).not.toContain("BEGIN PRIVATE KEY");
+    expect(serialized).not.toContain("passphrase");
+  });
+
+  it("omits the mTLS row entirely when no client certificate is configured", () => {
+    expect(getRow(MonitorType.Website, "tlsClientCertificate")).toBeUndefined();
+  });
+
+  it("shows synthetic monitor browsers, screen sizes and retry count", () => {
+    expect(getRow(MonitorType.SyntheticMonitor, "browserTypes")?.value).toEqual(
+      [BrowserType.Chromium],
+    );
+    expect(
+      getRow(MonitorType.SyntheticMonitor, "screenSizeTypes")?.value,
+    ).toEqual([ScreenSizeType.Desktop]);
+    expect(
+      getRow(MonitorType.SyntheticMonitor, "retryCountOnError")?.value,
+    ).toBe(2);
+  });
+
+  it("renders custom code as JavaScript so it is syntax highlighted", () => {
+    expect(
+      getRow(MonitorType.CustomJavaScriptCode, "customCode")?.valueType,
+    ).toBe(MonitorStepViewValueType.JavaScript);
+  });
+});
+
+describe("MonitorStepViewModel.getRows — DNS, domain and SQL monitors", () => {
+  it("shows the DNS query, record type and resolver, which used to render nothing", () => {
+    expect(getRow(MonitorType.DNS, "queryName")?.value).toBe("example.com");
+    expect(getRow(MonitorType.DNS, "recordType")?.value).toBe(DnsRecordType.A);
+    expect(getRow(MonitorType.DNS, "dnsServer")?.value).toBe("8.8.8.8");
+  });
+
+  it("tells the operator the system resolver is used when no DNS server is set", () => {
+    const rows: Array<MonitorStepViewRow> = MonitorStepViewModel.getRows({
+      monitorStep: buildStep({
+        dnsMonitor: {
+          queryName: "example.com",
+          recordType: DnsRecordType.CNAME,
+          hostname: "",
+          port: 53,
+          timeout: 5000,
+          retries: 3,
+        },
+      }),
+      monitorType: MonitorType.DNS,
+    });
+
+    const dnsServer: MonitorStepViewRow | undefined = rows.find(
+      (row: MonitorStepViewRow) => {
+        return row.key === "dnsServer";
+      },
+    );
+
+    expect(dnsServer?.value).toBeUndefined();
+    expect(dnsServer?.placeholder).toBe("System default resolver");
+  });
+
+  it("shows the domain name and lookup method", () => {
+    expect(getRow(MonitorType.Domain, "domainName")?.value).toBe("example.com");
+    expect(getRow(MonitorType.Domain, "lookupMethod")?.value).toBe(
+      DomainLookupMethod.Auto,
+    );
+  });
+
+  it("falls back to the Auto lookup method for steps saved before it existed", () => {
+    const rows: Array<MonitorStepViewRow> = MonitorStepViewModel.getRows({
+      monitorStep: buildStep({
+        domainMonitor: {
+          domainName: "legacy.example.com",
+        } as MonitorStepType["domainMonitor"],
+      }),
+      monitorType: MonitorType.Domain,
+    });
+
+    expect(
+      rows.find((row: MonitorStepViewRow) => {
+        return row.key === "lookupMethod";
+      })?.value,
+    ).toBe(DomainLookupMethod.Auto);
+  });
+
+  it("shows the DNSSEC zone and its resolvers", () => {
+    expect(getRow(MonitorType.DNSSEC, "dnssecDomainName")?.value).toBe(
+      "example.com",
+    );
+    expect(getRow(MonitorType.DNSSEC, "dnssecResolvers")?.value).toEqual([
+      "1.1.1.1",
+      "8.8.8.8",
+    ]);
+  });
+
+  it("summarizes the SQL connection and shows the query", () => {
+    expect(getRow(MonitorType.SQLQuery, "sqlDatabase")?.value).toBe(
+      "PostgreSQL · db.example.com:5432/orders",
+    );
+    expect(getRow(MonitorType.SQLQuery, "sqlQuery")?.value).toBe(
+      "SELECT count(*) FROM orders;",
+    );
+  });
+
+  it("never exposes the SQL password", () => {
+    expect(JSON.stringify(getRows(MonitorType.SQLQuery))).not.toContain(
+      "super-secret-password",
+    );
+  });
+
+  it("shows the external status page URL, provider and component filters", () => {
+    expect(getRow(MonitorType.ExternalStatusPage, "statusPageUrl")?.value).toBe(
+      "https://status.example.com",
+    );
+    expect(
+      getRow(MonitorType.ExternalStatusPage, "componentGroupName")?.value,
+    ).toBe("APIs");
+    expect(getRow(MonitorType.ExternalStatusPage, "componentName")?.value).toBe(
+      "Checkout API",
+    );
+  });
+});
+
+describe("MonitorStepViewModel.getRows — telemetry monitors", () => {
+  it("shows the log filter, window, severity and attributes", () => {
+    expect(getRow(MonitorType.Logs, "logBody")?.value).toBe("timeout");
+    expect(getRow(MonitorType.Logs, "lastXSecondsOfLogs")?.value).toBe(
+      "5 minutes",
+    );
+    expect(getRow(MonitorType.Logs, "severityTexts")?.value).toEqual([
+      LogSeverity.Error,
+    ]);
+    expect(getRow(MonitorType.Logs, "logAttributes")?.value).toEqual({
+      "service.name": "checkout",
+    });
+  });
+
+  it("carries telemetry service ids as strings for the viewer to resolve", () => {
+    const row: MonitorStepViewRow | undefined = getRow(
+      MonitorType.Logs,
+      "logTelemetryServices",
+    );
+
+    expect(row?.valueType).toBe(MonitorStepViewValueType.TelemetryServices);
+    expect(row?.value).toEqual(["11111111-1111-4111-8111-111111111111"]);
+  });
+
+  it("names span statuses instead of printing their numeric OTel codes", () => {
+    expect(getRow(MonitorType.Traces, "spanStatuses")?.value).toEqual([
+      "Error",
+    ]);
+    expect(getRow(MonitorType.Traces, "spanName")?.value).toBe(
+      "POST /checkout",
+    );
+    expect(getRow(MonitorType.Traces, "lastXSecondsOfSpans")?.value).toBe(
+      "2 minutes",
+    );
+  });
+
+  it("shows exception monitor configuration, which used to render nothing", () => {
+    expect(getRow(MonitorType.Exceptions, "exceptionMessage")?.value).toBe(
+      "undefined is not a function",
+    );
+    expect(getRow(MonitorType.Exceptions, "exceptionTypes")?.value).toEqual([
+      "TypeError",
+    ]);
+    expect(
+      getRow(MonitorType.Exceptions, "lastXSecondsOfExceptions")?.value,
+    ).toBe("10 minutes");
+    expect(getRow(MonitorType.Exceptions, "includeResolved")?.value).toBe(true);
+    expect(getRow(MonitorType.Exceptions, "includeArchived")?.value).toBe(
+      false,
+    );
+  });
+
+  it("shows the network device the monitor alerts on, which used to render nothing", () => {
+    const row: MonitorStepViewRow | undefined = getRow(
+      MonitorType.NetworkDevice,
+      "networkDeviceId",
+    );
+
+    expect(row?.valueType).toBe(MonitorStepViewValueType.NetworkDevice);
+    expect(row?.value).toBe("44444444-4444-4444-8444-444444444444");
+  });
+});
+
+describe("MonitorStepViewModel.getRows — metric-backed monitors", () => {
+  const METRIC_MONITOR_TYPES: Array<MonitorType> = [
+    MonitorType.Metrics,
+    MonitorType.Kubernetes,
+    MonitorType.Docker,
+    MonitorType.Podman,
+    MonitorType.Host,
+    MonitorType.Proxmox,
+    MonitorType.DockerSwarm,
+    MonitorType.Ceph,
+    MonitorType.IoTDevice,
+  ];
+
+  it.each(METRIC_MONITOR_TYPES)(
+    "names the metrics a %s monitor queries",
+    (monitorType: MonitorType) => {
+      expect(getRow(monitorType, "metricNames")?.value).toEqual([
+        "CPU Usage (container.cpu.usage · Avg)",
+        "container.memory.usage · Max",
+      ]);
+    },
+  );
+
+  it.each(METRIC_MONITOR_TYPES)(
+    "shows the rolling window a %s monitor evaluates over",
+    (monitorType: MonitorType) => {
+      const row: MonitorStepViewRow | undefined = getRow(
+        monitorType,
+        "rollingTime",
+      );
+
+      expect(row?.title).toBe("Time Range");
+      expect(typeof row?.value).toBe("string");
+      expect((row?.value as string).length).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(METRIC_MONITOR_TYPES)(
+    "shows formulas and group-by keys for a %s monitor",
+    (monitorType: MonitorType) => {
+      expect(getRow(monitorType, "metricFormulas")?.value).toEqual([
+        "CPU Percent (a * 100)",
+      ]);
+      expect(getRow(monitorType, "metricGroupBy")?.value).toEqual([
+        "host.name",
+      ]);
+    },
+  );
+
+  it("shows the Kubernetes cluster, scope and resource filters", () => {
+    expect(getRow(MonitorType.Kubernetes, "clusterIdentifier")?.value).toBe(
+      "prod-cluster",
+    );
+    expect(getRow(MonitorType.Kubernetes, "resourceScope")?.value).toBe(
+      KubernetesResourceScope.Workload,
+    );
+    expect(getRow(MonitorType.Kubernetes, "namespace")?.value).toBe("payments");
+    expect(getRow(MonitorType.Kubernetes, "workloadName")?.value).toBe(
+      "checkout",
+    );
+  });
+
+  it("drops Kubernetes filter rows that are not set instead of showing blanks", () => {
+    const rows: Array<MonitorStepViewRow> = MonitorStepViewModel.getRows({
+      monitorStep: buildStep({
+        kubernetesMonitor: {
+          clusterIdentifier: "prod-cluster",
+          resourceScope: KubernetesResourceScope.Cluster,
+          resourceFilters: {},
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past5Minutes,
+        },
+      }),
+      monitorType: MonitorType.Kubernetes,
+    });
+
+    const keys: Array<string> = rows.map((row: MonitorStepViewRow) => {
+      return row.key;
+    });
+
+    expect(keys).toContain("clusterIdentifier");
+    expect(keys).not.toContain("namespace");
+    expect(keys).not.toContain("podName");
+  });
+
+  it("shows the Docker host and container filters", () => {
+    expect(getRow(MonitorType.Docker, "hostIdentifier")?.value).toBe(
+      "docker-host-1",
+    );
+    expect(getRow(MonitorType.Docker, "containerName")?.value).toBe("checkout");
+    expect(getRow(MonitorType.Docker, "containerImage")?.value).toBe(
+      "checkout:latest",
+    );
+  });
+
+  it("shows the Podman host and container filter", () => {
+    expect(getRow(MonitorType.Podman, "hostIdentifier")?.value).toBe(
+      "podman-host-1",
+    );
+    expect(getRow(MonitorType.Podman, "containerName")?.value).toBe("billing");
+  });
+
+  it("shows the Host monitor's host", () => {
+    expect(getRow(MonitorType.Host, "hostIdentifier")?.value).toBe("web-1");
+    expect(getRowTitles(MonitorType.Host)).toContain("Host");
+  });
+
+  it("shows the Proxmox cluster, scope and guest", () => {
+    expect(getRow(MonitorType.Proxmox, "clusterIdentifier")?.value).toBe(
+      "pve-cluster",
+    );
+    expect(getRow(MonitorType.Proxmox, "proxmoxScope")?.value).toBe(
+      ProxmoxResourceScope.Guest,
+    );
+    expect(getRow(MonitorType.Proxmox, "proxmoxGuestId")?.value).toBe(
+      "qemu/100",
+    );
+  });
+
+  it("shows the Docker Swarm cluster, service and node", () => {
+    expect(getRow(MonitorType.DockerSwarm, "clusterIdentifier")?.value).toBe(
+      "swarm-cluster",
+    );
+    expect(getRow(MonitorType.DockerSwarm, "swarmServiceName")?.value).toBe(
+      "api",
+    );
+    expect(getRow(MonitorType.DockerSwarm, "swarmNodeName")?.value).toBe(
+      "swarm-node-2",
+    );
+  });
+
+  it("shows the Ceph cluster, OSD and pool", () => {
+    expect(getRow(MonitorType.Ceph, "clusterIdentifier")?.value).toBe(
+      "ceph-cluster",
+    );
+    expect(getRow(MonitorType.Ceph, "cephOsdId")?.value).toBe("osd.3");
+    expect(getRow(MonitorType.Ceph, "cephPoolId")?.value).toBe("2");
+  });
+
+  it("shows the IoT fleet, scope and device", () => {
+    expect(getRow(MonitorType.IoTDevice, "fleetIdentifier")?.value).toBe(
+      "fleet-a",
+    );
+    expect(getRow(MonitorType.IoTDevice, "iotScope")?.value).toBe(
+      IoTResourceScope.Device,
+    );
+    expect(getRow(MonitorType.IoTDevice, "iotDeviceId")?.value).toBe(
+      "device-9",
+    );
+  });
+
+  it("still renders the identity row when a metric monitor has no metrics selected yet", () => {
+    const rows: Array<MonitorStepViewRow> = MonitorStepViewModel.getRows({
+      monitorStep: buildStep({
+        hostMonitor: {
+          hostIdentifier: "web-9",
+          metricViewConfig: { queryConfigs: [], formulaConfigs: [] },
+          rollingTime: RollingTime.Past5Minutes,
+        },
+      }),
+      monitorType: MonitorType.Host,
+    });
+
+    const metricNames: MonitorStepViewRow | undefined = rows.find(
+      (row: MonitorStepViewRow) => {
+        return row.key === "metricNames";
+      },
+    );
+
+    expect(metricNames?.value).toEqual([]);
+    expect(metricNames?.placeholder).toBe("No metrics selected");
+  });
+});
+
+describe("MonitorStepViewModel metric helpers", () => {
+  it("prefers the alias title and falls back to the bare metric name", () => {
+    expect(
+      MonitorStepViewModel.getMetricQueryTitles(METRIC_VIEW_CONFIG),
+    ).toEqual([
+      "CPU Usage (container.cpu.usage · Avg)",
+      "container.memory.usage · Max",
+    ]);
+  });
+
+  it("drops queries that name no metric at all", () => {
+    expect(
+      MonitorStepViewModel.getMetricQueryTitles({
+        queryConfigs: [{ metricQueryData: { filterData: {} } }],
+        formulaConfigs: [],
+      }),
+    ).toEqual([]);
+  });
+
+  it("survives a metric view config saved by an older build", () => {
+    expect(
+      MonitorStepViewModel.getMetricQueryTitles(
+        undefined as unknown as MetricsViewConfig,
+      ),
+    ).toEqual([]);
+
+    expect(
+      MonitorStepViewModel.getMetricQueryTitles({
+        queryConfigs: null,
+        formulaConfigs: null,
+      } as unknown as MetricsViewConfig),
+    ).toEqual([]);
+  });
+
+  it("de-duplicates group-by keys across queries", () => {
+    expect(
+      MonitorStepViewModel.getMetricGroupByKeys({
+        queryConfigs: [
+          {
+            metricQueryData: {
+              filterData: { metricName: "a" },
+              groupByAttributeKeys: ["host.name", "service.name"],
+            },
+          },
+          {
+            metricQueryData: {
+              filterData: { metricName: "b" },
+              groupByAttributeKeys: ["host.name"],
+            },
+          },
+        ],
+        formulaConfigs: [],
+      }),
+    ).toEqual(["host.name", "service.name"]);
+  });
+
+  it("reads the metric view config out of whichever telemetry shape the step uses", () => {
+    expect(
+      MonitorStepViewModel.getMetricsViewConfig(
+        buildStepForMonitorType(MonitorType.Ceph),
+      ).queryConfigs,
+    ).toHaveLength(2);
+
+    expect(
+      MonitorStepViewModel.getMetricsViewConfig(
+        buildStepForMonitorType(MonitorType.API),
+      ),
+    ).toEqual({ queryConfigs: [], formulaConfigs: [] });
+  });
+
+  it("reads the rolling time out of whichever telemetry shape the step uses", () => {
+    expect(
+      MonitorStepViewModel.getRollingTime(
+        buildStepForMonitorType(MonitorType.IoTDevice),
+      ),
+    ).toBe(RollingTime.Past10Minutes);
+
+    expect(
+      MonitorStepViewModel.getRollingTime(
+        buildStepForMonitorType(MonitorType.Proxmox),
+      ),
+    ).toBe(RollingTime.Past1Hour);
+
+    expect(
+      MonitorStepViewModel.getRollingTime(
+        buildStepForMonitorType(MonitorType.API),
+      ),
+    ).toBeUndefined();
+
+    expect(MonitorStepViewModel.getRollingTime(undefined)).toBeUndefined();
+  });
+
+  it("offers a chart preview for every metric-backed monitor type and no others", () => {
+    for (const monitorType of [
+      MonitorType.Metrics,
+      MonitorType.Kubernetes,
+      MonitorType.Docker,
+      MonitorType.Podman,
+      MonitorType.Host,
+      MonitorType.Proxmox,
+      MonitorType.DockerSwarm,
+      MonitorType.Ceph,
+      MonitorType.IoTDevice,
+    ]) {
+      expect(MonitorStepViewModel.hasMetricPreview(monitorType)).toBe(true);
+    }
+
+    for (const monitorType of [
+      MonitorType.API,
+      MonitorType.Website,
+      MonitorType.Logs,
+      MonitorType.Traces,
+      MonitorType.Exceptions,
+      MonitorType.Manual,
+    ]) {
+      expect(MonitorStepViewModel.hasMetricPreview(monitorType)).toBe(false);
+    }
+  });
+});

--- a/Common/Tests/UI/Monitor/MonitorStepCriteriaView.test.tsx
+++ b/Common/Tests/UI/Monitor/MonitorStepCriteriaView.test.tsx
@@ -1,0 +1,432 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import * as React from "react";
+import { MemoryRouter } from "react-router-dom";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import Hostname from "../../../Types/API/Hostname";
+import HTTPMethod from "../../../Types/API/HTTPMethod";
+import URL from "../../../Types/API/URL";
+import MetricsViewConfig from "../../../Types/Metrics/MetricsViewConfig";
+import DnsRecordType from "../../../Types/Monitor/DnsMonitor/DnsRecordType";
+import MonitorCriteria from "../../../Types/Monitor/MonitorCriteria";
+import { KubernetesResourceScope } from "../../../Types/Monitor/MonitorStepKubernetesMonitor";
+import Port from "../../../Types/Port";
+import MonitorStep, {
+  MonitorStepType,
+} from "../../../Types/Monitor/MonitorStep";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+import RollingTime from "../../../Types/RollingTime/RollingTime";
+import Service from "../../../Models/DatabaseModels/Service";
+import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * WHAT THIS FILE PROTECTS
+ *
+ * This is the monitor "Criteria" page's step viewer, rendered for real.
+ * The bug it pins: for most monitor types the page showed criteria and
+ * nothing else — no destination, no metric name, no host — while the edit
+ * modal showed the whole configuration. MonitorStepViewModel.test.ts holds
+ * the mapping from step to rows; this file holds the other half, that the
+ * component actually PUTS those rows on the page (and, for metric monitors,
+ * the chart preview beside them).
+ *
+ * The metric preview is stubbed: it is the metric explorer's chart stack,
+ * and what matters here is that the viewer hands it the right config, not
+ * that ClickHouse answers.
+ */
+
+const getListMock: MockFunction = getJestMockFunction();
+const getItemMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+      getItem: (...args: Array<any>) => {
+        return getItemMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: () => {
+        return new ObjectID("99999999-9999-4999-8999-999999999999");
+      },
+    },
+  };
+});
+
+jest.mock(
+  "../../../../App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSteps/MonitorStepMetricPreview",
+  () => {
+    return {
+      __esModule: true,
+      default: (props: {
+        metricsViewConfig: MetricsViewConfig;
+        rollingTime: RollingTime | undefined;
+      }) => {
+        return (
+          <div data-testid="metric-preview">
+            {`${props.metricsViewConfig.queryConfigs.length} queries over ${props.rollingTime}`}
+          </div>
+        );
+      },
+    };
+  },
+);
+
+// Imported after the mocks above so the component picks them up.
+import MonitorStepElement from "../../../../App/FeatureSet/Dashboard/src/Components/Monitor/MonitorSteps/MonitorStep";
+
+/*
+ * The heading of the criteria section is the word "Criteria", which is also
+ * the default NAME of a criteria instance — so the heading alone is an
+ * ambiguous query. The description under it is unique to the section.
+ */
+const CRITERIA_SECTION_DESCRIPTION: string =
+  "Criteria we will use to determine your resource status.";
+
+const METRIC_VIEW_CONFIG: MetricsViewConfig = {
+  queryConfigs: [
+    {
+      metricAliasData: {
+        metricVariable: "a",
+        title: "CPU Usage",
+        description: undefined,
+        legend: undefined,
+        legendUnit: undefined,
+      },
+      metricQueryData: {
+        filterData: {
+          metricName: "container.cpu.usage",
+          aggegationType: AggregationType.Avg,
+        },
+      },
+    },
+  ],
+  formulaConfigs: [],
+};
+
+function buildStep(data: Partial<MonitorStepType>): MonitorStep {
+  const monitorStep: MonitorStep = new MonitorStep();
+
+  monitorStep.data = {
+    ...(monitorStep.data as MonitorStepType),
+    monitorCriteria: new MonitorCriteria(),
+    ...data,
+  } as MonitorStepType;
+
+  return monitorStep;
+}
+
+function renderStep(monitorType: MonitorType, monitorStep: MonitorStep): void {
+  render(
+    <MemoryRouter>
+      <MonitorStepElement
+        monitorType={monitorType}
+        monitorStep={monitorStep}
+        monitorStatusOptions={[]}
+        incidentSeverityOptions={[]}
+        alertSeverityOptions={[]}
+        onCallPolicyOptions={[]}
+        labelOptions={[]}
+        teamOptions={[]}
+        userOptions={[]}
+        incidentRoleOptions={[]}
+      />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  getListMock.mockReset();
+  getItemMock.mockReset();
+  getListMock.mockResolvedValue({ data: [], count: 0, skip: 0, limit: 0 });
+  getItemMock.mockResolvedValue(null);
+});
+
+describe("Monitor criteria page — metric monitors", () => {
+  it("names the metric and the window instead of showing an empty section", async () => {
+    renderStep(
+      MonitorType.Metrics,
+      buildStep({
+        metricMonitor: {
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past30Minutes,
+          telemetryServiceIds: [],
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Metrics")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("CPU Usage (container.cpu.usage · Avg)"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Time Range")).toBeInTheDocument();
+    expect(screen.getByText(RollingTime.Past30Minutes)).toBeInTheDocument();
+  });
+
+  it("renders the metric preview with the step's own config", async () => {
+    renderStep(
+      MonitorType.Metrics,
+      buildStep({
+        metricMonitor: {
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past30Minutes,
+          telemetryServiceIds: [],
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("metric-preview")).toHaveTextContent(
+        "1 queries over Past 30 Minutes",
+      );
+    });
+  });
+
+  it("shows the host an infrastructure monitor watches", async () => {
+    renderStep(
+      MonitorType.Host,
+      buildStep({
+        hostMonitor: {
+          hostIdentifier: "web-1",
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past5Minutes,
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("web-1")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("metric-preview")).toBeInTheDocument();
+  });
+
+  it("shows the Kubernetes cluster and its resource filters", async () => {
+    renderStep(
+      MonitorType.Kubernetes,
+      buildStep({
+        kubernetesMonitor: {
+          clusterIdentifier: "prod-cluster",
+          resourceScope: KubernetesResourceScope.Workload,
+          resourceFilters: { namespace: "payments" },
+          metricViewConfig: METRIC_VIEW_CONFIG,
+          rollingTime: RollingTime.Past5Minutes,
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("prod-cluster")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Namespace")).toBeInTheDocument();
+    expect(screen.getByText("payments")).toBeInTheDocument();
+  });
+});
+
+describe("Monitor criteria page — probe monitors", () => {
+  it("still shows the API destination and request type", async () => {
+    renderStep(
+      MonitorType.API,
+      buildStep({
+        monitorDestination: URL.fromString("https://api.example.com/health"),
+        requestType: HTTPMethod.POST,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("API URL")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("https://api.example.com/health"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(HTTPMethod.POST)).toBeInTheDocument();
+  });
+
+  it("shows the SSL certificate monitor's destination", async () => {
+    renderStep(
+      MonitorType.SSLCertificate,
+      buildStep({
+        monitorDestination: URL.fromString("https://secure.example.com"),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        // URL.toString() renders the root path explicitly.
+        screen.getByText("https://secure.example.com/"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows the port monitor's host and port", async () => {
+    renderStep(
+      MonitorType.Port,
+      buildStep({
+        monitorDestination: new Hostname("db.example.com"),
+        monitorDestinationPort: new Port(5432),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("db.example.com")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("5432")).toBeInTheDocument();
+  });
+
+  it("shows the DNS query, record type and resolver", async () => {
+    renderStep(
+      MonitorType.DNS,
+      buildStep({
+        dnsMonitor: {
+          queryName: "example.com",
+          recordType: DnsRecordType.A,
+          hostname: "8.8.8.8",
+          port: 53,
+          timeout: 5000,
+          retries: 3,
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("example.com")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Record Type")).toBeInTheDocument();
+    expect(screen.getByText("8.8.8.8")).toBeInTheDocument();
+  });
+});
+
+describe("Monitor criteria page — resolved references", () => {
+  it("names the telemetry services a log monitor is scoped to", async () => {
+    const service: Service = new Service();
+    service.id = new ObjectID("11111111-1111-4111-8111-111111111111");
+    service.name = "checkout";
+
+    getListMock.mockResolvedValue({
+      data: [service],
+      count: 1,
+      skip: 0,
+      limit: 10,
+    });
+
+    renderStep(
+      MonitorType.Logs,
+      buildStep({
+        logMonitor: {
+          attributes: {},
+          body: "timeout",
+          severityTexts: [],
+          telemetryServiceIds: [
+            new ObjectID("11111111-1111-4111-8111-111111111111"),
+          ],
+          lastXSecondsOfLogs: 60,
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("checkout")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Telemetry Services")).toBeInTheDocument();
+  });
+
+  it("names the network device a network device monitor alerts on", async () => {
+    const networkDevice: NetworkDevice = new NetworkDevice();
+    networkDevice.name = "core-switch-1";
+
+    getItemMock.mockResolvedValue(networkDevice);
+
+    renderStep(
+      MonitorType.NetworkDevice,
+      buildStep({
+        networkDeviceMonitor: {
+          networkDeviceId: "44444444-4444-4444-8444-444444444444",
+          monitorInterfaces: true,
+          collectEndpoints: false,
+          oids: [],
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("core-switch-1")).toBeInTheDocument();
+    });
+  });
+
+  it("falls back to the stored id when the network device no longer resolves", async () => {
+    getItemMock.mockResolvedValue(null);
+
+    renderStep(
+      MonitorType.NetworkDevice,
+      buildStep({
+        networkDeviceMonitor: {
+          networkDeviceId: "44444444-4444-4444-8444-444444444444",
+          monitorInterfaces: true,
+          collectEndpoints: false,
+          oids: [],
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("44444444-4444-4444-8444-444444444444"),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("Monitor criteria page — types without step configuration", () => {
+  it("hides the Monitor Details section for incoming request monitors but still shows criteria", async () => {
+    renderStep(MonitorType.IncomingRequest, buildStep({}));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(CRITERIA_SECTION_DESCRIPTION),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByTestId("monitor-step-details"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Monitor Details")).not.toBeInTheDocument();
+  });
+
+  it("always renders the criteria section, whatever the monitor type", async () => {
+    renderStep(
+      MonitorType.Website,
+      buildStep({
+        monitorDestination: URL.fromString("https://example.com"),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(CRITERIA_SECTION_DESCRIPTION),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("monitor-step-details")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## The bug

On a monitor's **Criteria** page you saw the criteria and nothing else — no destination, no metric name, no host. Clicking **Edit** showed the whole configuration in the modal.

The read-only step viewer was an `if (monitorType === ...)` chain covering roughly a third of the monitor types we ship. Everything else fell off the end of the chain: `fields` stayed empty, and the page rendered a "Monitor Details" heading with empty space under it.

Types that rendered nothing before this change:

| | |
|---|---|
| Metrics | Kubernetes, Docker, Host, Podman, Proxmox, Docker Swarm, Ceph, IoT Device |
| DNS | Exceptions |
| Network Device | SSL Certificate |

The failure was silent in the worst way — nothing threw, nothing warned. Adding a monitor type is the moment the gap opens, and nothing about adding a type forces anyone to look at the viewer.

## The fix

The mapping from *monitor step* to *what the page shows* moves out of the component into a pure module, [`MonitorStepViewModel`](https://github.com/OneUptime/oneuptime/blob/claude/monitor-criteria-page-display-63a7a0/App/FeatureSet/Dashboard/src/Utils/MonitorStepViewModel.ts) — plain data in, display rows out, no React and no fetches. It covers every type that has step configuration, and its test holds it to **every active monitor type at once**, so a new type can't quietly render nothing again.

Also on the page now:

- **Metric preview.** Metric-backed monitors get a read-only chart of the metrics they evaluate — the same view the edit modal shows while you pick them — alongside the metric names, formulas, group-by keys and rolling window.
- **Resolved references.** Telemetry service ids and the network device id are resolved to names. A device that has since been deleted falls back to its stored id rather than rendering blank, because that id is what the criteria are still pointed at.
- **No more empty section.** Types that genuinely have no step config (Manual, Server, Incoming Request/Email) no longer render a "Monitor Details" heading over nothing.
- Fields that existed but were never shown are now shown: per-step request timeout and retry overrides, telemetry entity keys, DNSSEC/SQL/domain options.

Secrets are never rendered. The mTLS row reports only *whether* a client certificate is configured — the certificate, key and passphrase never reach the view model — and neither does the SQL monitor's password. Both are pinned by tests that serialize the rows and assert the secret isn't in them.

## Tests

**114 new tests, all passing locally.**

`App/Tests/Dashboard/MonitorStepViewModel.test.ts` — 101 tests over the pure mapping. The central one is `getRows` across every active monitor type: a type either produces rows, or it is on an explicit list of types that genuinely have no step configuration. There is no third outcome. Plus per-type assertions, secret-redaction checks, and robustness against metric configs written by older builds (missing `metricViewConfig`, null `queryConfigs`).

`Common/Tests/UI/Monitor/MonitorStepCriteriaView.test.tsx` — 13 tests rendering the real viewer with React Testing Library, asserting the rows actually reach the page, that the metric preview receives the step's own config, that references resolve to names, and that the criteria section always renders while the details section disappears for types without config.

## Verification

Locally, on this branch:

- `MonitorStepViewModel.test.ts` — 101/101 pass
- `MonitorStepCriteriaView.test.tsx` — 13/13 pass
- `tsc --noEmit` over the Dashboard project — clean
- ESLint and Prettier over all five changed files — clean