### PR TITLE
feat(on-call): never drop a page silently

### DIFF
--- a/App/FeatureSet/Workers/DataMigrations/Index.ts
+++ b/App/FeatureSet/Workers/DataMigrations/Index.ts
@@ -101,6 +101,7 @@ import MoveNetworkDeviceMonitorCollectionToDevices from "./MoveNetworkDeviceMoni
 import BackfillNetworkSiteTypes from "./BackfillNetworkSiteTypes";
 import AddSessionIdToTelemetryTables from "./AddSessionIdToTelemetryTables";
 import AddScheduledMaintenanceTemplateOwnerPermissions from "./AddScheduledMaintenanceTemplateOwnerPermissions";
+import RepairEpisodeNotificationRuleSeverity from "./RepairEpisodeNotificationRuleSeverity";
 
 // This is the order in which the migrations will be run. Add new migrations to the end of the array.
 
@@ -332,6 +333,16 @@ const DataMigrations: Array<DataMigrationBase> = [
    * silent access.
    */
   new AddScheduledMaintenanceTemplateOwnerPermissions(),
+  /*
+   * Repairs the episode notification rules that were created with a NULL severity and so
+   * matched nothing the on-call path ever queried — the reason users who relied on the
+   * auto-created defaults received no alert-episode or incident-episode pages at all.
+   * Fans each NULL row out into one row per severity in its project (preserving the
+   * notification method and notifyAfterMinutes) and removes the original, which is both
+   * unreachable by the severity-filtered count query and invisible on the two episode
+   * rule pages. Idempotent and restartable, so a re-run is a clean no-op.
+   */
+  new RepairEpisodeNotificationRuleSeverity(),
 ];
 
 export default DataMigrations;

--- a/App/FeatureSet/Workers/DataMigrations/RepairEpisodeNotificationRuleSeverity.ts
+++ b/App/FeatureSet/Workers/DataMigrations/RepairEpisodeNotificationRuleSeverity.ts
@@ -1,0 +1,417 @@
+import DataMigrationBase from "./DataMigrationBase";
+import AlertSeverity from "Common/Models/DatabaseModels/AlertSeverity";
+import AlertSeverityService from "Common/Server/Services/AlertSeverityService";
+import IncidentSeverity from "Common/Models/DatabaseModels/IncidentSeverity";
+import IncidentSeverityService from "Common/Server/Services/IncidentSeverityService";
+import UserNotificationRule from "Common/Models/DatabaseModels/UserNotificationRule";
+import UserNotificationRuleService from "Common/Server/Services/UserNotificationRuleService";
+import Query from "Common/Server/Types/Database/Query";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "Common/Types/Database/LimitMax";
+import NotificationRuleType from "Common/Types/NotificationRule/NotificationRuleType";
+import ObjectID from "Common/Types/ObjectID";
+import logger from "Common/Server/Utils/Logger";
+
+/*
+ * How many NULL-severity rules are pulled per round trip. Small on purpose: each row
+ * fans out into one INSERT per severity in its project, so a large page turns into a
+ * long-running write burst against a table the on-call path reads on every page.
+ */
+const BATCH_SIZE: number = 100;
+
+/*
+ * Repairs the episode notification rules that were created without a severity.
+ *
+ * The bug: addDefaultNotificationRulesForVerifiedMethod created the two episode rule
+ * types through createSingleRule, which sets only `ruleType` and `notifyAfterMinutes` and
+ * leaves `alertSeverityId` / `incidentSeverityId` NULL. But UserOnCallLogService counts
+ * matching rules filtered by a CONCRETE severity id, and NULL never equals a uuid — so
+ * every one of these "default" rules counted as zero and the page took the dead-end
+ * branch. Users who never opened the episode rule pages (which is everyone who relied on
+ * the defaults) got no episode pages at all.
+ *
+ * The forward fix creates these rules per severity. This migration repairs the rows
+ * already in the table: each NULL-severity episode rule becomes one row per severity in
+ * its project, preserving the notification-method FK and `notifyAfterMinutes` so the
+ * user's original intent — "reach me here, after this long" — survives intact.
+ *
+ * Why the original is DELETED rather than left behind:
+ *
+ *   1. It can never match. The count query the on-call path runs always supplies a
+ *      concrete severity id, so a NULL row is unreachable by construction, not merely
+ *      unlikely.
+ *   2. It is invisible. Both episode rule pages (EpisodeOnCallRules.tsx and
+ *      IncidentEpisodeOnCallRules.tsx) scope their ModelTable by severity id, so a
+ *      NULL-severity row renders in no table on any page.
+ *
+ * Together those mean the user can neither be notified by the row nor see it nor remove
+ * it — it is pure invisible clutter that shows up only as an inflated rule count in any
+ * future readiness or compliance calculation. Leaving it is strictly worse than removing
+ * it, and the replacement rows carry everything it expressed.
+ *
+ * Idempotent: replacements are created only when an identical (project, user, ruleType,
+ * severity, method) rule does not already exist, and the NULL originals are gone after a
+ * successful pass, so a re-run finds nothing to do. Restartable: each row is fanned out
+ * and deleted before the next is read, so a killed pod resumes with at most one row
+ * half-done, and that row's duplicate replacements are suppressed by the existence check.
+ */
+export default class RepairEpisodeNotificationRuleSeverity extends DataMigrationBase {
+  public constructor() {
+    super("RepairEpisodeNotificationRuleSeverity");
+  }
+
+  public override async migrate(): Promise<void> {
+    await this.repairRulesForEpisodeRuleType(
+      NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+    );
+
+    await this.repairRulesForEpisodeRuleType(
+      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+    );
+  }
+
+  private async repairRulesForEpisodeRuleType(
+    ruleType: NotificationRuleType,
+  ): Promise<void> {
+    const isAlertEpisode: boolean =
+      ruleType === NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE;
+
+    const query: Query<UserNotificationRule> = isAlertEpisode
+      ? {
+          ruleType: ruleType,
+          alertSeverityId: QueryHelper.isNull(),
+        }
+      : {
+          ruleType: ruleType,
+          incidentSeverityId: QueryHelper.isNull(),
+        };
+
+    /*
+     * Severity lists are per project and every rule in a project fans out to the same
+     * list, so they are resolved once per project rather than once per rule. Keyed by
+     * project id; a project with thousands of affected users is the common shape here.
+     */
+    const severityIdsByProjectId: Map<string, Array<ObjectID>> = new Map<
+      string,
+      Array<ObjectID>
+    >();
+
+    let createdCount: number = 0;
+    let deletedCount: number = 0;
+
+    /*
+     * Rows we deliberately do not touch stay in the table, so they would be returned
+     * again by the next page-zero query and the loop would never drain. The cursor is
+     * therefore the running count of rows left in place: with `_id ASC` every row from an
+     * already-processed page sorts before every row not yet seen, so the untouched rows
+     * occupy exactly the first `leftInPlaceCount` positions of the remaining result set.
+     *
+     * (Rows INSERTed by another process mid-migration can land anywhere in that ordering
+     * because ids are random uuids, so a concurrent writer could hide one row from this
+     * pass. Data migrations run at boot before this pod serves traffic, and the pass is
+     * idempotent, so the cost of that is one extra run — not a corrupted row.)
+     */
+    let leftInPlaceCount: number = 0;
+
+    for (;;) {
+      const rules: Array<UserNotificationRule> =
+        await UserNotificationRuleService.findBy({
+          query: query,
+          select: {
+            _id: true,
+            projectId: true,
+            userId: true,
+            notifyAfterMinutes: true,
+            userEmailId: true,
+            userSmsId: true,
+            userCallId: true,
+            userPushId: true,
+            userWhatsAppId: true,
+            userTelegramId: true,
+            userWebhookId: true,
+          },
+          sort: {
+            _id: SortOrder.Ascending,
+          },
+          skip: leftInPlaceCount,
+          limit: BATCH_SIZE,
+          props: {
+            isRoot: true,
+          },
+        });
+
+      if (rules.length === 0) {
+        break;
+      }
+
+      for (const rule of rules) {
+        if (!rule.id || !rule.projectId || !rule.userId) {
+          /*
+           * A rule with no project or user cannot be fanned out (the replacement would
+           * fail the model's own NOT NULL constraints) and cannot be reasoned about.
+           * Left alone and reported rather than deleted: deleting rows we do not
+           * understand is not a repair.
+           */
+          logger.debug(
+            `RepairEpisodeNotificationRuleSeverity: skipping rule ${rule.id?.toString() || "(no id)"} because it has no projectId or userId.`,
+          );
+          leftInPlaceCount++;
+          continue;
+        }
+
+        const methodFks: Partial<UserNotificationRule> =
+          this.getNotificationMethodColumns(rule);
+
+        if (Object.keys(methodFks).length === 0) {
+          /*
+           * No notification method at all. Every rule createSingleRule produced carries
+           * exactly one, so this is something else — an opt-out row, or a row a future
+           * feature gave a meaning this migration predates. Fanning it out would create
+           * rules that deliver nothing and would be rejected by onBeforeCreate anyway.
+           */
+          logger.debug(
+            `RepairEpisodeNotificationRuleSeverity: skipping rule ${rule.id.toString()} because it carries no notification method.`,
+          );
+          leftInPlaceCount++;
+          continue;
+        }
+
+        const severityIds: Array<ObjectID> =
+          await this.getSeverityIdsForProject({
+            projectId: rule.projectId,
+            isAlertEpisode: isAlertEpisode,
+            cache: severityIdsByProjectId,
+          });
+
+        if (severityIds.length === 0) {
+          /*
+           * The project has no severities of this kind, so there is nothing to fan out
+           * to. Deleting here would throw away the user's chosen method and delay for a
+           * severity that has simply not been created yet, and would gain nothing — the
+           * row is equally unreachable either way. Left in place; the severity-creation
+           * backfill picks the intent up when the project's first severity appears.
+           */
+          logger.debug(
+            `RepairEpisodeNotificationRuleSeverity: project ${rule.projectId.toString()} has no ${isAlertEpisode ? "alert" : "incident"} severities, leaving rule ${rule.id.toString()} in place.`,
+          );
+          leftInPlaceCount++;
+          continue;
+        }
+
+        for (const severityId of severityIds) {
+          const created: boolean = await this.createRuleForSeverity({
+            rule: rule,
+            ruleType: ruleType,
+            severityId: severityId,
+            isAlertEpisode: isAlertEpisode,
+            methodFks: methodFks,
+          });
+
+          if (created) {
+            createdCount++;
+          }
+        }
+
+        /*
+         * Only after every replacement exists. If a create throws, the exception halts
+         * the migration with the original still present, so the retry re-runs a row that
+         * is at worst partially fanned out — and the existence check makes that free.
+         */
+        await UserNotificationRuleService.deleteOneById({
+          id: rule.id,
+          props: {
+            isRoot: true,
+          },
+        });
+
+        deletedCount++;
+      }
+    }
+
+    logger.debug(
+      `RepairEpisodeNotificationRuleSeverity: ${ruleType} — created ${createdCount} severity-scoped rule(s), deleted ${deletedCount} NULL-severity rule(s), left ${leftInPlaceCount} row(s) untouched.`,
+    );
+  }
+
+  /*
+   * Creates the replacement for one (rule, severity) pair unless it already exists.
+   * Returns whether a row was written, so the caller can report a truthful count on a
+   * partially-completed re-run.
+   */
+  private async createRuleForSeverity(input: {
+    rule: UserNotificationRule;
+    ruleType: NotificationRuleType;
+    severityId: ObjectID;
+    isAlertEpisode: boolean;
+    methodFks: Partial<UserNotificationRule>;
+  }): Promise<boolean> {
+    const { rule, ruleType, severityId, isAlertEpisode, methodFks } = input;
+
+    const severityQuery: Query<UserNotificationRule> = isAlertEpisode
+      ? { alertSeverityId: severityId }
+      : { incidentSeverityId: severityId };
+
+    const existingRule: UserNotificationRule | null =
+      await UserNotificationRuleService.findOneBy({
+        query: {
+          projectId: rule.projectId!,
+          userId: rule.userId!,
+          ruleType: ruleType,
+          ...severityQuery,
+          ...methodFks,
+        } as Query<UserNotificationRule>,
+        select: {
+          _id: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+    if (existingRule) {
+      return false;
+    }
+
+    const newRule: UserNotificationRule = new UserNotificationRule();
+    newRule.projectId = rule.projectId!;
+    newRule.userId = rule.userId!;
+    newRule.ruleType = ruleType;
+
+    /*
+     * `notifyAfterMinutes` is the whole reason this is a fan-out rather than a delete:
+     * a user who set "page me on Telegram after 15 minutes" keeps that delay on every
+     * severity. Defaulted to 0 only when the original never carried one.
+     */
+    newRule.notifyAfterMinutes = rule.notifyAfterMinutes ?? 0;
+
+    if (isAlertEpisode) {
+      newRule.alertSeverityId = severityId;
+    } else {
+      newRule.incidentSeverityId = severityId;
+    }
+
+    Object.assign(newRule, methodFks);
+
+    await UserNotificationRuleService.create({
+      data: newRule,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    return true;
+  }
+
+  /*
+   * The notification-method FK the original rule points at, as a partial model that can
+   * be spread into both the duplicate-detection query and the replacement row. Copying
+   * every FK that is set (rather than assuming one) keeps this correct if a rule is ever
+   * allowed to name more than one method.
+   */
+  private getNotificationMethodColumns(
+    rule: UserNotificationRule,
+  ): Partial<UserNotificationRule> {
+    const columns: Partial<UserNotificationRule> = {};
+
+    if (rule.userEmailId) {
+      columns.userEmailId = rule.userEmailId;
+    }
+
+    if (rule.userSmsId) {
+      columns.userSmsId = rule.userSmsId;
+    }
+
+    if (rule.userCallId) {
+      columns.userCallId = rule.userCallId;
+    }
+
+    if (rule.userPushId) {
+      columns.userPushId = rule.userPushId;
+    }
+
+    if (rule.userWhatsAppId) {
+      columns.userWhatsAppId = rule.userWhatsAppId;
+    }
+
+    if (rule.userTelegramId) {
+      columns.userTelegramId = rule.userTelegramId;
+    }
+
+    if (rule.userWebhookId) {
+      columns.userWebhookId = rule.userWebhookId;
+    }
+
+    return columns;
+  }
+
+  private async getSeverityIdsForProject(input: {
+    projectId: ObjectID;
+    isAlertEpisode: boolean;
+    cache: Map<string, Array<ObjectID>>;
+  }): Promise<Array<ObjectID>> {
+    const { projectId, isAlertEpisode, cache } = input;
+
+    const cacheKey: string = projectId.toString();
+    const cached: Array<ObjectID> | undefined = cache.get(cacheKey);
+
+    if (cached) {
+      return cached;
+    }
+
+    let severityIds: Array<ObjectID> = [];
+
+    if (isAlertEpisode) {
+      const severities: Array<AlertSeverity> =
+        await AlertSeverityService.findBy({
+          query: {
+            projectId: projectId,
+          },
+          select: {
+            _id: true,
+          },
+          skip: 0,
+          limit: LIMIT_PER_PROJECT,
+          props: {
+            isRoot: true,
+          },
+        });
+
+      severityIds = severities.map((severity: AlertSeverity) => {
+        return severity.id!;
+      });
+    } else {
+      const severities: Array<IncidentSeverity> =
+        await IncidentSeverityService.findBy({
+          query: {
+            projectId: projectId,
+          },
+          select: {
+            _id: true,
+          },
+          skip: 0,
+          limit: LIMIT_PER_PROJECT,
+          props: {
+            isRoot: true,
+          },
+        });
+
+      severityIds = severities.map((severity: IncidentSeverity) => {
+        return severity.id!;
+      });
+    }
+
+    cache.set(cacheKey, severityIds);
+
+    return severityIds;
+  }
+
+  public override async rollback(): Promise<void> {
+    /*
+     * Deliberately not reversible. Recreating the NULL-severity originals would restore
+     * rows that page nobody and that the user cannot see or delete — the exact defect
+     * this migration exists to remove.
+     */
+    return;
+  }
+}

--- a/App/FeatureSet/Workers/Index.ts
+++ b/App/FeatureSet/Workers/Index.ts
@@ -87,6 +87,21 @@ import "./Jobs/NetworkSite/RecomputeStaleRollups";
 // On-Call Duty Policy Executions.
 import "./Jobs/OnCallDutyPolicyExecutionLog/ExecutePendingExecutions";
 import "./Jobs/OnCallDutyPolicyExecutionLog/TimeoutStuckExecutions";
+
+/*
+ * On-Call Duty Policy notification rules.
+ *
+ * Every import in this file is load-bearing, not documentation: RunCron
+ * registers a job purely as a module side effect (it calls
+ * JobDictionary.setJobFunction and Queue.addJob at import time), so a job file
+ * nothing imports is never scheduled AND cannot be enqueued by name either —
+ * the Worker queue looks the function up in JobDictionary and silently does
+ * nothing when it is absent. The severity backfill is enqueued by name from
+ * IncidentSeverityService / AlertSeverityService, so without this line both
+ * that enqueue and the five-minute sweep are no-ops and severities created
+ * after a user joined stay uncovered.
+ */
+import "./Jobs/OnCallDutyPolicy/BackfillNotificationRulesForNewSeverities";
 // Payments.
 import "./Jobs/PaymentProvider/CheckSubscriptionStatus";
 import "./Jobs/PaymentProvider/PopulatePlanNameInProject";

--- a/App/FeatureSet/Workers/Jobs/OnCallDutyPolicy/BackfillNotificationRulesForNewSeverities.ts
+++ b/App/FeatureSet/Workers/Jobs/OnCallDutyPolicy/BackfillNotificationRulesForNewSeverities.ts
@@ -1,0 +1,777 @@
+import RunCron from "../../Utils/Cron";
+import OneUptimeDate from "Common/Types/Date";
+import NotificationRuleType from "Common/Types/NotificationRule/NotificationRuleType";
+import ObjectID from "Common/Types/ObjectID";
+import Query from "Common/Types/BaseDatabase/Query";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import Semaphore, {
+  SemaphoreMutex,
+} from "Common/Server/Infrastructure/Semaphore";
+import { EVERY_FIVE_MINUTE } from "Common/Utils/CronTime";
+import logger from "Common/Server/Utils/Logger";
+import AlertSeverityService from "Common/Server/Services/AlertSeverityService";
+import IncidentSeverityService from "Common/Server/Services/IncidentSeverityService";
+import UserEmailService from "Common/Server/Services/UserEmailService";
+import UserNotificationRuleService from "Common/Server/Services/UserNotificationRuleService";
+import AlertSeverity from "Common/Models/DatabaseModels/AlertSeverity";
+import IncidentSeverity from "Common/Models/DatabaseModels/IncidentSeverity";
+import UserEmail from "Common/Models/DatabaseModels/UserEmail";
+import UserNotificationRule from "Common/Models/DatabaseModels/UserNotificationRule";
+
+/*
+ * Gap A of Internal/Roadmap/OnCallNotificationReadiness.md.
+ *
+ * A responder's default notification rules are written twice in their life:
+ * when they join a project, and when they verify a notification method. Both
+ * paths iterate the severities that exist AT THAT MOMENT. Nothing ever revisited
+ * the question, so a severity created later - the "Sev4" somebody adds a year
+ * in - had a notification rule for precisely nobody. Every incident on it
+ * counted zero matching rules, wrote "No notification rules found for this user"
+ * into an execution log, and paged no one. It is the highest-frequency way a
+ * page goes missing.
+ *
+ * This job closes it. IncidentSeverityService.onCreateSuccess and
+ * AlertSeverityService.onCreateSuccess enqueue it by name the moment a severity
+ * is created (they duplicate JOB_NAME below verbatim - Common cannot import from
+ * App), so in practice it runs within seconds. It ALSO runs on a schedule over
+ * severities created in the recent past, which is what makes it safe: the Worker
+ * queue dispatches on job name and hands the job function no payload, so the job
+ * has to re-derive its own work set anyway, and re-deriving it means a lost
+ * enqueue - Redis down, worker mid-deploy - costs minutes of latency instead of
+ * a permanently uncovered severity.
+ *
+ * Every write it makes is guarded by what already exists, so running it twice
+ * over the same severity is a pair of reads and nothing else. The guarding is
+ * deliberately belt AND braces - a snapshot check, a per-row existence check
+ * and a single-flight lock - because a duplicated rule is a duplicated page,
+ * and a job that re-derives its own work set every five minutes over an
+ * hour-wide window gets many, many chances to duplicate one.
+ */
+
+/*
+ * Enqueued by name from Common/Server/Services/IncidentSeverityService.ts and
+ * Common/Server/Services/AlertSeverityService.ts. Renaming this means renaming
+ * it in both.
+ */
+const JOB_NAME: string =
+  "OnCallDutyPolicy:BackfillNotificationRulesForNewSeverities";
+
+/*
+ * How far back the scheduled sweep looks. Comfortably longer than the schedule,
+ * so a severity created while the worker was down or restarting is still picked
+ * up by a later tick. The window is cheap because severity creation is rare:
+ * in steady state it selects zero rows and the job ends after two reads.
+ */
+const BACKFILL_LOOKBACK_IN_MINUTES: number = 60;
+
+/*
+ * Single-flight lock for the sweep.
+ *
+ * The per-row existence check in createRule is a check-then-create, and
+ * check-then-create is exactly what two sweeps running at the same instant
+ * defeat: both read "no rule for this cell yet", both write one, and the
+ * responder is paged twice for one incident. Nothing in the database settles
+ * that on its own - UserNotificationRule carries no unique index over
+ * (project, user, ruleType, severity, method) - so the sweep is serialised
+ * here instead. Both ways this job can start, the five-minute schedule and the
+ * by-name enqueue from IncidentSeverityService / AlertSeverityService, run the
+ * same function and therefore take the same key, which is what makes "a
+ * severity created one second before a tick" safe.
+ *
+ * acquireAttemptsLimit: 1 - a run that finds the lock held skips instead of
+ * queueing behind it. The holder derives its work set from the same lookback
+ * query, so it is already covering the same severities; waiting would only
+ * repeat work in flight, and anything the holder misses is still inside the
+ * window for the next tick.
+ *
+ * The lock timeout deliberately outlives the job's own five-minute timeout:
+ * QueueWorker.runJobWithTimeout races the body rather than stopping it, so an
+ * overrunning sweep must keep holding the lock rather than let a second one in
+ * behind it. redis-semaphore's Mutex refreshes itself while it is held, so this
+ * value only bounds how long a CRASHED worker's lock lingers before another
+ * replica may take over.
+ */
+const SWEEP_LOCK_KEY: string = JOB_NAME;
+const SWEEP_LOCK_NAMESPACE: string = "Workers.Cron";
+const SWEEP_LOCK_TIMEOUT_MS: number =
+  OneUptimeDate.convertMinutesToMilliseconds(6);
+
+type SeverityKind = "incident" | "alert";
+
+interface NewSeverity {
+  id: ObjectID;
+  projectId: ObjectID;
+  kind: SeverityKind;
+}
+
+/*
+ * The two severity-scoped rule types per severity kind. Episode rules are
+ * included because they are severity-scoped too - UserOnCallLogService counts
+ * them filtered by a concrete severity id exactly like the non-episode ones.
+ */
+const RULE_TYPES_BY_SEVERITY_KIND: Record<
+  SeverityKind,
+  Array<NotificationRuleType>
+> = {
+  incident: [
+    NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+    NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+  ],
+  alert: [
+    NotificationRuleType.ON_CALL_EXECUTED_ALERT,
+    NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+  ],
+};
+
+type NotificationMethodColumn =
+  | "userEmailId"
+  | "userSmsId"
+  | "userCallId"
+  | "userPushId"
+  | "userWhatsAppId"
+  | "userTelegramId"
+  | "userWebhookId";
+
+const NOTIFICATION_METHOD_COLUMNS: Array<NotificationMethodColumn> = [
+  "userEmailId",
+  "userSmsId",
+  "userCallId",
+  "userPushId",
+  "userWhatsAppId",
+  "userTelegramId",
+  "userWebhookId",
+];
+
+/* One (channel, delay) the responder already asked for, ready to be re-stated. */
+interface MirroredRule {
+  methodColumn: NotificationMethodColumn;
+  methodId: ObjectID;
+  notifyAfterMinutes: number;
+}
+
+/*
+ * What one responder has already said about one rule type, distilled from their
+ * existing rows.
+ */
+interface ResponderIntent {
+  hasRuleForNewSeverity: boolean;
+  // Keyed on channel + method + delay, which is what "distinct pair" means here.
+  mirroredRules: Map<string, MirroredRule>;
+  hasOptOut: boolean;
+}
+
+RunCron(
+  JOB_NAME,
+  { schedule: EVERY_FIVE_MINUTE, runOnStartup: false },
+  async () => {
+    let mutex: SemaphoreMutex | null = null;
+
+    try {
+      mutex = await Semaphore.lock({
+        key: SWEEP_LOCK_KEY,
+        namespace: SWEEP_LOCK_NAMESPACE,
+        lockTimeout: SWEEP_LOCK_TIMEOUT_MS,
+        acquireAttemptsLimit: 1,
+      });
+    } catch (err) {
+      /*
+       * Either a sweep is already in flight - in which case skipping is the
+       * whole point - or Redis is unreachable, in which case no job of any
+       * kind is being dispatched anyway and there is nothing for this run to
+       * do differently.
+       */
+      logger.debug(
+        `${JOB_NAME}: could not acquire the sweep lock; a sweep is already in flight (or Redis is unavailable). Skipping this run: ${err}`,
+      );
+      return;
+    }
+
+    /*
+     * Everything below runs under the lock, released in `finally` so a throw
+     * anywhere frees it for the next tick instead of wedging the job until the
+     * lock times out.
+     */
+    try {
+      const newSeverities: Array<NewSeverity> =
+        await findRecentlyCreatedSeverities();
+
+      if (newSeverities.length === 0) {
+        return;
+      }
+
+      logger.debug(
+        `${JOB_NAME}: backfilling notification rules for ${newSeverities.length} recently created severity/severities`,
+        { service: "workers" },
+      );
+
+      for (const severity of newSeverities) {
+        /*
+         * One project's bad data must not stop the others. A severity that
+         * throws is logged and skipped; the next sweep will try it again while
+         * it is still inside the lookback window.
+         */
+        try {
+          await backfillSeverity(severity);
+        } catch (err) {
+          logger.error(
+            `${JOB_NAME}: failed to backfill notification rules for ${severity.kind} severity ${severity.id.toString()}`,
+          );
+          logger.error(err);
+        }
+      }
+    } finally {
+      try {
+        await Semaphore.release(mutex);
+      } catch (err) {
+        // a release failure only means the lock expires on its own timeout.
+        logger.error(`${JOB_NAME}: error releasing the sweep lock: ${err}`);
+      }
+    }
+  },
+);
+
+type FindRecentlyCreatedSeveritiesFunction = () => Promise<Array<NewSeverity>>;
+
+const findRecentlyCreatedSeverities: FindRecentlyCreatedSeveritiesFunction =
+  async (): Promise<Array<NewSeverity>> => {
+    const createdAfter: Date = OneUptimeDate.getSomeMinutesAgo(
+      BACKFILL_LOOKBACK_IN_MINUTES,
+    );
+
+    const incidentSeverities: Array<IncidentSeverity> =
+      await IncidentSeverityService.findAllBy({
+        query: {
+          createdAt: QueryHelper.greaterThanEqualTo(createdAfter),
+        },
+        select: {
+          _id: true,
+          projectId: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+    const alertSeverities: Array<AlertSeverity> =
+      await AlertSeverityService.findAllBy({
+        query: {
+          createdAt: QueryHelper.greaterThanEqualTo(createdAfter),
+        },
+        select: {
+          _id: true,
+          projectId: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+    const severities: Array<NewSeverity> = [];
+
+    for (const incidentSeverity of incidentSeverities) {
+      if (!incidentSeverity.id || !incidentSeverity.projectId) {
+        continue;
+      }
+
+      severities.push({
+        id: incidentSeverity.id,
+        projectId: incidentSeverity.projectId,
+        kind: "incident",
+      });
+    }
+
+    for (const alertSeverity of alertSeverities) {
+      if (!alertSeverity.id || !alertSeverity.projectId) {
+        continue;
+      }
+
+      severities.push({
+        id: alertSeverity.id,
+        projectId: alertSeverity.projectId,
+        kind: "alert",
+      });
+    }
+
+    return severities;
+  };
+
+type BackfillSeverityFunction = (severity: NewSeverity) => Promise<void>;
+
+const backfillSeverity: BackfillSeverityFunction = async (
+  severity: NewSeverity,
+): Promise<void> => {
+  /*
+   * Read once per severity, not once per rule type: the same set answers "who in
+   * this project can be reached at all?" for both rule types below.
+   */
+  const verifiedEmailIdByUserId: Map<string, ObjectID> =
+    await findVerifiedEmailsInProject(severity.projectId);
+
+  for (const ruleType of RULE_TYPES_BY_SEVERITY_KIND[severity.kind]) {
+    await backfillSeverityForRuleType(
+      severity,
+      ruleType,
+      verifiedEmailIdByUserId,
+    );
+  }
+};
+
+type FindVerifiedEmailsInProjectFunction = (
+  projectId: ObjectID,
+) => Promise<Map<string, ObjectID>>;
+
+const findVerifiedEmailsInProject: FindVerifiedEmailsInProjectFunction = async (
+  projectId: ObjectID,
+): Promise<Map<string, ObjectID>> => {
+  const userEmails: Array<UserEmail> = await UserEmailService.findAllBy({
+    query: {
+      projectId: projectId,
+      isVerified: true,
+    },
+    select: {
+      _id: true,
+      userId: true,
+    },
+    props: {
+      isRoot: true,
+    },
+  });
+
+  const verifiedEmailIdByUserId: Map<string, ObjectID> = new Map<
+    string,
+    ObjectID
+  >();
+
+  for (const userEmail of userEmails) {
+    if (!userEmail.id || !userEmail.userId) {
+      continue;
+    }
+
+    const userId: string = userEmail.userId.toString();
+
+    // A responder with several verified addresses gets a rule for the first.
+    if (!verifiedEmailIdByUserId.has(userId)) {
+      verifiedEmailIdByUserId.set(userId, userEmail.id);
+    }
+  }
+
+  return verifiedEmailIdByUserId;
+};
+
+type BackfillSeverityForRuleTypeFunction = (
+  severity: NewSeverity,
+  ruleType: NotificationRuleType,
+  verifiedEmailIdByUserId: Map<string, ObjectID>,
+) => Promise<void>;
+
+const backfillSeverityForRuleType: BackfillSeverityForRuleTypeFunction = async (
+  severity: NewSeverity,
+  ruleType: NotificationRuleType,
+  verifiedEmailIdByUserId: Map<string, ObjectID>,
+): Promise<void> => {
+  /*
+   * Every rule of this type in the project, in ONE read, grouped in memory
+   * afterwards. The obvious shape - loop the project's users, ask the database
+   * once per user per severity - is what TeamComplianceService does and why it
+   * is an N+1; a project with a thousand responders would issue a thousand
+   * queries per severity here.
+   */
+  const existingRules: Array<UserNotificationRule> =
+    await UserNotificationRuleService.findAllBy({
+      query: {
+        projectId: severity.projectId,
+        ruleType: ruleType,
+      },
+      select: {
+        _id: true,
+        userId: true,
+        notifyAfterMinutes: true,
+        isOptOut: true,
+        incidentSeverityId: true,
+        alertSeverityId: true,
+        userEmailId: true,
+        userSmsId: true,
+        userCallId: true,
+        userPushId: true,
+        userWhatsAppId: true,
+        userTelegramId: true,
+        userWebhookId: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+  const intentByUserId: Map<string, ResponderIntent> = buildResponderIntents(
+    existingRules,
+    severity,
+  );
+
+  /*
+   * Responders who have already said something about this rule type. Mirror what
+   * they said onto the new severity.
+   */
+  for (const [userId, intent] of intentByUserId) {
+    if (intent.hasRuleForNewSeverity) {
+      // Already covered - by an earlier run of this job, or by hand.
+      continue;
+    }
+
+    if (intent.mirroredRules.size > 0) {
+      for (const mirroredRule of intent.mirroredRules.values()) {
+        await createRule({
+          severity: severity,
+          ruleType: ruleType,
+          userId: new ObjectID(userId),
+          mirroredRule: mirroredRule,
+        });
+      }
+
+      continue;
+    }
+
+    /*
+     * They have rules of this type and every one of them is an opt-out: they
+     * have deliberately muted this rule type for every severity they have an
+     * opinion about. Mirroring the opt-out is the only answer that respects
+     * that - leaving the cell empty would hand them straight to the
+     * verified-method fallback, which is to say it would page someone who asked
+     * not to be paged.
+     */
+    if (intent.hasOptOut) {
+      await createRule({
+        severity: severity,
+        ruleType: ruleType,
+        userId: new ObjectID(userId),
+        mirroredRule: null,
+      });
+    }
+  }
+
+  /*
+   * Responders who have said nothing at all about this rule type get today's
+   * default: their verified email, immediately. That is exactly what
+   * addDefaultNotificationRuleForUser would have written for them had this
+   * severity existed when they joined.
+   */
+  for (const [userId, userEmailId] of verifiedEmailIdByUserId) {
+    if (intentByUserId.has(userId)) {
+      continue;
+    }
+
+    await createRule({
+      severity: severity,
+      ruleType: ruleType,
+      userId: new ObjectID(userId),
+      mirroredRule: {
+        methodColumn: "userEmailId",
+        methodId: userEmailId,
+        notifyAfterMinutes: 0,
+      },
+    });
+  }
+};
+
+type BuildResponderIntentsFunction = (
+  existingRules: Array<UserNotificationRule>,
+  severity: NewSeverity,
+) => Map<string, ResponderIntent>;
+
+/**
+ * Distils each responder's existing rows for one rule type into "what would this
+ * person want for a new severity?".
+ *
+ * The answer is: the same channels, at the same delays, that they already chose
+ * for this rule type on the severities they did configure. Someone who set "Sev1
+ * -> call me immediately, Sev3 -> email me after 15 minutes" gets a Sev4 rule
+ * built out of those same choices, rather than a hardcoded default. That
+ * distinction is the whole point: a default would ring the phone of a responder
+ * who only ever uses email, and would page immediately someone who deliberately
+ * built a delay into every rule they own. Mirroring can only ever hand a
+ * responder a channel they already opted into.
+ *
+ * Rows for the new severity itself are the idempotency guard, not input: seeing
+ * one means an earlier run (or the responder) already covered this cell.
+ *
+ * Rows with no severity at all still count as intent. Episode default rules were
+ * written without a severity id for a long time (Gap G), and those rows are just
+ * as much a statement of "this is how I want to be told" as a severity-scoped
+ * one.
+ */
+const buildResponderIntents: BuildResponderIntentsFunction = (
+  existingRules: Array<UserNotificationRule>,
+  severity: NewSeverity,
+): Map<string, ResponderIntent> => {
+  const intentByUserId: Map<string, ResponderIntent> = new Map<
+    string,
+    ResponderIntent
+  >();
+
+  const newSeverityId: string = severity.id.toString();
+
+  for (const rule of existingRules) {
+    if (!rule.userId) {
+      continue;
+    }
+
+    const userId: string = rule.userId.toString();
+
+    let intent: ResponderIntent | undefined = intentByUserId.get(userId);
+
+    if (!intent) {
+      intent = {
+        hasRuleForNewSeverity: false,
+        mirroredRules: new Map<string, MirroredRule>(),
+        hasOptOut: false,
+      };
+      intentByUserId.set(userId, intent);
+    }
+
+    const severityIdOnRule: ObjectID | undefined =
+      severity.kind === "incident"
+        ? rule.incidentSeverityId
+        : rule.alertSeverityId;
+
+    if (severityIdOnRule && severityIdOnRule.toString() === newSeverityId) {
+      intent.hasRuleForNewSeverity = true;
+      continue;
+    }
+
+    if (rule.isOptOut) {
+      intent.hasOptOut = true;
+      continue;
+    }
+
+    const notifyAfterMinutes: number = rule.notifyAfterMinutes || 0;
+
+    for (const methodColumn of NOTIFICATION_METHOD_COLUMNS) {
+      const methodId: ObjectID | undefined = rule[methodColumn];
+
+      if (!methodId) {
+        continue;
+      }
+
+      intent.mirroredRules.set(
+        `${methodColumn}:${methodId.toString()}:${notifyAfterMinutes}`,
+        {
+          methodColumn: methodColumn,
+          methodId: methodId,
+          notifyAfterMinutes: notifyAfterMinutes,
+        },
+      );
+    }
+  }
+
+  return intentByUserId;
+};
+
+type CreateRuleFunction = (data: {
+  severity: NewSeverity;
+  ruleType: NotificationRuleType;
+  userId: ObjectID;
+  // null writes the opt-out form: no method, isOptOut true.
+  mirroredRule: MirroredRule | null;
+}) => Promise<void>;
+
+const createRule: CreateRuleFunction = async (data: {
+  severity: NewSeverity;
+  ruleType: NotificationRuleType;
+  userId: ObjectID;
+  mirroredRule: MirroredRule | null;
+}): Promise<void> => {
+  /*
+   * Idempotence, mirroring UserNotificationRuleService.createSeverityScopedRules:
+   * ask for the exact row that is about to be written, and skip if it is
+   * already there.
+   *
+   * Sequential ticks were already covered - buildResponderIntents re-reads
+   * every rule of this type at the top of each run, so a later tick sees the
+   * rows an earlier one wrote and sets hasRuleForNewSeverity. What that cannot
+   * cover is two runs that OVERLAP: both take their snapshot before either
+   * writes, both conclude the cell is empty, and the responder ends up with two
+   * identical rules and therefore two pages for one incident. That overlap is
+   * likeliest at exactly the worst moment, because a new severity arrives by
+   * two routes at once - the by-name enqueue fires seconds after creation, and
+   * a scheduled sweep may already be part-way through the same severity.
+   * claimNotificationRuleExecution cannot save this: it de-duplicates per rule
+   * id, and these are genuinely distinct rows.
+   *
+   * So the snapshot is backed by a read of the row itself, taken immediately
+   * before the write instead of once per rule type. The key is the whole row
+   * minus its own id: project, user, rule type, severity, method - plus
+   * notifyAfterMinutes, which createSeverityScopedRules has no need of because
+   * it only ever writes zero. Here it is load-bearing: a responder who asked
+   * for "email me now" AND "email me in fifteen minutes" must get both rows on
+   * the new severity, and a key that ignored the delay would drop the second
+   * one during the same pass that wrote the first.
+   *
+   * This narrows the race from a whole sweep to the microseconds between the
+   * read and the write; the single-flight SWEEP_LOCK_KEY closes what is left,
+   * since only a lock (or a unique index, which this table does not have) can
+   * make check-then-create genuinely atomic.
+   */
+  const existingRuleQuery: Query<UserNotificationRule> = {
+    projectId: data.severity.projectId,
+    userId: data.userId,
+    ruleType: data.ruleType,
+    ...(data.severity.kind === "incident"
+      ? { incidentSeverityId: data.severity.id }
+      : { alertSeverityId: data.severity.id }),
+    ...(data.mirroredRule
+      ? {
+          ...buildNotificationMethodQuery(
+            data.mirroredRule.methodColumn,
+            data.mirroredRule.methodId,
+          ),
+          notifyAfterMinutes: data.mirroredRule.notifyAfterMinutes,
+        }
+      : { isOptOut: true }),
+  };
+
+  const existingRule: UserNotificationRule | null =
+    await UserNotificationRuleService.findOneBy({
+      query: existingRuleQuery,
+      select: {
+        _id: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+  if (existingRule) {
+    return;
+  }
+
+  const rule: UserNotificationRule = new UserNotificationRule();
+  rule.projectId = data.severity.projectId;
+  rule.userId = data.userId;
+  rule.ruleType = data.ruleType;
+
+  if (data.severity.kind === "incident") {
+    rule.incidentSeverityId = data.severity.id;
+  } else {
+    rule.alertSeverityId = data.severity.id;
+  }
+
+  if (data.mirroredRule) {
+    rule.notifyAfterMinutes = data.mirroredRule.notifyAfterMinutes;
+    applyNotificationMethod(
+      rule,
+      data.mirroredRule.methodColumn,
+      data.mirroredRule.methodId,
+    );
+  } else {
+    rule.notifyAfterMinutes = 0;
+    rule.isOptOut = true;
+  }
+
+  /*
+   * One responder's failure must not abort the rest of the project. The most
+   * likely cause is a method row deleted between the read above and this write,
+   * which cascades the FK away - a rule that could not be written for one person
+   * is worth a log line, not an aborted backfill for everybody else.
+   */
+  try {
+    await UserNotificationRuleService.create({
+      data: rule,
+      props: {
+        isRoot: true,
+      },
+    });
+  } catch (err) {
+    logger.error(
+      `${JOB_NAME}: could not create a ${data.ruleType} rule for user ${data.userId.toString()} on ${data.severity.kind} severity ${data.severity.id.toString()}`,
+    );
+    logger.error(err);
+  }
+};
+
+type BuildNotificationMethodQueryFunction = (
+  methodColumn: NotificationMethodColumn,
+  methodId: ObjectID,
+) => Query<UserNotificationRule>;
+
+/*
+ * The method half of the "does this row already exist?" query.
+ *
+ * Written as a switch for the same reason applyNotificationMethod below is: the
+ * existence check and the write have to name the same column, and a switch
+ * turns a renamed foreign key into a compile error rather than a query that
+ * quietly matches nothing and lets the duplicate through.
+ */
+const buildNotificationMethodQuery: BuildNotificationMethodQueryFunction = (
+  methodColumn: NotificationMethodColumn,
+  methodId: ObjectID,
+): Query<UserNotificationRule> => {
+  switch (methodColumn) {
+    case "userEmailId":
+      return { userEmailId: methodId };
+    case "userSmsId":
+      return { userSmsId: methodId };
+    case "userCallId":
+      return { userCallId: methodId };
+    case "userPushId":
+      return { userPushId: methodId };
+    case "userWhatsAppId":
+      return { userWhatsAppId: methodId };
+    case "userTelegramId":
+      return { userTelegramId: methodId };
+    case "userWebhookId":
+      return { userWebhookId: methodId };
+    default:
+      return {};
+  }
+};
+
+type ApplyNotificationMethodFunction = (
+  rule: UserNotificationRule,
+  methodColumn: NotificationMethodColumn,
+  methodId: ObjectID,
+) => void;
+
+/*
+ * Written as a switch rather than `rule[methodColumn] = methodId` so the column
+ * name and the model stay checked against each other: renaming a foreign key on
+ * UserNotificationRule fails here at compile time instead of silently writing a
+ * rule with no method, which onBeforeCreate would then reject at runtime.
+ */
+const applyNotificationMethod: ApplyNotificationMethodFunction = (
+  rule: UserNotificationRule,
+  methodColumn: NotificationMethodColumn,
+  methodId: ObjectID,
+): void => {
+  switch (methodColumn) {
+    case "userEmailId":
+      rule.userEmailId = methodId;
+      break;
+    case "userSmsId":
+      rule.userSmsId = methodId;
+      break;
+    case "userCallId":
+      rule.userCallId = methodId;
+      break;
+    case "userPushId":
+      rule.userPushId = methodId;
+      break;
+    case "userWhatsAppId":
+      rule.userWhatsAppId = methodId;
+      break;
+    case "userTelegramId":
+      rule.userTelegramId = methodId;
+      break;
+    case "userWebhookId":
+      rule.userWebhookId = methodId;
+      break;
+    default:
+      break;
+  }
+};
+
+export {
+  JOB_NAME,
+  backfillSeverity,
+  buildResponderIntents,
+  findRecentlyCreatedSeverities,
+};
+export type { MirroredRule, NewSeverity, ResponderIntent };

--- a/App/FeatureSet/Workers/Jobs/UserOnCallLog/ExecutePendingExecutions.ts
+++ b/App/FeatureSet/Workers/Jobs/UserOnCallLog/ExecutePendingExecutions.ts
@@ -6,7 +6,9 @@ import { EVERY_MINUTE } from "Common/Utils/CronTime";
 import { IsDevelopment } from "Common/Server/EnvironmentConfig";
 import IncidentService from "Common/Server/Services/IncidentService";
 import UserNotificationRuleService from "Common/Server/Services/UserNotificationRuleService";
-import UserOnCallLogService from "Common/Server/Services/UserOnCallLogService";
+import UserOnCallLogService, {
+  notOptOutRuleQuery,
+} from "Common/Server/Services/UserOnCallLogService";
 import logger from "Common/Server/Utils/Logger";
 import Incident from "Common/Models/DatabaseModels/Incident";
 import UserNotificationRule from "Common/Models/DatabaseModels/UserNotificationRule";
@@ -244,6 +246,20 @@ const executePendingNotificationLog: ExecutePendingNotificationLogFunction =
               alert?.alertSeverityId ||
               alertEpisode?.alertSeverityId ||
               undefined,
+            /*
+             * Opt-out rows are not rules. They carry exactly the columns this
+             * query filters on and no notification method at all, so without
+             * this predicate one would be selected here, handed to
+             * executeNotificationRuleItem, and "executed" - sending nothing
+             * while its timeline row reports a notification. It would also
+             * count as an outstanding rule for `isAllExecuted`, so the log
+             * stays Executing for an extra tick and burns its claim on a
+             * delivery that never happens. notOptOutRuleQuery is NULL-safe on
+             * purpose; isOptOut is nullable and is NULL on every rule written
+             * before the column existed, so a plain `false` here would exclude
+             * every real rule and stop all escalation.
+             */
+            isOptOut: notOptOutRuleQuery(),
           },
           select: {
             _id: true,

--- a/Common/Models/DatabaseModels/Project.ts
+++ b/Common/Models/DatabaseModels/Project.ts
@@ -1233,6 +1233,84 @@ export default class Project extends TenantModel {
   })
   public enableCallNotifications?: boolean = undefined;
 
+  /*
+   * When an on-call responder has no notification rule matching the rule type and
+   * severity of the page being routed to them, OneUptime falls back to whatever
+   * verified notification method they do have rather than delivering nothing. Turning
+   * this on restores the older behaviour: the execution is marked Error and no
+   * notification is attempted.
+   *
+   * The setting exists for projects that would rather see a loud configuration failure
+   * than an unexpected channel being used, and for projects whose responders express
+   * deliberate silence some other way. It is off by default because the behaviour it
+   * disables is the one that stops pages from being lost. Note that an explicit opt-out
+   * rule (UserNotificationRule.isOptOut) already suppresses the fallback for the exact
+   * rule type and severity the user asked to be left alone for, so this flag is only
+   * needed to opt out project-wide.
+   */
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.ReadProject,
+      Permission.UnAuthorizedSsoUser,
+      Permission.ProjectUser,
+    ],
+    update: [Permission.ProjectOwner, Permission.ManageProjectBilling],
+  })
+  @TableColumn({
+    required: true,
+    isDefaultValueColumn: true,
+    type: TableColumnType.Boolean,
+    title: "Disable On-Call Notification Fallback",
+    description:
+      "When enabled, a page routed to a responder with no matching notification rule fails instead of falling back to their verified notification methods.",
+    defaultValue: false,
+    example: false,
+  })
+  @Column({
+    nullable: false,
+    default: false,
+    type: ColumnType.Boolean,
+  })
+  public disableOnCallNotificationFallback?: boolean = undefined;
+
+  /*
+   * Throttle flag for the owner notification sent when the fallback above is used or
+   * when a responder turns out to be unreachable. An incident storm must not turn into a
+   * mail storm, so the owners are told once and the flag is cleared on the usual
+   * schedule.
+   *
+   * This is deliberately a new column rather than a reuse of
+   * lowCallAndSMSBalanceNotificationSentToOwners: that flag is shared by the SMS, Call
+   * and WhatsApp low-balance paths, and setting it here would silently suppress the
+   * billing warnings those paths depend on.
+   */
+  @ColumnAccessControl({
+    create: [],
+    read: [],
+    update: [],
+  })
+  @TableColumn({
+    required: true,
+    isDefaultValueColumn: true,
+    hideColumnInDocumentation: true,
+    type: TableColumnType.Boolean,
+    title: "On-Call Notification Fallback Used Notification Sent to Owners",
+    description:
+      "On-Call Notification Fallback Used Notification Sent to Owners",
+    defaultValue: false,
+  })
+  @Column({
+    nullable: false,
+    default: false,
+    type: ColumnType.Boolean,
+  })
+  public onCallFallbackUsedNotificationSentToOwners?: boolean = undefined;
+
   @ColumnAccessControl({
     create: [],
     read: [

--- a/Common/Models/DatabaseModels/UserNotificationRule.ts
+++ b/Common/Models/DatabaseModels/UserNotificationRule.ts
@@ -705,6 +705,55 @@ class UserNotificationRule extends BaseModel {
     transformer: ObjectID.getDatabaseTransformer(),
   })
   public alertSeverityId?: ObjectID = undefined;
+
+  /*
+   * An opt-out row is a rule that exists in order to send nothing. It carries a
+   * `ruleType` and a severity exactly like a normal rule, sets `isOptOut` to true, and
+   * holds NO notification-method relation at all — there is no userEmail, userSms,
+   * userCall, userPush, userWhatsApp, userTelegram or userWebhook on it, and that
+   * absence is the point rather than a misconfiguration.
+   *
+   * It exists because "this user has zero rules matching this ruleType and severity" is
+   * otherwise two completely different situations wearing the same clothes. Almost
+   * always it means the user never configured anything for that cell — a severity added
+   * after they joined, an episode rule type they never opened the page for — and a page
+   * routed to them must still land somewhere. Occasionally it means the user genuinely
+   * asked not to be woken for that cell, and paging them anyway would be the bug.
+   *
+   * Before this column the runtime could not tell those apart, so it chose the safe-
+   * looking option and delivered nothing, which is how pages were being lost silently.
+   * Making deliberate silence expressible as a row is the precondition for the fallback:
+   * once "do not page me" has somewhere to live, the remaining zero-row cases can be
+   * treated as misconfiguration and rescued by notifying the user on whatever verified
+   * method they do have.
+   *
+   * Note the `update` permission below. Every column on this model except
+   * `notifyAfterMinutes` is `update: []`, so copying a neighbour's access control would
+   * have left this flag writable only at create time — a user could opt out but never
+   * opt back in without deleting and recreating the row. Muting and unmuting is exactly
+   * the kind of preference that gets toggled, so it is explicitly updatable by its owner.
+   */
+  @ColumnAccessControl({
+    create: [Permission.CurrentUser],
+    read: [Permission.CurrentUser],
+    update: [Permission.CurrentUser],
+  })
+  @TableColumn({
+    type: TableColumnType.Boolean,
+    required: false,
+    isDefaultValueColumn: true,
+    title: "Opt Out of Notifications",
+    description:
+      "When true, this rule deliberately suppresses notifications for its rule type and severity instead of delivering any. A rule with this set carries no notification method.",
+    defaultValue: false,
+    example: false,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    nullable: true,
+    default: false,
+  })
+  public isOptOut?: boolean = undefined;
 }
 
 export default UserNotificationRule;

--- a/Common/Models/DatabaseModels/UserOnCallLogTimeline.ts
+++ b/Common/Models/DatabaseModels/UserOnCallLogTimeline.ts
@@ -238,6 +238,29 @@ export default class UserOnCallLogTimeline extends BaseModel {
   @JoinColumn({ name: "userNotificationRuleId" })
   public userNotificationRule?: UserNotificationRule = undefined;
 
+  /*
+   * Nullable, unlike every other id on this row.
+   *
+   * A timeline row records a delivery attempt, and not every delivery attempt
+   * is driven by a stored notification rule. When a responder is paged but has
+   * no rule matching the event's rule type and severity, the fallback delivers
+   * on whatever verified method they do have, driving the normal per-channel
+   * delivery path with a UserNotificationRule built in memory and never saved.
+   * That rule has no id, so there is nothing to point this column at.
+   *
+   * The alternative — persisting a synthetic rule row purely so the foreign key
+   * has something to reference — would put rules the user never configured into
+   * their notification settings, where they would show up in the UI, be matched
+   * by future executions, and have to be garbage collected. A NULL here states
+   * the truth plainly: this delivery had no rule behind it. Readers must treat
+   * the column as absent-by-design rather than as missing data.
+   *
+   * `required: true` is deliberately absent from the @TableColumn: that flag
+   * feeds getRequiredColumns(), which DatabaseService.checkRequiredFields reads
+   * to throw BadDataException before the insert is attempted. Leaving it on
+   * would reject every fallback row in the application layer even after the
+   * database column itself allows NULL.
+   */
   @ColumnAccessControl({
     create: [],
     read: [Permission.CurrentUser],
@@ -246,7 +269,6 @@ export default class UserOnCallLogTimeline extends BaseModel {
   @Index()
   @TableColumn({
     type: TableColumnType.ObjectID,
-    required: true,
     canReadOnRelationQuery: true,
     title: "User Notification Rule ID",
     description:
@@ -254,7 +276,7 @@ export default class UserOnCallLogTimeline extends BaseModel {
   })
   @Column({
     type: ColumnType.ObjectID,
-    nullable: false,
+    nullable: true,
     transformer: ObjectID.getDatabaseTransformer(),
   })
   public userNotificationRuleId?: ObjectID = undefined;

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786800000000-AddOnCallNotificationFallbackColumns.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786800000000-AddOnCallNotificationFallbackColumns.ts
@@ -1,0 +1,90 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * Schema for the on-call notification fallback: a page routed to a responder who
+ * has no notification rule matching the event's rule type and severity now goes
+ * out on whatever verified method they do have, instead of dead-ending with an
+ * Error status nobody reads.
+ *
+ * Hand-written rather than emitted by `npm run generate-postgres-migration`. The
+ * generator diffs the entire entity set against the live database, and several
+ * models in this worktree are being changed in parallel, so a generated file
+ * would have swept up unrelated in-flight columns. The statements below are
+ * exactly what the generator produces for these column definitions — compare
+ * `enableWhatsAppNotifications` (1759943124812) and `enableTelegramNotifications`
+ * (1776761171349) for the Project booleans, and `isFeatureFlagMonitorGroupsEnabled`
+ * in the InitialMigration for the nullable-with-default shape.
+ *
+ * UserNotificationRule.isOptOut is nullable because a rule that predates this
+ * column is simply not an opt-out; the DEFAULT covers rows written afterwards and
+ * the backfill for existing rows is the default itself. The two Project columns
+ * are NOT NULL like every other project boolean, so existing projects land on
+ * false: the fallback on, and no owner notification recorded as sent yet.
+ *
+ * UserOnCallLogTimeline.userNotificationRuleId is dropped to NULL-able because
+ * the fallback delivers through a UserNotificationRule constructed in memory and
+ * never saved — there is deliberately no stored rule behind a fallback page, so
+ * there is no id to record. It has been NOT NULL since the InitialMigration
+ * (1717605043663), which means that without this statement every fallback insert
+ * fails its required-field check and the feature cannot deliver anything at all.
+ * The foreign key on the column stays as it is: Postgres does not check a FK when
+ * the referencing column is NULL, so a NULL row is legal against the existing
+ * constraint and no index or constraint needs rebuilding.
+ */
+export class AddOnCallNotificationFallbackColumns1786800000000
+  implements MigrationInterface
+{
+  public name: string = "AddOnCallNotificationFallbackColumns1786800000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "UserNotificationRule" ADD "isOptOut" boolean DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Project" ADD "disableOnCallNotificationFallback" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Project" ADD "onCallFallbackUsedNotificationSentToOwners" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "UserOnCallLogTimeline" ALTER COLUMN "userNotificationRuleId" DROP NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    /*
+     * Restoring NOT NULL is only possible once nothing violates it, and after the
+     * fallback has run there will be timeline rows with a NULL rule id — one per
+     * fallback page delivered. A bare `SET NOT NULL` would abort the whole
+     * rollback on the first such row, so the rows are deleted first.
+     *
+     * This deletion is destructive and worth understanding before running down().
+     * What it removes is exactly the set of rows that could not have existed
+     * before this migration: fallback delivery records. Their history is real —
+     * they describe pages that were genuinely sent — but there is no way to
+     * express them in the pre-migration schema, so reverting the schema means
+     * giving them up. An operator who wants to keep the record should copy them
+     * out first:
+     *
+     *   SELECT * FROM "UserOnCallLogTimeline" WHERE "userNotificationRuleId" IS NULL;
+     *
+     * Ordinary rows are untouched: before this migration the column was NOT NULL,
+     * so nothing predating it can match.
+     */
+    await queryRunner.query(
+      `DELETE FROM "UserOnCallLogTimeline" WHERE "userNotificationRuleId" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "UserOnCallLogTimeline" ALTER COLUMN "userNotificationRuleId" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Project" DROP COLUMN "onCallFallbackUsedNotificationSentToOwners"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "Project" DROP COLUMN "disableOnCallNotificationFallback"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "UserNotificationRule" DROP COLUMN "isOptOut"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -517,6 +517,7 @@ import { AddMonitorDependency1786449497966 } from "./1786449497966-AddMonitorDep
 import { AddDeletedProjectTable1786461136170 } from "./1786461136170-AddDeletedProjectTable";
 import { MigrationName1786551733814 } from "./1786551733814-MigrationName";
 import { AddWorkflowLogStepTrace1786559879134 } from "./1786559879134-AddWorkflowLogStepTrace";
+import { AddOnCallNotificationFallbackColumns1786800000000 } from "./1786800000000-AddOnCallNotificationFallbackColumns";
 
 export default [
   InitialMigration,
@@ -1038,4 +1039,5 @@ export default [
   AddDeletedProjectTable1786461136170,
   MigrationName1786551733814,
   AddWorkflowLogStepTrace1786559879134,
+  AddOnCallNotificationFallbackColumns1786800000000,
 ];

--- a/Common/Server/Services/AlertSeverityService.ts
+++ b/Common/Server/Services/AlertSeverityService.ts
@@ -10,7 +10,18 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
 import ObjectID from "../../Types/ObjectID";
 import Model from "../../Models/DatabaseModels/AlertSeverity";
+import Queue, { QueueName } from "../Infrastructure/Queue";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+
+/*
+ * Must stay identical to the RunCron job name in
+ * App/FeatureSet/Workers/Jobs/OnCallDutyPolicy/BackfillNotificationRulesForNewSeverities.ts.
+ * Common cannot import from App, so the string is duplicated deliberately; the
+ * job file carries a matching comment naming its two enqueue sites.
+ */
+const BACKFILL_NOTIFICATION_RULES_JOB_NAME: string =
+  "OnCallDutyPolicy:BackfillNotificationRulesForNewSeverities";
+
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
@@ -38,6 +49,58 @@ export class Service extends DatabaseService<Model> {
       createBy: createBy,
       carryForward: null,
     };
+  }
+
+  /**
+   * A severity created today is a severity every existing responder has no
+   * notification rule for. See the twin hook on IncidentSeverityService for the
+   * full reasoning; the short version is that default rules are only ever
+   * written when a responder joins or verifies a method, and both iterate the
+   * severities that exist AT THAT MOMENT, so a severity added later pages
+   * nobody until something backfills it.
+   *
+   * Queued rather than inline because a project can hold thousands of
+   * responders and this hook runs inside the request that created the severity.
+   * Best-effort because the severity must be created either way - the backfill
+   * job also sweeps recently-created severities on its own schedule, so a
+   * dropped enqueue costs latency, not coverage.
+   */
+  @CaptureSpan()
+  protected override async onCreateSuccess(
+    _onCreate: OnCreate<Model>,
+    createdItem: Model,
+  ): Promise<Model> {
+    try {
+      await Queue.addJob(
+        QueueName.Worker,
+        `${BACKFILL_NOTIFICATION_RULES_JOB_NAME}-${createdItem.id?.toString()}`,
+        BACKFILL_NOTIFICATION_RULES_JOB_NAME,
+        {
+          /*
+           * The Worker queue dispatches purely on job NAME and hands the job
+           * function no payload, so the job re-derives which severities need
+           * backfilling for itself. These ride along for the queue inspector and
+           * the failure log.
+           */
+          projectId: createdItem.projectId?.toString() || "",
+          alertSeverityId: createdItem.id?.toString() || "",
+        },
+        {
+          // One active, one queued, latest payload wins - never N overlapping scans.
+          deduplication: {
+            id: BACKFILL_NOTIFICATION_RULES_JOB_NAME,
+            keepLastIfActive: true,
+          },
+        },
+      );
+    } catch (err) {
+      logger.error(
+        "Could not enqueue the on-call notification rule backfill for a newly created alert severity. The scheduled sweep will still pick it up.",
+      );
+      logger.error(err);
+    }
+
+    return createdItem;
   }
 
   @CaptureSpan()

--- a/Common/Server/Services/IncidentSeverityService.ts
+++ b/Common/Server/Services/IncidentSeverityService.ts
@@ -10,7 +10,18 @@ import LIMIT_MAX from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
 import ObjectID from "../../Types/ObjectID";
 import Model from "../../Models/DatabaseModels/IncidentSeverity";
+import Queue, { QueueName } from "../Infrastructure/Queue";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+
+/*
+ * Must stay identical to the RunCron job name in
+ * App/FeatureSet/Workers/Jobs/OnCallDutyPolicy/BackfillNotificationRulesForNewSeverities.ts.
+ * Common cannot import from App, so the string is duplicated deliberately; the
+ * job file carries a matching comment naming its two enqueue sites.
+ */
+const BACKFILL_NOTIFICATION_RULES_JOB_NAME: string =
+  "OnCallDutyPolicy:BackfillNotificationRulesForNewSeverities";
+
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
@@ -38,6 +49,71 @@ export class Service extends DatabaseService<Model> {
       createBy: createBy,
       carryForward: null,
     };
+  }
+
+  /**
+   * A severity created today is a severity every existing responder has no
+   * notification rule for.
+   *
+   * The default rules a responder gets are written when they join the project
+   * and when they verify a notification method, and both of those iterate the
+   * severities that exist AT THAT MOMENT. Nothing revisited the question
+   * afterwards, so adding a "Sev4" a year into a project silently switched off
+   * paging for it: every Sev4 incident counted zero matching rules and dropped
+   * into an execution log nobody reads.
+   *
+   * The repair is queued rather than run inline. A project can hold thousands of
+   * responders, this hook sits inside the request that created the severity, and
+   * a fan-out that slow would either time the request out or fail half-finished
+   * with nothing to roll back. The worker owns the work; this only rings the
+   * bell.
+   *
+   * Ringing the bell is best-effort on purpose. If Redis is unreachable the
+   * severity must still be created - the backfill job also sweeps
+   * recently-created severities on its own schedule, so a dropped enqueue costs
+   * a few minutes of latency, not coverage.
+   */
+  @CaptureSpan()
+  protected override async onCreateSuccess(
+    _onCreate: OnCreate<Model>,
+    createdItem: Model,
+  ): Promise<Model> {
+    try {
+      await Queue.addJob(
+        QueueName.Worker,
+        `${BACKFILL_NOTIFICATION_RULES_JOB_NAME}-${createdItem.id?.toString()}`,
+        BACKFILL_NOTIFICATION_RULES_JOB_NAME,
+        {
+          /*
+           * The Worker queue dispatches purely on job NAME and hands the job
+           * function no payload, so the job re-derives which severities need
+           * backfilling for itself. These ride along for the queue inspector and
+           * the failure log, where "which severity was this?" is the first
+           * question anyone asks.
+           */
+          projectId: createdItem.projectId?.toString() || "",
+          incidentSeverityId: createdItem.id?.toString() || "",
+        },
+        {
+          /*
+           * Seeding a project with four severities in one go must not start four
+           * overlapping scans that all see the same uncovered responders and all
+           * write the same rules. One active, one queued, latest payload wins.
+           */
+          deduplication: {
+            id: BACKFILL_NOTIFICATION_RULES_JOB_NAME,
+            keepLastIfActive: true,
+          },
+        },
+      );
+    } catch (err) {
+      logger.error(
+        "Could not enqueue the on-call notification rule backfill for a newly created incident severity. The scheduled sweep will still pick it up.",
+      );
+      logger.error(err);
+    }
+
+    return createdItem;
   }
 
   @CaptureSpan()

--- a/Common/Server/Services/OnCallNotificationAlertingService.ts
+++ b/Common/Server/Services/OnCallNotificationAlertingService.ts
@@ -1,0 +1,742 @@
+import DatabaseConfig from "../DatabaseConfig";
+import BaseService from "./BaseService";
+import MailService from "./MailService";
+import OnCallDutyPolicyOwnerTeamService from "./OnCallDutyPolicyOwnerTeamService";
+import OnCallDutyPolicyOwnerUserService from "./OnCallDutyPolicyOwnerUserService";
+import OnCallDutyPolicyService from "./OnCallDutyPolicyService";
+import ProjectService from "./ProjectService";
+import TeamMemberService from "./TeamMemberService";
+import UserService from "./UserService";
+import InProcessMemo from "../Utils/InProcessMemo";
+import logger from "../Utils/Logger";
+import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import URL from "../../Types/API/URL";
+import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
+import Dictionary from "../../Types/Dictionary";
+import EmailTemplateType from "../../Types/Email/EmailTemplateType";
+import NotificationRuleType from "../../Types/NotificationRule/NotificationRuleType";
+import ObjectID from "../../Types/ObjectID";
+import OnCallDutyPolicyOwnerTeam from "../../Models/DatabaseModels/OnCallDutyPolicyOwnerTeam";
+import OnCallDutyPolicyOwnerUser from "../../Models/DatabaseModels/OnCallDutyPolicyOwnerUser";
+import Project from "../../Models/DatabaseModels/Project";
+import User from "../../Models/DatabaseModels/User";
+
+/**
+ * What the paging path observed when it could not route a page the normal way.
+ *
+ * `fallbackChannelsUsed` is the whole story in one field: a non-empty array means the
+ * fallback reached the responder on those channels and this is a "your configuration is
+ * wrong, but nobody was dropped" warning; an empty array means the page was NOT delivered
+ * to this responder at all and this is the last-resort alert that somebody has to read.
+ */
+export interface UndeliverablePageNotificationData {
+  projectId: ObjectID;
+  userId: ObjectID;
+  ruleType: NotificationRuleType;
+  /** Human-readable severity ("Sev4"), used verbatim in the copy. Escaped before interpolation. */
+  severityName: string;
+  /** The policy that was executing, when known. Its owners are the closest thing to a responsible party. */
+  onCallDutyPolicyId?: ObjectID | undefined;
+  /** Channel names the fallback actually used, e.g. ["Email", "Push"]. Empty means nothing was delivered. */
+  fallbackChannelsUsed: Array<string>;
+}
+
+/*
+ * One notification per (projectId, userId, ruleType) per 24 hours.
+ *
+ * The trigger for this service is an on-call page, and pages arrive in storms: a single
+ * bad deploy can execute the same policy against the same responder hundreds of times in
+ * an hour, and every one of those executions takes exactly the same "no matching rule"
+ * branch. Without a window the fix for silent page loss would be a mail storm, which is
+ * the same failure wearing better clothes — nobody reads the two hundredth copy either.
+ */
+const NOTIFICATION_WINDOW_IN_MS: number = 24 * 60 * 60 * 1000;
+
+/*
+ * Bounded so a large install cannot turn the throttle into a memory leak: the keys are
+ * (project, user, ruleType) triples and a busy install has a lot of them. Eviction is
+ * oldest-first, and an evicted key simply means one extra email — the durable project
+ * flag below still catches the common case.
+ */
+const THROTTLE_MAX_ENTRIES: number = 10_000;
+
+export class OnCallNotificationAlertingService extends BaseService {
+  /*
+   * The fine-grained half of the throttle: exact (projectId, userId, ruleType) semantics,
+   * but only within one process.
+   *
+   * The durable half is Project.onCallFallbackUsedNotificationSentToOwners. A boolean
+   * column cannot record WHEN it was set, so it cannot express a 24h window on its own —
+   * it can only say "the owners have been told and nothing has cleared the flag yet".
+   * The two are combined in shouldNotifyOwners below, and the combination is deliberately
+   * biased towards sending: this whole phase exists because pages were being lost
+   * silently, and an extra owner email is a much cheaper mistake than a missed one.
+   */
+  private ownerNotificationThrottle: InProcessMemo<boolean> =
+    new InProcessMemo<boolean>({
+      ttlInMs: NOTIFICATION_WINDOW_IN_MS,
+      maxEntries: THROTTLE_MAX_ENTRIES,
+    });
+
+  /*
+   * The user-facing mail has no durable flag of its own by design. Constraint: the new
+   * project column throttles the OWNER mail, and reusing it here would let one responder's
+   * quiet period suppress the owners' alert (and vice versa). A per-process window is
+   * enough for the user mail because duplicates land in one person's inbox where they are
+   * self-evidently the same message, rather than fanning out across every project owner.
+   */
+  private userNotificationThrottle: InProcessMemo<boolean> =
+    new InProcessMemo<boolean>({
+      ttlInMs: NOTIFICATION_WINDOW_IN_MS,
+      maxEntries: THROTTLE_MAX_ENTRIES,
+    });
+
+  /**
+   * Tell the people who can fix it that a page either fell back to a channel nobody chose,
+   * or could not be delivered at all.
+   *
+   * Two audiences, notified independently so a failure to reach one never suppresses the
+   * other:
+   *  - the on-call policy's owners, falling back to the project's owners — they own the
+   *    configuration that is wrong;
+   *  - the responder themselves — they own the notification rules that are missing.
+   *
+   * This never throws. It is called from the on-call delivery path, where an exception
+   * raised while explaining a delivery problem would turn a degraded page into a lost one.
+   * Every failure is logged instead.
+   */
+  @CaptureSpan()
+  public async notifyOfUndeliverablePage(
+    data: UndeliverablePageNotificationData,
+  ): Promise<void> {
+    try {
+      if (!data.projectId || !data.userId) {
+        logger.error(
+          "OnCallNotificationAlertingService.notifyOfUndeliverablePage called without a projectId or userId. Nobody can be told about this undeliverable page.",
+        );
+        return;
+      }
+
+      const project: Project | null = await ProjectService.findOneById({
+        id: data.projectId,
+        select: {
+          _id: true,
+          name: true,
+          onCallFallbackUsedNotificationSentToOwners: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      if (!project) {
+        logger.error(
+          `OnCallNotificationAlertingService: project ${data.projectId.toString()} not found, so nobody can be told that a page to user ${data.userId.toString()} was undeliverable.`,
+        );
+        return;
+      }
+
+      const user: User | null = await UserService.findOneById({
+        id: data.userId,
+        select: {
+          _id: true,
+          name: true,
+          email: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      if (!user) {
+        logger.error(
+          `OnCallNotificationAlertingService: user ${data.userId.toString()} not found while reporting an undeliverable page in project ${data.projectId.toString()}.`,
+        );
+        return;
+      }
+
+      /*
+       * Owners first. The responder is by definition the person whose notification setup
+       * just failed to reach them, so they are the LESS reliable of the two audiences —
+       * if the fallback delivered nothing, the user mail below may well go nowhere either.
+       *
+       * Each audience gets its own try/catch. A DB error while resolving the policy's
+       * owners says nothing about whether the responder can be emailed, and letting it
+       * cancel the second notification would make one broken lookup silence both halves
+       * of the alert.
+       */
+      try {
+        await this.notifyOwners({
+          data: data,
+          project: project,
+          user: user,
+        });
+      } catch (err: unknown) {
+        logger.error(
+          `OnCallNotificationAlertingService: failed to notify the owners of an undeliverable page in project ${data.projectId.toString()}.`,
+        );
+        logger.error(err);
+      }
+
+      try {
+        await this.notifyAffectedUser({
+          data: data,
+          project: project,
+          user: user,
+        });
+      } catch (err: unknown) {
+        logger.error(
+          `OnCallNotificationAlertingService: failed to notify user ${data.userId.toString()} that their page in project ${data.projectId.toString()} was undeliverable.`,
+        );
+        logger.error(err);
+      }
+    } catch (err: unknown) {
+      logger.error(
+        "OnCallNotificationAlertingService.notifyOfUndeliverablePage failed. The page itself is unaffected; only the explanation was lost.",
+      );
+      logger.error(err);
+    }
+  }
+
+  /*
+   * Policy owners, then project owners. Not both: the policy owners are the specific,
+   * accountable audience, and mailing the whole ownership chain on every fallback is how
+   * owner notifications get filtered into a folder nobody opens.
+   */
+  private async notifyOwners(input: {
+    data: UndeliverablePageNotificationData;
+    project: Project;
+    user: User;
+  }): Promise<void> {
+    const { data, project, user } = input;
+
+    const throttleKey: string = this.getThrottleKey(data);
+
+    const shouldNotify: boolean = await this.shouldNotifyOwners({
+      project: project,
+      throttleKey: throttleKey,
+    });
+
+    if (!shouldNotify) {
+      logger.debug(
+        `OnCallNotificationAlertingService: owner notification for ${throttleKey} suppressed by the ${NOTIFICATION_WINDOW_IN_MS / (60 * 60 * 1000)}h throttle.`,
+      );
+      return;
+    }
+
+    const subject: string = this.getOwnerEmailSubject({
+      data: data,
+      project: project,
+    });
+
+    const message: string = await this.getOwnerEmailMessageHtml({
+      data: data,
+      project: project,
+      user: user,
+    });
+
+    const policyOwners: Array<User> = await this.findOnCallDutyPolicyOwners(
+      data.onCallDutyPolicyId,
+    );
+
+    if (policyOwners.length > 0) {
+      for (const owner of policyOwners) {
+        await this.sendSimpleMessage({
+          toUser: owner,
+          projectId: data.projectId,
+          subject: subject,
+          message: message,
+        });
+      }
+    } else {
+      /*
+       * getOwners returns [] whenever no team in the project holds
+       * Permission.ProjectOwner, and sendEmailToProjectOwners then returns without
+       * sending anything and without saying so. That silence is exactly the failure mode
+       * this service exists to remove, so the emptiness is checked here and logged loudly:
+       * an install with no owner team is one where the last-resort alert has nowhere to
+       * go, and that is worth an error line in the logs even though nothing is broken
+       * from the code's point of view.
+       *
+       * The extra getOwners call this costs is deliberate. Re-implementing the send here
+       * to avoid it would fork the owner-mail path, and this runs at most once per
+       * (project, user, ruleType) per day.
+       */
+      const projectOwners: Array<User> = await ProjectService.getOwners(
+        data.projectId,
+      );
+
+      if (projectOwners.length === 0) {
+        logger.error(
+          `OnCallNotificationAlertingService: project ${data.projectId.toString()} has no on-call policy owners and no project owners, so there is nobody to tell that a page to ${user.email?.toString() || data.userId.toString()} was undeliverable. Grant Permission.ProjectOwner to a team so alerts like this one have a destination.`,
+        );
+
+        /*
+         * Throttled like a successful send so a page storm produces one loud line per
+         * (project, user, ruleType) per day rather than one per page — an error nobody
+         * can find in the noise is not better than the silence it replaced. The durable
+         * project flag is deliberately left alone: nothing was sent, so "the owners have
+         * been told" must stay false.
+         */
+        this.ownerNotificationThrottle.set(throttleKey, true);
+        return;
+      }
+
+      await ProjectService.sendEmailToProjectOwners(
+        data.projectId,
+        subject,
+        message,
+      );
+    }
+
+    this.ownerNotificationThrottle.set(throttleKey, true);
+
+    await this.setOwnerNotificationFlag(data.projectId, true);
+  }
+
+  /*
+   * The throttle decision, split out because the interaction between the in-process window
+   * and the durable flag is the subtle part of this service.
+   */
+  private async shouldNotifyOwners(input: {
+    project: Project;
+    throttleKey: string;
+  }): Promise<boolean> {
+    const { project, throttleKey } = input;
+
+    if (this.ownerNotificationThrottle.get(throttleKey)) {
+      // This process mailed the owners about this exact triple inside the window.
+      return false;
+    }
+
+    if (project.onCallFallbackUsedNotificationSentToOwners) {
+      /*
+       * Another pod — or this one before a restart — already mailed the owners, and
+       * nothing has cleared the flag since. The column cannot tell us whether that was
+       * two minutes or two weeks ago, so there is no way to evaluate the window from it.
+       *
+       * Re-arm rather than guess. This page stays quiet (the owners did hear about the
+       * problem at some point) and the very next undeliverable page gets through, which
+       * means an install can never be permanently silenced by a latch nobody clears.
+       * The in-process key is deliberately NOT stamped here: stamping it would suppress
+       * that next page too, and a 24h silence after a pod restart is the one outcome this
+       * phase must not produce.
+       *
+       * The cost is bounded and known: across N pods this can produce up to one owner
+       * email per pod per triple per day instead of exactly one. That is the honest limit
+       * of what a project-scoped boolean can enforce, and it errs in the safe direction.
+       */
+      await this.setOwnerNotificationFlag(project.id!, false);
+      return false;
+    }
+
+    return true;
+  }
+
+  private async setOwnerNotificationFlag(
+    projectId: ObjectID,
+    value: boolean,
+  ): Promise<void> {
+    await ProjectService.updateOneById({
+      id: projectId,
+      data: {
+        onCallFallbackUsedNotificationSentToOwners: value,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+  }
+
+  private async notifyAffectedUser(input: {
+    data: UndeliverablePageNotificationData;
+    project: Project;
+    user: User;
+  }): Promise<void> {
+    const { data, project, user } = input;
+
+    if (!user.email) {
+      logger.error(
+        `OnCallNotificationAlertingService: user ${data.userId.toString()} has no account email, so they cannot be told that their page in project ${data.projectId.toString()} was undeliverable.`,
+      );
+      return;
+    }
+
+    const throttleKey: string = this.getThrottleKey(data);
+
+    if (this.userNotificationThrottle.get(throttleKey)) {
+      logger.debug(
+        `OnCallNotificationAlertingService: user notification for ${throttleKey} suppressed by the ${NOTIFICATION_WINDOW_IN_MS / (60 * 60 * 1000)}h throttle.`,
+      );
+      return;
+    }
+
+    const projectName: string = project.name || "your project";
+    const severity: string = data.severityName || "this severity";
+    const eventLabel: string = this.getRuleTypeLabel(data.ruleType);
+
+    const rulesLink: URL = await this.getNotificationRulesLinkInDashboard(
+      data.projectId,
+      data.ruleType,
+    );
+
+    const subject: string =
+      data.fallbackChannelsUsed.length > 0
+        ? `You were paged in ${projectName} without a notification rule`
+        : `A page in ${projectName} could not reach you`;
+
+    /*
+     * Same raw-HTML rule as the owner message: SimpleMessage.hbs renders `message`
+     * through a triple stache, so the project and severity names are escaped here. The
+     * channel list is generated by the fallback (["Email", "Push"]) rather than by a user,
+     * but it is escaped too so that stays safe if the fallback ever learns to name a
+     * channel after a user-supplied label.
+     */
+    const escapedLink: string = this.escapeHtml(rulesLink.toString());
+
+    const lines: Array<string> = [];
+
+    if (data.fallbackChannelsUsed.length > 0) {
+      lines.push(
+        `You were paged for a ${this.escapeHtml(severity)} ${this.escapeHtml(eventLabel)} in ${this.escapeHtml(projectName)}, but you have no notification rule configured for it. We reached you on your verified ${this.escapeHtml(this.formatChannelList(data.fallbackChannelsUsed))} instead.`,
+      );
+      lines.push(
+        `That fallback is a safety net, not a setting — it ignores everything you may have configured about how and when you want to be reached.`,
+      );
+      lines.push(
+        `Set up a rule so future pages arrive the way you want them to: <a href="${escapedLink}">${escapedLink}</a>`,
+      );
+    } else {
+      lines.push(
+        `You were paged for a ${this.escapeHtml(severity)} ${this.escapeHtml(eventLabel)} in ${this.escapeHtml(projectName)} and we could not deliver it. You have no notification rule for it and no verified notification method to fall back on, so nothing was sent anywhere.`,
+      );
+      lines.push(
+        `Until you add a verified notification method and a rule, every page routed to you is lost: <a href="${escapedLink}">${escapedLink}</a>`,
+      );
+    }
+
+    await this.sendSimpleMessage({
+      toUser: user,
+      projectId: data.projectId,
+      subject: subject,
+      message: lines.join("<br/><br/>"),
+    });
+
+    this.userNotificationThrottle.set(throttleKey, true);
+  }
+
+  private getOwnerEmailSubject(input: {
+    data: UndeliverablePageNotificationData;
+    project: Project;
+  }): string {
+    const { data, project } = input;
+
+    const projectName: string = project.name || "your project";
+
+    /*
+     * The subject is rendered through {{title}} in EmailTitle.hbs, which Handlebars
+     * escapes, and is also used verbatim as the SMTP subject header. Escaping it here
+     * would double-escape the first and corrupt the second, so raw values belong here and
+     * escaped values belong in the message body only.
+     */
+    return data.fallbackChannelsUsed.length > 0
+      ? `On-call fallback used in ${projectName}`
+      : `A page in ${projectName} reached nobody`;
+  }
+
+  private async getOwnerEmailMessageHtml(input: {
+    data: UndeliverablePageNotificationData;
+    project: Project;
+    user: User;
+  }): Promise<string> {
+    const { data, project, user } = input;
+
+    /*
+     * Everything below is interpolated into ProjectService.sendEmailToProjectOwners, which
+     * hands `message` to SimpleMessage.hbs where InfoBlock renders it through a triple
+     * stache ({{{info}}}) — i.e. as RAW HTML. User names, project names and severity names
+     * are all user-controlled strings, so every one of them is escaped on the way in.
+     */
+    const projectName: string = this.escapeHtml(project.name || "your project");
+    const userName: string = this.escapeHtml(
+      user.name?.toString() || user.email?.toString() || "A responder",
+    );
+    const userEmail: string = this.escapeHtml(user.email?.toString() || "");
+    const severity: string = this.escapeHtml(
+      data.severityName || "this severity",
+    );
+    const eventLabel: string = this.escapeHtml(
+      this.getRuleTypeLabel(data.ruleType),
+    );
+
+    const lines: Array<string> = [];
+
+    if (data.fallbackChannelsUsed.length > 0) {
+      lines.push(
+        `${userName}${userEmail ? ` (${userEmail})` : ""} was paged for a ${severity} ${eventLabel} in ${projectName}, but has no notification rule configured for it.`,
+      );
+      lines.push(
+        `The page was delivered on their verified ${this.escapeHtml(this.formatChannelList(data.fallbackChannelsUsed))} as a fallback, so nobody was dropped this time.`,
+      );
+    } else {
+      lines.push(
+        `${userName}${userEmail ? ` (${userEmail})` : ""} was paged for a ${severity} ${eventLabel} in ${projectName} and the page could not be delivered.`,
+      );
+      lines.push(
+        `They have no notification rule for it and no verified notification method to fall back on, so this page reached them on no channel at all. If they are the only responder on this escalation level, it reached nobody.`,
+      );
+    }
+
+    if (data.onCallDutyPolicyId) {
+      const policyName: string | null =
+        await OnCallDutyPolicyService.getOnCallDutyPolicyName({
+          onCallDutyPolicyId: data.onCallDutyPolicyId,
+        });
+
+      const policyLink: URL =
+        await OnCallDutyPolicyService.getOnCallDutyPolicyLinkInDashboard(
+          data.projectId,
+          data.onCallDutyPolicyId,
+        );
+
+      lines.push(
+        `On-call policy: <a href="${this.escapeHtml(policyLink.toString())}">${this.escapeHtml(policyName || "View policy")}</a>`,
+      );
+    }
+
+    lines.push(
+      `Ask them to add a rule for ${severity} ${eventLabel} in User Settings &gt; On-Call Rules, or remove them from the escalation level if they are not meant to be paged for it.`,
+    );
+
+    return lines.join("<br/><br/>");
+  }
+
+  /*
+   * The policy's own owners: direct owner users, plus every member of an owner team.
+   * Returns [] when no policy id was supplied, which is the caller's signal to fall back
+   * to the project owners.
+   */
+  private async findOnCallDutyPolicyOwners(
+    onCallDutyPolicyId: ObjectID | undefined,
+  ): Promise<Array<User>> {
+    if (!onCallDutyPolicyId) {
+      return [];
+    }
+
+    const ownerUsers: Array<OnCallDutyPolicyOwnerUser> =
+      await OnCallDutyPolicyOwnerUserService.findBy({
+        query: {
+          onCallDutyPolicyId: onCallDutyPolicyId,
+        },
+        select: {
+          _id: true,
+          user: {
+            _id: true,
+            name: true,
+            email: true,
+          },
+        },
+        skip: 0,
+        limit: LIMIT_PER_PROJECT,
+        props: {
+          isRoot: true,
+        },
+      });
+
+    const ownerTeams: Array<OnCallDutyPolicyOwnerTeam> =
+      await OnCallDutyPolicyOwnerTeamService.findBy({
+        query: {
+          onCallDutyPolicyId: onCallDutyPolicyId,
+        },
+        select: {
+          _id: true,
+          teamId: true,
+        },
+        skip: 0,
+        limit: LIMIT_PER_PROJECT,
+        props: {
+          isRoot: true,
+        },
+      });
+
+    const users: Array<User> = [];
+    const seenUserIds: Set<string> = new Set<string>();
+
+    const addUser: (user: User | undefined) => void = (
+      user: User | undefined,
+    ): void => {
+      if (!user || !user.id || !user.email) {
+        return;
+      }
+
+      const key: string = user.id.toString();
+
+      if (seenUserIds.has(key)) {
+        return;
+      }
+
+      seenUserIds.add(key);
+      users.push(user);
+    };
+
+    for (const ownerUser of ownerUsers) {
+      addUser(ownerUser.user);
+    }
+
+    const teamIds: Array<ObjectID> = [];
+
+    for (const ownerTeam of ownerTeams) {
+      if (ownerTeam.teamId) {
+        teamIds.push(ownerTeam.teamId);
+      }
+    }
+
+    if (teamIds.length > 0) {
+      const teamUsers: Array<User> =
+        await TeamMemberService.getUsersInTeams(teamIds);
+
+      for (const teamUser of teamUsers) {
+        addUser(teamUser);
+      }
+    }
+
+    return users;
+  }
+
+  private async sendSimpleMessage(input: {
+    toUser: User;
+    projectId: ObjectID;
+    subject: string;
+    message: string;
+  }): Promise<void> {
+    const { toUser, projectId, subject, message } = input;
+
+    if (!toUser.email) {
+      return;
+    }
+
+    const vars: Dictionary<string> = {
+      subject: subject,
+      message: message,
+    };
+
+    try {
+      await MailService.sendMail(
+        {
+          toEmail: toUser.email,
+          templateType: EmailTemplateType.SimpleMessage,
+          vars: vars,
+          subject: subject,
+        },
+        {
+          projectId: projectId,
+          userId: toUser.id!,
+        },
+      );
+    } catch (err: unknown) {
+      /*
+       * Swallowed on purpose: one unreachable recipient must not stop the rest of the
+       * owner list from hearing about a page that reached nobody.
+       */
+      logger.error(
+        `OnCallNotificationAlertingService: failed to email ${toUser.email.toString()} about an undeliverable on-call page.`,
+      );
+      logger.error(err);
+    }
+  }
+
+  private getThrottleKey(data: UndeliverablePageNotificationData): string {
+    return `${data.projectId.toString()}:${data.userId.toString()}:${data.ruleType}`;
+  }
+
+  /*
+   * NotificationRuleType's values are already English sentences ("When incident on-call
+   * policy is executed"), which read badly mid-sentence. These are the noun forms.
+   */
+  private getRuleTypeLabel(ruleType: NotificationRuleType): string {
+    switch (ruleType) {
+      case NotificationRuleType.ON_CALL_EXECUTED_INCIDENT:
+        return "incident";
+      case NotificationRuleType.ON_CALL_EXECUTED_ALERT:
+        return "alert";
+      case NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE:
+        return "alert episode";
+      case NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE:
+        return "incident episode";
+      case NotificationRuleType.WHEN_USER_GOES_ON_CALL:
+        return "on-call shift start";
+      case NotificationRuleType.WHEN_USER_GOES_OFF_CALL:
+        return "on-call shift end";
+      default:
+        return "on-call notification";
+    }
+  }
+
+  /*
+   * The four severity-scoped rule types each have their own settings page, and sending
+   * someone to the wrong one is how a "fix your rules" email gets ignored. The two shift
+   * rule types are configured on the incident page alongside everything else.
+   *
+   * These path segments mirror UserSettingsRoutePath in the Dashboard's RouteMap. They are
+   * duplicated rather than imported because Common/Server cannot reach App sources — the
+   * same reason OnCallDutyPolicyService.getOnCallDutyPolicyLinkInDashboard spells its
+   * route out by hand.
+   */
+  private getUserSettingsPathForRuleType(
+    ruleType: NotificationRuleType,
+  ): string {
+    switch (ruleType) {
+      case NotificationRuleType.ON_CALL_EXECUTED_ALERT:
+        return "alert-on-call-rules";
+      case NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE:
+        return "alert-episode-on-call-rules";
+      case NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE:
+        return "incident-episode-on-call-rules";
+      case NotificationRuleType.ON_CALL_EXECUTED_INCIDENT:
+      case NotificationRuleType.WHEN_USER_GOES_ON_CALL:
+      case NotificationRuleType.WHEN_USER_GOES_OFF_CALL:
+        return "incident-on-call-rules";
+      default:
+        return "notification-methods";
+    }
+  }
+
+  private async getNotificationRulesLinkInDashboard(
+    projectId: ObjectID,
+    ruleType: NotificationRuleType,
+  ): Promise<URL> {
+    const dashboardUrl: URL = await DatabaseConfig.getDashboardUrl();
+
+    return URL.fromString(dashboardUrl.toString()).addRoute(
+      `/${projectId.toString()}/user-settings/${this.getUserSettingsPathForRuleType(ruleType)}`,
+    );
+  }
+
+  private formatChannelList(channels: Array<string>): string {
+    if (channels.length === 0) {
+      return "";
+    }
+
+    if (channels.length === 1) {
+      return channels[0]!;
+    }
+
+    return `${channels.slice(0, -1).join(", ")} and ${channels[channels.length - 1]!}`;
+  }
+
+  /*
+   * ProjectService.sendEmailToProjectOwners hands `message` to a triple-stache Handlebars
+   * partial, so nothing between here and the recipient's inbox escapes anything. This is
+   * the only escaping in that path.
+   */
+  private escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+}
+
+export default new OnCallNotificationAlertingService();

--- a/Common/Server/Services/UserNotificationRuleService.ts
+++ b/Common/Server/Services/UserNotificationRuleService.ts
@@ -14,6 +14,13 @@ import TelegramService from "./TelegramService";
 import WebhookService from "./WebhookService";
 import WhatsAppService from "./WhatsAppService";
 import UserEmailService from "./UserEmailService";
+import UserCallService from "./UserCallService";
+import UserPushService from "./UserPushService";
+import UserSmsService from "./UserSmsService";
+import UserTelegramService from "./UserTelegramService";
+import UserWebhookService from "./UserWebhookService";
+import UserWhatsAppService from "./UserWhatsAppService";
+import ProjectService from "./ProjectService";
 import UserOnCallLogService from "./UserOnCallLogService";
 import UserOnCallLogTimelineService from "./UserOnCallLogTimelineService";
 import { AppApiRoute } from "../../ServiceRoute";
@@ -49,8 +56,16 @@ import UserNotificationExecutionStatus from "../../Types/UserNotification/UserNo
 import UserNotificationStatus from "../../Types/UserNotification/UserNotificationStatus";
 import Incident from "../../Models/DatabaseModels/Incident";
 import IncidentSeverity from "../../Models/DatabaseModels/IncidentSeverity";
+import Monitor from "../../Models/DatabaseModels/Monitor";
+import Project from "../../Models/DatabaseModels/Project";
 import ShortLink from "../../Models/DatabaseModels/ShortLink";
+import UserCall from "../../Models/DatabaseModels/UserCall";
 import UserEmail from "../../Models/DatabaseModels/UserEmail";
+import UserPush from "../../Models/DatabaseModels/UserPush";
+import UserSMS from "../../Models/DatabaseModels/UserSMS";
+import UserTelegram from "../../Models/DatabaseModels/UserTelegram";
+import UserWebhook from "../../Models/DatabaseModels/UserWebhook";
+import UserWhatsApp from "../../Models/DatabaseModels/UserWhatsApp";
 import Model from "../../Models/DatabaseModels/UserNotificationRule";
 import UserOnCallLog from "../../Models/DatabaseModels/UserOnCallLog";
 import UserOnCallLogTimeline from "../../Models/DatabaseModels/UserOnCallLogTimeline";
@@ -64,6 +79,8 @@ import AlertEpisodeMember from "../../Models/DatabaseModels/AlertEpisodeMember";
 import AlertEpisodeMemberService from "./AlertEpisodeMemberService";
 import IncidentEpisode from "../../Models/DatabaseModels/IncidentEpisode";
 import IncidentEpisodeService from "./IncidentEpisodeService";
+import IncidentEpisodeMember from "../../Models/DatabaseModels/IncidentEpisodeMember";
+import IncidentEpisodeMemberService from "./IncidentEpisodeMemberService";
 import WorkspaceNotificationRule from "../../Models/DatabaseModels/WorkspaceNotificationRule";
 import WorkspaceNotificationRuleService from "./WorkspaceNotificationRuleService";
 import PushNotificationService from "./PushNotificationService";
@@ -84,6 +101,100 @@ export interface NotificationMethodDescriptor {
   userWebhookId?: ObjectID;
 }
 
+/*
+ * Everything a single delivery attempt needs to know about the page it is
+ * carrying: which project, which entity fired it, which escalation produced it,
+ * and which UserOnCallLog row it must reconcile against. This used to be an
+ * inline object literal on executeNotificationRuleItem; it is named here because
+ * the fallback path (executeFallbackNotification) hands the very same bundle to
+ * the very same delivery code, and because callers outside this file now need to
+ * be able to type a variable against it.
+ */
+export interface ExecuteNotificationRuleOptions {
+  projectId: ObjectID;
+  triggeredByIncidentId?: ObjectID | undefined;
+  triggeredByAlertId?: ObjectID | undefined;
+  triggeredByAlertEpisodeId?: ObjectID | undefined;
+  triggeredByIncidentEpisodeId?: ObjectID | undefined;
+  userNotificationEventType: UserNotificationEventType;
+  onCallPolicyExecutionLogId?: ObjectID | undefined;
+  onCallPolicyId: ObjectID | undefined;
+  onCallPolicyEscalationRuleId?: ObjectID | undefined;
+  userNotificationLogId: ObjectID;
+  userBelongsToTeamId?: ObjectID | undefined;
+  onCallDutyPolicyExecutionLogTimelineId?: ObjectID | undefined;
+  onCallScheduleId?: ObjectID | undefined;
+}
+
+export interface ExecuteFallbackNotificationOptions
+  extends ExecuteNotificationRuleOptions {
+  userId: ObjectID;
+  userOnCallLogId: ObjectID;
+  ruleType: NotificationRuleType;
+  // Only used to explain, in prose, which severity had no rule configured.
+  severityName: string;
+}
+
+/*
+ * Why the fallback returns an outcome and not just a boolean.
+ *
+ * Its caller (UserOnCallLogService.onCreateSuccess) has to pick a
+ * UserNotificationExecutionStatus out of the answer, and
+ * UserNotificationExecutionStatus.Error is TERMINAL — ExecutePendingExecutions
+ * selects Executing and TimeoutStuckExecutions selects Started, so nothing
+ * anywhere re-selects an Error log. That makes the two ways of not notifying
+ * somebody opposites rather than synonyms: "this responder has nothing we can
+ * page them on" is a real, permanent misconfiguration worth burning the log
+ * for, while "the send raised" is a bad minute that a terminal status would
+ * turn into a permanently dropped page. Both are `notified: false`, so the
+ * difference has to survive the return or the caller cannot act on it.
+ */
+export enum FallbackNotificationOutcome {
+  /*
+   * A page was handed to at least one sender. Nothing below observes what the
+   * sender then did with it — every send in deliverNotificationForRule is
+   * fire-and-forget — so this means dispatched, not received.
+   */
+  Delivered = "Delivered",
+
+  /*
+   * There was nothing to try. The responder has no verified method the
+   * fallback may use and no webhook, or the only paid channels they have are
+   * switched off at the project level. Permanent: a retry finds the same
+   * nothing, and only a human adding a notification method changes it.
+   */
+  NoUsableNotificationMethod = "NoUsableNotificationMethod",
+
+  /*
+   * There was something to try and none of it went out: a send raised, or a
+   * chosen channel had no template for this event type, or another run already
+   * holds the fallback claim on this log and owns the outcome. All three are
+   * transient from the caller's point of view — none of them is evidence that
+   * the responder is unreachable, so none of them justifies a terminal status.
+   */
+  DeliveryFailed = "DeliveryFailed",
+}
+
+export interface FallbackNotificationResult {
+  outcome: FallbackNotificationOutcome;
+  /*
+   * Mirror of `outcome === FallbackNotificationOutcome.Delivered`, kept because
+   * most read sites only want the yes/no and re-deriving the comparison at each
+   * one is how a caller ends up asserting the wrong half of the enum.
+   */
+  notified: boolean;
+  channelsUsed: Array<string>;
+}
+
+/*
+ * The fallback is not tied to any UserNotificationRule row — there is no rule,
+ * which is the whole reason it runs — so it claims the on-call log under this
+ * reserved literal instead of a rule id. `executedNotificationRules` is a jsonb
+ * map keyed by arbitrary text, so the literal sits beside real rule uuids and
+ * can never collide with one.
+ */
+export const FALLBACK_NOTIFICATION_CLAIM_KEY: string = "__fallback__";
+
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
@@ -92,21 +203,7 @@ export class Service extends DatabaseService<Model> {
   @CaptureSpan()
   public async executeNotificationRuleItem(
     userNotificationRuleId: ObjectID,
-    options: {
-      projectId: ObjectID;
-      triggeredByIncidentId?: ObjectID | undefined;
-      triggeredByAlertId?: ObjectID | undefined;
-      triggeredByAlertEpisodeId?: ObjectID | undefined;
-      triggeredByIncidentEpisodeId?: ObjectID | undefined;
-      userNotificationEventType: UserNotificationEventType;
-      onCallPolicyExecutionLogId?: ObjectID | undefined;
-      onCallPolicyId: ObjectID | undefined;
-      onCallPolicyEscalationRuleId?: ObjectID | undefined;
-      userNotificationLogId: ObjectID;
-      userBelongsToTeamId?: ObjectID | undefined;
-      onCallDutyPolicyExecutionLogTimelineId?: ObjectID | undefined;
-      onCallScheduleId?: ObjectID | undefined;
-    },
+    options: ExecuteNotificationRuleOptions,
   ): Promise<void> {
     /*
      * Atomically claim this rule for this on-call log BEFORE sending, so two
@@ -173,24 +270,37 @@ export class Service extends DatabaseService<Model> {
       throw new BadDataException("Notification rule item not found.");
     }
 
-    /*
-     * If the project has a default Twilio config set, use it for all
-     * team-member SMS and Calls in this rule. Otherwise the global config
-     * is used by the notification service.
-     */
-    const projectTwilioConfig: TwilioConfig | undefined =
-      await ProjectCallSMSConfigService.getProjectDefaultTwilioConfig(
-        options.projectId,
-      );
+    await this.deliverNotificationForRule(notificationRuleItem, options);
+  }
 
+  /*
+   * Build the timeline row every channel block stamps its status onto.
+   *
+   * Callers keep ONE instance and mutate it, because after the first create()
+   * the instance carries an _id and a second create() with it UPDATEs the row
+   * it already wrote instead of inserting a new one. Anything that needs a row
+   * genuinely independent of the delivery attempts (the fell-through guard
+   * below) must therefore call this again for a fresh instance rather than
+   * reuse the one the channel blocks have been writing to.
+   */
+  private buildLogTimelineItem(
+    notificationRuleItem: Model,
+    options: ExecuteNotificationRuleOptions,
+  ): UserOnCallLogTimeline {
     const logTimelineItem: UserOnCallLogTimeline = new UserOnCallLogTimeline();
     logTimelineItem.projectId = options.projectId;
-    logTimelineItem.userNotificationLogId = options.userNotificationLogId;
-    logTimelineItem.userNotificationRuleId = userNotificationRuleId;
     logTimelineItem.userNotificationLogId = options.userNotificationLogId;
     logTimelineItem.userId = notificationRuleItem.userId!;
     logTimelineItem.userNotificationEventType =
       options.userNotificationEventType;
+
+    /*
+     * The fallback delivers through rules it builds in memory and never saves,
+     * so there is not always a rule id to point the row at.
+     */
+    if (notificationRuleItem.id) {
+      logTimelineItem.userNotificationRuleId = notificationRuleItem.id;
+    }
 
     if (options.userBelongsToTeamId) {
       logTimelineItem.userBelongsToTeamId = options.userBelongsToTeamId;
@@ -232,6 +342,56 @@ export class Service extends DatabaseService<Model> {
       logTimelineItem.onCallDutyPolicyExecutionLogTimelineId =
         options.onCallDutyPolicyExecutionLogTimelineId;
     }
+
+    return logTimelineItem;
+  }
+
+  /*
+   * The delivery half of executeNotificationRuleItem: given a rule that is
+   * already loaded with its method relations, decide what to send on which
+   * channel and hand it to the senders.
+   *
+   * It is split out from the public method so executeFallbackNotification can
+   * reuse it with a rule it assembled in memory and never persisted. The claim
+   * and the rule lookup that the public method does first are meaningless for a
+   * rule that does not exist in the database; everything from here down is
+   * exactly what the fallback needs.
+   *
+   * Returns whether a page was actually handed to a sender, which the fallback
+   * needs and the normal path ignores. Resolving without throwing is NOT the
+   * same as having sent something: a rule whose channel has no block for this
+   * event type falls all the way through to the guard at the bottom, writes an
+   * Error row and sends nothing. A caller that read "did not throw" as "paged"
+   * would name a channel the responder never heard from.
+   */
+  private async deliverNotificationForRule(
+    notificationRuleItem: Model,
+    options: ExecuteNotificationRuleOptions,
+  ): Promise<boolean> {
+    /*
+     * If the project has a default Twilio config set, use it for all
+     * team-member SMS and Calls in this rule. Otherwise the global config
+     * is used by the notification service.
+     */
+    const projectTwilioConfig: TwilioConfig | undefined =
+      await ProjectCallSMSConfigService.getProjectDefaultTwilioConfig(
+        options.projectId,
+      );
+
+    const logTimelineItem: UserOnCallLogTimeline = this.buildLogTimelineItem(
+      notificationRuleItem,
+      options,
+    );
+
+    /*
+     * Which channels this rule could actually deliver on, and whether any block
+     * below matched the event type. If a channel is contactable but no branch
+     * claimed the event, the page vanishes without a trace — the guard at the
+     * end of this method turns that into a visible Error row.
+     */
+    const contactableChannels: Array<string> =
+      this.getContactableChannelNames(notificationRuleItem);
+    let deliveryAttempted: boolean = false;
 
     // add status and status message and save.
 
@@ -382,6 +542,7 @@ export class Service extends DatabaseService<Model> {
         alert
       ) {
         // create an error log.
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending email to ${notificationRuleItem.userEmail?.email.toString()}`;
         logTimelineItem.userEmailId = notificationRuleItem.userEmail.id!;
@@ -435,6 +596,7 @@ export class Service extends DatabaseService<Model> {
         incident
       ) {
         // create an error log.
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending email to ${notificationRuleItem.userEmail?.email.toString()}`;
         logTimelineItem.userEmailId = notificationRuleItem.userEmail.id!;
@@ -487,6 +649,7 @@ export class Service extends DatabaseService<Model> {
           UserNotificationEventType.AlertEpisodeCreated &&
         alertEpisode
       ) {
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending email to ${notificationRuleItem.userEmail?.email.toString()}`;
         logTimelineItem.userEmailId = notificationRuleItem.userEmail.id!;
@@ -510,6 +673,61 @@ export class Service extends DatabaseService<Model> {
           userOnCallLogTimelineId: updatedLog.id!,
           projectId: options.projectId,
           alertEpisodeId: alertEpisode.id!,
+          userId: notificationRuleItem.userId!,
+          onCallPolicyId: options.onCallPolicyId,
+          onCallPolicyEscalationRuleId: options.onCallPolicyEscalationRuleId,
+          teamId: options.userBelongsToTeamId,
+          onCallDutyPolicyExecutionLogTimelineId:
+            options.onCallDutyPolicyExecutionLogTimelineId,
+          onCallScheduleId: options.onCallScheduleId,
+        }).catch(async (err: Error) => {
+          await UserOnCallLogTimelineService.updateOneById({
+            id: updatedLog.id!,
+            data: {
+              status: UserNotificationStatus.Error,
+              statusMessage: err.message || "Error sending email.",
+            },
+            props: {
+              isRoot: true,
+            },
+          });
+        });
+      }
+
+      // send email for incident episode
+      if (
+        options.userNotificationEventType ===
+          UserNotificationEventType.IncidentEpisodeCreated &&
+        incidentEpisode
+      ) {
+        deliveryAttempted = true;
+        logTimelineItem.status = UserNotificationStatus.Sending;
+        logTimelineItem.statusMessage = `Sending email to ${notificationRuleItem.userEmail?.email.toString()}`;
+        logTimelineItem.userEmailId = notificationRuleItem.userEmail.id!;
+
+        const updatedLog: UserOnCallLogTimeline =
+          await UserOnCallLogTimelineService.create({
+            data: logTimelineItem,
+            props: {
+              isRoot: true,
+            },
+          });
+
+        const emailMessage: EmailMessage =
+          await this.generateEmailTemplateForIncidentEpisodeCreated(
+            notificationRuleItem.userEmail?.email,
+            incidentEpisode,
+            updatedLog.id!,
+          );
+
+        /*
+         * No incidentEpisodeId is passed: MailService.sendMail accepts the key
+         * in its options type but never serialises it onto the request body, so
+         * passing it would look like a link that does not exist.
+         */
+        MailService.sendMail(emailMessage, {
+          userOnCallLogTimelineId: updatedLog.id!,
+          projectId: options.projectId,
           userId: notificationRuleItem.userId!,
           onCallPolicyId: options.onCallPolicyId,
           onCallPolicyEscalationRuleId: options.onCallPolicyEscalationRuleId,
@@ -561,6 +779,7 @@ export class Service extends DatabaseService<Model> {
         alert
       ) {
         // create an error log.
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending SMS to ${notificationRuleItem.userSms?.phone.toString()}.`;
         logTimelineItem.userSmsId = notificationRuleItem.userSms.id!;
@@ -614,6 +833,7 @@ export class Service extends DatabaseService<Model> {
         incident
       ) {
         // create an error log.
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending SMS to ${notificationRuleItem.userSms?.phone.toString()}.`;
         logTimelineItem.userSmsId = notificationRuleItem.userSms.id!;
@@ -667,6 +887,7 @@ export class Service extends DatabaseService<Model> {
           UserNotificationEventType.AlertEpisodeCreated &&
         alertEpisode
       ) {
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending SMS to ${notificationRuleItem.userSms?.phone.toString()}.`;
         logTimelineItem.userSmsId = notificationRuleItem.userSms.id!;
@@ -691,6 +912,61 @@ export class Service extends DatabaseService<Model> {
           customTwilioConfig: projectTwilioConfig,
           userOnCallLogTimelineId: updatedLog.id!,
           alertEpisodeId: alertEpisode.id!,
+          userId: notificationRuleItem.userId!,
+          onCallPolicyId: options.onCallPolicyId,
+          onCallPolicyEscalationRuleId: options.onCallPolicyEscalationRuleId,
+          teamId: options.userBelongsToTeamId,
+          onCallDutyPolicyExecutionLogTimelineId:
+            options.onCallDutyPolicyExecutionLogTimelineId,
+          onCallScheduleId: options.onCallScheduleId,
+        }).catch(async (err: Error) => {
+          await UserOnCallLogTimelineService.updateOneById({
+            id: updatedLog.id!,
+            data: {
+              status: UserNotificationStatus.Error,
+              statusMessage: err.message || "Error sending SMS.",
+            },
+            props: {
+              isRoot: true,
+            },
+          });
+        });
+      }
+
+      // send sms for incident episode
+      if (
+        options.userNotificationEventType ===
+          UserNotificationEventType.IncidentEpisodeCreated &&
+        incidentEpisode
+      ) {
+        deliveryAttempted = true;
+        logTimelineItem.status = UserNotificationStatus.Sending;
+        logTimelineItem.statusMessage = `Sending SMS to ${notificationRuleItem.userSms?.phone.toString()}.`;
+        logTimelineItem.userSmsId = notificationRuleItem.userSms.id!;
+
+        const updatedLog: UserOnCallLogTimeline =
+          await UserOnCallLogTimelineService.create({
+            data: logTimelineItem,
+            props: {
+              isRoot: true,
+            },
+          });
+
+        const smsMessage: SMS =
+          await this.generateSmsTemplateForIncidentEpisodeCreated(
+            notificationRuleItem.userSms.phone,
+            incidentEpisode,
+            updatedLog.id!,
+          );
+
+        /*
+         * SmsService accepts incidentEpisodeId but drops it on the floor when
+         * building the request body, so it is deliberately not passed here.
+         */
+        SmsService.sendSms(smsMessage, {
+          projectId: incidentEpisode.projectId,
+          customTwilioConfig: projectTwilioConfig,
+          userOnCallLogTimelineId: updatedLog.id!,
           userId: notificationRuleItem.userId!,
           onCallPolicyId: options.onCallPolicyId,
           onCallPolicyEscalationRuleId: options.onCallPolicyEscalationRuleId,
@@ -738,6 +1014,7 @@ export class Service extends DatabaseService<Model> {
           UserNotificationEventType.AlertCreated &&
         alert
       ) {
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending WhatsApp message to ${notificationRuleItem.userWhatsApp?.phone.toString()}.`;
         logTimelineItem.userWhatsAppId = notificationRuleItem.userWhatsApp.id!;
@@ -787,6 +1064,7 @@ export class Service extends DatabaseService<Model> {
           UserNotificationEventType.IncidentCreated &&
         incident
       ) {
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending WhatsApp message to ${notificationRuleItem.userWhatsApp?.phone.toString()}.`;
         logTimelineItem.userWhatsAppId = notificationRuleItem.userWhatsApp.id!;
@@ -837,6 +1115,7 @@ export class Service extends DatabaseService<Model> {
           UserNotificationEventType.AlertEpisodeCreated &&
         alertEpisode
       ) {
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending WhatsApp message to ${notificationRuleItem.userWhatsApp?.phone.toString()}.`;
         logTimelineItem.userWhatsAppId = notificationRuleItem.userWhatsApp.id!;
@@ -859,6 +1138,60 @@ export class Service extends DatabaseService<Model> {
         WhatsAppService.sendWhatsAppMessage(whatsAppMessage, {
           projectId: alertEpisode.projectId,
           alertEpisodeId: alertEpisode.id!,
+          userOnCallLogTimelineId: updatedLog.id!,
+          userId: notificationRuleItem.userId!,
+          onCallPolicyId: options.onCallPolicyId,
+          onCallPolicyEscalationRuleId: options.onCallPolicyEscalationRuleId,
+          teamId: options.userBelongsToTeamId,
+          onCallDutyPolicyExecutionLogTimelineId:
+            options.onCallDutyPolicyExecutionLogTimelineId,
+          onCallScheduleId: options.onCallScheduleId,
+        }).catch(async (err: Error) => {
+          await UserOnCallLogTimelineService.updateOneById({
+            id: updatedLog.id!,
+            data: {
+              status: UserNotificationStatus.Error,
+              statusMessage: err.message || "Error sending WhatsApp message.",
+            },
+            props: {
+              isRoot: true,
+            },
+          });
+        });
+      }
+
+      // send WhatsApp for incident episode
+      if (
+        options.userNotificationEventType ===
+          UserNotificationEventType.IncidentEpisodeCreated &&
+        incidentEpisode
+      ) {
+        deliveryAttempted = true;
+        logTimelineItem.status = UserNotificationStatus.Sending;
+        logTimelineItem.statusMessage = `Sending WhatsApp message to ${notificationRuleItem.userWhatsApp?.phone.toString()}.`;
+        logTimelineItem.userWhatsAppId = notificationRuleItem.userWhatsApp.id!;
+
+        const updatedLog: UserOnCallLogTimeline =
+          await UserOnCallLogTimelineService.create({
+            data: logTimelineItem,
+            props: {
+              isRoot: true,
+            },
+          });
+
+        const whatsAppMessage: WhatsAppMessage =
+          await this.generateWhatsAppTemplateForIncidentEpisodeCreated(
+            notificationRuleItem.userWhatsApp.phone,
+            incidentEpisode,
+            updatedLog.id!,
+          );
+
+        /*
+         * WhatsAppService accepts incidentEpisodeId but never writes it onto
+         * the request body, so it is deliberately not passed here.
+         */
+        WhatsAppService.sendWhatsAppMessage(whatsAppMessage, {
+          projectId: incidentEpisode.projectId,
           userOnCallLogTimelineId: updatedLog.id!,
           userId: notificationRuleItem.userId!,
           onCallPolicyId: options.onCallPolicyId,
@@ -908,6 +1241,7 @@ export class Service extends DatabaseService<Model> {
           UserNotificationEventType.AlertCreated &&
         alert
       ) {
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending Telegram message.`;
         logTimelineItem.userTelegramId = notificationRuleItem.userTelegram.id!;
@@ -960,6 +1294,7 @@ export class Service extends DatabaseService<Model> {
           UserNotificationEventType.IncidentCreated &&
         incident
       ) {
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending Telegram message.`;
         logTimelineItem.userTelegramId = notificationRuleItem.userTelegram.id!;
@@ -1012,6 +1347,7 @@ export class Service extends DatabaseService<Model> {
           UserNotificationEventType.AlertEpisodeCreated &&
         alertEpisode
       ) {
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending Telegram message.`;
         logTimelineItem.userTelegramId = notificationRuleItem.userTelegram.id!;
@@ -1037,6 +1373,62 @@ export class Service extends DatabaseService<Model> {
         TelegramService.sendTelegramMessage(telegramMessage, {
           projectId: alertEpisode.projectId,
           alertEpisodeId: alertEpisode.id!,
+          userOnCallLogTimelineId: updatedLog.id!,
+          userId: notificationRuleItem.userId!,
+          onCallPolicyId: options.onCallPolicyId,
+          onCallPolicyEscalationRuleId: options.onCallPolicyEscalationRuleId,
+          teamId: options.userBelongsToTeamId,
+          onCallDutyPolicyExecutionLogTimelineId:
+            options.onCallDutyPolicyExecutionLogTimelineId,
+          onCallScheduleId: options.onCallScheduleId,
+        }).catch(async (err: Error) => {
+          await UserOnCallLogTimelineService.updateOneById({
+            id: updatedLog.id!,
+            data: {
+              status: UserNotificationStatus.Error,
+              statusMessage: err.message || "Error sending Telegram message.",
+            },
+            props: {
+              isRoot: true,
+            },
+          });
+        });
+      }
+
+      if (
+        options.userNotificationEventType ===
+          UserNotificationEventType.IncidentEpisodeCreated &&
+        incidentEpisode
+      ) {
+        deliveryAttempted = true;
+        logTimelineItem.status = UserNotificationStatus.Sending;
+        logTimelineItem.statusMessage = `Sending Telegram message.`;
+        logTimelineItem.userTelegramId = notificationRuleItem.userTelegram.id!;
+
+        const updatedLog: UserOnCallLogTimeline =
+          await UserOnCallLogTimelineService.create({
+            data: logTimelineItem,
+            props: {
+              isRoot: true,
+            },
+          });
+
+        const telegramMessage: TelegramMessage = {
+          to: notificationRuleItem.userTelegram.telegramChatId,
+          body: await this.generateTelegramBodyForIncidentEpisodeCreated(
+            incidentEpisode,
+            updatedLog.id!,
+          ),
+          parseMode: "HTML",
+          disableWebPagePreview: true,
+        };
+
+        /*
+         * TelegramService accepts incidentEpisodeId but never writes it onto
+         * the request body, so it is deliberately not passed here.
+         */
+        TelegramService.sendTelegramMessage(telegramMessage, {
+          projectId: incidentEpisode.projectId,
           userOnCallLogTimelineId: updatedLog.id!,
           userId: notificationRuleItem.userId!,
           onCallPolicyId: options.onCallPolicyId,
@@ -1094,6 +1486,7 @@ export class Service extends DatabaseService<Model> {
         entityId?: ObjectID;
         entityKind: "alert" | "incident" | "alertEpisode" | "incidentEpisode";
       }): Promise<void> => {
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending webhook to ${webhookUrl}.`;
         logTimelineItem.userWebhookId = userWebhookId;
@@ -1284,6 +1677,7 @@ export class Service extends DatabaseService<Model> {
         alert
       ) {
         // create an error log.
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Making a call to ${notificationRuleItem.userCall?.phone.toString()}.`;
         logTimelineItem.userCallId = notificationRuleItem.userCall.id!;
@@ -1337,6 +1731,7 @@ export class Service extends DatabaseService<Model> {
         incident
       ) {
         // send call for incident
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Making a call to ${notificationRuleItem.userCall?.phone.toString()}.`;
         logTimelineItem.userCallId = notificationRuleItem.userCall.id!;
@@ -1390,6 +1785,7 @@ export class Service extends DatabaseService<Model> {
           UserNotificationEventType.AlertEpisodeCreated &&
         alertEpisode
       ) {
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Making a call to ${notificationRuleItem.userCall?.phone.toString()}.`;
         logTimelineItem.userCallId = notificationRuleItem.userCall.id!;
@@ -1414,6 +1810,61 @@ export class Service extends DatabaseService<Model> {
           customTwilioConfig: projectTwilioConfig,
           userOnCallLogTimelineId: updatedLog.id!,
           alertEpisodeId: alertEpisode.id!,
+          userId: notificationRuleItem.userId!,
+          onCallPolicyId: options.onCallPolicyId,
+          onCallPolicyEscalationRuleId: options.onCallPolicyEscalationRuleId,
+          teamId: options.userBelongsToTeamId,
+          onCallDutyPolicyExecutionLogTimelineId:
+            options.onCallDutyPolicyExecutionLogTimelineId,
+          onCallScheduleId: options.onCallScheduleId,
+        }).catch(async (err: Error) => {
+          await UserOnCallLogTimelineService.updateOneById({
+            id: updatedLog.id!,
+            data: {
+              status: UserNotificationStatus.Error,
+              statusMessage: err.message || "Error making call.",
+            },
+            props: {
+              isRoot: true,
+            },
+          });
+        });
+      }
+
+      // send call for incident episode
+      if (
+        options.userNotificationEventType ===
+          UserNotificationEventType.IncidentEpisodeCreated &&
+        incidentEpisode
+      ) {
+        deliveryAttempted = true;
+        logTimelineItem.status = UserNotificationStatus.Sending;
+        logTimelineItem.statusMessage = `Making a call to ${notificationRuleItem.userCall?.phone.toString()}.`;
+        logTimelineItem.userCallId = notificationRuleItem.userCall.id!;
+
+        const updatedLog: UserOnCallLogTimeline =
+          await UserOnCallLogTimelineService.create({
+            data: logTimelineItem,
+            props: {
+              isRoot: true,
+            },
+          });
+
+        const callRequest: CallRequest =
+          await this.generateCallTemplateForIncidentEpisodeCreated(
+            notificationRuleItem.userCall?.phone,
+            incidentEpisode,
+            updatedLog.id!,
+          );
+
+        /*
+         * CallService accepts incidentEpisodeId but never writes it onto the
+         * request body, so it is deliberately not passed here.
+         */
+        CallService.makeCall(callRequest, {
+          projectId: incidentEpisode.projectId,
+          customTwilioConfig: projectTwilioConfig,
+          userOnCallLogTimelineId: updatedLog.id!,
           userId: notificationRuleItem.userId!,
           onCallPolicyId: options.onCallPolicyId,
           onCallPolicyEscalationRuleId: options.onCallPolicyEscalationRuleId,
@@ -1464,6 +1915,7 @@ export class Service extends DatabaseService<Model> {
         alert
       ) {
         // create a log.
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending push notification to device.`;
         logTimelineItem.userPushId = notificationRuleItem.userPush.id!;
@@ -1544,6 +1996,7 @@ export class Service extends DatabaseService<Model> {
         incident
       ) {
         // create a log.
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending push notification to device.`;
         logTimelineItem.userPushId = notificationRuleItem.userPush.id!;
@@ -1623,6 +2076,7 @@ export class Service extends DatabaseService<Model> {
           UserNotificationEventType.AlertEpisodeCreated &&
         alertEpisode
       ) {
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending push notification to device.`;
         logTimelineItem.userPushId = notificationRuleItem.userPush.id!;
@@ -1701,6 +2155,7 @@ export class Service extends DatabaseService<Model> {
           UserNotificationEventType.IncidentEpisodeCreated &&
         incidentEpisode
       ) {
+        deliveryAttempted = true;
         logTimelineItem.status = UserNotificationStatus.Sending;
         logTimelineItem.statusMessage = `Sending push notification to device.`;
         logTimelineItem.userPushId = notificationRuleItem.userPush.id!;
@@ -1788,6 +2243,484 @@ export class Service extends DatabaseService<Model> {
         },
       });
     }
+
+    /*
+     * The fell-through guard.
+     *
+     * Gap F was a whole class of lost pages: a contactable channel, an event
+     * type that no block in that channel branched on, and therefore neither a
+     * send nor an error row — the responder was simply never told, and nothing
+     * anywhere recorded that. Rather than trust that every future event type
+     * gets wired into all seven blocks, make the omission loud.
+     *
+     * The row is built fresh instead of reusing logTimelineItem: that instance
+     * picks up an _id as soon as any block has created a row with it, and a
+     * second create() with it would UPDATE that row rather than insert this one.
+     */
+    if (contactableChannels.length > 0 && !deliveryAttempted) {
+      const statusMessage: string = `No notification template for ${options.userNotificationEventType} on ${contactableChannels.join(", ")}.`;
+
+      const fellThroughRow: UserOnCallLogTimeline = this.buildLogTimelineItem(
+        notificationRuleItem,
+        options,
+      );
+      fellThroughRow.status = UserNotificationStatus.Error;
+      fellThroughRow.statusMessage = statusMessage;
+
+      await UserOnCallLogTimelineService.create({
+        data: fellThroughRow,
+        props: {
+          isRoot: true,
+        },
+      });
+
+      logger.error(
+        `${statusMessage} User on-call log: ${options.userNotificationLogId.toString()}`,
+      );
+    }
+
+    return deliveryAttempted;
+  }
+
+  /*
+   * The channels this rule could actually reach the user on, by display name.
+   *
+   * These are the same gates each channel block opens with, so an empty list
+   * means "this rule can contact nobody" — a rule whose method was
+   * cascade-deleted, say — and a non-empty one means a page was expected to go
+   * out. Webhooks have no verification concept at all (UserWebhook has no
+   * isVerified column), so presence of a URL is the whole gate there.
+   */
+  private getContactableChannelNames(
+    notificationRuleItem: Model,
+  ): Array<string> {
+    const channels: Array<string> = [];
+
+    if (
+      notificationRuleItem.userEmail?.email &&
+      notificationRuleItem.userEmail?.isVerified
+    ) {
+      channels.push("Email");
+    }
+
+    if (
+      notificationRuleItem.userSms?.phone &&
+      notificationRuleItem.userSms?.isVerified
+    ) {
+      channels.push("SMS");
+    }
+
+    if (
+      notificationRuleItem.userWhatsApp?.phone &&
+      notificationRuleItem.userWhatsApp?.isVerified
+    ) {
+      channels.push("WhatsApp");
+    }
+
+    if (
+      notificationRuleItem.userTelegram?.telegramChatId &&
+      notificationRuleItem.userTelegram?.isVerified
+    ) {
+      channels.push("Telegram");
+    }
+
+    if (notificationRuleItem.userWebhook?.webhookUrl) {
+      channels.push("Webhook");
+    }
+
+    if (
+      notificationRuleItem.userCall?.phone &&
+      notificationRuleItem.userCall?.isVerified
+    ) {
+      channels.push("Call");
+    }
+
+    if (
+      notificationRuleItem.userPush?.deviceToken &&
+      notificationRuleItem.userPush?.isVerified
+    ) {
+      channels.push("Push");
+    }
+
+    return channels;
+  }
+
+  /*
+   * Page a responder who has NO notification rule matching what just fired.
+   *
+   * Zero matching rules is indistinguishable from "never configured" unless the
+   * user said otherwise, so the caller (UserOnCallLogService.onCreateSuccess)
+   * checks for an explicit opt-out row first and only reaches here when the
+   * silence looks accidental. Reaching a human on whatever they have verified
+   * beats honouring a configuration they never made.
+   *
+   * Nothing here observes delivery success: every send below is fire-and-forget
+   * (see deliverNotificationForRule), so `notified` means "a page was handed to
+   * the sender", not "a phone rang".
+   *
+   * The three ways this can end are spelled out in FallbackNotificationOutcome,
+   * and the caller must branch on them rather than on `notified` alone: only
+   * NoUsableNotificationMethod describes a responder who cannot be reached, and
+   * only that one is safe to record as a terminal status.
+   */
+  @CaptureSpan()
+  public async executeFallbackNotification(
+    options: ExecuteFallbackNotificationOptions,
+  ): Promise<FallbackNotificationResult> {
+    /*
+     * Claim the log under the reserved fallback key before doing anything, so
+     * two overlapping cron ticks cannot both fall back and double-page the same
+     * responder for one escalation.
+     */
+    const claimed: boolean =
+      await UserOnCallLogService.claimNotificationExecution({
+        userOnCallLogId: options.userOnCallLogId,
+        claimKey: FALLBACK_NOTIFICATION_CLAIM_KEY,
+      });
+
+    if (!claimed) {
+      /*
+       * A concurrent run already fell back for this log; it owns everything
+       * that happens next, including the log's final status. Reported as the
+       * transient outcome rather than as "no usable method", because the
+       * caller's response to the latter is a terminal Error — which would
+       * stamp "this responder is unreachable" over a page that is in flight.
+       */
+      return {
+        outcome: FallbackNotificationOutcome.DeliveryFailed,
+        notified: false,
+        channelsUsed: [],
+      };
+    }
+
+    const fallbackRules: Array<{ channelName: string; rule: Model }> =
+      await this.chooseFallbackChannels(options);
+
+    if (fallbackRules.length === 0) {
+      logger.warn(
+        `On-call fallback found no usable notification method for user ${options.userId.toString()} in project ${options.projectId.toString()} (${options.severityName} ${options.ruleType}). The page cannot be delivered.`,
+      );
+
+      return {
+        outcome: FallbackNotificationOutcome.NoUsableNotificationMethod,
+        notified: false,
+        channelsUsed: [],
+      };
+    }
+
+    const channelsUsed: Array<string> = [];
+    let anAttemptFailed: boolean = false;
+
+    /*
+     * One delivery call per channel, never a loop inside one call: the timeline
+     * row is a single mutable object inside deliverNotificationForRule, and a
+     * second create() with it would UPDATE the row the first channel wrote
+     * instead of inserting a second one — the second page would vanish from the
+     * timeline and, worse, overwrite the first one's status.
+     */
+    for (const fallbackRule of fallbackRules) {
+      try {
+        const dispatched: boolean = await this.deliverNotificationForRule(
+          fallbackRule.rule,
+          options,
+        );
+
+        /*
+         * Only a genuine dispatch earns a place in channelsUsed. The channel
+         * names in here are read back to the operator as "notified via fallback
+         * (Push, Email)", so a name added merely because the call resolved is a
+         * lie in the one place somebody looks to find out whether the responder
+         * was reached — and deliverNotificationForRule resolves perfectly
+         * happily when no block claimed the event type.
+         */
+        if (dispatched) {
+          channelsUsed.push(fallbackRule.channelName);
+        } else {
+          anAttemptFailed = true;
+
+          logger.error(
+            `On-call fallback dispatched nothing on ${fallbackRule.channelName} for user ${options.userId.toString()}: no notification template matched ${options.userNotificationEventType}.`,
+          );
+        }
+      } catch (err) {
+        anAttemptFailed = true;
+
+        logger.error(
+          `On-call fallback failed to deliver on ${fallbackRule.channelName} for user ${options.userId.toString()}.`,
+        );
+        logger.error(err);
+      }
+    }
+
+    if (channelsUsed.length > 0) {
+      return {
+        outcome: FallbackNotificationOutcome.Delivered,
+        notified: true,
+        channelsUsed: channelsUsed,
+      };
+    }
+
+    /*
+     * There were channels to try and not one of them carried a page. That is
+     * emphatically not the "responder has no notification method" case —
+     * chooseFallbackChannels returns only verified, project-enabled methods, so
+     * the responder is reachable and today simply failed to be reached.
+     *
+     * anAttemptFailed is necessarily true on this line, since every path
+     * through the loop that does not push a channel sets it. It is read rather
+     * than assumed so that a future channel that can finish without either
+     * dispatching or failing degrades into the transient outcome instead of
+     * silently telling the operator the responder has nothing configured.
+     */
+    return {
+      outcome: anAttemptFailed
+        ? FallbackNotificationOutcome.DeliveryFailed
+        : FallbackNotificationOutcome.NoUsableNotificationMethod,
+      notified: false,
+      channelsUsed: [],
+    };
+  }
+
+  /*
+   * Pick what to page the user on, and build an unsaved rule for each choice.
+   *
+   * Zero-cost channels win: push and email reach the most people for no money
+   * and no billing surprise, and there is no reason to pick between them, so a
+   * user who has both gets both. Only a user with neither is worth spending on,
+   * and then just once, in escalating-intrusiveness order.
+   *
+   * Paid channels are additionally gated on the project's own enable flags.
+   * SmsService and CallService enforce those at send time, but WhatsApp and
+   * Telegram only check them when a method is created — so a project that
+   * switched WhatsApp off would still be billed by a fallback that did not look.
+   */
+  private async chooseFallbackChannels(
+    options: ExecuteFallbackNotificationOptions,
+  ): Promise<Array<{ channelName: string; rule: Model }>> {
+    const chosen: Array<{ channelName: string; rule: Model }> = [];
+
+    const userPush: UserPush | null = await UserPushService.findOneBy({
+      query: {
+        projectId: options.projectId,
+        userId: options.userId,
+        isVerified: true,
+      },
+      select: {
+        _id: true,
+        deviceToken: true,
+        deviceType: true,
+        isVerified: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (userPush) {
+      const rule: Model = this.buildUnsavedFallbackRule(options);
+      rule.userPush = userPush;
+      rule.userPushId = userPush.id!;
+      chosen.push({ channelName: "Push", rule: rule });
+    }
+
+    const userEmail: UserEmail | null = await UserEmailService.findOneBy({
+      query: {
+        projectId: options.projectId,
+        userId: options.userId,
+        isVerified: true,
+      },
+      select: {
+        _id: true,
+        email: true,
+        isVerified: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (userEmail) {
+      const rule: Model = this.buildUnsavedFallbackRule(options);
+      rule.userEmail = userEmail;
+      rule.userEmailId = userEmail.id!;
+      chosen.push({ channelName: "Email", rule: rule });
+    }
+
+    if (chosen.length > 0) {
+      return chosen;
+    }
+
+    const project: Project | null = await ProjectService.findOneById({
+      id: options.projectId,
+      select: {
+        enableSmsNotifications: true,
+        enableCallNotifications: true,
+        enableWhatsAppNotifications: true,
+        enableTelegramNotifications: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (project?.enableSmsNotifications) {
+      const userSms: UserSMS | null = await UserSmsService.findOneBy({
+        query: {
+          projectId: options.projectId,
+          userId: options.userId,
+          isVerified: true,
+        },
+        select: {
+          _id: true,
+          phone: true,
+          isVerified: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      if (userSms) {
+        const rule: Model = this.buildUnsavedFallbackRule(options);
+        rule.userSms = userSms;
+        rule.userSmsId = userSms.id!;
+
+        return [{ channelName: "SMS", rule: rule }];
+      }
+    }
+
+    if (project?.enableCallNotifications) {
+      const userCall: UserCall | null = await UserCallService.findOneBy({
+        query: {
+          projectId: options.projectId,
+          userId: options.userId,
+          isVerified: true,
+        },
+        select: {
+          _id: true,
+          phone: true,
+          isVerified: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      if (userCall) {
+        const rule: Model = this.buildUnsavedFallbackRule(options);
+        rule.userCall = userCall;
+        rule.userCallId = userCall.id!;
+
+        return [{ channelName: "Call", rule: rule }];
+      }
+    }
+
+    if (project?.enableWhatsAppNotifications) {
+      const userWhatsApp: UserWhatsApp | null =
+        await UserWhatsAppService.findOneBy({
+          query: {
+            projectId: options.projectId,
+            userId: options.userId,
+            isVerified: true,
+          },
+          select: {
+            _id: true,
+            phone: true,
+            isVerified: true,
+          },
+          props: {
+            isRoot: true,
+          },
+        });
+
+      if (userWhatsApp) {
+        const rule: Model = this.buildUnsavedFallbackRule(options);
+        rule.userWhatsApp = userWhatsApp;
+        rule.userWhatsAppId = userWhatsApp.id!;
+
+        return [{ channelName: "WhatsApp", rule: rule }];
+      }
+    }
+
+    if (project?.enableTelegramNotifications) {
+      const userTelegram: UserTelegram | null =
+        await UserTelegramService.findOneBy({
+          query: {
+            projectId: options.projectId,
+            userId: options.userId,
+            isVerified: true,
+          },
+          select: {
+            _id: true,
+            telegramChatId: true,
+            telegramUserHandle: true,
+            isVerified: true,
+          },
+          props: {
+            isRoot: true,
+          },
+        });
+
+      if (userTelegram) {
+        const rule: Model = this.buildUnsavedFallbackRule(options);
+        rule.userTelegram = userTelegram;
+        rule.userTelegramId = userTelegram.id!;
+
+        return [{ channelName: "Telegram", rule: rule }];
+      }
+    }
+
+    /*
+     * A webhook costs the project nothing and has no verification concept at
+     * all (UserWebhook has no isVerified column), so its presence is the whole
+     * test, and there is no project flag to consult.
+     */
+    const userWebhook: UserWebhook | null = await UserWebhookService.findOneBy({
+      query: {
+        projectId: options.projectId,
+        userId: options.userId,
+      },
+      select: {
+        _id: true,
+        webhookUrl: true,
+        name: true,
+        secret: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (userWebhook) {
+      const rule: Model = this.buildUnsavedFallbackRule(options);
+      rule.userWebhook = userWebhook;
+      rule.userWebhookId = userWebhook.id!;
+
+      return [{ channelName: "Webhook", rule: rule }];
+    }
+
+    return chosen;
+  }
+
+  /*
+   * A UserNotificationRule that exists only for the length of one delivery.
+   *
+   * It is never saved: the user did not ask for this rule, and persisting it
+   * would silently rewrite their configuration behind their back. The method
+   * relation is populated as a loaded entity rather than just its FK because
+   * deliverNotificationForRule reads the relation (userEmail.email,
+   * userEmail.isVerified) and never dereferences the id.
+   */
+  private buildUnsavedFallbackRule(
+    options: ExecuteFallbackNotificationOptions,
+  ): Model {
+    const rule: Model = new Model();
+    rule.projectId = options.projectId;
+    rule.userId = options.userId;
+    rule.ruleType = options.ruleType;
+    rule.notifyAfterMinutes = 0;
+
+    return rule;
   }
 
   @CaptureSpan()
@@ -1960,6 +2893,64 @@ export class Service extends DatabaseService<Model> {
   }
 
   @CaptureSpan()
+  public async generateCallTemplateForIncidentEpisodeCreated(
+    to: Phone,
+    incidentEpisode: IncidentEpisode,
+    userOnCallLogTimelineId: ObjectID,
+  ): Promise<CallRequest> {
+    const host: Hostname = await DatabaseConfig.getHost();
+
+    const httpProtocol: Protocol = await DatabaseConfig.getHttpProtocol();
+
+    const episodeIdentifier: string = incidentEpisode.episodeNumberWithPrefix
+      ? `Incident episode ${incidentEpisode.episodeNumberWithPrefix}, ${incidentEpisode.title || "Incident Episode"}`
+      : incidentEpisode.episodeNumber !== undefined
+        ? `Incident episode number ${incidentEpisode.episodeNumber}, ${incidentEpisode.title || "Incident Episode"}`
+        : incidentEpisode.title || "Incident Episode";
+
+    const callRequest: CallRequest = {
+      to: to,
+      data: [
+        {
+          sayMessage: "This is a call from One Uptime",
+        },
+        {
+          sayMessage: "A new incident episode has been created",
+        },
+        {
+          sayMessage: episodeIdentifier,
+        },
+        {
+          introMessage: "To acknowledge this incident episode press 1",
+          numDigits: 1,
+          timeoutInSeconds: 10,
+          noInputMessage: "You have not entered any input. Good bye",
+          onInputCallRequest: {
+            "1": {
+              sayMessage:
+                "You have acknowledged this incident episode. Good bye",
+            },
+            default: {
+              sayMessage: "Invalid input. Good bye",
+            },
+          },
+          responseUrl: new URL(
+            httpProtocol,
+            host,
+            new Route(AppApiRoute.toString())
+              .addRoute(new UserOnCallLogTimeline().crudApiPath!)
+              .addRoute(
+                "/call/gather-input/" + userOnCallLogTimelineId.toString(),
+              ),
+          ),
+        },
+      ],
+    };
+
+    return callRequest;
+  }
+
+  @CaptureSpan()
   public async generateSmsTemplateForAlertCreated(
     to: Phone,
     alert: Alert,
@@ -2054,6 +3045,30 @@ export class Service extends DatabaseService<Model> {
     const sms: SMS = {
       to,
       message: `This is a message from OneUptime. A new alert episode has been created: ${episodeIdentifier}. To acknowledge this alert episode, please click on the following link ${url.toString()}`,
+    };
+
+    return sms;
+  }
+
+  @CaptureSpan()
+  public async generateSmsTemplateForIncidentEpisodeCreated(
+    to: Phone,
+    incidentEpisode: IncidentEpisode,
+    userOnCallLogTimelineId: ObjectID,
+  ): Promise<SMS> {
+    const url: URL = await this.buildOnCallAcknowledgeShortUrl(
+      userOnCallLogTimelineId,
+    );
+
+    const episodeIdentifier: string = incidentEpisode.episodeNumberWithPrefix
+      ? `${incidentEpisode.episodeNumberWithPrefix} (${incidentEpisode.title || "Incident Episode"})`
+      : incidentEpisode.episodeNumber !== undefined
+        ? `#${incidentEpisode.episodeNumber} (${incidentEpisode.title || "Incident Episode"})`
+        : incidentEpisode.title || "Incident Episode";
+
+    const sms: SMS = {
+      to,
+      message: `This is a message from OneUptime. A new incident episode has been created: ${episodeIdentifier}. To acknowledge this incident episode, please click on the following link ${url.toString()}`,
     };
 
     return sms;
@@ -2203,6 +3218,49 @@ export class Service extends DatabaseService<Model> {
       lines.push(
         "",
         `🔎 <a href="${this.escapeTelegramHtml(dashboardUrl.toString())}">View alert episode in OneUptime</a>`,
+      );
+    }
+
+    lines.push(
+      "",
+      `✅ <a href="${this.escapeTelegramHtml(ackUrl.toString())}">Tap to acknowledge</a>`,
+    );
+
+    return lines.join("\n");
+  }
+
+  @CaptureSpan()
+  public async generateTelegramBodyForIncidentEpisodeCreated(
+    incidentEpisode: IncidentEpisode,
+    userOnCallLogTimelineId: ObjectID,
+  ): Promise<string> {
+    const ackUrl: URL = await this.buildOnCallAcknowledgeShortUrl(
+      userOnCallLogTimelineId,
+    );
+
+    const episodeIdentifier: string = incidentEpisode.episodeNumberWithPrefix
+      ? `${incidentEpisode.episodeNumberWithPrefix} — ${incidentEpisode.title || "Incident Episode"}`
+      : incidentEpisode.episodeNumber !== undefined
+        ? `#${incidentEpisode.episodeNumber} — ${incidentEpisode.title || "Incident Episode"}`
+        : incidentEpisode.title || "Incident Episode";
+
+    const lines: Array<string> = [
+      "🔥 <b>New incident episode assigned to you</b>",
+      "",
+      `📋 <b>${this.escapeTelegramHtml(episodeIdentifier)}</b>`,
+      "",
+      "👤 You're getting this because you're on call.",
+    ];
+
+    if (incidentEpisode.projectId && incidentEpisode.id) {
+      const dashboardUrl: URL =
+        await IncidentEpisodeService.getEpisodeLinkInDashboard(
+          incidentEpisode.projectId,
+          incidentEpisode.id,
+        );
+      lines.push(
+        "",
+        `🔎 <a href="${this.escapeTelegramHtml(dashboardUrl.toString())}">View incident episode in OneUptime</a>`,
       );
     }
 
@@ -2373,6 +3431,51 @@ export class Service extends DatabaseService<Model> {
         alertEpisode.episodeNumberWithPrefix ||
         (alertEpisode.episodeNumber !== undefined
           ? alertEpisode.episodeNumber.toString()
+          : ""),
+      episode_link: episodeLinkOnDashboard,
+    };
+
+    const body: string = renderWhatsAppTemplate(templateKey, templateVariables);
+
+    return {
+      to,
+      body,
+      templateKey,
+      templateVariables,
+      templateLanguageCode: WhatsAppTemplateLanguage[templateKey],
+    };
+  }
+
+  @CaptureSpan()
+  public async generateWhatsAppTemplateForIncidentEpisodeCreated(
+    to: Phone,
+    incidentEpisode: IncidentEpisode,
+    userOnCallLogTimelineId: ObjectID,
+  ): Promise<WhatsAppMessage> {
+    const acknowledgeUrl: URL = await this.buildOnCallAcknowledgeShortUrl(
+      userOnCallLogTimelineId,
+    );
+
+    const episodeLinkOnDashboard: string =
+      incidentEpisode.projectId && incidentEpisode.id
+        ? (
+            await IncidentEpisodeService.getEpisodeLinkInDashboard(
+              incidentEpisode.projectId,
+              incidentEpisode.id,
+            )
+          ).toString()
+        : acknowledgeUrl.toString();
+
+    const templateKey: WhatsAppTemplateId =
+      WhatsAppTemplateIds.IncidentEpisodeCreated;
+    const templateVariables: Record<string, string> = {
+      project_name: incidentEpisode.project?.name || "OneUptime",
+      episode_title: incidentEpisode.title || "",
+      acknowledge_url: acknowledgeUrl.toString(),
+      episode_number:
+        incidentEpisode.episodeNumberWithPrefix ||
+        (incidentEpisode.episodeNumber !== undefined
+          ? incidentEpisode.episodeNumber.toString()
           : ""),
       episode_link: episodeLinkOnDashboard,
     };
@@ -2648,6 +3751,186 @@ export class Service extends DatabaseService<Model> {
   }
 
   @CaptureSpan()
+  public async generateEmailTemplateForIncidentEpisodeCreated(
+    to: Email,
+    incidentEpisode: IncidentEpisode,
+    userOnCallLogTimelineId: ObjectID,
+  ): Promise<EmailMessage> {
+    const host: Hostname = await DatabaseConfig.getHost();
+    const httpProtocol: Protocol = await DatabaseConfig.getHttpProtocol();
+
+    // Fetch incidents that are members of this episode
+    const episodeMembers: Array<IncidentEpisodeMember> =
+      await IncidentEpisodeMemberService.findBy({
+        query: {
+          incidentEpisodeId: incidentEpisode.id!,
+        },
+        select: {
+          incidentId: true,
+        },
+        props: {
+          isRoot: true,
+        },
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+      });
+
+    // Get the incident IDs
+    const incidentIds: Array<ObjectID> = episodeMembers
+      .map((member: IncidentEpisodeMember) => {
+        return member.incidentId;
+      })
+      .filter((id: ObjectID | undefined): id is ObjectID => {
+        return id !== undefined;
+      });
+
+    // Fetch full incident data with monitors
+    const incidents: Array<Incident> =
+      incidentIds.length > 0
+        ? await IncidentService.findBy({
+            query: {
+              _id: QueryHelper.any(incidentIds),
+            },
+            select: {
+              _id: true,
+              title: true,
+              incidentNumber: true,
+              incidentNumberWithPrefix: true,
+              monitors: {
+                _id: true,
+                name: true,
+              },
+            },
+            props: {
+              isRoot: true,
+            },
+            limit: LIMIT_PER_PROJECT,
+            skip: 0,
+          })
+        : [];
+
+    /*
+     * Unique monitors across every incident in the episode. An incident carries
+     * a list of monitors (unlike an alert, which has exactly one), so this
+     * flattens rather than reading a single relation.
+     */
+    const monitorNames: Set<string> = new Set();
+    for (const incident of incidents) {
+      for (const monitor of incident.monitors || []) {
+        if (monitor.name) {
+          monitorNames.add(monitor.name);
+        }
+      }
+    }
+
+    const resourcesAffected: string =
+      monitorNames.size > 0
+        ? Array.from(monitorNames).join(", ")
+        : "No resources identified";
+
+    // Build incidents list HTML with proper email styling
+    let incidentsListHtml: string = "";
+    if (incidents.length > 0) {
+      const incidentRows: string[] = [];
+      for (const incident of incidents) {
+        const incidentTitle: string = incident.title || "Untitled Incident";
+        const incidentNumber: string =
+          incident.incidentNumberWithPrefix ||
+          (incident.incidentNumber ? `#${incident.incidentNumber}` : "");
+        const incidentLink: string = (
+          await IncidentService.getIncidentLinkInDashboard(
+            incidentEpisode.projectId!,
+            incident.id!,
+          )
+        ).toString();
+        const monitorName: string =
+          (incident.monitors || [])
+            .map((monitor: Monitor): string => {
+              return monitor.name || "";
+            })
+            .filter((name: string): boolean => {
+              return name.length > 0;
+            })
+            .join(", ") || "";
+
+        incidentRows.push(`
+            <tr>
+              <td style="padding: 12px 16px; border-bottom: 1px solid #e2e8f0;">
+                <table cellpadding="0" cellspacing="0" width="100%">
+                  <tr>
+                    <td style="vertical-align: middle;">
+                      <span style="display: inline-block; background-color: #fee2e2; color: #991b1b; font-size: 12px; font-weight: 600; padding: 2px 8px; border-radius: 4px; margin-right: 8px;">${incidentNumber}</span>
+                      <a href="${incidentLink}" style="color: #2563eb; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; font-weight: 500; text-decoration: none;">${incidentTitle}</a>
+                      ${monitorName ? `<span style="display: block; color: #64748b; font-size: 12px; margin-top: 4px;">Monitor: ${monitorName}</span>` : ""}
+                    </td>
+                    <td style="text-align: right; vertical-align: middle;">
+                      <a href="${incidentLink}" style="color: #2563eb; font-size: 12px; text-decoration: none;">View →</a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          `);
+      }
+      if (incidentRows.length > 0) {
+        incidentsListHtml = `
+          <table cellpadding="0" cellspacing="0" width="100%" style="background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%); border-radius: 8px; border: 1px solid #e2e8f0; margin: 8px 0 16px 0;">
+            <tbody>
+              ${incidentRows.join("")}
+            </tbody>
+          </table>
+        `;
+      }
+    }
+
+    const episodeNumber: string =
+      incidentEpisode.episodeNumberWithPrefix ||
+      (incidentEpisode.episodeNumber
+        ? `#${incidentEpisode.episodeNumber}`
+        : "");
+
+    const vars: Dictionary<string> = {
+      incidentEpisodeTitle: incidentEpisode.title!,
+      episodeNumber: episodeNumber,
+      projectName: incidentEpisode.project!.name!,
+      currentState: incidentEpisode.currentIncidentState!.name!,
+      incidentEpisodeDescription: await Markdown.convertToHTML(
+        incidentEpisode.description! || "",
+        MarkdownContentType.Email,
+      ),
+      incidentEpisodeSeverity: incidentEpisode.incidentSeverity!.name!,
+      resourcesAffected: resourcesAffected,
+      rootCause:
+        incidentEpisode.rootCause ||
+        "No root cause identified for this incident episode",
+      incidentsList: incidentsListHtml,
+      incidentsCount: incidents.length.toString(),
+      incidentEpisodeViewLink: (
+        await IncidentEpisodeService.getEpisodeLinkInDashboard(
+          incidentEpisode.projectId!,
+          incidentEpisode.id!,
+        )
+      ).toString(),
+      acknowledgeIncidentEpisodeLink: new URL(
+        httpProtocol,
+        host,
+        new Route(AppApiRoute.toString())
+          .addRoute(new UserOnCallLogTimeline().crudApiPath!)
+          .addRoute("/acknowledge-page/" + userOnCallLogTimelineId.toString()),
+      ).toString(),
+    };
+
+    const emailMessage: EmailMessage = {
+      toEmail: to!,
+      templateType: EmailTemplateType.AcknowledgeIncidentEpisode,
+      vars: vars,
+      subject: `ACTION REQUIRED: Incident Episode ${episodeNumber} created - ${incidentEpisode.title!}`,
+    };
+
+    return emailMessage;
+  }
+
+  @CaptureSpan()
   public async startUserNotificationRulesExecution(
     userId: ObjectID,
     options: {
@@ -2814,22 +4097,45 @@ export class Service extends DatabaseService<Model> {
   protected override async onBeforeCreate(
     createBy: CreateBy<Model>,
   ): Promise<OnCreate<Model>> {
-    if (
-      !createBy.data.userCallId &&
-      !createBy.data.userCall &&
-      !createBy.data.userEmail &&
-      !createBy.data.userSms &&
-      !createBy.data.userSmsId &&
-      !createBy.data.userWhatsApp &&
-      !createBy.data.userWhatsAppId &&
-      !createBy.data.userTelegram &&
-      !createBy.data.userTelegramId &&
-      !createBy.data.userWebhook &&
-      !createBy.data.userWebhookId &&
-      !createBy.data.userEmailId &&
-      !createBy.data.userPushId &&
-      !createBy.data.userPush
-    ) {
+    const hasNotificationMethod: boolean = Boolean(
+      createBy.data.userCallId ||
+        createBy.data.userCall ||
+        createBy.data.userEmail ||
+        createBy.data.userSms ||
+        createBy.data.userSmsId ||
+        createBy.data.userWhatsApp ||
+        createBy.data.userWhatsAppId ||
+        createBy.data.userTelegram ||
+        createBy.data.userTelegramId ||
+        createBy.data.userWebhook ||
+        createBy.data.userWebhookId ||
+        createBy.data.userEmailId ||
+        createBy.data.userPushId ||
+        createBy.data.userPush,
+    );
+
+    /*
+     * An opt-out row is how a user says "deliberately do not page me for this
+     * rule type at this severity". It carries the rule type and the severity and
+     * nothing else — a method on it would be self-contradictory (reach me here;
+     * also never reach me), and its whole purpose is to make silence explicit so
+     * that every OTHER zero-rule case can be treated as misconfiguration and
+     * rescued by the fallback.
+     */
+    if (createBy.data.isOptOut) {
+      if (hasNotificationMethod) {
+        throw new BadDataException(
+          "An opt-out notification rule cannot have a notification method. Remove the notification method, or turn off opt-out.",
+        );
+      }
+
+      return {
+        createBy,
+        carryForward: null,
+      };
+    }
+
+    if (!hasNotificationMethod) {
       throw new BadDataException(
         "Call, SMS, WhatsApp, Telegram, Webhook, Email, or Push notification is required",
       );
@@ -2849,20 +4155,65 @@ export class Service extends DatabaseService<Model> {
   }): Promise<void> {
     const { projectId, userId, notificationMethod } = data;
 
-    await this.createIncidentOnCallRules(projectId, userId, notificationMethod);
-    await this.createAlertOnCallRules(projectId, userId, notificationMethod);
-    await this.createSingleRule(
+    /*
+     * Read each severity list once and reuse it for both rule types it drives.
+     * Incident severities scope both ON_CALL_EXECUTED_INCIDENT and
+     * ON_CALL_EXECUTED_INCIDENT_EPISODE; alert severities do the same for their
+     * two.
+     */
+    const incidentSeverityIds: Array<ObjectID> =
+      await this.getIncidentSeverityIds(projectId);
+    const alertSeverityIds: Array<ObjectID> =
+      await this.getAlertSeverityIds(projectId);
+
+    await this.createSeverityScopedRules({
       projectId,
       userId,
       notificationMethod,
-      NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
-    );
-    await this.createSingleRule(
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      severityIds: incidentSeverityIds,
+      severityColumn: "incidentSeverityId",
+    });
+
+    await this.createSeverityScopedRules({
       projectId,
       userId,
       notificationMethod,
-      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
-    );
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_ALERT,
+      severityIds: alertSeverityIds,
+      severityColumn: "alertSeverityId",
+    });
+
+    /*
+     * The two episode rule types are severity-scoped as well, and used not to
+     * be. UserOnCallLogService counts episode rules filtered by a concrete
+     * severity id, and the episode rule pages in User Settings scope their
+     * tables the same way — so a NULL-severity episode rule matched no page and
+     * appeared in no table. Users got "defaults" that were unreachable and
+     * invisible at the same time.
+     */
+    await this.createSeverityScopedRules({
+      projectId,
+      userId,
+      notificationMethod,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+      severityIds: alertSeverityIds,
+      severityColumn: "alertSeverityId",
+    });
+
+    await this.createSeverityScopedRules({
+      projectId,
+      userId,
+      notificationMethod,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+      severityIds: incidentSeverityIds,
+      severityColumn: "incidentSeverityId",
+    });
+
+    /*
+     * These two are about the user's shift, not about anything that fired, so
+     * they legitimately have no severity and stay single rules.
+     */
     await this.createSingleRule(
       projectId,
       userId,
@@ -2932,11 +4283,9 @@ export class Service extends DatabaseService<Model> {
     return query;
   }
 
-  private async createIncidentOnCallRules(
+  private async getIncidentSeverityIds(
     projectId: ObjectID,
-    userId: ObjectID,
-    notificationMethod: NotificationMethodDescriptor,
-  ): Promise<void> {
+  ): Promise<Array<ObjectID>> {
     const incidentSeverities: Array<IncidentSeverity> =
       await IncidentSeverityService.findBy({
         query: {
@@ -2952,46 +4301,14 @@ export class Service extends DatabaseService<Model> {
         },
       });
 
-    for (const incidentSeverity of incidentSeverities) {
-      const existingRule: Model | null = await this.findOneBy({
-        query: {
-          projectId,
-          userId,
-          ...this.getNotificationMethodQuery(notificationMethod),
-          incidentSeverityId: incidentSeverity.id!,
-          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
-        } as any,
-        props: {
-          isRoot: true,
-        },
-      });
-
-      if (existingRule) {
-        continue;
-      }
-
-      const rule: Model = new Model();
-      rule.projectId = projectId;
-      rule.userId = userId;
-      this.applyNotificationMethod(rule, notificationMethod);
-      rule.incidentSeverityId = incidentSeverity.id!;
-      rule.notifyAfterMinutes = 0;
-      rule.ruleType = NotificationRuleType.ON_CALL_EXECUTED_INCIDENT;
-
-      await this.create({
-        data: rule,
-        props: {
-          isRoot: true,
-        },
-      });
-    }
+    return incidentSeverities.map((severity: IncidentSeverity): ObjectID => {
+      return severity.id!;
+    });
   }
 
-  private async createAlertOnCallRules(
+  private async getAlertSeverityIds(
     projectId: ObjectID,
-    userId: ObjectID,
-    notificationMethod: NotificationMethodDescriptor,
-  ): Promise<void> {
+  ): Promise<Array<ObjectID>> {
     const alertSeverities: Array<AlertSeverity> =
       await AlertSeverityService.findBy({
         query: {
@@ -3007,14 +4324,33 @@ export class Service extends DatabaseService<Model> {
         },
       });
 
-    for (const alertSeverity of alertSeverities) {
+    return alertSeverities.map((severity: AlertSeverity): ObjectID => {
+      return severity.id!;
+    });
+  }
+
+  /*
+   * Seed one rule per severity for a severity-scoped rule type, skipping any
+   * (method, severity, ruleType) triple the user already has. The duplicate
+   * check is keyed on the same columns the write sets, so re-verifying a method
+   * never doubles a user's rules — and therefore never doubles their pages.
+   */
+  private async createSeverityScopedRules(data: {
+    projectId: ObjectID;
+    userId: ObjectID;
+    notificationMethod: NotificationMethodDescriptor;
+    ruleType: NotificationRuleType;
+    severityIds: Array<ObjectID>;
+    severityColumn: "incidentSeverityId" | "alertSeverityId";
+  }): Promise<void> {
+    for (const severityId of data.severityIds) {
       const existingRule: Model | null = await this.findOneBy({
         query: {
-          projectId,
-          userId,
-          ...this.getNotificationMethodQuery(notificationMethod),
-          alertSeverityId: alertSeverity.id!,
-          ruleType: NotificationRuleType.ON_CALL_EXECUTED_ALERT,
+          projectId: data.projectId,
+          userId: data.userId,
+          ...this.getNotificationMethodQuery(data.notificationMethod),
+          [data.severityColumn]: severityId,
+          ruleType: data.ruleType,
         } as any,
         props: {
           isRoot: true,
@@ -3026,12 +4362,12 @@ export class Service extends DatabaseService<Model> {
       }
 
       const rule: Model = new Model();
-      rule.projectId = projectId;
-      rule.userId = userId;
-      this.applyNotificationMethod(rule, notificationMethod);
-      rule.alertSeverityId = alertSeverity.id!;
+      rule.projectId = data.projectId;
+      rule.userId = data.userId;
+      this.applyNotificationMethod(rule, data.notificationMethod);
+      rule[data.severityColumn] = severityId;
       rule.notifyAfterMinutes = 0;
-      rule.ruleType = NotificationRuleType.ON_CALL_EXECUTED_ALERT;
+      rule.ruleType = data.ruleType;
 
       await this.create({
         data: rule,

--- a/Common/Server/Services/UserOnCallLogService.ts
+++ b/Common/Server/Services/UserOnCallLogService.ts
@@ -3,17 +3,27 @@ import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
 import DatabaseService from "./DatabaseService";
 import IncidentService from "./IncidentService";
 import OnCallDutyPolicyExecutionLogTimelineService from "./OnCallDutyPolicyExecutionLogTimelineService";
-import UserNotificationRuleService from "./UserNotificationRuleService";
+import OnCallNotificationAlertingService from "./OnCallNotificationAlertingService";
+import ProjectService from "./ProjectService";
+import UserService from "./UserService";
+import UserNotificationRuleService, {
+  FallbackNotificationOutcome,
+  FallbackNotificationResult,
+} from "./UserNotificationRuleService";
 import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
 import NotificationRuleType from "../../Types/NotificationRule/NotificationRuleType";
 import ObjectID from "../../Types/ObjectID";
+import { FindWhereProperty } from "../../Types/BaseDatabase/Query";
+import QueryHelper from "../Types/Database/QueryHelper";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import OnCallDutyExecutionLogTimelineStatus from "../../Types/OnCallDutyPolicy/OnCalDutyExecutionLogTimelineStatus";
 import PositiveNumber from "../../Types/PositiveNumber";
 import UserNotificationEventType from "../../Types/UserNotification/UserNotificationEventType";
 import UserNotificationExecutionStatus from "../../Types/UserNotification/UserNotificationExecutionStatus";
 import Incident from "../../Models/DatabaseModels/Incident";
+import Project from "../../Models/DatabaseModels/Project";
+import User from "../../Models/DatabaseModels/User";
 import UserNotificationRule from "../../Models/DatabaseModels/UserNotificationRule";
 import Model from "../../Models/DatabaseModels/UserOnCallLog";
 import { IsBillingEnabled } from "../EnvironmentConfig";
@@ -27,6 +37,62 @@ import OneUptimeDate from "../../Types/Date";
 import { JSONObject } from "../../Types/JSON";
 import logger from "../Utils/Logger";
 
+/*
+ * The status message the zero-rule dead-end wrote before the fallback existed,
+ * kept verbatim. A project that sets `disableOnCallNotificationFallback` is
+ * asking for precisely the old behaviour, so it must still receive precisely
+ * the old words - operators grep their execution logs for this sentence, and a
+ * characterisation test pins it character for character.
+ */
+export const NO_NOTIFICATION_RULES_STATUS_MESSAGE: string =
+  "No notification rules found for this user. User should add the rules in User Settings > On-Call Rules.";
+
+/*
+ * FindWhereProperty is constrained to object types, so the parameter is `any`
+ * here exactly as it is on every QueryHelper predicate - the value is a TypeORM
+ * Raw operator, not a boolean, and the column it lands on is what gives it
+ * meaning.
+ */
+export type NotOptOutRuleQueryFunction = () => FindWhereProperty<any>;
+
+/*
+ * "This row is not an opt-out row" - the predicate that EVERY query which
+ * counts notification rules or picks one to execute has to carry.
+ *
+ * An opt-out row is a UserNotificationRule that exists in order to send
+ * nothing. It carries exactly the columns those queries filter on - userId,
+ * projectId, ruleType and the severity - and holds no notification method at
+ * all. Without this predicate it is therefore indistinguishable from a real
+ * rule, and the damage is not a missing filter, it is a silent lie:
+ *
+ *   - the count comes back 1, so the zero-rule branch is never entered. Both
+ *     the opt-out handling and the whole fallback below become unreachable
+ *     code - the opt-out feature would be dead the day it shipped;
+ *   - the immediate-rule lookup then SELECTS the opt-out row and "executes"
+ *     it. There is no method on it, so nothing is sent - and yet the
+ *     escalation timeline is stamped Notification Sent / "Alert Sent",
+ *     because that write happens unconditionally after the loop. The
+ *     responder is never paged and the log tells the person reading it
+ *     afterwards that they were.
+ *
+ * The predicate has to mean "not true", NULL included. `isOptOut` is NULLABLE
+ * and was added long after these rows started existing, so it is NULL on every
+ * rule written before the column and stays NULL on any row created through a
+ * path that does not mention it. A plain `isOptOut: false` compares NULL =
+ * false, which evaluates to NULL rather than true, so it would exclude every
+ * pre-existing rule in every existing install - it would not merely fail to
+ * fix this, it would stop all paging. QueryHelper.notInOrNull emits
+ * `(col NOT IN ($1) OR col IS NULL)`, which is the NULL-safe not-equals; it is
+ * the same helper Probe:UpdateConnectionStatus uses for exactly this reason
+ * (its tests pin the choice of notInOrNull over notEquals on that grounds).
+ * QueryHelper takes its values as strings and Postgres resolves the bound
+ * literal against the column's own boolean type.
+ */
+export const notOptOutRuleQuery: NotOptOutRuleQueryFunction =
+  (): FindWhereProperty<any> => {
+    return QueryHelper.notInOrNull(["true"]);
+  };
+
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
@@ -36,21 +102,10 @@ export class Service extends DatabaseService<Model> {
   }
 
   /**
-   * Atomically claim the right to execute ONE notification rule for this on-call
-   * log. Overlapping UserOnCallLog:ExecutePendingExecutions runs (a tick that
-   * exceeds the 1-minute cadence, a stalled-job re-delivery, or a burst release
-   * across worker replicas) could both read executedNotificationRules without a
-   * given delayed rule's key, both write it, and both send — double-paging the
-   * responder for a single escalation (audit F7). This mirrors
-   * OnCallDutyPolicyExecutionLogService.claimEscalationAdvance: a single
-   * conditional UPDATE that sets executedNotificationRules[ruleId] only when the
-   * key is absent and RETURNs the affected row, so exactly one concurrent run
-   * wins and the loser skips.
-   *
-   * Fail-safe: if the atomic statement errors for any reason, fall back to the
-   * previous non-atomic read-modify-write so the rule is still marked and sent.
-   * For an on-call system a rare duplicate page (the pre-fix behavior) is far
-   * better than a missed page, so this never makes paging less reliable.
+   * Atomically claim the right to execute ONE notification rule for this
+   * on-call log. Rules are claimed under their own id; see
+   * claimNotificationExecution below for what the claim actually guarantees and
+   * why it is keyed by a string.
    *
    * Returns true when THIS call claimed the rule (caller should send), false when
    * it was already executed/claimed (caller should skip) or the log is missing.
@@ -60,7 +115,44 @@ export class Service extends DatabaseService<Model> {
     userOnCallLogId: ObjectID;
     userNotificationRuleId: ObjectID;
   }): Promise<boolean> {
-    const ruleKey: string = data.userNotificationRuleId.toString();
+    return await this.claimNotificationExecution({
+      userOnCallLogId: data.userOnCallLogId,
+      claimKey: data.userNotificationRuleId.toString(),
+    });
+  }
+
+  /**
+   * Atomically claim ONE delivery attempt against this on-call log, keyed by an
+   * arbitrary string. Overlapping UserOnCallLog:ExecutePendingExecutions runs (a
+   * tick that exceeds the 1-minute cadence, a stalled-job re-delivery, or a
+   * burst release across worker replicas) could both read
+   * executedNotificationRules without a given key, both write it, and both send
+   * — double-paging the responder for a single escalation (audit F7). This
+   * mirrors OnCallDutyPolicyExecutionLogService.claimEscalationAdvance: a single
+   * conditional UPDATE that sets executedNotificationRules[key] only when the
+   * key is absent and RETURNs the affected row, so exactly one concurrent run
+   * wins and the loser skips.
+   *
+   * The key is a string rather than a rule id because not every delivery attempt
+   * has a rule behind it. The verified-method fallback runs precisely BECAUSE no
+   * rule matched, so it has nothing to claim under and instead claims a reserved
+   * literal ("__fallback__"). executedNotificationRules is a jsonb map keyed by
+   * arbitrary text, so a reserved literal sits happily beside real rule uuids and
+   * can never collide with one. Keeping a single claim implementation means the
+   * fallback inherits this atomicity, its fail-safe and its audited SQL exactly,
+   * rather than growing a second, subtly different guard.
+   *
+   * Fail-safe: if the atomic statement errors for any reason, fall back to the
+   * previous non-atomic read-modify-write so the attempt is still marked and
+   * sent. For an on-call system a rare duplicate page (the pre-fix behavior) is
+   * far better than a missed page, so this never makes paging less reliable.
+   */
+  @CaptureSpan()
+  public async claimNotificationExecution(data: {
+    userOnCallLogId: ObjectID;
+    claimKey: string;
+  }): Promise<boolean> {
+    const ruleKey: string = data.claimKey;
 
     try {
       const nowIso: string = OneUptimeDate.getCurrentDate().toISOString();
@@ -225,6 +317,17 @@ export class Service extends DatabaseService<Model> {
         },
         select: {
           incidentSeverityId: true,
+          /*
+           * The severity NAME is only ever read on the no-rule path, where every
+           * message the responder or the operator sees has to say which severity
+           * had no rule ("no rule configured for Sev4"). It rides along on this
+           * lookup rather than being fetched separately because the join is free
+           * next to a second round trip, and because the no-rule path is already
+           * the slow, unhappy one.
+           */
+          incidentSeverity: {
+            name: true,
+          },
         },
       });
 
@@ -235,6 +338,14 @@ export class Service extends DatabaseService<Model> {
           projectId: createdItem.projectId!,
           ruleType: notificationRuleType,
           incidentSeverityId: incident?.incidentSeverityId as ObjectID,
+          /*
+           * An opt-out row would otherwise be counted as a rule here, and a
+           * count of 1 sends this log down the "you have rules, execute them"
+           * path where the only thing it can find to execute is the opt-out
+           * row itself: nothing is sent and the timeline says Alert Sent. See
+           * notOptOutRuleQuery above for the full consequence.
+           */
+          isOptOut: notOptOutRuleQuery(),
         },
         skip: 0,
         limit: LIMIT_PER_PROJECT,
@@ -253,6 +364,9 @@ export class Service extends DatabaseService<Model> {
         },
         select: {
           alertSeverityId: true,
+          alertSeverity: {
+            name: true,
+          },
         },
       });
 
@@ -262,6 +376,8 @@ export class Service extends DatabaseService<Model> {
           projectId: createdItem.projectId!,
           ruleType: notificationRuleType,
           alertSeverityId: alert?.alertSeverityId as ObjectID,
+          // Opt-out rows are not rules. See notOptOutRuleQuery above.
+          isOptOut: notOptOutRuleQuery(),
         },
         skip: 0,
         limit: LIMIT_PER_PROJECT,
@@ -280,6 +396,9 @@ export class Service extends DatabaseService<Model> {
         },
         select: {
           alertSeverityId: true,
+          alertSeverity: {
+            name: true,
+          },
         },
       });
 
@@ -289,6 +408,8 @@ export class Service extends DatabaseService<Model> {
           projectId: createdItem.projectId!,
           ruleType: notificationRuleType,
           alertSeverityId: alertEpisode?.alertSeverityId as ObjectID,
+          // Opt-out rows are not rules. See notOptOutRuleQuery above.
+          isOptOut: notOptOutRuleQuery(),
         },
         skip: 0,
         limit: LIMIT_PER_PROJECT,
@@ -308,6 +429,9 @@ export class Service extends DatabaseService<Model> {
         },
         select: {
           incidentSeverityId: true,
+          incidentSeverity: {
+            name: true,
+          },
         },
       });
 
@@ -317,6 +441,8 @@ export class Service extends DatabaseService<Model> {
           projectId: createdItem.projectId!,
           ruleType: notificationRuleType,
           incidentSeverityId: incidentEpisode?.incidentSeverityId as ObjectID,
+          // Opt-out rows are not rules. See notOptOutRuleQuery above.
+          isOptOut: notOptOutRuleQuery(),
         },
         skip: 0,
         limit: LIMIT_PER_PROJECT,
@@ -326,40 +452,15 @@ export class Service extends DatabaseService<Model> {
       });
     }
 
-    if (ruleCount.toNumber() === 0) {
-      // update this item to be processed.
-      await this.updateOneById({
-        id: createdItem.id!,
-        data: {
-          status: UserNotificationExecutionStatus.Error, // now the worker will pick this up and complete this or mark this as failed.
-          statusMessage:
-            "No notification rules found for this user. User should add the rules in User Settings > On-Call Rules.",
-        },
-        props: {
-          isRoot: true,
-        },
-      });
-
-      // update oncall timeline item as well.
-      await OnCallDutyPolicyExecutionLogTimelineService.updateOneById({
-        id: createdItem.onCallDutyPolicyExecutionLogTimelineId!,
-        data: {
-          status: OnCallDutyExecutionLogTimelineStatus.Error,
-          statusMessage:
-            "No notification rules found for this user. User should add the rules in User Settings > On-Call Rules.",
-        },
-        props: {
-          isRoot: true,
-        },
-      });
-
-      return createdItem;
-    }
-
     /*
-     * find immediate notification rule and alert the user.
      * Determine the alertSeverityId - can come from alert or alertEpisode
      * Determine the incidentSeverityId - can come from incident or incidentEpisode
+     *
+     * Resolved here, above the zero-rule branch, because BOTH paths need the
+     * same answer: the immediate-rule lookup below queries on it, and the
+     * no-rule handling has to look for an opt-out row against exactly the same
+     * (ruleType x severity) cell the count just came up empty for. Resolving it
+     * twice would be an invitation for the two to drift apart.
      */
     const alertSeverityIdForQuery: ObjectID | undefined =
       alert && alert.alertSeverityId
@@ -375,6 +476,33 @@ export class Service extends DatabaseService<Model> {
           ? (incidentEpisode.incidentSeverityId as ObjectID)
           : undefined;
 
+    /*
+     * Purely for prose. Every no-rule message names the severity, and an
+     * operator reading "no rule configured for Sev4" learns something that "no
+     * rule configured for 8f2c-..." does not. A parent entity whose severity row
+     * was deleted, or a mocked read that never selected the relation, leaves
+     * this blank, so there is a neutral phrase to fall back on.
+     */
+    const severityNameForMessage: string =
+      incident?.incidentSeverity?.name ||
+      incidentEpisode?.incidentSeverity?.name ||
+      alert?.alertSeverity?.name ||
+      alertEpisode?.alertSeverity?.name ||
+      "this severity";
+
+    if (ruleCount.toNumber() === 0) {
+      await this.handleNoMatchingNotificationRule({
+        createdItem: createdItem,
+        notificationRuleType: notificationRuleType,
+        incidentSeverityId: incidentSeverityIdForQuery,
+        alertSeverityId: alertSeverityIdForQuery,
+        severityName: severityNameForMessage,
+      });
+
+      return createdItem;
+    }
+
+    // find immediate notification rule and alert the user.
     const immediateNotificationRule: Array<UserNotificationRule> =
       await UserNotificationRuleService.findBy({
         query: {
@@ -384,6 +512,14 @@ export class Service extends DatabaseService<Model> {
           ruleType: notificationRuleType,
           incidentSeverityId: incidentSeverityIdForQuery,
           alertSeverityId: alertSeverityIdForQuery,
+          /*
+           * The predicate matters most here. An opt-out row has
+           * notifyAfterMinutes 0 like any immediate rule, so without it this
+           * lookup returns the row that exists to send nothing, hands it to
+           * executeNotificationRuleItem, and the unconditional "Alert Sent"
+           * write below then reports a page that was never dispatched.
+           */
+          isOptOut: notOptOutRuleQuery(),
         },
         select: {
           _id: true,
@@ -444,6 +580,383 @@ export class Service extends DatabaseService<Model> {
     });
 
     return createdItem;
+  }
+
+  /**
+   * Nothing matched (ruleType x severity) for this responder.
+   *
+   * That state used to be treated as a single thing - "misconfigured" - and
+   * written off with an Error row nobody reads while the escalation timer ran
+   * down as though the responder had simply declined to acknowledge. It is
+   * actually three different situations wearing the same clothes, and telling
+   * them apart is the whole of Phase 1:
+   *
+   *   1. The responder said, out loud, "do not page me for this". That is an
+   *      opt-out row: same ruleType, same severity, isOptOut true, no method.
+   *      It is checked FIRST, before the project setting and before any
+   *      delivery, and it ends the execution successfully - deliberate silence
+   *      is not a failure.
+   *   2. The project asked for the old behaviour wholesale, via
+   *      disableOnCallNotificationFallback. It gets the old behaviour exactly:
+   *      the same status, the same terminal Error, the same sentence.
+   *   3. Everything else - overwhelmingly a severity created after the
+   *      responder joined, or an episode rule type they never opened the page
+   *      for. Somebody is expecting this page to arrive, so it is delivered on
+   *      whatever verified method the responder does have.
+   *
+   * Note what "notified" can and cannot mean here. Every send downstream is
+   * fire-and-forget with a .catch that flips its own timeline row, so nothing
+   * on this path can observe whether a phone actually rang. `notified` means "a
+   * delivery was dispatched on at least one channel", and the per-channel
+   * timeline rows remain the record of what happened after that.
+   *
+   * Case 3 then splits again on WHY a fallback did not deliver, because the
+   * status this method writes is the difference between a log that is finished
+   * and a log that is merely unlucky - see the branch below. And every case 3
+   * ending, delivered or not, is reported to the humans who can fix the
+   * configuration through OnCallNotificationAlertingService; cases 1 and 2
+   * return before that, because neither is a surprise to anybody.
+   */
+  private async handleNoMatchingNotificationRule(data: {
+    createdItem: Model;
+    notificationRuleType: NotificationRuleType;
+    incidentSeverityId: ObjectID | undefined;
+    alertSeverityId: ObjectID | undefined;
+    severityName: string;
+  }): Promise<void> {
+    const createdItem: Model = data.createdItem;
+
+    const optOutRule: UserNotificationRule | null =
+      await UserNotificationRuleService.findOneBy({
+        query: {
+          userId: createdItem.userId!,
+          projectId: createdItem.projectId!,
+          ruleType: data.notificationRuleType,
+          incidentSeverityId: data.incidentSeverityId,
+          alertSeverityId: data.alertSeverityId,
+          isOptOut: true,
+        },
+        select: {
+          _id: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+    if (optOutRule) {
+      const optOutMessage: string = `You have opted out of notifications for ${
+        data.severityName
+      } ${this.getRuleTypeLabelForMessage(data.notificationRuleType)}.`;
+
+      /*
+       * Completed, not Error: the system did exactly what it was told to do.
+       * The timeline says Skipped rather than Notification Sent because nothing
+       * was in fact sent, and an operator scanning the escalation needs to see
+       * the difference between "muted on purpose" and "delivered".
+       */
+      await this.writeNoRuleOutcome({
+        createdItem: createdItem,
+        status: UserNotificationExecutionStatus.Completed,
+        timelineStatus: OnCallDutyExecutionLogTimelineStatus.Skipped,
+        statusMessage: optOutMessage,
+      });
+
+      return;
+    }
+
+    const project: Project | null = await ProjectService.findOneById({
+      id: createdItem.projectId!,
+      select: {
+        disableOnCallNotificationFallback: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (project?.disableOnCallNotificationFallback) {
+      await this.writeNoRuleOutcome({
+        createdItem: createdItem,
+        status: UserNotificationExecutionStatus.Error,
+        timelineStatus: OnCallDutyExecutionLogTimelineStatus.Error,
+        statusMessage: NO_NOTIFICATION_RULES_STATUS_MESSAGE,
+      });
+
+      /*
+       * Alert the humans BEFORE returning. A project that has turned the
+       * fallback off is not a project with nothing to report - it is the one
+       * population still losing pages exactly the way they were lost before any
+       * of this existed, because it has explicitly opted back into the old
+       * dead-end. Returning early here would have made the owner notification
+       * reach every project except the one that needs it most.
+       */
+      this.alertOfUndeliverablePage({
+        createdItem: createdItem,
+        notificationRuleType: data.notificationRuleType,
+        severityName: data.severityName,
+        fallbackChannelsUsed: [],
+      });
+
+      return;
+    }
+
+    let fallbackResult: FallbackNotificationResult | null = null;
+    let fallbackThrew: boolean = false;
+
+    try {
+      fallbackResult =
+        await UserNotificationRuleService.executeFallbackNotification({
+          userId: createdItem.userId!,
+          projectId: createdItem.projectId!,
+          userOnCallLogId: createdItem.id!,
+          ruleType: data.notificationRuleType,
+          severityName: data.severityName,
+          userNotificationLogId: createdItem.id!,
+          triggeredByIncidentId: createdItem.triggeredByIncidentId,
+          triggeredByAlertId: createdItem.triggeredByAlertId,
+          triggeredByAlertEpisodeId: createdItem.triggeredByAlertEpisodeId,
+          triggeredByIncidentEpisodeId:
+            createdItem.triggeredByIncidentEpisodeId,
+          userNotificationEventType: createdItem.userNotificationEventType!,
+          onCallPolicyExecutionLogId:
+            createdItem.onCallDutyPolicyExecutionLogId,
+          onCallPolicyId: createdItem.onCallDutyPolicyId,
+          onCallPolicyEscalationRuleId:
+            createdItem.onCallDutyPolicyEscalationRuleId,
+          userBelongsToTeamId: createdItem.userBelongsToTeamId,
+          onCallDutyPolicyExecutionLogTimelineId:
+            createdItem.onCallDutyPolicyExecutionLogTimelineId,
+          onCallScheduleId: createdItem.onCallDutyScheduleId,
+        });
+    } catch (err) {
+      /*
+       * The caller is part-way through paging an entire escalation level. A
+       * throw out of here would abort the responders queued behind this one, so
+       * a fallback that fails is recorded against THIS log and no further.
+       */
+      fallbackThrew = true;
+      logger.error(
+        `On-call notification fallback failed for UserOnCallLog ${createdItem.id?.toString()}`,
+      );
+      logger.error(err);
+    }
+
+    if (fallbackResult && fallbackResult.notified) {
+      const notifiedMessage: string = `No notification rule configured for ${
+        data.severityName
+      }; notified via fallback (${fallbackResult.channelsUsed.join(", ")}).`;
+
+      /*
+       * Executing, matching the normal path: there are no further rules to fire,
+       * so UserOnCallLog:ExecutePendingExecutions will find an empty rule list on
+       * its next tick and close the log out as Completed.
+       */
+      await this.writeNoRuleOutcome({
+        createdItem: createdItem,
+        status: UserNotificationExecutionStatus.Executing,
+        timelineStatus: OnCallDutyExecutionLogTimelineStatus.NotificationSent,
+        statusMessage: notifiedMessage,
+      });
+    } else {
+      const responderLabel: string = await this.getResponderLabelForMessage(
+        createdItem.userId,
+      );
+
+      /*
+       * Nothing was delivered, and every reason for that ends the same way:
+       * terminally, saying so.
+       *
+       * The tempting alternative is to treat a raised delivery attempt as
+       * transient and leave the log Executing for a retry, mirroring
+       * App/FeatureSet/Workers/Jobs/UserOnCallLog/ExecutePendingExecutions,
+       * which deliberately marks Error only for permanent bad-data failures.
+       * That analogy does not hold here, and following it produces a worse bug
+       * than the one it avoids.
+       *
+       * ExecutePendingExecutions re-enters ITSELF: it selects logs in Executing
+       * every minute and re-fires their still-due rules, so a log left live
+       * genuinely gets another attempt. This function does not. It is called
+       * from onCreateSuccess, once, at the moment the log row is written, and
+       * nothing re-enters it - so "leave it Executing for the next tick" buys
+       * no retry at all. What it actually buys is this: on the next tick
+       * ExecutePendingExecutions picks the log up, queries for due rules, finds
+       * none (there were none to begin with - that is why we are here), takes
+       * its all-executed path and marks the log Completed. onUpdateSuccess then
+       * translates Completed into NotificationSent on the escalation timeline,
+       * and within a minute the record reads "Alert Sent" for a page that was
+       * never delivered.
+       *
+       * That is precisely the silent lie the opt-out exclusion was fixed to
+       * remove, reintroduced through a different door. So both endings are
+       * terminal, and only the message differs: a responder with no verified
+       * method needs a different action than a delivery that blew up, and
+       * whoever reads the log deserves to be told which happened.
+       */
+      const isPermanentlyUndeliverable: boolean =
+        !fallbackThrew &&
+        fallbackResult !== null &&
+        fallbackResult.outcome ===
+          FallbackNotificationOutcome.NoUsableNotificationMethod;
+
+      await this.writeNoRuleOutcome({
+        createdItem: createdItem,
+        status: UserNotificationExecutionStatus.Error,
+        timelineStatus: OnCallDutyExecutionLogTimelineStatus.Error,
+        statusMessage: isPermanentlyUndeliverable
+          ? `${responderLabel} has no verified notification method, so this page could not be delivered. Ask them to add one in User Settings > Notification Methods.`
+          : `${responderLabel} has no notification rule for ${data.severityName} and the fallback delivery attempt failed, so this page was not delivered. Check the worker logs, then add a rule in User Settings > On-Call Rules.`,
+      });
+    }
+
+    /*
+     * Section 5: tell the humans who can fix this. The policy's owners own the
+     * configuration that is wrong; the responder owns the rules that are
+     * missing. Neither of them is reading execution logs.
+     *
+     * One call site rather than one per branch, because every path that reaches
+     * here is worth reporting and the difference between them is already
+     * carried by fallbackChannelsUsed: a non-empty list means "your
+     * configuration is wrong but nobody was dropped", an empty one means this
+     * responder was not reached at all - which is equally true of the
+     * no-verified-method ending and of the attempt that raised. The service
+     * throttles per (project, user, ruleType) per 24h, so a page storm down this
+     * branch cannot become a mail storm.
+     *
+     * Fire-and-forget with a .catch, exactly as
+     * startUserNotificationRulesExecution treats its workspace rules:
+     * notifyOfUndeliverablePage already swallows its own failures, and the
+     * .catch is the guarantee that even a bug in the explanation can never
+     * propagate into - or delay - the paging path that called it.
+     */
+    this.alertOfUndeliverablePage({
+      createdItem: createdItem,
+      notificationRuleType: data.notificationRuleType,
+      severityName: data.severityName,
+      fallbackChannelsUsed: fallbackResult ? fallbackResult.channelsUsed : [],
+    });
+  }
+
+  /*
+   * Fire-and-forget, exactly as startUserNotificationRulesExecution treats its
+   * workspace rules: notifyOfUndeliverablePage already swallows its own
+   * failures, and the .catch is the guarantee that even a bug in the
+   * explanation can never propagate into - or delay - the paging path that
+   * called it. Extracted to a helper because there are two callers now, and a
+   * second inline copy is how one of them ends up silently drifting from the
+   * other.
+   */
+  private alertOfUndeliverablePage(data: {
+    createdItem: Model;
+    notificationRuleType: NotificationRuleType;
+    severityName: string;
+    fallbackChannelsUsed: Array<string>;
+  }): void {
+    OnCallNotificationAlertingService.notifyOfUndeliverablePage({
+      projectId: data.createdItem.projectId!,
+      userId: data.createdItem.userId!,
+      ruleType: data.notificationRuleType,
+      severityName: data.severityName,
+      onCallDutyPolicyId: data.createdItem.onCallDutyPolicyId,
+      fallbackChannelsUsed: data.fallbackChannelsUsed,
+    }).catch((err: Error) => {
+      logger.error(err);
+    });
+  }
+
+  /*
+   * Both writes the no-rule path makes, in the order the pre-fallback code made
+   * them: the log first, then the on-call timeline. The log update's own
+   * onUpdateSuccess hook already maps the execution status onto the timeline, so
+   * the explicit second write is what lets this path say something the mapping
+   * cannot - Skipped for an opt-out, Notification Sent for a fallback that went
+   * out under an Executing log.
+   */
+  private async writeNoRuleOutcome(data: {
+    createdItem: Model;
+    status: UserNotificationExecutionStatus;
+    timelineStatus: OnCallDutyExecutionLogTimelineStatus;
+    statusMessage: string;
+  }): Promise<void> {
+    await this.updateOneById({
+      id: data.createdItem.id!,
+      data: {
+        status: data.status,
+        statusMessage: data.statusMessage,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+    await OnCallDutyPolicyExecutionLogTimelineService.updateOneById({
+      id: data.createdItem.onCallDutyPolicyExecutionLogTimelineId!,
+      data: {
+        status: data.timelineStatus,
+        statusMessage: data.statusMessage,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+  }
+
+  /*
+   * NotificationRuleType's values are whole sentences ("When incident on-call
+   * policy is executed"), which read badly mid-sentence. These are the noun
+   * forms for the messages this file writes. An unrecognised type falls back to
+   * the raw value rather than throwing - a status message is never worth losing
+   * a page over.
+   */
+  private getRuleTypeLabelForMessage(ruleType: NotificationRuleType): string {
+    switch (ruleType) {
+      case NotificationRuleType.ON_CALL_EXECUTED_INCIDENT:
+        return "incidents";
+      case NotificationRuleType.ON_CALL_EXECUTED_ALERT:
+        return "alerts";
+      case NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE:
+        return "incident episodes";
+      case NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE:
+        return "alert episodes";
+      default:
+        return ruleType;
+    }
+  }
+
+  /*
+   * "Jane Doe has no verified notification method" is actionable; "This user
+   * has no verified notification method" is a support ticket. The lookup is
+   * best-effort in every sense - it only feeds a string, so a missing user or a
+   * failed read degrades to a neutral phrase rather than propagating.
+   */
+  private async getResponderLabelForMessage(
+    userId: ObjectID | undefined,
+  ): Promise<string> {
+    if (!userId) {
+      return "This responder";
+    }
+
+    try {
+      const user: User | null = await UserService.findOneById({
+        id: userId,
+        select: {
+          name: true,
+          email: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      const label: string | undefined =
+        user?.name?.toString() || user?.email?.toString();
+
+      return label || "This responder";
+    } catch (err) {
+      logger.error(err);
+
+      return "This responder";
+    }
   }
 
   public getNotificationRuleType(

--- a/Common/Tests/Server/Services/DeliverNotificationForRuleExtraction.test.ts
+++ b/Common/Tests/Server/Services/DeliverNotificationForRuleExtraction.test.ts
@@ -1,0 +1,1354 @@
+import UserNotificationRuleService from "../../../Server/Services/UserNotificationRuleService";
+import UserOnCallLogService from "../../../Server/Services/UserOnCallLogService";
+import UserOnCallLogTimelineService from "../../../Server/Services/UserOnCallLogTimelineService";
+import ProjectCallSMSConfigService from "../../../Server/Services/ProjectCallSMSConfigService";
+import IncidentService from "../../../Server/Services/IncidentService";
+import AlertService from "../../../Server/Services/AlertService";
+import AlertEpisodeService from "../../../Server/Services/AlertEpisodeService";
+import IncidentEpisodeService from "../../../Server/Services/IncidentEpisodeService";
+import MailService from "../../../Server/Services/MailService";
+import SmsService from "../../../Server/Services/SmsService";
+import CallService from "../../../Server/Services/CallService";
+import WhatsAppService from "../../../Server/Services/WhatsAppService";
+import TelegramService from "../../../Server/Services/TelegramService";
+import WebhookService from "../../../Server/Services/WebhookService";
+import PushNotificationService from "../../../Server/Services/PushNotificationService";
+import logger from "../../../Server/Utils/Logger";
+import Incident from "../../../Models/DatabaseModels/Incident";
+import UserOnCallLogTimeline from "../../../Models/DatabaseModels/UserOnCallLogTimeline";
+import UserNotificationRule from "../../../Models/DatabaseModels/UserNotificationRule";
+import UserEmail from "../../../Models/DatabaseModels/UserEmail";
+import UserPush from "../../../Models/DatabaseModels/UserPush";
+import UserSMS from "../../../Models/DatabaseModels/UserSMS";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import Email from "../../../Types/Email";
+import Phone from "../../../Types/Phone";
+import ObjectID from "../../../Types/ObjectID";
+import URL from "../../../Types/API/URL";
+import { JSONObject } from "../../../Types/JSON";
+import EmailMessage from "../../../Types/Email/EmailMessage";
+import SMS from "../../../Types/SMS/SMS";
+import TwilioConfig from "../../../Types/CallAndSMS/TwilioConfig";
+import NotificationRuleType from "../../../Types/NotificationRule/NotificationRuleType";
+import PushDeviceType from "../../../Types/PushNotification/PushDeviceType";
+import UserNotificationEventType from "../../../Types/UserNotification/UserNotificationEventType";
+import UserNotificationStatus from "../../../Types/UserNotification/UserNotificationStatus";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+
+/*
+ * Phase 1 §2.1 split `executeNotificationRuleItem` in two. The public method
+ * kept its signature and now does only what a rule ID implies — claim the
+ * on-call log, load the rule, hand both to the delivery half — and everything
+ * from the Twilio-config lookup downwards moved into a private
+ * `deliverNotificationForRule(rule, options)`.
+ *
+ * The extraction exists so the on-call FALLBACK can reuse the delivery half
+ * with a UserNotificationRule it assembled in memory and never saved: there is
+ * no rule row to claim and no id to look up, so the first half is meaningless
+ * to it while the second half is exactly what it needs. That makes the SEAM
+ * between the two halves — not the seven channel blocks, which
+ * NotificationChannelEventCoverage.test.ts owns — the thing worth pinning, and
+ * this file pins five properties of it:
+ *
+ *   1. THE CLAIM IS STILL FIRST. The atomic claim (audit F7) is what stops two
+ *      overlapping cron ticks double-paging one responder. A refactor that let
+ *      the rule load drift above it, or that read `false` as "carry on", brings
+ *      duplicate pages straight back — so a lost claim is asserted to stop the
+ *      method before `findOneById` is even called, not merely before the send.
+ *
+ *   2. A MISSING RULE STILL THROWS. `BadDataException("Notification rule item
+ *      not found.")` is what ExecutePendingExecutions turns into an `Error`
+ *      log. Swallowing it during the split would leave the log stuck Executing
+ *      forever.
+ *
+ *   3. THE SELECT SURVIVED INTACT. Every channel gate reads
+ *      `<method>?.isVerified`, and an unselected column arrives as `undefined`.
+ *      Dropping `isVerified` from this select therefore does NOT page
+ *      unverified methods — it silences every VERIFIED one and writes "not
+ *      verified" rows about perfectly verified phones. `userWebhook`'s
+ *      `webhookUrl`/`name`/`secret` matter for the opposite reason: `secret`
+ *      signs the outgoing request. The shape is asserted field by field.
+ *
+ *   4. THE RULE CROSSES THE SEAM UNCHANGED. The object `findOneById` returned
+ *      and the caller's own options bag are handed to the delivery half by
+ *      reference — no copy, no reshaping, nothing dropped on the way.
+ *
+ *   5. THE DELIVERY HALF STANDS ALONE. It can be driven directly with an
+ *      UNSAVED, id-less rule and still writes a timeline row and dispatches.
+ *      This is the regression guard for blocker B1: while
+ *      `UserOnCallLogTimeline.userNotificationRuleId` was NOT NULL, every
+ *      fallback delivery threw at the first `create()` — before a single page
+ *      left the process — because an unsaved rule has no id to put there.
+ *
+ * Plus the one value the split had to keep hoisted: `projectTwilioConfig` is
+ * resolved ONCE, inside the delivery half, from `options.projectId`, and handed
+ * to the paid senders. Resolving it per channel would multiply a project-config
+ * read by the number of channels; resolving it in the public half would leave
+ * the fallback sending on the GLOBAL Twilio account.
+ *
+ * No database is touched. Every sender, every template generator and every
+ * persistence call is a `jest.spyOn` stub, and the private delivery half is
+ * reached through a cast, exactly as the neighbouring characterisation tests
+ * reach protected hooks.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const RULE_ID: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+const LOG_ID: ObjectID = new ObjectID("33333333-3333-4333-8333-333333333333");
+const USER_ID: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+const INCIDENT_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+const TEAM_ID: ObjectID = new ObjectID("66666666-6666-4666-8666-666666666666");
+const POLICY_ID: ObjectID = new ObjectID(
+  "77777777-7777-4777-8777-777777777777",
+);
+const ESCALATION_RULE_ID: ObjectID = new ObjectID(
+  "88888888-8888-4888-8888-888888888888",
+);
+const EXECUTION_LOG_TIMELINE_ID: ObjectID = new ObjectID(
+  "99999999-9999-4999-8999-999999999999",
+);
+const TIMELINE_ID: ObjectID = new ObjectID(
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+const EMAIL_METHOD_ID: ObjectID = new ObjectID(
+  "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+);
+const SMS_METHOD_ID: ObjectID = new ObjectID(
+  "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+);
+const PUSH_METHOD_ID: ObjectID = new ObjectID(
+  "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+);
+
+const RESPONDER_EMAIL: string = "responder@company.com";
+const RESPONDER_PHONE: string = "+11234567890";
+
+/* The options bag both halves share, taken from the public signature. */
+type ExecuteOptions = Parameters<
+  typeof UserNotificationRuleService.executeNotificationRuleItem
+>[1];
+
+/* The `select` / `props` bundle handed to findOneById. */
+interface FindOneByIdArg {
+  id: ObjectID;
+  select: JSONObject;
+  props: { isRoot: boolean };
+}
+
+/*
+ * `deliverNotificationForRule` is private, so TypeScript will not let a test
+ * name it on the service. It is a perfectly ordinary prototype method at
+ * runtime, and the fallback's whole design rests on it being callable with a
+ * rule that was never persisted — so it is reached here through a structural
+ * cast, the same trick the neighbouring files use for protected hooks.
+ *
+ * It returns whether a page was actually handed to a sender. That boolean is
+ * NOT decoration: executeFallbackNotification reads it to decide which channel
+ * names to tell the operator the responder was reached on.
+ */
+interface DeliveryHalf {
+  deliverNotificationForRule: (
+    notificationRuleItem: UserNotificationRule,
+    options: ExecuteOptions,
+  ) => Promise<boolean>;
+}
+
+function deliveryHalf(): DeliveryHalf {
+  return UserNotificationRuleService as unknown as DeliveryHalf;
+}
+
+/*
+ * The service mutates ONE UserOnCallLogTimeline instance per delivery call and
+ * hands that same instance to create(), so mock.calls all alias its final
+ * state. Snapshot the fields at call time instead; the raw instances are kept
+ * separately, because "did two delivery calls build two distinct rows" is a
+ * question only identity can answer.
+ */
+interface TimelineRow {
+  status: UserNotificationStatus | undefined;
+  statusMessage: string | undefined;
+  userId: ObjectID | undefined;
+  userNotificationRuleId: ObjectID | undefined;
+  userNotificationLogId: ObjectID | undefined;
+  projectId: ObjectID | undefined;
+  userNotificationEventType: UserNotificationEventType | undefined;
+  userEmailId: ObjectID | undefined;
+  userSmsId: ObjectID | undefined;
+  userPushId: ObjectID | undefined;
+  triggeredByIncidentId: ObjectID | undefined;
+  onCallDutyPolicyId: ObjectID | undefined;
+  onCallDutyPolicyEscalationRuleId: ObjectID | undefined;
+  userBelongsToTeamId: ObjectID | undefined;
+}
+
+function executeOptions(
+  overrides: Partial<ExecuteOptions> = {},
+): ExecuteOptions {
+  return {
+    projectId: PROJECT_ID,
+    userNotificationEventType: UserNotificationEventType.IncidentCreated,
+    triggeredByIncidentId: INCIDENT_ID,
+    onCallPolicyId: POLICY_ID,
+    onCallPolicyEscalationRuleId: ESCALATION_RULE_ID,
+    userBelongsToTeamId: TEAM_ID,
+    onCallDutyPolicyExecutionLogTimelineId: EXECUTION_LOG_TIMELINE_ID,
+    userNotificationLogId: LOG_ID,
+    ...overrides,
+  };
+}
+
+/*
+ * A rule as findOneById hands it back: hydrated, and carrying the `_id` of the
+ * row it was read from.
+ */
+function loadedRule(channels: JSONObject = {}): UserNotificationRule {
+  return {
+    id: RULE_ID,
+    _id: RULE_ID.toString(),
+    userId: USER_ID,
+    ...channels,
+  } as unknown as UserNotificationRule;
+}
+
+/*
+ * A rule as the FALLBACK builds it: a real model instance with no `_id`, so
+ * `.id` is genuinely null, assembled from the user's verified methods and
+ * never saved. Real model classes are used rather than object literals
+ * precisely because `id` is a getter over `_id` — a literal would fake the one
+ * property this half of the file is about.
+ */
+function unsavedFallbackRule(): UserNotificationRule {
+  const rule: UserNotificationRule = new UserNotificationRule();
+  rule.projectId = PROJECT_ID;
+  rule.userId = USER_ID;
+  rule.ruleType = NotificationRuleType.ON_CALL_EXECUTED_INCIDENT;
+  rule.notifyAfterMinutes = 0;
+
+  return rule;
+}
+
+function verifiedUserEmail(): UserEmail {
+  const userEmail: UserEmail = new UserEmail();
+  userEmail._id = EMAIL_METHOD_ID.toString();
+  userEmail.email = new Email(RESPONDER_EMAIL);
+  userEmail.isVerified = true;
+
+  return userEmail;
+}
+
+function verifiedUserSms(): UserSMS {
+  const userSms: UserSMS = new UserSMS();
+  userSms._id = SMS_METHOD_ID.toString();
+  userSms.phone = new Phone(RESPONDER_PHONE);
+  userSms.isVerified = true;
+
+  return userSms;
+}
+
+function verifiedUserPush(): UserPush {
+  const userPush: UserPush = new UserPush();
+  userPush._id = PUSH_METHOD_ID.toString();
+  userPush.deviceToken = "device-token";
+  userPush.deviceType = PushDeviceType.iOS;
+  userPush.isVerified = true;
+
+  return userPush;
+}
+
+function fakeIncident(): Incident {
+  return {
+    id: INCIDENT_ID,
+    projectId: PROJECT_ID,
+    title: "Checkout is down",
+    description: "Checkout returns 500 for every request.",
+    incidentNumber: 42,
+    incidentNumberWithPrefix: "INC-42",
+  } as unknown as Incident;
+}
+
+function fakeTwilioConfig(): TwilioConfig {
+  return {
+    accountSid: "AC-project-account",
+    authToken: "project-auth-token",
+    primaryPhoneNumber: new Phone("+15550001111"),
+    secondaryPhoneNumbers: [],
+  };
+}
+
+/* Every stub the two halves touch, so no test can reach a real service. */
+interface Spies {
+  claim: jest.SpyInstance;
+  findRule: jest.SpyInstance;
+  createRule: jest.SpyInstance;
+  twilio: jest.SpyInstance;
+  timelineCreate: jest.SpyInstance;
+  timelineUpdate: jest.SpyInstance;
+  incidentFind: jest.SpyInstance;
+  incidentLink: jest.SpyInstance;
+  alertFind: jest.SpyInstance;
+  alertEpisodeFind: jest.SpyInstance;
+  incidentEpisodeFind: jest.SpyInstance;
+  mail: jest.SpyInstance;
+  sms: jest.SpyInstance;
+  call: jest.SpyInstance;
+  whatsApp: jest.SpyInstance;
+  telegram: jest.SpyInstance;
+  webhook: jest.SpyInstance;
+  push: jest.SpyInstance;
+  emailTemplate: jest.SpyInstance;
+  smsTemplate: jest.SpyInstance;
+}
+
+describe("UserNotificationRuleService - the deliverNotificationForRule extraction", () => {
+  let spies: Spies;
+  let timelineRows: Array<TimelineRow>;
+  let timelineInstances: Array<UserOnCallLogTimeline>;
+
+  beforeEach(() => {
+    timelineRows = [];
+    timelineInstances = [];
+
+    jest.spyOn(logger, "error").mockImplementation((): void => {
+      return undefined;
+    });
+    jest.spyOn(logger, "warn").mockImplementation((): void => {
+      return undefined;
+    });
+
+    const timelineCreate: jest.SpyInstance = jest.spyOn(
+      UserOnCallLogTimelineService,
+      "create",
+    );
+    timelineCreate.mockImplementation(
+      (createBy: unknown): Promise<UserOnCallLogTimeline> => {
+        const data: UserOnCallLogTimeline = (
+          createBy as { data: UserOnCallLogTimeline }
+        ).data;
+
+        timelineInstances.push(data);
+        timelineRows.push({
+          status: data.status,
+          statusMessage: data.statusMessage,
+          userId: data.userId,
+          userNotificationRuleId: data.userNotificationRuleId,
+          userNotificationLogId: data.userNotificationLogId,
+          projectId: data.projectId,
+          userNotificationEventType: data.userNotificationEventType,
+          userEmailId: data.userEmailId,
+          userSmsId: data.userSmsId,
+          userPushId: data.userPushId,
+          triggeredByIncidentId: data.triggeredByIncidentId,
+          onCallDutyPolicyId: data.onCallDutyPolicyId,
+          onCallDutyPolicyEscalationRuleId:
+            data.onCallDutyPolicyEscalationRuleId,
+          userBelongsToTeamId: data.userBelongsToTeamId,
+        });
+
+        return Promise.resolve({
+          id: TIMELINE_ID,
+        } as unknown as UserOnCallLogTimeline);
+      },
+    );
+
+    spies = {
+      claim: jest
+        .spyOn(UserOnCallLogService, "claimNotificationRuleExecution")
+        .mockResolvedValue(true as never),
+      findRule: jest
+        .spyOn(UserNotificationRuleService, "findOneById")
+        .mockResolvedValue(loadedRule() as never),
+      createRule: jest
+        .spyOn(UserNotificationRuleService, "create")
+        .mockResolvedValue(loadedRule() as never),
+      twilio: jest
+        .spyOn(ProjectCallSMSConfigService, "getProjectDefaultTwilioConfig")
+        .mockResolvedValue(undefined as never),
+      timelineCreate: timelineCreate,
+      timelineUpdate: jest
+        .spyOn(UserOnCallLogTimelineService, "updateOneById")
+        .mockResolvedValue(undefined as never),
+      incidentFind: jest
+        .spyOn(IncidentService, "findOneById")
+        .mockResolvedValue(fakeIncident() as never),
+      incidentLink: jest
+        .spyOn(IncidentService, "getIncidentLinkInDashboard")
+        .mockResolvedValue(
+          URL.fromString("https://dashboard.example.com/incident") as never,
+        ),
+      alertFind: jest
+        .spyOn(AlertService, "findOneById")
+        .mockResolvedValue(null as never),
+      alertEpisodeFind: jest
+        .spyOn(AlertEpisodeService, "findOneById")
+        .mockResolvedValue(null as never),
+      incidentEpisodeFind: jest
+        .spyOn(IncidentEpisodeService, "findOneById")
+        .mockResolvedValue(null as never),
+      mail: jest
+        .spyOn(MailService, "sendMail")
+        .mockResolvedValue(undefined as never),
+      sms: jest
+        .spyOn(SmsService, "sendSms")
+        .mockResolvedValue(undefined as never),
+      call: jest
+        .spyOn(CallService, "makeCall")
+        .mockResolvedValue(undefined as never),
+      whatsApp: jest
+        .spyOn(WhatsAppService, "sendWhatsAppMessage")
+        .mockResolvedValue(undefined as never),
+      telegram: jest
+        .spyOn(TelegramService, "sendTelegramMessage")
+        .mockResolvedValue(undefined as never),
+      webhook: jest
+        .spyOn(WebhookService, "sendWebhook")
+        .mockResolvedValue(undefined as never),
+      push: jest
+        .spyOn(PushNotificationService, "sendPushNotification")
+        .mockResolvedValue(undefined as never),
+      emailTemplate: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateEmailTemplateForIncidentCreated",
+        )
+        .mockResolvedValue({} as EmailMessage as never),
+      smsTemplate: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateSmsTemplateForIncidentCreated",
+        )
+        .mockResolvedValue({} as SMS as never),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function everySender(): Array<jest.SpyInstance> {
+    return [
+      spies.mail,
+      spies.sms,
+      spies.call,
+      spies.whatsApp,
+      spies.telegram,
+      spies.webhook,
+      spies.push,
+    ];
+  }
+
+  /*
+   * Replace the delivery half so the public half can be observed on its own.
+   * Installed per test rather than in beforeEach, because the sections below
+   * that drive the delivery half directly need the REAL implementation.
+   */
+  function stubDeliveryHalf(): jest.SpyInstance {
+    return jest
+      .spyOn(deliveryHalf(), "deliverNotificationForRule")
+      .mockResolvedValue(true as never);
+  }
+
+  /* The second argument SmsService.sendSms was handed. */
+  function sentSmsOptions(): {
+    customTwilioConfig: TwilioConfig | undefined;
+  } {
+    return spies.sms.mock.calls[0]![1] as {
+      customTwilioConfig: TwilioConfig | undefined;
+    };
+  }
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (A) The claim still runs, and still runs FIRST.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("the public half still claims before it loads anything", () => {
+    test("a lost claim returns before findOneById is called at all", async () => {
+      spies.claim.mockResolvedValue(false as never);
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      expect(spies.claim).toHaveBeenCalledTimes(1);
+      /*
+       * The point of F7. Short-circuiting merely before the SEND would still
+       * let two ticks race on the read; the gate has to be above the read.
+       */
+      expect(spies.findRule).not.toHaveBeenCalled();
+    });
+
+    test("a lost claim never reaches the delivery half", async () => {
+      const deliver: jest.SpyInstance = stubDeliveryHalf();
+      spies.claim.mockResolvedValue(false as never);
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      expect(deliver).not.toHaveBeenCalled();
+    });
+
+    test("a lost claim sends nothing and writes no timeline row", async () => {
+      spies.claim.mockResolvedValue(false as never);
+      spies.findRule.mockResolvedValue(
+        loadedRule({
+          userEmail: verifiedUserEmail(),
+        } as unknown as JSONObject) as never,
+      );
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      for (const sender of everySender()) {
+        expect(sender).not.toHaveBeenCalled();
+      }
+      expect(spies.timelineCreate).not.toHaveBeenCalled();
+      expect(spies.timelineUpdate).not.toHaveBeenCalled();
+    });
+
+    test("a lost claim skips the Twilio config and the incident lookup too", async () => {
+      spies.claim.mockResolvedValue(false as never);
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      expect(spies.twilio).not.toHaveBeenCalled();
+      expect(spies.incidentFind).not.toHaveBeenCalled();
+    });
+
+    test("a lost claim RESOLVES - it is a normal outcome, not bad data", async () => {
+      spies.claim.mockResolvedValue(false as never);
+
+      /*
+       * ExecutePendingExecutions marks a log Error on BadDataException. A
+       * duplicate suppressed by the claim is not an error, so this path must
+       * resolve quietly or every suppressed duplicate burns its on-call log.
+       */
+      await expect(
+        UserNotificationRuleService.executeNotificationRuleItem(
+          RULE_ID,
+          executeOptions(),
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    test("the claim names this on-call log and this rule", async () => {
+      spies.claim.mockResolvedValue(false as never);
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions({ userNotificationLogId: LOG_ID }),
+      );
+
+      const claimArg: {
+        userOnCallLogId: ObjectID;
+        userNotificationRuleId: ObjectID;
+      } = spies.claim.mock.calls[0]![0] as {
+        userOnCallLogId: ObjectID;
+        userNotificationRuleId: ObjectID;
+      };
+      expect(claimArg.userOnCallLogId.toString()).toBe(LOG_ID.toString());
+      expect(claimArg.userNotificationRuleId.toString()).toBe(
+        RULE_ID.toString(),
+      );
+    });
+
+    test("the claim strictly PRECEDES the rule load, which precedes the delivery half", async () => {
+      const deliver: jest.SpyInstance = stubDeliveryHalf();
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      expect(spies.claim.mock.invocationCallOrder[0]).toBeLessThan(
+        spies.findRule.mock.invocationCallOrder[0] as number,
+      );
+      expect(spies.findRule.mock.invocationCallOrder[0]).toBeLessThan(
+        deliver.mock.invocationCallOrder[0] as number,
+      );
+    });
+
+    test("a claim that rejects propagates and nothing is loaded or delivered", async () => {
+      const deliver: jest.SpyInstance = stubDeliveryHalf();
+      spies.claim.mockRejectedValue(new Error("db connection reset") as never);
+
+      await expect(
+        UserNotificationRuleService.executeNotificationRuleItem(
+          RULE_ID,
+          executeOptions(),
+        ),
+      ).rejects.toThrow("db connection reset");
+
+      expect(spies.findRule).not.toHaveBeenCalled();
+      expect(deliver).not.toHaveBeenCalled();
+    });
+
+    test("a held claim lets execution proceed, and the rule is read exactly once", async () => {
+      stubDeliveryHalf();
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      expect(spies.claim).toHaveBeenCalledTimes(1);
+      expect(spies.findRule).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (B) A rule id that resolves to nothing.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("a rule id that resolves to nothing", () => {
+    test('still throws BadDataException("Notification rule item not found.")', async () => {
+      spies.findRule.mockResolvedValue(null as never);
+
+      await expect(
+        UserNotificationRuleService.executeNotificationRuleItem(
+          RULE_ID,
+          executeOptions(),
+        ),
+      ).rejects.toThrow(BadDataException);
+
+      await expect(
+        UserNotificationRuleService.executeNotificationRuleItem(
+          RULE_ID,
+          executeOptions(),
+        ),
+      ).rejects.toThrow("Notification rule item not found.");
+    });
+
+    test("the delivery half is never entered on a missing rule", async () => {
+      const deliver: jest.SpyInstance = stubDeliveryHalf();
+      spies.findRule.mockResolvedValue(null as never);
+
+      await expect(
+        UserNotificationRuleService.executeNotificationRuleItem(
+          RULE_ID,
+          executeOptions(),
+        ),
+      ).rejects.toThrow(BadDataException);
+
+      expect(deliver).not.toHaveBeenCalled();
+    });
+
+    test("the throw beats the Twilio config, the incident lookup and any timeline row", async () => {
+      spies.findRule.mockResolvedValue(null as never);
+
+      await expect(
+        UserNotificationRuleService.executeNotificationRuleItem(
+          RULE_ID,
+          executeOptions(),
+        ),
+      ).rejects.toThrow(BadDataException);
+
+      expect(spies.twilio).not.toHaveBeenCalled();
+      expect(spies.incidentFind).not.toHaveBeenCalled();
+      expect(spies.timelineCreate).not.toHaveBeenCalled();
+      for (const sender of everySender()) {
+        expect(sender).not.toHaveBeenCalled();
+      }
+    });
+
+    test("the claim has ALREADY been consumed when the rule turns out to be missing", async () => {
+      spies.findRule.mockResolvedValue(null as never);
+
+      await expect(
+        UserNotificationRuleService.executeNotificationRuleItem(
+          RULE_ID,
+          executeOptions(),
+        ),
+      ).rejects.toThrow(BadDataException);
+
+      /*
+       * Pinned as current behaviour, unchanged by the split: the claim is
+       * written before the rule is read, so a rule deleted between scheduling
+       * and execution burns its claim and no later tick retries it. Deliberate
+       * (a missing rule is permanent), but it means the claim is not released.
+       */
+      expect(spies.claim).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (C) The select the public half still passes.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("the select handed to findOneById", () => {
+    async function captureFindArg(): Promise<FindOneByIdArg> {
+      stubDeliveryHalf();
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      return spies.findRule.mock.calls[0]![0] as FindOneByIdArg;
+    }
+
+    test("targets the requested rule id, as root", async () => {
+      const arg: FindOneByIdArg = await captureFindArg();
+
+      expect(arg.id.toString()).toBe(RULE_ID.toString());
+      expect(arg.props.isRoot).toBe(true);
+    });
+
+    test("is EXACTLY this shape - a field lost in the split changes who gets paged", async () => {
+      const arg: FindOneByIdArg = await captureFindArg();
+
+      expect(arg.select).toEqual({
+        _id: true,
+        userId: true,
+        userCall: {
+          phone: true,
+          isVerified: true,
+        },
+        userSms: {
+          phone: true,
+          isVerified: true,
+        },
+        userWhatsApp: {
+          phone: true,
+          isVerified: true,
+        },
+        userTelegram: {
+          telegramChatId: true,
+          telegramUserHandle: true,
+          isVerified: true,
+        },
+        userWebhook: {
+          webhookUrl: true,
+          name: true,
+          secret: true,
+        },
+        userEmail: {
+          email: true,
+          isVerified: true,
+        },
+        userPush: {
+          deviceToken: true,
+          deviceType: true,
+          isVerified: true,
+        },
+      });
+    });
+
+    test.each<[string]>([
+      ["userCall"],
+      ["userSms"],
+      ["userWhatsApp"],
+      ["userTelegram"],
+      ["userEmail"],
+      ["userPush"],
+    ])(
+      "%s requests isVerified - every user-contactable channel is verification-gated",
+      async (channel: string) => {
+        const arg: FindOneByIdArg = await captureFindArg();
+        const selected: JSONObject = arg.select[channel] as JSONObject;
+
+        expect(selected).toBeDefined();
+        expect(selected["isVerified"]).toBe(true);
+      },
+    );
+
+    test.each<[string, string]>([
+      ["userCall", "phone"],
+      ["userSms", "phone"],
+      ["userWhatsApp", "phone"],
+      ["userTelegram", "telegramChatId"],
+      ["userEmail", "email"],
+      ["userPush", "deviceToken"],
+    ])(
+      "%s also requests its address column (%s), which the send gate reads alongside isVerified",
+      async (channel: string, addressColumn: string) => {
+        const arg: FindOneByIdArg = await captureFindArg();
+        const selected: JSONObject = arg.select[channel] as JSONObject;
+
+        expect(selected[addressColumn]).toBe(true);
+      },
+    );
+
+    test("userWebhook requests webhookUrl, name and secret - and no isVerified", async () => {
+      const arg: FindOneByIdArg = await captureFindArg();
+      const webhookSelect: JSONObject = arg.select["userWebhook"] as JSONObject;
+
+      /*
+       * Webhooks are the one user-contactable channel with no verification
+       * concept at all (UserWebhook has no isVerified column), so the delivery
+       * gate is `webhookUrl` alone. `secret` is not cosmetic: it signs the
+       * outgoing request, so an unselected secret ships UNSIGNED webhooks.
+       */
+      expect(webhookSelect).toEqual({
+        webhookUrl: true,
+        name: true,
+        secret: true,
+      });
+      expect(webhookSelect["isVerified"]).toBeUndefined();
+    });
+
+    test("userId is selected - the timeline row and every sender stamp it", async () => {
+      const arg: FindOneByIdArg = await captureFindArg();
+
+      expect(arg.select["userId"]).toBe(true);
+      expect(arg.select["_id"]).toBe(true);
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (D) The seam itself: what crosses from one half to the other.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("the seam between the two halves", () => {
+    test("the delivery half is entered exactly once per execution", async () => {
+      const deliver: jest.SpyInstance = stubDeliveryHalf();
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      expect(deliver).toHaveBeenCalledTimes(1);
+    });
+
+    test("the rule object findOneById returned is handed over BY REFERENCE, unchanged", async () => {
+      const rule: UserNotificationRule = loadedRule({
+        userEmail: verifiedUserEmail(),
+      } as unknown as JSONObject);
+      spies.findRule.mockResolvedValue(rule as never);
+      const deliver: jest.SpyInstance = stubDeliveryHalf();
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      /*
+       * Identity, not shape. A copy would be a real regression: the channel
+       * blocks read hydrated RELATIONS (userEmail.email, userEmail.isVerified),
+       * and any reshaping on the way across is exactly how a relation turns
+       * into a bare FK and a verified responder stops being contactable.
+       */
+      expect(deliver.mock.calls[0]![0]).toBe(rule);
+    });
+
+    test("the caller's options bag is handed over BY REFERENCE, unchanged", async () => {
+      const options: ExecuteOptions = executeOptions();
+      const deliver: jest.SpyInstance = stubDeliveryHalf();
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        options,
+      );
+
+      expect(deliver.mock.calls[0]![1]).toBe(options);
+    });
+
+    test("the public half itself does no delivery work - it is all beyond the seam", async () => {
+      stubDeliveryHalf();
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      /*
+       * With the delivery half stubbed out, NOTHING should be left running in
+       * the public method: no Twilio config, no trigger-entity lookup, no
+       * timeline row, no send. If any of these fire, part of the body was left
+       * behind on the claim-and-load side, where the fallback cannot reuse it.
+       */
+      expect(spies.twilio).not.toHaveBeenCalled();
+      expect(spies.incidentFind).not.toHaveBeenCalled();
+      expect(spies.alertFind).not.toHaveBeenCalled();
+      expect(spies.alertEpisodeFind).not.toHaveBeenCalled();
+      expect(spies.incidentEpisodeFind).not.toHaveBeenCalled();
+      expect(spies.timelineCreate).not.toHaveBeenCalled();
+      for (const sender of everySender()) {
+        expect(sender).not.toHaveBeenCalled();
+      }
+    });
+
+    test("the public method still resolves to undefined - the delivery boolean is swallowed", async () => {
+      const deliver: jest.SpyInstance = stubDeliveryHalf();
+      deliver.mockResolvedValue(false as never);
+
+      /*
+       * The delivery half reports whether anything was dispatched, and the
+       * fallback branches on that. The rule-driven path deliberately does not:
+       * its signature is Promise<void> and callers await it for sequencing
+       * only. Returning the boolean here would be a public-API change.
+       */
+      await expect(
+        UserNotificationRuleService.executeNotificationRuleItem(
+          RULE_ID,
+          executeOptions(),
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    test("a throwing delivery half propagates out of the public method", async () => {
+      const deliver: jest.SpyInstance = stubDeliveryHalf();
+      deliver.mockRejectedValue(
+        new BadDataException(
+          "Incident, Alert, Alert Episode, or Incident Episode not found.",
+        ) as never,
+      );
+
+      /*
+       * The delivery half is AWAITED, not fired and forgotten. That is what
+       * lets ExecutePendingExecutions turn a missing trigger entity into an
+       * Error on the log instead of an unhandled rejection.
+       */
+      await expect(
+        UserNotificationRuleService.executeNotificationRuleItem(
+          RULE_ID,
+          executeOptions(),
+        ),
+      ).rejects.toThrow(
+        "Incident, Alert, Alert Episode, or Incident Episode not found.",
+      );
+    });
+
+    test("end to end, unstubbed, the rule loaded by id still reaches a sender", async () => {
+      spies.findRule.mockResolvedValue(
+        loadedRule({
+          userEmail: verifiedUserEmail(),
+        } as unknown as JSONObject) as never,
+      );
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      expect(spies.mail).toHaveBeenCalledTimes(1);
+      expect(timelineRows).toHaveLength(1);
+      expect(timelineRows[0]?.status).toBe(UserNotificationStatus.Sending);
+      expect(timelineRows[0]?.statusMessage).toContain(RESPONDER_EMAIL);
+      // A rule that DOES have an id still stamps it on the timeline row.
+      expect(timelineRows[0]?.userNotificationRuleId?.toString()).toBe(
+        RULE_ID.toString(),
+      );
+      expect(timelineRows[0]?.userEmailId?.toString()).toBe(
+        EMAIL_METHOD_ID.toString(),
+      );
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (E) The delivery half driven directly with an UNSAVED rule.
+   *
+   * This is what the fallback does, and it is the regression guard for
+   * blocker B1.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("the delivery half accepts an unsaved, id-less rule", () => {
+    test("the rule the fallback builds really has no id", () => {
+      const rule: UserNotificationRule = unsavedFallbackRule();
+
+      /*
+       * Guarding the guard. `id` is a getter over `_id`, so a rule that was
+       * never saved reports null - and every assertion below about the
+       * timeline row depends on that actually being the case.
+       */
+      expect(rule.id).toBeNull();
+      expect(rule._id).toBeUndefined();
+    });
+
+    test("an id-less email rule still writes a timeline row and dispatches", async () => {
+      const rule: UserNotificationRule = unsavedFallbackRule();
+      rule.userEmail = verifiedUserEmail();
+      rule.userEmailId = EMAIL_METHOD_ID;
+
+      const dispatched: boolean =
+        await deliveryHalf().deliverNotificationForRule(rule, executeOptions());
+
+      /*
+       * BLOCKER B1. UserOnCallLogTimeline.userNotificationRuleId used to be
+       * NOT NULL, so this create() threw for every fallback delivery - before
+       * a single page left the process. The column is nullable now and
+       * buildLogTimelineItem only sets the id when the rule has one.
+       */
+      expect(dispatched).toBe(true);
+      expect(timelineRows).toHaveLength(1);
+      expect(timelineRows[0]?.userNotificationRuleId).toBeUndefined();
+      expect(timelineRows[0]?.status).toBe(UserNotificationStatus.Sending);
+      expect(timelineRows[0]?.statusMessage).toContain(RESPONDER_EMAIL);
+      expect(spies.mail).toHaveBeenCalledTimes(1);
+    });
+
+    test("the id-less row still carries everything a reader needs", async () => {
+      const rule: UserNotificationRule = unsavedFallbackRule();
+      rule.userEmail = verifiedUserEmail();
+      rule.userEmailId = EMAIL_METHOD_ID;
+
+      await deliveryHalf().deliverNotificationForRule(rule, executeOptions());
+
+      /*
+       * Losing the rule id must not quietly cost the row its other anchors -
+       * an operator opening the on-call timeline has to see which log, which
+       * user, which escalation and which incident this page belonged to.
+       */
+      expect(timelineRows[0]?.userId?.toString()).toBe(USER_ID.toString());
+      expect(timelineRows[0]?.projectId?.toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+      expect(timelineRows[0]?.userNotificationLogId?.toString()).toBe(
+        LOG_ID.toString(),
+      );
+      expect(timelineRows[0]?.userNotificationEventType).toBe(
+        UserNotificationEventType.IncidentCreated,
+      );
+      expect(timelineRows[0]?.triggeredByIncidentId?.toString()).toBe(
+        INCIDENT_ID.toString(),
+      );
+      expect(timelineRows[0]?.onCallDutyPolicyId?.toString()).toBe(
+        POLICY_ID.toString(),
+      );
+      expect(
+        timelineRows[0]?.onCallDutyPolicyEscalationRuleId?.toString(),
+      ).toBe(ESCALATION_RULE_ID.toString());
+      expect(timelineRows[0]?.userBelongsToTeamId?.toString()).toBe(
+        TEAM_ID.toString(),
+      );
+      // The method FK is read off the RELATION, which is all the fallback sets.
+      expect(timelineRows[0]?.userEmailId?.toString()).toBe(
+        EMAIL_METHOD_ID.toString(),
+      );
+    });
+
+    test("an id-less push rule dispatches too - push is the fallback's first choice", async () => {
+      const rule: UserNotificationRule = unsavedFallbackRule();
+      rule.userPush = verifiedUserPush();
+      rule.userPushId = PUSH_METHOD_ID;
+
+      const dispatched: boolean =
+        await deliveryHalf().deliverNotificationForRule(rule, executeOptions());
+
+      expect(dispatched).toBe(true);
+      expect(spies.push).toHaveBeenCalledTimes(1);
+      expect(timelineRows).toHaveLength(1);
+      expect(timelineRows[0]?.userNotificationRuleId).toBeUndefined();
+      expect(timelineRows[0]?.userPushId?.toString()).toBe(
+        PUSH_METHOD_ID.toString(),
+      );
+    });
+
+    test("driving the delivery half directly claims nothing and loads no rule", async () => {
+      const rule: UserNotificationRule = unsavedFallbackRule();
+      rule.userEmail = verifiedUserEmail();
+      rule.userEmailId = EMAIL_METHOD_ID;
+
+      await deliveryHalf().deliverNotificationForRule(rule, executeOptions());
+
+      /*
+       * The two things the public half does are exactly the two things a
+       * rule with no database row cannot do. If either had been left inside
+       * the delivery half, the fallback would try to claim a rule id it does
+       * not have and read a row that does not exist.
+       */
+      expect(spies.claim).not.toHaveBeenCalled();
+      expect(spies.findRule).not.toHaveBeenCalled();
+    });
+
+    test("the unsaved rule is never persisted on the way through", async () => {
+      const rule: UserNotificationRule = unsavedFallbackRule();
+      rule.userEmail = verifiedUserEmail();
+      rule.userEmailId = EMAIL_METHOD_ID;
+
+      await deliveryHalf().deliverNotificationForRule(rule, executeOptions());
+
+      /*
+       * The user never asked for this rule. Saving it would silently rewrite
+       * their notification configuration behind their back, and the next real
+       * page would match a rule they did not create.
+       */
+      expect(spies.createRule).not.toHaveBeenCalled();
+      expect(rule.id).toBeNull();
+    });
+
+    test("two delivery calls build two DISTINCT timeline instances", async () => {
+      const pushRule: UserNotificationRule = unsavedFallbackRule();
+      pushRule.userPush = verifiedUserPush();
+      pushRule.userPushId = PUSH_METHOD_ID;
+
+      const emailRule: UserNotificationRule = unsavedFallbackRule();
+      emailRule.userEmail = verifiedUserEmail();
+      emailRule.userEmailId = EMAIL_METHOD_ID;
+
+      await deliveryHalf().deliverNotificationForRule(
+        pushRule,
+        executeOptions(),
+      );
+      await deliveryHalf().deliverNotificationForRule(
+        emailRule,
+        executeOptions(),
+      );
+
+      /*
+       * Why the fallback calls this once PER CHANNEL with a freshly built
+       * rule instead of looping channels inside one call: the timeline item is
+       * a single mutable instance per call, and after the first create() it
+       * carries an _id - so a second create() with the SAME instance UPDATEs
+       * the row the first channel wrote instead of inserting a second one. Two
+       * calls means two instances, which is what keeps the second page
+       * visible.
+       */
+      expect(timelineInstances).toHaveLength(2);
+      expect(timelineInstances[0]).not.toBe(timelineInstances[1]);
+      expect(spies.push).toHaveBeenCalledTimes(1);
+      expect(spies.mail).toHaveBeenCalledTimes(1);
+    });
+
+    test("an id-less rule with no contactable method dispatches nothing and returns false", async () => {
+      const rule: UserNotificationRule = unsavedFallbackRule();
+
+      const dispatched: boolean =
+        await deliveryHalf().deliverNotificationForRule(rule, executeOptions());
+
+      /*
+       * The return value is the fallback's only evidence. "Resolved without
+       * throwing" is NOT "paged": a false here is what stops the operator
+       * being told the responder was reached on a channel that sent nothing.
+       */
+      expect(dispatched).toBe(false);
+      for (const sender of everySender()) {
+        expect(sender).not.toHaveBeenCalled();
+      }
+      expect(timelineRows).toHaveLength(0);
+    });
+
+    test("an id-less rule whose method is UNVERIFIED is not contacted", async () => {
+      const rule: UserNotificationRule = unsavedFallbackRule();
+      const userEmail: UserEmail = verifiedUserEmail();
+      userEmail.isVerified = false;
+      rule.userEmail = userEmail;
+      rule.userEmailId = EMAIL_METHOD_ID;
+
+      const dispatched: boolean =
+        await deliveryHalf().deliverNotificationForRule(rule, executeOptions());
+
+      /*
+       * The verification gates are inside the delivery half, so they apply to
+       * the fallback exactly as they apply to a configured rule. A fallback
+       * that could page unverified addresses would be a way to send mail to an
+       * address nobody proved they own.
+       */
+      expect(dispatched).toBe(false);
+      expect(spies.mail).not.toHaveBeenCalled();
+      expect(timelineRows).toHaveLength(1);
+      expect(timelineRows[0]?.status).toBe(UserNotificationStatus.Error);
+      expect(timelineRows[0]?.statusMessage).toContain("not verified");
+    });
+
+    test("a missing trigger entity still throws, even for an id-less rule", async () => {
+      spies.incidentFind.mockResolvedValue(null as never);
+
+      const rule: UserNotificationRule = unsavedFallbackRule();
+      rule.userEmail = verifiedUserEmail();
+      rule.userEmailId = EMAIL_METHOD_ID;
+
+      await expect(
+        deliveryHalf().deliverNotificationForRule(rule, executeOptions()),
+      ).rejects.toThrow(
+        "Incident, Alert, Alert Episode, or Incident Episode not found.",
+      );
+
+      expect(spies.mail).not.toHaveBeenCalled();
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (F) projectTwilioConfig: resolved once, in the delivery half.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("the project Twilio config", () => {
+    test("is resolved exactly once per delivery, from options.projectId", async () => {
+      const options: ExecuteOptions = executeOptions();
+      spies.findRule.mockResolvedValue(
+        loadedRule({
+          userSms: verifiedUserSms(),
+        } as unknown as JSONObject) as never,
+      );
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        options,
+      );
+
+      expect(spies.twilio).toHaveBeenCalledTimes(1);
+      /*
+       * Identity against the caller's own projectId. The channel blocks below
+       * pass the TRIGGER entity's projectId to the senders, so reading the
+       * config off the incident instead of the options would look identical in
+       * every normal case and diverge only in the odd one.
+       */
+      expect(spies.twilio.mock.calls[0]![0]).toBe(options.projectId);
+    });
+
+    test("is resolved AFTER the rule is loaded and BEFORE any timeline row or send", async () => {
+      spies.findRule.mockResolvedValue(
+        loadedRule({
+          userSms: verifiedUserSms(),
+        } as unknown as JSONObject) as never,
+      );
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      /*
+       * The ordering IS the extraction boundary: the config lookup was the
+       * first statement of the old body's second half, and it has to stay on
+       * the delivery side or the fallback never sees it.
+       */
+      expect(spies.findRule.mock.invocationCallOrder[0]).toBeLessThan(
+        spies.twilio.mock.invocationCallOrder[0] as number,
+      );
+      expect(spies.twilio.mock.invocationCallOrder[0]).toBeLessThan(
+        spies.timelineCreate.mock.invocationCallOrder[0] as number,
+      );
+      expect(spies.twilio.mock.invocationCallOrder[0]).toBeLessThan(
+        spies.sms.mock.invocationCallOrder[0] as number,
+      );
+    });
+
+    test("the resolved config object reaches SmsService.sendSms by reference", async () => {
+      const twilioConfig: TwilioConfig = fakeTwilioConfig();
+      spies.twilio.mockResolvedValue(twilioConfig as never);
+      spies.findRule.mockResolvedValue(
+        loadedRule({
+          userSms: verifiedUserSms(),
+        } as unknown as JSONObject) as never,
+      );
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      expect(spies.sms).toHaveBeenCalledTimes(1);
+      /*
+       * A project with its own Twilio account must be billed on that account.
+       * Dropping this key does not fail - it quietly sends every on-call SMS
+       * from the global OneUptime number.
+       */
+      expect(sentSmsOptions().customTwilioConfig).toBe(twilioConfig);
+    });
+
+    test("no project config resolves to undefined and is still passed through", async () => {
+      spies.twilio.mockResolvedValue(undefined as never);
+      spies.findRule.mockResolvedValue(
+        loadedRule({
+          userSms: verifiedUserSms(),
+        } as unknown as JSONObject) as never,
+      );
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      // undefined is the signal for "use the global config", not a bug.
+      expect(sentSmsOptions().customTwilioConfig).toBeUndefined();
+    });
+
+    test("a fallback-style delivery resolves the PROJECT's config too", async () => {
+      const twilioConfig: TwilioConfig = fakeTwilioConfig();
+      spies.twilio.mockResolvedValue(twilioConfig as never);
+
+      const rule: UserNotificationRule = unsavedFallbackRule();
+      rule.userSms = verifiedUserSms();
+      rule.userSmsId = SMS_METHOD_ID;
+
+      const options: ExecuteOptions = executeOptions();
+      await deliveryHalf().deliverNotificationForRule(rule, options);
+
+      /*
+       * The fallback picks a paid channel only when the responder has no
+       * zero-cost method, so when it does reach SMS the project's own Twilio
+       * account is the one that must be charged.
+       */
+      expect(spies.twilio).toHaveBeenCalledTimes(1);
+      expect(spies.twilio.mock.calls[0]![0]).toBe(options.projectId);
+      expect(sentSmsOptions().customTwilioConfig).toBe(twilioConfig);
+    });
+
+    test("it is hoisted above the channel blocks - two channels, still one lookup", async () => {
+      /*
+       * A rule with two methods is not something the product creates (a rule
+       * carries exactly one), and the fallback deliberately never builds one -
+       * see the distinct-instances test above for why. It is used HERE only to
+       * prove the config read sits above the channel blocks rather than inside
+       * them: were it per-block, this would be two reads.
+       */
+      spies.findRule.mockResolvedValue(
+        loadedRule({
+          userEmail: verifiedUserEmail(),
+          userSms: verifiedUserSms(),
+        } as unknown as JSONObject) as never,
+      );
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        executeOptions(),
+      );
+
+      expect(spies.mail).toHaveBeenCalledTimes(1);
+      expect(spies.sms).toHaveBeenCalledTimes(1);
+      expect(spies.twilio).toHaveBeenCalledTimes(1);
+    });
+
+    test("a Twilio config read that rejects takes the whole delivery down", async () => {
+      spies.twilio.mockRejectedValue(
+        new Error("project config read failed") as never,
+      );
+      spies.findRule.mockResolvedValue(
+        loadedRule({
+          userSms: verifiedUserSms(),
+        } as unknown as JSONObject) as never,
+      );
+
+      /*
+       * Pinned as current behaviour: the lookup is the first awaited statement
+       * of the delivery half and is not guarded, so a failing project-config
+       * read stops the page rather than falling back to the global config.
+       * Loud, and the log ends up Error - but it is a real single point of
+       * failure for channels that do not need Twilio at all.
+       */
+      await expect(
+        UserNotificationRuleService.executeNotificationRuleItem(
+          RULE_ID,
+          executeOptions(),
+        ),
+      ).rejects.toThrow("project config read failed");
+
+      expect(spies.sms).not.toHaveBeenCalled();
+      expect(spies.timelineCreate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/Common/Tests/Server/Services/EpisodeRuleSeverityRepair.test.ts
+++ b/Common/Tests/Server/Services/EpisodeRuleSeverityRepair.test.ts
@@ -1,0 +1,1802 @@
+import RepairEpisodeNotificationRuleSeverity from "../../../../App/FeatureSet/Workers/DataMigrations/RepairEpisodeNotificationRuleSeverity";
+import AlertSeverityService from "../../../Server/Services/AlertSeverityService";
+import IncidentSeverityService from "../../../Server/Services/IncidentSeverityService";
+import UserNotificationRuleService, {
+  NotificationMethodDescriptor,
+} from "../../../Server/Services/UserNotificationRuleService";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import logger from "../../../Server/Utils/Logger";
+import AlertSeverity from "../../../Models/DatabaseModels/AlertSeverity";
+import IncidentSeverity from "../../../Models/DatabaseModels/IncidentSeverity";
+import Model from "../../../Models/DatabaseModels/UserNotificationRule";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import LIMIT_MAX, { LIMIT_PER_PROJECT } from "../../../Types/Database/LimitMax";
+import NotificationRuleType from "../../../Types/NotificationRule/NotificationRuleType";
+import ObjectID from "../../../Types/ObjectID";
+import fs from "fs";
+import path from "path";
+import { FindOperator } from "typeorm";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * GAP G: the episode notification rules that pointed at no severity.
+ *
+ * A UserNotificationRule is matched to a page by (ruleType x severity). The
+ * on-call path counts them with a CONCRETE severity id in the query -
+ * UserOnCallLogService reads `alertEpisode.alertSeverityId` /
+ * `incidentEpisode.incidentSeverityId` and hands it straight to countBy - and
+ * `NULL = '<uuid>'` is never true in SQL. So a rule with a NULL severity id is
+ * not "a rule that matches everything"; it is a rule that matches NOTHING.
+ *
+ * That is what the defaults used to create. `createIncidentOnCallRules` and
+ * `createAlertOnCallRules` seeded their two rule types once per severity, but
+ * the two EPISODE rule types went through `createSingleRule`, which sets only
+ * `ruleType` and `notifyAfterMinutes`. Every responder who took the defaults -
+ * which is everyone who never opened User Settings - therefore had two episode
+ * "rules" that could not be reached by any alert-episode or incident-episode
+ * page. The system said they were covered. They were not.
+ *
+ * This file covers both halves of the fix.
+ *
+ *   HALF 1 - creation.
+ *   `addDefaultNotificationRulesForVerifiedMethod` now seeds the two episode
+ *   rule types per severity, alert episodes against AlertSeverity and incident
+ *   episodes against IncidentSeverity. The severity MODEL each type is scoped
+ *   by is asserted explicitly and with disjoint, differently-sized id sets,
+ *   because crossing the two lists is the natural way to get this wrong and it
+ *   fails silently: alert severity ids on incident-episode rules produce rows
+ *   that are perfectly well-formed, perfectly visible, and still match no page
+ *   ever. WHEN_USER_GOES_ON_CALL and WHEN_USER_GOES_OFF_CALL keep going
+ *   through the single-rule path with no severity at all, because they are
+ *   about the responder's shift rather than about anything that fired - they
+ *   are the two rule types for which severity-less is CORRECT, and conflating
+ *   them with the episode types is the mirror-image mistake.
+ *
+ *   HALF 2 - repair. `RepairEpisodeNotificationRuleSeverity` (a data migration
+ *   in App/FeatureSet/Workers/DataMigrations, registered in that folder's
+ *   Index.ts) fixes the rows already written: each NULL-severity episode rule
+ *   becomes one row per severity in its project, preserving the notification
+ *   method FK and `notifyAfterMinutes` so the responder's stated intent -
+ *   "reach me HERE, after THIS long" - survives the repair.
+ *
+ * WHY THE MIGRATION DELETES THE NULL ORIGINALS RATHER THAN LEAVING THEM.
+ * Leaving a row is normally the conservative choice, so the opposite call is
+ * worth stating precisely. These rows are unreachable AND invisible at the
+ * same time:
+ *
+ *   1. Unreachable. The count query the on-call path runs always supplies a
+ *      concrete severity id, so a NULL row can never be counted, can never be
+ *      executed, and can never page anybody. That is true by construction, not
+ *      merely likely.
+ *   2. Invisible. Both episode rule pages in the dashboard
+ *      (UserSettings/EpisodeOnCallRules.tsx and
+ *      UserSettings/IncidentEpisodeOnCallRules.tsx) scope their ModelTable by
+ *      a severity id, exactly as the non-episode pages do. A row with no
+ *      severity renders in no table on any page.
+ *
+ * So the user can neither be paged by the row nor see it nor delete it. Left
+ * behind it is pure clutter that only ever surfaces as an inflated rule count
+ * in some future readiness or compliance number - and the replacement rows
+ * carry everything it expressed. Deleting loses nothing; keeping costs a lie.
+ *
+ * The migration's most dangerous possible over-reach is the opposite of its
+ * job: sweeping up the shift rules, which are legitimately severity-less and
+ * whose fan-out would create rules that fire on every severity change of a
+ * responder's roster. That case, and the "already has a severity" and
+ * "not an episode rule type" cases, are all pinned below.
+ *
+ * Nothing here touches Postgres. Half 1 stubs the two severity services and
+ * the rule service's own findOneBy/create. Half 2 runs the migration against
+ * an in-memory stand-in for the user_notification_rule table that honours the
+ * query's rule type and NULL-severity filter, the `_id ASC` ordering and the
+ * skip/limit window - so the paging cursor, the drain condition and the
+ * idempotence are exercised for real rather than asserted against a script of
+ * canned pages.
+ */
+
+/*
+ * ------------------------------------------------------------------ *
+ * Fixtures shared by both halves.
+ * ------------------------------------------------------------------
+ */
+
+const PROJECT_A: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const PROJECT_B: ObjectID = new ObjectID(
+  "11111111-2222-4111-8111-111111111111",
+);
+const PROJECT_NO_SEVERITIES: ObjectID = new ObjectID(
+  "11111111-3333-4111-8111-111111111111",
+);
+
+const USER_ID: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+const OTHER_USER_ID: ObjectID = new ObjectID(
+  "22222222-3333-4222-8222-222222222222",
+);
+
+/*
+ * Deliberately disjoint id sets, and deliberately different sizes (3 incident
+ * vs 2 alert). A fan-out that reached for the wrong severity list would still
+ * produce plausible-looking rows, so the count is the second, independent
+ * signal that the right list was used.
+ */
+const INCIDENT_SEV_1: ObjectID = new ObjectID(
+  "aaaaaaa1-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+const INCIDENT_SEV_2: ObjectID = new ObjectID(
+  "aaaaaaa2-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+const INCIDENT_SEV_3: ObjectID = new ObjectID(
+  "aaaaaaa3-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+
+const ALERT_SEV_1: ObjectID = new ObjectID(
+  "bbbbbbb1-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+);
+const ALERT_SEV_2: ObjectID = new ObjectID(
+  "bbbbbbb2-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+);
+
+/* Project B's severities, so "fans out over ITS OWN project" is observable. */
+const PROJECT_B_INCIDENT_SEV: ObjectID = new ObjectID(
+  "aaaaaaa9-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+const PROJECT_B_ALERT_SEV: ObjectID = new ObjectID(
+  "bbbbbbb9-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+);
+
+const INCIDENT_SEVERITY_IDS: Array<ObjectID> = [
+  INCIDENT_SEV_1,
+  INCIDENT_SEV_2,
+  INCIDENT_SEV_3,
+];
+
+const ALERT_SEVERITY_IDS: Array<ObjectID> = [ALERT_SEV_1, ALERT_SEV_2];
+
+const EMAIL_METHOD_ID: ObjectID = new ObjectID(
+  "ccccccc1-cccc-4ccc-8ccc-cccccccccccc",
+);
+const TELEGRAM_METHOD_ID: ObjectID = new ObjectID(
+  "ccccccc2-cccc-4ccc-8ccc-cccccccccccc",
+);
+
+/* The seven FK columns a rule can name a notification method through. */
+type MethodColumn =
+  | "userEmailId"
+  | "userSmsId"
+  | "userCallId"
+  | "userWhatsAppId"
+  | "userTelegramId"
+  | "userWebhookId"
+  | "userPushId";
+
+const ALL_METHOD_COLUMNS: Array<MethodColumn> = [
+  "userEmailId",
+  "userSmsId",
+  "userCallId",
+  "userWhatsAppId",
+  "userTelegramId",
+  "userWebhookId",
+  "userPushId",
+];
+
+const EPISODE_RULE_TYPES: Array<NotificationRuleType> = [
+  NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+  NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+];
+
+/* The two rule types for which "no severity" is the correct answer. */
+const SHIFT_RULE_TYPES: Array<NotificationRuleType> = [
+  NotificationRuleType.WHEN_USER_GOES_ON_CALL,
+  NotificationRuleType.WHEN_USER_GOES_OFF_CALL,
+];
+
+function makeAlertSeverity(id: ObjectID): AlertSeverity {
+  const severity: AlertSeverity = new AlertSeverity(id);
+  severity._id = id.toString();
+
+  return severity;
+}
+
+function makeIncidentSeverity(id: ObjectID): IncidentSeverity {
+  const severity: IncidentSeverity = new IncidentSeverity(id);
+  severity._id = id.toString();
+
+  return severity;
+}
+
+function toStrings(ids: Array<ObjectID>): Array<string> {
+  return ids.map((id: ObjectID): string => {
+    return id.toString();
+  });
+}
+
+/*
+ * ------------------------------------------------------------------ *
+ * HALF 1 - what the defaults create.
+ * ------------------------------------------------------------------
+ */
+
+describe("GAP G half 1 - addDefaultNotificationRulesForVerifiedMethod seeds episode rules per severity", () => {
+  let seedCreateSpy: jest.SpyInstance;
+  let seedFindOneBySpy: jest.SpyInstance;
+  let seedAlertSeveritiesSpy: jest.SpyInstance;
+  let seedIncidentSeveritiesSpy: jest.SpyInstance;
+
+  function seededRules(): Array<Model> {
+    return seedCreateSpy.mock.calls.map((call: Array<unknown>): Model => {
+      return (call[0] as CreateBy<Model>).data;
+    });
+  }
+
+  function seededRulesOfType(ruleType: NotificationRuleType): Array<Model> {
+    return seededRules().filter((rule: Model): boolean => {
+      return rule.ruleType === ruleType;
+    });
+  }
+
+  function duplicateCheckQueries(): Array<Record<string, unknown>> {
+    return seedFindOneBySpy.mock.calls.map(
+      (call: Array<unknown>): Record<string, unknown> => {
+        return (call[0] as { query: Record<string, unknown> }).query;
+      },
+    );
+  }
+
+  function seedFor(
+    notificationMethod: NotificationMethodDescriptor,
+  ): Promise<void> {
+    return UserNotificationRuleService.addDefaultNotificationRulesForVerifiedMethod(
+      {
+        projectId: PROJECT_A,
+        userId: USER_ID,
+        notificationMethod: notificationMethod,
+      },
+    );
+  }
+
+  function seedForEmail(): Promise<void> {
+    return seedFor({ userEmailId: EMAIL_METHOD_ID });
+  }
+
+  beforeEach(() => {
+    seedIncidentSeveritiesSpy = jest
+      .spyOn(IncidentSeverityService, "findBy")
+      .mockResolvedValue(
+        INCIDENT_SEVERITY_IDS.map(makeIncidentSeverity) as never,
+      );
+
+    seedAlertSeveritiesSpy = jest
+      .spyOn(AlertSeverityService, "findBy")
+      .mockResolvedValue(ALERT_SEVERITY_IDS.map(makeAlertSeverity) as never);
+
+    // Nothing exists yet, so every candidate rule is created.
+    seedFindOneBySpy = jest.spyOn(UserNotificationRuleService, "findOneBy");
+    seedFindOneBySpy.mockResolvedValue(null as never);
+
+    seedCreateSpy = jest.spyOn(UserNotificationRuleService, "create");
+    seedCreateSpy.mockImplementation(
+      (createBy: CreateBy<Model>): Promise<Model> => {
+        return Promise.resolve(createBy.data);
+      },
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("one ALERT episode rule per alert severity, each carrying that severity id", async () => {
+    await seedForEmail();
+
+    const episodeRules: Array<Model> = seededRulesOfType(
+      NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+    );
+
+    expect(episodeRules).toHaveLength(ALERT_SEVERITY_IDS.length);
+    expect(
+      episodeRules.map((rule: Model): string => {
+        return rule.alertSeverityId!.toString();
+      }),
+    ).toEqual(toStrings(ALERT_SEVERITY_IDS));
+  });
+
+  test("one INCIDENT episode rule per incident severity, each carrying that severity id", async () => {
+    await seedForEmail();
+
+    const episodeRules: Array<Model> = seededRulesOfType(
+      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+    );
+
+    expect(episodeRules).toHaveLength(INCIDENT_SEVERITY_IDS.length);
+    expect(
+      episodeRules.map((rule: Model): string => {
+        return rule.incidentSeverityId!.toString();
+      }),
+    ).toEqual(toStrings(INCIDENT_SEVERITY_IDS));
+  });
+
+  test("alert episode rules are scoped by the ALERT severity model, never the incident one", async () => {
+    /*
+     * The crossing bug. Handing `createSeverityScopedRules` the incident list
+     * for the alert-episode rule type would write rows whose alertSeverityId
+     * is an IncidentSeverity's primary key - a foreign key pointing into the
+     * wrong table, which no alert episode's severity id will ever equal. The
+     * rows would look fine in every log and page nobody, so both halves are
+     * asserted: the ids are drawn from the alert list, and none of them comes
+     * from the incident list.
+     */
+    await seedForEmail();
+
+    const incidentIds: Array<string> = toStrings(INCIDENT_SEVERITY_IDS);
+
+    for (const rule of seededRulesOfType(
+      NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+    )) {
+      expect(toStrings(ALERT_SEVERITY_IDS)).toContain(
+        rule.alertSeverityId!.toString(),
+      );
+      expect(incidentIds).not.toContain(rule.alertSeverityId!.toString());
+      expect(rule.incidentSeverityId).toBeUndefined();
+    }
+  });
+
+  test("incident episode rules are scoped by the INCIDENT severity model, never the alert one", async () => {
+    await seedForEmail();
+
+    const alertIds: Array<string> = toStrings(ALERT_SEVERITY_IDS);
+
+    for (const rule of seededRulesOfType(
+      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+    )) {
+      expect(toStrings(INCIDENT_SEVERITY_IDS)).toContain(
+        rule.incidentSeverityId!.toString(),
+      );
+      expect(alertIds).not.toContain(rule.incidentSeverityId!.toString());
+      expect(rule.alertSeverityId).toBeUndefined();
+    }
+  });
+
+  test("the count of each episode rule type tracks its OWN severity list, not the other one", async () => {
+    /*
+     * A second, count-based check on the same crossing bug, with the two list
+     * lengths pulled far apart so a swap cannot coincidentally agree: four
+     * alert severities and one incident severity must give four alert-episode
+     * rules and one incident-episode rule, not the reverse.
+     */
+    const alertSeverityIds: Array<ObjectID> = [
+      ALERT_SEV_1,
+      ALERT_SEV_2,
+      PROJECT_B_ALERT_SEV,
+      new ObjectID("bbbbbbb4-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+    ];
+
+    seedAlertSeveritiesSpy.mockResolvedValue(
+      alertSeverityIds.map(makeAlertSeverity) as never,
+    );
+    seedIncidentSeveritiesSpy.mockResolvedValue([
+      makeIncidentSeverity(INCIDENT_SEV_1),
+    ] as never);
+
+    await seedForEmail();
+
+    expect(
+      seededRulesOfType(NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE),
+    ).toHaveLength(4);
+    expect(
+      seededRulesOfType(NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE),
+    ).toHaveLength(1);
+  });
+
+  test("no episode rule is created without a severity - the createSingleRule path is gone for these two", async () => {
+    /*
+     * The precise statement of GAP G. One severity-less episode row is enough
+     * to reintroduce it, so this asserts over every episode row rather than
+     * over a count.
+     */
+    await seedForEmail();
+
+    const episodeRules: Array<Model> = seededRules().filter(
+      (rule: Model): boolean => {
+        return EPISODE_RULE_TYPES.includes(rule.ruleType!);
+      },
+    );
+
+    expect(episodeRules).toHaveLength(
+      ALERT_SEVERITY_IDS.length + INCIDENT_SEVERITY_IDS.length,
+    );
+
+    for (const rule of episodeRules) {
+      expect(
+        Boolean(rule.alertSeverityId) || Boolean(rule.incidentSeverityId),
+      ).toBe(true);
+    }
+  });
+
+  test("the ONLY severity-less rules seeded are the two shift rules", async () => {
+    /*
+     * The complement of the assertion above, and the guard against
+     * over-correcting: WHEN_USER_GOES_ON_CALL / OFF_CALL describe the
+     * responder's roster rather than anything that fired, so they carry no
+     * severity by design and must keep going through createSingleRule.
+     */
+    await seedForEmail();
+
+    const severityLessRules: Array<Model> = seededRules().filter(
+      (rule: Model): boolean => {
+        return !rule.alertSeverityId && !rule.incidentSeverityId;
+      },
+    );
+
+    expect(
+      severityLessRules.map((rule: Model): NotificationRuleType => {
+        return rule.ruleType!;
+      }),
+    ).toEqual(SHIFT_RULE_TYPES);
+  });
+
+  test("each shift rule is seeded exactly once, regardless of how many severities exist", async () => {
+    await seedForEmail();
+
+    for (const ruleType of SHIFT_RULE_TYPES) {
+      expect(seededRulesOfType(ruleType)).toHaveLength(1);
+    }
+  });
+
+  test("the shift rules' duplicate check carries no severity key at all", async () => {
+    /*
+     * `createSingleRule` is private, so the observable signature of "this went
+     * through the single-rule path" is its lookup: project + user + method +
+     * ruleType and nothing else. An episode type appearing here without a
+     * severity key would mean GAP G had returned.
+     */
+    await seedForEmail();
+
+    const queries: Array<Record<string, unknown>> = duplicateCheckQueries();
+
+    const shiftQueries: Array<Record<string, unknown>> = queries.filter(
+      (query: Record<string, unknown>): boolean => {
+        return SHIFT_RULE_TYPES.includes(
+          query["ruleType"] as NotificationRuleType,
+        );
+      },
+    );
+
+    expect(shiftQueries).toHaveLength(SHIFT_RULE_TYPES.length);
+
+    for (const query of shiftQueries) {
+      expect(Object.keys(query)).not.toContain("alertSeverityId");
+      expect(Object.keys(query)).not.toContain("incidentSeverityId");
+    }
+  });
+
+  test("every episode rule's duplicate check IS keyed on a severity", async () => {
+    await seedForEmail();
+
+    const episodeQueries: Array<Record<string, unknown>> =
+      duplicateCheckQueries().filter(
+        (query: Record<string, unknown>): boolean => {
+          return EPISODE_RULE_TYPES.includes(
+            query["ruleType"] as NotificationRuleType,
+          );
+        },
+      );
+
+    expect(episodeQueries).toHaveLength(
+      ALERT_SEVERITY_IDS.length + INCIDENT_SEVERITY_IDS.length,
+    );
+
+    for (const query of episodeQueries) {
+      const isAlertEpisode: boolean =
+        query["ruleType"] ===
+        NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE;
+
+      const severityId: unknown = isAlertEpisode
+        ? query["alertSeverityId"]
+        : query["incidentSeverityId"];
+
+      expect(severityId).toBeDefined();
+      expect(
+        toStrings(
+          isAlertEpisode ? ALERT_SEVERITY_IDS : INCIDENT_SEVERITY_IDS,
+        ).includes((severityId as ObjectID).toString()),
+      ).toBe(true);
+    }
+  });
+
+  test("the verified method lands on every episode rule, on its own column only", async () => {
+    await seedFor({ userTelegramId: TELEGRAM_METHOD_ID });
+
+    const episodeRules: Array<Model> = seededRules().filter(
+      (rule: Model): boolean => {
+        return EPISODE_RULE_TYPES.includes(rule.ruleType!);
+      },
+    );
+
+    expect(episodeRules).toHaveLength(
+      ALERT_SEVERITY_IDS.length + INCIDENT_SEVERITY_IDS.length,
+    );
+
+    for (const rule of episodeRules) {
+      expect(rule.userTelegramId!.toString()).toBe(
+        TELEGRAM_METHOD_ID.toString(),
+      );
+
+      for (const column of ALL_METHOD_COLUMNS) {
+        if (column === "userTelegramId") {
+          continue;
+        }
+        expect(rule[column]).toBeUndefined();
+      }
+    }
+  });
+
+  test("every seeded episode rule pages immediately and belongs to the project and user", async () => {
+    await seedForEmail();
+
+    for (const rule of seededRules().filter((rule: Model): boolean => {
+      return EPISODE_RULE_TYPES.includes(rule.ruleType!);
+    })) {
+      expect(rule.notifyAfterMinutes).toBe(0);
+      expect(rule.projectId!.toString()).toBe(PROJECT_A.toString());
+      expect(rule.userId!.toString()).toBe(USER_ID.toString());
+    }
+  });
+
+  test("a project with no ALERT severities gets no alert-episode rules but keeps its incident ones", async () => {
+    /*
+     * Episode rules follow the severities now, so "none of that kind exist"
+     * has to mean "seed none" rather than "seed one severity-less row" - which
+     * is exactly the shape the old createSingleRule call had.
+     */
+    seedAlertSeveritiesSpy.mockResolvedValue([] as never);
+
+    await seedForEmail();
+
+    expect(
+      seededRulesOfType(NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE),
+    ).toHaveLength(0);
+    expect(
+      seededRulesOfType(NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE),
+    ).toHaveLength(INCIDENT_SEVERITY_IDS.length);
+
+    for (const ruleType of SHIFT_RULE_TYPES) {
+      expect(seededRulesOfType(ruleType)).toHaveLength(1);
+    }
+  });
+
+  test("a project with no severities of either kind still seeds the two shift rules and nothing else", async () => {
+    seedAlertSeveritiesSpy.mockResolvedValue([] as never);
+    seedIncidentSeveritiesSpy.mockResolvedValue([] as never);
+
+    await seedForEmail();
+
+    expect(
+      seededRules().map((rule: Model): NotificationRuleType => {
+        return rule.ruleType!;
+      }),
+    ).toEqual(SHIFT_RULE_TYPES);
+  });
+});
+
+/*
+ * ------------------------------------------------------------------ *
+ * HALF 2 - the repair migration.
+ * ------------------------------------------------------------------
+ */
+
+/* The shape of a findBy the migration issues against the rule table. */
+interface RuleFindByArgs {
+  query: Record<string, unknown>;
+  select?: Record<string, boolean> | undefined;
+  sort?: Record<string, SortOrder> | undefined;
+  skip?: number | undefined;
+  limit?: number | undefined;
+  props?: { isRoot?: boolean | undefined } | undefined;
+}
+
+interface RuleSeed {
+  id: ObjectID;
+  ruleType: NotificationRuleType;
+  projectId?: ObjectID | undefined;
+  userId?: ObjectID | undefined;
+  notifyAfterMinutes?: number | undefined;
+  alertSeverityId?: ObjectID | undefined;
+  incidentSeverityId?: ObjectID | undefined;
+  methodColumn?: MethodColumn | undefined;
+  methodId?: ObjectID | undefined;
+}
+
+function makeRule(seed: RuleSeed): Model {
+  const rule: Model = new Model(seed.id);
+  rule._id = seed.id.toString();
+  rule.ruleType = seed.ruleType;
+
+  if (seed.projectId) {
+    rule.projectId = seed.projectId;
+  }
+
+  if (seed.userId) {
+    rule.userId = seed.userId;
+  }
+
+  if (seed.notifyAfterMinutes !== undefined) {
+    rule.notifyAfterMinutes = seed.notifyAfterMinutes;
+  }
+
+  if (seed.alertSeverityId) {
+    rule.alertSeverityId = seed.alertSeverityId;
+  }
+
+  if (seed.incidentSeverityId) {
+    rule.incidentSeverityId = seed.incidentSeverityId;
+  }
+
+  if (seed.methodColumn && seed.methodId) {
+    rule[seed.methodColumn] = seed.methodId;
+  }
+
+  return rule;
+}
+
+/* Ids of rows the fixtures reference by name. */
+const NULL_ALERT_EPISODE_ID: ObjectID = new ObjectID(
+  "d0000001-dddd-4ddd-8ddd-dddddddddddd",
+);
+const NULL_INCIDENT_EPISODE_ID: ObjectID = new ObjectID(
+  "d0000002-dddd-4ddd-8ddd-dddddddddddd",
+);
+const SCOPED_ALERT_EPISODE_ID: ObjectID = new ObjectID(
+  "d0000003-dddd-4ddd-8ddd-dddddddddddd",
+);
+const NULL_ALERT_ON_CALL_ID: ObjectID = new ObjectID(
+  "d0000004-dddd-4ddd-8ddd-dddddddddddd",
+);
+const NULL_INCIDENT_ON_CALL_ID: ObjectID = new ObjectID(
+  "d0000005-dddd-4ddd-8ddd-dddddddddddd",
+);
+const GOES_ON_CALL_ID: ObjectID = new ObjectID(
+  "d0000006-dddd-4ddd-8ddd-dddddddddddd",
+);
+const GOES_OFF_CALL_ID: ObjectID = new ObjectID(
+  "d0000007-dddd-4ddd-8ddd-dddddddddddd",
+);
+const NO_METHOD_ID: ObjectID = new ObjectID(
+  "d0000008-dddd-4ddd-8ddd-dddddddddddd",
+);
+const NO_PROJECT_ID: ObjectID = new ObjectID(
+  "d0000009-dddd-4ddd-8ddd-dddddddddddd",
+);
+const PROJECT_B_NULL_ALERT_EPISODE_ID: ObjectID = new ObjectID(
+  "d000000a-dddd-4ddd-8ddd-dddddddddddd",
+);
+const ORPHAN_PROJECT_NULL_EPISODE_ID: ObjectID = new ObjectID(
+  "d000000b-dddd-4ddd-8ddd-dddddddddddd",
+);
+
+/* A NULL-severity alert-episode rule: exactly what the old defaults wrote. */
+function nullAlertEpisodeRule(overrides?: Partial<RuleSeed>): Model {
+  return makeRule({
+    id: NULL_ALERT_EPISODE_ID,
+    ruleType: NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+    projectId: PROJECT_A,
+    userId: USER_ID,
+    notifyAfterMinutes: 15,
+    methodColumn: "userTelegramId",
+    methodId: TELEGRAM_METHOD_ID,
+    ...overrides,
+  });
+}
+
+function nullIncidentEpisodeRule(overrides?: Partial<RuleSeed>): Model {
+  return makeRule({
+    id: NULL_INCIDENT_EPISODE_ID,
+    ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+    projectId: PROJECT_A,
+    userId: USER_ID,
+    notifyAfterMinutes: 0,
+    methodColumn: "userEmailId",
+    methodId: EMAIL_METHOD_ID,
+    ...overrides,
+  });
+}
+
+describe("GAP G half 2 - RepairEpisodeNotificationRuleSeverity", () => {
+  /* The in-memory stand-in for the user_notification_rule table. */
+  let table: Array<Model> = [];
+  /* An ordered log of the writes, so "delete only after create" is testable. */
+  let events: Array<string> = [];
+  let findByCalls: Array<RuleFindByArgs> = [];
+  let createdRuleCounter: number = 0;
+
+  let ruleFindBySpy: jest.SpyInstance;
+  let ruleFindOneBySpy: jest.SpyInstance;
+  let ruleCreateSpy: jest.SpyInstance;
+  let ruleDeleteSpy: jest.SpyInstance;
+  let alertSeveritiesSpy: jest.SpyInstance;
+  let incidentSeveritiesSpy: jest.SpyInstance;
+
+  const alertSeveritiesByProject: Map<string, Array<ObjectID>> = new Map<
+    string,
+    Array<ObjectID>
+  >();
+  const incidentSeveritiesByProject: Map<string, Array<ObjectID>> = new Map<
+    string,
+    Array<ObjectID>
+  >();
+
+  function runMigration(): Promise<void> {
+    return new RepairEpisodeNotificationRuleSeverity().migrate();
+  }
+
+  function createdRules(): Array<Model> {
+    return ruleCreateSpy.mock.calls.map((call: Array<unknown>): Model => {
+      return (call[0] as CreateBy<Model>).data;
+    });
+  }
+
+  function createdRulesOfType(ruleType: NotificationRuleType): Array<Model> {
+    return createdRules().filter((rule: Model): boolean => {
+      return rule.ruleType === ruleType;
+    });
+  }
+
+  function deletedRuleIds(): Array<string> {
+    return ruleDeleteSpy.mock.calls.map((call: Array<unknown>): string => {
+      return (call[0] as { id: ObjectID }).id.toString();
+    });
+  }
+
+  function tableIds(): Array<string> {
+    return table.map((rule: Model): string => {
+      return rule._id!;
+    });
+  }
+
+  function findByCallsForRuleType(
+    ruleType: NotificationRuleType,
+  ): Array<RuleFindByArgs> {
+    return findByCalls.filter((call: RuleFindByArgs): boolean => {
+      return call.query["ruleType"] === ruleType;
+    });
+  }
+
+  /* Does this stored row satisfy every key of the given query? */
+  function matchesQuery(rule: Model, query: Record<string, unknown>): boolean {
+    return Object.keys(query).every((key: string): boolean => {
+      const expected: unknown = query[key];
+      const actual: unknown = (rule as unknown as Record<string, unknown>)[key];
+
+      if (expected instanceof ObjectID) {
+        return (
+          actual instanceof ObjectID &&
+          actual.toString() === expected.toString()
+        );
+      }
+
+      return actual === expected;
+    });
+  }
+
+  beforeEach(() => {
+    table = [];
+    events = [];
+    findByCalls = [];
+    createdRuleCounter = 0;
+
+    alertSeveritiesByProject.clear();
+    incidentSeveritiesByProject.clear();
+    alertSeveritiesByProject.set(PROJECT_A.toString(), ALERT_SEVERITY_IDS);
+    alertSeveritiesByProject.set(PROJECT_B.toString(), [PROJECT_B_ALERT_SEV]);
+    alertSeveritiesByProject.set(PROJECT_NO_SEVERITIES.toString(), []);
+    incidentSeveritiesByProject.set(
+      PROJECT_A.toString(),
+      INCIDENT_SEVERITY_IDS,
+    );
+    incidentSeveritiesByProject.set(PROJECT_B.toString(), [
+      PROJECT_B_INCIDENT_SEV,
+    ]);
+    incidentSeveritiesByProject.set(PROJECT_NO_SEVERITIES.toString(), []);
+
+    /*
+     * The paging read. This honours the parts of the query the migration's
+     * correctness rests on - the rule type, the IS NULL severity filter, the
+     * `_id ASC` ordering and the skip/limit window - so a cursor that failed
+     * to advance would hang the loop here exactly as it would in production,
+     * rather than being papered over by a scripted sequence of pages.
+     */
+    ruleFindBySpy = jest.spyOn(UserNotificationRuleService, "findBy");
+    ruleFindBySpy.mockImplementation(
+      (findBy: RuleFindByArgs): Promise<Array<Model>> => {
+        findByCalls.push(findBy);
+
+        const ruleType: unknown = findBy.query["ruleType"];
+        const isAlertEpisodeQuery: boolean =
+          findBy.query["alertSeverityId"] !== undefined;
+
+        const matching: Array<Model> = table
+          .filter((rule: Model): boolean => {
+            if (rule.ruleType !== ruleType) {
+              return false;
+            }
+
+            return isAlertEpisodeQuery
+              ? !rule.alertSeverityId
+              : !rule.incidentSeverityId;
+          })
+          .sort((first: Model, second: Model): number => {
+            return (first._id || "").localeCompare(second._id || "");
+          });
+
+        const skip: number = findBy.skip ?? 0;
+        const limit: number = findBy.limit ?? matching.length;
+
+        return Promise.resolve(matching.slice(skip, skip + limit));
+      },
+    );
+
+    /* The duplicate check that makes the pass idempotent and restartable. */
+    ruleFindOneBySpy = jest.spyOn(UserNotificationRuleService, "findOneBy");
+    ruleFindOneBySpy.mockImplementation(
+      (findOneBy: {
+        query: Record<string, unknown>;
+      }): Promise<Model | null> => {
+        const found: Model | undefined = table.find((rule: Model): boolean => {
+          return matchesQuery(rule, findOneBy.query);
+        });
+
+        return Promise.resolve(found ?? null);
+      },
+    );
+
+    ruleCreateSpy = jest.spyOn(UserNotificationRuleService, "create");
+    ruleCreateSpy.mockImplementation(
+      (createBy: CreateBy<Model>): Promise<Model> => {
+        const created: Model = createBy.data;
+        createdRuleCounter++;
+        created._id = `cccccccc-0000-4000-8000-${String(createdRuleCounter).padStart(12, "0")}`;
+
+        const severityId: ObjectID | undefined =
+          created.alertSeverityId || created.incidentSeverityId;
+
+        events.push(`create:${severityId ? severityId.toString() : "none"}`);
+        table.push(created);
+
+        return Promise.resolve(created);
+      },
+    );
+
+    ruleDeleteSpy = jest.spyOn(UserNotificationRuleService, "deleteOneById");
+    ruleDeleteSpy.mockImplementation(
+      (deleteById: { id: ObjectID }): Promise<number> => {
+        events.push(`delete:${deleteById.id.toString()}`);
+
+        const index: number = table.findIndex((rule: Model): boolean => {
+          return rule._id === deleteById.id.toString();
+        });
+
+        if (index < 0) {
+          return Promise.resolve(0);
+        }
+
+        table.splice(index, 1);
+
+        return Promise.resolve(1);
+      },
+    );
+
+    alertSeveritiesSpy = jest.spyOn(AlertSeverityService, "findBy");
+    alertSeveritiesSpy.mockImplementation(
+      (findBy: {
+        query: { projectId: ObjectID };
+      }): Promise<Array<AlertSeverity>> => {
+        const ids: Array<ObjectID> =
+          alertSeveritiesByProject.get(findBy.query.projectId.toString()) ?? [];
+
+        return Promise.resolve(ids.map(makeAlertSeverity));
+      },
+    );
+
+    incidentSeveritiesSpy = jest.spyOn(IncidentSeverityService, "findBy");
+    incidentSeveritiesSpy.mockImplementation(
+      (findBy: {
+        query: { projectId: ObjectID };
+      }): Promise<Array<IncidentSeverity>> => {
+        const ids: Array<ObjectID> =
+          incidentSeveritiesByProject.get(findBy.query.projectId.toString()) ??
+          [];
+
+        return Promise.resolve(ids.map(makeIncidentSeverity));
+      },
+    );
+
+    jest.spyOn(logger, "debug").mockImplementation((): void => {
+      return undefined;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("fanning a NULL-severity episode rule out", () => {
+    test("an alert episode rule becomes one rule per ALERT severity in its project", async () => {
+      table = [nullAlertEpisodeRule()];
+
+      await runMigration();
+
+      const created: Array<Model> = createdRules();
+
+      expect(created).toHaveLength(ALERT_SEVERITY_IDS.length);
+      expect(
+        created.map((rule: Model): string => {
+          return rule.alertSeverityId!.toString();
+        }),
+      ).toEqual(toStrings(ALERT_SEVERITY_IDS));
+
+      for (const rule of created) {
+        expect(rule.ruleType).toBe(
+          NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+        );
+        expect(rule.incidentSeverityId).toBeUndefined();
+      }
+    });
+
+    test("an incident episode rule becomes one rule per INCIDENT severity in its project", async () => {
+      table = [nullIncidentEpisodeRule()];
+
+      await runMigration();
+
+      const created: Array<Model> = createdRules();
+
+      expect(created).toHaveLength(INCIDENT_SEVERITY_IDS.length);
+      expect(
+        created.map((rule: Model): string => {
+          return rule.incidentSeverityId!.toString();
+        }),
+      ).toEqual(toStrings(INCIDENT_SEVERITY_IDS));
+
+      for (const rule of created) {
+        expect(rule.ruleType).toBe(
+          NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+        );
+        expect(rule.alertSeverityId).toBeUndefined();
+      }
+    });
+
+    test("neither fan-out borrows the other kind's severity ids", async () => {
+      /*
+       * The repair's version of the crossing bug: an alert-episode row fanned
+       * out over incident severities would be just as unreachable as the NULL
+       * row it replaced, and the migration would then delete the evidence.
+       */
+      table = [nullAlertEpisodeRule(), nullIncidentEpisodeRule()];
+
+      await runMigration();
+
+      const alertIds: Array<string> = toStrings(ALERT_SEVERITY_IDS);
+      const incidentIds: Array<string> = toStrings(INCIDENT_SEVERITY_IDS);
+
+      for (const rule of createdRulesOfType(
+        NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+      )) {
+        expect(alertIds).toContain(rule.alertSeverityId!.toString());
+        expect(incidentIds).not.toContain(rule.alertSeverityId!.toString());
+      }
+
+      for (const rule of createdRulesOfType(
+        NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+      )) {
+        expect(incidentIds).toContain(rule.incidentSeverityId!.toString());
+        expect(alertIds).not.toContain(rule.incidentSeverityId!.toString());
+      }
+
+      expect(
+        createdRulesOfType(NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE),
+      ).toHaveLength(ALERT_SEVERITY_IDS.length);
+      expect(
+        createdRulesOfType(
+          NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+        ),
+      ).toHaveLength(INCIDENT_SEVERITY_IDS.length);
+    });
+
+    test("every replacement keeps the notification method the responder chose", async () => {
+      /*
+       * The whole point of a fan-out rather than a delete-and-reseed: a user
+       * who said "reach me on Telegram" must not silently become an e-mail
+       * user because the repair rebuilt from defaults.
+       */
+      table = [nullAlertEpisodeRule()];
+
+      await runMigration();
+
+      for (const rule of createdRules()) {
+        expect(rule.userTelegramId!.toString()).toBe(
+          TELEGRAM_METHOD_ID.toString(),
+        );
+
+        for (const column of ALL_METHOD_COLUMNS) {
+          if (column === "userTelegramId") {
+            continue;
+          }
+          expect(rule[column]).toBeUndefined();
+        }
+      }
+    });
+
+    test("every replacement keeps notifyAfterMinutes", async () => {
+      /*
+       * The delay is the other half of the responder's intent - it is what
+       * makes them the second line rather than the first. Resetting it to 0
+       * would page them immediately on every severity.
+       */
+      table = [nullAlertEpisodeRule({ notifyAfterMinutes: 15 })];
+
+      await runMigration();
+
+      for (const rule of createdRules()) {
+        expect(rule.notifyAfterMinutes).toBe(15);
+      }
+    });
+
+    test("notifyAfterMinutes defaults to 0 when the original carried none", async () => {
+      // The column is NOT NULL, so `undefined` would fail at insert time.
+      table = [nullAlertEpisodeRule({ notifyAfterMinutes: undefined })];
+
+      await runMigration();
+
+      expect(createdRules()).toHaveLength(ALERT_SEVERITY_IDS.length);
+      for (const rule of createdRules()) {
+        expect(rule.notifyAfterMinutes).toBe(0);
+      }
+    });
+
+    test("every replacement is stamped with the original's project and user", async () => {
+      table = [nullAlertEpisodeRule()];
+
+      await runMigration();
+
+      for (const rule of createdRules()) {
+        expect(rule.projectId!.toString()).toBe(PROJECT_A.toString());
+        expect(rule.userId!.toString()).toBe(USER_ID.toString());
+      }
+    });
+
+    test("replacements and deletions are internal, root-scoped writes", async () => {
+      table = [nullAlertEpisodeRule()];
+
+      await runMigration();
+
+      for (const call of ruleCreateSpy.mock.calls) {
+        expect((call[0] as CreateBy<Model>).props.isRoot).toBe(true);
+      }
+
+      for (const call of ruleDeleteSpy.mock.calls) {
+        expect((call[0] as { props: { isRoot: boolean } }).props.isRoot).toBe(
+          true,
+        );
+      }
+    });
+
+    test("each rule fans out over its OWN project's severities", async () => {
+      table = [
+        nullAlertEpisodeRule(),
+        nullAlertEpisodeRule({
+          id: PROJECT_B_NULL_ALERT_EPISODE_ID,
+          projectId: PROJECT_B,
+        }),
+      ];
+
+      await runMigration();
+
+      const projectARules: Array<Model> = createdRules().filter(
+        (rule: Model): boolean => {
+          return rule.projectId!.toString() === PROJECT_A.toString();
+        },
+      );
+      const projectBRules: Array<Model> = createdRules().filter(
+        (rule: Model): boolean => {
+          return rule.projectId!.toString() === PROJECT_B.toString();
+        },
+      );
+
+      expect(
+        projectARules.map((rule: Model): string => {
+          return rule.alertSeverityId!.toString();
+        }),
+      ).toEqual(toStrings(ALERT_SEVERITY_IDS));
+
+      expect(
+        projectBRules.map((rule: Model): string => {
+          return rule.alertSeverityId!.toString();
+        }),
+      ).toEqual([PROJECT_B_ALERT_SEV.toString()]);
+    });
+
+    test("a project's severity list is read once, not once per rule", async () => {
+      /*
+       * The fan-out is per rule but the severity list is per project, and a
+       * project with thousands of affected responders is the common shape of
+       * this bug. Two rules in one project must still be one severity read.
+       */
+      table = [
+        nullAlertEpisodeRule(),
+        nullAlertEpisodeRule({
+          id: PROJECT_B_NULL_ALERT_EPISODE_ID,
+          userId: OTHER_USER_ID,
+        }),
+      ];
+
+      await runMigration();
+
+      expect(alertSeveritiesSpy).toHaveBeenCalledTimes(1);
+      // No incident-episode rows at all, so that list is never needed.
+      expect(incidentSeveritiesSpy).not.toHaveBeenCalled();
+    });
+
+    test("the severity read is scoped to the project, root-scoped and bounded", async () => {
+      table = [nullAlertEpisodeRule()];
+
+      await runMigration();
+
+      const arg: {
+        query: { projectId: ObjectID };
+        props: { isRoot: boolean };
+        limit: number;
+        skip: number;
+      } = alertSeveritiesSpy.mock.calls[0][0] as {
+        query: { projectId: ObjectID };
+        props: { isRoot: boolean };
+        limit: number;
+        skip: number;
+      };
+
+      expect(arg.query.projectId.toString()).toBe(PROJECT_A.toString());
+      expect(arg.props.isRoot).toBe(true);
+      expect(arg.limit).toBe(LIMIT_PER_PROJECT);
+      expect(arg.skip).toBe(0);
+    });
+  });
+
+  describe("removing the NULL original", () => {
+    test("the NULL-severity row is deleted", async () => {
+      /*
+       * See the file header for why this row is removed rather than left: it
+       * can never be counted by the severity-filtered query AND it renders in
+       * no UI table, so the responder can neither be paged by it nor see it
+       * nor delete it themselves.
+       */
+      table = [nullAlertEpisodeRule()];
+
+      await runMigration();
+
+      expect(deletedRuleIds()).toEqual([NULL_ALERT_EPISODE_ID.toString()]);
+    });
+
+    test("the deletion happens only after every replacement exists", async () => {
+      /*
+       * Ordering is the migration's crash-safety story: a throw part-way
+       * through the fan-out must leave the original in place so the retry can
+       * finish the job. Deleting first would turn a crash into data loss.
+       */
+      table = [nullAlertEpisodeRule()];
+
+      await runMigration();
+
+      expect(events).toEqual([
+        `create:${ALERT_SEV_1.toString()}`,
+        `create:${ALERT_SEV_2.toString()}`,
+        `delete:${NULL_ALERT_EPISODE_ID.toString()}`,
+      ]);
+    });
+
+    test("the end state is severity-scoped rows only - no NULL row survives", async () => {
+      table = [nullAlertEpisodeRule(), nullIncidentEpisodeRule()];
+
+      await runMigration();
+
+      expect(table).toHaveLength(
+        ALERT_SEVERITY_IDS.length + INCIDENT_SEVERITY_IDS.length,
+      );
+
+      for (const rule of table) {
+        expect(
+          Boolean(rule.alertSeverityId) || Boolean(rule.incidentSeverityId),
+        ).toBe(true);
+      }
+    });
+  });
+
+  describe("rows it must not touch", () => {
+    test("an episode rule that already carries a severity is left exactly as it was", async () => {
+      /*
+       * Scoped to a different responder so it cannot double as one of the
+       * fan-out's own replacements - this asserts "not swept up", not "not
+       * duplicated".
+       */
+      const alreadyScoped: Model = makeRule({
+        id: SCOPED_ALERT_EPISODE_ID,
+        ruleType: NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+        projectId: PROJECT_A,
+        userId: OTHER_USER_ID,
+        notifyAfterMinutes: 30,
+        alertSeverityId: ALERT_SEV_1,
+        methodColumn: "userEmailId",
+        methodId: EMAIL_METHOD_ID,
+      });
+
+      table = [nullAlertEpisodeRule(), alreadyScoped];
+
+      await runMigration();
+
+      expect(deletedRuleIds()).toEqual([NULL_ALERT_EPISODE_ID.toString()]);
+      expect(tableIds()).toContain(SCOPED_ALERT_EPISODE_ID.toString());
+      expect(alreadyScoped.notifyAfterMinutes).toBe(30);
+      expect(alreadyScoped.alertSeverityId!.toString()).toBe(
+        ALERT_SEV_1.toString(),
+      );
+
+      for (const rule of createdRules()) {
+        expect(rule.userId!.toString()).toBe(USER_ID.toString());
+      }
+    });
+
+    test("NULL-severity rules of a NON-episode rule type are left alone", async () => {
+      const nonEpisodeRules: Array<Model> = [
+        makeRule({
+          id: NULL_ALERT_ON_CALL_ID,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_ALERT,
+          projectId: PROJECT_A,
+          userId: USER_ID,
+          notifyAfterMinutes: 5,
+          methodColumn: "userEmailId",
+          methodId: EMAIL_METHOD_ID,
+        }),
+        makeRule({
+          id: NULL_INCIDENT_ON_CALL_ID,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+          projectId: PROJECT_A,
+          userId: USER_ID,
+          notifyAfterMinutes: 5,
+          methodColumn: "userEmailId",
+          methodId: EMAIL_METHOD_ID,
+        }),
+      ];
+
+      table = [...nonEpisodeRules];
+
+      await runMigration();
+
+      expect(ruleCreateSpy).not.toHaveBeenCalled();
+      expect(ruleDeleteSpy).not.toHaveBeenCalled();
+      expect(tableIds()).toEqual([
+        NULL_ALERT_ON_CALL_ID.toString(),
+        NULL_INCIDENT_ON_CALL_ID.toString(),
+      ]);
+    });
+
+    test("WHEN_USER_GOES_ON_CALL / OFF_CALL rules are never fanned out", async () => {
+      /*
+       * The migration's most dangerous possible over-reach. These two rule
+       * types are severity-less BY DESIGN - they describe the responder's
+       * roster, not anything that fired - so a repair keyed on "episode-ish
+       * rule with no severity" that reached them would multiply every user's
+       * shift rules by the severity count and then delete the originals.
+       * Nothing about the result would look broken until people started
+       * getting one "you are on call" message per severity.
+       */
+      const shiftRules: Array<Model> = [
+        makeRule({
+          id: GOES_ON_CALL_ID,
+          ruleType: NotificationRuleType.WHEN_USER_GOES_ON_CALL,
+          projectId: PROJECT_A,
+          userId: USER_ID,
+          notifyAfterMinutes: 0,
+          methodColumn: "userEmailId",
+          methodId: EMAIL_METHOD_ID,
+        }),
+        makeRule({
+          id: GOES_OFF_CALL_ID,
+          ruleType: NotificationRuleType.WHEN_USER_GOES_OFF_CALL,
+          projectId: PROJECT_A,
+          userId: USER_ID,
+          notifyAfterMinutes: 0,
+          methodColumn: "userEmailId",
+          methodId: EMAIL_METHOD_ID,
+        }),
+      ];
+
+      table = [...shiftRules];
+
+      await runMigration();
+
+      expect(ruleCreateSpy).not.toHaveBeenCalled();
+      expect(ruleDeleteSpy).not.toHaveBeenCalled();
+      expect(tableIds()).toEqual([
+        GOES_ON_CALL_ID.toString(),
+        GOES_OFF_CALL_ID.toString(),
+      ]);
+    });
+
+    test("the migration only ever asks for the two episode rule types", async () => {
+      /*
+       * Stronger than "the shift rules survived": the shift rows are never
+       * even read, so no future edit to the row-level guards can reach them.
+       */
+      table = [
+        nullAlertEpisodeRule(),
+        makeRule({
+          id: GOES_ON_CALL_ID,
+          ruleType: NotificationRuleType.WHEN_USER_GOES_ON_CALL,
+          projectId: PROJECT_A,
+          userId: USER_ID,
+          notifyAfterMinutes: 0,
+          methodColumn: "userEmailId",
+          methodId: EMAIL_METHOD_ID,
+        }),
+      ];
+
+      await runMigration();
+
+      const queriedRuleTypes: Set<unknown> = new Set<unknown>(
+        findByCalls.map((call: RuleFindByArgs): unknown => {
+          return call.query["ruleType"];
+        }),
+      );
+
+      expect(queriedRuleTypes).toEqual(
+        new Set<NotificationRuleType>(EPISODE_RULE_TYPES),
+      );
+    });
+
+    test("a whole mixed table is repaired in exactly the two places it should be", async () => {
+      const shiftRule: Model = makeRule({
+        id: GOES_ON_CALL_ID,
+        ruleType: NotificationRuleType.WHEN_USER_GOES_ON_CALL,
+        projectId: PROJECT_A,
+        userId: USER_ID,
+        notifyAfterMinutes: 0,
+        methodColumn: "userEmailId",
+        methodId: EMAIL_METHOD_ID,
+      });
+
+      const scopedEpisodeRule: Model = makeRule({
+        id: SCOPED_ALERT_EPISODE_ID,
+        ruleType: NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+        projectId: PROJECT_A,
+        userId: OTHER_USER_ID,
+        notifyAfterMinutes: 0,
+        alertSeverityId: ALERT_SEV_1,
+        methodColumn: "userEmailId",
+        methodId: EMAIL_METHOD_ID,
+      });
+
+      const onCallRule: Model = makeRule({
+        id: NULL_ALERT_ON_CALL_ID,
+        ruleType: NotificationRuleType.ON_CALL_EXECUTED_ALERT,
+        projectId: PROJECT_A,
+        userId: USER_ID,
+        notifyAfterMinutes: 0,
+        methodColumn: "userEmailId",
+        methodId: EMAIL_METHOD_ID,
+      });
+
+      table = [
+        nullAlertEpisodeRule(),
+        nullIncidentEpisodeRule(),
+        scopedEpisodeRule,
+        onCallRule,
+        shiftRule,
+      ];
+
+      await runMigration();
+
+      expect(deletedRuleIds().sort()).toEqual(
+        [
+          NULL_ALERT_EPISODE_ID.toString(),
+          NULL_INCIDENT_EPISODE_ID.toString(),
+        ].sort(),
+      );
+
+      expect(createdRules()).toHaveLength(
+        ALERT_SEVERITY_IDS.length + INCIDENT_SEVERITY_IDS.length,
+      );
+
+      for (const survivor of [scopedEpisodeRule, onCallRule, shiftRule]) {
+        expect(tableIds()).toContain(survivor._id!);
+      }
+    });
+  });
+
+  describe("rows it deliberately leaves in place", () => {
+    test("a NULL row with no notification method is left alone, not deleted", async () => {
+      /*
+       * Every row createSingleRule wrote carries exactly one method, so a
+       * method-less row means something this migration does not understand.
+       * Fanning it out would write rules that deliver nothing (and that
+       * onBeforeCreate would reject); deleting it would destroy a row whose
+       * meaning is unknown. Leaving it is the only defensible option.
+       */
+      table = [
+        nullAlertEpisodeRule({
+          id: NO_METHOD_ID,
+          methodColumn: undefined,
+          methodId: undefined,
+        }),
+      ];
+
+      await runMigration();
+
+      expect(ruleCreateSpy).not.toHaveBeenCalled();
+      expect(ruleDeleteSpy).not.toHaveBeenCalled();
+      expect(tableIds()).toEqual([NO_METHOD_ID.toString()]);
+    });
+
+    test("a NULL row with no projectId is left alone, not deleted", async () => {
+      table = [
+        nullAlertEpisodeRule({ id: NO_PROJECT_ID, projectId: undefined }),
+      ];
+
+      await runMigration();
+
+      expect(ruleCreateSpy).not.toHaveBeenCalled();
+      expect(ruleDeleteSpy).not.toHaveBeenCalled();
+      expect(tableIds()).toEqual([NO_PROJECT_ID.toString()]);
+    });
+
+    test("a project with no severities of that kind keeps its row", async () => {
+      /*
+       * There is nothing to fan out to yet. Deleting would throw away the
+       * responder's chosen method and delay for a severity that simply has
+       * not been created; the row is equally unreachable either way, and the
+       * severity-creation backfill mirrors it forward when the project's
+       * first severity appears.
+       */
+      table = [
+        nullAlertEpisodeRule({
+          id: ORPHAN_PROJECT_NULL_EPISODE_ID,
+          projectId: PROJECT_NO_SEVERITIES,
+        }),
+      ];
+
+      await runMigration();
+
+      expect(ruleCreateSpy).not.toHaveBeenCalled();
+      expect(ruleDeleteSpy).not.toHaveBeenCalled();
+      expect(tableIds()).toEqual([ORPHAN_PROJECT_NULL_EPISODE_ID.toString()]);
+    });
+
+    test("left-in-place rows advance the paging cursor so the sweep still drains", async () => {
+      /*
+       * The subtle failure mode of "skip the row and move on": a row left in
+       * the table is returned again by the next page-zero query, so a cursor
+       * that did not count it would re-read the same page forever and the
+       * migration would never finish booting the pod. The skip offset is the
+       * running count of rows left behind, which is sound because `_id ASC`
+       * puts every already-seen row before every unseen one.
+       */
+      table = [
+        nullAlertEpisodeRule({
+          id: NO_METHOD_ID,
+          methodColumn: undefined,
+          methodId: undefined,
+        }),
+        nullAlertEpisodeRule({
+          id: NO_PROJECT_ID,
+          projectId: undefined,
+        }),
+        nullAlertEpisodeRule({
+          id: ORPHAN_PROJECT_NULL_EPISODE_ID,
+          projectId: PROJECT_NO_SEVERITIES,
+        }),
+        nullAlertEpisodeRule(),
+      ];
+
+      await runMigration();
+
+      const alertPassSkips: Array<number | undefined> = findByCallsForRuleType(
+        NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+      ).map((call: RuleFindByArgs): number | undefined => {
+        return call.skip;
+      });
+
+      /*
+       * One page returning all four rows, then a second read skipping the
+       * three that stayed - which finds nothing and ends the loop.
+       */
+      expect(alertPassSkips).toEqual([0, 3]);
+      expect(deletedRuleIds()).toEqual([NULL_ALERT_EPISODE_ID.toString()]);
+      expect(table).toHaveLength(3 + ALERT_SEVERITY_IDS.length);
+    });
+  });
+
+  describe("the query it runs", () => {
+    test("the alert pass filters on a NULL alertSeverityId", async () => {
+      table = [nullAlertEpisodeRule()];
+
+      await runMigration();
+
+      const call: RuleFindByArgs = findByCallsForRuleType(
+        NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+      )[0]!;
+
+      const operator: FindOperator<unknown> = call.query[
+        "alertSeverityId"
+      ] as FindOperator<unknown>;
+
+      const getSql: ((aliasPath: string) => string) | undefined =
+        operator.getSql;
+
+      expect(getSql).toBeDefined();
+      expect(getSql!("UserNotificationRule.alertSeverityId")).toBe(
+        "(UserNotificationRule.alertSeverityId IS NULL)",
+      );
+
+      /*
+       * The other severity column is not constrained at all: an alert-episode
+       * rule has no incident severity to speak of.
+       */
+      expect(Object.keys(call.query)).not.toContain("incidentSeverityId");
+    });
+
+    test("the incident pass filters on a NULL incidentSeverityId", async () => {
+      table = [nullIncidentEpisodeRule()];
+
+      await runMigration();
+
+      const call: RuleFindByArgs = findByCallsForRuleType(
+        NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+      )[0]!;
+
+      const getSql: ((aliasPath: string) => string) | undefined = (
+        call.query["incidentSeverityId"] as FindOperator<unknown>
+      ).getSql;
+
+      expect(getSql).toBeDefined();
+      expect(getSql!("UserNotificationRule.incidentSeverityId")).toBe(
+        "(UserNotificationRule.incidentSeverityId IS NULL)",
+      );
+      expect(Object.keys(call.query)).not.toContain("alertSeverityId");
+    });
+
+    test("the read selects everything the fan-out has to copy forward", async () => {
+      /*
+       * The select is load-bearing in a way that fails silently: an
+       * unselected `notifyAfterMinutes` arrives as undefined and is defaulted
+       * to 0, which would quietly reset every responder's escalation delay
+       * while the migration reported success. Same for the method FKs - a
+       * dropped column turns into "carries no notification method" and the
+       * row is skipped instead of repaired.
+       */
+      table = [nullAlertEpisodeRule()];
+
+      await runMigration();
+
+      const select: Record<string, boolean> = findByCallsForRuleType(
+        NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+      )[0]!.select!;
+
+      for (const key of [
+        "_id",
+        "projectId",
+        "userId",
+        "notifyAfterMinutes",
+        ...ALL_METHOD_COLUMNS,
+      ]) {
+        expect(select[key]).toBe(true);
+      }
+    });
+
+    test("the read is root-scoped", async () => {
+      table = [nullAlertEpisodeRule()];
+
+      await runMigration();
+
+      for (const call of findByCalls) {
+        expect(call.props!.isRoot).toBe(true);
+      }
+    });
+
+    test("the duplicate check is keyed on project, user, rule type, severity and method", async () => {
+      table = [nullAlertEpisodeRule()];
+
+      await runMigration();
+
+      const query: Record<string, unknown> = (
+        ruleFindOneBySpy.mock.calls[0][0] as {
+          query: Record<string, unknown>;
+        }
+      ).query;
+
+      expect((query["projectId"] as ObjectID).toString()).toBe(
+        PROJECT_A.toString(),
+      );
+      expect((query["userId"] as ObjectID).toString()).toBe(USER_ID.toString());
+      expect(query["ruleType"]).toBe(
+        NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+      );
+      expect((query["alertSeverityId"] as ObjectID).toString()).toBe(
+        ALERT_SEV_1.toString(),
+      );
+      expect((query["userTelegramId"] as ObjectID).toString()).toBe(
+        TELEGRAM_METHOD_ID.toString(),
+      );
+    });
+  });
+
+  describe("paging", () => {
+    test("it pages instead of loading every affected row at once", async () => {
+      /*
+       * Each row fans out into one INSERT per severity, so an unbounded read
+       * would turn the repair into one enormous write burst against a table
+       * the on-call path reads on every single page. 250 rows must arrive as
+       * bounded pages, not as one array.
+       */
+      alertSeveritiesByProject.set(PROJECT_A.toString(), [ALERT_SEV_1]);
+
+      /*
+       * Each row must belong to a DIFFERENT responder. The repair is idempotent
+       * by design: before writing, it asks findOneBy whether a rule already
+       * exists for (project, user, ruleType, severity, method). 250 rows that
+       * differ only by id describe the same rule 250 times, so the first one
+       * would be repaired and the other 249 correctly skipped as duplicates -
+       * which is the migration behaving properly, but it measures deduplication
+       * rather than paging and leaves this test asserting the wrong thing.
+       * Varying the user makes all 250 genuinely distinct repairs.
+       */
+      table = Array.from({ length: 250 }, (_unused: unknown, index: number) => {
+        return nullAlertEpisodeRule({
+          id: new ObjectID(
+            `eeeeeeee-0000-4000-8000-${String(index).padStart(12, "0")}`,
+          ),
+          userId: new ObjectID(
+            `dddddddd-0000-4000-8000-${String(index).padStart(12, "0")}`,
+          ),
+        });
+      });
+
+      await runMigration();
+
+      const alertPassCalls: Array<RuleFindByArgs> = findByCallsForRuleType(
+        NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+      );
+
+      // Three full-ish pages plus the empty read that ends the loop.
+      expect(alertPassCalls).toHaveLength(4);
+
+      for (const call of alertPassCalls) {
+        expect(call.limit).toBe(100);
+        expect(call.limit!).toBeLessThan(LIMIT_MAX);
+      }
+
+      expect(ruleCreateSpy).toHaveBeenCalledTimes(250);
+      expect(ruleDeleteSpy).toHaveBeenCalledTimes(250);
+      expect(table).toHaveLength(250);
+    });
+
+    test("every page is ordered by _id ascending, which is what makes the cursor sound", async () => {
+      table = [nullAlertEpisodeRule(), nullIncidentEpisodeRule()];
+
+      await runMigration();
+
+      expect(findByCalls.length).toBeGreaterThan(0);
+
+      for (const call of findByCalls) {
+        expect(call.sort).toEqual({ _id: SortOrder.Ascending });
+      }
+    });
+  });
+
+  describe("idempotence", () => {
+    test("a second run over a repaired table writes nothing", async () => {
+      table = [nullAlertEpisodeRule(), nullIncidentEpisodeRule()];
+
+      await runMigration();
+
+      const repairedIds: Array<string> = tableIds();
+
+      ruleCreateSpy.mockClear();
+      ruleDeleteSpy.mockClear();
+
+      await runMigration();
+
+      expect(ruleCreateSpy).not.toHaveBeenCalled();
+      expect(ruleDeleteSpy).not.toHaveBeenCalled();
+      expect(tableIds()).toEqual(repairedIds);
+    });
+
+    test("a half-finished pass is resumed without duplicating what it already wrote", async () => {
+      /*
+       * Restartability: the pod is killed after one replacement is inserted
+       * but before the original is deleted. The re-run must fill in only the
+       * missing severity - a duplicate here is a duplicate page.
+       */
+      const alreadyWritten: Model = makeRule({
+        id: SCOPED_ALERT_EPISODE_ID,
+        ruleType: NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+        projectId: PROJECT_A,
+        userId: USER_ID,
+        notifyAfterMinutes: 15,
+        alertSeverityId: ALERT_SEV_1,
+        methodColumn: "userTelegramId",
+        methodId: TELEGRAM_METHOD_ID,
+      });
+
+      table = [nullAlertEpisodeRule(), alreadyWritten];
+
+      await runMigration();
+
+      expect(createdRules()).toHaveLength(1);
+      expect(createdRules()[0]!.alertSeverityId!.toString()).toBe(
+        ALERT_SEV_2.toString(),
+      );
+      expect(deletedRuleIds()).toEqual([NULL_ALERT_EPISODE_ID.toString()]);
+      expect(table).toHaveLength(2);
+    });
+
+    test("running it twice does not double a responder's rules", async () => {
+      table = [nullAlertEpisodeRule()];
+
+      await runMigration();
+      await runMigration();
+
+      expect(table).toHaveLength(ALERT_SEVERITY_IDS.length);
+      expect(
+        table
+          .map((rule: Model): string => {
+            return rule.alertSeverityId!.toString();
+          })
+          .sort(),
+      ).toEqual(toStrings(ALERT_SEVERITY_IDS).sort());
+    });
+  });
+
+  describe("how it is wired in", () => {
+    test("rollback is a deliberate no-op rather than the base class's throw", async () => {
+      /*
+       * DataMigrationBase.rollback throws NotImplementedException. This one
+       * overrides it to do nothing on purpose: recreating the NULL originals
+       * would restore rows that page nobody and that the responder can
+       * neither see nor delete - the exact defect being removed.
+       */
+      await expect(
+        new RepairEpisodeNotificationRuleSeverity().rollback(),
+      ).resolves.toBeUndefined();
+    });
+
+    test("its recorded name matches the class name", () => {
+      /*
+       * The name is what the runner writes to the migrations table, so it is
+       * the identity that decides whether this migration ever runs again.
+       */
+      expect(new RepairEpisodeNotificationRuleSeverity().name).toBe(
+        "RepairEpisodeNotificationRuleSeverity",
+      );
+    });
+
+    test("it is registered in the DataMigrations list", () => {
+      /*
+       * Source-level pin. Importing the list itself would drag in the whole
+       * ClickHouse migration graph, so the registration - which is two edits,
+       * an import and an array entry, and easy to half-do - is checked as
+       * text instead. An unregistered migration is a repair that never runs.
+       */
+      const indexSource: string = fs.readFileSync(
+        path.join(
+          __dirname,
+          "../../../../App/FeatureSet/Workers/DataMigrations/Index.ts",
+        ),
+        "utf8",
+      );
+
+      expect(indexSource).toContain(
+        'import RepairEpisodeNotificationRuleSeverity from "./RepairEpisodeNotificationRuleSeverity";',
+      );
+      expect(indexSource).toContain(
+        "new RepairEpisodeNotificationRuleSeverity()",
+      );
+    });
+  });
+});

--- a/Common/Tests/Server/Services/NotificationChannelEventCoverage.test.ts
+++ b/Common/Tests/Server/Services/NotificationChannelEventCoverage.test.ts
@@ -1,0 +1,1728 @@
+import UserNotificationRuleService from "../../../Server/Services/UserNotificationRuleService";
+import UserOnCallLogService from "../../../Server/Services/UserOnCallLogService";
+import UserOnCallLogTimelineService from "../../../Server/Services/UserOnCallLogTimelineService";
+import ProjectCallSMSConfigService from "../../../Server/Services/ProjectCallSMSConfigService";
+import IncidentService from "../../../Server/Services/IncidentService";
+import AlertService from "../../../Server/Services/AlertService";
+import AlertEpisodeService from "../../../Server/Services/AlertEpisodeService";
+import IncidentEpisodeService from "../../../Server/Services/IncidentEpisodeService";
+import MailService from "../../../Server/Services/MailService";
+import SmsService from "../../../Server/Services/SmsService";
+import CallService from "../../../Server/Services/CallService";
+import WhatsAppService from "../../../Server/Services/WhatsAppService";
+import TelegramService from "../../../Server/Services/TelegramService";
+import WebhookService from "../../../Server/Services/WebhookService";
+import PushNotificationService from "../../../Server/Services/PushNotificationService";
+import logger from "../../../Server/Utils/Logger";
+import Alert from "../../../Models/DatabaseModels/Alert";
+import AlertEpisode from "../../../Models/DatabaseModels/AlertEpisode";
+import Incident from "../../../Models/DatabaseModels/Incident";
+import IncidentEpisode from "../../../Models/DatabaseModels/IncidentEpisode";
+import UserNotificationRule from "../../../Models/DatabaseModels/UserNotificationRule";
+import UserOnCallLogTimeline from "../../../Models/DatabaseModels/UserOnCallLogTimeline";
+import URL from "../../../Types/API/URL";
+import Email from "../../../Types/Email";
+import Phone from "../../../Types/Phone";
+import ObjectID from "../../../Types/ObjectID";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import PushDeviceType from "../../../Types/PushNotification/PushDeviceType";
+import UserNotificationEventType from "../../../Types/UserNotification/UserNotificationEventType";
+import UserNotificationStatus from "../../../Types/UserNotification/UserNotificationStatus";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * THE SHAPE OF THE BUG THIS FILE EXISTS TO CATCH.
+ *
+ * `deliverNotificationForRule` is seven independent channel blocks stacked one
+ * after another - email, SMS, WhatsApp, Telegram, webhook, call, push - and each
+ * block is itself a stack of `if (eventType === X && entity)` branches, one per
+ * UserNotificationEventType. That is a 7 x 4 grid written out by hand, twenty
+ * eight times, with no compiler anywhere insisting the grid is full.
+ *
+ * It was not full. Gap F: `IncidentEpisodeCreated` was wired into the webhook
+ * and push blocks and nowhere else, so a responder whose rule pointed at their
+ * email, phone, WhatsApp, Telegram or a voice call was told NOTHING when an
+ * incident episode paged them. Not a failed send - no send at all, and no error
+ * row either. Every gate the delivery path has (is the method verified? did the
+ * entity load? did the send throw?) passed. The page simply evaporated between
+ * the last matching `if` and the end of the function, and the on-call log went
+ * on believing the human had been contacted and had chosen not to acknowledge.
+ *
+ * A test that checked "email works" and "SMS works" would not have caught it,
+ * because email and SMS did work - for three of the four event types. Only the
+ * CARTESIAN PRODUCT catches a hole in a grid. So this file is table-driven on
+ * purpose: it builds {seven channels} x {every member of UserNotificationEventType}
+ * and asserts every single cell hands a page to its provider and writes a
+ * timeline row. Adding an eighth channel or a fifth event type without filling
+ * in the new row or column fails here, loudly, in the cell that is missing.
+ *
+ * Two canaries keep the table honest, because a table that quietly stops
+ * covering the thing it is a table OF is worse than no table:
+ *   - the event axis is checked against UserNotificationEventType itself, so a
+ *     new enum member fails until the matrix is extended;
+ *   - the channel axis is checked against getContactableChannelNames, which is
+ *     the production code's own answer to "what can we reach this user on".
+ *
+ * Beyond the grid, three behaviours the grid depends on are pinned:
+ *
+ *   1. THE FELL-THROUGH GUARD. Phase 1 added a backstop after the seven blocks:
+ *      if the rule could contact somebody and no branch claimed the event, write
+ *      an Error row naming the event type and the channels. That converts the
+ *      next Gap F from a silent hole into a visible failure - but only if it
+ *      actually fires, and only if it builds a FRESH timeline row (the one the
+ *      blocks share carries an _id after its first create, so reusing it would
+ *      UPDATE the earlier row instead of recording the miss).
+ *
+ *   2. THE UNVERIFIED PATH. An unverified method must produce exactly one Error
+ *      row saying so and must not send. Both halves matter: no row is a silent
+ *      drop, and a send would page a number nobody proved they own.
+ *
+ *   3. THE ROW COMES BEFORE THE BODY. The acknowledge deep-link is derived from
+ *      the timeline row's id, so the row has to be created BEFORE the message is
+ *      generated (PHASE1_SPEC constraint 6). Hoisting template generation out of
+ *      the per-attempt path - an obvious-looking optimisation, since the body is
+ *      identical for every recipient - would ship a page whose "acknowledge"
+ *      button points at nothing. Every generator call is therefore asserted to
+ *      happen after the create AND to receive that create's id.
+ *
+ * Nothing here touches a database or renders a template: the senders, the
+ * generators, the entity lookups and the timeline writes are all stubbed, so
+ * what is under test is purely which branch runs and in what order.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const RULE_ID: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+const LOG_ID: ObjectID = new ObjectID("33333333-3333-4333-8333-333333333333");
+const USER_ID: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+const METHOD_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+const TIMELINE_ID: ObjectID = new ObjectID(
+  "66666666-6666-4666-8666-666666666666",
+);
+const POLICY_ID: ObjectID = new ObjectID(
+  "77777777-7777-4777-8777-777777777777",
+);
+const INCIDENT_ID: ObjectID = new ObjectID(
+  "88888888-8888-4888-8888-888888888888",
+);
+const ALERT_ID: ObjectID = new ObjectID("99999999-9999-4999-8999-999999999999");
+const ALERT_EPISODE_ID: ObjectID = new ObjectID(
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+const INCIDENT_EPISODE_ID: ObjectID = new ObjectID(
+  "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+);
+
+const RESPONDER_EMAIL: string = "responder@company.com";
+const RESPONDER_PHONE: string = "+11234567890";
+const TELEGRAM_CHAT_ID: string = "987654321";
+const WEBHOOK_URL: string = "https://hooks.example.com/on-call";
+const DEVICE_TOKEN: string = "device-token";
+const TELEGRAM_BODY: string = "<b>telegram body</b>";
+
+/* The options bag `executeNotificationRuleItem` takes, without re-declaring it. */
+type ExecuteOptions = Parameters<
+  typeof UserNotificationRuleService.executeNotificationRuleItem
+>[1];
+
+/*
+ * The service mutates ONE UserOnCallLogTimeline instance and hands that same
+ * instance to create() over and over, so mock.calls all alias its final state.
+ * Snapshot the fields at call time instead. The instance itself is kept
+ * alongside, because "did the guard build a fresh row?" is a question about
+ * object identity and cannot be answered from a snapshot.
+ */
+interface TimelineRow {
+  status: UserNotificationStatus | undefined;
+  statusMessage: string | undefined;
+  userId: ObjectID | undefined;
+  userNotificationRuleId: ObjectID | undefined;
+  userNotificationLogId: ObjectID | undefined;
+  projectId: ObjectID | undefined;
+  userNotificationEventType: UserNotificationEventType | undefined;
+  methodIds: Record<string, ObjectID | undefined>;
+}
+
+/* Everything the second argument of every sender has in common. */
+interface SenderOptions {
+  projectId?: ObjectID | undefined;
+  userId?: ObjectID | undefined;
+  userOnCallLogTimelineId?: ObjectID | undefined;
+  alertEpisodeId?: ObjectID | undefined;
+  incidentEpisodeId?: ObjectID | undefined;
+}
+
+interface DeliverySpies {
+  claim: jest.SpyInstance;
+  findRule: jest.SpyInstance;
+  twilio: jest.SpyInstance;
+  timelineCreate: jest.SpyInstance;
+  timelineUpdate: jest.SpyInstance;
+  incidentFind: jest.SpyInstance;
+  alertFind: jest.SpyInstance;
+  alertEpisodeFind: jest.SpyInstance;
+  incidentEpisodeFind: jest.SpyInstance;
+  incidentLink: jest.SpyInstance;
+  alertLink: jest.SpyInstance;
+  alertEpisodeLink: jest.SpyInstance;
+  incidentEpisodeLink: jest.SpyInstance;
+  mail: jest.SpyInstance;
+  sms: jest.SpyInstance;
+  call: jest.SpyInstance;
+  whatsApp: jest.SpyInstance;
+  telegram: jest.SpyInstance;
+  webhook: jest.SpyInstance;
+  push: jest.SpyInstance;
+  loggerError: jest.SpyInstance;
+}
+
+let spies: DeliverySpies;
+let generators: Record<string, jest.SpyInstance>;
+let timelineRows: Array<TimelineRow>;
+let timelineInstances: Array<UserOnCallLogTimeline>;
+
+function flushMicrotasks(): Promise<void> {
+  return Promise.resolve()
+    .then((): Promise<void> => {
+      return Promise.resolve();
+    })
+    .then((): Promise<void> => {
+      return Promise.resolve();
+    });
+}
+
+function ruleItem(
+  channels: Record<string, unknown> = {},
+): UserNotificationRule {
+  return {
+    id: RULE_ID,
+    _id: RULE_ID.toString(),
+    userId: USER_ID,
+    ...channels,
+  } as unknown as UserNotificationRule;
+}
+
+function fakeIncident(): Incident {
+  return {
+    id: INCIDENT_ID,
+    projectId: PROJECT_ID,
+    title: "Checkout is down",
+    description: "Checkout returns 500 for every request.",
+    incidentNumber: 42,
+    incidentNumberWithPrefix: "INC-42",
+    project: { name: "Acme" },
+    incidentSeverity: { name: "Sev1" },
+    currentIncidentState: { name: "Created" },
+  } as unknown as Incident;
+}
+
+function fakeAlert(): Alert {
+  return {
+    id: ALERT_ID,
+    projectId: PROJECT_ID,
+    title: "Disk almost full",
+    description: "94% used on node-3.",
+    alertNumber: 7,
+    alertNumberWithPrefix: "ALR-7",
+    project: { name: "Acme" },
+    alertSeverity: { name: "Sev2" },
+    currentAlertState: { name: "Created" },
+  } as unknown as Alert;
+}
+
+function fakeAlertEpisode(): AlertEpisode {
+  return {
+    id: ALERT_EPISODE_ID,
+    projectId: PROJECT_ID,
+    title: "Node-3 is flapping",
+    description: "Six alerts in ten minutes.",
+    episodeNumber: 3,
+    episodeNumberWithPrefix: "AEP-3",
+    project: { name: "Acme" },
+    alertSeverity: { name: "Sev2" },
+    currentAlertState: { name: "Created" },
+  } as unknown as AlertEpisode;
+}
+
+function fakeIncidentEpisode(): IncidentEpisode {
+  return {
+    id: INCIDENT_EPISODE_ID,
+    projectId: PROJECT_ID,
+    title: "Checkout degradation",
+    description: "Three incidents share a root cause.",
+    episodeNumber: 9,
+    episodeNumberWithPrefix: "IEP-9",
+    project: { name: "Acme" },
+    incidentSeverity: { name: "Sev1" },
+    currentIncidentState: { name: "Created" },
+  } as unknown as IncidentEpisode;
+}
+
+/*
+ * One channel of the matrix: how to make a rule that can only reach the user
+ * that way, which provider must end up holding the page, and how the timeline
+ * row and the generator are supposed to be stamped.
+ */
+interface ChannelSpec {
+  /* The display name getContactableChannelNames gives this channel. */
+  channel: string;
+  /* A rule relation, verified, so the channel's send gate opens. */
+  verifiedMethod: () => Record<string, unknown>;
+  /* The same relation unverified. Null for Webhook, which has no such concept. */
+  unverifiedMethod: (() => Record<string, unknown>) | null;
+  /* Fragment of the Sending row this channel writes before handing over. */
+  sendingMessage: string;
+  /* Fragment of the Error row an unverified method must produce. */
+  unverifiedMessage: string;
+  /* The provider function the block must call. Read lazily: spies are per-test. */
+  sender: () => jest.SpyInstance;
+  /* The timeline column that attributes the row to this method. */
+  timelineMethodIdField: string;
+  /*
+   * The generator family that renders the body, plus where the timeline row id
+   * sits in its arguments. Null for Webhook and Push, which build their payload
+   * inline rather than through a generator.
+   */
+  generatorPrefix: string | null;
+  generatorTimelineIdArgIndex: number;
+}
+
+const CHANNEL_SPECS: Record<string, ChannelSpec> = {
+  Email: {
+    channel: "Email",
+    verifiedMethod: (): Record<string, unknown> => {
+      return {
+        userEmail: {
+          id: METHOD_ID,
+          email: new Email(RESPONDER_EMAIL),
+          isVerified: true,
+        },
+      };
+    },
+    unverifiedMethod: (): Record<string, unknown> => {
+      return {
+        userEmail: {
+          id: METHOD_ID,
+          email: new Email(RESPONDER_EMAIL),
+          isVerified: false,
+        },
+      };
+    },
+    sendingMessage: "Sending email to",
+    unverifiedMessage: "Email notification not sent because email",
+    sender: (): jest.SpyInstance => {
+      return spies.mail;
+    },
+    timelineMethodIdField: "userEmailId",
+    generatorPrefix: "generateEmailTemplateFor",
+    generatorTimelineIdArgIndex: 2,
+  },
+  SMS: {
+    channel: "SMS",
+    verifiedMethod: (): Record<string, unknown> => {
+      return {
+        userSms: {
+          id: METHOD_ID,
+          phone: new Phone(RESPONDER_PHONE),
+          isVerified: true,
+        },
+      };
+    },
+    unverifiedMethod: (): Record<string, unknown> => {
+      return {
+        userSms: {
+          id: METHOD_ID,
+          phone: new Phone(RESPONDER_PHONE),
+          isVerified: false,
+        },
+      };
+    },
+    sendingMessage: "Sending SMS to",
+    unverifiedMessage: "SMS not sent because phone",
+    sender: (): jest.SpyInstance => {
+      return spies.sms;
+    },
+    timelineMethodIdField: "userSmsId",
+    generatorPrefix: "generateSmsTemplateFor",
+    generatorTimelineIdArgIndex: 2,
+  },
+  WhatsApp: {
+    channel: "WhatsApp",
+    verifiedMethod: (): Record<string, unknown> => {
+      return {
+        userWhatsApp: {
+          id: METHOD_ID,
+          phone: new Phone(RESPONDER_PHONE),
+          isVerified: true,
+        },
+      };
+    },
+    unverifiedMethod: (): Record<string, unknown> => {
+      return {
+        userWhatsApp: {
+          id: METHOD_ID,
+          phone: new Phone(RESPONDER_PHONE),
+          isVerified: false,
+        },
+      };
+    },
+    sendingMessage: "Sending WhatsApp message to",
+    unverifiedMessage: "WhatsApp message not sent because phone",
+    sender: (): jest.SpyInstance => {
+      return spies.whatsApp;
+    },
+    timelineMethodIdField: "userWhatsAppId",
+    generatorPrefix: "generateWhatsAppTemplateFor",
+    generatorTimelineIdArgIndex: 2,
+  },
+  Telegram: {
+    channel: "Telegram",
+    verifiedMethod: (): Record<string, unknown> => {
+      return {
+        userTelegram: {
+          id: METHOD_ID,
+          telegramChatId: TELEGRAM_CHAT_ID,
+          isVerified: true,
+        },
+      };
+    },
+    unverifiedMethod: (): Record<string, unknown> => {
+      return {
+        userTelegram: {
+          id: METHOD_ID,
+          telegramChatId: TELEGRAM_CHAT_ID,
+          isVerified: false,
+        },
+      };
+    },
+    sendingMessage: "Sending Telegram message",
+    unverifiedMessage: "Telegram message not sent because",
+    sender: (): jest.SpyInstance => {
+      return spies.telegram;
+    },
+    timelineMethodIdField: "userTelegramId",
+    /* Telegram's generator takes (entity, timelineId) - no `to` argument. */
+    generatorPrefix: "generateTelegramBodyFor",
+    generatorTimelineIdArgIndex: 1,
+  },
+  Webhook: {
+    channel: "Webhook",
+    verifiedMethod: (): Record<string, unknown> => {
+      return {
+        userWebhook: {
+          id: METHOD_ID,
+          webhookUrl: WEBHOOK_URL,
+          name: "Pager bridge",
+          secret: "s3cr3t",
+        },
+      };
+    },
+    /*
+     * UserWebhook has no isVerified column at all, so there is no unverified
+     * shape to build and no "not verified" row to expect.
+     */
+    unverifiedMethod: null,
+    sendingMessage: "Sending webhook to",
+    unverifiedMessage: "",
+    sender: (): jest.SpyInstance => {
+      return spies.webhook;
+    },
+    timelineMethodIdField: "userWebhookId",
+    generatorPrefix: null,
+    generatorTimelineIdArgIndex: -1,
+  },
+  Call: {
+    channel: "Call",
+    verifiedMethod: (): Record<string, unknown> => {
+      return {
+        userCall: {
+          id: METHOD_ID,
+          phone: new Phone(RESPONDER_PHONE),
+          isVerified: true,
+        },
+      };
+    },
+    unverifiedMethod: (): Record<string, unknown> => {
+      return {
+        userCall: {
+          id: METHOD_ID,
+          phone: new Phone(RESPONDER_PHONE),
+          isVerified: false,
+        },
+      };
+    },
+    sendingMessage: "Making a call to",
+    unverifiedMessage: "Call not sent because phone",
+    sender: (): jest.SpyInstance => {
+      return spies.call;
+    },
+    timelineMethodIdField: "userCallId",
+    generatorPrefix: "generateCallTemplateFor",
+    generatorTimelineIdArgIndex: 2,
+  },
+  Push: {
+    channel: "Push",
+    verifiedMethod: (): Record<string, unknown> => {
+      return {
+        userPush: {
+          id: METHOD_ID,
+          deviceToken: DEVICE_TOKEN,
+          deviceType: PushDeviceType.iOS,
+          isVerified: true,
+        },
+      };
+    },
+    unverifiedMethod: (): Record<string, unknown> => {
+      return {
+        userPush: {
+          id: METHOD_ID,
+          deviceToken: DEVICE_TOKEN,
+          deviceType: PushDeviceType.iOS,
+          isVerified: false,
+        },
+      };
+    },
+    sendingMessage: "Sending push notification",
+    unverifiedMessage: "Push notification not sent because device is not",
+    sender: (): jest.SpyInstance => {
+      return spies.push;
+    },
+    timelineMethodIdField: "userPushId",
+    /* Push builds its payload through PushNotificationUtil, not a generator. */
+    generatorPrefix: null,
+    generatorTimelineIdArgIndex: -1,
+  },
+};
+
+/*
+ * One event type of the matrix: the options that make the delivery path resolve
+ * its triggering entity, and the names the channel blocks derive from it.
+ */
+interface EventSpec {
+  eventType: UserNotificationEventType;
+  makeOptions: () => ExecuteOptions;
+  /* Point this event's finder at a real entity; the other three stay null. */
+  arm: () => void;
+  /* Appended to a channel's generatorPrefix to name the generator for this cell. */
+  generatorSuffix: string;
+  /* The eventType string the webhook block puts on the wire. */
+  webhookEventType: string;
+}
+
+const EVENT_SPECS: Record<string, EventSpec> = {
+  IncidentCreated: {
+    eventType: UserNotificationEventType.IncidentCreated,
+    makeOptions: (): ExecuteOptions => {
+      return {
+        projectId: PROJECT_ID,
+        userNotificationEventType: UserNotificationEventType.IncidentCreated,
+        triggeredByIncidentId: INCIDENT_ID,
+        onCallPolicyId: POLICY_ID,
+        userNotificationLogId: LOG_ID,
+      };
+    },
+    arm: (): void => {
+      spies.incidentFind.mockResolvedValue(fakeIncident() as never);
+    },
+    generatorSuffix: "IncidentCreated",
+    webhookEventType: "on-call.incident.created",
+  },
+  AlertCreated: {
+    eventType: UserNotificationEventType.AlertCreated,
+    makeOptions: (): ExecuteOptions => {
+      return {
+        projectId: PROJECT_ID,
+        userNotificationEventType: UserNotificationEventType.AlertCreated,
+        triggeredByAlertId: ALERT_ID,
+        onCallPolicyId: POLICY_ID,
+        userNotificationLogId: LOG_ID,
+      };
+    },
+    arm: (): void => {
+      spies.alertFind.mockResolvedValue(fakeAlert() as never);
+    },
+    generatorSuffix: "AlertCreated",
+    webhookEventType: "on-call.alert.created",
+  },
+  AlertEpisodeCreated: {
+    eventType: UserNotificationEventType.AlertEpisodeCreated,
+    makeOptions: (): ExecuteOptions => {
+      return {
+        projectId: PROJECT_ID,
+        userNotificationEventType:
+          UserNotificationEventType.AlertEpisodeCreated,
+        triggeredByAlertEpisodeId: ALERT_EPISODE_ID,
+        onCallPolicyId: POLICY_ID,
+        userNotificationLogId: LOG_ID,
+      };
+    },
+    arm: (): void => {
+      spies.alertEpisodeFind.mockResolvedValue(fakeAlertEpisode() as never);
+    },
+    generatorSuffix: "AlertEpisodeCreated",
+    webhookEventType: "on-call.alertEpisode.created",
+  },
+  IncidentEpisodeCreated: {
+    eventType: UserNotificationEventType.IncidentEpisodeCreated,
+    makeOptions: (): ExecuteOptions => {
+      return {
+        projectId: PROJECT_ID,
+        userNotificationEventType:
+          UserNotificationEventType.IncidentEpisodeCreated,
+        triggeredByIncidentEpisodeId: INCIDENT_EPISODE_ID,
+        onCallPolicyId: POLICY_ID,
+        userNotificationLogId: LOG_ID,
+      };
+    },
+    arm: (): void => {
+      spies.incidentEpisodeFind.mockResolvedValue(
+        fakeIncidentEpisode() as never,
+      );
+    },
+    generatorSuffix: "IncidentEpisodeCreated",
+    webhookEventType: "on-call.incidentEpisode.created",
+  },
+};
+
+/*
+ * The two axes. Both are asserted against the production code below, so they
+ * cannot silently fall behind a newly added channel or event type.
+ */
+const CHANNEL_NAMES: Array<string> = [
+  "Email",
+  "SMS",
+  "WhatsApp",
+  "Telegram",
+  "Webhook",
+  "Call",
+  "Push",
+];
+
+const EVENT_NAMES: Array<string> = [
+  "IncidentCreated",
+  "AlertCreated",
+  "AlertEpisodeCreated",
+  "IncidentEpisodeCreated",
+];
+
+/* Channels whose body comes from a generator that takes the timeline row id. */
+const GENERATOR_CHANNEL_NAMES: Array<string> = [
+  "Email",
+  "SMS",
+  "WhatsApp",
+  "Telegram",
+  "Call",
+];
+
+/* Channels that have a verification concept at all (everything but Webhook). */
+const VERIFIABLE_CHANNEL_NAMES: Array<string> = [
+  "Email",
+  "SMS",
+  "WhatsApp",
+  "Telegram",
+  "Call",
+  "Push",
+];
+
+function buildMatrix(channelNames: Array<string>): Array<[string, string]> {
+  const rows: Array<[string, string]> = [];
+
+  for (const channelName of channelNames) {
+    for (const eventName of EVENT_NAMES) {
+      rows.push([channelName, eventName]);
+    }
+  }
+
+  return rows;
+}
+
+const FULL_MATRIX: Array<[string, string]> = buildMatrix(CHANNEL_NAMES);
+const GENERATOR_MATRIX: Array<[string, string]> = buildMatrix(
+  GENERATOR_CHANNEL_NAMES,
+);
+const UNVERIFIED_MATRIX: Array<[string, string]> = buildMatrix(
+  VERIFIABLE_CHANNEL_NAMES,
+);
+
+function channelSpec(channelName: string): ChannelSpec {
+  return CHANNEL_SPECS[channelName]!;
+}
+
+function eventSpec(eventName: string): EventSpec {
+  return EVENT_SPECS[eventName]!;
+}
+
+/* Every verified method at once - used to interrogate the channel census. */
+function everyVerifiedMethod(): Record<string, unknown> {
+  const methods: Record<string, unknown> = {};
+
+  for (const channelName of CHANNEL_NAMES) {
+    Object.assign(methods, channelSpec(channelName).verifiedMethod());
+  }
+
+  return methods;
+}
+
+/*
+ * getContactableChannelNames is private. Call it through a cast rather than
+ * widening the service's public surface, as the neighbouring characterisation
+ * tests do for protected hooks.
+ */
+function contactableChannelNames(rule: UserNotificationRule): Array<string> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (UserNotificationRuleService as any).getContactableChannelNames(rule);
+}
+
+function everySender(): Array<jest.SpyInstance> {
+  return [
+    spies.mail,
+    spies.sms,
+    spies.call,
+    spies.whatsApp,
+    spies.telegram,
+    spies.webhook,
+    spies.push,
+  ];
+}
+
+function otherSenders(channel: ChannelSpec): Array<jest.SpyInstance> {
+  const own: jest.SpyInstance = channel.sender();
+
+  return everySender().filter((sender: jest.SpyInstance): boolean => {
+    return sender !== own;
+  });
+}
+
+/* The options bag - always the second argument - that a sender was handed. */
+function senderOptions(sender: jest.SpyInstance): SenderOptions {
+  return sender.mock.calls[0][1] as SenderOptions;
+}
+
+describe("UserNotificationRuleService channel x event coverage", () => {
+  beforeEach(() => {
+    timelineRows = [];
+    timelineInstances = [];
+
+    const timelineCreate: jest.SpyInstance = jest.spyOn(
+      UserOnCallLogTimelineService,
+      "create",
+    );
+    timelineCreate.mockImplementation(
+      (createBy: unknown): Promise<UserOnCallLogTimeline> => {
+        const data: UserOnCallLogTimeline = (
+          createBy as { data: UserOnCallLogTimeline }
+        ).data;
+
+        timelineInstances.push(data);
+        timelineRows.push({
+          status: data.status,
+          statusMessage: data.statusMessage,
+          userId: data.userId,
+          userNotificationRuleId: data.userNotificationRuleId,
+          userNotificationLogId: data.userNotificationLogId,
+          projectId: data.projectId,
+          userNotificationEventType: data.userNotificationEventType,
+          methodIds: {
+            userEmailId: data.userEmailId,
+            userSmsId: data.userSmsId,
+            userCallId: data.userCallId,
+            userWhatsAppId: data.userWhatsAppId,
+            userTelegramId: data.userTelegramId,
+            userPushId: data.userPushId,
+            userWebhookId: data.userWebhookId,
+          },
+        });
+
+        return Promise.resolve({
+          id: TIMELINE_ID,
+        } as unknown as UserOnCallLogTimeline);
+      },
+    );
+
+    spies = {
+      /*
+       * claimNotificationRuleExecution issues raw SQL through the repository
+       * manager and swallows failures into a non-atomic fallback, so it is
+       * stubbed whole rather than at the database boundary.
+       */
+      claim: jest
+        .spyOn(UserOnCallLogService, "claimNotificationRuleExecution")
+        .mockResolvedValue(true as never),
+      findRule: jest
+        .spyOn(UserNotificationRuleService, "findOneById")
+        .mockResolvedValue(ruleItem() as never),
+      twilio: jest
+        .spyOn(ProjectCallSMSConfigService, "getProjectDefaultTwilioConfig")
+        .mockResolvedValue(undefined as never),
+      timelineCreate: timelineCreate,
+      timelineUpdate: jest
+        .spyOn(UserOnCallLogTimelineService, "updateOneById")
+        .mockResolvedValue(undefined as never),
+      /*
+       * All four finders start at null. Each test arms exactly the one its
+       * event type resolves through, which is also what proves the other three
+       * are never consulted.
+       */
+      incidentFind: jest
+        .spyOn(IncidentService, "findOneById")
+        .mockResolvedValue(null as never),
+      alertFind: jest
+        .spyOn(AlertService, "findOneById")
+        .mockResolvedValue(null as never),
+      alertEpisodeFind: jest
+        .spyOn(AlertEpisodeService, "findOneById")
+        .mockResolvedValue(null as never),
+      incidentEpisodeFind: jest
+        .spyOn(IncidentEpisodeService, "findOneById")
+        .mockResolvedValue(null as never),
+      /* The push blocks build a dashboard deep-link before sending. */
+      incidentLink: jest
+        .spyOn(IncidentService, "getIncidentLinkInDashboard")
+        .mockResolvedValue(
+          URL.fromString("https://oneuptime.test/incident") as never,
+        ),
+      alertLink: jest
+        .spyOn(AlertService, "getAlertLinkInDashboard")
+        .mockResolvedValue(
+          URL.fromString("https://oneuptime.test/alert") as never,
+        ),
+      alertEpisodeLink: jest
+        .spyOn(AlertEpisodeService, "getEpisodeLinkInDashboard")
+        .mockResolvedValue(
+          URL.fromString("https://oneuptime.test/alert-episode") as never,
+        ),
+      incidentEpisodeLink: jest
+        .spyOn(IncidentEpisodeService, "getEpisodeLinkInDashboard")
+        .mockResolvedValue(
+          URL.fromString("https://oneuptime.test/incident-episode") as never,
+        ),
+      mail: jest
+        .spyOn(MailService, "sendMail")
+        .mockResolvedValue(undefined as never),
+      sms: jest
+        .spyOn(SmsService, "sendSms")
+        .mockResolvedValue(undefined as never),
+      call: jest
+        .spyOn(CallService, "makeCall")
+        .mockResolvedValue(undefined as never),
+      whatsApp: jest
+        .spyOn(WhatsAppService, "sendWhatsAppMessage")
+        .mockResolvedValue(undefined as never),
+      telegram: jest
+        .spyOn(TelegramService, "sendTelegramMessage")
+        .mockResolvedValue(undefined as never),
+      webhook: jest
+        .spyOn(WebhookService, "sendWebhook")
+        .mockResolvedValue(undefined as never),
+      push: jest
+        .spyOn(PushNotificationService, "sendPushNotification")
+        .mockResolvedValue(undefined as never),
+      loggerError: jest.spyOn(logger, "error").mockImplementation((): void => {
+        return undefined;
+      }),
+    };
+
+    /*
+     * Every template generator is stubbed. They render Handlebars, shorten
+     * links and read DatabaseConfig; none of that is what this file is about,
+     * and a real one would drag a database into the test. Stubbing them also
+     * makes them observable, which is how the "row before body" ordering is
+     * asserted.
+     */
+    generators = {
+      generateEmailTemplateForIncidentCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateEmailTemplateForIncidentCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateEmailTemplateForAlertCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateEmailTemplateForAlertCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateEmailTemplateForAlertEpisodeCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateEmailTemplateForAlertEpisodeCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateEmailTemplateForIncidentEpisodeCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateEmailTemplateForIncidentEpisodeCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateSmsTemplateForIncidentCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateSmsTemplateForIncidentCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateSmsTemplateForAlertCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateSmsTemplateForAlertCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateSmsTemplateForAlertEpisodeCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateSmsTemplateForAlertEpisodeCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateSmsTemplateForIncidentEpisodeCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateSmsTemplateForIncidentEpisodeCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateWhatsAppTemplateForIncidentCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateWhatsAppTemplateForIncidentCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateWhatsAppTemplateForAlertCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateWhatsAppTemplateForAlertCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateWhatsAppTemplateForAlertEpisodeCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateWhatsAppTemplateForAlertEpisodeCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateWhatsAppTemplateForIncidentEpisodeCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateWhatsAppTemplateForIncidentEpisodeCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateTelegramBodyForIncidentCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateTelegramBodyForIncidentCreated",
+        )
+        .mockResolvedValue(TELEGRAM_BODY as never),
+      generateTelegramBodyForAlertCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateTelegramBodyForAlertCreated",
+        )
+        .mockResolvedValue(TELEGRAM_BODY as never),
+      generateTelegramBodyForAlertEpisodeCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateTelegramBodyForAlertEpisodeCreated",
+        )
+        .mockResolvedValue(TELEGRAM_BODY as never),
+      generateTelegramBodyForIncidentEpisodeCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateTelegramBodyForIncidentEpisodeCreated",
+        )
+        .mockResolvedValue(TELEGRAM_BODY as never),
+      generateCallTemplateForIncidentCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateCallTemplateForIncidentCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateCallTemplateForAlertCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateCallTemplateForAlertCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateCallTemplateForAlertEpisodeCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateCallTemplateForAlertEpisodeCreated",
+        )
+        .mockResolvedValue({} as never),
+      generateCallTemplateForIncidentEpisodeCreated: jest
+        .spyOn(
+          UserNotificationRuleService,
+          "generateCallTemplateForIncidentEpisodeCreated",
+        )
+        .mockResolvedValue({} as never),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /*
+   * Drive one cell of the matrix: a rule carrying exactly one verified method,
+   * an event type, and nothing else.
+   */
+  async function deliverCell(
+    channel: ChannelSpec,
+    event: EventSpec,
+  ): Promise<void> {
+    event.arm();
+    spies.findRule.mockResolvedValue(
+      ruleItem(channel.verifiedMethod()) as never,
+    );
+
+    await UserNotificationRuleService.executeNotificationRuleItem(
+      RULE_ID,
+      event.makeOptions(),
+    );
+
+    /*
+     * Sends are never awaited: executeNotificationRuleItem resolves while the
+     * provider promises are still in flight, and the .catch that flips a row to
+     * Error runs a microtask later. Flush before asserting on anything the
+     * post-send path touches.
+     */
+    await flushMicrotasks();
+  }
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (A) The axes themselves. If either of these fails, the matrix below has
+   * stopped covering the thing it claims to cover.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("the matrix axes track the production code", () => {
+    test("the event axis covers EVERY UserNotificationEventType member", () => {
+      /*
+       * The canary for the next Gap F. Adding a fifth event type to the enum
+       * fails here until it is added to EVENT_SPECS, at which point the matrix
+       * grows by seven cells and any channel that forgot the new branch fails.
+       */
+      const members: Array<string> = Object.values(UserNotificationEventType);
+
+      expect(EVENT_NAMES).toHaveLength(members.length);
+
+      const covered: Array<string> = EVENT_NAMES.map(
+        (eventName: string): string => {
+          return eventSpec(eventName).eventType;
+        },
+      );
+
+      for (const member of members) {
+        expect(covered).toContain(member);
+      }
+    });
+
+    test("the channel axis covers every channel getContactableChannelNames knows about", () => {
+      /*
+       * getContactableChannelNames is the delivery path's own answer to "what
+       * can this rule reach the user on", and the fell-through guard names
+       * those channels. Anything it can return must have a row in the matrix.
+       */
+      const allChannels: Array<string> = contactableChannelNames(
+        ruleItem(everyVerifiedMethod()),
+      );
+
+      expect([...allChannels].sort()).toEqual([...CHANNEL_NAMES].sort());
+    });
+
+    test("the matrix is the full cartesian product", () => {
+      expect(FULL_MATRIX).toHaveLength(
+        CHANNEL_NAMES.length * EVENT_NAMES.length,
+      );
+      expect(FULL_MATRIX).toHaveLength(28);
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (B) The grid. One test per cell.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("every channel dispatches for every event type", () => {
+    test.each<[string, string]>(FULL_MATRIX)(
+      "%s hands the page to its provider for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        /*
+         * The Gap F assertion. Before Phase 1 five of these cells reached this
+         * line with the provider untouched and the timeline empty.
+         */
+        expect(channel.sender()).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    test.each<[string, string]>(FULL_MATRIX)(
+      "%s contacts NO other channel for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        for (const sender of otherSenders(channel)) {
+          expect(sender).not.toHaveBeenCalled();
+        }
+      },
+    );
+
+    test.each<[string, string]>(FULL_MATRIX)(
+      "%s writes exactly one Sending timeline row for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        expect(timelineRows).toHaveLength(1);
+        expect(timelineRows[0]?.status).toBe(UserNotificationStatus.Sending);
+        /*
+         * statusMessage is nullable: false on the model, and it is the only
+         * thing an operator reading the timeline sees. A block that copied its
+         * neighbour's message would name the wrong channel here.
+         */
+        expect(timelineRows[0]?.statusMessage).toContain(
+          channel.sendingMessage,
+        );
+        /* The guard row would be an Error. Delivery happened, so it stays quiet. */
+        expect(timelineRows[0]?.status).not.toBe(UserNotificationStatus.Error);
+      },
+    );
+
+    test.each<[string, string]>(FULL_MATRIX)(
+      "%s stamps the timeline row with the page's identifiers for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        const row: TimelineRow | undefined = timelineRows[0];
+
+        expect(row?.userId?.toString()).toBe(USER_ID.toString());
+        expect(row?.userNotificationRuleId?.toString()).toBe(
+          RULE_ID.toString(),
+        );
+        expect(row?.userNotificationLogId?.toString()).toBe(LOG_ID.toString());
+        expect(row?.projectId?.toString()).toBe(PROJECT_ID.toString());
+        expect(row?.userNotificationEventType).toBe(event.eventType);
+        /* ...and with the method it was delivered on, so the row is attributable. */
+        expect(row?.methodIds[channel.timelineMethodIdField]?.toString()).toBe(
+          METHOD_ID.toString(),
+        );
+      },
+    );
+
+    test.each<[string, string]>(FULL_MATRIX)(
+      "%s hands the sender the created row id, the project and the user for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        const options: SenderOptions = senderOptions(channel.sender());
+
+        /*
+         * userOnCallLogTimelineId is how the provider's delivery callback finds
+         * the row to update, and how an acknowledgement is matched back to this
+         * attempt. A cell that passed the wrong id would look delivered and
+         * never reconcile.
+         */
+        expect(options.userOnCallLogTimelineId?.toString()).toBe(
+          TIMELINE_ID.toString(),
+        );
+        expect(options.projectId?.toString()).toBe(PROJECT_ID.toString());
+        expect(options.userId?.toString()).toBe(USER_ID.toString());
+      },
+    );
+
+    test.each<[string, string]>(FULL_MATRIX)(
+      "%s consults only the finder for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        const finders: Array<jest.SpyInstance> = [
+          spies.incidentFind,
+          spies.alertFind,
+          spies.alertEpisodeFind,
+          spies.incidentEpisodeFind,
+        ];
+
+        const called: Array<jest.SpyInstance> = finders.filter(
+          (finder: jest.SpyInstance): boolean => {
+            return finder.mock.calls.length > 0;
+          },
+        );
+
+        // The event type, not the ids on the options bag, picks the entity.
+        expect(called).toHaveLength(1);
+      },
+    );
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (C) The row must exist before the body is written (constraint 6).
+   * -----------------------------------------------------------------------
+   */
+
+  describe("the timeline row is created BEFORE the message body", () => {
+    test.each<[string, string]>(GENERATOR_MATRIX)(
+      "%s generates its %s body only after the row exists",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        const generator: jest.SpyInstance =
+          generators[channel.generatorPrefix! + event.generatorSuffix]!;
+
+        expect(generator).toHaveBeenCalledTimes(1);
+        expect(spies.timelineCreate.mock.invocationCallOrder[0]).toBeLessThan(
+          generator.mock.invocationCallOrder[0] as number,
+        );
+      },
+    );
+
+    test.each<[string, string]>(GENERATOR_MATRIX)(
+      "%s derives its %s acknowledge link from the created row id",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        const generator: jest.SpyInstance =
+          generators[channel.generatorPrefix! + event.generatorSuffix]!;
+
+        /*
+         * This is why the ordering is load-bearing rather than incidental: the
+         * generator turns this id into the acknowledge deep-link that is baked
+         * into the message. Hoisting generation above the create - the obvious
+         * "render once, send to many" optimisation - would produce a page whose
+         * acknowledge button points at a row that does not exist.
+         */
+        const timelineIdArgument: ObjectID = generator.mock.calls[0][
+          channel.generatorTimelineIdArgIndex
+        ] as ObjectID;
+
+        expect(timelineIdArgument.toString()).toBe(TIMELINE_ID.toString());
+      },
+    );
+
+    test.each<[string, string]>(GENERATOR_MATRIX)(
+      "%s generates the %s body before handing the page to the provider",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        const generator: jest.SpyInstance =
+          generators[channel.generatorPrefix! + event.generatorSuffix]!;
+
+        expect(generator.mock.invocationCallOrder[0]).toBeLessThan(
+          channel.sender().mock.invocationCallOrder[0] as number,
+        );
+      },
+    );
+
+    test.each<[string, string]>(GENERATOR_MATRIX)(
+      "%s uses no OTHER generator for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        const expectedName: string =
+          channel.generatorPrefix! + event.generatorSuffix;
+
+        for (const generatorName of Object.keys(generators)) {
+          if (generatorName === expectedName) {
+            continue;
+          }
+
+          /*
+           * A cell that fell through to a neighbour's template would still send
+           * something - the wrong thing, describing the wrong entity. Pin that
+           * exactly one generator runs, and that it is this cell's.
+           */
+          expect(generators[generatorName]).not.toHaveBeenCalled();
+        }
+      },
+    );
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (D) Channels with no generator still carry the row id.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("the webhook block", () => {
+    test.each<[string, string]>(buildMatrix(["Webhook"]))(
+      "%s puts the right eventType on the wire for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        const request: { url: string; eventType: string; payload: unknown } =
+          spies.webhook.mock.calls[0][0] as {
+            url: string;
+            eventType: string;
+            payload: unknown;
+          };
+
+        expect(request.url).toBe(WEBHOOK_URL);
+        expect(request.eventType).toBe(event.webhookEventType);
+      },
+    );
+
+    test.each<[string, string]>(buildMatrix(["Webhook"]))(
+      "%s repeats the eventType inside the payload for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        const request: { payload: Record<string, unknown> } = spies.webhook.mock
+          .calls[0][0] as { payload: Record<string, unknown> };
+
+        expect(request.payload["eventType"]).toBe(event.webhookEventType);
+        expect(request.payload["userId"]).toBe(USER_ID.toString());
+      },
+    );
+
+    test("a webhook is dispatched on webhookUrl alone - there is no verification gate", async () => {
+      /*
+       * UserWebhook has no isVerified column, so the presence of a URL is the
+       * whole gate. That is why Webhook is absent from the unverified matrix
+       * below rather than missing from it by oversight.
+       */
+      await deliverCell(
+        channelSpec("Webhook"),
+        eventSpec("IncidentEpisodeCreated"),
+      );
+
+      expect(spies.webhook).toHaveBeenCalledTimes(1);
+      expect(timelineRows).toHaveLength(1);
+      expect(timelineRows[0]?.status).toBe(UserNotificationStatus.Sending);
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (E) Episode linkage - what the sender is told the page is about.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("episode ids on the sender options", () => {
+    test.each<[string, string]>(
+      buildMatrix(["Email", "SMS", "WhatsApp", "Telegram", "Call", "Push"]),
+    )(
+      "%s links the alert episode it is paging about (%s is ignored unless it is the alert episode)",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        const options: SenderOptions = senderOptions(channel.sender());
+
+        if (event.eventType === UserNotificationEventType.AlertEpisodeCreated) {
+          expect(options.alertEpisodeId?.toString()).toBe(
+            ALERT_EPISODE_ID.toString(),
+          );
+        } else {
+          expect(options.alertEpisodeId).toBeUndefined();
+        }
+      },
+    );
+
+    test.each<[string, string]>(
+      buildMatrix(["Email", "SMS", "WhatsApp", "Telegram", "Call", "Push"]),
+    )(
+      "%s never passes an incidentEpisodeId for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        /*
+         * Deliberate, and pinned so it does not get "fixed" by adding the key
+         * without fixing the transport: every one of these services accepts
+         * incidentEpisodeId in its options type and then never serialises it
+         * onto the request body. Passing it would read as a link that exists.
+         * Contrast with alertEpisodeId above, which does travel.
+         */
+        expect(
+          senderOptions(channel.sender()).incidentEpisodeId,
+        ).toBeUndefined();
+      },
+    );
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (F) The unverified path: an Error row, and nothing sent.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("an unverified method is never contacted", () => {
+    async function deliverUnverifiedCell(
+      channel: ChannelSpec,
+      event: EventSpec,
+    ): Promise<void> {
+      event.arm();
+      spies.findRule.mockResolvedValue(
+        ruleItem(channel.unverifiedMethod!()) as never,
+      );
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        event.makeOptions(),
+      );
+      await flushMicrotasks();
+    }
+
+    test.each<[string, string]>(UNVERIFIED_MATRIX)(
+      "an unverified %s sends nothing for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverUnverifiedCell(channel, event);
+
+        for (const sender of everySender()) {
+          expect(sender).not.toHaveBeenCalled();
+        }
+      },
+    );
+
+    test.each<[string, string]>(UNVERIFIED_MATRIX)(
+      "an unverified %s writes exactly one Error row saying so for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverUnverifiedCell(channel, event);
+
+        /*
+         * Exactly one: the not-verified row. The fell-through guard must NOT
+         * also fire here - an unverified method is not a contactable channel,
+         * so there is no missing template to report and a second row would tell
+         * the operator a second, wrong story.
+         */
+        expect(timelineRows).toHaveLength(1);
+        expect(timelineRows[0]?.status).toBe(UserNotificationStatus.Error);
+        expect(timelineRows[0]?.statusMessage).toContain(
+          channel.unverifiedMessage,
+        );
+        expect(timelineRows[0]?.statusMessage).toContain("not verified");
+        expect(timelineRows[0]?.statusMessage).not.toContain(
+          "No notification template",
+        );
+      },
+    );
+
+    test.each<[string, string]>(UNVERIFIED_MATRIX)(
+      "an unverified %s never reaches a generator for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverUnverifiedCell(channel, event);
+
+        for (const generatorName of Object.keys(generators)) {
+          expect(generators[generatorName]).not.toHaveBeenCalled();
+        }
+      },
+    );
+
+    test("an unverified method is not a contactable channel", () => {
+      for (const channelName of VERIFIABLE_CHANNEL_NAMES) {
+        const channel: ChannelSpec = channelSpec(channelName);
+
+        expect(
+          contactableChannelNames(ruleItem(channel.unverifiedMethod!())),
+        ).toEqual([]);
+      }
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (G) The fell-through guard.
+   *
+   * With all twenty eight cells wired, no rule reaches this guard today - which
+   * is exactly the state it is meant to police, and exactly why it needs a test
+   * of its own rather than incidental coverage. The precondition it fires on is
+   * "the channel census found somebody reachable, and then no block claimed the
+   * event". The census is taken before the triggering entity is loaded, so
+   * dropping the relation inside the entity finder's stub reproduces that
+   * precondition exactly, standing in for a future event type that is wired
+   * into entity resolution but not into the channel blocks - which is precisely
+   * the shape Gap F had.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("the fell-through guard", () => {
+    function ruleThatLosesItsChannelsAfterTheCensus(
+      methods: Record<string, unknown>,
+      relationsToDrop: Array<string>,
+    ): UserNotificationRule {
+      const rule: UserNotificationRule = ruleItem(methods);
+
+      spies.alertEpisodeFind.mockImplementation((): Promise<AlertEpisode> => {
+        for (const relation of relationsToDrop) {
+          (rule as unknown as Record<string, unknown>)[relation] = undefined;
+        }
+
+        return Promise.resolve(fakeAlertEpisode());
+      });
+
+      spies.findRule.mockResolvedValue(rule as never);
+
+      return rule;
+    }
+
+    async function runGuardScenario(
+      methods: Record<string, unknown>,
+      relationsToDrop: Array<string>,
+    ): Promise<void> {
+      ruleThatLosesItsChannelsAfterTheCensus(methods, relationsToDrop);
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        eventSpec("AlertEpisodeCreated").makeOptions(),
+      );
+      await flushMicrotasks();
+    }
+
+    test("a contactable channel that no block claimed writes an Error row", async () => {
+      await runGuardScenario(channelSpec("SMS").verifiedMethod(), ["userSms"]);
+
+      for (const sender of everySender()) {
+        expect(sender).not.toHaveBeenCalled();
+      }
+
+      /*
+       * The whole point. Before the guard existed this execution produced no
+       * message AND no row: the page was simply gone, and the on-call log went
+       * on waiting for an acknowledgement that could never come.
+       */
+      expect(timelineRows).toHaveLength(1);
+      expect(timelineRows[0]?.status).toBe(UserNotificationStatus.Error);
+    });
+
+    test("the guard's row names the event type and the channel that had no template", async () => {
+      await runGuardScenario(channelSpec("SMS").verifiedMethod(), ["userSms"]);
+
+      expect(timelineRows[0]?.statusMessage).toBe(
+        "No notification template for Alert Episode Created on SMS.",
+      );
+    });
+
+    test("the guard names EVERY channel the rule could have reached", async () => {
+      const methods: Record<string, unknown> = {
+        ...channelSpec("Email").verifiedMethod(),
+        ...channelSpec("SMS").verifiedMethod(),
+      };
+
+      await runGuardScenario(methods, ["userEmail", "userSms"]);
+
+      // In getContactableChannelNames order: Email before SMS.
+      expect(timelineRows[0]?.statusMessage).toBe(
+        "No notification template for Alert Episode Created on Email, SMS.",
+      );
+    });
+
+    test("the guard's row carries the same identifiers a delivery row would", async () => {
+      await runGuardScenario(channelSpec("SMS").verifiedMethod(), ["userSms"]);
+
+      const row: TimelineRow | undefined = timelineRows[0];
+
+      expect(row?.userId?.toString()).toBe(USER_ID.toString());
+      expect(row?.userNotificationRuleId?.toString()).toBe(RULE_ID.toString());
+      expect(row?.userNotificationLogId?.toString()).toBe(LOG_ID.toString());
+      expect(row?.projectId?.toString()).toBe(PROJECT_ID.toString());
+      expect(row?.userNotificationEventType).toBe(
+        UserNotificationEventType.AlertEpisodeCreated,
+      );
+    });
+
+    test("the guard also logs, so the miss is visible outside the timeline", async () => {
+      await runGuardScenario(channelSpec("SMS").verifiedMethod(), ["userSms"]);
+
+      expect(spies.loggerError).toHaveBeenCalled();
+      expect(String(spies.loggerError.mock.calls[0][0])).toContain(
+        "No notification template for Alert Episode Created on SMS.",
+      );
+      // The on-call log id is what lets an operator find the dropped page.
+      expect(String(spies.loggerError.mock.calls[0][0])).toContain(
+        LOG_ID.toString(),
+      );
+    });
+
+    test("the guard builds a FRESH row rather than reusing the one the blocks write", async () => {
+      /*
+       * Constraint 1: the channel blocks share one UserOnCallLogTimeline
+       * instance, and after its first create() it carries an _id, so a second
+       * create() with it UPDATEs that row instead of inserting. Here an
+       * unverified email writes the first row and a vanishing SMS trips the
+       * guard; if the guard reused the shared instance it would overwrite the
+       * "email not verified" row and the operator would lose one of the two
+       * reasons this page failed.
+       */
+      const methods: Record<string, unknown> = {
+        ...channelSpec("Email").unverifiedMethod!(),
+        ...channelSpec("SMS").verifiedMethod(),
+      };
+
+      await runGuardScenario(methods, ["userSms"]);
+
+      expect(timelineRows).toHaveLength(2);
+      expect(timelineRows[0]?.statusMessage).toContain("not verified");
+      expect(timelineRows[1]?.statusMessage).toContain(
+        "No notification template",
+      );
+      // Two rows, two distinct instances - not one instance created twice.
+      expect(timelineInstances[0]).not.toBe(timelineInstances[1]);
+    });
+
+    test("a rule with no contactable channel at all stays silent", async () => {
+      /*
+       * The guard is gated on the census being non-empty. A rule whose method
+       * was cascade-deleted can contact nobody, so there is no missing template
+       * to report - it writes nothing, which is pinned here as the deliberate
+       * boundary of the guard rather than a second silent hole.
+       */
+      eventSpec("AlertEpisodeCreated").arm();
+      spies.findRule.mockResolvedValue(ruleItem() as never);
+
+      await UserNotificationRuleService.executeNotificationRuleItem(
+        RULE_ID,
+        eventSpec("AlertEpisodeCreated").makeOptions(),
+      );
+      await flushMicrotasks();
+
+      for (const sender of everySender()) {
+        expect(sender).not.toHaveBeenCalled();
+      }
+      expect(timelineRows).toHaveLength(0);
+    });
+
+    test.each<[string, string]>(FULL_MATRIX)(
+      "the guard stays quiet when %s delivered for %s",
+      async (channelName: string, eventName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec(eventName);
+
+        await deliverCell(channel, event);
+
+        for (const row of timelineRows) {
+          expect(row.statusMessage).not.toContain("No notification template");
+        }
+        expect(spies.loggerError).not.toHaveBeenCalled();
+      },
+    );
+
+    test("an event type nothing is wired for throws before the guard can speak", async () => {
+      /*
+       * The guard's blind spot, recorded rather than asserted as desirable: it
+       * sits AFTER the entity resolution that throws when no event branch
+       * matched, so it can only ever report a channel gap for an event type
+       * that already resolves an entity. A brand new event type with no
+       * resolution block at all fails as a BadDataException instead - still
+       * loud (the worker marks the log Error), but it never produces the
+       * per-channel row the guard was written to produce.
+       */
+      spies.findRule.mockResolvedValue(
+        ruleItem(channelSpec("SMS").verifiedMethod()) as never,
+      );
+      spies.incidentFind.mockResolvedValue(fakeIncident() as never);
+
+      await expect(
+        UserNotificationRuleService.executeNotificationRuleItem(RULE_ID, {
+          projectId: PROJECT_ID,
+          userNotificationEventType:
+            "Maintenance Started" as unknown as UserNotificationEventType,
+          triggeredByIncidentId: INCIDENT_ID,
+          onCallPolicyId: POLICY_ID,
+          userNotificationLogId: LOG_ID,
+        }),
+      ).rejects.toThrow(BadDataException);
+
+      expect(spies.incidentFind).not.toHaveBeenCalled();
+      expect(timelineRows).toHaveLength(0);
+      expect(spies.sms).not.toHaveBeenCalled();
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (H) A send that fails still flips its row - the matrix cells above all
+   * resolve, so the failure half is pinned once per channel here.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("a provider rejection flips the row it created", () => {
+    test.each<[string]>([
+      ["Email"],
+      ["SMS"],
+      ["WhatsApp"],
+      ["Telegram"],
+      ["Webhook"],
+      ["Call"],
+      ["Push"],
+    ])(
+      "%s marks its incident-episode row Error when the provider rejects",
+      async (channelName: string): Promise<void> => {
+        const channel: ChannelSpec = channelSpec(channelName);
+        const event: EventSpec = eventSpec("IncidentEpisodeCreated");
+
+        channel.sender().mockRejectedValue(new Error("provider down") as never);
+
+        await deliverCell(channel, event);
+
+        /*
+         * Nothing is awaited, so this update lands a microtask after
+         * executeNotificationRuleItem resolved - which is why deliverCell
+         * flushes. Without the flush this assertion races and passes or fails
+         * depending on how many awaits the block happened to contain.
+         */
+        expect(spies.timelineUpdate).toHaveBeenCalledTimes(1);
+
+        const update: {
+          id: ObjectID;
+          data: { status: UserNotificationStatus; statusMessage: string };
+        } = spies.timelineUpdate.mock.calls[0][0] as {
+          id: ObjectID;
+          data: { status: UserNotificationStatus; statusMessage: string };
+        };
+
+        expect(update.id.toString()).toBe(TIMELINE_ID.toString());
+        expect(update.data.status).toBe(UserNotificationStatus.Error);
+        expect(update.data.statusMessage).toBe("provider down");
+      },
+    );
+  });
+});

--- a/Common/Tests/Server/Services/OnCallNotificationFallback.test.ts
+++ b/Common/Tests/Server/Services/OnCallNotificationFallback.test.ts
@@ -1,0 +1,1744 @@
+import OnCallDutyPolicyExecutionLogTimelineService from "../../../Server/Services/OnCallDutyPolicyExecutionLogTimelineService";
+import OnCallNotificationAlertingService from "../../../Server/Services/OnCallNotificationAlertingService";
+import ProjectService from "../../../Server/Services/ProjectService";
+import UserCallService from "../../../Server/Services/UserCallService";
+import UserEmailService from "../../../Server/Services/UserEmailService";
+import UserNotificationRuleService, {
+  ExecuteFallbackNotificationOptions,
+  ExecuteNotificationRuleOptions,
+  FALLBACK_NOTIFICATION_CLAIM_KEY,
+  FallbackNotificationOutcome,
+  FallbackNotificationResult,
+} from "../../../Server/Services/UserNotificationRuleService";
+import UserOnCallLogService, {
+  NO_NOTIFICATION_RULES_STATUS_MESSAGE,
+} from "../../../Server/Services/UserOnCallLogService";
+import UserPushService from "../../../Server/Services/UserPushService";
+import UserService from "../../../Server/Services/UserService";
+import UserSmsService from "../../../Server/Services/UserSmsService";
+import UserTelegramService from "../../../Server/Services/UserTelegramService";
+import UserWebhookService from "../../../Server/Services/UserWebhookService";
+import UserWhatsAppService from "../../../Server/Services/UserWhatsAppService";
+import logger from "../../../Server/Utils/Logger";
+import Project from "../../../Models/DatabaseModels/Project";
+import UserNotificationRule from "../../../Models/DatabaseModels/UserNotificationRule";
+import UserOnCallLog from "../../../Models/DatabaseModels/UserOnCallLog";
+import Email from "../../../Types/Email";
+import Name from "../../../Types/Name";
+import NotificationRuleType from "../../../Types/NotificationRule/NotificationRuleType";
+import ObjectID from "../../../Types/ObjectID";
+import OnCallDutyExecutionLogTimelineStatus from "../../../Types/OnCallDutyPolicy/OnCalDutyExecutionLogTimelineStatus";
+import Phone from "../../../Types/Phone";
+import UserNotificationEventType from "../../../Types/UserNotification/UserNotificationEventType";
+import UserNotificationExecutionStatus from "../../../Types/UserNotification/UserNotificationExecutionStatus";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * The verified-method fallback: what happens when a responder is paged and has
+ * NO notification rule for the (ruleType x severity) that fired.
+ *
+ * Before Phase 1 that was a dead-end - an Error row nobody reads, no send, and
+ * an escalation timer running down as though the responder had simply declined
+ * to acknowledge (Gap C). The fallback pages them anyway, on whatever they have
+ * verified. This file pins the four things about it that are easy to get subtly,
+ * silently wrong:
+ *
+ *   1. WHICH CHANNELS. Zero-cost first: a responder with a verified push device
+ *      and a verified email gets both, because there is no reason to choose and
+ *      neither costs the project anything. Only a responder with neither is
+ *      worth spending money on, and then exactly once, down the ladder
+ *      SMS -> Call -> WhatsApp -> Telegram -> Webhook - and only through
+ *      channels the PROJECT still has switched on. That last clause is the one
+ *      with a bill attached: SmsService and CallService check their project flag
+ *      at send time, but WhatsApp and Telegram only check theirs when the method
+ *      is created, so a project that switched WhatsApp off would be billed by a
+ *      fallback that did not look for itself (spec constraint 7). It is driven
+ *      per channel below.
+ *
+ *   2. ONE DELIVERY CALL PER CHANNEL. This is the highest-value assertion in the
+ *      file (spec constraint 1). deliverNotificationForRule keeps ONE mutable
+ *      UserOnCallLogTimeline instance and mutates it as it walks its channel
+ *      blocks; after the first create() that instance carries an _id, so a
+ *      second create() with it UPDATEs the row it already wrote instead of
+ *      inserting a new one. A fallback that looped channels inside a single
+ *      delivery call would therefore overwrite the first channel's timeline row
+ *      with the second's - one page would vanish from the record entirely. So:
+ *      two channels means two calls, each with its OWN freshly built rule.
+ *
+ *   3. THE UNSAVED RULE. Each channel is delivered through a UserNotificationRule
+ *      assembled in memory and never persisted - the user did not ask for this
+ *      rule, and writing it would rewrite their configuration behind their back.
+ *      It has to carry the method RELATION (rule.userEmail as a loaded UserEmail
+ *      with .email and .isVerified), not merely the FK, because every channel
+ *      block reads the relation and never dereferences the id: a rule with only
+ *      userEmailId set sends nothing at all, quietly.
+ *
+ *   4. THE OUTCOME THE CALLER ACTS ON. UserNotificationExecutionStatus.Error is
+ *      TERMINAL - ExecutePendingExecutions selects Executing and
+ *      TimeoutStuckExecutions selects Started, so nothing re-selects an Error
+ *      log. "This responder has nothing we can page them on" is worth burning
+ *      the log for; "the send raised" is not the same thing at all, and both are
+ *      notified:false. Hence the three-way FallbackNotificationOutcome, and
+ *      hence the wiring assertions in section (F).
+ *
+ * Nothing here touches a database or a sender: deliverNotificationForRule is
+ * stubbed at the service boundary (it fans out into template generation, short
+ * links, seven providers and the timeline writer), and every lookup is a
+ * jest.spyOn. What is under test is the fallback's own decision-making.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const USER_ID: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+const LOG_ID: ObjectID = new ObjectID("33333333-3333-4333-8333-333333333333");
+const INCIDENT_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+const POLICY_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+const TIMELINE_ID: ObjectID = new ObjectID(
+  "66666666-6666-4666-8666-666666666666",
+);
+const INCIDENT_SEVERITY_ID: ObjectID = new ObjectID(
+  "77777777-7777-4777-8777-777777777777",
+);
+
+const EMAIL_METHOD_ID: ObjectID = new ObjectID(
+  "a1a1a1a1-a1a1-4a1a-8a1a-a1a1a1a1a1a1",
+);
+const PUSH_METHOD_ID: ObjectID = new ObjectID(
+  "a2a2a2a2-a2a2-4a2a-8a2a-a2a2a2a2a2a2",
+);
+const SMS_METHOD_ID: ObjectID = new ObjectID(
+  "a3a3a3a3-a3a3-4a3a-8a3a-a3a3a3a3a3a3",
+);
+const CALL_METHOD_ID: ObjectID = new ObjectID(
+  "a4a4a4a4-a4a4-4a4a-8a4a-a4a4a4a4a4a4",
+);
+const WHATSAPP_METHOD_ID: ObjectID = new ObjectID(
+  "a5a5a5a5-a5a5-4a5a-8a5a-a5a5a5a5a5a5",
+);
+const TELEGRAM_METHOD_ID: ObjectID = new ObjectID(
+  "a6a6a6a6-a6a6-4a6a-8a6a-a6a6a6a6a6a6",
+);
+const WEBHOOK_METHOD_ID: ObjectID = new ObjectID(
+  "a7a7a7a7-a7a7-4a7a-8a7a-a7a7a7a7a7a7",
+);
+
+const RESPONDER_EMAIL: string = "responder@company.com";
+const SEVERITY_NAME: string = "Sev4";
+const RESPONDER_NAME: string = "Jane Doe";
+
+/*
+ * The four project switches the paid ladder consults, and the flag key each
+ * channel is gated on. Kept as one table because the "is this channel allowed"
+ * question is asked identically for all four and answered in four separate
+ * blocks of production code - exactly the shape that drifts.
+ */
+type PaidChannelName = "SMS" | "Call" | "WhatsApp" | "Telegram";
+
+const SMS_FLAG: string = "enableSmsNotifications";
+const CALL_FLAG: string = "enableCallNotifications";
+const WHATSAPP_FLAG: string = "enableWhatsAppNotifications";
+const TELEGRAM_FLAG: string = "enableTelegramNotifications";
+
+/*
+ * A project row as chooseFallbackChannels reads it. Every paid channel starts
+ * DISABLED so that a test which forgets to enable one cannot accidentally bill
+ * for it - the interesting default is the restrictive one.
+ */
+function makeProject(overrides: Record<string, unknown> = {}): Project {
+  return {
+    _id: PROJECT_ID.toString(),
+    enableSmsNotifications: false,
+    enableCallNotifications: false,
+    enableWhatsAppNotifications: false,
+    enableTelegramNotifications: false,
+    ...overrides,
+  } as unknown as Project;
+}
+
+function makeVerifiedPush(): Record<string, unknown> {
+  return {
+    id: PUSH_METHOD_ID,
+    _id: PUSH_METHOD_ID.toString(),
+    deviceToken: "device-token",
+    deviceType: "iOS",
+    isVerified: true,
+  };
+}
+
+function makeVerifiedEmail(): Record<string, unknown> {
+  return {
+    id: EMAIL_METHOD_ID,
+    _id: EMAIL_METHOD_ID.toString(),
+    email: new Email(RESPONDER_EMAIL),
+    isVerified: true,
+  };
+}
+
+function makeVerifiedSms(): Record<string, unknown> {
+  return {
+    id: SMS_METHOD_ID,
+    _id: SMS_METHOD_ID.toString(),
+    phone: new Phone("+11234567890"),
+    isVerified: true,
+  };
+}
+
+function makeVerifiedCall(): Record<string, unknown> {
+  return {
+    id: CALL_METHOD_ID,
+    _id: CALL_METHOD_ID.toString(),
+    phone: new Phone("+11234567891"),
+    isVerified: true,
+  };
+}
+
+function makeVerifiedWhatsApp(): Record<string, unknown> {
+  return {
+    id: WHATSAPP_METHOD_ID,
+    _id: WHATSAPP_METHOD_ID.toString(),
+    phone: new Phone("+11234567892"),
+    isVerified: true,
+  };
+}
+
+function makeVerifiedTelegram(): Record<string, unknown> {
+  return {
+    id: TELEGRAM_METHOD_ID,
+    _id: TELEGRAM_METHOD_ID.toString(),
+    telegramChatId: "123456",
+    telegramUserHandle: "@responder",
+    isVerified: true,
+  };
+}
+
+/*
+ * Deliberately carries no isVerified: UserWebhook has no such column, so
+ * presence of a URL is the whole gate. A fixture that invented an isVerified
+ * would hide a regression that started requiring one.
+ */
+function makeWebhook(): Record<string, unknown> {
+  return {
+    id: WEBHOOK_METHOD_ID,
+    _id: WEBHOOK_METHOD_ID.toString(),
+    webhookUrl: "https://hooks.example.com/on-call",
+    name: "Pager bridge",
+    secret: "s3cr3t",
+  };
+}
+
+/*
+ * deliverNotificationForRule is private - it is the seam the fallback reuses
+ * from executeNotificationRuleItem, not part of the service's public surface.
+ * Spying on it needs a structural view of the singleton rather than a widened
+ * class, so the cast lives here and nowhere else.
+ */
+interface UserNotificationRuleServiceInternals {
+  deliverNotificationForRule: (
+    notificationRuleItem: UserNotificationRule,
+    options: ExecuteNotificationRuleOptions,
+  ) => Promise<boolean>;
+}
+
+function ruleServiceInternals(): UserNotificationRuleServiceInternals {
+  return UserNotificationRuleService as unknown as UserNotificationRuleServiceInternals;
+}
+
+interface UserOnCallLogServiceInternals {
+  handleNoMatchingNotificationRule: (data: {
+    createdItem: UserOnCallLog;
+    notificationRuleType: NotificationRuleType;
+    incidentSeverityId: ObjectID | undefined;
+    alertSeverityId: ObjectID | undefined;
+    severityName: string;
+  }) => Promise<void>;
+}
+
+function fallbackOptions(
+  overrides: Partial<ExecuteFallbackNotificationOptions> = {},
+): ExecuteFallbackNotificationOptions {
+  return {
+    userId: USER_ID,
+    projectId: PROJECT_ID,
+    userOnCallLogId: LOG_ID,
+    ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+    severityName: SEVERITY_NAME,
+    userNotificationLogId: LOG_ID,
+    userNotificationEventType: UserNotificationEventType.IncidentCreated,
+    triggeredByIncidentId: INCIDENT_ID,
+    onCallPolicyId: POLICY_ID,
+    ...overrides,
+  };
+}
+
+/* The query bundle every method lookup is handed. */
+interface FindOneByArg {
+  query: Record<string, unknown>;
+  select: Record<string, unknown>;
+  props: { isRoot: boolean };
+}
+
+function queryOf(spy: jest.SpyInstance): Record<string, unknown> {
+  return (spy.mock.calls[0]![0] as FindOneByArg).query;
+}
+
+function flushMicrotasks(): Promise<void> {
+  return Promise.resolve()
+    .then((): Promise<void> => {
+      return Promise.resolve();
+    })
+    .then((): Promise<void> => {
+      return Promise.resolve();
+    });
+}
+
+/*
+ * ------------------------------------------------------------------------- *
+ * (A)-(E) executeFallbackNotification itself.
+ * -------------------------------------------------------------------------
+ */
+
+describe("UserNotificationRuleService.executeFallbackNotification", () => {
+  let claimSpy: jest.SpyInstance;
+  let deliverSpy: jest.SpyInstance;
+  let ruleCreateSpy: jest.SpyInstance;
+  let pushFindSpy: jest.SpyInstance;
+  let emailFindSpy: jest.SpyInstance;
+  let smsFindSpy: jest.SpyInstance;
+  let callFindSpy: jest.SpyInstance;
+  let whatsAppFindSpy: jest.SpyInstance;
+  let telegramFindSpy: jest.SpyInstance;
+  let webhookFindSpy: jest.SpyInstance;
+  let projectFindSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.spyOn(logger, "error").mockImplementation((): void => {
+      return undefined;
+    });
+    jest.spyOn(logger, "warn").mockImplementation((): void => {
+      return undefined;
+    });
+
+    claimSpy = jest
+      .spyOn(UserOnCallLogService, "claimNotificationExecution")
+      .mockResolvedValue(true as never);
+
+    /*
+     * Stubbed at the service boundary. The real method fans out into template
+     * generation, short-link creation, seven providers and the timeline writer;
+     * its return value ("was a page actually handed to a sender") is the only
+     * part of it the fallback reasons about.
+     */
+    deliverSpy = jest
+      .spyOn(ruleServiceInternals(), "deliverNotificationForRule")
+      .mockResolvedValue(true as never);
+
+    ruleCreateSpy = jest
+      .spyOn(UserNotificationRuleService, "create")
+      .mockResolvedValue(undefined as never);
+
+    // A responder with nothing configured: every test opts IN to its methods.
+    pushFindSpy = jest
+      .spyOn(UserPushService, "findOneBy")
+      .mockResolvedValue(null as never);
+    emailFindSpy = jest
+      .spyOn(UserEmailService, "findOneBy")
+      .mockResolvedValue(null as never);
+    smsFindSpy = jest
+      .spyOn(UserSmsService, "findOneBy")
+      .mockResolvedValue(null as never);
+    callFindSpy = jest
+      .spyOn(UserCallService, "findOneBy")
+      .mockResolvedValue(null as never);
+    whatsAppFindSpy = jest
+      .spyOn(UserWhatsAppService, "findOneBy")
+      .mockResolvedValue(null as never);
+    telegramFindSpy = jest
+      .spyOn(UserTelegramService, "findOneBy")
+      .mockResolvedValue(null as never);
+    webhookFindSpy = jest
+      .spyOn(UserWebhookService, "findOneBy")
+      .mockResolvedValue(null as never);
+
+    projectFindSpy = jest
+      .spyOn(ProjectService, "findOneById")
+      .mockResolvedValue(makeProject() as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function runFallback(
+    overrides: Partial<ExecuteFallbackNotificationOptions> = {},
+  ): Promise<FallbackNotificationResult> {
+    return UserNotificationRuleService.executeFallbackNotification(
+      fallbackOptions(overrides),
+    );
+  }
+
+  function deliveredRules(): Array<UserNotificationRule> {
+    return deliverSpy.mock.calls.map(
+      (call: Array<unknown>): UserNotificationRule => {
+        return call[0] as UserNotificationRule;
+      },
+    );
+  }
+
+  function deliveredOptions(): Array<ExecuteNotificationRuleOptions> {
+    return deliverSpy.mock.calls.map(
+      (call: Array<unknown>): ExecuteNotificationRuleOptions => {
+        return call[1] as ExecuteNotificationRuleOptions;
+      },
+    );
+  }
+
+  function paidChannelFindSpy(channelName: PaidChannelName): jest.SpyInstance {
+    const byChannel: Record<PaidChannelName, jest.SpyInstance> = {
+      SMS: smsFindSpy,
+      Call: callFindSpy,
+      WhatsApp: whatsAppFindSpy,
+      Telegram: telegramFindSpy,
+    };
+
+    return byChannel[channelName];
+  }
+
+  function everyPaidChannelFindSpy(): Array<jest.SpyInstance> {
+    return [smsFindSpy, callFindSpy, whatsAppFindSpy, telegramFindSpy];
+  }
+
+  function giveResponderEveryPaidMethod(): void {
+    smsFindSpy.mockResolvedValue(makeVerifiedSms() as never);
+    callFindSpy.mockResolvedValue(makeVerifiedCall() as never);
+    whatsAppFindSpy.mockResolvedValue(makeVerifiedWhatsApp() as never);
+    telegramFindSpy.mockResolvedValue(makeVerifiedTelegram() as never);
+    webhookFindSpy.mockResolvedValue(makeWebhook() as never);
+  }
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (A) Channel selection - zero-cost channels.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("channel selection: the zero-cost pair", () => {
+    test("a responder with a verified push device AND a verified email gets BOTH", async () => {
+      pushFindSpy.mockResolvedValue(makeVerifiedPush() as never);
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      /*
+       * Both, and in this order: push and email cost nothing, so there is no
+       * reason to pick between them and every reason to maximise the chance of
+       * reaching a human who is not looking at their phone.
+       */
+      expect(result.channelsUsed).toEqual(["Push", "Email"]);
+      expect(result.notified).toBe(true);
+      expect(result.outcome).toBe(FallbackNotificationOutcome.Delivered);
+    });
+
+    test("a verified push device alone is enough - no paid channel is even looked up", async () => {
+      pushFindSpy.mockResolvedValue(makeVerifiedPush() as never);
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      expect(result.channelsUsed).toEqual(["Push"]);
+      for (const spy of everyPaidChannelFindSpy()) {
+        expect(spy).not.toHaveBeenCalled();
+      }
+      expect(webhookFindSpy).not.toHaveBeenCalled();
+    });
+
+    test("a verified email alone is enough - no paid channel is even looked up", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      expect(result.channelsUsed).toEqual(["Email"]);
+      for (const spy of everyPaidChannelFindSpy()) {
+        expect(spy).not.toHaveBeenCalled();
+      }
+    });
+
+    test("with a zero-cost channel available the project settings are never even read", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+
+      await runFallback();
+
+      /*
+       * The project row is only consulted to decide whether a PAID channel may
+       * be used. Reaching it at all on this path would mean the ladder is being
+       * evaluated when it should not be.
+       */
+      expect(projectFindSpy).not.toHaveBeenCalled();
+    });
+
+    test("the push lookup is scoped to this project, this user, and verified devices only", async () => {
+      pushFindSpy.mockResolvedValue(makeVerifiedPush() as never);
+
+      await runFallback();
+
+      const query: Record<string, unknown> = queryOf(pushFindSpy);
+      expect((query["projectId"] as ObjectID).toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+      expect((query["userId"] as ObjectID).toString()).toBe(USER_ID.toString());
+      /*
+       * The verification predicate lives in the QUERY, which is the only place
+       * it can live: nothing downstream re-checks it before the fallback builds
+       * a rule around the row. Dropping it would page an unverified device.
+       */
+      expect(query["isVerified"]).toBe(true);
+    });
+
+    test("the email lookup is scoped to this project, this user, and verified addresses only", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+
+      await runFallback();
+
+      const query: Record<string, unknown> = queryOf(emailFindSpy);
+      expect((query["projectId"] as ObjectID).toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+      expect((query["userId"] as ObjectID).toString()).toBe(USER_ID.toString());
+      expect(query["isVerified"]).toBe(true);
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (A continued) Channel selection - the paid ladder and its project gates.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("channel selection: the paid ladder", () => {
+    test.each<[PaidChannelName, string, Record<string, unknown>]>([
+      ["SMS", SMS_FLAG, makeVerifiedSms()],
+      ["Call", CALL_FLAG, makeVerifiedCall()],
+      ["WhatsApp", WHATSAPP_FLAG, makeVerifiedWhatsApp()],
+      ["Telegram", TELEGRAM_FLAG, makeVerifiedTelegram()],
+    ])(
+      "%s is used when the responder has it verified and the project has it enabled",
+      async (
+        channelName: PaidChannelName,
+        flagKey: string,
+        method: Record<string, unknown>,
+      ): Promise<void> => {
+        projectFindSpy.mockResolvedValue(
+          makeProject({ [flagKey]: true }) as never,
+        );
+        paidChannelFindSpy(channelName).mockResolvedValue(method as never);
+
+        const result: FallbackNotificationResult = await runFallback();
+
+        expect(result.channelsUsed).toEqual([channelName]);
+        expect(result.outcome).toBe(FallbackNotificationOutcome.Delivered);
+        // Exactly one paid channel, never a spree down the ladder.
+        expect(deliverSpy).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    test.each<[PaidChannelName, string, Record<string, unknown>]>([
+      ["SMS", SMS_FLAG, makeVerifiedSms()],
+      ["Call", CALL_FLAG, makeVerifiedCall()],
+      ["WhatsApp", WHATSAPP_FLAG, makeVerifiedWhatsApp()],
+      ["Telegram", TELEGRAM_FLAG, makeVerifiedTelegram()],
+    ])(
+      "%s is skipped - not even queried - when the project has it disabled",
+      async (
+        channelName: PaidChannelName,
+        _flagKey: string,
+        method: Record<string, unknown>,
+      ): Promise<void> => {
+        /*
+         * This is the constraint that stops a fallback billing a project that
+         * deliberately switched a channel off. Only SmsService and CallService
+         * enforce their flag at send time; WhatsApp and Telegram check theirs
+         * when a method is CREATED, so by the time a fallback picks one up the
+         * project's answer has never been asked. It is asked here.
+         */
+        projectFindSpy.mockResolvedValue(makeProject() as never);
+        paidChannelFindSpy(channelName).mockResolvedValue(method as never);
+
+        const result: FallbackNotificationResult = await runFallback();
+
+        expect(paidChannelFindSpy(channelName)).not.toHaveBeenCalled();
+        expect(result.channelsUsed).toEqual([]);
+        expect(result.notified).toBe(false);
+        expect(result.outcome).toBe(
+          FallbackNotificationOutcome.NoUsableNotificationMethod,
+        );
+        expect(deliverSpy).not.toHaveBeenCalled();
+      },
+    );
+
+    test("with everything available and everything enabled, SMS wins and the rest are never queried", async () => {
+      giveResponderEveryPaidMethod();
+      projectFindSpy.mockResolvedValue(
+        makeProject({
+          [SMS_FLAG]: true,
+          [CALL_FLAG]: true,
+          [WHATSAPP_FLAG]: true,
+          [TELEGRAM_FLAG]: true,
+        }) as never,
+      );
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      expect(result.channelsUsed).toEqual(["SMS"]);
+      expect(callFindSpy).not.toHaveBeenCalled();
+      expect(whatsAppFindSpy).not.toHaveBeenCalled();
+      expect(telegramFindSpy).not.toHaveBeenCalled();
+      expect(webhookFindSpy).not.toHaveBeenCalled();
+    });
+
+    test.each<[string, Record<string, unknown>, string]>([
+      [
+        "SMS off",
+        { [CALL_FLAG]: true, [WHATSAPP_FLAG]: true, [TELEGRAM_FLAG]: true },
+        "Call",
+      ],
+      [
+        "SMS and Call off",
+        { [WHATSAPP_FLAG]: true, [TELEGRAM_FLAG]: true },
+        "WhatsApp",
+      ],
+      ["SMS, Call and WhatsApp off", { [TELEGRAM_FLAG]: true }, "Telegram"],
+      ["every paid channel off", {}, "Webhook"],
+    ])(
+      "with %s, the ladder falls through to %s",
+      async (
+        _label: string,
+        flags: Record<string, unknown>,
+        expectedChannel: string,
+      ): Promise<void> => {
+        giveResponderEveryPaidMethod();
+        projectFindSpy.mockResolvedValue(makeProject(flags) as never);
+
+        const result: FallbackNotificationResult = await runFallback();
+
+        expect(result.channelsUsed).toEqual([expectedChannel]);
+      },
+    );
+
+    test.each<[PaidChannelName, string, Record<string, unknown>]>([
+      ["SMS", SMS_FLAG, makeVerifiedSms()],
+      ["Call", CALL_FLAG, makeVerifiedCall()],
+      ["WhatsApp", WHATSAPP_FLAG, makeVerifiedWhatsApp()],
+      ["Telegram", TELEGRAM_FLAG, makeVerifiedTelegram()],
+    ])(
+      "the %s lookup is verification-gated and scoped to this responder",
+      async (
+        channelName: PaidChannelName,
+        flagKey: string,
+        method: Record<string, unknown>,
+      ): Promise<void> => {
+        projectFindSpy.mockResolvedValue(
+          makeProject({ [flagKey]: true }) as never,
+        );
+        paidChannelFindSpy(channelName).mockResolvedValue(method as never);
+
+        await runFallback();
+
+        const query: Record<string, unknown> = queryOf(
+          paidChannelFindSpy(channelName),
+        );
+        expect(query["isVerified"]).toBe(true);
+        expect((query["projectId"] as ObjectID).toString()).toBe(
+          PROJECT_ID.toString(),
+        );
+        expect((query["userId"] as ObjectID).toString()).toBe(
+          USER_ID.toString(),
+        );
+      },
+    );
+
+    test("the paid ladder is only reached when BOTH zero-cost channels are missing", async () => {
+      pushFindSpy.mockResolvedValue(makeVerifiedPush() as never);
+      giveResponderEveryPaidMethod();
+      projectFindSpy.mockResolvedValue(
+        makeProject({ [SMS_FLAG]: true }) as never,
+      );
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      expect(result.channelsUsed).toEqual(["Push"]);
+      expect(smsFindSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (A continued) Channel selection - the webhook backstop.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("channel selection: the webhook backstop", () => {
+    test("a webhook qualifies on presence alone - it has no verification concept", async () => {
+      webhookFindSpy.mockResolvedValue(makeWebhook() as never);
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      expect(result.channelsUsed).toEqual(["Webhook"]);
+      expect(result.outcome).toBe(FallbackNotificationOutcome.Delivered);
+    });
+
+    test("the webhook lookup carries NO isVerified predicate", async () => {
+      webhookFindSpy.mockResolvedValue(makeWebhook() as never);
+
+      await runFallback();
+
+      const query: Record<string, unknown> = queryOf(webhookFindSpy);
+      /*
+       * UserWebhook has no isVerified column. Adding the predicate to this
+       * query for symmetry with the others would match nothing at all, and the
+       * backstop would silently stop existing.
+       */
+      expect(Object.keys(query).sort()).toEqual(["projectId", "userId"]);
+      expect(query["isVerified"]).toBeUndefined();
+    });
+
+    test("a webhook is still used when every paid channel is switched off - there is no flag for it", async () => {
+      giveResponderEveryPaidMethod();
+      projectFindSpy.mockResolvedValue(makeProject() as never);
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      expect(result.channelsUsed).toEqual(["Webhook"]);
+      for (const spy of everyPaidChannelFindSpy()) {
+        expect(spy).not.toHaveBeenCalled();
+      }
+    });
+
+    test("a project row that cannot be read bills nothing and still reaches the webhook", async () => {
+      projectFindSpy.mockResolvedValue(null as never);
+      giveResponderEveryPaidMethod();
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      /*
+       * `project?.enableSmsNotifications` on a null project is falsy, so a
+       * deleted or unreadable project fails CLOSED for everything with a bill
+       * attached and open for the one channel that has none.
+       */
+      for (const spy of everyPaidChannelFindSpy()) {
+        expect(spy).not.toHaveBeenCalled();
+      }
+      expect(result.channelsUsed).toEqual(["Webhook"]);
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (B) One delivery call per channel - spec constraint 1.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("one delivery call per channel", () => {
+    beforeEach(() => {
+      pushFindSpy.mockResolvedValue(makeVerifiedPush() as never);
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+    });
+
+    test("two chosen channels means deliverNotificationForRule is called TWICE", async () => {
+      await runFallback();
+
+      /*
+       * Not once with two methods on one rule. deliverNotificationForRule keeps
+       * a single mutable UserOnCallLogTimeline instance across its channel
+       * blocks, and that instance carries an _id after the first create(); a
+       * second create() with it UPDATEs the first row instead of inserting a
+       * second. Two channels inside one call would therefore leave ONE timeline
+       * row describing the second page and no trace of the first.
+       */
+      expect(deliverSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test("the two calls are handed DIFFERENT rule instances", async () => {
+      await runFallback();
+
+      const rules: Array<UserNotificationRule> = deliveredRules();
+      expect(rules).toHaveLength(2);
+      expect(rules[0]).not.toBe(rules[1]);
+    });
+
+    test("each rule carries exactly ONE method relation", async () => {
+      await runFallback();
+
+      const rules: Array<UserNotificationRule> = deliveredRules();
+      const pushRule: UserNotificationRule = rules[0]!;
+      const emailRule: UserNotificationRule = rules[1]!;
+
+      expect(pushRule.userPush).toBeDefined();
+      expect(pushRule.userEmail).toBeUndefined();
+      expect(pushRule.userEmailId).toBeUndefined();
+
+      expect(emailRule.userEmail).toBeDefined();
+      expect(emailRule.userPush).toBeUndefined();
+      expect(emailRule.userPushId).toBeUndefined();
+    });
+
+    test("no rule ever carries a second channel's method (the multiplexed-rule regression)", async () => {
+      await runFallback();
+
+      for (const rule of deliveredRules()) {
+        const methodsOnRule: Array<unknown> = [
+          rule.userEmail,
+          rule.userPush,
+          rule.userSms,
+          rule.userCall,
+          rule.userWhatsApp,
+          rule.userTelegram,
+          rule.userWebhook,
+        ].filter((method: unknown): boolean => {
+          return Boolean(method);
+        });
+
+        expect(methodsOnRule).toHaveLength(1);
+      }
+    });
+
+    test("both calls receive the very same options bundle the caller handed in", async () => {
+      const options: ExecuteFallbackNotificationOptions = fallbackOptions();
+
+      await UserNotificationRuleService.executeFallbackNotification(options);
+
+      const forwarded: Array<ExecuteNotificationRuleOptions> =
+        deliveredOptions();
+      /*
+       * Identity, not shape: everything that attributes the page back to its
+       * escalation (the incident id, the policy, the escalation rule, the
+       * on-call timeline row) rides in this object, and both channels have to
+       * describe the same page.
+       */
+      expect(forwarded[0]).toBe(options);
+      expect(forwarded[1]).toBe(options);
+    });
+
+    test("a single chosen channel produces exactly one call", async () => {
+      pushFindSpy.mockResolvedValue(null as never);
+
+      await runFallback();
+
+      expect(deliverSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (C) The unsaved rule.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("the rule handed to delivery is built in memory and never saved", () => {
+    test("the method RELATION is populated, not merely the foreign key", async () => {
+      const email: Record<string, unknown> = makeVerifiedEmail();
+      emailFindSpy.mockResolvedValue(email as never);
+
+      await runFallback();
+
+      const rule: UserNotificationRule = deliveredRules()[0]!;
+
+      /*
+       * Every channel block reads the relation (`userEmail?.email &&
+       * userEmail?.isVerified`) and never dereferences the id. A rule carrying
+       * only userEmailId would sail through delivery sending absolutely
+       * nothing, and the fallback would then report a channel it never used.
+       */
+      expect(rule.userEmail).toBe(email);
+      expect(rule.userEmail!.email!.toString()).toBe(RESPONDER_EMAIL);
+      expect(rule.userEmail!.isVerified).toBe(true);
+      // ...and the FK too, so the row is self-consistent if it is ever read.
+      expect(rule.userEmailId!.toString()).toBe(EMAIL_METHOD_ID.toString());
+    });
+
+    test("the push relation is populated with the device the sender needs", async () => {
+      const push: Record<string, unknown> = makeVerifiedPush();
+      pushFindSpy.mockResolvedValue(push as never);
+
+      await runFallback();
+
+      const rule: UserNotificationRule = deliveredRules()[0]!;
+      expect(rule.userPush).toBe(push);
+      expect(rule.userPush!.deviceToken).toBe("device-token");
+      expect(rule.userPush!.isVerified).toBe(true);
+      expect(rule.userPushId!.toString()).toBe(PUSH_METHOD_ID.toString());
+    });
+
+    test("the rule carries the responder, the project, the rule type and notifyAfterMinutes 0", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+
+      await runFallback();
+
+      const rule: UserNotificationRule = deliveredRules()[0]!;
+      expect(rule.userId!.toString()).toBe(USER_ID.toString());
+      expect(rule.projectId!.toString()).toBe(PROJECT_ID.toString());
+      expect(rule.ruleType).toBe(
+        NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      );
+      // Immediate: the page is already late by the time the fallback runs.
+      expect(rule.notifyAfterMinutes).toBe(0);
+    });
+
+    test("the rule type follows whatever the caller was paging for", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+
+      await runFallback({
+        ruleType: NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+      });
+
+      expect(deliveredRules()[0]!.ruleType).toBe(
+        NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+      );
+    });
+
+    test("the rule has no id, so no timeline row can point at a rule that does not exist", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+
+      await runFallback();
+
+      /*
+       * buildLogTimelineItem sets userNotificationRuleId only `if
+       * (notificationRuleItem.id)`. An id here would be a dangling FK on every
+       * timeline row the fallback writes.
+       */
+      expect(deliveredRules()[0]!.id).toBeNull();
+    });
+
+    test("no fallback rule is EVER persisted", async () => {
+      pushFindSpy.mockResolvedValue(makeVerifiedPush() as never);
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+
+      await runFallback();
+
+      /*
+       * The responder did not ask for these rules. Saving them would silently
+       * rewrite their notification configuration, and the next page would find
+       * "matching rules" that a human never created.
+       */
+      expect(ruleCreateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (D) The claim.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("the fallback claims the on-call log under a reserved key", () => {
+    test("the claim key is the literal __fallback__", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+
+      await runFallback();
+
+      expect(claimSpy).toHaveBeenCalledTimes(1);
+      const claimArg: { userOnCallLogId: ObjectID; claimKey: string } = claimSpy
+        .mock.calls[0]![0] as {
+        userOnCallLogId: ObjectID;
+        claimKey: string;
+      };
+
+      /*
+       * There is no rule to claim under - that is the entire reason the
+       * fallback is running - so it claims a reserved literal instead.
+       * executedNotificationRules is a jsonb map keyed by arbitrary text, so
+       * the literal sits beside real rule uuids and can never collide with one.
+       */
+      expect(claimArg.claimKey).toBe("__fallback__");
+      expect(claimArg.userOnCallLogId.toString()).toBe(LOG_ID.toString());
+    });
+
+    test("the exported claim key constant is that same literal", () => {
+      // Pinned because the string is the interop contract with existing rows.
+      expect(FALLBACK_NOTIFICATION_CLAIM_KEY).toBe("__fallback__");
+    });
+
+    test("the claim strictly precedes any method lookup", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+
+      await runFallback();
+
+      expect(claimSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        emailFindSpy.mock.invocationCallOrder[0] as number,
+      );
+    });
+
+    test("a lost claim delivers nothing and does not even look for a method", async () => {
+      claimSpy.mockResolvedValue(false as never);
+      pushFindSpy.mockResolvedValue(makeVerifiedPush() as never);
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      expect(deliverSpy).not.toHaveBeenCalled();
+      expect(pushFindSpy).not.toHaveBeenCalled();
+      expect(emailFindSpy).not.toHaveBeenCalled();
+      expect(result.notified).toBe(false);
+      expect(result.channelsUsed).toEqual([]);
+    });
+
+    test("a lost claim is DeliveryFailed, never NoUsableNotificationMethod", async () => {
+      claimSpy.mockResolvedValue(false as never);
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      /*
+       * The distinction is load-bearing. NoUsableNotificationMethod makes the
+       * caller write a TERMINAL Error onto the log - "this responder is
+       * unreachable" - which would be stamped over a page another run has in
+       * flight right now.
+       */
+      expect(result.outcome).toBe(FallbackNotificationOutcome.DeliveryFailed);
+      expect(result.outcome).not.toBe(
+        FallbackNotificationOutcome.NoUsableNotificationMethod,
+      );
+    });
+
+    test("of two concurrent fallbacks for one log, only the winner delivers", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+      claimSpy
+        .mockResolvedValueOnce(true as never)
+        .mockResolvedValueOnce(false as never);
+
+      const results: Array<FallbackNotificationResult> = await Promise.all([
+        runFallback(),
+        runFallback(),
+      ]);
+
+      // One page, not two - the responder's phone buzzes once.
+      expect(deliverSpy).toHaveBeenCalledTimes(1);
+      expect(results[0]!.notified).toBe(true);
+      expect(results[0]!.channelsUsed).toEqual(["Email"]);
+      expect(results[1]!.notified).toBe(false);
+      expect(results[1]!.channelsUsed).toEqual([]);
+      expect(results[1]!.outcome).toBe(
+        FallbackNotificationOutcome.DeliveryFailed,
+      );
+    });
+  });
+
+  /*
+   * ----------------------------------------------------------------------- *
+   * (E) The three outcomes.
+   * -----------------------------------------------------------------------
+   */
+
+  describe("the outcome the caller branches on", () => {
+    test("Delivered when at least one channel dispatched a page", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      expect(result.outcome).toBe(FallbackNotificationOutcome.Delivered);
+      expect(result.notified).toBe(true);
+      expect(result.channelsUsed).toEqual(["Email"]);
+    });
+
+    test("NoUsableNotificationMethod when the responder has nothing at all", async () => {
+      const result: FallbackNotificationResult = await runFallback();
+
+      /*
+       * The one permanent ending: a retry finds the same nothing, and only a
+       * human adding a notification method changes it. It is the only outcome
+       * the caller is allowed to turn into a terminal Error.
+       */
+      expect(result.outcome).toBe(
+        FallbackNotificationOutcome.NoUsableNotificationMethod,
+      );
+      expect(result.notified).toBe(false);
+      expect(result.channelsUsed).toEqual([]);
+      expect(deliverSpy).not.toHaveBeenCalled();
+    });
+
+    test("DeliveryFailed when the only chosen channel raised", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+      deliverSpy.mockRejectedValue(new Error("smtp exploded") as never);
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      /*
+       * There WAS something to try, so the responder is reachable and today
+       * simply was not reached. Reporting this as NoUsableNotificationMethod
+       * would tell the operator to go add a notification method that already
+       * exists.
+       */
+      expect(result.outcome).toBe(FallbackNotificationOutcome.DeliveryFailed);
+      expect(result.notified).toBe(false);
+      expect(result.channelsUsed).toEqual([]);
+    });
+
+    test("a raising channel does not take the fallback down with it", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+      deliverSpy.mockRejectedValue(new Error("smtp exploded") as never);
+
+      await expect(runFallback()).resolves.toBeDefined();
+    });
+
+    test("DeliveryFailed when the chosen channel fell through its event-type guard", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+      deliverSpy.mockResolvedValue(false as never);
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      /*
+       * deliverNotificationForRule resolves perfectly happily when no channel
+       * block claimed the event type - it writes an Error timeline row and
+       * returns false. "Did not throw" is emphatically not "paged".
+       */
+      expect(result.outcome).toBe(FallbackNotificationOutcome.DeliveryFailed);
+      expect(result.notified).toBe(false);
+    });
+
+    test("a channel that dispatched NOTHING is not listed in channelsUsed", async () => {
+      pushFindSpy.mockResolvedValue(makeVerifiedPush() as never);
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+      // Push goes out; email falls through to the guard and sends nothing.
+      deliverSpy
+        .mockResolvedValueOnce(true as never)
+        .mockResolvedValueOnce(false as never);
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      /*
+       * channelsUsed is read back to the operator verbatim as "notified via
+       * fallback (Push, Email)". A name in there that nobody was actually
+       * contacted on is a lie in the single place somebody looks to find out
+       * whether the responder was reached.
+       */
+      expect(result.channelsUsed).toEqual(["Push"]);
+      expect(result.channelsUsed).not.toContain("Email");
+      expect(result.outcome).toBe(FallbackNotificationOutcome.Delivered);
+      expect(result.notified).toBe(true);
+    });
+
+    test("one channel raising does not stop the next channel from being tried", async () => {
+      pushFindSpy.mockResolvedValue(makeVerifiedPush() as never);
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+      deliverSpy
+        .mockRejectedValueOnce(new Error("APNs down") as never)
+        .mockResolvedValueOnce(true as never);
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      expect(deliverSpy).toHaveBeenCalledTimes(2);
+      expect(result.channelsUsed).toEqual(["Email"]);
+      expect(result.outcome).toBe(FallbackNotificationOutcome.Delivered);
+      expect(result.notified).toBe(true);
+    });
+
+    test("notified always mirrors outcome === Delivered", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+
+      const delivered: FallbackNotificationResult = await runFallback();
+
+      deliverSpy.mockResolvedValue(false as never);
+      const failed: FallbackNotificationResult = await runFallback();
+
+      emailFindSpy.mockResolvedValue(null as never);
+      const nothing: FallbackNotificationResult = await runFallback();
+
+      for (const result of [delivered, failed, nothing]) {
+        expect(result.notified).toBe(
+          result.outcome === FallbackNotificationOutcome.Delivered,
+        );
+      }
+    });
+
+    test("an undelivered outcome always carries an empty channel list", async () => {
+      emailFindSpy.mockResolvedValue(makeVerifiedEmail() as never);
+      deliverSpy.mockResolvedValue(false as never);
+
+      const result: FallbackNotificationResult = await runFallback();
+
+      expect(result.notified).toBe(false);
+      expect(result.channelsUsed).toEqual([]);
+    });
+  });
+});
+
+/*
+ * ------------------------------------------------------------------------- *
+ * (F) The wiring: what UserOnCallLogService does with all of that.
+ * -------------------------------------------------------------------------
+ */
+
+describe("UserOnCallLogService.handleNoMatchingNotificationRule", () => {
+  let logUpdateSpy: jest.SpyInstance;
+  let timelineUpdateSpy: jest.SpyInstance;
+  let optOutFindSpy: jest.SpyInstance;
+  let projectFindSpy: jest.SpyInstance;
+  let fallbackSpy: jest.SpyInstance;
+  let userFindSpy: jest.SpyInstance;
+  let alertOwnersSpy: jest.SpyInstance;
+  let loggerErrorSpy: jest.SpyInstance;
+
+  interface StatusUpdateCall {
+    id: ObjectID;
+    data: {
+      status?: UserNotificationExecutionStatus | undefined;
+      statusMessage?: string | undefined;
+    };
+    props: { isRoot: boolean };
+  }
+
+  interface TimelineUpdateCall {
+    id: ObjectID;
+    data: {
+      status?: OnCallDutyExecutionLogTimelineStatus | undefined;
+      statusMessage?: string | undefined;
+    };
+    props: { isRoot: boolean };
+  }
+
+  interface UndeliverableAlertCall {
+    projectId: ObjectID;
+    userId: ObjectID;
+    ruleType: NotificationRuleType;
+    severityName: string;
+    onCallDutyPolicyId: ObjectID | undefined;
+    fallbackChannelsUsed: Array<string>;
+  }
+
+  function makeCreatedLog(): UserOnCallLog {
+    return {
+      id: LOG_ID,
+      _id: LOG_ID.toString(),
+      projectId: PROJECT_ID,
+      userId: USER_ID,
+      userNotificationEventType: UserNotificationEventType.IncidentCreated,
+      triggeredByIncidentId: INCIDENT_ID,
+      onCallDutyPolicyId: POLICY_ID,
+      onCallDutyPolicyExecutionLogTimelineId: TIMELINE_ID,
+    } as unknown as UserOnCallLog;
+  }
+
+  function callHandleNoMatchingNotificationRule(): Promise<void> {
+    return (
+      UserOnCallLogService as unknown as UserOnCallLogServiceInternals
+    ).handleNoMatchingNotificationRule({
+      createdItem: makeCreatedLog(),
+      notificationRuleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: INCIDENT_SEVERITY_ID,
+      alertSeverityId: undefined,
+      severityName: SEVERITY_NAME,
+    });
+  }
+
+  function statusUpdates(): Array<StatusUpdateCall> {
+    return logUpdateSpy.mock.calls.map(
+      (call: Array<unknown>): StatusUpdateCall => {
+        return call[0] as StatusUpdateCall;
+      },
+    );
+  }
+
+  function timelineUpdates(): Array<TimelineUpdateCall> {
+    return timelineUpdateSpy.mock.calls.map(
+      (call: Array<unknown>): TimelineUpdateCall => {
+        return call[0] as TimelineUpdateCall;
+      },
+    );
+  }
+
+  function lastStatusUpdate(): StatusUpdateCall {
+    const updates: Array<StatusUpdateCall> = statusUpdates();
+
+    return updates[updates.length - 1]!;
+  }
+
+  beforeEach(() => {
+    loggerErrorSpy = jest
+      .spyOn(logger, "error")
+      .mockImplementation((): void => {
+        return undefined;
+      });
+
+    logUpdateSpy = jest
+      .spyOn(UserOnCallLogService, "updateOneById")
+      .mockResolvedValue(undefined as never);
+
+    timelineUpdateSpy = jest
+      .spyOn(OnCallDutyPolicyExecutionLogTimelineService, "updateOneById")
+      .mockResolvedValue(undefined as never);
+
+    // No opt-out row: the interesting default is the one where a page is due.
+    optOutFindSpy = jest
+      .spyOn(UserNotificationRuleService, "findOneBy")
+      .mockResolvedValue(null as never);
+
+    // Fallback enabled, which is the product default.
+    projectFindSpy = jest
+      .spyOn(ProjectService, "findOneById")
+      .mockResolvedValue(makeProject() as never);
+
+    fallbackSpy = jest
+      .spyOn(UserNotificationRuleService, "executeFallbackNotification")
+      .mockResolvedValue({
+        outcome: FallbackNotificationOutcome.Delivered,
+        notified: true,
+        channelsUsed: ["Push", "Email"],
+      } as never);
+
+    userFindSpy = jest.spyOn(UserService, "findOneById").mockResolvedValue({
+      name: new Name(RESPONDER_NAME),
+    } as never);
+
+    alertOwnersSpy = jest
+      .spyOn(OnCallNotificationAlertingService, "notifyOfUndeliverablePage")
+      .mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("an opt-out row means deliberate silence", () => {
+    test("the log is Completed and the timeline says Skipped", async () => {
+      optOutFindSpy.mockResolvedValue({ _id: "opt-out-row" } as never);
+
+      await callHandleNoMatchingNotificationRule();
+
+      /*
+       * Completed, not Error: the system did exactly what it was told to do.
+       * Skipped rather than Notification Sent because nothing was in fact sent,
+       * and an operator scanning the escalation has to be able to tell "muted
+       * on purpose" from "delivered".
+       */
+      expect(lastStatusUpdate().data.status).toBe(
+        UserNotificationExecutionStatus.Completed,
+      );
+      expect(lastStatusUpdate().data.statusMessage).toContain("opted out");
+      expect(timelineUpdates()[0]!.data.status).toBe(
+        OnCallDutyExecutionLogTimelineStatus.Skipped,
+      );
+      expect(timelineUpdates()[0]!.id.toString()).toBe(TIMELINE_ID.toString());
+    });
+
+    test("the fallback is NEVER called, and the project is not even read", async () => {
+      optOutFindSpy.mockResolvedValue({ _id: "opt-out-row" } as never);
+
+      await callHandleNoMatchingNotificationRule();
+
+      /*
+       * The opt-out is checked FIRST, before the project setting and before any
+       * delivery. Paging somebody who asked not to be paged is the one failure
+       * mode the fallback could introduce, and this is what forecloses it.
+       */
+      expect(fallbackSpy).not.toHaveBeenCalled();
+      expect(projectFindSpy).not.toHaveBeenCalled();
+    });
+
+    test("nobody is alerted - an opt-out is not a misconfiguration", async () => {
+      optOutFindSpy.mockResolvedValue({ _id: "opt-out-row" } as never);
+
+      await callHandleNoMatchingNotificationRule();
+
+      expect(alertOwnersSpy).not.toHaveBeenCalled();
+    });
+
+    test("the opt-out lookup asks for exactly the cell that came up empty", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      const query: Record<string, unknown> = (
+        optOutFindSpy.mock.calls[0]![0] as { query: Record<string, unknown> }
+      ).query;
+
+      expect((query["userId"] as ObjectID).toString()).toBe(USER_ID.toString());
+      expect((query["projectId"] as ObjectID).toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+      expect(query["ruleType"]).toBe(
+        NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      );
+      expect((query["incidentSeverityId"] as ObjectID).toString()).toBe(
+        INCIDENT_SEVERITY_ID.toString(),
+      );
+      expect(query["isOptOut"]).toBe(true);
+    });
+  });
+
+  describe("disableOnCallNotificationFallback restores the old dead-end", () => {
+    beforeEach(() => {
+      projectFindSpy.mockResolvedValue(
+        makeProject({ disableOnCallNotificationFallback: true }) as never,
+      );
+    });
+
+    test("the log and the timeline both carry the ORIGINAL sentence, verbatim", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      /*
+       * A project that sets this flag is asking for precisely the pre-fallback
+       * behaviour, so it must receive precisely the pre-fallback words -
+       * operators grep their execution logs for this sentence.
+       */
+      expect(lastStatusUpdate().data.status).toBe(
+        UserNotificationExecutionStatus.Error,
+      );
+      expect(lastStatusUpdate().data.statusMessage).toBe(
+        NO_NOTIFICATION_RULES_STATUS_MESSAGE,
+      );
+      expect(timelineUpdates()[0]!.data.status).toBe(
+        OnCallDutyExecutionLogTimelineStatus.Error,
+      );
+      expect(timelineUpdates()[0]!.data.statusMessage).toBe(
+        NO_NOTIFICATION_RULES_STATUS_MESSAGE,
+      );
+    });
+
+    test("the fallback is never called - the project is never billed for one", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      expect(fallbackSpy).not.toHaveBeenCalled();
+    });
+
+    test("the owner alert IS still fired, with an empty channel list", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      /*
+       * This one is a real bug that was written and then fixed: the early
+       * return sat ABOVE the alert, so the owner notification reached every
+       * project except the one that needs it most. A project that has switched
+       * the fallback off is the population still losing pages exactly the way
+       * they were lost before any of this existed.
+       */
+      expect(alertOwnersSpy).toHaveBeenCalledTimes(1);
+
+      const alerted: UndeliverableAlertCall = alertOwnersSpy.mock
+        .calls[0]![0] as UndeliverableAlertCall;
+      expect(alerted.projectId.toString()).toBe(PROJECT_ID.toString());
+      expect(alerted.userId.toString()).toBe(USER_ID.toString());
+      expect(alerted.ruleType).toBe(
+        NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      );
+      expect(alerted.severityName).toBe(SEVERITY_NAME);
+      expect(alerted.onCallDutyPolicyId!.toString()).toBe(POLICY_ID.toString());
+      // Empty means "this responder was not reached at all".
+      expect(alerted.fallbackChannelsUsed).toEqual([]);
+    });
+  });
+
+  describe("the fallback delivered", () => {
+    test("the log is left Executing, not Completed and not Error", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      /*
+       * Executing matches the normal path: there are no further rules to fire,
+       * so ExecutePendingExecutions finds an empty rule list on its next tick
+       * and closes the log out as Completed.
+       */
+      expect(lastStatusUpdate().data.status).toBe(
+        UserNotificationExecutionStatus.Executing,
+      );
+    });
+
+    test("the message names the severity and the channels that carried the page", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      const message: string | undefined = lastStatusUpdate().data.statusMessage;
+      expect(message).toContain(
+        `No notification rule configured for ${SEVERITY_NAME}`,
+      );
+      expect(message).toContain("notified via fallback (Push, Email)");
+      // The old dead-end sentence is not written on this path at all.
+      expect(message).not.toBe(NO_NOTIFICATION_RULES_STATUS_MESSAGE);
+    });
+
+    test("the timeline says Notification Sent with the SAME message as the log", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      expect(timelineUpdates()).toHaveLength(1);
+      expect(timelineUpdates()[0]!.data.status).toBe(
+        OnCallDutyExecutionLogTimelineStatus.NotificationSent,
+      );
+      // Two records of one event must not tell an operator two stories.
+      expect(timelineUpdates()[0]!.data.statusMessage).toBe(
+        lastStatusUpdate().data.statusMessage,
+      );
+    });
+
+    test("the fallback is handed this log, this responder and this severity", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      expect(fallbackSpy).toHaveBeenCalledTimes(1);
+      const options: Record<string, unknown> = fallbackSpy.mock
+        .calls[0]![0] as Record<string, unknown>;
+
+      expect((options["userId"] as ObjectID).toString()).toBe(
+        USER_ID.toString(),
+      );
+      expect((options["projectId"] as ObjectID).toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+      expect((options["userOnCallLogId"] as ObjectID).toString()).toBe(
+        LOG_ID.toString(),
+      );
+      expect((options["userNotificationLogId"] as ObjectID).toString()).toBe(
+        LOG_ID.toString(),
+      );
+      expect(options["ruleType"]).toBe(
+        NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      );
+      expect(options["severityName"]).toBe(SEVERITY_NAME);
+      expect(options["userNotificationEventType"]).toBe(
+        UserNotificationEventType.IncidentCreated,
+      );
+      expect((options["triggeredByIncidentId"] as ObjectID).toString()).toBe(
+        INCIDENT_ID.toString(),
+      );
+    });
+
+    test("the humans are still told - a delivered fallback is still a misconfiguration", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      expect(alertOwnersSpy).toHaveBeenCalledTimes(1);
+      const alerted: UndeliverableAlertCall = alertOwnersSpy.mock
+        .calls[0]![0] as UndeliverableAlertCall;
+      /*
+       * A non-empty list is the "your configuration is wrong but nobody was
+       * dropped" signal, and it is what tells the two branches apart at the
+       * single call site.
+       */
+      expect(alerted.fallbackChannelsUsed).toEqual(["Push", "Email"]);
+    });
+  });
+
+  describe("the fallback found nothing to page the responder on", () => {
+    beforeEach(() => {
+      fallbackSpy.mockResolvedValue({
+        outcome: FallbackNotificationOutcome.NoUsableNotificationMethod,
+        notified: false,
+        channelsUsed: [],
+      } as never);
+    });
+
+    test("the log ends terminally, naming the responder and what to do about it", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      expect(lastStatusUpdate().data.status).toBe(
+        UserNotificationExecutionStatus.Error,
+      );
+      expect(lastStatusUpdate().data.statusMessage).toContain(RESPONDER_NAME);
+      expect(lastStatusUpdate().data.statusMessage).toContain(
+        "has no verified notification method",
+      );
+      expect(lastStatusUpdate().data.statusMessage).toContain(
+        "User Settings > Notification Methods",
+      );
+      expect(timelineUpdates()[0]!.data.status).toBe(
+        OnCallDutyExecutionLogTimelineStatus.Error,
+      );
+    });
+
+    test("a responder whose name cannot be read degrades to a neutral phrase", async () => {
+      userFindSpy.mockResolvedValue(null as never);
+
+      await callHandleNoMatchingNotificationRule();
+
+      /*
+       * The lookup only ever feeds a string, so a deleted user must not cost a
+       * status message - let alone throw out of the paging path.
+       */
+      expect(lastStatusUpdate().data.statusMessage).toContain("This responder");
+      expect(lastStatusUpdate().data.status).toBe(
+        UserNotificationExecutionStatus.Error,
+      );
+    });
+
+    test("the owners hear about it with an empty channel list", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      const alerted: UndeliverableAlertCall = alertOwnersSpy.mock
+        .calls[0]![0] as UndeliverableAlertCall;
+      expect(alerted.fallbackChannelsUsed).toEqual([]);
+    });
+  });
+
+  describe("the fallback tried and failed", () => {
+    test("a DeliveryFailed outcome does NOT claim the responder is unreachable", async () => {
+      fallbackSpy.mockResolvedValue({
+        outcome: FallbackNotificationOutcome.DeliveryFailed,
+        notified: false,
+        channelsUsed: [],
+      } as never);
+
+      await callHandleNoMatchingNotificationRule();
+
+      /*
+       * Sending the operator after a notification method that already exists
+       * wastes the one action the message is supposed to buy.
+       */
+      expect(lastStatusUpdate().data.statusMessage).toContain(
+        "the fallback delivery attempt failed",
+      );
+      expect(lastStatusUpdate().data.statusMessage).not.toContain(
+        "has no verified notification method",
+      );
+      expect(lastStatusUpdate().data.status).toBe(
+        UserNotificationExecutionStatus.Error,
+      );
+    });
+
+    test("a fallback that THREW still ends the log at Error, never at Executing", async () => {
+      fallbackSpy.mockRejectedValue(new Error("smtp exploded") as never);
+
+      await callHandleNoMatchingNotificationRule();
+
+      /*
+       * REGRESSION GUARD, and the reason this test exists at all: leaving the
+       * log Executing here looks like the kind thing to do - "transient
+       * failure, let the worker retry" - and it is a worse bug than the one it
+       * avoids. Nothing re-enters this function; it runs once, from
+       * onCreateSuccess, at the moment the row is written. So the next
+       * ExecutePendingExecutions tick picks the log up, queries for due rules,
+       * finds none (there were never any - that is why we are here), takes its
+       * all-executed path and marks the log COMPLETED. onUpdateSuccess then
+       * translates Completed into Notification Sent on the escalation timeline,
+       * and within a minute the record reads "Alert Sent" for a page that was
+       * never delivered.
+       */
+      expect(lastStatusUpdate().data.status).toBe(
+        UserNotificationExecutionStatus.Error,
+      );
+      expect(lastStatusUpdate().data.status).not.toBe(
+        UserNotificationExecutionStatus.Executing,
+      );
+      expect(timelineUpdates()[0]!.data.status).toBe(
+        OnCallDutyExecutionLogTimelineStatus.Error,
+      );
+      expect(timelineUpdates()[0]!.data.statusMessage).toBe(
+        lastStatusUpdate().data.statusMessage,
+      );
+    });
+
+    test("a fallback that threw is contained: the escalation is not taken down with it", async () => {
+      fallbackSpy.mockRejectedValue(new Error("smtp exploded") as never);
+
+      /*
+       * The caller is part-way through paging an entire escalation level. A
+       * throw out of here would abort every responder queued behind this one.
+       */
+      await expect(
+        callHandleNoMatchingNotificationRule(),
+      ).resolves.toBeUndefined();
+      expect(loggerErrorSpy).toHaveBeenCalled();
+    });
+
+    test("a fallback that threw still tells the humans", async () => {
+      fallbackSpy.mockRejectedValue(new Error("smtp exploded") as never);
+
+      await callHandleNoMatchingNotificationRule();
+
+      expect(alertOwnersSpy).toHaveBeenCalledTimes(1);
+      const alerted: UndeliverableAlertCall = alertOwnersSpy.mock
+        .calls[0]![0] as UndeliverableAlertCall;
+      expect(alerted.fallbackChannelsUsed).toEqual([]);
+    });
+  });
+
+  describe("the owner alert is fire-and-forget", () => {
+    test("a REJECTING notifyOfUndeliverablePage does not reject the paging path", async () => {
+      alertOwnersSpy.mockRejectedValue(
+        new Error("owner lookup exploded") as never,
+      );
+
+      /*
+       * The alert is an explanation of a delivery problem. A bug in the
+       * explanation must never propagate into - or delay - the paging path that
+       * produced it.
+       */
+      await expect(
+        callHandleNoMatchingNotificationRule(),
+      ).resolves.toBeUndefined();
+
+      await flushMicrotasks();
+
+      // Swallowed into the log rather than lost silently.
+      expect(loggerErrorSpy).toHaveBeenCalled();
+    });
+
+    test("a rejecting alert does not disturb the statuses that were already written", async () => {
+      alertOwnersSpy.mockRejectedValue(
+        new Error("owner lookup exploded") as never,
+      );
+
+      await callHandleNoMatchingNotificationRule();
+      await flushMicrotasks();
+
+      expect(lastStatusUpdate().data.status).toBe(
+        UserNotificationExecutionStatus.Executing,
+      );
+      expect(timelineUpdates()[0]!.data.status).toBe(
+        OnCallDutyExecutionLogTimelineStatus.NotificationSent,
+      );
+    });
+
+    test("the alert is NOT awaited - the paging path returns while it is still pending", async () => {
+      let release: () => void = (): void => {
+        return undefined;
+      };
+      const pending: Promise<void> = new Promise<void>(
+        (resolve: () => void): void => {
+          release = resolve;
+        },
+      );
+      alertOwnersSpy.mockReturnValue(pending);
+
+      /*
+       * If the alert were awaited, this await would never settle and the test
+       * would time out. Reaching the next line IS the assertion.
+       */
+      await callHandleNoMatchingNotificationRule();
+
+      expect(alertOwnersSpy).toHaveBeenCalledTimes(1);
+
+      release();
+      await pending;
+    });
+  });
+
+  describe("the writes the no-rule path makes", () => {
+    test("the log is written before the on-call timeline", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      /*
+       * Order matters: updateOneById's own onUpdateSuccess hook maps the
+       * execution status onto the timeline, and the explicit second write is
+       * what lets this path say something the mapping cannot - Skipped for an
+       * opt-out, Notification Sent under an Executing log.
+       */
+      expect(logUpdateSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        timelineUpdateSpy.mock.invocationCallOrder[0] as number,
+      );
+    });
+
+    test("exactly one log write and one timeline write, both as root", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      expect(statusUpdates()).toHaveLength(1);
+      expect(timelineUpdates()).toHaveLength(1);
+      expect(statusUpdates()[0]!.id.toString()).toBe(LOG_ID.toString());
+      expect(statusUpdates()[0]!.props.isRoot).toBe(true);
+      expect(timelineUpdates()[0]!.id.toString()).toBe(TIMELINE_ID.toString());
+      expect(timelineUpdates()[0]!.props.isRoot).toBe(true);
+    });
+
+    test("the timeline never says the generic 'Alert Sent' on this path", async () => {
+      await callHandleNoMatchingNotificationRule();
+
+      /*
+       * The normal path writes "Alert Sent". A fallback delivery deliberately
+       * writes something an operator can act on instead, so it can never be
+       * mistaken for a configured one.
+       */
+      expect(timelineUpdates()[0]!.data.statusMessage).not.toBe("Alert Sent");
+    });
+  });
+});

--- a/Common/Tests/Server/Services/SeverityCreationRuleBackfill.test.ts
+++ b/Common/Tests/Server/Services/SeverityCreationRuleBackfill.test.ts
@@ -8,8 +8,13 @@ import IncidentSeverityService, {
   Service as IncidentSeverityServiceClass,
 } from "../../../Server/Services/IncidentSeverityService";
 import OnCallDutyPolicyExecutionLogTimelineService from "../../../Server/Services/OnCallDutyPolicyExecutionLogTimelineService";
-import UserNotificationRuleService from "../../../Server/Services/UserNotificationRuleService";
+import ProjectService from "../../../Server/Services/ProjectService";
+import UserNotificationRuleService, {
+  FallbackNotificationOutcome,
+} from "../../../Server/Services/UserNotificationRuleService";
 import UserOnCallLogService from "../../../Server/Services/UserOnCallLogService";
+import UserService from "../../../Server/Services/UserService";
+import Queue, { QueueName } from "../../../Server/Infrastructure/Queue";
 import CreateBy from "../../../Server/Types/Database/CreateBy";
 import { OnCreate } from "../../../Server/Types/Database/Hooks";
 import Alert from "../../../Models/DatabaseModels/Alert";
@@ -29,42 +34,56 @@ import UserNotificationExecutionStatus from "../../../Types/UserNotification/Use
 import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
 
 /*
- * GAP A — a severity created after a user joined is a severity that user has no
- * notification rule for, and nothing anywhere backfills one.
+ * GAP A — a severity created after a user joined was a severity that user had
+ * no notification rule for, and nothing anywhere backfilled one.
  *
  * The default rules a responder gets are written by
  * UserNotificationRuleService.addDefaultNotificationRulesForVerifiedMethod(),
  * whose two severity-shaped halves — createIncidentOnCallRules() and
  * createAlertOnCallRules() — iterate the severities that exist AT THE MOMENT
  * THEY RUN. They run when a member joins a project, when a notification method
- * is verified, and in the MigrateDefaultUserNotificationRule migration. They do
- * NOT run when a severity is created, because neither IncidentSeverityService
- * nor AlertSeverityService defines any create-success hook at all: both stop at
- * onBeforeCreate, whose entire job is order rearrangement.
+ * is verified, and in the MigrateDefaultUserNotificationRule migration. They did
+ * NOT run when a severity was created, because neither IncidentSeverityService
+ * nor AlertSeverityService defined any create-success hook at all: both stopped
+ * at onBeforeCreate, whose entire job is order rearrangement.
  *
- * So "add a Sev4 a year into the project" is a silent paging outage for every
+ * So "add a Sev4 a year into the project" was a silent paging outage for every
  * existing user: UserOnCallLogService.onCreateSuccess counts rules with
- * { userId, projectId, ruleType, incidentSeverityId }, gets zero, writes
+ * { userId, projectId, ruleType, incidentSeverityId }, got zero, wrote
  * "No notification rules found for this user." into an execution log nobody
- * reads, and returns without paging anyone.
+ * reads, and returned without paging anyone.
  *
- * This file pins that behaviour in three layers:
+ * PHASE 1 CLOSED THIS, on two independent fronts, and this file now pins both:
  *
- *   (A) Neither severity service touches UserNotificationRuleService. Proven
- *       structurally (the create-side hooks they override, and the fact that
- *       onCreateSuccess is still DatabaseService's placeholder) and
- *       behaviourally (drive every hook they DO define; assert zero rules).
- *   (B) Rule creation is severity-snapshot-driven. The same user, the same
- *       project, run once against two severities and once against three, and
- *       the third severity only ever gets a rule because the method was called
- *       a SECOND time — which nothing does when a severity is created.
- *   (C) The resulting hole, asserted through the real runtime query. A user with
- *       rules for [A, B] and a project with severities [A, B, C] has zero rules
- *       matching a C-severity incident, so the page is dropped.
+ *   (A) Creating a severity enqueues
+ *       "OnCallDutyPolicy:BackfillNotificationRulesForNewSeverities" onto the
+ *       Worker queue. Proven structurally (onCreateSuccess is now an own
+ *       property on both services, no longer DatabaseService's placeholder) and
+ *       behaviourally (drive the hooks; assert the enqueue, its queue, its name
+ *       and its payload). The fan-out itself stays OUT of the request — a
+ *       project can hold thousands of responders — so "no rules written inline"
+ *       is still asserted, but it no longer means "no backfill".
+ *   (B) Rule creation is still severity-snapshot-driven, and that is fine now
+ *       that something else revisits the snapshot. This section is unchanged: it
+ *       documents why the backfill has to exist.
+ *   (C) The runtime hole. A user with rules for [A, B] and a project with
+ *       severities [A, B, C] still has zero rules matching a C-severity
+ *       incident — but the page is no longer dropped. UserOnCallLogService now
+ *       reaches for the verified-method fallback instead of the dead-end, so the
+ *       responder is notified and the log says so.
  *
- * Sections A and B are the buggy-by-design half. Every assertion carrying the
- * "GAP A" banner is one Phase 1 is expected to INVERT once the backfill lands.
+ * Assertions that used to carry the "GAP A" banner now carry "GAP A CLOSED" and
+ * state the post-Phase-1 behaviour.
  */
+
+/*
+ * Mirrors the private constant in IncidentSeverityService / AlertSeverityService,
+ * which in turn mirrors the RunCron job name in
+ * App/FeatureSet/Workers/Jobs/OnCallDutyPolicy/BackfillNotificationRulesForNewSeverities.ts.
+ * If a rename ever misses one of the three, this is where it surfaces.
+ */
+const BACKFILL_JOB_NAME: string =
+  "OnCallDutyPolicy:BackfillNotificationRulesForNewSeverities";
 
 const PROJECT_ID: ObjectID = new ObjectID("project-1");
 const USER_ID: ObjectID = new ObjectID("user-1");
@@ -104,6 +123,7 @@ interface StoredRule {
   alertSeverityId: string | undefined;
   notifyAfterMinutes: number | undefined;
   userEmailId: string | undefined;
+  isOptOut: boolean | undefined;
 }
 
 let ruleStore: Array<StoredRule> = [];
@@ -157,6 +177,35 @@ function ruleMatchesQuery(
     return false;
   }
 
+  /*
+   * isOptOut appears in queries in TWO different shapes, and conflating them
+   * makes this matcher reject everything.
+   *
+   *   - As a literal `true`: the no-rule path's opt-out lookup, asking whether
+   *     this exact (ruleType x severity) cell was deliberately muted.
+   *   - As a PREDICATE OBJECT: every counting and execution query excludes
+   *     opt-out rows with notOptOutRuleQuery(), which is
+   *     QueryHelper.notInOrNull(["true"]) - a TypeORM operator, not a boolean.
+   *     It is deliberately null-tolerant: isOptOut is nullable and every rule
+   *     written before the column existed has it NULL, so a plain
+   *     `isOptOut: false` would match none of them and quietly exclude every
+   *     pre-existing rule from paging.
+   *
+   * A boolean is compared directly; anything else is the exclusion predicate,
+   * which a row satisfies precisely when it is not an opt-out.
+   */
+  const expectedIsOptOut: unknown = query["isOptOut"];
+
+  if (expectedIsOptOut !== undefined) {
+    if (typeof expectedIsOptOut === "boolean") {
+      if (Boolean(rule.isOptOut) !== expectedIsOptOut) {
+        return false;
+      }
+    } else if (rule.isOptOut === true) {
+      return false;
+    }
+  }
+
   return true;
 }
 
@@ -166,9 +215,16 @@ function matchingRules(query: Record<string, unknown>): Array<StoredRule> {
   });
 }
 
-/* Remove a column the way a request that simply omitted it would. */
-function unsetColumn(model: Record<string, unknown>, column: string): void {
-  Reflect.deleteProperty(model, column);
+/*
+ * Remove a column the way a request that simply omitted it would.
+ *
+ * Takes `unknown` and narrows inside, the way callHook below does. Callers hand
+ * it a model INSTANCE, and a class with declared properties is not assignable to
+ * Record<string, unknown> under this repo's strict config - while `object` is
+ * banned by the lint rules. Widening at the boundary satisfies both.
+ */
+function unsetColumn(model: unknown, column: string): void {
+  Reflect.deleteProperty(model as Record<string, unknown>, column);
 }
 
 // Calls a protected hook without widening the service's public surface.
@@ -188,8 +244,9 @@ function callHook(
   return hooks[name]!.apply(service, args);
 }
 
-function ownHookNames(prototype: Record<string, unknown>): Array<string> {
-  return Object.getOwnPropertyNames(prototype)
+// Same reason as unsetColumn: callers pass a class prototype, not a map.
+function ownHookNames(prototype: unknown): Array<string> {
+  return Object.getOwnPropertyNames(prototype as Record<string, unknown>)
     .filter((name: string): boolean => {
       return name.startsWith("on");
     })
@@ -276,6 +333,7 @@ function stubUserNotificationRuleStore(): void {
       alertSeverityId: toIdString(model.alertSeverityId),
       notifyAfterMinutes: model.notifyAfterMinutes,
       userEmailId: toIdString(model.userEmailId),
+      isOptOut: model.isOptOut,
     });
 
     return Promise.resolve(model);
@@ -339,14 +397,29 @@ afterEach(() => {
 
 /*
  * ========================================================================= *
- * (A) Neither severity service has anything to do with notification rules.
+ * (A) Creating a severity now queues the backfill.
+ *
+ * GAP A CLOSED IN PHASE 1. This section used to prove the opposite: that
+ * neither severity service had any create-success hook at all, and that
+ * committing a severity row was followed by exactly nothing. Both services now
+ * override onCreateSuccess and enqueue
+ * "OnCallDutyPolicy:BackfillNotificationRulesForNewSeverities" onto the Worker
+ * queue.
+ *
+ * Note what did NOT change, and why it is still asserted: no rule is written
+ * inline. That is deliberate rather than residual. A project can hold thousands
+ * of responders and this hook runs inside the request that created the
+ * severity, so the fan-out belongs to the worker. "No inline rule creation" and
+ * "no backfill" used to be the same observation; they are now opposites, and
+ * the enqueue assertion is what tells them apart.
  * =========================================================================
  */
 
-describe("GAP A - IncidentSeverityService defines no rule-backfilling create hook", () => {
+describe("GAP A CLOSED - IncidentSeverityService queues the rule backfill on create", () => {
   let createSpy: jest.SpyInstance;
   let addDefaultsForMethodSpy: jest.SpyInstance;
   let addDefaultsForUserSpy: jest.SpyInstance;
+  let addJobSpy: jest.SpyInstance;
 
   beforeEach(() => {
     /*
@@ -360,6 +433,9 @@ describe("GAP A - IncidentSeverityService defines no rule-backfilling create hoo
     jest
       .spyOn(IncidentSeverityService, "updateOneBy")
       .mockResolvedValue(0 as never);
+
+    // The queue is the hook's only side effect; never reach Redis for it.
+    addJobSpy = jest.spyOn(Queue, "addJob").mockResolvedValue({} as never);
 
     createSpy = jest
       .spyOn(UserNotificationRuleService, "create")
@@ -387,32 +463,41 @@ describe("GAP A - IncidentSeverityService defines no rule-backfilling create hoo
     } as CreateBy<IncidentSeverity>;
   }
 
-  function expectNoRuleCreation(): void {
+  function createdSeverity(): IncidentSeverity {
+    const created: IncidentSeverity = new IncidentSeverity();
+    created._id = SEV_C.toString();
+    created.projectId = PROJECT_ID;
+
+    return created;
+  }
+
+  function expectNoInlineRuleCreation(): void {
     expect(createSpy).not.toHaveBeenCalled();
     expect(addDefaultsForMethodSpy).not.toHaveBeenCalled();
     expect(addDefaultsForUserSpy).not.toHaveBeenCalled();
   }
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts. Once
-   * IncidentSeverityService gains an onCreateSuccess that mirrors each existing
-   * user's methods onto the new severity, "onCreateSuccess" joins this list.
+   * GAP A CLOSED - onCreateSuccess is the hook Phase 1 added, so it now appears
+   * in this list. The rest of the list is unchanged: the backfill hangs off the
+   * success hook, not off any of the before-hooks.
    */
-  test("the only create-side hook it overrides is onBeforeCreate", () => {
+  test("it overrides onCreateSuccess alongside its ordering hooks", () => {
     expect(ownHookNames(IncidentSeverityServiceClass.prototype)).toEqual([
       "onBeforeCreate",
       "onBeforeDelete",
       "onBeforeUpdate",
+      "onCreateSuccess",
       "onDeleteSuccess",
     ]);
   });
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts. Sharing
-   * DatabaseService's identity is the precise statement of "does nothing":
-   * the inherited placeholder returns the created item and stops.
+   * GAP A CLOSED - the inverse of the original assertion. Sharing
+   * DatabaseService's identity was the precise statement of "does nothing"; a
+   * distinct own property is the precise statement that it now does something.
    */
-  test("onCreateSuccess is still DatabaseService's do-nothing placeholder", () => {
+  test("onCreateSuccess is no longer DatabaseService's do-nothing placeholder", () => {
     const proto: Record<string, unknown> =
       IncidentSeverityServiceClass.prototype as unknown as Record<
         string,
@@ -421,13 +506,13 @@ describe("GAP A - IncidentSeverityService defines no rule-backfilling create hoo
     const base: Record<string, unknown> =
       DatabaseService.prototype as unknown as Record<string, unknown>;
 
-    expect(proto["onCreateSuccess"]).toBe(base["onCreateSuccess"]);
+    expect(proto["onCreateSuccess"]).not.toBe(base["onCreateSuccess"]);
     expect(
       Object.prototype.hasOwnProperty.call(
         IncidentSeverityServiceClass.prototype,
         "onCreateSuccess",
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   test("it does not override onCreateError either, so there is no rule work on the failure path", () => {
@@ -440,16 +525,20 @@ describe("GAP A - IncidentSeverityService defines no rule-backfilling create hoo
   });
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts.
+   * GAP A CLOSED - the backfill hangs off onCreateSuccess, so the before-hook
+   * on its own still queues nothing and writes nothing. A severity that fails
+   * validation must not leave a backfill job behind for a row that was never
+   * committed.
    */
-  test("driving onBeforeCreate for a brand new severity creates no notification rules", async () => {
+  test("driving onBeforeCreate alone neither writes rules nor queues the backfill", async () => {
     await callHook(
       IncidentSeverityService,
       "onBeforeCreate",
       createBySeverity(),
     );
 
-    expectNoRuleCreation();
+    expectNoInlineRuleCreation();
+    expect(addJobSpy).not.toHaveBeenCalled();
   });
 
   test("onBeforeCreate only rearranges sibling order - that is its whole job", async () => {
@@ -465,15 +554,15 @@ describe("GAP A - IncidentSeverityService defines no rule-backfilling create hoo
     );
 
     expect(findBySpy).toHaveBeenCalledTimes(1);
-    expectNoRuleCreation();
+    expectNoInlineRuleCreation();
   });
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts. Driving the full
-   * create sequence (before-hook then success-hook) is the behavioural proof:
-   * the severity row is committed and not one rule follows it.
+   * GAP A CLOSED - driving the full create sequence is the behavioural proof.
+   * The severity row is committed and a backfill job follows it, on the Worker
+   * queue, named for the cron that owns it.
    */
-  test("the full create sequence (onBeforeCreate then onCreateSuccess) creates no rules", async () => {
+  test("the full create sequence queues the backfill job", async () => {
     const createBy: CreateBy<IncidentSeverity> = createBySeverity();
 
     const onCreate: OnCreate<IncidentSeverity> = (await callHook(
@@ -482,9 +571,7 @@ describe("GAP A - IncidentSeverityService defines no rule-backfilling create hoo
       createBy,
     )) as OnCreate<IncidentSeverity>;
 
-    const created: IncidentSeverity = new IncidentSeverity();
-    created._id = SEV_C.toString();
-    created.projectId = PROJECT_ID;
+    const created: IncidentSeverity = createdSeverity();
 
     const returned: unknown = await callHook(
       IncidentSeverityService,
@@ -493,9 +580,36 @@ describe("GAP A - IncidentSeverityService defines no rule-backfilling create hoo
       created,
     );
 
-    // The placeholder hands the created item straight back, untouched.
+    // The hook still hands the created item straight back.
     expect(returned).toBe(created);
-    expectNoRuleCreation();
+
+    expect(addJobSpy).toHaveBeenCalledTimes(1);
+    const call: Array<unknown> = addJobSpy.mock.calls[0]!;
+    expect(call[0]).toBe(QueueName.Worker);
+    expect(call[2]).toBe(BACKFILL_JOB_NAME);
+
+    // Still nothing inline - the fan-out is the worker's job, not the request's.
+    expectNoInlineRuleCreation();
+  });
+
+  /*
+   * GAP A CLOSED - a queue that is unreachable must not take the severity down
+   * with it. The scheduled sweep inside the backfill job re-scans recently
+   * created severities, so a dropped enqueue costs latency, not coverage.
+   */
+  test("an enqueue failure is swallowed and the created item is still returned", async () => {
+    addJobSpy.mockRejectedValue(new Error("redis is down") as never);
+
+    const created: IncidentSeverity = createdSeverity();
+
+    const returned: unknown = await callHook(
+      IncidentSeverityService,
+      "onCreateSuccess",
+      { createBy: createBySeverity(), carryForward: null },
+      created,
+    );
+
+    expect(returned).toBe(created);
   });
 
   test("a severity with no order is rejected, and still nothing touches rules", async () => {
@@ -506,7 +620,7 @@ describe("GAP A - IncidentSeverityService defines no rule-backfilling create hoo
       callHook(IncidentSeverityService, "onBeforeCreate", createBy),
     ).rejects.toBeInstanceOf(BadDataException);
 
-    expectNoRuleCreation();
+    expectNoInlineRuleCreation();
   });
 
   test("a severity with no projectId is rejected, and still nothing touches rules", async () => {
@@ -517,15 +631,16 @@ describe("GAP A - IncidentSeverityService defines no rule-backfilling create hoo
       callHook(IncidentSeverityService, "onBeforeCreate", createBy),
     ).rejects.toBeInstanceOf(BadDataException);
 
-    expectNoRuleCreation();
+    expectNoInlineRuleCreation();
   });
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts. This is the
-   * user-visible consequence stated as a test: however many people are already
-   * in the project, creating a severity considers none of them.
+   * GAP A CLOSED - the user-visible consequence, inverted. However many people
+   * are already in the project, creating a severity used to consider none of
+   * them. It still enumerates none of them HERE, because it hands the whole
+   * question to a job that carries the project and severity that changed.
    */
-  test("three existing project users are all left uncovered by the new severity", async () => {
+  test("the queued job names the project and severity whose responders need covering", async () => {
     const createBy: CreateBy<IncidentSeverity> = createBySeverity();
 
     const onCreate: OnCreate<IncidentSeverity> = (await callHook(
@@ -534,37 +649,39 @@ describe("GAP A - IncidentSeverityService defines no rule-backfilling create hoo
       createBy,
     )) as OnCreate<IncidentSeverity>;
 
-    const created: IncidentSeverity = new IncidentSeverity();
-    created._id = SEV_C.toString();
-    created.projectId = PROJECT_ID;
-
     await callHook(
       IncidentSeverityService,
       "onCreateSuccess",
       onCreate,
-      created,
+      createdSeverity(),
     );
 
-    /*
-     * Nothing enumerated the project's users at all - no TeamMember read, no
-     * per-user method lookup, no rule write. The count of users is irrelevant
-     * precisely because the code never asks.
-     */
+    expect(addJobSpy).toHaveBeenCalledTimes(1);
+    const payload: Record<string, unknown> = addJobSpy.mock
+      .calls[0]![3] as Record<string, unknown>;
+
+    expect(payload["projectId"]).toBe(PROJECT_ID.toString());
+    expect(payload["incidentSeverityId"]).toBe(SEV_C.toString());
+
+    // The request itself still writes no rules and reads no users.
     expect(addDefaultsForMethodSpy).toHaveBeenCalledTimes(0);
     expect(createSpy).toHaveBeenCalledTimes(0);
   });
 });
 
-describe("GAP A - AlertSeverityService defines no rule-backfilling create hook", () => {
+describe("GAP A CLOSED - AlertSeverityService queues the rule backfill on create", () => {
   let createSpy: jest.SpyInstance;
   let addDefaultsForMethodSpy: jest.SpyInstance;
   let addDefaultsForUserSpy: jest.SpyInstance;
+  let addJobSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.spyOn(AlertSeverityService, "findBy").mockResolvedValue([] as never);
     jest
       .spyOn(AlertSeverityService, "updateOneBy")
       .mockResolvedValue(0 as never);
+
+    addJobSpy = jest.spyOn(Queue, "addJob").mockResolvedValue({} as never);
 
     createSpy = jest
       .spyOn(UserNotificationRuleService, "create")
@@ -592,46 +709,48 @@ describe("GAP A - AlertSeverityService defines no rule-backfilling create hook",
     } as CreateBy<AlertSeverity>;
   }
 
-  function expectNoRuleCreation(): void {
+  function expectNoInlineRuleCreation(): void {
     expect(createSpy).not.toHaveBeenCalled();
     expect(addDefaultsForMethodSpy).not.toHaveBeenCalled();
     expect(addDefaultsForUserSpy).not.toHaveBeenCalled();
   }
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts.
+   * GAP A CLOSED - the alert half moves in lockstep with the incident half.
    */
-  test("the only create-side hook it overrides is onBeforeCreate", () => {
+  test("it overrides onCreateSuccess alongside its ordering hooks", () => {
     expect(ownHookNames(AlertSeverityServiceClass.prototype)).toEqual([
       "onBeforeCreate",
       "onBeforeDelete",
       "onBeforeUpdate",
+      "onCreateSuccess",
       "onDeleteSuccess",
     ]);
   });
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts.
+   * GAP A CLOSED - the inverse of the original assertion.
    */
-  test("onCreateSuccess is still DatabaseService's do-nothing placeholder", () => {
+  test("onCreateSuccess is no longer DatabaseService's do-nothing placeholder", () => {
     const proto: Record<string, unknown> =
       AlertSeverityServiceClass.prototype as unknown as Record<string, unknown>;
     const base: Record<string, unknown> =
       DatabaseService.prototype as unknown as Record<string, unknown>;
 
-    expect(proto["onCreateSuccess"]).toBe(base["onCreateSuccess"]);
+    expect(proto["onCreateSuccess"]).not.toBe(base["onCreateSuccess"]);
     expect(
       Object.prototype.hasOwnProperty.call(
         AlertSeverityServiceClass.prototype,
         "onCreateSuccess",
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts.
+   * GAP A CLOSED - the alert payload carries alertSeverityId, so the job can
+   * tell which of the two severity tables changed without guessing.
    */
-  test("the full create sequence (onBeforeCreate then onCreateSuccess) creates no rules", async () => {
+  test("the full create sequence queues the backfill job for the alert severity", async () => {
     const createBy: CreateBy<AlertSeverity> = createBySeverity();
 
     const onCreate: OnCreate<AlertSeverity> = (await callHook(
@@ -652,7 +771,17 @@ describe("GAP A - AlertSeverityService defines no rule-backfilling create hook",
     );
 
     expect(returned).toBe(created);
-    expectNoRuleCreation();
+
+    expect(addJobSpy).toHaveBeenCalledTimes(1);
+    const call: Array<unknown> = addJobSpy.mock.calls[0]!;
+    expect(call[0]).toBe(QueueName.Worker);
+    expect(call[2]).toBe(BACKFILL_JOB_NAME);
+
+    const payload: Record<string, unknown> = call[3] as Record<string, unknown>;
+    expect(payload["projectId"]).toBe(PROJECT_ID.toString());
+    expect(payload["alertSeverityId"]).toBe(ALERT_SEV_C.toString());
+
+    expectNoInlineRuleCreation();
   });
 
   test("a severity with no order is rejected, and still nothing touches rules", async () => {
@@ -663,7 +792,7 @@ describe("GAP A - AlertSeverityService defines no rule-backfilling create hook",
       callHook(AlertSeverityService, "onBeforeCreate", createBy),
     ).rejects.toBeInstanceOf(BadDataException);
 
-    expectNoRuleCreation();
+    expectNoInlineRuleCreation();
   });
 
   test("a severity with no projectId is rejected, and still nothing touches rules", async () => {
@@ -674,17 +803,21 @@ describe("GAP A - AlertSeverityService defines no rule-backfilling create hook",
       callHook(AlertSeverityService, "onBeforeCreate", createBy),
     ).rejects.toBeInstanceOf(BadDataException);
 
-    expectNoRuleCreation();
+    expectNoInlineRuleCreation();
   });
 });
 
 /*
  * ========================================================================= *
  * (B) Rule creation is a snapshot of the severities that exist at call time.
+ *
+ * Unchanged by Phase 1, and deliberately so: the fix was not to make this
+ * method clairvoyant, it was to arrange for something to call it again. Every
+ * assertion here still describes today's behaviour exactly.
  * =========================================================================
  */
 
-describe("GAP A - default rules are a snapshot of the severities that exist at call time", () => {
+describe("GAP A CLOSED - default rules are still a snapshot of the severities that exist at call time", () => {
   beforeEach(() => {
     stubUserNotificationRuleStore();
   });
@@ -745,17 +878,33 @@ describe("GAP A - default rules are a snapshot of the severities that exist at c
     expect(alertRule.notifyAfterMinutes).toBe(0);
   });
 
-  test("the four non-severity rule types are created regardless of how many severities exist", async () => {
+  test("only the two go-on/off-call rule types survive a project with no severities", async () => {
+    /*
+     * GAP G CLOSED - the two EPISODE rule types are severity-scoped now.
+     *
+     * They used to be created by createSingleRule, which sets ruleType and
+     * notifyAfterMinutes and no severity at all. That produced exactly one row
+     * per rule type carrying a NULL severity - and UserOnCallLogService counts
+     * episode rules filtered by a concrete severity id, so NULL never matched
+     * and every one of those "defaults" was dead. Worse, both episode pages
+     * scope their table by severity id, so the rows were invisible to the user
+     * who owned them: unmatchable AND unfixable.
+     *
+     * So with zero severities in the project there is now nothing to scope an
+     * episode rule TO, and none are written. Only WHEN_USER_GOES_ON_CALL and
+     * WHEN_USER_GOES_OFF_CALL remain genuinely severity-less, because "I went
+     * on call" is not an event that has a severity.
+     */
     stubSeverities([], []);
 
     await runDefaults();
 
     expect(
       rulesOfType(NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE),
-    ).toHaveLength(1);
+    ).toHaveLength(0);
     expect(
       rulesOfType(NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE),
-    ).toHaveLength(1);
+    ).toHaveLength(0);
     expect(
       rulesOfType(NotificationRuleType.WHEN_USER_GOES_ON_CALL),
     ).toHaveLength(1);
@@ -764,22 +913,33 @@ describe("GAP A - default rules are a snapshot of the severities that exist at c
     ).toHaveLength(1);
   });
 
-  test("a project with no severities yields only the four fixed rules - no severity coverage at all", async () => {
+  test("a project with no severities yields only the two go-on/off-call rules", async () => {
     stubSeverities([], []);
 
     await runDefaults();
 
-    expect(ruleStore).toHaveLength(4);
+    expect(ruleStore).toHaveLength(2);
     expect(incidentSeverityIdsCovered()).toEqual([]);
     expect(alertSeverityIdsCovered()).toEqual([]);
   });
 
-  test("two incident and two alert severities yield 2 + 2 + 4 rows", async () => {
+  test("two incident and two alert severities yield 2 + 2 + 2 + 2 + 2 rows", async () => {
+    /*
+     * Per severity: one incident rule, one alert rule, one incident-episode
+     * rule and one alert-episode rule - eight in total across two of each
+     * severity - plus the two severity-less go-on/off-call rules.
+     */
     stubSeverities([SEV_A, SEV_B], [ALERT_SEV_A, ALERT_SEV_B]);
 
     await runDefaults();
 
-    expect(ruleStore).toHaveLength(8);
+    expect(ruleStore).toHaveLength(10);
+    expect(
+      rulesOfType(NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE),
+    ).toHaveLength(2);
+    expect(
+      rulesOfType(NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE),
+    ).toHaveLength(2);
   });
 
   test("the severity lookup is project-scoped, root-privileged and capped at LIMIT_PER_PROJECT", async () => {
@@ -821,12 +981,14 @@ describe("GAP A - default rules are a snapshot of the severities that exist at c
   });
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts.
+   * GAP A CLOSED - this behaviour is unchanged, and it is exactly WHY the
+   * backfill has to exist.
    *
-   * The heart of it. Call one: severities [A, B]. A third severity C is then
-   * created in the project. Call two: severities [A, B, C] - and only NOW does
-   * the C rule appear. Nothing in the product makes call two happen when a
-   * severity is created, so in production the store stays frozen at [A, B].
+   * Call one: severities [A, B]. A third severity C is then created in the
+   * project. Call two: severities [A, B, C] - and only NOW does the C rule
+   * appear. This method is still a snapshot of the moment it runs; what Phase 1
+   * added is something that makes call two happen, namely the backfill job that
+   * IncidentSeverityService.onCreateSuccess now enqueues.
    */
   test("a third severity only gets a rule because the method was called a SECOND time", async () => {
     stubSeverities([SEV_A, SEV_B], []);
@@ -839,10 +1001,9 @@ describe("GAP A - default rules are a snapshot of the severities that exist at c
     ]);
 
     /*
-     * "Sev4" is created here. In production this is a plain
-     * IncidentSeverityService.create() and nothing else happens - see the
-     * section (A) tests above. The only reason C appears below is that this
-     * test explicitly re-runs the defaults, which the product never does.
+     * "Sev4" is created here. In production creating it enqueues the backfill
+     * job (see section (A)); this test stands in for that second pass by
+     * re-running the defaults directly.
      */
     stubSeverities([SEV_A, SEV_B, SEV_C], []);
     await runDefaults();
@@ -862,16 +1023,24 @@ describe("GAP A - default rules are a snapshot of the severities that exist at c
     stubSeverities([SEV_A, SEV_B, SEV_C], []);
     await runDefaults();
 
-    expect(ruleStore.length - afterFirstRun).toBe(1);
+    /*
+     * GAP G CLOSED - two rows, not one. A new incident severity now earns the
+     * responder an ON_CALL_EXECUTED_INCIDENT rule AND an
+     * ON_CALL_EXECUTED_INCIDENT_EPISODE rule, because episode rules are
+     * severity-scoped now instead of a single severity-less row that could
+     * never match.
+     */
+    expect(ruleStore.length - afterFirstRun).toBe(2);
     expect(
       rulesOfType(NotificationRuleType.ON_CALL_EXECUTED_INCIDENT),
     ).toHaveLength(3);
   });
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts.
+   * GAP A CLOSED - the alert half of the same snapshot property. Unchanged, and
+   * likewise the reason AlertSeverityService now enqueues the backfill too.
    */
-  test("a late alert severity is missed the same way", async () => {
+  test("a late alert severity is missed by this method the same way", async () => {
     stubSeverities([], [ALERT_SEV_A, ALERT_SEV_B]);
     await runDefaults();
 
@@ -880,7 +1049,7 @@ describe("GAP A - default rules are a snapshot of the severities that exist at c
       ALERT_SEV_B.toString(),
     ]);
 
-    // Severity C is created in the project. No rule work is triggered by that.
+    // Severity C is created in the project. This method alone does no rule work.
     stubSeverities([], [ALERT_SEV_A, ALERT_SEV_B]);
 
     expect(alertSeverityIdsCovered()).not.toContain(ALERT_SEV_C.toString());
@@ -918,17 +1087,19 @@ describe("GAP A - default rules are a snapshot of the severities that exist at c
  * (C) The coverage hole, read through the query UserOnCallLogService really
  *     issues: { userId, projectId, ruleType, incidentSeverityId }.
  *
- *     This section is the documented expectation Phase 1 has to satisfy. Today
- *     a C-severity incident finds zero rules and the page is dropped into an
- *     execution log; after the backfill (or the verified-method fallback) the
- *     same scenario must page somebody.
+ *     The hole itself is unchanged - a user with rules for [A, B] still has no
+ *     row for C until the backfill job runs - but the consequence is not. Phase
+ *     1 replaced the dead-end with the verified-method fallback, so the very
+ *     same C-severity incident now reaches the responder and the log records
+ *     which channel carried it.
  * =========================================================================
  */
 
-describe("GAP A - a severity added after the fact pages nobody", () => {
+describe("GAP A CLOSED - a severity added after the fact still pages, via the fallback", () => {
   let logUpdateSpy: jest.SpyInstance;
   let timelineUpdateSpy: jest.SpyInstance;
   let executeRuleSpy: jest.SpyInstance;
+  let fallbackSpy: jest.SpyInstance;
 
   beforeEach(async () => {
     stubUserNotificationRuleStore();
@@ -946,6 +1117,21 @@ describe("GAP A - a severity added after the fact pages nobody", () => {
     executeRuleSpy = jest
       .spyOn(UserNotificationRuleService, "executeNotificationRuleItem")
       .mockResolvedValue(undefined as never);
+
+    /*
+     * The three collaborators the no-rule path reaches for now. The project read
+     * decides whether the fallback is allowed at all (null => allowed, the
+     * default), the fallback itself reports which channels it dispatched on, and
+     * the user read only ever feeds a name into a failure message.
+     */
+    jest.spyOn(ProjectService, "findOneById").mockResolvedValue(null as never);
+    jest.spyOn(UserService, "findOneById").mockResolvedValue(null as never);
+    fallbackSpy = jest
+      .spyOn(UserNotificationRuleService, "executeFallbackNotification")
+      .mockResolvedValue({
+        notified: true,
+        channelsUsed: ["Email"],
+      } as never);
   });
 
   function stubIncident(incidentSeverityId: ObjectID): void {
@@ -1053,9 +1239,9 @@ describe("GAP A - a severity added after the fact pages nobody", () => {
   });
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts. The whole point
-   * of the gap in one line: rules exist for [A, B], the incident is C, the
-   * count is zero.
+   * GAP A CLOSED - the count is still zero, and that is correct: the backfill
+   * job has not run in this fixture. What changed is what a zero count now
+   * causes, which the tests below assert. This one stays as the premise.
    */
   test("a user with rules for [A, B] has ZERO rules matching a C-severity incident", async () => {
     const count: PositiveNumber = await UserNotificationRuleService.countBy({
@@ -1092,22 +1278,35 @@ describe("GAP A - a severity added after the fact pages nobody", () => {
   });
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts.
+   * GAP A CLOSED - the C-severity page is no longer dropped. No RULE is
+   * executed, because there is still no rule to execute; the fallback is what
+   * carries it, and it is handed the same severity name and rule type the count
+   * came up empty for.
    */
-  test("the C-severity page is dropped: nobody is notified", async () => {
+  test("the C-severity page reaches the responder through the fallback", async () => {
     stubIncident(SEV_C);
 
     await driveOnCreateSuccess(incidentOnCallLog());
 
     expect(executeRuleSpy).not.toHaveBeenCalled();
+    expect(fallbackSpy).toHaveBeenCalledTimes(1);
+
+    const options: Record<string, unknown> = fallbackSpy.mock
+      .calls[0]![0] as Record<string, unknown>;
+
+    expect(toIdString(options["userId"])).toBe(USER_ID.toString());
+    expect(toIdString(options["projectId"])).toBe(PROJECT_ID.toString());
+    expect(options["ruleType"]).toBe(
+      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+    );
   });
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts. Today the only
-   * trace is an Error row in an execution log; Phase 1 turns this into a
-   * fallback delivery (status Success) or an explicit, surfaced Error.
+   * GAP A CLOSED - the inversion that matters most. The log used to end at
+   * Error with a message nobody reads; it now ends at Executing with a message
+   * that says a human was reached and on what.
    */
-  test("the drop is recorded as an execution-log Error, not as a notification", async () => {
+  test("the outcome is a fallback delivery, not a terminal Error", async () => {
     stubIncident(SEV_C);
 
     await driveOnCreateSuccess(incidentOnCallLog());
@@ -1117,26 +1316,38 @@ describe("GAP A - a severity added after the fact pages nobody", () => {
       statusMessage?: string | undefined;
     }> = statusUpdates();
 
-    // First update marks it Started, second is the dead-end.
+    // First update marks it Started, second records the fallback delivery.
     expect(updates[0]!.status).toBe(UserNotificationExecutionStatus.Started);
-    expect(updates[1]!.status).toBe(UserNotificationExecutionStatus.Error);
-    expect(updates[1]!.statusMessage).toBe(
-      "No notification rules found for this user. User should add the rules in User Settings > On-Call Rules.",
-    );
-    // It never reaches the Executing state, so no worker picks it up.
+    expect(updates[1]!.status).toBe(UserNotificationExecutionStatus.Executing);
+    expect(updates[1]!.statusMessage).toContain("notified via fallback");
+    expect(updates[1]!.statusMessage).toContain("Email");
+
+    // The dead-end's sentence is gone from this path entirely.
+    expect(
+      updates.some(
+        (update: { statusMessage?: string | undefined }): boolean => {
+          return (
+            update.statusMessage ===
+            "No notification rules found for this user. User should add the rules in User Settings > On-Call Rules."
+          );
+        },
+      ),
+    ).toBe(false);
     expect(
       updates.some(
         (update: { status: UserNotificationExecutionStatus }): boolean => {
-          return update.status === UserNotificationExecutionStatus.Executing;
+          return update.status === UserNotificationExecutionStatus.Error;
         },
       ),
     ).toBe(false);
   });
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts.
+   * GAP A CLOSED - the timeline now reads as a delivery rather than a failure,
+   * and it names the channel. An operator reading the escalation can tell that
+   * somebody was reached and how.
    */
-  test("the on-call timeline shows Error with the same unread message", async () => {
+  test("the on-call timeline shows a notification sent through the fallback", async () => {
     stubIncident(SEV_C);
 
     await driveOnCreateSuccess(incidentOnCallLog());
@@ -1158,9 +1369,10 @@ describe("GAP A - a severity added after the fact pages nobody", () => {
 
     expect(timelineArg.id.toString()).toBe(TIMELINE_ID.toString());
     expect(timelineArg.data.status).toBe(
-      OnCallDutyExecutionLogTimelineStatus.Error,
+      OnCallDutyExecutionLogTimelineStatus.NotificationSent,
     );
-    expect(timelineArg.data.statusMessage).toContain(
+    expect(timelineArg.data.statusMessage).toContain("notified via fallback");
+    expect(timelineArg.data.statusMessage).not.toContain(
       "No notification rules found for this user",
     );
   });
@@ -1208,20 +1420,56 @@ describe("GAP A - a severity added after the fact pages nobody", () => {
   });
 
   /*
-   * GAP A - Phase 1 adds the backfill; this assertion inverts.
+   * GAP A CLOSED - alerts take the same route as incidents. The rule type
+   * handed to the fallback is the ALERT one, so whatever the fallback decides is
+   * decided against the right cell.
    */
-  test("an ALERT on a severity added after the fact is dropped the same way", async () => {
+  test("an ALERT on a severity added after the fact is rescued the same way", async () => {
     stubAlert(ALERT_SEV_C);
 
     await driveOnCreateSuccess(alertOnCallLog());
 
     expect(executeRuleSpy).not.toHaveBeenCalled();
+    expect(fallbackSpy).toHaveBeenCalledTimes(1);
+    expect(
+      (fallbackSpy.mock.calls[0]![0] as Record<string, unknown>)["ruleType"],
+    ).toBe(NotificationRuleType.ON_CALL_EXECUTED_ALERT);
 
     const updates: Array<{
       status: UserNotificationExecutionStatus;
       statusMessage?: string | undefined;
     }> = statusUpdates();
+    expect(updates[1]!.status).toBe(UserNotificationExecutionStatus.Executing);
+    expect(updates[1]!.statusMessage).toContain("notified via fallback");
+  });
+
+  /*
+   * GAP A CLOSED - and the other side of it. A responder with no verified
+   * method at all cannot be rescued by anything, and that is the one case that
+   * must still end as a loud, terminal Error naming what to do about it.
+   */
+  test("a responder with no verified method still ends as an explicit Error", async () => {
+    stubIncident(SEV_C);
+    fallbackSpy.mockResolvedValue({
+      notified: false,
+      outcome: FallbackNotificationOutcome.NoUsableNotificationMethod,
+      channelsUsed: [],
+    } as never);
+
+    await driveOnCreateSuccess(incidentOnCallLog());
+
+    const updates: Array<{
+      status: UserNotificationExecutionStatus;
+      statusMessage?: string | undefined;
+    }> = statusUpdates();
+
     expect(updates[1]!.status).toBe(UserNotificationExecutionStatus.Error);
+    expect(updates[1]!.statusMessage).toContain(
+      "has no verified notification method",
+    );
+    expect(updates[1]!.statusMessage).toContain(
+      "User Settings > Notification Methods",
+    );
   });
 
   test("an alert on a severity that existed at join time still pages", async () => {
@@ -1233,15 +1481,12 @@ describe("GAP A - a severity added after the fact pages nobody", () => {
   });
 
   /*
-   * The documented expectation for Phase 1, written as an executable target.
-   *
-   * The ONLY thing standing between "dropped" and "paged" is the presence of a
-   * row for (userId, projectId, ON_CALL_EXECUTED_INCIDENT, SEV_C). Backfilling
-   * that row on severity creation - exactly what section (A) proves does not
-   * happen today - is sufficient to close the hole with no change to
-   * UserOnCallLogService at all.
+   * The two Phase 1 halves are independent, and this is the proof: with the row
+   * present the responder is paged through their OWN configured rule and the
+   * fallback is never consulted at all. The backfill is what restores the
+   * responder's intent; the fallback is only the safety net under it.
    */
-  test("backfilling the missing row is sufficient: the very same C-severity incident then pages", async () => {
+  test("backfilling the missing row is sufficient: the very same C-severity incident pages through the real rule", async () => {
     stubIncident(SEV_C);
 
     // Re-running the defaults against a project that now has C is the backfill.
@@ -1251,6 +1496,7 @@ describe("GAP A - a severity added after the fact pages nobody", () => {
     await driveOnCreateSuccess(incidentOnCallLog());
 
     expect(executeRuleSpy).toHaveBeenCalledTimes(1);
+    expect(fallbackSpy).not.toHaveBeenCalled();
 
     const updates: Array<{ status: UserNotificationExecutionStatus }> =
       statusUpdates();

--- a/Common/Tests/Server/Services/SeverityRuleBackfill.test.ts
+++ b/Common/Tests/Server/Services/SeverityRuleBackfill.test.ts
@@ -1,0 +1,1818 @@
+import AlertSeverityService from "../../../Server/Services/AlertSeverityService";
+import IncidentSeverityService from "../../../Server/Services/IncidentSeverityService";
+import UserEmailService from "../../../Server/Services/UserEmailService";
+import UserNotificationRuleService from "../../../Server/Services/UserNotificationRuleService";
+import logger from "../../../Server/Utils/Logger";
+import AlertSeverity from "../../../Models/DatabaseModels/AlertSeverity";
+import IncidentSeverity from "../../../Models/DatabaseModels/IncidentSeverity";
+import UserEmail from "../../../Models/DatabaseModels/UserEmail";
+import UserNotificationRule from "../../../Models/DatabaseModels/UserNotificationRule";
+import LIMIT_MAX from "../../../Types/Database/LimitMax";
+import NotificationRuleType from "../../../Types/NotificationRule/NotificationRuleType";
+import ObjectID from "../../../Types/ObjectID";
+import { EVERY_FIVE_MINUTE } from "../../../Utils/CronTime";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * GAP A, the worker half.
+ *
+ * A severity created after a responder joined was a severity that responder had
+ * no notification rule for. Default rules are written exactly twice in a
+ * responder's life - when they join a project and when they verify a
+ * notification method - and both paths iterate the severities that exist AT
+ * THAT MOMENT. Nothing revisited the question, so the "Sev4" somebody adds a
+ * year in paged precisely nobody: every incident on it counted zero matching
+ * rules and dropped into an execution log no one reads.
+ *
+ * Phase 1 closed that with a worker job,
+ * App/FeatureSet/Workers/Jobs/OnCallDutyPolicy/BackfillNotificationRulesForNewSeverities.ts,
+ * enqueued by name from IncidentSeverityService.onCreateSuccess and
+ * AlertSeverityService.onCreateSuccess and also swept on a five-minute
+ * schedule over severities created in the last hour.
+ *
+ * The neighbouring SeverityCreationRuleBackfill.test.ts covers the ENQUEUE:
+ * that creating a severity puts the job on the Worker queue and writes nothing
+ * inline. This file covers THE JOB ITSELF, through the three functions it
+ * exports for exactly this purpose - findRecentlyCreatedSeverities,
+ * buildResponderIntents and backfillSeverity - rather than through RunCron.
+ *
+ * Four properties are load-bearing, and everything here serves one of them:
+ *
+ *   1. IT MIRRORS INTENT, IT DOES NOT IMPOSE A DEFAULT. Someone who set
+ *      "Sev1 -> call me immediately, Sev3 -> email me after fifteen minutes"
+ *      gets one new rule per distinct (method, delay) pair they already chose
+ *      for that rule type. Not a hardcoded email-at-zero, which would page
+ *      instantly a responder who deliberately built a delay into every rule
+ *      they own; and above all not a phone call for someone who has only ever
+ *      used email. Mirroring can only ever hand a responder a channel they
+ *      already opted into. A responder who muted the rule type entirely gets
+ *      the mute mirrored, not a page.
+ *
+ *   2. IT IS IDEMPOTENT. The job runs from two routes at once - the by-name
+ *      enqueue fires seconds after a severity is created, and a scheduled sweep
+ *      may already be part-way through the same severity - and
+ *      UserNotificationRule carries no unique index over
+ *      (project, user, ruleType, severity, method). A duplicated rule is a
+ *      duplicated page. Two guards are pinned separately below: the per-run
+ *      snapshot, and the per-row read taken immediately before each write that
+ *      catches the case where the snapshot was already stale.
+ *
+ *   3. IT DOES NOT LOAD A PROJECT PER RESPONDER. Reads are one project-wide
+ *      findAllBy per rule type - which pages in LIMIT_MAX batches under the
+ *      hood - not one query per responder. A thousand-responder project must
+ *      not issue a thousand queries per severity.
+ *
+ *   4. ONE RESPONDER'S FAILURE DOES NOT TAKE THE REST DOWN. A method row that
+ *      vanishes mid-run is a log line, not an aborted backfill for everybody
+ *      else in the project.
+ *
+ * No database is touched. UserNotificationRule is backed by an in-memory table
+ * so that rows written by one run are genuinely visible to the next - the
+ * idempotence assertions are only worth anything if the reader really reads
+ * what the writer really wrote.
+ */
+
+/*
+ * The job registers itself with RunCron at import time, which would otherwise
+ * reach for the Worker queue (and therefore Redis) as a side effect of
+ * importing this file. Mocked before the job module is imported, both to keep
+ * the import inert and to capture the registration itself.
+ */
+jest.mock("../../../../App/FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(),
+  };
+});
+
+// Imported AFTER the mock above so the registration lands in it.
+import RunCron from "../../../../App/FeatureSet/Workers/Utils/Cron";
+import {
+  JOB_NAME,
+  backfillSeverity,
+  buildResponderIntents,
+  findRecentlyCreatedSeverities,
+  MirroredRule,
+  NewSeverity,
+  ResponderIntent,
+} from "../../../../App/FeatureSet/Workers/Jobs/OnCallDutyPolicy/BackfillNotificationRulesForNewSeverities";
+
+/*
+ * The third copy of the job name. IncidentSeverityService and
+ * AlertSeverityService each duplicate this string deliberately (Common cannot
+ * import from App), and SeverityCreationRuleBackfill.test.ts pins their copies.
+ * This is the job's own, so a rename that misses any of the three surfaces.
+ */
+const EXPECTED_JOB_NAME: string =
+  "OnCallDutyPolicy:BackfillNotificationRulesForNewSeverities";
+
+const PROJECT_ID: ObjectID = new ObjectID("project-1");
+
+const USER_A: ObjectID = new ObjectID("user-a");
+const USER_B: ObjectID = new ObjectID("user-b");
+const USER_C: ObjectID = new ObjectID("user-c");
+
+const EMAIL_A: ObjectID = new ObjectID("user-email-a");
+const EMAIL_A_SECOND: ObjectID = new ObjectID("user-email-a-second");
+const EMAIL_B: ObjectID = new ObjectID("user-email-b");
+const EMAIL_C: ObjectID = new ObjectID("user-email-c");
+
+const CALL_A: ObjectID = new ObjectID("user-call-a");
+const SMS_A: ObjectID = new ObjectID("user-sms-a");
+const PUSH_A: ObjectID = new ObjectID("user-push-a");
+
+// The severities that existed when the responder configured their rules...
+const SEV_1: ObjectID = new ObjectID("incident-severity-1");
+const SEV_2: ObjectID = new ObjectID("incident-severity-2");
+const SEV_3: ObjectID = new ObjectID("incident-severity-3");
+// ...and the one added a year later, which nothing covered.
+const SEV_NEW: ObjectID = new ObjectID("incident-severity-4-added-later");
+
+const ALERT_SEV_1: ObjectID = new ObjectID("alert-severity-1");
+const ALERT_SEV_NEW: ObjectID = new ObjectID("alert-severity-4-added-later");
+
+const INCIDENT_RULE_TYPES: Array<NotificationRuleType> = [
+  NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+  NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+];
+
+const ALERT_RULE_TYPES: Array<NotificationRuleType> = [
+  NotificationRuleType.ON_CALL_EXECUTED_ALERT,
+  NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+];
+
+type RuleMethodColumn =
+  | "userEmailId"
+  | "userSmsId"
+  | "userCallId"
+  | "userPushId"
+  | "userWhatsAppId"
+  | "userTelegramId"
+  | "userWebhookId";
+
+type RuleIdColumn =
+  | RuleMethodColumn
+  | "projectId"
+  | "userId"
+  | "incidentSeverityId"
+  | "alertSeverityId";
+
+const METHOD_COLUMNS: Array<RuleMethodColumn> = [
+  "userEmailId",
+  "userSmsId",
+  "userCallId",
+  "userPushId",
+  "userWhatsAppId",
+  "userTelegramId",
+  "userWebhookId",
+];
+
+const ID_COLUMNS: Array<RuleIdColumn> = [
+  "projectId",
+  "userId",
+  "incidentSeverityId",
+  "alertSeverityId",
+  ...METHOD_COLUMNS,
+];
+
+/*
+ * ------------------------------------------------------------------------- *
+ * An in-memory stand-in for the UserNotificationRule table.
+ *
+ * Rows are real model instances, because that is what the job reads: it asks
+ * rules for `.userId`, `.isOptOut`, `.notifyAfterMinutes` and the seven method
+ * foreign keys, and hands `create` a model it built itself.
+ * -------------------------------------------------------------------------
+ */
+
+let ruleStore: Array<UserNotificationRule> = [];
+
+// Only the rows THIS run wrote - the whole point of the idempotence assertions.
+let createdRules: Array<UserNotificationRule> = [];
+
+/*
+ * When set, findAllBy reports this instead of the live table.
+ *
+ * That is how an OVERLAPPING run is expressed: the job's per-rule-type snapshot
+ * is taken once at the top of a run, so a second run that started before the
+ * first one wrote anything is a run whose snapshot no longer matches the table.
+ * findOneBy always reads the live table, which is precisely the guard under
+ * test.
+ */
+let frozenSnapshot: Array<UserNotificationRule> | null = null;
+
+// The verified email rows the project has, in the order the query returns them.
+let verifiedEmails: Array<{ userId: ObjectID; emailId: ObjectID }> = [];
+
+let ruleFindAllBySpy: jest.SpyInstance;
+let ruleFindOneBySpy: jest.SpyInstance;
+let ruleCreateSpy: jest.SpyInstance;
+let userEmailFindAllBySpy: jest.SpyInstance;
+let loggerErrorSpy: jest.SpyInstance;
+
+function idOf(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  return String(value);
+}
+
+interface RuleSpec {
+  userId: ObjectID;
+  ruleType: NotificationRuleType;
+  projectId?: ObjectID | undefined;
+  incidentSeverityId?: ObjectID | undefined;
+  alertSeverityId?: ObjectID | undefined;
+  notifyAfterMinutes?: number | undefined;
+  userEmailId?: ObjectID | undefined;
+  userSmsId?: ObjectID | undefined;
+  userCallId?: ObjectID | undefined;
+  userPushId?: ObjectID | undefined;
+  isOptOut?: boolean | undefined;
+}
+
+let seedCounter: number = 0;
+
+/*
+ * A rule row as the responder (or an earlier default-rule pass) left it.
+ * Columns are only set when the spec names them, so "no severity id at all" and
+ * "no delay at all" - both of which really occur in this table - stay
+ * expressible.
+ */
+function makeRule(spec: RuleSpec): UserNotificationRule {
+  seedCounter++;
+
+  const rule: UserNotificationRule = new UserNotificationRule();
+  rule._id = `seeded-rule-${seedCounter}`;
+  rule.projectId = spec.projectId || PROJECT_ID;
+  rule.userId = spec.userId;
+  rule.ruleType = spec.ruleType;
+
+  if (spec.incidentSeverityId) {
+    rule.incidentSeverityId = spec.incidentSeverityId;
+  }
+
+  if (spec.alertSeverityId) {
+    rule.alertSeverityId = spec.alertSeverityId;
+  }
+
+  if (spec.notifyAfterMinutes !== undefined) {
+    rule.notifyAfterMinutes = spec.notifyAfterMinutes;
+  }
+
+  if (spec.userEmailId) {
+    rule.userEmailId = spec.userEmailId;
+  }
+
+  if (spec.userSmsId) {
+    rule.userSmsId = spec.userSmsId;
+  }
+
+  if (spec.userCallId) {
+    rule.userCallId = spec.userCallId;
+  }
+
+  if (spec.userPushId) {
+    rule.userPushId = spec.userPushId;
+  }
+
+  if (spec.isOptOut !== undefined) {
+    rule.isOptOut = spec.isOptOut;
+  }
+
+  return rule;
+}
+
+function seedRule(spec: RuleSpec): UserNotificationRule {
+  const rule: UserNotificationRule = makeRule(spec);
+  ruleStore.push(rule);
+
+  return rule;
+}
+
+/*
+ * Match a stored row against a service query. A column the query does not carry
+ * is not a constraint, which mirrors how the real queries are built: the
+ * per-rule-type read names only projectId and ruleType, and the pre-write
+ * existence check names exactly one method column.
+ */
+function ruleMatchesQuery(
+  rule: UserNotificationRule,
+  query: Record<string, unknown>,
+): boolean {
+  for (const column of ID_COLUMNS) {
+    const expected: string | undefined = idOf(query[column]);
+
+    if (expected !== undefined && idOf(rule[column]) !== expected) {
+      return false;
+    }
+  }
+
+  const expectedRuleType: unknown = query["ruleType"];
+
+  if (expectedRuleType !== undefined && rule.ruleType !== expectedRuleType) {
+    return false;
+  }
+
+  const expectedDelay: unknown = query["notifyAfterMinutes"];
+
+  if (
+    expectedDelay !== undefined &&
+    rule.notifyAfterMinutes !== expectedDelay
+  ) {
+    return false;
+  }
+
+  /*
+   * Compared as a boolean because an ordinary rule leaves the column undefined
+   * rather than false, while the opt-out existence check asks for `true`.
+   */
+  const expectedOptOut: unknown = query["isOptOut"];
+
+  if (
+    expectedOptOut !== undefined &&
+    Boolean(rule.isOptOut) !== expectedOptOut
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function matchingRules(
+  source: Array<UserNotificationRule>,
+  query: Record<string, unknown>,
+): Array<UserNotificationRule> {
+  return source.filter((rule: UserNotificationRule): boolean => {
+    return ruleMatchesQuery(rule, query);
+  });
+}
+
+/* "userCallId:user-call-a", or "none" for an opt-out row. */
+function methodOf(rule: UserNotificationRule): string {
+  for (const column of METHOD_COLUMNS) {
+    const value: ObjectID | undefined = rule[column];
+
+    if (value) {
+      return `${column}:${value.toString()}`;
+    }
+  }
+
+  return "none";
+}
+
+/* The whole of what a rule says, in one comparable string: "how@when". */
+function shapeOf(rule: UserNotificationRule): string {
+  return `${methodOf(rule)}@${String(rule.notifyAfterMinutes)}`;
+}
+
+function createdOfType(
+  ruleType: NotificationRuleType,
+): Array<UserNotificationRule> {
+  return createdRules.filter((rule: UserNotificationRule): boolean => {
+    return rule.ruleType === ruleType;
+  });
+}
+
+function shapesCreatedFor(ruleType: NotificationRuleType): Array<string> {
+  return createdOfType(ruleType).map((rule: UserNotificationRule): string => {
+    return shapeOf(rule);
+  });
+}
+
+function incidentSeverity(id: ObjectID): NewSeverity {
+  return {
+    id: id,
+    projectId: PROJECT_ID,
+    kind: "incident",
+  };
+}
+
+function alertSeverity(id: ObjectID): NewSeverity {
+  return {
+    id: id,
+    projectId: PROJECT_ID,
+    kind: "alert",
+  };
+}
+
+function incidentSeverityRow(
+  id: ObjectID | null,
+  projectId: ObjectID | null,
+): IncidentSeverity {
+  const severity: IncidentSeverity = new IncidentSeverity();
+
+  if (id) {
+    severity._id = id.toString();
+  }
+
+  if (projectId) {
+    severity.projectId = projectId;
+  }
+
+  return severity;
+}
+
+function alertSeverityRow(
+  id: ObjectID | null,
+  projectId: ObjectID | null,
+): AlertSeverity {
+  const severity: AlertSeverity = new AlertSeverity();
+
+  if (id) {
+    severity._id = id.toString();
+  }
+
+  if (projectId) {
+    severity.projectId = projectId;
+  }
+
+  return severity;
+}
+
+function userEmailRow(userId: ObjectID, emailId: ObjectID): UserEmail {
+  const model: UserEmail = new UserEmail();
+  model._id = emailId.toString();
+  model.userId = userId;
+
+  return model;
+}
+
+function queryOf(
+  spy: jest.SpyInstance,
+  callIndex: number,
+): Record<string, unknown> {
+  return (spy.mock.calls[callIndex]![0] as { query: Record<string, unknown> })
+    .query;
+}
+
+function propsOf(
+  spy: jest.SpyInstance,
+  callIndex: number,
+): { isRoot?: boolean | undefined } {
+  return (
+    spy.mock.calls[callIndex]![0] as {
+      props: { isRoot?: boolean | undefined };
+    }
+  ).props;
+}
+
+beforeEach(() => {
+  ruleStore = [];
+  createdRules = [];
+  frozenSnapshot = null;
+  verifiedEmails = [];
+  seedCounter = 0;
+
+  ruleFindAllBySpy = jest
+    .spyOn(UserNotificationRuleService, "findAllBy")
+    .mockImplementation(((data: {
+      query: Record<string, unknown>;
+    }): Promise<Array<UserNotificationRule>> => {
+      return Promise.resolve(
+        matchingRules(frozenSnapshot || ruleStore, data.query),
+      );
+    }) as never);
+
+  ruleFindOneBySpy = jest
+    .spyOn(UserNotificationRuleService, "findOneBy")
+    .mockImplementation(((data: {
+      query: Record<string, unknown>;
+    }): Promise<UserNotificationRule | null> => {
+      return Promise.resolve(matchingRules(ruleStore, data.query)[0] || null);
+    }) as never);
+
+  ruleCreateSpy = jest
+    .spyOn(UserNotificationRuleService, "create")
+    .mockImplementation(((data: {
+      data: UserNotificationRule;
+    }): Promise<UserNotificationRule> => {
+      const rule: UserNotificationRule = data.data;
+      rule._id = `created-rule-${createdRules.length + 1}`;
+
+      ruleStore.push(rule);
+      createdRules.push(rule);
+
+      return Promise.resolve(rule);
+    }) as never);
+
+  userEmailFindAllBySpy = jest
+    .spyOn(UserEmailService, "findAllBy")
+    .mockImplementation(((): Promise<Array<UserEmail>> => {
+      return Promise.resolve(
+        verifiedEmails.map(
+          (entry: { userId: ObjectID; emailId: ObjectID }): UserEmail => {
+            return userEmailRow(entry.userId, entry.emailId);
+          },
+        ),
+      );
+    }) as never);
+
+  // The job logs a failed row rather than throwing; keep the output clean.
+  loggerErrorSpy = jest.spyOn(logger, "error").mockImplementation((): void => {
+    return undefined;
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+/*
+ * ========================================================================= *
+ * The registration itself.
+ * =========================================================================
+ */
+
+describe("the sweep is registered under the name both severity services enqueue", () => {
+  test("the job name is the exact string IncidentSeverityService and AlertSeverityService duplicate", () => {
+    expect(JOB_NAME).toBe(EXPECTED_JOB_NAME);
+  });
+
+  /*
+   * The by-name enqueue is best-effort: if Redis is unreachable when a severity
+   * is created, the enqueue is swallowed and coverage depends entirely on this
+   * schedule existing. runOnStartup stays false because a worker restart loop
+   * must not re-run the sweep on every boot.
+   */
+  test("it registers a five-minute schedule that does not run on startup", () => {
+    const runCronMock: jest.Mock = RunCron as unknown as jest.Mock;
+
+    expect(runCronMock).toHaveBeenCalledTimes(1);
+
+    const call: Array<unknown> = runCronMock.mock.calls[0]!;
+    expect(call[0]).toBe(EXPECTED_JOB_NAME);
+
+    const options: { schedule: string; runOnStartup: boolean } = call[1] as {
+      schedule: string;
+      runOnStartup: boolean;
+    };
+
+    expect(options.schedule).toBe(EVERY_FIVE_MINUTE);
+    expect(options.runOnStartup).toBe(false);
+  });
+});
+
+/*
+ * ========================================================================= *
+ * findRecentlyCreatedSeverities - the sweep re-derives its own work set.
+ *
+ * The Worker queue dispatches on job NAME and hands the job function no
+ * payload, so the job cannot be told which severity to cover; it has to ask.
+ * Asking over a window wider than the schedule is what makes a lost enqueue
+ * cost minutes of latency instead of a permanently uncovered severity.
+ * =========================================================================
+ */
+
+describe("findRecentlyCreatedSeverities", () => {
+  let incidentFindAllBySpy: jest.SpyInstance;
+  let alertFindAllBySpy: jest.SpyInstance;
+
+  function stubSeverityTables(
+    incidentRows: Array<IncidentSeverity>,
+    alertRows: Array<AlertSeverity>,
+  ): void {
+    incidentFindAllBySpy = jest
+      .spyOn(IncidentSeverityService, "findAllBy")
+      .mockResolvedValue(incidentRows as never);
+    alertFindAllBySpy = jest
+      .spyOn(AlertSeverityService, "findAllBy")
+      .mockResolvedValue(alertRows as never);
+  }
+
+  /*
+   * QueryHelper.greaterThanEqualTo builds a TypeORM Raw operator carrying its
+   * bound as a bound parameter. Reading it back is the only way to assert the
+   * window is a window at all rather than "every severity ever created".
+   */
+  function lookbackInMinutes(query: Record<string, unknown>): number {
+    const operator: { objectLiteralParameters?: Record<string, unknown> } =
+      query["createdAt"] as unknown as {
+        objectLiteralParameters?: Record<string, unknown>;
+      };
+
+    const parameters: Record<string, unknown> =
+      operator.objectLiteralParameters || {};
+    const values: Array<unknown> = Object.values(parameters);
+
+    expect(values).toHaveLength(1);
+
+    const bound: Date = values[0] as Date;
+
+    return (Date.now() - bound.getTime()) / (60 * 1000);
+  }
+
+  test("it reads both severity tables, root-privileged, selecting only what it needs", async () => {
+    stubSeverityTables([], []);
+
+    await findRecentlyCreatedSeverities();
+
+    expect(incidentFindAllBySpy).toHaveBeenCalledTimes(1);
+    expect(alertFindAllBySpy).toHaveBeenCalledTimes(1);
+
+    expect(propsOf(incidentFindAllBySpy, 0).isRoot).toBe(true);
+    expect(propsOf(alertFindAllBySpy, 0).isRoot).toBe(true);
+
+    const select: Record<string, unknown> = (
+      incidentFindAllBySpy.mock.calls[0]![0] as {
+        select: Record<string, unknown>;
+      }
+    ).select;
+
+    expect(select["_id"]).toBe(true);
+    expect(select["projectId"]).toBe(true);
+  });
+
+  test("the window is an hour wide - comfortably longer than the five-minute schedule", async () => {
+    stubSeverityTables([], []);
+
+    await findRecentlyCreatedSeverities();
+
+    expect(lookbackInMinutes(queryOf(incidentFindAllBySpy, 0))).toBeGreaterThan(
+      59,
+    );
+    expect(lookbackInMinutes(queryOf(incidentFindAllBySpy, 0))).toBeLessThan(
+      61,
+    );
+    expect(lookbackInMinutes(queryOf(alertFindAllBySpy, 0))).toBeGreaterThan(
+      59,
+    );
+    expect(lookbackInMinutes(queryOf(alertFindAllBySpy, 0))).toBeLessThan(61);
+  });
+
+  test("a quiet project yields no work at all - severity creation is rare", async () => {
+    stubSeverityTables([], []);
+
+    await expect(findRecentlyCreatedSeverities()).resolves.toEqual([]);
+  });
+
+  /*
+   * The kind tag is what tells backfillSeverity which of the two severity
+   * columns to write and which pair of rule types to cover, so a row from the
+   * wrong table would silently write a rule that can never match.
+   */
+  test("each severity is tagged with the table it came from", async () => {
+    stubSeverityTables(
+      [incidentSeverityRow(SEV_NEW, PROJECT_ID)],
+      [alertSeverityRow(ALERT_SEV_NEW, PROJECT_ID)],
+    );
+
+    const severities: Array<NewSeverity> =
+      await findRecentlyCreatedSeverities();
+
+    expect(severities).toHaveLength(2);
+
+    const incident: NewSeverity | undefined = severities.find(
+      (severity: NewSeverity): boolean => {
+        return severity.kind === "incident";
+      },
+    );
+    const alert: NewSeverity | undefined = severities.find(
+      (severity: NewSeverity): boolean => {
+        return severity.kind === "alert";
+      },
+    );
+
+    expect(incident!.id.toString()).toBe(SEV_NEW.toString());
+    expect(incident!.projectId.toString()).toBe(PROJECT_ID.toString());
+    expect(alert!.id.toString()).toBe(ALERT_SEV_NEW.toString());
+    expect(alert!.projectId.toString()).toBe(PROJECT_ID.toString());
+  });
+
+  test("a row with no id or no project is skipped rather than backfilled against nothing", async () => {
+    stubSeverityTables(
+      [
+        incidentSeverityRow(null, PROJECT_ID),
+        incidentSeverityRow(SEV_NEW, null),
+        incidentSeverityRow(SEV_1, PROJECT_ID),
+      ],
+      [alertSeverityRow(null, null)],
+    );
+
+    const severities: Array<NewSeverity> =
+      await findRecentlyCreatedSeverities();
+
+    expect(severities).toHaveLength(1);
+    expect(severities[0]!.id.toString()).toBe(SEV_1.toString());
+  });
+});
+
+/*
+ * ========================================================================= *
+ * buildResponderIntents - "what would this person want for a new severity?"
+ *
+ * The answer is: the same channels, at the same delays, that they already chose
+ * for this rule type on the severities they did configure.
+ * =========================================================================
+ */
+
+describe("buildResponderIntents", () => {
+  function intentsFor(
+    rules: Array<UserNotificationRule>,
+    severity: NewSeverity,
+  ): Map<string, ResponderIntent> {
+    return buildResponderIntents(rules, severity);
+  }
+
+  function mirroredOf(intent: ResponderIntent): Array<string> {
+    return Array.from(intent.mirroredRules.values()).map(
+      (mirrored: MirroredRule): string => {
+        return `${mirrored.methodColumn}:${mirrored.methodId.toString()}@${String(
+          mirrored.notifyAfterMinutes,
+        )}`;
+      },
+    );
+  }
+
+  test("the same (method, delay) used on three severities is one distinct pair", () => {
+    const intents: Map<string, ResponderIntent> = intentsFor(
+      [
+        makeRule({
+          userId: USER_A,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+          incidentSeverityId: SEV_1,
+          userEmailId: EMAIL_A,
+          notifyAfterMinutes: 0,
+        }),
+        makeRule({
+          userId: USER_A,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+          incidentSeverityId: SEV_2,
+          userEmailId: EMAIL_A,
+          notifyAfterMinutes: 0,
+        }),
+        makeRule({
+          userId: USER_A,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+          incidentSeverityId: SEV_3,
+          userEmailId: EMAIL_A,
+          notifyAfterMinutes: 0,
+        }),
+      ],
+      incidentSeverity(SEV_NEW),
+    );
+
+    expect(mirroredOf(intents.get(USER_A.toString())!)).toEqual([
+      `userEmailId:${EMAIL_A.toString()}@0`,
+    ]);
+  });
+
+  /*
+   * The delay is part of the key on purpose. "Email me now" and "email me in
+   * fifteen minutes" are two different requests, and a key that ignored the
+   * delay would collapse them into one.
+   */
+  test("the same method at two delays is two distinct pairs", () => {
+    const intents: Map<string, ResponderIntent> = intentsFor(
+      [
+        makeRule({
+          userId: USER_A,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+          incidentSeverityId: SEV_1,
+          userEmailId: EMAIL_A,
+          notifyAfterMinutes: 0,
+        }),
+        makeRule({
+          userId: USER_A,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+          incidentSeverityId: SEV_1,
+          userEmailId: EMAIL_A,
+          notifyAfterMinutes: 15,
+        }),
+      ],
+      incidentSeverity(SEV_NEW),
+    );
+
+    expect(mirroredOf(intents.get(USER_A.toString())!).sort()).toEqual([
+      `userEmailId:${EMAIL_A.toString()}@0`,
+      `userEmailId:${EMAIL_A.toString()}@15`,
+    ]);
+  });
+
+  test("two different channels at the same delay do not collide", () => {
+    const intents: Map<string, ResponderIntent> = intentsFor(
+      [
+        makeRule({
+          userId: USER_A,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+          incidentSeverityId: SEV_1,
+          userEmailId: EMAIL_A,
+          notifyAfterMinutes: 0,
+        }),
+        makeRule({
+          userId: USER_A,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+          incidentSeverityId: SEV_1,
+          userCallId: CALL_A,
+          notifyAfterMinutes: 0,
+        }),
+      ],
+      incidentSeverity(SEV_NEW),
+    );
+
+    expect(mirroredOf(intents.get(USER_A.toString())!)).toHaveLength(2);
+  });
+
+  test("responders are kept apart - one person's channels never leak into another's", () => {
+    const intents: Map<string, ResponderIntent> = intentsFor(
+      [
+        makeRule({
+          userId: USER_A,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+          incidentSeverityId: SEV_1,
+          userCallId: CALL_A,
+          notifyAfterMinutes: 0,
+        }),
+        makeRule({
+          userId: USER_B,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+          incidentSeverityId: SEV_1,
+          userEmailId: EMAIL_B,
+          notifyAfterMinutes: 30,
+        }),
+      ],
+      incidentSeverity(SEV_NEW),
+    );
+
+    expect(intents.size).toBe(2);
+    expect(mirroredOf(intents.get(USER_A.toString())!)).toEqual([
+      `userCallId:${CALL_A.toString()}@0`,
+    ]);
+    expect(mirroredOf(intents.get(USER_B.toString())!)).toEqual([
+      `userEmailId:${EMAIL_B.toString()}@30`,
+    ]);
+  });
+
+  /*
+   * A row for the new severity is the idempotency guard, not input: it means an
+   * earlier run - or the responder - already covered this cell, and mirroring
+   * it back onto itself would be the duplicate the whole design exists to
+   * avoid.
+   */
+  test("a row for the new severity marks the cell covered and is not itself mirrored", () => {
+    const intents: Map<string, ResponderIntent> = intentsFor(
+      [
+        makeRule({
+          userId: USER_A,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+          incidentSeverityId: SEV_NEW,
+          userEmailId: EMAIL_A,
+          notifyAfterMinutes: 0,
+        }),
+      ],
+      incidentSeverity(SEV_NEW),
+    );
+
+    const intent: ResponderIntent = intents.get(USER_A.toString())!;
+
+    expect(intent.hasRuleForNewSeverity).toBe(true);
+    expect(mirroredOf(intent)).toEqual([]);
+  });
+
+  test("an opt-out row is recorded as an opt-out and contributes no channel", () => {
+    const intents: Map<string, ResponderIntent> = intentsFor(
+      [
+        makeRule({
+          userId: USER_A,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+          incidentSeverityId: SEV_1,
+          isOptOut: true,
+          notifyAfterMinutes: 0,
+        }),
+      ],
+      incidentSeverity(SEV_NEW),
+    );
+
+    const intent: ResponderIntent = intents.get(USER_A.toString())!;
+
+    expect(intent.hasOptOut).toBe(true);
+    expect(intent.hasRuleForNewSeverity).toBe(false);
+    expect(mirroredOf(intent)).toEqual([]);
+  });
+
+  /*
+   * Episode default rules were written without a severity id for a long time
+   * (Gap G). Those rows are just as much a statement of "this is how I want to
+   * be told" as a severity-scoped one.
+   */
+  test("a row with no severity at all still counts as intent", () => {
+    const intents: Map<string, ResponderIntent> = intentsFor(
+      [
+        makeRule({
+          userId: USER_A,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+          userSmsId: SMS_A,
+          notifyAfterMinutes: 5,
+        }),
+      ],
+      incidentSeverity(SEV_NEW),
+    );
+
+    const intent: ResponderIntent = intents.get(USER_A.toString())!;
+
+    expect(intent.hasRuleForNewSeverity).toBe(false);
+    expect(mirroredOf(intent)).toEqual([`userSmsId:${SMS_A.toString()}@5`]);
+  });
+
+  test("a missing delay is read as immediate, not as undefined", () => {
+    const intents: Map<string, ResponderIntent> = intentsFor(
+      [
+        makeRule({
+          userId: USER_A,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+          incidentSeverityId: SEV_1,
+          userEmailId: EMAIL_A,
+        }),
+      ],
+      incidentSeverity(SEV_NEW),
+    );
+
+    const mirrored: Array<MirroredRule> = Array.from(
+      intents.get(USER_A.toString())!.mirroredRules.values(),
+    );
+
+    expect(mirrored[0]!.notifyAfterMinutes).toBe(0);
+  });
+
+  test("a row with no user is ignored entirely", () => {
+    const orphan: UserNotificationRule = new UserNotificationRule();
+    orphan._id = "orphan-rule";
+    orphan.ruleType = NotificationRuleType.ON_CALL_EXECUTED_INCIDENT;
+    orphan.userEmailId = EMAIL_A;
+
+    expect(intentsFor([orphan], incidentSeverity(SEV_NEW)).size).toBe(0);
+  });
+
+  /*
+   * The two severity columns are read according to the KIND being backfilled.
+   * A rule carrying an incidentSeverityId cannot mark an alert severity
+   * covered, however equal the ids happen to look.
+   */
+  test("an alert backfill reads alertSeverityId, never incidentSeverityId", () => {
+    const intents: Map<string, ResponderIntent> = intentsFor(
+      [
+        makeRule({
+          userId: USER_A,
+          ruleType: NotificationRuleType.ON_CALL_EXECUTED_ALERT,
+          incidentSeverityId: ALERT_SEV_NEW,
+          userEmailId: EMAIL_A,
+          notifyAfterMinutes: 0,
+        }),
+      ],
+      alertSeverity(ALERT_SEV_NEW),
+    );
+
+    const intent: ResponderIntent = intents.get(USER_A.toString())!;
+
+    expect(intent.hasRuleForNewSeverity).toBe(false);
+    expect(mirroredOf(intent)).toEqual([`userEmailId:${EMAIL_A.toString()}@0`]);
+  });
+});
+
+/*
+ * ========================================================================= *
+ * backfillSeverity - mirroring existing intent.
+ *
+ * Note throughout: one severity covers TWO rule types (incident and incident
+ * episode, or alert and alert episode), so a responder configured only for the
+ * non-episode type is mirrored there and falls back to their verified email for
+ * the episode one. The assertions are per rule type for exactly that reason.
+ * =========================================================================
+ */
+
+describe("backfillSeverity mirrors what the responder already asked for", () => {
+  /*
+   * The headline case. "Sev1 -> call me at once, Sev3 -> email me after fifteen
+   * minutes" must become one new rule per pair - not a surprise phone call at a
+   * delay they never chose, and not a flattened email-at-zero default.
+   */
+  test("a responder with two different (method, delay) pairs gets both of them", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      userCallId: CALL_A,
+      notifyAfterMinutes: 0,
+    });
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_3,
+      userEmailId: EMAIL_A,
+      notifyAfterMinutes: 15,
+    });
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    const shapes: Array<string> = shapesCreatedFor(
+      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+    );
+
+    expect(shapes).toHaveLength(2);
+    expect(shapes).toContain(`userCallId:${CALL_A.toString()}@0`);
+    expect(shapes).toContain(`userEmailId:${EMAIL_A.toString()}@15`);
+
+    // The flattened default they must NOT get: their email, immediately.
+    expect(shapes).not.toContain(`userEmailId:${EMAIL_A.toString()}@0`);
+  });
+
+  test("every new rule is bound to the new severity and to no other", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      userCallId: CALL_A,
+      notifyAfterMinutes: 0,
+    });
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    expect(createdRules.length).toBeGreaterThan(0);
+
+    for (const rule of createdRules) {
+      expect(rule.projectId!.toString()).toBe(PROJECT_ID.toString());
+      expect(rule.userId!.toString()).toBe(USER_A.toString());
+      expect(rule.incidentSeverityId!.toString()).toBe(SEV_NEW.toString());
+      expect(rule.alertSeverityId).toBeUndefined();
+    }
+  });
+
+  /*
+   * The failure mode a hardcoded default would produce: a responder who has
+   * only ever used email waking up to a phone call.
+   */
+  test("an email-only responder is never given a phone call", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      userEmailId: EMAIL_A,
+      notifyAfterMinutes: 10,
+    });
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    for (const rule of createdOfType(
+      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+    )) {
+      expect(rule.userCallId).toBeUndefined();
+      expect(rule.userSmsId).toBeUndefined();
+      expect(rule.notifyAfterMinutes).toBe(10);
+    }
+  });
+
+  test("the same pair repeated across severities produces exactly one new rule", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    for (const severityId of [SEV_1, SEV_2, SEV_3]) {
+      seedRule({
+        userId: USER_A,
+        ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+        incidentSeverityId: severityId,
+        userPushId: PUSH_A,
+        notifyAfterMinutes: 0,
+      });
+    }
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    expect(
+      shapesCreatedFor(NotificationRuleType.ON_CALL_EXECUTED_INCIDENT),
+    ).toEqual([`userPushId:${PUSH_A.toString()}@0`]);
+  });
+
+  /*
+   * A responder who deliberately muted this rule type gets the mute mirrored.
+   * Leaving the cell empty would hand them to the verified-method fallback in
+   * UserOnCallLogService, which is to say it would page someone who explicitly
+   * asked not to be paged.
+   */
+  test("a responder who opted out is given an opt-out row, not a page", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      isOptOut: true,
+      notifyAfterMinutes: 0,
+    });
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    const created: Array<UserNotificationRule> = createdOfType(
+      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+    );
+
+    expect(created).toHaveLength(1);
+    expect(created[0]!.isOptOut).toBe(true);
+    expect(methodOf(created[0]!)).toBe("none");
+    expect(created[0]!.notifyAfterMinutes).toBe(0);
+    expect(created[0]!.incidentSeverityId!.toString()).toBe(SEV_NEW.toString());
+  });
+
+  test("an opt-out on one severity does not silence a responder who configured another", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      isOptOut: true,
+      notifyAfterMinutes: 0,
+    });
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_3,
+      userEmailId: EMAIL_A,
+      notifyAfterMinutes: 0,
+    });
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    const created: Array<UserNotificationRule> = createdOfType(
+      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+    );
+
+    expect(created).toHaveLength(1);
+    expect(created[0]!.isOptOut).toBeUndefined();
+    expect(methodOf(created[0]!)).toBe(`userEmailId:${EMAIL_A.toString()}`);
+  });
+
+  /*
+   * Mirroring is per rule type. An incident-only responder's phone-call rule
+   * must not become an alert rule, and vice versa - the two lists are
+   * configured independently in the UI and mean different things.
+   */
+  test("an alert backfill ignores the responder's incident rules", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      userCallId: CALL_A,
+      notifyAfterMinutes: 0,
+    });
+
+    await backfillSeverity(alertSeverity(ALERT_SEV_NEW));
+
+    const shapes: Array<string> = shapesCreatedFor(
+      NotificationRuleType.ON_CALL_EXECUTED_ALERT,
+    );
+
+    expect(shapes).toEqual([`userEmailId:${EMAIL_A.toString()}@0`]);
+    expect(shapes).not.toContain(`userCallId:${CALL_A.toString()}@0`);
+  });
+
+  test("both rule types of a severity kind are covered, and only those two", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    const typesCovered: Array<NotificationRuleType | undefined> =
+      createdRules.map(
+        (rule: UserNotificationRule): NotificationRuleType | undefined => {
+          return rule.ruleType;
+        },
+      );
+
+    expect(typesCovered.sort()).toEqual([...INCIDENT_RULE_TYPES].sort());
+  });
+
+  test("an episode rule written without a severity is mirrored onto the new severity", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+      userSmsId: SMS_A,
+      notifyAfterMinutes: 5,
+    });
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    // Their stated channel, not the email default they never asked for.
+    expect(
+      shapesCreatedFor(NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE),
+    ).toEqual([`userSmsId:${SMS_A.toString()}@5`]);
+  });
+});
+
+/*
+ * ========================================================================= *
+ * backfillSeverity - the verified-email fallback.
+ *
+ * A responder who has said nothing at all about a rule type gets exactly what
+ * addDefaultNotificationRuleForUser would have written for them had the
+ * severity existed when they joined.
+ * =========================================================================
+ */
+
+describe("backfillSeverity falls back to the responder's verified email", () => {
+  test("a responder with no rules of that type gets their verified email, immediately", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    expect(createdRules).toHaveLength(2);
+
+    for (const ruleType of INCIDENT_RULE_TYPES) {
+      expect(shapesCreatedFor(ruleType)).toEqual([
+        `userEmailId:${EMAIL_A.toString()}@0`,
+      ]);
+    }
+
+    for (const rule of createdRules) {
+      expect(rule.isOptOut).toBeUndefined();
+    }
+  });
+
+  /*
+   * The read that decides who is reachable at all. Unverified addresses are
+   * excluded by the query itself, which is what makes "no verified method =>
+   * nothing written" true rather than accidental.
+   */
+  test("only verified addresses in this project are considered", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    const query: Record<string, unknown> = queryOf(userEmailFindAllBySpy, 0);
+
+    expect(idOf(query["projectId"])).toBe(PROJECT_ID.toString());
+    expect(query["isVerified"]).toBe(true);
+    expect(propsOf(userEmailFindAllBySpy, 0).isRoot).toBe(true);
+  });
+
+  test("a responder with no verified method gets nothing, and the run still covers everyone else", async () => {
+    // USER_B has no verified email row at all, so the project cannot reach them.
+    verifiedEmails = [
+      { userId: USER_A, emailId: EMAIL_A },
+      { userId: USER_C, emailId: EMAIL_C },
+    ];
+
+    await expect(
+      backfillSeverity(incidentSeverity(SEV_NEW)),
+    ).resolves.toBeUndefined();
+
+    const usersCovered: Array<string> = createdRules.map(
+      (rule: UserNotificationRule): string => {
+        return rule.userId!.toString();
+      },
+    );
+
+    expect(usersCovered).not.toContain(USER_B.toString());
+    expect(createdRules).toHaveLength(4);
+  });
+
+  test("a responder with several verified addresses gets one rule, on the first", async () => {
+    verifiedEmails = [
+      { userId: USER_A, emailId: EMAIL_A },
+      { userId: USER_A, emailId: EMAIL_A_SECOND },
+    ];
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    expect(createdRules).toHaveLength(2);
+    expect(
+      shapesCreatedFor(NotificationRuleType.ON_CALL_EXECUTED_INCIDENT),
+    ).toEqual([`userEmailId:${EMAIL_A.toString()}@0`]);
+  });
+
+  /*
+   * The fallback is only for responders who said NOTHING. Someone whose stated
+   * channel is SMS keeps SMS even though the email map is what enumerates the
+   * project.
+   */
+  test("a responder who stated a channel keeps it instead of the email default", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      userSmsId: SMS_A,
+      notifyAfterMinutes: 0,
+    });
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    expect(
+      shapesCreatedFor(NotificationRuleType.ON_CALL_EXECUTED_INCIDENT),
+    ).toEqual([`userSmsId:${SMS_A.toString()}@0`]);
+  });
+});
+
+/*
+ * ========================================================================= *
+ * backfillSeverity - idempotence.
+ *
+ * A duplicated rule is a duplicated page. There is no unique index over
+ * (project, user, ruleType, severity, method), so two guards do this work and
+ * they are pinned separately: the per-run snapshot, and the per-row read taken
+ * immediately before each write.
+ * =========================================================================
+ */
+
+describe("backfillSeverity is idempotent", () => {
+  test("running the same severity a second time writes nothing", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      userCallId: CALL_A,
+      notifyAfterMinutes: 0,
+    });
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+    const afterFirstRun: number = createdRules.length;
+    expect(afterFirstRun).toBeGreaterThan(0);
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    expect(createdRules).toHaveLength(afterFirstRun);
+  });
+
+  test("a third and fourth run still write nothing", async () => {
+    verifiedEmails = [
+      { userId: USER_A, emailId: EMAIL_A },
+      { userId: USER_B, emailId: EMAIL_B },
+    ];
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+    const afterFirstRun: number = createdRules.length;
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    expect(createdRules).toHaveLength(afterFirstRun);
+    expect(createdRules).toHaveLength(4);
+  });
+
+  /*
+   * The second guard, in isolation. Both runs took their snapshot before either
+   * wrote, so the snapshot cannot save the loser - only the read taken
+   * immediately before the write can, and it is the one that must fire here.
+   * That overlap is likeliest at exactly the worst moment: a new severity
+   * arrives by two routes at once, the by-name enqueue seconds after creation
+   * and a scheduled sweep already part-way through the same severity.
+   */
+  test("a row written by an overlapping run between the snapshot and the write is not duplicated", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    const existing: UserNotificationRule = seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      userCallId: CALL_A,
+      notifyAfterMinutes: 0,
+    });
+
+    // The snapshot BOTH overlapping runs took: nothing for the new severity yet.
+    frozenSnapshot = [existing];
+
+    // One run wins the race and writes its rows...
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+    const afterWinner: number = createdRules.length;
+    expect(afterWinner).toBeGreaterThan(0);
+
+    const readsBefore: number = ruleFindOneBySpy.mock.calls.length;
+
+    // ...and the loser is still working from the snapshot it took earlier.
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    expect(createdRules).toHaveLength(afterWinner);
+
+    /*
+     * It really did reach the write path and get stopped there - had the stale
+     * snapshot been what stopped it, no existence check would have been issued.
+     */
+    expect(ruleFindOneBySpy.mock.calls.length).toBeGreaterThan(readsBefore);
+  });
+
+  /*
+   * The existence check keys on the delay as well as the method. A responder
+   * who asked for "email me now" AND "email me in fifteen minutes" must get
+   * both rows on the new severity; a key that ignored the delay would drop the
+   * second one during the same pass that wrote the first.
+   */
+  test("two rules that differ only by delay both survive the existence check", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      userEmailId: EMAIL_A,
+      notifyAfterMinutes: 0,
+    });
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      userEmailId: EMAIL_A,
+      notifyAfterMinutes: 15,
+    });
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    const shapes: Array<string> = shapesCreatedFor(
+      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+    );
+
+    expect(shapes.sort()).toEqual([
+      `userEmailId:${EMAIL_A.toString()}@0`,
+      `userEmailId:${EMAIL_A.toString()}@15`,
+    ]);
+  });
+
+  test("a responder already covered by hand is left completely alone", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      userCallId: CALL_A,
+      notifyAfterMinutes: 0,
+    });
+    // They already wrote their own rule for the new severity.
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_NEW,
+      userEmailId: EMAIL_A,
+      notifyAfterMinutes: 45,
+    });
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    expect(
+      createdOfType(NotificationRuleType.ON_CALL_EXECUTED_INCIDENT),
+    ).toHaveLength(0);
+  });
+
+  /*
+   * The existence check has to name the new severity, or a rule for Sev1 would
+   * satisfy it and the new severity would stay uncovered forever - which is the
+   * original bug wearing a different hat.
+   */
+  test("the pre-write check names the whole row: project, user, type, severity, method and delay", async () => {
+    verifiedEmails = [];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      userCallId: CALL_A,
+      notifyAfterMinutes: 20,
+    });
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    const query: Record<string, unknown> = queryOf(ruleFindOneBySpy, 0);
+
+    expect(idOf(query["projectId"])).toBe(PROJECT_ID.toString());
+    expect(idOf(query["userId"])).toBe(USER_A.toString());
+    expect(query["ruleType"]).toBe(
+      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+    );
+    expect(idOf(query["incidentSeverityId"])).toBe(SEV_NEW.toString());
+    expect(idOf(query["userCallId"])).toBe(CALL_A.toString());
+    expect(query["notifyAfterMinutes"]).toBe(20);
+    expect(query["alertSeverityId"]).toBeUndefined();
+    expect(propsOf(ruleFindOneBySpy, 0).isRoot).toBe(true);
+  });
+
+  test("an alert backfill's existence check names alertSeverityId instead", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    await backfillSeverity(alertSeverity(ALERT_SEV_NEW));
+
+    const query: Record<string, unknown> = queryOf(ruleFindOneBySpy, 0);
+
+    expect(idOf(query["alertSeverityId"])).toBe(ALERT_SEV_NEW.toString());
+    expect(query["incidentSeverityId"]).toBeUndefined();
+  });
+
+  test("an opt-out row is not duplicated on a second run either", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+      incidentSeverityId: SEV_1,
+      isOptOut: true,
+      notifyAfterMinutes: 0,
+    });
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+    const afterFirstRun: number = createdRules.length;
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    expect(createdRules).toHaveLength(afterFirstRun);
+    expect(
+      createdOfType(NotificationRuleType.ON_CALL_EXECUTED_INCIDENT),
+    ).toHaveLength(1);
+  });
+});
+
+/*
+ * ========================================================================= *
+ * Alert severities take the identical route.
+ * =========================================================================
+ */
+
+describe("backfillSeverity covers alert severities the same way", () => {
+  test("an alert severity mirrors the responder's alert rules onto alertSeverityId", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_ALERT,
+      alertSeverityId: ALERT_SEV_1,
+      userPushId: PUSH_A,
+      notifyAfterMinutes: 0,
+    });
+
+    await backfillSeverity(alertSeverity(ALERT_SEV_NEW));
+
+    const created: Array<UserNotificationRule> = createdOfType(
+      NotificationRuleType.ON_CALL_EXECUTED_ALERT,
+    );
+
+    expect(created).toHaveLength(1);
+    expect(created[0]!.alertSeverityId!.toString()).toBe(
+      ALERT_SEV_NEW.toString(),
+    );
+    expect(created[0]!.incidentSeverityId).toBeUndefined();
+    expect(methodOf(created[0]!)).toBe(`userPushId:${PUSH_A.toString()}`);
+  });
+
+  test("an alert severity covers both alert rule types and no incident one", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    await backfillSeverity(alertSeverity(ALERT_SEV_NEW));
+
+    const typesCovered: Array<NotificationRuleType | undefined> =
+      createdRules.map(
+        (rule: UserNotificationRule): NotificationRuleType | undefined => {
+          return rule.ruleType;
+        },
+      );
+
+    expect(typesCovered.sort()).toEqual([...ALERT_RULE_TYPES].sort());
+  });
+
+  test("an incident backfill never writes an alert rule type", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    seedRule({
+      userId: USER_A,
+      ruleType: NotificationRuleType.ON_CALL_EXECUTED_ALERT,
+      alertSeverityId: ALERT_SEV_1,
+      userPushId: PUSH_A,
+      notifyAfterMinutes: 0,
+    });
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    for (const ruleType of ALERT_RULE_TYPES) {
+      expect(createdOfType(ruleType)).toHaveLength(0);
+    }
+  });
+
+  test("alert severities are idempotent on a second run too", async () => {
+    verifiedEmails = [{ userId: USER_A, emailId: EMAIL_A }];
+
+    await backfillSeverity(alertSeverity(ALERT_SEV_NEW));
+    const afterFirstRun: number = createdRules.length;
+
+    await backfillSeverity(alertSeverity(ALERT_SEV_NEW));
+
+    expect(createdRules).toHaveLength(afterFirstRun);
+  });
+});
+
+/*
+ * ========================================================================= *
+ * The fan-out: bounded reads, and failure isolation.
+ * =========================================================================
+ */
+
+describe("the fan-out is bounded and does not collapse on one responder", () => {
+  function seedProjectWithUsers(count: number): void {
+    verifiedEmails = [];
+
+    for (let index: number = 0; index < count; index++) {
+      verifiedEmails.push({
+        userId: new ObjectID(`bulk-user-${index}`),
+        emailId: new ObjectID(`bulk-user-email-${index}`),
+      });
+    }
+  }
+
+  /*
+   * The N+1 this job was written to avoid: looping the project's responders and
+   * asking the database once per responder per severity. Reads must be a
+   * function of the RULE TYPES, not of the head-count.
+   */
+  test("reads do not grow with the number of responders", async () => {
+    seedProjectWithUsers(25);
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    expect(createdRules).toHaveLength(50);
+
+    // One responder read for the severity, one rule read per rule type.
+    expect(userEmailFindAllBySpy).toHaveBeenCalledTimes(1);
+    expect(ruleFindAllBySpy).toHaveBeenCalledTimes(INCIDENT_RULE_TYPES.length);
+  });
+
+  test("the project-wide rule read is scoped to the project and one rule type", async () => {
+    seedProjectWithUsers(3);
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    const ruleTypesRead: Array<unknown> = ruleFindAllBySpy.mock.calls.map(
+      (call: Array<unknown>): unknown => {
+        return (call[0] as { query: Record<string, unknown> }).query[
+          "ruleType"
+        ];
+      },
+    );
+
+    expect(ruleTypesRead.sort()).toEqual([...INCIDENT_RULE_TYPES].sort());
+    expect(idOf(queryOf(ruleFindAllBySpy, 0)["projectId"])).toBe(
+      PROJECT_ID.toString(),
+    );
+    expect(propsOf(ruleFindAllBySpy, 0).isRoot).toBe(true);
+  });
+
+  /*
+   * findAllBy is the paging reader: it walks the table in LIMIT_MAX batches
+   * rather than issuing one unbounded query, which is what keeps a project with
+   * more responders than fit in a single page from being read in one gulp. The
+   * real findAllBy runs here; only the underlying page read is stubbed.
+   */
+  test("responders are read in bounded pages, not one unbounded query", async () => {
+    userEmailFindAllBySpy.mockRestore();
+
+    const singleRow: UserEmail = userEmailRow(USER_A, EMAIL_A);
+    let pageIndex: number = 0;
+
+    const emailFindBySpy: jest.SpyInstance = jest
+      .spyOn(UserEmailService, "findBy")
+      .mockImplementation(((): Promise<Array<UserEmail>> => {
+        pageIndex++;
+
+        if (pageIndex === 1) {
+          // A full page, which is what tells findAllBy to ask for another.
+          return Promise.resolve(
+            new Array<UserEmail>(LIMIT_MAX).fill(singleRow),
+          );
+        }
+
+        return Promise.resolve([]);
+      }) as never);
+
+    await backfillSeverity(incidentSeverity(SEV_NEW));
+
+    expect(emailFindBySpy).toHaveBeenCalledTimes(2);
+
+    const firstPage: { skip: number; limit: number } = emailFindBySpy.mock
+      .calls[0]![0] as { skip: number; limit: number };
+    const secondPage: { skip: number; limit: number } = emailFindBySpy.mock
+      .calls[1]![0] as { skip: number; limit: number };
+
+    expect(firstPage.skip).toBe(0);
+    expect(firstPage.limit).toBe(LIMIT_MAX);
+    expect(secondPage.skip).toBe(LIMIT_MAX);
+    expect(secondPage.limit).toBe(LIMIT_MAX);
+
+    // The page was one responder repeated, so one responder is covered.
+    expect(createdRules).toHaveLength(INCIDENT_RULE_TYPES.length);
+  });
+
+  /*
+   * The likeliest real failure: a method row deleted between the existence
+   * check and the write, which cascades the foreign key away. That is worth a
+   * log line for one person, not an aborted backfill for the whole project.
+   */
+  test("a write that fails for one responder does not stop the others", async () => {
+    verifiedEmails = [
+      { userId: USER_A, emailId: EMAIL_A },
+      { userId: USER_B, emailId: EMAIL_B },
+      { userId: USER_C, emailId: EMAIL_C },
+    ];
+
+    ruleCreateSpy.mockImplementation(((data: {
+      data: UserNotificationRule;
+    }): Promise<UserNotificationRule> => {
+      const rule: UserNotificationRule = data.data;
+
+      if (rule.userId && rule.userId.toString() === USER_B.toString()) {
+        return Promise.reject(
+          new Error("insert or update violates foreign key constraint"),
+        );
+      }
+
+      rule._id = `created-rule-${createdRules.length + 1}`;
+      ruleStore.push(rule);
+      createdRules.push(rule);
+
+      return Promise.resolve(rule);
+    }) as never);
+
+    await expect(
+      backfillSeverity(incidentSeverity(SEV_NEW)),
+    ).resolves.toBeUndefined();
+
+    const usersCovered: Array<string> = createdRules.map(
+      (rule: UserNotificationRule): string => {
+        return rule.userId!.toString();
+      },
+    );
+
+    expect(usersCovered).toContain(USER_A.toString());
+    expect(usersCovered).toContain(USER_C.toString());
+    expect(usersCovered).not.toContain(USER_B.toString());
+    expect(createdRules).toHaveLength(4);
+
+    // And the responder who was missed is named, not silently dropped.
+    const logged: Array<string> = loggerErrorSpy.mock.calls.map(
+      (call: Array<unknown>): string => {
+        return String(call[0]);
+      },
+    );
+
+    expect(
+      logged.some((message: string): boolean => {
+        return message.includes(USER_B.toString());
+      }),
+    ).toBe(true);
+  });
+
+  /*
+   * The boundary of that isolation, pinned so a future reader knows where it
+   * is: only the WRITE is wrapped. A failing existence READ propagates and ends
+   * this severity's pass. It is not a lost page - the sweep re-derives its work
+   * set from an hour-wide window every five minutes, so the responders after
+   * the failure are picked up by a later tick - but the rest of THIS pass does
+   * not happen.
+   */
+  test("a failing existence read ends this pass, leaving the rest to the next sweep", async () => {
+    verifiedEmails = [
+      { userId: USER_A, emailId: EMAIL_A },
+      { userId: USER_B, emailId: EMAIL_B },
+      { userId: USER_C, emailId: EMAIL_C },
+    ];
+
+    ruleFindOneBySpy.mockImplementation(((data: {
+      query: Record<string, unknown>;
+    }): Promise<UserNotificationRule | null> => {
+      if (idOf(data.query["userId"]) === USER_B.toString()) {
+        return Promise.reject(new Error("connection terminated unexpectedly"));
+      }
+
+      return Promise.resolve(matchingRules(ruleStore, data.query)[0] || null);
+    }) as never);
+
+    await expect(backfillSeverity(incidentSeverity(SEV_NEW))).rejects.toThrow(
+      "connection terminated unexpectedly",
+    );
+
+    const usersCovered: Array<string> = createdRules.map(
+      (rule: UserNotificationRule): string => {
+        return rule.userId!.toString();
+      },
+    );
+
+    expect(usersCovered).toEqual([USER_A.toString()]);
+  });
+
+  test("a project with nobody in it is a pair of reads and no writes", async () => {
+    verifiedEmails = [];
+
+    await expect(
+      backfillSeverity(incidentSeverity(SEV_NEW)),
+    ).resolves.toBeUndefined();
+
+    expect(createdRules).toHaveLength(0);
+    expect(ruleCreateSpy).not.toHaveBeenCalled();
+    expect(ruleFindOneBySpy).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Services/UserNotificationRuleDefaultCreation.test.ts
+++ b/Common/Tests/Server/Services/UserNotificationRuleDefaultCreation.test.ts
@@ -26,20 +26,28 @@ import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
  * zero, or the method id written onto the wrong foreign key — the user is on an
  * on-call policy that pages nobody, and nothing tells them so.
  *
- * This file pins the shape of that seeding as it is TODAY, before the readiness
- * work in Internal/Roadmap/OnCallNotificationReadiness.md changes anything:
+ * This file pins the shape of that seeding:
  *
  *   (A) addDefaultNotificationRulesForVerifiedMethod
  *       - one ON_CALL_EXECUTED_INCIDENT rule per incident severity,
  *       - one ON_CALL_EXECUTED_ALERT rule per alert severity,
- *       - exactly four "single" rules (alert episode, incident episode, goes on
- *         call, goes off call),
+ *       - one ON_CALL_EXECUTED_INCIDENT_EPISODE rule per incident severity and
+ *         one ON_CALL_EXECUTED_ALERT_EPISODE rule per alert severity (Phase 1
+ *         closed GAP G here: these two used to be seeded once each with a NULL
+ *         severity, which matched no severity-filtered page and showed up in no
+ *         severity-scoped UI table - "defaults" that were unreachable and
+ *         invisible at the same time),
+ *       - exactly two "single" rules (goes on call, goes off call), which
+ *         legitimately have no severity because they are about the user's shift
+ *         rather than about anything that fired,
  *       - every rule at notifyAfterMinutes = 0 (page immediately),
  *       - the verified method's id written to exactly one FK column, chosen per
  *         channel, and the same column used in the duplicate lookup,
  *       - idempotence: an existing rule for a (method, severity, ruleType)
  *         triple suppresses only that one create, never its neighbours,
- *       - a project with zero severities still gets the four single rules.
+ *       - a project with zero severities gets the two shift rules and nothing
+ *         else, because a rule for a severity that does not exist could never
+ *         have matched a page anyway.
  *
  *   (B) addDefaultNotificationRuleForUser, which is the joining-a-project entry
  *       point: it materialises a *verified* UserEmail when one does not exist,
@@ -105,9 +113,39 @@ const ALL_CHANNELS: Array<ChannelColumn> = [
   "userPushId",
 ];
 
-/* The four rule types that are seeded once, regardless of severities. */
+/* The rule types that are seeded once, regardless of severities. */
 const SINGLE_RULE_TYPES: Array<NotificationRuleType> = [
+  NotificationRuleType.WHEN_USER_GOES_ON_CALL,
+  NotificationRuleType.WHEN_USER_GOES_OFF_CALL,
+];
+
+/*
+ * The episode rule types. Since Phase 1 closed GAP G these are seeded once per
+ * severity - alert episodes against alert severities, incident episodes against
+ * incident severities - exactly like their non-episode counterparts.
+ */
+const EPISODE_RULE_TYPES: Array<NotificationRuleType> = [
   NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+  NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+];
+
+/*
+ * With the fixture below (3 incident severities, 2 alert severities):
+ * 3 incident + 2 alert + 2 alert episode + 3 incident episode + 2 single.
+ */
+const TOTAL_SEEDED_RULES: number = 12;
+
+/* The order the rules are seeded in, which is also the duplicate-check order. */
+const SEEDED_RULE_ORDER: Array<NotificationRuleType> = [
+  NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+  NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+  NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+  NotificationRuleType.ON_CALL_EXECUTED_ALERT,
+  NotificationRuleType.ON_CALL_EXECUTED_ALERT,
+  NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+  NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+  NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+  NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
   NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
   NotificationRuleType.WHEN_USER_GOES_ON_CALL,
   NotificationRuleType.WHEN_USER_GOES_OFF_CALL,
@@ -289,7 +327,7 @@ describe("addDefaultNotificationRulesForVerifiedMethod - what gets seeded", () =
     }
   });
 
-  test("exactly four single rules are seeded, one of each non-severity rule type", async () => {
+  test("exactly two single rules are seeded, one of each non-severity rule type", async () => {
     await runForEmailMethod();
 
     for (const ruleType of SINGLE_RULE_TYPES) {
@@ -297,7 +335,7 @@ describe("addDefaultNotificationRulesForVerifiedMethod - what gets seeded", () =
     }
   });
 
-  test("the four single rules carry no severity at all - they are not severity scoped", async () => {
+  test("the two single rules carry no severity at all - they are not severity scoped", async () => {
     await runForEmailMethod();
 
     const singles: Array<Model> = createdRules().filter(
@@ -306,25 +344,100 @@ describe("addDefaultNotificationRulesForVerifiedMethod - what gets seeded", () =
       },
     );
 
-    expect(singles).toHaveLength(4);
+    expect(singles).toHaveLength(2);
     for (const rule of singles) {
       expect(rule.incidentSeverityId).toBeUndefined();
       expect(rule.alertSeverityId).toBeUndefined();
     }
   });
 
-  test("the total is severities + severities + four, and nothing else", async () => {
+  test("one alert episode rule per ALERT severity, each carrying that severity", async () => {
+    /*
+     * GAP G, closed by Phase 1. These rows used to be created once with a NULL
+     * alertSeverityId, which the severity-filtered count query in
+     * UserOnCallLogService could never match - so every alert episode page for a
+     * user on defaults was dropped.
+     */
     await runForEmailMethod();
 
-    // 3 incident severities + 2 alert severities + 4 single rules.
-    expect(createSpy).toHaveBeenCalledTimes(9);
+    const episodeRules: Array<Model> = createdRulesOfType(
+      NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+    );
+
+    expect(episodeRules).toHaveLength(2);
+    expect(
+      episodeRules.map((rule: Model): string => {
+        return rule.alertSeverityId!.toString();
+      }),
+    ).toEqual([ALERT_SEV_1.toString(), ALERT_SEV_2.toString()]);
+
+    for (const rule of episodeRules) {
+      expect(rule.incidentSeverityId).toBeUndefined();
+    }
+  });
+
+  test("one incident episode rule per INCIDENT severity, each carrying that severity", async () => {
+    // GAP G, closed by Phase 1 - see the alert episode case above.
+    await runForEmailMethod();
+
+    const episodeRules: Array<Model> = createdRulesOfType(
+      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+    );
+
+    expect(episodeRules).toHaveLength(3);
+    expect(
+      episodeRules.map((rule: Model): string => {
+        return rule.incidentSeverityId!.toString();
+      }),
+    ).toEqual([
+      INCIDENT_SEV_1.toString(),
+      INCIDENT_SEV_2.toString(),
+      INCIDENT_SEV_3.toString(),
+    ]);
+
+    for (const rule of episodeRules) {
+      expect(rule.alertSeverityId).toBeUndefined();
+    }
+  });
+
+  test("no seeded episode rule is left without a severity", async () => {
+    /*
+     * The precise statement of GAP G: a NULL-severity episode rule matches no
+     * page and appears in no UI table, so it is worse than no rule at all - the
+     * user is told they are covered when they are not.
+     */
+    await runForEmailMethod();
+
+    const episodeRules: Array<Model> = createdRules().filter(
+      (rule: Model): boolean => {
+        return EPISODE_RULE_TYPES.includes(rule.ruleType!);
+      },
+    );
+
+    expect(episodeRules).toHaveLength(5);
+    for (const rule of episodeRules) {
+      expect(
+        rule.alertSeverityId !== undefined ||
+          rule.incidentSeverityId !== undefined,
+      ).toBe(true);
+    }
+  });
+
+  test("the total is incident + alert severities twice over, plus two, and nothing else", async () => {
+    await runForEmailMethod();
+
+    /*
+     * 3 incident + 2 alert on-call rules, then 2 alert episode + 3 incident
+     * episode rules, then the 2 shift rules.
+     */
+    expect(createSpy).toHaveBeenCalledTimes(TOTAL_SEEDED_RULES);
   });
 
   test("every seeded rule pages immediately - notifyAfterMinutes is 0", async () => {
     await runForEmailMethod();
 
     const rules: Array<Model> = createdRules();
-    expect(rules).toHaveLength(9);
+    expect(rules).toHaveLength(TOTAL_SEEDED_RULES);
     for (const rule of rules) {
       expect(rule.notifyAfterMinutes).toBe(0);
     }
@@ -347,7 +460,7 @@ describe("addDefaultNotificationRulesForVerifiedMethod - what gets seeded", () =
     }
   });
 
-  test("rules are seeded incident-first, then alert, then the four singles in a fixed order", async () => {
+  test("rules are seeded on-call-first, then the episodes, then the singles in a fixed order", async () => {
     /*
      * The order is not load-bearing for correctness, but it is the order the
      * duplicate checks run in too, so pinning it makes a reordering visible.
@@ -358,17 +471,7 @@ describe("addDefaultNotificationRulesForVerifiedMethod - what gets seeded", () =
       createdRules().map((rule: Model): NotificationRuleType => {
         return rule.ruleType!;
       }),
-    ).toEqual([
-      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
-      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
-      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
-      NotificationRuleType.ON_CALL_EXECUTED_ALERT,
-      NotificationRuleType.ON_CALL_EXECUTED_ALERT,
-      NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
-      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
-      NotificationRuleType.WHEN_USER_GOES_ON_CALL,
-      NotificationRuleType.WHEN_USER_GOES_OFF_CALL,
-    ]);
+    ).toEqual(SEEDED_RULE_ORDER);
   });
 
   test("severities are read for this project only, root-scoped, and up to the per-project limit", async () => {
@@ -376,6 +479,9 @@ describe("addDefaultNotificationRulesForVerifiedMethod - what gets seeded", () =
      * GAP A (OnCallNotificationReadiness.md 2.2): this read is a point-in-time
      * snapshot. Severities created after this call are never backfilled onto
      * existing users - pinned here so the backfill work has a baseline.
+     *
+     * Each list is read exactly ONCE even though it now drives two rule types
+     * apiece (on-call and episode), which is why the counts below stay at one.
      */
     await runForEmailMethod();
 
@@ -413,7 +519,7 @@ describe("addDefaultNotificationRulesForVerifiedMethod - the method lands on the
       await runForDescriptor(descriptorFor(channel));
 
       const rules: Array<Model> = createdRules();
-      expect(rules).toHaveLength(9);
+      expect(rules).toHaveLength(TOTAL_SEEDED_RULES);
 
       for (const rule of rules) {
         expect(rule[channel]?.toString()).toBe(METHOD_ID.toString());
@@ -439,7 +545,7 @@ describe("addDefaultNotificationRulesForVerifiedMethod - the method lands on the
       await runForDescriptor(descriptorFor(channel));
 
       const queries: Array<Record<string, unknown>> = duplicateCheckQueries();
-      expect(queries).toHaveLength(9);
+      expect(queries).toHaveLength(TOTAL_SEEDED_RULES);
 
       for (const query of queries) {
         expect((query[channel] as ObjectID).toString()).toBe(
@@ -476,7 +582,7 @@ describe("addDefaultNotificationRulesForVerifiedMethod - the method lands on the
     }
   });
 
-  test("an EMPTY descriptor still seeds nine method-less rules", async () => {
+  test("an EMPTY descriptor still seeds a full set of method-less rules", async () => {
     /*
      * KNOWN DEFECT, pinned as-is. With no id on the descriptor the duplicate
      * check degenerates to (projectId, userId, ruleType) and the created rows
@@ -488,7 +594,7 @@ describe("addDefaultNotificationRulesForVerifiedMethod - the method lands on the
     await runForDescriptor({});
 
     const rules: Array<Model> = createdRules();
-    expect(rules).toHaveLength(9);
+    expect(rules).toHaveLength(TOTAL_SEEDED_RULES);
 
     for (const rule of rules) {
       for (const channel of ALL_CHANNELS) {
@@ -506,7 +612,7 @@ describe("addDefaultNotificationRulesForVerifiedMethod - the method lands on the
   test("the duplicate check is root-scoped and keyed on project, user and rule type", async () => {
     await runForEmailMethod();
 
-    expect(findOneBySpy).toHaveBeenCalledTimes(9);
+    expect(findOneBySpy).toHaveBeenCalledTimes(TOTAL_SEEDED_RULES);
 
     for (const call of findOneBySpy.mock.calls) {
       const arg: {
@@ -549,7 +655,25 @@ describe("addDefaultNotificationRulesForVerifiedMethod - the method lands on the
       }),
     ).toEqual([ALERT_SEV_1.toString(), ALERT_SEV_2.toString()]);
 
-    for (const query of queries.slice(5)) {
+    // The episode checks are severity-keyed too, since Phase 1 closed GAP G.
+    expect(
+      queries.slice(5, 7).map((query: Record<string, unknown>): string => {
+        return (query["alertSeverityId"] as ObjectID).toString();
+      }),
+    ).toEqual([ALERT_SEV_1.toString(), ALERT_SEV_2.toString()]);
+
+    expect(
+      queries.slice(7, 10).map((query: Record<string, unknown>): string => {
+        return (query["incidentSeverityId"] as ObjectID).toString();
+      }),
+    ).toEqual([
+      INCIDENT_SEV_1.toString(),
+      INCIDENT_SEV_2.toString(),
+      INCIDENT_SEV_3.toString(),
+    ]);
+
+    // Only the two shift rules are looked up without a severity.
+    for (const query of queries.slice(10)) {
       expect(query["incidentSeverityId"]).toBeUndefined();
       expect(query["alertSeverityId"]).toBeUndefined();
     }
@@ -567,7 +691,7 @@ describe("addDefaultNotificationRulesForVerifiedMethod - idempotence", () => {
 
     await runForEmailMethod();
 
-    expect(findOneBySpy).toHaveBeenCalledTimes(9);
+    expect(findOneBySpy).toHaveBeenCalledTimes(TOTAL_SEEDED_RULES);
     expect(createSpy).not.toHaveBeenCalled();
   });
 
@@ -588,13 +712,26 @@ describe("addDefaultNotificationRulesForVerifiedMethod - idempotence", () => {
 
     await runForEmailMethod();
 
-    expect(createSpy).toHaveBeenCalledTimes(8);
+    /*
+     * Two rows are suppressed, not one: the incident on-call rule for SEV_2 and
+     * the incident EPISODE rule for SEV_2, both of which are now keyed on the
+     * same severity.
+     */
+    expect(createSpy).toHaveBeenCalledTimes(TOTAL_SEEDED_RULES - 2);
 
     const incidentRules: Array<Model> = createdRulesOfType(
       NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
     );
     expect(
       incidentRules.map((rule: Model): string => {
+        return rule.incidentSeverityId!.toString();
+      }),
+    ).toEqual([INCIDENT_SEV_1.toString(), INCIDENT_SEV_3.toString()]);
+
+    expect(
+      createdRulesOfType(
+        NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+      ).map((rule: Model): string => {
         return rule.incidentSeverityId!.toString();
       }),
     ).toEqual([INCIDENT_SEV_1.toString(), INCIDENT_SEV_3.toString()]);
@@ -617,13 +754,22 @@ describe("addDefaultNotificationRulesForVerifiedMethod - idempotence", () => {
 
     await runForEmailMethod();
 
-    expect(createSpy).toHaveBeenCalledTimes(8);
+    // Again two rows: the alert on-call rule and the alert episode rule.
+    expect(createSpy).toHaveBeenCalledTimes(TOTAL_SEEDED_RULES - 2);
 
     const alertRules: Array<Model> = createdRulesOfType(
       NotificationRuleType.ON_CALL_EXECUTED_ALERT,
     );
     expect(alertRules).toHaveLength(1);
     expect(alertRules[0]!.alertSeverityId!.toString()).toBe(
+      ALERT_SEV_2.toString(),
+    );
+
+    const alertEpisodeRules: Array<Model> = createdRulesOfType(
+      NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE,
+    );
+    expect(alertEpisodeRules).toHaveLength(1);
+    expect(alertEpisodeRules[0]!.alertSeverityId!.toString()).toBe(
       ALERT_SEV_2.toString(),
     );
   });
@@ -639,9 +785,18 @@ describe("addDefaultNotificationRulesForVerifiedMethod - idempotence", () => {
 
     await runForEmailMethod();
 
+    /*
+     * Every incident-severity-keyed row is suppressed - the 3 on-call rules and
+     * the 3 episode rules - leaving 2 alert, 2 alert episode and 2 shift rules.
+     */
     expect(createSpy).toHaveBeenCalledTimes(6);
     expect(
       createdRulesOfType(NotificationRuleType.ON_CALL_EXECUTED_INCIDENT),
+    ).toHaveLength(0);
+    expect(
+      createdRulesOfType(
+        NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+      ),
     ).toHaveLength(0);
     expect(
       createdRulesOfType(NotificationRuleType.ON_CALL_EXECUTED_ALERT),
@@ -663,7 +818,7 @@ describe("addDefaultNotificationRulesForVerifiedMethod - idempotence", () => {
 
       await runForEmailMethod();
 
-      expect(createSpy).toHaveBeenCalledTimes(8);
+      expect(createSpy).toHaveBeenCalledTimes(TOTAL_SEEDED_RULES - 1);
       expect(createdRulesOfType(existingRuleType)).toHaveLength(0);
 
       for (const otherRuleType of SINGLE_RULE_TYPES) {
@@ -672,6 +827,36 @@ describe("addDefaultNotificationRulesForVerifiedMethod - idempotence", () => {
         }
         expect(createdRulesOfType(otherRuleType)).toHaveLength(1);
       }
+    },
+  );
+
+  test.each<[NotificationRuleType, number]>([
+    [NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE, 2],
+    [NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE, 3],
+  ])(
+    "existing %s rules for every severity suppress exactly %i rows",
+    async (existingRuleType: NotificationRuleType, suppressedCount: number) => {
+      /*
+       * Episode rules are per-severity now, so "already seeded" is a statement
+       * about one severity at a time - stubbing the whole rule type standing in
+       * for a user who has all of them.
+       */
+      findOneBySpy.mockImplementation(
+        (findBy: { query: Record<string, unknown> }): Promise<Model | null> => {
+          return Promise.resolve(
+            findBy.query["ruleType"] === existingRuleType
+              ? existingRule()
+              : null,
+          );
+        },
+      );
+
+      await runForEmailMethod();
+
+      expect(createSpy).toHaveBeenCalledTimes(
+        TOTAL_SEEDED_RULES - suppressedCount,
+      );
+      expect(createdRulesOfType(existingRuleType)).toHaveLength(0);
     },
   );
 
@@ -691,7 +876,7 @@ describe("addDefaultNotificationRulesForVerifiedMethod - idempotence", () => {
 
     await runForDescriptor({ userSmsId: METHOD_ID });
 
-    expect(createSpy).toHaveBeenCalledTimes(9);
+    expect(createSpy).toHaveBeenCalledTimes(TOTAL_SEEDED_RULES);
   });
 
   test("the duplicate check runs once per candidate rule - no extra reads", async () => {
@@ -702,13 +887,18 @@ describe("addDefaultNotificationRulesForVerifiedMethod - idempotence", () => {
 });
 
 describe("addDefaultNotificationRulesForVerifiedMethod - a project with no severities", () => {
-  test("no per-severity rules are seeded, but the four single rules still are", async () => {
+  test("no per-severity rules are seeded, but the two shift rules still are", async () => {
+    /*
+     * The episode rules follow the severities now, so a project with none gets
+     * no episode rules either. That is the correct reading of GAP G: a rule for
+     * a severity that does not exist could never have matched a page anyway.
+     */
     incidentSeveritiesSpy.mockResolvedValue([] as never);
     alertSeveritiesSpy.mockResolvedValue([] as never);
 
     await runForEmailMethod();
 
-    expect(createSpy).toHaveBeenCalledTimes(4);
+    expect(createSpy).toHaveBeenCalledTimes(2);
     expect(
       createdRules().map((rule: Model): NotificationRuleType => {
         return rule.ruleType!;
@@ -716,20 +906,20 @@ describe("addDefaultNotificationRulesForVerifiedMethod - a project with no sever
     ).toEqual(SINGLE_RULE_TYPES);
   });
 
-  test("with no severities the duplicate check runs only for the four single rules", async () => {
+  test("with no severities the duplicate check runs only for the two shift rules", async () => {
     incidentSeveritiesSpy.mockResolvedValue([] as never);
     alertSeveritiesSpy.mockResolvedValue([] as never);
 
     await runForEmailMethod();
 
-    expect(findOneBySpy).toHaveBeenCalledTimes(4);
+    expect(findOneBySpy).toHaveBeenCalledTimes(2);
     for (const query of duplicateCheckQueries()) {
       expect(query["incidentSeverityId"]).toBeUndefined();
       expect(query["alertSeverityId"]).toBeUndefined();
     }
   });
 
-  test("the single rules still get the method and notifyAfterMinutes 0", async () => {
+  test("the shift rules still get the method and notifyAfterMinutes 0", async () => {
     incidentSeveritiesSpy.mockResolvedValue([] as never);
     alertSeveritiesSpy.mockResolvedValue([] as never);
 
@@ -746,11 +936,19 @@ describe("addDefaultNotificationRulesForVerifiedMethod - a project with no sever
 
     await runForEmailMethod();
 
-    // 0 incident + 2 alert + 4 single.
+    // 0 incident + 2 alert + 2 alert episode + 0 incident episode + 2 shift.
     expect(createSpy).toHaveBeenCalledTimes(6);
     expect(
       createdRulesOfType(NotificationRuleType.ON_CALL_EXECUTED_ALERT),
     ).toHaveLength(2);
+    expect(
+      createdRulesOfType(NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE),
+    ).toHaveLength(2);
+    expect(
+      createdRulesOfType(
+        NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+      ),
+    ).toHaveLength(0);
   });
 
   test("only alert severities missing still seeds the incident rules", async () => {
@@ -758,11 +956,19 @@ describe("addDefaultNotificationRulesForVerifiedMethod - a project with no sever
 
     await runForEmailMethod();
 
-    // 3 incident + 0 alert + 4 single.
-    expect(createSpy).toHaveBeenCalledTimes(7);
+    // 3 incident + 0 alert + 0 alert episode + 3 incident episode + 2 shift.
+    expect(createSpy).toHaveBeenCalledTimes(8);
     expect(
       createdRulesOfType(NotificationRuleType.ON_CALL_EXECUTED_INCIDENT),
     ).toHaveLength(3);
+    expect(
+      createdRulesOfType(
+        NotificationRuleType.ON_CALL_EXECUTED_INCIDENT_EPISODE,
+      ),
+    ).toHaveLength(3);
+    expect(
+      createdRulesOfType(NotificationRuleType.ON_CALL_EXECUTED_ALERT_EPISODE),
+    ).toHaveLength(0);
   });
 });
 
@@ -834,7 +1040,7 @@ describe("addDefaultNotificationRuleForUser - materialising the e-mail identity"
     );
 
     const rules: Array<Model> = createdRules();
-    expect(rules).toHaveLength(9);
+    expect(rules).toHaveLength(TOTAL_SEEDED_RULES);
     for (const rule of rules) {
       expect(rule.userEmailId!.toString()).toBe(CREATED_EMAIL_ID.toString());
       expect(rule.userSmsId).toBeUndefined();
@@ -902,7 +1108,7 @@ describe("addDefaultNotificationRuleForUser - reusing an existing e-mail identit
     );
 
     const rules: Array<Model> = createdRules();
-    expect(rules).toHaveLength(9);
+    expect(rules).toHaveLength(TOTAL_SEEDED_RULES);
     for (const rule of rules) {
       expect(rule.userEmailId!.toString()).toBe(EXISTING_EMAIL_ID.toString());
     }
@@ -938,7 +1144,7 @@ describe("addDefaultNotificationRuleForUser - reusing an existing e-mail identit
     );
 
     expect(userEmailCreateSpy).not.toHaveBeenCalled();
-    expect(createSpy).toHaveBeenCalledTimes(9);
+    expect(createSpy).toHaveBeenCalledTimes(TOTAL_SEEDED_RULES);
     expect(createdRules()[0]!.userEmailId!.toString()).toBe(
       EXISTING_EMAIL_ID.toString(),
     );
@@ -955,13 +1161,6 @@ describe("addDefaultNotificationRuleForUser - reusing an existing e-mail identit
       createdRules().map((rule: Model): NotificationRuleType => {
         return rule.ruleType!;
       }),
-    ).toEqual([
-      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
-      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
-      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
-      NotificationRuleType.ON_CALL_EXECUTED_ALERT,
-      NotificationRuleType.ON_CALL_EXECUTED_ALERT,
-      ...SINGLE_RULE_TYPES,
-    ]);
+    ).toEqual(SEEDED_RULE_ORDER);
   });
 });

--- a/Common/Tests/Server/Services/UserOnCallLogNoNotificationRules.test.ts
+++ b/Common/Tests/Server/Services/UserOnCallLogNoNotificationRules.test.ts
@@ -1,10 +1,15 @@
 import UserOnCallLogService from "../../../Server/Services/UserOnCallLogService";
-import UserNotificationRuleService from "../../../Server/Services/UserNotificationRuleService";
+import UserNotificationRuleService, {
+  FallbackNotificationOutcome,
+} from "../../../Server/Services/UserNotificationRuleService";
 import OnCallDutyPolicyExecutionLogTimelineService from "../../../Server/Services/OnCallDutyPolicyExecutionLogTimelineService";
 import IncidentService from "../../../Server/Services/IncidentService";
 import AlertService from "../../../Server/Services/AlertService";
 import AlertEpisodeService from "../../../Server/Services/AlertEpisodeService";
 import IncidentEpisodeService from "../../../Server/Services/IncidentEpisodeService";
+import ProjectService from "../../../Server/Services/ProjectService";
+import UserService from "../../../Server/Services/UserService";
+import Project from "../../../Models/DatabaseModels/Project";
 import CreateBy from "../../../Server/Types/Database/CreateBy";
 import UpdateBy from "../../../Server/Types/Database/UpdateBy";
 import { OnCreate, OnUpdate } from "../../../Server/Types/Database/Hooks";
@@ -25,28 +30,31 @@ import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
  * to a human. A UserOnCallLog row is written by the escalation machinery, and
  * this hook decides whether the responder's phone rings.
  *
- * The branch these tests are mostly about is the "no rules" dead-end at
- * UserOnCallLogService.ts:329. When the responder has ZERO UserNotificationRule
- * rows matching (ruleType x severity), the hook writes `Error` plus a status
- * message onto the log and onto the on-call timeline, and RETURNS. Nothing is
- * sent. Nobody is emailed. The escalation timer keeps running as if the person
- * had simply chosen not to acknowledge. This is Gap C in
- * Internal/Roadmap/OnCallNotificationReadiness.md, and Phase 1 replaces the
- * dead-end with a verified-method fallback.
+ * The branch these tests are mostly about USED to be a dead-end. When the
+ * responder had ZERO UserNotificationRule rows matching (ruleType x severity),
+ * the hook wrote `Error` plus a status message onto the log and onto the on-call
+ * timeline, and RETURNED. Nothing was sent. Nobody was emailed. The escalation
+ * timer kept running as if the person had simply chosen not to acknowledge. That
+ * is Gap C in Internal/Roadmap/OnCallNotificationReadiness.md.
  *
- * Everything in section (A) below therefore pins behaviour that is DELIBERATELY
- * WRONG today and is expected to change:
+ * GAP C CLOSED IN PHASE 1. The zero-rule branch now asks three questions in
+ * order, and section (A) below pins all three:
  *
- *   GAP C - Phase 1 replaces this dead-end with a verified-method fallback
- *           (status Success + "notified via fallback (<method>)"), an explicit
- *           opt-out path (status Skipped), and an owner-notification event. The
- *           assertions on `UserNotificationExecutionStatus.Error` and on the
- *           exact "No notification rules found for this user..." string are the
- *           ones a later phase must invert.
+ *   1. Is there an isOptOut row for this exact (ruleType x severity)? Then the
+ *      silence was asked for: status Completed, timeline Skipped, nothing sent.
+ *   2. Has the project set disableOnCallNotificationFallback? Then it wants the
+ *      old behaviour, and it gets it verbatim - the same Error, the same
+ *      sentence. That path is the reason the exact
+ *      "No notification rules found for this user..." string is still pinned
+ *      here, character for character.
+ *   3. Otherwise: the verified-method fallback. Delivered => status Executing
+ *      plus "notified via fallback (<channels>)" and a Notification Sent
+ *      timeline row. Nothing verified to deliver on => a loud, terminal Error
+ *      that names the responder and says where to fix it.
  *
- * The rest of the file pins the surrounding machinery that the fallback has to
- * keep working: which severity id is threaded into the rule count for each of
- * the four trigger kinds, the exact option bag handed to
+ * The rest of the file pins the surrounding machinery the fallback has to keep
+ * working: which severity id is threaded into the rule count for each of the
+ * four trigger kinds, the exact option bag handed to
  * executeNotificationRuleItem, the event-type -> rule-type mapping, the
  * execution-status -> timeline-status translation in onUpdateSuccess, and the
  * unconditional `status = Scheduled` stamp in onBeforeCreate.
@@ -110,12 +118,29 @@ const RULE_B_ID: ObjectID = new ObjectID(
 );
 
 /*
- * The literal the dead-end writes. Copied character-for-character from
- * UserOnCallLogService.ts:335 and :348 - it is written twice, and both copies
- * must agree or the log and the timeline tell the operator different stories.
+ * The literal the pre-fallback dead-end wrote, and still the literal written on
+ * the ONE path that asks for the old behaviour:
+ * project.disableOnCallNotificationFallback. Copied character-for-character from
+ * UserOnCallLogService's NO_NOTIFICATION_RULES_STATUS_MESSAGE - it is written to
+ * both the log and the timeline, and both copies must agree or they tell the
+ * operator different stories.
  */
 const NO_RULES_MESSAGE: string =
   "No notification rules found for this user. User should add the rules in User Settings > On-Call Rules.";
+
+/* The channel the stubbed fallback claims to have delivered on. */
+const FALLBACK_CHANNEL: string = "Email";
+
+/*
+ * A project row shaped the way the no-rule path reads it. `undefined` means the
+ * fallback is enabled, which is the product default.
+ */
+function makeProject(disableOnCallNotificationFallback?: boolean): Project {
+  return {
+    _id: PROJECT_ID.toString(),
+    disableOnCallNotificationFallback: disableOnCallNotificationFallback,
+  } as unknown as Project;
+}
 
 interface StatusUpdateCall {
   id: ObjectID;
@@ -255,7 +280,11 @@ let logUpdateSpy: jest.SpyInstance;
 let timelineUpdateSpy: jest.SpyInstance;
 let countBySpy: jest.SpyInstance;
 let ruleFindBySpy: jest.SpyInstance;
+let ruleFindOneBySpy: jest.SpyInstance;
 let executeRuleSpy: jest.SpyInstance;
+let fallbackSpy: jest.SpyInstance;
+let projectFindOneByIdSpy: jest.SpyInstance;
+let userFindOneByIdSpy: jest.SpyInstance;
 
 function statusUpdates(): Array<StatusUpdateCall> {
   return logUpdateSpy.mock.calls.map(
@@ -291,9 +320,37 @@ beforeEach(() => {
     .spyOn(UserNotificationRuleService, "findBy")
     .mockResolvedValue([] as never);
 
+  /*
+   * The opt-out lookup. "No opt-out row" is the default for this file: the
+   * interesting default is the one where a page SHOULD go out.
+   */
+  ruleFindOneBySpy = jest
+    .spyOn(UserNotificationRuleService, "findOneBy")
+    .mockResolvedValue(null as never);
+
   executeRuleSpy = jest
     .spyOn(UserNotificationRuleService, "executeNotificationRuleItem")
     .mockResolvedValue(undefined as never);
+
+  // Fallback enabled (the product default), and it reaches somebody.
+  projectFindOneByIdSpy = jest
+    .spyOn(ProjectService, "findOneById")
+    .mockResolvedValue(makeProject() as never);
+
+  fallbackSpy = jest
+    .spyOn(UserNotificationRuleService, "executeFallbackNotification")
+    .mockResolvedValue({
+      notified: true,
+      channelsUsed: [FALLBACK_CHANNEL],
+    } as never);
+
+  /*
+   * Only ever read to put a name in a failure message, so a null user is a
+   * perfectly good default - the message degrades to "This responder".
+   */
+  userFindOneByIdSpy = jest
+    .spyOn(UserService, "findOneById")
+    .mockResolvedValue(null as never);
 
   jest.spyOn(IncidentService, "findOneById").mockResolvedValue({
     incidentSeverityId: INCIDENT_SEVERITY_ID,
@@ -315,67 +372,231 @@ afterEach(() => {
 
 /*
  * ------------------------------------------------------------------------- *
- * (A) onCreateSuccess - the "no rules" dead-end.
+ * (A) onCreateSuccess - the "no rules" branch, and the three answers it now
+ *     has for it.
  * -------------------------------------------------------------------------
  */
 
 describe("UserOnCallLogService.onCreateSuccess - zero matching notification rules", () => {
   /*
-   * GAP C - Phase 1 inverts these assertions.
+   * GAP C CLOSED - these assertions are the inverted ones.
    *
-   * Every test in this describe block asserts that a responder with no matching
-   * rule is silently dropped: the log is marked Error, the timeline is marked
-   * Error, and nothing at all is sent. That is today's behaviour and it is the
-   * bug the readiness plan exists to fix.
+   * Every test in this describe block used to assert that a responder with no
+   * matching rule was silently dropped: log Error, timeline Error, nothing sent.
+   * They now assert the opposite - that the fallback carries the page and both
+   * records say so.
    */
 
-  test("the log is marked Error - a terminal status no worker re-selects", async () => {
+  test("the log ends at Executing, not at a terminal Error", async () => {
     await callOnCreateSuccess(makeCreatedLog(INCIDENT_LOG));
 
     const updates: Array<StatusUpdateCall> = statusUpdates();
 
     /*
-     * Two writes, in order: the hook first flips the freshly-created row to
-     * Started, then - finding no rules - straight to Error.
+     * Still exactly two writes, in order: the hook flips the freshly-created row
+     * to Started, then - having reached somebody through the fallback - to
+     * Executing, which is where the normal path leaves it too. The worker's next
+     * tick finds no outstanding rules and closes it out as Completed.
      */
     expect(updates).toHaveLength(2);
     expect(updates[0]!.data.status).toBe(
       UserNotificationExecutionStatus.Started,
     );
-    expect(updates[1]!.data.status).toBe(UserNotificationExecutionStatus.Error);
+    expect(updates[1]!.data.status).toBe(
+      UserNotificationExecutionStatus.Executing,
+    );
     expect(updates[1]!.id.toString()).toBe(LOG_ID.toString());
     expect(updates[1]!.props.isRoot).toBe(true);
   });
 
-  test("the log's statusMessage is the exact setup-your-rules string", async () => {
+  test("the log's statusMessage names the fallback and the channel it used", async () => {
     await callOnCreateSuccess(makeCreatedLog(INCIDENT_LOG));
 
     const updates: Array<StatusUpdateCall> = statusUpdates();
 
-    expect(updates[1]!.data.statusMessage).toBe(NO_RULES_MESSAGE);
-    // The message points at a settings page. Nothing emails the user it.
     expect(updates[1]!.data.statusMessage).toContain(
-      "User Settings > On-Call Rules",
+      "No notification rule configured for",
     );
+    expect(updates[1]!.data.statusMessage).toContain("notified via fallback");
+    expect(updates[1]!.data.statusMessage).toContain(FALLBACK_CHANNEL);
+    // The old dead-end sentence is not written on this path at all.
+    expect(updates[1]!.data.statusMessage).not.toBe(NO_RULES_MESSAGE);
   });
 
-  test("the on-call timeline gets the SAME Error status and the SAME message", async () => {
+  test("the on-call timeline says Notification Sent with the SAME message", async () => {
     await callOnCreateSuccess(makeCreatedLog(INCIDENT_LOG));
 
     const timeline: Array<TimelineUpdateCall> = timelineUpdates();
+    const updates: Array<StatusUpdateCall> = statusUpdates();
 
     expect(timeline).toHaveLength(1);
     expect(timeline[0]!.id.toString()).toBe(TIMELINE_ID.toString());
     expect(timeline[0]!.data.status).toBe(
-      OnCallDutyExecutionLogTimelineStatus.Error,
+      OnCallDutyExecutionLogTimelineStatus.NotificationSent,
     );
-    expect(timeline[0]!.data.statusMessage).toBe(NO_RULES_MESSAGE);
+    /*
+     * The log and the timeline must keep telling the operator the same story -
+     * that was true of the dead-end's two copies and it stays true here.
+     */
+    expect(timeline[0]!.data.statusMessage).toBe(
+      updates[1]!.data.statusMessage,
+    );
     expect(timeline[0]!.props.isRoot).toBe(true);
   });
 
-  test("executeNotificationRuleItem is NEVER called - the responder is not paged", async () => {
+  test("the opt-out lookup asks for exactly the cell the count came up empty for", async () => {
     await callOnCreateSuccess(makeCreatedLog(INCIDENT_LOG));
 
+    expect(ruleFindOneBySpy).toHaveBeenCalledTimes(1);
+    const query: Record<string, unknown> = (
+      ruleFindOneBySpy.mock.calls[0]![0] as { query: Record<string, unknown> }
+    ).query;
+
+    expect((query["userId"] as ObjectID).toString()).toBe(USER_ID.toString());
+    expect((query["projectId"] as ObjectID).toString()).toBe(
+      PROJECT_ID.toString(),
+    );
+    expect(query["ruleType"]).toBe(
+      NotificationRuleType.ON_CALL_EXECUTED_INCIDENT,
+    );
+    expect((query["incidentSeverityId"] as ObjectID).toString()).toBe(
+      INCIDENT_SEVERITY_ID.toString(),
+    );
+    expect(query["isOptOut"]).toBe(true);
+  });
+
+  test("an opt-out row means intentional silence: Completed, Skipped, nothing sent", async () => {
+    ruleFindOneBySpy.mockResolvedValue(makeRule(RULE_A_ID) as never);
+
+    await callOnCreateSuccess(makeCreatedLog(INCIDENT_LOG));
+
+    const updates: Array<StatusUpdateCall> = statusUpdates();
+    const timeline: Array<TimelineUpdateCall> = timelineUpdates();
+
+    expect(updates[1]!.data.status).toBe(
+      UserNotificationExecutionStatus.Completed,
+    );
+    expect(updates[1]!.data.statusMessage).toContain("opted out");
+    expect(timeline[0]!.data.status).toBe(
+      OnCallDutyExecutionLogTimelineStatus.Skipped,
+    );
+
+    /*
+     * The point of the opt-out row: it is checked BEFORE the project setting and
+     * before any delivery, so nothing is dispatched and no project read is even
+     * needed.
+     */
+    expect(fallbackSpy).not.toHaveBeenCalled();
+    expect(projectFindOneByIdSpy).not.toHaveBeenCalled();
+    expect(executeRuleSpy).not.toHaveBeenCalled();
+  });
+
+  test("disableOnCallNotificationFallback restores the old dead-end, word for word", async () => {
+    projectFindOneByIdSpy.mockResolvedValue(makeProject(true) as never);
+
+    await callOnCreateSuccess(makeCreatedLog(INCIDENT_LOG));
+
+    const updates: Array<StatusUpdateCall> = statusUpdates();
+    const timeline: Array<TimelineUpdateCall> = timelineUpdates();
+
+    expect(updates).toHaveLength(2);
+    expect(updates[1]!.data.status).toBe(UserNotificationExecutionStatus.Error);
+    expect(updates[1]!.data.statusMessage).toBe(NO_RULES_MESSAGE);
+    expect(updates[1]!.data.statusMessage).toContain(
+      "User Settings > On-Call Rules",
+    );
+
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]!.data.status).toBe(
+      OnCallDutyExecutionLogTimelineStatus.Error,
+    );
+    expect(timeline[0]!.data.statusMessage).toBe(NO_RULES_MESSAGE);
+
+    // A project that opted out of the fallback is never billed for one either.
+    expect(fallbackSpy).not.toHaveBeenCalled();
+  });
+
+  test("a responder with nothing verified ends as an Error that says what to do", async () => {
+    /*
+     * The outcome is what separates the two Error endings, so it has to be set
+     * here. notified:false alone means only "nothing went out"; it is
+     * NoUsableNotificationMethod that says the responder is unreachable rather
+     * than that a send blew up, and the two get different messages because they
+     * need different actions from whoever reads the log.
+     */
+    fallbackSpy.mockResolvedValue({
+      notified: false,
+      outcome: FallbackNotificationOutcome.NoUsableNotificationMethod,
+      channelsUsed: [],
+    } as never);
+
+    await callOnCreateSuccess(makeCreatedLog(INCIDENT_LOG));
+
+    const updates: Array<StatusUpdateCall> = statusUpdates();
+    const timeline: Array<TimelineUpdateCall> = timelineUpdates();
+
+    expect(updates[1]!.data.status).toBe(UserNotificationExecutionStatus.Error);
+    expect(updates[1]!.data.statusMessage).toContain(
+      "has no verified notification method",
+    );
+    expect(updates[1]!.data.statusMessage).toContain(
+      "User Settings > Notification Methods",
+    );
+    expect(timeline[0]!.data.status).toBe(
+      OnCallDutyExecutionLogTimelineStatus.Error,
+    );
+
+    /*
+     * The responder is read TWICE on this path, and both reads are wanted.
+     * This function reads them for their name, to put a person rather than a
+     * uuid in the status message. OnCallNotificationAlertingService then reads
+     * them again for their email, because it emails the responder directly -
+     * and it has to do its own read regardless, since the
+     * disableOnCallNotificationFallback branch reaches it without ever
+     * computing a label. Threading the row through to save one query would
+     * couple a fire-and-forget notifier to the paging path it must never be
+     * able to slow down or break.
+     */
+    expect(userFindOneByIdSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("a fallback that throws is contained: the escalation is not taken down with it", async () => {
+    /*
+     * The caller is part-way through paging a whole escalation level. If this
+     * hook threw, every responder queued behind this one would be skipped.
+     */
+    fallbackSpy.mockRejectedValue(new Error("smtp exploded") as never);
+
+    const created: Model = makeCreatedLog(INCIDENT_LOG);
+
+    await expect(callOnCreateSuccess(created)).resolves.toBe(created);
+
+    const updates: Array<StatusUpdateCall> = statusUpdates();
+
+    /*
+     * Error, and deliberately so. The tempting alternative - leave the log
+     * Executing so "the next tick retries" - buys no retry at all: nothing
+     * re-enters this hook. What it would actually buy is
+     * ExecutePendingExecutions picking the log up, finding no due rules (there
+     * were none, which is why the fallback ran), and closing it out as
+     * Completed - which onUpdateSuccess renders on the escalation timeline as
+     * "Alert Sent" for a page nobody received.
+     */
+    expect(updates[1]!.data.status).toBe(UserNotificationExecutionStatus.Error);
+    expect(updates[1]!.data.statusMessage).toContain(
+      "the fallback delivery attempt failed",
+    );
+    expect(updates[1]!.data.statusMessage).toContain("was not delivered");
+  });
+
+  test("executeNotificationRuleItem is NEVER called - there is no rule to execute", async () => {
+    await callOnCreateSuccess(makeCreatedLog(INCIDENT_LOG));
+
+    /*
+     * Unchanged, and it is not a contradiction of the fallback: the fallback
+     * builds its own unsaved rules and delivers them itself, precisely because
+     * there is no persisted rule to hand to executeNotificationRuleItem.
+     */
     expect(executeRuleSpy).not.toHaveBeenCalled();
   });
 
@@ -384,7 +605,8 @@ describe("UserOnCallLogService.onCreateSuccess - zero matching notification rule
 
     /*
      * countBy answered zero, so the hook returns before the notifyAfterMinutes
-     * findBy. Any fallback added later has to live between those two points.
+     * findBy. The fallback lives between those two points, and reaches for the
+     * opt-out row with findOneBy rather than widening this count.
      */
     expect(countBySpy).toHaveBeenCalledTimes(1);
     expect(ruleFindBySpy).not.toHaveBeenCalled();
@@ -398,21 +620,20 @@ describe("UserOnCallLogService.onCreateSuccess - zero matching notification rule
     expect(returned).toBe(created);
   });
 
-  test("the log never reaches Executing and the timeline never says Alert Sent", async () => {
+  test("the timeline never says 'Alert Sent' - the fallback message is more specific", async () => {
     await callOnCreateSuccess(makeCreatedLog(INCIDENT_LOG));
 
-    const sawExecuting: boolean = statusUpdates().some(
-      (update: StatusUpdateCall): boolean => {
-        return update.data.status === UserNotificationExecutionStatus.Executing;
-      },
-    );
     const sawAlertSent: boolean = timelineUpdates().some(
       (update: TimelineUpdateCall): boolean => {
         return update.data.statusMessage === "Alert Sent";
       },
     );
 
-    expect(sawExecuting).toBe(false);
+    /*
+     * The normal path's timeline message is the generic "Alert Sent". The
+     * fallback deliberately writes something an operator can act on instead, so
+     * a fallback delivery is never mistaken for a configured one.
+     */
     expect(sawAlertSent).toBe(false);
   });
 });
@@ -421,8 +642,10 @@ describe("UserOnCallLogService.onCreateSuccess - severity threading per trigger 
   /*
    * Each trigger kind loads its own parent entity and threads THAT entity's
    * severity id into the rule count. Getting the wrong key here would count
-   * rules for a severity the incident does not have, which reads as "no rules"
-   * and lands in the same dead-end.
+   * rules for a severity the incident does not have, which reads as "no rules" -
+   * and now sends the responder down the fallback path for a cell they are in
+   * fact configured for, which is a subtler bug than the old dead-end, not a
+   * milder one.
    */
 
   test.each<
@@ -463,7 +686,7 @@ describe("UserOnCallLogService.onCreateSuccess - severity threading per trigger 
       EPISODE_INCIDENT_SEVERITY_ID,
     ],
   ])(
-    "a %s-triggered log counts rules by its own severity, then dead-ends on zero",
+    "a %s-triggered log counts rules by its own severity, then falls back on zero",
     async (
       _label: string,
       overrides: Record<string, unknown>,
@@ -486,13 +709,20 @@ describe("UserOnCallLogService.onCreateSuccess - severity threading per trigger 
       expect(call.limit).toBe(LIMIT_PER_PROJECT);
       expect(call.props.isRoot).toBe(true);
 
-      // GAP C - Phase 1 inverts this: the zero-rule dead-end for every kind.
+      /*
+       * GAP C CLOSED - all four trigger kinds now reach the fallback, and each
+       * hands it ITS OWN rule type so the fallback reasons about the right cell.
+       */
+      const fallbackOptions: Record<string, unknown> = fallbackSpy.mock
+        .calls[0]![0] as Record<string, unknown>;
+      expect(fallbackOptions["ruleType"]).toBe(expectedRuleType);
+
       const updates: Array<StatusUpdateCall> = statusUpdates();
       expect(updates[updates.length - 1]!.data.status).toBe(
-        UserNotificationExecutionStatus.Error,
+        UserNotificationExecutionStatus.Executing,
       );
-      expect(updates[updates.length - 1]!.data.statusMessage).toBe(
-        NO_RULES_MESSAGE,
+      expect(updates[updates.length - 1]!.data.statusMessage).toContain(
+        "notified via fallback",
       );
       expect(executeRuleSpy).not.toHaveBeenCalled();
     },
@@ -507,21 +737,34 @@ describe("UserOnCallLogService.onCreateSuccess - severity threading per trigger 
      * An alert-triggered log queries alertSeverityId ONLY - incidentSeverityId
      * is not part of the object at all, so the count is not accidentally
      * narrowed by an incident severity.
+     *
+     * isOptOut is the fifth key and is load-bearing: without it an opt-out row
+     * counts as a matching rule, the zero-rule branch is never entered, and the
+     * immediate-rule lookup then executes the opt-out as though it were a real
+     * rule - sending nothing while the escalation timeline records
+     * "Alert Sent". Removing it from this list would let that regression back
+     * in silently.
      */
     expect(Object.keys(call.query).sort()).toEqual([
       "alertSeverityId",
+      "isOptOut",
       "projectId",
       "ruleType",
       "userId",
     ]);
   });
 
-  test("a missing parent entity still dead-ends, with an undefined severity in the query", async () => {
+  test("a missing parent entity still counts with an undefined severity in the query", async () => {
     /*
      * findOneById returning null (deleted incident, or a read that raced the
-     * write) makes `incident?.incidentSeverityId` undefined. Today that is
-     * passed straight through as the query value rather than being treated as
-     * an error, and the responder lands in the same silent dead-end.
+     * write) makes `incident?.incidentSeverityId` undefined. That is still
+     * passed straight through as the query value rather than being treated as an
+     * error - unchanged - so the count comes back zero.
+     *
+     * GAP C CLOSED - what changed is the consequence. The responder used to land
+     * in the silent dead-end; they now go to the fallback, which is the right
+     * answer for a race: somebody is on call for something, and losing the
+     * parent row is no reason to lose the page too.
      */
     jest.spyOn(IncidentService, "findOneById").mockResolvedValue(null as never);
 
@@ -532,24 +775,29 @@ describe("UserOnCallLogService.onCreateSuccess - severity threading per trigger 
 
     const updates: Array<StatusUpdateCall> = statusUpdates();
     expect(updates[updates.length - 1]!.data.status).toBe(
-      UserNotificationExecutionStatus.Error,
+      UserNotificationExecutionStatus.Executing,
     );
+    expect(fallbackSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("a log with no trigger id at all counts nothing and dead-ends", async () => {
+  test("a log with no trigger id at all counts nothing and falls back", async () => {
     /*
      * ruleCount starts at PositiveNumber(0) and none of the four `if` blocks
      * run, so countBy is never called and the hook falls straight into the
      * zero-rule branch.
+     *
+     * GAP C CLOSED - and out the other side into the fallback rather than an
+     * Error.
      */
     await callOnCreateSuccess(makeCreatedLog());
 
     expect(countBySpy).not.toHaveBeenCalled();
     const updates: Array<StatusUpdateCall> = statusUpdates();
     expect(updates[updates.length - 1]!.data.status).toBe(
-      UserNotificationExecutionStatus.Error,
+      UserNotificationExecutionStatus.Executing,
     );
     expect(executeRuleSpy).not.toHaveBeenCalled();
+    expect(fallbackSpy).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -711,6 +959,7 @@ describe("UserOnCallLogService.onCreateSuccess - at least one matching rule", ()
     expect(Object.keys(call.query).sort()).toEqual([
       "alertSeverityId",
       "incidentSeverityId",
+      "isOptOut",
       "notifyAfterMinutes",
       "projectId",
       "ruleType",

--- a/Common/Tests/__mocks__/bullmq.js
+++ b/Common/Tests/__mocks__/bullmq.js
@@ -1,0 +1,55 @@
+/*
+ * bullmq ships ESM and pulls in msgpackr, which is also ESM. Neither is listed
+ * in transformIgnorePatterns, so the moment any module under test reaches
+ * Server/Infrastructure/Queue the suite dies before a single test runs with
+ * "SyntaxError: Unexpected token 'export'" pointing at msgpackr/index.js.
+ *
+ * That import edge is not exotic: enqueueing a job is ordinary service code, so
+ * any service that schedules background work drags bullmq into the graph of
+ * every test that touches it, however indirectly. Mapping the package here -
+ * the same mechanism this config already uses for uuid, yaml, locter, otpauth
+ * and friends - fixes it once for every current and future test, instead of
+ * making each one repeat a hoisted jest.mock factory.
+ *
+ * The surface below is only what the real Queue wrapper calls. A test that
+ * needs to assert on queue behaviour should still declare its own
+ * jest.mock("bullmq", ...) with a richer factory, which takes precedence over
+ * this mapping - Common/Tests/Server/Infrastructure/Queue.test.ts does exactly
+ * that.
+ */
+
+class Queue {
+  constructor() {
+    this.add = jest.fn().mockResolvedValue({});
+    this.getRepeatableJobs = jest.fn().mockResolvedValue([]);
+    this.removeRepeatableByKey = jest.fn().mockResolvedValue(true);
+    this.getJob = jest.fn().mockResolvedValue(undefined);
+    this.clean = jest.fn().mockResolvedValue([]);
+    this.close = jest.fn().mockResolvedValue(undefined);
+    this.client = Promise.resolve({ on: jest.fn() });
+  }
+}
+
+class Worker {
+  constructor() {
+    this.on = jest.fn();
+    this.close = jest.fn().mockResolvedValue(undefined);
+  }
+}
+
+class QueueEvents {
+  constructor() {
+    this.on = jest.fn();
+    this.close = jest.fn().mockResolvedValue(undefined);
+  }
+}
+
+class Job {}
+
+module.exports = {
+  __esModule: true,
+  Queue,
+  Worker,
+  QueueEvents,
+  Job,
+};

--- a/Common/jest.config.json
+++ b/Common/jest.config.json
@@ -14,6 +14,7 @@
     "Common/(.*)": "<rootDir>/$1",
     "\\.(css|less|scss|sass)$": "<rootDir>/Tests/__mocks__/styleMock.js",
     "^uuid$": "<rootDir>/Tests/__mocks__/uuid.js",
+    "^bullmq$": "<rootDir>/Tests/__mocks__/bullmq.js",
     "^locter$": "<rootDir>/Tests/__mocks__/locter.js",
     "^yaml$": "<rootDir>/Tests/__mocks__/yaml.js",
     "^otpauth$": "<rootDir>/Tests/__mocks__/otpauth.js",


### PR DESCRIPTION
Stack 2/N — **base is `claude/oncall-readiness-p0-tests` (#3175), not master.** Review that first.

This is the PR that actually stops missed pages.

Four independent ways a responder on an on-call policy could be paged and receive
nothing. All four end the same way — a status message in an execution log nobody
reads — so none of them looked like outages.

## Gap C — no matching rule dead-ended

`UserOnCallLogService.onCreateSuccess` counted rules for `(ruleType × severity)`,
got zero, wrote `Error`, and returned. The escalation timer kept running as
though the responder had declined to acknowledge.

Now it falls back to whatever they have actually verified: **all zero-cost
channels together (push + email)**, reaching for a paid channel only when there
is no other option — and then only if the project has that channel enabled.
That last clause matters: `enableSmsNotifications` and friends are enforced at
method-*verification* time, not at send time, so a naive fallback would bill a
project for SMS it had switched off.

## Gap A — new severities were never backfilled

Creating a severity now enqueues a backfill that **mirrors what each responder
already asked for** — the distinct `(method, delay)` pairs they use for the same
rule type on other severities. Someone who set "Sev1 → call immediately, Sev3 →
email after 15 min" gets a sensible Sev4 rule, not a surprise phone call. It runs
as a job, not inline: a project can hold thousands of responders.

## Gap F — five of seven channels dropped incident-episode pages

Only the webhook and push blocks had an `IncidentEpisodeCreated` branch. Email,
SMS, WhatsApp, Telegram and Call sent nothing — and wrote no error row either,
because the `!isVerified` else-branch does not fire for a verified-but-*unhandled*
channel. All five now have one, plus a **fell-through guard** that turns any
future gap of this shape into a visible `Error` instead of a missing page.

## Gap G — every auto-created episode rule was dead

`createSingleRule` wrote the two episode rule types with **no severity id**, while
the matching count query filters on a concrete one. NULL never matched. Worse,
both episode pages scope their table by severity, so those rows were **invisible**
to the user who owned them — unmatchable *and* unfixable. They are severity-scoped
now, and a data migration fans out existing NULL rows and removes the originals.

## Deliberate silence is now expressible

An opt-out row (`ruleType` + severity + `isOptOut`, no method) means "do not page
me here". That is the precondition for treating the remaining zero-row cases as
misconfiguration rather than intent.

The exclusion predicate is `notInOrNull`, **not** a plain `false`. `isOptOut` is
nullable and every rule predating the column has it NULL, so `isOptOut: false`
would have matched nothing and quietly excluded every existing rule in every
project from paging — a total outage in the name of fixing a narrow bug.

## Two decisions worth challenging in review

**Both failure endings are terminal `Error`.** Leaving the log `Executing` for
"the next tick" buys no retry — nothing re-enters this hook — and would let
`ExecutePendingExecutions` find no due rules, close the log `Completed`, and
report **"Alert Sent"** for a page nobody received.

**`UserOnCallLogTimeline.userNotificationRuleId` becomes nullable.** A fallback
delivery has no stored rule behind it. The alternative — persisting synthetic
rules to satisfy a foreign key — would write configuration the user never asked
for, render it in their settings UI, and need garbage collecting.

## Verification

- **1,059 tests across 13 suites**, all passing
- `eslint` clean; `tsc` clean (3 pre-existing errors are missing optional DB driver typings)
- Migration SQL and the fallback's exact insert shape **executed against the live dev Postgres** in a rolled-back transaction — `INSERT 0 1` with a NULL rule id. FK constraints were dropped inside that transaction, so it proves NOT NULL semantics, not referential integrity.

Notable tests: a **table-driven channel × event-type matrix** that would have
caught Gap F; an idempotence test for the backfill (duplicate rules mean
duplicate pages); and a regression guard proving delivery works from an unsaved,
id-less rule.

## Known, pre-existing, not fixed here

Four sibling columns on `UserOnCallLogTimeline`
(`onCallDutyPolicyId`, `…EscalationRuleId`, `…ExecutionLogId`,
`…ExecutionLogTimelineId`) are NOT NULL while `buildLogTimelineItem` assigns them
conditionally. Safe in practice — every path reaching it comes from an escalation
that sets them — but it is the same latent shape as Gap C's blocker.
