### PR TITLE
feat(workflow): show broken settings in the builder instead of at run time

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Workflow/View/Builder.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Workflow/View/Builder.tsx
@@ -15,6 +15,12 @@ import ComponentMetadata, {
 import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
 import ConfirmModal from "Common/UI/Components/Modal/ConfirmModal";
+import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
+import {
+  WorkflowLintIssue,
+  WorkflowLintResult,
+  WorkflowLintSeverity,
+} from "Common/UI/Components/Workflow/GraphLint";
 import { loadComponentsAndCategories } from "Common/UI/Components/Workflow/Utils";
 import Workflow, {
   getEdgeDefaultProps,
@@ -36,6 +42,30 @@ import { useAsyncEffect } from "use-async-effect";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 
+type GetIssueSummaryTextFunction = (result: WorkflowLintResult) => string;
+
+const getIssueSummaryText: GetIssueSummaryTextFunction = (
+  result: WorkflowLintResult,
+): string => {
+  const parts: Array<string> = [];
+
+  if (result.errorCount > 0) {
+    parts.push(
+      `${result.errorCount} ${result.errorCount === 1 ? "problem" : "problems"}`,
+    );
+  }
+
+  if (result.warningCount > 0) {
+    parts.push(
+      `${result.warningCount} ${
+        result.warningCount === 1 ? "warning" : "warnings"
+      }`,
+    );
+  }
+
+  return parts.join(", ");
+};
+
 const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [saveStatus, setSaveStatus] = useState<string>("");
@@ -55,6 +85,9 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
     useState<boolean>(false);
 
   const [showRunModal, setShowRunModal] = useState<boolean>(false);
+
+  const [lintResult, setLintResult] = useState<WorkflowLintResult | null>(null);
+  const [showIssuesModal, setShowIssuesModal] = useState<boolean>(false);
 
   const loadGraph: PromiseVoidFunction = async (): Promise<void> => {
     try {
@@ -121,6 +154,16 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
               nodes[i]!.data.metadata = {
                 ...componentMetdata,
               };
+
+              /*
+               * Any error text in a stored graph is stale by definition — it
+               * describes what the builder said about a draft at some past
+               * moment, and the checks re-run on load anyway. Clearing it here
+               * means a graph that was saved with an error in it (possible
+               * before saveGraph started stripping the field) heals itself
+               * rather than showing a badge for a problem that is long fixed.
+               */
+              nodes[i]!.data.error = "";
             }
 
             // see if it has the trigger node.
@@ -209,6 +252,15 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
               };
 
               delete ((graph["nodes"] as Array<Node>)[i] as Node).data.metadata;
+
+              /*
+               * data.error holds whatever the builder's static checks are
+               * saying about this node right now. That is a property of the
+               * current draft, not of the workflow, and saving it means a
+               * message survives the fix that resolved it and comes back on
+               * the next load. Drop it on the way out.
+               */
+              delete ((graph["nodes"] as Array<Node>)[i] as Node).data.error;
             }
           }
 
@@ -314,6 +366,28 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
                 {saveStatus || "Ready"}
               </span>
             </div>
+
+            {/*
+              Static checks over the graph. Clicking opens the full list —
+              each node also carries its own badge on the canvas.
+            */}
+            {lintResult && lintResult.issues.length > 0 && (
+              <button
+                type="button"
+                onClick={() => {
+                  setShowIssuesModal(true);
+                }}
+                style={{
+                  fontSize: "0.75rem",
+                  fontWeight: 500,
+                  cursor: "pointer",
+                  textDecoration: "underline",
+                  color: lintResult.errorCount > 0 ? "#ef4444" : "#f59e0b",
+                }}
+              >
+                {getIssueSummaryText(lintResult)}
+              </button>
+            )}
           </div>
 
           <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
@@ -361,6 +435,9 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
               setShowComponentPickerModal(value);
             }}
             initialNodes={nodes}
+            onLintResultChange={(result: WorkflowLintResult) => {
+              setLintResult(result);
+            }}
             onRunModalUpdate={(value: boolean) => {
               setShowRunModal(value);
             }}
@@ -415,6 +492,50 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
             }}
             submitButtonType={ButtonStyleType.NORMAL}
           />
+        )}
+
+        {showIssuesModal && lintResult && (
+          <Modal
+            title="Problems with this workflow"
+            description="These are found by reading the workflow. Fixing them here saves a failed run later."
+            modalWidth={ModalWidth.Large}
+            submitButtonText="Close"
+            submitButtonStyleType={ButtonStyleType.NORMAL}
+            onSubmit={() => {
+              setShowIssuesModal(false);
+            }}
+          >
+            <div className="space-y-2">
+              {lintResult.issues.map(
+                (issue: WorkflowLintIssue, i: number): ReactElement => {
+                  const isError: boolean =
+                    issue.severity === WorkflowLintSeverity.Error;
+
+                  return (
+                    <div
+                      key={i}
+                      className={`rounded-md border p-3 ${
+                        isError
+                          ? "border-red-200 bg-red-50"
+                          : "border-amber-200 bg-amber-50"
+                      }`}
+                    >
+                      <p
+                        className={`text-xs font-semibold uppercase tracking-wider ${
+                          isError ? "text-red-700" : "text-amber-700"
+                        }`}
+                      >
+                        {issue.componentId || "This workflow"}
+                      </p>
+                      <p className="text-sm text-gray-700 mt-1">
+                        {issue.message}
+                      </p>
+                    </div>
+                  );
+                },
+              )}
+            </div>
+          </Modal>
         )}
 
         {showRunSuccessConfirmation && (

--- a/App/FeatureSet/Docs/Content/en/workflows/variables.md
+++ b/App/FeatureSet/Docs/Content/en/workflows/variables.md
@@ -114,14 +114,15 @@ The API key needs **Edit Workflow Variables** to write `content`, and **Read Wor
 
 Two things to watch:
 
-- **Don't rename a variable you reference.** `name` is part of `{{local.variables.NAME}}`. Changing it leaves every existing reference resolving to an empty string, silently.
+- **Don't rename a variable you reference.** `name` is part of `{{local.variables.NAME}}`. Changing it leaves every existing reference unresolved, and an unresolved reference is passed through as the literal text `{{local.variables.NAME}}` — see the gotcha below.
 - **A variable marked secret can still be written this way** — it just can't be read back. That's what makes it a safe place to park a rotating token.
 
 ## Gotchas
 
 - **Use the pickers.** They insert the exact component, return-value, and variable IDs expected by the runner and keep references independent of display labels.
 - **Variable names are case-sensitive.** `{{global.variables.MyKey}}` and `{{global.variables.mykey}}` are different.
-- **Missing fields become empty.** Referring to a field that doesn't exist gives you an empty string, not an error. Convenient — but it can hide bugs. Use a **Conditions** block to check important fields before continuing.
+- **A reference that doesn't resolve is left as-is, not blanked.** Referring to something that doesn't exist is not an error, and it does not give you an empty string either: the braces are passed straight through, so `{{local.components.api-get-1.returnValues.body}}` with a mistyped step id ends up in your Slack message, URL or request body verbatim, and the run still reports Success. The builder flags references it can't match before you save, and the run log carries a warning line for any that slip through — but for values you can't check ahead of time, use a **Conditions** block before continuing.
+- **Spaces inside the braces are not trimmed.** `{{ local.variables.NAME }}` is a different lookup from `{{local.variables.NAME}}` and never resolves. The one exception is inside an `{{#each}}` block, where names are trimmed.
 
 ## Where to read next
 

--- a/App/FeatureSet/Workflow/Services/RunWorkflow.ts
+++ b/App/FeatureSet/Workflow/Services/RunWorkflow.ts
@@ -16,6 +16,11 @@ import ComponentMetadata, {
   Port,
   ReturnValue,
 } from "Common/Types/Workflow/Component";
+import {
+  TemplateExpression,
+  TemplateExpressionKind,
+  parseTemplateExpressions,
+} from "Common/Types/Workflow/TemplateSyntax";
 import WorkflowStatus from "Common/Types/Workflow/WorkflowStatus";
 import WorkflowLogService from "Common/Server/Services/WorkflowLogService";
 import WorkflowService from "Common/Server/Services/WorkflowService";
@@ -616,6 +621,56 @@ export default class RunWorkflow {
     }
   }
 
+  /**
+   * Note in the run log every {{...}} reference that went in and came back out
+   * unchanged.
+   *
+   * VMAPI.replaceValueInPlace skips a reference it cannot resolve and leaves
+   * the literal text in place, so a mistyped path — {{local.componets.x}} for
+   * {{local.components.x}} — ships "{{local.componets.x}}" as the value and the
+   * run still reports Success. Whoever reads the log afterwards has no way to
+   * tell that from a value that was genuinely meant to be that text. This says
+   * so out loud.
+   *
+   * Compares against the input rather than just scanning the output, so a
+   * resolved value that happens to contain braces of its own is not reported.
+   */
+  private logUnresolvedReferences(params: {
+    argument: Argument;
+    before: JSONValue;
+    after: JSONValue;
+  }): void {
+    if (
+      typeof params.before !== "string" ||
+      typeof params.after !== "string"
+    ) {
+      return;
+    }
+
+    const unresolved: Array<string> = parseTemplateExpressions(params.before)
+      .filter((expression: TemplateExpression) => {
+        return (
+          expression.kind === TemplateExpressionKind.Reference &&
+          (params.after as string).includes(expression.raw)
+        );
+      })
+      .map((expression: TemplateExpression) => {
+        return expression.raw;
+      });
+
+    if (unresolved.length === 0) {
+      return;
+    }
+
+    const distinct: Array<string> = Array.from(new Set(unresolved));
+
+    this.log(
+      `Warning: ${distinct.join(", ")} in "${
+        params.argument.name
+      }" did not resolve to anything and was left as literal text. Check the step id and the return value name.`,
+    );
+  }
+
   public getComponentArguments(
     storageMap: StorageMap,
     component: NodeDataProp,
@@ -639,11 +694,19 @@ export default class RunWorkflow {
         continue;
       }
 
+      const contentBeforeSubstitution: JSONValue = argumentContent;
+
       argumentContent = VMAPI.replaceValueInPlace(
         storageMap as any,
         argumentContent as string,
         argument.type === ComponentInputType.JSON,
       );
+
+      this.logUnresolvedReferences({
+        argument: argument,
+        before: contentBeforeSubstitution,
+        after: argumentContent,
+      });
 
       if (
         typeof argumentContent === "string" &&

--- a/App/Tests/FeatureSet/Workflow/GetComponentArguments.test.ts
+++ b/App/Tests/FeatureSet/Workflow/GetComponentArguments.test.ts
@@ -1,0 +1,368 @@
+import IconProp from "Common/Types/Icon/IconProp";
+import { JSONObject } from "Common/Types/JSON";
+import ComponentMetadata, {
+  Argument,
+  ComponentInputType,
+  ComponentType,
+  NodeDataProp,
+  NodeType,
+} from "Common/Types/Workflow/Component";
+import RunWorkflow, {
+  StorageMap,
+} from "../../../FeatureSet/Workflow/Services/RunWorkflow";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+type MakeArgumentFunction = (
+  id: string,
+  type: ComponentInputType,
+) => Argument;
+
+const makeArgument: MakeArgumentFunction = (
+  id: string,
+  type: ComponentInputType,
+): Argument => {
+  return {
+    id: id,
+    name: id,
+    description: `${id} argument`,
+    type: type,
+    required: false,
+  };
+};
+
+type MakeNodeFunction = (
+  args: Array<Argument>,
+  values: JSONObject,
+) => NodeDataProp;
+
+const makeNode: MakeNodeFunction = (
+  args: Array<Argument>,
+  values: JSONObject,
+): NodeDataProp => {
+  const metadata: ComponentMetadata = {
+    id: "test-component",
+    title: "Test Component",
+    category: "Test",
+    description: "For tests",
+    iconProp: IconProp.Bolt,
+    componentType: ComponentType.Component,
+    arguments: args,
+    returnValues: [],
+    inPorts: [],
+    outPorts: [],
+  };
+
+  return {
+    error: "",
+    id: "test-component-1",
+    nodeType: NodeType.Node,
+    metadata: metadata,
+    metadataId: metadata.id,
+    internalId: "internal-1",
+    arguments: values,
+    returnValues: {},
+    componentType: ComponentType.Component,
+  };
+};
+
+type MakeStorageFunction = (params: {
+  variables?: Record<string, string> | undefined;
+  components?: { [x: string]: { returnValues: JSONObject } } | undefined;
+}) => StorageMap;
+
+const makeStorage: MakeStorageFunction = (params: {
+  variables?: Record<string, string> | undefined;
+  components?: { [x: string]: { returnValues: JSONObject } } | undefined;
+}): StorageMap => {
+  return {
+    local: {
+      variables: params.variables || {},
+      components: params.components || {},
+    },
+    global: {
+      variables: {},
+    },
+  };
+};
+
+type CapturedLogsFunction = (runner: RunWorkflow) => Array<string>;
+
+const logsOf: CapturedLogsFunction = (runner: RunWorkflow): Array<string> => {
+  const captured: Array<string> = [];
+
+  jest.spyOn(runner, "log").mockImplementation((data: unknown): void => {
+    captured.push(typeof data === "string" ? data : JSON.stringify(data));
+  });
+
+  return captured;
+};
+
+describe("getComponentArguments — substitution", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("substitutes a variable into a text argument", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    logsOf(runner);
+
+    const args: JSONObject = runner.getComponentArguments(
+      makeStorage({ variables: { token: "abc" } }),
+      makeNode([makeArgument("message", ComponentInputType.Text)], {
+        message: "Bearer {{local.variables.token}}",
+      }),
+    );
+
+    expect(args["message"]).toBe("Bearer abc");
+  });
+
+  test("parses a JSON argument into an object", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    logsOf(runner);
+
+    const args: JSONObject = runner.getComponentArguments(
+      makeStorage({}),
+      makeNode([makeArgument("request-body", ComponentInputType.JSON)], {
+        "request-body": '{"a": 1}',
+      }),
+    );
+
+    expect(args["request-body"]).toEqual({ a: 1 });
+  });
+
+  test("throws with the argument named when a JSON argument is malformed", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    logsOf(runner);
+
+    expect(() => {
+      return runner.getComponentArguments(
+        makeStorage({}),
+        makeNode([makeArgument("request-body", ComponentInputType.JSON)], {
+          "request-body": '{"a": 1,}',
+        }),
+      );
+    }).toThrow(/request-body/);
+  });
+
+  test("skips arguments that were never set", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    logsOf(runner);
+
+    const args: JSONObject = runner.getComponentArguments(
+      makeStorage({}),
+      makeNode([makeArgument("message", ComponentInputType.Text)], {}),
+    );
+
+    expect(args["message"]).toBeUndefined();
+  });
+});
+
+describe("getComponentArguments — header dictionaries in both shapes", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const headerArgument: Argument = makeArgument(
+    "request-headers",
+    ComponentInputType.StringDictionary,
+  );
+
+  test("carries the legacy JSON-string shape through unchanged", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    logsOf(runner);
+
+    const args: JSONObject = runner.getComponentArguments(
+      makeStorage({ variables: { token: "abc" } }),
+      makeNode([headerArgument], {
+        "request-headers": '{"Authorization": "Bearer {{local.variables.token}}"}',
+      }),
+    );
+
+    /*
+     * StringDictionary is not parsed here — the component does that with JSON5
+     * (ApiComponentUtils.sanitizeArgs), which is what lets a legacy value keep
+     * working. What matters is that the substitution happened.
+     */
+    expect(args["request-headers"]).toBe(
+      '{"Authorization": "Bearer abc"}',
+    );
+  });
+
+  test("carries the object shape through as an object", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    logsOf(runner);
+
+    const args: JSONObject = runner.getComponentArguments(
+      makeStorage({ variables: { token: "abc" } }),
+      makeNode([headerArgument], {
+        "request-headers": {
+          Authorization: "Bearer {{local.variables.token}}",
+        },
+      }),
+    );
+
+    expect(args["request-headers"]).toEqual({
+      Authorization: "Bearer abc",
+    });
+  });
+
+  test("keeps the object shape intact when a value contains a quote", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    logsOf(runner);
+
+    const args: JSONObject = runner.getComponentArguments(
+      makeStorage({ variables: { note: 'say "hi"' } }),
+      makeNode([headerArgument], {
+        "request-headers": { "X-Note": "{{local.variables.note}}" },
+      }),
+    );
+
+    expect(args["request-headers"]).toEqual({ "X-Note": 'say "hi"' });
+  });
+});
+
+describe("getComponentArguments — unresolved reference warnings", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("warns when a reference resolves to nothing and is left as text", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    const logs: Array<string> = logsOf(runner);
+
+    const args: JSONObject = runner.getComponentArguments(
+      makeStorage({}),
+      makeNode([makeArgument("message", ComponentInputType.Text)], {
+        message: "value is {{local.componets.api-get-1.returnValues.body}}",
+      }),
+    );
+
+    // The literal text still goes through — the warning is the whole point.
+    expect(args["message"]).toBe(
+      "value is {{local.componets.api-get-1.returnValues.body}}",
+    );
+
+    const warning: string | undefined = logs.find((line: string) => {
+      return line.startsWith("Warning:");
+    });
+
+    expect(warning).toBeDefined();
+    expect(warning).toMatch(/local\.componets\.api-get-1/);
+    expect(warning).toMatch(/"message"/);
+    expect(warning).toMatch(/literal text/);
+  });
+
+  test("lists each unresolved reference once", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    const logs: Array<string> = logsOf(runner);
+
+    runner.getComponentArguments(
+      makeStorage({}),
+      makeNode([makeArgument("message", ComponentInputType.Text)], {
+        message: "{{local.variables.a}} {{local.variables.a}} {{local.variables.b}}",
+      }),
+    );
+
+    const warning: string = logs.find((line: string) => {
+      return line.startsWith("Warning:");
+    }) as string;
+
+    expect(warning.match(/local\.variables\.a/g)).toHaveLength(1);
+    expect(warning).toMatch(/local\.variables\.b/);
+  });
+
+  test("says nothing when every reference resolved", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    const logs: Array<string> = logsOf(runner);
+
+    runner.getComponentArguments(
+      makeStorage({ variables: { token: "abc" } }),
+      makeNode([makeArgument("message", ComponentInputType.Text)], {
+        message: "{{local.variables.token}}",
+      }),
+    );
+
+    expect(
+      logs.filter((line: string) => {
+        return line.startsWith("Warning:");
+      }),
+    ).toHaveLength(0);
+  });
+
+  test("says nothing about an argument with no references at all", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    const logs: Array<string> = logsOf(runner);
+
+    runner.getComponentArguments(
+      makeStorage({}),
+      makeNode([makeArgument("message", ComponentInputType.Text)], {
+        message: "plain text",
+      }),
+    );
+
+    expect(logs).toHaveLength(0);
+  });
+
+  /*
+   * A resolved value is allowed to contain braces of its own. Warning on that
+   * would report a reference the author never wrote, so the check compares the
+   * argument before and after substitution rather than scanning the output.
+   */
+  test("does not warn when the resolved value itself contains braces", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    const logs: Array<string> = logsOf(runner);
+
+    runner.getComponentArguments(
+      makeStorage({ variables: { tpl: "{{not.a.reference}}" } }),
+      makeNode([makeArgument("message", ComponentInputType.Text)], {
+        message: "x {{local.variables.tpl}} y",
+      }),
+    );
+
+    expect(
+      logs.filter((line: string) => {
+        return line.startsWith("Warning:");
+      }),
+    ).toHaveLength(0);
+  });
+
+  test("does not warn for a whole-field reference that resolved to an object", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    const logs: Array<string> = logsOf(runner);
+
+    runner.getComponentArguments(
+      makeStorage({
+        components: {
+          "api-get-1": { returnValues: { "response-body": { a: 1 } } },
+        },
+      }),
+      makeNode([makeArgument("message", ComponentInputType.Text)], {
+        message: "{{local.components.api-get-1.returnValues.response-body}}",
+      }),
+    );
+
+    expect(
+      logs.filter((line: string) => {
+        return line.startsWith("Warning:");
+      }),
+    ).toHaveLength(0);
+  });
+
+  test("warns about a reference padded with spaces, which never resolves", () => {
+    const runner: RunWorkflow = new RunWorkflow();
+    const logs: Array<string> = logsOf(runner);
+
+    runner.getComponentArguments(
+      makeStorage({ variables: { token: "abc" } }),
+      makeNode([makeArgument("message", ComponentInputType.Text)], {
+        message: "{{ local.variables.token }}",
+      }),
+    );
+
+    expect(
+      logs.filter((line: string) => {
+        return line.startsWith("Warning:");
+      }),
+    ).toHaveLength(1);
+  });
+});

--- a/Common/Server/Types/Workflow/Components/API/Utils.ts
+++ b/Common/Server/Types/Workflow/Components/API/Utils.ts
@@ -4,7 +4,7 @@ import HTTPResponse from "../../../../../Types/API/HTTPResponse";
 import URL from "../../../../../Types/API/URL";
 import BadDataException from "../../../../../Types/Exception/BadDataException";
 import Exception from "../../../../../Types/Exception/Exception";
-import { JSONObject } from "../../../../../Types/JSON";
+import { JSONObject, JSONValue } from "../../../../../Types/JSON";
 import JSONFunctions from "../../../../../Types/JSONFunctions";
 import ComponentMetadata, {
   Port,
@@ -80,6 +80,49 @@ export class ApiComponentUtils {
       args["request-headers"] = JSONFunctions.parse(
         args["request-headers"] as string,
       );
+    }
+
+    /*
+     * Headers reach here from a key/value grid that can emit numbers and
+     * booleans, from a JSON document someone typed, or from a {{...}}
+     * substitution — and every consumer below blind-casts the result to
+     * Dictionary<string> before spreading it into the outgoing request. An
+     * array or a bare scalar spreads into per-index junk headers rather than
+     * failing, so check the shape and flatten the values to strings here.
+     */
+    if (args["request-headers"]) {
+      const headers: JSONValue = args["request-headers"] as JSONValue;
+
+      if (
+        typeof headers !== "object" ||
+        headers === null ||
+        Array.isArray(headers)
+      ) {
+        throw options.onError(
+          new BadDataException(
+            "Request headers must be a JSON object of header names and values.",
+          ),
+        );
+      }
+
+      const stringifiedHeaders: JSONObject = {};
+
+      for (const headerName of Object.keys(headers as JSONObject)) {
+        const headerValue: JSONValue = (headers as JSONObject)[
+          headerName
+        ] as JSONValue;
+
+        if (headerValue === null || headerValue === undefined) {
+          continue;
+        }
+
+        stringifiedHeaders[headerName] =
+          typeof headerValue === "object"
+            ? JSON.stringify(headerValue)
+            : String(headerValue);
+      }
+
+      args["request-headers"] = stringifiedHeaders;
     }
 
     if (!args["url"]) {

--- a/Common/Server/Utils/VM/VMAPI.ts
+++ b/Common/Server/Utils/VM/VMAPI.ts
@@ -34,6 +34,20 @@ export default class VMUtil {
       }
     }
 
+    /*
+     * When we stringified the value ourselves just above, every placeholder in
+     * the text we are about to substitute into sits inside a JSON string
+     * literal — that is what JSON.stringify did to it. A resolved value
+     * carrying a quote or a newline therefore has to be escaped, or the
+     * JSON.parse at the bottom of this method fails and the caller silently
+     * receives a corrupted string where it asked for an object.
+     *
+     * This is separate from the caller's isJSON flag, which describes text the
+     * caller wrote and where a placeholder may legitimately stand in for a bare
+     * JSON value rather than sit inside a string.
+     */
+    const shouldEscapeForJSON: boolean = Boolean(isJSON) || didStringify;
+
     if (
       typeof valueToReplaceInPlace === "string" &&
       valueToReplaceInPlace.toString().includes("{{") &&
@@ -45,7 +59,7 @@ export default class VMUtil {
       valueToReplaceInPlaceCopy = VMUtil.expandEachLoops(
         storageMap,
         valueToReplaceInPlaceCopy,
-        isJSON,
+        shouldEscapeForJSON,
       );
 
       const variablesInArgument: Array<string> = [];
@@ -83,11 +97,21 @@ export default class VMUtil {
         if (valueToReplaceInPlaceCopy.trim() === "{{" + variable + "}}") {
           valueToReplaceInPlaceCopy = valueToReplaceInPlace;
         } else {
+          const replacement: string = shouldEscapeForJSON
+            ? VMUtil.serializeValueForJSON(valueToReplaceInPlace)
+            : `${valueToReplaceInPlace}`;
+
+          /*
+           * Function form, not the string form. String.replace treats $&, $1,
+           * $` and $' in the REPLACEMENT as substitution patterns, so a
+           * resolved value of "50$" or "a$&b" rewrote itself using the matched
+           * text. A function replacement is taken literally.
+           */
           valueToReplaceInPlaceCopy = valueToReplaceInPlaceCopy.replace(
             "{{" + variable + "}}",
-            isJSON
-              ? VMUtil.serializeValueForJSON(valueToReplaceInPlace)
-              : `${valueToReplaceInPlace}`,
+            () => {
+              return replacement;
+            },
           );
         }
       }
@@ -294,10 +318,14 @@ export default class VMUtil {
         replacement = `${foundValue}`;
       }
 
-      body = body.replace(
-        "{{" + variable + "}}",
-        isJSON ? VMUtil.serializeValueForJSON(replacement) : replacement,
-      );
+      const substitution: string = isJSON
+        ? VMUtil.serializeValueForJSON(replacement)
+        : replacement;
+
+      // Function form — see the note on the same call in replaceValueInPlace.
+      body = body.replace("{{" + variable + "}}", () => {
+        return substitution;
+      });
     }
 
     return body;
@@ -313,6 +341,15 @@ export default class VMUtil {
       value = JSON.stringify(value);
     } else {
       value = value
+        /*
+         * Backslash first, and only first. It was missing entirely, so a value
+         * like a Windows path or a regex ("C:\Users", "\d+") produced an
+         * invalid escape sequence in the surrounding document and the
+         * JSON.parse that followed threw. Escaping it after the others would
+         * instead double-escape the backslashes they just introduced.
+         */
+        .split("\\")
+        .join("\\\\")
         .split("\t")
         .join("\\t")
         .split("\n")
@@ -355,6 +392,17 @@ export default class VMUtil {
         if (indexString !== "last") {
           index = parseInt(indexString);
         } else {
+          /*
+           * `current[arrayKey].length` was read unguarded, so `items[last]`
+           * against a key that is missing (or is not an array) threw a
+           * TypeError out of deepFind and killed the entire run — the one
+           * resolution failure in here that was not silent. Fall through to the
+           * undefined return that every other miss produces.
+           */
+          if (!Array.isArray(current[arrayKey])) {
+            return undefined;
+          }
+
           index = current[arrayKey].length - 1;
         }
 

--- a/Common/Tests/Server/Types/Workflow/Components/ApiComponentHeaders.test.ts
+++ b/Common/Tests/Server/Types/Workflow/Components/ApiComponentHeaders.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Request headers on the API components reach sanitizeArgs in three shapes: a
+ * JSON string (every workflow written before the key/value editor), an object
+ * (what the key/value editor produces), and whatever a {{...}} substitution
+ * left behind. Every consumer downstream casts the result to
+ * Dictionary<string> and spreads it into the outgoing request, so the shape
+ * has to be settled here.
+ */
+
+jest.mock("../../../../../Utils/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      get: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      patch: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
+});
+
+import ApiGet from "../../../../../Server/Types/Workflow/Components/API/Get";
+import { ApiComponentUtils } from "../../../../../Server/Types/Workflow/Components/API/Utils";
+import ComponentCode, {
+  RunOptions,
+} from "../../../../../Server/Types/Workflow/ComponentCode";
+import Exception from "../../../../../Types/Exception/Exception";
+import { JSONObject } from "../../../../../Types/JSON";
+import ObjectID from "../../../../../Types/ObjectID";
+import IconProp from "../../../../../Types/Icon/IconProp";
+import ComponentMetadata, {
+  Argument,
+  ComponentInputType,
+  ComponentType,
+} from "../../../../../Types/Workflow/Component";
+import APIComponents from "../../../../../Types/Workflow/Components/API";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import dns from "dns";
+
+type MakeOptionsFunction = () => RunOptions;
+
+const makeOptions: MakeOptionsFunction = (): RunOptions => {
+  return {
+    log: jest.fn() as RunOptions["log"],
+    workflowLogId: ObjectID.generate(),
+    workflowId: ObjectID.generate(),
+    projectId: ObjectID.generate(),
+    onError: ((exception: Exception): Exception => {
+      return exception;
+    }) as RunOptions["onError"],
+    executeWorkflow: async (): Promise<void> => {},
+  };
+};
+
+type SanitizeFunction = (headers: unknown) => Promise<JSONObject>;
+
+const sanitizeHeaders: SanitizeFunction = async (
+  headers: unknown,
+): Promise<JSONObject> => {
+  const component: ComponentCode = new ApiGet();
+
+  const result: { args: JSONObject } = await ApiComponentUtils.sanitizeArgs(
+    component.getMetadata(),
+    {
+      url: "https://api.example.com/thing",
+      "request-headers": headers as JSONObject,
+    },
+    makeOptions(),
+  );
+
+  return result.args["request-headers"] as JSONObject;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest
+    .spyOn(dns.promises, "lookup")
+    .mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("ApiComponentUtils.sanitizeArgs — header shapes", () => {
+  test("parses the legacy JSON-string shape", async () => {
+    await expect(
+      sanitizeHeaders('{"Authorization": "Bearer abc"}'),
+    ).resolves.toEqual({
+      Authorization: "Bearer abc",
+    });
+  });
+
+  test("parses a JSON5 string, which has always been accepted here", async () => {
+    await expect(sanitizeHeaders("{Authorization: 'Bearer abc'}")).resolves.toEqual(
+      {
+        Authorization: "Bearer abc",
+      },
+    );
+  });
+
+  test("passes the object shape through", async () => {
+    await expect(
+      sanitizeHeaders({ Authorization: "Bearer abc" }),
+    ).resolves.toEqual({ Authorization: "Bearer abc" });
+  });
+
+  test("flattens numbers and booleans the key/value editor can emit", async () => {
+    await expect(
+      sanitizeHeaders({ "X-Retries": 3, "X-Debug": true }),
+    ).resolves.toEqual({
+      "X-Retries": "3",
+      "X-Debug": "true",
+    });
+  });
+
+  test("drops null and undefined values instead of sending 'null'", async () => {
+    await expect(
+      sanitizeHeaders({ "X-A": "keep", "X-B": null }),
+    ).resolves.toEqual({ "X-A": "keep" });
+  });
+
+  test("serializes a nested value rather than sending [object Object]", async () => {
+    await expect(sanitizeHeaders({ "X-Meta": { a: 1 } })).resolves.toEqual({
+      "X-Meta": '{"a":1}',
+    });
+  });
+
+  test("rejects an array, which would spread into per-index junk headers", async () => {
+    await expect(sanitizeHeaders("[1, 2]")).rejects.toThrow(
+      /Request headers must be a JSON object/,
+    );
+  });
+
+  test("rejects a bare scalar", async () => {
+    await expect(sanitizeHeaders("42")).rejects.toThrow(
+      /Request headers must be a JSON object/,
+    );
+  });
+
+  test("leaves the request alone when no headers were given", async () => {
+    const component: ComponentCode = new ApiGet();
+
+    const result: { args: JSONObject } = await ApiComponentUtils.sanitizeArgs(
+      component.getMetadata(),
+      { url: "https://api.example.com/thing" },
+      makeOptions(),
+    );
+
+    expect(result.args["request-headers"]).toBeUndefined();
+  });
+});
+
+describe("API component metadata — headers are treated as secret", () => {
+  /*
+   * The key/value grid makes pasting a bearer token into a header the obvious
+   * thing to do. Without isSensitive the resolved value is written verbatim
+   * into the WorkflowLog for anyone who can read the project.
+   */
+  test("every API component marks request-headers sensitive", () => {
+    const componentsWithHeaders: Array<ComponentMetadata> =
+      APIComponents.filter((component: ComponentMetadata) => {
+        return component.arguments.some((arg: Argument) => {
+          return arg.id === "request-headers";
+        });
+      });
+
+    expect(componentsWithHeaders.length).toBe(5);
+
+    for (const component of componentsWithHeaders) {
+      const headerArgument: Argument = component.arguments.find(
+        (arg: Argument) => {
+          return arg.id === "request-headers";
+        },
+      ) as Argument;
+
+      expect(headerArgument.isSensitive).toBe(true);
+      expect(headerArgument.type).toBe(ComponentInputType.StringDictionary);
+    }
+  });
+
+  test("the components are the five request verbs", () => {
+    expect(
+      APIComponents.filter((component: ComponentMetadata) => {
+        return component.componentType === ComponentType.Component;
+      }).length,
+    ).toBeGreaterThanOrEqual(5);
+
+    expect(APIComponents[0]?.iconProp).toBe(IconProp.Globe);
+  });
+});

--- a/Common/Tests/Server/Utils/VM/VMAPISubstitution.test.ts
+++ b/Common/Tests/Server/Utils/VM/VMAPISubstitution.test.ts
@@ -1,0 +1,246 @@
+/*
+ * Substitution behaviour of VMUtil.replaceValueInPlace, focused on the three
+ * ways a resolved value used to come out wrong: unescaped quotes when the
+ * caller passed an object, `$`-patterns in the replacement text, and
+ * `[last]` against a key that is not an array.
+ */
+
+jest.mock("../../../../Server/Utils/VM/VMRunner", () => {
+  return {
+    __esModule: true,
+    default: {
+      runCodeInSandbox: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      error: jest.fn(),
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Utils/Telemetry/CaptureSpan", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return (
+        _target: any,
+        _propertyKey: string,
+        descriptor: PropertyDescriptor,
+      ) => {
+        return descriptor;
+      };
+    },
+  };
+});
+
+import VMUtil from "../../../../Server/Utils/VM/VMAPI";
+import { JSONObject, JSONValue } from "../../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+type MakeStorageFunction = (variables: JSONObject) => JSONObject;
+
+const makeStorage: MakeStorageFunction = (
+  variables: JSONObject,
+): JSONObject => {
+  return {
+    local: {
+      variables: variables,
+      components: {},
+    },
+    global: {
+      variables: {},
+    },
+  };
+};
+
+describe("replaceValueInPlace — object input (the key/value headers shape)", () => {
+  it("returns an object, not a string", () => {
+    const result: JSONValue = VMUtil.replaceValueInPlace(
+      makeStorage({ token: "abc" }),
+      { Authorization: "Bearer {{local.variables.token}}" } as never,
+      false,
+    ) as unknown as JSONValue;
+
+    expect(typeof result).toBe("object");
+    expect(result).toEqual({ Authorization: "Bearer abc" });
+  });
+
+  /*
+   * The regression this guards: the object is stringified, so every
+   * placeholder sits inside a JSON string literal. A resolved value carrying a
+   * quote used to be spliced in raw, the JSON.parse on the way back out threw,
+   * and the caller silently received a corrupted string where it asked for an
+   * object — which then spread into per-character HTTP headers.
+   */
+  it("escapes a resolved value containing a double quote", () => {
+    const result: JSONValue = VMUtil.replaceValueInPlace(
+      makeStorage({ note: 'he said "hi"' }),
+      { "X-Note": "{{local.variables.note}}" } as never,
+      false,
+    ) as unknown as JSONValue;
+
+    expect(typeof result).toBe("object");
+    expect(result).toEqual({ "X-Note": 'he said "hi"' });
+  });
+
+  it("escapes a resolved value containing a newline", () => {
+    const result: JSONValue = VMUtil.replaceValueInPlace(
+      makeStorage({ note: "line1\nline2" }),
+      { "X-Note": "{{local.variables.note}}" } as never,
+      false,
+    ) as unknown as JSONValue;
+
+    expect(typeof result).toBe("object");
+    expect(result).toEqual({ "X-Note": "line1\nline2" });
+  });
+
+  it("escapes a resolved value containing a backslash", () => {
+    const result: JSONValue = VMUtil.replaceValueInPlace(
+      makeStorage({ path: "C:\\Users" }),
+      { "X-Path": "{{local.variables.path}}" } as never,
+      false,
+    ) as unknown as JSONValue;
+
+    expect(typeof result).toBe("object");
+    expect((result as JSONObject)["X-Path"]).toBe("C:\\Users");
+  });
+
+  it("escapes a resolved value containing a regex", () => {
+    const result: JSONValue = VMUtil.replaceValueInPlace(
+      makeStorage({ pattern: "\\d+\\s" }),
+      { "X-Pattern": "{{local.variables.pattern}}" } as never,
+      false,
+    ) as unknown as JSONValue;
+
+    expect((result as JSONObject)["X-Pattern"]).toBe("\\d+\\s");
+  });
+
+  it("escapes a value carrying a backslash and a quote together", () => {
+    const result: JSONValue = VMUtil.replaceValueInPlace(
+      makeStorage({ v: 'a\\b"c' }),
+      { "X-V": "{{local.variables.v}}" } as never,
+      false,
+    ) as unknown as JSONValue;
+
+    expect((result as JSONObject)["X-V"]).toBe('a\\b"c');
+  });
+
+  it("leaves an object with no placeholders untouched", () => {
+    const result: JSONValue = VMUtil.replaceValueInPlace(
+      makeStorage({}),
+      { A: "b" } as never,
+      false,
+    ) as unknown as JSONValue;
+
+    expect(result).toEqual({ A: "b" });
+  });
+});
+
+describe("replaceValueInPlace — $ in resolved values", () => {
+  /*
+   * String.replace treats $&, $', $` and $1 in the REPLACEMENT as substitution
+   * patterns. A resolved value of "A$&B" used to render as "A{{v}}B", pasting
+   * the matched placeholder back into the output.
+   */
+  it("does not treat $& in a value as a substitution pattern", () => {
+    const result: string = VMUtil.replaceValueInPlace(
+      makeStorage({ v: "A$&B" }),
+      "start {{local.variables.v}} end",
+      false,
+    );
+
+    expect(result).toBe("start A$&B end");
+  });
+
+  it("does not treat $` or $' as substitution patterns", () => {
+    expect(
+      VMUtil.replaceValueInPlace(
+        makeStorage({ v: "x$`y" }),
+        "a {{local.variables.v}} b",
+        false,
+      ),
+    ).toBe("a x$`y b");
+
+    expect(
+      VMUtil.replaceValueInPlace(
+        makeStorage({ v: "x$'y" }),
+        "a {{local.variables.v}} b",
+        false,
+      ),
+    ).toBe("a x$'y b");
+  });
+
+  it("keeps a plain dollar amount intact", () => {
+    expect(
+      VMUtil.replaceValueInPlace(
+        makeStorage({ price: "$50" }),
+        "Total: {{local.variables.price}} today",
+        false,
+      ),
+    ).toBe("Total: $50 today");
+  });
+});
+
+describe("deepFind — [last] accessor", () => {
+  type FindFunction = (storage: JSONObject, path: string) => JSONValue;
+
+  const find: FindFunction = (
+    storage: JSONObject,
+    path: string,
+  ): JSONValue => {
+    return VMUtil.deepFind(storage, path);
+  };
+
+  it("resolves the final element of an array", () => {
+    expect(find({ items: ["a", "b", "c"] }, "items[last]")).toBe("c");
+  });
+
+  it("returns undefined rather than throwing when the key is missing", () => {
+    expect(find({}, "items[last]")).toBeUndefined();
+  });
+
+  it("returns undefined rather than throwing when the key is not an array", () => {
+    expect(find({ items: "not an array" }, "items[last]")).toBeUndefined();
+    expect(find({ items: 5 }, "items[last]")).toBeUndefined();
+    expect(find({ items: null }, "items[last]")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty array", () => {
+    expect(find({ items: [] }, "items[last]")).toBeUndefined();
+  });
+
+  it("still resolves a numeric accessor", () => {
+    expect(find({ items: ["a", "b"] }, "items[0]")).toBe("a");
+    expect(find({ items: ["a", "b"] }, "items[9]")).toBeUndefined();
+  });
+});
+
+describe("replaceValueInPlace — unresolved references", () => {
+  it("leaves the braces in place, which is what the builder warns about", () => {
+    expect(
+      VMUtil.replaceValueInPlace(
+        makeStorage({}),
+        "hello {{local.variables.missing}}",
+        false,
+      ),
+    ).toBe("hello {{local.variables.missing}}");
+  });
+
+  it("does not resolve a reference padded with spaces", () => {
+    expect(
+      VMUtil.replaceValueInPlace(
+        makeStorage({ v: "x" }),
+        "a {{ local.variables.v }} b",
+        false,
+      ),
+    ).toBe("a {{ local.variables.v }} b");
+  });
+});

--- a/Common/Tests/Types/Workflow/TemplateSyntax.test.ts
+++ b/Common/Tests/Types/Workflow/TemplateSyntax.test.ts
@@ -1,0 +1,377 @@
+import {
+  JSONSyntaxCheckResult,
+  ParsedReferencePath,
+  ReferenceRootType,
+  TemplateExpression,
+  TemplateExpressionKind,
+  checkJSONSyntax,
+  hasEachBlock,
+  looksLikeReferencePath,
+  maskTemplateExpressions,
+  parseReferencePath,
+  parseTemplateExpressions,
+} from "../../../Types/Workflow/TemplateSyntax";
+import { describe, expect, test } from "@jest/globals";
+
+describe("parseTemplateExpressions", () => {
+  test("finds nothing in text with no expressions", () => {
+    expect(parseTemplateExpressions("just some text")).toEqual([]);
+    expect(parseTemplateExpressions("")).toEqual([]);
+  });
+
+  test("is non-greedy, so adjacent expressions stay separate", () => {
+    const found: Array<TemplateExpression> = parseTemplateExpressions(
+      "{{local.variables.a}} and {{local.variables.b}}",
+    );
+
+    expect(found).toHaveLength(2);
+    expect(found[0]?.inner).toBe("local.variables.a");
+    expect(found[1]?.inner).toBe("local.variables.b");
+  });
+
+  test("records the exact source offsets", () => {
+    const found: Array<TemplateExpression> =
+      parseTemplateExpressions("ab{{x}}cd");
+
+    expect(found[0]?.startIndex).toBe(2);
+    expect(found[0]?.endIndex).toBe(7);
+    expect(found[0]?.raw).toBe("{{x}}");
+  });
+
+  test("keeps the untrimmed capture alongside the trimmed one", () => {
+    const found: Array<TemplateExpression> = parseTemplateExpressions(
+      "{{ local.variables.a }}",
+    );
+
+    expect(found[0]?.inner).toBe("local.variables.a");
+    expect(found[0]?.innerRaw).toBe(" local.variables.a ");
+  });
+
+  test("classifies each kind of expression", () => {
+    const found: Array<TemplateExpression> = parseTemplateExpressions(
+      "{{#each local.components.a.returnValues.items}}{{@index}}{{this}}{{name}}{{/each}}",
+    );
+
+    expect(
+      found.map((expression: TemplateExpression) => {
+        return expression.kind;
+      }),
+    ).toEqual([
+      TemplateExpressionKind.EachOpen,
+      TemplateExpressionKind.LoopIndex,
+      TemplateExpressionKind.LoopThis,
+      TemplateExpressionKind.Reference,
+      TemplateExpressionKind.EachClose,
+    ]);
+  });
+
+  test("marks loop bodies as inside a block, and the tags themselves as not", () => {
+    const found: Array<TemplateExpression> = parseTemplateExpressions(
+      "{{outer}}{{#each items}}{{inner}}{{/each}}{{after}}",
+    );
+
+    const byInner: Record<string, boolean> = {};
+
+    for (const expression of found) {
+      byInner[expression.inner] = expression.isInsideEachBlock;
+    }
+
+    expect(byInner["outer"]).toBe(false);
+    expect(byInner["#each items"]).toBe(false);
+    expect(byInner["inner"]).toBe(true);
+    expect(byInner["/each"]).toBe(false);
+    expect(byInner["after"]).toBe(false);
+  });
+
+  test("tracks nesting depth across nested loops", () => {
+    const found: Array<TemplateExpression> = parseTemplateExpressions(
+      "{{#each a}}{{one}}{{#each b}}{{two}}{{/each}}{{three}}{{/each}}{{four}}",
+    );
+
+    const byInner: Record<string, boolean> = {};
+
+    for (const expression of found) {
+      byInner[expression.inner] = expression.isInsideEachBlock;
+    }
+
+    expect(byInner["one"]).toBe(true);
+    expect(byInner["two"]).toBe(true);
+    expect(byInner["three"]).toBe(true);
+    expect(byInner["four"]).toBe(false);
+  });
+
+  test("does not carry loop state between calls", () => {
+    parseTemplateExpressions("{{#each a}}{{x}}");
+
+    const found: Array<TemplateExpression> = parseTemplateExpressions("{{y}}");
+
+    expect(found[0]?.isInsideEachBlock).toBe(false);
+  });
+});
+
+describe("hasEachBlock", () => {
+  test("detects opening and closing tags", () => {
+    expect(hasEachBlock("{{#each items}}x{{/each}}")).toBe(true);
+    expect(hasEachBlock("{{#each items}}")).toBe(true);
+    expect(hasEachBlock("{{/each}}")).toBe(true);
+  });
+
+  test("is false for ordinary references and empty input", () => {
+    expect(hasEachBlock("{{local.variables.a}}")).toBe(false);
+    expect(hasEachBlock("")).toBe(false);
+  });
+});
+
+describe("maskTemplateExpressions", () => {
+  test("substitutes a token that is legal as a value, in a string, and as a key", () => {
+    expect(maskTemplateExpressions('{"n": {{a}}}')).toBe('{"n": 1}');
+    expect(maskTemplateExpressions('{"s": "{{a}}"}')).toBe('{"s": "1"}');
+    expect(maskTemplateExpressions('{"{{a}}": 2}')).toBe('{"1": 2}');
+  });
+
+  test("leaves text without expressions alone", () => {
+    expect(maskTemplateExpressions('{"a": 1}')).toBe('{"a": 1}');
+  });
+});
+
+describe("checkJSONSyntax", () => {
+  test("accepts ordinary JSON", () => {
+    expect(checkJSONSyntax('{"a": 1}').isValid).toBe(true);
+    expect(checkJSONSyntax("[1, 2, 3]").isValid).toBe(true);
+  });
+
+  test("rejects the mistakes it exists to catch", () => {
+    const trailingComma: JSONSyntaxCheckResult = checkJSONSyntax('{"a": 1,}');
+
+    expect(trailingComma.isValid).toBe(false);
+    expect(trailingComma.wasSkipped).toBe(false);
+    expect(trailingComma.errorMessage).toBeTruthy();
+
+    expect(checkJSONSyntax('{"a": 1').isValid).toBe(false);
+    expect(checkJSONSyntax("{a: 1}").isValid).toBe(false);
+    expect(checkJSONSyntax("{'a': 1}").isValid).toBe(false);
+    expect(checkJSONSyntax("not json at all").isValid).toBe(false);
+  });
+
+  test("carries the parser's own message, unframed", () => {
+    const result: JSONSyntaxCheckResult = checkJSONSyntax('{"a": 1,}');
+
+    expect(result.errorMessage).not.toMatch(/is not valid JSON/);
+    expect(result.errorMessage).toMatch(/JSON|token|position/i);
+  });
+
+  /*
+   * The false-positive cases. Each of these is something a workflow author
+   * legitimately writes, and flagging any of them would disable Save on a
+   * workflow that runs correctly.
+   */
+  test("accepts a whole-field reference, which is not JSON as written", () => {
+    expect(
+      checkJSONSyntax("{{local.components.api-get-1.returnValues.body}}")
+        .isValid,
+    ).toBe(true);
+  });
+
+  test("accepts a reference standing in for a bare JSON value", () => {
+    expect(checkJSONSyntax('{"retries": {{local.variables.count}}}').isValid).toBe(
+      true,
+    );
+  });
+
+  test("accepts a reference inside a string literal", () => {
+    expect(
+      checkJSONSyntax('{"token": "Bearer {{local.variables.apiKey}}"}').isValid,
+    ).toBe(true);
+  });
+
+  test("accepts a reference used as an object key", () => {
+    expect(checkJSONSyntax('{"{{local.variables.k}}": 1}').isValid).toBe(true);
+  });
+
+  test("accepts a reference inside an array", () => {
+    expect(checkJSONSyntax('[{{local.variables.a}}, "b"]').isValid).toBe(true);
+  });
+
+  test("declines to judge anything containing a loop", () => {
+    const looped: JSONSyntaxCheckResult = checkJSONSyntax(
+      '[{{#each local.components.a.returnValues.items}}{"id":"{{this}}"},{{/each}}]',
+    );
+
+    expect(looped.isValid).toBe(true);
+    expect(looped.wasSkipped).toBe(true);
+  });
+
+  test("skips values that are not strings", () => {
+    expect(checkJSONSyntax({ a: 1 }).wasSkipped).toBe(true);
+    expect(checkJSONSyntax(["a"]).wasSkipped).toBe(true);
+    expect(checkJSONSyntax(12).wasSkipped).toBe(true);
+    expect(checkJSONSyntax(true).wasSkipped).toBe(true);
+    expect(checkJSONSyntax(null).wasSkipped).toBe(true);
+    expect(checkJSONSyntax(undefined).wasSkipped).toBe(true);
+  });
+
+  test("skips empty values, leaving the required-field message to stand", () => {
+    expect(checkJSONSyntax("").wasSkipped).toBe(true);
+    expect(checkJSONSyntax("   ").wasSkipped).toBe(true);
+    expect(checkJSONSyntax("\n").wasSkipped).toBe(true);
+  });
+
+  test("judges by JSON5's rules when asked, matching the lenient parsers", () => {
+    expect(checkJSONSyntax("{a: 1}", { allowJSON5: true }).isValid).toBe(true);
+    expect(checkJSONSyntax("{'a': 1}", { allowJSON5: true }).isValid).toBe(true);
+    expect(checkJSONSyntax('{"a": 1,}', { allowJSON5: true }).isValid).toBe(
+      true,
+    );
+  });
+
+  test("still rejects unparseable text under JSON5", () => {
+    expect(checkJSONSyntax("{oops", { allowJSON5: true }).isValid).toBe(false);
+  });
+
+  test("keeps templates working under JSON5 too", () => {
+    expect(
+      checkJSONSyntax('{a: "{{local.variables.x}}"}', { allowJSON5: true })
+        .isValid,
+    ).toBe(true);
+  });
+});
+
+describe("looksLikeReferencePath", () => {
+  test("accepts real reference paths", () => {
+    expect(looksLikeReferencePath("local.variables.apiKey")).toBe(true);
+    expect(
+      looksLikeReferencePath(
+        "local.components.api-get-1.returnValues.response-body",
+      ),
+    ).toBe(true);
+    expect(looksLikeReferencePath("global.variables.My Key")).toBe(true);
+    expect(looksLikeReferencePath("local.componets.x.returnValues.y")).toBe(
+      true,
+    );
+  });
+
+  test("accepts array accessors", () => {
+    expect(looksLikeReferencePath("a.items[0].name")).toBe(true);
+    expect(looksLikeReferencePath("a.items[last]")).toBe(true);
+  });
+
+  test("rejects captures that are really JavaScript", () => {
+    expect(looksLikeReferencePath(" return 1; ")).toBe(false);
+    expect(looksLikeReferencePath("a = b")).toBe(false);
+    expect(looksLikeReferencePath('x: "y"')).toBe(false);
+    expect(looksLikeReferencePath("f(x)")).toBe(false);
+    expect(looksLikeReferencePath("a + b")).toBe(false);
+  });
+
+  test("rejects an empty capture", () => {
+    expect(looksLikeReferencePath("")).toBe(false);
+    expect(looksLikeReferencePath("   ")).toBe(false);
+  });
+});
+
+describe("parseReferencePath", () => {
+  test("reads a local variable", () => {
+    const parsed: ParsedReferencePath = parseReferencePath(
+      "local.variables.apiKey",
+    );
+
+    expect(parsed.rootType).toBe(ReferenceRootType.LocalVariable);
+    expect(parsed.variableName).toBe("apiKey");
+  });
+
+  test("reads a global variable", () => {
+    const parsed: ParsedReferencePath = parseReferencePath(
+      "global.variables.region",
+    );
+
+    expect(parsed.rootType).toBe(ReferenceRootType.GlobalVariable);
+    expect(parsed.variableName).toBe("region");
+  });
+
+  test("reads a component return value, exactly as the picker writes it", () => {
+    const parsed: ParsedReferencePath = parseReferencePath(
+      "local.components.api-get-1.returnValues.response-body",
+    );
+
+    expect(parsed.rootType).toBe(ReferenceRootType.ComponentReturnValue);
+    expect(parsed.componentId).toBe("api-get-1");
+    expect(parsed.returnValueId).toBe("response-body");
+  });
+
+  test("stops at the return value and ignores the drill-in below it", () => {
+    const parsed: ParsedReferencePath = parseReferencePath(
+      "local.components.api-get-1.returnValues.response-body.data.items[0].id",
+    );
+
+    expect(parsed.rootType).toBe(ReferenceRootType.ComponentReturnValue);
+    expect(parsed.componentId).toBe("api-get-1");
+    expect(parsed.returnValueId).toBe("response-body");
+  });
+
+  test("strips array accessors when naming the parts", () => {
+    const parsed: ParsedReferencePath = parseReferencePath(
+      "local.components.api-get-1.returnValues.items[last]",
+    );
+
+    expect(parsed.returnValueId).toBe("items");
+  });
+
+  test("rejects an unknown root", () => {
+    const parsed: ParsedReferencePath = parseReferencePath("componets.x");
+
+    expect(parsed.rootType).toBe(ReferenceRootType.Unknown);
+    expect(parsed.reason).toMatch(/local|global/);
+  });
+
+  test("rejects a misspelled second segment", () => {
+    expect(parseReferencePath("local.component.x.returnValues.y").rootType).toBe(
+      ReferenceRootType.Unknown,
+    );
+    expect(parseReferencePath("global.variable.x").rootType).toBe(
+      ReferenceRootType.Unknown,
+    );
+  });
+
+  test("rejects a component path that does not say returnValues", () => {
+    const parsed: ParsedReferencePath = parseReferencePath(
+      "local.components.api-get-1.body",
+    );
+
+    expect(parsed.rootType).toBe(ReferenceRootType.Unknown);
+    expect(parsed.reason).toMatch(/returnValues/);
+  });
+
+  test("rejects truncated paths", () => {
+    expect(parseReferencePath("local.variables").rootType).toBe(
+      ReferenceRootType.Unknown,
+    );
+    expect(parseReferencePath("local.components").rootType).toBe(
+      ReferenceRootType.Unknown,
+    );
+    expect(
+      parseReferencePath("local.components.api-get-1.returnValues").rootType,
+    ).toBe(ReferenceRootType.Unknown);
+  });
+
+  test("rejects an empty part between two dots, which resolves to nothing", () => {
+    const parsed: ParsedReferencePath = parseReferencePath(
+      "local..variables.apiKey",
+    );
+
+    expect(parsed.rootType).toBe(ReferenceRootType.Unknown);
+    expect(parsed.reason).toMatch(/empty part/);
+  });
+
+  test("rejects an empty path", () => {
+    expect(parseReferencePath("").rootType).toBe(ReferenceRootType.Unknown);
+  });
+
+  test("allows spaces and hyphens inside a name, since only dots are structural", () => {
+    expect(parseReferencePath("global.variables.My Key").variableName).toBe(
+      "My Key",
+    );
+    expect(parseReferencePath("local.variables.api-key").variableName).toBe(
+      "api-key",
+    );
+  });
+});

--- a/Common/Tests/UI/Components/Forms/ValidationJSON.test.ts
+++ b/Common/Tests/UI/Components/Forms/ValidationJSON.test.ts
@@ -1,0 +1,237 @@
+import Validation from "../../../../UI/Components/Forms/Validation";
+import Field from "../../../../UI/Components/Forms/Types/Field";
+import FormFieldSchemaType from "../../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import FormValues from "../../../../UI/Components/Forms/Types/FormValues";
+import Dictionary from "../../../../Types/Dictionary";
+import { JSONObject, JSONValue } from "../../../../Types/JSON";
+import { describe, expect, test } from "@jest/globals";
+
+interface TestEntity extends JSONObject {
+  config?: JSONValue;
+  name?: JSONValue;
+}
+
+type MakeFieldFunction = (overrides?: Partial<Field<TestEntity>>) => Field<TestEntity>;
+
+const makeJSONField: MakeFieldFunction = (
+  overrides?: Partial<Field<TestEntity>>,
+): Field<TestEntity> => {
+  return {
+    title: "Config",
+    name: "config",
+    field: { config: true },
+    fieldType: FormFieldSchemaType.JSON,
+    ...overrides,
+  } as Field<TestEntity>;
+};
+
+type ValidateValueFunction = (
+  value: unknown,
+  field?: Field<TestEntity> | undefined,
+) => string | null;
+
+const validateValue: ValidateValueFunction = (
+  value: unknown,
+  field?: Field<TestEntity> | undefined,
+): string | null => {
+  return Validation.validateJSONSyntax(
+    value as never,
+    field || makeJSONField(),
+  );
+};
+
+describe("Validation.validateJSONSyntax — only acts on JSON fields", () => {
+  test("ignores every other field type", () => {
+    const textField: Field<TestEntity> = makeJSONField({
+      fieldType: FormFieldSchemaType.Text,
+    });
+
+    expect(validateValue("definitely not json", textField)).toBeNull();
+  });
+
+  test("names the field in the message", () => {
+    const message: string | null = validateValue('{"a":1,}');
+
+    expect(message).toMatch(/^Config is not valid JSON\./);
+  });
+});
+
+describe("Validation.validateJSONSyntax — catches the real mistakes", () => {
+  test("a trailing comma", () => {
+    expect(validateValue('{"a": 1,}')).toBeTruthy();
+  });
+
+  test("an unclosed brace", () => {
+    expect(validateValue('{"a": 1')).toBeTruthy();
+  });
+
+  test("unquoted keys and single quotes", () => {
+    expect(validateValue("{a: 1}")).toBeTruthy();
+    expect(validateValue("{'a': 1}")).toBeTruthy();
+  });
+
+  test("plain text in a JSON box", () => {
+    expect(validateValue("hello")).toBeTruthy();
+  });
+});
+
+describe("Validation.validateJSONSyntax — never fires on a working value", () => {
+  test("well-formed JSON", () => {
+    expect(validateValue('{"a": 1}')).toBeNull();
+    expect(validateValue("[1,2,3]")).toBeNull();
+    expect(validateValue('"a string"')).toBeNull();
+  });
+
+  /*
+   * The values that made a naive JSON.parse check unshippable. Each is a real
+   * thing a workflow author writes.
+   */
+  test("a whole-field template", () => {
+    expect(
+      validateValue("{{local.components.api-get-1.returnValues.response-body}}"),
+    ).toBeNull();
+  });
+
+  test("a template standing in for a bare value", () => {
+    expect(validateValue('{"retries": {{local.variables.count}}}')).toBeNull();
+  });
+
+  test("a template inside a string", () => {
+    expect(
+      validateValue('{"auth": "Bearer {{local.variables.token}}"}'),
+    ).toBeNull();
+  });
+
+  test("a loop, whose shape is only known at run time", () => {
+    expect(
+      validateValue(
+        '[{{#each local.components.a.returnValues.items}}{"id":"{{this}}"},{{/each}}]',
+      ),
+    ).toBeNull();
+  });
+
+  /*
+   * The seven model-backed forms elsewhere in the product bind real arrays and
+   * objects to a JSON field. Those must never be judged as text — this is the
+   * regression the raw-value plumbing exists to prevent.
+   */
+  test("an already-parsed object", () => {
+    expect(validateValue({ a: 1 })).toBeNull();
+  });
+
+  test("an already-parsed array", () => {
+    expect(validateValue(["https://a.example.com"])).toBeNull();
+  });
+
+  test("empty, so the required-field message stands instead", () => {
+    expect(validateValue("")).toBeNull();
+    expect(validateValue("   ")).toBeNull();
+    expect(validateValue(undefined)).toBeNull();
+    expect(validateValue(null)).toBeNull();
+  });
+});
+
+describe("Validation.validateJSONSyntax — allowJSON5", () => {
+  /*
+   * Some workflow argument types are read back with JSONFunctions.parse, which
+   * is JSON5. Judging those by JSON's rules would report a mistake in a
+   * workflow that runs perfectly well.
+   */
+  const looseField: Field<TestEntity> = makeJSONField({ allowJSON5: true });
+
+  test("accepts unquoted keys, single quotes and a trailing comma", () => {
+    expect(validateValue("{a: 1}", looseField)).toBeNull();
+    expect(validateValue("{'a': 1}", looseField)).toBeNull();
+    expect(validateValue('{"a": 1,}', looseField)).toBeNull();
+  });
+
+  test("still rejects text that is not parseable at all", () => {
+    expect(validateValue("{oops", looseField)).toBeTruthy();
+    expect(validateValue("hello", looseField)).toBeTruthy();
+  });
+
+  test("is off by default, so JSON fields stay strict", () => {
+    expect(validateValue('{"a": 1,}')).toBeTruthy();
+  });
+});
+
+describe("Validation.validate — end to end through the form validator", () => {
+  type RunValidateFunction = (
+    values: FormValues<TestEntity>,
+    fields: Array<Field<TestEntity>>,
+  ) => Dictionary<string>;
+
+  const runValidate: RunValidateFunction = (
+    values: FormValues<TestEntity>,
+    fields: Array<Field<TestEntity>>,
+  ): Dictionary<string> => {
+    return Validation.validate<TestEntity>({
+      formFields: fields,
+      values: values,
+      onValidate: undefined,
+    });
+  };
+
+  test("surfaces a JSON error against the field name", () => {
+    const errors: Dictionary<string> = runValidate(
+      { config: '{"a":1,}' } as FormValues<TestEntity>,
+      [makeJSONField()],
+    );
+
+    expect(errors["config"]).toMatch(/not valid JSON/);
+  });
+
+  test("says required, not malformed, when the box is empty", () => {
+    const errors: Dictionary<string> = runValidate(
+      { config: "" } as FormValues<TestEntity>,
+      [makeJSONField({ required: true })],
+    );
+
+    expect(errors["config"]).toMatch(/required/i);
+    expect(errors["config"]).not.toMatch(/not valid JSON/);
+  });
+
+  test("does not flag an object bound to a JSON field", () => {
+    const errors: Dictionary<string> = runValidate(
+      { config: { nested: { deep: true } } } as FormValues<TestEntity>,
+      [makeJSONField()],
+    );
+
+    expect(errors["config"]).toBeUndefined();
+  });
+
+  test("does not flag an array bound to a JSON field", () => {
+    const errors: Dictionary<string> = runValidate(
+      {
+        config: ["https://a.example.com", "https://b.example.com"],
+      } as FormValues<TestEntity>,
+      [makeJSONField()],
+    );
+
+    expect(errors["config"]).toBeUndefined();
+  });
+
+  test("leaves a hidden field alone", () => {
+    const errors: Dictionary<string> = runValidate(
+      { config: "{oops" } as FormValues<TestEntity>,
+      [
+        makeJSONField({
+          showIf: (): boolean => {
+            return false;
+          },
+        }),
+      ],
+    );
+
+    expect(errors["config"]).toBeUndefined();
+  });
+
+  test("reports nothing for a valid form", () => {
+    const errors: Dictionary<string> = runValidate(
+      { config: '{"a": 1}' } as FormValues<TestEntity>,
+      [makeJSONField()],
+    );
+
+    expect(Object.keys(errors)).toHaveLength(0);
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/GraphLint.test.ts
+++ b/Common/Tests/UI/Components/Workflow/GraphLint.test.ts
@@ -1,0 +1,822 @@
+import {
+  LintGraphEdge,
+  LintGraphNode,
+  WorkflowLintIssue,
+  WorkflowLintResult,
+  WorkflowLintRule,
+  WorkflowLintSeverity,
+  lintWorkflowGraph,
+} from "../../../../UI/Components/Workflow/GraphLint";
+import IconProp from "../../../../Types/Icon/IconProp";
+import { JSONObject } from "../../../../Types/JSON";
+import ComponentMetadata, {
+  Argument,
+  ComponentInputType,
+  ComponentType,
+  NodeType,
+  ReturnValue,
+} from "../../../../Types/Workflow/Component";
+import { describe, expect, test } from "@jest/globals";
+
+type MakeMetadataFunction = (params: {
+  id: string;
+  componentType?: ComponentType | undefined;
+  args?: Array<Argument> | undefined;
+  returnValues?: Array<ReturnValue> | undefined;
+}) => ComponentMetadata;
+
+const makeMetadata: MakeMetadataFunction = (params: {
+  id: string;
+  componentType?: ComponentType | undefined;
+  args?: Array<Argument> | undefined;
+  returnValues?: Array<ReturnValue> | undefined;
+}): ComponentMetadata => {
+  return {
+    id: params.id,
+    title: params.id,
+    category: "Test",
+    description: "A test component",
+    iconProp: IconProp.Bolt,
+    componentType: params.componentType || ComponentType.Component,
+    arguments: params.args || [],
+    returnValues: params.returnValues || [],
+    inPorts: [],
+    outPorts: [],
+  };
+};
+
+type MakeNodeFunction = (params: {
+  nodeId: string;
+  componentId: string;
+  componentType?: ComponentType | undefined;
+  args?: Array<Argument> | undefined;
+  returnValues?: Array<ReturnValue> | undefined;
+  values?: JSONObject | undefined;
+  nodeType?: NodeType | undefined;
+}) => LintGraphNode;
+
+const makeNode: MakeNodeFunction = (params: {
+  nodeId: string;
+  componentId: string;
+  componentType?: ComponentType | undefined;
+  args?: Array<Argument> | undefined;
+  returnValues?: Array<ReturnValue> | undefined;
+  values?: JSONObject | undefined;
+  nodeType?: NodeType | undefined;
+}): LintGraphNode => {
+  const componentType: ComponentType =
+    params.componentType || ComponentType.Component;
+
+  return {
+    id: params.nodeId,
+    data: {
+      error: "",
+      id: params.componentId,
+      nodeType: params.nodeType || NodeType.Node,
+      metadata: makeMetadata({
+        id: `${params.componentId}-metadata`,
+        componentType: componentType,
+        args: params.args,
+        returnValues: params.returnValues,
+      }),
+      metadataId: `${params.componentId}-metadata`,
+      internalId: `${params.nodeId}-internal`,
+      arguments: params.values || {},
+      returnValues: {},
+      componentType: componentType,
+    },
+  };
+};
+
+const textArgument: Argument = {
+  id: "message",
+  name: "Message",
+  description: "Text to send",
+  type: ComponentInputType.Text,
+  required: false,
+};
+
+const requiredUrlArgument: Argument = {
+  id: "url",
+  name: "URL",
+  description: "Where to send it",
+  type: ComponentInputType.URL,
+  required: true,
+};
+
+const jsonArgument: Argument = {
+  id: "request-body",
+  name: "Request Body",
+  description: "Body",
+  type: ComponentInputType.JSON,
+  required: false,
+};
+
+const bodyReturnValue: ReturnValue = {
+  id: "response-body",
+  name: "Response Body",
+  description: "What came back",
+  type: ComponentInputType.JSON,
+  required: false,
+};
+
+type MakeTriggerFunction = (nodeId: string, componentId: string) => LintGraphNode;
+
+const makeTrigger: MakeTriggerFunction = (
+  nodeId: string,
+  componentId: string,
+): LintGraphNode => {
+  return makeNode({
+    nodeId: nodeId,
+    componentId: componentId,
+    componentType: ComponentType.Trigger,
+  });
+};
+
+type RulesOfFunction = (result: WorkflowLintResult) => Array<WorkflowLintRule>;
+
+const rulesOf: RulesOfFunction = (
+  result: WorkflowLintResult,
+): Array<WorkflowLintRule> => {
+  return result.issues.map((issue: WorkflowLintIssue) => {
+    return issue.rule;
+  });
+};
+
+describe("lintWorkflowGraph — nothing to report", () => {
+  test("an empty graph is silent", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [],
+      edges: [],
+    });
+
+    expect(result.issues).toEqual([]);
+    expect(result.errorCount).toBe(0);
+    expect(result.warningCount).toBe(0);
+  });
+
+  test("a well-formed graph is silent", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const step: LintGraphNode = makeNode({
+      nodeId: "n2",
+      componentId: "api-post-1",
+      args: [requiredUrlArgument, jsonArgument],
+      values: {
+        url: "https://example.com",
+        "request-body": '{"a": 1}',
+      },
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, step],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    expect(result.issues).toEqual([]);
+  });
+
+  test("placeholder nodes are ignored entirely", () => {
+    const placeholder: LintGraphNode = makeNode({
+      nodeId: "n1",
+      componentId: "",
+      componentType: ComponentType.Trigger,
+      nodeType: NodeType.PlaceholderNode,
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [placeholder],
+      edges: [],
+    });
+
+    expect(result.issues).toEqual([]);
+  });
+});
+
+describe("lintWorkflowGraph — graph shape", () => {
+  test("reports a workflow with no trigger", () => {
+    const step: LintGraphNode = makeNode({
+      nodeId: "n1",
+      componentId: "log-1",
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [step],
+      edges: [],
+    });
+
+    expect(rulesOf(result)).toContain(WorkflowLintRule.NoTrigger);
+    expect(
+      result.issues.find((issue: WorkflowLintIssue) => {
+        return issue.rule === WorkflowLintRule.NoTrigger;
+      })?.nodeId,
+    ).toBeNull();
+  });
+
+  test("reports a step the trigger cannot reach, as a warning", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const connected: LintGraphNode = makeNode({
+      nodeId: "n2",
+      componentId: "log-1",
+    });
+    const orphan: LintGraphNode = makeNode({
+      nodeId: "n3",
+      componentId: "log-2",
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, connected, orphan],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    const issue: WorkflowLintIssue | undefined = result.issues.find(
+      (candidate: WorkflowLintIssue) => {
+        return candidate.rule === WorkflowLintRule.UnreachableComponent;
+      },
+    );
+
+    expect(issue?.componentId).toBe("log-2");
+    expect(issue?.severity).toBe(WorkflowLintSeverity.Warning);
+    expect(result.warningCount).toBe(1);
+  });
+
+  test("follows a chain of edges when deciding reachability", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const a: LintGraphNode = makeNode({ nodeId: "n2", componentId: "a" });
+    const b: LintGraphNode = makeNode({ nodeId: "n3", componentId: "b" });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, a, b],
+      edges: [
+        { source: "n1", target: "n2" },
+        { source: "n2", target: "n3" },
+      ],
+    });
+
+    expect(rulesOf(result)).not.toContain(
+      WorkflowLintRule.UnreachableComponent,
+    );
+  });
+
+  test("reports two steps sharing an id", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const first: LintGraphNode = makeNode({
+      nodeId: "n2",
+      componentId: "log-1",
+    });
+    const second: LintGraphNode = makeNode({
+      nodeId: "n3",
+      componentId: "log-1",
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, first, second],
+      edges: [
+        { source: "n1", target: "n2" },
+        { source: "n2", target: "n3" },
+      ],
+    });
+
+    const duplicates: Array<WorkflowLintIssue> = result.issues.filter(
+      (issue: WorkflowLintIssue) => {
+        return issue.rule === WorkflowLintRule.DuplicateComponentId;
+      },
+    );
+
+    // Both nodes are flagged, so either one shows the badge.
+    expect(duplicates).toHaveLength(2);
+    expect(duplicates[0]?.severity).toBe(WorkflowLintSeverity.Error);
+  });
+
+  test("reports an id containing a dot, which no reference can address", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const dotted: LintGraphNode = makeNode({
+      nodeId: "n2",
+      componentId: "api.get.1",
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, dotted],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    expect(rulesOf(result)).toContain(WorkflowLintRule.ComponentIdContainsDot);
+  });
+});
+
+describe("lintWorkflowGraph — arguments", () => {
+  test("reports a required argument left empty", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const step: LintGraphNode = makeNode({
+      nodeId: "n2",
+      componentId: "api-get-1",
+      args: [requiredUrlArgument],
+      values: {},
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, step],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    const issue: WorkflowLintIssue | undefined = result.issues.find(
+      (candidate: WorkflowLintIssue) => {
+        return candidate.rule === WorkflowLintRule.MissingRequiredArgument;
+      },
+    );
+
+    expect(issue?.argumentId).toBe("url");
+    expect(issue?.message).toMatch(/"URL" is required/);
+  });
+
+  test("treats whitespace and an empty object as empty", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const blank: LintGraphNode = makeNode({
+      nodeId: "n2",
+      componentId: "a",
+      args: [requiredUrlArgument],
+      values: { url: "   " },
+    });
+    const emptyObject: LintGraphNode = makeNode({
+      nodeId: "n3",
+      componentId: "b",
+      args: [{ ...requiredUrlArgument, type: ComponentInputType.JSON }],
+      values: { url: {} },
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, blank, emptyObject],
+      edges: [
+        { source: "n1", target: "n2" },
+        { source: "n2", target: "n3" },
+      ],
+    });
+
+    expect(
+      result.issues.filter((issue: WorkflowLintIssue) => {
+        return issue.rule === WorkflowLintRule.MissingRequiredArgument;
+      }),
+    ).toHaveLength(2);
+  });
+
+  test("does not treat false or zero as missing", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const step: LintGraphNode = makeNode({
+      nodeId: "n2",
+      componentId: "a",
+      args: [
+        {
+          id: "enabled",
+          name: "Enabled",
+          description: "",
+          type: ComponentInputType.Boolean,
+          required: true,
+        },
+        {
+          id: "count",
+          name: "Count",
+          description: "",
+          type: ComponentInputType.Number,
+          required: true,
+        },
+      ],
+      values: { enabled: false, count: 0 },
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, step],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    expect(rulesOf(result)).not.toContain(
+      WorkflowLintRule.MissingRequiredArgument,
+    );
+  });
+
+  test("reports malformed JSON in a JSON argument", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const step: LintGraphNode = makeNode({
+      nodeId: "n2",
+      componentId: "api-post-1",
+      args: [jsonArgument],
+      values: { "request-body": '{"a": 1,}' },
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, step],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    const issue: WorkflowLintIssue | undefined = result.issues.find(
+      (candidate: WorkflowLintIssue) => {
+        return candidate.rule === WorkflowLintRule.InvalidJSON;
+      },
+    );
+
+    expect(issue?.message).toMatch(/"Request Body" is not valid JSON/);
+  });
+
+  test("does not report JSON5 in an argument that is read with JSON5", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const step: LintGraphNode = makeNode({
+      nodeId: "n2",
+      componentId: "create-one-1",
+      args: [
+        {
+          id: "json",
+          name: "Data",
+          description: "",
+          type: ComponentInputType.BaseModel,
+          required: false,
+        },
+      ],
+      values: { json: "{name: 'x',}" },
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, step],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    expect(rulesOf(result)).not.toContain(WorkflowLintRule.InvalidJSON);
+  });
+
+  test("still reports JSON5 in an argument the runner parses strictly", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const step: LintGraphNode = makeNode({
+      nodeId: "n2",
+      componentId: "api-post-1",
+      args: [jsonArgument],
+      values: { "request-body": "{name: 'x',}" },
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, step],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    expect(rulesOf(result)).toContain(WorkflowLintRule.InvalidJSON);
+  });
+
+  test("does not report JSON that only looks malformed because of templates", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const step: LintGraphNode = makeNode({
+      nodeId: "n2",
+      componentId: "api-post-1",
+      args: [jsonArgument],
+      values: {
+        "request-body": '{"retries": {{local.variables.count}}}',
+      },
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, step],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    expect(rulesOf(result)).not.toContain(WorkflowLintRule.InvalidJSON);
+  });
+});
+
+describe("lintWorkflowGraph — references", () => {
+  type BuildPairFunction = (referenceText: string) => {
+    nodes: Array<LintGraphNode>;
+    edges: Array<LintGraphEdge>;
+  };
+
+  /*
+   * trigger -> api-get-1 -> log-1, where log-1's Message carries the reference
+   * under test. api-get-1 returns "response-body".
+   */
+  const buildPair: BuildPairFunction = (
+    referenceText: string,
+  ): { nodes: Array<LintGraphNode>; edges: Array<LintGraphEdge> } => {
+    return {
+      nodes: [
+        makeTrigger("n1", "manual-1"),
+        makeNode({
+          nodeId: "n2",
+          componentId: "api-get-1",
+          returnValues: [bodyReturnValue],
+        }),
+        makeNode({
+          nodeId: "n3",
+          componentId: "log-1",
+          args: [textArgument],
+          values: { message: referenceText },
+        }),
+      ],
+      edges: [
+        { source: "n1", target: "n2" },
+        { source: "n2", target: "n3" },
+      ],
+    };
+  };
+
+  test("accepts a reference the picker would have written", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph(
+      buildPair("{{local.components.api-get-1.returnValues.response-body}}"),
+    );
+
+    expect(result.issues).toEqual([]);
+  });
+
+  test("accepts a drill-in below the return value", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph(
+      buildPair(
+        "{{local.components.api-get-1.returnValues.response-body.data.items[0].id}}",
+      ),
+    );
+
+    expect(result.issues).toEqual([]);
+  });
+
+  test("accepts variable references without checking that they exist", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph(
+      buildPair("{{local.variables.token}} {{global.variables.region}}"),
+    );
+
+    expect(result.issues).toEqual([]);
+  });
+
+  test("reports a misspelled root", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph(
+      buildPair("{{local.componets.api-get-1.returnValues.response-body}}"),
+    );
+
+    expect(rulesOf(result)).toContain(WorkflowLintRule.UnknownReferenceRoot);
+  });
+
+  test("reports a step id that is not in the graph", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph(
+      buildPair("{{local.components.api-get-2.returnValues.response-body}}"),
+    );
+
+    const issue: WorkflowLintIssue | undefined = result.issues.find(
+      (candidate: WorkflowLintIssue) => {
+        return (
+          candidate.rule === WorkflowLintRule.UnknownReferencedComponent
+        );
+      },
+    );
+
+    expect(issue?.message).toMatch(/api-get-2/);
+  });
+
+  test("reports a return value the referenced step does not have", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph(
+      buildPair("{{local.components.api-get-1.returnValues.respones-body}}"),
+    );
+
+    const issue: WorkflowLintIssue | undefined = result.issues.find(
+      (candidate: WorkflowLintIssue) => {
+        return (
+          candidate.rule === WorkflowLintRule.UnknownReferencedReturnValue
+        );
+      },
+    );
+
+    expect(issue?.message).toMatch(/respones-body/);
+  });
+
+  test("reports a space inside the braces, which silently never resolves", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph(
+      buildPair("{{ local.components.api-get-1.returnValues.response-body }}"),
+    );
+
+    const issue: WorkflowLintIssue | undefined = result.issues.find(
+      (candidate: WorkflowLintIssue) => {
+        return candidate.rule === WorkflowLintRule.ReferenceHasWhitespace;
+      },
+    );
+
+    expect(issue?.severity).toBe(WorkflowLintSeverity.Error);
+    expect(issue?.message).toMatch(/space/);
+  });
+
+  test("reports a step referring to its own results", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [
+        makeTrigger("n1", "manual-1"),
+        makeNode({
+          nodeId: "n2",
+          componentId: "api-get-1",
+          args: [textArgument],
+          returnValues: [bodyReturnValue],
+          values: {
+            message:
+              "{{local.components.api-get-1.returnValues.response-body}}",
+          },
+        }),
+      ],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    expect(rulesOf(result)).toContain(WorkflowLintRule.SelfReference);
+  });
+
+  test("reports a reference to a step that runs later", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [
+        makeTrigger("n1", "manual-1"),
+        makeNode({
+          nodeId: "n2",
+          componentId: "first",
+          args: [textArgument],
+          values: {
+            message: "{{local.components.second.returnValues.response-body}}",
+          },
+        }),
+        makeNode({
+          nodeId: "n3",
+          componentId: "second",
+          returnValues: [bodyReturnValue],
+        }),
+      ],
+      edges: [
+        { source: "n1", target: "n2" },
+        { source: "n2", target: "n3" },
+      ],
+    });
+
+    const issue: WorkflowLintIssue | undefined = result.issues.find(
+      (candidate: WorkflowLintIssue) => {
+        return candidate.rule === WorkflowLintRule.ForwardReference;
+      },
+    );
+
+    expect(issue?.severity).toBe(WorkflowLintSeverity.Error);
+    expect(issue?.message).toMatch(/runs after this one/);
+  });
+
+  test("stays quiet about a step on a parallel branch, whose order is not decidable", () => {
+    /*
+     * trigger fans out to "sibling" and to "reader". The runner's queue is
+     * FIFO across branches, so sibling may well have run by the time reader
+     * does. Reporting it would be a guess.
+     */
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [
+        makeTrigger("n1", "manual-1"),
+        makeNode({
+          nodeId: "n2",
+          componentId: "sibling",
+          returnValues: [bodyReturnValue],
+        }),
+        makeNode({
+          nodeId: "n3",
+          componentId: "reader",
+          args: [textArgument],
+          values: {
+            message: "{{local.components.sibling.returnValues.response-body}}",
+          },
+        }),
+      ],
+      edges: [
+        { source: "n1", target: "n2" },
+        { source: "n1", target: "n3" },
+      ],
+    });
+
+    expect(result.issues).toEqual([]);
+  });
+
+  test("warns when the referenced step is never reached", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [
+        makeTrigger("n1", "manual-1"),
+        makeNode({
+          nodeId: "n2",
+          componentId: "reader",
+          args: [textArgument],
+          values: {
+            message: "{{local.components.island.returnValues.response-body}}",
+          },
+        }),
+        makeNode({
+          nodeId: "n3",
+          componentId: "island",
+          returnValues: [bodyReturnValue],
+        }),
+      ],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    expect(rulesOf(result)).toContain(
+      WorkflowLintRule.ReferenceToUnreachableComponent,
+    );
+  });
+
+  test("never reports references inside a loop body", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph(
+      buildPair(
+        "{{#each local.components.api-get-1.returnValues.response-body}}{{status}} {{labels.name}} {{@index}} {{this}}{{/each}}",
+      ),
+    );
+
+    expect(result.issues).toEqual([]);
+  });
+
+  test("still checks the loop's own array path", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph(
+      buildPair("{{#each local.componets.api-get-1.returnValues.x}}a{{/each}}"),
+    );
+
+    /*
+     * The {{#each}} tag is not a Reference, so it is not path-checked — this
+     * asserts the linter stays silent rather than inventing a rule it cannot
+     * apply soundly.
+     */
+    expect(result.issues).toEqual([]);
+  });
+
+  test("does not mistake JavaScript for a broken reference", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph(
+      buildPair("if (x) {{ return 1; }}"),
+    );
+
+    expect(result.issues).toEqual([]);
+  });
+
+  test("finds references nested inside an object-shaped argument", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [
+        makeTrigger("n1", "manual-1"),
+        makeNode({
+          nodeId: "n2",
+          componentId: "api-post-1",
+          args: [
+            {
+              id: "request-headers",
+              name: "Request Headers",
+              description: "",
+              type: ComponentInputType.StringDictionary,
+              required: false,
+            },
+          ],
+          values: {
+            "request-headers": {
+              Authorization: "Bearer {{local.componets.x.returnValues.y}}",
+            },
+          },
+        }),
+      ],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    expect(rulesOf(result)).toContain(WorkflowLintRule.UnknownReferenceRoot);
+  });
+});
+
+describe("lintWorkflowGraph — roll-up", () => {
+  test("combines several messages for one node onto one line each", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const step: LintGraphNode = makeNode({
+      nodeId: "n2",
+      componentId: "api.get.1",
+      args: [requiredUrlArgument, jsonArgument],
+      values: { "request-body": "{oops" },
+    });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, step],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    const combined: string = result.errorsByNodeId["n2"] as string;
+
+    expect(combined.split("\n").length).toBeGreaterThan(1);
+    expect(combined).toMatch(/dot/);
+    expect(combined).toMatch(/required/);
+  });
+
+  test("counts errors and warnings separately", () => {
+    const trigger: LintGraphNode = makeTrigger("n1", "manual-1");
+    const missing: LintGraphNode = makeNode({
+      nodeId: "n2",
+      componentId: "a",
+      args: [requiredUrlArgument],
+      values: {},
+    });
+    const orphan: LintGraphNode = makeNode({ nodeId: "n3", componentId: "b" });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [trigger, missing, orphan],
+      edges: [{ source: "n1", target: "n2" }],
+    });
+
+    expect(result.errorCount).toBe(1);
+    expect(result.warningCount).toBe(1);
+  });
+
+  test("keeps graph-wide issues out of the per-node map", () => {
+    const step: LintGraphNode = makeNode({ nodeId: "n1", componentId: "a" });
+
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [step],
+      edges: [],
+    });
+
+    expect(result.errorsByNodeId["n1"]).toBeUndefined();
+    expect(result.errorCount).toBe(1);
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/Utils.test.ts
+++ b/Common/Tests/UI/Components/Workflow/Utils.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Utils.ts imports the whole database-model registry for
+ * loadComponentsAndCategories, which nothing here exercises. Stubbing it keeps
+ * this suite from type-checking several hundred model files to test two pure
+ * functions.
+ */
+jest.mock("../../../../Models/DatabaseModels/Index", () => {
+  return {
+    __esModule: true,
+    default: [],
+  };
+});
+
+import {
+  componentInputTypeToFormFieldType,
+  parseStringDictionaryValue,
+} from "../../../../UI/Components/Workflow/Utils";
+import FormFieldSchemaType from "../../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import { JSONObject } from "../../../../Types/JSON";
+import { ComponentInputType } from "../../../../Types/Workflow/Component";
+import { describe, expect, test } from "@jest/globals";
+
+describe("parseStringDictionaryValue", () => {
+  test("treats an unset value as an empty dictionary", () => {
+    expect(parseStringDictionaryValue(undefined)).toEqual({});
+    expect(parseStringDictionaryValue(null)).toEqual({});
+    expect(parseStringDictionaryValue("")).toEqual({});
+    expect(parseStringDictionaryValue("   ")).toEqual({});
+  });
+
+  test("parses the JSON string shape every existing workflow stores", () => {
+    expect(
+      parseStringDictionaryValue('{"Authorization": "Bearer abc"}'),
+    ).toEqual({
+      Authorization: "Bearer abc",
+    });
+  });
+
+  test("accepts JSON5, which is what the components themselves accept", () => {
+    expect(parseStringDictionaryValue("{header1: 'value1'}")).toEqual({
+      header1: "value1",
+    });
+    expect(parseStringDictionaryValue('{"a": "b",}')).toEqual({ a: "b" });
+  });
+
+  test("passes an already-parsed object straight through", () => {
+    const value: JSONObject = { "X-Key": "v" };
+
+    expect(parseStringDictionaryValue(value)).toEqual({ "X-Key": "v" });
+  });
+
+  test("keeps numbers and booleans, which the row editor can represent", () => {
+    expect(parseStringDictionaryValue('{"n": 1, "b": true}')).toEqual({
+      n: 1,
+      b: true,
+    });
+  });
+
+  test("declines a whole-field template, which is not JSON as written", () => {
+    expect(
+      parseStringDictionaryValue(
+        "{{local.components.api-get-1.returnValues.response-headers}}",
+      ),
+    ).toBeNull();
+  });
+
+  test("declines text that does not parse, so it stays visible and fixable", () => {
+    expect(parseStringDictionaryValue('{"a": ')).toBeNull();
+    expect(parseStringDictionaryValue("not json")).toBeNull();
+  });
+
+  test("declines nested values the row editor would silently discard", () => {
+    expect(parseStringDictionaryValue('{"a": {"b": 1}}')).toBeNull();
+    expect(parseStringDictionaryValue('{"a": ["b"]}')).toBeNull();
+    expect(parseStringDictionaryValue('{"a": null}')).toBeNull();
+  });
+
+  test("declines arrays and scalars, which are not dictionaries", () => {
+    expect(parseStringDictionaryValue("[1, 2]")).toBeNull();
+    expect(parseStringDictionaryValue("42")).toBeNull();
+  });
+
+  test("keeps a value containing a template inside a string", () => {
+    expect(
+      parseStringDictionaryValue(
+        '{"Authorization": "Bearer {{local.variables.token}}"}',
+      ),
+    ).toEqual({
+      Authorization: "Bearer {{local.variables.token}}",
+    });
+  });
+});
+
+describe("componentInputTypeToFormFieldType — StringDictionary", () => {
+  test("uses the key/value editor for a value it can represent", () => {
+    expect(
+      componentInputTypeToFormFieldType(
+        ComponentInputType.StringDictionary,
+        '{"a": "b"}',
+      ).fieldType,
+    ).toBe(FormFieldSchemaType.Dictionary);
+  });
+
+  test("uses the key/value editor for an unset value", () => {
+    expect(
+      componentInputTypeToFormFieldType(
+        ComponentInputType.StringDictionary,
+        null,
+      ).fieldType,
+    ).toBe(FormFieldSchemaType.Dictionary);
+  });
+
+  test("falls back to the JSON editor for a whole-field template", () => {
+    expect(
+      componentInputTypeToFormFieldType(
+        ComponentInputType.StringDictionary,
+        "{{local.components.a.returnValues.response-headers}}",
+      ).fieldType,
+    ).toBe(FormFieldSchemaType.JSON);
+  });
+
+  test("falls back to the JSON editor for a value that does not parse", () => {
+    expect(
+      componentInputTypeToFormFieldType(
+        ComponentInputType.StringDictionary,
+        '{"a": ',
+      ).fieldType,
+    ).toBe(FormFieldSchemaType.JSON);
+  });
+
+  test("agrees with parseStringDictionaryValue for every case", () => {
+    const samples: Array<unknown> = [
+      undefined,
+      null,
+      "",
+      '{"a":"b"}',
+      "{a:'b'}",
+      "{{local.variables.x}}",
+      '{"a":{"b":1}}',
+      "[1,2]",
+      "garbage",
+      { a: "b" },
+    ];
+
+    for (const sample of samples) {
+      const expected: FormFieldSchemaType =
+        parseStringDictionaryValue(sample) === null
+          ? FormFieldSchemaType.JSON
+          : FormFieldSchemaType.Dictionary;
+
+      expect(
+        componentInputTypeToFormFieldType(
+          ComponentInputType.StringDictionary,
+          sample,
+        ).fieldType,
+      ).toBe(expected);
+    }
+  });
+});
+
+describe("componentInputTypeToFormFieldType — unchanged mappings", () => {
+  test("JSON-document types still use the code editor", () => {
+    const jsonTypes: Array<ComponentInputType> = [
+      ComponentInputType.JSON,
+      ComponentInputType.JSONArray,
+      ComponentInputType.Query,
+      ComponentInputType.Select,
+      ComponentInputType.BaseModel,
+      ComponentInputType.BaseModelArray,
+    ];
+
+    for (const type of jsonTypes) {
+      expect(componentInputTypeToFormFieldType(type, null).fieldType).toBe(
+        FormFieldSchemaType.JSON,
+      );
+    }
+  });
+
+  test("simple types are untouched", () => {
+    expect(
+      componentInputTypeToFormFieldType(ComponentInputType.Email, null)
+        .fieldType,
+    ).toBe(FormFieldSchemaType.Email);
+    expect(
+      componentInputTypeToFormFieldType(ComponentInputType.URL, null).fieldType,
+    ).toBe(FormFieldSchemaType.URL);
+    expect(
+      componentInputTypeToFormFieldType(ComponentInputType.Boolean, null)
+        .fieldType,
+    ).toBe(FormFieldSchemaType.Toggle);
+  });
+});

--- a/Common/Types/Workflow/Component.ts
+++ b/Common/Types/Workflow/Component.ts
@@ -30,6 +30,35 @@ export enum ComponentInputType {
   WorkflowSelect = "Workflow Select",
 }
 
+/*
+ * Argument types whose value is a JSON document but is read with
+ * JSONFunctions.parse — that is, JSON5 — rather than JSON.parse. Unquoted keys,
+ * single quotes and trailing commas therefore work in these, and a workflow
+ * written that way runs fine today.
+ *
+ * The distinction matters wherever a JSON document is checked for syntax
+ * before it runs: applying JSON.parse's rules to one of these would report a
+ * mistake in a workflow that does not have one. The strict set is everything
+ * else — RunWorkflow.getComponentArguments calls JSON.parse directly on
+ * JSON, Query and Select, so those really must be JSON.
+ */
+const JSON5_TOLERANT_INPUT_TYPES: Array<ComponentInputType> = [
+  ComponentInputType.StringDictionary,
+  ComponentInputType.JSONArray,
+  ComponentInputType.BaseModel,
+  ComponentInputType.BaseModelArray,
+];
+
+export type IsJSON5ToleratedInputTypeFunction = (
+  type: ComponentInputType,
+) => boolean;
+
+export const isJSON5ToleratedInputType: IsJSON5ToleratedInputTypeFunction = (
+  type: ComponentInputType,
+): boolean => {
+  return JSON5_TOLERANT_INPUT_TYPES.includes(type);
+};
+
 export enum ComponentType {
   Trigger = "Trigger",
   Component = "Component",

--- a/Common/Types/Workflow/Components/API.ts
+++ b/Common/Types/Workflow/Components/API.ts
@@ -37,6 +37,13 @@ const components: Array<ComponentMetadata> = [
         type: ComponentInputType.StringDictionary,
         required: false,
         isAdvanced: true,
+        /*
+         * Headers are where an Authorization bearer token gets typed, and
+         * without this the resolved value is written verbatim into the
+         * WorkflowLog for anyone with read access to the project. Only values
+         * that came from a variable marked secret were ever scrubbed.
+         */
+        isSensitive: true,
         placeholder:
           'Example: {"header1": "value1", "header2": "value2", ....}',
       },
@@ -123,6 +130,13 @@ const components: Array<ComponentMetadata> = [
         type: ComponentInputType.StringDictionary,
         required: false,
         isAdvanced: true,
+        /*
+         * Headers are where an Authorization bearer token gets typed, and
+         * without this the resolved value is written verbatim into the
+         * WorkflowLog for anyone with read access to the project. Only values
+         * that came from a variable marked secret were ever scrubbed.
+         */
+        isSensitive: true,
         placeholder:
           'Example: {"header1": "value1", "header2": "value2", ....}',
       },
@@ -209,6 +223,13 @@ const components: Array<ComponentMetadata> = [
         type: ComponentInputType.StringDictionary,
         required: false,
         isAdvanced: true,
+        /*
+         * Headers are where an Authorization bearer token gets typed, and
+         * without this the resolved value is written verbatim into the
+         * WorkflowLog for anyone with read access to the project. Only values
+         * that came from a variable marked secret were ever scrubbed.
+         */
+        isSensitive: true,
         placeholder:
           'Example: {"header1": "value1", "header2": "value2", ....}',
       },
@@ -295,6 +316,13 @@ const components: Array<ComponentMetadata> = [
         type: ComponentInputType.StringDictionary,
         required: false,
         isAdvanced: true,
+        /*
+         * Headers are where an Authorization bearer token gets typed, and
+         * without this the resolved value is written verbatim into the
+         * WorkflowLog for anyone with read access to the project. Only values
+         * that came from a variable marked secret were ever scrubbed.
+         */
+        isSensitive: true,
         placeholder:
           'Example: {"header1": "value1", "header2": "value2", ....}',
       },
@@ -381,6 +409,13 @@ const components: Array<ComponentMetadata> = [
         type: ComponentInputType.StringDictionary,
         required: false,
         isAdvanced: true,
+        /*
+         * Headers are where an Authorization bearer token gets typed, and
+         * without this the resolved value is written verbatim into the
+         * WorkflowLog for anyone with read access to the project. Only values
+         * that came from a variable marked secret were ever scrubbed.
+         */
+        isSensitive: true,
         placeholder:
           'Example: {"header1": "value1", "header2": "value2", ....}',
       },

--- a/Common/Types/Workflow/TemplateSyntax.ts
+++ b/Common/Types/Workflow/TemplateSyntax.ts
@@ -1,0 +1,499 @@
+/*
+ * Parsing helpers for the {{...}} template syntax that workflow arguments use.
+ *
+ * The runtime implementation lives in Common/Server/Utils/VM/VMAPI.ts
+ * (replaceValueInPlace, expandEachLoops, deepFind). Everything in this file
+ * mirrors that behaviour so the builder can warn about a broken reference
+ * before a run does — VMAPI deliberately skips a reference it cannot resolve
+ * ("Skip replacement if the variable is not found in the storageMap"), which
+ * means a typo like {{local.componets.api-get-1.returnValues.response-body}}
+ * is sent as literal text in the outgoing request and the run still reports
+ * Success. That silence is the bug this module exists to end.
+ *
+ * This lives in Common/Types (not Common/UI) because both the builder and the
+ * server-side runner need it, and Common/Types has no UI or server deps.
+ */
+
+import JSON5 from "json5";
+
+/**
+ * The exact expression matcher the runtime uses (VMAPI.ts: `/{{(.*?)}}/g`).
+ * Non-greedy, so `{{a}} and {{b}}` yields two matches rather than one.
+ * Built fresh on each use because a global RegExp carries lastIndex state.
+ */
+export type GetTemplateExpressionRegexFunction = () => RegExp;
+
+export const getTemplateExpressionRegex: GetTemplateExpressionRegexFunction =
+  (): RegExp => {
+    return /{{(.*?)}}/g;
+  };
+
+export enum TemplateExpressionKind {
+  /** A value reference, e.g. {{local.variables.apiKey}}. */
+  Reference = "Reference",
+  /** The opening tag of a loop, e.g. {{#each local.components.x.returnValues.items}}. */
+  EachOpen = "EachOpen",
+  /** The closing tag of a loop: {{/each}}. */
+  EachClose = "EachClose",
+  /** The loop index helper: {{@index}}. */
+  LoopIndex = "LoopIndex",
+  /** The current primitive element inside a loop: {{this}}. */
+  LoopThis = "LoopThis",
+}
+
+export interface TemplateExpression {
+  /** The full matched text, including the braces. */
+  raw: string;
+  /** The text between the braces, trimmed. */
+  inner: string;
+  /**
+   * The text between the braces exactly as written. Worth keeping separate,
+   * because the runtime is inconsistent about trimming: at the top level
+   * VMAPI.replaceValueInPlace hands the raw capture to deepFind, so
+   * `{{ local.variables.x }}` resolves nothing and leaves the braces in the
+   * output, while inside an {{#each}} body replaceLoopVariables trims first and
+   * the same spacing is harmless.
+   */
+  innerRaw: string;
+  kind: TemplateExpressionKind;
+  /** Index of the first `{` in the source string. */
+  startIndex: number;
+  /** Index one past the final `}` in the source string. */
+  endIndex: number;
+  /**
+   * True when this expression sits between an {{#each}} and its {{/each}}.
+   * Inside a loop, VMAPI resolves a reference against the current array
+   * element first and only then against the storage map
+   * (VMAPI.replaceLoopVariables), so a bare {{status}} is legitimate there and
+   * must never be reported as unknown.
+   */
+  isInsideEachBlock: boolean;
+}
+
+type ClassifyExpressionFunction = (inner: string) => TemplateExpressionKind;
+
+const classifyExpression: ClassifyExpressionFunction = (
+  inner: string,
+): TemplateExpressionKind => {
+  if (inner.startsWith("#each")) {
+    return TemplateExpressionKind.EachOpen;
+  }
+
+  if (inner === "/each") {
+    return TemplateExpressionKind.EachClose;
+  }
+
+  if (inner === "@index") {
+    return TemplateExpressionKind.LoopIndex;
+  }
+
+  if (inner === "this") {
+    return TemplateExpressionKind.LoopThis;
+  }
+
+  return TemplateExpressionKind.Reference;
+};
+
+export type ParseTemplateExpressionsFunction = (
+  value: string,
+) => Array<TemplateExpression>;
+
+/**
+ * Every {{...}} expression in `value`, in source order, each tagged with what
+ * it is and whether it sits inside a loop body.
+ */
+export const parseTemplateExpressions: ParseTemplateExpressionsFunction = (
+  value: string,
+): Array<TemplateExpression> => {
+  if (!value || typeof value !== "string") {
+    return [];
+  }
+
+  const expressions: Array<TemplateExpression> = [];
+  const regex: RegExp = getTemplateExpressionRegex();
+  let match: RegExpExecArray | null = null;
+  let eachDepth: number = 0;
+
+  while ((match = regex.exec(value)) !== null) {
+    const raw: string = match[0];
+    const innerRaw: string = match[1] || "";
+    const inner: string = innerRaw.trim();
+    const kind: TemplateExpressionKind = classifyExpression(inner);
+
+    /*
+     * A closing tag is not itself "inside" the block it closes, and an opening
+     * tag is not inside the block it opens — but the array path on an opening
+     * tag IS resolved against the enclosing scope, so nested opens still count
+     * as inside their parent.
+     */
+    if (kind === TemplateExpressionKind.EachClose) {
+      eachDepth = Math.max(0, eachDepth - 1);
+    }
+
+    expressions.push({
+      raw: raw,
+      inner: inner,
+      innerRaw: innerRaw,
+      kind: kind,
+      startIndex: match.index,
+      endIndex: match.index + raw.length,
+      isInsideEachBlock: eachDepth > 0,
+    });
+
+    if (kind === TemplateExpressionKind.EachOpen) {
+      eachDepth++;
+    }
+  }
+
+  return expressions;
+};
+
+export type HasEachBlockFunction = (value: string) => boolean;
+
+/**
+ * True when the value contains a loop. A loop expands to a variable number of
+ * repetitions of its body, so the shape of the final string is not knowable
+ * statically — callers that check structure (e.g. JSON validity) must bail out.
+ */
+export const hasEachBlock: HasEachBlockFunction = (value: string): boolean => {
+  if (!value || typeof value !== "string") {
+    return false;
+  }
+
+  return value.includes("{{#each") || value.includes("{{/each}}");
+};
+
+/*
+ * Substituted into a JSON document in place of every {{...}} expression before
+ * the document is parsed. `1` is chosen because it is simultaneously a legal
+ * JSON value (`{"n": {{x}}}` -> `{"n": 1}`), legal inside a string literal
+ * (`{"s": "{{x}}"}` -> `{"s": "1"}`), and legal as an object key
+ * (`{"{{x}}": 2}` -> `{"1": 2}`). Any of those three is a real thing people
+ * write, and all three have to survive masking or the check reports a
+ * syntax error where none exists.
+ */
+const TEMPLATE_MASK_TOKEN: string = "1";
+
+export type MaskTemplateExpressionsFunction = (value: string) => string;
+
+/**
+ * Replace every {{...}} expression with a neutral literal, so what remains can
+ * be checked for JSON syntax without the (unknown, run-time) substituted
+ * values.
+ */
+export const maskTemplateExpressions: MaskTemplateExpressionsFunction = (
+  value: string,
+): string => {
+  if (!value || typeof value !== "string") {
+    return value;
+  }
+
+  return value.replace(getTemplateExpressionRegex(), TEMPLATE_MASK_TOKEN);
+};
+
+export interface JSONSyntaxCheckResult {
+  /**
+   * False only when the value is definitely malformed. A value this module
+   * cannot decide about (a loop, a non-string, an empty box) is reported
+   * valid — the builder must never block on a guess.
+   */
+  isValid: boolean;
+  /**
+   * The JSON parser's own message ("Unexpected token } in JSON at position
+   * 24"), with no framing around it — callers phrase the sentence, since a
+   * form field and a canvas badge word it differently. Null when valid.
+   */
+  errorMessage: string | null;
+  /**
+   * True when the check was skipped rather than passed. Callers that want to
+   * explain themselves ("not checked: contains a loop") can use this.
+   */
+  wasSkipped: boolean;
+}
+
+export interface JSONSyntaxCheckOptions {
+  /**
+   * Judge the value by JSON5's rules instead of JSON's — unquoted keys, single
+   * quotes and trailing commas allowed. Set this wherever the code that will
+   * actually read the value uses JSONFunctions.parse, so the check cannot be
+   * stricter than the thing it is predicting.
+   */
+  allowJSON5?: boolean | undefined;
+}
+
+export type CheckJSONSyntaxFunction = (
+  value: unknown,
+  options?: JSONSyntaxCheckOptions | undefined,
+) => JSONSyntaxCheckResult;
+
+/**
+ * Is `value` a JSON document, once its {{...}} placeholders are accounted for?
+ *
+ * Deliberately permissive. It returns invalid only for a string that cannot
+ * become JSON no matter what the placeholders resolve to, because a false
+ * positive here disables the Save button on a workflow that actually works.
+ */
+export const checkJSONSyntax: CheckJSONSyntaxFunction = (
+  value: unknown,
+  options?: JSONSyntaxCheckOptions | undefined,
+): JSONSyntaxCheckResult => {
+  const skipped: JSONSyntaxCheckResult = {
+    isValid: true,
+    errorMessage: null,
+    wasSkipped: true,
+  };
+
+  /*
+   * Not a string: the field already holds a parsed object (the Dictionary
+   * editor and imported graphs both produce these). Nothing to parse.
+   */
+  if (typeof value !== "string") {
+    return skipped;
+  }
+
+  // Empty is the job of the required-field check, not this one.
+  if (value.trim() === "") {
+    return skipped;
+  }
+
+  /*
+   * A loop emits its body once per array element, so the document's structure
+   * depends on data that only exists at run time. Checking the unexpanded text
+   * would flag every correct loop ever written.
+   */
+  if (hasEachBlock(value)) {
+    return skipped;
+  }
+
+  const masked: string = maskTemplateExpressions(value);
+
+  try {
+    if (options?.allowJSON5) {
+      JSON5.parse(masked);
+    } else {
+      JSON.parse(masked);
+    }
+    return { isValid: true, errorMessage: null, wasSkipped: false };
+  } catch (err: unknown) {
+    const parserMessage: string =
+      err instanceof Error ? err.message : "Invalid JSON.";
+
+    return {
+      isValid: false,
+      errorMessage: parserMessage,
+      wasSkipped: false,
+    };
+  }
+};
+
+/* ------------------------------------------------------------------------ */
+/* Reference paths                                                           */
+/* ------------------------------------------------------------------------ */
+
+export enum ReferenceRootType {
+  LocalVariable = "LocalVariable",
+  GlobalVariable = "GlobalVariable",
+  ComponentReturnValue = "ComponentReturnValue",
+  /** Well-formed-looking but not a root the runtime storage map has. */
+  Unknown = "Unknown",
+}
+
+export interface ParsedReferencePath {
+  rootType: ReferenceRootType;
+  /** Populated for LocalVariable / GlobalVariable. */
+  variableName?: string | undefined;
+  /** Populated for ComponentReturnValue: the component's user-facing id. */
+  componentId?: string | undefined;
+  /** Populated for ComponentReturnValue: the return value's id. */
+  returnValueId?: string | undefined;
+  /**
+   * Why this path could not be understood. Only set when rootType is Unknown,
+   * and phrased for a builder to read.
+   */
+  reason?: string | undefined;
+}
+
+type StripArrayAccessorFunction = (segment: string) => string;
+
+/**
+ * `items[0]` -> `items`. VMUtil.deepFind splits a path on "." and then looks
+ * for a `[index]` suffix on each segment, so the name to match against
+ * metadata is whatever precedes the bracket.
+ */
+const stripArrayAccessor: StripArrayAccessorFunction = (
+  segment: string,
+): string => {
+  const bracketIndex: number = segment.indexOf("[");
+
+  if (bracketIndex === -1) {
+    return segment;
+  }
+
+  return segment.slice(0, bracketIndex);
+};
+
+/*
+ * Characters that appear in code but never in a reference path. A workflow's
+ * JavaScript component is templated like every other argument
+ * (RunWorkflow.getComponentArguments runs on all of them), so its source is
+ * scanned by the same regex — and JavaScript really can contain `{{` and `}}`
+ * on one line, e.g. `if (x) {{ return 1; }}`. Anything carrying these is code
+ * that happened to match, not a reference somebody typo'd, and reporting it
+ * would put a red badge on a component that works.
+ */
+const NON_REFERENCE_CHARACTERS: RegExp = /[{}()[\];=+*/&|!<>"'`,]/;
+
+export type LooksLikeReferencePathFunction = (capture: string) => boolean;
+
+/**
+ * Whether a template capture was plausibly *meant* to be a value reference.
+ * Used to decide whether an unrecognized path is worth complaining about.
+ *
+ * Array accessors are stripped first, since `items[0]` is a legitimate path
+ * segment even though it contains brackets.
+ */
+export const looksLikeReferencePath: LooksLikeReferencePathFunction = (
+  capture: string,
+): boolean => {
+  const trimmed: string = capture.trim();
+
+  if (trimmed === "") {
+    return false;
+  }
+
+  const withoutAccessors: string = trimmed.replace(/\[(\d+|last)\]/g, "");
+
+  return !NON_REFERENCE_CHARACTERS.test(withoutAccessors);
+};
+
+export type ParseReferencePathFunction = (path: string) => ParsedReferencePath;
+
+/**
+ * Break a reference path into the parts the builder can check against the
+ * graph. Mirrors the StorageMap shape built in RunWorkflow.getVariables:
+ *
+ *   local.variables.<name>
+ *   local.components.<componentId>.returnValues.<returnValueId>[...deeper]
+ *   global.variables.<name>
+ *
+ * Anything past the return value id is a drill-in to whatever that value
+ * happens to contain at run time, so it is not inspected here.
+ */
+export const parseReferencePath: ParseReferencePathFunction = (
+  path: string,
+): ParsedReferencePath => {
+  if (path.trim() === "") {
+    return {
+      rootType: ReferenceRootType.Unknown,
+      reason: "the reference is empty",
+    };
+  }
+
+  const rawSegments: Array<string> = path.split(".").map((segment: string) => {
+    return segment.trim();
+  });
+
+  /*
+   * deepFind splits on "." and bails on the first empty key, so a doubled dot
+   * silently resolves to nothing. Catch it here rather than filtering the
+   * empties out, which would make "local..variables.x" look perfectly fine.
+   */
+  if (
+    rawSegments.some((segment: string) => {
+      return segment.length === 0;
+    })
+  ) {
+    return {
+      rootType: ReferenceRootType.Unknown,
+      reason: "it has an empty part between two dots",
+    };
+  }
+
+  const segments: Array<string> = rawSegments;
+
+  const root: string = stripArrayAccessor(segments[0] as string);
+
+  if (root === "global") {
+    if (stripArrayAccessor(segments[1] || "") !== "variables") {
+      return {
+        rootType: ReferenceRootType.Unknown,
+        reason: '"global" must be followed by "variables"',
+      };
+    }
+
+    if (!segments[2]) {
+      return {
+        rootType: ReferenceRootType.Unknown,
+        reason: "no global variable name was given",
+      };
+    }
+
+    return {
+      rootType: ReferenceRootType.GlobalVariable,
+      variableName: stripArrayAccessor(segments[2]),
+    };
+  }
+
+  if (root !== "local") {
+    return {
+      rootType: ReferenceRootType.Unknown,
+      reason: `"${root}" is not a thing a reference can start with — use "local" or "global"`,
+    };
+  }
+
+  const second: string = stripArrayAccessor(segments[1] || "");
+
+  if (second === "variables") {
+    if (!segments[2]) {
+      return {
+        rootType: ReferenceRootType.Unknown,
+        reason: "no variable name was given",
+      };
+    }
+
+    return {
+      rootType: ReferenceRootType.LocalVariable,
+      variableName: stripArrayAccessor(segments[2]),
+    };
+  }
+
+  if (second !== "components") {
+    return {
+      rootType: ReferenceRootType.Unknown,
+      reason: `"local.${second}" is not valid — use "local.variables" or "local.components"`,
+    };
+  }
+
+  const componentId: string = stripArrayAccessor(segments[2] || "");
+
+  if (!componentId) {
+    return {
+      rootType: ReferenceRootType.Unknown,
+      reason: "no component id was given",
+    };
+  }
+
+  const third: string = stripArrayAccessor(segments[3] || "");
+
+  if (third !== "returnValues") {
+    return {
+      rootType: ReferenceRootType.Unknown,
+      reason: `"local.components.${componentId}" must be followed by "returnValues"`,
+    };
+  }
+
+  const returnValueId: string = stripArrayAccessor(segments[4] || "");
+
+  if (!returnValueId) {
+    return {
+      rootType: ReferenceRootType.Unknown,
+      reason: `no return value was named on "${componentId}"`,
+    };
+  }
+
+  return {
+    rootType: ReferenceRootType.ComponentReturnValue,
+    componentId: componentId,
+    returnValueId: returnValueId,
+  };
+};

--- a/Common/UI/Components/Forms/Types/Field.ts
+++ b/Common/UI/Components/Forms/Types/Field.ts
@@ -92,6 +92,13 @@ export default interface Field<TEntity> {
     | undefined;
   styleType?: FormFieldStyleType | undefined;
   showIf?: ((item: FormValues<TEntity>) => boolean) | undefined;
+  /**
+   * For a JSON field: judge its contents by JSON5's rules rather than JSON's.
+   * Set it where the code that eventually reads this value uses
+   * JSONFunctions.parse, so validation cannot reject a value that would have
+   * been read back perfectly well.
+   */
+  allowJSON5?: boolean | undefined;
   onChange?:
     | ((
         value: any,

--- a/Common/UI/Components/Forms/Validation.ts
+++ b/Common/UI/Components/Forms/Validation.ts
@@ -12,8 +12,12 @@ import Email from "../../../Types/Email";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import Exception from "../../../Types/Exception/Exception";
 import GenericObject from "../../../Types/GenericObject";
-import { JSONObject } from "../../../Types/JSON";
+import { JSONObject, JSONValue } from "../../../Types/JSON";
 import Phone from "../../../Types/Phone";
+import {
+  JSONSyntaxCheckResult,
+  checkJSONSyntax,
+} from "../../../Types/Workflow/TemplateSyntax";
 import { Logger } from "../../Utils/Logger";
 import Port from "../../../Types/Port";
 import Typeof from "../../../Types/Typeof";
@@ -320,6 +324,50 @@ export default class Validation {
     return null;
   }
 
+  /**
+   * A JSON field whose contents are not JSON.
+   *
+   * Until this existed, a stray trailing comma saved cleanly and only surfaced
+   * when something tried to parse it — for a workflow that meant a real run,
+   * at whatever hour the trigger fired, ending in
+   * "Invalid JSON provided for argument request-body"
+   * (RunWorkflow.getComponentArguments).
+   *
+   * Takes the raw value rather than the stringified `content` the other
+   * validators get, because a JSON-typed field can legitimately already hold a
+   * parsed object, and `String(anObject)` is "[object Object]" — which is not
+   * JSON, and would fail every time.
+   *
+   * Tolerates {{...}} handlebars: workflow arguments are templates, and
+   * `{"retries": {{local.variables.retryCount}}}` is not JSON as written but is
+   * JSON by the time it is parsed. checkJSONSyntax masks those before parsing
+   * and declines to judge anything containing a {{#each}} loop at all.
+   */
+  public static validateJSONSyntax<T extends GenericObject>(
+    value: JSONValue | undefined,
+    field: Field<T>,
+  ): string | null {
+    if (field.fieldType !== FormFieldSchemaType.JSON) {
+      return null;
+    }
+
+    const result: JSONSyntaxCheckResult = checkJSONSyntax(value, {
+      allowJSON5: field.allowJSON5,
+    });
+
+    if (result.isValid) {
+      return null;
+    }
+
+    return translateValidationMessage(
+      "{{field}} is not valid JSON. {{parserMessage}}",
+      {
+        field: field.title || field.name || "",
+        parserMessage: result.errorMessage || "",
+      },
+    );
+  }
+
   public static validate<T extends GenericObject>(args: {
     formFields: Array<Field<T>>;
     values: FormValues<T>;
@@ -373,6 +421,20 @@ export default class Validation {
         );
         if (resultValidateData) {
           errors[name] = resultValidateData;
+        }
+
+        /*
+         * Fed the raw value, not `content` — see validateJSONSyntax. An
+         * already-parsed object stringifies to "[object Object]", which would
+         * fail the check every time it was handed the stringified form.
+         */
+        const resultJSONSyntax: string | null = this.validateJSONSyntax(
+          (entries as JSONObject)[name] as JSONValue | undefined,
+          field,
+        );
+
+        if (resultJSONSyntax) {
+          errors[name] = resultJSONSyntax;
         }
 
         const resultMatch: string | null = this.validateMatchField(

--- a/Common/UI/Components/Workflow/ArgumentsForm.tsx
+++ b/Common/UI/Components/Workflow/ArgumentsForm.tsx
@@ -7,7 +7,10 @@ import FormValues from "../Forms/Types/FormValues";
 import ComponentValuePickerModal from "./ComponentValuePickerModal";
 import CronScheduleField from "./CronScheduleField";
 import ModelFieldPicker from "./ModelFieldPicker";
-import { componentInputTypeToFormFieldType } from "./Utils";
+import {
+  componentInputTypeToFormFieldType,
+  parseStringDictionaryValue,
+} from "./Utils";
 import VariableModal from "./VariableModal";
 import Dictionary from "../../../Types/Dictionary";
 import { JSONObject } from "../../../Types/JSON";
@@ -16,6 +19,7 @@ import {
   Argument,
   ComponentInputType,
   NodeDataProp,
+  isJSON5ToleratedInputType,
 } from "../../../Types/Workflow/Component";
 import { DropdownOption } from "../Dropdown/Dropdown";
 import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
@@ -52,6 +56,96 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
   >({});
 
   const [selectedArgId, setSelectedArgId] = useState<string>("");
+
+  /*
+   * Arguments flagged isAdvanced are collapsed behind a disclosure, so the
+   * settings panel opens on the two or three fields that actually decide what
+   * the step does rather than on every knob it has. A required argument is
+   * never collapsed no matter how it is flagged: BasicForm skips validation
+   * for a field hidden by showIf, so hiding a required one would let an
+   * incomplete step save cleanly.
+   */
+  const collapsibleAdvancedArguments: Array<Argument> = (
+    component.metadata.arguments || []
+  ).filter((arg: Argument) => {
+    return Boolean(arg.isAdvanced) && !arg.required;
+  });
+
+  const hasValueForArgument: (arg: Argument) => boolean = (
+    arg: Argument,
+  ): boolean => {
+    const value: unknown = component.arguments
+      ? component.arguments[arg.id]
+      : undefined;
+
+    if (value === undefined || value === null) {
+      return false;
+    }
+
+    if (typeof value === "string") {
+      return value.trim() !== "";
+    }
+
+    if (typeof value === "object") {
+      return Object.keys(value as JSONObject).length > 0;
+    }
+
+    return true;
+  };
+
+  /*
+   * Open on load when something down there is already set, so an existing
+   * configuration is never hidden from the person who comes back to read it.
+   */
+  const [showAdvanced, setShowAdvanced] = useState<boolean>(
+    collapsibleAdvancedArguments.some(hasValueForArgument),
+  );
+
+  const isCollapsibleAdvanced: (arg: Argument) => boolean = (
+    arg: Argument,
+  ): boolean => {
+    return collapsibleAdvancedArguments.some((advancedArg: Argument) => {
+      return advancedArg.id === arg.id;
+    });
+  };
+
+  /*
+   * StringDictionary arguments render as key/value rows, and the row editor
+   * needs a real object. Every workflow written before that change stored a
+   * JSON string, so parse those on the way into the form. Anything
+   * parseStringDictionaryValue declines stays a string and keeps the JSON
+   * editor (see componentInputTypeToFormFieldType), so the two always agree.
+   */
+  const formInitialValues: JSONObject = { ...(component.arguments || {}) };
+
+  for (const arg of component.metadata.arguments || []) {
+    if (arg.type !== ComponentInputType.StringDictionary) {
+      continue;
+    }
+
+    const parsed: JSONObject | null = parseStringDictionaryValue(
+      formInitialValues[arg.id],
+    );
+
+    if (parsed !== null) {
+      formInitialValues[arg.id] = parsed;
+    }
+  }
+
+  /*
+   * Everyday settings first, collapsible ones last, each group keeping its
+   * declared order. Without this an advanced argument declared in the middle
+   * would pop into the middle of the form when the disclosure opens.
+   */
+  const orderedArguments: Array<Argument> = [
+    ...(component.metadata.arguments || []).filter((arg: Argument) => {
+      return !isCollapsibleAdvanced(arg);
+    }),
+    ...collapsibleAdvancedArguments,
+  ];
+
+  const firstAdvancedArgumentIndex: number =
+    orderedArguments.length - collapsibleAdvancedArguments.length;
 
   /*
    * Workflows in the current project, used to populate dropdowns for any
@@ -163,7 +257,7 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
               hideSubmitButton={true}
               ref={formRef}
               initialValues={{
-                ...(component.arguments || {}),
+                ...formInitialValues,
               }}
               onChange={(values: FormValues<JSONObject>) => {
                 setComponent({
@@ -175,16 +269,23 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
                 });
               }}
               onFormValidationErrorChanged={(hasError: boolean) => {
-                if (hasFormValidationErrors["id"] !== hasError) {
+                /*
+                 * Keyed "arguments", not "id": the Identifier field in the
+                 * settings modal reports into the same dictionary under "id",
+                 * so both forms were overwriting each other. Typing in the
+                 * Identifier box cleared an outstanding argument error and
+                 * re-enabled Save on a component that was still invalid.
+                 */
+                if (hasFormValidationErrors["arguments"] !== hasError) {
                   setHasFormValidationErrors({
                     ...hasFormValidationErrors,
-                    id: hasError,
+                    arguments: hasError,
                   });
                 }
               }}
               fields={
                 component.metadata.arguments &&
-                component.metadata.arguments.map((arg: Argument) => {
+                orderedArguments.map((arg: Argument, argIndex: number) => {
                   const isWorkflowSelect: boolean =
                     arg.type === ComponentInputType.WorkflowSelect;
 
@@ -287,8 +388,24 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
                   const showVariableFooter: boolean =
                     !isWorkflowSelect && !useFieldPicker && !useCronPicker;
 
+                  const isAdvanced: boolean = isCollapsibleAdvanced(arg);
+
                   return {
                     title: `${arg.name}`,
+                    /*
+                     * The heading sits on the first advanced field, so the
+                     * disclosure reads as a labelled section rather than as a
+                     * run of extra inputs appearing out of nowhere.
+                     */
+                    sectionTitle:
+                      isAdvanced && argIndex === firstAdvancedArgumentIndex
+                        ? "Advanced"
+                        : undefined,
+                    showIf: isAdvanced
+                      ? (): boolean => {
+                          return showAdvanced;
+                        }
+                      : undefined,
                     footerElement: showVariableFooter ? (
                       <div className="text-gray-500">
                         <p className="text-sm">
@@ -323,12 +440,37 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
                     },
                     required: arg.required,
                     placeholder: arg.placeholder,
+                    /*
+                     * Some argument types are read back with JSON5 rather than
+                     * JSON, so the check has to be no stricter than the parser
+                     * that will actually see the value.
+                     */
+                    allowJSON5: isJSON5ToleratedInputType(arg.type),
                     ...baseField,
                   };
                 })
               }
             />
           )}
+
+        {collapsibleAdvancedArguments.length > 0 && (
+          <div className="mt-3">
+            <button
+              type="button"
+              aria-expanded={showAdvanced}
+              className="text-sm underline text-blue-500 hover:text-blue-600 cursor-pointer"
+              onClick={() => {
+                setShowAdvanced(!showAdvanced);
+              }}
+            >
+              {showAdvanced
+                ? "Hide advanced settings"
+                : `Show ${collapsibleAdvancedArguments.length} advanced setting${
+                    collapsibleAdvancedArguments.length === 1 ? "" : "s"
+                  }`}
+            </button>
+          </div>
+        )}
       </div>
       {showVariableModal && (
         <VariableModal

--- a/Common/UI/Components/Workflow/Component.tsx
+++ b/Common/UI/Components/Workflow/Component.tsx
@@ -372,35 +372,37 @@ const Node: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
           </div>
         )}
 
-      {/* Error indicator */}
+      {/* Error indicator — hover it to read what is actually wrong. */}
       {!props.data.isPreview && hasError && (
-        <div
-          style={{
-            position: "absolute",
-            top: "8px",
-            right: "8px",
-            zIndex: 10,
-            width: "22px",
-            height: "22px",
-            borderRadius: "50%",
-            backgroundColor:
-              "color-mix(in srgb, #ef4444 15%, var(--ou-surface-primary, #ffffff))",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            border: "1px solid rgb(248 113 113 / 45%)",
-          }}
-        >
-          <Icon
-            icon={IconProp.Alert}
+        <Tooltip text={props.data.error}>
+          <div
             style={{
-              color: "#ef4444",
-              width: "0.75rem",
-              height: "0.75rem",
+              position: "absolute",
+              top: "8px",
+              right: "8px",
+              zIndex: 10,
+              width: "22px",
+              height: "22px",
+              borderRadius: "50%",
+              backgroundColor:
+                "color-mix(in srgb, #ef4444 15%, var(--ou-surface-primary, #ffffff))",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              border: "1px solid rgb(248 113 113 / 45%)",
             }}
-            thick={ThickProp.Thick}
-          />
-        </div>
+          >
+            <Icon
+              icon={IconProp.Alert}
+              style={{
+                color: "#ef4444",
+                width: "0.75rem",
+                height: "0.75rem",
+              }}
+              thick={ThickProp.Thick}
+            />
+          </div>
+        </Tooltip>
       )}
 
       {/* Header bar with gradient */}

--- a/Common/UI/Components/Workflow/ComponentSettingsModal.tsx
+++ b/Common/UI/Components/Workflow/ComponentSettingsModal.tsx
@@ -188,14 +188,36 @@ const ComponentSettingsModal: FunctionComponent<ComponentProps> = (
       modalWidth={ModalWidth.Large}
       disableSubmitButton={hasErrors}
       leftFooterElement={
-        <Button
-          title="Delete"
-          icon={IconProp.Trash}
-          buttonStyle={ButtonStyleType.DANGER_OUTLINE}
-          onClick={() => {
-            setShowDeleteConfirmation(true);
-          }}
-        />
+        /*
+         * Say why Save is off. Form errors are only rendered under a field
+         * once it has been touched, so a component opened with a setting that
+         * was already invalid — a stored JSON value that does not parse, say —
+         * otherwise presents a dead button and no explanation anywhere.
+         */
+        hasErrors ? (
+          <div className="flex items-center gap-3">
+            <Button
+              title="Delete"
+              icon={IconProp.Trash}
+              buttonStyle={ButtonStyleType.DANGER_OUTLINE}
+              onClick={() => {
+                setShowDeleteConfirmation(true);
+              }}
+            />
+            <span className="text-sm text-red-600">
+              Some settings need fixing before this can be saved.
+            </span>
+          </div>
+        ) : (
+          <Button
+            title="Delete"
+            icon={IconProp.Trash}
+            buttonStyle={ButtonStyleType.DANGER_OUTLINE}
+            onClick={() => {
+              setShowDeleteConfirmation(true);
+            }}
+          />
+        )
       }
     >
       <>

--- a/Common/UI/Components/Workflow/GraphLint.ts
+++ b/Common/UI/Components/Workflow/GraphLint.ts
@@ -1,0 +1,591 @@
+/*
+ * Static checks over a workflow graph, run in the builder as the user edits.
+ *
+ * Every rule here corresponds to a way the runner (App/FeatureSet/Workflow/
+ * Services/RunWorkflow.ts) either throws at run time or — worse — carries on
+ * quietly with the wrong value. The point is to move those failures from "3am,
+ * in a log blob, after the trigger already fired" to "in the editor, before
+ * you save".
+ *
+ * Rules only fire on things that are knowable from the graph alone. Anything
+ * needing a network round trip (does this workflow variable exist?) is checked
+ * for shape but not for existence, because a false positive here puts a red
+ * badge on a workflow that runs perfectly.
+ */
+
+import Dictionary from "../../../Types/Dictionary";
+import { JSONObject, JSONValue } from "../../../Types/JSON";
+import {
+  Argument,
+  ComponentInputType,
+  ComponentType,
+  NodeDataProp,
+  NodeType,
+  ReturnValue,
+  isJSON5ToleratedInputType,
+} from "../../../Types/Workflow/Component";
+import {
+  ParsedReferencePath,
+  ReferenceRootType,
+  TemplateExpression,
+  TemplateExpressionKind,
+  checkJSONSyntax,
+  looksLikeReferencePath,
+  parseReferencePath,
+  parseTemplateExpressions,
+} from "../../../Types/Workflow/TemplateSyntax";
+
+export enum WorkflowLintSeverity {
+  /** The workflow will fail, or silently do the wrong thing, as written. */
+  Error = "Error",
+  /** Suspicious but survivable — e.g. a step that can never be reached. */
+  Warning = "Warning",
+}
+
+export enum WorkflowLintRule {
+  MissingRequiredArgument = "MissingRequiredArgument",
+  InvalidJSON = "InvalidJSON",
+  ReferenceHasWhitespace = "ReferenceHasWhitespace",
+  UnknownReferenceRoot = "UnknownReferenceRoot",
+  UnknownReferencedComponent = "UnknownReferencedComponent",
+  UnknownReferencedReturnValue = "UnknownReferencedReturnValue",
+  SelfReference = "SelfReference",
+  ForwardReference = "ForwardReference",
+  ReferenceToUnreachableComponent = "ReferenceToUnreachableComponent",
+  DuplicateComponentId = "DuplicateComponentId",
+  ComponentIdContainsDot = "ComponentIdContainsDot",
+  UnreachableComponent = "UnreachableComponent",
+  NoTrigger = "NoTrigger",
+}
+
+export interface WorkflowLintIssue {
+  rule: WorkflowLintRule;
+  severity: WorkflowLintSeverity;
+  /** The react-flow node id, or null when the issue is about the graph itself. */
+  nodeId: string | null;
+  /** The step's user-facing id ("api-get-1"), when the issue belongs to a step. */
+  componentId: string | null;
+  /** The argument the issue is about, when it is about one. */
+  argumentId: string | null;
+  /** Shown to the builder, verbatim. */
+  message: string;
+}
+
+export interface WorkflowLintResult {
+  issues: Array<WorkflowLintIssue>;
+  /**
+   * One combined message per react-flow node id, ready to drop into
+   * NodeDataProp.error so the canvas shows its (already implemented, until now
+   * never populated) red badge.
+   */
+  errorsByNodeId: Dictionary<string>;
+  errorCount: number;
+  warningCount: number;
+}
+
+/** Minimal structural view of a react-flow node — keeps this file testable. */
+export interface LintGraphNode {
+  id: string;
+  data: NodeDataProp;
+}
+
+/** Minimal structural view of a react-flow edge. */
+export interface LintGraphEdge {
+  source: string;
+  target: string;
+}
+
+/*
+ * Argument types the builder stores as a JSON document in a code editor. A
+ * malformed one throws in RunWorkflow.getComponentArguments (for JSON / Query /
+ * Select) or in the component itself (JSONFunctions.parse in
+ * CreateOneBaseModel, ApiComponentUtils.sanitizeArgs, and friends), so all of
+ * them are worth checking up front.
+ */
+const JSON_DOCUMENT_INPUT_TYPES: Array<ComponentInputType> = [
+  ComponentInputType.JSON,
+  ComponentInputType.JSONArray,
+  ComponentInputType.Query,
+  ComponentInputType.Select,
+  ComponentInputType.BaseModel,
+  ComponentInputType.BaseModelArray,
+  ComponentInputType.StringDictionary,
+];
+
+type IsEmptyArgumentValueFunction = (value: JSONValue | undefined) => boolean;
+
+/*
+ * `false` and `0` are values a builder deliberately set — only absence and the
+ * empty box count as missing. An empty object/array counts as missing too: the
+ * Dictionary editor writes `{}` for a field nobody filled in.
+ */
+const isEmptyArgumentValue: IsEmptyArgumentValueFunction = (
+  value: JSONValue | undefined,
+): boolean => {
+  if (value === undefined || value === null) {
+    return true;
+  }
+
+  if (typeof value === "string") {
+    return value.trim() === "";
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+
+  if (typeof value === "object") {
+    return Object.keys(value as JSONObject).length === 0;
+  }
+
+  return false;
+};
+
+type IsRealNodeFunction = (node: LintGraphNode) => boolean;
+
+const isRealNode: IsRealNodeFunction = (node: LintGraphNode): boolean => {
+  return Boolean(
+    node.data &&
+      node.data.nodeType !== NodeType.PlaceholderNode &&
+      node.data.metadata,
+  );
+};
+
+type BuildReachableSetFunction = (
+  startNodeIds: Array<string>,
+  adjacency: Dictionary<Array<string>>,
+) => Set<string>;
+
+/** Every node id reachable by following edges forward from `startNodeIds`. */
+const buildReachableSet: BuildReachableSetFunction = (
+  startNodeIds: Array<string>,
+  adjacency: Dictionary<Array<string>>,
+): Set<string> => {
+  const reachable: Set<string> = new Set<string>();
+  const queue: Array<string> = [...startNodeIds];
+
+  while (queue.length > 0) {
+    const current: string = queue.shift() as string;
+
+    if (reachable.has(current)) {
+      continue;
+    }
+
+    reachable.add(current);
+
+    for (const next of adjacency[current] || []) {
+      if (!reachable.has(next)) {
+        queue.push(next);
+      }
+    }
+  }
+
+  return reachable;
+};
+
+type CollectArgumentStringsFunction = (value: JSONValue) => Array<string>;
+
+/*
+ * A reference can hide anywhere a string can: the Dictionary editor stores an
+ * object whose values are strings, and imported graphs can hold arrays. Walk
+ * the whole value so {{...}} inside a header value is linted too.
+ */
+const collectArgumentStrings: CollectArgumentStringsFunction = (
+  value: JSONValue,
+): Array<string> => {
+  if (typeof value === "string") {
+    return [value];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item: JSONValue) => {
+      return collectArgumentStrings(item);
+    });
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value as JSONObject).flatMap((item: JSONValue) => {
+      return collectArgumentStrings(item as JSONValue);
+    });
+  }
+
+  return [];
+};
+
+export type LintWorkflowGraphFunction = (graph: {
+  nodes: Array<LintGraphNode>;
+  edges: Array<LintGraphEdge>;
+}) => WorkflowLintResult;
+
+/**
+ * Check a workflow graph and report everything wrong with it.
+ */
+export const lintWorkflowGraph: LintWorkflowGraphFunction = (graph: {
+  nodes: Array<LintGraphNode>;
+  edges: Array<LintGraphEdge>;
+}): WorkflowLintResult => {
+  const issues: Array<WorkflowLintIssue> = [];
+  const nodes: Array<LintGraphNode> = (graph.nodes || []).filter(isRealNode);
+  const edges: Array<LintGraphEdge> = graph.edges || [];
+
+  type AddIssueFunction = (issue: WorkflowLintIssue) => void;
+
+  const addIssue: AddIssueFunction = (issue: WorkflowLintIssue): void => {
+    issues.push(issue);
+  };
+
+  /* ---- indexes ---------------------------------------------------------- */
+
+  // The runner keys its storage map on node.data.id, not the react-flow id.
+  const nodesByComponentId: Dictionary<LintGraphNode> = {};
+  const componentIdCounts: Dictionary<number> = {};
+
+  for (const node of nodes) {
+    const componentId: string = node.data.id;
+
+    if (!componentId) {
+      continue;
+    }
+
+    componentIdCounts[componentId] = (componentIdCounts[componentId] || 0) + 1;
+
+    if (!nodesByComponentId[componentId]) {
+      nodesByComponentId[componentId] = node;
+    }
+  }
+
+  const adjacency: Dictionary<Array<string>> = {};
+
+  for (const edge of edges) {
+    if (!adjacency[edge.source]) {
+      adjacency[edge.source] = [];
+    }
+    adjacency[edge.source]?.push(edge.target);
+  }
+
+  const triggerNodes: Array<LintGraphNode> = nodes.filter(
+    (node: LintGraphNode) => {
+      return node.data.componentType === ComponentType.Trigger;
+    },
+  );
+
+  const reachableFromTrigger: Set<string> = buildReachableSet(
+    triggerNodes.map((node: LintGraphNode) => {
+      return node.id;
+    }),
+    adjacency,
+  );
+
+  /*
+   * Strict descendants of a node, computed at most once per node — the
+   * reference rules ask for this per argument, and recomputing a traversal
+   * inside that loop makes linting quadratic on graphs that are already wide.
+   */
+  const descendantCache: Dictionary<Set<string>> = {};
+
+  type GetDescendantsFunction = (nodeId: string) => Set<string>;
+
+  const getDescendants: GetDescendantsFunction = (
+    nodeId: string,
+  ): Set<string> => {
+    let descendants: Set<string> | undefined = descendantCache[nodeId];
+
+    if (!descendants) {
+      descendants = buildReachableSet(adjacency[nodeId] || [], adjacency);
+      descendantCache[nodeId] = descendants;
+    }
+
+    return descendants;
+  };
+
+  /* ---- graph-wide rules -------------------------------------------------- */
+
+  if (nodes.length > 0 && triggerNodes.length === 0) {
+    addIssue({
+      rule: WorkflowLintRule.NoTrigger,
+      severity: WorkflowLintSeverity.Error,
+      nodeId: null,
+      componentId: null,
+      argumentId: null,
+      message:
+        "This workflow has no trigger, so it can never start. Add a trigger and connect it to the first step.",
+    });
+  }
+
+  /* ---- per-node rules ---------------------------------------------------- */
+
+  for (const node of nodes) {
+    const data: NodeDataProp = node.data;
+    const componentId: string = data.id;
+    const argumentValues: JSONObject = (data.arguments as JSONObject) || {};
+
+    type AddNodeIssueFunction = (params: {
+      rule: WorkflowLintRule;
+      severity: WorkflowLintSeverity;
+      argumentId?: string | undefined;
+      message: string;
+    }) => void;
+
+    const addNodeIssue: AddNodeIssueFunction = (params: {
+      rule: WorkflowLintRule;
+      severity: WorkflowLintSeverity;
+      argumentId?: string | undefined;
+      message: string;
+    }): void => {
+      addIssue({
+        rule: params.rule,
+        severity: params.severity,
+        nodeId: node.id,
+        componentId: componentId || null,
+        argumentId: params.argumentId || null,
+        message: params.message,
+      });
+    };
+
+    // -- identity ---------------------------------------------------------
+
+    if (componentId && (componentIdCounts[componentId] || 0) > 1) {
+      addNodeIssue({
+        rule: WorkflowLintRule.DuplicateComponentId,
+        severity: WorkflowLintSeverity.Error,
+        message: `More than one step has the id "${componentId}". Ids must be unique — otherwise the steps overwrite each other's results and any reference to "${componentId}" is ambiguous.`,
+      });
+    }
+
+    if (componentId && componentId.includes(".")) {
+      addNodeIssue({
+        rule: WorkflowLintRule.ComponentIdContainsDot,
+        severity: WorkflowLintSeverity.Error,
+        message: `The id "${componentId}" contains a dot. References are split on dots, so no other step can read this one's results. Use dashes instead.`,
+      });
+    }
+
+    // -- reachability ------------------------------------------------------
+
+    if (
+      data.componentType !== ComponentType.Trigger &&
+      triggerNodes.length > 0 &&
+      !reachableFromTrigger.has(node.id)
+    ) {
+      addNodeIssue({
+        rule: WorkflowLintRule.UnreachableComponent,
+        severity: WorkflowLintSeverity.Warning,
+        message:
+          "Nothing connects to this step from the trigger, so it will never run.",
+      });
+    }
+
+    // -- arguments ---------------------------------------------------------
+
+    const argumentMetadata: Array<Argument> = data.metadata.arguments || [];
+
+    for (const argument of argumentMetadata) {
+      const value: JSONValue | undefined = argumentValues[argument.id];
+
+      if (argument.required && isEmptyArgumentValue(value)) {
+        addNodeIssue({
+          rule: WorkflowLintRule.MissingRequiredArgument,
+          severity: WorkflowLintSeverity.Error,
+          argumentId: argument.id,
+          message: `"${argument.name}" is required but empty.`,
+        });
+        continue;
+      }
+
+      if (isEmptyArgumentValue(value)) {
+        continue;
+      }
+
+      if (JSON_DOCUMENT_INPUT_TYPES.includes(argument.type)) {
+        const jsonCheck: {
+          isValid: boolean;
+          errorMessage: string | null;
+        } = checkJSONSyntax(value, {
+          allowJSON5: isJSON5ToleratedInputType(argument.type),
+        });
+
+        if (!jsonCheck.isValid) {
+          addNodeIssue({
+            rule: WorkflowLintRule.InvalidJSON,
+            severity: WorkflowLintSeverity.Error,
+            argumentId: argument.id,
+            message: `"${argument.name}" is not valid JSON. ${jsonCheck.errorMessage}`,
+          });
+        }
+      }
+
+      // -- references ------------------------------------------------------
+
+      for (const text of collectArgumentStrings(value as JSONValue)) {
+        const expressions: Array<TemplateExpression> =
+          parseTemplateExpressions(text);
+
+        for (const expression of expressions) {
+          if (expression.kind !== TemplateExpressionKind.Reference) {
+            continue;
+          }
+
+          /*
+           * Inside a loop, VMAPI resolves against the current array element
+           * before the storage map, so a bare {{status}} is correct there and
+           * cannot be checked from here.
+           */
+          if (expression.isInsideEachBlock) {
+            continue;
+          }
+
+          /*
+           * At the top level the runtime looks the path up exactly as written
+           * (VMAPI.replaceValueInPlace passes the raw capture to deepFind), so
+           * a stray space makes the reference resolve to nothing and the braces
+           * are shipped as literal text. Nothing about the rendered workflow
+           * hints at it, which makes this worth its own message rather than
+           * folding it into "unknown reference".
+           */
+          /*
+           * Every argument is templated, including the JavaScript component's
+           * source, and JavaScript can legitimately produce a {{...}} match on
+           * one line. Only complain about captures that were plausibly meant
+           * to be references.
+           */
+          if (!looksLikeReferencePath(expression.innerRaw)) {
+            continue;
+          }
+
+          if (expression.innerRaw !== expression.inner) {
+            addNodeIssue({
+              rule: WorkflowLintRule.ReferenceHasWhitespace,
+              severity: WorkflowLintSeverity.Error,
+              argumentId: argument.id,
+              message: `"${argument.name}" contains ${expression.raw}, which has a space inside the braces. Spaces are not trimmed here, so this resolves to nothing — write it as {{${expression.inner}}}.`,
+            });
+            continue;
+          }
+
+          const parsed: ParsedReferencePath = parseReferencePath(
+            expression.inner,
+          );
+
+          if (parsed.rootType === ReferenceRootType.Unknown) {
+            addNodeIssue({
+              rule: WorkflowLintRule.UnknownReferenceRoot,
+              severity: WorkflowLintSeverity.Error,
+              argumentId: argument.id,
+              message: `"${argument.name}" refers to ${expression.raw}, but ${parsed.reason}. Nothing will be substituted and the text will be sent as-is.`,
+            });
+            continue;
+          }
+
+          if (parsed.rootType !== ReferenceRootType.ComponentReturnValue) {
+            // A variable reference — well-formed. Existence needs the API.
+            continue;
+          }
+
+          const referencedComponentId: string = parsed.componentId as string;
+          const referencedNode: LintGraphNode | undefined =
+            nodesByComponentId[referencedComponentId];
+
+          if (!referencedNode) {
+            addNodeIssue({
+              rule: WorkflowLintRule.UnknownReferencedComponent,
+              severity: WorkflowLintSeverity.Error,
+              argumentId: argument.id,
+              message: `"${argument.name}" refers to a step called "${referencedComponentId}", but no step in this workflow has that id.`,
+            });
+            continue;
+          }
+
+          const returnValueId: string = parsed.returnValueId as string;
+          const returnValues: Array<ReturnValue> =
+            referencedNode.data.metadata.returnValues || [];
+
+          const hasReturnValue: boolean = returnValues.some(
+            (returnValue: ReturnValue) => {
+              return returnValue.id === returnValueId;
+            },
+          );
+
+          if (!hasReturnValue) {
+            addNodeIssue({
+              rule: WorkflowLintRule.UnknownReferencedReturnValue,
+              severity: WorkflowLintSeverity.Error,
+              argumentId: argument.id,
+              message: `"${argument.name}" reads "${returnValueId}" from step "${referencedComponentId}", but that step does not return anything by that name.`,
+            });
+            continue;
+          }
+
+          if (referencedNode.id === node.id) {
+            addNodeIssue({
+              rule: WorkflowLintRule.SelfReference,
+              severity: WorkflowLintSeverity.Error,
+              argumentId: argument.id,
+              message: `"${argument.name}" refers to this step's own results, which do not exist yet while its settings are being read.`,
+            });
+            continue;
+          }
+
+          /*
+           * A step that is downstream of this one has definitively not run
+           * when this step's arguments are resolved, so the reference is
+           * always empty. (The converse is not true — the runner's queue is
+           * FIFO across branches, so a step on a parallel branch may well have
+           * run. Only the unambiguous direction is reported.)
+           */
+          if (getDescendants(node.id).has(referencedNode.id)) {
+            addNodeIssue({
+              rule: WorkflowLintRule.ForwardReference,
+              severity: WorkflowLintSeverity.Error,
+              argumentId: argument.id,
+              message: `"${argument.name}" reads results from "${referencedComponentId}", but that step runs after this one, so it has no results yet.`,
+            });
+            continue;
+          }
+
+          if (
+            triggerNodes.length > 0 &&
+            !reachableFromTrigger.has(referencedNode.id)
+          ) {
+            addNodeIssue({
+              rule: WorkflowLintRule.ReferenceToUnreachableComponent,
+              severity: WorkflowLintSeverity.Warning,
+              argumentId: argument.id,
+              message: `"${argument.name}" reads results from "${referencedComponentId}", which is not connected to the trigger and so never runs.`,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  /* ---- roll up ----------------------------------------------------------- */
+
+  const errorsByNodeId: Dictionary<string> = {};
+  let errorCount: number = 0;
+  let warningCount: number = 0;
+
+  for (const issue of issues) {
+    if (issue.severity === WorkflowLintSeverity.Error) {
+      errorCount++;
+    } else {
+      warningCount++;
+    }
+
+    if (!issue.nodeId) {
+      continue;
+    }
+
+    errorsByNodeId[issue.nodeId] = errorsByNodeId[issue.nodeId]
+      ? `${errorsByNodeId[issue.nodeId]}\n${issue.message}`
+      : issue.message;
+  }
+
+  return {
+    issues: issues,
+    errorsByNodeId: errorsByNodeId,
+    errorCount: errorCount,
+    warningCount: warningCount,
+  };
+};
+
+export default lintWorkflowGraph;

--- a/Common/UI/Components/Workflow/RunForm.tsx
+++ b/Common/UI/Components/Workflow/RunForm.tsx
@@ -1,9 +1,16 @@
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import BasicForm, { FormProps } from "../Forms/BasicForm";
 import FormValues from "../Forms/Types/FormValues";
-import { componentInputTypeToFormFieldType } from "./Utils";
+import {
+  componentInputTypeToFormFieldType,
+  parseStringDictionaryValue,
+} from "./Utils";
 import { JSONObject } from "../../../Types/JSON";
-import { Argument, NodeDataProp } from "../../../Types/Workflow/Component";
+import {
+  Argument,
+  ComponentInputType,
+  NodeDataProp,
+} from "../../../Types/Workflow/Component";
 import React, {
   FunctionComponent,
   ReactElement,
@@ -34,6 +41,28 @@ const RunForm: FunctionComponent<ComponentProps> = (
     props.onFormChange(component);
   }, [component]);
 
+  /*
+   * Same hydration ArgumentsForm does: a StringDictionary renders as key/value
+   * rows, and those need a real object rather than the JSON string older
+   * workflows stored. The field type is chosen from the same value, so the two
+   * cannot disagree about which editor is on screen.
+   */
+  const formInitialValues: JSONObject = { ...(component.arguments || {}) };
+
+  for (const argument of component.metadata.runWorkflowManuallyArguments || []) {
+    if (argument.type !== ComponentInputType.StringDictionary) {
+      continue;
+    }
+
+    const parsed: JSONObject | null = parseStringDictionaryValue(
+      formInitialValues[argument.id],
+    );
+
+    if (parsed !== null) {
+      formInitialValues[argument.id] = parsed;
+    }
+  }
+
   return (
     <div className="mb-3 mt-3">
       <div className="mt-5 mb-5">
@@ -57,7 +86,7 @@ const RunForm: FunctionComponent<ComponentProps> = (
               hideSubmitButton={true}
               ref={formRef}
               initialValues={{
-                ...(component.arguments || {}),
+                ...formInitialValues,
               }}
               onChange={(values: FormValues<JSONObject>) => {
                 setComponent({
@@ -86,12 +115,16 @@ const RunForm: FunctionComponent<ComponentProps> = (
                       },
                       required: argument.required,
                       placeholder: argument.placeholder,
+                      /*
+                       * Decided from the value the form actually renders.
+                       * This used to read component.returnValues, which is not
+                       * where RunForm writes — so for a field holding a value
+                       * the row editor cannot represent, the editor on screen
+                       * and the value behind it could disagree.
+                       */
                       ...componentInputTypeToFormFieldType(
                         argument.type,
-                        component.returnValues &&
-                          component.returnValues[argument.id]
-                          ? component.returnValues[argument.id]
-                          : null,
+                        formInitialValues[argument.id] ?? null,
                       ),
                     };
                   },

--- a/Common/UI/Components/Workflow/Utils.ts
+++ b/Common/UI/Components/Workflow/Utils.ts
@@ -1,6 +1,8 @@
 import { DropdownOption } from "../Dropdown/Dropdown";
 import FormFieldSchemaType from "../Forms/Types/FormFieldSchemaType";
 import IconProp from "../../../Types/Icon/IconProp";
+import { JSONObject } from "../../../Types/JSON";
+import JSONFunctions from "../../../Types/JSONFunctions";
 import ComponentMetadata, {
   ComponentCategory,
   ComponentInputType,
@@ -43,6 +45,81 @@ export const loadComponentsAndCategories: LoadComponentsAndCategoriesFunction =
 
     return { components: initComponents, categories: initCategories };
   };
+
+export type ParseStringDictionaryValueFunction = (
+  argValue: unknown,
+) => JSONObject | null;
+
+/**
+ * The key/value view of a StringDictionary argument, or null when the value
+ * cannot be shown that way and belongs in the JSON editor instead.
+ *
+ * Editable as rows:
+ *   - nothing yet (a new component)
+ *   - an object of primitives, whether stored as an object (written by the row
+ *     editor) or as a JSON string (written by the old JSON editor, and by
+ *     every workflow that already exists)
+ *
+ * Not editable as rows, so left in the JSON editor:
+ *   - a whole-field template such as {{local.components.x.returnValues.headers}},
+ *     which substitutes an entire object at run time and is not JSON as written
+ *   - text that does not parse, which is exactly the case where the builder
+ *     most needs to see and fix what they typed
+ *   - nested objects or arrays, which the row editor cannot represent and would
+ *     therefore quietly discard
+ */
+export const parseStringDictionaryValue: ParseStringDictionaryValueFunction = (
+  argValue: unknown,
+): JSONObject | null => {
+  if (argValue === null || argValue === undefined || argValue === "") {
+    return {};
+  }
+
+  let candidate: unknown = argValue;
+
+  if (typeof candidate === "string") {
+    if (candidate.trim() === "") {
+      return {};
+    }
+
+    /*
+     * JSONFunctions.parse is JSON5, which is what the components themselves use
+     * on these values (ApiComponentUtils.sanitizeArgs). Parsing more strictly
+     * here than the runtime does would push a value that works today into the
+     * JSON editor for no reason.
+     */
+    try {
+      candidate = JSONFunctions.parse(candidate);
+    } catch {
+      return null;
+    }
+  }
+
+  if (
+    typeof candidate !== "object" ||
+    candidate === null ||
+    Array.isArray(candidate)
+  ) {
+    return null;
+  }
+
+  const entries: JSONObject = candidate as JSONObject;
+
+  for (const key of Object.keys(entries)) {
+    const value: unknown = entries[key];
+
+    const isPrimitive: boolean =
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean";
+
+    if (!isPrimitive) {
+      return null;
+    }
+  }
+
+  return entries;
+};
 
 type ComponentInputTypeToFormFieldTypeFunction = (
   componentInputType: ComponentInputType,
@@ -110,9 +187,24 @@ export const componentInputTypeToFormFieldType: ComponentInputTypeToFormFieldTyp
       };
     }
 
+    /*
+     * A dictionary of strings is a list of key/value pairs — request headers,
+     * query params — and asking someone to hand-write the braces and commas
+     * for that is where a good share of workflow JSON mistakes come from. Give
+     * it the key/value row editor instead.
+     *
+     * Values written before this change are JSON strings, and a value can also
+     * be something the row editor cannot represent (a whole-field
+     * {{...}} substitution, or nested objects). parseStringDictionaryValue
+     * decides; anything it cannot represent stays in the JSON editor, so no
+     * existing value is ever silently dropped on the floor.
+     */
     if (componentInputType === ComponentInputType.StringDictionary) {
       return {
-        fieldType: FormFieldSchemaType.JSON,
+        fieldType:
+          parseStringDictionaryValue(argValue) === null
+            ? FormFieldSchemaType.JSON
+            : FormFieldSchemaType.Dictionary,
       };
     }
 

--- a/Common/UI/Components/Workflow/Workflow.tsx
+++ b/Common/UI/Components/Workflow/Workflow.tsx
@@ -2,6 +2,12 @@ import WorkflowComponent from "./Component";
 import ComponentSettingsModal from "./ComponentSettingsModal";
 import ComponentsModal from "./ComponentsModal";
 import RunModal from "./RunModal";
+import {
+  LintGraphEdge,
+  LintGraphNode,
+  WorkflowLintResult,
+  lintWorkflowGraph,
+} from "./GraphLint";
 import { loadComponentsAndCategories } from "./Utils";
 import { VoidFunction } from "../../../Types/FunctionTypes";
 import IconProp from "../../../Types/Icon/IconProp";
@@ -17,6 +23,7 @@ import React, {
   FunctionComponent,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -112,6 +119,11 @@ export interface ComponentProps {
   onRunModalUpdate: (isModalShown: boolean) => void;
   onRun: (trigger: NodeDataProp) => void;
   webhookSecretKey?: string | undefined;
+  /**
+   * Called whenever the static checks over the graph are recomputed, so the
+   * page around the canvas can show a count and decide what to do about it.
+   */
+  onLintResultChange?: ((result: WorkflowLintResult) => void) | undefined;
 }
 
 const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
@@ -243,6 +255,45 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
       props.onWorkflowUpdated(nodes, edges);
     }
   }, [nodes, edges]);
+
+  /*
+   * Static checks over the graph, recomputed as it is edited.
+   *
+   * The results are deliberately NOT written back into node state. Node data is
+   * what gets persisted (Builder.saveGraph sends node.data verbatim, minus
+   * metadata), so storing lint output there would save today's warnings into
+   * the workflow itself and show them again on reload even once they were
+   * fixed. Deriving a separate array for rendering keeps the saved graph clean.
+   */
+  const lintResult: WorkflowLintResult = useMemo(() => {
+    return lintWorkflowGraph({
+      nodes: nodes as unknown as Array<LintGraphNode>,
+      edges: edges as unknown as Array<LintGraphEdge>,
+    });
+  }, [nodes, edges]);
+
+  useEffect(() => {
+    props.onLintResultChange?.(lintResult);
+  }, [lintResult]);
+
+  const nodesToRender: Array<Node> = useMemo(() => {
+    return nodes.map((node: Node) => {
+      const error: string = lintResult.errorsByNodeId[node.id] || "";
+
+      // Same object when there is nothing to say, so react-flow can bail early.
+      if (!error && !node.data.error) {
+        return node;
+      }
+
+      return {
+        ...node,
+        data: {
+          ...node.data,
+          error: error,
+        },
+      };
+    });
+  }, [nodes, lintResult]);
 
   const proOptions: ProOptions = { hideAttribution: true };
 
@@ -467,7 +518,7 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
         `}
       </style>
       <ReactFlow
-        nodes={nodes}
+        nodes={nodesToRender}
         edges={edges}
         fitView={true}
         onEdgeClick={() => {
@@ -584,12 +635,22 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
             setShowComponentSettingsModal(false);
           }}
           onSave={(componentData: NodeDataProp) => {
-            // Update the node.
+            /*
+             * The settings modal was opened from the rendered node, so what
+             * comes back carries whatever lint message was on it. Clear that
+             * before it reaches node state — state is what gets saved, and a
+             * message about today's mistake has no business being written into
+             * the workflow.
+             */
+            const dataToStore: NodeDataProp = {
+              ...componentData,
+              error: "",
+            };
 
             setNodes((nds: Array<Node>) => {
               return nds.map((n: Node) => {
-                if (n.data.internalId === componentData.internalId) {
-                  n.data = componentData;
+                if (n.data.internalId === dataToStore.internalId) {
+                  n.data = dataToStore;
                 }
 
                 return n;


### PR DESCRIPTION
## Why

The workflow builder let you save a workflow that could not possibly work, and said nothing about it.

- **Malformed JSON saved cleanly.** `Validation.ts` had per-type checks for Email, Port, URL, Hostname, Route, Phone, Color and Domain — and none for JSON. A trailing comma surfaced only when the runner parsed it: during a real run, at whatever hour the trigger fired, as `Invalid JSON provided for argument request-body` in a `\n`-joined text blob.
- **A mistyped reference failed silently and reported success.** `VMAPI.replaceValueInPlace` skips a reference it cannot resolve and leaves the literal text in place. `{{local.componets.api-get-1.returnValues.body}}` (note the typo) went out verbatim in the request body, and the run finished green.
- **The canvas already had an error state that nothing ever set.** `NodeDataProp.error` is in the type and `Component.tsx` draws a red border and badge from it — `grep` for anything assigning it returned nothing.
- **Request headers were a JSON textarea**, though `FormFieldSchemaType.Dictionary` and a key/value row editor already existed.
- **`Argument.isAdvanced` was declared and set** on the API and AI components, and `ArgumentsForm` never read it, so every knob had the same visual weight as the URL.

## What changed

**1. JSON fields are validated in the form.** `Validation.validateJSONSyntax` runs on `FormFieldSchemaType.JSON`. It is fed the **raw** value, not the stringified one — seven model-backed forms elsewhere (Session Replay, Data Sources, LLM Providers, Auto Remediation) bind real arrays and objects to JSON fields, and `String(anObject)` is `"[object Object]"`, which would have failed on every open.

It tolerates the template syntax, which is the part that made a naive `JSON.parse` unshippable. `{"retries": {{local.variables.count}}}` is not JSON as written but is JSON by the time it is parsed, so placeholders are masked before the check, and anything containing a `{{#each}}` loop is not judged at all.

**2. `StringDictionary` renders as key/value rows.** Headers and query params are key/value pairs; typing braces for them is not a skill worth requiring. Existing values are JSON strings, so `parseStringDictionaryValue` hydrates those into objects — using JSON5, matching the parser the components themselves use. Anything the row editor cannot represent (a whole-field `{{...}}` substitution, nested objects, text that does not parse) keeps the JSON editor, so no value is ever silently dropped. The field-type decision and the hydration come from the same function, so they cannot disagree.

**3. `isAdvanced` arguments collapse behind a disclosure.** A required argument is never collapsed — `BasicForm` skips validation for a field hidden by `showIf`, so hiding a required one would let an incomplete step save. The disclosure opens on load if anything inside it is already set.

**4. Unresolved references are called out.** The builder flags them before save; the runner logs a warning naming each one. The runtime check compares the argument before and after substitution rather than scanning the output, so a resolved value that happens to contain braces is not reported.

**5. A graph linter feeds the badge that was already there.** Missing required arguments, malformed JSON, unknown reference roots, unknown steps and return values, self-references, forward references, duplicate ids, ids containing a dot, and unreachable steps. The canvas shows a per-node badge (hover for the message) and the toolbar shows a count that opens the full list.

Lint output is derived at render and never written into node state — node data is what gets persisted, so storing it there would save today's warnings into the workflow and show them again after they were fixed. Three separate leak paths are closed: the settings-modal write-back, `saveGraph`, and `loadGraph`.

## Fixes found on the way

These are small, and each one is either required for the above to be correct or is a footgun the above makes more likely to be hit.

- **`VMAPI` corrupted objects containing templates.** When `replaceValueInPlace` stringifies an object itself, every placeholder is inside a JSON string literal, so a resolved value containing a quote or newline broke the `JSON.parse` on the way back out and the caller silently got a corrupted **string** where it asked for an object — which then spreads into per-character HTTP headers. Escaping now follows `didStringify`, which is narrower and safer than widening the caller's `isJSON` flag (that would change how placeholders behave in hand-written Query and Select documents).
- **`serializeValueForJSON` never escaped backslashes.** It handled `"`, `\t`, `\n`, `\r`, `\b` and `\f` but not `\` itself, so a value like `C:\Users` or `\d+` produced an invalid escape sequence in the surrounding document and the following `JSON.parse` threw — surfacing as `Invalid JSON provided for argument`. Found by a test written for the quote case. Escaped first, so it does not double-escape the sequences the other replacements introduce. Note this changes one accident: a value whose literal text was the two characters `\` and `n` previously round-tripped into a real newline, and now round-trips into `\n`, which is what it says.
- **`$` in a resolved value rewrote itself.** `String.replace` treats `$&`, `` $` ``, `$'` and `$1` in the *replacement* as patterns, so a variable worth `"A$&B"` rendered as `"A{{v}}B"`. Now a function replacement.
- **`items[last]` against a missing key threw.** `current[arrayKey].length` was unguarded, so it raised a `TypeError` out of `deepFind` and killed the whole run — the one resolution failure in there that was not silent. Now returns `undefined` like every other miss.
- **`request-headers` is marked `isSensitive`** on all five API components. A pasted bearer token was written verbatim into the `WorkflowLog`; only values sourced from a variable marked secret were ever scrubbed. A friendly key/value grid actively invites pasting one.
- **Header values are coerced to strings** and non-objects rejected in `sanitizeArgs`. The grid can emit numbers and booleans, and every consumer blind-casts to `Dictionary<string>` before spreading into the request; an array spread into per-index junk headers rather than failing.
- **`ArgumentsForm` and the Identifier field both reported validation errors under the key `id`**, so typing in the Identifier box cleared an outstanding argument error and re-enabled Save on a still-invalid component.
- **The disabled Save button now says why.** Form errors only render under a field once it has been touched, so a component opened with an already-invalid stored value presented a dead button and no explanation anywhere.
- **Docs corrected.** `variables.md` said an unresolved reference becomes an empty string. It does not — the braces are passed through. The distinction is the whole user-facing failure mode.

## Not in scope

`RunModal` normalizes `component.returnValues` while `RunForm` writes `component.arguments` and `Builder` sends `component.arguments`, so that JSON-parse loop is dead code on the manual-run path. Left alone deliberately; it wants its own change.

## Tests

Six new suites, 150+ cases, weighted toward the false positives that would make this unshippable — a template standing in for a bare JSON value, a template as an object key, a `{{#each}}` body, JavaScript that happens to contain `{{`, a step on a parallel branch whose order is genuinely undecidable, and JSON5 in the arguments that are read with JSON5.

| Suite | Covers |
|---|---|
| `Common/Tests/Types/Workflow/TemplateSyntax.test.ts` | expression parsing, loop scoping, masking, JSON checking, reference-path grammar |
| `Common/Tests/UI/Components/Workflow/GraphLint.test.ts` | every lint rule, plus the cases each rule must stay quiet about |
| `Common/Tests/UI/Components/Workflow/Utils.test.ts` | dictionary hydration and the field-type decision, asserted to agree |
| `Common/Tests/UI/Components/Forms/ValidationJSON.test.ts` | the JSON validator alone and through `Validation.validate` |
| `Common/Tests/Server/Utils/VM/VMAPISubstitution.test.ts` | object escaping, `$` patterns, `[last]` |
| `Common/Tests/Server/Types/Workflow/Components/ApiComponentHeaders.test.ts` | header shapes, coercion, the sensitive flag |
| `App/Tests/FeatureSet/Workflow/GetComponentArguments.test.ts` | both header shapes end to end, and the unresolved-reference warning |
