### PR TITLE
fix(dashboard): restore topology metadata for the new entity types

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Topology/TopologyMeta.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/TopologyMeta.ts
@@ -48,6 +48,35 @@ const META_BY_TYPE: Record<EntityType, EntityTypeMeta> = {
   },
   [EntityType.DockerSwarmTask]: { label: "Swarm Task", color: "#22d3ee" },
   [EntityType.TelemetrySdk]: { label: "Telemetry SDK", color: "#94a3b8" },
+  /*
+   * Inventory-mirrored types. Greens, to read as one family distinct from the
+   * telemetry-derived types above — on the graph these are things OneUptime
+   * polls rather than things that report in.
+   */
+  [EntityType.NetworkDevice]: { label: "Network Device", color: "#059669" },
+  [EntityType.CloudResource]: { label: "Cloud Resource", color: "#10b981" },
+  [EntityType.ServerlessFunction]: {
+    label: "Serverless Function",
+    color: "#34d399",
+  },
+  [EntityType.RumApplication]: { label: "RUM Application", color: "#14b8a6" },
+  [EntityType.IoTDevice]: { label: "IoT Device", color: "#047857" },
+  [EntityType.DockerHost]: { label: "Docker Host", color: "#0d9488" },
+  [EntityType.PodmanHost]: { label: "Podman Host", color: "#0f766e" },
+  /*
+   * Manual types. Amber, deliberately unlike everything else: these are the
+   * parts of the graph OneUptime cannot see for itself and is taking a
+   * human's word for.
+   */
+  [EntityType.ExternalService]: {
+    label: "External Service",
+    color: "#d97706",
+  },
+  [EntityType.ExternalDatabase]: {
+    label: "External Database",
+    color: "#b45309",
+  },
+  [EntityType.Appliance]: { label: "Appliance", color: "#f59e0b" },
 };
 
 export function metaForEntityType(


### PR DESCRIPTION
Fixes a broken `master`. **[#3157](https://github.com/OneUptime/oneuptime/pull/3157) landed with `compile-dashboard` failing** — my mistake, and this is the remedy.

## The break

[`TopologyMeta.ts`](App/FeatureSet/Dashboard/src/Components/Topology/TopologyMeta.ts) declares `META_BY_TYPE` as `Record<EntityType, EntityTypeMeta>` — exhaustive, so every entity type needs an entry. #3157 added ten new types (seven inventory-mirrored, three manual) and added none of theirs:

```
error TS2740: Type '{...}' is missing the following properties from
Record<EntityType, EntityTypeMeta>: "network.device", "cloud.resource",
"serverless.function", "rum.application", and 6 more.
```

## The fix

The ten missing entries. Presentation data only, no logic change:

- **Inventory-mirrored types** take greens, so they read as one family against the existing telemetry-derived palette — on the graph these are things OneUptime polls rather than things that report in.
- **Manual types** take amber, deliberately distinct: they're the parts of the graph OneUptime cannot see for itself and is taking a human's word for.

The exhaustive `Record` is what enforces this, so the compiler is the regression guard — no test needed or added.

## Verification

Ran the `compile-dashboard` command itself, exactly as [compile.yml:156](.github/workflows/compile.yml:156) defines it:

```
cd App/FeatureSet/Dashboard && npm install && npm run compile   # rc=0
cd Common && npm run compile                                     # rc=0
```

Both clean. I reproduced the original failure with the same command before fixing, so this isn't a guess at the cause.

## How it got in, for the record

I validated #3157 with Common and App test suites but never compiled the Dashboard package. The Dashboard test I wrote reads the component files *as text* to assert their wiring, which type-checks nothing — so it gave the appearance of UI coverage while the compiler never saw those files. Compiling each affected package is the check that would have caught this, and it's what I ran here.

Worth noting separately: `master` has branch protection with **no required status checks**, so a red PR can merge — and on a repo this active, a commit's own CI run is frequently cancelled by the next merge before it finishes. Both are worth a look independently of this fix.
