### PR TITLE
Rework the workflow builder's problems strip and panel

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Workflow/View/Builder.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Workflow/View/Builder.tsx
@@ -25,12 +25,13 @@ import ComponentMetadata, {
 import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
 import ConfirmModal from "Common/UI/Components/Modal/ConfirmModal";
-import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
-import {
-  WorkflowLintIssue,
-  WorkflowLintResult,
-  WorkflowLintSeverity,
-} from "Common/UI/Components/Workflow/GraphLint";
+import Dictionary from "Common/Types/Dictionary";
+import { WorkflowLintResult } from "Common/UI/Components/Workflow/GraphLint";
+import { buildStepTitlesByNodeId } from "Common/UI/Components/Workflow/GraphLintSummary";
+import WorkflowIssuesModal from "Common/UI/Components/Workflow/WorkflowIssuesModal";
+import WorkflowStatusBar, {
+  WorkflowSaveState,
+} from "Common/UI/Components/Workflow/WorkflowStatusBar";
 import { loadComponentsAndCategories } from "Common/UI/Components/Workflow/Utils";
 import Workflow, {
   getEdgeDefaultProps,
@@ -54,33 +55,11 @@ import { useAsyncEffect } from "use-async-effect";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 
-type GetIssueSummaryTextFunction = (result: WorkflowLintResult) => string;
-
-const getIssueSummaryText: GetIssueSummaryTextFunction = (
-  result: WorkflowLintResult,
-): string => {
-  const parts: Array<string> = [];
-
-  if (result.errorCount > 0) {
-    parts.push(
-      `${result.errorCount} ${result.errorCount === 1 ? "problem" : "problems"}`,
-    );
-  }
-
-  if (result.warningCount > 0) {
-    parts.push(
-      `${result.warningCount} ${
-        result.warningCount === 1 ? "warning" : "warnings"
-      }`,
-    );
-  }
-
-  return parts.join(", ");
-};
-
 const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [saveStatus, setSaveStatus] = useState<string>("");
+  const [saveState, setSaveState] = useState<WorkflowSaveState>(
+    WorkflowSaveState.Idle,
+  );
   const [saveTimeout, setSaveTimeout] = useState<ReturnType<
     typeof setTimeout
   > | null>(null);
@@ -97,6 +76,13 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
 
   const [lintResult, setLintResult] = useState<WorkflowLintResult | null>(null);
   const [showIssuesModal, setShowIssuesModal] = useState<boolean>(false);
+
+  /*
+   * The step the builder picked out of the issues list. The canvas owns the
+   * settings modal, so opening one from outside is a request it clears once it
+   * has acted on it.
+   */
+  const [stepToOpenNodeId, setStepToOpenNodeId] = useState<string | null>(null);
 
   /*
    * The run the builder started, followed until it settles. See
@@ -349,7 +335,7 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
     nodes: Array<Node>,
     edges: Array<Edge>,
   ): Promise<void> => {
-    setSaveStatus("Saving...");
+    setSaveState(WorkflowSaveState.Saving);
 
     if (saveTimeout) {
       clearTimeout(saveTimeout);
@@ -412,11 +398,11 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
             },
           });
 
-          setSaveStatus("Saved");
+          setSaveState(WorkflowSaveState.Saved);
         } catch (err) {
           setError(API.getFriendlyMessage(err));
 
-          setSaveStatus("Error saving");
+          setSaveState(WorkflowSaveState.Error);
         }
 
         if (saveTimeout) {
@@ -431,17 +417,11 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
     await loadGraph();
   }, []);
 
-  type GetSaveStatusColorFunction = () => string;
-
-  const getSaveStatusColor: GetSaveStatusColorFunction = (): string => {
-    if (saveStatus === "Saved") {
-      return "#10b981";
-    }
-    if (saveStatus === "Error saving") {
-      return "#ef4444";
-    }
-    return "#94a3b8";
-  };
+  /*
+   * The canvas names its own nodes, and the issues panel should call a step
+   * what the canvas calls it rather than only quoting the id it was given.
+   */
+  const stepTitlesByNodeId: Dictionary<string> = buildStepTitlesByNodeId(nodes);
 
   return (
     <Fragment>
@@ -460,71 +440,20 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
             boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.03)",
           }}
         >
-          <div
-            style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}
-          >
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "0.375rem",
-              }}
-            >
-              <div
-                style={{
-                  width: "7px",
-                  height: "7px",
-                  borderRadius: "50%",
-                  backgroundColor: getSaveStatusColor(),
-                  transition: "background-color 0.3s ease",
-                }}
-              />
-              <span
-                style={{
-                  fontSize: "0.75rem",
-                  color: getSaveStatusColor(),
-                  fontWeight: 500,
-                  transition: "color 0.3s ease",
-                }}
-              >
-                {saveStatus || "Ready"}
-              </span>
-            </div>
-
-            {/*
-              Static checks over the graph. Clicking opens the full list —
-              each node also carries its own badge on the canvas.
-            */}
-            {runWatchMessage && (
-              <span
-                style={{
-                  fontSize: "0.75rem",
-                  fontWeight: 500,
-                  color: runWatchFailed ? "#ef4444" : "#475569",
-                }}
-              >
-                {runWatchMessage}
-              </span>
-            )}
-
-            {lintResult && lintResult.issues.length > 0 && (
-              <button
-                type="button"
-                onClick={() => {
-                  setShowIssuesModal(true);
-                }}
-                style={{
-                  fontSize: "0.75rem",
-                  fontWeight: 500,
-                  cursor: "pointer",
-                  textDecoration: "underline",
-                  color: lintResult.errorCount > 0 ? "#ef4444" : "#f59e0b",
-                }}
-              >
-                {getIssueSummaryText(lintResult)}
-              </button>
-            )}
-          </div>
+          {/*
+            Save state, the run this builder started, and what the static
+            checks make of the graph. The checks are the clickable one — the
+            list they open is where a step's problems can be fixed.
+          */}
+          <WorkflowStatusBar
+            saveState={saveState}
+            lintResult={lintResult}
+            runStatusMessage={runWatchMessage}
+            runStatusFailed={runWatchFailed}
+            onShowIssues={() => {
+              setShowIssuesModal(true);
+            }}
+          />
 
           <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
             <Button
@@ -578,6 +507,10 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
               setShowRunModal(value);
             }}
             showRunModal={showRunModal}
+            openStepForNodeId={stepToOpenNodeId}
+            onStepOpened={() => {
+              setStepToOpenNodeId(null);
+            }}
             initialEdges={edges}
             onWorkflowUpdated={async (
               nodes: Array<Node>,
@@ -653,47 +586,21 @@ const Delete: FunctionComponent<PageComponentProps> = (): ReactElement => {
         )}
 
         {showIssuesModal && lintResult && (
-          <Modal
-            title="Problems with this workflow"
-            description="These are found by reading the workflow. Fixing them here saves a failed run later."
-            modalWidth={ModalWidth.Large}
-            submitButtonText="Close"
-            submitButtonStyleType={ButtonStyleType.NORMAL}
-            onSubmit={() => {
+          <WorkflowIssuesModal
+            lintResult={lintResult}
+            stepTitlesByNodeId={stepTitlesByNodeId}
+            onClose={() => {
               setShowIssuesModal(false);
             }}
-          >
-            <div className="space-y-2">
-              {lintResult.issues.map(
-                (issue: WorkflowLintIssue, i: number): ReactElement => {
-                  const isError: boolean =
-                    issue.severity === WorkflowLintSeverity.Error;
-
-                  return (
-                    <div
-                      key={i}
-                      className={`rounded-md border p-3 ${
-                        isError
-                          ? "border-red-200 bg-red-50"
-                          : "border-amber-200 bg-amber-50"
-                      }`}
-                    >
-                      <p
-                        className={`text-xs font-semibold uppercase tracking-wider ${
-                          isError ? "text-red-700" : "text-amber-700"
-                        }`}
-                      >
-                        {issue.componentId || "This workflow"}
-                      </p>
-                      <p className="text-sm text-gray-700 mt-1">
-                        {issue.message}
-                      </p>
-                    </div>
-                  );
-                },
-              )}
-            </div>
-          </Modal>
+            onGoToStep={(nodeId: string) => {
+              /*
+               * The settings modal the canvas is about to open would otherwise
+               * come up behind this one.
+               */
+              setShowIssuesModal(false);
+              setStepToOpenNodeId(nodeId);
+            }}
+          />
         )}
       </>
     </Fragment>

--- a/Common/Tests/UI/Components/Workflow/GraphLintSummary.test.ts
+++ b/Common/Tests/UI/Components/Workflow/GraphLintSummary.test.ts
@@ -1,0 +1,770 @@
+import {
+  LintGraphNode,
+  WorkflowLintIssue,
+  WorkflowLintResult,
+  WorkflowLintRule,
+  WorkflowLintSeverity,
+  lintWorkflowGraph,
+} from "../../../../UI/Components/Workflow/GraphLint";
+import {
+  OpenableGraphNode,
+  WORKFLOW_ISSUE_GRAPH_GROUP_KEY,
+  WORKFLOW_ISSUE_GRAPH_GROUP_TITLE,
+  WORKFLOW_ISSUE_UNTITLED_STEP_TITLE,
+  WorkflowIssueGroup,
+  WorkflowLintTone,
+  buildStepTitlesByNodeId,
+  findStepNodeToOpen,
+  getWorkflowLintCountText,
+  getWorkflowLintSeverityLabel,
+  getWorkflowLintStatusText,
+  getWorkflowLintTone,
+  groupWorkflowLintIssues,
+} from "../../../../UI/Components/Workflow/GraphLintSummary";
+import Dictionary from "../../../../Types/Dictionary";
+import IconProp from "../../../../Types/Icon/IconProp";
+import ComponentMetadata, {
+  Argument,
+  ComponentInputType,
+  ComponentType,
+  NodeType,
+} from "../../../../Types/Workflow/Component";
+import { describe, expect, test } from "@jest/globals";
+
+type MakeIssueFunction = (params: {
+  rule?: WorkflowLintRule | undefined;
+  severity?: WorkflowLintSeverity | undefined;
+  nodeId?: string | null | undefined;
+  componentId?: string | null | undefined;
+  argumentId?: string | null | undefined;
+  message?: string | undefined;
+}) => WorkflowLintIssue;
+
+const makeIssue: MakeIssueFunction = (params: {
+  rule?: WorkflowLintRule | undefined;
+  severity?: WorkflowLintSeverity | undefined;
+  nodeId?: string | null | undefined;
+  componentId?: string | null | undefined;
+  argumentId?: string | null | undefined;
+  message?: string | undefined;
+}): WorkflowLintIssue => {
+  return {
+    rule: params.rule || WorkflowLintRule.MissingRequiredArgument,
+    severity: params.severity || WorkflowLintSeverity.Error,
+    nodeId: params.nodeId === undefined ? "n1" : params.nodeId,
+    componentId:
+      params.componentId === undefined ? "api-get-1" : params.componentId,
+    argumentId: params.argumentId === undefined ? null : params.argumentId,
+    message: params.message || "Something is wrong.",
+  };
+};
+
+type MessagesOfFunction = (group: WorkflowIssueGroup) => Array<string>;
+
+const messagesOf: MessagesOfFunction = (
+  group: WorkflowIssueGroup,
+): Array<string> => {
+  return group.issues.map((issue: WorkflowLintIssue) => {
+    return issue.message;
+  });
+};
+
+describe("getWorkflowLintCountText", () => {
+  test("says nothing when there is nothing to report", () => {
+    expect(getWorkflowLintCountText({ errorCount: 0, warningCount: 0 })).toBe(
+      "",
+    );
+  });
+
+  test("counts one error in the singular", () => {
+    expect(getWorkflowLintCountText({ errorCount: 1, warningCount: 0 })).toBe(
+      "1 error",
+    );
+  });
+
+  test("counts several errors in the plural", () => {
+    expect(getWorkflowLintCountText({ errorCount: 4, warningCount: 0 })).toBe(
+      "4 errors",
+    );
+  });
+
+  test("counts one warning in the singular", () => {
+    expect(getWorkflowLintCountText({ errorCount: 0, warningCount: 1 })).toBe(
+      "1 warning",
+    );
+  });
+
+  test("counts several warnings in the plural", () => {
+    expect(getWorkflowLintCountText({ errorCount: 0, warningCount: 3 })).toBe(
+      "3 warnings",
+    );
+  });
+
+  test("puts errors before warnings when there are both", () => {
+    expect(getWorkflowLintCountText({ errorCount: 2, warningCount: 1 })).toBe(
+      "2 errors, 1 warning",
+    );
+  });
+});
+
+describe("getWorkflowLintStatusText", () => {
+  test("has something to say when there is nothing wrong", () => {
+    expect(getWorkflowLintStatusText({ errorCount: 0, warningCount: 0 })).toBe(
+      "No problems",
+    );
+  });
+
+  test("falls through to the counts when there is something wrong", () => {
+    expect(getWorkflowLintStatusText({ errorCount: 1, warningCount: 2 })).toBe(
+      "1 error, 2 warnings",
+    );
+  });
+});
+
+describe("getWorkflowLintTone", () => {
+  test("a clean graph is clean", () => {
+    expect(getWorkflowLintTone({ errorCount: 0, warningCount: 0 })).toBe(
+      WorkflowLintTone.Clean,
+    );
+  });
+
+  test("warnings alone are a warning", () => {
+    expect(getWorkflowLintTone({ errorCount: 0, warningCount: 2 })).toBe(
+      WorkflowLintTone.Warning,
+    );
+  });
+
+  test("one error outranks any number of warnings", () => {
+    expect(getWorkflowLintTone({ errorCount: 1, warningCount: 9 })).toBe(
+      WorkflowLintTone.Error,
+    );
+  });
+});
+
+describe("getWorkflowLintSeverityLabel", () => {
+  test("names both severities", () => {
+    expect(getWorkflowLintSeverityLabel(WorkflowLintSeverity.Error)).toBe(
+      "Error",
+    );
+    expect(getWorkflowLintSeverityLabel(WorkflowLintSeverity.Warning)).toBe(
+      "Warning",
+    );
+  });
+});
+
+describe("buildStepTitlesByNodeId", () => {
+  test("keys the title the canvas shows by react-flow node id", () => {
+    const titles: Dictionary<string> = buildStepTitlesByNodeId([
+      { id: "n1", data: { metadata: { title: "Send to Slack" } } },
+      { id: "n2", data: { metadata: { title: "Create Monitor Secret" } } },
+    ]);
+
+    expect(titles).toEqual({
+      n1: "Send to Slack",
+      n2: "Create Monitor Secret",
+    });
+  });
+
+  test("skips nodes with nothing usable to show", () => {
+    const titles: Dictionary<string> = buildStepTitlesByNodeId([
+      { id: "n1" },
+      { id: "n2", data: {} },
+      { id: "n3", data: { metadata: {} } },
+      { id: "n4", data: { metadata: { title: "" } } },
+      { id: "n5", data: { metadata: { title: "   " } } },
+    ]);
+
+    expect(titles).toEqual({});
+  });
+
+  test("trims whitespace around a title", () => {
+    const titles: Dictionary<string> = buildStepTitlesByNodeId([
+      { id: "n1", data: { metadata: { title: "  Send to Slack  " } } },
+    ]);
+
+    expect(titles["n1"]).toBe("Send to Slack");
+  });
+
+  test("survives an empty graph and missing ids", () => {
+    expect(buildStepTitlesByNodeId([])).toEqual({});
+    expect(
+      buildStepTitlesByNodeId([
+        { id: "", data: { metadata: { title: "Nameless" } } },
+      ]),
+    ).toEqual({});
+  });
+});
+
+describe("findStepNodeToOpen", () => {
+  const step: OpenableGraphNode = {
+    id: "n1",
+    data: { nodeType: NodeType.Node },
+  };
+  const placeholder: OpenableGraphNode = {
+    id: "n2",
+    data: { nodeType: NodeType.PlaceholderNode },
+  };
+
+  test("finds the step by react-flow node id", () => {
+    expect(
+      findStepNodeToOpen({ nodes: [placeholder, step], nodeId: "n1" }),
+    ).toBe(step);
+  });
+
+  test("opens nothing when nothing was asked for", () => {
+    expect(findStepNodeToOpen({ nodes: [step], nodeId: null })).toBeNull();
+    expect(findStepNodeToOpen({ nodes: [step], nodeId: undefined })).toBeNull();
+    expect(findStepNodeToOpen({ nodes: [step], nodeId: "" })).toBeNull();
+  });
+
+  test("opens nothing when the step has been deleted since", () => {
+    expect(findStepNodeToOpen({ nodes: [step], nodeId: "gone" })).toBeNull();
+    expect(findStepNodeToOpen({ nodes: [], nodeId: "n1" })).toBeNull();
+  });
+
+  test("a placeholder is not a step — it has no settings to open", () => {
+    expect(
+      findStepNodeToOpen({ nodes: [placeholder], nodeId: "n2" }),
+    ).toBeNull();
+  });
+
+  test("a node with no data at all is still openable", () => {
+    /*
+     * Node data is what the canvas hands back, so this only happens to an
+     * imported graph — better to open it and show what is there than to
+     * silently do nothing when the builder clicked.
+     */
+    const bare: OpenableGraphNode = { id: "n3" };
+
+    expect(findStepNodeToOpen({ nodes: [bare], nodeId: "n3" })).toBe(bare);
+  });
+});
+
+describe("groupWorkflowLintIssues — grouping", () => {
+  test("an empty list produces no groups", () => {
+    expect(groupWorkflowLintIssues({ issues: [] })).toEqual([]);
+  });
+
+  test("issues about the same node land in one group", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({ nodeId: "n1", message: "First problem." }),
+        makeIssue({ nodeId: "n1", message: "Second problem." }),
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(messagesOf(groups[0] as WorkflowIssueGroup)).toEqual([
+      "First problem.",
+      "Second problem.",
+    ]);
+  });
+
+  test("issues about different nodes stay apart", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({ nodeId: "n1", componentId: "api-get-1" }),
+        makeIssue({ nodeId: "n2", componentId: "api-post-1" }),
+      ],
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]?.nodeId).toBe("n1");
+    expect(groups[1]?.nodeId).toBe("n2");
+  });
+
+  test("two steps that share a component id still group by node", () => {
+    /*
+     * A duplicate id is itself something the lint reports, so the panel has to
+     * keep telling the two steps apart while the builder fixes it.
+     */
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({ nodeId: "n1", componentId: "api-get-1" }),
+        makeIssue({ nodeId: "n2", componentId: "api-get-1" }),
+      ],
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]?.key).not.toBe(groups[1]?.key);
+  });
+
+  test("issues about the graph itself group under the workflow", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({
+          rule: WorkflowLintRule.NoTrigger,
+          nodeId: null,
+          componentId: null,
+          message: "This workflow has no trigger.",
+        }),
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.key).toBe(WORKFLOW_ISSUE_GRAPH_GROUP_KEY);
+    expect(groups[0]?.title).toBe(WORKFLOW_ISSUE_GRAPH_GROUP_TITLE);
+    expect(groups[0]?.nodeId).toBeNull();
+    expect(groups[0]?.componentId).toBeNull();
+  });
+
+  test("an issue naming a step but no node groups with that step", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({ nodeId: null, componentId: "api-get-1", message: "One." }),
+        makeIssue({ nodeId: null, componentId: "api-get-1", message: "Two." }),
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.key).not.toBe(WORKFLOW_ISSUE_GRAPH_GROUP_KEY);
+    expect(groups[0]?.title).toBe("api-get-1");
+    expect(groups[0]?.issues).toHaveLength(2);
+  });
+
+  test("ignores holes in the issue list", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({ nodeId: "n1" }),
+        null as unknown as WorkflowLintIssue,
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.issues).toHaveLength(1);
+  });
+});
+
+describe("groupWorkflowLintIssues — titles", () => {
+  test("uses the title the canvas shows for the step", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [makeIssue({ nodeId: "n1", componentId: "api-get-1" })],
+      stepTitlesByNodeId: { n1: "Make API Request" },
+    });
+
+    expect(groups[0]?.title).toBe("Make API Request");
+    expect(groups[0]?.componentId).toBe("api-get-1");
+  });
+
+  test("falls back to the step id when the node has no title", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [makeIssue({ nodeId: "n1", componentId: "api-get-1" })],
+      stepTitlesByNodeId: {},
+    });
+
+    expect(groups[0]?.title).toBe("api-get-1");
+  });
+
+  test("falls back again when the step has no id either", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [makeIssue({ nodeId: "n1", componentId: null })],
+    });
+
+    expect(groups[0]?.title).toBe(WORKFLOW_ISSUE_UNTITLED_STEP_TITLE);
+  });
+
+  test("takes the title from the first issue seen for a node", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({ nodeId: "n1", componentId: "api-get-1" }),
+        makeIssue({ nodeId: "n1", componentId: "api-get-1" }),
+      ],
+      stepTitlesByNodeId: { n1: "Make API Request" },
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.title).toBe("Make API Request");
+  });
+});
+
+describe("groupWorkflowLintIssues — counting", () => {
+  test("counts each severity within a group", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({
+          nodeId: "n1",
+          severity: WorkflowLintSeverity.Error,
+          message: "One.",
+        }),
+        makeIssue({
+          nodeId: "n1",
+          severity: WorkflowLintSeverity.Error,
+          message: "Two.",
+        }),
+        makeIssue({
+          nodeId: "n1",
+          severity: WorkflowLintSeverity.Warning,
+          message: "Three.",
+        }),
+      ],
+    });
+
+    expect(groups[0]?.errorCount).toBe(2);
+    expect(groups[0]?.warningCount).toBe(1);
+  });
+
+  test("a deduplicated issue is not counted twice", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({ nodeId: "n1", message: "Same thing." }),
+        makeIssue({ nodeId: "n1", message: "Same thing." }),
+      ],
+    });
+
+    expect(groups[0]?.issues).toHaveLength(1);
+    expect(groups[0]?.errorCount).toBe(1);
+  });
+
+  test("group counts add up to the whole list", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({ nodeId: "n1", message: "A." }),
+        makeIssue({
+          nodeId: "n2",
+          severity: WorkflowLintSeverity.Warning,
+          message: "B.",
+        }),
+        makeIssue({ nodeId: null, componentId: null, message: "C." }),
+      ],
+    });
+
+    const totalErrors: number = groups.reduce(
+      (total: number, group: WorkflowIssueGroup) => {
+        return total + group.errorCount;
+      },
+      0,
+    );
+    const totalWarnings: number = groups.reduce(
+      (total: number, group: WorkflowIssueGroup) => {
+        return total + group.warningCount;
+      },
+      0,
+    );
+
+    expect(totalErrors).toBe(2);
+    expect(totalWarnings).toBe(1);
+  });
+});
+
+describe("groupWorkflowLintIssues — deduplication", () => {
+  test("drops an identical message repeated for the same step", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({ nodeId: "n1", message: '"URL" is required but empty.' }),
+        makeIssue({ nodeId: "n1", message: '"URL" is required but empty.' }),
+      ],
+    });
+
+    expect(messagesOf(groups[0] as WorkflowIssueGroup)).toEqual([
+      '"URL" is required but empty.',
+    ]);
+  });
+
+  test("keeps the same message when it is reported at a different severity", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({
+          nodeId: "n1",
+          severity: WorkflowLintSeverity.Error,
+          message: "Same words.",
+        }),
+        makeIssue({
+          nodeId: "n1",
+          severity: WorkflowLintSeverity.Warning,
+          message: "Same words.",
+        }),
+      ],
+    });
+
+    expect(groups[0]?.issues).toHaveLength(2);
+  });
+
+  test("keeps the same message when it belongs to a different step", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({ nodeId: "n1", message: "Same words." }),
+        makeIssue({ nodeId: "n2", message: "Same words." }),
+      ],
+    });
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]?.issues).toHaveLength(1);
+    expect(groups[1]?.issues).toHaveLength(1);
+  });
+});
+
+describe("groupWorkflowLintIssues — ordering", () => {
+  test("errors come before warnings inside a group", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({
+          nodeId: "n1",
+          severity: WorkflowLintSeverity.Warning,
+          message: "A warning.",
+        }),
+        makeIssue({
+          nodeId: "n1",
+          severity: WorkflowLintSeverity.Error,
+          message: "An error.",
+        }),
+      ],
+    });
+
+    expect(messagesOf(groups[0] as WorkflowIssueGroup)).toEqual([
+      "An error.",
+      "A warning.",
+    ]);
+  });
+
+  test("issues of one severity keep the order the checks found them in", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({ nodeId: "n1", message: "First." }),
+        makeIssue({ nodeId: "n1", message: "Second." }),
+        makeIssue({ nodeId: "n1", message: "Third." }),
+      ],
+    });
+
+    expect(messagesOf(groups[0] as WorkflowIssueGroup)).toEqual([
+      "First.",
+      "Second.",
+      "Third.",
+    ]);
+  });
+
+  test("the graph's own issues lead, even when a step has errors and it does not", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({ nodeId: "n1", message: "A step error." }),
+        makeIssue({
+          nodeId: null,
+          componentId: null,
+          severity: WorkflowLintSeverity.Warning,
+          message: "A graph warning.",
+        }),
+      ],
+    });
+
+    expect(groups[0]?.key).toBe(WORKFLOW_ISSUE_GRAPH_GROUP_KEY);
+    expect(groups[1]?.nodeId).toBe("n1");
+  });
+
+  test("steps with errors come before steps with only warnings", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({
+          nodeId: "n1",
+          severity: WorkflowLintSeverity.Warning,
+          message: "Only a warning.",
+        }),
+        makeIssue({
+          nodeId: "n2",
+          severity: WorkflowLintSeverity.Error,
+          message: "An error.",
+        }),
+      ],
+    });
+
+    expect(groups[0]?.nodeId).toBe("n2");
+    expect(groups[1]?.nodeId).toBe("n1");
+  });
+
+  test("steps of equal weight keep the order the checks found them in", () => {
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: [
+        makeIssue({ nodeId: "n3", message: "Third." }),
+        makeIssue({ nodeId: "n1", message: "First." }),
+        makeIssue({ nodeId: "n2", message: "Second." }),
+      ],
+    });
+
+    expect(
+      groups.map((group: WorkflowIssueGroup) => {
+        return group.nodeId;
+      }),
+    ).toEqual(["n3", "n1", "n2"]);
+  });
+
+  test("does not mutate the list it was given", () => {
+    const issues: Array<WorkflowLintIssue> = [
+      makeIssue({
+        nodeId: "n1",
+        severity: WorkflowLintSeverity.Warning,
+        message: "A warning.",
+      }),
+      makeIssue({
+        nodeId: "n1",
+        severity: WorkflowLintSeverity.Error,
+        message: "An error.",
+      }),
+    ];
+
+    groupWorkflowLintIssues({ issues: issues });
+
+    expect(
+      issues.map((issue: WorkflowLintIssue) => {
+        return issue.message;
+      }),
+    ).toEqual(["A warning.", "An error."]);
+  });
+});
+
+/*
+ * The panel is fed by lintWorkflowGraph, so the interesting case is a real
+ * graph rather than a hand-written issue list: the screenshot that started
+ * this work showed one step reported twice, once as unreachable and once for
+ * an empty required field.
+ */
+describe("groupWorkflowLintIssues — over a real linted graph", () => {
+  const jsonArgument: Argument = {
+    id: "json",
+    name: "JSON Object",
+    description: "The object to create",
+    type: ComponentInputType.JSON,
+    required: true,
+  };
+
+  type MakeMetadataFunction = (params: {
+    title: string;
+    componentType: ComponentType;
+    args: Array<Argument>;
+  }) => ComponentMetadata;
+
+  const makeMetadata: MakeMetadataFunction = (params: {
+    title: string;
+    componentType: ComponentType;
+    args: Array<Argument>;
+  }): ComponentMetadata => {
+    return {
+      id: params.title,
+      title: params.title,
+      category: "Test",
+      description: "A test component",
+      iconProp: IconProp.Bolt,
+      componentType: params.componentType,
+      arguments: params.args,
+      returnValues: [],
+      inPorts: [],
+      outPorts: [],
+    };
+  };
+
+  type MakeNodeFunction = (params: {
+    nodeId: string;
+    componentId: string;
+    title: string;
+    componentType?: ComponentType | undefined;
+    args?: Array<Argument> | undefined;
+  }) => LintGraphNode;
+
+  const makeNode: MakeNodeFunction = (params: {
+    nodeId: string;
+    componentId: string;
+    title: string;
+    componentType?: ComponentType | undefined;
+    args?: Array<Argument> | undefined;
+  }): LintGraphNode => {
+    const componentType: ComponentType =
+      params.componentType || ComponentType.Component;
+
+    return {
+      id: params.nodeId,
+      data: {
+        error: "",
+        id: params.componentId,
+        nodeType: NodeType.Node,
+        metadata: makeMetadata({
+          title: params.title,
+          componentType: componentType,
+          args: params.args || [],
+        }),
+        metadataId: `${params.componentId}-metadata`,
+        internalId: `${params.nodeId}-internal`,
+        arguments: {},
+        returnValues: {},
+        componentType: componentType,
+      },
+    };
+  };
+
+  test("a step that is both unreachable and unconfigured becomes one group", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [
+        makeNode({
+          nodeId: "n1",
+          componentId: "manual-1",
+          title: "Manual Trigger",
+          componentType: ComponentType.Trigger,
+        }),
+        makeNode({
+          nodeId: "n2",
+          componentId: "monitor-secret-create-one-1",
+          title: "Create Monitor Secret",
+          args: [jsonArgument],
+        }),
+      ],
+      edges: [],
+    });
+
+    expect(result.errorCount).toBe(1);
+    expect(result.warningCount).toBe(1);
+
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: result.issues,
+      stepTitlesByNodeId: buildStepTitlesByNodeId([
+        { id: "n1", data: { metadata: { title: "Manual Trigger" } } },
+        { id: "n2", data: { metadata: { title: "Create Monitor Secret" } } },
+      ]),
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.title).toBe("Create Monitor Secret");
+    expect(groups[0]?.componentId).toBe("monitor-secret-create-one-1");
+    expect(groups[0]?.errorCount).toBe(1);
+    expect(groups[0]?.warningCount).toBe(1);
+    expect(messagesOf(groups[0] as WorkflowIssueGroup)).toEqual([
+      '"JSON Object" is required but empty.',
+      "Nothing connects to this step from the trigger, so it will never run.",
+    ]);
+  });
+
+  test("a graph-wide problem leads the list ahead of the steps", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [
+        makeNode({
+          nodeId: "n1",
+          componentId: "api-post-1",
+          title: "Make API Request",
+          args: [jsonArgument],
+        }),
+      ],
+      edges: [],
+    });
+
+    const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+      issues: result.issues,
+    });
+
+    expect(groups[0]?.key).toBe(WORKFLOW_ISSUE_GRAPH_GROUP_KEY);
+    expect(groups[0]?.issues[0]?.rule).toBe(WorkflowLintRule.NoTrigger);
+    expect(groups[1]?.componentId).toBe("api-post-1");
+  });
+
+  test("a clean graph gives the panel nothing to show", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph({
+      nodes: [
+        makeNode({
+          nodeId: "n1",
+          componentId: "manual-1",
+          title: "Manual Trigger",
+          componentType: ComponentType.Trigger,
+        }),
+      ],
+      edges: [],
+    });
+
+    expect(groupWorkflowLintIssues({ issues: result.issues })).toEqual([]);
+    expect(getWorkflowLintTone(result)).toBe(WorkflowLintTone.Clean);
+    expect(getWorkflowLintStatusText(result)).toBe("No problems");
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/WorkflowIssuesModal.test.tsx
+++ b/Common/Tests/UI/Components/Workflow/WorkflowIssuesModal.test.tsx
@@ -1,0 +1,485 @@
+import {
+  WorkflowLintIssue,
+  WorkflowLintResult,
+  WorkflowLintRule,
+  WorkflowLintSeverity,
+} from "../../../../UI/Components/Workflow/GraphLint";
+import WorkflowIssuesModal from "../../../../UI/Components/Workflow/WorkflowIssuesModal";
+import { describe, expect, test } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { fireEvent, render, RenderResult } from "@testing-library/react";
+import React from "react";
+import getJestMockFunction, { MockFunction } from "../../../MockType";
+
+type MakeIssueFunction = (params: {
+  rule?: WorkflowLintRule | undefined;
+  severity?: WorkflowLintSeverity | undefined;
+  nodeId?: string | null | undefined;
+  componentId?: string | null | undefined;
+  message?: string | undefined;
+}) => WorkflowLintIssue;
+
+const makeIssue: MakeIssueFunction = (params: {
+  rule?: WorkflowLintRule | undefined;
+  severity?: WorkflowLintSeverity | undefined;
+  nodeId?: string | null | undefined;
+  componentId?: string | null | undefined;
+  message?: string | undefined;
+}): WorkflowLintIssue => {
+  return {
+    rule: params.rule || WorkflowLintRule.MissingRequiredArgument,
+    severity: params.severity || WorkflowLintSeverity.Error,
+    nodeId: params.nodeId === undefined ? "n1" : params.nodeId,
+    componentId:
+      params.componentId === undefined ? "api-get-1" : params.componentId,
+    argumentId: null,
+    message: params.message || "Something is wrong.",
+  };
+};
+
+type MakeLintResultFunction = (
+  issues: Array<WorkflowLintIssue>,
+) => WorkflowLintResult;
+
+const makeLintResult: MakeLintResultFunction = (
+  issues: Array<WorkflowLintIssue>,
+): WorkflowLintResult => {
+  return {
+    issues: issues,
+    errorsByNodeId: {},
+    errorCount: issues.filter((issue: WorkflowLintIssue) => {
+      return issue.severity === WorkflowLintSeverity.Error;
+    }).length,
+    warningCount: issues.filter((issue: WorkflowLintIssue) => {
+      return issue.severity === WorkflowLintSeverity.Warning;
+    }).length,
+  };
+};
+
+type NoopFunction = () => void;
+
+const noop: NoopFunction = (): void => {};
+
+describe("WorkflowIssuesModal — the panel itself", () => {
+  test("keeps the title and the sentence explaining why the list exists", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([makeIssue({})])}
+        onClose={noop}
+      />,
+    );
+
+    expect(getByTestId("modal-title")).toHaveTextContent(
+      "Problems with this workflow",
+    );
+    expect(getByTestId("modal-description")).toHaveTextContent(
+      "Fixing them here saves a failed run later.",
+    );
+  });
+
+  test("closes from the footer button", () => {
+    const onClose: MockFunction = getJestMockFunction();
+
+    const { getByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([makeIssue({})])}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(getByTestId("modal-footer-close-button"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("closes from the header button, which the old panel did not have", () => {
+    const onClose: MockFunction = getJestMockFunction();
+
+    const { getByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([makeIssue({})])}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(getByTestId("close-button"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("WorkflowIssuesModal — nothing to show", () => {
+  test("says so rather than showing an empty box", () => {
+    const { getByTestId, queryAllByTestId }: RenderResult = render(
+      <WorkflowIssuesModal lintResult={makeLintResult([])} onClose={noop} />,
+    );
+
+    expect(getByTestId("workflow-issues-empty")).toHaveTextContent(
+      "Nothing to fix here",
+    );
+    expect(queryAllByTestId("workflow-issue-group")).toHaveLength(0);
+  });
+
+  test("shows no counts when there is nothing to count", () => {
+    const { queryByTestId }: RenderResult = render(
+      <WorkflowIssuesModal lintResult={makeLintResult([])} onClose={noop} />,
+    );
+
+    expect(queryByTestId("workflow-issues-summary")).not.toBeInTheDocument();
+  });
+});
+
+describe("WorkflowIssuesModal — grouping", () => {
+  test("a step reported twice is one card, not two", () => {
+    const { queryAllByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({
+            nodeId: "n1",
+            componentId: "monitor-secret-create-one-1",
+            severity: WorkflowLintSeverity.Warning,
+            message:
+              "Nothing connects to this step from the trigger, so it will never run.",
+          }),
+          makeIssue({
+            nodeId: "n1",
+            componentId: "monitor-secret-create-one-1",
+            message: '"JSON Object" is required but empty.',
+          }),
+        ])}
+        onClose={noop}
+      />,
+    );
+
+    expect(queryAllByTestId("workflow-issue-group")).toHaveLength(1);
+    expect(queryAllByTestId("workflow-issue")).toHaveLength(2);
+  });
+
+  test("different steps get a card each", () => {
+    const { queryAllByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({ nodeId: "n1", componentId: "api-get-1" }),
+          makeIssue({ nodeId: "n2", componentId: "api-post-1" }),
+        ])}
+        onClose={noop}
+      />,
+    );
+
+    expect(queryAllByTestId("workflow-issue-group")).toHaveLength(2);
+  });
+
+  test("heads a card with the step's name and its id underneath", () => {
+    const { getByText }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({
+            nodeId: "n1",
+            componentId: "monitor-secret-create-one-1",
+          }),
+        ])}
+        stepTitlesByNodeId={{ n1: "Create Monitor Secret" }}
+        onClose={noop}
+      />,
+    );
+
+    expect(getByText("Create Monitor Secret")).toBeInTheDocument();
+    expect(getByText("monitor-secret-create-one-1")).toBeInTheDocument();
+  });
+
+  test("does not print the step id twice when it is all the card has to go on", () => {
+    const { queryAllByText }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({ nodeId: "n1", componentId: "api-get-1" }),
+        ])}
+        onClose={noop}
+      />,
+    );
+
+    expect(queryAllByText("api-get-1")).toHaveLength(1);
+  });
+
+  test("issues about the graph itself are headed as the workflow", () => {
+    const { getByText }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({
+            rule: WorkflowLintRule.NoTrigger,
+            nodeId: null,
+            componentId: null,
+            message: "This workflow has no trigger, so it can never start.",
+          }),
+        ])}
+        onClose={noop}
+      />,
+    );
+
+    expect(getByText("This workflow")).toBeInTheDocument();
+  });
+
+  test("shows every message the checks produced", () => {
+    const { getByText }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({ nodeId: "n1", message: "First problem." }),
+          makeIssue({ nodeId: "n2", message: "Second problem." }),
+        ])}
+        onClose={noop}
+      />,
+    );
+
+    expect(getByText("First problem.")).toBeInTheDocument();
+    expect(getByText("Second problem.")).toBeInTheDocument();
+  });
+});
+
+describe("WorkflowIssuesModal — counts", () => {
+  test("totals the whole list at the top", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({ nodeId: "n1", message: "One." }),
+          makeIssue({ nodeId: "n2", message: "Two." }),
+          makeIssue({
+            nodeId: "n2",
+            severity: WorkflowLintSeverity.Warning,
+            message: "Three.",
+          }),
+        ])}
+        onClose={noop}
+      />,
+    );
+
+    expect(getByTestId("workflow-issues-error-count")).toHaveTextContent(
+      "2 errors",
+    );
+    expect(getByTestId("workflow-issues-warning-count")).toHaveTextContent(
+      "1 warning",
+    );
+    expect(getByTestId("workflow-issues-summary")).toHaveTextContent(
+      "across 2 places",
+    );
+  });
+
+  test("says one place in the singular", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([makeIssue({ nodeId: "n1" })])}
+        onClose={noop}
+      />,
+    );
+
+    expect(getByTestId("workflow-issues-summary")).toHaveTextContent(
+      "across 1 place",
+    );
+  });
+
+  test("leaves out a count of zero", () => {
+    const { getByTestId, queryByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({ severity: WorkflowLintSeverity.Warning }),
+        ])}
+        onClose={noop}
+      />,
+    );
+
+    expect(
+      queryByTestId("workflow-issues-error-count"),
+    ).not.toBeInTheDocument();
+    expect(getByTestId("workflow-issues-warning-count")).toHaveTextContent(
+      "1 warning",
+    );
+  });
+
+  test("counts each card as well as the whole list", () => {
+    const { getAllByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({ nodeId: "n1", message: "One." }),
+          makeIssue({ nodeId: "n1", message: "Two." }),
+          makeIssue({
+            nodeId: "n1",
+            severity: WorkflowLintSeverity.Warning,
+            message: "Three.",
+          }),
+        ])}
+        onClose={noop}
+      />,
+    );
+
+    expect(
+      getAllByTestId("workflow-issue-group-error-count")[0],
+    ).toHaveTextContent("2 errors");
+    expect(
+      getAllByTestId("workflow-issue-group-warning-count")[0],
+    ).toHaveTextContent("1 warning");
+  });
+});
+
+describe("WorkflowIssuesModal — severity", () => {
+  test("marks an error and a warning differently", () => {
+    const { queryAllByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({ nodeId: "n1", message: "An error." }),
+          makeIssue({
+            nodeId: "n1",
+            severity: WorkflowLintSeverity.Warning,
+            message: "A warning.",
+          }),
+        ])}
+        onClose={noop}
+      />,
+    );
+
+    expect(queryAllByTestId("workflow-issue-error-icon")).toHaveLength(1);
+    expect(queryAllByTestId("workflow-issue-warning-icon")).toHaveLength(1);
+  });
+
+  test("says the severity in words, so it does not rest on colour alone", () => {
+    const { getByText }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({ nodeId: "n1", message: "An error." }),
+          makeIssue({
+            nodeId: "n1",
+            severity: WorkflowLintSeverity.Warning,
+            message: "A warning.",
+          }),
+        ])}
+        onClose={noop}
+      />,
+    );
+
+    expect(getByText(/^Error:/)).toBeInTheDocument();
+    expect(getByText(/^Warning:/)).toBeInTheDocument();
+  });
+
+  test("puts errors above warnings inside a card", () => {
+    const { getAllByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({
+            nodeId: "n1",
+            severity: WorkflowLintSeverity.Warning,
+            message: "A warning.",
+          }),
+          makeIssue({ nodeId: "n1", message: "An error." }),
+        ])}
+        onClose={noop}
+      />,
+    );
+
+    const issues: Array<HTMLElement> = getAllByTestId("workflow-issue");
+
+    expect(issues[0]).toHaveTextContent("An error.");
+    expect(issues[1]).toHaveTextContent("A warning.");
+  });
+
+  test("puts the workflow's own problems above the steps", () => {
+    const { getAllByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({ nodeId: "n1", message: "A step problem." }),
+          makeIssue({
+            rule: WorkflowLintRule.NoTrigger,
+            nodeId: null,
+            componentId: null,
+            message: "This workflow has no trigger.",
+          }),
+        ])}
+        onClose={noop}
+      />,
+    );
+
+    const groups: Array<HTMLElement> = getAllByTestId("workflow-issue-group");
+
+    expect(groups[0]).toHaveTextContent("This workflow has no trigger.");
+    expect(groups[1]).toHaveTextContent("A step problem.");
+  });
+});
+
+describe("WorkflowIssuesModal — getting to the step", () => {
+  test("offers to open the step the issues belong to", () => {
+    const onGoToStep: MockFunction = getJestMockFunction();
+
+    const { getByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({ nodeId: "n1", componentId: "api-get-1" }),
+        ])}
+        stepTitlesByNodeId={{ n1: "Make API Request" }}
+        onClose={noop}
+        onGoToStep={onGoToStep}
+      />,
+    );
+
+    fireEvent.click(getByTestId("workflow-issue-go-to-step"));
+
+    expect(onGoToStep).toHaveBeenCalledTimes(1);
+    expect(onGoToStep).toHaveBeenCalledWith("n1");
+  });
+
+  test("names the step it would open", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([makeIssue({ nodeId: "n1" })])}
+        stepTitlesByNodeId={{ n1: "Make API Request" }}
+        onClose={noop}
+        onGoToStep={getJestMockFunction()}
+      />,
+    );
+
+    expect(getByTestId("workflow-issue-go-to-step")).toHaveAttribute(
+      "aria-label",
+      "Open settings for Make API Request",
+    );
+  });
+
+  test("offers nothing for a problem with the workflow itself — there is no step to open", () => {
+    const { queryByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({
+            rule: WorkflowLintRule.NoTrigger,
+            nodeId: null,
+            componentId: null,
+            message: "This workflow has no trigger.",
+          }),
+        ])}
+        onClose={noop}
+        onGoToStep={getJestMockFunction()}
+      />,
+    );
+
+    expect(queryByTestId("workflow-issue-go-to-step")).not.toBeInTheDocument();
+  });
+
+  test("offers nothing when the page cannot open steps", () => {
+    const { queryByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([makeIssue({ nodeId: "n1" })])}
+        onClose={noop}
+      />,
+    );
+
+    expect(queryByTestId("workflow-issue-go-to-step")).not.toBeInTheDocument();
+  });
+
+  test("offers one per card when several steps have problems", () => {
+    const { getAllByTestId }: RenderResult = render(
+      <WorkflowIssuesModal
+        lintResult={makeLintResult([
+          makeIssue({ nodeId: "n1", componentId: "api-get-1" }),
+          makeIssue({ nodeId: "n2", componentId: "api-post-1" }),
+        ])}
+        onClose={noop}
+        onGoToStep={getJestMockFunction()}
+      />,
+    );
+
+    expect(getAllByTestId("workflow-issue-go-to-step")).toHaveLength(2);
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/WorkflowStatusBar.test.tsx
+++ b/Common/Tests/UI/Components/Workflow/WorkflowStatusBar.test.tsx
@@ -1,0 +1,288 @@
+import {
+  WorkflowLintIssue,
+  WorkflowLintResult,
+  WorkflowLintRule,
+  WorkflowLintSeverity,
+} from "../../../../UI/Components/Workflow/GraphLint";
+import WorkflowStatusBar, {
+  WorkflowSaveState,
+  getWorkflowSaveStatePresentation,
+} from "../../../../UI/Components/Workflow/WorkflowStatusBar";
+import { describe, expect, test } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { fireEvent, render, RenderResult } from "@testing-library/react";
+import React from "react";
+import getJestMockFunction, { MockFunction } from "../../../MockType";
+
+type MakeIssueFunction = (
+  severity: WorkflowLintSeverity,
+  message: string,
+) => WorkflowLintIssue;
+
+const makeIssue: MakeIssueFunction = (
+  severity: WorkflowLintSeverity,
+  message: string,
+): WorkflowLintIssue => {
+  return {
+    rule: WorkflowLintRule.MissingRequiredArgument,
+    severity: severity,
+    nodeId: "n1",
+    componentId: "api-get-1",
+    argumentId: null,
+    message: message,
+  };
+};
+
+type MakeLintResultFunction = (
+  issues: Array<WorkflowLintIssue>,
+) => WorkflowLintResult;
+
+const makeLintResult: MakeLintResultFunction = (
+  issues: Array<WorkflowLintIssue>,
+): WorkflowLintResult => {
+  return {
+    issues: issues,
+    errorsByNodeId: {},
+    errorCount: issues.filter((issue: WorkflowLintIssue) => {
+      return issue.severity === WorkflowLintSeverity.Error;
+    }).length,
+    warningCount: issues.filter((issue: WorkflowLintIssue) => {
+      return issue.severity === WorkflowLintSeverity.Warning;
+    }).length,
+  };
+};
+
+const CLEAN_RESULT: WorkflowLintResult = makeLintResult([]);
+
+describe("getWorkflowSaveStatePresentation", () => {
+  test("an untouched draft is ready rather than saved", () => {
+    expect(getWorkflowSaveStatePresentation(WorkflowSaveState.Idle).label).toBe(
+      "Ready",
+    );
+  });
+
+  test("names each of the other states", () => {
+    expect(
+      getWorkflowSaveStatePresentation(WorkflowSaveState.Saving).label,
+    ).toBe("Saving…");
+    expect(
+      getWorkflowSaveStatePresentation(WorkflowSaveState.Saved).label,
+    ).toBe("Saved");
+    expect(
+      getWorkflowSaveStatePresentation(WorkflowSaveState.Error).label,
+    ).toBe("Could not save");
+  });
+
+  test("a failed save is the only red one", () => {
+    expect(
+      getWorkflowSaveStatePresentation(WorkflowSaveState.Error).dotClassName,
+    ).toContain("red");
+    expect(
+      getWorkflowSaveStatePresentation(WorkflowSaveState.Saved).dotClassName,
+    ).not.toContain("red");
+    expect(
+      getWorkflowSaveStatePresentation(WorkflowSaveState.Idle).dotClassName,
+    ).not.toContain("red");
+  });
+});
+
+describe("WorkflowStatusBar — save state", () => {
+  test("shows the save state", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowStatusBar saveState={WorkflowSaveState.Saved} />,
+    );
+
+    expect(getByTestId("workflow-save-status")).toHaveTextContent("Saved");
+  });
+
+  test("shows a save that failed", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowStatusBar saveState={WorkflowSaveState.Error} />,
+    );
+
+    expect(getByTestId("workflow-save-status")).toHaveTextContent(
+      "Could not save",
+    );
+  });
+});
+
+describe("WorkflowStatusBar — the run it started", () => {
+  test("says nothing when no run is being watched", () => {
+    const { queryByTestId }: RenderResult = render(
+      <WorkflowStatusBar saveState={WorkflowSaveState.Saved} />,
+    );
+
+    expect(queryByTestId("workflow-run-status")).not.toBeInTheDocument();
+  });
+
+  test("shows what the run is doing", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowStatusBar
+        saveState={WorkflowSaveState.Saved}
+        runStatusMessage="Run in progress…"
+      />,
+    );
+
+    expect(getByTestId("workflow-run-status")).toHaveTextContent(
+      "Run in progress…",
+    );
+  });
+
+  test("colours a failed run red", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowStatusBar
+        saveState={WorkflowSaveState.Saved}
+        runStatusMessage="Run failed."
+        runStatusFailed={true}
+      />,
+    );
+
+    expect(getByTestId("workflow-run-status").className).toContain(
+      "text-red-700",
+    );
+  });
+
+  test("leaves a run that is still going neutral", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowStatusBar
+        saveState={WorkflowSaveState.Saved}
+        runStatusMessage="Run in progress…"
+      />,
+    );
+
+    expect(getByTestId("workflow-run-status").className).not.toContain(
+      "text-red-700",
+    );
+  });
+});
+
+describe("WorkflowStatusBar — what the checks found", () => {
+  test("shows nothing about the checks before they have run", () => {
+    const { queryByTestId }: RenderResult = render(
+      <WorkflowStatusBar saveState={WorkflowSaveState.Saved} />,
+    );
+
+    expect(queryByTestId("workflow-lint-status")).not.toBeInTheDocument();
+    expect(
+      queryByTestId("workflow-lint-status-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("says so when there is nothing wrong", () => {
+    const { getByTestId, queryByTestId }: RenderResult = render(
+      <WorkflowStatusBar
+        saveState={WorkflowSaveState.Saved}
+        lintResult={CLEAN_RESULT}
+      />,
+    );
+
+    expect(getByTestId("workflow-lint-status")).toHaveTextContent(
+      "No problems",
+    );
+    expect(
+      queryByTestId("workflow-lint-status-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("counts what it found", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowStatusBar
+        saveState={WorkflowSaveState.Saved}
+        lintResult={makeLintResult([
+          makeIssue(WorkflowLintSeverity.Error, "An error."),
+          makeIssue(WorkflowLintSeverity.Warning, "A warning."),
+        ])}
+      />,
+    );
+
+    expect(getByTestId("workflow-lint-status-button")).toHaveTextContent(
+      "1 error, 1 warning",
+    );
+  });
+
+  test("the counts are a button, not underlined text", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowStatusBar
+        saveState={WorkflowSaveState.Saved}
+        lintResult={makeLintResult([
+          makeIssue(WorkflowLintSeverity.Error, "An error."),
+        ])}
+      />,
+    );
+
+    const button: HTMLElement = getByTestId("workflow-lint-status-button");
+
+    expect(button.tagName).toBe("BUTTON");
+    expect(button).toHaveAttribute("type", "button");
+    expect(button.className).not.toContain("underline");
+  });
+
+  test("opens the list when clicked", () => {
+    const onShowIssues: MockFunction = getJestMockFunction();
+
+    const { getByTestId }: RenderResult = render(
+      <WorkflowStatusBar
+        saveState={WorkflowSaveState.Saved}
+        lintResult={makeLintResult([
+          makeIssue(WorkflowLintSeverity.Error, "An error."),
+        ])}
+        onShowIssues={onShowIssues}
+      />,
+    );
+
+    fireEvent.click(getByTestId("workflow-lint-status-button"));
+
+    expect(onShowIssues).toHaveBeenCalledTimes(1);
+  });
+
+  test("an error makes the pill red", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowStatusBar
+        saveState={WorkflowSaveState.Saved}
+        lintResult={makeLintResult([
+          makeIssue(WorkflowLintSeverity.Error, "An error."),
+          makeIssue(WorkflowLintSeverity.Warning, "A warning."),
+        ])}
+      />,
+    );
+
+    expect(getByTestId("workflow-lint-status-button").className).toContain(
+      "text-red-700",
+    );
+  });
+
+  test("warnings on their own make the pill amber", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowStatusBar
+        saveState={WorkflowSaveState.Saved}
+        lintResult={makeLintResult([
+          makeIssue(WorkflowLintSeverity.Warning, "A warning."),
+        ])}
+      />,
+    );
+
+    const className: string = getByTestId(
+      "workflow-lint-status-button",
+    ).className;
+
+    expect(className).toContain("text-amber-800");
+    expect(className).not.toContain("text-red-700");
+  });
+
+  test("the pill says out loud what it opens", () => {
+    const { getByTestId }: RenderResult = render(
+      <WorkflowStatusBar
+        saveState={WorkflowSaveState.Saved}
+        lintResult={makeLintResult([
+          makeIssue(WorkflowLintSeverity.Error, "An error."),
+          makeIssue(WorkflowLintSeverity.Error, "Another error."),
+        ])}
+      />,
+    );
+
+    expect(getByTestId("workflow-lint-status-button")).toHaveAttribute(
+      "aria-label",
+      "2 errors found in this workflow. Open the list.",
+    );
+  });
+});

--- a/Common/UI/Components/Workflow/GraphLintSummary.ts
+++ b/Common/UI/Components/Workflow/GraphLintSummary.ts
@@ -1,0 +1,401 @@
+/*
+ * How the builder presents what GraphLint found.
+ *
+ * GraphLint reports one issue per problem, which is right for a checker and
+ * wrong for a panel: a step with three empty required fields produces three
+ * issues, and rendering them flat gives three cards that happen to repeat the
+ * same step id. Everything here is about arranging that list instead —
+ * counting it, naming the step each issue belongs to, and folding one step's
+ * issues into a single group the builder can act on.
+ *
+ * The other half of the panel — taking the builder to the step a group is
+ * about — needs to look a node up by id, so that lives here too.
+ *
+ * Kept apart from the components that render it so all of it is testable
+ * without a DOM.
+ */
+
+import Dictionary from "../../../Types/Dictionary";
+import { NodeType } from "../../../Types/Workflow/Component";
+import { WorkflowLintIssue, WorkflowLintSeverity } from "./GraphLint";
+
+/** The part of a lint result a summary is built from. */
+export interface WorkflowLintCounts {
+  errorCount: number;
+  warningCount: number;
+}
+
+/**
+ * What the graph looks like overall. Drives one colour choice in the toolbar,
+ * so it is deliberately three states rather than a count.
+ */
+export enum WorkflowLintTone {
+  /** Nothing to report. */
+  Clean = "Clean",
+  /** Only warnings — the workflow runs, but probably not as intended. */
+  Warning = "Warning",
+  /** At least one error — the workflow fails, or does the wrong thing. */
+  Error = "Error",
+}
+
+/** Issues about the graph itself rather than any one step. */
+export const WORKFLOW_ISSUE_GRAPH_GROUP_KEY: string = "__workflow__";
+export const WORKFLOW_ISSUE_GRAPH_GROUP_TITLE: string = "This workflow";
+
+/** A step that has issues but no title and no id to show for itself. */
+export const WORKFLOW_ISSUE_UNTITLED_STEP_TITLE: string = "Untitled step";
+
+/** Every issue that belongs to one step (or to the graph), shown as one card. */
+export interface WorkflowIssueGroup {
+  /** Stable react key. */
+  key: string;
+  /** The react-flow node id, or null for issues about the graph itself. */
+  nodeId: string | null;
+  /** The step id the builder typed ("api-get-1"), when there is one. */
+  componentId: string | null;
+  /** Heading for the group — the step's title, falling back to its id. */
+  title: string;
+  issues: Array<WorkflowLintIssue>;
+  errorCount: number;
+  warningCount: number;
+}
+
+type PluraliseFunction = (count: number, singular: string) => string;
+
+const pluralise: PluraliseFunction = (
+  count: number,
+  singular: string,
+): string => {
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
+};
+
+export type GetWorkflowLintCountTextFunction = (
+  counts: WorkflowLintCounts,
+) => string;
+
+/**
+ * "1 error, 2 warnings" — empty when there is nothing to report.
+ *
+ * Errors are called errors rather than "problems" because the panel these
+ * counts label is titled "Problems", and having "problems" also mean
+ * specifically-the-errors inside it left the two counts reading as subsets of
+ * each other.
+ */
+export const getWorkflowLintCountText: GetWorkflowLintCountTextFunction = (
+  counts: WorkflowLintCounts,
+): string => {
+  const parts: Array<string> = [];
+
+  if (counts.errorCount > 0) {
+    parts.push(pluralise(counts.errorCount, "error"));
+  }
+
+  if (counts.warningCount > 0) {
+    parts.push(pluralise(counts.warningCount, "warning"));
+  }
+
+  return parts.join(", ");
+};
+
+export type GetWorkflowLintStatusTextFunction = (
+  counts: WorkflowLintCounts,
+) => string;
+
+/** The same counts, with something to say when there are none. */
+export const getWorkflowLintStatusText: GetWorkflowLintStatusTextFunction = (
+  counts: WorkflowLintCounts,
+): string => {
+  return getWorkflowLintCountText(counts) || "No problems";
+};
+
+export type GetWorkflowLintToneFunction = (
+  counts: WorkflowLintCounts,
+) => WorkflowLintTone;
+
+export const getWorkflowLintTone: GetWorkflowLintToneFunction = (
+  counts: WorkflowLintCounts,
+): WorkflowLintTone => {
+  if (counts.errorCount > 0) {
+    return WorkflowLintTone.Error;
+  }
+
+  if (counts.warningCount > 0) {
+    return WorkflowLintTone.Warning;
+  }
+
+  return WorkflowLintTone.Clean;
+};
+
+export type GetWorkflowLintSeverityLabelFunction = (
+  severity: WorkflowLintSeverity,
+) => string;
+
+/** The word for a severity — the panel says it out loud rather than only colouring it. */
+export const getWorkflowLintSeverityLabel: GetWorkflowLintSeverityLabelFunction =
+  (severity: WorkflowLintSeverity): string => {
+    return severity === WorkflowLintSeverity.Error ? "Error" : "Warning";
+  };
+
+/** The shape of a graph node this module needs — keeps react-flow out of here. */
+export interface TitledGraphNode {
+  id: string;
+  data?:
+    | {
+        metadata?: { title?: string | undefined } | undefined;
+      }
+    | undefined;
+}
+
+export type BuildStepTitlesByNodeIdFunction = (
+  nodes: Array<TitledGraphNode>,
+) => Dictionary<string>;
+
+/**
+ * Step titles keyed by react-flow node id, so the issues panel can name a step
+ * the way the canvas does rather than only by the id the builder typed.
+ */
+export const buildStepTitlesByNodeId: BuildStepTitlesByNodeIdFunction = (
+  nodes: Array<TitledGraphNode>,
+): Dictionary<string> => {
+  const titles: Dictionary<string> = {};
+
+  for (const node of nodes || []) {
+    if (!node || !node.id) {
+      continue;
+    }
+
+    const title: string | undefined = node.data?.metadata?.title;
+
+    if (title && title.trim()) {
+      titles[node.id] = title.trim();
+    }
+  }
+
+  return titles;
+};
+
+/** The shape of a graph node the "open this step" lookup needs. */
+export interface OpenableGraphNode {
+  id: string;
+  data?: { nodeType?: NodeType | undefined } | undefined;
+}
+
+export type FindStepNodeToOpenFunction = <T extends OpenableGraphNode>(params: {
+  nodes: Array<T>;
+  nodeId: string | null | undefined;
+}) => T | null;
+
+/**
+ * The node a "go to this step" request means, or null when there is nothing to
+ * open.
+ *
+ * A request can name a node that has since been deleted — the panel is a
+ * snapshot of what the checks last said, and the graph carries on being
+ * edited underneath it. A placeholder is not a step either: it is the empty
+ * slot where a trigger goes, and it has no settings.
+ */
+export const findStepNodeToOpen: FindStepNodeToOpenFunction = <
+  T extends OpenableGraphNode,
+>(params: {
+  nodes: Array<T>;
+  nodeId: string | null | undefined;
+}): T | null => {
+  if (!params.nodeId) {
+    return null;
+  }
+
+  const node: T | undefined = (params.nodes || []).find((node: T) => {
+    return node && node.id === params.nodeId;
+  });
+
+  if (!node || node.data?.nodeType === NodeType.PlaceholderNode) {
+    return null;
+  }
+
+  return node;
+};
+
+type GetGroupKeyFunction = (issue: WorkflowLintIssue) => string;
+
+const getGroupKey: GetGroupKeyFunction = (issue: WorkflowLintIssue): string => {
+  if (issue.nodeId) {
+    return `node:${issue.nodeId}`;
+  }
+
+  /*
+   * A graph-wide issue has no node. Anything that somehow names a step without
+   * naming its node still groups with that step rather than with the graph.
+   */
+  if (issue.componentId) {
+    return `component:${issue.componentId}`;
+  }
+
+  return WORKFLOW_ISSUE_GRAPH_GROUP_KEY;
+};
+
+type GetGroupTitleFunction = (params: {
+  issue: WorkflowLintIssue;
+  stepTitlesByNodeId: Dictionary<string>;
+}) => string;
+
+const getGroupTitle: GetGroupTitleFunction = (params: {
+  issue: WorkflowLintIssue;
+  stepTitlesByNodeId: Dictionary<string>;
+}): string => {
+  const { issue, stepTitlesByNodeId } = params;
+
+  if (!issue.nodeId && !issue.componentId) {
+    return WORKFLOW_ISSUE_GRAPH_GROUP_TITLE;
+  }
+
+  const titleFromGraph: string | undefined = issue.nodeId
+    ? stepTitlesByNodeId[issue.nodeId]
+    : undefined;
+
+  return (
+    titleFromGraph || issue.componentId || WORKFLOW_ISSUE_UNTITLED_STEP_TITLE
+  );
+};
+
+export type GroupWorkflowLintIssuesFunction = (params: {
+  issues: Array<WorkflowLintIssue>;
+  stepTitlesByNodeId?: Dictionary<string> | undefined;
+}) => Array<WorkflowIssueGroup>;
+
+/**
+ * One group per step, errors first, and the graph's own issues at the top.
+ *
+ * Identical messages inside a group are dropped: two rules can land on the
+ * same wording for the same step, and a panel that says the same sentence
+ * twice reads as a rendering bug rather than as two findings.
+ */
+export const groupWorkflowLintIssues: GroupWorkflowLintIssuesFunction =
+  (params: {
+    issues: Array<WorkflowLintIssue>;
+    stepTitlesByNodeId?: Dictionary<string> | undefined;
+  }): Array<WorkflowIssueGroup> => {
+    const stepTitlesByNodeId: Dictionary<string> =
+      params.stepTitlesByNodeId || {};
+    const groupsByKey: Dictionary<WorkflowIssueGroup> = {};
+    const orderedKeys: Array<string> = [];
+    const seenMessagesByKey: Dictionary<Set<string>> = {};
+
+    for (const issue of params.issues || []) {
+      if (!issue) {
+        continue;
+      }
+
+      const key: string = getGroupKey(issue);
+
+      let group: WorkflowIssueGroup | undefined = groupsByKey[key];
+
+      if (!group) {
+        group = {
+          key: key,
+          nodeId: issue.nodeId,
+          componentId: issue.componentId,
+          title: getGroupTitle({
+            issue: issue,
+            stepTitlesByNodeId: stepTitlesByNodeId,
+          }),
+          issues: [],
+          errorCount: 0,
+          warningCount: 0,
+        };
+
+        groupsByKey[key] = group;
+        seenMessagesByKey[key] = new Set<string>();
+        orderedKeys.push(key);
+      }
+
+      const seenMessages: Set<string> = seenMessagesByKey[key] as Set<string>;
+      const messageKey: string = `${issue.severity}|${issue.message}`;
+
+      if (seenMessages.has(messageKey)) {
+        continue;
+      }
+
+      seenMessages.add(messageKey);
+      group.issues.push(issue);
+
+      if (issue.severity === WorkflowLintSeverity.Error) {
+        group.errorCount++;
+      } else {
+        group.warningCount++;
+      }
+    }
+
+    const groups: Array<WorkflowIssueGroup> = orderedKeys
+      .map((key: string, index: number) => {
+        const group: WorkflowIssueGroup = groupsByKey[
+          key
+        ] as WorkflowIssueGroup;
+
+        /*
+         * Errors first inside a group: they are what stops the workflow, and a
+         * warning read first sets the wrong expectation about the rest.
+         * `index` keeps the sort stable across engines that do not guarantee it.
+         */
+        group.issues = group.issues
+          .map((issue: WorkflowLintIssue, issueIndex: number) => {
+            return { issue: issue, issueIndex: issueIndex };
+          })
+          .sort(
+            (
+              a: { issue: WorkflowLintIssue; issueIndex: number },
+              b: { issue: WorkflowLintIssue; issueIndex: number },
+            ) => {
+              const aIsError: number =
+                a.issue.severity === WorkflowLintSeverity.Error ? 0 : 1;
+              const bIsError: number =
+                b.issue.severity === WorkflowLintSeverity.Error ? 0 : 1;
+
+              if (aIsError !== bIsError) {
+                return aIsError - bIsError;
+              }
+
+              return a.issueIndex - b.issueIndex;
+            },
+          )
+          .map((entry: { issue: WorkflowLintIssue; issueIndex: number }) => {
+            return entry.issue;
+          });
+
+        return { group: group, index: index };
+      })
+      .sort(
+        (
+          a: { group: WorkflowIssueGroup; index: number },
+          b: { group: WorkflowIssueGroup; index: number },
+        ) => {
+          /*
+           * "This workflow has no trigger" is about the thing every step hangs
+           * off, so the graph's own issues lead regardless of what else is wrong.
+           */
+          const aIsGraph: number =
+            a.group.key === WORKFLOW_ISSUE_GRAPH_GROUP_KEY ? 0 : 1;
+          const bIsGraph: number =
+            b.group.key === WORKFLOW_ISSUE_GRAPH_GROUP_KEY ? 0 : 1;
+
+          if (aIsGraph !== bIsGraph) {
+            return aIsGraph - bIsGraph;
+          }
+
+          const aHasErrors: number = a.group.errorCount > 0 ? 0 : 1;
+          const bHasErrors: number = b.group.errorCount > 0 ? 0 : 1;
+
+          if (aHasErrors !== bHasErrors) {
+            return aHasErrors - bHasErrors;
+          }
+
+          return a.index - b.index;
+        },
+      )
+      .map((entry: { group: WorkflowIssueGroup; index: number }) => {
+        return entry.group;
+      });
+
+    return groups;
+  };
+
+export default groupWorkflowLintIssues;

--- a/Common/UI/Components/Workflow/Workflow.tsx
+++ b/Common/UI/Components/Workflow/Workflow.tsx
@@ -8,6 +8,7 @@ import {
   WorkflowLintResult,
   lintWorkflowGraph,
 } from "./GraphLint";
+import { findStepNodeToOpen } from "./GraphLintSummary";
 import { loadComponentsAndCategories } from "./Utils";
 import { VoidFunction } from "../../../Types/FunctionTypes";
 import IconProp from "../../../Types/Icon/IconProp";
@@ -126,6 +127,17 @@ export interface ComponentProps {
    * page around the canvas can show a count and decide what to do about it.
    */
   onLintResultChange?: ((result: WorkflowLintResult) => void) | undefined;
+  /**
+   * A react-flow node id whose settings should be opened. The issues panel
+   * lives outside the canvas but its whole point is fixing a step, and this is
+   * how it gets the builder there.
+   */
+  openStepForNodeId?: string | null | undefined;
+  /**
+   * Called once the request above has been handled — whether or not the node
+   * was still in the graph — so the page can clear it and ask again later.
+   */
+  onStepOpened?: (() => void) | undefined;
 }
 
 const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
@@ -277,6 +289,30 @@ const Workflow: FunctionComponent<ComponentProps> = (props: ComponentProps) => {
   useEffect(() => {
     props.onLintResultChange?.(lintResult);
   }, [lintResult]);
+
+  /*
+   * Opening a step from outside the canvas — the issues panel naming the node
+   * it is complaining about. A node that has since been deleted simply opens
+   * nothing; the request is still acknowledged so the page does not sit
+   * waiting for a step that no longer exists.
+   */
+  useEffect(() => {
+    if (!props.openStepForNodeId) {
+      return;
+    }
+
+    const nodeToOpen: Node | null = findStepNodeToOpen({
+      nodes: nodes,
+      nodeId: props.openStepForNodeId,
+    });
+
+    if (nodeToOpen) {
+      setSelectedNodeData(nodeToOpen.data as NodeDataProp);
+      setShowComponentSettingsModal(true);
+    }
+
+    props.onStepOpened?.();
+  }, [props.openStepForNodeId]);
 
   const nodesToRender: Array<Node> = useMemo(() => {
     return nodes.map((node: Node) => {

--- a/Common/UI/Components/Workflow/WorkflowIssuesModal.tsx
+++ b/Common/UI/Components/Workflow/WorkflowIssuesModal.tsx
@@ -1,0 +1,255 @@
+/*
+ * Everything the static checks found, arranged so it can be fixed.
+ *
+ * The list used to be one card per issue, each headed by the step id in caps,
+ * so a step with two problems announced itself twice and a workflow with six
+ * looked like six unrelated failures. Here the issues belong to the step they
+ * are about: one card per step, headed by the step's name, with a button that
+ * takes the builder to it. The panel says "fixing them here saves a failed run
+ * later" — this is the part that makes "here" mean something.
+ */
+
+import Icon, { SizeProp } from "../Icon/Icon";
+import Modal, { ModalWidth } from "../Modal/Modal";
+import IconProp from "../../../Types/Icon/IconProp";
+import Dictionary from "../../../Types/Dictionary";
+import {
+  WorkflowLintIssue,
+  WorkflowLintResult,
+  WorkflowLintSeverity,
+} from "./GraphLint";
+import {
+  WorkflowIssueGroup,
+  getWorkflowLintSeverityLabel,
+  groupWorkflowLintIssues,
+} from "./GraphLintSummary";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  lintResult: WorkflowLintResult;
+  /**
+   * Step titles by react-flow node id, so a group is headed the way the canvas
+   * heads the node rather than only by the id the builder typed.
+   */
+  stepTitlesByNodeId?: Dictionary<string> | undefined;
+  onClose: () => void;
+  /**
+   * Opens a step's settings. Without it the groups have no action and the
+   * panel is read-only, which is what happens for issues about the graph
+   * itself — there is no step to open.
+   */
+  onGoToStep?: ((nodeId: string) => void) | undefined;
+}
+
+type RenderSeverityIconFunction = (
+  severity: WorkflowLintSeverity,
+) => ReactElement;
+
+const renderSeverityIcon: RenderSeverityIconFunction = (
+  severity: WorkflowLintSeverity,
+): ReactElement => {
+  const isError: boolean = severity === WorkflowLintSeverity.Error;
+
+  return (
+    <span
+      className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full ${
+        isError ? "bg-red-100 text-red-600" : "bg-amber-100 text-amber-600"
+      }`}
+      data-testid={
+        isError ? "workflow-issue-error-icon" : "workflow-issue-warning-icon"
+      }
+    >
+      <Icon
+        icon={isError ? IconProp.Close : IconProp.Alert}
+        size={SizeProp.ExtraSmall}
+        className="h-2.5 w-2.5"
+      />
+    </span>
+  );
+};
+
+type RenderCountPillFunction = (params: {
+  count: number;
+  singular: string;
+  className: string;
+  testId: string;
+}) => ReactElement | null;
+
+const renderCountPill: RenderCountPillFunction = (params: {
+  count: number;
+  singular: string;
+  className: string;
+  testId: string;
+}): ReactElement | null => {
+  if (params.count <= 0) {
+    return null;
+  }
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium leading-4 whitespace-nowrap ${params.className}`}
+      data-testid={params.testId}
+    >
+      {params.count} {params.singular}
+      {params.count === 1 ? "" : "s"}
+    </span>
+  );
+};
+
+const WorkflowIssuesModal: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const groups: Array<WorkflowIssueGroup> = groupWorkflowLintIssues({
+    issues: props.lintResult.issues,
+    stepTitlesByNodeId: props.stepTitlesByNodeId,
+  });
+
+  return (
+    <Modal
+      title="Problems with this workflow"
+      description="These are found by reading the workflow. Fixing them here saves a failed run later."
+      modalWidth={ModalWidth.Medium}
+      closeButtonText="Close"
+      onClose={props.onClose}
+    >
+      <div className="space-y-3" data-testid="workflow-issues">
+        {groups.length === 0 ? (
+          <div
+            className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-gray-200 px-4 py-8 text-center"
+            data-testid="workflow-issues-empty"
+          >
+            <Icon
+              icon={IconProp.CheckCircle}
+              className="h-6 w-6 text-emerald-500"
+            />
+            <p className="text-sm font-medium text-gray-900">
+              Nothing to fix here
+            </p>
+            <p className="text-sm text-gray-500">
+              The checks found nothing wrong with this workflow.
+            </p>
+          </div>
+        ) : (
+          <>
+            {/*
+              A running total up front: the groups below say what is wrong with
+              each step, and this says how much of it there is in total.
+            */}
+            <div
+              className="flex flex-wrap items-center gap-2"
+              data-testid="workflow-issues-summary"
+            >
+              {renderCountPill({
+                count: props.lintResult.errorCount,
+                singular: "error",
+                className:
+                  "bg-red-50 text-red-700 ring-1 ring-inset ring-red-200",
+                testId: "workflow-issues-error-count",
+              })}
+              {renderCountPill({
+                count: props.lintResult.warningCount,
+                singular: "warning",
+                className:
+                  "bg-amber-50 text-amber-800 ring-1 ring-inset ring-amber-200",
+                testId: "workflow-issues-warning-count",
+              })}
+              <span className="text-xs text-gray-500">
+                across{" "}
+                {groups.length === 1 ? "1 place" : `${groups.length} places`}
+              </span>
+            </div>
+
+            {groups.map((group: WorkflowIssueGroup): ReactElement => {
+              const canGoToStep: boolean = Boolean(
+                props.onGoToStep && group.nodeId,
+              );
+
+              return (
+                <section
+                  key={group.key}
+                  className="overflow-hidden rounded-lg border border-gray-200"
+                  data-testid="workflow-issue-group"
+                >
+                  <header className="flex items-start justify-between gap-3 border-b border-gray-200 bg-gray-50 px-3 py-2">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-semibold text-gray-900">
+                        {group.title}
+                      </p>
+                      {group.componentId &&
+                        group.componentId !== group.title && (
+                          <p className="truncate font-mono text-xs text-gray-500">
+                            {group.componentId}
+                          </p>
+                        )}
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      {renderCountPill({
+                        count: group.errorCount,
+                        singular: "error",
+                        className:
+                          "bg-red-50 text-red-700 ring-1 ring-inset ring-red-200",
+                        testId: "workflow-issue-group-error-count",
+                      })}
+                      {renderCountPill({
+                        count: group.warningCount,
+                        singular: "warning",
+                        className:
+                          "bg-amber-50 text-amber-800 ring-1 ring-inset ring-amber-200",
+                        testId: "workflow-issue-group-warning-count",
+                      })}
+                      {canGoToStep && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            props.onGoToStep?.(group.nodeId as string);
+                          }}
+                          aria-label={`Open settings for ${group.title}`}
+                          data-testid="workflow-issue-go-to-step"
+                          className="inline-flex items-center gap-1 rounded-md border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1"
+                        >
+                          Open step
+                          <Icon
+                            icon={IconProp.ChevronRight}
+                            size={SizeProp.ExtraSmall}
+                            className="h-3 w-3"
+                          />
+                        </button>
+                      )}
+                    </div>
+                  </header>
+
+                  <ul className="divide-y divide-gray-100">
+                    {group.issues.map(
+                      (
+                        issue: WorkflowLintIssue,
+                        index: number,
+                      ): ReactElement => {
+                        return (
+                          <li
+                            key={`${issue.rule}-${index}`}
+                            className="flex items-start gap-2.5 px-3 py-2.5"
+                            data-testid="workflow-issue"
+                          >
+                            {renderSeverityIcon(issue.severity)}
+                            <p className="text-sm leading-5 text-gray-700">
+                              <span className="sr-only">
+                                {getWorkflowLintSeverityLabel(issue.severity)}:{" "}
+                              </span>
+                              {issue.message}
+                            </p>
+                          </li>
+                        );
+                      },
+                    )}
+                  </ul>
+                </section>
+              );
+            })}
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default WorkflowIssuesModal;

--- a/Common/UI/Components/Workflow/WorkflowStatusBar.tsx
+++ b/Common/UI/Components/Workflow/WorkflowStatusBar.tsx
@@ -1,0 +1,194 @@
+/*
+ * The strip above the canvas: whether the draft is saved, what the run it
+ * started is doing, and what the static checks have to say about it.
+ *
+ * All three used to be loose text of different shapes and colours sitting next
+ * to each other, and the checks in particular were a bare underlined link — the
+ * one thing on the strip that is clickable looked the least like a control.
+ * They are pills here so the strip reads as one row of statuses, and so the
+ * clickable one can carry a border, a hover state and a focus ring.
+ */
+
+import Icon, { SizeProp } from "../Icon/Icon";
+import IconProp from "../../../Types/Icon/IconProp";
+import { WorkflowLintResult } from "./GraphLint";
+import {
+  WorkflowLintTone,
+  getWorkflowLintCountText,
+  getWorkflowLintStatusText,
+  getWorkflowLintTone,
+} from "./GraphLintSummary";
+import React, { FunctionComponent, ReactElement } from "react";
+
+/** Where the draft is between the last edit and the server having it. */
+export enum WorkflowSaveState {
+  /** Nothing has been edited yet. */
+  Idle = "Idle",
+  Saving = "Saving",
+  Saved = "Saved",
+  Error = "Error",
+}
+
+export interface SaveStatePresentation {
+  label: string;
+  dotClassName: string;
+  textClassName: string;
+}
+
+export type GetSaveStatePresentationFunction = (
+  state: WorkflowSaveState,
+) => SaveStatePresentation;
+
+export const getWorkflowSaveStatePresentation: GetSaveStatePresentationFunction =
+  (state: WorkflowSaveState): SaveStatePresentation => {
+    if (state === WorkflowSaveState.Saved) {
+      return {
+        label: "Saved",
+        dotClassName: "bg-emerald-500",
+        textClassName: "text-emerald-700",
+      };
+    }
+
+    if (state === WorkflowSaveState.Saving) {
+      return {
+        label: "Saving…",
+        dotClassName: "bg-indigo-500 animate-pulse",
+        textClassName: "text-indigo-700",
+      };
+    }
+
+    if (state === WorkflowSaveState.Error) {
+      return {
+        label: "Could not save",
+        dotClassName: "bg-red-500",
+        textClassName: "text-red-700",
+      };
+    }
+
+    return {
+      label: "Ready",
+      dotClassName: "bg-gray-400",
+      textClassName: "text-gray-600",
+    };
+  };
+
+const PILL_CLASS_NAME: string =
+  "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium leading-4 whitespace-nowrap";
+
+type GetLintPillClassNameFunction = (tone: WorkflowLintTone) => string;
+
+const getLintPillClassName: GetLintPillClassNameFunction = (
+  tone: WorkflowLintTone,
+): string => {
+  if (tone === WorkflowLintTone.Error) {
+    return "border-red-200 bg-red-50 text-red-700 hover:bg-red-100 hover:border-red-300";
+  }
+
+  if (tone === WorkflowLintTone.Warning) {
+    return "border-amber-200 bg-amber-50 text-amber-800 hover:bg-amber-100 hover:border-amber-300";
+  }
+
+  return "border-emerald-200 bg-emerald-50 text-emerald-700";
+};
+
+export interface ComponentProps {
+  saveState: WorkflowSaveState;
+  /** null until the canvas has run its checks for the first time. */
+  lintResult?: WorkflowLintResult | null | undefined;
+  /** Opens the panel listing what the checks found. */
+  onShowIssues?: (() => void) | undefined;
+  /** What the run this builder started is doing, while it is doing it. */
+  runStatusMessage?: string | null | undefined;
+  runStatusFailed?: boolean | undefined;
+}
+
+const WorkflowStatusBar: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const savePresentation: SaveStatePresentation =
+    getWorkflowSaveStatePresentation(props.saveState);
+
+  const lintResult: WorkflowLintResult | null = props.lintResult || null;
+  const tone: WorkflowLintTone = lintResult
+    ? getWorkflowLintTone(lintResult)
+    : WorkflowLintTone.Clean;
+
+  const hasIssues: boolean = Boolean(
+    lintResult && lintResult.issues.length > 0,
+  );
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2"
+      data-testid="workflow-status-bar"
+    >
+      <span
+        className={`${PILL_CLASS_NAME} border-gray-200 bg-white ${savePresentation.textClassName}`}
+        data-testid="workflow-save-status"
+      >
+        <span
+          className={`h-1.5 w-1.5 shrink-0 rounded-full ${savePresentation.dotClassName}`}
+          aria-hidden="true"
+        />
+        {savePresentation.label}
+      </span>
+
+      {props.runStatusMessage && (
+        <span
+          className={`${PILL_CLASS_NAME} ${
+            props.runStatusFailed
+              ? "border-red-200 bg-red-50 text-red-700"
+              : "border-gray-200 bg-gray-50 text-gray-600"
+          }`}
+          data-testid="workflow-run-status"
+        >
+          <Icon
+            icon={props.runStatusFailed ? IconProp.Alert : IconProp.Play}
+            size={SizeProp.ExtraSmall}
+            className="h-3 w-3 shrink-0"
+          />
+          {props.runStatusMessage}
+        </span>
+      )}
+
+      {lintResult &&
+        (hasIssues ? (
+          <button
+            type="button"
+            onClick={props.onShowIssues}
+            title="See everything the checks found"
+            aria-label={`${getWorkflowLintCountText(
+              lintResult,
+            )} found in this workflow. Open the list.`}
+            data-testid="workflow-lint-status-button"
+            className={`${PILL_CLASS_NAME} cursor-pointer transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-1 ${getLintPillClassName(
+              tone,
+            )}`}
+          >
+            <Icon
+              icon={IconProp.Alert}
+              size={SizeProp.ExtraSmall}
+              className="h-3 w-3 shrink-0"
+            />
+            {getWorkflowLintCountText(lintResult)}
+          </button>
+        ) : (
+          <span
+            className={`${PILL_CLASS_NAME} ${getLintPillClassName(
+              WorkflowLintTone.Clean,
+            )}`}
+            data-testid="workflow-lint-status"
+          >
+            <Icon
+              icon={IconProp.CheckCircle}
+              size={SizeProp.ExtraSmall}
+              className="h-3 w-3 shrink-0"
+            />
+            {getWorkflowLintStatusText(lintResult)}
+          </span>
+        ))}
+    </div>
+  );
+};
+
+export default WorkflowStatusBar;


### PR DESCRIPTION
## What

Two bits of the workflow builder that report what the static checks found.

**The status strip.** The count of problems was bare underlined text — the one clickable thing on the strip looked the least like a control. All three statuses (save state, the run the builder started, what the checks found) are now pills of the same shape, so the strip reads as one row, and the clickable one carries a border, a hover state and a focus ring and says out loud what it opens. When the checks find nothing it says "No problems" rather than going blank.

**The problems panel.** It rendered one card per issue, each headed by the step id in caps, so a step with two problems announced itself twice and a workflow with six looked like six unrelated failures. Issues now belong to the step they are about:

- one card per step, headed by the name the canvas gives it with its id in mono underneath
- counts per card and a running total up front
- errors above warnings inside a card, and the workflow's own problems above the steps
- an **Open step** button per card that closes the panel and opens that step's settings — the panel says fixing them here saves a failed run later, and this is what makes "here" mean something
- severity stated in words for screen readers rather than resting on colour
- an empty state, a header close button, backdrop/Escape dismissal, and a readable width (was `max-w-7xl` for a list of sentences)

Counts now read "1 error, 1 warning" rather than "1 problem, 1 warning": the panel is titled Problems, so having "problem" also mean specifically the errors inside it left the two counts reading as subsets of each other.

## How

- `Common/UI/Components/Workflow/GraphLintSummary.ts` — new: counting, tone, grouping, dedupe, ordering, step titles, and the node lookup the "Open step" action needs. No DOM, so it is all unit-testable.
- `Common/UI/Components/Workflow/WorkflowStatusBar.tsx` — new: the strip.
- `Common/UI/Components/Workflow/WorkflowIssuesModal.tsx` — new: the panel.
- `Common/UI/Components/Workflow/Workflow.tsx` — `openStepForNodeId` / `onStepOpened`, so a step's settings can be opened from outside the canvas. A node deleted since the panel was opened acknowledges the request and opens nothing.
- `App/.../Workflow/View/Builder.tsx` — uses the three above; save state is a typed enum rather than compared strings, and ~150 lines of inline-styled markup come out.

## Tests

3 new suites, 78 tests, all passing alongside the existing 120 in `Common/Tests/UI/Components/Workflow/`:

- `GraphLintSummary.test.ts` (47) — pluralisation and both counts, tone precedence, severity labels, step titles (fallbacks, trimming, missing data), grouping by node vs by step vs graph-wide, two steps sharing a component id, dedupe by message and severity, ordering within and across groups, stability, no mutation of the input, the step lookup (deleted node, placeholder, empty id), and grouping over graphs run through the real `lintWorkflowGraph` — including the case from the report: one step that is both unreachable and missing a required field collapsing into a single card.
- `WorkflowStatusBar.test.tsx` (17) — save-state labels and colours, run status shown/hidden/failed, checks hidden before they run, clean state, counts, click, tone colours, and that the counts are a real button with an aria-label rather than underlined text.
- `WorkflowIssuesModal.test.tsx` (21) — title and description, both close paths, empty state, grouping and headings, per-card and total counts, singular/plural, severity marks and words, ordering, and the Open step action (fires with the node id, named for screen readers, absent for graph-wide issues and when the page cannot open steps).

`tsc --noEmit` is clean for both `Common` and `App`; eslint is clean on every touched file.

Not verified visually in a running app — the local dev stack serves the main checkout rather than this worktree. Happy to render it there if you want a look before merging.