### PR TITLE
feat(dashboard): show user emails alongside name and avatar

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/NotificationLogs/CallLogsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NotificationLogs/CallLogsTable.tsx
@@ -116,6 +116,8 @@ const CallLogsTable: FunctionComponent<CallLogsTableProps> = (
           statusMessage: true,
           user: {
             name: true,
+            email: true,
+            profilePictureId: true,
           },
         }}
         cardProps={{

--- a/App/FeatureSet/Dashboard/src/Components/NotificationLogs/EmailLogsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NotificationLogs/EmailLogsTable.tsx
@@ -116,6 +116,8 @@ const EmailLogsTable: FunctionComponent<EmailLogsTableProps> = (
           statusMessage: true,
           user: {
             name: true,
+            email: true,
+            profilePictureId: true,
           },
         }}
         cardProps={{

--- a/App/FeatureSet/Dashboard/src/Components/NotificationLogs/PushLogsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NotificationLogs/PushLogsTable.tsx
@@ -124,6 +124,8 @@ const PushLogsTable: FunctionComponent<PushLogsTableProps> = (
           deviceName: true,
           user: {
             name: true,
+            email: true,
+            profilePictureId: true,
           },
         }}
         cardProps={{

--- a/App/FeatureSet/Dashboard/src/Components/NotificationLogs/SmsLogsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NotificationLogs/SmsLogsTable.tsx
@@ -143,6 +143,8 @@ const SmsLogsTable: FunctionComponent<SmsLogsTableProps> = (
           statusMessage: true,
           user: {
             name: true,
+            email: true,
+            profilePictureId: true,
           },
         }}
         cardProps={{

--- a/App/FeatureSet/Dashboard/src/Components/NotificationLogs/TelegramLogsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NotificationLogs/TelegramLogsTable.tsx
@@ -156,6 +156,8 @@ const TelegramLogsTable: FunctionComponent<TelegramLogsTableProps> = (
           telegramMessageId: true,
           user: {
             name: true,
+            email: true,
+            profilePictureId: true,
           },
         }}
         cardProps={{

--- a/App/FeatureSet/Dashboard/src/Components/NotificationLogs/WebhookLogsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NotificationLogs/WebhookLogsTable.tsx
@@ -139,6 +139,8 @@ const WebhookLogsTable: FunctionComponent<WebhookLogsTableProps> = (
           statusMessage: true,
           user: {
             name: true,
+            email: true,
+            profilePictureId: true,
           },
         }}
         cardProps={{

--- a/App/FeatureSet/Dashboard/src/Components/NotificationLogs/WhatsAppLogsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NotificationLogs/WhatsAppLogsTable.tsx
@@ -156,6 +156,8 @@ const WhatsAppLogsTable: FunctionComponent<WhatsAppLogsTableProps> = (
           whatsAppMessageId: true,
           user: {
             name: true,
+            email: true,
+            profilePictureId: true,
           },
         }}
         cardProps={{

--- a/App/FeatureSet/Dashboard/src/Components/NotificationLogs/WorkspaceLogsTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NotificationLogs/WorkspaceLogsTable.tsx
@@ -181,6 +181,8 @@ const WorkspaceLogsTable: FunctionComponent<WorkspaceLogsTableProps> = (
           channelId: true,
           user: {
             name: true,
+            email: true,
+            profilePictureId: true,
           },
         }}
         cardProps={{

--- a/App/FeatureSet/Dashboard/src/Components/Team/TeamComplianceStatusTable.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Team/TeamComplianceStatusTable.tsx
@@ -122,6 +122,11 @@ const TeamComplianceStatusTable: React.ForwardRefExoticComponent<
           return (
             <UserElement
               user={{
+                /*
+                 * Without _id the avatar route cannot be built and the row
+                 * falls back to the blank profile picture.
+                 */
+                _id: item.userId,
                 name: item.userName,
                 email: item.userEmail,
                 profilePictureId: item.userProfilePictureId,

--- a/App/FeatureSet/Dashboard/src/Components/User/User.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/User/User.tsx
@@ -1,6 +1,6 @@
 import BaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import Route from "Common/Types/API/Route";
-import { JSONObject } from "Common/Types/JSON";
+import { JSONObject, JSONValue } from "Common/Types/JSON";
 import JSONFunctions from "Common/Types/JSONFunctions";
 import Image from "Common/UI/Components/Image/Image";
 import BlankProfilePic from "Common/UI/Images/users/blank-profile.svg";
@@ -16,7 +16,35 @@ export interface ComponentProps {
   suffixClassName?: string | undefined;
   usernameClassName?: string | undefined;
   prefixClassName?: string | undefined;
+  emailClassName?: string | undefined;
+  hideEmail?: boolean | undefined;
 }
+
+/*
+ * A user can arrive here as a model instance (Name / Email objects), as the
+ * serialized form of one ({_type: "Email", value: "..."}) or as a plain object
+ * a caller hand-built from an API response (a bare string). Calling toString()
+ * on the serialized shape yields "[object Object]", so unwrap it first.
+ */
+type ReadableValueFunction = (value: JSONValue | undefined) => string;
+
+const readableValue: ReadableValueFunction = (
+  value: JSONValue | undefined,
+): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  if (typeof value === "object") {
+    const serialized: JSONValue | undefined = (value as JSONObject)["value"];
+
+    if ((value as JSONObject)["_type"] && serialized !== undefined) {
+      return readableValue(serialized);
+    }
+  }
+
+  return value.toString();
+};
 
 const UserElement: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
@@ -92,16 +120,27 @@ const UserElement: FunctionComponent<ComponentProps> = (
   }
 
   if (user) {
+    const name: string = readableValue(user["name"]);
+    const email: string = readableValue(user["email"]);
+
+    /*
+     * The name line already falls back to the email when there is no name, so
+     * showing the email underneath as well would print it twice.
+     */
+    const showEmail: boolean = Boolean(
+      !props.hideEmail && name && email && name !== email,
+    );
+
     return (
       <div className="flex">
         <div>
           <Image
             className="h-8 w-8 rounded-full"
             imageUrl={profileImageRoute}
-            alt={user["name"]?.toString() || "User"}
+            alt={name || "User"}
           />
         </div>
-        <div className="mt-1 mr-1 ml-3">
+        <div className="mt-1 mr-1 ml-3 min-w-0">
           <div>
             <span
               className={props.prefixClassName ? props.prefixClassName : ""}
@@ -110,12 +149,20 @@ const UserElement: FunctionComponent<ComponentProps> = (
             </span>{" "}
             <span
               className={props.usernameClassName ? props.usernameClassName : ""}
-            >{`${
-              (user["name"]?.toString() as string) ||
-              (user["email"]?.toString() as string) ||
-              ""
-            }`}</span>{" "}
+            >{`${name || email}`}</span>{" "}
           </div>
+          {showEmail && (
+            <div
+              data-testid="user-email"
+              className={
+                props.emailClassName
+                  ? props.emailClassName
+                  : "truncate text-xs text-gray-500"
+              }
+            >
+              {email}
+            </div>
+          )}
         </div>
         {props.suffix && (
           <div>

--- a/App/FeatureSet/Dashboard/src/Components/User/Users.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/User/Users.tsx
@@ -9,6 +9,8 @@ export interface ComponentProps {
   suffixClassName?: string | undefined;
   usernameClassName?: string | undefined;
   prefixClassName?: string | undefined;
+  emailClassName?: string | undefined;
+  hideEmail?: boolean | undefined;
 }
 
 const UsersElement: FunctionComponent<ComponentProps> = (
@@ -30,6 +32,8 @@ const UsersElement: FunctionComponent<ComponentProps> = (
             suffixClassName={props.suffixClassName}
             usernameClassName={props.usernameClassName}
             prefixClassName={props.prefixClassName}
+            emailClassName={props.emailClassName}
+            hideEmail={props.hideEmail}
           />
         );
       })}

--- a/Common/Tests/App/Dashboard/OnCallReadinessSurfaces.test.tsx
+++ b/Common/Tests/App/Dashboard/OnCallReadinessSurfaces.test.tsx
@@ -520,6 +520,24 @@ type SummaryJsonFunction = (
 ) => JSONObject;
 
 /*
+ * The login addresses the fixture responders sign in with, read off the
+ * fixtures rather than retyped so a renamed responder cannot quietly drop out
+ * of the masking guard's exemption list and start passing for the wrong
+ * reason. These are NOT notification-method identifiers: those all live in
+ * ALL_RAW_IDENTIFIERS and must never render.
+ */
+const ALL_LOGIN_EMAILS: Array<string> = [
+  READY_USER,
+  PARTIAL_USER,
+  UNREACHABLE_USER,
+  TWO_TEAM_USER,
+  CHANNELS_OFF_USER,
+  DISTINCT_KIND_USER,
+].map((user: JSONObject) => {
+  return user["userEmail"] as string;
+});
+
+/*
  * `isFallbackEnabled` defaults to true because that is the product default
  * (disableOnCallNotificationFallback is false unless an admin sets it), and every
  * test that does not name it is asserting behaviour in the ordinary project. The
@@ -3527,10 +3545,41 @@ describe("no unmasked identifier reaches the DOM", () => {
     /*
      * The scan above catches the planted values by name; these two catch the
      * shape, so an identifier this file never thought of is caught too.
+     *
+     * Login addresses are removed first. A responder row shows the person's
+     * login email under their name, and that address is legitimate here for
+     * the same reason the mail draft below may carry it: an admin already
+     * reads it on Settings > Users and on the team page. What must never
+     * appear is a notification-method identifier, which is what the
+     * by-name scan above and the shape scan below still catch - substituting
+     * a method identifier for one of these addresses fails both.
      */
-    expect(container.textContent || "").not.toMatch(UNMASKED_EMAIL_PATTERN);
-    expect(container.textContent || "").not.toMatch(UNMASKED_PHONE_PATTERN);
+    let text: string = container.textContent || "";
+
+    for (const loginEmail of ALL_LOGIN_EMAILS) {
+      text = text.split(loginEmail).join("");
+    }
+
+    expect(text).not.toMatch(UNMASKED_EMAIL_PATTERN);
+    expect(text).not.toMatch(UNMASKED_PHONE_PATTERN);
   };
+
+  /*
+   * The other half of the exemption above: the login email is not merely
+   * tolerated on these surfaces, it is meant to be there, so that two
+   * responders who share a name are still tellable apart. If this stops
+   * holding, the exemption is protecting nothing and should go.
+   */
+  test("the responder row names the person by their login email", async () => {
+    respondWith(summaryJson(ALL_THREE_USERS));
+
+    const container: HTMLElement = await renderPolicyCard();
+
+    await screen.findByText("Zed Unreachable");
+
+    expect(container.textContent).toContain("zed.unreachable@example.com");
+    expect(container.textContent).toContain("jane.partial@example.com");
+  });
 
   test("the policy card renders masked identifiers only", async () => {
     respondWith(summaryJson(ALL_THREE_USERS));

--- a/Common/Tests/App/Dashboard/UserElementEmail.test.tsx
+++ b/Common/Tests/App/Dashboard/UserElementEmail.test.tsx
@@ -1,0 +1,447 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * The bundler turns an .svg import into a URL string; jest's asset mapper
+ * turns it into {}, which UserElement then feeds to Route.fromString and
+ * which throws. Hand it the string shape the browser actually gets.
+ */
+const BLANK_PROFILE_PIC: string = "/blank-profile.svg";
+
+jest.mock("../../../UI/Images/users/blank-profile.svg", () => {
+  return BLANK_PROFILE_PIC;
+});
+
+/*
+ * UserElement is the one user row the dashboard renders everywhere - tables,
+ * logs, on-call surfaces, "archived by" cells - so it is the single place the
+ * email had to be added. The email was already on the wire at almost every
+ * call site; the component simply dropped it, using it only as a stand-in when
+ * the name was missing.
+ *
+ * What these pin: the email is a line of its own beneath the name, it is never
+ * printed twice, and neither the avatar nor the "OneUptime" automation row
+ * regressed while adding it.
+ */
+
+import UserElement from "../../../../App/FeatureSet/Dashboard/src/Components/User/User";
+import UsersElement from "../../../../App/FeatureSet/Dashboard/src/Components/User/Users";
+import User from "../../../Models/DatabaseModels/User";
+import Email from "../../../Types/Email";
+import Name from "../../../Types/Name";
+
+const USER_ID: string = "00000000-0000-4000-8000-000000000001";
+const OTHER_USER_ID: string = "00000000-0000-4000-8000-000000000002";
+
+type BuildUserModelFunction = (spec: {
+  id?: string | undefined;
+  name?: string | undefined;
+  email?: string | undefined;
+}) => User;
+
+const buildUserModel: BuildUserModelFunction = (spec: {
+  id?: string | undefined;
+  name?: string | undefined;
+  email?: string | undefined;
+}): User => {
+  const user: User = new User();
+
+  if (spec.id) {
+    user._id = spec.id;
+  }
+
+  if (spec.name) {
+    user.name = new Name(spec.name);
+  }
+
+  if (spec.email) {
+    user.email = new Email(spec.email);
+  }
+
+  return user;
+};
+
+type AvatarFunction = () => HTMLImageElement;
+
+const avatar: AvatarFunction = (): HTMLImageElement => {
+  const images: Array<HTMLElement> = screen.getAllByRole("img");
+  return images[0] as HTMLImageElement;
+};
+
+describe("UserElement", () => {
+  describe("showing the email", () => {
+    /*
+     * The whole point of the change. If this fails, every user row in the
+     * dashboard is back to a bare name with no way to tell two people with the
+     * same name apart.
+     */
+    test("shows the email underneath the name", () => {
+      render(
+        <UserElement
+          user={{ _id: USER_ID, name: "Jane Doe", email: "jane@acme.com" }}
+        />,
+      );
+
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+      expect(screen.getByTestId("user-email")).toHaveTextContent(
+        "jane@acme.com",
+      );
+    });
+
+    test("puts the email on a line of its own, not inside the name", () => {
+      render(
+        <UserElement
+          user={{ _id: USER_ID, name: "Jane Doe", email: "jane@acme.com" }}
+        />,
+      );
+
+      expect(screen.getByText("Jane Doe")).not.toHaveTextContent(
+        "jane@acme.com",
+      );
+    });
+
+    test("reads the email off a User model, not just a plain object", () => {
+      render(
+        <UserElement
+          user={buildUserModel({
+            id: USER_ID,
+            name: "Jane Doe",
+            email: "jane@acme.com",
+          })}
+        />,
+      );
+
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+      expect(screen.getByTestId("user-email")).toHaveTextContent(
+        "jane@acme.com",
+      );
+    });
+
+    /*
+     * Callers that hand-build a user out of an API response pass the
+     * serialized form of an Email. toString() on that shape yields
+     * "[object Object]", which is what the reader would otherwise see.
+     */
+    test("unwraps a serialized Email rather than printing [object Object]", () => {
+      render(
+        <UserElement
+          user={{
+            _id: USER_ID,
+            name: "Jane Doe",
+            email: { _type: "Email", value: "jane@acme.com" },
+          }}
+        />,
+      );
+
+      expect(screen.getByTestId("user-email")).toHaveTextContent(
+        "jane@acme.com",
+      );
+      expect(screen.queryByText(/object Object/)).not.toBeInTheDocument();
+    });
+
+    test("unwraps a serialized Name the same way", () => {
+      render(
+        <UserElement
+          user={{
+            _id: USER_ID,
+            name: { _type: "Name", value: "Jane Doe" },
+            email: "jane@acme.com",
+          }}
+        />,
+      );
+
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+      expect(screen.queryByText(/object Object/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("not showing it twice", () => {
+    /*
+     * The name line already falls back to the email. Rendering the subline
+     * unconditionally would print the address twice on every user who has not
+     * set a name - which is most users right after they are invited.
+     */
+    test("keeps an email-only user to a single line", () => {
+      render(<UserElement user={{ _id: USER_ID, email: "jane@acme.com" }} />);
+
+      expect(screen.getByText("jane@acme.com")).toBeInTheDocument();
+      expect(screen.queryByTestId("user-email")).not.toBeInTheDocument();
+    });
+
+    test("adds no empty line for a user with a name but no email", () => {
+      render(<UserElement user={{ _id: USER_ID, name: "Jane Doe" }} />);
+
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+      expect(screen.queryByTestId("user-email")).not.toBeInTheDocument();
+    });
+
+    test("does not repeat an address stored as both the name and the email", () => {
+      render(
+        <UserElement
+          user={{
+            _id: USER_ID,
+            name: "jane@acme.com",
+            email: "jane@acme.com",
+          }}
+        />,
+      );
+
+      expect(screen.getByText("jane@acme.com")).toBeInTheDocument();
+      expect(screen.queryByTestId("user-email")).not.toBeInTheDocument();
+    });
+
+    test("treats an empty-string name as no name", () => {
+      render(
+        <UserElement
+          user={{ _id: USER_ID, name: "", email: "jane@acme.com" }}
+        />,
+      );
+
+      expect(screen.getByText("jane@acme.com")).toBeInTheDocument();
+      expect(screen.queryByTestId("user-email")).not.toBeInTheDocument();
+    });
+
+    test("treats an empty-string email as no email", () => {
+      render(
+        <UserElement user={{ _id: USER_ID, name: "Jane Doe", email: "" }} />,
+      );
+
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+      expect(screen.queryByTestId("user-email")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("the profile picture", () => {
+    test("points the avatar at the user's own picture", () => {
+      render(
+        <UserElement
+          user={{ _id: USER_ID, name: "Jane Doe", email: "jane@acme.com" }}
+        />,
+      );
+
+      expect(avatar()).toHaveAttribute(
+        "src",
+        `/api/user/profile-picture/${USER_ID}`,
+      );
+    });
+
+    test("builds the avatar from a User model's id", () => {
+      render(
+        <UserElement
+          user={buildUserModel({
+            id: OTHER_USER_ID,
+            name: "John Roe",
+            email: "john@acme.com",
+          })}
+        />,
+      );
+
+      expect(avatar()).toHaveAttribute(
+        "src",
+        `/api/user/profile-picture/${OTHER_USER_ID}`,
+      );
+    });
+
+    test("accepts `id` as well as `_id`", () => {
+      render(
+        <UserElement
+          user={{ id: USER_ID, name: "Jane Doe", email: "jane@acme.com" }}
+        />,
+      );
+
+      expect(avatar()).toHaveAttribute(
+        "src",
+        `/api/user/profile-picture/${USER_ID}`,
+      );
+    });
+
+    test("falls back to the blank picture, and still shows name and email, when there is no id", () => {
+      render(
+        <UserElement user={{ name: "Jane Doe", email: "jane@acme.com" }} />,
+      );
+
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+      expect(screen.getByTestId("user-email")).toHaveTextContent(
+        "jane@acme.com",
+      );
+      expect(avatar()).toHaveAttribute("src", BLANK_PROFILE_PIC);
+    });
+
+    test("survives an id that is not a valid ObjectID", () => {
+      render(
+        <UserElement
+          user={{ _id: "not-an-id", name: "Jane Doe", email: "jane@acme.com" }}
+        />,
+      );
+
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+      expect(screen.getByTestId("user-email")).toHaveTextContent(
+        "jane@acme.com",
+      );
+    });
+
+    test("names the avatar after the user so it is not an unlabelled image", () => {
+      render(
+        <UserElement
+          user={{ _id: USER_ID, name: "Jane Doe", email: "jane@acme.com" }}
+        />,
+      );
+
+      expect(avatar()).toHaveAttribute("alt", "Jane Doe");
+    });
+  });
+
+  describe("callers that want the compact row back", () => {
+    test("hideEmail drops the second line", () => {
+      render(
+        <UserElement
+          user={{ _id: USER_ID, name: "Jane Doe", email: "jane@acme.com" }}
+          hideEmail={true}
+        />,
+      );
+
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+      expect(screen.queryByTestId("user-email")).not.toBeInTheDocument();
+    });
+
+    test("emailClassName replaces the default styling", () => {
+      render(
+        <UserElement
+          user={{ _id: USER_ID, name: "Jane Doe", email: "jane@acme.com" }}
+          emailClassName="text-sm text-red-500"
+        />,
+      );
+
+      expect(screen.getByTestId("user-email")).toHaveClass("text-sm");
+      expect(screen.getByTestId("user-email")).not.toHaveClass("text-xs");
+    });
+
+    test("keeps the default styling when no override is given", () => {
+      render(
+        <UserElement
+          user={{ _id: USER_ID, name: "Jane Doe", email: "jane@acme.com" }}
+        />,
+      );
+
+      expect(screen.getByTestId("user-email")).toHaveClass("text-gray-500");
+    });
+  });
+
+  describe("rows that are not a person", () => {
+    /*
+     * An empty user object means the action was taken by automation. That row
+     * has no email and must not grow one.
+     */
+    test("still reads OneUptime for an automated action", () => {
+      render(<UserElement user={{}} />);
+
+      expect(screen.getByText("OneUptime")).toBeInTheDocument();
+      expect(screen.queryByTestId("user-email")).not.toBeInTheDocument();
+    });
+
+    /*
+     * A missing user reads as automation too - there is nobody to name and, in
+     * particular, no email to invent.
+     */
+    test("reads OneUptime for a null user", () => {
+      render(<UserElement user={null} />);
+
+      expect(screen.getByText("OneUptime")).toBeInTheDocument();
+      expect(screen.queryByTestId("user-email")).not.toBeInTheDocument();
+    });
+
+    test("reads OneUptime for an absent user", () => {
+      render(<UserElement />);
+
+      expect(screen.getByText("OneUptime")).toBeInTheDocument();
+      expect(screen.queryByTestId("user-email")).not.toBeInTheDocument();
+    });
+
+    test("gives the automation avatar an alt so it is not unlabelled", () => {
+      render(<UserElement user={{}} />);
+
+      expect(avatar()).toHaveAttribute("alt", "Automation");
+    });
+  });
+
+  describe("prefix and suffix", () => {
+    test("keeps the prefix beside the name and the email below it", () => {
+      render(
+        <UserElement
+          user={{ _id: USER_ID, name: "Jane Doe", email: "jane@acme.com" }}
+          prefix="Assigned to"
+        />,
+      );
+
+      expect(screen.getByText("Assigned to")).toBeInTheDocument();
+      expect(screen.getByTestId("user-email")).toHaveTextContent(
+        "jane@acme.com",
+      );
+    });
+
+    test("keeps rendering the suffix alongside the email", () => {
+      render(
+        <UserElement
+          user={{ _id: USER_ID, name: "Jane Doe", email: "jane@acme.com" }}
+          suffix="(on call)"
+        />,
+      );
+
+      expect(screen.getByText("(on call)")).toBeInTheDocument();
+      expect(screen.getByTestId("user-email")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("UsersElement", () => {
+  test("shows the email for every user in the list", () => {
+    render(
+      <UsersElement
+        users={[
+          buildUserModel({
+            id: USER_ID,
+            name: "Jane Doe",
+            email: "jane@acme.com",
+          }),
+          buildUserModel({
+            id: OTHER_USER_ID,
+            name: "John Roe",
+            email: "john@acme.com",
+          }),
+        ]}
+      />,
+    );
+
+    const emails: Array<HTMLElement> = screen.getAllByTestId("user-email");
+
+    expect(emails).toHaveLength(2);
+    expect(emails[0]).toHaveTextContent("jane@acme.com");
+    expect(emails[1]).toHaveTextContent("john@acme.com");
+  });
+
+  test("forwards hideEmail down to each row", () => {
+    render(
+      <UsersElement
+        users={[
+          buildUserModel({
+            id: USER_ID,
+            name: "Jane Doe",
+            email: "jane@acme.com",
+          }),
+        ]}
+        hideEmail={true}
+      />,
+    );
+
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    expect(screen.queryByTestId("user-email")).not.toBeInTheDocument();
+  });
+
+  test("still says so when there is nobody to list", () => {
+    render(<UsersElement users={[]} />);
+
+    expect(screen.getByText("No users.")).toBeInTheDocument();
+  });
+});

--- a/Common/Tests/App/Dashboard/UserEmailCallSites.test.tsx
+++ b/Common/Tests/App/Dashboard/UserEmailCallSites.test.tsx
@@ -1,0 +1,284 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import React, { ReactElement } from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * UserElement can only show an email the caller actually asked the API for,
+ * and an avatar it was given an id for. Two families of call sites failed one
+ * of those and would have kept rendering a bare name after the component
+ * change:
+ *
+ *   - the notification-log tables passed `selectMoreFields={{user: {name}}}`.
+ *     BaseModelTable's getSelectFields ASSIGNS selectMoreFields over the
+ *     select the columns built, rather than merging into it, so the narrower
+ *     one won and only the name was ever fetched.
+ *   - the team compliance table hand-builds its user object and left out the
+ *     id, so the avatar route could not be built at all.
+ *
+ * Both are invisible in a screenshot of a seeded dev project (short names, a
+ * default avatar) and silent in every other suite, so they are pinned here.
+ */
+
+const BLANK_PROFILE_PIC: string = "/blank-profile.svg";
+
+jest.mock("../../../UI/Images/users/blank-profile.svg", () => {
+  return BLANK_PROFILE_PIC;
+});
+
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: () => {
+        return [];
+      },
+      getProjectPermissions: () => {
+        return [];
+      },
+      getGlobalPermissions: () => {
+        return [];
+      },
+    },
+  };
+});
+
+/*
+ * The real ModelTable would drag in the facet bar, URL state and the pager.
+ * What matters here is the select it was handed and what its User column does
+ * with a row, so it is replaced by a recorder.
+ */
+type CapturedTableProps = {
+  selectMoreFields?: Record<string, unknown> | undefined;
+  columns: Array<{
+    title?: string | undefined;
+    field?: Record<string, unknown> | undefined;
+    getElement?: ((item: Record<string, unknown>) => ReactElement) | undefined;
+  }>;
+};
+
+let capturedTableProps: CapturedTableProps | null = null;
+
+jest.mock("../../../UI/Components/ModelTable/ModelTable", () => {
+  return {
+    __esModule: true,
+    default: (props: CapturedTableProps) => {
+      capturedTableProps = props;
+      return null;
+    },
+  };
+});
+
+import CallLogsTable from "../../../../App/FeatureSet/Dashboard/src/Components/NotificationLogs/CallLogsTable";
+import EmailLogsTable from "../../../../App/FeatureSet/Dashboard/src/Components/NotificationLogs/EmailLogsTable";
+import PushLogsTable from "../../../../App/FeatureSet/Dashboard/src/Components/NotificationLogs/PushLogsTable";
+import SmsLogsTable from "../../../../App/FeatureSet/Dashboard/src/Components/NotificationLogs/SmsLogsTable";
+import TelegramLogsTable from "../../../../App/FeatureSet/Dashboard/src/Components/NotificationLogs/TelegramLogsTable";
+import WebhookLogsTable from "../../../../App/FeatureSet/Dashboard/src/Components/NotificationLogs/WebhookLogsTable";
+import WhatsAppLogsTable from "../../../../App/FeatureSet/Dashboard/src/Components/NotificationLogs/WhatsAppLogsTable";
+import WorkspaceLogsTable from "../../../../App/FeatureSet/Dashboard/src/Components/NotificationLogs/WorkspaceLogsTable";
+import TeamComplianceStatusTable from "../../../../App/FeatureSet/Dashboard/src/Components/Team/TeamComplianceStatusTable";
+import API from "../../../UI/Utils/API/API";
+import ModelAPI from "../../../UI/Utils/ModelAPI/ModelAPI";
+import ProjectUtil from "../../../UI/Utils/Project";
+import ObjectID from "../../../Types/ObjectID";
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "00000000-0000-4000-8000-000000000001",
+);
+const TEAM_ID: ObjectID = new ObjectID("00000000-0000-4000-8000-000000000002");
+const USER_ID: string = "00000000-0000-4000-8000-000000000003";
+
+const NOTIFICATION_LOG_TABLES: Array<{
+  name: string;
+  Component: React.FunctionComponent<any>;
+}> = [
+  { name: "CallLogsTable", Component: CallLogsTable },
+  { name: "EmailLogsTable", Component: EmailLogsTable },
+  { name: "PushLogsTable", Component: PushLogsTable },
+  { name: "SmsLogsTable", Component: SmsLogsTable },
+  { name: "TelegramLogsTable", Component: TelegramLogsTable },
+  { name: "WebhookLogsTable", Component: WebhookLogsTable },
+  { name: "WhatsAppLogsTable", Component: WhatsAppLogsTable },
+  { name: "WorkspaceLogsTable", Component: WorkspaceLogsTable },
+];
+
+type UserColumnFunction = () => CapturedTableProps["columns"][0];
+
+const userColumn: UserColumnFunction = (): CapturedTableProps["columns"][0] => {
+  const column: CapturedTableProps["columns"][0] | undefined =
+    capturedTableProps?.columns.find(
+      (candidate: CapturedTableProps["columns"][0]) => {
+        return candidate.title === "User";
+      },
+    );
+
+  if (!column) {
+    throw new Error(
+      `No "User" column. Columns: ${(capturedTableProps?.columns || [])
+        .map((candidate: CapturedTableProps["columns"][0]) => {
+          return candidate.title;
+        })
+        .join(", ")}`,
+    );
+  }
+
+  return column;
+};
+
+describe("notification log tables", () => {
+  beforeEach(() => {
+    capturedTableProps = null;
+    jest.spyOn(ProjectUtil, "getCurrentProjectId").mockReturnValue(PROJECT_ID);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe.each(NOTIFICATION_LOG_TABLES)(
+    "$name",
+    ({ Component }: { Component: React.FunctionComponent<any> }) => {
+      beforeEach(() => {
+        render(<Component />);
+      });
+
+      /*
+       * selectMoreFields overwrites the column's user select rather than
+       * merging with it. Narrowing it back to { name } silently drops the
+       * email off the wire and the row goes back to a bare name, with the
+       * column definition still (misleadingly) asking for the email.
+       */
+      test("asks the API for the email, not just the name", () => {
+        expect(capturedTableProps!.selectMoreFields!["user"]).toEqual(
+          expect.objectContaining({ email: true }),
+        );
+      });
+
+      test("asks the API for the profile picture too", () => {
+        expect(capturedTableProps!.selectMoreFields!["user"]).toEqual(
+          expect.objectContaining({ profilePictureId: true }),
+        );
+      });
+
+      /*
+       * The two selects have to agree: whichever one wins, the column's
+       * getElement must have the fields it renders.
+       */
+      test("selects the same user fields in the column and in selectMoreFields", () => {
+        expect(capturedTableProps!.selectMoreFields!["user"]).toEqual(
+          userColumn().field!["user"],
+        );
+      });
+
+      test("renders the name, the email and the avatar for a log row", () => {
+        render(
+          userColumn().getElement!({
+            user: {
+              _id: USER_ID,
+              name: "Jane Doe",
+              email: "jane@acme.com",
+            },
+          }),
+        );
+
+        expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+        expect(screen.getByTestId("user-email")).toHaveTextContent(
+          "jane@acme.com",
+        );
+        expect(screen.getAllByRole("img")[0]).toHaveAttribute(
+          "src",
+          `/api/user/profile-picture/${USER_ID}`,
+        );
+      });
+
+      test("still renders a dash for a log row with no user", () => {
+        render(userColumn().getElement!({}));
+
+        expect(screen.getByText("-")).toBeInTheDocument();
+      });
+    },
+  );
+});
+
+describe("team compliance status table", () => {
+  const complianceResponse: {
+    teamId: string;
+    teamName: string;
+    complianceSettings: Array<{ ruleType: string; enabled: boolean }>;
+    userComplianceStatuses: Array<{
+      userId: string;
+      userName: string;
+      userEmail: string;
+      isCompliant: boolean;
+      nonCompliantRules: Array<{ ruleType: string; reason: string }>;
+    }>;
+  } = {
+    teamId: TEAM_ID.toString(),
+    teamName: "On-Call",
+    complianceSettings: [
+      { ruleType: "HasNotificationEmailMethod", enabled: true },
+    ],
+    userComplianceStatuses: [
+      {
+        userId: USER_ID,
+        userName: "Jane Doe",
+        userEmail: "jane@acme.com",
+        isCompliant: false,
+        nonCompliantRules: [
+          {
+            ruleType: "HasNotificationEmailMethod",
+            reason: "No email notification method",
+          },
+        ],
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    jest.spyOn(ModelAPI, "getCommonHeaders").mockReturnValue({});
+    jest
+      .spyOn(API, "get")
+      .mockResolvedValue({ data: complianceResponse } as never);
+
+    render(<TeamComplianceStatusTable teamId={TEAM_ID} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("shows the member's email beside their name", () => {
+    expect(screen.getByTestId("user-email")).toHaveTextContent("jane@acme.com");
+  });
+
+  /*
+   * The row is hand-built from the compliance payload. Without the id the
+   * avatar route cannot be built and every member falls back to the blank
+   * picture, which reads as "nobody has a photo" rather than as a bug.
+   */
+  test("builds the avatar from the member's own id", () => {
+    expect(screen.getAllByRole("img")[0]).toHaveAttribute(
+      "src",
+      `/api/user/profile-picture/${USER_ID}`,
+    );
+  });
+
+  test("still shows why the member is non-compliant", () => {
+    expect(screen.getByText("Non-Compliant")).toBeInTheDocument();
+    expect(
+      screen.getByText(/No email notification method/),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

`UserElement` is the user row the dashboard renders nearly everywhere — tables, notification logs, on-call surfaces, "archived by" cells — and it showed only a name. Two people with the same name were indistinguishable, and the email was **already on the wire** at almost every call site: the component used it only as a stand-in when the name was missing.

It now renders the email as a second line beneath the name, alongside the existing avatar.

- Where there is no name, the email stays on the first line as before, so it is never printed twice.
- The automation row (`OneUptime`) is untouched.
- `hideEmail` and `emailClassName` are available for callers that need the compact row back.

## Call sites that needed more than the shared component

- **The eight notification-log tables** passed `selectMoreFields={{user: {name}}}`. `BaseModelTable`'s `getSelectFields` *assigns* `selectMoreFields` over the select the columns built rather than merging into it, so the narrower one won and only the name was ever fetched — the avatar on those tables has been blank for the same reason. Both selects now agree.
- **The team compliance table** hand-builds its user object and left out the id, so the avatar route could not be built and every member fell back to the blank picture.

`UserElement` also now unwraps the serialized `{_type, value}` form of `Name`/`Email` that callers hand-building a user from an API response pass; it used to render those as `[object Object]`.

## The on-call readiness masking guard

`OnCallReadinessSurfaces.test.tsx` has a deliberate guard that no unmasked identifier reaches the DOM. It has two scans:

- a **by-name** scan over notification-method identifiers (email, phone, telegram, webhook) — these must never render, and still never do;
- a **shape** scan that additionally caught *any* email, which the responder row now legitimately shows.

That file's own mail-draft test already calls the login address legitimate here — *"the login email an admin can already read on every other screen"*. So the shape scan was narrowed rather than the feature dropped: login addresses are read off the fixtures (not retyped, so a renamed responder cannot silently drop out) and excluded from the shape scan only. Substituting a method identifier for one of them still fails both scans. A positive test was added pinning that the responder row does show the login email, so the exemption cannot end up protecting nothing.

## Tests

Two new suites, 71 tests:

- `Common/Tests/App/Dashboard/UserElementEmail.test.tsx` — the email line, the never-twice cases (email-only user, name-equals-email, empty strings), the avatar (`_id`, `id`, `User` model, no id, invalid ObjectID), serialized `Name`/`Email`, `hideEmail`/`emailClassName`, the automation row, prefix/suffix, and `UsersElement` forwarding.
- `Common/Tests/App/Dashboard/UserEmailCallSites.test.tsx` — parameterized over all eight notification-log tables (both selects agree and carry `email`/`profilePictureId`; the column renders name + email + avatar; a user-less row still renders `-`), plus the team compliance table end-to-end with a mocked API.

Verified these fail without the change: **34 of 43 fail** on the stashed tree.

- `Common/Tests/App/Dashboard`: 42 suites / 1295 tests pass.
- `Common/Tests/App` + `Common/Tests/UI`: 205 suites / 4671 tests pass.
- `App` and `Common` both compile clean (`tsc --noEmit`); eslint clean.

Not verified in a browser — the docker-compose dev stack was not running, and standing it up would not have exercised this worktree without a rebuild. The tests assert the rendered DOM structure, classes and avatar `src` directly.