### PR TITLE
feat(workflow): record what each step of a run did, and show it

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Workflow/View/Logs.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Workflow/View/Logs.tsx
@@ -7,6 +7,13 @@ import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import SimpleLogViewer from "Common/UI/Components/SimpleLogViewer/SimpleLogViewer";
+import StepTraceViewer from "Common/UI/Components/Workflow/StepTraceViewer";
+import {
+  WorkflowStepTrace,
+  emptyTrace,
+  parseTrace,
+} from "Common/Types/Workflow/StepTrace";
+import { JSONValue } from "Common/Types/JSON";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import WorkflowStatusElement from "Common/UI/Components/Workflow/WorkflowStatus";
 import DropdownUtil from "Common/UI/Utils/Dropdown";
@@ -25,6 +32,7 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
 
   const [showViewLogsModal, setShowViewLogsModal] = useState<boolean>(false);
   const [logs, setLogs] = useState<string>("");
+  const [stepTrace, setStepTrace] = useState<WorkflowStepTrace>(emptyTrace());
 
   return (
     <Fragment>
@@ -46,6 +54,7 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
           }}
           selectMoreFields={{
             logs: true,
+            stepTrace: true,
           }}
           actionButtons={[
             {
@@ -57,6 +66,7 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
                 onCompleteAction: VoidFunction,
               ) => {
                 setLogs(item["logs"] as string);
+                setStepTrace(parseTrace((item["stepTrace"] as JSONValue) || null));
                 setShowViewLogsModal(true);
 
                 onCompleteAction();
@@ -175,9 +185,23 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
             submitButtonText={"Close"}
             submitButtonStyleType={ButtonStyleType.NORMAL}
           >
-            <SimpleLogViewer title="Workflow Execution Log" height="500px">
-              {logs}
-            </SimpleLogViewer>
+            <div className="space-y-4">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900 mb-2">
+                  Steps
+                </h3>
+                <StepTraceViewer trace={stepTrace} />
+              </div>
+
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900 mb-2">
+                  Full log
+                </h3>
+                <SimpleLogViewer title="Workflow Execution Log" height="300px">
+                  {logs}
+                </SimpleLogViewer>
+              </div>
+            </div>
           </Modal>
         )}
       </>

--- a/App/FeatureSet/Workflow/Services/RunWorkflow.ts
+++ b/App/FeatureSet/Workflow/Services/RunWorkflow.ts
@@ -21,6 +21,15 @@ import {
   TemplateExpressionKind,
   parseTemplateExpressions,
 } from "Common/Types/Workflow/TemplateSyntax";
+import {
+  WorkflowStepStatus,
+  WorkflowStepTrace,
+  WorkflowStepTraceEntry,
+  appendTraceStep,
+  emptyTrace,
+  parseTrace,
+  truncateTraceValues,
+} from "Common/Types/Workflow/StepTrace";
 import WorkflowStatus from "Common/Types/Workflow/WorkflowStatus";
 import WorkflowLogService from "Common/Server/Services/WorkflowLogService";
 import WorkflowService from "Common/Server/Services/WorkflowService";
@@ -115,6 +124,7 @@ export default class RunWorkflow {
   private workflowLogId: ObjectID | null = null;
   private callChain: Array<string> = [];
   private workflowDeadlineAtInMs: number = 0;
+  private stepTrace: WorkflowStepTrace = emptyTrace();
 
   private getRemainingExecutionTimeInMs(): number {
     return getRemainingWorkflowTimeInMs(this.workflowDeadlineAtInMs);
@@ -187,6 +197,7 @@ export default class RunWorkflow {
             select: {
               resumeData: true,
               logs: true,
+              stepTrace: true,
             },
             props: {
               isRoot: true,
@@ -203,6 +214,14 @@ export default class RunWorkflow {
         if (existingLog.logs) {
           this.logs = [existingLog.logs as string];
         }
+
+        /*
+         * And the trace, so a run that slept reads as one continuous list of
+         * steps rather than restarting at whatever ran after it woke up.
+         */
+        this.stepTrace = parseTrace(
+          (existingLog.stepTrace as JSONValue) || null,
+        );
 
         const persisted: JSONObject = existingLog.resumeData as JSONObject;
 
@@ -396,11 +415,50 @@ export default class RunWorkflow {
         );
         this.log("Component Logs: " + executeComponentId);
 
-        const result: RunReturnType = await this.runComponent(
-          args,
-          stackItem.node,
-          setDidErrorOut,
-        );
+        const stepStartedAt: Date = OneUptimeDate.getCurrentDate();
+        let result: RunReturnType;
+
+        try {
+          result = await this.runComponent(
+            args,
+            stackItem.node,
+            setDidErrorOut,
+          );
+        } catch (stepError: unknown) {
+          /*
+           * Record the step that broke before letting the failure travel on.
+           * Without this the trace stops at the last step that worked, which
+           * is precisely the one nobody needs to look at.
+           */
+          this.recordStep({
+            node: stackItem.node,
+            args: args,
+            returnValues: {},
+            executedPort: null,
+            startedAt: stepStartedAt,
+            errorMessage:
+              stepError instanceof Exception
+                ? stepError.getMessage()
+                : String(stepError),
+          });
+
+          throw stepError;
+        }
+
+        /*
+         * A component can report failure by calling options.onError rather than
+         * throwing, which is how the API components signal their error port.
+         */
+        this.recordStep({
+          node: stackItem.node,
+          args: args,
+          returnValues: result.returnValues,
+          executedPort: result.executePort?.id || null,
+          startedAt: stepStartedAt,
+          errorMessage: didWorkflowErrorOut
+            ? "The component reported an error."
+            : undefined,
+        });
 
         /*
          * Check immediately after awaiting the component as well as before the
@@ -485,6 +543,7 @@ export default class RunWorkflow {
         data: {
           workflowStatus: WorkflowStatus.Success,
           logs: this.logs.join("\n"),
+          stepTrace: this.stepTrace as any,
           completedAt: OneUptimeDate.getCurrentDate(),
           // Run finished — drop any leftover suspend state.
           resumeData: null!,
@@ -510,6 +569,7 @@ export default class RunWorkflow {
           data: {
             workflowStatus: WorkflowStatus.Timeout,
             logs: this.logs.join("\n"),
+            stepTrace: this.stepTrace as any,
             completedAt: OneUptimeDate.getCurrentDate(),
             resumeData: null!,
             resumeAt: null!,
@@ -522,6 +582,7 @@ export default class RunWorkflow {
           data: {
             workflowStatus: WorkflowStatus.Error,
             logs: this.logs.join("\n"),
+            stepTrace: this.stepTrace as any,
             completedAt: OneUptimeDate.getCurrentDate(),
             resumeData: null!,
             resumeAt: null!,
@@ -579,6 +640,12 @@ export default class RunWorkflow {
       data: {
         workflowStatus: WorkflowStatus.Waiting,
         logs: this.logs.join("\n"),
+        /*
+         * Written on suspend as well as on completion: a parked run should be
+         * readable while it waits, and the steps it already took are exactly
+         * what someone checking on it wants to see.
+         */
+        stepTrace: this.stepTrace as any,
         resumeAt: resumeAt,
         /*
          * Cast keeps TS from deeply re-instantiating the recursive JSONObject
@@ -635,6 +702,52 @@ export default class RunWorkflow {
    * Compares against the input rather than just scanning the output, so a
    * resolved value that happens to contain braces of its own is not reported.
    */
+  /**
+   * Add one step to the run's trace.
+   *
+   * Redaction goes through exactly the same helper the text log uses, so a
+   * value hidden in `logs` cannot reappear here — the trace is readable by
+   * anyone who can read the log, and these are the same secrets.
+   */
+  private recordStep(params: {
+    node: NodeDataProp;
+    args: JSONObject;
+    returnValues: JSONObject;
+    executedPort: string | null;
+    startedAt: Date;
+    errorMessage?: string | undefined;
+  }): void {
+    const completedAt: Date = OneUptimeDate.getCurrentDate();
+
+    const entry: WorkflowStepTraceEntry = {
+      componentId: params.node.id,
+      metadataId: params.node.metadataId,
+      title: params.node.metadata?.title || params.node.metadataId,
+      status: params.errorMessage
+        ? WorkflowStepStatus.Error
+        : WorkflowStepStatus.Success,
+      startedAt: params.startedAt.toISOString(),
+      completedAt: completedAt.toISOString(),
+      durationInMs: completedAt.getTime() - params.startedAt.getTime(),
+      argumentValues: truncateTraceValues(
+        redactSensitiveComponentValuesForLogs(
+          params.args,
+          params.node.metadata?.arguments || [],
+        ),
+      ),
+      returnValues: truncateTraceValues(
+        redactSensitiveComponentValuesForLogs(
+          params.returnValues,
+          params.node.metadata?.returnValues || [],
+        ),
+      ),
+      executedPort: params.executedPort,
+      errorMessage: params.errorMessage,
+    };
+
+    this.stepTrace = appendTraceStep(this.stepTrace, entry);
+  }
+
   private logUnresolvedReferences(params: {
     argument: Argument;
     before: JSONValue;

--- a/App/Tests/FeatureSet/Workflow/RunWorkflowStepTrace.test.ts
+++ b/App/Tests/FeatureSet/Workflow/RunWorkflowStepTrace.test.ts
@@ -1,0 +1,400 @@
+/*
+ * The runner's side of the step trace: that a run records what each step did,
+ * that the trace is persisted with the run's final status, and — the part that
+ * matters most — that it redacts exactly what the text log redacts. The trace
+ * is readable by anyone who can read the log, so a secret hidden from one and
+ * not the other would be a leak dressed up as a feature.
+ */
+
+import Workflow from "Common/Models/DatabaseModels/Workflow";
+import WorkflowLogService from "Common/Server/Services/WorkflowLogService";
+import WorkflowService from "Common/Server/Services/WorkflowService";
+import { JSONObject } from "Common/Types/JSON";
+import IconProp from "Common/Types/Icon/IconProp";
+import ObjectID from "Common/Types/ObjectID";
+import ComponentMetadata, {
+  Argument,
+  ComponentInputType,
+  ComponentType,
+  NodeDataProp,
+  NodeType,
+  Port,
+  ReturnValue,
+} from "Common/Types/Workflow/Component";
+import WorkflowStatus from "Common/Types/Workflow/WorkflowStatus";
+import {
+  WorkflowStepStatus,
+  WorkflowStepTrace,
+  WorkflowStepTraceEntry,
+  parseTrace,
+} from "Common/Types/Workflow/StepTrace";
+import logger from "Common/Server/Utils/Logger";
+import RunWorkflow, {
+  RunStack,
+  StorageMap,
+  WORKFLOW_LOG_REDACTED_VALUE,
+} from "../../../FeatureSet/Workflow/Services/RunWorkflow";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+const WORKFLOW_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const WORKFLOW_LOG_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const PROJECT_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+const EMPTY_STORAGE_MAP: StorageMap = {
+  local: { variables: {}, components: {} },
+  global: { variables: {} },
+};
+
+interface RecordedSpy {
+  mock: { calls: Array<Array<unknown>> };
+}
+
+type ArgumentFunction = (id: string, isSensitive?: boolean) => Argument;
+
+const argument: ArgumentFunction = (
+  id: string,
+  isSensitive?: boolean,
+): Argument => {
+  return {
+    id: id,
+    name: id,
+    description: id,
+    type: ComponentInputType.Text,
+    required: false,
+    isSensitive: isSensitive,
+  };
+};
+
+type ReturnValueFunction = (id: string, isSensitive?: boolean) => ReturnValue;
+
+const returnValue: ReturnValueFunction = (
+  id: string,
+  isSensitive?: boolean,
+): ReturnValue => {
+  return {
+    id: id,
+    name: id,
+    description: id,
+    type: ComponentInputType.Text,
+    required: false,
+    isSensitive: isSensitive,
+  };
+};
+
+const SUCCESS_PORT: Port = {
+  id: "success",
+  title: "Success",
+  description: "Success",
+};
+
+type MetadataFunction = (params: {
+  args?: Array<Argument> | undefined;
+  returnValues?: Array<ReturnValue> | undefined;
+}) => ComponentMetadata;
+
+const metadata: MetadataFunction = (params: {
+  args?: Array<Argument> | undefined;
+  returnValues?: Array<ReturnValue> | undefined;
+}): ComponentMetadata => {
+  return {
+    id: "test-component",
+    title: "Test Component",
+    category: "Test",
+    description: "For tests",
+    iconProp: IconProp.Bolt,
+    componentType: ComponentType.Component,
+    arguments: params.args || [],
+    returnValues: params.returnValues || [],
+    inPorts: [],
+    outPorts: [SUCCESS_PORT],
+  };
+};
+
+type NodeFunction = (componentMetadata: ComponentMetadata) => NodeDataProp;
+
+const node: NodeFunction = (
+  componentMetadata: ComponentMetadata,
+): NodeDataProp => {
+  return {
+    error: "",
+    id: "test-component-1",
+    nodeType: NodeType.Node,
+    metadata: componentMetadata,
+    metadataId: componentMetadata.id,
+    internalId: "internal-1",
+    arguments: {},
+    returnValues: {},
+    componentType: ComponentType.Component,
+  };
+};
+
+type PrepareFunction = (
+  runner: RunWorkflow,
+  componentNode: NodeDataProp,
+) => RecordedSpy;
+
+const prepareSingleComponentRun: PrepareFunction = (
+  runner: RunWorkflow,
+  componentNode: NodeDataProp,
+): RecordedSpy => {
+  const workflowRow: Workflow = new Workflow();
+  workflowRow.graph = { nodes: [], edges: [] } as JSONObject;
+  workflowRow.projectId = PROJECT_ID;
+  workflowRow.isEnabled = true;
+
+  jest
+    .spyOn(WorkflowService as never, "findOneById")
+    .mockResolvedValue(workflowRow as never);
+
+  const updateLogSpy: RecordedSpy = jest
+    .spyOn(WorkflowLogService as never, "updateColumnsByIdWithoutHooks")
+    .mockResolvedValue(undefined as never) as unknown as RecordedSpy;
+
+  const runStack: RunStack = {
+    startWithComponentId: componentNode.id,
+    stack: { [componentNode.id]: { node: componentNode, outPorts: {} } },
+  };
+
+  jest.spyOn(runner, "makeRunStack").mockResolvedValue(runStack as never);
+  jest.spyOn(runner, "getVariables").mockResolvedValue({
+    storageMap: EMPTY_STORAGE_MAP,
+    variables: [],
+  } as never);
+
+  return updateLogSpy;
+};
+
+type LastTraceFunction = (updateLogSpy: RecordedSpy) => WorkflowStepTrace;
+
+const lastPersistedTrace: LastTraceFunction = (
+  updateLogSpy: RecordedSpy,
+): WorkflowStepTrace => {
+  const lastCall: unknown =
+    updateLogSpy.mock.calls[updateLogSpy.mock.calls.length - 1]?.[0];
+  const data: JSONObject = (lastCall as { data: JSONObject }).data;
+
+  return parseTrace(data["stepTrace"] as never);
+};
+
+describe("RunWorkflow step trace", () => {
+  beforeEach(() => {
+    jest.spyOn(logger, "error").mockImplementation((): void => {
+      return undefined;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("records the step that ran, with its component and port", async () => {
+    const componentNode: NodeDataProp = node(
+      metadata({ args: [argument("message")] }),
+    );
+    componentNode.arguments = { message: "hello" };
+
+    const runner: RunWorkflow = new RunWorkflow();
+    const updateLogSpy: RecordedSpy = prepareSingleComponentRun(
+      runner,
+      componentNode,
+    );
+
+    jest.spyOn(runner, "runComponent").mockResolvedValue({
+      returnValues: { result: "done" },
+      executePort: SUCCESS_PORT,
+    } as never);
+
+    await runner.runWorkflow({
+      arguments: {},
+      workflowId: WORKFLOW_ID,
+      workflowLogId: WORKFLOW_LOG_ID,
+      timeout: 5000,
+    });
+
+    const trace: WorkflowStepTrace = lastPersistedTrace(updateLogSpy);
+    const step: WorkflowStepTraceEntry = trace.steps[0] as WorkflowStepTraceEntry;
+
+    expect(trace.steps).toHaveLength(1);
+    expect(step.componentId).toBe("test-component-1");
+    expect(step.metadataId).toBe("test-component");
+    expect(step.title).toBe("Test Component");
+    expect(step.status).toBe(WorkflowStepStatus.Success);
+    expect(step.executedPort).toBe("success");
+    expect(step.argumentValues).toEqual({ message: "hello" });
+    expect(step.returnValues).toEqual({ result: "done" });
+  });
+
+  test("records timing that is present and not negative", async () => {
+    const componentNode: NodeDataProp = node(metadata({}));
+
+    const runner: RunWorkflow = new RunWorkflow();
+    const updateLogSpy: RecordedSpy = prepareSingleComponentRun(
+      runner,
+      componentNode,
+    );
+
+    jest
+      .spyOn(runner, "runComponent")
+      .mockResolvedValue({ returnValues: {} } as never);
+
+    await runner.runWorkflow({
+      arguments: {},
+      workflowId: WORKFLOW_ID,
+      workflowLogId: WORKFLOW_LOG_ID,
+      timeout: 5000,
+    });
+
+    const step: WorkflowStepTraceEntry = lastPersistedTrace(updateLogSpy)
+      .steps[0] as WorkflowStepTraceEntry;
+
+    expect(step.durationInMs).toBeGreaterThanOrEqual(0);
+    expect(Date.parse(step.startedAt)).not.toBeNaN();
+    expect(Date.parse(step.completedAt)).not.toBeNaN();
+  });
+
+  /*
+   * The trace carries the same values the text log does and is readable by the
+   * same people, so it has to hide the same things.
+   */
+  test("redacts sensitive arguments exactly as the log does", async () => {
+    const componentNode: NodeDataProp = node(
+      metadata({
+        args: [argument("apiKey", true), argument("url")],
+        returnValues: [returnValue("token", true), returnValue("status")],
+      }),
+    );
+    componentNode.arguments = {
+      apiKey: "super-secret",
+      url: "https://example.com",
+    };
+
+    const runner: RunWorkflow = new RunWorkflow();
+    const updateLogSpy: RecordedSpy = prepareSingleComponentRun(
+      runner,
+      componentNode,
+    );
+
+    jest.spyOn(runner, "runComponent").mockResolvedValue({
+      returnValues: { token: "secret-token", status: 200 },
+      executePort: SUCCESS_PORT,
+    } as never);
+
+    await runner.runWorkflow({
+      arguments: {},
+      workflowId: WORKFLOW_ID,
+      workflowLogId: WORKFLOW_LOG_ID,
+      timeout: 5000,
+    });
+
+    const step: WorkflowStepTraceEntry = lastPersistedTrace(updateLogSpy)
+      .steps[0] as WorkflowStepTraceEntry;
+
+    expect(step.argumentValues["apiKey"]).toBe(WORKFLOW_LOG_REDACTED_VALUE);
+    expect(step.argumentValues["url"]).toBe("https://example.com");
+    expect(step.returnValues["token"]).toBe(WORKFLOW_LOG_REDACTED_VALUE);
+    expect(step.returnValues["status"]).toBe(200);
+  });
+
+  test("the secret never appears anywhere in the persisted trace", async () => {
+    const componentNode: NodeDataProp = node(
+      metadata({ args: [argument("apiKey", true)] }),
+    );
+    componentNode.arguments = { apiKey: "super-secret-value" };
+
+    const runner: RunWorkflow = new RunWorkflow();
+    const updateLogSpy: RecordedSpy = prepareSingleComponentRun(
+      runner,
+      componentNode,
+    );
+
+    jest
+      .spyOn(runner, "runComponent")
+      .mockResolvedValue({ returnValues: {} } as never);
+
+    await runner.runWorkflow({
+      arguments: {},
+      workflowId: WORKFLOW_ID,
+      workflowLogId: WORKFLOW_LOG_ID,
+      timeout: 5000,
+    });
+
+    const serialized: string = JSON.stringify(
+      lastPersistedTrace(updateLogSpy),
+    );
+
+    expect(serialized).not.toContain("super-secret-value");
+  });
+
+  /*
+   * The step that broke the run is the one worth reading, so it has to be in
+   * the trace even though the failure aborts the loop.
+   */
+  test("records the failing step when a component throws", async () => {
+    const componentNode: NodeDataProp = node(metadata({}));
+
+    const runner: RunWorkflow = new RunWorkflow();
+    const updateLogSpy: RecordedSpy = prepareSingleComponentRun(
+      runner,
+      componentNode,
+    );
+
+    jest
+      .spyOn(runner, "runComponent")
+      .mockRejectedValue(new Error("component exploded") as never);
+
+    await runner.runWorkflow({
+      arguments: {},
+      workflowId: WORKFLOW_ID,
+      workflowLogId: WORKFLOW_LOG_ID,
+      timeout: 5000,
+    });
+
+    const trace: WorkflowStepTrace = lastPersistedTrace(updateLogSpy);
+    const step: WorkflowStepTraceEntry = trace.steps[0] as WorkflowStepTraceEntry;
+
+    expect(trace.steps).toHaveLength(1);
+    expect(step.status).toBe(WorkflowStepStatus.Error);
+    expect(step.errorMessage).toContain("component exploded");
+  });
+
+  test("persists the trace alongside the run's final status", async () => {
+    const componentNode: NodeDataProp = node(metadata({}));
+
+    const runner: RunWorkflow = new RunWorkflow();
+    const updateLogSpy: RecordedSpy = prepareSingleComponentRun(
+      runner,
+      componentNode,
+    );
+
+    jest
+      .spyOn(runner, "runComponent")
+      .mockResolvedValue({ returnValues: {} } as never);
+
+    await runner.runWorkflow({
+      arguments: {},
+      workflowId: WORKFLOW_ID,
+      workflowLogId: WORKFLOW_LOG_ID,
+      timeout: 5000,
+    });
+
+    const lastCall: unknown =
+      updateLogSpy.mock.calls[updateLogSpy.mock.calls.length - 1]?.[0];
+    const data: JSONObject = (lastCall as { data: JSONObject }).data;
+
+    expect(data["workflowStatus"]).toBe(WorkflowStatus.Success);
+    expect(data["stepTrace"]).toBeDefined();
+  });
+});

--- a/Common/Models/DatabaseModels/WorkflowLog.ts
+++ b/Common/Models/DatabaseModels/WorkflowLog.ts
@@ -348,6 +348,44 @@ export default class WorkflowLog extends BaseModel {
   })
   public resumeData?: JSONObject = undefined;
 
+  /*
+   * What each step of the run did, as data rather than as lines in `logs`:
+   * the component, its resolved arguments, what it returned, which out port it
+   * took and how long it took. Readable by anyone who can read the log itself,
+   * because it is the same information in a shape that can be rendered as a
+   * list of steps instead of a wall of text.
+   *
+   * Sensitive arguments and return values are redacted before they get here,
+   * by the same rules that redact them in `logs`.
+   */
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.WorkflowAdmin,
+      Permission.WorkflowMember,
+      Permission.WorkflowViewer,
+      Permission.ReadWorkflowLog,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    isDefaultValueColumn: false,
+    type: TableColumnType.JSON,
+    title: "Step Trace",
+    description:
+      "Structured per-step record of this run: arguments, return values, the port taken and timing.",
+  })
+  @Column({
+    type: ColumnType.JSON,
+    nullable: true,
+  })
+  public stepTrace?: JSONObject = undefined;
+
   @ColumnAccessControl({
     create: [],
     read: [],

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786559879134-AddWorkflowLogStepTrace.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786559879134-AddWorkflowLogStepTrace.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddWorkflowLogStepTrace1786559879134
+  implements MigrationInterface
+{
+  public name: string = "AddWorkflowLogStepTrace1786559879134";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "WorkflowLog" ADD "stepTrace" jsonb`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "WorkflowLog" DROP COLUMN "stepTrace"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -516,6 +516,7 @@ import { MigrationName1786446545142 } from "./1786446545142-MigrationName";
 import { AddMonitorDependency1786449497966 } from "./1786449497966-AddMonitorDependency";
 import { AddDeletedProjectTable1786461136170 } from "./1786461136170-AddDeletedProjectTable";
 import { MigrationName1786551733814 } from "./1786551733814-MigrationName";
+import { AddWorkflowLogStepTrace1786559879134 } from "./1786559879134-AddWorkflowLogStepTrace";
 
 export default [
   InitialMigration,
@@ -1036,4 +1037,5 @@ export default [
   AddMonitorDependency1786449497966,
   AddDeletedProjectTable1786461136170,
   MigrationName1786551733814,
+  AddWorkflowLogStepTrace1786559879134,
 ];

--- a/Common/Tests/Types/Workflow/StepTrace.test.ts
+++ b/Common/Tests/Types/Workflow/StepTrace.test.ts
@@ -1,0 +1,235 @@
+import {
+  MAX_TRACE_STEPS,
+  MAX_TRACE_VALUE_LENGTH,
+  TRUNCATED_VALUE_SUFFIX,
+  WorkflowStepStatus,
+  WorkflowStepTrace,
+  WorkflowStepTraceEntry,
+  appendTraceStep,
+  emptyTrace,
+  parseTrace,
+  truncateTraceValue,
+  truncateTraceValues,
+} from "../../../Types/Workflow/StepTrace";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, test } from "@jest/globals";
+
+type MakeEntryFunction = (
+  overrides?: Partial<WorkflowStepTraceEntry> | undefined,
+) => WorkflowStepTraceEntry;
+
+const makeEntry: MakeEntryFunction = (
+  overrides?: Partial<WorkflowStepTraceEntry> | undefined,
+): WorkflowStepTraceEntry => {
+  return {
+    componentId: "api-get-1",
+    metadataId: "api-get",
+    title: "API Get",
+    status: WorkflowStepStatus.Success,
+    startedAt: "2026-01-01T00:00:00.000Z",
+    completedAt: "2026-01-01T00:00:01.000Z",
+    durationInMs: 1000,
+    argumentValues: {},
+    returnValues: {},
+    executedPort: "success",
+    ...overrides,
+  };
+};
+
+describe("truncateTraceValue", () => {
+  test("leaves a short string alone", () => {
+    expect(truncateTraceValue("hello")).toBe("hello");
+  });
+
+  test("leaves a string exactly at the limit alone", () => {
+    const atLimit: string = "a".repeat(MAX_TRACE_VALUE_LENGTH);
+
+    expect(truncateTraceValue(atLimit)).toBe(atLimit);
+  });
+
+  test("cuts a string past the limit and says so", () => {
+    const tooLong: string = "a".repeat(MAX_TRACE_VALUE_LENGTH + 100);
+    const result: string = truncateTraceValue(tooLong) as string;
+
+    expect(result.endsWith(TRUNCATED_VALUE_SUFFIX)).toBe(true);
+    expect(result.length).toBe(
+      MAX_TRACE_VALUE_LENGTH + TRUNCATED_VALUE_SUFFIX.length,
+    );
+  });
+
+  test("leaves small structured values as structure, not text", () => {
+    const value: JSONObject = { a: 1, b: "two" };
+
+    expect(truncateTraceValue(value)).toEqual(value);
+  });
+
+  /*
+   * Half a serialized object looks like data but cannot be parsed, so a large
+   * object is replaced wholesale rather than cut in the middle.
+   */
+  test("replaces a large object with cut text rather than half an object", () => {
+    const big: JSONObject = { body: "x".repeat(MAX_TRACE_VALUE_LENGTH + 500) };
+    const result: unknown = truncateTraceValue(big);
+
+    expect(typeof result).toBe("string");
+    expect((result as string).endsWith(TRUNCATED_VALUE_SUFFIX)).toBe(true);
+  });
+
+  test("leaves primitives of other types alone", () => {
+    expect(truncateTraceValue(42)).toBe(42);
+    expect(truncateTraceValue(true)).toBe(true);
+    expect(truncateTraceValue(null)).toBeNull();
+  });
+
+  test("says so rather than throwing on a circular value", () => {
+    const circular: JSONObject = {};
+    (circular as unknown as { self: unknown }).self = circular;
+
+    expect(truncateTraceValue(circular)).toBe("[value could not be recorded]");
+  });
+
+  test("keeps a large array as text rather than dropping it", () => {
+    const bigArray: Array<string> = new Array(2000).fill("abcdefghij");
+    const result: unknown = truncateTraceValue(
+      bigArray as unknown as JSONObject,
+    );
+
+    expect(typeof result).toBe("string");
+  });
+});
+
+describe("truncateTraceValues", () => {
+  test("truncates each value independently", () => {
+    const values: JSONObject = {
+      small: "ok",
+      big: "x".repeat(MAX_TRACE_VALUE_LENGTH + 10),
+    };
+
+    const result: JSONObject = truncateTraceValues(values);
+
+    expect(result["small"]).toBe("ok");
+    expect((result["big"] as string).endsWith(TRUNCATED_VALUE_SUFFIX)).toBe(
+      true,
+    );
+  });
+
+  test("copes with an empty object", () => {
+    expect(truncateTraceValues({})).toEqual({});
+  });
+
+  test("keeps a redaction marker exactly as it is", () => {
+    expect(truncateTraceValues({ token: "[REDACTED]" })["token"]).toBe(
+      "[REDACTED]",
+    );
+  });
+});
+
+describe("appendTraceStep", () => {
+  test("adds a step to an empty trace", () => {
+    const trace: WorkflowStepTrace = appendTraceStep(emptyTrace(), makeEntry());
+
+    expect(trace.steps).toHaveLength(1);
+    expect(trace.truncated).toBeFalsy();
+  });
+
+  test("keeps steps in the order they ran", () => {
+    let trace: WorkflowStepTrace = emptyTrace();
+
+    trace = appendTraceStep(trace, makeEntry({ componentId: "first" }));
+    trace = appendTraceStep(trace, makeEntry({ componentId: "second" }));
+
+    expect(
+      trace.steps.map((step: WorkflowStepTraceEntry) => {
+        return step.componentId;
+      }),
+    ).toEqual(["first", "second"]);
+  });
+
+  test("does not mutate the trace it was given", () => {
+    const original: WorkflowStepTrace = emptyTrace();
+
+    appendTraceStep(original, makeEntry());
+
+    expect(original.steps).toHaveLength(0);
+  });
+
+  test("holds exactly the cap without flagging truncation", () => {
+    let trace: WorkflowStepTrace = emptyTrace();
+
+    for (let i: number = 0; i < MAX_TRACE_STEPS; i++) {
+      trace = appendTraceStep(trace, makeEntry({ componentId: `step-${i}` }));
+    }
+
+    expect(trace.steps).toHaveLength(MAX_TRACE_STEPS);
+    expect(trace.truncated).toBeFalsy();
+  });
+
+  /*
+   * A failed run is read from the end — the step that broke it is the last
+   * one — so the cap drops the oldest steps, not the newest.
+   */
+  test("drops the oldest steps past the cap and keeps the newest", () => {
+    let trace: WorkflowStepTrace = emptyTrace();
+
+    for (let i: number = 0; i < MAX_TRACE_STEPS + 5; i++) {
+      trace = appendTraceStep(trace, makeEntry({ componentId: `step-${i}` }));
+    }
+
+    expect(trace.steps).toHaveLength(MAX_TRACE_STEPS);
+    expect(trace.truncated).toBe(true);
+    expect(trace.steps[trace.steps.length - 1]?.componentId).toBe(
+      `step-${MAX_TRACE_STEPS + 4}`,
+    );
+    expect(trace.steps[0]?.componentId).toBe("step-5");
+  });
+
+  test("stays flagged as truncated once it has been", () => {
+    let trace: WorkflowStepTrace = emptyTrace();
+
+    for (let i: number = 0; i < MAX_TRACE_STEPS + 2; i++) {
+      trace = appendTraceStep(trace, makeEntry());
+    }
+
+    trace = appendTraceStep(trace, makeEntry());
+
+    expect(trace.truncated).toBe(true);
+  });
+});
+
+describe("parseTrace", () => {
+  test("reads back what was written", () => {
+    const trace: WorkflowStepTrace = appendTraceStep(
+      emptyTrace(),
+      makeEntry({ componentId: "log-1" }),
+    );
+
+    const roundTripped: WorkflowStepTrace = parseTrace(
+      JSON.parse(JSON.stringify(trace)),
+    );
+
+    expect(roundTripped.steps).toHaveLength(1);
+    expect(roundTripped.steps[0]?.componentId).toBe("log-1");
+  });
+
+  test("carries the truncated flag back", () => {
+    expect(parseTrace({ steps: [], truncated: true }).truncated).toBe(true);
+  });
+
+  /*
+   * Rows written before the column existed, or by an older build, must read as
+   * an empty trace so the viewer falls back to the raw log instead of throwing.
+   */
+  test("treats anything that is not a trace as empty", () => {
+    expect(parseTrace(null).steps).toEqual([]);
+    expect(parseTrace(undefined as never).steps).toEqual([]);
+    expect(parseTrace("nonsense").steps).toEqual([]);
+    expect(parseTrace(42).steps).toEqual([]);
+    expect(parseTrace([]).steps).toEqual([]);
+    expect(parseTrace({}).steps).toEqual([]);
+    expect(parseTrace({ steps: "not an array" }).steps).toEqual([]);
+  });
+
+  test("an empty trace is not flagged truncated", () => {
+    expect(parseTrace(null).truncated).toBeFalsy();
+  });
+});

--- a/Common/Types/Workflow/StepTrace.ts
+++ b/Common/Types/Workflow/StepTrace.ts
@@ -1,0 +1,183 @@
+/*
+ * A structured record of what each step of a workflow run actually did.
+ *
+ * The runner has always known this — it logs the arguments it resolved, the
+ * values a component returned, and which out port it took — but it flattened
+ * all of it into one newline-joined string, so the only way to answer "what did
+ * step three receive" was to read the whole blob. Keeping the same information
+ * as data lets the run be read as a list of steps, and lets a step be matched
+ * back to the node it came from on the canvas.
+ *
+ * The shapes live in Common/Types because the runner writes them, the API
+ * returns them, and the dashboard renders them.
+ */
+
+import { JSONObject, JSONValue } from "../JSON";
+
+export enum WorkflowStepStatus {
+  Success = "Success",
+  Error = "Error",
+}
+
+export interface WorkflowStepTraceEntry {
+  /** The step's user-facing id ("api-get-1") — matches a node on the canvas. */
+  componentId: string;
+  /** Which kind of component this was, e.g. "api-post". */
+  metadataId: string;
+  /** The component's title, so the trace reads without loading metadata. */
+  title: string;
+  status: WorkflowStepStatus;
+  startedAt: string;
+  completedAt: string;
+  durationInMs: number;
+  /** Resolved arguments, already redacted for sensitive fields. */
+  argumentValues: JSONObject;
+  /** Returned values, already redacted for sensitive fields. */
+  returnValues: JSONObject;
+  /** The out port taken, or null when the step ended the run. */
+  executedPort: string | null;
+  /** Present only on a failed step. */
+  errorMessage?: string | undefined;
+}
+
+export interface WorkflowStepTrace {
+  steps: Array<WorkflowStepTraceEntry>;
+  /**
+   * Set when steps were dropped to keep the row bounded. The dashboard says so
+   * rather than quietly showing a partial run as if it were complete.
+   */
+  truncated?: boolean | undefined;
+}
+
+/*
+ * A run is bounded by cycle detection, but a workflow that suspends and resumes
+ * accumulates across resumes, and a single value can be an entire HTTP response
+ * body. Both are capped: the row is written on every status change, and an
+ * unbounded trace would turn each of those writes into a large one.
+ */
+export const MAX_TRACE_STEPS: number = 100;
+export const MAX_TRACE_VALUE_LENGTH: number = 4000;
+
+export const TRUNCATED_VALUE_SUFFIX: string = "… (truncated)";
+
+export type TruncateTraceValueFunction = (value: JSONValue) => JSONValue;
+
+/**
+ * Shrink one recorded value to something a row can hold.
+ *
+ * Strings are cut; anything structured is measured by its JSON length and
+ * replaced wholesale when it is too big, because cutting a serialized object in
+ * half produces text that looks like data but cannot be parsed.
+ */
+export const truncateTraceValue: TruncateTraceValueFunction = (
+  value: JSONValue,
+): JSONValue => {
+  if (typeof value === "string") {
+    if (value.length <= MAX_TRACE_VALUE_LENGTH) {
+      return value;
+    }
+
+    return value.slice(0, MAX_TRACE_VALUE_LENGTH) + TRUNCATED_VALUE_SUFFIX;
+  }
+
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value !== "object") {
+    return value;
+  }
+
+  let serialized: string;
+
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    // Circular or otherwise unserializable: say so rather than throwing.
+    return "[value could not be recorded]";
+  }
+
+  if (serialized.length <= MAX_TRACE_VALUE_LENGTH) {
+    return value;
+  }
+
+  return (
+    serialized.slice(0, MAX_TRACE_VALUE_LENGTH) + TRUNCATED_VALUE_SUFFIX
+  );
+};
+
+export type TruncateTraceValuesFunction = (values: JSONObject) => JSONObject;
+
+export const truncateTraceValues: TruncateTraceValuesFunction = (
+  values: JSONObject,
+): JSONObject => {
+  const truncated: JSONObject = {};
+
+  for (const key of Object.keys(values || {})) {
+    truncated[key] = truncateTraceValue(values[key] as JSONValue);
+  }
+
+  return truncated;
+};
+
+export type AppendTraceStepFunction = (
+  trace: WorkflowStepTrace,
+  entry: WorkflowStepTraceEntry,
+) => WorkflowStepTrace;
+
+/**
+ * Add a step, keeping the trace within its cap.
+ *
+ * When the cap is reached the OLDEST steps are dropped: a run that failed is
+ * read from the end, and the step that broke it is the last one.
+ */
+export const appendTraceStep: AppendTraceStepFunction = (
+  trace: WorkflowStepTrace,
+  entry: WorkflowStepTraceEntry,
+): WorkflowStepTrace => {
+  const steps: Array<WorkflowStepTraceEntry> = [...(trace.steps || []), entry];
+
+  if (steps.length <= MAX_TRACE_STEPS) {
+    return { ...trace, steps: steps };
+  }
+
+  return {
+    ...trace,
+    steps: steps.slice(steps.length - MAX_TRACE_STEPS),
+    truncated: true,
+  };
+};
+
+export type EmptyTraceFunction = () => WorkflowStepTrace;
+
+export const emptyTrace: EmptyTraceFunction = (): WorkflowStepTrace => {
+  return { steps: [] };
+};
+
+export type ParseTraceFunction = (value: JSONValue) => WorkflowStepTrace;
+
+/**
+ * Read a trace back off a row, tolerating anything that is not one.
+ *
+ * Old runs predate the column and rows can be written by an older build, so
+ * this never throws — a trace it cannot understand reads as an empty one and
+ * the viewer falls back to the raw log.
+ */
+export const parseTrace: ParseTraceFunction = (
+  value: JSONValue,
+): WorkflowStepTrace => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return emptyTrace();
+  }
+
+  const steps: JSONValue | undefined = (value as JSONObject)["steps"];
+
+  if (!Array.isArray(steps)) {
+    return emptyTrace();
+  }
+
+  return {
+    steps: steps as unknown as Array<WorkflowStepTraceEntry>,
+    truncated: Boolean((value as JSONObject)["truncated"]),
+  };
+};

--- a/Common/UI/Components/Workflow/StepTraceViewer.tsx
+++ b/Common/UI/Components/Workflow/StepTraceViewer.tsx
@@ -1,0 +1,184 @@
+/*
+ * A workflow run, read as the list of steps it actually took.
+ *
+ * The raw log is still there and still useful — it carries the component's own
+ * log lines and the warnings the runner emits — but "what did this step
+ * receive, what did it return, and where did it go next" is a question about
+ * structure, and answering it by scanning a newline-joined blob was the whole
+ * problem.
+ */
+
+import Icon from "../Icon/Icon";
+import IconProp from "../../../Types/Icon/IconProp";
+import { JSONObject } from "../../../Types/JSON";
+import {
+  WorkflowStepStatus,
+  WorkflowStepTrace,
+  WorkflowStepTraceEntry,
+} from "../../../Types/Workflow/StepTrace";
+import React, { FunctionComponent, ReactElement, useState } from "react";
+
+export interface ComponentProps {
+  trace: WorkflowStepTrace;
+}
+
+type FormatDurationFunction = (durationInMs: number) => string;
+
+export const formatStepDuration: FormatDurationFunction = (
+  durationInMs: number,
+): string => {
+  if (durationInMs < 1000) {
+    return `${durationInMs}ms`;
+  }
+
+  if (durationInMs < 60000) {
+    return `${(durationInMs / 1000).toFixed(1)}s`;
+  }
+
+  const minutes: number = Math.floor(durationInMs / 60000);
+  const seconds: number = Math.round((durationInMs % 60000) / 1000);
+
+  return `${minutes}m ${seconds}s`;
+};
+
+interface ValueBlockProps {
+  title: string;
+  values: JSONObject;
+}
+
+const ValueBlock: FunctionComponent<ValueBlockProps> = (
+  props: ValueBlockProps,
+): ReactElement => {
+  const keys: Array<string> = Object.keys(props.values || {});
+
+  return (
+    <div>
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 mb-1">
+        {props.title}
+      </p>
+      {keys.length === 0 ? (
+        <p className="text-sm text-gray-400">None</p>
+      ) : (
+        <dl className="space-y-1">
+          {keys.map((key: string) => {
+            const value: unknown = props.values[key];
+            const text: string =
+              typeof value === "string" ? value : JSON.stringify(value, null, 2);
+
+            return (
+              <div key={key} className="text-sm">
+                <dt className="text-gray-500 font-medium">{key}</dt>
+                <dd className="text-gray-800 font-mono text-xs whitespace-pre-wrap break-all">
+                  {text}
+                </dd>
+              </div>
+            );
+          })}
+        </dl>
+      )}
+    </div>
+  );
+};
+
+interface StepRowProps {
+  step: WorkflowStepTraceEntry;
+  index: number;
+}
+
+const StepRow: FunctionComponent<StepRowProps> = (
+  props: StepRowProps,
+): ReactElement => {
+  const [isOpen, setIsOpen] = useState<boolean>(
+    props.step.status === WorkflowStepStatus.Error,
+  );
+
+  const isError: boolean = props.step.status === WorkflowStepStatus.Error;
+
+  return (
+    <div
+      className={`rounded-md border ${
+        isError ? "border-red-200 bg-red-50" : "border-gray-200 bg-white"
+      }`}
+    >
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        className="w-full text-left p-3 flex items-center gap-3 cursor-pointer"
+        onClick={() => {
+          setIsOpen(!isOpen);
+        }}
+      >
+        <span className="text-xs text-gray-400 w-5 shrink-0">
+          {props.index + 1}
+        </span>
+
+        <Icon
+          icon={isError ? IconProp.Alert : IconProp.CheckCircle}
+          className={`h-4 w-4 shrink-0 ${
+            isError ? "text-red-500" : "text-green-500"
+          }`}
+        />
+
+        <span className="flex-1 min-w-0">
+          <span className="block text-sm font-medium text-gray-900 truncate">
+            {props.step.title}
+          </span>
+          <span className="block text-xs text-gray-500 truncate">
+            {props.step.componentId}
+          </span>
+        </span>
+
+        <span className="text-xs text-gray-500 shrink-0">
+          {formatStepDuration(props.step.durationInMs)}
+        </span>
+
+        {props.step.executedPort && (
+          <span className="text-xs text-gray-500 shrink-0 hidden sm:inline">
+            → {props.step.executedPort}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div className="border-t border-gray-200 p-3 space-y-3">
+          {props.step.errorMessage && (
+            <p className="text-sm text-red-700">{props.step.errorMessage}</p>
+          )}
+          <ValueBlock title="Received" values={props.step.argumentValues} />
+          <ValueBlock title="Returned" values={props.step.returnValues} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+const StepTraceViewer: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const steps: Array<WorkflowStepTraceEntry> = props.trace?.steps || [];
+
+  if (steps.length === 0) {
+    return (
+      <p className="text-sm text-gray-500">
+        This run has no recorded steps. Runs from before step recording was
+        added show only the log below.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {props.trace.truncated && (
+        <p className="text-sm text-amber-700">
+          Only the last {steps.length} steps of this run were kept.
+        </p>
+      )}
+
+      {steps.map((step: WorkflowStepTraceEntry, index: number) => {
+        return <StepRow key={index} step={step} index={index} />;
+      })}
+    </div>
+  );
+};
+
+export default StepTraceViewer;


### PR DESCRIPTION
Third in the workflow series, after #3158 (make mistakes visible) and #3159 (stop hand-writing database JSON). This one makes a run readable.

## Why

A workflow run was one newline-joined string. The runner already knew everything interesting per step — the arguments it resolved, what the component returned, which out port it took — and flattened all of it into text. Answering "what did step three actually receive" meant reading the whole blob and trusting your eyes.

## What changed

A nullable JSONB `stepTrace` column on `WorkflowLog`, recording per step: component id and title, resolved arguments, return values, the port taken, timing, and any error. The Logs tab renders that as a list of steps, with the raw log kept underneath — the log still carries the component's own output and the runner's warnings, so it does not go away.

Failed steps are expanded by default, because they are why you opened the run.

## The parts worth reviewing

**Redaction.** The trace goes through `redactSensitiveComponentValuesForLogs`, the same helper the text log uses. The trace is readable by exactly the people who can read the log, so anything hidden from one has to be hidden from the other — a test asserts the secret string appears nowhere in the serialized trace, not just that the field reads `[REDACTED]`.

**The failing step is recorded.** A component that throws is written into the trace before the failure travels on. Without that the trace would stop at the last step that *worked*, which is precisely the one nobody needs to look at.

**Sleep.** The trace is written on suspend as well as on completion, so a parked run is readable while it waits, and restored on resume — a run that slept reads as one continuous list rather than restarting after it woke up.

**Bounded on both axes.** At most 100 steps, dropping the **oldest**: a failed run is read from the end. Values over 4KB are cut, and a large object is replaced wholesale rather than sliced, because half a serialized object looks like data but cannot be parsed. The row is written on every status change, so an unbounded trace would make each of those writes large.

**Old rows.** `parseTrace` tolerates anything that is not a trace, so runs predating the column read as empty and the viewer falls back to the log rather than throwing.

## Migration

Generated with `npm run generate-postgres-migration` (not hand-written) and registered in `SchemaMigrations/Index.ts`. `npm run check-postgres-schema-drift` applies every registered migration to the database and then tries to generate another; it reports **"No schema drift"**, which is the same check CI runs.

The column is nullable and additive, so it is safe on an existing database and `down()` drops it cleanly.

## Tests

| Suite | Cases | Covers |
|---|---|---|
| `Common/Tests/Types/Workflow/StepTrace.test.ts` | 21 | truncation of strings/objects/arrays/circular values, the step cap dropping oldest-first, the truncated flag latching, and `parseTrace` tolerating every non-trace shape |
| `App/Tests/FeatureSet/Workflow/RunWorkflowStepTrace.test.ts` | 6 | the runner records the step with its port and values, timing is sane, sensitive arguments *and* return values are redacted, the secret appears nowhere in the output, a throwing component is still recorded, and the trace lands with the final status |
| `App/Tests/FeatureSet/Workflow/RunWorkflow.test.ts` | 16 | existing suite, re-run — no regression from the runner changes |

## Still to come

- **Test a single step** — needs a new endpoint that executes one component as root. Research is done (it must replicate all four of `Manual.ts`'s auth gates, using the strict `assertAuthenticatedProjectMember` that rejects API keys); it is a real security surface and gets its own PR.
- **Workflow templates** — next after that.
