### PR TITLE
fix(telemetry): let a saved view be deselected again

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewer.tsx
@@ -25,6 +25,10 @@ import {
   resolveLogSavedViewTimeRange,
   withResolvedTime,
 } from "./LogSavedViewTimeRange";
+import {
+  buildClearedLogsViewState,
+  ClearedLogsViewState,
+} from "./LogsViewerDefaults";
 import { serializeSavedViewTimeRange } from "Common/Utils/Telemetry/SavedViewTimeRange";
 import ConfirmModal from "Common/UI/Components/Modal/ConfirmModal";
 import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
@@ -1079,6 +1083,31 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
     },
     [disableLiveMode, props],
   );
+
+  /*
+   * Deselect the active saved view and put the explorer back where it starts.
+   * Every field applying a view writes is written back to its default — see
+   * buildClearedLogsViewState, which owns that answer so it can be tested
+   * without a renderer.
+   */
+  const clearSavedView: () => void = useCallback((): void => {
+    const cleared: ClearedLogsViewState = buildClearedLogsViewState({
+      baseQuery: buildBaseQuery(props),
+      defaultPageSize: effectiveDefaultPageSize,
+      hostTimeRange: pinnedTimeRange || props.timeRangeOverride,
+    });
+
+    setTimeRange(cleared.timeRange);
+    setAppliedFacetFilters(cleared.facetFilters);
+    setFilterOptions(cleared.filterOptions);
+    setPage(cleared.page);
+    setPageSize(cleared.pageSize);
+    setSortField(cleared.sortField);
+    setSortOrder(cleared.sortOrder);
+    setSelectedColumns(cleared.columns);
+    setSelectedSavedViewId(null);
+    disableLiveMode();
+  }, [props, pinnedTimeRange, effectiveDefaultPageSize, disableLiveMode]);
 
   // --- Effects ---
 
@@ -2153,6 +2182,7 @@ const DashboardLogsViewer: FunctionComponent<ComponentProps> = (
               applySavedView(savedView);
             }
           }}
+          onClearSavedView={clearSavedView}
           onCreateSavedView={() => {
             setShowCreateSavedViewModal(true);
           }}

--- a/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewerDefaults.ts
+++ b/App/FeatureSet/Dashboard/src/Components/Logs/LogsViewerDefaults.ts
@@ -1,0 +1,72 @@
+import Log from "Common/Models/AnalyticsModels/Log";
+import Query from "Common/Types/BaseDatabase/Query";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import RangeStartAndEndDateTime from "Common/Types/Time/RangeStartAndEndDateTime";
+import { LogsSortField } from "Common/UI/Components/LogsViewer/LogsViewer";
+import { DEFAULT_LOGS_TABLE_COLUMNS } from "Common/UI/Components/LogsViewer/types";
+import { DEFAULT_SAVED_VIEW_TIME_RANGE } from "Common/Utils/Telemetry/SavedViewTimeRange";
+import { withResolvedTime } from "./LogSavedViewTimeRange";
+
+/*
+ * Deselecting a saved log view has to undo every field applying one wrote —
+ * window, facet chips, page, page size, sort and columns. Leaving any of them
+ * behind means "cleared" still shows the view's shape, which is the whole
+ * complaint. Keeping the answer here (rather than inline in the viewer) is
+ * what makes it testable: the explorer has no renderer in this suite.
+ */
+
+export interface ClearedLogsViewState {
+  /*
+   * The host's own window when it pins one, otherwise the rolling default,
+   * re-resolved against the clock on each call.
+   */
+  timeRange: RangeStartAndEndDateTime;
+  /*
+   * The host's own scope (service / trace / span / session / entity) with the
+   * default window stamped on. The scope survives clearing: it comes from the
+   * page the viewer is embedded in, not from the saved view.
+   */
+  filterOptions: Query<Log>;
+  // No facet chips — a fresh Map, never a shared empty one.
+  facetFilters: Map<string, Set<string>>;
+  page: number;
+  pageSize: number;
+  sortField: LogsSortField;
+  sortOrder: SortOrder;
+  columns: Array<string>;
+}
+
+export interface ClearedLogsViewInput {
+  // buildBaseQuery(props) — the scope the embedding page imposes.
+  baseQuery: Query<Log>;
+  // props.limit, or the viewer's own default when the host sets none.
+  defaultPageSize: number;
+  /*
+   * The window the embedding page imposes: a pinned incident/alert snapshot,
+   * or a controlled cursor from the entity telemetry hub. It belongs to the
+   * page, not to the saved view, so — like the scope above — it survives
+   * clearing. The same hosts are why the default view is never auto-applied:
+   * moving them off their moment is not what "no saved view" means. Absent
+   * for the standalone explorer, which falls back to the rolling default.
+   */
+  hostTimeRange?: RangeStartAndEndDateTime | null | undefined;
+}
+
+export function buildClearedLogsViewState(
+  input: ClearedLogsViewInput,
+): ClearedLogsViewState {
+  const timeRange: RangeStartAndEndDateTime = input.hostTimeRange || {
+    range: DEFAULT_SAVED_VIEW_TIME_RANGE,
+  };
+
+  return {
+    timeRange: timeRange,
+    filterOptions: withResolvedTime(input.baseQuery, timeRange),
+    facetFilters: new Map<string, Set<string>>(),
+    page: 1,
+    pageSize: input.defaultPageSize,
+    sortField: "time",
+    sortOrder: SortOrder.Descending,
+    columns: [...DEFAULT_LOGS_TABLE_COLUMNS],
+  };
+}

--- a/App/FeatureSet/Dashboard/src/Components/Metrics/MetricsViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Metrics/MetricsViewer.tsx
@@ -1421,9 +1421,14 @@ const MetricsViewer: FunctionComponent<Props> = (
         ),
       );
       setTimeRange(deserializeSavedViewTimeRange(state.timeRange));
-      if (state.pageSize) {
-        setPageSize(state.pageSize);
-      }
+      /*
+       * Unconditional, like every other field here: a view saved before page
+       * size was captured falls back to the default, and so does the empty
+       * state the saved-views control applies when a view is cleared. Guarding
+       * this one left the cleared explorer on the view's page size — and, via
+       * the URL mirror, still advertising it in the query string.
+       */
+      setPageSize(state.pageSize || DEFAULT_PAGE_SIZE);
       setPage(1);
     }, []);
 

--- a/App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetrySavedViewsControl.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Telemetry/TelemetrySavedViewsControl.tsx
@@ -190,6 +190,21 @@ function TelemetrySavedViewsControl<T extends TelemetrySavedViewModel>(
   );
 
   /*
+   * Deselect the active view and put the explorer back where it starts. An
+   * empty state is exactly what every host means by "no saved view": each
+   * applyState implementation substitutes its own defaults for the fields it
+   * finds missing, which is the same path a brand-new explorer takes.
+   *
+   * The initial-default guard is deliberately left set — re-applying the
+   * project default view the moment the user cleared it is what they were
+   * trying to get away from.
+   */
+  const clearSavedView: () => void = useCallback((): void => {
+    setSelectedSavedViewId(null);
+    applyState({});
+  }, [applyState]);
+
+  /*
    * Apply the default view once, after the first fetch resolves (so savedViews
    * is populated). Skipped when the URL already carried filter state.
    */
@@ -424,6 +439,7 @@ function TelemetrySavedViewsControl<T extends TelemetrySavedViewModel>(
             applySavedView(view);
           }
         }}
+        onClear={clearSavedView}
         onCreate={() => {
           setShowCreateModal(true);
         }}

--- a/App/FeatureSet/Dashboard/src/Components/Traces/TracesViewer.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Traces/TracesViewer.tsx
@@ -2360,9 +2360,14 @@ const TracesViewer: FunctionComponent<Props> = (props: Props): ReactElement => {
         ),
       );
       setTimeRange(deserializeSavedViewTimeRange(state.timeRange));
-      if (state.pageSize) {
-        setPageSize(state.pageSize);
-      }
+      /*
+       * Unconditional, like every other field here: a view saved before page
+       * size was captured falls back to the default, and so does the empty
+       * state the saved-views control applies when a view is cleared. Guarding
+       * this one left the cleared explorer on the view's page size — and, via
+       * the URL mirror, still advertising it in the query string.
+       */
+      setPageSize(state.pageSize || DEFAULT_PAGE_SIZE);
       // Views saved before the toggle existed default to showing all spans.
       setRootOnly(state.rootOnly ?? false);
       setPage(1);

--- a/App/Tests/Dashboard/LogsViewerDefaults.test.ts
+++ b/App/Tests/Dashboard/LogsViewerDefaults.test.ts
@@ -1,0 +1,276 @@
+import {
+  buildClearedLogsViewState,
+  ClearedLogsViewState,
+} from "../../FeatureSet/Dashboard/src/Components/Logs/LogsViewerDefaults";
+import Log from "Common/Models/AnalyticsModels/Log";
+import Includes from "Common/Types/BaseDatabase/Includes";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
+import Query from "Common/Types/BaseDatabase/Query";
+import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import TimeRange from "Common/Types/Time/TimeRange";
+import { DEFAULT_LOGS_TABLE_COLUMNS } from "Common/UI/Components/LogsViewer/types";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Deselecting a saved log view has to undo everything applying one did.
+ * Applying writes the window, the facet chips, the page, the page size, the
+ * sort and the column selection all at once, so a clear that forgets any one
+ * of them leaves the explorer still wearing the view — which is exactly the
+ * complaint in issue 3189, one field at a time.
+ *
+ * The host scope is the one thing that must NOT be cleared: it comes from the
+ * page the viewer is embedded in (a service, a trace, a replay session), not
+ * from the saved view, and dropping it would widen the query to the whole
+ * project.
+ */
+
+const ONE_HOUR_IN_MS: number = 60 * 60 * 1000;
+// Generous: only rules out a window anchored to a different hour entirely.
+const CLOCK_TOLERANCE_IN_MS: number = 60 * 1000;
+
+function scopedQuery(): Query<Log> {
+  return {
+    primaryEntityId: new Includes(["6512f1a0a1b2c3d4e5f60718"]),
+    traceId: new Includes(["b1c2d3"]),
+  } as unknown as Query<Log>;
+}
+
+function clearedWith(baseQuery: Query<Log>): ClearedLogsViewState {
+  return buildClearedLogsViewState({
+    baseQuery: baseQuery,
+    defaultPageSize: 100,
+  });
+}
+
+describe("buildClearedLogsViewState — the time selection", () => {
+  test("lands on the rolling default hour, not a frozen custom window", () => {
+    const cleared: ClearedLogsViewState = clearedWith({});
+
+    expect(cleared.timeRange.range).toBe(TimeRange.PAST_ONE_HOUR);
+    /*
+     * A Custom range would pin the explorer to whatever hour it happened to
+     * be when the view was cleared — the same staleness saved views had
+     * before the selection got its own column.
+     */
+    expect(cleared.timeRange.startAndEndDate).toBeUndefined();
+  });
+
+  test("stamps a freshly resolved window on the query", () => {
+    const before: number = Date.now();
+    const cleared: ClearedLogsViewState = clearedWith({});
+    const after: number = Date.now();
+
+    const time: InBetween<Date> = (
+      cleared.filterOptions as unknown as Record<string, InBetween<Date>>
+    )["time"]!;
+
+    expect(time).toBeInstanceOf(InBetween);
+
+    const startTime: number = new Date(time.startValue).getTime();
+    const endTime: number = new Date(time.endValue).getTime();
+
+    expect(endTime - startTime).toBeCloseTo(ONE_HOUR_IN_MS, -4);
+    expect(endTime).toBeGreaterThanOrEqual(before - CLOCK_TOLERANCE_IN_MS);
+    expect(endTime).toBeLessThanOrEqual(after + CLOCK_TOLERANCE_IN_MS);
+  });
+
+  test("keeps the window the embedding page pinned", () => {
+    /*
+     * An incident page pins the hour its incident is about. That window came
+     * from the page, not from the saved view, so clearing the view must not
+     * drag the reader off the moment they were sent to look at — the same
+     * reason the default saved view is never auto-applied for those hosts.
+     */
+    const pinnedStart: Date = new Date("2026-02-01T09:00:00.000Z");
+    const pinnedEnd: Date = new Date("2026-02-01T10:00:00.000Z");
+
+    const cleared: ClearedLogsViewState = buildClearedLogsViewState({
+      baseQuery: {},
+      defaultPageSize: 100,
+      hostTimeRange: {
+        range: TimeRange.CUSTOM,
+        startAndEndDate: new InBetween<Date>(pinnedStart, pinnedEnd),
+      },
+    });
+
+    expect(cleared.timeRange.range).toBe(TimeRange.CUSTOM);
+
+    const time: InBetween<Date> = (
+      cleared.filterOptions as unknown as Record<string, InBetween<Date>>
+    )["time"]!;
+
+    expect(new Date(time.startValue).getTime()).toBe(pinnedStart.getTime());
+    expect(new Date(time.endValue).getTime()).toBe(pinnedEnd.getTime());
+  });
+
+  test("a host that pins nothing still gets the rolling default", () => {
+    for (const hostTimeRange of [undefined, null]) {
+      const cleared: ClearedLogsViewState = buildClearedLogsViewState({
+        baseQuery: {},
+        defaultPageSize: 100,
+        hostTimeRange: hostTimeRange,
+      });
+
+      expect(cleared.timeRange.range).toBe(TimeRange.PAST_ONE_HOUR);
+    }
+  });
+
+  test("a rolling window the host controls is re-resolved, not frozen", () => {
+    // The entity hub drives a relative cursor; it must stay relative.
+    const cleared: ClearedLogsViewState = buildClearedLogsViewState({
+      baseQuery: {},
+      defaultPageSize: 100,
+      hostTimeRange: { range: TimeRange.PAST_ONE_DAY },
+    });
+
+    const time: InBetween<Date> = (
+      cleared.filterOptions as unknown as Record<string, InBetween<Date>>
+    )["time"]!;
+
+    expect(cleared.timeRange.range).toBe(TimeRange.PAST_ONE_DAY);
+    expect(
+      new Date(time.endValue).getTime() - new Date(time.startValue).getTime(),
+    ).toBeCloseTo(24 * ONE_HOUR_IN_MS, -5);
+  });
+
+  test("re-resolves the window on every call rather than reusing one", () => {
+    const first: ClearedLogsViewState = clearedWith({});
+    const second: ClearedLogsViewState = clearedWith({});
+
+    const firstTime: InBetween<Date> = (
+      first.filterOptions as unknown as Record<string, InBetween<Date>>
+    )["time"]!;
+    const secondTime: InBetween<Date> = (
+      second.filterOptions as unknown as Record<string, InBetween<Date>>
+    )["time"]!;
+
+    // Distinct objects, so mutating one explorer's window cannot touch another.
+    expect(secondTime).not.toBe(firstTime);
+  });
+});
+
+describe("buildClearedLogsViewState — the query", () => {
+  test("keeps the host scope the embedding page imposes", () => {
+    const cleared: ClearedLogsViewState = clearedWith(scopedQuery());
+    const query: Record<string, unknown> =
+      cleared.filterOptions as unknown as Record<string, unknown>;
+
+    expect(query["primaryEntityId"]).toBeInstanceOf(Includes);
+    expect((query["primaryEntityId"] as Includes).values).toEqual([
+      "6512f1a0a1b2c3d4e5f60718",
+    ]);
+    expect((query["traceId"] as Includes).values).toEqual(["b1c2d3"]);
+  });
+
+  test("carries nothing but the scope and the window", () => {
+    const cleared: ClearedLogsViewState = clearedWith(scopedQuery());
+
+    /*
+     * Any extra key here would be a predicate the saved view contributed and
+     * clearing failed to drop — severityText, a body search, a facet chip.
+     */
+    expect(Object.keys(cleared.filterOptions).sort()).toEqual([
+      "primaryEntityId",
+      "time",
+      "traceId",
+    ]);
+  });
+
+  test("an unscoped explorer clears down to the window alone", () => {
+    const cleared: ClearedLogsViewState = clearedWith({});
+
+    expect(Object.keys(cleared.filterOptions)).toEqual(["time"]);
+  });
+
+  test("does not mutate the base query it was handed", () => {
+    const baseQuery: Query<Log> = scopedQuery();
+
+    clearedWith(baseQuery);
+
+    expect(
+      (baseQuery as unknown as Record<string, unknown>)["time"],
+    ).toBeUndefined();
+  });
+
+  test("a base query that already carries a window has it replaced", () => {
+    const staleStart: Date = new Date("2020-03-01T10:00:00.000Z");
+    const staleEnd: Date = new Date("2020-03-01T11:00:00.000Z");
+
+    const cleared: ClearedLogsViewState = clearedWith({
+      time: new InBetween<Date>(staleStart, staleEnd),
+    } as unknown as Query<Log>);
+
+    const time: InBetween<Date> = (
+      cleared.filterOptions as unknown as Record<string, InBetween<Date>>
+    )["time"]!;
+
+    expect(new Date(time.startValue).getTime()).not.toBe(staleStart.getTime());
+  });
+});
+
+describe("buildClearedLogsViewState — the rest of the explorer", () => {
+  test("drops every facet chip", () => {
+    const cleared: ClearedLogsViewState = clearedWith({});
+
+    expect(cleared.facetFilters.size).toBe(0);
+  });
+
+  test("hands out a fresh chip map each time", () => {
+    /*
+     * The viewer mutates copies of this map as the user clicks facets. A
+     * shared instance would leak one explorer's chips into the next clear.
+     */
+    const first: ClearedLogsViewState = clearedWith({});
+    const second: ClearedLogsViewState = clearedWith({});
+
+    first.facetFilters.set("severityText", new Set(["Error"]));
+
+    expect(second.facetFilters.size).toBe(0);
+  });
+
+  test("returns to the first page", () => {
+    const cleared: ClearedLogsViewState = clearedWith({});
+
+    expect(cleared.page).toBe(1);
+  });
+
+  test("takes the page size the host considers default", () => {
+    // props.limit wins over the viewer's own default when the host sets one.
+    expect(
+      buildClearedLogsViewState({ baseQuery: {}, defaultPageSize: 25 })
+        .pageSize,
+    ).toBe(25);
+    expect(
+      buildClearedLogsViewState({ baseQuery: {}, defaultPageSize: 100 })
+        .pageSize,
+    ).toBe(100);
+  });
+
+  test("restores newest-first ordering by time", () => {
+    const cleared: ClearedLogsViewState = clearedWith({});
+
+    expect(cleared.sortField).toBe("time");
+    expect(cleared.sortOrder).toBe(SortOrder.Descending);
+  });
+
+  test("restores the default column selection", () => {
+    const cleared: ClearedLogsViewState = clearedWith({});
+
+    expect(cleared.columns).toEqual(DEFAULT_LOGS_TABLE_COLUMNS);
+  });
+
+  test("the returned columns are a copy of the shared default", () => {
+    /*
+     * The viewer pushes the cleared columns straight into state and then into
+     * localStorage. Handing back the module-level array would let a later
+     * column edit rewrite the defaults for the whole app.
+     */
+    const cleared: ClearedLogsViewState = clearedWith({});
+
+    expect(cleared.columns).not.toBe(DEFAULT_LOGS_TABLE_COLUMNS);
+
+    cleared.columns.push("traceId");
+
+    expect(DEFAULT_LOGS_TABLE_COLUMNS).not.toContain("traceId");
+  });
+});

--- a/App/Tests/Dashboard/SavedViewClearWiring.test.ts
+++ b/App/Tests/Dashboard/SavedViewClearWiring.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Picking a saved view on the Traces explorer was a one-way door: the dropdown
+ * checkmarked it and offered nothing that meant "none", so the only way back
+ * to the unfiltered explorer was a hard reload
+ * (github.com/OneUptime/oneuptime/issues/3189).
+ *
+ * The dropdown half of the fix is exercised for real in
+ * Common/Tests/UI/Components/*SavedViewsDropdown.test.tsx. What those cannot
+ * reach is the host wiring: whether the explorers actually hand a clear
+ * handler down, and whether that handler resets everything applying a view
+ * set. The App suite has no renderer, so — as in
+ * SavedViewFilterTupleWiring.test.ts — the wiring is checked by reading the
+ * sources.
+ *
+ * The last describe here is the one that earns its keep over time: it derives
+ * the fields "clear" must touch from the fields "apply" writes, so a field
+ * added to apply later fails this file until clear undoes it too.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+const COMPONENTS_DIR: string = path.join(DASHBOARD_SRC, "Components");
+
+function squash(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/.*$/gm, " ");
+}
+
+function readCodeAt(absolutePath: string): string {
+  return squash(stripComments(fs.readFileSync(absolutePath, "utf8")));
+}
+
+function readCode(...relativeParts: Array<string>): string {
+  return readCodeAt(path.join(DASHBOARD_SRC, ...relativeParts));
+}
+
+const CONTROL_CODE: string = readCode(
+  "Components",
+  "Telemetry",
+  "TelemetrySavedViewsControl.tsx",
+);
+const TRACES_CODE: string = readCode(
+  "Components",
+  "Traces",
+  "TracesViewer.tsx",
+);
+const METRICS_CODE: string = readCode(
+  "Components",
+  "Metrics",
+  "MetricsViewer.tsx",
+);
+const METRIC_EXPLORER_CODE: string = readCode(
+  "Components",
+  "Metrics",
+  "MetricExplorer.tsx",
+);
+const LOGS_CODE: string = readCode("Components", "Logs", "LogsViewer.tsx");
+
+/*
+ * The body of a `const name: ... = useCallback((...) => { ... }, [deps]);`,
+ * read out of the squashed source so the assertions below can be scoped to
+ * one function instead of the whole 2000-line viewer.
+ */
+function callbackBody(code: string, name: string): string {
+  const start: number = code.indexOf(`const ${name}:`);
+
+  if (start < 0) {
+    throw new Error(`${name} is not declared in this file`);
+  }
+
+  const depsStart: number = code.indexOf("}, [", start);
+
+  if (depsStart < 0) {
+    throw new Error(`could not find the end of ${name}`);
+  }
+
+  /*
+   * Prettier closes the deps array as `]);`, or — when the argument list is
+   * wide enough to wrap — as `],` on its own line before `);`, which squashes
+   * to `], );`. Matching only the first spelling silently ran the slice on
+   * into the NEXT callback, quietly widening whatever it was scoped to.
+   */
+  const end: number = code
+    .slice(depsStart)
+    .search(/\]\s*\)\s*;|\]\s*,\s*\)\s*;/);
+
+  if (end < 0) {
+    throw new Error(`could not find the deps array of ${name}`);
+  }
+
+  return code.slice(start, depsStart + end);
+}
+
+function stateSettersIn(body: string): Array<string> {
+  return Array.from(new Set(body.match(/set[A-Z]\w*\(/g) || [])).sort();
+}
+
+describe("the shared saved-views control offers a way out", () => {
+  test("the dropdown is given a clear handler", () => {
+    expect(CONTROL_CODE).toContain("onClear={clearSavedView}");
+  });
+
+  test("clearing drops the selection and resets the explorer", () => {
+    /*
+     * An empty state is what every host already treats as "nothing saved" —
+     * each applyState substitutes its own defaults for the missing fields.
+     */
+    expect(CONTROL_CODE).toContain(
+      squash("setSelectedSavedViewId(null); applyState({});"),
+    );
+  });
+
+  test("clearing does not re-arm the default-view auto-apply", () => {
+    /*
+     * The default view is applied once, behind hasAppliedInitialDefault.
+     * Resetting that ref on clear would re-apply the very view the user just
+     * dismissed the next time savedViews changed.
+     */
+    expect(CONTROL_CODE).not.toContain(
+      "hasAppliedInitialDefault.current=false",
+    );
+    expect(CONTROL_CODE).not.toContain(
+      "hasAppliedInitialDefault.current = false",
+    );
+  });
+});
+
+describe("every explorer mounting the control inherits clearing", () => {
+  function findFilesMounting(control: string): Array<string> {
+    const matches: Array<string> = [];
+
+    const walk: (directory: string) => void = (directory: string): void => {
+      for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const fullPath: string = path.join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+          walk(fullPath);
+          continue;
+        }
+
+        if (!entry.name.endsWith(".tsx")) {
+          continue;
+        }
+
+        if (readCodeAt(fullPath).includes(`<${control}`)) {
+          matches.push(fullPath);
+        }
+      }
+    };
+
+    walk(COMPONENTS_DIR);
+
+    return matches;
+  }
+
+  /*
+   * Listed rather than counted so that a fourth explorer shows up here as a
+   * failure — its applyState has to tolerate an empty state before it can be
+   * cleared, which is what the next block checks.
+   */
+  test("the known hosts are the ones this file pins", () => {
+    const hosts: Array<string> = findFilesMounting(
+      "TelemetrySavedViewsControl",
+    ).map((file: string): string => {
+      return path.basename(file);
+    });
+
+    expect(hosts.sort()).toEqual([
+      "MetricExplorer.tsx",
+      "MetricsViewer.tsx",
+      "TracesViewer.tsx",
+    ]);
+  });
+
+  test("no host reads a saved-view field without tolerating its absence", () => {
+    /*
+     * Clearing calls applyState({}), so any bare property access on a field
+     * of the stored state throws the moment the field is missing — the same
+     * class of crash a corrupt saved view already caused once.
+     */
+    for (const file of findFilesMounting("TelemetrySavedViewsControl")) {
+      const code: string = readCodeAt(file);
+
+      expect(code).not.toMatch(/state\.search\./);
+      expect(code).not.toMatch(/state\.filters\./);
+      expect(code).not.toMatch(/state\.timeRange\./);
+      expect(code).not.toMatch(/state\.explorerConfig\./);
+    }
+  });
+});
+
+describe("an empty view state lands each explorer on its defaults", () => {
+  test("traces: no search, no filter chips, the default hour, all spans, page one", () => {
+    expect(TRACES_CODE).toContain(
+      'const nextSearch: string = state.search || ""',
+    );
+    expect(TRACES_CODE).toContain("readSavedViewFilters(state.filters)");
+    expect(TRACES_CODE).toContain(
+      "setTimeRange(deserializeSavedViewTimeRange(state.timeRange))",
+    );
+    // Root-spans-only is a filter too: clearing has to let all spans back in.
+    expect(TRACES_CODE).toContain("setRootOnly(state.rootOnly ?? false)");
+    expect(TRACES_CODE).toContain("setPage(1)");
+    expect(TRACES_CODE).toContain(
+      "setPageSize(state.pageSize || DEFAULT_PAGE_SIZE)",
+    );
+  });
+
+  test("metrics list: no search, no filter chips, the default hour, page one", () => {
+    expect(METRICS_CODE).toContain(
+      'const nextSearch: string = state.search || ""',
+    );
+    expect(METRICS_CODE).toContain("readSavedViewFilters(state.filters)");
+    expect(METRICS_CODE).toContain(
+      "setTimeRange(deserializeSavedViewTimeRange(state.timeRange))",
+    );
+    expect(METRICS_CODE).toContain("setPage(1)");
+    expect(METRICS_CODE).toContain(
+      "setPageSize(state.pageSize || DEFAULT_PAGE_SIZE)",
+    );
+  });
+
+  test("no field is left behind a truthiness guard", () => {
+    /*
+     * `if (state.pageSize) { setPageSize(...) }` is the shape that broke this
+     * once: every other field defaulted, and page size alone survived the
+     * clear — visible both in the rows-per-page control and, through the URL
+     * mirror, in the query string of a supposedly cleared explorer.
+     */
+    for (const code of [TRACES_CODE, METRICS_CODE]) {
+      expect(code).not.toMatch(/if \(state\.\w+\) \{/);
+    }
+  });
+
+  test("metric explorer: one empty query builder row and the default hour", () => {
+    expect(METRIC_EXPLORER_CODE).toContain(
+      squash("(state.explorerConfig || {}) as JSONObject"),
+    );
+    expect(METRIC_EXPLORER_CODE).toContain("getDefaultEmptyQueryConfig()");
+    expect(METRIC_EXPLORER_CODE).toContain("TimeRange.PAST_ONE_HOUR");
+  });
+});
+
+describe("the logs explorer offers the same way out", () => {
+  const CLEAR_BODY: string = callbackBody(LOGS_CODE, "clearSavedView");
+  const APPLY_BODY: string = callbackBody(LOGS_CODE, "applySavedView");
+
+  test("the viewer is given a clear handler", () => {
+    expect(LOGS_CODE).toContain("onClearSavedView={clearSavedView}");
+  });
+
+  test("the two callback bodies really are separate", () => {
+    /*
+     * They sit next to each other in the file, and an earlier version of
+     * callbackBody ran off the end of applySavedView straight into
+     * clearSavedView — which would have made the parity test below compare a
+     * set against itself.
+     */
+    expect(APPLY_BODY).not.toContain("buildClearedLogsViewState");
+    expect(CLEAR_BODY).not.toContain("resolveLogSavedViewTimeRange");
+  });
+
+  test("clearing goes through the shared defaults builder", () => {
+    // Unit-tested for real in LogsViewerDefaults.test.ts.
+    expect(CLEAR_BODY).toContain("buildClearedLogsViewState({");
+    expect(CLEAR_BODY).toContain("baseQuery: buildBaseQuery(props)");
+  });
+
+  test("clearing keeps the window the embedding page pinned", () => {
+    /*
+     * An incident or alert page pins the moment it is about, and the entity
+     * hub drives a controlled cursor. Neither came from the saved view, so
+     * neither is the saved view's to take away — the same reason the default
+     * view is not auto-applied for those hosts.
+     */
+    expect(CLEAR_BODY).toContain(
+      "hostTimeRange: pinnedTimeRange || props.timeRangeOverride",
+    );
+  });
+
+  test("clearing drops the selection", () => {
+    expect(CLEAR_BODY).toContain("setSelectedSavedViewId(null)");
+  });
+
+  test("clearing stops live tailing, as applying a view does", () => {
+    /*
+     * Live mode pins the window to "now" and keeps re-querying. Leaving it on
+     * would immediately move the window the clear just reset.
+     */
+    expect(CLEAR_BODY).toContain("disableLiveMode()");
+  });
+
+  test("clearing undoes every piece of state applying a view sets", () => {
+    /*
+     * The point of this file. Applying a saved log view writes nine separate
+     * pieces of state; a clear that misses one leaves the explorer still
+     * wearing part of the view. Deriving the list from applySavedView rather
+     * than hard-coding it means a tenth field added there fails here.
+     */
+    const applied: Array<string> = stateSettersIn(APPLY_BODY);
+    const cleared: Array<string> = stateSettersIn(CLEAR_BODY);
+
+    expect(applied.length).toBeGreaterThan(0);
+
+    const missing: Array<string> = applied.filter((setter: string): boolean => {
+      return !cleared.includes(setter);
+    });
+
+    expect(missing).toEqual([]);
+  });
+
+  test("the fields clearing resets are the ones a saved view can carry", () => {
+    // A readable spelling of the same contract, so a failure above is legible.
+    for (const setter of [
+      "setTimeRange(",
+      "setAppliedFacetFilters(",
+      "setFilterOptions(",
+      "setPage(",
+      "setPageSize(",
+      "setSortField(",
+      "setSortOrder(",
+      "setSelectedColumns(",
+      "setSelectedSavedViewId(",
+    ]) {
+      expect(CLEAR_BODY).toContain(setter);
+    }
+  });
+});

--- a/Common/Tests/UI/Components/LogsSavedViewsDropdown.test.tsx
+++ b/Common/Tests/UI/Components/LogsSavedViewsDropdown.test.tsx
@@ -1,0 +1,304 @@
+import SavedViewsDropdown, {
+  SavedViewsDropdownProps,
+} from "../../../UI/Components/LogsViewer/components/SavedViewsDropdown";
+import LogsViewerToolbar from "../../../UI/Components/LogsViewer/components/LogsViewerToolbar";
+import LogsFacetSidebar from "../../../UI/Components/LogsViewer/components/LogsFacetSidebar";
+import { LogsSavedViewOption } from "../../../UI/Components/LogsViewer/types";
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  RenderResult,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * The logs explorer grew its saved views before the shared telemetry viewer
+ * did, so it carries its own copy of the dropdown — and its own copy of the
+ * bug in issue 3189: a view could be applied but never taken back off.
+ *
+ * Everything the telemetry dropdown gained is pinned here for the logs one
+ * too, plus the two extra surfaces logs has that traces does not: the toolbar
+ * that mounts the dropdown, and the facet sidebar, which lists the same views
+ * again down the left-hand side and re-applied them on click.
+ */
+
+const VIEWS: Array<LogsSavedViewOption> = [
+  { id: "errors", name: "Errors only" },
+  { id: "checkout", name: "Checkout service", isDefault: true },
+];
+
+const CLEAR_LABEL: string = "Clear view";
+const MENU_PROBE: string = "+ Save Current View";
+
+interface Handlers {
+  onSelect: (viewId: string) => void;
+  onClear: () => void;
+  onCreate: () => void;
+  onEdit: (viewId: string) => void;
+  onDelete: (viewId: string) => void;
+  onUpdateCurrent: () => void;
+}
+
+function makeHandlers(): Handlers {
+  return {
+    onSelect: jest.fn(),
+    onClear: jest.fn(),
+    onCreate: jest.fn(),
+    onEdit: jest.fn(),
+    onDelete: jest.fn(),
+    onUpdateCurrent: jest.fn(),
+  };
+}
+
+function renderDropdown(
+  overrides: Partial<SavedViewsDropdownProps> = {},
+  handlers: Handlers = makeHandlers(),
+): { handlers: Handlers; result: RenderResult } {
+  const props: SavedViewsDropdownProps = {
+    savedViews: VIEWS,
+    selectedSavedViewId: null,
+    ...handlers,
+    ...overrides,
+  };
+
+  return { handlers, result: render(<SavedViewsDropdown {...props} />) };
+}
+
+function trigger(): HTMLElement {
+  return screen.getAllByRole("button")[0]!;
+}
+
+function openMenu(): void {
+  fireEvent.click(trigger());
+}
+
+function isMenuOpen(): boolean {
+  return screen.queryByText(MENU_PROBE) !== null;
+}
+
+function rowFor(name: string): HTMLElement {
+  return screen.getByRole("button", { name: name });
+}
+
+describe("LogsViewer SavedViewsDropdown — clearing the applied view", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("clicking the applied view clears it instead of re-applying it", () => {
+    const { handlers } = renderDropdown({ selectedSavedViewId: "errors" });
+
+    openMenu();
+    fireEvent.click(rowFor("Errors only"));
+
+    expect(handlers.onClear).toHaveBeenCalledTimes(1);
+    expect(handlers.onSelect).not.toHaveBeenCalled();
+    expect(isMenuOpen()).toBe(false);
+  });
+
+  test("the explicit Clear view row clears and closes the menu", () => {
+    const { handlers } = renderDropdown({ selectedSavedViewId: "errors" });
+
+    openMenu();
+    fireEvent.click(rowFor(CLEAR_LABEL));
+
+    expect(handlers.onClear).toHaveBeenCalledTimes(1);
+    expect(handlers.onSelect).not.toHaveBeenCalled();
+    expect(isMenuOpen()).toBe(false);
+  });
+
+  test("the Clear view row is offered only while a view is applied", () => {
+    renderDropdown({ selectedSavedViewId: null });
+
+    openMenu();
+
+    expect(screen.queryByText(CLEAR_LABEL)).toBeNull();
+  });
+
+  test("a selection pointing at a view that no longer exists offers no clear row", () => {
+    renderDropdown({ selectedSavedViewId: "deleted-view" });
+
+    openMenu();
+
+    expect(screen.queryByText(CLEAR_LABEL)).toBeNull();
+  });
+
+  test("clicking a different view still applies it", () => {
+    const { handlers } = renderDropdown({ selectedSavedViewId: "errors" });
+
+    openMenu();
+    fireEvent.click(rowFor("Checkout service (default)"));
+
+    expect(handlers.onSelect).toHaveBeenCalledWith("checkout");
+    expect(handlers.onClear).not.toHaveBeenCalled();
+  });
+
+  test("aria-pressed tracks which view is applied", () => {
+    renderDropdown({ selectedSavedViewId: "errors" });
+
+    openMenu();
+
+    expect(rowFor("Errors only")).toHaveAttribute("aria-pressed", "true");
+    expect(rowFor("Checkout service (default)")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  test("without onClear the applied view is still merely re-applied", () => {
+    const { handlers } = renderDropdown({
+      selectedSavedViewId: "errors",
+      onClear: undefined,
+    });
+
+    openMenu();
+
+    expect(screen.queryByText(CLEAR_LABEL)).toBeNull();
+
+    fireEvent.click(rowFor("Errors only"));
+
+    expect(handlers.onSelect).toHaveBeenCalledWith("errors");
+    expect(handlers.onClear).not.toHaveBeenCalled();
+  });
+
+  test("Edit and Delete on the applied row do not clear it", () => {
+    const { handlers } = renderDropdown({ selectedSavedViewId: "errors" });
+
+    openMenu();
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]!);
+
+    expect(handlers.onEdit).toHaveBeenCalledWith("errors");
+
+    openMenu();
+    fireEvent.click(screen.getAllByRole("button", { name: "Delete" })[0]!);
+
+    expect(handlers.onDelete).toHaveBeenCalledWith("errors");
+    expect(handlers.onClear).not.toHaveBeenCalled();
+  });
+});
+
+/*
+ * The toolbar is the only thing that mounts the dropdown in the real logs
+ * explorer, so a clear handler that never reaches it is the same bug wearing
+ * a different hat. This renders the real toolbar rather than asserting on
+ * prop names.
+ */
+describe("LogsViewerToolbar hands the clear handler to the dropdown", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("Clear view appears in the toolbar's dropdown and fires the host handler", () => {
+    const onClearSavedView: () => void = jest.fn();
+    const onSavedViewSelect: (viewId: string) => void = jest.fn();
+
+    render(
+      <LogsViewerToolbar
+        resultCount={12}
+        savedViews={VIEWS}
+        selectedSavedViewId="errors"
+        onSavedViewSelect={onSavedViewSelect}
+        onClearSavedView={onClearSavedView}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Errors only/ }));
+    fireEvent.click(screen.getByRole("button", { name: CLEAR_LABEL }));
+
+    expect(onClearSavedView).toHaveBeenCalledTimes(1);
+    expect(onSavedViewSelect).not.toHaveBeenCalled();
+  });
+
+  test("a toolbar without a clear handler shows no Clear view row", () => {
+    render(
+      <LogsViewerToolbar
+        resultCount={12}
+        savedViews={VIEWS}
+        selectedSavedViewId="errors"
+        onSavedViewSelect={jest.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Errors only/ }));
+
+    expect(screen.queryByText(CLEAR_LABEL)).toBeNull();
+  });
+});
+
+/*
+ * The sidebar lists the same saved views a second time. It has no room for a
+ * "Clear view" row, so the toggle is the whole affordance there — and without
+ * it the sidebar quietly stayed a one-way door even after the dropdown was
+ * fixed.
+ */
+describe("LogsFacetSidebar toggles the applied view off", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function renderSidebar(
+    onClearSavedView: (() => void) | undefined,
+    onSavedViewSelect: (viewId: string) => void,
+  ): void {
+    render(
+      <LogsFacetSidebar
+        facetData={{}}
+        isLoading={false}
+        serviceMap={{}}
+        onIncludeFilter={jest.fn()}
+        onExcludeFilter={jest.fn()}
+        savedViews={VIEWS}
+        selectedSavedViewId="errors"
+        onSavedViewSelect={onSavedViewSelect}
+        onClearSavedView={onClearSavedView}
+      />,
+    );
+  }
+
+  test("clicking the applied view clears it", () => {
+    const onClearSavedView: () => void = jest.fn();
+    const onSavedViewSelect: (viewId: string) => void = jest.fn();
+
+    renderSidebar(onClearSavedView, onSavedViewSelect);
+    fireEvent.click(screen.getByRole("button", { name: /Errors only/ }));
+
+    expect(onClearSavedView).toHaveBeenCalledTimes(1);
+    expect(onSavedViewSelect).not.toHaveBeenCalled();
+  });
+
+  test("clicking another view still applies it", () => {
+    const onClearSavedView: () => void = jest.fn();
+    const onSavedViewSelect: (viewId: string) => void = jest.fn();
+
+    renderSidebar(onClearSavedView, onSavedViewSelect);
+    fireEvent.click(screen.getByRole("button", { name: /Checkout service/ }));
+
+    expect(onSavedViewSelect).toHaveBeenCalledWith("checkout");
+    expect(onClearSavedView).not.toHaveBeenCalled();
+  });
+
+  test("the applied row reports itself as pressed", () => {
+    renderSidebar(jest.fn(), jest.fn());
+
+    expect(screen.getByRole("button", { name: /Errors only/ })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      screen.getByRole("button", { name: /Checkout service/ }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("a sidebar without a clear handler re-applies as before", () => {
+    const onSavedViewSelect: (viewId: string) => void = jest.fn();
+
+    renderSidebar(undefined, onSavedViewSelect);
+    fireEvent.click(screen.getByRole("button", { name: /Errors only/ }));
+
+    expect(onSavedViewSelect).toHaveBeenCalledWith("errors");
+  });
+});

--- a/Common/Tests/UI/Components/LogsViewerClearSavedView.test.tsx
+++ b/Common/Tests/UI/Components/LogsViewerClearSavedView.test.tsx
@@ -1,0 +1,179 @@
+import { LogsSavedViewOption } from "../../../UI/Components/LogsViewer/types";
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * LogsViewer is the container between the logs explorer and the two places a
+ * saved view can be picked — the toolbar dropdown and the facet sidebar. Both
+ * of those are covered directly in LogsSavedViewsDropdown.test.tsx, and the
+ * host's clearSavedView is covered in App/Tests/Dashboard. This file is the
+ * middle link: the passthrough that connects them.
+ *
+ * It is worth its own file because that link is invisible when it breaks.
+ * Deleting `onClearSavedView: props.onClearSavedView` from the toolbar props
+ * object leaves the dropdown rendering, the host handler defined, every other
+ * test green — and the "Clear view" row simply never appears again, which is
+ * the original bug back in place.
+ *
+ * The container loads services and log attributes on mount, so both API
+ * surfaces are mocked out; nothing here depends on what they return beyond
+ * their resolving.
+ */
+
+/*
+ * Declared before jest.mock but dereferenced inside the factories: ts-jest
+ * hoists the jest.mock calls above these initializers, so naming the mocks
+ * directly in a factory would capture undefined.
+ */
+const getListMock: MockFunction = getJestMockFunction();
+const postMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+      getCommonHeaders: () => {
+        return {};
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      post: (...args: Array<any>) => {
+        return postMock(...args);
+      },
+      getFriendlyErrorMessage: (error: Error) => {
+        return error.message;
+      },
+      getFriendlyMessage: (error: Error) => {
+        return error.message;
+      },
+    },
+  };
+});
+
+getListMock.mockImplementation(() => {
+  return Promise.resolve({ data: [], count: 0, skip: 0, limit: 0 });
+});
+
+postMock.mockImplementation(() => {
+  return Promise.resolve({ data: {} });
+});
+
+// Imported after the mock so the container picks the mocked ModelAPI up.
+import LogsViewer from "../../../UI/Components/LogsViewer/LogsViewer";
+
+const VIEWS: Array<LogsSavedViewOption> = [
+  { id: "errors", name: "Errors only" },
+  { id: "checkout", name: "Checkout service", isDefault: true },
+];
+
+const CLEAR_LABEL: string = "Clear view";
+
+interface RenderedViewer {
+  onClearSavedView: () => void;
+  onSavedViewSelect: (viewId: string) => void;
+}
+
+async function renderViewer(
+  withClearHandler: boolean,
+): Promise<RenderedViewer> {
+  const onClearSavedView: () => void = jest.fn();
+  const onSavedViewSelect: (viewId: string) => void = jest.fn();
+
+  render(
+    <LogsViewer
+      logs={[]}
+      isLoading={false}
+      filterData={{}}
+      onFilterChanged={jest.fn()}
+      facetData={{}}
+      savedViews={VIEWS}
+      selectedSavedViewId="errors"
+      onSavedViewSelect={onSavedViewSelect}
+      {...(withClearHandler ? { onClearSavedView: onClearSavedView } : {})}
+    />,
+  );
+
+  // The container renders a loader until its service lookup resolves.
+  await waitFor(() => {
+    expect(screen.getAllByRole("button").length).toBeGreaterThan(0);
+  });
+
+  return {
+    onClearSavedView: onClearSavedView,
+    onSavedViewSelect: onSavedViewSelect,
+  };
+}
+
+function savedViewButtons(): Array<HTMLElement> {
+  return screen.getAllByRole("button", { name: /Errors only/ });
+}
+
+describe("LogsViewer forwards the clear handler to both saved-view surfaces", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("the toolbar dropdown offers Clear view and it reaches the host", async () => {
+    const { onClearSavedView, onSavedViewSelect } = await renderViewer(true);
+
+    /*
+     * The sidebar lists the view too, so the trigger is picked by its
+     * dropdown, not by name alone: the toolbar's trigger is the one that
+     * opens a panel containing the clear row.
+     */
+    for (const button of savedViewButtons()) {
+      fireEvent.click(button);
+    }
+
+    const clearRow: HTMLElement = screen.getByRole("button", {
+      name: CLEAR_LABEL,
+    });
+
+    fireEvent.click(clearRow);
+
+    expect(onClearSavedView).toHaveBeenCalled();
+    expect(onSavedViewSelect).not.toHaveBeenCalled();
+  });
+
+  test("the facet sidebar's applied row toggles off through the same handler", async () => {
+    const { onClearSavedView, onSavedViewSelect } = await renderViewer(true);
+
+    /*
+     * The sidebar's entry is a plain row rather than a dropdown trigger, so
+     * clicking it is the clear. It is the first of the two matches because
+     * the sidebar renders before the table column.
+     */
+    fireEvent.click(savedViewButtons()[0]!);
+
+    expect(onClearSavedView).toHaveBeenCalled();
+    expect(onSavedViewSelect).not.toHaveBeenCalled();
+  });
+
+  test("a host that passes no clear handler still gets the old behaviour", async () => {
+    const { onClearSavedView, onSavedViewSelect } = await renderViewer(false);
+
+    fireEvent.click(savedViewButtons()[0]!);
+
+    expect(screen.queryByText(CLEAR_LABEL)).toBeNull();
+    expect(onClearSavedView).not.toHaveBeenCalled();
+    expect(onSavedViewSelect).toHaveBeenCalledWith("errors");
+  });
+});

--- a/Common/Tests/UI/Components/TelemetrySavedViewsDropdown.test.tsx
+++ b/Common/Tests/UI/Components/TelemetrySavedViewsDropdown.test.tsx
@@ -1,0 +1,343 @@
+import SavedViewsDropdown, {
+  SavedViewsDropdownProps,
+} from "../../../UI/Components/TelemetryViewer/components/SavedViewsDropdown";
+import { SavedViewOption } from "../../../UI/Components/TelemetryViewer/types";
+import "@testing-library/jest-dom";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  RenderResult,
+} from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Applying a saved view used to be a one-way door. The dropdown drew a
+ * checkmark next to the active view, but clicking that row just re-applied it
+ * and there was no other control that meant "none" — so anyone who picked a
+ * view on the Traces explorer was stuck inside it for the rest of the session
+ * (github.com/OneUptime/oneuptime/issues/3189).
+ *
+ * Two affordances undo it, and both are pinned here: the checkmark behaves
+ * like the checkbox it looks like, and an explicit "Clear view" row spells the
+ * same thing out for anyone who never thinks to click a selected item twice.
+ *
+ * Nothing about deselection is allowed to leak into hosts that do not support
+ * it — a dropdown rendered without onClear must behave exactly as it did
+ * before, which the back-compat block below holds to.
+ */
+
+const VIEWS: Array<SavedViewOption> = [
+  { id: "wb-ims", name: "WB - IMS" },
+  { id: "checkout", name: "Errors in checkout", isDefault: true },
+];
+
+const CLEAR_LABEL: string = "Clear view";
+// Only ever rendered inside the open panel, so it doubles as an "is open" probe.
+const MENU_PROBE: string = "+ Save Current View";
+
+interface Handlers {
+  onSelect: (viewId: string) => void;
+  onClear: () => void;
+  onCreate: () => void;
+  onEdit: (viewId: string) => void;
+  onDelete: (viewId: string) => void;
+  onUpdateCurrent: () => void;
+}
+
+function makeHandlers(): Handlers {
+  return {
+    onSelect: jest.fn(),
+    onClear: jest.fn(),
+    onCreate: jest.fn(),
+    onEdit: jest.fn(),
+    onDelete: jest.fn(),
+    onUpdateCurrent: jest.fn(),
+  };
+}
+
+function renderDropdown(
+  overrides: Partial<SavedViewsDropdownProps> = {},
+  handlers: Handlers = makeHandlers(),
+): { handlers: Handlers; result: RenderResult } {
+  const props: SavedViewsDropdownProps = {
+    savedViews: VIEWS,
+    selectedSavedViewId: null,
+    ...handlers,
+    ...overrides,
+  };
+
+  return { handlers, result: render(<SavedViewsDropdown {...props} />) };
+}
+
+function rerenderDropdown(
+  result: RenderResult,
+  handlers: Handlers,
+  overrides: Partial<SavedViewsDropdownProps>,
+): void {
+  const props: SavedViewsDropdownProps = {
+    savedViews: VIEWS,
+    selectedSavedViewId: null,
+    ...handlers,
+    ...overrides,
+  };
+
+  result.rerender(<SavedViewsDropdown {...props} />);
+}
+
+function trigger(): HTMLElement {
+  return screen.getAllByRole("button")[0]!;
+}
+
+function openMenu(): void {
+  fireEvent.click(trigger());
+}
+
+function isMenuOpen(): boolean {
+  return screen.queryByText(MENU_PROBE) !== null;
+}
+
+function rowFor(name: string): HTMLElement {
+  return screen.getByRole("button", { name: name });
+}
+
+describe("SavedViewsDropdown — clearing the applied view", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("clicking the applied view clears it instead of re-applying it", () => {
+    const { handlers } = renderDropdown({ selectedSavedViewId: "wb-ims" });
+
+    openMenu();
+    fireEvent.click(rowFor("WB - IMS"));
+
+    expect(handlers.onClear).toHaveBeenCalledTimes(1);
+    // Re-applying what is already applied is the behaviour being replaced.
+    expect(handlers.onSelect).not.toHaveBeenCalled();
+    expect(isMenuOpen()).toBe(false);
+  });
+
+  test("the explicit Clear view row clears and closes the menu", () => {
+    const { handlers } = renderDropdown({ selectedSavedViewId: "wb-ims" });
+
+    openMenu();
+    fireEvent.click(rowFor(CLEAR_LABEL));
+
+    expect(handlers.onClear).toHaveBeenCalledTimes(1);
+    expect(handlers.onSelect).not.toHaveBeenCalled();
+    expect(isMenuOpen()).toBe(false);
+  });
+
+  test("the Clear view row is offered only while a view is applied", () => {
+    const { handlers, result } = renderDropdown({ selectedSavedViewId: null });
+
+    openMenu();
+    // Nothing is applied, so there is nothing the row could undo.
+    expect(screen.queryByText(CLEAR_LABEL)).toBeNull();
+
+    rerenderDropdown(result, handlers, { selectedSavedViewId: "checkout" });
+
+    expect(screen.getByText(CLEAR_LABEL)).toBeInTheDocument();
+  });
+
+  test("a selection pointing at a view that no longer exists offers no clear row", () => {
+    /*
+     * The host nulls a stale id in an effect, so for one render the dropdown
+     * holds an id matching nothing. Offering "Clear view" then would be a
+     * button that undoes a view the user cannot see.
+     */
+    renderDropdown({ selectedSavedViewId: "deleted-view" });
+
+    openMenu();
+
+    expect(screen.queryByText(CLEAR_LABEL)).toBeNull();
+  });
+
+  test("clicking a different view still applies it", () => {
+    const { handlers } = renderDropdown({ selectedSavedViewId: "wb-ims" });
+
+    openMenu();
+    fireEvent.click(rowFor("Errors in checkout (default)"));
+
+    expect(handlers.onSelect).toHaveBeenCalledTimes(1);
+    expect(handlers.onSelect).toHaveBeenCalledWith("checkout");
+    expect(handlers.onClear).not.toHaveBeenCalled();
+    expect(isMenuOpen()).toBe(false);
+  });
+
+  test("the trigger drops back to the generic label once the view is cleared", () => {
+    const { handlers, result } = renderDropdown({
+      selectedSavedViewId: "wb-ims",
+    });
+
+    expect(trigger()).toHaveTextContent("WB - IMS");
+
+    // What the host renders after onClear runs.
+    rerenderDropdown(result, handlers, { selectedSavedViewId: null });
+
+    expect(trigger()).toHaveTextContent("Saved Views");
+    expect(trigger()).not.toHaveTextContent("WB - IMS");
+  });
+
+  test("the cleared menu has nothing left to clear", () => {
+    const { handlers, result } = renderDropdown({
+      selectedSavedViewId: "wb-ims",
+    });
+
+    openMenu();
+    fireEvent.click(rowFor(CLEAR_LABEL));
+
+    rerenderDropdown(result, handlers, { selectedSavedViewId: null });
+    openMenu();
+
+    expect(screen.queryByText(CLEAR_LABEL)).toBeNull();
+    expect(handlers.onClear).toHaveBeenCalledTimes(1);
+    // Every row is now selectable again rather than being a toggle-off.
+    expect(rowFor("WB - IMS")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("clearing then picking the same view again re-applies it", () => {
+    const { handlers, result } = renderDropdown({
+      selectedSavedViewId: "wb-ims",
+    });
+
+    openMenu();
+    fireEvent.click(rowFor("WB - IMS"));
+
+    rerenderDropdown(result, handlers, { selectedSavedViewId: null });
+    openMenu();
+    fireEvent.click(rowFor("WB - IMS"));
+
+    expect(handlers.onClear).toHaveBeenCalledTimes(1);
+    expect(handlers.onSelect).toHaveBeenCalledTimes(1);
+    expect(handlers.onSelect).toHaveBeenCalledWith("wb-ims");
+  });
+});
+
+describe("SavedViewsDropdown — the row reports its own state", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("aria-pressed tracks which view is applied", () => {
+    renderDropdown({ selectedSavedViewId: "wb-ims" });
+
+    openMenu();
+
+    expect(rowFor("WB - IMS")).toHaveAttribute("aria-pressed", "true");
+    expect(rowFor("Errors in checkout (default)")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  test("the accessible name is the view name, not the checkmark glyph", () => {
+    renderDropdown({ selectedSavedViewId: "wb-ims" });
+
+    openMenu();
+
+    // "✓ WB - IMS" would be the computed name if the glyph leaked into it.
+    expect(rowFor("WB - IMS")).toBeInTheDocument();
+  });
+
+  test("the default badge is announced as a word, not dropped", () => {
+    /*
+     * The badge is inside the button, so an aria-label of just the view name
+     * would hide "default" from a screen reader while sighted users see it.
+     */
+    renderDropdown({ selectedSavedViewId: null });
+
+    openMenu();
+
+    expect(rowFor("Errors in checkout (default)")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Errors in checkout" }),
+    ).toBeNull();
+  });
+});
+
+describe("SavedViewsDropdown — hosts that do not support clearing", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("no Clear view row is rendered without onClear", () => {
+    renderDropdown({ selectedSavedViewId: "wb-ims", onClear: undefined });
+
+    openMenu();
+
+    expect(screen.queryByText(CLEAR_LABEL)).toBeNull();
+  });
+
+  test("clicking the applied view falls back to re-applying it", () => {
+    const { handlers } = renderDropdown({
+      selectedSavedViewId: "wb-ims",
+      onClear: undefined,
+    });
+
+    openMenu();
+    fireEvent.click(rowFor("WB - IMS"));
+
+    expect(handlers.onSelect).toHaveBeenCalledWith("wb-ims");
+    expect(handlers.onClear).not.toHaveBeenCalled();
+  });
+});
+
+describe("SavedViewsDropdown — the rest of the menu is unaffected", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("Edit on the applied row edits and does not clear", () => {
+    const { handlers } = renderDropdown({ selectedSavedViewId: "wb-ims" });
+
+    openMenu();
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[0]!);
+
+    expect(handlers.onEdit).toHaveBeenCalledWith("wb-ims");
+    expect(handlers.onClear).not.toHaveBeenCalled();
+    expect(handlers.onSelect).not.toHaveBeenCalled();
+  });
+
+  test("Delete on the applied row deletes and does not clear", () => {
+    const { handlers } = renderDropdown({ selectedSavedViewId: "wb-ims" });
+
+    openMenu();
+    fireEvent.click(screen.getAllByRole("button", { name: "Delete" })[0]!);
+
+    expect(handlers.onDelete).toHaveBeenCalledWith("wb-ims");
+    expect(handlers.onClear).not.toHaveBeenCalled();
+  });
+
+  test("Update on the applied row saves over it and does not clear", () => {
+    const { handlers } = renderDropdown({ selectedSavedViewId: "wb-ims" });
+
+    openMenu();
+    fireEvent.click(rowFor("Update"));
+
+    expect(handlers.onUpdateCurrent).toHaveBeenCalledTimes(1);
+    expect(handlers.onClear).not.toHaveBeenCalled();
+  });
+
+  test("Save Current View still creates and does not clear", () => {
+    const { handlers } = renderDropdown({ selectedSavedViewId: "wb-ims" });
+
+    openMenu();
+    fireEvent.click(rowFor(MENU_PROBE));
+
+    expect(handlers.onCreate).toHaveBeenCalledTimes(1);
+    expect(handlers.onClear).not.toHaveBeenCalled();
+  });
+
+  test("an empty view list still renders its empty state and no clear row", () => {
+    renderDropdown({ savedViews: [], selectedSavedViewId: null });
+
+    openMenu();
+
+    expect(screen.getByText("No saved views yet.")).toBeInTheDocument();
+    expect(screen.queryByText(CLEAR_LABEL)).toBeNull();
+  });
+});

--- a/Common/UI/Components/LogsViewer/LogsViewer.tsx
+++ b/Common/UI/Components/LogsViewer/LogsViewer.tsx
@@ -134,6 +134,8 @@ export interface ComponentProps {
   savedViews?: Array<LogsSavedViewOption> | undefined;
   selectedSavedViewId?: string | null;
   onSavedViewSelect?: ((viewId: string) => void) | undefined;
+  // Deselect the active saved view and reset the explorer to its default.
+  onClearSavedView?: (() => void) | undefined;
   onCreateSavedView?: (() => void) | undefined;
   onEditSavedView?: ((viewId: string) => void) | undefined;
   onDeleteSavedView?: ((viewId: string) => void) | undefined;
@@ -1044,6 +1046,7 @@ const LogsViewer: FunctionComponent<ComponentProps> = (
     savedViews: props.savedViews,
     selectedSavedViewId: props.selectedSavedViewId,
     onSavedViewSelect: props.onSavedViewSelect,
+    onClearSavedView: props.onClearSavedView,
     onCreateSavedView: props.onCreateSavedView,
     onEditSavedView: props.onEditSavedView,
     onDeleteSavedView: props.onDeleteSavedView,
@@ -1157,6 +1160,7 @@ const LogsViewer: FunctionComponent<ComponentProps> = (
               savedViews={props.savedViews}
               selectedSavedViewId={props.selectedSavedViewId}
               onSavedViewSelect={props.onSavedViewSelect}
+              onClearSavedView={props.onClearSavedView}
               onFacetSearchChange={props.onFacetSearchChange}
             />
           )}

--- a/Common/UI/Components/LogsViewer/components/LogsFacetSidebar.tsx
+++ b/Common/UI/Components/LogsViewer/components/LogsFacetSidebar.tsx
@@ -30,6 +30,8 @@ export interface LogsFacetSidebarProps {
   savedViews?: Array<LogsSavedViewOption> | undefined;
   selectedSavedViewId?: string | null | undefined;
   onSavedViewSelect?: ((viewId: string) => void) | undefined;
+  // Toggling the applied view off here has to clear it, not re-apply it.
+  onClearSavedView?: (() => void) | undefined;
   /*
    * Called (debounced) when typing in a resource facet's search box. Lets
    * the parent re-issue the facets request with the typed text scoped to
@@ -283,7 +285,13 @@ const LogsFacetSidebar: FunctionComponent<LogsFacetSidebarProps> = (
                         ? "bg-indigo-50 text-indigo-700"
                         : "text-gray-600 hover:bg-gray-50 hover:text-gray-800"
                     }`}
+                    aria-pressed={isSelected}
                     onClick={() => {
+                      if (isSelected && props.onClearSavedView) {
+                        props.onClearSavedView();
+                        return;
+                      }
+
                       props.onSavedViewSelect?.(view.id);
                     }}
                   >

--- a/Common/UI/Components/LogsViewer/components/LogsViewerToolbar.tsx
+++ b/Common/UI/Components/LogsViewer/components/LogsViewerToolbar.tsx
@@ -28,6 +28,7 @@ export interface LogsViewerToolbarProps {
   savedViews?: Array<LogsSavedViewOption> | undefined;
   selectedSavedViewId?: string | null | undefined;
   onSavedViewSelect?: ((viewId: string) => void) | undefined;
+  onClearSavedView?: (() => void) | undefined;
   onEditSavedView?: ((viewId: string) => void) | undefined;
   onDeleteSavedView?: ((viewId: string) => void) | undefined;
   onUpdateCurrentSavedView?: (() => void) | undefined;
@@ -153,6 +154,7 @@ const LogsViewerToolbar: FunctionComponent<LogsViewerToolbarProps> = (
             savedViews={props.savedViews}
             selectedSavedViewId={props.selectedSavedViewId}
             onSelect={props.onSavedViewSelect}
+            onClear={props.onClearSavedView}
             onCreate={props.onCreateSavedView}
             onEdit={props.onEditSavedView}
             onDelete={props.onDeleteSavedView}

--- a/Common/UI/Components/LogsViewer/components/SavedViewsDropdown.tsx
+++ b/Common/UI/Components/LogsViewer/components/SavedViewsDropdown.tsx
@@ -6,6 +6,13 @@ export interface SavedViewsDropdownProps {
   savedViews: Array<LogsSavedViewOption>;
   selectedSavedViewId?: string | null | undefined;
   onSelect: (viewId: string) => void;
+  /*
+   * Deselect the active view and return the explorer to its unfiltered
+   * default. Without this the checkmark is a one-way door: a view can be
+   * applied but never taken off. Hosts that cannot express "no view" simply
+   * omit it, and both clear affordances below disappear with it.
+   */
+  onClear?: (() => void) | undefined;
   onCreate?: (() => void) | undefined;
   onEdit?: ((viewId: string) => void) | undefined;
   onDelete?: ((viewId: string) => void) | undefined;
@@ -26,6 +33,17 @@ const SavedViewsDropdown: FunctionComponent<SavedViewsDropdownProps> = (
       return view.id === props.selectedSavedViewId;
     },
   );
+
+  /*
+   * Clearing is only offered once a view is actually applied — an inert
+   * "Clear view" row sitting above an unfiltered explorer says nothing.
+   */
+  const canClear: boolean = Boolean(props.onClear && selectedView);
+
+  const clearSelection: () => void = (): void => {
+    props.onClear?.();
+    setIsComponentVisible(false);
+  };
 
   return (
     <div className="relative" ref={ref}>
@@ -48,6 +66,31 @@ const SavedViewsDropdown: FunctionComponent<SavedViewsDropdownProps> = (
 
       {isComponentVisible && (
         <div className="absolute left-0 z-20 mt-2 w-72 rounded-lg border border-gray-200 bg-white shadow-xl">
+          {/*
+           * Explicit way back to the unfiltered explorer. Clicking the
+           * applied view also clears it, but that is only discoverable once
+           * you try it — this row says so out loud.
+           */}
+          {canClear && (
+            <div className="border-b border-gray-100 py-1">
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-gray-50"
+                onClick={clearSelection}
+              >
+                <span
+                  className="w-4 shrink-0 text-center text-xs text-gray-400"
+                  aria-hidden="true"
+                >
+                  ✕
+                </span>
+                <span className="truncate text-sm text-gray-600">
+                  Clear view
+                </span>
+              </button>
+            </div>
+          )}
+
           {/* View list */}
           <div className="max-h-72 overflow-y-auto py-1">
             {props.savedViews.length === 0 && (
@@ -69,13 +112,35 @@ const SavedViewsDropdown: FunctionComponent<SavedViewsDropdownProps> = (
                   <button
                     type="button"
                     className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                    /*
+                     * Spelled out so the row announces as its own name: the
+                     * ✓ is aria-hidden, and the "default" tag reads as a word
+                     * rather than a bare token appended to the view name.
+                     */
+                    aria-label={
+                      view.isDefault ? `${view.name} (default)` : view.name
+                    }
+                    /*
+                     * The checkmark reads as a checkbox, so the row behaves
+                     * like one: clicking the applied view takes it off again
+                     * instead of silently re-applying what is already on.
+                     */
+                    aria-pressed={isSelected}
                     onClick={() => {
+                      if (isSelected && props.onClear) {
+                        clearSelection();
+                        return;
+                      }
+
                       props.onSelect(view.id);
                       setIsComponentVisible(false);
                     }}
                   >
                     {/* Checkmark for selected */}
-                    <span className="w-4 shrink-0 text-center text-xs">
+                    <span
+                      className="w-4 shrink-0 text-center text-xs"
+                      aria-hidden="true"
+                    >
                       {isSelected ? (
                         <span className="text-indigo-600">✓</span>
                       ) : (

--- a/Common/UI/Components/TelemetryViewer/components/SavedViewsDropdown.tsx
+++ b/Common/UI/Components/TelemetryViewer/components/SavedViewsDropdown.tsx
@@ -8,6 +8,13 @@ export interface SavedViewsDropdownProps {
   savedViews: Array<SavedViewOption>;
   selectedSavedViewId?: string | null | undefined;
   onSelect: (viewId: string) => void;
+  /*
+   * Deselect the active view and return the explorer to its unfiltered
+   * default. Without this the checkmark is a one-way door: a view can be
+   * applied but never taken off. Hosts that cannot express "no view" simply
+   * omit it, and both clear affordances below disappear with it.
+   */
+  onClear?: (() => void) | undefined;
   onCreate?: (() => void) | undefined;
   onEdit?: ((viewId: string) => void) | undefined;
   onDelete?: ((viewId: string) => void) | undefined;
@@ -31,6 +38,17 @@ const SavedViewsDropdown: FunctionComponent<SavedViewsDropdownProps> = (
       return view.id === props.selectedSavedViewId;
     },
   );
+
+  /*
+   * Clearing is only offered once a view is actually applied — an inert
+   * "Clear view" row sitting above an unfiltered explorer says nothing.
+   */
+  const canClear: boolean = Boolean(props.onClear && selectedView);
+
+  const clearSelection: () => void = (): void => {
+    props.onClear?.();
+    setIsComponentVisible(false);
+  };
 
   return (
     <div className="relative" ref={ref}>
@@ -77,6 +95,31 @@ const SavedViewsDropdown: FunctionComponent<SavedViewsDropdownProps> = (
             props.dropdownAlignment === "right" ? "right-0" : "left-0"
           }`}
         >
+          {/*
+           * Explicit way back to the unfiltered explorer. Clicking the
+           * applied view also clears it, but that is only discoverable once
+           * you try it — this row says so out loud.
+           */}
+          {canClear && (
+            <div className="border-b border-gray-100 py-1">
+              <button
+                type="button"
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-gray-50"
+                onClick={clearSelection}
+              >
+                <span
+                  className="w-4 shrink-0 text-center text-xs text-gray-400"
+                  aria-hidden="true"
+                >
+                  ✕
+                </span>
+                <span className="truncate text-sm text-gray-600">
+                  Clear view
+                </span>
+              </button>
+            </div>
+          )}
+
           {/* View list */}
           <div className="max-h-72 overflow-y-auto py-1">
             {props.savedViews.length === 0 && (
@@ -98,13 +141,35 @@ const SavedViewsDropdown: FunctionComponent<SavedViewsDropdownProps> = (
                   <button
                     type="button"
                     className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                    /*
+                     * Spelled out so the row announces as its own name: the
+                     * ✓ is aria-hidden, and the "default" tag reads as a word
+                     * rather than a bare token appended to the view name.
+                     */
+                    aria-label={
+                      view.isDefault ? `${view.name} (default)` : view.name
+                    }
+                    /*
+                     * The checkmark reads as a checkbox, so the row behaves
+                     * like one: clicking the applied view takes it off again
+                     * instead of silently re-applying what is already on.
+                     */
+                    aria-pressed={isSelected}
                     onClick={() => {
+                      if (isSelected && props.onClear) {
+                        clearSelection();
+                        return;
+                      }
+
                       props.onSelect(view.id);
                       setIsComponentVisible(false);
                     }}
                   >
                     {/* Checkmark for selected */}
-                    <span className="w-4 shrink-0 text-center text-xs">
+                    <span
+                      className="w-4 shrink-0 text-center text-xs"
+                      aria-hidden="true"
+                    >
                       {isSelected ? (
                         <span className="text-indigo-600">✓</span>
                       ) : (


### PR DESCRIPTION
Fixes #3189.

## The bug

Picking a saved view on the Traces explorer was a one-way door. The dropdown drew a checkmark next to the active view, but clicking that row only re-applied it, and nothing in the menu meant "none" — so the only way back to the unfiltered explorer was a hard reload.

The same dropdown backs the Metrics list and the Metric Explorer, and the logs explorer carries its own copy of it, so all four had the bug.

## The fix

Both dropdowns take an optional `onClear` and offer two ways out:

- **clicking the applied row toggles it off** — the checkmark reads as a checkbox, so it now behaves like one;
- **an explicit "Clear view" row** appears above the list while a view is applied, for anyone who never thinks to click a selected item twice.

Hosts that pass no `onClear` keep the old behaviour exactly. The logs facet sidebar, which lists the same views a second time down the left-hand side, toggles off the same way (no room for a row there).

Clearing returns the explorer to the state a fresh page load produces. For traces and metrics that is `applyState({})` — every field each host reads already substitutes its own default when absent. Two things had to change for that to be true:

- **page size** was the one field guarded by `if (state.pageSize)`, so a cleared explorer kept the view's page size and, through the URL mirror, went on advertising `?pageSize=` in the query string. It now defaults like every neighbouring field, which also keeps the existing tolerance for views saved before page size was captured.
- **logs** need more than an empty state, so the reset lives in a new `buildClearedLogsViewState`. It keeps what belongs to the page rather than to the view — the host scope, and a pinned incident/alert window or a controlled cursor — and resets the window, facet chips, page, page size, sort and columns.

Deliberately unchanged: clearing does not re-arm the once-only default-view auto-apply. Re-applying the project default the moment the user dismissed it is what they were trying to get away from.

Also picked up along the way: the row's accessible name was `"✓ WB - IMS default"`; the glyph is now `aria-hidden` and the badge reads as `"WB - IMS (default)"`.

## Tests

Behaviour is driven for real in Common (jsdom + RTL), wiring is read from source in App, which has no renderer — the convention `SavedViewFilterTupleWiring.test.ts` already established.

| File | What it holds |
| --- | --- |
| `Common/Tests/UI/Components/TelemetrySavedViewsDropdown.test.tsx` | 18 cases: toggle-off, the Clear view row, the row only appearing while a view is applied, a stale selection id, re-selecting after a clear, `aria-pressed`, the trigger label, back-compat without `onClear`, and Edit/Delete/Update/Save not clearing |
| `Common/Tests/UI/Components/LogsSavedViewsDropdown.test.tsx` | the same for the logs dropdown, plus the real `LogsViewerToolbar` and `LogsFacetSidebar` |
| `Common/Tests/UI/Components/LogsViewerClearSavedView.test.tsx` | the `LogsViewer` container passthrough — deleting either forwarding line turns the Clear view row off silently, and these are what catch it |
| `App/Tests/Dashboard/LogsViewerDefaults.test.ts` | `buildClearedLogsViewState`: rolling vs pinned window, scope survival, no leftover predicates, fresh chip map, page/page size/sort/columns, and that the returned columns are a copy of the shared default |
| `App/Tests/Dashboard/SavedViewClearWiring.test.ts` | host wiring, per-host empty-state defaults, no field left behind a truthiness guard, and a check that **derives the fields clearing must reset from the fields applying a view writes**, so a tenth field added to apply fails here until clear undoes it too |

Verified by mutation: dropping a setter from `clearSavedView`, or either `LogsViewer` forwarding line, turns the relevant tests red.

`npm run fix` is clean, `tsc` passes in Common and App, and the full suites are green — App `Tests/Dashboard` 5387 tests / 147 suites, Common `Tests/UI/Components` 2099 tests / 124 suites.

Not verified against a running stack: this is a dropdown interaction, and the tests render the real components and click the real handlers rather than a stand-in.