### PR TITLE
Build the workflow record editor from the model schema

### DIFF
--- a/App/Tests/FeatureSet/Workflow/ModelSchema.test.ts
+++ b/App/Tests/FeatureSet/Workflow/ModelSchema.test.ts
@@ -57,6 +57,7 @@ import ModelSchemaAPI, {
 interface Column {
   id: string;
   title: string;
+  description?: string | undefined;
   type: string;
   isRelation: boolean;
   relatedColumns?: Array<Column> | undefined;
@@ -366,6 +367,20 @@ describe("Workflow /model-schema/:tableName column descriptors", () => {
 
     expect(findColumn(columns, "name")?.required).toBe(true);
     expect(findColumn(columns, "description")?.required).toBe(false);
+  });
+
+  /*
+   * The record editor labels each field with the model's own title and prints
+   * this sentence under it, so a column described here with nothing to say
+   * arrives on screen as a bare name. It was produced but asserted nowhere.
+   */
+  test("carries the model's own title and description for a column", async () => {
+    const columns: Array<Column> = await getColumnsFor("Monitor");
+    const name: Column | undefined = findColumn(columns, "name");
+
+    expect(name?.title).toBe("Name");
+    expect(typeof name?.description).toBe("string");
+    expect((name?.description as string).length).toBeGreaterThan(0);
   });
 
   /*

--- a/Common/Tests/Types/Workflow/BaseModelComponents.test.ts
+++ b/Common/Tests/Types/Workflow/BaseModelComponents.test.ts
@@ -203,6 +203,23 @@ describe("the write payload is keyed on columns", () => {
     );
   });
 
+  /*
+   * ArgumentsForm reads the argument id to decide whether the record editor
+   * opens with a blank row for every column a create must supply: "json" is a
+   * create, anything else is an update. An update that opened on six seeded
+   * fields when the builder meant to set one would be a regression nothing else
+   * here would catch, so the two spellings are pinned as a pair.
+   */
+  test('a create\'s payload is "json" and an update\'s is "data", never the reverse', () => {
+    expect(argumentOf(find("-create-one"), "json")).toBeDefined();
+    expect(argumentOf(find("-create-one"), "data")).toBeUndefined();
+
+    for (const idSuffix of ["-update-one", "-update-many"]) {
+      expect(argumentOf(find(idSuffix), "data")).toBeDefined();
+      expect(argumentOf(find(idSuffix), "json")).toBeUndefined();
+    }
+  });
+
   test("no component declares a BaseModel argument", () => {
     /*
      * The bug this whole change came from: the row editor was selected only for

--- a/Common/Tests/UI/Components/Workflow/ColumnEditor/ColumnControl.test.ts
+++ b/Common/Tests/UI/Components/Workflow/ColumnEditor/ColumnControl.test.ts
@@ -1,0 +1,289 @@
+/*
+ * Which control a column gets, and what values that control can hold without
+ * changing them.
+ *
+ * Every `type` here is a TableColumnType *value*, because that is what the
+ * /model-schema endpoint puts on the wire. Several values differ sharply from
+ * the member name that reads like the obvious literal — ShortText is "Text",
+ * ObjectID is "Object ID", LongURL is "URL", JavaScript is "JavaSCript" — and
+ * a mapping written against the names would classify the two most-declared
+ * column types as unknown while every test still passed.
+ */
+
+import TableColumnType from "../../../../../Types/Database/TableColumnType";
+import {
+  columnTypeLabel,
+  controlForColumn,
+  isOfferableColumn,
+  literalFitsControl,
+} from "../../../../../UI/Components/Workflow/ColumnEditor/ColumnControl";
+import { ModelColumnControl } from "../../../../../UI/Components/Workflow/ColumnEditor/ColumnRow";
+import { ModelSchemaColumn } from "../../../../../UI/Components/Workflow/ModelSchema";
+import { describe, expect, test } from "@jest/globals";
+
+type MakeColumnFunction = (
+  overrides: Partial<ModelSchemaColumn>,
+) => ModelSchemaColumn;
+
+const makeColumn: MakeColumnFunction = (
+  overrides: Partial<ModelSchemaColumn>,
+): ModelSchemaColumn => {
+  return {
+    id: "name",
+    title: "Name",
+    type: TableColumnType.ShortText,
+    isRelation: false,
+    ...overrides,
+  };
+};
+
+describe("controlForColumn — totality", () => {
+  test("every column type the database can declare gets a control", () => {
+    const allTypes: Array<string> = Object.values(TableColumnType);
+
+    // Guards against the enum growing and a new type silently becoming a text box.
+    expect(allTypes.length).toBeGreaterThan(0);
+
+    for (const type of allTypes) {
+      const control: ModelColumnControl = controlForColumn(
+        makeColumn({ type: type }),
+      );
+
+      expect(Object.values(ModelColumnControl)).toContain(control);
+    }
+  });
+
+  test("a column the schema does not describe still gets a usable control", () => {
+    /*
+     * The runner accepts column names this endpoint never surfaces, so an
+     * unknown key is typed as text rather than locked as unsupported.
+     */
+    expect(controlForColumn(undefined)).toBe(ModelColumnControl.Text);
+  });
+});
+
+describe("controlForColumn — the wire values, not the member names", () => {
+  test('ShortText, whose value is "Text", is a text box', () => {
+    expect(
+      controlForColumn(makeColumn({ type: TableColumnType.ShortText })),
+    ).toBe(ModelColumnControl.Text);
+    expect(TableColumnType.ShortText).toBe("Text");
+  });
+
+  test('ObjectID, whose value is "Object ID", is an ID box', () => {
+    expect(
+      controlForColumn(makeColumn({ type: TableColumnType.ObjectID })),
+    ).toBe(ModelColumnControl.ObjectId);
+    expect(TableColumnType.ObjectID).toBe("Object ID");
+  });
+
+  test('LongURL, whose value is "URL", is a text box', () => {
+    expect(
+      controlForColumn(makeColumn({ type: TableColumnType.LongURL })),
+    ).toBe(ModelColumnControl.Text);
+    expect(TableColumnType.LongURL).toBe("URL");
+  });
+
+  test("JavaScript, whose value carries a capital S typo, is long text", () => {
+    expect(
+      controlForColumn(makeColumn({ type: TableColumnType.JavaScript })),
+    ).toBe(ModelColumnControl.LongText);
+    expect(TableColumnType.JavaScript).toBe("JavaSCript");
+  });
+
+  test("every numeric flavour is a number box", () => {
+    const numericTypes: Array<string> = [
+      TableColumnType.Number,
+      TableColumnType.SmallNumber,
+      TableColumnType.BigNumber,
+      TableColumnType.PositiveNumber,
+      TableColumnType.SmallPositiveNumber,
+      TableColumnType.BigPositiveNumber,
+      TableColumnType.Port,
+    ];
+
+    for (const type of numericTypes) {
+      expect(controlForColumn(makeColumn({ type: type }))).toBe(
+        ModelColumnControl.Number,
+      );
+    }
+  });
+
+  test("boolean, date and color each get their own control", () => {
+    expect(
+      controlForColumn(makeColumn({ type: TableColumnType.Boolean })),
+    ).toBe(ModelColumnControl.Boolean);
+    expect(controlForColumn(makeColumn({ type: TableColumnType.Date }))).toBe(
+      ModelColumnControl.Date,
+    );
+    expect(controlForColumn(makeColumn({ type: TableColumnType.Color }))).toBe(
+      ModelColumnControl.Color,
+    );
+  });
+
+  test("the long-form text types share one textarea", () => {
+    const longTypes: Array<string> = [
+      TableColumnType.LongText,
+      TableColumnType.VeryLongText,
+      TableColumnType.Description,
+      TableColumnType.Markdown,
+      TableColumnType.HTML,
+      TableColumnType.CSS,
+    ];
+
+    for (const type of longTypes) {
+      expect(controlForColumn(makeColumn({ type: type }))).toBe(
+        ModelColumnControl.LongText,
+      );
+    }
+  });
+
+  test("blobs, nested structures and relations have no row that could hold them", () => {
+    const unsupportedTypes: Array<string> = [
+      TableColumnType.Entity,
+      TableColumnType.EntityArray,
+      TableColumnType.JSON,
+      TableColumnType.Array,
+      TableColumnType.Buffer,
+      TableColumnType.File,
+      TableColumnType.MonitorSteps,
+    ];
+
+    for (const type of unsupportedTypes) {
+      expect(controlForColumn(makeColumn({ type: type }))).toBe(
+        ModelColumnControl.Unsupported,
+      );
+    }
+  });
+
+  test("a relation is unsupported whatever its declared type says", () => {
+    expect(
+      controlForColumn(
+        makeColumn({ type: TableColumnType.ShortText, isRelation: true }),
+      ),
+    ).toBe(ModelColumnControl.Unsupported);
+  });
+
+  test("a single-value enum column is a text box, not a blob", () => {
+    /*
+     * Permission, MonitorType, WorkflowStatus and CustomFieldType are stored as
+     * short text with one enum value in them - TeamPermission.permission ships
+     * example: "ProjectOwner".
+     */
+    const enumTypes: Array<string> = [
+      TableColumnType.Permission,
+      TableColumnType.MonitorType,
+      TableColumnType.WorkflowStatus,
+      TableColumnType.CustomFieldType,
+    ];
+
+    for (const type of enumTypes) {
+      expect(controlForColumn(makeColumn({ type: type }))).toBe(
+        ModelColumnControl.Text,
+      );
+    }
+  });
+});
+
+describe("literalFitsControl", () => {
+  test("an untouched value fits every control", () => {
+    for (const control of Object.values(ModelColumnControl)) {
+      expect(literalFitsControl(control, "")).toBe(true);
+      expect(literalFitsControl(control, undefined)).toBe(true);
+    }
+  });
+
+  test("null does not fit, because an empty box cannot say null", () => {
+    /*
+     * This is the whole reason stored nulls survive a round trip: an empty
+     * control emits "", which a record drops, so a null has to be kept raw.
+     */
+    expect(literalFitsControl(ModelColumnControl.Text, null)).toBe(false);
+    expect(literalFitsControl(ModelColumnControl.Number, null)).toBe(false);
+  });
+
+  test("a number fits a number box and the string spelling of one does not", () => {
+    expect(literalFitsControl(ModelColumnControl.Number, 8080)).toBe(true);
+    expect(literalFitsControl(ModelColumnControl.Number, "8080")).toBe(false);
+    expect(literalFitsControl(ModelColumnControl.Number, "08080")).toBe(false);
+    expect(literalFitsControl(ModelColumnControl.Number, NaN)).toBe(false);
+  });
+
+  test("a boolean fits a boolean control and its string spelling does not", () => {
+    expect(literalFitsControl(ModelColumnControl.Boolean, true)).toBe(true);
+    expect(literalFitsControl(ModelColumnControl.Boolean, false)).toBe(true);
+    expect(literalFitsControl(ModelColumnControl.Boolean, "true")).toBe(false);
+  });
+
+  test("a date fits only as a parseable string", () => {
+    expect(
+      literalFitsControl(ModelColumnControl.Date, "2026-08-15T00:00:00.000Z"),
+    ).toBe(true);
+    expect(literalFitsControl(ModelColumnControl.Date, "not a date")).toBe(
+      false,
+    );
+    expect(literalFitsControl(ModelColumnControl.Date, 1786818975367)).toBe(
+      false,
+    );
+  });
+
+  test("a text control takes strings and nothing else", () => {
+    expect(literalFitsControl(ModelColumnControl.Text, "hello")).toBe(true);
+    expect(literalFitsControl(ModelColumnControl.Text, 12)).toBe(false);
+    expect(literalFitsControl(ModelColumnControl.Text, true)).toBe(false);
+  });
+});
+
+describe("isOfferableColumn", () => {
+  test("an ordinary scalar column is offered", () => {
+    expect(isOfferableColumn(makeColumn({}))).toBe(true);
+  });
+
+  test("a relation is not offered — its scalar ID sibling is", () => {
+    expect(isOfferableColumn(makeColumn({ isRelation: true }))).toBe(false);
+  });
+
+  test("the project column is not offered, because the runner stamps it", () => {
+    expect(isOfferableColumn(makeColumn({ isTenantColumn: true }))).toBe(false);
+  });
+
+  test("a column no row can hold is not offered", () => {
+    expect(
+      isOfferableColumn(makeColumn({ type: TableColumnType.MonitorSteps })),
+    ).toBe(false);
+  });
+});
+
+describe("columnTypeLabel", () => {
+  test("says what kind of value the field wants, in words", () => {
+    expect(columnTypeLabel(makeColumn({ type: TableColumnType.Boolean }))).toBe(
+      "True or false",
+    );
+    expect(columnTypeLabel(makeColumn({ type: TableColumnType.Date }))).toBe(
+      "Date and time",
+    );
+    expect(
+      columnTypeLabel(makeColumn({ type: TableColumnType.ObjectID })),
+    ).toBe("ID");
+    expect(columnTypeLabel(makeColumn({ type: TableColumnType.Port }))).toBe(
+      "Number",
+    );
+    expect(
+      columnTypeLabel(makeColumn({ type: TableColumnType.ShortText })),
+    ).toBe("Text");
+  });
+
+  test("a relation says so rather than naming its inner type", () => {
+    expect(columnTypeLabel(makeColumn({ isRelation: true }))).toBe("Relation");
+  });
+
+  test("an unsupported column names its raw type, which is what has to be written by hand", () => {
+    expect(
+      columnTypeLabel(makeColumn({ type: TableColumnType.MonitorSteps })),
+    ).toBe(TableColumnType.MonitorSteps);
+  });
+
+  test("an unknown column is labelled unknown rather than guessed at", () => {
+    expect(columnTypeLabel(undefined)).toBe("Unknown");
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/ColumnEditor/ColumnOperators.test.ts
+++ b/Common/Tests/UI/Components/Workflow/ColumnEditor/ColumnOperators.test.ts
@@ -1,0 +1,271 @@
+/*
+ * Which comparisons each kind of column offers.
+ *
+ * The rule that matters most here is the one about REPRESENTABLE_OPERATOR_TYPES:
+ * an operator the editor offers but cannot read back would lock the whole value
+ * to the JSON editor the next time the step is opened, which is the worst kind
+ * of bug in this file because it only shows up on the second visit.
+ */
+
+import { ObjectType } from "../../../../../Types/JSON";
+import {
+  DICTIONARY_FILTER_OPERATOR_OPTIONS,
+  DictionaryFilterOperator,
+  DictionaryFilterOperatorOption,
+} from "../../../../../UI/Components/Dictionary/DictionaryFilterOperator";
+import {
+  defaultOperatorForControl,
+  isKnownOperator,
+  operatorLabelFor,
+  operatorsForControl,
+} from "../../../../../UI/Components/Workflow/ColumnEditor/ColumnOperators";
+import { ModelColumnControl } from "../../../../../UI/Components/Workflow/ColumnEditor/ColumnRow";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * A copy of the private list in ModelColumnEditor, kept here deliberately: if
+ * the two ever disagree this test is the thing that notices.
+ */
+const REPRESENTABLE_OBJECT_TYPES: Array<string> = [
+  ObjectType.EqualTo,
+  ObjectType.NotEqual,
+  ObjectType.Search,
+  ObjectType.NotContains,
+  ObjectType.StartsWith,
+  ObjectType.EndsWith,
+  ObjectType.GreaterThan,
+  ObjectType.GreaterThanOrEqual,
+  ObjectType.LessThan,
+  ObjectType.LessThanOrEqual,
+  ObjectType.IsNull,
+  ObjectType.NotNull,
+  ObjectType.Includes,
+  ObjectType.IncludesNone,
+];
+
+/*
+ * The UI operator names and the wire object types are separate vocabularies:
+ * "Contains" serializes as a Search, and the two null checks are named for what
+ * they show rather than for the class behind them.
+ */
+const WIRE_TYPE_FOR_OPERATOR: Record<string, string> = {
+  [DictionaryFilterOperator.EqualTo]: ObjectType.EqualTo,
+  [DictionaryFilterOperator.NotEqual]: ObjectType.NotEqual,
+  [DictionaryFilterOperator.Contains]: ObjectType.Search,
+  [DictionaryFilterOperator.NotContains]: ObjectType.NotContains,
+  [DictionaryFilterOperator.StartsWith]: ObjectType.StartsWith,
+  [DictionaryFilterOperator.EndsWith]: ObjectType.EndsWith,
+  [DictionaryFilterOperator.GreaterThan]: ObjectType.GreaterThan,
+  [DictionaryFilterOperator.GreaterThanOrEqual]: ObjectType.GreaterThanOrEqual,
+  [DictionaryFilterOperator.LessThan]: ObjectType.LessThan,
+  [DictionaryFilterOperator.LessThanOrEqual]: ObjectType.LessThanOrEqual,
+  [DictionaryFilterOperator.IsEmpty]: ObjectType.IsNull,
+  [DictionaryFilterOperator.IsNotEmpty]: ObjectType.NotNull,
+  [DictionaryFilterOperator.IsAnyOf]: ObjectType.Includes,
+  [DictionaryFilterOperator.IsNoneOf]: ObjectType.IncludesNone,
+};
+
+describe("operatorsForControl — nothing offered that cannot be read back", () => {
+  test("every operator offered for every control round-trips through the editor", () => {
+    for (const control of Object.values(ModelColumnControl)) {
+      for (const operator of operatorsForControl(control)) {
+        const wireType: string | undefined = WIRE_TYPE_FOR_OPERATOR[operator];
+
+        expect(wireType).toBeDefined();
+        expect(REPRESENTABLE_OBJECT_TYPES).toContain(wireType);
+      }
+    }
+  });
+
+  test("every operator offered is one the dictionary layer knows how to build", () => {
+    for (const control of Object.values(ModelColumnControl)) {
+      for (const operator of operatorsForControl(control)) {
+        expect(isKnownOperator(operator)).toBe(true);
+      }
+    }
+  });
+
+  test("equals is offered by every control, and is the default", () => {
+    for (const control of Object.values(ModelColumnControl)) {
+      expect(operatorsForControl(control)).toContain(
+        DictionaryFilterOperator.EqualTo,
+      );
+      expect(defaultOperatorForControl(control)).toBe(
+        DictionaryFilterOperator.EqualTo,
+      );
+    }
+  });
+});
+
+describe("operatorsForControl — filtered by what the column can mean", () => {
+  test("a number offers the ordering comparisons and no substring ones", () => {
+    const operators: Array<DictionaryFilterOperator> = operatorsForControl(
+      ModelColumnControl.Number,
+    );
+
+    expect(operators).toContain(DictionaryFilterOperator.GreaterThan);
+    expect(operators).toContain(DictionaryFilterOperator.LessThanOrEqual);
+    expect(operators).not.toContain(DictionaryFilterOperator.Contains);
+    expect(operators).not.toContain(DictionaryFilterOperator.StartsWith);
+  });
+
+  test("an ID offers neither substring nor ordering — both are footguns on a uuid", () => {
+    const operators: Array<DictionaryFilterOperator> = operatorsForControl(
+      ModelColumnControl.ObjectId,
+    );
+
+    expect(operators).toContain(DictionaryFilterOperator.EqualTo);
+    expect(operators).toContain(DictionaryFilterOperator.IsAnyOf);
+    expect(operators).not.toContain(DictionaryFilterOperator.Contains);
+    expect(operators).not.toContain(DictionaryFilterOperator.GreaterThan);
+  });
+
+  test("a boolean offers only the four comparisons that mean anything", () => {
+    expect(operatorsForControl(ModelColumnControl.Boolean)).toEqual([
+      DictionaryFilterOperator.EqualTo,
+      DictionaryFilterOperator.NotEqual,
+      DictionaryFilterOperator.IsEmpty,
+      DictionaryFilterOperator.IsNotEmpty,
+    ]);
+  });
+
+  test("a date offers ordering but not membership lists", () => {
+    const operators: Array<DictionaryFilterOperator> = operatorsForControl(
+      ModelColumnControl.Date,
+    );
+
+    expect(operators).toContain(DictionaryFilterOperator.GreaterThan);
+    expect(operators).not.toContain(DictionaryFilterOperator.IsAnyOf);
+    expect(operators).not.toContain(DictionaryFilterOperator.Contains);
+  });
+
+  test("text keeps every operator it had before this filter existed", () => {
+    const operators: Array<DictionaryFilterOperator> = operatorsForControl(
+      ModelColumnControl.Text,
+    );
+
+    expect(operators).toContain(DictionaryFilterOperator.Contains);
+    expect(operators).toContain(DictionaryFilterOperator.NotContains);
+    expect(operators).toContain(DictionaryFilterOperator.StartsWith);
+    expect(operators).toContain(DictionaryFilterOperator.EndsWith);
+    expect(operators).toContain(DictionaryFilterOperator.IsAnyOf);
+  });
+
+  test("a column no row can hold still gets the widest list, not the narrowest", () => {
+    /*
+     * It is never offered in the picker, but a condition stored against one
+     * still renders, and narrowing that row would rewrite what it does.
+     */
+    expect(operatorsForControl(ModelColumnControl.Unsupported)).toEqual(
+      operatorsForControl(ModelColumnControl.Text),
+    );
+  });
+});
+
+describe("operatorsForControl — the operator already saved is never dropped", () => {
+  test("a contains saved against an ID column stays in that row's list", () => {
+    const operators: Array<DictionaryFilterOperator> = operatorsForControl(
+      ModelColumnControl.ObjectId,
+      DictionaryFilterOperator.Contains,
+    );
+
+    expect(operators).toContain(DictionaryFilterOperator.Contains);
+  });
+
+  test("an operator that is already in the list is not listed twice", () => {
+    const operators: Array<DictionaryFilterOperator> = operatorsForControl(
+      ModelColumnControl.Number,
+      DictionaryFilterOperator.GreaterThan,
+    );
+
+    expect(
+      operators.filter((operator: DictionaryFilterOperator) => {
+        return operator === DictionaryFilterOperator.GreaterThan;
+      }).length,
+    ).toBe(1);
+  });
+
+  test("the returned array is a copy — a caller cannot mutate the shared list", () => {
+    const first: Array<DictionaryFilterOperator> = operatorsForControl(
+      ModelColumnControl.Text,
+    );
+    first.push(DictionaryFilterOperator.GreaterThan);
+
+    expect(operatorsForControl(ModelColumnControl.Text)).not.toContain(
+      DictionaryFilterOperator.GreaterThan,
+    );
+  });
+});
+
+describe("operatorLabelFor", () => {
+  test("a date reads in date language", () => {
+    expect(
+      operatorLabelFor(
+        DictionaryFilterOperator.GreaterThan,
+        ModelColumnControl.Date,
+      ),
+    ).toBe("is after");
+    expect(
+      operatorLabelFor(
+        DictionaryFilterOperator.LessThanOrEqual,
+        ModelColumnControl.Date,
+      ),
+    ).toBe("is on or before");
+  });
+
+  test("a boolean reads as is / is not", () => {
+    expect(
+      operatorLabelFor(
+        DictionaryFilterOperator.EqualTo,
+        ModelColumnControl.Boolean,
+      ),
+    ).toBe("is");
+    expect(
+      operatorLabelFor(
+        DictionaryFilterOperator.NotEqual,
+        ModelColumnControl.Boolean,
+      ),
+    ).toBe("is not");
+  });
+
+  test("the null checks are worded as set / not set on every control", () => {
+    for (const control of Object.values(ModelColumnControl)) {
+      expect(operatorLabelFor(DictionaryFilterOperator.IsEmpty, control)).toBe(
+        "is not set",
+      );
+      expect(
+        operatorLabelFor(DictionaryFilterOperator.IsNotEmpty, control),
+      ).toBe("is set");
+    }
+  });
+
+  test("anything without an override keeps the shared wording", () => {
+    for (const option of DICTIONARY_FILTER_OPERATOR_OPTIONS) {
+      const label: string = operatorLabelFor(
+        option.operator,
+        ModelColumnControl.Text,
+      );
+
+      expect(label.length).toBeGreaterThan(0);
+    }
+
+    expect(
+      operatorLabelFor(
+        DictionaryFilterOperator.Contains,
+        ModelColumnControl.Text,
+      ),
+    ).toBe("contains");
+  });
+
+  test("an unknown operator falls back rather than rendering blank", () => {
+    const label: string = operatorLabelFor(
+      "SomethingElse" as DictionaryFilterOperator,
+      ModelColumnControl.Text,
+    );
+
+    const first: DictionaryFilterOperatorOption =
+      DICTIONARY_FILTER_OPERATOR_OPTIONS[0]!;
+
+    expect(label).toBe(first.label);
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/ColumnEditor/ColumnRow.test.ts
+++ b/Common/Tests/UI/Components/Workflow/ColumnEditor/ColumnRow.test.ts
@@ -1,0 +1,119 @@
+/*
+ * The row model, and the one function every edit goes through.
+ *
+ * changeColumnRow exists because the alternative — a callback per field — is
+ * silently broken in React: two of them fired from one event both close over
+ * the same render's row, and the second overwrites the first. That is not a
+ * theoretical hazard; it made a raw cell impossible to type into while the box
+ * on screen showed the new text, which is the worst shape a bug can take.
+ */
+
+import { DictionaryFilterOperator } from "../../../../../UI/Components/Dictionary/DictionaryFilterOperator";
+import {
+  ColumnValueMode,
+  ModelColumnRow,
+  changeColumnRow,
+  makeColumnRow,
+} from "../../../../../UI/Components/Workflow/ColumnEditor/ColumnRow";
+import { describe, expect, test } from "@jest/globals";
+
+describe("makeColumnRow", () => {
+  test("fills in the defaults an untouched row has", () => {
+    const row: ModelColumnRow = makeColumnRow({ columnId: "name" });
+
+    expect(row.columnId).toBe("name");
+    expect(row.operator).toBe(DictionaryFilterOperator.EqualTo);
+    expect(row.valueMode).toBe(ColumnValueMode.Literal);
+    expect(row.text).toBe("");
+    expect(row.values).toEqual([]);
+    expect(row.isSeeded).toBe(false);
+  });
+
+  test("gives every row an identity of its own", () => {
+    /*
+     * React keys rows by this. Keyed by column name instead, a row whose name
+     * is being typed would be unmounted and remounted on every keystroke, and
+     * the focused input would go with it.
+     */
+    const first: ModelColumnRow = makeColumnRow({ columnId: "name" });
+    const second: ModelColumnRow = makeColumnRow({ columnId: "name" });
+
+    expect(first.key).not.toBe(second.key);
+    expect(first.key.length).toBeGreaterThan(0);
+  });
+
+  test("keeps a raw value only when it was given one", () => {
+    expect(makeColumnRow({ columnId: "a" }).rawValue).toBeUndefined();
+    expect(
+      makeColumnRow({
+        columnId: "a",
+        valueMode: ColumnValueMode.Raw,
+        rawValue: null,
+      }).rawValue,
+    ).toBeNull();
+  });
+});
+
+describe("changeColumnRow", () => {
+  const raw: ModelColumnRow = makeColumnRow({
+    columnId: "port",
+    valueMode: ColumnValueMode.Raw,
+    text: "8080",
+    rawValue: "8080",
+  });
+
+  test("carries several changes at once, which is the whole point", () => {
+    const next: ModelColumnRow = changeColumnRow(raw, {
+      text: "9090",
+      valueMode: ColumnValueMode.Literal,
+    });
+
+    expect(next.text).toBe("9090");
+    expect(next.valueMode).toBe(ColumnValueMode.Literal);
+  });
+
+  test("drops the stored original once the row stops being raw", () => {
+    /*
+     * Otherwise serialization keeps emitting the value that was read, and the
+     * builder's own typing never reaches the workflow.
+     */
+    const next: ModelColumnRow = changeColumnRow(raw, {
+      text: "9090",
+      valueMode: ColumnValueMode.Literal,
+    });
+
+    expect(next.rawValue).toBeUndefined();
+  });
+
+  test("keeps the stored original while the row is still raw", () => {
+    const next: ModelColumnRow = changeColumnRow(raw, {
+      columnId: "portNumber",
+    });
+
+    expect(next.valueMode).toBe(ColumnValueMode.Raw);
+    expect(next.rawValue).toBe("8080");
+  });
+
+  test("a row that has been edited is no longer a blank the editor opened with", () => {
+    const seeded: ModelColumnRow = makeColumnRow({
+      columnId: "name",
+      isSeeded: true,
+    });
+
+    expect(changeColumnRow(seeded, { text: "Acknowledged" }).isSeeded).toBe(
+      false,
+    );
+  });
+
+  test("the row keeps its identity through an edit", () => {
+    expect(changeColumnRow(raw, { text: "9090" }).key).toBe(raw.key);
+  });
+
+  test("does not mutate the row it was given", () => {
+    changeColumnRow(raw, { text: "9090", valueMode: ColumnValueMode.Literal });
+
+    expect(raw.text).toBe("8080");
+    expect(raw.valueMode).toBe(ColumnValueMode.Raw);
+    expect(raw.rawValue).toBe("8080");
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/ColumnEditor/ColumnRowSerialization.test.ts
+++ b/Common/Tests/UI/Components/Workflow/ColumnEditor/ColumnRowSerialization.test.ts
@@ -154,6 +154,33 @@ describe("classifyRowValue — how a stored value is edited", () => {
     });
   });
 
+  test('a value a boolean column cannot hold keeps its own text, not "false"', () => {
+    /*
+     * Spelling every non-true value "false" put a stored "true" on screen as
+     * the word false - the opposite of what the workflow does - and the same
+     * function names the text of a raw row, where the value is by definition
+     * not a boolean.
+     */
+    expect(classifyRowValue(ModelColumnControl.Boolean, "true")).toEqual({
+      valueMode: ColumnValueMode.Raw,
+      text: "true",
+      rawValue: "true",
+    });
+    expect(classifyRowValue(ModelColumnControl.Boolean, "yes").text).toBe(
+      "yes",
+    );
+    expect(classifyRowValue(ModelColumnControl.Boolean, 1).text).toBe("1");
+  });
+
+  test("a real boolean still reads as true or false", () => {
+    expect(classifyRowValue(ModelColumnControl.Boolean, true).text).toBe(
+      "true",
+    );
+    expect(classifyRowValue(ModelColumnControl.Boolean, false).text).toBe(
+      "false",
+    );
+  });
+
   test("null is kept raw, because an empty box would mean something else", () => {
     expect(classifyRowValue(ModelColumnControl.Text, null)).toEqual({
       valueMode: ColumnValueMode.Raw,

--- a/Common/Tests/UI/Components/Workflow/ColumnEditor/ColumnRowSerialization.test.ts
+++ b/Common/Tests/UI/Components/Workflow/ColumnEditor/ColumnRowSerialization.test.ts
@@ -1,0 +1,941 @@
+/*
+ * Stored JSON -> rows -> stored JSON.
+ *
+ * This is where the risk of the whole change lives. The editor is mounted every
+ * time someone opens a step's settings, so a value that does not survive being
+ * read and written back is a workflow silently rewritten by being looked at.
+ * Most of what follows is about that: fixed points, and bytes that match what
+ * the previous editor produced.
+ */
+
+import TableColumnType from "../../../../../Types/Database/TableColumnType";
+import Dictionary from "../../../../../Types/Dictionary";
+import { JSONObject } from "../../../../../Types/JSON";
+import JSONFunctions from "../../../../../Types/JSONFunctions";
+import GreaterThan from "../../../../../Types/BaseDatabase/GreaterThan";
+import Includes from "../../../../../Types/BaseDatabase/Includes";
+import IncludesNone from "../../../../../Types/BaseDatabase/IncludesNone";
+import IsNull from "../../../../../Types/BaseDatabase/IsNull";
+import LessThan from "../../../../../Types/BaseDatabase/LessThan";
+import NotEqual from "../../../../../Types/BaseDatabase/NotEqual";
+import NotNull from "../../../../../Types/BaseDatabase/NotNull";
+import Search from "../../../../../Types/BaseDatabase/Search";
+import {
+  DictionaryEntryValue,
+  DictionaryFilterOperator,
+  buildDictionaryValue,
+} from "../../../../../UI/Components/Dictionary/DictionaryFilterOperator";
+import {
+  ColumnValueMode,
+  ModelColumnControl,
+  ModelColumnRow,
+  makeColumnRow,
+} from "../../../../../UI/Components/Workflow/ColumnEditor/ColumnRow";
+import {
+  buildOperatorValue,
+  classifyRowValue,
+  containsTemplateExpression,
+  emitRowValue,
+  rowIssue,
+  rowsFromParsedValue,
+  seedRequiredRows,
+  serializeColumnRows,
+} from "../../../../../UI/Components/Workflow/ColumnEditor/ColumnRowSerialization";
+import {
+  ModelColumnEditorMode,
+  buildColumnValueJson,
+  normalizeInitialValue,
+} from "../../../../../UI/Components/Workflow/ModelColumnEditor";
+import { ModelSchemaColumn } from "../../../../../UI/Components/Workflow/ModelSchema";
+import { describe, expect, test } from "@jest/globals";
+
+type MakeColumnFunction = (
+  overrides: Partial<ModelSchemaColumn> & { id: string },
+) => ModelSchemaColumn;
+
+const makeColumn: MakeColumnFunction = (
+  overrides: Partial<ModelSchemaColumn> & { id: string },
+): ModelSchemaColumn => {
+  return {
+    title: overrides.id,
+    type: TableColumnType.ShortText,
+    isRelation: false,
+    ...overrides,
+  };
+};
+
+const COLUMNS: Array<ModelSchemaColumn> = [
+  makeColumn({ id: "_id", type: TableColumnType.ObjectID }),
+  makeColumn({ id: "name", type: TableColumnType.Name, required: true }),
+  makeColumn({ id: "color", type: TableColumnType.Color, required: true }),
+  makeColumn({ id: "description", type: TableColumnType.LongText }),
+  makeColumn({ id: "port", type: TableColumnType.Port }),
+  makeColumn({ id: "isEnabled", type: TableColumnType.Boolean }),
+  makeColumn({ id: "createdAt", type: TableColumnType.Date }),
+  makeColumn({
+    id: "projectId",
+    type: TableColumnType.ObjectID,
+    isTenantColumn: true,
+    required: true,
+  }),
+  makeColumn({
+    id: "order",
+    type: TableColumnType.Number,
+    required: true,
+    hasDefault: true,
+  }),
+];
+
+type ParseFunction = (
+  text: string,
+  mode: ModelColumnEditorMode,
+) => Array<ModelColumnRow>;
+
+const parse: ParseFunction = (
+  text: string,
+  mode: ModelColumnEditorMode,
+): Array<ModelColumnRow> => {
+  return rowsFromParsedValue(normalizeInitialValue(text).parsed, COLUMNS, mode);
+};
+
+type RoundTripFunction = (text: string, mode: ModelColumnEditorMode) => string;
+
+/** Read the stored value and write it straight back out, touching nothing. */
+const roundTrip: RoundTripFunction = (
+  text: string,
+  mode: ModelColumnEditorMode,
+): string => {
+  return serializeColumnRows(parse(text, mode), COLUMNS, mode);
+};
+
+describe("containsTemplateExpression", () => {
+  test("uses the runtime's own matcher, so it agrees with what will be substituted", () => {
+    expect(containsTemplateExpression("{{local.variables.apiKey}}")).toBe(true);
+    expect(containsTemplateExpression("prefix {{a}} suffix")).toBe(true);
+    expect(containsTemplateExpression("nothing here")).toBe(false);
+    expect(containsTemplateExpression("{ not a reference }")).toBe(false);
+  });
+
+  test("is not confused by a previous call's match position", () => {
+    /*
+     * A global RegExp carries lastIndex between calls. Built fresh each time,
+     * so the same string answers the same way twice.
+     */
+    expect(containsTemplateExpression("{{a}}")).toBe(true);
+    expect(containsTemplateExpression("{{a}}")).toBe(true);
+  });
+});
+
+describe("classifyRowValue — how a stored value is edited", () => {
+  test("a reference is a reference on any column type", () => {
+    for (const control of Object.values(ModelColumnControl)) {
+      expect(classifyRowValue(control, "{{local.variables.x}}").valueMode).toBe(
+        ColumnValueMode.Reference,
+      );
+    }
+  });
+
+  test("a value the control can hold is edited normally", () => {
+    expect(classifyRowValue(ModelColumnControl.Number, 8080)).toEqual({
+      valueMode: ColumnValueMode.Literal,
+      text: "8080",
+    });
+    expect(classifyRowValue(ModelColumnControl.Boolean, false)).toEqual({
+      valueMode: ColumnValueMode.Literal,
+      text: "false",
+    });
+  });
+
+  test("a value whose type disagrees with the column is kept raw", () => {
+    expect(classifyRowValue(ModelColumnControl.Number, "8080")).toEqual({
+      valueMode: ColumnValueMode.Raw,
+      text: "8080",
+      rawValue: "8080",
+    });
+  });
+
+  test("null is kept raw, because an empty box would mean something else", () => {
+    expect(classifyRowValue(ModelColumnControl.Text, null)).toEqual({
+      valueMode: ColumnValueMode.Raw,
+      text: "",
+      rawValue: null,
+    });
+  });
+});
+
+describe("rowsFromParsedValue — record mode", () => {
+  test("keys keep the order they were written in", () => {
+    const rows: Array<ModelColumnRow> = parse(
+      '{"color":"#fff","name":"Acknowledged","_id":"1"}',
+      ModelColumnEditorMode.Record,
+    );
+
+    expect(
+      rows.map((row: ModelColumnRow) => {
+        return row.columnId;
+      }),
+    ).toEqual(["color", "name", "_id"]);
+  });
+
+  test("every record row is an equality — a record cannot save a comparison", () => {
+    const rows: Array<ModelColumnRow> = parse(
+      '{"name":"Acknowledged"}',
+      ModelColumnEditorMode.Record,
+    );
+
+    expect(rows[0]!.operator).toBe(DictionaryFilterOperator.EqualTo);
+  });
+
+  test("a column the model does not describe still gets a row", () => {
+    const rows: Array<ModelColumnRow> = parse(
+      '{"id":"1"}',
+      ModelColumnEditorMode.Record,
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.columnId).toBe("id");
+  });
+
+  test("nothing stored is no rows, not one blank one", () => {
+    expect(parse("", ModelColumnEditorMode.Record)).toEqual([]);
+  });
+});
+
+describe("rowsFromParsedValue — query mode", () => {
+  test("an operator wrapper is recovered as its operator", () => {
+    const rows: Array<ModelColumnRow> = parse(
+      JSON.stringify({ name: new Search<string>("acme") }),
+      ModelColumnEditorMode.Query,
+    );
+
+    expect(rows[0]!.operator).toBe(DictionaryFilterOperator.Contains);
+    expect(rows[0]!.text).toBe("acme");
+  });
+
+  test("a value-less operator keeps no value", () => {
+    const rows: Array<ModelColumnRow> = parse(
+      JSON.stringify({ name: new IsNull() }),
+      ModelColumnEditorMode.Query,
+    );
+
+    expect(rows[0]!.operator).toBe(DictionaryFilterOperator.IsEmpty);
+    expect(rows[0]!.text).toBe("");
+  });
+
+  test("a membership list is recovered whole", () => {
+    const rows: Array<ModelColumnRow> = parse(
+      JSON.stringify({ name: new Includes(["a", "b"]) }),
+      ModelColumnEditorMode.Query,
+    );
+
+    expect(rows[0]!.operator).toBe(DictionaryFilterOperator.IsAnyOf);
+    expect(rows[0]!.values).toEqual(["a", "b"]);
+  });
+
+  test("the scalar inside a wrapper keeps its own type", () => {
+    /*
+     * detectOperatorFromValue stringifies for display; a row has to see the
+     * number so it does not decide the value is a mismatched string.
+     */
+    const rows: Array<ModelColumnRow> = parse(
+      JSON.stringify({ port: new GreaterThan<number>(8080) }),
+      ModelColumnEditorMode.Query,
+    );
+
+    expect(rows[0]!.valueMode).toBe(ColumnValueMode.Literal);
+    expect(rows[0]!.text).toBe("8080");
+  });
+});
+
+describe("serializeColumnRows — the value each control emits", () => {
+  test("a number column emits a JSON number", () => {
+    expect(
+      serializeColumnRows(
+        [makeColumnRow({ columnId: "port", text: "8080" })],
+        COLUMNS,
+        ModelColumnEditorMode.Record,
+      ),
+    ).toBe('{"port":8080}');
+  });
+
+  test("a boolean column emits a JSON boolean", () => {
+    expect(
+      serializeColumnRows(
+        [makeColumnRow({ columnId: "isEnabled", text: "false" })],
+        COLUMNS,
+        ModelColumnEditorMode.Record,
+      ),
+    ).toBe('{"isEnabled":false}');
+  });
+
+  test("a date column emits its ISO string", () => {
+    expect(
+      serializeColumnRows(
+        [
+          makeColumnRow({
+            columnId: "createdAt",
+            text: "2026-08-15T09:30:00.000Z",
+          }),
+        ],
+        COLUMNS,
+        ModelColumnEditorMode.Record,
+      ),
+    ).toBe('{"createdAt":"2026-08-15T09:30:00.000Z"}');
+  });
+
+  test("a text column emits a string", () => {
+    expect(
+      serializeColumnRows(
+        [makeColumnRow({ columnId: "name", text: "Acknowledged" })],
+        COLUMNS,
+        ModelColumnEditorMode.Record,
+      ),
+    ).toBe('{"name":"Acknowledged"}');
+  });
+
+  test("text that is not a number is written as text, not dropped and not NaN", () => {
+    /*
+     * The row shows why it is wrong. Throwing the value away would take the
+     * builder's work with it, and NaN would serialize to null.
+     */
+    expect(
+      serializeColumnRows(
+        [makeColumnRow({ columnId: "port", text: "eighty eighty" })],
+        COLUMNS,
+        ModelColumnEditorMode.Record,
+      ),
+    ).toBe('{"port":"eighty eighty"}');
+  });
+
+  test("a reference is emitted quoted, whatever the column type", () => {
+    const reference: string = "{{local.variables.port}}";
+
+    expect(
+      serializeColumnRows(
+        [
+          makeColumnRow({
+            columnId: "port",
+            text: reference,
+            valueMode: ColumnValueMode.Reference,
+          }),
+        ],
+        COLUMNS,
+        ModelColumnEditorMode.Record,
+      ),
+    ).toBe(`{"port":"${reference}"}`);
+  });
+
+  test("a raw value is written back exactly as it was read", () => {
+    expect(
+      serializeColumnRows(
+        [
+          makeColumnRow({
+            columnId: "port",
+            text: "8080",
+            valueMode: ColumnValueMode.Raw,
+            rawValue: "8080",
+          }),
+        ],
+        COLUMNS,
+        ModelColumnEditorMode.Record,
+      ),
+    ).toBe('{"port":"8080"}');
+  });
+});
+
+describe("serializeColumnRows — what is kept and what is dropped", () => {
+  test("a record drops a field with nothing in it", () => {
+    expect(
+      serializeColumnRows(
+        [
+          makeColumnRow({ columnId: "name", text: "Acknowledged" }),
+          makeColumnRow({ columnId: "color", text: "" }),
+        ],
+        COLUMNS,
+        ModelColumnEditorMode.Record,
+      ),
+    ).toBe('{"name":"Acknowledged"}');
+  });
+
+  test("a record keeps false, zero and null — they are values, not blanks", () => {
+    const stored: string = serializeColumnRows(
+      [
+        makeColumnRow({ columnId: "isEnabled", text: "false" }),
+        makeColumnRow({ columnId: "port", text: "0" }),
+        makeColumnRow({
+          columnId: "name",
+          valueMode: ColumnValueMode.Raw,
+          rawValue: null,
+        }),
+      ],
+      COLUMNS,
+      ModelColumnEditorMode.Record,
+    );
+
+    expect(JSON.parse(stored)).toEqual({
+      isEnabled: false,
+      port: 0,
+      name: null,
+    });
+  });
+
+  test('a query keeps an empty condition — matching against "" is a real filter', () => {
+    expect(
+      serializeColumnRows(
+        [makeColumnRow({ columnId: "name", text: "" })],
+        COLUMNS,
+        ModelColumnEditorMode.Query,
+      ),
+    ).toBe('{"name":""}');
+  });
+
+  test('a row with no column chosen is dropped rather than written as ""', () => {
+    expect(
+      serializeColumnRows(
+        [
+          makeColumnRow({ columnId: "", text: "orphan" }),
+          makeColumnRow({ columnId: "name", text: "Acknowledged" }),
+        ],
+        COLUMNS,
+        ModelColumnEditorMode.Record,
+      ),
+    ).toBe('{"name":"Acknowledged"}');
+  });
+
+  test("nothing at all collapses to the empty string, not to {}", () => {
+    /*
+     * Form validation and the graph linter both read "" as "this required
+     * argument has not been filled in". "{}" would read as filled.
+     */
+    expect(serializeColumnRows([], COLUMNS, ModelColumnEditorMode.Record)).toBe(
+      "",
+    );
+    expect(
+      serializeColumnRows(
+        [makeColumnRow({ columnId: "name", text: "" })],
+        COLUMNS,
+        ModelColumnEditorMode.Record,
+      ),
+    ).toBe("");
+  });
+});
+
+describe("serializeColumnRows — byte-for-byte with the editor it replaces", () => {
+  type CaseType = {
+    operator: DictionaryFilterOperator;
+    row: Partial<ModelColumnRow>;
+    entry: DictionaryEntryValue;
+  };
+
+  /*
+   * Each case is the same condition expressed twice: as a row, and as the
+   * dictionary the previous editor would have handed buildColumnValueJson. The
+   * two have to produce identical bytes, because the wire format is what the
+   * server's deserializer is written against.
+   */
+  const cases: Array<CaseType> = [
+    {
+      operator: DictionaryFilterOperator.EqualTo,
+      row: { text: "acme" },
+      entry: "acme",
+    },
+    {
+      operator: DictionaryFilterOperator.NotEqual,
+      row: { text: "acme" },
+      entry: buildDictionaryValue({
+        operator: DictionaryFilterOperator.NotEqual,
+        rawValue: "acme",
+      }),
+    },
+    {
+      operator: DictionaryFilterOperator.Contains,
+      row: { text: "acme" },
+      entry: buildDictionaryValue({
+        operator: DictionaryFilterOperator.Contains,
+        rawValue: "acme",
+      }),
+    },
+    {
+      operator: DictionaryFilterOperator.NotContains,
+      row: { text: "acme" },
+      entry: buildDictionaryValue({
+        operator: DictionaryFilterOperator.NotContains,
+        rawValue: "acme",
+      }),
+    },
+    {
+      operator: DictionaryFilterOperator.StartsWith,
+      row: { text: "ac" },
+      entry: buildDictionaryValue({
+        operator: DictionaryFilterOperator.StartsWith,
+        rawValue: "ac",
+      }),
+    },
+    {
+      operator: DictionaryFilterOperator.EndsWith,
+      row: { text: "me" },
+      entry: buildDictionaryValue({
+        operator: DictionaryFilterOperator.EndsWith,
+        rawValue: "me",
+      }),
+    },
+    {
+      operator: DictionaryFilterOperator.IsEmpty,
+      row: {},
+      entry: buildDictionaryValue({
+        operator: DictionaryFilterOperator.IsEmpty,
+        rawValue: "",
+      }),
+    },
+    {
+      operator: DictionaryFilterOperator.IsNotEmpty,
+      row: {},
+      entry: buildDictionaryValue({
+        operator: DictionaryFilterOperator.IsNotEmpty,
+        rawValue: "",
+      }),
+    },
+    {
+      operator: DictionaryFilterOperator.IsAnyOf,
+      row: { values: ["a", "b"] },
+      entry: buildDictionaryValue({
+        operator: DictionaryFilterOperator.IsAnyOf,
+        rawValue: "",
+        rawValues: ["a", "b"],
+      }),
+    },
+    {
+      operator: DictionaryFilterOperator.IsNoneOf,
+      row: { values: ["a", "b"] },
+      entry: buildDictionaryValue({
+        operator: DictionaryFilterOperator.IsNoneOf,
+        rawValue: "",
+        rawValues: ["a", "b"],
+      }),
+    },
+  ];
+
+  test.each(cases)(
+    "$operator on a text column emits what the dictionary form emitted",
+    (testCase: CaseType) => {
+      const fromRows: string = serializeColumnRows(
+        [
+          makeColumnRow({
+            columnId: "name",
+            operator: testCase.operator,
+            ...testCase.row,
+          }),
+        ],
+        COLUMNS,
+        ModelColumnEditorMode.Query,
+      );
+
+      const fromDictionary: string = buildColumnValueJson(
+        { name: testCase.entry } as Dictionary<DictionaryEntryValue>,
+        ModelColumnEditorMode.Query,
+      );
+
+      expect(fromRows).toBe(fromDictionary);
+    },
+  );
+
+  test("the numeric comparisons emit what the dictionary form emitted", () => {
+    const numericOperators: Array<DictionaryFilterOperator> = [
+      DictionaryFilterOperator.GreaterThan,
+      DictionaryFilterOperator.GreaterThanOrEqual,
+      DictionaryFilterOperator.LessThan,
+      DictionaryFilterOperator.LessThanOrEqual,
+    ];
+
+    for (const operator of numericOperators) {
+      const fromRows: string = serializeColumnRows(
+        [makeColumnRow({ columnId: "port", operator: operator, text: "80" })],
+        COLUMNS,
+        ModelColumnEditorMode.Query,
+      );
+
+      const fromDictionary: string = buildColumnValueJson(
+        {
+          port: buildDictionaryValue({ operator: operator, rawValue: "80" }),
+        } as Dictionary<DictionaryEntryValue>,
+        ModelColumnEditorMode.Query,
+      );
+
+      expect(fromRows).toBe(fromDictionary);
+    }
+  });
+});
+
+describe("serializeColumnRows — the comparison that used to become NaN", () => {
+  test('a reference under "is after" keeps the reference', () => {
+    /*
+     * buildDictionaryValue does Number(text) for the ordering operators, so a
+     * reference became NaN and JSON.stringify wrote it as null - a query
+     * against NULL that matches nothing and reports no error at all.
+     */
+    const stored: string = serializeColumnRows(
+      [
+        makeColumnRow({
+          columnId: "createdAt",
+          operator: DictionaryFilterOperator.GreaterThan,
+          valueMode: ColumnValueMode.Reference,
+          text: "{{local.variables.since}}",
+        }),
+      ],
+      COLUMNS,
+      ModelColumnEditorMode.Query,
+    );
+
+    expect(JSON.parse(stored)).toEqual({
+      createdAt: {
+        _type: "GreaterThan",
+        value: "{{local.variables.since}}",
+      },
+    });
+  });
+
+  test('a date under "is before" keeps the date', () => {
+    const stored: string = serializeColumnRows(
+      [
+        makeColumnRow({
+          columnId: "createdAt",
+          operator: DictionaryFilterOperator.LessThan,
+          text: "2026-08-15T09:30:00.000Z",
+        }),
+      ],
+      COLUMNS,
+      ModelColumnEditorMode.Query,
+    );
+
+    expect(JSON.parse(stored)).toEqual({
+      createdAt: {
+        _type: "LessThan",
+        value: "2026-08-15T09:30:00.000Z",
+      },
+    });
+  });
+
+  test("a real number is still emitted as a number", () => {
+    const stored: string = serializeColumnRows(
+      [
+        makeColumnRow({
+          columnId: "port",
+          operator: DictionaryFilterOperator.GreaterThan,
+          text: "8080",
+        }),
+      ],
+      COLUMNS,
+      ModelColumnEditorMode.Query,
+    );
+
+    expect(JSON.parse(stored)).toEqual({
+      port: { _type: "GreaterThan", value: 8080 },
+    });
+  });
+});
+
+describe("what the editor writes, the server can read", () => {
+  type DeserializeFunction = (stored: string) => JSONObject;
+
+  /*
+   * The path a real run takes: the runner JSON.parses the stored string and the
+   * database component hands the result to JSONFunctions.deserialize.
+   */
+  const deserialize: DeserializeFunction = (stored: string): JSONObject => {
+    return JSONFunctions.deserialize(JSON.parse(stored)) as JSONObject;
+  };
+
+  test("each operator comes back as its own query helper", () => {
+    const stored: string = serializeColumnRows(
+      [
+        makeColumnRow({
+          columnId: "name",
+          operator: DictionaryFilterOperator.NotEqual,
+          text: "acme",
+        }),
+        makeColumnRow({
+          columnId: "description",
+          operator: DictionaryFilterOperator.Contains,
+          text: "down",
+        }),
+        makeColumnRow({
+          columnId: "port",
+          operator: DictionaryFilterOperator.LessThan,
+          text: "9000",
+        }),
+        makeColumnRow({
+          columnId: "createdAt",
+          operator: DictionaryFilterOperator.IsEmpty,
+        }),
+        makeColumnRow({
+          columnId: "_id",
+          operator: DictionaryFilterOperator.IsNotEmpty,
+        }),
+        makeColumnRow({
+          columnId: "color",
+          operator: DictionaryFilterOperator.IsAnyOf,
+          values: ["#fff", "#000"],
+        }),
+      ],
+      COLUMNS,
+      ModelColumnEditorMode.Query,
+    );
+
+    const result: JSONObject = deserialize(stored);
+
+    expect(result["name"]).toBeInstanceOf(NotEqual);
+    expect((result["name"] as NotEqual<string>).value).toBe("acme");
+    expect(result["description"]).toBeInstanceOf(Search);
+    expect(result["port"]).toBeInstanceOf(LessThan);
+    expect((result["port"] as LessThan<number>).value).toBe(9000);
+    expect(result["createdAt"]).toBeInstanceOf(IsNull);
+    expect(result["_id"]).toBeInstanceOf(NotNull);
+    expect(result["color"]).toBeInstanceOf(Includes);
+    expect((result["color"] as Includes).values).toEqual(["#fff", "#000"]);
+  });
+
+  test("an exclusion list comes back as IncludesNone", () => {
+    const stored: string = serializeColumnRows(
+      [
+        makeColumnRow({
+          columnId: "name",
+          operator: DictionaryFilterOperator.IsNoneOf,
+          values: ["a"],
+        }),
+      ],
+      COLUMNS,
+      ModelColumnEditorMode.Query,
+    );
+
+    expect(deserialize(stored)["name"]).toBeInstanceOf(IncludesNone);
+  });
+
+  test("a record of typed values deserializes to plain values", () => {
+    const stored: string = serializeColumnRows(
+      [
+        makeColumnRow({ columnId: "name", text: "Acknowledged" }),
+        makeColumnRow({ columnId: "port", text: "8080" }),
+        makeColumnRow({ columnId: "isEnabled", text: "true" }),
+      ],
+      COLUMNS,
+      ModelColumnEditorMode.Record,
+    );
+
+    expect(deserialize(stored)).toEqual({
+      name: "Acknowledged",
+      port: 8080,
+      isEnabled: true,
+    });
+  });
+});
+
+describe("reading a stored value and writing it straight back changes nothing", () => {
+  const fixtures: Array<{ text: string; mode: ModelColumnEditorMode }> = [
+    { text: '{"name":"acme"}', mode: ModelColumnEditorMode.Record },
+    { text: '{"port":8080}', mode: ModelColumnEditorMode.Record },
+    { text: '{"port":"8080"}', mode: ModelColumnEditorMode.Record },
+    { text: '{"isEnabled":false}', mode: ModelColumnEditorMode.Record },
+    { text: '{"name":null}', mode: ModelColumnEditorMode.Record },
+    {
+      text: '{"createdAt":"2026-08-15T09:30:00.000Z"}',
+      mode: ModelColumnEditorMode.Record,
+    },
+    {
+      text: '{"name":"{{local.variables.name}}"}',
+      mode: ModelColumnEditorMode.Record,
+    },
+    { text: '{"id":"legacy"}', mode: ModelColumnEditorMode.Record },
+    {
+      text: '{"color":"#ffffff","name":"a"}',
+      mode: ModelColumnEditorMode.Record,
+    },
+    { text: '{"name":""}', mode: ModelColumnEditorMode.Query },
+    {
+      text: JSON.stringify({ name: new Search<string>("acme") }),
+      mode: ModelColumnEditorMode.Query,
+    },
+    {
+      text: JSON.stringify({ port: new GreaterThan<number>(8080) }),
+      mode: ModelColumnEditorMode.Query,
+    },
+    {
+      text: JSON.stringify({ createdAt: new IsNull() }),
+      mode: ModelColumnEditorMode.Query,
+    },
+    {
+      text: JSON.stringify({ color: new Includes(["#fff", "#000"]) }),
+      mode: ModelColumnEditorMode.Query,
+    },
+    {
+      text: JSON.stringify({ name: new IncludesNone(["a"]) }),
+      mode: ModelColumnEditorMode.Query,
+    },
+  ];
+
+  test.each(fixtures)(
+    "$text survives being opened and written back",
+    (fixture: { text: string; mode: ModelColumnEditorMode }) => {
+      expect(roundTrip(fixture.text, fixture.mode)).toBe(fixture.text);
+    },
+  );
+
+  test("and survives it a second time, so there is no slow drift", () => {
+    for (const fixture of fixtures) {
+      const once: string = roundTrip(fixture.text, fixture.mode);
+      expect(roundTrip(once, fixture.mode)).toBe(once);
+    }
+  });
+
+  test("key order is preserved rather than sorted into the picker's order", () => {
+    const text: string = '{"port":1,"_id":"x","name":"a"}';
+
+    expect(roundTrip(text, ModelColumnEditorMode.Record)).toBe(text);
+  });
+});
+
+describe("seedRequiredRows", () => {
+  test("adds a blank row for each column a create must be given", () => {
+    const rows: Array<ModelColumnRow> = seedRequiredRows([], COLUMNS);
+
+    expect(
+      rows.map((row: ModelColumnRow) => {
+        return row.columnId;
+      }),
+    ).toEqual(["name", "color"]);
+  });
+
+  test("leaves out anything with a default, and the column the runner stamps", () => {
+    const seededIds: Array<string> = seedRequiredRows([], COLUMNS).map(
+      (row: ModelColumnRow) => {
+        return row.columnId;
+      },
+    );
+
+    // `order` is required but carries a default; `projectId` is the tenant column.
+    expect(seededIds).not.toContain("order");
+    expect(seededIds).not.toContain("projectId");
+  });
+
+  test("appends after what was stored, so stored key order is untouched", () => {
+    const stored: Array<ModelColumnRow> = [
+      makeColumnRow({ columnId: "color", text: "#fff" }),
+    ];
+
+    expect(
+      seedRequiredRows(stored, COLUMNS).map((row: ModelColumnRow) => {
+        return row.columnId;
+      }),
+    ).toEqual(["color", "name"]);
+  });
+
+  test("never overwrites a value that is already there", () => {
+    const stored: Array<ModelColumnRow> = [
+      makeColumnRow({ columnId: "name", text: "Acknowledged" }),
+    ];
+
+    expect(seedRequiredRows(stored, COLUMNS)[0]!.text).toBe("Acknowledged");
+  });
+
+  test("seeded rows serialize away, so an untouched create still reads as empty", () => {
+    /*
+     * This is what stops a create that has only been looked at from passing the
+     * form's required check and the graph linter's.
+     */
+    expect(
+      serializeColumnRows(
+        seedRequiredRows([], COLUMNS),
+        COLUMNS,
+        ModelColumnEditorMode.Record,
+      ),
+    ).toBe("");
+  });
+});
+
+describe("emitRowValue and buildOperatorValue in isolation", () => {
+  test("an empty literal is the marker a record drops", () => {
+    expect(
+      emitRowValue(
+        makeColumnRow({ columnId: "name", text: "" }),
+        ModelColumnControl.Text,
+      ),
+    ).toBe("");
+  });
+
+  test("a value-less operator carries no value at all", () => {
+    const built: DictionaryEntryValue = buildOperatorValue(
+      makeColumnRow({
+        columnId: "name",
+        operator: DictionaryFilterOperator.IsEmpty,
+        text: "ignored",
+      }),
+      ModelColumnControl.Text,
+    );
+
+    expect(built).toBeInstanceOf(IsNull);
+  });
+
+  test("equality carries no wrapper, which is what every old query looks like", () => {
+    expect(
+      buildOperatorValue(
+        makeColumnRow({ columnId: "name", text: "acme" }),
+        ModelColumnControl.Text,
+      ),
+    ).toBe("acme");
+  });
+});
+
+describe("rowIssue", () => {
+  test("says so when a number column has been given words", () => {
+    expect(
+      rowIssue(makeColumnRow({ columnId: "port", text: "eighty" }), COLUMNS[4]),
+    ).toBe("This column takes a number.");
+  });
+
+  test("says nothing when the number is a number", () => {
+    expect(
+      rowIssue(makeColumnRow({ columnId: "port", text: "8080" }), COLUMNS[4]),
+    ).toBeNull();
+  });
+
+  test("says so when a date column has been given something unparseable", () => {
+    expect(
+      rowIssue(
+        makeColumnRow({ columnId: "createdAt", text: "yesterday" }),
+        COLUMNS[6],
+      ),
+    ).toBe("This column takes a date and time.");
+  });
+
+  test("a reference is never an issue, on any column", () => {
+    expect(
+      rowIssue(
+        makeColumnRow({
+          columnId: "port",
+          text: "{{local.variables.port}}",
+          valueMode: ColumnValueMode.Reference,
+        }),
+        COLUMNS[4],
+      ),
+    ).toBeNull();
+  });
+
+  test("an untouched row is never an issue", () => {
+    expect(
+      rowIssue(makeColumnRow({ columnId: "port", text: "" }), COLUMNS[4]),
+    ).toBeNull();
+  });
+
+  test("a raw value is not reported as an issue — it is reported as raw", () => {
+    expect(
+      rowIssue(
+        makeColumnRow({
+          columnId: "port",
+          text: "8080",
+          valueMode: ColumnValueMode.Raw,
+          rawValue: "8080",
+        }),
+        COLUMNS[4],
+      ),
+    ).toBeNull();
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/ModelColumnEditor.render.test.tsx
+++ b/Common/Tests/UI/Components/Workflow/ModelColumnEditor.render.test.tsx
@@ -602,3 +602,165 @@ describe("when the schema cannot be loaded", () => {
     expect(await findByDisplayValue("name")).toBeInTheDocument();
   });
 });
+
+describe("an edit reaches the workflow, whatever the cell was holding", () => {
+  test("typing over a value kept raw stores what was typed", async () => {
+    /*
+     * The row for a stored value the column's own control cannot hold re-emits
+     * that value verbatim until it is edited. Reporting the mode change and the
+     * text change separately made the edit permanently impossible: both reports
+     * were built from the same render's row, so the second undid the first and
+     * the stored value won on every keystroke, while the box showed the new one.
+     */
+    const onChange: MockFunction = getJestMockFunction();
+
+    const { findByTestId }: RenderResult = renderEditor({
+      initialValue: '{"order":"3"}',
+      recordIntent: RecordIntent.Update,
+      onChange: onChange,
+    });
+
+    fireEvent.change(await findByTestId("model-column-value-order"), {
+      target: { value: "7" },
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith('{"order":7}');
+  });
+
+  test("typing into a field stored as null stores what was typed", async () => {
+    const onChange: MockFunction = getJestMockFunction();
+
+    const { findByTestId }: RenderResult = renderEditor({
+      initialValue: '{"name":null}',
+      recordIntent: RecordIntent.Update,
+      onChange: onChange,
+    });
+
+    fireEvent.change(await findByTestId("model-column-value-name"), {
+      target: { value: "Acknowledged" },
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith('{"name":"Acknowledged"}');
+  });
+
+  test("typing {{ turns the cell into a reference there and then", async () => {
+    const { findByTestId, getByTestId }: RenderResult = renderEditor({
+      initialValue: '{"name":"Acknowledged"}',
+      recordIntent: RecordIntent.Update,
+    });
+
+    fireEvent.change(await findByTestId("model-column-value-name"), {
+      target: { value: "{{local.variables.stateName}}" },
+    });
+
+    expect(
+      getByTestId("model-column-value-name-reference-toggle"),
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("and the reference is what gets stored", async () => {
+    const onChange: MockFunction = getJestMockFunction();
+
+    const { findByTestId }: RenderResult = renderEditor({
+      initialValue: '{"name":"Acknowledged"}',
+      recordIntent: RecordIntent.Update,
+      onChange: onChange,
+    });
+
+    fireEvent.change(await findByTestId("model-column-value-name"), {
+      target: { value: "{{local.variables.stateName}}" },
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      '{"name":"{{local.variables.stateName}}"}',
+    );
+  });
+});
+
+describe("typing a column name does not throw the row away", () => {
+  test("the key box keeps focus while it is being typed in", async () => {
+    /*
+     * The row used to be keyed on the column name it edits, so every keystroke
+     * gave it a new identity, unmounted it, and detached the focused input.
+     */
+    const { findByDisplayValue }: RenderResult = renderEditor({
+      initialValue: '{"id":"abc"}',
+      recordIntent: RecordIntent.Update,
+    });
+
+    const keyInput: HTMLElement = await findByDisplayValue("id");
+    keyInput.focus();
+
+    expect(document.activeElement).toBe(keyInput);
+
+    fireEvent.change(keyInput, { target: { value: "_i" } });
+
+    expect(document.body.contains(keyInput)).toBe(true);
+    expect(document.activeElement).toBe(keyInput);
+  });
+
+  test("correcting the column name clears the warning about it", async () => {
+    const { findByText, findByDisplayValue, queryByText }: RenderResult =
+      renderEditor({
+        initialValue: '{"id":"abc"}',
+        recordIntent: RecordIntent.Update,
+      });
+
+    expect(
+      await findByText(/"id" isn't a known column on this model/),
+    ).toBeInTheDocument();
+
+    fireEvent.change(await findByDisplayValue("id"), {
+      target: { value: "_id" },
+    });
+
+    expect(queryByText(/isn't a known column/)).toBeNull();
+  });
+});
+
+describe("the JSON view does not lose what the editor opened with", () => {
+  test("a create's required rows survive the trip through JSON", async () => {
+    /*
+     * The rows were seeded only on the way in, so the first look at the JSON
+     * left a create with no fields on screen and nothing saying which ones it
+     * needs.
+     */
+    const { findByTestId, getByTestId, getByText }: RenderResult = renderEditor(
+      {
+        recordIntent: RecordIntent.Create,
+      },
+    );
+
+    fireEvent.click(await findByTestId("model-column-json-toggle"));
+    fireEvent.click(getByTestId("model-column-json-toggle"));
+
+    expect(getByText("Name")).toBeInTheDocument();
+    expect(getByText("Color")).toBeInTheDocument();
+  });
+});
+
+describe("query mode keeps showing what a condition is really about", () => {
+  test("a condition on a column the picker cannot offer still names it", async () => {
+    /*
+     * projectId is a real column that the picker deliberately withholds - the
+     * workflow stamps it itself. A condition stored against it was rendering as
+     * an empty "Column" placeholder over a filter that was really there.
+     */
+    const { findByText }: RenderResult = renderEditor({
+      mode: ModelColumnEditorMode.Query,
+      initialValue: '{"projectId":"abc"}',
+    });
+
+    expect(await findByText("Project ID")).toBeInTheDocument();
+  });
+
+  test("conditions that take no value are still counted as set", async () => {
+    const { findByText }: RenderResult = renderEditor({
+      mode: ModelColumnEditorMode.Query,
+      initialValue: '{"createdAt":{"_type":"IsNull","value":null}}',
+    });
+
+    expect(await findByText(/1 condition set/)).toBeInTheDocument();
+  });
+});

--- a/Common/Tests/UI/Components/Workflow/ModelColumnEditor.render.test.tsx
+++ b/Common/Tests/UI/Components/Workflow/ModelColumnEditor.render.test.tsx
@@ -1,0 +1,604 @@
+/*
+ * What the builder actually sees.
+ *
+ * The complaint this editor exists to answer was that it asked for things the
+ * model schema had already said: the column's name, typed as free text into a
+ * box labelled "Key", and the value's type, picked from a dropdown offering
+ * Text / Number / Boolean. The first two suites below are about those two
+ * questions being gone.
+ *
+ * The third is about the invariant that guards every saved workflow: this
+ * component is mounted every time someone opens a step's settings, so it must
+ * not report a change until a change is actually made.
+ */
+
+import React from "react";
+
+jest.mock("../../../../UI/Utils/API/API", () => {
+  return {
+    __esModule: true,
+    default: {
+      get: jest.fn(),
+      getFriendlyMessage: jest.fn((error: unknown) => {
+        return String(error);
+      }),
+    },
+  };
+});
+
+/*
+ * Monaco cannot run in jsdom. A textarea that echoes the value is enough to
+ * assert what the JSON view was handed and to type into it.
+ */
+jest.mock("@monaco-editor/react", () => {
+  return {
+    __esModule: true,
+    loader: { config: jest.fn() },
+    default: (editorProps: {
+      value?: string | undefined;
+      onChange?: ((value: string | undefined) => void) | undefined;
+    }) => {
+      return (
+        <textarea
+          data-testid="monaco"
+          value={editorProps.value || ""}
+          onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+            editorProps.onChange?.(event.target.value);
+          }}
+        />
+      );
+    },
+  };
+});
+
+import HTTPErrorResponse from "../../../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../../../Types/API/HTTPResponse";
+import TableColumnType from "../../../../Types/Database/TableColumnType";
+import { JSONObject } from "../../../../Types/JSON";
+import ModelColumnEditor, {
+  ModelColumnEditorMode,
+  RecordIntent,
+} from "../../../../UI/Components/Workflow/ModelColumnEditor";
+import { ModelSchemaColumn } from "../../../../UI/Components/Workflow/ModelSchema";
+import API from "../../../../UI/Utils/API/API";
+import getJestMockFunction, { MockFunction } from "../../../MockType";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+import "@testing-library/jest-dom";
+import {
+  RenderResult,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
+
+type MakeColumnFunction = (
+  overrides: Partial<ModelSchemaColumn> & { id: string },
+) => ModelSchemaColumn;
+
+const makeColumn: MakeColumnFunction = (
+  overrides: Partial<ModelSchemaColumn> & { id: string },
+): ModelSchemaColumn => {
+  return {
+    title: overrides.id,
+    type: TableColumnType.ShortText,
+    isRelation: false,
+    ...overrides,
+  };
+};
+
+const COLUMNS: Array<ModelSchemaColumn> = [
+  makeColumn({
+    id: "_id",
+    title: "ID",
+    type: TableColumnType.ObjectID,
+    description: "The unique ID of this Incident State.",
+  }),
+  makeColumn({
+    id: "name",
+    title: "Name",
+    type: TableColumnType.Name,
+    required: true,
+    description: "The name of this Incident State.",
+  }),
+  makeColumn({
+    id: "color",
+    title: "Color",
+    type: TableColumnType.Color,
+    required: true,
+    description: "The color shown against this state.",
+  }),
+  makeColumn({
+    id: "order",
+    title: "Order",
+    type: TableColumnType.Number,
+    description: "Where this state sits in the list.",
+  }),
+  makeColumn({
+    id: "isResolvedState",
+    title: "Is Resolved State",
+    type: TableColumnType.Boolean,
+    description: "Whether reaching this state resolves the incident.",
+  }),
+  makeColumn({
+    id: "createdAt",
+    title: "Created At",
+    type: TableColumnType.Date,
+    description: "When this row was created.",
+  }),
+  makeColumn({
+    id: "projectId",
+    title: "Project ID",
+    type: TableColumnType.ObjectID,
+    isTenantColumn: true,
+  }),
+  makeColumn({
+    id: "monitorSteps",
+    title: "Monitor Steps",
+    type: TableColumnType.MonitorSteps,
+  }),
+];
+
+type MockApiGetFunction = () => MockFunction;
+
+const apiGet: MockApiGetFunction = (): MockFunction => {
+  return API.get as unknown as MockFunction;
+};
+
+type ResolveSchemaFunction = (columns?: Array<ModelSchemaColumn>) => void;
+
+const resolveSchemaWith: ResolveSchemaFunction = (
+  columns?: Array<ModelSchemaColumn>,
+): void => {
+  apiGet().mockResolvedValue(
+    new HTTPResponse<JSONObject>(
+      200,
+      { columns: columns || COLUMNS } as unknown as JSONObject,
+      {},
+    ),
+  );
+};
+
+type RenderEditorProps = {
+  mode?: ModelColumnEditorMode | undefined;
+  initialValue?: string | undefined;
+  recordIntent?: RecordIntent | undefined;
+  onChange?: MockFunction | undefined;
+  valueSuggestions?: Array<string> | undefined;
+};
+
+type RenderEditorFunction = (props?: RenderEditorProps) => RenderResult;
+
+const renderEditor: RenderEditorFunction = (
+  props?: RenderEditorProps,
+): RenderResult => {
+  return render(
+    <ModelColumnEditor
+      tableName="IncidentState"
+      mode={props?.mode || ModelColumnEditorMode.Record}
+      initialValue={props?.initialValue}
+      recordIntent={props?.recordIntent}
+      valueSuggestions={props?.valueSuggestions}
+      onChange={
+        (props?.onChange as unknown as (value: string) => void) ||
+        ((): void => {})
+      }
+    />,
+  );
+};
+
+beforeEach(() => {
+  resolveSchemaWith();
+});
+
+afterEach(() => {
+  apiGet().mockReset();
+});
+
+describe("the schema is used instead of being asked for", () => {
+  test("fields are labelled with the model's own titles and descriptions", async () => {
+    const { findByText, getByText }: RenderResult = renderEditor();
+
+    expect(await findByText("Name")).toBeInTheDocument();
+    expect(getByText("Color")).toBeInTheDocument();
+    expect(getByText("The name of this Incident State.")).toBeInTheDocument();
+    expect(
+      getByText("The color shown against this state."),
+    ).toBeInTheDocument();
+  });
+
+  test("the column name is shown, not asked for", async () => {
+    const { findByText, queryByPlaceholderText }: RenderResult = renderEditor();
+
+    await findByText("Name");
+
+    /*
+     * "Column" was the placeholder of the free-text key box. Its absence is the
+     * complaint being answered.
+     */
+    expect(queryByPlaceholderText("Column")).toBeNull();
+    expect(queryByPlaceholderText("Key")).toBeNull();
+  });
+
+  test("nothing anywhere asks what type the value is", async () => {
+    const { findByText, queryByText }: RenderResult = renderEditor();
+
+    await findByText("Name");
+
+    /*
+     * The old Type dropdown offered these three against every column, next to a
+     * schema that already knew. If any of them is on screen it is back.
+     */
+    expect(queryByText("Type")).toBeNull();
+    expect(queryByText("Number")).toBeNull();
+    expect(queryByText("Boolean")).toBeNull();
+  });
+
+  test("each field says what kind of value it wants, from the schema", async () => {
+    const { findByText, getByText }: RenderResult = renderEditor({
+      initialValue: '{"order":1,"isResolvedState":true,"createdAt":null}',
+      recordIntent: RecordIntent.Update,
+    });
+
+    expect(await findByText("Order")).toBeInTheDocument();
+    expect(getByText("Number")).toBeInTheDocument();
+    expect(getByText("True or false")).toBeInTheDocument();
+    expect(getByText("Date and time")).toBeInTheDocument();
+  });
+});
+
+describe("the control comes from the column type", () => {
+  test("a number column gets a number input", async () => {
+    const { findByTestId }: RenderResult = renderEditor({
+      initialValue: '{"order":3}',
+      recordIntent: RecordIntent.Update,
+    });
+
+    const input: HTMLElement = await findByTestId("model-column-value-order");
+
+    expect(input).toHaveAttribute("type", "number");
+
+    /*
+     * The shared Input writes its value into the DOM from an effect rather than
+     * from a value prop, so this settles a render after the element appears.
+     */
+    await waitFor(() => {
+      expect(input).toHaveValue(3);
+    });
+  });
+
+  test("a date column gets a date-and-time input", async () => {
+    const { findByTestId }: RenderResult = renderEditor({
+      initialValue: '{"createdAt":"2026-08-15T09:30:00.000Z"}',
+      recordIntent: RecordIntent.Update,
+    });
+
+    expect(await findByTestId("model-column-value-createdAt")).toHaveAttribute(
+      "type",
+      "datetime-local",
+    );
+  });
+
+  test('a boolean column gets three states, so "not set" can be said', async () => {
+    const { findByText, getByText }: RenderResult = renderEditor({
+      initialValue: '{"isResolvedState":true}',
+      recordIntent: RecordIntent.Update,
+    });
+
+    expect(await findByText("True")).toBeInTheDocument();
+    expect(getByText("False")).toBeInTheDocument();
+    expect(getByText("Not set")).toBeInTheDocument();
+  });
+
+  test("a column no row can hold is named rather than silently missing", async () => {
+    const { findByText }: RenderResult = renderEditor();
+
+    expect(
+      await findByText(/Monitor Steps.*can only be set with Edit as JSON/),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("opening a step does not rewrite what it does", () => {
+  test("nothing is reported while the schema is still loading", async () => {
+    const onChange: MockFunction = getJestMockFunction();
+
+    renderEditor({ onChange: onChange });
+
+    await waitFor(() => {
+      expect(apiGet()).toHaveBeenCalled();
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test("nothing is reported after the schema resolves and rows are seeded", async () => {
+    const onChange: MockFunction = getJestMockFunction();
+
+    const { findByText }: RenderResult = renderEditor({ onChange: onChange });
+
+    await findByText("Name");
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test("nothing is reported when a stored value is loaded", async () => {
+    const onChange: MockFunction = getJestMockFunction();
+
+    const { findByText }: RenderResult = renderEditor({
+      initialValue: '{"name":"Acknowledged","color":"#ffffff"}',
+      onChange: onChange,
+    });
+
+    await findByText("Name");
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test("nothing is reported by switching to JSON and back", async () => {
+    const onChange: MockFunction = getJestMockFunction();
+
+    const { findByTestId, getByTestId }: RenderResult = renderEditor({
+      initialValue: '{"name":"Acknowledged"}',
+      onChange: onChange,
+    });
+
+    fireEvent.click(await findByTestId("model-column-json-toggle"));
+    fireEvent.click(getByTestId("model-column-json-toggle"));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test("editing a value is reported, with the exact JSON that will be stored", async () => {
+    const onChange: MockFunction = getJestMockFunction();
+
+    const { findByTestId }: RenderResult = renderEditor({
+      initialValue: '{"name":"Acknowledged"}',
+      recordIntent: RecordIntent.Update,
+      onChange: onChange,
+    });
+
+    fireEvent.change(await findByTestId("model-column-value-name"), {
+      target: { value: "Resolved" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith('{"name":"Resolved"}');
+  });
+
+  test("a number is stored as a number, not as the text that was typed", async () => {
+    const onChange: MockFunction = getJestMockFunction();
+
+    const { findByTestId }: RenderResult = renderEditor({
+      initialValue: '{"order":1}',
+      recordIntent: RecordIntent.Update,
+      onChange: onChange,
+    });
+
+    fireEvent.change(await findByTestId("model-column-value-order"), {
+      target: { value: "7" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith('{"order":7}');
+  });
+
+  test("a boolean is stored as a boolean", async () => {
+    const onChange: MockFunction = getJestMockFunction();
+
+    const { findByText }: RenderResult = renderEditor({
+      initialValue: '{"isResolvedState":true}',
+      recordIntent: RecordIntent.Update,
+      onChange: onChange,
+    });
+
+    fireEvent.click(await findByText("False"));
+
+    expect(onChange).toHaveBeenCalledWith('{"isResolvedState":false}');
+  });
+});
+
+describe("a create opens on the fields it needs; an update does not", () => {
+  test("a create opens with a row for every column it must be given", async () => {
+    const { findByText, getByText }: RenderResult = renderEditor({
+      recordIntent: RecordIntent.Create,
+    });
+
+    expect(await findByText("Name")).toBeInTheDocument();
+    expect(getByText("Color")).toBeInTheDocument();
+  });
+
+  test("and says how many of them are still empty", async () => {
+    const { findByText }: RenderResult = renderEditor({
+      recordIntent: RecordIntent.Create,
+    });
+
+    expect(
+      await findByText(/2 required fields still empty/),
+    ).toBeInTheDocument();
+  });
+
+  test("an update opens on nothing, because it legitimately writes one column", async () => {
+    const { findByText, queryByText }: RenderResult = renderEditor({
+      recordIntent: RecordIntent.Update,
+    });
+
+    expect(await findByText("No fields set yet")).toBeInTheDocument();
+    expect(queryByText("Color")).toBeNull();
+  });
+
+  test("the project column is never seeded — the workflow stamps it itself", async () => {
+    const { findByText, queryByText }: RenderResult = renderEditor({
+      recordIntent: RecordIntent.Create,
+    });
+
+    await findByText("Name");
+
+    expect(queryByText("Project ID")).toBeNull();
+  });
+});
+
+describe("editing as JSON", () => {
+  test("the JSON view is offered and shows what is stored", async () => {
+    const { findByTestId, getByTestId }: RenderResult = renderEditor({
+      initialValue: '{"name":"Acknowledged"}',
+      recordIntent: RecordIntent.Update,
+    });
+
+    fireEvent.click(await findByTestId("model-column-json-toggle"));
+
+    expect(getByTestId("monaco")).toHaveValue('{"name":"Acknowledged"}');
+  });
+
+  test("a key added in the JSON view is there as a field on the way back", async () => {
+    /*
+     * The rows used to be seeded once and never re-read, so this edit was
+     * silently discarded and the next keystroke in any row wrote the pre-edit
+     * content back over it.
+     */
+    const { findByTestId, getByTestId, getByText }: RenderResult = renderEditor(
+      {
+        initialValue: '{"name":"Acknowledged"}',
+        recordIntent: RecordIntent.Update,
+      },
+    );
+
+    fireEvent.click(await findByTestId("model-column-json-toggle"));
+    fireEvent.change(getByTestId("monaco"), {
+      target: { value: '{"name":"Acknowledged","color":"#ffffff"}' },
+    });
+    fireEvent.click(getByTestId("model-column-json-toggle"));
+
+    expect(getByText("Color")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(getByTestId("model-column-value-color")).toHaveValue("#ffffff");
+    });
+  });
+
+  test("an edit rows cannot show refuses the trip back rather than losing it", async () => {
+    const { findByTestId, getByTestId, getByText }: RenderResult = renderEditor(
+      {
+        initialValue: '{"name":"Acknowledged"}',
+        recordIntent: RecordIntent.Update,
+      },
+    );
+
+    fireEvent.click(await findByTestId("model-column-json-toggle"));
+    fireEvent.change(getByTestId("monaco"), {
+      target: { value: '{"name":{"nested":"value"}}' },
+    });
+    fireEvent.click(getByTestId("model-column-json-toggle"));
+
+    // Still on JSON, with the edit intact and a reason given.
+    expect(getByTestId("monaco")).toHaveValue('{"name":{"nested":"value"}}');
+    expect(getByText(/can't go back to fields/)).toBeInTheDocument();
+  });
+
+  test("a value rows cannot show at all opens on JSON with the reason on screen", async () => {
+    const { findByText, queryByTestId }: RenderResult = renderEditor({
+      initialValue: '{"labels":["a","b"]}',
+      recordIntent: RecordIntent.Update,
+    });
+
+    expect(await findByText(/Editing as JSON, because/)).toBeInTheDocument();
+    expect(queryByTestId("model-column-json-toggle")).toBeNull();
+  });
+});
+
+describe("values the rows keep faithfully", () => {
+  test("a column this model does not describe keeps its row and is flagged", async () => {
+    const { findByText, getByDisplayValue }: RenderResult = renderEditor({
+      initialValue: '{"id":"00000000-0000-0000-0000-000000000000"}',
+      recordIntent: RecordIntent.Update,
+    });
+
+    // The "id" versus "_id" mistake has to stay visible, and fixable.
+    expect(await findByText("Not a column on this model")).toBeInTheDocument();
+    expect(getByDisplayValue("id")).toBeInTheDocument();
+  });
+
+  test("a stored value whose type disagrees with the column is left alone", async () => {
+    const { findByText }: RenderResult = renderEditor({
+      initialValue: '{"order":"3"}',
+      recordIntent: RecordIntent.Update,
+    });
+
+    expect(
+      await findByText(/Kept exactly as it was saved/),
+    ).toBeInTheDocument();
+  });
+
+  test("a reference is shown as a reference on a numeric column", async () => {
+    const { findByDisplayValue }: RenderResult = renderEditor({
+      initialValue: '{"order":"{{local.variables.position}}"}',
+      recordIntent: RecordIntent.Update,
+      valueSuggestions: ["{{local.variables.position}}"],
+    });
+
+    expect(
+      await findByDisplayValue("{{local.variables.position}}"),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("query mode", () => {
+  test("conditions get a real column picker and a comparison, not a type", async () => {
+    const { findByText, queryByText }: RenderResult = renderEditor({
+      mode: ModelColumnEditorMode.Query,
+      initialValue: '{"name":"Acknowledged"}',
+    });
+
+    expect(await findByText("Column")).toBeInTheDocument();
+    expect(await findByText("Comparison")).toBeInTheDocument();
+    expect(queryByText("Type")).toBeNull();
+  });
+
+  test("an empty query says what that means, which on a delete matters", async () => {
+    const { findByText, getByText }: RenderResult = renderEditor({
+      mode: ModelColumnEditorMode.Query,
+    });
+
+    expect(await findByText("No conditions yet")).toBeInTheDocument();
+    expect(
+      getByText("With no conditions this matches every record in the project."),
+    ).toBeInTheDocument();
+  });
+
+  test("a query is never seeded with required fields — it is not a record", async () => {
+    const { findByText }: RenderResult = renderEditor({
+      mode: ModelColumnEditorMode.Query,
+    });
+
+    expect(await findByText("No conditions yet")).toBeInTheDocument();
+  });
+});
+
+describe("when the schema cannot be loaded", () => {
+  test("the failure is shown and the value stays editable", async () => {
+    apiGet().mockResolvedValue(
+      new HTTPErrorResponse(500, { message: "boom" }, {}),
+    );
+
+    const { findByText, getByTestId }: RenderResult = renderEditor({
+      initialValue: '{"name":"Acknowledged"}',
+      recordIntent: RecordIntent.Update,
+    });
+
+    expect(
+      await findByText(/Couldn't load this model's columns/),
+    ).toBeInTheDocument();
+
+    // The escape hatch is still there, which is the whole point of keeping it.
+    expect(getByTestId("model-column-json-toggle")).toBeInTheDocument();
+  });
+
+  test("a stored field still gets a row, with its key editable", async () => {
+    apiGet().mockResolvedValue(
+      new HTTPErrorResponse(500, { message: "boom" }, {}),
+    );
+
+    const { findByDisplayValue }: RenderResult = renderEditor({
+      initialValue: '{"name":"Acknowledged"}',
+      recordIntent: RecordIntent.Update,
+    });
+
+    expect(await findByDisplayValue("name")).toBeInTheDocument();
+  });
+});

--- a/Common/UI/Components/AutocompleteTextInput/AutocompleteTextInput.tsx
+++ b/Common/UI/Components/AutocompleteTextInput/AutocompleteTextInput.tsx
@@ -27,6 +27,12 @@ export interface ComponentProps {
   isLoadingSuggestions?: boolean | undefined;
   loadingMessage?: string | undefined;
   noSuggestionsMessage?: string | undefined;
+  /*
+   * The id of the element that names this input. Without it a picker that draws
+   * its own label - the workflow record editor, where the field's name sits in
+   * the column beside the box - leaves the input unnamed to a screen reader.
+   */
+  ariaLabelledby?: string | undefined;
 }
 
 const BASE_INPUT_CLASS: string =
@@ -458,6 +464,7 @@ const AutocompleteTextInput: FunctionComponent<ComponentProps> = (
         className={getInputClassName()}
         data-testid={props.dataTestId}
         disabled={props.disabled}
+        aria-labelledby={props.ariaLabelledby}
         aria-autocomplete="list"
         aria-controls={listboxIdRef.current}
         aria-expanded={showMenu}

--- a/Common/UI/Components/TextArea/TextArea.tsx
+++ b/Common/UI/Components/TextArea/TextArea.tsx
@@ -22,6 +22,8 @@ export interface ComponentProps {
   autoFocus?: boolean | undefined;
   dataTestId?: string | undefined;
   disableSpellCheck?: boolean | undefined;
+  /** The id of the element that names this control, when it is labelled elsewhere. */
+  ariaLabelledby?: string | undefined;
 }
 
 const TextArea: FunctionComponent<ComponentProps> = (
@@ -71,6 +73,7 @@ const TextArea: FunctionComponent<ComponentProps> = (
           value={text}
           rows={6}
           spellCheck={!props.disableSpellCheck}
+          aria-labelledby={props.ariaLabelledby}
           aria-invalid={props.error ? "true" : undefined}
           aria-describedby={props.error ? "textarea-error-message" : undefined}
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/Common/UI/Components/Workflow/ArgumentsForm.tsx
+++ b/Common/UI/Components/Workflow/ArgumentsForm.tsx
@@ -6,7 +6,10 @@ import { CustomElementProps } from "../Forms/Types/Field";
 import FormValues from "../Forms/Types/FormValues";
 import ComponentValuePickerModal from "./ComponentValuePickerModal";
 import CronScheduleField from "./CronScheduleField";
-import ModelColumnEditor, { ModelColumnEditorMode } from "./ModelColumnEditor";
+import ModelColumnEditor, {
+  ModelColumnEditorMode,
+  RecordIntent,
+} from "./ModelColumnEditor";
 import ModelFieldPicker from "./ModelFieldPicker";
 import {
   componentInputTypeToFormFieldType,
@@ -488,6 +491,20 @@ const ArgumentsForm: FunctionComponent<ComponentProps> = (
                           <ModelColumnEditor
                             tableName={component.metadata.tableName as string}
                             mode={columnEditorMode}
+                            /*
+                             * A create writes a whole record, so it opens with a
+                             * row for every column it must be given. An update
+                             * legitimately writes one column, and seeding it
+                             * with six would present five fields nobody asked
+                             * for. The create payload is the argument called
+                             * "json" (BaseModel components); an update's is
+                             * "data".
+                             */
+                            recordIntent={
+                              arg.id === "json"
+                                ? RecordIntent.Create
+                                : RecordIntent.Update
+                            }
                             initialValue={customProps.initialValue}
                             onChange={(value: string) => {
                               void customProps.onChange?.(value);

--- a/Common/UI/Components/Workflow/ColumnEditor/AddColumnDropdown.tsx
+++ b/Common/UI/Components/Workflow/ColumnEditor/AddColumnDropdown.tsx
@@ -1,0 +1,177 @@
+/*
+ * The "add a field" picker.
+ *
+ * This is the part that answers the complaint directly: the columns are already
+ * known, so they are offered by name and description rather than typed from
+ * memory into a box labelled "Key". Required columns are grouped first, because
+ * on a create those are the ones that decide whether the step works at all.
+ */
+
+import IconProp from "../../../../Types/Icon/IconProp";
+import Button, { ButtonSize, ButtonStyleType } from "../../Button/Button";
+import Dropdown, {
+  DropdownOption,
+  DropdownOptionGroup,
+  DropdownValue,
+} from "../../Dropdown/Dropdown";
+import Icon from "../../Icon/Icon";
+import Input from "../../Input/Input";
+import { ModelSchemaColumn } from "../ModelSchema";
+import { columnTypeLabel } from "./ColumnControl";
+import React, { FunctionComponent, ReactElement, useState } from "react";
+
+export interface ComponentProps {
+  /** Already filtered to what may be offered, and to what is not on screen. */
+  columns: Array<ModelSchemaColumn>;
+  /** Column ids a create must be given a value for, listed first. */
+  requiredColumnIds: Array<string>;
+  placeholder: string;
+  /**
+   * True when there is nothing to offer from the schema - it failed to load, or
+   * every column is already on screen - and the builder must still be able to
+   * name one. The runner accepts column names this endpoint does not describe.
+   */
+  allowCustomColumn: boolean;
+  onAdd: (columnId: string) => void;
+  dataTestId?: string | undefined;
+}
+
+type ToOptionFunction = (column: ModelSchemaColumn) => DropdownOption;
+
+const toOption: ToOptionFunction = (
+  column: ModelSchemaColumn,
+): DropdownOption => {
+  return {
+    value: column.id,
+    label: `${column.title} · ${column.id}`,
+    /*
+     * The model's own description, shown as the option's second line. It is the
+     * sentence that was previously nowhere on this screen, and it is the whole
+     * reason the picker beats a text box.
+     */
+    description: column.description || columnTypeLabel(column),
+  };
+};
+
+const AddColumnDropdown: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [customColumnId, setCustomColumnId] = useState<string>("");
+  const [isNamingCustomColumn, setIsNamingCustomColumn] =
+    useState<boolean>(false);
+  /*
+   * Bumped after every pick to remount the dropdown. It keeps its selection in
+   * state of its own and only re-reads props.value when that prop changes, so
+   * without this the picker would go on displaying the field it just added -
+   * as though it were a filter rather than an action.
+   */
+  const [pickerNonce, setPickerNonce] = useState<number>(0);
+
+  type AddCustomColumnFunction = () => void;
+
+  const addCustomColumn: AddCustomColumnFunction = (): void => {
+    const columnId: string = customColumnId.trim();
+
+    if (columnId === "") {
+      return;
+    }
+
+    props.onAdd(columnId);
+    setCustomColumnId("");
+    setIsNamingCustomColumn(false);
+  };
+
+  const hasOptions: boolean = props.columns.length > 0;
+
+  if (isNamingCustomColumn || !hasOptions) {
+    return (
+      <div className="flex items-start gap-2">
+        <div className="w-64">
+          <Input
+            value={customColumnId}
+            placeholder="Column name"
+            outerDivClassName="relative w-full"
+            dataTestId={`${props.dataTestId || "model-column-add"}-custom`}
+            onChange={setCustomColumnId}
+            onEnterPress={addCustomColumn}
+          />
+        </div>
+        <Button
+          title="Add"
+          buttonSize={ButtonSize.Small}
+          buttonStyle={ButtonStyleType.OUTLINE}
+          onClick={addCustomColumn}
+        />
+        {hasOptions && (
+          <Button
+            title="Cancel"
+            buttonSize={ButtonSize.Small}
+            buttonStyle={ButtonStyleType.SECONDARY_LINK}
+            onClick={() => {
+              setIsNamingCustomColumn(false);
+              setCustomColumnId("");
+            }}
+          />
+        )}
+      </div>
+    );
+  }
+
+  const requiredColumns: Array<ModelSchemaColumn> = props.columns.filter(
+    (column: ModelSchemaColumn) => {
+      return props.requiredColumnIds.includes(column.id);
+    },
+  );
+
+  const otherColumns: Array<ModelSchemaColumn> = props.columns.filter(
+    (column: ModelSchemaColumn) => {
+      return !props.requiredColumnIds.includes(column.id);
+    },
+  );
+
+  const options: Array<DropdownOption | DropdownOptionGroup> =
+    requiredColumns.length > 0
+      ? [
+          { label: "Required", options: requiredColumns.map(toOption) },
+          { label: "All fields", options: otherColumns.map(toOption) },
+        ]
+      : props.columns.map(toOption);
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="w-72">
+        <Dropdown
+          key={pickerNonce}
+          options={options}
+          placeholder={props.placeholder}
+          className="relative w-full overflow-visible rounded-md"
+          isMultiSelect={false}
+          dataTestId={props.dataTestId || "model-column-add"}
+          ariaLabel={props.placeholder}
+          onChange={(value: DropdownValue | Array<DropdownValue> | null) => {
+            if (value === null || Array.isArray(value)) {
+              return;
+            }
+
+            setPickerNonce(pickerNonce + 1);
+            props.onAdd(String(value));
+          }}
+        />
+      </div>
+      {props.allowCustomColumn && (
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700"
+          onClick={() => {
+            setIsNamingCustomColumn(true);
+          }}
+        >
+          <Icon icon={IconProp.Add} className="h-3 w-3" />
+          Add a column by name
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default AddColumnDropdown;

--- a/Common/UI/Components/Workflow/ColumnEditor/ColumnConditionRow.tsx
+++ b/Common/UI/Components/Workflow/ColumnEditor/ColumnConditionRow.tsx
@@ -1,0 +1,238 @@
+/*
+ * One condition of a query: column, comparison, value.
+ *
+ * A condition genuinely picks its subject, so this row keeps a column picker -
+ * but a picker of real columns, not a text box. The comparison list is filtered
+ * by the column's type, so a Boolean column no longer offers "starts with" and
+ * an ID column no longer offers "greater than".
+ */
+
+import IconProp from "../../../../Types/Icon/IconProp";
+import Button, { ButtonStyleType } from "../../Button/Button";
+import {
+  DictionaryFilterOperator,
+  DictionaryFilterOperatorOption,
+  getOperatorOption,
+} from "../../Dictionary/DictionaryFilterOperator";
+import Dropdown, {
+  DropdownOption,
+  DropdownValue,
+} from "../../Dropdown/Dropdown";
+import AutocompleteTextInput from "../../AutocompleteTextInput/AutocompleteTextInput";
+import { ModelSchemaColumn } from "../ModelSchema";
+import { columnTypeLabel, controlForColumn } from "./ColumnControl";
+import { operatorLabelFor, operatorsForControl } from "./ColumnOperators";
+import {
+  ColumnValueMode,
+  ModelColumnControl,
+  ModelColumnRow,
+} from "./ColumnRow";
+import { rowIssue } from "./ColumnRowSerialization";
+import ColumnValueInput from "./ColumnValueInput";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  row: ModelColumnRow;
+  column: ModelSchemaColumn | undefined;
+  /** Every column the model describes, for this row's own picker. */
+  columns: Array<ModelSchemaColumn>;
+  suggestions?: Array<string> | undefined;
+  onChange: (row: ModelColumnRow) => void;
+  onRemove: () => void;
+}
+
+const ColumnConditionRow: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const control: ModelColumnControl = controlForColumn(props.column);
+  const operatorOption: DictionaryFilterOperatorOption = getOperatorOption(
+    props.row.operator,
+  );
+  const issue: string | null = rowIssue(props.row, props.column);
+  const isUnknownColumn: boolean = !props.column && props.row.columnId !== "";
+
+  /*
+   * The title alone is the label, with the column name carried in the option's
+   * second line and repeated as a chip under the picker once it is chosen.
+   * Putting both in the label - "Created At · createdAt" - is what a select
+   * ellipsizes first, and the name is exactly the half that gets cut.
+   */
+  const columnOptions: Array<DropdownOption> = props.columns.map(
+    (column: ModelSchemaColumn) => {
+      return {
+        value: column.id,
+        label: column.title,
+        description: `${column.id} · ${
+          column.description || columnTypeLabel(column)
+        }`,
+      };
+    },
+  );
+
+  /*
+   * A stored condition can name a column this endpoint does not describe - the
+   * runner accepts more names than the schema surfaces. Keep it in the list so
+   * the row shows what it is filtering on rather than an empty picker.
+   */
+  if (
+    isUnknownColumn &&
+    !columnOptions.some((option: DropdownOption) => {
+      return option.value === props.row.columnId;
+    })
+  ) {
+    columnOptions.unshift({
+      value: props.row.columnId,
+      label: props.row.columnId,
+      description: "Not a column on this model",
+    });
+  }
+
+  const operatorOptions: Array<DropdownOption> = operatorsForControl(
+    control,
+    props.row.operator,
+  ).map((operator: DictionaryFilterOperator) => {
+    return {
+      value: operator,
+      label: operatorLabelFor(operator, control),
+    };
+  });
+
+  /*
+   * Proportional column widths rather than fixed ones. A picker showing
+   * "Created At · createdAt" and a comparison reading "is on or before" both
+   * outgrow any rem figure that also leaves room for the value, and the settings
+   * panel is a different width on every screen. ModelQueryBuilder's header row
+   * repeats this template and has to stay in step with it.
+   */
+  const rowGridClass: string =
+    "group grid grid-cols-1 items-start gap-2 px-3 py-2.5 transition-colors hover:bg-gray-50/60 sm:grid-cols-[minmax(0,1fr)_minmax(0,0.85fr)_minmax(0,1.3fr)_auto]";
+
+  return (
+    <div className={rowGridClass} data-testid="model-column-row">
+      <div className="min-w-0">
+        {props.columns.length === 0 ? (
+          <AutocompleteTextInput
+            value={props.row.columnId}
+            placeholder="Column name"
+            outerDivClassName="relative w-full"
+            disableSpellCheck={true}
+            onChange={(value: string) => {
+              props.onChange({ ...props.row, columnId: value });
+            }}
+          />
+        ) : (
+          <Dropdown
+            options={columnOptions}
+            placeholder="Column"
+            className="relative w-full overflow-visible rounded-md"
+            isMultiSelect={false}
+            ariaLabel="Column"
+            dataTestId={`model-column-picker-${props.row.columnId}`}
+            value={columnOptions.find((option: DropdownOption) => {
+              return option.value === props.row.columnId;
+            })}
+            onChange={(value: DropdownValue | Array<DropdownValue> | null) => {
+              /*
+               * The dropdown is always clearable and hands back null. The row
+               * stays - a condition being retargeted is not a condition being
+               * deleted - and an empty column is dropped on serialization.
+               */
+              props.onChange({
+                ...props.row,
+                columnId:
+                  value === null || Array.isArray(value) ? "" : String(value),
+              });
+            }}
+          />
+        )}
+        {isUnknownColumn ? (
+          <span className="mt-1 inline-block rounded bg-amber-50 px-1.5 py-0.5 text-[11px] text-amber-700">
+            Not a column on this model
+          </span>
+        ) : (
+          props.column && (
+            <span className="mt-1 inline-block truncate rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[11px] text-gray-500">
+              {props.row.columnId}
+            </span>
+          )
+        )}
+      </div>
+
+      <Dropdown
+        options={operatorOptions}
+        className="relative w-full overflow-visible rounded-md"
+        isMultiSelect={false}
+        ariaLabel="Comparison"
+        dataTestId={`model-column-operator-${props.row.columnId}`}
+        value={operatorOptions.find((option: DropdownOption) => {
+          return option.value === props.row.operator;
+        })}
+        onChange={(value: DropdownValue | Array<DropdownValue> | null) => {
+          if (value === null || Array.isArray(value)) {
+            return;
+          }
+
+          const nextOperator: DictionaryFilterOperator =
+            value as DictionaryFilterOperator;
+          const nextOption: DictionaryFilterOperatorOption =
+            getOperatorOption(nextOperator);
+
+          /*
+           * The value is cleared when the shape of the input changes, so a
+           * scalar is never shipped where a list is expected, or the other way
+           * round.
+           */
+          props.onChange({
+            ...props.row,
+            operator: nextOperator,
+            text: nextOption.hidesValueInput ? "" : props.row.text,
+            values: nextOption.expectsMultiValue ? props.row.values : [],
+          });
+        }}
+      />
+
+      <div className="min-w-0">
+        <ColumnValueInput
+          control={control}
+          valueMode={props.row.valueMode}
+          text={props.row.text}
+          values={props.row.values}
+          operatorOption={operatorOption}
+          placeholder={props.column?.example || props.column?.placeholder}
+          suggestions={props.suggestions}
+          dataTestId={`model-column-value-${props.row.columnId}`}
+          onTextChange={(text: string) => {
+            props.onChange({ ...props.row, text: text });
+          }}
+          onValuesChange={(values: Array<string>) => {
+            props.onChange({ ...props.row, values: values });
+          }}
+          onValueModeChange={(valueMode: ColumnValueMode) => {
+            props.onChange({ ...props.row, valueMode: valueMode });
+          }}
+        />
+
+        {props.row.valueMode === ColumnValueMode.Raw && (
+          <p className="mt-1 text-[11px] text-amber-600">
+            Kept exactly as it was saved.
+          </p>
+        )}
+
+        {issue && <p className="mt-1 text-[11px] text-red-500">{issue}</p>}
+      </div>
+
+      <div className="flex items-center pt-1">
+        <Button
+          buttonStyle={ButtonStyleType.ICON}
+          icon={IconProp.Trash}
+          title="Remove"
+          dataTestId={`model-column-remove-${props.row.columnId}`}
+          className="opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100"
+          onClick={props.onRemove}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ColumnConditionRow;

--- a/Common/UI/Components/Workflow/ColumnEditor/ColumnConditionRow.tsx
+++ b/Common/UI/Components/Workflow/ColumnEditor/ColumnConditionRow.tsx
@@ -26,6 +26,7 @@ import {
   ColumnValueMode,
   ModelColumnControl,
   ModelColumnRow,
+  changeColumnRow,
 } from "./ColumnRow";
 import { rowIssue } from "./ColumnRowSerialization";
 import ColumnValueInput from "./ColumnValueInput";
@@ -37,6 +38,8 @@ export interface ComponentProps {
   /** Every column the model describes, for this row's own picker. */
   columns: Array<ModelSchemaColumn>;
   suggestions?: Array<string> | undefined;
+  /** Focused on mount, so a condition added from the picker is ready to type into. */
+  autoFocus?: boolean | undefined;
   onChange: (row: ModelColumnRow) => void;
   onRemove: () => void;
 }
@@ -70,20 +73,25 @@ const ColumnConditionRow: FunctionComponent<ComponentProps> = (
   );
 
   /*
-   * A stored condition can name a column this endpoint does not describe - the
-   * runner accepts more names than the schema surfaces. Keep it in the list so
-   * the row shows what it is filtering on rather than an empty picker.
+   * Whatever this condition already filters on is always in the list, even when
+   * the picker would not offer it: a name the endpoint does not describe at all,
+   * and equally a column it describes but does not offer - a relation, the
+   * project column, a JSON blob. Keyed on "is it in the options" rather than on
+   * "is it unknown", because the second misses the whole middle case and leaves
+   * the row showing an empty picker over a condition that is really there.
    */
   if (
-    isUnknownColumn &&
+    props.row.columnId !== "" &&
     !columnOptions.some((option: DropdownOption) => {
       return option.value === props.row.columnId;
     })
   ) {
     columnOptions.unshift({
       value: props.row.columnId,
-      label: props.row.columnId,
-      description: "Not a column on this model",
+      label: props.column?.title || props.row.columnId,
+      description: isUnknownColumn
+        ? "Not a column on this model"
+        : `${props.row.columnId} · can't be picked from the list`,
     });
   }
 
@@ -117,7 +125,7 @@ const ColumnConditionRow: FunctionComponent<ComponentProps> = (
             outerDivClassName="relative w-full"
             disableSpellCheck={true}
             onChange={(value: string) => {
-              props.onChange({ ...props.row, columnId: value });
+              props.onChange(changeColumnRow(props.row, { columnId: value }));
             }}
           />
         ) : (
@@ -137,11 +145,12 @@ const ColumnConditionRow: FunctionComponent<ComponentProps> = (
                * stays - a condition being retargeted is not a condition being
                * deleted - and an empty column is dropped on serialization.
                */
-              props.onChange({
-                ...props.row,
-                columnId:
-                  value === null || Array.isArray(value) ? "" : String(value),
-              });
+              props.onChange(
+                changeColumnRow(props.row, {
+                  columnId:
+                    value === null || Array.isArray(value) ? "" : String(value),
+                }),
+              );
             }}
           />
         )}
@@ -182,12 +191,13 @@ const ColumnConditionRow: FunctionComponent<ComponentProps> = (
            * scalar is never shipped where a list is expected, or the other way
            * round.
            */
-          props.onChange({
-            ...props.row,
-            operator: nextOperator,
-            text: nextOption.hidesValueInput ? "" : props.row.text,
-            values: nextOption.expectsMultiValue ? props.row.values : [],
-          });
+          props.onChange(
+            changeColumnRow(props.row, {
+              operator: nextOperator,
+              text: nextOption.hidesValueInput ? "" : props.row.text,
+              values: nextOption.expectsMultiValue ? props.row.values : [],
+            }),
+          );
         }}
       />
 
@@ -200,15 +210,10 @@ const ColumnConditionRow: FunctionComponent<ComponentProps> = (
           operatorOption={operatorOption}
           placeholder={props.column?.example || props.column?.placeholder}
           suggestions={props.suggestions}
+          autoFocus={props.autoFocus}
           dataTestId={`model-column-value-${props.row.columnId}`}
-          onTextChange={(text: string) => {
-            props.onChange({ ...props.row, text: text });
-          }}
-          onValuesChange={(values: Array<string>) => {
-            props.onChange({ ...props.row, values: values });
-          }}
-          onValueModeChange={(valueMode: ColumnValueMode) => {
-            props.onChange({ ...props.row, valueMode: valueMode });
+          onChange={(change: Partial<ModelColumnRow>) => {
+            props.onChange(changeColumnRow(props.row, change));
           }}
         />
 

--- a/Common/UI/Components/Workflow/ColumnEditor/ColumnControl.ts
+++ b/Common/UI/Components/Workflow/ColumnEditor/ColumnControl.ts
@@ -1,0 +1,255 @@
+/*
+ * Which control a column gets, decided from the model's own schema.
+ *
+ * This is the answer to "you already know the schema, why are you asking me?".
+ * The editor used to show a Type dropdown next to every row — Text, Number,
+ * Boolean — even though /model-schema/:tableName had already said that `color`
+ * is a Color and `name` is a Name. Nothing good could come of that dropdown:
+ * the builder could only agree with the schema or be wrong.
+ */
+
+import TableColumnType from "../../../../Types/Database/TableColumnType";
+import { ModelSchemaColumn } from "../ModelSchema";
+import { ModelColumnControl } from "./ColumnRow";
+
+/*
+ * Spelled with the enum, never with string literals. The wire carries the
+ * enum's *values* and several of them differ from the member name that reads
+ * like the obvious literal: ShortText is "Text", ObjectID is "Object ID",
+ * LongURL is "URL", PositiveNumber is "Positive Number" — and JavaScript is
+ * "JavaSCript", capital S and all. ModelSchema.ts:160 documents the same trap;
+ * a hand-written list here would classify the two most-declared column types
+ * as unsupported and quietly send every one of them to a plain text box.
+ */
+const TEXT_COLUMN_TYPES: Array<string> = [
+  TableColumnType.ShortText,
+  TableColumnType.Slug,
+  TableColumnType.Name,
+  TableColumnType.Email,
+  TableColumnType.Phone,
+  TableColumnType.Domain,
+  TableColumnType.IP,
+  TableColumnType.Version,
+  TableColumnType.LongURL,
+  TableColumnType.ShortURL,
+  TableColumnType.HashedString,
+  TableColumnType.Password,
+  TableColumnType.OTP,
+  TableColumnType.MonitorType,
+  TableColumnType.WorkflowStatus,
+  TableColumnType.CustomFieldType,
+  TableColumnType.Permission,
+];
+
+const LONG_TEXT_COLUMN_TYPES: Array<string> = [
+  TableColumnType.LongText,
+  TableColumnType.VeryLongText,
+  TableColumnType.Description,
+  TableColumnType.Markdown,
+  TableColumnType.HTML,
+  TableColumnType.CSS,
+  TableColumnType.JavaScript,
+];
+
+const NUMBER_COLUMN_TYPES: Array<string> = [
+  TableColumnType.Number,
+  TableColumnType.SmallNumber,
+  TableColumnType.BigNumber,
+  TableColumnType.PositiveNumber,
+  TableColumnType.SmallPositiveNumber,
+  TableColumnType.BigPositiveNumber,
+  TableColumnType.Port,
+];
+
+/*
+ * Everything a row cannot hold. Entity/EntityArray are relations - pointing a
+ * record at a related row means naming an existing record, which is what the
+ * scalar foreign-key column next to it (currentIncidentStateId, and every other
+ * "... ID" column) is for, and that column is offered normally.
+ */
+const UNSUPPORTED_COLUMN_TYPES: Array<string> = [
+  TableColumnType.Entity,
+  TableColumnType.EntityArray,
+  TableColumnType.JSON,
+  TableColumnType.Array,
+  TableColumnType.Buffer,
+  TableColumnType.File,
+  TableColumnType.MonitorSteps,
+];
+
+export type ControlForColumnFunction = (
+  column: ModelSchemaColumn | undefined,
+) => ModelColumnControl;
+
+/**
+ * The control for a column, or Text when the schema has nothing to say.
+ *
+ * An unknown column — one the endpoint did not describe, or a key typed before
+ * the schema loaded — gets Text rather than Unsupported, because the runner
+ * accepts column names this endpoint does not surface and locking those rows
+ * would be worse than letting them be typed.
+ */
+export const controlForColumn: ControlForColumnFunction = (
+  column: ModelSchemaColumn | undefined,
+): ModelColumnControl => {
+  if (!column) {
+    return ModelColumnControl.Text;
+  }
+
+  if (column.isRelation) {
+    return ModelColumnControl.Unsupported;
+  }
+
+  if (UNSUPPORTED_COLUMN_TYPES.includes(column.type)) {
+    return ModelColumnControl.Unsupported;
+  }
+
+  if (column.type === TableColumnType.Boolean) {
+    return ModelColumnControl.Boolean;
+  }
+
+  if (column.type === TableColumnType.Date) {
+    return ModelColumnControl.Date;
+  }
+
+  if (column.type === TableColumnType.ObjectID) {
+    return ModelColumnControl.ObjectId;
+  }
+
+  if (column.type === TableColumnType.Color) {
+    return ModelColumnControl.Color;
+  }
+
+  if (NUMBER_COLUMN_TYPES.includes(column.type)) {
+    return ModelColumnControl.Number;
+  }
+
+  if (LONG_TEXT_COLUMN_TYPES.includes(column.type)) {
+    return ModelColumnControl.LongText;
+  }
+
+  if (TEXT_COLUMN_TYPES.includes(column.type)) {
+    return ModelColumnControl.Text;
+  }
+
+  return ModelColumnControl.Text;
+};
+
+export type ColumnTypeLabelFunction = (
+  column: ModelSchemaColumn | undefined,
+) => string;
+
+/**
+ * The one-word type shown under a field's name, so the builder can see what
+ * kind of value is expected without opening the model's documentation.
+ */
+export const columnTypeLabel: ColumnTypeLabelFunction = (
+  column: ModelSchemaColumn | undefined,
+): string => {
+  if (!column) {
+    return "Unknown";
+  }
+
+  if (column.isRelation) {
+    return "Relation";
+  }
+
+  switch (controlForColumn(column)) {
+    case ModelColumnControl.Number:
+      return "Number";
+    case ModelColumnControl.Boolean:
+      return "True or false";
+    case ModelColumnControl.Date:
+      return "Date and time";
+    case ModelColumnControl.ObjectId:
+      return "ID";
+    case ModelColumnControl.Color:
+      return "Color";
+    case ModelColumnControl.LongText:
+      return "Long text";
+    case ModelColumnControl.Unsupported:
+      /*
+       * The raw column type is more use than the word "unsupported" here: it is
+       * what the builder will have to write by hand in the JSON editor.
+       */
+      return column.type;
+    default:
+      return "Text";
+  }
+};
+
+export type LiteralFitsControlFunction = (
+  control: ModelColumnControl,
+  value: unknown,
+) => boolean;
+
+/**
+ * Can this stored value be shown in the typed control without changing it?
+ *
+ * A `false` here is not an error — it sends the row to ColumnValueMode.Raw,
+ * where it is shown as text and re-emitted exactly as it was read. That is what
+ * stops opening a workflow and saving it again from rewriting `{"port":"8080"}`
+ * into `{"port":8080}` behind the builder's back.
+ */
+export const literalFitsControl: LiteralFitsControlFunction = (
+  control: ModelColumnControl,
+  value: unknown,
+): boolean => {
+  /*
+   * An empty control holds "" and nothing else. undefined and "" are what an
+   * untouched row is, so they fit; null does not, because an empty control
+   * cannot say "null" - it emits "", which a record drops entirely. A stored
+   * null therefore keeps its own value rather than being flattened into a
+   * missing field.
+   */
+  if (value === undefined || value === "") {
+    return true;
+  }
+
+  if (value === null) {
+    return false;
+  }
+
+  switch (control) {
+    case ModelColumnControl.Number:
+      return typeof value === "number" && !isNaN(value);
+    case ModelColumnControl.Boolean:
+      return typeof value === "boolean";
+    case ModelColumnControl.Date:
+      /*
+       * Dates travel as ISO strings. Anything else - a number of milliseconds,
+       * an operator wrapper - is shown raw rather than reinterpreted.
+       */
+      return typeof value === "string" && !isNaN(Date.parse(value));
+    default:
+      return typeof value === "string";
+  }
+};
+
+export type IsOfferableColumnFunction = (column: ModelSchemaColumn) => boolean;
+
+/**
+ * Should this column appear in the "add a field" picker?
+ *
+ * Note this only gates what is *offered*. A column already stored on the
+ * argument always gets its row, tenant column and all, because hiding a value
+ * that is really there is how an editor loses someone's work.
+ */
+export const isOfferableColumn: IsOfferableColumnFunction = (
+  column: ModelSchemaColumn,
+): boolean => {
+  if (column.isRelation) {
+    return false;
+  }
+
+  /*
+   * The workflow runner stamps the project column itself
+   * (ModelArguments.applyTenantColumn) and overwrites whatever was typed, so
+   * offering it would be offering a field that cannot work.
+   */
+  if (column.isTenantColumn) {
+    return false;
+  }
+
+  return controlForColumn(column) !== ModelColumnControl.Unsupported;
+};

--- a/Common/UI/Components/Workflow/ColumnEditor/ColumnFieldRow.tsx
+++ b/Common/UI/Components/Workflow/ColumnEditor/ColumnFieldRow.tsx
@@ -1,0 +1,184 @@
+/*
+ * One field of a record: the column's real name and description on the left,
+ * the value on the right.
+ *
+ * This is a settings form, not a table of key/value pairs, because the keys are
+ * not the builder's to invent - they are the model's columns, and the model has
+ * already said what each one is called and what it means.
+ */
+
+import IconProp from "../../../../Types/Icon/IconProp";
+import AutocompleteTextInput from "../../AutocompleteTextInput/AutocompleteTextInput";
+import Button, { ButtonStyleType } from "../../Button/Button";
+import { ModelSchemaColumn } from "../ModelSchema";
+import { columnTypeLabel, controlForColumn } from "./ColumnControl";
+import {
+  ColumnValueMode,
+  ModelColumnControl,
+  ModelColumnRow,
+} from "./ColumnRow";
+import { rowIssue } from "./ColumnRowSerialization";
+import ColumnValueInput from "./ColumnValueInput";
+import React, { FunctionComponent, ReactElement, useId } from "react";
+
+export interface ComponentProps {
+  row: ModelColumnRow;
+  /** Undefined when the stored key is not a column this model describes. */
+  column: ModelSchemaColumn | undefined;
+  /** Every column id, offered as autocomplete when a key has to be retyped. */
+  knownColumnIds: Array<string>;
+  isRequired: boolean;
+  suggestions?: Array<string> | undefined;
+  onChange: (row: ModelColumnRow) => void;
+  onRemove: () => void;
+}
+
+const ColumnFieldRow: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const labelId: string = useId();
+  const control: ModelColumnControl = controlForColumn(props.column);
+  const issue: string | null = rowIssue(props.row, props.column);
+  const isUnknownColumn: boolean = !props.column;
+  const typeLabel: string = columnTypeLabel(props.column);
+
+  /*
+   * An empty required field is worth pointing at, but only quietly: the step
+   * cannot be saved without it anyway (form validation reads the whole value),
+   * and a red row for something the builder has not reached yet reads as an
+   * error they made.
+   */
+  const isEmptyRequired: boolean =
+    props.isRequired && props.row.text === "" && props.row.values.length === 0;
+
+  return (
+    <div
+      className="group relative grid grid-cols-1 items-start gap-x-4 gap-y-2 px-3 py-3 transition-colors hover:bg-gray-50/60 sm:grid-cols-[minmax(0,14rem)_minmax(0,1fr)_auto]"
+      data-testid="model-column-row"
+    >
+      {isEmptyRequired && (
+        <span
+          className="absolute left-0 top-2 bottom-2 w-0.5 rounded-r bg-amber-400"
+          aria-hidden="true"
+        />
+      )}
+
+      <div className="min-w-0">
+        {isUnknownColumn ? (
+          <div>
+            <AutocompleteTextInput
+              value={props.row.columnId}
+              placeholder="Column name"
+              suggestions={props.knownColumnIds}
+              outerDivClassName="relative w-full"
+              className="block w-full rounded-md border border-amber-300 bg-white py-1.5 pl-2 pr-2 font-mono text-xs text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              disableSpellCheck={true}
+              onChange={(value: string) => {
+                props.onChange({ ...props.row, columnId: value });
+              }}
+            />
+            <span className="mt-1 inline-block rounded bg-amber-50 px-1.5 py-0.5 text-[11px] text-amber-700">
+              Not a column on this model
+            </span>
+          </div>
+        ) : (
+          <>
+            <label
+              id={labelId}
+              className="block truncate text-sm font-medium text-gray-900"
+            >
+              {props.column?.title}
+              {props.isRequired && (
+                <span className="ml-0.5 text-red-500" aria-hidden="true">
+                  *
+                </span>
+              )}
+            </label>
+            {/*
+              The column name and its type share a line. Stacked they made every
+              field four lines tall, and the two together are one fact: what this
+              key is called on the wire, and what shape of value it takes.
+
+              The type is dropped when it would only repeat the field's own name -
+              a column called "Color" does not need "Color" printed under it.
+            */}
+            <span className="mt-1 flex items-center gap-1.5 text-[11px] text-gray-500">
+              <span className="truncate rounded bg-gray-100 px-1.5 py-0.5 font-mono">
+                {props.row.columnId}
+              </span>
+              {typeLabel.toLowerCase() !==
+                (props.column?.title || "").toLowerCase() && (
+                <span className="truncate text-gray-400">{typeLabel}</span>
+              )}
+            </span>
+            {/*
+              Wrapped rather than truncated. This sentence is the model's own
+              explanation of the field and is often the only thing that settles
+              what to type; cutting it off mid-word and hiding the rest behind a
+              hover is not a real answer inside a modal.
+            */}
+            {props.column?.description && (
+              <span className="mt-1 block text-xs leading-snug text-gray-500">
+                {props.column.description}
+              </span>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className="min-w-0">
+        <ColumnValueInput
+          control={control}
+          valueMode={props.row.valueMode}
+          text={props.row.text}
+          values={props.row.values}
+          placeholder={props.column?.example || props.column?.placeholder}
+          suggestions={props.suggestions}
+          ariaLabelledby={isUnknownColumn ? undefined : labelId}
+          dataTestId={`model-column-value-${props.row.columnId}`}
+          onTextChange={(text: string) => {
+            props.onChange({ ...props.row, text: text, isSeeded: false });
+          }}
+          onValuesChange={(values: Array<string>) => {
+            props.onChange({ ...props.row, values: values, isSeeded: false });
+          }}
+          onValueModeChange={(valueMode: ColumnValueMode) => {
+            props.onChange({
+              ...props.row,
+              valueMode: valueMode,
+              isSeeded: false,
+            });
+          }}
+        />
+
+        {props.row.valueMode === ColumnValueMode.Raw && (
+          <p className="mt-1 text-[11px] text-amber-600">
+            Kept exactly as it was saved. Editing it rewrites it in this
+            column&apos;s own type.
+          </p>
+        )}
+
+        {issue && <p className="mt-1 text-[11px] text-red-500">{issue}</p>}
+
+        {props.column?.isTenantColumn && (
+          <p className="mt-1 text-[11px] text-gray-500">
+            The workflow sets this itself and ignores what you type here.
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center pt-1">
+        <Button
+          buttonStyle={ButtonStyleType.ICON}
+          icon={IconProp.Trash}
+          title="Remove"
+          dataTestId={`model-column-remove-${props.row.columnId}`}
+          className="opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100"
+          onClick={props.onRemove}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ColumnFieldRow;

--- a/Common/UI/Components/Workflow/ColumnEditor/ColumnFieldRow.tsx
+++ b/Common/UI/Components/Workflow/ColumnEditor/ColumnFieldRow.tsx
@@ -16,6 +16,7 @@ import {
   ColumnValueMode,
   ModelColumnControl,
   ModelColumnRow,
+  changeColumnRow,
 } from "./ColumnRow";
 import { rowIssue } from "./ColumnRowSerialization";
 import ColumnValueInput from "./ColumnValueInput";
@@ -29,6 +30,8 @@ export interface ComponentProps {
   knownColumnIds: Array<string>;
   isRequired: boolean;
   suggestions?: Array<string> | undefined;
+  /** Focused on mount, so a field added from the picker is ready to type into. */
+  autoFocus?: boolean | undefined;
   onChange: (row: ModelColumnRow) => void;
   onRemove: () => void;
 }
@@ -74,7 +77,7 @@ const ColumnFieldRow: FunctionComponent<ComponentProps> = (
               className="block w-full rounded-md border border-amber-300 bg-white py-1.5 pl-2 pr-2 font-mono text-xs text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
               disableSpellCheck={true}
               onChange={(value: string) => {
-                props.onChange({ ...props.row, columnId: value });
+                props.onChange(changeColumnRow(props.row, { columnId: value }));
               }}
             />
             <span className="mt-1 inline-block rounded bg-amber-50 px-1.5 py-0.5 text-[11px] text-amber-700">
@@ -135,19 +138,10 @@ const ColumnFieldRow: FunctionComponent<ComponentProps> = (
           placeholder={props.column?.example || props.column?.placeholder}
           suggestions={props.suggestions}
           ariaLabelledby={isUnknownColumn ? undefined : labelId}
+          autoFocus={props.autoFocus}
           dataTestId={`model-column-value-${props.row.columnId}`}
-          onTextChange={(text: string) => {
-            props.onChange({ ...props.row, text: text, isSeeded: false });
-          }}
-          onValuesChange={(values: Array<string>) => {
-            props.onChange({ ...props.row, values: values, isSeeded: false });
-          }}
-          onValueModeChange={(valueMode: ColumnValueMode) => {
-            props.onChange({
-              ...props.row,
-              valueMode: valueMode,
-              isSeeded: false,
-            });
+          onChange={(change: Partial<ModelColumnRow>) => {
+            props.onChange(changeColumnRow(props.row, change));
           }}
         />
 

--- a/Common/UI/Components/Workflow/ColumnEditor/ColumnOperators.ts
+++ b/Common/UI/Components/Workflow/ColumnEditor/ColumnOperators.ts
@@ -1,0 +1,206 @@
+/*
+ * Which comparisons a column can be filtered by, and what to call them.
+ *
+ * The old row editor offered all fourteen operators against every column, so a
+ * Boolean column offered "starts with" and an ID column offered "greater than".
+ * Both are accepted by the form and neither means anything - `uuid ILIKE '%x%'`
+ * needs a cast Postgres will not do for you.
+ *
+ * Only the labels change here. The DictionaryFilterOperator members, and
+ * therefore every byte that reaches the server, are exactly the ones the
+ * Dictionary form already emitted.
+ */
+
+import {
+  DICTIONARY_FILTER_OPERATOR_OPTIONS,
+  DictionaryFilterOperator,
+  DictionaryFilterOperatorOption,
+  getOperatorOption,
+} from "../../Dictionary/DictionaryFilterOperator";
+import { ModelColumnControl } from "./ColumnRow";
+
+const TEXT_OPERATORS: Array<DictionaryFilterOperator> = [
+  DictionaryFilterOperator.EqualTo,
+  DictionaryFilterOperator.NotEqual,
+  DictionaryFilterOperator.Contains,
+  DictionaryFilterOperator.NotContains,
+  DictionaryFilterOperator.StartsWith,
+  DictionaryFilterOperator.EndsWith,
+  DictionaryFilterOperator.IsAnyOf,
+  DictionaryFilterOperator.IsNoneOf,
+  DictionaryFilterOperator.IsEmpty,
+  DictionaryFilterOperator.IsNotEmpty,
+];
+
+const NUMBER_OPERATORS: Array<DictionaryFilterOperator> = [
+  DictionaryFilterOperator.EqualTo,
+  DictionaryFilterOperator.NotEqual,
+  DictionaryFilterOperator.GreaterThan,
+  DictionaryFilterOperator.GreaterThanOrEqual,
+  DictionaryFilterOperator.LessThan,
+  DictionaryFilterOperator.LessThanOrEqual,
+  DictionaryFilterOperator.IsAnyOf,
+  DictionaryFilterOperator.IsNoneOf,
+  DictionaryFilterOperator.IsEmpty,
+  DictionaryFilterOperator.IsNotEmpty,
+];
+
+const DATE_OPERATORS: Array<DictionaryFilterOperator> = [
+  DictionaryFilterOperator.EqualTo,
+  DictionaryFilterOperator.NotEqual,
+  DictionaryFilterOperator.GreaterThan,
+  DictionaryFilterOperator.GreaterThanOrEqual,
+  DictionaryFilterOperator.LessThan,
+  DictionaryFilterOperator.LessThanOrEqual,
+  DictionaryFilterOperator.IsEmpty,
+  DictionaryFilterOperator.IsNotEmpty,
+];
+
+const IDENTIFIER_OPERATORS: Array<DictionaryFilterOperator> = [
+  DictionaryFilterOperator.EqualTo,
+  DictionaryFilterOperator.NotEqual,
+  DictionaryFilterOperator.IsAnyOf,
+  DictionaryFilterOperator.IsNoneOf,
+  DictionaryFilterOperator.IsEmpty,
+  DictionaryFilterOperator.IsNotEmpty,
+];
+
+const BOOLEAN_OPERATORS: Array<DictionaryFilterOperator> = [
+  DictionaryFilterOperator.EqualTo,
+  DictionaryFilterOperator.NotEqual,
+  DictionaryFilterOperator.IsEmpty,
+  DictionaryFilterOperator.IsNotEmpty,
+];
+
+/*
+ * A date reads far better as "is after" than as ">", and the ordering
+ * operators are the whole point of filtering on one. Anything not listed keeps
+ * the shared label from DICTIONARY_FILTER_OPERATOR_OPTIONS.
+ */
+const DATE_OPERATOR_LABELS: Partial<Record<DictionaryFilterOperator, string>> =
+  {
+    [DictionaryFilterOperator.EqualTo]: "is",
+    [DictionaryFilterOperator.NotEqual]: "is not",
+    [DictionaryFilterOperator.GreaterThan]: "is after",
+    [DictionaryFilterOperator.GreaterThanOrEqual]: "is on or after",
+    [DictionaryFilterOperator.LessThan]: "is before",
+    [DictionaryFilterOperator.LessThanOrEqual]: "is on or before",
+    [DictionaryFilterOperator.IsEmpty]: "is not set",
+    [DictionaryFilterOperator.IsNotEmpty]: "is set",
+  };
+
+const BOOLEAN_OPERATOR_LABELS: Partial<
+  Record<DictionaryFilterOperator, string>
+> = {
+  [DictionaryFilterOperator.EqualTo]: "is",
+  [DictionaryFilterOperator.NotEqual]: "is not",
+  [DictionaryFilterOperator.IsEmpty]: "is not set",
+  [DictionaryFilterOperator.IsNotEmpty]: "is set",
+};
+
+const DEFAULT_OPERATOR_LABELS: Partial<
+  Record<DictionaryFilterOperator, string>
+> = {
+  [DictionaryFilterOperator.IsEmpty]: "is not set",
+  [DictionaryFilterOperator.IsNotEmpty]: "is set",
+};
+
+export type OperatorsForControlFunction = (
+  control: ModelColumnControl,
+  currentOperator?: DictionaryFilterOperator | undefined,
+) => Array<DictionaryFilterOperator>;
+
+/**
+ * The operators offered for a column, in the order they should be listed.
+ *
+ * `currentOperator` is always included even when the type filter would drop it.
+ * A query saved before this filter existed can hold "contains" on an ID column;
+ * leaving it out of the list would render a blank dropdown, and the next
+ * unrelated edit to that row would silently rewrite the operator to equals.
+ */
+export const operatorsForControl: OperatorsForControlFunction = (
+  control: ModelColumnControl,
+  currentOperator?: DictionaryFilterOperator | undefined,
+): Array<DictionaryFilterOperator> => {
+  let operators: Array<DictionaryFilterOperator>;
+
+  switch (control) {
+    case ModelColumnControl.Number:
+      operators = NUMBER_OPERATORS;
+      break;
+    case ModelColumnControl.Date:
+      operators = DATE_OPERATORS;
+      break;
+    case ModelColumnControl.ObjectId:
+    case ModelColumnControl.Color:
+      operators = IDENTIFIER_OPERATORS;
+      break;
+    case ModelColumnControl.Boolean:
+      operators = BOOLEAN_OPERATORS;
+      break;
+    default:
+      /*
+       * Unsupported lands here too. It is never offered in the picker, but a
+       * stored condition on such a column still gets a row, and that row should
+       * have the widest set rather than the narrowest.
+       */
+      operators = TEXT_OPERATORS;
+      break;
+  }
+
+  if (currentOperator && !operators.includes(currentOperator)) {
+    return [...operators, currentOperator];
+  }
+
+  return [...operators];
+};
+
+export type DefaultOperatorForControlFunction = (
+  control: ModelColumnControl,
+) => DictionaryFilterOperator;
+
+export const defaultOperatorForControl: DefaultOperatorForControlFunction =
+  (): DictionaryFilterOperator => {
+    /*
+     * Equals for every type. It is the only operator that is right more often
+     * than not, and it is the one the value serializes without a wrapper.
+     */
+    return DictionaryFilterOperator.EqualTo;
+  };
+
+export type OperatorLabelForFunction = (
+  operator: DictionaryFilterOperator,
+  control: ModelColumnControl,
+) => string;
+
+export const operatorLabelFor: OperatorLabelForFunction = (
+  operator: DictionaryFilterOperator,
+  control: ModelColumnControl,
+): string => {
+  const overrides: Partial<Record<DictionaryFilterOperator, string>> =
+    control === ModelColumnControl.Date
+      ? DATE_OPERATOR_LABELS
+      : control === ModelColumnControl.Boolean
+        ? BOOLEAN_OPERATOR_LABELS
+        : DEFAULT_OPERATOR_LABELS;
+
+  const override: string | undefined = overrides[operator];
+
+  if (override) {
+    return override;
+  }
+
+  return getOperatorOption(operator).label;
+};
+
+export type IsKnownOperatorFunction = (value: string) => boolean;
+
+export const isKnownOperator: IsKnownOperatorFunction = (
+  value: string,
+): boolean => {
+  return DICTIONARY_FILTER_OPERATOR_OPTIONS.some(
+    (option: DictionaryFilterOperatorOption) => {
+      return option.operator === value;
+    },
+  );
+};

--- a/Common/UI/Components/Workflow/ColumnEditor/ColumnRow.ts
+++ b/Common/UI/Components/Workflow/ColumnEditor/ColumnRow.ts
@@ -1,0 +1,96 @@
+/*
+ * The row model shared by the record form and the query builder.
+ *
+ * A row is one column of the model plus the value the builder typed for it.
+ * Everything the editor knows about a row that is not the schema lives here,
+ * and the two React bodies hold no state of their own — ModelColumnEditor owns
+ * the array and hands it down, so a row can never disagree with the JSON the
+ * argument is stored as.
+ */
+
+import { DictionaryFilterOperator } from "../../Dictionary/DictionaryFilterOperator";
+
+/**
+ * The kind of control a column's value is typed into.
+ *
+ * Deliberately much smaller than TableColumnType: the builder does not need a
+ * different box for Email than for Slug, and every extra control is another
+ * thing that can render the wrong way round. What matters is the shape of the
+ * value that comes out — string, number, boolean, ISO date — because that is
+ * what ends up in the JSON the server parses.
+ */
+export enum ModelColumnControl {
+  Text = "Text",
+  LongText = "LongText",
+  Number = "Number",
+  Boolean = "Boolean",
+  Date = "Date",
+  ObjectId = "ObjectId",
+  Color = "Color",
+  /** Buffers, files, nested JSON, monitor steps — no row can hold one. */
+  Unsupported = "Unsupported",
+}
+
+/**
+ * How the value in a row is being edited.
+ *
+ * Literal is the type-appropriate control. Reference is the {{ }} autocomplete,
+ * available on every column type because most creates are assembled out of an
+ * earlier step's return values. Raw is the escape hatch for a stored scalar
+ * whose JavaScript type disagrees with the column's — `{"port": "8080"}` on a
+ * numeric column — which is re-emitted exactly as it was read until the builder
+ * edits that one cell. Without Raw, opening a workflow and saving it again
+ * would quietly rewrite the stored bytes.
+ */
+export enum ColumnValueMode {
+  Literal = "Literal",
+  Reference = "Reference",
+  Raw = "Raw",
+}
+
+/**
+ * One row of the editor.
+ *
+ * `text` is what the control shows and is always a string, whatever the column
+ * type — the conversion to a JSON number/boolean/null happens once, on the way
+ * out, in ColumnRowSerialization. `values` is only used by the multi-value
+ * operators (is any of / is none of), which Record mode never offers.
+ */
+export interface ModelColumnRow {
+  /** The column name as it will be written into the JSON object. */
+  columnId: string;
+  operator: DictionaryFilterOperator;
+  valueMode: ColumnValueMode;
+  text: string;
+  values: Array<string>;
+  /**
+   * True for a blank row the editor opened with because the model says a create
+   * must supply this column. Seeded rows serialize away while they are empty,
+   * so an untouched Create One still reads as "nothing set" to form validation
+   * and to the graph linter.
+   */
+  isSeeded: boolean;
+  /**
+   * The value exactly as it was read from storage, kept only for
+   * ColumnValueMode.Raw so that round-tripping is byte-for-byte.
+   */
+  rawValue?: unknown;
+}
+
+export type MakeColumnRowFunction = (
+  row: Partial<ModelColumnRow> & { columnId: string },
+) => ModelColumnRow;
+
+export const makeColumnRow: MakeColumnRowFunction = (
+  row: Partial<ModelColumnRow> & { columnId: string },
+): ModelColumnRow => {
+  return {
+    columnId: row.columnId,
+    operator: row.operator || DictionaryFilterOperator.EqualTo,
+    valueMode: row.valueMode || ColumnValueMode.Literal,
+    text: row.text === undefined ? "" : row.text,
+    values: row.values || [],
+    isSeeded: Boolean(row.isSeeded),
+    ...(row.rawValue === undefined ? {} : { rawValue: row.rawValue }),
+  };
+};

--- a/Common/UI/Components/Workflow/ColumnEditor/ColumnRow.ts
+++ b/Common/UI/Components/Workflow/ColumnEditor/ColumnRow.ts
@@ -57,6 +57,14 @@ export enum ColumnValueMode {
  * operators (is any of / is none of), which Record mode never offers.
  */
 export interface ModelColumnRow {
+  /**
+   * This row's identity for React, fixed when the row is created.
+   *
+   * It cannot be the column name: an unknown column is edited in a text box, so
+   * keying on the name would give the row a new identity on every keystroke,
+   * unmount it mid-word and take the focused input with it.
+   */
+  key: string;
   /** The column name as it will be written into the JSON object. */
   columnId: string;
   operator: DictionaryFilterOperator;
@@ -77,6 +85,12 @@ export interface ModelColumnRow {
   rawValue?: unknown;
 }
 
+/*
+ * A counter rather than a random id, so a row's identity is reproducible and
+ * two editors mounted in the same page can never collide.
+ */
+let nextRowKey: number = 0;
+
 export type MakeColumnRowFunction = (
   row: Partial<ModelColumnRow> & { columnId: string },
 ) => ModelColumnRow;
@@ -84,7 +98,10 @@ export type MakeColumnRowFunction = (
 export const makeColumnRow: MakeColumnRowFunction = (
   row: Partial<ModelColumnRow> & { columnId: string },
 ): ModelColumnRow => {
+  nextRowKey = nextRowKey + 1;
+
   return {
+    key: row.key || `row-${nextRowKey}`,
     columnId: row.columnId,
     operator: row.operator || DictionaryFilterOperator.EqualTo,
     valueMode: row.valueMode || ColumnValueMode.Literal,
@@ -93,4 +110,48 @@ export const makeColumnRow: MakeColumnRowFunction = (
     isSeeded: Boolean(row.isSeeded),
     ...(row.rawValue === undefined ? {} : { rawValue: row.rawValue }),
   };
+};
+
+/**
+ * A row with some of its fields changed.
+ *
+ * Every edit goes through here rather than through several separate callbacks,
+ * because two callbacks fired from one event both close over the same render's
+ * row and the second silently discards the first. That is how editing a raw
+ * cell came to change the box on screen without changing what was stored.
+ *
+ * Leaving Raw drops the stored original: from that point the builder's own
+ * value is what the row means, in the column's own type.
+ */
+export type ChangeColumnRowFunction = (
+  row: ModelColumnRow,
+  change: Partial<
+    Pick<
+      ModelColumnRow,
+      "columnId" | "operator" | "valueMode" | "text" | "values"
+    >
+  >,
+) => ModelColumnRow;
+
+export const changeColumnRow: ChangeColumnRowFunction = (
+  row: ModelColumnRow,
+  change: Partial<
+    Pick<
+      ModelColumnRow,
+      "columnId" | "operator" | "valueMode" | "text" | "values"
+    >
+  >,
+): ModelColumnRow => {
+  const next: ModelColumnRow = {
+    ...row,
+    ...change,
+    // Any edit means the row is no longer just a blank the editor opened with.
+    isSeeded: false,
+  };
+
+  if (next.valueMode !== ColumnValueMode.Raw) {
+    delete next.rawValue;
+  }
+
+  return next;
 };

--- a/Common/UI/Components/Workflow/ColumnEditor/ColumnRowSerialization.ts
+++ b/Common/UI/Components/Workflow/ColumnEditor/ColumnRowSerialization.ts
@@ -89,8 +89,14 @@ const literalTextFor: LiteralTextForFunction = (
     return "";
   }
 
-  if (control === ModelColumnControl.Boolean) {
-    return value === true ? "true" : "false";
+  /*
+   * Only a real boolean is spelled out. Mapping everything else to "false" put
+   * a stored "true" - or "yes", or 1 - on screen as the word "false", which is
+   * the opposite of what the workflow does, and this function also names the
+   * text of a raw row, where the value is by definition not a boolean.
+   */
+  if (control === ModelColumnControl.Boolean && typeof value === "boolean") {
+    return value ? "true" : "false";
   }
 
   return String(value);

--- a/Common/UI/Components/Workflow/ColumnEditor/ColumnRowSerialization.ts
+++ b/Common/UI/Components/Workflow/ColumnEditor/ColumnRowSerialization.ts
@@ -1,0 +1,511 @@
+/*
+ * Stored JSON <-> rows, in both directions.
+ *
+ * The last step out is always buildColumnValueJson, and the operator wrappers
+ * are always built by buildDictionaryValue, so the bytes that reach the server
+ * are produced by exactly the code that produced them before this editor
+ * existed. Everything here decides *what* to hand those two functions.
+ *
+ * The rule that shapes the whole file: reading a value and writing it back
+ * unchanged must produce the same bytes. An editor that quietly rewrites
+ * {"port": "8080"} into {"port": 8080} the moment someone opens a workflow and
+ * saves it is worse than one that asks a question it should not have needed to
+ * ask.
+ */
+
+import GreaterThan from "../../../../Types/BaseDatabase/GreaterThan";
+import GreaterThanOrEqual from "../../../../Types/BaseDatabase/GreaterThanOrEqual";
+import LessThan from "../../../../Types/BaseDatabase/LessThan";
+import LessThanOrEqual from "../../../../Types/BaseDatabase/LessThanOrEqual";
+import Dictionary from "../../../../Types/Dictionary";
+import { JSONObject } from "../../../../Types/JSON";
+import { getTemplateExpressionRegex } from "../../../../Types/Workflow/TemplateSyntax";
+import {
+  DictionaryEntryValue,
+  DictionaryFilterOperator,
+  DictionaryFilterOperatorOption,
+  buildDictionaryValue,
+  detectOperatorFromValue,
+  getOperatorOption,
+} from "../../Dictionary/DictionaryFilterOperator";
+import {
+  ModelColumnEditorMode,
+  buildColumnValueJson,
+} from "../ModelColumnEditor";
+import {
+  ModelSchemaColumn,
+  findColumn,
+  requiredWritableColumns,
+} from "../ModelSchema";
+import { controlForColumn, literalFitsControl } from "./ColumnControl";
+import {
+  ColumnValueMode,
+  ModelColumnControl,
+  ModelColumnRow,
+  makeColumnRow,
+} from "./ColumnRow";
+
+export type ContainsTemplateExpressionFunction = (value: string) => boolean;
+
+/**
+ * Does this text hold a {{ }} reference?
+ *
+ * Uses the runtime's own matcher rather than a hand-rolled `/{{/`, so a value
+ * this editor calls a reference is one the runner will actually substitute.
+ */
+export const containsTemplateExpression: ContainsTemplateExpressionFunction = (
+  value: string,
+): boolean => {
+  return getTemplateExpressionRegex().test(value);
+};
+
+type UnwrapOperatorValueFunction = (value: unknown) => unknown;
+
+/*
+ * The scalar inside an operator wrapper, or the value itself when it is not
+ * one. detectOperatorFromValue gives back a string for display; this keeps the
+ * original JavaScript type so a stored number stays a number.
+ */
+const unwrapOperatorValue: UnwrapOperatorValueFunction = (
+  value: unknown,
+): unknown => {
+  if (value && typeof value === "object" && "value" in value) {
+    return (value as { value?: unknown }).value;
+  }
+
+  return value;
+};
+
+type LiteralTextForFunction = (
+  control: ModelColumnControl,
+  value: unknown,
+) => string;
+
+const literalTextFor: LiteralTextForFunction = (
+  control: ModelColumnControl,
+  value: unknown,
+): string => {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  if (control === ModelColumnControl.Boolean) {
+    return value === true ? "true" : "false";
+  }
+
+  return String(value);
+};
+
+export type ClassifyRowValueFunction = (
+  control: ModelColumnControl,
+  value: unknown,
+) => Pick<ModelColumnRow, "valueMode" | "text" | "rawValue">;
+
+/**
+ * Which of the three editing modes a stored value belongs in.
+ *
+ * Inferred once, when the value is read. Never guessed at render time - a cell
+ * that decided for itself what it was holding would flip modes as the builder
+ * typed.
+ */
+export const classifyRowValue: ClassifyRowValueFunction = (
+  control: ModelColumnControl,
+  value: unknown,
+): Pick<ModelColumnRow, "valueMode" | "text" | "rawValue"> => {
+  if (typeof value === "string" && containsTemplateExpression(value)) {
+    return { valueMode: ColumnValueMode.Reference, text: value };
+  }
+
+  /*
+   * null is a real stored value and no empty control can express it: an empty
+   * control emits "", which a record drops entirely. So it is kept raw and
+   * re-emitted verbatim until the builder types over it.
+   */
+  if (value === null) {
+    return { valueMode: ColumnValueMode.Raw, text: "", rawValue: null };
+  }
+
+  if (literalFitsControl(control, value)) {
+    return {
+      valueMode: ColumnValueMode.Literal,
+      text: literalTextFor(control, value),
+    };
+  }
+
+  return {
+    valueMode: ColumnValueMode.Raw,
+    text: literalTextFor(control, value),
+    rawValue: value,
+  };
+};
+
+export type RowsFromParsedValueFunction = (
+  parsed: JSONObject | null,
+  columns: Array<ModelSchemaColumn>,
+  mode: ModelColumnEditorMode,
+) => Array<ModelColumnRow>;
+
+/**
+ * The stored object, as rows, in the order its keys were written.
+ *
+ * Order is never sorted. The picker is sorted (the endpoint does it by title),
+ * but the rows are the document, and reordering them is rewriting the stored
+ * bytes for nothing.
+ */
+export const rowsFromParsedValue: RowsFromParsedValueFunction = (
+  parsed: JSONObject | null,
+  columns: Array<ModelSchemaColumn>,
+  mode: ModelColumnEditorMode,
+): Array<ModelColumnRow> => {
+  if (!parsed) {
+    return [];
+  }
+
+  const isQuery: boolean = mode === ModelColumnEditorMode.Query;
+  const rows: Array<ModelColumnRow> = [];
+
+  for (const key of Object.keys(parsed)) {
+    const value: unknown = parsed[key];
+    const column: ModelSchemaColumn | undefined = findColumn(columns, key);
+    const control: ModelColumnControl = controlForColumn(column);
+
+    if (!isQuery) {
+      rows.push(
+        makeColumnRow({
+          columnId: key,
+          operator: DictionaryFilterOperator.EqualTo,
+          ...classifyRowValue(control, value),
+        }),
+      );
+      continue;
+    }
+
+    const detected: {
+      operator: DictionaryFilterOperator;
+      rawValue: string;
+      rawValues?: Array<string> | undefined;
+    } = detectOperatorFromValue(value);
+
+    const option: DictionaryFilterOperatorOption = getOperatorOption(
+      detected.operator,
+    );
+
+    if (option.expectsMultiValue) {
+      rows.push(
+        makeColumnRow({
+          columnId: key,
+          operator: detected.operator,
+          values: detected.rawValues || [],
+        }),
+      );
+      continue;
+    }
+
+    if (option.hidesValueInput) {
+      rows.push(makeColumnRow({ columnId: key, operator: detected.operator }));
+      continue;
+    }
+
+    rows.push(
+      makeColumnRow({
+        columnId: key,
+        operator: detected.operator,
+        ...classifyRowValue(control, unwrapOperatorValue(value)),
+      }),
+    );
+  }
+
+  return rows;
+};
+
+export type SeedRequiredRowsFunction = (
+  rows: Array<ModelColumnRow>,
+  columns: Array<ModelSchemaColumn>,
+) => Array<ModelColumnRow>;
+
+/**
+ * One blank row per column a create must be given a value for, appended after
+ * whatever was stored.
+ *
+ * Appended, never inserted: the stored keys keep their order, so seeding cannot
+ * change the bytes of a workflow that is only opened and closed. Seeded rows
+ * hold "" and are dropped on the way out, so an untouched Create One still
+ * reads as empty to form validation and to the graph linter.
+ */
+export const seedRequiredRows: SeedRequiredRowsFunction = (
+  rows: Array<ModelColumnRow>,
+  columns: Array<ModelSchemaColumn>,
+): Array<ModelColumnRow> => {
+  const present: Set<string> = new Set(
+    rows.map((row: ModelColumnRow) => {
+      return row.columnId;
+    }),
+  );
+
+  const seeded: Array<ModelColumnRow> = [];
+
+  for (const column of requiredWritableColumns(columns)) {
+    if (present.has(column.id)) {
+      continue;
+    }
+
+    seeded.push(makeColumnRow({ columnId: column.id, isSeeded: true }));
+  }
+
+  return [...rows, ...seeded];
+};
+
+type EmitLiteralValueFunction = (
+  control: ModelColumnControl,
+  text: string,
+) => DictionaryEntryValue;
+
+/**
+ * A row's text, as the JSON value it stands for.
+ *
+ * "" is returned as "" rather than as null or omitted, because that is the
+ * marker buildColumnValueJson reads to drop a blank field from a record.
+ */
+const emitLiteralValue: EmitLiteralValueFunction = (
+  control: ModelColumnControl,
+  text: string,
+): DictionaryEntryValue => {
+  if (text === "") {
+    return "";
+  }
+
+  if (control === ModelColumnControl.Number) {
+    const asNumber: number = Number(text);
+
+    /*
+     * Text that is not a number is emitted as text, not dropped and not turned
+     * into NaN. The row shows why it is wrong; throwing the value away would
+     * take the builder's work with it.
+     */
+    if (text.trim() === "" || isNaN(asNumber)) {
+      return text;
+    }
+
+    return asNumber;
+  }
+
+  if (control === ModelColumnControl.Boolean) {
+    if (text === "true") {
+      return true;
+    }
+
+    if (text === "false") {
+      return false;
+    }
+
+    return text;
+  }
+
+  return text;
+};
+
+export type EmitRowValueFunction = (
+  row: ModelColumnRow,
+  control: ModelColumnControl,
+) => DictionaryEntryValue;
+
+/**
+ * The value half of a row, before any operator wrapper is put around it.
+ */
+export const emitRowValue: EmitRowValueFunction = (
+  row: ModelColumnRow,
+  control: ModelColumnControl,
+): DictionaryEntryValue => {
+  if (row.valueMode === ColumnValueMode.Raw) {
+    return row.rawValue as DictionaryEntryValue;
+  }
+
+  /*
+   * A reference is always emitted as a string, on every column type. The
+   * runner substitutes the text and the result is parsed as JSON, so an
+   * unquoted substitution on a numeric column would be a gamble on what the
+   * referenced value happens to look like. Postgres casts '5' to 5 on the way
+   * into an integer column; it cannot rescue a document that does not parse.
+   */
+  if (row.valueMode === ColumnValueMode.Reference) {
+    return row.text;
+  }
+
+  return emitLiteralValue(control, row.text);
+};
+
+type BuildComparisonWrapperFunction = (
+  operator: DictionaryFilterOperator,
+  value: string,
+) => DictionaryEntryValue | null;
+
+/*
+ * The ordering operators built over a string rather than a number.
+ *
+ * buildDictionaryValue does `new GreaterThan(Number(text))`, which is right for
+ * a number and silently destructive for anything else: a date or a {{ }}
+ * reference becomes NaN, and JSON.stringify writes NaN as null - a query
+ * against NULL that matches nothing and reports no error. These columns are
+ * declared CompareType = number | Date | string, so the string form is a value
+ * the wrapper was always able to hold.
+ */
+const buildComparisonWrapper: BuildComparisonWrapperFunction = (
+  operator: DictionaryFilterOperator,
+  value: string,
+): DictionaryEntryValue | null => {
+  switch (operator) {
+    case DictionaryFilterOperator.GreaterThan:
+      return new GreaterThan<string>(value);
+    case DictionaryFilterOperator.GreaterThanOrEqual:
+      return new GreaterThanOrEqual<string>(value);
+    case DictionaryFilterOperator.LessThan:
+      return new LessThan<string>(value);
+    case DictionaryFilterOperator.LessThanOrEqual:
+      return new LessThanOrEqual<string>(value);
+    default:
+      return null;
+  }
+};
+
+export type BuildOperatorValueFunction = (
+  row: ModelColumnRow,
+  control: ModelColumnControl,
+) => DictionaryEntryValue;
+
+/**
+ * A query row, wrapped in whatever its operator needs.
+ *
+ * Delegates to buildDictionaryValue for every case it handles correctly, so
+ * each wrapper class's own toJSON() still produces the bytes and the key order
+ * inside {_type, value} is unchanged.
+ */
+export const buildOperatorValue: BuildOperatorValueFunction = (
+  row: ModelColumnRow,
+  control: ModelColumnControl,
+): DictionaryEntryValue => {
+  const option: DictionaryFilterOperatorOption = getOperatorOption(
+    row.operator,
+  );
+
+  if (option.hidesValueInput) {
+    return buildDictionaryValue({ operator: row.operator, rawValue: "" });
+  }
+
+  if (option.expectsMultiValue) {
+    return buildDictionaryValue({
+      operator: row.operator,
+      rawValue: "",
+      rawValues: row.values,
+    });
+  }
+
+  const emitted: DictionaryEntryValue = emitRowValue(row, control);
+
+  /*
+   * Equality carries no wrapper at all - it is stored as the bare value, which
+   * is what every query written before operators existed looks like.
+   */
+  if (row.operator === DictionaryFilterOperator.EqualTo) {
+    return emitted;
+  }
+
+  if (option.expectsNumericValue && typeof emitted !== "number") {
+    const wrapper: DictionaryEntryValue | null = buildComparisonWrapper(
+      row.operator,
+      typeof emitted === "string" ? emitted : String(emitted ?? ""),
+    );
+
+    if (wrapper !== null) {
+      return wrapper;
+    }
+  }
+
+  return buildDictionaryValue({
+    operator: row.operator,
+    rawValue: typeof emitted === "string" ? emitted : String(emitted ?? ""),
+  });
+};
+
+export type RowsToEntryDictionaryFunction = (
+  rows: Array<ModelColumnRow>,
+  columns: Array<ModelSchemaColumn>,
+  mode: ModelColumnEditorMode,
+) => Dictionary<DictionaryEntryValue>;
+
+export const rowsToEntryDictionary: RowsToEntryDictionaryFunction = (
+  rows: Array<ModelColumnRow>,
+  columns: Array<ModelSchemaColumn>,
+  mode: ModelColumnEditorMode,
+): Dictionary<DictionaryEntryValue> => {
+  const entries: Dictionary<DictionaryEntryValue> = {};
+  const isQuery: boolean = mode === ModelColumnEditorMode.Query;
+
+  for (const row of rows) {
+    if (row.columnId.trim() === "") {
+      continue;
+    }
+
+    const control: ModelColumnControl = controlForColumn(
+      findColumn(columns, row.columnId),
+    );
+
+    entries[row.columnId] = isQuery
+      ? buildOperatorValue(row, control)
+      : emitRowValue(row, control);
+  }
+
+  return entries;
+};
+
+export type SerializeColumnRowsFunction = (
+  rows: Array<ModelColumnRow>,
+  columns: Array<ModelSchemaColumn>,
+  mode: ModelColumnEditorMode,
+) => string;
+
+/**
+ * The rows, as the string stored on the workflow argument.
+ *
+ * Ends in buildColumnValueJson, unchanged, which is what drops blank record
+ * fields and collapses an empty editor to "" rather than to "{}".
+ */
+export const serializeColumnRows: SerializeColumnRowsFunction = (
+  rows: Array<ModelColumnRow>,
+  columns: Array<ModelSchemaColumn>,
+  mode: ModelColumnEditorMode,
+): string => {
+  return buildColumnValueJson(rowsToEntryDictionary(rows, columns, mode), mode);
+};
+
+export type RowIssueFunction = (
+  row: ModelColumnRow,
+  column: ModelSchemaColumn | undefined,
+) => string | null;
+
+/**
+ * What is wrong with what has been typed into this row, in one sentence, or
+ * null when nothing is.
+ *
+ * Advisory only. Nothing here blocks saving: the value is still written, and
+ * the builder can still be right about a column this endpoint describes badly.
+ */
+export const rowIssue: RowIssueFunction = (
+  row: ModelColumnRow,
+  column: ModelSchemaColumn | undefined,
+): string | null => {
+  if (row.valueMode !== ColumnValueMode.Literal || row.text === "") {
+    return null;
+  }
+
+  const control: ModelColumnControl = controlForColumn(column);
+
+  if (control === ModelColumnControl.Number && isNaN(Number(row.text))) {
+    return "This column takes a number.";
+  }
+
+  if (control === ModelColumnControl.Date && isNaN(Date.parse(row.text))) {
+    return "This column takes a date and time.";
+  }
+
+  return null;
+};

--- a/Common/UI/Components/Workflow/ColumnEditor/ColumnValueInput.tsx
+++ b/Common/UI/Components/Workflow/ColumnEditor/ColumnValueInput.tsx
@@ -30,11 +30,25 @@ export interface ComponentProps {
   placeholder?: string | undefined;
   /** The other steps' return values and the workflow's variables. */
   suggestions?: Array<string> | undefined;
-  onTextChange: (value: string) => void;
-  onValuesChange: (values: Array<string>) => void;
-  onValueModeChange: (valueMode: ColumnValueMode) => void;
+  /**
+   * Every edit reports as one change.
+   *
+   * Deliberately not three callbacks: two of them fired from a single event
+   * both close over the same render's row, so the second silently discards the
+   * first - which is what made a raw cell impossible to type into and the
+   * "typing {{ turns this into a reference" behaviour dead.
+   */
+  onChange: (
+    change: Partial<{
+      text: string;
+      values: Array<string>;
+      valueMode: ColumnValueMode;
+    }>,
+  ) => void;
   tabIndex?: number | undefined;
   ariaLabelledby?: string | undefined;
+  /** Focused on mount, so picking a field lands the caret in its value box. */
+  autoFocus?: boolean | undefined;
   dataTestId?: string | undefined;
 }
 
@@ -58,10 +72,11 @@ const ColumnValueInput: FunctionComponent<ComponentProps> = (
    */
   const setTextAndDetectReference: SetTextFunction = (value: string): void => {
     if (!isReference && value.includes("{{")) {
-      props.onValueModeChange(ColumnValueMode.Reference);
+      props.onChange({ text: value, valueMode: ColumnValueMode.Reference });
+      return;
     }
 
-    props.onTextChange(value);
+    props.onChange({ text: value });
   };
 
   /*
@@ -91,9 +106,11 @@ const ColumnValueInput: FunctionComponent<ComponentProps> = (
           : "border-transparent text-gray-400 hover:border-gray-200 hover:bg-gray-50 hover:text-gray-600"
       }`}
       onClick={() => {
-        props.onValueModeChange(
-          isReference ? ColumnValueMode.Literal : ColumnValueMode.Reference,
-        );
+        props.onChange({
+          valueMode: isReference
+            ? ColumnValueMode.Literal
+            : ColumnValueMode.Reference,
+        });
       }}
     >
       {isReference ? "abc" : "{ }"}
@@ -116,7 +133,9 @@ const ColumnValueInput: FunctionComponent<ComponentProps> = (
         placeholder={props.placeholder}
         ariaLabelledby={props.ariaLabelledby}
         dataTestId={props.dataTestId}
-        onChange={props.onValuesChange}
+        onChange={(values: Array<string>) => {
+          props.onChange({ values: values });
+        }}
       />
     );
   }
@@ -135,8 +154,12 @@ const ColumnValueInput: FunctionComponent<ComponentProps> = (
             className={MONO_INPUT_CLASS}
             outerDivClassName={INPUT_WRAPPER_CLASS}
             disableSpellCheck={true}
+            autoFocus={props.autoFocus}
+            ariaLabelledby={props.ariaLabelledby}
             dataTestId={props.dataTestId}
-            onChange={props.onTextChange}
+            onChange={(value: string) => {
+              props.onChange({ text: value });
+            }}
           />
         </div>
         {referenceButton}
@@ -161,13 +184,21 @@ const ColumnValueInput: FunctionComponent<ComponentProps> = (
           ariaLabelledby={props.ariaLabelledby}
           dataTestId={props.dataTestId}
           tabIndex={props.tabIndex}
+          autoFocus={props.autoFocus}
           onChange={(value: string) => {
             /*
              * The first keystroke ends raw mode: what is in the box is now what
-             * the builder means, so it is written in the column's own type.
+             * the builder means, so it is written in the column's own type. The
+             * mode and the text move together in one change - reported
+             * separately, the second report would overwrite the first and the
+             * cell could never be typed into at all.
              */
-            props.onValueModeChange(ColumnValueMode.Literal);
-            setTextAndDetectReference(value);
+            props.onChange({
+              text: value,
+              valueMode: value.includes("{{")
+                ? ColumnValueMode.Reference
+                : ColumnValueMode.Literal,
+            });
           }}
         />
       );
@@ -178,8 +209,12 @@ const ColumnValueInput: FunctionComponent<ComponentProps> = (
         return (
           <BooleanSegments
             value={props.text}
+            ariaLabelledby={props.ariaLabelledby}
+            autoFocus={props.autoFocus}
             dataTestId={props.dataTestId}
-            onChange={props.onTextChange}
+            onChange={(value: string) => {
+              props.onChange({ text: value });
+            }}
           />
         );
 
@@ -193,7 +228,10 @@ const ColumnValueInput: FunctionComponent<ComponentProps> = (
             ariaLabelledby={props.ariaLabelledby}
             dataTestId={props.dataTestId}
             tabIndex={props.tabIndex}
-            onChange={props.onTextChange}
+            autoFocus={props.autoFocus}
+            onChange={(value: string) => {
+              props.onChange({ text: value });
+            }}
           />
         );
 
@@ -206,7 +244,10 @@ const ColumnValueInput: FunctionComponent<ComponentProps> = (
             ariaLabelledby={props.ariaLabelledby}
             dataTestId={props.dataTestId}
             tabIndex={props.tabIndex}
-            onChange={props.onTextChange}
+            autoFocus={props.autoFocus}
+            onChange={(value: string) => {
+              props.onChange({ text: value });
+            }}
           />
         );
 
@@ -219,7 +260,7 @@ const ColumnValueInput: FunctionComponent<ComponentProps> = (
             dataTestId={props.dataTestId}
             tabIndex={props.tabIndex}
             onChange={(value: Color | null) => {
-              props.onTextChange(value ? value.toString() : "");
+              props.onChange({ text: value ? value.toString() : "" });
             }}
           />
         );
@@ -230,8 +271,10 @@ const ColumnValueInput: FunctionComponent<ComponentProps> = (
             value={props.text}
             placeholder={props.placeholder}
             className="block w-full rounded-md border border-gray-300 bg-white py-2 px-3 text-sm placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 resize-y min-h-16"
+            ariaLabelledby={props.ariaLabelledby}
             dataTestId={props.dataTestId}
             tabIndex={props.tabIndex}
+            autoFocus={props.autoFocus}
             onChange={setTextAndDetectReference}
           />
         );
@@ -248,6 +291,8 @@ const ColumnValueInput: FunctionComponent<ComponentProps> = (
                 ? "block w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-3 font-mono text-xs text-gray-900 placeholder-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
                 : undefined
             }
+            ariaLabelledby={props.ariaLabelledby}
+            autoFocus={props.autoFocus}
             dataTestId={props.dataTestId}
             onChange={setTextAndDetectReference}
           />
@@ -265,6 +310,8 @@ const ColumnValueInput: FunctionComponent<ComponentProps> = (
 
 interface BooleanSegmentsProps {
   value: string;
+  ariaLabelledby?: string | undefined;
+  autoFocus?: boolean | undefined;
   dataTestId?: string | undefined;
   onChange: (value: string) => void;
 }
@@ -287,6 +334,7 @@ const BooleanSegments: FunctionComponent<BooleanSegmentsProps> = (
     <div
       className="inline-flex rounded-md border border-gray-300 bg-white p-0.5"
       role="group"
+      aria-labelledby={props.ariaLabelledby}
       data-testid={props.dataTestId}
     >
       {segments.map((segment: { label: string; value: string }) => {
@@ -296,6 +344,7 @@ const BooleanSegments: FunctionComponent<BooleanSegmentsProps> = (
           <button
             key={segment.label}
             type="button"
+            autoFocus={props.autoFocus && segment.value === "true"}
             aria-pressed={isSelected}
             className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
               isSelected

--- a/Common/UI/Components/Workflow/ColumnEditor/ColumnValueInput.tsx
+++ b/Common/UI/Components/Workflow/ColumnEditor/ColumnValueInput.tsx
@@ -1,0 +1,433 @@
+/*
+ * One value cell.
+ *
+ * The control comes from the column's type in the model schema, so nobody is
+ * asked whether the thing they are typing is Text, Number or Boolean - the
+ * model already said. What is left for the builder to choose is the one thing
+ * the schema genuinely cannot know: whether this value is typed in, or read
+ * from an earlier step at run time.
+ */
+
+import Color from "../../../../Types/Color";
+import IconProp from "../../../../Types/Icon/IconProp";
+import AutocompleteTextInput from "../../AutocompleteTextInput/AutocompleteTextInput";
+import { DictionaryFilterOperatorOption } from "../../Dictionary/DictionaryFilterOperator";
+import ColorPicker from "../../Forms/Fields/ColorPicker";
+import Icon from "../../Icon/Icon";
+import Input, { InputType } from "../../Input/Input";
+import TextArea from "../../TextArea/TextArea";
+import { ColumnValueMode, ModelColumnControl } from "./ColumnRow";
+import { containsTemplateExpression } from "./ColumnRowSerialization";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  control: ModelColumnControl;
+  valueMode: ColumnValueMode;
+  text: string;
+  values: Array<string>;
+  /** Absent in record mode, where every row is an equality. */
+  operatorOption?: DictionaryFilterOperatorOption | undefined;
+  placeholder?: string | undefined;
+  /** The other steps' return values and the workflow's variables. */
+  suggestions?: Array<string> | undefined;
+  onTextChange: (value: string) => void;
+  onValuesChange: (values: Array<string>) => void;
+  onValueModeChange: (valueMode: ColumnValueMode) => void;
+  tabIndex?: number | undefined;
+  ariaLabelledby?: string | undefined;
+  dataTestId?: string | undefined;
+}
+
+const INPUT_WRAPPER_CLASS: string = "relative w-full";
+
+const MONO_INPUT_CLASS: string =
+  "block w-full rounded-md border-0 bg-transparent py-1 pl-0 pr-0 font-mono text-xs text-indigo-900 placeholder-indigo-300 focus:outline-none focus:ring-0";
+
+const ColumnValueInput: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const isReference: boolean = props.valueMode === ColumnValueMode.Reference;
+
+  type SetTextFunction = (value: string) => void;
+
+  /*
+   * Typing "{{" anywhere in a text control means the builder is reaching for
+   * another step's output, so the cell becomes a reference there and then and
+   * keeps what has been typed. Without this the autocomplete would never open
+   * unless the reference button had been found first.
+   */
+  const setTextAndDetectReference: SetTextFunction = (value: string): void => {
+    if (!isReference && value.includes("{{")) {
+      props.onValueModeChange(ColumnValueMode.Reference);
+    }
+
+    props.onTextChange(value);
+  };
+
+  /*
+   * Spelled "{ }" rather than drawn as an icon. The shared variable glyph is a
+   * dashed square that reads as a placeholder or a spinner, and this button has
+   * to say what it does at a glance - it is the only route from a typed value to
+   * an earlier step's output, which is how most of these payloads are built.
+   */
+  const referenceButton: ReactElement = (
+    <button
+      type="button"
+      aria-pressed={isReference}
+      title={
+        isReference
+          ? "Type a value instead"
+          : "Use a value from an earlier step"
+      }
+      aria-label={
+        isReference
+          ? "Type a value instead"
+          : "Use a value from an earlier step"
+      }
+      data-testid={`${props.dataTestId || "model-column"}-reference-toggle`}
+      className={`shrink-0 rounded-md border px-1.5 py-1 font-mono text-[11px] leading-none transition-colors focus:outline-none focus:ring-1 focus:ring-indigo-500 ${
+        isReference
+          ? "border-indigo-200 bg-white text-indigo-500 hover:bg-indigo-50"
+          : "border-transparent text-gray-400 hover:border-gray-200 hover:bg-gray-50 hover:text-gray-600"
+      }`}
+      onClick={() => {
+        props.onValueModeChange(
+          isReference ? ColumnValueMode.Literal : ColumnValueMode.Reference,
+        );
+      }}
+    >
+      {isReference ? "abc" : "{ }"}
+    </button>
+  );
+
+  // An operator like "is not set" takes no value at all.
+  if (props.operatorOption?.hidesValueInput) {
+    return (
+      <div className="flex h-9 items-center rounded-md border border-dashed border-gray-200 px-3 text-xs text-gray-400">
+        No value needed
+      </div>
+    );
+  }
+
+  if (props.operatorOption?.expectsMultiValue) {
+    return (
+      <MultiValueInput
+        values={props.values}
+        placeholder={props.placeholder}
+        ariaLabelledby={props.ariaLabelledby}
+        dataTestId={props.dataTestId}
+        onChange={props.onValuesChange}
+      />
+    );
+  }
+
+  if (isReference) {
+    return (
+      <div className="flex w-full items-center gap-1.5 rounded-md border border-indigo-200 bg-indigo-50/40 px-2 py-1">
+        <span className="shrink-0 font-mono text-[11px] text-indigo-400">
+          {"{ }"}
+        </span>
+        <div className="min-w-0 flex-1">
+          <AutocompleteTextInput
+            value={props.text}
+            placeholder="{{local.components.step.returnValues.value}}"
+            suggestions={props.suggestions}
+            className={MONO_INPUT_CLASS}
+            outerDivClassName={INPUT_WRAPPER_CLASS}
+            disableSpellCheck={true}
+            dataTestId={props.dataTestId}
+            onChange={props.onTextChange}
+          />
+        </div>
+        {referenceButton}
+      </div>
+    );
+  }
+
+  type RenderControlFunction = () => ReactElement;
+
+  const renderControl: RenderControlFunction = (): ReactElement => {
+    /*
+     * A value the typed control cannot hold - text where the column wants a
+     * number, most often - is edited as text and written back exactly as it
+     * was read. Forcing it through the typed control would rewrite it.
+     */
+    if (props.valueMode === ColumnValueMode.Raw) {
+      return (
+        <Input
+          value={props.text}
+          placeholder={props.placeholder}
+          outerDivClassName={INPUT_WRAPPER_CLASS}
+          ariaLabelledby={props.ariaLabelledby}
+          dataTestId={props.dataTestId}
+          tabIndex={props.tabIndex}
+          onChange={(value: string) => {
+            /*
+             * The first keystroke ends raw mode: what is in the box is now what
+             * the builder means, so it is written in the column's own type.
+             */
+            props.onValueModeChange(ColumnValueMode.Literal);
+            setTextAndDetectReference(value);
+          }}
+        />
+      );
+    }
+
+    switch (props.control) {
+      case ModelColumnControl.Boolean:
+        return (
+          <BooleanSegments
+            value={props.text}
+            dataTestId={props.dataTestId}
+            onChange={props.onTextChange}
+          />
+        );
+
+      case ModelColumnControl.Number:
+        return (
+          <Input
+            type={InputType.NUMBER}
+            value={props.text}
+            placeholder={props.placeholder || "0"}
+            outerDivClassName={INPUT_WRAPPER_CLASS}
+            ariaLabelledby={props.ariaLabelledby}
+            dataTestId={props.dataTestId}
+            tabIndex={props.tabIndex}
+            onChange={props.onTextChange}
+          />
+        );
+
+      case ModelColumnControl.Date:
+        return (
+          <Input
+            type={InputType.DATETIME_LOCAL}
+            value={props.text}
+            outerDivClassName={INPUT_WRAPPER_CLASS}
+            ariaLabelledby={props.ariaLabelledby}
+            dataTestId={props.dataTestId}
+            tabIndex={props.tabIndex}
+            onChange={props.onTextChange}
+          />
+        );
+
+      case ModelColumnControl.Color:
+        return (
+          <ColorPicker
+            value={props.text}
+            placeholder={props.placeholder || "#000000"}
+            ariaLabelledby={props.ariaLabelledby}
+            dataTestId={props.dataTestId}
+            tabIndex={props.tabIndex}
+            onChange={(value: Color | null) => {
+              props.onTextChange(value ? value.toString() : "");
+            }}
+          />
+        );
+
+      case ModelColumnControl.LongText:
+        return (
+          <TextArea
+            value={props.text}
+            placeholder={props.placeholder}
+            className="block w-full rounded-md border border-gray-300 bg-white py-2 px-3 text-sm placeholder-gray-500 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 resize-y min-h-16"
+            dataTestId={props.dataTestId}
+            tabIndex={props.tabIndex}
+            onChange={setTextAndDetectReference}
+          />
+        );
+
+      default:
+        return (
+          <AutocompleteTextInput
+            value={props.text}
+            placeholder={props.placeholder}
+            suggestions={props.suggestions}
+            outerDivClassName={INPUT_WRAPPER_CLASS}
+            className={
+              props.control === ModelColumnControl.ObjectId
+                ? "block w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-3 font-mono text-xs text-gray-900 placeholder-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                : undefined
+            }
+            dataTestId={props.dataTestId}
+            onChange={setTextAndDetectReference}
+          />
+        );
+    }
+  };
+
+  return (
+    <div className="flex w-full items-center gap-1">
+      <div className="min-w-0 flex-1">{renderControl()}</div>
+      {referenceButton}
+    </div>
+  );
+};
+
+interface BooleanSegmentsProps {
+  value: string;
+  dataTestId?: string | undefined;
+  onChange: (value: string) => void;
+}
+
+/*
+ * Three states, not two. A boolean column with nothing typed into it is not
+ * "false" - it is a field the record does not set, and a toggle cannot say
+ * that. (The shared Toggle component also fires its onChange twice per click.)
+ */
+const BooleanSegments: FunctionComponent<BooleanSegmentsProps> = (
+  props: BooleanSegmentsProps,
+): ReactElement => {
+  const segments: Array<{ label: string; value: string }> = [
+    { label: "True", value: "true" },
+    { label: "False", value: "false" },
+    { label: "Not set", value: "" },
+  ];
+
+  return (
+    <div
+      className="inline-flex rounded-md border border-gray-300 bg-white p-0.5"
+      role="group"
+      data-testid={props.dataTestId}
+    >
+      {segments.map((segment: { label: string; value: string }) => {
+        const isSelected: boolean = props.value === segment.value;
+
+        return (
+          <button
+            key={segment.label}
+            type="button"
+            aria-pressed={isSelected}
+            className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+              isSelected
+                ? "bg-indigo-50 text-indigo-700"
+                : "text-gray-500 hover:text-gray-700"
+            }`}
+            onClick={() => {
+              props.onChange(segment.value);
+            }}
+          >
+            {segment.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+interface MultiValueInputProps {
+  values: Array<string>;
+  placeholder?: string | undefined;
+  ariaLabelledby?: string | undefined;
+  dataTestId?: string | undefined;
+  onChange: (values: Array<string>) => void;
+}
+
+/*
+ * "is any of" holds a list. The previous editor rendered a multi-select whose
+ * options were only ever the suggestions it had been handed, so a value nobody
+ * had suggested could not be entered at all - which for a list of IDs is every
+ * value. This is a chip input: type, press Enter or comma, and it is in.
+ */
+const MultiValueInput: FunctionComponent<MultiValueInputProps> = (
+  props: MultiValueInputProps,
+): ReactElement => {
+  const [draft, setDraft] = React.useState<string>("");
+
+  type CommitDraftFunction = () => void;
+
+  const commitDraft: CommitDraftFunction = (): void => {
+    const entry: string = draft.trim();
+
+    if (entry === "" || props.values.includes(entry)) {
+      setDraft("");
+      return;
+    }
+
+    props.onChange([...props.values, entry]);
+    setDraft("");
+  };
+
+  return (
+    <div className="w-full rounded-md border border-gray-300 bg-white px-2 py-1.5">
+      {props.values.length > 0 && (
+        <div className="mb-1 flex flex-wrap gap-1">
+          {props.values.map((value: string, index: number) => {
+            return (
+              <span
+                key={`${value}-${index}`}
+                className="inline-flex items-center gap-1 rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700"
+              >
+                {containsTemplateExpression(value) ? (
+                  <span className="font-mono text-indigo-600">{value}</span>
+                ) : (
+                  value
+                )}
+                <button
+                  type="button"
+                  aria-label={`Remove ${value}`}
+                  className="text-gray-400 hover:text-gray-600"
+                  onClick={() => {
+                    props.onChange(
+                      props.values.filter((_entry: string, i: number) => {
+                        return i !== index;
+                      }),
+                    );
+                  }}
+                >
+                  <Icon icon={IconProp.Close} className="h-3 w-3" />
+                </button>
+              </span>
+            );
+          })}
+        </div>
+      )}
+      <input
+        type="text"
+        value={draft}
+        aria-labelledby={props.ariaLabelledby}
+        data-testid={props.dataTestId}
+        placeholder={props.placeholder || "Type a value and press Enter"}
+        className="block w-full border-0 p-0 text-sm placeholder-gray-400 focus:outline-none focus:ring-0"
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+          const value: string = event.target.value;
+
+          if (value.endsWith(",")) {
+            setDraft(value.slice(0, -1));
+            /*
+             * setDraft is async, so commit from the typed text rather than from
+             * state, which still holds the previous keystroke here.
+             */
+            const entry: string = value.slice(0, -1).trim();
+
+            if (entry !== "" && !props.values.includes(entry)) {
+              props.onChange([...props.values, entry]);
+            }
+
+            setDraft("");
+            return;
+          }
+
+          setDraft(value);
+        }}
+        onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            commitDraft();
+            return;
+          }
+
+          if (
+            event.key === "Backspace" &&
+            draft === "" &&
+            props.values.length > 0
+          ) {
+            props.onChange(props.values.slice(0, -1));
+          }
+        }}
+        onBlur={commitDraft}
+      />
+    </div>
+  );
+};
+
+export default ColumnValueInput;

--- a/Common/UI/Components/Workflow/ColumnEditor/ModelQueryBuilder.tsx
+++ b/Common/UI/Components/Workflow/ColumnEditor/ModelQueryBuilder.tsx
@@ -1,0 +1,120 @@
+/*
+ * The query body: the conditions that decide which records a step acts on.
+ *
+ * Fully controlled, like the record form. One column header for the whole list
+ * rather than a Key/Operator/Value label repeated above every row, which is
+ * what made the old editor read as a spreadsheet.
+ */
+
+import IconProp from "../../../../Types/Icon/IconProp";
+import Icon from "../../Icon/Icon";
+import { ModelSchemaColumn, findColumn } from "../ModelSchema";
+import AddColumnDropdown from "./AddColumnDropdown";
+import { isOfferableColumn } from "./ColumnControl";
+import ColumnConditionRow from "./ColumnConditionRow";
+import { ModelColumnRow, makeColumnRow } from "./ColumnRow";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  rows: Array<ModelColumnRow>;
+  columns: Array<ModelSchemaColumn>;
+  suggestions?: Array<string> | undefined;
+  onChange: (rows: Array<ModelColumnRow>) => void;
+}
+
+const ModelQueryBuilder: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const offerableColumns: Array<ModelSchemaColumn> = props.columns.filter(
+    (column: ModelSchemaColumn) => {
+      return isOfferableColumn(column);
+    },
+  );
+
+  type ReplaceRowFunction = (index: number, row: ModelColumnRow) => void;
+
+  const replaceRow: ReplaceRowFunction = (
+    index: number,
+    row: ModelColumnRow,
+  ): void => {
+    const next: Array<ModelColumnRow> = [...props.rows];
+    next[index] = row;
+    props.onChange(next);
+  };
+
+  return (
+    <div>
+      <div className="overflow-hidden rounded-md border border-gray-200 bg-white">
+        {props.rows.length === 0 ? (
+          <div className="px-6 py-10 text-center">
+            <Icon
+              icon={IconProp.Filter}
+              className="mx-auto h-6 w-6 text-gray-300"
+            />
+            <p className="mt-2 text-sm font-medium text-gray-700">
+              No conditions yet
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              With no conditions this matches every record in the project.
+            </p>
+          </div>
+        ) : (
+          <>
+            {/* Column widths must stay in step with ColumnConditionRow's grid. */}
+            <div className="hidden border-b border-gray-100 bg-gray-50/60 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-gray-400 sm:grid sm:grid-cols-[minmax(0,1fr)_minmax(0,0.85fr)_minmax(0,1.3fr)_auto] sm:gap-2">
+              <span>Column</span>
+              <span>Comparison</span>
+              <span>Value</span>
+              <span className="w-8" />
+            </div>
+            <div className="divide-y divide-gray-100">
+              {props.rows.map((row: ModelColumnRow, index: number) => {
+                return (
+                  <ColumnConditionRow
+                    key={`${row.columnId}-${index}`}
+                    row={row}
+                    column={findColumn(props.columns, row.columnId)}
+                    columns={offerableColumns}
+                    suggestions={props.suggestions}
+                    onChange={(nextRow: ModelColumnRow) => {
+                      replaceRow(index, nextRow);
+                    }}
+                    onRemove={() => {
+                      props.onChange(
+                        props.rows.filter((_row: ModelColumnRow, i: number) => {
+                          return i !== index;
+                        }),
+                      );
+                    }}
+                  />
+                );
+              })}
+            </div>
+          </>
+        )}
+
+        <div className="border-t border-gray-100 bg-gray-50/40 px-3 py-2.5">
+          <AddColumnDropdown
+            columns={offerableColumns.filter((column: ModelSchemaColumn) => {
+              return !props.rows.some((row: ModelColumnRow) => {
+                return row.columnId === column.id;
+              });
+            })}
+            requiredColumnIds={[]}
+            placeholder="Add a condition..."
+            allowCustomColumn={true}
+            dataTestId="model-column-add"
+            onAdd={(columnId: string) => {
+              props.onChange([
+                ...props.rows,
+                makeColumnRow({ columnId: columnId }),
+              ]);
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ModelQueryBuilder;

--- a/Common/UI/Components/Workflow/ColumnEditor/ModelQueryBuilder.tsx
+++ b/Common/UI/Components/Workflow/ColumnEditor/ModelQueryBuilder.tsx
@@ -13,7 +13,7 @@ import AddColumnDropdown from "./AddColumnDropdown";
 import { isOfferableColumn } from "./ColumnControl";
 import ColumnConditionRow from "./ColumnConditionRow";
 import { ModelColumnRow, makeColumnRow } from "./ColumnRow";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, { FunctionComponent, ReactElement, useState } from "react";
 
 export interface ComponentProps {
   rows: Array<ModelColumnRow>;
@@ -25,6 +25,14 @@ export interface ComponentProps {
 const ModelQueryBuilder: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  /*
+   * The row just added from the picker, so its value control can take focus.
+   * Without it the picker remounts to clear its own selection and focus falls
+   * to the document body, which for a keyboard user means starting again from
+   * the top of the panel.
+   */
+  const [justAddedKey, setJustAddedKey] = useState<string>("");
+
   const offerableColumns: Array<ModelSchemaColumn> = props.columns.filter(
     (column: ModelSchemaColumn) => {
       return isOfferableColumn(column);
@@ -71,11 +79,12 @@ const ModelQueryBuilder: FunctionComponent<ComponentProps> = (
               {props.rows.map((row: ModelColumnRow, index: number) => {
                 return (
                   <ColumnConditionRow
-                    key={`${row.columnId}-${index}`}
+                    key={row.key}
                     row={row}
                     column={findColumn(props.columns, row.columnId)}
                     columns={offerableColumns}
                     suggestions={props.suggestions}
+                    autoFocus={row.key === justAddedKey}
                     onChange={(nextRow: ModelColumnRow) => {
                       replaceRow(index, nextRow);
                     }}
@@ -105,10 +114,12 @@ const ModelQueryBuilder: FunctionComponent<ComponentProps> = (
             allowCustomColumn={true}
             dataTestId="model-column-add"
             onAdd={(columnId: string) => {
-              props.onChange([
-                ...props.rows,
-                makeColumnRow({ columnId: columnId }),
-              ]);
+              const added: ModelColumnRow = makeColumnRow({
+                columnId: columnId,
+              });
+
+              setJustAddedKey(added.key);
+              props.onChange([...props.rows, added]);
             }}
           />
         </div>

--- a/Common/UI/Components/Workflow/ColumnEditor/ModelRecordForm.tsx
+++ b/Common/UI/Components/Workflow/ColumnEditor/ModelRecordForm.tsx
@@ -16,7 +16,7 @@ import AddColumnDropdown from "./AddColumnDropdown";
 import { isOfferableColumn } from "./ColumnControl";
 import ColumnFieldRow from "./ColumnFieldRow";
 import { ModelColumnRow, makeColumnRow } from "./ColumnRow";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, { FunctionComponent, ReactElement, useState } from "react";
 
 export interface ComponentProps {
   rows: Array<ModelColumnRow>;
@@ -28,6 +28,14 @@ export interface ComponentProps {
 const ModelRecordForm: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
+  /*
+   * The row just added from the picker, so its value control can take focus.
+   * Without it the picker remounts to clear its own selection and focus falls
+   * to the document body, which for a keyboard user means starting again from
+   * the top of the panel.
+   */
+  const [justAddedKey, setJustAddedKey] = useState<string>("");
+
   const requiredColumnIds: Array<string> = requiredWritableColumns(
     props.columns,
   ).map((column: ModelSchemaColumn) => {
@@ -95,12 +103,13 @@ const ModelRecordForm: FunctionComponent<ComponentProps> = (
             {props.rows.map((row: ModelColumnRow, index: number) => {
               return (
                 <ColumnFieldRow
-                  key={`${row.columnId}-${index}`}
+                  key={row.key}
                   row={row}
                   column={findColumn(props.columns, row.columnId)}
                   knownColumnIds={knownColumnIds}
                   isRequired={requiredColumnIds.includes(row.columnId)}
                   suggestions={props.suggestions}
+                  autoFocus={row.key === justAddedKey}
                   onChange={(nextRow: ModelColumnRow) => {
                     replaceRow(index, nextRow);
                   }}
@@ -125,10 +134,12 @@ const ModelRecordForm: FunctionComponent<ComponentProps> = (
             allowCustomColumn={true}
             dataTestId="model-column-add"
             onAdd={(columnId: string) => {
-              props.onChange([
-                ...props.rows,
-                makeColumnRow({ columnId: columnId }),
-              ]);
+              const added: ModelColumnRow = makeColumnRow({
+                columnId: columnId,
+              });
+
+              setJustAddedKey(added.key);
+              props.onChange([...props.rows, added]);
             }}
           />
         </div>

--- a/Common/UI/Components/Workflow/ColumnEditor/ModelRecordForm.tsx
+++ b/Common/UI/Components/Workflow/ColumnEditor/ModelRecordForm.tsx
@@ -1,0 +1,152 @@
+/*
+ * The record body: every field this step writes, as a form.
+ *
+ * Fully controlled - the rows live in ModelColumnEditor, so what is on screen
+ * and what is stored on the argument can never drift apart.
+ */
+
+import IconProp from "../../../../Types/Icon/IconProp";
+import Icon from "../../Icon/Icon";
+import {
+  ModelSchemaColumn,
+  findColumn,
+  requiredWritableColumns,
+} from "../ModelSchema";
+import AddColumnDropdown from "./AddColumnDropdown";
+import { isOfferableColumn } from "./ColumnControl";
+import ColumnFieldRow from "./ColumnFieldRow";
+import { ModelColumnRow, makeColumnRow } from "./ColumnRow";
+import React, { FunctionComponent, ReactElement } from "react";
+
+export interface ComponentProps {
+  rows: Array<ModelColumnRow>;
+  columns: Array<ModelSchemaColumn>;
+  suggestions?: Array<string> | undefined;
+  onChange: (rows: Array<ModelColumnRow>) => void;
+}
+
+const ModelRecordForm: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const requiredColumnIds: Array<string> = requiredWritableColumns(
+    props.columns,
+  ).map((column: ModelSchemaColumn) => {
+    return column.id;
+  });
+
+  const usedColumnIds: Array<string> = props.rows.map((row: ModelColumnRow) => {
+    return row.columnId;
+  });
+
+  const offerableColumns: Array<ModelSchemaColumn> = props.columns.filter(
+    (column: ModelSchemaColumn) => {
+      return isOfferableColumn(column) && !usedColumnIds.includes(column.id);
+    },
+  );
+
+  /*
+   * Named so the builder is not left wondering where a column went. Relations
+   * and blobs cannot be a single box, and saying which ones is kinder than
+   * silently offering a shorter list than the model has.
+   */
+  const unofferableColumnTitles: Array<string> = props.columns
+    .filter((column: ModelSchemaColumn) => {
+      return !isOfferableColumn(column) && !column.isTenantColumn;
+    })
+    .map((column: ModelSchemaColumn) => {
+      return column.title;
+    });
+
+  const knownColumnIds: Array<string> = props.columns.map(
+    (column: ModelSchemaColumn) => {
+      return column.id;
+    },
+  );
+
+  type ReplaceRowFunction = (index: number, row: ModelColumnRow) => void;
+
+  const replaceRow: ReplaceRowFunction = (
+    index: number,
+    row: ModelColumnRow,
+  ): void => {
+    const next: Array<ModelColumnRow> = [...props.rows];
+    next[index] = row;
+    props.onChange(next);
+  };
+
+  return (
+    <div>
+      <div className="overflow-hidden rounded-md border border-gray-200 bg-white">
+        {props.rows.length === 0 ? (
+          <div className="px-6 py-10 text-center">
+            <Icon
+              icon={IconProp.Database}
+              className="mx-auto h-6 w-6 text-gray-300"
+            />
+            <p className="mt-2 text-sm font-medium text-gray-700">
+              No fields set yet
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              Pick a field below to start building this record.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-100">
+            {props.rows.map((row: ModelColumnRow, index: number) => {
+              return (
+                <ColumnFieldRow
+                  key={`${row.columnId}-${index}`}
+                  row={row}
+                  column={findColumn(props.columns, row.columnId)}
+                  knownColumnIds={knownColumnIds}
+                  isRequired={requiredColumnIds.includes(row.columnId)}
+                  suggestions={props.suggestions}
+                  onChange={(nextRow: ModelColumnRow) => {
+                    replaceRow(index, nextRow);
+                  }}
+                  onRemove={() => {
+                    props.onChange(
+                      props.rows.filter((_row: ModelColumnRow, i: number) => {
+                        return i !== index;
+                      }),
+                    );
+                  }}
+                />
+              );
+            })}
+          </div>
+        )}
+
+        <div className="border-t border-gray-100 bg-gray-50/40 px-3 py-2.5">
+          <AddColumnDropdown
+            columns={offerableColumns}
+            requiredColumnIds={requiredColumnIds}
+            placeholder="Add a field..."
+            allowCustomColumn={true}
+            dataTestId="model-column-add"
+            onAdd={(columnId: string) => {
+              props.onChange([
+                ...props.rows,
+                makeColumnRow({ columnId: columnId }),
+              ]);
+            }}
+          />
+        </div>
+      </div>
+
+      {unofferableColumnTitles.length > 0 && (
+        <p className="mt-1.5 text-xs text-gray-400">
+          {unofferableColumnTitles.slice(0, 3).join(", ")}
+          {unofferableColumnTitles.length > 3
+            ? ` and ${unofferableColumnTitles.length - 3} other field${
+                unofferableColumnTitles.length - 3 === 1 ? "" : "s"
+              }`
+            : ""}{" "}
+          can only be set with Edit as JSON.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default ModelRecordForm;

--- a/Common/UI/Components/Workflow/ModelColumnEditor.tsx
+++ b/Common/UI/Components/Workflow/ModelColumnEditor.tsx
@@ -1,23 +1,25 @@
 /*
- * A row-based editor for the two workflow arguments that are keyed on a
+ * A schema-driven editor for the two workflow arguments that are keyed on a
  * model's columns: the Query that picks which records a component acts on,
  * and the record of values a create/update writes.
  *
  * Both were bare JSON editors, with the column names — and, for a query, the
- * operator syntax — left entirely to memory. The description on those
- * arguments had to carry a hint about "_id" versus "id" precisely because
- * nothing else told the builder what the columns were called.
+ * operator syntax — left entirely to memory. The first attempt at fixing that
+ * borrowed the generic key/value row editor, which asked for a column name as
+ * free text and then asked, in a dropdown next to it, whether the value was
+ * Text, Number or Boolean. Both questions were already answered:
+ * /model-schema/:tableName says that `color` is a Color and `name` is a Name,
+ * so the builder could only agree with the schema or be wrong.
  *
- * Everything needed to do better already existed: /model-schema/:tableName
- * knows the columns, and DictionaryForm's operator mode emits exactly the
- * {_type, value} shape that JSONFunctions.deserialize hydrates on the server
- * (FindManyBaseModel and friends). This wires the two together, and keeps a
- * JSON escape hatch for the values rows cannot express.
+ * So the rows are generated from the schema instead. A record is a form of the
+ * model's own fields, with their real titles and descriptions; a query is a
+ * list of conditions whose comparisons are filtered by the column's type. The
+ * JSON escape hatch stays for the values rows cannot express, and now it
+ * re-reads what was typed in it rather than discarding it.
  */
 
 import CodeEditor from "../CodeEditor/CodeEditor";
 import ComponentLoader from "../ComponentLoader/ComponentLoader";
-import DictionaryForm, { ValueType } from "../Dictionary/Dictionary";
 import { DictionaryEntryValue } from "../Dictionary/DictionaryFilterOperator";
 import Icon from "../Icon/Icon";
 import {
@@ -28,6 +30,14 @@ import {
   requiredWritableColumns,
   useModelSchema,
 } from "./ModelSchema";
+import { ModelColumnRow } from "./ColumnEditor/ColumnRow";
+import {
+  rowsFromParsedValue,
+  seedRequiredRows,
+  serializeColumnRows,
+} from "./ColumnEditor/ColumnRowSerialization";
+import ModelQueryBuilder from "./ColumnEditor/ModelQueryBuilder";
+import ModelRecordForm from "./ColumnEditor/ModelRecordForm";
 import CodeType from "../../../Types/Code/CodeType";
 import Dictionary from "../../../Types/Dictionary";
 import IconProp from "../../../Types/Icon/IconProp";
@@ -36,6 +46,7 @@ import { maskTemplateExpressions } from "../../../Types/Workflow/TemplateSyntax"
 import React, {
   FunctionComponent,
   ReactElement,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -47,6 +58,18 @@ export enum ModelColumnEditorMode {
   Record = "Record",
 }
 
+/**
+ * Whether the record being edited creates a row or updates one.
+ *
+ * It decides one thing: whether the editor opens with a blank row for every
+ * column a create must supply. An update legitimately writes a single column,
+ * so seeding those rows there presents six fields where the builder wanted one.
+ */
+export enum RecordIntent {
+  Create = "Create",
+  Update = "Update",
+}
+
 export interface ComponentProps {
   tableName: string;
   mode: ModelColumnEditorMode;
@@ -55,6 +78,8 @@ export interface ComponentProps {
   error?: string | undefined;
   placeholder?: string | undefined;
   tabIndex?: number | undefined;
+  /** Record mode only; ignored for a query. Defaults to Create. */
+  recordIntent?: RecordIntent | undefined;
   /*
    * Offered in any row whose column has no suggestions of its own - the other
    * steps' return values and the workflow's variables. The row editor replaced
@@ -356,54 +381,24 @@ const ModelColumnEditor: FunctionComponent<ComponentProps> = (
   const [viewMode, setViewMode] = useState<ViewMode>("builder");
 
   /*
-   * The row editor is uncontrolled after mount (DictionaryForm seeds itself
-   * once), so this is computed rather than held in state. It only has to be
-   * right on the render that first mounts DictionaryForm, which is the first
-   * render after the schema resolves — the loader below returns early until
-   * then.
+   * The rows are the editor's own state, and both bodies are fully controlled
+   * from here. Null until the schema resolves, because a row cannot be built
+   * before it is known what kind of column it is for.
    *
-   * Record mode opens with a blank row for every column a create must be given
-   * a value for. Seeding is additive and never overwrites what was stored, and
-   * blank rows are dropped on the way back out (buildColumnValueJson), so
-   * opening a saved workflow and saving it again cannot change what it does.
+   * Nothing in the seeding path calls props.onChange. That matters more than it
+   * looks: this component is mounted every time someone opens a step's
+   * settings, and a change fired during mount would rewrite the stored bytes of
+   * every workflow just for being looked at.
    */
-  const initialRows: Dictionary<DictionaryEntryValue> = useMemo(() => {
-    const stored: Dictionary<DictionaryEntryValue> = (initial.parsed ||
-      {}) as Dictionary<DictionaryEntryValue>;
-
-    if (isQuery || !schema.columns) {
-      return stored;
-    }
-
-    const seeded: Dictionary<DictionaryEntryValue> = { ...stored };
-
-    for (const column of requiredWritableColumns(schema.columns)) {
-      if (seeded[column.id] === undefined) {
-        seeded[column.id] = "";
-      }
-    }
-
-    return seeded;
-  }, [schema.columns, isQuery]);
+  const [rows, setRows] = useState<Array<ModelColumnRow> | null>(null);
 
   /*
-   * The model's own example for each column, shown in the row it belongs to.
-   * MonitorSecret.secretValue ships example: "sk_test_1234567890abcdefghijklmnop",
-   * which answers "what goes in this box" better than any prose in the sidebar.
+   * Why the switch back from JSON is refused, when it is. Empty means it is
+   * allowed.
    */
-  const valuePlaceholders: Dictionary<string> = useMemo(() => {
-    const placeholders: Dictionary<string> = {};
-
-    for (const column of schema.columns || []) {
-      const hint: string | undefined = column.example || column.placeholder;
-
-      if (hint) {
-        placeholders[column.id] = hint;
-      }
-    }
-
-    return placeholders;
-  }, [schema.columns]);
+  const [returnToRowsBlockedBy, setReturnToRowsBlockedBy] = useState<
+    Array<string>
+  >([]);
 
   const compatibility: CompatibilityResult = useMemo(() => {
     return classifyColumnValueCompatibility(
@@ -414,13 +409,33 @@ const ModelColumnEditor: FunctionComponent<ComponentProps> = (
     );
   }, [schema.columns, props.mode]);
 
-  const columnKeys: Array<string> = useMemo(() => {
-    return (schema.columns || []).map((column: ModelSchemaColumn) => {
-      return column.id;
-    });
-  }, [schema.columns]);
+  const columns: Array<ModelSchemaColumn> = schema.columns || [];
 
-  if (schema.isLoading) {
+  useEffect(() => {
+    if (schema.isLoading || rows !== null) {
+      return;
+    }
+
+    const storedRows: Array<ModelColumnRow> = rowsFromParsedValue(
+      initial.parsed,
+      columns,
+      props.mode,
+    );
+
+    /*
+     * A create opens with a blank row for every column it must be given, so the
+     * shape of the record is visible before anything is typed. Seeded rows hold
+     * "" and are dropped on the way out, so an untouched Create One still reads
+     * as empty to form validation and to the graph linter.
+     */
+    const shouldSeed: boolean =
+      !isQuery &&
+      (props.recordIntent || RecordIntent.Create) === RecordIntent.Create;
+
+    setRows(shouldSeed ? seedRequiredRows(storedRows, columns) : storedRows);
+  }, [schema.isLoading, schema.columns]);
+
+  if (schema.isLoading || rows === null) {
     return <ComponentLoader />;
   }
 
@@ -431,30 +446,98 @@ const ModelColumnEditor: FunctionComponent<ComponentProps> = (
 
   const onJsonChange: OnJsonChangeFunction = (value: string): void => {
     setJsonText(value);
+    /*
+     * Any block on returning to rows was about the previous text, so it is
+     * re-decided when the switch is next attempted rather than left standing.
+     */
+    setReturnToRowsBlockedBy([]);
     props.onChange(value);
   };
 
-  type OnRowsChangeFunction = (value: Dictionary<DictionaryEntryValue>) => void;
+  type OnRowsChangeFunction = (value: Array<ModelColumnRow>) => void;
 
   const onRowsChange: OnRowsChangeFunction = (
-    value: Dictionary<DictionaryEntryValue>,
+    value: Array<ModelColumnRow>,
   ): void => {
-    const asJson: string = buildColumnValueJson(value, props.mode);
+    setRows(value);
+
+    const asJson: string = serializeColumnRows(value, columns, props.mode);
     setJsonText(asJson);
     props.onChange(asJson);
   };
 
+  type ShowJsonFunction = () => void;
+
+  const showJson: ShowJsonFunction = (): void => {
+    /*
+     * What is shown is what is stored. Handing the code editor the text the
+     * argument held before the rows were edited would be the same data loss as
+     * the other direction, one step later.
+     */
+    setJsonText(serializeColumnRows(rows, columns, props.mode));
+    setViewMode("json");
+  };
+
+  type ShowRowsFunction = () => void;
+
+  const showRows: ShowRowsFunction = (): void => {
+    /*
+     * The JSON is re-read here, which is the fix for a real bug: the rows used
+     * to be seeded once and never again, so editing as JSON, adding a key and
+     * switching back silently dropped the key, and the next keystroke in any
+     * row overwrote the argument with the pre-edit content.
+     */
+    const edited: ParsedQuery = normalizeInitialValue(jsonText);
+    const editedCompatibility: CompatibilityResult =
+      classifyColumnValueCompatibility(
+        edited.parsed,
+        columns,
+        props.mode,
+        edited.hasTemplateExpressions,
+      );
+
+    if (!editedCompatibility.compatible) {
+      // Refused rather than silently losing the edit.
+      setReturnToRowsBlockedBy(editedCompatibility.reasons);
+      return;
+    }
+
+    setReturnToRowsBlockedBy([]);
+    setRows(rowsFromParsedValue(edited.parsed, columns, props.mode));
+    setViewMode("builder");
+  };
+
+  const filledRowCount: number = rows.filter((row: ModelColumnRow) => {
+    return row.columnId !== "" && (row.text !== "" || row.values.length > 0);
+  }).length;
+
+  const emptyRequiredCount: number = isQuery
+    ? 0
+    : requiredWritableColumns(columns).filter((column: ModelSchemaColumn) => {
+        return rows.some((row: ModelColumnRow) => {
+          return row.columnId === column.id && row.text === "";
+        });
+      }).length;
+
+  const noun: string = isQuery ? "condition" : "field";
+
   return (
     <div>
       {schema.error && (
-        <p className="text-sm text-amber-600 mb-2">
-          Couldn&apos;t load this model&apos;s columns ({schema.error}). You can
-          still write {isQuery ? "the query" : "these fields"} as JSON.
-        </p>
+        <div className="mb-2 flex items-start gap-2 rounded-md border border-red-200 bg-red-50/60 px-3 py-2.5">
+          <Icon
+            icon={IconProp.Alert}
+            className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-500"
+          />
+          <p className="text-sm text-red-700">
+            Couldn&apos;t load this model&apos;s columns ({schema.error}). You
+            can still write {isQuery ? "the query" : "these fields"} as JSON.
+          </p>
+        </div>
       )}
 
       {isLockedToJson && compatibility.reasons.length > 0 && (
-        <div className="mb-2 rounded-md border border-amber-200 bg-amber-50 p-3">
+        <div className="mb-2 rounded-md border border-amber-200 bg-amber-50/60 px-3 py-2.5">
           <p className="text-sm text-amber-800">Editing as JSON, because:</p>
           <ul className="mt-1 list-disc pl-5 text-sm text-amber-700">
             {compatibility.reasons.map((reason: string, i: number) => {
@@ -465,7 +548,7 @@ const ModelColumnEditor: FunctionComponent<ComponentProps> = (
       )}
 
       {!isLockedToJson && compatibility.reasons.length > 0 && (
-        <div className="mb-2 rounded-md border border-amber-200 bg-amber-50 p-3">
+        <div className="mb-2 rounded-md border border-amber-200 bg-amber-50/60 px-3 py-2.5">
           <ul className="list-disc pl-5 text-sm text-amber-700">
             {compatibility.reasons.map((reason: string, i: number) => {
               return <li key={i}>{reason}</li>;
@@ -474,19 +557,86 @@ const ModelColumnEditor: FunctionComponent<ComponentProps> = (
         </div>
       )}
 
+      {returnToRowsBlockedBy.length > 0 && (
+        <div className="mb-2 rounded-md border border-amber-200 bg-amber-50/60 px-3 py-2.5">
+          <p className="text-sm text-amber-800">
+            This can&apos;t go back to {isQuery ? "conditions" : "fields"},
+            because:
+          </p>
+          <ul className="mt-1 list-disc pl-5 text-sm text-amber-700">
+            {returnToRowsBlockedBy.map((reason: string, i: number) => {
+              return <li key={i}>{reason}</li>;
+            })}
+          </ul>
+        </div>
+      )}
+
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <p className="text-xs text-gray-500">
+          {effectiveMode === "builder" ? (
+            <>
+              {filledRowCount} {noun}
+              {filledRowCount === 1 ? "" : "s"} set
+              {emptyRequiredCount > 0 && (
+                <span className="text-amber-600">
+                  {" "}
+                  · {emptyRequiredCount} required field
+                  {emptyRequiredCount === 1 ? "" : "s"} still empty
+                </span>
+              )}
+            </>
+          ) : (
+            <>Editing the raw JSON this step will send.</>
+          )}
+        </p>
+
+        {!isLockedToJson && (
+          <button
+            type="button"
+            data-testid="model-column-json-toggle"
+            className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            onClick={() => {
+              if (effectiveMode === "builder") {
+                showJson();
+                return;
+              }
+
+              showRows();
+            }}
+          >
+            <Icon
+              icon={
+                effectiveMode === "builder"
+                  ? IconProp.Code
+                  : IconProp.ListBullet
+              }
+              className="h-3.5 w-3.5 text-gray-500"
+            />
+            {effectiveMode === "builder"
+              ? "Edit as JSON"
+              : isQuery
+                ? "Back to conditions"
+                : "Back to fields"}
+          </button>
+        )}
+      </div>
+
       {effectiveMode === "builder" ? (
-        <DictionaryForm
-          keys={columnKeys}
-          enableOperators={isQuery}
-          valueTypes={[ValueType.Text, ValueType.Number, ValueType.Boolean]}
-          addButtonSuffix={isQuery ? "condition" : "field"}
-          keyPlaceholder="Column"
-          valuePlaceholder="Value"
-          valuePlaceholders={valuePlaceholders}
-          defaultValueSuggestions={props.valueSuggestions}
-          initialValue={initialRows}
-          onChange={onRowsChange}
-        />
+        isQuery ? (
+          <ModelQueryBuilder
+            rows={rows}
+            columns={columns}
+            suggestions={props.valueSuggestions}
+            onChange={onRowsChange}
+          />
+        ) : (
+          <ModelRecordForm
+            rows={rows}
+            columns={columns}
+            suggestions={props.valueSuggestions}
+            onChange={onRowsChange}
+          />
+        )
       ) : (
         <CodeEditor
           type={CodeType.JSON}
@@ -497,25 +647,6 @@ const ModelColumnEditor: FunctionComponent<ComponentProps> = (
           placeholder={props.placeholder}
           onChange={onJsonChange}
         />
-      )}
-
-      {!isLockedToJson && (
-        <div className="mt-2">
-          <button
-            type="button"
-            className="text-sm underline text-blue-500 hover:text-blue-600 cursor-pointer inline-flex items-center gap-1"
-            onClick={() => {
-              setViewMode(effectiveMode === "builder" ? "json" : "builder");
-            }}
-          >
-            <Icon icon={IconProp.Code} className="h-3.5 w-3.5" />
-            {effectiveMode === "builder"
-              ? "Edit as JSON"
-              : isQuery
-                ? "Back to conditions"
-                : "Back to fields"}
-          </button>
-        </div>
       )}
 
       {props.error && effectiveMode === "builder" && (

--- a/Common/UI/Components/Workflow/ModelColumnEditor.tsx
+++ b/Common/UI/Components/Workflow/ModelColumnEditor.tsx
@@ -20,7 +20,10 @@
 
 import CodeEditor from "../CodeEditor/CodeEditor";
 import ComponentLoader from "../ComponentLoader/ComponentLoader";
-import { DictionaryEntryValue } from "../Dictionary/DictionaryFilterOperator";
+import {
+  DictionaryEntryValue,
+  getOperatorOption,
+} from "../Dictionary/DictionaryFilterOperator";
 import Icon from "../Icon/Icon";
 import {
   ModelSchemaAccess,
@@ -400,6 +403,11 @@ const ModelColumnEditor: FunctionComponent<ComponentProps> = (
     Array<string>
   >([]);
 
+  /*
+   * Whether the value can be shown as rows at all. Read from the value as it
+   * was loaded, deliberately: the decision has to be stable, or the editor
+   * would change shape under the builder's hands as they type.
+   */
   const compatibility: CompatibilityResult = useMemo(() => {
     return classifyColumnValueCompatibility(
       initial.parsed,
@@ -411,28 +419,41 @@ const ModelColumnEditor: FunctionComponent<ComponentProps> = (
 
   const columns: Array<ModelSchemaColumn> = schema.columns || [];
 
+  type BuildRowsFunction = (parsed: JSONObject | null) => Array<ModelColumnRow>;
+
+  /*
+   * A create opens with a blank row for every column it must be given, so the
+   * shape of the record is visible before anything is typed. Seeded rows hold
+   * "" and are dropped on the way out, so an untouched Create One still reads
+   * as empty to form validation and to the graph linter.
+   *
+   * Used by the JSON view's return trip as well as by the first load - built
+   * only on the way in, those rows disappeared the first time anyone looked at
+   * the JSON, and a create that had been read once no longer showed what it
+   * needed.
+   */
+  const buildRows: BuildRowsFunction = (
+    parsed: JSONObject | null,
+  ): Array<ModelColumnRow> => {
+    const storedRows: Array<ModelColumnRow> = rowsFromParsedValue(
+      parsed,
+      columns,
+      props.mode,
+    );
+
+    const shouldSeed: boolean =
+      !isQuery &&
+      (props.recordIntent || RecordIntent.Create) === RecordIntent.Create;
+
+    return shouldSeed ? seedRequiredRows(storedRows, columns) : storedRows;
+  };
+
   useEffect(() => {
     if (schema.isLoading || rows !== null) {
       return;
     }
 
-    const storedRows: Array<ModelColumnRow> = rowsFromParsedValue(
-      initial.parsed,
-      columns,
-      props.mode,
-    );
-
-    /*
-     * A create opens with a blank row for every column it must be given, so the
-     * shape of the record is visible before anything is typed. Seeded rows hold
-     * "" and are dropped on the way out, so an untouched Create One still reads
-     * as empty to form validation and to the graph linter.
-     */
-    const shouldSeed: boolean =
-      !isQuery &&
-      (props.recordIntent || RecordIntent.Create) === RecordIntent.Create;
-
-    setRows(shouldSeed ? seedRequiredRows(storedRows, columns) : storedRows);
+    setRows(buildRows(initial.parsed));
   }, [schema.isLoading, schema.columns]);
 
   if (schema.isLoading || rows === null) {
@@ -503,13 +524,45 @@ const ModelColumnEditor: FunctionComponent<ComponentProps> = (
     }
 
     setReturnToRowsBlockedBy([]);
-    setRows(rowsFromParsedValue(edited.parsed, columns, props.mode));
+    setRows(buildRows(edited.parsed));
     setViewMode("builder");
   };
 
   const filledRowCount: number = rows.filter((row: ModelColumnRow) => {
-    return row.columnId !== "" && (row.text !== "" || row.values.length > 0);
+    if (row.columnId === "") {
+      return false;
+    }
+
+    /*
+     * "is set" and "is not set" carry no value by design, so counting only rows
+     * that hold one reported a query with three real conditions as having none.
+     */
+    if (isQuery && getOperatorOption(row.operator).hidesValueInput) {
+      return true;
+    }
+
+    return row.text !== "" || row.values.length > 0;
   }).length;
+
+  /*
+   * Recomputed from the rows on screen rather than from the value as it was
+   * loaded, so fixing the column name that caused the warning also clears it.
+   * Read from the frozen initial value, the "id isn't a known column" note
+   * stayed up after the builder had corrected it to "_id", which reads as the
+   * editor not having noticed.
+   *
+   * Only the non-blocking half is live. Whether the value can be rows at all is
+   * decided once, above.
+   */
+  const unknownColumnWarnings: Array<string> = columns.length
+    ? rows
+        .filter((row: ModelColumnRow) => {
+          return row.columnId !== "" && !findColumn(columns, row.columnId);
+        })
+        .map((row: ModelColumnRow) => {
+          return `"${row.columnId}" isn't a known column on this model.`;
+        })
+    : [];
 
   const emptyRequiredCount: number = isQuery
     ? 0
@@ -547,10 +600,10 @@ const ModelColumnEditor: FunctionComponent<ComponentProps> = (
         </div>
       )}
 
-      {!isLockedToJson && compatibility.reasons.length > 0 && (
+      {!isLockedToJson && unknownColumnWarnings.length > 0 && (
         <div className="mb-2 rounded-md border border-amber-200 bg-amber-50/60 px-3 py-2.5">
           <ul className="list-disc pl-5 text-sm text-amber-700">
-            {compatibility.reasons.map((reason: string, i: number) => {
+            {unknownColumnWarnings.map((reason: string, i: number) => {
               return <li key={i}>{reason}</li>;
             })}
           </ul>


### PR DESCRIPTION
## The complaint

> In workflow components, you know the schema — why do you ask for it here?

The settings panel for a database step asked for two things the schema had already answered. The column name was typed as free text into a box labelled **Key**, and the value's type was picked from a dropdown offering **Text / Number / Boolean** — next to a `/model-schema/:tableName` response that had already said `color` is a Color and `name` is a Name. The builder could only agree with the schema or be wrong. The argument's own description had to carry a hint about `_id` versus `id` precisely because nothing on screen said what the columns were called.

## What this does

The rows are generated from the schema instead.

**A record is a form of the model's own fields.** Each carries its real title, its description, its column name as a mono chip, and a control chosen from its type — a number box for a number, three segments for a boolean (True / False / **Not set**, which a toggle cannot say), a date-and-time picker, a color picker, a textarea for long text. Fields are added from a searchable picker showing titles and descriptions, required ones grouped first. A create opens with a blank row for every column it must be given; an update opens on nothing, because it legitimately writes a single column.

**A query is a list of conditions** whose comparisons are filtered by the column's type, so a boolean no longer offers "starts with" and an ID no longer offers "greater than" (`uuid ILIKE '%x%'` needs a cast Postgres will not do for you). A date reads "is after" rather than ">".

**Every cell can still hold a `{{ }}` reference** — a `{ }` button on each row, and typing `{{` anywhere flips the cell into the autocomplete. Most creates are assembled out of a trigger's return values, so this had to work on a number and a boolean too, not just on text.

**Edit as JSON stays**, and now works in both directions. It used to seed the rows once and never again, so adding a key in the JSON view was silently discarded and the next keystroke in any row wrote the pre-edit content back over it. An edit the rows cannot show now refuses the trip back rather than losing it.

## The wire format does not change

Serialization still ends in the existing `buildColumnValueJson`, and operator wrappers are still built by `buildDictionaryValue`, so each class's own `toJSON()` produces the bytes. `ModelColumnEditorServerContract.test.ts` and `ModelColumnEditor.test.ts` pass **untouched** — the exported pure functions and their bodies are unchanged.

Two behaviours are deliberately different, both fixes:

- A stored scalar whose type disagrees with its column is kept raw and re-emitted verbatim until that cell is edited, so opening a workflow and saving it cannot rewrite `{"port": "8080"}` into `{"port": 8080}` behind the builder's back.
- An ordering comparison against a reference or a date no longer becomes `NaN` — which `JSON.stringify` wrote as `null`, a query against NULL that matched nothing and reported no error.

The editor never reports a change on mount, on schema load, on seeding, or on a view toggle. It is mounted every time someone opens a step's settings, so a change fired there would rewrite every saved workflow just for being looked at.

## Second commit

An adversarial review of the first commit found eight real defects, each now fixed with a test that fails without the fix. The worst: an edit to a raw cell was reported as two separate changes from one event, both built from the same render's row, so the second discarded the first — the cell was impossible to type into while the box on screen showed the new text. Details in the commit message.

## Tests

- `ColumnEditor/ColumnControl.test.ts` — the type-to-control map, total over every `TableColumnType` member, asserted against the **wire values** rather than the member names (`ShortText` is `"Text"`, `ObjectID` is `"Object ID"`, `JavaScript` is `"JavaSCript"`).
- `ColumnEditor/ColumnOperators.test.ts` — every operator offered is one the editor can read back, or it would lock the value to JSON on the next open.
- `ColumnEditor/ColumnRowSerialization.test.ts` — byte-equality against `buildColumnValueJson` for each operator, the full walk through `JSONFunctions.deserialize`, and fifteen stored values that must survive being opened and written back unchanged, twice.
- `ColumnEditor/ColumnRow.test.ts` — the single-change merge that the first commit got wrong.
- `ModelColumnEditor.render.test.tsx` — 40 cases, including the complaint itself (no "Key" box, no Type dropdown anywhere) and the invariant that opening a step reports no change.

1418 tests pass across the workflow, dictionary and workflow-type suites; 141 in `App/Tests/FeatureSet/Workflow`.

## Known follow-ups, deliberately not bundled

- `Dictionary.tsx`'s `valuePlaceholders` and `defaultValueSuggestions` are now dead — this was their only caller. Removing them puts a 477-line render test at risk for no benefit here.
- `InBetween` ("between two dates") is the one obviously missing comparison; it is absent from `REPRESENTABLE_OPERATOR_TYPES` too.
- Bare (unquoted) `{{ }}` emission on numeric and boolean columns. References are quoted today, which Postgres casts on the way in; unquoting needs a recoverable masker and a sentinel-collision guard, and is orthogonal to the complaint.