### PR TITLE
feat(topology): draw routers, switches, firewalls and hosts as distinct shapes

### DIFF
--- a/App/FeatureSet/BaseAPI/API/NetworkDeviceTopology.ts
+++ b/App/FeatureSet/BaseAPI/API/NetworkDeviceTopology.ts
@@ -105,6 +105,13 @@ export default class NetworkDeviceTopologyAPI {
                 interfacesDown: true,
                 vendor: true,
                 deviceModel: true,
+                /*
+                 * Not rendered — read only by the role classifier, which
+                 * is what lets a switch draw as a switch rather than as
+                 * another anonymous circle.
+                 */
+                sysDescr: true,
+                sysObjectId: true,
                 lldpNeighbors: true,
                 cdpNeighbors: true,
               },
@@ -242,6 +249,8 @@ export default class NetworkDeviceTopologyAPI {
                 interfacesDown: device.interfacesDown,
                 vendor: device.vendor,
                 deviceModel: device.deviceModel,
+                sysDescr: device.sysDescr,
+                sysObjectId: device.sysObjectId,
                 lldpNeighbors: device.lldpNeighbors,
                 cdpNeighbors: device.cdpNeighbors,
               };

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyFootprint.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyFootprint.ts
@@ -1,5 +1,12 @@
 import { NetworkTopologyNode } from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
 import { isEndpointNode } from "./EndpointNodeUtil";
+import {
+  DEVICE_NODE_BASE_RADIUS,
+  ENDPOINT_NODE_BASE_RADIUS,
+  TopologyShapeGeometry,
+  geometryForShape,
+  shapeGeometryForNode,
+} from "./TopologyNodeShape";
 
 /*
  * The drawing geometry of a topology node, in viewBox units.
@@ -19,11 +26,21 @@ import { isEndpointNode } from "./EndpointNodeUtil";
  * only ever needs to be good enough to keep labels from colliding.
  */
 
-// Managed and unmanaged devices are circles of this radius.
-export const DEVICE_NODE_RADIUS: number = 16;
-// Endpoints are small rounded rects so a fan of leaves stays readable.
-export const ENDPOINT_NODE_HALF_WIDTH: number = 9;
-export const ENDPOINT_NODE_HALF_HEIGHT: number = 7;
+/*
+ * The size class a node is drawn at. The SILHOUETTE is chosen by role in
+ * TopologyNodeShape — a switch is a rounded square, a firewall a diamond
+ * — and its half-extents come from there too, so the layout reserves room
+ * for the shape that is actually painted. These constants remain the
+ * unclassified case: a device with no role is still a circle of this
+ * radius, and an endpoint still the 9 × 7 rect it has always been.
+ */
+export const DEVICE_NODE_RADIUS: number = DEVICE_NODE_BASE_RADIUS;
+const ENDPOINT_RECT: TopologyShapeGeometry = geometryForShape(
+  "rect",
+  ENDPOINT_NODE_BASE_RADIUS,
+);
+export const ENDPOINT_NODE_HALF_WIDTH: number = ENDPOINT_RECT.halfWidth;
+export const ENDPOINT_NODE_HALF_HEIGHT: number = ENDPOINT_RECT.halfHeight;
 
 export const DEVICE_LABEL_FONT_SIZE: number = 12;
 export const ENDPOINT_LABEL_FONT_SIZE: number = 10;
@@ -162,8 +179,15 @@ export interface TopologyNodeFootprint {
   halfWidth: number;
   /** Half the glyph's height, label excluded. */
   halfHeight: number;
+  /**
+   * The silhouette this node is painted as — carried here so the renderer
+   * draws exactly the shape the layout reserved room for.
+   */
+  shape: TopologyShapeGeometry;
   /** Half the width of the widest label line, capped. */
   labelHalfWidth: number;
+  /** Centre to the baseline of the FIRST label line. */
+  labelBaselineOffset: number;
   /** Centre to the bottom of the last label line (positive, downward). */
   labelBottom: number;
   /** Radius used for glyph-vs-glyph separation, padding included. */
@@ -188,12 +212,9 @@ export const footprintForNode: (
 ): TopologyNodeFootprint => {
   const isEndpoint: boolean = isEndpointNode(node);
 
-  const halfWidth: number = isEndpoint
-    ? ENDPOINT_NODE_HALF_WIDTH
-    : DEVICE_NODE_RADIUS;
-  const halfHeight: number = isEndpoint
-    ? ENDPOINT_NODE_HALF_HEIGHT
-    : DEVICE_NODE_RADIUS;
+  const shape: TopologyShapeGeometry = shapeGeometryForNode(node);
+  const halfWidth: number = shape.halfWidth;
+  const halfHeight: number = shape.halfHeight;
 
   const lines: Array<string> = labelLinesForNode(node);
   const fontSize: number = isEndpoint
@@ -202,9 +223,20 @@ export const footprintForNode: (
   const lineHeight: number = isEndpoint
     ? ENDPOINT_LABEL_LINE_HEIGHT
     : DEVICE_LABEL_LINE_HEIGHT;
-  const baselineOffset: number = isEndpoint
-    ? ENDPOINT_LABEL_BASELINE_OFFSET
-    : DEVICE_LABEL_BASELINE_OFFSET;
+  /*
+   * The clearance between the bottom of the glyph and the first baseline
+   * is what the fixed offsets encode for a circle; a taller silhouette
+   * (the firewall diamond overshoots the circle by a couple of units)
+   * pushes its label down by the difference rather than letting the two
+   * touch.
+   */
+  const labelGap: number = isEndpoint
+    ? ENDPOINT_LABEL_BASELINE_OFFSET - ENDPOINT_NODE_HALF_HEIGHT
+    : DEVICE_LABEL_BASELINE_OFFSET - DEVICE_NODE_RADIUS;
+  const baselineOffset: number = Math.max(
+    isEndpoint ? ENDPOINT_LABEL_BASELINE_OFFSET : DEVICE_LABEL_BASELINE_OFFSET,
+    halfHeight + labelGap,
+  );
 
   let longestLine: number = 0;
   for (const line of lines) {
@@ -226,7 +258,9 @@ export const footprintForNode: (
   return {
     halfWidth: halfWidth,
     halfHeight: halfHeight,
+    shape: shape,
     labelHalfWidth: labelHalfWidth,
+    labelBaselineOffset: baselineOffset,
     labelBottom: labelBottom,
     collisionRadius: Math.max(halfWidth, halfHeight) + NODE_COLLISION_PADDING,
     inkHalfWidth: Math.max(halfWidth, labelHalfWidth),
@@ -262,7 +296,9 @@ export const buildFootprints: (
 export const DEFAULT_FOOTPRINT: TopologyNodeFootprint = {
   halfWidth: DEVICE_NODE_RADIUS,
   halfHeight: DEVICE_NODE_RADIUS,
+  shape: geometryForShape("circle", DEVICE_NODE_BASE_RADIUS),
   labelHalfWidth: 0,
+  labelBaselineOffset: DEVICE_LABEL_BASELINE_OFFSET,
   labelBottom: DEVICE_LABEL_BASELINE_OFFSET,
   collisionRadius: DEVICE_NODE_RADIUS + NODE_COLLISION_PADDING,
   inkHalfWidth: DEVICE_NODE_RADIUS,

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyNodeShape.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyNodeShape.ts
@@ -1,0 +1,287 @@
+import {
+  NetworkTopologyDeviceRole,
+  NetworkTopologyNode,
+} from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
+import { labelForDeviceRole } from "Common/Utils/Monitor/NetworkDeviceRoleUtil";
+import { isEndpointNode } from "./EndpointNodeUtil";
+import { TopologyPoint } from "./TopologyGraphUtil";
+
+/*
+ * What each kind of box on the network LOOKS like.
+ *
+ * Every node on the topology map used to be a circle — a core router, an
+ * access switch, the firewall at the edge and a ceiling camera were all
+ * the same 32px dot, and the only way to tell them apart was to read the
+ * label under each one. Reading a map should not require reading it word
+ * by word, so a node's role now picks its silhouette, following the
+ * conventions network engineers already draw with by hand:
+ *
+ *   router          circle          the classic router puck
+ *   switch          rounded square  the classic switch box
+ *   firewall        diamond         a barrier turned on its corner
+ *   wireless AP     triangle        a radiation cone
+ *   load balancer   hexagon         distinct from both box and puck
+ *   server          tower           taller than wide, like a chassis
+ *   storage         cylinder        the disk symbol
+ *   host / leaf     rect            what endpoints have always been
+ *   unknown         circle          neutral, and unchanged from before
+ *
+ * Pure and react-free on purpose: BOTH the layout (through
+ * TopologyFootprint) and the SVG renderer read this module, so a shape
+ * can never be drawn at a size the layout did not reserve room for. It
+ * also means every silhouette is unit-testable without a DOM.
+ */
+
+export type TopologyNodeShape =
+  | "circle"
+  | "rounded-square"
+  | "diamond"
+  | "triangle"
+  | "hexagon"
+  | "tower"
+  | "cylinder"
+  | "rect";
+
+/*
+ * The size a node is drawn at before its shape's aspect ratio is applied.
+ * Devices keep the radius the old circles used, so an unclassified graph
+ * renders pixel-for-pixel as it did; endpoints keep theirs.
+ */
+export const DEVICE_NODE_BASE_RADIUS: number = 16;
+export const ENDPOINT_NODE_BASE_RADIUS: number = 9;
+
+/*
+ * Half-extents as a fraction of the base radius. The infrastructure
+ * shapes are scaled so they carry roughly the same visual weight as the
+ * circle they replace — a diamond of the same half-width as a circle's
+ * radius reads much smaller, hence the 1.15.
+ */
+interface ShapeRatios {
+  width: number;
+  height: number;
+  /** Corner rounding, also as a fraction of the base radius. */
+  corner: number;
+}
+
+const SHAPE_RATIOS: Record<TopologyNodeShape, ShapeRatios> = {
+  circle: { width: 1, height: 1, corner: 0 },
+  "rounded-square": { width: 0.88, height: 0.88, corner: 0.22 },
+  diamond: { width: 1.15, height: 1.15, corner: 0 },
+  triangle: { width: 1.2, height: 1, corner: 0 },
+  // sin(60°) — a hexagon of circumradius 1 is that tall at its half-height.
+  hexagon: { width: 1, height: 0.8660254037844386, corner: 0 },
+  tower: { width: 0.62, height: 1, corner: 0.15 },
+  cylinder: { width: 0.72, height: 0.92, corner: 0 },
+  // 7/9 reproduces the endpoint rect's historical 9 × 7 exactly.
+  rect: { width: 1, height: 7 / 9, corner: 1 / 3 },
+};
+
+/*
+ * Role → silhouette. The leaf roles (printer, camera, phone, host) share
+ * the endpoint rect deliberately: they are all "something plugged into a
+ * port", the distinction between them is not structural, and inventing
+ * four more silhouettes for it would cost more legibility than it buys.
+ * Their labels and the legend still name them individually.
+ */
+const SHAPE_BY_ROLE: Record<NetworkTopologyDeviceRole, TopologyNodeShape> = {
+  router: "circle",
+  switch: "rounded-square",
+  firewall: "diamond",
+  wirelessAccessPoint: "triangle",
+  loadBalancer: "hexagon",
+  server: "tower",
+  storage: "cylinder",
+  printer: "rect",
+  camera: "rect",
+  phone: "rect",
+  host: "rect",
+  // Never looked up — see shapeForNode, which falls back on the kind.
+  unknown: "circle",
+};
+
+/**
+ * The node's role, with the fallback older payloads need.
+ *
+ * A payload from before roles existed carries none. An endpoint without
+ * one is a host — that is what being on the far side of an access port
+ * means — and anything else is honestly unknown.
+ */
+export function roleOfNode(
+  node: NetworkTopologyNode,
+): NetworkTopologyDeviceRole {
+  if (node.role) {
+    return node.role;
+  }
+  return isEndpointNode(node) ? "host" : "unknown";
+}
+
+/**
+ * The silhouette a node is drawn with.
+ *
+ * "unknown" is not a shape of its own: an unclassified endpoint stays the
+ * rect it has always been, and an unclassified device stays a circle.
+ */
+export function shapeForNode(node: NetworkTopologyNode): TopologyNodeShape {
+  const role: NetworkTopologyDeviceRole = roleOfNode(node);
+  if (role === "unknown") {
+    return isEndpointNode(node) ? "rect" : "circle";
+  }
+  return SHAPE_BY_ROLE[role];
+}
+
+/** The size class a node is drawn at, before shape ratios. */
+export function baseRadiusForNode(node: NetworkTopologyNode): number {
+  return isEndpointNode(node)
+    ? ENDPOINT_NODE_BASE_RADIUS
+    : DEVICE_NODE_BASE_RADIUS;
+}
+
+export interface TopologyShapeGeometry {
+  shape: TopologyNodeShape;
+  /** Half the silhouette's width, in viewBox units. Always positive. */
+  halfWidth: number;
+  /** Half the silhouette's height, in viewBox units. Always positive. */
+  halfHeight: number;
+  /**
+   * Vertices for the polygon shapes, centred on the origin and in draw
+   * order. Empty for the shapes drawn as a circle, a rect or a path.
+   */
+  points: Array<TopologyPoint>;
+  /** Corner rounding for the rect-family shapes; zero for the rest. */
+  cornerRadius: number;
+  /**
+   * Where the interface-count badge sits relative to the centre. Every
+   * shape but one is widest across its middle; a triangle is widest at
+   * its base, so its badge drops toward the centroid instead of hanging
+   * off the apex.
+   */
+  badgeBaselineOffset: number;
+}
+
+// Two decimal places is well under a rendered pixel and keeps paths short.
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/*
+ * Baseline for a 9px badge on a shape centred at y — half the cap height,
+ * which is what puts the digits' optical centre on the centre line.
+ */
+const DEFAULT_BADGE_OFFSET: number = 3;
+
+/** The geometry of one silhouette at one base radius. */
+export function geometryForShape(
+  shape: TopologyNodeShape,
+  baseRadius: number,
+): TopologyShapeGeometry {
+  const ratios: ShapeRatios = SHAPE_RATIOS[shape];
+  const halfWidth: number = round(baseRadius * ratios.width);
+  const halfHeight: number = round(baseRadius * ratios.height);
+
+  const points: Array<TopologyPoint> = [];
+  if (shape === "diamond") {
+    points.push(
+      { x: 0, y: -halfHeight },
+      { x: halfWidth, y: 0 },
+      { x: 0, y: halfHeight },
+      { x: -halfWidth, y: 0 },
+    );
+  } else if (shape === "triangle") {
+    points.push(
+      { x: 0, y: -halfHeight },
+      { x: halfWidth, y: halfHeight },
+      { x: -halfWidth, y: halfHeight },
+    );
+  } else if (shape === "hexagon") {
+    points.push(
+      { x: halfWidth, y: 0 },
+      { x: round(halfWidth / 2), y: halfHeight },
+      { x: round(-halfWidth / 2), y: halfHeight },
+      { x: -halfWidth, y: 0 },
+      { x: round(-halfWidth / 2), y: -halfHeight },
+      { x: round(halfWidth / 2), y: -halfHeight },
+    );
+  }
+
+  return {
+    shape: shape,
+    halfWidth: halfWidth,
+    halfHeight: halfHeight,
+    points: points,
+    cornerRadius: round(baseRadius * ratios.corner),
+    // 3 is the optical centre of a 9px badge on a shape centred at y.
+    badgeBaselineOffset:
+      shape === "triangle" ? round(halfHeight * 0.5) : DEFAULT_BADGE_OFFSET,
+  };
+}
+
+/** The geometry one node is drawn with — shape and size class together. */
+export function shapeGeometryForNode(
+  node: NetworkTopologyNode,
+): TopologyShapeGeometry {
+  return geometryForShape(shapeForNode(node), baseRadiusForNode(node));
+}
+
+/** `points="..."` for a polygon shape, translated to a centre. */
+export function polygonPointsAt(
+  geometry: TopologyShapeGeometry,
+  cx: number,
+  cy: number,
+): string {
+  return geometry.points
+    .map((point: TopologyPoint): string => {
+      return `${round(cx + point.x)},${round(cy + point.y)}`;
+    })
+    .join(" ");
+}
+
+/** How tall the elliptical cap of a cylinder is. */
+function cylinderCapHalfHeight(halfHeight: number): number {
+  return round(Math.min(halfHeight * 0.32, halfHeight));
+}
+
+/**
+ * The outline of a storage cylinder: an elliptical cap at each end joined
+ * by straight sides, drawn clockwise from the left of the top cap.
+ */
+export function cylinderBodyPathAt(
+  geometry: TopologyShapeGeometry,
+  cx: number,
+  cy: number,
+): string {
+  const w: number = geometry.halfWidth;
+  const h: number = geometry.halfHeight;
+  const ry: number = cylinderCapHalfHeight(h);
+  const top: number = round(cy - h + ry);
+  const bottom: number = round(cy + h - ry);
+  const left: number = round(cx - w);
+  const right: number = round(cx + w);
+  return [
+    `M ${left} ${top}`,
+    `A ${w} ${ry} 0 0 1 ${right} ${top}`,
+    `L ${right} ${bottom}`,
+    `A ${w} ${ry} 0 0 1 ${left} ${bottom}`,
+    "Z",
+  ].join(" ");
+}
+
+/**
+ * The front rim of the cylinder's top cap — the line that makes the
+ * silhouette read as a drum rather than as a lozenge.
+ */
+export function cylinderCapPathAt(
+  geometry: TopologyShapeGeometry,
+  cx: number,
+  cy: number,
+): string {
+  const w: number = geometry.halfWidth;
+  const h: number = geometry.halfHeight;
+  const ry: number = cylinderCapHalfHeight(h);
+  const top: number = round(cy - h + ry);
+  return `M ${round(cx + w)} ${top} A ${w} ${ry} 0 0 1 ${round(cx - w)} ${top}`;
+}
+
+/** Display name of a node's role, e.g. "Switch". */
+export function roleLabelForNode(node: NetworkTopologyNode): string {
+  return labelForDeviceRole(roleOfNode(node));
+}

--- a/App/FeatureSet/Dashboard/src/Components/Topology/NetworkDeviceDetailPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/NetworkDeviceDetailPanel.tsx
@@ -17,6 +17,10 @@ import {
   edgeKeyForEdge,
   linkStateForEdge,
 } from "./NetworkTopologyMeta";
+import {
+  roleLabelForNode,
+  roleOfNode,
+} from "../NetworkDevice/TopologyNodeShape";
 
 /*
  * Right-hand detail drawer for a topology device node. Keeps the user on
@@ -56,6 +60,17 @@ const NetworkDeviceDetailPanel: FunctionComponent<ComponentProps> = (
   const isEndpoint: boolean = node.kind === "endpoint";
 
   const detailRows: Array<{ label: string; value: string }> = [];
+  /*
+   * First row, because it is what the shape on the map claimed and this
+   * drawer is where somebody comes to check that claim. Omitted when the
+   * evidence named no role — "Unknown type" is not worth a row.
+   */
+  if (roleOfNode(node) !== "unknown") {
+    detailRows.push({
+      label: translateString("Type") || "Type",
+      value: roleLabelForNode(node),
+    });
+  }
   if (node.macAddress) {
     detailRows.push({
       label: translateString("MAC address") || "MAC address",

--- a/App/FeatureSet/Dashboard/src/Components/Topology/NetworkDeviceGraph.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/NetworkDeviceGraph.tsx
@@ -29,10 +29,17 @@ import {
   topologyStructuralSignature,
 } from "./NetworkTopologyViewModel";
 import {
-  TOPOLOGY_LEGEND,
   TopologyLegendEntry,
+  buildTopologyLegend,
   edgeKeyForEdge,
 } from "./NetworkTopologyMeta";
+import {
+  TopologyShapeGeometry,
+  cylinderBodyPathAt,
+  cylinderCapPathAt,
+  geometryForShape,
+  polygonPointsAt,
+} from "../NetworkDevice/TopologyNodeShape";
 import {
   PositionOverrides,
   TopologyLayoutMode,
@@ -163,6 +170,194 @@ const FIT_BOUNDS_PADDING: number = 40;
 let graphInstanceCounter: number = 0;
 
 const emptyOverrides: PositionOverrides = new Map<string, TopologyPoint>();
+
+/*
+ * The node glyph, drawn as whatever silhouette its role earned it. The
+ * geometry is NOT recomputed here — it rides in on the footprint, which
+ * is the same object the layout used to reserve space, so a shape can
+ * never be painted larger than the room made for it.
+ */
+const renderNodeSilhouette: (nodeView: TopologyNodeView) => ReactElement = (
+  nodeView: TopologyNodeView,
+): ReactElement => {
+  const geometry: TopologyShapeGeometry = nodeView.footprint.shape;
+  const isEndpoint: boolean = nodeView.kind === "endpoint";
+  const fillOpacity: number = isEndpoint
+    ? 0.85
+    : nodeView.kind === "device"
+      ? 0.9
+      : 1;
+  const strokeWidth: number = isEndpoint ? 1.5 : 2;
+  const paint: {
+    fill: string;
+    fillOpacity: number;
+    stroke: string;
+    strokeWidth: number;
+    strokeDasharray: string | undefined;
+  } = {
+    fill: nodeView.fill,
+    fillOpacity: fillOpacity,
+    stroke: nodeView.stroke,
+    strokeWidth: strokeWidth,
+    strokeDasharray: nodeView.strokeDashArray,
+  };
+
+  if (geometry.points.length > 0) {
+    return (
+      <polygon
+        data-topology-node-shape={geometry.shape}
+        points={polygonPointsAt(geometry, nodeView.x, nodeView.y)}
+        strokeLinejoin="round"
+        {...paint}
+      />
+    );
+  }
+
+  if (geometry.shape === "cylinder") {
+    /*
+     * Two paths: the silhouette, then the front rim of the top cap over
+     * it. Without the rim the outline reads as a lozenge, not a drum.
+     */
+    return (
+      <g data-topology-node-shape={geometry.shape}>
+        <path
+          d={cylinderBodyPathAt(geometry, nodeView.x, nodeView.y)}
+          {...paint}
+        />
+        <path
+          d={cylinderCapPathAt(geometry, nodeView.x, nodeView.y)}
+          fill="none"
+          stroke={nodeView.stroke}
+          strokeWidth={strokeWidth}
+          pointerEvents="none"
+        />
+      </g>
+    );
+  }
+
+  if (geometry.shape === "circle") {
+    return (
+      <circle
+        data-topology-node-shape={geometry.shape}
+        cx={nodeView.x}
+        cy={nodeView.y}
+        r={geometry.halfWidth}
+        {...paint}
+      />
+    );
+  }
+
+  // Everything left is a rect: the switch box, the server tower, the leaf.
+  return (
+    <rect
+      data-topology-node-shape={geometry.shape}
+      x={nodeView.x - geometry.halfWidth}
+      y={nodeView.y - geometry.halfHeight}
+      width={geometry.halfWidth * 2}
+      height={geometry.halfHeight * 2}
+      rx={geometry.cornerRadius}
+      {...paint}
+    />
+  );
+};
+
+/*
+ * One legend swatch. Drawn in a 16 × 10 box, so the node silhouettes are
+ * re-derived at a base radius that fits it rather than scaled down from
+ * the canvas geometry.
+ */
+const LEGEND_SWATCH_WIDTH: number = 16;
+const LEGEND_SWATCH_HEIGHT: number = 10;
+const LEGEND_SHAPE_BASE_RADIUS: number = 4.2;
+
+const renderLegendSwatch: (entry: TopologyLegendEntry) => ReactElement = (
+  entry: TopologyLegendEntry,
+): ReactElement => {
+  const cx: number = LEGEND_SWATCH_WIDTH / 2;
+  const cy: number = LEGEND_SWATCH_HEIGHT / 2;
+
+  if (entry.swatch === "line" || entry.swatch === "dashed-line") {
+    return (
+      <line
+        x1={0}
+        y1={cy}
+        x2={LEGEND_SWATCH_WIDTH}
+        y2={cy}
+        stroke={entry.color}
+        strokeWidth={2}
+        strokeDasharray={entry.swatch === "dashed-line" ? "3 2" : undefined}
+      />
+    );
+  }
+
+  if (entry.swatch === "square") {
+    return <rect x={3} y={2} width={10} height={7} rx={2} fill={entry.color} />;
+  }
+
+  if (entry.swatch === "shape" && entry.shape) {
+    const geometry: TopologyShapeGeometry = geometryForShape(
+      entry.shape,
+      LEGEND_SHAPE_BASE_RADIUS,
+    );
+    if (geometry.points.length > 0) {
+      return (
+        <polygon
+          points={polygonPointsAt(geometry, cx, cy)}
+          fill="none"
+          stroke={entry.color}
+          strokeWidth={1.5}
+          strokeLinejoin="round"
+        />
+      );
+    }
+    if (geometry.shape === "cylinder") {
+      return (
+        <path
+          d={cylinderBodyPathAt(geometry, cx, cy)}
+          fill="none"
+          stroke={entry.color}
+          strokeWidth={1.5}
+        />
+      );
+    }
+    if (geometry.shape === "circle") {
+      return (
+        <circle
+          cx={cx}
+          cy={cy}
+          r={geometry.halfWidth}
+          fill="none"
+          stroke={entry.color}
+          strokeWidth={1.5}
+        />
+      );
+    }
+    return (
+      <rect
+        x={cx - geometry.halfWidth}
+        y={cy - geometry.halfHeight}
+        width={geometry.halfWidth * 2}
+        height={geometry.halfHeight * 2}
+        rx={geometry.cornerRadius}
+        fill="none"
+        stroke={entry.color}
+        strokeWidth={1.5}
+      />
+    );
+  }
+
+  return (
+    <circle
+      cx={8}
+      cy={cy}
+      r={4}
+      fill={entry.swatch === "hollow-dot" ? "none" : entry.color}
+      stroke={entry.color}
+      strokeWidth={entry.swatch === "hollow-dot" ? 1.5 : 0}
+      strokeDasharray={entry.swatch === "hollow-dot" ? "2 1.5" : undefined}
+    />
+  );
+};
 
 const NetworkDeviceGraph: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
@@ -325,6 +520,15 @@ const NetworkDeviceGraph: FunctionComponent<ComponentProps> = (
     props.selectedEdgeKey,
     pinnedNodeIds,
   ]);
+
+  /*
+   * Built from the UNFILTERED node set on purpose: the key should explain
+   * the silhouettes this network contains, not flicker an entry away the
+   * moment a kind filter hides the last switch.
+   */
+  const legend: Array<TopologyLegendEntry> = useMemo(() => {
+    return buildTopologyLegend(nodes);
+  }, [nodes]);
 
   /*
    * The soft hulls behind the graph: one per island, one per endpoint
@@ -1428,35 +1632,12 @@ const NetworkDeviceGraph: FunctionComponent<ComponentProps> = (
                         <></>
                       )}
 
-                      {isEndpoint ? (
-                        <rect
-                          x={nodeView.x - footprint.halfWidth}
-                          y={nodeView.y - footprint.halfHeight}
-                          width={footprint.halfWidth * 2}
-                          height={footprint.halfHeight * 2}
-                          rx={3}
-                          fill={nodeView.fill}
-                          fillOpacity={0.85}
-                          stroke={nodeView.stroke}
-                          strokeWidth={1.5}
-                        />
-                      ) : (
-                        <circle
-                          cx={nodeView.x}
-                          cy={nodeView.y}
-                          r={footprint.halfWidth}
-                          fill={nodeView.fill}
-                          fillOpacity={nodeView.kind === "device" ? 0.9 : 1}
-                          stroke={nodeView.stroke}
-                          strokeWidth={2}
-                          strokeDasharray={nodeView.strokeDashArray}
-                        />
-                      )}
+                      {renderNodeSilhouette(nodeView)}
 
                       {nodeView.badge && showLabels ? (
                         <text
                           x={nodeView.x}
-                          y={nodeView.y + 3}
+                          y={nodeView.y + footprint.shape.badgeBaselineOffset}
                           textAnchor="middle"
                           fontSize={9}
                           fontWeight={600}
@@ -1476,11 +1657,13 @@ const NetworkDeviceGraph: FunctionComponent<ComponentProps> = (
                       {showLabels ? (
                         <text
                           x={nodeView.x}
-                          y={
-                            nodeView.y +
-                            footprint.halfHeight +
-                            (isEndpoint ? 12 : 14)
-                          }
+                          /*
+                           * From the footprint, not from a constant: a
+                           * diamond stands taller than the circle these
+                           * offsets were written for, and the layout has
+                           * already reserved room at exactly this baseline.
+                           */
+                          y={nodeView.y + footprint.labelBaselineOffset}
                           textAnchor="middle"
                           fontSize={isEndpoint ? 10 : 12}
                           fill="var(--ou-text-secondary, #374151)"
@@ -1536,47 +1719,18 @@ const NetworkDeviceGraph: FunctionComponent<ComponentProps> = (
         data-testid="network-topology-legend"
         className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2 rounded-lg border border-gray-100 px-3 py-2.5 text-xs text-gray-600"
       >
-        {TOPOLOGY_LEGEND.map((entry: TopologyLegendEntry): ReactElement => {
+        {legend.map((entry: TopologyLegendEntry): ReactElement => {
           return (
             <li
               key={`${entry.group}-${entry.label}`}
               className="flex items-center gap-1.5"
             >
-              <svg width={16} height={10} aria-hidden={true}>
-                {entry.swatch === "line" || entry.swatch === "dashed-line" ? (
-                  <line
-                    x1={0}
-                    y1={5}
-                    x2={16}
-                    y2={5}
-                    stroke={entry.color}
-                    strokeWidth={2}
-                    strokeDasharray={
-                      entry.swatch === "dashed-line" ? "3 2" : undefined
-                    }
-                  />
-                ) : entry.swatch === "square" ? (
-                  <rect
-                    x={3}
-                    y={2}
-                    width={10}
-                    height={7}
-                    rx={2}
-                    fill={entry.color}
-                  />
-                ) : (
-                  <circle
-                    cx={8}
-                    cy={5}
-                    r={4}
-                    fill={entry.swatch === "hollow-dot" ? "none" : entry.color}
-                    stroke={entry.color}
-                    strokeWidth={entry.swatch === "hollow-dot" ? 1.5 : 0}
-                    strokeDasharray={
-                      entry.swatch === "hollow-dot" ? "2 1.5" : undefined
-                    }
-                  />
-                )}
+              <svg
+                width={LEGEND_SWATCH_WIDTH}
+                height={LEGEND_SWATCH_HEIGHT}
+                aria-hidden={true}
+              >
+                {renderLegendSwatch(entry)}
               </svg>
               <span>
                 <span className="text-gray-400">{`${entry.group}: `}</span>

--- a/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyMeta.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyMeta.ts
@@ -1,9 +1,19 @@
 import {
+  NetworkTopologyDeviceRole,
   NetworkTopologyEdge,
   NetworkTopologyEdgeEndpoint,
   NetworkTopologyNode,
   NetworkTopologyNodeStatus,
 } from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
+import {
+  DEVICE_ROLES_IN_LEGEND_ORDER,
+  labelForDeviceRole,
+} from "Common/Utils/Monitor/NetworkDeviceRoleUtil";
+import {
+  TopologyNodeShape,
+  roleOfNode,
+  shapeForNode,
+} from "../NetworkDevice/TopologyNodeShape";
 
 /*
  * Pure, react-free presentation logic for the network topology graph:
@@ -111,7 +121,15 @@ export function edgeKeyForEdge(edge: NetworkTopologyEdge): string {
   return [edge.fromNodeId, edge.toNodeId].sort().join("::");
 }
 
-/** True when the node matches the search text on name, sysName or vendor. */
+/**
+ * True when the node matches the search text.
+ *
+ * Name, sysName and vendor are the identity fields; the ROLE is matched
+ * too, so typing "firewall" lights up every firewall on the map even
+ * though no device is called one. An unclassified node deliberately does
+ * not answer to "unknown type" — that would make a search for a role
+ * highlight everything we failed to classify.
+ */
 export function nodeMatchesSearch(
   node: NetworkTopologyNode,
   searchText: string,
@@ -120,7 +138,10 @@ export function nodeMatchesSearch(
   if (!lower) {
     return true;
   }
-  return [node.name, node.sysName, node.vendor].some(
+  const role: NetworkTopologyDeviceRole = roleOfNode(node);
+  const roleText: string | undefined =
+    role === "unknown" ? undefined : labelForDeviceRole(role);
+  return [node.name, node.sysName, node.vendor, roleText].some(
     (value: string | undefined) => {
       return Boolean(value && value.toLowerCase().includes(lower));
     },
@@ -174,11 +195,16 @@ export const ENDPOINT_NODE_STROKE: string = "#7c3aed";
 
 /** The key to reading the graph, as data rather than as prose. */
 export interface TopologyLegendEntry {
-  group: "Status" | "Kind" | "Link";
+  group: "Status" | "Kind" | "Type" | "Link";
   label: string;
-  /** How the swatch is drawn: a filled dot, an outline, or a line. */
-  swatch: "dot" | "hollow-dot" | "square" | "line" | "dashed-line";
+  /**
+   * How the swatch is drawn: a filled dot, an outline, a line, or — for
+   * the "Type" group — the node silhouette the role is drawn with.
+   */
+  swatch: "dot" | "hollow-dot" | "square" | "line" | "dashed-line" | "shape";
   color: string;
+  /** Set only on "shape" swatches: which silhouette to draw. */
+  shape?: TopologyNodeShape | undefined;
 }
 
 export const TOPOLOGY_LEGEND: Array<TopologyLegendEntry> = [
@@ -239,6 +265,62 @@ export const TOPOLOGY_LEGEND: Array<TopologyLegendEntry> = [
   },
 ];
 
+/** The neutral ink every shape swatch is drawn in. */
+export const LEGEND_SHAPE_COLOR: string = "var(--ou-text-muted, #6b7280)";
+
+/**
+ * The legend for one topology, silhouettes included.
+ *
+ * The type entries are built from the nodes actually on the map rather
+ * than from the full list of roles: a key that explains a storage
+ * cylinder to somebody whose network contains none is nine words of
+ * clutter, and this legend already has to survive being read on a phone.
+ * Roles that came back "unknown" get no entry either — the circle they
+ * fall back to is the same one a router uses, and claiming otherwise
+ * would be a lie about what the reader is looking at.
+ *
+ * Order is the fixed role order, never encounter order, so the key does
+ * not reshuffle itself under a poll.
+ */
+export function buildTopologyLegend(
+  nodes: Array<NetworkTopologyNode> | undefined,
+): Array<TopologyLegendEntry> {
+  const presentRoles: Set<NetworkTopologyDeviceRole> =
+    new Set<NetworkTopologyDeviceRole>();
+  for (const node of nodes || []) {
+    if (!node) {
+      continue;
+    }
+    const role: NetworkTopologyDeviceRole = roleOfNode(node);
+    if (role !== "unknown") {
+      presentRoles.add(role);
+    }
+  }
+
+  const typeEntries: Array<TopologyLegendEntry> = [];
+  for (const role of DEVICE_ROLES_IN_LEGEND_ORDER) {
+    if (!presentRoles.has(role)) {
+      continue;
+    }
+    typeEntries.push({
+      group: "Type",
+      label: labelForDeviceRole(role),
+      swatch: "shape",
+      color: LEGEND_SHAPE_COLOR,
+      shape: shapeForNode({
+        id: "legend",
+        name: "legend",
+        isManaged: true,
+        status: "unknown",
+        kind: "device",
+        role: role,
+      }),
+    });
+  }
+
+  return [...TOPOLOGY_LEGEND, ...typeEntries];
+}
+
 /**
  * What a screen reader hears for a node.
  *
@@ -248,6 +330,19 @@ export const TOPOLOGY_LEGEND: Array<TopologyLegendEntry> = [
  */
 export function accessibleLabelForNode(node: NetworkTopologyNode): string {
   const parts: Array<string> = [node.name || node.id];
+  /*
+   * The role goes first because it is what the SHAPE encodes, and the
+   * shape is exactly the information a screen reader cannot see. Skipped
+   * when unknown ("unknown type" tells nobody anything) and skipped for a
+   * plain endpoint host, which the word "endpoint" below already says.
+   */
+  const nodeRole: NetworkTopologyDeviceRole = roleOfNode(node);
+  if (
+    nodeRole !== "unknown" &&
+    !(nodeRole === "host" && node.kind === "endpoint")
+  ) {
+    parts.push(labelForDeviceRole(nodeRole).toLowerCase());
+  }
   if (node.kind === "endpoint") {
     parts.push("endpoint");
     if (node.ipAddress) {

--- a/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyViewModel.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/NetworkTopologyViewModel.ts
@@ -1,7 +1,12 @@
 import {
+  NetworkTopologyDeviceRole,
   NetworkTopologyEdge,
   NetworkTopologyNode,
 } from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
+import {
+  roleLabelForNode,
+  roleOfNode,
+} from "../NetworkDevice/TopologyNodeShape";
 import {
   endpointTooltipForNode,
   isEndpointNode,
@@ -44,6 +49,10 @@ export interface TopologyNodeView {
   x: number;
   y: number;
   kind: TopologyNodeKind;
+  /** What the node does on the network — this is what picks its shape. */
+  role: NetworkTopologyDeviceRole;
+  /** The role's display name, e.g. "Switch". */
+  roleLabel: string;
   status: string;
   fill: string;
   stroke: string;
@@ -137,11 +146,22 @@ const tooltipForNode: (node: NetworkTopologyNode) => string = (
   const interfacesSummary: string = hasInterfaceCounts
     ? `${node.interfacesUp ?? 0} up / ${node.interfacesDown ?? 0} down`
     : "";
-  return `${node.name} (${node.status}${
-    node.isManaged ? "" : ", unmanaged"
-  })${vendorSummary ? ` — ${vendorSummary}` : ""}${
-    interfacesSummary ? ` — ${interfacesSummary}` : ""
-  }`;
+  /*
+   * "core-1 (Switch, up)" — the role leads because the shape is what the
+   * reader is trying to confirm when they hover. An unclassified node
+   * simply omits it and reads exactly as it always did.
+   */
+  const role: NetworkTopologyDeviceRole = roleOfNode(node);
+  const descriptor: string = [
+    role === "unknown" ? undefined : roleLabelForNode(node),
+    node.status,
+    node.isManaged ? undefined : "unmanaged",
+  ]
+    .filter(Boolean)
+    .join(", ");
+  return `${node.name} (${descriptor})${
+    vendorSummary ? ` — ${vendorSummary}` : ""
+  }${interfacesSummary ? ` — ${interfacesSummary}` : ""}`;
 };
 
 /**
@@ -205,6 +225,8 @@ export const buildTopologyViewModel: (
       x: point.x,
       y: point.y,
       kind: kind,
+      role: roleOfNode(node),
+      roleLabel: roleLabelForNode(node),
       status: node.status,
       fill:
         kind === "endpoint"

--- a/App/Tests/Dashboard/NetworkTopologyMeta.test.ts
+++ b/App/Tests/Dashboard/NetworkTopologyMeta.test.ts
@@ -7,6 +7,10 @@ import {
 import {
   LINK_SATURATION_THRESHOLD_PERCENT,
   LINK_STATE_COLORS,
+  TOPOLOGY_LEGEND,
+  TopologyLegendEntry,
+  accessibleLabelForNode,
+  buildTopologyLegend,
   describeEndpoint,
   edgeKeyForEdge,
   edgeStrokeWidthForEdge,
@@ -308,5 +312,217 @@ describe("describeEndpoint", () => {
     expect(
       describeEndpoint({ interfaceName: "Gi0/1", inRateMbps: 5 }, undefined),
     ).toBe("Gi0/1 · ↓5.0 Mbps ↑—");
+  });
+});
+
+const deviceNode: (
+  overrides?: Partial<NetworkTopologyNode>,
+) => NetworkTopologyNode = (
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: "d1",
+    name: "core-1",
+    isManaged: true,
+    status: "up",
+    kind: "device",
+    ...overrides,
+  };
+};
+
+describe("nodeMatchesSearch — by role", () => {
+  test("a role name matches every node of that role", () => {
+    expect(nodeMatchesSearch(deviceNode({ role: "switch" }), "switch")).toBe(
+      true,
+    );
+    expect(nodeMatchesSearch(deviceNode({ role: "router" }), "switch")).toBe(
+      false,
+    );
+  });
+
+  test("role search is case-insensitive and matches partially", () => {
+    const balancer: NetworkTopologyNode = deviceNode({ role: "loadBalancer" });
+    expect(nodeMatchesSearch(balancer, "LOAD")).toBe(true);
+    expect(nodeMatchesSearch(balancer, "balancer")).toBe(true);
+  });
+
+  test("the display name is matched, not the internal role key", () => {
+    const wireless: NetworkTopologyNode = deviceNode({
+      role: "wirelessAccessPoint",
+    });
+    expect(nodeMatchesSearch(wireless, "Wireless AP")).toBe(true);
+    expect(nodeMatchesSearch(wireless, "accesspoint")).toBe(false);
+  });
+
+  test("searching a role never lights up everything we failed to classify", () => {
+    // "Unknown type" must not be a searchable label.
+    expect(nodeMatchesSearch(deviceNode({ role: "unknown" }), "unknown")).toBe(
+      false,
+    );
+    expect(nodeMatchesSearch(deviceNode(), "unknown type")).toBe(false);
+  });
+
+  test("identity search still works alongside it", () => {
+    const node: NetworkTopologyNode = deviceNode({
+      name: "core-1",
+      sysName: "core-1.example.com",
+      vendor: "Cisco",
+      role: "switch",
+    });
+    expect(nodeMatchesSearch(node, "core")).toBe(true);
+    expect(nodeMatchesSearch(node, "cisco")).toBe(true);
+    expect(nodeMatchesSearch(node, "example.com")).toBe(true);
+    expect(nodeMatchesSearch(node, "")).toBe(true);
+  });
+});
+
+describe("accessibleLabelForNode — roles", () => {
+  test("the role is announced, because the shape cannot be", () => {
+    expect(
+      accessibleLabelForNode(
+        deviceNode({ role: "firewall", vendor: "Palo Alto" }),
+      ),
+    ).toBe("core-1, firewall, managed device, status up, Palo Alto");
+  });
+
+  test("an unclassified device announces exactly what it always did", () => {
+    expect(accessibleLabelForNode(deviceNode())).toBe(
+      "core-1, managed device, status up",
+    );
+  });
+
+  test("a plain endpoint host does not say 'host, endpoint'", () => {
+    expect(
+      accessibleLabelForNode({
+        id: "endpoint:e1",
+        name: "pos-1",
+        isManaged: false,
+        status: "unknown",
+        kind: "endpoint",
+        role: "host",
+        ipAddress: "10.0.0.5",
+      }),
+    ).toBe("pos-1, endpoint, 10.0.0.5");
+  });
+
+  test("an endpoint with a real role announces it", () => {
+    expect(
+      accessibleLabelForNode({
+        id: "endpoint:e2",
+        name: "cam-1",
+        isManaged: false,
+        status: "unknown",
+        kind: "endpoint",
+        role: "camera",
+        vlanId: 12,
+      }),
+    ).toBe("cam-1, camera, endpoint, VLAN 12");
+  });
+});
+
+describe("buildTopologyLegend", () => {
+  const labelsOf: (
+    entries: Array<TopologyLegendEntry>,
+    group: string,
+  ) => Array<string> = (
+    entries: Array<TopologyLegendEntry>,
+    group: string,
+  ): Array<string> => {
+    return entries
+      .filter((entry: TopologyLegendEntry) => {
+        return entry.group === group;
+      })
+      .map((entry: TopologyLegendEntry) => {
+        return entry.label;
+      });
+  };
+
+  test("an unclassified graph gets no type entries at all", () => {
+    expect(buildTopologyLegend([deviceNode()])).toEqual(TOPOLOGY_LEGEND);
+    expect(buildTopologyLegend([])).toEqual(TOPOLOGY_LEGEND);
+    expect(buildTopologyLegend(undefined)).toEqual(TOPOLOGY_LEGEND);
+  });
+
+  test("only the types actually on the map are explained", () => {
+    const legend: Array<TopologyLegendEntry> = buildTopologyLegend([
+      deviceNode({ id: "d1", role: "switch" }),
+      deviceNode({ id: "d2", role: "router" }),
+      deviceNode({ id: "d3", role: "unknown" }),
+    ]);
+    expect(labelsOf(legend, "Type")).toEqual(["Router", "Switch"]);
+  });
+
+  test("a type present many times is listed once", () => {
+    const legend: Array<TopologyLegendEntry> = buildTopologyLegend([
+      deviceNode({ id: "d1", role: "switch" }),
+      deviceNode({ id: "d2", role: "switch" }),
+      deviceNode({ id: "d3", role: "switch" }),
+    ]);
+    expect(labelsOf(legend, "Type")).toEqual(["Switch"]);
+  });
+
+  test("the order is fixed, not encounter order — a poll must not reshuffle the key", () => {
+    const forward: Array<TopologyLegendEntry> = buildTopologyLegend([
+      deviceNode({ id: "d1", role: "storage" }),
+      deviceNode({ id: "d2", role: "router" }),
+      deviceNode({ id: "d3", role: "firewall" }),
+    ]);
+    const reversed: Array<TopologyLegendEntry> = buildTopologyLegend([
+      deviceNode({ id: "d3", role: "firewall" }),
+      deviceNode({ id: "d2", role: "router" }),
+      deviceNode({ id: "d1", role: "storage" }),
+    ]);
+    expect(labelsOf(forward, "Type")).toEqual([
+      "Router",
+      "Firewall",
+      "Storage",
+    ]);
+    expect(labelsOf(reversed, "Type")).toEqual(labelsOf(forward, "Type"));
+  });
+
+  test("every type entry carries the silhouette its nodes are drawn with", () => {
+    const legend: Array<TopologyLegendEntry> = buildTopologyLegend([
+      deviceNode({ id: "d1", role: "switch" }),
+      deviceNode({ id: "d2", role: "firewall" }),
+      deviceNode({ id: "d3", role: "storage" }),
+    ]);
+    const shapes: Record<string, string | undefined> = {};
+    for (const entry of legend) {
+      if (entry.group === "Type") {
+        shapes[entry.label] = entry.shape;
+      }
+    }
+    expect(shapes["Switch"]).toBe("rounded-square");
+    expect(shapes["Firewall"]).toBe("diamond");
+    expect(shapes["Storage"]).toBe("cylinder");
+  });
+
+  test("the status, kind and link entries are never disturbed", () => {
+    const legend: Array<TopologyLegendEntry> = buildTopologyLegend([
+      deviceNode({ role: "switch" }),
+    ]);
+    expect(legend.slice(0, TOPOLOGY_LEGEND.length)).toEqual(TOPOLOGY_LEGEND);
+    expect(labelsOf(legend, "Status")).toEqual(["Up", "Down", "Unknown"]);
+  });
+
+  test("endpoints without a role are listed as hosts", () => {
+    const legend: Array<TopologyLegendEntry> = buildTopologyLegend([
+      {
+        id: "endpoint:e1",
+        name: "pos-1",
+        isManaged: false,
+        status: "unknown",
+        kind: "endpoint",
+      },
+    ]);
+    expect(labelsOf(legend, "Type")).toEqual(["Host"]);
+  });
+
+  test("malformed entries in the node list do not break the key", () => {
+    const legend: Array<TopologyLegendEntry> = buildTopologyLegend([
+      undefined as unknown as NetworkTopologyNode,
+      deviceNode({ role: "router" }),
+    ]);
+    expect(labelsOf(legend, "Type")).toEqual(["Router"]);
   });
 });

--- a/App/Tests/Dashboard/NetworkTopologyViewModel.test.ts
+++ b/App/Tests/Dashboard/NetworkTopologyViewModel.test.ts
@@ -1307,3 +1307,159 @@ describe("buildTopologyViewModel — search match count", () => {
     expect(filtered.searchMatchCount).toBe(0);
   });
 });
+
+/*
+ * The view model is where a node's role becomes something the renderer
+ * and a screen reader can both use. It must survive payloads from before
+ * roles existed without changing what those payloads looked like.
+ */
+describe("buildTopologyViewModel — roles", () => {
+  const viewFor: (node: NetworkTopologyNode) => TopologyNodeView = (
+    node: NetworkTopologyNode,
+  ): TopologyNodeView => {
+    const model: TopologyViewModel = buildTopologyViewModel({
+      nodes: [node],
+      edges: [],
+      positions: new Map<string, TopologyPoint>([[node.id, { x: 10, y: 20 }]]),
+      searchText: "",
+      visibleKinds: ALL_NODE_KINDS,
+      focusNodeIds: new Set<string>(),
+      selectedNodeId: null,
+      selectedEdgeKey: null,
+      pinnedNodeIds: new Set<string>(),
+    });
+    return model.nodes[0]!;
+  };
+
+  test("the role and its label ride on the node view", () => {
+    const view: TopologyNodeView = viewFor(
+      makeDevice("d1", { role: "switch" }),
+    );
+    expect(view.role).toBe("switch");
+    expect(view.roleLabel).toBe("Switch");
+  });
+
+  test("the footprint carries the silhouette the role earned", () => {
+    expect(
+      viewFor(makeDevice("d1", { role: "firewall" })).footprint.shape.shape,
+    ).toBe("diamond");
+    expect(
+      viewFor(makeDevice("d2", { role: "storage" })).footprint.shape.shape,
+    ).toBe("cylinder");
+  });
+
+  test("a payload without roles still renders: devices unknown, endpoints hosts", () => {
+    const device: TopologyNodeView = viewFor(makeDevice("d1"));
+    expect(device.role).toBe("unknown");
+    expect(device.footprint.shape.shape).toBe("circle");
+
+    const endpoint: TopologyNodeView = viewFor(
+      makeEndpoint("endpoint:e1", { name: "pos-1" }),
+    );
+    expect(endpoint.role).toBe("host");
+    expect(endpoint.footprint.shape.shape).toBe("rect");
+  });
+
+  test("the tooltip leads with the role", () => {
+    expect(
+      viewFor(
+        makeDevice("d1", {
+          name: "core-1",
+          role: "switch",
+          status: "up",
+          vendor: "Cisco",
+          deviceModel: "C9300",
+        }),
+      ).tooltip,
+    ).toBe("core-1 (Switch, up) — Cisco C9300");
+  });
+
+  test("an unclassified device's tooltip reads exactly as it did before", () => {
+    expect(
+      viewFor(makeDevice("d1", { name: "core-1", status: "up" })).tooltip,
+    ).toBe("core-1 (up)");
+    expect(
+      viewFor(
+        makeUnmanaged("unmanaged:peer", { name: "peer", status: "unknown" }),
+      ).tooltip,
+    ).toBe("peer (unknown, unmanaged)");
+  });
+
+  test("an unmanaged peer with a role names it alongside 'unmanaged'", () => {
+    expect(
+      viewFor(
+        makeUnmanaged("unmanaged:peer", {
+          name: "peer",
+          status: "unknown",
+          role: "wirelessAccessPoint",
+        }),
+      ).tooltip,
+    ).toBe("peer (Wireless AP, unknown, unmanaged)");
+  });
+
+  test("the role changes the shape but never the status colours", () => {
+    /*
+     * Shape answers "what is it", colour answers "is it alright". The two
+     * are deliberately independent — a firewall that is down must still
+     * be red.
+     */
+    const downFirewall: TopologyNodeView = viewFor(
+      makeDevice("d1", { role: "firewall", status: "down" }),
+    );
+    expect(downFirewall.fill).toBe(NODE_STATUS_COLORS.down);
+    expect(downFirewall.footprint.shape.shape).toBe("diamond");
+
+    const upFirewall: TopologyNodeView = viewFor(
+      makeDevice("d2", { role: "firewall", status: "up" }),
+    );
+    expect(upFirewall.fill).toBe(NODE_STATUS_COLORS.up);
+    expect(upFirewall.footprint.shape.shape).toBe("diamond");
+  });
+
+  test("an endpoint keeps its violet regardless of the role", () => {
+    const camera: TopologyNodeView = viewFor(
+      makeEndpoint("endpoint:e1", { name: "cam-1", role: "camera" }),
+    );
+    expect(camera.fill).toBe(ENDPOINT_NODE_FILL);
+    expect(camera.stroke).toBe(ENDPOINT_NODE_STROKE);
+  });
+
+  test("an unmanaged peer keeps its dashed outline whatever shape it is", () => {
+    expect(
+      viewFor(makeUnmanaged("unmanaged:p", { role: "router" })).strokeDashArray,
+    ).toBe(UNMANAGED_DASH);
+  });
+
+  test("searching for a role dims everything that is not one", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("d1", { name: "core-1", role: "switch" }),
+      makeDevice("d2", { name: "core-2", role: "router" }),
+    ];
+    const model: TopologyViewModel = buildTopologyViewModel({
+      nodes: nodes,
+      edges: [],
+      positions: new Map<string, TopologyPoint>([
+        ["d1", { x: 0, y: 0 }],
+        ["d2", { x: 50, y: 0 }],
+      ]),
+      searchText: "switch",
+      visibleKinds: ALL_NODE_KINDS,
+      focusNodeIds: new Set<string>(),
+      selectedNodeId: null,
+      selectedEdgeKey: null,
+      pinnedNodeIds: new Set<string>(),
+    });
+
+    expect(model.searchMatchCount).toBe(1);
+    expect(
+      model.nodes.find((view: TopologyNodeView) => {
+        return view.id === "d1";
+      })?.isDimmed,
+    ).toBe(false);
+    expect(
+      model.nodes.find((view: TopologyNodeView) => {
+        return view.id === "d2";
+      })?.isDimmed,
+    ).toBe(true);
+  });
+});

--- a/App/Tests/Dashboard/TopologyFootprint.test.ts
+++ b/App/Tests/Dashboard/TopologyFootprint.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "@jest/globals";
-import { NetworkTopologyNode } from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
+import {
+  NetworkTopologyDeviceRole,
+  NetworkTopologyNode,
+} from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
 import {
   DEFAULT_FOOTPRINT,
   DEVICE_LABEL_BASELINE_OFFSET,
@@ -785,5 +788,150 @@ describe("footprintOrDefault — never returns undefined", () => {
     );
     expect(DEFAULT_FOOTPRINT.labelBottom).toBe(DEVICE_LABEL_BASELINE_OFFSET);
     expect(DEFAULT_FOOTPRINT.inkHalfWidth).toBe(DEVICE_NODE_RADIUS);
+  });
+});
+
+/*
+ * The footprint is the contract between the layout and the renderer: the
+ * layout reserves space with it, the renderer draws inside it. Roles
+ * changed what gets drawn, so these tests exist to make sure the space
+ * reserved moved with it — and that a graph with no roles at all still
+ * reserves exactly what it always did.
+ */
+describe("footprintForNode — role-driven silhouettes", () => {
+  test("the glyph extents come from the role's shape", () => {
+    const firewall: TopologyNodeFootprint = footprintForNode(
+      makeDevice("fw-1", { role: "firewall" }),
+    );
+    const server: TopologyNodeFootprint = footprintForNode(
+      makeDevice("srv-1", { role: "server" }),
+    );
+
+    // A diamond is wider and taller than the circle it replaces...
+    expect(firewall.halfWidth).toBeGreaterThan(DEVICE_NODE_RADIUS);
+    expect(firewall.halfHeight).toBeGreaterThan(DEVICE_NODE_RADIUS);
+    // ...and a server tower is narrower than it is tall.
+    expect(server.halfWidth).toBeLessThan(server.halfHeight);
+  });
+
+  test("the footprint carries the geometry the renderer will draw", () => {
+    const switchFootprint: TopologyNodeFootprint = footprintForNode(
+      makeDevice("sw-1", { role: "switch" }),
+    );
+    expect(switchFootprint.shape.shape).toBe("rounded-square");
+    expect(switchFootprint.shape.halfWidth).toBe(switchFootprint.halfWidth);
+    expect(switchFootprint.shape.halfHeight).toBe(switchFootprint.halfHeight);
+  });
+
+  test("collision radius grows with the shape, so a diamond cannot overlap", () => {
+    const circle: TopologyNodeFootprint = footprintForNode(
+      makeDevice("rtr-1", { role: "router" }),
+    );
+    const diamond: TopologyNodeFootprint = footprintForNode(
+      makeDevice("fw-1", { role: "firewall" }),
+    );
+    expect(diamond.collisionRadius).toBeGreaterThan(circle.collisionRadius);
+    expect(diamond.collisionRadius).toBe(
+      Math.max(diamond.halfWidth, diamond.halfHeight) + NODE_COLLISION_PADDING,
+    );
+  });
+
+  test("a taller silhouette pushes its label down instead of touching it", () => {
+    const circle: TopologyNodeFootprint = footprintForNode(
+      makeDevice("rtr-1", { role: "router" }),
+    );
+    const diamond: TopologyNodeFootprint = footprintForNode(
+      makeDevice("fw-1", { role: "firewall" }),
+    );
+    expect(circle.labelBaselineOffset).toBe(DEVICE_LABEL_BASELINE_OFFSET);
+    expect(diamond.labelBaselineOffset).toBeGreaterThan(
+      DEVICE_LABEL_BASELINE_OFFSET,
+    );
+    // The clearance below the glyph is the same in both cases.
+    expect(diamond.labelBaselineOffset - diamond.halfHeight).toBeCloseTo(
+      circle.labelBaselineOffset - circle.halfHeight,
+      5,
+    );
+  });
+
+  test("the label baseline is where the label block starts", () => {
+    const single: TopologyNodeFootprint = footprintForNode(
+      makeDevice("sw-1", { role: "switch", name: "sw" }),
+    );
+    expect(single.labelBottom).toBe(single.labelBaselineOffset);
+
+    const wrapped: TopologyNodeFootprint = footprintForNode(
+      makeDevice("sw-2", { role: "switch", name: "distribution switch two" }),
+    );
+    expect(wrapped.labelBottom).toBe(
+      wrapped.labelBaselineOffset + DEVICE_LABEL_LINE_HEIGHT,
+    );
+  });
+
+  test("every role produces a finite, positive, self-consistent footprint", () => {
+    const roles: Array<NetworkTopologyDeviceRole> = [
+      "router",
+      "switch",
+      "firewall",
+      "wirelessAccessPoint",
+      "loadBalancer",
+      "server",
+      "storage",
+      "printer",
+      "camera",
+      "phone",
+      "host",
+      "unknown",
+    ];
+    for (const role of roles) {
+      for (const node of [
+        makeDevice(`d-${role}`, { role: role }),
+        makeEndpoint(`endpoint:${role}`, { role: role }),
+      ]) {
+        const footprint: TopologyNodeFootprint = footprintForNode(node);
+        expect(footprint.halfWidth).toBeGreaterThan(0);
+        expect(footprint.halfHeight).toBeGreaterThan(0);
+        expect(Number.isFinite(footprint.collisionRadius)).toBe(true);
+        expect(footprint.collisionRadius).toBeGreaterThan(footprint.halfWidth);
+        expect(footprint.inkHalfWidth).toBeGreaterThanOrEqual(
+          footprint.halfWidth,
+        );
+        expect(footprint.labelBottom).toBeGreaterThanOrEqual(
+          footprint.labelBaselineOffset,
+        );
+      }
+    }
+  });
+
+  test("an endpoint is drawn at leaf size whatever its role says", () => {
+    const camera: TopologyNodeFootprint = footprintForNode(
+      makeEndpoint("endpoint:cam", { role: "camera" }),
+    );
+    expect(camera.halfWidth).toBe(ENDPOINT_NODE_HALF_WIDTH);
+    expect(camera.halfHeight).toBe(ENDPOINT_NODE_HALF_HEIGHT);
+  });
+
+  test("an unclassified graph is laid out exactly as it was before roles existed", () => {
+    /*
+     * The regression that matters most here: every existing saved
+     * arrangement, and every layout test in this suite, was written
+     * against these numbers.
+     */
+    const device: TopologyNodeFootprint = footprintForNode(
+      makeDevice("d1", { name: "core-1" }),
+    );
+    expect(device.halfWidth).toBe(DEVICE_NODE_RADIUS);
+    expect(device.halfHeight).toBe(DEVICE_NODE_RADIUS);
+    expect(device.collisionRadius).toBe(
+      DEVICE_NODE_RADIUS + NODE_COLLISION_PADDING,
+    );
+    expect(device.labelBaselineOffset).toBe(DEVICE_LABEL_BASELINE_OFFSET);
+
+    const endpoint: TopologyNodeFootprint = footprintForNode(
+      makeEndpoint("endpoint:e1", { name: "pos-1" }),
+    );
+    expect(endpoint.halfWidth).toBe(ENDPOINT_NODE_HALF_WIDTH);
+    expect(endpoint.halfHeight).toBe(ENDPOINT_NODE_HALF_HEIGHT);
+    expect(endpoint.labelBaselineOffset).toBe(ENDPOINT_LABEL_BASELINE_OFFSET);
   });
 });

--- a/App/Tests/Dashboard/TopologyNodeShape.test.ts
+++ b/App/Tests/Dashboard/TopologyNodeShape.test.ts
@@ -1,0 +1,445 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  NetworkTopologyDeviceRole,
+  NetworkTopologyNode,
+} from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
+import { DEVICE_ROLES_IN_LEGEND_ORDER } from "Common/Utils/Monitor/NetworkDeviceRoleUtil";
+import {
+  DEVICE_NODE_BASE_RADIUS,
+  ENDPOINT_NODE_BASE_RADIUS,
+  TopologyNodeShape,
+  TopologyShapeGeometry,
+  baseRadiusForNode,
+  cylinderBodyPathAt,
+  cylinderCapPathAt,
+  geometryForShape,
+  polygonPointsAt,
+  roleLabelForNode,
+  roleOfNode,
+  shapeForNode,
+  shapeGeometryForNode,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyNodeShape";
+import { TopologyPoint } from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyGraphUtil";
+
+/*
+ * The silhouettes are the whole point of the feature — a map on which a
+ * router, a switch and a firewall are three different shapes is readable
+ * at a glance, and one on which they are three identical circles is not.
+ * These tests pin the shape each role gets, the geometry every shape
+ * produces, and — most importantly — that an UNCLASSIFIED graph still
+ * renders exactly as it did before roles existed.
+ */
+
+type MakeNodeFunction = (
+  overrides?: Partial<NetworkTopologyNode>,
+) => NetworkTopologyNode;
+
+const makeDevice: MakeNodeFunction = (
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: "device-1",
+    name: "core-1",
+    isManaged: true,
+    status: "up",
+    kind: "device",
+    ...overrides,
+  };
+};
+
+const makeEndpoint: MakeNodeFunction = (
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: "endpoint:1",
+    name: "pos-1",
+    isManaged: false,
+    status: "unknown",
+    kind: "endpoint",
+    ...overrides,
+  };
+};
+
+const ALL_SHAPES: Array<TopologyNodeShape> = [
+  "circle",
+  "rounded-square",
+  "diamond",
+  "triangle",
+  "hexagon",
+  "tower",
+  "cylinder",
+  "rect",
+];
+
+describe("roleOfNode", () => {
+  test("uses the role the payload carries", () => {
+    expect(roleOfNode(makeDevice({ role: "switch" }))).toBe("switch");
+    expect(roleOfNode(makeEndpoint({ role: "camera" }))).toBe("camera");
+  });
+
+  test("a payload from before roles existed: devices unknown, endpoints hosts", () => {
+    expect(roleOfNode(makeDevice())).toBe("unknown");
+    expect(
+      roleOfNode({ id: "x", name: "x", isManaged: false, status: "unknown" }),
+    ).toBe("unknown");
+    // Being on the far side of an access port IS being a host.
+    expect(roleOfNode(makeEndpoint())).toBe("host");
+  });
+
+  test("an explicit 'unknown' is honoured, not re-derived", () => {
+    expect(roleOfNode(makeEndpoint({ role: "unknown" }))).toBe("unknown");
+  });
+});
+
+describe("shapeForNode", () => {
+  test("each infrastructure role gets its own silhouette", () => {
+    const expectations: Array<[NetworkTopologyDeviceRole, TopologyNodeShape]> =
+      [
+        ["router", "circle"],
+        ["switch", "rounded-square"],
+        ["firewall", "diamond"],
+        ["wirelessAccessPoint", "triangle"],
+        ["loadBalancer", "hexagon"],
+        ["server", "tower"],
+        ["storage", "cylinder"],
+      ];
+    for (const [role, shape] of expectations) {
+      expect(shapeForNode(makeDevice({ role: role }))).toBe(shape);
+    }
+  });
+
+  test("the infrastructure silhouettes are all distinct from one another", () => {
+    const shapes: Array<TopologyNodeShape> = [
+      "router",
+      "switch",
+      "firewall",
+      "wirelessAccessPoint",
+      "loadBalancer",
+      "server",
+      "storage",
+    ].map((role: string): TopologyNodeShape => {
+      return shapeForNode(
+        makeDevice({ role: role as NetworkTopologyDeviceRole }),
+      );
+    });
+    expect(new Set(shapes).size).toBe(shapes.length);
+  });
+
+  test("the leaf roles share the endpoint rect", () => {
+    for (const role of ["printer", "camera", "phone", "host"]) {
+      expect(
+        shapeForNode(makeEndpoint({ role: role as NetworkTopologyDeviceRole })),
+      ).toBe("rect");
+    }
+  });
+
+  test("unclassified nodes keep the shapes they have always had", () => {
+    expect(shapeForNode(makeDevice())).toBe("circle");
+    expect(shapeForNode(makeDevice({ role: "unknown" }))).toBe("circle");
+    expect(shapeForNode(makeEndpoint())).toBe("rect");
+    expect(shapeForNode(makeEndpoint({ role: "unknown" }))).toBe("rect");
+  });
+
+  test("every role in the legend order maps to a real shape", () => {
+    for (const role of DEVICE_ROLES_IN_LEGEND_ORDER) {
+      const shape: TopologyNodeShape = shapeForNode(makeDevice({ role: role }));
+      expect(ALL_SHAPES).toContain(shape);
+    }
+  });
+});
+
+describe("baseRadiusForNode", () => {
+  test("endpoints are drawn smaller than devices", () => {
+    expect(baseRadiusForNode(makeDevice())).toBe(DEVICE_NODE_BASE_RADIUS);
+    expect(baseRadiusForNode(makeEndpoint())).toBe(ENDPOINT_NODE_BASE_RADIUS);
+    expect(ENDPOINT_NODE_BASE_RADIUS).toBeLessThan(DEVICE_NODE_BASE_RADIUS);
+  });
+
+  test("the size class comes from the kind, not the role", () => {
+    // A switch discovered as an endpoint is still drawn at leaf size.
+    expect(baseRadiusForNode(makeEndpoint({ role: "switch" }))).toBe(
+      ENDPOINT_NODE_BASE_RADIUS,
+    );
+  });
+});
+
+describe("geometryForShape", () => {
+  test("every shape has finite, strictly positive half-extents", () => {
+    for (const shape of ALL_SHAPES) {
+      const geometry: TopologyShapeGeometry = geometryForShape(shape, 16);
+      expect(Number.isFinite(geometry.halfWidth)).toBe(true);
+      expect(Number.isFinite(geometry.halfHeight)).toBe(true);
+      expect(geometry.halfWidth).toBeGreaterThan(0);
+      expect(geometry.halfHeight).toBeGreaterThan(0);
+      expect(geometry.cornerRadius).toBeGreaterThanOrEqual(0);
+      expect(geometry.shape).toBe(shape);
+    }
+  });
+
+  test("half-extents scale linearly with the base radius", () => {
+    for (const shape of ALL_SHAPES) {
+      const small: TopologyShapeGeometry = geometryForShape(shape, 10);
+      const large: TopologyShapeGeometry = geometryForShape(shape, 20);
+      expect(large.halfWidth).toBeCloseTo(small.halfWidth * 2, 1);
+      expect(large.halfHeight).toBeCloseTo(small.halfHeight * 2, 1);
+    }
+  });
+
+  test("a circle's half-extents are the base radius, unchanged from before", () => {
+    const circle: TopologyShapeGeometry = geometryForShape(
+      "circle",
+      DEVICE_NODE_BASE_RADIUS,
+    );
+    expect(circle.halfWidth).toBe(DEVICE_NODE_BASE_RADIUS);
+    expect(circle.halfHeight).toBe(DEVICE_NODE_BASE_RADIUS);
+    expect(circle.points).toHaveLength(0);
+  });
+
+  test("the endpoint rect is still exactly 9 x 7", () => {
+    const rect: TopologyShapeGeometry = geometryForShape(
+      "rect",
+      ENDPOINT_NODE_BASE_RADIUS,
+    );
+    expect(rect.halfWidth).toBe(9);
+    expect(rect.halfHeight).toBe(7);
+    // The rounding the endpoint has always been drawn with.
+    expect(rect.cornerRadius).toBe(3);
+  });
+
+  test("only the polygon shapes carry vertices", () => {
+    const withPoints: Array<TopologyNodeShape> = [
+      "diamond",
+      "triangle",
+      "hexagon",
+    ];
+    for (const shape of ALL_SHAPES) {
+      const geometry: TopologyShapeGeometry = geometryForShape(shape, 16);
+      if (withPoints.includes(shape)) {
+        expect(geometry.points.length).toBeGreaterThanOrEqual(3);
+      } else {
+        expect(geometry.points).toHaveLength(0);
+      }
+    }
+  });
+
+  test("vertices stay inside the half-extents the layout reserved", () => {
+    for (const shape of [
+      "diamond",
+      "triangle",
+      "hexagon",
+    ] as Array<TopologyNodeShape>) {
+      const geometry: TopologyShapeGeometry = geometryForShape(shape, 16);
+      for (const point of geometry.points) {
+        expect(Math.abs(point.x)).toBeLessThanOrEqual(geometry.halfWidth);
+        expect(Math.abs(point.y)).toBeLessThanOrEqual(geometry.halfHeight);
+      }
+    }
+  });
+
+  test("polygons are centred on the origin", () => {
+    for (const shape of [
+      "diamond",
+      "triangle",
+      "hexagon",
+    ] as Array<TopologyNodeShape>) {
+      const geometry: TopologyShapeGeometry = geometryForShape(shape, 16);
+      const sumX: number = geometry.points.reduce(
+        (total: number, point: TopologyPoint): number => {
+          return total + point.x;
+        },
+        0,
+      );
+      expect(sumX).toBeCloseTo(0, 5);
+    }
+  });
+
+  test("the polygons each touch their own bounding box", () => {
+    // A shape narrower than its reserved extent would leave a visible gap.
+    for (const shape of [
+      "diamond",
+      "triangle",
+      "hexagon",
+    ] as Array<TopologyNodeShape>) {
+      const geometry: TopologyShapeGeometry = geometryForShape(shape, 16);
+      const maxX: number = Math.max(
+        ...geometry.points.map((point: TopologyPoint): number => {
+          return Math.abs(point.x);
+        }),
+      );
+      const maxY: number = Math.max(
+        ...geometry.points.map((point: TopologyPoint): number => {
+          return Math.abs(point.y);
+        }),
+      );
+      expect(maxX).toBeCloseTo(geometry.halfWidth, 5);
+      expect(maxY).toBeCloseTo(geometry.halfHeight, 5);
+    }
+  });
+
+  test("the triangle points up and the diamond stands on a corner", () => {
+    const triangle: TopologyShapeGeometry = geometryForShape("triangle", 16);
+    expect(triangle.points).toHaveLength(3);
+    expect(triangle.points[0]).toEqual({ x: 0, y: -triangle.halfHeight });
+
+    const diamond: TopologyShapeGeometry = geometryForShape("diamond", 16);
+    expect(diamond.points).toHaveLength(4);
+    expect(diamond.points[0]).toEqual({ x: 0, y: -diamond.halfHeight });
+    expect(diamond.points[1]).toEqual({ x: diamond.halfWidth, y: 0 });
+  });
+
+  test("the hexagon has six vertices", () => {
+    expect(geometryForShape("hexagon", 16).points).toHaveLength(6);
+  });
+
+  test("the server tower is taller than it is wide, the leaf rect wider than tall", () => {
+    const tower: TopologyShapeGeometry = geometryForShape("tower", 16);
+    expect(tower.halfHeight).toBeGreaterThan(tower.halfWidth);
+    const rect: TopologyShapeGeometry = geometryForShape("rect", 16);
+    expect(rect.halfWidth).toBeGreaterThan(rect.halfHeight);
+  });
+
+  test("the badge sits on the centre line, except on a triangle", () => {
+    /*
+     * A triangle is widest at its base, so a badge on the centre line
+     * hangs off the apex where there is no room for it.
+     */
+    for (const shape of ALL_SHAPES) {
+      const geometry: TopologyShapeGeometry = geometryForShape(shape, 16);
+      if (shape === "triangle") {
+        expect(geometry.badgeBaselineOffset).toBeGreaterThan(3);
+        expect(geometry.badgeBaselineOffset).toBeLessThan(geometry.halfHeight);
+      } else {
+        expect(geometry.badgeBaselineOffset).toBe(3);
+      }
+    }
+  });
+
+  test("only the rect-family shapes are rounded", () => {
+    expect(geometryForShape("rounded-square", 16).cornerRadius).toBeGreaterThan(
+      0,
+    );
+    expect(geometryForShape("tower", 16).cornerRadius).toBeGreaterThan(0);
+    expect(geometryForShape("rect", 16).cornerRadius).toBeGreaterThan(0);
+    expect(geometryForShape("circle", 16).cornerRadius).toBe(0);
+    expect(geometryForShape("diamond", 16).cornerRadius).toBe(0);
+  });
+});
+
+describe("shapeGeometryForNode", () => {
+  test("combines the role's shape with the kind's size class", () => {
+    const firewall: TopologyShapeGeometry = shapeGeometryForNode(
+      makeDevice({ role: "firewall" }),
+    );
+    expect(firewall.shape).toBe("diamond");
+    expect(firewall).toEqual(
+      geometryForShape("diamond", DEVICE_NODE_BASE_RADIUS),
+    );
+
+    const camera: TopologyShapeGeometry = shapeGeometryForNode(
+      makeEndpoint({ role: "camera" }),
+    );
+    expect(camera.shape).toBe("rect");
+    expect(camera.halfWidth).toBe(9);
+  });
+
+  test("an unclassified endpoint is byte-for-byte the old 9 x 7 rect", () => {
+    expect(shapeGeometryForNode(makeEndpoint())).toEqual(
+      geometryForShape("rect", ENDPOINT_NODE_BASE_RADIUS),
+    );
+  });
+});
+
+describe("polygonPointsAt", () => {
+  test("translates the vertices to the node's centre", () => {
+    const geometry: TopologyShapeGeometry = geometryForShape("diamond", 10);
+    const points: string = polygonPointsAt(geometry, 100, 50);
+    const pairs: Array<string> = points.split(" ");
+    expect(pairs).toHaveLength(4);
+    expect(pairs[0]).toBe(`100,${50 - geometry.halfHeight}`);
+    expect(pairs[1]).toBe(`${100 + geometry.halfWidth},50`);
+  });
+
+  test("every coordinate is a finite number", () => {
+    const geometry: TopologyShapeGeometry = geometryForShape("hexagon", 16);
+    for (const pair of polygonPointsAt(geometry, -12.5, 7.25).split(" ")) {
+      const [x, y] = pair.split(",");
+      expect(Number.isFinite(Number(x))).toBe(true);
+      expect(Number.isFinite(Number(y))).toBe(true);
+    }
+  });
+
+  test("a shape with no vertices produces an empty string", () => {
+    expect(polygonPointsAt(geometryForShape("circle", 16), 0, 0)).toBe("");
+  });
+});
+
+describe("the storage cylinder paths", () => {
+  const geometry: TopologyShapeGeometry = geometryForShape("cylinder", 16);
+
+  test("the body is a closed path of arcs and lines", () => {
+    const path: string = cylinderBodyPathAt(geometry, 40, 60);
+    expect(path.startsWith("M ")).toBe(true);
+    expect(path.endsWith("Z")).toBe(true);
+    expect((path.match(/A /g) || []).length).toBe(2);
+    expect(path).toContain("L ");
+  });
+
+  test("the cap is a single open arc across the top", () => {
+    const path: string = cylinderCapPathAt(geometry, 40, 60);
+    expect(path.startsWith("M ")).toBe(true);
+    expect(path.endsWith("Z")).toBe(false);
+    expect((path.match(/A /g) || []).length).toBe(1);
+  });
+
+  test("every coordinate in both paths is finite", () => {
+    const paths: string =
+      cylinderBodyPathAt(geometry, 40, 60) +
+      cylinderCapPathAt(geometry, 40, 60);
+    for (const token of paths.match(/-?\d+(\.\d+)?/g) || []) {
+      expect(Number.isFinite(Number(token))).toBe(true);
+    }
+  });
+
+  test("the drawing stays within the half-extents the layout reserved", () => {
+    /*
+     * Only the x coordinates are checked positionally — the arc radii in
+     * the path share the same number space, so an out-of-bounds x is the
+     * failure that would actually overlap a neighbour.
+     */
+    const path: string = cylinderBodyPathAt(geometry, 100, 100);
+    const xs: Array<number> = [
+      100 - geometry.halfWidth,
+      100 + geometry.halfWidth,
+    ];
+    for (const x of xs) {
+      expect(path).toContain(String(x));
+    }
+  });
+
+  test("the cap sits at the top of the cylinder, not at its centre", () => {
+    const cap: string = cylinderCapPathAt(geometry, 100, 100);
+    const firstY: number = Number(cap.split(" ")[2]);
+    expect(firstY).toBeLessThan(100);
+    expect(firstY).toBeGreaterThan(100 - geometry.halfHeight);
+  });
+});
+
+describe("roleLabelForNode", () => {
+  test("names the role a human would use", () => {
+    expect(roleLabelForNode(makeDevice({ role: "switch" }))).toBe("Switch");
+    expect(roleLabelForNode(makeDevice({ role: "wirelessAccessPoint" }))).toBe(
+      "Wireless AP",
+    );
+    expect(roleLabelForNode(makeDevice({ role: "loadBalancer" }))).toBe(
+      "Load balancer",
+    );
+  });
+
+  test("an unclassified device says so rather than inventing a role", () => {
+    expect(roleLabelForNode(makeDevice())).toBe("Unknown type");
+  });
+
+  test("an unclassified endpoint is a host", () => {
+    expect(roleLabelForNode(makeEndpoint())).toBe("Host");
+  });
+});

--- a/Common/Tests/Utils/Monitor/NetworkDeviceRoleUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/NetworkDeviceRoleUtil.test.ts
@@ -1,0 +1,514 @@
+import { describe, expect, test } from "@jest/globals";
+import { NetworkTopologyDeviceRole } from "../../../Types/Monitor/SnmpMonitor/NetworkTopology";
+import {
+  DEVICE_ROLES_IN_LEGEND_ORDER,
+  DEVICE_ROLE_LABELS,
+  classifyDeviceRole,
+  classifyEndpointRole,
+  labelForDeviceRole,
+} from "../../../Utils/Monitor/NetworkDeviceRoleUtil";
+
+/*
+ * The role classifier decides what shape every node on the topology map is
+ * drawn as, so these tests are written as a catalogue of real hardware
+ * strings — the ones SNMP actually returns — rather than as coverage of
+ * the regexes. The interesting cases are the collisions: vendors reuse
+ * each other's model prefixes (Juniper MX960 vs Meraki MX64), reuse their
+ * OWN prefixes across roles (Catalyst 2960 / 8300 / 9800), and put a
+ * Linux kernel in the sysDescr of things that are emphatically not
+ * servers.
+ */
+
+describe("classifyDeviceRole — switches", () => {
+  test("Cisco Catalyst and Nexus families", () => {
+    expect(classifyDeviceRole({ deviceModel: "Catalyst 2960X-48TS-L" })).toBe(
+      "switch",
+    );
+    expect(classifyDeviceRole({ deviceModel: "WS-C3850-48P" })).toBe("switch");
+    expect(classifyDeviceRole({ deviceModel: "Nexus 9336C-FX2" })).toBe(
+      "switch",
+    );
+    expect(classifyDeviceRole({ deviceModel: "C9300-24T" })).toBe("switch");
+  });
+
+  test("Juniper EX and QFX", () => {
+    expect(
+      classifyDeviceRole({
+        vendor: "Juniper Networks",
+        deviceModel: "EX4300-48T",
+      }),
+    ).toBe("switch");
+    expect(
+      classifyDeviceRole({
+        vendor: "Juniper Networks",
+        deviceModel: "QFX5120",
+      }),
+    ).toBe("switch");
+  });
+
+  test("other switching families", () => {
+    expect(classifyDeviceRole({ deviceModel: "DCS-7050SX3-48YC8" })).toBe(
+      "switch",
+    );
+    expect(classifyDeviceRole({ deviceModel: "FortiSwitch-124E" })).toBe(
+      "switch",
+    );
+    expect(classifyDeviceRole({ deviceModel: "ProCurve J9085A" })).toBe(
+      "switch",
+    );
+    expect(classifyDeviceRole({ deviceModel: "PowerConnect 5548" })).toBe(
+      "switch",
+    );
+    expect(classifyDeviceRole({ deviceModel: "USW-24-PoE" })).toBe("switch");
+  });
+
+  test("MikroTik CRS is a switch even though MikroTik reads as a router", () => {
+    expect(
+      classifyDeviceRole({ sysDescr: "MikroTik RouterOS CRS326-24G-2S+" }),
+    ).toBe("switch");
+  });
+});
+
+describe("classifyDeviceRole — routers", () => {
+  test("Cisco ISR and ASR", () => {
+    expect(classifyDeviceRole({ deviceModel: "ISR4331/K9" })).toBe("router");
+    expect(classifyDeviceRole({ deviceModel: "ASR1001-X" })).toBe("router");
+  });
+
+  test("Juniper MX only when the vendor evidence says Juniper", () => {
+    expect(
+      classifyDeviceRole({ vendor: "Juniper Networks", deviceModel: "MX960" }),
+    ).toBe("router");
+    expect(
+      classifyDeviceRole({ sysDescr: "Juniper Networks, Inc. mx240 JUNOS" }),
+    ).toBe("router");
+  });
+
+  test("MikroTik and other router families", () => {
+    expect(classifyDeviceRole({ sysDescr: "RouterOS CCR1036-8G-2S+" })).toBe(
+      "router",
+    );
+    expect(classifyDeviceRole({ deviceModel: "EdgeRouter 4" })).toBe("router");
+  });
+});
+
+describe("classifyDeviceRole — the Catalyst collision", () => {
+  test("Catalyst names three different roles and each wins its own", () => {
+    expect(classifyDeviceRole({ deviceModel: "Catalyst 2960X" })).toBe(
+      "switch",
+    );
+    expect(classifyDeviceRole({ deviceModel: "Catalyst 8300-1N1S-4T2X" })).toBe(
+      "router",
+    );
+    expect(
+      classifyDeviceRole({ deviceModel: "Catalyst 9800-40 Wireless" }),
+    ).toBe("wirelessAccessPoint");
+  });
+
+  test("the bare model codes collide the same way and resolve the same way", () => {
+    expect(classifyDeviceRole({ deviceModel: "C9300L-24P" })).toBe("switch");
+    expect(classifyDeviceRole({ deviceModel: "C8500-12X" })).toBe("router");
+    expect(classifyDeviceRole({ deviceModel: "C9800-CL" })).toBe(
+      "wirelessAccessPoint",
+    );
+  });
+});
+
+describe("classifyDeviceRole — the MX collision", () => {
+  test("Meraki MX is a firewall, Juniper MX is a router", () => {
+    expect(
+      classifyDeviceRole({ vendor: "Cisco Meraki", deviceModel: "MX68" }),
+    ).toBe("firewall");
+    expect(
+      classifyDeviceRole({ vendor: "Juniper Networks", deviceModel: "MX204" }),
+    ).toBe("router");
+  });
+
+  test("the Meraki rule reads the platform string, not just the vendor column", () => {
+    expect(classifyDeviceRole({ platform: "Meraki MX250 Cloud Managed" })).toBe(
+      "firewall",
+    );
+  });
+
+  test("an MX with no vendor evidence at all stays unknown rather than guessing", () => {
+    expect(classifyDeviceRole({ deviceModel: "MX100" })).toBe("unknown");
+  });
+});
+
+describe("classifyDeviceRole — firewalls", () => {
+  test("the major firewall families", () => {
+    expect(classifyDeviceRole({ deviceModel: "FortiGate-60F" })).toBe(
+      "firewall",
+    );
+    expect(classifyDeviceRole({ deviceModel: "PA-3220" })).toBe("firewall");
+    expect(classifyDeviceRole({ deviceModel: "SRX345" })).toBe("firewall");
+    expect(
+      classifyDeviceRole({ sysDescr: "Cisco Adaptive Security Appliance" }),
+    ).toBe("firewall");
+    expect(classifyDeviceRole({ deviceModel: "ASA5516-X" })).toBe("firewall");
+    expect(classifyDeviceRole({ sysDescr: "Firepower Threat Defense" })).toBe(
+      "firewall",
+    );
+    expect(classifyDeviceRole({ sysDescr: "SonicWALL NSa 2700" })).toBe(
+      "firewall",
+    );
+    expect(classifyDeviceRole({ sysDescr: "pfSense 2.7.0-RELEASE" })).toBe(
+      "firewall",
+    );
+  });
+
+  test("Sophos SG is a firewall and does not fall into the SG switch rule", () => {
+    expect(classifyDeviceRole({ deviceModel: "Sophos SG 210" })).toBe(
+      "firewall",
+    );
+    expect(classifyDeviceRole({ deviceModel: "SG350-28P" })).toBe("switch");
+  });
+});
+
+describe("classifyDeviceRole — wireless, load balancers, storage, servers", () => {
+  test("access points and controllers", () => {
+    expect(classifyDeviceRole({ deviceModel: "AIR-CAP3702I-A-K9" })).toBe(
+      "wirelessAccessPoint",
+    );
+    expect(classifyDeviceRole({ sysDescr: "Cisco Aironet 1852i" })).toBe(
+      "wirelessAccessPoint",
+    );
+    expect(classifyDeviceRole({ deviceModel: "FortiAP-231F" })).toBe(
+      "wirelessAccessPoint",
+    );
+    expect(
+      classifyDeviceRole({ vendor: "Cisco Meraki", deviceModel: "MR46" }),
+    ).toBe("wirelessAccessPoint");
+    expect(classifyDeviceRole({ deviceModel: "AP-515" })).toBe(
+      "wirelessAccessPoint",
+    );
+  });
+
+  test("load balancers", () => {
+    expect(classifyDeviceRole({ sysDescr: "BIG-IP 4000s" })).toBe(
+      "loadBalancer",
+    );
+    expect(classifyDeviceRole({ sysDescr: "NetScaler MPX 8905" })).toBe(
+      "loadBalancer",
+    );
+    expect(classifyDeviceRole({ deviceModel: "Thunder 3030S" })).toBe(
+      "unknown",
+    );
+    expect(classifyDeviceRole({ deviceModel: "A10 Thunder 3030S" })).toBe(
+      "loadBalancer",
+    );
+  });
+
+  test("storage", () => {
+    expect(
+      classifyDeviceRole({ vendor: "NetApp", sysDescr: "NetApp Release 9.9" }),
+    ).toBe("storage");
+    expect(classifyDeviceRole({ deviceModel: "Synology DS1819+" })).toBe(
+      "storage",
+    );
+  });
+
+  test("servers and hypervisors", () => {
+    expect(classifyDeviceRole({ sysDescr: "VMware ESXi 7.0.3" })).toBe(
+      "server",
+    );
+    expect(classifyDeviceRole({ deviceModel: "PowerEdge R740" })).toBe(
+      "server",
+    );
+    expect(classifyDeviceRole({ sysDescr: "HPE iLO 5" })).toBe("server");
+  });
+
+  test("printers, cameras and phones that speak SNMP", () => {
+    expect(classifyDeviceRole({ deviceModel: "HP LaserJet M607" })).toBe(
+      "printer",
+    );
+    expect(
+      classifyDeviceRole({ sysDescr: "AXIS P3245-LVE Network Camera" }),
+    ).toBe("camera");
+    expect(classifyDeviceRole({ sysDescr: "Cisco IP Phone 7961" })).toBe(
+      "phone",
+    );
+  });
+});
+
+describe("classifyDeviceRole — evidence precedence", () => {
+  test("the model beats a sysDescr that says something else", () => {
+    /*
+     * The box is a switch; its sysDescr is the vendor's boilerplate about
+     * the software image, which mentions routing.
+     */
+    expect(
+      classifyDeviceRole({
+        deviceModel: "Catalyst 2960X",
+        sysDescr: "Cisco IOS Software, IP Routing Base",
+      }),
+    ).toBe("switch");
+  });
+
+  test("sysDescr beats sysObjectId", () => {
+    expect(
+      classifyDeviceRole({
+        sysDescr: "FortiSwitch-148F",
+        // Fortinet's arc on its own would say firewall.
+        sysObjectId: "1.3.6.1.4.1.12356.106.1.1",
+      }),
+    ).toBe("switch");
+  });
+
+  test("sysObjectId beats the generic words in sysDescr", () => {
+    expect(
+      classifyDeviceRole({
+        sysDescr: "Linux-based security gateway appliance",
+        sysObjectId: "1.3.6.1.4.1.3375.2.1.3.4.10",
+      }),
+    ).toBe("loadBalancer");
+  });
+
+  test("a generic word in sysDescr beats the hostname convention", () => {
+    expect(
+      classifyDeviceRole({
+        sysDescr: "24-port Gigabit Switch",
+        name: "edge-fw01",
+      }),
+    ).toBe("switch");
+  });
+
+  test("sysName is preferred to name when the two disagree", () => {
+    expect(
+      classifyDeviceRole({ sysName: "core-rtr-1", name: "core-sw-1" }),
+    ).toBe("router");
+  });
+
+  test("the hostname beats a Linux kernel in sysDescr", () => {
+    /*
+     * The regression this ordering exists for: plenty of network gear
+     * announces "Linux ...", and calling every one of them a server would
+     * shape the whole map wrong.
+     */
+    expect(
+      classifyDeviceRole({
+        sysDescr: "Linux gw-1 5.4.0-91-generic x86_64",
+        name: "gw-1",
+      }),
+    ).toBe("router");
+    expect(
+      classifyDeviceRole({
+        sysDescr: "Linux fw-edge-1 5.15.0 x86_64",
+        name: "fw-edge-1",
+      }),
+    ).toBe("firewall");
+  });
+
+  test("the hostname also beats a generic SNMP agent OID", () => {
+    expect(
+      classifyDeviceRole({
+        sysObjectId: "1.3.6.1.4.1.8072.3.2.10",
+        name: "core-sw-2",
+      }),
+    ).toBe("switch");
+  });
+
+  test("a Linux box with an uninformative name is still a server", () => {
+    expect(
+      classifyDeviceRole({
+        sysDescr: "Linux app-3 5.4.0-91-generic x86_64",
+        name: "app-3",
+      }),
+    ).toBe("server");
+  });
+});
+
+describe("classifyDeviceRole — sysObjectId arcs", () => {
+  test("single-role vendor arcs", () => {
+    expect(
+      classifyDeviceRole({ sysObjectId: "1.3.6.1.4.1.25461.2.3.18" }),
+    ).toBe("firewall");
+    expect(classifyDeviceRole({ sysObjectId: "1.3.6.1.4.1.789.2.5" })).toBe(
+      "storage",
+    );
+    expect(
+      classifyDeviceRole({ sysObjectId: "1.3.6.1.4.1.30065.1.3011" }),
+    ).toBe("switch");
+    expect(classifyDeviceRole({ sysObjectId: "1.3.6.1.4.1.14988.1" })).toBe(
+      "router",
+    );
+  });
+
+  test("a leading dot, which many agents emit, is tolerated", () => {
+    expect(classifyDeviceRole({ sysObjectId: ".1.3.6.1.4.1.3375.2.1.3" })).toBe(
+      "loadBalancer",
+    );
+  });
+
+  test("an exact arc with no children matches", () => {
+    expect(classifyDeviceRole({ sysObjectId: "1.3.6.1.4.1.789" })).toBe(
+      "storage",
+    );
+  });
+
+  test("matching is on dotted boundaries, so a longer arc is not a prefix", () => {
+    /*
+     * ".11" (HP) must not swallow ".1124", and the printer arc under HP
+     * must not claim every HP switch.
+     */
+    expect(classifyDeviceRole({ sysObjectId: "1.3.6.1.4.1.7890.1" })).toBe(
+      "unknown",
+    );
+    expect(classifyDeviceRole({ sysObjectId: "1.3.6.1.4.1.11.2.3.7.11" })).toBe(
+      "unknown",
+    );
+    expect(classifyDeviceRole({ sysObjectId: "1.3.6.1.4.1.11.2.3.9.1" })).toBe(
+      "printer",
+    );
+  });
+
+  test("a mixed-catalogue vendor's arc says nothing on its own", () => {
+    // Cisco and Juniper make every kind of box; their arcs are no evidence.
+    expect(classifyDeviceRole({ sysObjectId: "1.3.6.1.4.1.9.1.1745" })).toBe(
+      "unknown",
+    );
+    expect(classifyDeviceRole({ sysObjectId: "1.3.6.1.4.1.2636.1.1.1" })).toBe(
+      "unknown",
+    );
+  });
+});
+
+describe("classifyDeviceRole — hostname conventions", () => {
+  test("the common abbreviations, as whole tokens", () => {
+    const expectations: Array<[string, NetworkTopologyDeviceRole]> = [
+      ["core-rtr-1", "router"],
+      ["dc1-gw01", "router"],
+      ["idf2-sw-3", "switch"],
+      ["spine-01", "switch"],
+      ["edge-fw01", "firewall"],
+      ["bldg-a-ap-12", "wirelessAccessPoint"],
+      ["prod-lb-2", "loadBalancer"],
+      ["srv-db-1", "server"],
+      ["nas-backup", "storage"],
+      ["lobby-cam-4", "camera"],
+    ];
+    for (const [name, role] of expectations) {
+      expect(classifyDeviceRole({ name: name })).toBe(role);
+    }
+  });
+
+  test("separators other than the hyphen work too", () => {
+    expect(classifyDeviceRole({ name: "core.sw.1" })).toBe("switch");
+    expect(classifyDeviceRole({ name: "core_fw_1" })).toBe("firewall");
+    expect(classifyDeviceRole({ name: "CORE SW 1" })).toBe("switch");
+  });
+
+  test("substrings never match — this is the whole point of tokenizing", () => {
+    expect(classifyDeviceRole({ name: "swansea-office" })).toBe("unknown");
+    expect(classifyDeviceRole({ name: "apex-1" })).toBe("unknown");
+    expect(classifyDeviceRole({ name: "lbrary-node" })).toBe("unknown");
+    expect(classifyDeviceRole({ name: "greatwall" })).toBe("unknown");
+  });
+
+  test("a token with a trailing index still matches", () => {
+    expect(classifyDeviceRole({ name: "sw01" })).toBe("switch");
+    expect(classifyDeviceRole({ name: "fw2.example.com" })).toBe("firewall");
+  });
+});
+
+describe("classifyDeviceRole — nothing to go on", () => {
+  test("empty, blank and absent signals all come back unknown", () => {
+    expect(classifyDeviceRole({})).toBe("unknown");
+    expect(
+      classifyDeviceRole({
+        name: "",
+        sysName: "   ",
+        sysDescr: "",
+        deviceModel: undefined,
+        sysObjectId: "",
+      }),
+    ).toBe("unknown");
+  });
+
+  test("an unremarkable name is unknown, not a bad guess", () => {
+    expect(classifyDeviceRole({ name: "device-42" })).toBe("unknown");
+  });
+
+  test("classification is case- and whitespace-insensitive", () => {
+    expect(classifyDeviceRole({ deviceModel: "  CATALYST   2960X  " })).toBe(
+      "switch",
+    );
+    expect(classifyDeviceRole({ deviceModel: "fortigate-60f" })).toBe(
+      "firewall",
+    );
+  });
+});
+
+describe("classifyEndpointRole", () => {
+  test("an endpoint with nothing said about it is a host", () => {
+    expect(classifyEndpointRole({})).toBe("host");
+    expect(classifyEndpointRole({ name: "aa:bb:cc:dd:ee:ff" })).toBe("host");
+    expect(classifyEndpointRole({ classification: "POS terminal" })).toBe(
+      "host",
+    );
+    expect(classifyEndpointRole({ classification: "Kiosk" })).toBe("host");
+  });
+
+  test("the human-typed classification is read first", () => {
+    expect(classifyEndpointRole({ classification: "Camera" })).toBe("camera");
+    expect(classifyEndpointRole({ classification: "printer" })).toBe("printer");
+    expect(classifyEndpointRole({ classification: "IP phone" })).toBe("phone");
+    expect(classifyEndpointRole({ classification: "Access point" })).toBe(
+      "wirelessAccessPoint",
+    );
+  });
+
+  test("the OUI vendor is the fallback when nobody classified it", () => {
+    expect(
+      classifyEndpointRole({ vendor: "Hikvision Digital Technology" }),
+    ).toBe("camera");
+    expect(classifyEndpointRole({ vendor: "Zebra Technologies" })).toBe(
+      "printer",
+    );
+    expect(classifyEndpointRole({ vendor: "Polycom Inc" })).toBe("phone");
+  });
+
+  test("a classification wins over a vendor that disagrees", () => {
+    expect(
+      classifyEndpointRole({
+        classification: "Camera",
+        vendor: "Zebra Technologies",
+      }),
+    ).toBe("camera");
+  });
+
+  test("an unrecognised vendor leaves it a host", () => {
+    expect(classifyEndpointRole({ vendor: "Intel Corporate" })).toBe("host");
+  });
+
+  test("the name is the last resort", () => {
+    expect(classifyEndpointRole({ name: "warehouse-camera-3" })).toBe("camera");
+  });
+});
+
+describe("labels", () => {
+  test("every role has a label", () => {
+    const roles: Array<NetworkTopologyDeviceRole> = Object.keys(
+      DEVICE_ROLE_LABELS,
+    ) as Array<NetworkTopologyDeviceRole>;
+    for (const role of roles) {
+      expect(typeof DEVICE_ROLE_LABELS[role]).toBe("string");
+      expect(DEVICE_ROLE_LABELS[role].length).toBeGreaterThan(0);
+    }
+  });
+
+  test("labelForDeviceRole falls back for an absent role", () => {
+    expect(labelForDeviceRole("switch")).toBe("Switch");
+    expect(labelForDeviceRole(undefined)).toBe(DEVICE_ROLE_LABELS.unknown);
+  });
+
+  test("the legend order lists every role except unknown, once each", () => {
+    expect(DEVICE_ROLES_IN_LEGEND_ORDER).not.toContain("unknown");
+    expect(new Set(DEVICE_ROLES_IN_LEGEND_ORDER).size).toBe(
+      DEVICE_ROLES_IN_LEGEND_ORDER.length,
+    );
+    expect(DEVICE_ROLES_IN_LEGEND_ORDER.length).toBe(
+      Object.keys(DEVICE_ROLE_LABELS).length - 1,
+    );
+  });
+});

--- a/Common/Tests/Utils/Monitor/NetworkTopologyUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/NetworkTopologyUtil.test.ts
@@ -445,3 +445,243 @@ describe("NetworkTopologyUtil.buildTopology", () => {
     });
   });
 });
+
+/*
+ * Roles are what give every node on the map its shape, so the builder has
+ * to attach one to all three kinds of node — the devices it was given,
+ * the unmanaged peers it invented from neighbor claims, and the endpoints
+ * it hung off switch ports.
+ */
+describe("NetworkTopologyUtil.buildTopology — device roles", () => {
+  const now: Date = new Date("2026-07-22T12:00:00Z");
+  const fresh: Date = new Date("2026-07-22T11:55:00Z");
+
+  const nodeById: (
+    result: TopologyBuildResult,
+    id: string,
+  ) => NetworkTopologyNode | undefined = (
+    result: TopologyBuildResult,
+    id: string,
+  ): NetworkTopologyNode | undefined => {
+    return result.nodes.find((node: NetworkTopologyNode) => {
+      return node.id === id;
+    });
+  };
+
+  test("managed devices are classified from their SNMP identity", () => {
+    const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+      [
+        {
+          id: "d1",
+          name: "core-1",
+          lastSeenAt: fresh,
+          deviceModel: "Catalyst 9300-48P",
+        },
+        {
+          id: "d2",
+          name: "edge-1",
+          lastSeenAt: fresh,
+          sysDescr: "FortiGate-60F v7.2.5",
+        },
+        {
+          id: "d3",
+          name: "dmz-1",
+          lastSeenAt: fresh,
+          sysObjectId: "1.3.6.1.4.1.3375.2.1.3.4.10",
+        },
+      ],
+      now,
+    );
+
+    expect(nodeById(result, "d1")?.role).toBe("switch");
+    expect(nodeById(result, "d2")?.role).toBe("firewall");
+    expect(nodeById(result, "d3")?.role).toBe("loadBalancer");
+  });
+
+  test("a device with no identity at all still carries an explicit role", () => {
+    const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+      [{ id: "d1", name: "device-42", lastSeenAt: fresh }],
+      now,
+    );
+    /*
+     * Explicitly "unknown" rather than absent — readers must not have to
+     * distinguish "we could not tell" from "this payload is old".
+     */
+    expect(nodeById(result, "d1")?.role).toBe("unknown");
+  });
+
+  test("the hostname is read as a last resort, sysName ahead of name", () => {
+    const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+      [
+        { id: "d1", name: "idf2-sw-3", lastSeenAt: fresh },
+        {
+          id: "d2",
+          name: "unhelpful",
+          sysName: "core-rtr-1",
+          lastSeenAt: fresh,
+        },
+      ],
+      now,
+    );
+    expect(nodeById(result, "d1")?.role).toBe("switch");
+    expect(nodeById(result, "d2")?.role).toBe("router");
+  });
+
+  test("an unmanaged CDP peer is classified from the platform it advertises", () => {
+    const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+      [
+        {
+          id: "d1",
+          name: "edge-1",
+          lastSeenAt: fresh,
+          cdpNeighbors: [
+            {
+              localInterfaceIndex: 1,
+              remoteDeviceId: "ap-lobby",
+              remotePlatform: "cisco AIR-CAP3702I-A-K9",
+            },
+          ],
+        },
+      ],
+      now,
+    );
+    expect(nodeById(result, "unmanaged:ap-lobby")?.role).toBe(
+      "wirelessAccessPoint",
+    );
+  });
+
+  test("a peer known only by name falls back to the naming convention", () => {
+    const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+      [
+        {
+          id: "d1",
+          name: "edge-1",
+          lastSeenAt: fresh,
+          lldpNeighbors: [
+            { localInterfaceIndex: 1, remoteSysName: "dist-sw-9" },
+          ],
+        },
+      ],
+      now,
+    );
+    expect(nodeById(result, "unmanaged:dist-sw-9")?.role).toBe("switch");
+  });
+
+  test("a peer with nothing to go on is unknown, not guessed at", () => {
+    const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+      [
+        {
+          id: "d1",
+          name: "edge-1",
+          lastSeenAt: fresh,
+          lldpNeighbors: [{ localInterfaceIndex: 1, remoteSysName: "peer-a" }],
+        },
+      ],
+      now,
+    );
+    expect(nodeById(result, "unmanaged:peer-a")?.role).toBe("unknown");
+  });
+
+  test("a later claim that brings a platform re-derives the peer's role", () => {
+    /*
+     * LLDP reports the peer first, by name only, so it starts out
+     * unknown; the CDP claim that follows carries the platform string —
+     * the only real evidence about that box — and must be allowed to
+     * change the shape it is drawn as.
+     */
+    const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+      [
+        {
+          id: "d1",
+          name: "edge-1",
+          lastSeenAt: fresh,
+          lldpNeighbors: [{ localInterfaceIndex: 1, remoteSysName: "peer-a" }],
+          cdpNeighbors: [
+            {
+              localInterfaceIndex: 1,
+              remoteDeviceId: "peer-a",
+              remotePlatform: "cisco WS-C2960X-48TS-L",
+            },
+          ],
+        },
+      ],
+      now,
+    );
+    const peer: NetworkTopologyNode | undefined = nodeById(
+      result,
+      "unmanaged:peer-a",
+    );
+    expect(peer?.deviceModel).toBe("cisco WS-C2960X-48TS-L");
+    expect(peer?.role).toBe("switch");
+  });
+
+  test("endpoints are hosts unless their classification says otherwise", () => {
+    const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+      [{ id: "d1", name: "edge-1", lastSeenAt: fresh }],
+      now,
+      [],
+      [
+        {
+          id: "e1",
+          macAddress: "aa:aa:aa:aa:aa:01",
+          attachedNetworkDeviceId: "d1",
+          lastSeenAt: fresh,
+        },
+        {
+          id: "e2",
+          macAddress: "aa:aa:aa:aa:aa:02",
+          classification: "Camera",
+          attachedNetworkDeviceId: "d1",
+          lastSeenAt: fresh,
+        },
+        {
+          id: "e3",
+          macAddress: "aa:aa:aa:aa:aa:03",
+          vendor: "Zebra Technologies",
+          attachedNetworkDeviceId: "d1",
+          lastSeenAt: fresh,
+        },
+        {
+          id: "e4",
+          macAddress: "aa:aa:aa:aa:aa:04",
+          classification: "POS terminal",
+          attachedNetworkDeviceId: "d1",
+          lastSeenAt: fresh,
+        },
+      ],
+    );
+
+    expect(nodeById(result, "endpoint:e1")?.role).toBe("host");
+    expect(nodeById(result, "endpoint:e2")?.role).toBe("camera");
+    expect(nodeById(result, "endpoint:e3")?.role).toBe("printer");
+    expect(nodeById(result, "endpoint:e4")?.role).toBe("host");
+  });
+
+  test("every node the builder emits carries a role", () => {
+    const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+      [
+        {
+          id: "d1",
+          name: "edge-1",
+          lastSeenAt: fresh,
+          lldpNeighbors: [{ localInterfaceIndex: 1, remoteSysName: "peer-a" }],
+        },
+      ],
+      now,
+      [],
+      [
+        {
+          id: "e1",
+          macAddress: "aa:aa:aa:aa:aa:01",
+          attachedNetworkDeviceId: "d1",
+          lastSeenAt: fresh,
+        },
+      ],
+    );
+
+    expect(result.nodes).toHaveLength(3);
+    for (const node of result.nodes) {
+      expect(node.role).toBeDefined();
+    }
+  });
+});

--- a/Common/Types/Monitor/SnmpMonitor/NetworkTopology.ts
+++ b/Common/Types/Monitor/SnmpMonitor/NetworkTopology.ts
@@ -26,6 +26,31 @@ export type NetworkTopologyLinkProtocol = "lldp" | "cdp" | "fdb";
  */
 export type NetworkTopologyNodeKind = "device" | "unmanaged" | "endpoint";
 
+/*
+ * What the node DOES on the network, as opposed to what we know about it
+ * (`kind`). Derived server-side from the identity SNMP and the discovery
+ * protocols already report — sysObjectId, sysDescr, model/platform, and
+ * finally the hostname — because a map on which a router, a switch and a
+ * camera are the same circle cannot be read at a glance.
+ *
+ * "unknown" is a real answer, not a failure: guessing a role from thin
+ * evidence is worse than drawing a neutral node, so the classifier only
+ * commits when the evidence names a product family or says the word.
+ */
+export type NetworkTopologyDeviceRole =
+  | "router"
+  | "switch"
+  | "firewall"
+  | "wirelessAccessPoint"
+  | "loadBalancer"
+  | "server"
+  | "storage"
+  | "printer"
+  | "camera"
+  | "phone"
+  | "host"
+  | "unknown";
+
 export interface NetworkTopologyNode {
   // Device id for managed nodes; a synthetic "unmanaged:<key>" id otherwise.
   id: string;
@@ -34,6 +59,12 @@ export interface NetworkTopologyNode {
   status: NetworkTopologyNodeStatus;
   // Missing on older payloads — derive from isManaged.
   kind?: NetworkTopologyNodeKind | undefined;
+  /*
+   * What the node does on the network (router, switch, firewall, ...).
+   * Missing on older payloads, and "unknown" when the evidence did not
+   * name one — readers must treat both the same way.
+   */
+  role?: NetworkTopologyDeviceRole | undefined;
   interfacesUp?: number | undefined;
   interfacesDown?: number | undefined;
   // Extra device identity for search and the detail panel (managed nodes).

--- a/Common/Utils/Monitor/NetworkDeviceRoleUtil.ts
+++ b/Common/Utils/Monitor/NetworkDeviceRoleUtil.ts
@@ -1,0 +1,533 @@
+import { NetworkTopologyDeviceRole } from "../../Types/Monitor/SnmpMonitor/NetworkTopology";
+
+/*
+ * Works out what a node on the network topology map DOES — router, switch,
+ * firewall, access point, load balancer, server, storage, or one of the
+ * leaf roles (printer, camera, phone, plain host).
+ *
+ * Why derive it rather than store it: nothing in SNMP hands us a role. The
+ * evidence we already collect does, though, and it arrives in a strict
+ * order of trustworthiness:
+ *
+ *   1. the product family in sysDescr / model / the CDP platform string
+ *      ("Catalyst 2960", "FortiGate-60F", "SRX340") — a named family is
+ *      the closest thing to a declaration of purpose,
+ *   2. the sysObjectId enterprise arc, for the vendors whose entire
+ *      catalogue is one role (Palo Alto, F5, NetApp, ...),
+ *   3. the generic words in sysDescr ("... Switch ...", "Load Balancer"),
+ *   4. the naming convention in the hostname ("core-sw-1", "edge-fw01"),
+ *   5. last and weakest, a general-purpose OS or SNMP agent in sysDescr —
+ *      "it is a computer", which loses to a hostname that says otherwise
+ *      because switches and firewalls announce Linux kernels too.
+ *
+ * Each tier is weaker than the one above it, so they are tried in order
+ * and the first answer wins. When nothing matches the answer is "unknown",
+ * which is deliberate: a neutral node is honest, and a router drawn as a
+ * firewall because its hostname happened to contain "fw" is not. This is
+ * also why unmanaged CDP/LLDP peers — for which we have a platform string
+ * and a name and nothing else — mostly come back "unknown", and should.
+ *
+ * Pure and dependency-free so it runs identically in the topology builder
+ * on the server and in the unit tests.
+ */
+
+/** Everything the classifier is allowed to look at. All best-effort. */
+export interface DeviceRoleSignals {
+  sysDescr?: string | undefined;
+  sysObjectId?: string | undefined;
+  vendor?: string | undefined;
+  /** NetworkDevice.deviceModel for managed nodes. */
+  deviceModel?: string | undefined;
+  /** The CDP platform string an unmanaged peer advertises about itself. */
+  platform?: string | undefined;
+  name?: string | undefined;
+  sysName?: string | undefined;
+}
+
+/** What a discovered (ARP/FDB) endpoint tells us about itself. */
+export interface EndpointRoleSignals {
+  /** User-editable free text: "POS", "Camera", "Printer", ... */
+  classification?: string | undefined;
+  vendor?: string | undefined;
+  name?: string | undefined;
+}
+
+interface RoleRule {
+  role: NetworkTopologyDeviceRole;
+  pattern: RegExp;
+  /*
+   * Only applied when the vendor evidence matches. This is what keeps
+   * Juniper's MX960 (a core router) apart from Meraki's MX64 (a security
+   * appliance) — the model strings are otherwise the same shape.
+   */
+  vendor?: RegExp | undefined;
+}
+
+/** Human-readable role names. One source of truth for UI and tests. */
+export const DEVICE_ROLE_LABELS: Record<NetworkTopologyDeviceRole, string> = {
+  router: "Router",
+  switch: "Switch",
+  firewall: "Firewall",
+  wirelessAccessPoint: "Wireless AP",
+  loadBalancer: "Load balancer",
+  server: "Server",
+  storage: "Storage",
+  printer: "Printer",
+  camera: "Camera",
+  phone: "IP phone",
+  host: "Host",
+  unknown: "Unknown type",
+};
+
+/** Every role except "unknown", in the order a legend should list them. */
+export const DEVICE_ROLES_IN_LEGEND_ORDER: ReadonlyArray<NetworkTopologyDeviceRole> =
+  [
+    "router",
+    "switch",
+    "firewall",
+    "wirelessAccessPoint",
+    "loadBalancer",
+    "server",
+    "storage",
+    "printer",
+    "camera",
+    "phone",
+    "host",
+  ];
+
+/*
+ * Tier 1 — named product families. Ordered most specific first, because
+ * the first match wins: the leaf roles come before the infrastructure
+ * ones so "Cisco IP Phone 7961" is a phone rather than being swallowed by
+ * a later Cisco rule.
+ *
+ * A note on the boundaries. Every pattern is anchored with a LEADING \b
+ * and, for the model-code alternatives, deliberately no trailing one:
+ * real model strings run straight on into suffixes ("AIR-CAP3702I-A-K9",
+ * "C9300L-24P", "DCS-7050SX3-48YC8"), and a closing \b silently refuses
+ * to match every one of them. Alternatives that are ordinary words keep
+ * their own trailing \b, so "nas" cannot match "nasa".
+ */
+const PRODUCT_RULES: ReadonlyArray<RoleRule> = [
+  // --- leaf devices that also speak SNMP ---
+  {
+    role: "camera",
+    pattern:
+      /\b(?:ip[- ]?camera|network camera|cctv\b|nvr\b|hikvision|dahua|axis [pqmf]\d{4})/,
+  },
+  { role: "camera", pattern: /\bmv\d{2}/, vendor: /meraki|cisco/ },
+  {
+    role: "phone",
+    pattern:
+      /\b(?:ip phone|voip phone|desk phone|polycom|yealink|grandstream|snom\b|spa\d{3}|cp-\d{4})/,
+  },
+  {
+    role: "printer",
+    pattern:
+      /\b(?:laserjet|officejet|deskjet|designjet|jetdirect|imagerunner|workcentre|workcenter|bizhub|kyocera|lexmark|mfp\b|multifunction printer)/,
+  },
+
+  // --- firewalls / security appliances ---
+  { role: "firewall", pattern: /\b(?:fortigate|fortiwifi|forti-gate)/ },
+  {
+    role: "firewall",
+    pattern: /\b(?:palo alto|pan-?os\b|pa-\d{3,4})/,
+  },
+  {
+    role: "firewall",
+    pattern:
+      /\b(?:adaptive security appliance|cisco asa\b|asa\d{4}|firepower|ftd\b|pix\b)/,
+  },
+  { role: "firewall", pattern: /\bsrx ?\d{2,4}|\bsrx\b/ },
+  {
+    role: "firewall",
+    pattern:
+      /\b(?:sonicwall|watchguard|check ?point|gaia\b|pfsense|opnsense|untangle|barracuda)/,
+  },
+  { role: "firewall", pattern: /\bsophos (?:xg|xgs|utm|sg)\b/ },
+  {
+    role: "firewall",
+    pattern: /\bmx\d{2,3}|\bz\d{1,2}\b/,
+    vendor: /meraki/,
+  },
+
+  // --- load balancers / application delivery ---
+  {
+    role: "loadBalancer",
+    pattern:
+      /\b(?:big-?ip|f5 networks|tmos\b|netscaler|citrix adc|a10 thunder|ax\d{4}|loadmaster|avi vantage|haproxy)/,
+  },
+
+  // --- wireless ---
+  {
+    role: "wirelessAccessPoint",
+    pattern:
+      /\b(?:aironet|air-(?:cap|ap|lap|sap|ct)|wlc\b|wireless lan controller|wireless controller)/,
+  },
+  /*
+   * Cisco recycled "Catalyst" across three roles, so the two that are not
+   * switches have to be claimed before the blanket Catalyst rule below:
+   * a 9800 is a wireless controller and an 8000 is a router.
+   */
+  {
+    role: "wirelessAccessPoint",
+    pattern: /\b(?:catalyst 98\d{2}|c98\d{2})/,
+  },
+  {
+    role: "wirelessAccessPoint",
+    pattern:
+      /\b(?:unifi ap|uap[- ]|u6-|nanostation|instant ap|iap\b|aruba ap|ap-\d{3}|fortiap|omada|eap\d{3}|cw9\d{3})/,
+  },
+  {
+    role: "wirelessAccessPoint",
+    pattern: /\bmr\d{2,3}/,
+    vendor: /meraki/,
+  },
+
+  /*
+   * --- switches ---
+   * First, the other half of the Catalyst disambiguation above.
+   */
+  {
+    role: "router",
+    pattern: /\b(?:catalyst 8\d{3}|c8\d{3})/,
+  },
+  {
+    role: "switch",
+    pattern:
+      /\b(?:catalyst|nexus|ws-c\d|c9[2345]\d{2}|c1000|c2960|c3[578]\d{2}|me-\d{4})/,
+  },
+  {
+    role: "switch",
+    pattern: /\b(?:ex\d{4}|qfx\d{4})/,
+  },
+  {
+    role: "switch",
+    pattern: /\bms\d{2,3}/,
+    vendor: /meraki/,
+  },
+  {
+    role: "switch",
+    pattern:
+      /\b(?:fortiswitch|procurve|powerconnect|force10|dcs-\d{4}|icx\d{4}|edgeswitch|unifi switch|usw-|crs\d{3}|css\d{3}|sg\d{3}|gs\d{3}|jl\d{3}[a-z]|s\d{4}-on|n\d{4}-on)/,
+  },
+
+  // --- routers ---
+  {
+    role: "router",
+    pattern: /\b(?:isr ?\d{3,4}|isr\b|asr ?\d{3,4}|c11\d{2}|c89\d\b|csr1000v)/,
+  },
+  {
+    role: "router",
+    pattern: /\b(?:mx\d{2,4}|ptx\d{4}|acx\d{4})/,
+    vendor: /juniper|junos/,
+  },
+  {
+    role: "router",
+    pattern:
+      /\b(?:routeros|mikrotik|ccr\d{4}|rb\d{3,4}|edgerouter|vyos\b|vsr\b)/,
+  },
+
+  // --- storage ---
+  {
+    role: "storage",
+    pattern:
+      /\b(?:netapp|data ontap|isilon|powerstore|powervault|unity xt|synology|qnap|truenas|freenas|pure ?storage|nimble storage|storwize|nas\b|san\b)/,
+  },
+
+  // --- servers / hypervisors / lights-out controllers ---
+  {
+    role: "server",
+    pattern:
+      /\b(?:esxi|vmware|proxmox|hyper-?v\b|xenserver|idrac\b|ilo\b|integrated lights-out|cimc\b|poweredge|proliant|thinksystem|primergy)/,
+  },
+];
+
+/*
+ * Tier 3 — the generic words. Only consulted when no product family
+ * matched, and only against sysDescr, which is the one field vendors
+ * write a sentence into.
+ */
+const GENERIC_RULES: ReadonlyArray<RoleRule> = [
+  {
+    role: "firewall",
+    pattern: /\b(firewall|security appliance|utm appliance)\b/,
+  },
+  {
+    role: "loadBalancer",
+    pattern: /\b(load ?balancer|application delivery controller)\b/,
+  },
+  {
+    role: "wirelessAccessPoint",
+    pattern: /\b(access point|wireless|wi-?fi|wlan)\b/,
+  },
+  { role: "printer", pattern: /\b(printer|print server|copier|scanner)\b/ },
+  { role: "camera", pattern: /\bcamera\b/ },
+  { role: "phone", pattern: /\b(phone|voip)\b/ },
+  { role: "switch", pattern: /\b(switch|switching)\b/ },
+  { role: "router", pattern: /\b(router|routing|gateway)\b/ },
+  { role: "storage", pattern: /\b(storage array|storage system|filer)\b/ },
+];
+
+/*
+ * The weakest evidence there is: a general-purpose operating system in
+ * sysDescr. It says the box is a computer, not what job it does — plenty
+ * of switches and firewalls announce a Linux kernel — so it is consulted
+ * only after the hostname has had its say. A machine called "gw-1" that
+ * runs Linux is a router; a machine called "app-3" that runs Linux is a
+ * server.
+ */
+const OPERATING_SYSTEM_RULES: ReadonlyArray<RoleRule> = [
+  {
+    role: "server",
+    pattern:
+      /\b(linux|windows|ubuntu|debian|centos|red ?hat|freebsd|solaris|net-snmp|\bserver\b)\b/,
+  },
+];
+
+/*
+ * Tier 2 — sysObjectId enterprise arcs, for vendors that only make one
+ * kind of box. Deliberately short: a vendor with a mixed catalogue (Cisco,
+ * Juniper, HPE, Ubiquiti) tells us nothing here, and a wrong shape is
+ * worse than a neutral one. Matched on dotted-prefix boundaries so
+ * ".1.3.6.1.4.1.11" cannot swallow ".1.3.6.1.4.1.1124".
+ */
+const SYS_OBJECT_ID_RULES: ReadonlyArray<{
+  prefix: string;
+  role: NetworkTopologyDeviceRole;
+}> = [
+  // Printers, most specific arcs first (HP's printer arc sits under HP's).
+  { prefix: "1.3.6.1.4.1.11.2.3.9", role: "printer" },
+  { prefix: "1.3.6.1.4.1.641", role: "printer" }, // Lexmark
+  { prefix: "1.3.6.1.4.1.1602", role: "printer" }, // Canon
+  { prefix: "1.3.6.1.4.1.367", role: "printer" }, // Ricoh
+  { prefix: "1.3.6.1.4.1.253", role: "printer" }, // Xerox
+  { prefix: "1.3.6.1.4.1.1248", role: "printer" }, // Epson
+  { prefix: "1.3.6.1.4.1.236", role: "printer" }, // Samsung printers
+  // Firewalls.
+  { prefix: "1.3.6.1.4.1.12356", role: "firewall" }, // Fortinet
+  { prefix: "1.3.6.1.4.1.25461", role: "firewall" }, // Palo Alto
+  { prefix: "1.3.6.1.4.1.2620", role: "firewall" }, // Check Point
+  { prefix: "1.3.6.1.4.1.8741", role: "firewall" }, // SonicWall
+  { prefix: "1.3.6.1.4.1.3097", role: "firewall" }, // WatchGuard
+  { prefix: "1.3.6.1.4.1.2604", role: "firewall" }, // Sophos / Astaro
+  // Load balancers.
+  { prefix: "1.3.6.1.4.1.3375", role: "loadBalancer" }, // F5
+  { prefix: "1.3.6.1.4.1.5951", role: "loadBalancer" }, // Citrix NetScaler
+  { prefix: "1.3.6.1.4.1.22610", role: "loadBalancer" }, // A10
+  // Storage.
+  { prefix: "1.3.6.1.4.1.789", role: "storage" }, // NetApp
+  // Switching / routing houses.
+  { prefix: "1.3.6.1.4.1.30065", role: "switch" }, // Arista
+  { prefix: "1.3.6.1.4.1.6027", role: "switch" }, // Force10 / Dell
+  { prefix: "1.3.6.1.4.1.14988", role: "router" }, // MikroTik
+];
+
+/*
+ * Generic SNMP agents. These identify the AGENT, not the appliance — a
+ * Linux firewall answers on Net-SNMP just as readily as a database server
+ * does — so, like the OS rules, they are consulted only after the
+ * hostname.
+ */
+const GENERIC_AGENT_SYS_OBJECT_ID_RULES: ReadonlyArray<{
+  prefix: string;
+  role: NetworkTopologyDeviceRole;
+}> = [
+  { prefix: "1.3.6.1.4.1.8072", role: "server" }, // Net-SNMP
+  { prefix: "1.3.6.1.4.1.2021", role: "server" }, // UCD-SNMP
+  { prefix: "1.3.6.1.4.1.311", role: "server" }, // Microsoft
+  { prefix: "1.3.6.1.4.1.6876", role: "server" }, // VMware
+];
+
+/*
+ * Tier 4 — hostname conventions. Whole tokens only ("core-sw-1" → "sw",
+ * "edge-fw01" → "fw01"), never substrings, so "swan" is not a switch and
+ * "apex" is not an access point.
+ */
+const NAME_RULES: ReadonlyArray<RoleRule> = [
+  { role: "router", pattern: /^(rtr|router|rt|gw|gwy|gateway)\d*$/ },
+  {
+    role: "switch",
+    pattern: /^(sw|swi|switch|sws|dsw|asw|csw|tor|leaf|spine)\d*$/,
+  },
+  { role: "firewall", pattern: /^(fw|fwl|firewall|asa|ngfw|utm)\d*$/ },
+  { role: "wirelessAccessPoint", pattern: /^(ap|wap|wifi|wlan|wlc)\d*$/ },
+  { role: "loadBalancer", pattern: /^(lb|slb|adc|vip)\d*$/ },
+  { role: "server", pattern: /^(srv|server|esx|esxi|vmhost)\d*$/ },
+  { role: "storage", pattern: /^(nas|san|stor|storage|filer)\d*$/ },
+  { role: "camera", pattern: /^(cam|camera|ipcam|cctv)\d*$/ },
+  { role: "printer", pattern: /^(prn|print|printer|mfp)\d*$/ },
+  { role: "phone", pattern: /^(phone|voip|sip)\d*$/ },
+];
+
+/*
+ * Endpoint classifications are free text a human typed, so they are
+ * matched loosely — but still whole-word, and still ordered so the
+ * specific ones win.
+ */
+const ENDPOINT_RULES: ReadonlyArray<RoleRule> = [
+  {
+    role: "camera",
+    pattern:
+      /\b(camera|cam|cctv|nvr|dvr|hikvision|dahua|axis communications)\b/,
+  },
+  {
+    role: "printer",
+    pattern:
+      /\b(printer|print|mfp|copier|scanner|label|zebra|brother|lexmark|kyocera|ricoh|xerox|epson)\b/,
+  },
+  {
+    role: "phone",
+    pattern:
+      /\b(phone|voip|sip|handset|intercom|polycom|yealink|avaya|mitel)\b/,
+  },
+  {
+    role: "wirelessAccessPoint",
+    pattern: /\b(access point|\bap\b|wireless|wi-?fi)\b/,
+  },
+  { role: "switch", pattern: /\bswitch\b/ },
+  { role: "router", pattern: /\b(router|gateway)\b/ },
+  { role: "server", pattern: /\b(server|nas|hypervisor)\b/ },
+];
+
+/** Lowercase, whitespace-collapsed, and safe on undefined. */
+function normalize(value: string | undefined): string {
+  return (value || "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function firstMatch(
+  rules: ReadonlyArray<RoleRule>,
+  haystack: string,
+  vendorText: string,
+): NetworkTopologyDeviceRole | undefined {
+  if (!haystack) {
+    return undefined;
+  }
+  for (const rule of rules) {
+    if (rule.vendor && !rule.vendor.test(vendorText)) {
+      continue;
+    }
+    if (rule.pattern.test(haystack)) {
+      return rule.role;
+    }
+  }
+  return undefined;
+}
+
+/*
+ * Dotted-prefix containment: the arc must end at a dot or at the end of
+ * the OID. Leading dots (".1.3.6.1...", which plenty of agents emit) are
+ * stripped first.
+ */
+function roleForSysObjectId(
+  sysObjectId: string | undefined,
+  rules: ReadonlyArray<{ prefix: string; role: NetworkTopologyDeviceRole }>,
+): NetworkTopologyDeviceRole | undefined {
+  const oid: string = normalize(sysObjectId).replace(/^\.+/, "");
+  if (!oid) {
+    return undefined;
+  }
+  for (const rule of rules) {
+    if (oid === rule.prefix || oid.startsWith(`${rule.prefix}.`)) {
+      return rule.role;
+    }
+  }
+  return undefined;
+}
+
+function roleForNameText(
+  value: string | undefined,
+): NetworkTopologyDeviceRole | undefined {
+  const text: string = normalize(value);
+  if (!text) {
+    return undefined;
+  }
+  /*
+   * Split on anything that is not a letter or a digit, which is how the
+   * separators people actually use ("-", ".", "_", " ") all behave.
+   */
+  for (const token of text.split(/[^a-z0-9]+/)) {
+    if (!token) {
+      continue;
+    }
+    for (const rule of NAME_RULES) {
+      if (rule.pattern.test(token)) {
+        return rule.role;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The role of one network device (managed) or discovery-protocol peer
+ * (unmanaged).
+ *
+ * Total: always returns a role, "unknown" when nothing is conclusive.
+ */
+export function classifyDeviceRole(
+  signals: DeviceRoleSignals,
+): NetworkTopologyDeviceRole {
+  const model: string = normalize(
+    [signals.deviceModel, signals.platform].filter(Boolean).join(" "),
+  );
+  const sysDescr: string = normalize(signals.sysDescr);
+  /*
+   * Vendor guards read every identity field, not just `vendor` — the word
+   * "Meraki" usually arrives inside sysDescr or the platform string, and
+   * `vendor` itself is often empty on an unmanaged peer.
+   */
+  const vendorText: string = normalize(
+    [signals.vendor, signals.deviceModel, signals.platform, signals.sysDescr]
+      .filter(Boolean)
+      .join(" "),
+  );
+
+  return (
+    firstMatch(PRODUCT_RULES, model, vendorText) ??
+    firstMatch(PRODUCT_RULES, sysDescr, vendorText) ??
+    roleForSysObjectId(signals.sysObjectId, SYS_OBJECT_ID_RULES) ??
+    firstMatch(GENERIC_RULES, sysDescr, vendorText) ??
+    roleForNameText(signals.sysName) ??
+    roleForNameText(signals.name) ??
+    roleForSysObjectId(
+      signals.sysObjectId,
+      GENERIC_AGENT_SYS_OBJECT_ID_RULES,
+    ) ??
+    firstMatch(OPERATING_SYSTEM_RULES, sysDescr, vendorText) ??
+    "unknown"
+  );
+}
+
+/**
+ * The role of a discovered (ARP/FDB) endpoint.
+ *
+ * An endpoint is a host until something says otherwise — that is what
+ * being on the far side of an access port means — so this never returns
+ * "unknown". The classification field is a human's own words about the
+ * thing, so it is read first, then the OUI vendor, then the name.
+ */
+export function classifyEndpointRole(
+  signals: EndpointRoleSignals,
+): NetworkTopologyDeviceRole {
+  const classification: string = normalize(signals.classification);
+  const vendor: string = normalize(signals.vendor);
+  const name: string = normalize(signals.name);
+
+  return (
+    firstMatch(ENDPOINT_RULES, classification, classification) ??
+    firstMatch(ENDPOINT_RULES, vendor, vendor) ??
+    firstMatch(ENDPOINT_RULES, name, name) ??
+    "host"
+  );
+}
+
+/** Display name for a role. Falls back to the "unknown" label. */
+export function labelForDeviceRole(
+  role: NetworkTopologyDeviceRole | undefined,
+): string {
+  if (!role) {
+    return DEVICE_ROLE_LABELS.unknown;
+  }
+  return DEVICE_ROLE_LABELS[role] || DEVICE_ROLE_LABELS.unknown;
+}

--- a/Common/Utils/Monitor/NetworkTopologyUtil.ts
+++ b/Common/Utils/Monitor/NetworkTopologyUtil.ts
@@ -8,6 +8,10 @@ import NetworkTopology, {
 import LldpNeighbor from "../../Types/Monitor/SnmpMonitor/LldpNeighbor";
 import CdpNeighbor from "../../Types/Monitor/SnmpMonitor/CdpNeighbor";
 import { normalizeMac } from "./EndpointAttachmentUtil";
+import {
+  classifyDeviceRole,
+  classifyEndpointRole,
+} from "./NetworkDeviceRoleUtil";
 
 export interface TopologyDeviceInput {
   id: string;
@@ -19,6 +23,12 @@ export interface TopologyDeviceInput {
   interfacesDown?: number | undefined;
   vendor?: string | undefined;
   deviceModel?: string | undefined;
+  /*
+   * SNMP identity, carried purely so the node can be classified into a
+   * role (router/switch/firewall/...). Neither is rendered directly.
+   */
+  sysDescr?: string | undefined;
+  sysObjectId?: string | undefined;
   lldpNeighbors?: Array<LldpNeighbor> | undefined;
   cdpNeighbors?: Array<CdpNeighbor> | undefined;
 }
@@ -145,6 +155,14 @@ export default class NetworkTopologyUtil {
         name: device.name,
         isManaged: true,
         kind: "device",
+        role: classifyDeviceRole({
+          sysDescr: device.sysDescr,
+          sysObjectId: device.sysObjectId,
+          vendor: device.vendor,
+          deviceModel: device.deviceModel,
+          name: device.name,
+          sysName: device.sysName || device.hostname,
+        }),
         status: NetworkTopologyUtil.deviceStatus(device, now),
         interfacesUp: device.interfacesUp,
         interfacesDown: device.interfacesDown,
@@ -180,19 +198,33 @@ export default class NetworkTopologyUtil {
           const existingUnmanaged: NetworkTopologyNode | undefined =
             unmanagedNodeById.get(toNodeId);
           if (!existingUnmanaged) {
+            const unmanagedName: string = claim.displayName || "Unknown device";
             const unmanagedNode: NetworkTopologyNode = {
               id: toNodeId,
-              name: claim.displayName || "Unknown device",
+              name: unmanagedName,
               isManaged: false,
               kind: "unmanaged",
+              role: classifyDeviceRole({
+                platform: claim.remotePlatform,
+                name: unmanagedName,
+              }),
               status: "unknown",
               deviceModel: claim.remotePlatform,
             };
             unmanagedNodeById.set(toNodeId, unmanagedNode);
             nodes.push(unmanagedNode);
           } else if (!existingUnmanaged.deviceModel && claim.remotePlatform) {
-            // A later CDP claim may know the platform the first one didn't.
+            /*
+             * A later CDP claim may know the platform the first one didn't
+             * — which is usually the only evidence a peer's role rests on,
+             * so the role is re-derived rather than left at whatever the
+             * name alone produced.
+             */
             existingUnmanaged.deviceModel = claim.remotePlatform;
+            existingUnmanaged.role = classifyDeviceRole({
+              platform: claim.remotePlatform,
+              name: existingUnmanaged.name,
+            });
           }
         }
 
@@ -348,15 +380,21 @@ export default class NetworkTopologyUtil {
       renderedEndpointCount++;
 
       const nodeId: string = `endpoint:${endpoint.id}`;
+      const endpointName: string =
+        endpoint.classification ||
+        endpoint.vendor ||
+        endpoint.ipAddress ||
+        endpoint.macAddress;
       nodes.push({
         id: nodeId,
-        name:
-          endpoint.classification ||
-          endpoint.vendor ||
-          endpoint.ipAddress ||
-          endpoint.macAddress,
+        name: endpointName,
         isManaged: false,
         kind: "endpoint",
+        role: classifyEndpointRole({
+          classification: endpoint.classification,
+          vendor: endpoint.vendor,
+          name: endpointName,
+        }),
         status: NetworkTopologyUtil.statusFromLastSeen(
           endpoint.lastSeenAt,
           now,


### PR DESCRIPTION
## The problem

Every node on the network topology map was the same circle. A core router, an access switch, the edge firewall, a ceiling AP and a NetApp filer were all a 32px dot, and the only way to tell any of them apart was to read the label underneath. Reading a map should not require reading it word by word.

## What this does

Nodes now carry a **role** — what the box does on the network — and the role picks the silhouette it is drawn with, following the conventions network engineers already draw with by hand:

| Role | Shape |
| --- | --- |
| Router | circle (the classic router puck) |
| Switch | rounded square |
| Firewall | diamond |
| Wireless AP / controller | triangle |
| Load balancer | hexagon |
| Server | tower (taller than wide) |
| Storage | cylinder |
| Printer / camera / phone / host | rect (what endpoints have always been) |
| Unknown | circle — unchanged from today |

Colour still means status and nothing else: a firewall that is down is a **red diamond**. Shape answers "what is it", colour answers "is it alright", and the two stay independent.

Roles also show up where the shape can't be seen:

- **Legend** gains a "Type" group, built from the nodes actually on the map, so a network with no storage never sees a cylinder explained. Order is fixed, so a poll cannot reshuffle the key.
- **Search** matches role names — typing `firewall` lights up every firewall even though no device is called one.
- **Screen readers** announce the role first, because the shape is exactly the information they cannot see.
- **Tooltip** and the **detail drawer** name the type.

## Where the role comes from

Nothing in SNMP hands us a role, so `Common/Utils/Monitor/NetworkDeviceRoleUtil.ts` derives one from evidence we already collect, in a strict order of trustworthiness:

1. the product family in the model / CDP platform string / sysDescr (`Catalyst 2960`, `FortiGate-60F`, `SRX340`),
2. the sysObjectId enterprise arc, for vendors whose entire catalogue is one role (Palo Alto, F5, NetApp, …),
3. the generic words in sysDescr ("… Switch …", "Load Balancer"),
4. the hostname convention (`core-sw-1`, `edge-fw01`),
5. last and weakest, a general-purpose OS or SNMP agent in sysDescr — "it is a computer", which loses to a hostname that says otherwise, because switches and firewalls announce Linux kernels too.

**No migration.** The role is derived server-side in the topology builder, which means it works on every existing device immediately, and it works for unmanaged CDP/LLDP peers too — which have no database row at all, only a platform string.

**"Unknown" is a real answer.** A neutral circle is honest; a router drawn as a firewall because its hostname happened to contain "fw" is not. Nodes with thin evidence stay unknown and render exactly as they do today.

The interesting cases are the collisions, and they are all pinned by tests: vendors reuse each other's model prefixes (Juniper **MX960** is a core router, Meraki **MX64** is a firewall), reuse their own prefixes across roles (Catalyst **2960** switch / **8300** router / **9800** wireless controller), and Sophos **SG** is a firewall while Cisco **SG350** is a switch.

## Layout safety

`footprintForNode` — the contract between the layouts and the renderer — now takes its glyph extents from the shape, so the space reserved always matches what is painted: a diamond reserves its extra height, a taller silhouette pushes its own label down instead of touching it, and collision radii grow with the shape. An **unclassified graph is laid out to exactly the same numbers as before**, which is what keeps every saved arrangement and every existing layout test valid.

## Tests

- `Common/Tests/Utils/Monitor/NetworkDeviceRoleUtil.test.ts` — new, ~48 tests written as a catalogue of real SNMP strings: each vendor family, the MX and Catalyst collisions, evidence precedence between the five tiers, sysObjectId dotted-prefix boundaries (`.11` must not swallow `.1124`), hostname tokenizing (`swansea` is not a switch, `apex` is not an access point), and the empty case.
- `App/Tests/Dashboard/TopologyNodeShape.test.ts` — new, ~30 tests: role→shape mapping, that the infrastructure silhouettes are all distinct, geometry finite/positive/linear in the base radius, polygons centred and touching their own bounding box, the cylinder paths, and that an unclassified graph is byte-for-byte the old geometry.
- Additions to `NetworkTopologyUtil.test.ts` (roles on devices, unmanaged peers, endpoints; a later CDP claim re-deriving a peer's role), `TopologyFootprint.test.ts`, `NetworkTopologyViewModel.test.ts` and `NetworkTopologyMeta.test.ts` (role search, aria labels, the dynamic legend).

## Follow-ups, deliberately not in here

- The tiered layout still infers "router vs switch" from FDB edges rather than from the role. Now that a real role exists, that tier assignment could use it — a behavioural change to the layout, so it belongs in its own PR.
- A user-settable override column on `NetworkDevice` for the cases the classifier gets wrong. The classifier is written as the single source of the answer, so an override would just short-circuit it.
