### PR TITLE
docs: restore Cons label eaten by a regex backreference in 14 locales

### DIFF
--- a/App/FeatureSet/Docs/Content/da/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/da/monitor/kubernetes-agent.md
@@ -80,7 +80,7 @@ En DaemonSet kører én OpenTelemetry Collector-pod pr. node. Den læser logfile
 En Deployment med én replika (`oneuptime/kubernetes-log-tailer`-imaget) bruger Kubernetes API'en til at streame container-logs — det samme endpoint, som `kubectl logs -f` bruger. Ingen hostPath, ingen værtsadgang, ingen DaemonSet.
 
 - **Fordele:** virker på GKE Autopilot, EKS Fargate og enhver klynge, der blokerer hostPath eller håndhæver `restricted` Pod Security Standard.
-$1 hver containerstream er en langvarig forbindelse til kube-apiserver. Én replika håndterer normalt nogle få tusinde containere. For meget store klynger skal du opdele separate releases med podLogs-scopede include-regler i namespaceFilters.rules.
+- **Ulemper:** hver containerstream er en langvarig forbindelse til kube-apiserver. Én replika håndterer normalt nogle få tusinde containere. For meget store klynger skal du opdele separate releases med podLogs-scopede include-regler i namespaceFilters.rules.
 
 ### Hvilken bør du bruge?
 

--- a/App/FeatureSet/Docs/Content/de/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/de/monitor/kubernetes-agent.md
@@ -80,7 +80,7 @@ Ein DaemonSet betreibt einen OpenTelemetry-Collector-Pod pro Node. Es liest Log-
 Ein Deployment mit einer einzelnen Replik (das `oneuptime/kubernetes-log-tailer`-Image) nutzt die Kubernetes-API, um Container-Logs zu streamen — derselbe Endpunkt, den `kubectl logs -f` verwendet. Kein hostPath, kein Host-Zugriff, kein DaemonSet.
 
 - **Vorteile:** funktioniert auf GKE Autopilot, EKS Fargate und jedem Cluster, der hostPath blockiert oder den `restricted`-Pod-Security-Standard erzwingt.
-$1 Jeder Container-Stream ist eine langlebige Verbindung zu kube-apiserver. Eine Replik bewältigt in der Praxis einige Tausend Container. Teilen Sie bei sehr großen Clustern separate Releases mit podLogs-bezogenen include-Regeln in namespaceFilters.rules auf.
+- **Nachteile:** Jeder Container-Stream ist eine langlebige Verbindung zu kube-apiserver. Eine Replik bewältigt in der Praxis einige Tausend Container. Teilen Sie bei sehr großen Clustern separate Releases mit podLogs-bezogenen include-Regeln in namespaceFilters.rules auf.
 
 ### Welchen sollten Sie verwenden?
 

--- a/App/FeatureSet/Docs/Content/es/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/es/monitor/kubernetes-agent.md
@@ -80,7 +80,7 @@ Un DaemonSet ejecuta un pod del OpenTelemetry Collector por nodo. Lee archivos d
 Un Deployment de una sola réplica (la imagen `oneuptime/kubernetes-log-tailer`) usa la API de Kubernetes para transmitir los registros de los contenedores — el mismo endpoint que usa `kubectl logs -f`. Sin hostPath, sin acceso al host, sin DaemonSet.
 
 - **Pros:** funciona en GKE Autopilot, EKS Fargate y cualquier clúster que bloquee hostPath o aplique el Pod Security Standard `restricted`.
-$1 Cada flujo de contenedor es una conexión de larga duración a kube-apiserver. Una réplica maneja cómodamente unos miles de contenedores. En clústeres muy grandes, divida versiones independientes con reglas include de ámbito podLogs en namespaceFilters.rules.
+- **Contras:** Cada flujo de contenedor es una conexión de larga duración a kube-apiserver. Una réplica maneja cómodamente unos miles de contenedores. En clústeres muy grandes, divida versiones independientes con reglas include de ámbito podLogs en namespaceFilters.rules.
 
 ### ¿Cuál debería usar?
 

--- a/App/FeatureSet/Docs/Content/fr/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/fr/monitor/kubernetes-agent.md
@@ -80,7 +80,7 @@ Un DaemonSet exécute un pod OpenTelemetry Collector par nœud. Il lit les fichi
 Un Deployment à réplique unique (l'image `oneuptime/kubernetes-log-tailer`) utilise l'API Kubernetes pour diffuser les logs des conteneurs — le même endpoint que `kubectl logs -f` utilise. Pas de hostPath, pas d'accès à l'hôte, pas de DaemonSet.
 
 - **Avantages :** fonctionne sur GKE Autopilot, EKS Fargate et tout cluster qui bloque hostPath ou applique le Pod Security Standard `restricted`.
-$1 Chaque flux de conteneur est une connexion de longue durée à kube-apiserver. Une réplique gère confortablement quelques milliers de conteneurs. Pour les très grands clusters, répartissez des releases distinctes avec des règles include de portée podLogs dans namespaceFilters.rules.
+- **Inconvénients :** Chaque flux de conteneur est une connexion de longue durée à kube-apiserver. Une réplique gère confortablement quelques milliers de conteneurs. Pour les très grands clusters, répartissez des releases distinctes avec des règles include de portée podLogs dans namespaceFilters.rules.
 
 ### Lequel devez-vous utiliser ?
 

--- a/App/FeatureSet/Docs/Content/hi/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/hi/monitor/kubernetes-agent.md
@@ -80,7 +80,7 @@ helm install oneuptime-agent oneuptime/kubernetes-agent \
 एकल-रेप्लिका Deployment (`oneuptime/kubernetes-log-tailer` इमेज) कंटेनर लॉग्स को स्ट्रीम करने के लिए Kubernetes API का उपयोग करता है — वही एंडपॉइंट जो `kubectl logs -f` उपयोग करता है। कोई hostPath नहीं, कोई होस्ट एक्सेस नहीं, कोई DaemonSet नहीं।
 
 - **फ़ायदे:** GKE Autopilot, EKS Fargate, और किसी भी क्लस्टर पर काम करता है जो hostPath को ब्लॉक करता है या `restricted` Pod Security Standard को लागू करता है।
-$1 हर कंटेनर स्ट्रीम kube-apiserver से लंबे समय तक चलने वाला कनेक्शन है। एक रेप्लिका सामान्यतः कुछ हज़ार कंटेनर संभालती है। बहुत बड़े क्लस्टर के लिए namespaceFilters.rules में podLogs स्कोप वाले include नियमों के साथ अलग-अलग रिलीज़ शार्ड करें।
+- **नुकसान:** हर कंटेनर स्ट्रीम kube-apiserver से लंबे समय तक चलने वाला कनेक्शन है। एक रेप्लिका सामान्यतः कुछ हज़ार कंटेनर संभालती है। बहुत बड़े क्लस्टर के लिए namespaceFilters.rules में podLogs स्कोप वाले include नियमों के साथ अलग-अलग रिलीज़ शार्ड करें।
 
 ### आपको कौन सा उपयोग करना चाहिए?
 

--- a/App/FeatureSet/Docs/Content/it/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/it/monitor/kubernetes-agent.md
@@ -80,7 +80,7 @@ Un DaemonSet esegue un pod OpenTelemetry Collector per nodo. Esso segue i file d
 Un Deployment a replica singola (l'immagine `oneuptime/kubernetes-log-tailer`) utilizza l'API di Kubernetes per trasmettere in streaming i log dei container — lo stesso endpoint utilizzato da `kubectl logs -f`. Nessun hostPath, nessun accesso all'host, nessun DaemonSet.
 
 - **Vantaggi:** funziona su GKE Autopilot, EKS Fargate e qualsiasi cluster che blocchi hostPath o imponga il Pod Security Standard `restricted`.
-$1 Ogni stream di container è una connessione di lunga durata a kube-apiserver. Una replica gestisce normalmente alcune migliaia di container. Nei cluster molto grandi, suddividi release separate con regole include di ambito podLogs in namespaceFilters.rules.
+- **Svantaggi:** Ogni stream di container è una connessione di lunga durata a kube-apiserver. Una replica gestisce normalmente alcune migliaia di container. Nei cluster molto grandi, suddividi release separate con regole include di ambito podLogs in namespaceFilters.rules.
 
 ### Quale dovreste usare?
 

--- a/App/FeatureSet/Docs/Content/ja/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/ja/monitor/kubernetes-agent.md
@@ -80,7 +80,7 @@ DaemonSet がノードごとに 1 つの OpenTelemetry Collector pod を実行�
 シングルレプリカの Deployment(`oneuptime/kubernetes-log-tailer` イメージ)が Kubernetes API を使用してコンテナログをストリーミングします。これは `kubectl logs -f` が使用するのと同じエンドポイントです。hostPath、ホストアクセス、DaemonSet はいずれも不要です。
 
 - **長所:** GKE Autopilot、EKS Fargate、および hostPath をブロックしたり `restricted` Pod Security Standard を強制したりするあらゆるクラスターで動作します。
-$1 各コンテナストリームはkube-apiserverへの長時間接続です。通常、1つのレプリカで数千のコンテナを処理できます。非常に大きなクラスタでは、namespaceFilters.rulesのpodLogsスコープ付きincludeルールでリリースを分けてシャーディングしてください。
+- **短所:** 各コンテナストリームはkube-apiserverへの長時間接続です。通常、1つのレプリカで数千のコンテナを処理できます。非常に大きなクラスタでは、namespaceFilters.rulesのpodLogsスコープ付きincludeルールでリリースを分けてシャーディングしてください。
 
 ### どちらを使うべきか?
 

--- a/App/FeatureSet/Docs/Content/ko/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/ko/monitor/kubernetes-agent.md
@@ -80,7 +80,7 @@ DaemonSet은 노드당 하나의 OpenTelemetry Collector 파드를 실행합니�
 단일 복제본 Deployment(`oneuptime/kubernetes-log-tailer` 이미지)가 Kubernetes API를 사용하여 컨테이너 로그를 스트리밍합니다 — `kubectl logs -f`가 사용하는 것과 동일한 엔드포인트입니다. hostPath도, 호스트 액세스도, DaemonSet도 필요 없습니다.
 
 - **장점:** GKE Autopilot, EKS Fargate 및 hostPath를 차단하거나 `restricted` Pod Security Standard를 적용하는 모든 클러스터에서 작동합니다.
-$1 각 컨테이너 스트림은 kube-apiserver에 대한 장기 연결입니다. 일반적으로 복제본 하나가 수천 개의 컨테이너를 처리합니다. 매우 큰 클러스터에서는 namespaceFilters.rules의 podLogs 범위 include 규칙으로 별도 릴리스를 샤딩하세요.
+- **단점:** 각 컨테이너 스트림은 kube-apiserver에 대한 장기 연결입니다. 일반적으로 복제본 하나가 수천 개의 컨테이너를 처리합니다. 매우 큰 클러스터에서는 namespaceFilters.rules의 podLogs 범위 include 규칙으로 별도 릴리스를 샤딩하세요.
 
 ### 어느 것을 사용해야 하나요?
 

--- a/App/FeatureSet/Docs/Content/nl/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/nl/monitor/kubernetes-agent.md
@@ -80,7 +80,7 @@ Een DaemonSet draait één OpenTelemetry Collector-pod per node. Hij leest logbe
 Een Deployment met één replica (de `oneuptime/kubernetes-log-tailer`-image) gebruikt de Kubernetes API om container-logboeken te streamen — hetzelfde endpoint dat `kubectl logs -f` gebruikt. Geen hostPath, geen host-toegang, geen DaemonSet.
 
 - **Voordelen:** werkt op GKE Autopilot, EKS Fargate en elk cluster dat hostPath blokkeert of de `restricted` Pod Security Standard afdwingt.
-$1 Elke containerstream is een langdurige verbinding met kube-apiserver. Eén replica verwerkt doorgaans enkele duizenden containers. Shard bij zeer grote clusters afzonderlijke releases met include-regels met de scope podLogs in namespaceFilters.rules.
+- **Nadelen:** Elke containerstream is een langdurige verbinding met kube-apiserver. Eén replica verwerkt doorgaans enkele duizenden containers. Shard bij zeer grote clusters afzonderlijke releases met include-regels met de scope podLogs in namespaceFilters.rules.
 
 ### Welke moet u gebruiken?
 

--- a/App/FeatureSet/Docs/Content/no/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/no/monitor/kubernetes-agent.md
@@ -80,7 +80,7 @@ En DaemonSet kjører én OpenTelemetry Collector-pod per node. Den leser loggfil
 En Deployment med én replika (bildet `oneuptime/kubernetes-log-tailer`) bruker Kubernetes-API-et til å strømme containerlogger — samme endepunkt som `kubectl logs -f` bruker. Ingen hostPath, ingen verts-tilgang, ingen DaemonSet.
 
 - **Fordeler:** fungerer på GKE Autopilot, EKS Fargate og enhver klynge som blokkerer hostPath eller håndhever `restricted` Pod Security Standard.
-$1 Hver containerstrøm er en langvarig forbindelse til kube-apiserver. Én replika håndterer vanligvis noen tusen containere. For svært store klynger bør du dele opp separate releases med podLogs-scopede include-regler i namespaceFilters.rules.
+- **Ulemper:** Hver containerstrøm er en langvarig forbindelse til kube-apiserver. Én replika håndterer vanligvis noen tusen containere. For svært store klynger bør du dele opp separate releases med podLogs-scopede include-regler i namespaceFilters.rules.
 
 ### Hvilken bør du bruke?
 

--- a/App/FeatureSet/Docs/Content/pt/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/pt/monitor/kubernetes-agent.md
@@ -80,7 +80,7 @@ Um DaemonSet executa um pod do OpenTelemetry Collector por cada nó. Lê os fich
 Um Deployment de réplica única (a imagem `oneuptime/kubernetes-log-tailer`) utiliza a API do Kubernetes para fazer streaming dos logs dos contentores — o mesmo endpoint que o `kubectl logs -f` utiliza. Sem hostPath, sem acesso ao host, sem DaemonSet.
 
 - **Vantagens:** funciona no GKE Autopilot, EKS Fargate e qualquer cluster que bloqueie hostPath ou imponha o Pod Security Standard `restricted`.
-$1 Cada fluxo de contêiner é uma conexão de longa duração com kube-apiserver. Uma réplica normalmente processa alguns milhares de contêineres. Em clusters muito grandes, divida releases separadas com regras include de escopo podLogs em namespaceFilters.rules.
+- **Desvantagens:** Cada fluxo de contêiner é uma conexão de longa duração com kube-apiserver. Uma réplica normalmente processa alguns milhares de contêineres. Em clusters muito grandes, divida releases separadas com regras include de escopo podLogs em namespaceFilters.rules.
 
 ### Qual deve utilizar?
 

--- a/App/FeatureSet/Docs/Content/ru/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/ru/monitor/kubernetes-agent.md
@@ -80,7 +80,7 @@ DaemonSet запускает один Pod OpenTelemetry Collector на кажд�
 Deployment с одной репликой (образ `oneuptime/kubernetes-log-tailer`) использует Kubernetes API для стриминга логов контейнеров — тот же endpoint, который использует `kubectl logs -f`. Никаких hostPath, никакого доступа к хосту, никакого DaemonSet.
 
 - **Преимущества:** работает на GKE Autopilot, EKS Fargate и в любом кластере, где заблокирован hostPath или применяется `restricted` Pod Security Standard.
-$1 Каждый поток контейнера — это долговременное соединение с kube-apiserver. Одна реплика обычно обрабатывает несколько тысяч контейнеров. В очень больших кластерах разделите отдельные релизы с правилами include области podLogs в namespaceFilters.rules.
+- **Недостатки:** Каждый поток контейнера — это долговременное соединение с kube-apiserver. Одна реплика обычно обрабатывает несколько тысяч контейнеров. В очень больших кластерах разделите отдельные релизы с правилами include области podLogs в namespaceFilters.rules.
 
 ### Какой режим использовать?
 

--- a/App/FeatureSet/Docs/Content/sv/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/sv/monitor/kubernetes-agent.md
@@ -80,7 +80,7 @@ En DaemonSet kör en OpenTelemetry Collector-pod per nod. Den läser loggfiler u
 En Deployment med en enda replika (avbildningen `oneuptime/kubernetes-log-tailer`) använder Kubernetes API för att strömma containerloggar — samma endpoint som `kubectl logs -f` använder. Ingen hostPath, ingen värdåtkomst, ingen DaemonSet.
 
 - **Fördelar:** fungerar på GKE Autopilot, EKS Fargate och alla kluster som blockerar hostPath eller framtvingar `restricted` Pod Security Standard.
-$1 Varje containerström är en långvarig anslutning till kube-apiserver. En replika hanterar normalt några tusen containrar. För mycket stora kluster bör du dela upp separata releaser med podLogs-scopade include-regler i namespaceFilters.rules.
+- **Nackdelar:** Varje containerström är en långvarig anslutning till kube-apiserver. En replika hanterar normalt några tusen containrar. För mycket stora kluster bör du dela upp separata releaser med podLogs-scopade include-regler i namespaceFilters.rules.
 
 ### Vilken bör du använda?
 

--- a/App/FeatureSet/Docs/Content/zh-TW/monitor/kubernetes-agent.md
+++ b/App/FeatureSet/Docs/Content/zh-TW/monitor/kubernetes-agent.md
@@ -120,7 +120,7 @@ DaemonSet 會在每個節點上執行一個 OpenTelemetry Collector pod。它透
 一個單一複本的 Deployment（`oneuptime/kubernetes-log-tailer` 映像檔）使用 Kubernetes API 來串流容器記錄 — 與 `kubectl logs -f` 所使用的相同端點。沒有 hostPath、沒有主機存取、沒有 DaemonSet。
 
 - **優點：** 可在 GKE Autopilot、EKS Fargate，以及任何封鎖 hostPath 或強制執行 `restricted` Pod Security Standard 的叢集上運作。
-$1 每個容器串流都是連到 kube-apiserver 的長連線。一個副本通常可處理數千個容器。對於超大型叢集，請在 namespaceFilters.rules 中使用 podLogs 作用域的 include 規則，將不同 release 分片。
+- **缺點：** 每個容器串流都是連到 kube-apiserver 的長連線。一個副本通常可處理數千個容器。對於超大型叢集，請在 namespaceFilters.rules 中使用 podLogs 作用域的 include 規則，將不同 release 分片。
 
 ### 您應該使用哪一個？
 


### PR DESCRIPTION
## What

14 translated copies of the Kubernetes agent guide had a literal `$1` at the start of the API-mode caveat bullet — a leaked sed/regex backreference from a past bulk edit:

```
- **Fordele:** virker på GKE Autopilot, EKS Fargate og enhver klynge, der blokerer hostPath …
$1 hver containerstream er en langvarig forbindelse til kube-apiserver. …
```

It renders verbatim on the docs site. And because the bullet also lost its `- ` prefix it stopped being a list item entirely, so the line ran into the preceding bullet instead of pairing with it as the Pros/Cons counterpart.

## How the label was chosen

The English source reads `- **Cons:**`. Rather than translate that fresh, each label was taken **from the affected file itself** — every one of them already has its own translation of Pros/Cons in the DaemonSet-mode section directly above. That keeps locale-specific punctuation intact:

| | | | |
|---|---|---|---|
| da `Ulemper:` | de `Nachteile:` | es `Contras:` | fr `Inconvénients :` (space before colon) |
| hi `नुकसान:` | it `Svantaggi:` | ja `短所:` | ko `단점:` |
| nl `Nadelen:` | no `Ulemper:` | pt `Desvantagens:` | ru `Недостатки:` |
| sv `Nackdelar:` | zh-TW `缺點：` (fullwidth colon) | | |

Sentence bodies are untouched. One line changes per file — 14 files, 14 insertions, 14 deletions.

## Verification

- Zero `$1` remaining under `App/FeatureSet/Docs/Content/`.
- No other `$2`–`$9` or `\1`–`\9` backreference artifacts anywhere in `Docs/Content`, `HelmChart/`, or the in-product Kubernetes docs.
- All 16 locales now have both bullets in the API-mode section (was 1 in the 14 affected).
- `Scripts/Docs/CheckAnchors.ts` passes.

## Noted, not fixed

The same bulk edit appears to have also stripped backtick code formatting from the sentence bodies in these translations — English has `` `kube-apiserver` ``, `` `podLogs` ``, `` `namespaceFilters.rules` ``; the translations have them as bare text. Left alone here to keep this diff to the one-line-per-file regression fix. Worth a follow-up sweep if you want the code spans restored across locales.