### PR TITLE
feat(workflow): row editors for database arguments, and run feedback

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Workflow/View/Builder.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Workflow/View/Builder.tsx
@@ -6,6 +6,16 @@ import IconProp from "Common/Types/Icon/IconProp";
 import { JSONObject } from "Common/Types/JSON";
 import JSONFunctions from "Common/Types/JSONFunctions";
 import ObjectID from "Common/Types/ObjectID";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import WorkflowStatus from "Common/Types/Workflow/WorkflowStatus";
+import WorkflowLog from "Common/Models/DatabaseModels/WorkflowLog";
+import {
+  RUN_WATCH_POLL_INTERVAL_MS,
+  RunWatchDecision,
+  WatchedRun,
+  decideRunWatch,
+  isFailedRunStatus,
+} from "Common/UI/Components/Workflow/RunStatusWatcher";
 import ComponentMetadata, {
   ComponentCategory,
   ComponentType,
@@ -28,13 +38,15 @@ import Workflow, {
 } from "Common/UI/Components/Workflow/Workflow";
 import { WORKFLOW_URL } from "Common/UI/Config";
 import API from "Common/UI/Utils/API/API";
-import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import Navigation from "Common/UI/Utils/Navigation";
 import WorkflowModel from "Common/Models/DatabaseModels/Workflow";
 import React, {
   Fragment,
   FunctionComponent,
   ReactElement,
+  useEffect,
+  useRef,
   useState,
 } from "react";
 import { Edge, Node } from "reactflow";
@@ -78,9 +90,6 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
   const [error, setError] = useState<string>("");
   const [webhookSecretKey, setWebhookSecretKey] = useState<string>("");
 
-  const [showRunSuccessConfirmation, setShowRunSuccessConfirmation] =
-    useState<boolean>(false);
-
   const [showComponentPickerModal, setShowComponentPickerModal] =
     useState<boolean>(false);
 
@@ -88,6 +97,121 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
 
   const [lintResult, setLintResult] = useState<WorkflowLintResult | null>(null);
   const [showIssuesModal, setShowIssuesModal] = useState<boolean>(false);
+
+  /*
+   * The run the builder started, followed until it settles. See
+   * RunStatusWatcher for why this is a poll rather than something the run
+   * endpoint hands back.
+   */
+  const [runWatchMessage, setRunWatchMessage] = useState<string | null>(null);
+  const [runWatchFailed, setRunWatchFailed] = useState<boolean>(false);
+  const runWatchTimer: React.MutableRefObject<ReturnType<
+    typeof setTimeout
+  > | null> = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /*
+   * Runs that already existed when the watch started. The manual-run endpoint
+   * does not return a log id (RunWorkflow creates the WorkflowLog when a
+   * worker picks the job up), so the newest run is only *this* run once its id
+   * differs from the newest one that existed beforehand.
+   */
+  const runIdBeforeTrigger: React.MutableRefObject<string | null> = useRef<
+    string | null
+  >(null);
+
+  type FetchLatestRunFunction = () => Promise<WatchedRun | null>;
+
+  const fetchLatestRun: FetchLatestRunFunction =
+    async (): Promise<WatchedRun | null> => {
+      const result: ListResult<WorkflowLog> =
+        await ModelAPI.getList<WorkflowLog>({
+          modelType: WorkflowLog,
+          query: { workflowId: modelId },
+          limit: 1,
+          skip: 0,
+          select: { _id: true, workflowStatus: true },
+          sort: { createdAt: SortOrder.Descending },
+        });
+
+      const latest: WorkflowLog | undefined = result.data[0];
+
+      if (!latest || !latest._id) {
+        return null;
+      }
+
+      return {
+        runId: latest._id.toString(),
+        status: latest.workflowStatus as WorkflowStatus,
+      };
+    };
+
+  type PollRunFunction = (pollCount: number) => Promise<void>;
+
+  const pollRun: PollRunFunction = async (pollCount: number): Promise<void> => {
+    let run: WatchedRun | null = null;
+
+    try {
+      run = await fetchLatestRun();
+    } catch {
+      /*
+       * A failed poll is not a failed run. Keep watching — the next poll may
+       * well succeed, and the Logs tab is the fallback either way.
+       */
+      run = null;
+    }
+
+    // Not our run yet: the worker has not created its log.
+    if (run && run.runId === runIdBeforeTrigger.current) {
+      run = null;
+    }
+
+    const decision: RunWatchDecision = decideRunWatch({
+      run: run,
+      pollCount: pollCount,
+    });
+
+    setRunWatchMessage(decision.message);
+    setRunWatchFailed(isFailedRunStatus(run?.status));
+
+    if (!decision.shouldContinue) {
+      return;
+    }
+
+    runWatchTimer.current = setTimeout(() => {
+      void pollRun(pollCount + 1);
+    }, RUN_WATCH_POLL_INTERVAL_MS);
+  };
+
+  type StartWatchingRunFunction = () => void;
+
+  const startWatchingRun: StartWatchingRunFunction = (): void => {
+    if (runWatchTimer.current) {
+      clearTimeout(runWatchTimer.current);
+      runWatchTimer.current = null;
+    }
+
+    setRunWatchFailed(false);
+    setRunWatchMessage("Starting run…");
+
+    void (async (): Promise<void> => {
+      try {
+        const existing: WatchedRun | null = await fetchLatestRun();
+        runIdBeforeTrigger.current = existing ? existing.runId : null;
+      } catch {
+        runIdBeforeTrigger.current = null;
+      }
+
+      void pollRun(0);
+    })();
+  };
+
+  useEffect(() => {
+    return () => {
+      if (runWatchTimer.current) {
+        clearTimeout(runWatchTimer.current);
+      }
+    };
+  }, []);
 
   const loadGraph: PromiseVoidFunction = async (): Promise<void> => {
     try {
@@ -371,6 +495,18 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
               Static checks over the graph. Clicking opens the full list —
               each node also carries its own badge on the canvas.
             */}
+            {runWatchMessage && (
+              <span
+                style={{
+                  fontSize: "0.75rem",
+                  fontWeight: 500,
+                  color: runWatchFailed ? "#ef4444" : "#475569",
+                }}
+              >
+                {runWatchMessage}
+              </span>
+            )}
+
             {lintResult && lintResult.issues.length > 0 && (
               <button
                 type="button"
@@ -474,7 +610,7 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
                   throw result;
                 }
 
-                setShowRunSuccessConfirmation(true);
+                startWatchingRun();
               } catch (err) {
                 setError(API.getFriendlyMessage(err));
               }
@@ -536,18 +672,6 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
               )}
             </div>
           </Modal>
-        )}
-
-        {showRunSuccessConfirmation && (
-          <ConfirmModal
-            title={`Workflow Triggered`}
-            description={`Your workflow has been scheduled to execute. Check the Logs tab to monitor the run.`}
-            submitButtonText={"Got it"}
-            onSubmit={() => {
-              setShowRunSuccessConfirmation(false);
-            }}
-            submitButtonType={ButtonStyleType.NORMAL}
-          />
         )}
       </>
     </Fragment>

--- a/Common/Tests/Types/SerializableObjectDictionaryImportCycle.test.ts
+++ b/Common/Tests/Types/SerializableObjectDictionaryImportCycle.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Importing an operator class FIRST is the whole point of this file.
+ *
+ * Includes, IncludesAll and IncludesNone import JSONFunctions (their fromJSON
+ * deserializes the values inside them), and JSONFunctions imports the
+ * dictionary that holds them — a cycle. While the dictionary was a plain
+ * object literal, whichever side of the cycle initialized second captured the
+ * other as `undefined`, so `{"_type":"Includes","value":[...]}` came back out
+ * of JSONFunctions.deserialize as a plain object instead of an Includes. A
+ * plain object reaching TypeORM is a silently wrong query rather than an
+ * error, which is exactly the kind of failure worth pinning down.
+ *
+ * Jest gives each test file its own module registry, so this file's import
+ * order genuinely reproduces the bad ordering.
+ */
+
+import Includes from "../../Types/BaseDatabase/Includes";
+import IncludesAll from "../../Types/BaseDatabase/IncludesAll";
+import IncludesNone from "../../Types/BaseDatabase/IncludesNone";
+import EqualTo from "../../Types/BaseDatabase/EqualTo";
+import EqualToOrNull from "../../Types/BaseDatabase/EqualToOrNull";
+import GreaterThan from "../../Types/BaseDatabase/GreaterThan";
+import GreaterThanOrEqual from "../../Types/BaseDatabase/GreaterThanOrEqual";
+import GreaterThanOrNull from "../../Types/BaseDatabase/GreaterThanOrNull";
+import InBetween from "../../Types/BaseDatabase/InBetween";
+import IsNull from "../../Types/BaseDatabase/IsNull";
+import LessThan from "../../Types/BaseDatabase/LessThan";
+import LessThanOrEqual from "../../Types/BaseDatabase/LessThanOrEqual";
+import LessThanOrNull from "../../Types/BaseDatabase/LessThanOrNull";
+import NotContains from "../../Types/BaseDatabase/NotContains";
+import NotEqual from "../../Types/BaseDatabase/NotEqual";
+import NotNull from "../../Types/BaseDatabase/NotNull";
+import Search from "../../Types/BaseDatabase/Search";
+import StartsWith from "../../Types/BaseDatabase/StartsWith";
+import EndsWith from "../../Types/BaseDatabase/EndsWith";
+import SerializableObjectDictionary from "../../Types/SerializableObjectDictionary";
+import JSONFunctions from "../../Types/JSONFunctions";
+import { JSONObject, ObjectType } from "../../Types/JSON";
+import ObjectID from "../../Types/ObjectID";
+import { describe, expect, test } from "@jest/globals";
+
+describe("SerializableObjectDictionary registration", () => {
+  /*
+   * The regression itself. These three sit on the cycle, and this file imports
+   * them before the dictionary — the order that used to leave them undefined.
+   */
+  test("the classes on the import cycle resolve", () => {
+    expect(SerializableObjectDictionary[ObjectType.Includes]).toBe(Includes);
+    expect(SerializableObjectDictionary[ObjectType.IncludesAll]).toBe(
+      IncludesAll,
+    );
+    expect(SerializableObjectDictionary[ObjectType.IncludesNone]).toBe(
+      IncludesNone,
+    );
+  });
+
+  test("each entry resolves to the class it names", () => {
+    expect(SerializableObjectDictionary[ObjectType.EqualTo]).toBe(EqualTo);
+    expect(SerializableObjectDictionary[ObjectType.NotEqual]).toBe(NotEqual);
+    expect(SerializableObjectDictionary[ObjectType.Search]).toBe(Search);
+    expect(SerializableObjectDictionary[ObjectType.GreaterThan]).toBe(
+      GreaterThan,
+    );
+    expect(SerializableObjectDictionary[ObjectType.IsNull]).toBe(IsNull);
+    expect(SerializableObjectDictionary[ObjectType.NotNull]).toBe(NotNull);
+  });
+
+  test("entries stay resolvable when read more than once", () => {
+    expect(SerializableObjectDictionary[ObjectType.Includes]).toBe(Includes);
+    expect(SerializableObjectDictionary[ObjectType.Includes]).toBe(Includes);
+  });
+
+  test("an unknown type resolves to nothing rather than throwing", () => {
+    expect(SerializableObjectDictionary["NotAThing"]).toBeUndefined();
+  });
+});
+
+type RoundTripFunction = (value: unknown) => unknown;
+
+/** JSON.stringify -> JSON.parse -> deserialize, exactly as a request does. */
+const roundTrip: RoundTripFunction = (value: unknown): unknown => {
+  const parsed: JSONObject = JSON.parse(JSON.stringify({ v: value }));
+
+  return (JSONFunctions.deserialize(parsed) as JSONObject)["v"];
+};
+
+describe("query operators survive a serialize/deserialize round trip", () => {
+  test("Includes keeps its class and its values", () => {
+    const result: unknown = roundTrip(new Includes(["x", "y"]));
+
+    expect(result).toBeInstanceOf(Includes);
+    expect((result as Includes).values).toEqual(["x", "y"]);
+  });
+
+  test("IncludesNone keeps its class and its values", () => {
+    const result: unknown = roundTrip(new IncludesNone(["x"]));
+
+    expect(result).toBeInstanceOf(IncludesNone);
+    expect((result as IncludesNone).values).toEqual(["x"]);
+  });
+
+  test("IncludesAll keeps its class and its values", () => {
+    const result: unknown = roundTrip(new IncludesAll(["x", "y"]));
+
+    expect(result).toBeInstanceOf(IncludesAll);
+  });
+
+  test("an empty membership list survives", () => {
+    const result: unknown = roundTrip(new Includes([]));
+
+    expect(result).toBeInstanceOf(Includes);
+    expect((result as Includes).values).toEqual([]);
+  });
+
+  test("ObjectIDs inside a membership list come back as ObjectIDs", () => {
+    const id: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+    const result: unknown = roundTrip(new Includes([id]));
+
+    expect(result).toBeInstanceOf(Includes);
+    expect((result as Includes).values[0]).toBeInstanceOf(ObjectID);
+  });
+
+  test("the comparison operators keep their class and value", () => {
+    expect(roundTrip(new NotEqual<string>("a"))).toBeInstanceOf(NotEqual);
+    expect(roundTrip(new EqualTo<string>("a"))).toBeInstanceOf(EqualTo);
+    expect(roundTrip(new EqualToOrNull<string>("a"))).toBeInstanceOf(
+      EqualToOrNull,
+    );
+    expect(roundTrip(new GreaterThan<number>(1))).toBeInstanceOf(GreaterThan);
+    expect(roundTrip(new GreaterThanOrEqual<number>(1))).toBeInstanceOf(
+      GreaterThanOrEqual,
+    );
+    expect(roundTrip(new LessThan<number>(1))).toBeInstanceOf(LessThan);
+    expect(roundTrip(new LessThanOrEqual<number>(1))).toBeInstanceOf(
+      LessThanOrEqual,
+    );
+    expect(roundTrip(new GreaterThanOrNull<number>(1))).toBeInstanceOf(
+      GreaterThanOrNull,
+    );
+    expect(roundTrip(new LessThanOrNull<number>(1))).toBeInstanceOf(
+      LessThanOrNull,
+    );
+  });
+
+  test("the text operators keep their class", () => {
+    expect(roundTrip(new Search("a"))).toBeInstanceOf(Search);
+    expect(roundTrip(new NotContains("a"))).toBeInstanceOf(NotContains);
+    expect(roundTrip(new StartsWith("a"))).toBeInstanceOf(StartsWith);
+    expect(roundTrip(new EndsWith("a"))).toBeInstanceOf(EndsWith);
+  });
+
+  test("the null checks keep their class", () => {
+    expect(roundTrip(new IsNull())).toBeInstanceOf(IsNull);
+    expect(roundTrip(new NotNull())).toBeInstanceOf(NotNull);
+  });
+
+  test("InBetween keeps both of its bounds", () => {
+    const result: unknown = roundTrip(new InBetween<number>(1, 5));
+
+    expect(result).toBeInstanceOf(InBetween);
+    expect((result as InBetween<number>).startValue).toBe(1);
+    expect((result as InBetween<number>).endValue).toBe(5);
+  });
+
+  test("a numeric comparison keeps its number, not a string of it", () => {
+    const result: unknown = roundTrip(new GreaterThan<number>(42));
+
+    expect((result as GreaterThan<number>).value).toBe(42);
+  });
+
+  test("plain values are left exactly as they are", () => {
+    expect(roundTrip("plain")).toBe("plain");
+    expect(roundTrip(7)).toBe(7);
+    expect(roundTrip(true)).toBe(true);
+    expect(roundTrip(null)).toBeNull();
+  });
+
+  test("a whole query of mixed operators deserializes together", () => {
+    const query: JSONObject = JSON.parse(
+      JSON.stringify({
+        name: new Search("acme"),
+        tags: new Includes(["a", "b"]),
+        count: new GreaterThan<number>(3),
+        deletedAt: new IsNull(),
+        isEnabled: true,
+      }),
+    );
+
+    const result: JSONObject = JSONFunctions.deserialize(query) as JSONObject;
+
+    expect(result["name"]).toBeInstanceOf(Search);
+    expect(result["tags"]).toBeInstanceOf(Includes);
+    expect(result["count"]).toBeInstanceOf(GreaterThan);
+    expect(result["deletedAt"]).toBeInstanceOf(IsNull);
+    expect(result["isEnabled"]).toBe(true);
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/ModelColumnEditor.test.ts
+++ b/Common/Tests/UI/Components/Workflow/ModelColumnEditor.test.ts
@@ -1,0 +1,287 @@
+/*
+ * The two pure decisions behind the column row editor: whether a stored value
+ * can be shown as rows at all, and what the rows serialize back to.
+ *
+ * The serialization side matters most — the string this produces is handed
+ * straight to the server, where JSONFunctions.deserialize has to turn the
+ * operator wrappers back into the QueryHelper objects TypeORM understands.
+ */
+
+import {
+  ModelColumnEditorMode,
+  buildColumnValueJson,
+  classifyColumnValueCompatibility,
+} from "../../../../UI/Components/Workflow/ModelColumnEditor";
+import { ModelSchemaColumn } from "../../../../UI/Components/Workflow/ModelSchema";
+import Dictionary from "../../../../Types/Dictionary";
+import { DictionaryEntryValue } from "../../../../UI/Components/Dictionary/DictionaryFilterOperator";
+import { JSONObject, ObjectType } from "../../../../Types/JSON";
+import GreaterThan from "../../../../Types/BaseDatabase/GreaterThan";
+import Includes from "../../../../Types/BaseDatabase/Includes";
+import IsNull from "../../../../Types/BaseDatabase/IsNull";
+import NotEqual from "../../../../Types/BaseDatabase/NotEqual";
+import Search from "../../../../Types/BaseDatabase/Search";
+import { describe, expect, test } from "@jest/globals";
+
+type MakeColumnFunction = (
+  id: string,
+  type?: string | undefined,
+) => ModelSchemaColumn;
+
+const makeColumn: MakeColumnFunction = (
+  id: string,
+  type?: string | undefined,
+): ModelSchemaColumn => {
+  return {
+    id: id,
+    title: id,
+    type: type || "ShortText",
+    isRelation: false,
+  };
+};
+
+const COLUMNS: Array<ModelSchemaColumn> = [
+  makeColumn("_id", "ObjectID"),
+  makeColumn("name"),
+  makeColumn("createdAt", "Date"),
+  makeColumn("isEnabled", "Boolean"),
+];
+
+describe("classifyColumnValueCompatibility — plain values", () => {
+  test("an empty query is representable", () => {
+    expect(
+      classifyColumnValueCompatibility({}, COLUMNS, ModelColumnEditorMode.Query)
+        .compatible,
+    ).toBe(true);
+  });
+
+  test("scalar values are representable", () => {
+    const result: { compatible: boolean; reasons: Array<string> } =
+      classifyColumnValueCompatibility(
+        { name: "abc", isEnabled: true },
+        COLUMNS,
+        ModelColumnEditorMode.Query,
+      );
+
+    expect(result.compatible).toBe(true);
+    expect(result.reasons).toEqual([]);
+  });
+
+  test("a null value is representable", () => {
+    expect(
+      classifyColumnValueCompatibility(
+        { name: null } as unknown as JSONObject,
+        COLUMNS,
+        ModelColumnEditorMode.Query,
+      ).compatible,
+    ).toBe(true);
+  });
+
+  test("text that is not a JSON object is not representable", () => {
+    const result: { compatible: boolean; reasons: Array<string> } =
+      classifyColumnValueCompatibility(
+        null,
+        COLUMNS,
+        ModelColumnEditorMode.Query,
+      );
+
+    expect(result.compatible).toBe(false);
+    expect(result.reasons[0]).toMatch(/isn't a JSON object/);
+  });
+
+  /*
+   * An unknown column is exactly the "id" versus "_id" mistake. Say so, but
+   * keep the rows — the builder needs to see the row to fix it.
+   */
+  test("an unknown column is reported without locking the editor", () => {
+    const result: { compatible: boolean; reasons: Array<string> } =
+      classifyColumnValueCompatibility(
+        { id: "abc" },
+        COLUMNS,
+        ModelColumnEditorMode.Query,
+      );
+
+    expect(result.compatible).toBe(true);
+    expect(result.reasons[0]).toMatch(/"id" isn't a known column/);
+  });
+
+  test("columns are not checked when the schema failed to load", () => {
+    const result: { compatible: boolean; reasons: Array<string> } =
+      classifyColumnValueCompatibility(
+        { anything: "abc" },
+        [],
+        ModelColumnEditorMode.Query,
+      );
+
+    expect(result.compatible).toBe(true);
+    expect(result.reasons).toEqual([]);
+  });
+});
+
+describe("classifyColumnValueCompatibility — operators", () => {
+  test("a query shows the operators the rows support", () => {
+    const supported: Array<string> = [
+      ObjectType.EqualTo,
+      ObjectType.NotEqual,
+      ObjectType.Search,
+      ObjectType.NotContains,
+      ObjectType.StartsWith,
+      ObjectType.EndsWith,
+      ObjectType.GreaterThan,
+      ObjectType.GreaterThanOrEqual,
+      ObjectType.LessThan,
+      ObjectType.LessThanOrEqual,
+      ObjectType.IsNull,
+      ObjectType.NotNull,
+      ObjectType.Includes,
+      ObjectType.IncludesNone,
+    ];
+
+    for (const objectType of supported) {
+      const result: { compatible: boolean } = classifyColumnValueCompatibility(
+        { name: { _type: objectType, value: "x" } },
+        COLUMNS,
+        ModelColumnEditorMode.Query,
+      );
+
+      expect(result.compatible).toBe(true);
+    }
+  });
+
+  test("an operator the rows cannot show keeps the JSON editor", () => {
+    const result: { compatible: boolean; reasons: Array<string> } =
+      classifyColumnValueCompatibility(
+        { createdAt: { _type: ObjectType.InBetween, value: "x" } },
+        COLUMNS,
+        ModelColumnEditorMode.Query,
+      );
+
+    expect(result.compatible).toBe(false);
+    expect(result.reasons[0]).toMatch(/InBetween/);
+  });
+
+  /*
+   * A record is a set of values to write. An operator there would be nonsense,
+   * so it belongs in the JSON editor where the builder can see what they have.
+   */
+  test("an operator in a record is not representable", () => {
+    const result: { compatible: boolean; reasons: Array<string> } =
+      classifyColumnValueCompatibility(
+        { name: { _type: ObjectType.NotEqual, value: "x" } },
+        COLUMNS,
+        ModelColumnEditorMode.Record,
+      );
+
+    expect(result.compatible).toBe(false);
+  });
+
+  test("a nested relation query keeps the JSON editor", () => {
+    const result: { compatible: boolean; reasons: Array<string> } =
+      classifyColumnValueCompatibility(
+        { project: { _id: "abc" } },
+        COLUMNS,
+        ModelColumnEditorMode.Query,
+      );
+
+    expect(result.compatible).toBe(false);
+    expect(result.reasons.join(" ")).toMatch(/nested record/);
+  });
+
+  test("a bare array keeps the JSON editor and suggests the operator", () => {
+    const result: { compatible: boolean; reasons: Array<string> } =
+      classifyColumnValueCompatibility(
+        { name: ["a", "b"] } as unknown as JSONObject,
+        COLUMNS,
+        ModelColumnEditorMode.Query,
+      );
+
+    expect(result.compatible).toBe(false);
+    expect(result.reasons[0]).toMatch(/is any of/);
+  });
+});
+
+describe("buildColumnValueJson", () => {
+  test("an empty set collapses to empty text, so required still fires", () => {
+    expect(buildColumnValueJson({})).toBe("");
+  });
+
+  test("a row with no column name is dropped", () => {
+    const rows: Dictionary<DictionaryEntryValue> = {
+      "": "orphan",
+    } as Dictionary<DictionaryEntryValue>;
+
+    expect(buildColumnValueJson(rows)).toBe("");
+  });
+
+  test("plain values serialize as plain JSON", () => {
+    const rows: Dictionary<DictionaryEntryValue> = {
+      name: "abc",
+      isEnabled: true,
+    } as Dictionary<DictionaryEntryValue>;
+
+    expect(JSON.parse(buildColumnValueJson(rows))).toEqual({
+      name: "abc",
+      isEnabled: true,
+    });
+  });
+
+  /*
+   * The contract with the server: every operator wrapper has to come out as
+   * {_type, value}, because that is the only shape JSONFunctions.deserialize
+   * turns back into a QueryHelper object.
+   */
+  test("an operator serializes to the shape the server rehydrates", () => {
+    const rows: Dictionary<DictionaryEntryValue> = {
+      name: new NotEqual<string>("abc"),
+    } as unknown as Dictionary<DictionaryEntryValue>;
+
+    expect(JSON.parse(buildColumnValueJson(rows))).toEqual({
+      name: { _type: ObjectType.NotEqual, value: "abc" },
+    });
+  });
+
+  test("every operator the editor offers round-trips through JSON", () => {
+    const rows: Dictionary<DictionaryEntryValue> = {
+      a: new NotEqual<string>("x"),
+      b: new Search("y"),
+      c: new GreaterThan<number>(5),
+      d: new IsNull(),
+      e: new Includes(["p", "q"]),
+    } as unknown as Dictionary<DictionaryEntryValue>;
+
+    const parsed: JSONObject = JSON.parse(buildColumnValueJson(rows));
+
+    expect((parsed["a"] as JSONObject)["_type"]).toBe(ObjectType.NotEqual);
+    expect((parsed["b"] as JSONObject)["_type"]).toBe(ObjectType.Search);
+    expect((parsed["c"] as JSONObject)["_type"]).toBe(ObjectType.GreaterThan);
+    expect((parsed["d"] as JSONObject)["_type"]).toBe(ObjectType.IsNull);
+    expect((parsed["e"] as JSONObject)["_type"]).toBe(ObjectType.Includes);
+  });
+
+  test("a template placeholder survives as an ordinary string value", () => {
+    const rows: Dictionary<DictionaryEntryValue> = {
+      _id: "{{local.components.api-get-1.returnValues.response-body}}",
+    } as Dictionary<DictionaryEntryValue>;
+
+    expect(JSON.parse(buildColumnValueJson(rows))).toEqual({
+      _id: "{{local.components.api-get-1.returnValues.response-body}}",
+    });
+  });
+
+  test("what it emits is readable again by the compatibility check", () => {
+    const rows: Dictionary<DictionaryEntryValue> = {
+      name: new NotEqual<string>("abc"),
+      isEnabled: true,
+    } as unknown as Dictionary<DictionaryEntryValue>;
+
+    const roundTripped: JSONObject = JSON.parse(buildColumnValueJson(rows));
+
+    expect(
+      classifyColumnValueCompatibility(
+        roundTripped,
+        COLUMNS,
+        ModelColumnEditorMode.Query,
+      ).compatible,
+    ).toBe(true);
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/ModelColumnEditorServerContract.test.ts
+++ b/Common/Tests/UI/Components/Workflow/ModelColumnEditorServerContract.test.ts
@@ -1,0 +1,185 @@
+/*
+ * The contract that matters: what the row editor writes into a workflow
+ * argument has to survive the trip to the server and come back out as the
+ * QueryHelper objects TypeORM understands.
+ *
+ * The builder writes a JSON string. RunWorkflow.getComponentArguments parses
+ * it, and FindManyBaseModel (and every other database component) hands the
+ * result to JSONFunctions.deserialize before it reaches the query builder.
+ * This walks that whole path, so a change to either end that breaks the other
+ * fails here rather than at run time.
+ */
+
+import {
+  ModelColumnEditorMode,
+  buildColumnValueJson,
+  classifyColumnValueCompatibility,
+} from "../../../../UI/Components/Workflow/ModelColumnEditor";
+import Dictionary from "../../../../Types/Dictionary";
+import { DictionaryEntryValue } from "../../../../UI/Components/Dictionary/DictionaryFilterOperator";
+import { JSONObject } from "../../../../Types/JSON";
+import JSONFunctions from "../../../../Types/JSONFunctions";
+import EqualToOrNull from "../../../../Types/BaseDatabase/EqualToOrNull";
+import GreaterThan from "../../../../Types/BaseDatabase/GreaterThan";
+import GreaterThanOrEqual from "../../../../Types/BaseDatabase/GreaterThanOrEqual";
+import Includes from "../../../../Types/BaseDatabase/Includes";
+import IncludesNone from "../../../../Types/BaseDatabase/IncludesNone";
+import IsNull from "../../../../Types/BaseDatabase/IsNull";
+import LessThan from "../../../../Types/BaseDatabase/LessThan";
+import NotEqual from "../../../../Types/BaseDatabase/NotEqual";
+import NotNull from "../../../../Types/BaseDatabase/NotNull";
+import Search from "../../../../Types/BaseDatabase/Search";
+import StartsWith from "../../../../Types/BaseDatabase/StartsWith";
+import { describe, expect, test } from "@jest/globals";
+
+type RoundTripFunction = (rows: Dictionary<DictionaryEntryValue>) => JSONObject;
+
+/**
+ * Builder rows -> stored string -> parsed by the runner -> deserialized by the
+ * component. Exactly the path a real run takes.
+ */
+const roundTrip: RoundTripFunction = (
+  rows: Dictionary<DictionaryEntryValue>,
+): JSONObject => {
+  const stored: string = buildColumnValueJson(rows);
+  const parsedByRunner: JSONObject = JSON.parse(stored);
+
+  return JSONFunctions.deserialize(parsedByRunner) as JSONObject;
+};
+
+describe("row editor output survives the server's deserialization", () => {
+  test("a plain equality stays a plain value", () => {
+    const result: JSONObject = roundTrip({
+      name: "acme",
+    } as Dictionary<DictionaryEntryValue>);
+
+    expect(result["name"]).toBe("acme");
+  });
+
+  test("a not-equal comes back as a NotEqual", () => {
+    const result: JSONObject = roundTrip({
+      name: new NotEqual<string>("acme"),
+    } as unknown as Dictionary<DictionaryEntryValue>);
+
+    expect(result["name"]).toBeInstanceOf(NotEqual);
+    expect((result["name"] as NotEqual<string>).value).toBe("acme");
+  });
+
+  test("a contains comes back as a Search", () => {
+    const result: JSONObject = roundTrip({
+      name: new Search("acm"),
+    } as unknown as Dictionary<DictionaryEntryValue>);
+
+    expect(result["name"]).toBeInstanceOf(Search);
+  });
+
+  test("a starts-with comes back as a StartsWith", () => {
+    const result: JSONObject = roundTrip({
+      name: new StartsWith("ac"),
+    } as unknown as Dictionary<DictionaryEntryValue>);
+
+    expect(result["name"]).toBeInstanceOf(StartsWith);
+  });
+
+  test("numeric comparisons keep their type and their number", () => {
+    const result: JSONObject = roundTrip({
+      a: new GreaterThan<number>(5),
+      b: new GreaterThanOrEqual<number>(6),
+      c: new LessThan<number>(7),
+    } as unknown as Dictionary<DictionaryEntryValue>);
+
+    expect(result["a"]).toBeInstanceOf(GreaterThan);
+    expect((result["a"] as GreaterThan<number>).value).toBe(5);
+    expect(result["b"]).toBeInstanceOf(GreaterThanOrEqual);
+    expect(result["c"]).toBeInstanceOf(LessThan);
+  });
+
+  test("the null checks come back as IsNull and NotNull", () => {
+    const result: JSONObject = roundTrip({
+      a: new IsNull(),
+      b: new NotNull(),
+    } as unknown as Dictionary<DictionaryEntryValue>);
+
+    expect(result["a"]).toBeInstanceOf(IsNull);
+    expect(result["b"]).toBeInstanceOf(NotNull);
+  });
+
+  test("membership operators keep their whole list", () => {
+    const result: JSONObject = roundTrip({
+      a: new Includes(["x", "y"]),
+      b: new IncludesNone(["z"]),
+    } as unknown as Dictionary<DictionaryEntryValue>);
+
+    expect(result["a"]).toBeInstanceOf(Includes);
+    expect((result["a"] as Includes).values).toEqual(["x", "y"]);
+    expect(result["b"]).toBeInstanceOf(IncludesNone);
+  });
+
+  test("equal-to-or-null survives", () => {
+    const result: JSONObject = roundTrip({
+      a: new EqualToOrNull<string>("x"),
+    } as unknown as Dictionary<DictionaryEntryValue>);
+
+    expect(result["a"]).toBeInstanceOf(EqualToOrNull);
+  });
+
+  test("several conditions in one query all survive together", () => {
+    const result: JSONObject = roundTrip({
+      name: new Search("acme"),
+      isEnabled: true,
+      count: new GreaterThan<number>(3),
+      deletedAt: new IsNull(),
+    } as unknown as Dictionary<DictionaryEntryValue>);
+
+    expect(Object.keys(result).sort()).toEqual([
+      "count",
+      "deletedAt",
+      "isEnabled",
+      "name",
+    ]);
+    expect(result["isEnabled"]).toBe(true);
+    expect(result["name"]).toBeInstanceOf(Search);
+  });
+
+  /*
+   * A template is substituted before the component ever sees the value, so at
+   * this point it is just a string — it must not be mistaken for structure.
+   */
+  test("a template placeholder passes through untouched", () => {
+    const result: JSONObject = roundTrip({
+      _id: "{{local.components.api-get-1.returnValues.response-body}}",
+    } as Dictionary<DictionaryEntryValue>);
+
+    expect(result["_id"]).toBe(
+      "{{local.components.api-get-1.returnValues.response-body}}",
+    );
+  });
+
+  test("a record of values to write deserializes to plain values", () => {
+    const stored: string = buildColumnValueJson({
+      name: "acme",
+      isEnabled: true,
+      count: 4,
+    } as Dictionary<DictionaryEntryValue>);
+
+    expect(JSONFunctions.deserialize(JSON.parse(stored))).toEqual({
+      name: "acme",
+      isEnabled: true,
+      count: 4,
+    });
+  });
+
+  test("what the editor emits, the editor can read back", () => {
+    const rows: Dictionary<DictionaryEntryValue> = {
+      name: new Search("acme"),
+      count: new GreaterThan<number>(3),
+    } as unknown as Dictionary<DictionaryEntryValue>;
+
+    const stored: JSONObject = JSON.parse(buildColumnValueJson(rows));
+
+    expect(
+      classifyColumnValueCompatibility(stored, [], ModelColumnEditorMode.Query)
+        .compatible,
+    ).toBe(true);
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/ModelSchema.test.ts
+++ b/Common/Tests/UI/Components/Workflow/ModelSchema.test.ts
@@ -1,0 +1,174 @@
+jest.mock("../../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      get: jest.fn(),
+      getFriendlyMessage: jest.fn((err: unknown) => {
+        return String(err);
+      }),
+    },
+  };
+});
+
+import {
+  ModelSchemaColumn,
+  fetchModelSchema,
+  findColumn,
+  isBooleanColumn,
+  isNumericColumn,
+  isScalarColumn,
+} from "../../../../UI/Components/Workflow/ModelSchema";
+import API from "../../../../UI/Utils/API/API";
+import HTTPErrorResponse from "../../../../Types/API/HTTPErrorResponse";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+type MakeColumnFunction = (
+  overrides: Partial<ModelSchemaColumn>,
+) => ModelSchemaColumn;
+
+const makeColumn: MakeColumnFunction = (
+  overrides: Partial<ModelSchemaColumn>,
+): ModelSchemaColumn => {
+  return {
+    id: "name",
+    title: "Name",
+    type: "ShortText",
+    isRelation: false,
+    ...overrides,
+  };
+};
+
+describe("isScalarColumn", () => {
+  test("accepts the column types a single input can hold", () => {
+    const scalarTypes: Array<string> = [
+      "ShortText",
+      "LongText",
+      "ObjectID",
+      "Number",
+      "Boolean",
+      "Date",
+      "Email",
+      "URL",
+      "Markdown",
+    ];
+
+    for (const type of scalarTypes) {
+      expect(isScalarColumn(makeColumn({ type: type }))).toBe(true);
+    }
+  });
+
+  test("rejects a relation, however it is typed", () => {
+    expect(
+      isScalarColumn(makeColumn({ type: "ShortText", isRelation: true })),
+    ).toBe(false);
+    expect(
+      isScalarColumn(makeColumn({ type: "Entity", isRelation: true })),
+    ).toBe(false);
+  });
+
+  test("rejects types a single box cannot hold", () => {
+    expect(isScalarColumn(makeColumn({ type: "JSON" }))).toBe(false);
+    expect(isScalarColumn(makeColumn({ type: "Buffer" }))).toBe(false);
+    expect(isScalarColumn(makeColumn({ type: "EntityArray" }))).toBe(false);
+  });
+
+  test("rejects a type it has never heard of", () => {
+    expect(isScalarColumn(makeColumn({ type: "SomethingNew" }))).toBe(false);
+  });
+});
+
+describe("isNumericColumn", () => {
+  test("is true for the two numeric types", () => {
+    expect(isNumericColumn(makeColumn({ type: "Number" }))).toBe(true);
+    expect(isNumericColumn(makeColumn({ type: "PositiveNumber" }))).toBe(true);
+  });
+
+  test("is false for everything else", () => {
+    expect(isNumericColumn(makeColumn({ type: "ShortText" }))).toBe(false);
+    expect(isNumericColumn(makeColumn({ type: "Boolean" }))).toBe(false);
+  });
+});
+
+describe("isBooleanColumn", () => {
+  test("is true only for Boolean", () => {
+    expect(isBooleanColumn(makeColumn({ type: "Boolean" }))).toBe(true);
+    expect(isBooleanColumn(makeColumn({ type: "ShortText" }))).toBe(false);
+  });
+});
+
+describe("findColumn", () => {
+  const columns: Array<ModelSchemaColumn> = [
+    makeColumn({ id: "_id" }),
+    makeColumn({ id: "name" }),
+  ];
+
+  test("finds a column by id", () => {
+    expect(findColumn(columns, "_id")?.id).toBe("_id");
+  });
+
+  test("returns nothing for an id that isn't there", () => {
+    expect(findColumn(columns, "id")).toBeUndefined();
+  });
+
+  test("is case sensitive, as column names are", () => {
+    expect(findColumn(columns, "Name")).toBeUndefined();
+  });
+
+  test("copes with an empty list", () => {
+    expect(findColumn([], "name")).toBeUndefined();
+  });
+});
+
+describe("fetchModelSchema", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  type MockedGetFunction = (value: unknown) => void;
+
+  const mockGet: MockedGetFunction = (value: unknown): void => {
+    (API.get as unknown as jest.Mock).mockResolvedValue(value);
+  };
+
+  test("returns the columns the endpoint sent", async () => {
+    mockGet({
+      data: { tableName: "Monitor", columns: [makeColumn({ id: "_id" })] },
+    });
+
+    const columns: Array<ModelSchemaColumn> = await fetchModelSchema("Monitor");
+
+    expect(columns).toHaveLength(1);
+    expect(columns[0]?.id).toBe("_id");
+  });
+
+  test("returns an empty list when the endpoint sends no columns", async () => {
+    mockGet({ data: { tableName: "Monitor" } });
+
+    await expect(fetchModelSchema("Monitor")).resolves.toEqual([]);
+  });
+
+  test("throws when the endpoint answers with an error", async () => {
+    const errorResponse: HTTPErrorResponse = new HTTPErrorResponse(
+      500,
+      { message: "boom" },
+      {},
+    );
+
+    mockGet(errorResponse);
+
+    await expect(fetchModelSchema("Monitor")).rejects.toBe(errorResponse);
+  });
+
+  test("escapes the table name into the path", async () => {
+    mockGet({ data: { columns: [] } });
+
+    await fetchModelSchema("Weird/Name");
+
+    const call: { url: { toString: () => string } } = (
+      API.get as unknown as jest.Mock
+    ).mock.calls[0][0] as { url: { toString: () => string } };
+
+    expect(call.url.toString()).toContain("Weird%2FName");
+    expect(call.url.toString()).not.toContain("Weird/Name");
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/RunStatusWatcher.test.ts
+++ b/Common/Tests/UI/Components/Workflow/RunStatusWatcher.test.ts
@@ -1,0 +1,152 @@
+import {
+  MAX_RUN_WATCH_POLLS,
+  RunWatchDecision,
+  decideRunWatch,
+  isFailedRunStatus,
+  isTerminalRunStatus,
+} from "../../../../UI/Components/Workflow/RunStatusWatcher";
+import WorkflowStatus from "../../../../Types/Workflow/WorkflowStatus";
+import { describe, expect, test } from "@jest/globals";
+
+describe("isTerminalRunStatus", () => {
+  test("settles on the statuses a run never leaves", () => {
+    expect(isTerminalRunStatus(WorkflowStatus.Success)).toBe(true);
+    expect(isTerminalRunStatus(WorkflowStatus.Error)).toBe(true);
+    expect(isTerminalRunStatus(WorkflowStatus.Timeout)).toBe(true);
+    expect(isTerminalRunStatus(WorkflowStatus.WorkflowCountExceeded)).toBe(
+      true,
+    );
+  });
+
+  test("keeps watching while a run is still moving", () => {
+    expect(isTerminalRunStatus(WorkflowStatus.Scheduled)).toBe(false);
+    expect(isTerminalRunStatus(WorkflowStatus.Running)).toBe(false);
+  });
+
+  /*
+   * Waiting is a Sleep step parking the run. It carries on afterwards, so it
+   * is not an ending — but it is also not worth watching, which decideRunWatch
+   * handles separately.
+   */
+  test("does not treat Waiting as an ending", () => {
+    expect(isTerminalRunStatus(WorkflowStatus.Waiting)).toBe(false);
+  });
+
+  test("handles nothing at all", () => {
+    expect(isTerminalRunStatus(null)).toBe(false);
+    expect(isTerminalRunStatus(undefined)).toBe(false);
+  });
+});
+
+describe("isFailedRunStatus", () => {
+  test("is true only for the unhappy endings", () => {
+    expect(isFailedRunStatus(WorkflowStatus.Error)).toBe(true);
+    expect(isFailedRunStatus(WorkflowStatus.Timeout)).toBe(true);
+    expect(isFailedRunStatus(WorkflowStatus.WorkflowCountExceeded)).toBe(true);
+
+    expect(isFailedRunStatus(WorkflowStatus.Success)).toBe(false);
+    expect(isFailedRunStatus(WorkflowStatus.Running)).toBe(false);
+    expect(isFailedRunStatus(WorkflowStatus.Waiting)).toBe(false);
+    expect(isFailedRunStatus(null)).toBe(false);
+    expect(isFailedRunStatus(undefined)).toBe(false);
+  });
+});
+
+describe("decideRunWatch", () => {
+  test("keeps waiting while the run has not appeared yet", () => {
+    const decision: RunWatchDecision = decideRunWatch({
+      run: null,
+      pollCount: 0,
+    });
+
+    expect(decision.shouldContinue).toBe(true);
+    expect(decision.message).toMatch(/Starting/i);
+  });
+
+  test("keeps watching a running run and says so", () => {
+    const decision: RunWatchDecision = decideRunWatch({
+      run: { runId: "a", status: WorkflowStatus.Running },
+      pollCount: 1,
+    });
+
+    expect(decision.shouldContinue).toBe(true);
+    expect(decision.message).toMatch(/running/i);
+  });
+
+  test("keeps watching a scheduled run", () => {
+    expect(
+      decideRunWatch({
+        run: { runId: "a", status: WorkflowStatus.Scheduled },
+        pollCount: 1,
+      }).shouldContinue,
+    ).toBe(true);
+  });
+
+  test("stops on success with a plain statement", () => {
+    const decision: RunWatchDecision = decideRunWatch({
+      run: { runId: "a", status: WorkflowStatus.Success },
+      pollCount: 3,
+    });
+
+    expect(decision.shouldContinue).toBe(false);
+    expect(decision.message).toMatch(/finished successfully/i);
+  });
+
+  test("stops on failure and points at the logs", () => {
+    const decision: RunWatchDecision = decideRunWatch({
+      run: { runId: "a", status: WorkflowStatus.Error },
+      pollCount: 3,
+    });
+
+    expect(decision.shouldContinue).toBe(false);
+    expect(decision.message).toMatch(/Logs tab/);
+  });
+
+  test("stops on timeout", () => {
+    expect(
+      decideRunWatch({
+        run: { runId: "a", status: WorkflowStatus.Timeout },
+        pollCount: 3,
+      }).shouldContinue,
+    ).toBe(false);
+  });
+
+  test("stops following a run that went to sleep, and explains why", () => {
+    const decision: RunWatchDecision = decideRunWatch({
+      run: { runId: "a", status: WorkflowStatus.Waiting },
+      pollCount: 3,
+    });
+
+    expect(decision.shouldContinue).toBe(false);
+    expect(decision.message).toMatch(/sleeping/i);
+    expect(decision.message).toMatch(/carry on/i);
+  });
+
+  test("gives up rather than polling forever", () => {
+    const decision: RunWatchDecision = decideRunWatch({
+      run: { runId: "a", status: WorkflowStatus.Running },
+      pollCount: MAX_RUN_WATCH_POLLS,
+    });
+
+    expect(decision.shouldContinue).toBe(false);
+    expect(decision.message).toMatch(/taking a while/i);
+  });
+
+  test("gives up even when the run never appeared", () => {
+    const decision: RunWatchDecision = decideRunWatch({
+      run: null,
+      pollCount: MAX_RUN_WATCH_POLLS,
+    });
+
+    expect(decision.shouldContinue).toBe(false);
+  });
+
+  test("polls right up to the limit but not past it", () => {
+    expect(
+      decideRunWatch({
+        run: { runId: "a", status: WorkflowStatus.Running },
+        pollCount: MAX_RUN_WATCH_POLLS - 1,
+      }).shouldContinue,
+    ).toBe(true);
+  });
+});

--- a/Common/Types/SerializableObjectDictionary.ts
+++ b/Common/Types/SerializableObjectDictionary.ts
@@ -40,46 +40,140 @@ import Phone from "./Phone";
 import Port from "./Port";
 import Version from "./Version";
 
+/*
+ * Every entry is a getter, not a direct reference.
+ *
+ * Three of these classes — Includes, IncludesAll and IncludesNone — import
+ * JSONFunctions so their fromJSON can deserialize the values inside them, and
+ * JSONFunctions imports this dictionary. That is a cycle, and with a plain
+ * object literal the entry a cycle passes through is captured as `undefined`:
+ * whichever of the two modules loads second sees the first only half
+ * initialized. Which of them loads first depends on the whole app's import
+ * graph, so `{"_type":"Includes","value":[...]}` deserialized into a real
+ * Includes in some entry points and stayed a plain object in others — and a
+ * plain object reaching TypeORM is a silently wrong query, not an error.
+ *
+ * A getter defers the lookup to the first property access, by which time every
+ * module has finished initializing.
+ */
 const SerializableObjectDictionary: Dictionary<any> = {
-  [ObjectType.Phone]: Phone,
-  [ObjectType.DateTime]: OneUptimeDate,
-  [ObjectType.ObjectID]: ObjectID,
-  [ObjectType.Name]: Name,
-  [ObjectType.EqualTo]: EqualTo,
-  [ObjectType.EqualToOrNull]: EqualToOrNull,
-  [ObjectType.MonitorSteps]: MonitorSteps,
-  [ObjectType.MonitorStep]: MonitorStep,
-  [ObjectType.MonitorCriteria]: MonitorCriteria,
-  [ObjectType.MonitorCriteriaInstance]: MonitorCriteriaInstance,
-  [ObjectType.NotEqual]: NotEqual,
-  [ObjectType.Email]: Email,
-  [ObjectType.Color]: Color,
-  [ObjectType.Domain]: Domain,
-  [ObjectType.Version]: Version,
-  [ObjectType.Route]: Route,
-  [ObjectType.URL]: URL,
-  [ObjectType.IP]: IP,
-  [ObjectType.Search]: Search,
-  [ObjectType.MultiSearch]: MultiSearch,
-  [ObjectType.GreaterThan]: GreaterThan,
-  [ObjectType.GreaterThanOrEqual]: GreaterThanOrEqual,
-  [ObjectType.LessThan]: LessThan,
-  [ObjectType.LessThanOrEqual]: LessThanOrEqual,
-  [ObjectType.LessThanOrNull]: LessThanOrNull,
-  [ObjectType.GreaterThanOrNull]: GreaterThanOrNull,
-  [ObjectType.Port]: Port,
-  [ObjectType.Hostname]: Hostname,
-  [ObjectType.HashedString]: HashedString,
-  [ObjectType.InBetween]: InBetween,
-  [ObjectType.Includes]: Includes,
-  [ObjectType.IncludesAll]: IncludesAll,
-  [ObjectType.IncludesNone]: IncludesNone,
-  [ObjectType.StartsWith]: StartsWith,
-  [ObjectType.EndsWith]: EndsWith,
-  [ObjectType.NotContains]: NotContains,
-  [ObjectType.NotNull]: NotNull,
-  [ObjectType.IsNull]: IsNull,
-  [ObjectType.Recurring]: Recurring,
+  get [ObjectType.Phone](): any {
+    return Phone;
+  },
+  get [ObjectType.DateTime](): any {
+    return OneUptimeDate;
+  },
+  get [ObjectType.ObjectID](): any {
+    return ObjectID;
+  },
+  get [ObjectType.Name](): any {
+    return Name;
+  },
+  get [ObjectType.EqualTo](): any {
+    return EqualTo;
+  },
+  get [ObjectType.EqualToOrNull](): any {
+    return EqualToOrNull;
+  },
+  get [ObjectType.MonitorSteps](): any {
+    return MonitorSteps;
+  },
+  get [ObjectType.MonitorStep](): any {
+    return MonitorStep;
+  },
+  get [ObjectType.MonitorCriteria](): any {
+    return MonitorCriteria;
+  },
+  get [ObjectType.MonitorCriteriaInstance](): any {
+    return MonitorCriteriaInstance;
+  },
+  get [ObjectType.NotEqual](): any {
+    return NotEqual;
+  },
+  get [ObjectType.Email](): any {
+    return Email;
+  },
+  get [ObjectType.Color](): any {
+    return Color;
+  },
+  get [ObjectType.Domain](): any {
+    return Domain;
+  },
+  get [ObjectType.Version](): any {
+    return Version;
+  },
+  get [ObjectType.Route](): any {
+    return Route;
+  },
+  get [ObjectType.URL](): any {
+    return URL;
+  },
+  get [ObjectType.IP](): any {
+    return IP;
+  },
+  get [ObjectType.Search](): any {
+    return Search;
+  },
+  get [ObjectType.MultiSearch](): any {
+    return MultiSearch;
+  },
+  get [ObjectType.GreaterThan](): any {
+    return GreaterThan;
+  },
+  get [ObjectType.GreaterThanOrEqual](): any {
+    return GreaterThanOrEqual;
+  },
+  get [ObjectType.LessThan](): any {
+    return LessThan;
+  },
+  get [ObjectType.LessThanOrEqual](): any {
+    return LessThanOrEqual;
+  },
+  get [ObjectType.LessThanOrNull](): any {
+    return LessThanOrNull;
+  },
+  get [ObjectType.GreaterThanOrNull](): any {
+    return GreaterThanOrNull;
+  },
+  get [ObjectType.Port](): any {
+    return Port;
+  },
+  get [ObjectType.Hostname](): any {
+    return Hostname;
+  },
+  get [ObjectType.HashedString](): any {
+    return HashedString;
+  },
+  get [ObjectType.InBetween](): any {
+    return InBetween;
+  },
+  get [ObjectType.Includes](): any {
+    return Includes;
+  },
+  get [ObjectType.IncludesAll](): any {
+    return IncludesAll;
+  },
+  get [ObjectType.IncludesNone](): any {
+    return IncludesNone;
+  },
+  get [ObjectType.StartsWith](): any {
+    return StartsWith;
+  },
+  get [ObjectType.EndsWith](): any {
+    return EndsWith;
+  },
+  get [ObjectType.NotContains](): any {
+    return NotContains;
+  },
+  get [ObjectType.NotNull](): any {
+    return NotNull;
+  },
+  get [ObjectType.IsNull](): any {
+    return IsNull;
+  },
+  get [ObjectType.Recurring](): any {
+    return Recurring;
+  },
 };
 
 export default SerializableObjectDictionary;

--- a/Common/Types/Workflow/Components/BaseModel.ts
+++ b/Common/Types/Workflow/Components/BaseModel.ts
@@ -19,9 +19,13 @@ export default class BaseModelComponent {
      * Every one of these arguments is keyed on column names, and the single
      * most common way to get one wrong is to write "id" - which is what an ID
      * is called everywhere else in the product - when the column is "_id".
-     * Both spellings work now, but the hint has to say so where the builder is
-     * actually typing, because the Query argument is a bare JSON editor with
-     * no field picker behind it.
+     * Both spellings work.
+     *
+     * Query and record arguments now get a row editor backed by the model's
+     * real column list (ModelColumnEditor), so the names are offered rather
+     * than remembered. The hint stays because that editor keeps a JSON escape
+     * hatch for the queries rows cannot express, and because it is still the
+     * only thing explaining the two spellings.
      */
     const columnHint: string = `Keys are column names on ${model.singularName}. The ID column is "_id" (the "id" spelling is accepted too).`;
 

--- a/Common/UI/Components/Workflow/ArgumentsForm.tsx
+++ b/Common/UI/Components/Workflow/ArgumentsForm.tsx
@@ -6,6 +6,7 @@ import { CustomElementProps } from "../Forms/Types/Field";
 import FormValues from "../Forms/Types/FormValues";
 import ComponentValuePickerModal from "./ComponentValuePickerModal";
 import CronScheduleField from "./CronScheduleField";
+import ModelColumnEditor, { ModelColumnEditorMode } from "./ModelColumnEditor";
 import ModelFieldPicker from "./ModelFieldPicker";
 import {
   componentInputTypeToFormFieldType,
@@ -308,6 +309,25 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
                   const useCronPicker: boolean =
                     arg.type === ComponentInputType.CronTab;
 
+                  /*
+                   * Query arguments (which records does this act on) and
+                   * BaseModel arguments (which values does it write) are both
+                   * keyed on the model's columns, so both get the row editor
+                   * backed by the model schema. Same tableName requirement as
+                   * the field picker.
+                   *
+                   * BaseModelArray is deliberately not included: it holds a
+                   * list of records, which rows cannot represent.
+                   */
+                  const columnEditorMode: ModelColumnEditorMode | undefined =
+                    !component.metadata.tableName
+                      ? undefined
+                      : arg.type === ComponentInputType.Query
+                        ? ModelColumnEditorMode.Query
+                        : arg.type === ComponentInputType.BaseModel
+                          ? ModelColumnEditorMode.Record
+                          : undefined;
+
                   let baseField: {
                     fieldType: import("../Forms/Types/FormFieldSchemaType").default;
                     dropdownOptions?: Array<DropdownOption> | undefined;
@@ -317,7 +337,29 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
                     ) => ReactElement | undefined;
                   };
 
-                  if (useFieldPicker) {
+                  if (columnEditorMode) {
+                    baseField = {
+                      fieldType: FormFieldSchemaType.CustomComponent,
+                      getCustomElement: (
+                        _values: FormValues<JSONObject>,
+                        customProps: CustomElementProps,
+                      ): ReactElement => {
+                        return (
+                          <ModelColumnEditor
+                            tableName={component.metadata.tableName as string}
+                            mode={columnEditorMode}
+                            initialValue={customProps.initialValue}
+                            onChange={(value: string) => {
+                              void customProps.onChange?.(value);
+                            }}
+                            placeholder={customProps.placeholder}
+                            error={customProps.error}
+                            tabIndex={customProps.tabIndex}
+                          />
+                        );
+                      },
+                    };
+                  } else if (useFieldPicker) {
                     baseField = {
                       fieldType: FormFieldSchemaType.CustomComponent,
                       getCustomElement: (
@@ -386,7 +428,10 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
                    * and a schedule can't reference component return values).
                    */
                   const showVariableFooter: boolean =
-                    !isWorkflowSelect && !useFieldPicker && !useCronPicker;
+                    !isWorkflowSelect &&
+                    !useFieldPicker &&
+                    !useCronPicker &&
+                    !columnEditorMode;
 
                   const isAdvanced: boolean = isCollapsibleAdvanced(arg);
 

--- a/Common/UI/Components/Workflow/ModelColumnEditor.tsx
+++ b/Common/UI/Components/Workflow/ModelColumnEditor.tsx
@@ -1,0 +1,396 @@
+/*
+ * A row-based editor for the two workflow arguments that are keyed on a
+ * model's columns: the Query that picks which records a component acts on,
+ * and the record of values a create/update writes.
+ *
+ * Both were bare JSON editors, with the column names — and, for a query, the
+ * operator syntax — left entirely to memory. The description on those
+ * arguments had to carry a hint about "_id" versus "id" precisely because
+ * nothing else told the builder what the columns were called.
+ *
+ * Everything needed to do better already existed: /model-schema/:tableName
+ * knows the columns, and DictionaryForm's operator mode emits exactly the
+ * {_type, value} shape that JSONFunctions.deserialize hydrates on the server
+ * (FindManyBaseModel and friends). This wires the two together, and keeps a
+ * JSON escape hatch for the values rows cannot express.
+ */
+
+import CodeEditor from "../CodeEditor/CodeEditor";
+import ComponentLoader from "../ComponentLoader/ComponentLoader";
+import DictionaryForm, { ValueType } from "../Dictionary/Dictionary";
+import { DictionaryEntryValue } from "../Dictionary/DictionaryFilterOperator";
+import Icon from "../Icon/Icon";
+import {
+  ModelSchemaColumn,
+  ModelSchemaState,
+  findColumn,
+  useModelSchema,
+} from "./ModelSchema";
+import CodeType from "../../../Types/Code/CodeType";
+import Dictionary from "../../../Types/Dictionary";
+import IconProp from "../../../Types/Icon/IconProp";
+import { JSONObject, ObjectType } from "../../../Types/JSON";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export enum ModelColumnEditorMode {
+  /** Conditions that select records: column, operator, value. */
+  Query = "Query",
+  /** Values to write: column, value. No operators — you cannot save a ">". */
+  Record = "Record",
+}
+
+export interface ComponentProps {
+  tableName: string;
+  mode: ModelColumnEditorMode;
+  initialValue?: string | JSONObject | null | undefined;
+  onChange: (value: string) => void;
+  error?: string | undefined;
+  placeholder?: string | undefined;
+  tabIndex?: number | undefined;
+}
+
+type ViewMode = "builder" | "json";
+
+/*
+ * Operator wrappers the row editor can show. Anything else in a stored query
+ * (an InBetween, a relation sub-object, a raw QueryHelper construct) keeps the
+ * JSON editor rather than being silently flattened.
+ */
+const REPRESENTABLE_OPERATOR_TYPES: Array<string> = [
+  ObjectType.EqualTo,
+  ObjectType.NotEqual,
+  ObjectType.Search,
+  ObjectType.NotContains,
+  ObjectType.StartsWith,
+  ObjectType.EndsWith,
+  ObjectType.GreaterThan,
+  ObjectType.GreaterThanOrEqual,
+  ObjectType.LessThan,
+  ObjectType.LessThanOrEqual,
+  ObjectType.IsNull,
+  ObjectType.NotNull,
+  ObjectType.Includes,
+  ObjectType.IncludesNone,
+];
+
+interface ParsedQuery {
+  /** The raw text, always kept so the JSON editor can show it verbatim. */
+  text: string;
+  /** The parsed object, or null when the text is not a JSON object. */
+  parsed: JSONObject | null;
+}
+
+type NormalizeInitialValueFunction = (
+  value: string | JSONObject | null | undefined,
+) => ParsedQuery;
+
+const normalizeInitialValue: NormalizeInitialValueFunction = (
+  value: string | JSONObject | null | undefined,
+): ParsedQuery => {
+  if (value === null || value === undefined || value === "") {
+    return { text: "", parsed: {} };
+  }
+
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return { text: JSON.stringify(value, null, 2), parsed: value };
+  }
+
+  if (typeof value !== "string") {
+    return { text: String(value), parsed: null };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return { text: value, parsed: parsed as JSONObject };
+    }
+
+    return { text: value, parsed: null };
+  } catch {
+    return { text: value, parsed: null };
+  }
+};
+
+interface CompatibilityResult {
+  compatible: boolean;
+  /** Shown to the builder so a locked JSON editor is never unexplained. */
+  reasons: Array<string>;
+}
+
+type ClassifyCompatibilityFunction = (
+  parsed: JSONObject | null,
+  columns: Array<ModelSchemaColumn>,
+  mode: ModelColumnEditorMode,
+) => CompatibilityResult;
+
+/**
+ * Can this value be shown as rows without losing anything?
+ *
+ * Deliberately conservative: when in doubt the JSON editor stays, because a
+ * value silently rewritten into something that means something else is far
+ * worse than one the builder has to keep editing as text.
+ */
+export const classifyColumnValueCompatibility: ClassifyCompatibilityFunction = (
+  parsed: JSONObject | null,
+  columns: Array<ModelSchemaColumn>,
+  mode: ModelColumnEditorMode,
+): CompatibilityResult => {
+  if (parsed === null) {
+    return {
+      compatible: false,
+      reasons: ["The current value isn't a JSON object."],
+    };
+  }
+
+  const reasons: Array<string> = [];
+
+  for (const key of Object.keys(parsed)) {
+    /*
+     * Columns are only checked when the schema actually loaded. An unknown key
+     * is worth saying out loud — it is the "id" versus "_id" mistake — but it
+     * does not force the JSON editor, since the runner accepts column names
+     * this endpoint does not surface.
+     */
+    if (columns.length > 0 && !findColumn(columns, key)) {
+      reasons.push(`"${key}" isn't a known column on this model.`);
+    }
+
+    const value: unknown = parsed[key];
+
+    if (value === null) {
+      continue;
+    }
+
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      reasons.push(
+        `"${key}" holds a list. Use the "is any of" operator instead, or keep editing as JSON.`,
+      );
+      continue;
+    }
+
+    if (typeof value === "object") {
+      const objectType: unknown = (value as JSONObject)["_type"];
+
+      if (
+        mode === ModelColumnEditorMode.Query &&
+        typeof objectType === "string" &&
+        REPRESENTABLE_OPERATOR_TYPES.includes(objectType)
+      ) {
+        continue;
+      }
+
+      if (typeof objectType === "string") {
+        reasons.push(`"${key}" uses ${objectType}, which the rows can't show.`);
+        continue;
+      }
+
+      reasons.push(
+        `"${key}" holds a nested record, which the rows can't show.`,
+      );
+      continue;
+    }
+
+    reasons.push(`"${key}" has an unexpected value.`);
+  }
+
+  /*
+   * An unknown column name is a warning, not a reason to lock the editor —
+   * the builder can still fix it in the row that shows it.
+   */
+  const blocking: Array<string> = reasons.filter((reason: string) => {
+    return !reason.includes("isn't a known column");
+  });
+
+  return { compatible: blocking.length === 0, reasons: reasons };
+};
+
+type BuildQueryJsonFunction = (
+  value: Dictionary<DictionaryEntryValue>,
+) => string;
+
+/**
+ * The rows, as the string stored on the workflow argument.
+ *
+ * Empty collapses to "" rather than "{}" so a required argument still reads as
+ * empty to form validation and to the graph linter.
+ */
+export const buildColumnValueJson: BuildQueryJsonFunction = (
+  value: Dictionary<DictionaryEntryValue>,
+): string => {
+  const entries: JSONObject = {};
+
+  for (const key of Object.keys(value)) {
+    if (key.trim() === "") {
+      continue;
+    }
+
+    entries[key] = value[key] as never;
+  }
+
+  if (Object.keys(entries).length === 0) {
+    return "";
+  }
+
+  /*
+   * The operator wrappers serialize themselves through toJSON() into
+   * {_type, value}, which is exactly what the server rehydrates with
+   * JSONFunctions.deserialize.
+   */
+  return JSON.stringify(entries);
+};
+
+const ModelColumnEditor: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const schema: ModelSchemaState = useModelSchema(props.tableName);
+  const isQuery: boolean = props.mode === ModelColumnEditorMode.Query;
+
+  const initial: ParsedQuery = useMemo(() => {
+    return normalizeInitialValue(props.initialValue);
+  }, []);
+
+  const [jsonText, setJsonText] = useState<string>(initial.text);
+  const [viewMode, setViewMode] = useState<ViewMode>("builder");
+
+  /*
+   * The row editor is uncontrolled after mount (DictionaryForm seeds itself
+   * once), so the initial value is captured rather than recomputed.
+   */
+  const initialRows: React.MutableRefObject<Dictionary<DictionaryEntryValue>> =
+    useRef<Dictionary<DictionaryEntryValue>>(
+      (initial.parsed || {}) as Dictionary<DictionaryEntryValue>,
+    );
+
+  const compatibility: CompatibilityResult = useMemo(() => {
+    return classifyColumnValueCompatibility(
+      initial.parsed,
+      schema.columns || [],
+      props.mode,
+    );
+  }, [schema.columns, props.mode]);
+
+  const columnKeys: Array<string> = useMemo(() => {
+    return (schema.columns || []).map((column: ModelSchemaColumn) => {
+      return column.id;
+    });
+  }, [schema.columns]);
+
+  if (schema.isLoading) {
+    return <ComponentLoader />;
+  }
+
+  const isLockedToJson: boolean = !compatibility.compatible;
+  const effectiveMode: ViewMode = isLockedToJson ? "json" : viewMode;
+
+  type OnJsonChangeFunction = (value: string) => void;
+
+  const onJsonChange: OnJsonChangeFunction = (value: string): void => {
+    setJsonText(value);
+    props.onChange(value);
+  };
+
+  type OnRowsChangeFunction = (value: Dictionary<DictionaryEntryValue>) => void;
+
+  const onRowsChange: OnRowsChangeFunction = (
+    value: Dictionary<DictionaryEntryValue>,
+  ): void => {
+    const asJson: string = buildColumnValueJson(value);
+    setJsonText(asJson);
+    props.onChange(asJson);
+  };
+
+  return (
+    <div>
+      {schema.error && (
+        <p className="text-sm text-amber-600 mb-2">
+          Couldn&apos;t load this model&apos;s columns ({schema.error}). You can
+          still write the query as JSON.
+        </p>
+      )}
+
+      {isLockedToJson && compatibility.reasons.length > 0 && (
+        <div className="mb-2 rounded-md border border-amber-200 bg-amber-50 p-3">
+          <p className="text-sm text-amber-800">Editing as JSON, because:</p>
+          <ul className="mt-1 list-disc pl-5 text-sm text-amber-700">
+            {compatibility.reasons.map((reason: string, i: number) => {
+              return <li key={i}>{reason}</li>;
+            })}
+          </ul>
+        </div>
+      )}
+
+      {!isLockedToJson && compatibility.reasons.length > 0 && (
+        <div className="mb-2 rounded-md border border-amber-200 bg-amber-50 p-3">
+          <ul className="list-disc pl-5 text-sm text-amber-700">
+            {compatibility.reasons.map((reason: string, i: number) => {
+              return <li key={i}>{reason}</li>;
+            })}
+          </ul>
+        </div>
+      )}
+
+      {effectiveMode === "builder" ? (
+        <DictionaryForm
+          keys={columnKeys}
+          enableOperators={isQuery}
+          valueTypes={[ValueType.Text, ValueType.Number, ValueType.Boolean]}
+          addButtonSuffix={isQuery ? "condition" : "field"}
+          keyPlaceholder="Column"
+          valuePlaceholder="Value"
+          initialValue={initialRows.current}
+          onChange={onRowsChange}
+        />
+      ) : (
+        <CodeEditor
+          type={CodeType.JSON}
+          tabIndex={props.tabIndex}
+          error={props.error}
+          initialValue={initial.text}
+          value={jsonText}
+          placeholder={props.placeholder}
+          onChange={onJsonChange}
+        />
+      )}
+
+      {!isLockedToJson && (
+        <div className="mt-2">
+          <button
+            type="button"
+            className="text-sm underline text-blue-500 hover:text-blue-600 cursor-pointer inline-flex items-center gap-1"
+            onClick={() => {
+              setViewMode(effectiveMode === "builder" ? "json" : "builder");
+            }}
+          >
+            <Icon icon={IconProp.Code} className="h-3.5 w-3.5" />
+            {effectiveMode === "builder"
+              ? "Edit as JSON"
+              : isQuery
+                ? "Back to conditions"
+                : "Back to fields"}
+          </button>
+        </div>
+      )}
+
+      {props.error && effectiveMode === "builder" && (
+        <p className="mt-1 text-sm text-red-400">{props.error}</p>
+      )}
+    </div>
+  );
+};
+
+export default ModelColumnEditor;

--- a/Common/UI/Components/Workflow/ModelSchema.ts
+++ b/Common/UI/Components/Workflow/ModelSchema.ts
@@ -1,0 +1,196 @@
+/*
+ * Shared access to the workflow /model-schema/:tableName endpoint.
+ *
+ * Three builder inputs are backed by a model's column list — the field picker
+ * for Select arguments, the query builder for Query arguments, and the record
+ * form for create/update arguments — and all three want the same fetch, the
+ * same loading and error handling, and the same column shape.
+ */
+
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import URL from "../../../Types/API/URL";
+import { JSONObject } from "../../../Types/JSON";
+import { WORKFLOW_URL } from "../../Config";
+import API from "../../Utils/API/API";
+import { useEffect, useState } from "react";
+
+/**
+ * A column as the endpoint describes it. `type` is deliberately a bare string
+ * rather than the server-side TableColumnType enum, so this file stays on the
+ * browser side of the wire format.
+ */
+export interface ModelSchemaColumn {
+  id: string;
+  title: string;
+  description?: string;
+  type: string;
+  isRelation: boolean;
+  relatedTableName?: string | undefined;
+  relatedColumns?: Array<ModelSchemaColumn> | undefined;
+}
+
+export interface ModelSchemaState {
+  columns: Array<ModelSchemaColumn> | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export type FetchModelSchemaFunction = (
+  tableName: string,
+) => Promise<Array<ModelSchemaColumn>>;
+
+export const fetchModelSchema: FetchModelSchemaFunction = async (
+  tableName: string,
+): Promise<Array<ModelSchemaColumn>> => {
+  const url: URL = URL.fromString(WORKFLOW_URL.toString()).addRoute(
+    `/model-schema/${encodeURIComponent(tableName)}`,
+  );
+
+  const result: HTTPResponse<JSONObject> | HTTPErrorResponse =
+    await API.get<JSONObject>({ url });
+
+  if (result instanceof HTTPErrorResponse) {
+    throw result;
+  }
+
+  const data: JSONObject = result.data as JSONObject;
+
+  return (data["columns"] as unknown as Array<ModelSchemaColumn>) || [];
+};
+
+export type UseModelSchemaFunction = (
+  tableName: string | undefined,
+) => ModelSchemaState;
+
+/**
+ * Load a model's columns, once per table name.
+ *
+ * Never throws: a failure leaves `columns` as an empty array and puts the
+ * message in `error`, so a caller can fall back to its JSON editor rather than
+ * showing the builder a blank panel.
+ */
+export const useModelSchema: UseModelSchemaFunction = (
+  tableName: string | undefined,
+): ModelSchemaState => {
+  const [columns, setColumns] = useState<Array<ModelSchemaColumn> | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(Boolean(tableName));
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!tableName) {
+      setColumns([]);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled: boolean = false;
+
+    const load: () => Promise<void> = async (): Promise<void> => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const loaded: Array<ModelSchemaColumn> =
+          await fetchModelSchema(tableName);
+
+        if (cancelled) {
+          return;
+        }
+
+        setColumns(loaded);
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+
+        setError(API.getFriendlyMessage(err));
+        setColumns([]);
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tableName]);
+
+  return { columns: columns, isLoading: isLoading, error: error };
+};
+
+/*
+ * Column types that hold a single scalar the builder can sensibly type into a
+ * box. Everything else (relations, JSON blobs, buffers) needs the JSON editor.
+ */
+const SCALAR_COLUMN_TYPES: Array<string> = [
+  "ShortText",
+  "LongText",
+  "VeryLongText",
+  "Slug",
+  "Email",
+  "Phone",
+  "Color",
+  "Domain",
+  "Name",
+  "Description",
+  "ObjectID",
+  "Number",
+  "PositiveNumber",
+  "Boolean",
+  "Date",
+  "Password",
+  "HashedString",
+  "Port",
+  "Hostname",
+  "URL",
+  "Route",
+  "IP",
+  "Version",
+  "Markdown",
+  "HTML",
+  "JavaScript",
+  "CSS",
+];
+
+export type IsScalarColumnFunction = (column: ModelSchemaColumn) => boolean;
+
+export const isScalarColumn: IsScalarColumnFunction = (
+  column: ModelSchemaColumn,
+): boolean => {
+  return !column.isRelation && SCALAR_COLUMN_TYPES.includes(column.type);
+};
+
+export type IsNumericColumnFunction = (column: ModelSchemaColumn) => boolean;
+
+export const isNumericColumn: IsNumericColumnFunction = (
+  column: ModelSchemaColumn,
+): boolean => {
+  return column.type === "Number" || column.type === "PositiveNumber";
+};
+
+export type IsBooleanColumnFunction = (column: ModelSchemaColumn) => boolean;
+
+export const isBooleanColumn: IsBooleanColumnFunction = (
+  column: ModelSchemaColumn,
+): boolean => {
+  return column.type === "Boolean";
+};
+
+export type FindColumnFunction = (
+  columns: Array<ModelSchemaColumn>,
+  columnId: string,
+) => ModelSchemaColumn | undefined;
+
+export const findColumn: FindColumnFunction = (
+  columns: Array<ModelSchemaColumn>,
+  columnId: string,
+): ModelSchemaColumn | undefined => {
+  return columns.find((column: ModelSchemaColumn) => {
+    return column.id === columnId;
+  });
+};

--- a/Common/UI/Components/Workflow/RunStatusWatcher.ts
+++ b/Common/UI/Components/Workflow/RunStatusWatcher.ts
@@ -1,0 +1,122 @@
+/*
+ * Pure helpers behind the builder's "what happened to the run I just started"
+ * strip.
+ *
+ * Triggering a run from the builder used to end at a modal saying the workflow
+ * had been scheduled and that the Logs tab would know more. That left the one
+ * question the builder actually has — did it work — to a different page, a
+ * table, and a text blob. The runner does not hand back a log id at enqueue
+ * time (RunWorkflow creates the WorkflowLog itself once it picks the job up),
+ * so the builder watches for the run instead of being told about it.
+ *
+ * The logic that decides when to stop watching lives here, separate from the
+ * page, because it is the part worth testing.
+ */
+
+import WorkflowStatus from "../../../Types/Workflow/WorkflowStatus";
+
+/**
+ * Statuses a run never moves on from. Waiting is not one of them — a Sleep
+ * step parks a run for as long as it likes and it carries on afterwards.
+ */
+const TERMINAL_STATUSES: Array<WorkflowStatus> = [
+  WorkflowStatus.Success,
+  WorkflowStatus.Error,
+  WorkflowStatus.Timeout,
+  WorkflowStatus.WorkflowCountExceeded,
+];
+
+export type IsTerminalRunStatusFunction = (
+  status: WorkflowStatus | null | undefined,
+) => boolean;
+
+export const isTerminalRunStatus: IsTerminalRunStatusFunction = (
+  status: WorkflowStatus | null | undefined,
+): boolean => {
+  if (!status) {
+    return false;
+  }
+
+  return TERMINAL_STATUSES.includes(status);
+};
+
+export type IsFailedRunStatusFunction = (
+  status: WorkflowStatus | null | undefined,
+) => boolean;
+
+export const isFailedRunStatus: IsFailedRunStatusFunction = (
+  status: WorkflowStatus | null | undefined,
+): boolean => {
+  return (
+    status === WorkflowStatus.Error ||
+    status === WorkflowStatus.Timeout ||
+    status === WorkflowStatus.WorkflowCountExceeded
+  );
+};
+
+/*
+ * How long to keep watching. A run that suspends on a Sleep step can outlive
+ * any sensible watch, so the strip stops following it and points at the Logs
+ * tab rather than polling for hours.
+ */
+export const MAX_RUN_WATCH_POLLS: number = 60;
+export const RUN_WATCH_POLL_INTERVAL_MS: number = 2000;
+
+export interface WatchedRun {
+  runId: string;
+  status: WorkflowStatus;
+}
+
+export interface RunWatchDecision {
+  /** Poll again? */
+  shouldContinue: boolean;
+  /** Text for the strip. Null when there is nothing to say yet. */
+  message: string | null;
+}
+
+export type DecideRunWatchFunction = (params: {
+  run: WatchedRun | null;
+  pollCount: number;
+}) => RunWatchDecision;
+
+/**
+ * What the strip should say, and whether to keep looking.
+ */
+export const decideRunWatch: DecideRunWatchFunction = (params: {
+  run: WatchedRun | null;
+  pollCount: number;
+}): RunWatchDecision => {
+  if (params.pollCount >= MAX_RUN_WATCH_POLLS) {
+    return {
+      shouldContinue: false,
+      message:
+        "This run is taking a while. Open the Logs tab to follow it from there.",
+    };
+  }
+
+  if (!params.run) {
+    return { shouldContinue: true, message: "Starting run…" };
+  }
+
+  if (isTerminalRunStatus(params.run.status)) {
+    return {
+      shouldContinue: false,
+      message: isFailedRunStatus(params.run.status)
+        ? `Run ${params.run.status.toLowerCase()}. Open the Logs tab to see why.`
+        : "Run finished successfully.",
+    };
+  }
+
+  if (params.run.status === WorkflowStatus.Waiting) {
+    return {
+      shouldContinue: false,
+      message:
+        "This run is sleeping and will carry on by itself. Follow it in the Logs tab.",
+    };
+  }
+
+  return {
+    shouldContinue: true,
+    message: `Run ${params.run.status.toLowerCase()}…`,
+  };
+};


### PR DESCRIPTION
Follow-up to #3158, which made workflow mistakes *visible*. This one removes a class of them entirely, and closes the loop after you press Run.

## Why

Three things were left after the last pass:

- **Every database component's most important argument was a raw JSON textarea.** "Which records does this act on" and "what values does it write" are both keyed on a model's columns, and the builder had to remember both the column names and the operator syntax. The description on those arguments literally carried a hint about `_id` versus `id` because nothing else told you what the columns were called — and the code comment behind it said why: *"the Query argument is a bare JSON editor with no field picker behind it."*
- **Pressing "Run Workflow" ended at a modal saying it had been scheduled**, and pointed at a different tab. The one question you actually have — did it work — needed a page, a table and a text blob.
- Everything needed to fix the first one already existed: `/model-schema/:tableName` knows the columns, and `DictionaryForm`'s operator mode emits exactly the `{_type, value}` shape `JSONFunctions.deserialize` hydrates on the server. Nothing had wired them together.

## What changed

**1. A row editor for Query and record arguments** (`ModelColumnEditor`). Column, operator, value — with the column names offered from the model's real schema, and the operator list limited to the ones the server can actually rehydrate. Records use the same editor without operators, since you cannot save a "greater than".

It keeps a JSON escape hatch, and it is deliberately conservative about when it takes over: a nested relation query, an operator the rows can't show, a whole-field `{{...}}` substitution, or anything that isn't a JSON object all stay in the JSON editor, with a banner saying which of those it was. An unknown column name is reported but does *not* lock the editor — that's the `id`/`_id` mistake, and you need to see the row to fix it.

`BaseModelArray` deliberately keeps the JSON editor: it holds a list of records, which rows can't represent.

**2. The builder now tells you what happened to the run it started.** The manual-run endpoint can't return a log id (`RunWorkflow` creates the `WorkflowLog` when a worker picks the job up), so the builder notes the newest run before triggering and watches for a different one. It reports Scheduled → Running → finished, and stops watching a run that goes to sleep on a `Sleep` step rather than polling for hours.

**3. Shared model-schema access** (`ModelSchema.ts`). The field picker, the query builder and the record editor all wanted the same fetch, loading and error handling.

## The bug this turned up

Writing the round-trip test for the query builder surfaced a real one, and it is the reason this PR touches a core file.

`Includes`, `IncludesAll` and `IncludesNone` import `JSONFunctions` (their `fromJSON` deserializes the values inside them), and `JSONFunctions` imports `SerializableObjectDictionary`, which imports them back. With a plain object literal, **the entry a cycle passes through is captured as `undefined`** — whichever module initializes second sees the other half-built. Which one that is depends on the whole app's import graph.

The effect: `{"_type":"Includes","value":[...]}` deserialized into a real `Includes` from some entry points and stayed a plain object from others. A plain object reaching TypeORM is a **silently wrong query**, not an error. `is any of` / `is none of` are ordinary filter operators, so this was reachable well before this PR.

Fixed by making every dictionary entry a lazy getter, which defers the lookup past module initialization. The existing `SerializableObjectDictionary.test.ts` is untouched and still passes (its completeness and `fromJSON` checks read straight through the getters). A new `SerializableObjectDictionaryImportCycle.test.ts` sits alongside it and imports the three cyclic classes **first** — the order that used to break — because jest gives each file its own module registry, so the import order is the thing under test and needs its own file.

I've kept this fix in the same PR because the query builder emits those operators, so shipping it without the fix would ship a broken "is any of".

## Tests

88 new assertions across 5 new suites, and a **618-assertion regression across 46 suites** covering serialization, every query operator, query building and the existing workflow suites — run because the dictionary change touches a core path.

| Suite | Covers |
|---|---|
| `Types/SerializableObjectDictionaryImportCycle.test.ts` | the three cyclic classes resolve under adverse import order; every operator survives serialize → parse → deserialize, including `ObjectID`s inside a membership list and both bounds of an `InBetween` |
| `Workflow/ModelColumnEditorServerContract.test.ts` | the full path a real run takes — builder rows → stored string → runner's `JSON.parse` → component's `JSONFunctions.deserialize` — asserted per operator |
| `Workflow/ModelColumnEditor.test.ts` | which stored values can be shown as rows and which must stay JSON; what the rows serialize to; that the two agree |
| `Workflow/ModelSchema.test.ts` | column classification, lookup, fetch behaviour, error propagation, path escaping |
| `Workflow/RunStatusWatcher.test.ts` | when to keep watching, when to stop, the `Waiting` case, and the poll ceiling |
| existing workflow + forms suites | unchanged, re-run as regression |

The tests are weighted toward the cases that would make this unshippable: an operator that looks fine but doesn't deserialize, a query the rows would silently flatten, and a template placeholder being mistaken for structure.

## Still to come

Deliberately not in this PR, each for a stated reason:

- **Per-step run trace** — the biggest remaining win, but it needs a `WorkflowLog` schema migration and its own runner changes. Wants to be its own change.
- **Test a single step** — needs a new authenticated endpoint that executes one component as root; that is a real security surface and deserves separate review.
- **Workflow templates** — needs product content decisions, not just plumbing.
