### PR TITLE
fix(network-map): name every unit in a coincident cluster

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardNetworkMapComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardNetworkMapComponent.tsx
@@ -42,7 +42,6 @@ import {
 } from "../../NetworkSite/Geo/GeoViewport";
 import {
   NETWORK_MAP_LABEL_FONT_SIZE,
-  NETWORK_MAP_LABEL_GAP,
   NETWORK_MAP_LEGEND,
   NetworkMapLegendEntry,
   NetworkMapMarker,
@@ -576,31 +575,64 @@ const DashboardNetworkMapComponentElement: FunctionComponent<ComponentProps> = (
                     ) : (
                       <></>
                     )}
-                    {marker.label ? (
-                      <text
-                        x={marker.x}
-                        /*
-                         * Below the marker unless the collision pass had to
-                         * put it above — the same geometry resolveMarkerLabels
-                         * measured against, or the placement it chose would
-                         * not be the placement drawn.
-                         */
-                        y={
-                          marker.labelPlacement === "above"
-                            ? marker.y - (radius + NETWORK_MAP_LABEL_GAP / zoom)
-                            : marker.y + radius + NETWORK_MAP_LABEL_GAP / zoom
-                        }
-                        dominantBaseline="central"
-                        textAnchor="middle"
-                        fill="var(--ou-text-secondary, #4b5563)"
-                        fontSize={NETWORK_MAP_LABEL_FONT_SIZE / zoom}
-                        stroke="var(--ou-surface-primary, #ffffff)"
-                        strokeWidth={2.5 / zoom}
-                        paintOrder="stroke"
-                        style={{ pointerEvents: "none" }}
-                      >
-                        {marker.label}
-                      </text>
+                    {marker.label && marker.labelPlacement ? (
+                      <>
+                        {/*
+                         * A name that could not fit against its marker is
+                         * pushed off it and keeps a thread back, so it is
+                         * still obvious whose name it is. Without this, sites
+                         * sitting on near-identical coordinates lost every
+                         * name but the first.
+                         */}
+                        {marker.labelPlacement.leaderLine ? (
+                          <line
+                            x1={
+                              marker.x +
+                              marker.labelPlacement.leaderLine.x1 / zoom
+                            }
+                            y1={
+                              marker.y +
+                              marker.labelPlacement.leaderLine.y1 / zoom
+                            }
+                            x2={
+                              marker.x +
+                              marker.labelPlacement.leaderLine.x2 / zoom
+                            }
+                            y2={
+                              marker.y +
+                              marker.labelPlacement.leaderLine.y2 / zoom
+                            }
+                            stroke="var(--ou-text-secondary, #4b5563)"
+                            strokeWidth={0.9 / zoom}
+                            strokeOpacity={0.7}
+                            strokeLinecap="round"
+                            style={{ pointerEvents: "none" }}
+                          />
+                        ) : (
+                          <></>
+                        )}
+                        <text
+                          /*
+                           * Position and anchor come straight off the
+                           * placement, in the screen units the collision pass
+                           * measured them in — the map must draw the name in
+                           * the box that pass reserved, or the placement it
+                           * chose is not the placement drawn.
+                           */
+                          x={marker.x + marker.labelPlacement.offsetX / zoom}
+                          y={marker.y + marker.labelPlacement.offsetY / zoom}
+                          dominantBaseline="central"
+                          textAnchor={marker.labelPlacement.textAnchor}
+                          fill="var(--ou-text-secondary, #4b5563)"
+                          fontSize={NETWORK_MAP_LABEL_FONT_SIZE / zoom}
+                          stroke="var(--ou-surface-primary, #ffffff)"
+                          strokeWidth={2.5 / zoom}
+                          paintOrder="stroke"
+                          style={{ pointerEvents: "none" }}
+                        >
+                          {marker.label}
+                        </text>
+                      </>
                     ) : (
                       <></>
                     )}

--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/NetworkMapWidgetData.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/NetworkMapWidgetData.ts
@@ -7,7 +7,6 @@ import {
   resolveMarkerLabels,
   LabelPlacement,
   MapMarker,
-  LABEL_GAP,
   LABEL_FONT_SIZE,
   MAX_LABELLED_MARKERS,
 } from "../../NetworkSite/SiteMapViewModel";
@@ -251,13 +250,16 @@ export const resolveNetworkMapMaxSites: (
 };
 
 /*
- * Label geometry, re-exported from the full map so the renderer draws names
- * at exactly the size and offset resolveMarkerLabels measured them at. Two
- * different constants would mean the collision pass approving a layout the
- * map then draws differently — which is worse than no collision pass, since
- * it would look deliberate.
+ * Label size, re-exported from the full map so the renderer draws names at
+ * exactly the size resolveMarkerLabels measured them at. Two different
+ * constants would mean the collision pass approving a layout the map then
+ * draws differently — which is worse than no collision pass, since it would
+ * look deliberate.
+ *
+ * There is no gap constant here any more, and there must not be one: every
+ * offset a name is drawn at now comes back on its LabelPlacement, so the
+ * renderer has nothing left to re-derive.
  */
-export const NETWORK_MAP_LABEL_GAP: number = LABEL_GAP;
 export const NETWORK_MAP_LABEL_FONT_SIZE: number = LABEL_FONT_SIZE;
 
 /**
@@ -296,9 +298,9 @@ export interface NetworkMapMarker {
   /** Name drawn under the marker, or "" when this marker gets no label. */
   label: string;
   /*
-   * Where that name sits relative to the marker. Below reads best — the eye
-   * goes marker-then-name — so it is tried first; above is the escape hatch
-   * for a marker with a neighbour directly beneath it. Null when the marker
+   * Where that name sits relative to the marker, and how to draw it: the
+   * offset from the marker, the text anchor, and the thread back to the
+   * marker for a name that had to be pushed off it. Null when the marker
    * carries no name at all.
    */
   labelPlacement: LabelPlacement | null;
@@ -365,11 +367,12 @@ export interface BuildNetworkMapMarkersInput {
  * holds its neighbours.
  *
  * Names are then placed greedily in that same order — biggest marker first,
- * since that is the one a reader is most likely to be looking for — trying
- * below the marker and then above it. A name that fits in neither position
- * is DROPPED rather than stacked on something: an overlapped label is
- * unreadable and it hides its neighbour, so two names on top of each other
- * are worse than one name and a tooltip.
+ * since that is the one a reader is most likely to be looking for — spiralling
+ * outwards from the marker until a position is clear of every name already
+ * placed and of every other marker. A name pushed off its marker keeps a
+ * thread back to it; a name with nowhere to go at all is DROPPED rather than
+ * stacked on something, because an overlapped label is unreadable and it
+ * hides its neighbour. See resolveMarkerLabels.
  */
 export const buildNetworkMapMarkers: (
   input: BuildNetworkMapMarkersInput,

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteGeoMap.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteGeoMap.tsx
@@ -34,7 +34,6 @@ import {
   DrawableMapLink,
   MapMarker,
   LABEL_FONT_SIZE,
-  LABEL_GAP,
   LabelPlacement,
   PlacedMapMarker,
   buildMapLinks,
@@ -505,6 +504,16 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
   const hasNudgedMarkers: boolean = placedMarkers.some(
     (marker: PlacedMapMarker): boolean => {
       return marker.needsLeaderLine;
+    },
+  );
+
+  /*
+   * And whether it has to explain the OTHER kind of line: the thread from a
+   * marker to a name that could not fit against it.
+   */
+  const hasThreadedLabels: boolean = Array.from(labelPlacements.values()).some(
+    (placement: LabelPlacement): boolean => {
+      return placement.leaderLine !== null;
     },
   );
 
@@ -1198,6 +1207,15 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
                 );
                 const hasCount: boolean = marker.count > 1;
                 const key: string = marker.key;
+                /*
+                 * Where this marker's name goes — position, anchor and the
+                 * thread back to the marker when the name could not fit
+                 * against it. All of it comes from resolveMarkerLabels:
+                 * re-deriving any of it here would let the map draw a name
+                 * somewhere the collision pass never checked.
+                 */
+                const labelPlacement: LabelPlacement | undefined =
+                  labelPlacements.get(key);
                 const activate: () => void = (): void => {
                   if (marker.ids.length === 1) {
                     setOpenCluster(null);
@@ -1350,43 +1368,97 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
                     )}
 
                     {/*
-                     * The name, under the marker. This is the difference
+                     * The name, by the marker. This is the difference
                      * between a map of your network and a scatter of dots:
                      * "Region 1000" is on the map, where the customer put
                      * it, instead of only in a tooltip.
+                     *
+                     * Position and anchor come straight off the placement —
+                     * offsets are screen units, like everything else that
+                     * must not grow with the map, so they are divided by the
+                     * zoom and added to where the marker is drawn.
                      *
                      * paint-order draws the stroke first, so the halo sits
                      * BEHIND the glyphs and the label stays readable over a
                      * coastline, a landmass or another marker.
                      */}
-                    {marker.label && labelPlacements.has(key) ? (
-                      <text
-                        x={marker.x}
-                        /*
-                         * The label's CENTRE, matching the box
-                         * resolveMarkerLabels reserved for it — dy centres
-                         * the glyphs on it the same way the count inside the
-                         * marker is centred.
-                         */
-                        y={
-                          marker.y +
-                          (labelPlacements.get(key) === "above" ? -1 : 1) *
-                            ((marker.isContainer ? side / 2 : radius) +
-                              LABEL_GAP / zoom)
-                        }
-                        dy="0.36em"
-                        textAnchor="middle"
-                        fontSize={LABEL_FONT_SIZE / zoom}
-                        fontWeight={600}
-                        fill="var(--ou-text-secondary, #374151)"
-                        stroke="var(--ou-surface-primary, #ffffff)"
-                        strokeWidth={3 / zoom}
-                        strokeLinejoin="round"
-                        paintOrder="stroke"
-                        style={{ pointerEvents: "none" }}
-                      >
-                        {marker.label}
-                      </text>
+                    {marker.label && labelPlacement ? (
+                      <>
+                        {/*
+                         * A name that could not fit against its marker keeps
+                         * a thread back to it — the same bargain the marker
+                         * leader lines make with position, and what lets a
+                         * dozen units in one retail park all keep their
+                         * names. Neutral rather than the marker's colour: a
+                         * name is typography, not status, and a second
+                         * coloured thread beside the anchor line would read
+                         * as a second claim about the site.
+                         */}
+                        {labelPlacement.leaderLine ? (
+                          <g aria-hidden="true">
+                            <line
+                              x1={
+                                marker.x + labelPlacement.leaderLine.x1 / zoom
+                              }
+                              y1={
+                                marker.y + labelPlacement.leaderLine.y1 / zoom
+                              }
+                              x2={
+                                marker.x + labelPlacement.leaderLine.x2 / zoom
+                              }
+                              y2={
+                                marker.y + labelPlacement.leaderLine.y2 / zoom
+                              }
+                              stroke="var(--ou-surface-primary, #ffffff)"
+                              strokeWidth={3 / zoom}
+                              strokeOpacity={0.9}
+                              strokeLinecap="round"
+                            />
+                            <line
+                              x1={
+                                marker.x + labelPlacement.leaderLine.x1 / zoom
+                              }
+                              y1={
+                                marker.y + labelPlacement.leaderLine.y1 / zoom
+                              }
+                              x2={
+                                marker.x + labelPlacement.leaderLine.x2 / zoom
+                              }
+                              y2={
+                                marker.y + labelPlacement.leaderLine.y2 / zoom
+                              }
+                              stroke="var(--ou-chart-tick, #6b7280)"
+                              strokeWidth={0.9 / zoom}
+                              strokeOpacity={0.75}
+                              strokeLinecap="round"
+                            />
+                          </g>
+                        ) : (
+                          <></>
+                        )}
+                        <text
+                          x={marker.x + labelPlacement.offsetX / zoom}
+                          /*
+                           * The label's CENTRE, matching the box
+                           * resolveMarkerLabels reserved for it — dy centres
+                           * the glyphs on it the same way the count inside
+                           * the marker is centred.
+                           */
+                          y={marker.y + labelPlacement.offsetY / zoom}
+                          dy="0.36em"
+                          textAnchor={labelPlacement.textAnchor}
+                          fontSize={LABEL_FONT_SIZE / zoom}
+                          fontWeight={600}
+                          fill="var(--ou-text-secondary, #374151)"
+                          stroke="var(--ou-surface-primary, #ffffff)"
+                          strokeWidth={3 / zoom}
+                          strokeLinejoin="round"
+                          paintOrder="stroke"
+                          style={{ pointerEvents: "none" }}
+                        >
+                          {marker.label}
+                        </text>
+                      </>
                     ) : (
                       <></>
                     )}
@@ -1674,6 +1746,48 @@ const SiteGeoMap: FunctionComponent<ComponentProps> = (
               <circle cx="18" cy="4" r="4" fill={CLUSTER_COLORS["none"]} />
             </svg>
             Nudged apart — the line ends at the real spot
+          </span>
+        ) : (
+          <></>
+        )}
+
+        {/*
+         * A line on this map used to mean exactly one thing, and the key
+         * above said so. A name that could not fit against its marker is
+         * now joined to it by a second, thinner kind of line — so once any
+         * are drawn, the key has to stop claiming every line is a nudge.
+         */}
+        {hasThreadedLabels ? (
+          <span
+            data-testid="site-geo-map-label-thread-key"
+            className="flex items-center gap-1.5 text-xs text-gray-600"
+          >
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 24 12"
+              className="h-3 w-6 flex-shrink-0"
+            >
+              <circle cx="4" cy="6" r="3" fill={CLUSTER_COLORS["none"]} />
+              <line
+                x1="7"
+                y1="6"
+                x2="14"
+                y2="6"
+                stroke="var(--ou-chart-tick, #6b7280)"
+                strokeWidth="1"
+                strokeLinecap="round"
+              />
+              <rect
+                x="14"
+                y="3"
+                width="8"
+                height="6"
+                rx="1"
+                fill="var(--ou-chart-tick, #6b7280)"
+                fillOpacity="0.35"
+              />
+            </svg>
+            Name set clear — the line joins it to its marker
           </span>
         ) : (
           <></>

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel.ts
@@ -605,27 +605,53 @@ export const MAX_MARKER_LABEL_CHARS: number = 22;
 export const truncateMarkerLabel: (value: string) => string = (
   value: string,
 ): string => {
-  if (value.length <= MAX_MARKER_LABEL_CHARS) {
-    return value;
+  /*
+   * Trimmed first. A site named entirely of spaces is not a name, and an
+   * untrimmed one is TRUTHY: it would be handed to the placement pass, take
+   * a reserved box away from a marker with a real name, and then draw
+   * nothing in it — a hole in the layout that nothing on screen accounts for.
+   */
+  const name: string = value.trim();
+  if (name.length <= MAX_MARKER_LABEL_CHARS) {
+    return name;
   }
-  return `${value.slice(0, MAX_MARKER_LABEL_CHARS - 1).trimEnd()}…`;
+  return `${name.slice(0, MAX_MARKER_LABEL_CHARS - 1).trimEnd()}…`;
 };
-
 /*
  * Label geometry, in screen units — the same units screenRadius is in.
  * The character width is an approximation of a 600-weight sans glyph at
  * LABEL_FONT_SIZE; it only has to be close enough to decide overlap, and
- * erring slightly wide means the map drops a label rather than printing two
- * on top of each other.
+ * erring slightly wide means the map pushes a name further out rather than
+ * printing two on top of each other.
  */
 export const LABEL_FONT_SIZE: number = 10;
 const LABEL_CHAR_WIDTH: number = 5.6;
 const LABEL_HEIGHT: number = 12;
+
+/*
+ * Above and below, the gap is measured from the marker's edge to the label's
+ * CENTRE: a label is one line of text, positioned by its centre, and half a
+ * line's height is comfortably less than this either way.
+ */
 export const LABEL_GAP: number = 10;
+
+/*
+ * Sideways it is measured to the label's near EDGE instead. A name set
+ * beside its marker starts right there — measuring to the centre would push
+ * a twenty-character box half its own width away from the thing it names.
+ */
+export const LABEL_SIDE_GAP: number = 5;
+
 // Labels this close to each other read as collided even when they do not touch.
 const LABEL_PADDING: number = 2;
 
-interface LabelRect {
+/*
+ * The box a name occupies on screen, padding included. This is the unit the
+ * whole collision pass works in: a name is reserved as one of these, and
+ * everything it has to keep clear of — the other names, the marker bodies —
+ * is compared as one of these too.
+ */
+export interface LabelBounds {
   left: number;
   right: number;
   top: number;
@@ -633,54 +659,262 @@ interface LabelRect {
 }
 
 /*
- * Where a marker's name sits relative to it. Below reads best — the eye
- * goes marker-then-name — so it is always tried first; above is the escape
- * hatch for a marker with a neighbour directly beneath it.
+ * Where a marker's name sits relative to it. Below reads best — the eye goes
+ * marker-then-name — so it is tried first, then above, then the two sides,
+ * then the corners.
+ *
+ * This is a preference order, not a ranking of quality: every one of these
+ * is a perfectly readable place for a name, and having eight to choose from
+ * instead of two is most of what keeps a level's names on the map at all.
  */
-export type LabelPlacement = "below" | "above";
+export type LabelDirection =
+  | "below"
+  | "above"
+  | "right"
+  | "left"
+  | "below-right"
+  | "below-left"
+  | "above-right"
+  | "above-left";
 
-export const LABEL_PLACEMENTS: Array<LabelPlacement> = ["below", "above"];
+export const LABEL_DIRECTIONS: Array<LabelDirection> = [
+  "below",
+  "above",
+  "right",
+  "left",
+  "below-right",
+  "below-left",
+  "above-right",
+  "above-left",
+];
+
+// The compass as a step per axis. Diagonals are normalised where they are used.
+const DIRECTION_STEPS: Record<LabelDirection, { x: number; y: number }> = {
+  below: { x: 0, y: 1 },
+  above: { x: 0, y: -1 },
+  right: { x: 1, y: 0 },
+  left: { x: -1, y: 0 },
+  "below-right": { x: 1, y: 1 },
+  "below-left": { x: -1, y: 1 },
+  "above-right": { x: 1, y: -1 },
+  "above-left": { x: -1, y: -1 },
+};
 
 /*
- * A container is drawn as a square of side CONTAINER_SIDE_FACTOR * r, so its
- * label clears the SIDE rather than the circumscribed circle.
+ * ── Names that cannot fit against their marker ─────────────────────────
+ *
+ * Eight positions around a marker are plenty for a map whose markers are
+ * spread over a country. They are nowhere near enough for a dozen units in
+ * one retail park.
+ *
+ * Those units arrive at near-identical coordinates. The collision layout
+ * fans their MARKERS apart into a disc a few dozen screen units across (see
+ * Geo/MarkerLayout.ts) so none of them is hidden — but a name is a box
+ * roughly seventy screen units wide, and a dozen of those do not fit in the
+ * ring around a disc that small. Every name but the first two used to be
+ * dropped, and zooming in never brought them back: zoom multiplies the
+ * distance between two markers in the WORLD, and between two units on the
+ * same street that distance is zero.
+ *
+ * So a name with nowhere to sit is PUSHED off its marker, a step at a time,
+ * until it finds room — and once it is off, a thin thread is drawn from the
+ * marker to the name so it is still obvious whose name it is. That is the
+ * same bargain the marker layout already makes with position, and it is
+ * what lets a dozen names spread over the space around a pile-up instead of
+ * two of them fitting and ten vanishing.
  */
-const markerLabelRect: (
+export const LABEL_PUSH_STEP: number = 8;
+
+/*
+ * How far a name may be pushed from its marker, in screen units. Past it the
+ * reader is tracing a line across the map rather than reading a label, and
+ * dropping the name is more honest than pretending the thread explains it.
+ *
+ * It is dimensioned against the worst case the map can actually present:
+ * MAX_LABELLED_MARKERS markers, all on one point, all named at the
+ * MAX_MARKER_LABEL_CHARS cap. That seats every name with the furthest of
+ * them sitting just about on this number — a dozen units in one retail park,
+ * which is what this is really for, never gets past a third of it.
+ *
+ * Note this is longer than MAX_MARKER_DISPLACEMENT, which bounds how far a
+ * MARKER may be moved. That is deliberate: a marker carries a position, and
+ * moving one a long way makes the map wrong. A name carries nothing but
+ * itself.
+ */
+export const MAX_LABEL_PUSH: number = 176;
+
+/*
+ * Ceiling on the candidate positions examined per call. Fitting on the first
+ * try is the normal case — a map with room on it never gets past the first
+ * candidate for any marker — and this only bites on a level so crowded that
+ * most of its names are being pushed. Names are resolved again on every zoom
+ * step, and a map that stutters under a wheel is a worse map than one with a
+ * couple of names missing from a crowd.
+ */
+const MAX_LABEL_CANDIDATE_VISITS: number = 120_000;
+
+// Where a label's text is anchored horizontally, as SVG spells it.
+export type LabelTextAnchor = "middle" | "start" | "end";
+
+/*
+ * The thread from a marker to a name that no longer sits against it, in
+ * SCREEN units RELATIVE to the marker's drawn position — so a renderer
+ * divides by the zoom and adds the marker's coordinates, exactly as it does
+ * for every other screen-sized piece of the map.
+ *
+ * It starts on the marker's edge rather than at its centre, so the line does
+ * not print over the marker it belongs to, and ends on the nearest edge of
+ * the label's box rather than at the text, so it does not print over the
+ * name either.
+ */
+export interface LabelLeaderLine {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+/**
+ * Everything a renderer needs to draw one name: nothing here has to be
+ * re-derived, and nothing may be.
+ *
+ * The collision pass reserved a box at an exact size and offset. A renderer
+ * that computed its own offset would be free to draw the name somewhere the
+ * pass never checked — which is worse than having no collision pass at all,
+ * because the overlap would then look deliberate.
+ */
+export interface LabelPlacement {
+  direction: LabelDirection;
+  /*
+   * How far past its attached position the name had to be pushed, in screen
+   * units. Zero for a name sitting against its marker, which is the case
+   * for nearly every name on nearly every map.
+   */
+  push: number;
+  /*
+   * Where the text is anchored, relative to the marker's DRAWN position, in
+   * screen units. Add the marker's coordinates and divide by the zoom.
+   */
+  offsetX: number;
+  offsetY: number;
+  textAnchor: LabelTextAnchor;
+  // Null when the name is against its marker and needs no explaining.
+  leaderLine: LabelLeaderLine | null;
+}
+
+/*
+ * A container is drawn as a square of side CONTAINER_SIDE_FACTOR * r, so
+ * everything that has to keep clear of it — its label, its thread, its
+ * neighbours' labels — clears the SIDE rather than the circumscribed circle.
+ */
+const markerHalfExtent: (marker: MapMarker) => number = (
   marker: MapMarker,
-  zoom: number,
-  placement: LabelPlacement,
-) => LabelRect = (
+): number => {
+  return marker.isContainer
+    ? (marker.screenRadius * CONTAINER_SIDE_FACTOR) / 2
+    : marker.screenRadius;
+};
+
+// The box a name occupies, padding included, in screen units.
+const labelBoxSize: (marker: MapMarker) => { width: number; height: number } = (
   marker: MapMarker,
-  zoom: number,
-  placement: LabelPlacement,
-): LabelRect => {
-  const width: number = Math.max(
-    marker.label.length * LABEL_CHAR_WIDTH,
-    LABEL_CHAR_WIDTH,
-  );
-  const centerX: number = marker.x * zoom;
-  const offset: number =
-    (marker.isContainer
-      ? (marker.screenRadius * CONTAINER_SIDE_FACTOR) / 2
-      : marker.screenRadius) + LABEL_GAP;
-  const centerY: number =
-    marker.y * zoom + (placement === "above" ? -offset : offset);
+): { width: number; height: number } => {
   return {
-    left: centerX - width / 2 - LABEL_PADDING,
-    right: centerX + width / 2 + LABEL_PADDING,
-    top: centerY - LABEL_HEIGHT / 2 - LABEL_PADDING,
-    bottom: centerY + LABEL_HEIGHT / 2 + LABEL_PADDING,
+    width:
+      Math.max(marker.label.length * LABEL_CHAR_WIDTH, LABEL_CHAR_WIDTH) +
+      LABEL_PADDING * 2,
+    height: LABEL_HEIGHT + LABEL_PADDING * 2,
+  };
+};
+
+/*
+ * A zoom that can be divided by and multiplied with. A map that has not been
+ * measured yet reports a zero or a NaN for a frame or two, and a name is
+ * better placed at the wrong magnification than not placed at all.
+ */
+const safeMapZoom: (zoom: number) => number = (zoom: number): number => {
+  return Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
+};
+
+// One position a name could take: the box it would occupy, and how to draw it.
+interface LabelCandidate {
+  direction: LabelDirection;
+  push: number;
+  rect: LabelBounds;
+  offsetX: number;
+  offsetY: number;
+  textAnchor: LabelTextAnchor;
+}
+
+/**
+ * The box a name would occupy in one direction, pushed `push` screen units
+ * further out than its attached position.
+ *
+ * The push is applied along the UNIT vector of the direction, so one step is
+ * the same distance whichever of the eight ways it goes — a corner is not
+ * quietly forty percent further out than a side.
+ */
+const labelCandidateAt: (
+  marker: MapMarker,
+  zoom: number,
+  direction: LabelDirection,
+  push: number,
+) => LabelCandidate = (
+  marker: MapMarker,
+  zoom: number,
+  direction: LabelDirection,
+  push: number,
+): LabelCandidate => {
+  const step: { x: number; y: number } = DIRECTION_STEPS[direction];
+  const length: number = Math.sqrt(step.x * step.x + step.y * step.y);
+  const unitX: number = step.x / length;
+  const unitY: number = step.y / length;
+
+  const half: number = markerHalfExtent(marker);
+  const size: { width: number; height: number } = labelBoxSize(marker);
+  const markerX: number = marker.x * zoom;
+  const markerY: number = marker.y * zoom;
+
+  const centerX: number =
+    markerX + step.x * (half + LABEL_SIDE_GAP + size.width / 2) + unitX * push;
+  const centerY: number = markerY + step.y * (half + LABEL_GAP) + unitY * push;
+
+  /*
+   * The text itself is narrower than its box by the padding either side.
+   * A name beside its marker is anchored on the edge nearest the marker, so
+   * it reads outwards from the thing it names.
+   */
+  const textWidth: number = size.width - LABEL_PADDING * 2;
+  const textAnchor: LabelTextAnchor =
+    step.x === 0 ? "middle" : step.x > 0 ? "start" : "end";
+  const textX: number =
+    step.x === 0
+      ? centerX
+      : step.x > 0
+        ? centerX - textWidth / 2
+        : centerX + textWidth / 2;
+
+  return {
+    direction: direction,
+    push: push,
+    rect: {
+      left: centerX - size.width / 2,
+      right: centerX + size.width / 2,
+      top: centerY - size.height / 2,
+      bottom: centerY + size.height / 2,
+    },
+    offsetX: textX - markerX,
+    offsetY: centerY - markerY,
+    textAnchor: textAnchor,
   };
 };
 
 // The marker's own body, in the same screen units as its label rect.
-const markerBodyRect: (marker: MapMarker, zoom: number) => LabelRect = (
+const markerBodyRect: (marker: MapMarker, zoom: number) => LabelBounds = (
   marker: MapMarker,
   zoom: number,
-): LabelRect => {
-  const half: number = marker.isContainer
-    ? (marker.screenRadius * CONTAINER_SIDE_FACTOR) / 2
-    : marker.screenRadius;
+): LabelBounds => {
+  const half: number = markerHalfExtent(marker);
   const centerX: number = marker.x * zoom;
   const centerY: number = marker.y * zoom;
   return {
@@ -691,9 +925,9 @@ const markerBodyRect: (marker: MapMarker, zoom: number) => LabelRect = (
   };
 };
 
-const rectsOverlap: (a: LabelRect, b: LabelRect) => boolean = (
-  a: LabelRect,
-  b: LabelRect,
+const rectsOverlap: (a: LabelBounds, b: LabelBounds) => boolean = (
+  a: LabelBounds,
+  b: LabelBounds,
 ): boolean => {
   return !(
     a.right <= b.left ||
@@ -704,25 +938,148 @@ const rectsOverlap: (a: LabelRect, b: LabelRect) => boolean = (
 };
 
 /**
- * Where each marker draws its name at this zoom — and which markers do not
- * get to draw one at all.
+ * The thread from a marker to a pushed name, or null when the name is still
+ * sitting against its marker and nothing needs explaining.
+ *
+ * Relative to the marker's drawn position, in screen units.
+ */
+const leaderLineFor: (
+  marker: MapMarker,
+  zoom: number,
+  candidate: LabelCandidate,
+) => LabelLeaderLine | null = (
+  marker: MapMarker,
+  zoom: number,
+  candidate: LabelCandidate,
+): LabelLeaderLine | null => {
+  if (candidate.push <= 0) {
+    return null;
+  }
+
+  const markerX: number = marker.x * zoom;
+  const markerY: number = marker.y * zoom;
+  /*
+   * The point on the label's box closest to the marker — which for a name
+   * directly below is the middle of its top edge, and for a name off to one
+   * side is the middle of its near edge. Aiming at the box rather than at
+   * the text keeps the thread from ending inside the glyphs.
+   */
+  const nearX: number = Math.min(
+    Math.max(markerX, candidate.rect.left),
+    candidate.rect.right,
+  );
+  const nearY: number = Math.min(
+    Math.max(markerY, candidate.rect.top),
+    candidate.rect.bottom,
+  );
+
+  const deltaX: number = nearX - markerX;
+  const deltaY: number = nearY - markerY;
+  const distance: number = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+  const half: number = markerHalfExtent(marker);
+  // Nothing to draw if the box reaches the marker's edge on its own.
+  if (distance <= half) {
+    return null;
+  }
+
+  return {
+    x1: (deltaX / distance) * half,
+    y1: (deltaY / distance) * half,
+    x2: deltaX,
+    y2: deltaY,
+  };
+};
+
+/**
+ * Whether a line segment passes through a box.
+ *
+ * Liang–Barsky, which answers this without allocating and without a special
+ * case for a vertical or horizontal segment — and both are the common case
+ * here, since a name pushed straight down has a perfectly vertical thread.
+ * Touching an edge does not count as crossing it: a thread that ends exactly
+ * on a neighbouring box's edge is not passing through it.
+ */
+const segmentCrossesRect: (
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  rect: LabelBounds,
+) => boolean = (
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  rect: LabelBounds,
+): boolean => {
+  const deltaX: number = x2 - x1;
+  const deltaY: number = y2 - y1;
+  const edges: Array<number> = [-deltaX, deltaX, -deltaY, deltaY];
+  const distances: Array<number> = [
+    x1 - rect.left,
+    rect.right - x1,
+    y1 - rect.top,
+    rect.bottom - y1,
+  ];
+
+  let enter: number = 0;
+  let exit: number = 1;
+
+  for (let index: number = 0; index < 4; index++) {
+    const edge: number = edges[index]!;
+    const distance: number = distances[index]!;
+    if (edge === 0) {
+      // Parallel to this edge: outside it means the segment misses entirely.
+      if (distance < 0) {
+        return false;
+      }
+      continue;
+    }
+    const crossing: number = distance / edge;
+    if (edge < 0) {
+      if (crossing > exit) {
+        return false;
+      }
+      if (crossing > enter) {
+        enter = crossing;
+      }
+    } else {
+      if (crossing < enter) {
+        return false;
+      }
+      if (crossing < exit) {
+        exit = crossing;
+      }
+    }
+  }
+
+  return enter < exit;
+};
+
+/**
+ * Where each marker draws its name at this zoom — and which markers, if any,
+ * do not get to draw one at all.
  *
  * Three regions whose centroids fall in the same corner of a state print
  * their names on top of each other, which is worse than printing none of
  * them: an overlapped label is unreadable AND it hides its neighbour. So
  * names are placed greedily in paint order — biggest marker first, since
- * that is the one a reader is most likely to be looking for — trying below
- * the marker and then above it, and a name that fits in neither position is
- * dropped rather than stacked on something.
+ * that is the one a reader is most likely to be looking for — and each one
+ * takes the first position that is clear of every name already placed and
+ * of every other marker's body. A name half-covered by the neighbouring
+ * region's disc reads as a rendering bug, not as a dense map.
  *
- * A label must clear the other MARKERS too, not just the other labels: a
- * name half-covered by the neighbouring region's disc reads as a rendering
- * bug, not as a dense map.
+ * "The first position" is a spiral outwards: the eight places around the
+ * marker itself, then the same eight a step further out, and so on up to
+ * MAX_LABEL_PUSH — see the note above LABEL_PUSH_STEP for why a name has to
+ * be allowed to leave its marker at all. A name that has been pushed keeps a
+ * thread back, and the search prefers a position whose thread crosses
+ * nothing to one that fits but has to cross a name already on the map.
  *
  * Zoom is the only thing this depends on, not the pan: markers keep their
- * relative distances as the frame moves, so a drag never re-decides which
- * names are on the map. Zooming in genuinely separates them and the dropped
- * names come back.
+ * relative distances as the frame moves, so a drag never re-decides where a
+ * name goes. Zooming in genuinely separates markers that are apart in the
+ * world, and their names walk back in towards them.
  */
 export const resolveMarkerLabels: (
   markers: Array<MapMarker>,
@@ -731,21 +1088,35 @@ export const resolveMarkerLabels: (
   markers: Array<MapMarker>,
   zoom: number,
 ): Map<string, LabelPlacement> => {
-  const safeZoom: number = Number.isFinite(zoom) && zoom > 0 ? zoom : 1;
+  const safeZoom: number = safeMapZoom(zoom);
   const resolved: Map<string, LabelPlacement> = new Map<
     string,
     LabelPlacement
   >();
-  const placed: Array<LabelRect> = [];
+  const placed: Array<LabelBounds> = [];
 
-  const bodies: Array<LabelRect> = markers.map(
-    (marker: MapMarker): LabelRect => {
-      return markerBodyRect(marker, safeZoom);
+  /*
+   * A marker with coordinates that are not finite is drawn nowhere, so it has
+   * no body to keep clear of and no place to hang a name. Its entry is null
+   * rather than a rectangle of NaNs, because every comparison against a NaN
+   * is false and rectsOverlap would therefore report it as overlapping EVERY
+   * candidate — costing every other marker on the level its name.
+   *
+   * Geo/MarkerLayout.ts passes the same markers straight through for the
+   * same reason: this is not the place that decides whether they are drawn.
+   */
+  const bodies: Array<LabelBounds | null> = markers.map(
+    (marker: MapMarker): LabelBounds | null => {
+      return Number.isFinite(marker.x) && Number.isFinite(marker.y)
+        ? markerBodyRect(marker, safeZoom)
+        : null;
     },
   );
 
-  const fits: (rect: LabelRect, index: number) => boolean = (
-    rect: LabelRect,
+  let visits: number = 0;
+
+  const fits: (rect: LabelBounds, index: number) => boolean = (
+    rect: LabelBounds,
     index: number,
   ): boolean => {
     for (const other of placed) {
@@ -754,33 +1125,165 @@ export const resolveMarkerLabels: (
       }
     }
     for (let other: number = 0; other < bodies.length; other++) {
+      const body: LabelBounds | null = bodies[other]!;
       /*
        * Its own body never counts: the label is deliberately placed hard
        * against it, and a generous glyph-width estimate can graze it.
        */
-      if (other !== index && rectsOverlap(rect, bodies[other]!)) {
+      if (other !== index && body && rectsOverlap(rect, body)) {
         return false;
       }
     }
     return true;
   };
 
-  for (let index: number = 0; index < markers.length; index++) {
-    const marker: MapMarker = markers[index]!;
-    if (!marker.label) {
-      continue;
-    }
-    for (const placement of LABEL_PLACEMENTS) {
-      const rect: LabelRect = markerLabelRect(marker, safeZoom, placement);
-      if (fits(rect, index)) {
-        placed.push(rect);
-        resolved.set(marker.key, placement);
-        break;
+  /*
+   * A thread that runs through a name, or through another marker, is worse
+   * than no thread: it points at the wrong thing. Nothing is dropped over
+   * it — a crossed thread still beats a missing name — but a position that
+   * avoids it wins over one that does not.
+   */
+  const threadIsClear: (
+    marker: MapMarker,
+    leader: LabelLeaderLine,
+    index: number,
+  ) => boolean = (
+    marker: MapMarker,
+    leader: LabelLeaderLine,
+    index: number,
+  ): boolean => {
+    const fromX: number = marker.x * safeZoom + leader.x1;
+    const fromY: number = marker.y * safeZoom + leader.y1;
+    const toX: number = marker.x * safeZoom + leader.x2;
+    const toY: number = marker.y * safeZoom + leader.y2;
+    for (const other of placed) {
+      if (segmentCrossesRect(fromX, fromY, toX, toY, other)) {
+        return false;
       }
     }
+    for (let other: number = 0; other < bodies.length; other++) {
+      const body: LabelBounds | null = bodies[other]!;
+      if (
+        other !== index &&
+        body &&
+        segmentCrossesRect(fromX, fromY, toX, toY, body)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  /*
+   * The spiral, walked outwards. The first position that fits AND whose
+   * thread crosses nothing wins outright; the first that merely fits is
+   * kept as the fallback, so a name is only ever dropped when the whole
+   * spiral had nowhere to put it.
+   */
+  const chooseCandidate: (
+    marker: MapMarker,
+    index: number,
+  ) => LabelCandidate | null = (
+    marker: MapMarker,
+    index: number,
+  ): LabelCandidate | null => {
+    let fallback: LabelCandidate | null = null;
+
+    for (
+      let push: number = 0;
+      push <= MAX_LABEL_PUSH;
+      push += LABEL_PUSH_STEP
+    ) {
+      /*
+       * Out of budget: the eight positions AGAINST the marker are still
+       * tried — they are eight comparisons, and they are the ones that fit
+       * on an ordinary map — but the spiral stops here. Degrading to "a name
+       * with room around it keeps it" beats a cliff where every remaining
+       * marker on the level goes nameless at once.
+       */
+      if (push > 0 && visits >= MAX_LABEL_CANDIDATE_VISITS) {
+        return fallback;
+      }
+
+      for (const direction of LABEL_DIRECTIONS) {
+        visits++;
+
+        const candidate: LabelCandidate = labelCandidateAt(
+          marker,
+          safeZoom,
+          direction,
+          push,
+        );
+        if (!fits(candidate.rect, index)) {
+          continue;
+        }
+
+        const leader: LabelLeaderLine | null = leaderLineFor(
+          marker,
+          safeZoom,
+          candidate,
+        );
+        if (!leader || threadIsClear(marker, leader, index)) {
+          return candidate;
+        }
+        if (!fallback) {
+          fallback = candidate;
+        }
+      }
+    }
+
+    return fallback;
+  };
+
+  for (let index: number = 0; index < markers.length; index++) {
+    const marker: MapMarker = markers[index]!;
+    // No name to draw, or nowhere on the map to draw it (see `bodies`).
+    if (!marker.label || !bodies[index]) {
+      continue;
+    }
+
+    const candidate: LabelCandidate | null = chooseCandidate(marker, index);
+    if (!candidate) {
+      continue;
+    }
+
+    placed.push(candidate.rect);
+    resolved.set(marker.key, {
+      direction: candidate.direction,
+      push: candidate.push,
+      offsetX: candidate.offsetX,
+      offsetY: candidate.offsetY,
+      textAnchor: candidate.textAnchor,
+      leaderLine: leaderLineFor(marker, safeZoom, candidate),
+    });
   }
 
   return resolved;
+};
+
+/**
+ * The box resolveMarkerLabels reserved for this name, in screen units.
+ *
+ * The pass guarantees these do not overlap each other or any marker's body;
+ * that guarantee is only worth anything while everything that cares about a
+ * name's footprint asks the same function for it, rather than rebuilding the
+ * geometry from the offsets and a guess at the glyph width.
+ */
+export const labelBounds: (
+  marker: MapMarker,
+  zoom: number,
+  placement: LabelPlacement,
+) => LabelBounds = (
+  marker: MapMarker,
+  zoom: number,
+  placement: LabelPlacement,
+): LabelBounds => {
+  return labelCandidateAt(
+    marker,
+    safeMapZoom(zoom),
+    placement.direction,
+    placement.push,
+  ).rect;
 };
 
 // One drawable marker. Positions are viewBox units; radius is screen units.

--- a/App/Tests/Dashboard/NetworkMapWidgetData.test.ts
+++ b/App/Tests/Dashboard/NetworkMapWidgetData.test.ts
@@ -33,7 +33,11 @@ import {
   ROBINSON_VIEW_BOX_WIDTH,
   projectRobinson,
 } from "../../FeatureSet/Dashboard/src/Components/NetworkSite/Geo/GeoProjection";
-import { MAX_LABELLED_MARKERS } from "../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel";
+import {
+  LabelBounds,
+  MAX_LABELLED_MARKERS,
+  labelBounds,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel";
 
 /*
  * The react-free half of the Network Map dashboard widget: narrowing
@@ -452,21 +456,21 @@ describe("buildNetworkMapMarkers", () => {
 
     expect(only.label).toBe("Camden Store");
     // Below reads best — the eye goes marker, then name.
-    expect(only.labelPlacement).toBe("below");
+    expect(only.labelPlacement?.direction).toBe("below");
+    // Nothing to move out of the way of, so nothing is moved.
+    expect(only.labelPlacement?.push).toBe(0);
+    expect(only.labelPlacement?.leaderLine).toBeNull();
   });
 
   /*
-   * Two names printed on top of each other are worse than one name: the
-   * overlapped label is unreadable AND it hides its neighbour. So a name
-   * that fits in neither position is dropped, and the tooltip carries it.
+   * Eight sites crowded into one small city: far enough apart at this cell
+   * size to stay separate markers, and far too close for eight names to sit
+   * side by side under them. Every one of them keeps its name — the ones
+   * that cannot fit against their marker are pushed off it and threaded
+   * back rather than dropped.
    */
-  test("drops a name it cannot place clear of its neighbours", () => {
-    /*
-     * Eight sites in one small city with long names: they are far enough
-     * apart at this cell size to stay separate markers, and far too close
-     * for eight labels to sit side by side.
-     */
-    const crowded: Array<NetworkMapSite> = Array.from(
+  function crowdedCity(): Array<NetworkMapSite> {
+    return Array.from(
       { length: 8 },
       (_unused: unknown, index: number): NetworkMapSite => {
         return site({
@@ -477,65 +481,103 @@ describe("buildNetworkMapMarkers", () => {
         });
       },
     );
+  }
 
-    const result: Array<NetworkMapMarker> = markers(crowded, true, 0.5);
-    const labelled: Array<NetworkMapMarker> = result.filter(
-      (marker: NetworkMapMarker): boolean => {
-        return marker.label !== "";
-      },
-    );
+  test("keeps every name on a crowded map by pushing the ones that do not fit", () => {
+    const result: Array<NetworkMapMarker> = markers(crowdedCity(), true, 0.5);
 
     expect(result.length).toBe(8);
-    expect(labelled.length).toBeLessThan(result.length);
-
-    // Whatever survived carries a placement; whatever did not carries none.
     for (const marker of result) {
-      if (marker.label) {
-        expect(marker.labelPlacement).not.toBeNull();
-      } else {
-        expect(marker.labelPlacement).toBeNull();
-      }
+      expect(marker.label).not.toBe("");
+      expect(marker.labelPlacement).not.toBeNull();
+    }
+
+    // Some of these cannot possibly have fitted where they wanted to.
+    const pushed: Array<NetworkMapMarker> = result.filter(
+      (marker: NetworkMapMarker): boolean => {
+        return (marker.labelPlacement?.push ?? 0) > 0;
+      },
+    );
+    expect(pushed.length).toBeGreaterThan(0);
+    // And exactly those carry the thread that explains where they belong.
+    for (const marker of result) {
+      expect(marker.labelPlacement?.leaderLine === null).toBe(
+        marker.labelPlacement?.push === 0,
+      );
     }
   });
 
   /*
-   * Zoom genuinely separates markers, so a name that could not be placed on
-   * the world view comes back once the frame tightens around the same
-   * sites. This is the property that makes dropping labels acceptable
-   * rather than lossy.
+   * Zoom genuinely separates markers that are apart in the world, so the
+   * names walk back in against them and the threads go away. This is what
+   * keeps a busy frame from being a permanent scattering of labels.
    */
-  test("places more names as the frame zooms in on the same sites", () => {
-    /*
-     * Short names on purpose: the point under test is that ZOOM recovers
-     * labels, and a name wide enough to never fit at any realistic zoom
-     * would hold the count flat and prove nothing.
-     */
-    const crowded: Array<NetworkMapSite> = Array.from(
-      { length: 8 },
-      (_unused: unknown, index: number): NetworkMapSite => {
-        return site({
-          id: `site-${index}`,
-          name: `S${index}`,
-          latitude: 51.5 + index * 0.35,
-          longitude: -0.12 + index * 0.35,
-        });
-      },
-    );
+  test("names settle back against their markers as the frame zooms in", () => {
+    const crowded: Array<NetworkMapSite> = crowdedCity();
 
-    const countLabels: (zoom: number) => number = (zoom: number): number => {
+    const countPushed: (zoom: number) => number = (zoom: number): number => {
       return markers(crowded, true, 0.5, zoom).filter(
         (marker: NetworkMapMarker): boolean => {
-          return marker.label !== "";
+          return (marker.labelPlacement?.push ?? 0) > 0;
         },
       ).length;
     };
 
     /*
      * These eight sit on a diagonal about 15 screen units apart at zoom 12,
-     * which a 15-unit-wide label box still collides with — so the check
-     * uses a frame tight enough to actually separate them. MAX_ZOOM is 64.
+     * which a long label box still collides with — so the check uses a frame
+     * tight enough to actually separate them. MAX_ZOOM is 64.
      */
-    expect(countLabels(40)).toBeGreaterThan(countLabels(1));
+    expect(countPushed(1)).toBeGreaterThan(0);
+    expect(countPushed(40)).toBe(0);
+  });
+
+  /*
+   * A name is never printed on top of another one, however crowded the
+   * frame: an overlapped label is unreadable AND it hides its neighbour.
+   */
+  test("no two names the widget draws overlap", () => {
+    const result: Array<NetworkMapMarker> = markers(crowdedCity(), true, 0.5);
+
+    const boxes: Array<LabelBounds> = [];
+    for (const marker of result) {
+      if (!marker.labelPlacement) {
+        continue;
+      }
+      boxes.push(
+        labelBounds(
+          {
+            key: marker.key,
+            x: marker.x,
+            y: marker.y,
+            ids: marker.ids,
+            count: marker.count,
+            screenRadius: marker.screenRadius,
+            colorKey: marker.colorKey,
+            isContainer: false,
+            isApproximate: false,
+            label: marker.label,
+            tooltip: marker.tooltip,
+          },
+          1,
+          marker.labelPlacement,
+        ),
+      );
+    }
+
+    expect(boxes.length).toBe(8);
+    for (let a: number = 0; a < boxes.length; a++) {
+      for (let b: number = a + 1; b < boxes.length; b++) {
+        const first: LabelBounds = boxes[a]!;
+        const second: LabelBounds = boxes[b]!;
+        expect(
+          first.right <= second.left ||
+            first.left >= second.right ||
+            first.bottom <= second.top ||
+            first.top >= second.bottom,
+        ).toBe(true);
+      }
+    }
   });
 
   test("gives a cluster no label, since it stands for more than one name", () => {

--- a/App/Tests/Dashboard/NetworkMapWidgetInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkMapWidgetInvariants.test.ts
@@ -386,6 +386,47 @@ describe("Network Map widget rendering", () => {
   });
 
   /*
+   * The collision pass reserves a box for each name at an exact offset and
+   * hands it back on the placement. A renderer that re-derived that offset
+   * would be free to paint the name somewhere the pass never checked, and
+   * the overlap it produced would look deliberate. So the widget draws at
+   * marker + offset / zoom, and it no longer carries a gap constant of its
+   * own to drift from the one the pass measured with.
+   */
+  test("names are drawn at the offset the collision pass reserved", () => {
+    const widget: string = readApp(...WIDGET);
+
+    expect(widget).toContain(
+      squash("x={marker.x + marker.labelPlacement.offsetX / zoom}"),
+    );
+    expect(widget).toContain(
+      squash("y={marker.y + marker.labelPlacement.offsetY / zoom}"),
+    );
+    expect(widget).toContain(
+      squash("textAnchor={marker.labelPlacement.textAnchor}"),
+    );
+    expect(readAppCode(...WIDGET)).not.toContain("LABEL_GAP");
+  });
+
+  /*
+   * Sites on near-identical coordinates used to lose every name but the
+   * first: there was nowhere to put the others that was clear of the
+   * neighbours. They are now pushed off their marker instead, which is only
+   * honest while each one keeps a thread back to the marker it names.
+   */
+  test("a name pushed off its marker keeps a thread back to it", () => {
+    const widget: string = readApp(...WIDGET);
+
+    expect(widget).toContain(squash("{marker.labelPlacement.leaderLine ? ("));
+    expect(widget).toContain(
+      squash("x1={ marker.x + marker.labelPlacement.leaderLine.x1 / zoom }"),
+    );
+    expect(widget).toContain(
+      squash("y2={ marker.y + marker.labelPlacement.leaderLine.y2 / zoom }"),
+    );
+  });
+
+  /*
    * The outlines are the backdrop; the markers are the subject. A failed
    * geometry fetch must cost the reader a coastline, not the whole widget.
    */

--- a/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
@@ -896,6 +896,59 @@ describe("SiteGeoMap", () => {
   });
 
   /*
+   * The collision pass reserves a box at an exact offset and hands it back
+   * on the placement. A renderer that computed its own offset instead would
+   * be free to draw the name somewhere that pass never checked — which is
+   * worse than having no collision pass at all, because the overlap would
+   * then look deliberate. So the map must draw at marker + offset / zoom and
+   * nowhere else, and there must be no second copy of the gap constant here
+   * to drift away from the one the pass measured with.
+   */
+  test("names are drawn at the offset the collision pass reserved", () => {
+    expect(source).toContain(
+      squash("x={marker.x + labelPlacement.offsetX / zoom}"),
+    );
+    expect(source).toContain(
+      squash("y={marker.y + labelPlacement.offsetY / zoom}"),
+    );
+    expect(source).toContain(squash("textAnchor={labelPlacement.textAnchor}"));
+    // No re-derived geometry: the gap constant is not even imported.
+    expect(
+      readCode("Components", "NetworkSite", "SiteGeoMap.tsx"),
+    ).not.toContain("LABEL_GAP");
+  });
+
+  /*
+   * A name moved off its marker without saying so is the same lie a
+   * displaced marker would be. The thread is the whole licence for pushing
+   * it — and a name still sitting against its marker must not get one,
+   * because a thread nobody can see is ink for nothing.
+   */
+  test("a pushed name keeps a thread back to its marker", () => {
+    expect(source).toContain(squash("{labelPlacement.leaderLine ? ("));
+    expect(source).toContain(
+      squash("x1={ marker.x + labelPlacement.leaderLine.x1 / zoom }"),
+    );
+    expect(source).toContain(
+      squash("y2={ marker.y + labelPlacement.leaderLine.y2 / zoom }"),
+    );
+  });
+
+  /*
+   * The key used to say every line on this map was a nudged marker, because
+   * every line was. There are two kinds now, so a frame drawing the second
+   * one has to say what it is — and a frame drawing none must not.
+   */
+  test("the label threads get their own key, and only when there are some", () => {
+    expect(source).toContain(
+      squash("const hasThreadedLabels: boolean = Array.from("),
+    );
+    expect(source).toContain(squash("return placement.leaderLine !== null;"));
+    expect(source).toContain(squash("{hasThreadedLabels ? ("));
+    expect(source).toContain('data-testid="site-geo-map-label-thread-key"');
+  });
+
+  /*
    * A marker moved off its coordinates without saying so is a map that
    * lies. The line back to the anchor is the whole reason the displacement
    * is allowed at all.

--- a/App/Tests/Dashboard/SiteMapViewModel.test.ts
+++ b/App/Tests/Dashboard/SiteMapViewModel.test.ts
@@ -22,8 +22,14 @@ import {
   MAX_MARKER_LABEL_CHARS,
   MIN_CLUSTER_RADIUS,
   FingerprintableSite,
+  LABEL_DIRECTIONS,
+  LABEL_PUSH_STEP,
+  LabelBounds,
+  LabelDirection,
   LabelPlacement,
+  MAX_LABEL_PUSH,
   MapMarker,
+  labelBounds,
   PinnableSite,
   PlacedMapMarker,
   buildMapMarkers,
@@ -1301,14 +1307,65 @@ describe("truncateMarkerLabel", () => {
   test("handles an empty name", () => {
     expect(truncateMarkerLabel("")).toBe("");
   });
+
+  /*
+   * A name of nothing but spaces is not a name — but it is TRUTHY, so an
+   * untrimmed one sails past every "does this marker have a label" guard,
+   * takes a reserved box away from a marker with a real name, and draws
+   * nothing in it.
+   */
+  test("a name of nothing but whitespace is no name at all", () => {
+    expect(truncateMarkerLabel("   ")).toBe("");
+    expect(truncateMarkerLabel("\t\n ")).toBe("");
+  });
+
+  test("surrounding whitespace does not count towards the length", () => {
+    expect(truncateMarkerLabel("  Camden Store  ")).toBe("Camden Store");
+  });
+});
+
+/*
+ * A blank-named site used to steal the slot under its neighbour's marker.
+ */
+describe("a site with a blank name takes no label slot", () => {
+  test("its neighbour keeps the position it wanted", () => {
+    const markers: Array<MapMarker> = buildMapMarkers({
+      sites: [
+        mapSite({ id: "blank", name: "   ", latitude: 51.5, longitude: -0.12 }),
+        mapSite({
+          id: "named",
+          name: "Camden Store",
+          latitude: 51.5,
+          longitude: -0.12,
+        }),
+      ],
+      mode: "grouped",
+      cellSize: 0,
+    });
+
+    const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+      markers,
+      1,
+    );
+
+    expect(placements.has("blank")).toBe(false);
+    expect(placements.get("named")?.direction).toBe("below");
+    expect(placements.get("named")?.push).toBe(0);
+  });
 });
 
 /*
  * Names on the map are the whole point of the grouped view — "Region 1000"
- * belongs where the customer put it, not only in a tooltip. But three
- * regions whose centroids land in one corner of a state would print their
- * names on top of each other, which hides two of them AND makes the third
- * unreadable.
+ * belongs where the customer put it, not only in a tooltip. But three regions
+ * whose centroids land in one corner of a state would print their names on
+ * top of each other, which hides two of them AND makes the third unreadable.
+ *
+ * The hard case is a level of UNITS: a dozen of them in one retail park
+ * arrive at near-identical coordinates, the marker layout fans the markers
+ * apart but the names are boxes seventy screen units wide, and zooming in
+ * never separates them because there is no distance between them to magnify.
+ * Two positions per marker left ten of those twelve nameless; the spiral
+ * below is what fixed it, and most of this suite is about keeping it fixed.
  */
 describe("resolveMarkerLabels", () => {
   function markerAt(
@@ -1333,13 +1390,67 @@ describe("resolveMarkerLabels", () => {
     };
   }
 
+  // The boxes that were actually reserved, in the order they were placed.
+  function boxesOf(
+    markers: Array<MapMarker>,
+    placements: Map<string, LabelPlacement>,
+    zoom: number,
+  ): Array<LabelBounds> {
+    const boxes: Array<LabelBounds> = [];
+    for (const marker of markers) {
+      const placement: LabelPlacement | undefined = placements.get(marker.key);
+      if (placement) {
+        boxes.push(labelBounds(marker, zoom, placement));
+      }
+    }
+    return boxes;
+  }
+
+  function overlaps(a: LabelBounds, b: LabelBounds): boolean {
+    return !(
+      a.right <= b.left ||
+      a.left >= b.right ||
+      a.bottom <= b.top ||
+      a.top >= b.bottom
+    );
+  }
+
+  function bodyOf(marker: MapMarker, zoom: number): LabelBounds {
+    const half: number = marker.isContainer
+      ? (marker.screenRadius * CONTAINER_SIDE_FACTOR) / 2
+      : marker.screenRadius;
+    return {
+      left: marker.x * zoom - half,
+      right: marker.x * zoom + half,
+      top: marker.y * zoom - half,
+      bottom: marker.y * zoom + half,
+    };
+  }
+
   test("well-separated markers all keep their names, below them", () => {
     const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
       [markerAt("A", 100, 100), markerAt("B", 300, 300)],
       1,
     );
-    expect(placements.get("A")).toBe("below");
-    expect(placements.get("B")).toBe("below");
+    expect(placements.get("A")?.direction).toBe("below");
+    expect(placements.get("B")?.direction).toBe("below");
+  });
+
+  /*
+   * A name with room around it must not be nudged even slightly: the map
+   * would redraw every label a hair off where the marker is on a map with
+   * nothing colliding on it.
+   */
+  test("a name with room around it is not pushed at all", () => {
+    const placement: LabelPlacement = resolveMarkerLabels(
+      [markerAt("A", 100, 100)],
+      1,
+    ).get("A") as LabelPlacement;
+
+    expect(placement.push).toBe(0);
+    expect(placement.offsetX).toBe(0);
+    expect(placement.textAnchor).toBe("middle");
+    expect(placement.leaderLine).toBeNull();
   });
 
   test("a marker with no label is never placed", () => {
@@ -1351,8 +1462,9 @@ describe("resolveMarkerLabels", () => {
   });
 
   /*
-   * Below is tried first because the eye reads marker-then-name; above is
-   * the escape hatch, so a name is only lost when neither position is free.
+   * Below is tried first because the eye reads marker-then-name; above is the
+   * first escape hatch, so a name only leaves the vertical axis when both
+   * ends of it are taken.
    */
   test("a label blocked from below flips above rather than disappearing", () => {
     const blocker: MapMarker = markerAt("blocker", 100, 118, { label: "" });
@@ -1360,52 +1472,89 @@ describe("resolveMarkerLabels", () => {
       [markerAt("A", 100, 100), blocker],
       1,
     );
-    expect(placements.get("A")).toBe("above");
+    expect(placements.get("A")?.direction).toBe("above");
   });
 
-  test("a label with nowhere to go is dropped, not stacked", () => {
-    const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+  /*
+   * The old behaviour: boxed in above and below, the name was DROPPED. That
+   * is the defect from the Units view in miniature — there was plenty of room
+   * either side and nothing looked there.
+   */
+  test("a label boxed in above and below goes sideways instead of vanishing", () => {
+    const placement: LabelPlacement = resolveMarkerLabels(
       [
         markerAt("A", 100, 100),
         markerAt("above", 100, 82, { label: "" }),
         markerAt("below", 100, 118, { label: "" }),
       ],
       1,
-    );
-    expect(placements.has("A")).toBe(false);
+    ).get("A") as LabelPlacement;
+
+    expect(placement.direction).toBe("right");
+    // Beside its marker, so it reads outwards from it.
+    expect(placement.textAnchor).toBe("start");
+    expect(placement.offsetX).toBeGreaterThan(0);
+    expect(placement.offsetY).toBe(0);
+    // Still against the marker, so nothing has to be explained.
+    expect(placement.push).toBe(0);
+    expect(placement.leaderLine).toBeNull();
+  });
+
+  test("a label boxed in on three sides takes the fourth", () => {
+    const placement: LabelPlacement = resolveMarkerLabels(
+      [
+        markerAt("A", 100, 100),
+        markerAt("above", 100, 82, { label: "" }),
+        markerAt("below", 100, 118, { label: "" }),
+        markerAt("right", 116, 100, { label: "" }),
+      ],
+      1,
+    ).get("A") as LabelPlacement;
+
+    expect(placement.direction).toBe("left");
+    expect(placement.textAnchor).toBe("end");
+    expect(placement.offsetX).toBeLessThan(0);
   });
 
   /*
-   * Paint order is biggest-first, so the region a reader is most likely to
-   * be looking for is the one that keeps its name.
+   * Paint order is biggest-first, so the region a reader is most likely to be
+   * looking for is the one that keeps the position closest to its marker.
    */
   test("when two names collide the first in paint order keeps the better spot", () => {
-    /*
-     * Far enough apart that neither marker BODY blocks a label — the
-     * collision under test is name-against-name. The bigger marker comes
-     * first in paint order and keeps the preferred position below it; its
-     * neighbour is pushed above rather than dropped.
-     */
     const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
       [markerAt("Big", 100, 100), markerAt("Small", 118, 100)],
       1,
     );
-    expect(placements.get("Big")).toBe("below");
-    expect(placements.get("Small")).toBe("above");
+    expect(placements.get("Big")?.direction).toBe("below");
+    expect(placements.get("Small")?.direction).toBe("above");
+  });
+
+  test("an empty marker list resolves to no labels", () => {
+    expect(resolveMarkerLabels([], 1).size).toBe(0);
   });
 
   /*
-   * Zooming in genuinely separates markers, so names dropped at a wide
-   * frame come back — that is what makes dropping them acceptable.
+   * A marker with corrupt coordinates is drawn nowhere, so it has no body to
+   * keep clear of and no place to hang a name. Treating it as a rectangle of
+   * NaNs would be catastrophic rather than merely wrong: every comparison
+   * against a NaN is false, so it would read as overlapping EVERY candidate
+   * and cost every other marker on the level its name.
    */
-  test("zooming in brings dropped names back", () => {
-    const markers: Array<MapMarker> = [
-      markerAt("A", 100, 100),
-      markerAt("above", 100, 84, { label: "" }),
-      markerAt("below", 100, 116, { label: "" }),
-    ];
-    expect(resolveMarkerLabels(markers, 1).size).toBe(0);
-    expect(resolveMarkerLabels(markers, 12).size).toBe(1);
+  test("a marker with corrupt coordinates costs nobody else their name", () => {
+    const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+      [
+        markerAt("broken", Number.NaN, 100),
+        markerAt("alsoBroken", 100, Number.POSITIVE_INFINITY),
+        markerAt("A", 100, 100),
+        markerAt("B", 400, 400),
+      ],
+      1,
+    );
+
+    expect(placements.has("broken")).toBe(false);
+    expect(placements.has("alsoBroken")).toBe(false);
+    expect(placements.get("A")?.direction).toBe("below");
+    expect(placements.get("B")?.direction).toBe("below");
   });
 
   test("a non-finite or zero zoom does not throw or lose every name", () => {
@@ -1416,10 +1565,6 @@ describe("resolveMarkerLabels", () => {
     expect(resolveMarkerLabels(markers, Number.NaN).size).toBe(2);
     expect(resolveMarkerLabels(markers, 0).size).toBe(2);
     expect(resolveMarkerLabels(markers, -3).size).toBe(2);
-  });
-
-  test("an empty marker list resolves to no labels", () => {
-    expect(resolveMarkerLabels([], 1).size).toBe(0);
   });
 
   test("is deterministic for the same markers and zoom", () => {
@@ -1453,10 +1598,670 @@ describe("resolveMarkerLabels", () => {
       1,
     );
     // Two short names both sit below their markers; two long ones cannot.
-    expect(short.get("A")).toBe("below");
-    expect(short.get("B")).toBe("below");
-    expect(long.get("A")).toBe("below");
-    expect(long.get("B")).toBe("above");
+    expect(short.get("A")?.direction).toBe("below");
+    expect(short.get("B")?.direction).toBe("below");
+    expect(long.get("A")?.direction).toBe("below");
+    expect(long.get("B")?.direction).toBe("above");
+  });
+
+  /*
+   * ── The defect in the issue ────────────────────────────────────────────
+   *
+   * A dozen units in one retail park, at coordinates a customer entered to
+   * four decimal places — which is to say, at the same point. Ten of the
+   * twelve used to go nameless at every zoom the map has.
+   */
+  describe("a pile of units on one point", () => {
+    function pile(count: number, zoom: number): Array<PlacedMapMarker> {
+      const units: Array<MapMarker> = Array.from(
+        { length: count },
+        (_unused: unknown, index: number): MapMarker => {
+          const name: string = `WB Unit ${(316 + index)
+            .toString()
+            .padStart(4, "0")}`;
+          return markerAt(name, 480, 250, {
+            label: name,
+            count: 1,
+            isContainer: false,
+            screenRadius: MIN_CLUSTER_RADIUS,
+          });
+        },
+      );
+      return layoutMapMarkers(units, zoom);
+    }
+
+    test("every one of a dozen coincident units keeps its name", () => {
+      const markers: Array<PlacedMapMarker> = pile(12, MAX_ZOOM);
+      const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+        markers,
+        MAX_ZOOM,
+      );
+      expect(placements.size).toBe(12);
+    });
+
+    /*
+     * Not only at the deepest zoom: the reporter's screenshot was taken
+     * zoomed in, but the names have to survive the frame the map opens on
+     * too. Nothing here depends on the zoom, which is the point — the
+     * markers are laid out in screen units either way.
+     */
+    test.each([1, 4, 20, MAX_ZOOM])(
+      "a dozen coincident units keep their names at zoom %s",
+      (zoom: number) => {
+        const markers: Array<PlacedMapMarker> = pile(12, zoom);
+        expect(resolveMarkerLabels(markers, zoom).size).toBe(12);
+      },
+    );
+
+    test("the names it draws never overlap each other", () => {
+      const markers: Array<PlacedMapMarker> = pile(12, MAX_ZOOM);
+      const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+        markers,
+        MAX_ZOOM,
+      );
+      const boxes: Array<LabelBounds> = boxesOf(markers, placements, MAX_ZOOM);
+
+      expect(boxes).toHaveLength(12);
+      for (let a: number = 0; a < boxes.length; a++) {
+        for (let b: number = a + 1; b < boxes.length; b++) {
+          expect(overlaps(boxes[a]!, boxes[b]!)).toBe(false);
+        }
+      }
+    });
+
+    test("a name never lands on another unit's marker", () => {
+      const markers: Array<PlacedMapMarker> = pile(12, MAX_ZOOM);
+      const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+        markers,
+        MAX_ZOOM,
+      );
+
+      for (const owner of markers) {
+        const placement: LabelPlacement | undefined = placements.get(owner.key);
+        if (!placement) {
+          continue;
+        }
+        const box: LabelBounds = labelBounds(owner, MAX_ZOOM, placement);
+        for (const other of markers) {
+          if (other.key === owner.key) {
+            continue;
+          }
+          expect(overlaps(box, bodyOf(other, MAX_ZOOM))).toBe(false);
+        }
+      }
+    });
+
+    /*
+     * A name that had to leave its marker keeps a thread back to it — that
+     * is the whole licence for moving it. A name still sitting against its
+     * marker must NOT have one: a thread nobody can see is ink and a legend
+     * entry for nothing.
+     */
+    test("exactly the pushed names carry a thread", () => {
+      const markers: Array<PlacedMapMarker> = pile(12, MAX_ZOOM);
+      const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+        markers,
+        MAX_ZOOM,
+      );
+
+      let pushed: number = 0;
+      for (const placement of placements.values()) {
+        expect(placement.leaderLine === null).toBe(placement.push === 0);
+        if (placement.push > 0) {
+          pushed++;
+        }
+      }
+      // A pile this tight cannot possibly seat twelve names unpushed.
+      expect(pushed).toBeGreaterThan(0);
+    });
+
+    test("no name is pushed further than the map allows", () => {
+      const markers: Array<PlacedMapMarker> = pile(24, MAX_ZOOM);
+      const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+        markers,
+        MAX_ZOOM,
+      );
+
+      for (const placement of placements.values()) {
+        expect(placement.push).toBeLessThanOrEqual(MAX_LABEL_PUSH);
+        expect(placement.push % LABEL_PUSH_STEP).toBe(0);
+      }
+    });
+
+    /*
+     * Two dozen is past anything the reporter had and still well inside the
+     * label budget, so it has to work too.
+     */
+    test("two dozen coincident units all keep their names", () => {
+      const markers: Array<PlacedMapMarker> = pile(24, MAX_ZOOM);
+      expect(resolveMarkerLabels(markers, MAX_ZOOM).size).toBe(24);
+    });
+
+    test("the pile lays out the same way twice", () => {
+      const markers: Array<PlacedMapMarker> = pile(12, MAX_ZOOM);
+      expect(
+        Array.from(resolveMarkerLabels(markers, MAX_ZOOM).entries()),
+      ).toEqual(Array.from(resolveMarkerLabels(markers, MAX_ZOOM).entries()));
+    });
+  });
+
+  /*
+   * ── The thread ─────────────────────────────────────────────────────────
+   */
+  describe("the thread back to the marker", () => {
+    function pushedPlacement(): {
+      marker: MapMarker;
+      placement: LabelPlacement;
+    } {
+      /*
+       * Boxed in on all eight sides, so the only room left is further out.
+       */
+      const owner: MapMarker = markerAt("A", 500, 500, { label: "Name" });
+      const blockers: Array<MapMarker> = [];
+      for (let dx: number = -1; dx <= 1; dx++) {
+        for (let dy: number = -1; dy <= 1; dy++) {
+          if (dx === 0 && dy === 0) {
+            continue;
+          }
+          blockers.push(
+            markerAt(`b${dx}${dy}`, 500 + dx * 22, 500 + dy * 22, {
+              label: "",
+            }),
+          );
+        }
+      }
+      const placement: LabelPlacement = resolveMarkerLabels(
+        [owner, ...blockers],
+        1,
+      ).get("A") as LabelPlacement;
+      return { marker: owner, placement: placement };
+    }
+
+    test("a boxed-in name is pushed out and threaded rather than dropped", () => {
+      const { placement }: { placement: LabelPlacement } = pushedPlacement();
+      expect(placement).toBeDefined();
+      expect(placement.push).toBeGreaterThan(0);
+      expect(placement.leaderLine).not.toBeNull();
+    });
+
+    test("the thread starts on the marker's edge, not at its centre", () => {
+      const {
+        marker,
+        placement,
+      }: { marker: MapMarker; placement: LabelPlacement } = pushedPlacement();
+      const half: number = (marker.screenRadius * CONTAINER_SIDE_FACTOR) / 2;
+      const start: number = Math.hypot(
+        placement.leaderLine?.x1 as number,
+        placement.leaderLine?.y1 as number,
+      );
+      /*
+       * Exactly the marker's half-extent along the direction of the name: a
+       * thread from the centre would print over the marker it belongs to.
+       */
+      expect(start).toBeCloseTo(half, 6);
+    });
+
+    test("the thread ends on the label's box, not inside the glyphs", () => {
+      const {
+        marker,
+        placement,
+      }: { marker: MapMarker; placement: LabelPlacement } = pushedPlacement();
+      const box: LabelBounds = labelBounds(marker, 1, placement);
+      const endX: number = marker.x + (placement.leaderLine?.x2 as number);
+      const endY: number = marker.y + (placement.leaderLine?.y2 as number);
+
+      // On the boundary of the box, to floating-point tolerance.
+      const onEdge: boolean =
+        Math.abs(endX - box.left) < 1e-6 ||
+        Math.abs(endX - box.right) < 1e-6 ||
+        Math.abs(endY - box.top) < 1e-6 ||
+        Math.abs(endY - box.bottom) < 1e-6;
+      expect(onEdge).toBe(true);
+      expect(endX).toBeGreaterThanOrEqual(box.left - 1e-6);
+      expect(endX).toBeLessThanOrEqual(box.right + 1e-6);
+      expect(endY).toBeGreaterThanOrEqual(box.top - 1e-6);
+      expect(endY).toBeLessThanOrEqual(box.bottom + 1e-6);
+    });
+
+    test("the thread is shorter than the marker could be pushed", () => {
+      const { placement }: { placement: LabelPlacement } = pushedPlacement();
+      const length: number = Math.hypot(
+        (placement.leaderLine?.x2 as number) -
+          (placement.leaderLine?.x1 as number),
+        (placement.leaderLine?.y2 as number) -
+          (placement.leaderLine?.y1 as number),
+      );
+      expect(length).toBeGreaterThan(0);
+      expect(length).toBeLessThanOrEqual(MAX_LABEL_PUSH);
+    });
+
+    /*
+     * A thread that runs through a name points at the wrong thing. It is a
+     * preference rather than a rule — a crossed thread still beats a missing
+     * name — but on an ordinary pile-up nothing should have to cross.
+     */
+    test("threads in a pile do not run through the names already placed", () => {
+      const units: Array<MapMarker> = Array.from(
+        { length: 10 },
+        (_unused: unknown, index: number): MapMarker => {
+          const name: string = `Unit ${index}`;
+          return markerAt(name, 480, 250, {
+            label: name,
+            count: 1,
+            isContainer: false,
+          });
+        },
+      );
+      const markers: Array<PlacedMapMarker> = layoutMapMarkers(units, 8);
+      const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+        markers,
+        8,
+      );
+
+      const boxes: Map<string, LabelBounds> = new Map<string, LabelBounds>();
+      for (const marker of markers) {
+        const placement: LabelPlacement | undefined = placements.get(
+          marker.key,
+        );
+        if (placement) {
+          boxes.set(marker.key, labelBounds(marker, 8, placement));
+        }
+      }
+
+      for (const marker of markers) {
+        const placement: LabelPlacement | undefined = placements.get(
+          marker.key,
+        );
+        if (!placement?.leaderLine) {
+          continue;
+        }
+        const fromX: number = marker.x * 8 + placement.leaderLine.x1;
+        const fromY: number = marker.y * 8 + placement.leaderLine.y1;
+        const toX: number = marker.x * 8 + placement.leaderLine.x2;
+        const toY: number = marker.y * 8 + placement.leaderLine.y2;
+
+        for (const [key, box] of boxes) {
+          if (key === marker.key) {
+            continue;
+          }
+          // Sampled along the thread — a crossing shows up at some point on it.
+          for (let step: number = 1; step < 20; step++) {
+            const at: number = step / 20;
+            const x: number = fromX + (toX - fromX) * at;
+            const y: number = fromY + (toY - fromY) * at;
+            const inside: boolean =
+              x > box.left && x < box.right && y > box.top && y < box.bottom;
+            expect(inside).toBe(false);
+          }
+        }
+      }
+    });
+  });
+
+  /*
+   * ── The eight positions ────────────────────────────────────────────────
+   */
+  describe("the positions a name can take", () => {
+    test("there are eight of them, and no duplicates", () => {
+      expect(LABEL_DIRECTIONS).toHaveLength(8);
+      expect(new Set(LABEL_DIRECTIONS).size).toBe(8);
+    });
+
+    // Below reads best, so it is what an uncrowded map uses everywhere.
+    test("below is tried first", () => {
+      expect(LABEL_DIRECTIONS[0]).toBe("below");
+    });
+
+    /*
+     * The anchor has to match the side the name is on, or a twenty-character
+     * name set to the left of its marker would run back over it.
+     */
+    test.each<[LabelDirection, string, number]>([
+      ["below", "middle", 0],
+      ["above", "middle", 0],
+      ["right", "start", 1],
+      ["left", "end", -1],
+      ["below-right", "start", 1],
+      ["below-left", "end", -1],
+      ["above-right", "start", 1],
+      ["above-left", "end", -1],
+    ])(
+      "%s anchors %s and sits on the expected side",
+      (direction: LabelDirection, anchor: string, horizontalSign: number) => {
+        /*
+         * Blank blockers on every side but the one under test, so the search
+         * is forced into it. They are placed far enough out that they only
+         * rule out the ring of positions against the marker.
+         */
+        const wanted: { x: number; y: number } = {
+          x: direction.includes("right")
+            ? 1
+            : direction.includes("left")
+              ? -1
+              : 0,
+          y: direction.startsWith("below")
+            ? 1
+            : direction.startsWith("above")
+              ? -1
+              : 0,
+        };
+        const owner: MapMarker = markerAt("A", 500, 500, { label: "Name" });
+        const blockers: Array<MapMarker> = [];
+        for (let dx: number = -1; dx <= 1; dx++) {
+          for (let dy: number = -1; dy <= 1; dy++) {
+            if (
+              (dx === 0 && dy === 0) ||
+              (dx === wanted.x && dy === wanted.y)
+            ) {
+              continue;
+            }
+            blockers.push(
+              markerAt(`b${dx}${dy}`, 500 + dx * 26, 500 + dy * 20, {
+                label: "",
+              }),
+            );
+          }
+        }
+
+        const placement: LabelPlacement = resolveMarkerLabels(
+          [owner, ...blockers],
+          1,
+        ).get("A") as LabelPlacement;
+
+        expect(placement.textAnchor).toBe(anchor);
+        expect(Math.sign(placement.offsetX)).toBe(horizontalSign);
+      },
+    );
+
+    /*
+     * One step out is one step out whichever way it goes. Adding the push to
+     * both axes of a corner would make a diagonal step forty percent longer
+     * than a straight one, and the spiral would stop being a spiral.
+     */
+    test("a step out is the same distance in every direction", () => {
+      const marker: MapMarker = markerAt("A", 0, 0, { label: "Name" });
+      const distances: Array<number> = LABEL_DIRECTIONS.map(
+        (direction: LabelDirection): number => {
+          const attached: LabelBounds = labelBounds(marker, 1, {
+            direction: direction,
+            push: 0,
+            offsetX: 0,
+            offsetY: 0,
+            textAnchor: "middle",
+            leaderLine: null,
+          });
+          const pushed: LabelBounds = labelBounds(marker, 1, {
+            direction: direction,
+            push: 40,
+            offsetX: 0,
+            offsetY: 0,
+            textAnchor: "middle",
+            leaderLine: null,
+          });
+          return Math.hypot(
+            (pushed.left + pushed.right) / 2 -
+              (attached.left + attached.right) / 2,
+            (pushed.top + pushed.bottom) / 2 -
+              (attached.top + attached.bottom) / 2,
+          );
+        },
+      );
+      for (const distance of distances) {
+        expect(distance).toBeCloseTo(40, 6);
+      }
+    });
+  });
+
+  /*
+   * ── What the renderers are handed ──────────────────────────────────────
+   *
+   * Both maps draw a name at marker + offset / zoom. If the offset did not
+   * scale with the zoom, every name would drift off its marker the moment
+   * anybody zoomed.
+   */
+  describe("the offsets handed to a renderer", () => {
+    test("a name below its marker sits a marker-radius plus a gap under it", () => {
+      const marker: MapMarker = markerAt("A", 100, 100, {
+        isContainer: false,
+        label: "Name",
+      });
+      const placement: LabelPlacement = resolveMarkerLabels([marker], 1).get(
+        "A",
+      ) as LabelPlacement;
+
+      expect(placement.offsetY).toBeGreaterThan(marker.screenRadius);
+      expect(placement.offsetY).toBeLessThan(marker.screenRadius + 20);
+    });
+
+    /*
+     * The offsets are SCREEN units, and a marker's radius is too, so the same
+     * name is the same distance from its marker in pixels at every zoom.
+     */
+    test("the offset is a screen distance, unchanged by the zoom", () => {
+      const marker: MapMarker = markerAt("A", 100, 100, { label: "Name" });
+      const at: (zoom: number) => LabelPlacement = (
+        zoom: number,
+      ): LabelPlacement => {
+        return resolveMarkerLabels(
+          [{ ...marker, x: 100 / zoom, y: 100 / zoom }],
+          zoom,
+        ).get("A") as LabelPlacement;
+      };
+      expect(at(1).offsetY).toBeCloseTo(at(32).offsetY, 6);
+      expect(at(1).offsetX).toBeCloseTo(at(32).offsetX, 6);
+    });
+
+    /*
+     * A container is a SQUARE of side CONTAINER_SIDE_FACTOR * r, so its name
+     * clears the side rather than the circle around it — the same shape the
+     * map draws and the same one the collision layout keeps clear.
+     */
+    test("a container's name clears the square, a site's name the disc", () => {
+      const disc: LabelPlacement = resolveMarkerLabels(
+        [markerAt("A", 100, 100, { isContainer: false, label: "Name" })],
+        1,
+      ).get("A") as LabelPlacement;
+      const square: LabelPlacement = resolveMarkerLabels(
+        [markerAt("A", 100, 100, { isContainer: true, label: "Name" })],
+        1,
+      ).get("A") as LabelPlacement;
+
+      expect(square.offsetY).toBeCloseTo(
+        (MIN_CLUSTER_RADIUS * CONTAINER_SIDE_FACTOR) / 2 +
+          (disc.offsetY - MIN_CLUSTER_RADIUS),
+        6,
+      );
+    });
+
+    test("labelBounds gives back the box the placement was measured in", () => {
+      const marker: MapMarker = markerAt("A", 100, 100, { label: "Name" });
+      const placement: LabelPlacement = resolveMarkerLabels([marker], 1).get(
+        "A",
+      ) as LabelPlacement;
+      const box: LabelBounds = labelBounds(marker, 1, placement);
+
+      // The text's anchor point is inside the box that was reserved for it.
+      expect(marker.x + placement.offsetX).toBeGreaterThanOrEqual(box.left);
+      expect(marker.x + placement.offsetX).toBeLessThanOrEqual(box.right);
+      expect(marker.y + placement.offsetY).toBeGreaterThan(box.top);
+      expect(marker.y + placement.offsetY).toBeLessThan(box.bottom);
+    });
+
+    test("labelBounds survives a zoom that has not been measured yet", () => {
+      const marker: MapMarker = markerAt("A", 100, 100, { label: "Name" });
+      const placement: LabelPlacement = resolveMarkerLabels(
+        [marker],
+        Number.NaN,
+      ).get("A") as LabelPlacement;
+
+      expect(labelBounds(marker, Number.NaN, placement)).toEqual(
+        labelBounds(marker, 1, placement),
+      );
+    });
+  });
+
+  /*
+   * ── Names still come back as the frame tightens ────────────────────────
+   */
+  describe("zoom", () => {
+    /*
+     * Markers that ARE apart in the world separate as the frame tightens, so
+     * their names walk back in against them and the threads go away. This is
+     * the property that keeps the spiral from being a permanent scattering.
+     */
+    test("zooming in pulls names back against their markers", () => {
+      const markers: Array<MapMarker> = Array.from(
+        { length: 6 },
+        (_unused: unknown, index: number): MapMarker => {
+          const name: string = `Store ${index}`;
+          return markerAt(name, 480 + index * 0.6, 250 + index * 0.4, {
+            label: name,
+            count: 1,
+            isContainer: false,
+          });
+        },
+      );
+
+      const pushedAt: (zoom: number) => number = (zoom: number): number => {
+        let pushed: number = 0;
+        for (const placement of resolveMarkerLabels(markers, zoom).values()) {
+          if (placement.push > 0) {
+            pushed++;
+          }
+        }
+        return pushed;
+      };
+
+      expect(pushedAt(1)).toBeGreaterThan(0);
+      expect(pushedAt(MAX_ZOOM)).toBe(0);
+    });
+
+    test("zooming in never costs a name", () => {
+      const markers: Array<MapMarker> = Array.from(
+        { length: 8 },
+        (_unused: unknown, index: number): MapMarker => {
+          const name: string = `A Fairly Long Name ${index}`;
+          return markerAt(name, 480 + index * 0.5, 250 + index * 0.5, {
+            label: name,
+            count: 1,
+            isContainer: false,
+          });
+        },
+      );
+
+      const counts: Array<number> = [1, 2, 4, 8, 16, 32, MAX_ZOOM].map(
+        (zoom: number): number => {
+          return resolveMarkerLabels(markers, zoom).size;
+        },
+      );
+      for (let index: number = 1; index < counts.length; index++) {
+        expect(counts[index]!).toBeGreaterThanOrEqual(counts[index - 1]!);
+      }
+      expect(counts[counts.length - 1]).toBe(markers.length);
+    });
+  });
+
+  /*
+   * ── The last resort ────────────────────────────────────────────────────
+   */
+  describe("when there is genuinely nowhere to put a name", () => {
+    /*
+     * Dropping is still the answer once the spiral runs out: two names on top
+     * of each other are worse than one name and a tooltip. It just takes a
+     * far more crowded map to get there than it used to.
+     */
+    /*
+     * A solid field of nameless markers around one that wants a name, wider
+     * in every direction than the spiral can reach. The blank markers are
+     * closer together than they are wide, so there is not one gap in it.
+     */
+    function walledIn(): Array<MapMarker> {
+      const wall: Array<MapMarker> = [];
+      for (let column: number = -19; column <= 19; column++) {
+        for (let row: number = -19; row <= 19; row++) {
+          if (column === 0 && row === 0) {
+            continue;
+          }
+          wall.push(
+            markerAt(`b${column}:${row}`, 500 + column * 12, 500 + row * 12, {
+              label: "",
+            }),
+          );
+        }
+      }
+      return wall;
+    }
+
+    test("a name with nowhere left to go is dropped, not stacked", () => {
+      const owner: MapMarker = markerAt("A", 500, 500);
+
+      expect(resolveMarkerLabels([owner, ...walledIn()], 1).has("A")).toBe(
+        false,
+      );
+    });
+
+    test("dropping one name does not cost the others theirs", () => {
+      const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+        [
+          markerAt("far", 100, 100, { label: "Far Away" }),
+          markerAt("A", 500, 500),
+          ...walledIn(),
+        ],
+        1,
+      );
+
+      expect(placements.has("far")).toBe(true);
+      expect(placements.has("A")).toBe(false);
+    });
+  });
+
+  /*
+   * A level of a thousand sites is laid out again on every wheel tick of a
+   * zoom. The spiral must not turn that into a stutter.
+   */
+  test("a crowded level resolves without running away", () => {
+    const units: Array<MapMarker> = Array.from(
+      { length: MAX_LABELLED_MARKERS },
+      (_unused: unknown, index: number): MapMarker => {
+        const name: string = `Long Franchise Name ${index}`;
+        return markerAt(name, 480, 250, {
+          label: name,
+          count: 1,
+          isContainer: false,
+        });
+      },
+    );
+    const markers: Array<PlacedMapMarker> = layoutMapMarkers(units, MAX_ZOOM);
+
+    const started: number = Date.now();
+    const placements: Map<string, LabelPlacement> = resolveMarkerLabels(
+      markers,
+      MAX_ZOOM,
+    );
+    /*
+     * Generous by two orders of magnitude — this is a runaway detector, not a
+     * benchmark, and a CI runner under load must not fail it.
+     */
+    expect(Date.now() - started).toBeLessThan(2000);
+    expect(placements.size).toBeGreaterThan(0);
+  });
+
+  /*
+   * The map hands this its markers including the ones with no name — the "all
+   * sites" view is thousands of them — so the unnameable majority must not
+   * cost anything.
+   */
+  test("markers with no name are skipped rather than searched for", () => {
+    const markers: Array<MapMarker> = Array.from(
+      { length: 2000 },
+      (_unused: unknown, index: number): MapMarker => {
+        return markerAt(`m${index}`, 480, 250, { label: "" });
+      },
+    );
+
+    const started: number = Date.now();
+    expect(resolveMarkerLabels(markers, 4).size).toBe(0);
+    expect(Date.now() - started).toBeLessThan(2000);
   });
 });
 
@@ -1806,32 +2611,37 @@ describe("layoutMapMarkers", () => {
    * touches — the name under the marker, the tooltip anchor, the site picker
    * — follows the marker they can SEE, not the coordinate underneath it.
    */
-  test("names come back once the markers they belong to are pulled apart", () => {
-    /*
-     * Short names, so what is being measured is the marker positions rather
-     * than how wide "Region 1000" is: a label reserves a box roughly its own
-     * length, and six long names cannot fit around one point however well
-     * the markers are spread.
-     */
+  test("names sit against their markers once those are pulled apart", () => {
     const markers: Array<MapMarker> = ["A", "B", "C", "D", "E", "F"].map(
       (name: string): MapMarker => {
-        return marker(name, 480, 250);
+        return marker(name, 480, 250, { label: `Region ${name}00` });
       },
     );
 
-    const stacked: number = resolveMarkerLabels(markers, 1).size;
-    const spread: number = resolveMarkerLabels(
-      layoutMapMarkers(markers, 1),
-      1,
-    ).size;
+    // How far, in total, the names had to be pushed off their markers.
+    const totalPush: (of: Array<MapMarker>) => number = (
+      of: Array<MapMarker>,
+    ): number => {
+      let total: number = 0;
+      for (const placement of resolveMarkerLabels(of, 1).values()) {
+        total += placement.push;
+      }
+      return total;
+    };
 
     /*
-     * Stacked, every name but the two that fit above and below has to be
-     * dropped rather than printed on top of another one. Spread out, the
-     * map can say what each marker is again.
+     * Every name survives either way — the placement spiral sees to that.
+     * The difference the layout makes is that the names no longer have to be
+     * flung as far to find room: six markers stacked on one point leave
+     * nowhere near their own coordinates for six names to sit.
      */
-    expect(stacked).toBeLessThan(markers.length);
-    expect(spread).toBeGreaterThan(stacked);
+    expect(resolveMarkerLabels(markers, 1).size).toBe(markers.length);
+    expect(resolveMarkerLabels(layoutMapMarkers(markers, 1), 1).size).toBe(
+      markers.length,
+    );
+    expect(totalPush(layoutMapMarkers(markers, 1))).toBeLessThan(
+      totalPush(markers),
+    );
   });
 
   /*


### PR DESCRIPTION
Fixes #3188.

## The defect

On the Network Map's **Units** view, a cluster of units pinned to near-identical coordinates showed exactly two names — at every zoom, including the deepest one the map has.

Reproduced against the shipped code with the reporter's shape (12 units, one point, names like `WB Unit 0316`):

| n units on one point | before | after |
|---|---|---|
| 3 | 2 / 3 | 3 / 3 |
| 6 | 2 / 6 | 6 / 6 |
| **12** | **2 / 12** | **12 / 12** |
| 20 | 2 / 20 | 20 / 20 |
| 48 | 2 / 48 | 48 / 48 |

Identical at zoom 1, 20 and 64, and identical for every name length.

## Why it was always exactly two

`resolveMarkerLabels` offered each marker two candidate boxes — centred directly below it and directly above it — and required each to clear every already-placed name **and every other marker's body**.

The marker collision layout (`Geo/MarkerLayout.ts`) fans a coincident pile apart in *screen* units, so the pile occupies the same patch of screen at every magnification. Every candidate box inside that patch landed in the pile's own body field. Only the single **topmost** marker could take "above" and the single **bottommost** could take "below". Everything between them was dropped — which is why the answer was 2 regardless of pile size or name width.

Zoom could not recover them: zoom magnifies the distance between two markers **in the world**, and between two units on the same street that distance is zero. Sweeping the fixture, a dozen units need roughly 0.35° of separation — about 39 km — before the second name appears at `MAX_ZOOM`. That is why Datacenters and Franchise/Corporate rollups were fine: they are genuinely tens of kilometres apart, not on a different code path.

## The fix

A name is now placed by walking a spiral outwards: the **eight** positions around the marker, then the same eight a step further out (`LABEL_PUSH_STEP = 8`), up to `MAX_LABEL_PUSH = 176` screen units. A name that had to leave its marker keeps a thin **thread** back to it, and the search prefers a position whose thread crosses nothing over one that merely fits.

Both halves earn their place: on the reporter's pile the eight directions alone recover 8–9 of 12, and the push is what seats the last few.

`MAX_LABEL_PUSH` is dimensioned against the worst case the map can present — `MAX_LABELLED_MARKERS` markers on one point, all named at the `MAX_MARKER_LABEL_CHARS` cap — which seats every name with the furthest just about on the cap. A dozen units in one retail park never gets past a third of it.

Dropping a name is still the last resort once the spiral runs out: two names on top of each other are worse than one name and a tooltip. It just takes a far more crowded map to get there.

### Geometry moved out of the renderers

`LabelPlacement` was the string union `"below" | "above"`, and each of the two maps re-derived the offset from its own copy of the gap constant. It is now an object carrying the direction, the push, the screen-unit offset to the text, its anchor and the thread — so both maps draw the name in the box the collision pass actually reserved. `labelBounds()` exposes that box so nothing has to rebuild it. `NETWORK_MAP_LABEL_GAP` is gone; there is nothing left for it to be a second copy of.

### Two things noticed on the way

- The `SiteGeoMap` key said every line on the map was a nudged marker, because every line was. There are two kinds now, so a frame drawing the second one explains it — and a frame drawing none still says nothing.
- `truncateMarkerLabel` now trims. A site named entirely of spaces was *truthy*, so it sailed past every "does this marker have a name" guard, took a reserved box away from a neighbour with a real name, and drew nothing in it.

## Cost

0.1 ms at n=12 and 1.7 ms at n=48, on the pathological all-coincident pile. Markers with no name short-circuit before the search, so the 2500-marker "all sites" view is unaffected (0.05 ms). `MAX_LABEL_CANDIDATE_VISITS` is the backstop, and running out of it now costs only the *pushed* positions — the eight against the marker are always still tried, so the degradation is "names that had room keep it" rather than a cliff.

## Tests

`App/Tests/Dashboard/` — 5401 passing, 145 suites.

New coverage, all of it failing on the pre-fix code:

- the issue's case end to end: 12 and 24 coincident units keep every name, at zoom 1, 4, 20 and 64
- no two reserved boxes overlap, and no name lands on another unit's marker
- exactly the pushed names carry a thread; a name against its marker carries none
- the thread starts on the marker's edge and ends on the label's box, not inside the glyphs
- threads in a pile do not run through names already placed
- the eight directions: anchors, sides, and that one step out is the same distance whichever way it goes
- the offsets are screen distances, unchanged by zoom; a container's name clears the square and a site's the disc
- zooming in pulls names back against their markers and never costs one
- a name with genuinely nowhere to go is still dropped, and dropping it costs nobody else theirs
- a marker with corrupt coordinates costs nobody else their name (a rectangle of NaNs would have read as overlapping *every* candidate)
- both renderers draw at the offset the pass reserved, carry the thread, and no longer hold a gap constant of their own

Verified: `npx tsc --noEmit` in `App` and in `App/FeatureSet/Dashboard`, and `npx eslint --fix` over every changed file.
