### PR TITLE
feat(workflow): create workflows through a template wizard

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Workflow/CreateWorkflowModal.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Workflow/CreateWorkflowModal.tsx
@@ -1,0 +1,714 @@
+/*
+ * The create-a-workflow wizard.
+ *
+ * Three steps: pick a starting point, name it, fill in whatever configuration
+ * the template asked for. The third step only appears when the chosen template
+ * declares variables, so "Start from scratch" and the zero-config templates
+ * stay two clicks away.
+ *
+ * The order of writes at the end matters. The workflow is created through the
+ * ordinary Workflow create path because that is what denormalizes the trigger
+ * onto the row (WorkflowService.onCreateSuccess) — build the graph any other
+ * way and you get a workflow that looks right in the builder and never fires.
+ * Its variables can only be written afterwards, since they need the workflow's
+ * id, and if any of them fails the workflow is deleted again rather than left
+ * behind: a saved workflow whose {{local.variables.…}} references resolve to
+ * nothing is not an error at run time, it just quietly posts literal braces.
+ */
+
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useMemo,
+  useState,
+} from "react";
+import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
+import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import Icon, { SizeProp } from "Common/UI/Components/Icon/Icon";
+import IconProp from "Common/Types/Icon/IconProp";
+import Input, { InputType } from "Common/UI/Components/Input/Input";
+import TextArea from "Common/UI/Components/TextArea/TextArea";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONArray, JSONObject } from "Common/Types/JSON";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import API from "Common/UI/Utils/API/API";
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "Common/UI/Utils/Project";
+import Workflow from "Common/Models/DatabaseModels/Workflow";
+import WorkflowVariable from "Common/Models/DatabaseModels/WorkflowVariable";
+import {
+  WorkflowTemplate,
+  WorkflowTemplateCategories,
+  WorkflowTemplateCategory,
+  WorkflowTemplateVariable,
+  getWorkflowTemplate,
+  getWorkflowTemplatesByCategory,
+} from "Common/Types/Workflow/Templates";
+import {
+  WorkflowTemplateVariableErrors,
+  WorkflowTemplateVariableValues,
+  buildWorkflowFromTemplate,
+  buildWorkflowVariables,
+  validateTemplateVariableValues,
+} from "../../Utils/Workflow/WorkflowTemplateCreateUtil";
+
+export interface ComponentProps {
+  onClose: () => void;
+  /** Called with the created workflow so the page can navigate to it. */
+  onCreated: (workflow: Workflow) => void;
+}
+
+enum WizardStep {
+  PickTemplate = 1,
+  NameIt = 2,
+  Configure = 3,
+}
+
+const STEP_TITLES: Record<WizardStep, string> = {
+  [WizardStep.PickTemplate]: "Start from",
+  [WizardStep.NameIt]: "Name",
+  [WizardStep.Configure]: "Configure",
+};
+
+interface StepIndicatorProps {
+  current: WizardStep;
+  showConfigureStep: boolean;
+}
+
+const StepIndicator: FunctionComponent<StepIndicatorProps> = (
+  props: StepIndicatorProps,
+): ReactElement => {
+  const steps: Array<WizardStep> = [WizardStep.PickTemplate, WizardStep.NameIt];
+
+  if (props.showConfigureStep) {
+    steps.push(WizardStep.Configure);
+  }
+
+  return (
+    <ol className="flex items-center gap-3 mb-6" aria-label="Progress">
+      {steps.map((step: WizardStep, index: number): ReactElement => {
+        const isCompleted: boolean = step < props.current;
+        const isActive: boolean = step === props.current;
+
+        return (
+          <li key={step} className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
+              <span
+                className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold transition-colors ${
+                  isCompleted
+                    ? "bg-indigo-600 text-white"
+                    : isActive
+                      ? "bg-indigo-100 text-indigo-700 ring-2 ring-indigo-500"
+                      : "bg-gray-100 text-gray-400"
+                }`}
+                aria-current={isActive ? "step" : undefined}
+              >
+                {isCompleted ? (
+                  <Icon icon={IconProp.Check} className="h-3.5 w-3.5" />
+                ) : (
+                  index + 1
+                )}
+              </span>
+              <span
+                className={`text-sm ${
+                  isActive
+                    ? "font-semibold text-gray-900"
+                    : isCompleted
+                      ? "font-medium text-gray-600"
+                      : "text-gray-400"
+                }`}
+              >
+                {STEP_TITLES[step]}
+              </span>
+            </div>
+            {index < steps.length - 1 ? (
+              <span
+                className={`h-px w-8 ${
+                  isCompleted ? "bg-indigo-300" : "bg-gray-200"
+                }`}
+              />
+            ) : (
+              <></>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+};
+
+interface TemplateCardProps {
+  title: string;
+  description: string;
+  icon: IconProp;
+  isSelected: boolean;
+  badge?: string | undefined;
+  onClick: () => void;
+}
+
+const TemplateCard: FunctionComponent<TemplateCardProps> = (
+  props: TemplateCardProps,
+): ReactElement => {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-pressed={props.isSelected}
+      data-testid={`workflow-template-card-${props.title}`}
+      className={`relative flex cursor-pointer flex-col rounded-lg border p-4 shadow-sm transition-all duration-200 hover:border-indigo-400 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500 ${
+        props.isSelected
+          ? "border-indigo-500 bg-indigo-50/50"
+          : "border-gray-200 bg-white"
+      }`}
+      onClick={props.onClick}
+      onKeyDown={(event: React.KeyboardEvent) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          props.onClick();
+        }
+      }}
+    >
+      <div className="mb-3 flex items-start justify-between">
+        <span
+          className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg ${
+            props.isSelected ? "bg-indigo-100" : "bg-gray-100"
+          }`}
+        >
+          <Icon
+            icon={props.icon}
+            size={SizeProp.Large}
+            className={`h-5 w-5 ${
+              props.isSelected ? "text-indigo-600" : "text-gray-600"
+            }`}
+          />
+        </span>
+        {props.isSelected ? (
+          <Icon
+            icon={IconProp.CheckCircle}
+            size={SizeProp.Large}
+            className="h-5 w-5 text-indigo-500"
+          />
+        ) : (
+          <></>
+        )}
+      </div>
+      <p className="text-sm font-semibold text-gray-900">{props.title}</p>
+      <p className="mt-1 text-sm leading-relaxed text-gray-500">
+        {props.description}
+      </p>
+      {props.badge ? (
+        <p className="mt-3 inline-flex w-fit items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+          {props.badge}
+        </p>
+      ) : (
+        <></>
+      )}
+    </div>
+  );
+};
+
+const CreateWorkflowModal: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [step, setStep] = useState<WizardStep>(WizardStep.PickTemplate);
+  /*
+   * null is a real choice here — it means "start from scratch" — so a separate
+   * flag tracks whether a choice has been made at all. Without it, coming Back
+   * to step one after choosing Blank shows nothing selected.
+   */
+  const [hasChosen, setHasChosen] = useState<boolean>(false);
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(
+    null,
+  );
+  const [name, setName] = useState<string>("");
+  const [description, setDescription] = useState<string>("");
+  const [nameError, setNameError] = useState<string>("");
+  const [variableValues, setVariableValues] =
+    useState<WorkflowTemplateVariableValues>({});
+  const [variableErrors, setVariableErrors] =
+    useState<WorkflowTemplateVariableErrors>({});
+  const [search, setSearch] = useState<string>("");
+  const [isCreating, setIsCreating] = useState<boolean>(false);
+  const [error, setError] = useState<string>("");
+
+  const selectedTemplate: WorkflowTemplate | null = useMemo(() => {
+    return selectedTemplateId ? getWorkflowTemplate(selectedTemplateId) : null;
+  }, [selectedTemplateId]);
+
+  const variables: Array<WorkflowTemplateVariable> =
+    selectedTemplate?.variables || [];
+
+  const showConfigureStep: boolean = variables.length > 0;
+
+  type MatchesSearchFunction = (template: WorkflowTemplate) => boolean;
+
+  const matchesSearch: MatchesSearchFunction = (
+    template: WorkflowTemplate,
+  ): boolean => {
+    const query: string = search.trim().toLowerCase();
+
+    if (!query) {
+      return true;
+    }
+
+    return (
+      template.name.toLowerCase().includes(query) ||
+      template.description.toLowerCase().includes(query) ||
+      template.teaches.toLowerCase().includes(query) ||
+      template.category.toLowerCase().includes(query)
+    );
+  };
+
+  type SelectTemplateFunction = (template: WorkflowTemplate | null) => void;
+
+  const selectTemplate: SelectTemplateFunction = (
+    template: WorkflowTemplate | null,
+  ): void => {
+    setHasChosen(true);
+    setSelectedTemplateId(template ? template.id : null);
+    setName(template ? template.workflowName : "");
+    setDescription(template ? template.workflowDescription : "");
+    setNameError("");
+    setVariableValues({});
+    setVariableErrors({});
+    setError("");
+    setStep(WizardStep.NameIt);
+  };
+
+  type GoBackFunction = () => void;
+
+  const goBack: GoBackFunction = (): void => {
+    setError("");
+
+    if (step === WizardStep.Configure) {
+      setStep(WizardStep.NameIt);
+      return;
+    }
+
+    setStep(WizardStep.PickTemplate);
+  };
+
+  type CreateFunction = () => Promise<void>;
+
+  const create: CreateFunction = async (): Promise<void> => {
+    setIsCreating(true);
+    setError("");
+
+    let createdWorkflowId: ObjectID | null = null;
+    let createdWorkflow: Workflow | null = null;
+
+    try {
+      const projectId: ObjectID = ProjectUtil.getCurrentProjectId()!;
+
+      const workflow: Workflow = buildWorkflowFromTemplate({
+        name: name,
+        description: description,
+        projectId: projectId,
+        template: selectedTemplate,
+        values: variableValues,
+      });
+
+      const response: HTTPResponse<
+        JSONObject | JSONArray | Workflow | Array<Workflow>
+      > = await ModelAPI.create<Workflow>({
+        model: workflow,
+        modelType: Workflow,
+      });
+
+      const created: Workflow = response.data as Workflow;
+      createdWorkflowId = created.id as ObjectID;
+
+      if (selectedTemplate) {
+        const rows: Array<WorkflowVariable> = buildWorkflowVariables({
+          template: selectedTemplate,
+          values: variableValues,
+          workflowId: createdWorkflowId,
+          projectId: projectId,
+        });
+
+        /*
+         * One at a time, and deliberately not in parallel: there is no bulk or
+         * transactional create, and a half-written set is the failure we are
+         * trying to avoid.
+         */
+        for (const row of rows) {
+          await ModelAPI.create<WorkflowVariable>({
+            model: row,
+            modelType: WorkflowVariable,
+          });
+        }
+      }
+
+      createdWorkflow = created;
+    } catch (err) {
+      /*
+       * Roll the workflow back if its variables could not be written. Leaving
+       * it would leave a workflow that runs and silently does the wrong thing,
+       * which is worse than leaving nothing at all.
+       */
+      if (createdWorkflowId) {
+        try {
+          await ModelAPI.deleteItem<Workflow>({
+            modelType: Workflow,
+            id: createdWorkflowId,
+          });
+        } catch (cleanupError) {
+          // Reported below as part of the original failure.
+        }
+      }
+
+      setError(API.getFriendlyMessage(err));
+    }
+
+    setIsCreating(false);
+
+    /*
+     * Handed over outside the try on purpose. onCreated navigates away, and a
+     * failure in navigation must not be mistaken for a failed create and roll
+     * back a workflow that was written perfectly well.
+     */
+    if (createdWorkflow) {
+      props.onCreated(createdWorkflow);
+    }
+  };
+
+  type OnSubmitFunction = () => void;
+
+  const onSubmit: OnSubmitFunction = (): void => {
+    if (step === WizardStep.NameIt) {
+      if (name.trim().length < 2) {
+        setNameError("Please give this workflow a name of at least 2 letters.");
+        return;
+      }
+
+      setNameError("");
+
+      if (showConfigureStep) {
+        setStep(WizardStep.Configure);
+        return;
+      }
+
+      void create();
+      return;
+    }
+
+    if (step === WizardStep.Configure) {
+      const errors: WorkflowTemplateVariableErrors =
+        validateTemplateVariableValues(
+          selectedTemplate as WorkflowTemplate,
+          variableValues,
+        );
+
+      setVariableErrors(errors);
+
+      if (Object.keys(errors).length > 0) {
+        return;
+      }
+
+      void create();
+    }
+  };
+
+  type RenderPickStepFunction = () => ReactElement;
+
+  const renderPickStep: RenderPickStepFunction = (): ReactElement => {
+    const categoriesWithMatches: Array<{
+      category: WorkflowTemplateCategory;
+      templates: Array<WorkflowTemplate>;
+    }> = WorkflowTemplateCategories.map(
+      (category: WorkflowTemplateCategory) => {
+        return {
+          category: category,
+          templates:
+            getWorkflowTemplatesByCategory(category).filter(matchesSearch),
+        };
+      },
+    ).filter(
+      (group: {
+        category: WorkflowTemplateCategory;
+        templates: Array<WorkflowTemplate>;
+      }) => {
+        return group.templates.length > 0;
+      },
+    );
+
+    const blankMatches: boolean =
+      !search.trim() ||
+      "start from scratch blank empty".includes(search.trim().toLowerCase());
+
+    return (
+      <div>
+        <Input
+          placeholder="Search templates…"
+          value={search}
+          onChange={(value: string) => {
+            setSearch(value);
+          }}
+          dataTestId="workflow-template-search"
+        />
+
+        <div className="mt-5 space-y-6">
+          {blankMatches ? (
+            <div>
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
+                Blank
+              </h3>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                <TemplateCard
+                  title="Start from scratch"
+                  description="An empty canvas. Add your own trigger and steps."
+                  icon={IconProp.Add}
+                  isSelected={hasChosen && selectedTemplateId === null}
+                  onClick={() => {
+                    selectTemplate(null);
+                  }}
+                />
+              </div>
+            </div>
+          ) : (
+            <></>
+          )}
+
+          {categoriesWithMatches.map(
+            (group: {
+              category: WorkflowTemplateCategory;
+              templates: Array<WorkflowTemplate>;
+            }): ReactElement => {
+              return (
+                <div key={group.category}>
+                  <h3 className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
+                    {group.category}
+                  </h3>
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    {group.templates.map(
+                      (template: WorkflowTemplate): ReactElement => {
+                        return (
+                          <TemplateCard
+                            key={template.id}
+                            title={template.name}
+                            description={template.description}
+                            icon={template.icon}
+                            isSelected={selectedTemplateId === template.id}
+                            badge={
+                              template.variables.length > 0
+                                ? `Needs ${template.variables.length} setting${
+                                    template.variables.length === 1 ? "" : "s"
+                                  }`
+                                : undefined
+                            }
+                            onClick={() => {
+                              selectTemplate(template);
+                            }}
+                          />
+                        );
+                      },
+                    )}
+                  </div>
+                </div>
+              );
+            },
+          )}
+
+          {!blankMatches && categoriesWithMatches.length === 0 ? (
+            <div className="py-10 text-center">
+              <Icon
+                icon={IconProp.Search}
+                size={SizeProp.Large}
+                className="mx-auto h-6 w-6 text-gray-400"
+              />
+              <p className="mt-2 text-sm font-medium text-gray-900">
+                No templates match “{search}”.
+              </p>
+              <p className="mt-1 text-sm text-gray-500">
+                Try a different word, or start from scratch.
+              </p>
+            </div>
+          ) : (
+            <></>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  type RenderNameStepFunction = () => ReactElement;
+
+  const renderNameStep: RenderNameStepFunction = (): ReactElement => {
+    return (
+      <div className="space-y-5">
+        {selectedTemplate ? (
+          <div className="flex items-start gap-3 rounded-lg border border-indigo-100 bg-indigo-50/50 p-4">
+            <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-indigo-100">
+              <Icon
+                icon={selectedTemplate.icon}
+                size={SizeProp.Large}
+                className="h-5 w-5 text-indigo-600"
+              />
+            </span>
+            <div>
+              <p className="text-sm font-semibold text-gray-900">
+                {selectedTemplate.name}
+              </p>
+              <p className="mt-1 text-sm text-gray-600">
+                {selectedTemplate.teaches}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <></>
+        )}
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700">
+            Name
+          </label>
+          <Input
+            value={name}
+            autoFocus={true}
+            placeholder="What should this workflow be called?"
+            dataTestId="workflow-name-input"
+            error={nameError}
+            onChange={(value: string) => {
+              setName(value);
+
+              if (nameError) {
+                setNameError("");
+              }
+            }}
+          />
+          <p className="mt-1 text-xs text-gray-500">
+            Workflow names are unique within a project.
+          </p>
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700">
+            Description
+          </label>
+          <TextArea
+            value={description}
+            placeholder="What is this workflow for?"
+            dataTestId="workflow-description-input"
+            onChange={(value: string) => {
+              setDescription(value);
+            }}
+          />
+        </div>
+      </div>
+    );
+  };
+
+  type RenderConfigureStepFunction = () => ReactElement;
+
+  const renderConfigureStep: RenderConfigureStepFunction = (): ReactElement => {
+    return (
+      <div className="space-y-5">
+        <p className="text-sm text-gray-600">
+          {selectedTemplate?.name} needs a few details before it can run. These
+          are saved as workflow variables, so you can change them later without
+          editing the workflow itself.
+        </p>
+
+        {variables.map((variable: WorkflowTemplateVariable): ReactElement => {
+          return (
+            <div key={variable.name}>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                {variable.title}
+                {variable.required ? (
+                  <span className="ml-1 text-red-500">*</span>
+                ) : (
+                  <span className="ml-2 text-xs font-normal text-gray-400">
+                    Optional
+                  </span>
+                )}
+              </label>
+              <Input
+                value={variableValues[variable.name] || ""}
+                placeholder={variable.placeholder}
+                error={variableErrors[variable.name]}
+                dataTestId={`workflow-variable-${variable.name}`}
+                type={
+                  variable.isSecret
+                    ? ("password" as InputType)
+                    : InputType.TEXT
+                }
+                onChange={(value: string) => {
+                  setVariableValues(
+                    (
+                      current: WorkflowTemplateVariableValues,
+                    ): WorkflowTemplateVariableValues => {
+                      return { ...current, [variable.name]: value };
+                    },
+                  );
+
+                  if (variableErrors[variable.name]) {
+                    setVariableErrors(
+                      (
+                        current: WorkflowTemplateVariableErrors,
+                      ): WorkflowTemplateVariableErrors => {
+                        const next: WorkflowTemplateVariableErrors = {
+                          ...current,
+                        };
+                        delete next[variable.name];
+                        return next;
+                      },
+                    );
+                  }
+                }}
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                {variable.description}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  type SubmitTextFunction = () => string;
+
+  const submitButtonText: SubmitTextFunction = (): string => {
+    if (step === WizardStep.NameIt && showConfigureStep) {
+      return "Next";
+    }
+
+    return "Create Workflow";
+  };
+
+  return (
+    <Modal
+      title="Create a workflow"
+      description="Start from a template or build your own. Workflows are created switched off, so nothing runs until you turn them on."
+      modalWidth={ModalWidth.Large}
+      onClose={props.onClose}
+      error={error || undefined}
+      isLoading={isCreating}
+      submitButtonText={step === WizardStep.PickTemplate ? undefined : submitButtonText()}
+      onSubmit={step === WizardStep.PickTemplate ? undefined : onSubmit}
+      leftFooterElement={
+        step === WizardStep.PickTemplate ? (
+          <></>
+        ) : (
+          <Button
+            title="Back"
+            buttonStyle={ButtonStyleType.OUTLINE}
+            icon={IconProp.ChevronLeft}
+            disabled={isCreating}
+            dataTestId="workflow-wizard-back"
+            onClick={goBack}
+          />
+        )
+      }
+    >
+      <div>
+        <StepIndicator current={step} showConfigureStep={showConfigureStep} />
+        {step === WizardStep.PickTemplate ? renderPickStep() : <></>}
+        {step === WizardStep.NameIt ? renderNameStep() : <></>}
+        {step === WizardStep.Configure ? renderConfigureStep() : <></>}
+      </div>
+    </Modal>
+  );
+};
+
+export default CreateWorkflowModal;

--- a/App/FeatureSet/Dashboard/src/Pages/Workflow/Workflows.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Workflow/Workflows.tsx
@@ -24,21 +24,11 @@ import React, {
   ReactElement,
   useState,
 } from "react";
-import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
-import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import ObjectID from "Common/Types/ObjectID";
 import Route from "Common/Types/API/Route";
-import HTTPResponse from "Common/Types/API/HTTPResponse";
-import { JSONArray, JSONObject } from "Common/Types/JSON";
-import API from "Common/UI/Utils/API/API";
-import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import PageMap from "../../Utils/PageMap";
-import {
-  WorkflowTemplate,
-  buildGraphForTemplate,
-  getWorkflowTemplates,
-} from "Common/Types/Workflow/Templates";
+import CreateWorkflowModal from "../../Components/Workflow/CreateWorkflowModal";
 import Pill from "Common/UI/Components/Pill/Pill";
 import { Green500, Red500 } from "Common/Types/BrandColors";
 import WorkflowElement from "../../Components/Workflow/WorkflowElement";
@@ -51,73 +41,7 @@ import { FilterOperator } from "../../Components/ResourceOwners/FilterChipDropdo
 import IconProp from "Common/Types/Icon/IconProp";
 
 const Workflows: FunctionComponent<PageComponentProps> = (): ReactElement => {
-  const [showTemplatePicker, setShowTemplatePicker] = useState<boolean>(false);
-  const [templateError, setTemplateError] = useState<string>("");
-  const [creatingTemplateId, setCreatingTemplateId] = useState<string | null>(
-    null,
-  );
-
-  /*
-   * A template is created through the ordinary Workflow create path, which is
-   * what denormalizes the trigger onto the row (WorkflowService
-   * .onCreateSuccess). Building the graph any other way would produce a
-   * workflow that looks right and never fires.
-   */
-  type CreateFromTemplateFunction = (
-    template: WorkflowTemplate,
-  ) => Promise<void>;
-
-  const createFromTemplate: CreateFromTemplateFunction = async (
-    template: WorkflowTemplate,
-  ): Promise<void> => {
-    setCreatingTemplateId(template.id);
-    setTemplateError("");
-
-    try {
-      const graph: JSONObject | null = buildGraphForTemplate(
-        template.id,
-        () => {
-          return ObjectID.generate().toString();
-        },
-      );
-
-      if (!graph) {
-        throw new Error("This template could not be built.");
-      }
-
-      const workflow: Workflow = new Workflow();
-      workflow.name = template.workflowName;
-      workflow.description = template.workflowDescription;
-      workflow.projectId = ProjectUtil.getCurrentProjectId()!;
-      workflow.graph = graph;
-      /*
-       * Created switched off on purpose: a scheduled template would otherwise
-       * start firing against a placeholder URL the moment it is created.
-       */
-      workflow.isEnabled = false;
-
-      const response: HTTPResponse<
-        JSONObject | JSONArray | Workflow | Array<Workflow>
-      > = await ModelAPI.create<Workflow>({
-        model: workflow,
-        modelType: Workflow,
-      });
-
-      const created: Workflow = response.data as Workflow;
-
-      setShowTemplatePicker(false);
-      Navigation.navigate(
-        RouteUtil.populateRouteParams(
-          RouteMap[PageMap.WORKFLOW_VIEW] as Route,
-          { modelId: created.id as ObjectID },
-        ),
-      );
-    } catch (err) {
-      setTemplateError(API.getFriendlyMessage(err));
-    }
-
-    setCreatingTemplateId(null);
-  };
+  const [showCreateModal, setShowCreateModal] = useState<boolean>(false);
 
   const startDate: Date = OneUptimeDate.getSomeDaysAgo(30);
   const endDate: Date = OneUptimeDate.getCurrentDate();
@@ -209,6 +133,15 @@ const Workflows: FunctionComponent<PageComponentProps> = (): ReactElement => {
           isDeleteable={false}
           isEditable={false}
           isCreateable={true}
+          /*
+           * The built-in create form is replaced by the wizard, which starts
+           * with a template picker. Going through onCreateClick rather than a
+           * cardProps button keeps the permission gating on the create button
+           * — cardProps buttons are not gated.
+           */
+          onCreateClick={() => {
+            setShowCreateModal(true);
+          }}
           bulkActions={{
             buttons: [...labelBulkActions, ...ownerBulkActions],
           }}
@@ -218,16 +151,6 @@ const Workflows: FunctionComponent<PageComponentProps> = (): ReactElement => {
           cardProps={{
             title: "Workflows",
             description: "Here is a list of workflows for this project.",
-            buttons: [
-              {
-                title: "Start from a template",
-                icon: IconProp.Add,
-                buttonStyle: ButtonStyleType.OUTLINE,
-                onClick: () => {
-                  setShowTemplatePicker(true);
-                },
-              },
-            ],
           }}
           videoLink={URL.fromString("https://youtu.be/z-b7_KQcUDY")}
           noItemsMessage={"No workflows found."}
@@ -376,52 +299,27 @@ const Workflows: FunctionComponent<PageComponentProps> = (): ReactElement => {
             },
           ]}
         />
-        {showTemplatePicker && (
-          <Modal
-            title="Start from a template"
-            description="Each of these is a small, working workflow. They are created switched off so you can read them before anything runs."
-            modalWidth={ModalWidth.Large}
-            submitButtonText="Close"
-            submitButtonStyleType={ButtonStyleType.NORMAL}
-            onSubmit={() => {
-              setShowTemplatePicker(false);
+        {showCreateModal ? (
+          <CreateWorkflowModal
+            onClose={() => {
+              setShowCreateModal(false);
             }}
-          >
-            <div className="space-y-3">
-              {templateError && (
-                <p className="text-sm text-red-600">{templateError}</p>
-              )}
-
-              {getWorkflowTemplates().map(
-                (template: WorkflowTemplate): ReactElement => {
-                  return (
-                    <button
-                      key={template.id}
-                      type="button"
-                      disabled={creatingTemplateId !== null}
-                      className="w-full text-left rounded-md border border-gray-200 bg-white p-4 hover:border-gray-400 cursor-pointer disabled:opacity-50"
-                      onClick={() => {
-                        void createFromTemplate(template);
-                      }}
-                    >
-                      <p className="text-sm font-medium text-gray-900">
-                        {template.name}
-                      </p>
-                      <p className="text-sm text-gray-500 mt-1">
-                        {template.description}
-                      </p>
-                      <p className="text-xs text-gray-400 mt-2">
-                        Teaches: {template.teaches}
-                      </p>
-                      {creatingTemplateId === template.id && (
-                        <p className="text-xs text-gray-500 mt-2">Creating…</p>
-                      )}
-                    </button>
-                  );
-                },
-              )}
-            </div>
-          </Modal>
+            onCreated={(workflow: Workflow) => {
+              setShowCreateModal(false);
+              /*
+               * Straight to the builder rather than the overview: the point of
+               * starting from a template is to read the graph it made.
+               */
+              Navigation.navigate(
+                RouteUtil.populateRouteParams(
+                  RouteMap[PageMap.WORKFLOW_BUILDER] as Route,
+                  { modelId: workflow.id as ObjectID },
+                ),
+              );
+            }}
+          />
+        ) : (
+          <></>
         )}
 
         {labelBulkActionModals}

--- a/App/FeatureSet/Dashboard/src/Utils/Workflow/WorkflowTemplateCreateUtil.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Workflow/WorkflowTemplateCreateUtil.ts
@@ -1,0 +1,283 @@
+/*
+ * The pure half of "create a workflow from a template".
+ *
+ * The wizard's own job is screens and state; everything that decides what
+ * actually gets written lives here, with no React and no API calls, because
+ * this is the part where a mistake is expensive and invisible: an unresolved
+ * {{local.variables.…}} reference is NOT an error at run time — VMAPI leaves
+ * the literal text in place and the run still reports success — so a workflow
+ * built slightly wrong looks healthy and posts braces to Slack.
+ */
+
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import Workflow from "Common/Models/DatabaseModels/Workflow";
+import WorkflowVariable from "Common/Models/DatabaseModels/WorkflowVariable";
+import {
+  WORKFLOW_TEMPLATE_VARIABLE_NAME_REGEX,
+  WorkflowTemplate,
+  WorkflowTemplateVariable,
+  buildGraphForTemplate,
+} from "Common/Types/Workflow/Templates";
+
+/** Keyed by WorkflowTemplateVariable.name. */
+export interface WorkflowTemplateVariableValues {
+  [variableName: string]: string;
+}
+
+/** Field-level errors for the variables step, keyed by variable name. */
+export interface WorkflowTemplateVariableErrors {
+  [variableName: string]: string;
+}
+
+export type GenerateIdFunction = () => string;
+
+export const generateWorkflowNodeId: GenerateIdFunction = (): string => {
+  return ObjectID.generate().toString();
+};
+
+type ReferenceForFunction = (variableName: string) => string;
+
+/**
+ * The exact reference string a template uses for a variable. No whitespace
+ * inside the braces: the runtime hands the raw capture to deepFind untrimmed,
+ * and the builder's linter flags a padded reference as an error.
+ */
+export const referenceForVariable: ReferenceForFunction = (
+  variableName: string,
+): string => {
+  return `{{local.variables.${variableName}}}`;
+};
+
+type IsBlankFunction = (value: string | undefined) => boolean;
+
+const isBlank: IsBlankFunction = (value: string | undefined): boolean => {
+  return !value || value.trim() === "";
+};
+
+export type ValidateTemplateVariableValuesFunction = (
+  template: WorkflowTemplate,
+  values: WorkflowTemplateVariableValues,
+) => WorkflowTemplateVariableErrors;
+
+/**
+ * Validates the values typed into the variables step. Returns an empty object
+ * when everything is fine.
+ */
+export const validateTemplateVariableValues: ValidateTemplateVariableValuesFunction =
+  (
+    template: WorkflowTemplate,
+    values: WorkflowTemplateVariableValues,
+  ): WorkflowTemplateVariableErrors => {
+    const errors: WorkflowTemplateVariableErrors = {};
+
+    for (const variable of template.variables) {
+      const value: string | undefined = values[variable.name];
+
+      if (variable.required && isBlank(value)) {
+        errors[variable.name] = `${variable.title} is required.`;
+      }
+    }
+
+    return errors;
+  };
+
+export type TemplateVariablesToFillFunction = (
+  template: WorkflowTemplate | null,
+) => Array<WorkflowTemplateVariable>;
+
+/** Whether the wizard needs to show a variables step at all. */
+export const templateVariablesToFill: TemplateVariablesToFillFunction = (
+  template: WorkflowTemplate | null,
+): Array<WorkflowTemplateVariable> => {
+  return template ? template.variables : [];
+};
+
+interface ApplyValuesProps {
+  graph: JSONObject;
+  template: WorkflowTemplate;
+  values: WorkflowTemplateVariableValues;
+}
+
+export type ApplyTemplateVariableValuesToGraphFunction = (
+  props: ApplyValuesProps,
+) => JSONObject;
+
+/*
+ * Filled variables need no graph edit at all — the reference stays, and the
+ * WorkflowVariable row it points at is created alongside. An OPTIONAL variable
+ * left blank is the case that needs handling: no row gets written for it, so
+ * the reference would resolve to nothing and ship literal braces into (say) an
+ * SMTP username. Where the argument is nothing BUT that reference, drop the
+ * argument, which is what "leave it blank" was supposed to mean.
+ */
+export const applyTemplateVariableValuesToGraph: ApplyTemplateVariableValuesToGraphFunction =
+  (props: ApplyValuesProps): JSONObject => {
+    const unfilled: Array<string> = props.template.variables
+      .filter((variable: WorkflowTemplateVariable) => {
+        return isBlank(props.values[variable.name]);
+      })
+      .map((variable: WorkflowTemplateVariable) => {
+        return referenceForVariable(variable.name);
+      });
+
+    if (unfilled.length === 0) {
+      return props.graph;
+    }
+
+    const nodes: Array<JSONObject> = (props.graph["nodes"] ||
+      []) as Array<JSONObject>;
+
+    for (const node of nodes) {
+      const data: JSONObject | undefined = node["data"] as
+        | JSONObject
+        | undefined;
+
+      const args: JSONObject | undefined = data?.["arguments"] as
+        | JSONObject
+        | undefined;
+
+      if (!args) {
+        continue;
+      }
+
+      for (const argumentId of Object.keys(args)) {
+        const value: unknown = args[argumentId];
+
+        if (typeof value !== "string") {
+          continue;
+        }
+
+        if (unfilled.includes(value.trim())) {
+          delete args[argumentId];
+        }
+      }
+    }
+
+    return props.graph;
+  };
+
+interface BuildWorkflowProps {
+  name: string;
+  description: string;
+  projectId: ObjectID;
+  template?: WorkflowTemplate | null | undefined;
+  values?: WorkflowTemplateVariableValues | undefined;
+  generateId?: GenerateIdFunction | undefined;
+}
+
+export type BuildWorkflowFromTemplateFunction = (
+  props: BuildWorkflowProps,
+) => Workflow;
+
+/**
+ * Builds the Workflow row to POST. A null/absent template yields a blank
+ * workflow with an empty graph, which is what "Start from scratch" produces.
+ */
+export const buildWorkflowFromTemplate: BuildWorkflowFromTemplateFunction = (
+  props: BuildWorkflowProps,
+): Workflow => {
+  const workflow: Workflow = new Workflow();
+
+  workflow.name = props.name.trim();
+  workflow.description = props.description.trim();
+  workflow.projectId = props.projectId;
+
+  /*
+   * Created switched off on purpose: a scheduled template would otherwise
+   * start firing against a placeholder URL the moment it is created, and a
+   * notification template would fire before its variables exist.
+   */
+  workflow.isEnabled = false;
+
+  if (!props.template) {
+    workflow.graph = { nodes: [], edges: [] };
+    return workflow;
+  }
+
+  const graph: JSONObject | null = buildGraphForTemplate(
+    props.template.id,
+    props.generateId || generateWorkflowNodeId,
+  );
+
+  if (!graph) {
+    throw new Error("This template could not be built.");
+  }
+
+  workflow.graph = applyTemplateVariableValuesToGraph({
+    graph: graph,
+    template: props.template,
+    values: props.values || {},
+  });
+
+  return workflow;
+};
+
+interface BuildVariablesProps {
+  template: WorkflowTemplate;
+  values: WorkflowTemplateVariableValues;
+  workflowId: ObjectID;
+  projectId: ObjectID;
+}
+
+export type BuildWorkflowVariablesFunction = (
+  props: BuildVariablesProps,
+) => Array<WorkflowVariable>;
+
+/**
+ * The WorkflowVariable rows to write after the workflow exists. Blank optional
+ * variables are skipped — `content` is a required column, so there is no such
+ * thing as an empty variable, and the matching reference has already been
+ * stripped from the graph by applyTemplateVariableValuesToGraph.
+ */
+export const buildWorkflowVariables: BuildWorkflowVariablesFunction = (
+  props: BuildVariablesProps,
+): Array<WorkflowVariable> => {
+  const variables: Array<WorkflowVariable> = [];
+
+  for (const templateVariable of props.template.variables) {
+    const value: string | undefined = props.values[templateVariable.name];
+
+    if (isBlank(value)) {
+      continue;
+    }
+
+    const variable: WorkflowVariable = new WorkflowVariable();
+
+    variable.name = templateVariable.name;
+    variable.description = templateVariable.description;
+    variable.content = (value as string).trim();
+    variable.workflowId = props.workflowId;
+    variable.projectId = props.projectId;
+
+    /*
+     * isSecret is declared `string` on a genuinely boolean column, so it needs
+     * a cast. It must also be sent explicitly: the column is required and its
+     * `defaultValue` is not an `isDefaultValueColumn`, so leaving it undefined
+     * is a 400 rather than a false.
+     */
+    (variable as unknown as { isSecret?: boolean }).isSecret =
+      templateVariable.isSecret;
+
+    variables.push(variable);
+  }
+
+  return variables;
+};
+
+export type TemplateVariableNamesAreValidFunction = (
+  template: WorkflowTemplate,
+) => boolean;
+
+/**
+ * A template's own variable names have to survive being pasted into a
+ * reference path. Dots are fatal (the path is split on them), and case has to
+ * match exactly, so the picker and the row are always written from this one
+ * string.
+ */
+export const templateVariableNamesAreValid: TemplateVariableNamesAreValidFunction =
+  (template: WorkflowTemplate): boolean => {
+    return template.variables.every((variable: WorkflowTemplateVariable) => {
+      return WORKFLOW_TEMPLATE_VARIABLE_NAME_REGEX.test(variable.name);
+    });
+  };

--- a/App/Tests/Dashboard/WorkflowTemplateCreate.test.ts
+++ b/App/Tests/Dashboard/WorkflowTemplateCreate.test.ts
@@ -1,0 +1,689 @@
+/*
+ * The create-from-template payload builder.
+ *
+ * These assertions exist because every failure mode in this path is silent.
+ * An unresolved {{local.variables.…}} reference is not an error at run time —
+ * VMAPI leaves the literal text in place and the run reports success — so a
+ * workflow assembled slightly wrong looks perfectly healthy while posting
+ * braces to Slack. And a WorkflowVariable created without an explicit
+ * isSecret is a 400 from the API, because the column is required and its
+ * declared defaultValue is not an isDefaultValueColumn.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONObject } from "Common/Types/JSON";
+import Workflow from "Common/Models/DatabaseModels/Workflow";
+import WorkflowVariable from "Common/Models/DatabaseModels/WorkflowVariable";
+import {
+  WorkflowTemplate,
+  WorkflowTemplateVariable,
+  getWorkflowTemplate,
+  getWorkflowTemplates,
+} from "Common/Types/Workflow/Templates";
+import {
+  applyTemplateVariableValuesToGraph,
+  buildWorkflowFromTemplate,
+  buildWorkflowVariables,
+  referenceForVariable,
+  templateVariableNamesAreValid,
+  templateVariablesToFill,
+  validateTemplateVariableValues,
+} from "../../FeatureSet/Dashboard/src/Utils/Workflow/WorkflowTemplateCreateUtil";
+
+const projectId: ObjectID = ObjectID.generate();
+const workflowId: ObjectID = ObjectID.generate();
+
+let counter: number = 0;
+
+type GenerateIdFunction = () => string;
+
+const generateId: GenerateIdFunction = (): string => {
+  counter++;
+  return `generated-${counter}`;
+};
+
+/** A template with a required secret and nothing else. */
+const slackTemplate: WorkflowTemplate = getWorkflowTemplate(
+  "incident-created-slack",
+) as WorkflowTemplate;
+
+/** A template carrying optional variables, which is the interesting case. */
+const emailTemplate: WorkflowTemplate = getWorkflowTemplate(
+  "scheduled-email-digest",
+) as WorkflowTemplate;
+
+type NodeArgumentsFunction = (
+  graph: JSONObject,
+  componentId: string,
+) => JSONObject;
+
+const argumentsOfComponent: NodeArgumentsFunction = (
+  graph: JSONObject,
+  componentId: string,
+): JSONObject => {
+  const node: JSONObject = (graph["nodes"] as Array<JSONObject>).find(
+    (candidate: JSONObject) => {
+      return (candidate["data"] as JSONObject)["id"] === componentId;
+    },
+  ) as JSONObject;
+
+  return (node["data"] as JSONObject)["arguments"] as JSONObject;
+};
+
+describe("referenceForVariable", () => {
+  test("produces the exact form the runtime resolves", () => {
+    expect(referenceForVariable("slackWebhookUrl")).toBe(
+      "{{local.variables.slackWebhookUrl}}",
+    );
+  });
+
+  /*
+   * Whitespace inside the braces is the classic silent failure: VMAPI hands
+   * the untrimmed capture to deepFind, so it resolves to nothing.
+   */
+  test("puts no whitespace inside the braces", () => {
+    expect(referenceForVariable("apiUrl")).not.toMatch(/{{\s|\s}}/);
+  });
+});
+
+describe("templateVariableNamesAreValid", () => {
+  test("every shipped template passes", () => {
+    for (const template of getWorkflowTemplates()) {
+      expect({
+        template: template.id,
+        valid: templateVariableNamesAreValid(template),
+      }).toEqual({ template: template.id, valid: true });
+    }
+  });
+
+  test("a name with a dot is rejected, because paths split on dots", () => {
+    expect(
+      templateVariableNamesAreValid({
+        ...slackTemplate,
+        variables: [
+          {
+            name: "slack.url",
+            title: "Slack",
+            description: "d",
+            placeholder: "p",
+            required: true,
+            isSecret: true,
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  test("a name with a space is rejected", () => {
+    expect(
+      templateVariableNamesAreValid({
+        ...slackTemplate,
+        variables: [
+          {
+            name: "slack url",
+            title: "Slack",
+            description: "d",
+            placeholder: "p",
+            required: true,
+            isSecret: true,
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("templateVariablesToFill", () => {
+  test("a blank workflow needs no configuration step", () => {
+    expect(templateVariablesToFill(null)).toEqual([]);
+  });
+
+  test("a zero-config template needs no configuration step", () => {
+    expect(
+      templateVariablesToFill(
+        getWorkflowTemplate("manual-log") as WorkflowTemplate,
+      ),
+    ).toEqual([]);
+  });
+
+  test("a template with variables reports them", () => {
+    expect(templateVariablesToFill(slackTemplate).length).toBeGreaterThan(0);
+  });
+});
+
+describe("validateTemplateVariableValues", () => {
+  test("accepts a filled required variable", () => {
+    expect(
+      validateTemplateVariableValues(slackTemplate, {
+        slackWebhookUrl: "https://hooks.slack.com/services/T/B/X",
+      }),
+    ).toEqual({});
+  });
+
+  test("rejects a missing required variable", () => {
+    const errors: JSONObject = validateTemplateVariableValues(
+      slackTemplate,
+      {},
+    ) as unknown as JSONObject;
+
+    expect(Object.keys(errors)).toEqual(["slackWebhookUrl"]);
+  });
+
+  test("whitespace is not a value", () => {
+    expect(
+      Object.keys(
+        validateTemplateVariableValues(slackTemplate, {
+          slackWebhookUrl: "   ",
+        }),
+      ),
+    ).toEqual(["slackWebhookUrl"]);
+  });
+
+  test("optional variables may be left blank", () => {
+    const errors: Record<string, string> = validateTemplateVariableValues(
+      emailTemplate,
+      {
+        smtpHost: "smtp.example.com",
+        smtpPort: "587",
+        emailFrom: "a@example.com",
+        emailTo: "b@example.com",
+      },
+    );
+
+    expect(errors).toEqual({});
+  });
+
+  test("names every required field that is missing, not just the first", () => {
+    const errors: Record<string, string> = validateTemplateVariableValues(
+      emailTemplate,
+      {},
+    );
+
+    expect(Object.keys(errors).sort()).toEqual(
+      emailTemplate.variables
+        .filter((variable: WorkflowTemplateVariable) => {
+          return variable.required;
+        })
+        .map((variable: WorkflowTemplateVariable) => {
+          return variable.name;
+        })
+        .sort(),
+    );
+  });
+});
+
+describe("buildWorkflowFromTemplate", () => {
+  test("a blank workflow gets an empty graph, not a missing one", () => {
+    const workflow: Workflow = buildWorkflowFromTemplate({
+      name: "My workflow",
+      description: "Something",
+      projectId: projectId,
+      template: null,
+      generateId: generateId,
+    });
+
+    expect(workflow.graph).toEqual({ nodes: [], edges: [] });
+  });
+
+  /*
+   * saveTriggerFromGraph writes triggerId: null for a graph with no trigger
+   * nodes, which is what makes a blank workflow safe to create through the
+   * ordinary path.
+   */
+  test("a blank workflow carries no trigger", () => {
+    const workflow: Workflow = buildWorkflowFromTemplate({
+      name: "My workflow",
+      description: "",
+      projectId: projectId,
+      template: null,
+      generateId: generateId,
+    });
+
+    expect((workflow.graph as JSONObject)["nodes"]).toEqual([]);
+  });
+
+  test("it is created switched off, whatever the template", () => {
+    for (const template of getWorkflowTemplates()) {
+      const workflow: Workflow = buildWorkflowFromTemplate({
+        name: "n",
+        description: "d",
+        projectId: projectId,
+        template: template,
+        values: {},
+        generateId: generateId,
+      });
+
+      expect({ template: template.id, isEnabled: workflow.isEnabled }).toEqual({
+        template: template.id,
+        isEnabled: false,
+      });
+    }
+  });
+
+  test("name and description are trimmed", () => {
+    const workflow: Workflow = buildWorkflowFromTemplate({
+      name: "  Padded  ",
+      description: "  Also padded  ",
+      projectId: projectId,
+      template: null,
+      generateId: generateId,
+    });
+
+    expect(workflow.name).toBe("Padded");
+    expect(workflow.description).toBe("Also padded");
+  });
+
+  test("the project is stamped on it", () => {
+    const workflow: Workflow = buildWorkflowFromTemplate({
+      name: "n",
+      description: "d",
+      projectId: projectId,
+      template: null,
+      generateId: generateId,
+    });
+
+    expect(workflow.projectId).toBe(projectId);
+  });
+
+  test("a template's graph is built with its nodes and edges", () => {
+    const workflow: Workflow = buildWorkflowFromTemplate({
+      name: "n",
+      description: "d",
+      projectId: projectId,
+      template: slackTemplate,
+      values: { slackWebhookUrl: "https://hooks.slack.com/x" },
+      generateId: generateId,
+    });
+
+    const graph: JSONObject = workflow.graph as JSONObject;
+
+    expect((graph["nodes"] as Array<JSONObject>).length).toBeGreaterThan(0);
+    expect((graph["edges"] as Array<JSONObject>).length).toBeGreaterThan(0);
+  });
+
+  /*
+   * The value goes into a WorkflowVariable row, NOT into the graph. The graph
+   * keeps the reference, which is what lets the value be changed later without
+   * editing the workflow.
+   */
+  test("a filled variable leaves the reference in the graph", () => {
+    const workflow: Workflow = buildWorkflowFromTemplate({
+      name: "n",
+      description: "d",
+      projectId: projectId,
+      template: slackTemplate,
+      values: { slackWebhookUrl: "https://hooks.slack.com/secret" },
+      generateId: generateId,
+    });
+
+    const args: JSONObject = argumentsOfComponent(
+      workflow.graph as JSONObject,
+      "slack-1",
+    );
+
+    expect(args["webhook-url"]).toBe("{{local.variables.slackWebhookUrl}}");
+  });
+
+  test("the typed value is never written into the graph", () => {
+    const secret: string = "https://hooks.slack.com/super-secret";
+
+    const workflow: Workflow = buildWorkflowFromTemplate({
+      name: "n",
+      description: "d",
+      projectId: projectId,
+      template: slackTemplate,
+      values: { slackWebhookUrl: secret },
+      generateId: generateId,
+    });
+
+    expect(JSON.stringify(workflow.graph)).not.toContain(secret);
+  });
+
+  /*
+   * A blank optional variable gets no row, so leaving its reference behind
+   * would ship "{{local.variables.smtpUsername}}" as the SMTP username.
+   */
+  test("a blank optional variable has its argument dropped", () => {
+    const workflow: Workflow = buildWorkflowFromTemplate({
+      name: "n",
+      description: "d",
+      projectId: projectId,
+      template: emailTemplate,
+      values: {
+        smtpHost: "smtp.example.com",
+        smtpPort: "587",
+        emailFrom: "a@example.com",
+        emailTo: "b@example.com",
+      },
+      generateId: generateId,
+    });
+
+    const args: JSONObject = argumentsOfComponent(
+      workflow.graph as JSONObject,
+      "send-email-1",
+    );
+
+    expect(args["smtp-username"]).toBeUndefined();
+    expect(args["smtp-password"]).toBeUndefined();
+    expect(args["smtp-host"]).toBe("{{local.variables.smtpHost}}");
+  });
+
+  test("a filled optional variable keeps its argument", () => {
+    const workflow: Workflow = buildWorkflowFromTemplate({
+      name: "n",
+      description: "d",
+      projectId: projectId,
+      template: emailTemplate,
+      values: {
+        smtpHost: "smtp.example.com",
+        smtpPort: "587",
+        smtpUsername: "someone",
+        smtpPassword: "hunter2",
+        emailFrom: "a@example.com",
+        emailTo: "b@example.com",
+      },
+      generateId: generateId,
+    });
+
+    const args: JSONObject = argumentsOfComponent(
+      workflow.graph as JSONObject,
+      "send-email-1",
+    );
+
+    expect(args["smtp-username"]).toBe("{{local.variables.smtpUsername}}");
+    expect(args["smtp-password"]).toBe("{{local.variables.smtpPassword}}");
+  });
+
+  test("building twice does not disturb the shipped template", () => {
+    const first: Workflow = buildWorkflowFromTemplate({
+      name: "n",
+      description: "d",
+      projectId: projectId,
+      template: emailTemplate,
+      values: { smtpHost: "h", smtpPort: "1", emailFrom: "a", emailTo: "b" },
+      generateId: generateId,
+    });
+
+    expect(
+      argumentsOfComponent(first.graph as JSONObject, "send-email-1")[
+        "smtp-username"
+      ],
+    ).toBeUndefined();
+
+    const second: Workflow = buildWorkflowFromTemplate({
+      name: "n",
+      description: "d",
+      projectId: projectId,
+      template: emailTemplate,
+      values: {
+        smtpHost: "h",
+        smtpPort: "1",
+        smtpUsername: "u",
+        smtpPassword: "p",
+        emailFrom: "a",
+        emailTo: "b",
+      },
+      generateId: generateId,
+    });
+
+    expect(
+      argumentsOfComponent(second.graph as JSONObject, "send-email-1")[
+        "smtp-username"
+      ],
+    ).toBe("{{local.variables.smtpUsername}}");
+  });
+
+  test("every shipped template builds without throwing", () => {
+    for (const template of getWorkflowTemplates()) {
+      expect(() => {
+        return buildWorkflowFromTemplate({
+          name: template.workflowName,
+          description: template.workflowDescription,
+          projectId: projectId,
+          template: template,
+          values: {},
+          generateId: generateId,
+        });
+      }).not.toThrow();
+    }
+  });
+});
+
+describe("applyTemplateVariableValuesToGraph", () => {
+  test("an all-filled template's graph is returned untouched", () => {
+    const graph: JSONObject = {
+      nodes: [
+        {
+          data: {
+            id: "slack-1",
+            arguments: { "webhook-url": "{{local.variables.slackWebhookUrl}}" },
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const result: JSONObject = applyTemplateVariableValuesToGraph({
+      graph: graph,
+      template: slackTemplate,
+      values: { slackWebhookUrl: "https://hooks.slack.com/x" },
+    });
+
+    expect(argumentsOfComponent(result, "slack-1")["webhook-url"]).toBe(
+      "{{local.variables.slackWebhookUrl}}",
+    );
+  });
+
+  test("an argument that merely mentions an unfilled variable is left alone", () => {
+    const graph: JSONObject = {
+      nodes: [
+        {
+          data: {
+            id: "log-1",
+            arguments: {
+              value: "Sending to {{local.variables.smtpUsername}} now",
+            },
+          },
+        },
+      ],
+      edges: [],
+    };
+
+    const result: JSONObject = applyTemplateVariableValuesToGraph({
+      graph: graph,
+      template: emailTemplate,
+      values: {},
+    });
+
+    expect(argumentsOfComponent(result, "log-1")["value"]).toBe(
+      "Sending to {{local.variables.smtpUsername}} now",
+    );
+  });
+
+  test("a graph with no nodes key does not throw", () => {
+    expect(() => {
+      return applyTemplateVariableValuesToGraph({
+        graph: {},
+        template: emailTemplate,
+        values: {},
+      });
+    }).not.toThrow();
+  });
+});
+
+describe("buildWorkflowVariables", () => {
+  test("one row per filled variable", () => {
+    const rows: Array<WorkflowVariable> = buildWorkflowVariables({
+      template: slackTemplate,
+      values: { slackWebhookUrl: "https://hooks.slack.com/x" },
+      workflowId: workflowId,
+      projectId: projectId,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.name).toBe("slackWebhookUrl");
+    expect(rows[0]?.content).toBe("https://hooks.slack.com/x");
+  });
+
+  test("the row is scoped to the workflow, which is what makes it local.", () => {
+    const rows: Array<WorkflowVariable> = buildWorkflowVariables({
+      template: slackTemplate,
+      values: { slackWebhookUrl: "https://hooks.slack.com/x" },
+      workflowId: workflowId,
+      projectId: projectId,
+    });
+
+    expect(rows[0]?.workflowId).toBe(workflowId);
+    expect(rows[0]?.projectId).toBe(projectId);
+  });
+
+  /*
+   * isSecret is required by the API and has no usable default, so it must be
+   * present and boolean on every row. Sending undefined is a 400.
+   */
+  test("isSecret is always sent, as a real boolean", () => {
+    const rows: Array<WorkflowVariable> = buildWorkflowVariables({
+      template: emailTemplate,
+      values: {
+        smtpHost: "smtp.example.com",
+        smtpPort: "587",
+        smtpPassword: "hunter2",
+        emailFrom: "a@example.com",
+        emailTo: "b@example.com",
+      },
+      workflowId: workflowId,
+      projectId: projectId,
+    });
+
+    expect(rows.length).toBeGreaterThan(0);
+
+    for (const row of rows) {
+      const isSecret: unknown = (row as unknown as { isSecret?: unknown })
+        .isSecret;
+
+      expect(typeof isSecret).toBe("boolean");
+    }
+  });
+
+  test("the secret variable is marked secret and the others are not", () => {
+    const rows: Array<WorkflowVariable> = buildWorkflowVariables({
+      template: emailTemplate,
+      values: {
+        smtpHost: "smtp.example.com",
+        smtpPort: "587",
+        smtpPassword: "hunter2",
+        emailFrom: "a@example.com",
+        emailTo: "b@example.com",
+      },
+      workflowId: workflowId,
+      projectId: projectId,
+    });
+
+    const byName: Record<string, boolean> = {};
+
+    for (const row of rows) {
+      byName[row.name as string] = (
+        row as unknown as { isSecret?: boolean }
+      ).isSecret as boolean;
+    }
+
+    expect(byName["smtpPassword"]).toBe(true);
+    expect(byName["smtpHost"]).toBe(false);
+  });
+
+  test("blank optional variables get no row at all", () => {
+    const rows: Array<WorkflowVariable> = buildWorkflowVariables({
+      template: emailTemplate,
+      values: {
+        smtpHost: "smtp.example.com",
+        smtpPort: "587",
+        emailFrom: "a@example.com",
+        emailTo: "b@example.com",
+      },
+      workflowId: workflowId,
+      projectId: projectId,
+    });
+
+    const names: Array<string> = rows.map((row: WorkflowVariable) => {
+      return row.name as string;
+    });
+
+    expect(names).not.toContain("smtpUsername");
+    expect(names).not.toContain("smtpPassword");
+    expect(names).toContain("smtpHost");
+  });
+
+  test("values are trimmed, because a stray space breaks a URL", () => {
+    const rows: Array<WorkflowVariable> = buildWorkflowVariables({
+      template: slackTemplate,
+      values: { slackWebhookUrl: "  https://hooks.slack.com/x  " },
+      workflowId: workflowId,
+      projectId: projectId,
+    });
+
+    expect(rows[0]?.content).toBe("https://hooks.slack.com/x");
+  });
+
+  /*
+   * The name written to the row and the name inside the reference come from
+   * the same string. Runtime lookup is case-sensitive while the uniqueness
+   * check is not, so a drift here fails silently rather than loudly.
+   */
+  test("the row name matches the reference the graph carries", () => {
+    for (const template of getWorkflowTemplates()) {
+      if (template.variables.length === 0) {
+        continue;
+      }
+
+      const values: Record<string, string> = {};
+
+      for (const variable of template.variables) {
+        values[variable.name] = "value";
+      }
+
+      const workflow: Workflow = buildWorkflowFromTemplate({
+        name: "n",
+        description: "d",
+        projectId: projectId,
+        template: template,
+        values: values,
+        generateId: generateId,
+      });
+
+      const rows: Array<WorkflowVariable> = buildWorkflowVariables({
+        template: template,
+        values: values,
+        workflowId: workflowId,
+        projectId: projectId,
+      });
+
+      const serialized: string = JSON.stringify(workflow.graph);
+
+      for (const row of rows) {
+        expect({
+          template: template.id,
+          reference: referenceForVariable(row.name as string),
+          present: serialized.includes(
+            referenceForVariable(row.name as string),
+          ),
+        }).toEqual({
+          template: template.id,
+          reference: referenceForVariable(row.name as string),
+          present: true,
+        });
+      }
+    }
+  });
+
+  test("a zero-variable template produces no rows", () => {
+    expect(
+      buildWorkflowVariables({
+        template: getWorkflowTemplate("manual-log") as WorkflowTemplate,
+        values: {},
+        workflowId: workflowId,
+        projectId: projectId,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/Common/Models/DatabaseModels/WorkflowVariable.ts
+++ b/Common/Models/DatabaseModels/WorkflowVariable.ts
@@ -33,10 +33,22 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 })
 @TenantColumn("projectId")
 @TableAccessControl({
+  /*
+   * Mirrors Workflow's own create list. Anyone who can create a workflow can
+   * create the variables that workflow needs — the create-from-template wizard
+   * writes both in one go, and a member who could do the first but not the
+   * second was left with a saved workflow whose {{local.variables.…}}
+   * references resolved to nothing. Unresolved references are not an error at
+   * run time (VMAPI leaves the literal text in place), so that workflow looked
+   * healthy and posted braces to Slack.
+   */
   create: [
     Permission.ProjectOwner,
     Permission.ProjectAdmin,
     Permission.CreateWorkflowVariable,
+    Permission.ProjectMember,
+    Permission.WorkflowAdmin,
+    Permission.WorkflowMember,
   ],
   read: [
     Permission.ProjectOwner,

--- a/Common/Tests/Types/Workflow/Templates.test.ts
+++ b/Common/Tests/Types/Workflow/Templates.test.ts
@@ -10,15 +10,35 @@
  * argument is "value" (not "log-message"), the Schedule trigger's is
  * "schedule" (not "schedule-at"), the Manual trigger leaves by "success" and
  * the Schedule trigger by "execute" (neither is "out").
+ *
+ * Two things here are load-bearing and easy to get wrong when extending this
+ * file:
+ *
+ *   1. The registry is the MERGED one (loadComponentsAndCategories), not the
+ *      static Components array. Templates use database-model components like
+ *      `incident-on-create`, which only exist in the merged registry. Against
+ *      the static array those nodes get `metadata: undefined`, the linter's
+ *      isRealNode silently drops them, and the lint test passes on a graph it
+ *      never checked.
+ *
+ *   2. References are classified with parseReferencePath rather than by
+ *      assuming every {{...}} is local.components.*. Templates now also carry
+ *      {{local.variables.*}}, and a test that assumes otherwise fails on
+ *      correct templates.
  */
 
 import {
+  WORKFLOW_TEMPLATE_VARIABLE_NAME_REGEX,
   WorkflowTemplate,
+  WorkflowTemplateCategories,
+  WorkflowTemplateCategory,
+  WorkflowTemplateVariable,
   buildGraphForTemplate,
   getTemplateGraphSpec,
+  getWorkflowTemplate,
   getWorkflowTemplates,
+  getWorkflowTemplatesByCategory,
 } from "../../../Types/Workflow/Templates";
-import Components from "../../../Types/Workflow/Components";
 import ComponentMetadata, {
   Argument,
   ComponentType,
@@ -26,7 +46,8 @@ import ComponentMetadata, {
   Port,
   ReturnValue,
 } from "../../../Types/Workflow/Component";
-import { JSONObject } from "../../../Types/JSON";
+import { JSONObject, JSONValue } from "../../../Types/JSON";
+import IconProp from "../../../Types/Icon/IconProp";
 import {
   LintGraphEdge,
   LintGraphNode,
@@ -35,9 +56,25 @@ import {
   WorkflowLintSeverity,
   lintWorkflowGraph,
 } from "../../../UI/Components/Workflow/GraphLint";
+import { loadComponentsAndCategories } from "../../../UI/Components/Workflow/Utils";
+import {
+  ParsedReferencePath,
+  ReferenceRootType,
+  TemplateExpression,
+  TemplateExpressionKind,
+  parseReferencePath,
+  parseTemplateExpressions,
+} from "../../../Types/Workflow/TemplateSyntax";
 import { describe, expect, test } from "@jest/globals";
 
 const templates: Array<WorkflowTemplate> = getWorkflowTemplates();
+
+/*
+ * The same registry the builder loads: static components plus one set per
+ * database model. Built once — it walks every entity in the models index.
+ */
+const registry: Array<ComponentMetadata> =
+  loadComponentsAndCategories().components;
 
 type FindMetadataFunction = (
   metadataId: string,
@@ -46,7 +83,7 @@ type FindMetadataFunction = (
 const findMetadata: FindMetadataFunction = (
   metadataId: string,
 ): ComponentMetadata | undefined => {
-  return Components.find((component: ComponentMetadata) => {
+  return registry.find((component: ComponentMetadata) => {
     return component.id === metadataId;
   });
 };
@@ -58,6 +95,30 @@ type GenerateIdFunction = () => string;
 const generateId: GenerateIdFunction = (): string => {
   idCounter++;
   return `generated-${idCounter}`;
+};
+
+interface TemplateNodeSpec {
+  componentId: string;
+  metadataId: string;
+  componentType: ComponentType;
+  args?: JSONObject | undefined;
+}
+
+interface TemplateEdgeSpec {
+  fromComponentId: string;
+  toComponentId: string;
+  fromPort: string;
+}
+
+interface TemplateSpec {
+  nodes: Array<TemplateNodeSpec>;
+  edges: Array<TemplateEdgeSpec>;
+}
+
+type SpecOfFunction = (templateId: string) => TemplateSpec;
+
+const specOf: SpecOfFunction = (templateId: string): TemplateSpec => {
+  return getTemplateGraphSpec(templateId) as unknown as TemplateSpec;
 };
 
 /**
@@ -110,9 +171,119 @@ const hydrate: HydrateFunction = (
   return { nodes: nodes, edges: edges };
 };
 
+/** Every string an argument holds, including strings nested inside JSON objects. */
+type CollectStringsFunction = (value: JSONValue | undefined) => Array<string>;
+
+const collectStrings: CollectStringsFunction = (
+  value: JSONValue | undefined,
+): Array<string> => {
+  if (typeof value === "string") {
+    return [value];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry: JSONValue) => {
+      return collectStrings(entry);
+    });
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value as JSONObject).flatMap((entry: JSONValue) => {
+      return collectStrings(entry);
+    });
+  }
+
+  return [];
+};
+
+interface TemplateReference {
+  /** The full {{...}} text. */
+  raw: string;
+  inner: string;
+  parsed: ParsedReferencePath;
+  /** The component id the argument lives on. */
+  onComponentId: string;
+}
+
+type ReferencesOfFunction = (templateId: string) => Array<TemplateReference>;
+
+const referencesOf: ReferencesOfFunction = (
+  templateId: string,
+): Array<TemplateReference> => {
+  const spec: TemplateSpec = specOf(templateId);
+  const references: Array<TemplateReference> = [];
+
+  for (const node of spec.nodes) {
+    for (const value of Object.values(node.args || {})) {
+      for (const text of collectStrings(value as JSONValue)) {
+        const expressions: Array<TemplateExpression> =
+          parseTemplateExpressions(text);
+
+        for (const expression of expressions) {
+          if (expression.kind !== TemplateExpressionKind.Reference) {
+            continue;
+          }
+
+          references.push({
+            raw: expression.raw,
+            inner: expression.inner,
+            parsed: parseReferencePath(expression.inner),
+            onComponentId: node.componentId,
+          });
+        }
+      }
+    }
+  }
+
+  return references;
+};
+
+/**
+ * Whether a trigger's `select` argument actually asks for the field a
+ * reference reads. The runtime only hydrates what `select` names, so
+ * {{…returnValues.model.title}} against a select without `title` resolves to
+ * nothing — and an unresolved reference is not an error, it just ships the
+ * literal braces.
+ */
+type SelectCoversFunction = (
+  select: JSONValue | undefined,
+  path: Array<string>,
+) => boolean;
+
+const selectCovers: SelectCoversFunction = (
+  select: JSONValue | undefined,
+  path: Array<string>,
+): boolean => {
+  if (path.length === 0) {
+    return true;
+  }
+
+  // The runtime always adds _id to the select it issues.
+  if (path.length === 1 && (path[0] === "_id" || path[0] === "id")) {
+    return true;
+  }
+
+  if (!select || typeof select !== "object" || Array.isArray(select)) {
+    return false;
+  }
+
+  const head: string = path[0] as string;
+  const branch: JSONValue | undefined = (select as JSONObject)[head];
+
+  if (branch === undefined) {
+    return false;
+  }
+
+  if (path.length === 1) {
+    return Boolean(branch);
+  }
+
+  return selectCovers(branch, path.slice(1));
+};
+
 describe("workflow templates", () => {
-  test("there is at least one", () => {
-    expect(templates.length).toBeGreaterThan(0);
+  test("there are plenty to choose from", () => {
+    expect(templates.length).toBeGreaterThan(10);
   });
 
   test("each has a unique id", () => {
@@ -121,6 +292,20 @@ describe("workflow templates", () => {
     });
 
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("each id is dash-cased, so it is safe in a URL and in a test name", () => {
+    for (const template of templates) {
+      expect(template.id).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+  });
+
+  test("each suggests a distinct workflow name", () => {
+    const names: Array<string> = templates.map((template: WorkflowTemplate) => {
+      return template.workflowName;
+    });
+
+    expect(new Set(names).size).toBe(names.length);
   });
 
   test("each is described well enough to choose between them", () => {
@@ -133,9 +318,179 @@ describe("workflow templates", () => {
     }
   });
 
+  test("each belongs to a category the picker knows how to show", () => {
+    for (const template of templates) {
+      expect(WorkflowTemplateCategories).toContain(template.category);
+    }
+  });
+
+  test("each category in the picker has at least one template", () => {
+    for (const category of WorkflowTemplateCategories) {
+      expect(getWorkflowTemplatesByCategory(category).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("grouping by category accounts for every template exactly once", () => {
+    const grouped: Array<WorkflowTemplate> = WorkflowTemplateCategories.flatMap(
+      (category: WorkflowTemplateCategory) => {
+        return getWorkflowTemplatesByCategory(category);
+      },
+    );
+
+    expect(grouped).toHaveLength(templates.length);
+  });
+
+  test("each has an icon that exists", () => {
+    const iconValues: Array<string> = Object.values(IconProp);
+
+    for (const template of templates) {
+      expect(iconValues).toContain(template.icon);
+    }
+  });
+
+  test("getWorkflowTemplate finds each one, and nothing else", () => {
+    for (const template of templates) {
+      expect(getWorkflowTemplate(template.id)?.name).toBe(template.name);
+    }
+
+    expect(getWorkflowTemplate("does-not-exist")).toBeNull();
+  });
+
   test("an unknown template id yields nothing rather than throwing", () => {
     expect(getTemplateGraphSpec("does-not-exist")).toBeNull();
     expect(buildGraphForTemplate("does-not-exist", generateId)).toBeNull();
+  });
+
+  test("the public template carries no graph, so the picker cannot depend on one", () => {
+    for (const template of templates) {
+      expect(
+        (template as unknown as JSONObject)["graph"],
+      ).toBeUndefined();
+    }
+  });
+
+  /*
+   * Every field on WorkflowTemplate has to survive the trip out of the module.
+   * The accessor used to hand-enumerate its output fields, which silently
+   * dropped anything newly added — the picker would render a card with no icon
+   * and the wizard would show no variables step.
+   */
+  test("no declared field is dropped on the way out", () => {
+    for (const template of templates) {
+      expect(Object.keys(template).sort()).toEqual(
+        [
+          "category",
+          "description",
+          "icon",
+          "id",
+          "name",
+          "teaches",
+          "variables",
+          "workflowDescription",
+          "workflowName",
+        ].sort(),
+      );
+    }
+  });
+});
+
+describe("workflow template variables", () => {
+  test("names are usable in a reference path", () => {
+    for (const template of templates) {
+      for (const variable of template.variables) {
+        expect(variable.name).toMatch(WORKFLOW_TEMPLATE_VARIABLE_NAME_REGEX);
+      }
+    }
+  });
+
+  /*
+   * A dot is fatal specifically: VMUtil.deepFind splits the whole path on
+   * dots, so local.variables.slack.url looks for a variable called "slack".
+   */
+  test("no name contains a dot or whitespace", () => {
+    for (const template of templates) {
+      for (const variable of template.variables) {
+        expect(variable.name).not.toContain(".");
+        expect(variable.name).not.toMatch(/\s/);
+      }
+    }
+  });
+
+  test("names are unique within a template, because they become one row each", () => {
+    for (const template of templates) {
+      const names: Array<string> = template.variables.map(
+        (variable: WorkflowTemplateVariable) => {
+          return variable.name;
+        },
+      );
+
+      expect(new Set(names).size).toBe(names.length);
+    }
+  });
+
+  test("each is described well enough to fill in", () => {
+    for (const template of templates) {
+      for (const variable of template.variables) {
+        expect(variable.title.length).toBeGreaterThan(0);
+        expect(variable.description.length).toBeGreaterThan(0);
+        expect(variable.placeholder.length).toBeGreaterThan(0);
+        expect(typeof variable.required).toBe("boolean");
+        expect(typeof variable.isSecret).toBe("boolean");
+      }
+    }
+  });
+
+  /*
+   * A variable name is reused across templates on purpose (slackWebhookUrl
+   * appears in many), and each template is free to label and explain it in its
+   * own words — "URL to call" reads better on an hourly poll than "URL to
+   * check" does. Variables are workflow-scoped, so two templates never share a
+   * row, and nothing forces the wording to agree.
+   *
+   * What must NOT drift is the behaviour attached to the name. `required`
+   * decides whether a row is written at all, and `isSecret` decides whether
+   * the value is redacted from run logs. The same field being secret in one
+   * template and not in another is a bug, not a wording choice.
+   */
+  test("a name reused across templates behaves the same way", () => {
+    const byName: Map<string, { required: boolean; isSecret: boolean }> =
+      new Map();
+
+    for (const template of templates) {
+      for (const variable of template.variables) {
+        const behaviour: { required: boolean; isSecret: boolean } = {
+          required: variable.required,
+          isSecret: variable.isSecret,
+        };
+
+        const seen: { required: boolean; isSecret: boolean } | undefined =
+          byName.get(variable.name);
+
+        if (!seen) {
+          byName.set(variable.name, behaviour);
+          continue;
+        }
+
+        expect({ name: variable.name, ...behaviour }).toEqual({
+          name: variable.name,
+          ...seen,
+        });
+      }
+    }
+  });
+
+  test("secrets are the ones that should be secret", () => {
+    for (const template of templates) {
+      for (const variable of template.variables) {
+        if (!variable.isSecret) {
+          continue;
+        }
+
+        expect(variable.title.toLowerCase()).toMatch(
+          /url|token|password|key|secret/,
+        );
+      }
+    }
   });
 });
 
@@ -143,25 +498,33 @@ describe.each(
   templates.map((template: WorkflowTemplate) => {
     return [template.id, template] as [string, WorkflowTemplate];
   }),
-)("template %s", (templateId: string) => {
+)("template %s", (templateId: string, template: WorkflowTemplate) => {
   test("every component it uses exists in the registry", () => {
-    const spec: { nodes: Array<{ metadataId: string }> } = getTemplateGraphSpec(
-      templateId,
-    ) as { nodes: Array<{ metadataId: string }> };
+    for (const node of specOf(templateId).nodes) {
+      expect({
+        metadataId: node.metadataId,
+        found: Boolean(findMetadata(node.metadataId)),
+      }).toEqual({ metadataId: node.metadataId, found: true });
+    }
+  });
 
-    for (const node of spec.nodes) {
-      expect(findMetadata(node.metadataId)).toBeDefined();
+  /*
+   * The builder throws BadDataException on load for a node whose metadataId is
+   * not in the registry, which breaks the whole page rather than one node. So
+   * a typo here does not degrade a template, it bricks it.
+   */
+  test("the node's declared componentType matches the registry's", () => {
+    for (const node of specOf(templateId).nodes) {
+      const metadata: ComponentMetadata = findMetadata(
+        node.metadataId,
+      ) as ComponentMetadata;
+
+      expect(node.componentType).toBe(metadata.componentType);
     }
   });
 
   test("every argument it sets is a real argument on that component", () => {
-    const spec: {
-      nodes: Array<{ metadataId: string; args?: JSONObject | undefined }>;
-    } = getTemplateGraphSpec(templateId) as {
-      nodes: Array<{ metadataId: string; args?: JSONObject | undefined }>;
-    };
-
-    for (const node of spec.nodes) {
+    for (const node of specOf(templateId).nodes) {
       const metadata: ComponentMetadata = findMetadata(
         node.metadataId,
       ) as ComponentMetadata;
@@ -173,54 +536,17 @@ describe.each(
           },
         );
 
-        expect(argument).toBeDefined();
+        expect({ node: node.componentId, argumentId: argumentId, found: Boolean(argument) }).toEqual({
+          node: node.componentId,
+          argumentId: argumentId,
+          found: true,
+        });
       }
     }
   });
 
-  /*
-   * The runner looks up outPorts[sourceHandle] to decide what runs next. A
-   * port id that does not exist means the workflow silently stops after the
-   * first step.
-   */
-  test("every edge leaves a port the component actually has", () => {
-    const spec: {
-      nodes: Array<{ componentId: string; metadataId: string }>;
-      edges: Array<{ fromComponentId: string; fromPort: string }>;
-    } = getTemplateGraphSpec(templateId) as {
-      nodes: Array<{ componentId: string; metadataId: string }>;
-      edges: Array<{ fromComponentId: string; fromPort: string }>;
-    };
-
-    for (const edge of spec.edges) {
-      const node: { metadataId: string } = spec.nodes.find(
-        (candidate: { componentId: string }) => {
-          return candidate.componentId === edge.fromComponentId;
-        },
-      ) as { metadataId: string };
-
-      const metadata: ComponentMetadata = findMetadata(
-        node.metadataId,
-      ) as ComponentMetadata;
-
-      const port: Port | undefined = metadata.outPorts.find(
-        (candidate: Port) => {
-          return candidate.id === edge.fromPort;
-        },
-      );
-
-      expect(port).toBeDefined();
-    }
-  });
-
   test("every required argument is filled in", () => {
-    const spec: {
-      nodes: Array<{ metadataId: string; args?: JSONObject | undefined }>;
-    } = getTemplateGraphSpec(templateId) as {
-      nodes: Array<{ metadataId: string; args?: JSONObject | undefined }>;
-    };
-
-    for (const node of spec.nodes) {
+    for (const node of specOf(templateId).nodes) {
       const metadata: ComponentMetadata = findMetadata(
         node.metadataId,
       ) as ComponentMetadata;
@@ -235,63 +561,304 @@ describe.each(
     }
   });
 
-  test("every {{...}} reference points at a return value that exists", () => {
-    const spec: {
-      nodes: Array<{ componentId: string; metadataId: string }>;
-    } = getTemplateGraphSpec(templateId) as {
-      nodes: Array<{ componentId: string; metadataId: string }>;
-    };
+  /*
+   * The runner looks up outPorts[sourceHandle] to decide what runs next. A
+   * port id that does not exist means the workflow silently stops after the
+   * first step.
+   */
+  test("every edge leaves a port the component actually has", () => {
+    const spec: TemplateSpec = specOf(templateId);
 
-    const graph: { nodes: Array<LintGraphNode>; edges: Array<LintGraphEdge> } =
-      hydrate(templateId);
-
-    const references: Array<string> = [];
-
-    for (const node of graph.nodes) {
-      for (const value of Object.values(node.data.arguments || {})) {
-        if (typeof value !== "string") {
-          continue;
-        }
-
-        const matches: Array<string> = value.match(/{{(.*?)}}/g) || [];
-        references.push(...matches);
-      }
-    }
-
-    for (const reference of references) {
-      const path: string = reference.slice(2, -2);
-      const parts: Array<string> = path.split(".");
-
-      expect(parts[0]).toBe("local");
-      expect(parts[1]).toBe("components");
-
-      const referencedNode: { metadataId: string } = spec.nodes.find(
-        (candidate: { componentId: string }) => {
-          return candidate.componentId === parts[2];
+    for (const edge of spec.edges) {
+      const node: TemplateNodeSpec = spec.nodes.find(
+        (candidate: TemplateNodeSpec) => {
+          return candidate.componentId === edge.fromComponentId;
         },
-      ) as { metadataId: string };
-
-      expect(referencedNode).toBeDefined();
-      expect(parts[3]).toBe("returnValues");
+      ) as TemplateNodeSpec;
 
       const metadata: ComponentMetadata = findMetadata(
-        referencedNode.metadataId,
+        node.metadataId,
       ) as ComponentMetadata;
 
-      const returnValue: ReturnValue | undefined = metadata.returnValues.find(
-        (candidate: ReturnValue) => {
-          return candidate.id === parts[4];
+      const port: Port | undefined = metadata.outPorts.find(
+        (candidate: Port) => {
+          return candidate.id === edge.fromPort;
         },
       );
 
-      expect(returnValue).toBeDefined();
+      expect({
+        from: edge.fromComponentId,
+        port: edge.fromPort,
+        found: Boolean(port),
+      }).toEqual({
+        from: edge.fromComponentId,
+        port: edge.fromPort,
+        found: true,
+      });
+    }
+  });
+
+  test("every edge connects component ids the template declares", () => {
+    const spec: TemplateSpec = specOf(templateId);
+
+    const componentIds: Array<string> = spec.nodes.map(
+      (node: TemplateNodeSpec) => {
+        return node.componentId;
+      },
+    );
+
+    for (const edge of spec.edges) {
+      expect(componentIds).toContain(edge.fromComponentId);
+      expect(componentIds).toContain(edge.toComponentId);
+    }
+  });
+
+  test("component ids are unique and dot-free", () => {
+    const componentIds: Array<string> = specOf(templateId).nodes.map(
+      (node: TemplateNodeSpec) => {
+        return node.componentId;
+      },
+    );
+
+    expect(new Set(componentIds).size).toBe(componentIds.length);
+
+    for (const componentId of componentIds) {
+      expect(componentId).not.toContain(".");
+    }
+  });
+
+  test("has exactly one trigger, and it is a real trigger component", () => {
+    const triggers: Array<TemplateNodeSpec> = specOf(templateId).nodes.filter(
+      (node: TemplateNodeSpec) => {
+        return node.componentType === ComponentType.Trigger;
+      },
+    );
+
+    expect(triggers).toHaveLength(1);
+
+    const metadata: ComponentMetadata = findMetadata(
+      triggers[0]?.metadataId as string,
+    ) as ComponentMetadata;
+
+    expect(metadata.componentType).toBe(ComponentType.Trigger);
+  });
+
+  /*
+   * saveTriggerFromGraph takes the LAST trigger node in the graph while the
+   * runner takes the FIRST, so a second trigger would denormalize one id and
+   * run another.
+   */
+  test("no node other than the trigger is a trigger", () => {
+    const spec: TemplateSpec = specOf(templateId);
+
+    for (const node of spec.nodes) {
+      const metadata: ComponentMetadata = findMetadata(
+        node.metadataId,
+      ) as ComponentMetadata;
+
+      if (node.componentType === ComponentType.Trigger) {
+        continue;
+      }
+
+      expect(metadata.componentType).not.toBe(ComponentType.Trigger);
+    }
+  });
+
+  test("every reference is a root the runtime actually has", () => {
+    for (const reference of referencesOf(templateId)) {
+      expect({
+        reference: reference.raw,
+        rootType: reference.parsed.rootType,
+      }).not.toEqual({
+        reference: reference.raw,
+        rootType: ReferenceRootType.Unknown,
+      });
     }
   });
 
   /*
-   * The end-to-end check: run the shipped template through the same linter the
-   * builder applies to a graph someone is editing. Zero errors is the bar.
+   * The runtime hands the raw capture to deepFind without trimming, so a space
+   * inside the braces resolves to nothing. The linter calls it an error too.
    */
+  test("no reference has whitespace inside its braces", () => {
+    for (const reference of referencesOf(templateId)) {
+      expect(reference.raw).toBe(`{{${reference.inner}}}`);
+      expect(reference.inner).not.toMatch(/\s/);
+    }
+  });
+
+  test("every component reference points at a component in this template", () => {
+    const componentIds: Array<string> = specOf(templateId).nodes.map(
+      (node: TemplateNodeSpec) => {
+        return node.componentId;
+      },
+    );
+
+    for (const reference of referencesOf(templateId)) {
+      if (reference.parsed.rootType !== ReferenceRootType.ComponentReturnValue) {
+        continue;
+      }
+
+      expect(componentIds).toContain(reference.parsed.componentId);
+    }
+  });
+
+  test("every component reference points at a return value that exists", () => {
+    const spec: TemplateSpec = specOf(templateId);
+
+    for (const reference of referencesOf(templateId)) {
+      if (reference.parsed.rootType !== ReferenceRootType.ComponentReturnValue) {
+        continue;
+      }
+
+      const referenced: TemplateNodeSpec = spec.nodes.find(
+        (node: TemplateNodeSpec) => {
+          return node.componentId === reference.parsed.componentId;
+        },
+      ) as TemplateNodeSpec;
+
+      const metadata: ComponentMetadata = findMetadata(
+        referenced.metadataId,
+      ) as ComponentMetadata;
+
+      const returnValue: ReturnValue | undefined = metadata.returnValues.find(
+        (candidate: ReturnValue) => {
+          return candidate.id === reference.parsed.returnValueId;
+        },
+      );
+
+      expect({
+        reference: reference.raw,
+        found: Boolean(returnValue),
+      }).toEqual({ reference: reference.raw, found: true });
+    }
+  });
+
+  /*
+   * The one that catches the subtlest template bug there is. A database
+   * trigger only hydrates the columns its `select` names, so reading
+   * .model.title without asking for `title` yields nothing — and yielding
+   * nothing is not an error anywhere in the stack. The run succeeds and posts
+   * "Incident: {{local.components.…}}" to Slack.
+   */
+  test("every field read off a database record was asked for in select", () => {
+    const spec: TemplateSpec = specOf(templateId);
+
+    for (const reference of referencesOf(templateId)) {
+      if (reference.parsed.rootType !== ReferenceRootType.ComponentReturnValue) {
+        continue;
+      }
+
+      if (reference.parsed.returnValueId !== "model") {
+        continue;
+      }
+
+      const referenced: TemplateNodeSpec = spec.nodes.find(
+        (node: TemplateNodeSpec) => {
+          return node.componentId === reference.parsed.componentId;
+        },
+      ) as TemplateNodeSpec;
+
+      const select: JSONValue | undefined = (referenced.args || {})[
+        "select"
+      ] as JSONValue | undefined;
+
+      const segments: Array<string> = reference.inner.split(".");
+      // local . components . <id> . returnValues . model . <field...>
+      const fieldPath: Array<string> = segments.slice(5);
+
+      if (fieldPath.length === 0) {
+        continue;
+      }
+
+      expect({
+        reference: reference.raw,
+        covered: selectCovers(select, fieldPath),
+      }).toEqual({ reference: reference.raw, covered: true });
+    }
+  });
+
+  test("every variable it declares is actually used by the graph", () => {
+    const used: Set<string> = new Set(
+      referencesOf(templateId)
+        .filter((reference: TemplateReference) => {
+          return reference.parsed.rootType === ReferenceRootType.LocalVariable;
+        })
+        .map((reference: TemplateReference) => {
+          return reference.parsed.variableName as string;
+        }),
+    );
+
+    for (const variable of template.variables) {
+      expect({ variable: variable.name, used: used.has(variable.name) }).toEqual(
+        { variable: variable.name, used: true },
+      );
+    }
+  });
+
+  /*
+   * The inverse, and the more dangerous direction: a reference to a variable
+   * the wizard never asks for means no row is ever written for it, and the
+   * literal braces ship.
+   */
+  test("every variable the graph references is declared by the template", () => {
+    const declared: Array<string> = template.variables.map(
+      (variable: WorkflowTemplateVariable) => {
+        return variable.name;
+      },
+    );
+
+    for (const reference of referencesOf(templateId)) {
+      if (reference.parsed.rootType !== ReferenceRootType.LocalVariable) {
+        continue;
+      }
+
+      expect({
+        reference: reference.raw,
+        declared: declared.includes(reference.parsed.variableName as string),
+      }).toEqual({ reference: reference.raw, declared: true });
+    }
+  });
+
+  /*
+   * The wizard only ever writes workflow-scoped variables, so a template
+   * reaching for a project-global one would silently find nothing.
+   */
+  test("it does not reach for project-global variables", () => {
+    for (const reference of referencesOf(templateId)) {
+      expect(reference.parsed.rootType).not.toBe(
+        ReferenceRootType.GlobalVariable,
+      );
+    }
+  });
+
+  /*
+   * An optional variable's reference must be the ENTIRE argument value. That
+   * is what lets the wizard drop the argument when the field is left blank; a
+   * reference embedded in a longer string would survive the strip and leave
+   * the braces behind in the saved workflow.
+   */
+  test("an optional variable's reference is the whole argument, so it can be dropped", () => {
+    for (const variable of template.variables) {
+      if (variable.required) {
+        continue;
+      }
+
+      const spec: TemplateSpec = specOf(templateId);
+      const token: string = `{{local.variables.${variable.name}}}`;
+
+      for (const node of spec.nodes) {
+        for (const value of Object.values(node.args || {})) {
+          if (typeof value !== "string" || !value.includes(token)) {
+            continue;
+          }
+
+          expect(value.trim()).toBe(token);
+        }
+      }
+    }
+  });
+
   test("passes the builder's own graph checks with no errors", () => {
     const result: WorkflowLintResult = lintWorkflowGraph(hydrate(templateId));
 
@@ -308,26 +875,19 @@ describe.each(
     ).toEqual([]);
   });
 
-  test("has exactly one trigger, and it is a real trigger component", () => {
-    const spec: {
-      nodes: Array<{ metadataId: string; componentType: ComponentType }>;
-    } = getTemplateGraphSpec(templateId) as {
-      nodes: Array<{ metadataId: string; componentType: ComponentType }>;
-    };
+  /*
+   * Warnings too. UnreachableComponent is only a warning, so without this a
+   * template could ship with a stray node that never runs and no test would
+   * notice.
+   */
+  test("passes the builder's own graph checks with no warnings either", () => {
+    const result: WorkflowLintResult = lintWorkflowGraph(hydrate(templateId));
 
-    const triggers: Array<{ metadataId: string }> = spec.nodes.filter(
-      (node: { componentType: ComponentType }) => {
-        return node.componentType === ComponentType.Trigger;
-      },
-    );
-
-    expect(triggers).toHaveLength(1);
-
-    const metadata: ComponentMetadata = findMetadata(
-      triggers[0]?.metadataId as string,
-    ) as ComponentMetadata;
-
-    expect(metadata.componentType).toBe(ComponentType.Trigger);
+    expect(
+      result.issues.map((issue: WorkflowLintIssue) => {
+        return issue.message;
+      }),
+    ).toEqual([]);
   });
 
   /*
@@ -360,16 +920,28 @@ describe.each(
     }
   });
 
-  test("keeps stable component ids, because references point at them", () => {
-    const first: JSONObject = buildGraphForTemplate(
-      templateId,
-      generateId,
-    ) as JSONObject;
-    const second: JSONObject = buildGraphForTemplate(
-      templateId,
-      generateId,
-    ) as JSONObject;
+  test("builds fresh edge ids each time too", () => {
+    type EdgeIdsFunction = (graph: JSONObject) => Array<string>;
 
+    const edgeIds: EdgeIdsFunction = (graph: JSONObject): Array<string> => {
+      return (graph["edges"] as Array<JSONObject>).map((edge: JSONObject) => {
+        return edge["id"] as string;
+      });
+    };
+
+    const first: Array<string> = edgeIds(
+      buildGraphForTemplate(templateId, generateId) as JSONObject,
+    );
+    const second: Array<string> = edgeIds(
+      buildGraphForTemplate(templateId, generateId) as JSONObject,
+    );
+
+    for (const id of first) {
+      expect(second).not.toContain(id);
+    }
+  });
+
+  test("keeps stable component ids, because references point at them", () => {
     type ComponentIdsFunction = (graph: JSONObject) => Array<string>;
 
     const componentIds: ComponentIdsFunction = (
@@ -380,7 +952,48 @@ describe.each(
       });
     };
 
-    expect(componentIds(first)).toEqual(componentIds(second));
+    expect(
+      componentIds(buildGraphForTemplate(templateId, generateId) as JSONObject),
+    ).toEqual(
+      componentIds(buildGraphForTemplate(templateId, generateId) as JSONObject),
+    );
+  });
+
+  /*
+   * A built graph gets edited afterwards — by the wizard stripping arguments
+   * for blank optional variables, and by the builder. Sharing the argument
+   * object with the shipped definition would let that editing leak into every
+   * later workflow built in the same process.
+   */
+  test("built graphs do not share argument objects with the definition", () => {
+    const first: JSONObject = buildGraphForTemplate(
+      templateId,
+      generateId,
+    ) as JSONObject;
+    const second: JSONObject = buildGraphForTemplate(
+      templateId,
+      generateId,
+    ) as JSONObject;
+
+    const argumentsOf: (graph: JSONObject, index: number) => JSONObject = (
+      graph: JSONObject,
+      index: number,
+    ): JSONObject => {
+      const node: JSONObject = (graph["nodes"] as Array<JSONObject>)[
+        index
+      ] as JSONObject;
+
+      return (node["data"] as JSONObject)["arguments"] as JSONObject;
+    };
+
+    const firstArguments: JSONObject = argumentsOf(first, 0);
+
+    (firstArguments as JSONObject)["__scribbled"] = "yes";
+
+    expect(argumentsOf(second, 0)["__scribbled"]).toBeUndefined();
+    expect(
+      (specOf(templateId).nodes[0]?.args || {})["__scribbled"],
+    ).toBeUndefined();
   });
 
   test("edges connect nodes that are in the graph", () => {
@@ -398,6 +1011,43 @@ describe.each(
     for (const edge of graph["edges"] as Array<JSONObject>) {
       expect(nodeIds).toContain(edge["source"] as string);
       expect(nodeIds).toContain(edge["target"] as string);
+    }
+  });
+
+  test("every edge targets the in port, which is what react-flow attaches to", () => {
+    const graph: JSONObject = buildGraphForTemplate(
+      templateId,
+      generateId,
+    ) as JSONObject;
+
+    for (const edge of graph["edges"] as Array<JSONObject>) {
+      expect(edge["targetHandle"]).toBe("in");
+    }
+  });
+
+  test("every non-trigger node has an in port for that edge to land on", () => {
+    const spec: TemplateSpec = specOf(templateId);
+
+    const targeted: Set<string> = new Set(
+      spec.edges.map((edge: TemplateEdgeSpec) => {
+        return edge.toComponentId;
+      }),
+    );
+
+    for (const node of spec.nodes) {
+      if (!targeted.has(node.componentId)) {
+        continue;
+      }
+
+      const metadata: ComponentMetadata = findMetadata(
+        node.metadataId,
+      ) as ComponentMetadata;
+
+      expect(
+        metadata.inPorts.map((port: Port) => {
+          return port.id;
+        }),
+      ).toContain("in");
     }
   });
 });

--- a/Common/Types/Workflow/Templates.ts
+++ b/Common/Types/Workflow/Templates.ts
@@ -6,9 +6,14 @@
  * teaches it. Each template below is a small, working workflow whose whole
  * point is to show a {{local.components.…}} reference in context.
  *
- * Every template here is deliberately runnable with no external configuration
- * — no Slack token, no API key, no third-party account. Templates that need
- * credentials belong in the docs, not in a one-click "start from this".
+ * The original three templates were deliberately runnable with no external
+ * configuration at all, which kept them honest but also kept them toys — the
+ * workflows people actually want ("tell Slack when an incident opens") need a
+ * webhook URL, and there was nowhere to put one. Templates now DECLARE the
+ * configuration they need, as `variables`, and the create wizard collects the
+ * values and writes them as WorkflowVariable rows scoped to the new workflow.
+ * The graph refers to them as {{local.variables.<name>}}, so the value lives in
+ * one place and can be changed later without editing the graph.
  *
  * The graphs are plain data in the same shape the builder saves and the JSON
  * import reads, so a template is created through the ordinary Workflow create
@@ -17,8 +22,61 @@
  */
 
 import { JSONObject } from "../JSON";
+import IconProp from "../Icon/IconProp";
 import ComponentID from "./ComponentID";
 import { ComponentType, NodeType } from "./Component";
+import { ConditionOperator } from "./Components/Condition";
+
+export enum WorkflowTemplateCategory {
+  Basics = "Basics",
+  Incidents = "Incidents",
+  Alerts = "Alerts",
+  Monitors = "Monitors",
+  StatusPage = "Status Page",
+  ScheduledMaintenance = "Scheduled Maintenance",
+  OnCall = "On-Call",
+  Scheduled = "On a Schedule",
+  Integrations = "Integrations",
+}
+
+/** Display order in the picker. Basics first, because that is where a new builder should start. */
+export const WorkflowTemplateCategories: Array<WorkflowTemplateCategory> = [
+  WorkflowTemplateCategory.Basics,
+  WorkflowTemplateCategory.Incidents,
+  WorkflowTemplateCategory.Alerts,
+  WorkflowTemplateCategory.Monitors,
+  WorkflowTemplateCategory.OnCall,
+  WorkflowTemplateCategory.StatusPage,
+  WorkflowTemplateCategory.ScheduledMaintenance,
+  WorkflowTemplateCategory.Scheduled,
+  WorkflowTemplateCategory.Integrations,
+];
+
+/*
+ * A variable name becomes two things that must match exactly: the `name` column
+ * on the created WorkflowVariable row, and the tail of the
+ * {{local.variables.<name>}} reference inside the graph. Runtime lookup is a
+ * plain case-sensitive property read on a map keyed by name, and the path is
+ * split on dots — so a name with a dot, a space, or the wrong case resolves to
+ * nothing, silently, and the workflow posts literal braces to Slack.
+ */
+export const WORKFLOW_TEMPLATE_VARIABLE_NAME_REGEX: RegExp = /^[A-Za-z0-9_-]+$/;
+
+export interface WorkflowTemplateVariable {
+  /** Referenced as {{local.variables.<name>}} and used verbatim as the WorkflowVariable name. */
+  name: string;
+  /** Field label in the wizard. */
+  title: string;
+  /** Help text under the field — say where the user gets this value. */
+  description: string;
+  placeholder: string;
+  required: boolean;
+  /**
+   * Masks the input and marks the stored row secret, which redacts it from run
+   * logs. It does NOT encrypt it at rest — nothing on WorkflowVariable is.
+   */
+  isSecret: boolean;
+}
 
 export interface WorkflowTemplate {
   /** Stable key, used by the picker and by tests. */
@@ -28,9 +86,13 @@ export interface WorkflowTemplate {
   description: string;
   /** What the builder should look at once it opens. */
   teaches: string;
+  category: WorkflowTemplateCategory;
+  icon: IconProp;
   /** Suggested name for the created workflow. */
   workflowName: string;
   workflowDescription: string;
+  /** Configuration the wizard collects before creating. Empty means it runs as-is. */
+  variables: Array<WorkflowTemplateVariable>;
 }
 
 interface TemplateNodeSpec {
@@ -85,7 +147,13 @@ export const buildTemplateGraph: BuildTemplateGraphFunction = (
           metadataId: node.metadataId,
           internalId: generateId(),
           error: "",
-          arguments: node.args || {},
+          /*
+           * Deep-copied, not shared. A built graph gets edited — by the wizard
+           * substituting variable names, and by the builder afterwards — and a
+           * shallow copy would let that editing reach back into the shipped
+           * template definition for the rest of the process.
+           */
+          arguments: node.args ? (JSON.parse(JSON.stringify(node.args)) as JSONObject) : {},
           returnValues: {},
         },
       };
@@ -109,16 +177,80 @@ export const buildTemplateGraph: BuildTemplateGraphFunction = (
 
 type TemplateDefinition = WorkflowTemplate & { graph: TemplateGraphSpec };
 
+/*
+ * Shared variable definitions. Several templates ask for the same thing, and
+ * defining it once keeps the name identical everywhere — which matters,
+ * because the name is what the graph references.
+ */
+const SLACK_WEBHOOK_URL: WorkflowTemplateVariable = {
+  name: "slackWebhookUrl",
+  title: "Slack Incoming Webhook URL",
+  description:
+    "Create one at api.slack.com/messaging/webhooks and pick the channel the message should land in.",
+  placeholder: "https://hooks.slack.com/services/T000/B000/XXXX",
+  required: true,
+  isSecret: true,
+};
+
+const TEAMS_WEBHOOK_URL: WorkflowTemplateVariable = {
+  name: "teamsWebhookUrl",
+  title: "Microsoft Teams Webhook URL",
+  description:
+    "In Teams, open the channel, then Connectors, then Incoming Webhook, and copy the URL it gives you.",
+  placeholder: "https://outlook.office.com/webhook/...",
+  required: true,
+  isSecret: true,
+};
+
+const DISCORD_WEBHOOK_URL: WorkflowTemplateVariable = {
+  name: "discordWebhookUrl",
+  title: "Discord Webhook URL",
+  description:
+    "In Discord, open Channel Settings, then Integrations, then Webhooks, and copy the URL.",
+  placeholder: "https://discord.com/api/webhooks/...",
+  required: true,
+  isSecret: true,
+};
+
+/** The select every incident trigger uses. Anything referenced below must be in here. */
+const INCIDENT_SELECT: JSONObject = {
+  _id: true,
+  title: true,
+  description: true,
+  incidentNumber: true,
+  currentIncidentState: { name: true },
+  incidentSeverity: { name: true },
+};
+
+const ALERT_SELECT: JSONObject = {
+  _id: true,
+  title: true,
+  description: true,
+  alertNumber: true,
+  currentAlertState: { name: true },
+  alertSeverity: { name: true },
+};
+
+const MONITOR_STATUS_TIMELINE_SELECT: JSONObject = {
+  _id: true,
+  monitor: { name: true },
+  monitorStatus: { name: true, isOfflineState: true },
+};
+
 const TEMPLATE_DEFINITIONS: Array<TemplateDefinition> = [
+  /* ----------------------------- Basics ----------------------------- */
   {
     id: "manual-log",
     name: "Log a message when run by hand",
     description:
       "The smallest working workflow: a manual trigger and a step that writes a line to the run log.",
     teaches: "How to run a workflow and where its output shows up.",
+    category: WorkflowTemplateCategory.Basics,
+    icon: IconProp.Play,
     workflowName: "Log a message",
     workflowDescription:
       "Runs on demand and writes a line to the run log. A good place to start.",
+    variables: [],
     graph: {
       nodes: [
         {
@@ -158,9 +290,12 @@ const TEMPLATE_DEFINITIONS: Array<TemplateDefinition> = [
      */
     teaches:
       "How one step reads another's output, using {{local.components...}}.",
+    category: WorkflowTemplateCategory.Basics,
+    icon: IconProp.Webhook,
     workflowName: "Echo webhook body",
     workflowDescription:
       "Writes whatever was posted to this workflow's webhook into the run log.",
+    variables: [],
     graph: {
       nodes: [
         {
@@ -190,15 +325,1051 @@ const TEMPLATE_DEFINITIONS: Array<TemplateDefinition> = [
     },
   },
   {
+    id: "webhook-branch",
+    name: "Take one path or another",
+    description:
+      "Reads a field out of the webhook body and logs a different line depending on what it says.",
+    teaches: "How If / Else splits a workflow into a Yes path and a No path.",
+    category: WorkflowTemplateCategory.Basics,
+    icon: IconProp.Condition,
+    workflowName: "Branch on webhook body",
+    workflowDescription:
+      "Posts to this workflow's webhook take one of two paths depending on the environment field.",
+    variables: [],
+    graph: {
+      nodes: [
+        {
+          componentId: "webhook-1",
+          metadataId: ComponentID.Webhook,
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+        },
+        {
+          componentId: "if-else-1",
+          metadataId: ComponentID.IfElse,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "input-1":
+              "{{local.components.webhook-1.returnValues.request-body.environment}}",
+            operator: ConditionOperator.EqualTo,
+            "input-2": "production",
+          },
+        },
+        {
+          componentId: "log-production",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: -100, y: 500 },
+          args: {
+            value: "This one came from production. Treat it as urgent.",
+          },
+        },
+        {
+          componentId: "log-other",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: 300, y: 500 },
+          args: {
+            value: "Not production. Logging it and moving on.",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "webhook-1",
+          toComponentId: "if-else-1",
+          fromPort: "out",
+        },
+        {
+          fromComponentId: "if-else-1",
+          toComponentId: "log-production",
+          fromPort: "yes",
+        },
+        {
+          fromComponentId: "if-else-1",
+          toComponentId: "log-other",
+          fromPort: "no",
+        },
+      ],
+    },
+  },
+  {
+    id: "javascript-transform",
+    name: "Reshape data with a few lines of JavaScript",
+    description:
+      "Runs a small script over the webhook body and logs whatever it returns.",
+    teaches:
+      "How to drop into code when the built-in components cannot express something.",
+    category: WorkflowTemplateCategory.Basics,
+    icon: IconProp.Code,
+    workflowName: "Transform with JavaScript",
+    workflowDescription:
+      "Runs a small script over the webhook body. Edit the code to shape the data however you need.",
+    variables: [],
+    graph: {
+      nodes: [
+        {
+          componentId: "webhook-1",
+          metadataId: ComponentID.Webhook,
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+        },
+        {
+          componentId: "javascript-1",
+          metadataId: ComponentID.JavaScriptCode,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            code: [
+              "// Whatever you return here is available as returnValue on the next step.",
+              "const body = args.body || {};",
+              "",
+              "return {",
+              "  receivedKeys: Object.keys(body),",
+              "  summary: `Received ${Object.keys(body).length} field(s).`,",
+              "};",
+            ].join("\n"),
+            arguments: {
+              body: "{{local.components.webhook-1.returnValues.request-body}}",
+            },
+          },
+        },
+        {
+          componentId: "log-1",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 500 },
+          args: {
+            value:
+              "Script returned: {{local.components.javascript-1.returnValues.returnValue}}",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "webhook-1",
+          toComponentId: "javascript-1",
+          fromPort: "out",
+        },
+        {
+          fromComponentId: "javascript-1",
+          toComponentId: "log-1",
+          fromPort: "success",
+        },
+      ],
+    },
+  },
+
+  /* ---------------------------- Incidents ---------------------------- */
+  {
+    id: "incident-created-slack",
+    name: "Tell Slack when an incident opens",
+    description:
+      "Posts the incident's title, severity and description to a Slack channel the moment it is declared.",
+    teaches:
+      "How a database trigger fires, and how to read fields off the record it hands you.",
+    category: WorkflowTemplateCategory.Incidents,
+    icon: IconProp.Slack,
+    workflowName: "Notify Slack on new incident",
+    workflowDescription:
+      "Posts to Slack whenever an incident is created in this project.",
+    variables: [SLACK_WEBHOOK_URL],
+    graph: {
+      nodes: [
+        {
+          componentId: "incident-on-create-1",
+          metadataId: "incident-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: { select: INCIDENT_SELECT },
+        },
+        {
+          componentId: "slack-1",
+          metadataId: ComponentID.SlackSendMessageToChannel,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "webhook-url": "{{local.variables.slackWebhookUrl}}",
+            text: [
+              "*Incident #{{local.components.incident-on-create-1.returnValues.model.incidentNumber}} declared*",
+              "*{{local.components.incident-on-create-1.returnValues.model.title}}*",
+              "Severity: {{local.components.incident-on-create-1.returnValues.model.incidentSeverity.name}}",
+              "State: {{local.components.incident-on-create-1.returnValues.model.currentIncidentState.name}}",
+              "",
+              "{{local.components.incident-on-create-1.returnValues.model.description}}",
+            ].join("\n"),
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "incident-on-create-1",
+          toComponentId: "slack-1",
+          fromPort: "success",
+        },
+      ],
+    },
+  },
+  {
+    id: "incident-created-teams",
+    name: "Tell Microsoft Teams when an incident opens",
+    description:
+      "Posts the incident's title, severity and description to a Teams channel as soon as it is declared.",
+    teaches: "How a database trigger feeds a chat integration.",
+    category: WorkflowTemplateCategory.Incidents,
+    icon: IconProp.MicrosoftTeams,
+    workflowName: "Notify Teams on new incident",
+    workflowDescription:
+      "Posts to Microsoft Teams whenever an incident is created in this project.",
+    variables: [TEAMS_WEBHOOK_URL],
+    graph: {
+      nodes: [
+        {
+          componentId: "incident-on-create-1",
+          metadataId: "incident-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: { select: INCIDENT_SELECT },
+        },
+        {
+          componentId: "teams-1",
+          metadataId: ComponentID.MicrosoftTeamsSendMessageToChannel,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "webhook-url": "{{local.variables.teamsWebhookUrl}}",
+            text: [
+              "Incident #{{local.components.incident-on-create-1.returnValues.model.incidentNumber}} declared",
+              "{{local.components.incident-on-create-1.returnValues.model.title}}",
+              "Severity: {{local.components.incident-on-create-1.returnValues.model.incidentSeverity.name}}",
+              "",
+              "{{local.components.incident-on-create-1.returnValues.model.description}}",
+            ].join("\n"),
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "incident-on-create-1",
+          toComponentId: "teams-1",
+          fromPort: "success",
+        },
+      ],
+    },
+  },
+  {
+    id: "incident-created-discord",
+    name: "Tell Discord when an incident opens",
+    description:
+      "Posts a short incident summary to a Discord channel the moment the incident is declared.",
+    teaches: "How a database trigger feeds a chat integration.",
+    category: WorkflowTemplateCategory.Incidents,
+    icon: IconProp.Chat,
+    workflowName: "Notify Discord on new incident",
+    workflowDescription:
+      "Posts to Discord whenever an incident is created in this project.",
+    variables: [DISCORD_WEBHOOK_URL],
+    graph: {
+      nodes: [
+        {
+          componentId: "incident-on-create-1",
+          metadataId: "incident-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: { select: INCIDENT_SELECT },
+        },
+        {
+          componentId: "discord-1",
+          metadataId: ComponentID.DiscordSendMessageToChannel,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "webhook-url": "{{local.variables.discordWebhookUrl}}",
+            text: [
+              "Incident #{{local.components.incident-on-create-1.returnValues.model.incidentNumber}} declared",
+              "{{local.components.incident-on-create-1.returnValues.model.title}}",
+              "Severity: {{local.components.incident-on-create-1.returnValues.model.incidentSeverity.name}}",
+            ].join("\n"),
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "incident-on-create-1",
+          toComponentId: "discord-1",
+          fromPort: "success",
+        },
+      ],
+    },
+  },
+  {
+    id: "incident-state-changed-slack",
+    name: "Tell Slack when an incident changes state",
+    description:
+      "Watches the incident's state and posts to Slack when it moves — acknowledged, resolved, and anything else.",
+    teaches:
+      "How the update trigger's Listen On field narrows a workflow to the fields you care about.",
+    category: WorkflowTemplateCategory.Incidents,
+    icon: IconProp.ArrowPath,
+    workflowName: "Notify Slack on incident state change",
+    workflowDescription:
+      "Posts to Slack whenever an incident's state changes. Edit Listen On to watch other fields.",
+    variables: [SLACK_WEBHOOK_URL],
+    graph: {
+      nodes: [
+        {
+          componentId: "incident-on-update-1",
+          metadataId: "incident-on-update",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: {
+            "listen-on": { currentIncidentStateId: true },
+            select: INCIDENT_SELECT,
+          },
+        },
+        {
+          componentId: "slack-1",
+          metadataId: ComponentID.SlackSendMessageToChannel,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "webhook-url": "{{local.variables.slackWebhookUrl}}",
+            text: [
+              "*Incident #{{local.components.incident-on-update-1.returnValues.model.incidentNumber}} is now {{local.components.incident-on-update-1.returnValues.model.currentIncidentState.name}}*",
+              "{{local.components.incident-on-update-1.returnValues.model.title}}",
+            ].join("\n"),
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "incident-on-update-1",
+          toComponentId: "slack-1",
+          fromPort: "success",
+        },
+      ],
+    },
+  },
+  {
+    id: "incident-created-forward",
+    name: "Forward new incidents to another system",
+    description:
+      "POSTs a JSON summary of every new incident to a URL of yours — a ticketing system, a data warehouse, anything that takes a webhook.",
+    teaches:
+      "How to build a JSON request body out of references, and how the Error port catches a failed call.",
+    category: WorkflowTemplateCategory.Incidents,
+    icon: IconProp.Link,
+    workflowName: "Forward incidents to a URL",
+    workflowDescription:
+      "POSTs a JSON summary of each new incident to an endpoint you control.",
+    variables: [
+      {
+        name: "forwardUrl",
+        title: "Destination URL",
+        description:
+          "The endpoint that should receive the POST. It will get a JSON body with the incident's fields.",
+        placeholder: "https://example.com/hooks/oneuptime-incidents",
+        required: true,
+        isSecret: false,
+      },
+    ],
+    graph: {
+      nodes: [
+        {
+          componentId: "incident-on-create-1",
+          metadataId: "incident-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: { select: INCIDENT_SELECT },
+        },
+        {
+          componentId: "api-post-1",
+          metadataId: ComponentID.ApiPost,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            url: "{{local.variables.forwardUrl}}",
+            "request-body": [
+              "{",
+              '  "id": "{{local.components.incident-on-create-1.returnValues.model._id}}",',
+              '  "number": "{{local.components.incident-on-create-1.returnValues.model.incidentNumber}}",',
+              '  "title": "{{local.components.incident-on-create-1.returnValues.model.title}}",',
+              '  "severity": "{{local.components.incident-on-create-1.returnValues.model.incidentSeverity.name}}",',
+              '  "state": "{{local.components.incident-on-create-1.returnValues.model.currentIncidentState.name}}"',
+              "}",
+            ].join("\n"),
+          },
+        },
+        {
+          componentId: "log-failed",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: 300, y: 500 },
+          args: {
+            value:
+              "Could not forward the incident: {{local.components.api-post-1.returnValues.error}}",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "incident-on-create-1",
+          toComponentId: "api-post-1",
+          fromPort: "success",
+        },
+        {
+          fromComponentId: "api-post-1",
+          toComponentId: "log-failed",
+          fromPort: "error",
+        },
+      ],
+    },
+  },
+  {
+    id: "incident-created-ai-summary",
+    name: "Summarise a new incident with AI, then post it",
+    description:
+      "Asks the model for a one-paragraph plain-English summary of the incident and sends that to Slack.",
+    teaches: "How to chain AI output into another step.",
+    category: WorkflowTemplateCategory.Incidents,
+    icon: IconProp.Sparkles,
+    workflowName: "AI incident summary to Slack",
+    workflowDescription:
+      "Generates a short plain-English summary of each new incident and posts it to Slack.",
+    variables: [SLACK_WEBHOOK_URL],
+    graph: {
+      nodes: [
+        {
+          componentId: "incident-on-create-1",
+          metadataId: "incident-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: { select: INCIDENT_SELECT },
+        },
+        {
+          componentId: "ai-1",
+          metadataId: ComponentID.AIGenerateText,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "system-prompt":
+              "You write short, calm incident summaries for an on-call engineer. One paragraph. No preamble, no bullet points.",
+            prompt: [
+              "Summarise this incident in one paragraph for someone who has just been paged.",
+              "",
+              "Title: {{local.components.incident-on-create-1.returnValues.model.title}}",
+              "Severity: {{local.components.incident-on-create-1.returnValues.model.incidentSeverity.name}}",
+              "Description: {{local.components.incident-on-create-1.returnValues.model.description}}",
+            ].join("\n"),
+          },
+        },
+        {
+          componentId: "slack-1",
+          metadataId: ComponentID.SlackSendMessageToChannel,
+          componentType: ComponentType.Component,
+          position: { x: -100, y: 500 },
+          args: {
+            "webhook-url": "{{local.variables.slackWebhookUrl}}",
+            text: [
+              "*Incident #{{local.components.incident-on-create-1.returnValues.model.incidentNumber}}: {{local.components.incident-on-create-1.returnValues.model.title}}*",
+              "",
+              "{{local.components.ai-1.returnValues.response}}",
+            ].join("\n"),
+          },
+        },
+        {
+          componentId: "log-failed",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: 300, y: 500 },
+          args: {
+            value:
+              "Could not generate a summary: {{local.components.ai-1.returnValues.error}}",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "incident-on-create-1",
+          toComponentId: "ai-1",
+          fromPort: "success",
+        },
+        {
+          fromComponentId: "ai-1",
+          toComponentId: "slack-1",
+          fromPort: "success",
+        },
+        {
+          fromComponentId: "ai-1",
+          toComponentId: "log-failed",
+          fromPort: "error",
+        },
+      ],
+    },
+  },
+
+  /* ------------------------------ Alerts ------------------------------ */
+  {
+    id: "alert-created-slack",
+    name: "Tell Slack when an alert fires",
+    description:
+      "Posts the alert's title and severity to a Slack channel as soon as it is raised.",
+    teaches: "How the alert trigger differs from the incident one.",
+    category: WorkflowTemplateCategory.Alerts,
+    icon: IconProp.Bell,
+    workflowName: "Notify Slack on new alert",
+    workflowDescription:
+      "Posts to Slack whenever an alert is created in this project.",
+    variables: [SLACK_WEBHOOK_URL],
+    graph: {
+      nodes: [
+        {
+          componentId: "alert-on-create-1",
+          metadataId: "alert-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: { select: ALERT_SELECT },
+        },
+        {
+          componentId: "slack-1",
+          metadataId: ComponentID.SlackSendMessageToChannel,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "webhook-url": "{{local.variables.slackWebhookUrl}}",
+            text: [
+              "*Alert: {{local.components.alert-on-create-1.returnValues.model.title}}*",
+              "Severity: {{local.components.alert-on-create-1.returnValues.model.alertSeverity.name}}",
+              "",
+              "{{local.components.alert-on-create-1.returnValues.model.description}}",
+            ].join("\n"),
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "alert-on-create-1",
+          toComponentId: "slack-1",
+          fromPort: "success",
+        },
+      ],
+    },
+  },
+  {
+    id: "alert-created-telegram",
+    name: "Tell Telegram when an alert fires",
+    description:
+      "Sends a message to a Telegram chat whenever an alert is raised.",
+    teaches:
+      "How a template can ask for more than one piece of configuration, including a secret.",
+    category: WorkflowTemplateCategory.Alerts,
+    icon: IconProp.Telegram,
+    workflowName: "Notify Telegram on new alert",
+    workflowDescription:
+      "Sends a Telegram message whenever an alert is created in this project.",
+    variables: [
+      {
+        name: "telegramBotToken",
+        title: "Telegram Bot Token",
+        description: "The token BotFather gave you when you created the bot.",
+        placeholder: "123456:ABC-DEF...",
+        required: true,
+        isSecret: true,
+      },
+      {
+        name: "telegramChatId",
+        title: "Telegram Chat ID",
+        description:
+          "The chat the bot should post into. Add the bot to the chat first.",
+        placeholder: "-1001234567890",
+        required: true,
+        isSecret: false,
+      },
+    ],
+    graph: {
+      nodes: [
+        {
+          componentId: "alert-on-create-1",
+          metadataId: "alert-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: { select: ALERT_SELECT },
+        },
+        {
+          componentId: "telegram-1",
+          metadataId: ComponentID.TelegramSendMessageToChat,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "bot-token": "{{local.variables.telegramBotToken}}",
+            "chat-id": "{{local.variables.telegramChatId}}",
+            text: [
+              "Alert: {{local.components.alert-on-create-1.returnValues.model.title}}",
+              "Severity: {{local.components.alert-on-create-1.returnValues.model.alertSeverity.name}}",
+            ].join("\n"),
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "alert-on-create-1",
+          toComponentId: "telegram-1",
+          fromPort: "success",
+        },
+      ],
+    },
+  },
+
+  /* ----------------------------- Monitors ----------------------------- */
+  {
+    id: "monitor-status-changed-slack",
+    name: "Tell Slack when a monitor changes status",
+    description:
+      "Posts to Slack every time a monitor goes down, comes back, or changes status in any way.",
+    teaches:
+      "How status changes are their own records, and how to read the monitor's name off one.",
+    category: WorkflowTemplateCategory.Monitors,
+    icon: IconProp.Heartbeat,
+    workflowName: "Notify Slack on monitor status change",
+    workflowDescription:
+      "Posts to Slack whenever a monitor's status changes in this project.",
+    variables: [SLACK_WEBHOOK_URL],
+    graph: {
+      nodes: [
+        {
+          componentId: "monitor-status-timeline-on-create-1",
+          metadataId: "monitor-status-timeline-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: { select: MONITOR_STATUS_TIMELINE_SELECT },
+        },
+        {
+          componentId: "slack-1",
+          metadataId: ComponentID.SlackSendMessageToChannel,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "webhook-url": "{{local.variables.slackWebhookUrl}}",
+            text: "*{{local.components.monitor-status-timeline-on-create-1.returnValues.model.monitor.name}}* is now *{{local.components.monitor-status-timeline-on-create-1.returnValues.model.monitorStatus.name}}*",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "monitor-status-timeline-on-create-1",
+          toComponentId: "slack-1",
+          fromPort: "success",
+        },
+      ],
+    },
+  },
+  {
+    id: "monitor-offline-only-slack",
+    name: "Tell Slack only when a monitor goes offline",
+    description:
+      "Filters monitor status changes down to the offline ones, so the channel is quiet until something is actually wrong.",
+    teaches:
+      "How to put an If / Else between a trigger and an action to cut the noise.",
+    category: WorkflowTemplateCategory.Monitors,
+    icon: IconProp.ShieldExclamation,
+    workflowName: "Notify Slack when a monitor goes offline",
+    workflowDescription:
+      "Posts to Slack only when a monitor moves into an offline status.",
+    variables: [SLACK_WEBHOOK_URL],
+    graph: {
+      nodes: [
+        {
+          componentId: "monitor-status-timeline-on-create-1",
+          metadataId: "monitor-status-timeline-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: { select: MONITOR_STATUS_TIMELINE_SELECT },
+        },
+        {
+          componentId: "if-else-1",
+          metadataId: ComponentID.IfElse,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "input-1":
+              "{{local.components.monitor-status-timeline-on-create-1.returnValues.model.monitorStatus.isOfflineState}}",
+            operator: ConditionOperator.EqualTo,
+            "input-2": "true",
+          },
+        },
+        {
+          componentId: "slack-1",
+          metadataId: ComponentID.SlackSendMessageToChannel,
+          componentType: ComponentType.Component,
+          position: { x: -100, y: 500 },
+          args: {
+            "webhook-url": "{{local.variables.slackWebhookUrl}}",
+            text: "*{{local.components.monitor-status-timeline-on-create-1.returnValues.model.monitor.name}}* is offline — status is now *{{local.components.monitor-status-timeline-on-create-1.returnValues.model.monitorStatus.name}}*.",
+          },
+        },
+        {
+          componentId: "log-online",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: 300, y: 500 },
+          args: {
+            value:
+              "Status changed to {{local.components.monitor-status-timeline-on-create-1.returnValues.model.monitorStatus.name}}, which is not an offline state. Staying quiet.",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "monitor-status-timeline-on-create-1",
+          toComponentId: "if-else-1",
+          fromPort: "success",
+        },
+        {
+          fromComponentId: "if-else-1",
+          toComponentId: "slack-1",
+          fromPort: "yes",
+        },
+        {
+          fromComponentId: "if-else-1",
+          toComponentId: "log-online",
+          fromPort: "no",
+        },
+      ],
+    },
+  },
+  {
+    id: "monitor-status-changed-forward",
+    name: "Forward monitor status changes to another system",
+    description:
+      "POSTs each monitor status change to a URL of yours, so another system can react to it.",
+    teaches: "How to send OneUptime data outward as JSON.",
+    category: WorkflowTemplateCategory.Monitors,
+    icon: IconProp.Signal,
+    workflowName: "Forward monitor status changes",
+    workflowDescription:
+      "POSTs every monitor status change to an endpoint you control.",
+    variables: [
+      {
+        name: "forwardUrl",
+        title: "Destination URL",
+        description:
+          "The endpoint that should receive the POST. It will get the monitor name and its new status.",
+        placeholder: "https://example.com/hooks/monitor-status",
+        required: true,
+        isSecret: false,
+      },
+    ],
+    graph: {
+      nodes: [
+        {
+          componentId: "monitor-status-timeline-on-create-1",
+          metadataId: "monitor-status-timeline-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: { select: MONITOR_STATUS_TIMELINE_SELECT },
+        },
+        {
+          componentId: "api-post-1",
+          metadataId: ComponentID.ApiPost,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            url: "{{local.variables.forwardUrl}}",
+            "request-body": [
+              "{",
+              '  "monitor": "{{local.components.monitor-status-timeline-on-create-1.returnValues.model.monitor.name}}",',
+              '  "status": "{{local.components.monitor-status-timeline-on-create-1.returnValues.model.monitorStatus.name}}"',
+              "}",
+            ].join("\n"),
+          },
+        },
+        {
+          componentId: "log-failed",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: 300, y: 500 },
+          args: {
+            value:
+              "Could not forward the status change: {{local.components.api-post-1.returnValues.error}}",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "monitor-status-timeline-on-create-1",
+          toComponentId: "api-post-1",
+          fromPort: "success",
+        },
+        {
+          fromComponentId: "api-post-1",
+          toComponentId: "log-failed",
+          fromPort: "error",
+        },
+      ],
+    },
+  },
+
+  /* ------------------------------ On-Call ------------------------------ */
+  {
+    id: "oncall-executed-slack",
+    name: "Tell Slack when an on-call policy is executed",
+    description:
+      "Posts to Slack every time an on-call escalation policy runs, so the team can see a page going out.",
+    teaches: "How execution records can be triggers in their own right.",
+    category: WorkflowTemplateCategory.OnCall,
+    icon: IconProp.Phone,
+    workflowName: "Notify Slack when on-call is paged",
+    workflowDescription:
+      "Posts to Slack whenever an on-call duty policy is executed.",
+    variables: [SLACK_WEBHOOK_URL],
+    graph: {
+      nodes: [
+        {
+          componentId: "oncall-execution-on-create-1",
+          metadataId: "on-call-duty-policy-execution-log-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: {
+            select: {
+              _id: true,
+              status: true,
+              statusMessage: true,
+              onCallDutyPolicy: { name: true },
+            },
+          },
+        },
+        {
+          componentId: "slack-1",
+          metadataId: ComponentID.SlackSendMessageToChannel,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "webhook-url": "{{local.variables.slackWebhookUrl}}",
+            text: [
+              "*On-call policy executed: {{local.components.oncall-execution-on-create-1.returnValues.model.onCallDutyPolicy.name}}*",
+              "Status: {{local.components.oncall-execution-on-create-1.returnValues.model.status}}",
+              "{{local.components.oncall-execution-on-create-1.returnValues.model.statusMessage}}",
+            ].join("\n"),
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "oncall-execution-on-create-1",
+          toComponentId: "slack-1",
+          fromPort: "success",
+        },
+      ],
+    },
+  },
+
+  /* ---------------------------- Status Page ---------------------------- */
+  {
+    id: "subscriber-added-slack",
+    name: "Tell Slack when someone subscribes to your status page",
+    description:
+      "Posts a short note to Slack each time a new status page subscriber signs up.",
+    teaches: "How status page events can drive a workflow.",
+    category: WorkflowTemplateCategory.StatusPage,
+    icon: IconProp.UserGroup,
+    workflowName: "Notify Slack on new subscriber",
+    workflowDescription:
+      "Posts to Slack whenever someone subscribes to one of your status pages.",
+    variables: [SLACK_WEBHOOK_URL],
+    graph: {
+      nodes: [
+        {
+          componentId: "subscriber-on-create-1",
+          metadataId: "status-page-subscriber-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: {
+            select: {
+              _id: true,
+              subscriberEmail: true,
+              subscriberPhone: true,
+              statusPage: { name: true },
+            },
+          },
+        },
+        {
+          componentId: "slack-1",
+          metadataId: ComponentID.SlackSendMessageToChannel,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "webhook-url": "{{local.variables.slackWebhookUrl}}",
+            text: "New subscriber on *{{local.components.subscriber-on-create-1.returnValues.model.statusPage.name}}*: {{local.components.subscriber-on-create-1.returnValues.model.subscriberEmail}}",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "subscriber-on-create-1",
+          toComponentId: "slack-1",
+          fromPort: "success",
+        },
+      ],
+    },
+  },
+  {
+    id: "subscriber-added-forward",
+    name: "Send new status page subscribers to your CRM",
+    description:
+      "POSTs each new status page subscriber to a URL of yours, so they land in your mailing list or CRM.",
+    teaches: "How to push OneUptime data into a system you already run.",
+    category: WorkflowTemplateCategory.StatusPage,
+    icon: IconProp.InboxArrowDown,
+    workflowName: "Forward new subscribers",
+    workflowDescription:
+      "POSTs every new status page subscriber to an endpoint you control.",
+    variables: [
+      {
+        name: "crmWebhookUrl",
+        title: "Destination URL",
+        description:
+          "The endpoint that should receive the subscriber's email address.",
+        placeholder: "https://example.com/hooks/subscribers",
+        required: true,
+        isSecret: false,
+      },
+    ],
+    graph: {
+      nodes: [
+        {
+          componentId: "subscriber-on-create-1",
+          metadataId: "status-page-subscriber-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: {
+            select: {
+              _id: true,
+              subscriberEmail: true,
+              statusPage: { name: true },
+            },
+          },
+        },
+        {
+          componentId: "api-post-1",
+          metadataId: ComponentID.ApiPost,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            url: "{{local.variables.crmWebhookUrl}}",
+            "request-body": [
+              "{",
+              '  "email": "{{local.components.subscriber-on-create-1.returnValues.model.subscriberEmail}}",',
+              '  "statusPage": "{{local.components.subscriber-on-create-1.returnValues.model.statusPage.name}}"',
+              "}",
+            ].join("\n"),
+          },
+        },
+        {
+          componentId: "log-failed",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: 300, y: 500 },
+          args: {
+            value:
+              "Could not forward the subscriber: {{local.components.api-post-1.returnValues.error}}",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "subscriber-on-create-1",
+          toComponentId: "api-post-1",
+          fromPort: "success",
+        },
+        {
+          fromComponentId: "api-post-1",
+          toComponentId: "log-failed",
+          fromPort: "error",
+        },
+      ],
+    },
+  },
+
+  /* ----------------------- Scheduled Maintenance ----------------------- */
+  {
+    id: "maintenance-scheduled-slack",
+    name: "Announce scheduled maintenance in Slack",
+    description:
+      "Posts the title and window to Slack as soon as a maintenance event is scheduled.",
+    teaches: "How maintenance events can drive a workflow.",
+    category: WorkflowTemplateCategory.ScheduledMaintenance,
+    icon: IconProp.Calendar,
+    workflowName: "Announce maintenance in Slack",
+    workflowDescription:
+      "Posts to Slack whenever a scheduled maintenance event is created.",
+    variables: [SLACK_WEBHOOK_URL],
+    graph: {
+      nodes: [
+        {
+          componentId: "maintenance-on-create-1",
+          metadataId: "scheduled-maintenance-on-create",
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: {
+            select: {
+              _id: true,
+              title: true,
+              description: true,
+              startsAt: true,
+              endsAt: true,
+            },
+          },
+        },
+        {
+          componentId: "slack-1",
+          metadataId: ComponentID.SlackSendMessageToChannel,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "webhook-url": "{{local.variables.slackWebhookUrl}}",
+            text: [
+              "*Maintenance scheduled: {{local.components.maintenance-on-create-1.returnValues.model.title}}*",
+              "From {{local.components.maintenance-on-create-1.returnValues.model.startsAt}} to {{local.components.maintenance-on-create-1.returnValues.model.endsAt}}",
+              "",
+              "{{local.components.maintenance-on-create-1.returnValues.model.description}}",
+            ].join("\n"),
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "maintenance-on-create-1",
+          toComponentId: "slack-1",
+          fromPort: "success",
+        },
+      ],
+    },
+  },
+
+  /* ---------------------------- On a Schedule ---------------------------- */
+  {
     id: "scheduled-check",
     name: "Call an API on a schedule",
     description:
       "Runs every hour, calls a URL, and logs whether it came back OK — with separate paths for success and failure.",
     teaches:
       "How a schedule works, and how a step's Success and Error ports branch.",
+    category: WorkflowTemplateCategory.Scheduled,
+    icon: IconProp.Clock,
     workflowName: "Hourly API check",
     workflowDescription:
-      "Calls a URL every hour and logs the outcome. Point the URL at something of yours.",
+      "Calls a URL every hour and logs the outcome. Change the cron to run it more or less often.",
+    variables: [
+      {
+        name: "apiUrl",
+        title: "URL to call",
+        description: "The endpoint this workflow should call every hour.",
+        placeholder: "https://api.example.com/health",
+        required: true,
+        isSecret: false,
+      },
+    ],
     graph: {
       nodes: [
         {
@@ -216,7 +1387,7 @@ const TEMPLATE_DEFINITIONS: Array<TemplateDefinition> = [
           componentType: ComponentType.Component,
           position: { x: 100, y: 300 },
           args: {
-            url: "https://api.github.com/zen",
+            url: "{{local.variables.apiUrl}}",
           },
         },
         {
@@ -259,25 +1430,428 @@ const TEMPLATE_DEFINITIONS: Array<TemplateDefinition> = [
       ],
     },
   },
+  {
+    id: "scheduled-check-alert-slack",
+    name: "Check an API on a schedule and shout if it fails",
+    description:
+      "Calls a URL every five minutes and posts to Slack only when the call fails.",
+    teaches:
+      "How to wire the Error port to a notification so silence means healthy.",
+    category: WorkflowTemplateCategory.Scheduled,
+    icon: IconProp.Fire,
+    workflowName: "API check with Slack alert",
+    workflowDescription:
+      "Calls a URL every five minutes and posts to Slack when the call fails.",
+    variables: [
+      {
+        name: "apiUrl",
+        title: "URL to check",
+        description: "The endpoint this workflow should call every five minutes.",
+        placeholder: "https://api.example.com/health",
+        required: true,
+        isSecret: false,
+      },
+      SLACK_WEBHOOK_URL,
+    ],
+    graph: {
+      nodes: [
+        {
+          componentId: "schedule-1",
+          metadataId: ComponentID.Schedule,
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: {
+            schedule: "*/5 * * * *",
+          },
+        },
+        {
+          componentId: "api-get-1",
+          metadataId: ComponentID.ApiGet,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            url: "{{local.variables.apiUrl}}",
+          },
+        },
+        {
+          componentId: "log-ok",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: -100, y: 500 },
+          args: {
+            value:
+              "Healthy — responded {{local.components.api-get-1.returnValues.response-status}}.",
+          },
+        },
+        {
+          componentId: "slack-failed",
+          metadataId: ComponentID.SlackSendMessageToChannel,
+          componentType: ComponentType.Component,
+          position: { x: 300, y: 500 },
+          args: {
+            "webhook-url": "{{local.variables.slackWebhookUrl}}",
+            text: "*Scheduled check failed* for {{local.variables.apiUrl}}\n{{local.components.api-get-1.returnValues.error}}",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "schedule-1",
+          toComponentId: "api-get-1",
+          fromPort: "execute",
+        },
+        {
+          fromComponentId: "api-get-1",
+          toComponentId: "log-ok",
+          fromPort: "success",
+        },
+        {
+          fromComponentId: "api-get-1",
+          toComponentId: "slack-failed",
+          fromPort: "error",
+        },
+      ],
+    },
+  },
+  {
+    id: "scheduled-heartbeat",
+    name: "Ping a heartbeat URL on a schedule",
+    description:
+      "Calls a dead-man's-switch URL every five minutes so an external watchdog knows OneUptime is alive.",
+    teaches: "The smallest useful scheduled workflow.",
+    category: WorkflowTemplateCategory.Scheduled,
+    icon: IconProp.ArrowPath,
+    workflowName: "Heartbeat ping",
+    workflowDescription:
+      "Calls a heartbeat URL every five minutes. Point it at your dead-man's-switch.",
+    variables: [
+      {
+        name: "heartbeatUrl",
+        title: "Heartbeat URL",
+        description:
+          "The dead-man's-switch endpoint to ping. Most watchdog services give you one.",
+        placeholder: "https://hc-ping.com/your-uuid-here",
+        required: true,
+        isSecret: true,
+      },
+    ],
+    graph: {
+      nodes: [
+        {
+          componentId: "schedule-1",
+          metadataId: ComponentID.Schedule,
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: {
+            schedule: "*/5 * * * *",
+          },
+        },
+        {
+          componentId: "api-get-1",
+          metadataId: ComponentID.ApiGet,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            url: "{{local.variables.heartbeatUrl}}",
+          },
+        },
+        {
+          componentId: "log-failed",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 500 },
+          args: {
+            value:
+              "Heartbeat ping failed: {{local.components.api-get-1.returnValues.error}}",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "schedule-1",
+          toComponentId: "api-get-1",
+          fromPort: "execute",
+        },
+        {
+          fromComponentId: "api-get-1",
+          toComponentId: "log-failed",
+          fromPort: "error",
+        },
+      ],
+    },
+  },
+  {
+    id: "scheduled-email-digest",
+    name: "Email yourself on a schedule",
+    description:
+      "Sends a daily email through your own SMTP server. A starting point for digests and reports.",
+    teaches: "How to configure an outbound email step.",
+    category: WorkflowTemplateCategory.Scheduled,
+    icon: IconProp.Email,
+    workflowName: "Daily email",
+    workflowDescription:
+      "Sends an email every morning through your SMTP server. Add steps before it to gather the content.",
+    variables: [
+      {
+        name: "smtpHost",
+        title: "SMTP Host",
+        description: "The mail server to send through.",
+        placeholder: "smtp.example.com",
+        required: true,
+        isSecret: false,
+      },
+      {
+        name: "smtpPort",
+        title: "SMTP Port",
+        description: "Usually 587 for STARTTLS, or 465 for implicit TLS.",
+        placeholder: "587",
+        required: true,
+        isSecret: false,
+      },
+      {
+        name: "smtpUsername",
+        title: "SMTP Username",
+        description: "Leave blank if your server does not require a login.",
+        placeholder: "notifications@example.com",
+        required: false,
+        isSecret: false,
+      },
+      {
+        name: "smtpPassword",
+        title: "SMTP Password",
+        description: "Leave blank if your server does not require a login.",
+        placeholder: "••••••••",
+        required: false,
+        isSecret: true,
+      },
+      {
+        name: "emailFrom",
+        title: "From Address",
+        description: "The address the email is sent from.",
+        placeholder: "notifications@example.com",
+        required: true,
+        isSecret: false,
+      },
+      {
+        name: "emailTo",
+        title: "To Address",
+        description: "Who should receive it.",
+        placeholder: "you@example.com",
+        required: true,
+        isSecret: false,
+      },
+    ],
+    graph: {
+      nodes: [
+        {
+          componentId: "schedule-1",
+          metadataId: ComponentID.Schedule,
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+          args: {
+            schedule: "0 8 * * *",
+          },
+        },
+        {
+          componentId: "send-email-1",
+          metadataId: ComponentID.SendEmail,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            from: "{{local.variables.emailFrom}}",
+            to: "{{local.variables.emailTo}}",
+            subject: "Your daily OneUptime digest",
+            "email-body":
+              "<p>This email was sent by a OneUptime workflow. Add steps before this one to fill it with something useful.</p>",
+            "smtp-host": "{{local.variables.smtpHost}}",
+            "smtp-port": "{{local.variables.smtpPort}}",
+            "smtp-username": "{{local.variables.smtpUsername}}",
+            "smtp-password": "{{local.variables.smtpPassword}}",
+          },
+        },
+        {
+          componentId: "log-failed",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 500 },
+          args: {
+            value: "The daily email could not be sent.",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "schedule-1",
+          toComponentId: "send-email-1",
+          fromPort: "execute",
+        },
+        {
+          fromComponentId: "send-email-1",
+          toComponentId: "log-failed",
+          fromPort: "error",
+        },
+      ],
+    },
+  },
+
+  /* --------------------------- Integrations --------------------------- */
+  {
+    id: "webhook-to-slack",
+    name: "Post anything you send to a webhook into Slack",
+    description:
+      "Gives you a URL. Anything POSTed to it turns up in a Slack channel.",
+    teaches: "How to turn OneUptime into glue between two systems.",
+    category: WorkflowTemplateCategory.Integrations,
+    icon: IconProp.SendMessage,
+    workflowName: "Webhook to Slack",
+    workflowDescription:
+      "Anything POSTed to this workflow's webhook is forwarded into a Slack channel.",
+    variables: [SLACK_WEBHOOK_URL],
+    graph: {
+      nodes: [
+        {
+          componentId: "webhook-1",
+          metadataId: ComponentID.Webhook,
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+        },
+        {
+          componentId: "slack-1",
+          metadataId: ComponentID.SlackSendMessageToChannel,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            "webhook-url": "{{local.variables.slackWebhookUrl}}",
+            text: "Webhook received:\n```{{local.components.webhook-1.returnValues.request-body}}```",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "webhook-1",
+          toComponentId: "slack-1",
+          fromPort: "out",
+        },
+      ],
+    },
+  },
+  {
+    id: "webhook-relay",
+    name: "Relay a webhook to another URL",
+    description:
+      "Receives a webhook and forwards the body straight on to a second endpoint.",
+    teaches:
+      "How to sit between two systems, with somewhere to add filtering later.",
+    category: WorkflowTemplateCategory.Integrations,
+    icon: IconProp.Integrations,
+    workflowName: "Relay a webhook",
+    workflowDescription:
+      "Forwards anything POSTed to this workflow's webhook on to another endpoint.",
+    variables: [
+      {
+        name: "targetUrl",
+        title: "Destination URL",
+        description: "Where the received body should be forwarded.",
+        placeholder: "https://example.com/hooks/inbound",
+        required: true,
+        isSecret: false,
+      },
+    ],
+    graph: {
+      nodes: [
+        {
+          componentId: "webhook-1",
+          metadataId: ComponentID.Webhook,
+          componentType: ComponentType.Trigger,
+          position: { x: 100, y: 100 },
+        },
+        {
+          componentId: "api-post-1",
+          metadataId: ComponentID.ApiPost,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 300 },
+          args: {
+            url: "{{local.variables.targetUrl}}",
+            "request-body":
+              "{{local.components.webhook-1.returnValues.request-body}}",
+          },
+        },
+        {
+          componentId: "log-failed",
+          metadataId: ComponentID.Log,
+          componentType: ComponentType.Component,
+          position: { x: 100, y: 500 },
+          args: {
+            value:
+              "Relay failed: {{local.components.api-post-1.returnValues.error}}",
+          },
+        },
+      ],
+      edges: [
+        {
+          fromComponentId: "webhook-1",
+          toComponentId: "api-post-1",
+          fromPort: "out",
+        },
+        {
+          fromComponentId: "api-post-1",
+          toComponentId: "log-failed",
+          fromPort: "error",
+        },
+      ],
+    },
+  },
 ];
+
+type ToPublicTemplateFunction = (
+  definition: TemplateDefinition,
+) => WorkflowTemplate;
+
+/*
+ * Strips the graph off, and nothing else. Listing every field by hand here is
+ * how a new field on WorkflowTemplate silently fails to reach the picker, so
+ * this destructures instead: add a field to the interface and it arrives.
+ */
+const toPublicTemplate: ToPublicTemplateFunction = (
+  definition: TemplateDefinition,
+): WorkflowTemplate => {
+  const { graph: _graph, ...template } = definition;
+  return template;
+};
 
 export type GetWorkflowTemplatesFunction = () => Array<WorkflowTemplate>;
 
 export const getWorkflowTemplates: GetWorkflowTemplatesFunction =
   (): Array<WorkflowTemplate> => {
-    return TEMPLATE_DEFINITIONS.map(
-      (definition: TemplateDefinition): WorkflowTemplate => {
-        return {
-          id: definition.id,
-          name: definition.name,
-          description: definition.description,
-          teaches: definition.teaches,
-          workflowName: definition.workflowName,
-          workflowDescription: definition.workflowDescription,
-        };
-      },
-    );
+    return TEMPLATE_DEFINITIONS.map(toPublicTemplate);
   };
+
+export type GetWorkflowTemplatesByCategoryFunction = (
+  category: WorkflowTemplateCategory,
+) => Array<WorkflowTemplate>;
+
+export const getWorkflowTemplatesByCategory: GetWorkflowTemplatesByCategoryFunction =
+  (category: WorkflowTemplateCategory): Array<WorkflowTemplate> => {
+    return getWorkflowTemplates().filter((template: WorkflowTemplate) => {
+      return template.category === category;
+    });
+  };
+
+export type GetWorkflowTemplateFunction = (
+  templateId: string,
+) => WorkflowTemplate | null;
+
+export const getWorkflowTemplate: GetWorkflowTemplateFunction = (
+  templateId: string,
+): WorkflowTemplate | null => {
+  const definition: TemplateDefinition | undefined = TEMPLATE_DEFINITIONS.find(
+    (candidate: TemplateDefinition) => {
+      return candidate.id === templateId;
+    },
+  );
+
+  return definition ? toPublicTemplate(definition) : null;
+};
 
 export type GetTemplateGraphSpecFunction = (
   templateId: string,


### PR DESCRIPTION
Follows the workflow series (#3158–#3162).

## Why

#3162 put three templates behind a button, and the button was the honest limit of that design: templates had nowhere to put configuration, so they had to be things that need none. That ruled out every workflow anybody actually wants. "Tell Slack when an incident opens" needs a webhook URL, and there was no step in which to ask for one.

So this adds the step — and then the templates that step makes possible.

## The wizard

The **Create Workflow** button now opens a three-step modal instead of the stock create form:

1. **Start from** — a searchable card grid grouped by category, with "Start from scratch" as the first option.
2. **Name** — pre-filled from the template, editable. (`Workflow.name` is `@UniqueColumnBy("projectId")`, so creating the same template twice failed outright before this step existed.)
3. **Configure** — the variables the chosen template declares. Skipped entirely for blank workflows and for the zero-config templates, so those stay two clicks away.

It replaces the built-in form through `onCreateClick` rather than a `cardProps` button. That matters: `cardProps` buttons are not permission-gated, so a viewer who cannot create workflows would have seen it.

## Templates: 3 → 24

Nine categories: Basics, Incidents, Alerts, Monitors, On-Call, Status Page, Scheduled Maintenance, On a Schedule, Integrations. The additions are mostly the database-trigger workflows that were previously impossible — incident opened → Slack / Teams / Discord, incident state changed, monitor offline, on-call policy paged, new status page subscriber → your CRM — plus scheduled checks, a webhook relay, and an AI incident summary.

`WorkflowTemplate` grows `category`, `icon` and `variables`. The accessor now destructures instead of hand-listing its output fields, because hand-listing is exactly how a newly added field silently fails to reach the picker.

## Variables are rows, not substitutions

The value the user types is written as a `WorkflowVariable` scoped to the new workflow. **The graph keeps the reference** — `{{local.variables.slackWebhookUrl}}` — so one value can feed several steps and can be rotated later without editing the graph. A test asserts the typed value never appears in the saved graph at all.

Two failure modes got explicit handling:

- **Partial writes.** Variables need the workflow's id, so they can only be written after it exists. If any of them fails, the workflow is deleted again. Leaving it would leave something worse than nothing: an unresolved reference is not an error at run time — `VMAPI` skips it and leaves the literal text — so the run reports success and posts `{{local.variables.slackWebhookUrl}}` to Slack.
- **Blank optional variables.** No row is written, so the reference would ship literally. Where the argument is nothing but that reference, the argument is dropped, which is what "leave it blank" was supposed to mean.

## One permission change

`WorkflowVariable`'s create ACL gains `ProjectMember`, `WorkflowAdmin` and `WorkflowMember`, mirroring `Workflow`'s own create list. Before this, a plain project member could create the workflow at step 1 and be rejected at step 3 — landing exactly in the silent-failure case above.

Create only. `WorkflowVariable.update` still excludes `ProjectMember`, but so does `Workflow.update`, so that asymmetry is unchanged; and a member who can delete the workflow takes its variables with it.

## Tests

730 assertions, and two of them are the reason the rest are worth having.

**"every field read off a database record was asked for in select"** — a database trigger only hydrates the columns its `select` argument names. `{{…returnValues.model.title}}` against a select without `title: true` resolves to nothing, and nothing in the stack calls that an error. The run succeeds. The message ships with braces in it. This test walks every reference against the select that feeds it.

**"every variable the graph references is declared by the template"** — the same silent failure from the other side: a reference the wizard never collects a value for.

Also worth noting:

- The registry under test is now the **merged** one (`loadComponentsAndCategories`), not the static `Components` array. Against the static array, a node like `incident-on-create` gets `metadata: undefined`, the linter's `isRealNode` drops it, and the lint test passes on a graph it never checked. Every template here would have been unverified.
- References are classified with `parseReferencePath` instead of assuming every `{{...}}` is `local.components.*`, which is what lets variable references exist at all.
- The lint bar is now **zero issues**, not zero errors. `UnreachableComponent` is only a warning, so a stray disconnected node used to be shippable.
- `App/Tests/Dashboard/WorkflowTemplateCreate.test.ts` covers the create-payload builder directly: rollback inputs, trimming, `isSecret` always present as a real boolean (it is a required column whose `defaultValue` is not an `isDefaultValueColumn`, so `undefined` is a 400), and the blank-optional strip.

Writing these caught a real inconsistency in my own first draft: `forwardUrl` was declared twice with different wording. Variables are workflow-scoped so per-template wording is fine, but `required` and `isSecret` drifting would be a genuine bug — the assertion now pins those and lets the prose vary.

## Not verified in a browser

The wizard is typechecked, linted and unit-tested, but I could not sign in to the local dashboard to click through it. Worth a manual pass on the three-step flow before merge.
