### PR TITLE
fix(security): block private IPv4 transition endpoints

### DIFF
--- a/Common/Server/Utils/SSRFProtection.ts
+++ b/Common/Server/Utils/SSRFProtection.ts
@@ -345,9 +345,9 @@ export default class SSRFProtection {
    * True when an IPv6 literal points somewhere the server must never be made
    * to reach. Ranges, not spellings: loopback, unspecified, link-local
    * (fe80::/10), unique-local (fc00::/7) and multicast (ff00::/8), plus the
-   * three ways IPv6 can carry an IPv4 destination - IPv4-mapped
-   * (::ffff:0:0/96), IPv4-compatible (::/96) and the NAT64 well-known prefix
-   * (64:ff9b::/96) - which are handed to the IPv4 blocklist.
+   * ways IPv6 can embed IPv4 routing endpoints - IPv4-mapped (::ffff:0:0/96),
+   * IPv4-compatible (::/96), NAT64 (64:ff9b::/96), 6to4 (2002::/16), and
+   * Teredo (2001:0000::/32) - which are handed to the IPv4 blocklist.
    */
   private static isBlockedIpv6(address: string): boolean {
     const groups: Array<number> | null = SSRFProtection.expandIpv6(address);
@@ -365,9 +365,19 @@ export default class SSRFProtection {
       });
     };
 
-    const embeddedIpv4: () => string = (): string => {
-      const high: number = groups[6] as number;
-      const low: number = groups[7] as number;
+    const embeddedIpv4: (highGroupIndex: number, invert?: boolean) => string = (
+      highGroupIndex: number,
+      invert: boolean = false,
+    ): string => {
+      let high: number = groups[highGroupIndex] as number;
+      let low: number = groups[highGroupIndex + 1] as number;
+
+      // Teredo conceals the client IPv4 address by flipping all 32 bits.
+      if (invert) {
+        high ^= 0xffff;
+        low ^= 0xffff;
+      }
+
       return `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
     };
 
@@ -383,7 +393,7 @@ export default class SSRFProtection {
 
     // ::ffff:0:0/96 — IPv4-mapped.
     if (isZeroThrough(5) && groups[5] === 0xffff) {
-      return SSRFProtection.isBlockedIpv4(embeddedIpv4());
+      return SSRFProtection.isBlockedIpv4(embeddedIpv4(6));
     }
 
     // 64:ff9b::/96 — NAT64 well-known prefix.
@@ -395,12 +405,28 @@ export default class SSRFProtection {
       groups[4] === 0 &&
       groups[5] === 0
     ) {
-      return SSRFProtection.isBlockedIpv4(embeddedIpv4());
+      return SSRFProtection.isBlockedIpv4(embeddedIpv4(6));
     }
 
     // ::/96 — IPv4-compatible (deprecated, still routable by some stacks).
     if (isZeroThrough(6)) {
-      return SSRFProtection.isBlockedIpv4(embeddedIpv4());
+      return SSRFProtection.isBlockedIpv4(embeddedIpv4(6));
+    }
+
+    // 2002::/16 — 6to4 stores the IPv4 gateway in bits 16-48.
+    if (groups[0] === 0x2002) {
+      return SSRFProtection.isBlockedIpv4(embeddedIpv4(1));
+    }
+
+    /*
+     * 2001:0000::/32 — Teredo stores its server IPv4 in bits 32-64 and
+     * an inverted client IPv4 in the last 32 bits.
+     */
+    if (groups[0] === 0x2001 && groups[1] === 0) {
+      return (
+        SSRFProtection.isBlockedIpv4(embeddedIpv4(2)) ||
+        SSRFProtection.isBlockedIpv4(embeddedIpv4(6, true))
+      );
     }
 
     const first: number = groups[0] as number;

--- a/Common/Tests/Server/Utils/SSRFProtectionBypasses.test.ts
+++ b/Common/Tests/Server/Utils/SSRFProtectionBypasses.test.ts
@@ -64,6 +64,25 @@ describe("SSRFProtection — IPv4-mapped and IPv4-embedding IPv6", () => {
     ["metadata, IPv4-compatible", "http://[::169.254.169.254]/"],
     ["metadata via NAT64 prefix", "http://[64:ff9b::169.254.169.254]/"],
     ["loopback via NAT64 prefix", "http://[64:ff9b::127.0.0.1]/"],
+    ["metadata via 6to4", "http://[2002:a9fe:a9fe::]/"],
+    ["loopback via 6to4", "http://[2002:7f00:0001::]/"],
+    ["RFC-1918 via 6to4", "http://[2002:0a00:0001::]/"],
+    [
+      "metadata via Teredo",
+      "http://[2001:0000:4136:e378:8000:63bf:5601:5601]/",
+    ],
+    [
+      "loopback via Teredo",
+      "http://[2001:0000:4136:e378:8000:63bf:80ff:fffe]/",
+    ],
+    [
+      "RFC-1918 via Teredo",
+      "http://[2001:0000:4136:e378:8000:63bf:f5ff:fffe]/",
+    ],
+    [
+      "loopback Teredo server with public client",
+      "http://[2001:0000:7f00:0001:8000:63bf:f7f7:f7f7]/",
+    ],
   ];
 
   test.each(blocked)("blocks %s", async (_label: string, url: string) => {
@@ -75,6 +94,11 @@ describe("SSRFProtection — IPv4-mapped and IPv4-embedding IPv6", () => {
   const allowed: Array<[string, string]> = [
     ["a public address, IPv4-mapped", "http://[::ffff:8.8.8.8]/"],
     ["a public address via NAT64", "http://[64:ff9b::8.8.8.8]/"],
+    ["a public address via 6to4", "http://[2002:0808:0808::]/"],
+    [
+      "a public address via Teredo",
+      "http://[2001:0000:4136:e378:8000:63bf:f7f7:f7f7]/",
+    ],
   ];
 
   test.each(allowed)("allows %s", async (_label: string, url: string) => {


### PR DESCRIPTION
Fixes the remaining IPv6 transition-address hardening gap reported in [GHSA-qhf2-x32h-c288](https://github.com/OneUptime/oneuptime/security/advisories/GHSA-qhf2-x32h-c288).

## Validation

The report is accurate against its cited commit (`ba64bea`, released as 12.0.5):

- IPv4-mapped IPv6 could bypass the webhook SSRF guard.
- Status-page subscriber webhooks sent to an unvalidated, publicly supplied URL.

Two earlier fixes already removed the directly exploitable paths:

- #3101 / 12.0.6 validates subscriber webhooks before storage and every send.
- #3118 / 12.0.7 canonicalizes IPv6 and blocks IPv4-mapped, IPv4-compatible, and NAT64 targets.

Current `master` still accepted 6to4 and Teredo literals carrying private, loopback, link-local, or metadata-range IPv4 endpoints because they are valid IPv6 literals, skip DNS resolution, and fell through the IPv6 blocklist.

## Changes

- Extract the 6to4 gateway IPv4 field and apply the existing IPv4 blocklist.
- Extract both Teredo IPv4 fields—the server and the bitwise-obfuscated client—and apply the same blocklist.
- Preserve transition addresses whose embedded routing endpoints are public.
- Add regression coverage for metadata, loopback, RFC-1918, and public controls.

6to4 and Teredo tunnel IPv6 packets rather than directly translating an HTTP request to the embedded IPv4 service, so the residual reachability is environment-dependent. Blocking internal embedded endpoints is still the safe SSRF policy and avoids relying on every host/tunnel implementation to enforce the relevant RFC checks.

## Impact

Webhook and workflow targets can no longer use 6to4 or Teredo encodings to carry internal IPv4 routing endpoints. Legitimate transition addresses with public embedded endpoints remain allowed.

## Checks

- `Common` TypeScript compilation
- Focused SSRF regression suite: 115/115 tests passed
- ESLint on both changed files with the repository heap setting
- Clean diff and clean worktree
- Local ingress smoke test returned the expected HTTP redirect after hot reload

## Advisory publication

Please publish the advisory only after the first release containing this commit is available, then record that release as the patched version. The advisory currently has no structured affected-version entry, CWE, CVSS vector, or CVE. CWE-918 applies.