### PR TITLE
feat(workflow): run just this step, from the builder

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Workflow/View/Builder.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Workflow/View/Builder.tsx
@@ -451,6 +451,28 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
               setEdges(edges);
               await saveGraph(nodes, edges);
             }}
+            onRunStep={async (component: NodeDataProp) => {
+              try {
+                const result: HTTPErrorResponse | HTTPResponse<JSONObject> =
+                  await API.post({
+                    url: URL.fromString(WORKFLOW_URL.toString()).addRoute(
+                      "/run-step/" + modelId.toString(),
+                    ),
+                    data: {
+                      componentId: component.id,
+                    },
+                    headers: ModelAPI.getCommonHeaders(),
+                  });
+
+                if (result instanceof HTTPErrorResponse) {
+                  throw result;
+                }
+
+                startWatchingRun();
+              } catch (err) {
+                setError(API.getFriendlyMessage(err));
+              }
+            }}
             onRun={async (component: NodeDataProp) => {
               try {
                 const result: HTTPErrorResponse | HTTPResponse<JSONObject> =

--- a/App/FeatureSet/Workflow/API/RunStep.ts
+++ b/App/FeatureSet/Workflow/API/RunStep.ts
@@ -1,0 +1,179 @@
+import QueueWorkflow from "../Services/QueueWorkflow";
+import DatabaseCommonInteractionProps from "Common/Types/BaseDatabase/DatabaseCommonInteractionProps";
+import BadDataException from "Common/Types/Exception/BadDataException";
+import NotAuthorizedException from "Common/Types/Exception/NotAuthorizedException";
+import ObjectID from "Common/Types/ObjectID";
+import Permission, {
+  PermissionHelper,
+  UserPermission,
+  UserTenantAccessPermission,
+} from "Common/Types/Permission";
+import CommonAPI from "Common/Server/API/CommonAPI";
+import UserMiddleware from "Common/Server/Middleware/UserAuthorization";
+import WorkflowService from "Common/Server/Services/WorkflowService";
+import Workflow from "Common/Models/DatabaseModels/Workflow";
+import Express, {
+  ExpressRequest,
+  ExpressResponse,
+  ExpressRouter,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import Response from "Common/Server/Utils/Response";
+
+/**
+ * "Run just this step" from the workflow builder.
+ *
+ * This runs the step FOR REAL. There is no notion of a safe or read-only
+ * component anywhere in the product: roughly half the registry sends messages,
+ * calls arbitrary URLs, or creates, updates and deletes rows, and none of that
+ * is undone afterwards. The endpoint is named and worded accordingly, and the
+ * dashboard confirms before calling it.
+ *
+ * It deliberately does NOT execute the component itself. It enqueues an
+ * ordinary workflow run that happens to be narrowed to one step, so it inherits
+ * everything a run already has and adds no new execution path:
+ *
+ *   - the workflow must be enabled, the subscription paid, and the project's
+ *     plan run-limit respected (QueueWorkflow.addWorkflowToQueue)
+ *   - a WorkflowLog row is written, so a step that sends a message or deletes
+ *     rows leaves an audit trail like any other run
+ *   - the component executes on a worker, not inside the API process, which
+ *     the deployment topology deliberately separates (DISABLE_QUEUE_WORKERS on
+ *     the api role)
+ *   - logs and returned values are redacted by the runner's existing rules
+ *     rather than being handed back in the HTTP response
+ *
+ * The caller gets "Scheduled", exactly as the manual run does, and reads the
+ * result from the run's step trace.
+ */
+export default class RunStepAPI {
+  public router!: ExpressRouter;
+
+  public constructor() {
+    this.router = Express.getRouter();
+
+    this.router.post(
+      `/run-step/:workflowId`,
+      UserMiddleware.getUserMiddleware,
+      this.runSingleStep,
+    );
+  }
+
+  public async runSingleStep(
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      if (!req.params["workflowId"]) {
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new BadDataException("workflowId not found in URL"),
+        );
+      }
+
+      const componentId: string | undefined = req.body?.componentId;
+
+      if (!componentId || typeof componentId !== "string") {
+        return Response.sendErrorResponse(
+          req,
+          res,
+          new BadDataException("componentId is required"),
+        );
+      }
+
+      const workflowId: ObjectID = new ObjectID(
+        req.params["workflowId"] as string,
+      );
+
+      const databaseProps: DatabaseCommonInteractionProps =
+        await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+      /*
+       * Same four gates as the manual run, in the same order and for the same
+       * reasons — see App/FeatureSet/Workflow/API/Manual.ts. getUserMiddleware
+       * is a context loader rather than a gate, so an unauthenticated request
+       * reaches here tagged Public; this route runs component code, so it has
+       * to prove the caller itself.
+       */
+      const projectId: ObjectID =
+        CommonAPI.assertAuthenticatedProjectMember(databaseProps);
+
+      /*
+       * The tenant above is only the project the caller claimed in the header.
+       * Take the owning project off the workflow row and require the two to
+       * match, so a member of project A cannot reach project B's workflow by
+       * sending their own header.
+       */
+      const workflow: Workflow | null = await WorkflowService.findOneById({
+        id: workflowId,
+        select: {
+          projectId: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      CommonAPI.assertResourceBelongsToProject({
+        resourceProjectId: workflow?.projectId,
+        projectId: projectId,
+      });
+
+      RunStepAPI.assertCallerCanRunWorkflow({
+        databaseProps: databaseProps,
+        projectId: projectId,
+      });
+
+      await QueueWorkflow.addWorkflowToQueue({
+        workflowId: workflowId,
+        returnValues: {},
+        runOnlyComponentId: componentId,
+      });
+
+      return Response.sendJsonObjectResponse(req, res, {
+        status: "Scheduled",
+      });
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  /*
+   * Running one step executes component code inside the project just as a full
+   * run does, so it is gated on the same write-level permissions as updating
+   * the Workflow model — identical to the manual run. Anyone who can reach the
+   * builder's settings panel already holds these.
+   */
+  private static assertCallerCanRunWorkflow(data: {
+    databaseProps: DatabaseCommonInteractionProps;
+    projectId: ObjectID;
+  }): void {
+    if (data.databaseProps.isMasterAdmin) {
+      return;
+    }
+
+    const tenantPermission: UserTenantAccessPermission | undefined =
+      data.databaseProps.userTenantAccessPermission?.[
+        data.projectId.toString()
+      ];
+
+    const callerPermissions: Array<Permission> = (
+      tenantPermission?.permissions || []
+    ).map((userPermission: UserPermission) => {
+      return userPermission.permission;
+    });
+
+    if (
+      !PermissionHelper.doesPermissionsIntersect(
+        callerPermissions,
+        new Workflow().getUpdatePermissions(),
+      )
+    ) {
+      throw new NotAuthorizedException(
+        "You do not have permission to run this workflow.",
+      );
+    }
+  }
+}

--- a/App/FeatureSet/Workflow/Index.ts
+++ b/App/FeatureSet/Workflow/Index.ts
@@ -1,5 +1,6 @@
 import ComponentCodeAPI from "./API/ComponentCode";
 import ManualAPI from "./API/Manual";
+import RunStepAPI from "./API/RunStep";
 import ModelSchemaAPI from "./API/ModelSchema";
 import WorkflowAPI from "./API/Workflow";
 import RunWorkflow from "./Services/RunWorkflow";
@@ -28,6 +29,7 @@ const WorkflowFeatureSet: FeatureSet = {
       const app: ExpressApplication = Express.getExpressApp();
 
       app.use(`/${APP_NAME}/manual`, new ManualAPI().router);
+      app.use(`/${APP_NAME}`, new RunStepAPI().router);
 
       app.use(`/${APP_NAME}`, new ModelSchemaAPI().router);
 
@@ -87,6 +89,9 @@ const WorkflowFeatureSet: FeatureSet = {
               callChain:
                 (job.data["callChain"] as Array<string> | undefined) || [],
               isResume: job.data["isResume"] === true,
+              runOnlyComponentId:
+                (job.data["runOnlyComponentId"] as string | undefined) ||
+                undefined,
             });
           },
           { concurrency: 100 },

--- a/App/FeatureSet/Workflow/Services/QueueWorkflow.ts
+++ b/App/FeatureSet/Workflow/Services/QueueWorkflow.ts
@@ -244,6 +244,7 @@ export default class QueueWorkflow {
         workflowLogId: workflowLog?._id || null,
         workflowId: workflow._id,
         callChain: executeWorkflow.callChain || [],
+        runOnlyComponentId: executeWorkflow.runOnlyComponentId || null,
       },
       {
         scheduleAt: resolvedScheduleAt,

--- a/App/FeatureSet/Workflow/Services/RunWorkflow.ts
+++ b/App/FeatureSet/Workflow/Services/RunWorkflow.ts
@@ -298,7 +298,25 @@ export default class RunWorkflow {
 
       // form a run stack.
 
-      const runStack: RunStack = await this.makeRunStack(workflow.graph);
+      let runStack: RunStack = await this.makeRunStack(workflow.graph);
+
+      /*
+       * "Run just this step": narrow the stack to the one component and start
+       * there. Its out ports are dropped so nothing downstream follows, and
+       * because this happens after makeRunStack the component still gets its
+       * real metadata and arguments.
+       *
+       * Any {{...}} the step reads from another component resolves to nothing,
+       * since nothing else ran — the runner already logs a warning naming each
+       * reference that did not resolve, which is the honest outcome rather
+       * than a silent empty value.
+       */
+      if (runProps.runOnlyComponentId) {
+        runStack = this.narrowRunStackToSingleComponent(
+          runStack,
+          runProps.runOnlyComponentId,
+        );
+      }
 
       /*
        * Guard against workflows that have no executable entry point. This
@@ -753,10 +771,7 @@ export default class RunWorkflow {
     before: JSONValue;
     after: JSONValue;
   }): void {
-    if (
-      typeof params.before !== "string" ||
-      typeof params.after !== "string"
-    ) {
+    if (typeof params.before !== "string" || typeof params.after !== "string") {
       return;
     }
 
@@ -1051,6 +1066,39 @@ export default class RunWorkflow {
           JSON.stringify(data),
       );
     }
+  }
+
+  /**
+   * Reduce a run stack to the single component the caller asked for.
+   *
+   * Throws when that component is not in the graph, rather than falling back to
+   * a full run — a request to run one step must never turn into a request to
+   * run the whole workflow.
+   */
+  public narrowRunStackToSingleComponent(
+    runStack: RunStack,
+    componentId: string,
+  ): RunStack {
+    const item: RunStackItem | undefined = runStack.stack[componentId];
+
+    if (!item) {
+      throw new BadDataException(
+        "Cannot run step " +
+          componentId +
+          ": there is no step with that id in this workflow.",
+      );
+    }
+
+    return {
+      startWithComponentId: componentId,
+      stack: {
+        [componentId]: {
+          node: item.node,
+          // No out ports: nothing downstream of this step should follow.
+          outPorts: {},
+        },
+      },
+    };
   }
 
   public async makeRunStack(graph: JSONObject): Promise<RunStack> {

--- a/App/Tests/FeatureSet/Workflow/NarrowRunStack.test.ts
+++ b/App/Tests/FeatureSet/Workflow/NarrowRunStack.test.ts
@@ -1,0 +1,151 @@
+/*
+ * Narrowing a run to a single step. The property that matters is containment:
+ * a request to run one step must run exactly that step and nothing else, and
+ * must never quietly widen into a full run.
+ */
+
+import IconProp from "Common/Types/Icon/IconProp";
+import ComponentMetadata, {
+  ComponentType,
+  NodeDataProp,
+  NodeType,
+} from "Common/Types/Workflow/Component";
+import RunWorkflow, {
+  RunStack,
+} from "../../../FeatureSet/Workflow/Services/RunWorkflow";
+import { describe, expect, test } from "@jest/globals";
+
+type MakeNodeFunction = (componentId: string) => NodeDataProp;
+
+const makeNode: MakeNodeFunction = (componentId: string): NodeDataProp => {
+  const metadata: ComponentMetadata = {
+    id: "test-component",
+    title: componentId,
+    category: "Test",
+    description: "For tests",
+    iconProp: IconProp.Bolt,
+    componentType: ComponentType.Component,
+    arguments: [],
+    returnValues: [],
+    inPorts: [],
+    outPorts: [],
+  };
+
+  return {
+    error: "",
+    id: componentId,
+    nodeType: NodeType.Node,
+    metadata: metadata,
+    metadataId: metadata.id,
+    internalId: `${componentId}-internal`,
+    arguments: { some: "argument" },
+    returnValues: {},
+    componentType: ComponentType.Component,
+  };
+};
+
+type MakeStackFunction = () => RunStack;
+
+const makeStack: MakeStackFunction = (): RunStack => {
+  return {
+    startWithComponentId: "trigger-1",
+    stack: {
+      "trigger-1": {
+        node: makeNode("trigger-1"),
+        outPorts: { out: ["step-a"] },
+      },
+      "step-a": {
+        node: makeNode("step-a"),
+        outPorts: { success: ["step-b"], error: ["step-c"] },
+      },
+      "step-b": { node: makeNode("step-b"), outPorts: {} },
+      "step-c": { node: makeNode("step-c"), outPorts: {} },
+    },
+  };
+};
+
+describe("narrowRunStackToSingleComponent", () => {
+  test("starts at the requested component", () => {
+    const narrowed: RunStack =
+      new RunWorkflow().narrowRunStackToSingleComponent(makeStack(), "step-a");
+
+    expect(narrowed.startWithComponentId).toBe("step-a");
+  });
+
+  test("keeps only that component in the stack", () => {
+    const narrowed: RunStack =
+      new RunWorkflow().narrowRunStackToSingleComponent(makeStack(), "step-a");
+
+    expect(Object.keys(narrowed.stack)).toEqual(["step-a"]);
+  });
+
+  /*
+   * The containment property: with no out ports, the run loop has nothing to
+   * queue after this step, so nothing downstream can follow.
+   */
+  test("drops the component's out ports so nothing downstream follows", () => {
+    const narrowed: RunStack =
+      new RunWorkflow().narrowRunStackToSingleComponent(makeStack(), "step-a");
+
+    expect(narrowed.stack["step-a"]?.outPorts).toEqual({});
+  });
+
+  test("keeps the component's own node, arguments and metadata", () => {
+    const narrowed: RunStack =
+      new RunWorkflow().narrowRunStackToSingleComponent(makeStack(), "step-a");
+
+    const node: NodeDataProp = narrowed.stack["step-a"]?.node as NodeDataProp;
+
+    expect(node.id).toBe("step-a");
+    expect(node.arguments).toEqual({ some: "argument" });
+    expect(node.metadata).toBeDefined();
+  });
+
+  test("can narrow to the trigger itself", () => {
+    const narrowed: RunStack =
+      new RunWorkflow().narrowRunStackToSingleComponent(
+        makeStack(),
+        "trigger-1",
+      );
+
+    expect(Object.keys(narrowed.stack)).toEqual(["trigger-1"]);
+    expect(narrowed.stack["trigger-1"]?.outPorts).toEqual({});
+  });
+
+  /*
+   * Refusing is the safe outcome. Falling back to the original stack would
+   * turn "run this one step" into "run the whole workflow".
+   */
+  test("refuses an id that is not in the graph rather than running everything", () => {
+    expect(() => {
+      return new RunWorkflow().narrowRunStackToSingleComponent(
+        makeStack(),
+        "does-not-exist",
+      );
+    }).toThrow(/no step with that id/);
+  });
+
+  test("refuses an empty id", () => {
+    expect(() => {
+      return new RunWorkflow().narrowRunStackToSingleComponent(makeStack(), "");
+    }).toThrow();
+  });
+
+  test("does not mutate the stack it was given", () => {
+    const original: RunStack = makeStack();
+
+    new RunWorkflow().narrowRunStackToSingleComponent(original, "step-a");
+
+    expect(Object.keys(original.stack).sort()).toEqual([
+      "step-a",
+      "step-b",
+      "step-c",
+      "trigger-1",
+    ]);
+    expect(original.stack["step-a"]?.outPorts).toEqual({
+      success: ["step-b"],
+      error: ["step-c"],
+    });
+    expect(original.startWithComponentId).toBe("trigger-1");
+  });
+});

--- a/App/Tests/FeatureSet/Workflow/RunStepAuth.test.ts
+++ b/App/Tests/FeatureSet/Workflow/RunStepAuth.test.ts
@@ -1,0 +1,506 @@
+/*
+ * ---------------------------------------------------------------------------
+ * POST /workflow/run-step/:workflowId — "run just this step" from the builder.
+ *
+ * This route runs component code inside a project: chat and email sends,
+ * arbitrary outbound HTTP, per-model create/update/delete, sandboxed
+ * JavaScript. It is the same blast radius as the manual run, so it carries the
+ * same four gates, and the load-bearing assertion in every deny case below is
+ * that QueueWorkflow.addWorkflowToQueue was NEVER called. An error response on
+ * its own would not prove the work was stopped.
+ *
+ * The route deliberately enqueues rather than executing inline. Everything the
+ * queue enforces — the workflow being enabled, a paid subscription, the plan's
+ * run limit, a WorkflowLog for the audit trail, and running on a worker rather
+ * than in the API process — is inherited only because the handler goes through
+ * addWorkflowToQueue. A test here pins that it does.
+ * ---------------------------------------------------------------------------
+ */
+
+import RunStepAPI from "../../../FeatureSet/Workflow/API/RunStep";
+import QueueWorkflow from "../../../FeatureSet/Workflow/Services/QueueWorkflow";
+import CommonAPI from "Common/Server/API/CommonAPI";
+import WorkflowService from "Common/Server/Services/WorkflowService";
+import WorkflowModel from "Common/Models/DatabaseModels/Workflow";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import DatabaseCommonInteractionProps from "Common/Types/BaseDatabase/DatabaseCommonInteractionProps";
+import Dictionary from "Common/Types/Dictionary";
+import BadDataException from "Common/Types/Exception/BadDataException";
+import NotAuthorizedException from "Common/Types/Exception/NotAuthorizedException";
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import Permission, {
+  UserPermission,
+  UserTenantAccessPermission,
+} from "Common/Types/Permission";
+import UserType from "Common/Types/UserType";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "@jest/globals";
+
+type RouterFunction = (
+  req: ExpressRequest,
+  res: ExpressResponse,
+  next: NextFunction,
+) => void | Promise<void>;
+
+type MockRoute = {
+  method: string;
+  uri: string;
+  middleware: RouterFunction;
+  handlerFunction: RouterFunction;
+};
+
+const mockRoutes: Array<MockRoute> = [];
+
+type RegisterRouteFunction = (
+  method: string,
+) => (
+  uri: string,
+  middleware: RouterFunction,
+  handlerFunction: RouterFunction,
+) => void;
+
+const registerRoute: RegisterRouteFunction = (method: string) => {
+  return (
+    uri: string,
+    middleware: RouterFunction,
+    handlerFunction: RouterFunction,
+  ): void => {
+    mockRoutes.push({
+      method: method.toUpperCase(),
+      uri: uri,
+      middleware: middleware,
+      handlerFunction: handlerFunction,
+    });
+  };
+};
+
+const mockRouter: {
+  get: jest.Mock;
+  post: jest.Mock;
+  put: jest.Mock;
+  delete: jest.Mock;
+} = {
+  get: jest.fn().mockImplementation(registerRoute("get")),
+  post: jest.fn().mockImplementation(registerRoute("post")),
+  put: jest.fn().mockImplementation(registerRoute("put")),
+  delete: jest.fn().mockImplementation(registerRoute("delete")),
+};
+
+jest.mock("Common/Server/Utils/Express", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "Common/Server/Utils/Express",
+  ) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    __esModule: true,
+    default: {
+      ...((actual["default"] as Record<string, unknown>) || {}),
+      getRouter: (): unknown => {
+        return mockRouter;
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendJsonObjectResponse: jest.fn(),
+      sendErrorResponse: jest.fn(),
+      sendEmptySuccessResponse: jest.fn(),
+      sendEntityResponse: jest.fn(),
+    },
+  };
+});
+
+/*
+ * The queue is not under test — whether the handler ever reaches it is.
+ * Mocking the module also keeps the real runner (and its isolated-vm native
+ * binding) out of this suite.
+ */
+jest.mock("../../../FeatureSet/Workflow/Services/QueueWorkflow", () => {
+  return {
+    __esModule: true,
+    default: {
+      addWorkflowToQueue: jest.fn(),
+    },
+  };
+});
+
+const RUN_STEP_ROUTE: string = "/run-step/:workflowId";
+
+type RouteCallResult = {
+  thrownToNext: unknown;
+  nextCallCount: number;
+};
+
+type MatchRouteFunction = (method: string, uri: string) => MockRoute;
+
+const matchRoute: MatchRouteFunction = (
+  method: string,
+  uri: string,
+): MockRoute => {
+  const route: MockRoute | undefined = mockRoutes.find(
+    (candidate: MockRoute) => {
+      return candidate.method === method.toUpperCase() && candidate.uri === uri;
+    },
+  );
+
+  if (!route) {
+    throw new Error(`Route ${method} ${uri} was never registered`);
+  }
+
+  return route;
+};
+
+type CallRouteFunction = (data: {
+  workflowId?: string | undefined;
+  body?: JSONObject | undefined;
+}) => Promise<RouteCallResult>;
+
+const callRunStepRoute: CallRouteFunction = async (data: {
+  workflowId?: string | undefined;
+  body?: JSONObject | undefined;
+}): Promise<RouteCallResult> => {
+  const params: Dictionary<string> = {};
+
+  if (data.workflowId !== undefined) {
+    params["workflowId"] = data.workflowId;
+  }
+
+  const req: ExpressRequest = {
+    params: params,
+    query: {},
+    body: data.body === undefined ? { componentId: "log-1" } : data.body,
+    headers: {},
+  } as unknown as ExpressRequest;
+
+  const res: ExpressResponse = {
+    send: jest.fn(),
+    json: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+  } as unknown as ExpressResponse;
+
+  const next: jest.Mock = jest.fn();
+
+  await matchRoute("POST", RUN_STEP_ROUTE).handlerFunction(
+    req,
+    res,
+    next as unknown as NextFunction,
+  );
+
+  return {
+    thrownToNext: next.mock.calls[0] ? next.mock.calls[0][0] : undefined,
+    nextCallCount: next.mock.calls.length,
+  };
+};
+
+type BuildPropsFunction = (data: {
+  projectId: ObjectID;
+  userId: ObjectID;
+  permissions: Array<Permission>;
+  isMasterAdmin?: boolean | undefined;
+}) => DatabaseCommonInteractionProps;
+
+const buildUserProps: BuildPropsFunction = (data: {
+  projectId: ObjectID;
+  userId: ObjectID;
+  permissions: Array<Permission>;
+  isMasterAdmin?: boolean | undefined;
+}): DatabaseCommonInteractionProps => {
+  const permissionMap: Dictionary<UserTenantAccessPermission> = {};
+
+  permissionMap[data.projectId.toString()] = {
+    _type: "UserTenantAccessPermission",
+    projectId: data.projectId,
+    permissions: data.permissions.map((permission: Permission) => {
+      const userPermission: UserPermission = {
+        _type: "UserPermission",
+        permission: permission,
+        labelIds: [],
+      };
+
+      return userPermission;
+    }),
+  } as UserTenantAccessPermission;
+
+  return {
+    tenantId: data.projectId,
+    userId: data.userId,
+    userType: data.isMasterAdmin ? UserType.MasterAdmin : UserType.User,
+    userTenantAccessPermission: permissionMap,
+    ...(data.isMasterAdmin ? { isMasterAdmin: true } : {}),
+  } as DatabaseCommonInteractionProps;
+};
+
+describe("POST /workflow/run-step/:workflowId", () => {
+  let callerProjectId: ObjectID;
+  let otherProjectId: ObjectID;
+  let callerUserId: ObjectID;
+  let workflowId: ObjectID;
+
+  let getPropsSpy: jest.SpyInstance;
+  let findOneByIdSpy: jest.SpyInstance;
+  let addWorkflowToQueueSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    mockRoutes.length = 0;
+    new RunStepAPI();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    callerProjectId = ObjectID.generate();
+    otherProjectId = ObjectID.generate();
+    callerUserId = ObjectID.generate();
+    workflowId = ObjectID.generate();
+
+    getPropsSpy = jest.spyOn(CommonAPI, "getDatabaseCommonInteractionProps");
+    findOneByIdSpy = jest.spyOn(WorkflowService, "findOneById");
+    addWorkflowToQueueSpy = jest
+      .spyOn(QueueWorkflow, "addWorkflowToQueue")
+      .mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  type MockWorkflowFunction = (projectId: ObjectID | null) => void;
+
+  const mockWorkflowInProject: MockWorkflowFunction = (
+    projectId: ObjectID | null,
+  ): void => {
+    if (!projectId) {
+      findOneByIdSpy.mockResolvedValue(null as never);
+      return;
+    }
+
+    const workflow: WorkflowModel = new WorkflowModel();
+    workflow.id = workflowId;
+    workflow.projectId = projectId;
+
+    findOneByIdSpy.mockResolvedValue(workflow as never);
+  };
+
+  describe("allows an authorized member of the workflow's own project", () => {
+    test("enqueues the step and reports it scheduled", async () => {
+      getPropsSpy.mockResolvedValue(
+        buildUserProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+          permissions: [Permission.ProjectOwner],
+        }) as never,
+      );
+      mockWorkflowInProject(callerProjectId);
+
+      const result: RouteCallResult = await callRunStepRoute({
+        workflowId: workflowId.toString(),
+        body: { componentId: "api-post-1" },
+      });
+
+      expect(result.thrownToNext).toBeUndefined();
+      expect(addWorkflowToQueueSpy).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * The route must go through the queue rather than executing the component
+     * itself: the enabled check, the billing checks, the plan run-limit, the
+     * WorkflowLog audit row and the worker topology all live behind this call.
+     */
+    test("asks the queue to run only the requested component", async () => {
+      getPropsSpy.mockResolvedValue(
+        buildUserProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+          permissions: [Permission.ProjectOwner],
+        }) as never,
+      );
+      mockWorkflowInProject(callerProjectId);
+
+      await callRunStepRoute({
+        workflowId: workflowId.toString(),
+        body: { componentId: "api-post-1" },
+      });
+
+      const enqueued: JSONObject = addWorkflowToQueueSpy.mock
+        .calls[0]?.[0] as JSONObject;
+
+      expect(enqueued["runOnlyComponentId"]).toBe("api-post-1");
+      expect((enqueued["workflowId"] as ObjectID).toString()).toBe(
+        workflowId.toString(),
+      );
+    });
+
+    test("lets a master admin through", async () => {
+      getPropsSpy.mockResolvedValue(
+        buildUserProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+          permissions: [],
+          isMasterAdmin: true,
+        }) as never,
+      );
+      mockWorkflowInProject(callerProjectId);
+
+      await callRunStepRoute({ workflowId: workflowId.toString() });
+
+      expect(addWorkflowToQueueSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("refuses, and runs nothing, when", () => {
+    test("the workflow id is missing", async () => {
+      await callRunStepRoute({ workflowId: undefined });
+
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+      // Rejected before auth machinery is even consulted.
+      expect(getPropsSpy).not.toHaveBeenCalled();
+    });
+
+    test("no component id was given", async () => {
+      await callRunStepRoute({
+        workflowId: workflowId.toString(),
+        body: {},
+      });
+
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+      expect(getPropsSpy).not.toHaveBeenCalled();
+    });
+
+    test("the component id is not a string", async () => {
+      await callRunStepRoute({
+        workflowId: workflowId.toString(),
+        body: { componentId: { evil: true } } as unknown as JSONObject,
+      });
+
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+      expect(getPropsSpy).not.toHaveBeenCalled();
+    });
+
+    test("the caller is not logged in", async () => {
+      getPropsSpy.mockResolvedValue({
+        userType: UserType.Public,
+      } as never);
+
+      const result: RouteCallResult = await callRunStepRoute({
+        workflowId: workflowId.toString(),
+      });
+
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+      expect(result.thrownToNext).toBeInstanceOf(BadDataException);
+    });
+
+    test("the caller holds no permission on the claimed project", async () => {
+      getPropsSpy.mockResolvedValue(
+        buildUserProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+          permissions: [],
+        }) as never,
+      );
+      mockWorkflowInProject(callerProjectId);
+
+      const result: RouteCallResult = await callRunStepRoute({
+        workflowId: workflowId.toString(),
+      });
+
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+    });
+
+    /*
+     * Read-level membership is not enough: running a step writes.
+     */
+    test("the caller can only read the project", async () => {
+      getPropsSpy.mockResolvedValue(
+        buildUserProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+          permissions: [Permission.Viewer],
+        }) as never,
+      );
+      mockWorkflowInProject(callerProjectId);
+
+      const result: RouteCallResult = await callRunStepRoute({
+        workflowId: workflowId.toString(),
+      });
+
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+    });
+
+    /*
+     * The claimed tenant comes from a caller-supplied header, so being a
+     * legitimate member of SOME project cannot be enough.
+     */
+    test("the workflow belongs to a different project", async () => {
+      getPropsSpy.mockResolvedValue(
+        buildUserProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+          permissions: [Permission.ProjectOwner],
+        }) as never,
+      );
+      mockWorkflowInProject(otherProjectId);
+
+      const result: RouteCallResult = await callRunStepRoute({
+        workflowId: workflowId.toString(),
+      });
+
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+      expect(result.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+    });
+
+    /*
+     * Rejected the same way a foreign workflow is, deliberately: a different
+     * error here would let the route be used to discover which workflow ids
+     * exist in other projects.
+     */
+    test("the workflow does not exist — indistinguishable from a foreign one", async () => {
+      getPropsSpy.mockResolvedValue(
+        buildUserProps({
+          projectId: callerProjectId,
+          userId: callerUserId,
+          permissions: [Permission.ProjectOwner],
+        }) as never,
+      );
+
+      mockWorkflowInProject(null);
+      const missing: RouteCallResult = await callRunStepRoute({
+        workflowId: workflowId.toString(),
+      });
+
+      mockWorkflowInProject(otherProjectId);
+      const foreign: RouteCallResult = await callRunStepRoute({
+        workflowId: workflowId.toString(),
+      });
+
+      expect(addWorkflowToQueueSpy).not.toHaveBeenCalled();
+      expect(missing.thrownToNext).toBeInstanceOf(NotAuthorizedException);
+      expect((missing.thrownToNext as Error).message).toBe(
+        (foreign.thrownToNext as Error).message,
+      );
+    });
+  });
+
+  test("the route is registered behind the user middleware", () => {
+    const route: MockRoute = matchRoute("POST", RUN_STEP_ROUTE);
+
+    expect(route.middleware).toBeDefined();
+  });
+});

--- a/Common/Server/Types/Workflow/TriggerCode.ts
+++ b/Common/Server/Types/Workflow/TriggerCode.ts
@@ -20,6 +20,18 @@ export interface ExecuteWorkflowType {
    * should leave this undefined.
    */
   callChain?: Array<string>;
+  /**
+   * When set, the run executes only this one component instead of starting at
+   * the trigger and following the graph. Backs the builder's "run just this
+   * step" button.
+   *
+   * Deliberately routed through the queue like any other run, so it inherits
+   * every gate a run has: the workflow must be enabled, the subscription must
+   * be paid, the plan's run limit applies, a WorkflowLog is written for the
+   * audit trail, and the component executes on a worker rather than inside the
+   * API process.
+   */
+  runOnlyComponentId?: string | undefined;
 }
 
 export interface InitProps {

--- a/Common/Server/Types/Workflow/Workflow.ts
+++ b/Common/Server/Types/Workflow/Workflow.ts
@@ -19,4 +19,9 @@ export interface RunProps {
    * depth across workflow boundaries.
    */
   callChain?: Array<string>;
+  /**
+   * Execute only this component (by its user-facing id) instead of walking the
+   * graph from the trigger. See ExecuteWorkflowType.runOnlyComponentId.
+   */
+  runOnlyComponentId?: string | undefined;
 }

--- a/Common/UI/Components/Workflow/ComponentSettingsModal.tsx
+++ b/Common/UI/Components/Workflow/ComponentSettingsModal.tsx
@@ -22,6 +22,11 @@ export interface ComponentProps {
   onClose: () => void;
   onSave: (component: NodeDataProp) => void;
   onDelete: (component: NodeDataProp) => void;
+  /**
+   * Run this one step now. Absent for triggers, which have nothing to run on
+   * their own.
+   */
+  onRunStep?: ((component: NodeDataProp) => void) | undefined;
   component: NodeDataProp;
   graphComponents: Array<NodeDataProp>;
   workflowId: ObjectID;
@@ -66,6 +71,8 @@ const ComponentSettingsModal: FunctionComponent<ComponentProps> = (
     Dictionary<boolean>
   >({});
   const [showDeleteConfirmation, setShowDeleteConfirmation] =
+    useState<boolean>(false);
+  const [showRunStepConfirmation, setShowRunStepConfirmation] =
     useState<boolean>(false);
 
   const settingsSection: ReactElement = (
@@ -209,18 +216,50 @@ const ComponentSettingsModal: FunctionComponent<ComponentProps> = (
             </span>
           </div>
         ) : (
-          <Button
-            title="Delete"
-            icon={IconProp.Trash}
-            buttonStyle={ButtonStyleType.DANGER_OUTLINE}
-            onClick={() => {
-              setShowDeleteConfirmation(true);
-            }}
-          />
+          <div className="flex items-center gap-3">
+            <Button
+              title="Delete"
+              icon={IconProp.Trash}
+              buttonStyle={ButtonStyleType.DANGER_OUTLINE}
+              onClick={() => {
+                setShowDeleteConfirmation(true);
+              }}
+            />
+            {props.onRunStep && (
+              <Button
+                title="Run just this step"
+                icon={IconProp.Play}
+                buttonStyle={ButtonStyleType.OUTLINE}
+                onClick={() => {
+                  setShowRunStepConfirmation(true);
+                }}
+              />
+            )}
+          </div>
         )
       }
     >
       <>
+        {showRunStepConfirmation && (
+          <ConfirmModal
+            title={`Run this step now?`}
+            /*
+             * Worded as what it is. There is no dry run: the step executes for
+             * real, and anything it sends or changes is not undone afterwards.
+             */
+            description={`This runs "${component.metadata.title}" for real, on its own. Anything it sends, writes or deletes actually happens. Values it reads from other steps will be empty, because nothing else runs.`}
+            onClose={() => {
+              setShowRunStepConfirmation(false);
+            }}
+            submitButtonText="Run this step"
+            onSubmit={() => {
+              setShowRunStepConfirmation(false);
+              props.onRunStep?.(component);
+            }}
+            submitButtonType={ButtonStyleType.NORMAL}
+          />
+        )}
+
         {showDeleteConfirmation && (
           <ConfirmModal
             title={`Delete ${component.metadata.componentType}`}

--- a/Common/UI/Components/Workflow/Workflow.tsx
+++ b/Common/UI/Components/Workflow/Workflow.tsx
@@ -118,6 +118,8 @@ export interface ComponentProps {
   workflowId: ObjectID;
   onRunModalUpdate: (isModalShown: boolean) => void;
   onRun: (trigger: NodeDataProp) => void;
+  /** Run one component on its own. */
+  onRunStep?: ((component: NodeDataProp) => void) | undefined;
   webhookSecretKey?: string | undefined;
   /**
    * Called whenever the static checks over the graph are recomputed, so the
@@ -626,6 +628,16 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
           onDelete={(component: NodeDataProp) => {
             deleteNode(component.id);
           }}
+          /*
+           * Triggers have nothing to run on their own — they are the thing
+           * that starts a run, so "run just this step" is meaningless for one.
+           */
+          onRunStep={
+            props.onRunStep &&
+            selectedNodeData.componentType !== ComponentType.Trigger
+              ? props.onRunStep
+              : undefined
+          }
           description={
             selectedNodeData && selectedNodeData.metadata.description
               ? selectedNodeData.metadata.description


### PR DESCRIPTION
Builds on #3160 (this branch). Adds "Run just this step" to a component's settings panel.

## Why the obvious implementation is wrong

The natural reading of "test a single step" is an endpoint that calls `RunWorkflow.runComponent`. That is wrong three times over, and the research that turned this up is the reason the PR looks the way it does:

1. **`runComponent` reads private state.** It uses `this.projectId`, `this.workflowId` and `this.workflowDeadlineAtInMs`, all set only inside `runWorkflow`. Calling it from a handler passes `projectId: null` into every component — and the BaseModel components stamp `options.projectId` straight onto the query and the tenant column. That is a cross-tenant database hole.
2. **It would bypass the queue's gates.** `QueueWorkflow.addWorkflowToQueue` is where `isEnabled`, unpaid-subscription, and the project's 30-day plan run limit are enforced.
3. **It would leave no trace and run in the wrong process.** No `WorkflowLog` row, so a step that sends a message or deletes rows leaves nothing behind; and it would execute component code inside the API process, which the deployment topology deliberately separates (`DISABLE_QUEUE_WORKERS` on the api role).

## What this does instead

It enqueues an **ordinary workflow run that happens to be narrowed to one component**. No new execution path exists, so every gate, the audit row, the worker topology, and the existing redaction are inherited rather than reimplemented.

- `RunProps` / `ExecuteWorkflowType` carry `runOnlyComponentId` through the queue into the runner.
- `narrowRunStackToSingleComponent` keeps that component and **drops its out ports**, so nothing downstream follows. It **throws** on an id that is not in the graph rather than falling back — a request to run one step must never widen into a request to run the whole workflow.
- The route repeats `Manual.ts`'s four gates in the same order and for the same reasons, and a nonexistent workflow is refused **identically** to a foreign one, so it cannot be used to discover which workflow ids exist in other projects.

You read the result through the step trace from #3160 and the run watcher from #3159 — the three changes compose rather than each growing their own reporting.

## On calling it a "test"

I didn't. There is no notion of a safe or read-only component anywhere in the product: roughly half the registry sends chat or email, calls arbitrary URLs, or creates, updates and deletes rows, and none of it is undone afterwards. The confirmation says what actually happens:

> This runs "…" for real, on its own. Anything it sends, writes or deletes actually happens. Values it reads from other steps will be empty, because nothing else runs.

That last clause matters: a step run alone cannot resolve `{{local.components.…}}` from steps that did not run. The runner already warns per unresolved reference (added in #3158), so this is visible rather than silent.

Triggers get no button — they are the thing that starts a run.

## Tests

| Suite | Cases | Covers |
|---|---|---|
| `RunStepAuth.test.ts` | 12 | every deny path, each asserting **`addWorkflowToQueue` was never called** — an error response alone would not prove the work was stopped. Includes: not logged in, no permission, read-only permission, foreign project, nonexistent workflow (indistinguishable from foreign, asserted by comparing messages), missing/non-string component id rejected before auth is consulted. Plus that the handler goes *through* the queue, which is the only reason the gates apply. |
| `NarrowRunStack.test.ts` | 8 | containment — only that component survives, out ports are dropped, an unknown id throws instead of running everything, and the input stack is not mutated |
| existing App workflow suites | 88 | re-run; `ManualWorkflowRunAuth`, `RunWorkflow`, `RunWorkflowStepTrace`, `QueueWorkflow`, `GetComponentArguments`, `ModelSchema` all pass unchanged |

100 assertions across 8 suites in App, all green.
