### PR TITLE
fix(network-map): paint widget labels at the weight their box was measured for

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardNetworkMapComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardNetworkMapComponent.tsx
@@ -625,6 +625,19 @@ const DashboardNetworkMapComponentElement: FunctionComponent<ComponentProps> = (
                           textAnchor={marker.labelPlacement.textAnchor}
                           fill="var(--ou-text-secondary, #4b5563)"
                           fontSize={NETWORK_MAP_LABEL_FONT_SIZE / zoom}
+                          /*
+                           * The weight LABEL_CHAR_WIDTH was measured at, and
+                           * the weight the full-page map paints — see the
+                           * note beside that constant for why a renderer may
+                           * go lighter but never heavier.
+                           *
+                           * It earns its place here on legibility alone: this
+                           * map squeezes the whole world into a dashboard
+                           * tile, so its names land well UNDER
+                           * NETWORK_MAP_LABEL_FONT_SIZE on screen, and a 400
+                           * at that size greys out against a coastline.
+                           */
+                          fontWeight={600}
                           stroke="var(--ou-surface-primary, #ffffff)"
                           strokeWidth={2.5 / zoom}
                           paintOrder="stroke"

--- a/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkSite/SiteMapViewModel.ts
@@ -617,12 +617,23 @@ export const truncateMarkerLabel: (value: string) => string = (
   }
   return `${name.slice(0, MAX_MARKER_LABEL_CHARS - 1).trimEnd()}…`;
 };
+
 /*
  * Label geometry, in screen units — the same units screenRadius is in.
- * The character width is an approximation of a 600-weight sans glyph at
- * LABEL_FONT_SIZE; it only has to be close enough to decide overlap, and
- * erring slightly wide means the map pushes a name further out rather than
- * printing two on top of each other.
+ *
+ * The character width approximates a 600-weight Inter glyph at
+ * LABEL_FONT_SIZE. Measured over a spread of real site names, Inter averages
+ * 5.31 units per character at weight 600 and 5.20 at 400, so 5.6 carries
+ * roughly five percent of slack over the weight the maps actually paint. It
+ * only has to be close enough to decide overlap.
+ *
+ * That slack is the contract, and it runs ONE WAY. A renderer may paint a
+ * name lighter or smaller than this was measured for and the reservation
+ * still holds — it simply reserved more than it needed. Painting it heavier
+ * or larger draws outside the box the collision pass approved, and an
+ * overlap the pass approved looks deliberate rather than crowded. Both maps
+ * therefore paint LABEL_FONT_SIZE at weight 600, and the two invariant
+ * suites pin them there.
  */
 export const LABEL_FONT_SIZE: number = 10;
 const LABEL_CHAR_WIDTH: number = 5.6;

--- a/App/Tests/Dashboard/NetworkMapWidgetInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkMapWidgetInvariants.test.ts
@@ -409,6 +409,32 @@ describe("Network Map widget rendering", () => {
   });
 
   /*
+   * The collision pass reserves each name a box built from LABEL_FONT_SIZE
+   * and a per-character width measured at weight 600. Painting the name
+   * LIGHTER or SMALLER than that is safe — the box was simply bigger than it
+   * needed to be. Painting it heavier or larger draws outside the box the
+   * pass approved, and an overlap the pass approved reads as deliberate
+   * rather than crowded. So this pins the two values that are not free.
+   *
+   * The widget ran at the browser default of 400 for a while. That was safe,
+   * but it also meant the same element rendered differently on the two maps,
+   * and this map paints BELOW LABEL_FONT_SIZE — it squeezes the world into a
+   * tile — which is exactly where a 400 greys out.
+   */
+  test("names are painted at the size and weight their box was measured for", () => {
+    const labelText: string = readApp(...WIDGET)
+      .split("textAnchor={marker.labelPlacement.textAnchor}")[1]!
+      .split("{marker.label}")[0]!;
+
+    expect(labelText).toContain(
+      "fontSize={NETWORK_MAP_LABEL_FONT_SIZE / zoom}",
+    );
+    expect(labelText).toContain("fontWeight={600}");
+    // The shared constant or nothing — a second literal is how they drift.
+    expect(labelText).not.toContain("fontSize={10");
+  });
+
+  /*
    * Sites on near-identical coordinates used to lose every name but the
    * first: there was nowhere to put the others that was clear of the
    * neighbours. They are now pushed off their marker instead, which is only

--- a/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
+++ b/App/Tests/Dashboard/NetworkSitePageInvariants.test.ts
@@ -919,6 +919,24 @@ describe("SiteGeoMap", () => {
   });
 
   /*
+   * The other half of the reservation. The collision pass sizes each box
+   * from LABEL_FONT_SIZE and a per-character width measured at weight 600;
+   * painting the name lighter or smaller than that is safe, but heavier or
+   * larger draws outside the box the pass approved — an overlap that then
+   * looks deliberate. The widget suite pins the same two values.
+   */
+  test("names are painted at the size and weight their box was measured for", () => {
+    const labelText: string = source
+      .split("textAnchor={labelPlacement.textAnchor}")[1]!
+      .split("{marker.label}")[0]!;
+
+    expect(labelText).toContain("fontSize={LABEL_FONT_SIZE / zoom}");
+    expect(labelText).toContain("fontWeight={600}");
+    // The shared constant or nothing — a second literal is how they drift.
+    expect(labelText).not.toContain("fontSize={10");
+  });
+
+  /*
    * A name moved off its marker without saying so is the same lie a
    * displaced marker would be. The thread is the whole licence for pushing
    * it — and a name still sitting against its marker must not get one,


### PR DESCRIPTION
Follow-up to #3198, which made both maps draw each name in the box the collision pass reserved. This settles the one thing left over: the two renderers painted that box at different font weights.

## What was inconsistent

`LABEL_CHAR_WIDTH` is documented as an approximation of a **600**-weight glyph at `LABEL_FONT_SIZE`, and `SiteGeoMap` paints its names at 600. The dashboard widget set no `fontWeight` at all, so it painted at the browser default of **400** — reserving boxes measured for a heavier face than the one it drew.

## Measured, not guessed

Against the Inter variable font the app actually ships (`InterVariable.woff2`, applied to `*` in `views/index.ejs`), over a spread of real site names at 10px:

| | avg advance per character |
|---|---|
| weight 400 | 5.203 |
| weight 600 | 5.309 |
| `LABEL_CHAR_WIDTH` | 5.6 |

So the weight gap is **2.04%**, against an estimate that already carries ~5% of slack over 600. The widget was never at risk of overlap, and could not have been: **lighter than the reservation is structurally the safe direction**, permanently. The premise that this was a latent correctness problem does not survive the measurement.

## Why change it anyway

Legibility, at the sizes this particular map paints. The widget squeezes the whole 960-unit world into a dashboard tile, so its names land well *under* `LABEL_FONT_SIZE` on screen — roughly 7px on a wide tile, 5px on a half-width one. A 400-weight grey at that size greys out against a coastline; 600 holds. The map that renders smallest wanted the heavier face most, which is the opposite of what the "widget is quieter than the full page" reading would suggest.

It also means the same element renders the same way on both maps, and at the weight the shared geometry is calibrated for.

## The invariant, now pinned on both renderers

Painting a name **larger or heavier** than its reservation draws outside the box the collision pass approved — and an overlap the pass approved reads as deliberate rather than crowded. That is the direction that is not free, so both suites now pin the size and the weight of their own label `<text>`:

- `NetworkMapWidgetInvariants.test.ts` → "names are painted at the size and weight their box was measured for"
- `NetworkSitePageInvariants.test.ts` → same, for `SiteGeoMap`

Both assertions are scoped to the label element itself (the widget already uses `fontWeight={600}` for the count inside a marker, so an unscoped match would have passed vacuously). I verified both fail when the `fontWeight` is removed, and pass when it is restored.

The reasoning is written down beside `LABEL_CHAR_WIDTH`, where the calibration lives, including the measured numbers and the one-way slack rule — so the next person to look at this does not have to re-measure.

## Verified

- `App/Tests/Dashboard/` — 5403 passing, 145 suites
- `npx tsc --noEmit` in `App` and in `App/FeatureSet/Dashboard`
- `npx eslint --fix` over every changed file
