### PR TITLE
Fix Kubernetes resources being classified as inventory hosts

### DIFF
--- a/Common/Server/Utils/Telemetry/TelemetryEntity.ts
+++ b/Common/Server/Utils/Telemetry/TelemetryEntity.ts
@@ -398,6 +398,17 @@ export default class InventoryItem {
    * cluster/namespace identity so e.g. the "default" namespace in two
    * clusters does not collide.
    */
+  private static readonly kubernetesIdentityAttributeKeys: ReadonlyArray<string> =
+    [
+      "k8s.cluster.name",
+      "k8s.namespace.name",
+      "k8s.node.name",
+      "k8s.node.uid",
+      "k8s.pod.name",
+      "k8s.pod.uid",
+      "k8s.deployment.name",
+    ];
+
   private static readonly resolvers: Array<
     (
       attrs: EntityAttributes,
@@ -441,13 +452,19 @@ export default class InventoryItem {
      * here on host.id would make the host entity key unmatchable on the read
      * side (`InventoryItem.keyForHost(hostIdentifier)`). Moving host
      * identity to host.id is a separate, deferred hardening that would
-     * migrate the MV and this identity together. A k8s node (which carries
-     * k8s.node.name, not host.name, and is rejected by autoDiscoverHost) is
-     * cataloged via the dedicated `k8s.node` entity, not as a host.
+     * migrate the MV and this identity together.
+     *
+     * Application SDKs running inside Kubernetes commonly auto-detect the
+     * pod hostname and publish it as `host.name`. That value does not identify
+     * a machine: the same resource's k8s.* identity identifies the pod, node,
+     * namespace, deployment and cluster that Inventory should catalog. Match
+     * autoDiscoverHost's phantom-host gate by refusing the heuristic Host
+     * whenever a supported Kubernetes identity is present. Explicit OTLP
+     * entity_refs remain authoritative because they bypass these resolvers.
      */
     (attrs: EntityAttributes) => {
       const hostName: string | null = InventoryItem.str(attrs, "host.name");
-      if (!hostName) {
+      if (!hostName || InventoryItem.hasKubernetesIdentity(attrs)) {
         return null;
       }
       return { entityType: EntityType.Host, id: { "host.name": hostName } };
@@ -793,6 +810,19 @@ export default class InventoryItem {
     }
     return value.filter((item: unknown): item is string => {
       return typeof item === "string" && item.trim().length > 0;
+    });
+  }
+
+  /**
+   * Whether this resource carries an identity that a Kubernetes resolver can
+   * attach to a typed Inventory item. Pod and node UIDs count because their
+   * resolvers accept UID-only identity. Cluster UID deliberately does not:
+   * OneUptime's cluster identity is name-keyed, so UID alone cannot produce a
+   * KubernetesCluster item and must not hide an otherwise valid Host.
+   */
+  private static hasKubernetesIdentity(attrs: EntityAttributes): boolean {
+    return this.kubernetesIdentityAttributeKeys.some((key: string): boolean => {
+      return this.str(attrs, key) !== null;
     });
   }
 

--- a/Common/Tests/Server/Services/MetricEntityMVKeyParity.test.ts
+++ b/Common/Tests/Server/Services/MetricEntityMVKeyParity.test.ts
@@ -30,14 +30,19 @@ describe("entity-MV routing keys — parity with ingest-stamped scalar entity ke
   const projectId: string = "proj-123";
 
   /*
-   * A resource carrying all four routable identities at once, with
-   * casing/whitespace drift to exercise canonicalization.
+   * Keep standalone-host and Kubernetes fixtures separate: Kubernetes
+   * resources can carry an SDK-detected host.name (often the pod hostname),
+   * but ingest deliberately does not stamp that as a Host entity.
    */
-  const attributes: Record<string, string> = {
+  const standaloneHostAttributes: Record<string, string> = {
     "host.name": "Web-Server-01 ",
-    "k8s.cluster.name": "Prod-EU-1",
     "container.id": "ABC123def456",
     "service.name": "Checkout",
+  };
+
+  const kubernetesAttributes: Record<string, string> = {
+    ...standaloneHostAttributes,
+    "k8s.cluster.name": "Prod-EU-1",
   };
 
   type FirstOfTypeFunction = (
@@ -61,15 +66,30 @@ describe("entity-MV routing keys — parity with ingest-stamped scalar entity ke
     );
   };
 
-  test("each routable read-side key byte-matches the stamped scalar column", () => {
+  test("standalone-host read-side keys byte-match the stamped scalar columns", () => {
     const entities: Array<ExtractedEntity> = InventoryItem.extractEntities({
       projectId,
-      attributes,
+      attributes: standaloneHostAttributes,
     });
 
     expect(firstOfType(entities, EntityType.Host)).toBe(
       keyForHost(projectId, "Web-Server-01 "),
     );
+    expect(firstOfType(entities, EntityType.Container)).toBe(
+      keyForContainer(projectId, "ABC123def456"),
+    );
+    expect(firstOfType(entities, EntityType.Service)).toBe(
+      keyForService(projectId, "Checkout"),
+    );
+  });
+
+  test("Kubernetes read-side keys byte-match while the phantom Host key stays absent", () => {
+    const entities: Array<ExtractedEntity> = InventoryItem.extractEntities({
+      projectId,
+      attributes: kubernetesAttributes,
+    });
+
+    expect(firstOfType(entities, EntityType.Host)).toBe("");
     expect(firstOfType(entities, EntityType.KubernetesCluster)).toBe(
       keyForKubernetesCluster(projectId, "Prod-EU-1"),
     );
@@ -82,26 +102,45 @@ describe("entity-MV routing keys — parity with ingest-stamped scalar entity ke
   });
 
   test("read-side keys canonicalize exactly like ingest (spelling drift lands on one rollup stream)", () => {
-    const drifted: Array<ExtractedEntity> = InventoryItem.extractEntities({
-      projectId,
-      attributes: {
-        "host.name": "web-server-01",
-        "k8s.cluster.name": " prod-eu-1 ",
-        "container.id": "abc123DEF456",
-        "service.name": "  checkout",
-      },
-    });
+    const driftedStandaloneHost: Array<ExtractedEntity> =
+      InventoryItem.extractEntities({
+        projectId,
+        attributes: {
+          "host.name": "web-server-01",
+          "container.id": "abc123DEF456",
+          "service.name": "  checkout",
+        },
+      });
 
-    expect(firstOfType(drifted, EntityType.Host)).toBe(
+    expect(firstOfType(driftedStandaloneHost, EntityType.Host)).toBe(
       keyForHost(projectId, "Web-Server-01 "),
     );
-    expect(firstOfType(drifted, EntityType.KubernetesCluster)).toBe(
-      keyForKubernetesCluster(projectId, "Prod-EU-1"),
-    );
-    expect(firstOfType(drifted, EntityType.Container)).toBe(
+    expect(firstOfType(driftedStandaloneHost, EntityType.Container)).toBe(
       keyForContainer(projectId, "ABC123def456"),
     );
-    expect(firstOfType(drifted, EntityType.Service)).toBe(
+    expect(firstOfType(driftedStandaloneHost, EntityType.Service)).toBe(
+      keyForService(projectId, "Checkout"),
+    );
+
+    const driftedKubernetes: Array<ExtractedEntity> =
+      InventoryItem.extractEntities({
+        projectId,
+        attributes: {
+          "host.name": "web-server-01",
+          "k8s.cluster.name": " prod-eu-1 ",
+          "container.id": "abc123DEF456",
+          "service.name": "  checkout",
+        },
+      });
+
+    expect(firstOfType(driftedKubernetes, EntityType.Host)).toBe("");
+    expect(
+      firstOfType(driftedKubernetes, EntityType.KubernetesCluster),
+    ).toBe(keyForKubernetesCluster(projectId, "Prod-EU-1"));
+    expect(firstOfType(driftedKubernetes, EntityType.Container)).toBe(
+      keyForContainer(projectId, "ABC123def456"),
+    );
+    expect(firstOfType(driftedKubernetes, EntityType.Service)).toBe(
       keyForService(projectId, "Checkout"),
     );
   });
@@ -155,19 +194,31 @@ describe("entity-MV routing keys — parity with ingest-stamped scalar entity ke
     );
   });
 
-  test("entityKeys membership (the entityScope raw predicate) contains every routable key", () => {
+  test("standalone-host entityKeys membership contains the Host key", () => {
     const membershipKeys: Array<string> = InventoryItem.extractEntityKeys({
       projectId,
-      attributes,
+      attributes: standaloneHostAttributes,
+    });
+
+    expect(membershipKeys).toContain(keyForHost(projectId, "Web-Server-01 "));
+  });
+
+  test("Kubernetes entityKeys membership contains typed keys and excludes the phantom Host key", () => {
+    const membershipKeys: Array<string> = InventoryItem.extractEntityKeys({
+      projectId,
+      attributes: kubernetesAttributes,
     });
 
     for (const key of [
-      keyForHost(projectId, "Web-Server-01 "),
       keyForKubernetesCluster(projectId, "Prod-EU-1"),
       keyForContainer(projectId, "ABC123def456"),
       keyForService(projectId, "Checkout"),
     ]) {
       expect(membershipKeys).toContain(key);
     }
+
+    expect(membershipKeys).not.toContain(
+      keyForHost(projectId, "Web-Server-01 "),
+    );
   });
 });

--- a/Common/Tests/Server/Utils/Telemetry/TelemetryEntity.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/TelemetryEntity.test.ts
@@ -191,6 +191,99 @@ describe("InventoryItem.extractEntities — per type", () => {
     expect(typesFor({ "host.id": "h-123" })).not.toContain(EntityType.Host);
   });
 
+  test("host: a standalone host identity still produces a host", () => {
+    expect(
+      typesFor({
+        "host.name": "web-1",
+        "os.type": "linux",
+      }),
+    ).toEqual([EntityType.Host]);
+  });
+
+  test.each([
+    ["pod name", "k8s.pod.name", "checkout-7d9f", EntityType.KubernetesPod],
+    ["pod uid", "k8s.pod.uid", "pod-uid-1", EntityType.KubernetesPod],
+    ["node name", "k8s.node.name", "worker-1", EntityType.KubernetesNode],
+    ["node uid", "k8s.node.uid", "node-uid-1", EntityType.KubernetesNode],
+    ["cluster", "k8s.cluster.name", "prod-us", EntityType.KubernetesCluster],
+    ["namespace", "k8s.namespace.name", "shop", EntityType.KubernetesNamespace],
+    [
+      "deployment",
+      "k8s.deployment.name",
+      "checkout",
+      EntityType.KubernetesDeployment,
+    ],
+  ] as Array<[string, string, string, EntityType]>)(
+    "host.name beside a k8s %s identity does not create a phantom host",
+    (
+      _label: string,
+      identityKey: string,
+      identityValue: string,
+      expectedType: EntityType,
+    ) => {
+      const types: Array<EntityType> = typesFor({
+        "host.name": "checkout-7d9f",
+        "os.type": "linux",
+        [identityKey]: identityValue,
+      });
+
+      expect(types).toContain(expectedType);
+      expect(types).not.toContain(EntityType.Host);
+    },
+  );
+
+  test("a cluster UID alone does not hide a real host", () => {
+    const types: Array<EntityType> = typesFor({
+      "host.name": "web-1",
+      "os.type": "linux",
+      "k8s.cluster.uid": "cluster-uid-1",
+    });
+
+    /*
+     * Cluster rows are intentionally name-keyed, so a UID-only resource
+     * cannot produce a KubernetesCluster entity. Without an attachable
+     * Kubernetes entity, the UID must not suppress an otherwise valid Host.
+     */
+    expect(types).not.toContain(EntityType.KubernetesCluster);
+    expect(types).toEqual([EntityType.Host]);
+  });
+
+  test.each([
+    "k8s.cluster.name",
+    "k8s.cluster.uid",
+    "k8s.namespace.name",
+    "k8s.node.name",
+    "k8s.node.uid",
+    "k8s.pod.name",
+    "k8s.pod.uid",
+    "k8s.deployment.name",
+  ])("a blank %s value does not hide a real host", (identityKey: string) => {
+    expect(
+      typesFor({
+        "host.name": "web-1",
+        "os.type": "linux",
+        [identityKey]: "   ",
+      }),
+    ).toEqual([EntityType.Host]);
+  });
+
+  test.each([
+    ["k8s.pod.phase", "Running"],
+    ["k8s.pod.label.app", "checkout"],
+    ["k8s.wombat", "future-metadata"],
+  ])(
+    "an unrelated Kubernetes attribute %s does not hide a real host",
+    (attributeKey: string, attributeValue: string) => {
+      expect(
+        typesFor({
+          "host.name": "web-1",
+          "os.type": "linux",
+          [attributeKey]: attributeValue,
+        }),
+      ).toEqual([EntityType.Host]);
+    },
+  );
+
   test("k8s.cluster: keyed on name only, ignoring uid (read side is name-based)", () => {
     const e: ExtractedEntity | undefined = entityOfType(
       { "k8s.cluster.uid": "u-1", "k8s.cluster.name": "prod-us" },
@@ -359,7 +452,7 @@ describe("InventoryItem.extractEntities — composition & safety", () => {
     expect(typesFor({ "http.method": "GET" })).toEqual([]);
   });
 
-  test("a full k8s resource yields the whole entity set", () => {
+  test("a full k8s resource yields its proper entity set without a phantom host", () => {
     const types: Array<EntityType> = typesFor({
       "service.name": "checkout",
       "service.instance.id": "i-1",
@@ -377,7 +470,6 @@ describe("InventoryItem.extractEntities — composition & safety", () => {
       new Set([
         EntityType.Service,
         EntityType.ServiceInstance,
-        EntityType.Host,
         EntityType.KubernetesCluster,
         EntityType.KubernetesNamespace,
         EntityType.KubernetesNode,
@@ -792,6 +884,23 @@ describe("extractEntities — OTLP entity_refs (authoritative path)", () => {
       return e.entityType === EntityType.Host;
     })!;
     expect(host.entityKey).toBe(keyForHost(PROJECT, "web-1"));
+  });
+
+  test("an explicit host ref remains authoritative on a Kubernetes resource", () => {
+    const entities: Array<ExtractedEntity> = InventoryItem.extractEntities({
+      projectId: PROJECT,
+      attributes: {
+        "host.name": "checkout-7d9f",
+        "k8s.cluster.name": "prod-us",
+        "k8s.namespace.name": "shop",
+        "k8s.pod.name": "checkout-7d9f",
+      },
+      entityRefs: [{ type: "host", idKeys: ["host.name"] }],
+    });
+
+    expect(entities).toHaveLength(1);
+    expect(entities[0]!.entityType).toBe(EntityType.Host);
+    expect(entities[0]!.entityKey).toBe(keyForHost(PROJECT, "checkout-7d9f"));
   });
 
   test("unknown ref types are skipped (debug log), known refs still built", () => {


### PR DESCRIPTION
## Summary

- stop heuristic Host extraction when an OTLP resource carries a supported Kubernetes identity
- keep the resource attached to its proper typed inventory entity (Pod, Node, Cluster, Namespace, or Deployment)
- preserve standalone Host discovery and explicit OTLP `entity_refs`
- keep metric scalar keys and entity-membership keys consistent with the corrected classification

## Root cause

Application SDKs running inside Kubernetes commonly publish the pod/container hostname as `host.name`. Inventory ran every entity resolver independently, so the same resource emitted both a Kubernetes Pod and a phantom Host. The Host resolver now recognizes Kubernetes identities before creating a heuristic Host item.

The guard covers cluster name, namespace name, node name/UID, pod name/UID, and deployment name. Cluster UID alone remains host-eligible because OneUptime cannot attach a cluster inventory entity without the name.

## Tests

- `npm run fix`
- `cd Common && npm run compile`
- targeted inventory extraction and entity-key parity suites: 86 tests passed
- coverage includes every supported Kubernetes identity, UID-only boundaries, blank and unrelated Kubernetes attributes, full mixed resources, standalone hosts, authoritative entity refs, canonicalized keys, and membership-key parity

No database migration is required.