### PR TITLE
feat(dashboard): render SLO widgets on public dashboards

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardSloComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardSloComponent.tsx
@@ -13,8 +13,8 @@ import DashboardSloComponent, {
 } from "Common/Types/Dashboard/DashboardComponents/DashboardSloComponent";
 import { DashboardBaseComponentProps } from "./DashboardBaseComponent";
 import DashboardResourceList from "../Utils/DashboardResourceList";
+import SloWidgetData from "../Utils/SloWidgetData";
 import ServiceLevelObjective from "Common/Models/DatabaseModels/ServiceLevelObjective";
-import SloHistory from "Common/Models/AnalyticsModels/SloHistory";
 import AggregatedResult from "Common/Types/BaseDatabase/AggregatedResult";
 import AggregationInterval from "Common/Types/BaseDatabase/AggregationInterval";
 import AggregationType from "Common/Types/BaseDatabase/AggregationType";
@@ -42,8 +42,6 @@ import {
   SLO_NOT_EVALUATED_TEXT,
   SloWidgetTileDisplay,
 } from "Common/Utils/Slo/SloWidgetFormat";
-import AnalyticsModelAPI from "Common/UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI";
-import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 import API from "Common/UI/Utils/API/API";
 import ProjectUtil from "Common/UI/Utils/Project";
 import Icon from "Common/UI/Components/Icon/Icon";
@@ -127,6 +125,15 @@ const DashboardSloComponentElement: FunctionComponent<ComponentProps> = (
   const isChart: boolean = displayType === SloWidgetDisplayType.Chart;
 
   /*
+   * The public endpoints resolve the widget — and therefore the SLO they are
+   * allowed to read — from this id, so the fetch depends on it. Depend on the
+   * STRING: a re-render can hand us a fresh ObjectID for the same widget, and
+   * an identity-based dep would refetch on every one of those (arePropsEqual
+   * below compares the same way).
+   */
+  const componentIdKey: string = props.componentId.toString();
+
+  /*
    * refreshTick is a dep so each auto-refresh re-resolves a relative range
    * ("Past 1 hour") into a fresh concrete window; without it the window is
    * frozen at mount and every refresh re-queries the same stale span. Same
@@ -164,21 +171,14 @@ const DashboardSloComponentElement: FunctionComponent<ComponentProps> = (
       }
 
       /*
-       * SLOs are not exposed through the public-dashboard resource proxy, so
-       * on a shared dashboard say so instead of firing a request that would
-       * come back 401 and surface as a raw error.
+       * A public dashboard has no session and no "current project" — its
+       * reads go through the dashboard-scoped public endpoints instead, which
+       * derive the SLO and the project from the stored widget server-side.
        */
-      if (DashboardResourceList.isPublic()) {
-        setSlo(null);
-        setChartPoints([]);
-        setError("SLO widgets are not available on public dashboards.");
-        setIsLoading(false);
-        return;
-      }
-
+      const isPublicDashboard: boolean = DashboardResourceList.isPublic();
       const projectId: ObjectID | null = ProjectUtil.getCurrentProjectId();
 
-      if (!projectId) {
+      if (!isPublicDashboard && !projectId) {
         setError("No project selected.");
         setIsLoading(false);
         return;
@@ -188,18 +188,9 @@ const DashboardSloComponentElement: FunctionComponent<ComponentProps> = (
 
       try {
         const fetchedSlo: ServiceLevelObjective | null =
-          await ModelAPI.getItem<ServiceLevelObjective>({
-            modelType: ServiceLevelObjective,
-            id: sloId,
-            select: {
-              name: true,
-              targetPercentage: true,
-              currentSliPercentage: true,
-              errorBudgetRemainingPercentage: true,
-              errorBudgetRemainingSeconds: true,
-              currentBurnRate: true,
-              sloStatus: true,
-            },
+          await SloWidgetData.fetchSlo({
+            serviceLevelObjectiveId: sloId,
+            componentId: props.componentId,
           });
 
         if (isStale()) {
@@ -235,11 +226,16 @@ const DashboardSloComponentElement: FunctionComponent<ComponentProps> = (
          * page's charts.)
          */
         const result: AggregatedResult =
-          await AnalyticsModelAPI.aggregate<SloHistory>({
-            modelType: SloHistory,
+          await SloWidgetData.aggregateSloHistory({
+            componentId: props.componentId,
             aggregateBy: {
               query: {
-                projectId: projectId,
+                /*
+                 * On a public dashboard there is no current project and the
+                 * server pins the scope itself; the ObjectID cast keeps the
+                 * authenticated query shape unchanged.
+                 */
+                projectId: projectId as ObjectID,
                 sloId: sloId,
                 metricName: getSloHistoryMetricName(sloMetric),
                 bucketStart: new InBetween(startDate, endDate),
@@ -298,7 +294,13 @@ const DashboardSloComponentElement: FunctionComponent<ComponentProps> = (
       if (!isStale()) {
         setIsLoading(false);
       }
-    }, [serviceLevelObjectiveId, sloMetric, isChart, startAndEndDate]);
+    }, [
+      serviceLevelObjectiveId,
+      sloMetric,
+      isChart,
+      startAndEndDate,
+      componentIdKey,
+    ]);
 
   useEffect(() => {
     fetchData();

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardResourceList.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/DashboardResourceList.ts
@@ -33,6 +33,7 @@ export type DashboardResourceType =
   | "ceph-resource"
   | "docker-swarm-resource"
   | "network-site"
+  | "slo"
   | "span"
   | "log";
 

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/SloWidgetData.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/SloWidgetData.ts
@@ -1,0 +1,137 @@
+import DashboardResourceList, {
+  DashboardResourceRequestOptions,
+} from "./DashboardResourceList";
+import {
+  getPublicDashboardContext,
+  PublicDashboardContext,
+} from "./PublicDashboardContext";
+import SloHistory from "Common/Models/AnalyticsModels/SloHistory";
+import ServiceLevelObjective from "Common/Models/DatabaseModels/ServiceLevelObjective";
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import AggregateBy from "Common/Types/BaseDatabase/AggregateBy";
+import AggregatedResult from "Common/Types/BaseDatabase/AggregatedResult";
+import Query from "Common/Types/BaseDatabase/Query";
+import Select from "Common/Types/BaseDatabase/Select";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { JSONObject } from "Common/Types/JSON";
+import JSONFunctions from "Common/Types/JSONFunctions";
+import ObjectID from "Common/Types/ObjectID";
+import AnalyticsModelAPI from "Common/UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+
+/*
+ * Data access for the dashboard SLO widget, which reads the same two things
+ * on an authenticated dashboard and on an anonymous public one — but through
+ * different endpoints.
+ *
+ * Keeping both routes here (rather than branching inside the renderer) means
+ * the public and private paths cannot drift in what they SELECT, which is the
+ * field that decides what an anonymous viewer gets to see.
+ */
+
+/*
+ * Exactly the fields the widget renders. The public endpoint pins its own
+ * copy of this select server-side and ignores whatever the client sends, so
+ * this list is the widget's contract, never its access control.
+ */
+export const SLO_WIDGET_SELECT: Select<ServiceLevelObjective> = {
+  name: true,
+  targetPercentage: true,
+  currentSliPercentage: true,
+  errorBudgetRemainingPercentage: true,
+  errorBudgetRemainingSeconds: true,
+  currentBurnRate: true,
+  sloStatus: true,
+};
+
+export default class SloWidgetData {
+  /**
+   * The SLO's current numbers.
+   *
+   * Public dashboards go through the shared resource-list endpoint, which
+   * resolves the SLO from the STORED widget config — so the id below is only
+   * ever used by the authenticated path.
+   */
+  public static async fetchSlo(data: {
+    serviceLevelObjectiveId: ObjectID;
+    componentId: ObjectID;
+  }): Promise<ServiceLevelObjective | null> {
+    /*
+     * No variables are sent: an SLO widget names one SLO outright, so unlike
+     * the list widgets its server-side policy has nothing to interpolate.
+     */
+    const requestOptions: DashboardResourceRequestOptions | undefined =
+      DashboardResourceList.getRequestOptions("slo", {
+        componentId: data.componentId,
+      });
+
+    if (!requestOptions) {
+      return ModelAPI.getItem<ServiceLevelObjective>({
+        modelType: ServiceLevelObjective,
+        id: data.serviceLevelObjectiveId,
+        select: SLO_WIDGET_SELECT,
+      });
+    }
+
+    const listResult: ListResult<ServiceLevelObjective> =
+      await ModelAPI.getList<ServiceLevelObjective>({
+        modelType: ServiceLevelObjective,
+        requestOptions: requestOptions,
+        query: {
+          _id: data.serviceLevelObjectiveId,
+        } as Query<ServiceLevelObjective>,
+        select: SLO_WIDGET_SELECT,
+        sort: {
+          name: SortOrder.Ascending,
+        },
+        limit: 1,
+        skip: 0,
+      });
+
+    /*
+     * A widget pointed at a since-deleted SLO comes back as an empty list
+     * rather than a 404, which is the same "this SLO no longer exists" state
+     * the authenticated path expresses with null.
+     */
+    return listResult.data[0] || null;
+  }
+
+  /**
+   * The SLO's history series for the widget's Chart display.
+   *
+   * The public endpoint takes the componentId instead of a query: it rebuilds
+   * the whole aggregation from the stored widget and only reads the time
+   * window out of `aggregateBy`.
+   */
+  public static async aggregateSloHistory(data: {
+    componentId: ObjectID;
+    aggregateBy: AggregateBy<SloHistory>;
+  }): Promise<AggregatedResult> {
+    const context: PublicDashboardContext | null = getPublicDashboardContext();
+
+    if (!context) {
+      return AnalyticsModelAPI.aggregate<SloHistory>({
+        modelType: SloHistory,
+        aggregateBy: data.aggregateBy,
+      });
+    }
+
+    const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+      await context.postJSON(
+        `/slo-history-aggregate/${context.dashboardId.toString()}`,
+        {
+          componentId: data.componentId.toString(),
+          aggregateBy: JSONFunctions.serialize(
+            data.aggregateBy as any,
+          ) as JSONObject,
+        },
+      );
+
+    if (response instanceof HTTPErrorResponse) {
+      throw response;
+    }
+
+    return response.data as unknown as AggregatedResult;
+  }
+}

--- a/App/FeatureSet/Docs/Content/en/dashboards/sharing.md
+++ b/App/FeatureSet/Docs/Content/en/dashboards/sharing.md
@@ -20,6 +20,8 @@ A public dashboard:
 
 Treat enabling a public dashboard like publishing a webpage. Every widget on it becomes world-readable. Look at what's on the canvas before you flip the switch.
 
+Each widget publishes only what it draws, and only for the resources it was pointed at. An SLO widget, for instance, publishes that SLO's headline numbers but never its definition — see [SLO](/docs/dashboards/widgets#slo). External **Data Source** widgets are the exception: they are dropped from a public dashboard entirely rather than rendered, because their configuration is the query itself.
+
 ## Master password
 
 To put a password on a public dashboard:

--- a/App/FeatureSet/Docs/Content/en/dashboards/widgets.md
+++ b/App/FeatureSet/Docs/Content/en/dashboards/widgets.md
@@ -161,6 +161,21 @@ A live list of monitors and their current status.
 
 Use it when: you want a fleet view — "are all the sites up?"
 
+## Service Level Objectives
+
+### SLO
+
+One Service Level Objective, drawn either as a single number or as a line over time.
+
+**Settings**: which SLO, which of its three numbers (SLI, Error Budget Remaining, or Burn Rate), Tile or Chart display, and an optional title.
+
+- **Tile** prints the current number, plus a second line where there is one — the target under the SLI, minutes remaining under the error budget. A status pill colors the whole thing.
+- **Chart** draws the same number over the dashboard's time range, with the target marked as a dashed line on the SLI series. History is written every few minutes by the evaluation worker, so a brand-new SLO charts as empty until it has been evaluated for the first time.
+
+Use it when: the dashboard is answering "are we meeting what we promised?" rather than "what is happening right now".
+
+The SLO widget works on [public dashboards](/docs/dashboards/sharing). What gets published is the SLO's headline numbers — its name, target, current SLI, error budget remaining, burn rate, and status — regardless of which one of them the widget happens to draw. Its definition stays private: the monitors it watches, its labels, its description, its query, and its evaluation schedule are never sent to a public viewer. A Tile widget publishes only those current numbers; a Chart widget also publishes the history of the one series it charts, and nothing else.
+
 ## Kubernetes resource lists
 
 For projects with a [Kubernetes Agent](/docs/monitor/kubernetes-agent) installed. Each one takes optional filters for cluster, namespace, and labels.
@@ -202,7 +217,7 @@ Your network sites drawn on the world map, each pinned at its own latitude and l
 
 The map frames itself to the sites it drew — an estate inside one country fills the frame with that country, one spread across continents opens on the world. There are no zoom or pan controls: a dashboard tile is a picture, and the Network Map page under Network is where you walk the hierarchy.
 
-Above the map it prints how many sites are down, because a two-pixel red dot among two hundred green ones is not something anyone reads at dashboard distance. Below it, a coverage line says what the map is *not* showing — sites with no coordinates, and whether the row cap was hit.
+Above the map it prints how many sites are down, because a two-pixel red dot among two hundred green ones is not something anyone reads at dashboard distance. Below it, a coverage line says what the map is _not_ showing — sites with no coordinates, and whether the row cap was hit.
 
 **Settings**: title, map or list view, maximum sites drawn, whether to print site names, and filters by site type and by status. Site names come off automatically when the map gets too busy for them to be readable; the tooltip still names every marker.
 
@@ -218,6 +233,7 @@ A few quick rules:
 - **Breakdown across many things?** Table.
 - **What's happening in the system right now?** Log Stream, Trace List, Incident List.
 - **The state of a specific group of resources?** The matching list widget.
+- **Are we meeting the reliability we promised?** SLO.
 - **Where in the world your network is, and what's red?** Network Map.
 - **A heading, a paragraph, or a link?** Text.
 - **Something none of the above covers?** HTML — but only after checking that a built-in widget really can't do it.

--- a/App/Tests/Dashboard/DashboardResourceList.test.ts
+++ b/App/Tests/Dashboard/DashboardResourceList.test.ts
@@ -76,4 +76,38 @@ describe("DashboardResourceList request context", () => {
       ],
     });
   });
+
+  /*
+   * The SLO widget is the one resource that carries no variables — it names a
+   * single SLO outright — so it exercises the widget-identity-only shape of a
+   * public request.
+   */
+  test("routes an SLO read to the dashboard-scoped public endpoint", () => {
+    setPublicDashboardContext({
+      dashboardId: new ObjectID("dashboard-id"),
+      apiUrl: URL.fromString("https://example.com/public-dashboard-api"),
+      postJSON: jest.fn<PublicDashboardPostJSON>(),
+    });
+
+    const options: ReturnType<typeof DashboardResourceList.getRequestOptions> =
+      DashboardResourceList.getRequestOptions("slo", {
+        componentId: new ObjectID("component-id"),
+      });
+
+    expect(options?.overrideRequestUrl.toString()).toBe(
+      "https://example.com/public-dashboard-api/resource-list/dashboard-id/slo",
+    );
+    expect(options?.additionalRequestBody).toEqual({
+      componentId: "component-id",
+      variables: [],
+    });
+  });
+
+  test("leaves an authenticated SLO read on the private CRUD route", () => {
+    expect(
+      DashboardResourceList.getRequestOptions("slo", {
+        componentId: new ObjectID("component-id"),
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/Common/Server/API/DashboardAPI.ts
+++ b/Common/Server/API/DashboardAPI.ts
@@ -51,8 +51,10 @@ import ProxmoxResource from "../../Models/DatabaseModels/ProxmoxResource";
 import CephResource from "../../Models/DatabaseModels/CephResource";
 import DockerSwarmResource from "../../Models/DatabaseModels/DockerSwarmResource";
 import NetworkSite from "../../Models/DatabaseModels/NetworkSite";
+import ServiceLevelObjective from "../../Models/DatabaseModels/ServiceLevelObjective";
 import Span from "../../Models/AnalyticsModels/Span";
 import Log from "../../Models/AnalyticsModels/Log";
+import SloHistory from "../../Models/AnalyticsModels/SloHistory";
 import IncidentService from "../Services/IncidentService";
 import AlertService from "../Services/AlertService";
 import MonitorService from "../Services/MonitorService";
@@ -66,13 +68,20 @@ import ProxmoxResourceService from "../Services/ProxmoxResourceService";
 import CephResourceService from "../Services/CephResourceService";
 import DockerSwarmResourceService from "../Services/DockerSwarmResourceService";
 import NetworkSiteService from "../Services/NetworkSiteService";
+import ServiceLevelObjectiveService from "../Services/ServiceLevelObjectiveService";
 import SpanService from "../Services/SpanService";
 import LogService from "../Services/LogService";
+import SloHistoryService from "../Services/SloHistoryService";
 import DashboardComponentType from "../../Types/Dashboard/DashboardComponentType";
 import { DashboardVariableType } from "../../Types/Dashboard/DashboardVariable";
 import PublicDashboardResourceListPolicy, {
   PublicDashboardResourceListPolicyResult,
 } from "../Utils/Dashboard/PublicDashboardResourceListPolicy";
+import PublicDashboardSloHistoryPolicy, {
+  PublicDashboardSloHistoryPolicyResult,
+} from "../Utils/Dashboard/PublicDashboardSloHistoryPolicy";
+import AggregationType from "../../Types/BaseDatabase/AggregationType";
+import InBetween from "../../Types/BaseDatabase/InBetween";
 import { applyIncidentSelfPrivacyFilter } from "../Utils/Incident/IncidentPrivacyFilter";
 import { applyAlertSelfPrivacyFilter } from "../Utils/Alert/AlertPrivacyFilter";
 
@@ -96,6 +105,19 @@ interface PublicDashboardResourceConfig {
   };
   widgets: Partial<Record<DashboardComponentType, string | null>>;
 }
+
+/*
+ * Named rather than inlined below: the SLO history route selects its widget
+ * through the same registry entry as the resource-list route, so both must
+ * agree on which stored widgets count as "an SLO widget on this dashboard".
+ */
+const PUBLIC_DASHBOARD_SLO_RESOURCE: PublicDashboardResourceConfig = {
+  modelType: ServiceLevelObjective,
+  service: ServiceLevelObjectiveService,
+  widgets: {
+    [DashboardComponentType.Slo]: null,
+  },
+};
 
 const PUBLIC_DASHBOARD_RESOURCES: Record<
   string,
@@ -258,6 +280,7 @@ const PUBLIC_DASHBOARD_RESOURCES: Record<
       [DashboardComponentType.LogStream]: null,
     },
   },
+  slo: PUBLIC_DASHBOARD_SLO_RESOURCE,
 };
 
 type ResolveDashboardIdOrThrowFunction = (
@@ -1248,6 +1271,137 @@ export default class DashboardAPI extends BaseAPI<
       },
     );
 
+    /*
+     * Public SLO history aggregation for the SLO widget's Chart display.
+     *
+     * The SLO's CURRENT numbers come back through /resource-list/.../slo
+     * like every other widget's data; this route serves the time SERIES
+     * behind them, which lives in ClickHouse and so needs an aggregation
+     * rather than a list.
+     *
+     * Nothing the caller sends selects data. The SLO and the series are
+     * read out of the stored widget (identified by componentId), the
+     * aggregation columns are fixed, the bucket size is recomputed from the
+     * window, and the project is pinned to the dashboard's — so the only
+     * caller-supplied input that survives is the time window itself.
+     * Authorization reuses DashboardService.hasReadAccess.
+     */
+    this.router.post(
+      `${new this.entityType()
+        .getCrudApiPath()
+        ?.toString()}/slo-history-aggregate/:dashboardId`,
+      UserMiddleware.getUserMiddleware,
+      async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+        try {
+          const dashboardId: ObjectID = new ObjectID(
+            req.params["dashboardId"] as string,
+          );
+
+          const accessResult: {
+            hasReadAccess: boolean;
+            error?: NotAuthenticatedException | ForbiddenException;
+          } = await DashboardService.hasReadAccess({
+            dashboardId,
+            req,
+          });
+
+          if (!accessResult.hasReadAccess) {
+            throw (
+              accessResult.error ||
+              new BadDataException("Access denied to this dashboard.")
+            );
+          }
+
+          if (!req.body || !req.body["aggregateBy"]) {
+            throw new BadDataException("aggregateBy is required.");
+          }
+
+          const dashboard: Dashboard | null =
+            await DashboardService.findOneById({
+              id: dashboardId,
+              select: {
+                _id: true,
+                projectId: true,
+                dashboardViewConfig: true,
+              },
+              props: {
+                isRoot: true,
+              },
+            });
+
+          if (!dashboard || !dashboard.projectId) {
+            throw new NotFoundException("Dashboard not found");
+          }
+
+          const widget: JSONObject = DashboardAPI.selectPublicResourceWidget({
+            dashboardViewConfig: dashboard.dashboardViewConfig,
+            config: PUBLIC_DASHBOARD_SLO_RESOURCE,
+            requestedComponentId: req.body["componentId"],
+          });
+
+          const policy: PublicDashboardSloHistoryPolicyResult =
+            PublicDashboardSloHistoryPolicy.build({
+              widget,
+              requestedAggregateBy: JSONFunctions.deserialize(
+                req.body["aggregateBy"] as JSONObject,
+              ),
+            });
+
+          const aggregateResult: AggregatedResult =
+            await SloHistoryService.aggregateBy({
+              /*
+               * Narrow the assertion to `query` alone. Everything else in
+               * this literal is typed against SloHistory — the column names
+               * below are `keyof SloHistory` — so asserting the whole object
+               * would turn off exactly the check that catches a typo or a
+               * renamed column at compile time instead of at runtime.
+               */
+              query: {
+                projectId: dashboard.projectId,
+                sloId: policy.serviceLevelObjectiveId,
+                metricName: policy.metricName,
+                bucketStart: new InBetween<Date>(
+                  policy.startDate,
+                  policy.endDate,
+                ),
+              } as unknown as AggregateBy<SloHistory>["query"],
+              /*
+               * All three SLO series are instantaneous gauges, so averaging
+               * the raw buckets that fall inside one chart point is the only
+               * roll-up that means anything — same as the authenticated
+               * widget and the SLO detail page.
+               */
+              aggregationType: AggregationType.Avg,
+              aggregateColumnName: "value",
+              aggregationTimestampColumnName: "bucketStart",
+              aggregationInterval: policy.aggregationInterval,
+              startTimestamp: policy.startDate,
+              endTimestamp: policy.endDate,
+              // Oldest -> newest so the line renders left to right.
+              sort: {
+                bucketStart: SortOrder.Ascending,
+              },
+              limit: policy.limit,
+              skip: 0,
+              /*
+               * Run as root: authorization is already enforced by
+               * hasReadAccess above and the project scope is pinned in the
+               * query.
+               */
+              props: {
+                isRoot: true,
+              },
+            });
+
+          return Response.sendJsonObjectResponse(req, res, {
+            ...(aggregateResult as unknown as JSONObject),
+          });
+        } catch (err) {
+          next(err);
+        }
+      },
+    );
+
     this.router.post(
       `${new this.entityType()
         .getCrudApiPath()
@@ -1379,7 +1533,21 @@ export default class DashboardAPI extends BaseAPI<
           typeof componentObject["componentType"] === "string"
             ? componentObject["componentType"]
             : "",
-        title: getStringArgument("chartTitle") || getStringArgument("title"),
+        /*
+         * Widgets do not agree on where the author's heading lives — each
+         * one's settings form names its own argument (`chartTitle`,
+         * `gaugeTitle`, `tableTitle`, the SLO widget's `widgetTitle`, plain
+         * `title` elsewhere). Read every key that is actually a heading
+         * today, so a summary is not blank for a widget that plainly has a
+         * title on the page. A widget type added later with yet another key
+         * needs adding here too.
+         */
+        title:
+          getStringArgument("chartTitle") ||
+          getStringArgument("gaugeTitle") ||
+          getStringArgument("tableTitle") ||
+          getStringArgument("widgetTitle") ||
+          getStringArgument("title"),
         description: getStringArgument("chartDescription"),
         text: getStringArgument("text"),
         metricNames: Array.from(

--- a/Common/Server/Utils/Dashboard/PublicDashboardResourceListPolicy.ts
+++ b/Common/Server/Utils/Dashboard/PublicDashboardResourceListPolicy.ts
@@ -10,6 +10,9 @@ import DashboardVariable, {
 import BadDataException from "../../../Types/Exception/BadDataException";
 import { JSONObject, JSONValue } from "../../../Types/JSON";
 import JSONFunctions from "../../../Types/JSONFunctions";
+import PublicDashboardSloWidget, {
+  PublicDashboardSloWidgetConfig,
+} from "./PublicDashboardSloWidget";
 import {
   LogFilter,
   queryStringToFilter,
@@ -473,6 +476,24 @@ export default class PublicDashboardResourceListPolicy {
           severityText: true,
           body: true,
         };
+      /*
+       * Exactly the seven display fields the SLO widget renders. Everything
+       * else the model carries — description, slug, the bound monitors and
+       * labels, the metric query config, the evaluation schedule, createdBy —
+       * stays private: an SLO's headline numbers are publishable, its
+       * definition is not.
+       */
+      case DashboardComponentType.Slo:
+        return {
+          _id: true,
+          name: true,
+          targetPercentage: true,
+          currentSliPercentage: true,
+          errorBudgetRemainingPercentage: true,
+          errorBudgetRemainingSeconds: true,
+          currentBurnRate: true,
+          sloStatus: true,
+        };
       default:
         throw new BadDataException(
           "This dashboard widget cannot list public resources.",
@@ -676,6 +697,10 @@ export default class PublicDashboardResourceListPolicy {
           argumentsObject,
           requestedQuery,
         });
+      case DashboardComponentType.Slo:
+        return PublicDashboardResourceListPolicy.buildSloPolicy(
+          argumentsObject,
+        );
       default:
         throw new BadDataException(
           `Unsupported public dashboard resource widget: ${componentType}`,
@@ -1391,6 +1416,28 @@ export default class PublicDashboardResourceListPolicy {
         fallbackLimit: DEFAULT_TELEMETRY_LIMIT,
       }),
       interpolateAttributeMap: true,
+    };
+  }
+
+  /*
+   * The SLO widget renders exactly one SLO — the one its author picked — so
+   * the stored id IS the whole query. Pinning `_id` to it and capping the
+   * read at a single row means the route can return that SLO's headline
+   * numbers and nothing else: it can neither be walked across the project's
+   * other SLOs nor turned into a filter oracle, because it accepts no filter
+   * at all.
+   */
+  private static buildSloPolicy(
+    argumentsObject: Record<string, unknown>,
+  ): PolicyDraft {
+    const config: PublicDashboardSloWidgetConfig =
+      PublicDashboardSloWidget.readConfigFromArguments(argumentsObject);
+
+    return {
+      resourceType: "slo",
+      query: { _id: config.serviceLevelObjectiveId },
+      sort: { name: SortOrder.Ascending },
+      limit: 1,
     };
   }
 

--- a/Common/Server/Utils/Dashboard/PublicDashboardSloHistoryPolicy.ts
+++ b/Common/Server/Utils/Dashboard/PublicDashboardSloHistoryPolicy.ts
@@ -1,0 +1,163 @@
+import AggregationInterval from "../../../Types/BaseDatabase/AggregationInterval";
+import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import OneUptimeDate from "../../../Types/Date";
+import { SloWidgetDisplayType } from "../../../Types/Dashboard/DashboardComponents/DashboardSloComponent";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import {
+  getSloChartAggregationInterval,
+  getSloHistoryMetricName,
+} from "../../../Utils/Slo/SloWidgetFormat";
+import PublicDashboardSloWidget, {
+  PublicDashboardSloWidgetConfig,
+} from "./PublicDashboardSloWidget";
+
+/*
+ * Server-owned policy for the unauthenticated SLO history aggregation.
+ *
+ * Same contract as PublicDashboardResourceListPolicy: nothing the caller
+ * sends becomes part of the query except the time window. WHICH SLO and
+ * WHICH of its three series are read come from the stored widget alone, the
+ * aggregation columns are fixed, and the bucket size is recomputed from the
+ * window with the very same helper the widget uses — so a public viewer's
+ * only lever is "which slice of the series the dashboard already publishes
+ * do I want to see".
+ */
+export interface PublicDashboardSloHistoryPolicyResult {
+  serviceLevelObjectiveId: ObjectID;
+  /** SloHistory.metricName for the widget's chosen series. */
+  metricName: string;
+  startDate: Date;
+  endDate: Date;
+  aggregationInterval: AggregationInterval;
+  limit: number;
+}
+
+export interface BuildPublicDashboardSloHistoryPolicyData {
+  widget: unknown;
+  /** The caller's `aggregateBy`, already JSONFunctions.deserialize'd. */
+  requestedAggregateBy: unknown;
+}
+
+/*
+ * The furthest back a window is allowed to reach. 400 days is SloHistory's
+ * own TTL (see the ttlExpression on the model), so anything older can only
+ * return empty buckets anyway — bounding it here is what stops a hand-rolled
+ * request from asking ClickHouse to grid out centuries.
+ *
+ * A longer window is CLAMPED, not refused. The range picker on a public
+ * dashboard offers an unbounded custom range, and the sibling widgets — the
+ * metric charts on the very same page — just render whatever that range
+ * holds. Throwing here would make one widget show a server error string
+ * while its neighbours drew fine, purely because the viewer is anonymous.
+ */
+const MAX_WINDOW_IN_DAYS: number = 400;
+const MAX_WINDOW_IN_MINUTES: number = MAX_WINDOW_IN_DAYS * 24 * 60;
+
+export default class PublicDashboardSloHistoryPolicy {
+  public static build(
+    data: BuildPublicDashboardSloHistoryPolicyData,
+  ): PublicDashboardSloHistoryPolicyResult {
+    const config: PublicDashboardSloWidgetConfig =
+      PublicDashboardSloWidget.readConfig(data.widget);
+
+    /*
+     * Only a Chart widget publishes the SERIES. A Tile widget publishes the
+     * SLO's current numbers and nothing more, so serving 400 days of history
+     * for one would hand out history its author never put on the page.
+     */
+    if (config.displayType !== SloWidgetDisplayType.Chart) {
+      throw new BadDataException(
+        "This dashboard widget does not chart SLO history.",
+      );
+    }
+
+    const requestedAggregateBy: Record<string, unknown> =
+      PublicDashboardSloHistoryPolicy.requireObject(
+        data.requestedAggregateBy,
+        "aggregateBy",
+      );
+
+    const startDate: Date = PublicDashboardSloHistoryPolicy.validDate(
+      requestedAggregateBy["startTimestamp"],
+      "startTimestamp",
+    );
+    const endDate: Date = PublicDashboardSloHistoryPolicy.validDate(
+      requestedAggregateBy["endTimestamp"],
+      "endTimestamp",
+    );
+
+    /*
+     * An inverted or zero-length window is not a range the picker can
+     * produce — it only ever comes from a hand-rolled request, and there is
+     * no sensible slice of history to answer it with.
+     */
+    if (startDate.getTime() >= endDate.getTime()) {
+      throw new BadDataException(
+        "Public dashboard SLO history range is invalid.",
+      );
+    }
+
+    const clampedStartDate: Date =
+      OneUptimeDate.getMinutesBetweenTwoDates(startDate, endDate) >
+      MAX_WINDOW_IN_MINUTES
+        ? new Date(endDate.getTime() - MAX_WINDOW_IN_MINUTES * 60 * 1000)
+        : startDate;
+
+    const rangeInMinutes: number = OneUptimeDate.getMinutesBetweenTwoDates(
+      clampedStartDate,
+      endDate,
+    );
+
+    return {
+      serviceLevelObjectiveId: config.serviceLevelObjectiveId,
+      metricName: getSloHistoryMetricName(config.sloMetric),
+      startDate: clampedStartDate,
+      endDate,
+      /*
+       * Recomputed, never copied. The widget derives its bucket size from
+       * the same window with the same helper, so the client still gets the
+       * grid it drew its x-axis for — without being able to choose one.
+       */
+      aggregationInterval: getSloChartAggregationInterval(rangeInMinutes),
+      limit: LIMIT_PER_PROJECT,
+    };
+  }
+
+  private static validDate(value: unknown, key: string): Date {
+    if (value instanceof Date && Number.isFinite(value.getTime())) {
+      return new Date(value.getTime());
+    }
+
+    if (typeof value === "string" && value.length <= 128) {
+      const date: Date = new Date(value);
+
+      if (Number.isFinite(date.getTime())) {
+        return date;
+      }
+    }
+
+    throw new BadDataException(
+      `Public dashboard SLO history ${key} is not a valid date.`,
+    );
+  }
+
+  /*
+   * Returns an OWN-properties copy. JSON.parse turns a literal "__proto__"
+   * member into a real own key and JSONFunctions.deserialize copies it with
+   * `newVal[key] = …`, which fires Object.prototype's __proto__ setter — so a
+   * plain `object["startTimestamp"]` lookup would walk the prototype chain
+   * and read something the caller never sent as an own key. Copying first
+   * means every field this policy reads is a field that was really there.
+   */
+  private static requireObject(
+    value: unknown,
+    label: string,
+  ): Record<string, unknown> {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new BadDataException(`${label} must be an object.`);
+    }
+
+    return { ...(value as Record<string, unknown>) };
+  }
+}

--- a/Common/Server/Utils/Dashboard/PublicDashboardSloWidget.ts
+++ b/Common/Server/Utils/Dashboard/PublicDashboardSloWidget.ts
@@ -1,0 +1,147 @@
+import {
+  SloWidgetDisplayType,
+  SloWidgetMetric,
+} from "../../../Types/Dashboard/DashboardComponents/DashboardSloComponent";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * The stored configuration of ONE SLO widget, read back from the dashboard's
+ * JSON column.
+ *
+ * Two unauthenticated routes are driven by this config — the resource-list
+ * read that returns the SLO's current numbers, and the SloHistory aggregation
+ * that returns its series — so both must agree on exactly which SLO and which
+ * series the widget's author published. Parsing it once here is what keeps
+ * them from drifting apart.
+ *
+ * Everything here comes out of a JSONB column that an older (or hand-edited)
+ * client may have written, so nothing is trusted to be well typed.
+ */
+export interface PublicDashboardSloWidgetConfig {
+  serviceLevelObjectiveId: ObjectID;
+  sloMetric: SloWidgetMetric;
+  displayType: SloWidgetDisplayType;
+}
+
+export default class PublicDashboardSloWidget {
+  /** Read the config off a whole stored widget (`{ arguments: { … } }`). */
+  public static readConfig(widget: unknown): PublicDashboardSloWidgetConfig {
+    return PublicDashboardSloWidget.readConfigFromArguments(
+      PublicDashboardSloWidget.readArguments(widget),
+    );
+  }
+
+  /** Read the config off a widget's already-extracted `arguments` object. */
+  public static readConfigFromArguments(
+    argumentsObject: Record<string, unknown>,
+  ): PublicDashboardSloWidgetConfig {
+    return {
+      serviceLevelObjectiveId:
+        PublicDashboardSloWidget.readServiceLevelObjectiveId(argumentsObject),
+      sloMetric: PublicDashboardSloWidget.readSloMetric(argumentsObject),
+      displayType: PublicDashboardSloWidget.readDisplayType(argumentsObject),
+    };
+  }
+
+  private static readArguments(widget: unknown): Record<string, unknown> {
+    if (!widget || typeof widget !== "object" || Array.isArray(widget)) {
+      throw new BadDataException("Dashboard widget must be an object.");
+    }
+
+    const argumentsObject: unknown = (widget as Record<string, unknown>)[
+      "arguments"
+    ];
+
+    if (
+      !argumentsObject ||
+      typeof argumentsObject !== "object" ||
+      Array.isArray(argumentsObject)
+    ) {
+      throw new BadDataException(
+        "Dashboard widget arguments must be an object.",
+      );
+    }
+
+    return argumentsObject as Record<string, unknown>;
+  }
+
+  /*
+   * The SLO the widget's author picked IS the authorization decision: the id
+   * comes only from stored config, never from the request, so this endpoint
+   * can never be pointed at another SLO in the project.
+   */
+  private static readServiceLevelObjectiveId(
+    argumentsObject: Record<string, unknown>,
+  ): ObjectID {
+    const serviceLevelObjectiveId: unknown =
+      argumentsObject["serviceLevelObjectiveId"];
+
+    if (
+      typeof serviceLevelObjectiveId !== "string" ||
+      serviceLevelObjectiveId.trim().length === 0
+    ) {
+      throw new BadDataException(
+        "This dashboard widget has no Service Level Objective selected.",
+      );
+    }
+
+    const trimmed: string = serviceLevelObjectiveId.trim();
+
+    ObjectID.validateUUID(trimmed);
+
+    return new ObjectID(trimmed);
+  }
+
+  /*
+   * Sli is the widget's own default, and these arguments come out of a JSONB
+   * column that a dashboard created through the CRUD API — or hand-edited —
+   * may simply have written without them, so an absent value is not an error.
+   * An unrecognised value IS, rather than silently falling back: a stored
+   * string that is not one of the three series should never be able to
+   * quietly become "SLI" on a public page.
+   */
+  private static readSloMetric(
+    argumentsObject: Record<string, unknown>,
+  ): SloWidgetMetric {
+    const sloMetric: unknown = argumentsObject["sloMetric"];
+
+    if (sloMetric === undefined || sloMetric === null || sloMetric === "") {
+      return SloWidgetMetric.Sli;
+    }
+
+    if (
+      typeof sloMetric !== "string" ||
+      !(Object.values(SloWidgetMetric) as Array<string>).includes(sloMetric)
+    ) {
+      throw new BadDataException("Dashboard widget sloMetric is invalid.");
+    }
+
+    return sloMetric as SloWidgetMetric;
+  }
+
+  private static readDisplayType(
+    argumentsObject: Record<string, unknown>,
+  ): SloWidgetDisplayType {
+    const displayType: unknown = argumentsObject["displayType"];
+
+    if (
+      displayType === undefined ||
+      displayType === null ||
+      displayType === ""
+    ) {
+      return SloWidgetDisplayType.Tile;
+    }
+
+    if (
+      typeof displayType !== "string" ||
+      !(Object.values(SloWidgetDisplayType) as Array<string>).includes(
+        displayType,
+      )
+    ) {
+      throw new BadDataException("Dashboard widget displayType is invalid.");
+    }
+
+    return displayType as SloWidgetDisplayType;
+  }
+}

--- a/Common/Tests/App/Dashboard/SloWidgetFetching.test.tsx
+++ b/Common/Tests/App/Dashboard/SloWidgetFetching.test.tsx
@@ -1,0 +1,531 @@
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { RenderResult, cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * The SLO widget is the first widget to read a SINGLE model row on a public
+ * dashboard, and it reads two different things through two different public
+ * endpoints. Both halves of that are asserted here against the REQUESTS the
+ * widget issues, because the request is where the security boundary lives:
+ *
+ *  - an anonymous viewer must get the widget's data (it used to be refused
+ *    outright with "SLO widgets are not available on public dashboards"), and
+ *  - it must arrive through the dashboard-scoped endpoints, which resolve the
+ *    SLO from the stored widget — never through the private CRUD routes,
+ *    whose 401 sends the viewer to /accounts/login.
+ *
+ * The authenticated path is asserted alongside it so the two cannot drift.
+ */
+
+const getItemMock: MockFunction = getJestMockFunction();
+const getListMock: MockFunction = getJestMockFunction();
+const aggregateMock: MockFunction = getJestMockFunction();
+const getCurrentProjectIdMock: MockFunction = getJestMockFunction();
+const lineChartRenderMock: MockFunction = getJestMockFunction();
+
+/*
+ * The arrow wrappers are load bearing: jest.mock is hoisted above the compiled
+ * requires, so the mock variables above are still unassigned when the factory
+ * runs. Dereferencing them lazily, at call time, is what makes this work.
+ */
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getItem: (...args: Array<any>) => {
+        return getItemMock(...args);
+      },
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      aggregate: (...args: Array<any>) => {
+        return aggregateMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: (...args: Array<any>) => {
+        return getCurrentProjectIdMock(...args);
+      },
+    },
+  };
+});
+
+/*
+ * recharts measures a 0x0 parent in jsdom and renders nothing, so the real
+ * chart would test neither the series nor the axes. What matters here is what
+ * the widget hands down.
+ */
+jest.mock("../../../UI/Components/Charts/Line/LineChart", () => {
+  return {
+    __esModule: true,
+    default: (props: LineChartStubProps): React.ReactElement => {
+      lineChartRenderMock(props);
+      return React.createElement(
+        "div",
+        { "data-testid": "line-chart" },
+        `points:${props.data[0]?.data.length ?? 0}`,
+      );
+    },
+  };
+});
+
+import DashboardSloComponentElement from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardSloComponent";
+import { DashboardBaseComponentProps } from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent";
+import {
+  PublicDashboardContext,
+  setPublicDashboardContext,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/PublicDashboardContext";
+import ServiceLevelObjective from "../../../Models/DatabaseModels/ServiceLevelObjective";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import AggregatedResult from "../../../Types/BaseDatabase/AggregatedResult";
+import AggregationInterval from "../../../Types/BaseDatabase/AggregationInterval";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import DashboardSloComponent, {
+  SloWidgetDisplayType,
+  SloWidgetMetric,
+} from "../../../Types/Dashboard/DashboardComponents/DashboardSloComponent";
+import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
+import { JSONObject, ObjectType } from "../../../Types/JSON";
+import JSONFunctions from "../../../Types/JSONFunctions";
+import ObjectID from "../../../Types/ObjectID";
+import SloStatus from "../../../Types/ServiceLevelObjective/SloStatus";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+
+interface LineChartStubProps {
+  data: Array<{ seriesName: string; data: Array<{ x: Date; y: number }> }>;
+}
+
+const COMPONENT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const DASHBOARD_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const SLO_ID: ObjectID = new ObjectID("33333333-3333-4333-8333-333333333333");
+const PROJECT_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+
+/*
+ * A CUSTOM range pins the window to fixed instants; a relative range would
+ * resolve against the wall clock and make the window assertions untestable.
+ * Six hours buckets at five minutes, which is what the assertions expect.
+ */
+const START_DATE: Date = new Date("2026-08-10T00:00:00.000Z");
+const END_DATE: Date = new Date("2026-08-10T06:00:00.000Z");
+
+const DASHBOARD_RANGE: RangeStartAndEndDateTime = {
+  range: TimeRange.CUSTOM,
+  startAndEndDate: new InBetween<Date>(START_DATE, END_DATE),
+};
+
+const DASHBOARD_VIEW_CONFIG: DashboardViewConfig = {
+  _type: ObjectType.DashboardViewConfig,
+  components: [],
+  heightInDashboardUnits: 60,
+};
+
+/** Every postJSON call the public dashboard client received. */
+interface PublicRequest {
+  route: string;
+  body: JSONObject;
+}
+
+let publicRequests: Array<PublicRequest> = [];
+let publicResponse: JSONObject = { data: [] };
+
+const PUBLIC_DASHBOARD_CONTEXT: PublicDashboardContext = {
+  dashboardId: DASHBOARD_ID,
+  apiUrl: {
+    toString: (): string => {
+      return "http://localhost/public-dashboard-api";
+    },
+  },
+  postJSON: (route: string, body: JSONObject) => {
+    publicRequests.push({ route, body });
+    return Promise.resolve({
+      data: publicResponse,
+    } as unknown as HTTPResponse<JSONObject>);
+  },
+} as unknown as PublicDashboardContext;
+
+type BuildSloFunction = (
+  overrides?: Partial<ServiceLevelObjective>,
+) => ServiceLevelObjective;
+
+const buildSlo: BuildSloFunction = (
+  overrides: Partial<ServiceLevelObjective> = {},
+): ServiceLevelObjective => {
+  const slo: ServiceLevelObjective = new ServiceLevelObjective();
+  slo.name = "Checkout availability";
+  slo.targetPercentage = 99.9;
+  slo.currentSliPercentage = 99.95;
+  slo.errorBudgetRemainingPercentage = 42.5;
+  slo.errorBudgetRemainingSeconds = 3600;
+  slo.currentBurnRate = 1.25;
+  slo.sloStatus = SloStatus.Healthy;
+  return Object.assign(slo, overrides);
+};
+
+type BuildPropsFunction = (
+  overrides?: Partial<DashboardBaseComponentProps>,
+) => DashboardBaseComponentProps;
+
+const buildBaseProps: BuildPropsFunction = (
+  overrides: Partial<DashboardBaseComponentProps> = {},
+): DashboardBaseComponentProps => {
+  return {
+    componentId: COMPONENT_ID,
+    isEditMode: false,
+    isSelected: false,
+    key: "slo-widget",
+    onComponentUpdate: (): void => {
+      // The widget never writes back through this.
+    },
+    totalCurrentDashboardWidthInPx: 1200,
+    dashboardCanvasTopInPx: 0,
+    dashboardCanvasLeftInPx: 0,
+    dashboardCanvasWidthInPx: 1200,
+    dashboardCanvasHeightInPx: 800,
+    dashboardComponentHeightInPx: 320,
+    dashboardComponentWidthInPx: 480,
+    dashboardViewConfig: DASHBOARD_VIEW_CONFIG,
+    dashboardStartAndEndDate: DASHBOARD_RANGE,
+    metricTypes: [],
+    refreshTick: 0,
+    variables: undefined,
+    ...overrides,
+  };
+};
+
+type RenderWidgetFunction = (
+  args: DashboardSloComponent["arguments"],
+) => RenderResult;
+
+const renderWidget: RenderWidgetFunction = (
+  args: DashboardSloComponent["arguments"],
+): RenderResult => {
+  const component: DashboardSloComponent = {
+    _type: ObjectType.DashboardComponent,
+    componentId: COMPONENT_ID,
+    componentType: DashboardComponentType.Slo,
+    topInDashboardUnits: 0,
+    leftInDashboardUnits: 0,
+    widthInDashboardUnits: 3,
+    heightInDashboardUnits: 3,
+    minWidthInDashboardUnits: 2,
+    minHeightInDashboardUnits: 2,
+    arguments: args,
+  } as unknown as DashboardSloComponent;
+
+  return render(
+    <DashboardSloComponentElement
+      {...buildBaseProps()}
+      component={component}
+    />,
+  );
+};
+
+beforeEach((): void => {
+  jest.clearAllMocks();
+  publicRequests = [];
+  publicResponse = { data: [] };
+  getCurrentProjectIdMock.mockReturnValue(PROJECT_ID);
+  getItemMock.mockResolvedValue(buildSlo());
+  getListMock.mockResolvedValue({
+    data: [buildSlo()],
+    count: 1,
+    skip: 0,
+    limit: 1,
+  });
+  aggregateMock.mockResolvedValue({ data: [] } as AggregatedResult);
+});
+
+afterEach((): void => {
+  cleanup();
+  setPublicDashboardContext(null);
+});
+
+describe("SLO widget on a public dashboard", () => {
+  beforeEach((): void => {
+    setPublicDashboardContext(PUBLIC_DASHBOARD_CONTEXT);
+    /*
+     * A public dashboard has no session and therefore no current project.
+     * This is the exact condition the widget used to refuse on.
+     */
+    getCurrentProjectIdMock.mockReturnValue(null);
+  });
+
+  test("renders the SLO instead of refusing anonymous viewers", async () => {
+    renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      sloMetric: SloWidgetMetric.Sli,
+      displayType: SloWidgetDisplayType.Tile,
+    });
+
+    expect(await screen.findByText("99.95%")).toBeInTheDocument();
+    expect(screen.getByText("target 99.9%")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/not available on public dashboards/i),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/no project selected/i)).not.toBeInTheDocument();
+  });
+
+  test("reads the SLO through the dashboard-scoped resource endpoint", async () => {
+    renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      displayType: SloWidgetDisplayType.Tile,
+    });
+
+    await screen.findByText("99.95%");
+
+    // The private single-item CRUD route would 401 and bounce to login.
+    expect(getItemMock).not.toHaveBeenCalled();
+    expect(getListMock).toHaveBeenCalledTimes(1);
+
+    const listArgs: JSONObject = getListMock.mock.calls[0]![0] as JSONObject;
+    const requestOptions: JSONObject = listArgs["requestOptions"] as JSONObject;
+
+    expect(
+      (
+        requestOptions["overrideRequestUrl"] as { toString: () => string }
+      ).toString(),
+    ).toBe(
+      `http://localhost/public-dashboard-api/resource-list/${DASHBOARD_ID.toString()}/slo`,
+    );
+    /*
+     * componentId is what lets the server resolve WHICH stored widget — and
+     * therefore which SLO — this request is allowed to read.
+     */
+    expect(
+      (requestOptions["additionalRequestBody"] as JSONObject)["componentId"],
+    ).toBe(COMPONENT_ID.toString());
+    expect(listArgs["limit"]).toBe(1);
+  });
+
+  test("reads chart history through the public SLO history endpoint", async () => {
+    publicResponse = {
+      data: [
+        { timestamp: "2026-08-10T00:00:00.000Z", value: "99.9" },
+        { timestamp: "2026-08-10T00:05:00.000Z", value: 99.8 },
+      ],
+    };
+
+    renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      sloMetric: SloWidgetMetric.BurnRate,
+      displayType: SloWidgetDisplayType.Chart,
+    });
+
+    expect(await screen.findByTestId("line-chart")).toHaveTextContent(
+      "points:2",
+    );
+
+    // The private analytics /aggregate route would 401 and bounce to login.
+    expect(aggregateMock).not.toHaveBeenCalled();
+    expect(publicRequests.length).toBe(1);
+
+    const request: PublicRequest = publicRequests[0]!;
+    expect(request.route).toBe(
+      `/slo-history-aggregate/${DASHBOARD_ID.toString()}`,
+    );
+    expect(request.body["componentId"]).toBe(COMPONENT_ID.toString());
+
+    /*
+     * The window is the ONE thing the public endpoint reads out of
+     * aggregateBy — it rebuilds everything else from the stored widget — and
+     * it hard-fails without it. So it has to survive the wire serializer,
+     * which is what the server deserializes on the other side.
+     */
+    const aggregateBy: JSONObject = JSONFunctions.deserialize(
+      request.body["aggregateBy"] as JSONObject,
+    ) as JSONObject;
+
+    expect(
+      new Date(aggregateBy["startTimestamp"] as string).toISOString(),
+    ).toBe(START_DATE.toISOString());
+    expect(new Date(aggregateBy["endTimestamp"] as string).toISOString()).toBe(
+      END_DATE.toISOString(),
+    );
+
+    /*
+     * The rest is sent but discarded server-side. Asserted anyway so the two
+     * paths keep sending the same shape — the authenticated route DOES read
+     * these.
+     */
+    expect(aggregateBy["aggregateColumnName"]).toBe("value");
+    expect(aggregateBy["aggregationTimestampColumnName"]).toBe("bucketStart");
+    expect(aggregateBy["aggregationType"]).toBe(AggregationType.Avg);
+    expect(aggregateBy["aggregationInterval"]).toBe(
+      AggregationInterval.FiveMinutes,
+    );
+  });
+
+  test("coerces decimal strings and drops unusable history rows", async () => {
+    publicResponse = {
+      data: [
+        { timestamp: "2026-08-10T00:00:00.000Z", value: "99.9" },
+        { timestamp: null, value: 50 },
+        { timestamp: "2026-08-10T00:10:00.000Z", value: "not-a-number" },
+        { timestamp: "2026-08-10T00:15:00.000Z", value: 98.5 },
+      ],
+    };
+
+    renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      displayType: SloWidgetDisplayType.Chart,
+    });
+
+    expect(await screen.findByTestId("line-chart")).toHaveTextContent(
+      "points:2",
+    );
+  });
+
+  test("shows the empty-history state rather than an error when nothing is stored", async () => {
+    renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      displayType: SloWidgetDisplayType.Chart,
+    });
+
+    expect(
+      await screen.findByText(/No history for the selected/i),
+    ).toBeInTheDocument();
+  });
+
+  test("does not fetch anything for an unconfigured widget", async () => {
+    renderWidget({ displayType: SloWidgetDisplayType.Tile });
+
+    expect(
+      await screen.findByText("Click to select an SLO"),
+    ).toBeInTheDocument();
+    expect(getListMock).not.toHaveBeenCalled();
+    expect(publicRequests.length).toBe(0);
+  });
+
+  test("says the SLO is gone when the endpoint returns no row", async () => {
+    getListMock.mockResolvedValue({ data: [], count: 0, skip: 0, limit: 1 });
+
+    renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      displayType: SloWidgetDisplayType.Tile,
+    });
+
+    expect(
+      await screen.findByText("This SLO no longer exists."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("SLO widget on an authenticated dashboard", () => {
+  test("keeps reading the SLO through the private CRUD route", async () => {
+    renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      sloMetric: SloWidgetMetric.ErrorBudgetRemaining,
+      displayType: SloWidgetDisplayType.Tile,
+    });
+
+    expect(await screen.findByText("42.5%")).toBeInTheDocument();
+    expect(screen.getByText("60 min remaining")).toBeInTheDocument();
+
+    expect(getListMock).not.toHaveBeenCalled();
+    expect(getItemMock).toHaveBeenCalledTimes(1);
+
+    const itemArgs: JSONObject = getItemMock.mock.calls[0]![0] as JSONObject;
+    expect((itemArgs["id"] as ObjectID).toString()).toBe(SLO_ID.toString());
+    expect(itemArgs["requestOptions"]).toBeUndefined();
+    // Only the seven display fields, on the private route as on the public one.
+    expect(itemArgs["select"]).toEqual({
+      name: true,
+      targetPercentage: true,
+      currentSliPercentage: true,
+      errorBudgetRemainingPercentage: true,
+      errorBudgetRemainingSeconds: true,
+      currentBurnRate: true,
+      sloStatus: true,
+    });
+  });
+
+  test("keeps aggregating history through the private analytics route", async () => {
+    aggregateMock.mockResolvedValue({
+      data: [{ timestamp: START_DATE, value: 99.9 }],
+    } as AggregatedResult);
+
+    renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      sloMetric: SloWidgetMetric.Sli,
+      displayType: SloWidgetDisplayType.Chart,
+    });
+
+    expect(await screen.findByTestId("line-chart")).toHaveTextContent(
+      "points:1",
+    );
+    expect(publicRequests.length).toBe(0);
+    expect(aggregateMock).toHaveBeenCalledTimes(1);
+
+    const aggregateArgs: JSONObject = aggregateMock.mock
+      .calls[0]![0] as JSONObject;
+    const aggregateBy: JSONObject = aggregateArgs["aggregateBy"] as JSONObject;
+    const query: JSONObject = aggregateBy["query"] as JSONObject;
+
+    expect(query["projectId"]).toBe(PROJECT_ID);
+    expect((query["sloId"] as ObjectID).toString()).toBe(SLO_ID.toString());
+    expect(query["metricName"]).toBe("sli.percent");
+    expect(aggregateBy["sort"]).toEqual({
+      bucketStart: SortOrder.Ascending,
+    });
+
+    // Same window as the public path — the two must not drift.
+    expect((aggregateBy["startTimestamp"] as Date).toISOString()).toBe(
+      START_DATE.toISOString(),
+    );
+    expect((aggregateBy["endTimestamp"] as Date).toISOString()).toBe(
+      END_DATE.toISOString(),
+    );
+    const bucketStart: InBetween<Date> = query[
+      "bucketStart"
+    ] as unknown as InBetween<Date>;
+    expect(bucketStart).toBeInstanceOf(InBetween);
+    expect(bucketStart.startValue.toISOString()).toBe(START_DATE.toISOString());
+    expect(bucketStart.endValue.toISOString()).toBe(END_DATE.toISOString());
+  });
+
+  test("still refuses to guess a project when there is no session project", async () => {
+    getCurrentProjectIdMock.mockReturnValue(null);
+
+    renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      displayType: SloWidgetDisplayType.Tile,
+    });
+
+    expect(await screen.findByText("No project selected.")).toBeInTheDocument();
+    expect(getItemMock).not.toHaveBeenCalled();
+    expect(getListMock).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/API/DashboardPublicResourceListAPI.test.ts
+++ b/Common/Tests/Server/API/DashboardPublicResourceListAPI.test.ts
@@ -15,6 +15,7 @@ import NetworkSiteService from "../../../Server/Services/NetworkSiteService";
 import PodmanHostService from "../../../Server/Services/PodmanHostService";
 import PodmanResourceService from "../../../Server/Services/PodmanResourceService";
 import ProxmoxResourceService from "../../../Server/Services/ProxmoxResourceService";
+import ServiceLevelObjectiveService from "../../../Server/Services/ServiceLevelObjectiveService";
 import SpanService from "../../../Server/Services/SpanService";
 import PublicDashboardResourceListPolicy, {
   BuildPublicDashboardResourceListPolicyData,
@@ -103,7 +104,15 @@ interface ResourceRouteCase {
   componentType: DashboardComponentType;
   service: ListService;
   kind: string | null;
+  /** Stored widget arguments this component type cannot be built without. */
+  argumentsObject?: JSONObject | undefined;
 }
+
+/*
+ * The SLO widget names one SLO outright, so unlike every other resource it
+ * has no valid empty configuration.
+ */
+const SLO_ID: ObjectID = ObjectID.generate();
 
 const RESOURCE_ROUTE_CASES: Array<ResourceRouteCase> = [
   {
@@ -292,6 +301,13 @@ const RESOURCE_ROUTE_CASES: Array<ResourceRouteCase> = [
     service: LogService,
     kind: null,
   },
+  {
+    resourceType: "slo",
+    componentType: DashboardComponentType.Slo,
+    service: ServiceLevelObjectiveService,
+    kind: null,
+    argumentsObject: { serviceLevelObjectiveId: SLO_ID.toString() },
+  },
 ];
 
 const ALL_SERVICES: Array<ListService> = [
@@ -310,6 +326,7 @@ const ALL_SERVICES: Array<ListService> = [
   DockerSwarmResourceService,
   SpanService,
   LogService,
+  ServiceLevelObjectiveService,
 ];
 
 describe("DashboardAPI public resource-list", () => {
@@ -470,6 +487,7 @@ describe("DashboardAPI public resource-list", () => {
         jest.clearAllMocks();
         const { widget, componentId } = buildWidget({
           componentType: routeCase.componentType,
+          argumentsObject: routeCase.argumentsObject,
         });
         setDashboardWidgets([widget]);
 

--- a/Common/Tests/Server/API/DashboardPublicSloAPI.test.ts
+++ b/Common/Tests/Server/API/DashboardPublicSloAPI.test.ts
@@ -1,0 +1,880 @@
+import Dashboard from "../../../Models/DatabaseModels/Dashboard";
+import DashboardAPI from "../../../Server/API/DashboardAPI";
+import DashboardService from "../../../Server/Services/DashboardService";
+import ServiceLevelObjectiveService from "../../../Server/Services/ServiceLevelObjectiveService";
+import SloHistoryService from "../../../Server/Services/SloHistoryService";
+import PasswordHash from "../../../Server/Utils/PasswordHash";
+import PublicDashboardSloHistoryPolicy from "../../../Server/Utils/Dashboard/PublicDashboardSloHistoryPolicy";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import AggregationInterval from "../../../Types/BaseDatabase/AggregationInterval";
+import AggregationType from "../../../Types/BaseDatabase/AggregationType";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import {
+  SloWidgetDisplayType,
+  SloWidgetMetric,
+} from "../../../Types/Dashboard/DashboardComponents/DashboardSloComponent";
+import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
+import HashedString from "../../../Types/HashedString";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ForbiddenException from "../../../Types/Exception/ForbiddenException";
+import NotAuthenticatedException from "../../../Types/Exception/NotAuthenticatedException";
+import NotFoundException from "../../../Types/Exception/NotFoundException";
+import { JSONObject } from "../../../Types/JSON";
+import JSONFunctions from "../../../Types/JSONFunctions";
+import ObjectID from "../../../Types/ObjectID";
+import { mockRouter } from "./Helpers";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "@jest/globals";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEntityArrayResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendJsonObjectResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+    sendErrorResponse: jest.fn().mockImplementation((...args: []) => {
+      return args;
+    }),
+  };
+});
+
+const RESOURCE_LIST_ROUTE: string =
+  "/dashboard/resource-list/:dashboardId/:resourceType";
+const SLO_HISTORY_ROUTE: string =
+  "/dashboard/slo-history-aggregate/:dashboardId";
+
+const RANGE_START: Date = new Date("2026-08-09T00:00:00.000Z");
+const RANGE_END: Date = new Date("2026-08-09T06:00:00.000Z");
+
+/*
+ * An SLO on a public dashboard is a deliberate publication: the owner drops
+ * the widget on a shared board and, by doing so, publishes that one SLO's
+ * headline numbers and — for a Chart widget — the series behind them.
+ *
+ * These tests hold the two halves of that bargain. The widget's data really
+ * does reach an anonymous viewer, AND nothing else does: not another SLO in
+ * the project, not another series of the same SLO, not the SLO's definition,
+ * and not another tenant's project.
+ */
+describe("DashboardAPI public SLO", () => {
+  let dashboardId: ObjectID;
+  let projectId: ObjectID;
+  let serviceLevelObjectiveId: ObjectID;
+  let dashboard: Dashboard;
+  let mockResponse: ExpressResponse;
+  let nextFunction: NextFunction;
+
+  beforeAll(() => {
+    mockRouter.routes.length = 0;
+    new DashboardAPI();
+  });
+
+  interface BuiltWidget {
+    widget: JSONObject;
+    componentId: ObjectID;
+  }
+
+  type BuildSloWidgetFunction = (argumentsObject?: JSONObject) => BuiltWidget;
+
+  const buildSloWidget: BuildSloWidgetFunction = (
+    argumentsObject?: JSONObject,
+  ): BuiltWidget => {
+    const componentId: ObjectID = ObjectID.generate();
+
+    return {
+      componentId,
+      widget: {
+        _type: "DashboardComponent",
+        componentId: componentId.toString(),
+        componentType: DashboardComponentType.Slo,
+        topInDashboardUnits: 0,
+        leftInDashboardUnits: 0,
+        widthInDashboardUnits: 3,
+        heightInDashboardUnits: 3,
+        arguments: {
+          serviceLevelObjectiveId: serviceLevelObjectiveId.toString(),
+          ...(argumentsObject || {}),
+        },
+      },
+    };
+  };
+
+  type BuildChartWidgetFunction = (argumentsObject?: JSONObject) => BuiltWidget;
+
+  const buildSloChartWidget: BuildChartWidgetFunction = (
+    argumentsObject?: JSONObject,
+  ): BuiltWidget => {
+    return buildSloWidget({
+      displayType: SloWidgetDisplayType.Chart,
+      ...(argumentsObject || {}),
+    });
+  };
+
+  type SetWidgetsFunction = (widgets: Array<JSONObject>) => void;
+
+  const setWidgets: SetWidgetsFunction = (widgets: Array<JSONObject>): void => {
+    dashboard.dashboardViewConfig = {
+      _type: "DashboardViewConfig",
+      heightInDashboardUnits: 24,
+      components: widgets,
+      variables: [],
+    } as unknown as DashboardViewConfig;
+  };
+
+  type CallResourceListFunction = (body?: JSONObject) => Promise<void>;
+
+  const callResourceList: CallResourceListFunction = async (
+    body?: JSONObject,
+  ): Promise<void> => {
+    const request: ExpressRequest = {
+      params: {
+        dashboardId: dashboardId.toString(),
+        resourceType: "slo",
+      },
+      body: body || {},
+      query: {},
+      cookies: {},
+      headers: {},
+      socket: {},
+      ips: [],
+    } as unknown as ExpressRequest;
+
+    await mockRouter
+      .match("post", RESOURCE_LIST_ROUTE)
+      .handlerFunction(request, mockResponse, nextFunction);
+  };
+
+  /*
+   * The window a widget really sends, alongside the fields it also sends that
+   * the server must throw away.
+   */
+  type BuildAggregateByFunction = (overrides?: JSONObject) => JSONObject;
+
+  const buildAggregateBy: BuildAggregateByFunction = (
+    overrides?: JSONObject,
+  ): JSONObject => {
+    return {
+      query: {
+        projectId: projectId,
+        sloId: serviceLevelObjectiveId,
+        metricName: "sli.percent",
+        bucketStart: new InBetween<Date>(RANGE_START, RANGE_END),
+      },
+      aggregationType: AggregationType.Avg,
+      aggregateColumnName: "value",
+      aggregationTimestampColumnName: "bucketStart",
+      aggregationInterval: AggregationInterval.FiveMinutes,
+      startTimestamp: RANGE_START,
+      endTimestamp: RANGE_END,
+      sort: { bucketStart: SortOrder.Ascending },
+      limit: LIMIT_PER_PROJECT,
+      skip: 0,
+      ...(overrides || {}),
+    } as unknown as JSONObject;
+  };
+
+  type CallSloHistoryFunction = (body?: JSONObject) => Promise<void>;
+
+  const callSloHistory: CallSloHistoryFunction = async (
+    body?: JSONObject,
+  ): Promise<void> => {
+    const request: ExpressRequest = {
+      params: {
+        dashboardId: dashboardId.toString(),
+      },
+      body: body || {},
+      query: {},
+      cookies: {},
+      headers: {},
+      socket: {},
+      ips: [],
+    } as unknown as ExpressRequest;
+
+    await mockRouter
+      .match("post", SLO_HISTORY_ROUTE)
+      .handlerFunction(request, mockResponse, nextFunction);
+  };
+
+  type GetFindByArgsFunction = () => JSONObject;
+
+  const getFindByArgs: GetFindByArgsFunction = (): JSONObject => {
+    const calls: Array<Array<unknown>> = (
+      ServiceLevelObjectiveService.findBy as jest.Mock
+    ).mock.calls as Array<Array<unknown>>;
+
+    expect(calls.length).toBe(1);
+
+    return calls[0]![0] as JSONObject;
+  };
+
+  type GetAggregateArgsFunction = () => JSONObject;
+
+  const getAggregateArgs: GetAggregateArgsFunction = (): JSONObject => {
+    const calls: Array<Array<unknown>> = (
+      SloHistoryService.aggregateBy as jest.Mock
+    ).mock.calls as Array<Array<unknown>>;
+
+    expect(calls.length).toBe(1);
+
+    return calls[0]![0] as JSONObject;
+  };
+
+  type GetThrownErrorFunction = () => unknown;
+
+  const getThrownError: GetThrownErrorFunction = (): unknown => {
+    const calls: Array<Array<unknown>> = (nextFunction as jest.Mock).mock
+      .calls as Array<Array<unknown>>;
+
+    expect(calls.length).toBe(1);
+
+    return calls[0]![0];
+  };
+
+  type ExpectNothingReadFunction = () => void;
+
+  const expectNothingRead: ExpectNothingReadFunction = (): void => {
+    expect(ServiceLevelObjectiveService.findBy).not.toHaveBeenCalled();
+    expect(SloHistoryService.aggregateBy).not.toHaveBeenCalled();
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    dashboardId = ObjectID.generate();
+    projectId = ObjectID.generate();
+    serviceLevelObjectiveId = ObjectID.generate();
+
+    dashboard = new Dashboard();
+    dashboard.id = dashboardId;
+    dashboard.projectId = projectId;
+    dashboard.isPublicDashboard = true;
+    dashboard.enableMasterPassword = false;
+    setWidgets([]);
+
+    jest.spyOn(DashboardService, "findOneById").mockResolvedValue(dashboard);
+    jest
+      .spyOn(ServiceLevelObjectiveService, "findBy")
+      .mockResolvedValue([] as never);
+    jest
+      .spyOn(SloHistoryService, "aggregateBy")
+      .mockResolvedValue({ data: [] } as never);
+
+    mockResponse = {
+      cookie: jest.fn(),
+      send: jest.fn(),
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    } as unknown as ExpressResponse;
+
+    nextFunction = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("resource-list: the SLO's current numbers", () => {
+    it("serves the SLO the widget names, pinned to the dashboard's project", async () => {
+      const slo: BuiltWidget = buildSloWidget();
+      setWidgets([slo.widget]);
+
+      await callResourceList({ componentId: slo.componentId.toString() });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+
+      const findByArgs: JSONObject = getFindByArgs();
+      const query: JSONObject = findByArgs["query"] as JSONObject;
+
+      expect(query["projectId"]).toBe(projectId);
+      expect((query["_id"] as ObjectID).toString()).toBe(
+        serviceLevelObjectiveId.toString(),
+      );
+      expect(findByArgs["limit"]).toBe(1);
+      expect(findByArgs["skip"]).toBe(0);
+      expect(findByArgs["props"]).toEqual({ isRoot: true });
+      expect(findByArgs["select"]).toEqual({
+        _id: true,
+        name: true,
+        targetPercentage: true,
+        currentSliPercentage: true,
+        errorBudgetRemainingPercentage: true,
+        errorBudgetRemainingSeconds: true,
+        currentBurnRate: true,
+        sloStatus: true,
+      });
+      expect(Response.sendEntityArrayResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it("refuses to read an SLO the dashboard does not show", async () => {
+      const foreignSloId: ObjectID = ObjectID.generate();
+      const slo: BuiltWidget = buildSloWidget();
+      setWidgets([slo.widget]);
+
+      await callResourceList({
+        componentId: slo.componentId.toString(),
+        query: { _id: foreignSloId.toString() },
+        select: { description: true, metricQueryConfig: true, monitors: true },
+        sort: { createdAt: SortOrder.Descending },
+        limit: LIMIT_PER_PROJECT,
+      });
+
+      const findByArgs: JSONObject = getFindByArgs();
+      const query: JSONObject = findByArgs["query"] as JSONObject;
+
+      expect((query["_id"] as ObjectID).toString()).toBe(
+        serviceLevelObjectiveId.toString(),
+      );
+      expect((query["_id"] as ObjectID).toString()).not.toBe(
+        foreignSloId.toString(),
+      );
+      expect(
+        (findByArgs["select"] as JSONObject)["description"],
+      ).toBeUndefined();
+      expect(
+        (findByArgs["select"] as JSONObject)["metricQueryConfig"],
+      ).toBeUndefined();
+      expect((findByArgs["select"] as JSONObject)["monitors"]).toBeUndefined();
+      expect(findByArgs["limit"]).toBe(1);
+    });
+
+    it("refuses the resource entirely when the dashboard has no SLO widget", async () => {
+      setWidgets([]);
+
+      await callResourceList({});
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+      expectNothingRead();
+    });
+
+    it("reads the exact widget when a dashboard shows several SLOs", async () => {
+      const otherSloId: ObjectID = ObjectID.generate();
+      const first: BuiltWidget = buildSloWidget();
+      const second: BuiltWidget = buildSloWidget({
+        serviceLevelObjectiveId: otherSloId.toString(),
+      });
+      setWidgets([first.widget, second.widget]);
+
+      await callResourceList({ componentId: second.componentId.toString() });
+
+      const query: JSONObject = getFindByArgs()["query"] as JSONObject;
+      expect((query["_id"] as ObjectID).toString()).toBe(otherSloId.toString());
+    });
+
+    it("requires a componentId once more than one SLO widget exists", async () => {
+      setWidgets([buildSloWidget().widget, buildSloWidget().widget]);
+
+      await callResourceList({});
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+      expectNothingRead();
+    });
+
+    it("auto-binds the only SLO widget when no componentId is sent", async () => {
+      setWidgets([buildSloWidget().widget]);
+
+      await callResourceList({});
+
+      expect(nextFunction).not.toHaveBeenCalled();
+      expect(ServiceLevelObjectiveService.findBy).toHaveBeenCalledTimes(1);
+    });
+
+    it("serves a Tile widget as readily as a Chart widget", async () => {
+      for (const displayType of Object.values(SloWidgetDisplayType)) {
+        jest.clearAllMocks();
+        const slo: BuiltWidget = buildSloWidget({ displayType });
+        setWidgets([slo.widget]);
+
+        await callResourceList({ componentId: slo.componentId.toString() });
+
+        expect(nextFunction).not.toHaveBeenCalled();
+        expect(ServiceLevelObjectiveService.findBy).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it("fails closed on a widget whose stored SLO id is missing or malformed", async () => {
+      for (const brokenId of [undefined, "", "not-a-uuid"]) {
+        jest.clearAllMocks();
+        const slo: BuiltWidget = buildSloWidget({
+          serviceLevelObjectiveId: brokenId as string,
+        });
+        setWidgets([slo.widget]);
+
+        await callResourceList({ componentId: slo.componentId.toString() });
+
+        expect(getThrownError()).toBeInstanceOf(BadDataException);
+        expectNothingRead();
+      }
+    });
+  });
+
+  describe("slo-history-aggregate: the series behind the numbers", () => {
+    it("aggregates only the widget's own SLO and series", async () => {
+      const slo: BuiltWidget = buildSloChartWidget({
+        sloMetric: SloWidgetMetric.ErrorBudgetRemaining,
+      });
+      setWidgets([slo.widget]);
+
+      await callSloHistory({
+        componentId: slo.componentId.toString(),
+        aggregateBy: buildAggregateBy(),
+      });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+
+      const aggregateArgs: JSONObject = getAggregateArgs();
+      const query: JSONObject = aggregateArgs["query"] as JSONObject;
+
+      expect(query["projectId"]).toBe(projectId);
+      expect((query["sloId"] as ObjectID).toString()).toBe(
+        serviceLevelObjectiveId.toString(),
+      );
+      expect(query["metricName"]).toBe("error.budget.remaining.percent");
+
+      const bucketStart: InBetween<Date> = query[
+        "bucketStart"
+      ] as unknown as InBetween<Date>;
+      expect(bucketStart).toBeInstanceOf(InBetween);
+      expect(new Date(bucketStart.startValue).toISOString()).toBe(
+        RANGE_START.toISOString(),
+      );
+      expect(new Date(bucketStart.endValue).toISOString()).toBe(
+        RANGE_END.toISOString(),
+      );
+
+      expect(aggregateArgs["aggregationType"]).toBe(AggregationType.Avg);
+      expect(aggregateArgs["aggregateColumnName"]).toBe("value");
+      expect(aggregateArgs["aggregationTimestampColumnName"]).toBe(
+        "bucketStart",
+      );
+      expect(aggregateArgs["aggregationInterval"]).toBe(
+        AggregationInterval.FiveMinutes,
+      );
+      expect(aggregateArgs["sort"]).toEqual({
+        bucketStart: SortOrder.Ascending,
+      });
+      expect(aggregateArgs["limit"]).toBe(LIMIT_PER_PROJECT);
+      expect(aggregateArgs["skip"]).toBe(0);
+      expect(aggregateArgs["props"]).toEqual({ isRoot: true });
+    });
+
+    it("ignores a forged project, SLO, series, column and page", async () => {
+      const slo: BuiltWidget = buildSloChartWidget();
+      setWidgets([slo.widget]);
+
+      const foreignProjectId: ObjectID = ObjectID.generate();
+      const foreignSloId: ObjectID = ObjectID.generate();
+
+      await callSloHistory({
+        componentId: slo.componentId.toString(),
+        aggregateBy: buildAggregateBy({
+          query: {
+            projectId: foreignProjectId,
+            sloId: foreignSloId,
+            metricName: "burn.rate",
+            bucketStart: new InBetween<Date>(
+              new Date("2000-01-01T00:00:00.000Z"),
+              new Date("2030-01-01T00:00:00.000Z"),
+            ),
+          },
+          aggregationType: AggregationType.Max,
+          aggregateColumnName: "version",
+          aggregationTimestampColumnName: "version",
+          aggregationInterval: AggregationInterval.Total,
+          sort: { version: SortOrder.Descending },
+          limit: 1,
+          skip: 5000,
+        } as unknown as JSONObject),
+      });
+
+      const aggregateArgs: JSONObject = getAggregateArgs();
+      const query: JSONObject = aggregateArgs["query"] as JSONObject;
+
+      expect(query["projectId"]).toBe(projectId);
+      expect(query["projectId"]).not.toBe(foreignProjectId);
+      expect((query["sloId"] as ObjectID).toString()).toBe(
+        serviceLevelObjectiveId.toString(),
+      );
+      expect(query["metricName"]).toBe("sli.percent");
+      expect(aggregateArgs["aggregationType"]).toBe(AggregationType.Avg);
+      expect(aggregateArgs["aggregateColumnName"]).toBe("value");
+      expect(aggregateArgs["aggregationTimestampColumnName"]).toBe(
+        "bucketStart",
+      );
+      expect(aggregateArgs["aggregationInterval"]).toBe(
+        AggregationInterval.FiveMinutes,
+      );
+      expect(aggregateArgs["limit"]).toBe(LIMIT_PER_PROJECT);
+      expect(aggregateArgs["skip"]).toBe(0);
+    });
+
+    it("takes the window from the request", async () => {
+      const slo: BuiltWidget = buildSloChartWidget();
+      setWidgets([slo.widget]);
+
+      const start: Date = new Date("2026-07-10T00:00:00.000Z");
+      const end: Date = new Date("2026-07-17T00:00:00.000Z");
+
+      await callSloHistory({
+        componentId: slo.componentId.toString(),
+        aggregateBy: buildAggregateBy({
+          startTimestamp: start,
+          endTimestamp: end,
+        } as unknown as JSONObject),
+      });
+
+      const aggregateArgs: JSONObject = getAggregateArgs();
+      expect(
+        new Date(aggregateArgs["startTimestamp"] as string).toISOString(),
+      ).toBe(start.toISOString());
+      expect(
+        new Date(aggregateArgs["endTimestamp"] as string).toISOString(),
+      ).toBe(end.toISOString());
+      // A week-long window buckets hourly, whatever the caller asked for.
+      expect(aggregateArgs["aggregationInterval"]).toBe(
+        AggregationInterval.Hour,
+      );
+    });
+
+    it("accepts an aggregateBy that has been through the wire serializer", async () => {
+      const slo: BuiltWidget = buildSloChartWidget();
+      setWidgets([slo.widget]);
+
+      await callSloHistory({
+        componentId: slo.componentId.toString(),
+        aggregateBy: JSONFunctions.serialize(
+          buildAggregateBy() as JSONObject,
+        ) as JSONObject,
+      });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+
+      const query: JSONObject = getAggregateArgs()["query"] as JSONObject;
+      const bucketStart: InBetween<Date> = query[
+        "bucketStart"
+      ] as unknown as InBetween<Date>;
+
+      expect(new Date(bucketStart.startValue).toISOString()).toBe(
+        RANGE_START.toISOString(),
+      );
+      expect(new Date(bucketStart.endValue).toISOString()).toBe(
+        RANGE_END.toISOString(),
+      );
+    });
+
+    it("returns the aggregation result to the viewer", async () => {
+      const slo: BuiltWidget = buildSloChartWidget();
+      setWidgets([slo.widget]);
+
+      jest.spyOn(SloHistoryService, "aggregateBy").mockResolvedValue({
+        data: [{ timestamp: RANGE_START, value: 99.95 }],
+      } as never);
+
+      await callSloHistory({
+        componentId: slo.componentId.toString(),
+        aggregateBy: buildAggregateBy(),
+      });
+
+      expect(Response.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+
+      const responseBody: JSONObject = (
+        Response.sendJsonObjectResponse as jest.Mock
+      ).mock.calls[0]![2] as JSONObject;
+
+      expect((responseBody["data"] as Array<JSONObject>).length).toBe(1);
+    });
+
+    it("refuses a Tile widget, which publishes no series", async () => {
+      const slo: BuiltWidget = buildSloWidget({
+        displayType: SloWidgetDisplayType.Tile,
+      });
+      setWidgets([slo.widget]);
+
+      await callSloHistory({
+        componentId: slo.componentId.toString(),
+        aggregateBy: buildAggregateBy(),
+      });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+      expectNothingRead();
+    });
+
+    it("refuses a componentId that is not an SLO widget on this dashboard", async () => {
+      const slo: BuiltWidget = buildSloChartWidget();
+      setWidgets([slo.widget]);
+
+      for (const componentId of [
+        ObjectID.generate().toString(),
+        "not-a-uuid",
+        42,
+        {},
+      ]) {
+        jest.clearAllMocks();
+
+        await callSloHistory({
+          componentId: componentId as string,
+          aggregateBy: buildAggregateBy(),
+        });
+
+        expect(getThrownError()).toBeInstanceOf(BadDataException);
+        expectNothingRead();
+      }
+    });
+
+    it("reads the exact chart widget when a dashboard charts several SLOs", async () => {
+      const otherSloId: ObjectID = ObjectID.generate();
+      const first: BuiltWidget = buildSloChartWidget();
+      const second: BuiltWidget = buildSloChartWidget({
+        serviceLevelObjectiveId: otherSloId.toString(),
+        sloMetric: SloWidgetMetric.BurnRate,
+      });
+      setWidgets([first.widget, second.widget]);
+
+      await callSloHistory({
+        componentId: second.componentId.toString(),
+        aggregateBy: buildAggregateBy(),
+      });
+
+      const query: JSONObject = getAggregateArgs()["query"] as JSONObject;
+      expect((query["sloId"] as ObjectID).toString()).toBe(
+        otherSloId.toString(),
+      );
+      expect((query["sloId"] as ObjectID).toString()).not.toBe(
+        serviceLevelObjectiveId.toString(),
+      );
+      expect(query["metricName"]).toBe("burn.rate");
+    });
+
+    it("requires a componentId once more than one SLO widget exists", async () => {
+      setWidgets([buildSloChartWidget().widget, buildSloChartWidget().widget]);
+
+      await callSloHistory({ aggregateBy: buildAggregateBy() });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+      expectNothingRead();
+    });
+
+    it("refuses when the dashboard has no SLO widget at all", async () => {
+      setWidgets([]);
+
+      await callSloHistory({ aggregateBy: buildAggregateBy() });
+
+      expect(getThrownError()).toBeInstanceOf(BadDataException);
+      expectNothingRead();
+    });
+
+    it("requires an aggregateBy body", async () => {
+      const slo: BuiltWidget = buildSloChartWidget();
+      setWidgets([slo.widget]);
+
+      for (const body of [
+        {},
+        { componentId: slo.componentId.toString() },
+        { componentId: slo.componentId.toString(), aggregateBy: null },
+      ] as Array<JSONObject>) {
+        jest.clearAllMocks();
+
+        await callSloHistory(body);
+
+        expect(getThrownError()).toBeInstanceOf(BadDataException);
+        expectNothingRead();
+      }
+    });
+
+    it("rejects an unusable window before touching ClickHouse", async () => {
+      const slo: BuiltWidget = buildSloChartWidget();
+      setWidgets([slo.widget]);
+
+      const brokenWindows: Array<JSONObject> = [
+        { startTimestamp: "yesterday" },
+        { endTimestamp: null },
+        { startTimestamp: RANGE_END, endTimestamp: RANGE_START },
+        { startTimestamp: RANGE_START, endTimestamp: RANGE_START },
+      ] as unknown as Array<JSONObject>;
+
+      for (const brokenWindow of brokenWindows) {
+        jest.clearAllMocks();
+
+        await callSloHistory({
+          componentId: slo.componentId.toString(),
+          aggregateBy: buildAggregateBy(brokenWindow),
+        });
+
+        expect(getThrownError()).toBeInstanceOf(BadDataException);
+        expectNothingRead();
+      }
+    });
+
+    /*
+     * A window reaching past SloHistory's retention is answered, not refused
+     * — the public range picker is unbounded and the metric widgets on the
+     * same page render whatever it produces. Only the reach back is cut, so
+     * ClickHouse is still never asked to grid out decades.
+     */
+    it("clamps an over-long window instead of erroring the widget", async () => {
+      const slo: BuiltWidget = buildSloChartWidget();
+      setWidgets([slo.widget]);
+
+      const endDate: Date = new Date("2026-01-01T00:00:00.000Z");
+      const startDate: Date = new Date("2020-01-01T00:00:00.000Z");
+
+      await callSloHistory({
+        componentId: slo.componentId.toString(),
+        aggregateBy: buildAggregateBy({
+          startTimestamp: startDate,
+          endTimestamp: endDate,
+        } as unknown as JSONObject),
+      });
+
+      expect(nextFunction).not.toHaveBeenCalled();
+
+      const aggregateArgs: JSONObject = getAggregateArgs();
+      const bucketStart: InBetween<Date> = (
+        aggregateArgs["query"] as JSONObject
+      )["bucketStart"] as unknown as InBetween<Date>;
+
+      const retentionInMs: number = 400 * 24 * 60 * 60 * 1000;
+      expect(new Date(bucketStart.endValue).toISOString()).toBe(
+        endDate.toISOString(),
+      );
+      expect(new Date(bucketStart.startValue).toISOString()).toBe(
+        new Date(endDate.getTime() - retentionInMs).toISOString(),
+      );
+      expect(new Date(bucketStart.startValue).getTime()).toBeGreaterThan(
+        startDate.getTime(),
+      );
+    });
+  });
+
+  describe("dashboard authorization", () => {
+    it("rejects both routes for a dashboard that is not public", async () => {
+      const slo: BuiltWidget = buildSloChartWidget();
+      setWidgets([slo.widget]);
+      dashboard.isPublicDashboard = false;
+
+      await callResourceList({ componentId: slo.componentId.toString() });
+      expect(getThrownError()).toBeInstanceOf(NotAuthenticatedException);
+      expectNothingRead();
+
+      jest.clearAllMocks();
+      await callSloHistory({
+        componentId: slo.componentId.toString(),
+        aggregateBy: buildAggregateBy(),
+      });
+      expect(getThrownError()).toBeInstanceOf(NotAuthenticatedException);
+      expectNothingRead();
+    });
+
+    it("rejects both routes for a dashboard with no project", async () => {
+      const slo: BuiltWidget = buildSloChartWidget();
+      setWidgets([slo.widget]);
+      delete dashboard.projectId;
+
+      await callResourceList({ componentId: slo.componentId.toString() });
+      expect(getThrownError()).toBeInstanceOf(NotFoundException);
+      expectNothingRead();
+
+      jest.clearAllMocks();
+      await callSloHistory({
+        componentId: slo.componentId.toString(),
+        aggregateBy: buildAggregateBy(),
+      });
+      expect(getThrownError()).toBeInstanceOf(NotFoundException);
+      expectNothingRead();
+    });
+
+    /*
+     * The two routes must go through DashboardService.hasReadAccess rather
+     * than checking `isPublicDashboard` themselves — both already load the
+     * dashboard, so open-coding the flag is an easy and silent regression
+     * that would drop master-password and IP-allowlist gating entirely.
+     */
+    it("rejects both routes on a password-protected dashboard with no cookie", async () => {
+      const slo: BuiltWidget = buildSloChartWidget();
+      setWidgets([slo.widget]);
+      dashboard.enableMasterPassword = true;
+      dashboard.masterPasswordSalt = PasswordHash.generateSalt();
+      dashboard.masterPassword = new HashedString(
+        await PasswordHash.hash({
+          plainValue: "correct-horse-battery-staple",
+          salt: dashboard.masterPasswordSalt,
+        }),
+        true,
+      );
+
+      await callResourceList({ componentId: slo.componentId.toString() });
+      expect(getThrownError()).toBeInstanceOf(NotAuthenticatedException);
+      expectNothingRead();
+
+      jest.clearAllMocks();
+      await callSloHistory({
+        componentId: slo.componentId.toString(),
+        aggregateBy: buildAggregateBy(),
+      });
+      expect(getThrownError()).toBeInstanceOf(NotAuthenticatedException);
+      expectNothingRead();
+    });
+
+    it("rejects both routes when the viewer's IP is not on the allowlist", async () => {
+      const slo: BuiltWidget = buildSloChartWidget();
+      setWidgets([slo.widget]);
+      dashboard.ipWhitelist = "10.0.0.1";
+
+      await callResourceList({ componentId: slo.componentId.toString() });
+      expect(getThrownError()).toBeInstanceOf(ForbiddenException);
+      expectNothingRead();
+
+      jest.clearAllMocks();
+      await callSloHistory({
+        componentId: slo.componentId.toString(),
+        aggregateBy: buildAggregateBy(),
+      });
+      expect(getThrownError()).toBeInstanceOf(ForbiddenException);
+      expectNothingRead();
+    });
+
+    it("checks access before it ever reads the widget", async () => {
+      const slo: BuiltWidget = buildSloChartWidget();
+      setWidgets([slo.widget]);
+      dashboard.isPublicDashboard = false;
+
+      const buildSpy: jest.SpiedFunction<
+        typeof PublicDashboardSloHistoryPolicy.build
+      > = jest.spyOn(PublicDashboardSloHistoryPolicy, "build");
+
+      await callSloHistory({
+        componentId: slo.componentId.toString(),
+        aggregateBy: buildAggregateBy(),
+      });
+
+      expect(buildSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/Dashboard/PublicDashboardResourceListPolicy.test.ts
+++ b/Common/Tests/Server/Utils/Dashboard/PublicDashboardResourceListPolicy.test.ts
@@ -7,12 +7,19 @@ import Search from "../../../../Types/BaseDatabase/Search";
 import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
 import { LIMIT_PER_PROJECT } from "../../../../Types/Database/LimitMax";
 import DashboardComponentType from "../../../../Types/Dashboard/DashboardComponentType";
+import {
+  SloWidgetDisplayType,
+  SloWidgetMetric,
+} from "../../../../Types/Dashboard/DashboardComponents/DashboardSloComponent";
 import { DashboardVariableType } from "../../../../Types/Dashboard/DashboardVariable";
 import BadDataException from "../../../../Types/Exception/BadDataException";
 import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
 
 const RANGE_START: Date = new Date("2026-08-09T10:00:00.000Z");
 const RANGE_END: Date = new Date("2026-08-09T11:00:00.000Z");
+
+const SLO_ID: ObjectID = ObjectID.generate();
 
 function range(): InBetween<Date> {
   return new InBetween<Date>(RANGE_START, RANGE_END);
@@ -504,6 +511,25 @@ const MAPPING_CASES: Array<MappingCase> = [
     expectedSort: { time: SortOrder.Descending },
     expectedLimit: 50,
   },
+  {
+    name: "slo",
+    componentType: DashboardComponentType.Slo,
+    resourceType: "slo",
+    argumentsObject: {
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      sloMetric: SloWidgetMetric.BurnRate,
+      displayType: SloWidgetDisplayType.Chart,
+      widgetTitle: "Checkout availability",
+      /*
+       * A widget can only ever name ONE SLO, so a stray maxRows must not be
+       * able to turn its read into a page of the project's other SLOs.
+       */
+      maxRows: 500,
+    },
+    expectedQuery: { _id: SLO_ID },
+    expectedSort: { name: SortOrder.Ascending },
+    expectedLimit: 1,
+  },
 ];
 
 describe("PublicDashboardResourceListPolicy", () => {
@@ -568,6 +594,151 @@ describe("PublicDashboardResourceListPolicy", () => {
       expect(node["phase"]).toBeUndefined();
       expect(deployment["isReady"]).toBe(true);
       expect(deployment["phase"]).toBeUndefined();
+    });
+  });
+
+  describe("SLO widgets", () => {
+    const sloArguments: JSONObject = {
+      serviceLevelObjectiveId: SLO_ID.toString(),
+    };
+
+    it("publishes only the seven numbers the widget renders", () => {
+      const select: JSONObject = build({
+        componentType: DashboardComponentType.Slo,
+        argumentsObject: sloArguments,
+      }).select;
+
+      expect(select).toEqual({
+        _id: true,
+        name: true,
+        targetPercentage: true,
+        currentSliPercentage: true,
+        errorBudgetRemainingPercentage: true,
+        errorBudgetRemainingSeconds: true,
+        currentBurnRate: true,
+        sloStatus: true,
+      });
+
+      /*
+       * The definition of an SLO is not publishable even though its headline
+       * numbers are: which monitors it watches, how it is evaluated, and who
+       * created it all stay behind the session.
+       */
+      for (const privateColumn of [
+        "description",
+        "slug",
+        "monitors",
+        "monitorLabels",
+        "autoAddedMonitors",
+        "downtimeMonitorStatuses",
+        "labels",
+        "metricQueryConfig",
+        "sliType",
+        "windowType",
+        "windowDays",
+        "timezone",
+        "projectId",
+        "createdByUserId",
+        "createdByUser",
+        "lastEvaluatedAt",
+        "nextEvaluationAt",
+      ]) {
+        expect(select[privateColumn]).toBeUndefined();
+      }
+    });
+
+    it("ignores the caller's query entirely", () => {
+      const result: PublicDashboardResourceListPolicyResult = build({
+        componentType: DashboardComponentType.Slo,
+        argumentsObject: sloArguments,
+        requestedQuery: {
+          _id: ObjectID.generate().toString(),
+          projectId: ObjectID.generate().toString(),
+          name: "probe",
+          isEnabled: true,
+        },
+      });
+
+      expect(result.query).toEqual({ _id: SLO_ID });
+      expect(result.limit).toBe(1);
+    });
+
+    it("fails closed when the widget names no SLO", () => {
+      for (const brokenArguments of [
+        {},
+        { serviceLevelObjectiveId: "" },
+        { serviceLevelObjectiveId: "   " },
+        { serviceLevelObjectiveId: null },
+      ] as Array<JSONObject>) {
+        expect(() => {
+          return build({
+            componentType: DashboardComponentType.Slo,
+            argumentsObject: brokenArguments,
+          });
+        }).toThrow(BadDataException);
+      }
+    });
+
+    it("fails closed when the stored SLO id is not a UUID", () => {
+      for (const brokenId of [
+        "not-a-uuid",
+        "1",
+        "' OR 1=1 --",
+        SLO_ID.toString().replace(/-/g, ""),
+      ]) {
+        expect(() => {
+          return build({
+            componentType: DashboardComponentType.Slo,
+            argumentsObject: { serviceLevelObjectiveId: brokenId },
+          });
+        }).toThrow(BadDataException);
+      }
+
+      expect(() => {
+        return build({
+          componentType: DashboardComponentType.Slo,
+          argumentsObject: {
+            serviceLevelObjectiveId: [SLO_ID.toString()],
+          } as unknown as JSONObject,
+        });
+      }).toThrow(BadDataException);
+    });
+
+    it("accepts every stored metric and display type the widget can persist", () => {
+      for (const sloMetric of Object.values(SloWidgetMetric)) {
+        for (const displayType of Object.values(SloWidgetDisplayType)) {
+          const result: PublicDashboardResourceListPolicyResult = build({
+            componentType: DashboardComponentType.Slo,
+            argumentsObject: {
+              ...sloArguments,
+              sloMetric,
+              displayType,
+            },
+          });
+
+          /*
+           * Neither argument changes the row that is read — they only pick
+           * which of its numbers the widget draws.
+           */
+          expect(result.query).toEqual({ _id: SLO_ID });
+        }
+      }
+    });
+
+    it("rejects a stored metric or display type it does not recognise", () => {
+      expect(() => {
+        return build({
+          componentType: DashboardComponentType.Slo,
+          argumentsObject: { ...sloArguments, sloMetric: "Everything" },
+        });
+      }).toThrow(BadDataException);
+
+      expect(() => {
+        return build({
+          componentType: DashboardComponentType.Slo,
+          argumentsObject: { ...sloArguments, displayType: "Raw" },
+        });
+      }).toThrow(BadDataException);
     });
   });
 

--- a/Common/Tests/Server/Utils/Dashboard/PublicDashboardSloHistoryPolicy.test.ts
+++ b/Common/Tests/Server/Utils/Dashboard/PublicDashboardSloHistoryPolicy.test.ts
@@ -1,0 +1,383 @@
+import PublicDashboardSloHistoryPolicy, {
+  PublicDashboardSloHistoryPolicyResult,
+} from "../../../../Server/Utils/Dashboard/PublicDashboardSloHistoryPolicy";
+import PublicDashboardSloWidget, {
+  PublicDashboardSloWidgetConfig,
+} from "../../../../Server/Utils/Dashboard/PublicDashboardSloWidget";
+import AggregationInterval from "../../../../Types/BaseDatabase/AggregationInterval";
+import { LIMIT_PER_PROJECT } from "../../../../Types/Database/LimitMax";
+import DashboardComponentType from "../../../../Types/Dashboard/DashboardComponentType";
+import {
+  SloWidgetDisplayType,
+  SloWidgetMetric,
+} from "../../../../Types/Dashboard/DashboardComponents/DashboardSloComponent";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import ObjectID from "../../../../Types/ObjectID";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * The SLO history route is unauthenticated, so this policy is the whole
+ * boundary between "the series this dashboard publishes" and "any SloHistory
+ * row in the owning project". Everything below is written from that angle:
+ * what the caller can move, and what it provably cannot.
+ */
+
+const SLO_ID: ObjectID = ObjectID.generate();
+
+const RANGE_START: Date = new Date("2026-08-09T00:00:00.000Z");
+const RANGE_END: Date = new Date("2026-08-09T06:00:00.000Z");
+
+type WidgetArguments = Record<string, unknown>;
+
+function sloWidget(argumentsObject: WidgetArguments = {}): WidgetArguments {
+  return {
+    componentType: DashboardComponentType.Slo,
+    componentId: ObjectID.generate().toString(),
+    arguments: {
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      displayType: SloWidgetDisplayType.Chart,
+      ...argumentsObject,
+    },
+  };
+}
+
+/*
+ * Deliberately hostile: every field other than the window names something the
+ * widget's author never published — another project, another SLO, another
+ * series, an unbounded page, and an aggregation over the write-version
+ * column. Not one of them may appear in the result.
+ */
+function aggregateBy(overrides: WidgetArguments = {}): WidgetArguments {
+  return {
+    query: {
+      projectId: ObjectID.generate(),
+      sloId: ObjectID.generate(),
+      metricName: "burn.rate",
+    },
+    aggregationType: "Max",
+    aggregateColumnName: "version",
+    aggregationTimestampColumnName: "version",
+    aggregationInterval: AggregationInterval.Total,
+    startTimestamp: RANGE_START,
+    endTimestamp: RANGE_END,
+    limit: 999999,
+    skip: 500,
+    ...overrides,
+  };
+}
+
+function build(data: {
+  widgetArguments?: WidgetArguments | undefined;
+  requestedAggregateBy?: unknown;
+}): PublicDashboardSloHistoryPolicyResult {
+  return PublicDashboardSloHistoryPolicy.build({
+    widget: sloWidget(data.widgetArguments),
+    requestedAggregateBy:
+      "requestedAggregateBy" in data
+        ? data.requestedAggregateBy
+        : aggregateBy(),
+  });
+}
+
+describe("PublicDashboardSloHistoryPolicy", () => {
+  describe("what the stored widget decides", () => {
+    it("reads the SLO id from the widget and never from the request", () => {
+      expect(build({}).serviceLevelObjectiveId.toString()).toBe(
+        SLO_ID.toString(),
+      );
+    });
+
+    it("maps each stored metric to its own SloHistory series", () => {
+      const expectedMetricNames: Record<SloWidgetMetric, string> = {
+        [SloWidgetMetric.Sli]: "sli.percent",
+        [SloWidgetMetric.ErrorBudgetRemaining]:
+          "error.budget.remaining.percent",
+        [SloWidgetMetric.BurnRate]: "burn.rate",
+      };
+
+      for (const sloMetric of Object.values(SloWidgetMetric)) {
+        expect(build({ widgetArguments: { sloMetric } }).metricName).toBe(
+          expectedMetricNames[sloMetric],
+        );
+      }
+    });
+
+    it("defaults to the SLI series when the widget predates the metric picker", () => {
+      for (const sloMetric of [undefined, null, ""]) {
+        expect(build({ widgetArguments: { sloMetric } }).metricName).toBe(
+          "sli.percent",
+        );
+      }
+    });
+
+    it("rejects a stored metric it does not recognise", () => {
+      for (const sloMetric of ["sli.percent", "Everything", 3, ["Sli"]]) {
+        expect(() => {
+          return build({ widgetArguments: { sloMetric } });
+        }).toThrow(BadDataException);
+      }
+    });
+
+    it("serves history only for a Chart widget", () => {
+      expect(() => {
+        return build({
+          widgetArguments: { displayType: SloWidgetDisplayType.Tile },
+        });
+      }).toThrow(BadDataException);
+
+      /*
+       * A widget saved before the display picker existed defaults to Tile, so
+       * it publishes its current numbers and nothing more.
+       */
+      expect(() => {
+        return build({ widgetArguments: { displayType: undefined } });
+      }).toThrow(BadDataException);
+
+      expect(() => {
+        return build({ widgetArguments: { displayType: "Raw" } });
+      }).toThrow(BadDataException);
+    });
+
+    it("fails closed on a widget that names no SLO or names it badly", () => {
+      for (const brokenId of [
+        undefined,
+        null,
+        "",
+        "   ",
+        "not-a-uuid",
+        42,
+        [SLO_ID.toString()],
+      ]) {
+        expect(() => {
+          return build({
+            widgetArguments: { serviceLevelObjectiveId: brokenId },
+          });
+        }).toThrow(BadDataException);
+      }
+    });
+
+    it("fails closed on a widget that is not a widget", () => {
+      for (const brokenWidget of [
+        null,
+        undefined,
+        "widget",
+        7,
+        [],
+        {},
+        { arguments: 3 },
+        { arguments: null },
+        { arguments: [] },
+      ]) {
+        expect(() => {
+          return PublicDashboardSloHistoryPolicy.build({
+            widget: brokenWidget,
+            requestedAggregateBy: aggregateBy(),
+          });
+        }).toThrow(BadDataException);
+      }
+    });
+  });
+
+  describe("what the caller may move", () => {
+    it("keeps the requested window and nothing else from aggregateBy", () => {
+      const result: PublicDashboardSloHistoryPolicyResult = build({});
+
+      expect(result.startDate.toISOString()).toBe(RANGE_START.toISOString());
+      expect(result.endDate.toISOString()).toBe(RANGE_END.toISOString());
+
+      /*
+       * The forged project, SLO, series, aggregation columns, interval, limit
+       * and skip are all absent: the result carries no field they could ride
+       * out on.
+       */
+      expect(Object.keys(result).sort()).toEqual([
+        "aggregationInterval",
+        "endDate",
+        "limit",
+        "metricName",
+        "serviceLevelObjectiveId",
+        "startDate",
+      ]);
+      expect(result.serviceLevelObjectiveId.toString()).toBe(SLO_ID.toString());
+      expect(result.metricName).toBe("sli.percent");
+    });
+
+    it("accepts ISO date strings, which is what a JSON round trip produces", () => {
+      const result: PublicDashboardSloHistoryPolicyResult = build({
+        requestedAggregateBy: aggregateBy({
+          startTimestamp: RANGE_START.toISOString(),
+          endTimestamp: RANGE_END.toISOString(),
+        }),
+      });
+
+      expect(result.startDate.toISOString()).toBe(RANGE_START.toISOString());
+      expect(result.endDate.toISOString()).toBe(RANGE_END.toISOString());
+    });
+
+    it("recomputes the bucket size from the window rather than trusting it", () => {
+      const intervalCases: Array<{
+        hours: number;
+        expected: AggregationInterval;
+      }> = [
+        { hours: 1, expected: AggregationInterval.FiveMinutes },
+        { hours: 12, expected: AggregationInterval.FiveMinutes },
+        { hours: 24, expected: AggregationInterval.ThirtyMinutes },
+        { hours: 24 * 7, expected: AggregationInterval.Hour },
+        { hours: 24 * 90, expected: AggregationInterval.Day },
+      ];
+
+      for (const intervalCase of intervalCases) {
+        const endDate: Date = new Date(
+          RANGE_START.getTime() + intervalCase.hours * 60 * 60 * 1000,
+        );
+
+        const result: PublicDashboardSloHistoryPolicyResult = build({
+          requestedAggregateBy: aggregateBy({
+            endTimestamp: endDate,
+            // Deliberately the coarsest possible ask; it must be discarded.
+            aggregationInterval: AggregationInterval.Total,
+          }),
+        });
+
+        expect(result.aggregationInterval).toBe(intervalCase.expected);
+      }
+    });
+
+    it("pins the page size to the project ceiling", () => {
+      expect(
+        build({ requestedAggregateBy: aggregateBy({ limit: 1 }) }).limit,
+      ).toBe(LIMIT_PER_PROJECT);
+      expect(
+        build({ requestedAggregateBy: aggregateBy({ limit: -5, skip: 900 }) })
+          .limit,
+      ).toBe(LIMIT_PER_PROJECT);
+    });
+  });
+
+  describe("window validation", () => {
+    it("rejects a missing or non-object aggregateBy", () => {
+      for (const broken of [undefined, null, "aggregateBy", 5, []]) {
+        expect(() => {
+          return build({ requestedAggregateBy: broken });
+        }).toThrow(BadDataException);
+      }
+    });
+
+    it("rejects timestamps that are not dates", () => {
+      const brokenDates: Array<unknown> = [
+        undefined,
+        null,
+        "yesterday",
+        {},
+        [],
+        new Date("nope"),
+        // Longer than the accepted date-string bound.
+        "2026-08-09T00:00:00.000Z".padEnd(200, " "),
+      ];
+
+      for (const brokenDate of brokenDates) {
+        expect(() => {
+          return build({
+            requestedAggregateBy: aggregateBy({ startTimestamp: brokenDate }),
+          });
+        }).toThrow(BadDataException);
+
+        expect(() => {
+          return build({
+            requestedAggregateBy: aggregateBy({ endTimestamp: brokenDate }),
+          });
+        }).toThrow(BadDataException);
+      }
+    });
+
+    it("rejects an inverted or empty window", () => {
+      expect(() => {
+        return build({
+          requestedAggregateBy: aggregateBy({
+            startTimestamp: RANGE_END,
+            endTimestamp: RANGE_START,
+          }),
+        });
+      }).toThrow(BadDataException);
+
+      expect(() => {
+        return build({
+          requestedAggregateBy: aggregateBy({
+            startTimestamp: RANGE_START,
+            endTimestamp: RANGE_START,
+          }),
+        });
+      }).toThrow(BadDataException);
+    });
+
+    /*
+     * A window longer than the history's own retention is CLAMPED rather than
+     * refused: the public range picker is unbounded and the metric widgets
+     * beside this one just render whatever the range holds, so throwing would
+     * make the SLO chart the only tile on the page showing an error.
+     */
+    it("clamps a window longer than the history's own retention", () => {
+      const retentionInMs: number = 400 * 24 * 60 * 60 * 1000;
+      const justInside: Date = new Date(RANGE_START.getTime() + retentionInMs);
+      const wayOutside: Date = new Date(
+        RANGE_START.getTime() + retentionInMs * 3,
+      );
+
+      const inside: PublicDashboardSloHistoryPolicyResult = build({
+        requestedAggregateBy: aggregateBy({ endTimestamp: justInside }),
+      });
+      expect(inside.startDate.toISOString()).toBe(RANGE_START.toISOString());
+      expect(inside.aggregationInterval).toBe(AggregationInterval.Day);
+
+      const clamped: PublicDashboardSloHistoryPolicyResult = build({
+        requestedAggregateBy: aggregateBy({ endTimestamp: wayOutside }),
+      });
+
+      // The end the viewer asked for is kept; only the reach back is cut.
+      expect(clamped.endDate.toISOString()).toBe(wayOutside.toISOString());
+      expect(clamped.startDate.toISOString()).toBe(
+        new Date(wayOutside.getTime() - retentionInMs).toISOString(),
+      );
+      expect(clamped.startDate.getTime()).toBeGreaterThan(
+        RANGE_START.getTime(),
+      );
+      /*
+       * Any window big enough to be clamped is far past the 45-day tier, so
+       * the client's interval (computed from the unclamped window) and the
+       * server's (from the clamped one) still agree — the chart's x-axis and
+       * the buckets it receives stay on the same grid.
+       */
+      expect(clamped.aggregationInterval).toBe(AggregationInterval.Day);
+    });
+  });
+});
+
+describe("PublicDashboardSloWidget", () => {
+  it("reads the same config from a widget and from its arguments", () => {
+    const widget: WidgetArguments = sloWidget({
+      sloMetric: SloWidgetMetric.ErrorBudgetRemaining,
+    });
+
+    const fromWidget: PublicDashboardSloWidgetConfig =
+      PublicDashboardSloWidget.readConfig(widget);
+    const fromArguments: PublicDashboardSloWidgetConfig =
+      PublicDashboardSloWidget.readConfigFromArguments(
+        widget["arguments"] as WidgetArguments,
+      );
+
+    expect(fromWidget.serviceLevelObjectiveId.toString()).toBe(
+      fromArguments.serviceLevelObjectiveId.toString(),
+    );
+    expect(fromWidget.sloMetric).toBe(SloWidgetMetric.ErrorBudgetRemaining);
+    expect(fromArguments.sloMetric).toBe(SloWidgetMetric.ErrorBudgetRemaining);
+    expect(fromWidget.displayType).toBe(SloWidgetDisplayType.Chart);
+  });
+
+  it("trims a stored id before validating it", () => {
+    expect(
+      PublicDashboardSloWidget.readConfigFromArguments({
+        serviceLevelObjectiveId: `  ${SLO_ID.toString()}  `,
+      }).serviceLevelObjectiveId.toString(),
+    ).toBe(SLO_ID.toString());
+  });
+});

--- a/E2E/Tests/Dashboard/SloPublicDashboard.spec.ts
+++ b/E2E/Tests/Dashboard/SloPublicDashboard.spec.ts
@@ -1,0 +1,651 @@
+import {
+  APIRequestContext,
+  Browser,
+  Page,
+  expect,
+  test,
+} from "@playwright/test";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import JSONFunctions from "Common/Types/JSONFunctions";
+import ObjectID from "Common/Types/ObjectID";
+import Faker from "Common/Utils/Faker";
+import { registerAndCreateProject } from "./Helpers/ProductOnboarding";
+import { createItem, JSONish, toId } from "./Helpers/MonitorAlerting";
+import { publicPost, publicPostStatus } from "./Helpers/StatusPagePublic";
+
+/*
+ * SLO widgets on a public dashboard: project -> SLO -> public dashboard ->
+ * anonymous visitor.
+ *
+ * The point of this spec is the negative half. It is easy to make an
+ * unauthenticated endpoint return the right row and much easier to make it
+ * return more than the row: the SLO widget publishes an SLO's headline
+ * numbers, and its definition — description, bound monitors, labels, query
+ * config, evaluation schedule — must stay behind the session. So every read
+ * below asserts both what came back AND what did not.
+ *
+ * A second SLO is created and deliberately left off the dashboard. Nothing on
+ * the public surface may be able to reach it: not by asking for it by id, not
+ * by widening the query, not by pointing a componentId at it.
+ *
+ * Anti-flake notes:
+ * - every read goes through a request context with no session cookies, since
+ *   a public endpoint that only answers its own project's session is broken
+ *   and a same-session request would never catch that
+ * - names are run-unique so a re-run never collides with leftover rows
+ * - nothing asserts an EVALUATED number. The SLO evaluation worker runs on
+ *   its own schedule and will not have touched a seconds-old SLO, so the
+ *   state columns are legitimately null and the history series legitimately
+ *   empty. The assertions are about which FIELDS and which ROWS are served.
+ * - chromium only: this is server behaviour, not a rendering engine.
+ */
+
+test.describe.configure({ mode: "serial", retries: 1 });
+
+/** An SLO id that exists in no project, for the forged-query assertions. */
+const FORGED_SLO_ID: string = "00000000-0000-4000-8000-000000000000";
+
+/** Exactly the fields the SLO widget renders. */
+const PUBLISHED_FIELDS: Array<string> = [
+  "name",
+  "targetPercentage",
+  "currentSliPercentage",
+  "errorBudgetRemainingPercentage",
+  "errorBudgetRemainingSeconds",
+  "currentBurnRate",
+  "sloStatus",
+];
+
+/*
+ * Columns that describe HOW the SLO is defined rather than how it is doing.
+ * None of these may ever appear in a public response.
+ */
+const PRIVATE_FIELDS: Array<string> = [
+  "description",
+  "slug",
+  "monitors",
+  "monitorLabels",
+  "autoAddedMonitors",
+  "downtimeMonitorStatuses",
+  "labels",
+  "metricQueryConfig",
+  "sliType",
+  "multiMonitorMode",
+  "windowType",
+  "windowDays",
+  "timezone",
+  "atRiskThresholdPercentage",
+  "errorBudgetTotalSeconds",
+  "lastEvaluatedAt",
+  "nextEvaluationAt",
+  "createdByUserId",
+];
+
+type CreateSloFunction = (data: {
+  page: Page;
+  projectId: string;
+  name: string;
+}) => Promise<string>;
+
+const createSlo: CreateSloFunction = async (data: {
+  page: Page;
+  projectId: string;
+  name: string;
+}): Promise<string> => {
+  const slo: JSONish = await createItem({
+    page: data.page,
+    projectId: data.projectId,
+    path: "/api/service-level-objective",
+    item: {
+      name: data.name,
+      // Deliberately distinctive: the negative assertions search for it.
+      description: `PRIVATE-DEFINITION-${data.name}`,
+      projectId: data.projectId,
+      sliType: "Monitor Uptime",
+      targetPercentage: 99.9,
+      windowType: "Rolling",
+      windowDays: 30,
+      atRiskThresholdPercentage: 20,
+      multiMonitorMode: "Any Monitor Down",
+    },
+  });
+
+  const sloId: string = toId(slo["_id"]);
+  expect(sloId, `SLO ${data.name} should have been created`).not.toBe("");
+  return sloId;
+};
+
+interface SloWidget {
+  componentId: string;
+  component: JSONish;
+}
+
+type BuildSloWidgetFunction = (data: {
+  sloId: string;
+  displayType: "Tile" | "Chart";
+  topInDashboardUnits: number;
+  widgetTitle: string;
+}) => SloWidget;
+
+const buildSloWidget: BuildSloWidgetFunction = (data: {
+  sloId: string;
+  displayType: "Tile" | "Chart";
+  topInDashboardUnits: number;
+  widgetTitle: string;
+}): SloWidget => {
+  const componentId: string = crypto.randomUUID();
+
+  return {
+    componentId,
+    component: {
+      _type: "DashboardComponent",
+      componentId,
+      componentType: "Slo",
+      topInDashboardUnits: data.topInDashboardUnits,
+      leftInDashboardUnits: 0,
+      widthInDashboardUnits: 3,
+      heightInDashboardUnits: 3,
+      minWidthInDashboardUnits: 2,
+      minHeightInDashboardUnits: 2,
+      arguments: {
+        serviceLevelObjectiveId: data.sloId,
+        sloMetric: "Sli",
+        displayType: data.displayType,
+        widgetTitle: data.widgetTitle,
+      },
+    },
+  };
+};
+
+type SloHistoryAggregateByFunction = (data: {
+  startDate: Date;
+  endDate: Date;
+}) => JSONish;
+
+/*
+ * The exact body SloWidgetData.aggregateSloHistory posts — the full
+ * aggregateBy the chart builds, run through JSONFunctions.serialize, so the
+ * timestamps travel as `{_type: "DateTime", value: ...}` rather than as bare
+ * ISO strings.
+ *
+ * Hand-rolling a simpler shape here would exercise a wire format nothing in
+ * the product actually emits, and this spec is the only place the real one
+ * meets a real server.
+ */
+const sloHistoryAggregateBy: SloHistoryAggregateByFunction = (data: {
+  startDate: Date;
+  endDate: Date;
+}): JSONish => {
+  return JSONFunctions.serialize({
+    /*
+     * The real client sends its own query alongside the window. The server
+     * discards it and rebuilds from the stored widget, so this one names an
+     * SLO that does not exist — if it were ever honoured, the request would
+     * fail loudly rather than quietly return someone else's series.
+     */
+    query: {
+      sloId: new ObjectID(FORGED_SLO_ID),
+      metricName: "burn.rate",
+      bucketStart: new InBetween<Date>(data.startDate, data.endDate),
+    },
+    aggregationType: "Avg",
+    aggregateColumnName: "value",
+    aggregationTimestampColumnName: "bucketStart",
+    aggregationInterval: "FiveMinutes",
+    startTimestamp: data.startDate,
+    endTimestamp: data.endDate,
+    sort: { bucketStart: "Ascending" },
+    limit: 10000,
+    skip: 0,
+  } as JSONish) as JSONish;
+};
+
+type ExpectNoPrivateFieldsFunction = (data: {
+  payload: JSONish | Array<JSONish>;
+  privateDescription: string;
+  label: string;
+}) => void;
+
+const expectNoPrivateFields: ExpectNoPrivateFieldsFunction = (data: {
+  payload: JSONish | Array<JSONish>;
+  privateDescription: string;
+  label: string;
+}): void => {
+  const serialized: string = JSON.stringify(data.payload);
+
+  for (const privateField of PRIVATE_FIELDS) {
+    expect(
+      serialized.includes(`"${privateField}"`),
+      `${data.label} must not carry the SLO's ${privateField}`,
+    ).toBe(false);
+  }
+
+  expect(
+    serialized.includes(data.privateDescription),
+    `${data.label} must not carry the SLO's description`,
+  ).toBe(false);
+};
+
+test.describe("SLO widgets on a public dashboard", () => {
+  test.skip(({ browserName }: { browserName: string }) => {
+    return browserName !== "chromium";
+  }, "server behaviour, one engine is enough");
+
+  test("publishes an SLO's numbers to an anonymous visitor and nothing else", async ({
+    page,
+    browser,
+  }: {
+    page: Page;
+    browser: Browser;
+  }) => {
+    test.setTimeout(600000);
+
+    const unique: string = Faker.generateName().toString().replace(/\s/g, "-");
+
+    const projectId: string = await registerAndCreateProject({
+      page,
+      projectNamePrefix: "SLO Public Dashboard E2E",
+    });
+
+    // The SLO the dashboard publishes.
+    const publishedSloName: string = `Published SLO ${unique}`;
+    const publishedSloId: string = await createSlo({
+      page,
+      projectId,
+      name: publishedSloName,
+    });
+
+    /*
+     * A second SLO in the same project that no widget points at. It is the
+     * control: the public surface must be unable to reach it by any means.
+     */
+    const hiddenSloName: string = `Hidden SLO ${unique}`;
+    const hiddenSloId: string = await createSlo({
+      page,
+      projectId,
+      name: hiddenSloName,
+    });
+
+    const tileWidget: SloWidget = buildSloWidget({
+      sloId: publishedSloId,
+      displayType: "Tile",
+      topInDashboardUnits: 0,
+      widgetTitle: `Tile ${unique}`,
+    });
+    const chartWidget: SloWidget = buildSloWidget({
+      sloId: publishedSloId,
+      displayType: "Chart",
+      topInDashboardUnits: 4,
+      widgetTitle: `Chart ${unique}`,
+    });
+
+    const dashboard: JSONish = await createItem({
+      page,
+      projectId,
+      path: "/api/dashboard",
+      item: {
+        name: `SLO Dashboard ${unique}`,
+        description: "Created by SloPublicDashboard.spec.ts",
+        projectId,
+        isPublicDashboard: true,
+        dashboardViewConfig: {
+          _type: "DashboardViewConfig",
+          heightInDashboardUnits: 24,
+          components: [tileWidget.component, chartWidget.component],
+          variables: [],
+        },
+      },
+    });
+
+    const dashboardId: string = toId(dashboard["_id"]);
+    expect(dashboardId, "dashboard should have been created").not.toBe("");
+
+    // Everything below runs with no session cookies at all.
+    const anonymous: APIRequestContext = (await browser.newContext()).request;
+
+    // ── the config the viewer's page renders from ────────────────────────
+    const viewConfigResponse: JSONish = await publicPost({
+      request: anonymous,
+      path: `/public-dashboard-api/view-config/${dashboardId}`,
+    });
+
+    const serializedViewConfig: string = JSON.stringify(
+      viewConfigResponse["dashboardViewConfig"],
+    );
+
+    /*
+     * The SLO widgets must survive the anonymous view-config sanitizer — the
+     * external Data Source widgets are stripped there, and an over-broad
+     * strip would silently take these with them and leave a blank page.
+     */
+    expect(
+      serializedViewConfig.includes(tileWidget.componentId),
+      "the Tile SLO widget must survive into the anonymous view config",
+    ).toBe(true);
+    expect(
+      serializedViewConfig.includes(chartWidget.componentId),
+      "the Chart SLO widget must survive into the anonymous view config",
+    ).toBe(true);
+
+    // ── the SLO's current numbers ───────────────────────────────────────
+    const listResponse: JSONish = await publicPost({
+      request: anonymous,
+      path: `/public-dashboard-api/resource-list/${dashboardId}/slo`,
+      body: { componentId: tileWidget.componentId },
+    });
+
+    const rows: Array<JSONish> = (listResponse["data"] || []) as Array<JSONish>;
+    expect(rows.length, "the widget's SLO should be served").toBe(1);
+
+    const row: JSONish = rows[0]!;
+    expect(row["name"]).toBe(publishedSloName);
+    expect(Number(row["targetPercentage"])).toBe(99.9);
+
+    /*
+     * The exact assertion: every key that came back is one of the seven the
+     * widget draws (plus the _id every list response carries). The state
+     * columns are legitimately null on a seconds-old SLO, so their VALUES
+     * are not asserted — their presence is not what matters, the absence of
+     * everything else is.
+     */
+    for (const returnedField of Object.keys(row)) {
+      expect(
+        [...PUBLISHED_FIELDS, "_id"].includes(returnedField),
+        `the public SLO row must not carry ${returnedField}`,
+      ).toBe(true);
+    }
+    expectNoPrivateFields({
+      payload: rows,
+      privateDescription: `PRIVATE-DEFINITION-${publishedSloName}`,
+      label: "the public SLO row",
+    });
+
+    // ── the series behind them ──────────────────────────────────────────
+    const endDate: Date = new Date();
+    const startDate: Date = new Date(endDate.getTime() - 60 * 60 * 1000);
+
+    const historyResponse: JSONish = await publicPost({
+      request: anonymous,
+      path: `/public-dashboard-api/slo-history-aggregate/${dashboardId}`,
+      body: {
+        componentId: chartWidget.componentId,
+        aggregateBy: sloHistoryAggregateBy({ startDate, endDate }),
+      },
+    });
+
+    /*
+     * A seconds-old SLO has no history yet, so the only safe assertion is
+     * the SHAPE: an aggregation that ran and returned a series (usually
+     * empty), rather than an error.
+     */
+    expect(
+      Array.isArray(historyResponse["data"]),
+      "the history endpoint should return a series",
+    ).toBe(true);
+
+    // ── the machine-readable overview ───────────────────────────────────
+    const overview: JSONish = await publicPost({
+      request: anonymous,
+      path: `/public-dashboard-api/overview/${dashboardId}`,
+    });
+
+    /*
+     * The summaries are what a crawler reads via llms.txt. An SLO widget
+     * stores its heading under `widgetTitle`, so a summary builder that only
+     * knows `chartTitle`/`title` would describe it as an untitled "Slo".
+     */
+    const summaries: Array<JSONish> = (overview["components"] ||
+      []) as Array<JSONish>;
+    const sloSummaries: Array<JSONish> = summaries.filter(
+      (summary: JSONish) => {
+        return summary["componentType"] === "Slo";
+      },
+    );
+
+    expect(sloSummaries.length, "both SLO widgets should be summarised").toBe(
+      2,
+    );
+    expect(
+      sloSummaries.map((summary: JSONish) => {
+        return summary["title"];
+      }),
+      "the overview should carry each SLO widget's title",
+    ).toEqual(expect.arrayContaining([`Tile ${unique}`, `Chart ${unique}`]));
+    /*
+     * The summaries are derived from the stored config, so a description
+     * check here could not fail. What CAN regress is the shape: assert each
+     * summary is confined to its declared keys, so a future field added to
+     * the builder has to be considered rather than shipped by default.
+     */
+    for (const summary of sloSummaries) {
+      for (const key of Object.keys(summary)) {
+        expect(
+          [
+            "componentType",
+            "title",
+            "description",
+            "text",
+            "metricNames",
+          ].includes(key),
+          `the overview summary must not carry ${key}`,
+        ).toBe(true);
+      }
+    }
+
+    // ── the SLO the dashboard does not show ─────────────────────────────
+    const forgedList: JSONish = await publicPost({
+      request: anonymous,
+      path: `/public-dashboard-api/resource-list/${dashboardId}/slo`,
+      body: {
+        componentId: tileWidget.componentId,
+        query: { _id: hiddenSloId },
+        select: { description: true, monitors: true },
+        limit: 100,
+      },
+    });
+
+    /*
+     * The forged query is discarded rather than refused, so the assertion is
+     * that the read landed on the widget's own SLO anyway — and that the
+     * forged `select` did not widen the projection. The description checked
+     * for is the PUBLISHED SLO's: that is the one the server actually holds
+     * a row for, so it is the one a widened select would leak.
+     */
+    const forgedRows: Array<JSONish> = (forgedList["data"] ||
+      []) as Array<JSONish>;
+    expect(forgedRows.length, "a forged query must not widen the read").toBe(1);
+    expect(
+      forgedRows[0]!["name"],
+      "a forged _id must not redirect the read",
+    ).toBe(publishedSloName);
+    expect(
+      forgedRows[0]!["name"],
+      "a forged _id must not reach the SLO the dashboard does not show",
+    ).not.toBe(hiddenSloName);
+    expectNoPrivateFields({
+      payload: forgedRows,
+      privateDescription: `PRIVATE-DEFINITION-${publishedSloName}`,
+      label: "a forged public SLO read",
+    });
+
+    /*
+     * The two refusals below share their route, body and request context with
+     * the successful history read above — only the componentId differs. That
+     * request is their positive control: a 4xx here cannot be a typo'd path
+     * or a missing dashboard id, because the same path just answered 200.
+     */
+
+    // A Tile widget publishes no series.
+    const tileHistoryStatus: number = await publicPostStatus({
+      request: anonymous,
+      path: `/public-dashboard-api/slo-history-aggregate/${dashboardId}`,
+      body: {
+        componentId: tileWidget.componentId,
+        aggregateBy: sloHistoryAggregateBy({ startDate, endDate }),
+      },
+    });
+
+    expect(tileHistoryStatus, "a Tile widget must not serve SLO history").toBe(
+      400,
+    );
+
+    // A componentId that is not a widget on this dashboard.
+    const forgedComponentStatus: number = await publicPostStatus({
+      request: anonymous,
+      path: `/public-dashboard-api/slo-history-aggregate/${dashboardId}`,
+      body: {
+        componentId: crypto.randomUUID(),
+        aggregateBy: sloHistoryAggregateBy({ startDate, endDate }),
+      },
+    });
+
+    expect(
+      forgedComponentStatus,
+      "an unknown componentId must be refused",
+    ).toBe(400);
+  });
+
+  test("does not serve SLO data from a dashboard that is not public", async ({
+    page,
+    browser,
+  }: {
+    page: Page;
+    browser: Browser;
+  }) => {
+    test.setTimeout(600000);
+
+    const unique: string = Faker.generateName().toString().replace(/\s/g, "-");
+
+    const projectId: string = await registerAndCreateProject({
+      page,
+      projectNamePrefix: "SLO Private Dashboard E2E",
+    });
+
+    const sloId: string = await createSlo({
+      page,
+      projectId,
+      name: `Private SLO ${unique}`,
+    });
+
+    const widget: SloWidget = buildSloWidget({
+      sloId,
+      displayType: "Chart",
+      topInDashboardUnits: 0,
+      widgetTitle: `Private ${unique}`,
+    });
+
+    const dashboard: JSONish = await createItem({
+      page,
+      projectId,
+      path: "/api/dashboard",
+      item: {
+        name: `Private SLO Dashboard ${unique}`,
+        description: "Created by SloPublicDashboard.spec.ts",
+        projectId,
+        isPublicDashboard: false,
+        dashboardViewConfig: {
+          _type: "DashboardViewConfig",
+          heightInDashboardUnits: 24,
+          components: [widget.component],
+          variables: [],
+        },
+      },
+    });
+
+    const dashboardId: string = toId(dashboard["_id"]);
+    expect(dashboardId, "dashboard should have been created").not.toBe("");
+
+    const anonymous: APIRequestContext = (await browser.newContext()).request;
+    const endDate: Date = new Date();
+    const startDate: Date = new Date(endDate.getTime() - 60 * 60 * 1000);
+
+    const listStatus: number = await publicPostStatus({
+      request: anonymous,
+      path: `/public-dashboard-api/resource-list/${dashboardId}/slo`,
+      body: { componentId: widget.componentId },
+    });
+    const historyStatus: number = await publicPostStatus({
+      request: anonymous,
+      path: `/public-dashboard-api/slo-history-aggregate/${dashboardId}`,
+      body: {
+        componentId: widget.componentId,
+        aggregateBy: sloHistoryAggregateBy({ startDate, endDate }),
+      },
+    });
+
+    /*
+     * A refusal only means something if the same request would have
+     * SUCCEEDED against a public dashboard — otherwise a typo'd route or an
+     * empty dashboard id 404s and these assertions pass while proving
+     * nothing. So build the identical dashboard with isPublicDashboard set
+     * and issue both requests against it.
+     *
+     * A second dashboard rather than flipping this one: `isPublicDashboard`
+     * is `create: PlanType.Free` but `update: PlanType.Growth`, so the update
+     * would be refused on a billing-enabled run for reasons that have nothing
+     * to do with what this test is about.
+     */
+    const controlWidget: SloWidget = buildSloWidget({
+      sloId,
+      displayType: "Chart",
+      topInDashboardUnits: 0,
+      widgetTitle: `Control ${unique}`,
+    });
+
+    const controlDashboard: JSONish = await createItem({
+      page,
+      projectId,
+      path: "/api/dashboard",
+      item: {
+        name: `Control SLO Dashboard ${unique}`,
+        description: "Created by SloPublicDashboard.spec.ts",
+        projectId,
+        isPublicDashboard: true,
+        dashboardViewConfig: {
+          _type: "DashboardViewConfig",
+          heightInDashboardUnits: 24,
+          components: [controlWidget.component],
+          variables: [],
+        },
+      },
+    });
+
+    const controlDashboardId: string = toId(controlDashboard["_id"]);
+    expect(
+      controlDashboardId,
+      "control dashboard should have been created",
+    ).not.toBe("");
+
+    const listStatusWhenPublic: number = await publicPostStatus({
+      request: anonymous,
+      path: `/public-dashboard-api/resource-list/${controlDashboardId}/slo`,
+      body: { componentId: controlWidget.componentId },
+    });
+    const historyStatusWhenPublic: number = await publicPostStatus({
+      request: anonymous,
+      path: `/public-dashboard-api/slo-history-aggregate/${controlDashboardId}`,
+      body: {
+        componentId: controlWidget.componentId,
+        aggregateBy: sloHistoryAggregateBy({ startDate, endDate }),
+      },
+    });
+
+    expect(
+      listStatusWhenPublic,
+      "positive control: the same SLO read must succeed once the dashboard is public",
+    ).toBe(200);
+    expect(
+      historyStatusWhenPublic,
+      "positive control: the same history read must succeed once the dashboard is public",
+    ).toBe(200);
+
+    expect(
+      listStatus,
+      `an anonymous SLO read on a private dashboard should be rejected, got ${listStatus}`,
+    ).toBe(401);
+    expect(
+      historyStatus,
+      `an anonymous SLO history read on a private dashboard should be rejected, got ${historyStatus}`,
+    ).toBe(401);
+  });
+});


### PR DESCRIPTION
Closes the gap where an SLO widget on a shared dashboard rendered nothing but *"SLO widgets are not available on public dashboards."*

## What changes for a user

An SLO widget on a public dashboard now renders for anonymous viewers, in both display modes — the Tile's current number and the Chart's series over the dashboard's time range.

## What gets published, and what does not

Putting the widget on a shared board is the opt-in, same as every other public widget. What that opts into is the SLO's **headline numbers** — name, target, current SLI, error budget remaining, burn rate, status. Its **definition** stays private: description, bound monitors, labels, metric query config, evaluation schedule, `createdBy`. Those are not merely filtered out of the response; they are never selected, so there is no path by which they can be returned.

A Tile widget publishes only the current numbers. A Chart widget also publishes the history of the one series it charts.

## How it is scoped

Two unauthenticated reads, both driven by the **stored widget** rather than by anything the caller sends:

**`POST /public-dashboard-api/resource-list/:dashboardId/slo`** reuses the existing `PUBLIC_DASHBOARD_RESOURCES` registry and `PublicDashboardResourceListPolicy`. The query is pinned to `_id` = the widget's stored SLO id, capped at one row, and projected to exactly the seven display fields. It accepts no filter at all, so it can be neither walked across the project's other SLOs nor used as a filter oracle.

**`POST /public-dashboard-api/slo-history-aggregate/:dashboardId`** is new. Which SLO and which of its three series come from the widget (selected by `componentId`, required as soon as a dashboard carries more than one). The aggregation columns, sort, page size and bucket interval are all server-chosen — the interval is *recomputed* from the window with the same helper the client uses, so the two agree without the client getting a say. The only caller-supplied input that survives is the time window.

Both run as root only after `DashboardService.hasReadAccess` (public flag, IP allowlist, master password), with `projectId` pinned last from the dashboard.

Two judgement calls worth naming:

- **An over-long window is clamped, not refused.** The public range picker is unbounded and the metric charts beside this widget just render whatever the range holds. Throwing would have made the SLO tile the only thing on the page showing a server error, purely because the viewer is anonymous. The clamp still bounds the read at SloHistory's own 400-day retention, past which there is nothing to return anyway.
- **A Tile widget is refused history outright.** Serving 400 days of series for a tile would hand out data its author never put on the page.

## Also in here

The public `/overview` summary (what llms.txt and crawlers read) built titles from `chartTitle`/`title` only, so an SLO widget summarised as untitled — and so, it turns out, does every Gauge and Table widget, which store theirs under `gaugeTitle`/`tableTitle`. Now reads each widget's own heading key. This only fills in titles that were `null`; the same strings already travelled in the response's `dashboardViewConfig`, so nothing new is disclosed.

## Tests

74 new cases, all passing, plus the existing suites still green (2519 in `Common`, 4390 in `App`):

| Where | What it pins |
|---|---|
| `DashboardPublicSloAPI.test.ts` (26) | Both routes end to end: project pinning, the fixed select, forged project/SLO/series/column/page all ignored, Tile refused history, multi-widget `componentId` selection, master-password and IP-allowlist refusals on both routes |
| `PublicDashboardSloHistoryPolicy.test.ts` (17) | The policy in isolation — what the widget decides vs. what the caller may move, window validation, the clamp |
| `SloWidgetFetching.test.tsx` (10) | The widget rendering in **both** modes, asserted against the requests it issues, so the public and private paths cannot drift |
| `PublicDashboardResourceListPolicy.test.ts` (+6) | The SLO projection, including an explicit list of columns that must stay out |
| `DashboardResourceList.test.ts` (+2) | The `slo` resource routes to the dashboard-scoped endpoint |

Plus `E2E/Tests/Dashboard/SloPublicDashboard.spec.ts`, which builds a project, two SLOs (one deliberately left off the dashboard), and a public dashboard, then reads it as an anonymous visitor. It asserts the returned keys are confined to the published set, that a forged `_id`/`select`/`limit` cannot widen or redirect the read, and that a private dashboard refuses both routes — with a positive control, so a typo'd path cannot pass that last one by 404-ing.

## What I did not verify

The E2E spec **has not been executed** — it needs a full docker-compose stack, and `E2E/node_modules` isn't installed in this worktree, so I couldn't even typecheck it locally. Every request path, body shape and response shape in it was checked against the server code by hand, and CI's Compile job typechecks it, but it will meet a real server for the first time in the release pipeline. Worth a look from someone who can run it.

No live browser check either, for the same reason.

## Review notes

This went through an adversarial review pass (22 findings raised, 3 survived refutation). The surviving ones are fixed here: the window clamp above, and two comment/doc inaccuracies. Two things a human reviewer may want to weigh in on:

- **Docs are English-only.** The repo is inconsistent here — the HTML widget was added to all 16 locales in one commit, the Network Map to `en` alone. I followed the more recent precedent rather than machine-translating into 15 languages I can't check.
- **`gaugeTitle`/`tableTitle` in the overview** is adjacent to the SLO work. It is a two-key change with no disclosure risk, but say the word and I'll pull it into its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
