### PR TITLE
feat(dashboard): add a note textbox to bulk change-state modals

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Alert/AlertsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Alert/AlertsTable.tsx
@@ -20,6 +20,7 @@ import Query from "Common/Types/BaseDatabase/Query";
 import Search from "Common/Types/BaseDatabase/Search";
 import Alert from "Common/Models/DatabaseModels/Alert";
 import AlertCustomField from "Common/Models/DatabaseModels/AlertCustomField";
+import AlertNoteTemplate from "Common/Models/DatabaseModels/AlertNoteTemplate";
 import AlertOwnerTeam from "Common/Models/DatabaseModels/AlertOwnerTeam";
 import AlertOwnerUser from "Common/Models/DatabaseModels/AlertOwnerUser";
 import AlertSeverity from "Common/Models/DatabaseModels/AlertSeverity";
@@ -60,14 +61,22 @@ import Icon from "Common/UI/Components/Icon/Icon";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import API from "Common/UI/Utils/API/API";
-import BasicFormModal from "Common/UI/Components/FormModal/BasicFormModal";
-import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import ObjectID from "Common/Types/ObjectID";
 import AlertStateTimeline from "Common/Models/DatabaseModels/AlertStateTimeline";
 import GlobalEvents from "Common/UI/Utils/GlobalEvents";
 import { REFRESH_SIDEBAR_COUNT_EVENT } from "Common/UI/Components/SideMenu/CountModelSideMenuItem";
 import LiveDuration from "../EventView/LiveDuration";
 import useEventTimelineEndDates from "../EventView/useEventTimelineEndDates";
+import useNoteTemplates from "../EventView/useNoteTemplates";
+import BulkChangeStateModal, {
+  BulkChangeStateSubmitData,
+} from "../EventView/BulkChangeStateModal";
+import {
+  BulkStateChangeNoteType,
+  BulkStateChangeSkipDecision,
+  buildBulkStateChangeMiscDataProps,
+  getBulkStateChangeSkipDecision,
+} from "../../Utils/BulkStateChange";
 
 export interface ComponentProps {
   query?: Query<Alert> | undefined;
@@ -110,6 +119,10 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
     eventIds: resolvedAlertIds,
     eventIdField: "alertId",
     timelineModelType: AlertStateTimeline,
+  });
+
+  const { noteTemplates } = useNoteTemplates<AlertNoteTemplate>({
+    modelType: AlertNoteTemplate,
   });
 
   const { bulkActions: labelBulkActions, modals: labelBulkActionModals } =
@@ -408,11 +421,15 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
   }, []);
 
   const handleBulkStateChange: (
-    targetStateId: ObjectID,
-  ) => Promise<void> = async (targetStateId: ObjectID): Promise<void> => {
+    data: BulkChangeStateSubmitData,
+  ) => Promise<void> = async (
+    data: BulkChangeStateSubmitData,
+  ): Promise<void> => {
     if (!bulkActionProps) {
       return;
     }
+
+    const targetStateId: ObjectID = data.stateId;
 
     const { items, onProgressInfo, onBulkActionStart, onBulkActionEnd } =
       bulkActionProps;
@@ -428,6 +445,11 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
     }
 
     const targetOrder: number = targetState.order || 0;
+
+    const miscDataProps: JSONObject = buildBulkStateChangeMiscDataProps({
+      noteType: BulkStateChangeNoteType.Private,
+      note: data.note,
+    });
 
     onBulkActionStart();
 
@@ -460,12 +482,18 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
           fetchedAlert?.currentAlertState?.order || 0;
 
         // Skip if already at or past the target state
-        if (currentOrder >= targetOrder) {
-          const currentStateName: string =
-            fetchedAlert?.currentAlertState?.name || "Unknown";
+        const skipDecision: BulkStateChangeSkipDecision =
+          getBulkStateChangeSkipDecision({
+            currentOrder: currentOrder,
+            targetOrder: targetOrder,
+            currentStateName: fetchedAlert?.currentAlertState?.name,
+            targetStateName: targetState.name,
+          });
+
+        if (skipDecision.shouldSkip) {
           failedItems.push({
             item: alert,
-            failedMessage: `Skipped: Already at "${currentStateName}" (at or past "${targetState.name}")`,
+            failedMessage: skipDecision.skippedMessage!,
           });
         } else {
           // Create state timeline to change state
@@ -477,6 +505,7 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
           await ModelAPI.create<AlertStateTimeline>({
             model: stateTimeline,
             modelType: AlertStateTimeline,
+            miscDataProps: miscDataProps,
           });
 
           successItems.push(alert);
@@ -906,35 +935,25 @@ const AlertsTable: FunctionComponent<ComponentProps> = (
       {ownerBulkActionModals}
 
       {showBulkStateChangeModal && (
-        <BasicFormModal
+        <BulkChangeStateModal
           title="Change Alert State"
           description="Select the state to change alerts to. Alerts already at or past the selected state will be skipped."
+          stateFieldKey="alertStateId"
+          stateOptions={alertStates.map((state: AlertState) => {
+            return {
+              label: state.name || "",
+              value: state.id?.toString() || "",
+            };
+          })}
+          noteType={BulkStateChangeNoteType.Private}
+          noteTitle="Private Note"
+          noteDescription="Add an optional private note about this state change. Only your team can see it, and the same note is added to every alert you selected."
+          noteTemplates={noteTemplates}
           onClose={() => {
             setShowBulkStateChangeModal(false);
             setBulkActionProps(null);
           }}
-          submitButtonText="Change State"
-          onSubmit={async (formData: { alertStateId: ObjectID }) => {
-            await handleBulkStateChange(formData.alertStateId);
-          }}
-          formProps={{
-            fields: [
-              {
-                field: {
-                  alertStateId: true,
-                },
-                title: "Select State",
-                fieldType: FormFieldSchemaType.Dropdown,
-                required: true,
-                dropdownOptions: alertStates.map((state: AlertState) => {
-                  return {
-                    label: state.name || "",
-                    value: state.id?.toString() || "",
-                  };
-                }),
-              },
-            ],
-          }}
+          onSubmit={handleBulkStateChange}
         />
       )}
     </>

--- a/App/FeatureSet/Dashboard/src/Components/AlertEpisode/AlertEpisodesTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AlertEpisode/AlertEpisodesTable.tsx
@@ -13,6 +13,7 @@ import Pill from "Common/UI/Components/Pill/Pill";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import Query from "Common/Types/BaseDatabase/Query";
 import AlertEpisode from "Common/Models/DatabaseModels/AlertEpisode";
+import AlertNoteTemplate from "Common/Models/DatabaseModels/AlertNoteTemplate";
 import AlertSeverity from "Common/Models/DatabaseModels/AlertSeverity";
 import AlertState from "Common/Models/DatabaseModels/AlertState";
 import AlertGroupingRule from "Common/Models/DatabaseModels/AlertGroupingRule";
@@ -37,12 +38,21 @@ import IconProp from "Common/Types/Icon/IconProp";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import API from "Common/UI/Utils/API/API";
-import BasicFormModal from "Common/UI/Components/FormModal/BasicFormModal";
-import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import ObjectID from "Common/Types/ObjectID";
+import { JSONObject } from "Common/Types/JSON";
 import AlertEpisodeStateTimeline from "Common/Models/DatabaseModels/AlertEpisodeStateTimeline";
 import GlobalEvents from "Common/UI/Utils/GlobalEvents";
 import { REFRESH_SIDEBAR_COUNT_EVENT } from "Common/UI/Components/SideMenu/CountModelSideMenuItem";
+import useNoteTemplates from "../EventView/useNoteTemplates";
+import BulkChangeStateModal, {
+  BulkChangeStateSubmitData,
+} from "../EventView/BulkChangeStateModal";
+import {
+  BulkStateChangeNoteType,
+  BulkStateChangeSkipDecision,
+  buildBulkStateChangeMiscDataProps,
+  getBulkStateChangeSkipDecision,
+} from "../../Utils/BulkStateChange";
 
 export interface ComponentProps {
   query?: Query<AlertEpisode> | undefined;
@@ -61,6 +71,10 @@ const AlertEpisodesTable: FunctionComponent<ComponentProps> = (
     useState<boolean>(false);
   const [bulkActionProps, setBulkActionProps] =
     useState<BulkActionOnClickProps<AlertEpisode> | null>(null);
+
+  const { noteTemplates } = useNoteTemplates<AlertNoteTemplate>({
+    modelType: AlertNoteTemplate,
+  });
 
   const { bulkActions: labelBulkActions, modals: labelBulkActionModals } =
     useBulkLabelActions<AlertEpisode>({ modelType: AlertEpisode });
@@ -100,11 +114,15 @@ const AlertEpisodesTable: FunctionComponent<ComponentProps> = (
   }, []);
 
   const handleBulkStateChange: (
-    targetStateId: ObjectID,
-  ) => Promise<void> = async (targetStateId: ObjectID): Promise<void> => {
+    data: BulkChangeStateSubmitData,
+  ) => Promise<void> = async (
+    data: BulkChangeStateSubmitData,
+  ): Promise<void> => {
     if (!bulkActionProps) {
       return;
     }
+
+    const targetStateId: ObjectID = data.stateId;
 
     const { items, onProgressInfo, onBulkActionStart, onBulkActionEnd } =
       bulkActionProps;
@@ -120,6 +138,11 @@ const AlertEpisodesTable: FunctionComponent<ComponentProps> = (
     }
 
     const targetOrder: number = targetState.order || 0;
+
+    const miscDataProps: JSONObject = buildBulkStateChangeMiscDataProps({
+      noteType: BulkStateChangeNoteType.Private,
+      note: data.note,
+    });
 
     onBulkActionStart();
 
@@ -153,12 +176,18 @@ const AlertEpisodesTable: FunctionComponent<ComponentProps> = (
           fetchedEpisode?.currentAlertState?.order || 0;
 
         // Skip if already at or past the target state
-        if (currentOrder >= targetOrder) {
-          const currentStateName: string =
-            fetchedEpisode?.currentAlertState?.name || "Unknown";
+        const skipDecision: BulkStateChangeSkipDecision =
+          getBulkStateChangeSkipDecision({
+            currentOrder: currentOrder,
+            targetOrder: targetOrder,
+            currentStateName: fetchedEpisode?.currentAlertState?.name,
+            targetStateName: targetState.name,
+          });
+
+        if (skipDecision.shouldSkip) {
           failedItems.push({
             item: episode,
-            failedMessage: `Skipped: Already at "${currentStateName}" (at or past "${targetState.name}")`,
+            failedMessage: skipDecision.skippedMessage!,
           });
         } else {
           // Create state timeline to change state
@@ -171,6 +200,7 @@ const AlertEpisodesTable: FunctionComponent<ComponentProps> = (
           await ModelAPI.create<AlertEpisodeStateTimeline>({
             model: stateTimeline,
             modelType: AlertEpisodeStateTimeline,
+            miscDataProps: miscDataProps,
           });
 
           successItems.push(episode);
@@ -506,35 +536,25 @@ const AlertEpisodesTable: FunctionComponent<ComponentProps> = (
       )}
 
       {showBulkStateChangeModal && (
-        <BasicFormModal
+        <BulkChangeStateModal
           title="Change Episode State"
           description="Select the state to change episodes to. Episodes already at or past the selected state will be skipped. Member alerts will also be updated."
+          stateFieldKey="alertStateId"
+          stateOptions={alertStates.map((state: AlertState) => {
+            return {
+              label: state.name || "",
+              value: state.id?.toString() || "",
+            };
+          })}
+          noteType={BulkStateChangeNoteType.Private}
+          noteTitle="Private Note"
+          noteDescription="Add an optional private note about this state change. Only your team can see it, and the same note is added to every episode you selected."
+          noteTemplates={noteTemplates}
           onClose={() => {
             setShowBulkStateChangeModal(false);
             setBulkActionProps(null);
           }}
-          submitButtonText="Change State"
-          onSubmit={async (formData: { alertStateId: ObjectID }) => {
-            await handleBulkStateChange(formData.alertStateId);
-          }}
-          formProps={{
-            fields: [
-              {
-                field: {
-                  alertStateId: true,
-                },
-                title: "Select State",
-                fieldType: FormFieldSchemaType.Dropdown,
-                required: true,
-                dropdownOptions: alertStates.map((state: AlertState) => {
-                  return {
-                    label: state.name || "",
-                    value: state.id?.toString() || "",
-                  };
-                }),
-              },
-            ],
-          }}
+          onSubmit={handleBulkStateChange}
         />
       )}
     </>

--- a/App/FeatureSet/Dashboard/src/Components/EventView/BulkChangeStateModal.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/EventView/BulkChangeStateModal.tsx
@@ -1,0 +1,170 @@
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import { DropdownOption } from "Common/UI/Components/Dropdown/Dropdown";
+import BasicFormModal from "Common/UI/Components/FormModal/BasicFormModal";
+import Field from "Common/UI/Components/Forms/Types/Field";
+import Fields from "Common/UI/Components/Forms/Types/Fields";
+import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
+import FormValues from "Common/UI/Components/Forms/Types/FormValues";
+import SelectFormFields from "Common/UI/Types/SelectEntityField";
+import { ModalWidth } from "Common/UI/Components/Modal/Modal";
+import React, { FunctionComponent, ReactElement } from "react";
+import {
+  BulkStateChangeNoteTemplate,
+  BulkStateChangeNoteType,
+  getBulkStateChangeNoteFieldKey,
+  getBulkStateChangeNoteTemplateFieldKey,
+  getNoteFromTemplate,
+} from "../../Utils/BulkStateChange";
+
+export interface BulkChangeStateSubmitData {
+  stateId: ObjectID;
+  note?: string | undefined;
+  shouldStatusPageSubscribersBeNotified?: boolean | undefined;
+}
+
+export interface ComponentProps {
+  title: string;
+  description: string;
+  submitButtonText?: string | undefined;
+  /** The state timeline column the picked state is submitted under. */
+  stateFieldKey: string;
+  stateOptions: Array<DropdownOption>;
+  noteType: BulkStateChangeNoteType;
+  noteTitle: string;
+  noteDescription: string;
+  noteTemplates: Array<BulkStateChangeNoteTemplate>;
+  showNotifyStatusPageSubscribers?: boolean | undefined;
+  onClose: () => void;
+  onSubmit: (data: BulkChangeStateSubmitData) => Promise<void>;
+}
+
+export const NOTIFY_SUBSCRIBERS_FIELD_KEY: string =
+  "shouldStatusPageSubscribersBeNotified";
+
+/**
+ * The "Change State" modal behind a table's bulk action. It carries the same
+ * optional note (and template shortcut) as the single-event change-state modal
+ * on the event overview page, so a bulk change is just as traceable as a
+ * one-off one.
+ */
+const BulkChangeStateModal: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const noteFieldKey: string = getBulkStateChangeNoteFieldKey(props.noteType);
+  const noteTemplateFieldKey: string = getBulkStateChangeNoteTemplateFieldKey(
+    props.noteType,
+  );
+
+  const fields: Fields<JSONObject> = [
+    {
+      field: {
+        [props.stateFieldKey]: true,
+      } as SelectFormFields<JSONObject>,
+      title: "Select State",
+      fieldType: FormFieldSchemaType.Dropdown,
+      required: true,
+      dropdownOptions: props.stateOptions,
+    },
+  ];
+
+  if (props.noteTemplates.length > 0) {
+    const templateField: Field<JSONObject> = {
+      field: {
+        [noteTemplateFieldKey]: true,
+      } as SelectFormFields<JSONObject>,
+      onChange: (
+        value: string,
+        currentValues: FormValues<JSONObject>,
+        setNewFormValues: (currentFormValues: FormValues<JSONObject>) => void,
+      ) => {
+        const note: string = getNoteFromTemplate(props.noteTemplates, value);
+
+        if (note) {
+          setNewFormValues({
+            ...currentValues,
+            [noteFieldKey]: note,
+          });
+        }
+      },
+      fieldType: FormFieldSchemaType.Dropdown,
+      dropdownOptions: props.noteTemplates.map(
+        (template: BulkStateChangeNoteTemplate): DropdownOption => {
+          return {
+            value: template.id,
+            label: template.templateName,
+          };
+        },
+      ),
+      description:
+        "If you have a template for this state change, select it here.",
+      title: "Select Note Template",
+      required: false,
+      overrideFieldKey: noteTemplateFieldKey,
+    };
+
+    fields.push(templateField);
+  }
+
+  fields.push({
+    field: {
+      [noteFieldKey]: true,
+    } as SelectFormFields<JSONObject>,
+    fieldType: FormFieldSchemaType.Markdown,
+    description: props.noteDescription,
+    title: props.noteTitle,
+    required: false,
+    overrideFieldKey: noteFieldKey,
+  });
+
+  if (props.showNotifyStatusPageSubscribers) {
+    fields.push({
+      field: {
+        [NOTIFY_SUBSCRIBERS_FIELD_KEY]: true,
+      } as SelectFormFields<JSONObject>,
+      fieldType: FormFieldSchemaType.Checkbox,
+      description: "Notify subscribers of this state change.",
+      title: "Notify Status Page Subscribers",
+      required: false,
+      defaultValue: true,
+    });
+  }
+
+  return (
+    <BasicFormModal<JSONObject>
+      title={props.title}
+      description={props.description}
+      modalWidth={ModalWidth.Large}
+      onClose={props.onClose}
+      submitButtonText={props.submitButtonText || "Change State"}
+      onSubmit={async (formData: JSONObject) => {
+        const selectedStateId: string = String(
+          formData[props.stateFieldKey] || "",
+        );
+
+        if (!selectedStateId) {
+          return;
+        }
+
+        const note: unknown = formData[noteFieldKey];
+
+        await props.onSubmit({
+          stateId: new ObjectID(selectedStateId),
+          note: typeof note === "string" ? note : undefined,
+          ...(props.showNotifyStatusPageSubscribers
+            ? {
+                shouldStatusPageSubscribersBeNotified: Boolean(
+                  formData[NOTIFY_SUBSCRIBERS_FIELD_KEY],
+                ),
+              }
+            : {}),
+        });
+      }}
+      formProps={{
+        fields: fields,
+      }}
+    />
+  );
+};
+
+export default BulkChangeStateModal;

--- a/App/FeatureSet/Dashboard/src/Components/EventView/useNoteTemplates.ts
+++ b/App/FeatureSet/Dashboard/src/Components/EventView/useNoteTemplates.ts
@@ -1,0 +1,97 @@
+import Query from "Common/Types/BaseDatabase/Query";
+import Select from "Common/Types/BaseDatabase/Select";
+import Sort from "Common/Types/BaseDatabase/Sort";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import DatabaseBaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "Common/UI/Utils/Project";
+import { useEffect, useState } from "react";
+import { BulkStateChangeNoteTemplate } from "../../Utils/BulkStateChange";
+
+type NoteTemplateModel = DatabaseBaseModel & {
+  templateName?: string | undefined;
+  note?: string | undefined;
+};
+
+export interface UseNoteTemplatesProps<TTemplate extends NoteTemplateModel> {
+  modelType: { new (): TTemplate };
+}
+
+export interface UseNoteTemplatesResult {
+  noteTemplates: Array<BulkStateChangeNoteTemplate>;
+}
+
+/**
+ * Load this project's note templates so a bulk state change can offer the same
+ * "pick a template" shortcut the single-event change-state modal offers.
+ * Template loading is best effort: the note textbox stays usable when the
+ * fetch fails, the dropdown just does not show up.
+ */
+export default function useNoteTemplates<TTemplate extends NoteTemplateModel>(
+  props: UseNoteTemplatesProps<TTemplate>,
+): UseNoteTemplatesResult {
+  const [noteTemplates, setNoteTemplates] = useState<
+    Array<BulkStateChangeNoteTemplate>
+  >([]);
+
+  useEffect(() => {
+    let isCancelled: boolean = false;
+
+    const fetchNoteTemplates: () => Promise<void> = async (): Promise<void> => {
+      try {
+        const result: ListResult<TTemplate> = await ModelAPI.getList<TTemplate>(
+          {
+            modelType: props.modelType,
+            query: {
+              projectId: ProjectUtil.getCurrentProjectId()!,
+            } as Query<TTemplate>,
+            limit: 99,
+            skip: 0,
+            select: {
+              _id: true,
+              templateName: true,
+              note: true,
+            } as Select<TTemplate>,
+            sort: {
+              templateName: SortOrder.Ascending,
+            } as Sort<TTemplate>,
+          },
+        );
+
+        if (isCancelled) {
+          return;
+        }
+
+        setNoteTemplates(
+          result.data.map(
+            (template: TTemplate): BulkStateChangeNoteTemplate => {
+              return {
+                id: template.id?.toString() || "",
+                templateName: template.templateName || "",
+                note: template.note || "",
+              };
+            },
+          ),
+        );
+      } catch {
+        if (!isCancelled) {
+          setNoteTemplates([]);
+        }
+      }
+    };
+
+    fetchNoteTemplates().catch(() => {
+      if (!isCancelled) {
+        setNoteTemplates([]);
+      }
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [props.modelType]);
+
+  return {
+    noteTemplates,
+  };
+}

--- a/App/FeatureSet/Dashboard/src/Components/Incident/IncidentsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Incident/IncidentsTable.tsx
@@ -31,6 +31,7 @@ import Incident from "Common/Models/DatabaseModels/Incident";
 import IncidentCustomField from "Common/Models/DatabaseModels/IncidentCustomField";
 import IncidentOwnerTeam from "Common/Models/DatabaseModels/IncidentOwnerTeam";
 import IncidentOwnerUser from "Common/Models/DatabaseModels/IncidentOwnerUser";
+import IncidentNoteTemplate from "Common/Models/DatabaseModels/IncidentNoteTemplate";
 import IncidentSeverity from "Common/Models/DatabaseModels/IncidentSeverity";
 import IncidentState from "Common/Models/DatabaseModels/IncidentState";
 import IncidentTemplate from "Common/Models/DatabaseModels/IncidentTemplate";
@@ -68,6 +69,16 @@ import GlobalEvents from "Common/UI/Utils/GlobalEvents";
 import { REFRESH_SIDEBAR_COUNT_EVENT } from "Common/UI/Components/SideMenu/CountModelSideMenuItem";
 import LiveDuration from "../EventView/LiveDuration";
 import useEventTimelineEndDates from "../EventView/useEventTimelineEndDates";
+import useNoteTemplates from "../EventView/useNoteTemplates";
+import BulkChangeStateModal, {
+  BulkChangeStateSubmitData,
+} from "../EventView/BulkChangeStateModal";
+import {
+  BulkStateChangeNoteType,
+  BulkStateChangeSkipDecision,
+  buildBulkStateChangeMiscDataProps,
+  getBulkStateChangeSkipDecision,
+} from "../../Utils/BulkStateChange";
 
 export interface ComponentProps {
   query?: Query<Incident> | undefined;
@@ -113,6 +124,10 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
     eventIds: resolvedIncidentIds,
     eventIdField: "incidentId",
     timelineModelType: IncidentStateTimeline,
+  });
+
+  const { noteTemplates } = useNoteTemplates<IncidentNoteTemplate>({
+    modelType: IncidentNoteTemplate,
   });
 
   const { bulkActions: labelBulkActions, modals: labelBulkActionModals } =
@@ -340,11 +355,15 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
   }, []);
 
   const handleBulkStateChange: (
-    targetStateId: ObjectID,
-  ) => Promise<void> = async (targetStateId: ObjectID): Promise<void> => {
+    data: BulkChangeStateSubmitData,
+  ) => Promise<void> = async (
+    data: BulkChangeStateSubmitData,
+  ): Promise<void> => {
     if (!bulkActionProps) {
       return;
     }
+
+    const targetStateId: ObjectID = data.stateId;
 
     const { items, onProgressInfo, onBulkActionStart, onBulkActionEnd } =
       bulkActionProps;
@@ -360,6 +379,11 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
     }
 
     const targetOrder: number = targetState.order || 0;
+
+    const miscDataProps: JSONObject = buildBulkStateChangeMiscDataProps({
+      noteType: BulkStateChangeNoteType.Public,
+      note: data.note,
+    });
 
     onBulkActionStart();
 
@@ -393,12 +417,18 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
           fetchedIncident?.currentIncidentState?.order || 0;
 
         // Skip if already at or past the target state
-        if (currentOrder >= targetOrder) {
-          const currentStateName: string =
-            fetchedIncident?.currentIncidentState?.name || "Unknown";
+        const skipDecision: BulkStateChangeSkipDecision =
+          getBulkStateChangeSkipDecision({
+            currentOrder: currentOrder,
+            targetOrder: targetOrder,
+            currentStateName: fetchedIncident?.currentIncidentState?.name,
+            targetStateName: targetState.name,
+          });
+
+        if (skipDecision.shouldSkip) {
           failedItems.push({
             item: incident,
-            failedMessage: `Skipped: Already at "${currentStateName}" (at or past "${targetState.name}")`,
+            failedMessage: skipDecision.skippedMessage!,
           });
         } else {
           // Create state timeline to change state
@@ -407,10 +437,13 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
           stateTimeline.incidentId = incident.id;
           stateTimeline.incidentStateId = targetStateId;
           stateTimeline.projectId = ProjectUtil.getCurrentProjectId()!;
+          stateTimeline.shouldStatusPageSubscribersBeNotified =
+            data.shouldStatusPageSubscribersBeNotified ?? true;
 
           await ModelAPI.create<IncidentStateTimeline>({
             model: stateTimeline,
             modelType: IncidentStateTimeline,
+            miscDataProps: miscDataProps,
           });
 
           successItems.push(incident);
@@ -948,35 +981,26 @@ const IncidentsTable: FunctionComponent<ComponentProps> = (
       {ownerBulkActionModals}
 
       {showBulkStateChangeModal && (
-        <BasicFormModal
+        <BulkChangeStateModal
           title="Change Incident State"
           description="Select the state to change incidents to. Incidents already at or past the selected state will be skipped."
+          stateFieldKey="incidentStateId"
+          stateOptions={incidentStates.map((state: IncidentState) => {
+            return {
+              label: state.name || "",
+              value: state.id?.toString() || "",
+            };
+          })}
+          noteType={BulkStateChangeNoteType.Public}
+          noteTitle="Public Note"
+          noteDescription="Post a public note about this state change to the status page. The same note is added to every incident you selected."
+          noteTemplates={noteTemplates}
+          showNotifyStatusPageSubscribers={true}
           onClose={() => {
             setShowBulkStateChangeModal(false);
             setBulkActionProps(null);
           }}
-          submitButtonText="Change State"
-          onSubmit={async (formData: { incidentStateId: ObjectID }) => {
-            await handleBulkStateChange(formData.incidentStateId);
-          }}
-          formProps={{
-            fields: [
-              {
-                field: {
-                  incidentStateId: true,
-                },
-                title: "Select State",
-                fieldType: FormFieldSchemaType.Dropdown,
-                required: true,
-                dropdownOptions: incidentStates.map((state: IncidentState) => {
-                  return {
-                    label: state.name || "",
-                    value: state.id?.toString() || "",
-                  };
-                }),
-              },
-            ],
-          }}
+          onSubmit={handleBulkStateChange}
         />
       )}
     </>

--- a/App/FeatureSet/Dashboard/src/Components/IncidentEpisode/IncidentEpisodesTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/IncidentEpisode/IncidentEpisodesTable.tsx
@@ -13,6 +13,7 @@ import Pill from "Common/UI/Components/Pill/Pill";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import Query from "Common/Types/BaseDatabase/Query";
 import IncidentEpisode from "Common/Models/DatabaseModels/IncidentEpisode";
+import IncidentNoteTemplate from "Common/Models/DatabaseModels/IncidentNoteTemplate";
 import IncidentSeverity from "Common/Models/DatabaseModels/IncidentSeverity";
 import IncidentState from "Common/Models/DatabaseModels/IncidentState";
 import Label from "Common/Models/DatabaseModels/Label";
@@ -37,12 +38,21 @@ import Navigation from "Common/UI/Utils/Navigation";
 import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import API from "Common/UI/Utils/API/API";
-import BasicFormModal from "Common/UI/Components/FormModal/BasicFormModal";
-import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import ObjectID from "Common/Types/ObjectID";
+import { JSONObject } from "Common/Types/JSON";
 import IncidentEpisodeStateTimeline from "Common/Models/DatabaseModels/IncidentEpisodeStateTimeline";
 import GlobalEvents from "Common/UI/Utils/GlobalEvents";
 import { REFRESH_SIDEBAR_COUNT_EVENT } from "Common/UI/Components/SideMenu/CountModelSideMenuItem";
+import useNoteTemplates from "../EventView/useNoteTemplates";
+import BulkChangeStateModal, {
+  BulkChangeStateSubmitData,
+} from "../EventView/BulkChangeStateModal";
+import {
+  BulkStateChangeNoteType,
+  BulkStateChangeSkipDecision,
+  buildBulkStateChangeMiscDataProps,
+  getBulkStateChangeSkipDecision,
+} from "../../Utils/BulkStateChange";
 
 export interface ComponentProps {
   query?: Query<IncidentEpisode> | undefined;
@@ -62,6 +72,10 @@ const IncidentEpisodesTable: FunctionComponent<ComponentProps> = (
     useState<boolean>(false);
   const [bulkActionProps, setBulkActionProps] =
     useState<BulkActionOnClickProps<IncidentEpisode> | null>(null);
+
+  const { noteTemplates } = useNoteTemplates<IncidentNoteTemplate>({
+    modelType: IncidentNoteTemplate,
+  });
 
   const { bulkActions: labelBulkActions, modals: labelBulkActionModals } =
     useBulkLabelActions<IncidentEpisode>({ modelType: IncidentEpisode });
@@ -102,11 +116,15 @@ const IncidentEpisodesTable: FunctionComponent<ComponentProps> = (
   }, []);
 
   const handleBulkStateChange: (
-    targetStateId: ObjectID,
-  ) => Promise<void> = async (targetStateId: ObjectID): Promise<void> => {
+    data: BulkChangeStateSubmitData,
+  ) => Promise<void> = async (
+    data: BulkChangeStateSubmitData,
+  ): Promise<void> => {
     if (!bulkActionProps) {
       return;
     }
+
+    const targetStateId: ObjectID = data.stateId;
 
     const { items, onProgressInfo, onBulkActionStart, onBulkActionEnd } =
       bulkActionProps;
@@ -122,6 +140,11 @@ const IncidentEpisodesTable: FunctionComponent<ComponentProps> = (
     }
 
     const targetOrder: number = targetState.order || 0;
+
+    const miscDataProps: JSONObject = buildBulkStateChangeMiscDataProps({
+      noteType: BulkStateChangeNoteType.Private,
+      note: data.note,
+    });
 
     onBulkActionStart();
 
@@ -155,12 +178,18 @@ const IncidentEpisodesTable: FunctionComponent<ComponentProps> = (
           fetchedEpisode?.currentIncidentState?.order || 0;
 
         // Skip if already at or past the target state
-        if (currentOrder >= targetOrder) {
-          const currentStateName: string =
-            fetchedEpisode?.currentIncidentState?.name || "Unknown";
+        const skipDecision: BulkStateChangeSkipDecision =
+          getBulkStateChangeSkipDecision({
+            currentOrder: currentOrder,
+            targetOrder: targetOrder,
+            currentStateName: fetchedEpisode?.currentIncidentState?.name,
+            targetStateName: targetState.name,
+          });
+
+        if (skipDecision.shouldSkip) {
           failedItems.push({
             item: episode,
-            failedMessage: `Skipped: Already at "${currentStateName}" (at or past "${targetState.name}")`,
+            failedMessage: skipDecision.skippedMessage!,
           });
         } else {
           // Create state timeline to change state
@@ -173,6 +202,7 @@ const IncidentEpisodesTable: FunctionComponent<ComponentProps> = (
           await ModelAPI.create<IncidentEpisodeStateTimeline>({
             model: stateTimeline,
             modelType: IncidentEpisodeStateTimeline,
+            miscDataProps: miscDataProps,
           });
 
           successItems.push(episode);
@@ -483,35 +513,25 @@ const IncidentEpisodesTable: FunctionComponent<ComponentProps> = (
       )}
 
       {showBulkStateChangeModal && (
-        <BasicFormModal
+        <BulkChangeStateModal
           title="Change Episode State"
           description="Select the state to change episodes to. Episodes already at or past the selected state will be skipped. Member incidents will also be updated."
+          stateFieldKey="incidentStateId"
+          stateOptions={incidentStates.map((state: IncidentState) => {
+            return {
+              label: state.name || "",
+              value: state.id?.toString() || "",
+            };
+          })}
+          noteType={BulkStateChangeNoteType.Private}
+          noteTitle="Private Note"
+          noteDescription="Add an optional private note about this state change. Only your team can see it, and the same note is added to every episode you selected."
+          noteTemplates={noteTemplates}
           onClose={() => {
             setShowBulkStateChangeModal(false);
             setBulkActionProps(null);
           }}
-          submitButtonText="Change State"
-          onSubmit={async (formData: { incidentStateId: ObjectID }) => {
-            await handleBulkStateChange(formData.incidentStateId);
-          }}
-          formProps={{
-            fields: [
-              {
-                field: {
-                  incidentStateId: true,
-                },
-                title: "Select State",
-                fieldType: FormFieldSchemaType.Dropdown,
-                required: true,
-                dropdownOptions: incidentStates.map((state: IncidentState) => {
-                  return {
-                    label: state.name || "",
-                    value: state.id?.toString() || "",
-                  };
-                }),
-              },
-            ],
-          }}
+          onSubmit={handleBulkStateChange}
         />
       )}
     </>

--- a/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/ScheduledMaintenance/ScheduledMaintenanceTable.tsx
@@ -16,6 +16,7 @@ import Query from "Common/Types/BaseDatabase/Query";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import ScheduledMaintenance from "Common/Models/DatabaseModels/ScheduledMaintenance";
 import ScheduledMaintenanceCustomField from "Common/Models/DatabaseModels/ScheduledMaintenanceCustomField";
+import ScheduledMaintenanceNoteTemplate from "Common/Models/DatabaseModels/ScheduledMaintenanceNoteTemplate";
 import ScheduledMaintenanceOwnerTeam from "Common/Models/DatabaseModels/ScheduledMaintenanceOwnerTeam";
 import ScheduledMaintenanceOwnerUser from "Common/Models/DatabaseModels/ScheduledMaintenanceOwnerUser";
 import ScheduledMaintenanceState from "Common/Models/DatabaseModels/ScheduledMaintenanceState";
@@ -67,6 +68,16 @@ import ScheduledMaintenanceStateTimeline from "Common/Models/DatabaseModels/Sche
 import GlobalEvents from "Common/UI/Utils/GlobalEvents";
 import { REFRESH_SIDEBAR_COUNT_EVENT } from "Common/UI/Components/SideMenu/CountModelSideMenuItem";
 import LiveDuration from "../EventView/LiveDuration";
+import useNoteTemplates from "../EventView/useNoteTemplates";
+import BulkChangeStateModal, {
+  BulkChangeStateSubmitData,
+} from "../EventView/BulkChangeStateModal";
+import {
+  BulkStateChangeNoteType,
+  BulkStateChangeSkipDecision,
+  buildBulkStateChangeMiscDataProps,
+  getBulkStateChangeSkipDecision,
+} from "../../Utils/BulkStateChange";
 
 export interface ComponentProps {
   query?: Query<ScheduledMaintenance> | undefined;
@@ -96,6 +107,10 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
     useState<boolean>(false);
   const [bulkActionProps, setBulkActionProps] =
     useState<BulkActionOnClickProps<ScheduledMaintenance> | null>(null);
+
+  const { noteTemplates } = useNoteTemplates<ScheduledMaintenanceNoteTemplate>({
+    modelType: ScheduledMaintenanceNoteTemplate,
+  });
 
   const { bulkActions: labelBulkActions, modals: labelBulkActionModals } =
     useBulkLabelActions<ScheduledMaintenance>({
@@ -257,11 +272,15 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
   }, []);
 
   const handleBulkStateChange: (
-    targetStateId: ObjectID,
-  ) => Promise<void> = async (targetStateId: ObjectID): Promise<void> => {
+    data: BulkChangeStateSubmitData,
+  ) => Promise<void> = async (
+    data: BulkChangeStateSubmitData,
+  ): Promise<void> => {
     if (!bulkActionProps) {
       return;
     }
+
+    const targetStateId: ObjectID = data.stateId;
 
     const { items, onProgressInfo, onBulkActionStart, onBulkActionEnd } =
       bulkActionProps;
@@ -276,6 +295,11 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
     }
 
     const targetOrder: number = targetState.order || 0;
+
+    const miscDataProps: JSONObject = buildBulkStateChangeMiscDataProps({
+      noteType: BulkStateChangeNoteType.Public,
+      note: data.note,
+    });
 
     onBulkActionStart();
 
@@ -310,13 +334,20 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
             ?.order || 0;
 
         // Skip if already at or past the target state
-        if (currentOrder >= targetOrder) {
-          const currentStateName: string =
-            fetchedScheduledMaintenance?.currentScheduledMaintenanceState
-              ?.name || "Unknown";
+        const skipDecision: BulkStateChangeSkipDecision =
+          getBulkStateChangeSkipDecision({
+            currentOrder: currentOrder,
+            targetOrder: targetOrder,
+            currentStateName:
+              fetchedScheduledMaintenance?.currentScheduledMaintenanceState
+                ?.name,
+            targetStateName: targetState.name,
+          });
+
+        if (skipDecision.shouldSkip) {
           failedItems.push({
             item: scheduledMaintenance,
-            failedMessage: `Skipped: Already at "${currentStateName}" (at or past "${targetState.name}")`,
+            failedMessage: skipDecision.skippedMessage!,
           });
         } else {
           // Create state timeline to change state
@@ -325,10 +356,13 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
           stateTimeline.scheduledMaintenanceId = scheduledMaintenance.id;
           stateTimeline.scheduledMaintenanceStateId = targetStateId;
           stateTimeline.projectId = ProjectUtil.getCurrentProjectId()!;
+          stateTimeline.shouldStatusPageSubscribersBeNotified =
+            data.shouldStatusPageSubscribersBeNotified ?? true;
 
           await ModelAPI.create<ScheduledMaintenanceStateTimeline>({
             model: stateTimeline,
             modelType: ScheduledMaintenanceStateTimeline,
+            miscDataProps: miscDataProps,
           });
 
           successItems.push(scheduledMaintenance);
@@ -894,39 +928,28 @@ const ScheduledMaintenancesTable: FunctionComponent<ComponentProps> = (
       {ownerBulkActionModals}
 
       {showBulkStateChangeModal && (
-        <BasicFormModal
+        <BulkChangeStateModal
           title="Change Scheduled Maintenance State"
           description="Select the state to change scheduled maintenance events to. Events already at or past the selected state will be skipped."
+          stateFieldKey="scheduledMaintenanceStateId"
+          stateOptions={scheduledMaintenanceStates.map(
+            (state: ScheduledMaintenanceState) => {
+              return {
+                label: state.name || "",
+                value: state.id?.toString() || "",
+              };
+            },
+          )}
+          noteType={BulkStateChangeNoteType.Public}
+          noteTitle="Public Note"
+          noteDescription="Post a public note about this state change to the status page. The same note is added to every event you selected."
+          noteTemplates={noteTemplates}
+          showNotifyStatusPageSubscribers={true}
           onClose={() => {
             setShowBulkStateChangeModal(false);
             setBulkActionProps(null);
           }}
-          submitButtonText="Change State"
-          onSubmit={async (formData: {
-            scheduledMaintenanceStateId: ObjectID;
-          }) => {
-            await handleBulkStateChange(formData.scheduledMaintenanceStateId);
-          }}
-          formProps={{
-            fields: [
-              {
-                field: {
-                  scheduledMaintenanceStateId: true,
-                },
-                title: "Select State",
-                fieldType: FormFieldSchemaType.Dropdown,
-                required: true,
-                dropdownOptions: scheduledMaintenanceStates.map(
-                  (state: ScheduledMaintenanceState) => {
-                    return {
-                      label: state.name || "",
-                      value: state.id?.toString() || "",
-                    };
-                  },
-                ),
-              },
-            ],
-          }}
+          onSubmit={handleBulkStateChange}
         />
       )}
     </div>

--- a/App/FeatureSet/Dashboard/src/Utils/BulkStateChange.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/BulkStateChange.ts
@@ -1,0 +1,108 @@
+import { JSONObject } from "Common/Types/JSON";
+
+/**
+ * Which note a bulk state change writes. Public notes are published to the
+ * status page (incidents, scheduled maintenance) while private notes stay
+ * internal to the team (alerts, episodes). This mirrors what the single-event
+ * "change state" modal on the event overview page already offers.
+ */
+export enum BulkStateChangeNoteType {
+  Public = "Public",
+  Private = "Private",
+}
+
+export interface BulkStateChangeNoteTemplate {
+  id: string;
+  templateName: string;
+  note: string;
+}
+
+/**
+ * The key the note travels under. It is not a column on the state timeline
+ * model — the timeline services read it off `miscDataProps` and turn it into
+ * a public or internal note on the event.
+ */
+export function getBulkStateChangeNoteFieldKey(
+  noteType: BulkStateChangeNoteType,
+): string {
+  return noteType === BulkStateChangeNoteType.Public
+    ? "publicNote"
+    : "privateNote";
+}
+
+export function getBulkStateChangeNoteTemplateFieldKey(
+  noteType: BulkStateChangeNoteType,
+): string {
+  return `${getBulkStateChangeNoteFieldKey(noteType)}Template`;
+}
+
+/**
+ * Find the note body behind a selected template. Returns an empty string when
+ * nothing matches so callers can leave the note field untouched.
+ */
+export function getNoteFromTemplate(
+  templates: Array<BulkStateChangeNoteTemplate>,
+  templateId: string | undefined | null,
+): string {
+  if (!templateId) {
+    return "";
+  }
+
+  const template: BulkStateChangeNoteTemplate | undefined = templates.find(
+    (template: BulkStateChangeNoteTemplate) => {
+      return template.id === templateId.toString();
+    },
+  );
+
+  return template?.note || "";
+}
+
+/**
+ * Build the `miscDataProps` payload for one state timeline create. A blank
+ * note is dropped entirely so an untouched textbox never creates an empty
+ * note on the event.
+ */
+export function buildBulkStateChangeMiscDataProps(data: {
+  noteType: BulkStateChangeNoteType;
+  note?: string | undefined;
+}): JSONObject {
+  if (!data.note || data.note.trim() === "") {
+    return {};
+  }
+
+  return {
+    [getBulkStateChangeNoteFieldKey(data.noteType)]: data.note,
+  };
+}
+
+export interface BulkStateChangeSkipDecision {
+  shouldSkip: boolean;
+  skippedMessage?: string | undefined;
+}
+
+/**
+ * Bulk state changes only move events forward. An event already at (or past)
+ * the target state is reported as skipped rather than failed, because nothing
+ * went wrong — there was simply nothing to do.
+ */
+export function getBulkStateChangeSkipDecision(data: {
+  currentOrder: number;
+  targetOrder: number;
+  currentStateName?: string | undefined;
+  targetStateName?: string | undefined;
+}): BulkStateChangeSkipDecision {
+  if (data.currentOrder < data.targetOrder) {
+    return {
+      shouldSkip: false,
+    };
+  }
+
+  const currentStateName: string = data.currentStateName || "Unknown";
+
+  return {
+    shouldSkip: true,
+    skippedMessage: `Skipped: Already at "${currentStateName}" (at or past "${
+      data.targetStateName || "Unknown"
+    }")`,
+  };
+}

--- a/App/Tests/Dashboard/BulkChangeStateNoteWiring.test.ts
+++ b/App/Tests/Dashboard/BulkChangeStateNoteWiring.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Every table with a bulk "Change State" action must offer the same optional
+ * note the single-event change-state modal on the overview page offers, and
+ * must actually forward that note to the API. A table that renders the modal
+ * but drops `miscDataProps` would show a textbox that quietly does nothing,
+ * which is the exact bug these assertions exist to prevent.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function readSource(...relativePath: Array<string>): string {
+  return fs
+    .readFileSync(path.join(DASHBOARD_SRC, ...relativePath), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/.*$/gm, " ")
+    .replace(/\s+/g, " ");
+}
+
+interface BulkTableCase {
+  name: string;
+  component: Array<string>;
+  noteType: "Public" | "Private";
+  noteTitle: string;
+  stateFieldKey: string;
+  timelineModelType: string;
+  notifiesStatusPageSubscribers: boolean;
+  noteTemplateModelType: string;
+}
+
+const BULK_TABLES: Array<BulkTableCase> = [
+  {
+    name: "Incidents",
+    component: ["Components", "Incident", "IncidentsTable.tsx"],
+    noteType: "Public",
+    noteTitle: "Public Note",
+    stateFieldKey: "incidentStateId",
+    timelineModelType: "IncidentStateTimeline",
+    notifiesStatusPageSubscribers: true,
+    noteTemplateModelType: "IncidentNoteTemplate",
+  },
+  {
+    name: "Alerts",
+    component: ["Components", "Alert", "AlertsTable.tsx"],
+    noteType: "Private",
+    noteTitle: "Private Note",
+    stateFieldKey: "alertStateId",
+    timelineModelType: "AlertStateTimeline",
+    notifiesStatusPageSubscribers: false,
+    noteTemplateModelType: "AlertNoteTemplate",
+  },
+  {
+    name: "Scheduled Maintenance",
+    component: [
+      "Components",
+      "ScheduledMaintenance",
+      "ScheduledMaintenanceTable.tsx",
+    ],
+    noteType: "Public",
+    noteTitle: "Public Note",
+    stateFieldKey: "scheduledMaintenanceStateId",
+    timelineModelType: "ScheduledMaintenanceStateTimeline",
+    notifiesStatusPageSubscribers: true,
+    noteTemplateModelType: "ScheduledMaintenanceNoteTemplate",
+  },
+  {
+    name: "Incident Episodes",
+    component: ["Components", "IncidentEpisode", "IncidentEpisodesTable.tsx"],
+    noteType: "Private",
+    noteTitle: "Private Note",
+    stateFieldKey: "incidentStateId",
+    timelineModelType: "IncidentEpisodeStateTimeline",
+    notifiesStatusPageSubscribers: false,
+    noteTemplateModelType: "IncidentNoteTemplate",
+  },
+  {
+    name: "Alert Episodes",
+    component: ["Components", "AlertEpisode", "AlertEpisodesTable.tsx"],
+    noteType: "Private",
+    noteTitle: "Private Note",
+    stateFieldKey: "alertStateId",
+    timelineModelType: "AlertEpisodeStateTimeline",
+    notifiesStatusPageSubscribers: false,
+    noteTemplateModelType: "AlertNoteTemplate",
+  },
+];
+
+describe("bulk change-state modal offers a note on every event table", () => {
+  test.each(BULK_TABLES)(
+    "$name renders the shared bulk change-state modal with a note",
+    (bulkTable: BulkTableCase) => {
+      const source: string = readSource(...bulkTable.component);
+
+      expect(source).toContain("<BulkChangeStateModal");
+      expect(source).toContain(`stateFieldKey="${bulkTable.stateFieldKey}"`);
+      expect(source).toContain(
+        `noteType={BulkStateChangeNoteType.${bulkTable.noteType}}`,
+      );
+      expect(source).toContain(`noteTitle="${bulkTable.noteTitle}"`);
+      expect(source).toContain("noteTemplates={noteTemplates}");
+    },
+  );
+
+  test.each(BULK_TABLES)(
+    "$name loads note templates from $noteTemplateModelType",
+    (bulkTable: BulkTableCase) => {
+      const source: string = readSource(...bulkTable.component);
+
+      expect(source).toContain(
+        `useNoteTemplates<${bulkTable.noteTemplateModelType}>(`,
+      );
+      expect(source).toContain(
+        `modelType: ${bulkTable.noteTemplateModelType},`,
+      );
+    },
+  );
+
+  test.each(BULK_TABLES)(
+    "$name forwards the note to the $timelineModelType create",
+    (bulkTable: BulkTableCase) => {
+      const source: string = readSource(...bulkTable.component);
+
+      expect(source).toContain("buildBulkStateChangeMiscDataProps({");
+      expect(source).toContain(
+        `noteType: BulkStateChangeNoteType.${bulkTable.noteType},`,
+      );
+      expect(source).toContain("note: data.note,");
+      expect(source).toContain(
+        `ModelAPI.create<${bulkTable.timelineModelType}>(`,
+      );
+      expect(source).toContain("miscDataProps: miscDataProps,");
+    },
+  );
+
+  test.each(BULK_TABLES)(
+    "$name only offers the subscriber toggle when the event reaches a status page",
+    (bulkTable: BulkTableCase) => {
+      const source: string = readSource(...bulkTable.component);
+
+      if (bulkTable.notifiesStatusPageSubscribers) {
+        expect(source).toContain("showNotifyStatusPageSubscribers={true}");
+        expect(source).toContain(
+          "stateTimeline.shouldStatusPageSubscribersBeNotified = data.shouldStatusPageSubscribersBeNotified ?? true;",
+        );
+      } else {
+        expect(source).not.toContain("showNotifyStatusPageSubscribers");
+        expect(source).not.toContain("shouldStatusPageSubscribersBeNotified");
+      }
+    },
+  );
+
+  test.each(BULK_TABLES)(
+    "$name reuses the shared skip rule instead of inlining it",
+    (bulkTable: BulkTableCase) => {
+      const source: string = readSource(...bulkTable.component);
+
+      expect(source).toContain("getBulkStateChangeSkipDecision({");
+      expect(source).toContain("if (skipDecision.shouldSkip) {");
+      expect(source).not.toContain("if (currentOrder >= targetOrder)");
+    },
+  );
+});
+
+describe("shared bulk change-state modal", () => {
+  const source: string = readSource(
+    "Components",
+    "EventView",
+    "BulkChangeStateModal.tsx",
+  );
+
+  test("renders the note as an optional markdown textbox", () => {
+    expect(source).toContain("fieldType: FormFieldSchemaType.Markdown");
+    expect(source).toContain("title: props.noteTitle,");
+    expect(source).toContain("description: props.noteDescription,");
+  });
+
+  test("keeps the state picker required", () => {
+    expect(source).toContain('title: "Select State",');
+    expect(source).toContain("required: true,");
+  });
+
+  test("shows the note template picker only when templates exist", () => {
+    expect(source).toContain("if (props.noteTemplates.length > 0) {");
+  });
+
+  test("adds the subscriber toggle only for events that have one", () => {
+    expect(source).toContain("if (props.showNotifyStatusPageSubscribers) {");
+  });
+
+  test("submits the picked state as an ObjectID", () => {
+    expect(source).toContain("stateId: new ObjectID(selectedStateId),");
+  });
+});

--- a/App/Tests/Dashboard/BulkStateChange.test.ts
+++ b/App/Tests/Dashboard/BulkStateChange.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "@jest/globals";
+import { JSONObject } from "Common/Types/JSON";
+import {
+  BulkStateChangeNoteTemplate,
+  BulkStateChangeNoteType,
+  BulkStateChangeSkipDecision,
+  buildBulkStateChangeMiscDataProps,
+  getBulkStateChangeNoteFieldKey,
+  getBulkStateChangeNoteTemplateFieldKey,
+  getBulkStateChangeSkipDecision,
+  getNoteFromTemplate,
+} from "../../FeatureSet/Dashboard/src/Utils/BulkStateChange";
+
+/*
+ * The note a user writes in a bulk "Change State" modal rides along with each
+ * state timeline create under `miscDataProps`. The timeline services key off
+ * the exact field name, so these tests pin the names down as well as the
+ * "an untouched textbox writes nothing" rule.
+ */
+
+const TEMPLATES: Array<BulkStateChangeNoteTemplate> = [
+  {
+    id: "019acd20-1111-4111-8111-111111111111",
+    templateName: "Mitigation started",
+    note: "We have started mitigating this.",
+  },
+  {
+    id: "019acd20-2222-4222-8222-222222222222",
+    templateName: "Empty template",
+    note: "",
+  },
+];
+
+describe("bulk state change note field keys", () => {
+  test("a public note travels under publicNote", () => {
+    expect(getBulkStateChangeNoteFieldKey(BulkStateChangeNoteType.Public)).toBe(
+      "publicNote",
+    );
+    expect(
+      getBulkStateChangeNoteTemplateFieldKey(BulkStateChangeNoteType.Public),
+    ).toBe("publicNoteTemplate");
+  });
+
+  test("a private note travels under privateNote", () => {
+    expect(
+      getBulkStateChangeNoteFieldKey(BulkStateChangeNoteType.Private),
+    ).toBe("privateNote");
+    expect(
+      getBulkStateChangeNoteTemplateFieldKey(BulkStateChangeNoteType.Private),
+    ).toBe("privateNoteTemplate");
+  });
+});
+
+describe("getNoteFromTemplate", () => {
+  test("returns the note body of the selected template", () => {
+    expect(getNoteFromTemplate(TEMPLATES, TEMPLATES[0]!.id)).toBe(
+      "We have started mitigating this.",
+    );
+  });
+
+  test("returns an empty string when no template is selected", () => {
+    expect(getNoteFromTemplate(TEMPLATES, undefined)).toBe("");
+    expect(getNoteFromTemplate(TEMPLATES, null)).toBe("");
+    expect(getNoteFromTemplate(TEMPLATES, "")).toBe("");
+  });
+
+  test("returns an empty string for an unknown template id", () => {
+    expect(getNoteFromTemplate(TEMPLATES, "not-a-template")).toBe("");
+  });
+
+  test("returns an empty string when the matched template has no body", () => {
+    expect(getNoteFromTemplate(TEMPLATES, TEMPLATES[1]!.id)).toBe("");
+  });
+
+  test("returns an empty string when there are no templates at all", () => {
+    expect(getNoteFromTemplate([], TEMPLATES[0]!.id)).toBe("");
+  });
+});
+
+describe("buildBulkStateChangeMiscDataProps", () => {
+  test("sends a public note under publicNote", () => {
+    const miscDataProps: JSONObject = buildBulkStateChangeMiscDataProps({
+      noteType: BulkStateChangeNoteType.Public,
+      note: "Rolled back the bad deploy.",
+    });
+
+    expect(miscDataProps).toEqual({
+      publicNote: "Rolled back the bad deploy.",
+    });
+  });
+
+  test("sends a private note under privateNote", () => {
+    const miscDataProps: JSONObject = buildBulkStateChangeMiscDataProps({
+      noteType: BulkStateChangeNoteType.Private,
+      note: "Mapped to Dynamics case 4821.",
+    });
+
+    expect(miscDataProps).toEqual({
+      privateNote: "Mapped to Dynamics case 4821.",
+    });
+  });
+
+  test("sends nothing when the note is missing, empty or only whitespace", () => {
+    expect(
+      buildBulkStateChangeMiscDataProps({
+        noteType: BulkStateChangeNoteType.Public,
+      }),
+    ).toEqual({});
+
+    expect(
+      buildBulkStateChangeMiscDataProps({
+        noteType: BulkStateChangeNoteType.Public,
+        note: "",
+      }),
+    ).toEqual({});
+
+    expect(
+      buildBulkStateChangeMiscDataProps({
+        noteType: BulkStateChangeNoteType.Private,
+        note: "   \n\t  ",
+      }),
+    ).toEqual({});
+  });
+
+  test("keeps the note body byte for byte so markdown survives", () => {
+    const note: string = "## Heading\n\n- item one\n- item two\n";
+
+    expect(
+      buildBulkStateChangeMiscDataProps({
+        noteType: BulkStateChangeNoteType.Public,
+        note: note,
+      }),
+    ).toEqual({
+      publicNote: note,
+    });
+  });
+});
+
+describe("getBulkStateChangeSkipDecision", () => {
+  test("moves an event forward when it is behind the target state", () => {
+    const decision: BulkStateChangeSkipDecision =
+      getBulkStateChangeSkipDecision({
+        currentOrder: 1,
+        targetOrder: 3,
+        currentStateName: "Created",
+        targetStateName: "Resolved",
+      });
+
+    expect(decision.shouldSkip).toBe(false);
+    expect(decision.skippedMessage).toBeUndefined();
+  });
+
+  test("skips an event that is already at the target state", () => {
+    const decision: BulkStateChangeSkipDecision =
+      getBulkStateChangeSkipDecision({
+        currentOrder: 3,
+        targetOrder: 3,
+        currentStateName: "Resolved",
+        targetStateName: "Resolved",
+      });
+
+    expect(decision.shouldSkip).toBe(true);
+    expect(decision.skippedMessage).toBe(
+      'Skipped: Already at "Resolved" (at or past "Resolved")',
+    );
+  });
+
+  test("skips an event that is past the target state", () => {
+    const decision: BulkStateChangeSkipDecision =
+      getBulkStateChangeSkipDecision({
+        currentOrder: 5,
+        targetOrder: 2,
+        currentStateName: "Resolved",
+        targetStateName: "Acknowledged",
+      });
+
+    expect(decision.shouldSkip).toBe(true);
+    expect(decision.skippedMessage).toBe(
+      'Skipped: Already at "Resolved" (at or past "Acknowledged")',
+    );
+  });
+
+  test("falls back to Unknown when a state name could not be loaded", () => {
+    const decision: BulkStateChangeSkipDecision =
+      getBulkStateChangeSkipDecision({
+        currentOrder: 2,
+        targetOrder: 2,
+      });
+
+    expect(decision.shouldSkip).toBe(true);
+    expect(decision.skippedMessage).toBe(
+      'Skipped: Already at "Unknown" (at or past "Unknown")',
+    );
+  });
+});

--- a/Common/Server/Services/AlertEpisodeStateTimelineService.ts
+++ b/Common/Server/Services/AlertEpisodeStateTimelineService.ts
@@ -20,6 +20,9 @@ import AlertEpisodeFeedService from "./AlertEpisodeFeedService";
 import { AlertEpisodeFeedEventType } from "../../Models/DatabaseModels/AlertEpisodeFeed";
 import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
 import AlertEpisodeService from "./AlertEpisodeService";
+import AlertEpisodeInternalNote from "../../Models/DatabaseModels/AlertEpisodeInternalNote";
+import AlertEpisodeInternalNoteService from "./AlertEpisodeInternalNoteService";
+import { JSONObject } from "../../Types/JSON";
 
 export class Service extends DatabaseService<AlertEpisodeStateTimeline> {
   public constructor() {
@@ -182,11 +185,21 @@ export class Service extends DatabaseService<AlertEpisodeStateTimeline> {
         alertEpisodeId: createBy.data.alertEpisodeId?.toString(),
       } as LogAttributes);
 
+      /*
+       * The note a user writes when they change the state. It is not a column
+       * on this model, so it travels alongside the create and becomes an
+       * internal note on the episode once the timeline row exists.
+       */
+      const privateNote: string | undefined = (
+        createBy.miscDataProps as JSONObject | undefined
+      )?.["privateNote"] as string | undefined;
+
       return {
         createBy,
         carryForward: {
           statusTimelineBeforeThisStatus: stateBeforeThis || null,
           statusTimelineAfterThisStatus: stateAfterThis || null,
+          privateNote: privateNote,
           mutex: mutex,
         },
       };
@@ -432,6 +445,22 @@ export class Service extends DatabaseService<AlertEpisodeStateTimeline> {
           createdItem.createdByUserId || onCreate.createBy.props.userId,
       },
     });
+
+    if (onCreate.carryForward.privateNote) {
+      const privateNote: string = onCreate.carryForward.privateNote;
+
+      const episodeInternalNote: AlertEpisodeInternalNote =
+        new AlertEpisodeInternalNote();
+      episodeInternalNote.alertEpisodeId = createdItem.alertEpisodeId;
+      episodeInternalNote.note = privateNote;
+      episodeInternalNote.createdAt = createdItem.startsAt!;
+      episodeInternalNote.projectId = createdItem.projectId!;
+
+      await AlertEpisodeInternalNoteService.create({
+        data: episodeInternalNote,
+        props: onCreate.createBy.props,
+      });
+    }
 
     return createdItem;
   }

--- a/Common/Server/Services/IncidentEpisodeStateTimelineService.ts
+++ b/Common/Server/Services/IncidentEpisodeStateTimelineService.ts
@@ -20,6 +20,9 @@ import IncidentEpisodeFeedService from "./IncidentEpisodeFeedService";
 import { IncidentEpisodeFeedEventType } from "../../Models/DatabaseModels/IncidentEpisodeFeed";
 import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
 import IncidentEpisodeService from "./IncidentEpisodeService";
+import IncidentEpisodeInternalNote from "../../Models/DatabaseModels/IncidentEpisodeInternalNote";
+import IncidentEpisodeInternalNoteService from "./IncidentEpisodeInternalNoteService";
+import { JSONObject } from "../../Types/JSON";
 
 export class Service extends DatabaseService<IncidentEpisodeStateTimeline> {
   public constructor() {
@@ -188,11 +191,21 @@ export class Service extends DatabaseService<IncidentEpisodeStateTimeline> {
         incidentEpisodeId: createBy.data.incidentEpisodeId?.toString(),
       } as LogAttributes);
 
+      /*
+       * The note a user writes when they change the state. It is not a column
+       * on this model, so it travels alongside the create and becomes an
+       * internal note on the episode once the timeline row exists.
+       */
+      const privateNote: string | undefined = (
+        createBy.miscDataProps as JSONObject | undefined
+      )?.["privateNote"] as string | undefined;
+
       return {
         createBy,
         carryForward: {
           statusTimelineBeforeThisStatus: stateBeforeThis || null,
           statusTimelineAfterThisStatus: stateAfterThis || null,
+          privateNote: privateNote,
           mutex: mutex,
         },
       };
@@ -441,6 +454,22 @@ export class Service extends DatabaseService<IncidentEpisodeStateTimeline> {
           createdItem.createdByUserId || onCreate.createBy.props.userId,
       },
     });
+
+    if (onCreate.carryForward.privateNote) {
+      const privateNote: string = onCreate.carryForward.privateNote;
+
+      const episodeInternalNote: IncidentEpisodeInternalNote =
+        new IncidentEpisodeInternalNote();
+      episodeInternalNote.incidentEpisodeId = createdItem.incidentEpisodeId;
+      episodeInternalNote.note = privateNote;
+      episodeInternalNote.createdAt = createdItem.startsAt!;
+      episodeInternalNote.projectId = createdItem.projectId!;
+
+      await IncidentEpisodeInternalNoteService.create({
+        data: episodeInternalNote,
+        props: onCreate.createBy.props,
+      });
+    }
 
     return createdItem;
   }

--- a/Common/Tests/Server/Services/EpisodeStateTimelineNote.test.ts
+++ b/Common/Tests/Server/Services/EpisodeStateTimelineNote.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, describe, expect, test } from "@jest/globals";
+import AlertEpisodeFeedService from "../../../Server/Services/AlertEpisodeFeedService";
+import AlertEpisodeInternalNoteService from "../../../Server/Services/AlertEpisodeInternalNoteService";
+import AlertEpisodeService from "../../../Server/Services/AlertEpisodeService";
+import AlertEpisodeStateTimelineService from "../../../Server/Services/AlertEpisodeStateTimelineService";
+import AlertStateService from "../../../Server/Services/AlertStateService";
+import IncidentEpisodeFeedService from "../../../Server/Services/IncidentEpisodeFeedService";
+import IncidentEpisodeInternalNoteService from "../../../Server/Services/IncidentEpisodeInternalNoteService";
+import IncidentEpisodeService from "../../../Server/Services/IncidentEpisodeService";
+import IncidentEpisodeStateTimelineService from "../../../Server/Services/IncidentEpisodeStateTimelineService";
+import IncidentStateService from "../../../Server/Services/IncidentStateService";
+import Semaphore from "../../../Server/Infrastructure/Semaphore";
+import { OnCreate } from "../../../Server/Types/Database/Hooks";
+import AlertEpisodeInternalNote from "../../../Models/DatabaseModels/AlertEpisodeInternalNote";
+import AlertEpisodeStateTimeline from "../../../Models/DatabaseModels/AlertEpisodeStateTimeline";
+import IncidentEpisodeInternalNote from "../../../Models/DatabaseModels/IncidentEpisodeInternalNote";
+import IncidentEpisodeStateTimeline from "../../../Models/DatabaseModels/IncidentEpisodeStateTimeline";
+import OneUptimeDate from "../../../Types/Date";
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * Changing an episode's state can carry an optional private note — from the
+ * episode overview panel or from the bulk "Change State" action on the
+ * episodes table. The note is not a column on the state timeline: it rides
+ * along under `miscDataProps`. These tests cover both halves of that trip.
+ * onBeforeCreate has to pick the note up, and onCreateSuccess has to turn it
+ * into an internal note on the episode. Miss either half and the textbox
+ * silently throws the user's note away.
+ */
+
+interface EpisodeTimelineHooks<TTimeline> {
+  onBeforeCreate: (createBy: {
+    data: TTimeline;
+    miscDataProps?: Record<string, unknown> | undefined;
+    props: Record<string, unknown>;
+  }) => Promise<OnCreate<never>>;
+  onCreateSuccess: (
+    onCreate: {
+      createBy: { data: TTimeline; props: Record<string, unknown> };
+      carryForward: Record<string, unknown>;
+    },
+    createdItem: TTimeline,
+  ) => Promise<TTimeline>;
+}
+
+const incidentEpisodeHooks: EpisodeTimelineHooks<IncidentEpisodeStateTimeline> =
+  IncidentEpisodeStateTimelineService as unknown as EpisodeTimelineHooks<IncidentEpisodeStateTimeline>;
+
+const alertEpisodeHooks: EpisodeTimelineHooks<AlertEpisodeStateTimeline> =
+  AlertEpisodeStateTimelineService as unknown as EpisodeTimelineHooks<AlertEpisodeStateTimeline>;
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "019acd20-1111-4111-8111-111111111111",
+);
+const EPISODE_ID: ObjectID = new ObjectID(
+  "019acd20-2222-4222-8222-222222222222",
+);
+const STATE_ID: ObjectID = new ObjectID("019acd20-3333-4333-8333-333333333333");
+const TIMELINE_ID: ObjectID = new ObjectID(
+  "019acd20-4444-4444-8444-444444444444",
+);
+
+const NOTE_ON_INCIDENT_EPISODE: string = "Mapped to Dynamics case 4821.";
+const NOTE_ON_ALERT_EPISODE: string = "Paged the on-call team.";
+
+function mockSemaphore(): void {
+  jest.spyOn(Semaphore, "lock").mockResolvedValue(null as never);
+  jest.spyOn(Semaphore, "release").mockResolvedValue(undefined as never);
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("IncidentEpisodeStateTimelineService note handling", () => {
+  function buildTimeline(): IncidentEpisodeStateTimeline {
+    const timeline: IncidentEpisodeStateTimeline =
+      new IncidentEpisodeStateTimeline();
+    timeline.id = TIMELINE_ID;
+    timeline.projectId = PROJECT_ID;
+    timeline.incidentEpisodeId = EPISODE_ID;
+    timeline.incidentStateId = STATE_ID;
+    timeline.startsAt = OneUptimeDate.getCurrentDate();
+    /*
+     * A set endsAt means this row is not the latest one, which keeps
+     * onCreateSuccess out of the "cascade to member incidents" branch. The
+     * note handling under test is independent of that branch.
+     */
+    timeline.endsAt = OneUptimeDate.getCurrentDate();
+
+    return timeline;
+  }
+
+  function mockOnBeforeCreateLookups(): void {
+    mockSemaphore();
+    jest
+      .spyOn(IncidentEpisodeStateTimelineService, "findOneBy")
+      .mockResolvedValue(null);
+  }
+
+  function mockOnCreateSuccessLookups(): void {
+    jest.spyOn(IncidentStateService, "findOneBy").mockResolvedValue(null);
+    jest.spyOn(IncidentEpisodeService, "findOneById").mockResolvedValue(null);
+    jest
+      .spyOn(IncidentEpisodeFeedService, "createIncidentEpisodeFeedItem")
+      .mockResolvedValue(undefined as never);
+  }
+
+  function mockInternalNoteCreate(): jest.SpyInstance {
+    return jest
+      .spyOn(IncidentEpisodeInternalNoteService, "create")
+      .mockResolvedValue(new IncidentEpisodeInternalNote() as never);
+  }
+
+  test("onBeforeCreate carries the private note forward", async () => {
+    mockOnBeforeCreateLookups();
+
+    const onCreate: OnCreate<never> = await incidentEpisodeHooks.onBeforeCreate(
+      {
+        data: buildTimeline(),
+        miscDataProps: {
+          privateNote: NOTE_ON_INCIDENT_EPISODE,
+        },
+        props: { isRoot: true },
+      },
+    );
+
+    expect(onCreate.carryForward.privateNote).toBe(NOTE_ON_INCIDENT_EPISODE);
+  });
+
+  test("onBeforeCreate leaves the note undefined when none was written", async () => {
+    mockOnBeforeCreateLookups();
+
+    const onCreate: OnCreate<never> = await incidentEpisodeHooks.onBeforeCreate(
+      {
+        data: buildTimeline(),
+        props: { isRoot: true },
+      },
+    );
+
+    expect(onCreate.carryForward.privateNote).toBeUndefined();
+  });
+
+  test("onCreateSuccess turns the carried note into an episode internal note", async () => {
+    mockOnCreateSuccessLookups();
+    const createNote: jest.SpyInstance = mockInternalNoteCreate();
+
+    const createdItem: IncidentEpisodeStateTimeline = buildTimeline();
+
+    await incidentEpisodeHooks.onCreateSuccess(
+      {
+        createBy: { data: createdItem, props: { isRoot: true } },
+        carryForward: {
+          statusTimelineBeforeThisStatus: null,
+          statusTimelineAfterThisStatus: null,
+          privateNote: NOTE_ON_INCIDENT_EPISODE,
+          mutex: null,
+        },
+      },
+      createdItem,
+    );
+
+    expect(createNote).toHaveBeenCalledTimes(1);
+
+    const note: IncidentEpisodeInternalNote = createNote.mock.calls[0]![0].data;
+
+    expect(note.note).toBe(NOTE_ON_INCIDENT_EPISODE);
+    expect(note.incidentEpisodeId?.toString()).toBe(EPISODE_ID.toString());
+    expect(note.projectId?.toString()).toBe(PROJECT_ID.toString());
+    expect(note.createdAt).toEqual(createdItem.startsAt);
+  });
+
+  test("onCreateSuccess writes no note when the textbox was left empty", async () => {
+    mockOnCreateSuccessLookups();
+    const createNote: jest.SpyInstance = mockInternalNoteCreate();
+
+    const createdItem: IncidentEpisodeStateTimeline = buildTimeline();
+
+    await incidentEpisodeHooks.onCreateSuccess(
+      {
+        createBy: { data: createdItem, props: { isRoot: true } },
+        carryForward: {
+          statusTimelineBeforeThisStatus: null,
+          statusTimelineAfterThisStatus: null,
+          privateNote: undefined,
+          mutex: null,
+        },
+      },
+      createdItem,
+    );
+
+    expect(createNote).not.toHaveBeenCalled();
+  });
+});
+
+describe("AlertEpisodeStateTimelineService note handling", () => {
+  function buildTimeline(): AlertEpisodeStateTimeline {
+    const timeline: AlertEpisodeStateTimeline = new AlertEpisodeStateTimeline();
+    timeline.id = TIMELINE_ID;
+    timeline.projectId = PROJECT_ID;
+    timeline.alertEpisodeId = EPISODE_ID;
+    timeline.alertStateId = STATE_ID;
+    timeline.startsAt = OneUptimeDate.getCurrentDate();
+    timeline.endsAt = OneUptimeDate.getCurrentDate();
+
+    return timeline;
+  }
+
+  function mockOnBeforeCreateLookups(): void {
+    mockSemaphore();
+    jest
+      .spyOn(AlertEpisodeStateTimelineService, "findOneBy")
+      .mockResolvedValue(null);
+  }
+
+  function mockOnCreateSuccessLookups(): void {
+    jest.spyOn(AlertStateService, "findOneBy").mockResolvedValue(null);
+    jest.spyOn(AlertEpisodeService, "findOneById").mockResolvedValue(null);
+    jest
+      .spyOn(AlertEpisodeFeedService, "createAlertEpisodeFeedItem")
+      .mockResolvedValue(undefined as never);
+  }
+
+  function mockInternalNoteCreate(): jest.SpyInstance {
+    return jest
+      .spyOn(AlertEpisodeInternalNoteService, "create")
+      .mockResolvedValue(new AlertEpisodeInternalNote() as never);
+  }
+
+  test("onBeforeCreate carries the private note forward", async () => {
+    mockOnBeforeCreateLookups();
+
+    const onCreate: OnCreate<never> = await alertEpisodeHooks.onBeforeCreate({
+      data: buildTimeline(),
+      miscDataProps: {
+        privateNote: NOTE_ON_ALERT_EPISODE,
+      },
+      props: { isRoot: true },
+    });
+
+    expect(onCreate.carryForward.privateNote).toBe(NOTE_ON_ALERT_EPISODE);
+  });
+
+  test("onBeforeCreate leaves the note undefined when none was written", async () => {
+    mockOnBeforeCreateLookups();
+
+    const onCreate: OnCreate<never> = await alertEpisodeHooks.onBeforeCreate({
+      data: buildTimeline(),
+      props: { isRoot: true },
+    });
+
+    expect(onCreate.carryForward.privateNote).toBeUndefined();
+  });
+
+  test("onCreateSuccess turns the carried note into an episode internal note", async () => {
+    mockOnCreateSuccessLookups();
+    const createNote: jest.SpyInstance = mockInternalNoteCreate();
+
+    const createdItem: AlertEpisodeStateTimeline = buildTimeline();
+
+    await alertEpisodeHooks.onCreateSuccess(
+      {
+        createBy: { data: createdItem, props: { isRoot: true } },
+        carryForward: {
+          statusTimelineBeforeThisStatus: null,
+          statusTimelineAfterThisStatus: null,
+          privateNote: NOTE_ON_ALERT_EPISODE,
+          mutex: null,
+        },
+      },
+      createdItem,
+    );
+
+    expect(createNote).toHaveBeenCalledTimes(1);
+
+    const note: AlertEpisodeInternalNote = createNote.mock.calls[0]![0].data;
+
+    expect(note.note).toBe(NOTE_ON_ALERT_EPISODE);
+    expect(note.alertEpisodeId?.toString()).toBe(EPISODE_ID.toString());
+    expect(note.projectId?.toString()).toBe(PROJECT_ID.toString());
+    expect(note.createdAt).toEqual(createdItem.startsAt);
+  });
+
+  test("onCreateSuccess writes no note when the textbox was left empty", async () => {
+    mockOnCreateSuccessLookups();
+    const createNote: jest.SpyInstance = mockInternalNoteCreate();
+
+    const createdItem: AlertEpisodeStateTimeline = buildTimeline();
+
+    await alertEpisodeHooks.onCreateSuccess(
+      {
+        createBy: { data: createdItem, props: { isRoot: true } },
+        carryForward: {
+          statusTimelineBeforeThisStatus: null,
+          statusTimelineAfterThisStatus: null,
+          mutex: null,
+        },
+      },
+      createdItem,
+    );
+
+    expect(createNote).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/UI/Utils/ModelAPICreateMiscData.test.ts
+++ b/Common/Tests/UI/Utils/ModelAPICreateMiscData.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from "@jest/globals";
+import IncidentStateTimeline from "../../../Models/DatabaseModels/IncidentStateTimeline";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import { FormType } from "../../../UI/Components/Forms/ModelForm";
+import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
+
+/*
+ * A model's form sends extra, non-column values (the note a user writes when
+ * they change an incident state, for one) under `miscDataProps`. Anything
+ * creating a model outside of a form — the bulk "Change State" action on the
+ * event tables — goes through ModelAPI.create, so create has to forward that
+ * payload too. It used to hard-code an empty object, which quietly dropped
+ * every note a bulk action tried to send.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "019acd20-1111-4111-8111-111111111111",
+);
+
+function buildStateTimeline(): IncidentStateTimeline {
+  const stateTimeline: IncidentStateTimeline = new IncidentStateTimeline();
+  stateTimeline.projectId = PROJECT_ID;
+
+  return stateTimeline;
+}
+
+describe("ModelAPI.create miscDataProps", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("forwards miscDataProps to the create request", async () => {
+    const createOrUpdate: jest.SpyInstance = jest
+      .spyOn(ModelAPI, "createOrUpdate")
+      .mockResolvedValue({} as never);
+
+    const miscDataProps: JSONObject = {
+      publicNote: "Rolled back the bad deploy.",
+    };
+
+    await ModelAPI.create<IncidentStateTimeline>({
+      model: buildStateTimeline(),
+      modelType: IncidentStateTimeline,
+      miscDataProps: miscDataProps,
+    });
+
+    expect(createOrUpdate).toHaveBeenCalledTimes(1);
+    expect(createOrUpdate.mock.calls[0]![0].miscDataProps).toEqual({
+      publicNote: "Rolled back the bad deploy.",
+    });
+    expect(createOrUpdate.mock.calls[0]![0].formType).toBe(FormType.Create);
+  });
+
+  test("sends an empty payload when the caller has nothing extra to send", async () => {
+    const createOrUpdate: jest.SpyInstance = jest
+      .spyOn(ModelAPI, "createOrUpdate")
+      .mockResolvedValue({} as never);
+
+    await ModelAPI.create<IncidentStateTimeline>({
+      model: buildStateTimeline(),
+      modelType: IncidentStateTimeline,
+    });
+
+    expect(createOrUpdate).toHaveBeenCalledTimes(1);
+    expect(createOrUpdate.mock.calls[0]![0].miscDataProps).toEqual({});
+  });
+
+  test("keeps forwarding request options alongside miscDataProps", async () => {
+    const createOrUpdate: jest.SpyInstance = jest
+      .spyOn(ModelAPI, "createOrUpdate")
+      .mockResolvedValue({} as never);
+
+    await ModelAPI.create<IncidentStateTimeline>({
+      model: buildStateTimeline(),
+      modelType: IncidentStateTimeline,
+      miscDataProps: { privateNote: "Internal only." },
+      requestOptions: {
+        requestHeaders: {
+          "x-test": "1",
+        },
+      },
+    });
+
+    expect(createOrUpdate.mock.calls[0]![0].miscDataProps).toEqual({
+      privateNote: "Internal only.",
+    });
+    expect(createOrUpdate.mock.calls[0]![0].requestOptions).toEqual({
+      requestHeaders: {
+        "x-test": "1",
+      },
+    });
+  });
+});

--- a/Common/UI/Components/FormModal/BasicFormModal.tsx
+++ b/Common/UI/Components/FormModal/BasicFormModal.tsx
@@ -5,7 +5,7 @@ import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import BasicForm, {
   BaseComponentProps as BasicFormComponentProps,
 } from "../Forms/BasicForm";
-import Modal from "../Modal/Modal";
+import Modal, { ModalWidth } from "../Modal/Modal";
 import GenericObject from "../../../Types/GenericObject";
 import React, { ReactElement, useEffect, useRef, useState } from "react";
 
@@ -19,6 +19,7 @@ export interface ComponentProps<T extends GenericObject> {
   submitButtonStyleType?: undefined | ButtonStyleType;
   formProps: BasicFormComponentProps<T>;
   description?: string | undefined;
+  modalWidth?: ModalWidth | undefined;
 }
 
 const BasicFormModal: <T extends GenericObject>(

--- a/Common/UI/Utils/ModelAPI/ModelAPI.ts
+++ b/Common/UI/Utils/ModelAPI/ModelAPI.ts
@@ -50,6 +50,12 @@ export default class ModelAPI {
   public static async create<TBaseModel extends BaseModel>(data: {
     model: TBaseModel;
     modelType: { new (): TBaseModel };
+    /*
+     * Extra values that are not columns on the model but that the service
+     * reads off `createBy.miscDataProps` (for example the note a user writes
+     * when they change an incident state).
+     */
+    miscDataProps?: JSONObject | undefined;
     requestOptions?: RequestOptions | undefined;
   }): Promise<
     HTTPResponse<JSONObject | JSONArray | TBaseModel | Array<TBaseModel>>
@@ -58,7 +64,7 @@ export default class ModelAPI {
       model: data.model,
       modelType: data.modelType,
       formType: FormType.Create,
-      miscDataProps: {},
+      miscDataProps: data.miscDataProps || {},
       requestOptions: data.requestOptions,
     });
   }


### PR DESCRIPTION
Closes part of #3036.

## The problem

Changing an event's state from its **overview page** has always offered an optional note — a public note for incidents and scheduled maintenance, a private note for alerts and episodes. The bulk **Change State** action on the event tables offered only a state picker, so a bulk change lost the reason or the reference behind it. That is precisely the context that matters when an external system reacts to the state change (the issue's example: an alert moved to a "Mapped" state with no way to say *which* Dynamics case it maps to).

## What this does

The bulk change-state modal now carries the same optional note and note-template shortcut as the single-event modal, on all five event tables:

| Table | Note | Notify subscribers toggle |
| --- | --- | --- |
| Incidents | Public Note | yes |
| Scheduled Maintenance | Public Note | yes |
| Alerts | Private Note | no |
| Incident Episodes | Private Note | no |
| Alert Episodes | Private Note | no |

The note is applied to every event in the selection. An untouched (or whitespace-only) textbox sends nothing, so it can never create an empty note. The subscriber toggle defaults to on, which matches what bulk changes do today — both underlying columns already default to `true` in the database.

All five modals now come from one shared `BulkChangeStateModal` component instead of five near-identical `BasicFormModal` blocks.

## Fixes found along the way

- **`ModelAPI.create` hard-coded `miscDataProps: {}`.** Notes travel to the timeline services under `miscDataProps`, so a note could never have reached the API from anything other than a form. `create` now forwards the caller's payload; `createOrUpdate` already accepted it.
- **Episode state timelines dropped the note entirely.** `IncidentEpisodeStateTimelineService` and `AlertEpisodeStateTimelineService` never read `privateNote` off `miscDataProps` — so the episode overview page's *existing* textbox was silently discarding what users typed. Both services now turn the note into an internal note on the episode, mirroring `AlertStateTimelineService`.
- **Deduplication.** The "already at or past the target state, report as skipped" rule was copy-pasted in all five tables. It now lives in one helper with tests.

## Tests

56 new assertions across four files:

- `App/Tests/Dashboard/BulkStateChange.test.ts` — the pure helpers: note field keys (`publicNote` / `privateNote` — the exact names the services key off), template lookup, the blank-note rule, markdown preserved byte for byte, and the skip decision at/before/past the target state.
- `App/Tests/Dashboard/BulkChangeStateNoteWiring.test.ts` — per table: renders the shared modal, loads the right note-template model, forwards `miscDataProps` into `ModelAPI.create`, offers the subscriber toggle only where a status page exists, and uses the shared skip rule. A table that renders the textbox but drops `miscDataProps` would show a control that quietly does nothing — these assertions exist to catch exactly that.
- `Common/Tests/Server/Services/EpisodeStateTimelineNote.test.ts` — both halves of the note's trip through each episode service: `onBeforeCreate` picks it up, `onCreateSuccess` writes the internal note, and neither fires when the textbox was left empty.
- `Common/Tests/UI/Utils/ModelAPICreateMiscData.test.ts` — `create` forwards `miscDataProps`, defaults to `{}`, and still passes request options through.

## Verification

- `tsc --noEmit` clean on `App/FeatureSet/Dashboard`.
- `tsc --noEmit` clean on `Common` apart from three pre-existing errors in untouched files (`mysql2`, `pg` types, `mssql` missing from the local install).
- 56/56 new tests pass; prettier clean.
- Not exercised in a running browser: the docker dev environment mounts the main checkout rather than this worktree, so the modal has not been clicked through by hand.

## Not in scope

Issue #3036 also asks for the message to be surfaced in the **State Timeline** and **Audit Logs**. This PR covers the bulk-view textbox only; the note lands where the single-event note already lands (the event's public/internal notes and its feed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)