### PR TITLE
fix(ip): anchor the IPv6 validator so it stops accepting substrings

### DIFF
--- a/Common/Tests/Types/IP/IP.test.ts
+++ b/Common/Tests/Types/IP/IP.test.ts
@@ -1,4 +1,5 @@
 import IP from "../../../Types/IP/IP";
+import { ObjectType } from "../../../Types/JSON";
 
 describe("IP()", () => {
   test("expect ip to be defined", () => {
@@ -77,5 +78,269 @@ describe("IP()", () => {
 
   test("should return null from the transformers to function", () => {
     expect(IP.getDatabaseTransformer().to("")).toBe(null);
+  });
+});
+
+/*
+ * The validators are anchored, so a value only counts as an address when the
+ * WHOLE string is one. These cases pin that down: the IPv6 pattern used to be
+ * unanchored and reported anything merely containing an address-shaped
+ * substring as valid.
+ */
+describe("IP.isIP() anchoring", () => {
+  const VALID_IPV4: Array<string> = [
+    "0.0.0.0",
+    "127.0.0.1",
+    "10.0.0.4",
+    "196.223.149.8",
+    "203.0.113.7",
+    "255.255.255.255",
+  ];
+
+  const VALID_IPV6: Array<string> = [
+    "::",
+    "::1",
+    "fd00::1",
+    "fe80::1",
+    "2001:db8::1",
+    "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+    "2001:db8:0:0:0:0:0:1",
+    "a:b:c:d:e:f:1:2",
+    // Uppercase hex is valid.
+    "2001:DB8::1",
+    // Zone identifier, as reported for link-local addresses.
+    "fe80::1%eth0",
+    // IPv4-mapped, the form Node reports for a dual-stack socket.
+    "::ffff:127.0.0.1",
+    "::ffff:203.0.113.7",
+    "::11.22.33.44",
+    "2001:db8::192.168.0.1",
+  ];
+
+  test.each(VALID_IPV4)("accepts the IPv4 address %s", (value: string) => {
+    expect(IP.isIP(value)).toBe(true);
+    expect(new IP(value).isIPv4()).toBe(true);
+    expect(new IP(value).isIPv6()).toBe(false);
+  });
+
+  test.each(VALID_IPV6)("accepts the IPv6 address %s", (value: string) => {
+    expect(IP.isIP(value)).toBe(true);
+    expect(new IP(value).isIPv6()).toBe(true);
+    expect(new IP(value).isIPv4()).toBe(false);
+  });
+
+  /*
+   * Every one of these was accepted before the pattern was anchored. They are
+   * the whole point of the change, so they are listed out rather than folded
+   * into the generic invalid list below.
+   */
+  const ADDRESS_SHAPED_SUBSTRINGS: Array<string> = [
+    "evil 2001:db8::1 evil",
+    "not-an-ip-::1",
+    "x2001:db8::1",
+    "2001:db8::1x",
+    "<script>::1</script>",
+    // Leading/trailing whitespace is not part of an address.
+    "  ::1  ",
+    "::1 ",
+    " ::1",
+    // A whole forwarded-for chain is a list, not an address.
+    "::1, 1.2.3.4",
+    "2001:db8::1, 198.51.100.5",
+    // A newline is the classic way to smuggle a second value past a check.
+    "2001:db8::1\n1.2.3.4",
+    // Bracketed host:port, which is what a proxy emits for IPv6.
+    "[2001:db8::1]:443",
+    "[2001:db8::1]",
+    // Triple colon is not valid IPv6 -- only one "::" run is allowed.
+    "2001:0db8:85a3:::8a2e:0370:7334",
+    // A CIDR entry is a range, not a single address.
+    "2001:db8::/32",
+    // Out-of-range hex group.
+    "gggg::1",
+    "2001:db8::1::2",
+  ];
+
+  test.each(ADDRESS_SHAPED_SUBSTRINGS)(
+    "rejects %j, which only contains something address-shaped",
+    (value: string) => {
+      expect(IP.isIP(value)).toBe(false);
+    },
+  );
+
+  const NOT_ADDRESSES: Array<string> = [
+    "",
+    " ",
+    "hello",
+    "Invalid IP",
+    "unknown",
+    "localhost",
+    "example.com",
+    "1.2.3.4.5",
+    "1.2.3",
+    "256.1.1.1",
+    "10.0.0.0/8",
+    "203.0.113.7:51234",
+    "-1.0.0.0",
+    "01.02.03.04.05",
+  ];
+
+  test.each(NOT_ADDRESSES)("rejects %j", (value: string) => {
+    expect(IP.isIP(value)).toBe(false);
+  });
+
+  test.each([...ADDRESS_SHAPED_SUBSTRINGS, ...NOT_ADDRESSES])(
+    "constructing an IP from %j throws",
+    (value: string) => {
+      expect(() => {
+        return new IP(value);
+      }).toThrow("IP is not a valid address");
+    },
+  );
+
+  /*
+   * The validators no longer carry the `g` flag. `.test()` on a `g` regex
+   * advances lastIndex between calls, so the same input could otherwise
+   * answer differently depending on how many times it had been asked.
+   */
+  test("answers the same for repeated calls with the same input", () => {
+    for (let i: number = 0; i < 5; i++) {
+      expect(IP.isIP("2001:db8::1")).toBe(true);
+      expect(IP.isIP("127.0.0.1")).toBe(true);
+      expect(IP.isIP("evil 2001:db8::1 evil")).toBe(false);
+    }
+  });
+
+  test("answers the same when interleaving valid and invalid input", () => {
+    const inputs: Array<[string, boolean]> = [
+      ["2001:db8::1", true],
+      ["[2001:db8::1]:443", false],
+      ["2001:db8::1", true],
+      ["::1, 1.2.3.4", false],
+      ["::1", true],
+    ];
+
+    for (const [value, expected] of inputs) {
+      expect(IP.isIP(value)).toBe(expected);
+    }
+  });
+});
+
+describe("IP deserialization rejects invalid addresses", () => {
+  test("fromDatabase throws for an address-shaped substring", () => {
+    expect(() => {
+      return IP.fromDatabase("[2001:db8::1]:443");
+    }).toThrow("IP is not a valid address");
+  });
+
+  test("fromJSON throws for an address-shaped substring", () => {
+    expect(() => {
+      return IP.fromJSON({ _type: ObjectType.IP, value: "evil ::1 evil" });
+    }).toThrow("IP is not a valid address");
+  });
+
+  test("fromJSON round-trips a valid address", () => {
+    const ip: IP = new IP("2001:db8::1");
+    expect(IP.fromJSON(ip.toJSON()).toString()).toBe("2001:db8::1");
+  });
+
+  test("the database transformer throws for an address-shaped substring", () => {
+    expect(() => {
+      return IP.getDatabaseTransformer().from("evil 2001:db8::1 evil");
+    }).toThrow("IP is not a valid address");
+  });
+});
+
+describe("IP.isInWhitelist()", () => {
+  test("matches an exact IPv4 entry", () => {
+    expect(
+      IP.isInWhitelist({ ips: ["203.0.113.7"], whitelist: ["203.0.113.7"] }),
+    ).toBe(true);
+  });
+
+  test("matches an exact IPv6 entry", () => {
+    expect(
+      IP.isInWhitelist({ ips: ["2001:db8::1"], whitelist: ["2001:db8::1"] }),
+    ).toBe(true);
+  });
+
+  test("does not match a different address", () => {
+    expect(
+      IP.isInWhitelist({ ips: ["198.51.100.5"], whitelist: ["203.0.113.7"] }),
+    ).toBe(false);
+  });
+
+  test("matches an IPv4 CIDR range", () => {
+    expect(
+      IP.isInWhitelist({ ips: ["10.1.2.3"], whitelist: ["10.0.0.0/8"] }),
+    ).toBe(true);
+  });
+
+  test("does not match an address outside the CIDR range", () => {
+    expect(
+      IP.isInWhitelist({ ips: ["11.1.2.3"], whitelist: ["10.0.0.0/8"] }),
+    ).toBe(false);
+  });
+
+  test("returns false for an empty whitelist", () => {
+    expect(IP.isInWhitelist({ ips: ["203.0.113.7"], whitelist: [] })).toBe(
+      false,
+    );
+  });
+
+  test("skips blank whitelist entries", () => {
+    expect(
+      IP.isInWhitelist({
+        ips: ["203.0.113.7"],
+        whitelist: ["", "   ", "203.0.113.7"],
+      }),
+    ).toBe(true);
+  });
+
+  /*
+   * The caller is expected to hand this one address it has already resolved.
+   * A value that merely contains an address is not one, and asking about it
+   * is a caller bug -- it throws rather than quietly answering false, which
+   * an access check would then read as a clean deny.
+   */
+  test("throws for an address-shaped substring", () => {
+    expect(() => {
+      return IP.isInWhitelist({
+        ips: ["evil 2001:db8::1 evil"],
+        whitelist: ["2001:db8::1"],
+      });
+    }).toThrow("Invalid IP address");
+  });
+
+  test("throws for a bracketed host:port", () => {
+    expect(() => {
+      return IP.isInWhitelist({
+        ips: ["[2001:db8::1]:443"],
+        whitelist: ["2001:db8::1"],
+      });
+    }).toThrow("Invalid IP address");
+  });
+
+  test("throws for a whole forwarded-for chain passed as one value", () => {
+    expect(() => {
+      return IP.isInWhitelist({
+        ips: ["203.0.113.7, 198.51.100.5"],
+        whitelist: ["203.0.113.7"],
+      });
+    }).toThrow("Invalid IP address");
+  });
+
+  /*
+   * A bracketed or padded spelling of an allowlisted address never matched an
+   * entry anyway -- it just used to reach the comparison instead of being
+   * rejected. Either way it is not granted access.
+   */
+  test("does not grant access to a padded spelling of a listed address", () => {
+    expect(() => {
+      return IP.isInWhitelist({
+        ips: [" 203.0.113.7 "],
+        whitelist: ["203.0.113.7"],
+      });
+    }).toThrow("Invalid IP address");
   });
 });

--- a/Common/Tests/Types/IP/IPv6.test.ts
+++ b/Common/Tests/Types/IP/IPv6.test.ts
@@ -2,8 +2,19 @@ import IP from "../../../Types/IP/IPv6";
 
 describe("IPv6()", () => {
   test("should be IPv6", () => {
-    const ip: IP = new IP("2001:0db8:85a3:::8a2e:0370:7334");
+    const ip: IP = new IP("2001:0db8:85a3::8a2e:0370:7334");
     expect(ip.isIPv6()).toBeTruthy();
+  });
+
+  /*
+   * This address used to be accepted: a triple colon is not valid IPv6, but
+   * the validator was unanchored and matched the address-shaped substring
+   * inside it.
+   */
+  test("should reject an address with a triple colon", () => {
+    expect(() => {
+      new IP("2001:0db8:85a3:::8a2e:0370:7334");
+    }).toThrow("IP is not a valid address");
   });
 
   test("should not be IPv4", () => {

--- a/Common/Types/IP/IP.ts
+++ b/Common/Types/IP/IP.ts
@@ -133,9 +133,30 @@ export default class IP extends DatabaseProperty {
     return this.ip;
   }
 
+  /*
+   * Both validators below are ANCHORED, and deliberately so.
+   *
+   * An unanchored pattern accepts any string that merely CONTAINS something
+   * address-shaped, which is never what a validator should mean. The IPv6
+   * pattern used to be unanchored, so `evil 2001:db8::1 evil`,
+   * `[2001:db8::1]:443` and `2001:0db8:85a3:::8a2e:0370:7334` all reported as
+   * valid addresses. Every consumer of isIP inherited that: an allowlist check
+   * accepted a value it could then never match, a monitor destination stored a
+   * hostname as an IP literal, and IpCanonicalUtil was handed input it could
+   * not canonicalize.
+   *
+   * Neither pattern carries the `g` flag either. `.test()` on a `g` regex is
+   * stateful -- it advances `lastIndex` between calls -- and only happens to
+   * be safe here because the literal is re-created on every call. A hoisted
+   * constant would have made alternate calls silently return the wrong answer.
+   *
+   * Note that neither validator trims: callers pass the exact string they mean
+   * to validate. Whitespace-padded input is rejected, which is how the IPv4
+   * side has always behaved.
+   */
   private static isIPv4(str: string): boolean {
     const regexExp: RegExp =
-      /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/gi;
+      /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/i;
     const result: boolean = regexExp.test(str);
 
     return result;
@@ -143,7 +164,7 @@ export default class IP extends DatabaseProperty {
 
   private static isIPv6(str: string): boolean {
     const regexExp: RegExp =
-      /(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))/gi;
+      /^(?:([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/i;
     return regexExp.test(str);
   }
 


### PR DESCRIPTION
## The bug

`IP.isIPv6`'s regex had no `^`/`$`, so any string that merely **contains** something address-shaped validated as an address:

```ts
IP.isIP("evil 2001:db8::1 evil");            // true
IP.isIP("[2001:db8::1]:443");                // true
IP.isIP("2001:0db8:85a3:::8a2e:0370:7334");  // true -- triple colon isn't valid IPv6
IP.isIP("::1, 1.2.3.4");                     // true -- a list, not an address
```

`isIPv4` immediately above it **was** anchored, so the two halves of the same validator disagreed about what "valid" meant.

## The fix

Wrap the alternation in `^(?:...)$`, and drop the `/g` flag on both validators. `.test()` on a `/g` regex is stateful — it advances `lastIndex` between calls — and was only safe here because the literal is re-created on every call. Hoisting it to a module constant later would have made alternate calls silently return the wrong answer.

## Fallout

Checked every caller of `IP.isIP` / the constructor / `fromJSON` / `fromDatabase`. Nothing depended on the loose behaviour, and two callers get strictly more correct:

- **`NetworkDeviceHydrationUtil`** and **`SnmpMonitor`** branch on `IP.isIP` to tell an IP literal from a DNS name. A hostname containing an address-shaped substring was misclassified as a literal — `SnmpMonitor` would pick the `udp6` transport for a DNS name on that basis.
- **`DashboardService`** / **`StatusPageService`** feed `X-Forwarded-For` entries to `IP.isInWhitelist`, which throws `BadDataException` on an invalid address. Both already **fail closed**: the `catch` logs and falls through to `hasReadAccess: false`, so a throw is a denial, not a 500.
- The **`ipAddress` columns** on `UserSession`, `StatusPagePrivateUserSession` and `RumSessionReplayView` are plain `ShortText` — never routed through `IP` validation, so no stored value is re-parsed.
- **Stored `ipWhitelist` values** are compared as strings against a validated address; entries themselves are never run through `isIP` (CIDR networks go through the already-anchored `isIPv4`).

Every legitimate form still validates — `::`, `::1`, zone IDs (`fe80::1%eth0`), IPv4-mapped (`::ffff:127.0.0.1`, the form Node reports for a dual-stack socket), embedded IPv4, and uppercase hex.

### One behaviour change worth naming

A monitor destination stored as `_type: IP` whose value was only ever accepted because of the loose match — say `[2001:db8::1]:443` typed into the destination field — now throws on `MonitorStep.fromJSON` instead of parsing. Such a value could never have worked as a monitor target anyway.

## Tests

`Common/Tests/Types/IP/IP.test.ts` gains ~120 cases: a table of valid IPv4/IPv6 forms, the substring-rejection cases above, statefulness checks that pin the `/g` removal, deserialization rejection via `fromJSON`/`fromDatabase`/the transformer, and `isInWhitelist` coverage (exact match, CIDR, empty/blank entries, and the throw on a non-address).

`IPv6.test.ts` asserted the triple-colon address was valid IPv6 — that test was pinning the bug, so it now asserts the rejection instead.

All 123 tests in `Tests/Types/IP` pass, as do the downstream suites (`IpCanonicalUtil`, `DashboardPublicSloAPI`, `DashboardPublicAttributeValuesAPI` — 72 tests).

## Relationship to #3171

Found while reviewing #3171 (X-Forwarded-For spoofing). **Not exploitable through that path** — `ClientIp.ts` there guards with an anchored character-class check before calling `IP.isIP`, and explicitly comments that it is compensating for this unanchored pattern. This fixes the root cause for every *other* caller.

The two PRs touch disjoint parts of `IP.ts` (#3171 rewrites `isInWhitelist`; this changes only the two regex methods), so they merge cleanly in either order. Once both land, the compensating comment in `ClientIp.ts` can be relaxed — though the guard is still worth keeping, since it also handles port-stripping and `unknown` placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)