### PR TITLE
feat(workflow): start from a template

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Workflow/Workflows.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Workflow/Workflows.tsx
@@ -18,7 +18,26 @@ import Workflow from "Common/Models/DatabaseModels/Workflow";
 import WorkflowLog from "Common/Models/DatabaseModels/WorkflowLog";
 import WorkflowOwnerTeam from "Common/Models/DatabaseModels/WorkflowOwnerTeam";
 import WorkflowOwnerUser from "Common/Models/DatabaseModels/WorkflowOwnerUser";
-import React, { Fragment, FunctionComponent, ReactElement } from "react";
+import React, {
+  Fragment,
+  FunctionComponent,
+  ReactElement,
+  useState,
+} from "react";
+import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
+import { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import ObjectID from "Common/Types/ObjectID";
+import Route from "Common/Types/API/Route";
+import { JSONObject } from "Common/Types/JSON";
+import API from "Common/UI/Utils/API/API";
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
+import PageMap from "../../Utils/PageMap";
+import {
+  WorkflowTemplate,
+  buildGraphForTemplate,
+  getWorkflowTemplates,
+} from "Common/Types/Workflow/Templates";
 import Pill from "Common/UI/Components/Pill/Pill";
 import { Green500, Red500 } from "Common/Types/BrandColors";
 import WorkflowElement from "../../Components/Workflow/WorkflowElement";
@@ -31,6 +50,70 @@ import { FilterOperator } from "../../Components/ResourceOwners/FilterChipDropdo
 import IconProp from "Common/Types/Icon/IconProp";
 
 const Workflows: FunctionComponent<PageComponentProps> = (): ReactElement => {
+  const [showTemplatePicker, setShowTemplatePicker] = useState<boolean>(false);
+  const [templateError, setTemplateError] = useState<string>("");
+  const [creatingTemplateId, setCreatingTemplateId] = useState<string | null>(
+    null,
+  );
+
+  /*
+   * A template is created through the ordinary Workflow create path, which is
+   * what denormalizes the trigger onto the row (WorkflowService
+   * .onCreateSuccess). Building the graph any other way would produce a
+   * workflow that looks right and never fires.
+   */
+  type CreateFromTemplateFunction = (
+    template: WorkflowTemplate,
+  ) => Promise<void>;
+
+  const createFromTemplate: CreateFromTemplateFunction = async (
+    template: WorkflowTemplate,
+  ): Promise<void> => {
+    setCreatingTemplateId(template.id);
+    setTemplateError("");
+
+    try {
+      const graph: JSONObject | null = buildGraphForTemplate(
+        template.id,
+        () => {
+          return ObjectID.generate().toString();
+        },
+      );
+
+      if (!graph) {
+        throw new Error("This template could not be built.");
+      }
+
+      const workflow: Workflow = new Workflow();
+      workflow.name = template.workflowName;
+      workflow.description = template.workflowDescription;
+      workflow.projectId = ProjectUtil.getCurrentProjectId()!;
+      workflow.graph = graph;
+      /*
+       * Created switched off on purpose: a scheduled template would otherwise
+       * start firing against a placeholder URL the moment it is created.
+       */
+      workflow.isEnabled = false;
+
+      const created: Workflow = await ModelAPI.create<Workflow>({
+        data: workflow,
+        modelType: Workflow,
+      });
+
+      setShowTemplatePicker(false);
+      Navigation.navigate(
+        RouteUtil.populateRouteParams(
+          RouteMap[PageMap.WORKFLOW_VIEW] as Route,
+          { modelId: created.id as ObjectID },
+        ),
+      );
+    } catch (err) {
+      setTemplateError(API.getFriendlyMessage(err));
+    }
+
+    setCreatingTemplateId(null);
+  };
+
   const startDate: Date = OneUptimeDate.getSomeDaysAgo(30);
   const endDate: Date = OneUptimeDate.getCurrentDate();
   const plan: PlanType | null = ProjectUtil.getCurrentPlan();
@@ -130,6 +213,16 @@ const Workflows: FunctionComponent<PageComponentProps> = (): ReactElement => {
           cardProps={{
             title: "Workflows",
             description: "Here is a list of workflows for this project.",
+            buttons: [
+              {
+                title: "Start from a template",
+                icon: IconProp.Add,
+                buttonStyle: ButtonStyleType.OUTLINE,
+                onClick: () => {
+                  setShowTemplatePicker(true);
+                },
+              },
+            ],
           }}
           videoLink={URL.fromString("https://youtu.be/z-b7_KQcUDY")}
           noItemsMessage={"No workflows found."}
@@ -278,6 +371,54 @@ const Workflows: FunctionComponent<PageComponentProps> = (): ReactElement => {
             },
           ]}
         />
+        {showTemplatePicker && (
+          <Modal
+            title="Start from a template"
+            description="Each of these is a small, working workflow. They are created switched off so you can read them before anything runs."
+            modalWidth={ModalWidth.Large}
+            submitButtonText="Close"
+            submitButtonStyleType={ButtonStyleType.NORMAL}
+            onSubmit={() => {
+              setShowTemplatePicker(false);
+            }}
+          >
+            <div className="space-y-3">
+              {templateError && (
+                <p className="text-sm text-red-600">{templateError}</p>
+              )}
+
+              {getWorkflowTemplates().map(
+                (template: WorkflowTemplate): ReactElement => {
+                  return (
+                    <button
+                      key={template.id}
+                      type="button"
+                      disabled={creatingTemplateId !== null}
+                      className="w-full text-left rounded-md border border-gray-200 bg-white p-4 hover:border-gray-400 cursor-pointer disabled:opacity-50"
+                      onClick={() => {
+                        void createFromTemplate(template);
+                      }}
+                    >
+                      <p className="text-sm font-medium text-gray-900">
+                        {template.name}
+                      </p>
+                      <p className="text-sm text-gray-500 mt-1">
+                        {template.description}
+                      </p>
+                      <p className="text-xs text-gray-400 mt-2">
+                        Teaches: {template.teaches}
+                      </p>
+                      {creatingTemplateId === template.id && (
+                        <p className="text-xs text-gray-500 mt-2">Creating…</p>
+                      )}
+                    </button>
+                  );
+                },
+              )}
+            </div>
+          </Modal>
+        )}
+
         {labelBulkActionModals}
         {ownerBulkActionModals}
       </>

--- a/Common/Tests/Types/Workflow/Templates.test.ts
+++ b/Common/Tests/Types/Workflow/Templates.test.ts
@@ -1,0 +1,403 @@
+/*
+ * Every shipped template is checked against the real component registry and
+ * against the same linter the builder runs.
+ *
+ * A template is the first workflow a lot of people will ever see, so one with
+ * a mistyped argument id, a reference to a return value that does not exist,
+ * or an edge leaving a port the component does not have would be worse than
+ * shipping no templates at all — it teaches the wrong thing and looks broken
+ * on arrival. Writing these tests caught exactly that: the Log component's
+ * argument is "value" (not "log-message"), the Schedule trigger's is
+ * "schedule" (not "schedule-at"), the Manual trigger leaves by "success" and
+ * the Schedule trigger by "execute" (neither is "out").
+ */
+
+import {
+  WorkflowTemplate,
+  buildGraphForTemplate,
+  getTemplateGraphSpec,
+  getWorkflowTemplates,
+} from "../../../Types/Workflow/Templates";
+import Components from "../../../Types/Workflow/Components";
+import ComponentMetadata, {
+  Argument,
+  ComponentType,
+  NodeDataProp,
+  Port,
+  ReturnValue,
+} from "../../../Types/Workflow/Component";
+import { JSONObject } from "../../../Types/JSON";
+import {
+  LintGraphEdge,
+  LintGraphNode,
+  WorkflowLintIssue,
+  WorkflowLintResult,
+  WorkflowLintSeverity,
+  lintWorkflowGraph,
+} from "../../../UI/Components/Workflow/GraphLint";
+import { describe, expect, test } from "@jest/globals";
+
+const templates: Array<WorkflowTemplate> = getWorkflowTemplates();
+
+type FindMetadataFunction = (
+  metadataId: string,
+) => ComponentMetadata | undefined;
+
+const findMetadata: FindMetadataFunction = (
+  metadataId: string,
+): ComponentMetadata | undefined => {
+  return Components.find((component: ComponentMetadata) => {
+    return component.id === metadataId;
+  });
+};
+
+let idCounter: number = 0;
+
+type GenerateIdFunction = () => string;
+
+const generateId: GenerateIdFunction = (): string => {
+  idCounter++;
+  return `generated-${idCounter}`;
+};
+
+/**
+ * Build a template's graph and hydrate each node with its real metadata, the
+ * way the builder does on load. Without the metadata the linter cannot check
+ * arguments or return values.
+ */
+type HydrateFunction = (templateId: string) => {
+  nodes: Array<LintGraphNode>;
+  edges: Array<LintGraphEdge>;
+};
+
+const hydrate: HydrateFunction = (
+  templateId: string,
+): { nodes: Array<LintGraphNode>; edges: Array<LintGraphEdge> } => {
+  const graph: JSONObject = buildGraphForTemplate(
+    templateId,
+    generateId,
+  ) as JSONObject;
+
+  const rawNodes: Array<JSONObject> = graph["nodes"] as Array<JSONObject>;
+  const rawEdges: Array<JSONObject> = graph["edges"] as Array<JSONObject>;
+
+  const nodes: Array<LintGraphNode> = rawNodes.map(
+    (node: JSONObject): LintGraphNode => {
+      const data: JSONObject = node["data"] as JSONObject;
+      const metadata: ComponentMetadata | undefined = findMetadata(
+        data["metadataId"] as string,
+      );
+
+      return {
+        id: node["id"] as string,
+        data: {
+          ...(data as unknown as NodeDataProp),
+          metadata: metadata as ComponentMetadata,
+        },
+      };
+    },
+  );
+
+  const edges: Array<LintGraphEdge> = rawEdges.map(
+    (edge: JSONObject): LintGraphEdge => {
+      return {
+        source: edge["source"] as string,
+        target: edge["target"] as string,
+      };
+    },
+  );
+
+  return { nodes: nodes, edges: edges };
+};
+
+describe("workflow templates", () => {
+  test("there is at least one", () => {
+    expect(templates.length).toBeGreaterThan(0);
+  });
+
+  test("each has a unique id", () => {
+    const ids: Array<string> = templates.map((template: WorkflowTemplate) => {
+      return template.id;
+    });
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("each is described well enough to choose between them", () => {
+    for (const template of templates) {
+      expect(template.name.length).toBeGreaterThan(0);
+      expect(template.description.length).toBeGreaterThan(0);
+      expect(template.teaches.length).toBeGreaterThan(0);
+      expect(template.workflowName.length).toBeGreaterThan(0);
+      expect(template.workflowDescription.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("an unknown template id yields nothing rather than throwing", () => {
+    expect(getTemplateGraphSpec("does-not-exist")).toBeNull();
+    expect(buildGraphForTemplate("does-not-exist", generateId)).toBeNull();
+  });
+});
+
+describe.each(
+  templates.map((template: WorkflowTemplate) => {
+    return [template.id, template] as [string, WorkflowTemplate];
+  }),
+)("template %s", (templateId: string) => {
+  test("every component it uses exists in the registry", () => {
+    const spec: { nodes: Array<{ metadataId: string }> } = getTemplateGraphSpec(
+      templateId,
+    ) as { nodes: Array<{ metadataId: string }> };
+
+    for (const node of spec.nodes) {
+      expect(findMetadata(node.metadataId)).toBeDefined();
+    }
+  });
+
+  test("every argument it sets is a real argument on that component", () => {
+    const spec: {
+      nodes: Array<{ metadataId: string; args?: JSONObject | undefined }>;
+    } = getTemplateGraphSpec(templateId) as {
+      nodes: Array<{ metadataId: string; args?: JSONObject | undefined }>;
+    };
+
+    for (const node of spec.nodes) {
+      const metadata: ComponentMetadata = findMetadata(
+        node.metadataId,
+      ) as ComponentMetadata;
+
+      for (const argumentId of Object.keys(node.args || {})) {
+        const argument: Argument | undefined = metadata.arguments.find(
+          (candidate: Argument) => {
+            return candidate.id === argumentId;
+          },
+        );
+
+        expect(argument).toBeDefined();
+      }
+    }
+  });
+
+  /*
+   * The runner looks up outPorts[sourceHandle] to decide what runs next. A
+   * port id that does not exist means the workflow silently stops after the
+   * first step.
+   */
+  test("every edge leaves a port the component actually has", () => {
+    const spec: {
+      nodes: Array<{ componentId: string; metadataId: string }>;
+      edges: Array<{ fromComponentId: string; fromPort: string }>;
+    } = getTemplateGraphSpec(templateId) as {
+      nodes: Array<{ componentId: string; metadataId: string }>;
+      edges: Array<{ fromComponentId: string; fromPort: string }>;
+    };
+
+    for (const edge of spec.edges) {
+      const node: { metadataId: string } = spec.nodes.find(
+        (candidate: { componentId: string }) => {
+          return candidate.componentId === edge.fromComponentId;
+        },
+      ) as { metadataId: string };
+
+      const metadata: ComponentMetadata = findMetadata(
+        node.metadataId,
+      ) as ComponentMetadata;
+
+      const port: Port | undefined = metadata.outPorts.find(
+        (candidate: Port) => {
+          return candidate.id === edge.fromPort;
+        },
+      );
+
+      expect(port).toBeDefined();
+    }
+  });
+
+  test("every required argument is filled in", () => {
+    const spec: {
+      nodes: Array<{ metadataId: string; args?: JSONObject | undefined }>;
+    } = getTemplateGraphSpec(templateId) as {
+      nodes: Array<{ metadataId: string; args?: JSONObject | undefined }>;
+    };
+
+    for (const node of spec.nodes) {
+      const metadata: ComponentMetadata = findMetadata(
+        node.metadataId,
+      ) as ComponentMetadata;
+
+      for (const argument of metadata.arguments) {
+        if (!argument.required) {
+          continue;
+        }
+
+        expect(Object.keys(node.args || {})).toContain(argument.id);
+      }
+    }
+  });
+
+  test("every {{...}} reference points at a return value that exists", () => {
+    const spec: {
+      nodes: Array<{ componentId: string; metadataId: string }>;
+    } = getTemplateGraphSpec(templateId) as {
+      nodes: Array<{ componentId: string; metadataId: string }>;
+    };
+
+    const graph: { nodes: Array<LintGraphNode>; edges: Array<LintGraphEdge> } =
+      hydrate(templateId);
+
+    const references: Array<string> = [];
+
+    for (const node of graph.nodes) {
+      for (const value of Object.values(node.data.arguments || {})) {
+        if (typeof value !== "string") {
+          continue;
+        }
+
+        const matches: Array<string> = value.match(/{{(.*?)}}/g) || [];
+        references.push(...matches);
+      }
+    }
+
+    for (const reference of references) {
+      const path: string = reference.slice(2, -2);
+      const parts: Array<string> = path.split(".");
+
+      expect(parts[0]).toBe("local");
+      expect(parts[1]).toBe("components");
+
+      const referencedNode: { metadataId: string } = spec.nodes.find(
+        (candidate: { componentId: string }) => {
+          return candidate.componentId === parts[2];
+        },
+      ) as { metadataId: string };
+
+      expect(referencedNode).toBeDefined();
+      expect(parts[3]).toBe("returnValues");
+
+      const metadata: ComponentMetadata = findMetadata(
+        referencedNode.metadataId,
+      ) as ComponentMetadata;
+
+      const returnValue: ReturnValue | undefined = metadata.returnValues.find(
+        (candidate: ReturnValue) => {
+          return candidate.id === parts[4];
+        },
+      );
+
+      expect(returnValue).toBeDefined();
+    }
+  });
+
+  /*
+   * The end-to-end check: run the shipped template through the same linter the
+   * builder applies to a graph someone is editing. Zero errors is the bar.
+   */
+  test("passes the builder's own graph checks with no errors", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph(hydrate(templateId));
+
+    const errors: Array<WorkflowLintIssue> = result.issues.filter(
+      (issue: WorkflowLintIssue) => {
+        return issue.severity === WorkflowLintSeverity.Error;
+      },
+    );
+
+    expect(
+      errors.map((issue: WorkflowLintIssue) => {
+        return issue.message;
+      }),
+    ).toEqual([]);
+  });
+
+  test("has exactly one trigger, and it is a real trigger component", () => {
+    const spec: {
+      nodes: Array<{ metadataId: string; componentType: ComponentType }>;
+    } = getTemplateGraphSpec(templateId) as {
+      nodes: Array<{ metadataId: string; componentType: ComponentType }>;
+    };
+
+    const triggers: Array<{ metadataId: string }> = spec.nodes.filter(
+      (node: { componentType: ComponentType }) => {
+        return node.componentType === ComponentType.Trigger;
+      },
+    );
+
+    expect(triggers).toHaveLength(1);
+
+    const metadata: ComponentMetadata = findMetadata(
+      triggers[0]?.metadataId as string,
+    ) as ComponentMetadata;
+
+    expect(metadata.componentType).toBe(ComponentType.Trigger);
+  });
+
+  /*
+   * Two workflows created from one template must not share react-flow ids, or
+   * editing one would be liable to disturb the other on import/export.
+   */
+  test("builds fresh node ids each time", () => {
+    const first: JSONObject = buildGraphForTemplate(
+      templateId,
+      generateId,
+    ) as JSONObject;
+    const second: JSONObject = buildGraphForTemplate(
+      templateId,
+      generateId,
+    ) as JSONObject;
+
+    const firstIds: Array<string> = (first["nodes"] as Array<JSONObject>).map(
+      (node: JSONObject) => {
+        return node["id"] as string;
+      },
+    );
+    const secondIds: Array<string> = (second["nodes"] as Array<JSONObject>).map(
+      (node: JSONObject) => {
+        return node["id"] as string;
+      },
+    );
+
+    for (const id of firstIds) {
+      expect(secondIds).not.toContain(id);
+    }
+  });
+
+  test("keeps stable component ids, because references point at them", () => {
+    const first: JSONObject = buildGraphForTemplate(
+      templateId,
+      generateId,
+    ) as JSONObject;
+    const second: JSONObject = buildGraphForTemplate(
+      templateId,
+      generateId,
+    ) as JSONObject;
+
+    type ComponentIdsFunction = (graph: JSONObject) => Array<string>;
+
+    const componentIds: ComponentIdsFunction = (
+      graph: JSONObject,
+    ): Array<string> => {
+      return (graph["nodes"] as Array<JSONObject>).map((node: JSONObject) => {
+        return (node["data"] as JSONObject)["id"] as string;
+      });
+    };
+
+    expect(componentIds(first)).toEqual(componentIds(second));
+  });
+
+  test("edges connect nodes that are in the graph", () => {
+    const graph: JSONObject = buildGraphForTemplate(
+      templateId,
+      generateId,
+    ) as JSONObject;
+
+    const nodeIds: Array<string> = (graph["nodes"] as Array<JSONObject>).map(
+      (node: JSONObject) => {
+        return node["id"] as string;
+      },
+    );
+
+    for (const edge of graph["edges"] as Array<JSONObject>) {
+      expect(nodeIds).toContain(edge["source"] as string);
+      expect(nodeIds).toContain(edge["target"] as string);
+    }
+  });
+});

--- a/Common/Types/Workflow/Templates.ts
+++ b/Common/Types/Workflow/Templates.ts
@@ -1,0 +1,316 @@
+/*
+ * Starter workflows.
+ *
+ * An empty canvas is a bad first lesson: the thing a new builder most needs to
+ * learn is how one step reads another's output, and nothing on a blank graph
+ * teaches it. Each template below is a small, working workflow whose whole
+ * point is to show a {{local.components.…}} reference in context.
+ *
+ * Every template here is deliberately runnable with no external configuration
+ * — no Slack token, no API key, no third-party account. Templates that need
+ * credentials belong in the docs, not in a one-click "start from this".
+ *
+ * The graphs are plain data in the same shape the builder saves and the JSON
+ * import reads, so a template is created through the ordinary Workflow create
+ * path (which denormalizes the trigger onto the row in
+ * WorkflowService.onCreateSuccess).
+ */
+
+import { JSONObject } from "../JSON";
+import ComponentID from "./ComponentID";
+import { ComponentType, NodeType } from "./Component";
+
+export interface WorkflowTemplate {
+  /** Stable key, used by the picker and by tests. */
+  id: string;
+  name: string;
+  /** One line, shown on the card. */
+  description: string;
+  /** What the builder should look at once it opens. */
+  teaches: string;
+  /** Suggested name for the created workflow. */
+  workflowName: string;
+  workflowDescription: string;
+}
+
+interface TemplateNodeSpec {
+  componentId: string;
+  metadataId: string;
+  componentType: ComponentType;
+  position: { x: number; y: number };
+  args?: JSONObject | undefined;
+}
+
+interface TemplateEdgeSpec {
+  fromComponentId: string;
+  toComponentId: string;
+  fromPort: string;
+}
+
+interface TemplateGraphSpec {
+  nodes: Array<TemplateNodeSpec>;
+  edges: Array<TemplateEdgeSpec>;
+}
+
+/*
+ * Node and edge identifiers are generated per creation rather than baked in,
+ * so two workflows made from the same template never share react-flow ids.
+ * The component ids (the user-facing "log-1") are stable, because that is what
+ * the {{...}} references inside the template point at.
+ */
+export type BuildTemplateGraphFunction = (
+  spec: TemplateGraphSpec,
+  generateId: () => string,
+) => JSONObject;
+
+export const buildTemplateGraph: BuildTemplateGraphFunction = (
+  spec: TemplateGraphSpec,
+  generateId: () => string,
+): JSONObject => {
+  const nodeIdByComponentId: Record<string, string> = {};
+
+  const nodes: Array<JSONObject> = spec.nodes.map(
+    (node: TemplateNodeSpec): JSONObject => {
+      const nodeId: string = generateId();
+      nodeIdByComponentId[node.componentId] = nodeId;
+
+      return {
+        id: nodeId,
+        type: "node",
+        position: node.position,
+        data: {
+          id: node.componentId,
+          nodeType: NodeType.Node,
+          componentType: node.componentType,
+          metadataId: node.metadataId,
+          internalId: generateId(),
+          error: "",
+          arguments: node.args || {},
+          returnValues: {},
+        },
+      };
+    },
+  );
+
+  const edges: Array<JSONObject> = spec.edges.map(
+    (edge: TemplateEdgeSpec): JSONObject => {
+      return {
+        id: generateId(),
+        source: nodeIdByComponentId[edge.fromComponentId] as string,
+        target: nodeIdByComponentId[edge.toComponentId] as string,
+        sourceHandle: edge.fromPort,
+        targetHandle: "in",
+      };
+    },
+  );
+
+  return { nodes: nodes, edges: edges };
+};
+
+type TemplateDefinition = WorkflowTemplate & { graph: TemplateGraphSpec };
+
+const TEMPLATE_DEFINITIONS: Array<TemplateDefinition> = [
+  {
+    id: "manual-log",
+    name: "Log a message when run by hand",
+    description:
+      "The smallest working workflow: a manual trigger and a step that writes a line to the run log.",
+    teaches: "How to run a workflow and where its output shows up.",
+    workflowName: "Log a message",
+    workflowDescription:
+      "Runs on demand and writes a line to the run log. A good place to start.",
+    graph: {
+      nodes: [
+        {
+          componentId: "manual-1",
+          metadataId: ComponentID.Manual,
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+        },
+        {
+          componentId: "log-1",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            value: "Hello from OneUptime. This workflow ran.",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "manual-1",
+          toComponentId: "log-1",
+          fromPort: "success",
+        },
+      ],
+    },
+  },
+  {
+    id: "webhook-echo",
+    name: "Echo what a webhook sent",
+    description:
+      "Takes the body posted to this workflow's webhook and writes it back out to the log.",
+    /*
+     * The reason this template exists: the log message is a reference, not
+     * text, and seeing that in place is the fastest way to understand the
+     * whole substitution model.
+     */
+    teaches:
+      "How one step reads another's output, using {{local.components...}}.",
+    workflowName: "Echo webhook body",
+    workflowDescription:
+      "Writes whatever was posted to this workflow's webhook into the run log.",
+    graph: {
+      nodes: [
+        {
+          componentId: "webhook-1",
+          metadataId: ComponentID.Webhook,
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+        },
+        {
+          componentId: "log-1",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            value:
+              "Webhook received: {{local.components.webhook-1.returnValues.request-body}}",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "webhook-1",
+          toComponentId: "log-1",
+          fromPort: "out",
+        },
+      ],
+    },
+  },
+  {
+    id: "scheduled-check",
+    name: "Call an API on a schedule",
+    description:
+      "Runs every hour, calls a URL, and logs whether it came back OK — with separate paths for success and failure.",
+    teaches:
+      "How a schedule works, and how a step's Success and Error ports branch.",
+    workflowName: "Hourly API check",
+    workflowDescription:
+      "Calls a URL every hour and logs the outcome. Point the URL at something of yours.",
+    graph: {
+      nodes: [
+        {
+          componentId: "schedule-1",
+          metadataId: ComponentID.Schedule,
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: {
+            schedule: "0 * * * *",
+          },
+        },
+        {
+          componentId: "api-get-1",
+          metadataId: ComponentID.ApiGet,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            url: "https://api.github.com/zen",
+          },
+        },
+        {
+          componentId: "log-ok",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: -100, y: 500 },
+          args: {
+            value:
+              "Responded {{local.components.api-get-1.returnValues.response-status}}: {{local.components.api-get-1.returnValues.response-body}}",
+          },
+        },
+        {
+          componentId: "log-failed",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: 300, y: 500 },
+          args: {
+            value:
+              "Call failed: {{local.components.api-get-1.returnValues.error}}",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "schedule-1",
+          toComponentId: "api-get-1",
+          fromPort: "execute",
+        },
+        {
+          fromComponentId: "api-get-1",
+          toComponentId: "log-ok",
+          fromPort: "success",
+        },
+        {
+          fromComponentId: "api-get-1",
+          toComponentId: "log-failed",
+          fromPort: "error",
+        },
+      ],
+    },
+  },
+];
+
+export type GetWorkflowTemplatesFunction = () => Array<WorkflowTemplate>;
+
+export const getWorkflowTemplates: GetWorkflowTemplatesFunction =
+  (): Array<WorkflowTemplate> => {
+    return TEMPLATE_DEFINITIONS.map(
+      (definition: TemplateDefinition): WorkflowTemplate => {
+        return {
+          id: definition.id,
+          name: definition.name,
+          description: definition.description,
+          teaches: definition.teaches,
+          workflowName: definition.workflowName,
+          workflowDescription: definition.workflowDescription,
+        };
+      },
+    );
+  };
+
+export type GetTemplateGraphSpecFunction = (
+  templateId: string,
+) => TemplateGraphSpec | null;
+
+export const getTemplateGraphSpec: GetTemplateGraphSpecFunction = (
+  templateId: string,
+): TemplateGraphSpec | null => {
+  const definition: TemplateDefinition | undefined = TEMPLATE_DEFINITIONS.find(
+    (candidate: TemplateDefinition) => {
+      return candidate.id === templateId;
+    },
+  );
+
+  return definition ? definition.graph : null;
+};
+
+export type BuildGraphForTemplateFunction = (
+  templateId: string,
+  generateId: () => string,
+) => JSONObject | null;
+
+export const buildGraphForTemplate: BuildGraphForTemplateFunction = (
+  templateId: string,
+  generateId: () => string,
+): JSONObject | null => {
+  const spec: TemplateGraphSpec | null = getTemplateGraphSpec(templateId);
+
+  if (!spec) {
+    return null;
+  }
+
+  return buildTemplateGraph(spec, generateId);
+};
+
+export default getWorkflowTemplates;


### PR DESCRIPTION
Last of the workflow series (after #3158, #3159, #3160, #3161).

## Why

An empty canvas is a bad first lesson. The single thing a new builder most needs to learn is how one step reads another's output — and nothing on a blank graph teaches it. Import/export already landed, so the graph format is proven; this puts three small working workflows behind a button.

## The templates

| Template | Teaches |
|---|---|
| **Log a message when run by hand** | How to run a workflow and where its output shows up — the smallest thing that works. |
| **Echo what a webhook sent** | How one step reads another's output. This one exists *only* to show a `{{local.components.webhook-1.returnValues.request-body}}` reference in place. |
| **Call an API on a schedule** | A cron trigger, and a step that branches on its Success and Error ports. |

All three run with **no external configuration** — no Slack token, no API key, no third-party account. Templates that need credentials belong in the docs, not behind a one-click "start from this".

## Two decisions worth noting

**Created switched off.** Otherwise the scheduled template starts firing against a placeholder URL the moment it exists.

**Created through the ordinary Workflow create path.** That is what denormalizes the trigger onto the row (`WorkflowService.onCreateSuccess`). Building the graph and writing it any other way produces a workflow that looks right in the builder and never fires — exactly the trap the JSON import feature hit and fixed. Node and edge ids are generated per creation so two workflows from one template never collide, while component ids stay stable, because that is what the `{{...}}` references inside the template point at.

## Tests found four real bugs

Every shipped template is validated against the **real component registry** and run through the **same linter the builder applies** (`lintWorkflowGraph` from #3158), with zero errors as the bar. A template is the first workflow many people will ever see; one with a mistyped argument id would teach the wrong thing and look broken on arrival.

Writing these tests caught four mistakes in my first draft:

- the Log component's argument is `value`, not `log-message`
- the Schedule trigger's is `schedule`, not `schedule-at`
- the Manual trigger leaves by `success`, not `out`
- the Schedule trigger leaves by `execute`, not `out`

The last two matter most: the runner resolves the next step via `outPorts[sourceHandle]`, so a wrong port id means the workflow **silently stops after its first step** — it would have looked fine on the canvas.

34 assertions, covering per template: every component exists, every argument set is real, every required argument is filled, every edge leaves a port the component actually has, every `{{...}}` points at a return value that exists, exactly one trigger, fresh node ids per build, stable component ids across builds, edges connecting real nodes — plus the end-to-end lint check.
