### PR TITLE
fix(button): stop disabled primary/secondary buttons rendering as enabled

### DIFF
--- a/Common/Tests/UI/Components/Button.test.tsx
+++ b/Common/Tests/UI/Components/Button.test.tsx
@@ -1,6 +1,7 @@
 import Button, {
   ButtonSize,
   ButtonStyleType,
+  ComponentProps,
 } from "../../../UI/Components/Button/Button";
 import ButtonType from "../../../UI/Components/Button/ButtonTypes";
 import ShortcutKey from "../../../UI/Components/ShortcutKey/ShortcutKey";
@@ -198,5 +199,283 @@ describe("Button", () => {
     const testId: HTMLElement = screen.getByTestId("test-id");
     fireEvent.click(testId);
     expect(handleClick).toBeCalled();
+  });
+});
+
+type RenderButtonFunction = (props: Partial<ComponentProps>) => HTMLElement;
+
+const renderButton: RenderButtonFunction = (
+  props: Partial<ComponentProps>,
+): HTMLElement => {
+  const { unmount } = render(<Button dataTestId="test-id" {...props} />);
+  const button: HTMLElement = screen.getByTestId("test-id");
+  // Clone so assertions survive the unmount and each case starts from a clean DOM.
+  const clone: HTMLElement = button.cloneNode(true) as HTMLElement;
+  unmount();
+  return clone;
+};
+
+type ClassesOfFunction = (element: HTMLElement) => Array<string>;
+
+const classesOf: ClassesOfFunction = (element: HTMLElement): Array<string> => {
+  return element.className.split(/\s+/).filter((cssClass: string) => {
+    return cssClass.length > 0;
+  });
+};
+
+/*
+ * Every ButtonStyleType, so new styles are covered by the invariants below
+ * without anyone having to remember to add them here.
+ */
+const ALL_BUTTON_STYLES: Array<[string, ButtonStyleType]> = Object.keys(
+  ButtonStyleType,
+)
+  .filter((key: string) => {
+    return isNaN(Number(key));
+  })
+  .map((key: string) => {
+    return [key, ButtonStyleType[key as keyof typeof ButtonStyleType]] as [
+      string,
+      ButtonStyleType,
+    ];
+  });
+
+describe("Button disabled styling", () => {
+  /*
+   * The regression this suite exists for: the disabled background used to be
+   * appended alongside the enabled one, and Tailwind emits .bg-indigo-300
+   * before .bg-indigo-600, so the enabled colour won the cascade and every
+   * disabled primary button rendered at full saturation.
+   */
+  test("disabled PRIMARY does not carry the enabled background class", () => {
+    const button: HTMLElement = renderButton({
+      buttonStyle: ButtonStyleType.PRIMARY,
+      disabled: true,
+    });
+
+    expect(button).not.toHaveClass("bg-indigo-600");
+    expect(button).toHaveClass("bg-indigo-300");
+  });
+
+  test("disabled SECONDARY does not carry the enabled background class", () => {
+    const button: HTMLElement = renderButton({
+      buttonStyle: ButtonStyleType.SECONDARY,
+      disabled: true,
+    });
+
+    expect(button).not.toHaveClass("bg-indigo-100");
+    expect(button).toHaveClass("bg-indigo-300");
+  });
+
+  test("enabled PRIMARY keeps the enabled background and no disabled background", () => {
+    const button: HTMLElement = renderButton({
+      buttonStyle: ButtonStyleType.PRIMARY,
+      disabled: false,
+    });
+
+    expect(button).toHaveClass("bg-indigo-600");
+    expect(button).not.toHaveClass("bg-indigo-300");
+  });
+
+  test("enabled SECONDARY keeps the enabled background and no disabled background", () => {
+    const button: HTMLElement = renderButton({
+      buttonStyle: ButtonStyleType.SECONDARY,
+      disabled: false,
+    });
+
+    expect(button).toHaveClass("bg-indigo-100");
+    expect(button).not.toHaveClass("bg-indigo-300");
+  });
+
+  test("an omitted disabled prop styles PRIMARY as enabled", () => {
+    const button: HTMLElement = renderButton({
+      buttonStyle: ButtonStyleType.PRIMARY,
+    });
+
+    expect(button).toHaveClass("bg-indigo-600");
+    expect(button).not.toHaveClass("bg-indigo-300");
+  });
+
+  test("an omitted disabled prop styles SECONDARY as enabled", () => {
+    const button: HTMLElement = renderButton({
+      buttonStyle: ButtonStyleType.SECONDARY,
+    });
+
+    expect(button).toHaveClass("bg-indigo-100");
+    expect(button).not.toHaveClass("bg-indigo-300");
+  });
+
+  test.each(ALL_BUTTON_STYLES)(
+    "%s emits at most one background utility when disabled",
+    (_name: string, buttonStyle: ButtonStyleType) => {
+      const button: HTMLElement = renderButton({ buttonStyle, disabled: true });
+
+      const backgrounds: Array<string> = classesOf(button).filter(
+        (cssClass: string) => {
+          return cssClass.startsWith("bg-");
+        },
+      );
+
+      expect(backgrounds.length).toBeLessThanOrEqual(1);
+    },
+  );
+
+  test.each(ALL_BUTTON_STYLES)(
+    "%s emits at most one background utility when enabled",
+    (_name: string, buttonStyle: ButtonStyleType) => {
+      const button: HTMLElement = renderButton({
+        buttonStyle,
+        disabled: false,
+      });
+
+      const backgrounds: Array<string> = classesOf(button).filter(
+        (cssClass: string) => {
+          return cssClass.startsWith("bg-");
+        },
+      );
+
+      expect(backgrounds.length).toBeLessThanOrEqual(1);
+    },
+  );
+
+  const DIMMING_STYLES: Array<[string, ButtonStyleType]> = [
+    ["PRIMARY", ButtonStyleType.PRIMARY],
+    ["SECONDARY", ButtonStyleType.SECONDARY],
+  ];
+
+  test.each(DIMMING_STYLES)(
+    "%s resolves to a different background when disabled",
+    (_name: string, buttonStyle: ButtonStyleType) => {
+      type BackgroundOfFunction = (disabled: boolean) => string | undefined;
+
+      const backgroundOf: BackgroundOfFunction = (
+        disabled: boolean,
+      ): string | undefined => {
+        return classesOf(renderButton({ buttonStyle, disabled })).find(
+          (cssClass: string) => {
+            return cssClass.startsWith("bg-");
+          },
+        );
+      };
+
+      const enabled: string | undefined = backgroundOf(false);
+      const disabled: string | undefined = backgroundOf(true);
+
+      expect(enabled).toBeDefined();
+      expect(disabled).toBeDefined();
+      expect(disabled).not.toBe(enabled);
+    },
+  );
+});
+
+describe("Button hover styling", () => {
+  /*
+   * Hover affordances are gated on `disabled`; the ternary used to be inverted,
+   * so hover styles applied to exactly the buttons that could not be clicked.
+   */
+  const HOVER_GATED_STYLES: Array<[string, ButtonStyleType, string]> = [
+    ["PRIMARY", ButtonStyleType.PRIMARY, "hover:bg-indigo-700"],
+    ["SECONDARY", ButtonStyleType.SECONDARY, "hover:bg-indigo-200"],
+    ["DANGER", ButtonStyleType.DANGER, "hover:bg-red-700"],
+    ["DANGER_OUTLINE", ButtonStyleType.DANGER_OUTLINE, "hover:bg-red-50"],
+    ["SUCCESS", ButtonStyleType.SUCCESS, "hover:bg-green-700"],
+    ["SUCCESS_OUTLINE", ButtonStyleType.SUCCESS_OUTLINE, "hover:bg-green-50"],
+    ["WARNING", ButtonStyleType.WARNING, "hover:bg-yellow-700"],
+    ["WARNING_OUTLINE", ButtonStyleType.WARNING_OUTLINE, "hover:bg-yellow-50"],
+    ["ICON", ButtonStyleType.ICON, "hover:text-gray-900"],
+    ["ICON_LIGHT", ButtonStyleType.ICON_LIGHT, "hover:text-gray-500"],
+  ];
+
+  test.each(HOVER_GATED_STYLES)(
+    "%s applies its hover class only when enabled",
+    (_name: string, buttonStyle: ButtonStyleType, hoverClass: string) => {
+      expect(renderButton({ buttonStyle, disabled: false })).toHaveClass(
+        hoverClass,
+      );
+      expect(renderButton({ buttonStyle, disabled: true })).not.toHaveClass(
+        hoverClass,
+      );
+    },
+  );
+});
+
+describe("Button class list composition", () => {
+  test("the size class is appended for every style", () => {
+    ALL_BUTTON_STYLES.forEach(([, buttonStyle]: [string, ButtonStyleType]) => {
+      expect(
+        renderButton({ buttonStyle, buttonSize: ButtonSize.Small }),
+      ).toHaveClass("px-2", "py-1");
+    });
+  });
+
+  test("a caller-supplied className is appended alongside the style classes", () => {
+    const button: HTMLElement = renderButton({
+      buttonStyle: ButtonStyleType.PRIMARY,
+      className: "my-custom-class",
+      disabled: true,
+    });
+
+    expect(button).toHaveClass("my-custom-class");
+    expect(button).toHaveClass("bg-indigo-300");
+  });
+
+  test("every style resolves to a non-empty class list in both states", () => {
+    ALL_BUTTON_STYLES.forEach(([, buttonStyle]: [string, ButtonStyleType]) => {
+      [true, false].forEach((disabled: boolean) => {
+        expect(
+          classesOf(renderButton({ buttonStyle, disabled })).length,
+        ).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  test("no style emits a class twice", () => {
+    ALL_BUTTON_STYLES.forEach(([, buttonStyle]: [string, ButtonStyleType]) => {
+      [true, false].forEach((disabled: boolean) => {
+        const classes: Array<string> = classesOf(
+          renderButton({ buttonStyle, disabled }),
+        );
+
+        expect(classes).toHaveLength(new Set(classes).size);
+      });
+    });
+  });
+});
+
+describe("Button disabled behaviour", () => {
+  test("a disabled button is marked disabled to assistive technology", () => {
+    const button: HTMLElement = renderButton({
+      buttonStyle: ButtonStyleType.PRIMARY,
+      disabled: true,
+    });
+
+    expect(button).toHaveAttribute("disabled");
+    expect(button).toHaveAttribute("aria-disabled", "true");
+  });
+
+  test("a loading button is disabled", () => {
+    const button: HTMLElement = renderButton({
+      buttonStyle: ButtonStyleType.PRIMARY,
+      isLoading: true,
+    });
+
+    expect(button).toHaveAttribute("disabled");
+    expect(button).toHaveAttribute("aria-disabled", "true");
+  });
+
+  test("a disabled button does not fire onClick", () => {
+    const handleClick: () => void = jest.fn();
+    render(
+      <Button
+        dataTestId="test-id"
+        buttonStyle={ButtonStyleType.PRIMARY}
+        disabled={true}
+        onClick={handleClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("test-id"));
+
+    expect(handleClick).not.toBeCalled();
   });
 });

--- a/Common/UI/Components/Button/Button.tsx
+++ b/Common/UI/Components/Button/Button.tsx
@@ -158,47 +158,39 @@ const Button: FunctionComponent<ComponentProps> = ({
 
   if (buttonStyle === ButtonStyleType.DANGER) {
     buttonStyleCssClass = `inline-flex w-full justify-center rounded-md border border-transparent bg-red-600 text-base font-medium text-white shadow-sm ${
-      disabled ? "hover:bg-red-700" : ""
+      disabled ? "" : "hover:bg-red-700"
     } focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 md:ml-3 md:w-auto md:text-sm`;
   }
 
   if (buttonStyle === ButtonStyleType.DANGER_OUTLINE) {
     buttonStyleCssClass = `inline-flex w-full justify-center rounded-md border border-red-700 bg-white text-base font-medium text-red-700 shadow-sm ${
-      disabled ? "hover:bg-red-50" : ""
+      disabled ? "" : "hover:bg-red-50"
     } focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 md:mt-0 md:ml-3 md:w-auto md:text-sm`;
   }
 
   if (buttonStyle === ButtonStyleType.PRIMARY) {
     loadingIconClassName += ` text-indigo-100`;
-    buttonStyleCssClass = `inline-flex w-full justify-center rounded-md border border-transparent bg-indigo-600 text-base font-medium text-white shadow-sm ${
-      disabled ? "hover:bg-indigo-700" : ""
-    } focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 md:ml-3 md:w-auto md:text-sm`;
-
-    if (disabled) {
-      buttonStyleCssClass += ` bg-indigo-300`;
-    }
+    buttonStyleCssClass = `inline-flex w-full justify-center rounded-md border border-transparent ${
+      disabled ? "bg-indigo-300" : "bg-indigo-600 hover:bg-indigo-700"
+    } text-base font-medium text-white shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 md:ml-3 md:w-auto md:text-sm`;
   }
 
   if (buttonStyle === ButtonStyleType.SECONDARY) {
     loadingIconClassName += ` text-indigo-500`;
-    buttonStyleCssClass = `inline-flex items-center rounded-md border border-transparent bg-indigo-100 text-sm font-medium text-indigo-700 ${
-      disabled ? "hover:bg-indigo-200" : ""
-    } focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`;
-
-    if (disabled) {
-      buttonStyleCssClass += ` bg-indigo-300`;
-    }
+    buttonStyleCssClass = `inline-flex items-center rounded-md border border-transparent ${
+      disabled ? "bg-indigo-300" : "bg-indigo-100 hover:bg-indigo-200"
+    } text-sm font-medium text-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`;
   }
 
   if (buttonStyle === ButtonStyleType.ICON_LIGHT) {
     buttonStyleCssClass = `rounded-md bg-white text-gray-400 ${
-      disabled ? "hover:text-gray-500" : ""
+      disabled ? "" : "hover:text-gray-500"
     }  focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`;
   }
 
   if (buttonStyle === ButtonStyleType.ICON) {
     buttonStyleCssClass = `rounded-md bg-transparent text-gray-600 ${
-      disabled ? "hover:text-gray-900" : ""
+      disabled ? "" : "hover:text-gray-900"
     }  focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2`;
   }
 
@@ -225,25 +217,25 @@ const Button: FunctionComponent<ComponentProps> = ({
 
   if (buttonStyle === ButtonStyleType.SUCCESS) {
     buttonStyleCssClass = `inline-flex w-full justify-center rounded-md border border-transparent bg-green-600 text-base font-medium text-white shadow-sm ${
-      disabled ? "hover:bg-green-700" : ""
+      disabled ? "" : "hover:bg-green-700"
     }  focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 md:ml-3 md:w-auto md:text-sm`;
   }
 
   if (buttonStyle === ButtonStyleType.SUCCESS_OUTLINE) {
     buttonStyleCssClass = `inline-flex w-full justify-center rounded-md border border-green-700 bg-white text-base font-medium text-green-700 shadow-sm ${
-      disabled ? "hover:bg-green-50" : ""
+      disabled ? "" : "hover:bg-green-50"
     }  focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 md:mt-0 md:ml-3 md:w-auto md:text-sm`;
   }
 
   if (buttonStyle === ButtonStyleType.WARNING) {
     buttonStyleCssClass = `inline-flex w-full justify-center rounded-md border border-transparent bg-yellow-600 text-base font-medium text-white shadow-sm  ${
-      disabled ? "hover:bg-yellow-700" : ""
+      disabled ? "" : "hover:bg-yellow-700"
     }  focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2 md:ml-3 md:w-auto md:text-sm`;
   }
 
   if (buttonStyle === ButtonStyleType.WARNING_OUTLINE) {
     buttonStyleCssClass = `inline-flex w-full justify-center rounded-md border border-yellow-700 bg-white text-base font-medium text-yellow-700 shadow-sm ${
-      disabled ? "hover:bg-yellow-50" : ""
+      disabled ? "" : "hover:bg-yellow-50"
     }   focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2 md:mt-0 md:ml-3 md:w-auto md:text-sm`;
   }
 


### PR DESCRIPTION
## The bug

A disabled `PRIMARY` button ended up with **both** `bg-indigo-600` and `bg-indigo-300` in its class list — the base class was set first, then the disabled colour was appended:

```tsx
buttonStyleCssClass = `... bg-indigo-600 ...`;

if (disabled) {
  buttonStyleCssClass += ` bg-indigo-300`;
}
```

Class order in the attribute doesn't decide the winner — stylesheet order does, and Tailwind emits `.bg-indigo-300` before `.bg-indigo-600`. So `bg-indigo-600` won and `getComputedStyle(button).backgroundColor` on a disabled primary button was `rgb(79, 70, 229)`, identical to an enabled one. Every disabled primary/secondary button in the product looked clickable. Confirmed live against the dashboard's Tailwind 3.4.5 build on a modal footer's "Go" button with `disableSubmitButton` true.

`SECONDARY` had the same shape (`bg-indigo-100` + appended `bg-indigo-300`).

## The fix

Choose the background conditionally so exactly one background utility reaches the class list:

```tsx
buttonStyleCssClass = `inline-flex w-full justify-center rounded-md border border-transparent ${
  disabled ? "bg-indigo-300" : "bg-indigo-600 hover:bg-indigo-700"
} text-base font-medium text-white shadow-sm ...`;
```

## Also in here: an inverted hover ternary

The same blocks gated hover styles on `disabled` the wrong way round:

```tsx
${disabled ? "hover:bg-indigo-700" : ""}
```

Hover affordances applied to exactly the buttons that could *not* be clicked, and enabled buttons had none. That inversion had been copied across eight other styles — `DANGER`, `DANGER_OUTLINE`, `SUCCESS`, `SUCCESS_OUTLINE`, `WARNING`, `WARNING_OUTLINE`, `ICON`, `ICON_LIGHT` — so all of them are corrected here rather than just the two in the report.

## Tests

`Common/Tests/UI/Components/Button.test.tsx` gains coverage driven off `ButtonStyleType` itself, so styles added later are covered without anyone remembering to update a list:

- disabled `PRIMARY`/`SECONDARY` carry the dimmed background and not the enabled one, and vice versa
- an omitted `disabled` prop styles as enabled
- **every** style, in **both** states: at most one `bg-*` utility, no duplicate classes, non-empty class list
- the dimming styles resolve to a *different* background when disabled
- the ten hover-gated styles apply their hover class only when enabled
- `disabled` and `isLoading` both mark the button disabled and `aria-disabled`; a disabled button doesn't fire `onClick`

76 tests pass. The 16 targeting these defects fail against the previous component (verified by stashing the fix), so they're a real regression guard rather than a restatement of current behaviour.

```
Tests:       76 passed, 76 total
```

`tsc --noEmit` and `eslint` are clean on both files, and the three other suites that reference these indigo classes (`Toggle`, `ConfirmModal`, `EventStatusPanel`) still pass.

## Left alone deliberately

Two things nearby that are *not* part of this fix, flagged rather than silently changed:

- `NORMAL`, `LINK`, `SECONDARY_LINK` and the `OUTLINE` variants apply their hover classes unconditionally, so they still show hover feedback while disabled. That was never gated on `disabled`, so it's a separate design question.
- Styling keys off the `disabled` prop alone, while the DOM `disabled` attribute is `disabled || isLoading`. A loading button is therefore non-interactive but still renders at full saturation — the same class of defect as this PR, but changing it alters how every loading button looks.