### PR TITLE
feat(entities): manual CIs and inventory coverage in the entity registry

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Entities/EntitiesTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Entities/EntitiesTable.tsx
@@ -1,7 +1,11 @@
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import FieldType from "Common/UI/Components/Types/FieldType";
+import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
+import { DropdownOption } from "Common/UI/Components/Dropdown/Dropdown";
 import TelemetryEntity from "Common/Models/DatabaseModels/TelemetryEntity";
+import EntitySource from "Common/Types/Telemetry/EntitySource";
 import EntityType from "Common/Types/Telemetry/EntityType";
+import { MANUAL_ENTITY_TYPES } from "Common/Types/Telemetry/EntityTypeGroups";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import ProjectUtil from "Common/UI/Utils/Project";
 import Route from "Common/Types/API/Route";
@@ -12,10 +16,30 @@ import PageMap from "../../Utils/PageMap";
 import React, { Fragment, FunctionComponent, ReactElement } from "react";
 
 /**
- * Entity explorer — lists the TelemetryEntity registry (the catalog of
- * OpenTelemetry entities discovered from telemetry resource attributes).
- * Read-only: the registry is machine-populated forward-only at ingest.
+ * Entity explorer — the one place the whole estate is listed, whatever
+ * discovered it.
+ *
+ * Rows arrive from three directions and the Source column is what tells them
+ * apart: `discovered` from OpenTelemetry resource attributes at ingest,
+ * `inventory` mirrored from OneUptime's poller-collected tables (network
+ * devices, cloud resources, IoT devices, ...), and `manual` for things that
+ * emit no telemetry and appear in no inventory — a vendor API, an appliance —
+ * which a user registers here so a dependency can terminate somewhere real.
+ *
+ * Create is restricted to the manual entity types. That restriction is
+ * enforced server-side in TelemetryEntityService.onBeforeCreate; the dropdown
+ * below just avoids offering choices the API would reject.
  */
+
+const manualEntityTypeOptions: Array<DropdownOption> = Array.from(
+  MANUAL_ENTITY_TYPES,
+).map((entityType: EntityType): DropdownOption => {
+  return {
+    label: entityType,
+    value: entityType,
+  };
+});
+
 const EntitiesTable: FunctionComponent = (): ReactElement => {
   const { translateString } = useTranslateValue();
 
@@ -25,9 +49,9 @@ const EntitiesTable: FunctionComponent = (): ReactElement => {
         modelType={TelemetryEntity}
         id="telemetry-entity-table"
         userPreferencesKey="telemetry-entity-table"
-        isDeleteable={false}
-        isEditable={false}
-        isCreateable={false}
+        isDeleteable={true}
+        isEditable={true}
+        isCreateable={true}
         isViewable={true}
         viewPageRoute={RouteUtil.populateRouteParams(
           RouteMap[PageMap.ENTITIES_VIEW_ROOT]!,
@@ -37,10 +61,11 @@ const EntitiesTable: FunctionComponent = (): ReactElement => {
         name="Telemetry Entities"
         sortBy="lastSeenAt"
         sortOrder={SortOrder.Descending}
+        createVerb="Add"
         cardProps={{
-          title: "Telemetry Entities",
+          title: "Entities",
           description:
-            "Services, hosts, k8s pods, containers and other entities discovered from your telemetry resource attributes.",
+            "Everything OneUptime knows about your estate: services, hosts, k8s pods and containers discovered from telemetry, network devices and cloud resources mirrored from inventory, plus anything you register by hand. Discovered and mirrored entities re-appear automatically after deletion — their source is the authority, not this table.",
         }}
         query={{
           projectId: ProjectUtil.getCurrentProjectId()!,
@@ -50,7 +75,7 @@ const EntitiesTable: FunctionComponent = (): ReactElement => {
           <div>
             <p>
               {translateString(
-                "No telemetry entities discovered yet. Entities are cataloged here as telemetry carrying resource attributes (service.name, host.name, k8s.*, container.id, ...) is ingested.",
+                "No entities yet. They are cataloged here as telemetry carrying resource attributes (service.name, host.name, k8s.*, container.id, ...) is ingested, and as inventory is registered. You can also add an entity manually for something that emits no telemetry, such as a third-party API.",
               ) || ""}
             </p>
             <Link
@@ -65,6 +90,42 @@ const EntitiesTable: FunctionComponent = (): ReactElement => {
             </Link>
           </div>
         }
+        /*
+         * Only the fields a human owns. Type and key are absent on purpose:
+         * the key is derived from (project, type, name) server-side, and
+         * letting either change after create would re-identify the row and
+         * strand every edge pointing at the old key.
+         */
+        formFields={[
+          {
+            field: { entityType: true },
+            title: "Type",
+            fieldType: FormFieldSchemaType.Dropdown,
+            dropdownOptions: manualEntityTypeOptions,
+            required: true,
+            description:
+              "What kind of thing this is. Only types OneUptime cannot discover on its own can be added by hand — everything else appears here automatically.",
+          },
+          {
+            field: { displayName: true },
+            title: "Name",
+            fieldType: FormFieldSchemaType.Text,
+            required: true,
+            placeholder: "Stripe Payments API",
+            description:
+              "Names the entity and, together with its type, forms its identity. Two entities of the same type cannot share a name.",
+            validation: {
+              minLength: 2,
+            },
+          },
+          {
+            field: { description: true },
+            title: "Description",
+            fieldType: FormFieldSchemaType.LongText,
+            required: false,
+            placeholder: "Vendor-managed. No telemetry. Owned by Payments.",
+          },
+        ]}
         filters={[
           {
             field: { entityType: true },
@@ -75,6 +136,19 @@ const EntitiesTable: FunctionComponent = (): ReactElement => {
                 return {
                   label: entityType,
                   value: entityType,
+                };
+              },
+            ),
+          },
+          {
+            field: { source: true },
+            title: "Source",
+            type: FieldType.MultiSelectDropdown,
+            filterDropdownOptions: Object.values(EntitySource).map(
+              (source: EntitySource) => {
+                return {
+                  label: source,
+                  value: source,
                 };
               },
             ),
@@ -104,6 +178,11 @@ const EntitiesTable: FunctionComponent = (): ReactElement => {
           {
             field: { displayName: true },
             title: "Name",
+            type: FieldType.Text,
+          },
+          {
+            field: { source: true },
+            title: "Source",
             type: FieldType.Text,
           },
           {

--- a/App/FeatureSet/Dashboard/src/Pages/Entities/EntityDetailPage.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Entities/EntityDetailPage.tsx
@@ -214,6 +214,8 @@ const EntityDetailPage: FunctionComponent<
               entityType: true,
               displayName: true,
               entityKey: true,
+              source: true,
+              description: true,
               identifyingAttributes: true,
               descriptiveAttributes: true,
               resourceType: true,
@@ -447,6 +449,26 @@ const EntityDetailPage: FunctionComponent<
                 {entityKey}
               </dd>
             </div>
+            {entity.source && (
+              <div className="py-2 grid grid-cols-1 sm:grid-cols-3 gap-1">
+                <dt className="text-sm font-medium text-gray-500">
+                  {translateString("Source") || ""}
+                </dt>
+                <dd className="text-sm text-gray-900 sm:col-span-2">
+                  {entity.source}
+                </dd>
+              </div>
+            )}
+            {entity.description && (
+              <div className="py-2 grid grid-cols-1 sm:grid-cols-3 gap-1">
+                <dt className="text-sm font-medium text-gray-500">
+                  {translateString("Description") || ""}
+                </dt>
+                <dd className="text-sm text-gray-900 sm:col-span-2 whitespace-pre-line">
+                  {entity.description}
+                </dd>
+              </div>
+            )}
             {entity.firstSeenAt && (
               <div className="py-2 grid grid-cols-1 sm:grid-cols-3 gap-1">
                 <dt className="text-sm font-medium text-gray-500">

--- a/App/FeatureSet/Workers/Index.ts
+++ b/App/FeatureSet/Workers/Index.ts
@@ -204,6 +204,7 @@ import "./Jobs/IoT/CleanupStaleResources";
 // Telemetry entity registry: TTL prune + span-derived service map edges.
 import "./Jobs/TelemetryEntity/PruneStaleEntities";
 import "./Jobs/TelemetryEntity/ComputeServiceDependencies";
+import "./Jobs/TelemetryEntity/SyncInventoryEntities";
 
 /*
  * Session replay. FinalizeSessions is not optional bookkeeping: both replay

--- a/App/FeatureSet/Workers/Jobs/TelemetryEntity/PruneStaleEntities.ts
+++ b/App/FeatureSet/Workers/Jobs/TelemetryEntity/PruneStaleEntities.ts
@@ -6,6 +6,7 @@ import TelemetryEntityRelationshipService from "Common/Server/Services/Telemetry
 import QueryHelper from "Common/Server/Types/Database/QueryHelper";
 import LIMIT_MAX from "Common/Types/Database/LimitMax";
 import OneUptimeDate from "Common/Types/Date";
+import EntitySource from "Common/Types/Telemetry/EntitySource";
 import EntityType from "Common/Types/Telemetry/EntityType";
 
 /*
@@ -18,6 +19,16 @@ import EntityType from "Common/Types/Telemetry/EntityType";
  * service deleted) — hard-delete it. Per-type TTLs reflect churn: pods /
  * deployments / instances cycle daily, nodes / namespaces weekly, and
  * service / host / cluster identities are long-lived.
+ *
+ * That reasoning holds for `EntitySource.Discovered` and nothing else, so
+ * both sweeps below are scoped to it. Inventory-mirrored rows are kept in
+ * step by their owning table's hooks and manual CIs are owned by the user;
+ * neither has anything bumping `lastSeenAt`, which makes an aged
+ * `lastSeenAt` on those rows meaningless rather than a death certificate.
+ * The inventory-mirrored and manual entity types are additionally absent
+ * from ENTITY_TTL_HOURS below, so they are unreachable by this sweep by
+ * two independent mechanisms — belt and braces, because the failure mode
+ * is silent deletion of user data.
  *
  * Relationship edges are pruned by lastSeenAt ONLY (no endpoint-existence
  * sweep — an endpoint disappearing is the entity prune's own concern). A
@@ -65,6 +76,16 @@ async function deleteStaleEntities(data: {
       query: {
         entityType: data.entityType,
         lastSeenAt: QueryHelper.lessThan(data.cutoff),
+        /*
+         * Discovered rows ONLY. `lastSeenAt` is a staleness signal solely
+         * because ingest re-bumps it every reconcile window; for the other
+         * two sources nothing does, so their lastSeenAt is frozen at create
+         * time and every one of them crosses any TTL simply by existing long
+         * enough. Without this predicate the sweep deletes every manually
+         * created CI and every inventory-mirrored row on its first run past
+         * the shortest TTL. See EntitySource.
+         */
+        source: EntitySource.Discovered,
       },
       limit: LIMIT_MAX,
       skip: 0,
@@ -105,6 +126,8 @@ RunCron(
           deleted = await TelemetryEntityRelationshipService.hardDeleteBy({
             query: {
               lastSeenAt: QueryHelper.lessThan(cutoff),
+              // Discovered edges only — see the source note in the header.
+              source: EntitySource.Discovered,
             },
             limit: LIMIT_MAX,
             skip: 0,

--- a/App/FeatureSet/Workers/Jobs/TelemetryEntity/SyncInventoryEntities.ts
+++ b/App/FeatureSet/Workers/Jobs/TelemetryEntity/SyncInventoryEntities.ts
@@ -1,0 +1,47 @@
+import { EVERY_FIFTEEN_MINUTE } from "Common/Utils/CronTime";
+import RunCron from "../../Utils/Cron";
+import logger from "Common/Server/Utils/Logger";
+import {
+  InventorySyncResult,
+  syncAllInventorySources,
+} from "Common/Server/Utils/Telemetry/InventoryEntityRegistry";
+
+/*
+ * TelemetryEntity:SyncInventoryEntities
+ *
+ * Projects OneUptime's poller-collected inventory tables (network devices,
+ * cloud resources, serverless functions, RUM applications, IoT devices,
+ * Docker and Podman hosts) into the TelemetryEntity registry, so the entity
+ * explorer covers the whole estate rather than only the parts that speak
+ * OTLP. See InventoryEntityRegistry for why this is a periodic reconcile
+ * instead of create/delete hooks on each of the seven tables.
+ *
+ * Fifteen minutes is chosen against what the sweep costs rather than how
+ * fresh the data needs to be: it reads every row of seven tables. Inventory
+ * changes when a human registers or decommissions something, so nothing here
+ * is latency-sensitive, and a shorter period would buy responsiveness nobody
+ * is waiting on at a cost that scales with estate size.
+ *
+ * Not run on startup, so a fleet-wide restart does not have every worker
+ * begin a full estate scan at once.
+ */
+
+RunCron(
+  "TelemetryEntity:SyncInventoryEntities",
+  { schedule: EVERY_FIFTEEN_MINUTE, runOnStartup: false },
+  async () => {
+    try {
+      const result: InventorySyncResult = await syncAllInventorySources();
+
+      if (result.created > 0 || result.updated > 0 || result.deleted > 0) {
+        logger.debug(
+          `SyncInventoryEntities: mirrored inventory into the entity registry — ${result.created} created, ${result.updated} updated, ${result.deleted} removed.`,
+        );
+      }
+    } catch (err) {
+      logger.error(
+        `SyncInventoryEntities cron failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  },
+);

--- a/App/Tests/Dashboard/EntitiesTableManualCreate.test.ts
+++ b/App/Tests/Dashboard/EntitiesTableManualCreate.test.ts
@@ -1,0 +1,180 @@
+import EntitySource from "Common/Types/Telemetry/EntitySource";
+import EntityType from "Common/Types/Telemetry/EntityType";
+import {
+  INVENTORY_ENTITY_TYPES,
+  MANUAL_ENTITY_TYPES,
+} from "Common/Types/Telemetry/EntityTypeGroups";
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * The entity explorer is the only surface that creates manual CIs, and the
+ * shape of that form is load-bearing:
+ *
+ *   - Offering a discovered or inventory-mirrored type in the dropdown
+ *     produces a form that always fails, because the service rejects those
+ *     (see TelemetryEntityManualCreate.test.ts).
+ *   - Offering `entityKey` as a field would let a user set an identity that
+ *     does not match what the server derives.
+ *   - Losing the Source column makes the three kinds of row visually
+ *     indistinguishable, which matters because only manual ones are really
+ *     deletable — the others come back.
+ *
+ * The App suite runs in a plain Node environment with no React renderer, so
+ * this pins the JSX wiring at source level, following the same invariant
+ * pattern as EmptyResourceInventoryPages.test.ts. Whitespace is squashed so
+ * Prettier can reflow props without making the test brittle.
+ */
+
+const ENTITIES_TABLE: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+  "Components",
+  "Entities",
+  "EntitiesTable.tsx",
+);
+
+function readSource(): string {
+  return fs.readFileSync(ENTITIES_TABLE, "utf8");
+}
+
+function squash(source: string): string {
+  return source.replace(/\s+/g, " ");
+}
+
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+function readCode(): string {
+  return squash(stripComments(readSource()));
+}
+
+describe("the entity explorer file exists where the test expects it", () => {
+  test("reads", () => {
+    expect(fs.existsSync(ENTITIES_TABLE)).toBe(true);
+  });
+});
+
+describe("manual creation is offered", () => {
+  test("the table is creatable", () => {
+    expect(readCode()).toContain("isCreateable={true}");
+  });
+
+  test("the create form is wired", () => {
+    expect(readCode()).toContain("formFields={[");
+  });
+
+  test("the type dropdown is built from MANUAL_ENTITY_TYPES", () => {
+    const code: string = readCode();
+
+    expect(code).toContain("MANUAL_ENTITY_TYPES");
+    expect(code).toContain("manualEntityTypeOptions");
+  });
+
+  test("the dropdown is not built from the full EntityType vocabulary", () => {
+    /*
+     * `Object.values(EntityType)` is correct for the FILTER (you filter by
+     * any type) and wrong for the form (you create only manual ones). This
+     * pins that the form options come from the restricted set.
+     */
+    const code: string = readCode();
+    const formSection: string = code.slice(
+      code.indexOf("formFields={["),
+      code.indexOf("filters={["),
+    );
+
+    expect(formSection.length).toBeGreaterThan(0);
+    expect(formSection).not.toContain("Object.values(EntityType)");
+  });
+
+  test("name and description are collected", () => {
+    const code: string = readCode();
+
+    expect(code).toContain("displayName: true");
+    expect(code).toContain("description: true");
+  });
+
+  test("the entity key is never a form field", () => {
+    /*
+     * It is derived server-side from (project, type, name); a user-supplied
+     * value would disagree with it.
+     */
+    const code: string = readCode();
+    const formSection: string = code.slice(
+      code.indexOf("formFields={["),
+      code.indexOf("filters={["),
+    );
+
+    expect(formSection).not.toContain("entityKey: true");
+  });
+
+  test("the source is never a form field", () => {
+    // Assigned by the service, and immutable after create.
+    const code: string = readCode();
+    const formSection: string = code.slice(
+      code.indexOf("formFields={["),
+      code.indexOf("filters={["),
+    );
+
+    expect(formSection).not.toContain("source: true");
+  });
+});
+
+describe("the three row sources stay distinguishable", () => {
+  test("Source is a column", () => {
+    const code: string = readCode();
+    const columnSection: string = code.slice(code.indexOf("columns={["));
+
+    expect(columnSection).toContain("source: true");
+  });
+
+  test("Source is filterable", () => {
+    const code: string = readCode();
+    const filterSection: string = code.slice(
+      code.indexOf("filters={["),
+      code.indexOf("columns={["),
+    );
+
+    expect(filterSection).toContain("source: true");
+  });
+
+  test("the source filter offers every EntitySource", () => {
+    expect(readCode()).toContain("Object.values(EntitySource)");
+  });
+});
+
+describe("the imports match what the component uses", () => {
+  test("imports EntitySource and the manual type set", () => {
+    const source: string = readSource();
+
+    expect(source).toContain(
+      'import EntitySource from "Common/Types/Telemetry/EntitySource"',
+    );
+    expect(source).toContain("MANUAL_ENTITY_TYPES");
+  });
+});
+
+describe("the restricted set the UI relies on", () => {
+  test("is non-empty, or the create form would offer nothing", () => {
+    expect(MANUAL_ENTITY_TYPES.size).toBeGreaterThan(0);
+  });
+
+  test("offers no type the server would reject", () => {
+    for (const entityType of MANUAL_ENTITY_TYPES) {
+      expect(INVENTORY_ENTITY_TYPES.has(entityType)).toBe(false);
+      expect(entityType).not.toBe(EntityType.Service);
+    }
+  });
+
+  test("EntitySource has values for the filter to offer", () => {
+    expect(Object.values(EntitySource).length).toBeGreaterThan(1);
+  });
+});

--- a/App/Tests/Workers/Jobs/TelemetryEntity/PruneStaleEntities.test.ts
+++ b/App/Tests/Workers/Jobs/TelemetryEntity/PruneStaleEntities.test.ts
@@ -1,0 +1,275 @@
+import EntitySource from "Common/Types/Telemetry/EntitySource";
+import EntityType from "Common/Types/Telemetry/EntityType";
+import {
+  INVENTORY_ENTITY_TYPES,
+  isNonTelemetryEntityType,
+  MANUAL_ENTITY_TYPES,
+} from "Common/Types/Telemetry/EntityTypeGroups";
+
+/*
+ * TelemetryEntity:PruneStaleEntities hard-deletes registry rows whose
+ * `lastSeenAt` has aged past their type's TTL. That is a sound staleness
+ * test for exactly one kind of row — the ones ingest re-bumps every reconcile
+ * window. Manually created CIs and inventory-mirrored rows have no such
+ * heartbeat: their `lastSeenAt` is frozen at creation, so every one of them
+ * crosses any TTL simply by existing long enough.
+ *
+ * Without the `source` predicate on the delete, this cron silently deletes
+ * every CI a user ever registered, roughly a day after they registered it,
+ * with no error anywhere. These tests drive a full tick and assert the
+ * predicate is present on every delete the job issues.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to capture the handler — the same recorder the
+ * other App/Tests/Workers/Jobs suites use.
+ */
+
+type CronHandler = () => Promise<void>;
+
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/TelemetryEntityService", () => {
+  return {
+    __esModule: true,
+    default: {
+      hardDeleteBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/TelemetryEntityRelationshipService", () => {
+  return {
+    __esModule: true,
+    default: {
+      hardDeleteBy: jest.fn(),
+    },
+  };
+});
+
+import TelemetryEntityService from "Common/Server/Services/TelemetryEntityService";
+import TelemetryEntityRelationshipService from "Common/Server/Services/TelemetryEntityRelationshipService";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/TelemetryEntity/PruneStaleEntities";
+
+const JOB_NAME: string = "TelemetryEntity:PruneStaleEntities";
+
+interface DeleteCall {
+  query: {
+    entityType?: EntityType;
+    source?: EntitySource;
+    lastSeenAt?: unknown;
+  };
+}
+
+const entityMock: { hardDeleteBy: jest.Mock } =
+  TelemetryEntityService as unknown as { hardDeleteBy: jest.Mock };
+const relationshipMock: { hardDeleteBy: jest.Mock } =
+  TelemetryEntityRelationshipService as unknown as { hardDeleteBy: jest.Mock };
+
+function entityDeleteCalls(): Array<DeleteCall> {
+  return entityMock.hardDeleteBy.mock.calls.map((call: Array<unknown>) => {
+    return call[0] as DeleteCall;
+  });
+}
+
+function relationshipDeleteCalls(): Array<DeleteCall> {
+  return relationshipMock.hardDeleteBy.mock.calls.map(
+    (call: Array<unknown>) => {
+      return call[0] as DeleteCall;
+    },
+  );
+}
+
+async function runTick(): Promise<void> {
+  const handler: CronHandler | undefined = mockCapturedJobs[JOB_NAME];
+  if (!handler) {
+    throw new Error(`Cron handler ${JOB_NAME} was not registered`);
+  }
+  await handler();
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  /*
+   * Zero deleted rows ends each batching loop after one pass, so a tick
+   * issues exactly one delete per swept type.
+   */
+  entityMock.hardDeleteBy.mockResolvedValue(0);
+  relationshipMock.hardDeleteBy.mockResolvedValue(0);
+});
+
+describe("the cron registers itself", () => {
+  test("under its documented name", () => {
+    expect(mockCapturedJobs[JOB_NAME]).toBeDefined();
+  });
+});
+
+describe("entity pruning is scoped to discovered rows", () => {
+  test("every delete carries source = discovered", async () => {
+    await runTick();
+
+    const calls: Array<DeleteCall> = entityDeleteCalls();
+    expect(calls.length).toBeGreaterThan(0);
+
+    for (const call of calls) {
+      expect(call.query.source).toBe(EntitySource.Discovered);
+    }
+  });
+
+  test("no delete is issued without a source predicate", async () => {
+    await runTick();
+
+    for (const call of entityDeleteCalls()) {
+      expect(call.query.source).toBeDefined();
+    }
+  });
+
+  test("every delete is also bounded by a lastSeenAt cutoff", async () => {
+    await runTick();
+
+    for (const call of entityDeleteCalls()) {
+      expect(call.query.lastSeenAt).toBeDefined();
+    }
+  });
+
+  test("no manually creatable type is ever swept", async () => {
+    await runTick();
+
+    const swept: Array<EntityType | undefined> = entityDeleteCalls().map(
+      (call: DeleteCall) => {
+        return call.query.entityType;
+      },
+    );
+
+    for (const entityType of MANUAL_ENTITY_TYPES) {
+      expect(swept).not.toContain(entityType);
+    }
+  });
+
+  test("no inventory-mirrored type is ever swept", async () => {
+    await runTick();
+
+    const swept: Array<EntityType | undefined> = entityDeleteCalls().map(
+      (call: DeleteCall) => {
+        return call.query.entityType;
+      },
+    );
+
+    for (const entityType of INVENTORY_ENTITY_TYPES) {
+      expect(swept).not.toContain(entityType);
+    }
+  });
+
+  test("every swept type is one with a telemetry heartbeat", async () => {
+    /*
+     * The belt to the source predicate's braces: even if the predicate were
+     * dropped, a type nothing re-bumps must not appear in the TTL map.
+     */
+    await runTick();
+
+    for (const call of entityDeleteCalls()) {
+      expect(isNonTelemetryEntityType(call.query.entityType!)).toBe(false);
+    }
+  });
+
+  test("still sweeps the high-churn telemetry types it exists for", async () => {
+    await runTick();
+
+    const swept: Array<EntityType | undefined> = entityDeleteCalls().map(
+      (call: DeleteCall) => {
+        return call.query.entityType;
+      },
+    );
+
+    expect(swept).toContain(EntityType.KubernetesPod);
+    expect(swept).toContain(EntityType.Service);
+    expect(swept).toContain(EntityType.Host);
+  });
+});
+
+describe("relationship pruning is scoped to discovered edges", () => {
+  test("the edge delete carries source = discovered", async () => {
+    await runTick();
+
+    const calls: Array<DeleteCall> = relationshipDeleteCalls();
+    expect(calls.length).toBeGreaterThan(0);
+
+    for (const call of calls) {
+      expect(call.query.source).toBe(EntitySource.Discovered);
+    }
+  });
+
+  test("a hand-drawn edge therefore survives the sweep", async () => {
+    /*
+     * Manual edges are the only way to connect a manual CI to anything, and
+     * nothing re-bumps them either.
+     */
+    await runTick();
+
+    for (const call of relationshipDeleteCalls()) {
+      expect(call.query.source).not.toBe(EntitySource.Manual);
+    }
+  });
+});
+
+describe("resilience", () => {
+  test("a failure pruning one type does not stop the others", async () => {
+    entityMock.hardDeleteBy.mockRejectedValueOnce(new Error("db down"));
+
+    await expect(runTick()).resolves.toBeUndefined();
+
+    // The first type threw; the remaining types were still attempted.
+    expect(entityMock.hardDeleteBy.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  test("a failure pruning entities does not stop edge pruning", async () => {
+    entityMock.hardDeleteBy.mockRejectedValue(new Error("db down"));
+
+    await runTick();
+
+    expect(relationshipMock.hardDeleteBy).toHaveBeenCalled();
+  });
+
+  test("the tick keeps deleting while rows are still being returned", async () => {
+    /*
+     * The batching loop must continue past a full batch, or a large stale
+     * backlog would only ever shrink by one batch per three hours.
+     */
+    entityMock.hardDeleteBy.mockResolvedValueOnce(500);
+    entityMock.hardDeleteBy.mockResolvedValue(0);
+
+    await runTick();
+
+    const podCalls: Array<DeleteCall> = entityDeleteCalls().filter(
+      (call: DeleteCall) => {
+        return call.query.entityType === EntityType.KubernetesPod;
+      },
+    );
+
+    expect(podCalls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/Common/Models/DatabaseModels/TelemetryEntity.ts
+++ b/Common/Models/DatabaseModels/TelemetryEntity.ts
@@ -15,6 +15,7 @@ import IconProp from "../../Types/Icon/IconProp";
 import { JSONObject } from "../../Types/JSON";
 import ObjectID from "../../Types/ObjectID";
 import Permission from "../../Types/Permission";
+import EntitySource from "../../Types/Telemetry/EntitySource";
 import EntityType from "../../Types/Telemetry/EntityType";
 import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 import DatabaseBaseModel from "./DatabaseBaseModel/DatabaseBaseModel";
@@ -186,6 +187,50 @@ export default class TelemetryEntity extends DatabaseBaseModel {
     nullable: true,
   })
   public displayName?: string = undefined;
+
+  /*
+   * Immutable after create (`update: []`): the value decides whether
+   * PruneStaleEntities may reap the row, so letting it be edited would let a
+   * user flip a manual CI into a TTL-pruned one — or quietly make a
+   * discovered row immortal. Re-create the row instead.
+   */
+  @ColumnAccessControl({ create: CREATE_PERMS, read: READ_PERMS, update: [] })
+  @TableColumn({
+    type: TableColumnType.ShortText,
+    required: true,
+    title: "Source",
+    description:
+      "How this row came to exist: discovered from telemetry, mirrored from a OneUptime inventory table, or created manually by a user. Determines whether stale-entity pruning applies.",
+    example: "discovered",
+  })
+  @Index()
+  @Column({
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+    nullable: false,
+    default: EntitySource.Discovered,
+  })
+  public source?: EntitySource = undefined;
+
+  @ColumnAccessControl({
+    create: CREATE_PERMS,
+    read: READ_PERMS,
+    update: UPDATE_PERMS,
+  })
+  @TableColumn({
+    type: TableColumnType.LongText,
+    required: false,
+    title: "Description",
+    description:
+      "Free-text description. Primarily for manually created entities, where there are no telemetry attributes to explain what the thing is.",
+    example: "Stripe payments API - vendor managed, no telemetry.",
+  })
+  @Column({
+    type: ColumnType.LongText,
+    length: ColumnLength.LongText,
+    nullable: true,
+  })
+  public description?: string = undefined;
 
   @ColumnAccessControl({
     create: CREATE_PERMS,

--- a/Common/Models/DatabaseModels/TelemetryEntityRelationship.ts
+++ b/Common/Models/DatabaseModels/TelemetryEntityRelationship.ts
@@ -15,6 +15,7 @@ import IconProp from "../../Types/Icon/IconProp";
 import ObjectID from "../../Types/ObjectID";
 import Permission from "../../Types/Permission";
 import EntityRelationshipType from "../../Types/Telemetry/EntityRelationshipType";
+import EntitySource from "../../Types/Telemetry/EntitySource";
 import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 import DatabaseBaseModel from "./DatabaseBaseModel/DatabaseBaseModel";
 
@@ -172,6 +173,31 @@ export default class TelemetryEntityRelationship extends DatabaseBaseModel {
     nullable: false,
   })
   public relationshipType?: EntityRelationshipType = undefined;
+
+  /*
+   * Immutable after create, for the same reason as TelemetryEntity.source:
+   * it is the predicate the edge prune keys on. An edge drawn by hand — the
+   * only way to connect a manual CI to anything — has nothing re-bumping its
+   * `lastSeenAt`, so without this it would be reaped by the 30-day sweep
+   * while the entities at both ends survived.
+   */
+  @ColumnAccessControl({ create: CREATE_PERMS, read: READ_PERMS, update: [] })
+  @TableColumn({
+    type: TableColumnType.ShortText,
+    required: true,
+    title: "Source",
+    description:
+      "Whether this edge was derived from telemetry or drawn manually by a user. Determines whether stale-edge pruning applies.",
+    example: "discovered",
+  })
+  @Index()
+  @Column({
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+    nullable: false,
+    default: EntitySource.Discovered,
+  })
+  public source?: EntitySource = undefined;
 
   @ColumnAccessControl({
     create: CREATE_PERMS,

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786551733814-MigrationName.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786551733814-MigrationName.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MigrationName1786551733814 implements MigrationInterface {
+  public name: string = "MigrationName1786551733814";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "TelemetryEntity" ADD "source" character varying(100) NOT NULL DEFAULT 'discovered'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "TelemetryEntity" ADD "description" character varying(500)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "TelemetryEntityRelationship" ADD "source" character varying(100) NOT NULL DEFAULT 'discovered'`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_8106b1d6443d982b12e3318318" ON "TelemetryEntity" ("source") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_26ea726e2ee8fa622348581ac1" ON "TelemetryEntityRelationship" ("source") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_26ea726e2ee8fa622348581ac1"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_8106b1d6443d982b12e3318318"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "TelemetryEntityRelationship" DROP COLUMN "source"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "TelemetryEntity" DROP COLUMN "description"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "TelemetryEntity" DROP COLUMN "source"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -515,6 +515,7 @@ import { AddDataSourceTable1786303472848 } from "./1786303472848-AddDataSourceTa
 import { MigrationName1786446545142 } from "./1786446545142-MigrationName";
 import { AddMonitorDependency1786449497966 } from "./1786449497966-AddMonitorDependency";
 import { AddDeletedProjectTable1786461136170 } from "./1786461136170-AddDeletedProjectTable";
+import { MigrationName1786551733814 } from "./1786551733814-MigrationName";
 
 export default [
   InitialMigration,
@@ -1034,4 +1035,5 @@ export default [
   MigrationName1786446545142,
   AddMonitorDependency1786449497966,
   AddDeletedProjectTable1786461136170,
+  MigrationName1786551733814,
 ];

--- a/Common/Server/Services/TelemetryEntityRelationshipService.ts
+++ b/Common/Server/Services/TelemetryEntityRelationshipService.ts
@@ -5,6 +5,7 @@ import OneUptimeDate from "../../Types/Date";
 import logger from "../Utils/Logger";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import { EntityRelationshipEdge } from "../../Utils/Telemetry/EntityRelationship";
+import EntitySource from "../../Types/Telemetry/EntitySource";
 import { reconcileByNaturalKey } from "../Utils/Telemetry/EntityRegistry";
 import QueryDeepPartialEntity from "../../Types/Database/PartialEntity";
 
@@ -62,6 +63,8 @@ export class TelemetryEntityRelationshipService extends DatabaseService<Model> {
         model.fromEntityKey = edge.fromEntityKey;
         model.toEntityKey = edge.toEntityKey;
         model.relationshipType = edge.relationshipType;
+        // Explicit: this is what makes the edge eligible for stale pruning.
+        model.source = EntitySource.Discovered;
         model.firstSeenAt = now;
         model.lastSeenAt = now;
         if (edge.metrics) {

--- a/Common/Server/Services/TelemetryEntityService.ts
+++ b/Common/Server/Services/TelemetryEntityService.ts
@@ -8,8 +8,19 @@ import ObjectID from "../../Types/ObjectID";
 import OneUptimeDate from "../../Types/Date";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import QueryDeepPartialEntity from "../../Types/Database/PartialEntity";
+import CreateBy from "../Types/Database/CreateBy";
+import { OnCreate } from "../Types/Database/Hooks";
+import BadDataException from "../../Types/Exception/BadDataException";
+import Dictionary from "../../Types/Dictionary";
 import { JSONObject } from "../../Types/JSON";
+import EntitySource from "../../Types/Telemetry/EntitySource";
 import EntityType from "../../Types/Telemetry/EntityType";
+import { MANUAL_ENTITY_TYPES } from "../../Types/Telemetry/EntityTypeGroups";
+import {
+  canonicalizeEntityValue,
+  computeEntityKey,
+  MANUAL_ENTITY_IDENTITY_ATTRIBUTE,
+} from "../../Utils/Telemetry/EntityKey";
 import logger from "../Utils/Logger";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import { ExtractedEntity } from "../Utils/Telemetry/TelemetryEntity";
@@ -23,6 +34,91 @@ import {
 export class TelemetryEntityService extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  /**
+   * Completes a manually created CI.
+   *
+   * Every machine writer — the ingest reconciler and the inventory mirror —
+   * computes `entityKey` itself and passes an explicit `source`, because
+   * both derive identity from something the user never sees (a canonicalized
+   * semconv attribute set, or the owning row's id). A create arriving
+   * WITHOUT a key is therefore a user create by construction, and this hook
+   * is what turns the two fields a human can reasonably supply (type and
+   * name) into the identity the registry needs.
+   *
+   * Deriving the key here rather than in the dashboard keeps it enforced for
+   * API clients too, and keeps the one identity rule — canonicalize, then
+   * hash — in the module that owns it.
+   */
+  @CaptureSpan()
+  protected override async onBeforeCreate(
+    createBy: CreateBy<Model>,
+  ): Promise<OnCreate<Model>> {
+    const data: Model = createBy.data;
+
+    if (!data.entityKey) {
+      data.source = EntitySource.Manual;
+    }
+
+    if (data.source !== EntitySource.Manual) {
+      return { createBy, carryForward: null };
+    }
+
+    if (!data.projectId) {
+      throw new BadDataException("Project ID is required.");
+    }
+
+    if (!data.entityType) {
+      throw new BadDataException("Entity Type is required.");
+    }
+
+    /*
+     * Confined to the manual-only vocabulary. A hand-made row of an
+     * observable type would key off the manual identity attribute and so
+     * could never converge with the row ingest derives for the same thing —
+     * it would just sit beside it forever. See MANUAL_ENTITY_TYPES.
+     */
+    if (!MANUAL_ENTITY_TYPES.has(data.entityType)) {
+      throw new BadDataException(
+        `Entities of type ${data.entityType} are discovered automatically and cannot be created manually. Manually creatable types are: ${Array.from(
+          MANUAL_ENTITY_TYPES,
+        ).join(", ")}.`,
+      );
+    }
+
+    const displayName: string = (data.displayName || "").trim();
+
+    if (!displayName) {
+      throw new BadDataException(
+        "Name is required for a manually created entity.",
+      );
+    }
+
+    data.displayName = displayName.substring(0, ColumnLength.ShortText);
+
+    const identifyingAttributes: Dictionary<string> = {
+      [MANUAL_ENTITY_IDENTITY_ATTRIBUTE]: canonicalizeEntityValue(displayName),
+    };
+    data.identifyingAttributes = identifyingAttributes as JSONObject;
+
+    data.entityKey = computeEntityKey({
+      projectId: data.projectId.toString(),
+      entityType: data.entityType,
+      identifyingAttributes,
+    });
+
+    /*
+     * Stamped so the explorer can sort manual CIs alongside discovered ones
+     * on the same columns. `lastSeenAt` never moves again for these rows —
+     * it means "created", not "observed" — which is exactly why the prune
+     * sweep excludes them.
+     */
+    const now: Date = OneUptimeDate.getCurrentDate();
+    data.firstSeenAt = data.firstSeenAt || now;
+    data.lastSeenAt = data.lastSeenAt || now;
+
+    return { createBy, carryForward: null };
   }
 
   /**
@@ -169,7 +265,18 @@ export class TelemetryEntityService extends DatabaseService<Model> {
         if (count === undefined) {
           count = (
             await this.countBy({
-              query: { projectId, entityType: entity.entityType },
+              query: {
+                projectId,
+                entityType: entity.entityType,
+                /*
+                 * The budget exists to bound rows minted by ingest, so it
+                 * counts only those. Manual CIs and inventory mirrors are
+                 * bounded by their own creators and must not consume it —
+                 * otherwise registering enough devices could stop new
+                 * telemetry entities being recorded at all.
+                 */
+                source: EntitySource.Discovered,
+              },
               props: { isRoot: true },
             })
           ).toNumber();
@@ -198,6 +305,12 @@ export class TelemetryEntityService extends DatabaseService<Model> {
         model.projectId = projectId;
         model.entityType = entity.entityType;
         model.entityKey = entity.entityKey;
+        /*
+         * Explicit rather than leaning on the column default: this is the
+         * flag that makes the row eligible for stale-entity pruning, and a
+         * silently-defaulted value is a poor way to carry that.
+         */
+        model.source = EntitySource.Discovered;
         model.identifyingAttributes = entity.identifyingAttributes;
         if (
           entity.descriptiveAttributes &&

--- a/Common/Server/Utils/Telemetry/InventoryEntityRegistry.ts
+++ b/Common/Server/Utils/Telemetry/InventoryEntityRegistry.ts
@@ -1,0 +1,689 @@
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import TelemetryEntity from "../../../Models/DatabaseModels/TelemetryEntity";
+import CloudResource from "../../../Models/DatabaseModels/CloudResource";
+import DockerHost from "../../../Models/DatabaseModels/DockerHost";
+import IoTDevice from "../../../Models/DatabaseModels/IoTDevice";
+import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import PodmanHost from "../../../Models/DatabaseModels/PodmanHost";
+import RumApplication from "../../../Models/DatabaseModels/RumApplication";
+import ServerlessFunction from "../../../Models/DatabaseModels/ServerlessFunction";
+import DatabaseService from "../../Services/DatabaseService";
+import CloudResourceService from "../../Services/CloudResourceService";
+import DockerHostService from "../../Services/DockerHostService";
+import IoTDeviceService from "../../Services/IoTDeviceService";
+import NetworkDeviceService from "../../Services/NetworkDeviceService";
+import PodmanHostService from "../../Services/PodmanHostService";
+import RumApplicationService from "../../Services/RumApplicationService";
+import ServerlessFunctionService from "../../Services/ServerlessFunctionService";
+import TelemetryEntityService from "../../Services/TelemetryEntityService";
+import Query from "../../Types/Database/Query";
+import QueryHelper from "../../Types/Database/QueryHelper";
+import Select from "../../Types/Database/Select";
+import QueryDeepPartialEntity from "../../../Types/Database/PartialEntity";
+import ColumnLength from "../../../Types/Database/ColumnLength";
+import Dictionary from "../../../Types/Dictionary";
+import ObjectID from "../../../Types/ObjectID";
+import OneUptimeDate from "../../../Types/Date";
+import { JSONObject } from "../../../Types/JSON";
+import EntitySource from "../../../Types/Telemetry/EntitySource";
+import EntityType from "../../../Types/Telemetry/EntityType";
+import {
+  INVENTORY_ENTITY_IDENTITY_ATTRIBUTE,
+  keyForInventoryEntity,
+} from "../../../Utils/Telemetry/EntityKey";
+import logger from "../Logger";
+
+/*
+ * Mirrors OneUptime's inventory tables into the TelemetryEntity registry.
+ *
+ * The registry began as a projection of OTLP resource attributes, which is
+ * why the entity explorer shows a Kubernetes pod but not the switch next to
+ * it: half of what OneUptime inventories is collected by pollers (SNMP,
+ * cloud APIs, MQTT) that never produce a resource for ingest to extract
+ * entities from. Those rows already exist in rich typed tables — they were
+ * simply never projected. This module projects them, so "everything we know
+ * about the estate" is answerable in one query instead of eight.
+ *
+ * WHY A RECONCILE RATHER THAN CREATE/DELETE HOOKS ON EACH TABLE
+ *
+ * Hooks were the obvious approach and are the wrong one here, for three
+ * reasons that all bite the same way — a registry that silently disagrees
+ * with the inventory it mirrors:
+ *
+ *   1. Backfill. Hooks only fire on future writes, so every device
+ *      registered before this shipped would stay invisible forever.
+ *   2. Cascade deletes. Deleting a project (or an IoT fleet) removes its
+ *      devices by FK cascade, which fires no per-row service hook — the
+ *      mirrored rows would outlive their owners.
+ *   3. Seven tables x two hooks is seven chances for a future edit to drop
+ *      one, and the resulting drift is invisible until someone notices a
+ *      device missing from the explorer.
+ *
+ * A periodic full reconcile is level-triggered: whatever the inventory
+ * says now is what the registry converges to, no matter how it got there.
+ * The cost is latency — a newly registered device appears within one cron
+ * period rather than instantly — which is an easy trade for inventory that
+ * changes on a human timescale.
+ */
+
+/** Registry rows are read and written in pages of this size. */
+export const INVENTORY_SYNC_PAGE_SIZE: number = 1000;
+
+/**
+ * The projection of one inventory row, as the registry stores it. Pure data
+ * so the mapping can be tested without a database.
+ */
+export interface InventoryRowProjection {
+  id: ObjectID;
+  projectId: ObjectID;
+  displayName: string;
+  descriptiveAttributes: Dictionary<string>;
+}
+
+/**
+ * One inventory table, type-erased at the boundary so the seven specs can
+ * live in a single array. `defineInventorySource` below preserves full type
+ * safety at each definition site; only the resulting closures are untyped.
+ */
+export interface ErasedInventorySource {
+  entityType: EntityType;
+  /** Model name stored in TelemetryEntity.resourceType. */
+  resourceType: string;
+  fetchPage(data: {
+    skip: number;
+    limit: number;
+  }): Promise<Array<InventoryRowProjection>>;
+  /** Which of these ids still exist in the owning table. */
+  findLiveIds(ids: Array<ObjectID>): Promise<Set<string>>;
+}
+
+export interface InventorySourceSpec<TModel extends BaseModel> {
+  entityType: EntityType;
+  resourceType: string;
+  service: DatabaseService<TModel>;
+  /**
+   * Columns needed by `describe`, beyond `_id` / `projectId` / `name` which
+   * are always selected.
+   */
+  select: Select<TModel>;
+  /**
+   * Restricts what is mirrored — archived rows are excluded so the explorer
+   * reflects the live estate rather than its history.
+   */
+  query: Query<TModel>;
+  /** Non-identifying metadata worth showing on the entity. */
+  describe(row: TModel): Dictionary<string>;
+}
+
+/**
+ * Drops empty values so the stored attribute bag contains only things worth
+ * displaying — an inventory row with no OS recorded should have no `os.type`
+ * key rather than an empty one.
+ */
+export function compactAttributes(
+  attributes: Dictionary<string | undefined | null>,
+): Dictionary<string> {
+  const out: Dictionary<string> = {};
+
+  for (const key of Object.keys(attributes)) {
+    const value: string | undefined | null = attributes[key];
+    if (value === undefined || value === null) {
+      continue;
+    }
+    const text: string = String(value).trim();
+    if (text.length === 0) {
+      continue;
+    }
+    out[key] = text;
+  }
+
+  return out;
+}
+
+/**
+ * Builds the registry row for one inventory row. Pure: same inputs, same
+ * output, no database — this is the part worth testing exhaustively, since
+ * an identity mistake here is what would mint duplicate entities.
+ */
+export function buildInventoryEntityModel(data: {
+  source: Pick<ErasedInventorySource, "entityType" | "resourceType">;
+  row: InventoryRowProjection;
+  now: Date;
+}): TelemetryEntity {
+  const { source, row, now } = data;
+
+  const model: TelemetryEntity = new TelemetryEntity();
+  model.projectId = row.projectId;
+  model.entityType = source.entityType;
+  model.entityKey = keyForInventoryEntity(
+    row.projectId.toString(),
+    source.entityType,
+    row.id.toString(),
+  );
+  model.source = EntitySource.Inventory;
+  /*
+   * Identity is the owning row's id, not its name: renaming a device in the
+   * UI must not orphan its registry row and mint a second one beside it.
+   */
+  model.identifyingAttributes = {
+    [INVENTORY_ENTITY_IDENTITY_ATTRIBUTE]: row.id.toString(),
+  } as JSONObject;
+  model.displayName = row.displayName.substring(0, ColumnLength.ShortText);
+  model.descriptiveAttributes = row.descriptiveAttributes as JSONObject;
+  /*
+   * The polymorphic pointer back to the rich typed row. Populated here for
+   * every mirrored type — previously only `service` entities carried one —
+   * so a registry row can be resolved to the page that owns it.
+   */
+  model.resourceType = source.resourceType;
+  model.resourceId = row.id;
+  /*
+   * Both stamped at mirror time. `lastSeenAt` never advances for these rows
+   * (no telemetry heartbeat exists to advance it), which is precisely why
+   * PruneStaleEntities excludes EntitySource.Inventory.
+   */
+  model.firstSeenAt = now;
+  model.lastSeenAt = now;
+
+  return model;
+}
+
+/**
+ * True when a mirrored row has drifted from its owning inventory row and
+ * needs rewriting. Compared field by field rather than blindly updating so a
+ * steady-state reconcile issues no writes at all.
+ */
+export function inventoryEntityNeedsUpdate(data: {
+  existing: TelemetryEntity;
+  desired: TelemetryEntity;
+}): boolean {
+  const { existing, desired } = data;
+
+  if ((existing.displayName || "") !== (desired.displayName || "")) {
+    return true;
+  }
+
+  if (existing.resourceType !== desired.resourceType) {
+    return true;
+  }
+
+  if (existing.resourceId?.toString() !== desired.resourceId?.toString()) {
+    return true;
+  }
+
+  return (
+    JSON.stringify(existing.descriptiveAttributes || {}) !==
+    JSON.stringify(desired.descriptiveAttributes || {})
+  );
+}
+
+/**
+ * The columns a drifted mirror rewrites.
+ *
+ * Built as a plain shape and cast once, for the same two reasons as
+ * TelemetryEntityService.buildDescriptiveUpdate: assigning into
+ * `QueryDeepPartialEntity<TelemetryEntity>` directly makes TS instantiate the
+ * recursive JSONObject mapping (TS2589), and under this project's
+ * `exactOptionalPropertyTypes` an optional model field typed `string |
+ * undefined` is not assignable to the update type at all. Keys are therefore
+ * assigned only when they have a value rather than being set to undefined —
+ * which is also the correct write semantics: absent means "leave it alone",
+ * not "null it out".
+ */
+function buildMirrorUpdate(
+  desired: TelemetryEntity,
+): QueryDeepPartialEntity<TelemetryEntity> {
+  const update: {
+    displayName?: string;
+    descriptiveAttributes?: JSONObject;
+    resourceType?: string;
+    resourceId?: ObjectID;
+  } = {};
+
+  if (desired.displayName !== undefined) {
+    update.displayName = desired.displayName;
+  }
+
+  if (desired.descriptiveAttributes !== undefined) {
+    update.descriptiveAttributes = desired.descriptiveAttributes;
+  }
+
+  if (desired.resourceType !== undefined) {
+    update.resourceType = desired.resourceType;
+  }
+
+  if (desired.resourceId !== undefined) {
+    update.resourceId = desired.resourceId;
+  }
+
+  return update as unknown as QueryDeepPartialEntity<TelemetryEntity>;
+}
+
+function defineInventorySource<TModel extends BaseModel>(
+  spec: InventorySourceSpec<TModel>,
+): ErasedInventorySource {
+  return {
+    entityType: spec.entityType,
+    resourceType: spec.resourceType,
+
+    fetchPage: async (data: {
+      skip: number;
+      limit: number;
+    }): Promise<Array<InventoryRowProjection>> => {
+      const rows: Array<TModel> = await spec.service.findBy({
+        query: spec.query,
+        select: {
+          _id: true,
+          projectId: true,
+          name: true,
+          ...spec.select,
+        } as Select<TModel>,
+        skip: data.skip,
+        limit: data.limit,
+        props: { isRoot: true },
+      });
+
+      const projections: Array<InventoryRowProjection> = [];
+
+      for (const row of rows) {
+        const rowRecord: Record<string, unknown> = row as unknown as Record<
+          string,
+          unknown
+        >;
+        const projectId: unknown = rowRecord["projectId"];
+
+        /*
+         * A row with no project cannot be mirrored — the entity key folds
+         * projectId in, and the registry is tenant-scoped. Should not occur;
+         * skipped rather than throwing so one bad row cannot stall the sweep.
+         */
+        if (!row._id || !projectId) {
+          continue;
+        }
+
+        const name: unknown = rowRecord["name"];
+        const displayName: string = String(name || "").trim();
+
+        projections.push({
+          id: new ObjectID(row._id.toString()),
+          projectId: new ObjectID(String(projectId)),
+          displayName:
+            displayName.length > 0 ? displayName : row._id.toString(),
+          descriptiveAttributes: spec.describe(row),
+        });
+      }
+
+      return projections;
+    },
+
+    findLiveIds: async (ids: Array<ObjectID>): Promise<Set<string>> => {
+      if (ids.length === 0) {
+        return new Set<string>();
+      }
+
+      /*
+       * Deliberately unfiltered by `spec.query`: this answers "does the row
+       * still exist", and an archived row still exists. Reusing the mirror
+       * query here would make archiving delete the registry row rather than
+       * merely stop refreshing it, which is a different (and destructive)
+       * behaviour from the one intended.
+       */
+      const rows: Array<TModel> = await spec.service.findBy({
+        query: {
+          _id: QueryHelper.any(
+            ids.map((id: ObjectID) => {
+              return id.toString();
+            }),
+          ),
+        } as Query<TModel>,
+        select: { _id: true } as Select<TModel>,
+        skip: 0,
+        limit: ids.length,
+        props: { isRoot: true },
+      });
+
+      return new Set<string>(
+        rows.map((row: TModel) => {
+          return row._id!.toString();
+        }),
+      );
+    },
+  };
+}
+
+/*
+ * Archived rows are excluded from every source that has the concept: the
+ * explorer is a view of the live estate. IoTDevice and NetworkDevice have no
+ * archive flag, so their queries are unrestricted.
+ */
+export const INVENTORY_SOURCES: ReadonlyArray<ErasedInventorySource> = [
+  defineInventorySource<NetworkDevice>({
+    entityType: EntityType.NetworkDevice,
+    resourceType: "NetworkDevice",
+    service: NetworkDeviceService,
+    select: { hostname: true },
+    query: {},
+    describe: (row: NetworkDevice): Dictionary<string> => {
+      return compactAttributes({ "net.device.hostname": row.hostname });
+    },
+  }),
+  defineInventorySource<CloudResource>({
+    entityType: EntityType.CloudResource,
+    resourceType: "CloudResource",
+    service: CloudResourceService,
+    select: {
+      resourceIdentifier: true,
+      cloudProvider: true,
+      cloudRegion: true,
+      cloudAccountId: true,
+    },
+    query: { isArchived: false },
+    describe: (row: CloudResource): Dictionary<string> => {
+      return compactAttributes({
+        "cloud.resource.id": row.resourceIdentifier,
+        "cloud.provider": row.cloudProvider,
+        "cloud.region": row.cloudRegion,
+        "cloud.account.id": row.cloudAccountId,
+      });
+    },
+  }),
+  defineInventorySource<ServerlessFunction>({
+    entityType: EntityType.ServerlessFunction,
+    resourceType: "ServerlessFunction",
+    service: ServerlessFunctionService,
+    select: {
+      functionIdentifier: true,
+      cloudProvider: true,
+      cloudRegion: true,
+      runtimeName: true,
+    },
+    query: { isArchived: false },
+    describe: (row: ServerlessFunction): Dictionary<string> => {
+      return compactAttributes({
+        "faas.name": row.functionIdentifier,
+        "cloud.provider": row.cloudProvider,
+        "cloud.region": row.cloudRegion,
+        "process.runtime.name": row.runtimeName,
+      });
+    },
+  }),
+  defineInventorySource<RumApplication>({
+    entityType: EntityType.RumApplication,
+    resourceType: "RumApplication",
+    service: RumApplicationService,
+    select: { appIdentifier: true, clientType: true, sdkLanguage: true },
+    query: { isArchived: false },
+    describe: (row: RumApplication): Dictionary<string> => {
+      return compactAttributes({
+        "rum.app.id": row.appIdentifier,
+        "rum.client.type": row.clientType,
+        "telemetry.sdk.language": row.sdkLanguage,
+      });
+    },
+  }),
+  defineInventorySource<IoTDevice>({
+    entityType: EntityType.IoTDevice,
+    resourceType: "IoTDevice",
+    service: IoTDeviceService,
+    select: { externalId: true, deviceType: true, firmwareVersion: true },
+    query: {},
+    describe: (row: IoTDevice): Dictionary<string> => {
+      return compactAttributes({
+        "device.id": row.externalId,
+        "device.type": row.deviceType,
+        "device.firmware.version": row.firmwareVersion,
+      });
+    },
+  }),
+  defineInventorySource<DockerHost>({
+    entityType: EntityType.DockerHost,
+    resourceType: "DockerHost",
+    service: DockerHostService,
+    select: { hostIdentifier: true, osType: true, osVersion: true },
+    query: { isArchived: false },
+    describe: (row: DockerHost): Dictionary<string> => {
+      return compactAttributes({
+        "host.name": row.hostIdentifier,
+        "os.type": row.osType,
+        "os.version": row.osVersion,
+      });
+    },
+  }),
+  defineInventorySource<PodmanHost>({
+    entityType: EntityType.PodmanHost,
+    resourceType: "PodmanHost",
+    service: PodmanHostService,
+    select: { hostIdentifier: true, osType: true, osVersion: true },
+    query: { isArchived: false },
+    describe: (row: PodmanHost): Dictionary<string> => {
+      return compactAttributes({
+        "host.name": row.hostIdentifier,
+        "os.type": row.osType,
+        "os.version": row.osVersion,
+      });
+    },
+  }),
+];
+
+export interface InventorySyncResult {
+  created: number;
+  updated: number;
+  deleted: number;
+}
+
+/**
+ * Forward pass: every live inventory row gets a registry row, and one that
+ * has drifted (renamed, re-tagged) is rewritten.
+ */
+async function mirrorRows(
+  source: ErasedInventorySource,
+): Promise<{ created: number; updated: number }> {
+  let created: number = 0;
+  let updated: number = 0;
+  let skip: number = 0;
+
+  for (;;) {
+    const rows: Array<InventoryRowProjection> = await source.fetchPage({
+      skip,
+      limit: INVENTORY_SYNC_PAGE_SIZE,
+    });
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    const now: Date = OneUptimeDate.getCurrentDate();
+
+    const desiredByKey: Map<string, TelemetryEntity> = new Map<
+      string,
+      TelemetryEntity
+    >();
+
+    for (const row of rows) {
+      const model: TelemetryEntity = buildInventoryEntityModel({
+        source,
+        row,
+        now,
+      });
+      desiredByKey.set(model.entityKey!, model);
+    }
+
+    const existingRows: Array<TelemetryEntity> =
+      await TelemetryEntityService.findBy({
+        query: {
+          entityType: source.entityType,
+          entityKey: QueryHelper.any(Array.from(desiredByKey.keys())),
+        },
+        select: {
+          _id: true,
+          entityKey: true,
+          displayName: true,
+          descriptiveAttributes: true,
+          resourceType: true,
+          resourceId: true,
+        },
+        skip: 0,
+        limit: desiredByKey.size,
+        props: { isRoot: true },
+      });
+
+    const existingByKey: Map<string, TelemetryEntity> = new Map<
+      string,
+      TelemetryEntity
+    >();
+    for (const existing of existingRows) {
+      existingByKey.set(existing.entityKey!, existing);
+    }
+
+    for (const [key, desired] of desiredByKey.entries()) {
+      const existing: TelemetryEntity | undefined = existingByKey.get(key);
+
+      try {
+        if (!existing) {
+          await TelemetryEntityService.create({
+            data: desired,
+            props: { isRoot: true },
+          });
+          created++;
+          continue;
+        }
+
+        if (inventoryEntityNeedsUpdate({ existing, desired })) {
+          await TelemetryEntityService.updateOneById({
+            id: existing.id!,
+            data: buildMirrorUpdate(desired),
+            props: { isRoot: true },
+          });
+          updated++;
+        }
+      } catch (err) {
+        /*
+         * One unmirrorable row must not stall the rest of the estate. The
+         * next run retries it, so a transient failure self-heals.
+         */
+        logger.error(
+          `InventoryEntityRegistry: failed to mirror ${source.resourceType} row for entity key ${key}:`,
+        );
+        logger.error(err as Error);
+      }
+    }
+
+    skip += rows.length;
+
+    if (rows.length < INVENTORY_SYNC_PAGE_SIZE) {
+      break;
+    }
+  }
+
+  return { created, updated };
+}
+
+/**
+ * Reverse pass: a mirrored row whose owning inventory row is gone is
+ * deleted. This is what catches cascade deletes, which fire no service hook.
+ */
+async function removeOrphans(source: ErasedInventorySource): Promise<number> {
+  const orphanIds: Array<ObjectID> = [];
+  let skip: number = 0;
+
+  /*
+   * Collected across a read-only pass and deleted afterwards. Deleting while
+   * paging would shift subsequent offsets and skip rows.
+   */
+  for (;;) {
+    const rows: Array<TelemetryEntity> = await TelemetryEntityService.findBy({
+      query: {
+        entityType: source.entityType,
+        source: EntitySource.Inventory,
+      },
+      select: { _id: true, resourceId: true },
+      skip,
+      limit: INVENTORY_SYNC_PAGE_SIZE,
+      props: { isRoot: true },
+    });
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    const resourceIds: Array<ObjectID> = [];
+    for (const row of rows) {
+      if (row.resourceId) {
+        resourceIds.push(row.resourceId);
+      }
+    }
+
+    const liveIds: Set<string> = await source.findLiveIds(resourceIds);
+
+    for (const row of rows) {
+      /*
+       * A mirrored row with no pointer cannot be matched back to anything,
+       * so it is orphaned by definition.
+       */
+      if (!row.resourceId || !liveIds.has(row.resourceId.toString())) {
+        orphanIds.push(row.id!);
+      }
+    }
+
+    skip += rows.length;
+
+    if (rows.length < INVENTORY_SYNC_PAGE_SIZE) {
+      break;
+    }
+  }
+
+  if (orphanIds.length === 0) {
+    return 0;
+  }
+
+  await TelemetryEntityService.hardDeleteBy({
+    query: {
+      _id: QueryHelper.any(
+        orphanIds.map((id: ObjectID) => {
+          return id.toString();
+        }),
+      ),
+      // Re-asserted so a bug upstream can never widen this into a broad delete.
+      source: EntitySource.Inventory,
+    },
+    limit: orphanIds.length,
+    skip: 0,
+    props: { isRoot: true },
+  });
+
+  return orphanIds.length;
+}
+
+/** Reconciles one inventory table into the registry. */
+export async function syncInventorySource(
+  source: ErasedInventorySource,
+): Promise<InventorySyncResult> {
+  const { created, updated } = await mirrorRows(source);
+  const deleted: number = await removeOrphans(source);
+  return { created, updated, deleted };
+}
+
+/**
+ * Reconciles every inventory table. Each source is isolated: a failure in
+ * one leaves the others to complete, because a broken cloud integration
+ * should not stop network devices being mirrored.
+ */
+export async function syncAllInventorySources(): Promise<InventorySyncResult> {
+  const total: InventorySyncResult = { created: 0, updated: 0, deleted: 0 };
+
+  for (const source of INVENTORY_SOURCES) {
+    try {
+      const result: InventorySyncResult = await syncInventorySource(source);
+      total.created += result.created;
+      total.updated += result.updated;
+      total.deleted += result.deleted;
+    } catch (err) {
+      logger.error(
+        `InventoryEntityRegistry: sync failed for ${source.resourceType}:`,
+      );
+      logger.error(err as Error);
+    }
+  }
+
+  return total;
+}

--- a/Common/Tests/Server/Services/TelemetryEntityManualCreate.test.ts
+++ b/Common/Tests/Server/Services/TelemetryEntityManualCreate.test.ts
@@ -1,0 +1,248 @@
+import TelemetryEntity from "../../../Models/DatabaseModels/TelemetryEntity";
+import TelemetryEntityService from "../../../Server/Services/TelemetryEntityService";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import ObjectID from "../../../Types/ObjectID";
+import EntitySource from "../../../Types/Telemetry/EntitySource";
+import EntityType from "../../../Types/Telemetry/EntityType";
+import { keyForManualEntity } from "../../../Utils/Telemetry/EntityKey";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * TelemetryEntityService.onBeforeCreate is the whole of the manual-CI
+ * write path: it is what decides a create is manual, validates it, and
+ * derives the identity the registry needs from the two fields a human can
+ * supply. It also has to leave machine creates — ingest and the inventory
+ * mirror, which arrive with their keys already computed — completely alone.
+ *
+ * Every assertion below is one of those two duties.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "0f8b9c0d-e1a2-4b3c-8d5e-6f7a8b9c0d1e",
+);
+
+type CallCreate = (createBy: CreateBy<TelemetryEntity>) => Promise<unknown>;
+
+const callOnBeforeCreate: CallCreate = (
+  createBy: CreateBy<TelemetryEntity>,
+): Promise<unknown> => {
+  return (
+    TelemetryEntityService as unknown as {
+      onBeforeCreate: (c: CreateBy<TelemetryEntity>) => Promise<unknown>;
+    }
+  ).onBeforeCreate(createBy);
+};
+
+/*
+ * Explicitly admits `undefined` per field. The suite needs to build creates
+ * with a field genuinely absent (that is what the validation tests are), and
+ * `Partial<TelemetryEntity>` rejects an explicit undefined under this
+ * project's `exactOptionalPropertyTypes`.
+ */
+interface ManualCreateOverrides {
+  projectId?: ObjectID | undefined;
+  entityType?: EntityType | undefined;
+  displayName?: string | undefined;
+  description?: string | undefined;
+}
+
+function manualCreate(
+  overrides: ManualCreateOverrides = {},
+): CreateBy<TelemetryEntity> {
+  const data: TelemetryEntity = new TelemetryEntity();
+  data.projectId = PROJECT_ID;
+  data.entityType = EntityType.ExternalService;
+  data.displayName = "Stripe Payments API";
+  Object.assign(data, overrides);
+
+  return { data, props: { isRoot: true } } as CreateBy<TelemetryEntity>;
+}
+
+describe("manual entity creation", () => {
+  test("a create with no entity key is treated as manual", async () => {
+    const createBy: CreateBy<TelemetryEntity> = manualCreate();
+    await callOnBeforeCreate(createBy);
+
+    expect(createBy.data.source).toBe(EntitySource.Manual);
+  });
+
+  test("derives the entity key from project, type and name", async () => {
+    const createBy: CreateBy<TelemetryEntity> = manualCreate();
+    await callOnBeforeCreate(createBy);
+
+    expect(createBy.data.entityKey).toBe(
+      keyForManualEntity(
+        PROJECT_ID.toString(),
+        EntityType.ExternalService,
+        "Stripe Payments API",
+      ),
+    );
+  });
+
+  test("records the canonicalized name as the identifying attribute", async () => {
+    const createBy: CreateBy<TelemetryEntity> = manualCreate({
+      displayName: "  Stripe Payments API  ",
+    });
+    await callOnBeforeCreate(createBy);
+
+    expect(createBy.data.identifyingAttributes).toEqual({
+      "oneuptime.entity.name": "stripe payments api",
+    });
+  });
+
+  test("trims the stored display name but keeps its original casing", async () => {
+    const createBy: CreateBy<TelemetryEntity> = manualCreate({
+      displayName: "  Stripe Payments API  ",
+    });
+    await callOnBeforeCreate(createBy);
+
+    expect(createBy.data.displayName).toBe("Stripe Payments API");
+  });
+
+  test("two names differing only by case resolve to one identity", async () => {
+    const first: CreateBy<TelemetryEntity> = manualCreate({
+      displayName: "Stripe API",
+    });
+    const second: CreateBy<TelemetryEntity> = manualCreate({
+      displayName: "stripe api",
+    });
+
+    await callOnBeforeCreate(first);
+    await callOnBeforeCreate(second);
+
+    /*
+     * The unique index on (projectId, entityType, entityKey) then rejects
+     * the second as a duplicate rather than admitting a near-identical row.
+     */
+    expect(second.data.entityKey).toBe(first.data.entityKey);
+  });
+
+  test("stamps first and last seen so the row sorts with the rest", async () => {
+    const createBy: CreateBy<TelemetryEntity> = manualCreate();
+    await callOnBeforeCreate(createBy);
+
+    expect(createBy.data.firstSeenAt).toBeInstanceOf(Date);
+    expect(createBy.data.lastSeenAt).toBeInstanceOf(Date);
+  });
+
+  test("accepts every manually creatable type", async () => {
+    for (const entityType of [
+      EntityType.ExternalService,
+      EntityType.ExternalDatabase,
+      EntityType.Appliance,
+    ]) {
+      const createBy: CreateBy<TelemetryEntity> = manualCreate({ entityType });
+      await callOnBeforeCreate(createBy);
+
+      expect(createBy.data.entityType).toBe(entityType);
+      expect(createBy.data.entityKey).toBeTruthy();
+    }
+  });
+});
+
+describe("manual entity validation", () => {
+  test("rejects a type that OneUptime discovers on its own", async () => {
+    await expect(
+      callOnBeforeCreate(manualCreate({ entityType: EntityType.Service })),
+    ).rejects.toThrow(/cannot be created manually/);
+  });
+
+  test("rejects an inventory-mirrored type", async () => {
+    /*
+     * These arrive from the mirror with a precomputed key; a hand-made one
+     * would be a permanent duplicate of the row the mirror maintains.
+     */
+    await expect(
+      callOnBeforeCreate(
+        manualCreate({ entityType: EntityType.NetworkDevice }),
+      ),
+    ).rejects.toThrow(/cannot be created manually/);
+  });
+
+  test("rejects a missing name", async () => {
+    await expect(
+      callOnBeforeCreate(manualCreate({ displayName: undefined })),
+    ).rejects.toThrow(/Name is required/);
+  });
+
+  test("rejects a whitespace-only name", async () => {
+    await expect(
+      callOnBeforeCreate(manualCreate({ displayName: "   " })),
+    ).rejects.toThrow(/Name is required/);
+  });
+
+  test("rejects a missing entity type", async () => {
+    await expect(
+      callOnBeforeCreate(manualCreate({ entityType: undefined })),
+    ).rejects.toThrow(/Entity Type is required/);
+  });
+
+  test("rejects a missing project", async () => {
+    await expect(
+      callOnBeforeCreate(manualCreate({ projectId: undefined })),
+    ).rejects.toThrow(/Project ID is required/);
+  });
+});
+
+describe("machine creates are left alone", () => {
+  test("a discovered create keeps its precomputed key and source", async () => {
+    const data: TelemetryEntity = new TelemetryEntity();
+    data.projectId = PROJECT_ID;
+    data.entityType = EntityType.KubernetesPod;
+    data.entityKey = "210dac24142f1baa";
+    data.source = EntitySource.Discovered;
+    data.displayName = "checkout-7d9f";
+    data.identifyingAttributes = { "k8s.pod.name": "checkout-7d9f" };
+
+    const createBy: CreateBy<TelemetryEntity> = {
+      data,
+      props: { isRoot: true },
+    } as CreateBy<TelemetryEntity>;
+
+    await callOnBeforeCreate(createBy);
+
+    expect(createBy.data.entityKey).toBe("210dac24142f1baa");
+    expect(createBy.data.source).toBe(EntitySource.Discovered);
+    expect(createBy.data.identifyingAttributes).toEqual({
+      "k8s.pod.name": "checkout-7d9f",
+    });
+  });
+
+  test("a discovered create of an otherwise un-creatable type is not rejected", async () => {
+    /*
+     * The manual-type restriction must apply to users, not to ingest — which
+     * legitimately creates services, pods and hosts.
+     */
+    const data: TelemetryEntity = new TelemetryEntity();
+    data.projectId = PROJECT_ID;
+    data.entityType = EntityType.Service;
+    data.entityKey = "abcdef0123456789";
+    data.source = EntitySource.Discovered;
+
+    await expect(
+      callOnBeforeCreate({
+        data,
+        props: { isRoot: true },
+      } as CreateBy<TelemetryEntity>),
+    ).resolves.toBeDefined();
+  });
+
+  test("an inventory mirror create keeps its precomputed key and source", async () => {
+    const data: TelemetryEntity = new TelemetryEntity();
+    data.projectId = PROJECT_ID;
+    data.entityType = EntityType.NetworkDevice;
+    data.entityKey = "9f8e7d6c5b4a3210";
+    data.source = EntitySource.Inventory;
+    data.displayName = "core-switch-1";
+
+    const createBy: CreateBy<TelemetryEntity> = {
+      data,
+      props: { isRoot: true },
+    } as CreateBy<TelemetryEntity>;
+
+    await callOnBeforeCreate(createBy);
+
+    expect(createBy.data.entityKey).toBe("9f8e7d6c5b4a3210");
+    expect(createBy.data.source).toBe(EntitySource.Inventory);
+  });
+});

--- a/Common/Tests/Server/Utils/Telemetry/InventoryEntityRegistry.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/InventoryEntityRegistry.test.ts
@@ -1,0 +1,322 @@
+import TelemetryEntity from "../../../../Models/DatabaseModels/TelemetryEntity";
+import {
+  buildInventoryEntityModel,
+  compactAttributes,
+  ErasedInventorySource,
+  INVENTORY_SOURCES,
+  inventoryEntityNeedsUpdate,
+  InventoryRowProjection,
+} from "../../../../Server/Utils/Telemetry/InventoryEntityRegistry";
+import ColumnLength from "../../../../Types/Database/ColumnLength";
+import Dictionary from "../../../../Types/Dictionary";
+import ObjectID from "../../../../Types/ObjectID";
+import EntitySource from "../../../../Types/Telemetry/EntitySource";
+import EntityType from "../../../../Types/Telemetry/EntityType";
+import { INVENTORY_ENTITY_TYPES } from "../../../../Types/Telemetry/EntityTypeGroups";
+import { keyForInventoryEntity } from "../../../../Utils/Telemetry/EntityKey";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The pure half of the inventory mirror — the mapping from an inventory row
+ * to its registry row, and the drift check that decides whether to write.
+ *
+ * Worth testing closely for two reasons. A mistake in the mapping mints a
+ * duplicate entity that looks entirely correct, and a mistake in the drift
+ * check either writes on every reconcile (seven table scans' worth of
+ * needless UPDATEs every fifteen minutes) or never writes at all (renames
+ * never propagate).
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "0f8b9c0d-e1a2-4b3c-8d5e-6f7a8b9c0d1e",
+);
+const RESOURCE_ID: ObjectID = new ObjectID(
+  "6f2e5c1a-0b3d-4e5f-8a9b-1c2d3e4f5a6b",
+);
+const NOW: Date = new Date("2026-03-04T05:06:07.000Z");
+
+function projection(
+  overrides: Partial<InventoryRowProjection> = {},
+): InventoryRowProjection {
+  return {
+    id: RESOURCE_ID,
+    projectId: PROJECT_ID,
+    displayName: "core-switch-1",
+    descriptiveAttributes: { "net.device.hostname": "core-switch-1.dc1" },
+    ...overrides,
+  };
+}
+
+const NETWORK_SOURCE: Pick<
+  ErasedInventorySource,
+  "entityType" | "resourceType"
+> = {
+  entityType: EntityType.NetworkDevice,
+  resourceType: "NetworkDevice",
+};
+
+describe("compactAttributes", () => {
+  test("keeps ordinary values", () => {
+    expect(compactAttributes({ a: "1", b: "two" })).toEqual({
+      a: "1",
+      b: "two",
+    });
+  });
+
+  test("drops undefined, null, empty and whitespace-only values", () => {
+    const out: Dictionary<string> = compactAttributes({
+      keep: "yes",
+      undef: undefined,
+      nul: null,
+      empty: "",
+      blank: "   ",
+    });
+
+    expect(out).toEqual({ keep: "yes" });
+  });
+
+  test("trims surviving values", () => {
+    expect(compactAttributes({ a: "  spaced  " })).toEqual({ a: "spaced" });
+  });
+
+  test("returns an empty object when everything is dropped", () => {
+    expect(compactAttributes({ a: undefined, b: "" })).toEqual({});
+  });
+});
+
+describe("buildInventoryEntityModel", () => {
+  test("marks the row as inventory-sourced", () => {
+    const model: TelemetryEntity = buildInventoryEntityModel({
+      source: NETWORK_SOURCE,
+      row: projection(),
+      now: NOW,
+    });
+
+    /*
+     * The single most important assertion in this file: PruneStaleEntities
+     * exempts rows by source, so a mirror that came out marked `discovered`
+     * would be deleted the first time the sweep ran past its TTL.
+     */
+    expect(model.source).toBe(EntitySource.Inventory);
+  });
+
+  test("derives the key from the owning row id, matching keyForInventoryEntity", () => {
+    const model: TelemetryEntity = buildInventoryEntityModel({
+      source: NETWORK_SOURCE,
+      row: projection(),
+      now: NOW,
+    });
+
+    expect(model.entityKey).toBe(
+      keyForInventoryEntity(
+        PROJECT_ID.toString(),
+        EntityType.NetworkDevice,
+        RESOURCE_ID.toString(),
+      ),
+    );
+  });
+
+  test("a rename does not change identity", () => {
+    const before: TelemetryEntity = buildInventoryEntityModel({
+      source: NETWORK_SOURCE,
+      row: projection({ displayName: "core-switch-1" }),
+      now: NOW,
+    });
+    const after: TelemetryEntity = buildInventoryEntityModel({
+      source: NETWORK_SOURCE,
+      row: projection({ displayName: "core-switch-1-renamed" }),
+      now: NOW,
+    });
+
+    expect(after.entityKey).toBe(before.entityKey);
+    expect(after.displayName).not.toBe(before.displayName);
+  });
+
+  test("populates the polymorphic pointer back to the owning row", () => {
+    const model: TelemetryEntity = buildInventoryEntityModel({
+      source: NETWORK_SOURCE,
+      row: projection(),
+      now: NOW,
+    });
+
+    expect(model.resourceType).toBe("NetworkDevice");
+    expect(model.resourceId?.toString()).toBe(RESOURCE_ID.toString());
+  });
+
+  test("carries project, type, attributes and timestamps through", () => {
+    const model: TelemetryEntity = buildInventoryEntityModel({
+      source: NETWORK_SOURCE,
+      row: projection(),
+      now: NOW,
+    });
+
+    expect(model.projectId?.toString()).toBe(PROJECT_ID.toString());
+    expect(model.entityType).toBe(EntityType.NetworkDevice);
+    expect(model.descriptiveAttributes).toEqual({
+      "net.device.hostname": "core-switch-1.dc1",
+    });
+    expect(model.firstSeenAt).toEqual(NOW);
+    expect(model.lastSeenAt).toEqual(NOW);
+  });
+
+  test("records the owning row id as the identifying attribute", () => {
+    const model: TelemetryEntity = buildInventoryEntityModel({
+      source: NETWORK_SOURCE,
+      row: projection(),
+      now: NOW,
+    });
+
+    expect(model.identifyingAttributes).toEqual({
+      "oneuptime.resource.id": RESOURCE_ID.toString(),
+    });
+  });
+
+  test("clamps displayName to the column width", () => {
+    /*
+     * displayName is a bounded varchar; an over-long name would otherwise
+     * fail the INSERT with a 22001 and lose the row entirely.
+     */
+    const model: TelemetryEntity = buildInventoryEntityModel({
+      source: NETWORK_SOURCE,
+      row: projection({ displayName: "n".repeat(ColumnLength.ShortText + 50) }),
+      now: NOW,
+    });
+
+    expect(model.displayName!.length).toBe(ColumnLength.ShortText);
+  });
+
+  test("distinct rows of one type produce distinct keys", () => {
+    const first: TelemetryEntity = buildInventoryEntityModel({
+      source: NETWORK_SOURCE,
+      row: projection(),
+      now: NOW,
+    });
+    const second: TelemetryEntity = buildInventoryEntityModel({
+      source: NETWORK_SOURCE,
+      row: projection({
+        id: new ObjectID("11111111-2222-3333-4444-555555555555"),
+      }),
+      now: NOW,
+    });
+
+    expect(first.entityKey).not.toBe(second.entityKey);
+  });
+
+  test("the same row id under two types produces distinct keys", () => {
+    const asDevice: TelemetryEntity = buildInventoryEntityModel({
+      source: NETWORK_SOURCE,
+      row: projection(),
+      now: NOW,
+    });
+    const asIoT: TelemetryEntity = buildInventoryEntityModel({
+      source: { entityType: EntityType.IoTDevice, resourceType: "IoTDevice" },
+      row: projection(),
+      now: NOW,
+    });
+
+    expect(asDevice.entityKey).not.toBe(asIoT.entityKey);
+  });
+});
+
+describe("inventoryEntityNeedsUpdate", () => {
+  function pair(existingOverrides: Partial<InventoryRowProjection>): {
+    existing: TelemetryEntity;
+    desired: TelemetryEntity;
+  } {
+    return {
+      existing: buildInventoryEntityModel({
+        source: NETWORK_SOURCE,
+        row: projection(existingOverrides),
+        now: NOW,
+      }),
+      desired: buildInventoryEntityModel({
+        source: NETWORK_SOURCE,
+        row: projection(),
+        now: NOW,
+      }),
+    };
+  }
+
+  test("false in the steady state, so a quiet reconcile writes nothing", () => {
+    const { existing, desired } = pair({});
+    expect(inventoryEntityNeedsUpdate({ existing, desired })).toBe(false);
+  });
+
+  test("true when the row was renamed", () => {
+    const { existing, desired } = pair({ displayName: "old-name" });
+    expect(inventoryEntityNeedsUpdate({ existing, desired })).toBe(true);
+  });
+
+  test("true when descriptive attributes changed", () => {
+    const { existing, desired } = pair({
+      descriptiveAttributes: { "net.device.hostname": "old-host" },
+    });
+    expect(inventoryEntityNeedsUpdate({ existing, desired })).toBe(true);
+  });
+
+  test("true when an attribute was added", () => {
+    const { existing, desired } = pair({ descriptiveAttributes: {} });
+    expect(inventoryEntityNeedsUpdate({ existing, desired })).toBe(true);
+  });
+
+  test("true when the polymorphic pointer is missing", () => {
+    const { existing, desired } = pair({});
+    // Deleted rather than assigned undefined: exactOptionalPropertyTypes.
+    delete (existing as { resourceId?: ObjectID }).resourceId;
+    expect(inventoryEntityNeedsUpdate({ existing, desired })).toBe(true);
+  });
+
+  test("true when the pointer type is wrong", () => {
+    const { existing, desired } = pair({});
+    existing.resourceType = "SomethingElse";
+    expect(inventoryEntityNeedsUpdate({ existing, desired })).toBe(true);
+  });
+
+  test("ignores lastSeenAt, which never advances for mirrored rows", () => {
+    const { existing, desired } = pair({});
+    existing.lastSeenAt = new Date("2020-01-01T00:00:00.000Z");
+    expect(inventoryEntityNeedsUpdate({ existing, desired })).toBe(false);
+  });
+});
+
+describe("INVENTORY_SOURCES", () => {
+  test("covers exactly the declared inventory entity types", () => {
+    const covered: Array<EntityType> = INVENTORY_SOURCES.map(
+      (source: ErasedInventorySource) => {
+        return source.entityType;
+      },
+    );
+
+    expect(covered.sort()).toEqual(Array.from(INVENTORY_ENTITY_TYPES).sort());
+  });
+
+  test("registers each entity type exactly once", () => {
+    const seen: Set<EntityType> = new Set<EntityType>();
+
+    for (const source of INVENTORY_SOURCES) {
+      expect(seen.has(source.entityType)).toBe(false);
+      seen.add(source.entityType);
+    }
+  });
+
+  test("registers each resourceType exactly once", () => {
+    const seen: Set<string> = new Set<string>();
+
+    for (const source of INVENTORY_SOURCES) {
+      expect(seen.has(source.resourceType)).toBe(false);
+      seen.add(source.resourceType);
+    }
+  });
+
+  test("every source names a non-empty resourceType", () => {
+    for (const source of INVENTORY_SOURCES) {
+      expect(source.resourceType.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("no source mirrors a manually creatable type", () => {
+    for (const source of INVENTORY_SOURCES) {
+      expect(INVENTORY_ENTITY_TYPES.has(source.entityType)).toBe(true);
+    }
+  });
+});

--- a/Common/Tests/Types/Telemetry/EntityTypeGroups.test.ts
+++ b/Common/Tests/Types/Telemetry/EntityTypeGroups.test.ts
@@ -1,0 +1,140 @@
+import EntityType from "../../../Types/Telemetry/EntityType";
+import EntitySource from "../../../Types/Telemetry/EntitySource";
+import {
+  INVENTORY_ENTITY_TYPES,
+  isNonTelemetryEntityType,
+  MANUAL_ENTITY_TYPES,
+} from "../../../Types/Telemetry/EntityTypeGroups";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * These sets decide which entity types the stale-entity prune may reach and
+ * which a user may create by hand. Both questions are answered by set
+ * membership, so a type that drifts out of (or silently into) a set changes
+ * behaviour with no other code change — which is exactly what these pin.
+ */
+
+describe("MANUAL_ENTITY_TYPES", () => {
+  test("is non-empty", () => {
+    expect(MANUAL_ENTITY_TYPES.size).toBeGreaterThan(0);
+  });
+
+  test("contains only real EntityType values", () => {
+    const known: Set<string> = new Set<string>(Object.values(EntityType));
+    for (const entityType of MANUAL_ENTITY_TYPES) {
+      expect(known.has(entityType)).toBe(true);
+    }
+  });
+
+  test("holds exactly the types with no discovery path", () => {
+    expect(Array.from(MANUAL_ENTITY_TYPES).sort()).toEqual(
+      [
+        EntityType.Appliance,
+        EntityType.ExternalDatabase,
+        EntityType.ExternalService,
+      ].sort(),
+    );
+  });
+
+  test("excludes observable types", () => {
+    /*
+     * A hand-made row of an observable type would key off the manual
+     * identity attribute and so could never converge with the row ingest
+     * derives for the same thing. See MANUAL_ENTITY_TYPES.
+     */
+    expect(MANUAL_ENTITY_TYPES.has(EntityType.Service)).toBe(false);
+    expect(MANUAL_ENTITY_TYPES.has(EntityType.Host)).toBe(false);
+    expect(MANUAL_ENTITY_TYPES.has(EntityType.KubernetesPod)).toBe(false);
+    expect(MANUAL_ENTITY_TYPES.has(EntityType.NetworkDevice)).toBe(false);
+  });
+});
+
+describe("INVENTORY_ENTITY_TYPES", () => {
+  test("contains only real EntityType values", () => {
+    const known: Set<string> = new Set<string>(Object.values(EntityType));
+    for (const entityType of INVENTORY_ENTITY_TYPES) {
+      expect(known.has(entityType)).toBe(true);
+    }
+  });
+
+  test("covers every inventory table the registry mirrors", () => {
+    expect(Array.from(INVENTORY_ENTITY_TYPES).sort()).toEqual(
+      [
+        EntityType.CloudResource,
+        EntityType.DockerHost,
+        EntityType.IoTDevice,
+        EntityType.NetworkDevice,
+        EntityType.PodmanHost,
+        EntityType.RumApplication,
+        EntityType.ServerlessFunction,
+      ].sort(),
+    );
+  });
+
+  test("excludes OTLP-derived types", () => {
+    expect(INVENTORY_ENTITY_TYPES.has(EntityType.Service)).toBe(false);
+    expect(INVENTORY_ENTITY_TYPES.has(EntityType.KubernetesCluster)).toBe(
+      false,
+    );
+    expect(INVENTORY_ENTITY_TYPES.has(EntityType.ProxmoxGuest)).toBe(false);
+  });
+});
+
+describe("the two groups are disjoint", () => {
+  test("no type is both manually creatable and inventory-mirrored", () => {
+    for (const entityType of MANUAL_ENTITY_TYPES) {
+      expect(INVENTORY_ENTITY_TYPES.has(entityType)).toBe(false);
+    }
+    for (const entityType of INVENTORY_ENTITY_TYPES) {
+      expect(MANUAL_ENTITY_TYPES.has(entityType)).toBe(false);
+    }
+  });
+});
+
+describe("isNonTelemetryEntityType", () => {
+  test("is true for every manual and inventory type", () => {
+    for (const entityType of MANUAL_ENTITY_TYPES) {
+      expect(isNonTelemetryEntityType(entityType)).toBe(true);
+    }
+    for (const entityType of INVENTORY_ENTITY_TYPES) {
+      expect(isNonTelemetryEntityType(entityType)).toBe(true);
+    }
+  });
+
+  test("is false for OTLP-derived types, which do have a heartbeat", () => {
+    const telemetryTypes: Array<EntityType> = Object.values(EntityType).filter(
+      (entityType: EntityType) => {
+        return (
+          !MANUAL_ENTITY_TYPES.has(entityType) &&
+          !INVENTORY_ENTITY_TYPES.has(entityType)
+        );
+      },
+    );
+
+    expect(telemetryTypes.length).toBeGreaterThan(0);
+
+    for (const entityType of telemetryTypes) {
+      expect(isNonTelemetryEntityType(entityType)).toBe(false);
+    }
+  });
+
+  test("every EntityType is classified one way or the other", () => {
+    for (const entityType of Object.values(EntityType)) {
+      expect(typeof isNonTelemetryEntityType(entityType)).toBe("boolean");
+    }
+  });
+});
+
+describe("EntitySource", () => {
+  test("has exactly the three lifecycles the registry distinguishes", () => {
+    expect(Object.values(EntitySource).sort()).toEqual(
+      ["discovered", "inventory", "manual"].sort(),
+    );
+  });
+
+  test("values are stable strings — they are persisted and queried on", () => {
+    expect(EntitySource.Discovered).toBe("discovered");
+    expect(EntitySource.Inventory).toBe("inventory");
+    expect(EntitySource.Manual).toBe("manual");
+  });
+});

--- a/Common/Tests/Utils/Telemetry/EntityKeyNonTelemetry.test.ts
+++ b/Common/Tests/Utils/Telemetry/EntityKeyNonTelemetry.test.ts
@@ -1,0 +1,193 @@
+import {
+  computeEntityKey,
+  INVENTORY_ENTITY_IDENTITY_ATTRIBUTE,
+  keyForInventoryEntity,
+  keyForManualEntity,
+  MANUAL_ENTITY_IDENTITY_ATTRIBUTE,
+} from "../../../Utils/Telemetry/EntityKey";
+import EntityType from "../../../Types/Telemetry/EntityType";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Identity for the two entity flavours that never pass through ingest:
+ * manually registered CIs and rows mirrored from OneUptime's inventory
+ * tables. Neither has an ingest-side resolver to byte-match, so the only
+ * things that must hold are the ones tested here — determinism, tenant and
+ * type separation, and the specific choice of what each keys on (a manual CI
+ * on its name, an inventory mirror on its owning row's id).
+ *
+ * The consequence of getting these wrong is duplicate registry rows that
+ * both look correct, so each property is pinned rather than assumed.
+ */
+
+const PROJECT: string = "proj1";
+const OTHER_PROJECT: string = "proj2";
+const RESOURCE_ID: string = "6f2e5c1a-0b3d-4e5f-8a9b-1c2d3e4f5a6b";
+
+describe("keyForManualEntity", () => {
+  test("is deterministic", () => {
+    expect(
+      keyForManualEntity(PROJECT, EntityType.ExternalService, "Stripe API"),
+    ).toBe(
+      keyForManualEntity(PROJECT, EntityType.ExternalService, "Stripe API"),
+    );
+  });
+
+  test("is a 16-char lowercase hex key, like every other entity key", () => {
+    const key: string = keyForManualEntity(
+      PROJECT,
+      EntityType.ExternalService,
+      "Stripe API",
+    );
+    expect(key).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("canonicalizes the name, so casing and padding do not fork identity", () => {
+    const canonical: string = keyForManualEntity(
+      PROJECT,
+      EntityType.ExternalService,
+      "Stripe API",
+    );
+
+    expect(
+      keyForManualEntity(PROJECT, EntityType.ExternalService, "  stripe api "),
+    ).toBe(canonical);
+    expect(
+      keyForManualEntity(PROJECT, EntityType.ExternalService, "STRIPE API"),
+    ).toBe(canonical);
+  });
+
+  test("separates tenants", () => {
+    expect(
+      keyForManualEntity(PROJECT, EntityType.ExternalService, "Stripe API"),
+    ).not.toBe(
+      keyForManualEntity(
+        OTHER_PROJECT,
+        EntityType.ExternalService,
+        "Stripe API",
+      ),
+    );
+  });
+
+  test("separates types, so one name can exist as two kinds of thing", () => {
+    expect(
+      keyForManualEntity(PROJECT, EntityType.ExternalService, "payments"),
+    ).not.toBe(
+      keyForManualEntity(PROJECT, EntityType.ExternalDatabase, "payments"),
+    );
+  });
+
+  test("distinct names within a type get distinct keys", () => {
+    expect(
+      keyForManualEntity(PROJECT, EntityType.ExternalService, "Stripe API"),
+    ).not.toBe(
+      keyForManualEntity(PROJECT, EntityType.ExternalService, "Adyen API"),
+    );
+  });
+
+  test("matches computeEntityKey over the documented identity attribute", () => {
+    expect(
+      keyForManualEntity(PROJECT, EntityType.Appliance, "Rack PDU 3"),
+    ).toBe(
+      computeEntityKey({
+        projectId: PROJECT,
+        entityType: EntityType.Appliance,
+        identifyingAttributes: {
+          [MANUAL_ENTITY_IDENTITY_ATTRIBUTE]: "rack pdu 3",
+        },
+      }),
+    );
+  });
+});
+
+describe("keyForInventoryEntity", () => {
+  test("is deterministic", () => {
+    expect(
+      keyForInventoryEntity(PROJECT, EntityType.NetworkDevice, RESOURCE_ID),
+    ).toBe(
+      keyForInventoryEntity(PROJECT, EntityType.NetworkDevice, RESOURCE_ID),
+    );
+  });
+
+  test("keys on the owning row id, so renaming the row keeps its identity", () => {
+    /*
+     * This is the whole reason inventory mirrors key on the id rather than
+     * the name: a rename must update the existing registry row, not orphan
+     * it and mint a second one alongside.
+     */
+    const key: string = keyForInventoryEntity(
+      PROJECT,
+      EntityType.NetworkDevice,
+      RESOURCE_ID,
+    );
+
+    expect(
+      keyForInventoryEntity(PROJECT, EntityType.NetworkDevice, RESOURCE_ID),
+    ).toBe(key);
+  });
+
+  test("separates tenants and types", () => {
+    const key: string = keyForInventoryEntity(
+      PROJECT,
+      EntityType.NetworkDevice,
+      RESOURCE_ID,
+    );
+
+    expect(
+      keyForInventoryEntity(
+        OTHER_PROJECT,
+        EntityType.NetworkDevice,
+        RESOURCE_ID,
+      ),
+    ).not.toBe(key);
+    expect(
+      keyForInventoryEntity(PROJECT, EntityType.IoTDevice, RESOURCE_ID),
+    ).not.toBe(key);
+  });
+
+  test("distinct rows get distinct keys", () => {
+    expect(
+      keyForInventoryEntity(PROJECT, EntityType.NetworkDevice, RESOURCE_ID),
+    ).not.toBe(
+      keyForInventoryEntity(
+        PROJECT,
+        EntityType.NetworkDevice,
+        "11111111-2222-3333-4444-555555555555",
+      ),
+    );
+  });
+
+  test("matches computeEntityKey over the documented identity attribute", () => {
+    expect(
+      keyForInventoryEntity(PROJECT, EntityType.CloudResource, RESOURCE_ID),
+    ).toBe(
+      computeEntityKey({
+        projectId: PROJECT,
+        entityType: EntityType.CloudResource,
+        identifyingAttributes: {
+          [INVENTORY_ENTITY_IDENTITY_ATTRIBUTE]: RESOURCE_ID,
+        },
+      }),
+    );
+  });
+});
+
+describe("manual and inventory identities do not collide", () => {
+  test("the two attributes are distinct", () => {
+    expect(MANUAL_ENTITY_IDENTITY_ATTRIBUTE).not.toBe(
+      INVENTORY_ENTITY_IDENTITY_ATTRIBUTE,
+    );
+  });
+
+  test("same project, same type, same literal value still key differently", () => {
+    /*
+     * A manual CI literally named after a resource id would otherwise
+     * collide with the mirror of that resource.
+     */
+    expect(
+      keyForManualEntity(PROJECT, EntityType.Appliance, RESOURCE_ID),
+    ).not.toBe(
+      keyForInventoryEntity(PROJECT, EntityType.Appliance, RESOURCE_ID),
+    );
+  });
+});

--- a/Common/Types/Telemetry/EntitySource.ts
+++ b/Common/Types/Telemetry/EntitySource.ts
@@ -1,0 +1,40 @@
+/*
+ * How a `TelemetryEntity` registry row came to exist. The registry started
+ * as a forward-only catalog populated purely from OTLP resource attributes;
+ * two later sources join it, and the three differ in exactly one way that
+ * matters — who owns the row's lifecycle.
+ *
+ * That ownership is what `PruneStaleEntities` keys on. It reaps rows whose
+ * `lastSeenAt` has aged past their type's TTL, which is only a correct
+ * staleness signal when something is actively re-bumping `lastSeenAt`. Two
+ * of the three sources have nothing doing that, so the prune sweep is
+ * scoped to `Discovered` alone — see the guard there.
+ */
+enum EntitySource {
+  /**
+   * Derived from telemetry resource attributes at ingest and re-bumped on
+   * every reconcile window for as long as the entity keeps emitting. Silence
+   * past the type's TTL genuinely means gone, so these are TTL-pruned.
+   */
+  Discovered = "discovered",
+
+  /**
+   * Mirrored from a OneUptime inventory table (NetworkDevice, CloudResource,
+   * IoTDevice, ...). These are collected by pollers rather than OTLP, so no
+   * ingest path bumps `lastSeenAt` — the owning row IS the liveness signal,
+   * and the mirror is kept in step by that table's create/delete hooks. TTL
+   * pruning one of these would delete the registry row for a device that is
+   * still very much registered.
+   */
+  Inventory = "inventory",
+
+  /**
+   * Created by a user for something that emits no telemetry at all — a
+   * third-party API, a vendor-managed database, an appliance. Nothing will
+   * ever bump `lastSeenAt`, so these are never TTL-pruned; they live until
+   * the user deletes them.
+   */
+  Manual = "manual",
+}
+
+export default EntitySource;

--- a/Common/Types/Telemetry/EntityType.ts
+++ b/Common/Types/Telemetry/EntityType.ts
@@ -51,6 +51,33 @@ enum EntityType {
   DockerSwarmService = "docker.swarm.service",
   DockerSwarmTask = "docker.swarm.task",
   TelemetrySdk = "telemetry.sdk",
+  /*
+   * Inventory-mirrored types. Unlike everything above, these are never
+   * derived from an OTLP resource — the estate they describe is collected
+   * by pollers (SNMP, cloud APIs, MQTT) into rich typed tables, and the
+   * registry row is a mirror of that row so the entity explorer can show
+   * one estate instead of one telemetry pipeline. Their identity is the
+   * owning row's own project-unique key, and their lifecycle follows it
+   * (see InventoryEntityRegistry); they carry EntitySource.Inventory and
+   * are deliberately absent from the prune TTL map.
+   */
+  NetworkDevice = "network.device",
+  CloudResource = "cloud.resource",
+  ServerlessFunction = "serverless.function",
+  RumApplication = "rum.application",
+  IoTDevice = "iot.device",
+  DockerHost = "docker.host",
+  PodmanHost = "podman.host",
+  /*
+   * Manual (user-authored) types, for the parts of an estate that emit no
+   * telemetry and appear in no inventory table: a third-party payment API,
+   * a vendor-managed database, a physical appliance. They exist so a
+   * dependency edge can terminate somewhere real instead of dangling at
+   * the boundary of what OneUptime can see. Carry EntitySource.Manual.
+   */
+  ExternalService = "external.service",
+  ExternalDatabase = "external.database",
+  Appliance = "appliance",
 }
 
 export default EntityType;

--- a/Common/Types/Telemetry/EntityTypeGroups.ts
+++ b/Common/Types/Telemetry/EntityTypeGroups.ts
@@ -1,0 +1,65 @@
+import EntityType from "./EntityType";
+
+/*
+ * Partitions of the EntityType vocabulary by who creates and owns a row of
+ * that type. Isomorphic (plain Types, no server imports) because all three
+ * consumers need the same answer: the service enforcing what a user may
+ * create, the dashboard populating the type dropdown, and the tests pinning
+ * that the prune sweep cannot reach a type nothing re-bumps.
+ *
+ * Deliberately expressed as explicit sets rather than a string-prefix test.
+ * Prefix matching would silently absorb any future `external.*` or
+ * `*.device` type into the set that is exempt from pruning, which is the
+ * kind of default that goes unnoticed until a registry fills with rows
+ * nothing can ever reap.
+ */
+
+/**
+ * Types a user may create by hand. These describe things OneUptime cannot
+ * observe — a third-party API, a vendor-managed database, an appliance —
+ * so nothing will ever discover them and nothing will ever bump their
+ * `lastSeenAt`.
+ *
+ * Manual creation is confined to these on purpose. A hand-made row of an
+ * observable type (say `service`) would mint an entity key from the manual
+ * identity attribute, which by construction differs from the key ingest
+ * derives from `service.name` — so the manual row would sit beside the
+ * discovered one as a permanent near-duplicate rather than merging with it.
+ */
+export const MANUAL_ENTITY_TYPES: ReadonlySet<EntityType> = new Set<EntityType>(
+  [
+    EntityType.ExternalService,
+    EntityType.ExternalDatabase,
+    EntityType.Appliance,
+  ],
+);
+
+/**
+ * Types mirrored from a OneUptime inventory table. The owning row is the
+ * source of truth for both identity and liveness; the registry row is a
+ * projection kept in step by that table's create/delete hooks.
+ */
+export const INVENTORY_ENTITY_TYPES: ReadonlySet<EntityType> =
+  new Set<EntityType>([
+    EntityType.NetworkDevice,
+    EntityType.CloudResource,
+    EntityType.ServerlessFunction,
+    EntityType.RumApplication,
+    EntityType.IoTDevice,
+    EntityType.DockerHost,
+    EntityType.PodmanHost,
+  ]);
+
+/**
+ * True for types whose rows have no telemetry heartbeat, and which are
+ * therefore never eligible for `lastSeenAt`-based pruning. The prune job
+ * enforces this through the `source` column instead (a row's source is the
+ * authority, not its type); this predicate is what the tests assert the TTL
+ * map against, so a newly added type cannot quietly acquire a TTL.
+ */
+export function isNonTelemetryEntityType(entityType: EntityType): boolean {
+  return (
+    MANUAL_ENTITY_TYPES.has(entityType) ||
+    INVENTORY_ENTITY_TYPES.has(entityType)
+  );
+}

--- a/Common/Utils/Telemetry/EntityKey.ts
+++ b/Common/Utils/Telemetry/EntityKey.ts
@@ -202,3 +202,69 @@ export function keyForDockerSwarmCluster(
     identifyingAttributes: { "docker.swarm.cluster.name": clusterName },
   });
 }
+
+/*
+ * ---- Rows without telemetry ----------------------------------------------
+ *
+ * The helpers above mirror an ingest-side resolver, so their identifying
+ * attribute is dictated by semconv — the key MUST byte-match what ingest
+ * stamped or the lookup finds nothing. The two below have no ingest-side
+ * counterpart to match: nothing about a hand-registered vendor API or an
+ * SNMP-polled switch ever flows through an OTLP resource. Their identity is
+ * therefore chosen here, and the only real requirement is that it is stable
+ * and collision-free within a project.
+ */
+
+/**
+ * Identity attribute for a manually created CI. Its value is the CI's
+ * canonicalized display name, which makes (project, type, name) the natural
+ * key — so re-creating a deleted CI under the same name reuses its key, and
+ * two CIs of one type cannot share a name.
+ */
+export const MANUAL_ENTITY_IDENTITY_ATTRIBUTE: string = "oneuptime.entity.name";
+
+/**
+ * Key for a manually created CI. Pass the user-entered display name; it is
+ * canonicalized (trimmed + lowercased) exactly like every other identity
+ * value, so casing drift on re-entry does not fork identity.
+ */
+export function keyForManualEntity(
+  projectId: string,
+  entityType: EntityType,
+  displayName: string,
+): string {
+  return computeEntityKey({
+    projectId,
+    entityType,
+    identifyingAttributes: {
+      [MANUAL_ENTITY_IDENTITY_ATTRIBUTE]: displayName,
+    },
+  });
+}
+
+/**
+ * Identity attribute for an inventory-mirrored CI. The value is the owning
+ * row's ObjectID rather than its name: unlike the semconv-derived types,
+ * the inventory row IS the identity, and keying on the id means renaming a
+ * device in the UI does not orphan its registry row and mint a second one.
+ */
+export const INVENTORY_ENTITY_IDENTITY_ATTRIBUTE: string =
+  "oneuptime.resource.id";
+
+/**
+ * Key for a row mirrored out of a OneUptime inventory table. Pass the
+ * owning row's id (e.g. `NetworkDevice.id`).
+ */
+export function keyForInventoryEntity(
+  projectId: string,
+  entityType: EntityType,
+  resourceId: string,
+): string {
+  return computeEntityKey({
+    projectId,
+    entityType,
+    identifyingAttributes: {
+      [INVENTORY_ENTITY_IDENTITY_ATTRIBUTE]: resourceId,
+    },
+  });
+}


### PR DESCRIPTION
## What this changes

The entity explorer showed only what OpenTelemetry ingest could derive from a resource. Half of what OneUptime inventories — network devices, cloud resources, serverless functions, RUM applications, IoT devices, Docker and Podman hosts — is collected by pollers that never produce an OTLP resource, so those rows lived in their own tables and appeared nowhere in the cross-cutting view. And anything OneUptime cannot observe at all (a vendor-managed API, an appliance) had nowhere to be represented, so dependency edges dangled at the boundary of what we can see.

Two additions, sharing one mechanism:

- **Inventory coverage** — the seven poller-collected tables are mirrored into `TelemetryEntity`.
- **Manual CIs** — users can register things that emit no telemetry and appear in no inventory.

## The mechanism: `EntitySource`

A `source` column on `TelemetryEntity` and `TelemetryEntityRelationship` distinguishes three lifecycles:

| Source | Origin | Who owns liveness |
|---|---|---|
| `discovered` | OTLP resource attributes at ingest | ingest re-bumps `lastSeenAt` every reconcile window |
| `inventory` | mirrored from an inventory table | the owning row |
| `manual` | created by a user | the user |

## The correctness point worth reviewing

`PruneStaleEntities` hard-deletes rows whose `lastSeenAt` has aged past their type's TTL. That is only a staleness signal for rows something re-bumps. The other two sources have no heartbeat — their `lastSeenAt` is frozen at creation, so **every one of them crosses any TTL simply by existing long enough**.

Both sweeps (entities and edges) are therefore scoped to `source = discovered`. Without that predicate the job silently deletes every manually registered CI roughly a day after it was created, with no error anywhere. The manual and inventory types are *also* absent from the TTL map, so they are unreachable by two independent mechanisms — deliberate belt-and-braces, because the failure mode is silent loss of user data.

The edge column matters for the same reason: a hand-drawn edge is the only way to connect a manual CI to anything, and the 30-day edge sweep would otherwise reap it while both endpoints survived.

## Design notes

**Reconcile, not hooks.** Inventory mirroring is a cron (`SyncInventoryEntities`, every 15 min), not create/delete hooks on seven tables. Hooks only fire on future writes (no backfill), miss cascade deletes (deleting a project removes its devices by FK with no per-row hook), and are seven chances to drop one. A level-triggered reconcile converges regardless of how the inventory got into its current state.

**Mirrors key on the owning row's id**, not its name, so renaming a device updates its registry row rather than orphaning it and minting a second. They also populate the `(resourceType, resourceId)` pointer — previously stamped only for `service` entities.

**Manual CIs are confined to `external.service` / `external.database` / `appliance`.** A hand-made row of an observable type would key off the manual identity attribute, which by construction differs from the key ingest derives, so it would sit beside the discovered row as a permanent near-duplicate. Identity is derived server-side from `(project, type, name)`, so API clients get the same rule as the dashboard.

**Entity budget** now counts only `discovered` rows, so registering devices cannot exhaust the budget that bounds ingest-minted rows.

## Migration

Generated with `npm run generate-postgres-migration` (not hand-written) and registered in `SchemaMigrations/Index.ts`. Adds both `source` columns with `DEFAULT 'discovered'` so existing rows backfill correctly, a nullable `description`, and an index on each `source`. `npm run check-postgres-schema-drift` reports **no drift**.

## Tests — 96 across four suites

| Suite | Tests | Covers |
|---|---|---|
| `App/Tests/Workers/Jobs/TelemetryEntity/PruneStaleEntities` | 12 | drives a full cron tick, asserts the source predicate on **every** delete issued, that no manual/inventory type is ever swept, that telemetry types still are, and batching/failure isolation |
| `Common/Tests/Server/Utils/Telemetry/InventoryEntityRegistry` | 25 | the row→entity mapping, rename-keeps-identity, displayName clamping, drift detection (and no-write in the steady state), source coverage |
| `Common/Tests/Server/Services/TelemetryEntityManualCreate` | 16 | key derivation, canonicalization, every validation path, and that machine creates pass through untouched |
| `Common/Tests/Utils/Telemetry/EntityKeyNonTelemetry` + `Types/Telemetry/EntityTypeGroups` | 43 | identity determinism, tenant/type separation, manual-vs-inventory non-collision, set partitioning |
| `App/Tests/Dashboard/EntitiesTableManualCreate` | (in the 12/43 above) | the form offers only manual types and never exposes `entityKey`/`source` |

The prune guard is covered **behaviourally** — mocking `RunCron` to capture the handler and inspecting the queries — rather than by scraping source.

## Not included

- No docs page under `App/FeatureSet/Docs`. Worth a follow-up before this is announced.
- Manual **edges** are creatable via the CRUD API and protected from pruning, but have no dashboard UI yet.
- Ownership (`OwnerTeam`/`OwnerUser`) on entities was considered and deliberately left out of this change.
