### PR TITLE
feat(network): "Run now" to apply Site Assignment / Label Rules retroactively

### DIFF
--- a/App/FeatureSet/BaseAPI/API/NetworkRuleRun.ts
+++ b/App/FeatureSet/BaseAPI/API/NetworkRuleRun.ts
@@ -1,0 +1,241 @@
+import BadDataException from "Common/Types/Exception/BadDataException";
+import NotAuthorizedException from "Common/Types/Exception/NotAuthorizedException";
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import Permission, {
+  PermissionHelper,
+  UserPermission,
+} from "Common/Types/Permission";
+import DatabaseCommonInteractionProps from "Common/Types/BaseDatabase/DatabaseCommonInteractionProps";
+import DatabaseCommonInteractionPropsUtil, {
+  PermissionType,
+} from "Common/Types/BaseDatabase/DatabaseCommonInteractionPropsUtil";
+import CommonAPI from "Common/Server/API/CommonAPI";
+import UserMiddleware from "Common/Server/Middleware/UserAuthorization";
+import Express, {
+  ExpressRequest,
+  ExpressResponse,
+  ExpressRouter,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import Response from "Common/Server/Utils/Response";
+import NetworkDevice from "Common/Models/DatabaseModels/NetworkDevice";
+import NetworkDeviceLabelRule from "Common/Models/DatabaseModels/NetworkDeviceLabelRule";
+import NetworkSiteAssignmentRule from "Common/Models/DatabaseModels/NetworkSiteAssignmentRule";
+import NetworkDeviceLabelRuleEngineService from "Common/Server/Services/NetworkDeviceLabelRuleEngineService";
+import NetworkDeviceService from "Common/Server/Services/NetworkDeviceService";
+import {
+  LabelRuleRunResult,
+  SiteAssignmentRuleRunResult,
+} from "Common/Types/NetworkAutomation/RuleRunResult";
+import DatabaseBaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+
+/*
+ * ------------------------------------------------------------------
+ * NetworkRuleRunAPI
+ *
+ * "Run now" for the two Network Automation rule kinds:
+ *
+ *   POST /network-site-assignment-rule/:ruleId/run
+ *   POST /network-device-label-rule/:ruleId/run
+ *
+ * Both rule kinds only ever fire on device create (and, for site
+ * assignment, on an identity change or the next poll of a device with
+ * no site). A rule written after an estate was imported therefore never
+ * reaches any of it, and short of deleting and rediscovering every
+ * device there was no way to close that gap — OneUptime/oneuptime#3191.
+ * These two endpoints apply one rule to the devices that already exist.
+ *
+ * Both mutate network devices, so both demand the permission to update
+ * the rule AND the permission to update a network device. The required
+ * sets are read off the models' own @TableAccessControl rather than
+ * restated here, so an ACL edit on either model cannot drift from what
+ * these endpoints enforce.
+ * ------------------------------------------------------------------
+ */
+
+/*
+ * The permissions a caller must hold to run a rule of this kind: the rule
+ * model's update ACL, intersected with nothing — both it and NetworkDevice's
+ * update ACL have to be satisfied, checked separately below.
+ */
+function getUpdatePermissions(model: DatabaseBaseModel): Array<Permission> {
+  return model.getUpdatePermissions() || [];
+}
+
+function callerPermissions(
+  props: DatabaseCommonInteractionProps,
+): Array<Permission> {
+  /*
+   * Read through getUserPermissions(Allow) rather than off
+   * userTenantAccessPermission directly: those entries hold grants AND
+   * denials together, discriminated only by isBlockPermission, so mapping
+   * them raw would count a team's explicit block as a grant.
+   */
+  return DatabaseCommonInteractionPropsUtil.getUserPermissions(
+    props,
+    PermissionType.Allow,
+  ).map((userPermission: UserPermission) => {
+    return userPermission.permission;
+  });
+}
+
+function assertCanRunRule(data: {
+  props: DatabaseCommonInteractionProps;
+  ruleModel: DatabaseBaseModel;
+  ruleLabel: string;
+}): void {
+  if (data.props.isMasterAdmin) {
+    return;
+  }
+
+  const held: Array<Permission> = callerPermissions(data.props);
+
+  const holdsAnyOf: (required: Array<Permission>) => boolean = (
+    required: Array<Permission>,
+  ): boolean => {
+    return held.some((permission: Permission) => {
+      return required.includes(permission);
+    });
+  };
+
+  if (!holdsAnyOf(getUpdatePermissions(data.ruleModel))) {
+    throw new NotAuthorizedException(
+      `You do not have permission to run ${data.ruleLabel}.`,
+    );
+  }
+
+  /*
+   * Running a rule writes to devices. Without this a role allowed to author
+   * rules but not to touch the inventory could edit it wholesale through a
+   * rule, which is exactly the permission it does not have.
+   */
+  if (!holdsAnyOf(getUpdatePermissions(new NetworkDevice()))) {
+    throw new NotAuthorizedException(
+      `You do not have permission to update network devices, which running ${data.ruleLabel} does. Missing permission: ${PermissionHelper.getTitle(
+        Permission.EditNetworkDevice,
+      )}.`,
+    );
+  }
+}
+
+/*
+ * ":ruleId" as an ObjectID, or a message the caller can act on. The format
+ * check is explicit: ObjectID's constructor takes any string, so an id that
+ * is not a UUID would otherwise reach the query layer and come back as a
+ * Postgres syntax error instead of a bad request.
+ */
+function readRuleId(req: ExpressRequest): ObjectID {
+  const ruleIdParam: string | undefined = req.params["ruleId"];
+
+  if (!ruleIdParam) {
+    throw new BadDataException("Rule ID is required.");
+  }
+
+  if (!ObjectID.isValidUUID(ruleIdParam)) {
+    throw new BadDataException("Invalid Rule ID.");
+  }
+
+  return new ObjectID(ruleIdParam);
+}
+
+/*
+ * A body flag, read strictly: only a literal `true` turns on the destructive
+ * half of a site assignment run, so a "true" string or a stray 1 cannot move
+ * devices somebody placed by hand.
+ */
+function readBooleanFlag(body: JSONObject, key: string): boolean {
+  return body[key] === true;
+}
+
+export default class NetworkRuleRunAPI {
+  public getRouter(): ExpressRouter {
+    const router: ExpressRouter = Express.getRouter();
+
+    router.post(
+      "/network-site-assignment-rule/:ruleId/run",
+      UserMiddleware.getUserMiddleware,
+      async (
+        req: ExpressRequest,
+        res: ExpressResponse,
+        next: NextFunction,
+      ): Promise<void> => {
+        try {
+          const props: DatabaseCommonInteractionProps =
+            await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+          const projectId: ObjectID = CommonAPI.assertTenantScoped(props);
+
+          assertCanRunRule({
+            props: props,
+            ruleModel: new NetworkSiteAssignmentRule(),
+            ruleLabel: "site assignment rules",
+          });
+
+          const body: JSONObject = (req.body || {}) as JSONObject;
+
+          const result: SiteAssignmentRuleRunResult =
+            await NetworkDeviceService.applySiteAssignmentRuleToExistingDevices(
+              {
+                ruleId: readRuleId(req),
+                projectId: projectId,
+                reassignDevicesAlreadyInASite: readBooleanFlag(
+                  body,
+                  "reassignDevicesAlreadyInASite",
+                ),
+              },
+            );
+
+          return Response.sendJsonObjectResponse(
+            req,
+            res,
+            result as unknown as JSONObject,
+          );
+        } catch (err) {
+          return next(err);
+        }
+      },
+    );
+
+    router.post(
+      "/network-device-label-rule/:ruleId/run",
+      UserMiddleware.getUserMiddleware,
+      async (
+        req: ExpressRequest,
+        res: ExpressResponse,
+        next: NextFunction,
+      ): Promise<void> => {
+        try {
+          const props: DatabaseCommonInteractionProps =
+            await CommonAPI.getDatabaseCommonInteractionProps(req);
+
+          const projectId: ObjectID = CommonAPI.assertTenantScoped(props);
+
+          assertCanRunRule({
+            props: props,
+            ruleModel: new NetworkDeviceLabelRule(),
+            ruleLabel: "network device label rules",
+          });
+
+          const result: LabelRuleRunResult =
+            await NetworkDeviceLabelRuleEngineService.applyRuleToExistingNetworkDevices(
+              {
+                ruleId: readRuleId(req),
+                projectId: projectId,
+              },
+            );
+
+          return Response.sendJsonObjectResponse(
+            req,
+            res,
+            result as unknown as JSONObject,
+          );
+        } catch (err) {
+          return next(err);
+        }
+      },
+    );
+
+    return router;
+  }
+}

--- a/App/FeatureSet/BaseAPI/Index.ts
+++ b/App/FeatureSet/BaseAPI/Index.ts
@@ -109,6 +109,7 @@ import UserAPI from "Common/Server/API/UserAPI";
 import NetworkDeviceFlowAPI from "./API/NetworkDeviceFlow";
 import NetworkDeviceTopologyAPI from "./API/NetworkDeviceTopology";
 import NetworkLatencyMatrixAPI from "./API/NetworkLatencyMatrix";
+import NetworkRuleRunAPI from "./API/NetworkRuleRun";
 import NetworkSiteHierarchyAPI from "./API/NetworkSiteHierarchy";
 import ServiceDependencyTimeseriesAPI from "./API/ServiceDependencyTimeseries";
 import ServiceOperationalStatusAPI from "./API/ServiceOperationalStatus";
@@ -4859,6 +4860,15 @@ const BaseAPIFeatureSet: FeatureSet = {
     app.use(
       `/${APP_NAME.toLocaleLowerCase()}`,
       new NetworkLatencyMatrixAPI().getRouter(),
+    );
+    /*
+     * "Run now" for the network automation rules. Mounted after both rule
+     * models' CRUD routers; BaseAPI claims no `/:id/run` path, so the two
+     * sub-routes here are reached rather than swallowed.
+     */
+    app.use(
+      `/${APP_NAME.toLocaleLowerCase()}`,
+      new NetworkRuleRunAPI().getRouter(),
     );
     app.use(
       `/${APP_NAME.toLocaleLowerCase()}`,

--- a/App/FeatureSet/Dashboard/src/Components/NetworkAutomation/RunRuleNowModal.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkAutomation/RunRuleNowModal.tsx
@@ -1,0 +1,118 @@
+import CheckboxElement from "Common/UI/Components/Checkbox/Checkbox";
+import ConfirmModal from "Common/UI/Components/Modal/ConfirmModal";
+import ModelAPI from "Common/UI/Utils/ModelAPI/ModelAPI";
+import RunNetworkRule, {
+  NetworkRuleKind,
+  NetworkRuleRunOutcome,
+} from "Common/UI/Utils/NetworkAutomation/RunNetworkRule";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useCallback,
+  useState,
+} from "react";
+
+export { NetworkRuleKind };
+
+export interface ComponentProps {
+  ruleKind: NetworkRuleKind;
+  ruleId: string;
+  // Shown in the modal title when the rule has a name; site rules have none.
+  ruleName?: string | undefined;
+  onClose: () => void;
+}
+
+/*
+ * "Run now" for a Network Automation rule: a confirmation first (site
+ * assignment rules can be asked to overwrite existing placements, so that
+ * choice belongs before the run, not after), then the same modal turned into
+ * the report of what the run did.
+ */
+const RunRuleNowModal: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [isRunning, setIsRunning] = useState<boolean>(false);
+  const [error, setError] = useState<string>("");
+  const [summary, setSummary] = useState<string>("");
+  const [reassignDevicesAlreadyInASite, setReassignDevicesAlreadyInASite] =
+    useState<boolean>(false);
+
+  const isSiteAssignment: boolean =
+    props.ruleKind === NetworkRuleKind.SiteAssignment;
+
+  const runRule: () => Promise<void> = useCallback(async (): Promise<void> => {
+    setIsRunning(true);
+    setError("");
+
+    /*
+     * The tenantid header the common headers carry is what scopes the run to
+     * the current project — the endpoint refuses a request without it rather
+     * than guessing.
+     */
+    const outcome: NetworkRuleRunOutcome = await RunNetworkRule.run({
+      ruleKind: props.ruleKind,
+      ruleId: props.ruleId,
+      reassignDevicesAlreadyInASite: reassignDevicesAlreadyInASite,
+      headers: ModelAPI.getCommonHeaders(),
+    });
+
+    if (outcome.isSuccess) {
+      setSummary(outcome.message);
+    } else {
+      setError(outcome.message);
+    }
+
+    setIsRunning(false);
+  }, [props.ruleKind, props.ruleId, reassignDevicesAlreadyInASite]);
+
+  const title: string = props.ruleName
+    ? `Run "${props.ruleName}" Now`
+    : "Run This Rule Now";
+
+  /*
+   * Once the run has answered, the modal stops being a confirmation and
+   * becomes the report: one button, and it closes.
+   */
+  if (summary) {
+    return (
+      <ConfirmModal
+        title={title}
+        description={summary}
+        submitButtonText="Close"
+        onSubmit={props.onClose}
+      />
+    );
+  }
+
+  const description: string = isSiteAssignment
+    ? "Evaluate this rule against the network devices that already exist and assign the ones it matches to its site. Rules normally only run when a device is discovered or renamed, so this is how a rule reaches devices that were already in your inventory when you wrote it.\n\nDevices that already belong to a site are left alone, and a device that also matches a higher-priority rule is left to that rule."
+    : "Evaluate this rule against the network devices that already exist and attach its labels to the ones it matches. Rules normally only run when a device is discovered, so this is how a rule reaches devices that were already in your inventory when you wrote it.\n\nLabels are only added, never removed, so running this more than once is safe.";
+
+  return (
+    <ConfirmModal
+      title={title}
+      description={description}
+      error={error || undefined}
+      isLoading={isRunning}
+      submitButtonText="Run Rule"
+      onSubmit={runRule}
+      onClose={props.onClose}
+    >
+      {isSiteAssignment ? (
+        <CheckboxElement
+          title="Move devices that are already assigned to a site"
+          description="Off by default. Nothing records whether a device's site was chosen by a rule or by a person, so this can move devices somebody placed by hand."
+          value={reassignDevicesAlreadyInASite}
+          dataTestId="run-rule-reassign-devices-checkbox"
+          onChange={(value: boolean) => {
+            setReassignDevicesAlreadyInASite(value);
+          }}
+        />
+      ) : (
+        <></>
+      )}
+    </ConfirmModal>
+  );
+};
+
+export default RunRuleNowModal;

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/LabelRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Settings/LabelRules.tsx
@@ -1,5 +1,11 @@
 import PageComponentProps from "../../PageComponentProps";
+import RunRuleNowModal, {
+  NetworkRuleKind,
+} from "../../../Components/NetworkAutomation/RunRuleNowModal";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { ErrorFunction, VoidFunction } from "Common/Types/FunctionTypes";
+import IconProp from "Common/Types/Icon/IconProp";
+import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import { ModalWidth } from "Common/UI/Components/Modal/Modal";
@@ -7,7 +13,12 @@ import Pill from "Common/UI/Components/Pill/Pill";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import Navigation from "Common/UI/Utils/Navigation";
 import NetworkDeviceLabelRule from "Common/Models/DatabaseModels/NetworkDeviceLabelRule";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, {
+  Fragment,
+  FunctionComponent,
+  ReactElement,
+  useState,
+} from "react";
 import { Green, Red } from "Common/Types/BrandColors";
 import Label from "Common/Models/DatabaseModels/Label";
 
@@ -26,150 +37,200 @@ A rule matches a network device only when **all** specified criteria pass. Empty
 ### Action
 
 When a rule matches, every label listed in \`Labels to Add\` is attached to the network device. Already-attached labels are not duplicated. Multiple matching rules all fire — the union of their labels ends up attached.
+
+### Applying a Rule to Devices You Already Have
+
+Rules fire when a network device is created, so a rule written after your devices were discovered does not reach them. **Run Now** on a rule evaluates it against every network device in the project and attaches its labels to the ones it matches. Labels are only ever added, so running it more than once is safe. A disabled rule will not run.
 `;
 
 const NetworkDeviceLabelRulesPage: FunctionComponent<
   PageComponentProps
 > = (): ReactElement => {
+  // The rule a "Run now" is open for, by id, plus its name for the title.
+  const [ruleBeingRun, setRuleBeingRun] = useState<{
+    id: string;
+    name: string | undefined;
+  } | null>(null);
+
   return (
-    <ModelTable<NetworkDeviceLabelRule>
-      modelType={NetworkDeviceLabelRule}
-      id="networkDevice-label-rules-table"
-      name="Settings > Network Device Label Rules"
-      userPreferencesKey="networkDevice-label-rules-table"
-      saveFilterProps={{
-        tableId: "network-device-label-rules-table",
-      }}
-      isDeleteable={true}
-      isEditable={true}
-      isCreateable={true}
-      createEditModalWidth={ModalWidth.Large}
-      cardProps={{
-        title: "Network Device Label Rules",
-        description:
-          "Auto-attach labels when matching network devices are created.",
-      }}
-      helpContent={{
-        title: "How Network Device Label Rules Work",
-        description: "Match network devices and attach labels automatically.",
-        markdown: networkDeviceLabelDocumentation,
-      }}
-      sortBy="name"
-      sortOrder={SortOrder.Ascending}
-      selectMoreFields={{ isEnabled: true }}
-      filters={[
-        { field: { name: true }, title: "Name", type: FieldType.Text },
-        {
-          field: { isEnabled: true },
-          title: "Enabled",
-          type: FieldType.Boolean,
-        },
-      ]}
-      columns={[
-        { field: { name: true }, title: "Name", type: FieldType.Text },
-        {
-          field: { description: true },
-          title: "Description",
-          type: FieldType.Text,
-        },
-        {
-          field: { isEnabled: true },
-          title: "Status",
-          type: FieldType.Boolean,
-          getElement: (item: NetworkDeviceLabelRule): ReactElement => {
-            return item.isEnabled ? (
-              <Pill color={Green} text="Enabled" />
-            ) : (
-              <Pill color={Red} text="Disabled" />
-            );
+    <Fragment>
+      <ModelTable<NetworkDeviceLabelRule>
+        modelType={NetworkDeviceLabelRule}
+        id="networkDevice-label-rules-table"
+        name="Settings > Network Device Label Rules"
+        userPreferencesKey="networkDevice-label-rules-table"
+        saveFilterProps={{
+          tableId: "network-device-label-rules-table",
+        }}
+        isDeleteable={true}
+        isEditable={true}
+        isCreateable={true}
+        createEditModalWidth={ModalWidth.Large}
+        cardProps={{
+          title: "Network Device Label Rules",
+          description:
+            "Auto-attach labels when matching network devices are created. Use Run Now on a rule to apply it to devices that already exist.",
+        }}
+        helpContent={{
+          title: "How Network Device Label Rules Work",
+          description: "Match network devices and attach labels automatically.",
+          markdown: networkDeviceLabelDocumentation,
+        }}
+        actionButtons={[
+          {
+            title: "Run Now",
+            buttonStyleType: ButtonStyleType.NORMAL,
+            icon: IconProp.Play,
+            onClick: async (
+              item: NetworkDeviceLabelRule,
+              onCompleteAction: VoidFunction,
+              onError: ErrorFunction,
+            ) => {
+              try {
+                const id: string | undefined = item._id?.toString();
+
+                if (id) {
+                  setRuleBeingRun({ id: id, name: item.name });
+                }
+
+                onCompleteAction();
+              } catch (err) {
+                onCompleteAction();
+                onError(err as Error);
+              }
+            },
           },
-        },
-      ]}
-      viewPageRoute={Navigation.getCurrentRoute()}
-      formSteps={[
-        { title: "Basic Info", id: "basic-info" },
-        { title: "Match Criteria", id: "match-criteria", columns: 2 },
-        { title: "Labels", id: "labels", columns: 2 },
-      ]}
-      formFields={[
-        {
-          field: { name: true },
-          title: "Name",
-          stepId: "basic-info",
-          fieldType: FormFieldSchemaType.Text,
-          required: true,
-          placeholder: "Tag matching network devices",
-          validation: { minLength: 2 },
-        },
-        {
-          field: { description: true },
-          title: "Description",
-          stepId: "basic-info",
-          fieldType: FormFieldSchemaType.LongText,
-          required: false,
-        },
-        {
-          field: { isEnabled: true },
-          title: "Enabled",
-          stepId: "basic-info",
-          fieldType: FormFieldSchemaType.Toggle,
-          required: false,
-          description: "Enable or disable this rule.",
-        },
-        {
-          field: { networkDeviceLabels: true },
-          title: "Network Device Labels",
-          stepId: "match-criteria",
-          sectionTitle: "Match by Attributes",
-          sectionDescription:
-            "Only trigger for network devices that already have at least one of these labels. Leave empty to skip the filter.",
-          fieldType: FormFieldSchemaType.MultiSelectDropdown,
-          dropdownModal: {
-            type: Label,
-            labelField: "name",
-            valueField: "_id",
+        ]}
+        sortBy="name"
+        sortOrder={SortOrder.Ascending}
+        selectMoreFields={{ isEnabled: true }}
+        filters={[
+          { field: { name: true }, title: "Name", type: FieldType.Text },
+          {
+            field: { isEnabled: true },
+            title: "Enabled",
+            type: FieldType.Boolean,
           },
-          required: false,
-          placeholder: "Select Network Device Labels (optional)",
-        },
-        {
-          field: { networkDeviceNamePattern: true },
-          title: "Network Device Name Pattern",
-          stepId: "match-criteria",
-          sectionTitle: "Match by Pattern",
-          sectionDescription:
-            "Case-insensitive regex — or a '*' wildcard pattern such as *0664* — matched against the network device name and description.",
-          fieldType: FormFieldSchemaType.Text,
-          required: false,
-          placeholder: "core-switch-.* or *0664*",
-        },
-        {
-          field: { networkDeviceDescriptionPattern: true },
-          title: "Network Device Description Pattern",
-          stepId: "match-criteria",
-          fieldType: FormFieldSchemaType.Text,
-          required: false,
-          placeholder: "production|critical",
-        },
-        {
-          field: { labelsToAdd: true },
-          title: "Labels to Add",
-          stepId: "labels",
-          sectionTitle: "Labels to Attach",
-          sectionDescription:
-            "When this rule matches, every selected label is attached to the network device. Already-attached labels are not duplicated.",
-          fieldType: FormFieldSchemaType.MultiSelectDropdown,
-          dropdownModal: {
-            type: Label,
-            labelField: "name",
-            valueField: "_id",
+        ]}
+        columns={[
+          { field: { name: true }, title: "Name", type: FieldType.Text },
+          {
+            field: { description: true },
+            title: "Description",
+            type: FieldType.Text,
           },
-          required: false,
-          placeholder: "Select Labels",
-        },
-      ]}
-      showRefreshButton={true}
-    />
+          {
+            field: { isEnabled: true },
+            title: "Status",
+            type: FieldType.Boolean,
+            getElement: (item: NetworkDeviceLabelRule): ReactElement => {
+              return item.isEnabled ? (
+                <Pill color={Green} text="Enabled" />
+              ) : (
+                <Pill color={Red} text="Disabled" />
+              );
+            },
+          },
+        ]}
+        viewPageRoute={Navigation.getCurrentRoute()}
+        formSteps={[
+          { title: "Basic Info", id: "basic-info" },
+          { title: "Match Criteria", id: "match-criteria", columns: 2 },
+          { title: "Labels", id: "labels", columns: 2 },
+        ]}
+        formFields={[
+          {
+            field: { name: true },
+            title: "Name",
+            stepId: "basic-info",
+            fieldType: FormFieldSchemaType.Text,
+            required: true,
+            placeholder: "Tag matching network devices",
+            validation: { minLength: 2 },
+          },
+          {
+            field: { description: true },
+            title: "Description",
+            stepId: "basic-info",
+            fieldType: FormFieldSchemaType.LongText,
+            required: false,
+          },
+          {
+            field: { isEnabled: true },
+            title: "Enabled",
+            stepId: "basic-info",
+            fieldType: FormFieldSchemaType.Toggle,
+            required: false,
+            description: "Enable or disable this rule.",
+          },
+          {
+            field: { networkDeviceLabels: true },
+            title: "Network Device Labels",
+            stepId: "match-criteria",
+            sectionTitle: "Match by Attributes",
+            sectionDescription:
+              "Only trigger for network devices that already have at least one of these labels. Leave empty to skip the filter.",
+            fieldType: FormFieldSchemaType.MultiSelectDropdown,
+            dropdownModal: {
+              type: Label,
+              labelField: "name",
+              valueField: "_id",
+            },
+            required: false,
+            placeholder: "Select Network Device Labels (optional)",
+          },
+          {
+            field: { networkDeviceNamePattern: true },
+            title: "Network Device Name Pattern",
+            stepId: "match-criteria",
+            sectionTitle: "Match by Pattern",
+            sectionDescription:
+              "Case-insensitive regex — or a '*' wildcard pattern such as *0664* — matched against the network device name and description.",
+            fieldType: FormFieldSchemaType.Text,
+            required: false,
+            placeholder: "core-switch-.* or *0664*",
+          },
+          {
+            field: { networkDeviceDescriptionPattern: true },
+            title: "Network Device Description Pattern",
+            stepId: "match-criteria",
+            fieldType: FormFieldSchemaType.Text,
+            required: false,
+            placeholder: "production|critical",
+          },
+          {
+            field: { labelsToAdd: true },
+            title: "Labels to Add",
+            stepId: "labels",
+            sectionTitle: "Labels to Attach",
+            sectionDescription:
+              "When this rule matches, every selected label is attached to the network device. Already-attached labels are not duplicated.",
+            fieldType: FormFieldSchemaType.MultiSelectDropdown,
+            dropdownModal: {
+              type: Label,
+              labelField: "name",
+              valueField: "_id",
+            },
+            required: false,
+            placeholder: "Select Labels",
+          },
+        ]}
+        showRefreshButton={true}
+      />
+
+      {ruleBeingRun ? (
+        <RunRuleNowModal
+          ruleKind={NetworkRuleKind.DeviceLabel}
+          ruleId={ruleBeingRun.id}
+          ruleName={ruleBeingRun.name}
+          onClose={() => {
+            setRuleBeingRun(null);
+          }}
+        />
+      ) : (
+        <></>
+      )}
+    </Fragment>
   );
 };
 

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkSite/AssignmentRules.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkSite/AssignmentRules.tsx
@@ -1,15 +1,32 @@
 import PageComponentProps from "../PageComponentProps";
+import RunRuleNowModal, {
+  NetworkRuleKind,
+} from "../../Components/NetworkAutomation/RunRuleNowModal";
 import NetworkSite from "Common/Models/DatabaseModels/NetworkSite";
 import NetworkSiteAssignmentRule from "Common/Models/DatabaseModels/NetworkSiteAssignmentRule";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import { ErrorFunction, VoidFunction } from "Common/Types/FunctionTypes";
+import IconProp from "Common/Types/Icon/IconProp";
+import { ButtonStyleType } from "Common/UI/Components/Button/Button";
 import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
-import React, { Fragment, FunctionComponent, ReactElement } from "react";
+import React, {
+  Fragment,
+  FunctionComponent,
+  ReactElement,
+  useState,
+} from "react";
 
 const NetworkSiteAssignmentRules: FunctionComponent<
   PageComponentProps
 > = (): ReactElement => {
+  /*
+   * The rule a "Run now" is open for. Assignment rules have no name, so the
+   * modal identifies itself by what it is about to do instead.
+   */
+  const [ruleIdBeingRun, setRuleIdBeingRun] = useState<string | null>(null);
+
   return (
     <Fragment>
       <ModelTable<NetworkSiteAssignmentRule>
@@ -27,9 +44,29 @@ const NetworkSiteAssignmentRules: FunctionComponent<
         cardProps={{
           title: "Assignment Rules",
           description:
-            "Automatically assign discovered devices to a site by subnet CIDR or hostname pattern. The higher priority number wins; ties are broken by the older rule. Rules are evaluated when a device is created, when its hostname / name / SNMP system name changes, and on the next poll of any device that has no site yet. A device you assigned to a site by hand is never moved unless its identity changes.",
+            "Automatically assign discovered devices to a site by subnet CIDR or hostname pattern. The higher priority number wins; ties are broken by the older rule. Rules are evaluated when a device is created, when its hostname / name / SNMP system name changes, and on the next poll of any device that has no site yet. A device you assigned to a site by hand is never moved unless its identity changes. Use Run Now on a rule to apply it to devices that already exist.",
         }}
         noItemsMessage="No assignment rules yet. Add one to route newly discovered devices into the right site automatically."
+        actionButtons={[
+          {
+            title: "Run Now",
+            buttonStyleType: ButtonStyleType.NORMAL,
+            icon: IconProp.Play,
+            onClick: async (
+              item: NetworkSiteAssignmentRule,
+              onCompleteAction: VoidFunction,
+              onError: ErrorFunction,
+            ) => {
+              try {
+                setRuleIdBeingRun(item._id?.toString() || null);
+                onCompleteAction();
+              } catch (err) {
+                onCompleteAction();
+                onError(err as Error);
+              }
+            },
+          },
+        ]}
         filters={[
           {
             field: {
@@ -165,6 +202,18 @@ const NetworkSiteAssignmentRules: FunctionComponent<
           },
         ]}
       />
+
+      {ruleIdBeingRun ? (
+        <RunRuleNowModal
+          ruleKind={NetworkRuleKind.SiteAssignment}
+          ruleId={ruleIdBeingRun}
+          onClose={() => {
+            setRuleIdBeingRun(null);
+          }}
+        />
+      ) : (
+        <></>
+      )}
     </Fragment>
   );
 };

--- a/App/Tests/BaseAPI/NetworkRuleRunAPI.test.ts
+++ b/App/Tests/BaseAPI/NetworkRuleRunAPI.test.ts
@@ -1,0 +1,551 @@
+import { mockRouter } from "Common/Tests/Server/API/Helpers";
+import CommonAPI from "Common/Server/API/CommonAPI";
+import NetworkDeviceLabelRuleEngineService from "Common/Server/Services/NetworkDeviceLabelRuleEngineService";
+import NetworkDeviceService from "Common/Server/Services/NetworkDeviceService";
+import Response from "Common/Server/Utils/Response";
+import DatabaseCommonInteractionProps from "Common/Types/BaseDatabase/DatabaseCommonInteractionProps";
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import Permission, { UserPermission } from "Common/Types/Permission";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+jest.mock("Common/Server/Utils/Express", () => {
+  return {
+    __esModule: true,
+    default: {
+      getRouter: () => {
+        return mockRouter;
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendJsonObjectResponse: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Middleware/UserAuthorization", () => {
+  return {
+    __esModule: true,
+    default: {
+      getUserMiddleware: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/NetworkDeviceService", () => {
+  return {
+    __esModule: true,
+    default: { applySiteAssignmentRuleToExistingDevices: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Services/NetworkDeviceLabelRuleEngineService", () => {
+  return {
+    __esModule: true,
+    default: { applyRuleToExistingNetworkDevices: jest.fn() },
+  };
+});
+
+/*
+ * Importing the API module registers both routes on the mocked router, so
+ * each handler can be invoked directly with every service call observable.
+ *
+ * CommonAPI is deliberately NOT mocked: assertTenantScoped is part of what
+ * these endpoints promise, and the permission gate below is only meaningful
+ * against the real props helper.
+ */
+import NetworkRuleRunAPI from "../../FeatureSet/BaseAPI/API/NetworkRuleRun";
+
+new NetworkRuleRunAPI().getRouter();
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const RULE_ID: ObjectID = ObjectID.generate();
+
+const deviceService: {
+  applySiteAssignmentRuleToExistingDevices: jest.Mock;
+} = NetworkDeviceService as unknown as {
+  applySiteAssignmentRuleToExistingDevices: jest.Mock;
+};
+
+const labelRuleEngine: { applyRuleToExistingNetworkDevices: jest.Mock } =
+  NetworkDeviceLabelRuleEngineService as unknown as {
+    applyRuleToExistingNetworkDevices: jest.Mock;
+  };
+
+const responseUtil: { sendJsonObjectResponse: jest.Mock } =
+  Response as unknown as { sendJsonObjectResponse: jest.Mock };
+
+const mockResponse: ExpressResponse = {} as ExpressResponse;
+
+// A caller holding exactly the listed permissions inside the project.
+function propsWith(data: {
+  permissions?: Array<Permission> | undefined;
+  blockedPermissions?: Array<Permission> | undefined;
+  tenantId?: ObjectID | null | undefined;
+  isMasterAdmin?: boolean | undefined;
+}): DatabaseCommonInteractionProps {
+  const tenantId: ObjectID | undefined =
+    data.tenantId === undefined ? PROJECT_ID : data.tenantId || undefined;
+
+  const toUserPermission: (
+    permission: Permission,
+    isBlockPermission: boolean,
+  ) => UserPermission = (
+    permission: Permission,
+    isBlockPermission: boolean,
+  ): UserPermission => {
+    return {
+      permission: permission,
+      labelIds: [],
+      isBlockPermission: isBlockPermission,
+      _type: "UserPermission",
+    } as UserPermission;
+  };
+
+  return {
+    tenantId: tenantId,
+    isMasterAdmin: data.isMasterAdmin || false,
+    userId: ObjectID.generate(),
+    userTenantAccessPermission: tenantId
+      ? {
+          [tenantId.toString()]: {
+            projectId: tenantId,
+            permissions: [
+              ...(data.permissions || []).map((permission: Permission) => {
+                return toUserPermission(permission, false);
+              }),
+              ...(data.blockedPermissions || []).map(
+                (permission: Permission) => {
+                  return toUserPermission(permission, true);
+                },
+              ),
+            ],
+            _type: "UserTenantAccessPermission",
+          },
+        }
+      : undefined,
+  } as unknown as DatabaseCommonInteractionProps;
+}
+
+function mockProps(props: DatabaseCommonInteractionProps): void {
+  jest
+    .spyOn(CommonAPI, "getDatabaseCommonInteractionProps")
+    .mockResolvedValue(props);
+}
+
+async function callRoute(data: {
+  uri: string;
+  ruleId?: string | undefined;
+  body?: JSONObject | undefined;
+}): Promise<NextFunction> {
+  const next: NextFunction = jest.fn() as unknown as NextFunction;
+
+  const req: ExpressRequest = {
+    params: {
+      ruleId: data.ruleId === undefined ? RULE_ID.toString() : data.ruleId,
+    },
+    body: data.body || {},
+  } as unknown as ExpressRequest;
+
+  await mockRouter
+    .match("post", data.uri)
+    .handlerFunction(req, mockResponse, next);
+
+  return next;
+}
+
+const SITE_RULE_URI: string = "/network-site-assignment-rule/:ruleId/run";
+const LABEL_RULE_URI: string = "/network-device-label-rule/:ruleId/run";
+
+function errorFrom(next: NextFunction): Error {
+  const calls: Array<Array<unknown>> = (next as unknown as jest.Mock).mock
+    .calls as Array<Array<unknown>>;
+  expect(calls).toHaveLength(1);
+  return calls[0]![0] as Error;
+}
+
+/*
+ * A role that satisfies both rule kinds. The two models' update ACLs are not
+ * identical - a project member may edit an assignment rule but not a label
+ * rule - so the shared default is the one that clears both.
+ */
+const ADMIN_PERMISSIONS: Array<Permission> = [Permission.ProjectAdmin];
+
+describe("Network automation rule run endpoints", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProps(propsWith({ permissions: ADMIN_PERMISSIONS }));
+    deviceService.applySiteAssignmentRuleToExistingDevices.mockResolvedValue({
+      devicesEvaluated: 3,
+      devicesMatched: 2,
+      devicesAssigned: 2,
+      devicesAlreadyInRuleSite: 0,
+      devicesSkippedAlreadyInAnotherSite: 0,
+      devicesClaimedByHigherPriorityRule: 0,
+      devicesFailed: 0,
+      isTruncated: false,
+    } as never);
+    labelRuleEngine.applyRuleToExistingNetworkDevices.mockResolvedValue({
+      devicesEvaluated: 3,
+      devicesMatched: 2,
+      devicesLabeled: 2,
+      labelsAttached: 2,
+      labelsFailed: 0,
+      isTruncated: false,
+    } as never);
+  });
+
+  describe("route registration", () => {
+    test("both routes are registered behind the user middleware", () => {
+      for (const uri of [SITE_RULE_URI, LABEL_RULE_URI]) {
+        const route: { middlewares: Array<unknown> } = mockRouter.match(
+          "post",
+          uri,
+        );
+        expect(route.middlewares).toHaveLength(1);
+      }
+    });
+  });
+
+  describe("POST /network-site-assignment-rule/:ruleId/run", () => {
+    test("runs the rule for the caller's project and returns the counters", async () => {
+      const next: NextFunction = await callRoute({ uri: SITE_RULE_URI });
+
+      expect(next).not.toHaveBeenCalled();
+
+      const args: JSONObject = deviceService
+        .applySiteAssignmentRuleToExistingDevices.mock
+        .calls[0]![0] as JSONObject;
+
+      expect((args["ruleId"] as ObjectID).toString()).toBe(RULE_ID.toString());
+      expect((args["projectId"] as ObjectID).toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+
+      expect(responseUtil.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+      expect(
+        (responseUtil.sendJsonObjectResponse.mock.calls[0]![2] as JSONObject)[
+          "devicesAssigned"
+        ],
+      ).toBe(2);
+    });
+
+    // The destructive half is off unless the body says so, in as many words.
+    test("does not overwrite existing assignments by default", async () => {
+      await callRoute({ uri: SITE_RULE_URI });
+
+      const args: JSONObject = deviceService
+        .applySiteAssignmentRuleToExistingDevices.mock
+        .calls[0]![0] as JSONObject;
+
+      expect(args["reassignDevicesAlreadyInASite"]).toBe(false);
+    });
+
+    test("passes the overwrite flag through when it is set", async () => {
+      await callRoute({
+        uri: SITE_RULE_URI,
+        body: { reassignDevicesAlreadyInASite: true },
+      });
+
+      const args: JSONObject = deviceService
+        .applySiteAssignmentRuleToExistingDevices.mock
+        .calls[0]![0] as JSONObject;
+
+      expect(args["reassignDevicesAlreadyInASite"]).toBe(true);
+    });
+
+    /*
+     * Only a literal true turns it on. A "true" string or a stray 1 - what a
+     * hand-written client or a form encoder sends - must not be enough to
+     * move devices somebody placed by hand.
+     */
+    test.each([["true"], [1], ["yes"], [{}]])(
+      "treats a non-boolean overwrite flag (%p) as off",
+      async (value: unknown) => {
+        await callRoute({
+          uri: SITE_RULE_URI,
+          body: { reassignDevicesAlreadyInASite: value } as JSONObject,
+        });
+
+        const args: JSONObject = deviceService
+          .applySiteAssignmentRuleToExistingDevices.mock
+          .calls[0]![0] as JSONObject;
+
+        expect(args["reassignDevicesAlreadyInASite"]).toBe(false);
+      },
+    );
+
+    test("rejects a request with no project scope", async () => {
+      mockProps(propsWith({ permissions: ADMIN_PERMISSIONS, tenantId: null }));
+
+      const next: NextFunction = await callRoute({ uri: SITE_RULE_URI });
+
+      expect(errorFrom(next).message).toContain("Project ID is required");
+      expect(
+        deviceService.applySiteAssignmentRuleToExistingDevices,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("rejects a malformed rule id", async () => {
+      const next: NextFunction = await callRoute({
+        uri: SITE_RULE_URI,
+        ruleId: "not-a-uuid",
+      });
+
+      expect(errorFrom(next).message).toContain("Invalid Rule ID");
+      expect(
+        deviceService.applySiteAssignmentRuleToExistingDevices,
+      ).not.toHaveBeenCalled();
+    });
+
+    // A service failure is the caller's answer, not a swallowed 200.
+    test("forwards a service failure to the error handler", async () => {
+      deviceService.applySiteAssignmentRuleToExistingDevices.mockRejectedValue(
+        new Error("Assignment rule not found.") as never,
+      );
+
+      const next: NextFunction = await callRoute({ uri: SITE_RULE_URI });
+
+      expect(errorFrom(next).message).toBe("Assignment rule not found.");
+      expect(responseUtil.sendJsonObjectResponse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /network-device-label-rule/:ruleId/run", () => {
+    test("runs the rule for the caller's project and returns the counters", async () => {
+      const next: NextFunction = await callRoute({ uri: LABEL_RULE_URI });
+
+      expect(next).not.toHaveBeenCalled();
+
+      const args: JSONObject = labelRuleEngine.applyRuleToExistingNetworkDevices
+        .mock.calls[0]![0] as JSONObject;
+
+      expect((args["ruleId"] as ObjectID).toString()).toBe(RULE_ID.toString());
+      expect((args["projectId"] as ObjectID).toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+
+      expect(
+        (responseUtil.sendJsonObjectResponse.mock.calls[0]![2] as JSONObject)[
+          "labelsAttached"
+        ],
+      ).toBe(2);
+    });
+
+    test("rejects a request with no project scope", async () => {
+      mockProps(propsWith({ permissions: ADMIN_PERMISSIONS, tenantId: null }));
+
+      const next: NextFunction = await callRoute({ uri: LABEL_RULE_URI });
+
+      expect(errorFrom(next).message).toContain("Project ID is required");
+      expect(
+        labelRuleEngine.applyRuleToExistingNetworkDevices,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("forwards a service failure to the error handler", async () => {
+      labelRuleEngine.applyRuleToExistingNetworkDevices.mockRejectedValue(
+        new Error("This label rule is disabled.") as never,
+      );
+
+      const next: NextFunction = await callRoute({ uri: LABEL_RULE_URI });
+
+      expect(errorFrom(next).message).toBe("This label rule is disabled.");
+      expect(responseUtil.sendJsonObjectResponse).not.toHaveBeenCalled();
+    });
+  });
+
+  /*
+   * Running a rule writes to the inventory, so it takes the permission to
+   * edit the rule AND the permission to update a network device. Both sets
+   * are read off the models' own access control, so these tests are what
+   * keeps an ACL edit from silently widening the endpoint.
+   */
+  describe("permissions", () => {
+    test.each([
+      [Permission.ProjectOwner],
+      [Permission.ProjectAdmin],
+      [Permission.ProjectMember],
+      [Permission.SettingsAdmin],
+      [Permission.SettingsMember],
+    ])("allows a caller holding %s", async (permission: Permission) => {
+      mockProps(propsWith({ permissions: [permission] }));
+
+      const next: NextFunction = await callRoute({ uri: SITE_RULE_URI });
+
+      expect(next).not.toHaveBeenCalled();
+      expect(
+        deviceService.applySiteAssignmentRuleToExistingDevices,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * The two rule models do not share an update ACL: a project member may
+     * edit an assignment rule but not a label rule. Reading the required set
+     * off each model is what keeps the endpoints in step with that, rather
+     * than inventing a permission story of their own.
+     */
+    test("refuses a project member on the label rule endpoint", async () => {
+      mockProps(propsWith({ permissions: [Permission.ProjectMember] }));
+
+      const next: NextFunction = await callRoute({ uri: LABEL_RULE_URI });
+
+      expect(errorFrom(next).message).toContain(
+        "You do not have permission to run network device label rules",
+      );
+      expect(
+        labelRuleEngine.applyRuleToExistingNetworkDevices,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("refuses a read-only caller", async () => {
+      mockProps(
+        propsWith({
+          permissions: [
+            Permission.Viewer,
+            Permission.ReadNetworkSiteAssignmentRule,
+            Permission.ReadNetworkDevice,
+          ],
+        }),
+      );
+
+      const next: NextFunction = await callRoute({ uri: SITE_RULE_URI });
+
+      expect(errorFrom(next).message).toContain(
+        "You do not have permission to run site assignment rules",
+      );
+      expect(
+        deviceService.applySiteAssignmentRuleToExistingDevices,
+      ).not.toHaveBeenCalled();
+    });
+
+    /*
+     * The device half of the gate: a caller granted the fine-grained rule
+     * permission but not the device one cannot rewrite the inventory
+     * through a rule.
+     */
+    test("refuses a caller who may edit the rule but not devices", async () => {
+      mockProps(
+        propsWith({
+          permissions: [Permission.EditNetworkSiteAssignmentRule],
+        }),
+      );
+
+      const next: NextFunction = await callRoute({ uri: SITE_RULE_URI });
+
+      expect(errorFrom(next).message).toContain(
+        "You do not have permission to update network devices",
+      );
+      expect(
+        deviceService.applySiteAssignmentRuleToExistingDevices,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("allows the fine-grained pair for site assignment rules", async () => {
+      mockProps(
+        propsWith({
+          permissions: [
+            Permission.EditNetworkSiteAssignmentRule,
+            Permission.EditNetworkDevice,
+          ],
+        }),
+      );
+
+      const next: NextFunction = await callRoute({ uri: SITE_RULE_URI });
+
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    test("allows the fine-grained pair for label rules", async () => {
+      mockProps(
+        propsWith({
+          permissions: [
+            Permission.EditNetworkDeviceLabelRule,
+            Permission.EditNetworkDevice,
+          ],
+        }),
+      );
+
+      const next: NextFunction = await callRoute({ uri: LABEL_RULE_URI });
+
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    // The rule kinds do not share a permission: one does not unlock the other.
+    test("refuses a label-rule caller on the site assignment endpoint", async () => {
+      mockProps(
+        propsWith({
+          permissions: [
+            Permission.EditNetworkDeviceLabelRule,
+            Permission.EditNetworkDevice,
+          ],
+        }),
+      );
+
+      const next: NextFunction = await callRoute({ uri: SITE_RULE_URI });
+
+      expect(errorFrom(next).message).toContain(
+        "You do not have permission to run site assignment rules",
+      );
+    });
+
+    /*
+     * A team's explicit BLOCK entry sits in the same permission dictionary as
+     * its grants, discriminated only by isBlockPermission. Reading them raw
+     * would count a block as a grant.
+     */
+    test("does not count a blocked permission as a grant", async () => {
+      mockProps(
+        propsWith({
+          permissions: [],
+          blockedPermissions: [
+            Permission.ProjectAdmin,
+            Permission.EditNetworkDevice,
+          ],
+        }),
+      );
+
+      const next: NextFunction = await callRoute({ uri: SITE_RULE_URI });
+
+      expect(errorFrom(next).message).toContain("You do not have permission");
+      expect(
+        deviceService.applySiteAssignmentRuleToExistingDevices,
+      ).not.toHaveBeenCalled();
+    });
+
+    test("lets a master admin through", async () => {
+      mockProps(propsWith({ permissions: [], isMasterAdmin: true }));
+
+      const next: NextFunction = await callRoute({ uri: SITE_RULE_URI });
+
+      expect(next).not.toHaveBeenCalled();
+      expect(
+        deviceService.applySiteAssignmentRuleToExistingDevices,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    /*
+     * Permission is checked before the project scope is used, but after the
+     * scope assertion - an unscoped request is told about the missing header
+     * rather than about permissions it may well have.
+     */
+    test("reports a missing project scope ahead of a permission failure", async () => {
+      mockProps(propsWith({ permissions: [], tenantId: null }));
+
+      const next: NextFunction = await callRoute({ uri: SITE_RULE_URI });
+
+      expect(errorFrom(next).message).toContain("Project ID is required");
+    });
+  });
+});

--- a/Common/Server/Services/NetworkDeviceLabelRuleEngineService.ts
+++ b/Common/Server/Services/NetworkDeviceLabelRuleEngineService.ts
@@ -3,10 +3,37 @@ import NetworkDevice from "../../Models/DatabaseModels/NetworkDevice";
 import NetworkDeviceLabelRule from "../../Models/DatabaseModels/NetworkDeviceLabelRule";
 import NetworkDeviceLabelRuleService from "./NetworkDeviceLabelRuleService";
 import NetworkDeviceService from "./NetworkDeviceService";
+import BadDataException from "../../Types/Exception/BadDataException";
 import ObjectID from "../../Types/ObjectID";
+import SortOrder from "../../Types/BaseDatabase/SortOrder";
+import { LabelRuleRunResult } from "../../Types/NetworkAutomation/RuleRunResult";
 import RulePatternMatchUtil from "../../Utils/Rules/RulePatternMatchUtil";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
+
+/*
+ * Bounds on one manual "Run now" of a label rule. The automatic path only
+ * ever sees a single freshly created device; a retroactive run walks the
+ * whole estate, so it reads devices in pages and stops at a cap, reporting
+ * isTruncated instead of holding an HTTP request open over a full fleet.
+ */
+export const MAX_DEVICES_PER_LABEL_RULE_RUN: number = 10000;
+const LABEL_RULE_RUN_PAGE_SIZE: number = 1000;
+
+/*
+ * How many (device, label) pairs one INSERT attaches. TypeORM expands
+ * `.of(ids).add(labelId)` into a parameter per id, and Postgres refuses a
+ * statement with more than 65535 of them.
+ */
+const LABEL_ATTACH_CHUNK_SIZE: number = 500;
+
+function chunk<T>(items: Array<T>, size: number): Array<Array<T>> {
+  const chunks: Array<Array<T>> = [];
+  for (let index: number = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
 
 class NetworkDeviceLabelRuleEngineServiceClass {
   /**
@@ -131,6 +158,219 @@ class NetworkDeviceLabelRuleEngineServiceClass {
         networkDeviceId: networkDevice.id?.toString(),
       } as LogAttributes);
     }
+  }
+
+  /*
+   * Runs ONE label rule against the network devices that already exist.
+   *
+   * The automatic engine above only fires on device creation, so a rule
+   * written after an estate was imported or discovered would never reach a
+   * single one of those devices (OneUptime/oneuptime#3191). This is the
+   * manual counterpart: same matcher, same "already-attached labels are not
+   * duplicated" guarantee, applied across the project instead of to one row.
+   *
+   * Safe to run repeatedly — attaching labels is additive and idempotent, so
+   * a second run reports devicesMatched with devicesLabeled at zero.
+   */
+  @CaptureSpan()
+  public async applyRuleToExistingNetworkDevices(data: {
+    ruleId: ObjectID;
+    projectId: ObjectID;
+  }): Promise<LabelRuleRunResult> {
+    const rule: NetworkDeviceLabelRule | null =
+      await NetworkDeviceLabelRuleService.findOneBy({
+        query: {
+          _id: data.ruleId,
+          projectId: data.projectId,
+        },
+        select: {
+          _id: true,
+          name: true,
+          isEnabled: true,
+          networkDeviceLabels: { _id: true },
+          networkDeviceNamePattern: true,
+          networkDeviceDescriptionPattern: true,
+          labelsToAdd: { _id: true },
+        },
+        props: { isRoot: true },
+      });
+
+    if (!rule) {
+      throw new BadDataException("Label rule not found.");
+    }
+
+    /*
+     * A disabled rule is one the user has switched off; running it by hand
+     * would contradict the toggle they can see right next to the button.
+     */
+    if (!rule.isEnabled) {
+      throw new BadDataException(
+        "This label rule is disabled. Enable it before running it.",
+      );
+    }
+
+    const labelIdsToAdd: Array<string> = (rule.labelsToAdd || [])
+      .map((label: Label) => {
+        return label.id?.toString() || "";
+      })
+      .filter((id: string) => {
+        return id !== "";
+      });
+
+    if (labelIdsToAdd.length === 0) {
+      throw new BadDataException(
+        "This label rule has no labels to add, so running it would do nothing.",
+      );
+    }
+
+    const result: LabelRuleRunResult = {
+      devicesEvaluated: 0,
+      devicesMatched: 0,
+      devicesLabeled: 0,
+      labelsAttached: 0,
+      labelsFailed: 0,
+      isTruncated: false,
+    };
+
+    // Counted across pages so a device is never counted twice.
+    const labeledDeviceIds: Set<string> = new Set();
+
+    let skip: number = 0;
+
+    for (;;) {
+      const devices: Array<NetworkDevice> = await NetworkDeviceService.findBy({
+        query: {
+          projectId: data.projectId,
+        },
+        select: {
+          _id: true,
+          name: true,
+          description: true,
+          labels: { _id: true },
+        },
+        /*
+         * Sorted by id so paging stays stable across the writes this run
+         * makes: attaching a label never changes a device's id, so no row
+         * can shift between pages and be skipped or seen twice.
+         */
+        sort: {
+          _id: SortOrder.Ascending,
+        },
+        limit: LABEL_RULE_RUN_PAGE_SIZE,
+        skip: skip,
+        props: { isRoot: true },
+      });
+
+      if (devices.length === 0) {
+        break;
+      }
+
+      /*
+       * One INSERT per label rather than per device: every matched device
+       * needs the same label set, so the work collapses into a handful of
+       * statements no matter how large the estate is.
+       */
+      const deviceIdsByLabelId: Map<string, Array<string>> = new Map();
+
+      for (const device of devices) {
+        result.devicesEvaluated++;
+
+        if (!this.doesNetworkDeviceMatchRule(device, rule)) {
+          continue;
+        }
+
+        result.devicesMatched++;
+
+        const deviceId: string | undefined = device.id?.toString();
+
+        if (!deviceId) {
+          continue;
+        }
+
+        const existingLabelIds: Set<string> = new Set(
+          (device.labels || []).map((label: Label) => {
+            return label.id?.toString() || "";
+          }),
+        );
+
+        for (const labelId of labelIdsToAdd) {
+          if (existingLabelIds.has(labelId)) {
+            continue;
+          }
+
+          const deviceIds: Array<string> =
+            deviceIdsByLabelId.get(labelId) || [];
+          deviceIds.push(deviceId);
+          deviceIdsByLabelId.set(labelId, deviceIds);
+        }
+      }
+
+      for (const [labelId, deviceIds] of deviceIdsByLabelId) {
+        for (const deviceIdChunk of chunk(deviceIds, LABEL_ATTACH_CHUNK_SIZE)) {
+          try {
+            await NetworkDeviceService.getRepository()
+              .createQueryBuilder()
+              .relation(NetworkDevice, "labels")
+              .of(deviceIdChunk)
+              .add(labelId);
+
+            result.labelsAttached += deviceIdChunk.length;
+
+            for (const deviceId of deviceIdChunk) {
+              labeledDeviceIds.add(deviceId);
+            }
+          } catch (error) {
+            /*
+             * A failed batch must not abandon the rest of the estate — the
+             * run reports it and carries on.
+             */
+            result.labelsFailed += deviceIdChunk.length;
+            logger.error(
+              `Error attaching label ${labelId} from network device label rule ${data.ruleId.toString()}: ${error}`,
+              {
+                projectId: data.projectId.toString(),
+              } as LogAttributes,
+            );
+          }
+        }
+      }
+
+      skip += devices.length;
+
+      if (devices.length < LABEL_RULE_RUN_PAGE_SIZE) {
+        break;
+      }
+
+      if (skip >= MAX_DEVICES_PER_LABEL_RULE_RUN) {
+        /*
+         * A full last page is not proof that more devices exist — an estate
+         * of exactly the cap would report a truncation that never happened.
+         * One row settles it.
+         */
+        const nextDevice: Array<NetworkDevice> =
+          await NetworkDeviceService.findBy({
+            query: {
+              projectId: data.projectId,
+            },
+            select: {
+              _id: true,
+            },
+            sort: {
+              _id: SortOrder.Ascending,
+            },
+            limit: 1,
+            skip: skip,
+            props: { isRoot: true },
+          });
+
+        result.isTruncated = nextDevice.length > 0;
+        break;
+      }
+    }
+
+    result.devicesLabeled = labeledDeviceIds.size;
+
+    return result;
   }
 
   private doesNetworkDeviceMatchRule(

--- a/Common/Server/Services/NetworkDeviceService.ts
+++ b/Common/Server/Services/NetworkDeviceService.ts
@@ -14,12 +14,14 @@ import UpdateBy from "../Types/Database/UpdateBy";
 import Query from "../Types/Database/Query";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import logger, { LogAttributes } from "../Utils/Logger";
-import LIMIT_MAX from "../../Types/Database/LimitMax";
+import LIMIT_MAX, { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
+import SortOrder from "../../Types/BaseDatabase/SortOrder";
 import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import BadDataException from "../../Types/Exception/BadDataException";
 import ObjectID from "../../Types/ObjectID";
 import OneUptimeDate from "../../Types/Date";
 import CidrMatchUtil from "../../Utils/NetworkSite/CidrMatchUtil";
+import { SiteAssignmentRuleRunResult } from "../../Types/NetworkAutomation/RuleRunResult";
 import { NetworkDeviceMonitoringMethodUtil } from "../../Types/NetworkDevice/NetworkDeviceMonitoringMethod";
 import RelationIdUtil from "../Utils/Database/RelationIdUtil";
 import { EntityManager } from "typeorm";
@@ -76,6 +78,39 @@ const MONITOR_KEYS: Array<string> = ["monitorId", "monitor"];
 
 function readMonitorIdFromData(data: Record<string, unknown>): ObjectID | null {
   return RelationIdUtil.read(data, MONITOR_KEYS);
+}
+
+/*
+ * How many devices a single manual "Run now" of an assignment rule walks.
+ * The automatic path only ever sees one device at a time, so this cap is the
+ * only thing standing between a rule run and a full-fleet table scan inside
+ * one HTTP request. Runs that hit it report isTruncated so the caller can say
+ * "run it again" rather than quietly leave half the estate unassigned.
+ */
+export const MAX_DEVICES_PER_RULE_RUN: number = LIMIT_PER_PROJECT;
+
+// Devices are read in pages so a large estate never lands in memory at once.
+const RULE_RUN_PAGE_SIZE: number = 1000;
+
+/*
+ * The identity a rule is matched against. The hostname column holds an IP
+ * address or a DNS name depending on how the device got here, so it is passed
+ * as both — ipInCidr rejects non-IP strings safely. Mirrors the single-device
+ * path in applySiteAssignmentRulesToDevice; both must stay in step or a
+ * manual run would disagree with what discovery does.
+ */
+function toRuleMatchTarget(device: Model): {
+  ip: string | undefined;
+  hostname: string | undefined;
+  sysName: string | undefined;
+  name: string | undefined;
+} {
+  return {
+    ip: device.hostname,
+    hostname: device.hostname,
+    sysName: device.sysName,
+    name: device.name,
+  };
 }
 
 export class Service extends DatabaseService<Model> {
@@ -616,20 +651,14 @@ export class Service extends DatabaseService<Model> {
     }
 
     /*
-     * The device's hostname column stores an IP address or a DNS name; pass
-     * it as both — ipInCidr safely rejects non-IP strings. `name` is passed
-     * too because a discovery import puts the responding IP in `hostname`
-     * and the device's real identity in `name`, so a hostname pattern that
-     * only ever saw `hostname` could not match anything a user recognises.
+     * `name` is matched on as well as `hostname` because a discovery import
+     * puts the responding IP in `hostname` and the device's real identity in
+     * `name`, so a hostname pattern that only ever saw `hostname` could not
+     * match anything a user recognises. See toRuleMatchTarget.
      */
     const winner: NetworkSiteAssignmentRule | null = CidrMatchUtil.pickRule(
       rules,
-      {
-        ip: device.hostname,
-        hostname: device.hostname,
-        sysName: device.sysName,
-        name: device.name,
-      },
+      toRuleMatchTarget(device),
     );
 
     if (!winner || !winner.siteId) {
@@ -652,6 +681,230 @@ export class Service extends DatabaseService<Model> {
         isRoot: true,
       },
     });
+  }
+
+  /*
+   * Runs ONE assignment rule against the devices that already exist, which is
+   * the half the automatic path cannot do: rules only ever fire on create, on
+   * an identity change, or on the next poll of a device that has no site, so
+   * a rule written after the estate was imported would never reach it
+   * (OneUptime/oneuptime#3191).
+   *
+   * Two rules of the automatic path are kept deliberately:
+   *
+   *   - priority still decides. A device this rule matches but a
+   *     higher-priority rule also matches is REPORTED, not moved: running one
+   *     rule must never quietly do another rule's work, or the button would
+   *     produce a placement no rule alone explains.
+   *   - a device already in a site is left alone unless the caller explicitly
+   *     asks otherwise. Nothing records whether a site was chosen by a human
+   *     or by a rule, so overwriting is the caller's decision to make, with
+   *     the warning that goes with it — and it is not needed for the case the
+   *     button exists for, since a device imported before the rule existed
+   *     has no site at all.
+   */
+  @CaptureSpan()
+  public async applySiteAssignmentRuleToExistingDevices(data: {
+    ruleId: ObjectID;
+    projectId: ObjectID;
+    reassignDevicesAlreadyInASite: boolean;
+  }): Promise<SiteAssignmentRuleRunResult> {
+    /*
+     * Every rule in the project, not just the one being run — pickRule needs
+     * the whole set to answer "does something outrank this rule here?".
+     * Loading them by project is also what scopes the run to the tenant: a
+     * rule id from another project simply is not in this list.
+     */
+    const rules: Array<NetworkSiteAssignmentRule> =
+      await NetworkSiteAssignmentRuleService.findBy({
+        query: {
+          projectId: data.projectId,
+        },
+        select: {
+          _id: true,
+          siteId: true,
+          subnetCidr: true,
+          hostnamePattern: true,
+          priority: true,
+          createdAt: true,
+        },
+        limit: LIMIT_MAX,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      });
+
+    const rule: NetworkSiteAssignmentRule | undefined = rules.find(
+      (candidate: NetworkSiteAssignmentRule) => {
+        return candidate._id?.toString() === data.ruleId.toString();
+      },
+    );
+
+    if (!rule) {
+      throw new BadDataException("Assignment rule not found.");
+    }
+
+    if (!rule.siteId) {
+      throw new BadDataException(
+        "This assignment rule has no site to assign devices to.",
+      );
+    }
+
+    const ruleSiteId: ObjectID = rule.siteId;
+
+    const result: SiteAssignmentRuleRunResult = {
+      devicesEvaluated: 0,
+      devicesMatched: 0,
+      devicesAssigned: 0,
+      devicesAlreadyInRuleSite: 0,
+      devicesSkippedAlreadyInAnotherSite: 0,
+      devicesClaimedByHigherPriorityRule: 0,
+      devicesFailed: 0,
+      isTruncated: false,
+    };
+
+    let skip: number = 0;
+
+    for (;;) {
+      const devices: Array<Model> = await this.findBy({
+        query: {
+          projectId: data.projectId,
+        },
+        select: {
+          _id: true,
+          siteId: true,
+          hostname: true,
+          sysName: true,
+          name: true,
+        },
+        /*
+         * Sorted by id so paging stays stable while the run writes to the
+         * very rows it is paging over. Assigning a site never changes an id,
+         * so no device can be skipped or seen twice.
+         */
+        sort: {
+          _id: SortOrder.Ascending,
+        },
+        limit: RULE_RUN_PAGE_SIZE,
+        skip: skip,
+        props: {
+          isRoot: true,
+        },
+      });
+
+      if (devices.length === 0) {
+        break;
+      }
+
+      for (const device of devices) {
+        result.devicesEvaluated++;
+
+        const target: ReturnType<typeof toRuleMatchTarget> =
+          toRuleMatchTarget(device);
+
+        if (!CidrMatchUtil.ruleMatches(rule, target)) {
+          continue;
+        }
+
+        result.devicesMatched++;
+
+        if (device.siteId?.toString() === ruleSiteId.toString()) {
+          result.devicesAlreadyInRuleSite++;
+          continue;
+        }
+
+        if (device.siteId && !data.reassignDevicesAlreadyInASite) {
+          result.devicesSkippedAlreadyInAnotherSite++;
+          continue;
+        }
+
+        const winner: NetworkSiteAssignmentRule | null = CidrMatchUtil.pickRule(
+          rules,
+          target,
+        );
+
+        if (winner?._id?.toString() !== rule._id?.toString()) {
+          result.devicesClaimedByHigherPriorityRule++;
+          continue;
+        }
+
+        /*
+         * Counted as a failure rather than skipped silently: every matched
+         * device has to land in exactly one bucket, or the summary the
+         * operator reads would not add up.
+         */
+        if (!device.id) {
+          result.devicesFailed++;
+          continue;
+        }
+
+        /*
+         * Through updateOneById, not a bulk UPDATE: onUpdateSuccess is what
+         * refreshes the rollups of the site the device left and the site it
+         * joined, and a raw write would leave both stale.
+         */
+        try {
+          await this.updateOneById({
+            id: device.id,
+            data: {
+              siteId: ruleSiteId,
+            },
+            props: {
+              isRoot: true,
+            },
+          });
+
+          result.devicesAssigned++;
+        } catch (error) {
+          // One unhappy device must not abandon the rest of the estate.
+          result.devicesFailed++;
+          logger.error(
+            `Error assigning site from assignment rule ${data.ruleId.toString()} to device ${device.id.toString()}: ${error}`,
+            {
+              projectId: data.projectId.toString(),
+              networkDeviceId: device.id.toString(),
+            } as LogAttributes,
+          );
+        }
+      }
+
+      skip += devices.length;
+
+      if (devices.length < RULE_RUN_PAGE_SIZE) {
+        break;
+      }
+
+      if (skip >= MAX_DEVICES_PER_RULE_RUN) {
+        /*
+         * A full last page does not prove there is an eleventh thousand of
+         * devices — an estate of exactly the cap would report a truncation
+         * that never happened, and the UI would tell the user to run it
+         * again forever. One row is enough to settle it.
+         */
+        const nextDevice: Array<Model> = await this.findBy({
+          query: {
+            projectId: data.projectId,
+          },
+          select: {
+            _id: true,
+          },
+          sort: {
+            _id: SortOrder.Ascending,
+          },
+          limit: 1,
+          skip: skip,
+          props: {
+            isRoot: true,
+          },
+        });
+
+        result.isTruncated = nextDevice.length > 0;
+        break;
+      }
+    }
+
+    return result;
   }
 
   /*

--- a/Common/Tests/Server/Services/NetworkDeviceLabelRuleRun.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceLabelRuleRun.test.ts
@@ -1,0 +1,618 @@
+import NetworkDeviceLabelRuleEngineService from "../../../Server/Services/NetworkDeviceLabelRuleEngineService";
+import NetworkDeviceLabelRuleService from "../../../Server/Services/NetworkDeviceLabelRuleService";
+import NetworkDeviceService from "../../../Server/Services/NetworkDeviceService";
+import Label from "../../../Models/DatabaseModels/Label";
+import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import NetworkDeviceLabelRule from "../../../Models/DatabaseModels/NetworkDeviceLabelRule";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import { LabelRuleRunResult } from "../../../Types/NetworkAutomation/RuleRunResult";
+import { describe, expect, it, afterEach, beforeEach } from "@jest/globals";
+
+/*
+ * Contract under test - "Run now" for a network device label rule
+ * (OneUptime/oneuptime#3191).
+ *
+ * The automatic engine only fires when a device is created, so a rule
+ * written after an estate was discovered never touches any of it.
+ * applyRuleToExistingNetworkDevices is the manual counterpart: the same
+ * matcher, the same "already-attached labels are not duplicated" guarantee,
+ * applied across a whole project instead of to one row.
+ *
+ * The things worth pinning down are the ones a bulk path can get wrong that a
+ * one-row path cannot: it must attach labels in as few statements as the work
+ * allows, count a device once no matter how many pages or labels it appears
+ * under, survive a failed batch, and refuse to run a rule the user has
+ * switched off.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "99999999-9999-4999-8999-999999999999",
+);
+const RULE_ID: ObjectID = new ObjectID("77777777-7777-4777-8777-777777777777");
+const LABEL_A_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const LABEL_B_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const PREREQUISITE_LABEL_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+
+function deviceId(index: number): ObjectID {
+  const suffix: string = index.toString(16).padStart(12, "0");
+  return new ObjectID(`00000000-0000-4000-8000-${suffix}`);
+}
+
+function fakeLabel(id: ObjectID): Label {
+  return { id: id, _id: id.toString() } as unknown as Label;
+}
+
+function fakeDevice(data: {
+  index?: number | undefined;
+  name?: string | undefined;
+  description?: string | undefined;
+  labels?: Array<ObjectID> | undefined;
+}): NetworkDevice {
+  const id: ObjectID = deviceId(data.index ?? 0);
+
+  return {
+    id: id,
+    _id: id.toString(),
+    projectId: PROJECT_ID,
+    name: data.name,
+    description: data.description,
+    labels: (data.labels || []).map((labelId: ObjectID) => {
+      return fakeLabel(labelId);
+    }),
+  } as unknown as NetworkDevice;
+}
+
+function fakeRule(data: {
+  isEnabled?: boolean | undefined;
+  labelsToAdd?: Array<ObjectID> | undefined;
+  networkDeviceLabels?: Array<ObjectID> | undefined;
+  networkDeviceNamePattern?: string | undefined;
+  networkDeviceDescriptionPattern?: string | undefined;
+}): NetworkDeviceLabelRule {
+  return {
+    id: RULE_ID,
+    _id: RULE_ID.toString(),
+    projectId: PROJECT_ID,
+    name: "Tag core switches",
+    isEnabled: data.isEnabled ?? true,
+    labelsToAdd: (data.labelsToAdd || [LABEL_A_ID]).map((id: ObjectID) => {
+      return fakeLabel(id);
+    }),
+    networkDeviceLabels: (data.networkDeviceLabels || []).map(
+      (id: ObjectID) => {
+        return fakeLabel(id);
+      },
+    ),
+    networkDeviceNamePattern: data.networkDeviceNamePattern,
+    networkDeviceDescriptionPattern: data.networkDeviceDescriptionPattern,
+  } as unknown as NetworkDeviceLabelRule;
+}
+
+function mockRule(rule: NetworkDeviceLabelRule | null): jest.SpyInstance {
+  return jest
+    .spyOn(NetworkDeviceLabelRuleService, "findOneBy")
+    .mockResolvedValue(rule);
+}
+
+function mockDevices(devices: Array<NetworkDevice>): jest.SpyInstance {
+  return jest
+    .spyOn(NetworkDeviceService, "findBy")
+    .mockImplementation(async (data: any) => {
+      const skip: number = data.skip || 0;
+      const limit: number = data.limit || devices.length;
+      return devices.slice(skip, skip + limit) as any;
+    });
+}
+
+function mockGeneratedDevices(totalDevices: number): jest.SpyInstance {
+  return jest
+    .spyOn(NetworkDeviceService, "findBy")
+    .mockImplementation(async (data: any) => {
+      const skip: number = data.skip || 0;
+      const limit: number = data.limit || 0;
+      const page: Array<NetworkDevice> = [];
+
+      for (
+        let index: number = skip;
+        index < Math.min(skip + limit, totalDevices);
+        index++
+      ) {
+        page.push(fakeDevice({ index: index, name: "core-switch" }));
+      }
+
+      return page as any;
+    });
+}
+
+/*
+ * The relation query builder the engine attaches labels through. Recorded as
+ * (labelId, deviceIds) pairs so a test can assert the shape of the writes -
+ * one statement per label, not one per device.
+ */
+interface RelationAdd {
+  labelId: string;
+  deviceIds: Array<string>;
+}
+
+function mockRelationBuilder(data?: {
+  failOnLabelId?: string | undefined;
+}): Array<RelationAdd> {
+  const adds: Array<RelationAdd> = [];
+
+  const builder: any = {
+    createQueryBuilder: () => {
+      return builder;
+    },
+    relation: () => {
+      return builder;
+    },
+    of: (deviceIds: Array<string>) => {
+      builder.pendingDeviceIds = deviceIds;
+      return builder;
+    },
+    add: async (labelId: string) => {
+      if (data?.failOnLabelId && labelId === data.failOnLabelId) {
+        throw new Error("duplicate key value violates unique constraint");
+      }
+
+      adds.push({
+        labelId: labelId,
+        deviceIds: [...(builder.pendingDeviceIds as Array<string>)],
+      });
+    },
+  };
+
+  jest
+    .spyOn(NetworkDeviceService, "getRepository")
+    .mockReturnValue(builder as any);
+
+  return adds;
+}
+
+function run(
+  overrides: {
+    ruleId?: ObjectID | undefined;
+    projectId?: ObjectID | undefined;
+  } = {},
+): Promise<LabelRuleRunResult> {
+  return NetworkDeviceLabelRuleEngineService.applyRuleToExistingNetworkDevices({
+    ruleId: overrides.ruleId || RULE_ID,
+    projectId: overrides.projectId || PROJECT_ID,
+  });
+}
+
+describe("NetworkDeviceLabelRuleEngineService.applyRuleToExistingNetworkDevices", () => {
+  beforeEach(() => {
+    // Silence the logs the failure-path tests deliberately provoke.
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("rule resolution", () => {
+    it("rejects a rule that does not exist", async () => {
+      mockRule(null);
+      mockDevices([]);
+
+      await expect(run()).rejects.toThrow(BadDataException);
+    });
+
+    /*
+     * The tenant guard: the lookup is scoped, so another project's rule id
+     * reads as "not found" and nothing of that project is touched.
+     */
+    it("looks the rule up scoped to the project", async () => {
+      const ruleSpy: jest.SpyInstance = mockRule(null);
+      const devicesSpy: jest.SpyInstance = mockDevices([]);
+
+      await expect(run({ projectId: OTHER_PROJECT_ID })).rejects.toThrow(
+        "Label rule not found.",
+      );
+
+      const query: any = ruleSpy.mock.calls[0]![0].query;
+      expect(query._id.toString()).toBe(RULE_ID.toString());
+      expect(query.projectId.toString()).toBe(OTHER_PROJECT_ID.toString());
+      expect(devicesSpy).not.toHaveBeenCalled();
+    });
+
+    /*
+     * Running a rule the operator has switched off would contradict the
+     * toggle sitting right next to the button.
+     */
+    it("refuses to run a disabled rule", async () => {
+      mockRule(fakeRule({ isEnabled: false }));
+      const devicesSpy: jest.SpyInstance = mockDevices([]);
+
+      await expect(run()).rejects.toThrow(
+        "This label rule is disabled. Enable it before running it.",
+      );
+      expect(devicesSpy).not.toHaveBeenCalled();
+    });
+
+    it("refuses to run a rule that attaches no labels", async () => {
+      mockRule(fakeRule({ labelsToAdd: [] }));
+      const devicesSpy: jest.SpyInstance = mockDevices([]);
+
+      await expect(run()).rejects.toThrow(
+        "This label rule has no labels to add, so running it would do nothing.",
+      );
+      expect(devicesSpy).not.toHaveBeenCalled();
+    });
+
+    it("scopes the device query to the project and pages it by id", async () => {
+      mockRule(fakeRule({}));
+      const devicesSpy: jest.SpyInstance = mockDevices([]);
+      mockRelationBuilder();
+
+      await run();
+
+      expect(devicesSpy.mock.calls[0]![0].query.projectId.toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+      expect(devicesSpy.mock.calls[0]![0].sort).toEqual({
+        _id: SortOrder.Ascending,
+      });
+    });
+  });
+
+  describe("matching", () => {
+    it("attaches the rule's labels to every matching device", async () => {
+      mockRule(
+        fakeRule({
+          networkDeviceNamePattern: "core-.*",
+          labelsToAdd: [LABEL_A_ID],
+        }),
+      );
+      mockDevices([
+        fakeDevice({ index: 0, name: "core-switch-1" }),
+        fakeDevice({ index: 1, name: "edge-router-1" }),
+        fakeDevice({ index: 2, name: "core-switch-2" }),
+      ]);
+      const adds: Array<RelationAdd> = mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesEvaluated).toBe(3);
+      expect(result.devicesMatched).toBe(2);
+      expect(result.devicesLabeled).toBe(2);
+      expect(result.labelsAttached).toBe(2);
+      expect(adds).toEqual([
+        {
+          labelId: LABEL_A_ID.toString(),
+          deviceIds: [deviceId(0).toString(), deviceId(2).toString()],
+        },
+      ]);
+    });
+
+    /*
+     * The glob syntax the neighbouring site assignment rules use has to keep
+     * working here too - a rule written as `*0664*` used to compile to
+     * nothing and silently label no device (OneUptime/oneuptime#2940).
+     */
+    it("accepts a '*' wildcard pattern as well as a regex", async () => {
+      mockRule(fakeRule({ networkDeviceNamePattern: "*0664*" }));
+      mockDevices([
+        fakeDevice({ index: 0, name: "UN0664LANSWI03" }),
+        fakeDevice({ index: 1, name: "UN0999LANSWI03" }),
+      ]);
+      const adds: Array<RelationAdd> = mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesMatched).toBe(1);
+      expect(adds[0]!.deviceIds).toEqual([deviceId(0).toString()]);
+    });
+
+    it("matches on the description pattern too", async () => {
+      mockRule(
+        fakeRule({ networkDeviceDescriptionPattern: "production|critical" }),
+      );
+      mockDevices([
+        fakeDevice({ index: 0, name: "sw-1", description: "production core" }),
+        fakeDevice({ index: 1, name: "sw-2", description: "lab bench" }),
+      ]);
+      const adds: Array<RelationAdd> = mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesMatched).toBe(1);
+      expect(adds[0]!.deviceIds).toEqual([deviceId(0).toString()]);
+    });
+
+    it("requires every populated criterion to match", async () => {
+      mockRule(
+        fakeRule({
+          networkDeviceNamePattern: "core-.*",
+          networkDeviceDescriptionPattern: "production",
+        }),
+      );
+      mockDevices([
+        fakeDevice({ index: 0, name: "core-1", description: "lab" }),
+        fakeDevice({ index: 1, name: "edge-1", description: "production" }),
+        fakeDevice({ index: 2, name: "core-2", description: "production" }),
+      ]);
+      const adds: Array<RelationAdd> = mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesMatched).toBe(1);
+      expect(adds[0]!.deviceIds).toEqual([deviceId(2).toString()]);
+    });
+
+    // The prerequisite filter is any-of, matching the automatic engine.
+    it("honours the prerequisite label filter", async () => {
+      mockRule(
+        fakeRule({
+          networkDeviceLabels: [PREREQUISITE_LABEL_ID],
+          labelsToAdd: [LABEL_A_ID],
+        }),
+      );
+      mockDevices([
+        fakeDevice({ index: 0, name: "sw-1", labels: [PREREQUISITE_LABEL_ID] }),
+        fakeDevice({ index: 1, name: "sw-2", labels: [] }),
+        fakeDevice({ index: 2, name: "sw-3", labels: [LABEL_B_ID] }),
+      ]);
+      const adds: Array<RelationAdd> = mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesMatched).toBe(1);
+      expect(adds[0]!.deviceIds).toEqual([deviceId(0).toString()]);
+    });
+
+    /*
+     * A rule with no criteria matches everything, which is what the
+     * automatic engine already does on device create. The manual run has to
+     * agree with it, or the button would mean something different from the
+     * rule it is attached to.
+     */
+    it("matches every device when the rule has no criteria", async () => {
+      mockRule(fakeRule({}));
+      mockDevices([
+        fakeDevice({ index: 0, name: "anything" }),
+        fakeDevice({ index: 1 }),
+      ]);
+      const adds: Array<RelationAdd> = mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesMatched).toBe(2);
+      expect(adds[0]!.deviceIds).toHaveLength(2);
+    });
+
+    /*
+     * A pattern that is neither a valid regex nor a wildcard glob can never
+     * match; it must label nothing rather than throw the run away.
+     */
+    it("matches nothing for an unusable pattern instead of failing", async () => {
+      mockRule(fakeRule({ networkDeviceNamePattern: "core-[" }));
+      mockDevices([fakeDevice({ index: 0, name: "core-[" })]);
+      const adds: Array<RelationAdd> = mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesMatched).toBe(0);
+      expect(adds).toHaveLength(0);
+    });
+  });
+
+  describe("idempotence", () => {
+    it("does not re-attach a label the device already carries", async () => {
+      mockRule(fakeRule({ labelsToAdd: [LABEL_A_ID] }));
+      mockDevices([
+        fakeDevice({ index: 0, name: "sw-1", labels: [LABEL_A_ID] }),
+        fakeDevice({ index: 1, name: "sw-2", labels: [] }),
+      ]);
+      const adds: Array<RelationAdd> = mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesMatched).toBe(2);
+      expect(result.devicesLabeled).toBe(1);
+      expect(result.labelsAttached).toBe(1);
+      expect(adds[0]!.deviceIds).toEqual([deviceId(1).toString()]);
+    });
+
+    /*
+     * A second run of the same rule is the common case - the operator clicks
+     * it again to be sure. It has to be a clean no-op, reported as such.
+     */
+    it("attaches nothing on a second run of the same rule", async () => {
+      mockRule(fakeRule({ labelsToAdd: [LABEL_A_ID] }));
+      mockDevices([
+        fakeDevice({ index: 0, name: "sw-1", labels: [LABEL_A_ID] }),
+        fakeDevice({ index: 1, name: "sw-2", labels: [LABEL_A_ID] }),
+      ]);
+      const adds: Array<RelationAdd> = mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesMatched).toBe(2);
+      expect(result.devicesLabeled).toBe(0);
+      expect(result.labelsAttached).toBe(0);
+      expect(adds).toHaveLength(0);
+    });
+
+    it("adds only the labels a partially labelled device is missing", async () => {
+      mockRule(fakeRule({ labelsToAdd: [LABEL_A_ID, LABEL_B_ID] }));
+      mockDevices([
+        fakeDevice({ index: 0, name: "sw-1", labels: [LABEL_A_ID] }),
+      ]);
+      const adds: Array<RelationAdd> = mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesLabeled).toBe(1);
+      expect(result.labelsAttached).toBe(1);
+      expect(adds).toEqual([
+        {
+          labelId: LABEL_B_ID.toString(),
+          deviceIds: [deviceId(0).toString()],
+        },
+      ]);
+    });
+  });
+
+  describe("write batching", () => {
+    /*
+     * One statement per label, not one per device. A per-device write would
+     * turn a ten-thousand-device estate into ten thousand round trips inside
+     * a single HTTP request.
+     */
+    it("writes one batch per label, whatever the device count", async () => {
+      mockRule(fakeRule({ labelsToAdd: [LABEL_A_ID, LABEL_B_ID] }));
+      mockDevices([
+        fakeDevice({ index: 0, name: "sw-1" }),
+        fakeDevice({ index: 1, name: "sw-2" }),
+        fakeDevice({ index: 2, name: "sw-3" }),
+      ]);
+      const adds: Array<RelationAdd> = mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(adds).toHaveLength(2);
+      expect(adds[0]!.deviceIds).toHaveLength(3);
+      expect(adds[1]!.deviceIds).toHaveLength(3);
+      expect(result.devicesLabeled).toBe(3);
+      expect(result.labelsAttached).toBe(6);
+    });
+
+    /*
+     * Postgres refuses a statement with more than 65535 parameters, so a
+     * batch is chunked well below that.
+     */
+    it("chunks a batch that would otherwise be one huge statement", async () => {
+      mockRule(fakeRule({ labelsToAdd: [LABEL_A_ID] }));
+      mockGeneratedDevices(1000);
+      const adds: Array<RelationAdd> = mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(adds).toHaveLength(2);
+      expect(adds[0]!.deviceIds).toHaveLength(500);
+      expect(adds[1]!.deviceIds).toHaveLength(500);
+      expect(result.labelsAttached).toBe(1000);
+      expect(result.devicesLabeled).toBe(1000);
+    });
+  });
+
+  describe("resilience and reporting", () => {
+    it("counts a failed batch and keeps going with the other labels", async () => {
+      mockRule(fakeRule({ labelsToAdd: [LABEL_A_ID, LABEL_B_ID] }));
+      mockDevices([
+        fakeDevice({ index: 0, name: "sw-1" }),
+        fakeDevice({ index: 1, name: "sw-2" }),
+      ]);
+      const adds: Array<RelationAdd> = mockRelationBuilder({
+        failOnLabelId: LABEL_A_ID.toString(),
+      });
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(adds).toHaveLength(1);
+      expect(adds[0]!.labelId).toBe(LABEL_B_ID.toString());
+      expect(result.labelsAttached).toBe(2);
+      expect(result.labelsFailed).toBe(2);
+      // The devices still gained label B, so they count as labelled.
+      expect(result.devicesLabeled).toBe(2);
+    });
+
+    it("reports no devices labelled when every batch fails", async () => {
+      mockRule(fakeRule({ labelsToAdd: [LABEL_A_ID] }));
+      mockDevices([fakeDevice({ index: 0, name: "sw-1" })]);
+      mockRelationBuilder({ failOnLabelId: LABEL_A_ID.toString() });
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesMatched).toBe(1);
+      expect(result.devicesLabeled).toBe(0);
+      expect(result.labelsAttached).toBe(0);
+      expect(result.labelsFailed).toBe(1);
+    });
+
+    it("returns an all-zero result for a project with no devices", async () => {
+      mockRule(fakeRule({}));
+      mockDevices([]);
+      const adds: Array<RelationAdd> = mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result).toEqual({
+        devicesEvaluated: 0,
+        devicesMatched: 0,
+        devicesLabeled: 0,
+        labelsAttached: 0,
+        labelsFailed: 0,
+        isTruncated: false,
+      });
+      expect(adds).toHaveLength(0);
+    });
+  });
+
+  describe("paging and the run cap", () => {
+    it("walks every page of a multi-page estate", async () => {
+      mockRule(fakeRule({ labelsToAdd: [LABEL_A_ID] }));
+      const devicesSpy: jest.SpyInstance = mockGeneratedDevices(2500);
+      mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesEvaluated).toBe(2500);
+      expect(result.devicesLabeled).toBe(2500);
+      expect(result.isTruncated).toBe(false);
+      expect(devicesSpy).toHaveBeenCalledTimes(3);
+      expect(devicesSpy.mock.calls[1]![0].skip).toBe(1000);
+    });
+
+    /*
+     * devicesLabeled is a distinct count, so a device cannot be counted
+     * twice by appearing under two labels or in two chunks.
+     */
+    it("counts each labelled device once across pages and labels", async () => {
+      mockRule(fakeRule({ labelsToAdd: [LABEL_A_ID, LABEL_B_ID] }));
+      mockGeneratedDevices(1500);
+      mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesLabeled).toBe(1500);
+      expect(result.labelsAttached).toBe(3000);
+    });
+
+    it("stops at the cap and reports the run as truncated", async () => {
+      mockRule(fakeRule({ labelsToAdd: [LABEL_A_ID] }));
+      mockGeneratedDevices(10500);
+      mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesEvaluated).toBe(10000);
+      expect(result.isTruncated).toBe(true);
+    });
+
+    it("does not report truncation for an estate of exactly the cap", async () => {
+      mockRule(fakeRule({ labelsToAdd: [LABEL_A_ID] }));
+      mockGeneratedDevices(10000);
+      mockRelationBuilder();
+
+      const result: LabelRuleRunResult = await run();
+
+      expect(result.devicesEvaluated).toBe(10000);
+      expect(result.isTruncated).toBe(false);
+    });
+  });
+});

--- a/Common/Tests/Server/Services/NetworkSiteAssignmentRuleRun.test.ts
+++ b/Common/Tests/Server/Services/NetworkSiteAssignmentRuleRun.test.ts
@@ -1,0 +1,706 @@
+import NetworkDeviceService from "../../../Server/Services/NetworkDeviceService";
+import NetworkSiteAssignmentRuleService from "../../../Server/Services/NetworkSiteAssignmentRuleService";
+import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import NetworkSiteAssignmentRule from "../../../Models/DatabaseModels/NetworkSiteAssignmentRule";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import { SiteAssignmentRuleRunResult } from "../../../Types/NetworkAutomation/RuleRunResult";
+import { describe, expect, it, afterEach } from "@jest/globals";
+
+/*
+ * Contract under test - "Run now" for a site assignment rule
+ * (OneUptime/oneuptime#3191).
+ *
+ * Rules only fire on device create, on an identity change, or on the next
+ * poll of a device with no site, so a rule written after an estate was
+ * imported never reaches it. applySiteAssignmentRuleToExistingDevices is the
+ * manual path that does, and it keeps two promises of the automatic one:
+ *
+ *   - priority still decides. A device this rule matches but a
+ *     higher-priority rule also matches is reported, never moved: one rule's
+ *     button must not do another rule's work.
+ *   - a device that already belongs to a site is left alone unless the caller
+ *     explicitly asked to overwrite, because nothing records whether that
+ *     site was chosen by a rule or by a person.
+ *
+ * Everything else here is about being honest with the operator: the counters
+ * have to add up, one device's failure must not abandon the rest of the
+ * fleet, and a run that stopped at the cap has to say so.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const OTHER_PROJECT_ID: ObjectID = new ObjectID(
+  "99999999-9999-4999-8999-999999999999",
+);
+const SITE_A_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const SITE_B_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const RULE_ID: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+const OTHER_RULE_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+
+function deviceId(index: number): ObjectID {
+  /*
+   * Deterministic per-index ids so a paging test can assert exactly which
+   * devices were touched without hard-coding ten thousand UUIDs.
+   */
+  const suffix: string = index.toString(16).padStart(12, "0");
+  return new ObjectID(`00000000-0000-4000-8000-${suffix}`);
+}
+
+function fakeDevice(data: {
+  index?: number | undefined;
+  id?: ObjectID | undefined;
+  siteId?: ObjectID | undefined;
+  hostname?: string | undefined;
+  sysName?: string | undefined;
+  name?: string | undefined;
+}): NetworkDevice {
+  const id: ObjectID = data.id || deviceId(data.index ?? 0);
+
+  return {
+    id: id,
+    _id: id.toString(),
+    projectId: PROJECT_ID,
+    siteId: data.siteId,
+    hostname: data.hostname,
+    sysName: data.sysName,
+    name: data.name,
+  } as unknown as NetworkDevice;
+}
+
+function fakeRule(data: {
+  id?: ObjectID | undefined;
+  // null means "a rule row with no site", which is a state the run rejects.
+  siteId?: ObjectID | null | undefined;
+  subnetCidr?: string | undefined;
+  hostnamePattern?: string | undefined;
+  priority?: number | undefined;
+  createdAt?: Date | undefined;
+}): NetworkSiteAssignmentRule {
+  const id: ObjectID = data.id || RULE_ID;
+
+  return {
+    id: id,
+    _id: id.toString(),
+    projectId: PROJECT_ID,
+    siteId: data.siteId === undefined ? SITE_A_ID : data.siteId || undefined,
+    subnetCidr: data.subnetCidr,
+    hostnamePattern: data.hostnamePattern,
+    priority: data.priority ?? 0,
+    createdAt: data.createdAt,
+  } as unknown as NetworkSiteAssignmentRule;
+}
+
+function mockRules(rules: Array<NetworkSiteAssignmentRule>): jest.SpyInstance {
+  return jest
+    .spyOn(NetworkSiteAssignmentRuleService, "findBy")
+    .mockResolvedValue(rules);
+}
+
+// A findBy that pages over a fixed list, honouring skip and limit.
+function mockDevices(devices: Array<NetworkDevice>): jest.SpyInstance {
+  return jest
+    .spyOn(NetworkDeviceService, "findBy")
+    .mockImplementation(async (data: any) => {
+      const skip: number = data.skip || 0;
+      const limit: number = data.limit || devices.length;
+      return devices.slice(skip, skip + limit) as any;
+    });
+}
+
+/*
+ * The same, but generated on demand: a truncation test needs more devices
+ * than it is worth building arrays for.
+ */
+function mockGeneratedDevices(totalDevices: number): jest.SpyInstance {
+  return jest
+    .spyOn(NetworkDeviceService, "findBy")
+    .mockImplementation(async (data: any) => {
+      const skip: number = data.skip || 0;
+      const limit: number = data.limit || 0;
+      const page: Array<NetworkDevice> = [];
+
+      for (
+        let index: number = skip;
+        index < Math.min(skip + limit, totalDevices);
+        index++
+      ) {
+        page.push(fakeDevice({ index: index, hostname: "10.0.5.9" }));
+      }
+
+      return page as any;
+    });
+}
+
+function mockUpdate(): jest.SpyInstance {
+  return jest
+    .spyOn(NetworkDeviceService, "updateOneById")
+    .mockResolvedValue(undefined as never);
+}
+
+function run(
+  overrides: {
+    ruleId?: ObjectID | undefined;
+    projectId?: ObjectID | undefined;
+    reassignDevicesAlreadyInASite?: boolean | undefined;
+  } = {},
+): Promise<SiteAssignmentRuleRunResult> {
+  return NetworkDeviceService.applySiteAssignmentRuleToExistingDevices({
+    ruleId: overrides.ruleId || RULE_ID,
+    projectId: overrides.projectId || PROJECT_ID,
+    reassignDevicesAlreadyInASite:
+      overrides.reassignDevicesAlreadyInASite ?? false,
+  });
+}
+
+describe("NetworkDeviceService.applySiteAssignmentRuleToExistingDevices", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("rule resolution", () => {
+    it("rejects a rule id that is not one of the project's rules", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.0.0/8" })]);
+      mockDevices([]);
+
+      await expect(run({ ruleId: OTHER_RULE_ID })).rejects.toThrow(
+        BadDataException,
+      );
+    });
+
+    /*
+     * The tenant guard: the rules are loaded by project, so a rule id from
+     * another project is simply not in the list and the run refuses. Nothing
+     * about another tenant's estate is read or written.
+     */
+    it("refuses to run a rule belonging to another project", async () => {
+      const rulesSpy: jest.SpyInstance = mockRules([]);
+      const devicesSpy: jest.SpyInstance = mockDevices([
+        fakeDevice({ hostname: "10.0.5.9" }),
+      ]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      await expect(run({ projectId: OTHER_PROJECT_ID })).rejects.toThrow(
+        "Assignment rule not found.",
+      );
+
+      expect(rulesSpy.mock.calls[0]![0].query.projectId.toString()).toBe(
+        OTHER_PROJECT_ID.toString(),
+      );
+      expect(devicesSpy).not.toHaveBeenCalled();
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects a rule that has no site to assign to", async () => {
+      mockRules([fakeRule({ siteId: null, subnetCidr: "10.0.0.0/8" })]);
+      mockDevices([]);
+
+      await expect(run()).rejects.toThrow(
+        "This assignment rule has no site to assign devices to.",
+      );
+    });
+
+    it("scopes both the rule and the device query to the project", async () => {
+      const rulesSpy: jest.SpyInstance = mockRules([
+        fakeRule({ subnetCidr: "10.0.0.0/8" }),
+      ]);
+      const devicesSpy: jest.SpyInstance = mockDevices([]);
+
+      await run();
+
+      expect(rulesSpy.mock.calls[0]![0].query.projectId.toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+      expect(devicesSpy.mock.calls[0]![0].query.projectId.toString()).toBe(
+        PROJECT_ID.toString(),
+      );
+    });
+
+    /*
+     * Paging over rows the run is itself writing to is only safe under a
+     * stable sort. Ids never change when a site is assigned; a createdAt or
+     * name sort would let a row shift between pages and be skipped.
+     */
+    it("pages devices under a stable id sort", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.0.0/8" })]);
+      const devicesSpy: jest.SpyInstance = mockDevices([]);
+
+      await run();
+
+      expect(devicesSpy.mock.calls[0]![0].sort).toEqual({
+        _id: SortOrder.Ascending,
+      });
+    });
+  });
+
+  describe("matching", () => {
+    it("assigns a matching device that has no site", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.5.0/24" })]);
+      mockDevices([fakeDevice({ hostname: "10.0.5.9" })]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesEvaluated).toBe(1);
+      expect(result.devicesMatched).toBe(1);
+      expect(result.devicesAssigned).toBe(1);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+
+      const args: any = updateSpy.mock.calls[0]![0];
+      expect(args.id.toString()).toBe(deviceId(0).toString());
+      expect(args.data.siteId.toString()).toBe(SITE_A_ID.toString());
+    });
+
+    /*
+     * Through updateOneById as root, never a bulk UPDATE: onUpdateSuccess is
+     * what refreshes the rollups of the site the device left and the one it
+     * joined, and a raw write would leave both stale.
+     */
+    it("assigns through updateOneById so site rollups are refreshed", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.5.0/24" })]);
+      mockDevices([fakeDevice({ hostname: "10.0.5.9" })]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      await run();
+
+      expect(updateSpy.mock.calls[0]![0].props).toEqual({ isRoot: true });
+    });
+
+    it("leaves a device no criterion matches alone", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.5.0/24" })]);
+      mockDevices([fakeDevice({ hostname: "172.16.0.1" })]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesEvaluated).toBe(1);
+      expect(result.devicesMatched).toBe(0);
+      expect(result.devicesAssigned).toBe(0);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    /*
+     * A discovery import stores the responding IP in `hostname` and the SNMP
+     * identity in `name` / `sysName`, so a retroactive run has to try a
+     * hostname pattern against all three - exactly as the per-device path
+     * does, or the button would disagree with the scan.
+     */
+    it("matches a hostname pattern against the SNMP sysName", async () => {
+      mockRules([fakeRule({ hostnamePattern: "unit-1042-*" })]);
+      mockDevices([
+        fakeDevice({ hostname: "10.0.5.9", sysName: "unit-1042-core" }),
+      ]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesAssigned).toBe(1);
+      expect(updateSpy.mock.calls[0]![0].data.siteId.toString()).toBe(
+        SITE_A_ID.toString(),
+      );
+    });
+
+    it("matches a hostname pattern against the display name", async () => {
+      mockRules([fakeRule({ hostnamePattern: "*0664*" })]);
+      mockDevices([
+        fakeDevice({ hostname: "10.0.5.9", name: "UN0664LANSWI03" }),
+      ]);
+
+      mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesAssigned).toBe(1);
+    });
+
+    it("requires every populated criterion to match", async () => {
+      mockRules([
+        fakeRule({ subnetCidr: "10.0.5.0/24", hostnamePattern: "core-*" }),
+      ]);
+      mockDevices([
+        // In the subnet, wrong name.
+        fakeDevice({ index: 0, hostname: "10.0.5.9", name: "edge-1" }),
+        // Right name, outside the subnet.
+        fakeDevice({ index: 1, hostname: "172.16.0.4", name: "core-1" }),
+        // Both.
+        fakeDevice({ index: 2, hostname: "10.0.5.10", name: "core-2" }),
+      ]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesEvaluated).toBe(3);
+      expect(result.devicesMatched).toBe(1);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      expect(updateSpy.mock.calls[0]![0].id.toString()).toBe(
+        deviceId(2).toString(),
+      );
+    });
+
+    it("never matches a rule with no criteria at all", async () => {
+      mockRules([fakeRule({})]);
+      mockDevices([
+        fakeDevice({ index: 0, hostname: "10.0.5.9" }),
+        fakeDevice({ index: 1, name: "anything" }),
+      ]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesEvaluated).toBe(2);
+      expect(result.devicesMatched).toBe(0);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("devices that already belong to a site", () => {
+    it("counts a device already in this rule's site without updating it", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.5.0/24" })]);
+      mockDevices([fakeDevice({ hostname: "10.0.5.9", siteId: SITE_A_ID })]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesMatched).toBe(1);
+      expect(result.devicesAlreadyInRuleSite).toBe(1);
+      expect(result.devicesAssigned).toBe(0);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    /*
+     * The default. Nothing in the schema says whether SITE_B was chosen by a
+     * rule or by a person, so a plain run must not overwrite it.
+     */
+    it("leaves a device in another site alone by default", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.5.0/24" })]);
+      mockDevices([fakeDevice({ hostname: "10.0.5.9", siteId: SITE_B_ID })]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesMatched).toBe(1);
+      expect(result.devicesSkippedAlreadyInAnotherSite).toBe(1);
+      expect(result.devicesAssigned).toBe(0);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("moves a device out of another site when explicitly asked to", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.5.0/24" })]);
+      mockDevices([fakeDevice({ hostname: "10.0.5.9", siteId: SITE_B_ID })]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run({
+        reassignDevicesAlreadyInASite: true,
+      });
+
+      expect(result.devicesAssigned).toBe(1);
+      expect(result.devicesSkippedAlreadyInAnotherSite).toBe(0);
+      expect(updateSpy.mock.calls[0]![0].data.siteId.toString()).toBe(
+        SITE_A_ID.toString(),
+      );
+    });
+
+    /*
+     * Even with the overwrite flag on, a device already in the rule's own
+     * site is a no-op - re-running a rule must not churn writes (each one
+     * would recompute a site rollup) for nothing.
+     */
+    it("still skips a device already in this rule's site when overwriting", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.5.0/24" })]);
+      mockDevices([fakeDevice({ hostname: "10.0.5.9", siteId: SITE_A_ID })]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run({
+        reassignDevicesAlreadyInASite: true,
+      });
+
+      expect(result.devicesAlreadyInRuleSite).toBe(1);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("priority", () => {
+    it("leaves a device a higher-priority rule also matches to that rule", async () => {
+      mockRules([
+        fakeRule({ subnetCidr: "10.0.0.0/8", priority: 1 }),
+        fakeRule({
+          id: OTHER_RULE_ID,
+          siteId: SITE_B_ID,
+          subnetCidr: "10.0.5.0/24",
+          priority: 10,
+        }),
+      ]);
+      mockDevices([fakeDevice({ hostname: "10.0.5.9" })]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesMatched).toBe(1);
+      expect(result.devicesClaimedByHigherPriorityRule).toBe(1);
+      expect(result.devicesAssigned).toBe(0);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("assigns when this rule is the one that outranks the others", async () => {
+      mockRules([
+        fakeRule({ subnetCidr: "10.0.5.0/24", priority: 10 }),
+        fakeRule({
+          id: OTHER_RULE_ID,
+          siteId: SITE_B_ID,
+          subnetCidr: "10.0.0.0/8",
+          priority: 1,
+        }),
+      ]);
+      mockDevices([fakeDevice({ hostname: "10.0.5.9" })]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesAssigned).toBe(1);
+      expect(result.devicesClaimedByHigherPriorityRule).toBe(0);
+      expect(updateSpy.mock.calls[0]![0].data.siteId.toString()).toBe(
+        SITE_A_ID.toString(),
+      );
+    });
+
+    // Ties go to the older rule, the same way the automatic path breaks them.
+    it("yields to an equally ranked but older rule", async () => {
+      mockRules([
+        fakeRule({
+          subnetCidr: "10.0.5.0/24",
+          priority: 5,
+          createdAt: new Date("2024-02-01T00:00:00Z"),
+        }),
+        fakeRule({
+          id: OTHER_RULE_ID,
+          siteId: SITE_B_ID,
+          subnetCidr: "10.0.5.0/24",
+          priority: 5,
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+        }),
+      ]);
+      mockDevices([fakeDevice({ hostname: "10.0.5.9" })]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesClaimedByHigherPriorityRule).toBe(1);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("wins an equally ranked tie when it is the older rule", async () => {
+      mockRules([
+        fakeRule({
+          subnetCidr: "10.0.5.0/24",
+          priority: 5,
+          createdAt: new Date("2024-01-01T00:00:00Z"),
+        }),
+        fakeRule({
+          id: OTHER_RULE_ID,
+          siteId: SITE_B_ID,
+          subnetCidr: "10.0.5.0/24",
+          priority: 5,
+          createdAt: new Date("2024-02-01T00:00:00Z"),
+        }),
+      ]);
+      mockDevices([fakeDevice({ hostname: "10.0.5.9" })]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesAssigned).toBe(1);
+      expect(updateSpy.mock.calls[0]![0].data.siteId.toString()).toBe(
+        SITE_A_ID.toString(),
+      );
+    });
+
+    /*
+     * Priority is checked AFTER the already-in-a-site checks, so a device a
+     * higher-priority rule wants is still reported under the reason the
+     * operator can act on first.
+     */
+    it("reports a device already in another site before consulting priority", async () => {
+      mockRules([
+        fakeRule({ subnetCidr: "10.0.0.0/8", priority: 1 }),
+        fakeRule({
+          id: OTHER_RULE_ID,
+          siteId: SITE_B_ID,
+          subnetCidr: "10.0.5.0/24",
+          priority: 10,
+        }),
+      ]);
+      mockDevices([fakeDevice({ hostname: "10.0.5.9", siteId: SITE_B_ID })]);
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesSkippedAlreadyInAnotherSite).toBe(1);
+      expect(result.devicesClaimedByHigherPriorityRule).toBe(0);
+    });
+  });
+
+  describe("resilience and reporting", () => {
+    it("counts a failed device update and keeps going", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.5.0/24" })]);
+      mockDevices([
+        fakeDevice({ index: 0, hostname: "10.0.5.9" }),
+        fakeDevice({ index: 1, hostname: "10.0.5.10" }),
+        fakeDevice({ index: 2, hostname: "10.0.5.11" }),
+      ]);
+
+      const updateSpy: jest.SpyInstance = jest
+        .spyOn(NetworkDeviceService, "updateOneById")
+        .mockImplementation(async (data: any) => {
+          if (data.id.toString() === deviceId(1).toString()) {
+            throw new Error("deadlock detected");
+          }
+          return undefined as never;
+        });
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(updateSpy).toHaveBeenCalledTimes(3);
+      expect(result.devicesMatched).toBe(3);
+      expect(result.devicesAssigned).toBe(2);
+      expect(result.devicesFailed).toBe(1);
+    });
+
+    /*
+     * A row with no usable id cannot be updated. It still has to be
+     * accounted for, or the buckets would not add up to devicesMatched and
+     * the summary would silently under-report.
+     */
+    it("counts a device with no id as a failure rather than losing it", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.5.0/24" })]);
+      mockDevices([
+        {
+          projectId: PROJECT_ID,
+          hostname: "10.0.5.9",
+        } as unknown as NetworkDevice,
+      ]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesMatched).toBe(1);
+      expect(result.devicesFailed).toBe(1);
+      expect(result.devicesAssigned).toBe(0);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns an all-zero result for a project with no devices", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.5.0/24" })]);
+      mockDevices([]);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result).toEqual({
+        devicesEvaluated: 0,
+        devicesMatched: 0,
+        devicesAssigned: 0,
+        devicesAlreadyInRuleSite: 0,
+        devicesSkippedAlreadyInAnotherSite: 0,
+        devicesClaimedByHigherPriorityRule: 0,
+        devicesFailed: 0,
+        isTruncated: false,
+      });
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    /*
+     * Every evaluated device lands in exactly one bucket, or a zero
+     * assignment count could never be explained to the operator.
+     */
+    it("accounts for every matched device in exactly one bucket", async () => {
+      mockRules([
+        fakeRule({ subnetCidr: "10.0.0.0/8", priority: 1 }),
+        fakeRule({
+          id: OTHER_RULE_ID,
+          siteId: SITE_B_ID,
+          subnetCidr: "10.0.9.0/24",
+          priority: 10,
+        }),
+      ]);
+      mockDevices([
+        // Assigned.
+        fakeDevice({ index: 0, hostname: "10.0.5.9" }),
+        // Already in this rule's site.
+        fakeDevice({ index: 1, hostname: "10.0.5.10", siteId: SITE_A_ID }),
+        // In another site.
+        fakeDevice({ index: 2, hostname: "10.0.5.11", siteId: SITE_B_ID }),
+        // Claimed by the higher-priority rule.
+        fakeDevice({ index: 3, hostname: "10.0.9.4" }),
+        // No match at all.
+        fakeDevice({ index: 4, hostname: "172.16.0.1" }),
+      ]);
+      mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesEvaluated).toBe(5);
+      expect(result.devicesMatched).toBe(4);
+      expect(
+        result.devicesAssigned +
+          result.devicesAlreadyInRuleSite +
+          result.devicesSkippedAlreadyInAnotherSite +
+          result.devicesClaimedByHigherPriorityRule +
+          result.devicesFailed,
+      ).toBe(result.devicesMatched);
+    });
+  });
+
+  describe("paging and the run cap", () => {
+    it("walks every page of a multi-page estate", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.5.0/24" })]);
+      const devicesSpy: jest.SpyInstance = mockGeneratedDevices(2500);
+      const updateSpy: jest.SpyInstance = mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesEvaluated).toBe(2500);
+      expect(result.devicesAssigned).toBe(2500);
+      expect(updateSpy).toHaveBeenCalledTimes(2500);
+      expect(result.isTruncated).toBe(false);
+
+      // 1000 + 1000 + 500, and the short page ends the walk.
+      expect(devicesSpy).toHaveBeenCalledTimes(3);
+      expect(devicesSpy.mock.calls[1]![0].skip).toBe(1000);
+      expect(devicesSpy.mock.calls[2]![0].skip).toBe(2000);
+    });
+
+    it("stops at the cap and reports the run as truncated", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.5.0/24" })]);
+      mockGeneratedDevices(10500);
+      mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesEvaluated).toBe(10000);
+      expect(result.isTruncated).toBe(true);
+    });
+
+    /*
+     * A full last page is not proof that more devices exist. An estate of
+     * exactly the cap must not report a truncation, or the UI would tell the
+     * operator to run it again forever.
+     */
+    it("does not report truncation for an estate of exactly the cap", async () => {
+      mockRules([fakeRule({ subnetCidr: "10.0.5.0/24" })]);
+      mockGeneratedDevices(10000);
+      mockUpdate();
+
+      const result: SiteAssignmentRuleRunResult = await run();
+
+      expect(result.devicesEvaluated).toBe(10000);
+      expect(result.isTruncated).toBe(false);
+    });
+  });
+});

--- a/Common/Tests/Types/NetworkAutomation/RuleRunResult.test.ts
+++ b/Common/Tests/Types/NetworkAutomation/RuleRunResult.test.ts
@@ -1,0 +1,184 @@
+import {
+  LabelRuleRunResult,
+  RuleRunResultUtil,
+  SiteAssignmentRuleRunResult,
+} from "../../../Types/NetworkAutomation/RuleRunResult";
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test - narrowing a rule run's response.
+ *
+ * The dashboard renders these counters straight into a sentence, so anything
+ * the parser lets through untyped ends up on screen. A field the server did
+ * not send has to read as zero, not as "NaN devices"; isTruncated has to be a
+ * real boolean, not whatever truthy value happened to arrive.
+ */
+
+describe("RuleRunResultUtil.parseSiteAssignmentRuleRunResult", () => {
+  it("reads a full response", () => {
+    const parsed: SiteAssignmentRuleRunResult =
+      RuleRunResultUtil.parseSiteAssignmentRuleRunResult({
+        devicesEvaluated: 40,
+        devicesMatched: 12,
+        devicesAssigned: 8,
+        devicesAlreadyInRuleSite: 2,
+        devicesSkippedAlreadyInAnotherSite: 1,
+        devicesClaimedByHigherPriorityRule: 1,
+        devicesFailed: 0,
+        isTruncated: false,
+      } as JSONObject);
+
+    expect(parsed).toEqual({
+      devicesEvaluated: 40,
+      devicesMatched: 12,
+      devicesAssigned: 8,
+      devicesAlreadyInRuleSite: 2,
+      devicesSkippedAlreadyInAnotherSite: 1,
+      devicesClaimedByHigherPriorityRule: 1,
+      devicesFailed: 0,
+      isTruncated: false,
+    });
+  });
+
+  it("reads every missing counter as zero", () => {
+    const parsed: SiteAssignmentRuleRunResult =
+      RuleRunResultUtil.parseSiteAssignmentRuleRunResult({});
+
+    expect(parsed).toEqual({
+      devicesEvaluated: 0,
+      devicesMatched: 0,
+      devicesAssigned: 0,
+      devicesAlreadyInRuleSite: 0,
+      devicesSkippedAlreadyInAnotherSite: 0,
+      devicesClaimedByHigherPriorityRule: 0,
+      devicesFailed: 0,
+      isTruncated: false,
+    });
+  });
+
+  it("survives a null or undefined body", () => {
+    expect(
+      RuleRunResultUtil.parseSiteAssignmentRuleRunResult(null).devicesEvaluated,
+    ).toBe(0);
+    expect(
+      RuleRunResultUtil.parseSiteAssignmentRuleRunResult(undefined)
+        .devicesMatched,
+    ).toBe(0);
+  });
+
+  /*
+   * A numeric string is exactly what a hand-rolled proxy or a JSON layer that
+   * stringifies large numbers would send. It must not become "12" concatenated
+   * into a sentence, nor NaN.
+   */
+  it("refuses a non-numeric counter rather than passing it through", () => {
+    const parsed: SiteAssignmentRuleRunResult =
+      RuleRunResultUtil.parseSiteAssignmentRuleRunResult({
+        devicesEvaluated: "40",
+        devicesMatched: null,
+        devicesAssigned: {},
+      } as unknown as JSONObject);
+
+    expect(parsed.devicesEvaluated).toBe(0);
+    expect(parsed.devicesMatched).toBe(0);
+    expect(parsed.devicesAssigned).toBe(0);
+  });
+
+  it("refuses NaN and Infinity", () => {
+    const parsed: SiteAssignmentRuleRunResult =
+      RuleRunResultUtil.parseSiteAssignmentRuleRunResult({
+        devicesEvaluated: Number.NaN,
+        devicesMatched: Number.POSITIVE_INFINITY,
+      } as unknown as JSONObject);
+
+    expect(parsed.devicesEvaluated).toBe(0);
+    expect(parsed.devicesMatched).toBe(0);
+  });
+
+  it("treats only a literal true as truncation", () => {
+    expect(
+      RuleRunResultUtil.parseSiteAssignmentRuleRunResult({
+        isTruncated: true,
+      }).isTruncated,
+    ).toBe(true);
+
+    expect(
+      RuleRunResultUtil.parseSiteAssignmentRuleRunResult({
+        isTruncated: "true",
+      } as unknown as JSONObject).isTruncated,
+    ).toBe(false);
+
+    expect(
+      RuleRunResultUtil.parseSiteAssignmentRuleRunResult({
+        isTruncated: 1,
+      } as unknown as JSONObject).isTruncated,
+    ).toBe(false);
+  });
+
+  // Unknown fields are dropped: the shape the UI reads is the declared one.
+  it("ignores fields it does not know", () => {
+    const parsed: SiteAssignmentRuleRunResult =
+      RuleRunResultUtil.parseSiteAssignmentRuleRunResult({
+        devicesEvaluated: 3,
+        somethingElse: "ignored",
+      } as unknown as JSONObject);
+
+    expect(parsed.devicesEvaluated).toBe(3);
+    expect(Object.keys(parsed)).not.toContain("somethingElse");
+  });
+});
+
+describe("RuleRunResultUtil.parseLabelRuleRunResult", () => {
+  it("reads a full response", () => {
+    const parsed: LabelRuleRunResult =
+      RuleRunResultUtil.parseLabelRuleRunResult({
+        devicesEvaluated: 40,
+        devicesMatched: 12,
+        devicesLabeled: 10,
+        labelsAttached: 20,
+        labelsFailed: 0,
+        isTruncated: true,
+      } as JSONObject);
+
+    expect(parsed).toEqual({
+      devicesEvaluated: 40,
+      devicesMatched: 12,
+      devicesLabeled: 10,
+      labelsAttached: 20,
+      labelsFailed: 0,
+      isTruncated: true,
+    });
+  });
+
+  it("reads every missing counter as zero", () => {
+    const parsed: LabelRuleRunResult =
+      RuleRunResultUtil.parseLabelRuleRunResult({});
+
+    expect(parsed).toEqual({
+      devicesEvaluated: 0,
+      devicesMatched: 0,
+      devicesLabeled: 0,
+      labelsAttached: 0,
+      labelsFailed: 0,
+      isTruncated: false,
+    });
+  });
+
+  it("survives a null body", () => {
+    expect(RuleRunResultUtil.parseLabelRuleRunResult(null).labelsAttached).toBe(
+      0,
+    );
+  });
+
+  it("refuses a non-numeric counter", () => {
+    const parsed: LabelRuleRunResult =
+      RuleRunResultUtil.parseLabelRuleRunResult({
+        labelsAttached: "20",
+        devicesLabeled: false,
+      } as unknown as JSONObject);
+
+    expect(parsed.labelsAttached).toBe(0);
+    expect(parsed.devicesLabeled).toBe(0);
+  });
+});

--- a/Common/Tests/UI/Utils/RunNetworkRule.test.ts
+++ b/Common/Tests/UI/Utils/RunNetworkRule.test.ts
@@ -1,0 +1,320 @@
+import API from "../../../UI/Utils/API/API";
+import RunNetworkRule, {
+  NetworkRuleKind,
+  NetworkRuleRunOutcome,
+} from "../../../UI/Utils/NetworkAutomation/RunNetworkRule";
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import URL from "../../../Types/API/URL";
+import { JSONObject } from "../../../Types/JSON";
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * Contract under test - the dashboard half of "Run now"
+ * (OneUptime/oneuptime#3191).
+ *
+ * Three things can only go wrong here, and all three are invisible from the
+ * server: posting to the wrong route (nothing runs and the user sees a 404),
+ * sending the overwrite flag as anything other than a real boolean (the
+ * endpoint reads only a literal true, so a run silently declines to do what
+ * the checkbox promised), and turning a failure into a blank modal.
+ */
+
+const RULE_ID: string = "44444444-4444-4444-8444-444444444444";
+
+function successResponse(body: JSONObject): HTTPResponse<JSONObject> {
+  return new HTTPResponse<JSONObject>(200, body, {});
+}
+
+function mockPost(
+  response: HTTPResponse<JSONObject> | HTTPErrorResponse,
+): jest.SpiedFunction<typeof API.post> {
+  return jest.spyOn(API, "post").mockResolvedValue(response as never) as any;
+}
+
+function lastPostArgs(spy: jest.SpiedFunction<typeof API.post>): {
+  url: URL;
+  data: JSONObject;
+  headers?: Record<string, string> | undefined;
+} {
+  return (spy.mock.calls[0] as Array<unknown>)[0] as {
+    url: URL;
+    data: JSONObject;
+    headers?: Record<string, string> | undefined;
+  };
+}
+
+const SITE_RUN_RESULT: JSONObject = {
+  devicesEvaluated: 40,
+  devicesMatched: 12,
+  devicesAssigned: 12,
+  devicesAlreadyInRuleSite: 0,
+  devicesSkippedAlreadyInAnotherSite: 0,
+  devicesClaimedByHigherPriorityRule: 0,
+  devicesFailed: 0,
+  isTruncated: false,
+};
+
+const LABEL_RUN_RESULT: JSONObject = {
+  devicesEvaluated: 40,
+  devicesMatched: 12,
+  devicesLabeled: 12,
+  labelsAttached: 24,
+  labelsFailed: 0,
+  isTruncated: false,
+};
+
+describe("RunNetworkRule.getRunRoute", () => {
+  it("routes a site assignment rule to its own endpoint", () => {
+    expect(
+      RunNetworkRule.getRunRoute({
+        ruleKind: NetworkRuleKind.SiteAssignment,
+        ruleId: RULE_ID,
+      }),
+    ).toBe(`/network-site-assignment-rule/${RULE_ID}/run`);
+  });
+
+  it("routes a label rule to its own endpoint", () => {
+    expect(
+      RunNetworkRule.getRunRoute({
+        ruleKind: NetworkRuleKind.DeviceLabel,
+        ruleId: RULE_ID,
+      }),
+    ).toBe(`/network-device-label-rule/${RULE_ID}/run`);
+  });
+});
+
+describe("RunNetworkRule.run", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("the request", () => {
+    it("posts to the site assignment endpoint for that rule kind", async () => {
+      const spy: jest.SpiedFunction<typeof API.post> = mockPost(
+        successResponse(SITE_RUN_RESULT),
+      );
+
+      await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.SiteAssignment,
+        ruleId: RULE_ID,
+      });
+
+      expect(lastPostArgs(spy).url.toString()).toContain(
+        `/network-site-assignment-rule/${RULE_ID}/run`,
+      );
+    });
+
+    it("posts to the label rule endpoint for that rule kind", async () => {
+      const spy: jest.SpiedFunction<typeof API.post> = mockPost(
+        successResponse(LABEL_RUN_RESULT),
+      );
+
+      await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.DeviceLabel,
+        ruleId: RULE_ID,
+      });
+
+      expect(lastPostArgs(spy).url.toString()).toContain(
+        `/network-device-label-rule/${RULE_ID}/run`,
+      );
+    });
+
+    /*
+     * The tenantid header is what scopes the run to the current project. A
+     * request without it is refused by the endpoint, so the caller's headers
+     * have to survive this hop.
+     */
+    it("passes the caller's headers through", async () => {
+      const spy: jest.SpiedFunction<typeof API.post> = mockPost(
+        successResponse(SITE_RUN_RESULT),
+      );
+
+      await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.SiteAssignment,
+        ruleId: RULE_ID,
+        headers: { tenantid: "project-1" },
+      });
+
+      expect(lastPostArgs(spy).headers).toEqual({ tenantid: "project-1" });
+    });
+
+    it("sends the overwrite flag off unless it was asked for", async () => {
+      const spy: jest.SpiedFunction<typeof API.post> = mockPost(
+        successResponse(SITE_RUN_RESULT),
+      );
+
+      await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.SiteAssignment,
+        ruleId: RULE_ID,
+      });
+
+      expect(lastPostArgs(spy).data).toEqual({
+        reassignDevicesAlreadyInASite: false,
+      });
+    });
+
+    /*
+     * A real boolean, not a truthy value: the endpoint reads only a literal
+     * true, so anything else would leave the checkbox looking broken.
+     */
+    it("sends the overwrite flag as a literal boolean", async () => {
+      const spy: jest.SpiedFunction<typeof API.post> = mockPost(
+        successResponse(SITE_RUN_RESULT),
+      );
+
+      await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.SiteAssignment,
+        ruleId: RULE_ID,
+        reassignDevicesAlreadyInASite: true,
+      });
+
+      expect(lastPostArgs(spy).data["reassignDevicesAlreadyInASite"]).toBe(
+        true,
+      );
+    });
+
+    // A label run has nothing to overwrite, so it must not carry the flag.
+    it("never sends the overwrite flag for a label rule", async () => {
+      const spy: jest.SpiedFunction<typeof API.post> = mockPost(
+        successResponse(LABEL_RUN_RESULT),
+      );
+
+      await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.DeviceLabel,
+        ruleId: RULE_ID,
+        reassignDevicesAlreadyInASite: true,
+      });
+
+      expect(lastPostArgs(spy).data).toEqual({});
+    });
+
+    /*
+     * An empty id would post to `/…//run`, which matches no route and comes
+     * back as a 404 that says nothing about the real problem.
+     */
+    it("refuses to post a rule with no id", async () => {
+      const spy: jest.SpiedFunction<typeof API.post> = mockPost(
+        successResponse(SITE_RUN_RESULT),
+      );
+
+      const outcome: NetworkRuleRunOutcome = await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.SiteAssignment,
+        ruleId: "",
+      });
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(outcome.isSuccess).toBe(false);
+      expect(outcome.message).toContain("no id");
+    });
+  });
+
+  describe("the answer", () => {
+    it("summarises a site assignment run", async () => {
+      mockPost(successResponse(SITE_RUN_RESULT));
+
+      const outcome: NetworkRuleRunOutcome = await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.SiteAssignment,
+        ruleId: RULE_ID,
+      });
+
+      expect(outcome.isSuccess).toBe(true);
+      expect(outcome.message).toContain(
+        "Assigned 12 devices to this rule's site.",
+      );
+    });
+
+    it("summarises a label rule run", async () => {
+      mockPost(successResponse(LABEL_RUN_RESULT));
+
+      const outcome: NetworkRuleRunOutcome = await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.DeviceLabel,
+        ruleId: RULE_ID,
+      });
+
+      expect(outcome.isSuccess).toBe(true);
+      expect(outcome.message).toContain("Labelled 12 devices");
+    });
+
+    /*
+     * The kinds must not be summarised with each other's sentences - a label
+     * run reported as "assigned 0 devices" would read as a failure.
+     */
+    it("does not describe a label run in site assignment terms", async () => {
+      mockPost(successResponse(LABEL_RUN_RESULT));
+
+      const outcome: NetworkRuleRunOutcome = await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.DeviceLabel,
+        ruleId: RULE_ID,
+      });
+
+      expect(outcome.message).not.toContain("Assigned");
+    });
+
+    it("explains a run that changed nothing rather than reporting success blankly", async () => {
+      mockPost(
+        successResponse({
+          ...SITE_RUN_RESULT,
+          devicesAssigned: 0,
+          devicesSkippedAlreadyInAnotherSite: 12,
+        }),
+      );
+
+      const outcome: NetworkRuleRunOutcome = await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.SiteAssignment,
+        ruleId: RULE_ID,
+      });
+
+      expect(outcome.isSuccess).toBe(true);
+      expect(outcome.message).toContain("No devices were reassigned.");
+      expect(outcome.message).toContain("already belong to another site");
+    });
+
+    /*
+     * An empty body still has to produce a sentence. A server that answered
+     * with nothing must not leave the modal blank.
+     */
+    it("survives a response carrying no counters", async () => {
+      mockPost(successResponse({}));
+
+      const outcome: NetworkRuleRunOutcome = await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.SiteAssignment,
+        ruleId: RULE_ID,
+      });
+
+      expect(outcome.isSuccess).toBe(true);
+      expect(outcome.message).toContain("No devices were reassigned.");
+    });
+  });
+
+  describe("failures", () => {
+    it("reports a failure response as a message, not a success", async () => {
+      mockPost(
+        new HTTPErrorResponse(400, { message: "Label rule not found." }, {}),
+      );
+
+      const outcome: NetworkRuleRunOutcome = await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.DeviceLabel,
+        ruleId: RULE_ID,
+      });
+
+      expect(outcome.isSuccess).toBe(false);
+      expect(outcome.message).toContain("Label rule not found.");
+    });
+
+    // A thrown request (offline, DNS, an aborted fetch) must not escape.
+    it("reports a thrown request as a message", async () => {
+      jest
+        .spyOn(API, "post")
+        .mockRejectedValue(new Error("Network request failed") as never);
+
+      const outcome: NetworkRuleRunOutcome = await RunNetworkRule.run({
+        ruleKind: NetworkRuleKind.SiteAssignment,
+        ruleId: RULE_ID,
+      });
+
+      expect(outcome.isSuccess).toBe(false);
+      expect(outcome.message).toContain("Network request failed");
+    });
+  });
+});

--- a/Common/Tests/Utils/NetworkAutomation/RuleRunSummary.test.ts
+++ b/Common/Tests/Utils/NetworkAutomation/RuleRunSummary.test.ts
@@ -1,0 +1,286 @@
+import RuleRunSummary from "../../../Utils/NetworkAutomation/RuleRunSummary";
+import {
+  LabelRuleRunResult,
+  SiteAssignmentRuleRunResult,
+} from "../../../Types/NetworkAutomation/RuleRunResult";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * Contract under test - the sentences a "Run now" reports back with.
+ *
+ * The interesting case is not the happy one. A rule run that changes nothing
+ * is the norm once a rule has been run once, and "0 devices assigned" with no
+ * reason attached reads as a broken button. Every way a matched device can be
+ * left alone therefore has to name itself and, where the operator can do
+ * something about it, say what.
+ */
+
+function siteRun(
+  overrides: Partial<SiteAssignmentRuleRunResult> = {},
+): SiteAssignmentRuleRunResult {
+  return {
+    devicesEvaluated: 0,
+    devicesMatched: 0,
+    devicesAssigned: 0,
+    devicesAlreadyInRuleSite: 0,
+    devicesSkippedAlreadyInAnotherSite: 0,
+    devicesClaimedByHigherPriorityRule: 0,
+    devicesFailed: 0,
+    isTruncated: false,
+    ...overrides,
+  };
+}
+
+function labelRun(
+  overrides: Partial<LabelRuleRunResult> = {},
+): LabelRuleRunResult {
+  return {
+    devicesEvaluated: 0,
+    devicesMatched: 0,
+    devicesLabeled: 0,
+    labelsAttached: 0,
+    labelsFailed: 0,
+    isTruncated: false,
+    ...overrides,
+  };
+}
+
+describe("RuleRunSummary.describeSiteAssignmentRun", () => {
+  it("leads with what changed", () => {
+    const summary: string = RuleRunSummary.describeSiteAssignmentRun(
+      siteRun({
+        devicesEvaluated: 40,
+        devicesMatched: 12,
+        devicesAssigned: 12,
+      }),
+    );
+
+    expect(summary).toContain("Assigned 12 devices to this rule's site.");
+  });
+
+  it("uses the singular for a single device", () => {
+    const summary: string = RuleRunSummary.describeSiteAssignmentRun(
+      siteRun({ devicesEvaluated: 1, devicesMatched: 1, devicesAssigned: 1 }),
+    );
+
+    expect(summary).toContain("Assigned 1 device to this rule's site.");
+    expect(summary).not.toContain("1 devices");
+  });
+
+  /*
+   * The whole point of the counters: a run that assigned nothing has to say
+   * how much it looked at and how much it matched, or the operator cannot
+   * tell a rule that does not match from a rule with nothing left to do.
+   */
+  it("explains a run that assigned nothing", () => {
+    const summary: string = RuleRunSummary.describeSiteAssignmentRun(
+      siteRun({ devicesEvaluated: 40, devicesMatched: 0 }),
+    );
+
+    expect(summary).toContain("No devices were reassigned.");
+    expect(summary).toContain("matched 0 devices out of the 40");
+  });
+
+  it("says when the matched devices were already in this rule's site", () => {
+    const summary: string = RuleRunSummary.describeSiteAssignmentRun(
+      siteRun({
+        devicesEvaluated: 40,
+        devicesMatched: 12,
+        devicesAlreadyInRuleSite: 12,
+      }),
+    );
+
+    expect(summary).toContain(
+      "12 devices already belonged to this rule's site",
+    );
+  });
+
+  // The skip the operator can undo - so the summary names the switch.
+  it("points at the overwrite option when devices were left in another site", () => {
+    const summary: string = RuleRunSummary.describeSiteAssignmentRun(
+      siteRun({
+        devicesEvaluated: 40,
+        devicesMatched: 12,
+        devicesSkippedAlreadyInAnotherSite: 12,
+      }),
+    );
+
+    expect(summary).toContain("already belong to another site");
+    expect(summary).toContain(
+      "Move devices that are already assigned to a site",
+    );
+  });
+
+  // The skip the operator fixes by running the OTHER rule.
+  it("explains a device claimed by a higher-priority rule", () => {
+    const summary: string = RuleRunSummary.describeSiteAssignmentRun(
+      siteRun({
+        devicesEvaluated: 40,
+        devicesMatched: 3,
+        devicesClaimedByHigherPriorityRule: 3,
+      }),
+    );
+
+    expect(summary).toContain("matched a higher-priority rule as well");
+    expect(summary).toContain("Run that rule to place them.");
+  });
+
+  it("reports failures", () => {
+    const summary: string = RuleRunSummary.describeSiteAssignmentRun(
+      siteRun({
+        devicesEvaluated: 40,
+        devicesMatched: 4,
+        devicesAssigned: 3,
+        devicesFailed: 1,
+      }),
+    );
+
+    expect(summary).toContain("1 device could not be updated");
+  });
+
+  it("tells the operator to run again after a truncated run", () => {
+    const summary: string = RuleRunSummary.describeSiteAssignmentRun(
+      siteRun({
+        devicesEvaluated: 10000,
+        devicesMatched: 10,
+        devicesAssigned: 10,
+        isTruncated: true,
+      }),
+    );
+
+    expect(summary).toContain("Only the first 10000 devices were evaluated");
+    expect(summary).toContain("Run the rule again");
+  });
+
+  // A run can hit several of these at once; none of them may swallow another.
+  it("reports every applicable reason in one summary", () => {
+    const summary: string = RuleRunSummary.describeSiteAssignmentRun(
+      siteRun({
+        devicesEvaluated: 100,
+        devicesMatched: 10,
+        devicesAssigned: 4,
+        devicesAlreadyInRuleSite: 2,
+        devicesSkippedAlreadyInAnotherSite: 2,
+        devicesClaimedByHigherPriorityRule: 1,
+        devicesFailed: 1,
+      }),
+    );
+
+    expect(summary).toContain("Assigned 4 devices");
+    expect(summary).toContain("2 devices already belonged");
+    expect(summary).toContain("already belong to another site");
+    expect(summary).toContain("higher-priority rule");
+    expect(summary).toContain("could not be updated");
+  });
+
+  it("stays silent about buckets that are empty", () => {
+    const summary: string = RuleRunSummary.describeSiteAssignmentRun(
+      siteRun({
+        devicesEvaluated: 40,
+        devicesMatched: 12,
+        devicesAssigned: 12,
+      }),
+    );
+
+    expect(summary).not.toContain("higher-priority");
+    expect(summary).not.toContain("could not be updated");
+    expect(summary).not.toContain("Only the first");
+  });
+});
+
+describe("RuleRunSummary.describeLabelRun", () => {
+  it("leads with what was labelled", () => {
+    const summary: string = RuleRunSummary.describeLabelRun(
+      labelRun({
+        devicesEvaluated: 40,
+        devicesMatched: 12,
+        devicesLabeled: 12,
+        labelsAttached: 24,
+      }),
+    );
+
+    expect(summary).toContain("Labelled 12 devices (24 labels attached).");
+  });
+
+  it("uses the singular for a single device and a single label", () => {
+    const summary: string = RuleRunSummary.describeLabelRun(
+      labelRun({
+        devicesEvaluated: 1,
+        devicesMatched: 1,
+        devicesLabeled: 1,
+        labelsAttached: 1,
+      }),
+    );
+
+    expect(summary).toContain("Labelled 1 device (1 label attached).");
+  });
+
+  /*
+   * Matching everything and attaching nothing is the signature of a rule that
+   * has already been run. Saying so is the difference between "it worked, and
+   * there was nothing left to do" and "it did not work".
+   */
+  it("explains a rule that has already been applied", () => {
+    const summary: string = RuleRunSummary.describeLabelRun(
+      labelRun({ devicesEvaluated: 40, devicesMatched: 12, devicesLabeled: 0 }),
+    );
+
+    expect(summary).toContain("No labels were attached.");
+    expect(summary).toContain("matched 12 devices out of the 40");
+    expect(summary).toContain(
+      "Every matching device already carries this rule's labels",
+    );
+  });
+
+  // Nothing matched is a different answer, and must not claim otherwise.
+  it("does not claim devices are already labelled when nothing matched", () => {
+    const summary: string = RuleRunSummary.describeLabelRun(
+      labelRun({ devicesEvaluated: 40, devicesMatched: 0 }),
+    );
+
+    expect(summary).toContain("No labels were attached.");
+    expect(summary).not.toContain("already carries");
+  });
+
+  it("reports failures", () => {
+    const summary: string = RuleRunSummary.describeLabelRun(
+      labelRun({
+        devicesEvaluated: 40,
+        devicesMatched: 5,
+        devicesLabeled: 4,
+        labelsAttached: 4,
+        labelsFailed: 1,
+      }),
+    );
+
+    expect(summary).toContain("1 label could not be attached");
+  });
+
+  it("tells the operator to run again after a truncated run", () => {
+    const summary: string = RuleRunSummary.describeLabelRun(
+      labelRun({
+        devicesEvaluated: 10000,
+        devicesMatched: 10,
+        devicesLabeled: 10,
+        labelsAttached: 10,
+        isTruncated: true,
+      }),
+    );
+
+    expect(summary).toContain("Only the first 10000 devices were evaluated");
+  });
+
+  it("stays silent about buckets that are empty", () => {
+    const summary: string = RuleRunSummary.describeLabelRun(
+      labelRun({
+        devicesEvaluated: 40,
+        devicesMatched: 12,
+        devicesLabeled: 12,
+        labelsAttached: 12,
+      }),
+    );
+
+    expect(summary).not.toContain("could not be attached");
+    expect(summary).not.toContain("Only the first");
+  });
+});

--- a/Common/Types/NetworkAutomation/RuleRunResult.ts
+++ b/Common/Types/NetworkAutomation/RuleRunResult.ts
@@ -1,0 +1,121 @@
+import { JSONObject } from "../JSON";
+
+/*
+ * What a manual "Run now" of a Network Automation rule did.
+ *
+ * Both rule kinds fire automatically only when a device is created (and, for
+ * site assignment, when its identity changes or on the next poll of a device
+ * with no site), so a rule written after an estate was imported never reaches
+ * it. "Run now" closes that gap — OneUptime/oneuptime#3191 — and these are the
+ * shapes it answers with.
+ *
+ * They live in Types, not next to the services that produce them, because the
+ * dashboard renders the same counters the server computed and neither side
+ * should be restating the other's field names.
+ */
+
+/*
+ * One run of a site assignment rule. Every device the run looked at lands in
+ * exactly one bucket, which is what lets the UI explain an assignment count of
+ * zero: "nothing matched" and "everything that matched is already there" are
+ * very different answers, and a single number cannot tell them apart.
+ */
+export interface SiteAssignmentRuleRunResult {
+  // Devices in the project the run evaluated.
+  devicesEvaluated: number;
+  // Of those, the ones this rule's criteria matched.
+  devicesMatched: number;
+  // Matched devices whose site this run actually changed.
+  devicesAssigned: number;
+  // Matched devices already sitting in this rule's site.
+  devicesAlreadyInRuleSite: number;
+  /*
+   * Matched devices left alone because they are already in some OTHER site
+   * and the run was not asked to overwrite existing assignments.
+   */
+  devicesSkippedAlreadyInAnotherSite: number;
+  /*
+   * Matched devices a higher-priority rule also matches. Running one rule
+   * never does another rule's work, so these are reported rather than moved.
+   */
+  devicesClaimedByHigherPriorityRule: number;
+  // Matched devices whose update threw. Logged server-side, never fatal.
+  devicesFailed: number;
+  // True when the run stopped at its device cap with devices left over.
+  isTruncated: boolean;
+}
+
+// One run of a network device label rule.
+export interface LabelRuleRunResult {
+  // Devices in the project the run evaluated.
+  devicesEvaluated: number;
+  // Of those, the ones this rule's criteria matched.
+  devicesMatched: number;
+  /*
+   * Matched devices that gained at least one label. Lower than devicesMatched
+   * whenever a device already carries everything the rule attaches —
+   * re-running a rule is idempotent, not additive.
+   */
+  devicesLabeled: number;
+  // (device, label) pairs actually inserted.
+  labelsAttached: number;
+  // Pairs whose insert threw. Logged server-side, never fatal.
+  labelsFailed: number;
+  // True when the run stopped at its device cap with devices left over.
+  isTruncated: boolean;
+}
+
+/*
+ * A count off the wire. An absent or non-numeric field reads as zero rather
+ * than as NaN: a summary line that says "NaN devices" is worse than one that
+ * under-reports a counter the server never sent.
+ */
+function readCount(json: JSONObject, key: string): number {
+  const value: unknown = json[key];
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return value;
+}
+
+export class RuleRunResultUtil {
+  public static parseSiteAssignmentRuleRunResult(
+    json: JSONObject | undefined | null,
+  ): SiteAssignmentRuleRunResult {
+    const source: JSONObject = json || {};
+
+    return {
+      devicesEvaluated: readCount(source, "devicesEvaluated"),
+      devicesMatched: readCount(source, "devicesMatched"),
+      devicesAssigned: readCount(source, "devicesAssigned"),
+      devicesAlreadyInRuleSite: readCount(source, "devicesAlreadyInRuleSite"),
+      devicesSkippedAlreadyInAnotherSite: readCount(
+        source,
+        "devicesSkippedAlreadyInAnotherSite",
+      ),
+      devicesClaimedByHigherPriorityRule: readCount(
+        source,
+        "devicesClaimedByHigherPriorityRule",
+      ),
+      devicesFailed: readCount(source, "devicesFailed"),
+      isTruncated: source["isTruncated"] === true,
+    };
+  }
+
+  public static parseLabelRuleRunResult(
+    json: JSONObject | undefined | null,
+  ): LabelRuleRunResult {
+    const source: JSONObject = json || {};
+
+    return {
+      devicesEvaluated: readCount(source, "devicesEvaluated"),
+      devicesMatched: readCount(source, "devicesMatched"),
+      devicesLabeled: readCount(source, "devicesLabeled"),
+      labelsAttached: readCount(source, "labelsAttached"),
+      labelsFailed: readCount(source, "labelsFailed"),
+      isTruncated: source["isTruncated"] === true,
+    };
+  }
+}

--- a/Common/UI/Utils/NetworkAutomation/RunNetworkRule.ts
+++ b/Common/UI/Utils/NetworkAutomation/RunNetworkRule.ts
@@ -1,0 +1,122 @@
+import URL from "../../../Types/API/URL";
+import Dictionary from "../../../Types/Dictionary";
+import HTTPErrorResponse from "../../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import { JSONObject } from "../../../Types/JSON";
+import { RuleRunResultUtil } from "../../../Types/NetworkAutomation/RuleRunResult";
+import RuleRunSummary from "../../../Utils/NetworkAutomation/RuleRunSummary";
+import { APP_API_URL } from "../../Config";
+import API from "../API/API";
+
+/*
+ * Client for the two Network Automation "Run now" endpoints.
+ *
+ * Both rule kinds fire automatically only when a device is created (and, for
+ * site assignment, when its identity changes or on the next poll of a device
+ * with no site), so a rule written after an estate was imported never reaches
+ * it. These endpoints apply one rule to the devices that already exist —
+ * OneUptime/oneuptime#3191.
+ *
+ * The two differ only in the route they post to and in whether the run can
+ * overwrite something a person chose, so they share one client rather than
+ * two that drift.
+ */
+
+export enum NetworkRuleKind {
+  SiteAssignment = "SiteAssignment",
+  DeviceLabel = "DeviceLabel",
+}
+
+const RULE_RUN_ROUTE: Record<NetworkRuleKind, string> = {
+  [NetworkRuleKind.SiteAssignment]: "/network-site-assignment-rule",
+  [NetworkRuleKind.DeviceLabel]: "/network-device-label-rule",
+};
+
+/*
+ * What the caller shows. A failed run is not an exception here: the modal
+ * renders the same sentence either way, only in the error slot.
+ */
+export interface NetworkRuleRunOutcome {
+  isSuccess: boolean;
+  message: string;
+}
+
+export default class RunNetworkRule {
+  public static getRunRoute(data: {
+    ruleKind: NetworkRuleKind;
+    ruleId: string;
+  }): string {
+    return `${RULE_RUN_ROUTE[data.ruleKind]}/${data.ruleId}/run`;
+  }
+
+  public static async run(data: {
+    ruleKind: NetworkRuleKind;
+    ruleId: string;
+    /*
+     * Site assignment only, and only ever sent as a real boolean — the
+     * endpoint accepts nothing else, so a run cannot move devices somebody
+     * placed by hand through a stray truthy value.
+     */
+    reassignDevicesAlreadyInASite?: boolean | undefined;
+    headers?: Dictionary<string> | undefined;
+  }): Promise<NetworkRuleRunOutcome> {
+    /*
+     * Without this the request would go to `/…//run`, which matches no route
+     * and comes back as an unhelpful 404 rather than as the real problem.
+     */
+    if (!data.ruleId) {
+      return {
+        isSuccess: false,
+        message: "This rule has no id, so it cannot be run.",
+      };
+    }
+
+    const isSiteAssignment: boolean =
+      data.ruleKind === NetworkRuleKind.SiteAssignment;
+
+    try {
+      const response: HTTPResponse<JSONObject> | HTTPErrorResponse =
+        await API.post<JSONObject>({
+          url: URL.fromString(APP_API_URL.toString()).addRoute(
+            RunNetworkRule.getRunRoute({
+              ruleKind: data.ruleKind,
+              ruleId: data.ruleId,
+            }),
+          ),
+          data: isSiteAssignment
+            ? {
+                reassignDevicesAlreadyInASite: Boolean(
+                  data.reassignDevicesAlreadyInASite,
+                ),
+              }
+            : {},
+          ...(data.headers ? { headers: data.headers } : {}),
+        });
+
+      if (response.isFailure()) {
+        return {
+          isSuccess: false,
+          message: API.getFriendlyMessage(response),
+        };
+      }
+
+      const body: JSONObject = (response.data || {}) as JSONObject;
+
+      return {
+        isSuccess: true,
+        message: isSiteAssignment
+          ? RuleRunSummary.describeSiteAssignmentRun(
+              RuleRunResultUtil.parseSiteAssignmentRuleRunResult(body),
+            )
+          : RuleRunSummary.describeLabelRun(
+              RuleRunResultUtil.parseLabelRuleRunResult(body),
+            ),
+      };
+    } catch (err) {
+      return {
+        isSuccess: false,
+        message: API.getFriendlyMessage(err),
+      };
+    }
+  }
+}

--- a/Common/Utils/NetworkAutomation/RuleRunSummary.ts
+++ b/Common/Utils/NetworkAutomation/RuleRunSummary.ts
@@ -1,0 +1,147 @@
+import {
+  LabelRuleRunResult,
+  SiteAssignmentRuleRunResult,
+} from "../../Types/NetworkAutomation/RuleRunResult";
+
+/*
+ * Turns a rule run's counters into the sentences the dashboard shows.
+ *
+ * Pure and dependency-free on purpose: "the rule matched 12 devices but
+ * assigned none of them" is the answer people actually need from this
+ * feature — a run that did nothing is the common case once a rule has been
+ * run once — and phrasing that badly is a support ticket. Keeping it out of
+ * the component makes every branch of it testable.
+ */
+
+function pluralize(count: number, singular: string, plural: string): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function devices(count: number): string {
+  return pluralize(count, "device", "devices");
+}
+
+export class RuleRunSummary {
+  /*
+   * The headline sentence for a site assignment run: what changed, or the
+   * most useful reason nothing did.
+   */
+  public static describeSiteAssignmentRun(
+    result: SiteAssignmentRuleRunResult,
+  ): string {
+    const lines: Array<string> = [];
+
+    if (result.devicesAssigned > 0) {
+      lines.push(
+        `Assigned ${devices(result.devicesAssigned)} to this rule's site.`,
+      );
+    } else {
+      lines.push(
+        `No devices were reassigned. This rule matched ${devices(
+          result.devicesMatched,
+        )} out of the ${devices(result.devicesEvaluated)} it looked at.`,
+      );
+    }
+
+    /*
+     * The three ways a matched device can be left alone. Each is reported
+     * only when it happened, and each names the fix, because "12 matched, 0
+     * assigned" with no explanation reads as a broken button.
+     */
+    if (result.devicesAlreadyInRuleSite > 0) {
+      lines.push(
+        `${devices(
+          result.devicesAlreadyInRuleSite,
+        )} already belonged to this rule's site.`,
+      );
+    }
+
+    if (result.devicesSkippedAlreadyInAnotherSite > 0) {
+      lines.push(
+        `${devices(
+          result.devicesSkippedAlreadyInAnotherSite,
+        )} were left where they are because they already belong to another site. Re-run with "Move devices that are already assigned to a site" to include them.`,
+      );
+    }
+
+    if (result.devicesClaimedByHigherPriorityRule > 0) {
+      lines.push(
+        `${devices(
+          result.devicesClaimedByHigherPriorityRule,
+        )} matched a higher-priority rule as well, so this rule left them to it. Run that rule to place them.`,
+      );
+    }
+
+    if (result.devicesFailed > 0) {
+      lines.push(
+        `${devices(
+          result.devicesFailed,
+        )} could not be updated. Check the server logs for the reason.`,
+      );
+    }
+
+    if (result.isTruncated) {
+      lines.push(
+        `Only the first ${devices(
+          result.devicesEvaluated,
+        )} were evaluated. Run the rule again to continue through the rest of the project.`,
+      );
+    }
+
+    return lines.join(" ");
+  }
+
+  // The same, for a label rule run.
+  public static describeLabelRun(result: LabelRuleRunResult): string {
+    const lines: Array<string> = [];
+
+    if (result.devicesLabeled > 0) {
+      lines.push(
+        `Labelled ${devices(result.devicesLabeled)} (${pluralize(
+          result.labelsAttached,
+          "label",
+          "labels",
+        )} attached).`,
+      );
+    } else {
+      lines.push(
+        `No labels were attached. This rule matched ${devices(
+          result.devicesMatched,
+        )} out of the ${devices(result.devicesEvaluated)} it looked at.`,
+      );
+
+      /*
+       * Matching everything and attaching nothing is the signature of a rule
+       * that has already been run — say so, rather than leaving it looking
+       * like a failure.
+       */
+      if (result.devicesMatched > 0) {
+        lines.push(
+          "Every matching device already carries this rule's labels, so there was nothing to add.",
+        );
+      }
+    }
+
+    if (result.labelsFailed > 0) {
+      lines.push(
+        `${pluralize(
+          result.labelsFailed,
+          "label",
+          "labels",
+        )} could not be attached. Check the server logs for the reason.`,
+      );
+    }
+
+    if (result.isTruncated) {
+      lines.push(
+        `Only the first ${devices(
+          result.devicesEvaluated,
+        )} were evaluated. Run the rule again to continue through the rest of the project.`,
+      );
+    }
+
+    return lines.join(" ");
+  }
+}
+
+export default RuleRunSummary;


### PR DESCRIPTION
Closes #3191.

## The gap

Site Assignment Rules and Network Device Label Rules only fire when a device is **created** — and, for site assignment, when its identity changes or on the next poll of a device that has no site. A rule written *after* an estate was imported or discovered therefore never reaches a single one of those devices. Short of deleting and rediscovering a live inventory, there was no way to close that.

## What this adds

A **Run Now** button on each rule in both tables, backed by two endpoints:

```
POST /network-site-assignment-rule/:ruleId/run
POST /network-device-label-rule/:ruleId/run
```

Clicking it opens a confirmation that explains what the run will do, then turns into the report of what it did.

### Site assignment runs keep the automatic path's promises

- **Priority still decides.** A device this rule matches but a *higher-priority* rule also matches is reported, never moved — running one rule must not quietly do another rule's work, or the button would produce a placement no rule alone explains. The summary says which devices those were and that running the other rule will place them.
- **A device already in a site is left alone** unless the operator explicitly asks otherwise. Nothing in the schema records whether a site was chosen by a rule or by a person, so overwriting is their decision — the checkbox is off by default and says exactly what it risks. It is not needed for the case the button exists for: a device imported before the rule existed has no site at all.
- Assignments go through `updateOneById`, so `onUpdateSuccess` refreshes the rollups of both the site the device left and the site it joined.

### Label runs are idempotent

Same matcher as the automatic engine, applied across the project instead of to one row. Already-attached labels are never duplicated, so a second run reports its matches with nothing to add rather than doing damage. Writes are batched into one statement per label (chunked at 500 devices) instead of one per device. A **disabled** rule refuses to run — running it would contradict the toggle next to the button.

### Being honest about what happened

A run that changed nothing is the normal case once a rule has been run once, and "0 devices assigned" with no explanation reads as a broken button. Every evaluated device therefore lands in exactly one bucket — matched-and-assigned, already in this site, already in another site, claimed by a higher-priority rule, or failed — and the summary names each reason that actually occurred, plus what the operator can do about it.

Both runs page the device list under a stable `_id` sort (safe, since a run writes to the very rows it pages over), stop at 10,000 devices, and report `isTruncated` only when there really are more — an estate of exactly the cap must not tell the operator to run it again forever.

### Permissions

Both endpoints require the permission to **update the rule** *and* the permission to **update a network device** — a role that may author rules but not touch the inventory cannot rewrite it through one. Both required sets are read off the models' own `@TableAccessControl` rather than restated in the API, so an ACL edit on either model cannot drift from what the endpoints enforce. (This is why a Project Member can run an assignment rule but not a label rule: the two models' update ACLs genuinely differ.)

## Tests

**123 new tests**, all passing, plus the existing network suites (no regressions).

| Suite | Tests | Covers |
| --- | --- | --- |
| `Common/Tests/Server/Services/NetworkSiteAssignmentRuleRun.test.ts` | 28 | rule/tenant resolution, CIDR + hostname/sysName/name matching, all five outcome buckets, priority and createdAt tie-breaks, the overwrite flag, per-device failure isolation, multi-page walks, the cap and its off-by-one |
| `Common/Tests/Server/Services/NetworkDeviceLabelRuleRun.test.ts` | 24 | project-scoped lookup, disabled/empty-rule refusals, regex *and* `*` glob patterns, prerequisite labels, idempotence, one-batch-per-label and chunking, failed-batch resilience, distinct device counting across pages |
| `App/Tests/BaseAPI/NetworkRuleRunAPI.test.ts` | 28 | route registration, request shaping, tenant assertion, malformed ids, error forwarding, and the full permission matrix including blocked-permission entries and master admin |
| `Common/Tests/UI/Utils/RunNetworkRule.test.ts` | 16 | endpoint selection per rule kind, the overwrite flag sent as a literal boolean, header pass-through, empty-id guard, success/failure/thrown-request handling |
| `Common/Tests/Utils/NetworkAutomation/RuleRunSummary.test.ts` | 17 | every summary branch, pluralisation, and that empty buckets stay silent |
| `Common/Tests/Types/NetworkAutomation/RuleRunResult.test.ts` | 11 | response narrowing — missing/NaN/string counters read as zero, only a literal `true` counts as truncation |

Verified locally: `tsc --noEmit` clean in `Common` and `App`, `eslint` clean on every touched file.

## Notes for review

- No schema change — this is behaviour over existing tables.
- `MAX_DEVICES_PER_RULE_RUN` is 10,000 (`LIMIT_PER_PROJECT`). Larger estates need a second click; the summary tells the operator so. Moving this to a background job would be the next step if that turns out to be common.
- Scope is the two rule kinds the issue names. `NetworkDeviceOwnerRule` and `NetworkDeviceLinkRule` have the same limitation and could get the same treatment; they are deliberately not in this PR.
