### PR TITLE
feat(ask-ai): feed the copilot — platform-wide tools, memory, cancel, feedback, native entry points

### DIFF
--- a/App/FeatureSet/AdminDashboard/src/Pages/Settings/LlmProviders/Index.tsx
+++ b/App/FeatureSet/AdminDashboard/src/Pages/Settings/LlmProviders/Index.tsx
@@ -206,9 +206,9 @@ const Settings: FunctionComponent = (): ReactElement => {
             stepId: "provider-settings",
             fieldType: FormFieldSchemaType.Text,
             required: false,
-            placeholder: "gpt-4o, claude-3-opus, llama-3.3-70b-versatile",
+            placeholder: "gpt-5.1, claude-sonnet-5, llama-3.3-70b-versatile",
             description:
-              "The specific model or deployment name to use (e.g., gpt-4o for OpenAI, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq, mistral-large-latest for Mistral). Required for OpenAI-compatible providers — it must match a model your server exposes.",
+              "The specific model or deployment name to use (e.g., gpt-5.1 for OpenAI, claude-sonnet-5 for Anthropic, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq, mistral-large-latest for Mistral). Required for OpenAI-compatible providers — it must match a model your server exposes.",
           },
           {
             field: {

--- a/App/FeatureSet/Dashboard/src/App.tsx
+++ b/App/FeatureSet/Dashboard/src/App.tsx
@@ -635,6 +635,16 @@ const App: () => JSX.Element = () => {
             />
 
             <PageRoute
+              path={RouteMap[PageMap.AI_COPILOT_CONVERSATION]?.toString() || ""}
+              element={
+                <AICopilot
+                  {...commonPageProps}
+                  pageRoute={RouteMap[PageMap.AI_COPILOT_CONVERSATION] as Route}
+                />
+              }
+            />
+
+            <PageRoute
               path={
                 RouteMap[PageMap.HOME_NOT_OPERATIONAL_MONITORS]?.toString() ||
                 ""

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/AIChatPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/AIChatPanel.tsx
@@ -1,4 +1,5 @@
 import IconProp from "Common/Types/Icon/IconProp";
+import ObjectID from "Common/Types/ObjectID";
 import Route from "Common/Types/API/Route";
 import Icon from "Common/UI/Components/Icon/Icon";
 import GlobalEvents from "Common/UI/Utils/GlobalEvents";
@@ -20,7 +21,7 @@ import ChatMessageList from "./ChatMessageList";
 import PageContextChip from "./PageContextChip";
 import ProviderPicker from "./ProviderPicker";
 import PermissionModePicker from "./PermissionModePicker";
-import { useAiChat, UseAiChat } from "./useAiChat";
+import { ChatMessageFeedback, useAiChat, UseAiChat } from "./useAiChat";
 
 /*
  * The "Ask AI" quick launcher: a compact slide-over for fast questions from
@@ -38,9 +39,17 @@ const AIChatPanel: FunctionComponent = (): ReactElement => {
   // ---- open/close ----------------------------------------------------------
 
   useEffect(() => {
-    const toggle: () => void = (): void => {
+    /*
+     * AI_CHAT_TOGGLE toggles by default; dispatchers can pass
+     * { forceOpen: true } ("Ask AI about this" buttons on entity pages) so a
+     * click never accidentally closes an already-open panel.
+     */
+    const toggle: (event: CustomEvent) => void = (event: CustomEvent): void => {
+      const forceOpen: boolean = Boolean(
+        (event?.detail as { forceOpen?: boolean } | undefined)?.forceOpen,
+      );
       setIsOpen((open: boolean) => {
-        return !open;
+        return forceOpen ? true : !open;
       });
     };
 
@@ -48,6 +57,47 @@ const AIChatPanel: FunctionComponent = (): ReactElement => {
 
     return () => {
       GlobalEvents.removeEventListener(EventName.AI_CHAT_TOGGLE, toggle);
+    };
+  }, []);
+
+  // Cmd/Ctrl + I opens Ask AI from anywhere — keyboard operators included.
+  useEffect(() => {
+    const onKeyDown: (event: KeyboardEvent) => void = (
+      event: KeyboardEvent,
+    ): void => {
+      if (
+        !(event.metaKey || event.ctrlKey) ||
+        event.shiftKey ||
+        event.altKey ||
+        event.key.toLowerCase() !== "i" ||
+        event.defaultPrevented
+      ) {
+        return;
+      }
+
+      /*
+       * Cmd/Ctrl+I is also the universal italics shortcut: while the user is
+       * typing in any input, textarea, or rich-text editor, leave the event
+       * alone so note/postmortem editors keep their formatting shortcut.
+       */
+      const target: HTMLElement | null = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      setIsOpen((open: boolean) => {
+        return !open;
+      });
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
     };
   }, []);
 
@@ -81,8 +131,21 @@ const AIChatPanel: FunctionComponent = (): ReactElement => {
     };
   }, [isOpen]);
 
+  /*
+   * Expanding keeps the active thread: the full page reads the conversation id
+   * from its route, so the user lands exactly where they were.
+   */
   const openFullCopilot: () => void = (): void => {
     setIsOpen(false);
+    if (chat.activeConversationId) {
+      Navigation.navigate(
+        RouteUtil.populateRouteParams(
+          RouteMap[PageMap.AI_COPILOT_CONVERSATION] as Route,
+          { modelId: new ObjectID(chat.activeConversationId) },
+        ),
+      );
+      return;
+    }
     Navigation.navigate(
       RouteUtil.populateRouteParams(RouteMap[PageMap.AI_COPILOT] as Route),
     );
@@ -292,6 +355,14 @@ const AIChatPanel: FunctionComponent = (): ReactElement => {
                       // handled in the hook
                     });
                 }}
+                onFeedback={(
+                  messageId: string,
+                  feedback: ChatMessageFeedback | null,
+                ) => {
+                  chat.sendFeedback(messageId, feedback).catch(() => {
+                    // handled in the hook
+                  });
+                }}
               />
 
               {chat.isWorking && (
@@ -311,6 +382,16 @@ const AIChatPanel: FunctionComponent = (): ReactElement => {
             !chat.isSending && !chat.isWorking && !chat.isAwaitingApproval
           }
           isWorking={chat.isWorking}
+          isStopping={chat.isCancelling}
+          onStop={
+            chat.isWorking && !chat.isAwaitingApproval
+              ? () => {
+                  chat.cancelRun().catch(() => {
+                    // handled in the hook
+                  });
+                }
+              : undefined
+          }
           leading={composerLeading}
           contextChip={contextChip}
           placeholder={composerPlaceholder}

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/AskAIButton.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/AskAIButton.tsx
@@ -1,0 +1,41 @@
+import IconProp from "Common/Types/Icon/IconProp";
+import Icon from "Common/UI/Components/Icon/Icon";
+import GlobalEvents from "Common/UI/Utils/GlobalEvents";
+import React, { FunctionComponent, ReactElement } from "react";
+import EventName from "../../Utils/EventName";
+
+export interface ComponentProps {
+  /*
+   * Label defaults to "Ask AI" — pass e.g. "Ask AI about this incident" where
+   * the surrounding page has room for the longer affordance.
+   */
+  label?: string | undefined;
+}
+
+/*
+ * The entity-page entry point into Ask AI. It only opens the panel — the chat
+ * detects what "this" is from the current route, so the button placed on an
+ * incident view opens a conversation already grounded in that incident.
+ * forceOpen (rather than toggle) so a click never closes an open panel.
+ */
+const AskAIButton: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  return (
+    <button
+      type="button"
+      data-testid="ask-ai-button"
+      onClick={() => {
+        GlobalEvents.dispatchEvent(EventName.AI_CHAT_TOGGLE, {
+          forceOpen: true,
+        });
+      }}
+      className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:border-gray-300 hover:bg-gray-50 hover:text-gray-900"
+    >
+      <Icon icon={IconProp.Sparkles} className="h-3.5 w-3.5" />
+      {props.label || "Ask AI"}
+    </button>
+  );
+};
+
+export default AskAIButton;

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/ChatInput.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/ChatInput.tsx
@@ -18,6 +18,13 @@ export interface ComponentProps {
   canSend: boolean;
   isWorking: boolean;
   /*
+   * When provided and a run is working, the send button becomes a Stop button
+   * that cancels the in-flight run — operators learn things mid-investigation
+   * and should never be locked out for the full turn budget.
+   */
+  onStop?: (() => void) | undefined;
+  isStopping?: boolean | undefined;
+  /*
    * Optional control rendered on the left of the composer footer (the model
    * switcher). Kept as a slot so the composer stays reusable across surfaces.
    */
@@ -91,25 +98,43 @@ const ChatInput: FunctionComponent<ComponentProps> = (
             }}
             className="max-h-40 flex-1 resize-none border-0 bg-transparent p-0 text-sm leading-6 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-0"
           />
-          <button
-            type="button"
-            title="Send (Enter)"
-            disabled={!isSendable}
-            onClick={() => {
-              trySend();
-            }}
-            className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg transition-colors ${
-              isSendable
-                ? "bg-gray-900 text-white hover:bg-gray-800"
-                : "bg-gray-100 text-gray-300"
-            }`}
-          >
-            {props.isWorking ? (
-              <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-gray-200 border-t-gray-400"></span>
-            ) : (
-              <Icon icon={IconProp.PaperAirplane} className="h-4 w-4" />
-            )}
-          </button>
+          {props.isWorking && props.onStop ? (
+            <button
+              type="button"
+              title="Stop generating"
+              disabled={props.isStopping}
+              onClick={() => {
+                props.onStop?.();
+              }}
+              className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-gray-900 text-white transition-colors hover:bg-gray-700"
+            >
+              {props.isStopping ? (
+                <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-gray-500 border-t-white"></span>
+              ) : (
+                <span className="h-2.5 w-2.5 rounded-[2px] bg-white"></span>
+              )}
+            </button>
+          ) : (
+            <button
+              type="button"
+              title="Send (Enter)"
+              disabled={!isSendable}
+              onClick={() => {
+                trySend();
+              }}
+              className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg transition-colors ${
+                isSendable
+                  ? "bg-gray-900 text-white hover:bg-gray-800"
+                  : "bg-gray-100 text-gray-300"
+              }`}
+            >
+              {props.isWorking ? (
+                <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-gray-200 border-t-gray-400"></span>
+              ) : (
+                <Icon icon={IconProp.PaperAirplane} className="h-4 w-4" />
+              )}
+            </button>
+          )}
         </div>
       </div>
       <div className="mt-2.5 space-y-2 px-1">

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/ChatMessageList.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/ChatMessageList.tsx
@@ -1,4 +1,6 @@
-import AIConversationMessage from "Common/Models/DatabaseModels/AIConversationMessage";
+import AIConversationMessage, {
+  AIConversationMessageFeedback,
+} from "Common/Models/DatabaseModels/AIConversationMessage";
 import AIRun from "Common/Models/DatabaseModels/AIRun";
 import AIChatMessageRole from "Common/Types/AI/AIChatMessageRole";
 import AIChatMessageStatus from "Common/Types/AI/AIChatMessageStatus";
@@ -11,6 +13,7 @@ import CitationChips from "./CitationChips";
 import SafeChatMarkdown from "./SafeChatMarkdown";
 import ToolApprovalCard, { ToolDecision } from "./ToolApprovalCard";
 import WidgetRenderer from "./Widgets/WidgetRenderer";
+import { ChatMessageFeedback } from "./useAiChat";
 
 export interface ComponentProps {
   messages: Array<AIConversationMessage>;
@@ -21,6 +24,10 @@ export interface ComponentProps {
     assistantMessageId: string,
     decisions: Array<ToolDecision>,
   ) => void;
+  // Thumbs rating on an assistant answer; clicking the active thumb clears it.
+  onFeedback?:
+    | ((messageId: string, feedback: ChatMessageFeedback | null) => void)
+    | undefined;
 }
 
 const ChatMessageList: FunctionComponent<ComponentProps> = (
@@ -162,6 +169,13 @@ const ChatMessageList: FunctionComponent<ComponentProps> = (
             </div>
 
             <div className="min-w-0 flex-1">
+              {message.status === AIChatMessageStatus.Cancelled && (
+                <div className="flex items-center gap-2 text-sm text-gray-400">
+                  <Icon icon={IconProp.StopCircle} className="h-4 w-4" />
+                  <span>{message.contentInMarkdown || "Stopped by user."}</span>
+                </div>
+              )}
+
               {message.status === AIChatMessageStatus.Error && (
                 <div className="rounded-xl border border-rose-100 bg-rose-50 px-4 py-3">
                   <div className="flex items-start gap-2.5">
@@ -233,6 +247,58 @@ const ChatMessageList: FunctionComponent<ComponentProps> = (
                           </>
                         )}
                       </button>
+                      {props.onFeedback && (
+                        <span className="flex items-center gap-0.5">
+                          <button
+                            type="button"
+                            title="Good answer"
+                            onClick={() => {
+                              props.onFeedback?.(
+                                messageId,
+                                message.userFeedback ===
+                                  AIConversationMessageFeedback.Up
+                                  ? null
+                                  : AIConversationMessageFeedback.Up,
+                              );
+                            }}
+                            className={`rounded-md p-1 transition-colors hover:bg-gray-100 ${
+                              message.userFeedback ===
+                              AIConversationMessageFeedback.Up
+                                ? "text-emerald-500"
+                                : "text-gray-400 hover:text-gray-600"
+                            }`}
+                          >
+                            <Icon
+                              icon={IconProp.HandThumbUp}
+                              className="h-3 w-3"
+                            />
+                          </button>
+                          <button
+                            type="button"
+                            title="Poor answer"
+                            onClick={() => {
+                              props.onFeedback?.(
+                                messageId,
+                                message.userFeedback ===
+                                  AIConversationMessageFeedback.Down
+                                  ? null
+                                  : AIConversationMessageFeedback.Down,
+                              );
+                            }}
+                            className={`rounded-md p-1 transition-colors hover:bg-gray-100 ${
+                              message.userFeedback ===
+                              AIConversationMessageFeedback.Down
+                                ? "text-rose-500"
+                                : "text-gray-400 hover:text-gray-600"
+                            }`}
+                          >
+                            <Icon
+                              icon={IconProp.HandThumbDown}
+                              className="h-3 w-3"
+                            />
+                          </button>
+                        </span>
+                      )}
                     </div>
                   )}
                 </div>

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/CitationChips.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/CitationChips.tsx
@@ -1,56 +1,20 @@
-import PageMap from "../../Utils/PageMap";
-import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
-import Route from "Common/Types/API/Route";
-import {
-  AIChatCitation,
-  AIChatCitationTargetType,
-} from "Common/Types/AI/AIChatTypes";
+import { AIChatCitation } from "Common/Types/AI/AIChatTypes";
 import IconProp from "Common/Types/Icon/IconProp";
 import Icon from "Common/UI/Components/Icon/Icon";
-import Navigation from "Common/UI/Utils/Navigation";
 import React, { FunctionComponent, ReactElement } from "react";
+import {
+  navigateToCitationTarget,
+  targetTypeToIcon,
+} from "./CitationTargetNav";
 
 export interface ComponentProps {
   citations: Array<AIChatCitation>;
 }
 
-const targetTypeToPageMap: { [key in AIChatCitationTargetType]: PageMap } = {
-  [AIChatCitationTargetType.Logs]: PageMap.LOGS,
-  [AIChatCitationTargetType.Traces]: PageMap.TRACES,
-  [AIChatCitationTargetType.TraceView]: PageMap.TRACE_VIEW,
-  [AIChatCitationTargetType.Metrics]: PageMap.METRICS,
-  [AIChatCitationTargetType.Exceptions]: PageMap.EXCEPTIONS,
-  [AIChatCitationTargetType.Incidents]: PageMap.INCIDENTS,
-  [AIChatCitationTargetType.IncidentView]: PageMap.INCIDENT_VIEW,
-  [AIChatCitationTargetType.Alerts]: PageMap.ALERTS,
-  [AIChatCitationTargetType.AlertView]: PageMap.ALERT_VIEW,
-  [AIChatCitationTargetType.Monitors]: PageMap.MONITORS,
-  [AIChatCitationTargetType.MonitorView]: PageMap.MONITOR_VIEW,
-  [AIChatCitationTargetType.ScheduledMaintenanceEvents]:
-    PageMap.SCHEDULED_MAINTENANCE_EVENTS,
-  [AIChatCitationTargetType.ScheduledMaintenanceView]:
-    PageMap.SCHEDULED_MAINTENANCE_VIEW,
-};
-
-const targetTypeToIcon: { [key in AIChatCitationTargetType]: IconProp } = {
-  [AIChatCitationTargetType.Logs]: IconProp.Logs,
-  [AIChatCitationTargetType.Traces]: IconProp.Activity,
-  [AIChatCitationTargetType.TraceView]: IconProp.Activity,
-  [AIChatCitationTargetType.Metrics]: IconProp.ChartBar,
-  [AIChatCitationTargetType.Exceptions]: IconProp.Error,
-  [AIChatCitationTargetType.Incidents]: IconProp.Alert,
-  [AIChatCitationTargetType.IncidentView]: IconProp.Alert,
-  [AIChatCitationTargetType.Alerts]: IconProp.Bell,
-  [AIChatCitationTargetType.AlertView]: IconProp.Bell,
-  [AIChatCitationTargetType.Monitors]: IconProp.Cube,
-  [AIChatCitationTargetType.MonitorView]: IconProp.Cube,
-  [AIChatCitationTargetType.ScheduledMaintenanceEvents]: IconProp.Clock,
-  [AIChatCitationTargetType.ScheduledMaintenanceView]: IconProp.Clock,
-};
-
 /*
  * Server-minted citation chips. A chip with rowCount 0 is proof of absence —
- * the query ran and found nothing — and renders muted.
+ * the query ran and found nothing — and renders muted. Target-to-route and
+ * target-to-icon mapping is shared with the widgets via CitationTargetNav.
  */
 const CitationChips: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
@@ -62,30 +26,7 @@ const CitationChips: FunctionComponent<ComponentProps> = (
   const navigateToCitation: (citation: AIChatCitation) => void = (
     citation: AIChatCitation,
   ): void => {
-    if (!citation.target) {
-      return;
-    }
-
-    const pageMapKey: PageMap | undefined =
-      targetTypeToPageMap[citation.target.type];
-
-    const route: Route | undefined = pageMapKey
-      ? (RouteMap[pageMapKey] as Route)
-      : undefined;
-
-    if (!route) {
-      return;
-    }
-
-    const params: { [key: string]: string } = citation.target.params || {};
-    const firstParamValue: string | undefined = Object.values(params)[0];
-
-    Navigation.navigate(
-      RouteUtil.populateRouteParams(
-        route,
-        firstParamValue ? { modelId: firstParamValue } : undefined,
-      ),
-    );
+    navigateToCitationTarget(citation.target);
   };
 
   return (

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/CitationTargetNav.ts
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/CitationTargetNav.ts
@@ -31,6 +31,18 @@ export const targetTypeToPageMap: {
     PageMap.SCHEDULED_MAINTENANCE_EVENTS,
   [AIChatCitationTargetType.ScheduledMaintenanceView]:
     PageMap.SCHEDULED_MAINTENANCE_VIEW,
+  [AIChatCitationTargetType.OnCallPolicies]: PageMap.ON_CALL_DUTY_POLICIES,
+  [AIChatCitationTargetType.OnCallPolicyView]: PageMap.ON_CALL_DUTY_POLICY_VIEW,
+  [AIChatCitationTargetType.StatusPages]: PageMap.STATUS_PAGES,
+  [AIChatCitationTargetType.StatusPageView]: PageMap.STATUS_PAGE_VIEW,
+  [AIChatCitationTargetType.Slos]: PageMap.SLOS,
+  [AIChatCitationTargetType.SloView]: PageMap.SLO_VIEW,
+  [AIChatCitationTargetType.Runbooks]: PageMap.RUNBOOKS,
+  [AIChatCitationTargetType.RunbookView]: PageMap.RUNBOOK_VIEW,
+  [AIChatCitationTargetType.Workflows]: PageMap.WORKFLOWS,
+  [AIChatCitationTargetType.WorkflowView]: PageMap.WORKFLOW_VIEW,
+  [AIChatCitationTargetType.Probes]: PageMap.MONITORS_SETTINGS_PROBES,
+  [AIChatCitationTargetType.Teams]: PageMap.TEAMS,
 };
 
 export const targetTypeToIcon: {
@@ -49,6 +61,18 @@ export const targetTypeToIcon: {
   [AIChatCitationTargetType.MonitorView]: IconProp.Cube,
   [AIChatCitationTargetType.ScheduledMaintenanceEvents]: IconProp.Clock,
   [AIChatCitationTargetType.ScheduledMaintenanceView]: IconProp.Clock,
+  [AIChatCitationTargetType.OnCallPolicies]: IconProp.Call,
+  [AIChatCitationTargetType.OnCallPolicyView]: IconProp.Call,
+  [AIChatCitationTargetType.StatusPages]: IconProp.CheckCircle,
+  [AIChatCitationTargetType.StatusPageView]: IconProp.CheckCircle,
+  [AIChatCitationTargetType.Slos]: IconProp.ArrowTrendingUp,
+  [AIChatCitationTargetType.SloView]: IconProp.ArrowTrendingUp,
+  [AIChatCitationTargetType.Runbooks]: IconProp.Book,
+  [AIChatCitationTargetType.RunbookView]: IconProp.Book,
+  [AIChatCitationTargetType.Workflows]: IconProp.Workflow,
+  [AIChatCitationTargetType.WorkflowView]: IconProp.Workflow,
+  [AIChatCitationTargetType.Probes]: IconProp.Signal,
+  [AIChatCitationTargetType.Teams]: IconProp.Team,
 };
 
 export function getRouteForCitationTarget(

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/Export/ConversationPdf.ts
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/Export/ConversationPdf.ts
@@ -319,6 +319,16 @@ class ConversationPdfBuilder {
       return;
     }
 
+    // A cancelled turn is a stop marker, not assistant prose.
+    if (message.status === AIChatMessageStatus.Cancelled) {
+      this.pdf.paragraph(message.contentInMarkdown || "Stopped by user.", {
+        size: 9,
+        color: PDF_COLORS.muted,
+      });
+      this.pdf.moveDown(8);
+      return;
+    }
+
     if (message.contentInMarkdown) {
       /*
        * Neutralized before parsing, so the blocks that reach the renderer no

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/Widgets/EntityListWidget.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/Widgets/EntityListWidget.tsx
@@ -1,7 +1,13 @@
-import { AIChatWidget, AIChatWidgetType } from "Common/Types/AI/AIChatTypes";
+import {
+  AIChatCitationTarget,
+  AIChatCitationTargetType,
+  AIChatWidget,
+  AIChatWidgetType,
+} from "Common/Types/AI/AIChatTypes";
 import { JSONObject } from "Common/Types/JSON";
 import OneUptimeDate from "Common/Types/Date";
 import React, { FunctionComponent, ReactElement } from "react";
+import { navigateToCitationTarget } from "../CitationTargetNav";
 
 export interface ComponentProps {
   widget: AIChatWidget;
@@ -112,10 +118,44 @@ const EntityListWidget: FunctionComponent<ComponentProps> = (
           ? toStr(item["alertNumber"])
           : toStr(item["incidentNumber"]);
 
+        /*
+         * Rows the AI just found should be one click from the entity itself —
+         * incidents and alerts carry their id, so deep-link straight to it.
+         */
+        const rowId: string = toStr(item["id"]);
+        const rowTarget: AIChatCitationTarget | undefined = rowId
+          ? isAlert
+            ? {
+                type: AIChatCitationTargetType.AlertView,
+                params: { alertId: rowId },
+              }
+            : {
+                type: AIChatCitationTargetType.IncidentView,
+                params: { incidentId: rowId },
+              }
+          : undefined;
+
         return (
           <div
             key={index}
-            className="rounded-lg border border-gray-200 bg-gray-50/70 px-3 py-2.5"
+            role={rowTarget ? "button" : undefined}
+            tabIndex={rowTarget ? 0 : undefined}
+            onClick={() => {
+              if (rowTarget) {
+                navigateToCitationTarget(rowTarget);
+              }
+            }}
+            onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>) => {
+              if (rowTarget && (event.key === "Enter" || event.key === " ")) {
+                event.preventDefault();
+                navigateToCitationTarget(rowTarget);
+              }
+            }}
+            className={`rounded-lg border border-gray-200 bg-gray-50/70 px-3 py-2.5 ${
+              rowTarget
+                ? "cursor-pointer transition-colors hover:border-gray-300 hover:bg-gray-100"
+                : ""
+            }`}
           >
             <div className="flex items-start justify-between gap-2">
               <div className="min-w-0">

--- a/App/FeatureSet/Dashboard/src/Components/AIChat/useAiChat.ts
+++ b/App/FeatureSet/Dashboard/src/Components/AIChat/useAiChat.ts
@@ -1,5 +1,7 @@
 import AIConversation from "Common/Models/DatabaseModels/AIConversation";
-import AIConversationMessage from "Common/Models/DatabaseModels/AIConversationMessage";
+import AIConversationMessage, {
+  AIConversationMessageFeedback,
+} from "Common/Models/DatabaseModels/AIConversationMessage";
 import AIRun from "Common/Models/DatabaseModels/AIRun";
 import AIRunEvent from "Common/Models/DatabaseModels/AIRunEvent";
 import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
@@ -22,7 +24,11 @@ import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import Realtime from "Common/UI/Utils/Realtime";
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
 import PageContextUtil, { DashboardPageContext } from "./PageContext";
+
+// The thumbs rating a user can put on an assistant answer.
+export type ChatMessageFeedback = AIConversationMessageFeedback;
 
 const POLL_INTERVAL_MS: number = 1200;
 
@@ -82,6 +88,18 @@ export interface UseAiChat {
     decisions: Array<{ toolCallId: string; approved: boolean }>,
   ) => Promise<void>;
   sendMessage: (contentOverride?: string) => Promise<void>;
+  /*
+   * Stops the in-flight run for the active conversation: the server marks the
+   * run Cancelled and finalizes the assistant message as "Stopped by user."
+   * so the conversation unlocks immediately.
+   */
+  cancelRun: () => Promise<void>;
+  isCancelling: boolean;
+  // Thumbs up/down on an assistant answer; null clears the rating.
+  sendFeedback: (
+    messageId: string,
+    feedback: ChatMessageFeedback | null,
+  ) => Promise<void>;
   openConversation: (conversationId: string) => void;
   newConversation: () => void;
   deleteConversation: (conversationId: string) => void;
@@ -101,6 +119,13 @@ export interface UseAiChat {
  */
 export function useAiChat(options: { enabled: boolean }): UseAiChat {
   const { enabled } = options;
+
+  /*
+   * The current route — page context re-detects on navigation so a panel left
+   * open while the user browses from incident A to incident B never keeps
+   * sending stale "this incident = A" context.
+   */
+  const locationPathname: string = useLocation().pathname;
 
   const [conversations, setConversations] = useState<Array<AIConversation>>([]);
   const [activeConversationId, setActiveConversationId] = useState<
@@ -308,6 +333,7 @@ export function useAiChat(options: { enabled: boolean }): UseAiChat {
               errorMessage: true,
               aiRunId: true,
               createdAt: true,
+              userFeedback: true,
             },
             sort: {
               createdAt: SortOrder.Descending,
@@ -332,7 +358,9 @@ export function useAiChat(options: { enabled: boolean }): UseAiChat {
               .map((action: AIChatToolAction) => {
                 return action.status;
               })
-              .join(",")}:${(message.contentInMarkdown || "").length}`;
+              .join(",")}:${(message.contentInMarkdown || "").length}:${
+              message.userFeedback || ""
+            }`;
           })
           .join("|");
 
@@ -449,10 +477,14 @@ export function useAiChat(options: { enabled: boolean }): UseAiChat {
   }, [enabled, fetchConversations, fetchProviders]);
 
   /*
-   * Detect page context each time the surface opens: what page was the user
-   * on when they reached for Ask AI? Attached by default (the composer chip
-   * lets them detach), with the entity's display title resolved async.
+   * Detect page context each time the surface opens AND each time the route
+   * changes while it is open: what page is the user on right now? Attached by
+   * default (the composer chip lets them detach), with the entity's display
+   * title resolved async.
    */
+  const lastContextSignatureRef: React.MutableRefObject<string> =
+    useRef<string>("");
+
   useEffect(() => {
     if (!enabled) {
       return;
@@ -461,8 +493,23 @@ export function useAiChat(options: { enabled: boolean }): UseAiChat {
     const detected: DashboardPageContext | null =
       PageContextUtil.detectPageContext();
 
+    /*
+     * Re-attach only when the context actually changed (a genuinely new
+     * page). If the user explicitly detached the chip and the route change
+     * resolved to the same context, their choice must hold — silently
+     * re-attaching would send context they just removed.
+     */
+    const signature: string = detected
+      ? `${detected.type}:${detected.entityId || ""}`
+      : "";
+    const contextChanged: boolean =
+      signature !== lastContextSignatureRef.current;
+    lastContextSignatureRef.current = signature;
+
     setPageContext(detected);
-    setIsPageContextAttached(Boolean(detected));
+    if (contextChanged) {
+      setIsPageContextAttached(Boolean(detected));
+    }
 
     if (detected?.isEntity) {
       PageContextUtil.resolveEntityTitle(detected)
@@ -482,7 +529,7 @@ export function useAiChat(options: { enabled: boolean }): UseAiChat {
           // The generic chip label is fine without a title.
         });
     }
-  }, [enabled]);
+  }, [enabled, locationPathname]);
 
   // ---- working state + polling ---------------------------------------------
 
@@ -811,6 +858,102 @@ export function useAiChat(options: { enabled: boolean }): UseAiChat {
     [isSubmittingApproval, fetchMessages],
   );
 
+  const [isCancelling, setIsCancelling] = useState<boolean>(false);
+
+  const cancelRun: () => Promise<void> =
+    useCallback(async (): Promise<void> => {
+      if (!activeConversationIdRef.current || isCancelling) {
+        return;
+      }
+
+      setIsCancelling(true);
+
+      try {
+        const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+          await API.post<JSONObject>({
+            url: URL.fromString(APP_API_URL.toString() + "/ai-chat/cancel-run"),
+            data: {
+              conversationId: activeConversationIdRef.current,
+            },
+            headers: ModelAPI.getCommonHeaders(),
+          });
+
+        if (response instanceof HTTPErrorResponse) {
+          throw response;
+        }
+
+        if (activeConversationIdRef.current) {
+          await fetchMessages(activeConversationIdRef.current);
+        }
+      } catch (err) {
+        /*
+         * Losing the race is success: if the answer finished in the moment
+         * between clicking Stop and the request landing, the server rejects
+         * the cancel because nothing is running — don't paint an error
+         * banner over a fully rendered answer; just refresh.
+         */
+        const isLostRace: boolean =
+          err instanceof HTTPErrorResponse && err.statusCode === 400;
+        if (!isLostRace) {
+          setError(API.getFriendlyMessage(err));
+        }
+        if (activeConversationIdRef.current) {
+          fetchMessages(activeConversationIdRef.current).catch(() => {
+            // handled in fetchMessages
+          });
+        }
+      }
+
+      setIsCancelling(false);
+      setIsAwaitingResponse(false);
+    }, [isCancelling, fetchMessages]);
+
+  const sendFeedback: (
+    messageId: string,
+    feedback: ChatMessageFeedback | null,
+  ) => Promise<void> = useCallback(
+    async (
+      messageId: string,
+      feedback: ChatMessageFeedback | null,
+    ): Promise<void> => {
+      // Optimistic: flip the thumbs immediately; the poll reconciles later.
+      setMessages((current: Array<AIConversationMessage>) => {
+        return current.map((message: AIConversationMessage) => {
+          if (message.id?.toString() === messageId) {
+            message.userFeedback = feedback || undefined;
+          }
+          return message;
+        });
+      });
+
+      try {
+        const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+          await API.post<JSONObject>({
+            url: URL.fromString(
+              APP_API_URL.toString() + "/ai-chat/message-feedback",
+            ),
+            data: {
+              messageId: messageId,
+              feedback: feedback,
+            },
+            headers: ModelAPI.getCommonHeaders(),
+          });
+
+        if (response instanceof HTTPErrorResponse) {
+          throw response;
+        }
+      } catch (err) {
+        setError(API.getFriendlyMessage(err));
+        if (activeConversationIdRef.current) {
+          fetchMessages(activeConversationIdRef.current).catch(() => {
+            // handled in fetchMessages
+          });
+        }
+      }
+    },
+    [fetchMessages],
+  );
+
   return {
     conversations,
     activeConversationId,
@@ -839,6 +982,9 @@ export function useAiChat(options: { enabled: boolean }): UseAiChat {
     isSubmittingApproval,
     respondToApproval,
     sendMessage,
+    cancelRun,
+    isCancelling,
+    sendFeedback,
     openConversation,
     newConversation,
     deleteConversation,

--- a/App/FeatureSet/Dashboard/src/Components/Header/AskAI.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Header/AskAI.tsx
@@ -9,7 +9,7 @@ const AskAI: () => JSX.Element = (): ReactElement => {
     <HeaderIconDropdownButton
       icon={IconProp.Sparkles}
       name="Ask AI"
-      title="Ask AI"
+      title="Ask AI (Cmd/Ctrl + I)"
       showDropdown={false}
       onClick={() => {
         GlobalEvents.dispatchEvent(EventName.AI_CHAT_TOGGLE);

--- a/App/FeatureSet/Dashboard/src/Pages/AICopilot/AICopilot.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/AICopilot/AICopilot.tsx
@@ -8,15 +8,29 @@ import ChatMessageList from "../../Components/AIChat/ChatMessageList";
 import PageContextChip from "../../Components/AIChat/PageContextChip";
 import ProviderPicker from "../../Components/AIChat/ProviderPicker";
 import PermissionModePicker from "../../Components/AIChat/PermissionModePicker";
-import { useAiChat, UseAiChat } from "../../Components/AIChat/useAiChat";
+import {
+  ChatMessageFeedback,
+  useAiChat,
+  UseAiChat,
+} from "../../Components/AIChat/useAiChat";
+import PageMap from "../../Utils/PageMap";
+import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import AIConversation from "Common/Models/DatabaseModels/AIConversation";
+import Route from "Common/Types/API/Route";
 import OneUptimeDate from "Common/Types/Date";
 import IconProp from "Common/Types/Icon/IconProp";
+import ObjectID from "Common/Types/ObjectID";
 import Icon from "Common/UI/Components/Icon/Icon";
 import Page from "Common/UI/Components/Page/Page";
 import UiAnalytics from "Common/UI/Utils/Analytics";
+import Navigation from "Common/UI/Utils/Navigation";
 import ProjectUtil from "Common/UI/Utils/Project";
-import React, { FunctionComponent, ReactElement, useEffect } from "react";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useEffect,
+  useRef,
+} from "react";
 
 /*
  * Meaningful, non-redundant page header copy. The title is the feature name;
@@ -45,6 +59,60 @@ const AICopilot: FunctionComponent<PageComponentProps> = (): ReactElement => {
       projectId: ProjectUtil.getCurrentProjectId()?.toString() || "",
     });
   }, []);
+
+  /*
+   * Deep link: /ai/chat/:conversationId opens that thread — so a refresh keeps
+   * your place and a conversation can be linked in an incident channel. The
+   * param is read once on mount; rail clicks afterwards sync the URL below.
+   */
+  const didOpenFromUrlRef: React.MutableRefObject<boolean> = useRef(false);
+
+  useEffect(() => {
+    if (didOpenFromUrlRef.current) {
+      return;
+    }
+    didOpenFromUrlRef.current = true;
+
+    const lastParam: string = Navigation.getLastParamAsString();
+    // The bare /ai/chat route ends in "chat" — only a UUID is a conversation.
+    if (lastParam && ObjectID.isValidUUID(lastParam.replace("/", ""))) {
+      chat.openConversation(lastParam.replace("/", ""));
+    }
+  }, []);
+
+  /*
+   * Keep the URL in step with the open thread without remounting the page:
+   * replaceState only rewrites the address bar, so polling and scroll state
+   * survive while refresh/share still land on the right conversation.
+   */
+  const syncUrlToConversation: (conversationId: string | undefined) => void = (
+    conversationId: string | undefined,
+  ): void => {
+    const route: Route = conversationId
+      ? RouteUtil.populateRouteParams(
+          RouteMap[PageMap.AI_COPILOT_CONVERSATION] as Route,
+          { modelId: conversationId },
+        )
+      : RouteUtil.populateRouteParams(RouteMap[PageMap.AI_COPILOT] as Route);
+    window.history.replaceState({}, "", route.toString());
+  };
+
+  /*
+   * Sync on every active-thread change (rail click, first send creating the
+   * conversation, "new chat"). Until a conversation has ever been active,
+   * leave the URL alone so the mount-time deep link isn't clobbered.
+   */
+  const hasHadConversationRef: React.MutableRefObject<boolean> = useRef(false);
+
+  useEffect(() => {
+    if (chat.activeConversationId) {
+      hasHadConversationRef.current = true;
+    }
+    if (!hasHadConversationRef.current) {
+      return;
+    }
+    syncUrlToConversation(chat.activeConversationId);
+  }, [chat.activeConversationId]);
 
   const composerLeading: ReactElement = (
     <div className="flex flex-wrap items-center gap-1.5">
@@ -277,6 +345,14 @@ const AICopilot: FunctionComponent<PageComponentProps> = (): ReactElement => {
                         // handled in the hook
                       });
                   }}
+                  onFeedback={(
+                    messageId: string,
+                    feedback: ChatMessageFeedback | null,
+                  ) => {
+                    chat.sendFeedback(messageId, feedback).catch(() => {
+                      // handled in the hook
+                    });
+                  }}
                 />
 
                 {chat.isWorking && (
@@ -297,6 +373,16 @@ const AICopilot: FunctionComponent<PageComponentProps> = (): ReactElement => {
                 !chat.isSending && !chat.isWorking && !chat.isAwaitingApproval
               }
               isWorking={chat.isWorking}
+              isStopping={chat.isCancelling}
+              onStop={
+                chat.isWorking && !chat.isAwaitingApproval
+                  ? () => {
+                      chat.cancelRun().catch(() => {
+                        // handled in the hook
+                      });
+                    }
+                  : undefined
+              }
               leading={composerLeading}
               contextChip={contextChip}
               onSend={() => {

--- a/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Alerts/View/Index.tsx
@@ -1,4 +1,5 @@
 import ChangeAlertState from "../../../Components/Alert/ChangeState";
+import AskAIButton from "../../../Components/AIChat/AskAIButton";
 import LabelsElement from "Common/UI/Components/Label/Labels";
 import OnCallDutyPoliciesView from "../../../Components/OnCallPolicy/OnCallPolicies";
 import PageComponentProps from "../../PageComponentProps";
@@ -420,6 +421,9 @@ const AlertView: FunctionComponent<PageComponentProps> = (): ReactElement => {
             await fetchData();
           }}
         />
+        <div className="mt-3 flex justify-end">
+          <AskAIButton label="Ask AI about this alert" />
+        </div>
       </div>
 
       <div className="grid grid-cols-1 items-start gap-6 xl:grid-cols-3">

--- a/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Incidents/View/Index.tsx
@@ -55,6 +55,7 @@ import RemediationSuggestionCard from "../../../Components/AutoRemediation/Remed
 import IncidentAffectedResources from "./AffectedResources";
 import MonitorSummarySnapshotCard from "../../../Components/Monitor/MonitorSummarySnapshotCard";
 import IncidentMemberRoleAssignment from "../../../Components/Incident/IncidentMemberRoleAssignment";
+import AskAIButton from "../../../Components/AIChat/AskAIButton";
 import EventStatTile from "../../../Components/EventView/EventStatTile";
 import Monitor from "Common/Models/DatabaseModels/Monitor";
 import DockerHost from "Common/Models/DatabaseModels/DockerHost";
@@ -475,6 +476,9 @@ const IncidentView: FunctionComponent<
             await fetchData();
           }}
         />
+        <div className="mt-3 flex justify-end">
+          <AskAIButton label="Ask AI about this incident" />
+        </div>
       </div>
 
       <div className="grid grid-cols-1 items-start gap-6 xl:grid-cols-3">

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/View/Index.tsx
@@ -1,6 +1,7 @@
 import LabelsElement from "Common/UI/Components/Label/Labels";
 import DependencySuppressionWarning from "../../../Components/Monitor/DependencySuppressionWarning";
 import DisabledWarning from "../../../Components/Monitor/DisabledWarning";
+import AskAIButton from "../../../Components/AIChat/AskAIButton";
 import IncomingMonitorLink from "../../../Components/Monitor/IncomingRequestMonitor/IncomingMonitorLink";
 import IncomingEmailMonitorLink from "../../../Components/Monitor/IncomingEmailMonitor/IncomingEmailMonitorLink";
 import ServerMonitorDocumentation from "../../../Components/Monitor/ServerMonitor/Documentation";
@@ -509,6 +510,9 @@ const MonitorView: FunctionComponent<PageComponentProps> = (): ReactElement => {
 
   return (
     <Fragment>
+      <div className="mb-4 flex justify-end">
+        <AskAIButton label="Ask AI about this monitor" />
+      </div>
       {monitor && monitor.isAllProbesDisconnectedFromThisMonitor && (
         <Alert
           type={AlertType.DANGER}

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/LlmProviderView.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/LlmProviderView.tsx
@@ -148,9 +148,9 @@ const LlmProviderView: FunctionComponent<PageComponentProps> = (
             stepId: "provider-settings",
             fieldType: FormFieldSchemaType.Text,
             required: false,
-            placeholder: "gpt-4o, claude-3-opus, llama-3.3-70b-versatile",
+            placeholder: "gpt-5.1, claude-sonnet-5, llama-3.3-70b-versatile",
             description:
-              "The specific model or deployment name to use (e.g., gpt-4o for OpenAI, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq, mistral-large-latest for Mistral). Required for OpenAI-compatible providers — it must match a model your server exposes.",
+              "The specific model or deployment name to use (e.g., gpt-5.1 for OpenAI, claude-sonnet-5 for Anthropic, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq, mistral-large-latest for Mistral). Required for OpenAI-compatible providers — it must match a model your server exposes.",
           },
           {
             field: {

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/LlmProviders.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/LlmProviders.tsx
@@ -353,9 +353,9 @@ const LlmPage: FunctionComponent<PageComponentProps> = (): ReactElement => {
               stepId: "provider-settings",
               fieldType: FormFieldSchemaType.Text,
               required: false,
-              placeholder: "gpt-4o, claude-3-opus, llama-3.3-70b-versatile",
+              placeholder: "gpt-5.1, claude-sonnet-5, llama-3.3-70b-versatile",
               description:
-                "The specific model or deployment name to use (e.g., gpt-4o for OpenAI, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq, mistral-large-latest for Mistral). Required for OpenAI-compatible providers — it must match a model your server exposes.",
+                "The specific model or deployment name to use (e.g., gpt-5.1 for OpenAI, claude-sonnet-5 for Anthropic, your deployment name for Azure OpenAI, llama-3.3-70b-versatile for Groq, mistral-large-latest for Mistral). Required for OpenAI-compatible providers — it must match a model your server exposes.",
             },
             {
               field: {

--- a/App/FeatureSet/Dashboard/src/Utils/PageMap.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/PageMap.ts
@@ -985,6 +985,8 @@ enum PageMap {
 
   // AI Copilot (full-page chat over observability data)
   AI_COPILOT = "AI_COPILOT",
+  // Same page, deep-linked to one conversation (shareable/bookmarkable).
+  AI_COPILOT_CONVERSATION = "AI_COPILOT_CONVERSATION",
 
   // Push Logs in resource views
 }

--- a/App/FeatureSet/Dashboard/src/Utils/RouteMap.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/RouteMap.ts
@@ -5487,6 +5487,10 @@ const RouteMap: Dictionary<Route> = {
     `/dashboard/${RouteParams.ProjectID}/ai/chat`,
   ),
 
+  [PageMap.AI_COPILOT_CONVERSATION]: new Route(
+    `/dashboard/${RouteParams.ProjectID}/ai/chat/${RouteParams.ModelID}`,
+  ),
+
   [PageMap.LLM]: new Route(
     `/dashboard/${RouteParams.ProjectID}/llm/${LlmRoutePath[PageMap.LLM]}`,
   ),

--- a/App/FeatureSet/Docs/Content/en/ai/ask-ai.md
+++ b/App/FeatureSet/Docs/Content/en/ai/ask-ai.md
@@ -1,0 +1,39 @@
+# Ask AI — The Observability Copilot
+
+Ask AI is OneUptime's built-in chat over your project's data. It answers questions about logs, traces, metrics, exceptions, incidents, alerts, monitors, on-call, status pages, SLOs, runbooks, workflows and probes — and it can act (create incidents, acknowledge alerts, page on-call, post notes, open pull requests) with your approval. Every factual claim in an answer is backed by a citation chip showing the exact query it ran.
+
+Open it from the **Ask AI** sparkles button in the header, with **Cmd/Ctrl + I** from anywhere in the dashboard, or with the **Ask AI** button on incident, alert and monitor pages. There is also a full-page workspace under **AI** > **Chat**; each conversation there has its own URL, so a thread can be bookmarked or pasted into an incident channel.
+
+## What it can see
+
+Ask AI answers only from tool results — it queries your project live rather than answering from memory. Its read tools cover:
+
+- **Telemetry**: log search and histograms, trace aggregations and span trees, metrics, exceptions, and anomaly checks against learned baselines.
+- **Incident response**: incidents and alerts (including state filters — "what is active right now?"), their full activity timelines (state changes, internal and public notes, feed), owners, and free-text search over past incidents to reuse prior resolutions.
+- **On-call**: who is on call right now, policies and escalation chains, and whether recent pages were delivered and acknowledged.
+- **The AI's own work**: the results of autonomous AI SRE investigations and AI Insights, so "what did the AI find?" is answered from the posted analysis instead of re-derived from scratch.
+- **Platform**: monitors (with status filters), status pages and their subscribers, SLOs, runbook content, workflow runs, probe health, teams, and connected code repositories.
+
+## Page context
+
+Ask AI knows what page you opened it from. On an incident page, "why did this happen?" means that incident — the composer shows a context chip you can detach. If you navigate to another page while the panel is open, the context follows you. The conversation also remembers its original subject server-side, so follow-up turns keep resolving "this incident" even days later.
+
+## Actions and permission modes
+
+Every conversation has a permission mode:
+
+- **Read-only** — action tools are withheld entirely; the AI can only query.
+- **Ask for approval** (default) — the AI proposes an action and you approve or deny each one on an approval card before it runs.
+- **Auto-run** — actions the model requests run immediately. Use with care.
+
+Actions include creating incidents, acknowledging/resolving incidents and alerts, changing severity, posting **internal** notes (never visible on status pages), posting public status-page updates (clearly separate, since those notify subscribers), paging an on-call policy, running runbooks, starting an autonomous investigation, and proposing code changes as pull requests.
+
+## Steering a conversation
+
+- **Stop**: while the AI is investigating, the send button becomes a stop button — cancel a run at any time and ask something else immediately.
+- **Feedback**: rate any answer with thumbs up/down. Ratings are stored with the message so answer quality can be measured over time.
+- **Cost**: each answer's footer shows tokens, cost, and how many queries were run, and every query is listed as a citation chip that deep-links to the underlying data.
+
+## Requirements
+
+Ask AI uses your project's configured LLM provider (see [LLM Providers](/docs/ai/llm-provider)). On OneUptime Cloud it works out of the box with metered AI tokens; self-hosted deployments configure a provider or the global provider environment variables. Answers are only as good as the model behind them — small self-hosted models without reliable tool-calling will underperform.

--- a/App/FeatureSet/Docs/Content/en/ai/llm-provider.md
+++ b/App/FeatureSet/Docs/Content/en/ai/llm-provider.md
@@ -36,7 +36,7 @@ On a self-hosted instance, the fastest way to enable AI features for **every pro
 ```bash
 GLOBAL_LLM_PROVIDER_TYPE=Ollama
 GLOBAL_LLM_PROVIDER_BASE_URL=http://your-ollama-host:11434
-GLOBAL_LLM_PROVIDER_MODEL_NAME=llama3
+GLOBAL_LLM_PROVIDER_MODEL_NAME=llama3.1
 # No API key needed — Ollama is keyless.
 ```
 
@@ -45,7 +45,7 @@ GLOBAL_LLM_PROVIDER_MODEL_NAME=llama3
 ```bash
 GLOBAL_LLM_PROVIDER_TYPE=OpenAI
 GLOBAL_LLM_PROVIDER_API_KEY=sk-xxxxxxxxxxxxxxxxxxxx
-GLOBAL_LLM_PROVIDER_MODEL_NAME=gpt-4o
+GLOBAL_LLM_PROVIDER_MODEL_NAME=gpt-5.1
 ```
 
 The sync is declarative: changing the variables updates the provider on the next restart, and unsetting `GLOBAL_LLM_PROVIDER_TYPE` removes it. Global providers created manually in the Admin Dashboard are never touched. Projects can still add their own provider under **Project Settings** > **AI** > **LLM Providers** — a project-owned provider always takes precedence over the global one.
@@ -54,15 +54,15 @@ The sync is declarative: changing the variables updates the provider on the next
 
 OneUptime currently supports the following LLM providers:
 
-| Provider              | Description                                                             | API Key Required | Base URL Required |
-| --------------------- | ----------------------------------------------------------------------- | ---------------- | ----------------- |
-| **OpenAI**            | GPT-4, GPT-4o, GPT-3.5 Turbo, and other OpenAI models                   | Yes              | No (uses default) |
-| **Azure OpenAI**      | OpenAI models hosted on your Azure deployment                           | Yes              | Yes               |
-| **Anthropic**         | Claude 3 Opus, Claude 3 Sonnet, Claude 3 Haiku, and other Claude models | Yes              | No (uses default) |
-| **Groq**              | Fast inference for Llama, Mixtral, and other open models                | Yes              | No (uses default) |
-| **Mistral**           | Mistral's hosted models                                                 | Yes              | No (uses default) |
-| **Ollama**            | Self-hosted open-source models like Llama 2, Mistral, CodeLlama, etc.   | No               | Yes               |
-| **OpenAI Compatible** | Any OpenAI-compatible server (vLLM, LocalAI, LM Studio, etc.)           | No (optional)    | Yes               |
+| Provider              | Description                                                                  | API Key Required | Base URL Required |
+| --------------------- | ---------------------------------------------------------------------------- | ---------------- | ----------------- |
+| **OpenAI**            | GPT-5.1 and other OpenAI models                                              | Yes              | No (uses default) |
+| **Azure OpenAI**      | OpenAI models hosted on your Azure deployment                                | Yes              | Yes               |
+| **Anthropic**         | Claude Sonnet 5, Claude Opus 5, Claude Haiku 4.5, and other Claude models    | Yes              | No (uses default) |
+| **Groq**              | Fast inference for Llama, Mixtral, and other open models                     | Yes              | No (uses default) |
+| **Mistral**           | Mistral's hosted models                                                      | Yes              | No (uses default) |
+| **Ollama**            | Self-hosted open-source models like Llama 3.1, Mistral, Qwen, etc.           | No               | Yes               |
+| **OpenAI Compatible** | Any OpenAI-compatible server (vLLM, LocalAI, LM Studio, etc.)                | No (optional)    | Yes               |
 
 ## Setting Up an LLM Provider
 
@@ -80,7 +80,7 @@ Fill in the following fields:
 - **Description** (optional): A description to help identify the purpose of this provider
 - **LLM Provider**: Select the provider type (OpenAI, Azure OpenAI, Anthropic, Groq, Mistral, Ollama, or OpenAI Compatible)
 - **API Key**: Your API key (required for OpenAI, Azure OpenAI, Anthropic, Groq, and Mistral; optional for Ollama and OpenAI-compatible servers)
-- **Model Name**: The specific model to use (e.g., `gpt-4o`, `claude-3-opus-20240229`, `llama2`)
+- **Model Name**: The specific model to use (e.g., `gpt-5.1`, `claude-sonnet-5`, `llama3.1`)
 - **Base URL** (optional): Custom API endpoint URL (required for Azure OpenAI, Ollama, and OpenAI Compatible; optional for others)
 
 ## Provider-Specific Configuration
@@ -91,10 +91,8 @@ Fill in the following fields:
 2. Select **OpenAI** as the LLM Provider
 3. Enter your API key
 4. Choose a model name:
-   - `gpt-4o` - Most capable model, best for complex tasks
-   - `gpt-4o-mini` - Faster and more cost-effective
-   - `gpt-4-turbo` - Good balance of capability and speed
-   - `gpt-3.5-turbo` - Fast and economical
+   - `gpt-5.1` - Recommended default, strong at tool-calling and complex investigations
+   - `gpt-5.1-mini` - Faster and more cost-effective
 
 **Example Configuration:**
 
@@ -102,7 +100,7 @@ Fill in the following fields:
 Name: Production OpenAI
 LLM Provider: OpenAI
 API Key: sk-xxxxxxxxxxxxxxxxxxxx
-Model Name: gpt-4o
+Model Name: gpt-5.1
 ```
 
 ### Anthropic
@@ -111,10 +109,9 @@ Model Name: gpt-4o
 2. Select **Anthropic** as the LLM Provider
 3. Enter your API key
 4. Choose a model name:
-   - `claude-3-opus-20240229` - Most capable model
-   - `claude-3-sonnet-20240229` - Good balance of intelligence and speed
-   - `claude-3-haiku-20240307` - Fastest and most compact
-   - `claude-3-5-sonnet-20241022` - Latest Sonnet model
+   - `claude-sonnet-5` - Recommended default, best balance of intelligence, speed, and cost
+   - `claude-opus-5` - Most capable model, for the hardest investigations
+   - `claude-haiku-4-5` - Fastest and most cost-effective
 
 **Example Configuration:**
 
@@ -122,7 +119,7 @@ Model Name: gpt-4o
 Name: Production Anthropic
 LLM Provider: Anthropic
 API Key: sk-ant-xxxxxxxxxxxxxxxxxxxx
-Model Name: claude-3-5-sonnet-20241022
+Model Name: claude-sonnet-5
 ```
 
 ### Ollama (Self-Hosted)
@@ -130,7 +127,7 @@ Model Name: claude-3-5-sonnet-20241022
 Ollama allows you to run open-source LLMs locally or on your own infrastructure.
 
 1. Install Ollama from [ollama.ai](https://ollama.ai)
-2. Pull your desired model: `ollama pull llama2`
+2. Pull your desired model: `ollama pull llama3.1`
 3. Ensure Ollama is running and accessible
 4. Select **Ollama** as the LLM Provider
 5. Enter the Base URL (e.g., `http://localhost:11434`)
@@ -142,16 +139,17 @@ Ollama allows you to run open-source LLMs locally or on your own infrastructure.
 Name: Local Ollama
 LLM Provider: Ollama
 Base URL: http://localhost:11434
-Model Name: llama2
+Model Name: llama3.1
 ```
 
 **Popular Ollama Models:**
 
-- `llama2` - Meta's Llama 2 model
-- `llama3` - Meta's Llama 3 model
-- `mistral` - Mistral AI's model
-- `codellama` - Code-specialized Llama model
-- `mixtral` - Mistral's mixture of experts model
+- `llama3.1` - Meta's Llama 3.1 model, the oldest Llama with tool-calling support
+- `llama3.3` - Meta's Llama 3.3 model
+- `qwen2.5` - Alibaba's Qwen 2.5 model
+- `mistral-nemo` - Mistral AI's Nemo model
+
+> Note: OneUptime's AI features are agentic — they rely heavily on tool calling. Use `llama3.1` or newer (or another tool-calling-capable model). Small models or models without tool-calling support (e.g. `llama2`, the original `llama3`) produce poor results: they cannot query your monitors, incidents, or telemetry, so investigations come back empty or hallucinated.
 
 ### OpenAI Compatible (vLLM, LocalAI, LM Studio, etc.)
 
@@ -219,7 +217,7 @@ For enterprise deployments or when using proxy services, you can specify a custo
 
 ## Best Practices
 
-1. **Use descriptive names**: Name your providers clearly (e.g., "Production GPT-4", "Development Ollama")
+1. **Use descriptive names**: Name your providers clearly (e.g., "Production OpenAI", "Development Ollama")
 2. **Secure your API keys**: API keys are encrypted at rest, but avoid sharing them
 3. **Test your configuration**: After setting up, verify the provider works with AI features
 4. **Monitor usage**: Keep track of API usage to manage costs

--- a/App/FeatureSet/Docs/Utils/Nav.ts
+++ b/App/FeatureSet/Docs/Utils/Nav.ts
@@ -662,6 +662,7 @@ const DocsNav: NavGroup[] = [
   {
     title: "AI",
     links: [
+      { title: "Ask AI", url: "/docs/ai/ask-ai" },
       { title: "AI SRE", url: "/docs/ai/ai-sre" },
       { title: "Fix Tasks", url: "/docs/ai/ai-agent" },
       { title: "LLM Providers", url: "/docs/ai/llm-provider" },

--- a/Common/Models/DatabaseModels/AIConversation.ts
+++ b/Common/Models/DatabaseModels/AIConversation.ts
@@ -18,6 +18,7 @@ import ObjectID from "../../Types/ObjectID";
 import Permission from "../../Types/Permission";
 import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 import EnableDocumentation from "../../Types/Database/EnableDocumentation";
+import { AIChatPageContext } from "../../Types/AI/AIChatPageContext";
 
 /*
  * A conversation between a user and the OneUptime AI about the project's
@@ -234,6 +235,37 @@ export default class AIConversation extends BaseModel {
     length: ColumnLength.ShortText,
   })
   public permissionMode?: string = undefined;
+
+  /*
+   * The conversation's subject: the dashboard page (usually one specific
+   * entity, e.g. an incident) the user was looking at when the conversation
+   * started. ChatAgentRunner persists it from the first turn that carries a
+   * sanitized page context and falls back to it on later turns that arrive
+   * without one, so "this incident" keeps resolving after the user navigates
+   * away. Written only by the server (never member-writable through CRUD),
+   * so it cannot be forged to point at another project's entity.
+   */
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.JSON,
+    title: "Page Context",
+    description:
+      "The dashboard page (entity) this conversation is about. Set from the first message that carried a page context.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.JSON,
+  })
+  public pageContext?: AIChatPageContext = undefined;
 
   @ColumnAccessControl({
     create: [],

--- a/Common/Models/DatabaseModels/AIConversationMessage.ts
+++ b/Common/Models/DatabaseModels/AIConversationMessage.ts
@@ -28,6 +28,18 @@ import {
 } from "../../Types/AI/AIChatTypes";
 
 /*
+ * Thumbs feedback the user can leave on an assistant message via
+ * POST /ai-chat/message-feedback. Stored as the enum's string value in a
+ * ShortText column, the same shape as `role` and `status`. Declared here
+ * (not in Types/AI) because it is a property of this row, not a shared
+ * chat-protocol concept.
+ */
+export enum AIConversationMessageFeedback {
+  Up = "Up",
+  Down = "Down",
+}
+
+/*
  * A single message in an AI conversation. Create/update table permissions are
  * deliberately EMPTY: only the server (isRoot) writes message rows. This
  * prevents project members from forging assistant messages with fabricated
@@ -415,6 +427,35 @@ export default class AIConversationMessage extends BaseModel {
     length: ColumnLength.LongText,
   })
   public errorMessage?: string = undefined;
+
+  /*
+   * Update ACL is empty like every other column: feedback is written only by
+   * the server through POST /ai-chat/message-feedback, which verifies the
+   * requesting user owns the conversation and the message is assistant-role.
+   * Null means no feedback has been left (or it was cleared).
+   */
+  @ColumnAccessControl({
+    create: [],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+    ],
+    update: [],
+  })
+  @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    title: "User Feedback",
+    description:
+      "Thumbs feedback the user left on this assistant message: Up or Down.",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public userFeedback?: AIConversationMessageFeedback = undefined;
 
   @ColumnAccessControl({
     create: [],

--- a/Common/Server/API/AIChatAPI.ts
+++ b/Common/Server/API/AIChatAPI.ts
@@ -33,14 +33,19 @@ import {
   AIChatToolActionStatus,
 } from "../../Types/AI/AIChatTypes";
 import { JSONArray, JSONObject } from "../../Types/JSON";
+import AIRunEventType from "../../Types/AI/AIRunEventType";
 import AIRunStatus from "../../Types/AI/AIRunStatus";
 import AIRunType from "../../Types/AI/AIRunType";
 import AIConversation from "../../Models/DatabaseModels/AIConversation";
-import AIConversationMessage from "../../Models/DatabaseModels/AIConversationMessage";
+import AIConversationMessage, {
+  AIConversationMessageFeedback,
+} from "../../Models/DatabaseModels/AIConversationMessage";
 import AIRun from "../../Models/DatabaseModels/AIRun";
+import AIRunEvent from "../../Models/DatabaseModels/AIRunEvent";
 import Project from "../../Models/DatabaseModels/Project";
 import AIConversationService from "../Services/AIConversationService";
 import AIConversationMessageService from "../Services/AIConversationMessageService";
+import AIRunEventService from "../Services/AIRunEventService";
 import AIRunService from "../Services/AIRunService";
 import ProjectService from "../Services/ProjectService";
 import LlmProviderService from "../Services/LlmProviderService";
@@ -53,6 +58,16 @@ import logger from "../Utils/Logger";
 
 const MAX_USER_MESSAGE_LENGTH: number = 8000;
 const MAX_CONCURRENT_RUNS_PER_PROJECT: number = 3;
+
+// Final message content and run error for a turn the user stopped.
+const STOPPED_BY_USER_TEXT: string = "Stopped by user.";
+
+/*
+ * Cancel's terminal event must sort after every progress event the runner
+ * emitted — same convention as the runner's own failure finalizer, which
+ * starts its event sequence at 100000.
+ */
+const CANCEL_EVENT_SEQUENCE: number = 100000;
 
 const router: ExpressRouter = Express.getRouter();
 
@@ -697,6 +712,305 @@ router.post(
         conversationId: conversationId.toString(),
         assistantMessageId: assistantMessageId.toString(),
         aiRunId: message.aiRunId.toString(),
+      });
+      return;
+    } catch (err) {
+      next(err);
+      return;
+    }
+  },
+);
+
+/*
+ * Stops the conversation's in-flight turn. Flips the active run to Cancelled,
+ * finalizes the in-flight assistant message as "Stopped by user." and emits a
+ * terminal run event so the polling UI sees closure. Every write is guarded on
+ * the row's current status, so racing the runner is safe: whichever side
+ * finalizes first wins and the loser's write matches zero rows (the runner
+ * also checks for cancellation cooperatively between its steps). Cancelling
+ * the run is also what releases the conversation for the next send —
+ * send-message's governor only blocks on Running/WaitingForApproval runs.
+ */
+router.post(
+  "/ai-chat/cancel-run",
+  UserMiddleware.getUserMiddleware,
+  async (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const props: DatabaseCommonInteractionProps =
+        await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+      if (!props.userId) {
+        throw new NotAuthorizedException(
+          "AI chat requires a logged-in user session.",
+        );
+      }
+
+      if (!props.tenantId) {
+        throw new BadDataException("Project ID is required (tenantid header).");
+      }
+
+      const projectId: ObjectID = props.tenantId;
+      const userId: ObjectID = props.userId;
+
+      const conversationIdString: string = req.body["conversationId"] as string;
+
+      if (!conversationIdString) {
+        throw new BadDataException("conversationId is required.");
+      }
+
+      const conversationId: ObjectID = new ObjectID(conversationIdString);
+
+      // The privacy pin makes this return null for other users' rows.
+      const conversation: AIConversation | null =
+        await AIConversationService.findOneById({
+          id: conversationId,
+          select: { _id: true },
+          props: props,
+        });
+
+      if (!conversation) {
+        throw new BadDataException("Conversation not found.");
+      }
+
+      /*
+       * The conversation's live run: actively generating (Running) or paused
+       * for the user's approval (WaitingForApproval). The per-conversation
+       * governor allows at most one, so no sort is needed.
+       */
+      const activeRun: AIRun | null = await AIRunService.findOneBy({
+        query: {
+          conversationId: conversationId,
+          projectId: projectId,
+          status: QueryHelper.any([
+            AIRunStatus.Running,
+            AIRunStatus.WaitingForApproval,
+          ]),
+        },
+        select: { _id: true },
+        props: { isRoot: true },
+      });
+
+      if (!activeRun) {
+        throw new BadDataException(
+          "No response is being generated in this conversation.",
+        );
+      }
+
+      /*
+       * Status-guarded finalization, the same shape as the runner's own
+       * finalizer: only a still-in-flight run is flipped, so a run the runner
+       * completed (or errored) inside the race window is never overwritten.
+       * updateOneBy returns the matched-row count — zero from both guards
+       * means the other side won and already wrote the final state.
+       */
+      let cancelledRunCount: number = 0;
+
+      for (const inFlightRunStatus of [
+        AIRunStatus.Running,
+        AIRunStatus.WaitingForApproval,
+      ]) {
+        cancelledRunCount += await AIRunService.updateOneBy({
+          query: {
+            _id: activeRun.id!.toString(),
+            status: inFlightRunStatus,
+          },
+          data: {
+            status: AIRunStatus.Cancelled,
+            completedAt: OneUptimeDate.getCurrentDate(),
+            errorMessage: STOPPED_BY_USER_TEXT,
+            // A cancelled turn must never be resumable.
+            pausedState: null,
+          } as never,
+          props: { isRoot: true },
+        });
+      }
+
+      /*
+       * Finalize the run's in-flight assistant message the same guarded way:
+       * a message another path already finalized — completed with its full
+       * answer, or errored — keeps what it has.
+       */
+      for (const inFlightMessageStatus of [
+        AIChatMessageStatus.InProgress,
+        AIChatMessageStatus.WaitingForApproval,
+      ]) {
+        await AIConversationMessageService.updateOneBy({
+          query: {
+            aiRunId: activeRun.id!,
+            status: inFlightMessageStatus,
+          },
+          data: {
+            status: AIChatMessageStatus.Cancelled,
+            contentInMarkdown: STOPPED_BY_USER_TEXT,
+          } as never,
+          props: { isRoot: true },
+        });
+      }
+
+      /*
+       * Terminal event, only when this request actually took the run —
+       * emitting closure over a turn the runner finished would tell the UI a
+       * completed answer failed. RunFailed is the event enum's terminal
+       * "did not finish" member; the summary carries the human reason.
+       */
+      if (cancelledRunCount > 0) {
+        try {
+          const cancelEvent: AIRunEvent = new AIRunEvent();
+          cancelEvent.projectId = projectId;
+          cancelEvent.aiRunId = activeRun.id!;
+          cancelEvent.userId = userId;
+          cancelEvent.sequence = CANCEL_EVENT_SEQUENCE;
+          cancelEvent.eventType = AIRunEventType.RunFailed;
+          cancelEvent.resultSummary = { errorMessage: STOPPED_BY_USER_TEXT };
+
+          await AIRunEventService.create({
+            data: cancelEvent,
+            props: { isRoot: true },
+          });
+        } catch (error) {
+          // Events are progress telemetry — never fail the cancel over them.
+          logger.error(
+            `Failed to emit AI chat cancel event: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+
+      Response.sendJsonObjectResponse(req, res, {
+        conversationId: conversationId.toString(),
+        aiRunId: activeRun.id!.toString(),
+        cancelled: cancelledRunCount > 0,
+      });
+      return;
+    } catch (err) {
+      next(err);
+      return;
+    }
+  },
+);
+
+/*
+ * Stores thumbs feedback on an assistant message (or clears it with null).
+ * Ownership is enforced the same way as the other routes: the message AND its
+ * conversation must resolve under the requesting user's props (the privacy
+ * pin returns null for other users' rows), and only assistant-role messages
+ * accept feedback. Persistence only — no analytics pipeline yet.
+ */
+router.post(
+  "/ai-chat/message-feedback",
+  UserMiddleware.getUserMiddleware,
+  async (
+    req: ExpressRequest,
+    res: ExpressResponse,
+    next: NextFunction,
+  ): Promise<void> => {
+    try {
+      const props: DatabaseCommonInteractionProps =
+        await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+      if (!props.userId) {
+        throw new NotAuthorizedException(
+          "AI chat requires a logged-in user session.",
+        );
+      }
+
+      if (!props.tenantId) {
+        throw new BadDataException("Project ID is required (tenantid header).");
+      }
+
+      const messageIdString: string = req.body["messageId"] as string;
+
+      if (!messageIdString) {
+        throw new BadDataException("messageId is required.");
+      }
+
+      const messageId: ObjectID = new ObjectID(messageIdString);
+
+      /*
+       * Validate before any read: feedback is exactly "Up", "Down" or null
+       * (null clears). Anything else — including a missing key — is a bad
+       * request, never silently coerced.
+       */
+      if (!("feedback" in (req.body as JSONObject))) {
+        throw new BadDataException(
+          'feedback is required: "Up", "Down" or null (null clears feedback).',
+        );
+      }
+
+      const rawFeedback: string | null | undefined = req.body["feedback"] as
+        | string
+        | null
+        | undefined;
+
+      let feedback: AIConversationMessageFeedback | null = null;
+
+      if (rawFeedback !== null && rawFeedback !== undefined) {
+        if (
+          rawFeedback !== AIConversationMessageFeedback.Up &&
+          rawFeedback !== AIConversationMessageFeedback.Down
+        ) {
+          throw new BadDataException(
+            'feedback must be "Up", "Down" or null (null clears feedback).',
+          );
+        }
+
+        feedback = rawFeedback as AIConversationMessageFeedback;
+      }
+
+      // The privacy pin makes this return null for other users' rows.
+      const message: AIConversationMessage | null =
+        await AIConversationMessageService.findOneById({
+          id: messageId,
+          select: {
+            _id: true,
+            conversationId: true,
+            role: true,
+          },
+          props: props,
+        });
+
+      if (!message || !message.conversationId) {
+        throw new BadDataException("Message not found.");
+      }
+
+      /*
+       * Belt and braces, matching respond-to-approval: the message's
+       * conversation must also resolve under this user's props.
+       */
+      const conversation: AIConversation | null =
+        await AIConversationService.findOneById({
+          id: message.conversationId,
+          select: { _id: true },
+          props: props,
+        });
+
+      if (!conversation) {
+        throw new BadDataException("Message not found.");
+      }
+
+      if (message.role !== AIChatMessageRole.Assistant) {
+        throw new BadDataException(
+          "Feedback can only be left on assistant messages.",
+        );
+      }
+
+      // Root write: message columns are deliberately not user-writable.
+      await AIConversationMessageService.updateOneById({
+        id: messageId,
+        data: {
+          userFeedback: feedback,
+        } as never,
+        props: { isRoot: true },
+      });
+
+      Response.sendJsonObjectResponse(req, res, {
+        messageId: messageId.toString(),
+        feedback: feedback,
       });
       return;
     } catch (err) {

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787100000000-AddAIConversationPageContext.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787100000000-AddAIConversationPageContext.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * AIConversation.pageContext: the conversation's subject — the dashboard page
+ * (usually one specific entity, e.g. an incident) the user was looking at
+ * when the conversation started. ChatAgentRunner persists it from the first
+ * turn that carries a sanitized page context, and turns that arrive without
+ * one fall back to it, so "this incident" keeps resolving after the user
+ * navigates away mid-conversation.
+ *
+ * Hand-written rather than emitted by `npm run generate-postgres-migration`.
+ * The generator diffs the entire entity set against the live database, and
+ * several models in this worktree are being changed in parallel, so a
+ * generated file would have swept up unrelated in-flight columns. The
+ * statement below is exactly what the generator produces for a nullable JSON
+ * column — compare "widgets" and "pausedState" in
+ * 1783453297388-AddAIChatWriteActionsAndWidgets.
+ *
+ * Nullable with no default: a conversation without a pinned subject is the
+ * normal state (the user opened Ask AI from nowhere in particular), and every
+ * pre-existing conversation is exactly that.
+ */
+export class AddAIConversationPageContext1787100000000
+  implements MigrationInterface
+{
+  public name: string = "AddAIConversationPageContext1787100000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "AIConversation" ADD "pageContext" jsonb`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "AIConversation" DROP COLUMN "pageContext"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787200000000-AddAIChatMessageFeedback.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787200000000-AddAIChatMessageFeedback.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * AIConversationMessage.userFeedback: thumbs feedback ("Up" | "Down") the user
+ * left on an assistant message via POST /ai-chat/message-feedback. Nullable
+ * with no default — no feedback is the normal state, and every pre-existing
+ * message is exactly that. Clearing feedback writes NULL back.
+ *
+ * Hand-written rather than emitted by `npm run generate-postgres-migration`.
+ * The generator diffs the entire entity set against the live database, and
+ * several models in this worktree are being changed in parallel, so a
+ * generated file would have swept up unrelated in-flight columns. The
+ * statement below is exactly what the generator produces for a nullable
+ * ShortText column (ColumnLength.ShortText = 100) — compare "analysisTldr" in
+ * 1786600000000-AddInvestigationAnalysisTldr for the varchar shape.
+ */
+export class AddAIChatMessageFeedback1787200000000
+  implements MigrationInterface
+{
+  public name: string = "AddAIChatMessageFeedback1787200000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "AIConversationMessage" ADD "userFeedback" character varying(100)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "AIConversationMessage" DROP COLUMN "userFeedback"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -524,6 +524,8 @@ import { AddNetworkDeviceLink1786634985763 } from "./1786634985763-AddNetworkDev
 import { AddNetworkDeviceLinkRule1786639512056 } from "./1786639512056-AddNetworkDeviceLinkRule";
 import { AddNetworkTopologySuppression1786639972982 } from "./1786639972982-AddNetworkTopologySuppression";
 import { AddOnCallNotificationFallbackColumns1787000000000 } from "./1787000000000-AddOnCallNotificationFallbackColumns";
+import { AddAIConversationPageContext1787100000000 } from "./1787100000000-AddAIConversationPageContext";
+import { AddAIChatMessageFeedback1787200000000 } from "./1787200000000-AddAIChatMessageFeedback";
 
 export default [
   InitialMigration,
@@ -1052,4 +1054,6 @@ export default [
   RenameTelemetryEntityToInventoryItem1786800000000,
   AddInventoryItemArchiveAndCustomFields1786900000000,
   AddOnCallNotificationFallbackColumns1787000000000,
+  AddAIConversationPageContext1787100000000,
+  AddAIChatMessageFeedback1787200000000,
 ];

--- a/Common/Server/Services/AIService.ts
+++ b/Common/Server/Services/AIService.ts
@@ -323,6 +323,12 @@ export interface AILogRequest {
 export interface AILogResponse {
   content: string;
   toolCalls?: Array<LLMToolCall> | undefined;
+  /*
+   * Why generation stopped, straight from the provider: "length" means the
+   * output hit the token cap, so callers can surface truncation instead of
+   * presenting a cut-off answer as complete.
+   */
+  stopReason?: LLMCompletionResponse["stopReason"];
   llmLog: LlmLog;
 }
 
@@ -705,6 +711,7 @@ export class Service extends BaseService {
       return {
         content: response.content,
         toolCalls: response.toolCalls,
+        stopReason: response.stopReason,
         llmLog: savedLog,
       };
     } catch (error) {

--- a/Common/Server/Utils/AI/Chat/ChatAgentRunner.ts
+++ b/Common/Server/Utils/AI/Chat/ChatAgentRunner.ts
@@ -1,6 +1,8 @@
+import AIConversation from "../../../../Models/DatabaseModels/AIConversation";
 import AIConversationMessage from "../../../../Models/DatabaseModels/AIConversationMessage";
 import AIRun from "../../../../Models/DatabaseModels/AIRun";
 import DatabaseCommonInteractionProps from "../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import PositiveNumber from "../../../../Types/PositiveNumber";
 import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
 import OneUptimeDate from "../../../../Types/Date";
 import { JSONObject } from "../../../../Types/JSON";
@@ -47,8 +49,12 @@ export interface ChatTurnRequest {
   /*
    * What the user was looking at in the dashboard when they sent this message
    * (already sanitized by the API). Folded into the system prompt so "this
-   * incident" resolves to the entity on screen. Per-turn: not persisted, and
-   * not needed on resume (the paused state already contains the built prompt).
+   * incident" resolves to the entity on screen. The first turn that carries
+   * one persists it to AIConversation.pageContext as the conversation's
+   * subject; later turns that arrive without a page context (the user
+   * navigated away mid-conversation) fall back to that persisted subject so
+   * "this incident" keeps resolving. Not needed on resume (the paused state
+   * already contains the built prompt).
    */
   pageContext?: AIChatPageContext | undefined;
   // The requesting user's real permission props, captured at request time.
@@ -69,7 +75,27 @@ const MAX_HISTORY_MESSAGES: number = 20;
 const MAX_OUTPUT_TOKENS: number = 4096;
 const TEMPERATURE: number = 0.2;
 
+/*
+ * Replayed history is bounded twice: by row count (MAX_HISTORY_MESSAGES,
+ * above) and by an approximate token budget so a few enormous answers cannot
+ * crowd the entire context window. chars/4 is the usual rough heuristic for
+ * English prose + JSON.
+ */
+const MAX_HISTORY_TOKENS: number = 24000;
+const APPROX_CHARS_PER_TOKEN: number = 4;
+
+// Caps for the per-message evidence digest appended to replayed answers.
+const MAX_EVIDENCE_DIGEST_CHARS: number = 1500;
+const MAX_DIGEST_ARGUMENTS_CHARS: number = 200;
+const MAX_SHOWN_SUMMARY_CHARS: number = 300;
+
+// Conversation title generation (first exchange only).
+const MAX_TITLE_CHARS: number = 90;
+const MAX_TITLE_SOURCE_CHARS: number = 500;
+const TITLE_MAX_OUTPUT_TOKENS: number = 100;
+
 export const OBSERVABILITY_CHAT_FEATURE: string = "Observability Chat";
+export const CHAT_TITLE_FEATURE: string = "Chat Title";
 
 /*
  * Remove citation markers the model fabricated: only markers matching
@@ -99,6 +125,275 @@ export function stripFabricatedCitationMarkers(
  */
 export function escapeToolResultContent(text: string): string {
   return text.replace(/<\/(tool_result)/gi, "<\\/$1");
+}
+
+/*
+ * A compact, replayable record of the evidence behind a prior assistant
+ * answer, e.g.:
+ *
+ *   [Evidence from this turn: C1 query_incidents({"incidentId":"..."}) ->
+ *   5 rows (Incidents, last 168h); C2 ...]
+ *
+ * History replay strips the [C#] markers from prior prose (this turn's
+ * citations are different objects), which used to discard all prior evidence.
+ * The digest keeps that evidence referable — the model can see what was
+ * already queried, with which arguments, and what came back — without
+ * replaying the raw tool payloads.
+ */
+export function buildEvidenceDigest(citations: Array<AIChatCitation>): string {
+  if (citations.length === 0) {
+    return "";
+  }
+
+  const prefix: string = "[Evidence from this turn: ";
+  const entries: Array<string> = [];
+  let usedChars: number = prefix.length + 1; // +1 for the closing bracket
+  let includedCount: number = 0;
+
+  for (const citation of citations) {
+    let queryArguments: string;
+    try {
+      queryArguments = JSON.stringify(citation.queryArguments || {});
+    } catch {
+      queryArguments = "{…}";
+    }
+
+    if (queryArguments.length > MAX_DIGEST_ARGUMENTS_CHARS) {
+      queryArguments = `${queryArguments.substring(
+        0,
+        MAX_DIGEST_ARGUMENTS_CHARS,
+      )}…`;
+    }
+
+    const entry: string = `${citation.id} ${citation.toolName}(${queryArguments}) -> ${citation.rowCount} rows (${citation.label})`;
+    const separatorChars: number = entries.length > 0 ? 2 : 0; // "; "
+
+    if (
+      entries.length > 0 &&
+      usedChars + separatorChars + entry.length > MAX_EVIDENCE_DIGEST_CHARS
+    ) {
+      break;
+    }
+
+    entries.push(entry);
+    usedChars += separatorChars + entry.length;
+    includedCount++;
+  }
+
+  const omittedCount: number = citations.length - includedCount;
+
+  let digest: string = prefix + entries.join("; ");
+  if (omittedCount > 0) {
+    digest += `; ... and ${omittedCount} more ${
+      omittedCount === 1 ? "query" : "queries"
+    }`;
+  }
+
+  return `${digest}]`;
+}
+
+/*
+ * A one-line summary of the non-text content of a prior assistant message —
+ * widget titles first (the user actually saw those), tool-action titles as a
+ * fallback. Used so widget-only answers no longer vanish from replayed
+ * history. Returns "" when there is nothing to summarize.
+ */
+export function summarizeShownContent(
+  widgets: Array<AIChatWidget>,
+  toolActions: Array<AIChatToolAction>,
+): string {
+  const widgetTitles: Array<string> = widgets
+    .map((widget: AIChatWidget) => {
+      return widget.title;
+    })
+    .filter((title: string) => {
+      return Boolean(title);
+    });
+
+  const actionTitles: Array<string> = toolActions
+    .map((action: AIChatToolAction) => {
+      return action.title;
+    })
+    .filter((title: string) => {
+      return Boolean(title);
+    });
+
+  const summary: string = (
+    widgetTitles.length > 0 ? widgetTitles : actionTitles
+  ).join(", ");
+
+  return summary.length > MAX_SHOWN_SUMMARY_CHARS
+    ? `${summary.substring(0, MAX_SHOWN_SUMMARY_CHARS)}…`
+    : summary;
+}
+
+// One prior conversation message, already rendered for replay to the LLM.
+export interface ReplayedHistoryMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface HistoryBudgetResult {
+  kept: Array<ReplayedHistoryMessage>;
+  // How many of the oldest entries were dropped to fit the budget.
+  droppedCount: number;
+}
+
+/*
+ * Enforce an approximate token budget over replayed history, dropping oldest
+ * entries first. The newest entry (the user message that started this turn)
+ * is always kept, even if it alone exceeds the budget — the model needs
+ * something to answer.
+ */
+export function applyHistoryTokenBudget(
+  entries: Array<ReplayedHistoryMessage>,
+  maxTokens: number,
+): HistoryBudgetResult {
+  const kept: Array<ReplayedHistoryMessage> = [];
+  let usedTokens: number = 0;
+
+  for (let i: number = entries.length - 1; i >= 0; i--) {
+    const entry: ReplayedHistoryMessage | undefined = entries[i];
+    if (!entry) {
+      continue;
+    }
+
+    const entryTokens: number = Math.ceil(
+      entry.content.length / APPROX_CHARS_PER_TOKEN,
+    );
+
+    if (kept.length > 0 && usedTokens + entryTokens > maxTokens) {
+      return { kept, droppedCount: i + 1 };
+    }
+
+    kept.unshift(entry);
+    usedTokens += entryTokens;
+  }
+
+  return { kept, droppedCount: 0 };
+}
+
+/*
+ * Render one persisted conversation message for history replay, or undefined
+ * when the row should be skipped (unfinished/errored assistant turns, empty
+ * rows). Assistant answers get their stale [C#] markers stripped and a
+ * compact evidence digest appended; widget-only answers are replayed as a
+ * "[Showed the user: …]" summary instead of vanishing.
+ */
+export function buildReplayedHistoryMessage(
+  message: AIConversationMessage,
+): ReplayedHistoryMessage | undefined {
+  if (message.role === AIChatMessageRole.User) {
+    if (!message.contentInMarkdown) {
+      return undefined;
+    }
+    return { role: "user", content: message.contentInMarkdown };
+  }
+
+  /*
+   * Assistant rows: replay only terminal-with-output turns. Cancelled is
+   * terminal too — a cancelled turn's partial answer is part of what the
+   * user saw. In-flight and errored rows are skipped as before.
+   */
+  if (
+    message.status !== AIChatMessageStatus.Completed &&
+    message.status !== AIChatMessageStatus.Cancelled
+  ) {
+    return undefined;
+  }
+
+  const digest: string = buildEvidenceDigest(message.citations || []);
+
+  /*
+   * A cancelled turn's contentInMarkdown is the server's finalizer text
+   * ("Stopped by user."), not assistant prose — replaying it verbatim
+   * teaches the model to imitate or apologize for it. Replay a neutral
+   * marker instead, keeping the evidence digest so queries that DID run
+   * before the stop stay referable.
+   */
+  if (message.status === AIChatMessageStatus.Cancelled) {
+    const cancelledParts: Array<string> = [
+      "[The user stopped this answer before it finished.]",
+    ];
+    if (digest) {
+      cancelledParts.push(digest);
+    }
+    return { role: "assistant", content: cancelledParts.join("\n\n") };
+  }
+
+  /*
+   * A prior assistant answer carries [C#] citation markers that pointed at
+   * that turn's tool results — citations that no longer exist in this turn.
+   * Left in the replayed history the model echoes and renumbers them, and
+   * this turn's stripFabricatedCitationMarkers then deletes the unmatched
+   * ones, leaving claims that look uncited. Strip the markers from replayed
+   * answers so only freshly minted citations ever appear; the digest above
+   * keeps the underlying evidence referable.
+   */
+  const prose: string = (message.contentInMarkdown || "").replace(
+    /\s?\[C\d+\]/g,
+    "",
+  );
+
+  if (prose.trim()) {
+    return {
+      role: "assistant",
+      content: digest ? `${prose}\n\n${digest}` : prose,
+    };
+  }
+
+  const shown: string = summarizeShownContent(
+    message.widgets || [],
+    message.toolActions || [],
+  );
+
+  const parts: Array<string> = [];
+  if (shown) {
+    parts.push(`[Showed the user: ${shown}]`);
+  }
+  if (digest) {
+    parts.push(digest);
+  }
+
+  if (parts.length === 0) {
+    return undefined;
+  }
+
+  return { role: "assistant", content: parts.join("\n\n") };
+}
+
+/*
+ * Clean up an LLM-generated conversation title: first non-empty line only,
+ * wrapping quotes and markdown headings stripped, trailing punctuation
+ * removed, whitespace collapsed, clamped to MAX_TITLE_CHARS. Returns "" when
+ * nothing usable remains (callers keep the old title in that case).
+ */
+export function sanitizeGeneratedTitle(raw: string): string {
+  const firstLine: string | undefined = raw
+    .split("\n")
+    .map((line: string) => {
+      return line.trim();
+    })
+    .find((line: string) => {
+      return line.length > 0;
+    });
+
+  let title: string = firstLine || "";
+
+  title = title
+    .replace(/^#+\s*/, "")
+    .replace(/^Title:\s*/i, "")
+    .replace(/^["'`“”‘’\s]+/, "")
+    .replace(/["'`“”‘’\s]+$/, "")
+    .replace(/[.,;:!?…\s]+$/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (title.length > MAX_TITLE_CHARS) {
+    title = title.substring(0, MAX_TITLE_CHARS).trim();
+  }
+
+  return title;
 }
 
 interface TurnState {
@@ -139,8 +434,17 @@ export default class ChatAgentRunner {
         eventType: AIRunEventType.RunStarted,
       });
 
-      const messages: Array<LLMMessage> =
-        await this.buildInitialMessages(request);
+      /*
+       * The conversation's subject: a fresh page context is persisted on
+       * first use, and turns without one fall back to the persisted subject.
+       */
+      const pageContext: AIChatPageContext | undefined =
+        await this.resolvePageContext(request);
+
+      const messages: Array<LLMMessage> = await this.buildInitialMessages(
+        request,
+        pageContext,
+      );
 
       await this.runAgentLoop(request, state, messages, toolContext);
     } catch (error) {
@@ -284,6 +588,15 @@ export default class ChatAgentRunner {
 
     // Apply the decisions: run approved actions, refuse denied ones.
     for (const toolCall of pendingToolCalls) {
+      /*
+       * Cooperative cancellation: if POST /ai-chat/cancel-run took the run while
+       * this batch was executing, it already finalized the assistant message
+       * and the run. Abandon immediately — write nothing, emit nothing.
+       */
+      if (await this.isRunCancelled(request)) {
+        return;
+      }
+
       const decision: ResumeToolDecision | undefined = decisions.find(
         (item: ResumeToolDecision) => {
           return item.toolCallId === toolCall.id;
@@ -361,9 +674,19 @@ export default class ChatAgentRunner {
     toolContext: ToolContext,
   ): Promise<LoopOutcome> {
     let finalContent: string = "";
+    let finalStopReason: string | undefined = undefined;
     let manifest: AIRunEgressManifest | undefined = undefined;
 
     while (true) {
+      /*
+       * Cooperative cancellation: POST /ai-chat/cancel-run flips the run to
+       * Cancelled and finalizes the assistant message itself. Abandon
+       * immediately — overwrite nothing, emit nothing further.
+       */
+      if (await this.isRunCancelled(request)) {
+        return { paused: false };
+      }
+
       const budgetExhausted: boolean =
         state.llmCallCount >= MAX_LLM_CALLS - 1 ||
         state.toolCallCount >= MAX_TOOL_CALLS ||
@@ -425,7 +748,15 @@ export default class ChatAgentRunner {
       if (
         !budgetExhausted &&
         response.toolCalls &&
-        response.toolCalls.length > 0
+        response.toolCalls.length > 0 &&
+        /*
+         * Never execute tool calls from a truncated response: when the
+         * output hit the token cap mid-generation, the parsed calls may have
+         * cut-off arguments — running one (especially a mutation) would act
+         * on mangled input. Fall through to the final-answer path, which
+         * appends the truncation notice instead.
+         */
+        response.stopReason !== "length"
       ) {
         messages.push({
           role: "assistant",
@@ -436,6 +767,11 @@ export default class ChatAgentRunner {
         const pendingApproval: Array<LLMToolCall> = [];
 
         for (const toolCall of response.toolCalls) {
+          // Re-check between tools: a batch can run long and cancel must cut in.
+          if (await this.isRunCancelled(request)) {
+            return { paused: false };
+          }
+
           /*
            * The batch size is model-controlled — budgets must hold inside
            * the batch too, not just between LLM rounds.
@@ -545,6 +881,8 @@ export default class ChatAgentRunner {
       }
 
       finalContent = response.content;
+      finalStopReason = response.stopReason;
+
       break;
     }
 
@@ -552,6 +890,11 @@ export default class ChatAgentRunner {
       finalContent,
       state.citations,
     );
+
+    // Make output truncation visible instead of silently ending mid-sentence.
+    if (finalStopReason === "length") {
+      finalContent = `${finalContent}\n\n_[Answer truncated by the output token limit.]_`;
+    }
 
     if (manifest) {
       manifest.llmCallCount = state.llmCallCount;
@@ -561,7 +904,8 @@ export default class ChatAgentRunner {
 
     /*
      * Scope the finalizing writes by current status so a run the stale-run
-     * sweeper already failed (or a crashed retry) is never flipped back to
+     * sweeper already failed, a crashed retry — or a message the cancel
+     * endpoint already finalized as Cancelled — is never flipped back to
      * Completed underneath the user.
      */
     await AIConversationMessageService.updateOneBy({
@@ -579,7 +923,7 @@ export default class ChatAgentRunner {
       props: { isRoot: true },
     });
 
-    await AIRunService.updateOneBy({
+    const finalizedRunCount: number = await AIRunService.updateOneBy({
       query: {
         _id: request.aiRunId.toString(),
         status: AIRunStatus.Running,
@@ -598,11 +942,30 @@ export default class ChatAgentRunner {
       props: { isRoot: true },
     });
 
+    /*
+     * Zero rows means the run is no longer ours — the cancel endpoint (or the
+     * stale-run sweeper) finalized it while the last LLM round was in flight.
+     * Its owner wrote the final state; emit nothing further.
+     */
+    if (finalizedRunCount === 0) {
+      return { paused: false };
+    }
+
     await this.emitEvent(request, state, {
       eventType: AIRunEventType.RunCompleted,
     });
 
     await this.updateConversationAfterTurn(request);
+
+    /*
+     * Naming the conversation is cosmetic: fire-and-forget, off the critical
+     * path, and a failure never affects the finished turn.
+     */
+    this.generateConversationTitleIfFirstExchange(request).catch(
+      (error: Error) => {
+        logger.error(`AI chat title generation failed: ${error.message}`);
+      },
+    );
 
     return { paused: false };
   }
@@ -663,16 +1026,30 @@ export default class ChatAgentRunner {
     state: TurnState,
     status: AIChatMessageStatus,
   ): Promise<void> {
-    await AIConversationMessageService.updateOneById({
-      id: request.assistantMessageId,
-      data: {
-        citations: state.citations,
-        widgets: state.widgets,
-        toolActions: state.toolActions,
-        status: status,
-      } as never,
-      props: { isRoot: true },
-    });
+    /*
+     * Scope progress writes to rows still in flight so they can never
+     * resurrect a message another path already finalized — completed,
+     * errored, or cancelled by POST /ai-chat/cancel-run while a tool batch was
+     * running. Same protection the finalizing writes use.
+     */
+    for (const inFlightStatus of [
+      AIChatMessageStatus.InProgress,
+      AIChatMessageStatus.WaitingForApproval,
+    ]) {
+      await AIConversationMessageService.updateOneBy({
+        query: {
+          _id: request.assistantMessageId.toString(),
+          status: inFlightStatus,
+        },
+        data: {
+          citations: state.citations,
+          widgets: state.widgets,
+          toolActions: state.toolActions,
+          status: status,
+        } as never,
+        props: { isRoot: true },
+      });
+    }
   }
 
   // Upsert a tool action (mutation) into state, keyed by the tool call id.
@@ -870,13 +1247,18 @@ export default class ChatAgentRunner {
 
   private static async buildInitialMessages(
     request: ChatTurnRequest,
+    pageContext: AIChatPageContext | undefined,
   ): Promise<Array<LLMMessage>> {
     /*
      * History is read with the requesting user's props: the privacy pin
-     * guarantees these are the user's own messages.
+     * guarantees these are the user's own messages. The count (pinned the
+     * same way) tells us how many earlier messages the row cap left behind.
      */
-    const history: Array<AIConversationMessage> =
-      await AIConversationMessageService.findBy({
+    const [history, totalMessageCount]: [
+      Array<AIConversationMessage>,
+      PositiveNumber,
+    ] = await Promise.all([
+      AIConversationMessageService.findBy({
         query: {
           conversationId: request.conversationId,
         },
@@ -884,6 +1266,9 @@ export default class ChatAgentRunner {
           role: true,
           contentInMarkdown: true,
           status: true,
+          citations: true,
+          widgets: true,
+          toolActions: true,
         },
         sort: {
           createdAt: SortOrder.Descending,
@@ -891,7 +1276,40 @@ export default class ChatAgentRunner {
         limit: MAX_HISTORY_MESSAGES,
         skip: 0,
         props: request.props,
-      });
+      }),
+      AIConversationMessageService.countBy({
+        query: {
+          conversationId: request.conversationId,
+        },
+        props: request.props,
+      }),
+    ]);
+
+    const fetchedCount: number = history.length;
+
+    // Oldest first, skipping unfinished/errored assistant rows.
+    const replayable: Array<ReplayedHistoryMessage> = [];
+    for (const message of history.reverse()) {
+      const replayed: ReplayedHistoryMessage | undefined =
+        buildReplayedHistoryMessage(message);
+      if (replayed) {
+        replayable.push(replayed);
+      }
+    }
+
+    const budgeted: HistoryBudgetResult = applyHistoryTokenBudget(
+      replayable,
+      MAX_HISTORY_TOKENS,
+    );
+
+    /*
+     * Everything the model will not see: rows beyond the fetch cap plus rows
+     * the token budget dropped. Skipped in-flight/errored rows are not
+     * counted — they were never replayable in the first place.
+     */
+    const droppedCount: number =
+      Math.max(0, totalMessageCount.toNumber() - fetchedCount) +
+      budgeted.droppedCount;
 
     const messages: Array<LLMMessage> = [
       {
@@ -899,43 +1317,204 @@ export default class ChatAgentRunner {
         content: buildObservabilityChatSystemPrompt({
           currentTime: OneUptimeDate.getCurrentDate(),
           permissionMode: request.permissionMode,
-          pageContext: request.pageContext,
+          pageContext: pageContext,
         }),
       },
     ];
 
-    // Oldest first, skipping unfinished/errored assistant rows.
-    for (const message of history.reverse()) {
-      if (!message.contentInMarkdown) {
-        continue;
-      }
-
-      if (
-        message.role === AIChatMessageRole.Assistant &&
-        message.status !== AIChatMessageStatus.Completed
-      ) {
-        continue;
-      }
-
-      const isUserMessage: boolean = message.role === AIChatMessageRole.User;
-
+    if (droppedCount > 0) {
+      // Tell the model history is partial so it never asserts "you never said X".
       messages.push({
-        role: isUserMessage ? "user" : "assistant",
-        /*
-         * A prior assistant answer carries [C#] citation markers that pointed
-         * at that turn's tool results — citations that no longer exist in this
-         * turn. Left in the replayed history the model echoes and renumbers
-         * them, and this turn's stripFabricatedCitationMarkers then deletes the
-         * unmatched ones, leaving claims that look uncited. Strip the markers
-         * from replayed answers so only freshly minted citations ever appear.
-         */
-        content: isUserMessage
-          ? message.contentInMarkdown
-          : message.contentInMarkdown.replace(/\s?\[C\d+\]/g, ""),
+        role: "user",
+        content: `[Note: ${droppedCount} earlier messages in this conversation were omitted for length.]`,
+      });
+    }
+
+    for (const entry of budgeted.kept) {
+      messages.push({
+        role: entry.role,
+        content: entry.content,
       });
     }
 
     return messages;
+  }
+
+  /*
+   * Cheap cooperative-cancellation probe: a status-only read of the run.
+   * Checked at the top of every agent-loop iteration and before every tool
+   * execution. A probe failure never kills the turn — cancellation is
+   * best-effort, and the status-scoped finalizing writes are the backstop.
+   */
+  private static async isRunCancelled(
+    request: ChatTurnRequest,
+  ): Promise<boolean> {
+    try {
+      const run: AIRun | null = await AIRunService.findOneById({
+        id: request.aiRunId,
+        select: {
+          status: true,
+        },
+        props: { isRoot: true },
+      });
+
+      return run?.status === AIRunStatus.Cancelled;
+    } catch {
+      return false;
+    }
+  }
+
+  /*
+   * Resolve the page context for this turn and keep the conversation's
+   * subject persistent: the first turn that carries a page context pins it to
+   * AIConversation.pageContext (root props — same as the runner's other
+   * conversation updates), and later turns without one fall back to the
+   * pinned subject so "this incident" keeps resolving. Page context is a
+   * hint, so a failure here degrades to whatever the request carried rather
+   * than failing the turn.
+   */
+  private static async resolvePageContext(
+    request: ChatTurnRequest,
+  ): Promise<AIChatPageContext | undefined> {
+    try {
+      const conversation: AIConversation | null =
+        await AIConversationService.findOneById({
+          id: request.conversationId,
+          select: {
+            pageContext: true,
+          },
+          props: { isRoot: true },
+        });
+
+      const persisted: AIChatPageContext | undefined =
+        conversation?.pageContext || undefined;
+
+      if (!request.pageContext) {
+        return persisted;
+      }
+
+      /*
+       * Persist the LATEST explicit context, not just the first: when the
+       * user carries a conversation from incident A to incident B, "this
+       * incident" on later contextless turns must mean B — replaying a
+       * stale first subject would silently flip the conversation back.
+       */
+      const persistedSignature: string = persisted
+        ? `${persisted.type}:${persisted.entityId || ""}`
+        : "";
+      const incomingSignature: string = `${request.pageContext.type}:${
+        request.pageContext.entityId || ""
+      }`;
+
+      if (persistedSignature !== incomingSignature) {
+        await AIConversationService.updateOneById({
+          id: request.conversationId,
+          data: {
+            pageContext: request.pageContext,
+          } as never,
+          props: { isRoot: true },
+        });
+      }
+
+      return request.pageContext;
+    } catch (error) {
+      logger.error(
+        `Failed to resolve AI chat page context: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return request.pageContext;
+    }
+  }
+
+  /*
+   * After the first successful exchange, name the conversation with a small
+   * LLM call. Callers invoke this fire-and-forget: it runs off the turn's
+   * critical path and any failure is logged, never surfaced.
+   */
+  private static async generateConversationTitleIfFirstExchange(
+    request: ChatTurnRequest,
+  ): Promise<void> {
+    const messageCount: PositiveNumber =
+      await AIConversationMessageService.countBy({
+        query: {
+          conversationId: request.conversationId,
+          /*
+           * Count only completed rows: a first turn that errored or was
+           * stopped still leaves rows behind, and counting those would
+           * permanently skip titling once the first SUCCESSFUL exchange
+           * finally lands.
+           */
+          status: AIChatMessageStatus.Completed,
+        },
+        props: { isRoot: true },
+      });
+
+    // Only the first user/assistant exchange earns a generated title.
+    if (messageCount.toNumber() > 2) {
+      return;
+    }
+
+    const firstUserMessage: AIConversationMessage | null =
+      await AIConversationMessageService.findOneBy({
+        query: {
+          conversationId: request.conversationId,
+          role: AIChatMessageRole.User,
+        },
+        select: {
+          contentInMarkdown: true,
+        },
+        sort: {
+          createdAt: SortOrder.Ascending,
+        },
+        props: { isRoot: true },
+      });
+
+    const firstMessageText: string = (firstUserMessage?.contentInMarkdown || "")
+      .substring(0, MAX_TITLE_SOURCE_CHARS)
+      .trim();
+
+    if (!firstMessageText) {
+      return;
+    }
+
+    const response: AILogResponse = await AIService.executeWithLogging({
+      projectId: request.projectId,
+      userId: request.userId,
+      aiRunId: request.aiRunId,
+      llmProviderId: request.llmProviderId,
+      feature: CHAT_TITLE_FEATURE,
+      messages: [
+        {
+          role: "system",
+          content:
+            "You title conversations. Reply with ONLY a concise 3-8 word title for the conversation — no quotes, no trailing punctuation, no explanation.",
+        },
+        {
+          role: "user",
+          content: `Title a conversation that starts with this user message:\n\n${firstMessageText}`,
+        },
+      ],
+      maxTokens: TITLE_MAX_OUTPUT_TOKENS,
+      temperature: TEMPERATURE,
+      // Same privacy rule as the chat itself: LlmLog is project-readable.
+      storeContentPreviews: false,
+    });
+
+    const title: string = sanitizeGeneratedTitle(response.content);
+
+    // An unusable title keeps whatever the conversation already had.
+    if (!title) {
+      return;
+    }
+
+    await AIConversationService.updateOneById({
+      id: request.conversationId,
+      data: {
+        title: title,
+      } as never,
+      props: { isRoot: true },
+    });
   }
 
   private static async heartbeat(
@@ -1022,7 +1601,9 @@ export default class ChatAgentRunner {
      * finalization (e.g. a transient error updating the conversation) must
      * not flip an already-Completed answer to Error. Both non-terminal
      * statuses are covered — InProgress (a live turn) and WaitingForApproval
-     * (a turn that errored while resuming).
+     * (a turn that errored while resuming). Terminal statuses (Completed,
+     * Error, Cancelled) are deliberately excluded: a message the cancel
+     * endpoint finalized is never flipped to Error underneath the user.
      */
     for (const inFlightStatus of [
       AIChatMessageStatus.InProgress,
@@ -1043,11 +1624,13 @@ export default class ChatAgentRunner {
       });
     }
 
+    let failedRunCount: number = 0;
+
     for (const inFlightStatus of [
       AIRunStatus.Running,
       AIRunStatus.WaitingForApproval,
     ]) {
-      await AIRunService.updateOneBy({
+      failedRunCount += await AIRunService.updateOneBy({
         query: {
           _id: request.aiRunId.toString(),
           status: inFlightStatus,
@@ -1061,7 +1644,19 @@ export default class ChatAgentRunner {
         props: { isRoot: true },
       }).catch(() => {
         // best-effort
+        return 0;
       });
+    }
+
+    /*
+     * Emit the terminal event only when this call actually flipped the run.
+     * Zero rows means another writer already finalized it — most commonly
+     * the cancel endpoint, which emitted its own terminal event at the same
+     * sequence; emitting a second one here would make a deliberately stopped
+     * turn render as a provider failure.
+     */
+    if (failedRunCount === 0) {
+      return;
     }
 
     const state: TurnState = this.freshState();

--- a/Common/Server/Utils/AI/Chat/ObservabilityAssistant.ts
+++ b/Common/Server/Utils/AI/Chat/ObservabilityAssistant.ts
@@ -100,6 +100,14 @@ export interface ObservabilityAssistantRequest {
    * an extra tool can never shadow a registered one.
    */
   extraTools?: Array<ObservabilityAssistantExtraTool> | undefined;
+  /*
+   * Toolbox tools withheld from the model for this run — and refused if the
+   * model somehow names one anyway. The autonomous investigation lane uses
+   * this to hide get_ai_investigation from itself: the "latest investigation"
+   * for the subject would be the model's own in-flight run, and polling it
+   * burns budget on a status that cannot resolve until this run finishes.
+   */
+  excludeToolNames?: Array<string> | undefined;
 }
 
 /*
@@ -178,6 +186,10 @@ export default class ObservabilityAssistant {
       }
     }
 
+    const excludedToolNames: Set<string> = new Set(
+      request.excludeToolNames || [],
+    );
+
     let systemPromptContent: string = buildObservabilityChatSystemPrompt({
       currentTime: OneUptimeDate.getCurrentDate(),
       /*
@@ -242,7 +254,11 @@ export default class ObservabilityAssistant {
         tools: budgetExhausted
           ? undefined
           : [
-              ...AIToolbox.getLlmToolDefinitions(AIChatPermissionMode.ReadOnly),
+              ...AIToolbox.getLlmToolDefinitions(
+                AIChatPermissionMode.ReadOnly,
+              ).filter((definition: LLMToolDefinition) => {
+                return !excludedToolNames.has(definition.name);
+              }),
               ...Array.from(extraToolsByName.values()).map(
                 (extraTool: ObservabilityAssistantExtraTool) => {
                   return extraTool.definition;
@@ -271,7 +287,13 @@ export default class ObservabilityAssistant {
       if (
         !budgetExhausted &&
         response.toolCalls &&
-        response.toolCalls.length > 0
+        response.toolCalls.length > 0 &&
+        /*
+         * A response truncated by the output cap can carry tool calls with
+         * cut-off arguments — never execute those; fall through to the
+         * final-answer path instead (mirrors ChatAgentRunner).
+         */
+        response.stopReason !== "length"
       ) {
         messages.push({
           role: "assistant",
@@ -317,7 +339,14 @@ export default class ObservabilityAssistant {
             extraToolsByName.get(toolCall.name);
 
           let outcome: ToolCallOutcome;
-          if (extraTool) {
+          if (excludedToolNames.has(toolCall.name)) {
+            // Defense in depth: excluded tools are refused even if named.
+            outcome = {
+              success: false,
+              textForLlm: `Error: ${toolCall.name} is not available in this run. Answer with the data you already have.`,
+              errorMessage: `Tool excluded for this run: ${toolCall.name}`,
+            };
+          } else if (extraTool) {
             try {
               outcome = await extraTool.execute(toolCall.arguments);
             } catch (err) {

--- a/Common/Server/Utils/AI/Chat/ObservabilityChatPrompt.ts
+++ b/Common/Server/Utils/AI/Chat/ObservabilityChatPrompt.ts
@@ -10,17 +10,23 @@ import AIChatPermissionMode from "../../../../Types/AI/AIChatPermissionMode";
  * untrusted data.
  */
 
+/*
+ * The action list shared by the two modes that can act. Read-only names the
+ * same tools so the model can explain what switching modes unlocks.
+ */
+const ACTION_LIST: string = `create incidents, acknowledge or resolve incidents and alerts, post internal notes (create_incident_note / create_alert_note — visible only to the team, never notifies status page subscribers; post_incident_status_update is the public counterpart), start an autonomous AI investigation (start_investigation), and change code (open_code_pull_request, commit_code_to_branch)`;
+
 function buildActionGuidance(mode: AIChatPermissionMode): string {
   if (mode === AIChatPermissionMode.ReadOnly) {
-    return `5. This conversation is READ-ONLY. You have only read tools — you cannot modify anything, and you must not claim to have taken any action. If the user asks you to create an incident, acknowledge an alert, change code, or make any other change, explain that read-only mode is on and they can switch modes to let you act.`;
+    return `5. This conversation is READ-ONLY. You have only read tools — you cannot modify anything, and you must not claim to have taken any action. If the user asks you to create an incident, acknowledge an alert, post an internal note (create_incident_note / create_alert_note), start an investigation (start_investigation), change code, or make any other change, explain that read-only mode is on and they can switch modes to let you act.`;
   }
 
   if (mode === AIChatPermissionMode.AutoRun) {
-    return `5. You can take actions: create incidents, acknowledge or resolve incidents and alerts, and change code (open_code_pull_request, commit_code_to_branch). Actions you request run IMMEDIATELY without a separate confirmation. Because of that, only take an action the user clearly asked for; if intent is ambiguous, ask a clarifying question instead of acting. Read the relevant data first (e.g. query_incidents to get an incidentId, or read_code_file before rewriting a file) before acting on it. After an action succeeds, tell the user exactly what you did.`;
+    return `5. You can take actions: ${ACTION_LIST}. Actions you request run IMMEDIATELY without a separate confirmation. Because of that, only take an action the user clearly asked for; if intent is ambiguous, ask a clarifying question instead of acting. Read the relevant data first (e.g. query_incidents to get an incidentId, or read_code_file before rewriting a file) before acting on it. After an action succeeds, tell the user exactly what you did.`;
   }
 
   // AskForApproval (default)
-  return `5. You can take actions: create incidents, acknowledge or resolve incidents and alerts, and change code (open_code_pull_request, commit_code_to_branch). When the user asks you to act, call the appropriate tool — the user is shown an approval card and must APPROVE each action before it runs, so propose the action rather than asking "should I?" in prose. Read the relevant data first (e.g. query_incidents to get an incidentId, or read_code_file before rewriting a file) before acting on it. If an action is denied, acknowledge it was not done and continue helping. Never claim an action happened unless the tool result confirms it.`;
+  return `5. You can take actions: ${ACTION_LIST}. When the user asks you to act, call the appropriate tool — the user is shown an approval card and must APPROVE each action before it runs, so propose the action rather than asking "should I?" in prose. Read the relevant data first (e.g. query_incidents to get an incidentId, or read_code_file before rewriting a file) before acting on it. If an action is denied, acknowledge it was not done and continue helping. Never claim an action happened unless the tool result confirms it.`;
 }
 
 /*
@@ -37,9 +43,9 @@ function buildEntityContextGuidance(context: AIChatPageContext): string {
 
   switch (context.type) {
     case AIChatPageContextType.Incident:
-      return `an incident${titlePart}. Fetch its full details with query_incidents using incidentId="${id}" before answering questions about it. Incident actions (acknowledge_incident, resolve_incident, post_incident_status_update, change_incident_severity, page_on_call_policy, run_runbook) take this same incidentId. Use the incident's start time and affected monitors to scope log, trace and metric queries when investigating it.`;
+      return `an incident${titlePart}. Fetch its full details with query_incidents using incidentId="${id}" before answering questions about it. An autonomous AI investigation may already exist for this incident — call get_ai_investigation first and build on (and cite) its findings rather than re-deriving them from raw telemetry. get_incident_timeline is how to answer "what's the latest": it returns the incident's state changes, notes and notifications in order. Incident actions (acknowledge_incident, resolve_incident, post_incident_status_update, change_incident_severity, page_on_call_policy, run_runbook) take this same incidentId. Use the incident's start time and affected monitors to scope log, trace and metric queries when investigating it.`;
     case AIChatPageContextType.Alert:
-      return `an alert${titlePart}. Fetch its full details with query_alerts using alertId="${id}" before answering questions about it. Alert actions (acknowledge_alert, resolve_alert) take this same alertId. Use the alert's creation time to scope log, trace and metric queries when investigating it.`;
+      return `an alert${titlePart}. Fetch its full details with query_alerts using alertId="${id}" before answering questions about it. An autonomous AI investigation may already exist for this alert — call get_ai_investigation first and build on (and cite) its findings rather than re-deriving them from raw telemetry. get_alert_timeline is how to answer "what's the latest" on this alert. Alert actions (acknowledge_alert, resolve_alert) take this same alertId. Use the alert's creation time to scope log, trace and metric queries when investigating it.`;
     case AIChatPageContextType.Monitor:
       return `a monitor${titlePart}. Fetch its details and recent status timeline with query_monitors using monitorId="${id}". For this monitor's metrics, query_metrics and baseline_anomaly accept this id as entityId.`;
     case AIChatPageContextType.ScheduledMaintenanceEvent:
@@ -115,7 +121,7 @@ export function buildObservabilityChatSystemPrompt(data: {
   permissionMode: AIChatPermissionMode;
   pageContext?: AIChatPageContext | undefined;
 }): string {
-  return `You are OneUptime's observability copilot: a careful SRE analyst that answers questions about — and can take action on — this project's traces, metrics, logs, exceptions, incidents, monitors, alerts and scheduled maintenance, and the source code in its connected code repositories.
+  return `You are OneUptime's observability copilot: a careful SRE analyst that answers questions about — and can take action on — this project's traces, metrics, logs, exceptions, incidents, monitors, alerts and scheduled maintenance, the on-call, status page, SLO and runbook platform around them, and the source code in its connected code repositories.
 
 The current time is ${data.currentTime.toISOString()}.${buildPageContextSection(
     data.pageContext,
@@ -135,6 +141,13 @@ ${buildActionGuidance(data.permissionMode)}
 - Prefer aggregations (query_traces, log_histogram, query_metrics, top_exceptions) to establish the shape of a problem, then drill into raw data (search_logs, get_trace) for evidence.
 - Always pass explicit ISO 8601 time ranges. If the user did not specify one, use the last hour for logs and the last 24 hours for metrics/traces, and say which window you used.
 - When durations are involved they are in milliseconds unless stated otherwise.
+- Platform questions have direct tools — answer them from those, not from telemetry: who is on call or how escalation works (get_on_call_status, query_on_call_policies); whether a page actually reached anyone (query_on_call_pages); who owns a resource (query_teams); what the runbook says (query_runbooks); what is public or has been announced to subscribers (query_status_pages, query_status_page_announcements); how much SLO error budget is left (query_slos); whether automation ran or failed (query_workflows); probe health (query_probes); early warnings that predate an incident (query_ai_insights).
+- When a question is genuinely ambiguous (which service? which time window? which environment?) and a wrong guess would waste the query budget or mislead, ask one focused clarifying question instead of running default-window queries. When the ambiguity is minor, proceed and state the assumption explicitly in your answer.
+
+## Reading tool results
+
+- Results are sanitized before you see them: emails, IP addresses and secrets are replaced with markers like [redacted-email] or [redacted-ip]. Treat these as sanitization placeholders, never as literal data values. If the redacted value is itself what the user asked for, say the value is redacted in this view — do not guess it.
+- Long fields may end in "... [truncated]". To see the rest, narrow the query to fewer rows or fetch the single record by its id.
 
 ## Reading the source code
 
@@ -160,6 +173,7 @@ You can propose code changes. open_code_pull_request is the right tool almost al
 ## Answer style
 
 - Be concise. Lead with the answer, then the supporting evidence.
+- For investigations: lead with the finding, then separate confirmed facts (each cited) from hypotheses, labeling hypotheses as such. State the time window you examined. If a multi-step investigation ends inconclusive, close with what you would check next.
 - The dashboard renders rich widgets (charts, tables, trace waterfalls, resource cards) from your tool results automatically, so do NOT re-paste large tables the tools already returned — reference them and interpret them instead.
 - When you could not fully verify something, say what you verified and what you could not.`;
 }

--- a/Common/Server/Utils/AI/SRE/AIInvestigationEngine.ts
+++ b/Common/Server/Utils/AI/SRE/AIInvestigationEngine.ts
@@ -332,6 +332,13 @@ export default class AIInvestigationEngine {
           maxOutputTokens: request.maxOutputTokens ?? MAX_OUTPUT_TOKENS,
           onStep,
           extraTools: request.extraTools,
+          /*
+           * The chat-facing AI-meta tools are hidden from the investigator:
+           * "the latest investigation" for this subject IS this in-flight
+           * run, so the model would poll its own unfinished status ("check
+           * again in a minute") and burn budget instead of investigating.
+           */
+          excludeToolNames: ["get_ai_investigation", "start_investigation"],
         });
 
       /*

--- a/Common/Server/Utils/AI/Toolbox/AIActionTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/AIActionTools.ts
@@ -78,7 +78,7 @@ const resolveRunbookUpdatePermissions: () => Array<Permission> =
 export const PageOnCallPolicyTool: ObservabilityTool = {
   name: "page_on_call_policy",
   description:
-    "Page (trigger) an on-call duty policy so its responders are notified about an incident. Provide the on-call policy id and the incident id it relates to. Use query tools to find the on-call policy id and incident id first. This notifies real people — only do it when clearly asked.",
+    "Page (trigger) an on-call duty policy so its responders are notified about an incident. Provide the on-call policy id and the incident id it relates to. Find the policy id with query_on_call_policies and the incident id with query_incidents first. This notifies real people — only do it when clearly asked.",
   inputSchema: {
     type: "object",
     properties: {
@@ -200,7 +200,7 @@ export const PageOnCallPolicyTool: ObservabilityTool = {
 export const RunRunbookTool: ObservabilityTool = {
   name: "run_runbook",
   description:
-    "Start (execute) a runbook by its id, optionally linked to an incident. Use this to run a predefined remediation or diagnostic automation. Find the runbook id with query tools first.",
+    "Start (execute) a runbook by its id, optionally linked to an incident. Use this to run a predefined remediation or diagnostic automation. Find the runbook id (and read its steps) with query_runbooks first.",
   inputSchema: {
     type: "object",
     properties: {

--- a/Common/Server/Utils/AI/Toolbox/AIMetaTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/AIMetaTools.ts
@@ -1,0 +1,863 @@
+import AIRun from "../../../../Models/DatabaseModels/AIRun";
+import AIInsight from "../../../../Models/DatabaseModels/AIInsight";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import Alert from "../../../../Models/DatabaseModels/Alert";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import Permission from "../../../../Types/Permission";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import Query from "../../../../Types/BaseDatabase/Query";
+import OneUptimeDate from "../../../../Types/Date";
+import AIRunType from "../../../../Types/AI/AIRunType";
+import AIRunStatus, {
+  AIRunStatusHelper,
+} from "../../../../Types/AI/AIRunStatus";
+import AIInsightStatus from "../../../../Types/AI/AIInsightStatus";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import AIRunService from "../../../Services/AIRunService";
+import AIInsightService from "../../../Services/AIInsightService";
+import IncidentService from "../../../Services/IncidentService";
+import AlertService from "../../../Services/AlertService";
+import QueryHelper from "../../../Types/Database/QueryHelper";
+import PostedRootCause from "../SRE/PostedRootCause";
+import AIInvestigationQueue from "../SRE/InvestigationQueue";
+import { DEFAULT_INCIDENT_DEDUPE_WINDOW_MINUTES } from "../SRE/IncidentInvestigationRunner";
+import ToolResultSerializer, { SerializedResult } from "./Serializer";
+import WidgetBuilder from "./WidgetBuilder";
+import {
+  ObservabilityTool,
+  ToolArgs,
+  ToolContext,
+  ToolExecutionResult,
+} from "./ToolTypes";
+
+/*
+ * AI meta tools — make the chat aware of OneUptime's OTHER AI lanes.
+ *
+ * The platform already runs autonomous investigations (cited RCAs posted to
+ * incident/alert timelines) and preventive AI Insights (deterministic
+ * detector findings with AI triage), but the chat could neither see them nor
+ * start one — so it would happily re-derive a root cause from raw telemetry
+ * that an investigation had already analyzed. These tools close that gap:
+ *   - get_ai_investigation reads the investigation run(s) for one subject,
+ *   - query_ai_insights lists recent preventive findings,
+ *   - start_investigation enqueues a run through the SAME durable queue the
+ *     automatic lanes use (AIInvestigationQueue), for subjects the automatic
+ *     gates skipped.
+ */
+
+// How many investigation runs one get_ai_investigation call returns at most.
+const MAX_INVESTIGATION_RUNS_RETURNED: number = 5;
+
+/*
+ * Detects the analysis' own "the evidence was inconclusive" verdict in the
+ * posted prose/TL;DR. Purely informational (the note tells the model to be
+ * honest about the uncertainty) — nothing operational branches on it, so a
+ * false negative only omits a hint.
+ */
+const INCONCLUSIVE_RE: RegExp = /inconclusive/i;
+
+/*
+ * Derived from the model ACLs so the tool gates can never drift from RBAC.
+ * Resolved lazily rather than at module load: this module is pulled in
+ * through the service import graph before the model classes are fully wired
+ * up, so calling a model method at import time throws a circular-dependency
+ * TypeError. By the time a tool actually executes, every module is loaded.
+ */
+let cachedAiRunReadPermissions: Array<Permission> | null = null;
+const resolveAiRunReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedAiRunReadPermissions) {
+      cachedAiRunReadPermissions = new AIRun().getReadPermissions();
+    }
+    return cachedAiRunReadPermissions;
+  };
+
+let cachedAiInsightReadPermissions: Array<Permission> | null = null;
+const resolveAiInsightReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedAiInsightReadPermissions) {
+      cachedAiInsightReadPermissions = new AIInsight().getReadPermissions();
+    }
+    return cachedAiInsightReadPermissions;
+  };
+
+/*
+ * AIRun rows are server-authored (empty create ACL), so gating the mutation
+ * on AIRun.getCreatePermissions() would make it unrunnable. Starting an
+ * investigation operates on the incident/alert (it posts an RCA to that
+ * subject's timeline), so gate on the subject models' update ACLs — the same
+ * proxy AIActionTools uses for page_on_call_policy.
+ */
+let cachedStartInvestigationPermissions: Array<Permission> | null = null;
+const resolveStartInvestigationPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedStartInvestigationPermissions) {
+      const combined: Array<Permission> = [
+        ...new Incident().getUpdatePermissions(),
+        ...new Alert().getUpdatePermissions(),
+      ];
+      cachedStartInvestigationPermissions = Array.from(new Set(combined));
+    }
+    return cachedStartInvestigationPermissions;
+  };
+
+/*
+ * The incident/alert an investigation tool call is about, resolved UNDER THE
+ * USER'S RBAC (ctx.props) — this is the tenancy + visibility check that lets
+ * the isRoot reads inside PostedRootCause stay safe, and it rejects a
+ * cross-project id outright.
+ */
+interface AIInvestigationSubject {
+  incidentId: ObjectID | undefined;
+  alertId: ObjectID | undefined;
+  // "Incident #12" / "Alert #7" — falls back to the raw id when no number exists.
+  label: string;
+  citationType: AIChatCitationTargetType;
+  citationParams: { [key: string]: string };
+  // First affected monitor — the dedupe key the automatic investigation lanes record.
+  monitorId: ObjectID | undefined;
+}
+
+const fetchInvestigationSubject: (
+  incidentId: ObjectID | undefined,
+  alertId: ObjectID | undefined,
+  ctx: ToolContext,
+) => Promise<AIInvestigationSubject | null> = async (
+  incidentId: ObjectID | undefined,
+  alertId: ObjectID | undefined,
+  ctx: ToolContext,
+): Promise<AIInvestigationSubject | null> => {
+  if (incidentId) {
+    const incident: Incident | null = await IncidentService.findOneById({
+      id: incidentId,
+      select: {
+        _id: true,
+        incidentNumber: true,
+        monitors: {
+          _id: true,
+        },
+      },
+      props: ctx.props,
+    });
+
+    if (!incident) {
+      return null;
+    }
+
+    const firstMonitorIdString: string | undefined =
+      incident.monitors && incident.monitors.length > 0
+        ? incident.monitors[0]?._id
+        : undefined;
+
+    return {
+      incidentId: incidentId,
+      alertId: undefined,
+      label: incident.incidentNumber
+        ? `Incident #${incident.incidentNumber}`
+        : `Incident ${incidentId.toString()}`,
+      citationType: AIChatCitationTargetType.IncidentView,
+      citationParams: { incidentId: incidentId.toString() },
+      monitorId: firstMonitorIdString
+        ? new ObjectID(firstMonitorIdString)
+        : undefined,
+    };
+  }
+
+  if (alertId) {
+    const alert: Alert | null = await AlertService.findOneById({
+      id: alertId,
+      select: {
+        _id: true,
+        alertNumber: true,
+        monitorId: true,
+      },
+      props: ctx.props,
+    });
+
+    if (!alert) {
+      return null;
+    }
+
+    return {
+      incidentId: undefined,
+      alertId: alertId,
+      label: alert.alertNumber
+        ? `Alert #${alert.alertNumber}`
+        : `Alert ${alertId.toString()}`,
+      citationType: AIChatCitationTargetType.AlertView,
+      citationParams: { alertId: alertId.toString() },
+      monitorId: alert.monitorId,
+    };
+  }
+
+  return null;
+};
+
+/*
+ * The AIRun rows that ARE the investigation lane for one incident/alert.
+ * projectId is pinned to the tenant from ctx because the subject ids are
+ * untrusted model arguments — same defense IncidentTools uses for its
+ * owner join-table lookups.
+ */
+const buildSubjectRunQuery: (
+  incidentId: ObjectID | undefined,
+  alertId: ObjectID | undefined,
+  ctx: ToolContext,
+) => Query<AIRun> = (
+  incidentId: ObjectID | undefined,
+  alertId: ObjectID | undefined,
+  ctx: ToolContext,
+): Query<AIRun> => {
+  if (incidentId) {
+    return {
+      projectId: ctx.projectId,
+      runType: AIRunType.Investigation,
+      triggeredByIncidentId: incidentId,
+    };
+  }
+
+  if (alertId) {
+    return {
+      projectId: ctx.projectId,
+      runType: AIRunType.Investigation,
+      triggeredByAlertId: alertId,
+    };
+  }
+
+  // Callers validate "exactly one of" before building the query.
+  throw new BadDataException(
+    "An investigation subject requires an incidentId or an alertId.",
+  );
+};
+
+/*
+ * ---------------------------------------------------------------------------
+ * get_ai_investigation — the autonomous RCA for one incident/alert.
+ * ---------------------------------------------------------------------------
+ */
+export const GetAIInvestigationTool: ObservabilityTool = {
+  name: "get_ai_investigation",
+  description:
+    "Get the autonomous AI investigation (root cause analysis) for one incident or alert. ALWAYS call this FIRST — before re-deriving a root cause from raw telemetry — when the user asks about an incident or alert: an autonomous investigation may already have analyzed it and posted a cited RCA to its timeline. Pass exactly one of incidentId (from query_incidents) or alertId (from query_alerts). Returns the latest investigation runs with their status (Queued/Running/Completed/Error/Cancelled/Stale), the AI's TL;DR, the full posted root-cause analysis of the latest completed run, the code-fix recommendation, any human verdict and auto-grade, and started/completed timestamps. It also says honestly when the analysis was inconclusive (posted in quiet mode) or when no investigation exists — in which case you can offer start_investigation.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      incidentId: {
+        type: "string",
+        description:
+          "The incident's ID (find it with query_incidents). Pass exactly one of incidentId or alertId.",
+      },
+      alertId: {
+        type: "string",
+        description:
+          "The alert's ID (find it with query_alerts). Pass exactly one of incidentId or alertId.",
+      },
+    },
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveAiRunReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const incidentId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "incidentId",
+    );
+    const alertId: ObjectID | undefined = ToolArgs.getObjectID(args, "alertId");
+
+    if ((incidentId && alertId) || (!incidentId && !alertId)) {
+      return {
+        dataForLlm:
+          "Error: pass exactly one of incidentId or alertId — an investigation belongs to a single incident OR a single alert.",
+        rowCount: 0,
+        citationLabel: "AI investigation (invalid arguments)",
+        redactionCount: 0,
+        isTruncated: false,
+      };
+    }
+
+    const subject: AIInvestigationSubject | null =
+      await fetchInvestigationSubject(incidentId, alertId, ctx);
+
+    if (!subject) {
+      return {
+        dataForLlm: `Error: ${incidentId ? "incident" : "alert"} not found (or you do not have access to it).`,
+        rowCount: 0,
+        citationLabel: "AI investigation (subject not found)",
+        redactionCount: 0,
+        isTruncated: false,
+      };
+    }
+
+    const runs: Array<AIRun> = await AIRunService.findBy({
+      query: buildSubjectRunQuery(incidentId, alertId, ctx),
+      select: {
+        _id: true,
+        status: true,
+        analysisTldr: true,
+        codeFixRecommendation: true,
+        humanVerdict: true,
+        autoGrade: true,
+        createdAt: true,
+        startedAt: true,
+        completedAt: true,
+        attemptCount: true,
+        errorMessage: true,
+      },
+      sort: {
+        createdAt: SortOrder.Descending,
+      },
+      limit: MAX_INVESTIGATION_RUNS_RETURNED,
+      skip: 0,
+      /*
+       * Root props by design: AIRunPrivacyFilter pins non-root reads to
+       * (runType=CodeFix OR userId=caller), and autonomous investigation
+       * runs carry no userId — under user props this query matches zero
+       * rows for every regular member, defeating the tool. Access is
+       * already authorized above: the subject incident/alert was fetched
+       * under the USER's props (honest not-found on no access), the query
+       * pins projectId to the authenticated tenant, and the analysis this
+       * returns is the same text the investigation posted to the incident
+       * feed, which project members can read.
+       */
+      props: { isRoot: true },
+    });
+
+    if (runs.length === 0) {
+      return {
+        dataForLlm: `No AI investigation runs exist for ${subject.label}. The automatic gates may have skipped it (severity floor, dedupe window, the project's automatic-investigation opt-in, or the daily AI budget). You can offer to start one with start_investigation.`,
+        rowCount: 0,
+        citationLabel: `AI investigation for ${subject.label} (none found)`,
+        citationTarget: {
+          type: subject.citationType,
+          params: subject.citationParams,
+        },
+        redactionCount: 0,
+        isTruncated: false,
+      };
+    }
+
+    /*
+     * The posted RCA is the payload the model actually needs, and it lives
+     * on the subject's feed (PostedRootCause is its single reader). Subject
+     * visibility was already verified under the user's RBAC above, so the
+     * isRoot read inside PostedRootCause cannot cross a tenant boundary.
+     */
+    const latestCompletedRun: AIRun | undefined = runs.find((run: AIRun) => {
+      return run.status === AIRunStatus.Completed;
+    });
+
+    let postedAnalysis: string | null = null;
+    if (latestCompletedRun && latestCompletedRun.id) {
+      postedAnalysis = await PostedRootCause.getForInvestigation({
+        incidentId: incidentId,
+        alertId: alertId,
+        aiRunId: latestCompletedRun.id,
+        runCompletedAt: latestCompletedRun.completedAt,
+      });
+    }
+
+    const rows: Array<JSONObject> = runs.map((run: AIRun) => {
+      return {
+        runId: run.id?.toString(),
+        status: run.status,
+        queuedAt: run.createdAt,
+        startedAt: run.startedAt,
+        completedAt: run.completedAt,
+        attemptCount: run.attemptCount,
+        analysisTldr: run.analysisTldr,
+        codeFixRecommendation: run.codeFixRecommendation,
+        humanVerdict: run.humanVerdict,
+        autoGrade: run.autoGrade,
+        errorMessage: run.errorMessage,
+      };
+    });
+
+    // Tell the model plainly what state the LATEST run is in.
+    const latestRun: AIRun = runs[0] as AIRun;
+    let statusNote: string;
+    switch (latestRun.status) {
+      case AIRunStatus.Queued:
+        statusNote =
+          "The latest investigation is still QUEUED — no worker has claimed it yet. Check again shortly with get_ai_investigation.";
+        break;
+      case AIRunStatus.Running:
+      case AIRunStatus.WaitingForApproval:
+        statusNote =
+          "The latest investigation is still RUNNING — its analysis has not been posted yet. Check again in a minute or two.";
+        break;
+      case AIRunStatus.Completed:
+        statusNote = postedAnalysis
+          ? "The latest investigation COMPLETED and posted the root cause analysis below. Use and cite it instead of re-deriving the analysis from raw telemetry (verify against current telemetry only where the user asks you to)."
+          : "The latest investigation COMPLETED, but no posted analysis could be found on the timeline.";
+        break;
+      default:
+        // Error / Cancelled / Stale — the row's errorMessage says why.
+        statusNote =
+          `The latest investigation did NOT produce an analysis (status: ${latestRun.status}). ${latestRun.errorMessage || ""}`.trim();
+        break;
+    }
+
+    /*
+     * Quiet-mode honesty: an inconclusive analysis is posted to the timeline
+     * WITHOUT the loud workspace/on-call ping. Surface that so the model
+     * repeats the uncertainty instead of presenting the hypothesis as fact.
+     */
+    const isInconclusive: boolean = INCONCLUSIVE_RE.test(
+      `${latestCompletedRun?.analysisTldr || ""}\n${postedAnalysis || ""}`,
+    );
+    if (isInconclusive) {
+      statusNote = `${statusNote} NOTE: the investigation reported the evidence was INCONCLUSIVE — it was posted in quiet mode (timeline only, no loud workspace notification). Be honest about that uncertainty.`;
+    }
+
+    const serializedRuns: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    const parts: Array<string> = [statusNote, serializedRuns.text];
+
+    let analysisRedactionCount: number = 0;
+    let analysisIsTruncated: boolean = false;
+    if (postedAnalysis && latestCompletedRun) {
+      const serializedAnalysis: SerializedResult =
+        ToolResultSerializer.serializeText(postedAnalysis, 1);
+      analysisRedactionCount = serializedAnalysis.redactionCount;
+      analysisIsTruncated = serializedAnalysis.isTruncated;
+      parts.push(
+        `--- Posted root cause analysis (run ${latestCompletedRun.id?.toString()}) ---\n${serializedAnalysis.text}`,
+      );
+    }
+
+    return {
+      dataForLlm: parts.join("\n\n"),
+      rowCount: serializedRuns.rowCount,
+      citationLabel: `AI investigation for ${subject.label} (${runs.length} ${runs.length === 1 ? "run" : "runs"})`,
+      citationTarget: {
+        type: subject.citationType,
+        params: subject.citationParams,
+      },
+      redactionCount: serializedRuns.redactionCount + analysisRedactionCount,
+      isTruncated: serializedRuns.isTruncated || analysisIsTruncated,
+      widget: WidgetBuilder.table({
+        title: `AI investigations — ${subject.label}`,
+        columns: [
+          { key: "status", title: "Status" },
+          { key: "analysisTldr", title: "TL;DR" },
+          { key: "startedAt", title: "Started", type: "date" },
+          { key: "completedAt", title: "Completed", type: "date" },
+        ],
+        rows: rows,
+        link: {
+          type: subject.citationType,
+          params: subject.citationParams,
+        },
+      }),
+    };
+  },
+};
+
+/*
+ * ---------------------------------------------------------------------------
+ * query_ai_insights — recent preventive findings ("any early warnings?").
+ * ---------------------------------------------------------------------------
+ */
+export const QueryAIInsightsTool: ObservabilityTool = {
+  name: "query_ai_insights",
+  description:
+    "List recent AI Insights — preventive findings from OneUptime AI's deterministic telemetry sensors (new/spiking exceptions, error-log spikes, trace-latency regressions, metric drift), each optionally triaged by AI. Use this to answer 'any early warnings for this service?' or to correlate an incident with warnings that pre-dated it. Optional filters: serviceId (a telemetry service id) and status (Detected, ActionRequired, FixOpened, Resolved, Dismissed). Returns each insight's type, severity, status, AI triage classification and summary, affected service and first/last-seen times, most recently seen first (default: seen in the last 7 days).",
+  inputSchema: {
+    type: "object",
+    properties: {
+      serviceId: {
+        type: "string",
+        description:
+          "Only insights about this telemetry service (optional). Find service ids with lookup_context.",
+      },
+      status: {
+        type: "string",
+        description:
+          "Only insights in this status (optional). One of: Detected, ActionRequired, FixOpened, Resolved, Dismissed.",
+      },
+      lookbackDays: {
+        type: "number",
+        description:
+          "Only insights last seen within this many days (default 7, max 90).",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum insights to return (default 10, max 25).",
+      },
+      skip: {
+        type: "number",
+        description: "Rows to skip for pagination (default 0).",
+      },
+    },
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveAiInsightReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const statusArg: string | undefined = ToolArgs.getString(args, "status");
+    let statusFilter: AIInsightStatus | undefined = undefined;
+
+    if (statusArg) {
+      statusFilter = Object.values(AIInsightStatus).find(
+        (value: AIInsightStatus) => {
+          return value.toLowerCase() === statusArg.toLowerCase();
+        },
+      );
+
+      if (!statusFilter) {
+        return {
+          dataForLlm: `Error: status "${statusArg}" is not a valid AI insight status. Valid statuses: ${Object.values(
+            AIInsightStatus,
+          ).join(", ")}.`,
+          rowCount: 0,
+          citationLabel: "AI insights (invalid status filter)",
+          redactionCount: 0,
+          isTruncated: false,
+        };
+      }
+    }
+
+    const serviceId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "serviceId",
+    );
+    const lookbackDays: number = ToolArgs.getNumber(args, "lookbackDays", {
+      defaultValue: 7,
+      min: 1,
+      max: 90,
+    });
+    const limit: number = ToolArgs.getNumber(args, "limit", {
+      defaultValue: 10,
+      min: 1,
+      max: 25,
+    });
+    const skip: number = ToolArgs.getNumber(args, "skip", {
+      defaultValue: 0,
+      min: 0,
+      max: 500,
+    });
+
+    const endTime: Date = OneUptimeDate.getCurrentDate();
+    const startTime: Date = OneUptimeDate.getSomeDaysAgo(lookbackDays);
+
+    /*
+     * lastSeenAt (not createdAt): a finding first detected weeks ago that
+     * the scanner is STILL re-detecting today is exactly the live early
+     * warning this tool exists to surface.
+     */
+    const query: Query<AIInsight> = {
+      projectId: ctx.projectId,
+      lastSeenAt: QueryHelper.inBetween(startTime, endTime),
+    };
+    if (serviceId) {
+      query.telemetryServiceId = serviceId;
+    }
+    if (statusFilter) {
+      query.status = statusFilter;
+    }
+
+    const totalCount: number = (
+      await AIInsightService.countBy({
+        query: query,
+        props: ctx.props,
+      })
+    ).toNumber();
+
+    const insights: Array<AIInsight> = await AIInsightService.findBy({
+      query: query,
+      select: {
+        _id: true,
+        insightType: true,
+        status: true,
+        severity: true,
+        classification: true,
+        title: true,
+        serviceName: true,
+        telemetryServiceId: true,
+        metricName: true,
+        occurrenceCount: true,
+        firstSeenAt: true,
+        lastSeenAt: true,
+        triageSummaryMarkdown: true,
+        humanVerdict: true,
+      },
+      sort: {
+        lastSeenAt: SortOrder.Descending,
+      },
+      limit: limit,
+      skip: skip,
+      props: ctx.props,
+    });
+
+    const rows: Array<JSONObject> = insights.map((insight: AIInsight) => {
+      return {
+        id: insight.id?.toString(),
+        insightType: insight.insightType,
+        status: insight.status,
+        severity: insight.severity,
+        classification: insight.classification,
+        title: insight.title,
+        serviceName: insight.serviceName,
+        telemetryServiceId: insight.telemetryServiceId?.toString(),
+        metricName: insight.metricName,
+        occurrenceCount: insight.occurrenceCount,
+        firstSeenAt: insight.firstSeenAt,
+        lastSeenAt: insight.lastSeenAt,
+        humanVerdict: insight.humanVerdict,
+        triageSummary: insight.triageSummaryMarkdown,
+      };
+    });
+
+    const serialized: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    let dataForLlm: string = serialized.text;
+    if (rows.length > 0 && totalCount > rows.length) {
+      dataForLlm = `Showing rows ${skip + 1}–${skip + rows.length} of ${totalCount} total. Pass skip to page further.\n${dataForLlm}`;
+    }
+
+    // No dedicated dashboard page target exists for insights — no deep link.
+    return {
+      dataForLlm: dataForLlm,
+      rowCount: serialized.rowCount,
+      citationLabel: `AI insights, last ${lookbackDays}d (${totalCount} found)`,
+      redactionCount: serialized.redactionCount,
+      isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `AI insights (${totalCount})`,
+              description: `Preventive findings seen in the last ${lookbackDays}d`,
+              columns: [
+                { key: "severity", title: "Severity" },
+                { key: "title", title: "Finding" },
+                { key: "serviceName", title: "Service" },
+                { key: "status", title: "Status" },
+                { key: "classification", title: "Triage" },
+                { key: "lastSeenAt", title: "Last seen", type: "date" },
+              ],
+              rows: rows,
+            })
+          : undefined,
+    };
+  },
+};
+
+/*
+ * ---------------------------------------------------------------------------
+ * start_investigation — enqueue an AI RCA the automatic gates skipped.
+ * ---------------------------------------------------------------------------
+ */
+export const StartInvestigationTool: ObservabilityTool = {
+  name: "start_investigation",
+  description:
+    "Start (enqueue) an autonomous AI investigation for one incident or alert. Use this when get_ai_investigation shows no investigation exists — the automatic gates (severity floor, dedupe window) may have skipped the subject — and the user wants an AI root cause analysis. Pass exactly one of incidentId (from query_incidents) or alertId (from query_alerts). The run is queued durably, usually completes within a few minutes, and posts a cited RCA to the subject's timeline. If an investigation is already queued/running for the subject, or one was started within the last 30 minutes, no duplicate is started and the result says so. Read the outcome with get_ai_investigation.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      incidentId: {
+        type: "string",
+        description:
+          "The incident's ID to investigate (find it with query_incidents). Pass exactly one of incidentId or alertId.",
+      },
+      alertId: {
+        type: "string",
+        description:
+          "The alert's ID to investigate (find it with query_alerts). Pass exactly one of incidentId or alertId.",
+      },
+    },
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveStartInvestigationPermissions();
+  },
+  isMutation: true,
+  buildActionTitle: (args: JSONObject): string => {
+    const incidentId: string | undefined = ToolArgs.getString(
+      args,
+      "incidentId",
+    );
+    if (incidentId) {
+      return `Start AI investigation for incident ${incidentId}`;
+    }
+
+    const alertId: string | undefined = ToolArgs.getString(args, "alertId");
+    if (alertId) {
+      return `Start AI investigation for alert ${alertId}`;
+    }
+
+    return "Start AI investigation";
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const incidentId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "incidentId",
+    );
+    const alertId: ObjectID | undefined = ToolArgs.getObjectID(args, "alertId");
+
+    if ((incidentId && alertId) || (!incidentId && !alertId)) {
+      throw new BadDataException(
+        "Pass exactly one of incidentId or alertId — an investigation belongs to a single incident OR a single alert.",
+      );
+    }
+
+    const subject: AIInvestigationSubject | null =
+      await fetchInvestigationSubject(incidentId, alertId, ctx);
+
+    if (!subject) {
+      throw new BadDataException(
+        `${incidentId ? "Incident" : "Alert"} not found (or you do not have access to it).`,
+      );
+    }
+
+    const subjectRunQuery: Query<AIRun> = buildSubjectRunQuery(
+      incidentId,
+      alertId,
+      ctx,
+    );
+
+    /*
+     * Per-subject dedupe, mirrored from the automatic lanes but keyed on the
+     * exact entity: never stack a second live run on the same subject.
+     * (The severity floor is deliberately NOT applied — an explicit user
+     * request overrides that automatic cost gate.)
+     */
+    const activeRunCount: number = (
+      await AIRunService.countBy({
+        query: {
+          ...subjectRunQuery,
+          status: QueryHelper.notIn(AIRunStatusHelper.terminalStatuses()),
+        },
+        /*
+         * Root props: investigation runs carry no userId, so the AIRun
+         * privacy pin would zero this count for regular members and the
+         * dedupe guard would never fire (see get_ai_investigation for the
+         * full rationale — subject access was checked under user props and
+         * the query pins projectId).
+         */
+        props: { isRoot: true },
+      })
+    ).toNumber();
+
+    if (activeRunCount > 0) {
+      return {
+        dataForLlm: `An AI investigation is already queued or running for ${subject.label} — not starting another. Follow it with get_ai_investigation.`,
+        rowCount: 0,
+        citationLabel: `Investigation already in progress for ${subject.label}`,
+        citationTarget: {
+          type: subject.citationType,
+          params: subject.citationParams,
+        },
+        redactionCount: 0,
+        isTruncated: false,
+      };
+    }
+
+    /*
+     * Cooldown: reuse the automatic lane's default dedupe window (30
+     * minutes). A run that recently settled for this exact subject already
+     * answered — or errored on — the same question; point the model at it
+     * instead of double-spending the budget.
+     */
+    const cooldownStart: Date = OneUptimeDate.getSomeMinutesAgo(
+      DEFAULT_INCIDENT_DEDUPE_WINDOW_MINUTES,
+    );
+    const recentRunCount: number = (
+      await AIRunService.countBy({
+        query: {
+          ...subjectRunQuery,
+          createdAt: QueryHelper.greaterThan(cooldownStart),
+        },
+        // Root props for the same reason as the active-run guard above.
+        props: { isRoot: true },
+      })
+    ).toNumber();
+
+    if (recentRunCount > 0) {
+      return {
+        dataForLlm: `A recent AI investigation already exists for ${subject.label} (started within the last ${DEFAULT_INCIDENT_DEDUPE_WINDOW_MINUTES} minutes) — not starting a duplicate. Read it with get_ai_investigation.`,
+        rowCount: 0,
+        citationLabel: `Recent investigation exists for ${subject.label}`,
+        citationTarget: {
+          type: subject.citationType,
+          params: subject.citationParams,
+        },
+        redactionCount: 0,
+        isTruncated: false,
+      };
+    }
+
+    /*
+     * The SAME durable enqueue path the automatic lanes use: an AIRun in
+     * status Queued that the worker poller claims (with an inline kick for
+     * happy-path latency). projectId comes from ctx — never from an
+     * argument. enqueue never throws; null means the daily autonomous AI
+     * budget quiet-skipped it or the enqueue failed.
+     */
+    const enqueuedRunId: ObjectID | null = await AIInvestigationQueue.enqueue({
+      projectId: ctx.projectId,
+      subjectIncidentId: incidentId,
+      subjectAlertId: alertId,
+      subjectMonitorId: subject.monitorId,
+    });
+
+    if (!enqueuedRunId) {
+      return {
+        dataForLlm: `The investigation for ${subject.label} could not be enqueued — the project's daily autonomous AI token budget may be exhausted, or the enqueue failed. Try again later.`,
+        rowCount: 0,
+        citationLabel: `Investigation not enqueued for ${subject.label}`,
+        citationTarget: {
+          type: subject.citationType,
+          params: subject.citationParams,
+        },
+        redactionCount: 0,
+        isTruncated: false,
+      };
+    }
+
+    const serialized: SerializedResult = ToolResultSerializer.serializeRows([
+      {
+        runId: enqueuedRunId.toString(),
+        subject: subject.label,
+        status: AIRunStatus.Queued,
+      },
+    ]);
+
+    return {
+      dataForLlm: `Queued AI investigation run ${enqueuedRunId.toString()} for ${subject.label}. It usually completes within a few minutes and posts a cited root-cause analysis to the ${incidentId ? "incident" : "alert"} timeline. Read the result with get_ai_investigation.\n${serialized.text}`,
+      rowCount: 1,
+      citationLabel: `AI investigation queued for ${subject.label}`,
+      citationTarget: {
+        type: subject.citationType,
+        params: subject.citationParams,
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: false,
+      widget: WidgetBuilder.resourceCard({
+        title: "AI investigation queued",
+        resourceType: "AIRun",
+        heading: subject.label,
+        subheading: "Investigation queued",
+        fields: [
+          { label: "Run", value: enqueuedRunId.toString() },
+          { label: "Subject", value: subject.label },
+        ],
+        link: {
+          type: subject.citationType,
+          params: subject.citationParams,
+        },
+      }),
+    };
+  },
+};

--- a/Common/Server/Utils/AI/Toolbox/AlertTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/AlertTools.ts
@@ -1,10 +1,15 @@
 import Alert from "../../../../Models/DatabaseModels/Alert";
+import AlertOwnerTeam from "../../../../Models/DatabaseModels/AlertOwnerTeam";
+import AlertOwnerUser from "../../../../Models/DatabaseModels/AlertOwnerUser";
 import { JSONObject } from "../../../../Types/JSON";
 import ObjectID from "../../../../Types/ObjectID";
 import Permission from "../../../../Types/Permission";
+import Query from "../../../../Types/BaseDatabase/Query";
 import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
 import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
 import AlertService from "../../../Services/AlertService";
+import AlertOwnerTeamService from "../../../Services/AlertOwnerTeamService";
+import AlertOwnerUserService from "../../../Services/AlertOwnerUserService";
 import QueryHelper from "../../../Types/Database/QueryHelper";
 import OneUptimeDate from "../../../../Types/Date";
 import ToolResultSerializer, { SerializedResult } from "./Serializer";
@@ -32,25 +37,39 @@ const resolveReadPermissions: () => Array<Permission> =
     return cachedReadPermissions;
   };
 
+type AlertStateFilter = "active" | "resolved" | "any";
+
 export const QueryAlertsTool: ObservabilityTool = {
   name: "query_alerts",
   description:
-    "Query alerts in this project. Returns the most recent alerts with their current state and severity. Pass alertId to get full details of one alert.",
+    "Query alerts in this project with their current state and severity. To answer 'which alerts are active/firing right now?' pass state='active' — it returns every unresolved alert regardless of age (no time window unless createdWithinHours is passed explicitly). state='resolved' returns only resolved alerts; the default 'any' returns both, limited to the createdWithinHours window. Results are newest-first; the result reports the total match count — pass skip to page through more. Pass alertId to get full details of one alert, including its description and its owners (teams and users).",
   inputSchema: {
     type: "object",
     properties: {
       alertId: {
         type: "string",
-        description: "Get one alert by its ID (includes description).",
+        description:
+          "Get one alert by its ID (includes description and owners).",
+      },
+      state: {
+        type: "string",
+        enum: ["active", "resolved", "any"],
+        description:
+          "Filter by current alert state: 'active' = not yet resolved (any age), 'resolved' = resolved only, 'any' = both (default).",
       },
       createdWithinHours: {
         type: "number",
         description:
-          "Only alerts created within this many hours (default 24, max 720).",
+          "Only alerts created within this many hours (default 24, max 720). Ignored for state='active' unless passed explicitly, so long-running active alerts are never hidden.",
       },
       limit: {
         type: "number",
         description: "Maximum alerts to return (default 10, max 25).",
+      },
+      skip: {
+        type: "number",
+        description:
+          "Rows to skip for paging through a large result (default 0, max 500).",
       },
     },
   },
@@ -82,6 +101,73 @@ export const QueryAlertsTool: ObservabilityTool = {
         props: ctx.props,
       });
 
+      let ownerTeamNames: string = "";
+      let ownerUserNames: string = "";
+
+      if (alert) {
+        /*
+         * Owners live in join tables, not on the Alert row itself. projectId
+         * is pinned to the tenant from ctx because alertId is an untrusted
+         * model argument.
+         */
+        const ownerTeams: Array<AlertOwnerTeam> =
+          await AlertOwnerTeamService.findBy({
+            query: {
+              alertId: alertId,
+              projectId: ctx.projectId,
+            },
+            select: {
+              _id: true,
+              team: {
+                name: true,
+              },
+            },
+            limit: 10,
+            skip: 0,
+            props: ctx.props,
+          });
+
+        const ownerUsers: Array<AlertOwnerUser> =
+          await AlertOwnerUserService.findBy({
+            query: {
+              alertId: alertId,
+              projectId: ctx.projectId,
+            },
+            select: {
+              _id: true,
+              user: {
+                name: true,
+                email: true,
+              },
+            },
+            limit: 10,
+            skip: 0,
+            props: ctx.props,
+          });
+
+        ownerTeamNames = ownerTeams
+          .map((ownerTeam: AlertOwnerTeam) => {
+            return ownerTeam.team?.name || "";
+          })
+          .filter((value: string) => {
+            return value.length > 0;
+          })
+          .join(", ");
+
+        ownerUserNames = ownerUsers
+          .map((ownerUser: AlertOwnerUser) => {
+            return (
+              ownerUser.user?.name?.toString() ||
+              ownerUser.user?.email?.toString() ||
+              ""
+            );
+          })
+          .filter((value: string) => {
+            return value.length > 0;
+          })
+          .join(", ");
+      }
+
       const rows: Array<JSONObject> = alert
         ? [
             {
@@ -92,6 +178,8 @@ export const QueryAlertsTool: ObservabilityTool = {
               state: alert.currentAlertState?.name,
               severity: alert.alertSeverity?.name,
               createdAt: alert.createdAt,
+              ownerTeams: ownerTeamNames || undefined,
+              ownerUsers: ownerUserNames || undefined,
             },
           ]
         : [];
@@ -123,6 +211,14 @@ export const QueryAlertsTool: ObservabilityTool = {
       };
     }
 
+    const stateArg: string | undefined = ToolArgs.getString(args, "state");
+    const state: AlertStateFilter =
+      stateArg?.toLowerCase() === "active"
+        ? "active"
+        : stateArg?.toLowerCase() === "resolved"
+          ? "resolved"
+          : "any";
+
     const createdWithinHours: number = ToolArgs.getNumber(
       args,
       "createdWithinHours",
@@ -133,17 +229,52 @@ export const QueryAlertsTool: ObservabilityTool = {
       min: 1,
       max: 25,
     });
+    const skip: number = ToolArgs.getNumber(args, "skip", {
+      defaultValue: 0,
+      min: 0,
+      max: 500,
+    });
 
-    const endTime: Date = OneUptimeDate.getCurrentDate();
-    const startTime: Date = OneUptimeDate.addRemoveHours(
-      endTime,
-      -1 * createdWithinHours,
-    );
+    const query: Query<Alert> = {};
+
+    /*
+     * State is matched through the AlertState flags rather than the state
+     * name, so custom state names ("Firing", "Triaged", …) still classify
+     * correctly: anything not flagged resolved counts as active.
+     */
+    if (state === "active") {
+      query.currentAlertState = { isResolvedState: false };
+    } else if (state === "resolved") {
+      query.currentAlertState = { isResolvedState: true };
+    }
+
+    /*
+     * "active" answers "what is firing right now?" — an alert that opened a
+     * week ago and is still unresolved must show up, so the createdAt window
+     * only applies when the model asked for one explicitly. "Explicitly"
+     * mirrors ToolArgs.getNumber parsing (same rule as IncidentTools): only
+     * a usable number counts — junk like "all" would otherwise re-impose
+     * the 24h default and hide exactly the long-running alerts this filter
+     * exists to surface.
+     */
+    const rawWindow: unknown = args["createdWithinHours"];
+    const hasExplicitWindow: boolean =
+      (typeof rawWindow === "number" && Number.isFinite(rawWindow)) ||
+      (typeof rawWindow === "string" &&
+        rawWindow.trim().length > 0 &&
+        Number.isFinite(Number(rawWindow)));
+
+    if (state !== "active" || hasExplicitWindow) {
+      const endTime: Date = OneUptimeDate.getCurrentDate();
+      const startTime: Date = OneUptimeDate.addRemoveHours(
+        endTime,
+        -1 * createdWithinHours,
+      );
+      query.createdAt = QueryHelper.inBetween(startTime, endTime);
+    }
 
     const alerts: Array<Alert> = await AlertService.findBy({
-      query: {
-        createdAt: QueryHelper.inBetween(startTime, endTime),
-      },
+      query: query,
       select: {
         _id: true,
         title: true,
@@ -160,9 +291,16 @@ export const QueryAlertsTool: ObservabilityTool = {
         createdAt: SortOrder.Descending,
       },
       limit: limit,
-      skip: 0,
+      skip: skip,
       props: ctx.props,
     });
+
+    const totalCount: number = (
+      await AlertService.countBy({
+        query: query,
+        props: ctx.props,
+      })
+    ).toNumber();
 
     const rows: Array<JSONObject> = alerts.map((alert: Alert) => {
       return {
@@ -178,10 +316,31 @@ export const QueryAlertsTool: ObservabilityTool = {
     const serialized: SerializedResult =
       ToolResultSerializer.serializeRows(rows);
 
+    let dataForLlm: string = serialized.text;
+    if (rows.length > 0 && totalCount > rows.length) {
+      dataForLlm = `Showing rows ${skip + 1}–${skip + rows.length} of ${totalCount} total. Pass skip to page further.\n${serialized.text}`;
+    }
+
+    let scopeLabel: string;
+    if (state === "active") {
+      scopeLabel = hasExplicitWindow
+        ? `Active alerts, last ${createdWithinHours}h`
+        : "Active alerts";
+    } else if (state === "resolved") {
+      scopeLabel = `Resolved alerts, last ${createdWithinHours}h`;
+    } else {
+      scopeLabel = `Alerts, last ${createdWithinHours}h`;
+    }
+
+    const citationLabel: string =
+      totalCount > serialized.rowCount
+        ? `${scopeLabel} (${serialized.rowCount} of ${totalCount})`
+        : `${scopeLabel} (${serialized.rowCount} found)`;
+
     return {
-      dataForLlm: serialized.text,
+      dataForLlm: dataForLlm,
       rowCount: serialized.rowCount,
-      citationLabel: `Alerts, last ${createdWithinHours}h (${serialized.rowCount} found)`,
+      citationLabel: citationLabel,
       citationTarget: {
         type: AIChatCitationTargetType.Alerts,
       },
@@ -191,7 +350,10 @@ export const QueryAlertsTool: ObservabilityTool = {
         rows.length > 0
           ? WidgetBuilder.alertList({
               title: `Alerts (${rows.length})`,
-              description: `Created in the last ${createdWithinHours}h`,
+              description:
+                state === "active" && !hasExplicitWindow
+                  ? "Currently unresolved alerts"
+                  : `Created in the last ${createdWithinHours}h`,
               items: rows,
               link: { type: AIChatCitationTargetType.Alerts },
             })

--- a/Common/Server/Utils/AI/Toolbox/IncidentTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/IncidentTools.ts
@@ -1,10 +1,17 @@
 import Incident from "../../../../Models/DatabaseModels/Incident";
+import IncidentOwnerTeam from "../../../../Models/DatabaseModels/IncidentOwnerTeam";
+import IncidentOwnerUser from "../../../../Models/DatabaseModels/IncidentOwnerUser";
+import BadDataException from "../../../../Types/Exception/BadDataException";
 import { JSONObject } from "../../../../Types/JSON";
 import ObjectID from "../../../../Types/ObjectID";
 import Permission from "../../../../Types/Permission";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import Query from "../../../../Types/BaseDatabase/Query";
 import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
 import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
 import IncidentService from "../../../Services/IncidentService";
+import IncidentOwnerTeamService from "../../../Services/IncidentOwnerTeamService";
+import IncidentOwnerUserService from "../../../Services/IncidentOwnerUserService";
 import QueryHelper from "../../../Types/Database/QueryHelper";
 import OneUptimeDate from "../../../../Types/Date";
 import ToolResultSerializer, { SerializedResult } from "./Serializer";
@@ -15,6 +22,15 @@ import {
   ToolContext,
   ToolExecutionResult,
 } from "./ToolTypes";
+
+// Allowed values for query_incidents' `state` filter.
+type IncidentStateFilter = "active" | "resolved" | "any";
+
+const INCIDENT_STATE_FILTERS: Array<IncidentStateFilter> = [
+  "active",
+  "resolved",
+  "any",
+];
 
 /*
  * Derived from the model ACL so the tool gate can never drift from RBAC.
@@ -35,7 +51,7 @@ const resolveReadPermissions: () => Array<Permission> =
 export const QueryIncidentsTool: ObservabilityTool = {
   name: "query_incidents",
   description:
-    "Query incidents in this project. Returns the most recent incidents with their current state and severity. Pass incidentId to get full details of one incident — including its affected monitors, labels, root cause, remediation and postmortem notes, and the incident window (telemetryWindowStart) to pivot into logs/traces/metrics for the affected services.",
+    'Query incidents in this project. Returns the most recent incidents with their current state and severity. Pass state="active" to list currently unresolved incidents regardless of when they were created (use this for \'what incidents are active/open right now?\'), or state="resolved" for closed ones. Pass incidentId to get full details of one incident — including its owner teams and owner users, affected monitors, labels, root cause, remediation and postmortem notes, and the incident window (telemetryWindowStart) to pivot into logs/traces/metrics for the affected services. For the incident\'s activity thread — state changes, notes and the latest updates — use get_incident_timeline.',
   inputSchema: {
     type: "object",
     properties: {
@@ -43,14 +59,25 @@ export const QueryIncidentsTool: ObservabilityTool = {
         type: "string",
         description: "Get one incident by its ID (includes description).",
       },
+      state: {
+        type: "string",
+        enum: ["active", "resolved", "any"],
+        description:
+          "Filter by current state: 'active' = not yet resolved (ignores the time window unless createdWithinHours is passed explicitly, so long-running open incidents are included), 'resolved' = resolved only, 'any' = no state filter (default).",
+      },
       createdWithinHours: {
         type: "number",
         description:
-          "Only incidents created within this many hours (default 168 = 7 days, max 720).",
+          "Only incidents created within this many hours (default 168 = 7 days, max 720). Ignored when state is 'active' unless passed explicitly.",
       },
       limit: {
         type: "number",
         description: "Maximum incidents to return (default 10, max 25).",
+      },
+      skip: {
+        type: "number",
+        description:
+          "Number of incidents to skip for pagination (default 0, max 500).",
       },
     },
   },
@@ -96,6 +123,76 @@ export const QueryIncidentsTool: ObservabilityTool = {
       });
 
       /*
+       * Ownership lives in join tables (IncidentOwnerTeam/IncidentOwnerUser),
+       * not as relations on the Incident model itself, so "who owns this
+       * incident?" needs two extra scoped queries. projectId is pinned to the
+       * tenant from ctx because incidentId is an untrusted model argument.
+       */
+      let ownerTeamNames: string = "";
+      let ownerUserNames: string = "";
+
+      if (incident) {
+        const [ownerTeams, ownerUsers]: [
+          Array<IncidentOwnerTeam>,
+          Array<IncidentOwnerUser>,
+        ] = await Promise.all([
+          IncidentOwnerTeamService.findBy({
+            query: {
+              incidentId: incidentId,
+              projectId: ctx.projectId,
+            },
+            select: {
+              _id: true,
+              team: {
+                name: true,
+              },
+            },
+            limit: 25,
+            skip: 0,
+            props: ctx.props,
+          }),
+          IncidentOwnerUserService.findBy({
+            query: {
+              incidentId: incidentId,
+              projectId: ctx.projectId,
+            },
+            select: {
+              _id: true,
+              user: {
+                name: true,
+                email: true,
+              },
+            },
+            limit: 25,
+            skip: 0,
+            props: ctx.props,
+          }),
+        ]);
+
+        ownerTeamNames = ownerTeams
+          .map((ownerTeam: IncidentOwnerTeam) => {
+            return ownerTeam.team?.name || "";
+          })
+          .filter((value: string) => {
+            return value.length > 0;
+          })
+          .join(", ");
+
+        ownerUserNames = ownerUsers
+          .map((ownerUser: IncidentOwnerUser) => {
+            return (
+              ownerUser.user?.name?.toString() ||
+              ownerUser.user?.email?.toString() ||
+              ""
+            );
+          })
+          .filter((value: string) => {
+            return value.length > 0;
+          })
+          .join(", ");
+      }
+
+      /*
        * Surface the incident's blast radius (affected monitors + labels) and
        * its own window so the model can pivot from an incident into the
        * logs/traces/metrics of the affected services over the right time
@@ -129,6 +226,8 @@ export const QueryIncidentsTool: ObservabilityTool = {
               state: incident.currentIncidentState?.name,
               severity: incident.incidentSeverity?.name,
               createdAt: incident.createdAt,
+              ownerTeams: ownerTeamNames || undefined,
+              ownerUsers: ownerUserNames || undefined,
               affectedMonitors: affectedMonitors || undefined,
               labels: incidentLabels || undefined,
               rootCause: incident.rootCause,
@@ -166,6 +265,20 @@ export const QueryIncidentsTool: ObservabilityTool = {
       };
     }
 
+    const stateFilterString: string =
+      ToolArgs.getString(args, "state") || "any";
+
+    if (
+      !INCIDENT_STATE_FILTERS.includes(stateFilterString as IncidentStateFilter)
+    ) {
+      throw new BadDataException(
+        `Invalid state: ${stateFilterString}. Use one of: active, resolved, any.`,
+      );
+    }
+
+    const stateFilter: IncidentStateFilter =
+      stateFilterString as IncidentStateFilter;
+
     const createdWithinHours: number = ToolArgs.getNumber(
       args,
       "createdWithinHours",
@@ -176,6 +289,27 @@ export const QueryIncidentsTool: ObservabilityTool = {
       min: 1,
       max: 25,
     });
+    const skip: number = ToolArgs.getNumber(args, "skip", {
+      defaultValue: 0,
+      min: 0,
+      max: 500,
+    });
+
+    /*
+     * Mirrors ToolArgs.getNumber parsing: the window was "provided" only when
+     * the raw argument is a usable number. Needed because an active incident
+     * opened months ago must still show up for "what's active right now?" —
+     * so state=active drops the createdAt filter unless the model explicitly
+     * asked for a window.
+     */
+    const rawWindow: unknown = args["createdWithinHours"];
+    const windowProvided: boolean =
+      (typeof rawWindow === "number" && Number.isFinite(rawWindow)) ||
+      (typeof rawWindow === "string" &&
+        rawWindow.trim().length > 0 &&
+        Number.isFinite(Number(rawWindow)));
+
+    const applyTimeFilter: boolean = stateFilter !== "active" || windowProvided;
 
     const endTime: Date = OneUptimeDate.getCurrentDate();
     const startTime: Date = OneUptimeDate.addRemoveHours(
@@ -183,10 +317,34 @@ export const QueryIncidentsTool: ObservabilityTool = {
       -1 * createdWithinHours,
     );
 
+    const query: Query<Incident> = {};
+
+    if (applyTimeFilter) {
+      query.createdAt = QueryHelper.inBetween(startTime, endTime);
+    }
+
+    /*
+     * currentIncidentState is resolved through the state's flags rather than
+     * by name, because state names are user-configurable per project while
+     * isResolvedState is the canonical "closed" marker.
+     */
+    if (stateFilter === "active") {
+      query.currentIncidentState = {
+        isResolvedState: false,
+      };
+    } else if (stateFilter === "resolved") {
+      query.currentIncidentState = {
+        isResolvedState: true,
+      };
+    }
+
+    const totalCount: PositiveNumber = await IncidentService.countBy({
+      query: query,
+      props: ctx.props,
+    });
+
     const incidents: Array<Incident> = await IncidentService.findBy({
-      query: {
-        createdAt: QueryHelper.inBetween(startTime, endTime),
-      },
+      query: query,
       select: {
         _id: true,
         title: true,
@@ -203,7 +361,7 @@ export const QueryIncidentsTool: ObservabilityTool = {
         createdAt: SortOrder.Descending,
       },
       limit: limit,
-      skip: 0,
+      skip: skip,
       props: ctx.props,
     });
 
@@ -221,10 +379,31 @@ export const QueryIncidentsTool: ObservabilityTool = {
     const serialized: SerializedResult =
       ToolResultSerializer.serializeRows(rows);
 
+    const total: number = totalCount.toNumber();
+
+    let dataForLlm: string = serialized.text;
+    if (total > rows.length && rows.length > 0) {
+      dataForLlm = `Showing rows ${skip + 1}–${skip + rows.length} of ${total} total. Pass skip to page further.\n${dataForLlm}`;
+    } else if (total > 0 && rows.length === 0 && skip > 0) {
+      // Paged past the end: keep the model oriented instead of a bare empty.
+      dataForLlm = `No rows at skip=${skip}; there are ${total} total. Lower skip to page back.\n${dataForLlm}`;
+    }
+
+    const windowLabel: string = applyTimeFilter
+      ? `, last ${createdWithinHours}h`
+      : "";
+
+    let stateLabel: string = "Incidents";
+    if (stateFilter === "active") {
+      stateLabel = "Active incidents";
+    } else if (stateFilter === "resolved") {
+      stateLabel = "Resolved incidents";
+    }
+
     return {
-      dataForLlm: serialized.text,
+      dataForLlm: dataForLlm,
       rowCount: serialized.rowCount,
-      citationLabel: `Incidents, last ${createdWithinHours}h (${serialized.rowCount} found)`,
+      citationLabel: `${stateLabel}${windowLabel} (${total} total)`,
       citationTarget: {
         type: AIChatCitationTargetType.Incidents,
       },
@@ -233,8 +412,10 @@ export const QueryIncidentsTool: ObservabilityTool = {
       widget:
         rows.length > 0
           ? WidgetBuilder.incidentList({
-              title: `Incidents (${rows.length})`,
-              description: `Created in the last ${createdWithinHours}h`,
+              title: `${stateLabel} (${total})`,
+              description: applyTimeFilter
+                ? `Created in the last ${createdWithinHours}h`
+                : "Regardless of when they were created",
               items: rows,
               link: { type: AIChatCitationTargetType.Incidents },
             })

--- a/Common/Server/Utils/AI/Toolbox/Index.ts
+++ b/Common/Server/Utils/AI/Toolbox/Index.ts
@@ -17,6 +17,26 @@ import { QueryIncidentsTool, SearchIncidentsTool } from "./IncidentTools";
 import { QueryAlertsTool } from "./AlertTools";
 import { QueryMonitorsTool } from "./MonitorTools";
 import { QueryScheduledMaintenanceTool } from "./ScheduledMaintenanceTools";
+import {
+  GetOnCallStatusTool,
+  QueryOnCallPagesTool,
+  QueryOnCallPoliciesTool,
+} from "./OnCallTools";
+import {
+  QueryStatusPageAnnouncementsTool,
+  QueryStatusPagesTool,
+} from "./StatusPageTools";
+import { QuerySlosTool } from "./SloTools";
+import { QueryRunbooksTool } from "./RunbookTools";
+import { GetAlertTimelineTool, GetIncidentTimelineTool } from "./TimelineTools";
+import {
+  GetAIInvestigationTool,
+  QueryAIInsightsTool,
+  StartInvestigationTool,
+} from "./AIMetaTools";
+import { QueryProbesTool, QueryWorkflowsTool } from "./WorkflowProbeTools";
+import { QueryTeamsTool } from "./TeamTools";
+import { CreateAlertNoteTool, CreateIncidentNoteTool } from "./NoteWriteTools";
 import { TopExceptionsTool } from "./ExceptionTools";
 import { LogHistogramTool, SearchLogsTool } from "./LogTools";
 import { RecentChangesTool } from "./RecentChangesTools";
@@ -72,9 +92,33 @@ export default class AIToolbox {
     LookupContextTool,
     QueryIncidentsTool,
     SearchIncidentsTool,
+    GetIncidentTimelineTool,
+    GetAlertTimelineTool,
     QueryAlertsTool,
     QueryMonitorsTool,
     QueryScheduledMaintenanceTool,
+    /*
+     * Platform reads: the operational surface an on-call product exists to
+     * answer questions about — who is on call, what does the runbook say,
+     * what do customers see, is the error budget burning.
+     */
+    QueryOnCallPoliciesTool,
+    GetOnCallStatusTool,
+    QueryOnCallPagesTool,
+    QueryStatusPagesTool,
+    QueryStatusPageAnnouncementsTool,
+    QuerySlosTool,
+    QueryRunbooksTool,
+    QueryWorkflowsTool,
+    QueryProbesTool,
+    QueryTeamsTool,
+    /*
+     * The AI's own prior work: autonomous investigation results and insight
+     * findings. Chat reads these first instead of re-deriving a root cause
+     * the platform already posted.
+     */
+    GetAIInvestigationTool,
+    QueryAIInsightsTool,
     TopExceptionsTool,
     SearchLogsTool,
     LogHistogramTool,
@@ -102,6 +146,10 @@ export default class AIToolbox {
     RunRunbookTool,
     PostIncidentStatusUpdateTool,
     ChangeIncidentSeverityTool,
+    // Private notes (never notify status-page subscribers) + investigations.
+    CreateIncidentNoteTool,
+    CreateAlertNoteTool,
+    StartInvestigationTool,
     /*
      * Code writes (mutations). These never touch the default or a protected
      * branch — every chat-authored commit lands somewhere a human must still

--- a/Common/Server/Utils/AI/Toolbox/MonitorTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/MonitorTools.ts
@@ -1,14 +1,22 @@
 import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import MonitorOwnerTeam from "../../../../Models/DatabaseModels/MonitorOwnerTeam";
+import MonitorOwnerUser from "../../../../Models/DatabaseModels/MonitorOwnerUser";
+import MonitorStatus from "../../../../Models/DatabaseModels/MonitorStatus";
 import MonitorStatusTimeline from "../../../../Models/DatabaseModels/MonitorStatusTimeline";
 import { JSONObject } from "../../../../Types/JSON";
 import ObjectID from "../../../../Types/ObjectID";
 import Permission from "../../../../Types/Permission";
+import Query from "../../../../Types/BaseDatabase/Query";
 import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
 import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
 import MonitorService from "../../../Services/MonitorService";
+import MonitorOwnerTeamService from "../../../Services/MonitorOwnerTeamService";
+import MonitorOwnerUserService from "../../../Services/MonitorOwnerUserService";
+import MonitorStatusService from "../../../Services/MonitorStatusService";
 import MonitorStatusTimelineService from "../../../Services/MonitorStatusTimelineService";
 import QueryHelper from "../../../Types/Database/QueryHelper";
 import ToolResultSerializer, { SerializedResult } from "./Serializer";
+import WidgetBuilder from "./WidgetBuilder";
 import {
   ObservabilityTool,
   ToolArgs,
@@ -35,22 +43,37 @@ const resolveReadPermissions: () => Array<Permission> =
 export const QueryMonitorsTool: ObservabilityTool = {
   name: "query_monitors",
   description:
-    "List monitors in this project with their current status. Pass monitorId to also get that monitor's recent status timeline (when it went up or down).",
+    "List monitors in this project with their current status (name and color). To answer 'which monitors are down / not operational right now?' pass problemsOnly=true — it returns only monitors whose current status is not an operational state. To list monitors in one specific status (e.g. 'Degraded' or 'Offline'), pass monitorStatusName (case-insensitive). Returned monitors are ordered problems-first (worst status first, then name); the result reports the total match count — pass skip to page through more. Pass monitorId to get one monitor's details, its owners (teams and users) and its recent status timeline (when it went up or down).",
   inputSchema: {
     type: "object",
     properties: {
       monitorId: {
         type: "string",
         description:
-          "Get one monitor by its ID, including its recent status timeline.",
+          "Get one monitor by its ID, including its owners and recent status timeline.",
       },
       nameSearch: {
         type: "string",
         description: "Filter monitors whose name contains this text.",
       },
+      monitorStatusName: {
+        type: "string",
+        description:
+          "Only monitors currently in this status, matched by MonitorStatus name (case-insensitive, e.g. 'Operational', 'Degraded', 'Offline'). If nothing matches, the result lists the status names that exist in this project.",
+      },
+      problemsOnly: {
+        type: "boolean",
+        description:
+          "true = only monitors whose current status is NOT an operational state (i.e. degraded/offline/any custom problem status). Use this to answer 'what is down right now?'.",
+      },
       limit: {
         type: "number",
         description: "Maximum monitors to return (default 25, max 50).",
+      },
+      skip: {
+        type: "number",
+        description:
+          "Rows to skip for paging through a large result (default 0, max 500).",
       },
     },
   },
@@ -75,15 +98,21 @@ export const QueryMonitorsTool: ObservabilityTool = {
           monitorType: true,
           currentMonitorStatus: {
             name: true,
+            color: true,
           },
         },
         props: ctx.props,
       });
 
+      /*
+       * projectId is pinned to the tenant from ctx on every query keyed by
+       * monitorId, because monitorId is an untrusted model argument.
+       */
       const timeline: Array<MonitorStatusTimeline> =
         await MonitorStatusTimelineService.findBy({
           query: {
             monitorId: monitorId,
+            projectId: ctx.projectId,
           },
           select: {
             createdAt: true,
@@ -99,6 +128,69 @@ export const QueryMonitorsTool: ObservabilityTool = {
           props: ctx.props,
         });
 
+      let ownerTeamNames: string = "";
+      let ownerUserNames: string = "";
+
+      if (monitor) {
+        // Owners live in join tables, not on the Monitor row itself.
+        const ownerTeams: Array<MonitorOwnerTeam> =
+          await MonitorOwnerTeamService.findBy({
+            query: {
+              monitorId: monitorId,
+              projectId: ctx.projectId,
+            },
+            select: {
+              _id: true,
+              team: {
+                name: true,
+              },
+            },
+            limit: 10,
+            skip: 0,
+            props: ctx.props,
+          });
+
+        const ownerUsers: Array<MonitorOwnerUser> =
+          await MonitorOwnerUserService.findBy({
+            query: {
+              monitorId: monitorId,
+              projectId: ctx.projectId,
+            },
+            select: {
+              _id: true,
+              user: {
+                name: true,
+                email: true,
+              },
+            },
+            limit: 10,
+            skip: 0,
+            props: ctx.props,
+          });
+
+        ownerTeamNames = ownerTeams
+          .map((ownerTeam: MonitorOwnerTeam) => {
+            return ownerTeam.team?.name || "";
+          })
+          .filter((value: string) => {
+            return value.length > 0;
+          })
+          .join(", ");
+
+        ownerUserNames = ownerUsers
+          .map((ownerUser: MonitorOwnerUser) => {
+            return (
+              ownerUser.user?.name?.toString() ||
+              ownerUser.user?.email?.toString() ||
+              ""
+            );
+          })
+          .filter((value: string) => {
+            return value.length > 0;
+          })
+          .join(", ");
+      }
+
       const rows: Array<JSONObject> = [];
 
       if (monitor) {
@@ -108,6 +200,9 @@ export const QueryMonitorsTool: ObservabilityTool = {
           name: monitor.name,
           type: monitor.monitorType,
           currentStatus: monitor.currentMonitorStatus?.name,
+          statusColor: monitor.currentMonitorStatus?.color?.toString(),
+          ownerTeams: ownerTeamNames || undefined,
+          ownerUsers: ownerUserNames || undefined,
         });
       }
 
@@ -122,6 +217,23 @@ export const QueryMonitorsTool: ObservabilityTool = {
       const serialized: SerializedResult =
         ToolResultSerializer.serializeRows(rows);
 
+      const cardFields: Array<{ label: string; value: string }> = [];
+      if (monitor?.monitorType) {
+        cardFields.push({ label: "Type", value: String(monitor.monitorType) });
+      }
+      if (monitor?.currentMonitorStatus?.name) {
+        cardFields.push({
+          label: "Status",
+          value: monitor.currentMonitorStatus.name,
+        });
+      }
+      if (ownerTeamNames) {
+        cardFields.push({ label: "Owner teams", value: ownerTeamNames });
+      }
+      if (ownerUserNames) {
+        cardFields.push({ label: "Owner users", value: ownerUserNames });
+      }
+
       return {
         dataForLlm: serialized.text,
         rowCount: serialized.rowCount,
@@ -132,6 +244,19 @@ export const QueryMonitorsTool: ObservabilityTool = {
         },
         redactionCount: serialized.redactionCount,
         isTruncated: serialized.isTruncated,
+        widget: monitor
+          ? WidgetBuilder.resourceCard({
+              title: `Monitor ${monitor.name || ""}`.trim(),
+              resourceType: "Monitor",
+              heading: monitor.name || "Monitor",
+              subheading: monitor.currentMonitorStatus?.name,
+              fields: cardFields,
+              link: {
+                type: AIChatCitationTargetType.MonitorView,
+                params: { monitorId: monitorId.toString() },
+              },
+            })
+          : undefined,
       };
     }
 
@@ -140,54 +265,216 @@ export const QueryMonitorsTool: ObservabilityTool = {
       min: 1,
       max: 50,
     });
+    const skip: number = ToolArgs.getNumber(args, "skip", {
+      defaultValue: 0,
+      min: 0,
+      max: 500,
+    });
     const nameSearch: string | undefined = ToolArgs.getString(
       args,
       "nameSearch",
     );
+    const monitorStatusName: string | undefined = ToolArgs.getString(
+      args,
+      "monitorStatusName",
+    );
+    const problemsOnly: boolean =
+      ToolArgs.getBoolean(args, "problemsOnly") === true;
+
+    const query: Query<Monitor> = {};
+
+    if (nameSearch) {
+      query.name = QueryHelper.search(nameSearch);
+    }
+
+    /*
+     * "Not operational" is matched through the MonitorStatus flag rather than
+     * status names, so custom problem statuses ("Maintenance", "Partial
+     * outage", …) are still caught.
+     */
+    if (problemsOnly) {
+      query.currentMonitorStatus = { isOperationalState: false };
+    }
+
+    if (monitorStatusName) {
+      /*
+       * Status names are matched case-insensitively against this project's
+       * MonitorStatus rows first, then the monitors are filtered by the
+       * matched status ids — a name typo therefore fails loudly with the list
+       * of real status names instead of silently returning zero monitors.
+       */
+      const statuses: Array<MonitorStatus> = await MonitorStatusService.findBy({
+        query: {},
+        select: {
+          _id: true,
+          name: true,
+        },
+        sort: {
+          priority: SortOrder.Ascending,
+        },
+        limit: 100,
+        skip: 0,
+        props: ctx.props,
+      });
+
+      const wanted: string = monitorStatusName.toLowerCase();
+
+      let matched: Array<MonitorStatus> = statuses.filter(
+        (status: MonitorStatus) => {
+          return (status.name || "").toLowerCase() === wanted;
+        },
+      );
+
+      // Fall back to substring matching ("degrade" → "Degraded").
+      if (matched.length === 0) {
+        matched = statuses.filter((status: MonitorStatus) => {
+          return (status.name || "").toLowerCase().includes(wanted);
+        });
+      }
+
+      if (matched.length === 0) {
+        const availableNames: string = statuses
+          .map((status: MonitorStatus) => {
+            return status.name || "";
+          })
+          .filter((value: string) => {
+            return value.length > 0;
+          })
+          .join(", ");
+
+        return {
+          dataForLlm: `No monitor status matches "${monitorStatusName}". Statuses in this project: ${availableNames || "(none)"}. Retry with one of these names, or use problemsOnly=true for all non-operational monitors.`,
+          rowCount: 0,
+          citationLabel: `Monitors in status "${monitorStatusName}" (0 found)`,
+          citationTarget: {
+            type: AIChatCitationTargetType.Monitors,
+          },
+          redactionCount: 0,
+          isTruncated: false,
+        };
+      }
+
+      const matchedIds: Array<ObjectID> = [];
+      for (const status of matched) {
+        if (status.id) {
+          matchedIds.push(status.id);
+        }
+      }
+
+      query.currentMonitorStatusId = QueryHelper.any(matchedIds);
+    }
 
     const monitors: Array<Monitor> = await MonitorService.findBy({
-      query: nameSearch
-        ? {
-            name: QueryHelper.search(nameSearch),
-          }
-        : {},
+      query: query,
       select: {
         _id: true,
         name: true,
         monitorType: true,
         currentMonitorStatus: {
           name: true,
+          color: true,
+          priority: true,
+          isOperationalState: true,
         },
       },
       sort: {
         name: SortOrder.Ascending,
       },
       limit: limit,
-      skip: 0,
+      skip: skip,
       props: ctx.props,
     });
 
-    const rows: Array<JSONObject> = monitors.map((monitor: Monitor) => {
+    const totalCount: number = (
+      await MonitorService.countBy({
+        query: query,
+        props: ctx.props,
+      })
+    ).toNumber();
+
+    /*
+     * Page boundaries are defined by the stable name-ascending DB sort; the
+     * fetched page is then reordered problems-first (higher status priority =
+     * worse, shown first) so a mixed page leads with what is broken. To scan
+     * ALL problem monitors across a large project, problemsOnly=true is the
+     * reliable filter — this reorder is presentation only.
+     */
+    const sortedMonitors: Array<Monitor> = [...monitors].sort(
+      (a: Monitor, b: Monitor): number => {
+        const aProblem: boolean =
+          a.currentMonitorStatus?.isOperationalState === false;
+        const bProblem: boolean =
+          b.currentMonitorStatus?.isOperationalState === false;
+        if (aProblem !== bProblem) {
+          return aProblem ? -1 : 1;
+        }
+        const aPriority: number = a.currentMonitorStatus?.priority ?? 0;
+        const bPriority: number = b.currentMonitorStatus?.priority ?? 0;
+        if (aPriority !== bPriority) {
+          return bPriority - aPriority;
+        }
+        return (a.name || "").localeCompare(b.name || "");
+      },
+    );
+
+    const rows: Array<JSONObject> = sortedMonitors.map((monitor: Monitor) => {
       return {
         id: monitor.id?.toString(),
         name: monitor.name,
         type: monitor.monitorType,
         currentStatus: monitor.currentMonitorStatus?.name,
+        statusColor: monitor.currentMonitorStatus?.color?.toString(),
+        isOperational: monitor.currentMonitorStatus?.isOperationalState,
       };
     });
 
     const serialized: SerializedResult =
       ToolResultSerializer.serializeRows(rows);
 
+    let dataForLlm: string = serialized.text;
+    if (rows.length > 0 && totalCount > rows.length) {
+      dataForLlm = `Showing rows ${skip + 1}–${skip + rows.length} of ${totalCount} total. Pass skip to page further.\n${serialized.text}`;
+    }
+
+    let scopeLabel: string;
+    if (monitorStatusName) {
+      scopeLabel = `Monitors in status "${monitorStatusName}"`;
+    } else if (problemsOnly) {
+      scopeLabel = "Monitors with problems";
+    } else {
+      scopeLabel = "Monitors";
+    }
+
+    const citationLabel: string =
+      totalCount > serialized.rowCount
+        ? `${scopeLabel} (${serialized.rowCount} of ${totalCount})`
+        : `${scopeLabel} (${serialized.rowCount} found)`;
+
     return {
-      dataForLlm: serialized.text,
+      dataForLlm: dataForLlm,
       rowCount: serialized.rowCount,
-      citationLabel: `Monitors (${serialized.rowCount} found)`,
+      citationLabel: citationLabel,
       citationTarget: {
         type: AIChatCitationTargetType.Monitors,
       },
       redactionCount: serialized.redactionCount,
       isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `${scopeLabel} (${rows.length})`,
+              description: problemsOnly
+                ? "Only monitors whose current status is not operational"
+                : "Non-operational monitors first",
+              columns: [
+                { key: "name", title: "Monitor", type: "text" },
+                { key: "type", title: "Type", type: "text" },
+                { key: "currentStatus", title: "Status", type: "text" },
+              ],
+              rows: rows,
+              link: { type: AIChatCitationTargetType.Monitors },
+            })
+          : undefined,
     };
   },
 };

--- a/Common/Server/Utils/AI/Toolbox/NoteWriteTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/NoteWriteTools.ts
@@ -1,0 +1,295 @@
+import Alert from "../../../../Models/DatabaseModels/Alert";
+import AlertInternalNote from "../../../../Models/DatabaseModels/AlertInternalNote";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import IncidentInternalNote from "../../../../Models/DatabaseModels/IncidentInternalNote";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import Permission from "../../../../Types/Permission";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import AlertService from "../../../Services/AlertService";
+import AlertInternalNoteService from "../../../Services/AlertInternalNoteService";
+import IncidentService from "../../../Services/IncidentService";
+import IncidentInternalNoteService from "../../../Services/IncidentInternalNoteService";
+import ToolResultSerializer, { SerializedResult } from "./Serializer";
+import WidgetBuilder from "./WidgetBuilder";
+import {
+  ObservabilityTool,
+  ToolArgs,
+  ToolContext,
+  ToolExecutionResult,
+} from "./ToolTypes";
+
+/*
+ * Private (internal) note tools — the team-only counterpart of
+ * post_incident_status_update. Internal notes live in the dashboard's private
+ * note feed: they never render on a status page and never notify status page
+ * subscribers, so the copilot can file investigation findings without any
+ * customer-visible side effect.
+ *
+ * The acting user is always ctx.props.userId — never a tool argument.
+ *
+ * Permissions are resolved lazily (not at module load) because this module is
+ * pulled in through the service import graph before the model classes are
+ * fully wired up — calling a model method at import time throws a
+ * circular-dependency TypeError. By the time a tool executes, every module is
+ * loaded.
+ */
+
+let cachedIncidentNoteCreatePermissions: Array<Permission> | null = null;
+const resolveIncidentNoteCreatePermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedIncidentNoteCreatePermissions) {
+      cachedIncidentNoteCreatePermissions =
+        new IncidentInternalNote().getCreatePermissions();
+    }
+    return cachedIncidentNoteCreatePermissions;
+  };
+
+let cachedAlertNoteCreatePermissions: Array<Permission> | null = null;
+const resolveAlertNoteCreatePermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedAlertNoteCreatePermissions) {
+      cachedAlertNoteCreatePermissions =
+        new AlertInternalNote().getCreatePermissions();
+    }
+    return cachedAlertNoteCreatePermissions;
+  };
+
+// Widgets preview the note; long notes are cut so the card stays a card.
+function previewOf(note: string): string {
+  return note.length > 200 ? `${note.substring(0, 200)}…` : note;
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * create_incident_note — private internal note on an incident.
+ * ---------------------------------------------------------------------------
+ */
+export const CreateIncidentNoteTool: ObservabilityTool = {
+  name: "create_incident_note",
+  description:
+    "Add a PRIVATE internal note to an incident. Internal notes are visible only to team members in the dashboard — they NEVER appear on any status page and notify NO status page subscribers. Use this for investigation findings, working notes and responder handoffs. For a customer-facing update that goes on the status page, use post_incident_status_update instead. Find the incidentId with query_incidents first.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      incidentId: {
+        type: "string",
+        description:
+          "The incident's ID (required). Find it with query_incidents first.",
+      },
+      note: {
+        type: "string",
+        description:
+          "The internal note text in markdown (required). Visible to team members only.",
+      },
+    },
+    required: ["incidentId", "note"],
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveIncidentNoteCreatePermissions();
+  },
+  isMutation: true,
+  buildActionTitle: (args: JSONObject): string => {
+    return `Add private internal note to incident ${ToolArgs.getString(args, "incidentId") || ""}`.trim();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const incidentId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "incidentId",
+    );
+    if (!incidentId) {
+      throw new BadDataException(
+        "incidentId is required. Use query_incidents to find it first.",
+      );
+    }
+
+    const note: string | undefined = ToolArgs.getString(args, "note");
+    if (!note) {
+      throw new BadDataException("note is required (the internal note text).");
+    }
+
+    const userId: ObjectID | undefined = ctx.props.userId;
+    if (!userId) {
+      throw new BadDataException(
+        "No authenticated user in context; cannot post an internal note.",
+      );
+    }
+
+    // Visibility check under the user's RBAC before writing anything.
+    const incident: Incident | null = await IncidentService.findOneById({
+      id: incidentId,
+      select: { _id: true, incidentNumber: true, title: true },
+      props: ctx.props,
+    });
+    if (!incident) {
+      throw new BadDataException(
+        "Incident not found (or you do not have access to it).",
+      );
+    }
+
+    const internalNote: IncidentInternalNote = new IncidentInternalNote();
+    internalNote.incidentId = incidentId;
+    internalNote.projectId = ctx.projectId;
+    internalNote.note = note;
+    internalNote.createdByUserId = userId;
+
+    const createdNote: IncidentInternalNote =
+      await IncidentInternalNoteService.create({
+        data: internalNote,
+        props: ctx.props,
+      });
+
+    const noteIdString: string = createdNote.id?.toString() || "";
+    const incidentIdString: string = incidentId.toString();
+
+    const serialized: SerializedResult = ToolResultSerializer.serializeRows([
+      {
+        noteId: noteIdString,
+        incidentNumber: incident.incidentNumber,
+        visibility: "internal (team members only)",
+      },
+    ]);
+
+    return {
+      dataForLlm: `Added a private internal note to incident #${incident.incidentNumber} ("${incident.title}"). It is visible to team members only — it does not appear on any status page and no subscribers were notified.\n${serialized.text}`,
+      rowCount: 1,
+      citationLabel: `Internal note on incident #${incident.incidentNumber}`,
+      citationTarget: {
+        type: AIChatCitationTargetType.IncidentView,
+        params: { incidentId: incidentIdString },
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: false,
+      widget: WidgetBuilder.resourceCard({
+        title: "Internal note added",
+        resourceType: "Incident",
+        heading: `#${incident.incidentNumber} · ${incident.title}`,
+        subheading: "Private — team members only",
+        fields: [{ label: "Note", value: previewOf(note) }],
+        link: {
+          type: AIChatCitationTargetType.IncidentView,
+          params: { incidentId: incidentIdString },
+        },
+      }),
+    };
+  },
+};
+
+/*
+ * ---------------------------------------------------------------------------
+ * create_alert_note — private internal note on an alert.
+ * ---------------------------------------------------------------------------
+ */
+export const CreateAlertNoteTool: ObservabilityTool = {
+  name: "create_alert_note",
+  description:
+    "Add a PRIVATE internal note to an alert. Internal notes are visible only to team members in the dashboard — they NEVER appear on any status page and notify NO status page subscribers. Use this for triage findings, working notes and responder handoffs on an alert. Find the alertId with query_alerts first.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      alertId: {
+        type: "string",
+        description:
+          "The alert's ID (required). Find it with query_alerts first.",
+      },
+      note: {
+        type: "string",
+        description:
+          "The internal note text in markdown (required). Visible to team members only.",
+      },
+    },
+    required: ["alertId", "note"],
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveAlertNoteCreatePermissions();
+  },
+  isMutation: true,
+  buildActionTitle: (args: JSONObject): string => {
+    return `Add private internal note to alert ${ToolArgs.getString(args, "alertId") || ""}`.trim();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const alertId: ObjectID | undefined = ToolArgs.getObjectID(args, "alertId");
+    if (!alertId) {
+      throw new BadDataException(
+        "alertId is required. Use query_alerts to find it first.",
+      );
+    }
+
+    const note: string | undefined = ToolArgs.getString(args, "note");
+    if (!note) {
+      throw new BadDataException("note is required (the internal note text).");
+    }
+
+    const userId: ObjectID | undefined = ctx.props.userId;
+    if (!userId) {
+      throw new BadDataException(
+        "No authenticated user in context; cannot post an internal note.",
+      );
+    }
+
+    // Visibility check under the user's RBAC before writing anything.
+    const alert: Alert | null = await AlertService.findOneById({
+      id: alertId,
+      select: { _id: true, alertNumber: true, title: true },
+      props: ctx.props,
+    });
+    if (!alert) {
+      throw new BadDataException(
+        "Alert not found (or you do not have access to it).",
+      );
+    }
+
+    const internalNote: AlertInternalNote = new AlertInternalNote();
+    internalNote.alertId = alertId;
+    internalNote.projectId = ctx.projectId;
+    internalNote.note = note;
+    internalNote.createdByUserId = userId;
+
+    const createdNote: AlertInternalNote =
+      await AlertInternalNoteService.create({
+        data: internalNote,
+        props: ctx.props,
+      });
+
+    const noteIdString: string = createdNote.id?.toString() || "";
+    const alertIdString: string = alertId.toString();
+
+    const serialized: SerializedResult = ToolResultSerializer.serializeRows([
+      {
+        noteId: noteIdString,
+        alertNumber: alert.alertNumber,
+        visibility: "internal (team members only)",
+      },
+    ]);
+
+    return {
+      dataForLlm: `Added a private internal note to alert #${alert.alertNumber} ("${alert.title}"). It is visible to team members only — it does not appear on any status page and no subscribers were notified.\n${serialized.text}`,
+      rowCount: 1,
+      citationLabel: `Internal note on alert #${alert.alertNumber}`,
+      citationTarget: {
+        type: AIChatCitationTargetType.AlertView,
+        params: { alertId: alertIdString },
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: false,
+      widget: WidgetBuilder.resourceCard({
+        title: "Internal note added",
+        resourceType: "Alert",
+        heading: `#${alert.alertNumber} · ${alert.title}`,
+        subheading: "Private — team members only",
+        fields: [{ label: "Note", value: previewOf(note) }],
+        link: {
+          type: AIChatCitationTargetType.AlertView,
+          params: { alertId: alertIdString },
+        },
+      }),
+    };
+  },
+};

--- a/Common/Server/Utils/AI/Toolbox/OnCallTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/OnCallTools.ts
@@ -1,0 +1,1246 @@
+import OnCallDutyPolicy from "../../../../Models/DatabaseModels/OnCallDutyPolicy";
+import OnCallDutyPolicyEscalationRule from "../../../../Models/DatabaseModels/OnCallDutyPolicyEscalationRule";
+import OnCallDutyPolicyEscalationRuleSchedule from "../../../../Models/DatabaseModels/OnCallDutyPolicyEscalationRuleSchedule";
+import OnCallDutyPolicyEscalationRuleTeam from "../../../../Models/DatabaseModels/OnCallDutyPolicyEscalationRuleTeam";
+import OnCallDutyPolicyEscalationRuleUser from "../../../../Models/DatabaseModels/OnCallDutyPolicyEscalationRuleUser";
+import OnCallDutyPolicyExecutionLog from "../../../../Models/DatabaseModels/OnCallDutyPolicyExecutionLog";
+import OnCallDutyPolicySchedule from "../../../../Models/DatabaseModels/OnCallDutyPolicySchedule";
+import User from "../../../../Models/DatabaseModels/User";
+import UserOnCallLog from "../../../../Models/DatabaseModels/UserOnCallLog";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import Permission from "../../../../Types/Permission";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "../../../../Types/Database/LimitMax";
+import {
+  AIChatCitationTargetType,
+  AIChatWidgetColumn,
+} from "../../../../Types/AI/AIChatTypes";
+import OnCallDutyPolicyEscalationRuleScheduleService from "../../../Services/OnCallDutyPolicyEscalationRuleScheduleService";
+import OnCallDutyPolicyEscalationRuleService from "../../../Services/OnCallDutyPolicyEscalationRuleService";
+import OnCallDutyPolicyEscalationRuleTeamService from "../../../Services/OnCallDutyPolicyEscalationRuleTeamService";
+import OnCallDutyPolicyEscalationRuleUserService from "../../../Services/OnCallDutyPolicyEscalationRuleUserService";
+import OnCallDutyPolicyExecutionLogService from "../../../Services/OnCallDutyPolicyExecutionLogService";
+import OnCallDutyPolicyScheduleService from "../../../Services/OnCallDutyPolicyScheduleService";
+import OnCallDutyPolicyService from "../../../Services/OnCallDutyPolicyService";
+import UserOnCallLogService from "../../../Services/UserOnCallLogService";
+import Query from "../../../Types/Database/Query";
+import QueryHelper from "../../../Types/Database/QueryHelper";
+import Select from "../../../Types/Database/Select";
+import ToolResultSerializer, { SerializedResult } from "./Serializer";
+import WidgetBuilder from "./WidgetBuilder";
+import {
+  ObservabilityTool,
+  ToolArgs,
+  ToolContext,
+  ToolExecutionResult,
+} from "./ToolTypes";
+
+/*
+ * Derived from the model ACLs so the tool gates can never drift from RBAC.
+ * Resolved lazily rather than at module load: this module is pulled in through
+ * the service import graph before the model classes are fully wired up, so
+ * calling a model method at import time throws a circular-dependency
+ * TypeError. By the time a tool actually executes, every module is loaded.
+ */
+let cachedPolicyReadPermissions: Array<Permission> | null = null;
+const resolvePolicyReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedPolicyReadPermissions) {
+      cachedPolicyReadPermissions = new OnCallDutyPolicy().getReadPermissions();
+    }
+    return cachedPolicyReadPermissions;
+  };
+
+let cachedScheduleReadPermissions: Array<Permission> | null = null;
+const resolveScheduleReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedScheduleReadPermissions) {
+      cachedScheduleReadPermissions =
+        new OnCallDutyPolicySchedule().getReadPermissions();
+    }
+    return cachedScheduleReadPermissions;
+  };
+
+let cachedExecutionLogReadPermissions: Array<Permission> | null = null;
+const resolveExecutionLogReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedExecutionLogReadPermissions) {
+      cachedExecutionLogReadPermissions =
+        new OnCallDutyPolicyExecutionLog().getReadPermissions();
+    }
+    return cachedExecutionLogReadPermissions;
+  };
+
+/*
+ * "Nobody on call" is a state worth naming, not missing data — an uncovered
+ * schedule must never render as a silent blank the model glosses over.
+ */
+const NO_ONE_ON_CALL: string = "No one is on call";
+const SCHEDULE_NOT_ACCESSIBLE: string =
+  "Schedule not accessible (no read access or deleted)";
+
+function nameOf(user: User | undefined | null): string | undefined {
+  const displayName: string = user?.name?.toString().trim() || "";
+  if (displayName.length > 0) {
+    return displayName;
+  }
+  return user?.id ? user.id.toString() : undefined;
+}
+
+interface EscalationRuleTargets {
+  users: Array<string>;
+  teams: Array<string>;
+  schedules: Array<string>;
+}
+
+interface PolicyEscalationData {
+  rulesByPolicyId: Map<string, Array<OnCallDutyPolicyEscalationRule>>;
+  targetsByRuleId: Map<string, EscalationRuleTargets>;
+  ruleUsers: Array<OnCallDutyPolicyEscalationRuleUser>;
+  ruleTeams: Array<OnCallDutyPolicyEscalationRuleTeam>;
+  ruleSchedules: Array<OnCallDutyPolicyEscalationRuleSchedule>;
+}
+
+function getOrCreateTargets(
+  targetsByRuleId: Map<string, EscalationRuleTargets>,
+  ruleId: string,
+): EscalationRuleTargets {
+  let targets: EscalationRuleTargets | undefined = targetsByRuleId.get(ruleId);
+  if (!targets) {
+    targets = { users: [], teams: [], schedules: [] };
+    targetsByRuleId.set(ruleId, targets);
+  }
+  return targets;
+}
+
+/*
+ * Loads the escalation rules of the given policies together with what each
+ * rule pages (direct users, teams, schedules). Every query runs under the
+ * requesting user's props so RBAC applies — this tool never widens access.
+ */
+async function fetchEscalationData(
+  policyIds: Array<ObjectID>,
+  ctx: ToolContext,
+): Promise<PolicyEscalationData> {
+  const data: PolicyEscalationData = {
+    rulesByPolicyId: new Map<string, Array<OnCallDutyPolicyEscalationRule>>(),
+    targetsByRuleId: new Map<string, EscalationRuleTargets>(),
+    ruleUsers: [],
+    ruleTeams: [],
+    ruleSchedules: [],
+  };
+
+  if (policyIds.length === 0) {
+    return data;
+  }
+
+  /*
+   * The four sources are independent (all filter on the same policy ids) —
+   * fetch them in parallel; serially they were the dominant tool latency.
+   */
+  const [rules, ruleUsers, ruleTeams, ruleSchedules] = await Promise.all([
+    OnCallDutyPolicyEscalationRuleService.findBy({
+      query: {
+        onCallDutyPolicyId: QueryHelper.any(policyIds),
+      },
+      select: {
+        _id: true,
+        name: true,
+        order: true,
+        escalateAfterInMinutes: true,
+        onCallDutyPolicyId: true,
+      },
+      sort: {
+        order: SortOrder.Ascending,
+      },
+      limit: LIMIT_PER_PROJECT,
+      skip: 0,
+      props: ctx.props,
+    }),
+    OnCallDutyPolicyEscalationRuleUserService.findBy({
+      query: {
+        onCallDutyPolicyId: QueryHelper.any(policyIds),
+      },
+      select: {
+        _id: true,
+        onCallDutyPolicyEscalationRuleId: true,
+        user: {
+          _id: true,
+          name: true,
+        },
+      },
+      limit: LIMIT_PER_PROJECT,
+      skip: 0,
+      props: ctx.props,
+    }),
+    OnCallDutyPolicyEscalationRuleTeamService.findBy({
+      query: {
+        onCallDutyPolicyId: QueryHelper.any(policyIds),
+      },
+      select: {
+        _id: true,
+        onCallDutyPolicyEscalationRuleId: true,
+        team: {
+          _id: true,
+          name: true,
+        },
+      },
+      limit: LIMIT_PER_PROJECT,
+      skip: 0,
+      props: ctx.props,
+    }),
+    OnCallDutyPolicyEscalationRuleScheduleService.findBy({
+      query: {
+        onCallDutyPolicyId: QueryHelper.any(policyIds),
+      },
+      select: {
+        _id: true,
+        onCallDutyPolicyEscalationRuleId: true,
+        onCallDutyPolicyScheduleId: true,
+        onCallDutyPolicySchedule: {
+          _id: true,
+          name: true,
+        },
+      },
+      limit: LIMIT_PER_PROJECT,
+      skip: 0,
+      props: ctx.props,
+    }),
+  ]);
+
+  data.ruleUsers = ruleUsers;
+  data.ruleTeams = ruleTeams;
+  data.ruleSchedules = ruleSchedules;
+
+  for (const rule of rules) {
+    const policyKey: string = rule.onCallDutyPolicyId?.toString() || "";
+    const existing: Array<OnCallDutyPolicyEscalationRule> =
+      data.rulesByPolicyId.get(policyKey) || [];
+    existing.push(rule);
+    data.rulesByPolicyId.set(policyKey, existing);
+  }
+
+  for (const link of data.ruleUsers) {
+    const ruleKey: string =
+      link.onCallDutyPolicyEscalationRuleId?.toString() || "";
+    if (!ruleKey) {
+      continue;
+    }
+    getOrCreateTargets(data.targetsByRuleId, ruleKey).users.push(
+      nameOf(link.user) || "Unknown user",
+    );
+  }
+
+  for (const link of data.ruleTeams) {
+    const ruleKey: string =
+      link.onCallDutyPolicyEscalationRuleId?.toString() || "";
+    if (!ruleKey) {
+      continue;
+    }
+    getOrCreateTargets(data.targetsByRuleId, ruleKey).teams.push(
+      link.team?.name || "Unknown team",
+    );
+  }
+
+  for (const link of data.ruleSchedules) {
+    const ruleKey: string =
+      link.onCallDutyPolicyEscalationRuleId?.toString() || "";
+    if (!ruleKey) {
+      continue;
+    }
+    getOrCreateTargets(data.targetsByRuleId, ruleKey).schedules.push(
+      link.onCallDutyPolicySchedule?.name || "Unknown schedule",
+    );
+  }
+
+  return data;
+}
+
+function formatRuleTargets(targets: EscalationRuleTargets | undefined): string {
+  const parts: Array<string> = [];
+  if (targets && targets.users.length > 0) {
+    parts.push(`users [${targets.users.join(", ")}]`);
+  }
+  if (targets && targets.teams.length > 0) {
+    parts.push(`teams [${targets.teams.join(", ")}]`);
+  }
+  if (targets && targets.schedules.length > 0) {
+    parts.push(`schedules [${targets.schedules.join(", ")}]`);
+  }
+  return parts.join(", ") || "no targets";
+}
+
+function formatEscalationChain(
+  rules: Array<OnCallDutyPolicyEscalationRule>,
+  targetsByRuleId: Map<string, EscalationRuleTargets>,
+): string {
+  if (rules.length === 0) {
+    return "No escalation rules configured";
+  }
+
+  return rules
+    .map((rule: OnCallDutyPolicyEscalationRule): string => {
+      const targetText: string = formatRuleTargets(
+        targetsByRuleId.get(rule.id?.toString() || ""),
+      );
+      const escalateText: string = rule.escalateAfterInMinutes
+        ? ` (escalates after ${rule.escalateAfterInMinutes}m)`
+        : "";
+      return `${rule.order ?? "?"}. ${rule.name || "Unnamed rule"}: ${targetText}${escalateText}`;
+    })
+    .join(" | ");
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * query_on_call_policies — discover policies and their escalation chains.
+ * ---------------------------------------------------------------------------
+ */
+export const QueryOnCallPoliciesTool: ObservabilityTool = {
+  name: "query_on_call_policies",
+  description:
+    "Query on-call duty policies in this project — who gets paged and in what order. List mode returns each policy (id, name, description) with its escalation rule chain: rule order plus the users, teams and schedules each rule pages. Pass onCallPolicyId to get full details of one policy. Use this to find the id to pass to page_on_call_policy, get_on_call_status or query_on_call_pages.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      onCallPolicyId: {
+        type: "string",
+        description:
+          "Get one on-call policy by its ID (includes description, labels and the full escalation chain).",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum policies to return (default 10, max 25).",
+      },
+      skip: {
+        type: "number",
+        description:
+          "Rows to skip, for paging through long policy lists (default 0, max 500).",
+      },
+    },
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolvePolicyReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const onCallPolicyId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "onCallPolicyId",
+    );
+
+    if (onCallPolicyId) {
+      const policy: OnCallDutyPolicy | null =
+        await OnCallDutyPolicyService.findOneById({
+          id: onCallPolicyId,
+          select: {
+            _id: true,
+            name: true,
+            description: true,
+            repeatPolicyIfNoOneAcknowledges: true,
+            repeatPolicyIfNoOneAcknowledgesNoOfTimes: true,
+            labels: {
+              name: true,
+            },
+          },
+          props: ctx.props,
+        });
+
+      const escalation: PolicyEscalationData = policy
+        ? await fetchEscalationData([onCallPolicyId], ctx)
+        : {
+            rulesByPolicyId: new Map<
+              string,
+              Array<OnCallDutyPolicyEscalationRule>
+            >(),
+            targetsByRuleId: new Map<string, EscalationRuleTargets>(),
+            ruleUsers: [],
+            ruleTeams: [],
+            ruleSchedules: [],
+          };
+
+      const rules: Array<OnCallDutyPolicyEscalationRule> =
+        escalation.rulesByPolicyId.get(onCallPolicyId.toString()) || [];
+
+      const policyLabels: string = (policy?.labels || [])
+        .map((label: { name?: string }) => {
+          return label.name || "";
+        })
+        .filter((value: string) => {
+          return value.length > 0;
+        })
+        .join(", ");
+
+      const rows: Array<JSONObject> = policy
+        ? [
+            {
+              id: policy.id?.toString(),
+              name: policy.name,
+              description: policy.description,
+              labels: policyLabels || undefined,
+              repeatsIfNoOneAcknowledges:
+                policy.repeatPolicyIfNoOneAcknowledges,
+              repeatCount: policy.repeatPolicyIfNoOneAcknowledgesNoOfTimes,
+              escalationRuleCount: rules.length,
+              escalationChain: formatEscalationChain(
+                rules,
+                escalation.targetsByRuleId,
+              ),
+            },
+          ]
+        : [];
+
+      const serialized: SerializedResult =
+        ToolResultSerializer.serializeRows(rows);
+
+      const ruleFields: Array<{ label: string; value: string }> = rules.map(
+        (rule: OnCallDutyPolicyEscalationRule) => {
+          const targetText: string = formatRuleTargets(
+            escalation.targetsByRuleId.get(rule.id?.toString() || ""),
+          );
+          const escalateText: string = rule.escalateAfterInMinutes
+            ? ` (escalates after ${rule.escalateAfterInMinutes}m)`
+            : "";
+          return {
+            label: `Rule ${rule.order ?? "?"}${rule.name ? ` — ${rule.name}` : ""}`,
+            value: `${targetText}${escalateText}`,
+          };
+        },
+      );
+
+      return {
+        dataForLlm: serialized.text,
+        rowCount: serialized.rowCount,
+        citationLabel: `On-call policy '${policy?.name || onCallPolicyId.toString()}'`,
+        citationTarget: {
+          type: AIChatCitationTargetType.OnCallPolicyView,
+          params: { onCallDutyPolicyId: onCallPolicyId.toString() },
+        },
+        redactionCount: serialized.redactionCount,
+        isTruncated: serialized.isTruncated,
+        widget: policy
+          ? WidgetBuilder.resourceCard({
+              title: `On-call policy: ${policy.name || ""}`.trim(),
+              resourceType: "On-Call Policy",
+              heading: policy.name || onCallPolicyId.toString(),
+              subheading: policy.description,
+              fields:
+                ruleFields.length > 0
+                  ? ruleFields
+                  : [
+                      {
+                        label: "Escalation rules",
+                        value: "None configured",
+                      },
+                    ],
+              link: {
+                type: AIChatCitationTargetType.OnCallPolicyView,
+                params: { onCallDutyPolicyId: onCallPolicyId.toString() },
+              },
+            })
+          : undefined,
+      };
+    }
+
+    const limit: number = ToolArgs.getNumber(args, "limit", {
+      defaultValue: 10,
+      min: 1,
+      max: 25,
+    });
+    const skip: number = ToolArgs.getNumber(args, "skip", {
+      defaultValue: 0,
+      min: 0,
+      max: 500,
+    });
+
+    const totalCount: PositiveNumber = await OnCallDutyPolicyService.countBy({
+      query: {},
+      props: ctx.props,
+    });
+
+    const policies: Array<OnCallDutyPolicy> =
+      await OnCallDutyPolicyService.findBy({
+        query: {},
+        select: {
+          _id: true,
+          name: true,
+          description: true,
+        },
+        sort: {
+          name: SortOrder.Ascending,
+        },
+        limit: limit,
+        skip: skip,
+        props: ctx.props,
+      });
+
+    const policyIds: Array<ObjectID> = policies
+      .map((policy: OnCallDutyPolicy) => {
+        return policy.id;
+      })
+      .filter((id: ObjectID | null): id is ObjectID => {
+        return Boolean(id);
+      });
+
+    const escalation: PolicyEscalationData = await fetchEscalationData(
+      policyIds,
+      ctx,
+    );
+
+    const rows: Array<JSONObject> = policies.map((policy: OnCallDutyPolicy) => {
+      const rules: Array<OnCallDutyPolicyEscalationRule> =
+        escalation.rulesByPolicyId.get(policy.id?.toString() || "") || [];
+      return {
+        id: policy.id?.toString(),
+        name: policy.name,
+        description: policy.description,
+        escalationChain: formatEscalationChain(
+          rules,
+          escalation.targetsByRuleId,
+        ),
+      };
+    });
+
+    const serialized: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    const total: number = totalCount.toNumber();
+    const hasMore: boolean = total > rows.length && rows.length > 0;
+    const dataForLlm: string = hasMore
+      ? `Showing rows ${skip + 1}–${skip + rows.length} of ${total} total. Pass skip to page further.\n${serialized.text}`
+      : serialized.text;
+
+    return {
+      dataForLlm: dataForLlm,
+      rowCount: serialized.rowCount,
+      citationLabel: hasMore
+        ? `On-call policies (${rows.length} of ${total})`
+        : `On-call policies (${serialized.rowCount} found)`,
+      citationTarget: {
+        type: AIChatCitationTargetType.OnCallPolicies,
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `On-call policies (${rows.length})`,
+              columns: [
+                { key: "name", title: "Policy", type: "text" },
+                { key: "description", title: "Description", type: "text" },
+                {
+                  key: "escalationChain",
+                  title: "Escalation chain",
+                  type: "text",
+                },
+              ],
+              rows: rows,
+              link: { type: AIChatCitationTargetType.OnCallPolicies },
+            })
+          : undefined,
+    };
+  },
+};
+
+/*
+ * ---------------------------------------------------------------------------
+ * get_on_call_status — who is on call RIGHT NOW.
+ * ---------------------------------------------------------------------------
+ */
+
+/*
+ * Roster fields are persisted on the schedule and refreshed every minute by
+ * the RefreshHandoffTime worker (overrides included) — the same source the
+ * dashboard's "On Call Now" column reads. Reading them costs one RBAC-checked
+ * query instead of re-resolving schedule layers per request.
+ */
+const scheduleRosterSelect: Select<OnCallDutyPolicySchedule> = {
+  _id: true,
+  name: true,
+  currentUserOnRoster: {
+    _id: true,
+    name: true,
+  },
+  nextUserOnRoster: {
+    _id: true,
+    name: true,
+  },
+  rosterStartAt: true,
+  rosterHandoffAt: true,
+  rosterNextStartAt: true,
+};
+
+function scheduleStatusRow(
+  schedule: OnCallDutyPolicySchedule,
+  source?: string,
+): JSONObject {
+  const currentName: string | undefined = nameOf(schedule.currentUserOnRoster);
+  return {
+    scheduleId: schedule.id?.toString(),
+    source: source ?? `Schedule '${schedule.name || ""}'`,
+    onCallNow: currentName || NO_ONE_ON_CALL,
+    onCallUserId: schedule.currentUserOnRoster?.id?.toString(),
+    onCallSince: schedule.rosterStartAt,
+    handsOffAt: schedule.rosterHandoffAt,
+    nextUp: nameOf(schedule.nextUserOnRoster),
+    nextStartsAt: schedule.rosterNextStartAt,
+  };
+}
+
+/*
+ * Distinct responders across rows: schedule/direct rows dedupe on user id,
+ * team rows count once per team. Sentinel rows ("no one", inaccessible) are
+ * excluded so the headline count never inflates.
+ */
+function countResponders(rows: Array<JSONObject>): number {
+  const responderKeys: Set<string> = new Set<string>();
+  for (const row of rows) {
+    const userId: string | undefined = row["onCallUserId"] as
+      | string
+      | undefined;
+    const who: string | undefined = row["onCallNow"] as string | undefined;
+    if (userId) {
+      responderKeys.add(`user:${userId}`);
+    } else if (
+      who &&
+      who !== NO_ONE_ON_CALL &&
+      who !== SCHEDULE_NOT_ACCESSIBLE
+    ) {
+      responderKeys.add(`who:${who}`);
+    }
+  }
+  return responderKeys.size;
+}
+
+function respondersLabel(count: number): string {
+  return `${count} ${count === 1 ? "responder" : "responders"}`;
+}
+
+const onCallStatusColumns: Array<AIChatWidgetColumn> = [
+  { key: "source", title: "Schedule / rule", type: "text" },
+  { key: "onCallNow", title: "On call now", type: "text" },
+  { key: "onCallSince", title: "Since", type: "date" },
+  { key: "handsOffAt", title: "Hands off", type: "date" },
+  { key: "nextUp", title: "Next up", type: "text" },
+  { key: "nextStartsAt", title: "Next starts", type: "date" },
+];
+
+export const GetOnCallStatusTool: ObservabilityTool = {
+  name: "get_on_call_status",
+  description:
+    "Who is on call RIGHT NOW. With no arguments, returns every on-call schedule in the project with the user currently on the roster, since when, when they hand off, and who is up next. Pass scheduleId for one schedule, or onCallPolicyId to see who each escalation rule of that policy would page (direct users, whole teams, and the current on-roster user of each linked schedule). Find ids with query_on_call_policies. Roster data is kept fresh by the platform (refreshed about every minute, overrides included).",
+  inputSchema: {
+    type: "object",
+    properties: {
+      scheduleId: {
+        type: "string",
+        description: "Get the current on-call status of one schedule by ID.",
+      },
+      onCallPolicyId: {
+        type: "string",
+        description:
+          "Get who would be paged by each escalation rule of this on-call policy. Find the id with query_on_call_policies.",
+      },
+      limit: {
+        type: "number",
+        description:
+          "Maximum schedules to return when listing all (default 20, max 50).",
+      },
+    },
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveScheduleReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const scheduleId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "scheduleId",
+    );
+    const onCallPolicyId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "onCallPolicyId",
+    );
+    const limit: number = ToolArgs.getNumber(args, "limit", {
+      defaultValue: 20,
+      min: 1,
+      max: 50,
+    });
+
+    if (scheduleId) {
+      const schedule: OnCallDutyPolicySchedule | null =
+        await OnCallDutyPolicyScheduleService.findOneById({
+          id: scheduleId,
+          select: scheduleRosterSelect,
+          props: ctx.props,
+        });
+
+      const rows: Array<JSONObject> = schedule
+        ? [scheduleStatusRow(schedule)]
+        : [];
+
+      const serialized: SerializedResult =
+        ToolResultSerializer.serializeRows(rows);
+
+      const onCallNow: string =
+        (rows[0]?.["onCallNow"] as string | undefined) || NO_ONE_ON_CALL;
+
+      const cardFields: Array<{ label: string; value: string }> = [];
+      if (schedule?.rosterStartAt) {
+        cardFields.push({
+          label: "On call since",
+          value: schedule.rosterStartAt.toISOString(),
+        });
+      }
+      if (schedule?.rosterHandoffAt) {
+        cardFields.push({
+          label: "Hands off at",
+          value: schedule.rosterHandoffAt.toISOString(),
+        });
+      }
+      const nextUp: string | undefined = nameOf(schedule?.nextUserOnRoster);
+      if (nextUp) {
+        cardFields.push({ label: "Next up", value: nextUp });
+      }
+      if (schedule?.rosterNextStartAt) {
+        cardFields.push({
+          label: "Next shift starts",
+          value: schedule.rosterNextStartAt.toISOString(),
+        });
+      }
+
+      return {
+        dataForLlm: serialized.text,
+        rowCount: serialized.rowCount,
+        citationLabel: `On-call now: '${schedule?.name || scheduleId.toString()}'`,
+        citationTarget: {
+          type: AIChatCitationTargetType.OnCallPolicies,
+        },
+        redactionCount: serialized.redactionCount,
+        isTruncated: serialized.isTruncated,
+        widget: schedule
+          ? WidgetBuilder.resourceCard({
+              title: `On-call schedule '${schedule.name || ""}'`.trim(),
+              resourceType: "On-Call Schedule",
+              heading: schedule.name || scheduleId.toString(),
+              subheading:
+                onCallNow === NO_ONE_ON_CALL
+                  ? NO_ONE_ON_CALL
+                  : `On call now: ${onCallNow}`,
+              fields: cardFields,
+              link: { type: AIChatCitationTargetType.OnCallPolicies },
+            })
+          : undefined,
+      };
+    }
+
+    if (onCallPolicyId) {
+      const policy: OnCallDutyPolicy | null =
+        await OnCallDutyPolicyService.findOneById({
+          id: onCallPolicyId,
+          select: {
+            _id: true,
+            name: true,
+          },
+          props: ctx.props,
+        });
+
+      if (!policy) {
+        return {
+          dataForLlm:
+            "(no rows found) — on-call policy not found or not accessible. Find valid ids with query_on_call_policies.",
+          rowCount: 0,
+          citationLabel: "On-call now (policy not found)",
+          citationTarget: {
+            type: AIChatCitationTargetType.OnCallPolicies,
+          },
+          redactionCount: 0,
+          isTruncated: false,
+        };
+      }
+
+      const escalation: PolicyEscalationData = await fetchEscalationData(
+        [onCallPolicyId],
+        ctx,
+      );
+
+      const scheduleIds: Array<ObjectID> = escalation.ruleSchedules
+        .map((link: OnCallDutyPolicyEscalationRuleSchedule) => {
+          return (
+            link.onCallDutyPolicyScheduleId ||
+            link.onCallDutyPolicySchedule?.id ||
+            null
+          );
+        })
+        .filter((id: ObjectID | null): id is ObjectID => {
+          return Boolean(id);
+        });
+
+      const schedules: Array<OnCallDutyPolicySchedule> =
+        scheduleIds.length > 0
+          ? await OnCallDutyPolicyScheduleService.findBy({
+              query: {
+                _id: QueryHelper.any(scheduleIds),
+              },
+              select: scheduleRosterSelect,
+              sort: {
+                name: SortOrder.Ascending,
+              },
+              /*
+               * Sized to the id list, NOT the caller's row limit: this fetch
+               * exists to resolve every schedule the escalation rules
+               * reference — capping it short would make the fallback below
+               * falsely report readable schedules as "not accessible".
+               */
+              limit: scheduleIds.length,
+              skip: 0,
+              props: ctx.props,
+            })
+          : [];
+
+      const scheduleById: Map<string, OnCallDutyPolicySchedule> = new Map<
+        string,
+        OnCallDutyPolicySchedule
+      >();
+      for (const schedule of schedules) {
+        scheduleById.set(schedule.id?.toString() || "", schedule);
+      }
+
+      const rules: Array<OnCallDutyPolicyEscalationRule> =
+        escalation.rulesByPolicyId.get(onCallPolicyId.toString()) || [];
+
+      const rows: Array<JSONObject> = [];
+
+      for (const rule of rules) {
+        const ruleKey: string = rule.id?.toString() || "";
+        const ruleLabel: string = `Rule ${rule.order ?? "?"}`;
+
+        for (const link of escalation.ruleUsers) {
+          if (link.onCallDutyPolicyEscalationRuleId?.toString() !== ruleKey) {
+            continue;
+          }
+          rows.push({
+            source: `${ruleLabel} — direct responder`,
+            onCallNow: nameOf(link.user) || "Unknown user",
+            onCallUserId: link.user?.id?.toString(),
+            note: "Paged whenever this rule fires",
+          });
+        }
+
+        for (const link of escalation.ruleTeams) {
+          if (link.onCallDutyPolicyEscalationRuleId?.toString() !== ruleKey) {
+            continue;
+          }
+          const teamName: string = link.team?.name || "Unknown team";
+          rows.push({
+            source: `${ruleLabel} — team '${teamName}'`,
+            onCallNow: `All members of '${teamName}'`,
+            note: "Every team member is paged when this rule fires",
+          });
+        }
+
+        for (const link of escalation.ruleSchedules) {
+          if (link.onCallDutyPolicyEscalationRuleId?.toString() !== ruleKey) {
+            continue;
+          }
+          const linkedScheduleId: string =
+            link.onCallDutyPolicyScheduleId?.toString() ||
+            link.onCallDutyPolicySchedule?.id?.toString() ||
+            "";
+          const schedule: OnCallDutyPolicySchedule | undefined =
+            scheduleById.get(linkedScheduleId);
+          if (schedule) {
+            rows.push(
+              scheduleStatusRow(
+                schedule,
+                `${ruleLabel} — schedule '${schedule.name || ""}'`,
+              ),
+            );
+          } else {
+            rows.push({
+              source: `${ruleLabel} — schedule '${link.onCallDutyPolicySchedule?.name || linkedScheduleId}'`,
+              onCallNow: SCHEDULE_NOT_ACCESSIBLE,
+            });
+          }
+        }
+      }
+
+      const serialized: SerializedResult =
+        ToolResultSerializer.serializeRows(rows);
+
+      return {
+        dataForLlm: serialized.text,
+        rowCount: serialized.rowCount,
+        citationLabel: `On-call now for '${policy.name || onCallPolicyId.toString()}' (${respondersLabel(countResponders(rows))})`,
+        citationTarget: {
+          type: AIChatCitationTargetType.OnCallPolicyView,
+          params: { onCallDutyPolicyId: onCallPolicyId.toString() },
+        },
+        redactionCount: serialized.redactionCount,
+        isTruncated: serialized.isTruncated,
+        widget:
+          rows.length > 0
+            ? WidgetBuilder.table({
+                title: `On-call now: ${policy.name || ""}`.trim(),
+                description: "Who each escalation rule pages, in order",
+                columns: onCallStatusColumns,
+                rows: rows,
+                link: {
+                  type: AIChatCitationTargetType.OnCallPolicyView,
+                  params: { onCallDutyPolicyId: onCallPolicyId.toString() },
+                },
+              })
+            : undefined,
+      };
+    }
+
+    const schedules: Array<OnCallDutyPolicySchedule> =
+      await OnCallDutyPolicyScheduleService.findBy({
+        query: {},
+        select: scheduleRosterSelect,
+        sort: {
+          name: SortOrder.Ascending,
+        },
+        limit: limit,
+        skip: 0,
+        props: ctx.props,
+      });
+
+    const rows: Array<JSONObject> = schedules.map(
+      (schedule: OnCallDutyPolicySchedule) => {
+        return scheduleStatusRow(schedule);
+      },
+    );
+
+    const serialized: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    return {
+      dataForLlm: serialized.text,
+      rowCount: serialized.rowCount,
+      citationLabel: `On-call now (${respondersLabel(countResponders(rows))})`,
+      citationTarget: {
+        type: AIChatCitationTargetType.OnCallPolicies,
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `On-call now (${rows.length} ${rows.length === 1 ? "schedule" : "schedules"})`,
+              columns: onCallStatusColumns,
+              rows: rows,
+              link: { type: AIChatCitationTargetType.OnCallPolicies },
+            })
+          : undefined,
+    };
+  },
+};
+
+/*
+ * ---------------------------------------------------------------------------
+ * query_on_call_pages — recent policy executions and who was notified.
+ * ---------------------------------------------------------------------------
+ */
+
+function formatTrigger(log: OnCallDutyPolicyExecutionLog): string | undefined {
+  if (log.triggeredByIncident) {
+    const incidentNumber: string = log.triggeredByIncident.incidentNumber
+      ? ` #${log.triggeredByIncident.incidentNumber}`
+      : "";
+    return `Incident${incidentNumber}: ${log.triggeredByIncident.title || ""}`.trim();
+  }
+  if (log.triggeredByAlert) {
+    return `Alert: ${log.triggeredByAlert.title || ""}`.trim();
+  }
+  if (log.triggeredByUser) {
+    return `Manually triggered by ${nameOf(log.triggeredByUser) || "a user"}`;
+  }
+  return undefined;
+}
+
+export const QueryOnCallPagesTool: ObservabilityTool = {
+  name: "query_on_call_pages",
+  description:
+    "Recent on-call pages (on-call policy executions): when a policy was triggered, by which incident or alert, how far it escalated, who was notified and whether anyone acknowledged. Defaults to the last 24 hours; pass startTime/endTime (ISO 8601) for another window. Filter by onCallPolicyId (find it with query_on_call_policies), incidentId (query_incidents) or alertId (query_alerts). Use this to answer 'was anyone paged?', 'who was notified?' and 'did anyone acknowledge?'.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      onCallPolicyId: {
+        type: "string",
+        description: "Only pages of this on-call policy.",
+      },
+      incidentId: {
+        type: "string",
+        description: "Only pages triggered by this incident.",
+      },
+      alertId: {
+        type: "string",
+        description: "Only pages triggered by this alert.",
+      },
+      startTime: {
+        type: "string",
+        description:
+          "Start of the time range as an ISO 8601 timestamp. Defaults to 24 hours before endTime.",
+      },
+      endTime: {
+        type: "string",
+        description:
+          "End of the time range as an ISO 8601 timestamp. Defaults to now.",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum pages to return (default 10, max 25).",
+      },
+      skip: {
+        type: "number",
+        description:
+          "Rows to skip, for paging through long result sets (default 0, max 500).",
+      },
+    },
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveExecutionLogReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const onCallPolicyId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "onCallPolicyId",
+    );
+    const incidentId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "incidentId",
+    );
+    const alertId: ObjectID | undefined = ToolArgs.getObjectID(args, "alertId");
+
+    const { startTime, endTime } = ToolArgs.getTimeRange(args, {
+      defaultHours: 24,
+      maxDays: 90,
+    });
+
+    const limit: number = ToolArgs.getNumber(args, "limit", {
+      defaultValue: 10,
+      min: 1,
+      max: 25,
+    });
+    const skip: number = ToolArgs.getNumber(args, "skip", {
+      defaultValue: 0,
+      min: 0,
+      max: 500,
+    });
+
+    const query: Query<OnCallDutyPolicyExecutionLog> = {
+      createdAt: QueryHelper.inBetween(startTime, endTime),
+    };
+    if (onCallPolicyId) {
+      query.onCallDutyPolicyId = onCallPolicyId;
+    }
+    if (incidentId) {
+      query.triggeredByIncidentId = incidentId;
+    }
+    if (alertId) {
+      query.triggeredByAlertId = alertId;
+    }
+
+    const totalCount: PositiveNumber =
+      await OnCallDutyPolicyExecutionLogService.countBy({
+        query: query,
+        props: ctx.props,
+      });
+
+    const logs: Array<OnCallDutyPolicyExecutionLog> =
+      await OnCallDutyPolicyExecutionLogService.findBy({
+        query: query,
+        select: {
+          _id: true,
+          createdAt: true,
+          status: true,
+          statusMessage: true,
+          lastExecutedEscalationRuleOrder: true,
+          acknowledgedAt: true,
+          onCallDutyPolicy: {
+            _id: true,
+            name: true,
+          },
+          triggeredByIncident: {
+            _id: true,
+            title: true,
+            incidentNumber: true,
+          },
+          triggeredByAlert: {
+            _id: true,
+            title: true,
+          },
+          triggeredByUser: {
+            _id: true,
+            name: true,
+          },
+          acknowledgedByUser: {
+            _id: true,
+            name: true,
+          },
+        },
+        sort: {
+          createdAt: SortOrder.Descending,
+        },
+        limit: limit,
+        skip: skip,
+        props: ctx.props,
+      });
+
+    /*
+     * Per-responder delivery/ack outcomes come from UserOnCallLog — one row
+     * per user the execution notified. Fetched in one batch for all returned
+     * executions, under the same requesting-user props.
+     */
+    const executionLogIds: Array<ObjectID> = logs
+      .map((log: OnCallDutyPolicyExecutionLog) => {
+        return log.id;
+      })
+      .filter((id: ObjectID | null): id is ObjectID => {
+        return Boolean(id);
+      });
+
+    const userLogs: Array<UserOnCallLog> =
+      executionLogIds.length > 0
+        ? await UserOnCallLogService.findBy({
+            query: {
+              onCallDutyPolicyExecutionLogId: QueryHelper.any(executionLogIds),
+            },
+            select: {
+              _id: true,
+              onCallDutyPolicyExecutionLogId: true,
+              status: true,
+              statusMessage: true,
+              acknowledgedAt: true,
+              user: {
+                _id: true,
+                name: true,
+              },
+            },
+            sort: {
+              createdAt: SortOrder.Ascending,
+            },
+            limit: LIMIT_PER_PROJECT,
+            skip: 0,
+            props: ctx.props,
+          })
+        : [];
+
+    const notifiedByExecutionId: Map<string, Array<string>> = new Map<
+      string,
+      Array<string>
+    >();
+    for (const userLog of userLogs) {
+      const executionKey: string =
+        userLog.onCallDutyPolicyExecutionLogId?.toString() || "";
+      if (!executionKey) {
+        continue;
+      }
+      const entries: Array<string> =
+        notifiedByExecutionId.get(executionKey) || [];
+      entries.push(
+        `${nameOf(userLog.user) || "Unknown user"}: ${userLog.status || "Unknown"}${
+          userLog.acknowledgedAt ? " (acknowledged)" : ""
+        }`,
+      );
+      notifiedByExecutionId.set(executionKey, entries);
+    }
+
+    const rows: Array<JSONObject> = logs.map(
+      (log: OnCallDutyPolicyExecutionLog) => {
+        const notified: Array<string> =
+          notifiedByExecutionId.get(log.id?.toString() || "") || [];
+        return {
+          id: log.id?.toString(),
+          triggeredAt: log.createdAt,
+          policy: log.onCallDutyPolicy?.name,
+          policyId: log.onCallDutyPolicy?.id?.toString(),
+          trigger: formatTrigger(log),
+          status: log.status,
+          statusMessage: log.statusMessage,
+          escalatedToRuleOrder: log.lastExecutedEscalationRuleOrder,
+          acknowledgedBy: nameOf(log.acknowledgedByUser),
+          acknowledgedAt: log.acknowledgedAt,
+          notified:
+            notified.length > 0
+              ? notified.join(", ")
+              : "No individual notifications recorded",
+        };
+      },
+    );
+
+    const serialized: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    /*
+     * Window label for the citation: hours for short windows, whole days for
+     * long ones, so "last 24h" and "last 7d" both read naturally.
+     */
+    const windowHours: number = Math.max(
+      1,
+      Math.round((endTime.getTime() - startTime.getTime()) / (60 * 60 * 1000)),
+    );
+    const windowLabel: string =
+      windowHours >= 48 && windowHours % 24 === 0
+        ? `${windowHours / 24}d`
+        : `${windowHours}h`;
+
+    const total: number = totalCount.toNumber();
+    const hasMore: boolean = total > rows.length && rows.length > 0;
+    const dataForLlm: string = hasMore
+      ? `Showing rows ${skip + 1}–${skip + rows.length} of ${total} total. Pass skip to page further.\n${serialized.text}`
+      : serialized.text;
+
+    return {
+      dataForLlm: dataForLlm,
+      rowCount: serialized.rowCount,
+      citationLabel: hasMore
+        ? `On-call pages, last ${windowLabel} (${rows.length} of ${total})`
+        : `On-call pages, last ${windowLabel} (${serialized.rowCount} found)`,
+      citationTarget: onCallPolicyId
+        ? {
+            type: AIChatCitationTargetType.OnCallPolicyView,
+            params: { onCallDutyPolicyId: onCallPolicyId.toString() },
+          }
+        : {
+            type: AIChatCitationTargetType.OnCallPolicies,
+          },
+      redactionCount: serialized.redactionCount,
+      isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `On-call pages (${rows.length})`,
+              description: `Policy executions in the last ${windowLabel}`,
+              columns: [
+                { key: "triggeredAt", title: "Triggered", type: "date" },
+                { key: "policy", title: "Policy", type: "text" },
+                { key: "trigger", title: "Trigger", type: "text" },
+                { key: "status", title: "Status", type: "text" },
+                { key: "acknowledgedBy", title: "Acked by", type: "text" },
+                { key: "notified", title: "Notified", type: "text" },
+              ],
+              rows: rows,
+              link: onCallPolicyId
+                ? {
+                    type: AIChatCitationTargetType.OnCallPolicyView,
+                    params: {
+                      onCallDutyPolicyId: onCallPolicyId.toString(),
+                    },
+                  }
+                : { type: AIChatCitationTargetType.OnCallPolicies },
+            })
+          : undefined,
+    };
+  },
+};

--- a/Common/Server/Utils/AI/Toolbox/RunbookTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/RunbookTools.ts
@@ -1,0 +1,424 @@
+import Runbook from "../../../../Models/DatabaseModels/Runbook";
+import RunbookExecution from "../../../../Models/DatabaseModels/RunbookExecution";
+import { JSONArray, JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import Permission from "../../../../Types/Permission";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import RunbookStepType from "../../../../Types/Runbook/RunbookStepType";
+import { RunbookStep } from "../../../../Types/Runbook/RunbookStep";
+import RunbookService from "../../../Services/RunbookService";
+import RunbookExecutionService from "../../../Services/RunbookExecutionService";
+import logger from "../../Logger";
+import ToolResultSerializer, { SerializedResult } from "./Serializer";
+import WidgetBuilder from "./WidgetBuilder";
+import {
+  ObservabilityTool,
+  ToolArgs,
+  ToolContext,
+  ToolExecutionResult,
+} from "./ToolTypes";
+
+/*
+ * Derived from the model ACL so the tool gate can never drift from RBAC.
+ * Resolved lazily rather than at module load: this module is pulled in through
+ * the service import graph before the Runbook model class is fully wired up,
+ * so calling a model method at import time throws a circular-dependency
+ * TypeError. By the time a tool actually executes, every module is loaded.
+ */
+let cachedReadPermissions: Array<Permission> | null = null;
+const resolveReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedReadPermissions) {
+      cachedReadPermissions = new Runbook().getReadPermissions();
+    }
+    return cachedReadPermissions;
+  };
+
+// How many of the runbook's latest executions the detail mode surfaces.
+const RECENT_EXECUTIONS_LIMIT: number = 5;
+
+/*
+ * Runbook.steps is an unvalidated JSON column, so every field read below is
+ * defensive: a hand-edited or legacy step must degrade to a partial row, not
+ * throw.
+ */
+function configString(config: JSONObject, key: string): string {
+  const value: unknown = config[key];
+  return typeof value === "string" ? value : "";
+}
+
+/*
+ * One human/model-readable line describing what a step actually DOES — the
+ * script, command, request or prompt behind it. Long values are fine here:
+ * the serializer caps each field at its per-field limit.
+ */
+function describeStepInstructions(step: RunbookStep): string {
+  const config: JSONObject = (step.config || {}) as unknown as JSONObject;
+
+  switch (step.type) {
+    case RunbookStepType.Manual: {
+      return "Manual step — a responder performs this by hand (see the step title/description).";
+    }
+    case RunbookStepType.JavaScript: {
+      return `Runs JavaScript on a runner: ${configString(config, "script")}`;
+    }
+    case RunbookStepType.Bash: {
+      return `Runs bash on a runner: ${configString(config, "script")}`;
+    }
+    case RunbookStepType.HttpRequest: {
+      const body: string = configString(config, "body");
+      return `HTTP ${configString(config, "method")} ${configString(config, "url")}${
+        body ? ` with body: ${body}` : ""
+      }`;
+    }
+    case RunbookStepType.AI: {
+      return `AI step with prompt: ${configString(config, "prompt")}`;
+    }
+    case RunbookStepType.SSH: {
+      return `Runs over SSH: ${configString(config, "command")}`;
+    }
+    case RunbookStepType.Kubernetes: {
+      const replicas: unknown = config["replicas"];
+      return `Kubernetes ${configString(config, "action")} on ${configString(
+        config,
+        "workloadKind",
+      )} ${configString(config, "namespace")}/${configString(
+        config,
+        "workloadName",
+      )}${typeof replicas === "number" ? ` (replicas: ${replicas})` : ""}`;
+    }
+    default: {
+      // Unknown step type (newer schema than this build) — show the raw config.
+      return JSON.stringify(config);
+    }
+  }
+}
+
+// Steps in execution order, tolerating malformed entries in the JSON column.
+function parseSteps(steps: JSONArray | undefined): Array<RunbookStep> {
+  const rawSteps: Array<RunbookStep> =
+    (steps as unknown as Array<RunbookStep>) || [];
+
+  return rawSteps
+    .filter((step: RunbookStep) => {
+      return Boolean(step) && typeof step === "object";
+    })
+    .slice()
+    .sort((a: RunbookStep, b: RunbookStep) => {
+      return (Number(a.order) || 0) - (Number(b.order) || 0);
+    });
+}
+
+export const QueryRunbooksTool: ObservabilityTool = {
+  name: "query_runbooks",
+  description:
+    "Query runbooks (predefined response/remediation procedures) in this project. Without arguments it lists runbooks with their id, name, description, step count and whether they are enabled. Pass runbookId to read one runbook's full ordered steps — each step's title, type and the exact instructions/script/command it runs — plus its recent executions (status, when, who triggered it). Use this to answer 'what does the runbook say to do?' and to find the runbookId to pass to run_runbook.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      runbookId: {
+        type: "string",
+        description:
+          "Get one runbook by its ID — returns the full ordered step content and the runbook's most recent executions. Find the id by calling this tool without arguments first.",
+      },
+      limit: {
+        type: "number",
+        description:
+          "List mode: maximum runbooks to return (default 10, max 25).",
+      },
+      skip: {
+        type: "number",
+        description:
+          "List mode: how many runbooks to skip, for paging through a long list (default 0).",
+      },
+    },
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const runbookId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "runbookId",
+    );
+
+    if (runbookId) {
+      const runbook: Runbook | null = await RunbookService.findOneById({
+        id: runbookId,
+        select: {
+          _id: true,
+          name: true,
+          description: true,
+          isEnabled: true,
+          steps: true,
+          createdAt: true,
+          labels: {
+            name: true,
+          },
+        },
+        props: ctx.props,
+      });
+
+      if (!runbook) {
+        const serialized: SerializedResult = ToolResultSerializer.serializeRows(
+          [],
+        );
+
+        return {
+          dataForLlm: serialized.text,
+          rowCount: serialized.rowCount,
+          citationLabel: `Runbook ${runbookId.toString()}`,
+          citationTarget: {
+            type: AIChatCitationTargetType.RunbookView,
+            params: { runbookId: runbookId.toString() },
+          },
+          redactionCount: serialized.redactionCount,
+          isTruncated: serialized.isTruncated,
+        };
+      }
+
+      const steps: Array<RunbookStep> = parseSteps(runbook.steps);
+
+      const labels: string = (runbook.labels || [])
+        .map((label: { name?: string }) => {
+          return label.name || "";
+        })
+        .filter((value: string) => {
+          return value.length > 0;
+        })
+        .join(", ");
+
+      /*
+       * Recent executions are fetched best-effort: RunbookExecution has its
+       * own read ACL (ReadRunbookExecution vs ReadRunbook), so a user who can
+       * read the runbook may still be denied its executions. The steps — the
+       * reason this tool exists — must not be lost to that.
+       */
+      let executions: Array<RunbookExecution> = [];
+      try {
+        executions = await RunbookExecutionService.findBy({
+          query: {
+            runbookId: runbookId,
+            /*
+             * runbookId is an untrusted model argument, so the tenant is
+             * pinned from ctx — same as IncidentTools' owner-table queries.
+             */
+            projectId: ctx.projectId,
+          },
+          select: {
+            _id: true,
+            status: true,
+            createdAt: true,
+            startedAt: true,
+            completedAt: true,
+            failureReason: true,
+            triggeredByUser: {
+              name: true,
+            },
+          },
+          sort: {
+            createdAt: SortOrder.Descending,
+          },
+          limit: RECENT_EXECUTIONS_LIMIT,
+          skip: 0,
+          props: ctx.props,
+        });
+      } catch (error) {
+        logger.debug(`query_runbooks: executions fetch skipped: ${error}`);
+      }
+
+      /*
+       * One record list with a `section` discriminator: the runbook header,
+       * then its steps in execution order, then the latest executions. The
+       * model reads it top-to-bottom the way a responder reads the runbook.
+       */
+      const stepRows: Array<JSONObject> = steps.map(
+        (step: RunbookStep, index: number) => {
+          return {
+            section: "step",
+            stepNumber: index + 1,
+            title: step.title,
+            type: step.type,
+            description: step.description,
+            instructions: describeStepInstructions(step),
+            requireApproval: step.requireApproval === true ? true : undefined,
+            continueOnFailure:
+              step.continueOnFailure === true ? true : undefined,
+          };
+        },
+      );
+
+      const executionRows: Array<JSONObject> = executions.map(
+        (execution: RunbookExecution) => {
+          return {
+            section: "recent_execution",
+            executionId: execution.id?.toString(),
+            status: execution.status,
+            triggeredBy:
+              execution.triggeredByUser?.name?.toString() || "Automation",
+            createdAt: execution.createdAt,
+            startedAt: execution.startedAt,
+            completedAt: execution.completedAt,
+            failureReason: execution.failureReason,
+          };
+        },
+      );
+
+      const rows: Array<JSONObject> = [
+        {
+          section: "runbook",
+          id: runbook.id?.toString(),
+          name: runbook.name,
+          description: runbook.description,
+          enabled: runbook.isEnabled !== false,
+          stepCount: steps.length,
+          labels: labels || undefined,
+          createdAt: runbook.createdAt,
+        },
+        ...stepRows,
+        ...executionRows,
+      ];
+
+      const serialized: SerializedResult =
+        ToolResultSerializer.serializeRows(rows);
+
+      const runbookIdString: string = runbookId.toString();
+
+      return {
+        dataForLlm: serialized.text,
+        rowCount: serialized.rowCount,
+        citationLabel: `Runbook "${runbook.name}" (${steps.length} step${
+          steps.length === 1 ? "" : "s"
+        })`,
+        citationTarget: {
+          type: AIChatCitationTargetType.RunbookView,
+          params: { runbookId: runbookIdString },
+        },
+        redactionCount: serialized.redactionCount,
+        isTruncated: serialized.isTruncated,
+        widget:
+          stepRows.length > 0
+            ? WidgetBuilder.table({
+                title: `Runbook: ${runbook.name}`,
+                description: runbook.description,
+                columns: [
+                  { key: "stepNumber", title: "#", type: "number" },
+                  { key: "title", title: "Step", type: "text" },
+                  { key: "type", title: "Type", type: "text" },
+                  { key: "instructions", title: "Instructions", type: "text" },
+                ],
+                rows: stepRows,
+                link: {
+                  type: AIChatCitationTargetType.RunbookView,
+                  params: { runbookId: runbookIdString },
+                },
+              })
+            : WidgetBuilder.resourceCard({
+                title: "Runbook",
+                resourceType: "Runbook",
+                heading: runbook.name || "Runbook",
+                subheading:
+                  runbook.isEnabled !== false ? "Enabled" : "Disabled",
+                fields: [
+                  { label: "Description", value: runbook.description || "—" },
+                  { label: "Steps", value: "0" },
+                ],
+                link: {
+                  type: AIChatCitationTargetType.RunbookView,
+                  params: { runbookId: runbookIdString },
+                },
+              }),
+      };
+    }
+
+    const limit: number = ToolArgs.getNumber(args, "limit", {
+      defaultValue: 10,
+      min: 1,
+      max: 25,
+    });
+    const skip: number = ToolArgs.getNumber(args, "skip", {
+      defaultValue: 0,
+      min: 0,
+      max: 500,
+    });
+
+    const runbooks: Array<Runbook> = await RunbookService.findBy({
+      query: {},
+      select: {
+        _id: true,
+        name: true,
+        description: true,
+        isEnabled: true,
+        steps: true,
+        createdAt: true,
+      },
+      sort: {
+        createdAt: SortOrder.Descending,
+      },
+      limit: limit,
+      skip: skip,
+      props: ctx.props,
+    });
+
+    const totalCountPositive: PositiveNumber = await RunbookService.countBy({
+      query: {},
+      props: ctx.props,
+    });
+    const totalCount: number = totalCountPositive.toNumber();
+
+    const rows: Array<JSONObject> = runbooks.map((runbook: Runbook) => {
+      return {
+        id: runbook.id?.toString(),
+        name: runbook.name,
+        description: runbook.description,
+        stepCount: parseSteps(runbook.steps).length,
+        enabled: runbook.isEnabled !== false,
+        createdAt: runbook.createdAt,
+      };
+    });
+
+    const serialized: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    // Tell the model it is looking at one page of a longer list.
+    const isPaged: boolean = rows.length > 0 && totalCount > rows.length;
+    const pagingPrefix: string = isPaged
+      ? `Showing rows ${skip + 1}–${skip + rows.length} of ${totalCount} total. Pass skip to page further.\n`
+      : "";
+
+    return {
+      dataForLlm: `${pagingPrefix}${serialized.text}`,
+      rowCount: serialized.rowCount,
+      citationLabel: isPaged
+        ? `Runbooks (${rows.length} of ${totalCount})`
+        : `Runbooks (${serialized.rowCount} found)`,
+      citationTarget: {
+        type: AIChatCitationTargetType.Runbooks,
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `Runbooks (${rows.length})`,
+              description: isPaged
+                ? `Showing ${rows.length} of ${totalCount} runbooks`
+                : undefined,
+              columns: [
+                { key: "name", title: "Name", type: "text" },
+                { key: "stepCount", title: "Steps", type: "number" },
+                { key: "enabled", title: "Enabled", type: "text" },
+                { key: "description", title: "Description", type: "text" },
+              ],
+              rows: rows,
+              link: { type: AIChatCitationTargetType.Runbooks },
+            })
+          : undefined,
+    };
+  },
+};

--- a/Common/Server/Utils/AI/Toolbox/SloTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/SloTools.ts
@@ -1,0 +1,456 @@
+import ServiceLevelObjective from "../../../../Models/DatabaseModels/ServiceLevelObjective";
+import ServiceLevelObjectiveBurnRateRule from "../../../../Models/DatabaseModels/ServiceLevelObjectiveBurnRateRule";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import Permission from "../../../../Types/Permission";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import SloStatus from "../../../../Types/ServiceLevelObjective/SloStatus";
+import SloWindowType from "../../../../Types/ServiceLevelObjective/SloWindowType";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import ServiceLevelObjectiveService from "../../../Services/ServiceLevelObjectiveService";
+import ServiceLevelObjectiveBurnRateRuleService from "../../../Services/ServiceLevelObjectiveBurnRateRuleService";
+import Query from "../../../Types/Database/Query";
+import QueryHelper from "../../../Types/Database/QueryHelper";
+import ToolResultSerializer, { SerializedResult } from "./Serializer";
+import WidgetBuilder from "./WidgetBuilder";
+import {
+  ObservabilityTool,
+  ToolArgs,
+  ToolContext,
+  ToolExecutionResult,
+} from "./ToolTypes";
+
+/*
+ * Derived from the model ACL so the tool gate can never drift from RBAC.
+ * Resolved lazily rather than at module load: this module is pulled in through
+ * the service import graph before the ServiceLevelObjective model class is
+ * fully wired up, so calling a model method at import time throws a
+ * circular-dependency TypeError. By the time a tool actually executes, every
+ * module is loaded.
+ */
+let cachedReadPermissions: Array<Permission> | null = null;
+const resolveReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedReadPermissions) {
+      cachedReadPermissions = new ServiceLevelObjective().getReadPermissions();
+    }
+    return cachedReadPermissions;
+  };
+
+/*
+ * Compliance figures on the SLO row (current SLI %, error budget remaining,
+ * burn rate, status) are persisted by the SLO evaluation worker — the same
+ * values the SLO dashboard shows. This tool reports them as-of
+ * lastEvaluatedAt and never recomputes them live, so the note below travels
+ * with every non-empty result to keep the model honest about freshness.
+ */
+const COMPLIANCE_NOTE: string =
+  "Note: compliance figures (currentSliPercentage, errorBudgetRemaining*, currentBurnRate, sloStatus) are the platform's persisted values from the last worker evaluation (see lastEvaluatedAt) — not recomputed live. Rows without these fields have not been evaluated yet.\n";
+
+function joinNames(items: Array<{ name?: string }> | undefined): string {
+  return (items || [])
+    .map((item: { name?: string }) => {
+      return item.name || "";
+    })
+    .filter((value: string) => {
+      return value.length > 0;
+    })
+    .join(", ");
+}
+
+// "Rolling 30d" / "Calendar Month" — compact window description for one row.
+function describeWindow(slo: ServiceLevelObjective): string {
+  if (slo.windowType === SloWindowType.CalendarMonth) {
+    return SloWindowType.CalendarMonth;
+  }
+  return `${SloWindowType.Rolling} ${slo.windowDays ?? 30}d`;
+}
+
+// Percentage formatting for widget fields only; LLM rows keep raw numbers.
+function formatPercent(value: number | undefined | null): string {
+  if (value === undefined || value === null) {
+    return "not evaluated yet";
+  }
+  return `${Math.round(value * 100) / 100}%`;
+}
+
+export const QuerySlosTool: ObservabilityTool = {
+  name: "query_slos",
+  description:
+    "List Service Level Objectives (SLOs) in this project: what each one measures (monitor uptime or a metric SLI), its target percentage, compliance window, attached monitors, and the latest persisted compliance status — current SLI %, error budget remaining and burn rate as computed by the platform at its last evaluation (this tool never recomputes compliance live). Pass sloId (an SLO ID from this tool's own list results) to get one SLO's full definition plus its burn-rate alert rules and their thresholds. Use query_alerts to see alerts those burn-rate rules fired, and query_monitors for the current status of an SLO's monitors.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      sloId: {
+        type: "string",
+        description:
+          "Get one SLO by its ID — includes the full definition (SLI type, downtime statuses, monitor labels, at-risk threshold, error budget seconds) and its burn-rate rules with thresholds and alert windows.",
+      },
+      sloStatus: {
+        type: "string",
+        enum: Object.values(SloStatus),
+        description:
+          "Only list SLOs currently in this status (e.g. 'At Risk' or 'Budget Exhausted' to find SLOs in trouble).",
+      },
+      nameSearch: {
+        type: "string",
+        description: "Filter SLOs whose name contains this text.",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum SLOs to return (default 10, max 25).",
+      },
+      skip: {
+        type: "number",
+        description:
+          "Rows to skip for pagination (default 0). The result says when more rows exist.",
+      },
+    },
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const sloId: ObjectID | undefined = ToolArgs.getObjectID(args, "sloId");
+
+    if (sloId) {
+      const slo: ServiceLevelObjective | null =
+        await ServiceLevelObjectiveService.findOneById({
+          id: sloId,
+          select: {
+            _id: true,
+            name: true,
+            description: true,
+            isEnabled: true,
+            sliType: true,
+            multiMonitorMode: true,
+            metricQueryConfig: true,
+            targetPercentage: true,
+            windowType: true,
+            windowDays: true,
+            timezone: true,
+            atRiskThresholdPercentage: true,
+            sloStatus: true,
+            currentSliPercentage: true,
+            errorBudgetRemainingPercentage: true,
+            errorBudgetRemainingSeconds: true,
+            errorBudgetTotalSeconds: true,
+            currentBurnRate: true,
+            lastEvaluatedAt: true,
+            monitors: {
+              _id: true,
+              name: true,
+            },
+            monitorLabels: {
+              name: true,
+            },
+            downtimeMonitorStatuses: {
+              name: true,
+            },
+            labels: {
+              name: true,
+            },
+          },
+          props: ctx.props,
+        });
+
+      const rows: Array<JSONObject> = [];
+
+      if (slo) {
+        rows.push({
+          record: "slo",
+          id: slo.id?.toString(),
+          name: slo.name,
+          description: slo.description,
+          isEnabled: slo.isEnabled,
+          sliType: slo.sliType,
+          multiMonitorMode: slo.multiMonitorMode,
+          metricQueryConfig: slo.metricQueryConfig,
+          targetPercentage: slo.targetPercentage,
+          window: describeWindow(slo),
+          timezone: slo.timezone,
+          atRiskThresholdPercentage: slo.atRiskThresholdPercentage,
+          sloStatus: slo.sloStatus,
+          currentSliPercentage: slo.currentSliPercentage,
+          errorBudgetRemainingPercentage: slo.errorBudgetRemainingPercentage,
+          errorBudgetRemainingSeconds: slo.errorBudgetRemainingSeconds,
+          errorBudgetTotalSeconds: slo.errorBudgetTotalSeconds,
+          currentBurnRate: slo.currentBurnRate,
+          lastEvaluatedAt: slo.lastEvaluatedAt,
+          monitors: joinNames(slo.monitors) || undefined,
+          autoAttachMonitorLabels: joinNames(slo.monitorLabels) || undefined,
+          downtimeMonitorStatuses:
+            joinNames(slo.downtimeMonitorStatuses) || undefined,
+          labels: joinNames(slo.labels) || undefined,
+        });
+      }
+
+      /*
+       * Burn-rate rules are only fetched when the SLO itself is visible to
+       * the user — the rule table is OwnedThrough the SLO, so this also
+       * avoids leaking rule names for an SLO the user cannot read.
+       */
+      let rules: Array<ServiceLevelObjectiveBurnRateRule> = [];
+
+      if (slo) {
+        rules = await ServiceLevelObjectiveBurnRateRuleService.findBy({
+          query: {
+            serviceLevelObjectiveId: sloId,
+          },
+          select: {
+            _id: true,
+            name: true,
+            isEnabled: true,
+            burnRateThreshold: true,
+            longWindowInMinutes: true,
+            shortWindowInMinutes: true,
+            minimumSampleCount: true,
+            refireSuppressionMinutes: true,
+            alertSeverity: {
+              name: true,
+            },
+            lastAlertCreatedAt: true,
+            lastAlertResolvedAt: true,
+          },
+          sort: {
+            burnRateThreshold: SortOrder.Descending,
+          },
+          limit: 25,
+          skip: 0,
+          props: ctx.props,
+        });
+      }
+
+      for (const rule of rules) {
+        rows.push({
+          record: "burnRateRule",
+          id: rule.id?.toString(),
+          name: rule.name,
+          isEnabled: rule.isEnabled,
+          burnRateThreshold: rule.burnRateThreshold,
+          longWindowInMinutes: rule.longWindowInMinutes,
+          shortWindowInMinutes: rule.shortWindowInMinutes,
+          minimumSampleCount: rule.minimumSampleCount,
+          refireSuppressionMinutes: rule.refireSuppressionMinutes,
+          alertSeverity: rule.alertSeverity?.name,
+          lastAlertCreatedAt: rule.lastAlertCreatedAt,
+          lastAlertResolvedAt: rule.lastAlertResolvedAt,
+        });
+      }
+
+      const serialized: SerializedResult =
+        ToolResultSerializer.serializeRows(rows);
+
+      return {
+        dataForLlm:
+          rows.length > 0
+            ? `${COMPLIANCE_NOTE}${serialized.text}`
+            : serialized.text,
+        rowCount: serialized.rowCount,
+        citationLabel: `SLO ${slo?.name || sloId.toString()}`,
+        citationTarget: {
+          type: AIChatCitationTargetType.SloView,
+          params: { sloId: sloId.toString() },
+        },
+        redactionCount: serialized.redactionCount,
+        isTruncated: serialized.isTruncated,
+        widget: slo
+          ? WidgetBuilder.resourceCard({
+              title: `SLO ${slo.name ?? ""}`.trim(),
+              resourceType: "Service Level Objective",
+              heading: slo.name || sloId.toString(),
+              subheading: slo.description,
+              fields: [
+                {
+                  label: "Target",
+                  value: formatPercent(slo.targetPercentage),
+                },
+                { label: "Window", value: describeWindow(slo) },
+                { label: "SLI type", value: slo.sliType || "" },
+                { label: "Status", value: slo.sloStatus || "" },
+                {
+                  label: "Current SLI",
+                  value: formatPercent(slo.currentSliPercentage),
+                },
+                {
+                  label: "Error budget left",
+                  value: formatPercent(slo.errorBudgetRemainingPercentage),
+                },
+                {
+                  label: "Burn rate",
+                  value:
+                    slo.currentBurnRate !== undefined &&
+                    slo.currentBurnRate !== null
+                      ? String(Math.round(slo.currentBurnRate * 100) / 100)
+                      : "not evaluated yet",
+                },
+                { label: "Monitors", value: joinNames(slo.monitors) || "none" },
+                { label: "Burn-rate rules", value: String(rules.length) },
+              ],
+              link: {
+                type: AIChatCitationTargetType.SloView,
+                params: { sloId: sloId.toString() },
+              },
+            })
+          : undefined,
+      };
+    }
+
+    const statusFilterString: string | undefined = ToolArgs.getString(
+      args,
+      "sloStatus",
+    );
+
+    let statusFilter: SloStatus | undefined = undefined;
+    if (statusFilterString) {
+      statusFilter = Object.values(SloStatus).find(
+        (status: SloStatus): boolean => {
+          return status.toLowerCase() === statusFilterString.toLowerCase();
+        },
+      );
+
+      // An unknown status silently matching nothing would read as "all clear".
+      if (!statusFilter) {
+        return {
+          dataForLlm: `Error: sloStatus "${statusFilterString}" is not a valid SLO status. Valid values: ${Object.values(
+            SloStatus,
+          ).join(", ")}.`,
+          rowCount: 0,
+          citationLabel: "SLOs (invalid status filter)",
+          redactionCount: 0,
+          isTruncated: false,
+        };
+      }
+    }
+
+    const nameSearch: string | undefined = ToolArgs.getString(
+      args,
+      "nameSearch",
+    );
+    const limit: number = ToolArgs.getNumber(args, "limit", {
+      defaultValue: 10,
+      min: 1,
+      max: 25,
+    });
+    const skip: number = ToolArgs.getNumber(args, "skip", {
+      defaultValue: 0,
+      min: 0,
+      max: 500,
+    });
+
+    const query: Query<ServiceLevelObjective> = {};
+    if (statusFilter) {
+      query.sloStatus = statusFilter;
+    }
+    if (nameSearch) {
+      query.name = QueryHelper.search(nameSearch);
+    }
+
+    const slos: Array<ServiceLevelObjective> =
+      await ServiceLevelObjectiveService.findBy({
+        query: query,
+        select: {
+          _id: true,
+          name: true,
+          isEnabled: true,
+          sliType: true,
+          targetPercentage: true,
+          windowType: true,
+          windowDays: true,
+          sloStatus: true,
+          currentSliPercentage: true,
+          errorBudgetRemainingPercentage: true,
+          currentBurnRate: true,
+          lastEvaluatedAt: true,
+          monitors: {
+            name: true,
+          },
+        },
+        sort: {
+          name: SortOrder.Ascending,
+        },
+        limit: limit,
+        skip: skip,
+        props: ctx.props,
+      });
+
+    const totalCount: PositiveNumber =
+      await ServiceLevelObjectiveService.countBy({
+        query: query,
+        props: ctx.props,
+      });
+    const total: number = totalCount.toNumber();
+
+    const rows: Array<JSONObject> = slos.map((slo: ServiceLevelObjective) => {
+      return {
+        id: slo.id?.toString(),
+        name: slo.name,
+        isEnabled: slo.isEnabled,
+        sliType: slo.sliType,
+        targetPercentage: slo.targetPercentage,
+        window: describeWindow(slo),
+        monitors: joinNames(slo.monitors) || undefined,
+        sloStatus: slo.sloStatus,
+        currentSliPercentage: slo.currentSliPercentage,
+        errorBudgetRemainingPercentage: slo.errorBudgetRemainingPercentage,
+        currentBurnRate: slo.currentBurnRate,
+        lastEvaluatedAt: slo.lastEvaluatedAt,
+      };
+    });
+
+    const serialized: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    let prefix: string = "";
+    if (rows.length > 0) {
+      if (total > rows.length) {
+        prefix += `Showing rows ${skip + 1}–${skip + rows.length} of ${total} total. Pass skip to page further.\n`;
+      }
+      prefix += COMPLIANCE_NOTE;
+    }
+
+    const filterLabel: string = statusFilter ? `${statusFilter} ` : "";
+
+    return {
+      dataForLlm: `${prefix}${serialized.text}`,
+      rowCount: serialized.rowCount,
+      citationLabel: `${filterLabel}SLOs (${total} found)`,
+      citationTarget: {
+        type: AIChatCitationTargetType.Slos,
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `${filterLabel}SLOs (${total})`,
+              description:
+                "Compliance columns are as of each SLO's last evaluation.",
+              columns: [
+                { key: "name", title: "Name", type: "text" },
+                { key: "targetPercentage", title: "Target %", type: "number" },
+                { key: "window", title: "Window", type: "text" },
+                {
+                  key: "currentSliPercentage",
+                  title: "Current SLI %",
+                  type: "number",
+                },
+                {
+                  key: "errorBudgetRemainingPercentage",
+                  title: "Budget left %",
+                  type: "number",
+                },
+                { key: "currentBurnRate", title: "Burn rate", type: "number" },
+                { key: "sloStatus", title: "Status", type: "text" },
+              ],
+              rows: rows,
+              link: { type: AIChatCitationTargetType.Slos },
+            })
+          : undefined,
+    };
+  },
+};

--- a/Common/Server/Utils/AI/Toolbox/StatusPageTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/StatusPageTools.ts
@@ -1,0 +1,559 @@
+import StatusPage from "../../../../Models/DatabaseModels/StatusPage";
+import StatusPageAnnouncement from "../../../../Models/DatabaseModels/StatusPageAnnouncement";
+import StatusPageResource from "../../../../Models/DatabaseModels/StatusPageResource";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import Permission from "../../../../Types/Permission";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import StatusPageService from "../../../Services/StatusPageService";
+import StatusPageAnnouncementService from "../../../Services/StatusPageAnnouncementService";
+import StatusPageResourceService from "../../../Services/StatusPageResourceService";
+import StatusPageSubscriberService from "../../../Services/StatusPageSubscriberService";
+import Query from "../../../Types/Database/Query";
+import QueryHelper from "../../../Types/Database/QueryHelper";
+import OneUptimeDate from "../../../../Types/Date";
+import ToolResultSerializer, { SerializedResult } from "./Serializer";
+import WidgetBuilder from "./WidgetBuilder";
+import {
+  ObservabilityTool,
+  ToolArgs,
+  ToolContext,
+  ToolExecutionResult,
+} from "./ToolTypes";
+
+/*
+ * Derived from the model ACL so the tool gate can never drift from RBAC.
+ * Resolved lazily rather than at module load: this module is pulled in through
+ * the service import graph before the model classes are fully wired up, so
+ * calling a model method at import time throws a circular-dependency
+ * TypeError. By the time a tool actually executes, every module is loaded.
+ */
+let cachedStatusPageReadPermissions: Array<Permission> | null = null;
+const resolveStatusPageReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedStatusPageReadPermissions) {
+      cachedStatusPageReadPermissions = new StatusPage().getReadPermissions();
+    }
+    return cachedStatusPageReadPermissions;
+  };
+
+let cachedAnnouncementReadPermissions: Array<Permission> | null = null;
+const resolveAnnouncementReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedAnnouncementReadPermissions) {
+      cachedAnnouncementReadPermissions =
+        new StatusPageAnnouncement().getReadPermissions();
+    }
+    return cachedAnnouncementReadPermissions;
+  };
+
+// Resources a detail view lists — enough for any real page, still bounded.
+const MAX_RESOURCES_PER_PAGE: number = 50;
+
+/*
+ * The public URL is a convenience field: it comes from GlobalConfig/custom
+ * domain lookups (cached inside StatusPageService), and a failure there must
+ * not take down the status page listing itself.
+ */
+async function resolvePublicUrl(
+  statusPageId: ObjectID,
+): Promise<string | undefined> {
+  try {
+    return await StatusPageService.getStatusPageURL(statusPageId);
+  } catch {
+    return undefined;
+  }
+}
+
+function joinNames(items: Array<{ name?: string }> | undefined): string {
+  return (items || [])
+    .map((item: { name?: string }) => {
+      return item.name || "";
+    })
+    .filter((value: string) => {
+      return value.length > 0;
+    })
+    .join(", ");
+}
+
+/*
+ * "Checkout (monitor: checkout-api)" — the display name the public sees plus
+ * the backing monitor/group, so the model can pivot from a public resource to
+ * the internal monitor it maps to.
+ */
+function describeResource(resource: StatusPageResource): string {
+  const monitorName: string =
+    resource.monitor?.name || resource.monitorGroup?.name || "";
+  const displayName: string = resource.displayName || monitorName;
+
+  if (!displayName) {
+    return "";
+  }
+
+  if (monitorName && monitorName !== displayName) {
+    const sourceKind: string = resource.monitor?.name
+      ? "monitor"
+      : "monitor group";
+    return `${displayName} (${sourceKind}: ${monitorName})`;
+  }
+
+  return displayName;
+}
+
+/*
+ * "Showing rows 3–4 of 12 total…" prefix for paged list results, so a slice
+ * never masquerades as the full picture.
+ */
+function buildPagingPrefix(data: {
+  skip: number;
+  returnedRows: number;
+  totalCount: number;
+}): string {
+  if (data.totalCount <= data.returnedRows) {
+    return "";
+  }
+  return `Showing rows ${data.skip + 1}–${data.skip + data.returnedRows} of ${data.totalCount} total. Pass skip to page further.\n`;
+}
+
+export const QueryStatusPagesTool: ObservabilityTool = {
+  name: "query_status_pages",
+  description:
+    "List the status pages in this project and what each one shows to the outside world. Use this BEFORE post_incident_status_update so you know which status pages exist, what an incident affects publicly, and how many subscribers a post will reach. List mode returns every page's id, name, description, visibility and public URL. Pass statusPageId (an id from the list) for detail mode: the monitors/resources displayed on that page and the count of active (confirmed, not unsubscribed) email/SMS/webhook subscribers a public post notifies. Use query_status_page_announcements to see what has already been announced.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      statusPageId: {
+        type: "string",
+        description:
+          "Get one status page by its ID (includes the resources it displays and its active subscriber count).",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum status pages to return (default 10, max 25).",
+      },
+      skip: {
+        type: "number",
+        description:
+          "Rows to skip for pagination (default 0). Use with limit when the project has more status pages than one call returns.",
+      },
+    },
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveStatusPageReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const statusPageId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "statusPageId",
+    );
+
+    if (statusPageId) {
+      const statusPage: StatusPage | null = await StatusPageService.findOneById(
+        {
+          id: statusPageId,
+          select: {
+            _id: true,
+            name: true,
+            description: true,
+            pageTitle: true,
+            pageDescription: true,
+            isPublicStatusPage: true,
+          },
+          props: ctx.props,
+        },
+      );
+
+      if (!statusPage) {
+        const serializedEmpty: SerializedResult =
+          ToolResultSerializer.serializeRows([]);
+
+        return {
+          dataForLlm: serializedEmpty.text,
+          rowCount: 0,
+          citationLabel: `Status page ${statusPageId.toString()}`,
+          citationTarget: {
+            type: AIChatCitationTargetType.StatusPageView,
+            params: { statusPageId: statusPageId.toString() },
+          },
+          redactionCount: serializedEmpty.redactionCount,
+          isTruncated: serializedEmpty.isTruncated,
+        };
+      }
+
+      /*
+       * Active subscribers = confirmed and not unsubscribed — the same filter
+       * StatusPageSubscriberService.getSubscribersByStatusPage uses when it
+       * actually sends notifications, so this count is the real reach of a
+       * public post. projectId is pinned to the tenant from ctx on both
+       * sub-queries because statusPageId is an untrusted model argument.
+       */
+      const [resources, activeSubscribers, publicUrl]: [
+        Array<StatusPageResource>,
+        PositiveNumber,
+        string | undefined,
+      ] = await Promise.all([
+        StatusPageResourceService.findBy({
+          query: {
+            statusPageId: statusPageId,
+            projectId: ctx.projectId,
+          },
+          select: {
+            _id: true,
+            displayName: true,
+            monitor: {
+              name: true,
+            },
+            monitorGroup: {
+              name: true,
+            },
+          },
+          sort: {
+            order: SortOrder.Ascending,
+          },
+          limit: MAX_RESOURCES_PER_PAGE,
+          skip: 0,
+          props: ctx.props,
+        }),
+        StatusPageSubscriberService.countBy({
+          query: {
+            statusPageId: statusPageId,
+            projectId: ctx.projectId,
+            isUnsubscribed: false,
+            isSubscriptionConfirmed: true,
+          },
+          props: ctx.props,
+        }),
+        resolvePublicUrl(statusPageId),
+      ]);
+
+      const resourceSummaries: string = resources
+        .map((resource: StatusPageResource) => {
+          return describeResource(resource);
+        })
+        .filter((value: string) => {
+          return value.length > 0;
+        })
+        .join(", ");
+
+      const visibility: string =
+        statusPage.isPublicStatusPage === false ? "Private" : "Public";
+
+      const rows: Array<JSONObject> = [
+        {
+          id: statusPage.id?.toString(),
+          name: statusPage.name,
+          description: statusPage.description,
+          pageTitle: statusPage.pageTitle,
+          pageDescription: statusPage.pageDescription,
+          visibility: visibility,
+          publicUrl: publicUrl,
+          resourcesShown: resourceSummaries || undefined,
+          resourceCount: resources.length,
+          activeSubscriberCount: activeSubscribers.toNumber(),
+        },
+      ];
+
+      const serialized: SerializedResult =
+        ToolResultSerializer.serializeRows(rows);
+
+      const cardFields: Array<{ label: string; value: string }> = [
+        { label: "Visibility", value: visibility },
+      ];
+      if (publicUrl) {
+        cardFields.push({ label: "Public URL", value: publicUrl });
+      }
+      cardFields.push({
+        label: "Resources shown",
+        value: resourceSummaries
+          ? `${resources.length}: ${resourceSummaries}`
+          : "0",
+      });
+      cardFields.push({
+        label: "Active subscribers",
+        value: activeSubscribers.toNumber().toString(),
+      });
+
+      return {
+        dataForLlm: serialized.text,
+        rowCount: serialized.rowCount,
+        citationLabel: `Status page "${statusPage.name || statusPageId.toString()}"`,
+        citationTarget: {
+          type: AIChatCitationTargetType.StatusPageView,
+          params: { statusPageId: statusPageId.toString() },
+        },
+        redactionCount: serialized.redactionCount,
+        isTruncated: serialized.isTruncated,
+        widget: WidgetBuilder.resourceCard({
+          title: `Status page: ${statusPage.name || statusPageId.toString()}`,
+          resourceType: "Status Page",
+          heading: statusPage.name || statusPageId.toString(),
+          subheading: statusPage.description,
+          fields: cardFields,
+          link: {
+            type: AIChatCitationTargetType.StatusPageView,
+            params: { statusPageId: statusPageId.toString() },
+          },
+        }),
+      };
+    }
+
+    const limit: number = ToolArgs.getNumber(args, "limit", {
+      defaultValue: 10,
+      min: 1,
+      max: 25,
+    });
+    const skip: number = ToolArgs.getNumber(args, "skip", {
+      defaultValue: 0,
+      min: 0,
+      max: 500,
+    });
+
+    const [statusPages, totalCount]: [Array<StatusPage>, PositiveNumber] =
+      await Promise.all([
+        StatusPageService.findBy({
+          query: {},
+          select: {
+            _id: true,
+            name: true,
+            description: true,
+            isPublicStatusPage: true,
+          },
+          sort: {
+            name: SortOrder.Ascending,
+          },
+          limit: limit,
+          skip: skip,
+          props: ctx.props,
+        }),
+        StatusPageService.countBy({
+          query: {},
+          props: ctx.props,
+        }),
+      ]);
+
+    const rows: Array<JSONObject> = await Promise.all(
+      statusPages.map(async (statusPage: StatusPage): Promise<JSONObject> => {
+        return {
+          id: statusPage.id?.toString(),
+          name: statusPage.name,
+          description: statusPage.description,
+          visibility:
+            statusPage.isPublicStatusPage === false ? "Private" : "Public",
+          publicUrl: statusPage.id
+            ? await resolvePublicUrl(statusPage.id)
+            : undefined,
+        };
+      }),
+    );
+
+    const serialized: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    const pagingPrefix: string = buildPagingPrefix({
+      skip: skip,
+      returnedRows: rows.length,
+      totalCount: totalCount.toNumber(),
+    });
+
+    return {
+      dataForLlm: `${pagingPrefix}${serialized.text}`,
+      rowCount: serialized.rowCount,
+      citationLabel: `Status pages (${totalCount.toNumber()} total)`,
+      citationTarget: {
+        type: AIChatCitationTargetType.StatusPages,
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `Status pages (${totalCount.toNumber()})`,
+              columns: [
+                { key: "name", title: "Name", type: "text" },
+                { key: "description", title: "Description", type: "text" },
+                { key: "visibility", title: "Visibility", type: "text" },
+                { key: "publicUrl", title: "Public URL", type: "text" },
+              ],
+              rows: rows,
+              link: {
+                type: AIChatCitationTargetType.StatusPages,
+              },
+            })
+          : undefined,
+    };
+  },
+};
+
+export const QueryStatusPageAnnouncementsTool: ObservabilityTool = {
+  name: "query_status_page_announcements",
+  description:
+    "List recent announcements posted to this project's status pages — title, description, when each was shown (showAnnouncementAt) and which status pages it appears on. Use it to check what has already been communicated publicly before posting a new update with post_incident_status_update. Pass statusPageId (an id from query_status_pages) to see only announcements on that page. Defaults to announcements shown in the last 30 days.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      statusPageId: {
+        type: "string",
+        description:
+          "Only announcements shown on this status page (an id from query_status_pages).",
+      },
+      withinDays: {
+        type: "number",
+        description:
+          "Only announcements shown within this many days in the past (default 30, max 365).",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum announcements to return (default 10, max 25).",
+      },
+      skip: {
+        type: "number",
+        description:
+          "Rows to skip for pagination (default 0). Use with limit to page through more announcements.",
+      },
+    },
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveAnnouncementReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const statusPageId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "statusPageId",
+    );
+    const withinDays: number = ToolArgs.getNumber(args, "withinDays", {
+      defaultValue: 30,
+      min: 1,
+      max: 365,
+    });
+    const limit: number = ToolArgs.getNumber(args, "limit", {
+      defaultValue: 10,
+      min: 1,
+      max: 25,
+    });
+    const skip: number = ToolArgs.getNumber(args, "skip", {
+      defaultValue: 0,
+      min: 0,
+      max: 500,
+    });
+
+    const endTime: Date = OneUptimeDate.getCurrentDate();
+    const startTime: Date = OneUptimeDate.addRemoveDays(
+      endTime,
+      -1 * withinDays,
+    );
+
+    const query: Query<StatusPageAnnouncement> = {
+      showAnnouncementAt: QueryHelper.inBetween(startTime, endTime),
+    };
+
+    if (statusPageId) {
+      /*
+       * Many-to-many relation filter: TypeORM matches on the related row's
+       * id, but the Query typing wants the relation type — same cast as
+       * StatusPageAPI's active-announcement lookup. projectId is pinned to
+       * the tenant from ctx because statusPageId is an untrusted model
+       * argument (matching the same API precedent).
+       */
+      query.statusPages = statusPageId as any;
+      query.projectId = ctx.projectId;
+    }
+
+    const [announcements, totalCount]: [
+      Array<StatusPageAnnouncement>,
+      PositiveNumber,
+    ] = await Promise.all([
+      StatusPageAnnouncementService.findBy({
+        query: query,
+        select: {
+          _id: true,
+          title: true,
+          description: true,
+          showAnnouncementAt: true,
+          endAnnouncementAt: true,
+          statusPages: {
+            _id: true,
+            name: true,
+          },
+        },
+        sort: {
+          showAnnouncementAt: SortOrder.Descending,
+        },
+        limit: limit,
+        skip: skip,
+        props: ctx.props,
+      }),
+      StatusPageAnnouncementService.countBy({
+        query: query,
+        props: ctx.props,
+      }),
+    ]);
+
+    const rows: Array<JSONObject> = announcements.map(
+      (announcement: StatusPageAnnouncement) => {
+        return {
+          id: announcement.id?.toString(),
+          title: announcement.title,
+          description: announcement.description,
+          showAnnouncementAt: announcement.showAnnouncementAt,
+          endAnnouncementAt: announcement.endAnnouncementAt,
+          statusPages: joinNames(announcement.statusPages) || undefined,
+        };
+      },
+    );
+
+    const serialized: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    const pagingPrefix: string = buildPagingPrefix({
+      skip: skip,
+      returnedRows: rows.length,
+      totalCount: totalCount.toNumber(),
+    });
+
+    return {
+      dataForLlm: `${pagingPrefix}${serialized.text}`,
+      rowCount: serialized.rowCount,
+      citationLabel: `Status page announcements, last ${withinDays}d (${totalCount.toNumber()} total)`,
+      citationTarget: statusPageId
+        ? {
+            type: AIChatCitationTargetType.StatusPageView,
+            params: { statusPageId: statusPageId.toString() },
+          }
+        : {
+            type: AIChatCitationTargetType.StatusPages,
+          },
+      redactionCount: serialized.redactionCount,
+      isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `Status page announcements (${rows.length})`,
+              description: `Shown in the last ${withinDays}d`,
+              columns: [
+                { key: "title", title: "Title", type: "text" },
+                { key: "showAnnouncementAt", title: "Shown at", type: "date" },
+                { key: "endAnnouncementAt", title: "Ends at", type: "date" },
+                { key: "statusPages", title: "Status pages", type: "text" },
+              ],
+              rows: rows,
+              link: statusPageId
+                ? {
+                    type: AIChatCitationTargetType.StatusPageView,
+                    params: { statusPageId: statusPageId.toString() },
+                  }
+                : {
+                    type: AIChatCitationTargetType.StatusPages,
+                  },
+            })
+          : undefined,
+    };
+  },
+};

--- a/Common/Server/Utils/AI/Toolbox/TeamTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/TeamTools.ts
@@ -1,0 +1,327 @@
+import Team from "../../../../Models/DatabaseModels/Team";
+import TeamMember from "../../../../Models/DatabaseModels/TeamMember";
+import User from "../../../../Models/DatabaseModels/User";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import Permission from "../../../../Types/Permission";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import { LIMIT_PER_PROJECT } from "../../../../Types/Database/LimitMax";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import TeamService from "../../../Services/TeamService";
+import TeamMemberService from "../../../Services/TeamMemberService";
+import QueryHelper from "../../../Types/Database/QueryHelper";
+import ToolResultSerializer, { SerializedResult } from "./Serializer";
+import WidgetBuilder from "./WidgetBuilder";
+import {
+  ObservabilityTool,
+  ToolArgs,
+  ToolContext,
+  ToolExecutionResult,
+} from "./ToolTypes";
+
+/*
+ * Derived from the model ACL so the tool gate can never drift from RBAC.
+ * Resolved lazily rather than at module load: this module is pulled in through
+ * the service import graph before the Team model class is fully wired up, so
+ * calling a model method at import time throws a circular-dependency
+ * TypeError. By the time a tool actually executes, every module is loaded.
+ */
+let cachedReadPermissions: Array<Permission> | null = null;
+const resolveReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedReadPermissions) {
+      cachedReadPermissions = new Team().getReadPermissions();
+    }
+    return cachedReadPermissions;
+  };
+
+/*
+ * Members are surfaced by display name, not email: the serializer redacts
+ * every email before the payload reaches the LLM, so a name is the only
+ * identifier the model can actually read back to the user.
+ */
+function displayNameOf(user: User | undefined | null): string {
+  const displayName: string = user?.name?.toString().trim() || "";
+  if (displayName.length > 0) {
+    return displayName;
+  }
+  return user?.id ? user.id.toString() : "Unknown user";
+}
+
+export const QueryTeamsTool: ObservabilityTool = {
+  name: "query_teams",
+  description:
+    "Query the teams in this project. Without arguments it lists every team with its id, name, description and member count. Pass teamId to see one team's members by display name (and whether an invite is still pending). Use this to answer 'who is on the platform team?' or 'which team should own this?' — team names here match the ownerTeams shown by query_incidents and the escalation teams shown by query_on_call_policies.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      teamId: {
+        type: "string",
+        description:
+          "Get one team by its ID — returns the team plus its members by name. Find the id by calling this tool without arguments first.",
+      },
+      limit: {
+        type: "number",
+        description: "List mode: maximum teams to return (default 10, max 25).",
+      },
+      skip: {
+        type: "number",
+        description:
+          "List mode: how many teams to skip, for paging through a long list (default 0).",
+      },
+    },
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const teamId: ObjectID | undefined = ToolArgs.getObjectID(args, "teamId");
+
+    if (teamId) {
+      const team: Team | null = await TeamService.findOneById({
+        id: teamId,
+        select: {
+          _id: true,
+          name: true,
+          description: true,
+          createdAt: true,
+        },
+        props: ctx.props,
+      });
+
+      if (!team) {
+        const serialized: SerializedResult = ToolResultSerializer.serializeRows(
+          [],
+        );
+
+        return {
+          dataForLlm: serialized.text,
+          rowCount: serialized.rowCount,
+          citationLabel: `Team ${teamId.toString()}`,
+          citationTarget: {
+            type: AIChatCitationTargetType.Teams,
+          },
+          redactionCount: serialized.redactionCount,
+          isTruncated: serialized.isTruncated,
+        };
+      }
+
+      /*
+       * Membership lives in the TeamMember join table, not as a relation on
+       * Team. projectId is pinned to the tenant from ctx because teamId is an
+       * untrusted model argument.
+       */
+      const members: Array<TeamMember> = await TeamMemberService.findBy({
+        query: {
+          teamId: teamId,
+          projectId: ctx.projectId,
+        },
+        select: {
+          _id: true,
+          hasAcceptedInvitation: true,
+          user: {
+            _id: true,
+            name: true,
+            email: true,
+          },
+        },
+        sort: {
+          createdAt: SortOrder.Ascending,
+        },
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        props: ctx.props,
+      });
+
+      const memberRows: Array<JSONObject> = members.map(
+        (member: TeamMember) => {
+          return {
+            section: "member",
+            name: displayNameOf(member.user),
+            email: member.user?.email?.toString(),
+            status:
+              member.hasAcceptedInvitation === false
+                ? "invited (not yet accepted)"
+                : "member",
+          };
+        },
+      );
+
+      const rows: Array<JSONObject> = [
+        {
+          section: "team",
+          id: team.id?.toString(),
+          name: team.name,
+          description: team.description,
+          memberCount: memberRows.length,
+          createdAt: team.createdAt,
+        },
+        ...memberRows,
+      ];
+
+      const serialized: SerializedResult =
+        ToolResultSerializer.serializeRows(rows);
+
+      const memberLabel: string = `${memberRows.length} member${
+        memberRows.length === 1 ? "" : "s"
+      }`;
+
+      return {
+        dataForLlm: serialized.text,
+        rowCount: serialized.rowCount,
+        citationLabel: `Team "${team.name}" (${memberLabel})`,
+        citationTarget: {
+          type: AIChatCitationTargetType.Teams,
+        },
+        redactionCount: serialized.redactionCount,
+        isTruncated: serialized.isTruncated,
+        widget:
+          memberRows.length > 0
+            ? WidgetBuilder.table({
+                title: `Team: ${team.name}`,
+                description: team.description,
+                columns: [
+                  { key: "name", title: "Member", type: "text" },
+                  { key: "email", title: "Email", type: "text" },
+                  { key: "status", title: "Status", type: "text" },
+                ],
+                rows: memberRows,
+                link: { type: AIChatCitationTargetType.Teams },
+              })
+            : WidgetBuilder.resourceCard({
+                title: "Team",
+                resourceType: "Team",
+                heading: team.name || "Team",
+                subheading: "No members",
+                fields: [
+                  { label: "Description", value: team.description || "—" },
+                  { label: "Members", value: "0" },
+                ],
+                link: { type: AIChatCitationTargetType.Teams },
+              }),
+      };
+    }
+
+    const limit: number = ToolArgs.getNumber(args, "limit", {
+      defaultValue: 10,
+      min: 1,
+      max: 25,
+    });
+    const skip: number = ToolArgs.getNumber(args, "skip", {
+      defaultValue: 0,
+      min: 0,
+      max: 500,
+    });
+
+    const teams: Array<Team> = await TeamService.findBy({
+      query: {},
+      select: {
+        _id: true,
+        name: true,
+        description: true,
+      },
+      sort: {
+        name: SortOrder.Ascending,
+      },
+      limit: limit,
+      skip: skip,
+      props: ctx.props,
+    });
+
+    const totalCountPositive: PositiveNumber = await TeamService.countBy({
+      query: {},
+      props: ctx.props,
+    });
+    const totalCount: number = totalCountPositive.toNumber();
+
+    /*
+     * Member counts come from one scoped fetch of the join rows for this page
+     * of teams (counted in memory), not one countBy per team. projectId is
+     * pinned to the tenant so the join fetch can never cross projects.
+     */
+    const teamIds: Array<ObjectID> = teams
+      .map((team: Team) => {
+        return team.id;
+      })
+      .filter((id: ObjectID | null | undefined): id is ObjectID => {
+        return Boolean(id);
+      });
+
+    const memberCountByTeamId: Map<string, number> = new Map<string, number>();
+
+    if (teamIds.length > 0) {
+      const memberLinks: Array<TeamMember> = await TeamMemberService.findBy({
+        query: {
+          teamId: QueryHelper.any(teamIds),
+          projectId: ctx.projectId,
+        },
+        select: {
+          _id: true,
+          teamId: true,
+        },
+        limit: LIMIT_PER_PROJECT,
+        skip: 0,
+        props: ctx.props,
+      });
+
+      for (const link of memberLinks) {
+        const key: string = link.teamId?.toString() || "";
+        if (!key) {
+          continue;
+        }
+        memberCountByTeamId.set(key, (memberCountByTeamId.get(key) || 0) + 1);
+      }
+    }
+
+    const rows: Array<JSONObject> = teams.map((team: Team) => {
+      return {
+        id: team.id?.toString(),
+        name: team.name,
+        description: team.description,
+        memberCount: memberCountByTeamId.get(team.id?.toString() || "") || 0,
+      };
+    });
+
+    const serialized: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    // Tell the model it is looking at one page of a longer list.
+    const isPaged: boolean = rows.length > 0 && totalCount > rows.length;
+    const pagingPrefix: string = isPaged
+      ? `Showing rows ${skip + 1}–${skip + rows.length} of ${totalCount} total. Pass skip to page further.\n`
+      : "";
+
+    return {
+      dataForLlm: `${pagingPrefix}${serialized.text}`,
+      rowCount: serialized.rowCount,
+      citationLabel: isPaged
+        ? `Teams (${rows.length} of ${totalCount})`
+        : `Teams (${serialized.rowCount} found)`,
+      citationTarget: {
+        type: AIChatCitationTargetType.Teams,
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `Teams (${rows.length})`,
+              description: isPaged
+                ? `Showing ${rows.length} of ${totalCount} teams`
+                : undefined,
+              columns: [
+                { key: "name", title: "Name", type: "text" },
+                { key: "memberCount", title: "Members", type: "number" },
+                { key: "description", title: "Description", type: "text" },
+              ],
+              rows: rows,
+              link: { type: AIChatCitationTargetType.Teams },
+            })
+          : undefined,
+    };
+  },
+};

--- a/Common/Server/Utils/AI/Toolbox/TimelineTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/TimelineTools.ts
@@ -1,0 +1,613 @@
+import Alert from "../../../../Models/DatabaseModels/Alert";
+import AlertFeed, {
+  AlertFeedEventType,
+} from "../../../../Models/DatabaseModels/AlertFeed";
+import AlertInternalNote from "../../../../Models/DatabaseModels/AlertInternalNote";
+import AlertStateTimeline from "../../../../Models/DatabaseModels/AlertStateTimeline";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import IncidentFeed, {
+  IncidentFeedEventType,
+} from "../../../../Models/DatabaseModels/IncidentFeed";
+import IncidentInternalNote from "../../../../Models/DatabaseModels/IncidentInternalNote";
+import IncidentPublicNote from "../../../../Models/DatabaseModels/IncidentPublicNote";
+import IncidentStateTimeline from "../../../../Models/DatabaseModels/IncidentStateTimeline";
+import User from "../../../../Models/DatabaseModels/User";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import Permission from "../../../../Types/Permission";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import {
+  AIChatCitationTargetType,
+  AIChatWidgetColumn,
+} from "../../../../Types/AI/AIChatTypes";
+import AlertFeedService from "../../../Services/AlertFeedService";
+import AlertInternalNoteService from "../../../Services/AlertInternalNoteService";
+import AlertService from "../../../Services/AlertService";
+import AlertStateTimelineService from "../../../Services/AlertStateTimelineService";
+import IncidentFeedService from "../../../Services/IncidentFeedService";
+import IncidentInternalNoteService from "../../../Services/IncidentInternalNoteService";
+import IncidentPublicNoteService from "../../../Services/IncidentPublicNoteService";
+import IncidentService from "../../../Services/IncidentService";
+import IncidentStateTimelineService from "../../../Services/IncidentStateTimelineService";
+import QueryHelper from "../../../Types/Database/QueryHelper";
+import ToolResultSerializer, { SerializedResult } from "./Serializer";
+import WidgetBuilder from "./WidgetBuilder";
+import {
+  ObservabilityTool,
+  ToolArgs,
+  ToolContext,
+  ToolExecutionResult,
+} from "./ToolTypes";
+
+/*
+ * Merged activity timelines for incidents and alerts. Each tool stitches the
+ * entity's state changes, notes and feed events into one chronological view so
+ * the model can answer "what's the latest on this incident?" from the actual
+ * response thread instead of only the incident's static fields.
+ */
+
+// Hard cap on merged timeline entries (also the per-source fetch limit).
+const MAX_TIMELINE_ENTRIES: number = 50;
+
+/*
+ * Derived from the model ACL so the tool gate can never drift from RBAC.
+ * Resolved lazily rather than at module load: this module is pulled in through
+ * the service import graph before the model classes are fully wired up, so
+ * calling a model method at import time throws a circular-dependency
+ * TypeError. By the time a tool actually executes, every module is loaded.
+ *
+ * The gate uses the parent entity's (Incident/Alert) read ACL: the timeline is
+ * incident/alert data, and each per-source query below still enforces its own
+ * model ACL through ctx.props.
+ */
+let cachedIncidentReadPermissions: Array<Permission> | null = null;
+const resolveIncidentReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedIncidentReadPermissions) {
+      cachedIncidentReadPermissions = new Incident().getReadPermissions();
+    }
+    return cachedIncidentReadPermissions;
+  };
+
+let cachedAlertReadPermissions: Array<Permission> | null = null;
+const resolveAlertReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedAlertReadPermissions) {
+      cachedAlertReadPermissions = new Alert().getReadPermissions();
+    }
+    return cachedAlertReadPermissions;
+  };
+
+// Display name for a timeline author; email is a fallback (redacted for the LLM).
+const formatAuthor: (user: User | undefined) => string | undefined = (
+  user: User | undefined,
+): string | undefined => {
+  if (!user) {
+    return undefined;
+  }
+  return user.name?.toString() || user.email?.toString() || undefined;
+};
+
+const entryTime: (row: JSONObject) => number = (row: JSONObject): number => {
+  const at: unknown = row["at"];
+  if (at instanceof Date) {
+    return at.getTime();
+  }
+  return 0;
+};
+
+/*
+ * Sort newest-first, keep the newest `limit`, then flip to chronological
+ * order. Because every source is fetched newest-first with the same limit,
+ * any row a source dropped is older than all rows it returned — so the merged
+ * newest-`limit` slice is exact.
+ */
+const keepNewestChronological: (
+  rows: Array<JSONObject>,
+  limit: number,
+) => Array<JSONObject> = (
+  rows: Array<JSONObject>,
+  limit: number,
+): Array<JSONObject> => {
+  const newestFirst: Array<JSONObject> = [...rows].sort(
+    (a: JSONObject, b: JSONObject) => {
+      return entryTime(b) - entryTime(a);
+    },
+  );
+  return newestFirst.slice(0, limit).reverse();
+};
+
+const timelineWidgetColumns: Array<AIChatWidgetColumn> = [
+  { key: "at", title: "When", type: "date" },
+  { key: "type", title: "Type" },
+  { key: "author", title: "By" },
+  { key: "entry", title: "Entry" },
+];
+
+export const GetIncidentTimelineTool: ObservabilityTool = {
+  name: "get_incident_timeline",
+  description:
+    "Get one merged, chronological activity timeline for an incident: state changes, internal (private) notes, public status-page notes, and feed events — each entry tagged with its type, timestamp and author where available. Use this for 'what's the latest on this incident?', 'who did what and when?', or to reconstruct the response thread. Pass incidentId from query_incidents or search_incidents. Returns at most the 50 newest entries, oldest first.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      incidentId: {
+        type: "string",
+        description:
+          "The incident's ID (from query_incidents or search_incidents).",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum timeline entries to return (default 50, max 50).",
+      },
+    },
+    required: ["incidentId"],
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveIncidentReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const incidentId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "incidentId",
+    );
+
+    if (!incidentId) {
+      return {
+        dataForLlm:
+          "Error: incidentId is required. Pass the incident's ID (from query_incidents or search_incidents).",
+        rowCount: 0,
+        citationLabel: "Incident timeline (no incident id)",
+        redactionCount: 0,
+        isTruncated: false,
+      };
+    }
+
+    const limit: number = ToolArgs.getNumber(args, "limit", {
+      defaultValue: MAX_TIMELINE_ENTRIES,
+      min: 1,
+      max: MAX_TIMELINE_ENTRIES,
+    });
+
+    /*
+     * Resolve the incident under the requesting user's props first: a
+     * missing or foreign-tenant incident yields an honest empty result
+     * instead of four pointless timeline queries.
+     */
+    const incident: Incident | null = await IncidentService.findOneById({
+      id: incidentId,
+      select: {
+        _id: true,
+        incidentNumber: true,
+        title: true,
+      },
+      props: ctx.props,
+    });
+
+    if (!incident) {
+      return {
+        dataForLlm: `Incident ${incidentId.toString()} was not found in this project.`,
+        rowCount: 0,
+        citationLabel: "Incident timeline (not found)",
+        redactionCount: 0,
+        isTruncated: false,
+      };
+    }
+
+    /*
+     * projectId is pinned to the tenant from ctx on every source query
+     * because incidentId is an untrusted model argument.
+     */
+    const [stateTimeline, internalNotes, publicNotes, feedItems]: [
+      Array<IncidentStateTimeline>,
+      Array<IncidentInternalNote>,
+      Array<IncidentPublicNote>,
+      Array<IncidentFeed>,
+    ] = await Promise.all([
+      IncidentStateTimelineService.findBy({
+        query: {
+          incidentId: incidentId,
+          projectId: ctx.projectId,
+        },
+        select: {
+          _id: true,
+          createdAt: true,
+          startsAt: true,
+          rootCause: true,
+          incidentState: {
+            name: true,
+          },
+          createdByUser: {
+            name: true,
+            email: true,
+          },
+        },
+        sort: {
+          createdAt: SortOrder.Descending,
+        },
+        limit: limit,
+        skip: 0,
+        props: ctx.props,
+      }),
+      IncidentInternalNoteService.findBy({
+        query: {
+          incidentId: incidentId,
+          projectId: ctx.projectId,
+        },
+        select: {
+          _id: true,
+          note: true,
+          createdAt: true,
+          createdByUser: {
+            name: true,
+            email: true,
+          },
+        },
+        sort: {
+          createdAt: SortOrder.Descending,
+        },
+        limit: limit,
+        skip: 0,
+        props: ctx.props,
+      }),
+      IncidentPublicNoteService.findBy({
+        query: {
+          incidentId: incidentId,
+          projectId: ctx.projectId,
+        },
+        select: {
+          _id: true,
+          note: true,
+          createdAt: true,
+          postedAt: true,
+          createdByUser: {
+            name: true,
+            email: true,
+          },
+        },
+        sort: {
+          createdAt: SortOrder.Descending,
+        },
+        limit: limit,
+        skip: 0,
+        props: ctx.props,
+      }),
+      IncidentFeedService.findBy({
+        query: {
+          incidentId: incidentId,
+          projectId: ctx.projectId,
+          /*
+           * The feed mirrors state changes and notes (the services write a
+           * feed item alongside each) — exclude those event types here so the
+           * merged timeline doesn't list every state change and note twice,
+           * halving the real coverage of the newest-N cap.
+           */
+          incidentFeedEventType: QueryHelper.notIn([
+            IncidentFeedEventType.IncidentStateChanged,
+            IncidentFeedEventType.PublicNote,
+            IncidentFeedEventType.PrivateNote,
+          ]),
+        },
+        select: {
+          _id: true,
+          feedInfoInMarkdown: true,
+          incidentFeedEventType: true,
+          createdAt: true,
+          postedAt: true,
+          user: {
+            name: true,
+            email: true,
+          },
+        },
+        sort: {
+          createdAt: SortOrder.Descending,
+        },
+        limit: limit,
+        skip: 0,
+        props: ctx.props,
+      }),
+    ]);
+
+    const merged: Array<JSONObject> = [
+      ...stateTimeline.map((item: IncidentStateTimeline): JSONObject => {
+        let entry: string = `State changed to ${item.incidentState?.name || "(unknown)"}`;
+        if (item.rootCause) {
+          entry = `${entry}. Root cause: ${item.rootCause}`;
+        }
+        return {
+          at: item.startsAt || item.createdAt,
+          type: "state-change",
+          author: formatAuthor(item.createdByUser),
+          entry: entry,
+        };
+      }),
+      ...internalNotes.map((item: IncidentInternalNote): JSONObject => {
+        return {
+          at: item.createdAt,
+          type: "internal-note",
+          author: formatAuthor(item.createdByUser),
+          entry: item.note,
+        };
+      }),
+      ...publicNotes.map((item: IncidentPublicNote): JSONObject => {
+        return {
+          at: item.postedAt || item.createdAt,
+          type: "public-note",
+          author: formatAuthor(item.createdByUser),
+          entry: item.note,
+        };
+      }),
+      ...feedItems.map((item: IncidentFeed): JSONObject => {
+        return {
+          at: item.postedAt || item.createdAt,
+          type: "feed",
+          author: formatAuthor(item.user),
+          entry: item.feedInfoInMarkdown,
+          eventType: item.incidentFeedEventType,
+        };
+      }),
+    ];
+
+    const rows: Array<JSONObject> = keepNewestChronological(merged, limit);
+
+    const serialized: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    let dataForLlm: string = serialized.text;
+    if (merged.length > rows.length) {
+      dataForLlm = `Showing the newest ${rows.length} of ${merged.length} fetched timeline entries (each source capped at ${limit}), oldest first.\n${dataForLlm}`;
+    }
+
+    const incidentLabel: string = incident.incidentNumber
+      ? `#${incident.incidentNumber}`
+      : incidentId.toString();
+
+    return {
+      dataForLlm: dataForLlm,
+      rowCount: serialized.rowCount,
+      citationLabel: `Incident ${incidentLabel} timeline (${serialized.rowCount} entries)`,
+      citationTarget: {
+        type: AIChatCitationTargetType.IncidentView,
+        params: { incidentId: incidentId.toString() },
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `Incident ${incidentLabel} timeline`,
+              description: incident.title,
+              columns: timelineWidgetColumns,
+              rows: rows,
+              link: {
+                type: AIChatCitationTargetType.IncidentView,
+                params: { incidentId: incidentId.toString() },
+              },
+            })
+          : undefined,
+    };
+  },
+};
+
+export const GetAlertTimelineTool: ObservabilityTool = {
+  name: "get_alert_timeline",
+  description:
+    "Get one merged, chronological activity timeline for an alert: state changes, internal notes, and feed events — each entry tagged with its type, timestamp and author where available. Use this for 'what's the latest on this alert?' or to see who acknowledged/resolved it and when. Pass alertId from query_alerts. Returns at most the 50 newest entries, oldest first.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      alertId: {
+        type: "string",
+        description: "The alert's ID (from query_alerts).",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum timeline entries to return (default 50, max 50).",
+      },
+    },
+    required: ["alertId"],
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveAlertReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const alertId: ObjectID | undefined = ToolArgs.getObjectID(args, "alertId");
+
+    if (!alertId) {
+      return {
+        dataForLlm:
+          "Error: alertId is required. Pass the alert's ID (from query_alerts).",
+        rowCount: 0,
+        citationLabel: "Alert timeline (no alert id)",
+        redactionCount: 0,
+        isTruncated: false,
+      };
+    }
+
+    const limit: number = ToolArgs.getNumber(args, "limit", {
+      defaultValue: MAX_TIMELINE_ENTRIES,
+      min: 1,
+      max: MAX_TIMELINE_ENTRIES,
+    });
+
+    const alert: Alert | null = await AlertService.findOneById({
+      id: alertId,
+      select: {
+        _id: true,
+        alertNumber: true,
+        title: true,
+      },
+      props: ctx.props,
+    });
+
+    if (!alert) {
+      return {
+        dataForLlm: `Alert ${alertId.toString()} was not found in this project.`,
+        rowCount: 0,
+        citationLabel: "Alert timeline (not found)",
+        redactionCount: 0,
+        isTruncated: false,
+      };
+    }
+
+    // projectId pinned to the tenant from ctx; alertId is untrusted.
+    const [stateTimeline, internalNotes, feedItems]: [
+      Array<AlertStateTimeline>,
+      Array<AlertInternalNote>,
+      Array<AlertFeed>,
+    ] = await Promise.all([
+      AlertStateTimelineService.findBy({
+        query: {
+          alertId: alertId,
+          projectId: ctx.projectId,
+        },
+        select: {
+          _id: true,
+          createdAt: true,
+          startsAt: true,
+          rootCause: true,
+          alertState: {
+            name: true,
+          },
+          createdByUser: {
+            name: true,
+            email: true,
+          },
+        },
+        sort: {
+          createdAt: SortOrder.Descending,
+        },
+        limit: limit,
+        skip: 0,
+        props: ctx.props,
+      }),
+      AlertInternalNoteService.findBy({
+        query: {
+          alertId: alertId,
+          projectId: ctx.projectId,
+        },
+        select: {
+          _id: true,
+          note: true,
+          createdAt: true,
+          createdByUser: {
+            name: true,
+            email: true,
+          },
+        },
+        sort: {
+          createdAt: SortOrder.Descending,
+        },
+        limit: limit,
+        skip: 0,
+        props: ctx.props,
+      }),
+      AlertFeedService.findBy({
+        query: {
+          alertId: alertId,
+          projectId: ctx.projectId,
+          // Same dedup as the incident feed: these are mirrored by the
+          // dedicated state-timeline and note sources fetched above.
+          alertFeedEventType: QueryHelper.notIn([
+            AlertFeedEventType.AlertStateChanged,
+            AlertFeedEventType.PrivateNote,
+          ]),
+        },
+        select: {
+          _id: true,
+          feedInfoInMarkdown: true,
+          alertFeedEventType: true,
+          createdAt: true,
+          postedAt: true,
+          user: {
+            name: true,
+            email: true,
+          },
+        },
+        sort: {
+          createdAt: SortOrder.Descending,
+        },
+        limit: limit,
+        skip: 0,
+        props: ctx.props,
+      }),
+    ]);
+
+    const merged: Array<JSONObject> = [
+      ...stateTimeline.map((item: AlertStateTimeline): JSONObject => {
+        let entry: string = `State changed to ${item.alertState?.name || "(unknown)"}`;
+        if (item.rootCause) {
+          entry = `${entry}. Root cause: ${item.rootCause}`;
+        }
+        return {
+          at: item.startsAt || item.createdAt,
+          type: "state-change",
+          author: formatAuthor(item.createdByUser),
+          entry: entry,
+        };
+      }),
+      ...internalNotes.map((item: AlertInternalNote): JSONObject => {
+        return {
+          at: item.createdAt,
+          type: "internal-note",
+          author: formatAuthor(item.createdByUser),
+          entry: item.note,
+        };
+      }),
+      ...feedItems.map((item: AlertFeed): JSONObject => {
+        return {
+          at: item.postedAt || item.createdAt,
+          type: "feed",
+          author: formatAuthor(item.user),
+          entry: item.feedInfoInMarkdown,
+          eventType: item.alertFeedEventType,
+        };
+      }),
+    ];
+
+    const rows: Array<JSONObject> = keepNewestChronological(merged, limit);
+
+    const serialized: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    let dataForLlm: string = serialized.text;
+    if (merged.length > rows.length) {
+      dataForLlm = `Showing the newest ${rows.length} of ${merged.length} fetched timeline entries (each source capped at ${limit}), oldest first.\n${dataForLlm}`;
+    }
+
+    const alertLabel: string = alert.alertNumber
+      ? `#${alert.alertNumber}`
+      : alertId.toString();
+
+    return {
+      dataForLlm: dataForLlm,
+      rowCount: serialized.rowCount,
+      citationLabel: `Alert ${alertLabel} timeline (${serialized.rowCount} entries)`,
+      citationTarget: {
+        type: AIChatCitationTargetType.AlertView,
+        params: { alertId: alertId.toString() },
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `Alert ${alertLabel} timeline`,
+              description: alert.title,
+              columns: timelineWidgetColumns,
+              rows: rows,
+              link: {
+                type: AIChatCitationTargetType.AlertView,
+                params: { alertId: alertId.toString() },
+              },
+            })
+          : undefined,
+    };
+  },
+};

--- a/Common/Server/Utils/AI/Toolbox/WorkflowProbeTools.ts
+++ b/Common/Server/Utils/AI/Toolbox/WorkflowProbeTools.ts
@@ -1,0 +1,664 @@
+import Probe, {
+  ProbeConnectionStatus,
+} from "../../../../Models/DatabaseModels/Probe";
+import Workflow from "../../../../Models/DatabaseModels/Workflow";
+import WorkflowLog from "../../../../Models/DatabaseModels/WorkflowLog";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import Permission from "../../../../Types/Permission";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import SortOrder from "../../../../Types/BaseDatabase/SortOrder";
+import WorkflowStatus from "../../../../Types/Workflow/WorkflowStatus";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import MonitorProbeService from "../../../Services/MonitorProbeService";
+import ProbeService from "../../../Services/ProbeService";
+import WorkflowLogService from "../../../Services/WorkflowLogService";
+import WorkflowService from "../../../Services/WorkflowService";
+import QueryHelper from "../../../Types/Database/QueryHelper";
+import OneUptimeDate from "../../../../Types/Date";
+import ToolResultSerializer, { SerializedResult } from "./Serializer";
+import WidgetBuilder from "./WidgetBuilder";
+import {
+  ObservabilityTool,
+  ToolArgs,
+  ToolContext,
+  ToolExecutionResult,
+} from "./ToolTypes";
+
+/*
+ * Derived from the model ACLs so the tool gates can never drift from RBAC.
+ * Resolved lazily rather than at module load: this module is pulled in through
+ * the service import graph before the model classes are fully wired up, so
+ * calling a model method at import time throws a circular-dependency
+ * TypeError. By the time a tool actually executes, every module is loaded.
+ */
+let cachedWorkflowReadPermissions: Array<Permission> | null = null;
+const resolveWorkflowReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedWorkflowReadPermissions) {
+      cachedWorkflowReadPermissions = new Workflow().getReadPermissions();
+    }
+    return cachedWorkflowReadPermissions;
+  };
+
+let cachedProbeReadPermissions: Array<Permission> | null = null;
+const resolveProbeReadPermissions: () => Array<Permission> =
+  (): Array<Permission> => {
+    if (!cachedProbeReadPermissions) {
+      cachedProbeReadPermissions = new Probe().getReadPermissions();
+    }
+    return cachedProbeReadPermissions;
+  };
+
+// Run outcomes that count as a failure when summarizing recent workflow runs.
+const RUN_FAILURE_STATUSES: Set<WorkflowStatus> = new Set<WorkflowStatus>([
+  WorkflowStatus.Error,
+  WorkflowStatus.Timeout,
+  WorkflowStatus.WorkflowCountExceeded,
+]);
+
+/*
+ * How many recent WorkflowLog rows to scan (one query, project-wide across the
+ * listed workflows) when computing per-workflow run outcomes in list mode.
+ */
+const RECENT_RUNS_LOOKBACK: number = 50;
+
+/*
+ * The serializer caps every field at 500 chars but keeps the HEAD of an
+ * over-long value — while a workflow run's failure prints at the END of its
+ * log. Slice the tail ourselves, under the serializer's cap, so the error
+ * line survives serialization.
+ */
+const LOG_TAIL_CHARS: number = 450;
+
+function tailOfLog(logs: string | undefined): string | undefined {
+  if (!logs) {
+    return undefined;
+  }
+  if (logs.length <= LOG_TAIL_CHARS) {
+    return logs;
+  }
+  return `… ${logs.slice(-1 * LOG_TAIL_CHARS)}`;
+}
+
+/*
+ * Probe staleness threshold, in exact parity with the platform's own status
+ * judgment: the Probe:UpdateConnectionStatus worker
+ * (App/FeatureSet/Workers/Jobs/Probe/UpdateConnectionStatus.ts) marks a probe
+ * Disconnected once lastAlive <= now - 3 minutes (or lastAlive was never set),
+ * and the dashboard renders that stored status. Computing the same rule live
+ * from lastAlive gives the identical verdict without the worker's up-to-a-
+ * minute lag.
+ */
+const PROBE_STALE_CUTOFF_IN_MINUTES: number = 3;
+
+interface WorkflowRunOutcome {
+  lastRunStatus: string | undefined;
+  lastRunAt: Date | undefined;
+  recentRuns: number;
+  recentFailures: number;
+}
+
+export const QueryWorkflowsTool: ObservabilityTool = {
+  name: "query_workflows",
+  description:
+    "Query automation workflows in this project. List mode returns each workflow (name, description, enabled) with its recent run outcomes — last run status/time and how many of the recent runs failed. Pass workflowId (from the list mode `id` field) to get detail mode: the workflow plus its most recent runs (status, startedAt, completedAt, duration) including the tail of the run log for failed runs — use that to answer 'why did this workflow fail?'.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      workflowId: {
+        type: "string",
+        description:
+          "Get one workflow by its ID, with its recent runs and failure logs.",
+      },
+      runsLimit: {
+        type: "number",
+        description:
+          "Detail mode only: maximum recent runs to return (default 10, max 20).",
+      },
+      limit: {
+        type: "number",
+        description: "Maximum workflows to return (default 10, max 25).",
+      },
+      skip: {
+        type: "number",
+        description:
+          "List mode pagination: how many workflows to skip (default 0, max 500).",
+      },
+    },
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveWorkflowReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const workflowId: ObjectID | undefined = ToolArgs.getObjectID(
+      args,
+      "workflowId",
+    );
+
+    if (workflowId) {
+      const workflow: Workflow | null = await WorkflowService.findOneById({
+        id: workflowId,
+        select: {
+          _id: true,
+          name: true,
+          description: true,
+          isEnabled: true,
+          createdAt: true,
+        },
+        props: ctx.props,
+      });
+
+      if (!workflow) {
+        const serializedEmpty: SerializedResult =
+          ToolResultSerializer.serializeRows([]);
+
+        return {
+          dataForLlm: serializedEmpty.text,
+          rowCount: serializedEmpty.rowCount,
+          citationLabel: `Workflow ${workflowId.toString()}`,
+          citationTarget: {
+            type: AIChatCitationTargetType.WorkflowView,
+            params: { workflowId: workflowId.toString() },
+          },
+          redactionCount: serializedEmpty.redactionCount,
+          isTruncated: serializedEmpty.isTruncated,
+        };
+      }
+
+      const runsLimit: number = ToolArgs.getNumber(args, "runsLimit", {
+        defaultValue: 10,
+        min: 1,
+        max: 20,
+      });
+
+      /*
+       * projectId is pinned to the tenant from ctx because workflowId is an
+       * untrusted model argument — same defense-in-depth as the sibling tools.
+       */
+      const runs: Array<WorkflowLog> = await WorkflowLogService.findBy({
+        query: {
+          workflowId: workflowId,
+          projectId: ctx.projectId,
+        },
+        select: {
+          _id: true,
+          workflowStatus: true,
+          startedAt: true,
+          completedAt: true,
+          resumeAt: true,
+          createdAt: true,
+          logs: true,
+        },
+        sort: {
+          createdAt: SortOrder.Descending,
+        },
+        limit: runsLimit,
+        skip: 0,
+        props: ctx.props,
+      });
+
+      const workflowRow: JSONObject = {
+        record: "workflow",
+        id: workflow.id?.toString(),
+        name: workflow.name,
+        description: workflow.description,
+        enabled: Boolean(workflow.isEnabled),
+        createdAt: workflow.createdAt,
+      };
+
+      const runRows: Array<JSONObject> = runs.map((run: WorkflowLog) => {
+        const isFailedRun: boolean = run.workflowStatus
+          ? RUN_FAILURE_STATUSES.has(run.workflowStatus)
+          : false;
+
+        return {
+          record: "run",
+          runId: run.id?.toString(),
+          status: run.workflowStatus,
+          startedAt: run.startedAt,
+          completedAt: run.completedAt,
+          durationSeconds:
+            run.startedAt && run.completedAt
+              ? OneUptimeDate.getDifferenceInSeconds(
+                  run.completedAt,
+                  run.startedAt,
+                )
+              : undefined,
+          resumeAt: run.resumeAt,
+          // Only failed runs carry log text: that is where the answer lives.
+          logTail: isFailedRun ? tailOfLog(run.logs) : undefined,
+        };
+      });
+
+      const rows: Array<JSONObject> = [workflowRow, ...runRows];
+
+      const serialized: SerializedResult =
+        ToolResultSerializer.serializeRows(rows);
+
+      return {
+        dataForLlm: serialized.text,
+        rowCount: serialized.rowCount,
+        citationLabel: `Workflow "${workflow.name}" (${runs.length} recent runs)`,
+        citationTarget: {
+          type: AIChatCitationTargetType.WorkflowView,
+          params: { workflowId: workflowId.toString() },
+        },
+        redactionCount: serialized.redactionCount,
+        isTruncated: serialized.isTruncated,
+        widget:
+          runRows.length > 0
+            ? WidgetBuilder.table({
+                title: `Workflow "${workflow.name}" — recent runs`,
+                description: workflow.isEnabled
+                  ? undefined
+                  : "This workflow is disabled.",
+                columns: [
+                  { key: "status", title: "Status", type: "text" },
+                  { key: "startedAt", title: "Started", type: "date" },
+                  { key: "completedAt", title: "Completed", type: "date" },
+                  {
+                    key: "durationSeconds",
+                    title: "Duration (s)",
+                    type: "number",
+                  },
+                ],
+                rows: runRows,
+                link: {
+                  type: AIChatCitationTargetType.WorkflowView,
+                  params: { workflowId: workflowId.toString() },
+                },
+              })
+            : WidgetBuilder.resourceCard({
+                title: `Workflow "${workflow.name}"`,
+                resourceType: "Workflow",
+                heading: workflow.name || "Workflow",
+                subheading: workflow.description,
+                fields: [
+                  {
+                    label: "Enabled",
+                    value: workflow.isEnabled ? "Yes" : "No",
+                  },
+                  { label: "Recent runs", value: "0" },
+                ],
+                link: {
+                  type: AIChatCitationTargetType.WorkflowView,
+                  params: { workflowId: workflowId.toString() },
+                },
+              }),
+      };
+    }
+
+    const limit: number = ToolArgs.getNumber(args, "limit", {
+      defaultValue: 10,
+      min: 1,
+      max: 25,
+    });
+    const skip: number = ToolArgs.getNumber(args, "skip", {
+      defaultValue: 0,
+      min: 0,
+      max: 500,
+    });
+
+    const workflows: Array<Workflow> = await WorkflowService.findBy({
+      query: {},
+      select: {
+        _id: true,
+        name: true,
+        description: true,
+        isEnabled: true,
+        createdAt: true,
+      },
+      sort: {
+        createdAt: SortOrder.Descending,
+      },
+      limit: limit,
+      skip: skip,
+      props: ctx.props,
+    });
+
+    const totalCount: number = (
+      await WorkflowService.countBy({
+        query: {},
+        props: ctx.props,
+      })
+    ).toNumber();
+
+    /*
+     * One project-wide query over the listed workflows' recent runs, grouped
+     * in memory, instead of one WorkflowLog query per workflow.
+     */
+    const outcomes: Map<string, WorkflowRunOutcome> = new Map<
+      string,
+      WorkflowRunOutcome
+    >();
+
+    if (workflows.length > 0) {
+      const workflowIds: Array<ObjectID> = workflows
+        .map((workflow: Workflow) => {
+          return workflow.id;
+        })
+        .filter((id: ObjectID | null | undefined): id is ObjectID => {
+          return Boolean(id);
+        });
+
+      const recentLogs: Array<WorkflowLog> = await WorkflowLogService.findBy({
+        query: {
+          workflowId: QueryHelper.any(workflowIds),
+          projectId: ctx.projectId,
+        },
+        select: {
+          workflowId: true,
+          workflowStatus: true,
+          createdAt: true,
+        },
+        sort: {
+          createdAt: SortOrder.Descending,
+        },
+        limit: RECENT_RUNS_LOOKBACK,
+        skip: 0,
+        props: ctx.props,
+      });
+
+      for (const log of recentLogs) {
+        const key: string = log.workflowId?.toString() || "";
+        if (!key) {
+          continue;
+        }
+
+        let outcome: WorkflowRunOutcome | undefined = outcomes.get(key);
+        if (!outcome) {
+          outcome = {
+            lastRunStatus: undefined,
+            lastRunAt: undefined,
+            recentRuns: 0,
+            recentFailures: 0,
+          };
+          outcomes.set(key, outcome);
+        }
+
+        outcome.recentRuns += 1;
+        if (
+          log.workflowStatus &&
+          RUN_FAILURE_STATUSES.has(log.workflowStatus)
+        ) {
+          outcome.recentFailures += 1;
+        }
+        // Logs are sorted most-recent-first: the first row seen is the last run.
+        if (!outcome.lastRunStatus) {
+          outcome.lastRunStatus = log.workflowStatus;
+          outcome.lastRunAt = log.createdAt;
+        }
+      }
+    }
+
+    const rows: Array<JSONObject> = workflows.map((workflow: Workflow) => {
+      const outcome: WorkflowRunOutcome | undefined = outcomes.get(
+        workflow.id?.toString() || "",
+      );
+
+      return {
+        id: workflow.id?.toString(),
+        name: workflow.name,
+        description: workflow.description,
+        enabled: Boolean(workflow.isEnabled),
+        lastRunStatus: outcome?.lastRunStatus,
+        lastRunAt: outcome?.lastRunAt,
+        recentRuns: outcome ? outcome.recentRuns : 0,
+        recentFailures: outcome ? outcome.recentFailures : 0,
+      };
+    });
+
+    const serialized: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    let dataForLlm: string = serialized.text;
+    if (totalCount > rows.length) {
+      dataForLlm = `Showing rows ${skip + 1}–${skip + rows.length} of ${totalCount} total. Pass skip to page further.\n${dataForLlm}`;
+    }
+
+    return {
+      dataForLlm: dataForLlm,
+      rowCount: serialized.rowCount,
+      citationLabel:
+        totalCount > rows.length
+          ? `Workflows (showing ${rows.length} of ${totalCount})`
+          : `Workflows (${serialized.rowCount} found)`,
+      citationTarget: {
+        type: AIChatCitationTargetType.Workflows,
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `Workflows (${rows.length})`,
+              description: `Run outcomes from the last ${RECENT_RUNS_LOOKBACK} runs across these workflows`,
+              columns: [
+                { key: "name", title: "Name", type: "text" },
+                { key: "enabled", title: "Enabled", type: "text" },
+                { key: "lastRunStatus", title: "Last run", type: "text" },
+                { key: "lastRunAt", title: "Last run at", type: "date" },
+                {
+                  key: "recentFailures",
+                  title: "Recent failures",
+                  type: "number",
+                },
+              ],
+              rows: rows,
+              link: { type: AIChatCitationTargetType.Workflows },
+            })
+          : undefined,
+    };
+  },
+};
+
+export const QueryProbesTool: ObservabilityTool = {
+  name: "query_probes",
+  description:
+    "Query monitoring probes and their health: name, description, probe version, lastAlive heartbeat, a connected/disconnected judgment (same 3-minute staleness rule the dashboard status uses) and how many of this project's monitors each probe serves. Use this when a monitor is not being checked or checks look stale — a disconnected probe that serves the monitor is the usual cause; then use query_monitors to inspect the monitor itself. Includes the platform's global probes as well as this project's custom probes.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      limit: {
+        type: "number",
+        description:
+          "Maximum probes to return per kind — custom and global (default 10, max 25).",
+      },
+      includeGlobalProbes: {
+        type: "boolean",
+        description:
+          "Include the platform's global probes (default true). Set false to see only this project's custom probes.",
+      },
+    },
+  },
+  get requiredPermissions(): Array<Permission> {
+    return resolveProbeReadPermissions();
+  },
+  execute: async (
+    args: JSONObject,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    const limit: number = ToolArgs.getNumber(args, "limit", {
+      defaultValue: 10,
+      min: 1,
+      max: 25,
+    });
+    const includeGlobalProbes: boolean =
+      ToolArgs.getBoolean(args, "includeGlobalProbes") ?? true;
+
+    /*
+     * Never select `key` here: it is the probe's auth secret (read-restricted
+     * to project owners/admins), and the global fetch below runs as root.
+     */
+    const probeSelect: {
+      _id: boolean;
+      name: boolean;
+      description: boolean;
+      probeVersion: boolean;
+      lastAlive: boolean;
+      connectionStatus: boolean;
+    } = {
+      _id: true,
+      name: true,
+      description: true,
+      probeVersion: true,
+      lastAlive: true,
+      connectionStatus: true,
+    };
+
+    // This project's custom probes — tenant-scoped through ctx.props.
+    const projectProbes: Array<Probe> = await ProbeService.findBy({
+      query: {},
+      select: probeSelect,
+      sort: {
+        name: SortOrder.Ascending,
+      },
+      limit: limit,
+      skip: 0,
+      props: ctx.props,
+    });
+
+    /*
+     * Global probes have projectId = null, so the tenant-scoped query above
+     * can never return them — yet they run most monitors on OneUptime Cloud.
+     * Mirror the platform's own user-facing /probe/global-probes endpoint
+     * (Common/Server/API/ProbeAPI.ts): root props with the query pinned to
+     * isGlobalProbe: true, and a fixed select of the same non-secret columns
+     * that endpoint serves to every authenticated user.
+     */
+    let globalProbes: Array<Probe> = [];
+    if (includeGlobalProbes) {
+      globalProbes = await ProbeService.findBy({
+        query: {
+          isGlobalProbe: true,
+        },
+        select: probeSelect,
+        sort: {
+          name: SortOrder.Ascending,
+        },
+        limit: limit,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      });
+    }
+
+    const seenProbeIds: Set<string> = new Set<string>();
+    const probesWithScope: Array<{ probe: Probe; isGlobal: boolean }> = [];
+
+    for (const probe of projectProbes) {
+      const id: string = probe.id?.toString() || "";
+      if (!id || seenProbeIds.has(id)) {
+        continue;
+      }
+      seenProbeIds.add(id);
+      probesWithScope.push({ probe: probe, isGlobal: false });
+    }
+
+    for (const probe of globalProbes) {
+      const id: string = probe.id?.toString() || "";
+      if (!id || seenProbeIds.has(id)) {
+        continue;
+      }
+      seenProbeIds.add(id);
+      probesWithScope.push({ probe: probe, isGlobal: true });
+    }
+
+    const now: Date = OneUptimeDate.getCurrentDate();
+    const staleCutoff: Date = OneUptimeDate.getSomeMinutesAgo(
+      PROBE_STALE_CUTOFF_IN_MINUTES,
+    );
+
+    const rows: Array<JSONObject> = await Promise.all(
+      probesWithScope.map(
+        async (entry: { probe: Probe; isGlobal: boolean }) => {
+          /*
+           * Tenant-scoped: only THIS project's monitor assignments count —
+           * projectId is pinned explicitly because global probes serve every
+           * project on the platform.
+           */
+          const monitorCount: PositiveNumber =
+            await MonitorProbeService.countBy({
+              query: {
+                probeId: entry.probe.id!,
+                projectId: ctx.projectId,
+              },
+              props: ctx.props,
+            });
+
+          const lastAlive: Date | undefined = entry.probe.lastAlive
+            ? OneUptimeDate.fromString(entry.probe.lastAlive)
+            : undefined;
+
+          /*
+           * Same verdict the status worker writes: connected only when the
+           * heartbeat is strictly fresher than the 3-minute cutoff. A probe
+           * that never reported is disconnected.
+           */
+          const isConnected: boolean = lastAlive
+            ? lastAlive.getTime() > staleCutoff.getTime()
+            : false;
+
+          return {
+            id: entry.probe.id?.toString(),
+            name: entry.probe.name,
+            description: entry.probe.description,
+            status: isConnected
+              ? ProbeConnectionStatus.Connected
+              : ProbeConnectionStatus.Disconnected,
+            lastAlive: lastAlive,
+            minutesSinceLastAlive: lastAlive
+              ? OneUptimeDate.getDifferenceInMinutes(now, lastAlive)
+              : undefined,
+            probeVersion: entry.probe.probeVersion?.toString(),
+            monitorsServed: monitorCount.toNumber(),
+            isGlobalProbe: entry.isGlobal,
+          };
+        },
+      ),
+    );
+
+    const disconnectedCount: number = rows.filter((row: JSONObject) => {
+      return row["status"] === ProbeConnectionStatus.Disconnected;
+    }).length;
+
+    const serialized: SerializedResult =
+      ToolResultSerializer.serializeRows(rows);
+
+    return {
+      dataForLlm: serialized.text,
+      rowCount: serialized.rowCount,
+      citationLabel:
+        rows.length > 0
+          ? `Probes (${serialized.rowCount} found, ${disconnectedCount} disconnected)`
+          : "Probes (0 found)",
+      citationTarget: {
+        type: AIChatCitationTargetType.Probes,
+      },
+      redactionCount: serialized.redactionCount,
+      isTruncated: serialized.isTruncated,
+      widget:
+        rows.length > 0
+          ? WidgetBuilder.table({
+              title: `Probes (${rows.length})`,
+              description: `Disconnected = no heartbeat in the last ${PROBE_STALE_CUTOFF_IN_MINUTES} minutes`,
+              columns: [
+                { key: "name", title: "Name", type: "text" },
+                { key: "status", title: "Status", type: "text" },
+                { key: "lastAlive", title: "Last alive", type: "date" },
+                { key: "probeVersion", title: "Version", type: "text" },
+                { key: "monitorsServed", title: "Monitors", type: "number" },
+                { key: "isGlobalProbe", title: "Global", type: "text" },
+              ],
+              rows: rows,
+              link: { type: AIChatCitationTargetType.Probes },
+            })
+          : undefined,
+    };
+  },
+};

--- a/Common/Server/Utils/LLM/LLMService.ts
+++ b/Common/Server/Utils/LLM/LLMService.ts
@@ -76,7 +76,14 @@ export interface LLMUsage {
 export interface LLMCompletionResponse {
   content: string;
   toolCalls?: Array<LLMToolCall> | undefined;
-  stopReason?: "stop" | "tool_use" | undefined;
+  /*
+   * "length" means the provider cut generation off at the output-token cap —
+   * the content is incomplete and must not be presented as a finished answer.
+   * Every wire branch maps its provider-specific truncation signal here
+   * (OpenAI-style finish_reason "length", Anthropic stop_reason "max_tokens",
+   * Ollama done_reason "length").
+   */
+  stopReason?: "stop" | "tool_use" | "length" | undefined;
   usage: LLMUsage | undefined;
 }
 
@@ -793,6 +800,24 @@ export default class LLMService {
       this.parseOpenAIToolCalls(message);
 
     /*
+     * finish_reason "length" means the model hit the output-token cap, so the
+     * content (or a trailing tool call) is truncated. It takes precedence over
+     * the tool-call heuristic: executing a cut-off tool call or presenting a
+     * cut-off answer as complete would be wrong either way. Otherwise the
+     * presence of tool calls decides — some OpenAI-compatible servers report
+     * finish_reason "stop" even when they emitted tool calls.
+     */
+    const finishReason: string = (choices[0]!["finish_reason"] as string) || "";
+
+    let stopReason: "stop" | "tool_use" | "length" = "stop";
+
+    if (finishReason === "length") {
+      stopReason = "length";
+    } else if (toolCalls && toolCalls.length > 0) {
+      stopReason = "tool_use";
+    }
+
+    /*
      * OpenAI (and Azure OpenAI) automatically cache a stable prompt prefix
      * once it is long enough and report the cache hit under
      * prompt_tokens_details.cached_tokens — surface it for cost visibility.
@@ -806,7 +831,7 @@ export default class LLMService {
     return {
       content: (message["content"] as string) || "",
       toolCalls: toolCalls,
-      stopReason: toolCalls && toolCalls.length > 0 ? "tool_use" : "stop",
+      stopReason: stopReason,
       usage: usage
         ? {
             promptTokens: usage["prompt_tokens"] as number,
@@ -960,8 +985,14 @@ export default class LLMService {
       [LlmType.Mistral]: "https://api.mistral.ai/v1",
     };
 
+    /*
+     * gpt-5.1 is a reasoning model: REASONING_MODEL_NAME_REGEX matches it, so
+     * the first request already goes out with max_completion_tokens instead
+     * of the legacy max_tokens, and any sampling params it rejects are
+     * dropped by the error-driven retry.
+     */
     const defaultModels: Record<string, string> = {
-      [LlmType.OpenAI]: "gpt-4o",
+      [LlmType.OpenAI]: "gpt-5.1",
       [LlmType.Groq]: "llama-3.3-70b-versatile",
       [LlmType.Mistral]: "mistral-large-latest",
     };
@@ -971,7 +1002,7 @@ export default class LLMService {
       defaultBaseUrls[config.llmType] ||
       "https://api.openai.com/v1";
     const modelName: string =
-      config.modelName || defaultModels[config.llmType] || "gpt-4o";
+      config.modelName || defaultModels[config.llmType] || "gpt-5.1";
     const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
       await this.postOpenAIChatCompletion({
         requestUrl: this.buildOpenAICompatibleChatCompletionsUrl(baseUrl),
@@ -1049,6 +1080,15 @@ export default class LLMService {
       );
     }
 
+    /*
+     * On Azure the model field is the DEPLOYMENT NAME the operator chose —
+     * not a model id. Keep the long-standing "gpt-4o" guess for tenants who
+     * left it blank: existing deployments named after the old default keep
+     * working, and Azure deployment names cannot contain dots, so a
+     * "gpt-5.1"-style id would never match a real deployment. The
+     * error-driven parameter adaptation corrects token-param mismatches
+     * either way.
+     */
     const modelName: string = config.modelName || "gpt-4o";
     const requestUrl: string = LLMService.buildAzureOpenAIChatCompletionsUrl(
       config.baseUrl,
@@ -1198,7 +1238,11 @@ export default class LLMService {
     }
 
     const baseUrl: string = config.baseUrl || "https://api.anthropic.com/v1";
-    const modelName: string = config.modelName || "claude-sonnet-4-20250514";
+    /*
+     * Current Sonnet alias. The dated claude-sonnet-4-20250514 ID this used to
+     * default to is deprecated and retires in June 2026.
+     */
+    const modelName: string = config.modelName || "claude-sonnet-5";
 
     let systemMessage: string = "";
 
@@ -1321,10 +1365,25 @@ export default class LLMService {
 
     const usage: JSONObject = jsonData["usage"] as JSONObject;
 
+    /*
+     * Anthropic reports truncation as stop_reason "max_tokens" — surface it as
+     * "length" so callers never present a cut-off answer as complete.
+     */
+    const anthropicStopReason: string =
+      (jsonData["stop_reason"] as string) || "";
+
+    let stopReason: "stop" | "tool_use" | "length" = "stop";
+
+    if (anthropicStopReason === "tool_use") {
+      stopReason = "tool_use";
+    } else if (anthropicStopReason === "max_tokens") {
+      stopReason = "length";
+    }
+
     return {
       content: textContent,
       toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
-      stopReason: jsonData["stop_reason"] === "tool_use" ? "tool_use" : "stop",
+      stopReason: stopReason,
       usage: usage
         ? {
             promptTokens: (usage["input_tokens"] as number) || 0,
@@ -1362,7 +1421,8 @@ export default class LLMService {
       throw new BadDataException("Ollama base URL is required");
     }
 
-    const modelName: string = config.modelName || "llama2";
+    // llama2 predates tool calling entirely; llama3.1 is the oldest sane default.
+    const modelName: string = config.modelName || "llama3.1";
 
     const requestData: JSONObject = {
       model: modelName,
@@ -1479,10 +1539,27 @@ export default class LLMService {
     const ollamaCompletionTokens: number =
       (jsonData["eval_count"] as number) || 0;
 
+    /*
+     * Ollama reports why generation ended in done_reason on the final
+     * /api/chat response: "length" when num_predict cut the output off
+     * ("limit" is accepted too for wire-compat variants). Truncation takes
+     * precedence over the tool-call heuristic — a cut-off tool call must not
+     * be executed.
+     */
+    const doneReason: string = (jsonData["done_reason"] as string) || "";
+
+    let stopReason: "stop" | "tool_use" | "length" = "stop";
+
+    if (doneReason === "length" || doneReason === "limit") {
+      stopReason = "length";
+    } else if (toolCalls && toolCalls.length > 0) {
+      stopReason = "tool_use";
+    }
+
     return {
       content: (message["content"] as string) || "",
       toolCalls: toolCalls,
-      stopReason: toolCalls && toolCalls.length > 0 ? "tool_use" : "stop",
+      stopReason: stopReason,
       usage:
         ollamaPromptTokens || ollamaCompletionTokens
           ? {

--- a/Common/Tests/Server/API/AIChatCancelAndFeedback.test.ts
+++ b/Common/Tests/Server/API/AIChatCancelAndFeedback.test.ts
@@ -1,0 +1,437 @@
+import { mockRouter } from "./Helpers";
+import "../../../Server/API/AIChatAPI";
+import CommonAPI from "../../../Server/API/CommonAPI";
+import AIConversationService from "../../../Server/Services/AIConversationService";
+import AIConversationMessageService from "../../../Server/Services/AIConversationMessageService";
+import AIRunEventService from "../../../Server/Services/AIRunEventService";
+import AIRunService from "../../../Server/Services/AIRunService";
+import UpdateOneBy from "../../../Server/Types/Database/UpdateOneBy";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import AIConversation from "../../../Models/DatabaseModels/AIConversation";
+import AIConversationMessage, {
+  AIConversationMessageFeedback,
+} from "../../../Models/DatabaseModels/AIConversationMessage";
+import AIRun from "../../../Models/DatabaseModels/AIRun";
+import AIRunEvent from "../../../Models/DatabaseModels/AIRunEvent";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import AIChatMessageRole from "../../../Types/AI/AIChatMessageRole";
+import AIChatMessageStatus from "../../../Types/AI/AIChatMessageStatus";
+import AIRunEventType from "../../../Types/AI/AIRunEventType";
+import AIRunStatus from "../../../Types/AI/AIRunStatus";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendJsonObjectResponse: jest.fn(),
+  };
+});
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+const USER_ID: ObjectID = new ObjectID("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+const CONVERSATION_ID: ObjectID = new ObjectID(
+  "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+);
+const RUN_ID: ObjectID = new ObjectID("dddddddd-dddd-4ddd-8ddd-dddddddddddd");
+const MESSAGE_ID: ObjectID = new ObjectID(
+  "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+);
+
+const props: DatabaseCommonInteractionProps = {
+  userId: USER_ID,
+  tenantId: PROJECT_ID,
+} as DatabaseCommonInteractionProps;
+
+function requestFor(body: JSONObject): ExpressRequest {
+  return {
+    body,
+  } as unknown as ExpressRequest;
+}
+
+function response(): ExpressResponse {
+  return {} as ExpressResponse;
+}
+
+function sentPayload(): JSONObject {
+  const send: jest.Mock =
+    Response.sendJsonObjectResponse as unknown as jest.Mock;
+  return send.mock.calls[0]![2] as JSONObject;
+}
+
+function activeChatRun(status: AIRunStatus): AIRun {
+  const run: AIRun = new AIRun(RUN_ID);
+  run.status = status;
+  return run;
+}
+
+function assistantMessage(): AIConversationMessage {
+  const message: AIConversationMessage = new AIConversationMessage(MESSAGE_ID);
+  message.conversationId = CONVERSATION_ID;
+  message.role = AIChatMessageRole.Assistant;
+  return message;
+}
+
+async function callCancelRoute(body?: JSONObject): Promise<NextFunction> {
+  const req: ExpressRequest = requestFor(
+    body || { conversationId: CONVERSATION_ID.toString() },
+  );
+  const next: ReturnType<typeof jest.fn> = jest.fn();
+
+  await mockRouter
+    .match("post", "/ai-chat/cancel-run")
+    .handlerFunction(req, response(), next as unknown as NextFunction);
+
+  return next as unknown as NextFunction;
+}
+
+async function callFeedbackRoute(body: JSONObject): Promise<NextFunction> {
+  const req: ExpressRequest = requestFor(body);
+  const next: ReturnType<typeof jest.fn> = jest.fn();
+
+  await mockRouter
+    .match("post", "/ai-chat/message-feedback")
+    .handlerFunction(req, response(), next as unknown as NextFunction);
+
+  return next as unknown as NextFunction;
+}
+
+describe("POST /ai-chat/cancel-run", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .spyOn(CommonAPI, "getDatabaseCommonInteractionProps")
+      .mockResolvedValue(props);
+    jest
+      .spyOn(AIConversationService, "findOneById")
+      .mockResolvedValue(new AIConversation(CONVERSATION_ID));
+    jest
+      .spyOn(AIRunService, "findOneBy")
+      .mockResolvedValue(activeChatRun(AIRunStatus.Running));
+
+    /*
+     * The status-guarded run flip: only the Running-guard matches (the run
+     * really is Running), the WaitingForApproval-guard matches zero rows —
+     * exactly what the database would report.
+     */
+    jest
+      .spyOn(AIRunService, "updateOneBy")
+      .mockImplementation((update: UpdateOneBy<AIRun>) => {
+        return Promise.resolve(
+          (update.query as JSONObject)["status"] === AIRunStatus.Running
+            ? 1
+            : 0,
+        );
+      });
+    jest
+      .spyOn(AIConversationMessageService, "updateOneBy")
+      .mockResolvedValue(1);
+    jest.spyOn(AIRunEventService, "create").mockResolvedValue(new AIRunEvent());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("cancels the active run, finalizes the message and emits a terminal event", async () => {
+    const next: NextFunction = await callCancelRoute();
+
+    expect(next).not.toHaveBeenCalled();
+
+    /*
+     * The active-run lookup is tenant-scoped and only matches live statuses.
+     * QueryHelper.any builds a Raw FindOperator with a RANDOM parameter name,
+     * so it cannot be compared structurally — assert on the operator's
+     * parameter values instead.
+     */
+    expect(AIRunService.findOneBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          conversationId: CONVERSATION_ID,
+          projectId: PROJECT_ID,
+        }),
+      }),
+    );
+
+    const findRunQuery: JSONObject = (
+      (AIRunService.findOneBy as unknown as jest.Mock).mock
+        .calls[0]![0] as JSONObject
+    )["query"] as JSONObject;
+    const statusOperatorParameters: Array<unknown> = Object.values(
+      (
+        findRunQuery["status"] as {
+          _objectLiteralParameters?: Record<string, unknown>;
+        }
+      )._objectLiteralParameters || {},
+    );
+    expect(statusOperatorParameters).toEqual([
+      [AIRunStatus.Running, AIRunStatus.WaitingForApproval],
+    ]);
+
+    // The run flip is guarded on the run still being in flight.
+    expect(AIRunService.updateOneBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: { _id: RUN_ID.toString(), status: AIRunStatus.Running },
+        data: expect.objectContaining({
+          status: AIRunStatus.Cancelled,
+          errorMessage: "Stopped by user.",
+          pausedState: null,
+        }),
+      }),
+    );
+
+    // The message finalization is guarded on both in-flight statuses.
+    for (const inFlightStatus of [
+      AIChatMessageStatus.InProgress,
+      AIChatMessageStatus.WaitingForApproval,
+    ]) {
+      expect(AIConversationMessageService.updateOneBy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: { aiRunId: RUN_ID, status: inFlightStatus },
+          data: expect.objectContaining({
+            status: AIChatMessageStatus.Cancelled,
+            contentInMarkdown: "Stopped by user.",
+          }),
+        }),
+      );
+    }
+
+    // Terminal closure event for the polling UI.
+    expect(AIRunEventService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          projectId: PROJECT_ID,
+          aiRunId: RUN_ID,
+          userId: USER_ID,
+          eventType: AIRunEventType.RunFailed,
+          resultSummary: { errorMessage: "Stopped by user." },
+        }),
+      }),
+    );
+
+    expect(sentPayload()).toEqual({
+      conversationId: CONVERSATION_ID.toString(),
+      aiRunId: RUN_ID.toString(),
+      cancelled: true,
+    });
+  });
+
+  it("rejects when the conversation has no active run — a finished run is never touched", async () => {
+    jest.spyOn(AIRunService, "findOneBy").mockResolvedValue(null);
+
+    const next: NextFunction = await callCancelRoute();
+
+    expect(next).toHaveBeenCalledWith(
+      new BadDataException(
+        "No response is being generated in this conversation.",
+      ),
+    );
+    expect(AIRunService.updateOneBy).not.toHaveBeenCalled();
+    expect(AIConversationMessageService.updateOneBy).not.toHaveBeenCalled();
+    expect(AIRunEventService.create).not.toHaveBeenCalled();
+    expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+  });
+
+  it("reports cancelled: false and emits no event when the runner finalized first", async () => {
+    // Both status guards match zero rows: the run completed in the race window.
+    jest.spyOn(AIRunService, "updateOneBy").mockResolvedValue(0);
+
+    const next: NextFunction = await callCancelRoute();
+
+    expect(next).not.toHaveBeenCalled();
+
+    /*
+     * Every write stays status-guarded, so the completed run and its
+     * completed message are untouched even though the writes were attempted.
+     */
+    const runUpdateCalls: Array<Array<unknown>> = (
+      AIRunService.updateOneBy as unknown as jest.Mock
+    ).mock.calls as Array<Array<unknown>>;
+    for (const call of runUpdateCalls) {
+      const query: JSONObject = (call[0] as UpdateOneBy<AIRun>)
+        .query as JSONObject;
+      expect([AIRunStatus.Running, AIRunStatus.WaitingForApproval]).toContain(
+        query["status"],
+      );
+    }
+
+    expect(AIRunEventService.create).not.toHaveBeenCalled();
+    expect(sentPayload()).toEqual(
+      expect.objectContaining({ cancelled: false }),
+    );
+  });
+
+  it("rejects another user's conversation before reading any run", async () => {
+    // The privacy pin returns null for a conversation this user does not own.
+    jest.spyOn(AIConversationService, "findOneById").mockResolvedValue(null);
+
+    const next: NextFunction = await callCancelRoute();
+
+    expect(next).toHaveBeenCalledWith(
+      new BadDataException("Conversation not found."),
+    );
+    expect(AIRunService.findOneBy).not.toHaveBeenCalled();
+    expect(AIRunService.updateOneBy).not.toHaveBeenCalled();
+    expect(AIConversationMessageService.updateOneBy).not.toHaveBeenCalled();
+    expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+  });
+
+  it("requires a conversationId", async () => {
+    const next: NextFunction = await callCancelRoute({});
+
+    expect(next).toHaveBeenCalledWith(
+      new BadDataException("conversationId is required."),
+    );
+    expect(AIConversationService.findOneById).not.toHaveBeenCalled();
+    expect(AIRunService.updateOneBy).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /ai-chat/message-feedback", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .spyOn(CommonAPI, "getDatabaseCommonInteractionProps")
+      .mockResolvedValue(props);
+    jest
+      .spyOn(AIConversationMessageService, "findOneById")
+      .mockResolvedValue(assistantMessage());
+    jest
+      .spyOn(AIConversationService, "findOneById")
+      .mockResolvedValue(new AIConversation(CONVERSATION_ID));
+    jest
+      .spyOn(AIConversationMessageService, "updateOneById")
+      .mockResolvedValue(1);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("stores thumbs-up feedback on an assistant message the user owns", async () => {
+    const next: NextFunction = await callFeedbackRoute({
+      messageId: MESSAGE_ID.toString(),
+      feedback: "Up",
+    });
+
+    expect(next).not.toHaveBeenCalled();
+
+    // The message is read under the USER's props: the privacy pin applies.
+    expect(AIConversationMessageService.findOneById).toHaveBeenCalledWith(
+      expect.objectContaining({ props: props }),
+    );
+
+    expect(AIConversationMessageService.updateOneById).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: MESSAGE_ID,
+        data: { userFeedback: AIConversationMessageFeedback.Up },
+      }),
+    );
+    expect(sentPayload()).toEqual({
+      messageId: MESSAGE_ID.toString(),
+      feedback: AIConversationMessageFeedback.Up,
+    });
+  });
+
+  it("clears feedback when null is sent", async () => {
+    const next: NextFunction = await callFeedbackRoute({
+      messageId: MESSAGE_ID.toString(),
+      feedback: null,
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(AIConversationMessageService.updateOneById).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: MESSAGE_ID,
+        data: { userFeedback: null },
+      }),
+    );
+    expect(sentPayload()).toEqual({
+      messageId: MESSAGE_ID.toString(),
+      feedback: null,
+    });
+  });
+
+  it("rejects an invalid feedback value before any read", async () => {
+    const next: NextFunction = await callFeedbackRoute({
+      messageId: MESSAGE_ID.toString(),
+      feedback: "Sideways",
+    });
+
+    expect(next).toHaveBeenCalledWith(expect.any(BadDataException));
+    expect(AIConversationMessageService.findOneById).not.toHaveBeenCalled();
+    expect(AIConversationMessageService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  it("rejects feedback on a user-role message", async () => {
+    const userMessage: AIConversationMessage = assistantMessage();
+    userMessage.role = AIChatMessageRole.User;
+    jest
+      .spyOn(AIConversationMessageService, "findOneById")
+      .mockResolvedValue(userMessage);
+
+    const next: NextFunction = await callFeedbackRoute({
+      messageId: MESSAGE_ID.toString(),
+      feedback: "Down",
+    });
+
+    expect(next).toHaveBeenCalledWith(
+      new BadDataException("Feedback can only be left on assistant messages."),
+    );
+    expect(AIConversationMessageService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  it("rejects a message the privacy pin hides (another user's row)", async () => {
+    jest
+      .spyOn(AIConversationMessageService, "findOneById")
+      .mockResolvedValue(null);
+
+    const next: NextFunction = await callFeedbackRoute({
+      messageId: MESSAGE_ID.toString(),
+      feedback: "Up",
+    });
+
+    expect(next).toHaveBeenCalledWith(
+      new BadDataException("Message not found."),
+    );
+    expect(AIConversationService.findOneById).not.toHaveBeenCalled();
+    expect(AIConversationMessageService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  it("rejects a message whose conversation does not resolve for this user", async () => {
+    jest.spyOn(AIConversationService, "findOneById").mockResolvedValue(null);
+
+    const next: NextFunction = await callFeedbackRoute({
+      messageId: MESSAGE_ID.toString(),
+      feedback: "Up",
+    });
+
+    expect(next).toHaveBeenCalledWith(
+      new BadDataException("Message not found."),
+    );
+    expect(AIConversationMessageService.updateOneById).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Utils/AI/AIMetaTools.test.ts
+++ b/Common/Tests/Server/Utils/AI/AIMetaTools.test.ts
@@ -1,0 +1,586 @@
+import {
+  GetAIInvestigationTool,
+  QueryAIInsightsTool,
+  StartInvestigationTool,
+} from "../../../../Server/Utils/AI/Toolbox/AIMetaTools";
+import {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../Server/Utils/AI/Toolbox/ToolTypes";
+import AIRunService from "../../../../Server/Services/AIRunService";
+import AIInsightService from "../../../../Server/Services/AIInsightService";
+import IncidentService from "../../../../Server/Services/IncidentService";
+import AlertService from "../../../../Server/Services/AlertService";
+import PostedRootCause from "../../../../Server/Utils/AI/SRE/PostedRootCause";
+import AIInvestigationQueue from "../../../../Server/Utils/AI/SRE/InvestigationQueue";
+import AIRun from "../../../../Models/DatabaseModels/AIRun";
+import AIInsight from "../../../../Models/DatabaseModels/AIInsight";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import Alert from "../../../../Models/DatabaseModels/Alert";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import AIRunStatus from "../../../../Types/AI/AIRunStatus";
+import AIRunType from "../../../../Types/AI/AIRunType";
+import AIInsightStatus from "../../../../Types/AI/AIInsightStatus";
+import AIInsightSeverity from "../../../../Types/AI/AIInsightSeverity";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * The AI meta tools make the chat aware of the platform's other AI lanes:
+ * get_ai_investigation reads the autonomous RCA for one incident/alert,
+ * query_ai_insights lists preventive detector findings, start_investigation
+ * enqueues a run through the same durable queue the automatic lanes use.
+ * These tests lock in what the model (and the queue) rely on: subject
+ * visibility runs under the user's RBAC, dedupe never double-enqueues, empty
+ * results are honest, and tenancy comes from ctx — never from an argument.
+ */
+
+const ctx: ToolContext = {
+  projectId: ObjectID.generate(),
+  props: { isRoot: true },
+};
+
+const INCIDENT_ID: ObjectID = ObjectID.generate();
+const ALERT_ID: ObjectID = ObjectID.generate();
+const MONITOR_ID: ObjectID = ObjectID.generate();
+const RUN_ID: ObjectID = ObjectID.generate();
+
+function buildIncident(): Incident {
+  const incident: Incident = new Incident();
+  incident._id = INCIDENT_ID.toString();
+  incident.incidentNumber = 12;
+
+  const monitor: Monitor = new Monitor();
+  monitor._id = MONITOR_ID.toString();
+  incident.monitors = [monitor];
+
+  return incident;
+}
+
+function buildAlert(): Alert {
+  const alert: Alert = new Alert();
+  alert._id = ALERT_ID.toString();
+  alert.alertNumber = 7;
+  alert.monitorId = MONITOR_ID;
+  return alert;
+}
+
+function buildRun(data?: {
+  status?: AIRunStatus;
+  analysisTldr?: string;
+  errorMessage?: string;
+}): AIRun {
+  const run: AIRun = new AIRun();
+  run._id = RUN_ID.toString();
+  run.status = data?.status ?? AIRunStatus.Completed;
+  if (data?.analysisTldr) {
+    run.analysisTldr = data.analysisTldr;
+  }
+  if (data?.errorMessage) {
+    run.errorMessage = data.errorMessage;
+  }
+  run.createdAt = new Date("2026-08-14T10:00:00Z");
+  run.startedAt = new Date("2026-08-14T10:00:05Z");
+  run.completedAt = new Date("2026-08-14T10:02:00Z");
+  run.attemptCount = 1;
+  return run;
+}
+
+function buildInsight(data?: {
+  title?: string;
+  status?: AIInsightStatus;
+  severity?: AIInsightSeverity;
+}): AIInsight {
+  const insight: AIInsight = new AIInsight();
+  insight._id = ObjectID.generate().toString();
+  insight.title = data?.title ?? "Error log spike in checkout-service";
+  insight.status = data?.status ?? AIInsightStatus.ActionRequired;
+  insight.severity = data?.severity ?? AIInsightSeverity.High;
+  insight.serviceName = "checkout-service";
+  insight.occurrenceCount = 3;
+  insight.firstSeenAt = new Date("2026-08-13T08:00:00Z");
+  insight.lastSeenAt = new Date("2026-08-14T09:00:00Z");
+  return insight;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("get_ai_investigation — incident path", () => {
+  test("returns the completed run with its posted analysis and a view citation", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(AIRunService, "findBy")
+      .mockResolvedValue([
+        buildRun({ analysisTldr: "Cache stampede after the 09:40 deploy." }),
+      ] as never);
+    jest
+      .spyOn(PostedRootCause, "getForInvestigation")
+      .mockResolvedValue(
+        "## AI — Automated Root Cause Analysis\nThe cache stampede began after deploy 4711.",
+      );
+
+    const result: ToolExecutionResult = await GetAIInvestigationTool.execute(
+      { incidentId: INCIDENT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(result.dataForLlm).toContain("Cache stampede after the 09:40");
+    expect(result.dataForLlm).toContain("The cache stampede began after");
+    expect(result.dataForLlm).toContain(AIRunStatus.Completed);
+    expect(result.citationLabel).toBe(
+      "AI investigation for Incident #12 (1 run)",
+    );
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.IncidentView,
+      params: { incidentId: INCIDENT_ID.toString() },
+    });
+    expect(result.widget).toBeDefined();
+
+    /*
+     * The run query must be scoped to this incident's investigation lane
+     * and run under the requesting user's props.
+     */
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    const query: JSONObject = callArgs["query"] as JSONObject;
+    expect(query["runType"]).toBe(AIRunType.Investigation);
+    expect((query["triggeredByIncidentId"] as ObjectID).toString()).toBe(
+      INCIDENT_ID.toString(),
+    );
+    // Tenancy is pinned from ctx — never from an argument.
+    expect(query["projectId"]).toBe(ctx.projectId);
+    /*
+     * The run read deliberately uses root props: investigation runs carry no
+     * userId, so the AIRun privacy pin would hide them from every regular
+     * member. Access is authorized by the user-props subject fetch above and
+     * the projectId pin asserted here.
+     */
+    expect(callArgs["props"]).toStrictEqual({ isRoot: true });
+  });
+
+  test("a still-running investigation says so and fetches no analysis", async () => {
+    jest
+      .spyOn(AlertService, "findOneById")
+      .mockResolvedValue(buildAlert() as never);
+    jest
+      .spyOn(AIRunService, "findBy")
+      .mockResolvedValue([buildRun({ status: AIRunStatus.Running })] as never);
+    const analysisSpy: jest.SpyInstance = jest.spyOn(
+      PostedRootCause,
+      "getForInvestigation",
+    );
+
+    const result: ToolExecutionResult = await GetAIInvestigationTool.execute(
+      { alertId: ALERT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.dataForLlm).toContain("still RUNNING");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.AlertView,
+      params: { alertId: ALERT_ID.toString() },
+    });
+    expect(analysisSpy).not.toHaveBeenCalled();
+  });
+
+  test("an inconclusive analysis carries the quiet-mode honesty note", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+    jest.spyOn(AIRunService, "findBy").mockResolvedValue([
+      buildRun({
+        analysisTldr: "The evidence was inconclusive; telemetry is missing.",
+      }),
+    ] as never);
+    jest.spyOn(PostedRootCause, "getForInvestigation").mockResolvedValue(null);
+
+    const result: ToolExecutionResult = await GetAIInvestigationTool.execute(
+      { incidentId: INCIDENT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.dataForLlm).toContain("INCONCLUSIVE");
+    expect(result.dataForLlm).toContain("quiet mode");
+  });
+
+  test("a failed run surfaces its error message honestly", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+    jest.spyOn(AIRunService, "findBy").mockResolvedValue([
+      buildRun({
+        status: AIRunStatus.Error,
+        errorMessage: "No LLM provider configured.",
+      }),
+    ] as never);
+
+    const result: ToolExecutionResult = await GetAIInvestigationTool.execute(
+      { incidentId: INCIDENT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.dataForLlm).toContain("did NOT produce an analysis");
+    expect(result.dataForLlm).toContain("No LLM provider configured.");
+  });
+
+  test("no runs is honest: zero rows, no widget, points at start_investigation", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+    jest.spyOn(AIRunService, "findBy").mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await GetAIInvestigationTool.execute(
+      { incidentId: INCIDENT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(result.dataForLlm).toContain("start_investigation");
+  });
+
+  test("requires exactly one of incidentId/alertId", async () => {
+    const neither: ToolExecutionResult = await GetAIInvestigationTool.execute(
+      {},
+      ctx,
+    );
+    expect(neither.rowCount).toBe(0);
+    expect(neither.dataForLlm).toContain("Error:");
+
+    const both: ToolExecutionResult = await GetAIInvestigationTool.execute(
+      { incidentId: INCIDENT_ID.toString(), alertId: ALERT_ID.toString() },
+      ctx,
+    );
+    expect(both.rowCount).toBe(0);
+    expect(both.dataForLlm).toContain("Error:");
+  });
+
+  test("an invisible subject is an error envelope, not a leak", async () => {
+    jest.spyOn(IncidentService, "findOneById").mockResolvedValue(null as never);
+
+    const result: ToolExecutionResult = await GetAIInvestigationTool.execute(
+      { incidentId: INCIDENT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.dataForLlm).toContain("not found");
+    expect(result.widget).toBeUndefined();
+  });
+
+  test("required permissions derive from the AIRun read ACL", () => {
+    expect(GetAIInvestigationTool.requiredPermissions.length).toBeGreaterThan(
+      0,
+    );
+  });
+});
+
+describe("query_ai_insights", () => {
+  test("lists recent insights with filters reaching the service query", async () => {
+    const serviceId: ObjectID = ObjectID.generate();
+    jest
+      .spyOn(AIInsightService, "countBy")
+      .mockResolvedValue(new PositiveNumber(2) as never);
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(AIInsightService, "findBy")
+      .mockResolvedValue([
+        buildInsight(),
+        buildInsight({
+          title: "p99 latency regression on /checkout",
+          severity: AIInsightSeverity.Medium,
+        }),
+      ] as never);
+
+    const result: ToolExecutionResult = await QueryAIInsightsTool.execute(
+      {
+        serviceId: serviceId.toString(),
+        // Case-insensitive status matching — the model rarely gets casing right.
+        status: "actionrequired",
+      },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(2);
+    expect(result.dataForLlm).toContain("Error log spike in checkout-service");
+    expect(result.dataForLlm).toContain("p99 latency regression");
+    expect(result.citationLabel).toBe("AI insights, last 7d (2 found)");
+    expect(result.citationTarget).toBeUndefined();
+    expect(result.widget).toBeDefined();
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    const query: JSONObject = callArgs["query"] as JSONObject;
+    expect((query["telemetryServiceId"] as ObjectID).toString()).toBe(
+      serviceId.toString(),
+    );
+    expect(query["status"]).toBe(AIInsightStatus.ActionRequired);
+    expect(query["lastSeenAt"]).toBeDefined();
+    expect(query["projectId"]).toBe(ctx.projectId);
+    expect(callArgs["props"]).toBe(ctx.props);
+    expect(callArgs["limit"]).toBe(10);
+  });
+
+  test("clamps lookbackDays and limit", async () => {
+    jest
+      .spyOn(AIInsightService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(AIInsightService, "findBy")
+      .mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryAIInsightsTool.execute(
+      { lookbackDays: 10000, limit: 999 },
+      ctx,
+    );
+
+    expect(result.citationLabel).toBe("AI insights, last 90d (0 found)");
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["limit"]).toBe(25);
+  });
+
+  test("paginates: skip reaches the query and the total is disclosed", async () => {
+    jest
+      .spyOn(AIInsightService, "countBy")
+      .mockResolvedValue(new PositiveNumber(30) as never);
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(AIInsightService, "findBy")
+      .mockResolvedValue([buildInsight(), buildInsight()] as never);
+
+    const result: ToolExecutionResult = await QueryAIInsightsTool.execute(
+      { skip: 5, limit: 2 },
+      ctx,
+    );
+
+    expect(result.dataForLlm).toContain(
+      "Showing rows 6–7 of 30 total. Pass skip to page further.",
+    );
+    expect(result.citationLabel).toBe("AI insights, last 7d (30 found)");
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["skip"]).toBe(5);
+  });
+
+  test("an invalid status filter is an error envelope listing valid values", async () => {
+    const findBySpy: jest.SpyInstance = jest.spyOn(AIInsightService, "findBy");
+
+    const result: ToolExecutionResult = await QueryAIInsightsTool.execute(
+      { status: "Exploded" },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.dataForLlm).toContain("Error:");
+    expect(result.dataForLlm).toContain(AIInsightStatus.ActionRequired);
+    expect(findBySpy).not.toHaveBeenCalled();
+  });
+
+  test("an empty window is honest: zero rows and no widget", async () => {
+    jest
+      .spyOn(AIInsightService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+    jest.spyOn(AIInsightService, "findBy").mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryAIInsightsTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+  });
+
+  test("required permissions derive from the AIInsight read ACL", () => {
+    expect(QueryAIInsightsTool.requiredPermissions.length).toBeGreaterThan(0);
+  });
+});
+
+describe("start_investigation", () => {
+  test("enqueues through the durable queue with ctx tenancy and the monitor dedupe key", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+    jest
+      .spyOn(AIRunService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+    const enqueueSpy: jest.SpyInstance = jest
+      .spyOn(AIInvestigationQueue, "enqueue")
+      .mockResolvedValue(RUN_ID as never);
+
+    const result: ToolExecutionResult = await StartInvestigationTool.execute(
+      // A hostile projectId argument must be ignored — tenancy is ctx-only.
+      { incidentId: INCIDENT_ID.toString(), projectId: "attacker-project" },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(result.dataForLlm).toContain("Queued AI investigation run");
+    expect(result.dataForLlm).toContain("get_ai_investigation");
+    expect(result.citationLabel).toBe(
+      "AI investigation queued for Incident #12",
+    );
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.IncidentView,
+      params: { incidentId: INCIDENT_ID.toString() },
+    });
+    expect(result.widget).toBeDefined();
+
+    const enqueueArgs: JSONObject = enqueueSpy.mock.calls[0]?.[0] as JSONObject;
+    expect(enqueueArgs["projectId"]).toBe(ctx.projectId);
+    expect((enqueueArgs["subjectIncidentId"] as ObjectID).toString()).toBe(
+      INCIDENT_ID.toString(),
+    );
+    expect((enqueueArgs["subjectMonitorId"] as ObjectID).toString()).toBe(
+      MONITOR_ID.toString(),
+    );
+    expect(enqueueArgs["subjectAlertId"]).toBeUndefined();
+  });
+
+  test("alert path passes the alert's monitor as the dedupe key", async () => {
+    jest
+      .spyOn(AlertService, "findOneById")
+      .mockResolvedValue(buildAlert() as never);
+    jest
+      .spyOn(AIRunService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+    const enqueueSpy: jest.SpyInstance = jest
+      .spyOn(AIInvestigationQueue, "enqueue")
+      .mockResolvedValue(RUN_ID as never);
+
+    const result: ToolExecutionResult = await StartInvestigationTool.execute(
+      { alertId: ALERT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.AlertView,
+      params: { alertId: ALERT_ID.toString() },
+    });
+
+    const enqueueArgs: JSONObject = enqueueSpy.mock.calls[0]?.[0] as JSONObject;
+    expect((enqueueArgs["subjectAlertId"] as ObjectID).toString()).toBe(
+      ALERT_ID.toString(),
+    );
+    expect((enqueueArgs["subjectMonitorId"] as ObjectID).toString()).toBe(
+      MONITOR_ID.toString(),
+    );
+    expect(enqueueArgs["subjectIncidentId"]).toBeUndefined();
+  });
+
+  test("a live run means no duplicate: clear message, no enqueue", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+    jest
+      .spyOn(AIRunService, "countBy")
+      .mockResolvedValueOnce(new PositiveNumber(1) as never);
+    const enqueueSpy: jest.SpyInstance = jest.spyOn(
+      AIInvestigationQueue,
+      "enqueue",
+    );
+
+    const result: ToolExecutionResult = await StartInvestigationTool.execute(
+      { incidentId: INCIDENT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.dataForLlm).toContain("already queued or running");
+    expect(result.widget).toBeUndefined();
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+
+  test("a run inside the 30-minute cooldown means no duplicate either", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+    jest
+      .spyOn(AIRunService, "countBy")
+      // First count: live runs (none). Second count: runs in the cooldown window (one).
+      .mockResolvedValueOnce(new PositiveNumber(0) as never)
+      .mockResolvedValueOnce(new PositiveNumber(1) as never);
+    const enqueueSpy: jest.SpyInstance = jest.spyOn(
+      AIInvestigationQueue,
+      "enqueue",
+    );
+
+    const result: ToolExecutionResult = await StartInvestigationTool.execute(
+      { incidentId: INCIDENT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.dataForLlm).toContain("recent AI investigation");
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+
+  test("a budget quiet-skip (enqueue returns null) is reported honestly", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+    jest
+      .spyOn(AIRunService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+    jest.spyOn(AIInvestigationQueue, "enqueue").mockResolvedValue(null);
+
+    const result: ToolExecutionResult = await StartInvestigationTool.execute(
+      { incidentId: INCIDENT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.dataForLlm).toContain("could not be enqueued");
+    expect(result.widget).toBeUndefined();
+  });
+
+  test("rejects missing/ambiguous subject arguments", async () => {
+    await expect(StartInvestigationTool.execute({}, ctx)).rejects.toThrow(
+      BadDataException,
+    );
+    await expect(
+      StartInvestigationTool.execute(
+        { incidentId: INCIDENT_ID.toString(), alertId: ALERT_ID.toString() },
+        ctx,
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  test("rejects a subject the user cannot see", async () => {
+    jest.spyOn(IncidentService, "findOneById").mockResolvedValue(null as never);
+
+    await expect(
+      StartInvestigationTool.execute(
+        { incidentId: INCIDENT_ID.toString() },
+        ctx,
+      ),
+    ).rejects.toThrow("Incident not found");
+  });
+
+  test("buildActionTitle names the subject from validated args", () => {
+    expect(
+      StartInvestigationTool.buildActionTitle?.({
+        incidentId: INCIDENT_ID.toString(),
+      }),
+    ).toBe(`Start AI investigation for incident ${INCIDENT_ID.toString()}`);
+    expect(
+      StartInvestigationTool.buildActionTitle?.({
+        alertId: ALERT_ID.toString(),
+      }),
+    ).toBe(`Start AI investigation for alert ${ALERT_ID.toString()}`);
+  });
+
+  test("is a mutation gated by the subject models' update ACLs", () => {
+    expect(StartInvestigationTool.isMutation).toBe(true);
+    expect(StartInvestigationTool.requiredPermissions.length).toBeGreaterThan(
+      0,
+    );
+  });
+});

--- a/Common/Tests/Server/Utils/AI/AlertMonitorFilters.test.ts
+++ b/Common/Tests/Server/Utils/AI/AlertMonitorFilters.test.ts
@@ -1,0 +1,582 @@
+import { QueryAlertsTool } from "../../../../Server/Utils/AI/Toolbox/AlertTools";
+import { QueryMonitorsTool } from "../../../../Server/Utils/AI/Toolbox/MonitorTools";
+import {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../Server/Utils/AI/Toolbox/ToolTypes";
+import AlertService from "../../../../Server/Services/AlertService";
+import AlertOwnerTeamService from "../../../../Server/Services/AlertOwnerTeamService";
+import AlertOwnerUserService from "../../../../Server/Services/AlertOwnerUserService";
+import MonitorService from "../../../../Server/Services/MonitorService";
+import MonitorOwnerTeamService from "../../../../Server/Services/MonitorOwnerTeamService";
+import MonitorOwnerUserService from "../../../../Server/Services/MonitorOwnerUserService";
+import MonitorStatusService from "../../../../Server/Services/MonitorStatusService";
+import MonitorStatusTimelineService from "../../../../Server/Services/MonitorStatusTimelineService";
+import QueryHelper from "../../../../Server/Types/Database/QueryHelper";
+import Alert from "../../../../Models/DatabaseModels/Alert";
+import AlertOwnerTeam from "../../../../Models/DatabaseModels/AlertOwnerTeam";
+import AlertOwnerUser from "../../../../Models/DatabaseModels/AlertOwnerUser";
+import AlertSeverity from "../../../../Models/DatabaseModels/AlertSeverity";
+import AlertState from "../../../../Models/DatabaseModels/AlertState";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import MonitorOwnerTeam from "../../../../Models/DatabaseModels/MonitorOwnerTeam";
+import MonitorOwnerUser from "../../../../Models/DatabaseModels/MonitorOwnerUser";
+import MonitorStatus from "../../../../Models/DatabaseModels/MonitorStatus";
+import MonitorStatusTimeline from "../../../../Models/DatabaseModels/MonitorStatusTimeline";
+import Team from "../../../../Models/DatabaseModels/Team";
+import User from "../../../../Models/DatabaseModels/User";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import Color from "../../../../Types/Color";
+import { JSONObject } from "../../../../Types/JSON";
+import MonitorType from "../../../../Types/Monitor/MonitorType";
+import Name from "../../../../Types/Name";
+import ObjectID from "../../../../Types/ObjectID";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * These tests lock in the new filtering surface of query_alerts and
+ * query_monitors: that state / problemsOnly / monitorStatusName actually
+ * reach the service query (asserted on the spy's call args, not on the
+ * result), that skip/totalCount paging is reported honestly, and that
+ * detail mode surfaces owners.
+ */
+
+const ctx: ToolContext = {
+  projectId: ObjectID.generate(),
+  props: { isRoot: true },
+};
+
+function buildAlert(data?: {
+  number?: number;
+  title?: string;
+  state?: string;
+}): Alert {
+  const alert: Alert = new Alert();
+  alert._id = ObjectID.generate().toString();
+  alert.title = data?.title ?? "CPU usage high";
+  alert.alertNumber = data?.number ?? 42;
+  alert.createdAt = new Date("2026-08-01T00:00:00Z");
+
+  const state: AlertState = new AlertState();
+  state.name = data?.state ?? "Created";
+  alert.currentAlertState = state;
+
+  const severity: AlertSeverity = new AlertSeverity();
+  severity.name = "Critical";
+  alert.alertSeverity = severity;
+
+  return alert;
+}
+
+function buildMonitorStatus(data: {
+  id?: ObjectID;
+  name: string;
+  priority: number;
+  operational: boolean;
+  color?: string;
+}): MonitorStatus {
+  const status: MonitorStatus = new MonitorStatus();
+  status._id = (data.id ?? ObjectID.generate()).toString();
+  status.name = data.name;
+  status.priority = data.priority;
+  status.isOperationalState = data.operational;
+  if (data.color) {
+    status.color = new Color(data.color);
+  }
+  return status;
+}
+
+function buildMonitor(data: { name: string; status?: MonitorStatus }): Monitor {
+  const monitor: Monitor = new Monitor();
+  monitor._id = ObjectID.generate().toString();
+  monitor.name = data.name;
+  monitor.monitorType = MonitorType.Website;
+  if (data.status) {
+    monitor.currentMonitorStatus = data.status;
+  }
+  return monitor;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("query_alerts — state filter", () => {
+  test("state='active' filters on isResolvedState=false and drops the createdAt window", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(AlertService, "findBy")
+      .mockResolvedValue([buildAlert()] as never);
+    const countBySpy: jest.SpyInstance = jest
+      .spyOn(AlertService, "countBy")
+      .mockResolvedValue(new PositiveNumber(1) as never);
+
+    const result: ToolExecutionResult = await QueryAlertsTool.execute(
+      { state: "active" },
+      ctx,
+    );
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["query"]).toEqual({
+      currentAlertState: { isResolvedState: false },
+    });
+    expect(callArgs["props"]).toBe(ctx.props);
+
+    // countBy must see the exact same query the rows came from.
+    const countArgs: JSONObject = countBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(countArgs["query"]).toBe(callArgs["query"]);
+
+    expect(result.rowCount).toBe(1);
+    expect(result.citationLabel).toBe("Active alerts (1 found)");
+  });
+
+  test("state='active' keeps an explicitly requested createdAt window", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(AlertService, "findBy")
+      .mockResolvedValue([] as never);
+    jest
+      .spyOn(AlertService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    await QueryAlertsTool.execute(
+      { state: "active", createdWithinHours: 6 },
+      ctx,
+    );
+
+    const query: JSONObject = (findBySpy.mock.calls[0]?.[0] as JSONObject)[
+      "query"
+    ] as JSONObject;
+    expect(query["currentAlertState"]).toEqual({ isResolvedState: false });
+    expect(query["createdAt"]).toBeDefined();
+  });
+
+  test("state='resolved' filters on isResolvedState=true within the default window", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(AlertService, "findBy")
+      .mockResolvedValue([buildAlert({ state: "Resolved" })] as never);
+    jest
+      .spyOn(AlertService, "countBy")
+      .mockResolvedValue(new PositiveNumber(1) as never);
+
+    const result: ToolExecutionResult = await QueryAlertsTool.execute(
+      { state: "resolved" },
+      ctx,
+    );
+
+    const query: JSONObject = (findBySpy.mock.calls[0]?.[0] as JSONObject)[
+      "query"
+    ] as JSONObject;
+    expect(query["currentAlertState"]).toEqual({ isResolvedState: true });
+    expect(query["createdAt"]).toBeDefined();
+    expect(result.citationLabel).toBe("Resolved alerts, last 24h (1 found)");
+  });
+
+  test("default state='any' applies no state condition", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(AlertService, "findBy")
+      .mockResolvedValue([buildAlert()] as never);
+    jest
+      .spyOn(AlertService, "countBy")
+      .mockResolvedValue(new PositiveNumber(1) as never);
+
+    const result: ToolExecutionResult = await QueryAlertsTool.execute({}, ctx);
+
+    const query: JSONObject = (findBySpy.mock.calls[0]?.[0] as JSONObject)[
+      "query"
+    ] as JSONObject;
+    expect(query["currentAlertState"]).toBeUndefined();
+    expect(query["createdAt"]).toBeDefined();
+    expect(result.citationLabel).toBe("Alerts, last 24h (1 found)");
+  });
+});
+
+describe("query_alerts — paging", () => {
+  test("reports the total and the shown slice when more rows exist", async () => {
+    jest
+      .spyOn(AlertService, "findBy")
+      .mockResolvedValue([
+        buildAlert({ number: 1 }),
+        buildAlert({ number: 2 }),
+      ] as never);
+    jest
+      .spyOn(AlertService, "countBy")
+      .mockResolvedValue(new PositiveNumber(30) as never);
+
+    const result: ToolExecutionResult = await QueryAlertsTool.execute(
+      { state: "active" },
+      ctx,
+    );
+
+    expect(result.dataForLlm).toContain(
+      "Showing rows 1–2 of 30 total. Pass skip to page further.",
+    );
+    expect(result.citationLabel).toBe("Active alerts (2 of 30)");
+  });
+
+  test("skip reaches the query and is clamped to 500", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(AlertService, "findBy")
+      .mockResolvedValue([] as never);
+    jest
+      .spyOn(AlertService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    await QueryAlertsTool.execute({ skip: 700, limit: 999 }, ctx);
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["skip"]).toBe(500);
+    expect(callArgs["limit"]).toBe(25);
+  });
+
+  test("an empty result is honest: zero rows, no widget, no paging banner", async () => {
+    jest.spyOn(AlertService, "findBy").mockResolvedValue([] as never);
+    jest
+      .spyOn(AlertService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    const result: ToolExecutionResult = await QueryAlertsTool.execute(
+      { state: "active" },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(result.dataForLlm).not.toContain("Showing rows");
+  });
+});
+
+describe("query_alerts — detail mode owners", () => {
+  test("includes owner teams and users in the detail row", async () => {
+    const alertId: ObjectID = ObjectID.generate();
+
+    jest
+      .spyOn(AlertService, "findOneById")
+      .mockResolvedValue(buildAlert() as never);
+
+    const team: Team = new Team();
+    team.name = "SRE";
+    const ownerTeam: AlertOwnerTeam = new AlertOwnerTeam();
+    ownerTeam.team = team;
+    const ownerTeamSpy: jest.SpyInstance = jest
+      .spyOn(AlertOwnerTeamService, "findBy")
+      .mockResolvedValue([ownerTeam] as never);
+
+    const user: User = new User();
+    user.name = new Name("Alice Smith");
+    const ownerUser: AlertOwnerUser = new AlertOwnerUser();
+    ownerUser.user = user;
+    jest
+      .spyOn(AlertOwnerUserService, "findBy")
+      .mockResolvedValue([ownerUser] as never);
+
+    const result: ToolExecutionResult = await QueryAlertsTool.execute(
+      { alertId: alertId.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(result.dataForLlm).toContain("SRE");
+    expect(result.dataForLlm).toContain("Alice Smith");
+
+    // The owner lookup is keyed by an untrusted id, so it must be tenant-pinned.
+    const ownerQuery: JSONObject = (
+      ownerTeamSpy.mock.calls[0]?.[0] as JSONObject
+    )["query"] as JSONObject;
+    expect(ownerQuery["projectId"]).toBe(ctx.projectId);
+
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.AlertView,
+      params: { alertId: alertId.toString() },
+    });
+    expect(result.widget).toBeDefined();
+  });
+
+  test("a missing alert is honest: zero rows and no owner lookups", async () => {
+    jest.spyOn(AlertService, "findOneById").mockResolvedValue(null as never);
+    const ownerTeamSpy: jest.SpyInstance = jest
+      .spyOn(AlertOwnerTeamService, "findBy")
+      .mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryAlertsTool.execute(
+      { alertId: ObjectID.generate().toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(ownerTeamSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("query_monitors — problemsOnly filter", () => {
+  test("problemsOnly=true filters on isOperationalState=false at the DB level", async () => {
+    const downStatus: MonitorStatus = buildMonitorStatus({
+      name: "Offline",
+      priority: 3,
+      operational: false,
+      color: "#ff0000",
+    });
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([
+        buildMonitor({ name: "Payments API", status: downStatus }),
+      ] as never);
+    const countBySpy: jest.SpyInstance = jest
+      .spyOn(MonitorService, "countBy")
+      .mockResolvedValue(new PositiveNumber(1) as never);
+
+    const result: ToolExecutionResult = await QueryMonitorsTool.execute(
+      { problemsOnly: true },
+      ctx,
+    );
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["query"]).toEqual({
+      currentMonitorStatus: { isOperationalState: false },
+    });
+    expect(callArgs["props"]).toBe(ctx.props);
+
+    const countArgs: JSONObject = countBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(countArgs["query"]).toBe(callArgs["query"]);
+
+    expect(result.rowCount).toBe(1);
+    expect(result.citationLabel).toBe("Monitors with problems (1 found)");
+    // The row carries the status name and its color for rendering.
+    expect(result.dataForLlm).toContain("Offline");
+    expect(result.dataForLlm).toContain("#ff0000");
+    expect(result.widget).toBeDefined();
+  });
+});
+
+describe("query_monitors — monitorStatusName filter", () => {
+  test("resolves the status name case-insensitively and filters by its id", async () => {
+    const offlineId: ObjectID = ObjectID.generate();
+    jest.spyOn(MonitorStatusService, "findBy").mockResolvedValue([
+      buildMonitorStatus({
+        name: "Operational",
+        priority: 1,
+        operational: true,
+      }),
+      buildMonitorStatus({ name: "Degraded", priority: 2, operational: false }),
+      buildMonitorStatus({
+        id: offlineId,
+        name: "Offline",
+        priority: 3,
+        operational: false,
+      }),
+    ] as never);
+
+    const anySpy: jest.SpyInstance = jest.spyOn(QueryHelper, "any");
+
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([] as never);
+    jest
+      .spyOn(MonitorService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    await QueryMonitorsTool.execute({ monitorStatusName: "OFFLINE" }, ctx);
+
+    // The matched status id — and only that id — reaches the monitor query.
+    expect(anySpy).toHaveBeenCalledWith([offlineId]);
+    const query: JSONObject = (findBySpy.mock.calls[0]?.[0] as JSONObject)[
+      "query"
+    ] as JSONObject;
+    expect(query["currentMonitorStatusId"]).toBe(anySpy.mock.results[0]?.value);
+  });
+
+  test("an unknown status name fails loudly with the real status names", async () => {
+    jest.spyOn(MonitorStatusService, "findBy").mockResolvedValue([
+      buildMonitorStatus({
+        name: "Operational",
+        priority: 1,
+        operational: true,
+      }),
+      buildMonitorStatus({
+        name: "Offline",
+        priority: 3,
+        operational: false,
+      }),
+    ] as never);
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryMonitorsTool.execute(
+      { monitorStatusName: "Bogus" },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(result.dataForLlm).toContain('No monitor status matches "Bogus"');
+    expect(result.dataForLlm).toContain("Operational");
+    expect(result.dataForLlm).toContain("Offline");
+    expect(findBySpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("query_monitors — ordering and paging", () => {
+  test("non-operational monitors come first, worst status first, then name", async () => {
+    const up: MonitorStatus = buildMonitorStatus({
+      name: "Operational",
+      priority: 1,
+      operational: true,
+    });
+    const degraded: MonitorStatus = buildMonitorStatus({
+      name: "Degraded",
+      priority: 2,
+      operational: false,
+    });
+    const offline: MonitorStatus = buildMonitorStatus({
+      name: "Offline",
+      priority: 3,
+      operational: false,
+    });
+
+    // DB returns name-ascending; the page must be reordered problems-first.
+    jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([
+        buildMonitor({ name: "Alpha", status: up }),
+        buildMonitor({ name: "Mid", status: degraded }),
+        buildMonitor({ name: "Zulu", status: offline }),
+      ] as never);
+    jest
+      .spyOn(MonitorService, "countBy")
+      .mockResolvedValue(new PositiveNumber(3) as never);
+
+    const result: ToolExecutionResult = await QueryMonitorsTool.execute(
+      {},
+      ctx,
+    );
+
+    const zulu: number = result.dataForLlm.indexOf("Zulu");
+    const mid: number = result.dataForLlm.indexOf("Mid");
+    const alpha: number = result.dataForLlm.indexOf("Alpha");
+    expect(zulu).toBeGreaterThanOrEqual(0);
+    expect(zulu).toBeLessThan(mid);
+    expect(mid).toBeLessThan(alpha);
+  });
+
+  test("reports the total and clamps skip/limit", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(MonitorService, "findBy")
+      .mockResolvedValue([
+        buildMonitor({
+          name: "Solo",
+          status: buildMonitorStatus({
+            name: "Operational",
+            priority: 1,
+            operational: true,
+          }),
+        }),
+      ] as never);
+    jest
+      .spyOn(MonitorService, "countBy")
+      .mockResolvedValue(new PositiveNumber(120) as never);
+
+    const result: ToolExecutionResult = await QueryMonitorsTool.execute(
+      { skip: 5000, limit: 5000 },
+      ctx,
+    );
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["skip"]).toBe(500);
+    expect(callArgs["limit"]).toBe(50);
+    expect(result.dataForLlm).toContain(
+      "Showing rows 501–501 of 120 total. Pass skip to page further.",
+    );
+    expect(result.citationLabel).toBe("Monitors (1 of 120)");
+  });
+
+  test("an empty list is honest: zero rows and no widget", async () => {
+    jest.spyOn(MonitorService, "findBy").mockResolvedValue([] as never);
+    jest
+      .spyOn(MonitorService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    const result: ToolExecutionResult = await QueryMonitorsTool.execute(
+      { problemsOnly: true },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(result.dataForLlm).not.toContain("Showing rows");
+  });
+});
+
+describe("query_monitors — detail mode owners", () => {
+  test("includes owner teams and users next to the status timeline", async () => {
+    const monitorId: ObjectID = ObjectID.generate();
+
+    jest.spyOn(MonitorService, "findOneById").mockResolvedValue(
+      buildMonitor({
+        name: "Payments API",
+        status: buildMonitorStatus({
+          name: "Offline",
+          priority: 3,
+          operational: false,
+          color: "#ff0000",
+        }),
+      }) as never,
+    );
+
+    const timelineEntry: MonitorStatusTimeline = new MonitorStatusTimeline();
+    timelineEntry.createdAt = new Date("2026-08-13T10:00:00Z");
+    timelineEntry.monitorStatus = buildMonitorStatus({
+      name: "Offline",
+      priority: 3,
+      operational: false,
+    });
+    jest
+      .spyOn(MonitorStatusTimelineService, "findBy")
+      .mockResolvedValue([timelineEntry] as never);
+
+    const team: Team = new Team();
+    team.name = "Platform";
+    const ownerTeam: MonitorOwnerTeam = new MonitorOwnerTeam();
+    ownerTeam.team = team;
+    const ownerTeamSpy: jest.SpyInstance = jest
+      .spyOn(MonitorOwnerTeamService, "findBy")
+      .mockResolvedValue([ownerTeam] as never);
+
+    const user: User = new User();
+    user.name = new Name("Bob Jones");
+    const ownerUser: MonitorOwnerUser = new MonitorOwnerUser();
+    ownerUser.user = user;
+    jest
+      .spyOn(MonitorOwnerUserService, "findBy")
+      .mockResolvedValue([ownerUser] as never);
+
+    const result: ToolExecutionResult = await QueryMonitorsTool.execute(
+      { monitorId: monitorId.toString() },
+      ctx,
+    );
+
+    // monitor row + 1 timeline row
+    expect(result.rowCount).toBe(2);
+    expect(result.dataForLlm).toContain("Platform");
+    expect(result.dataForLlm).toContain("Bob Jones");
+    expect(result.dataForLlm).toContain("Offline");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.MonitorView,
+      params: { monitorId: monitorId.toString() },
+    });
+    expect(result.widget).toBeDefined();
+
+    // The owner lookup is keyed by an untrusted id, so it must be tenant-pinned.
+    const ownerQuery: JSONObject = (
+      ownerTeamSpy.mock.calls[0]?.[0] as JSONObject
+    )["query"] as JSONObject;
+    expect(ownerQuery["projectId"]).toBe(ctx.projectId);
+  });
+});
+
+describe("query_alerts / query_monitors — permissions", () => {
+  test("required permissions derive from the model read ACLs", () => {
+    expect(QueryAlertsTool.requiredPermissions.length).toBeGreaterThan(0);
+    expect(QueryMonitorsTool.requiredPermissions.length).toBeGreaterThan(0);
+  });
+});

--- a/Common/Tests/Server/Utils/AI/ChatAgentRunner.test.ts
+++ b/Common/Tests/Server/Utils/AI/ChatAgentRunner.test.ts
@@ -1,0 +1,726 @@
+import ChatAgentRunner, {
+  ChatTurnRequest,
+  applyHistoryTokenBudget,
+  buildEvidenceDigest,
+  buildReplayedHistoryMessage,
+  sanitizeGeneratedTitle,
+  summarizeShownContent,
+  HistoryBudgetResult,
+  ReplayedHistoryMessage,
+} from "../../../../Server/Utils/AI/Chat/ChatAgentRunner";
+import AIService, {
+  AILogRequest,
+  AILogResponse,
+} from "../../../../Server/Services/AIService";
+import AIConversationMessageService from "../../../../Server/Services/AIConversationMessageService";
+import AIConversationService from "../../../../Server/Services/AIConversationService";
+import AIRunEventService from "../../../../Server/Services/AIRunEventService";
+import AIRunService from "../../../../Server/Services/AIRunService";
+import AIConversation from "../../../../Models/DatabaseModels/AIConversation";
+import AIConversationMessage from "../../../../Models/DatabaseModels/AIConversationMessage";
+import AIRun from "../../../../Models/DatabaseModels/AIRun";
+import AIChatMessageRole from "../../../../Types/AI/AIChatMessageRole";
+import AIChatMessageStatus from "../../../../Types/AI/AIChatMessageStatus";
+import AIChatPageContextType, {
+  AIChatPageContext,
+} from "../../../../Types/AI/AIChatPageContext";
+import AIChatPermissionMode from "../../../../Types/AI/AIChatPermissionMode";
+import AIRunStatus from "../../../../Types/AI/AIRunStatus";
+import {
+  AIChatCitation,
+  AIChatToolAction,
+  AIChatToolActionStatus,
+  AIChatWidget,
+  AIChatWidgetType,
+} from "../../../../Types/AI/AIChatTypes";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * Locks in the runner's history-replay, cancellation, page-context and title
+ * behavior: evidence digests keep prior queries referable, the token budget
+ * drops oldest history first (with a visible note), a cancelled run is
+ * abandoned without overwriting the finalized message, the conversation's
+ * subject survives later turns, and titles come from a small sanitized LLM
+ * call that can never hurt the turn.
+ */
+
+// AIChatMessageStatus.Cancelled lands with the parallel cancel-endpoint change.
+const CANCELLED_STATUS: AIChatMessageStatus =
+  "Cancelled" as AIChatMessageStatus;
+
+function buildCitation(data?: {
+  id?: string;
+  toolName?: string;
+  queryArguments?: JSONObject;
+  rowCount?: number;
+  label?: string;
+}): AIChatCitation {
+  return {
+    id: data?.id ?? "C1",
+    toolName: data?.toolName ?? "query_incidents",
+    queryArguments: data?.queryArguments ?? { incidentId: "abc" },
+    rowCount: data?.rowCount ?? 5,
+    label: data?.label ?? "Incidents, last 168h",
+  };
+}
+
+function buildWidget(title: string): AIChatWidget {
+  return {
+    id: "W1",
+    type: AIChatWidgetType.Table,
+    title: title,
+    data: {},
+  };
+}
+
+function buildToolAction(title: string): AIChatToolAction {
+  return {
+    id: "t1",
+    toolName: "create_incident",
+    title: title,
+    arguments: {},
+    isMutation: true,
+    requiresApproval: true,
+    status: AIChatToolActionStatus.Executed,
+  };
+}
+
+function buildHistoryMessage(data: {
+  role: AIChatMessageRole;
+  content?: string;
+  status?: AIChatMessageStatus;
+  citations?: Array<AIChatCitation>;
+  widgets?: Array<AIChatWidget>;
+  toolActions?: Array<AIChatToolAction>;
+}): AIConversationMessage {
+  const message: AIConversationMessage = new AIConversationMessage();
+  message.role = data.role;
+  message.contentInMarkdown = data.content ?? "";
+  message.status = data.status ?? AIChatMessageStatus.Completed;
+  if (data.citations) {
+    message.citations = data.citations;
+  }
+  if (data.widgets) {
+    message.widgets = data.widgets;
+  }
+  if (data.toolActions) {
+    message.toolActions = data.toolActions;
+  }
+  return message;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("buildEvidenceDigest", () => {
+  test("formats each citation as id tool(args) -> rows (label)", () => {
+    const digest: string = buildEvidenceDigest([buildCitation()]);
+    expect(digest).toBe(
+      '[Evidence from this turn: C1 query_incidents({"incidentId":"abc"}) -> 5 rows (Incidents, last 168h)]',
+    );
+  });
+
+  test("returns empty string when there are no citations", () => {
+    expect(buildEvidenceDigest([])).toBe("");
+  });
+
+  test("clamps long query arguments to ~200 chars", () => {
+    const digest: string = buildEvidenceDigest([
+      buildCitation({
+        queryArguments: { filter: "x".repeat(500) },
+      }),
+    ]);
+
+    // 200 chars of JSON + the ellipsis, not the full 500-char filter.
+    expect(digest).toContain("…");
+    expect(digest.length).toBeLessThan(300);
+  });
+
+  test("caps the digest at ~1500 chars and reports omitted queries", () => {
+    const citations: Array<AIChatCitation> = [];
+    for (let i: number = 0; i < 30; i++) {
+      citations.push(
+        buildCitation({
+          id: `C${i + 1}`,
+          label: `Result set ${i + 1}: ${"y".repeat(120)}`,
+        }),
+      );
+    }
+
+    const digest: string = buildEvidenceDigest(citations);
+
+    expect(digest.length).toBeLessThanOrEqual(1560);
+    expect(digest).toMatch(/\.\.\. and \d+ more queries]$/);
+  });
+});
+
+describe("summarizeShownContent", () => {
+  test("prefers widget titles", () => {
+    const summary: string = summarizeShownContent(
+      [buildWidget("Error volume by service"), buildWidget("p95 latency")],
+      [buildToolAction("Create incident: Checkout down")],
+    );
+    expect(summary).toBe("Error volume by service, p95 latency");
+  });
+
+  test("falls back to tool action titles when there are no widgets", () => {
+    const summary: string = summarizeShownContent(
+      [],
+      [buildToolAction("Create incident: Checkout down")],
+    );
+    expect(summary).toBe("Create incident: Checkout down");
+  });
+
+  test("returns empty string when there is nothing to summarize", () => {
+    expect(summarizeShownContent([], [])).toBe("");
+  });
+});
+
+describe("applyHistoryTokenBudget", () => {
+  function entry(content: string): ReplayedHistoryMessage {
+    return { role: "user", content };
+  }
+
+  test("keeps everything when within budget", () => {
+    const entries: Array<ReplayedHistoryMessage> = [
+      entry("a".repeat(40)),
+      entry("b".repeat(40)),
+    ];
+
+    const result: HistoryBudgetResult = applyHistoryTokenBudget(entries, 100);
+
+    expect(result.kept).toHaveLength(2);
+    expect(result.droppedCount).toBe(0);
+  });
+
+  test("drops oldest entries first and reports how many", () => {
+    // 100 tokens each (400 chars / 4); budget fits only the two newest.
+    const entries: Array<ReplayedHistoryMessage> = [
+      entry(`old ${"a".repeat(396)}`),
+      entry(`mid ${"b".repeat(396)}`),
+      entry(`new ${"c".repeat(396)}`),
+    ];
+
+    const result: HistoryBudgetResult = applyHistoryTokenBudget(entries, 250);
+
+    expect(result.droppedCount).toBe(1);
+    expect(result.kept).toHaveLength(2);
+    expect(result.kept[0]?.content).toContain("mid");
+    expect(result.kept[1]?.content).toContain("new");
+  });
+
+  test("always keeps the newest entry even when it alone exceeds the budget", () => {
+    const entries: Array<ReplayedHistoryMessage> = [entry("z".repeat(4000))];
+
+    const result: HistoryBudgetResult = applyHistoryTokenBudget(entries, 10);
+
+    expect(result.kept).toHaveLength(1);
+    expect(result.droppedCount).toBe(0);
+  });
+});
+
+describe("sanitizeGeneratedTitle", () => {
+  test("strips wrapping quotes and trailing punctuation", () => {
+    expect(sanitizeGeneratedTitle('"Checkout Latency Investigation."\n')).toBe(
+      "Checkout Latency Investigation",
+    );
+  });
+
+  test("keeps only the first non-empty line and drops Title: prefixes", () => {
+    expect(
+      sanitizeGeneratedTitle(
+        '\nTitle: "Payment failures spike"\nHere is why I chose it...',
+      ),
+    ).toBe("Payment failures spike");
+  });
+
+  test("clamps to 90 chars", () => {
+    const title: string = sanitizeGeneratedTitle("word ".repeat(50));
+    expect(title.length).toBeLessThanOrEqual(90);
+  });
+
+  test("returns empty string when nothing usable remains", () => {
+    expect(sanitizeGeneratedTitle('  "..." \n')).toBe("");
+    expect(sanitizeGeneratedTitle("")).toBe("");
+  });
+});
+
+describe("buildReplayedHistoryMessage", () => {
+  test("replays user messages verbatim", () => {
+    const replayed: ReplayedHistoryMessage | undefined =
+      buildReplayedHistoryMessage(
+        buildHistoryMessage({
+          role: AIChatMessageRole.User,
+          content: "What broke?",
+        }),
+      );
+
+    expect(replayed).toEqual({ role: "user", content: "What broke?" });
+  });
+
+  test("strips stale [C#] markers and appends the evidence digest", () => {
+    const replayed: ReplayedHistoryMessage | undefined =
+      buildReplayedHistoryMessage(
+        buildHistoryMessage({
+          role: AIChatMessageRole.Assistant,
+          content: "Errors spiked at 02:38 [C1].",
+          citations: [buildCitation()],
+        }),
+      );
+
+    expect(replayed?.content).toContain("Errors spiked at 02:38.");
+    expect(replayed?.content).not.toContain("[C1]");
+    expect(replayed?.content).toContain(
+      'C1 query_incidents({"incidentId":"abc"}) -> 5 rows (Incidents, last 168h)',
+    );
+  });
+
+  test("replays widget-only answers as a shown-content summary", () => {
+    const replayed: ReplayedHistoryMessage | undefined =
+      buildReplayedHistoryMessage(
+        buildHistoryMessage({
+          role: AIChatMessageRole.Assistant,
+          content: "",
+          citations: [buildCitation()],
+          widgets: [buildWidget("Error volume by service")],
+        }),
+      );
+
+    expect(replayed?.content).toContain(
+      "[Showed the user: Error volume by service]",
+    );
+    expect(replayed?.content).toContain("C1 query_incidents(");
+  });
+
+  test("skips in-flight and errored assistant rows but replays cancelled ones", () => {
+    expect(
+      buildReplayedHistoryMessage(
+        buildHistoryMessage({
+          role: AIChatMessageRole.Assistant,
+          content: "still thinking",
+          status: AIChatMessageStatus.InProgress,
+        }),
+      ),
+    ).toBeUndefined();
+
+    expect(
+      buildReplayedHistoryMessage(
+        buildHistoryMessage({
+          role: AIChatMessageRole.Assistant,
+          content: "",
+          status: AIChatMessageStatus.Error,
+        }),
+      ),
+    ).toBeUndefined();
+
+    /*
+     * A cancelled turn's contentInMarkdown is the server's finalizer text,
+     * not assistant prose — it replays as a neutral stop marker so the model
+     * never imitates or apologizes for "Stopped by user.".
+     */
+    const cancelled: ReplayedHistoryMessage | undefined =
+      buildReplayedHistoryMessage(
+        buildHistoryMessage({
+          role: AIChatMessageRole.Assistant,
+          content: "Stopped by user.",
+          status: CANCELLED_STATUS,
+        }),
+      );
+    expect(cancelled?.content).toContain(
+      "[The user stopped this answer before it finished.]",
+    );
+    expect(cancelled?.content).not.toContain("Stopped by user.");
+  });
+
+  test("skips assistant rows with nothing at all to replay", () => {
+    expect(
+      buildReplayedHistoryMessage(
+        buildHistoryMessage({
+          role: AIChatMessageRole.Assistant,
+          content: "",
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * runTurn service-spy tests
+ * ---------------------------------------------------------------------------
+ */
+
+const INCIDENT_ID: string = "0b6ff65a-71a1-40b0-8b9c-6c11f5f6a123";
+
+function buildRequest(data?: {
+  pageContext?: AIChatPageContext | undefined;
+}): ChatTurnRequest {
+  return {
+    projectId: ObjectID.generate(),
+    userId: ObjectID.generate(),
+    conversationId: ObjectID.generate(),
+    assistantMessageId: ObjectID.generate(),
+    aiRunId: ObjectID.generate(),
+    permissionMode: AIChatPermissionMode.ReadOnly,
+    pageContext: data?.pageContext,
+    props: { userId: ObjectID.generate() },
+  };
+}
+
+function buildRun(status: AIRunStatus): AIRun {
+  const run: AIRun = new AIRun();
+  run.status = status;
+  return run;
+}
+
+function chatResponse(content: string, stopReason?: string): AILogResponse {
+  return {
+    content: content,
+    toolCalls: undefined,
+    stopReason: stopReason,
+    llmLog: { totalTokens: 10, costInUSDCents: 1 },
+  } as unknown as AILogResponse;
+}
+
+// Let fire-and-forget chains (title generation) settle.
+async function flushAsync(): Promise<void> {
+  for (let i: number = 0; i < 10; i++) {
+    await new Promise<void>((resolve: () => void) => {
+      setTimeout(resolve, 0);
+    });
+  }
+}
+
+interface RunnerSpies {
+  executeWithLogging: jest.SpyInstance;
+  conversationFindOneById: jest.SpyInstance;
+  conversationUpdateOneById: jest.SpyInstance;
+  messageFindBy: jest.SpyInstance;
+  messageCountBy: jest.SpyInstance;
+  messageFindOneBy: jest.SpyInstance;
+  messageUpdateOneBy: jest.SpyInstance;
+  runFindOneById: jest.SpyInstance;
+  runUpdateOneBy: jest.SpyInstance;
+}
+
+function installRunnerSpies(data: {
+  runStatus?: AIRunStatus;
+  history?: Array<AIConversationMessage>;
+  historyCount?: number;
+  titleCount?: number;
+  conversation?: AIConversation;
+}): RunnerSpies {
+  jest.spyOn(AIRunEventService, "create").mockResolvedValue({} as never);
+  jest.spyOn(AIRunService, "updateOneById").mockResolvedValue(1 as never);
+
+  const runFindOneById: jest.SpyInstance = jest
+    .spyOn(AIRunService, "findOneById")
+    .mockResolvedValue(
+      buildRun(data.runStatus ?? AIRunStatus.Running) as never,
+    );
+
+  const runUpdateOneBy: jest.SpyInstance = jest
+    .spyOn(AIRunService, "updateOneBy")
+    .mockResolvedValue(1 as never);
+
+  const messageFindBy: jest.SpyInstance = jest
+    .spyOn(AIConversationMessageService, "findBy")
+    .mockResolvedValue((data.history ?? []) as never);
+
+  const messageCountBy: jest.SpyInstance = jest
+    .spyOn(AIConversationMessageService, "countBy")
+    .mockResolvedValueOnce(
+      new PositiveNumber(
+        data.historyCount ?? (data.history ?? []).length,
+      ) as never,
+    )
+    .mockResolvedValue(
+      new PositiveNumber(
+        data.titleCount ?? data.historyCount ?? (data.history ?? []).length,
+      ) as never,
+    );
+
+  const messageFindOneBy: jest.SpyInstance = jest
+    .spyOn(AIConversationMessageService, "findOneBy")
+    .mockResolvedValue(null as never);
+
+  const messageUpdateOneBy: jest.SpyInstance = jest
+    .spyOn(AIConversationMessageService, "updateOneBy")
+    .mockResolvedValue(1 as never);
+
+  const conversationFindOneById: jest.SpyInstance = jest
+    .spyOn(AIConversationService, "findOneById")
+    .mockResolvedValue((data.conversation ?? new AIConversation()) as never);
+
+  const conversationUpdateOneById: jest.SpyInstance = jest
+    .spyOn(AIConversationService, "updateOneById")
+    .mockResolvedValue(1 as never);
+
+  const executeWithLogging: jest.SpyInstance = jest
+    .spyOn(AIService, "executeWithLogging")
+    .mockResolvedValue(chatResponse("All good.") as never);
+
+  return {
+    executeWithLogging,
+    conversationFindOneById,
+    conversationUpdateOneById,
+    messageFindBy,
+    messageCountBy,
+    messageFindOneBy,
+    messageUpdateOneBy,
+    runFindOneById,
+    runUpdateOneBy,
+  };
+}
+
+function findCallWithDataKey(
+  spy: jest.SpyInstance,
+  key: string,
+): JSONObject | undefined {
+  for (const call of spy.mock.calls) {
+    const arg: { data?: JSONObject } | undefined = call[0] as
+      | { data?: JSONObject }
+      | undefined;
+    if (arg?.data && (arg.data as JSONObject)[key] !== undefined) {
+      return arg.data as JSONObject;
+    }
+  }
+  return undefined;
+}
+
+describe("ChatAgentRunner.runTurn — cooperative cancellation", () => {
+  test("abandons a cancelled run without calling the LLM or overwriting the message", async () => {
+    const spies: RunnerSpies = installRunnerSpies({
+      runStatus: AIRunStatus.Cancelled,
+    });
+
+    await ChatAgentRunner.runTurn(buildRequest());
+    await flushAsync();
+
+    expect(spies.executeWithLogging).not.toHaveBeenCalled();
+    // The cancel endpoint owns the message and run: no finalizing writes here.
+    expect(spies.messageUpdateOneBy).not.toHaveBeenCalled();
+    expect(spies.runUpdateOneBy).not.toHaveBeenCalled();
+    expect(spies.conversationUpdateOneById).not.toHaveBeenCalled();
+  });
+});
+
+describe("ChatAgentRunner.runTurn — page context persistence", () => {
+  test("persists a fresh page context on the conversation and folds it into the prompt", async () => {
+    const pageContext: AIChatPageContext = {
+      type: AIChatPageContextType.Incident,
+      entityId: INCIDENT_ID,
+      entityTitle: "Checkout down",
+    };
+
+    const spies: RunnerSpies = installRunnerSpies({ titleCount: 5 });
+
+    await ChatAgentRunner.runTurn(buildRequest({ pageContext }));
+    await flushAsync();
+
+    // Persisted as the conversation's subject (it had none).
+    const persisted: JSONObject | undefined = findCallWithDataKey(
+      spies.conversationUpdateOneById,
+      "pageContext",
+    );
+    expect(persisted).toBeDefined();
+    expect(persisted?.["pageContext"]).toEqual(pageContext);
+
+    // Folded into the system prompt.
+    const llmRequest: AILogRequest = spies.executeWithLogging.mock
+      .calls[0]?.[0] as AILogRequest;
+    expect(llmRequest.messages[0]?.content).toContain(
+      `incidentId="${INCIDENT_ID}"`,
+    );
+    expect(llmRequest.messages[0]?.content).toContain('titled "Checkout down"');
+  });
+
+  test("falls back to the persisted subject when the turn carries no page context", async () => {
+    const conversation: AIConversation = new AIConversation();
+    conversation.pageContext = {
+      type: AIChatPageContextType.Incident,
+      entityId: INCIDENT_ID,
+      entityTitle: "DB outage",
+    };
+
+    const spies: RunnerSpies = installRunnerSpies({
+      conversation,
+      titleCount: 5,
+    });
+
+    await ChatAgentRunner.runTurn(buildRequest());
+    await flushAsync();
+
+    const llmRequest: AILogRequest = spies.executeWithLogging.mock
+      .calls[0]?.[0] as AILogRequest;
+    expect(llmRequest.messages[0]?.content).toContain(
+      `incidentId="${INCIDENT_ID}"`,
+    );
+    expect(llmRequest.messages[0]?.content).toContain('titled "DB outage"');
+
+    // Nothing re-persisted: the subject was already pinned.
+    expect(
+      findCallWithDataKey(spies.conversationUpdateOneById, "pageContext"),
+    ).toBeUndefined();
+  });
+});
+
+describe("ChatAgentRunner.runTurn — history replay", () => {
+  test("replays digests, widget-only summaries and an omitted-history note", async () => {
+    // Newest first, exactly as the Descending findBy returns them.
+    const history: Array<AIConversationMessage> = [
+      buildHistoryMessage({
+        role: AIChatMessageRole.User,
+        content: "What happened?",
+      }),
+      buildHistoryMessage({
+        role: AIChatMessageRole.Assistant,
+        content: "",
+        widgets: [buildWidget("Error volume by service")],
+      }),
+      buildHistoryMessage({
+        role: AIChatMessageRole.Assistant,
+        content: "Errors spiked at 02:38 [C1].",
+        citations: [buildCitation()],
+      }),
+    ];
+
+    const spies: RunnerSpies = installRunnerSpies({
+      history,
+      historyCount: 23,
+      titleCount: 23,
+    });
+
+    await ChatAgentRunner.runTurn(buildRequest());
+    await flushAsync();
+
+    const llmRequest: AILogRequest = spies.executeWithLogging.mock
+      .calls[0]?.[0] as AILogRequest;
+    const contents: Array<string> = llmRequest.messages.map(
+      (message: { content: string }) => {
+        return message.content;
+      },
+    );
+
+    // 20 of the 23 rows never made it past the fetch cap.
+    expect(contents[1]).toBe(
+      "[Note: 20 earlier messages in this conversation were omitted for length.]",
+    );
+
+    // Prior evidence is replayed as a digest, with stale markers stripped.
+    expect(contents[2]).toContain("Errors spiked at 02:38.");
+    expect(contents[2]).not.toContain("[C1]");
+    expect(contents[2]).toContain(
+      'C1 query_incidents({"incidentId":"abc"}) -> 5 rows (Incidents, last 168h)',
+    );
+
+    // The widget-only answer no longer vanishes.
+    expect(contents[3]).toContain("[Showed the user: Error volume by service]");
+
+    expect(contents[4]).toBe("What happened?");
+
+    // A long conversation gets no generated title.
+    expect(spies.executeWithLogging).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ChatAgentRunner.runTurn — output truncation notice", () => {
+  test("appends a visible truncation marker when stopReason is length", async () => {
+    const spies: RunnerSpies = installRunnerSpies({ titleCount: 5 });
+    spies.executeWithLogging.mockResolvedValue(
+      chatResponse("Partial answer", "length") as never,
+    );
+
+    await ChatAgentRunner.runTurn(buildRequest());
+    await flushAsync();
+
+    const finalized: JSONObject | undefined = findCallWithDataKey(
+      spies.messageUpdateOneBy,
+      "contentInMarkdown",
+    );
+    expect(finalized?.["contentInMarkdown"]).toBe(
+      "Partial answer\n\n_[Answer truncated by the output token limit.]_",
+    );
+  });
+});
+
+describe("ChatAgentRunner.runTurn — conversation titles", () => {
+  test("names the conversation after the first exchange via a small sanitized LLM call", async () => {
+    const firstUserMessage: AIConversationMessage = buildHistoryMessage({
+      role: AIChatMessageRole.User,
+      content: "Why is checkout failing?",
+    });
+
+    const spies: RunnerSpies = installRunnerSpies({
+      history: [firstUserMessage],
+      historyCount: 2,
+      titleCount: 2,
+    });
+
+    spies.messageFindOneBy.mockResolvedValue(firstUserMessage as never);
+    spies.executeWithLogging
+      .mockResolvedValueOnce(
+        chatResponse("Checkout is failing because of X.") as never,
+      )
+      .mockResolvedValueOnce(
+        chatResponse('"Checkout Failure Investigation."\n') as never,
+      );
+
+    await ChatAgentRunner.runTurn(buildRequest());
+    await flushAsync();
+
+    expect(spies.executeWithLogging).toHaveBeenCalledTimes(2);
+
+    const titleRequest: AILogRequest = spies.executeWithLogging.mock
+      .calls[1]?.[0] as AILogRequest;
+    expect(titleRequest.feature).toBe("Chat Title");
+    expect(titleRequest.maxTokens).toBe(100);
+    expect(titleRequest.storeContentPreviews).toBe(false);
+    expect(
+      titleRequest.messages.find((message: { content: string }) => {
+        return message.content.includes("Why is checkout failing?");
+      }),
+    ).toBeDefined();
+
+    const titleUpdate: JSONObject | undefined = findCallWithDataKey(
+      spies.conversationUpdateOneById,
+      "title",
+    );
+    expect(titleUpdate?.["title"]).toBe("Checkout Failure Investigation");
+  });
+
+  test("a title failure never affects the finished turn", async () => {
+    const firstUserMessage: AIConversationMessage = buildHistoryMessage({
+      role: AIChatMessageRole.User,
+      content: "Why is checkout failing?",
+    });
+
+    const spies: RunnerSpies = installRunnerSpies({
+      history: [firstUserMessage],
+      historyCount: 2,
+      titleCount: 2,
+    });
+
+    spies.messageFindOneBy.mockResolvedValue(firstUserMessage as never);
+    spies.executeWithLogging
+      .mockResolvedValueOnce(chatResponse("Answer.") as never)
+      .mockRejectedValueOnce(new Error("provider exploded") as never);
+
+    await ChatAgentRunner.runTurn(buildRequest());
+    await flushAsync();
+
+    // The turn itself finalized normally (message completed, run completed).
+    const finalized: JSONObject | undefined = findCallWithDataKey(
+      spies.messageUpdateOneBy,
+      "contentInMarkdown",
+    );
+    expect(finalized?.["contentInMarkdown"]).toBe("Answer.");
+    expect(
+      findCallWithDataKey(spies.conversationUpdateOneById, "title"),
+    ).toBeUndefined();
+  });
+});

--- a/Common/Tests/Server/Utils/AI/IncidentToolsFilters.test.ts
+++ b/Common/Tests/Server/Utils/AI/IncidentToolsFilters.test.ts
@@ -1,0 +1,315 @@
+import { QueryIncidentsTool } from "../../../../Server/Utils/AI/Toolbox/IncidentTools";
+import {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../Server/Utils/AI/Toolbox/ToolTypes";
+import IncidentOwnerTeamService from "../../../../Server/Services/IncidentOwnerTeamService";
+import IncidentOwnerUserService from "../../../../Server/Services/IncidentOwnerUserService";
+import IncidentService from "../../../../Server/Services/IncidentService";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import IncidentOwnerTeam from "../../../../Models/DatabaseModels/IncidentOwnerTeam";
+import IncidentOwnerUser from "../../../../Models/DatabaseModels/IncidentOwnerUser";
+import IncidentSeverity from "../../../../Models/DatabaseModels/IncidentSeverity";
+import IncidentState from "../../../../Models/DatabaseModels/IncidentState";
+import Team from "../../../../Models/DatabaseModels/Team";
+import User from "../../../../Models/DatabaseModels/User";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../../Types/JSON";
+import Name from "../../../../Types/Name";
+import ObjectID from "../../../../Types/ObjectID";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * query_incidents grew a state filter, skip pagination and owner details.
+ * These tests lock in the load-bearing behavior: state="active" filters on
+ * the canonical isResolvedState flag WITHOUT a createdAt window (so an open
+ * incident from months ago still answers "what's active right now?"), skip
+ * pagination reports the true total, and detail mode surfaces owner teams
+ * and users scoped to the ctx tenant.
+ */
+
+const ctx: ToolContext = {
+  projectId: ObjectID.generate(),
+  props: { isRoot: true },
+};
+
+const INCIDENT_ID: ObjectID = ObjectID.generate();
+
+function buildIncident(data?: { number?: number; title?: string }): Incident {
+  const incident: Incident = new Incident();
+  incident._id = INCIDENT_ID.toString();
+  incident.incidentNumber = data?.number ?? 42;
+  incident.title = data?.title ?? "Checkout is down";
+
+  const state: IncidentState = new IncidentState();
+  state.name = "Investigating";
+  incident.currentIncidentState = state;
+
+  const severity: IncidentSeverity = new IncidentSeverity();
+  severity.name = "Critical";
+  incident.incidentSeverity = severity;
+
+  return incident;
+}
+
+function mockList(data: { incidents: Array<Incident>; total: number }): {
+  findBySpy: jest.SpyInstance;
+  countBySpy: jest.SpyInstance;
+} {
+  return {
+    countBySpy: jest
+      .spyOn(IncidentService, "countBy")
+      .mockResolvedValue(new PositiveNumber(data.total) as never),
+    findBySpy: jest
+      .spyOn(IncidentService, "findBy")
+      .mockResolvedValue(data.incidents as never),
+  };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("query_incidents — state filter", () => {
+  test("state=active filters on isResolvedState=false with NO createdAt window", async () => {
+    const spies: { findBySpy: jest.SpyInstance; countBySpy: jest.SpyInstance } =
+      mockList({ incidents: [buildIncident()], total: 1 });
+
+    const result: ToolExecutionResult = await QueryIncidentsTool.execute(
+      { state: "active" },
+      ctx,
+    );
+
+    const callArgs: JSONObject = spies.findBySpy.mock
+      .calls[0]?.[0] as JSONObject;
+    const query: JSONObject = callArgs["query"] as JSONObject;
+
+    expect(query["currentIncidentState"]).toEqual({ isResolvedState: false });
+    // An open incident created months ago must still be found.
+    expect(query["createdAt"]).toBeUndefined();
+
+    // countBy sees the same query so the reported total matches the filter.
+    const countArgs: JSONObject = spies.countBySpy.mock
+      .calls[0]?.[0] as JSONObject;
+    expect(countArgs["query"]).toEqual(query);
+
+    expect(result.citationLabel).toBe("Active incidents (1 total)");
+    expect(result.rowCount).toBe(1);
+    expect(result.widget).toBeDefined();
+  });
+
+  test("state=active honors an explicitly passed time window", async () => {
+    const spies: { findBySpy: jest.SpyInstance } = mockList({
+      incidents: [],
+      total: 0,
+    });
+
+    await QueryIncidentsTool.execute(
+      { state: "active", createdWithinHours: 24 },
+      ctx,
+    );
+
+    const callArgs: JSONObject = spies.findBySpy.mock
+      .calls[0]?.[0] as JSONObject;
+    const query: JSONObject = callArgs["query"] as JSONObject;
+
+    expect(query["currentIncidentState"]).toEqual({ isResolvedState: false });
+    expect(query["createdAt"]).toBeDefined();
+  });
+
+  test("state=resolved filters on isResolvedState=true within the window", async () => {
+    const spies: { findBySpy: jest.SpyInstance } = mockList({
+      incidents: [],
+      total: 0,
+    });
+
+    const result: ToolExecutionResult = await QueryIncidentsTool.execute(
+      { state: "resolved" },
+      ctx,
+    );
+
+    const callArgs: JSONObject = spies.findBySpy.mock
+      .calls[0]?.[0] as JSONObject;
+    const query: JSONObject = callArgs["query"] as JSONObject;
+
+    expect(query["currentIncidentState"]).toEqual({ isResolvedState: true });
+    expect(query["createdAt"]).toBeDefined();
+    expect(result.citationLabel).toBe(
+      "Resolved incidents, last 168h (0 total)",
+    );
+  });
+
+  test("default (no state) keeps the old behavior: window only, no state filter", async () => {
+    const spies: { findBySpy: jest.SpyInstance } = mockList({
+      incidents: [buildIncident()],
+      total: 1,
+    });
+
+    const result: ToolExecutionResult = await QueryIncidentsTool.execute(
+      {},
+      ctx,
+    );
+
+    const callArgs: JSONObject = spies.findBySpy.mock
+      .calls[0]?.[0] as JSONObject;
+    const query: JSONObject = callArgs["query"] as JSONObject;
+
+    expect(query["currentIncidentState"]).toBeUndefined();
+    expect(query["createdAt"]).toBeDefined();
+    expect(callArgs["props"]).toBe(ctx.props);
+    expect(callArgs["limit"]).toBe(10);
+    expect(callArgs["skip"]).toBe(0);
+    expect(result.citationLabel).toBe("Incidents, last 168h (1 total)");
+  });
+
+  test("an invalid state value is rejected", async () => {
+    await expect(
+      QueryIncidentsTool.execute({ state: "open" }, ctx),
+    ).rejects.toThrow(BadDataException);
+  });
+});
+
+describe("query_incidents — skip pagination", () => {
+  test("reports the slice and total when more rows exist", async () => {
+    const incidents: Array<Incident> = [
+      buildIncident({ number: 11 }),
+      buildIncident({ number: 12 }),
+    ];
+    const spies: { findBySpy: jest.SpyInstance } = mockList({
+      incidents: incidents,
+      total: 40,
+    });
+
+    const result: ToolExecutionResult = await QueryIncidentsTool.execute(
+      { skip: 10 },
+      ctx,
+    );
+
+    const callArgs: JSONObject = spies.findBySpy.mock
+      .calls[0]?.[0] as JSONObject;
+    expect(callArgs["skip"]).toBe(10);
+
+    expect(result.dataForLlm).toContain(
+      "Showing rows 11–12 of 40 total. Pass skip to page further.",
+    );
+    expect(result.citationLabel).toBe("Incidents, last 168h (40 total)");
+    // rowCount reflects the returned slice, not the total.
+    expect(result.rowCount).toBe(2);
+  });
+
+  test("no paging banner when everything fits in one page", async () => {
+    mockList({ incidents: [buildIncident()], total: 1 });
+
+    const result: ToolExecutionResult = await QueryIncidentsTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.dataForLlm).not.toContain("Pass skip to page further");
+  });
+
+  test("paging past the end stays oriented instead of a bare empty", async () => {
+    mockList({ incidents: [], total: 40 });
+
+    const result: ToolExecutionResult = await QueryIncidentsTool.execute(
+      { skip: 100 },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.dataForLlm).toContain(
+      "No rows at skip=100; there are 40 total.",
+    );
+    expect(result.widget).toBeUndefined();
+  });
+
+  test("clamps skip and limit", async () => {
+    const spies: { findBySpy: jest.SpyInstance } = mockList({
+      incidents: [],
+      total: 0,
+    });
+
+    await QueryIncidentsTool.execute({ skip: 99999, limit: 9999 }, ctx);
+
+    const callArgs: JSONObject = spies.findBySpy.mock
+      .calls[0]?.[0] as JSONObject;
+    expect(callArgs["skip"]).toBe(500);
+    expect(callArgs["limit"]).toBe(25);
+  });
+});
+
+describe("query_incidents — detail mode owners", () => {
+  function buildDetailIncident(): Incident {
+    const incident: Incident = buildIncident();
+    incident.monitors = [];
+    incident.labels = [];
+    return incident;
+  }
+
+  test("surfaces owner teams and owner users, scoped to the ctx tenant", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildDetailIncident() as never);
+
+    const ownerTeam: IncidentOwnerTeam = new IncidentOwnerTeam();
+    const team: Team = new Team();
+    team.name = "SRE";
+    ownerTeam.team = team;
+
+    const ownerUser: IncidentOwnerUser = new IncidentOwnerUser();
+    const user: User = new User();
+    user.name = new Name("Alice Doe");
+    ownerUser.user = user;
+
+    const teamSpy: jest.SpyInstance = jest
+      .spyOn(IncidentOwnerTeamService, "findBy")
+      .mockResolvedValue([ownerTeam] as never);
+    const userSpy: jest.SpyInstance = jest
+      .spyOn(IncidentOwnerUserService, "findBy")
+      .mockResolvedValue([ownerUser] as never);
+
+    const result: ToolExecutionResult = await QueryIncidentsTool.execute(
+      { incidentId: INCIDENT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(result.dataForLlm).toContain("SRE");
+    expect(result.dataForLlm).toContain("Alice Doe");
+
+    // Owner lookups are pinned to the tenant: incidentId is an untrusted arg.
+    for (const spy of [teamSpy, userSpy]) {
+      const callArgs: JSONObject = spy.mock.calls[0]?.[0] as JSONObject;
+      const query: JSONObject = callArgs["query"] as JSONObject;
+      expect((query["incidentId"] as ObjectID).toString()).toBe(
+        INCIDENT_ID.toString(),
+      );
+      expect(query["projectId"]).toBe(ctx.projectId);
+      expect(callArgs["props"]).toBe(ctx.props);
+    }
+  });
+
+  test("a missing incident skips owner lookups and stays honest", async () => {
+    jest.spyOn(IncidentService, "findOneById").mockResolvedValue(null as never);
+
+    const teamSpy: jest.SpyInstance = jest.spyOn(
+      IncidentOwnerTeamService,
+      "findBy",
+    );
+    const userSpy: jest.SpyInstance = jest.spyOn(
+      IncidentOwnerUserService,
+      "findBy",
+    );
+
+    const result: ToolExecutionResult = await QueryIncidentsTool.execute(
+      { incidentId: INCIDENT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(teamSpy).not.toHaveBeenCalled();
+    expect(userSpy).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Utils/AI/LLMServiceStopReason.test.ts
+++ b/Common/Tests/Server/Utils/AI/LLMServiceStopReason.test.ts
@@ -1,0 +1,314 @@
+import API from "../../../../Utils/API";
+import HTTPResponse from "../../../../Types/API/HTTPResponse";
+import { JSONObject } from "../../../../Types/JSON";
+import LlmType from "../../../../Types/LLM/LlmType";
+import LLMService, {
+  LLMCompletionResponse,
+  LLMProviderConfig,
+} from "../../../../Server/Utils/LLM/LLMService";
+import stubLLMEgressGuard from "./StubLLMEgressGuard";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * Output-length truncation must surface as stopReason "length" — mapping it to
+ * "stop" makes callers present cut-off answers as complete. These tests pin
+ * the wire mapping for every provider branch, mocked at the HTTP boundary the
+ * same way the other LLMService suites are.
+ */
+
+type PostSpy = ReturnType<typeof jest.spyOn>;
+
+function mockPost(response: JSONObject): PostSpy {
+  return jest.spyOn(API, "post").mockResolvedValue({
+    jsonData: response,
+  } as unknown as HTTPResponse<JSONObject>) as PostSpy;
+}
+
+const openAIConfig: LLMProviderConfig = {
+  llmType: LlmType.OpenAI,
+  apiKey: "test-key",
+  modelName: "gpt-test",
+};
+
+const azureConfig: LLMProviderConfig = {
+  llmType: LlmType.AzureOpenAI,
+  apiKey: "test-key",
+  baseUrl:
+    "https://example.openai.azure.com/openai/deployments/test-deployment",
+  modelName: "gpt-test",
+};
+
+const anthropicConfig: LLMProviderConfig = {
+  llmType: LlmType.Anthropic,
+  apiKey: "test-key",
+  modelName: "claude-test",
+};
+
+const ollamaConfig: LLMProviderConfig = {
+  llmType: LlmType.Ollama,
+  baseUrl: "http://localhost:11434",
+  modelName: "llama-test",
+};
+
+function openAIStyleResponse(data: {
+  finishReason: string;
+  withToolCalls?: boolean;
+}): JSONObject {
+  const message: JSONObject = {
+    role: "assistant",
+    content: data.withToolCalls ? null : "partial or complete answer",
+  };
+
+  if (data.withToolCalls) {
+    message["tool_calls"] = [
+      {
+        id: "call_1",
+        type: "function",
+        function: { name: "get_monitor", arguments: '{"monitorId":"m1"}' },
+      },
+    ];
+  }
+
+  return {
+    choices: [{ message: message, finish_reason: data.finishReason }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+}
+
+async function getStopReason(
+  config: LLMProviderConfig,
+  response: JSONObject,
+): Promise<LLMCompletionResponse> {
+  mockPost(response);
+
+  return LLMService.getCompletion({
+    llmProviderConfig: config,
+    messages: [{ role: "user", content: "hello" }],
+  });
+}
+
+beforeEach(() => {
+  stubLLMEgressGuard();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  LLMService.clearRequestAdaptationCache();
+});
+
+describe("OpenAI-compatible finish_reason mapping", () => {
+  test('maps finish_reason "length" to stopReason "length"', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      openAIConfig,
+      openAIStyleResponse({ finishReason: "length" }),
+    );
+
+    expect(result.stopReason).toBe("length");
+  });
+
+  test('maps finish_reason "stop" to stopReason "stop"', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      openAIConfig,
+      openAIStyleResponse({ finishReason: "stop" }),
+    );
+
+    expect(result.stopReason).toBe("stop");
+  });
+
+  test('maps finish_reason "tool_calls" with tool calls to "tool_use"', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      openAIConfig,
+      openAIStyleResponse({ finishReason: "tool_calls", withToolCalls: true }),
+    );
+
+    expect(result.stopReason).toBe("tool_use");
+    expect(result.toolCalls).toHaveLength(1);
+  });
+
+  test('keeps "tool_use" for compatible servers that report finish_reason "stop" alongside tool calls', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      openAIConfig,
+      openAIStyleResponse({ finishReason: "stop", withToolCalls: true }),
+    );
+
+    expect(result.stopReason).toBe("tool_use");
+  });
+
+  test('truncation wins over tool calls: finish_reason "length" with tool calls maps to "length"', async () => {
+    /*
+     * A response cut off mid-tool-call still carries the partial tool_calls
+     * array. Executing a truncated call would be wrong, so the wire truth
+     * ("length") must win over the tool-call heuristic.
+     */
+    const result: LLMCompletionResponse = await getStopReason(
+      openAIConfig,
+      openAIStyleResponse({ finishReason: "length", withToolCalls: true }),
+    );
+
+    expect(result.stopReason).toBe("length");
+  });
+
+  test("missing finish_reason still maps to a defined stopReason", async () => {
+    const response: JSONObject = openAIStyleResponse({ finishReason: "stop" });
+    delete ((response["choices"] as Array<JSONObject>)[0] as JSONObject)[
+      "finish_reason"
+    ];
+
+    const result: LLMCompletionResponse = await getStopReason(
+      openAIConfig,
+      response,
+    );
+
+    expect(result.stopReason).toBe("stop");
+  });
+});
+
+describe("Azure OpenAI finish_reason mapping", () => {
+  test('maps finish_reason "length" to stopReason "length"', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      azureConfig,
+      openAIStyleResponse({ finishReason: "length" }),
+    );
+
+    expect(result.stopReason).toBe("length");
+  });
+
+  test('maps finish_reason "stop" to stopReason "stop"', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      azureConfig,
+      openAIStyleResponse({ finishReason: "stop" }),
+    );
+
+    expect(result.stopReason).toBe("stop");
+  });
+});
+
+describe("Anthropic stop_reason mapping", () => {
+  function anthropicResponse(data: {
+    stopReason: string;
+    withToolUse?: boolean;
+  }): JSONObject {
+    const content: Array<JSONObject> = [
+      { type: "text", text: "partial or complete answer" },
+    ];
+
+    if (data.withToolUse) {
+      content.push({
+        type: "tool_use",
+        id: "toolu_1",
+        name: "get_monitor",
+        input: { monitorId: "m1" },
+      });
+    }
+
+    return {
+      content: content,
+      stop_reason: data.stopReason,
+      usage: { input_tokens: 1, output_tokens: 1 },
+    };
+  }
+
+  test('maps stop_reason "max_tokens" to stopReason "length"', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      anthropicConfig,
+      anthropicResponse({ stopReason: "max_tokens" }),
+    );
+
+    expect(result.stopReason).toBe("length");
+  });
+
+  test('maps stop_reason "end_turn" to stopReason "stop"', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      anthropicConfig,
+      anthropicResponse({ stopReason: "end_turn" }),
+    );
+
+    expect(result.stopReason).toBe("stop");
+  });
+
+  test('maps stop_reason "tool_use" to stopReason "tool_use"', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      anthropicConfig,
+      anthropicResponse({ stopReason: "tool_use", withToolUse: true }),
+    );
+
+    expect(result.stopReason).toBe("tool_use");
+    expect(result.toolCalls).toHaveLength(1);
+  });
+});
+
+describe("Ollama done_reason mapping", () => {
+  function ollamaResponse(data: {
+    doneReason?: string;
+    withToolCalls?: boolean;
+  }): JSONObject {
+    const message: JSONObject = {
+      role: "assistant",
+      content: "partial or complete answer",
+    };
+
+    if (data.withToolCalls) {
+      message["tool_calls"] = [
+        { function: { name: "get_monitor", arguments: { monitorId: "m1" } } },
+      ];
+    }
+
+    const response: JSONObject = {
+      message: message,
+      prompt_eval_count: 1,
+      eval_count: 1,
+    };
+
+    if (data.doneReason !== undefined) {
+      response["done_reason"] = data.doneReason;
+    }
+
+    return response;
+  }
+
+  test('maps done_reason "length" to stopReason "length"', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      ollamaConfig,
+      ollamaResponse({ doneReason: "length" }),
+    );
+
+    expect(result.stopReason).toBe("length");
+  });
+
+  test('maps done_reason "limit" to stopReason "length"', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      ollamaConfig,
+      ollamaResponse({ doneReason: "limit" }),
+    );
+
+    expect(result.stopReason).toBe("length");
+  });
+
+  test('maps done_reason "stop" with tool calls to "tool_use"', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      ollamaConfig,
+      ollamaResponse({ doneReason: "stop", withToolCalls: true }),
+    );
+
+    expect(result.stopReason).toBe("tool_use");
+    expect(result.toolCalls).toHaveLength(1);
+  });
+
+  test('maps done_reason "stop" without tool calls to "stop"', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      ollamaConfig,
+      ollamaResponse({ doneReason: "stop" }),
+    );
+
+    expect(result.stopReason).toBe("stop");
+  });
+
+  test('missing done_reason maps to "stop" for a plain text answer', async () => {
+    const result: LLMCompletionResponse = await getStopReason(
+      ollamaConfig,
+      ollamaResponse({}),
+    );
+
+    expect(result.stopReason).toBe("stop");
+  });
+});

--- a/Common/Tests/Server/Utils/AI/LLMServiceToolCalling.test.ts
+++ b/Common/Tests/Server/Utils/AI/LLMServiceToolCalling.test.ts
@@ -56,7 +56,16 @@ describe("LLMService tool calling — OpenAI-compatible", () => {
     });
 
     const response: LLMCompletionResponse = await LLMService.getCompletion({
-      llmProviderConfig: { llmType: LlmType.OpenAI, apiKey: "test-key" },
+      llmProviderConfig: {
+        llmType: LlmType.OpenAI,
+        apiKey: "test-key",
+        /*
+         * Pinned to a legacy (non-reasoning) model: the blank-model default is
+         * now a reasoning model that sends max_completion_tokens, and this
+         * test asserts the legacy max_tokens request shape.
+         */
+        modelName: "gpt-4o",
+      },
       messages: [{ role: "user", content: "find logs" }],
       tools: [
         {
@@ -405,7 +414,16 @@ describe("LLMService — additionalParams (per-provider overrides)", () => {
     });
 
     await LLMService.getCompletion({
-      llmProviderConfig: { llmType: LlmType.OpenAI, apiKey: "test-key" },
+      llmProviderConfig: {
+        llmType: LlmType.OpenAI,
+        apiKey: "test-key",
+        /*
+         * Pinned to a legacy (non-reasoning) model: the blank-model default is
+         * now a reasoning model that sends max_completion_tokens, and this
+         * test asserts the legacy max_tokens path specifically.
+         */
+        modelName: "gpt-4o",
+      },
       messages: [{ role: "user", content: "hi" }],
       maxTokens: 1024,
       additionalParams: { temperature: 0.2, top_p: 0.9 },
@@ -427,7 +445,12 @@ describe("LLMService — additionalParams (per-provider overrides)", () => {
     });
 
     await LLMService.getCompletion({
-      llmProviderConfig: { llmType: LlmType.OpenAI, apiKey: "test-key" },
+      llmProviderConfig: {
+        llmType: LlmType.OpenAI,
+        apiKey: "test-key",
+        // Legacy model, so max_tokens would be sent unless the override wins.
+        modelName: "gpt-4o",
+      },
       messages: [{ role: "user", content: "hi" }],
       maxTokens: 1024,
       // gpt-5 / o1 / o3 reject max_tokens and require max_completion_tokens.

--- a/Common/Tests/Server/Utils/AI/NoteWriteTools.test.ts
+++ b/Common/Tests/Server/Utils/AI/NoteWriteTools.test.ts
@@ -1,0 +1,268 @@
+import {
+  CreateAlertNoteTool,
+  CreateIncidentNoteTool,
+} from "../../../../Server/Utils/AI/Toolbox/NoteWriteTools";
+import {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../Server/Utils/AI/Toolbox/ToolTypes";
+import AlertService from "../../../../Server/Services/AlertService";
+import AlertInternalNoteService from "../../../../Server/Services/AlertInternalNoteService";
+import IncidentService from "../../../../Server/Services/IncidentService";
+import IncidentInternalNoteService from "../../../../Server/Services/IncidentInternalNoteService";
+import Alert from "../../../../Models/DatabaseModels/Alert";
+import AlertInternalNote from "../../../../Models/DatabaseModels/AlertInternalNote";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import IncidentInternalNote from "../../../../Models/DatabaseModels/IncidentInternalNote";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * create_incident_note / create_alert_note file PRIVATE internal notes — the
+ * team-only counterpart of post_incident_status_update. These tests lock in
+ * the mutation contract: the acting user comes from ctx.props (never a tool
+ * argument), the write is tenant-pinned from ctx, the result carries the
+ * created note id with a deep-link citation, and the required-argument
+ * failures are loud (BadDataException), not silent.
+ */
+
+const USER_ID: ObjectID = ObjectID.generate();
+
+const ctx: ToolContext = {
+  projectId: ObjectID.generate(),
+  props: { isRoot: true, userId: USER_ID },
+};
+
+const INCIDENT_ID: ObjectID = ObjectID.generate();
+const ALERT_ID: ObjectID = ObjectID.generate();
+const NOTE_ID: ObjectID = ObjectID.generate();
+
+function buildIncident(): Incident {
+  const incident: Incident = new Incident();
+  incident._id = INCIDENT_ID.toString();
+  incident.incidentNumber = 42;
+  incident.title = "Checkout down";
+  return incident;
+}
+
+function buildAlert(): Alert {
+  const alert: Alert = new Alert();
+  alert._id = ALERT_ID.toString();
+  alert.alertNumber = 9;
+  alert.title = "High CPU on api-1";
+  return alert;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("create_incident_note", () => {
+  test("creates the private note as ctx's user and cites the incident", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+
+    const createdNote: IncidentInternalNote = new IncidentInternalNote();
+    createdNote._id = NOTE_ID.toString();
+    const createSpy: jest.SpyInstance = jest
+      .spyOn(IncidentInternalNoteService, "create")
+      .mockResolvedValue(createdNote as never);
+
+    const result: ToolExecutionResult = await CreateIncidentNoteTool.execute(
+      {
+        incidentId: INCIDENT_ID.toString(),
+        note: "DB failover completed; watching error rates.",
+      },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(result.dataForLlm).toContain(NOTE_ID.toString());
+    expect(result.dataForLlm).toContain("#42");
+    expect(result.dataForLlm).toContain("team members only");
+    expect(result.citationLabel).toBe("Internal note on incident #42");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.IncidentView,
+      params: { incidentId: INCIDENT_ID.toString() },
+    });
+    expect(result.widget).toBeDefined();
+
+    // The write runs under the user's props with tenancy pinned from ctx.
+    const callArgs: JSONObject = createSpy.mock.calls[0]?.[0] as JSONObject;
+    const data: IncidentInternalNote = callArgs["data"] as IncidentInternalNote;
+    expect(data.note).toBe("DB failover completed; watching error rates.");
+    expect(data.projectId).toBe(ctx.projectId);
+    expect(String(data.incidentId)).toBe(INCIDENT_ID.toString());
+    expect(data.createdByUserId).toBe(USER_ID);
+    expect(callArgs["props"]).toBe(ctx.props);
+  });
+
+  test("the acting user comes from ctx.props even when args smuggle a userId", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+
+    const createSpy: jest.SpyInstance = jest
+      .spyOn(IncidentInternalNoteService, "create")
+      .mockResolvedValue(new IncidentInternalNote() as never);
+
+    await CreateIncidentNoteTool.execute(
+      {
+        incidentId: INCIDENT_ID.toString(),
+        note: "note text",
+        userId: ObjectID.generate().toString(),
+        createdByUserId: ObjectID.generate().toString(),
+      },
+      ctx,
+    );
+
+    const callArgs: JSONObject = createSpy.mock.calls[0]?.[0] as JSONObject;
+    const data: IncidentInternalNote = callArgs["data"] as IncidentInternalNote;
+    expect(data.createdByUserId).toBe(USER_ID);
+  });
+
+  test("missing incidentId is a loud BadData error", async () => {
+    await expect(
+      CreateIncidentNoteTool.execute({ note: "orphan note" }, ctx),
+    ).rejects.toThrow("incidentId is required");
+  });
+
+  test("missing note is a loud BadData error", async () => {
+    await expect(
+      CreateIncidentNoteTool.execute(
+        { incidentId: INCIDENT_ID.toString() },
+        ctx,
+      ),
+    ).rejects.toThrow("note is required");
+  });
+
+  test("refuses to write when the incident is not visible to the user", async () => {
+    jest.spyOn(IncidentService, "findOneById").mockResolvedValue(null as never);
+    const createSpy: jest.SpyInstance = jest.spyOn(
+      IncidentInternalNoteService,
+      "create",
+    );
+
+    await expect(
+      CreateIncidentNoteTool.execute(
+        { incidentId: INCIDENT_ID.toString(), note: "note text" },
+        ctx,
+      ),
+    ).rejects.toThrow("Incident not found");
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  test("refuses to write without an authenticated user in context", async () => {
+    const anonymousCtx: ToolContext = {
+      projectId: ctx.projectId,
+      props: { isRoot: true },
+    };
+
+    await expect(
+      CreateIncidentNoteTool.execute(
+        { incidentId: INCIDENT_ID.toString(), note: "note text" },
+        anonymousCtx,
+      ),
+    ).rejects.toThrow("No authenticated user");
+  });
+
+  test("buildActionTitle names the incident from validated args", () => {
+    expect(
+      CreateIncidentNoteTool.buildActionTitle!({
+        incidentId: INCIDENT_ID.toString(),
+      }),
+    ).toBe(`Add private internal note to incident ${INCIDENT_ID.toString()}`);
+  });
+
+  test("is a mutation whose permissions derive from the note model's create ACL", () => {
+    expect(CreateIncidentNoteTool.isMutation).toBe(true);
+    expect(CreateIncidentNoteTool.requiredPermissions.length).toBeGreaterThan(
+      0,
+    );
+  });
+});
+
+describe("create_alert_note", () => {
+  test("creates the private note as ctx's user and cites the alert", async () => {
+    jest
+      .spyOn(AlertService, "findOneById")
+      .mockResolvedValue(buildAlert() as never);
+
+    const createdNote: AlertInternalNote = new AlertInternalNote();
+    createdNote._id = NOTE_ID.toString();
+    const createSpy: jest.SpyInstance = jest
+      .spyOn(AlertInternalNoteService, "create")
+      .mockResolvedValue(createdNote as never);
+
+    const result: ToolExecutionResult = await CreateAlertNoteTool.execute(
+      {
+        alertId: ALERT_ID.toString(),
+        note: "CPU normalized after rollout pause.",
+      },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(result.dataForLlm).toContain(NOTE_ID.toString());
+    expect(result.dataForLlm).toContain("#9");
+    expect(result.dataForLlm).toContain("team members only");
+    expect(result.citationLabel).toBe("Internal note on alert #9");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.AlertView,
+      params: { alertId: ALERT_ID.toString() },
+    });
+    expect(result.widget).toBeDefined();
+
+    const callArgs: JSONObject = createSpy.mock.calls[0]?.[0] as JSONObject;
+    const data: AlertInternalNote = callArgs["data"] as AlertInternalNote;
+    expect(data.note).toBe("CPU normalized after rollout pause.");
+    expect(data.projectId).toBe(ctx.projectId);
+    expect(String(data.alertId)).toBe(ALERT_ID.toString());
+    expect(data.createdByUserId).toBe(USER_ID);
+    expect(callArgs["props"]).toBe(ctx.props);
+  });
+
+  test("missing alertId is a loud BadData error", async () => {
+    await expect(
+      CreateAlertNoteTool.execute({ note: "orphan note" }, ctx),
+    ).rejects.toThrow("alertId is required");
+  });
+
+  test("missing note is a loud BadData error", async () => {
+    await expect(
+      CreateAlertNoteTool.execute({ alertId: ALERT_ID.toString() }, ctx),
+    ).rejects.toThrow("note is required");
+  });
+
+  test("refuses to write when the alert is not visible to the user", async () => {
+    jest.spyOn(AlertService, "findOneById").mockResolvedValue(null as never);
+    const createSpy: jest.SpyInstance = jest.spyOn(
+      AlertInternalNoteService,
+      "create",
+    );
+
+    await expect(
+      CreateAlertNoteTool.execute(
+        { alertId: ALERT_ID.toString(), note: "note text" },
+        ctx,
+      ),
+    ).rejects.toThrow("Alert not found");
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  test("buildActionTitle names the alert from validated args", () => {
+    expect(
+      CreateAlertNoteTool.buildActionTitle!({
+        alertId: ALERT_ID.toString(),
+      }),
+    ).toBe(`Add private internal note to alert ${ALERT_ID.toString()}`);
+  });
+
+  test("is a mutation whose permissions derive from the note model's create ACL", () => {
+    expect(CreateAlertNoteTool.isMutation).toBe(true);
+    expect(CreateAlertNoteTool.requiredPermissions.length).toBeGreaterThan(0);
+  });
+});

--- a/Common/Tests/Server/Utils/AI/ObservabilityChatPrompt.test.ts
+++ b/Common/Tests/Server/Utils/AI/ObservabilityChatPrompt.test.ts
@@ -110,6 +110,35 @@ describe("buildPageContextSection", () => {
 
     expect(section).toContain("It is not evidence");
   });
+
+  /*
+   * An autonomous investigation may already have run for the incident/alert
+   * the user is looking at. The page guidance must send the model to that
+   * finished work (get_ai_investigation) and to the timeline tool for
+   * "what's the latest" — otherwise it re-derives everything from raw
+   * telemetry on every question.
+   */
+  test("incident guidance builds on the AI investigation and the timeline", () => {
+    const section: string = buildPageContextSection({
+      type: AIChatPageContextType.Incident,
+      entityId: ENTITY_ID,
+    });
+
+    expect(section).toContain("get_ai_investigation");
+    expect(section).toContain("build on (and cite) its findings");
+    expect(section).toContain("get_incident_timeline");
+  });
+
+  test("alert guidance builds on the AI investigation and the timeline", () => {
+    const section: string = buildPageContextSection({
+      type: AIChatPageContextType.Alert,
+      entityId: ENTITY_ID,
+    });
+
+    expect(section).toContain("get_ai_investigation");
+    expect(section).toContain("build on (and cite) its findings");
+    expect(section).toContain("get_alert_timeline");
+  });
 });
 
 describe("buildObservabilityChatSystemPrompt with page context", () => {
@@ -174,4 +203,144 @@ describe("buildObservabilityChatSystemPrompt — how it describes code changes",
       "open_code_pull_request is the right tool almost always",
     );
   });
+});
+
+/*
+ * The platform-questions paragraph maps each class of "how is this being
+ * handled" question to the exact tool that answers it, so the model never
+ * tries to answer on-call or status-page questions from telemetry.
+ */
+describe("buildObservabilityChatSystemPrompt — platform questions guidance", () => {
+  const prompt: string = buildObservabilityChatSystemPrompt({
+    currentTime: new Date("2026-07-16T00:00:00Z"),
+    permissionMode: AIChatPermissionMode.ReadOnly,
+  });
+
+  test.each<[string, string]>([
+    ["who is on call", "get_on_call_status"],
+    ["escalation", "query_on_call_policies"],
+    ["page delivery", "query_on_call_pages"],
+    ["ownership", "query_teams"],
+    ["runbook contents", "query_runbooks"],
+    ["public status", "query_status_pages"],
+    ["subscriber announcements", "query_status_page_announcements"],
+    ["SLO budget", "query_slos"],
+    ["automation failures", "query_workflows"],
+    ["probe health", "query_probes"],
+    ["early warnings", "query_ai_insights"],
+  ])("%s questions route to %s", (_label: string, tool: string) => {
+    expect(prompt).toContain(tool);
+  });
+
+  test("tells the model these beat telemetry for platform questions", () => {
+    expect(prompt).toContain(
+      "Platform questions have direct tools — answer them from those, not from telemetry",
+    );
+  });
+});
+
+describe("buildObservabilityChatSystemPrompt — clarifying question policy", () => {
+  const prompt: string = buildObservabilityChatSystemPrompt({
+    currentTime: new Date("2026-07-16T00:00:00Z"),
+    permissionMode: AIChatPermissionMode.AskForApproval,
+  });
+
+  test("asks one focused question only when ambiguity is costly", () => {
+    expect(prompt).toContain(
+      "which service? which time window? which environment?",
+    );
+    expect(prompt).toContain("one focused clarifying question");
+  });
+
+  test("minor ambiguity proceeds with a stated assumption", () => {
+    expect(prompt).toContain("state the assumption explicitly");
+  });
+});
+
+/*
+ * Tool results arrive sanitized. Without this section the model quotes
+ * "[redacted-email]" back to the user as if it were the literal value, or
+ * treats a "[truncated]" tail as the end of the data.
+ */
+describe("buildObservabilityChatSystemPrompt — sanitization markers", () => {
+  const prompt: string = buildObservabilityChatSystemPrompt({
+    currentTime: new Date("2026-07-16T00:00:00Z"),
+    permissionMode: AIChatPermissionMode.AskForApproval,
+  });
+
+  test("names the redaction placeholders and forbids quoting them as values", () => {
+    expect(prompt).toContain("[redacted-email]");
+    expect(prompt).toContain("[redacted-ip]");
+    expect(prompt).toContain("never as literal data values");
+  });
+
+  test("says what to answer when the redacted value is the answer", () => {
+    expect(prompt).toContain("the value is redacted in this view");
+  });
+
+  test("explains truncation and how to see the rest", () => {
+    expect(prompt).toContain('"... [truncated]"');
+    expect(prompt).toContain("fetch the single record");
+  });
+});
+
+describe("buildObservabilityChatSystemPrompt — investigation answer shape", () => {
+  const prompt: string = buildObservabilityChatSystemPrompt({
+    currentTime: new Date("2026-07-16T00:00:00Z"),
+    permissionMode: AIChatPermissionMode.AskForApproval,
+  });
+
+  test("leads with the finding and separates facts from hypotheses", () => {
+    expect(prompt).toContain("lead with the finding");
+    expect(prompt).toContain("confirmed facts (each cited) from hypotheses");
+  });
+
+  test("states the window and what comes next when inconclusive", () => {
+    expect(prompt).toContain("time window you examined");
+    expect(prompt).toContain("what you would check next");
+  });
+});
+
+/*
+ * The action list now includes internal notes and kicking off an autonomous
+ * investigation. Every permission mode must name these tools — the acting
+ * modes so the model uses them, read-only so it can explain what switching
+ * modes unlocks.
+ */
+describe("buildObservabilityChatSystemPrompt — action guidance per mode", () => {
+  test.each<[AIChatPermissionMode]>([
+    [AIChatPermissionMode.ReadOnly],
+    [AIChatPermissionMode.AskForApproval],
+    [AIChatPermissionMode.AutoRun],
+  ])(
+    "%s names the note and investigation tools",
+    (mode: AIChatPermissionMode) => {
+      const prompt: string = buildObservabilityChatSystemPrompt({
+        currentTime: new Date("2026-07-16T00:00:00Z"),
+        permissionMode: mode,
+      });
+
+      expect(prompt).toContain("create_incident_note");
+      expect(prompt).toContain("create_alert_note");
+      expect(prompt).toContain("start_investigation");
+    },
+  );
+
+  test.each<[AIChatPermissionMode]>([
+    [AIChatPermissionMode.AskForApproval],
+    [AIChatPermissionMode.AutoRun],
+  ])(
+    "%s contrasts private notes with the public status update",
+    (mode: AIChatPermissionMode) => {
+      const prompt: string = buildObservabilityChatSystemPrompt({
+        currentTime: new Date("2026-07-16T00:00:00Z"),
+        permissionMode: mode,
+      });
+
+      expect(prompt).toContain("never notifies status page subscribers");
+      expect(prompt).toContain(
+        "post_incident_status_update is the public counterpart",
+      );
+    },
+  );
 });

--- a/Common/Tests/Server/Utils/AI/OnCallTools.test.ts
+++ b/Common/Tests/Server/Utils/AI/OnCallTools.test.ts
@@ -1,0 +1,664 @@
+import {
+  GetOnCallStatusTool,
+  QueryOnCallPagesTool,
+  QueryOnCallPoliciesTool,
+} from "../../../../Server/Utils/AI/Toolbox/OnCallTools";
+import {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../Server/Utils/AI/Toolbox/ToolTypes";
+import OnCallDutyPolicyEscalationRuleScheduleService from "../../../../Server/Services/OnCallDutyPolicyEscalationRuleScheduleService";
+import OnCallDutyPolicyEscalationRuleService from "../../../../Server/Services/OnCallDutyPolicyEscalationRuleService";
+import OnCallDutyPolicyEscalationRuleTeamService from "../../../../Server/Services/OnCallDutyPolicyEscalationRuleTeamService";
+import OnCallDutyPolicyEscalationRuleUserService from "../../../../Server/Services/OnCallDutyPolicyEscalationRuleUserService";
+import OnCallDutyPolicyExecutionLogService from "../../../../Server/Services/OnCallDutyPolicyExecutionLogService";
+import OnCallDutyPolicyScheduleService from "../../../../Server/Services/OnCallDutyPolicyScheduleService";
+import OnCallDutyPolicyService from "../../../../Server/Services/OnCallDutyPolicyService";
+import UserOnCallLogService from "../../../../Server/Services/UserOnCallLogService";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import OnCallDutyPolicy from "../../../../Models/DatabaseModels/OnCallDutyPolicy";
+import OnCallDutyPolicyEscalationRule from "../../../../Models/DatabaseModels/OnCallDutyPolicyEscalationRule";
+import OnCallDutyPolicyEscalationRuleSchedule from "../../../../Models/DatabaseModels/OnCallDutyPolicyEscalationRuleSchedule";
+import OnCallDutyPolicyEscalationRuleTeam from "../../../../Models/DatabaseModels/OnCallDutyPolicyEscalationRuleTeam";
+import OnCallDutyPolicyEscalationRuleUser from "../../../../Models/DatabaseModels/OnCallDutyPolicyEscalationRuleUser";
+import OnCallDutyPolicyExecutionLog from "../../../../Models/DatabaseModels/OnCallDutyPolicyExecutionLog";
+import OnCallDutyPolicySchedule from "../../../../Models/DatabaseModels/OnCallDutyPolicySchedule";
+import Team from "../../../../Models/DatabaseModels/Team";
+import User from "../../../../Models/DatabaseModels/User";
+import UserOnCallLog from "../../../../Models/DatabaseModels/UserOnCallLog";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import BadDataException from "../../../../Types/Exception/BadDataException";
+import { JSONObject } from "../../../../Types/JSON";
+import Name from "../../../../Types/Name";
+import ObjectID from "../../../../Types/ObjectID";
+import OnCallDutyPolicyStatus from "../../../../Types/OnCallDutyPolicy/OnCallDutyPolicyStatus";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import UserNotificationExecutionStatus from "../../../../Types/UserNotification/UserNotificationExecutionStatus";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * These three tools close the on-call discovery gap: page_on_call_policy's
+ * description tells the model to "find the id with query_on_call_policies",
+ * get_on_call_status must answer "who is on call?" precisely (including the
+ * honest "no one is on call" case), and query_on_call_pages must show who was
+ * actually notified and whether anyone acknowledged. The tests lock in the
+ * result envelope each of those flows depends on.
+ */
+
+const ctx: ToolContext = {
+  projectId: ObjectID.generate(),
+  props: { isRoot: true },
+};
+
+const POLICY_ID: ObjectID = ObjectID.generate();
+const RULE_1_ID: ObjectID = ObjectID.generate();
+const RULE_2_ID: ObjectID = ObjectID.generate();
+const SCHEDULE_ID: ObjectID = ObjectID.generate();
+
+function buildUser(name: string): User {
+  const user: User = new User();
+  user._id = ObjectID.generate().toString();
+  user.name = new Name(name);
+  return user;
+}
+
+function buildPolicy(data?: {
+  id?: ObjectID;
+  name?: string;
+  description?: string;
+}): OnCallDutyPolicy {
+  const policy: OnCallDutyPolicy = new OnCallDutyPolicy();
+  policy._id = (data?.id ?? POLICY_ID).toString();
+  policy.name = data?.name ?? "Payments primary";
+  policy.description = data?.description ?? "Pages the payments on-call.";
+  return policy;
+}
+
+function buildRule(data: {
+  id: ObjectID;
+  order: number;
+  name: string;
+  escalateAfterInMinutes?: number;
+}): OnCallDutyPolicyEscalationRule {
+  const rule: OnCallDutyPolicyEscalationRule =
+    new OnCallDutyPolicyEscalationRule();
+  rule._id = data.id.toString();
+  rule.order = data.order;
+  rule.name = data.name;
+  rule.onCallDutyPolicyId = POLICY_ID;
+  if (data.escalateAfterInMinutes !== undefined) {
+    rule.escalateAfterInMinutes = data.escalateAfterInMinutes;
+  }
+  return rule;
+}
+
+function buildRuleUser(
+  ruleId: ObjectID,
+  userName: string,
+): OnCallDutyPolicyEscalationRuleUser {
+  const link: OnCallDutyPolicyEscalationRuleUser =
+    new OnCallDutyPolicyEscalationRuleUser();
+  link._id = ObjectID.generate().toString();
+  link.onCallDutyPolicyEscalationRuleId = ruleId;
+  link.user = buildUser(userName);
+  return link;
+}
+
+function buildRuleTeam(
+  ruleId: ObjectID,
+  teamName: string,
+): OnCallDutyPolicyEscalationRuleTeam {
+  const link: OnCallDutyPolicyEscalationRuleTeam =
+    new OnCallDutyPolicyEscalationRuleTeam();
+  link._id = ObjectID.generate().toString();
+  link.onCallDutyPolicyEscalationRuleId = ruleId;
+  const team: Team = new Team();
+  team._id = ObjectID.generate().toString();
+  team.name = teamName;
+  link.team = team;
+  return link;
+}
+
+function buildRuleSchedule(
+  ruleId: ObjectID,
+  scheduleId: ObjectID,
+  scheduleName: string,
+): OnCallDutyPolicyEscalationRuleSchedule {
+  const link: OnCallDutyPolicyEscalationRuleSchedule =
+    new OnCallDutyPolicyEscalationRuleSchedule();
+  link._id = ObjectID.generate().toString();
+  link.onCallDutyPolicyEscalationRuleId = ruleId;
+  link.onCallDutyPolicyScheduleId = scheduleId;
+  const schedule: OnCallDutyPolicySchedule = new OnCallDutyPolicySchedule();
+  schedule._id = scheduleId.toString();
+  schedule.name = scheduleName;
+  link.onCallDutyPolicySchedule = schedule;
+  return link;
+}
+
+function buildSchedule(data?: {
+  id?: ObjectID;
+  name?: string;
+  currentUserName?: string;
+  nextUserName?: string;
+}): OnCallDutyPolicySchedule {
+  const schedule: OnCallDutyPolicySchedule = new OnCallDutyPolicySchedule();
+  schedule._id = (data?.id ?? SCHEDULE_ID).toString();
+  schedule.name = data?.name ?? "Primary rotation";
+  if (data?.currentUserName) {
+    schedule.currentUserOnRoster = buildUser(data.currentUserName);
+    schedule.rosterStartAt = new Date("2026-08-11T09:00:00Z");
+    schedule.rosterHandoffAt = new Date("2026-08-18T09:00:00Z");
+  }
+  if (data?.nextUserName) {
+    schedule.nextUserOnRoster = buildUser(data.nextUserName);
+    schedule.rosterNextStartAt = new Date("2026-08-18T09:00:00Z");
+  }
+  return schedule;
+}
+
+interface EscalationMocks {
+  rules?: Array<OnCallDutyPolicyEscalationRule>;
+  users?: Array<OnCallDutyPolicyEscalationRuleUser>;
+  teams?: Array<OnCallDutyPolicyEscalationRuleTeam>;
+  schedules?: Array<OnCallDutyPolicyEscalationRuleSchedule>;
+}
+
+function mockEscalationData(data: EscalationMocks): void {
+  jest
+    .spyOn(OnCallDutyPolicyEscalationRuleService, "findBy")
+    .mockResolvedValue((data.rules ?? []) as never);
+  jest
+    .spyOn(OnCallDutyPolicyEscalationRuleUserService, "findBy")
+    .mockResolvedValue((data.users ?? []) as never);
+  jest
+    .spyOn(OnCallDutyPolicyEscalationRuleTeamService, "findBy")
+    .mockResolvedValue((data.teams ?? []) as never);
+  jest
+    .spyOn(OnCallDutyPolicyEscalationRuleScheduleService, "findBy")
+    .mockResolvedValue((data.schedules ?? []) as never);
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("query_on_call_policies — detail mode", () => {
+  test("returns the policy with its full escalation chain and a view citation", async () => {
+    jest
+      .spyOn(OnCallDutyPolicyService, "findOneById")
+      .mockResolvedValue(buildPolicy() as never);
+    mockEscalationData({
+      rules: [
+        buildRule({
+          id: RULE_1_ID,
+          order: 1,
+          name: "Primary",
+          escalateAfterInMinutes: 5,
+        }),
+        buildRule({ id: RULE_2_ID, order: 2, name: "Backup" }),
+      ],
+      users: [buildRuleUser(RULE_1_ID, "Alice Smith")],
+      teams: [buildRuleTeam(RULE_2_ID, "SRE")],
+      schedules: [
+        buildRuleSchedule(RULE_1_ID, SCHEDULE_ID, "Primary rotation"),
+      ],
+    });
+
+    const result: ToolExecutionResult = await QueryOnCallPoliciesTool.execute(
+      { onCallPolicyId: POLICY_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(result.dataForLlm).toContain("Payments primary");
+    expect(result.dataForLlm).toContain("Alice Smith");
+    expect(result.dataForLlm).toContain("SRE");
+    expect(result.dataForLlm).toContain("Primary rotation");
+    expect(result.dataForLlm).toContain("escalates after 5m");
+    expect(result.citationLabel).toBe("On-call policy 'Payments primary'");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.OnCallPolicyView,
+      params: { onCallDutyPolicyId: POLICY_ID.toString() },
+    });
+    expect(result.widget).toBeDefined();
+  });
+
+  test("a missing policy is honest: zero rows, no widget", async () => {
+    jest
+      .spyOn(OnCallDutyPolicyService, "findOneById")
+      .mockResolvedValue(null as never);
+
+    const result: ToolExecutionResult = await QueryOnCallPoliciesTool.execute(
+      { onCallPolicyId: POLICY_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+  });
+});
+
+describe("query_on_call_policies — list mode", () => {
+  test("lists policies with their escalation chains", async () => {
+    jest
+      .spyOn(OnCallDutyPolicyService, "countBy")
+      .mockResolvedValue(new PositiveNumber(2) as never);
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(OnCallDutyPolicyService, "findBy")
+      .mockResolvedValue([
+        buildPolicy(),
+        buildPolicy({
+          id: ObjectID.generate(),
+          name: "Platform secondary",
+          description: "Backup escalation path.",
+        }),
+      ] as never);
+    mockEscalationData({
+      rules: [buildRule({ id: RULE_1_ID, order: 1, name: "Primary" })],
+      users: [buildRuleUser(RULE_1_ID, "Alice Smith")],
+    });
+
+    const result: ToolExecutionResult = await QueryOnCallPoliciesTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(2);
+    expect(result.dataForLlm).toContain("Payments primary");
+    expect(result.dataForLlm).toContain("Platform secondary");
+    expect(result.dataForLlm).toContain("Alice Smith");
+    // The policy with no rules must say so, not silently show nothing.
+    expect(result.dataForLlm).toContain("No escalation rules configured");
+    expect(result.citationLabel).toBe("On-call policies (2 found)");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.OnCallPolicies,
+    });
+    expect(result.widget).toBeDefined();
+
+    // The query must run under the requesting user's props, never as root+.
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["props"]).toBe(ctx.props);
+    expect(callArgs["limit"]).toBe(10);
+    expect(callArgs["skip"]).toBe(0);
+  });
+
+  test("clamps limit, honors skip, and reports pagination honestly", async () => {
+    jest
+      .spyOn(OnCallDutyPolicyService, "countBy")
+      .mockResolvedValue(new PositiveNumber(60) as never);
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(OnCallDutyPolicyService, "findBy")
+      .mockResolvedValue([
+        buildPolicy(),
+        buildPolicy({ id: ObjectID.generate(), name: "Platform secondary" }),
+      ] as never);
+    mockEscalationData({});
+
+    const result: ToolExecutionResult = await QueryOnCallPoliciesTool.execute(
+      { limit: 999, skip: 20 },
+      ctx,
+    );
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["limit"]).toBe(25);
+    expect(callArgs["skip"]).toBe(20);
+    expect(result.dataForLlm).toContain(
+      "Showing rows 21–22 of 60 total. Pass skip to page further.",
+    );
+    expect(result.citationLabel).toBe("On-call policies (2 of 60)");
+  });
+
+  test("an empty project is honest: zero rows and no widget", async () => {
+    jest
+      .spyOn(OnCallDutyPolicyService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+    jest
+      .spyOn(OnCallDutyPolicyService, "findBy")
+      .mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryOnCallPoliciesTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.dataForLlm).toContain("(no rows found)");
+    expect(result.widget).toBeUndefined();
+  });
+});
+
+describe("get_on_call_status — all schedules", () => {
+  test("reports who is on call now and names the uncovered schedule honestly", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(OnCallDutyPolicyScheduleService, "findBy")
+      .mockResolvedValue([
+        buildSchedule({
+          currentUserName: "Alice Smith",
+          nextUserName: "Bob Jones",
+        }),
+        buildSchedule({
+          id: ObjectID.generate(),
+          name: "Weekend rotation",
+          nextUserName: "Bob Jones",
+        }),
+      ] as never);
+
+    const result: ToolExecutionResult = await GetOnCallStatusTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(2);
+    expect(result.dataForLlm).toContain("Alice Smith");
+    expect(result.dataForLlm).toContain("No one is on call");
+    expect(result.dataForLlm).toContain("Bob Jones");
+    // Handoff time is part of the answer to "who is on call?".
+    expect(result.dataForLlm).toContain("2026-08-18");
+    expect(result.citationLabel).toBe("On-call now (1 responder)");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.OnCallPolicies,
+    });
+    expect(result.widget).toBeDefined();
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["props"]).toBe(ctx.props);
+    expect(callArgs["limit"]).toBe(20);
+  });
+
+  test("clamps the limit argument", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(OnCallDutyPolicyScheduleService, "findBy")
+      .mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await GetOnCallStatusTool.execute(
+      { limit: 999 },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["limit"]).toBe(50);
+  });
+});
+
+describe("get_on_call_status — single schedule", () => {
+  test("returns the current and next on-roster user for one schedule", async () => {
+    jest
+      .spyOn(OnCallDutyPolicyScheduleService, "findOneById")
+      .mockResolvedValue(
+        buildSchedule({
+          currentUserName: "Alice Smith",
+          nextUserName: "Bob Jones",
+        }) as never,
+      );
+
+    const result: ToolExecutionResult = await GetOnCallStatusTool.execute(
+      { scheduleId: SCHEDULE_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(result.dataForLlm).toContain("Alice Smith");
+    expect(result.dataForLlm).toContain("Bob Jones");
+    expect(result.citationLabel).toBe("On-call now: 'Primary rotation'");
+    expect(result.widget).toBeDefined();
+  });
+
+  test("a missing schedule is honest: zero rows, no widget", async () => {
+    jest
+      .spyOn(OnCallDutyPolicyScheduleService, "findOneById")
+      .mockResolvedValue(null as never);
+
+    const result: ToolExecutionResult = await GetOnCallStatusTool.execute(
+      { scheduleId: SCHEDULE_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+  });
+});
+
+describe("get_on_call_status — by policy", () => {
+  test("walks the escalation rules: direct users, teams and schedule rosters", async () => {
+    jest
+      .spyOn(OnCallDutyPolicyService, "findOneById")
+      .mockResolvedValue(buildPolicy() as never);
+    mockEscalationData({
+      rules: [
+        buildRule({ id: RULE_1_ID, order: 1, name: "Primary" }),
+        buildRule({ id: RULE_2_ID, order: 2, name: "Backup" }),
+      ],
+      users: [buildRuleUser(RULE_1_ID, "Alice Smith")],
+      teams: [buildRuleTeam(RULE_2_ID, "SRE")],
+      schedules: [
+        buildRuleSchedule(RULE_1_ID, SCHEDULE_ID, "Primary rotation"),
+      ],
+    });
+    const scheduleFindBySpy: jest.SpyInstance = jest
+      .spyOn(OnCallDutyPolicyScheduleService, "findBy")
+      .mockResolvedValue([
+        buildSchedule({ currentUserName: "Carol Chen" }),
+      ] as never);
+
+    const result: ToolExecutionResult = await GetOnCallStatusTool.execute(
+      { onCallPolicyId: POLICY_ID.toString() },
+      ctx,
+    );
+
+    // Rule 1 direct user + rule 1 schedule roster + rule 2 team.
+    expect(result.rowCount).toBe(3);
+    expect(result.dataForLlm).toContain("Alice Smith");
+    expect(result.dataForLlm).toContain("Carol Chen");
+    expect(result.dataForLlm).toContain("All members of 'SRE'");
+    expect(result.citationLabel).toBe(
+      "On-call now for 'Payments primary' (3 responders)",
+    );
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.OnCallPolicyView,
+      params: { onCallDutyPolicyId: POLICY_ID.toString() },
+    });
+    expect(result.widget).toBeDefined();
+
+    const callArgs: JSONObject = scheduleFindBySpy.mock
+      .calls[0]?.[0] as JSONObject;
+    expect(callArgs["props"]).toBe(ctx.props);
+  });
+
+  test("an unknown policy id is honest: zero rows and a clear label", async () => {
+    jest
+      .spyOn(OnCallDutyPolicyService, "findOneById")
+      .mockResolvedValue(null as never);
+
+    const result: ToolExecutionResult = await GetOnCallStatusTool.execute(
+      { onCallPolicyId: POLICY_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.citationLabel).toBe("On-call now (policy not found)");
+    expect(result.widget).toBeUndefined();
+  });
+});
+
+function buildExecutionLog(data?: {
+  id?: ObjectID;
+  status?: OnCallDutyPolicyStatus;
+  acknowledgedByUserName?: string;
+}): OnCallDutyPolicyExecutionLog {
+  const log: OnCallDutyPolicyExecutionLog = new OnCallDutyPolicyExecutionLog();
+  log._id = (data?.id ?? ObjectID.generate()).toString();
+  log.createdAt = new Date("2026-08-14T01:00:00Z");
+  log.status = data?.status ?? OnCallDutyPolicyStatus.Completed;
+  log.onCallDutyPolicy = buildPolicy();
+  const incident: Incident = new Incident();
+  incident._id = ObjectID.generate().toString();
+  incident.title = "Checkout down";
+  incident.incidentNumber = 42;
+  log.triggeredByIncident = incident;
+  log.lastExecutedEscalationRuleOrder = 1;
+  if (data?.acknowledgedByUserName) {
+    log.acknowledgedByUser = buildUser(data.acknowledgedByUserName);
+    log.acknowledgedAt = new Date("2026-08-14T01:04:00Z");
+  }
+  return log;
+}
+
+function buildUserLog(data: {
+  executionLogId: ObjectID;
+  userName: string;
+  status: UserNotificationExecutionStatus;
+  acknowledged?: boolean;
+}): UserOnCallLog {
+  const userLog: UserOnCallLog = new UserOnCallLog();
+  userLog._id = ObjectID.generate().toString();
+  userLog.onCallDutyPolicyExecutionLogId = data.executionLogId;
+  userLog.user = buildUser(data.userName);
+  userLog.status = data.status;
+  if (data.acknowledged) {
+    userLog.acknowledgedAt = new Date("2026-08-14T01:04:00Z");
+  }
+  return userLog;
+}
+
+describe("query_on_call_pages", () => {
+  test("returns recent executions with trigger, ack and per-user outcomes", async () => {
+    const EXECUTION_ID: ObjectID = ObjectID.generate();
+    jest
+      .spyOn(OnCallDutyPolicyExecutionLogService, "countBy")
+      .mockResolvedValue(new PositiveNumber(1) as never);
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(OnCallDutyPolicyExecutionLogService, "findBy")
+      .mockResolvedValue([
+        buildExecutionLog({
+          id: EXECUTION_ID,
+          acknowledgedByUserName: "Alice Smith",
+        }),
+      ] as never);
+    jest.spyOn(UserOnCallLogService, "findBy").mockResolvedValue([
+      buildUserLog({
+        executionLogId: EXECUTION_ID,
+        userName: "Alice Smith",
+        status: UserNotificationExecutionStatus.Completed,
+        acknowledged: true,
+      }),
+      buildUserLog({
+        executionLogId: EXECUTION_ID,
+        userName: "Bob Jones",
+        status: UserNotificationExecutionStatus.Error,
+      }),
+    ] as never);
+
+    const result: ToolExecutionResult = await QueryOnCallPagesTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(result.dataForLlm).toContain("Incident #42: Checkout down");
+    expect(result.dataForLlm).toContain("Payments primary");
+    expect(result.dataForLlm).toContain(
+      "Alice Smith: Completed (acknowledged)",
+    );
+    expect(result.dataForLlm).toContain("Bob Jones: Error");
+    expect(result.citationLabel).toBe("On-call pages, last 24h (1 found)");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.OnCallPolicies,
+    });
+    expect(result.widget).toBeDefined();
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["props"]).toBe(ctx.props);
+    expect(callArgs["limit"]).toBe(10);
+  });
+
+  test("policy and incident filters reach the service query", async () => {
+    const INCIDENT_ID: ObjectID = ObjectID.generate();
+    jest
+      .spyOn(OnCallDutyPolicyExecutionLogService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(OnCallDutyPolicyExecutionLogService, "findBy")
+      .mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryOnCallPagesTool.execute(
+      {
+        onCallPolicyId: POLICY_ID.toString(),
+        incidentId: INCIDENT_ID.toString(),
+      },
+      ctx,
+    );
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    const query: JSONObject = callArgs["query"] as JSONObject;
+    expect(String(query["onCallDutyPolicyId"])).toBe(POLICY_ID.toString());
+    expect(String(query["triggeredByIncidentId"])).toBe(INCIDENT_ID.toString());
+    // Filtering by a policy makes the citation deep-link to that policy.
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.OnCallPolicyView,
+      params: { onCallDutyPolicyId: POLICY_ID.toString() },
+    });
+  });
+
+  test("honors skip and reports pagination honestly", async () => {
+    jest
+      .spyOn(OnCallDutyPolicyExecutionLogService, "countBy")
+      .mockResolvedValue(new PositiveNumber(40) as never);
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(OnCallDutyPolicyExecutionLogService, "findBy")
+      .mockResolvedValue([buildExecutionLog(), buildExecutionLog()] as never);
+    jest.spyOn(UserOnCallLogService, "findBy").mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryOnCallPagesTool.execute(
+      { skip: 10 },
+      ctx,
+    );
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["skip"]).toBe(10);
+    expect(result.dataForLlm).toContain(
+      "Showing rows 11–12 of 40 total. Pass skip to page further.",
+    );
+    expect(result.citationLabel).toBe("On-call pages, last 24h (2 of 40)");
+  });
+
+  test("rejects an unparseable startTime instead of silently changing the window", async () => {
+    await expect(
+      QueryOnCallPagesTool.execute({ startTime: "not-a-date" }, ctx),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  test("an empty window is honest and skips the per-user fetch", async () => {
+    jest
+      .spyOn(OnCallDutyPolicyExecutionLogService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+    jest
+      .spyOn(OnCallDutyPolicyExecutionLogService, "findBy")
+      .mockResolvedValue([] as never);
+    const userLogSpy: jest.SpyInstance = jest
+      .spyOn(UserOnCallLogService, "findBy")
+      .mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryOnCallPagesTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(userLogSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("on-call tools — permissions", () => {
+  test("required permissions derive from the model read ACLs", () => {
+    expect(QueryOnCallPoliciesTool.requiredPermissions.length).toBeGreaterThan(
+      0,
+    );
+    expect(GetOnCallStatusTool.requiredPermissions.length).toBeGreaterThan(0);
+    expect(QueryOnCallPagesTool.requiredPermissions.length).toBeGreaterThan(0);
+  });
+});

--- a/Common/Tests/Server/Utils/AI/RunbookTools.test.ts
+++ b/Common/Tests/Server/Utils/AI/RunbookTools.test.ts
@@ -1,0 +1,325 @@
+import { QueryRunbooksTool } from "../../../../Server/Utils/AI/Toolbox/RunbookTools";
+import {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../Server/Utils/AI/Toolbox/ToolTypes";
+import RunbookService from "../../../../Server/Services/RunbookService";
+import RunbookExecutionService from "../../../../Server/Services/RunbookExecutionService";
+import Runbook from "../../../../Models/DatabaseModels/Runbook";
+import RunbookExecution from "../../../../Models/DatabaseModels/RunbookExecution";
+import User from "../../../../Models/DatabaseModels/User";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import { JSONArray, JSONObject } from "../../../../Types/JSON";
+import Name from "../../../../Types/Name";
+import ObjectID from "../../../../Types/ObjectID";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import RunbookExecutionStatus from "../../../../Types/Runbook/RunbookExecutionStatus";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * query_runbooks closes the gap where run_runbook said "find the runbook id
+ * with query tools first" but no such tool existed, and "what does our runbook
+ * say?" was unanswerable. These tests lock in what the model relies on: the
+ * detail mode returns the steps IN ORDER with their actual commands plus
+ * recent executions, the list mode paginates honestly, empty results are
+ * honest (rowCount 0, no widget), and citations deep-link to the runbook.
+ */
+
+const ctx: ToolContext = {
+  projectId: ObjectID.generate(),
+  props: { isRoot: true },
+};
+
+const RUNBOOK_ID: ObjectID = ObjectID.generate();
+
+function buildRunbook(data?: {
+  id?: ObjectID;
+  name?: string;
+  isEnabled?: boolean;
+  steps?: JSONArray | undefined;
+}): Runbook {
+  const runbook: Runbook = new Runbook();
+  runbook._id = (data?.id ?? RUNBOOK_ID).toString();
+  runbook.name = data?.name ?? "Database failover";
+  runbook.description = "What to do when the primary database is unreachable.";
+  runbook.isEnabled = data?.isEnabled ?? true;
+  runbook.createdAt = new Date("2026-07-01T09:00:00Z");
+
+  // Deliberately stored out of order — the tool must sort by `order`.
+  const steps: JSONArray | undefined =
+    data && "steps" in data
+      ? data.steps
+      : ([
+          {
+            id: "step-2",
+            order: 2,
+            type: "Bash",
+            title: "Restart API gateway",
+            config: {
+              script: "systemctl restart api-gateway",
+              agentId: "agent-1",
+            },
+          },
+          {
+            id: "step-1",
+            order: 1,
+            type: "Manual",
+            title: "Check dashboards",
+            description: "Open the API latency dashboard and confirm impact.",
+            config: {},
+          },
+        ] as JSONArray);
+
+  // exactOptionalPropertyTypes: leave `steps` unset instead of assigning undefined.
+  if (steps) {
+    runbook.steps = steps;
+  }
+
+  return runbook;
+}
+
+function buildExecution(data?: {
+  status?: RunbookExecutionStatus;
+  triggeredByUserName?: string;
+}): RunbookExecution {
+  const execution: RunbookExecution = new RunbookExecution();
+  execution._id = ObjectID.generate().toString();
+  execution.status = data?.status ?? RunbookExecutionStatus.Completed;
+  execution.createdAt = new Date("2026-08-10T12:00:00Z");
+  execution.startedAt = new Date("2026-08-10T12:00:05Z");
+  execution.completedAt = new Date("2026-08-10T12:02:00Z");
+
+  if (data?.triggeredByUserName) {
+    const user: User = new User();
+    user.name = new Name(data.triggeredByUserName);
+    execution.triggeredByUser = user;
+  }
+
+  return execution;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("query_runbooks — detail mode", () => {
+  test("returns the steps in execution order with their commands, plus recent executions", async () => {
+    jest
+      .spyOn(RunbookService, "findOneById")
+      .mockResolvedValue(buildRunbook() as never);
+
+    const executionsSpy: jest.SpyInstance = jest
+      .spyOn(RunbookExecutionService, "findBy")
+      .mockResolvedValue([
+        buildExecution({ triggeredByUserName: "Sam Rivera" }),
+        buildExecution({ status: RunbookExecutionStatus.Failed }),
+      ] as never);
+
+    const result: ToolExecutionResult = await QueryRunbooksTool.execute(
+      { runbookId: RUNBOOK_ID.toString() },
+      ctx,
+    );
+
+    // Header + 2 steps + 2 executions.
+    expect(result.rowCount).toBe(5);
+
+    // Steps come back sorted by `order`, not storage order.
+    const manualIndex: number = result.dataForLlm.indexOf("Check dashboards");
+    const bashIndex: number = result.dataForLlm.indexOf("Restart API gateway");
+    expect(manualIndex).toBeGreaterThan(-1);
+    expect(bashIndex).toBeGreaterThan(-1);
+    expect(manualIndex).toBeLessThan(bashIndex);
+
+    // The actual command content — the reason this tool exists.
+    expect(result.dataForLlm).toContain("systemctl restart api-gateway");
+
+    // Recent executions: status, who triggered, and rule-triggered fallback.
+    expect(result.dataForLlm).toContain("Completed");
+    expect(result.dataForLlm).toContain("Sam Rivera");
+    expect(result.dataForLlm).toContain("Automation");
+
+    expect(result.citationLabel).toBe('Runbook "Database failover" (2 steps)');
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.RunbookView,
+      params: { runbookId: RUNBOOK_ID.toString() },
+    });
+    expect(result.widget).toBeDefined();
+
+    /*
+     * The executions query is scoped to THIS runbook AND pinned to the
+     * tenant from ctx (runbookId is an untrusted model argument), under the
+     * user's props.
+     */
+    const executionCallArgs: JSONObject = executionsSpy.mock
+      .calls[0]?.[0] as JSONObject;
+    expect(
+      String((executionCallArgs["query"] as JSONObject)["runbookId"]),
+    ).toBe(RUNBOOK_ID.toString());
+    expect(
+      String((executionCallArgs["query"] as JSONObject)["projectId"]),
+    ).toBe(ctx.projectId.toString());
+    expect(executionCallArgs["props"]).toBe(ctx.props);
+  });
+
+  test("a runbook with no steps still returns its header and is honest about the count", async () => {
+    jest
+      .spyOn(RunbookService, "findOneById")
+      .mockResolvedValue(buildRunbook({ steps: undefined }) as never);
+    jest
+      .spyOn(RunbookExecutionService, "findBy")
+      .mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryRunbooksTool.execute(
+      { runbookId: RUNBOOK_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(result.dataForLlm).toContain("stepCount=0");
+    expect(result.citationLabel).toBe('Runbook "Database failover" (0 steps)');
+    expect(result.widget).toBeDefined();
+  });
+
+  test("a missing runbook is honest: zero rows, no widget, no executions fetch", async () => {
+    jest.spyOn(RunbookService, "findOneById").mockResolvedValue(null as never);
+    const executionsSpy: jest.SpyInstance = jest
+      .spyOn(RunbookExecutionService, "findBy")
+      .mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryRunbooksTool.execute(
+      { runbookId: RUNBOOK_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(executionsSpy).not.toHaveBeenCalled();
+  });
+
+  test("steps survive a denied executions fetch — executions are best-effort", async () => {
+    jest
+      .spyOn(RunbookService, "findOneById")
+      .mockResolvedValue(buildRunbook() as never);
+    jest
+      .spyOn(RunbookExecutionService, "findBy")
+      .mockRejectedValue(new Error("Not authorized") as never);
+
+    const result: ToolExecutionResult = await QueryRunbooksTool.execute(
+      { runbookId: RUNBOOK_ID.toString() },
+      ctx,
+    );
+
+    // Header + 2 steps; the denied executions cost nothing else.
+    expect(result.rowCount).toBe(3);
+    expect(result.dataForLlm).toContain("systemctl restart api-gateway");
+  });
+});
+
+describe("query_runbooks — list mode", () => {
+  test("lists runbooks with step count and enabled flag", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(RunbookService, "findBy")
+      .mockResolvedValue([
+        buildRunbook(),
+        buildRunbook({
+          id: ObjectID.generate(),
+          name: "Cache flush",
+          isEnabled: false,
+          steps: undefined,
+        }),
+      ] as never);
+    jest
+      .spyOn(RunbookService, "countBy")
+      .mockResolvedValue(new PositiveNumber(2) as never);
+
+    const result: ToolExecutionResult = await QueryRunbooksTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(2);
+    expect(result.dataForLlm).toContain("Database failover");
+    expect(result.dataForLlm).toContain("Cache flush");
+    expect(result.dataForLlm).toContain("stepCount=2");
+    expect(result.dataForLlm).toContain("enabled=false");
+    // Full result set — no pagination hint.
+    expect(result.dataForLlm).not.toContain("Pass skip to page further");
+    expect(result.citationLabel).toBe("Runbooks (2 found)");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.Runbooks,
+    });
+    expect(result.widget).toBeDefined();
+
+    // The query must run under the requesting user's props, never as root+.
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["props"]).toBe(ctx.props);
+    expect(callArgs["limit"]).toBe(10);
+    expect(callArgs["skip"]).toBe(0);
+  });
+
+  test("pages honestly when more runbooks exist than were returned", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(RunbookService, "findBy")
+      .mockResolvedValue(
+        Array.from({ length: 10 }, (_unused: unknown, index: number) => {
+          return buildRunbook({
+            id: ObjectID.generate(),
+            name: `Runbook ${index + 1}`,
+          });
+        }) as never,
+      );
+    jest
+      .spyOn(RunbookService, "countBy")
+      .mockResolvedValue(new PositiveNumber(40) as never);
+
+    const result: ToolExecutionResult = await QueryRunbooksTool.execute(
+      { skip: 5 },
+      ctx,
+    );
+
+    expect(result.dataForLlm).toContain(
+      "Showing rows 6–15 of 40 total. Pass skip to page further.",
+    );
+    expect(result.citationLabel).toBe("Runbooks (10 of 40)");
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["skip"]).toBe(5);
+  });
+
+  test("clamps limit and skip arguments", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(RunbookService, "findBy")
+      .mockResolvedValue([] as never);
+    jest
+      .spyOn(RunbookService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    await QueryRunbooksTool.execute({ limit: 999, skip: -50 }, ctx);
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["limit"]).toBe(25);
+    expect(callArgs["skip"]).toBe(0);
+  });
+
+  test("an empty project is honest: zero rows and no widget", async () => {
+    jest.spyOn(RunbookService, "findBy").mockResolvedValue([] as never);
+    jest
+      .spyOn(RunbookService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    const result: ToolExecutionResult = await QueryRunbooksTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(result.citationLabel).toBe("Runbooks (0 found)");
+  });
+});
+
+describe("query_runbooks — permissions", () => {
+  test("required permissions derive from the Runbook read ACL", () => {
+    expect(QueryRunbooksTool.requiredPermissions.length).toBeGreaterThan(0);
+  });
+});

--- a/Common/Tests/Server/Utils/AI/SloTools.test.ts
+++ b/Common/Tests/Server/Utils/AI/SloTools.test.ts
@@ -1,0 +1,306 @@
+import { QuerySlosTool } from "../../../../Server/Utils/AI/Toolbox/SloTools";
+import {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../Server/Utils/AI/Toolbox/ToolTypes";
+import ServiceLevelObjectiveService from "../../../../Server/Services/ServiceLevelObjectiveService";
+import ServiceLevelObjectiveBurnRateRuleService from "../../../../Server/Services/ServiceLevelObjectiveBurnRateRuleService";
+import ServiceLevelObjective from "../../../../Models/DatabaseModels/ServiceLevelObjective";
+import ServiceLevelObjectiveBurnRateRule from "../../../../Models/DatabaseModels/ServiceLevelObjectiveBurnRateRule";
+import AlertSeverity from "../../../../Models/DatabaseModels/AlertSeverity";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import SliType from "../../../../Types/ServiceLevelObjective/SliType";
+import SloStatus from "../../../../Types/ServiceLevelObjective/SloStatus";
+import SloWindowType from "../../../../Types/ServiceLevelObjective/SloWindowType";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * query_slos surfaces SLO definitions plus the worker-persisted compliance
+ * columns. These tests lock in what the model relies on: the detail mode
+ * returns the definition, persisted compliance and burn-rate rules for one
+ * SLO; the list mode respects clamps, pagination and the status filter;
+ * compliance is always labeled as persisted (never recomputed); and empty
+ * results are honest (rowCount 0, no widget).
+ */
+
+const ctx: ToolContext = {
+  projectId: ObjectID.generate(),
+  props: { isRoot: true },
+};
+
+const SLO_ID: ObjectID = ObjectID.generate();
+
+function buildSlo(data?: {
+  id?: ObjectID;
+  name?: string;
+  status?: SloStatus;
+  evaluated?: boolean;
+  monitors?: Array<string>;
+}): ServiceLevelObjective {
+  const slo: ServiceLevelObjective = new ServiceLevelObjective();
+  slo._id = (data?.id ?? SLO_ID).toString();
+  slo.name = data?.name ?? "Checkout availability";
+  slo.description = "Checkout must stay reachable.";
+  slo.isEnabled = true;
+  slo.sliType = SliType.MonitorUptime;
+  slo.targetPercentage = 99.9;
+  slo.windowType = SloWindowType.Rolling;
+  slo.windowDays = 30;
+  slo.atRiskThresholdPercentage = 20;
+  slo.sloStatus = data?.status ?? SloStatus.Healthy;
+
+  if (data?.evaluated !== false) {
+    slo.currentSliPercentage = 99.95;
+    slo.errorBudgetRemainingPercentage = 47.3;
+    slo.errorBudgetRemainingSeconds = 20460;
+    slo.errorBudgetTotalSeconds = 43200;
+    slo.currentBurnRate = 0.8;
+    slo.lastEvaluatedAt = new Date("2026-08-14T09:00:00Z");
+  }
+
+  slo.monitors = (data?.monitors ?? ["Checkout API"]).map(
+    (name: string): Monitor => {
+      const monitor: Monitor = new Monitor();
+      monitor.name = name;
+      return monitor;
+    },
+  );
+
+  return slo;
+}
+
+function buildRule(data?: {
+  name?: string;
+  threshold?: number;
+}): ServiceLevelObjectiveBurnRateRule {
+  const rule: ServiceLevelObjectiveBurnRateRule =
+    new ServiceLevelObjectiveBurnRateRule();
+  rule._id = ObjectID.generate().toString();
+  rule.name = data?.name ?? "Fast burn";
+  rule.isEnabled = true;
+  rule.burnRateThreshold = data?.threshold ?? 14.4;
+  rule.longWindowInMinutes = 60;
+  rule.shortWindowInMinutes = 5;
+
+  const severity: AlertSeverity = new AlertSeverity();
+  severity.name = "Critical";
+  rule.alertSeverity = severity;
+
+  return rule;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("query_slos — detail mode", () => {
+  test("returns the definition, persisted compliance and burn-rate rules with a view citation", async () => {
+    jest
+      .spyOn(ServiceLevelObjectiveService, "findOneById")
+      .mockResolvedValue(buildSlo() as never);
+    const rulesSpy: jest.SpyInstance = jest
+      .spyOn(ServiceLevelObjectiveBurnRateRuleService, "findBy")
+      .mockResolvedValue([
+        buildRule({ name: "Fast burn", threshold: 14.4 }),
+        buildRule({ name: "Slow burn", threshold: 3 }),
+      ] as never);
+
+    const result: ToolExecutionResult = await QuerySlosTool.execute(
+      { sloId: SLO_ID.toString() },
+      ctx,
+    );
+
+    // SLO row + 2 burn-rate rule rows.
+    expect(result.rowCount).toBe(3);
+    expect(result.dataForLlm).toContain("Checkout availability");
+    expect(result.dataForLlm).toContain("targetPercentage=99.9");
+    expect(result.dataForLlm).toContain("Rolling 30d");
+    expect(result.dataForLlm).toContain("Checkout API");
+    expect(result.dataForLlm).toContain("currentSliPercentage=99.95");
+    expect(result.dataForLlm).toContain("Fast burn");
+    expect(result.dataForLlm).toContain("burnRateThreshold=14.4");
+    expect(result.dataForLlm).toContain("Slow burn");
+    // Compliance figures must be labeled as persisted, not live.
+    expect(result.dataForLlm).toContain("last worker evaluation");
+    expect(result.citationLabel).toBe("SLO Checkout availability");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.SloView,
+      params: { sloId: SLO_ID.toString() },
+    });
+    expect(result.widget).toBeDefined();
+
+    // Rules are scoped to this SLO and run under the user's props.
+    const ruleCallArgs: JSONObject = rulesSpy.mock.calls[0]?.[0] as JSONObject;
+    expect(
+      (ruleCallArgs["query"] as JSONObject)[
+        "serviceLevelObjectiveId"
+      ]?.toString(),
+    ).toBe(SLO_ID.toString());
+    expect(ruleCallArgs["props"]).toBe(ctx.props);
+  });
+
+  test("a missing SLO is honest: zero rows, no widget, no rule lookup", async () => {
+    jest
+      .spyOn(ServiceLevelObjectiveService, "findOneById")
+      .mockResolvedValue(null as never);
+    const rulesSpy: jest.SpyInstance = jest
+      .spyOn(ServiceLevelObjectiveBurnRateRuleService, "findBy")
+      .mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QuerySlosTool.execute(
+      { sloId: SLO_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(rulesSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("query_slos — list mode", () => {
+  test("lists SLOs with target, window and persisted compliance", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(ServiceLevelObjectiveService, "findBy")
+      .mockResolvedValue([
+        buildSlo(),
+        buildSlo({
+          id: ObjectID.generate(),
+          name: "Search latency",
+          status: SloStatus.AtRisk,
+          evaluated: false,
+          monitors: [],
+        }),
+      ] as never);
+    jest
+      .spyOn(ServiceLevelObjectiveService, "countBy")
+      .mockResolvedValue(new PositiveNumber(2) as never);
+
+    const result: ToolExecutionResult = await QuerySlosTool.execute({}, ctx);
+
+    expect(result.rowCount).toBe(2);
+    expect(result.dataForLlm).toContain("Checkout availability");
+    expect(result.dataForLlm).toContain("Search latency");
+    // Persisted-compliance note travels with every non-empty result.
+    expect(result.dataForLlm).toContain("last worker evaluation");
+    // Nothing paginated: no "Showing rows" banner.
+    expect(result.dataForLlm).not.toContain("Showing rows");
+    expect(result.citationLabel).toBe("SLOs (2 found)");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.Slos,
+    });
+    expect(result.widget).toBeDefined();
+
+    // The query must run under the requesting user's props, never as root+.
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["props"]).toBe(ctx.props);
+    expect(callArgs["limit"]).toBe(10);
+    expect(callArgs["skip"]).toBe(0);
+  });
+
+  test("the sloStatus filter reaches the service query (case-insensitively)", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(ServiceLevelObjectiveService, "findBy")
+      .mockResolvedValue([buildSlo({ status: SloStatus.AtRisk })] as never);
+    const countBySpy: jest.SpyInstance = jest
+      .spyOn(ServiceLevelObjectiveService, "countBy")
+      .mockResolvedValue(new PositiveNumber(1) as never);
+
+    const result: ToolExecutionResult = await QuerySlosTool.execute(
+      { sloStatus: "at risk" },
+      ctx,
+    );
+
+    expect(result.citationLabel).toBe("At Risk SLOs (1 found)");
+
+    const findQuery: JSONObject = (findBySpy.mock.calls[0]?.[0] as JSONObject)[
+      "query"
+    ] as JSONObject;
+    expect(findQuery["sloStatus"]).toBe(SloStatus.AtRisk);
+
+    // countBy must count the same filtered set, or the total lies.
+    const countQuery: JSONObject = (
+      countBySpy.mock.calls[0]?.[0] as JSONObject
+    )["query"] as JSONObject;
+    expect(countQuery["sloStatus"]).toBe(SloStatus.AtRisk);
+  });
+
+  test("an invalid sloStatus is an error envelope, not a silent empty match", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(ServiceLevelObjectiveService, "findBy")
+      .mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QuerySlosTool.execute(
+      { sloStatus: "Exploded" },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.dataForLlm).toContain("Error:");
+    expect(result.dataForLlm).toContain(SloStatus.BudgetExhausted);
+    expect(result.widget).toBeUndefined();
+    expect(findBySpy).not.toHaveBeenCalled();
+  });
+
+  test("clamps limit and skip arguments", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(ServiceLevelObjectiveService, "findBy")
+      .mockResolvedValue([] as never);
+    jest
+      .spyOn(ServiceLevelObjectiveService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    await QuerySlosTool.execute({ limit: 999, skip: -5 }, ctx);
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["limit"]).toBe(25);
+    expect(callArgs["skip"]).toBe(0);
+  });
+
+  test("tells the model when it is only seeing a page of a larger set", async () => {
+    jest
+      .spyOn(ServiceLevelObjectiveService, "findBy")
+      .mockResolvedValue([
+        buildSlo(),
+        buildSlo({ id: ObjectID.generate(), name: "Search latency" }),
+      ] as never);
+    jest
+      .spyOn(ServiceLevelObjectiveService, "countBy")
+      .mockResolvedValue(new PositiveNumber(30) as never);
+
+    const result: ToolExecutionResult = await QuerySlosTool.execute(
+      { skip: 10, limit: 2 },
+      ctx,
+    );
+
+    expect(result.dataForLlm).toContain(
+      "Showing rows 11–12 of 30 total. Pass skip to page further.",
+    );
+    expect(result.citationLabel).toBe("SLOs (30 found)");
+  });
+
+  test("an empty project is honest: zero rows, no widget, no compliance note", async () => {
+    jest
+      .spyOn(ServiceLevelObjectiveService, "findBy")
+      .mockResolvedValue([] as never);
+    jest
+      .spyOn(ServiceLevelObjectiveService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    const result: ToolExecutionResult = await QuerySlosTool.execute({}, ctx);
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(result.dataForLlm).toBe("(no rows found)");
+  });
+});
+
+describe("query_slos — permissions", () => {
+  test("required permissions derive from the model read ACL", () => {
+    expect(QuerySlosTool.requiredPermissions.length).toBeGreaterThan(0);
+  });
+});

--- a/Common/Tests/Server/Utils/AI/StatusPageTools.test.ts
+++ b/Common/Tests/Server/Utils/AI/StatusPageTools.test.ts
@@ -1,0 +1,391 @@
+import {
+  QueryStatusPageAnnouncementsTool,
+  QueryStatusPagesTool,
+} from "../../../../Server/Utils/AI/Toolbox/StatusPageTools";
+import {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../Server/Utils/AI/Toolbox/ToolTypes";
+import StatusPageService from "../../../../Server/Services/StatusPageService";
+import StatusPageAnnouncementService from "../../../../Server/Services/StatusPageAnnouncementService";
+import StatusPageResourceService from "../../../../Server/Services/StatusPageResourceService";
+import StatusPageSubscriberService from "../../../../Server/Services/StatusPageSubscriberService";
+import StatusPage from "../../../../Models/DatabaseModels/StatusPage";
+import StatusPageAnnouncement from "../../../../Models/DatabaseModels/StatusPageAnnouncement";
+import StatusPageResource from "../../../../Models/DatabaseModels/StatusPageResource";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * query_status_pages / query_status_page_announcements close the gap where
+ * chat could post public status updates but could not see which status pages
+ * exist or what they already say. These tests lock in what the model relies
+ * on: list mode shows every page (with visibility and public URL) and pages
+ * honestly, detail mode shows the public blast radius (resources shown) and
+ * the reach of a post (active subscriber count), and citations deep-link to
+ * the right dashboard page.
+ */
+
+const ctx: ToolContext = {
+  projectId: ObjectID.generate(),
+  props: { isRoot: true },
+};
+
+const PAGE_ID: ObjectID = ObjectID.generate();
+
+function buildStatusPage(data?: {
+  id?: ObjectID;
+  name?: string;
+  isPublic?: boolean;
+}): StatusPage {
+  const statusPage: StatusPage = new StatusPage();
+  statusPage._id = (data?.id ?? PAGE_ID).toString();
+  statusPage.name = data?.name ?? "Acme Status";
+  statusPage.description = "Customer-facing status page.";
+  statusPage.isPublicStatusPage = data?.isPublic ?? true;
+  return statusPage;
+}
+
+function buildResource(
+  displayName: string,
+  monitorName?: string,
+): StatusPageResource {
+  const resource: StatusPageResource = new StatusPageResource();
+  resource._id = ObjectID.generate().toString();
+  resource.displayName = displayName;
+
+  if (monitorName) {
+    const monitor: Monitor = new Monitor();
+    monitor.name = monitorName;
+    resource.monitor = monitor;
+  }
+
+  return resource;
+}
+
+function buildAnnouncement(data?: {
+  title?: string;
+  pages?: Array<string>;
+}): StatusPageAnnouncement {
+  const announcement: StatusPageAnnouncement = new StatusPageAnnouncement();
+  announcement._id = ObjectID.generate().toString();
+  announcement.title = data?.title ?? "Elevated error rates";
+  announcement.description = "We are investigating elevated error rates.";
+  announcement.showAnnouncementAt = new Date("2026-08-01T10:00:00Z");
+
+  announcement.statusPages = (data?.pages ?? ["Acme Status"]).map(
+    (name: string): StatusPage => {
+      const statusPage: StatusPage = new StatusPage();
+      statusPage.name = name;
+      return statusPage;
+    },
+  );
+
+  return announcement;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("query_status_pages — list mode", () => {
+  test("lists status pages with visibility and public URL, with a list citation", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(StatusPageService, "findBy")
+      .mockResolvedValue([
+        buildStatusPage(),
+        buildStatusPage({
+          id: ObjectID.generate(),
+          name: "Internal Status",
+          isPublic: false,
+        }),
+      ] as never);
+    jest
+      .spyOn(StatusPageService, "countBy")
+      .mockResolvedValue(new PositiveNumber(2) as never);
+    jest
+      .spyOn(StatusPageService, "getStatusPageURL")
+      .mockResolvedValue("https://status.acme.dev" as never);
+
+    const result: ToolExecutionResult = await QueryStatusPagesTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(2);
+    expect(result.dataForLlm).toContain("Acme Status");
+    expect(result.dataForLlm).toContain("Internal Status");
+    expect(result.dataForLlm).toContain("https://status.acme.dev");
+    expect(result.dataForLlm).toContain("Private");
+    // All rows returned: no paging banner.
+    expect(result.dataForLlm).not.toContain("Showing rows");
+    expect(result.citationLabel).toBe("Status pages (2 total)");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.StatusPages,
+    });
+    expect(result.widget).toBeDefined();
+
+    // The query must run under the requesting user's props, never as root+.
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["props"]).toBe(ctx.props);
+    expect(callArgs["limit"]).toBe(10);
+    expect(callArgs["skip"]).toBe(0);
+  });
+
+  test("marks a paged slice honestly and puts the total in the citation", async () => {
+    jest
+      .spyOn(StatusPageService, "findBy")
+      .mockResolvedValue([
+        buildStatusPage(),
+        buildStatusPage({ id: ObjectID.generate(), name: "EU Status" }),
+      ] as never);
+    jest
+      .spyOn(StatusPageService, "countBy")
+      .mockResolvedValue(new PositiveNumber(5) as never);
+    jest
+      .spyOn(StatusPageService, "getStatusPageURL")
+      .mockResolvedValue("https://status.acme.dev" as never);
+
+    const result: ToolExecutionResult = await QueryStatusPagesTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.dataForLlm.startsWith("Showing rows 1–2 of 5 total.")).toBe(
+      true,
+    );
+    expect(result.citationLabel).toBe("Status pages (5 total)");
+  });
+
+  test("clamps limit and skip; an empty project is honest", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(StatusPageService, "findBy")
+      .mockResolvedValue([] as never);
+    jest
+      .spyOn(StatusPageService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    const result: ToolExecutionResult = await QueryStatusPagesTool.execute(
+      { limit: 999, skip: 99999 },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["limit"]).toBe(25);
+    expect(callArgs["skip"]).toBe(500);
+  });
+
+  test("a public URL lookup failure degrades to no URL, not a tool error", async () => {
+    jest
+      .spyOn(StatusPageService, "findBy")
+      .mockResolvedValue([buildStatusPage()] as never);
+    jest
+      .spyOn(StatusPageService, "countBy")
+      .mockResolvedValue(new PositiveNumber(1) as never);
+    jest
+      .spyOn(StatusPageService, "getStatusPageURL")
+      .mockRejectedValue(new Error("global config unavailable") as never);
+
+    const result: ToolExecutionResult = await QueryStatusPagesTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(result.dataForLlm).toContain("Acme Status");
+    expect(result.dataForLlm).not.toContain("publicUrl=");
+  });
+});
+
+describe("query_status_pages — detail mode", () => {
+  test("returns the page's public resources and active subscriber count with a view citation", async () => {
+    jest
+      .spyOn(StatusPageService, "findOneById")
+      .mockResolvedValue(buildStatusPage() as never);
+    jest
+      .spyOn(StatusPageResourceService, "findBy")
+      .mockResolvedValue([
+        buildResource("Checkout", "checkout-api"),
+        buildResource("CDN"),
+      ] as never);
+    const countBySpy: jest.SpyInstance = jest
+      .spyOn(StatusPageSubscriberService, "countBy")
+      .mockResolvedValue(new PositiveNumber(42) as never);
+    jest
+      .spyOn(StatusPageService, "getStatusPageURL")
+      .mockResolvedValue("https://status.acme.dev" as never);
+
+    const result: ToolExecutionResult = await QueryStatusPagesTool.execute(
+      { statusPageId: PAGE_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(result.dataForLlm).toContain("Checkout (monitor: checkout-api)");
+    expect(result.dataForLlm).toContain("CDN");
+    expect(result.dataForLlm).toContain("activeSubscriberCount=42");
+    expect(result.dataForLlm).toContain("https://status.acme.dev");
+    expect(result.citationLabel).toBe('Status page "Acme Status"');
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.StatusPageView,
+      params: { statusPageId: PAGE_ID.toString() },
+    });
+    expect(result.widget).toBeDefined();
+
+    /*
+     * The subscriber count must be the real reach of a post: scoped to this
+     * page and to confirmed, still-subscribed recipients — under the
+     * requesting user's props, pinned to the tenant (statusPageId is an
+     * untrusted model argument).
+     */
+    const countArgs: JSONObject = countBySpy.mock.calls[0]?.[0] as JSONObject;
+    const countQuery: JSONObject = countArgs["query"] as JSONObject;
+    expect(countQuery["statusPageId"]?.toString()).toBe(PAGE_ID.toString());
+    expect(countQuery["projectId"]).toBe(ctx.projectId);
+    expect(countQuery["isUnsubscribed"]).toBe(false);
+    expect(countQuery["isSubscriptionConfirmed"]).toBe(true);
+    expect(countArgs["props"]).toBe(ctx.props);
+  });
+
+  test("a missing page is honest: zero rows, no widget, no follow-up queries", async () => {
+    jest
+      .spyOn(StatusPageService, "findOneById")
+      .mockResolvedValue(null as never);
+    const resourcesSpy: jest.SpyInstance = jest
+      .spyOn(StatusPageResourceService, "findBy")
+      .mockResolvedValue([] as never);
+    const subscribersSpy: jest.SpyInstance = jest
+      .spyOn(StatusPageSubscriberService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    const result: ToolExecutionResult = await QueryStatusPagesTool.execute(
+      { statusPageId: PAGE_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(resourcesSpy).not.toHaveBeenCalled();
+    expect(subscribersSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("query_status_page_announcements", () => {
+  test("lists recent announcements with the pages they appear on", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(StatusPageAnnouncementService, "findBy")
+      .mockResolvedValue([
+        buildAnnouncement(),
+        buildAnnouncement({
+          title: "Maintenance window scheduled",
+          pages: ["Acme Status", "EU Status"],
+        }),
+      ] as never);
+    jest
+      .spyOn(StatusPageAnnouncementService, "countBy")
+      .mockResolvedValue(new PositiveNumber(2) as never);
+
+    const result: ToolExecutionResult =
+      await QueryStatusPageAnnouncementsTool.execute({}, ctx);
+
+    expect(result.rowCount).toBe(2);
+    expect(result.dataForLlm).toContain("Elevated error rates");
+    expect(result.dataForLlm).toContain("Maintenance window scheduled");
+    expect(result.dataForLlm).toContain("Acme Status, EU Status");
+    expect(result.dataForLlm).toContain("2026-08-01");
+    expect(result.citationLabel).toBe(
+      "Status page announcements, last 30d (2 total)",
+    );
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.StatusPages,
+    });
+    expect(result.widget).toBeDefined();
+
+    // Unfiltered call: window filter present, no relation filter, user props.
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    const query: JSONObject = callArgs["query"] as JSONObject;
+    expect(query["showAnnouncementAt"]).toBeDefined();
+    expect(query["statusPages"]).toBeUndefined();
+    expect(callArgs["props"]).toBe(ctx.props);
+    expect(callArgs["limit"]).toBe(10);
+  });
+
+  test("statusPageId filter reaches the relation query and switches the citation", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(StatusPageAnnouncementService, "findBy")
+      .mockResolvedValue([buildAnnouncement()] as never);
+    jest
+      .spyOn(StatusPageAnnouncementService, "countBy")
+      .mockResolvedValue(new PositiveNumber(1) as never);
+
+    const result: ToolExecutionResult =
+      await QueryStatusPageAnnouncementsTool.execute(
+        { statusPageId: PAGE_ID.toString() },
+        ctx,
+      );
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    const query: JSONObject = callArgs["query"] as JSONObject;
+    expect(query["statusPages"]?.toString()).toBe(PAGE_ID.toString());
+    // The untrusted id filter must come pinned to the tenant from ctx.
+    expect(query["projectId"]).toBe(ctx.projectId);
+
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.StatusPageView,
+      params: { statusPageId: PAGE_ID.toString() },
+    });
+  });
+
+  test("clamps withinDays and limit", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(StatusPageAnnouncementService, "findBy")
+      .mockResolvedValue([] as never);
+    jest
+      .spyOn(StatusPageAnnouncementService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    const result: ToolExecutionResult =
+      await QueryStatusPageAnnouncementsTool.execute(
+        { withinDays: 99999, limit: 500 },
+        ctx,
+      );
+
+    expect(result.citationLabel).toBe(
+      "Status page announcements, last 365d (0 total)",
+    );
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["limit"]).toBe(25);
+  });
+
+  test("an empty window is honest: zero rows and no widget", async () => {
+    jest
+      .spyOn(StatusPageAnnouncementService, "findBy")
+      .mockResolvedValue([] as never);
+    jest
+      .spyOn(StatusPageAnnouncementService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    const result: ToolExecutionResult =
+      await QueryStatusPageAnnouncementsTool.execute({}, ctx);
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+  });
+});
+
+describe("status page tools — permissions", () => {
+  test("required permissions derive from the model read ACLs", () => {
+    expect(QueryStatusPagesTool.requiredPermissions.length).toBeGreaterThan(0);
+    expect(
+      QueryStatusPageAnnouncementsTool.requiredPermissions.length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/Common/Tests/Server/Utils/AI/TeamTools.test.ts
+++ b/Common/Tests/Server/Utils/AI/TeamTools.test.ts
@@ -1,0 +1,257 @@
+import { QueryTeamsTool } from "../../../../Server/Utils/AI/Toolbox/TeamTools";
+import {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../Server/Utils/AI/Toolbox/ToolTypes";
+import TeamService from "../../../../Server/Services/TeamService";
+import TeamMemberService from "../../../../Server/Services/TeamMemberService";
+import Team from "../../../../Models/DatabaseModels/Team";
+import TeamMember from "../../../../Models/DatabaseModels/TeamMember";
+import User from "../../../../Models/DatabaseModels/User";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import { JSONObject } from "../../../../Types/JSON";
+import Email from "../../../../Types/Email";
+import Name from "../../../../Types/Name";
+import ObjectID from "../../../../Types/ObjectID";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * query_teams answers "who is on the platform team?" / "which team should own
+ * this?". These tests lock in what the model relies on: the detail mode
+ * surfaces member NAMES (emails are redacted by the serializer, so a name is
+ * the only member identifier the model can read back), list mode carries a
+ * member count per team, tenancy is pinned from ctx (never an argument), and
+ * empty results are honest (rowCount 0, no widget).
+ */
+
+const ctx: ToolContext = {
+  projectId: ObjectID.generate(),
+  props: { isRoot: true },
+};
+
+const TEAM_ID: ObjectID = ObjectID.generate();
+
+function buildTeam(data?: {
+  id?: ObjectID;
+  name?: string;
+  description?: string;
+}): Team {
+  const team: Team = new Team();
+  team._id = (data?.id ?? TEAM_ID).toString();
+  team.name = data?.name ?? "Platform";
+  team.description = data?.description ?? "Owns shared infrastructure.";
+  return team;
+}
+
+function buildMember(data: {
+  name: string;
+  email: string;
+  teamId?: ObjectID;
+  hasAcceptedInvitation?: boolean;
+}): TeamMember {
+  const member: TeamMember = new TeamMember();
+  member._id = ObjectID.generate().toString();
+  if (data.teamId) {
+    member.teamId = data.teamId;
+  }
+  member.hasAcceptedInvitation = data.hasAcceptedInvitation ?? true;
+
+  const user: User = new User();
+  user._id = ObjectID.generate().toString();
+  user.name = new Name(data.name);
+  user.email = new Email(data.email);
+  member.user = user;
+
+  return member;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("query_teams — detail mode", () => {
+  test("returns the team's members by name, with emails redacted for the LLM", async () => {
+    jest
+      .spyOn(TeamService, "findOneById")
+      .mockResolvedValue(buildTeam() as never);
+
+    const membersSpy: jest.SpyInstance = jest
+      .spyOn(TeamMemberService, "findBy")
+      .mockResolvedValue([
+        buildMember({ name: "Sam Iyer", email: "sam@acme.com" }),
+        buildMember({
+          name: "Riya Patel",
+          email: "riya@acme.com",
+          hasAcceptedInvitation: false,
+        }),
+      ] as never);
+
+    const result: ToolExecutionResult = await QueryTeamsTool.execute(
+      { teamId: TEAM_ID.toString() },
+      ctx,
+    );
+
+    // One team header row + two member rows.
+    expect(result.rowCount).toBe(3);
+    expect(result.dataForLlm).toContain("Platform");
+    expect(result.dataForLlm).toContain("Sam Iyer");
+    expect(result.dataForLlm).toContain("Riya Patel");
+    expect(result.dataForLlm).toContain("invited (not yet accepted)");
+
+    // The serializer must strip emails — names are the usable identifier.
+    expect(result.dataForLlm).not.toContain("sam@acme.com");
+    expect(result.dataForLlm).toContain("[redacted-email]");
+    expect(result.redactionCount).toBeGreaterThanOrEqual(2);
+
+    expect(result.citationLabel).toBe('Team "Platform" (2 members)');
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.Teams,
+    });
+    expect(result.widget).toBeDefined();
+
+    /*
+     * teamId is an untrusted model argument, so the member fetch must be
+     * pinned to the tenant from ctx and run under the user's own props.
+     */
+    const callArgs: JSONObject = membersSpy.mock.calls[0]?.[0] as JSONObject;
+    const query: JSONObject = callArgs["query"] as JSONObject;
+    expect(String(query["teamId"])).toBe(TEAM_ID.toString());
+    expect(query["projectId"]).toBe(ctx.projectId);
+    expect(callArgs["props"]).toBe(ctx.props);
+  });
+
+  test("a missing team is honest: zero rows, no widget", async () => {
+    jest.spyOn(TeamService, "findOneById").mockResolvedValue(null as never);
+    const membersSpy: jest.SpyInstance = jest
+      .spyOn(TeamMemberService, "findBy")
+      .mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryTeamsTool.execute(
+      { teamId: TEAM_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    // No team, no member fetch.
+    expect(membersSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("query_teams — list mode", () => {
+  test("lists teams with a member count per team", async () => {
+    const otherTeamId: ObjectID = ObjectID.generate();
+
+    const teamsSpy: jest.SpyInstance = jest
+      .spyOn(TeamService, "findBy")
+      .mockResolvedValue([
+        buildTeam({ id: TEAM_ID, name: "Platform" }),
+        buildTeam({
+          id: otherTeamId,
+          name: "SRE",
+          description: "Runs on-call.",
+        }),
+      ] as never);
+    jest
+      .spyOn(TeamService, "countBy")
+      .mockResolvedValue(new PositiveNumber(2) as never);
+
+    const membersSpy: jest.SpyInstance = jest
+      .spyOn(TeamMemberService, "findBy")
+      .mockResolvedValue([
+        buildMember({ name: "A", email: "a@x.com", teamId: TEAM_ID }),
+        buildMember({ name: "B", email: "b@x.com", teamId: TEAM_ID }),
+        buildMember({ name: "C", email: "c@x.com", teamId: TEAM_ID }),
+        buildMember({ name: "D", email: "d@x.com", teamId: otherTeamId }),
+      ] as never);
+
+    const result: ToolExecutionResult = await QueryTeamsTool.execute({}, ctx);
+
+    expect(result.rowCount).toBe(2);
+    expect(result.dataForLlm).toContain("Platform");
+    expect(result.dataForLlm).toContain("SRE");
+    expect(result.dataForLlm).toContain("memberCount=3");
+    expect(result.dataForLlm).toContain("memberCount=1");
+    expect(result.citationLabel).toBe("Teams (2 found)");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.Teams,
+    });
+    expect(result.widget).toBeDefined();
+
+    // The team query must run under the requesting user's props, never root+.
+    const teamCallArgs: JSONObject = teamsSpy.mock.calls[0]?.[0] as JSONObject;
+    expect(teamCallArgs["props"]).toBe(ctx.props);
+    expect(teamCallArgs["limit"]).toBe(10);
+
+    // The member-count join fetch is pinned to the tenant from ctx.
+    const memberCallArgs: JSONObject = membersSpy.mock
+      .calls[0]?.[0] as JSONObject;
+    const memberQuery: JSONObject = memberCallArgs["query"] as JSONObject;
+    expect(memberQuery["projectId"]).toBe(ctx.projectId);
+    expect(memberCallArgs["props"]).toBe(ctx.props);
+  });
+
+  test("clamps the limit argument", async () => {
+    const teamsSpy: jest.SpyInstance = jest
+      .spyOn(TeamService, "findBy")
+      .mockResolvedValue([] as never);
+    jest
+      .spyOn(TeamService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+
+    const result: ToolExecutionResult = await QueryTeamsTool.execute(
+      { limit: 999, skip: -5 },
+      ctx,
+    );
+
+    expect(result.citationLabel).toBe("Teams (0 found)");
+
+    const callArgs: JSONObject = teamsSpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["limit"]).toBe(25);
+    expect(callArgs["skip"]).toBe(0);
+  });
+
+  test("tells the model when it is looking at one page of a longer list", async () => {
+    jest
+      .spyOn(TeamService, "findBy")
+      .mockResolvedValue([
+        buildTeam({ id: TEAM_ID, name: "Platform" }),
+        buildTeam({ id: ObjectID.generate(), name: "SRE" }),
+      ] as never);
+    jest
+      .spyOn(TeamService, "countBy")
+      .mockResolvedValue(new PositiveNumber(7) as never);
+    jest.spyOn(TeamMemberService, "findBy").mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryTeamsTool.execute({}, ctx);
+
+    expect(result.dataForLlm).toContain(
+      "Showing rows 1–2 of 7 total. Pass skip to page further.",
+    );
+    expect(result.citationLabel).toBe("Teams (2 of 7)");
+  });
+
+  test("an empty project is honest: zero rows and no widget", async () => {
+    jest.spyOn(TeamService, "findBy").mockResolvedValue([] as never);
+    jest
+      .spyOn(TeamService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+    const membersSpy: jest.SpyInstance = jest
+      .spyOn(TeamMemberService, "findBy")
+      .mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryTeamsTool.execute({}, ctx);
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    // No teams on this page — no member-count fetch either.
+    expect(membersSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("query_teams — permissions", () => {
+  test("required permissions derive from the model read ACL", () => {
+    expect(QueryTeamsTool.requiredPermissions.length).toBeGreaterThan(0);
+  });
+});

--- a/Common/Tests/Server/Utils/AI/TimelineTools.test.ts
+++ b/Common/Tests/Server/Utils/AI/TimelineTools.test.ts
@@ -1,0 +1,472 @@
+import {
+  GetAlertTimelineTool,
+  GetIncidentTimelineTool,
+} from "../../../../Server/Utils/AI/Toolbox/TimelineTools";
+import {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../Server/Utils/AI/Toolbox/ToolTypes";
+import AlertFeedService from "../../../../Server/Services/AlertFeedService";
+import AlertInternalNoteService from "../../../../Server/Services/AlertInternalNoteService";
+import AlertService from "../../../../Server/Services/AlertService";
+import AlertStateTimelineService from "../../../../Server/Services/AlertStateTimelineService";
+import IncidentFeedService from "../../../../Server/Services/IncidentFeedService";
+import IncidentInternalNoteService from "../../../../Server/Services/IncidentInternalNoteService";
+import IncidentPublicNoteService from "../../../../Server/Services/IncidentPublicNoteService";
+import IncidentService from "../../../../Server/Services/IncidentService";
+import IncidentStateTimelineService from "../../../../Server/Services/IncidentStateTimelineService";
+import Alert from "../../../../Models/DatabaseModels/Alert";
+import AlertFeed, {
+  AlertFeedEventType,
+} from "../../../../Models/DatabaseModels/AlertFeed";
+import AlertInternalNote from "../../../../Models/DatabaseModels/AlertInternalNote";
+import AlertState from "../../../../Models/DatabaseModels/AlertState";
+import AlertStateTimeline from "../../../../Models/DatabaseModels/AlertStateTimeline";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import IncidentFeed, {
+  IncidentFeedEventType,
+} from "../../../../Models/DatabaseModels/IncidentFeed";
+import IncidentInternalNote from "../../../../Models/DatabaseModels/IncidentInternalNote";
+import IncidentPublicNote from "../../../../Models/DatabaseModels/IncidentPublicNote";
+import IncidentState from "../../../../Models/DatabaseModels/IncidentState";
+import IncidentStateTimeline from "../../../../Models/DatabaseModels/IncidentStateTimeline";
+import User from "../../../../Models/DatabaseModels/User";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import { JSONObject } from "../../../../Types/JSON";
+import Name from "../../../../Types/Name";
+import ObjectID from "../../../../Types/ObjectID";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * get_incident_timeline / get_alert_timeline merge state changes, notes and
+ * feed events into one chronological thread. These tests lock in what the
+ * model relies on: entries from every source appear tagged and in time order,
+ * the newest-N cap is honest about slicing, tenancy is pinned to ctx, and
+ * missing entities yield empty results instead of phantom timelines.
+ */
+
+const ctx: ToolContext = {
+  projectId: ObjectID.generate(),
+  props: { isRoot: true },
+};
+
+const INCIDENT_ID: ObjectID = ObjectID.generate();
+const ALERT_ID: ObjectID = ObjectID.generate();
+
+function buildUser(name: string): User {
+  const user: User = new User();
+  user.name = new Name(name);
+  return user;
+}
+
+function buildIncident(): Incident {
+  const incident: Incident = new Incident();
+  incident._id = INCIDENT_ID.toString();
+  incident.incidentNumber = 42;
+  incident.title = "Checkout is down";
+  return incident;
+}
+
+function buildStateChange(data: {
+  state: string;
+  at: Date;
+  by?: string;
+  rootCause?: string;
+}): IncidentStateTimeline {
+  const timeline: IncidentStateTimeline = new IncidentStateTimeline();
+  timeline._id = ObjectID.generate().toString();
+  timeline.startsAt = data.at;
+  timeline.createdAt = data.at;
+  if (data.rootCause) {
+    timeline.rootCause = data.rootCause;
+  }
+  const state: IncidentState = new IncidentState();
+  state.name = data.state;
+  timeline.incidentState = state;
+  if (data.by) {
+    timeline.createdByUser = buildUser(data.by);
+  }
+  return timeline;
+}
+
+function buildInternalNote(data: {
+  note: string;
+  at: Date;
+  by?: string;
+}): IncidentInternalNote {
+  const note: IncidentInternalNote = new IncidentInternalNote();
+  note._id = ObjectID.generate().toString();
+  note.note = data.note;
+  note.createdAt = data.at;
+  if (data.by) {
+    note.createdByUser = buildUser(data.by);
+  }
+  return note;
+}
+
+function buildPublicNote(data: {
+  note: string;
+  at: Date;
+  by?: string;
+}): IncidentPublicNote {
+  const note: IncidentPublicNote = new IncidentPublicNote();
+  note._id = ObjectID.generate().toString();
+  note.note = data.note;
+  note.postedAt = data.at;
+  note.createdAt = data.at;
+  if (data.by) {
+    note.createdByUser = buildUser(data.by);
+  }
+  return note;
+}
+
+function buildFeedItem(data: { info: string; at: Date }): IncidentFeed {
+  const feed: IncidentFeed = new IncidentFeed();
+  feed._id = ObjectID.generate().toString();
+  feed.feedInfoInMarkdown = data.info;
+  feed.postedAt = data.at;
+  feed.createdAt = data.at;
+  feed.incidentFeedEventType = IncidentFeedEventType.IncidentCreated;
+  return feed;
+}
+
+function mockIncidentSources(data: {
+  stateTimeline?: Array<IncidentStateTimeline>;
+  internalNotes?: Array<IncidentInternalNote>;
+  publicNotes?: Array<IncidentPublicNote>;
+  feedItems?: Array<IncidentFeed>;
+}): {
+  stateSpy: jest.SpyInstance;
+  internalSpy: jest.SpyInstance;
+  publicSpy: jest.SpyInstance;
+  feedSpy: jest.SpyInstance;
+} {
+  return {
+    stateSpy: jest
+      .spyOn(IncidentStateTimelineService, "findBy")
+      .mockResolvedValue((data.stateTimeline ?? []) as never),
+    internalSpy: jest
+      .spyOn(IncidentInternalNoteService, "findBy")
+      .mockResolvedValue((data.internalNotes ?? []) as never),
+    publicSpy: jest
+      .spyOn(IncidentPublicNoteService, "findBy")
+      .mockResolvedValue((data.publicNotes ?? []) as never),
+    feedSpy: jest
+      .spyOn(IncidentFeedService, "findBy")
+      .mockResolvedValue((data.feedItems ?? []) as never),
+  };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("get_incident_timeline", () => {
+  test("merges all four sources into one chronological, tagged thread", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+
+    const spies: { stateSpy: jest.SpyInstance } = mockIncidentSources({
+      stateTimeline: [
+        buildStateChange({
+          state: "Investigating",
+          at: new Date("2026-08-01T10:00:00Z"),
+          by: "Alice Doe",
+        }),
+      ],
+      internalNotes: [
+        buildInternalNote({
+          note: "Rolled back the deploy.",
+          at: new Date("2026-08-01T10:30:00Z"),
+          by: "Bob Ray",
+        }),
+      ],
+      publicNotes: [
+        buildPublicNote({
+          note: "We are seeing elevated errors.",
+          at: new Date("2026-08-01T11:00:00Z"),
+        }),
+      ],
+      feedItems: [
+        buildFeedItem({
+          info: "Incident created",
+          at: new Date("2026-08-01T09:45:00Z"),
+        }),
+      ],
+    });
+
+    const result: ToolExecutionResult = await GetIncidentTimelineTool.execute(
+      { incidentId: INCIDENT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(4);
+    expect(result.dataForLlm).toContain("Investigating");
+    expect(result.dataForLlm).toContain("Rolled back the deploy.");
+    expect(result.dataForLlm).toContain("We are seeing elevated errors.");
+    expect(result.dataForLlm).toContain("Incident created");
+
+    // Every entry is tagged with its source type and author where available.
+    expect(result.dataForLlm).toContain("state-change");
+    expect(result.dataForLlm).toContain("internal-note");
+    expect(result.dataForLlm).toContain("public-note");
+    expect(result.dataForLlm).toContain("feed");
+    expect(result.dataForLlm).toContain("Alice Doe");
+    expect(result.dataForLlm).toContain("Bob Ray");
+
+    // Chronological order: feed (09:45) → state (10:00) → internal (10:30) → public (11:00).
+    const feedIndex: number = result.dataForLlm.indexOf("Incident created");
+    const stateIndex: number = result.dataForLlm.indexOf("Investigating");
+    const internalIndex: number = result.dataForLlm.indexOf("Rolled back");
+    const publicIndex: number = result.dataForLlm.indexOf("elevated errors");
+    expect(feedIndex).toBeLessThan(stateIndex);
+    expect(stateIndex).toBeLessThan(internalIndex);
+    expect(internalIndex).toBeLessThan(publicIndex);
+
+    expect(result.citationLabel).toBe("Incident #42 timeline (4 entries)");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.IncidentView,
+      params: { incidentId: INCIDENT_ID.toString() },
+    });
+    expect(result.widget).toBeDefined();
+
+    // Tenancy: every source query is pinned to the ctx tenant, under ctx props.
+    const callArgs: JSONObject = spies.stateSpy.mock
+      .calls[0]?.[0] as JSONObject;
+    const query: JSONObject = callArgs["query"] as JSONObject;
+    expect((query["incidentId"] as ObjectID).toString()).toBe(
+      INCIDENT_ID.toString(),
+    );
+    expect(query["projectId"]).toBe(ctx.projectId);
+    expect(callArgs["props"]).toBe(ctx.props);
+  });
+
+  test("clamps limit to 50 on every source query", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+
+    const spies: {
+      stateSpy: jest.SpyInstance;
+      internalSpy: jest.SpyInstance;
+      publicSpy: jest.SpyInstance;
+      feedSpy: jest.SpyInstance;
+    } = mockIncidentSources({});
+
+    await GetIncidentTimelineTool.execute(
+      { incidentId: INCIDENT_ID.toString(), limit: 9999 },
+      ctx,
+    );
+
+    for (const spy of [
+      spies.stateSpy,
+      spies.internalSpy,
+      spies.publicSpy,
+      spies.feedSpy,
+    ]) {
+      const callArgs: JSONObject = spy.mock.calls[0]?.[0] as JSONObject;
+      expect(callArgs["limit"]).toBe(50);
+    }
+  });
+
+  test("keeps only the newest entries when over the limit, and says so", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+
+    mockIncidentSources({
+      stateTimeline: [
+        buildStateChange({
+          state: "Resolved",
+          at: new Date("2026-08-01T12:00:00Z"),
+        }),
+      ],
+      internalNotes: [
+        buildInternalNote({
+          note: "Oldest note, should be dropped.",
+          at: new Date("2026-08-01T09:00:00Z"),
+        }),
+      ],
+      publicNotes: [
+        buildPublicNote({
+          note: "Newest public note.",
+          at: new Date("2026-08-01T13:00:00Z"),
+        }),
+      ],
+    });
+
+    const result: ToolExecutionResult = await GetIncidentTimelineTool.execute(
+      { incidentId: INCIDENT_ID.toString(), limit: 2 },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(2);
+    expect(result.dataForLlm).toContain("Resolved");
+    expect(result.dataForLlm).toContain("Newest public note.");
+    expect(result.dataForLlm).not.toContain("Oldest note");
+    expect(result.dataForLlm).toContain("Showing the newest 2 of 3");
+  });
+
+  test("missing incidentId returns an error envelope, not a query", async () => {
+    const findOneByIdSpy: jest.SpyInstance = jest.spyOn(
+      IncidentService,
+      "findOneById",
+    );
+
+    const result: ToolExecutionResult = await GetIncidentTimelineTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.dataForLlm).toContain("Error: incidentId is required");
+    expect(result.widget).toBeUndefined();
+    expect(findOneByIdSpy).not.toHaveBeenCalled();
+  });
+
+  test("an unknown incident is honest: zero rows, no timeline queries", async () => {
+    jest.spyOn(IncidentService, "findOneById").mockResolvedValue(null as never);
+
+    const spies: { stateSpy: jest.SpyInstance } = mockIncidentSources({});
+
+    const result: ToolExecutionResult = await GetIncidentTimelineTool.execute(
+      { incidentId: INCIDENT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.dataForLlm).toContain("not found");
+    expect(result.widget).toBeUndefined();
+    expect(spies.stateSpy).not.toHaveBeenCalled();
+  });
+
+  test("an incident with no activity yields an honest empty result", async () => {
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(buildIncident() as never);
+
+    mockIncidentSources({});
+
+    const result: ToolExecutionResult = await GetIncidentTimelineTool.execute(
+      { incidentId: INCIDENT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+  });
+
+  test("required permissions derive from the incident read ACL", () => {
+    expect(GetIncidentTimelineTool.requiredPermissions.length).toBeGreaterThan(
+      0,
+    );
+  });
+});
+
+describe("get_alert_timeline", () => {
+  function buildAlert(): Alert {
+    const alert: Alert = new Alert();
+    alert._id = ALERT_ID.toString();
+    alert.alertNumber = 7;
+    alert.title = "CPU is high";
+    return alert;
+  }
+
+  test("merges state changes, internal notes and feed events chronologically", async () => {
+    jest
+      .spyOn(AlertService, "findOneById")
+      .mockResolvedValue(buildAlert() as never);
+
+    const stateTimeline: AlertStateTimeline = new AlertStateTimeline();
+    stateTimeline._id = ObjectID.generate().toString();
+    stateTimeline.startsAt = new Date("2026-08-02T10:00:00Z");
+    stateTimeline.createdAt = new Date("2026-08-02T10:00:00Z");
+    const alertState: AlertState = new AlertState();
+    alertState.name = "Acknowledged";
+    stateTimeline.alertState = alertState;
+    stateTimeline.createdByUser = buildUser("Carol Kim");
+
+    const internalNote: AlertInternalNote = new AlertInternalNote();
+    internalNote._id = ObjectID.generate().toString();
+    internalNote.note = "Scaling up the pool.";
+    internalNote.createdAt = new Date("2026-08-02T10:15:00Z");
+
+    const feedItem: AlertFeed = new AlertFeed();
+    feedItem._id = ObjectID.generate().toString();
+    feedItem.feedInfoInMarkdown = "Alert created";
+    feedItem.postedAt = new Date("2026-08-02T09:55:00Z");
+    feedItem.createdAt = new Date("2026-08-02T09:55:00Z");
+    feedItem.alertFeedEventType = AlertFeedEventType.AlertCreated;
+
+    const stateSpy: jest.SpyInstance = jest
+      .spyOn(AlertStateTimelineService, "findBy")
+      .mockResolvedValue([stateTimeline] as never);
+    jest
+      .spyOn(AlertInternalNoteService, "findBy")
+      .mockResolvedValue([internalNote] as never);
+    jest
+      .spyOn(AlertFeedService, "findBy")
+      .mockResolvedValue([feedItem] as never);
+
+    const result: ToolExecutionResult = await GetAlertTimelineTool.execute(
+      { alertId: ALERT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(3);
+    expect(result.dataForLlm).toContain("Acknowledged");
+    expect(result.dataForLlm).toContain("Scaling up the pool.");
+    expect(result.dataForLlm).toContain("Alert created");
+    expect(result.dataForLlm).toContain("Carol Kim");
+
+    // Chronological: feed (09:55) → state (10:00) → internal note (10:15).
+    const feedIndex: number = result.dataForLlm.indexOf("Alert created");
+    const stateIndex: number = result.dataForLlm.indexOf("Acknowledged");
+    const noteIndex: number = result.dataForLlm.indexOf("Scaling up");
+    expect(feedIndex).toBeLessThan(stateIndex);
+    expect(stateIndex).toBeLessThan(noteIndex);
+
+    expect(result.citationLabel).toBe("Alert #7 timeline (3 entries)");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.AlertView,
+      params: { alertId: ALERT_ID.toString() },
+    });
+    expect(result.widget).toBeDefined();
+
+    // Tenancy is pinned to ctx on the source queries.
+    const callArgs: JSONObject = stateSpy.mock.calls[0]?.[0] as JSONObject;
+    const query: JSONObject = callArgs["query"] as JSONObject;
+    expect((query["alertId"] as ObjectID).toString()).toBe(ALERT_ID.toString());
+    expect(query["projectId"]).toBe(ctx.projectId);
+    expect(callArgs["props"]).toBe(ctx.props);
+  });
+
+  test("missing alertId returns an error envelope", async () => {
+    const result: ToolExecutionResult = await GetAlertTimelineTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.dataForLlm).toContain("Error: alertId is required");
+    expect(result.widget).toBeUndefined();
+  });
+
+  test("an unknown alert is honest: zero rows and no widget", async () => {
+    jest.spyOn(AlertService, "findOneById").mockResolvedValue(null as never);
+
+    const result: ToolExecutionResult = await GetAlertTimelineTool.execute(
+      { alertId: ALERT_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.dataForLlm).toContain("not found");
+    expect(result.widget).toBeUndefined();
+  });
+
+  test("required permissions derive from the alert read ACL", () => {
+    expect(GetAlertTimelineTool.requiredPermissions.length).toBeGreaterThan(0);
+  });
+});

--- a/Common/Tests/Server/Utils/AI/WorkflowProbeTools.test.ts
+++ b/Common/Tests/Server/Utils/AI/WorkflowProbeTools.test.ts
@@ -1,0 +1,428 @@
+import {
+  QueryProbesTool,
+  QueryWorkflowsTool,
+} from "../../../../Server/Utils/AI/Toolbox/WorkflowProbeTools";
+import {
+  ToolContext,
+  ToolExecutionResult,
+} from "../../../../Server/Utils/AI/Toolbox/ToolTypes";
+import MonitorProbeService from "../../../../Server/Services/MonitorProbeService";
+import ProbeService from "../../../../Server/Services/ProbeService";
+import WorkflowLogService from "../../../../Server/Services/WorkflowLogService";
+import WorkflowService from "../../../../Server/Services/WorkflowService";
+import Probe from "../../../../Models/DatabaseModels/Probe";
+import Workflow from "../../../../Models/DatabaseModels/Workflow";
+import WorkflowLog from "../../../../Models/DatabaseModels/WorkflowLog";
+import { AIChatCitationTargetType } from "../../../../Types/AI/AIChatTypes";
+import { JSONObject } from "../../../../Types/JSON";
+import ObjectID from "../../../../Types/ObjectID";
+import OneUptimeDate from "../../../../Types/Date";
+import PositiveNumber from "../../../../Types/PositiveNumber";
+import Version from "../../../../Types/Version";
+import WorkflowStatus from "../../../../Types/Workflow/WorkflowStatus";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * query_workflows and query_probes close the "is my automation running / is
+ * my probe alive" gaps. These tests lock in what the model relies on: detail
+ * mode surfaces the log TAIL of failed runs (where the error actually is),
+ * list mode summarizes recent outcomes per workflow, probe health reuses the
+ * exact 3-minute staleness rule the platform's status worker applies, empty
+ * results stay honest (rowCount 0, no widget), and every query runs under the
+ * requesting user's props.
+ */
+
+const ctx: ToolContext = {
+  projectId: ObjectID.generate(),
+  props: { isRoot: true },
+};
+
+const WORKFLOW_ID: ObjectID = ObjectID.generate();
+const PROJECT_PROBE_ID: ObjectID = ObjectID.generate();
+const GLOBAL_PROBE_ID: ObjectID = ObjectID.generate();
+
+function buildWorkflow(data?: {
+  id?: ObjectID;
+  name?: string;
+  enabled?: boolean;
+}): Workflow {
+  const workflow: Workflow = new Workflow();
+  workflow._id = (data?.id ?? WORKFLOW_ID).toString();
+  workflow.name = data?.name ?? "Deploy notifier";
+  workflow.description = "Notifies the team on deploys.";
+  workflow.isEnabled = data?.enabled ?? true;
+  workflow.createdAt = new Date("2026-07-01T00:00:00Z");
+  return workflow;
+}
+
+function buildRun(data: {
+  status: WorkflowStatus;
+  logs?: string;
+  createdAt?: Date;
+  workflowId?: ObjectID;
+}): WorkflowLog {
+  const run: WorkflowLog = new WorkflowLog();
+  run._id = ObjectID.generate().toString();
+  run.workflowStatus = data.status;
+  run.startedAt = new Date("2026-08-14T10:00:00Z");
+  run.completedAt = new Date("2026-08-14T10:00:42Z");
+  run.createdAt = data.createdAt ?? new Date("2026-08-14T10:00:00Z");
+  if (data.workflowId) {
+    run.workflowId = data.workflowId;
+  }
+  if (data.logs) {
+    run.logs = data.logs;
+  }
+  return run;
+}
+
+function buildProbe(data: {
+  id?: ObjectID;
+  name: string;
+  lastAlive?: Date;
+  version?: string;
+}): Probe {
+  const probe: Probe = new Probe();
+  probe._id = (data.id ?? ObjectID.generate()).toString();
+  probe.name = data.name;
+  probe.description = "Runs checks from one region.";
+  if (data.lastAlive) {
+    probe.lastAlive = data.lastAlive;
+  }
+  probe.probeVersion = new Version(data.version ?? "1.0.2");
+  return probe;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("query_workflows — detail mode", () => {
+  test("returns the workflow, its recent runs and the log tail of failed runs", async () => {
+    jest
+      .spyOn(WorkflowService, "findOneById")
+      .mockResolvedValue(buildWorkflow() as never);
+
+    /*
+     * The failed run's log is longer than the serializer's 500-char field cap
+     * and the error line is at the END — the tool must slice the tail so the
+     * error survives serialization.
+     */
+    const failedRunLogs: string =
+      "A".repeat(600) + "FATAL: webhook returned 500";
+
+    const logsSpy: jest.SpyInstance = jest
+      .spyOn(WorkflowLogService, "findBy")
+      .mockResolvedValue([
+        buildRun({ status: WorkflowStatus.Error, logs: failedRunLogs }),
+        buildRun({ status: WorkflowStatus.Success, logs: "all steps ok" }),
+      ] as never);
+
+    const result: ToolExecutionResult = await QueryWorkflowsTool.execute(
+      { workflowId: WORKFLOW_ID.toString() },
+      ctx,
+    );
+
+    // 1 workflow row + 2 run rows.
+    expect(result.rowCount).toBe(3);
+    expect(result.dataForLlm).toContain("Deploy notifier");
+    expect(result.dataForLlm).toContain("FATAL: webhook returned 500");
+    // Successful runs carry no log text.
+    expect(result.dataForLlm).not.toContain("all steps ok");
+    expect(result.dataForLlm).toContain("durationSeconds=42");
+    expect(result.citationLabel).toBe(
+      'Workflow "Deploy notifier" (2 recent runs)',
+    );
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.WorkflowView,
+      params: { workflowId: WORKFLOW_ID.toString() },
+    });
+    expect(result.widget).toBeDefined();
+
+    /*
+     * The run query must be scoped to this workflow AND pinned to the tenant
+     * (workflowId is an untrusted model argument), under the user's props.
+     */
+    const callArgs: JSONObject = logsSpy.mock.calls[0]?.[0] as JSONObject;
+    expect(String((callArgs["query"] as JSONObject)["workflowId"])).toBe(
+      WORKFLOW_ID.toString(),
+    );
+    expect(String((callArgs["query"] as JSONObject)["projectId"])).toBe(
+      ctx.projectId.toString(),
+    );
+    expect(callArgs["props"]).toBe(ctx.props);
+  });
+
+  test("clamps runsLimit to 20", async () => {
+    jest
+      .spyOn(WorkflowService, "findOneById")
+      .mockResolvedValue(buildWorkflow() as never);
+    const logsSpy: jest.SpyInstance = jest
+      .spyOn(WorkflowLogService, "findBy")
+      .mockResolvedValue([] as never);
+
+    await QueryWorkflowsTool.execute(
+      { workflowId: WORKFLOW_ID.toString(), runsLimit: 999 },
+      ctx,
+    );
+
+    const callArgs: JSONObject = logsSpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["limit"]).toBe(20);
+  });
+
+  test("a missing workflow is honest: zero rows, no widget", async () => {
+    jest.spyOn(WorkflowService, "findOneById").mockResolvedValue(null as never);
+    const logsSpy: jest.SpyInstance = jest.spyOn(WorkflowLogService, "findBy");
+
+    const result: ToolExecutionResult = await QueryWorkflowsTool.execute(
+      { workflowId: WORKFLOW_ID.toString() },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(logsSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("query_workflows — list mode", () => {
+  test("lists workflows with recent run outcomes", async () => {
+    const otherWorkflowId: ObjectID = ObjectID.generate();
+
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(WorkflowService, "findBy")
+      .mockResolvedValue([
+        buildWorkflow(),
+        buildWorkflow({
+          id: otherWorkflowId,
+          name: "Cleanup job",
+          enabled: false,
+        }),
+      ] as never);
+    jest
+      .spyOn(WorkflowService, "countBy")
+      .mockResolvedValue(new PositiveNumber(2) as never);
+
+    // Most-recent-first, matching the sort the tool requests.
+    jest.spyOn(WorkflowLogService, "findBy").mockResolvedValue([
+      buildRun({
+        status: WorkflowStatus.Error,
+        workflowId: WORKFLOW_ID,
+        createdAt: new Date("2026-08-14T09:00:00Z"),
+      }),
+      buildRun({
+        status: WorkflowStatus.Success,
+        workflowId: WORKFLOW_ID,
+        createdAt: new Date("2026-08-14T08:00:00Z"),
+      }),
+    ] as never);
+
+    const result: ToolExecutionResult = await QueryWorkflowsTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(2);
+    expect(result.dataForLlm).toContain("Deploy notifier");
+    expect(result.dataForLlm).toContain("Cleanup job");
+    // The latest run (Error) wins the lastRunStatus slot; one recent failure.
+    expect(result.dataForLlm).toContain("lastRunStatus=Error");
+    expect(result.dataForLlm).toContain("recentFailures=1");
+    expect(result.citationLabel).toBe("Workflows (2 found)");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.Workflows,
+    });
+    expect(result.widget).toBeDefined();
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["props"]).toBe(ctx.props);
+    expect(callArgs["limit"]).toBe(10);
+    expect(callArgs["skip"]).toBe(0);
+  });
+
+  test("clamps limit/skip and reports the total when paging", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(WorkflowService, "findBy")
+      .mockResolvedValue([buildWorkflow()] as never);
+    jest
+      .spyOn(WorkflowService, "countBy")
+      .mockResolvedValue(new PositiveNumber(100) as never);
+    jest.spyOn(WorkflowLogService, "findBy").mockResolvedValue([] as never);
+
+    const result: ToolExecutionResult = await QueryWorkflowsTool.execute(
+      { limit: 999, skip: -10 },
+      ctx,
+    );
+
+    const callArgs: JSONObject = findBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(callArgs["limit"]).toBe(25);
+    expect(callArgs["skip"]).toBe(0);
+
+    expect(result.dataForLlm).toContain(
+      "Showing rows 1–1 of 100 total. Pass skip to page further.",
+    );
+    expect(result.citationLabel).toBe("Workflows (showing 1 of 100)");
+  });
+
+  test("an empty project is honest: zero rows, no widget, no run lookup", async () => {
+    jest.spyOn(WorkflowService, "findBy").mockResolvedValue([] as never);
+    jest
+      .spyOn(WorkflowService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0) as never);
+    const logsSpy: jest.SpyInstance = jest.spyOn(WorkflowLogService, "findBy");
+
+    const result: ToolExecutionResult = await QueryWorkflowsTool.execute(
+      {},
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(logsSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("query_probes", () => {
+  function mockMonitorCounts(): jest.SpyInstance {
+    const countBySpy: jest.SpyInstance = jest.spyOn(
+      MonitorProbeService,
+      "countBy",
+    );
+    countBySpy.mockImplementation((data: unknown): Promise<PositiveNumber> => {
+      const query: JSONObject = (data as JSONObject)["query"] as JSONObject;
+      const probeId: string = String(query["probeId"]);
+      return Promise.resolve(
+        new PositiveNumber(probeId === PROJECT_PROBE_ID.toString() ? 3 : 0),
+      );
+    });
+    return countBySpy;
+  }
+
+  test("reports health, version and monitor counts for custom and global probes", async () => {
+    const probesSpy: jest.SpyInstance = jest
+      .spyOn(ProbeService, "findBy")
+      .mockResolvedValueOnce([
+        buildProbe({
+          id: PROJECT_PROBE_ID,
+          name: "EU probe",
+          lastAlive: OneUptimeDate.getCurrentDate(),
+          version: "3.0.1",
+        }),
+      ] as never)
+      .mockResolvedValueOnce([
+        buildProbe({
+          id: GLOBAL_PROBE_ID,
+          name: "Global US",
+          lastAlive: OneUptimeDate.getSomeMinutesAgo(10),
+        }),
+      ] as never);
+    const countBySpy: jest.SpyInstance = mockMonitorCounts();
+
+    const result: ToolExecutionResult = await QueryProbesTool.execute({}, ctx);
+
+    expect(result.rowCount).toBe(2);
+    expect(result.dataForLlm).toContain("EU probe");
+    expect(result.dataForLlm).toContain("status=connected");
+    expect(result.dataForLlm).toContain("probeVersion=3.0.1");
+    expect(result.dataForLlm).toContain("monitorsServed=3");
+    // The stale global probe is judged with the same 3-minute rule.
+    expect(result.dataForLlm).toContain("Global US");
+    expect(result.dataForLlm).toContain("status=disconnected");
+    expect(result.dataForLlm).toContain("isGlobalProbe=true");
+    expect(result.citationLabel).toBe("Probes (2 found, 1 disconnected)");
+    expect(result.citationTarget).toEqual({
+      type: AIChatCitationTargetType.Probes,
+    });
+    expect(result.widget).toBeDefined();
+
+    // Custom probes: the user's own props. Global probes: pinned root query.
+    const firstCall: JSONObject = probesSpy.mock.calls[0]?.[0] as JSONObject;
+    expect(firstCall["props"]).toBe(ctx.props);
+    const secondCall: JSONObject = probesSpy.mock.calls[1]?.[0] as JSONObject;
+    expect(secondCall["query"]).toEqual({ isGlobalProbe: true });
+    expect((secondCall["props"] as JSONObject)["isRoot"]).toBe(true);
+
+    /*
+     * Monitor counts are tenant-scoped: the user's props AND an explicit
+     * projectId pin, because global probes serve every project.
+     */
+    const countCall: JSONObject = countBySpy.mock.calls[0]?.[0] as JSONObject;
+    expect(countCall["props"]).toBe(ctx.props);
+    expect(String((countCall["query"] as JSONObject)["projectId"])).toBe(
+      ctx.projectId.toString(),
+    );
+  });
+
+  test("a probe at or past the 3-minute cutoff — or with no heartbeat — is disconnected", async () => {
+    jest.spyOn(ProbeService, "findBy").mockResolvedValueOnce([
+      buildProbe({
+        name: "Stale probe",
+        lastAlive: OneUptimeDate.getSomeMinutesAgo(3),
+      }),
+      buildProbe({ name: "Never-seen probe" }),
+    ] as never);
+    mockMonitorCounts();
+
+    const result: ToolExecutionResult = await QueryProbesTool.execute(
+      { includeGlobalProbes: false },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(2);
+    expect(result.dataForLlm).not.toContain("status=connected");
+    expect(result.citationLabel).toBe("Probes (2 found, 2 disconnected)");
+  });
+
+  test("includeGlobalProbes=false skips the global fetch", async () => {
+    const probesSpy: jest.SpyInstance = jest
+      .spyOn(ProbeService, "findBy")
+      .mockResolvedValueOnce([
+        buildProbe({
+          id: PROJECT_PROBE_ID,
+          name: "EU probe",
+          lastAlive: OneUptimeDate.getCurrentDate(),
+        }),
+      ] as never);
+    mockMonitorCounts();
+
+    const result: ToolExecutionResult = await QueryProbesTool.execute(
+      { includeGlobalProbes: false },
+      ctx,
+    );
+
+    expect(result.rowCount).toBe(1);
+    expect(probesSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("clamps the limit argument on both fetches", async () => {
+    const probesSpy: jest.SpyInstance = jest
+      .spyOn(ProbeService, "findBy")
+      .mockResolvedValue([] as never);
+    mockMonitorCounts();
+
+    await QueryProbesTool.execute({ limit: 999 }, ctx);
+
+    const firstCall: JSONObject = probesSpy.mock.calls[0]?.[0] as JSONObject;
+    expect(firstCall["limit"]).toBe(25);
+    const secondCall: JSONObject = probesSpy.mock.calls[1]?.[0] as JSONObject;
+    expect(secondCall["limit"]).toBe(25);
+  });
+
+  test("no probes at all is honest: zero rows, no widget, no monitor counts", async () => {
+    jest.spyOn(ProbeService, "findBy").mockResolvedValue([] as never);
+    const countBySpy: jest.SpyInstance = mockMonitorCounts();
+
+    const result: ToolExecutionResult = await QueryProbesTool.execute({}, ctx);
+
+    expect(result.rowCount).toBe(0);
+    expect(result.widget).toBeUndefined();
+    expect(countBySpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("query_workflows / query_probes — permissions", () => {
+  test("required permissions derive from the model read ACLs", () => {
+    expect(QueryWorkflowsTool.requiredPermissions.length).toBeGreaterThan(0);
+    expect(QueryProbesTool.requiredPermissions.length).toBeGreaterThan(0);
+  });
+});

--- a/Common/Types/AI/AIChatMessageStatus.ts
+++ b/Common/Types/AI/AIChatMessageStatus.ts
@@ -9,6 +9,12 @@ enum AIChatMessageStatus {
   WaitingForApproval = "WaitingForApproval",
   Completed = "Completed",
   Error = "Error",
+  /*
+   * The user pressed Stop: POST /ai-chat/cancel-run finalized the message
+   * mid-generation (contentInMarkdown says so). Terminal like Error, but
+   * deliberate — never counted or rendered as a failure.
+   */
+  Cancelled = "Cancelled",
 }
 
 export default AIChatMessageStatus;
@@ -17,7 +23,8 @@ export class AIChatMessageStatusHelper {
   public static isTerminalStatus(status: AIChatMessageStatus): boolean {
     return (
       status === AIChatMessageStatus.Completed ||
-      status === AIChatMessageStatus.Error
+      status === AIChatMessageStatus.Error ||
+      status === AIChatMessageStatus.Cancelled
     );
   }
 

--- a/Common/Types/AI/AIChatTypes.ts
+++ b/Common/Types/AI/AIChatTypes.ts
@@ -24,6 +24,18 @@ export enum AIChatCitationTargetType {
   MonitorView = "MonitorView",
   ScheduledMaintenanceEvents = "ScheduledMaintenanceEvents",
   ScheduledMaintenanceView = "ScheduledMaintenanceView",
+  OnCallPolicies = "OnCallPolicies",
+  OnCallPolicyView = "OnCallPolicyView",
+  StatusPages = "StatusPages",
+  StatusPageView = "StatusPageView",
+  Slos = "Slos",
+  SloView = "SloView",
+  Runbooks = "Runbooks",
+  RunbookView = "RunbookView",
+  Workflows = "Workflows",
+  WorkflowView = "WorkflowView",
+  Probes = "Probes",
+  Teams = "Teams",
 }
 
 export interface AIChatCitationTarget {

--- a/Common/UI/Utils/AIChatExport/ConversationMarkdown.ts
+++ b/Common/UI/Utils/AIChatExport/ConversationMarkdown.ts
@@ -87,6 +87,16 @@ function messageToMarkdown(
     return lines;
   }
 
+  /*
+   * A cancelled turn's content is the server's finalizer text ("Stopped by
+   * user."), not assistant prose — export it as the stop marker it is, the
+   * same way the chat UI renders it.
+   */
+  if (message.status === AIChatMessageStatus.Cancelled) {
+    lines.push(`> _${message.contentInMarkdown || "Stopped by user."}_`, "");
+    return lines;
+  }
+
   if (message.contentInMarkdown) {
     lines.push(neutralizeAssistantMarkdown(message.contentInMarkdown), "");
   }


### PR DESCRIPTION
## Why

Ask AI's grounding rules (citations, answer-only-from-tools, approval flows) were already strong — but the copilot was **starved**. It had no read access to on-call, incident timelines, status pages, SLOs, runbooks, workflows, probes, or teams; it couldn't see the platform's own AI investigations; it forgot its own evidence between turns; and there was exactly one entry point in the whole product. The "answer only from tool results" rule (correct!) turned every one of those gaps into *"I could not determine that."* This PR feeds it.

## What's included

### 15 new toolbox tools (12 read + 3 actions)
All follow the existing rails: RBAC-derived permissions, tenant pinning, serializer redaction/truncation, server-minted citations, inline widgets, honest empty results, and skip-pagination with disclosed totals.

| Area | Tools |
|---|---|
| On-call | `query_on_call_policies`, `get_on_call_status` (who's on call **right now**), `query_on_call_pages` (delivery/ack outcomes) |
| Incident depth | `get_incident_timeline`, `get_alert_timeline` — one merged chronological thread (state changes, internal/public notes, feed; feed-mirrored events deduped) |
| Platform | `query_status_pages` (+ subscriber reach), `query_status_page_announcements`, `query_slos` (worker-persisted compliance, honestly stamped as-of), `query_runbooks` (full step content), `query_workflows` (failed-run log tails), `query_probes` (health via the 3-min staleness rule), `query_teams` |
| AI self-awareness | `get_ai_investigation` (chat reads the posted RCA instead of re-deriving it), `query_ai_insights`, `start_investigation` (mutation; reuses the durable queue + dedupe/cooldown) |
| Notes | `create_incident_note` / `create_alert_note` — **private** internal notes, clearly contrasted with the public status-update tool |

Also: `page_on_call_policy` / `run_runbook` descriptions now point at real id-discovery tools; incidents/alerts gain a `state` filter (`active` drops the created-at window so a months-old open incident is findable); monitors gain status filters + problems-first sorting.

### Conversation memory
- History replay carries per-turn **evidence digests** (tool + args + row counts) and widget summaries — "what about the second one?" now has a referent.
- Token-budgeted history (~24k tokens) with an explicit omission note; widget-only turns no longer vanish.
- The conversation's subject page-context persists server-side (latest explicit context wins), so "this incident" survives later turns.
- First exchanges get an LLM-generated title (fire-and-forget, never blocks the turn).

### Control & feedback
- `POST /ai-chat/cancel-run` + a stop button in the composer: status-guarded on both sides (API finalization + cooperative runner probes), idempotent under races, no lockouts.
- `POST /ai-chat/message-feedback` + thumbs on every answer (`userFeedback` column) — chat quality is finally measurable.

### Native entry points
- **Ask AI about this** buttons on incident / alert / monitor views; **Cmd/Ctrl+I** global shortcut (with an editable-target guard so italics still works in editors).
- Page context re-detects on navigation while honoring an explicit detach.
- Conversation deep links: `/ai/chat/:conversationId` (panel→full-page expand keeps the thread; rail clicks sync the URL).
- Clickable widget rows; citation-target navigation extended to all new tool types (and the duplicated chip maps consolidated).

### LLM layer
- `stopReason: "length"` mapped from every provider wire and plumbed through `AIService` — truncated answers get a visible marker, and **truncated tool calls are never executed** (both agent loops).
- Blank-model defaults refreshed: OpenAI `gpt-5.1`, Anthropic `claude-sonnet-5`, Ollama `llama3.1`. Azure deliberately keeps `gpt-4o` (that field is a *deployment name*; dots aren't even valid). ⚠️ Self-hosted Ollama installs relying on the blank-model default should `ollama pull llama3.1` (or set a model explicitly).
- Docs: `llm-provider.md` updated off retired Claude 3 ids; new **Ask AI** docs page; provider-settings placeholder strings refreshed.

### Prompt
Investigation-first guidance on incident/alert context (read the posted RCA before re-deriving), a platform-questions routing map, a clarifying-question policy, an explanation of redaction/truncation markers, and confirmed-vs-hypothesis answer shape. All covered by the prompt test suite (50 tests).

## Adversarial review (pre-merge)

An 8-angle multi-agent review of this diff ran before commit. Its 10 confirmed findings are **fixed in this PR** with regression tests — highlights: the AIRun privacy pin silently blanked `get_ai_investigation` for every non-admin (root-props read with user-props subject authorization + projectId pin), truncated tool-call execution, a cancel/error terminal-event race, timeline double-counting, and the Azure default regression.

## Verification

- `Common` tsc: clean. `App` tsc: clean for changed files (remaining errors are pre-existing worktree/main-checkout type-identity artifacts in an untouched test).
- eslint + prettier: clean on all 68 changed files.
- **88 suites / 1495 tests pass** across the AI surface, including ~200 new tests for the new tools, runner memory, cancel/feedback routes, and prompt.

## Notes & follow-ups

- **Migrations**: two hand-written (`AddAIConversationPageContext`, `AddAIChatMessageFeedback`), registered in the index. AGENTS.md prefers the generator; it was avoided here because it would sweep unrelated in-flight columns — the SQL matches generator output shape (nullable jsonb / varchar(100)). Please run `npm run check-postgres-schema-drift` in CI as usual.
- Deferred cleanups (mechanical, no behavior impact — happy to do in a follow-up): extract shared paging-banner/lazy-permissions/owner-lookup/display-name helpers across the tool files; fuse the runner's cancellation probe into the heartbeat write; batch `query_probes` monitor counts; drive the copilot page purely off the route param instead of `replaceState`.
- Token streaming (SSE) is the one roadmap item deliberately not in this PR — it's an infra project across all seven provider wires and deserves its own change.
