### PR TITLE
fix(on-call): make schedule coverage gaps visible instead of rendering nothing

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/EscalationRule/EscalationRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/EscalationRule/EscalationRules.tsx
@@ -424,6 +424,14 @@ const EscalationRules: FunctionComponent<ComponentProps> = (
             onCallDutyPolicySchedule: {
               _id: true,
               name: true,
+              /*
+               * Whether the schedule has anybody on call right now. Already
+               * persisted and refreshed every minute by the RefreshHandoffTime
+               * worker, so reading it here is free — and without it the chip
+               * below claims a schedule is a responder even when it would
+               * currently page no one.
+               */
+              currentUserIdOnRoster: true,
             },
           },
           sort: {},
@@ -657,20 +665,45 @@ const EscalationRules: FunctionComponent<ComponentProps> = (
   const getScheduleChip: (
     schedule: OnCallDutyPolicySchedule,
   ) => ReactElement = (schedule: OnCallDutyPolicySchedule): ReactElement => {
+    /*
+     * A schedule with nobody on call right now is listed as a responder but
+     * would page no one. Rendering it identically to a healthy schedule makes
+     * a broken escalation level look correctly configured.
+     */
+    const isUncovered: boolean = !schedule.currentUserIdOnRoster;
+
     return (
       <span
         key={`schedule-${schedule.id?.toString()}`}
-        className="inline-flex items-center gap-2 rounded-full bg-white ring-1 ring-inset ring-gray-200 py-1 pl-1 pr-3 shadow-sm"
+        title={
+          isUncovered
+            ? "No one is currently on call in this schedule - this level would not notify anyone right now."
+            : undefined
+        }
+        className={`inline-flex items-center gap-2 rounded-full bg-white py-1 pl-1 pr-3 shadow-sm ring-1 ring-inset ${
+          isUncovered ? "ring-amber-300" : "ring-gray-200"
+        }`}
       >
-        <span className="h-6 w-6 rounded-full bg-indigo-100 flex items-center justify-center">
+        <span
+          className={`flex h-6 w-6 items-center justify-center rounded-full ${
+            isUncovered ? "bg-amber-100" : "bg-indigo-100"
+          }`}
+        >
           <Icon
-            icon={IconProp.Calendar}
-            className="h-3.5 w-3.5 text-indigo-600"
+            icon={isUncovered ? IconProp.Alert : IconProp.Calendar}
+            className={`h-3.5 w-3.5 ${
+              isUncovered ? "text-amber-600" : "text-indigo-600"
+            }`}
           />
         </span>
         <span className="text-sm font-medium text-gray-700">
           {schedule.name?.toString()}
         </span>
+        {isUncovered && (
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-amber-700">
+            No one on call
+          </span>
+        )}
       </span>
     );
   };
@@ -1052,6 +1085,7 @@ const EscalationRules: FunctionComponent<ComponentProps> = (
             label:
               join.onCallDutyPolicySchedule.name?.toString() ||
               "On-call schedule",
+            isUncovered: !join.onCallDutyPolicySchedule.currentUserIdOnRoster,
           });
         }
       }

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/EscalationRule/EscalationSummary.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/EscalationRule/EscalationSummary.tsx
@@ -14,6 +14,12 @@ export type ResponderType = "schedule" | "team" | "user";
 export interface EscalationResponder {
   label: string;
   type: ResponderType;
+  /*
+   * Schedule responders only: true when the schedule currently has nobody on
+   * call. Such a responder exists on paper but would page no one, so it is
+   * drawn in amber rather than identically to a healthy responder.
+   */
+  isUncovered?: boolean | undefined;
 }
 
 export interface EscalationLevelSummary {
@@ -142,13 +148,35 @@ const EscalationSummary: FunctionComponent<ComponentProps> = (
           return (
             <span
               key={`r-${i}`}
-              className="inline-flex items-center gap-1 rounded-md bg-gray-50 px-2 py-0.5 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-200"
+              title={
+                responder.isUncovered
+                  ? "No one is currently on call in this schedule."
+                  : undefined
+              }
+              className={`inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${
+                responder.isUncovered
+                  ? "bg-amber-50 text-amber-700 ring-amber-200"
+                  : "bg-gray-50 text-gray-700 ring-gray-200"
+              }`}
             >
               <Icon
-                icon={responderIcon(responder.type)}
-                className={`h-3 w-3 ${responderIconColor(responder.type)}`}
+                icon={
+                  responder.isUncovered
+                    ? IconProp.Alert
+                    : responderIcon(responder.type)
+                }
+                className={`h-3 w-3 ${
+                  responder.isUncovered
+                    ? "text-amber-500"
+                    : responderIconColor(responder.type)
+                }`}
               />
               {responder.label}
+              {responder.isUncovered && (
+                <span className="text-[10px] font-semibold uppercase tracking-wide">
+                  no one on call
+                </span>
+              )}
             </span>
           );
         })}

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/ExecutionLogs/ExecutionLogsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/ExecutionLogs/ExecutionLogsTable.tsx
@@ -213,6 +213,21 @@ const ExecutionLogsTable: FunctionComponent<ComponentProps> = (
       getElement: (item: OnCallDutyPolicyExecutionLog): ReactElement => {
         if (item["status"] === OnCallDutyPolicyStatus.Completed) {
           return <Pill color={Green} text={OnCallDutyPolicyStatus.Completed} />;
+        } else if (
+          item["status"] === OnCallDutyPolicyStatus.CompletedWithNoNotifications
+        ) {
+          /*
+           * A completed execution that paged nobody is not a success. Rendering
+           * it in the same green as a successful page is how a policy that
+           * silently notified no one goes unnoticed for weeks.
+           */
+          return (
+            <Pill
+              color={Yellow}
+              text={OnCallDutyPolicyStatus.CompletedWithNoNotifications}
+              tooltip="This execution ran to completion without notifying anyone. Usually every escalation rule targeted an on-call schedule that had nobody on call."
+            />
+          );
         } else if (item["status"] === OnCallDutyPolicyStatus.Started) {
           return <Pill color={Yellow} text={OnCallDutyPolicyStatus.Started} />;
         } else if (item["status"] === OnCallDutyPolicyStatus.Scheduled) {

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/ExecutionLogs/ExecutionLogsTimelineTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/ExecutionLogs/ExecutionLogsTimelineTable.tsx
@@ -4,8 +4,10 @@ import BaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBa
 import { Green, Red, Yellow } from "Common/Types/BrandColors";
 import { ErrorFunction, VoidFunction } from "Common/Types/FunctionTypes";
 import ObjectID from "Common/Types/ObjectID";
+import IconProp from "Common/Types/Icon/IconProp";
 import OnCallDutyExecutionLogTimelineStatus from "Common/Types/OnCallDutyPolicy/OnCalDutyExecutionLogTimelineStatus";
 import { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import Icon from "Common/UI/Components/Icon/Icon";
 import ConfirmModal from "Common/UI/Components/Modal/ConfirmModal";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import Pill from "Common/UI/Components/Pill/Pill";
@@ -51,6 +53,17 @@ const ExecutionLogTimelineTable: FunctionComponent<ComponentProps> = (
         }}
         selectMoreFields={{
           statusMessage: true,
+          /*
+           * The schedule this step targeted. Populated by the escalation runner
+           * on every schedule step — including the "nobody was on call" skip,
+           * which is the one row where it is the whole story. Without it, a
+           * coverage-gap skip rendered as `Skipped` / `-` / `-`, indistinguishable
+           * from a duplicate-notification skip.
+           */
+          onCallDutySchedule: {
+            _id: true,
+            name: true,
+          },
         }}
         noItemsMessage={"No notifications sent out so far."}
         showRefreshButton={true}
@@ -170,6 +183,44 @@ const ExecutionLogTimelineTable: FunctionComponent<ComponentProps> = (
                       BaseModel.fromJSON(item["alertSentToUser"], User) as User
                     }
                   />
+                );
+              }
+
+              /*
+               * A step that targeted a schedule but has no recipient means the
+               * schedule had nobody on call. Naming that explicitly is the
+               * difference between "this row is uninteresting" and "this is why
+               * the incident sat unacknowledged".
+               */
+              if (item["onCallDutyScheduleId"]) {
+                return (
+                  <span className="inline-flex items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 ring-1 ring-inset ring-amber-200">
+                    <Icon icon={IconProp.Alert} className="h-3.5 w-3.5" />
+                    No one was on call
+                  </span>
+                );
+              }
+
+              return <p>-</p>;
+            },
+          },
+          {
+            field: {
+              onCallDutySchedule: {
+                name: true,
+              },
+            },
+            title: "Schedule",
+            type: FieldType.Element,
+            hideOnMobile: true,
+            getElement: (
+              item: OnCallDutyPolicyExecutionLogTimeline,
+            ): ReactElement => {
+              if (item["onCallDutySchedule"]?.name) {
+                return (
+                  <span className="text-sm text-gray-700">
+                    {item["onCallDutySchedule"].name.toString()}
+                  </span>
                 );
               }
 

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallPolicySummary.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallPolicySummary.tsx
@@ -29,6 +29,11 @@ interface PolicyOverview {
   teamNames: Array<string>;
   userNames: Array<string>;
   levelsWithNoResponders: number;
+  /*
+   * Levels whose only responders are schedules with nobody on call right now.
+   * These pass the "has responders" check but would still notify no one.
+   */
+  levelsUncoveredBySchedule: number;
 }
 
 // Compact human duration, e.g. "immediately", "5 min", "1 hr 30 min".
@@ -115,7 +120,12 @@ const OnCallPolicySummary: FunctionComponent<ComponentProps> = (
           select: {
             _id: true,
             onCallDutyPolicyEscalationRuleId: true,
-            onCallDutyPolicySchedule: { _id: true, name: true },
+            onCallDutyPolicySchedule: {
+              _id: true,
+              name: true,
+              // See levelsUncoveredBySchedule below.
+              currentUserIdOnRoster: true,
+            },
           },
           sort: {},
         }),
@@ -153,6 +163,18 @@ const OnCallPolicySummary: FunctionComponent<ComponentProps> = (
       const userNamesById: Record<string, string> = {};
       const rulesWithResponders: Set<string> = new Set<string>();
 
+      /*
+       * Rules whose ONLY responders are schedules that currently have nobody on
+       * call. Such a rule passes the "has responders" check above — a join row
+       * exists — but would notify no one if reached right now, which is exactly
+       * the failure this summary is supposed to warn about. Tracked separately
+       * from levelsWithNoResponders because the remedy differs: one needs a
+       * responder added to the rule, the other needs the schedule's coverage
+       * fixed.
+       */
+      const rulesWithCoveredResponders: Set<string> = new Set<string>();
+      const rulesTargetingSchedules: Set<string> = new Set<string>();
+
       for (const join of scheduleJoins.data) {
         const id: string = join.onCallDutyPolicySchedule?.id?.toString() || "";
         if (id) {
@@ -164,6 +186,10 @@ const OnCallPolicySummary: FunctionComponent<ComponentProps> = (
           join.onCallDutyPolicyEscalationRuleId?.toString() || "";
         if (ruleId) {
           rulesWithResponders.add(ruleId);
+          rulesTargetingSchedules.add(ruleId);
+          if (join.onCallDutyPolicySchedule?.currentUserIdOnRoster) {
+            rulesWithCoveredResponders.add(ruleId);
+          }
         }
       }
       for (const join of teamJoins.data) {
@@ -175,6 +201,8 @@ const OnCallPolicySummary: FunctionComponent<ComponentProps> = (
           join.onCallDutyPolicyEscalationRuleId?.toString() || "";
         if (ruleId) {
           rulesWithResponders.add(ruleId);
+          // A team responder is reachable regardless of any schedule's coverage.
+          rulesWithCoveredResponders.add(ruleId);
         }
       }
       for (const join of userJoins.data) {
@@ -189,12 +217,28 @@ const OnCallPolicySummary: FunctionComponent<ComponentProps> = (
           join.onCallDutyPolicyEscalationRuleId?.toString() || "";
         if (ruleId) {
           rulesWithResponders.add(ruleId);
+          // A directly-assigned user is reachable regardless of schedule coverage.
+          rulesWithCoveredResponders.add(ruleId);
         }
       }
 
       const levelsWithNoResponders: number = orderedRules.filter(
         (rule: OnCallDutyPolicyEscalationRule) => {
           return !rulesWithResponders.has(rule.id?.toString() || "");
+        },
+      ).length;
+
+      /*
+       * Levels that DO have responders assigned but would still page nobody
+       * right now, because every responder they have is an uncovered schedule.
+       */
+      const levelsUncoveredBySchedule: number = orderedRules.filter(
+        (rule: OnCallDutyPolicyEscalationRule) => {
+          const ruleId: string = rule.id?.toString() || "";
+          return (
+            rulesTargetingSchedules.has(ruleId) &&
+            !rulesWithCoveredResponders.has(ruleId)
+          );
         },
       ).length;
 
@@ -207,6 +251,7 @@ const OnCallPolicySummary: FunctionComponent<ComponentProps> = (
         teamNames: Object.values(teamNamesById),
         userNames: Object.values(userNamesById),
         levelsWithNoResponders,
+        levelsUncoveredBySchedule,
       });
     } catch (err) {
       setError(API.getFriendlyMessage(err));
@@ -477,6 +522,29 @@ const OnCallPolicySummary: FunctionComponent<ComponentProps> = (
                   along the way{" "}
                   {overview.levelsWithNoResponders === 1 ? "has" : "have"} no
                   responders and will notify no one when reached.
+                </span>
+              </div>
+            ) : (
+              <></>
+            )}
+            {overview.levelsUncoveredBySchedule > 0 ? (
+              <div className="mt-4 flex items-start gap-2 border-t border-amber-200/70 pt-3 text-xs leading-relaxed text-amber-700">
+                <Icon
+                  icon={IconProp.Alert}
+                  className="mt-px h-3.5 w-3.5 flex-shrink-0 text-amber-500"
+                />
+                <span>
+                  <span className="font-semibold">
+                    {overview.levelsUncoveredBySchedule}{" "}
+                    {overview.levelsUncoveredBySchedule === 1
+                      ? "level"
+                      : "levels"}
+                  </span>{" "}
+                  {overview.levelsUncoveredBySchedule === 1 ? "has" : "have"}{" "}
+                  responders assigned, but every one of them is an on-call
+                  schedule with no one on call right now — so{" "}
+                  {overview.levelsUncoveredBySchedule === 1 ? "it" : "they"}{" "}
+                  would still notify no one if reached now.
                 </span>
               </div>
             ) : (

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/FinalScheduleSummary.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/FinalScheduleSummary.tsx
@@ -1,15 +1,18 @@
 import { getColorForUserId, getUserInitials } from "./LayerUserColors";
 import {
+  formatDurationFromSeconds,
   formatRelativeStart,
   formatShiftDuration,
   formatShiftInstant,
 } from "./LayerSummary";
 import Dictionary from "Common/Types/Dictionary";
 import IconProp from "Common/Types/Icon/IconProp";
-import ScheduleShiftUtil, {
+import OneUptimeDate from "Common/Types/Date";
+import {
   CoverageGap,
-  CurrentAndNextShift,
   OnCallShift,
+  ScheduleCoverageState,
+  ScheduleCoverageStatus,
 } from "Common/Types/OnCallDutyPolicy/ScheduleShiftUtil";
 import Icon from "Common/UI/Components/Icon/Icon";
 import React, { FunctionComponent, ReactElement } from "react";
@@ -18,6 +21,17 @@ export interface UserInfo {
   name: string;
   email: string;
 }
+
+/*
+ * Holes shorter than this are real (the detector reports anything above the
+ * engine's own ±1s seams) but too small to be worth a warning row each, so they
+ * are collapsed into a single count. This is a DISPLAY threshold — it never
+ * hides a gap from the coverage percentage or the gap count.
+ */
+const SHORT_GAP_SECONDS: number = 60;
+
+// How many full-size gap warnings to list before collapsing the rest into a count.
+const MAX_SHOWN_GAPS: number = 3;
 
 export interface ComponentProps {
   /*
@@ -33,6 +47,14 @@ export interface ComponentProps {
    * override substitutes).
    */
   userById: Dictionary<UserInfo>;
+  /*
+   * Pre-computed coverage state from ScheduleShiftUtil.getCoverageState. Passed
+   * in rather than derived here so this component and the calendar grid beside
+   * it can never disagree about whether the schedule is covered.
+   */
+  coverage: ScheduleCoverageState;
+  // Link to the layers tab, offered as the remedy when no users are assigned.
+  layersPageLink?: ReactElement | undefined;
 }
 
 const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
@@ -48,14 +70,22 @@ const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
     return getUserInitials(info?.name || "", info?.email || "");
   };
 
-  const { current, next }: CurrentAndNextShift =
-    ScheduleShiftUtil.getCurrentAndNextShift(props.shifts, props.now);
+  const current: OnCallShift | null = props.coverage.current;
+  const next: OnCallShift | null = props.coverage.next;
+  const gaps: Array<CoverageGap> = props.coverage.gaps;
 
-  const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
-    props.shifts,
-    props.now,
-    props.windowEnd,
-  );
+  /*
+   * Split the gaps into ones worth their own warning row and sub-minute slivers
+   * (typically layers whose restriction windows are misaligned by seconds).
+   * Both are counted in the coverage strip; only the first kind gets a row.
+   */
+  const notableGaps: Array<CoverageGap> = gaps.filter((gap: CoverageGap) => {
+    return (
+      OneUptimeDate.getDifferenceInSeconds(gap.end, gap.start) >=
+      SHORT_GAP_SECONDS
+    );
+  });
+  const shortGapCount: number = gaps.length - notableGaps.length;
 
   const upcoming: Array<OnCallShift> = props.shifts
     .filter((shift: OnCallShift) => {
@@ -83,6 +113,33 @@ const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
     );
   };
 
+  /*
+   * The remedy shown under "nobody is on call" depends on WHY nobody is on
+   * call. Telling someone to "widen a layer's active hours" when the real
+   * problem is that no user is assigned to any layer sends them to the wrong
+   * screen entirely.
+   */
+  const getNoCoverageRemedy: () => ReactElement = (): ReactElement => {
+    if (props.coverage.status === ScheduleCoverageStatus.NoUsers) {
+      return (
+        <p className="mt-1 text-xs text-amber-700">
+          No users are assigned to any layer in this schedule, so nobody will
+          ever be paged and every alert routed here will go unanswered.
+          {props.layersPageLink ? (
+            <> Add users on the {props.layersPageLink}.</>
+          ) : null}
+        </p>
+      );
+    }
+
+    return (
+      <p className="mt-1 text-xs text-amber-700">
+        Add a 24/7 fallback layer, or widen a layer&apos;s active hours, to
+        close this gap.
+      </p>
+    );
+  };
+
   const getNowCard: () => ReactElement = (): ReactElement => {
     if (!current) {
       return (
@@ -94,10 +151,7 @@ const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
           <div className="mt-2 text-sm font-medium text-amber-800">
             No one is currently on call in this schedule.
           </div>
-          <p className="mt-1 text-xs text-amber-700">
-            Add a 24/7 fallback layer, or widen a layer&apos;s active hours, to
-            close this gap.
-          </p>
+          {getNoCoverageRemedy()}
         </div>
       );
     }
@@ -166,13 +220,68 @@ const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
     );
   };
 
+  /*
+   * A single always-present line stating how much of the window is covered.
+   * Unlike the gap rows below it, this renders even at 100% coverage — so
+   * "fully covered" is an explicit statement rather than the absence of a
+   * warning, which is indistinguishable from a screen that failed to load.
+   */
+  const getCoverageStrip: () => ReactElement = (): ReactElement => {
+    const percent: number = Math.round(props.coverage.coverageRatio * 100);
+    const isFullyCovered: boolean = props.coverage.gaps.length === 0;
+    const windowDays: number = Math.max(
+      1,
+      Math.round(
+        OneUptimeDate.getDifferenceInSeconds(props.windowEnd, props.now) /
+          86400,
+      ),
+    );
+
+    /*
+     * Round-to-100 would claim full coverage for a schedule with a tiny hole,
+     * which is the exact misreport this whole screen exists to prevent.
+     */
+    const displayPercent: number =
+      !isFullyCovered && percent >= 100 ? 99 : percent;
+
+    return (
+      <div
+        className={`flex flex-wrap items-center gap-x-3 gap-y-1.5 rounded-lg border px-3 py-2 text-xs ${
+          isFullyCovered
+            ? "border-green-200 bg-green-50 text-green-800"
+            : "border-amber-200 bg-amber-50 text-amber-800"
+        }`}
+      >
+        <span className="inline-flex items-center gap-1.5 font-semibold">
+          <Icon
+            icon={isFullyCovered ? IconProp.CheckCircle : IconProp.Alert}
+            className="h-3.5 w-3.5"
+          />
+          {isFullyCovered
+            ? `Fully covered for the next ${windowDays} days`
+            : `${displayPercent}% covered over the next ${windowDays} days`}
+        </span>
+        {!isFullyCovered && (
+          <span>
+            {formatDurationFromSeconds(props.coverage.uncoveredSeconds)}{" "}
+            uncovered across{" "}
+            {props.coverage.gaps.length === 1
+              ? "1 gap"
+              : `${props.coverage.gaps.length} gaps`}
+          </span>
+        )}
+      </div>
+    );
+  };
+
   const getGapWarnings: () => ReactElement = (): ReactElement => {
     /*
-     * Show only the nearest couple of gaps so a heavily-restricted schedule
-     * does not produce a wall of warnings.
+     * Show only the nearest few gaps so a heavily-restricted schedule does not
+     * produce a wall of warnings; the coverage strip above already carries the
+     * full total, so collapsing the tail here loses nothing.
      */
-    const shownGaps: Array<CoverageGap> = gaps.slice(0, 2);
-    const remaining: number = gaps.length - shownGaps.length;
+    const shownGaps: Array<CoverageGap> = notableGaps.slice(0, MAX_SHOWN_GAPS);
+    const remaining: number = notableGaps.length - shownGaps.length;
 
     return (
       <div className="space-y-2">
@@ -189,7 +298,11 @@ const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
               <span>
                 <span className="font-semibold">Coverage gap:</span> no one is
                 on call from {formatShiftInstant(gap.start, props.timezone)} to{" "}
-                {formatShiftInstant(gap.end, props.timezone)}.
+                {formatShiftInstant(gap.end, props.timezone)}
+                <span className="ml-1 text-amber-600">
+                  ({formatShiftDuration(gap.start, gap.end)})
+                </span>
+                .
               </span>
             </div>
           );
@@ -198,6 +311,13 @@ const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
           <div className="text-xs text-amber-700">
             + {remaining} more coverage {remaining === 1 ? "gap" : "gaps"} in
             the coming weeks.
+          </div>
+        )}
+        {shortGapCount > 0 && (
+          <div className="text-xs text-amber-700">
+            + {shortGapCount} coverage {shortGapCount === 1 ? "gap" : "gaps"}{" "}
+            shorter than a minute, usually caused by layers whose active hours
+            are misaligned by a few seconds.
           </div>
         )}
       </div>
@@ -252,6 +372,8 @@ const FinalScheduleSummary: FunctionComponent<ComponentProps> = (
         {getNowCard()}
         {getNextCard()}
       </div>
+
+      {getCoverageStrip()}
 
       {gaps.length > 0 && getGapWarnings()}
 

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerCard.tsx
@@ -266,44 +266,48 @@ const LayerCard: FunctionComponent<ComponentProps> = (
             <SummaryChip icon={IconProp.Clock} text={restrictionSummary} />
           </div>
 
-          {/* Live "who is on call right now" line, derived from the rotation. */}
-          {userCount > 0 && (
-            <div className="mt-2 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-gray-500">
-              <span
-                className="inline-block h-2 w-2 flex-shrink-0 rounded-full"
-                style={{
-                  backgroundColor: currentAndNext.current
-                    ? getColorForUserId(currentAndNext.current.userId)
-                    : "#d1d5db",
-                }}
-              />
-              {currentAndNext.current ? (
+          {/*
+           * Live "who is on call right now" line, derived from the rotation.
+           * Rendered even with no users assigned — that is precisely the case
+           * where this layer can never put anybody on call, so suppressing the
+           * line there (as this used to) hid the most important state it has.
+           */}
+          <div className="mt-2 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-xs text-gray-500">
+            <span
+              className="inline-block h-2 w-2 flex-shrink-0 rounded-full"
+              style={{
+                backgroundColor: currentAndNext.current
+                  ? getColorForUserId(currentAndNext.current.userId)
+                  : "#d1d5db",
+              }}
+            />
+            {currentAndNext.current ? (
+              <span>
+                <span className="font-semibold text-gray-700">
+                  {nameById[currentAndNext.current.userId] || "Unknown user"}
+                </span>{" "}
+                on call now
+              </span>
+            ) : (
+              <span className="text-amber-700">
+                {userCount === 0
+                  ? "No users assigned - this layer never puts anyone on call"
+                  : "No one on call in this layer right now"}
+              </span>
+            )}
+            {currentAndNext.next && (
+              <>
+                <span className="text-gray-300">&middot;</span>
                 <span>
-                  <span className="font-semibold text-gray-700">
-                    {nameById[currentAndNext.current.userId] || "Unknown user"}
+                  Up next{" "}
+                  <span className="font-medium text-gray-700">
+                    {nameById[currentAndNext.next.userId] || "Unknown user"}
                   </span>{" "}
-                  on call now
+                  {formatRelativeStart(currentAndNext.next.start, preview.now)}
                 </span>
-              ) : (
-                <span>No one on call in this layer right now</span>
-              )}
-              {currentAndNext.next && (
-                <>
-                  <span className="text-gray-300">&middot;</span>
-                  <span>
-                    Up next{" "}
-                    <span className="font-medium text-gray-700">
-                      {nameById[currentAndNext.next.userId] || "Unknown user"}
-                    </span>{" "}
-                    {formatRelativeStart(
-                      currentAndNext.next.start,
-                      preview.now,
-                    )}
-                  </span>
-                </>
-              )}
-            </div>
-          )}
+              </>
+            )}
+          </div>
         </div>
 
         {/* Actions */}
@@ -364,7 +368,7 @@ const LayerCard: FunctionComponent<ComponentProps> = (
       {/* Body */}
       {props.isExpanded && (
         <div className="border-t border-gray-200 px-4 py-5 md:px-5">
-          {userCount > 0 && (
+          {userCount > 0 ? (
             <div className="mb-6">
               <LayerRotationSummary
                 layer={layer}
@@ -372,7 +376,26 @@ const LayerCard: FunctionComponent<ComponentProps> = (
                 timezone={props.timezone}
                 events={preview.events}
                 now={preview.now}
+                /*
+                 * A layer only has a fallback if something sits BELOW it in
+                 * priority order. Without this the summary claimed that
+                 * lower-priority layers cover the off-hours even for the last
+                 * layer, where the off-hours are a genuine coverage hole.
+                 */
+                hasLowerPriorityLayer={props.index < props.total - 1}
               />
+            </div>
+          ) : (
+            <div className="mb-6 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-800">
+              <Icon
+                icon={IconProp.Alert}
+                className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-amber-500"
+              />
+              <span>
+                <span className="font-semibold">No users assigned.</span> This
+                layer produces no on-call coverage at all. Add at least one user
+                below, or this layer will never page anyone.
+              </span>
             </div>
           )}
 

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerRotationSummary.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerRotationSummary.tsx
@@ -3,6 +3,7 @@ import {
   formatDurationFromSeconds,
   formatRelativeStart,
   formatShiftInstant,
+  summarizeOffHoursFallback,
   summarizeRestriction,
   summarizeRotation,
 } from "./LayerSummary";
@@ -29,6 +30,12 @@ export interface ComponentProps {
   now: Date;
   // How many upcoming turns to list. Defaults to 5.
   numberOfShifts?: number | undefined;
+  /*
+   * Whether any layer sits BELOW this one in priority order. Decides whether
+   * this layer's off-hours are covered by a fallback or are a genuine hole in
+   * the schedule — the summary must not promise a fallback that does not exist.
+   */
+  hasLowerPriorityLayer: boolean;
 }
 
 interface UserDisplay {
@@ -97,6 +104,15 @@ const LayerRotationSummary: FunctionComponent<ComponentProps> = (
     restrictionTimes,
     props.timezone,
   );
+
+  const offHoursFallback: string | null = summarizeOffHoursFallback({
+    hasRestriction,
+    hasLowerPriorityLayer: props.hasLowerPriorityLayer,
+  });
+
+  // Amber styling when the off-hours are a real hole rather than a hand-over.
+  const isOffHoursUncovered: boolean =
+    hasRestriction && !props.hasLowerPriorityLayer;
 
   /*
    * No renderable users (parent shows its own "add users" prompt, or every row
@@ -264,14 +280,21 @@ const LayerRotationSummary: FunctionComponent<ComponentProps> = (
             next hand-off, then it passes to the next person in order.
           </>
         )}
-        {hasRestriction && (
+        {hasRestriction && offHoursFallback && (
           <>
             {" "}
             Coverage is limited to{" "}
             <span className="font-semibold text-gray-900">
               {restrictionSummary.toLowerCase()}
             </span>
-            ; outside those hours, lower-priority layers take over.
+            ;{" "}
+            <span
+              className={
+                isOffHoursUncovered ? "font-medium text-amber-700" : undefined
+              }
+            >
+              {offHoursFallback}
+            </span>
           </>
         )}
       </p>
@@ -296,11 +319,19 @@ const LayerRotationSummary: FunctionComponent<ComponentProps> = (
               })}
             </ol>
             {hasRestriction && (
-              <p className="mt-2 text-[11px] leading-relaxed text-gray-400">
+              <p
+                className={`mt-2 text-[11px] leading-relaxed ${
+                  isOffHoursUncovered ? "text-amber-700" : "text-gray-400"
+                }`}
+              >
                 Each row shows a person&apos;s full rotation turn; the duration
                 counts only active on-call hours (
-                {restrictionSummary.toLowerCase()}). Outside those hours,
-                lower-priority layers take over.
+                {restrictionSummary.toLowerCase()}).{" "}
+                {summarizeOffHoursFallback({
+                  hasRestriction,
+                  hasLowerPriorityLayer: props.hasLowerPriorityLayer,
+                  capitalize: true,
+                })}
               </p>
             )}
           </>

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerSummary.ts
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerSummary.ts
@@ -150,6 +150,44 @@ export function summarizeRestriction(
   return `${weekly.length} weekly time windows`;
 }
 
+/*
+ * What actually happens outside a restricted layer's active hours.
+ *
+ * This used to be a hard-coded "outside those hours, lower-priority layers take
+ * over" — which is only true when a lower-priority layer EXISTS. For the
+ * bottom-priority layer (and for a schedule with a single layer, the common
+ * case) it was a flat falsehood: a user configuring one Mon-Fri 9-5 layer was
+ * told that nights and weekends were handled, when in fact nobody is on call
+ * then and every alert in that window goes unanswered.
+ *
+ * Returns null when there is nothing to say (no restriction => the layer covers
+ * every hour), so callers can omit the sentence entirely.
+ */
+export function summarizeOffHoursFallback(data: {
+  hasRestriction: boolean;
+  hasLowerPriorityLayer: boolean;
+  /*
+   * The sentence is used both mid-sentence (after a semicolon) and as a
+   * sentence of its own, so the caller states which it needs rather than
+   * slicing the returned string.
+   */
+  capitalize?: boolean | undefined;
+}): string | null {
+  if (!data.hasRestriction) {
+    return null;
+  }
+
+  const sentence: string = data.hasLowerPriorityLayer
+    ? "outside those hours, lower-priority layers take over."
+    : "outside those hours nobody in this schedule is on call — this is the lowest-priority layer, so there is nothing to fall back to.";
+
+  if (!data.capitalize) {
+    return sentence;
+  }
+
+  return sentence.charAt(0).toUpperCase() + sentence.slice(1);
+}
+
 export function summarizeStartsAt(startsAt: Date | undefined): string {
   if (!startsAt) {
     return "Start time not set";

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/Layers.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/Layers.tsx
@@ -13,6 +13,11 @@ import IconProp from "Common/Types/Icon/IconProp";
 import { JSONArray, JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
 import RestrictionTimes from "Common/Types/OnCallDutyPolicy/RestrictionTimes";
+import LayerUtil, { LayerProps } from "Common/Types/OnCallDutyPolicy/Layer";
+import ScheduleShiftUtil, {
+  ScheduleCoverageState,
+  ScheduleCoverageStatus,
+} from "Common/Types/OnCallDutyPolicy/ScheduleShiftUtil";
 import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import Card from "Common/UI/Components/Card/Card";
 import ComponentLoader from "Common/UI/Components/ComponentLoader/ComponentLoader";
@@ -27,6 +32,13 @@ import OnCallDutyPolicyScheduleLayer from "Common/Models/DatabaseModels/OnCallDu
 import OnCallDutyPolicyScheduleLayerUser from "Common/Models/DatabaseModels/OnCallDutyPolicyScheduleLayerUser";
 import OnCallDutyPolicySchedule from "Common/Models/DatabaseModels/OnCallDutyPolicySchedule";
 import React, { FunctionComponent, ReactElement, useEffect } from "react";
+
+/*
+ * Window the coverage banner reasons over. Matches the preview's summary window
+ * so the banner at the top of the page and the gap list at the bottom always
+ * describe the same span of time.
+ */
+const COVERAGE_WINDOW_DAYS: number = 42;
 
 export interface ComponentProps {
   onCallDutyPolicyScheduleId: ObjectID;
@@ -495,6 +507,119 @@ const Layers: FunctionComponent<ComponentProps> = (
     );
   };
 
+  /*
+   * A compact statement of the schedule's coverage, rendered above the layer
+   * cards. Computed with exactly the same LayerUtil + ScheduleShiftUtil pipeline
+   * the preview at the bottom of the page uses, so the two can never disagree.
+   *
+   * Deliberately NOT a blocking form validation: a partially-covered schedule is
+   * a legitimate configuration (an escalation policy may intend a business-hours
+   * layer to fall through to a team). The point is that the consequence is
+   * stated at the moment of editing rather than discovered during an incident.
+   */
+  const coverageBanner: GetReactElementFunction = (): ReactElement => {
+    const now: Date = OneUptimeDate.getCurrentDate();
+    const windowEnd: Date = OneUptimeDate.addRemoveDays(
+      now,
+      COVERAGE_WINDOW_DAYS,
+    );
+
+    const layerProps: Array<LayerProps> = layers.map(
+      (layer: OnCallDutyPolicyScheduleLayer): LayerProps => {
+        const layerId: string = layer.id?.toString() || "";
+        return {
+          users: (layerUsers[layerId] || [])
+            .map((layerUser: OnCallDutyPolicyScheduleLayerUser) => {
+              return layerUser.user!;
+            })
+            .filter(Boolean),
+          startDateTimeOfLayer: layer.startsAt!,
+          handOffTime: layer.handOffTime!,
+          rotation: layer.rotation!,
+          restrictionTimes: layer.restrictionTimes!,
+          timezone: scheduleTimezone,
+        };
+      },
+    );
+
+    const assignedUserCount: number = layerProps.reduce(
+      (total: number, layerProp: LayerProps) => {
+        return total + layerProp.users.length;
+      },
+      0,
+    );
+
+    const coverage: ScheduleCoverageState = ScheduleShiftUtil.getCoverageState({
+      layerCount: layers.length,
+      assignedUserCount,
+      shifts: ScheduleShiftUtil.groupEventsIntoShifts(
+        new LayerUtil().getMultiLayerEvents({
+          calendarStartDate: now,
+          calendarEndDate: windowEnd,
+          layers: layerProps,
+        }),
+      ),
+      now,
+      windowEnd,
+    });
+
+    if (
+      coverage.status === ScheduleCoverageStatus.Covered &&
+      coverage.gaps.length === 0
+    ) {
+      return (
+        <div className="mb-5 flex items-start gap-2 rounded-lg border border-green-200 bg-green-50 px-3 py-2.5 text-xs text-green-800">
+          <Icon
+            icon={IconProp.CheckCircle}
+            className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-green-500"
+          />
+          <span>
+            <span className="font-semibold">Fully covered.</span> Someone is on
+            call at every moment of the next {COVERAGE_WINDOW_DAYS} days.
+          </span>
+        </div>
+      );
+    }
+
+    const percent: number = Math.round(coverage.coverageRatio * 100);
+
+    let message: ReactElement = (
+      <span>
+        <span className="font-semibold">
+          {coverage.gaps.length === 1
+            ? "1 coverage gap"
+            : `${coverage.gaps.length} coverage gaps`}{" "}
+          in the next {COVERAGE_WINDOW_DAYS} days.
+        </span>{" "}
+        Someone is on call for {percent >= 100 ? 99 : percent}% of that window.
+        During the rest, alerts routed to this schedule will notify no one. See
+        the final schedule below for exactly when.
+      </span>
+    );
+
+    if (coverage.status === ScheduleCoverageStatus.NoUsers) {
+      message = (
+        <span>
+          <span className="font-semibold">
+            No users are assigned to any layer.
+          </span>{" "}
+          Nobody is ever on call in this schedule, so every alert routed here
+          will go unanswered. Expand a layer below and add at least one user.
+        </span>
+      );
+    }
+
+    return (
+      <div className="mb-5 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-800">
+        <Icon
+          icon={IconProp.Alert}
+          className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-amber-500"
+        />
+        {message}
+      </div>
+    );
+  };
+
   type SaveScheduleTimezoneFunction = (
     timezone: string | undefined,
   ) => Promise<void>;
@@ -619,6 +744,14 @@ const Layers: FunctionComponent<ComponentProps> = (
         </div>
         <div className="flex-shrink-0">{addLayerButton()}</div>
       </div>
+
+      {/*
+       * Coverage state, stated at the point of EDITING rather than only in the
+       * preview at the bottom of the page. Someone configuring a Mon-Fri layer
+       * gets told immediately that nights and weekends are uncovered, instead of
+       * having to scroll past every layer card to find out.
+       */}
+      {coverageBanner()}
 
       {/* Layer list */}
       <div className="space-y-4">

--- a/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayersPreview.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayersPreview.tsx
@@ -7,13 +7,16 @@ import IconProp from "Common/Types/Icon/IconProp";
 import Dictionary from "Common/Types/Dictionary";
 import LayerUtil, { LayerProps } from "Common/Types/OnCallDutyPolicy/Layer";
 import ScheduleShiftUtil, {
+  CoverageGap,
   OnCallShift,
+  ScheduleCoverageState,
 } from "Common/Types/OnCallDutyPolicy/ScheduleShiftUtil";
 import UserOverrideUtil, {
   OverrideEventMeta,
   UserOverrideRecord,
 } from "Common/Types/OnCallDutyPolicy/UserOverrideUtil";
 import StartAndEndTime from "Common/Types/Time/StartAndEndTime";
+import { VoidFunction } from "Common/Types/FunctionTypes";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
 import GreaterThanOrEqual from "Common/Types/BaseDatabase/GreaterThanOrEqual";
 import IsNull from "Common/Types/BaseDatabase/IsNull";
@@ -42,6 +45,15 @@ import React, {
  * that happen to fall in the calendar's currently-visible range.
  */
 const SUMMARY_WINDOW_DAYS: number = 42;
+
+/*
+ * How often the preview re-reads the wall clock. Everything on this screen is
+ * anchored to "now" — who is on call, which gap contains this instant, how much
+ * of a shift is left — so a value captured once at mount slowly turns into a
+ * lie. A dashboard left open through a hand-off (or through the start of a
+ * coverage gap) would otherwise keep showing the person who WAS on call.
+ */
+const NOW_REFRESH_INTERVAL_MS: number = 30 * 1000;
 
 export interface ComponentProps {
   layers: Array<OnCallDutyPolicyScheduleLayer>;
@@ -110,6 +122,42 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
   const [calendarEvents, setCalendarEvents] = useState<Array<CalendarEvent>>(
     [],
   );
+
+  // Uncovered stretches inside the calendar's currently-visible range.
+  const [calendarGaps, setCalendarGaps] = useState<Array<CoverageGap>>([]);
+
+  /*
+   * "now" is held in state, not read during render, so the coverage state
+   * actually advances while the page is open. setInterval alone is not enough:
+   * browsers throttle (and on mobile, suspend) timers in background tabs, so a
+   * tab restored after hours would show a stale "on call right now" until the
+   * next tick. Re-reading on visibilitychange makes the refresh immediate.
+   */
+  const [now, setNow] = useState<Date>(OneUptimeDate.getCurrentDate());
+
+  useEffect(() => {
+    const tick: VoidFunction = (): void => {
+      setNow(OneUptimeDate.getCurrentDate());
+    };
+
+    const intervalId: ReturnType<typeof setInterval> = setInterval(
+      tick,
+      NOW_REFRESH_INTERVAL_MS,
+    );
+
+    const onVisibilityChange: VoidFunction = (): void => {
+      if (document.visibilityState === "visible") {
+        tick();
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
 
   /*
    * The timezone the preview is DISPLAYED in. Distinct from props.timezone,
@@ -369,8 +417,8 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
     shifts: Array<OnCallShift>;
     now: Date;
     windowEnd: Date;
+    coverage: ScheduleCoverageState;
   } = useMemo(() => {
-    const now: Date = OneUptimeDate.getCurrentDate();
     const windowEnd: Date = OneUptimeDate.addRemoveDays(
       now,
       SUMMARY_WINDOW_DAYS,
@@ -389,12 +437,37 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
       });
     }
 
+    const shifts: Array<OnCallShift> =
+      ScheduleShiftUtil.groupEventsIntoShifts(events);
+
+    /*
+     * assignedUserCount counts ASSIGNMENT ROWS, not distinct people, and is
+     * taken from the layers rather than from the computed events — a schedule
+     * whose layers have no users produces no events at all, and we need to be
+     * able to tell that apart from "users exist but none is on call right now".
+     */
+    const assignedUserCount: number = props.layers.reduce(
+      (total: number, layer: OnCallDutyPolicyScheduleLayer) => {
+        return (
+          total + (props.allLayerUsers[layer.id?.toString() || ""] || []).length
+        );
+      },
+      0,
+    );
+
     return {
-      shifts: ScheduleShiftUtil.groupEventsIntoShifts(events),
+      shifts,
       now,
       windowEnd,
+      coverage: ScheduleShiftUtil.getCoverageState({
+        layerCount: props.layers.length,
+        assignedUserCount,
+        shifts,
+        now,
+        windowEnd,
+      }),
     };
-  }, [props.layers, props.allLayerUsers, props.timezone, overrideRecords]);
+  }, [props.layers, props.allLayerUsers, props.timezone, overrideRecords, now]);
 
   useEffect(() => {
     const layerUtil: LayerUtil = new LayerUtil();
@@ -412,6 +485,26 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
         overrides: overrideRecords,
       });
     }
+
+    /*
+     * Gaps for the VISIBLE range, computed before the events below are
+     * relabelled from user ids to display names. They are drawn as hatched
+     * background bands so an uncovered stretch reads as "we computed this and
+     * nobody is on call" instead of as an empty grid.
+     *
+     * Computed over the calendar's own range rather than reusing the summary's
+     * 42-day window, so navigating to a past or far-future week still shades
+     * that week correctly.
+     */
+    setCalendarGaps(
+      ScheduleShiftUtil.getCoverageGaps(
+        ScheduleShiftUtil.groupEventsIntoShifts(events),
+        startTime,
+        endTime,
+        // Sub-minute slivers would render as invisible hairlines on the grid.
+        { minimumGapSeconds: 60 },
+      ),
+    );
 
     const userById: Dictionary<UserInfo> = {
       ...scheduleUsersById,
@@ -476,6 +569,29 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
     });
   }, [calendarEvents, viewAsTimezone]);
 
+  /*
+   * The same display shift for the uncovered bands. They carry no title —
+   * react-big-calendar draws background events without text — so the "Uncovered"
+   * legend swatch below is what names them.
+   */
+  const displayGapEvents: Array<CalendarEvent> = useMemo(() => {
+    return calendarGaps.map((gap: CoverageGap, index: number) => {
+      return {
+        id: -1 * (index + 1),
+        title: "",
+        allDay: false,
+        start: OneUptimeDate.getLocalDateFromWallClockInTimezone(
+          gap.start,
+          viewAsTimezone,
+        ),
+        end: OneUptimeDate.getLocalDateFromWallClockInTimezone(
+          gap.end,
+          viewAsTimezone,
+        ),
+      };
+    });
+  }, [calendarGaps, viewAsTimezone]);
+
   // "now" shifted into the view zone so the grid opens on that zone's today.
   const displayDefaultDate: Date = useMemo(() => {
     return OneUptimeDate.getLocalDateFromWallClockInTimezone(
@@ -517,20 +633,33 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
        * Textual "who is on call now / next / upcoming" summary of the combined
        * schedule, above the calendar grid it is derived from.
        */}
-      {uniqueUsers.length > 0 && (
+      {/*
+       * Rendered whenever the schedule has layers — NOT only when it has users.
+       * Gating this on "has users" was exactly inverted: a schedule with no
+       * assigned users is permanently uncovered, and it was the one case where
+       * the component that says so never mounted, leaving an empty calendar and
+       * no explanation. FinalScheduleSummary handles zero shifts on its own.
+       */}
+      {props.layers.length > 0 && (
         <FinalScheduleSummary
           shifts={summaryData.shifts}
           now={summaryData.now}
           windowEnd={summaryData.windowEnd}
+          coverage={summaryData.coverage}
           timezone={viewAsTimezone}
           userById={{ ...scheduleUsersById, ...overrideUserInfo }}
         />
       )}
 
-      {uniqueUsers.length > 0 && (
+      {/*
+       * The legend for the grid below. Renders when there is either a colour to
+       * explain or a hatched band to name — a schedule with no users still needs
+       * the "Uncovered" key, since in that case the whole grid is hatched.
+       */}
+      {(uniqueUsers.length > 0 || calendarGaps.length > 0) && (
         <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
           <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">
-            On-Call Users
+            {uniqueUsers.length > 0 ? "On-Call Users" : "Legend"}
           </span>
           {uniqueUsers.map((u: UserColorAssignment) => {
             return (
@@ -552,6 +681,20 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
               </div>
             );
           })}
+          {/*
+           * Names the hatched bands drawn on the grid below. Only shown when
+           * the visible range actually contains one, so a fully-covered week
+           * does not carry a legend entry for something that is not there.
+           */}
+          {calendarGaps.length > 0 && (
+            <div
+              className="inline-flex items-center gap-1.5 rounded-md bg-white px-2 py-1 text-xs text-gray-700 ring-1 ring-inset ring-amber-200"
+              title="Nobody is on call during these hours"
+            >
+              <span className="oneuptime-calendar-gap-swatch inline-block h-2.5 w-2.5 rounded-sm" />
+              <span className="font-medium text-amber-800">Uncovered</span>
+            </div>
+          )}
         </div>
       )}
 
@@ -597,6 +740,7 @@ const LayersPreview: FunctionComponent<ComponentProps> = (
 
       <Calendar
         events={displayEvents}
+        backgroundEvents={displayGapEvents}
         defaultDate={displayDefaultDate}
         onRangeChange={(startEndTime: StartAndEndTime) => {
           /*

--- a/App/FeatureSet/Dashboard/src/Pages/OnCallDuty/OnCallDutySchedule/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/OnCallDuty/OnCallDutySchedule/Index.tsx
@@ -26,10 +26,14 @@ const OnCallDutyScheduleView: FunctionComponent<
 
   let alertTitle: ReactElement | null = null;
 
-  if (
-    onCallSchedule &&
-    (onCallSchedule.currentUserOnRoster || onCallSchedule.nextUserOnRoster)
-  ) {
+  /*
+   * Rendered as soon as the schedule has loaded, NOT only when somebody is on
+   * the roster. The old condition required a current OR next user, which made
+   * the "does not have any users on the roster" branch below unreachable in the
+   * one state it was written for — a schedule with nobody on call now and
+   * nobody scheduled next showed no banner at all.
+   */
+  if (onCallSchedule) {
     alertTitle = (
       <div className="space-y-2">
         {onCallSchedule.currentUserOnRoster && (
@@ -68,10 +72,13 @@ const OnCallDutyScheduleView: FunctionComponent<
         )}
         {!onCallSchedule.currentUserOnRoster && (
           <div>
-            <strong>
-              This schedule does not have any users on the roster.
-            </strong>{" "}
-            <span>This schedule is not currently active. &nbsp;</span>
+            <strong>No one is currently on call in this schedule.</strong>{" "}
+            <span>
+              {onCallSchedule.nextUserOnRoster
+                ? "This is a coverage gap: any alert that escalates to this schedule right now will not page anyone. Coverage resumes at the hand-off below."
+                : "Nobody is on call now and nobody is scheduled next, so every alert that escalates to this schedule will go unanswered. Check the layers below - a layer with no users assigned, or restricted active hours with no 24/7 fallback layer, will leave the schedule uncovered."}
+              &nbsp;
+            </span>
           </div>
         )}
         {onCallSchedule.nextUserOnRoster && (

--- a/App/FeatureSet/Dashboard/src/Pages/OnCallDuty/OnCallDutySchedules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/OnCallDuty/OnCallDutySchedules.tsx
@@ -1,5 +1,8 @@
 import LabelsElement from "Common/UI/Components/Label/Labels";
 import ProjectUtil from "Common/UI/Utils/Project";
+import UserElement from "../../Components/User/User";
+import Icon from "Common/UI/Components/Icon/Icon";
+import IconProp from "Common/Types/Icon/IconProp";
 import PageComponentProps from "../PageComponentProps";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import TimezoneUtil from "Common/UI/Utils/Timezone";
@@ -131,6 +134,21 @@ const OnCallDutyPage: FunctionComponent<
             },
           },
         ]}
+        /*
+         * currentUserOnRoster / nextUserOnRoster back the "On call now" column
+         * below. Both are already persisted on the schedule and refreshed every
+         * minute by the RefreshHandoffTime worker, so this costs no extra work
+         * on the server — the list simply never asked for them before, which is
+         * why an uncovered schedule and a healthy one rendered as identical rows.
+         */
+        selectMoreFields={{
+          rosterNextStartAt: true,
+          nextUserOnRoster: {
+            _id: true,
+            name: true,
+            email: true,
+          },
+        }}
         columns={[
           {
             field: {
@@ -138,6 +156,49 @@ const OnCallDutyPage: FunctionComponent<
             },
             title: "Name",
             type: FieldType.Text,
+          },
+          {
+            field: {
+              currentUserOnRoster: {
+                _id: true,
+                name: true,
+                email: true,
+                profilePictureId: true,
+              },
+            },
+            title: "On Call Now",
+            type: FieldType.Element,
+            /*
+             * Deliberately NOT `noValueMessage: "-"`. A dash is exactly the
+             * silent blank this column exists to replace: "nobody is on call"
+             * is a state worth naming, not missing data.
+             */
+            getElement: (item: OnCallDutySchedule): ReactElement => {
+              if (item.currentUserOnRoster) {
+                return <UserElement user={item.currentUserOnRoster} />;
+              }
+
+              return (
+                <div className="flex flex-col gap-0.5">
+                  <span className="inline-flex w-fit items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 ring-1 ring-inset ring-amber-200">
+                    <Icon icon={IconProp.Alert} className="h-3.5 w-3.5" />
+                    No one on call
+                  </span>
+                  {item.rosterNextStartAt && item.nextUserOnRoster ? (
+                    <span className="text-xs text-gray-400">
+                      Resumes{" "}
+                      {OneUptimeDate.getDateAsLocalFormattedString(
+                        item.rosterNextStartAt,
+                      )}
+                    </span>
+                  ) : (
+                    <span className="text-xs text-gray-400">
+                      No upcoming shifts
+                    </span>
+                  )}
+                </div>
+              );
+            },
           },
           {
             field: {

--- a/App/FeatureSet/Workers/Jobs/OnCallDutyPolicyExecutionLog/ExecutePendingExecutions.ts
+++ b/App/FeatureSet/Workers/Jobs/OnCallDutyPolicyExecutionLog/ExecutePendingExecutions.ts
@@ -11,6 +11,9 @@ import IncidentService from "Common/Server/Services/IncidentService";
 import AlertService from "Common/Server/Services/AlertService";
 import AlertEpisodeService from "Common/Server/Services/AlertEpisodeService";
 import IncidentEpisodeService from "Common/Server/Services/IncidentEpisodeService";
+import OnCallDutyPolicyExecutionLogTimelineService from "Common/Server/Services/OnCallDutyPolicyExecutionLogTimelineService";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import PositiveNumber from "Common/Types/PositiveNumber";
 
 RunCron(
   "OnCallDutyPolicyExecutionLog:ExecutePendingExecutions",
@@ -366,12 +369,42 @@ const executeOnCallPolicy: ExecuteOnCallPolicyFunction = async (
         `No rules to execute and no repeats left. Marking execution as complete.`,
       );
 
+      /*
+       * "Completed" on its own is ambiguous: a policy that walked every
+       * escalation rule and paged nobody — because each rule targeted a
+       * schedule with a coverage gap — reached this line with the same green
+       * "Execution Completed" as one that successfully paged the on-call
+       * engineer, so a policy could notify no one indefinitely without anything
+       * on screen looking wrong.
+       *
+       * Derived from the timeline rows rather than tracked in a counter column:
+       * a row has a recipient exactly when somebody was actually notified, so
+       * this cannot drift out of sync with what really happened, and it needs
+       * no schema change.
+       */
+      const notifiedCount: PositiveNumber =
+        await OnCallDutyPolicyExecutionLogTimelineService.countBy({
+          query: {
+            onCallDutyPolicyExecutionLogId: executionLog.id!,
+            alertSentToUserId: QueryHelper.notNull(),
+          },
+          props: {
+            isRoot: true,
+          },
+        });
+
+      const notifiedSomeone: boolean = notifiedCount.toNumber() > 0;
+
       // mark this as complete as we have no rules to execute.
       await OnCallDutyPolicyExecutionLogService.updateOneById({
         id: executionLog.id!,
         data: {
-          status: OnCallDutyPolicyStatus.Completed,
-          statusMessage: "Execution completed.",
+          status: notifiedSomeone
+            ? OnCallDutyPolicyStatus.Completed
+            : OnCallDutyPolicyStatus.CompletedWithNoNotifications,
+          statusMessage: notifiedSomeone
+            ? "Execution completed."
+            : "Execution completed, but no one was notified. Every escalation rule in this policy reached no one - usually because the on-call schedules it targets had nobody on call.",
         },
         props: {
           isRoot: true,

--- a/App/Tests/Dashboard/LayerOffHoursFallback.test.ts
+++ b/App/Tests/Dashboard/LayerOffHoursFallback.test.ts
@@ -1,0 +1,225 @@
+import { summarizeOffHoursFallback } from "../../FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallScheduleLayer/LayerSummary";
+
+/*
+ * The exact phrase the UI used to print for EVERY restricted layer. On the
+ * lowest-priority layer it is a lie (there is no layer underneath to take
+ * over), so its reappearance in that branch is the regression these tests
+ * exist to catch. Kept as a constant so the check reads the same everywhere.
+ */
+const TAKE_OVER_PHRASE: string = "take over";
+
+/*
+ * Every non-null sentence is rendered straight into the layer header, so it has
+ * to be a real sentence: not blank, and terminated.
+ */
+function expectRenderableSentence(sentence: string | null): void {
+  expect(sentence).not.toBeNull();
+  expect(typeof sentence).toBe("string");
+  expect((sentence as string).trim().length).toBeGreaterThan(0);
+  expect((sentence as string).endsWith(".")).toBe(true);
+}
+
+describe("LayerSummary.summarizeOffHoursFallback: no restriction", () => {
+  /*
+   * An unrestricted layer covers all 24 hours, so there are no "off hours" to
+   * describe at all. Returning a sentence here would tell a 24/7 layer's owner
+   * that some other layer covers them at night, which is both wrong and
+   * alarming. Both lower-priority-layer values must stay null: the presence of
+   * a layer underneath must never be able to resurrect the sentence.
+   */
+  test("returns null when the layer has no restriction, for either lower-priority value", () => {
+    const withLowerLayer: string | null = summarizeOffHoursFallback({
+      hasRestriction: false,
+      hasLowerPriorityLayer: true,
+    });
+    const withoutLowerLayer: string | null = summarizeOffHoursFallback({
+      hasRestriction: false,
+      hasLowerPriorityLayer: false,
+    });
+
+    expect(withLowerLayer).toBeNull();
+    expect(withoutLowerLayer).toBeNull();
+  });
+
+  /*
+   * capitalize is a formatting knob; it must not become an accidental gate that
+   * makes an unrestricted layer produce a sentence.
+   */
+  test("capitalize does not resurrect the sentence for an unrestricted layer", () => {
+    expect(
+      summarizeOffHoursFallback({
+        hasRestriction: false,
+        hasLowerPriorityLayer: true,
+        capitalize: true,
+      }),
+    ).toBeNull();
+    expect(
+      summarizeOffHoursFallback({
+        hasRestriction: false,
+        hasLowerPriorityLayer: false,
+        capitalize: true,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("LayerSummary.summarizeOffHoursFallback: restricted layer with a layer underneath", () => {
+  /*
+   * This is the one configuration in which the historic sentence was actually
+   * true — a restricted layer with a lower-priority layer beneath it really
+   * does hand off outside its hours. The fix must not have thrown the true
+   * case out along with the false one.
+   */
+  test("says lower-priority layers take over", () => {
+    const sentence: string | null = summarizeOffHoursFallback({
+      hasRestriction: true,
+      hasLowerPriorityLayer: true,
+    });
+
+    expectRenderableSentence(sentence);
+    expect(sentence).toContain("lower-priority layers take over");
+  });
+});
+
+describe("LayerSummary.summarizeOffHoursFallback: restricted lowest-priority layer", () => {
+  /*
+   * The bug this whole function exists for: a single Mon-Fri 9-5 layer is the
+   * lowest-priority layer, so nights and weekends are a genuine coverage gap.
+   * The user must be told that in plain words instead of being reassured.
+   * Asserted on meaning rather than exact wording so copy edits stay free.
+   */
+  test("states plainly that nobody is on call outside the restricted hours", () => {
+    const sentence: string | null = summarizeOffHoursFallback({
+      hasRestriction: true,
+      hasLowerPriorityLayer: false,
+    });
+
+    expectRenderableSentence(sentence);
+    expect(sentence as string).toMatch(/nobody/i);
+    expect(sentence as string).toMatch(/nobody[\s\S]*on call/i);
+  });
+
+  /*
+   * The precise regression: any edit that reintroduces the hand-off promise on
+   * the bottom layer — by re-merging the branches, by flipping the
+   * hasLowerPriorityLayer condition, or by pasting the old copy back — puts
+   * "take over" into this string again.
+   */
+  test("never promises a hand-off when there is no layer to hand off to", () => {
+    const plain: string | null = summarizeOffHoursFallback({
+      hasRestriction: true,
+      hasLowerPriorityLayer: false,
+    });
+    const capitalized: string | null = summarizeOffHoursFallback({
+      hasRestriction: true,
+      hasLowerPriorityLayer: false,
+      capitalize: true,
+    });
+
+    expect(plain).not.toContain(TAKE_OVER_PHRASE);
+    expect(capitalized).not.toContain(TAKE_OVER_PHRASE);
+  });
+
+  /*
+   * The two branches must not have collapsed into one shared string; if they
+   * ever read identically, one of the two configurations is being described
+   * wrongly no matter which wording survived.
+   */
+  test("differs from the sentence used when a lower-priority layer exists", () => {
+    const lowest: string | null = summarizeOffHoursFallback({
+      hasRestriction: true,
+      hasLowerPriorityLayer: false,
+    });
+    const withFallback: string | null = summarizeOffHoursFallback({
+      hasRestriction: true,
+      hasLowerPriorityLayer: true,
+    });
+
+    expect(lowest).not.toBe(withFallback);
+  });
+});
+
+describe("LayerSummary.summarizeOffHoursFallback: capitalize option", () => {
+  /*
+   * Callers splice this after a semicolon ("Daily 9-5; outside those hours...")
+   * or print it as its own sentence. Getting the default wrong produces a
+   * mid-sentence capital or a lowercase sentence start in the layer header, so
+   * the default (omitted) must stay lowercase for both branches.
+   */
+  test("omitted capitalize starts lowercase in both branches", () => {
+    const lowest: string | null = summarizeOffHoursFallback({
+      hasRestriction: true,
+      hasLowerPriorityLayer: false,
+    });
+    const withFallback: string | null = summarizeOffHoursFallback({
+      hasRestriction: true,
+      hasLowerPriorityLayer: true,
+    });
+
+    expect(lowest as string).toMatch(/^[a-z]/);
+    expect(withFallback as string).toMatch(/^[a-z]/);
+  });
+
+  /*
+   * An explicit false is the documented way to ask for the mid-sentence form,
+   * so it must behave exactly like omitting the option rather than falling into
+   * some third state.
+   */
+  test("capitalize false is identical to omitting it", () => {
+    const omittedLowest: string | null = summarizeOffHoursFallback({
+      hasRestriction: true,
+      hasLowerPriorityLayer: false,
+    });
+    const explicitFalseLowest: string | null = summarizeOffHoursFallback({
+      hasRestriction: true,
+      hasLowerPriorityLayer: false,
+      capitalize: false,
+    });
+    const omittedWithFallback: string | null = summarizeOffHoursFallback({
+      hasRestriction: true,
+      hasLowerPriorityLayer: true,
+    });
+    const explicitFalseWithFallback: string | null = summarizeOffHoursFallback({
+      hasRestriction: true,
+      hasLowerPriorityLayer: true,
+      capitalize: false,
+    });
+
+    expect(explicitFalseLowest).toBe(omittedLowest);
+    expect(explicitFalseWithFallback).toBe(omittedWithFallback);
+  });
+
+  /*
+   * Capitalizing must only touch the first letter. A naive implementation
+   * (toUpperCase on the whole string, or a sentence-case pass) would shout the
+   * warning or mangle the em-dash clause, and a slice bug would silently drop
+   * the first word of the coverage-gap warning.
+   */
+  test("capitalize true only uppercases the first character, for both branches", () => {
+    const branches: Array<boolean> = [true, false];
+
+    for (const hasLowerPriorityLayer of branches) {
+      const lower: string | null = summarizeOffHoursFallback({
+        hasRestriction: true,
+        hasLowerPriorityLayer: hasLowerPriorityLayer,
+        capitalize: false,
+      });
+      const upper: string | null = summarizeOffHoursFallback({
+        hasRestriction: true,
+        hasLowerPriorityLayer: hasLowerPriorityLayer,
+        capitalize: true,
+      });
+
+      expectRenderableSentence(lower);
+      expectRenderableSentence(upper);
+
+      const lowerText: string = lower as string;
+      const upperText: string = upper as string;
+
+      expect(upperText.charAt(0)).toBe(lowerText.charAt(0).toUpperCase());
+      expect(upperText.charAt(0)).toMatch(/^[A-Z]$/);
+      expect(upperText.slice(1)).toBe(lowerText.slice(1));
+      expect(upperText.length).toBe(lowerText.length);
+    }
+  });
+});

--- a/Common/Models/DatabaseModels/OnCallDutyPolicyFeed.ts
+++ b/Common/Models/DatabaseModels/OnCallDutyPolicyFeed.ts
@@ -37,6 +37,15 @@ export enum OnCallDutyPolicyFeedEventType {
   OwnerTeamRemoved = "OwnerTeamRemoved",
   UserOverrideAdded = "UserOverrideAdded",
   UserOverrideRemoved = "UserOverrideRemoved",
+  /*
+   * A schedule attached to this policy stopped having anybody on call. Distinct
+   * from RosterHandoff, which describes one person replacing another: this is
+   * the case where nobody replaces them, so alerts escalating to that schedule
+   * will page no one. It is the only push signal for a coverage gap — without
+   * it a gap opens in silence and is only discoverable by visiting the
+   * schedule's page and looking.
+   */
+  CoverageGapStarted = "CoverageGapStarted",
 }
 
 @EnableDocumentation()

--- a/Common/Server/Services/OnCallDutyPolicyEscalationRuleScheduleService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyEscalationRuleScheduleService.ts
@@ -85,6 +85,43 @@ export class Service extends DatabaseService<Model> {
         },
       );
 
+    /*
+     * Record the attachment in the policy feed BEFORE the early return below.
+     *
+     * This used to sit at the bottom of the method, after `if (!userOnSchedule)
+     * return`, so attaching a schedule that happened to have nobody on call at
+     * that instant produced no feed item and no workspace message at all — the
+     * audit trail silently depended on the roster state at the moment of the
+     * click. Note the asymmetry it created: the delete path emits its feed item
+     * from onBeforeDelete, which runs unconditionally, so removals were always
+     * recorded while additions could vanish.
+     *
+     * When nobody is on call, the entry says so — attaching a schedule that
+     * currently pages no one is exactly the thing an operator wants to see.
+     */
+    const feedOnCallDutyPolicyId: ObjectID | undefined | null =
+      createdModel.onCallDutyPolicy?.id;
+
+    if (feedOnCallDutyPolicyId) {
+      const noCoverageSuffix: string = userOnSchedule
+        ? ""
+        : " ⚠️ **No one is currently on call in this schedule**, so alerts escalating to this rule will not notify anyone until coverage resumes.";
+
+      await OnCallDutyPolicyFeedService.createOnCallDutyPolicyFeedItem({
+        onCallDutyPolicyId: feedOnCallDutyPolicyId,
+        projectId: createdModel.projectId!,
+        onCallDutyPolicyFeedEventType:
+          OnCallDutyPolicyFeedEventType.OnCallDutyScheduleAdded,
+        displayColor: userOnSchedule ? Gray500 : Red500,
+        feedInfoInMarkdown: `📅 Added on-call schedule **${createdModel.onCallDutyPolicySchedule?.name || ""}** from the [On-Call Policy ${createdModel.onCallDutyPolicy?.name || ""}](${(await OnCallDutyPolicyService.getOnCallDutyPolicyLinkInDashboard(createdModel.projectId!, feedOnCallDutyPolicyId)).toString()}) escalation rule **${createdModel.onCallDutyPolicyEscalationRule?.name}** with order **${createdModel.onCallDutyPolicyEscalationRule?.order}**.${noCoverageSuffix}`,
+        userId: createdModel.createdByUserId || undefined,
+        workspaceNotification: {
+          sendWorkspaceNotification: true,
+          notifyUserId: createdModel.createdByUserId || undefined,
+        },
+      });
+    }
+
     if (!userOnSchedule) {
       return createdItem;
     }
@@ -202,35 +239,10 @@ export class Service extends DatabaseService<Model> {
       eventType,
     });
 
-    // add workspace message.
-
-    const onCallDutyPolicyId: ObjectID | undefined | null =
-      createdModel.onCallDutyPolicy!.id;
-    const projectId: ObjectID | undefined = createdModel.projectId;
-
-    const createdByUserId: ObjectID | undefined | null =
-      createdModel.createdByUserId;
-
-    const onCallSchedule: OnCallDutyPolicySchedule | undefined =
-      createdModel.onCallDutyPolicySchedule;
-    const onCallDutyPolicyName: string | null =
-      createdModel.onCallDutyPolicy?.name || "";
-
-    if (onCallDutyPolicyId) {
-      await OnCallDutyPolicyFeedService.createOnCallDutyPolicyFeedItem({
-        onCallDutyPolicyId: onCallDutyPolicyId,
-        projectId: projectId!,
-        onCallDutyPolicyFeedEventType:
-          OnCallDutyPolicyFeedEventType.OnCallDutyScheduleAdded,
-        displayColor: Gray500,
-        feedInfoInMarkdown: `📅 Added on-call schedule **${onCallSchedule?.name || ""}** from the [On-Call Policy ${onCallDutyPolicyName}](${(await OnCallDutyPolicyService.getOnCallDutyPolicyLinkInDashboard(projectId!, onCallDutyPolicyId!)).toString()}) escalation rule **${createdModel.onCallDutyPolicyEscalationRule?.name}** with order **${createdModel.onCallDutyPolicyEscalationRule?.order}**.`,
-        userId: createdByUserId || undefined,
-        workspaceNotification: {
-          sendWorkspaceNotification: true,
-          notifyUserId: createdByUserId || undefined,
-        },
-      });
-    }
+    /*
+     * The "schedule added" feed item is emitted above, before the
+     * no-one-on-call early return, so it is recorded unconditionally.
+     */
 
     return createdItem;
   }

--- a/Common/Server/Services/OnCallDutyPolicyExecutionLogService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyExecutionLogService.ts
@@ -332,6 +332,12 @@ export class Service extends DatabaseService<Model> {
         return Yellow500;
       case OnCallDutyPolicyStatus.Completed:
         return Green500;
+      /*
+       * Amber, not green: the policy finished, but finishing without paging
+       * anyone is a failure of the thing the policy exists to do.
+       */
+      case OnCallDutyPolicyStatus.CompletedWithNoNotifications:
+        return Yellow500;
       case OnCallDutyPolicyStatus.Error:
         return Red500;
       default:
@@ -349,6 +355,8 @@ export class Service extends DatabaseService<Model> {
         return "▶️";
       case OnCallDutyPolicyStatus.Completed:
         return "🏁";
+      case OnCallDutyPolicyStatus.CompletedWithNoNotifications:
+        return "⚠️";
       case OnCallDutyPolicyStatus.Error:
         return "❌";
       default:

--- a/Common/Server/Services/OnCallDutyPolicyExecutionLogTimelineService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyExecutionLogTimelineService.ts
@@ -91,6 +91,13 @@ export class Service extends DatabaseService<Model> {
           triggeredByIncidentId: true,
           triggeredByAlertId: true,
           triggeredByAlertEpisodeId: true,
+          /*
+           * Was missing from this select while the guard below (and the feed
+           * branch further down) read it — so it was always undefined and every
+           * incident-episode-triggered execution returned early, producing no
+           * on-call feed entries at all for that trigger type.
+           */
+          triggeredByIncidentEpisodeId: true,
           projectId: true,
           status: true,
           statusMessage: true,
@@ -221,21 +228,63 @@ export class Service extends DatabaseService<Model> {
           incidentOrAlertLink = `[Incident Episode ${incidentEpisodeNumberResult.numberWithPrefix || "#" + incidentEpisodeNumberResult.number}](${(await IncidentEpisodeService.getEpisodeLinkInDashboard(onCallDutyPolicyExecutionLogTimeline.projectId!, onCallDutyPolicyExecutionLogTimeline.triggeredByIncidentEpisodeId)).toString()})`;
         }
 
-        let feedInfoInMarkdown: string = `**${this.getEmojiBasedOnStatus(status)} ${incidentOrAlertLink} On-Call Alert ${status} to ${await UserService.getUserMarkdownString(
-          {
-            userId: onCallDutyPolicyExecutionLogTimeline.alertSentToUserId!,
-            projectId: onCallDutyPolicyExecutionLogTimeline.projectId!,
-          },
-        )}**
+        const policyLink: string = `**[${onCallDutyPolicyExecutionLogTimeline.onCallDutyPolicy.name}](${(await OnCallDutyPolicyService.getOnCallDutyPolicyLinkInDashboard(onCallDutyPolicyExecutionLogTimeline.projectId!, onCallDutyPolicyExecutionLogTimeline.onCallDutyPolicy.id!)).toString()})**`;
 
-The on-call policy **[${onCallDutyPolicyExecutionLogTimeline.onCallDutyPolicy.name}](${(await OnCallDutyPolicyService.getOnCallDutyPolicyLinkInDashboard(onCallDutyPolicyExecutionLogTimeline.projectId!, onCallDutyPolicyExecutionLogTimeline.onCallDutyPolicy.id!)).toString()})** has been triggered. The escalation rule **${onCallDutyPolicyExecutionLogTimeline.onCallDutyPolicyEscalationRule?.name}** ${onCallDutyPolicyExecutionLogTimeline.onCallDutySchedule?.name ? String(" and schedule **" + onCallDutyPolicyExecutionLogTimeline.onCallDutySchedule?.name + "**") : ""} were applied. ${await UserService.getUserMarkdownString(
-          {
-            userId: onCallDutyPolicyExecutionLogTimeline.alertSentToUserId!,
-            projectId: onCallDutyPolicyExecutionLogTimeline.projectId!,
-          },
-        )} was alerted. The status of this alert is **${status}** with the message: \`${onCallDutyPolicyExecutionLogTimeline.statusMessage}\`. ${onCallDutyPolicyExecutionLogTimeline.userBelongsToTeam?.name ? "The alert was sent because the user belogs to the team **" + onCallDutyPolicyExecutionLogTimeline.userBelongsToTeam?.name + "** " : ""} ${onCallDutyPolicyExecutionLogTimeline.isAcknowledged ? "The alert was acknowledged at **" + onCallDutyPolicyExecutionLogTimeline.acknowledgedAt + "** " : ""}`;
+        const scheduleClause: string = onCallDutyPolicyExecutionLogTimeline
+          .onCallDutySchedule?.name
+          ? String(
+              " and schedule **" +
+                onCallDutyPolicyExecutionLogTimeline.onCallDutySchedule?.name +
+                "**",
+            )
+          : "";
 
-        if (onCallDutyPolicyExecutionLogTimeline.overridedByUser) {
+        /*
+         * Some timeline rows have NO recipient by construction: a schedule that
+         * currently has nobody on call (a coverage gap), or an escalation rule
+         * with no responders at all. Those rows are exactly the ones an operator
+         * most needs to understand, so they get their own wording.
+         *
+         * Building the "was alerted" sentence for them used to interpolate
+         * `alertSentToUserId!` — a non-null assertion on a field that is never
+         * set here — which rendered a feed entry claiming somebody was paged
+         * when in fact nobody was.
+         */
+        const hasRecipient: boolean = Boolean(
+          onCallDutyPolicyExecutionLogTimeline.alertSentToUserId,
+        );
+
+        let feedInfoInMarkdown: string = "";
+
+        if (!hasRecipient) {
+          const noRecipientReason: string = onCallDutyPolicyExecutionLogTimeline
+            .onCallDutySchedule?.name
+            ? `no one was on call in schedule **${onCallDutyPolicyExecutionLogTimeline.onCallDutySchedule.name}**`
+            : "this escalation rule had no responders";
+
+          feedInfoInMarkdown = `**${this.getEmojiBasedOnStatus(status)} ${incidentOrAlertLink} On-Call Alert ${status} — nobody was notified**
+
+The on-call policy ${policyLink} has been triggered. The escalation rule **${onCallDutyPolicyExecutionLogTimeline.onCallDutyPolicyEscalationRule?.name}**${scheduleClause} were applied, but ${noRecipientReason}, so **no one was notified at this step**. The status of this step is **${status}** with the message: \`${onCallDutyPolicyExecutionLogTimeline.statusMessage}\`.`;
+        } else {
+          feedInfoInMarkdown = `**${this.getEmojiBasedOnStatus(status)} ${incidentOrAlertLink} On-Call Alert ${status} to ${await UserService.getUserMarkdownString(
+            {
+              userId: onCallDutyPolicyExecutionLogTimeline.alertSentToUserId!,
+              projectId: onCallDutyPolicyExecutionLogTimeline.projectId!,
+            },
+          )}**
+
+The on-call policy ${policyLink} has been triggered. The escalation rule **${onCallDutyPolicyExecutionLogTimeline.onCallDutyPolicyEscalationRule?.name}** ${scheduleClause} were applied. ${await UserService.getUserMarkdownString(
+            {
+              userId: onCallDutyPolicyExecutionLogTimeline.alertSentToUserId!,
+              projectId: onCallDutyPolicyExecutionLogTimeline.projectId!,
+            },
+          )} was alerted. The status of this alert is **${status}** with the message: \`${onCallDutyPolicyExecutionLogTimeline.statusMessage}\`. ${onCallDutyPolicyExecutionLogTimeline.userBelongsToTeam?.name ? "The alert was sent because the user belogs to the team **" + onCallDutyPolicyExecutionLogTimeline.userBelongsToTeam?.name + "** " : ""} ${onCallDutyPolicyExecutionLogTimeline.isAcknowledged ? "The alert was acknowledged at **" + onCallDutyPolicyExecutionLogTimeline.acknowledgedAt + "** " : ""}`;
+        }
+
+        if (
+          hasRecipient &&
+          onCallDutyPolicyExecutionLogTimeline.overridedByUser
+        ) {
           feedInfoInMarkdown += `The alert was supposed to be sent to **${await UserService.getUserMarkdownString(
             {
               userId: onCallDutyPolicyExecutionLogTimeline.overridedByUser.id!,

--- a/Common/Server/Services/OnCallDutyPolicyScheduleService.ts
+++ b/Common/Server/Services/OnCallDutyPolicyScheduleService.ts
@@ -39,7 +39,7 @@ import logger, { LogAttributes } from "../Utils/Logger";
 import Semaphore, { SemaphoreMutex } from "../Infrastructure/Semaphore";
 import OnCallDutyPolicyFeedService from "./OnCallDutyPolicyFeedService";
 import { OnCallDutyPolicyFeedEventType } from "../../Models/DatabaseModels/OnCallDutyPolicyFeed";
-import { Green500 } from "../../Types/BrandColors";
+import { Green500, Red500 } from "../../Types/BrandColors";
 import OnCallDutyPolicyTimeLogService from "./OnCallDutyPolicyTimeLogService";
 import OnCallDutyPolicyScheduleLabelRuleEngineService from "./OnCallDutyPolicyScheduleLabelRuleEngineService";
 import OnCallDutyPolicyScheduleOwnerRuleEngineService from "./OnCallDutyPolicyScheduleOwnerRuleEngineService";
@@ -542,6 +542,66 @@ export class Service extends DatabaseService<OnCallDutyPolicySchedule> {
               },
             )}**.`,
             userId: sendEmailToUserId || undefined,
+            workspaceNotification: {
+              sendWorkspaceNotification: true,
+              notifyUserId: undefined,
+            },
+          });
+        }
+
+        /*
+         * Somebody was on call and now nobody is. This branch is the mirror of
+         * the two above and used to be missing entirely: the "now on-call"
+         * branch requires a NEW user to exist, and the "no longer on-call"
+         * branch notifies only the departing person — who is precisely the one
+         * individual that can no longer do anything about it. So a schedule
+         * running off the end of its rotation, or into restricted hours with no
+         * fallback layer, opened a coverage gap in complete silence.
+         *
+         * Deliberately NOT tied to a user notification bundle (email/SMS/call):
+         * there is no on-call person to send it to. It goes to the policy feed
+         * and out to the workspace channel, where whoever owns the policy sees it.
+         */
+        if (
+          previousInformation.currentUserIdOnRoster?.toString() &&
+          !newInformation.currentUserIdOnRoster?.toString()
+        ) {
+          const onCallDutyPolicyId: ObjectID =
+            escalationRule.onCallDutyPolicy!.id!;
+
+          const policyLink: string = (
+            await OnCallDutyPolicyService.getOnCallDutyPolicyLinkInDashboard(
+              projectId!,
+              onCallDutyPolicyId!,
+            )
+          ).toString();
+
+          /*
+           * When a next user is known, say when coverage resumes — that turns
+           * "nobody is on call" from an alarm into an actionable window.
+           */
+          const resumesClause: string = newInformation.nextUserIdOnRoster
+            ? ` Coverage resumes at **${OneUptimeDate.getDateAsFormattedStringInMultipleTimezones(
+                {
+                  date:
+                    newInformation.nextRosterStartAt ||
+                    newInformation.nextHandOffTimeAt ||
+                    OneUptimeDate.getCurrentDate(),
+                  timezones: [Timezone.GMT],
+                },
+              )}** with **${await UserService.getUserMarkdownString({
+                userId: newInformation.nextUserIdOnRoster,
+                projectId: projectId!,
+              })}**.`
+            : " No further shifts are scheduled, so this schedule will keep paging no one until it is fixed.";
+
+          await OnCallDutyPolicyFeedService.createOnCallDutyPolicyFeedItem({
+            onCallDutyPolicyId: onCallDutyPolicyId,
+            projectId: projectId!,
+            onCallDutyPolicyFeedEventType:
+              OnCallDutyPolicyFeedEventType.CoverageGapStarted,
+            displayColor: Red500,
+            feedInfoInMarkdown: `⚠️ **Coverage gap: no one is on call in schedule ${onCallSchedule.name}.** [On-Call Policy ${escalationRule.onCallDutyPolicy?.name}](${policyLink}) escalation rule **${escalationRule.onCallDutyPolicyEscalationRule?.name}** with order **${escalationRule.onCallDutyPolicyEscalationRule?.order}** targets this schedule, so any alert that escalates to it right now will notify nobody.${resumesClause}`,
             workspaceNotification: {
               sendWorkspaceNotification: true,
               notifyUserId: undefined,

--- a/Common/Server/Services/UserService.ts
+++ b/Common/Server/Services/UserService.ts
@@ -133,6 +133,17 @@ export class Service extends DatabaseService<Model> {
     userId: ObjectID;
     projectId: ObjectID;
   }): Promise<string> {
+    /*
+     * Callers reach this through non-null assertions on nullable columns (an
+     * on-call timeline row for a coverage gap has no recipient, for example).
+     * Querying with an undefined id is not a harmless no-op — the id key is
+     * dropped from the WHERE clause, so the query degrades into "any user" and
+     * would name an arbitrary person. Fail closed instead.
+     */
+    if (!data.userId) {
+      return "";
+    }
+
     const user: Model | null = await this.findOneBy({
       query: {
         _id: data.userId,

--- a/Common/Tests/Server/Services/OnCallDutyPolicyExecutionLogTimelineGapFeed.test.ts
+++ b/Common/Tests/Server/Services/OnCallDutyPolicyExecutionLogTimelineGapFeed.test.ts
@@ -1,0 +1,394 @@
+import OnCallDutyPolicyExecutionLogTimelineService from "../../../Server/Services/OnCallDutyPolicyExecutionLogTimelineService";
+import IncidentFeedService from "../../../Server/Services/IncidentFeedService";
+import IncidentEpisodeFeedService from "../../../Server/Services/IncidentEpisodeFeedService";
+import IncidentService from "../../../Server/Services/IncidentService";
+import IncidentEpisodeService from "../../../Server/Services/IncidentEpisodeService";
+import OnCallDutyPolicyService from "../../../Server/Services/OnCallDutyPolicyService";
+import UserService from "../../../Server/Services/UserService";
+import Model from "../../../Models/DatabaseModels/OnCallDutyPolicyExecutionLogTimeline";
+import OnCallDutyExecutionLogTimelineStatus from "../../../Types/OnCallDutyPolicy/OnCalDutyExecutionLogTimelineStatus";
+import ObjectID from "../../../Types/ObjectID";
+import URL from "../../../Types/API/URL";
+import logger from "../../../Server/Utils/Logger";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+
+/*
+ * addToIncidentOrAlertFeed turns an on-call execution timeline row into the
+ * human-readable entry that lands in the incident feed and the workspace channel.
+ *
+ * Some rows have NO recipient by construction: the escalation runner writes a
+ * `Skipped` row carrying only a schedule id when that schedule currently has
+ * nobody on call (a coverage gap), and another when a rule has no responders at
+ * all. Those rows are exactly the ones an operator most needs to understand —
+ * they are the reason an incident sat unacknowledged.
+ *
+ * The builder used to interpolate `alertSentToUserId!` unconditionally: a
+ * non-null assertion on a column that is never set for those rows. The result
+ * was a feed entry asserting that somebody "was alerted" when in fact nobody
+ * was. These tests pin the branch that now distinguishes the two, and the
+ * separate fail-closed guard in UserService that stops an undefined id from
+ * degrading into a query that matches an arbitrary user.
+ *
+ * Everything is stubbed at the service boundary — no Postgres involved.
+ */
+
+const service: any = OnCallDutyPolicyExecutionLogTimelineService as any;
+
+/*
+ * The REAL getUserMarkdownString, captured at module load — before the
+ * beforeEach below swaps in a stub for the feed-builder tests. The guard tests
+ * at the bottom of this file must exercise the real implementation; calling
+ * UserService.getUserMarkdownString there would hit the stub and pass
+ * vacuously.
+ */
+const realGetUserMarkdownString: (data: {
+  userId: ObjectID;
+  projectId: ObjectID;
+}) => Promise<string> = UserService.getUserMarkdownString.bind(UserService);
+
+const PROJECT_ID: ObjectID = new ObjectID("project1");
+const TIMELINE_ID: ObjectID = new ObjectID("timeline1");
+const POLICY_ID: ObjectID = new ObjectID("policy1");
+const INCIDENT_ID: ObjectID = new ObjectID("incident1");
+const INCIDENT_EPISODE_ID: ObjectID = new ObjectID("incidentEpisode1");
+const USER_ID: ObjectID = new ObjectID("user1");
+
+// Markdown captured from whichever feed service the builder routed to.
+interface CapturedFeed {
+  target: string;
+  markdown: string;
+}
+
+let captured: Array<CapturedFeed> = [];
+
+// Saved originals, restored in afterEach so suites stay independent.
+const originals: Record<string, any> = {};
+
+/*
+ * Overrides are a loose record rather than Partial<Model>: the suite needs to
+ * set relation/id fields back to undefined to describe rows the runner really
+ * writes, and exactOptionalPropertyTypes forbids that on the model type.
+ */
+type BuildRowFunction = (overrides: Record<string, unknown>) => Model;
+
+/*
+ * A timeline row as the builder's own findOneById would return it: relations
+ * already resolved, ids present. Defaults describe an incident-triggered
+ * `Skipped` step against a named schedule with NO recipient — the coverage-gap
+ * shape.
+ */
+const buildRow: BuildRowFunction = (
+  overrides: Record<string, unknown>,
+): Model => {
+  return {
+    _id: TIMELINE_ID,
+    projectId: PROJECT_ID,
+    status: OnCallDutyExecutionLogTimelineStatus.Skipped,
+    statusMessage:
+      "Skipped because no active users are found in this schedule.",
+    triggeredByIncidentId: INCIDENT_ID,
+    onCallDutyPolicy: {
+      name: "Production Paging",
+      id: POLICY_ID,
+    },
+    onCallDutyPolicyEscalationRule: {
+      name: "Level 1",
+      id: new ObjectID("rule1"),
+    },
+    onCallDutySchedule: {
+      name: "Weekend Rotation",
+      id: new ObjectID("schedule1"),
+    },
+    ...overrides,
+  } as unknown as Model;
+};
+
+beforeEach(() => {
+  captured = [];
+
+  /*
+   * Logger is noisy here (the builder debug-logs the whole row); silence it so
+   * a failing assertion is readable.
+   */
+  originals["loggerDebug"] = logger.debug;
+  (logger as any).debug = () => {};
+
+  originals["findOneById"] = service.findOneById;
+
+  originals["incidentFeed"] = IncidentFeedService.createIncidentFeedItem;
+  (IncidentFeedService as any).createIncidentFeedItem = async (data: {
+    feedInfoInMarkdown: string;
+  }): Promise<void> => {
+    captured.push({ target: "incident", markdown: data.feedInfoInMarkdown });
+  };
+
+  originals["incidentEpisodeFeed"] =
+    IncidentEpisodeFeedService.createIncidentEpisodeFeedItem;
+  (IncidentEpisodeFeedService as any).createIncidentEpisodeFeedItem =
+    async (data: { feedInfoInMarkdown: string }): Promise<void> => {
+      captured.push({
+        target: "incidentEpisode",
+        markdown: data.feedInfoInMarkdown,
+      });
+    };
+
+  originals["incidentNumber"] = IncidentService.getIncidentNumber;
+  (IncidentService as any).getIncidentNumber = async (): Promise<{
+    number: number | null;
+    numberWithPrefix: string | null;
+  }> => {
+    return { number: 12, numberWithPrefix: "#12" };
+  };
+
+  originals["incidentLink"] = IncidentService.getIncidentLinkInDashboard;
+  (IncidentService as any).getIncidentLinkInDashboard =
+    async (): Promise<URL> => {
+      return URL.fromString("https://oneuptime.test/incident/12");
+    };
+
+  originals["episodeNumber"] = IncidentEpisodeService.getEpisodeNumber;
+  (IncidentEpisodeService as any).getEpisodeNumber = async (): Promise<{
+    number: number | null;
+    numberWithPrefix: string | null;
+  }> => {
+    return { number: 7, numberWithPrefix: "#7" };
+  };
+
+  originals["episodeLink"] = IncidentEpisodeService.getEpisodeLinkInDashboard;
+  (IncidentEpisodeService as any).getEpisodeLinkInDashboard =
+    async (): Promise<URL> => {
+      return URL.fromString("https://oneuptime.test/incident-episode/7");
+    };
+
+  originals["policyLink"] =
+    OnCallDutyPolicyService.getOnCallDutyPolicyLinkInDashboard;
+  (OnCallDutyPolicyService as any).getOnCallDutyPolicyLinkInDashboard =
+    async (): Promise<URL> => {
+      return URL.fromString("https://oneuptime.test/policy/1");
+    };
+
+  originals["userMarkdown"] = UserService.getUserMarkdownString;
+  (UserService as any).getUserMarkdownString = async (data: {
+    userId: ObjectID;
+  }): Promise<string> => {
+    /*
+     * Mirrors the real guard: a falsy id yields an empty string rather than a
+     * name. If the builder ever calls this for a gap row, the assertions below
+     * catch the resulting "alerted to <nothing>" sentence.
+     */
+    if (!data.userId) {
+      return "";
+    }
+    return "[Alice](https://oneuptime.test/user/1)";
+  };
+});
+
+afterEach(() => {
+  (logger as any).debug = originals["loggerDebug"];
+  service.findOneById = originals["findOneById"];
+  (IncidentFeedService as any).createIncidentFeedItem =
+    originals["incidentFeed"];
+  (IncidentEpisodeFeedService as any).createIncidentEpisodeFeedItem =
+    originals["incidentEpisodeFeed"];
+  (IncidentService as any).getIncidentNumber = originals["incidentNumber"];
+  (IncidentService as any).getIncidentLinkInDashboard =
+    originals["incidentLink"];
+  (IncidentEpisodeService as any).getEpisodeNumber = originals["episodeNumber"];
+  (IncidentEpisodeService as any).getEpisodeLinkInDashboard =
+    originals["episodeLink"];
+  (OnCallDutyPolicyService as any).getOnCallDutyPolicyLinkInDashboard =
+    originals["policyLink"];
+  (UserService as any).getUserMarkdownString = originals["userMarkdown"];
+});
+
+type RunBuilderFunction = (row: Model) => Promise<void>;
+
+const runBuilder: RunBuilderFunction = async (row: Model): Promise<void> => {
+  service.findOneById = async (): Promise<Model> => {
+    return row;
+  };
+
+  await OnCallDutyPolicyExecutionLogTimelineService.addToIncidentOrAlertFeed({
+    onCallDutyPolicyExecutionLogTimelineId: TIMELINE_ID,
+  });
+};
+
+describe("OnCallDutyPolicyExecutionLogTimelineService gap feed entries", () => {
+  describe("a step with no recipient", () => {
+    test("never claims anyone was alerted", async () => {
+      await runBuilder(buildRow({}));
+
+      expect(captured).toHaveLength(1);
+
+      /*
+       * The exact sentence that used to be produced for these rows. Its
+       * reappearance means the non-null assertion is back.
+       */
+      expect(captured[0]!.markdown).not.toContain("was alerted");
+    });
+
+    test("names the uncovered schedule as the reason nobody was paged", async () => {
+      await runBuilder(buildRow({}));
+
+      expect(captured[0]!.markdown).toContain("nobody was notified");
+      expect(captured[0]!.markdown).toContain("no one was on call in schedule");
+      expect(captured[0]!.markdown).toContain("Weekend Rotation");
+      expect(captured[0]!.markdown).toContain(
+        "no one was notified at this step",
+      );
+    });
+
+    test("falls back to the no-responders wording when no schedule was targeted", async () => {
+      /*
+       * The sibling case: a rule with no responders at all writes a Skipped row
+       * with neither a recipient nor a schedule. Blaming a schedule here would
+       * send the operator to the wrong screen.
+       */
+      await runBuilder(buildRow({ onCallDutySchedule: undefined }));
+
+      expect(captured[0]!.markdown).toContain(
+        "this escalation rule had no responders",
+      );
+      expect(captured[0]!.markdown).not.toContain("on call in schedule");
+    });
+
+    test("still carries the policy, rule and status message", async () => {
+      await runBuilder(buildRow({}));
+
+      const markdown: string = captured[0]!.markdown;
+      expect(markdown).toContain("Production Paging");
+      expect(markdown).toContain("Level 1");
+      expect(markdown).toContain(
+        "Skipped because no active users are found in this schedule.",
+      );
+    });
+
+    test("does not render an empty user link where a name would go", async () => {
+      await runBuilder(buildRow({}));
+
+      /*
+       * Guards the specific visual symptom of the old bug: "On-Call Alert
+       * Skipped to " followed by nothing, because getUserMarkdownString
+       * returned "" for the undefined id.
+       */
+      expect(captured[0]!.markdown).not.toContain("Skipped to ");
+      expect(captured[0]!.markdown).not.toContain("to **");
+    });
+  });
+
+  describe("a step that did notify someone", () => {
+    test("keeps the original alerted wording", async () => {
+      await runBuilder(
+        buildRow({
+          status: OnCallDutyExecutionLogTimelineStatus.NotificationSent,
+          statusMessage: "Notification sent.",
+          alertSentToUserId: USER_ID,
+        }),
+      );
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0]!.markdown).toContain("was alerted");
+      expect(captured[0]!.markdown).toContain("Alice");
+      expect(captured[0]!.markdown).not.toContain("nobody was notified");
+    });
+  });
+
+  describe("incident episode triggers", () => {
+    /*
+     * triggeredByIncidentEpisodeId was missing from the builder's own select
+     * while the guard below it read that field, so it was always undefined and
+     * EVERY incident-episode execution returned before writing anything. The
+     * episode feed branch was unreachable dead code.
+     *
+     * This test drives the builder with a row that only has an episode id — the
+     * shape the fixed select now produces — and asserts an entry is written.
+     */
+    test("produce a feed entry rather than being silently dropped", async () => {
+      await runBuilder(
+        buildRow({
+          triggeredByIncidentId: undefined,
+          triggeredByIncidentEpisodeId: INCIDENT_EPISODE_ID,
+        }),
+      );
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0]!.target).toBe("incidentEpisode");
+      expect(captured[0]!.markdown).toContain("Incident Episode");
+    });
+
+    test("carry the same no-recipient wording as other trigger types", async () => {
+      await runBuilder(
+        buildRow({
+          triggeredByIncidentId: undefined,
+          triggeredByIncidentEpisodeId: INCIDENT_EPISODE_ID,
+        }),
+      );
+
+      expect(captured[0]!.markdown).toContain("nobody was notified");
+      expect(captured[0]!.markdown).not.toContain("was alerted");
+    });
+  });
+
+  describe("rows with no trigger at all", () => {
+    test("are skipped without writing a feed entry", async () => {
+      await runBuilder(
+        buildRow({
+          triggeredByIncidentId: undefined,
+        }),
+      );
+
+      expect(captured).toHaveLength(0);
+    });
+  });
+});
+
+describe("UserService.getUserMarkdownString fail-closed guard", () => {
+  test("returns an empty string for a missing user id without querying", async () => {
+    /*
+     * Callers reach this through non-null assertions on nullable columns. An
+     * undefined id must not reach the query layer: the id key would be dropped
+     * from the WHERE clause, degrading the lookup into "any user" and naming an
+     * arbitrary person in a feed entry. Fail closed instead.
+     */
+    const originalFindOneBy: any = (UserService as any).findOneBy;
+    let queried: boolean = false;
+
+    (UserService as any).findOneBy = async (): Promise<null> => {
+      queried = true;
+      return null;
+    };
+
+    try {
+      const result: string = await realGetUserMarkdownString({
+        userId: undefined as unknown as ObjectID,
+        projectId: PROJECT_ID,
+      });
+
+      expect(result).toBe("");
+      expect(queried).toBe(false);
+    } finally {
+      (UserService as any).findOneBy = originalFindOneBy;
+    }
+  });
+
+  test("still queries when a real user id is supplied", async () => {
+    const originalFindOneBy: any = (UserService as any).findOneBy;
+    let queried: boolean = false;
+
+    (UserService as any).findOneBy = async (): Promise<null> => {
+      queried = true;
+      return null;
+    };
+
+    try {
+      await realGetUserMarkdownString({
+        userId: USER_ID,
+        projectId: PROJECT_ID,
+      });
+
+      expect(queried).toBe(true);
+    } finally {
+      (UserService as any).findOneBy = originalFindOneBy;
+    }
+  });
+});

--- a/Common/Tests/Types/OnCallDutyPolicy/ScheduleCoverageEndToEnd.test.ts
+++ b/Common/Tests/Types/OnCallDutyPolicy/ScheduleCoverageEndToEnd.test.ts
@@ -1,0 +1,489 @@
+import User from "../../../Models/DatabaseModels/User";
+import CalendarEvent from "../../../Types/Calendar/CalendarEvent";
+import OneUptimeDate from "../../../Types/Date";
+import EventInterval from "../../../Types/Events/EventInterval";
+import Recurring from "../../../Types/Events/Recurring";
+import LayerUtil, { LayerProps } from "../../../Types/OnCallDutyPolicy/Layer";
+import RestrictionTimes, {
+  RestrictionType,
+  WeeklyResctriction,
+} from "../../../Types/OnCallDutyPolicy/RestrictionTimes";
+import ScheduleShiftUtil, {
+  CoverageGap,
+  OnCallShift,
+  ScheduleCoverageState,
+  ScheduleCoverageStatus,
+} from "../../../Types/OnCallDutyPolicy/ScheduleShiftUtil";
+
+/*
+ * End-to-end coverage of the pipeline every on-call UI surface actually runs:
+ *
+ *   LayerUtil.getMultiLayerEvents -> ScheduleShiftUtil.groupEventsIntoShifts
+ *     -> getCoverageGaps / getCoverageState
+ *
+ * The individual stages have their own exhaustive suites, but the headline bug
+ * (a schedule with a coverage gap rendering as nothing at all) lived in the
+ * COMPOSITION: the engine legitimately emits zero events for an unassigned
+ * layer, and the consumer treated "no events" as "nothing to warn about"
+ * instead of "nobody is ever on call". These tests pin the composed behaviour
+ * so a change in any single stage that breaks the whole cannot pass unnoticed.
+ *
+ * Every layer declares an explicit "UTC" schedule timezone and every instant is
+ * built from a fixed ISO string, so restriction wall-clock windows resolve
+ * identically no matter which timezone the test process runs in.
+ */
+
+const UTC_ZONE: string = "UTC";
+
+const at: (iso: string) => Date = (iso: string): Date => {
+  return OneUptimeDate.fromString(iso);
+};
+
+function user(id: string): User {
+  return {
+    id: {
+      toString: (): string => {
+        return id;
+      },
+    } as any,
+  } as User;
+}
+
+function rotation(
+  intervalType: EventInterval,
+  intervalCount: number,
+): Recurring {
+  return Recurring.fromJSON({
+    _type: "Recurring",
+    value: {
+      intervalType: intervalType,
+      intervalCount: { _type: "PositiveNumber", value: intervalCount },
+    },
+  } as any);
+}
+
+function noRestriction(): RestrictionTimes {
+  const restrictionTimes: RestrictionTimes = new RestrictionTimes();
+  restrictionTimes.restictionType = RestrictionType.None;
+  restrictionTimes.dayRestrictionTimes = null;
+  return restrictionTimes;
+}
+
+/*
+ * A weekly restriction window authored by its wall-clock start/end. The engine
+ * derives the enforced weekday from the timestamp itself (startDay/endDay are
+ * informational), so the instants must land on the intended day.
+ */
+function weeklyWindow(startISO: string, endISO: string): WeeklyResctriction {
+  const startTime: Date = at(startISO);
+  const endTime: Date = at(endISO);
+
+  return {
+    startDay: OneUptimeDate.getDayOfWeek(startTime, UTC_ZONE),
+    endDay: OneUptimeDate.getDayOfWeek(endTime, UTC_ZONE),
+    startTime,
+    endTime,
+  };
+}
+
+/*
+ * The single most common real-world schedule shape: office hours, Mon-Fri
+ * 09:00-17:00. Authored as five separate weekday windows (one continuous
+ * Mon 09:00 -> Fri 17:00 window would wrongly cover the nights too).
+ */
+function businessHoursRestriction(): RestrictionTimes {
+  const restrictionTimes: RestrictionTimes = new RestrictionTimes();
+  restrictionTimes.restictionType = RestrictionType.Weekly;
+  restrictionTimes.weeklyRestrictionTimes = [
+    weeklyWindow("2026-01-05T09:00:00Z", "2026-01-05T17:00:00Z"),
+    weeklyWindow("2026-01-06T09:00:00Z", "2026-01-06T17:00:00Z"),
+    weeklyWindow("2026-01-07T09:00:00Z", "2026-01-07T17:00:00Z"),
+    weeklyWindow("2026-01-08T09:00:00Z", "2026-01-08T17:00:00Z"),
+    weeklyWindow("2026-01-09T09:00:00Z", "2026-01-09T17:00:00Z"),
+  ];
+  return restrictionTimes;
+}
+
+/*
+ * Window anchored on a Monday so weekday-restricted expectations (nights,
+ * weekends) are easy to reason about, and long enough that a weekend falls
+ * strictly INSIDE it — a trailing weekend would be swallowed by the deliberate
+ * "no trailing gap" rule and would not prove anything.
+ */
+const WINDOW_START: Date = at("2026-01-05T00:00:00Z");
+const WINDOW_END: Date = at("2026-01-19T00:00:00Z");
+const WINDOW_SECONDS: number = 14 * 24 * 3600;
+
+const HANDOFF: Date = at("2026-01-05T09:00:00Z");
+
+function expand(layers: Array<LayerProps>): Array<CalendarEvent> {
+  const util: LayerUtil = new LayerUtil();
+
+  return util.getMultiLayerEvents({
+    layers: layers,
+    calendarStartDate: WINDOW_START,
+    calendarEndDate: WINDOW_END,
+  });
+}
+
+function shiftsFor(layers: Array<LayerProps>): Array<OnCallShift> {
+  return ScheduleShiftUtil.groupEventsIntoShifts(expand(layers));
+}
+
+function secondsOf(gap: CoverageGap): number {
+  return OneUptimeDate.getDifferenceInSeconds(gap.end, gap.start);
+}
+
+/*
+ * Assert a boundary lands on the authored wall-clock instant, allowing for the
+ * engine's own one-second artifact: LayerUtil resumes each segment with
+ * addRemoveSeconds(end, 1), so a restriction window entered from a preceding
+ * fully-restricted period opens at 09:00:01 rather than 09:00:00. One second is
+ * the whole budget on purpose — this is the tolerance that was lowered from 90s
+ * because a wider one silently absorbed genuine sub-minute misalignments.
+ */
+function expectInstantNear(actual: Date, expected: Date): void {
+  expect(
+    Math.abs(OneUptimeDate.getDifferenceInSeconds(actual, expected)),
+  ).toBeLessThanOrEqual(1);
+}
+
+describe("Schedule coverage end to end (LayerUtil -> shifts -> gaps/state)", () => {
+  describe("a layer with nobody assigned", () => {
+    /*
+     * The headline bug, composed. Layer.isDataValid short-circuits on an empty
+     * user list, so the engine emits zero events — which is indistinguishable
+     * from "quiet window" unless the consumer is told the assigned-user count.
+     * This is a PERMANENT 100% coverage hole, and the UI used to gate its gap
+     * warning on `assignedUserCount > 0`, i.e. it rendered the warning in every
+     * case EXCEPT the one that needed it.
+     */
+    const unassignedLayer: LayerProps = {
+      users: [],
+      startDateTimeOfLayer: WINDOW_START,
+      handOffTime: HANDOFF,
+      restrictionTimes: noRestriction(),
+      rotation: rotation(EventInterval.Day, 1),
+      timezone: UTC_ZONE,
+    };
+
+    test("produces no events and therefore no shifts", () => {
+      const events: Array<CalendarEvent> = expand([unassignedLayer]);
+
+      expect(events).toHaveLength(0);
+      expect(ScheduleShiftUtil.groupEventsIntoShifts(events)).toHaveLength(0);
+    });
+
+    test("reports one gap spanning the entire window", () => {
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        shiftsFor([unassignedLayer]),
+        WINDOW_START,
+        WINDOW_END,
+      );
+
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0]!.start).toEqual(WINDOW_START);
+      expect(gaps[0]!.end).toEqual(WINDOW_END);
+    });
+
+    test("resolves to NoUsers rather than to a merely uncovered instant", () => {
+      const state: ScheduleCoverageState = ScheduleShiftUtil.getCoverageState({
+        layerCount: 1,
+        assignedUserCount: 0,
+        shifts: shiftsFor([unassignedLayer]),
+        now: WINDOW_START,
+        windowEnd: WINDOW_END,
+      });
+
+      /*
+       * NoUsers must win over UncoveredNow: the remedy differs ("assign users"
+       * vs "widen the active hours"), and only the explicit status keeps a
+       * caller from silently falling through to a covered-looking render.
+       */
+      expect(state.status).toBe(ScheduleCoverageStatus.NoUsers);
+      expect(state.current).toBeNull();
+      expect(state.next).toBeNull();
+      expect(state.uncoveredSeconds).toBe(WINDOW_SECONDS);
+      expect(state.coverageRatio).toBe(0);
+    });
+  });
+
+  describe("a single unrestricted 24/7 layer", () => {
+    const alwaysOnLayer: LayerProps = {
+      users: [user("solo")],
+      startDateTimeOfLayer: WINDOW_START,
+      handOffTime: HANDOFF,
+      restrictionTimes: noRestriction(),
+      rotation: rotation(EventInterval.Day, 1),
+      timezone: UTC_ZONE,
+    };
+
+    test("collapses a fortnight of daily handoffs into one uninterrupted shift", () => {
+      /*
+       * A single-user daily rotation emits one segment per rotation period, each
+       * starting exactly one second after the previous ends. Those seams are the
+       * engine's own artifact, not coverage holes, so the summary must show one
+       * continuous stretch — not fourteen suspicious-looking fragments.
+       */
+      const shifts: Array<OnCallShift> = shiftsFor([alwaysOnLayer]);
+
+      expect(shifts).toHaveLength(1);
+      expect(shifts[0]!.userId).toBe("solo");
+      expect(shifts[0]!.start).toEqual(WINDOW_START);
+      expect(shifts[0]!.end).toEqual(WINDOW_END);
+    });
+
+    test("reports no gaps and full coverage over the whole window", () => {
+      const state: ScheduleCoverageState = ScheduleShiftUtil.getCoverageState({
+        layerCount: 1,
+        assignedUserCount: 1,
+        shifts: shiftsFor([alwaysOnLayer]),
+        now: WINDOW_START,
+        windowEnd: WINDOW_END,
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.Covered);
+      expect(state.gaps).toHaveLength(0);
+      expect(state.uncoveredSeconds).toBe(0);
+      expect(state.coverageRatio).toBe(1);
+      expect(state.current?.userId).toBe("solo");
+    });
+  });
+
+  describe("a single Mon-Fri 09:00-17:00 layer", () => {
+    const officeHoursLayer: LayerProps = {
+      users: [user("dayshift")],
+      startDateTimeOfLayer: WINDOW_START,
+      handOffTime: HANDOFF,
+      restrictionTimes: businessHoursRestriction(),
+      rotation: rotation(EventInterval.Day, 1),
+      timezone: UTC_ZONE,
+    };
+
+    test("yields one shift per business day across the two weeks", () => {
+      const shifts: Array<OnCallShift> = shiftsFor([officeHoursLayer]);
+
+      expect(shifts).toHaveLength(10);
+      expectInstantNear(shifts[0]!.start, at("2026-01-05T09:00:00Z"));
+      expectInstantNear(shifts[0]!.end, at("2026-01-05T17:00:00Z"));
+      expectInstantNear(shifts[9]!.start, at("2026-01-16T09:00:00Z"));
+      expectInstantNear(shifts[9]!.end, at("2026-01-16T17:00:00Z"));
+    });
+
+    test("reports the morning, every night and the weekend as gaps", () => {
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        shiftsFor([officeHoursLayer]),
+        WINDOW_START,
+        WINDOW_END,
+      );
+
+      /*
+       * One leading gap (midnight until the first 09:00) plus one gap between
+       * each pair of the ten business-day shifts. The stretch after the last
+       * Friday is deliberately NOT reported: it is an artifact of where the
+       * summary window happens to end, not a misconfiguration.
+       */
+      expect(gaps).toHaveLength(10);
+      expect(gaps[0]!.start).toEqual(WINDOW_START);
+      expectInstantNear(gaps[0]!.end, at("2026-01-05T09:00:00Z"));
+
+      const weekendGaps: Array<CoverageGap> = gaps.filter(
+        (gap: CoverageGap) => {
+          return secondsOf(gap) > 24 * 3600;
+        },
+      );
+
+      expect(weekendGaps).toHaveLength(1);
+      expectInstantNear(weekendGaps[0]!.start, at("2026-01-09T17:00:00Z"));
+      expectInstantNear(weekendGaps[0]!.end, at("2026-01-12T09:00:00Z"));
+    });
+
+    test("never reports a sub-minute gap, so engine seams cannot masquerade as holes", () => {
+      /*
+       * The regression this guards: the weekly expansion tiles restriction
+       * windows week by week and advances segments with +/-1s steps. If any of
+       * those seams leaked into the gap list, the schedule page would display a
+       * list of one-second "coverage holes" that no operator can act on — the
+       * noise that motivated a 90s contiguity tolerance, which in turn silently
+       * hid genuine sub-minute misalignments.
+       */
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        shiftsFor([officeHoursLayer]),
+        WINDOW_START,
+        WINDOW_END,
+      );
+
+      expect(gaps.length).toBeGreaterThan(0);
+
+      for (const gap of gaps) {
+        expect(secondsOf(gap)).toBeGreaterThanOrEqual(60);
+      }
+    });
+
+    test("resolves to UncoveredNow — not NoUsers — when now falls in an off-hours gap", () => {
+      /*
+       * Users ARE assigned here, so the remedy is "extend the active hours or
+       * add a fallback layer", never "assign somebody". Conflating this with
+       * NoUsers is what the explicit status enum exists to prevent.
+       */
+      const state: ScheduleCoverageState = ScheduleShiftUtil.getCoverageState({
+        layerCount: 1,
+        assignedUserCount: 1,
+        shifts: shiftsFor([officeHoursLayer]),
+        now: at("2026-01-06T03:00:00Z"),
+        windowEnd: WINDOW_END,
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.UncoveredNow);
+      expect(state.current).toBeNull();
+      expect(state.next).not.toBeNull();
+      expectInstantNear(state.next!.start, at("2026-01-06T09:00:00Z"));
+      expect(state.uncoveredSeconds).toBeGreaterThan(0);
+      expect(state.coverageRatio).toBeLessThan(1);
+    });
+  });
+
+  describe("a business-hours layer stacked over a 24/7 fallback", () => {
+    /*
+     * The configuration operators are told to use to close the off-hours holes
+     * above. The lower-priority layer is trimmed around the higher-priority
+     * windows by the priority merge, which leaves +/-1s seams everywhere the
+     * two meet — so this is simultaneously the test that those seams do not
+     * resurface as gaps once the layers are composed.
+     */
+    const layers: Array<LayerProps> = [
+      {
+        users: [user("primary")],
+        startDateTimeOfLayer: WINDOW_START,
+        handOffTime: HANDOFF,
+        restrictionTimes: businessHoursRestriction(),
+        rotation: rotation(EventInterval.Day, 1),
+        timezone: UTC_ZONE,
+      },
+      {
+        users: [user("fallback-a"), user("fallback-b")],
+        startDateTimeOfLayer: WINDOW_START,
+        handOffTime: HANDOFF,
+        restrictionTimes: noRestriction(),
+        rotation: rotation(EventInterval.Week, 1),
+        timezone: UTC_ZONE,
+      },
+    ];
+
+    test("closes every off-hours hole the restricted layer leaves", () => {
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        shiftsFor(layers),
+        WINDOW_START,
+        WINDOW_END,
+      );
+
+      expect(gaps).toHaveLength(0);
+    });
+
+    test("still hands the business-hours user the daytime and the fallback the night", () => {
+      const shifts: Array<OnCallShift> = shiftsFor(layers);
+
+      const onCallAt: (instant: Date) => string | null = (
+        instant: Date,
+      ): string | null => {
+        for (const shift of shifts) {
+          if (
+            OneUptimeDate.isOnOrBefore(shift.start, instant) &&
+            OneUptimeDate.isAfter(shift.end, instant)
+          ) {
+            return shift.userId;
+          }
+        }
+        return null;
+      };
+
+      expect(onCallAt(at("2026-01-06T12:00:00Z"))).toBe("primary");
+      expect(onCallAt(at("2026-01-06T03:00:00Z"))).not.toBe("primary");
+      expect(onCallAt(at("2026-01-06T03:00:00Z"))).not.toBeNull();
+      // Saturday: the restricted layer is silent, so the fallback owns the day.
+      expect(onCallAt(at("2026-01-10T12:00:00Z"))).not.toBe("primary");
+      expect(onCallAt(at("2026-01-10T12:00:00Z"))).not.toBeNull();
+    });
+
+    test("reports full coverage from an off-hours instant", () => {
+      const state: ScheduleCoverageState = ScheduleShiftUtil.getCoverageState({
+        layerCount: 2,
+        assignedUserCount: 3,
+        shifts: shiftsFor(layers),
+        now: at("2026-01-06T03:00:00Z"),
+        windowEnd: WINDOW_END,
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.Covered);
+      expect(state.current).not.toBeNull();
+      expect(state.uncoveredSeconds).toBe(0);
+      expect(state.coverageRatio).toBe(1);
+    });
+  });
+
+  describe("a multi-user 24/7 rotation", () => {
+    const rotatingLayer: LayerProps = {
+      users: [user("A"), user("B"), user("C")],
+      startDateTimeOfLayer: WINDOW_START,
+      handOffTime: HANDOFF,
+      restrictionTimes: noRestriction(),
+      rotation: rotation(EventInterval.Day, 1),
+      timezone: UTC_ZONE,
+    };
+
+    test("hands over between users without leaving a hole at any handoff", () => {
+      /*
+       * Each handoff is a user change, so the shifts CANNOT merge and every
+       * boundary is exposed. A one-second handoff seam being treated as a real
+       * hole here would flag a perfectly healthy rotation as broken fourteen
+       * times over.
+       */
+      const shifts: Array<OnCallShift> = shiftsFor([rotatingLayer]);
+
+      expect(shifts.length).toBeGreaterThan(10);
+
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        shifts,
+        WINDOW_START,
+        WINDOW_END,
+      );
+
+      expect(gaps).toHaveLength(0);
+
+      for (let index: number = 1; index < shifts.length; index++) {
+        const seamSeconds: number = OneUptimeDate.getDifferenceInSeconds(
+          shifts[index]!.start,
+          shifts[index - 1]!.end,
+        );
+        expect(seamSeconds).toBeLessThanOrEqual(1);
+      }
+    });
+
+    test("cycles the users in order across the whole window", () => {
+      const shifts: Array<OnCallShift> = shiftsFor([rotatingLayer]);
+      const order: Array<string> = ["A", "B", "C"];
+
+      shifts.forEach((shift: OnCallShift, index: number) => {
+        expect(shift.userId).toBe(order[index % order.length]);
+      });
+    });
+
+    test("resolves the current and next on-call user mid-rotation", () => {
+      const state: ScheduleCoverageState = ScheduleShiftUtil.getCoverageState({
+        layerCount: 1,
+        assignedUserCount: 3,
+        shifts: shiftsFor([rotatingLayer]),
+        now: at("2026-01-08T12:00:00Z"),
+        windowEnd: WINDOW_END,
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.Covered);
+      expect(state.gaps).toHaveLength(0);
+      expect(state.coverageRatio).toBe(1);
+      expect(state.current).not.toBeNull();
+      expect(state.next).not.toBeNull();
+      expect(state.next!.userId).not.toBe(state.current!.userId);
+      expect(state.next!.start).toEqual(at("2026-01-09T09:00:01Z"));
+    });
+  });
+});

--- a/Common/Tests/Types/OnCallDutyPolicy/ScheduleCoverageGapTolerance.test.ts
+++ b/Common/Tests/Types/OnCallDutyPolicy/ScheduleCoverageGapTolerance.test.ts
@@ -1,0 +1,479 @@
+import CalendarEvent from "../../../Types/Calendar/CalendarEvent";
+import OneUptimeDate from "../../../Types/Date";
+import EventInterval from "../../../Types/Events/EventInterval";
+import Recurring from "../../../Types/Events/Recurring";
+import LayerUtil, { LayerProps } from "../../../Types/OnCallDutyPolicy/Layer";
+import RestrictionTimes, {
+  RestrictionType,
+} from "../../../Types/OnCallDutyPolicy/RestrictionTimes";
+import ScheduleShiftUtil, {
+  CoverageGap,
+  CurrentAndNextShift,
+  OnCallShift,
+  ScheduleCoverageState,
+  ScheduleCoverageStatus,
+} from "../../../Types/OnCallDutyPolicy/ScheduleShiftUtil";
+import User from "../../../Models/DatabaseModels/User";
+
+/*
+ * Pins the contiguity / gap tolerance of the coverage detector, which was
+ * lowered from 90 seconds to 5 seconds.
+ *
+ * At 90s the detector silently swallowed genuine sub-minute coverage holes: two
+ * layers whose active hours were misaligned by a minute reported FULL coverage,
+ * so the one screen that should have warned "nobody is on call" showed nothing.
+ * The tolerance only exists to absorb the on-call engine's own artifacts, which
+ * are exactly one second wide (LayerUtil advances segments with
+ * addRemoveSeconds(end, 1) and the multi-layer priority merge leaves seams of
+ * the same +/-1s magnitude). These tests fence the tolerance in from both
+ * sides: over-tightening below the 1s artifact would flood the UI with phantom
+ * gaps, and loosening it back towards a minute would re-hide real holes.
+ */
+
+// Build a CalendarEvent the way LayerUtil emits one: user id in `title`.
+const event: (userId: string, start: Date, end: Date) => CalendarEvent = (
+  userId: string,
+  start: Date,
+  end: Date,
+): CalendarEvent => {
+  return {
+    id: 0,
+    title: userId,
+    allDay: false,
+    start,
+    end,
+  };
+};
+
+const at: (iso: string) => Date = (iso: string): Date => {
+  return OneUptimeDate.fromString(iso);
+};
+
+const mkShift: (userId: string, start: Date, end: Date) => OnCallShift = (
+  userId: string,
+  start: Date,
+  end: Date,
+): OnCallShift => {
+  return {
+    userId,
+    start,
+    end,
+    coverageSeconds: OneUptimeDate.getDifferenceInSeconds(end, start),
+  };
+};
+
+const user: (id: string) => User = (id: string): User => {
+  return {
+    id: {
+      toString: (): string => {
+        return id;
+      },
+    } as any,
+  } as User;
+};
+
+const noRestriction: () => RestrictionTimes = (): RestrictionTimes => {
+  const restriction: RestrictionTimes = new RestrictionTimes();
+  restriction.restictionType = RestrictionType.None;
+  restriction.dayRestrictionTimes = null;
+  return restriction;
+};
+
+const dailyRotation: () => Recurring = (): Recurring => {
+  return Recurring.fromJSON({
+    _type: "Recurring",
+    value: {
+      intervalType: EventInterval.Day,
+      intervalCount: { _type: "PositiveNumber", value: 1 },
+    },
+  } as any);
+};
+
+// A one-day summary window with the handover sitting in the middle of it.
+const WINDOW_START: Date = at("2024-01-01T09:00:00Z");
+const HANDOVER: Date = at("2024-01-01T17:00:00Z");
+const WINDOW_END: Date = at("2024-01-02T09:00:00Z");
+
+/*
+ * Two shifts belonging to DIFFERENT users, separated by a hole of exactly
+ * `holeSeconds`. Different users matter: same-user segments can be collapsed by
+ * the grouper, whereas a hole between two people is the misconfiguration this
+ * detector exists to surface.
+ */
+const shiftsWithHoleOf: (holeSeconds: number) => Array<OnCallShift> = (
+  holeSeconds: number,
+): Array<OnCallShift> => {
+  return [
+    mkShift("alice", WINDOW_START, HANDOVER),
+    mkShift(
+      "bob",
+      OneUptimeDate.addRemoveSeconds(HANDOVER, holeSeconds),
+      WINDOW_END,
+    ),
+  ];
+};
+
+const eventsWithHoleOf: (
+  userId: string,
+  holeSeconds: number,
+) => Array<CalendarEvent> = (
+  userId: string,
+  holeSeconds: number,
+): Array<CalendarEvent> => {
+  return [
+    event(userId, WINDOW_START, HANDOVER),
+    event(
+      userId,
+      OneUptimeDate.addRemoveSeconds(HANDOVER, holeSeconds),
+      WINDOW_END,
+    ),
+  ];
+};
+
+describe("Schedule coverage gap tolerance", () => {
+  describe("engine artifacts stay invisible", () => {
+    test("a one-second seam between two different users is not a gap", () => {
+      /*
+       * This is the exact artifact the tolerance exists for: the multi-layer
+       * priority merge hands over from one user to the next with a 1s seam.
+       * Tightening the tolerance below this would paint a phantom gap at every
+       * single handover in the schedule.
+       */
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        shiftsWithHoleOf(1),
+        WINDOW_START,
+        WINDOW_END,
+      );
+
+      expect(gaps).toEqual([]);
+    });
+
+    test("a one-second seam between the same user merges into one shift", () => {
+      /*
+       * LayerUtil splits one rotation turn into several segments joined by
+       * addRemoveSeconds(end, 1). If these did not merge, a single overnight
+       * turn would render as a stack of near-identical rows.
+       */
+      const shifts: Array<OnCallShift> =
+        ScheduleShiftUtil.groupEventsIntoShifts(eventsWithHoleOf("alice", 1));
+
+      expect(shifts).toHaveLength(1);
+      expect(shifts[0]!.userId).toBe("alice");
+      expect(shifts[0]!.start).toEqual(WINDOW_START);
+      expect(shifts[0]!.end).toEqual(WINDOW_END);
+    });
+
+    test("real LayerUtil rotation output produces no phantom gaps", () => {
+      /*
+       * Guards the tolerance against the engine it has to tolerate, rather than
+       * against a hand-written approximation of it: if LayerUtil's segment
+       * seams ever widen past the tolerance, this fails instead of the UI
+       * quietly filling with gaps nobody scheduled.
+       */
+      const layerStart: Date = at("2026-01-01T00:00:00Z");
+      const calendarEnd: Date = OneUptimeDate.addRemoveDays(layerStart, 5);
+
+      const layer: LayerProps = {
+        users: [user("alice"), user("bob")],
+        startDateTimeOfLayer: layerStart,
+        handOffTime: OneUptimeDate.addRemoveHours(layerStart, 12),
+        restrictionTimes: noRestriction(),
+        rotation: dailyRotation(),
+      };
+
+      const events: Array<CalendarEvent> = new LayerUtil().getEvents({
+        ...layer,
+        calendarStartDate: layerStart,
+        calendarEndDate: calendarEnd,
+      });
+
+      const shifts: Array<OnCallShift> =
+        ScheduleShiftUtil.groupEventsIntoShifts(events);
+
+      // A 24/7 rotation with two users must alternate, not collapse into one shift.
+      expect(shifts.length).toBeGreaterThan(1);
+
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        shifts,
+        layerStart,
+        shifts[shifts.length - 1]!.end,
+      );
+
+      expect(gaps).toEqual([]);
+    });
+  });
+
+  describe("genuine sub-minute holes are reported again", () => {
+    test("a 60-second hole between two different users is a gap", () => {
+      /*
+       * The regression this whole change is about: two layers misaligned by one
+       * minute. At the old 90s tolerance this reported perfect coverage.
+       */
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        shiftsWithHoleOf(60),
+        WINDOW_START,
+        WINDOW_END,
+      );
+
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0]!.start).toEqual(HANDOVER);
+      expect(gaps[0]!.end).toEqual(at("2024-01-01T17:01:00Z"));
+    });
+
+    test("getCoverageState still bills the 60-second hole while somebody is on call now", () => {
+      /*
+       * A schedule can be Covered at this instant and still be broken later in
+       * the day. The status must not be allowed to mask the upcoming hole, which
+       * is what a caller renders the warning from.
+       */
+      const state: ScheduleCoverageState = ScheduleShiftUtil.getCoverageState({
+        layerCount: 2,
+        assignedUserCount: 2,
+        shifts: shiftsWithHoleOf(60),
+        now: WINDOW_START,
+        windowEnd: WINDOW_END,
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.Covered);
+      expect(state.current?.userId).toBe("alice");
+      expect(state.gaps).toHaveLength(1);
+      expect(state.uncoveredSeconds).toBe(60);
+      expect(state.coverageRatio).toBeCloseTo((86400 - 60) / 86400, 10);
+    });
+
+    test("a same-user hole wider than the tolerance stays two separate shifts", () => {
+      /*
+       * The tolerance drives merging as well as gap reporting. At 90s a
+       * one-minute hole inside one person's coverage was absorbed into a single
+       * shift, so the summary claimed continuous cover that did not exist.
+       */
+      const shifts: Array<OnCallShift> =
+        ScheduleShiftUtil.groupEventsIntoShifts(eventsWithHoleOf("alice", 60));
+
+      expect(shifts).toHaveLength(2);
+
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        shifts,
+        WINDOW_START,
+        WINDOW_END,
+      );
+
+      expect(gaps).toHaveLength(1);
+    });
+  });
+
+  describe("boundary sweep on the gap threshold", () => {
+    /*
+     * Determined by reading the implementation and confirmed by running:
+     * getCoverageGaps reports a hole when
+     *   getDifferenceInSeconds(end, start) > minimumGapSeconds
+     * with minimumGapSeconds defaulting to the 5s contiguity tolerance. The
+     * comparison is STRICTLY greater-than, so the smallest reported hole is 6s
+     * and a hole of exactly 5s is still absorbed. All instants here are whole
+     * seconds, so moment's truncation towards zero and the absolute value that
+     * getDifferenceInSeconds returns never come into play; the boundary is
+     * exactly 5 -> silent, 6 -> reported.
+     *
+     * The 89/90/91 rows are the old tolerance: every one of them must now be
+     * reported, which is precisely what regressed before.
+     */
+    const cases: Array<{ holeSeconds: number; isReported: boolean }> = [
+      { holeSeconds: 4, isReported: false },
+      { holeSeconds: 5, isReported: false },
+      { holeSeconds: 6, isReported: true },
+      { holeSeconds: 89, isReported: true },
+      { holeSeconds: 90, isReported: true },
+      { holeSeconds: 91, isReported: true },
+    ];
+
+    for (const testCase of cases) {
+      test(`a ${testCase.holeSeconds}s hole is ${
+        testCase.isReported ? "reported" : "absorbed"
+      }`, () => {
+        const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+          shiftsWithHoleOf(testCase.holeSeconds),
+          WINDOW_START,
+          WINDOW_END,
+        );
+
+        expect(gaps).toHaveLength(testCase.isReported ? 1 : 0);
+      });
+
+      /*
+       * The same threshold governs whether two same-user segments collapse, so
+       * the two sides can never drift apart into a state where a shift is shown
+       * as continuous while a gap is simultaneously reported inside it.
+       */
+      test(`a ${testCase.holeSeconds}s hole ${
+        testCase.isReported ? "splits" : "merges"
+      } same-user segments`, () => {
+        const shifts: Array<OnCallShift> =
+          ScheduleShiftUtil.groupEventsIntoShifts(
+            eventsWithHoleOf("alice", testCase.holeSeconds),
+          );
+
+        expect(shifts).toHaveLength(testCase.isReported ? 2 : 1);
+      });
+    }
+  });
+
+  describe("minimumGapSeconds option", () => {
+    test("60 suppresses a sub-minute hole that the default reports", () => {
+      /*
+       * A render layer that considers 30 seconds to be display noise raises the
+       * floor itself, instead of the detector hiding it from every caller —
+       * which is how the 90s default hid real holes from the alerting surfaces
+       * too.
+       */
+      const shifts: Array<OnCallShift> = shiftsWithHoleOf(30);
+
+      expect(
+        ScheduleShiftUtil.getCoverageGaps(shifts, WINDOW_START, WINDOW_END),
+      ).toHaveLength(1);
+
+      expect(
+        ScheduleShiftUtil.getCoverageGaps(shifts, WINDOW_START, WINDOW_END, {
+          minimumGapSeconds: 60,
+        }),
+      ).toHaveLength(0);
+    });
+
+    test("0 surfaces even the one-second engine seam", () => {
+      // An audit-style caller can opt into seeing every hole, artifacts included.
+      const gaps: Array<CoverageGap> = ScheduleShiftUtil.getCoverageGaps(
+        shiftsWithHoleOf(1),
+        WINDOW_START,
+        WINDOW_END,
+        { minimumGapSeconds: 0 },
+      );
+
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0]!.start).toEqual(HANDOVER);
+      expect(gaps[0]!.end).toEqual(at("2024-01-01T17:00:01Z"));
+    });
+
+    test("omitting it, and passing undefined, both fall back to the 5s default", () => {
+      /*
+       * getCoverageState always forwards { minimumGapSeconds: undefined } when
+       * the caller omits it, so an `undefined` check that was written as a
+       * falsy check would silently turn the floor into 0 and report every seam.
+       */
+      const shifts: Array<OnCallShift> = shiftsWithHoleOf(5);
+
+      expect(
+        ScheduleShiftUtil.getCoverageGaps(shifts, WINDOW_START, WINDOW_END),
+      ).toHaveLength(0);
+
+      expect(
+        ScheduleShiftUtil.getCoverageGaps(shifts, WINDOW_START, WINDOW_END, {
+          minimumGapSeconds: undefined,
+        }),
+      ).toHaveLength(0);
+
+      const state: ScheduleCoverageState = ScheduleShiftUtil.getCoverageState({
+        layerCount: 1,
+        assignedUserCount: 2,
+        shifts: shiftsWithHoleOf(6),
+        now: WINDOW_START,
+        windowEnd: WINDOW_END,
+      });
+
+      expect(state.gaps).toHaveLength(1);
+      expect(state.uncoveredSeconds).toBe(6);
+    });
+
+    test("raising it hides the hole from the report but not from the shifts", () => {
+      /*
+       * minimumGapSeconds is a reporting filter only. If it ever leaked into
+       * grouping, a caller that quietened short holes would also start claiming
+       * one continuous shift across them — the exact false "fully covered"
+       * reading this change removed.
+       */
+      const shifts: Array<OnCallShift> =
+        ScheduleShiftUtil.groupEventsIntoShifts(eventsWithHoleOf("alice", 60));
+
+      expect(shifts).toHaveLength(2);
+
+      const state: ScheduleCoverageState = ScheduleShiftUtil.getCoverageState({
+        layerCount: 1,
+        assignedUserCount: 1,
+        shifts,
+        now: WINDOW_START,
+        windowEnd: WINDOW_END,
+        minimumGapSeconds: 3600,
+      });
+
+      expect(state.gaps).toEqual([]);
+      expect(state.uncoveredSeconds).toBe(0);
+      expect(state.coverageRatio).toBe(1);
+
+      // The hole is still real: nobody is on call inside it.
+      const insideHole: CurrentAndNextShift =
+        ScheduleShiftUtil.getCurrentAndNextShift(
+          shifts,
+          at("2024-01-01T17:00:30Z"),
+        );
+
+      expect(insideHole.current).toBeNull();
+      expect(insideHole.next?.start).toEqual(at("2024-01-01T17:01:00Z"));
+    });
+  });
+
+  describe("grouping behaviour that must not change", () => {
+    test("genuinely touching segments still merge", () => {
+      // Zero-second seam: the previous segment's end is the next one's start.
+      const shifts: Array<OnCallShift> =
+        ScheduleShiftUtil.groupEventsIntoShifts(eventsWithHoleOf("alice", 0));
+
+      expect(shifts).toHaveLength(1);
+      expect(shifts[0]!.start).toEqual(WINDOW_START);
+      expect(shifts[0]!.end).toEqual(WINDOW_END);
+      // Two 8h + 16h segments, so the span and the active time agree here.
+      expect(shifts[0]!.coverageSeconds).toBe(24 * 3600);
+    });
+
+    test("mergeAcrossGaps collapses a whole rotation turn regardless of tolerance", () => {
+      /*
+       * The per-layer rotation summary shows "alice: Mon -> Fri" as one turn.
+       * The tolerance must not be consulted at all on this path, otherwise
+       * lowering it would explode every restricted rotation into one row per
+       * day.
+       */
+      const events: Array<CalendarEvent> = [
+        event("alice", at("2024-01-01T09:00:00Z"), at("2024-01-01T17:00:00Z")),
+        event("alice", at("2024-01-02T09:00:00Z"), at("2024-01-02T17:00:00Z")),
+        event("bob", at("2024-01-03T09:00:00Z"), at("2024-01-03T17:00:00Z")),
+      ];
+
+      const shifts: Array<OnCallShift> =
+        ScheduleShiftUtil.groupEventsIntoShifts(events, {
+          mergeAcrossGaps: true,
+        });
+
+      expect(shifts).toHaveLength(2);
+      expect(shifts[0]!.userId).toBe("alice");
+      expect(shifts[0]!.end).toEqual(at("2024-01-02T17:00:00Z"));
+      // Real active time across the turn, not the 32h wall-clock span.
+      expect(shifts[0]!.coverageSeconds).toBe(16 * 3600);
+      expect(shifts[1]!.userId).toBe("bob");
+    });
+
+    test("a sub-tolerance seam never merges two different users", () => {
+      /*
+       * The tolerance decides contiguity, never identity. Merging across users
+       * would attribute somebody else's minutes to the wrong on-call person.
+       */
+      const events: Array<CalendarEvent> = [
+        event("alice", WINDOW_START, HANDOVER),
+        event("bob", OneUptimeDate.addRemoveSeconds(HANDOVER, 1), WINDOW_END),
+      ];
+
+      const shifts: Array<OnCallShift> =
+        ScheduleShiftUtil.groupEventsIntoShifts(events);
+
+      expect(shifts).toHaveLength(2);
+      expect(shifts[0]!.userId).toBe("alice");
+      expect(shifts[1]!.userId).toBe("bob");
+    });
+  });
+});

--- a/Common/Tests/Types/OnCallDutyPolicy/ScheduleCoverageState.test.ts
+++ b/Common/Tests/Types/OnCallDutyPolicy/ScheduleCoverageState.test.ts
@@ -1,0 +1,822 @@
+import OneUptimeDate from "../../../Types/Date";
+import ScheduleShiftUtil, {
+  CoverageGap,
+  OnCallShift,
+  ScheduleCoverageState,
+  ScheduleCoverageStatus,
+} from "../../../Types/OnCallDutyPolicy/ScheduleShiftUtil";
+
+/*
+ * getCoverageState is the replacement for the inverted `assignedUserCount > 0`
+ * gate that made a schedule with a permanent coverage gap render as nothing at
+ * all. Every surface that shows "who is on call" now derives its state from
+ * here, so this suite pins the whole contract: the status precedence, the
+ * current/next passthrough, and the ratio arithmetic (including the degenerate
+ * windows a caller can hand it).
+ */
+
+const at: (iso: string) => Date = (iso: string): Date => {
+  return OneUptimeDate.fromString(iso);
+};
+
+/*
+ * Build an OnCallShift literal directly. getCoverageState never reads
+ * coverageSeconds, so defaulting it to the wall-clock span keeps the fixtures
+ * honest without making them noisy.
+ */
+const mkShift: (userId: string, start: Date, end: Date) => OnCallShift = (
+  userId: string,
+  start: Date,
+  end: Date,
+): OnCallShift => {
+  return {
+    userId,
+    start,
+    end,
+    coverageSeconds: OneUptimeDate.getDifferenceInSeconds(end, start),
+  };
+};
+
+/*
+ * Fixed instants only — a suite that computed "now" from the clock would flip
+ * between Covered and UncoveredNow depending on when CI happened to run.
+ */
+const NOW: Date = at("2024-03-04T12:00:00Z");
+const WINDOW_END: Date = at("2024-03-05T12:00:00Z");
+const WINDOW_SECONDS: number = 24 * 3600;
+
+/*
+ * Defaults describe a healthy schedule (one layer, one assigned user, a 24h
+ * summary window) so each test only spells out the field it is exercising.
+ */
+function coverage(data: {
+  layerCount?: number | undefined;
+  assignedUserCount?: number | undefined;
+  shifts?: Array<OnCallShift> | undefined;
+  now?: Date | undefined;
+  windowEnd?: Date | undefined;
+  minimumGapSeconds?: number | undefined;
+}): ScheduleCoverageState {
+  return ScheduleShiftUtil.getCoverageState({
+    layerCount: data.layerCount === undefined ? 1 : data.layerCount,
+    assignedUserCount:
+      data.assignedUserCount === undefined ? 1 : data.assignedUserCount,
+    shifts: data.shifts === undefined ? [] : data.shifts,
+    now: data.now === undefined ? NOW : data.now,
+    windowEnd: data.windowEnd === undefined ? WINDOW_END : data.windowEnd,
+    minimumGapSeconds: data.minimumGapSeconds,
+  });
+}
+
+function sumGapSeconds(gaps: Array<CoverageGap>): number {
+  return gaps.reduce((total: number, gap: CoverageGap): number => {
+    return total + OneUptimeDate.getDifferenceInSeconds(gap.end, gap.start);
+  }, 0);
+}
+
+const coveringShift: OnCallShift = mkShift(
+  "alice",
+  at("2024-03-04T09:00:00Z"),
+  at("2024-03-05T12:00:00Z"),
+);
+
+describe("ScheduleShiftUtil.getCoverageState", () => {
+  describe("status precedence", () => {
+    test("reports NoLayers when the schedule has no layers at all", () => {
+      const state: ScheduleCoverageState = coverage({
+        layerCount: 0,
+        assignedUserCount: 0,
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.NoLayers);
+    });
+
+    /*
+     * NoLayers must win over everything else: a schedule with no layers cannot
+     * produce coverage, so any shifts handed in are stale data from a previous
+     * render and must not talk the UI out of the "add a layer" remedy.
+     */
+    test("NoLayers outranks assigned users and shifts that cover now", () => {
+      const state: ScheduleCoverageState = coverage({
+        layerCount: 0,
+        assignedUserCount: 5,
+        shifts: [coveringShift],
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.NoLayers);
+      expect(state.status).not.toBe(ScheduleCoverageStatus.Covered);
+    });
+
+    /*
+     * THE HEADLINE REGRESSION. Layers exist but nobody is assigned to them, so
+     * the engine emits zero events and NOBODY is ever on call. The old UI gated
+     * its gap warning on `assignedUserCount > 0` — exactly inverted — so this
+     * permanent 100% gap was the one state that rendered nothing at all.
+     */
+    test("reports NoUsers when layers exist but nobody is assigned", () => {
+      const state: ScheduleCoverageState = coverage({
+        layerCount: 2,
+        assignedUserCount: 0,
+        shifts: [],
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.NoUsers);
+      expect(state.status).not.toBe(ScheduleCoverageStatus.Covered);
+      expect(state.status).not.toBe(ScheduleCoverageStatus.UncoveredNow);
+      expect(state.current).toBeNull();
+      expect(state.gaps).toHaveLength(1);
+      expect(state.uncoveredSeconds).toBe(WINDOW_SECONDS);
+      expect(state.coverageRatio).toBe(0);
+    });
+
+    /*
+     * The remedies differ: NoUsers means "assign somebody", UncoveredNow means
+     * "widen the rotation". Collapsing the unassigned schedule into the generic
+     * uncovered state would send the operator to the wrong fix.
+     */
+    test("NoUsers outranks UncoveredNow rather than collapsing into it", () => {
+      const state: ScheduleCoverageState = coverage({
+        layerCount: 1,
+        assignedUserCount: 0,
+        shifts: [],
+        now: NOW,
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.NoUsers);
+    });
+
+    /*
+     * Stale shifts left over from before the last user was removed must not
+     * flip an unassigned schedule back to Covered.
+     */
+    test("NoUsers outranks Covered even when a shift still spans now", () => {
+      const state: ScheduleCoverageState = coverage({
+        layerCount: 1,
+        assignedUserCount: 0,
+        shifts: [coveringShift],
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.NoUsers);
+      expect(state.current).not.toBeNull();
+    });
+
+    test("reports UncoveredNow when users are assigned but no shift spans now", () => {
+      const state: ScheduleCoverageState = coverage({
+        layerCount: 1,
+        assignedUserCount: 3,
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-04T20:00:00Z"),
+            at("2024-03-05T04:00:00Z"),
+          ),
+        ],
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.UncoveredNow);
+      expect(state.current).toBeNull();
+    });
+
+    test("reports Covered when a shift spans now", () => {
+      const state: ScheduleCoverageState = coverage({
+        layerCount: 1,
+        assignedUserCount: 1,
+        shifts: [coveringShift],
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.Covered);
+      expect(state.current?.userId).toBe("alice");
+    });
+
+    /*
+     * The status answers "is somebody on call RIGHT NOW"; the gaps array carries
+     * the rest of the window. Downgrading to UncoveredNow because of a hole
+     * three hours from now would fire a false alarm during a healthy shift.
+     */
+    test("stays Covered when somebody is on call now but later gaps exist", () => {
+      const state: ScheduleCoverageState = coverage({
+        layerCount: 1,
+        assignedUserCount: 2,
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-04T09:00:00Z"),
+            at("2024-03-04T17:00:00Z"),
+          ),
+          mkShift(
+            "bob",
+            at("2024-03-05T09:00:00Z"),
+            at("2024-03-05T12:00:00Z"),
+          ),
+        ],
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.Covered);
+      expect(state.gaps.length).toBeGreaterThan(0);
+    });
+
+    /*
+     * A caller that derives its counts from an array length can hand over -1
+     * from a `findIndex`, and a deleted layer can transiently report 0. Both
+     * must land in the "misconfigured" statuses, never in Covered.
+     */
+    test("treats a negative layerCount as NoLayers", () => {
+      const state: ScheduleCoverageState = coverage({
+        layerCount: -1,
+        assignedUserCount: 4,
+        shifts: [coveringShift],
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.NoLayers);
+    });
+
+    test("treats a negative assignedUserCount as NoUsers", () => {
+      const state: ScheduleCoverageState = coverage({
+        layerCount: 1,
+        assignedUserCount: -3,
+        shifts: [coveringShift],
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.NoUsers);
+    });
+
+    /*
+     * Boundary of the "contains now" test. A handover is inclusive at the start
+     * and exclusive at the end, so the two people never both count as current
+     * and the instant of handover is never reported as an uncovered second.
+     */
+    test("a shift starting exactly at now already counts as Covered", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [mkShift("alice", NOW, at("2024-03-04T20:00:00Z"))],
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.Covered);
+      expect(state.current?.userId).toBe("alice");
+    });
+
+    test("a shift ending exactly at now no longer counts as Covered", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [mkShift("alice", at("2024-03-04T04:00:00Z"), NOW)],
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.UncoveredNow);
+      expect(state.current).toBeNull();
+    });
+  });
+
+  describe("current and next passthrough", () => {
+    test("current spans now and next is the earliest strictly future shift", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-04T09:00:00Z"),
+            at("2024-03-04T17:00:00Z"),
+          ),
+          mkShift(
+            "bob",
+            at("2024-03-04T17:00:00Z"),
+            at("2024-03-05T01:00:00Z"),
+          ),
+          mkShift(
+            "carol",
+            at("2024-03-05T01:00:00Z"),
+            at("2024-03-05T09:00:00Z"),
+          ),
+        ],
+      });
+
+      expect(state.current?.userId).toBe("alice");
+      expect(state.next?.userId).toBe("bob");
+    });
+
+    test("both current and next are null when there are no shifts", () => {
+      const state: ScheduleCoverageState = coverage({ shifts: [] });
+
+      expect(state.current).toBeNull();
+      expect(state.next).toBeNull();
+    });
+
+    /*
+     * Inside a gap the UI still has something useful to say — "nobody until
+     * 9:00 AM" — which only works if next survives a null current.
+     */
+    test("next is still resolved while current is null inside a gap", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-04T01:00:00Z"),
+            at("2024-03-04T09:00:00Z"),
+          ),
+          mkShift(
+            "bob",
+            at("2024-03-04T18:00:00Z"),
+            at("2024-03-05T02:00:00Z"),
+          ),
+        ],
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.UncoveredNow);
+      expect(state.current).toBeNull();
+      expect(state.next?.userId).toBe("bob");
+    });
+
+    /*
+     * Multi-layer merges interleave events from several layers, so the caller's
+     * array is not guaranteed to be ordered by start time. next must be the
+     * earliest future shift, not simply the first future entry encountered.
+     */
+    test("next is the earliest future shift regardless of input ordering", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [
+          mkShift(
+            "carol",
+            at("2024-03-05T06:00:00Z"),
+            at("2024-03-05T10:00:00Z"),
+          ),
+          mkShift(
+            "bob",
+            at("2024-03-04T18:00:00Z"),
+            at("2024-03-04T22:00:00Z"),
+          ),
+        ],
+      });
+
+      expect(state.next?.userId).toBe("bob");
+    });
+
+    test("next is null once now is past every shift", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-01T09:00:00Z"),
+            at("2024-03-01T17:00:00Z"),
+          ),
+        ],
+      });
+
+      expect(state.current).toBeNull();
+      expect(state.next).toBeNull();
+    });
+  });
+
+  describe("coverageRatio and uncoveredSeconds", () => {
+    test("a fully covered window reports ratio 1 and zero uncovered seconds", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [mkShift("alice", NOW, WINDOW_END)],
+      });
+
+      expect(state.gaps).toHaveLength(0);
+      expect(state.uncoveredSeconds).toBe(0);
+      expect(state.coverageRatio).toBe(1);
+    });
+
+    test("a window covered only for its second half reports ratio 0.5", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [mkShift("alice", at("2024-03-05T00:00:00Z"), WINDOW_END)],
+      });
+
+      expect(state.uncoveredSeconds).toBe(12 * 3600);
+      expect(state.coverageRatio).toBeCloseTo(0.5, 6);
+    });
+
+    test("no shifts at all reports ratio 0 and the entire window uncovered", () => {
+      const state: ScheduleCoverageState = coverage({ shifts: [] });
+
+      expect(state.uncoveredSeconds).toBe(WINDOW_SECONDS);
+      expect(state.coverageRatio).toBe(0);
+    });
+
+    test("uncoveredSeconds is the sum of the reported gap durations", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-04T13:00:00Z"),
+            at("2024-03-04T15:00:00Z"),
+          ),
+          mkShift(
+            "bob",
+            at("2024-03-04T18:00:00Z"),
+            at("2024-03-04T20:00:00Z"),
+          ),
+        ],
+      });
+
+      expect(state.gaps).toHaveLength(2);
+      expect(state.uncoveredSeconds).toBe(sumGapSeconds(state.gaps));
+      expect(state.uncoveredSeconds).toBe(1 * 3600 + 3 * 3600);
+    });
+
+    /*
+     * A zero-length window is what a caller produces when it renders "the rest
+     * of today" at midnight. Dividing by it must not leak NaN or Infinity into
+     * a percentage badge.
+     */
+    test("windowEnd equal to now reports ratio 0 with no NaN or Infinity", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [coveringShift],
+        windowEnd: NOW,
+      });
+
+      expect(Number.isFinite(state.coverageRatio)).toBe(true);
+      expect(Number.isNaN(state.coverageRatio)).toBe(false);
+      expect(state.coverageRatio).toBe(0);
+      expect(state.uncoveredSeconds).toBe(0);
+      expect(state.gaps).toHaveLength(0);
+    });
+
+    /*
+     * SUSPECTED PRODUCT BUG — asserting the correct behaviour, marked failing.
+     *
+     * An inverted window (windowEnd before now) is what a caller produces from
+     * a stale or mis-ordered range, and it must degrade to "we know nothing",
+     * i.e. ratio 0 — the same answer as the zero-length window above.
+     *
+     * This is a REGRESSION TEST for a real defect: the original clamp tested
+     * `windowSeconds <= 0`, but OneUptimeDate.getDifferenceInSeconds returns the
+     * ABSOLUTE difference, so an inverted window yielded a positive
+     * windowSeconds, zero gaps, and a confident ratio of 1. The function whose
+     * entire job is to surface missing coverage reported 100% covered. The
+     * window's order is now tested explicitly with isBefore.
+     */
+    test("windowEnd before now reports ratio 0 rather than a false 100%", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [],
+        now: NOW,
+        windowEnd: at("2024-03-03T12:00:00Z"),
+      });
+
+      expect(Number.isFinite(state.coverageRatio)).toBe(true);
+      expect(state.coverageRatio).toBeGreaterThanOrEqual(0);
+      expect(state.coverageRatio).toBe(0);
+    });
+
+    test("an inverted window never yields a negative or non-finite ratio", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [],
+        now: NOW,
+        windowEnd: at("2024-03-03T12:00:00Z"),
+      });
+
+      expect(Number.isFinite(state.coverageRatio)).toBe(true);
+      expect(Number.isNaN(state.coverageRatio)).toBe(false);
+      expect(state.coverageRatio).toBeGreaterThanOrEqual(0);
+      expect(state.coverageRatio).toBeLessThanOrEqual(1);
+    });
+
+    /*
+     * A schedule with no layers (or no assigned users) can never put anyone on
+     * call, so its coverage is 0 whatever shifts a caller happened to pass in.
+     * The ratio used to be derived purely from those shifts and ignore the
+     * status, letting a stale set render "100% covered" directly beside
+     * "no layers configured".
+     */
+    test("ratio is 0 for NoLayers even when stale shifts cover the window", () => {
+      const state: ScheduleCoverageState = coverage({
+        layerCount: 0,
+        assignedUserCount: 0,
+        shifts: [mkShift("alice", NOW, WINDOW_END)],
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.NoLayers);
+      expect(state.coverageRatio).toBe(0);
+    });
+
+    /*
+     * Shifts are fetched over a wider range than the summary window, so the
+     * leading gap can be many times the window itself. Without the lower clamp
+     * that arithmetic goes negative and a progress bar renders backwards.
+     */
+    test("clamps to 0 when the leading gap overshoots a short window", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-06T00:00:00Z"),
+            at("2024-03-06T08:00:00Z"),
+          ),
+        ],
+        windowEnd: at("2024-03-04T13:00:00Z"),
+      });
+
+      expect(state.uncoveredSeconds).toBeGreaterThan(3600);
+      expect(state.coverageRatio).toBe(0);
+    });
+
+    /*
+     * LayerUtil advances each following segment with addRemoveSeconds(end, 1)
+     * and the multi-layer merge leaves seams of the same magnitude, so a
+     * one-second hole is an engine artifact and must never be billed as
+     * uncovered time.
+     */
+    test("the engine's one-second seam is not counted as uncovered time", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-04T09:00:00Z"),
+            at("2024-03-04T17:00:00Z"),
+          ),
+          mkShift(
+            "bob",
+            at("2024-03-04T17:00:01Z"),
+            at("2024-03-05T12:00:00Z"),
+          ),
+        ],
+      });
+
+      expect(state.gaps).toHaveLength(0);
+      expect(state.uncoveredSeconds).toBe(0);
+      expect(state.coverageRatio).toBe(1);
+    });
+
+    /*
+     * Guards the contiguity tolerance drop from 90s to 5s: a schedule whose
+     * layers are misaligned by a minute is genuinely uncovered for that minute
+     * and used to report full coverage.
+     */
+    test("a one-minute misalignment between layers is reported as a real gap", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-04T09:00:00Z"),
+            at("2024-03-04T17:00:00Z"),
+          ),
+          mkShift(
+            "bob",
+            at("2024-03-04T17:01:00Z"),
+            at("2024-03-05T12:00:00Z"),
+          ),
+        ],
+      });
+
+      expect(state.gaps).toHaveLength(1);
+      expect(state.uncoveredSeconds).toBe(60);
+      expect(state.coverageRatio).toBeCloseTo(
+        (WINDOW_SECONDS - 60) / WINDOW_SECONDS,
+        6,
+      );
+    });
+
+    /*
+     * Render surfaces that consider sub-five-minute holes to be display noise
+     * raise the threshold themselves rather than relying on the detector to
+     * hide real misconfiguration from everybody.
+     */
+    test("minimumGapSeconds lets a caller suppress holes it treats as noise", () => {
+      const state: ScheduleCoverageState = coverage({
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-04T09:00:00Z"),
+            at("2024-03-04T17:00:00Z"),
+          ),
+          mkShift(
+            "bob",
+            at("2024-03-04T17:01:00Z"),
+            at("2024-03-05T12:00:00Z"),
+          ),
+        ],
+        minimumGapSeconds: 300,
+      });
+
+      expect(state.gaps).toHaveLength(0);
+      expect(state.uncoveredSeconds).toBe(0);
+      expect(state.coverageRatio).toBe(1);
+    });
+
+    /*
+     * The ratio feeds percentage labels and progress bars, so no combination of
+     * window and shift data may escape [0,1] or turn non-finite — including the
+     * degenerate windows above and shifts that sit entirely outside the window.
+     */
+    test("ratio stays finite and within [0,1] across a spread of inputs", () => {
+      const windowEnds: Array<Date> = [
+        at("2024-03-03T12:00:00Z"),
+        NOW,
+        at("2024-03-04T12:00:01Z"),
+        at("2024-03-04T13:00:00Z"),
+        WINDOW_END,
+        at("2024-04-03T12:00:00Z"),
+      ];
+
+      const shiftSets: Array<Array<OnCallShift>> = [
+        [],
+        [mkShift("alice", NOW, WINDOW_END)],
+        [
+          mkShift(
+            "alice",
+            at("2024-03-04T09:00:00Z"),
+            at("2024-03-04T17:00:00Z"),
+          ),
+          mkShift(
+            "bob",
+            at("2024-03-05T09:00:00Z"),
+            at("2024-03-05T17:00:00Z"),
+          ),
+        ],
+        [
+          mkShift(
+            "alice",
+            at("2024-02-01T00:00:00Z"),
+            at("2024-02-02T00:00:00Z"),
+          ),
+        ],
+        [
+          mkShift(
+            "alice",
+            at("2024-06-01T00:00:00Z"),
+            at("2024-06-02T00:00:00Z"),
+          ),
+        ],
+      ];
+
+      for (const windowEnd of windowEnds) {
+        for (const shifts of shiftSets) {
+          const state: ScheduleCoverageState = coverage({
+            shifts,
+            windowEnd,
+          });
+
+          expect(Number.isFinite(state.coverageRatio)).toBe(true);
+          expect(Number.isNaN(state.coverageRatio)).toBe(false);
+          expect(state.coverageRatio).toBeGreaterThanOrEqual(0);
+          expect(state.coverageRatio).toBeLessThanOrEqual(1);
+          expect(Number.isFinite(state.uncoveredSeconds)).toBe(true);
+          expect(state.uncoveredSeconds).toBeGreaterThanOrEqual(0);
+        }
+      }
+    });
+  });
+
+  describe("adversarial shift input", () => {
+    /*
+     * getCoverageState runs inside render paths with no error boundary of its
+     * own, so a malformed shift list must degrade to a wrong-but-safe answer
+     * rather than blanking the schedule page with an exception. These are the
+     * shapes the multi-layer merge and override lens can actually produce.
+     */
+    const adversarialShiftSets: Array<{
+      name: string;
+      shifts: Array<OnCallShift>;
+    }> = [
+      { name: "an empty shift list", shifts: [] },
+      {
+        name: "shifts handed over out of start order",
+        shifts: [
+          mkShift(
+            "carol",
+            at("2024-03-05T06:00:00Z"),
+            at("2024-03-05T10:00:00Z"),
+          ),
+          mkShift(
+            "alice",
+            at("2024-03-04T09:00:00Z"),
+            at("2024-03-04T17:00:00Z"),
+          ),
+          mkShift(
+            "bob",
+            at("2024-03-04T20:00:00Z"),
+            at("2024-03-05T04:00:00Z"),
+          ),
+        ],
+      },
+      {
+        name: "shifts that overlap each other",
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-04T09:00:00Z"),
+            at("2024-03-04T18:00:00Z"),
+          ),
+          mkShift(
+            "bob",
+            at("2024-03-04T11:00:00Z"),
+            at("2024-03-05T02:00:00Z"),
+          ),
+        ],
+      },
+      {
+        name: "a shift fully swallowed by an earlier one",
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-04T00:00:00Z"),
+            at("2024-03-06T00:00:00Z"),
+          ),
+          mkShift(
+            "bob",
+            at("2024-03-04T11:00:00Z"),
+            at("2024-03-04T13:00:00Z"),
+          ),
+        ],
+      },
+      {
+        name: "zero-length shifts",
+        shifts: [
+          mkShift("alice", NOW, NOW),
+          mkShift(
+            "bob",
+            at("2024-03-04T18:00:00Z"),
+            at("2024-03-04T18:00:00Z"),
+          ),
+        ],
+      },
+      {
+        name: "an inverted shift whose end precedes its start",
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-04T18:00:00Z"),
+            at("2024-03-04T09:00:00Z"),
+          ),
+        ],
+      },
+      {
+        name: "shifts lying entirely outside the window",
+        shifts: [
+          mkShift(
+            "alice",
+            at("2023-01-01T00:00:00Z"),
+            at("2023-01-02T00:00:00Z"),
+          ),
+          mkShift(
+            "bob",
+            at("2030-01-01T00:00:00Z"),
+            at("2030-01-02T00:00:00Z"),
+          ),
+        ],
+      },
+    ];
+
+    for (const scenario of adversarialShiftSets) {
+      test(`returns a well-formed state for ${scenario.name}`, () => {
+        let state: ScheduleCoverageState | null = null;
+
+        expect(() => {
+          state = coverage({
+            layerCount: 1,
+            assignedUserCount: 2,
+            shifts: scenario.shifts,
+          });
+        }).not.toThrow();
+
+        const resolved: ScheduleCoverageState = state!;
+
+        expect(
+          Object.values(ScheduleCoverageStatus).includes(resolved.status),
+        ).toBe(true);
+        expect(Array.isArray(resolved.gaps)).toBe(true);
+        expect(Number.isFinite(resolved.uncoveredSeconds)).toBe(true);
+        expect(resolved.uncoveredSeconds).toBeGreaterThanOrEqual(0);
+        expect(resolved.coverageRatio).toBeGreaterThanOrEqual(0);
+        expect(resolved.coverageRatio).toBeLessThanOrEqual(1);
+        expect(resolved.uncoveredSeconds).toBe(sumGapSeconds(resolved.gaps));
+      });
+    }
+
+    /*
+     * A zero-length shift is a degenerate override (start === end). It covers no
+     * instant at all, so it must never be presented as the person on call.
+     */
+    test("a zero-length shift is never resolved as the current shift", () => {
+      const state: ScheduleCoverageState = coverage({
+        layerCount: 1,
+        assignedUserCount: 1,
+        shifts: [mkShift("alice", NOW, NOW)],
+      });
+
+      expect(state.current).toBeNull();
+      expect(state.status).toBe(ScheduleCoverageStatus.UncoveredNow);
+    });
+
+    /*
+     * Overlapping shifts come out of the multi-layer priority merge. The
+     * overlap must not be double-counted into a gap, and the higher shift must
+     * not be mistaken for "up next" while it is already running.
+     */
+    test("overlapping shifts stay Covered without inventing a gap", () => {
+      const state: ScheduleCoverageState = coverage({
+        layerCount: 2,
+        assignedUserCount: 2,
+        shifts: [
+          mkShift(
+            "alice",
+            at("2024-03-04T09:00:00Z"),
+            at("2024-03-04T18:00:00Z"),
+          ),
+          mkShift("bob", at("2024-03-04T11:00:00Z"), WINDOW_END),
+        ],
+      });
+
+      expect(state.status).toBe(ScheduleCoverageStatus.Covered);
+      expect(state.gaps).toHaveLength(0);
+      expect(state.uncoveredSeconds).toBe(0);
+      expect(state.next).toBeNull();
+    });
+  });
+});

--- a/Common/Types/OnCallDutyPolicy/OnCallDutyPolicyStatus.ts
+++ b/Common/Types/OnCallDutyPolicy/OnCallDutyPolicyStatus.ts
@@ -3,6 +3,19 @@ enum OnCallDutyPolicyStatus {
   Started = "Started",
   Executing = "Executing",
   Completed = "Execution Completed",
+  /*
+   * Terminal, like Completed, but the policy walked every escalation rule
+   * without paging a single person — typically because every rule targeted an
+   * on-call schedule that had nobody on call. Kept distinct from Completed
+   * because the two used to be indistinguishable: an incident that notified
+   * nobody closed out with the same green "Execution Completed" as one that
+   * successfully paged the on-call engineer, so a policy could silently notify
+   * no one indefinitely.
+   *
+   * `status` is a varchar column (not a Postgres enum type), so adding this
+   * value needs no schema migration.
+   */
+  CompletedWithNoNotifications = "Execution Completed - No One Notified",
   Error = "Error",
 }
 

--- a/Common/Types/OnCallDutyPolicy/ScheduleShiftUtil.ts
+++ b/Common/Types/OnCallDutyPolicy/ScheduleShiftUtil.ts
@@ -49,13 +49,55 @@ export interface CurrentAndNextShift {
 }
 
 /*
- * Two coverage segments are considered part of the same continuous shift when
- * the gap between them is below this threshold. LayerUtil starts each following
- * segment exactly one second after the previous one ends, so anything within a
- * couple of minutes is "touching"; anything larger is a genuine off-hours gap
- * (a restriction window closing, a rotation with no fallback layer, etc.).
+ * Why a schedule currently has (or does not have) somebody on call. The four
+ * states are mutually exclusive and ordered by how early the misconfiguration
+ * happens, so a caller can render the most specific remedy it knows about:
+ *
+ * - NoLayers      the schedule has no layers at all -> "add a layer"
+ * - NoUsers       layers exist but nobody is assigned to any of them, so the
+ *                 engine emits zero events and NOBODY is ever on call. This is
+ *                 a permanent 100% gap, not an off-hours one, and it needs its
+ *                 own remedy ("assign users") — telling someone to widen their
+ *                 active hours here would be wrong.
+ * - UncoveredNow  users are assigned and shifts exist, but none covers `now`
+ * - Covered       somebody is on call at this instant
  */
-const CONTIGUITY_TOLERANCE_SECONDS: number = 90;
+export enum ScheduleCoverageStatus {
+  NoLayers = "NoLayers",
+  NoUsers = "NoUsers",
+  UncoveredNow = "UncoveredNow",
+  Covered = "Covered",
+}
+
+export interface ScheduleCoverageState {
+  status: ScheduleCoverageStatus;
+  current: OnCallShift | null;
+  next: OnCallShift | null;
+  gaps: Array<CoverageGap>;
+  // Total uncovered seconds inside [now, windowEnd].
+  uncoveredSeconds: number;
+  /*
+   * Fraction of [now, windowEnd] that somebody is on call for, 0..1. 0 for both
+   * NoLayers and NoUsers; 1 for a schedule with no gaps at all.
+   */
+  coverageRatio: number;
+}
+
+/*
+ * Two coverage segments belong to the same continuous shift when the hole
+ * between them is at or below this threshold. LayerUtil starts each following
+ * segment exactly one second after the previous one ends (Layer.ts advances
+ * with addRemoveSeconds(end, 1)) and the multi-layer priority merge leaves
+ * seams of the same ±1s magnitude, so a few seconds of slack is all that is
+ * needed to absorb the engine's own artifacts.
+ *
+ * This used to be 90 seconds, which silently swallowed genuine sub-minute
+ * coverage holes — a schedule whose layers were misaligned by a minute
+ * reported full coverage. Anything above the engine artifact is a real hole and
+ * is now reported; callers that consider very short holes to be display noise
+ * filter them at the render layer (see getCoverageGaps' minimumGapSeconds).
+ */
+const CONTIGUITY_TOLERANCE_SECONDS: number = 5;
 
 export default class ScheduleShiftUtil {
   /*
@@ -191,6 +233,7 @@ export default class ScheduleShiftUtil {
     shifts: Array<OnCallShift>,
     windowStart: Date,
     windowEnd: Date,
+    options?: { minimumGapSeconds?: number | undefined } | undefined,
   ): Array<CoverageGap> {
     const gaps: Array<CoverageGap> = [];
 
@@ -199,18 +242,24 @@ export default class ScheduleShiftUtil {
     }
 
     /*
-     * A gap only "counts" when it is longer than the contiguity tolerance, so
+     * A hole only "counts" as a gap when it is longer than the threshold, so
      * the one-second boundaries LayerUtil leaves between segments never show up
-     * as spurious coverage holes.
+     * as spurious coverage holes. Callers that treat short holes as display
+     * noise (rather than as a misconfiguration worth reporting) raise
+     * minimumGapSeconds instead of relying on the detector to hide them.
      */
+    const minimumGapSeconds: number =
+      options?.minimumGapSeconds === undefined
+        ? CONTIGUITY_TOLERANCE_SECONDS
+        : options.minimumGapSeconds;
+
     const isRealGap: (start: Date, end: Date) => boolean = (
       start: Date,
       end: Date,
     ): boolean => {
       return (
         OneUptimeDate.isAfter(end, start) &&
-        OneUptimeDate.getDifferenceInSeconds(end, start) >
-          CONTIGUITY_TOLERANCE_SECONDS
+        OneUptimeDate.getDifferenceInSeconds(end, start) > minimumGapSeconds
       );
     };
 
@@ -253,5 +302,101 @@ export default class ScheduleShiftUtil {
     }
 
     return gaps;
+  }
+
+  /*
+   * The single source of truth for "does this schedule have anybody on call,
+   * and if not, why not". Every surface that renders coverage derives its state
+   * from here rather than inventing its own condition.
+   *
+   * This exists because the UI used to gate its gap warnings on
+   * `assignedUserCount > 0` — a condition that is exactly INVERTED, since zero
+   * assigned users IS the total-gap state. The one screen that would have said
+   * "nobody is on call" was therefore the one screen that never rendered.
+   * Returning an explicit status makes that class of mistake impossible: a
+   * caller must handle NoUsers, it cannot accidentally fall into "covered".
+   */
+  public static getCoverageState(data: {
+    layerCount: number;
+    assignedUserCount: number;
+    shifts: Array<OnCallShift>;
+    now: Date;
+    windowEnd: Date;
+    minimumGapSeconds?: number | undefined;
+  }): ScheduleCoverageState {
+    const { current, next }: CurrentAndNextShift = this.getCurrentAndNextShift(
+      data.shifts,
+      data.now,
+    );
+
+    const gaps: Array<CoverageGap> = this.getCoverageGaps(
+      data.shifts,
+      data.now,
+      data.windowEnd,
+      { minimumGapSeconds: data.minimumGapSeconds },
+    );
+
+    const uncoveredSeconds: number = gaps.reduce(
+      (total: number, gap: CoverageGap) => {
+        return total + OneUptimeDate.getDifferenceInSeconds(gap.end, gap.start);
+      },
+      0,
+    );
+
+    let status: ScheduleCoverageStatus = ScheduleCoverageStatus.Covered;
+
+    if (data.layerCount <= 0) {
+      status = ScheduleCoverageStatus.NoLayers;
+    } else if (data.assignedUserCount <= 0) {
+      status = ScheduleCoverageStatus.NoUsers;
+    } else if (!current) {
+      status = ScheduleCoverageStatus.UncoveredNow;
+    }
+
+    /*
+     * Test the window's ORDER explicitly rather than inferring it from the sign
+     * of the difference: OneUptimeDate.getDifferenceInSeconds returns an
+     * ABSOLUTE value, so an inverted window (windowEnd before now) yields a
+     * positive windowSeconds. Combined with getCoverageGaps bailing out on such
+     * a window and returning no gaps, the ratio then computed to a confident
+     * 1 — the function whose entire job is to surface missing coverage would
+     * report 100% covered. Fail to 0, never to "everything is fine".
+     */
+    const hasUsableWindow: boolean = OneUptimeDate.isBefore(
+      data.now,
+      data.windowEnd,
+    );
+
+    const windowSeconds: number = hasUsableWindow
+      ? OneUptimeDate.getDifferenceInSeconds(data.windowEnd, data.now)
+      : 0;
+
+    /*
+     * A schedule with no layers, or with layers but nobody assigned to them,
+     * can never put anyone on call — its coverage is 0 by definition, whatever
+     * shifts a caller happened to pass in. Deriving the ratio purely from those
+     * shifts would let a stale set report "100% covered" next to "no layers
+     * configured".
+     */
+    const canEverCover: boolean =
+      status !== ScheduleCoverageStatus.NoLayers &&
+      status !== ScheduleCoverageStatus.NoUsers;
+
+    const coverageRatio: number =
+      !hasUsableWindow || !canEverCover
+        ? 0
+        : Math.min(
+            1,
+            Math.max(0, (windowSeconds - uncoveredSeconds) / windowSeconds),
+          );
+
+    return {
+      status,
+      current,
+      next,
+      gaps,
+      uncoveredSeconds,
+      coverageRatio,
+    };
   }
 }

--- a/Common/UI/Components/Calendar/Calendar.css
+++ b/Common/UI/Components/Calendar/Calendar.css
@@ -259,3 +259,46 @@
   color: #9ca3af;
   font-size: 0.875rem;
 }
+
+/* ---------- Background events (uncovered regions) ----------
+   Painted behind the grid to make ABSENCE visible. An on-call schedule with
+   nobody on call used to render as plain whitespace, which reads exactly like a
+   grid that failed to load; the hatch says "we computed this, and it is empty".
+   Kept deliberately low-contrast so real event blocks stay dominant. */
+.oneuptime-calendar .rbc-day-slot .rbc-background-event,
+.oneuptime-calendar .rbc-background-event {
+  background-color: rgba(251, 191, 36, 0.09); /* amber-400 @ 9% */
+  background-image: repeating-linear-gradient(
+    45deg,
+    rgba(217, 119, 6, 0.16) 0,
+    rgba(217, 119, 6, 0.16) 1px,
+    transparent 1px,
+    transparent 7px
+  );
+  border: none;
+  border-left: 2px solid rgba(217, 119, 6, 0.35); /* amber-600 */
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0;
+  pointer-events: none;
+  opacity: 1;
+}
+
+.oneuptime-calendar .rbc-day-slot .rbc-background-event:hover {
+  filter: none;
+  box-shadow: none;
+}
+
+/* Legend swatch that names the hatched bands. Kept in this file so the swatch
+   and the band it describes can never drift apart. */
+.oneuptime-calendar-gap-swatch {
+  background-color: rgba(251, 191, 36, 0.25);
+  background-image: repeating-linear-gradient(
+    45deg,
+    rgba(217, 119, 6, 0.55) 0,
+    rgba(217, 119, 6, 0.55) 1px,
+    transparent 1px,
+    transparent 4px
+  );
+  border: 1px solid rgba(217, 119, 6, 0.4);
+}

--- a/Common/UI/Components/Calendar/Calendar.tsx
+++ b/Common/UI/Components/Calendar/Calendar.tsx
@@ -20,6 +20,13 @@ const localizer: DateLocalizer = momentLocalizer(moment);
 export interface ComponentProps {
   id?: string | undefined;
   events: Array<CalendarEvent>;
+  /*
+   * Events painted BEHIND the grid rather than as blocks in it. Used to shade
+   * regions that are meaningful by their absence — an on-call schedule's
+   * uncovered hours, for example, which would otherwise be indistinguishable
+   * from a grid that simply failed to load.
+   */
+  backgroundEvents?: Array<CalendarEvent> | undefined;
   defaultCalendarView?: DefaultCalendarView;
   /*
    * Which date the calendar initially opens on. Defaults to "now". Callers that
@@ -81,6 +88,7 @@ const CalendarElement: FunctionComponent<ComponentProps> = (
       <Calendar
         defaultDate={defaultDate}
         events={props.events}
+        backgroundEvents={props.backgroundEvents || []}
         localizer={localizer}
         showMultiDayTimes
         views={CALENDAR_VIEWS}


### PR DESCRIPTION
## The problem

When an on-call schedule has a **coverage gap** — a period where nobody is on call — we showed nothing.

Gap detection already existed and was correct. `ScheduleShiftUtil.getCoverageGaps` handled the empty case properly, and `FinalScheduleSummary` already had an amber "No one is currently on call" card. The problem was that `getCoverageGaps` had **exactly one call site in the codebase**, and that component was mounted behind a gate that is exactly inverted:

```
LayersPreview.tsx:520   {uniqueUsers.length > 0 && (<FinalScheduleSummary … />)}
```

`uniqueUsers` comes only from layer user-assignment rows, and `Layer.ts:377` emits no events when a layer has no users. So **zero assigned users *is* the 100%-gap state — and that was the one state where the warning didn't render.** You got a card titled "Final Schedule" containing an empty calendar and a timezone picker. That is the default state immediately after "Create schedule → Add Layer", which every new user hits.

The same inversion was independently reimplemented twice more, on the schedule Overview page (`Index.tsx:29`, which made its own "does not have any users on the roster" copy unreachable) and on the layer card (`LayerCard.tsx:270`).

Everywhere else a gap was an **absence** rather than a warning: blank calendar pixels, a missing feed item, a `-` in a table cell, a green "Execution Completed" pill.

## What changed

### Single source of truth
`ScheduleShiftUtil.getCoverageState` returns an explicit `NoLayers` / `NoUsers` / `UncoveredNow` / `Covered` status alongside the gaps, uncovered seconds, and a coverage ratio. Every coverage surface derives from it. A caller must handle `NoUsers`; it can no longer fall into "covered" by accident.

### Gap detection
- `CONTIGUITY_TOLERANCE_SECONDS` **90 → 5**. The engine artifact it exists to absorb is exactly 1 second (`Layer.ts` advances with `addRemoveSeconds(end, 1)`); at 90 a schedule whose layers were misaligned by a minute reported full coverage. Short holes are now filtered at the render layer via a new `minimumGapSeconds` option instead of being hidden by the detector. All 33 pre-existing on-call suites stay green.
- The window's **order** is now tested explicitly rather than inferred from the sign of a difference. `getDifferenceInSeconds` returns an **absolute** value, so an inverted window produced a confident `coverageRatio` of 1 — the function whose entire job is to surface missing coverage reporting 100% covered.
- `coverageRatio` is 0 for `NoLayers`/`NoUsers`, matching its documented contract.

Both of those last two were **found by the new test suites while they were being written**, in code added by this PR. Each has a regression test.

### UI
- Render the summary whenever the schedule has layers, not only when it has users, and branch the remedy copy — a no-users schedule is told to assign users, not to "widen active hours".
- Fix the same inverted gate on the Overview page and the layer card.
- An always-present coverage strip, so "fully covered" is a statement rather than the absence of a warning.
- Uncovered stretches drawn as hatched bands on the calendar with a legend entry, so an empty grid is distinguishable from one that failed to load.
- `now` held in state, so a gap that opens while the page is open is actually detected.
- The layer summary no longer claims "lower-priority layers take over" for the **lowest**-priority layer, where nothing takes over. A user configuring a single Mon–Fri 9-5 layer was explicitly told nights and weekends were handled.
- "On call now" column on the schedules list; schedule column and a "no one was on call" marker on the execution timeline; amber treatment for uncovered schedules in the policy summary and escalation chips.
- Coverage banner on the layers page, at the point of editing.

### Server
- **New**: `CoverageGapStarted` feed item + workspace notification when a schedule's roster drops to nobody. The "now on-call" branch required a *new* user to exist and the "no longer on-call" branch notified only the departing person — the one individual who can no longer act on it — so a gap opened in complete silence. This is the only push signal for a gap.
- Stop building "X was alerted" from a non-null assertion on `alertSentToUserId` for rows that have **no recipient by construction** (a coverage-gap skip). Those entries claimed somebody was paged when nobody was.
- Add the missing `triggeredByIncidentEpisodeId` to the timeline feed `select`. The guard 50 lines below read that field, so it was always undefined and **every incident-episode execution returned early**, producing no on-call feed entries at all for that trigger type.
- Fail closed in `UserService.getUserMarkdownString` on a missing user id: an undefined id was dropped from the WHERE clause, degrading the lookup into "any user".
- Record the schedule-added feed item **before** the no-one-on-call early return, so attaching a schedule is always audited. (The delete path emits from `onBeforeDelete`, which runs unconditionally — so removals were always recorded while additions could vanish.)
- Distinguish `Execution Completed` from `Execution Completed - No One Notified`, derived from the timeline rows so it cannot drift out of sync. **No migration**: `status` is a varchar, not a Postgres enum.

## Tests

**90 new tests.** Full suites green:

| Suite | Result |
|---|---|
| `Common/Tests/Types/OnCallDutyPolicy` + new server suite | 37 suites, **1637 passing** (was 1547) |
| `App/Tests/Dashboard` | 116 suites, **4399 passing** |

New files:
- `ScheduleCoverageState.test.ts` — 39 tests: status precedence (including the headline "layers exist, zero users ⇒ NoUsers, explicitly *not* Covered"), current/next passthrough, ratio arithmetic, and adversarial input (unsorted, overlapping, zero-length, inverted, out-of-window shifts).
- `ScheduleCoverageGapTolerance.test.ts` — 25 tests pinning the 90 → 5 change, with a boundary sweep (4s/5s absorbed, 6s/89s/90s/91s reported) backed by real `LayerUtil` output, plus `minimumGapSeconds` semantics.
- `ScheduleCoverageEndToEnd.test.ts` — 15 tests over the full `LayerUtil → groupEventsIntoShifts → getCoverageGaps` pipeline, which nothing tested together before.
- `OnCallDutyPolicyExecutionLogTimelineGapFeed.test.ts` — 11 tests stubbing at the service boundary (no Postgres) for the feed-builder branch and the `UserService` guard.
- `LayerOffHoursFallback.test.ts` — 9 tests over the off-hours-fallback truth table, asserting the string never contains "take over" when there is no fallback.

`npx eslint` clean and `tsc --noEmit` clean on both `Common` and `App`.

## Notes

- **No database migration.** The one place that wanted a new column (`notifiedUserCount`) was reworked to derive the same answer from existing timeline rows plus a new `status` value — `status` is a varchar, so nothing schema-level changed. This also can't drift from reality the way a manually-incremented counter can.
- The tolerance change (90 → 5) is the only behavioural change to shared detection logic. It's the highest-risk item here; all 33 pre-existing on-call suites pass unchanged.
