### PR TITLE
fix(security): stop userinfo standing in for the host in the SSRF guard

### DIFF
--- a/Common/Server/Utils/SSRFProtection.ts
+++ b/Common/Server/Utils/SSRFProtection.ts
@@ -126,10 +126,12 @@ export default class SSRFProtection {
     }
 
     /*
-     * OneUptime's URL parser keeps the port glued to the host (e.g.
-     * "169.254.169.254:80"). Strip it before the checks below, otherwise a
-     * literal-with-port slips past the IPv4 blocklist and, because it contains
-     * a ":", is mistaken for an IP literal and skips DNS resolution entirely.
+     * OneUptime's URL parser hands back the whole authority — userinfo, host
+     * and port glued together ("user:pw@169.254.169.254:80"). Reduce it to the
+     * bare host before the checks below: a literal-with-port otherwise slips
+     * past the IPv4 blocklist and, because it contains a ":", is mistaken for
+     * an IP literal and skips DNS resolution entirely, and userinfo otherwise
+     * gets to nominate the host outright.
      */
     const hostname: string = SSRFProtection.extractHost(rawHost);
 
@@ -137,16 +139,41 @@ export default class SSRFProtection {
       throw new BadDataException("Webhook URL must include a host.");
     }
 
-    if (SSRFProtection.isBlockedHostnameLiteral(hostname)) {
-      throw new BadDataException(
-        "Webhook URL points to a private, loopback, or link-local address and is not allowed.",
-      );
+    /*
+     * Check the host BOTH parsers see, not just ours.
+     *
+     * A guard is only worth something if it reasons about the host the HTTP
+     * client will actually dial, and OneUptime's parser and WHATWG do not
+     * always agree on which substring that is — userinfo was one such
+     * disagreement, and treating it as the only one would be optimistic. So
+     * whenever the two answers differ, both are held to the blocklist and a
+     * verdict of "internal" from either one is enough to refuse. A legitimate
+     * public URL parses to a public host under both, and pays only a string
+     * comparison for the privilege.
+     */
+    const whatwgHostname: string = SSRFProtection.getBareHostname(rawUrl);
+
+    const hostnames: Array<string> =
+      whatwgHostname && whatwgHostname !== hostname
+        ? [hostname, whatwgHostname]
+        : [hostname];
+
+    for (const host of hostnames) {
+      if (SSRFProtection.isBlockedHostnameLiteral(host)) {
+        throw new BadDataException(
+          "Webhook URL points to a private, loopback, or link-local address and is not allowed.",
+        );
+      }
     }
 
-    if (!SSRFProtection.isIpLiteral(hostname)) {
+    for (const host of hostnames) {
+      if (SSRFProtection.isIpLiteral(host)) {
+        continue;
+      }
+
       let resolved: Array<{ address: string }> = [];
       try {
-        resolved = await dns.promises.lookup(hostname, { all: true });
+        resolved = await dns.promises.lookup(host, { all: true });
       } catch {
         throw new BadDataException(
           "Webhook URL hostname could not be resolved via DNS.",
@@ -166,12 +193,34 @@ export default class SSRFProtection {
   }
 
   /*
-   * Extracts the bare host (IPv4, IPv6, or hostname) from a "host[:port]"
-   * string, handling bracketed IPv6 (`[::1]`, `[::1]:8080`) and unbracketed
-   * IPv6 literals (which contain multiple colons and carry no port).
+   * Everything up to and including the LAST "@" is userinfo, never the host.
+   *
+   * This matters because OneUptime's Hostname deliberately KEEPS userinfo in
+   * the string it stores, and a "host:port" split over that string reads the
+   * USERNAME as the host: "example.com:pass@169.254.169.254" holds exactly one
+   * colon, so splitting on it answers "example.com" — which resolves publicly
+   * and sails through the blocklist — while every RFC 3986 client (axios, and
+   * WHATWG before it) dials 169.254.169.254.
+   *
+   * The LAST "@" is the delimiter, which is how WHATWG resolves an authority
+   * carrying more than one and therefore where the HTTP client will split it.
+   * Hostname's own validation happens to reject a second "@" before this runs,
+   * so the choice only shows up on hosts reaching us by another route — but
+   * splitting on the first "@" would be a bypass the day that changes.
+   */
+  private static stripUserInfo(authority: string): string {
+    const atIndex: number = authority.lastIndexOf("@");
+    return atIndex === -1 ? authority : authority.substring(atIndex + 1);
+  }
+
+  /*
+   * Extracts the bare host (IPv4, IPv6, or hostname) from a
+   * "[userinfo@]host[:port]" string, handling bracketed IPv6 (`[::1]`,
+   * `[::1]:8080`) and unbracketed IPv6 literals (which contain multiple colons
+   * and carry no port).
    */
   private static extractHost(hostWithPort: string): string {
-    const host: string = hostWithPort.trim();
+    const host: string = SSRFProtection.stripUserInfo(hostWithPort.trim());
 
     if (host.startsWith("[")) {
       const closingBracketIndex: number = host.indexOf("]");

--- a/Common/Tests/Server/Utils/SSRFProtectionBypasses.test.ts
+++ b/Common/Tests/Server/Utils/SSRFProtectionBypasses.test.ts
@@ -195,12 +195,19 @@ describe("SSRFProtection — IPv4 ranges", () => {
   });
 });
 
-describe("SSRFProtection — alternate IPv4 notations resolve before they are judged", () => {
+describe("SSRFProtection — alternate IPv4 notations are decoded, not delegated", () => {
   /*
-   * net.isIP rejects these, so they are not treated as literals - they go to
-   * DNS, where getaddrinfo decodes the notation, and the ADDRESS IT RETURNS is
-   * what gets checked. That is the property under test: the guard never has to
-   * understand decimal or octal IPv4 itself.
+   * net.isIP rejects all of these, so our own parser does not see a literal.
+   * WHATWG does: it decodes decimal, octal, hex and short-form IPv4 per the URL
+   * spec, and since the guard checks the host WHATWG names as well as our own,
+   * the address is judged directly.
+   *
+   * This used to be delegated to getaddrinfo instead - "not a literal" meant
+   * "send it to DNS and check the answer". That worked only where the platform
+   * resolver happened to decode the same notations, and macOS does not decode
+   * octal: "http://0177.0.0.1/" resolved to the public 177.0.0.1 and was
+   * ALLOWED, while axios connected to 127.0.0.1. Deciding it from the URL is
+   * both stricter and the same everywhere.
    */
   const notations: Array<[string, string]> = [
     ["decimal", "http://2852039166/"],
@@ -210,11 +217,12 @@ describe("SSRFProtection — alternate IPv4 notations resolve before they are ju
   ];
 
   test.each(notations)(
-    "blocks %s notation once resolved",
+    "blocks %s notation without asking DNS",
     async (_label: string, url: string) => {
-      lookupSpy.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+      // A resolver that answers "public" must not be able to rescue these.
+      lookupSpy.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
       expect(await isBlocked(url)).toBe(true);
-      expect(lookupSpy).toHaveBeenCalled();
+      expect(lookupSpy).not.toHaveBeenCalled();
     },
   );
 });

--- a/Common/Tests/Server/Utils/SSRFProtectionUserInfo.test.ts
+++ b/Common/Tests/Server/Utils/SSRFProtectionUserInfo.test.ts
@@ -1,0 +1,351 @@
+import SSRFProtection from "../../../Server/Utils/SSRFProtection";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import dns from "dns";
+
+/*
+ * "http://example.com:pass@169.254.169.254/" is one URL with two readings.
+ *
+ * OneUptime's Hostname keeps userinfo in the string it stores, on purpose:
+ * customers really do put "https://user:token@host/path" in webhook fields and
+ * those rows already exist. The guard then read that string and split it on
+ * ":" to drop a port — and "example.com:pass@169.254.169.254" holds exactly
+ * one colon, so the split answered "example.com". That name resolves publicly,
+ * so the blocklist and the DNS re-check both passed, and axios — which parses
+ * per RFC 3986 like every other client — connected to 169.254.169.254 with the
+ * validated name sitting harmlessly in the Authorization material.
+ *
+ * The colon is what made it work. "http://example.com@169.254.169.254/" has no
+ * colon, took the whole string to DNS, and failed closed. So this was never
+ * about credentials being present; it was about the guard and the HTTP client
+ * disagreeing over which substring is the host.
+ *
+ * Two properties are pinned below. First: the host is whatever comes after the
+ * last "@", always. Second: when our parser and WHATWG disagree about the host
+ * at all, both answers are judged and either one saying "internal" refuses the
+ * request — because the next disagreement will not be about userinfo.
+ */
+
+type LookupSpy = jest.SpiedFunction<
+  (
+    hostname: string,
+    options: { all: true },
+  ) => Promise<Array<{ address: string; family: number }>>
+>;
+
+let lookupSpy: LookupSpy;
+
+beforeEach(() => {
+  lookupSpy = jest.spyOn(dns.promises, "lookup") as unknown as LookupSpy;
+  /*
+   * Only "example.com" and the hooks subdomain exist. Anything else throwing
+   * ENOTFOUND is what production does with a name that does not resolve, and
+   * it keeps a test from passing merely because a lookup was mocked away.
+   */
+  lookupSpy.mockImplementation(
+    async (
+      hostname: string,
+    ): Promise<Array<{ address: string; family: number }>> => {
+      if (hostname === "example.com" || hostname === "hooks.example.com") {
+        return [{ address: "93.184.216.34", family: 4 }];
+      }
+      throw new Error(`ENOTFOUND ${hostname}`);
+    },
+  );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+async function isBlocked(url: string): Promise<boolean> {
+  try {
+    await SSRFProtection.validateWebhookTargetIsSafe(url);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe("SSRFProtection — userinfo cannot stand in for the host", () => {
+  /*
+   * Every one of these connects to the address after the "@". Most of them
+   * were allowed outright before the fix; the last two failed closed for a
+   * reason that was never the guard doing its job — the ":80" gave the
+   * authority a second colon so the whole unusable string went to DNS, and
+   * "user" simply does not resolve on this host. A DNS search domain would
+   * have carried that second one straight through.
+   */
+  const blocked: Array<[string, string]> = [
+    [
+      "metadata endpoint behind a public-looking username",
+      "http://example.com:pass@169.254.169.254/latest/meta-data/",
+    ],
+    ["loopback behind userinfo", "http://example.com:pass@127.0.0.1/"],
+    ["empty password is enough", "http://example.com:@169.254.169.254/"],
+    ["a numeric password reads as a port", "http://example.com:80@10.0.0.5/"],
+    ["localhost behind userinfo", "http://example.com:pass@localhost/"],
+    ["RFC-1918 behind userinfo", "http://example.com:pass@192.168.1.1/"],
+    ["CGNAT behind userinfo", "http://example.com:pass@100.64.0.1/"],
+    ["unspecified address behind userinfo", "http://example.com:pass@0.0.0.0/"],
+    [
+      "metadata by name behind userinfo",
+      "http://example.com:pass@metadata.google.internal/computeMetadata/v1/",
+    ],
+    [
+      "internal host AND an explicit port",
+      "http://example.com:pass@169.254.169.254:80/latest/",
+    ],
+    ["username only, with the colon in it", "http://user:pass@127.0.0.1/"],
+    ["https is no different", "https://example.com:pass@169.254.169.254/"],
+  ];
+
+  test.each(blocked)("blocks %s", async (_label: string, url: string) => {
+    expect(await isBlocked(url)).toBe(true);
+  });
+
+  /*
+   * The bug needed a colon inside the userinfo to survive the port split.
+   * These spellings failed closed even before the fix; they are here so a
+   * future refactor cannot quietly re-open them.
+   */
+  const colonlessUserInfo: Array<string> = [
+    "http://example.com@169.254.169.254/",
+    "http://example.com@127.0.0.1/",
+    "http://user@10.0.0.1/",
+  ];
+
+  test.each(colonlessUserInfo)(
+    "blocks %s (no colon in userinfo)",
+    async (url: string) => {
+      expect(await isBlocked(url)).toBe(true);
+    },
+  );
+
+  test("the last @ wins, not the first", async () => {
+    /*
+     * Hostname rejects a second "@" outright (userinfo may not contain one),
+     * so this must be refused rather than parsed as host "b@127.0.0.1" or
+     * host "a".
+     */
+    expect(await isBlocked("http://a@b@127.0.0.1/")).toBe(true);
+  });
+
+  test("an internal literal is refused without a DNS round trip", async () => {
+    expect(await isBlocked("http://example.com:pass@169.254.169.254/")).toBe(
+      true,
+    );
+    expect(lookupSpy).not.toHaveBeenCalled();
+  });
+
+  test("the username is never the thing resolved", async () => {
+    /*
+     * The tell for the original bug: "example.com" went to DNS and the real
+     * host never did. If anything is resolved here it must be the host.
+     */
+    await isBlocked("http://example.com:pass@internal.invalid/");
+
+    for (const call of lookupSpy.mock.calls) {
+      expect(call[0]).not.toBe("example.com");
+    }
+  });
+});
+
+describe("SSRFProtection — userinfo carrying an IPv6 host", () => {
+  const blocked: Array<[string, string]> = [
+    ["loopback", "http://example.com:pass@[::1]/"],
+    [
+      "IPv4-mapped metadata",
+      "http://example.com:pass@[::ffff:169.254.169.254]/",
+    ],
+    ["link-local", "http://example.com:pass@[fe80::1]/"],
+    ["unique-local", "http://example.com:pass@[fd12:3456:789a::1]/"],
+    ["mapped loopback with a port", "http://user:pw@[::ffff:127.0.0.1]:8080/"],
+  ];
+
+  test.each(blocked)(
+    "blocks %s behind userinfo",
+    async (_label: string, url: string) => {
+      expect(await isBlocked(url)).toBe(true);
+    },
+  );
+
+  test("allows a public IPv6 host behind userinfo", async () => {
+    expect(await isBlocked("https://user:pw@[2606:4700:4700::1111]/hook")).toBe(
+      false,
+    );
+  });
+});
+
+describe("SSRFProtection — real basic-auth webhooks still work", () => {
+  /*
+   * The fix must not turn into a ban on userinfo. "https://user:token@host/"
+   * is a documented way to authenticate a webhook and those URLs are already
+   * stored; blocking them would break delivery on read, not just on write.
+   */
+  const allowed: Array<[string, string]> = [
+    [
+      "public host with user and password",
+      "https://user:token@example.com/hook",
+    ],
+    ["public host with a username only", "https://user@example.com/hook"],
+    ["subdomain with credentials", "https://svc:s3cr3t@hooks.example.com/x"],
+    ["credentials plus a port", "https://user:token@example.com:8443/hook"],
+    ["an empty password on a public host", "https://user:@example.com/hook"],
+  ];
+
+  test.each(allowed)("allows %s", async (_label: string, url: string) => {
+    expect(await isBlocked(url)).toBe(false);
+  });
+
+  test("the DNS check still applies to the host behind userinfo", async () => {
+    // A public-looking host that resolves internally is still refused.
+    lookupSpy.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+    expect(await isBlocked("https://user:token@example.com/hook")).toBe(true);
+  });
+});
+
+describe("SSRFProtection — getBareHostname reads past userinfo", () => {
+  /*
+   * Host-pinning allowlists (Slack, Teams) compare against this. If userinfo
+   * could pass for the host, "https://slack.com:x@169.254.169.254/" would
+   * satisfy a pin on slack.com and dial the metadata endpoint instead.
+   */
+  const cases: Array<[string, string]> = [
+    ["https://slack.com:x@169.254.169.254/", "169.254.169.254"],
+    ["https://user:pass@hooks.example.com/x", "hooks.example.com"],
+    ["https://user@example.com:8443/x", "example.com"],
+    ["https://user:pass@[::1]/x", "::1"],
+    ["https://example.com/x", "example.com"],
+  ];
+
+  test.each(cases)(
+    "reads the host of %s as %s",
+    (url: string, expected: string) => {
+      expect(SSRFProtection.getBareHostname(url)).toBe(expected);
+    },
+  );
+
+  test("an allowlist pin is not satisfied by a username", () => {
+    expect(
+      SSRFProtection.isUrlOnAllowedDomain(
+        "https://slack.com:x@169.254.169.254/api",
+        ["slack.com"],
+      ),
+    ).toBe(false);
+  });
+
+  test("an allowlist pin still accepts the real host", () => {
+    expect(
+      SSRFProtection.isUrlOnAllowedDomain(
+        "https://user:t@hooks.slack.com/api",
+        ["slack.com"],
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("SSRFProtection — both parsers' idea of the host are judged", () => {
+  /*
+   * Userinfo was one way for OneUptime's parser and WHATWG to disagree about
+   * the host. The guard now checks whichever hosts the two of them name, so a
+   * disagreement is a refusal rather than a bypass. These assert the property
+   * directly, so a differential nobody has found yet still fails closed.
+   */
+  test("blocks when only WHATWG sees the internal host", async () => {
+    /*
+     * Our parser answers "example.com" from the userinfo; WHATWG answers
+     * 169.254.169.254. One vote for "internal" is enough.
+     */
+    expect(await isBlocked("http://example.com:pass@169.254.169.254/")).toBe(
+      true,
+    );
+  });
+
+  test("blocks when only our parser sees the internal host", async () => {
+    /*
+     * The mirror image, and a real disagreement rather than a contrived one:
+     * WHATWG treats "\" as an authority terminator for special schemes, so it
+     * reads the host as "example.com" and the rest as a path. Ours does not,
+     * and reads 169.254.169.254. Neither parser is wrong about its own spec —
+     * which is the whole argument for consulting both.
+     */
+    expect(await isBlocked("http://example.com\\@169.254.169.254/")).toBe(true);
+  });
+
+  test("blocks an internal literal that a fragment tries to re-authority", async () => {
+    expect(
+      await isBlocked("http://[::ffff:169.254.169.254]#@example.com/"),
+    ).toBe(true);
+  });
+
+  test("resolves the second host too, when neither is a literal", async () => {
+    /*
+     * The case that pins the DNS half rather than the blocklist half. Both
+     * parsers name a NAME here, not an address, so the literal check cannot
+     * settle it: WHATWG stops the authority at the backslash and says
+     * "a.example", ours reads through to "b.example". Only a.example points
+     * somewhere internal, and it is the one WE would not have looked up.
+     *
+     * Narrow the DNS loop back to a single host and this is the test that
+     * goes red.
+     */
+    lookupSpy.mockImplementation(
+      async (
+        hostname: string,
+      ): Promise<Array<{ address: string; family: number }>> => {
+        if (hostname === "a.example") {
+          return [{ address: "10.0.0.7", family: 4 }];
+        }
+        if (hostname === "b.example") {
+          return [{ address: "93.184.216.34", family: 4 }];
+        }
+        throw new Error(`ENOTFOUND ${hostname}`);
+      },
+    );
+
+    expect(await isBlocked("http://a.example\\@b.example/")).toBe(true);
+
+    const looked: Array<unknown> = lookupSpy.mock.calls.map(
+      (call: Array<unknown>) => {
+        return call[0];
+      },
+    );
+    expect(looked).toContain("a.example");
+    expect(looked).toContain("b.example");
+  });
+
+  test("an internal literal in the USERINFO does not condemn a public host", async () => {
+    /*
+     * The false positive the old split produced, in mirror image: the address
+     * is the username and the host is ordinary. Splitting on ":" answered
+     * "169.254.169.254" and refused a perfectly good webhook.
+     */
+    expect(await isBlocked("https://169.254.169.254:x@example.com/hook")).toBe(
+      false,
+    );
+  });
+
+  test("a plain public URL costs no extra DNS lookup", async () => {
+    /*
+     * The two parsers agree here, so there is exactly one host to resolve.
+     * If this starts failing, the agreement check has stopped short-circuiting
+     * and every webhook delivery is paying for a second lookup.
+     */
+    expect(await isBlocked("https://hooks.example.com/hook")).toBe(false);
+    expect(lookupSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("a public URL with credentials also costs one lookup", async () => {
+    expect(await isBlocked("https://user:token@hooks.example.com/hook")).toBe(
+      false,
+    );
+    expect(lookupSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

`validateWebhookTargetIsSafe` could be walked past to loopback, RFC-1918 and the cloud metadata endpoint by putting the internal address after a `userinfo@` prefix:

```
http://example.com:pass@169.254.169.254/latest/meta-data/   → allowed, connects to 169.254.169.254
http://example.com:pass@127.0.0.1/                          → allowed, connects to 127.0.0.1
http://example.com:80@10.0.0.5/                             → allowed, connects to 10.0.0.5
http://example.com:pass@localhost/                          → allowed
```

`Hostname` deliberately keeps userinfo in the authority string it stores, and its own docs say callers must not split that string themselves. The guard did exactly that: it took `parsed.hostname.hostname` and split on `:` to drop a port. `example.com:pass@169.254.169.254` holds exactly one colon, so the split answered `example.com` — which resolves publicly, so both the blocklist and the DNS re-check passed, while axios parsed the same string per RFC 3986 and dialled the address after the `@`.

The colon is what made it work; `http://example.com@169.254.169.254/` has none, went to DNS whole, and failed closed. So this was never about credentials being present — it was about the guard and the HTTP client disagreeing over which substring is the host.

This reaches every caller of the guard, including `StatusPageSubscriberWebhook`, whose `subscriberWebhook` field is creatable by unauthenticated visitors on a public status page.

## The fix

**1. `stripUserInfo()`, called from `extractHost()`.** Everything through the last `@` is userinfo, never the host. The last `@` is the delimiter because that is where WHATWG — and therefore the HTTP client — splits an authority carrying more than one.

**2. Both parsers' idea of the host is judged.** Userinfo was one way for OneUptime's parser and WHATWG to disagree about the host, and treating it as the only one would be optimistic. When the two answers differ, both are held to the blocklist and either verdict of "internal" refuses the request. A legitimate public URL parses to a public host under both and pays only a string comparison.

Basic-auth webhooks (`https://user:token@host/`) keep working — those URLs are real and already stored, so the fix parses them correctly rather than rejecting them.

## Unplanned side effect, in our favour

Consulting WHATWG means alternate IPv4 notations are now decoded from the URL instead of delegated to `getaddrinfo`. That closes a platform-dependent hole: macOS does not octal-decode, so `http://0177.0.0.1/` resolved to the public 177.0.0.1 and was **allowed**, while axios connected to 127.0.0.1. It is now refused deterministically, without a DNS round trip.

`SSRFProtectionBypasses.test.ts` had pinned the old mechanism ("these go to DNS and the answer is checked"). That block is rewritten to assert the stronger property, with the resolver mocked to answer *public* so nothing but direct decoding can produce a block.

## Tests

`Common/Tests/Server/Utils/SSRFProtectionUserInfo.test.ts` — 44 cases:

- every PoC payload, plus empty/numeric passwords, colonless userinfo, and a doubled `@`
- userinfo carrying IPv6 hosts (loopback, IPv4-mapped metadata, link-local, ULA, mapped-with-port)
- **negative coverage**: real basic-auth webhooks on public hosts still deliver, including with ports and empty passwords
- the DNS layer still applies to the host behind userinfo
- `getBareHostname` / `isUrlOnAllowedDomain` are not fooled — a pin on `slack.com` is not satisfied by `https://slack.com:x@169.254.169.254/`
- the parser-agreement property in both directions, including a case where only WHATWG sees the internal host (userinfo) and one where only our parser does (`http://example.com\@169.254.169.254/` — WHATWG terminates the authority at the backslash, we do not)
- lookup-count assertions, so the short-circuit cannot silently regress into two DNS lookups per delivery

Two of these exist because a mutation-testing pass over the suite found them missing:

- **the DNS half of the dual-parser check.** `http://a.example\@b.example/` is the case where the two parsers name two *names* rather than addresses, so the blocklist cannot settle it and only the second lookup can. Narrowing the DNS loop back to one host was otherwise invisible to all three suites.
- **the false positive the old split also produced.** `https://169.254.169.254:x@example.com/hook` put the address in the username; splitting on `:` refused a perfectly good webhook.

```
Test Suites: 3 passed, 3 total
Tests:       185 passed, 185 total
```

Also verified green on Node 26: `VMRunnerSsrf.test.ts`, `VMAPI.test.ts`, `VMAPISubstitution.test.ts`.

## Not addressed here

Deliberately out of scope, each still open:

- `Hostname.fromString()` splits on `:` the same way and has the same shape of bug. It is not on this guard's path (`URL.fromString` uses `new Hostname(authority)`), and changing it has a much wider blast radius.
- 6to4 (`2002::/16`) and Teredo (`2001:0::/32`) are still not decoded by `isBlockedIpv6`.
- **Three separate bypasses of the VM axios bridge**, where the guard validates a URL correctly and attacker-controlled axios config then redirects the actual connection. No amount of host-parsing hardening reaches these — the guard is handed a genuinely public host:
  - `httpAgent` / `httpsAgent` options override the connect target (and re-enable `socketPath`, which the top-level `delete` was added to close).
  - `baseURL` with `allowAbsoluteUrls: false` — axios prepends `baseURL` even to an absolute URL, and `../` segments normalize the prefix away to give an arbitrary path on the internal host.
  - A falsy positional url — the guard reads `config.url`, axios prefers the empty positional one and dials `baseURL`.

  The fix belongs in `VMRunner`: dispatch the *validated* URL and strip the config keys that can redirect it, rather than patching each channel as it is found.
