### PR TITLE
fix(ui): make the label colour field fillable, and stop the modal eating the form (#3143)

### DIFF
--- a/Common/Tests/UI/Components/Forms/AnchoredFieldPopupKeyboard.test.tsx
+++ b/Common/Tests/UI/Components/Forms/AnchoredFieldPopupKeyboard.test.tsx
@@ -1,0 +1,382 @@
+import BasicForm from "../../../../UI/Components/Forms/BasicForm";
+import ColorPicker from "../../../../UI/Components/Forms/Fields/ColorPicker";
+import IconPicker from "../../../../UI/Components/Forms/Fields/IconPicker";
+import Fields from "../../../../UI/Components/Forms/Types/Fields";
+import FormFieldSchemaType from "../../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import FormValues from "../../../../UI/Components/Forms/Types/FormValues";
+import Modal from "../../../../UI/Components/Modal/Modal";
+import Color from "../../../../Types/Color";
+import IconProp from "../../../../Types/Icon/IconProp";
+import getJestMockFunction, { MockFunction } from "../../../../Tests/MockType";
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * The colour and icon fields are triggers dressed as text boxes: a readOnly
+ * input whose only job is to open a portalled popup, which it used to do on
+ * click and on nothing else. Every key was dead. That left a keyboard user with
+ * no way in at all — and on the Create Label form (issue #3143) the colour is
+ * required, so no way in meant no way to submit the form either.
+ *
+ * Both fields drive UseAnchoredFieldPopup, so the behaviour is stated once per
+ * field here and the shared parts are pinned in both.
+ */
+
+const OPENING_KEYS: Array<string> = ["Enter", " ", "ArrowDown", "ArrowUp"];
+
+type RenderColorPickerFunction = (
+  props?: Partial<{ readOnly: boolean; disabled: boolean }>,
+) => MockFunction;
+
+const renderColorPicker: RenderColorPickerFunction = (
+  props: Partial<{ readOnly: boolean; disabled: boolean }> = {},
+): MockFunction => {
+  const onChange: MockFunction = getJestMockFunction();
+
+  render(
+    <ColorPicker
+      dataTestId="color-value"
+      placeholder="Please select color for this label."
+      onChange={onChange}
+      readOnly={props.readOnly}
+      disabled={props.disabled}
+      tabIndex={0}
+    />,
+  );
+
+  return onChange;
+};
+
+type GetFieldFunction = (testId: string) => HTMLInputElement;
+
+const getField: GetFieldFunction = (testId: string): HTMLInputElement => {
+  return screen.getByTestId(testId) as HTMLInputElement;
+};
+
+describe("Opening an anchored field popup from the keyboard", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("ColorPicker", () => {
+    test.each(OPENING_KEYS)(
+      "%p opens the popup and moves focus into it",
+      (key: string) => {
+        renderColorPicker();
+
+        const field: HTMLInputElement = getField("color-value");
+
+        field.focus();
+        fireEvent.keyDown(field, { key });
+
+        const popup: HTMLElement = screen.getByTestId("color-picker-popup");
+
+        expect(popup).toBeInTheDocument();
+
+        /*
+         * Landing on the popup's first control is what makes the field
+         * fillable: for a colour that control is ChromePicker's hex box, so
+         * "open it and type the brand hex" is a complete keyboard path.
+         */
+        expect(popup.contains(document.activeElement)).toBe(true);
+      },
+    );
+
+    test("a keyboard user can open the picker and set a hex end to end", async () => {
+      const onChange: MockFunction = renderColorPicker();
+      const field: HTMLInputElement = getField("color-value");
+
+      field.focus();
+      fireEvent.keyDown(field, { key: "Enter" });
+
+      const focusedControl: HTMLElement = document.activeElement as HTMLElement;
+
+      expect(focusedControl.tagName).toEqual("INPUT");
+
+      fireEvent.change(focusedControl, { target: { value: "#32a852" } });
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(new Color("#32a852"));
+      });
+
+      // Escape puts the user back where they were, with the value kept.
+      fireEvent.keyDown(focusedControl, { key: "Escape" });
+
+      expect(screen.queryByTestId("color-picker-popup")).toBeNull();
+      expect(document.activeElement).toBe(field);
+      expect(field.value).toEqual("#32a852");
+    });
+
+    test("an opening key is claimed, so nothing downstream acts on it too", () => {
+      renderColorPicker();
+
+      const field: HTMLInputElement = getField("color-value");
+
+      /*
+       * fireEvent returns false when a cancelable event had preventDefault
+       * called on it. That is what stops Input's own onEnterPress from also
+       * firing, and what would stop a real <form> around the field from
+       * submitting on the way past.
+       */
+      expect(fireEvent.keyDown(field, { key: "Enter" })).toBe(false);
+      expect(fireEvent.keyDown(field, { key: " " })).toBe(false);
+    });
+
+    test("Enter on an already open field moves focus in rather than closing it", () => {
+      renderColorPicker();
+
+      const field: HTMLInputElement = getField("color-value");
+
+      fireEvent.click(field);
+
+      const popup: HTMLElement = screen.getByTestId("color-picker-popup");
+
+      // A pointer user's popup opens under their cursor and leaves focus alone.
+      expect(popup.contains(document.activeElement)).toBe(false);
+
+      field.focus();
+      fireEvent.keyDown(field, { key: "Enter" });
+
+      expect(screen.getByTestId("color-picker-popup")).toBeInTheDocument();
+      expect(popup.contains(document.activeElement)).toBe(true);
+    });
+
+    test("keys that are not opening keys are left alone", () => {
+      renderColorPicker();
+
+      const field: HTMLInputElement = getField("color-value");
+
+      expect(fireEvent.keyDown(field, { key: "Tab" })).toBe(true);
+      expect(fireEvent.keyDown(field, { key: "a" })).toBe(true);
+      expect(screen.queryByTestId("color-picker-popup")).toBeNull();
+    });
+
+    test("a readOnly field opens for neither pointer nor keyboard", () => {
+      renderColorPicker({ readOnly: true });
+
+      const field: HTMLInputElement = getField("color-value");
+
+      fireEvent.click(field);
+      fireEvent.keyDown(field, { key: "Enter" });
+      fireEvent.keyDown(field, { key: "ArrowDown" });
+
+      expect(screen.queryByTestId("color-picker-popup")).toBeNull();
+    });
+
+    test("a disabled field opens for neither pointer nor keyboard", () => {
+      renderColorPicker({ disabled: true });
+
+      const field: HTMLInputElement = getField("color-value");
+
+      fireEvent.click(field);
+      fireEvent.keyDown(field, { key: "Enter" });
+      fireEvent.keyDown(field, { key: "ArrowDown" });
+
+      expect(screen.queryByTestId("color-picker-popup")).toBeNull();
+    });
+
+    test("the field advertises the popup it controls", () => {
+      renderColorPicker();
+
+      const field: HTMLInputElement = getField("color-value");
+
+      expect(field).toHaveAttribute("aria-haspopup", "dialog");
+      expect(field).toHaveAttribute("aria-expanded", "false");
+      expect(field).not.toHaveAttribute("aria-controls");
+
+      fireEvent.click(field);
+
+      const popup: HTMLElement = screen.getByTestId("color-picker-popup");
+
+      expect(field).toHaveAttribute("aria-expanded", "true");
+      expect(field.getAttribute("aria-controls")).toEqual(popup.id);
+      expect(popup.id).toBeTruthy();
+      expect(popup).toHaveAttribute("role", "dialog");
+      expect(popup).toHaveAttribute("aria-label", "Color picker");
+    });
+  });
+
+  describe("IconPicker", () => {
+    type RenderIconPickerFunction = () => MockFunction;
+
+    const renderIconPicker: RenderIconPickerFunction = (): MockFunction => {
+      const onChange: MockFunction = getJestMockFunction();
+
+      render(
+        <IconPicker
+          dataTestId="icon-value"
+          placeholder="No icon"
+          onChange={onChange}
+          tabIndex={0}
+        />,
+      );
+
+      return onChange;
+    };
+
+    test.each(OPENING_KEYS)(
+      "%p opens the popup and moves focus into it",
+      (key: string) => {
+        renderIconPicker();
+
+        const field: HTMLInputElement = getField("icon-value");
+
+        field.focus();
+        fireEvent.keyDown(field, { key });
+
+        const popup: HTMLElement = screen.getByTestId("icon-picker-popup");
+
+        expect(popup).toBeInTheDocument();
+        expect(popup.contains(document.activeElement)).toBe(true);
+      },
+    );
+
+    test("a keyboard user can search for an icon and choose it", () => {
+      const onChange: MockFunction = renderIconPicker();
+      const field: HTMLInputElement = getField("icon-value");
+
+      field.focus();
+      fireEvent.keyDown(field, { key: "Enter" });
+
+      const popup: HTMLElement = screen.getByTestId("icon-picker-popup");
+      const searchBox: HTMLElement = document.activeElement as HTMLElement;
+
+      expect(popup.contains(searchBox)).toBe(true);
+
+      fireEvent.change(searchBox, { target: { value: IconProp.Alert } });
+
+      /*
+       * The cells used to be plain divs, so Tab skipped straight past the only
+       * control that can set this field.
+       */
+      const cell: HTMLElement = within(popup).getByRole("button", {
+        name: IconProp.Alert,
+      });
+
+      cell.focus();
+      expect(document.activeElement).toBe(cell);
+
+      fireEvent.click(cell);
+
+      expect(onChange).toHaveBeenCalledWith(IconProp.Alert);
+      expect(screen.queryByTestId("icon-picker-popup")).toBeNull();
+      expect(document.activeElement).toBe(field);
+      expect(field.value).toEqual(IconProp.Alert);
+    });
+
+    test("the field advertises the popup it controls", () => {
+      renderIconPicker();
+
+      const field: HTMLInputElement = getField("icon-value");
+
+      expect(field).toHaveAttribute("aria-haspopup", "dialog");
+      expect(field).toHaveAttribute("aria-expanded", "false");
+
+      fireEvent.click(field);
+
+      const popup: HTMLElement = screen.getByTestId("icon-picker-popup");
+
+      expect(field).toHaveAttribute("aria-expanded", "true");
+      expect(field.getAttribute("aria-controls")).toEqual(popup.id);
+      expect(popup).toHaveAttribute("role", "dialog");
+      expect(popup).toHaveAttribute("aria-label", "Icon picker");
+    });
+  });
+
+  /*
+   * The two surfaces the field actually ships on: inside a form, where Enter is
+   * a submit, and inside a modal, where Escape is a dismissal.
+   */
+  describe("inside the Label form and its modal", () => {
+    const LABEL_FIELDS: Fields<FormValues<Record<string, unknown>>> = [
+      {
+        field: { name: true },
+        title: "Name",
+        fieldType: FormFieldSchemaType.Text,
+        required: true,
+        dataTestId: "name",
+      },
+      {
+        field: { color: true },
+        title: "Label Color",
+        fieldType: FormFieldSchemaType.Color,
+        required: true,
+        dataTestId: "color-value",
+      },
+    ];
+
+    test("Enter on the colour field opens the picker and posts nothing", async () => {
+      const onSubmit: MockFunction = getJestMockFunction();
+
+      render(
+        <BasicForm
+          id="create-label"
+          fields={LABEL_FIELDS}
+          onSubmit={onSubmit}
+          submitButtonText="Create Label"
+        />,
+      );
+
+      fireEvent.change(screen.getByTestId("name"), {
+        target: { value: "WB Unit-BB" },
+      });
+
+      const field: HTMLInputElement = getField("color-value");
+
+      field.focus();
+      expect(fireEvent.keyDown(field, { key: "Enter" })).toBe(false);
+
+      expect(screen.getByTestId("color-picker-popup")).toBeInTheDocument();
+
+      /*
+       * The picker is the only thing that happens: no submit, so no "Label
+       * Color is required." for a field being filled in right now.
+       */
+      await waitFor(() => {
+        expect(screen.queryByText("Label Color is required.")).toBeNull();
+      });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    test("Escape closes the picker without taking the modal with it", () => {
+      const onClose: MockFunction = getJestMockFunction();
+
+      render(
+        <Modal title="Create New Label" onClose={onClose}>
+          <ColorPicker
+            dataTestId="color-value"
+            placeholder="Please select color for this label."
+            onChange={getJestMockFunction()}
+            tabIndex={0}
+          />
+        </Modal>,
+      );
+
+      const field: HTMLInputElement = getField("color-value");
+
+      field.focus();
+      fireEvent.keyDown(field, { key: "ArrowDown" });
+
+      expect(screen.getByTestId("color-picker-popup")).toBeInTheDocument();
+
+      fireEvent.keyDown(document.activeElement as HTMLElement, {
+        key: "Escape",
+      });
+
+      expect(screen.queryByTestId("color-picker-popup")).toBeNull();
+      expect(onClose).not.toHaveBeenCalled();
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+      expect(document.activeElement).toBe(field);
+    });
+  });
+});

--- a/Common/Tests/UI/Components/Forms/ColorPickerPicking.test.tsx
+++ b/Common/Tests/UI/Components/Forms/ColorPickerPicking.test.tsx
@@ -1,0 +1,569 @@
+import BasicForm from "../../../../UI/Components/Forms/BasicForm";
+import ColorPicker from "../../../../UI/Components/Forms/Fields/ColorPicker";
+import Fields from "../../../../UI/Components/Forms/Types/Fields";
+import FormFieldSchemaType from "../../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import FormValues from "../../../../UI/Components/Forms/Types/FormValues";
+import Modal from "../../../../UI/Components/Modal/Modal";
+import Color from "../../../../Types/Color";
+import getJestMockFunction, { MockFunction } from "../../../../Tests/MockType";
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React, { ReactElement } from "react";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "@jest/globals";
+
+/*
+ * Issue #3143: on Settings > Labels > Create Label, choosing a colour made the
+ * whole modal vanish and threw the half-filled form away. Label Color is
+ * required, so that left no way to create a label at all.
+ *
+ * The dismissal itself was a Modal-level bug (#3133): ColorPicker portals its
+ * popup to document.body so the modal body cannot clip it, and React dispatches
+ * synthetic events through the REACT tree, so a press inside the popup still
+ * reached the backdrop handler — which read "not a DOM descendant of the panel"
+ * as "outside" and closed the dialog.
+ *
+ * ModalPortalDismissal.test.tsx states that contract for every portalling
+ * surface, but it presses the popup's hex box. What the bug report actually
+ * shows is a *drag across the saturation square*, and that is a different event
+ * sequence: react-color takes the press, binds mousemove and mouseup on window,
+ * and the click that finally bubbles into Modal arrives after the colour has
+ * already changed under it. These tests drive the real ChromePicker through
+ * that sequence, end to end, up to the value the form submits.
+ */
+
+/*
+ * react-color reads pageX/pageY to work out where in the square the pointer
+ * landed, and jsdom populates neither — its handler throws before it can
+ * compute a colour, so nothing downstream of a press can be tested without
+ * this. Nothing here scrolls, so the client coordinates are the page ones.
+ */
+const definePageCoordinates: () => void = (): void => {
+  ["pageX", "pageY"].forEach((property: string) => {
+    Object.defineProperty(MouseEvent.prototype, property, {
+      configurable: true,
+      get(this: MouseEvent): number {
+        return property === "pageX" ? this.clientX : this.clientY;
+      },
+    });
+  });
+};
+
+const deletePageCoordinates: () => void = (): void => {
+  Reflect.deleteProperty(MouseEvent.prototype, "pageX");
+  Reflect.deleteProperty(MouseEvent.prototype, "pageY");
+};
+
+/*
+ * The saturation square and the hue strip both measure themselves to map a
+ * pointer position onto a colour, and every box in jsdom is zero by zero.
+ */
+const SATURATION_BOX_WIDTH_PX: number = 200;
+const SATURATION_BOX_HEIGHT_PX: number = 120;
+const HUE_STRIP_WIDTH_PX: number = 200;
+const HUE_STRIP_HEIGHT_PX: number = 10;
+
+type GiveElementABoxFunction = (
+  element: HTMLElement,
+  width: number,
+  height: number,
+) => void;
+
+const giveElementABox: GiveElementABoxFunction = (
+  element: HTMLElement,
+  width: number,
+  height: number,
+): void => {
+  element.getBoundingClientRect = (): DOMRect => {
+    return {
+      bottom: height,
+      height,
+      left: 0,
+      right: width,
+      top: 0,
+      width,
+      x: 0,
+      y: 0,
+      toJSON: (): Record<string, never> => {
+        return {};
+      },
+    } as DOMRect;
+  };
+};
+
+interface PickerHarness {
+  onClose: MockFunction;
+  onChange: MockFunction;
+}
+
+type OpenPickerFunction = () => HTMLElement;
+
+const openPicker: OpenPickerFunction = (): HTMLElement => {
+  fireEvent.click(screen.getByTestId("color-value"));
+
+  return screen.getByTestId("color-picker-popup");
+};
+
+/*
+ * The elements react-color takes the press on and measures itself against. The
+ * saturation one carries no class of its own — it is the parent of the
+ * `.saturation-white` overlay; the hue strip is `.hue-horizontal` itself.
+ */
+type GetSurfaceFunction = (popup: HTMLElement) => HTMLElement;
+
+const getSaturationSquare: GetSurfaceFunction = (
+  popup: HTMLElement,
+): HTMLElement => {
+  const overlay: HTMLElement | null = popup.querySelector(".saturation-white");
+
+  if (!overlay?.parentElement) {
+    throw new Error("ChromePicker did not render a saturation square.");
+  }
+
+  giveElementABox(
+    overlay.parentElement,
+    SATURATION_BOX_WIDTH_PX,
+    SATURATION_BOX_HEIGHT_PX,
+  );
+
+  return overlay.parentElement;
+};
+
+const getHueStrip: GetSurfaceFunction = (popup: HTMLElement): HTMLElement => {
+  const strip: HTMLElement | null = popup.querySelector(".hue-horizontal");
+
+  if (!strip) {
+    throw new Error("ChromePicker did not render a hue strip.");
+  }
+
+  giveElementABox(strip, HUE_STRIP_WIDTH_PX, HUE_STRIP_HEIGHT_PX);
+
+  return strip;
+};
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+/*
+ * A real pointer drag, in the order a browser fires it: the press lands on the
+ * square, the moves and the release go to window because that is where
+ * react-color binds them, and the click arrives last on the element the press
+ * started on.
+ */
+type DragFunction = (element: HTMLElement, from: Point, to: Point) => void;
+
+const drag: DragFunction = (
+  element: HTMLElement,
+  from: Point,
+  to: Point,
+): void => {
+  fireEvent.mouseDown(element, { clientX: from.x, clientY: from.y });
+  fireEvent.mouseMove(window, { clientX: to.x, clientY: to.y });
+  fireEvent.mouseUp(window, { clientX: to.x, clientY: to.y });
+  fireEvent.click(element, { clientX: to.x, clientY: to.y });
+};
+
+type RenderPickerInModalFunction = () => PickerHarness;
+
+const renderPickerInModal: RenderPickerInModalFunction = (): PickerHarness => {
+  const onClose: MockFunction = getJestMockFunction();
+  const onChange: MockFunction = getJestMockFunction();
+
+  render(
+    <Modal title="Create New Label" onClose={onClose}>
+      <ColorPicker
+        dataTestId="color-value"
+        placeholder="Please select color for this label."
+        onChange={onChange}
+      />
+    </Modal>,
+  );
+
+  return { onChange, onClose };
+};
+
+type GetColorFieldFunction = () => HTMLInputElement;
+
+const getColorField: GetColorFieldFunction = (): HTMLInputElement => {
+  return screen.getByTestId("color-value") as HTMLInputElement;
+};
+
+describe("Picking a colour inside a modal (issue #3143)", () => {
+  beforeAll(() => {
+    definePageCoordinates();
+  });
+
+  afterAll(() => {
+    deletePageCoordinates();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("the reported flow: dragging across the saturation square", () => {
+    test("keeps the modal open, keeps the popup open and reports the colour", async () => {
+      const harness: PickerHarness = renderPickerInModal();
+      const popup: HTMLElement = openPicker();
+      const square: HTMLElement = getSaturationSquare(popup);
+
+      // Half across, half down: full-saturation, half-brightness red.
+      drag(square, { x: 20, y: 20 }, { x: 100, y: 60 });
+
+      await waitFor(() => {
+        expect(harness.onChange).toHaveBeenCalled();
+      });
+
+      expect(harness.onClose).not.toHaveBeenCalled();
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+      expect(screen.getByTestId("color-picker-popup")).toBeInTheDocument();
+
+      const picked: Color = harness.onChange.mock.calls[
+        harness.onChange.mock.calls.length - 1
+      ]![0] as Color;
+
+      expect(picked).toBeInstanceOf(Color);
+      expect(picked.toString()).toMatch(/^#[0-9a-f]{6}$/i);
+      expect(getColorField().value).toEqual(picked.toString());
+    });
+
+    test("the press does not arm the backdrop, so the next click is harmless", async () => {
+      const harness: PickerHarness = renderPickerInModal();
+      const popup: HTMLElement = openPicker();
+      const square: HTMLElement = getSaturationSquare(popup);
+
+      drag(square, { x: 20, y: 20 }, { x: 100, y: 60 });
+
+      /*
+       * Modal remembers where a press started so that selecting text and
+       * releasing past the panel edge is not a dismissal. A press that began in
+       * the portalled popup must not leave that memory set to "outside".
+       */
+      fireEvent.click(screen.getByTestId("modal-title"));
+
+      expect(harness.onClose).not.toHaveBeenCalled();
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+    });
+
+    test("a drag that leaves the popup and releases over the backdrop keeps the modal", async () => {
+      const harness: PickerHarness = renderPickerInModal();
+      const popup: HTMLElement = openPicker();
+      const square: HTMLElement = getSaturationSquare(popup);
+      const backdropLayer: HTMLElement =
+        screen.getByTestId("modal").parentElement!;
+
+      /*
+       * Overshooting a 200px-wide square is the normal way to reach full
+       * saturation. react-color clamps the coordinates; the release lands on
+       * the backdrop, and the browser then fires the click on the nearest
+       * common ancestor of press and release, which is the body.
+       */
+      fireEvent.mouseDown(square, { clientX: 100, clientY: 60 });
+      fireEvent.mouseMove(window, { clientX: 900, clientY: 900 });
+      fireEvent.mouseUp(backdropLayer, { clientX: 900, clientY: 900 });
+      fireEvent.click(document.body, { clientX: 900, clientY: 900 });
+
+      await waitFor(() => {
+        expect(harness.onChange).toHaveBeenCalled();
+      });
+
+      expect(harness.onClose).not.toHaveBeenCalled();
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+    });
+  });
+
+  describe("the other two ways to pick a colour", () => {
+    test("dragging the hue strip keeps the modal open and changes the colour", async () => {
+      const harness: PickerHarness = renderPickerInModal();
+      const popup: HTMLElement = openPicker();
+      const square: HTMLElement = getSaturationSquare(popup);
+
+      // Give it a saturated colour first, so a hue change is visible in the hex.
+      drag(square, { x: 200, y: 0 }, { x: 200, y: 0 });
+
+      await waitFor(() => {
+        expect(harness.onChange).toHaveBeenCalled();
+      });
+
+      const beforeHueChange: string = getColorField().value;
+      const hueStrip: HTMLElement = getHueStrip(popup);
+
+      drag(hueStrip, { x: 10, y: 5 }, { x: 120, y: 5 });
+
+      await waitFor(() => {
+        expect(getColorField().value).not.toEqual(beforeHueChange);
+      });
+
+      expect(harness.onClose).not.toHaveBeenCalled();
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+    });
+
+    test("typing a hex into the popup keeps the modal open and reports the colour", async () => {
+      const harness: PickerHarness = renderPickerInModal();
+      const popup: HTMLElement = openPicker();
+      const hexBox: HTMLInputElement = popup.querySelector(
+        "input",
+      ) as HTMLInputElement;
+
+      fireEvent.mouseDown(hexBox);
+      fireEvent.click(hexBox);
+      fireEvent.change(hexBox, { target: { value: "#32a852" } });
+
+      await waitFor(() => {
+        expect(harness.onChange).toHaveBeenCalledWith(new Color("#32a852"));
+      });
+
+      expect(harness.onClose).not.toHaveBeenCalled();
+      expect(getColorField().value).toEqual("#32a852");
+    });
+  });
+
+  describe("the value the form gets is the value on screen", () => {
+    test("a picked colour reaches onChange in the same tick the field shows it", () => {
+      const harness: PickerHarness = renderPickerInModal();
+      const popup: HTMLElement = openPicker();
+      const square: HTMLElement = getSaturationSquare(popup);
+
+      /*
+       * The picker used to paint the swatch from react-color's onChange and
+       * feed the form from onChangeComplete, which is debounced by 100ms — so
+       * for that window the field showed a colour the form did not hold. No
+       * waitFor here: that the two agree immediately is the point of the test.
+       */
+      fireEvent.mouseDown(square, { clientX: 100, clientY: 60 });
+
+      expect(harness.onChange).toHaveBeenCalled();
+
+      const reported: Color = harness.onChange.mock.calls[
+        harness.onChange.mock.calls.length - 1
+      ]![0] as Color;
+
+      expect(getColorField().value).toEqual(reported.toString());
+    });
+
+    test("there is no alpha channel to produce a colour the column cannot hold", async () => {
+      const harness: PickerHarness = renderPickerInModal();
+      const popup: HTMLElement = openPicker();
+
+      /*
+       * react-color reports a fully transparent colour as the literal string
+       * "transparent" — eleven characters, where Label.color holds ten, and
+       * Color validates nothing on the way through. Dropping the alpha slider
+       * is what stops the field producing a value that cannot be saved.
+       */
+      expect(popup.querySelector(".alpha-picker")).toBeNull();
+
+      const square: HTMLElement = getSaturationSquare(popup);
+
+      // The corner that is #000000, the only colour react-color calls transparent.
+      drag(square, { x: 0, y: 120 }, { x: 0, y: 120 });
+
+      await waitFor(() => {
+        expect(harness.onChange).toHaveBeenCalled();
+      });
+
+      harness.onChange.mock.calls.forEach((call: Array<unknown>) => {
+        expect((call[0] as Color).toString()).toMatch(/^#[0-9a-f]{6}$/i);
+      });
+    });
+  });
+
+  describe("the required error is reachable, not just visible", () => {
+    test("the field points at its own message and is marked invalid", () => {
+      render(
+        <ColorPicker
+          dataTestId="color-value"
+          placeholder="Please select color for this label."
+          error="Label Color is required."
+          onChange={getJestMockFunction()}
+        />,
+      );
+
+      const field: HTMLInputElement = getColorField();
+      const message: HTMLElement = screen.getByTestId("error-message");
+
+      expect(field).toHaveAttribute("aria-invalid", "true");
+      expect(field.getAttribute("aria-describedby")).toEqual(message.id);
+      expect(message.id).toBeTruthy();
+      expect(message).toHaveAttribute("role", "alert");
+      expect(message).toHaveTextContent("Label Color is required.");
+    });
+
+    test("a field with no error advertises neither", () => {
+      renderPickerInModal();
+
+      const field: HTMLInputElement = getColorField();
+
+      expect(field).not.toHaveAttribute("aria-invalid");
+      expect(field).not.toHaveAttribute("aria-describedby");
+    });
+  });
+
+  describe("the modal is still dismissable the ordinary ways", () => {
+    test("a press that starts and ends on the backdrop still closes it", () => {
+      const harness: PickerHarness = renderPickerInModal();
+      const backdropLayer: HTMLElement =
+        screen.getByTestId("modal").parentElement!;
+
+      fireEvent.mouseDown(backdropLayer);
+      fireEvent.mouseUp(backdropLayer);
+      fireEvent.click(backdropLayer);
+
+      expect(harness.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test("with the picker open, the first backdrop press only puts the picker away", () => {
+      const harness: PickerHarness = renderPickerInModal();
+      const backdropLayer: HTMLElement =
+        screen.getByTestId("modal").parentElement!;
+
+      openPicker();
+
+      fireEvent.mouseDown(backdropLayer);
+      fireEvent.mouseUp(backdropLayer);
+      fireEvent.click(backdropLayer);
+
+      expect(screen.queryByTestId("color-picker-popup")).toBeNull();
+      expect(harness.onClose).not.toHaveBeenCalled();
+
+      // The picker gone, the next press dismisses the dialog as usual.
+      fireEvent.mouseDown(backdropLayer);
+      fireEvent.mouseUp(backdropLayer);
+      fireEvent.click(backdropLayer);
+
+      expect(harness.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test("the close button still works after a colour has been dragged out", async () => {
+      const harness: PickerHarness = renderPickerInModal();
+      const popup: HTMLElement = openPicker();
+      const square: HTMLElement = getSaturationSquare(popup);
+
+      drag(square, { x: 20, y: 20 }, { x: 100, y: 60 });
+
+      await waitFor(() => {
+        expect(harness.onChange).toHaveBeenCalled();
+      });
+
+      fireEvent.click(screen.getByTestId("close-button"));
+
+      expect(harness.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test("Escape dismisses the popup first and the modal second", async () => {
+      const harness: PickerHarness = renderPickerInModal();
+      const popup: HTMLElement = openPicker();
+
+      fireEvent.keyDown(popup, { key: "Escape" });
+
+      expect(screen.queryByTestId("color-picker-popup")).toBeNull();
+      expect(harness.onClose).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(getColorField(), { key: "Escape" });
+
+      expect(harness.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /*
+   * The report is about a form, not a component: the point of picking a colour
+   * is that "Label Color is required." goes away and the value reaches submit.
+   */
+  describe("through the Label form the bug was reported on", () => {
+    const LABEL_FIELDS: Fields<FormValues<Record<string, unknown>>> = [
+      {
+        field: { name: true },
+        title: "Name",
+        fieldType: FormFieldSchemaType.Text,
+        required: true,
+        dataTestId: "name",
+      },
+      {
+        field: { color: true },
+        title: "Label Color",
+        fieldType: FormFieldSchemaType.Color,
+        required: true,
+        placeholder: "Please select color for this label.",
+        dataTestId: "color-value",
+      },
+    ];
+
+    type RenderLabelFormFunction = (onSubmit: MockFunction) => ReactElement;
+
+    const renderLabelForm: RenderLabelFormFunction = (
+      onSubmit: MockFunction,
+    ): ReactElement => {
+      return (
+        <Modal title="Create New Label" onClose={getJestMockFunction()}>
+          <BasicForm
+            id="create-label"
+            fields={LABEL_FIELDS}
+            onSubmit={onSubmit}
+            submitButtonText="Create Label"
+          />
+        </Modal>
+      );
+    };
+
+    test("picking a colour clears the required error and submits the value", async () => {
+      const onSubmit: MockFunction = getJestMockFunction();
+
+      render(renderLabelForm(onSubmit));
+
+      fireEvent.change(screen.getByTestId("name"), {
+        target: { value: "WB Unit-BB" },
+      });
+
+      // The state the report ends in: blocked, with nowhere to go.
+      fireEvent.click(screen.getByRole("button", { name: /create label/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Label Color is required."),
+        ).toBeInTheDocument();
+      });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+
+      const popup: HTMLElement = openPicker();
+      const square: HTMLElement = getSaturationSquare(popup);
+
+      drag(square, { x: 20, y: 20 }, { x: 100, y: 60 });
+
+      await waitFor(() => {
+        expect(screen.queryByText("Label Color is required.")).toBeNull();
+      });
+
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: /create label/i }));
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+      });
+
+      const submitted: Record<string, unknown> = onSubmit.mock
+        .calls[0]![0] as Record<string, unknown>;
+
+      expect(submitted["name"]).toEqual("WB Unit-BB");
+      expect(submitted["color"]).toBeInstanceOf(Color);
+      expect((submitted["color"] as Color).toString()).toMatch(
+        /^#[0-9a-f]{6}$/i,
+      );
+    });
+  });
+});

--- a/Common/Tests/UI/Components/ModalPortalDismissal.test.tsx
+++ b/Common/Tests/UI/Components/ModalPortalDismissal.test.tsx
@@ -75,7 +75,25 @@ type PressFunction = (element: HTMLElement) => void;
 
 const press: PressFunction = (element: HTMLElement): void => {
   fireEvent.mouseDown(element);
+  fireEvent.mouseUp(element);
   fireEvent.click(element);
+};
+
+/*
+ * A press that begins on one element and ends on another. The browser reports
+ * the click against the nearest common ancestor of the two, which for anything
+ * inside the dialog is the backdrop layer itself — so the click alone cannot
+ * tell a drag from a dismissal, and the modal has to watch both ends.
+ */
+type DragPressFunction = (from: HTMLElement, to: HTMLElement) => void;
+
+const dragPress: DragPressFunction = (
+  from: HTMLElement,
+  to: HTMLElement,
+): void => {
+  fireEvent.mouseDown(from);
+  fireEvent.mouseUp(to);
+  fireEvent.click(getBackdropLayer().parentElement!);
 };
 
 interface PortalHarness {
@@ -467,6 +485,78 @@ describe("Modal dismissal and portalled dropdown menus", () => {
       expect(harness.onClose).not.toHaveBeenCalled();
 
       // The dialog is still dismissable the ordinary way.
+      press(getBackdropLayer());
+
+      expect(harness.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test("a press that starts on the backdrop and ends on the panel is a drag, not a dismissal", () => {
+      const harness: PortalHarness = renderInModal(<div>Modal content</div>);
+
+      /*
+       * Pressing outside and releasing inside — reaching for the backdrop,
+       * changing your mind, letting go over the form. The click lands on the
+       * backdrop layer either way, so before the modal tracked the release this
+       * discarded whatever had been typed.
+       */
+      dragPress(getBackdropLayer(), screen.getByText("Modal content"));
+
+      expect(harness.onClose).not.toHaveBeenCalled();
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+    });
+
+    test("a press that starts on the panel and ends on the backdrop is a drag too", () => {
+      const harness: PortalHarness = renderInModal(<div>Modal content</div>);
+
+      // Selecting text in the body and releasing past the panel edge.
+      dragPress(screen.getByText("Modal content"), getBackdropLayer());
+
+      expect(harness.onClose).not.toHaveBeenCalled();
+    });
+
+    test("a release on a portalled menu does not dismiss the dialog either", () => {
+      const harness: PortalHarness = renderInModal(
+        <div>
+          {createPortal(
+            <button type="button" data-testid="portalled-option">
+              pick me
+            </button>,
+            document.body,
+          )}
+        </div>,
+      );
+
+      dragPress(getBackdropLayer(), screen.getByTestId("portalled-option"));
+
+      expect(harness.onClose).not.toHaveBeenCalled();
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+    });
+
+    test("dismissing an open picker leaves the modal behind it standing", () => {
+      const harness: PortalHarness = renderInModal(
+        <ColorPicker
+          dataTestId="color-value"
+          placeholder="Pick a color"
+          onChange={jest.fn()}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("color-value"));
+      expect(screen.getByTestId("color-picker-popup")).toBeInTheDocument();
+
+      /*
+       * The popup covers a good part of the backdrop, so "click off it to put
+       * it away" is the obvious gesture — and one press used to close the
+       * picker and the form behind it together. Dismissal belongs to the
+       * topmost layer that is open.
+       */
+      press(getBackdropLayer());
+
+      expect(screen.queryByTestId("color-picker-popup")).toBeNull();
+      expect(harness.onClose).not.toHaveBeenCalled();
+      expect(screen.getByTestId("modal")).toBeInTheDocument();
+
+      // With the picker gone, the very next backdrop press dismisses as usual.
       press(getBackdropLayer());
 
       expect(harness.onClose).toHaveBeenCalledTimes(1);

--- a/Common/UI/Components/Forms/Fields/ColorPicker.tsx
+++ b/Common/UI/Components/Forms/Fields/ColorPicker.tsx
@@ -10,6 +10,7 @@ import React, {
   FunctionComponent,
   ReactElement,
   useEffect,
+  useId,
   useState,
 } from "react";
 import { createPortal } from "react-dom";
@@ -43,13 +44,19 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
     anchorRef,
     popupRef,
     isPopupOpen,
+    popupId,
     popupPosition,
     portalTarget,
+    onTriggerKeyDown,
     togglePopup,
   }: AnchoredFieldPopup = useAnchoredFieldPopup({
     popupMaxHeight: COLOR_PICKER_POPUP_MAX_HEIGHT_PX,
     popupWidth: COLOR_PICKER_POPUP_WIDTH_PX,
   });
+
+  const isInteractive: boolean = !props.readOnly && !props.disabled;
+  const generatedId: string = useId();
+  const errorId: string = `${generatedId}-color-picker-error`;
 
   const [isInitialValuesInitialized, setIsInitialValuesInitialized] =
     useState<boolean>(false);
@@ -79,20 +86,39 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
       >
         <div
           onClick={() => {
-            if (!props.readOnly) {
+            if (isInteractive) {
               togglePopup();
             }
           }}
+          aria-hidden="true"
           className="rounded h-5 w-5 border border-gray-200 cursor-pointer"
           style={{ backgroundColor: color.toString() }}
         ></div>
 
         <Input
           onClick={() => {
-            if (!props.readOnly) {
+            if (isInteractive) {
               togglePopup();
             }
           }}
+          /*
+           * The field is a trigger, not a text box: it is readOnly and its only
+           * job is to open the picker. Without this a keyboard user cannot
+           * reach the picker at all, which on a required colour - the Create
+           * Label form - means they cannot submit the form either.
+           */
+          onKeyDown={isInteractive ? onTriggerKeyDown : undefined}
+          ariaHasPopup="dialog"
+          ariaExpanded={isPopupOpen}
+          ariaControls={isPopupOpen ? popupId : undefined}
+          /*
+           * The message below belongs to the whole control rather than to this
+           * input, so it has to be pointed at explicitly - otherwise "Label
+           * Color is required." is on screen and nowhere in the accessibility
+           * tree, and a screen reader user is told only that the form failed.
+           */
+          ariaDescribedby={props.error ? errorId : undefined}
+          ariaInvalid={Boolean(props.error)}
           disabled={props.disabled}
           dataTestId={props.dataTestId}
           onBlur={props.onBlur}
@@ -113,16 +139,24 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
           onFocus={props.onFocus || undefined}
         />
         {color && !props.disabled && (
-          <Icon
-            icon={IconProp.Close}
-            className="text-gray-400 h-5 w-5 cursor-pointer hover:text-gray-600"
+          /*
+           * A button, not a bare svg with a click handler: undoing a choice has
+           * to be reachable by the same keyboard that made it.
+           */
+          <button
+            type="button"
+            aria-label="Clear color"
+            title="Clear color"
+            className="flex items-center text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
             onClick={() => {
               setColor("");
               if (props.onChange) {
                 props.onChange(null);
               }
             }}
-          />
+          >
+            <Icon icon={IconProp.Close} className="h-5 w-5 cursor-pointer" />
+          </button>
         )}
       </div>
       {/*
@@ -134,6 +168,9 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
             <div
               ref={popupRef}
               data-testid="color-picker-popup"
+              id={popupId}
+              role="dialog"
+              aria-label="Color picker"
               tabIndex={-1}
               className="fixed overflow-auto rounded-md shadow-lg"
               style={{
@@ -147,10 +184,24 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
             >
               <ChromePicker
                 color={color}
+                /*
+                 * The field stores a bare hex, so an alpha channel it cannot
+                 * represent is worse than no alpha at all: react-color reports
+                 * a fully transparent colour as the literal "transparent",
+                 * which sails through Color (it validates nothing) and is then
+                 * rejected on save as longer than the ten characters the column
+                 * holds - for a colour the user can see in the swatch.
+                 */
+                disableAlpha={true}
+                /*
+                 * One callback, not two. The swatch used to be painted from
+                 * onChange and the form fed from onChangeComplete, which
+                 * react-color debounces by 100ms — so for that window the field
+                 * showed a colour the form did not hold yet. The value always
+                 * arrived in the end, but there is no reason for the two to
+                 * disagree at all.
+                 */
                 onChange={(color: ColorResult) => {
-                  setColor(color.hex);
-                }}
-                onChangeComplete={(color: ColorResult) => {
                   return handleChange(color.hex);
                 }}
               />
@@ -159,7 +210,12 @@ const ColorPicker: FunctionComponent<ComponentProps> = (
           )
         : null}
       {props.error && (
-        <p data-testid="error-message" className="mt-1 text-sm text-red-400">
+        <p
+          id={errorId}
+          role="alert"
+          data-testid="error-message"
+          className="mt-1 text-sm text-red-400"
+        >
           {props.error}
         </p>
       )}

--- a/Common/UI/Components/Forms/Fields/IconPicker.tsx
+++ b/Common/UI/Components/Forms/Fields/IconPicker.tsx
@@ -9,6 +9,7 @@ import React, {
   FunctionComponent,
   ReactElement,
   useEffect,
+  useId,
   useState,
 } from "react";
 import { createPortal } from "react-dom";
@@ -41,14 +42,20 @@ const IconPicker: FunctionComponent<ComponentProps> = (
     anchorRef,
     popupRef,
     isPopupOpen,
+    popupId,
     popupPosition,
     portalTarget,
     closePopup,
+    onTriggerKeyDown,
     togglePopup,
   }: AnchoredFieldPopup = useAnchoredFieldPopup({
     popupMaxHeight: ICON_PICKER_POPUP_MAX_HEIGHT_PX,
     popupWidth: ICON_PICKER_POPUP_WIDTH_PX,
   });
+
+  const isInteractive: boolean = !props.readOnly && !props.disabled;
+  const generatedId: string = useId();
+  const errorId: string = `${generatedId}-icon-picker-error`;
 
   const [isInitialValuesInitialized, setIsInitialValuesInitialized] =
     useState<boolean>(false);
@@ -84,10 +91,11 @@ const IconPicker: FunctionComponent<ComponentProps> = (
       >
         <div
           onClick={() => {
-            if (!props.readOnly && !props.disabled) {
+            if (isInteractive) {
               togglePopup();
             }
           }}
+          aria-hidden="true"
           className="flex items-center justify-center h-5 w-5 cursor-pointer"
         >
           {selectedIcon ? (
@@ -99,10 +107,18 @@ const IconPicker: FunctionComponent<ComponentProps> = (
 
         <Input
           onClick={() => {
-            if (!props.readOnly && !props.disabled) {
+            if (isInteractive) {
               togglePopup();
             }
           }}
+          // The field is a trigger, not a text box - see ColorPicker.
+          onKeyDown={isInteractive ? onTriggerKeyDown : undefined}
+          ariaHasPopup="dialog"
+          ariaExpanded={isPopupOpen}
+          ariaControls={isPopupOpen ? popupId : undefined}
+          // The message below belongs to the control, not to this input.
+          ariaDescribedby={props.error ? errorId : undefined}
+          ariaInvalid={Boolean(props.error)}
           disabled={props.disabled}
           dataTestId={props.dataTestId}
           onBlur={props.onBlur}
@@ -119,14 +135,19 @@ const IconPicker: FunctionComponent<ComponentProps> = (
           onFocus={props.onFocus || undefined}
         />
         {selectedIcon && !props.disabled && (
-          <Icon
-            icon={IconProp.Close}
-            className="text-gray-400 h-5 w-5 cursor-pointer hover:text-gray-600"
+          // A button, not a bare svg with a click handler - see ColorPicker.
+          <button
+            type="button"
+            aria-label="Clear icon"
+            title="Clear icon"
+            className="flex items-center text-gray-400 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
             onClick={() => {
               setSelectedIcon(null);
               props.onChange(null);
             }}
-          />
+          >
+            <Icon icon={IconProp.Close} className="h-5 w-5 cursor-pointer" />
+          </button>
         )}
       </div>
       {/*
@@ -138,6 +159,9 @@ const IconPicker: FunctionComponent<ComponentProps> = (
             <div
               ref={popupRef}
               data-testid="icon-picker-popup"
+              id={popupId}
+              role="dialog"
+              aria-label="Icon picker"
               tabIndex={-1}
               className="fixed flex flex-col overflow-hidden bg-white border border-gray-200 rounded-lg shadow-lg p-3"
               style={{
@@ -166,13 +190,22 @@ const IconPicker: FunctionComponent<ComponentProps> = (
               {/* Icons grid */}
               <div className="grid grid-cols-6 gap-2 min-h-0 flex-1 overflow-y-auto">
                 {filteredIcons.map((icon: IconProp) => {
+                  /*
+                   * A button rather than a div: the grid is the only way to set
+                   * this field, so every cell has to be reachable by Tab and
+                   * answer to Enter and Space. type="button" keeps it from
+                   * submitting the form the field sits in.
+                   */
                   return (
-                    <div
+                    <button
                       key={icon}
+                      type="button"
                       onClick={() => {
                         handleChange(icon);
                       }}
-                      className={`flex items-center justify-center p-2 rounded cursor-pointer hover:bg-gray-100 ${
+                      aria-pressed={selectedIcon === icon}
+                      aria-label={icon}
+                      className={`flex items-center justify-center p-2 rounded cursor-pointer hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
                         selectedIcon === icon
                           ? "bg-indigo-100 ring-2 ring-indigo-500"
                           : ""
@@ -180,7 +213,7 @@ const IconPicker: FunctionComponent<ComponentProps> = (
                       title={icon}
                     >
                       <Icon icon={icon} className="h-5 w-5 text-gray-600" />
-                    </div>
+                    </button>
                   );
                 })}
               </div>
@@ -195,7 +228,12 @@ const IconPicker: FunctionComponent<ComponentProps> = (
           )
         : null}
       {props.error && (
-        <p data-testid="error-message" className="mt-1 text-sm text-red-400">
+        <p
+          id={errorId}
+          role="alert"
+          data-testid="error-message"
+          className="mt-1 text-sm text-red-400"
+        >
           {props.error}
         </p>
       )}

--- a/Common/UI/Components/Input/Input.tsx
+++ b/Common/UI/Components/Input/Input.tsx
@@ -25,7 +25,20 @@ export interface ComponentProps {
   initialValue?: undefined | string | Date;
   id?: string | undefined;
   ariaLabelledby?: string | undefined;
+  // Set together by fields that open a popup, so the state is on the focusable element.
+  ariaHasPopup?: "dialog" | "listbox" | "menu" | "grid" | "tree" | undefined;
+  ariaExpanded?: boolean | undefined;
+  ariaControls?: string | undefined;
+  /*
+   * For fields that render their own error text - a picker whose message sits
+   * below the whole control rather than below this input.
+   */
+  ariaDescribedby?: string | undefined;
+  ariaInvalid?: boolean | undefined;
   onClick?: undefined | (() => void);
+  onKeyDown?:
+    | undefined
+    | ((event: React.KeyboardEvent<HTMLInputElement>) => void);
   placeholder?: undefined | string;
   className?: undefined | string;
   onChange?: undefined | ((value: string) => void);
@@ -164,8 +177,13 @@ const Input: FunctionComponent<ComponentProps> = (
           spellCheck={!props.disableSpellCheck}
           autoComplete={props.autoComplete}
           aria-labelledby={props.ariaLabelledby}
-          aria-invalid={props.error ? "true" : undefined}
-          aria-describedby={props.error ? "input-error-message" : undefined}
+          aria-haspopup={props.ariaHasPopup}
+          aria-expanded={props.ariaExpanded}
+          aria-controls={props.ariaControls}
+          aria-invalid={props.error || props.ariaInvalid ? "true" : undefined}
+          aria-describedby={
+            props.error ? "input-error-message" : props.ariaDescribedby
+          }
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             const value: string | Date = e.target.value;
 
@@ -194,8 +212,18 @@ const Input: FunctionComponent<ComponentProps> = (
           }}
           tabIndex={props.tabIndex}
           onKeyDown={
-            props.onEnterPress
+            props.onEnterPress || props.onKeyDown
               ? (event: React.KeyboardEvent<HTMLInputElement>) => {
+                  props.onKeyDown?.(event);
+
+                  /*
+                   * A handler that claimed the key - a picker opening its popup
+                   * on Enter, say - has already decided what it means.
+                   */
+                  if (event.defaultPrevented) {
+                    return;
+                  }
+
                   if (event.key === "Enter") {
                     props.onEnterPress?.();
                   }

--- a/Common/UI/Components/Modal/Modal.tsx
+++ b/Common/UI/Components/Modal/Modal.tsx
@@ -7,6 +7,7 @@ import ModalFooter from "./ModalFooter";
 import { VeryLightGray } from "../../../Types/BrandColors";
 import IconProp from "../../../Types/Icon/IconProp";
 import useTranslateValue from "../../Utils/Translation";
+import { wasPressConsumedByAnAnchoredPopup } from "../../Types/LayeredDismissal";
 import { lockPageScroll, unlockPageScroll } from "../../Utils/PageScrollLock";
 import React, {
   FunctionComponent,
@@ -77,6 +78,8 @@ const Modal: FunctionComponent<ComponentProps> = (
     (() => void) | undefined
   >(props.onClose);
   const backdropPressStartedOutsideRef: React.MutableRefObject<boolean> =
+    useRef<boolean>(false);
+  const backdropPressEndedInsideRef: React.MutableRefObject<boolean> =
     useRef<boolean>(false);
   const titleId: string = useId();
   const descriptionId: string = useId();
@@ -332,25 +335,54 @@ const Modal: FunctionComponent<ComponentProps> = (
   const onBackdropMouseDown: BackdropPressHandler = (
     event: React.MouseEvent<HTMLDivElement>,
   ): void => {
+    backdropPressEndedInsideRef.current = false;
+
+    /*
+     * A press that a portalled popup has already spent on closing itself is
+     * not a dismissal of this dialog. Without this, clicking the backdrop to
+     * put away an open colour picker closed the picker and the form behind it
+     * in one go.
+     */
+    if (wasPressConsumedByAnAnchoredPopup(event.nativeEvent)) {
+      backdropPressStartedOutsideRef.current = false;
+      return;
+    }
+
     backdropPressStartedOutsideRef.current = isEventOutsideModal(event);
+  };
+
+  const onBackdropMouseUp: BackdropPressHandler = (
+    event: React.MouseEvent<HTMLDivElement>,
+  ): void => {
+    /*
+     * The click that follows is reported against the nearest common ancestor
+     * of press and release — this very layer — so by the time it arrives the
+     * two ends are indistinguishable. Where the release landed has to be
+     * recorded while it is still known.
+     */
+    backdropPressEndedInsideRef.current = !isEventOutsideModal(event);
   };
 
   const onBackdropClick: BackdropPressHandler = (
     event: React.MouseEvent<HTMLDivElement>,
   ): void => {
     /*
-     * Both ends of the click have to land on the backdrop. Selecting text in
-     * the body and releasing the mouse past the edge of the panel is a drag,
-     * not a dismissal, and it used to be the fastest way to lose a filled-in
-     * form.
+     * Both ends of the click have to land on the backdrop. A press that
+     * wandered across the edge of the panel in either direction is a drag —
+     * selecting text in the body and releasing outside, or pressing outside and
+     * releasing on the panel — and either used to be the fastest way to lose a
+     * filled-in form.
      */
     const pressStartedOutside: boolean = backdropPressStartedOutsideRef.current;
+    const pressEndedInside: boolean = backdropPressEndedInsideRef.current;
     backdropPressStartedOutsideRef.current = false;
+    backdropPressEndedInsideRef.current = false;
 
     if (
       props.disableCloseOnBackdropClick ||
       !props.onClose ||
       !pressStartedOutside ||
+      pressEndedInside ||
       !isEventOutsideModal(event) ||
       !isTopmostDialog()
     ) {
@@ -391,6 +423,7 @@ const Modal: FunctionComponent<ComponentProps> = (
       <div
         className="fixed inset-0 z-50 overflow-y-auto"
         onMouseDown={onBackdropMouseDown}
+        onMouseUp={onBackdropMouseUp}
         onClick={onBackdropClick}
       >
         <div className="flex min-h-full items-end justify-center p-0 text-center sm:items-center sm:p-6">

--- a/Common/UI/Types/LayeredDismissal.ts
+++ b/Common/UI/Types/LayeredDismissal.ts
@@ -1,0 +1,31 @@
+/*
+ * Dismissal belongs to the topmost layer that is open.
+ *
+ * A colour picker, an icon grid or an autocomplete menu inside a modal is
+ * portalled to document.body so the modal body cannot clip it, and it closes
+ * itself on a press that lands anywhere else. Very often "anywhere else" is the
+ * modal's own backdrop, which reads the same press as a dismissal of the whole
+ * dialog - so one click aimed at the popup takes the half-filled form with it.
+ *
+ * A popup that consumes a press records it here, and the backdrop skips any
+ * press it finds. The set is keyed on the native event object and holds it
+ * weakly, so nothing outlives the press it describes.
+ */
+
+const pressesConsumedByAnAnchoredPopup: WeakSet<Event> = new WeakSet<Event>();
+
+export type ConsumePressFunction = (event: Event) => void;
+
+export const consumePressForAnchoredPopup: ConsumePressFunction = (
+  event: Event,
+): void => {
+  pressesConsumedByAnAnchoredPopup.add(event);
+};
+
+export type WasPressConsumedFunction = (event: Event) => boolean;
+
+export const wasPressConsumedByAnAnchoredPopup: WasPressConsumedFunction = (
+  event: Event,
+): boolean => {
+  return pressesConsumedByAnAnchoredPopup.has(event);
+};

--- a/Common/UI/Types/UseAnchoredFieldPopup.ts
+++ b/Common/UI/Types/UseAnchoredFieldPopup.ts
@@ -1,6 +1,8 @@
+import { consumePressForAnchoredPopup } from "./LayeredDismissal";
 import React, {
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useRef,
   useState,
@@ -44,9 +46,25 @@ export interface AnchoredFieldPopup {
   isPopupOpen: boolean;
   popupPosition: AnchoredFieldPopupPosition | null;
   portalTarget: HTMLElement | null;
+  popupId: string;
   closePopup: (shouldReturnFocus?: boolean) => void;
   togglePopup: () => void;
+  // Opens the popup from a trigger's keyboard, and moves focus into it.
+  onTriggerKeyDown: (event: React.KeyboardEvent) => void;
 }
+
+/*
+ * The keys that open a popup from its trigger. ArrowDown/ArrowUp match the
+ * listbox convention every other menu in this codebase follows; Enter and Space
+ * are what a button-shaped control is expected to answer to.
+ */
+const POPUP_OPENING_KEYS: Array<string> = [
+  "Enter",
+  " ",
+  "Spacebar",
+  "ArrowDown",
+  "ArrowUp",
+];
 
 type GetFocusableElementsFunction = (
   container: HTMLElement,
@@ -83,6 +101,27 @@ const useAnchoredFieldPopup: UseAnchoredFieldPopupFunction = (
   const popupRef: React.MutableRefObject<HTMLDivElement | null> =
     useRef<HTMLDivElement | null>(null);
 
+  const popupId: string = useId();
+
+  /*
+   * A pointer user wants the popup to appear under the field and their pointer
+   * to stay where it is. A keyboard user has no other way in, so opening from
+   * the keyboard hands focus to the popup's first control - the hex box for a
+   * colour, the search box for an icon.
+   */
+  const shouldMoveFocusIntoPopupRef: React.MutableRefObject<boolean> =
+    useRef<boolean>(false);
+
+  const focusPopup: () => void = useCallback((): void => {
+    const popup: HTMLDivElement | null = popupRef.current;
+
+    if (!popup) {
+      return;
+    }
+
+    (getFocusableElements(popup)[0] || popup).focus();
+  }, []);
+
   const closePopup: (shouldReturnFocus?: boolean) => void = useCallback(
     (shouldReturnFocus?: boolean): void => {
       setIsPopupOpen(false);
@@ -114,6 +153,58 @@ const useAnchoredFieldPopup: UseAnchoredFieldPopupFunction = (
       return !isOpen;
     });
   }, []);
+
+  const openPopup: (shouldMoveFocusIntoPopup?: boolean) => void = useCallback(
+    (shouldMoveFocusIntoPopup?: boolean): void => {
+      shouldMoveFocusIntoPopupRef.current = Boolean(shouldMoveFocusIntoPopup);
+      setIsPopupOpen(true);
+    },
+    [],
+  );
+
+  const onTriggerKeyDown: (event: React.KeyboardEvent) => void = useCallback(
+    (event: React.KeyboardEvent): void => {
+      if (event.defaultPrevented || !POPUP_OPENING_KEYS.includes(event.key)) {
+        return;
+      }
+
+      /*
+       * The key opened the popup and means nothing else after that: Input's
+       * own onEnterPress stands down on a defaultPrevented event, and a
+       * trigger placed inside a real <form> - which nothing about Input
+       * prevents, even though this codebase's forms are not form elements -
+       * would otherwise submit it on the way past.
+       */
+      event.preventDefault();
+
+      if (isPopupOpen) {
+        focusPopup();
+        return;
+      }
+
+      openPopup(true);
+    },
+    [isPopupOpen, focusPopup, openPopup],
+  );
+
+  /*
+   * Waits for a measured position, not just for the open flag: until then the
+   * popup is `visibility: hidden` so it cannot flash at the top left corner,
+   * and a hidden element refuses focus. jsdom has no such scruples, so this
+   * ordering only shows itself in a browser.
+   */
+  useEffect(() => {
+    if (
+      !isPopupOpen ||
+      !popupPosition ||
+      !shouldMoveFocusIntoPopupRef.current
+    ) {
+      return;
+    }
+
+    shouldMoveFocusIntoPopupRef.current = false;
+    focusPopup();
+  }, [isPopupOpen, popupPosition, focusPopup]);
 
   const updatePopupPosition: () => void = useCallback((): void => {
     if (!anchorRef.current || typeof window === "undefined") {
@@ -222,6 +313,12 @@ const useAnchoredFieldPopup: UseAnchoredFieldPopupFunction = (
         return;
       }
 
+      /*
+       * This press is spent on closing the popup. Claiming it stops the modal
+       * underneath from reading the same press as a backdrop dismissal and
+       * throwing the form away along with the picker.
+       */
+      consumePressForAnchoredPopup(event);
       closePopup(false);
     };
 
@@ -311,6 +408,8 @@ const useAnchoredFieldPopup: UseAnchoredFieldPopupFunction = (
     anchorRef,
     closePopup,
     isPopupOpen,
+    onTriggerKeyDown,
+    popupId,
     popupPosition,
     popupRef,
     portalTarget: typeof document === "undefined" ? null : document.body,


### PR DESCRIPTION
Fixes #3143.

## What the report shows, and what is already fixed

The video attached to the issue is a modal-dismissal bug, not a colour-picker bug: the picker
opens fine, the user drags across the saturation square, and on release the whole **Create New
Label** modal unmounts with the form in it.

ColorPicker portals its popup to `document.body` so the modal body cannot clip it, and React
dispatches synthetic events through the *React* tree rather than the DOM tree — so a press inside
that popup still reached `Modal`'s backdrop handler, which read "not a DOM descendant of the panel"
as "outside" and closed the dialog. That is #3133, fixed on master in 0b961b31c6 the day before
this issue was filed.

I confirmed it rather than assuming: built a Chrome harness around the real `Modal` +
`ColorPicker`, checked out `Modal.tsx` at `0b961b31c6^`, and reproduced the report exactly — the
saturation drag fires `onClose`. On master it does not. The screenshots also show the modal styling
from e75351d783 (two days earlier), so **the reported build sits in the window between the two
commits**; anyone seeing this on a current build should say so on the issue, because that would be
a different bug from the one I reproduced.

So this PR does two things: it pins that flow down with tests that actually exercise it, and it
fixes what is *still* broken on the same form.

## Still broken on master

**The required colour cannot be set from a keyboard at all.** The field is a `readOnly` input whose
only behaviour is `onClick`. No `role`, no `aria-haspopup`, no `aria-expanded`, and every key dead —
I verified this in Chrome before changing anything. That is the issue's "there's currently no way to
create a new label at all through this path", still literally true for anyone not using a mouse.
`IconPicker` shares the hook and had the same hole, plus a grid of `<div>`s that `Tab` skips.

(I first wrote this up as "and `Enter` implicitly submits the form" — it does not. `BasicForm`
renders no `<form>` element anywhere in this stack, so `Enter` did nothing at all rather than
something wrong. The opening keys still call `preventDefault`, so that `Input`'s own `onEnterPress`
stands down and a trigger dropped inside a real `<form>` later cannot submit it.)

**The alpha slider can produce a value the column cannot hold.** react-color reports a fully
transparent colour as the literal string `"transparent"`. `Color` validates nothing, so it reaches
the form, and `Label.color` holds ten characters — the save is then rejected for a colour the user
can see in the swatch. The field stores a bare hex; an alpha channel it cannot represent is worse
than none.

**The field and the form disagreed for 100ms.** The swatch was painted from react-color's
`onChange` and the form fed from `onChangeComplete`, which react-color debounces internally. The
value always arrived in the end and I could not construct a submit path fast enough to observe the
gap, so this is tidying rather than a user-facing bug — but there is no reason for the two to
disagree at all, and one callback is simpler than two.

**"Label Color is required." was never announced.** The message rendered below the control with
nothing tying it to the input, so a screen reader user was told only that the form failed.

**Two more ways to lose the form to the backdrop** (found by an adversarial audit of this flow,
both reproduced in Chrome):

- A press that starts on the backdrop and ends *inside* the panel dismissed the dialog. The comment
  in `Modal` claims both ends have to land on the backdrop, but only the start was checked — the
  click is reported against the common ancestor of press and release, which is the backdrop layer
  itself, so the click alone cannot tell a drag from a dismissal.
- With a picker open, one backdrop press closed the picker *and* the modal. The popup covers a good
  part of the backdrop, so "click off it to put it away" is the obvious gesture, and it cost you the
  form. Dismissal now belongs to the topmost layer that is open.

## Changes

- `UseAnchoredFieldPopup` — `onTriggerKeyDown` opens the popup on Enter/Space/ArrowDown/ArrowUp,
  claims the key so nothing downstream acts on it too, and moves focus to the popup's first control (the
  hex box for a colour, the search box for an icon). Focus waits for a measured position, since the
  popup is `visibility: hidden` until then and a hidden element refuses focus — a browser-only
  ordering that jsdom does not reproduce. A popup that consumes an outside press records it.
- `LayeredDismissal` (new) — a WeakSet of presses an anchored popup has already spent, so the
  backdrop can skip them.
- `Modal` — tracks where a press *ends*, not just where it starts, and ignores presses an anchored
  popup consumed.
- `ColorPicker` / `IconPicker` — keyboard trigger, `aria-haspopup`/`aria-expanded`/`aria-controls`,
  `role="dialog"` + a name on the popup, the error text wired to the field with
  `aria-describedby`/`aria-invalid`/`role="alert"`, and the clear "×" promoted from a bare `svg` to
  a real button. ColorPicker also drops the alpha slider and reports on `onChange`. IconPicker's
  grid cells are buttons.
- `Input` — passes through `onKeyDown` and the popup/description ARIA attributes, so the state sits
  on the focusable element. A handler that calls `preventDefault` takes precedence over
  `onEnterPress`.

## Tests

`Common/Tests/UI/Components/Forms/ColorPickerPicking.test.tsx` (new) drives the real `ChromePicker`
through the reported gesture — mousedown on the saturation square, mousemove and mouseup on window,
then the click — which is a different event sequence from the existing coverage (that presses the
hex box, and a click-only test passes even with the bug fully present). Also the hue strip, a drag
that leaves the popup and releases over the backdrop, the value landing in the same tick the field
shows it, the absent alpha channel, the error wiring, and the whole thing through `BasicForm` with
the Label fields: blocked on "Label Color is required.", pick a colour, submit, assert the value.

`Common/Tests/UI/Components/Forms/AnchoredFieldPopupKeyboard.test.tsx` (new) covers each opening key
for both pickers, focus landing in the popup, the end-to-end keyboard path (open, type a hex,
Escape, value kept), the opening keys being claimed, readOnly/disabled staying shut, and the ARIA
contract.

`ModalPortalDismissal.test.tsx` gains the two drag directions, a release on a portalled menu, and
the layered-dismissal case; its `press` helper now fires `mouseup` as well, which is what a browser
does.

jsdom does not populate `pageX`/`pageY` on `MouseEvent` and react-color reads exactly those, so the
picking tests define them from the client coordinates — without that, react-color throws before it
can compute a colour and nothing downstream is testable.
