### PR TITLE
fix(workflow): align template creation form

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Workflow/CreateWorkflowModal.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Workflow/CreateWorkflowModal.tsx
@@ -26,8 +26,11 @@ import Modal, { ModalWidth } from "Common/UI/Components/Modal/Modal";
 import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import Icon, { SizeProp } from "Common/UI/Components/Icon/Icon";
 import IconProp from "Common/Types/Icon/IconProp";
-import Input, { InputType } from "Common/UI/Components/Input/Input";
+import Input from "Common/UI/Components/Input/Input";
 import TextArea from "Common/UI/Components/TextArea/TextArea";
+import Steps from "Common/UI/Components/Forms/Steps/Steps";
+import { FormStep } from "Common/UI/Components/Forms/Types/FormStep";
+import FieldLabelElement from "Common/UI/Components/Forms/Fields/FieldLabel";
 import ObjectID from "Common/Types/ObjectID";
 import { JSONArray, JSONObject } from "Common/Types/JSON";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
@@ -59,82 +62,37 @@ export interface ComponentProps {
 }
 
 enum WizardStep {
-  PickTemplate = 1,
-  NameIt = 2,
-  Configure = 3,
+  PickTemplate = "pick-template",
+  NameIt = "name",
+  Configure = "configure",
 }
 
-const STEP_TITLES: Record<WizardStep, string> = {
-  [WizardStep.PickTemplate]: "Start from",
-  [WizardStep.NameIt]: "Name",
-  [WizardStep.Configure]: "Configure",
-};
+export type GetWorkflowWizardFormStepsFunction = (
+  showConfigureStep: boolean,
+) => Array<FormStep<JSONObject>>;
 
-interface StepIndicatorProps {
-  current: WizardStep;
-  showConfigureStep: boolean;
-}
+export const getWorkflowWizardFormSteps: GetWorkflowWizardFormStepsFunction = (
+  showConfigureStep: boolean,
+): Array<FormStep<JSONObject>> => {
+  const steps: Array<FormStep<JSONObject>> = [
+    {
+      id: WizardStep.PickTemplate,
+      title: "Start from",
+    },
+    {
+      id: WizardStep.NameIt,
+      title: "Name",
+    },
+  ];
 
-const StepIndicator: FunctionComponent<StepIndicatorProps> = (
-  props: StepIndicatorProps,
-): ReactElement => {
-  const steps: Array<WizardStep> = [WizardStep.PickTemplate, WizardStep.NameIt];
-
-  if (props.showConfigureStep) {
-    steps.push(WizardStep.Configure);
+  if (showConfigureStep) {
+    steps.push({
+      id: WizardStep.Configure,
+      title: "Configure",
+    });
   }
 
-  return (
-    <ol className="flex items-center gap-3 mb-6" aria-label="Progress">
-      {steps.map((step: WizardStep, index: number): ReactElement => {
-        const isCompleted: boolean = step < props.current;
-        const isActive: boolean = step === props.current;
-
-        return (
-          <li key={step} className="flex items-center gap-3">
-            <div className="flex items-center gap-2">
-              <span
-                className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold transition-colors ${
-                  isCompleted
-                    ? "bg-indigo-600 text-white"
-                    : isActive
-                      ? "bg-indigo-100 text-indigo-700 ring-2 ring-indigo-500"
-                      : "bg-gray-100 text-gray-400"
-                }`}
-                aria-current={isActive ? "step" : undefined}
-              >
-                {isCompleted ? (
-                  <Icon icon={IconProp.Check} className="h-3.5 w-3.5" />
-                ) : (
-                  index + 1
-                )}
-              </span>
-              <span
-                className={`text-sm ${
-                  isActive
-                    ? "font-semibold text-gray-900"
-                    : isCompleted
-                      ? "font-medium text-gray-600"
-                      : "text-gray-400"
-                }`}
-              >
-                {STEP_TITLES[step]}
-              </span>
-            </div>
-            {index < steps.length - 1 ? (
-              <span
-                className={`h-px w-8 ${
-                  isCompleted ? "bg-indigo-300" : "bg-gray-200"
-                }`}
-              />
-            ) : (
-              <></>
-            )}
-          </li>
-        );
-      })}
-    </ol>
-  );
+  return steps;
 };
 
 interface TemplateCardProps {
@@ -239,6 +197,8 @@ const CreateWorkflowModal: FunctionComponent<ComponentProps> = (
     selectedTemplate?.variables || [];
 
   const showConfigureStep: boolean = variables.length > 0;
+  const wizardFormSteps: Array<FormStep<JSONObject>> =
+    getWorkflowWizardFormSteps(showConfigureStep);
 
   type MatchesSearchFunction = (template: WorkflowTemplate) => boolean;
 
@@ -559,10 +519,14 @@ const CreateWorkflowModal: FunctionComponent<ComponentProps> = (
         )}
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">
-            Name
-          </label>
+          <FieldLabelElement
+            title="Name"
+            htmlFor="workflow-name"
+            required={true}
+            description="Workflow names are unique within a project."
+          />
           <Input
+            id="workflow-name"
             value={name}
             autoFocus={true}
             placeholder="What should this workflow be called?"
@@ -576,16 +540,15 @@ const CreateWorkflowModal: FunctionComponent<ComponentProps> = (
               }
             }}
           />
-          <p className="mt-1 text-xs text-gray-500">
-            Workflow names are unique within a project.
-          </p>
         </div>
 
         <div>
-          <label className="mb-1 block text-sm font-medium text-gray-700">
-            Description
-          </label>
+          <FieldLabelElement
+            title="Description"
+            htmlFor="workflow-description"
+          />
           <TextArea
+            id="workflow-description"
             value={description}
             placeholder="What is this workflow for?"
             dataTestId="workflow-description-input"
@@ -610,26 +573,22 @@ const CreateWorkflowModal: FunctionComponent<ComponentProps> = (
         </p>
 
         {variables.map((variable: WorkflowTemplateVariable): ReactElement => {
+          const inputId: string = `workflow-variable-${variable.name}`;
+
           return (
             <div key={variable.name}>
-              <label className="mb-1 block text-sm font-medium text-gray-700">
-                {variable.title}
-                {variable.required ? (
-                  <span className="ml-1 text-red-500">*</span>
-                ) : (
-                  <span className="ml-2 text-xs font-normal text-gray-400">
-                    Optional
-                  </span>
-                )}
-              </label>
+              <FieldLabelElement
+                title={variable.title}
+                htmlFor={inputId}
+                required={variable.required}
+                description={variable.description}
+              />
               <Input
+                id={inputId}
                 value={variableValues[variable.name] || ""}
                 placeholder={variable.placeholder}
                 error={variableErrors[variable.name]}
-                dataTestId={`workflow-variable-${variable.name}`}
-                type={
-                  variable.isSecret ? ("password" as InputType) : InputType.TEXT
-                }
+                dataTestId={inputId}
                 onChange={(value: string) => {
                   setVariableValues(
                     (
@@ -654,9 +613,6 @@ const CreateWorkflowModal: FunctionComponent<ComponentProps> = (
                   }
                 }}
               />
-              <p className="mt-1 text-xs text-gray-500">
-                {variable.description}
-              </p>
             </div>
           );
         })}
@@ -701,11 +657,30 @@ const CreateWorkflowModal: FunctionComponent<ComponentProps> = (
         )
       }
     >
-      <div>
-        <StepIndicator current={step} showConfigureStep={showConfigureStep} />
-        {step === WizardStep.PickTemplate ? renderPickStep() : <></>}
-        {step === WizardStep.NameIt ? renderNameStep() : <></>}
-        {step === WizardStep.Configure ? renderConfigureStep() : <></>}
+      <div className="flex">
+        <div
+          style={{ flex: "0 1 auto" }}
+          className="mr-10 hidden lg:block"
+          data-testid="workflow-wizard-steps"
+        >
+          <Steps<JSONObject>
+            currentFormStepId={step}
+            steps={wizardFormSteps}
+            formValues={{}}
+            onClick={(formStep: FormStep<JSONObject>) => {
+              setStep(formStep.id as WizardStep);
+            }}
+          />
+        </div>
+        <div
+          className="w-auto pt-6"
+          style={{ flex: "1 1 auto" }}
+          data-testid="workflow-wizard-step-content"
+        >
+          {step === WizardStep.PickTemplate ? renderPickStep() : <></>}
+          {step === WizardStep.NameIt ? renderNameStep() : <></>}
+          {step === WizardStep.Configure ? renderConfigureStep() : <></>}
+        </div>
       </div>
     </Modal>
   );

--- a/Common/Tests/App/Dashboard/CreateWorkflowModal.test.tsx
+++ b/Common/Tests/App/Dashboard/CreateWorkflowModal.test.tsx
@@ -1,0 +1,536 @@
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  RenderResult,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import React from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+jest.mock("Common/UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      create: jest.fn(),
+      deleteItem: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      getFriendlyMessage: jest.fn((error: unknown): string => {
+        return error instanceof Error ? error.message : "Request failed.";
+      }),
+    },
+  };
+});
+
+import CreateWorkflowModal from "../../../../App/FeatureSet/Dashboard/src/Components/Workflow/CreateWorkflowModal";
+import Workflow from "../../../Models/DatabaseModels/Workflow";
+import WorkflowVariable from "../../../Models/DatabaseModels/WorkflowVariable";
+import ObjectID from "../../../Types/ObjectID";
+import {
+  WorkflowTemplate,
+  WorkflowTemplateVariable,
+  getWorkflowTemplate,
+} from "../../../Types/Workflow/Templates";
+import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "../../../UI/Utils/Project";
+import getJestMockFunction, { MockFunction } from "../../../Tests/MockType";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "0198c8ec-2a1d-7f0c-9e75-384194161001",
+);
+const WORKFLOW_ID: ObjectID = new ObjectID(
+  "0198c8ec-2a1d-7f0c-9e75-384194161002",
+);
+
+const SLACK_TEMPLATE_ID: string = "incident-created-slack";
+const EMAIL_TEMPLATE_ID: string = "scheduled-email-digest";
+const FORWARD_TEMPLATE_ID: string = "incident-created-forward";
+const ZERO_CONFIG_TEMPLATE_ID: string = "manual-log";
+
+interface ModelCreateArguments {
+  model: Workflow | WorkflowVariable;
+  modelType: typeof Workflow | typeof WorkflowVariable;
+}
+
+interface ModelDeleteArguments {
+  modelType: typeof Workflow;
+  id: ObjectID;
+}
+
+const mockCreate: MockFunction = ModelAPI.create as unknown as MockFunction;
+const mockDeleteItem: MockFunction =
+  ModelAPI.deleteItem as unknown as MockFunction;
+const mockGetCurrentProjectId: MockFunction =
+  ProjectUtil.getCurrentProjectId as unknown as MockFunction;
+
+interface ModalHarness {
+  view: RenderResult;
+  onClose: MockFunction;
+  onCreated: MockFunction;
+}
+
+type RenderModalFunction = () => ModalHarness;
+
+const renderModal: RenderModalFunction = (): ModalHarness => {
+  const onClose: MockFunction = getJestMockFunction();
+  const onCreated: MockFunction = getJestMockFunction();
+  const view: RenderResult = render(
+    <CreateWorkflowModal onClose={onClose} onCreated={onCreated} />,
+  );
+
+  return {
+    view: view,
+    onClose: onClose,
+    onCreated: onCreated,
+  };
+};
+
+type GetTemplateFunction = (templateId: string) => WorkflowTemplate;
+
+const getTemplate: GetTemplateFunction = (
+  templateId: string,
+): WorkflowTemplate => {
+  const template: WorkflowTemplate | null = getWorkflowTemplate(templateId);
+
+  if (!template) {
+    throw new Error(`Workflow template "${templateId}" was not found.`);
+  }
+
+  return template;
+};
+
+type SelectTemplateFunction = (templateId: string) => WorkflowTemplate;
+
+const selectTemplate: SelectTemplateFunction = (
+  templateId: string,
+): WorkflowTemplate => {
+  const template: WorkflowTemplate = getTemplate(templateId);
+
+  fireEvent.click(
+    screen.getByTestId(`workflow-template-card-${template.name}`),
+  );
+
+  return template;
+};
+
+type SubmitFunction = () => void;
+
+const submit: SubmitFunction = (): void => {
+  fireEvent.click(screen.getByTestId("modal-footer-submit-button"));
+};
+
+type GoToConfigureFunction = (templateId: string) => WorkflowTemplate;
+
+const goToConfigure: GoToConfigureFunction = (
+  templateId: string,
+): WorkflowTemplate => {
+  const template: WorkflowTemplate = selectTemplate(templateId);
+
+  submit();
+
+  const firstVariable: WorkflowTemplateVariable | undefined =
+    template.variables[0];
+
+  if (!firstVariable) {
+    throw new Error(`Workflow template "${templateId}" has no variables.`);
+  }
+
+  expect(
+    screen.getByTestId(`workflow-variable-${firstVariable.name}`),
+  ).toBeInTheDocument();
+
+  return template;
+};
+
+type GetVariableInputFunction = (variableName: string) => HTMLInputElement;
+
+const getVariableInput: GetVariableInputFunction = (
+  variableName: string,
+): HTMLInputElement => {
+  return screen.getByTestId(
+    `workflow-variable-${variableName}`,
+  ) as HTMLInputElement;
+};
+
+type FillVariableFunction = (variableName: string, value: string) => void;
+
+const fillVariable: FillVariableFunction = (
+  variableName: string,
+  value: string,
+): void => {
+  fireEvent.change(getVariableInput(variableName), {
+    target: { value: value },
+  });
+};
+
+type GetProgressFunction = () => HTMLElement;
+
+const getProgress: GetProgressFunction = (): HTMLElement => {
+  return screen.getByRole("navigation", { name: "Progress" });
+};
+
+type ExpectActiveStepFunction = (title: string) => void;
+
+const expectActiveStep: ExpectActiveStepFunction = (title: string): void => {
+  const label: HTMLElement = within(getProgress()).getByText(title);
+
+  expect(label.closest('[aria-current="step"]')).not.toBeNull();
+};
+
+type CreatedWorkflowFunction = () => Workflow;
+
+const createdWorkflow: CreatedWorkflowFunction = (): Workflow => {
+  const workflow: Workflow = new Workflow();
+  workflow.id = WORKFLOW_ID;
+  workflow.name = "Created workflow";
+  return workflow;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetCurrentProjectId.mockReturnValue(PROJECT_ID);
+  mockDeleteItem.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CreateWorkflowModal variable input types", () => {
+  test("a secret-only Slack template still presents an ordinary text input", () => {
+    renderModal();
+    const template: WorkflowTemplate = goToConfigure(SLACK_TEMPLATE_ID);
+
+    expect(template.variables).toHaveLength(1);
+    expect(template.variables[0]?.isSecret).toBe(true);
+    expect(getVariableInput("slackWebhookUrl")).toHaveAttribute("type", "text");
+  });
+
+  test("the mixed SMTP template renders every public and secret value as text", () => {
+    renderModal();
+    const template: WorkflowTemplate = goToConfigure(EMAIL_TEMPLATE_ID);
+
+    expect(
+      template.variables.map((variable: WorkflowTemplateVariable) => {
+        return {
+          name: variable.name,
+          isSecret: variable.isSecret,
+          inputType: getVariableInput(variable.name).type,
+        };
+      }),
+    ).toEqual([
+      { name: "smtpHost", isSecret: false, inputType: "text" },
+      { name: "smtpPort", isSecret: false, inputType: "text" },
+      { name: "smtpUsername", isSecret: false, inputType: "text" },
+      { name: "smtpPassword", isSecret: true, inputType: "text" },
+      { name: "emailFrom", isSecret: false, inputType: "text" },
+      { name: "emailTo", isSecret: false, inputType: "text" },
+    ]);
+  });
+
+  test("a non-secret destination URL uses a text input", () => {
+    renderModal();
+    const template: WorkflowTemplate = goToConfigure(FORWARD_TEMPLATE_ID);
+
+    expect(template.variables).toHaveLength(1);
+    expect(template.variables[0]?.isSecret).toBe(false);
+    expect(getVariableInput("forwardUrl")).toHaveAttribute("type", "text");
+  });
+});
+
+describe("CreateWorkflowModal standard form steps", () => {
+  test("uses the shared vertical progress rail and its active-step semantics", () => {
+    renderModal();
+
+    const progress: HTMLElement = getProgress();
+    const stepList: HTMLElement = within(progress).getByRole("list");
+
+    expect(stepList).toHaveClass("space-y-6");
+    expectActiveStep("Start from");
+    expect(within(progress).getByText("Name")).toBeInTheDocument();
+    expect(within(progress).queryByText("Configure")).not.toBeInTheDocument();
+  });
+
+  test("only adds Configure for templates that declare variables", () => {
+    renderModal();
+
+    selectTemplate(ZERO_CONFIG_TEMPLATE_ID);
+
+    expectActiveStep("Name");
+    expect(
+      within(getProgress()).queryByText("Configure"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(within(getProgress()).getByText("Start from"));
+    expect(screen.getByTestId("workflow-template-search")).toBeInTheDocument();
+
+    selectTemplate(SLACK_TEMPLATE_ID);
+
+    expectActiveStep("Name");
+    expect(within(getProgress()).getByText("Configure")).toBeInTheDocument();
+  });
+
+  test("a completed step can navigate back to the template picker", () => {
+    renderModal();
+    selectTemplate(SLACK_TEMPLATE_ID);
+
+    const startFromStep: HTMLElement =
+      within(getProgress()).getByText("Start from");
+    expect(startFromStep.closest("li")).toHaveClass("cursor-pointer");
+
+    fireEvent.click(startFromStep);
+
+    expect(screen.getByTestId("workflow-template-search")).toBeInTheDocument();
+    expectActiveStep("Start from");
+  });
+});
+
+describe("CreateWorkflowModal wizard state and validation", () => {
+  test("Back preserves the workflow name and values already entered", async () => {
+    renderModal();
+    selectTemplate(EMAIL_TEMPLATE_ID);
+
+    fireEvent.change(screen.getByTestId("workflow-name-input"), {
+      target: { value: "My daily digest" },
+    });
+    submit();
+
+    fillVariable("smtpHost", "smtp.example.com");
+    fillVariable("smtpPassword", "not-masked-in-this-form");
+
+    fireEvent.click(screen.getByTestId("workflow-wizard-back"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workflow-name-input")).toHaveValue(
+        "My daily digest",
+      );
+    });
+
+    submit();
+
+    await waitFor(() => {
+      expect(getVariableInput("smtpHost")).toHaveValue("smtp.example.com");
+      expect(getVariableInput("smtpPassword")).toHaveValue(
+        "not-masked-in-this-form",
+      );
+    });
+    expect(getVariableInput("smtpPassword")).toHaveAttribute("type", "text");
+  });
+
+  test("reports every missing required SMTP field but not optional fields", () => {
+    renderModal();
+    goToConfigure(EMAIL_TEMPLATE_ID);
+
+    submit();
+
+    expect(screen.getByText("SMTP Host is required.")).toBeInTheDocument();
+    expect(screen.getByText("SMTP Port is required.")).toBeInTheDocument();
+    expect(screen.getByText("From Address is required.")).toBeInTheDocument();
+    expect(screen.getByText("To Address is required.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("SMTP Username is required."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("SMTP Password is required."),
+    ).not.toBeInTheDocument();
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("CreateWorkflowModal creation orchestration", () => {
+  test("creates the workflow first, then variables in declaration order with secret flags intact", async () => {
+    const created: Workflow = createdWorkflow();
+
+    mockCreate.mockImplementation(
+      async (
+        data: ModelCreateArguments,
+      ): Promise<{ data: Workflow | WorkflowVariable }> => {
+        if (data.modelType === Workflow) {
+          return { data: created };
+        }
+
+        return { data: data.model };
+      },
+    );
+
+    const harness: ModalHarness = renderModal();
+    goToConfigure(EMAIL_TEMPLATE_ID);
+
+    const values: Record<string, string> = {
+      smtpHost: "smtp.example.com",
+      smtpPort: "587",
+      smtpUsername: "mailer",
+      smtpPassword: "smtp-secret",
+      emailFrom: "notifications@example.com",
+      emailTo: "team@example.com",
+    };
+
+    for (const [name, value] of Object.entries(values)) {
+      fillVariable(name, value);
+    }
+
+    submit();
+
+    await waitFor(() => {
+      expect(harness.onCreated).toHaveBeenCalledWith(created);
+    });
+
+    const createArguments: Array<ModelCreateArguments> =
+      mockCreate.mock.calls.map((call: Array<unknown>) => {
+        return call[0] as ModelCreateArguments;
+      });
+
+    expect(createArguments).toHaveLength(7);
+    expect(createArguments[0]?.modelType).toBe(Workflow);
+    expect(createArguments[0]?.model).toBeInstanceOf(Workflow);
+
+    const variableRows: Array<WorkflowVariable> = createArguments
+      .slice(1)
+      .map((data: ModelCreateArguments) => {
+        expect(data.modelType).toBe(WorkflowVariable);
+        expect(data.model).toBeInstanceOf(WorkflowVariable);
+        return data.model as WorkflowVariable;
+      });
+
+    expect(
+      variableRows.map((variable: WorkflowVariable) => {
+        return variable.name;
+      }),
+    ).toEqual([
+      "smtpHost",
+      "smtpPort",
+      "smtpUsername",
+      "smtpPassword",
+      "emailFrom",
+      "emailTo",
+    ]);
+
+    expect(
+      variableRows.map((variable: WorkflowVariable) => {
+        return {
+          name: variable.name,
+          content: variable.content,
+          isSecret: (variable as unknown as { isSecret: boolean }).isSecret,
+          workflowId: variable.workflowId?.toString(),
+          projectId: variable.projectId?.toString(),
+        };
+      }),
+    ).toEqual([
+      {
+        name: "smtpHost",
+        content: "smtp.example.com",
+        isSecret: false,
+        workflowId: WORKFLOW_ID.toString(),
+        projectId: PROJECT_ID.toString(),
+      },
+      {
+        name: "smtpPort",
+        content: "587",
+        isSecret: false,
+        workflowId: WORKFLOW_ID.toString(),
+        projectId: PROJECT_ID.toString(),
+      },
+      {
+        name: "smtpUsername",
+        content: "mailer",
+        isSecret: false,
+        workflowId: WORKFLOW_ID.toString(),
+        projectId: PROJECT_ID.toString(),
+      },
+      {
+        name: "smtpPassword",
+        content: "smtp-secret",
+        isSecret: true,
+        workflowId: WORKFLOW_ID.toString(),
+        projectId: PROJECT_ID.toString(),
+      },
+      {
+        name: "emailFrom",
+        content: "notifications@example.com",
+        isSecret: false,
+        workflowId: WORKFLOW_ID.toString(),
+        projectId: PROJECT_ID.toString(),
+      },
+      {
+        name: "emailTo",
+        content: "team@example.com",
+        isSecret: false,
+        workflowId: WORKFLOW_ID.toString(),
+        projectId: PROJECT_ID.toString(),
+      },
+    ]);
+    expect(mockDeleteItem).not.toHaveBeenCalled();
+  });
+
+  test("rolls the new workflow back when creating its variable fails", async () => {
+    const created: Workflow = createdWorkflow();
+    const variableFailure: Error = new Error("Variable could not be saved.");
+
+    mockCreate.mockImplementation(
+      async (
+        data: ModelCreateArguments,
+      ): Promise<{ data: Workflow | WorkflowVariable }> => {
+        if (data.modelType === Workflow) {
+          return { data: created };
+        }
+
+        throw variableFailure;
+      },
+    );
+
+    const harness: ModalHarness = renderModal();
+    goToConfigure(SLACK_TEMPLATE_ID);
+    fillVariable("slackWebhookUrl", "https://hooks.slack.com/services/T/B/X");
+
+    expect(getVariableInput("slackWebhookUrl")).toHaveAttribute("type", "text");
+
+    submit();
+
+    await waitFor(() => {
+      expect(mockDeleteItem).toHaveBeenCalledTimes(1);
+    });
+
+    const deleteArguments: ModelDeleteArguments = mockDeleteItem.mock
+      .calls[0]?.[0] as ModelDeleteArguments;
+
+    expect(deleteArguments.modelType).toBe(Workflow);
+    expect(deleteArguments.id.toString()).toBe(WORKFLOW_ID.toString());
+    expect(harness.onCreated).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText("Variable could not be saved."),
+    ).toBeInTheDocument();
+
+    const failedVariable: WorkflowVariable = mockCreate.mock.calls[1]?.[0]
+      .model as WorkflowVariable;
+    expect(failedVariable.name).toBe("slackWebhookUrl");
+    expect((failedVariable as unknown as { isSecret: boolean }).isSecret).toBe(
+      true,
+    );
+  });
+});

--- a/Common/Types/Workflow/Templates.ts
+++ b/Common/Types/Workflow/Templates.ts
@@ -72,8 +72,9 @@ export interface WorkflowTemplateVariable {
   placeholder: string;
   required: boolean;
   /**
-   * Masks the input and marks the stored row secret, which redacts it from run
-   * logs. It does NOT encrypt it at rest — nothing on WorkflowVariable is.
+   * Marks the stored row secret, which redacts it from run logs. This is a
+   * persistence concern and does not change how the create wizard displays the
+   * field. It does NOT encrypt it at rest — nothing on WorkflowVariable is.
    */
   isSecret: boolean;
 }


### PR DESCRIPTION
## Summary

- Render workflow-template variables as ordinary text fields while preserving each variable's stored `isSecret` flag for run-log redaction.
- Replace the bespoke horizontal wizard indicator with OneUptime's shared vertical form-step rail and shared field labels.
- Add comprehensive modal coverage for variable presentation, step behavior, validation, state preservation, creation ordering, secret metadata, and rollback.

## Why

The template wizard used `isSecret` for two separate concerns: persistence/redaction and browser presentation. Several common templates only declare secret webhook values, so every configuration input appeared as a password field. The wizard also maintained custom step chrome that had drifted from the rest of OneUptime's forms.

## Impact

Workflow creation keeps the same persistence and redaction behavior. Only the template form presentation changes, and the wizard now follows the shared OneUptime form pattern.

## Testing

- `npm run fix`
- `Common: npm run compile`
- `App/FeatureSet/Dashboard: npm run compile`
- New CreateWorkflowModal UI suite: 10 passed
- Workflow template creation suite: 36 passed
- Workflow template definition suite: 694 passed
