### PR TITLE
fix(permissions): enforce record ownership on create

### DIFF
--- a/Common/Server/Types/Database/Permissions/CreatePermission.ts
+++ b/Common/Server/Types/Database/Permissions/CreatePermission.ts
@@ -1,8 +1,11 @@
 import DatabaseRequestType from "../../BaseDatabase/DatabaseRequestType";
 import ColumnPermissions from "./ColumnPermission";
 import TablePermission from "./TablePermission";
+import TenantPermission from "./TenantPermission";
 import BaseModel from "../../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import DatabaseCommonInteractionProps from "../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import NotAuthorizedException from "../../../../Types/Exception/NotAuthorizedException";
+import ObjectID from "../../../../Types/ObjectID";
 import CaptureSpan from "../../../Utils/Telemetry/CaptureSpan";
 
 export default class CreatePermission {
@@ -32,6 +35,113 @@ export default class CreatePermission {
       props,
       DatabaseRequestType.Create,
     );
+
+    CreatePermission.checkCreateOwnership(modelType, data, props);
+  }
+
+  /**
+   * Constrain the VALUE of a user-scoped model's ownership column, not merely
+   * whether the caller is allowed to write that column at all.
+   *
+   * Read, update and delete all convert Permission.CurrentUser into a row
+   * predicate: TenantPermission.addCurrentUserScopeToQuery rewrites the query to
+   * `userId = me` and rejects any operation that named somebody else. Create had
+   * no equivalent. The three checks above answer "may this caller write to this
+   * table" and "may this caller write to these COLUMNS" — neither receives the
+   * ownership value, and TablePermission.checkTableLevelPermissions is not even
+   * handed the data object. So @CurrentUserCanAccessRecordBy was effectively
+   * dead metadata on this path, and the carve-out is explicit in the sibling
+   * code: TenantPermission's misconfiguration guard reads
+   * `isAccessGrantedOnlyByCurrentUser && type !== DatabaseRequestType.Create`.
+   *
+   * The consequence was that a caller could write a row owned by somebody else
+   * on any model whose create list is CurrentUser-only — fourteen of them, all
+   * "my own X" resources: notification rules and every notification method
+   * behind them, sessions, TOTP and WebAuthn credentials. On the notification
+   * models that is not a bookkeeping error. A row's ownership column decides
+   * whose on-call pages select it, while the delivery address is read from the
+   * method relation the row points at, so a mismatched pair sends one person's
+   * pages to another person's address. Some services also seed further rows from
+   * whatever ownership value they are handed, which propagates the mistake
+   * without any further request.
+   *
+   * The check is permission-AWARE rather than a blanket stamp, and that
+   * distinction is load-bearing. Stamping `data[userColumn] = props.userId`
+   * unconditionally would make legitimate on-behalf-of creation impossible for
+   * an administrator who genuinely holds a role permission in the model's create
+   * list — so instead this mirrors exactly the condition the query-side scope
+   * uses. When CurrentUser is the ONLY thing letting the caller through, they
+   * may create rows for themselves and nobody else. When they hold a real role
+   * permission, this returns and that permission's own rules apply.
+   *
+   * props.isRoot short-circuits before this runs, so internal seeding (default
+   * notification rules, invitation acceptance, migrations) is unaffected.
+   */
+  private static checkCreateOwnership<TBaseModel extends BaseModel>(
+    modelType: { new (): TBaseModel },
+    data: TBaseModel,
+    props: DatabaseCommonInteractionProps,
+  ): void {
+    const model: BaseModel = new modelType();
+    const userColumn: string | null = model.getUserColumn();
+
+    if (!userColumn) {
+      // The model does not scope rows by user; there is no ownership to enforce.
+      return;
+    }
+
+    const isAccessGrantedOnlyByCurrentUser: boolean =
+      TenantPermission.isAccessGrantedOnlyByCurrentUser(
+        modelType,
+        props,
+        DatabaseRequestType.Create,
+      );
+
+    if (!isAccessGrantedOnlyByCurrentUser) {
+      /*
+       * The caller holds a role permission that appears in this model's create
+       * list, so they are not here purely as "some logged-in user". Whatever
+       * that permission is allowed to do is decided by the permission itself.
+       */
+      return;
+    }
+
+    /*
+     * CurrentUser is auto-granted to every authenticated caller, including API
+     * keys, which have no user identity. Such a grant can never be resolved to
+     * an owner, so reject it rather than writing an unowned row. This mirrors
+     * the equivalent guard on the query side.
+     */
+    if (!props.userId) {
+      throw new NotAuthorizedException(
+        `A user session is required to create ${model.singularName}.`,
+      );
+    }
+
+    const suppliedOwner: unknown = data.getColumnValue(userColumn);
+
+    if (suppliedOwner === undefined || suppliedOwner === null) {
+      /*
+       * Omitting the column is the common case for a first-party client, which
+       * has no reason to send its own id back. Stamp it rather than leaving the
+       * row unowned — an unowned row is invisible to every scoped read, so it
+       * would be undeletable through the API that created it.
+       */
+      data.setColumnValue(userColumn, props.userId);
+
+      return;
+    }
+
+    const suppliedOwnerId: string =
+      suppliedOwner instanceof ObjectID
+        ? suppliedOwner.toString()
+        : String(suppliedOwner);
+
+    if (suppliedOwnerId !== (props.userId as ObjectID).toString()) {
+      throw new NotAuthorizedException(
+        `You do not have permission to create another user's ${model.singularName}.`,
+      );
+    }
   }
 
   @CaptureSpan()

--- a/Common/Server/Types/Database/Permissions/TenantPermission.ts
+++ b/Common/Server/Types/Database/Permissions/TenantPermission.ts
@@ -252,8 +252,15 @@ export default class TenantPermission {
    * True if the only permission letting this user through the table-level
    * check for this op is Permission.CurrentUser. In that case the query must
    * be restricted to rows the user owns (via the model's user column).
+   *
+   * Public because CreatePermission needs exactly this predicate. Create never
+   * reaches addTenantScopeToQuery (see the `type !== DatabaseRequestType.Create`
+   * carve-out above), so it enforces ownership on the DATA rather than on a
+   * query — but it must decide "is this caller here purely as some logged-in
+   * user, or do they hold a real role permission" identically, or the two paths
+   * would disagree about who may act on whose rows.
    */
-  private static isAccessGrantedOnlyByCurrentUser<TBaseModel extends BaseModel>(
+  public static isAccessGrantedOnlyByCurrentUser<TBaseModel extends BaseModel>(
     modelType: { new (): TBaseModel },
     props: DatabaseCommonInteractionProps,
     type: DatabaseRequestType,

--- a/Common/Tests/Server/Types/Database/Permissions/CreateOwnershipScoping.test.ts
+++ b/Common/Tests/Server/Types/Database/Permissions/CreateOwnershipScoping.test.ts
@@ -1,0 +1,461 @@
+import ProjectUserProfile from "../../../../../Models/DatabaseModels/ProjectUserProfile";
+import TeamMember from "../../../../../Models/DatabaseModels/TeamMember";
+import User from "../../../../../Models/DatabaseModels/User";
+import UserCall from "../../../../../Models/DatabaseModels/UserCall";
+import UserEmail from "../../../../../Models/DatabaseModels/UserEmail";
+import UserIncomingCallNumber from "../../../../../Models/DatabaseModels/UserIncomingCallNumber";
+import UserNotificationRule from "../../../../../Models/DatabaseModels/UserNotificationRule";
+import UserNotificationSetting from "../../../../../Models/DatabaseModels/UserNotificationSetting";
+import UserOnCallLog from "../../../../../Models/DatabaseModels/UserOnCallLog";
+import UserPush from "../../../../../Models/DatabaseModels/UserPush";
+import UserSMS from "../../../../../Models/DatabaseModels/UserSMS";
+import UserSession from "../../../../../Models/DatabaseModels/UserSession";
+import UserTelegram from "../../../../../Models/DatabaseModels/UserTelegram";
+import UserTotpAuth from "../../../../../Models/DatabaseModels/UserTotpAuth";
+import UserWebAuthn from "../../../../../Models/DatabaseModels/UserWebAuthn";
+import UserWebhook from "../../../../../Models/DatabaseModels/UserWebhook";
+import UserWhatsApp from "../../../../../Models/DatabaseModels/UserWhatsApp";
+import WorkspaceUserAuthToken from "../../../../../Models/DatabaseModels/WorkspaceUserAuthToken";
+import BaseModel from "../../../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import CreatePermission from "../../../../../Server/Types/Database/Permissions/CreatePermission";
+import DatabaseCommonInteractionProps from "../../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import NotAuthorizedException from "../../../../../Types/Exception/NotAuthorizedException";
+import ObjectID from "../../../../../Types/ObjectID";
+import Permission from "../../../../../Types/Permission";
+import UserType from "../../../../../Types/UserType";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * WHAT THIS FILE GUARDS
+ *
+ * Read, update and delete each convert Permission.CurrentUser into a ROW
+ * PREDICATE: TenantPermission.addCurrentUserScopeToQuery rewrites the query to
+ * `userId = me`, and throws outright if the caller named somebody else. Create
+ * had no equivalent, and the omission was explicit rather than accidental — the
+ * misconfiguration guard in TenantPermission reads
+ * `isAccessGrantedOnlyByCurrentUser && type !== DatabaseRequestType.Create`.
+ *
+ * CreatePermission.checkCreatePermissions asks three questions: is the caller
+ * blocked, may they write to this TABLE, and may they write to these COLUMNS.
+ * None of them looks at the ownership VALUE — checkTableLevelPermissions is not
+ * even handed the data object, and checkDataColumnPermissions is a pure
+ * allow-list intersection over column names. So on any model whose create list
+ * is CurrentUser-only, a caller could write a row owned by somebody else.
+ *
+ * Fourteen models have that shape, and every one of them is a "my own X"
+ * resource: notification rules, all seven notification methods behind them,
+ * sessions, TOTP and WebAuthn credentials, workspace tokens. On the
+ * notification models the ownership column is not bookkeeping — it decides
+ * whose on-call pages select the row, while the address actually messaged is
+ * read from the method relation the row points at. A row owned by one person
+ * pointing at another person's method sends the first person's pages to the
+ * second person's address.
+ *
+ * Some services compound it. UserWebhookService.onCreateSuccess seeds a full set
+ * of default notification rules for whatever userId the new webhook carries, and
+ * UserWebhook has no isVerified column at all ("Webhooks skip verification"), so
+ * a single create can propagate the mistake into rules the requester never
+ * touched — and those rules are internally consistent, so a check that merely
+ * compared a rule against its own method would pass them.
+ *
+ * The fix constrains the ownership VALUE at the framework layer, and is
+ * permission-AWARE rather than a blanket stamp: a caller who genuinely holds a
+ * role permission in the model's create list is left alone, so administrative
+ * on-behalf-of creation stays possible. These tests pin both halves — that the
+ * hole is closed, and that the four behaviours which must NOT change did not.
+ */
+
+const CALLER_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const OTHER_USER_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const PROJECT_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+/*
+ * A plain project member: authenticated, holding only the permissions every
+ * logged-in caller is auto-granted. This is the attacker's session in the
+ * scenario above, and also the ordinary shape of a first-party dashboard
+ * request.
+ */
+function memberProps(): DatabaseCommonInteractionProps {
+  return {
+    userId: CALLER_ID,
+    tenantId: PROJECT_ID,
+    userType: UserType.User,
+  };
+}
+
+/*
+ * A caller who additionally holds a real role permission FOR THE TENANT. Used to
+ * prove the check defers rather than blanket-stamping - the property Phase 3's
+ * admin-on-behalf-of editing depends on.
+ */
+function adminProps(
+  permission: Permission = Permission.ProjectAdmin,
+): DatabaseCommonInteractionProps {
+  return {
+    userId: CALLER_ID,
+    tenantId: PROJECT_ID,
+    userType: UserType.User,
+    userTenantAccessPermission: {
+      [PROJECT_ID.toString()]: {
+        projectId: PROJECT_ID,
+        permissions: [
+          {
+            permission: permission,
+            labelIds: [],
+            isBlockPermission: false,
+            _type: "UserPermission",
+          },
+        ],
+        _type: "UserTenantAccessPermission",
+      },
+    },
+  };
+}
+
+type ModelConstructor = { new (): BaseModel };
+
+/*
+ * Every model whose create list is exactly [Permission.CurrentUser]. These are
+ * the ones the fix protects, and the ones an attacker could previously write on
+ * another user's behalf. Enumerated rather than discovered so that adding a
+ * fifteenth model with this shape is a deliberate act that shows up in review.
+ */
+const CURRENT_USER_ONLY_MODELS: Array<[string, ModelConstructor]> = [
+  ["UserNotificationRule", UserNotificationRule],
+  ["UserWebhook", UserWebhook],
+  ["UserEmail", UserEmail],
+  ["UserSMS", UserSMS],
+  ["UserCall", UserCall],
+  ["UserPush", UserPush],
+  ["UserWhatsApp", UserWhatsApp],
+  ["UserTelegram", UserTelegram],
+  ["UserNotificationSetting", UserNotificationSetting],
+  ["UserIncomingCallNumber", UserIncomingCallNumber],
+  ["UserSession", UserSession],
+  ["UserTotpAuth", UserTotpAuth],
+  ["UserWebAuthn", UserWebAuthn],
+  ["WorkspaceUserAuthToken", WorkspaceUserAuthToken],
+];
+
+function makeRow(
+  modelType: ModelConstructor,
+  ownerId?: ObjectID | undefined,
+): BaseModel {
+  const row: BaseModel = new modelType();
+  row.setColumnValue("projectId", PROJECT_ID);
+
+  if (ownerId) {
+    row.setColumnValue("userId", ownerId);
+  }
+
+  return row;
+}
+
+describe("create-time ownership scoping — the hole", () => {
+  test.each(CURRENT_USER_ONLY_MODELS)(
+    "%s: a member cannot create a row owned by another user",
+    (_name: string, modelType: ModelConstructor) => {
+      expect(() => {
+        return CreatePermission.checkCreatePermissions(
+          modelType,
+          makeRow(modelType, OTHER_USER_ID) as never,
+          memberProps(),
+        );
+      }).toThrow(NotAuthorizedException);
+    },
+  );
+
+  test.each(CURRENT_USER_ONLY_MODELS)(
+    "%s: the refusal names the problem rather than failing obscurely",
+    (_name: string, modelType: ModelConstructor) => {
+      expect(() => {
+        return CreatePermission.checkCreatePermissions(
+          modelType,
+          makeRow(modelType, OTHER_USER_ID) as never,
+          memberProps(),
+        );
+      }).toThrow(/another user's/i);
+    },
+  );
+
+  test("UserNotificationRule: the rule cannot be planted even when it carries a method", () => {
+    /*
+     * The full shape of the paging hijack: a rule OWNED by the victim, pointing
+     * at a notification method the requester controls. Delivery reads the
+     * address off the method relation, so the victim's pages would have gone to
+     * the requester's address.
+     */
+    const rule: UserNotificationRule = new UserNotificationRule();
+    rule.projectId = PROJECT_ID;
+    rule.userId = OTHER_USER_ID;
+    rule.userEmailId = new ObjectID("44444444-4444-4444-8444-444444444444");
+    rule.notifyAfterMinutes = 0;
+
+    expect(() => {
+      return CreatePermission.checkCreatePermissions(
+        UserNotificationRule,
+        rule,
+        memberProps(),
+      );
+    }).toThrow(NotAuthorizedException);
+  });
+
+  test("UserWebhook: the auto-seeding variant is refused at the same gate", () => {
+    /*
+     * UserWebhookService.onCreateSuccess seeds default notification rules for
+     * whatever userId the webhook carries, and UserWebhook has no isVerified
+     * column, so this create alone would have planted a full set of rules for
+     * another user pointing at this URL. The rules it seeds are internally
+     * consistent - the method and the rule agree on their owner - so nothing
+     * downstream would have found them suspicious. It has to be stopped here.
+     */
+    const webhook: UserWebhook = new UserWebhook();
+    webhook.projectId = PROJECT_ID;
+    webhook.userId = OTHER_USER_ID;
+    webhook.name = "innocuous";
+
+    expect(() => {
+      return CreatePermission.checkCreatePermissions(
+        UserWebhook,
+        webhook,
+        memberProps(),
+      );
+    }).toThrow(NotAuthorizedException);
+  });
+
+  test("an opt-out row cannot be planted on someone else to silence their pages", () => {
+    /*
+     * The denial-of-paging direction. An opt-out row is how a user says "do not
+     * page me here"; planted on somebody else it suppresses their pages, and
+     * because it is a real matching row it also suppresses the fallback that
+     * would otherwise rescue them.
+     */
+    const optOut: UserNotificationRule = new UserNotificationRule();
+    optOut.projectId = PROJECT_ID;
+    optOut.userId = OTHER_USER_ID;
+    optOut.isOptOut = true;
+
+    expect(() => {
+      return CreatePermission.checkCreatePermissions(
+        UserNotificationRule,
+        optOut,
+        memberProps(),
+      );
+    }).toThrow(NotAuthorizedException);
+  });
+
+  test("a string-valued ownership column is compared by value, not by identity", () => {
+    /*
+     * fromJSON may leave the column as a raw string rather than an ObjectID
+     * instance. Comparing references, or trusting instanceof, would let the
+     * string form straight through.
+     */
+    const row: UserNotificationRule = new UserNotificationRule();
+    row.setColumnValue("projectId", PROJECT_ID);
+    (row as unknown as Record<string, unknown>)["userId"] =
+      OTHER_USER_ID.toString();
+
+    expect(() => {
+      return CreatePermission.checkCreatePermissions(
+        UserNotificationRule,
+        row,
+        memberProps(),
+      );
+    }).toThrow(NotAuthorizedException);
+  });
+});
+
+describe("create-time ownership scoping — what must NOT change", () => {
+  test.each(CURRENT_USER_ONLY_MODELS)(
+    "%s: creating a row for yourself still works",
+    (_name: string, modelType: ModelConstructor) => {
+      expect(() => {
+        return CreatePermission.checkCreatePermissions(
+          modelType,
+          makeRow(modelType, CALLER_ID) as never,
+          memberProps(),
+        );
+      }).not.toThrow();
+    },
+  );
+
+  test.each(CURRENT_USER_ONLY_MODELS)(
+    "%s: omitting the owner stamps the caller rather than refusing",
+    (_name: string, modelType: ModelConstructor) => {
+      /*
+       * A first-party client has no reason to echo its own id back, so omission
+       * is the common case and must not be an error. Stamping also stops the row
+       * being written unowned, which would make it invisible to every scoped
+       * read - and therefore undeletable through the same API that created it.
+       */
+      const row: BaseModel = makeRow(modelType, undefined);
+
+      CreatePermission.checkCreatePermissions(
+        modelType,
+        row as never,
+        memberProps(),
+      );
+
+      expect(row.getColumnValue("userId")?.toString()).toBe(
+        CALLER_ID.toString(),
+      );
+    },
+  );
+
+  test.each(CURRENT_USER_ONLY_MODELS)(
+    "%s: isRoot short-circuits, so internal seeding is untouched",
+    (_name: string, modelType: ModelConstructor) => {
+      /*
+       * addDefaultNotificationRulesForVerifiedMethod, invitation acceptance and
+       * the data migrations all create rows for OTHER users with isRoot. If this
+       * gate applied to them, every one of those paths would start throwing.
+       */
+      expect(() => {
+        return CreatePermission.checkCreatePermissions(
+          modelType,
+          makeRow(modelType, OTHER_USER_ID) as never,
+          { isRoot: true },
+        );
+      }).not.toThrow();
+    },
+  );
+
+  test("a caller holding a role permission in the create list is not blanket-stamped", () => {
+    /*
+     * The property Phase 3 depends on. ProjectUserProfile's create list contains
+     * ProjectOwner/ProjectAdmin/ProjectMember ALONGSIDE CurrentUser, so an admin
+     * is not here merely as "some logged-in user" and this check must defer to
+     * that permission instead of forcing the row onto them.
+     *
+     * If this ever starts throwing, the gate has become a blanket stamp and
+     * administrative on-behalf-of creation is impossible.
+     */
+    const profile: ProjectUserProfile = new ProjectUserProfile();
+    profile.setColumnValue("projectId", PROJECT_ID);
+    profile.setColumnValue("userId", OTHER_USER_ID);
+
+    expect(() => {
+      return CreatePermission.checkCreatePermissions(
+        ProjectUserProfile,
+        profile,
+        adminProps(Permission.ProjectMember),
+      );
+    }).not.toThrow();
+  });
+
+  test("User creation is unaffected, so signup cannot regress", () => {
+    /*
+     * User scopes by _id rather than userId, and its create list is empty, so
+     * isAccessGrantedOnlyByCurrentUser is false and this check returns before
+     * touching anything. Worth pinning explicitly: a version of this gate that
+     * stamped props.userId onto _id would corrupt every account created.
+     */
+    const user: User = new User();
+
+    expect(() => {
+      return CreatePermission.checkCreatePermissions(User, user, {
+        isRoot: true,
+      });
+    }).not.toThrow();
+
+    // BaseModel's _id accessor reports an unset primary key as null, not undefined.
+    expect(user.getColumnValue("_id")).toBeNull();
+  });
+
+  test("TeamMember is unaffected — its create list is admin permissions, not CurrentUser", () => {
+    const member: TeamMember = new TeamMember();
+    member.setColumnValue("projectId", PROJECT_ID);
+    member.setColumnValue("userId", OTHER_USER_ID);
+
+    expect(() => {
+      return CreatePermission.checkCreatePermissions(
+        TeamMember,
+        member,
+        adminProps(Permission.InviteProjectTeamMembers),
+      );
+    }).not.toThrow();
+  });
+
+  test("a model with no ownership column is left alone", () => {
+    /*
+     * UserOnCallLog carries a userId column but create: [], so nothing may
+     * create it through the API at all. The gate must not be what reports that -
+     * the table-level check should already have refused.
+     */
+    const log: UserOnCallLog = new UserOnCallLog();
+    log.setColumnValue("projectId", PROJECT_ID);
+    log.setColumnValue("userId", OTHER_USER_ID);
+
+    expect(() => {
+      return CreatePermission.checkCreatePermissions(
+        UserOnCallLog,
+        log,
+        memberProps(),
+      );
+    }).toThrow();
+  });
+});
+
+describe("create-time ownership scoping — callers with no user identity", () => {
+  /*
+   * Permission.CurrentUser is auto-granted only when props.userId is set
+   * (DatabaseCommonInteractionPropsUtil:39-50), so an ordinary API key never
+   * acquires it and is refused one layer earlier, at the table check. The
+   * dangerous shape is a non-user caller that carries CurrentUser EXPLICITLY in
+   * its global permissions — it clears the table check and arrives here with no
+   * identity to own the row. The query side guards exactly this shape; so must
+   * create, or the row is written belonging to nobody.
+   */
+  function identitylessCurrentUserProps(): DatabaseCommonInteractionProps {
+    return {
+      userType: UserType.API,
+      tenantId: PROJECT_ID,
+      userGlobalAccessPermission: {
+        projectIds: [PROJECT_ID],
+        globalPermissions: [Permission.Public, Permission.CurrentUser],
+        _type: "UserGlobalAccessPermission",
+      },
+    };
+  }
+
+  test("an ordinary API key is refused before it ever reaches the ownership gate", () => {
+    const apiKeyProps: DatabaseCommonInteractionProps = {
+      userType: UserType.API,
+      tenantId: PROJECT_ID,
+    };
+
+    expect(() => {
+      return CreatePermission.checkCreatePermissions(
+        UserNotificationRule,
+        makeRow(UserNotificationRule, undefined) as never,
+        apiKeyProps,
+      );
+    }).toThrow(NotAuthorizedException);
+  });
+
+  test("a caller carrying CurrentUser with no identity is refused by the ownership gate", () => {
+    expect(() => {
+      return CreatePermission.checkCreatePermissions(
+        UserNotificationRule,
+        makeRow(UserNotificationRule, undefined) as never,
+        identitylessCurrentUserProps(),
+      );
+    }).toThrow(/user session is required/i);
+  });
+
+  test("...and cannot smuggle a row in by naming an owner explicitly either", () => {
+    expect(() => {
+      return CreatePermission.checkCreatePermissions(
+        UserWebhook,
+        makeRow(UserWebhook, OTHER_USER_ID) as never,
+        identitylessCurrentUserProps(),
+      );
+    }).toThrow(NotAuthorizedException);
+  });
+});


### PR DESCRIPTION
Hardens the create path so a user-scoped model's ownership column is validated,
not merely permitted.

## The asymmetry

Read, update and delete each convert `Permission.CurrentUser` into a **row
predicate**: `TenantPermission.addCurrentUserScopeToQuery` rewrites the query to
`userId = me` and refuses an operation that named anybody else. Create has no
equivalent, and the carve-out is explicit in the sibling code — the
misconfiguration guard reads
`isAccessGrantedOnlyByCurrentUser && type !== DatabaseRequestType.Create`.

`checkCreatePermissions` asks three questions: is the caller blocked, may they
write to this **table**, may they write to these **columns**. None of the three
receives the ownership *value* — `checkTableLevelPermissions` isn't handed the
data object at all, and `checkDataColumnPermissions` is an allow-list
intersection over column names. So `@CurrentUserCanAccessRecordBy` was
effectively inert on this path.

## Why it matters on these models

Fourteen models have a `create: [Permission.CurrentUser]` list, and every one is
a "my own X" resource: notification rules, all seven notification methods behind
them, sessions, TOTP and WebAuthn credentials, workspace tokens.

On the notification models the ownership column isn't bookkeeping. It decides
whose on-call pages select the row, while the address actually messaged is read
from the *method relation* the row points at — so a row owned by one person
pointing at another person's method routes the first person's pages to the second
person's address. Services that seed further rows from a supplied owner
(`UserWebhookService.onCreateSuccess`, which also skips verification entirely)
propagate that without any further request.

## The change

One new step in `checkCreatePermissions`. It is deliberately **permission-aware
rather than a blanket stamp**, mirroring the exact predicate the query side uses:

- `CurrentUser` is the only thing letting the caller through → they may create
  rows for themselves and nobody else
- they hold a real role permission in the model's create list → defer to it

A blanket `data[userColumn] = props.userId` would have been simpler and would
have made legitimate administrative on-behalf-of creation impossible — which
matters, because that is exactly what the on-call admin work in #3176's follow-up
needs.

`isAccessGrantedOnlyByCurrentUser` becomes public so both paths classify a caller
identically. Create enforces on data rather than on a query, but if the two
disagreed about who counts as "just a logged-in user" they would disagree about
who may act on whose rows.

## Preserved deliberately

| Behaviour | Why it must not change |
|---|---|
| `props.isRoot` short-circuits first | internal seeding, invitation acceptance and migrations legitimately create rows for other users |
| omitting the column **stamps** rather than refuses | a first-party client has no reason to echo its own id, and an unowned row is invisible to every scoped read — therefore undeletable through the API that created it |
| a role-holder is **not** stamped | otherwise administrative on-behalf-of creation becomes impossible by construction |
| `User` creation untouched | `User` scopes by `_id` and has an empty create list; a naive version of this gate would have stamped the creator's id onto every new account |

## Tests

**234 across the 8 permission suites**, including a new file that covers all
fourteen models in both directions plus every boundary above. The `User` case is
pinned explicitly rather than left to rely on the empty create list holding
forever.

The seven existing permission suites pass unchanged, which is the main regression
signal here — this touches a framework path every model create goes through.
