### PR TITLE
fix(url): support tel:/sms:, tolerate legacy URLs on read, stay strict on write

### DIFF
--- a/Common/Server/Utils/SSRFProtection.ts
+++ b/Common/Server/Utils/SSRFProtection.ts
@@ -82,10 +82,11 @@ export default class SSRFProtection {
     rawUrl: string | URL,
   ): Promise<void> {
     /*
-     * URL.fromString only knows http/https/ws/wss/mongodb/mailto and silently
-     * DEFAULTS anything else to https - "file:///etc/passwd" comes back as
-     * host "file", not as a file: URL - so the protocol check below never sees
-     * the scheme the caller actually wrote. Read it off the raw string first.
+     * URL.fromString only knows http/https/ws/wss/mongodb/mailto/tel/sms and
+     * silently DEFAULTS anything else to https - "file:///etc/passwd" comes
+     * back as host "file", not as a file: URL - so the protocol check below
+     * never sees the scheme the caller actually wrote. Read it off the raw
+     * string first.
      *
      * The ":" must be followed by "/" or this would treat the host in a
      * scheme-less "example.com:8080/hook" as a scheme and reject it.

--- a/Common/Tests/Types/API/URLMalformedTolerance.test.ts
+++ b/Common/Tests/Types/API/URLMalformedTolerance.test.ts
@@ -1,0 +1,301 @@
+import Protocol from "../../../Types/API/Protocol";
+import URL from "../../../Types/API/URL";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * A status page went blank because ONE footer link, saved years earlier by a
+ * looser validator as "https://tel:3136361710/", no longer parsed. The value
+ * was hydrated by the column transformer during findBy, so the throw escaped
+ * the query and 400'd the whole /master-page config endpoint — the page never
+ * got its config and sat on "Loading..." forever.
+ *
+ * The rule these tests pin: reads tolerate a value that no longer validates,
+ * writes never accept one. A single bad legacy row may degrade itself and
+ * nothing else.
+ */
+
+interface Transformer {
+  to: (value: unknown) => unknown;
+  from: (value: unknown) => unknown;
+}
+
+const transformer: Transformer = URL.getDatabaseTransformer() as Transformer;
+
+/*
+ * Values the old character-allowlist Hostname accepted and the current
+ * structural one does not. Every one of these can already be sitting in a
+ * customer's database.
+ */
+const legacyUnparseableValues: Array<string> = [
+  // The value that actually took the status page down.
+  "https://tel:3136361710/",
+  // Ports that are not ports.
+  "https://host:99999999/",
+  "https://example.com:notaport/",
+  // Hosts that are not hosts.
+  "https://-leading-dash.example.com/",
+  "https://trailing-dash-.example.com/",
+  "https:// /",
+  "https://exa mple.com/",
+];
+
+describe("URL — reads tolerate a value that no longer parses", () => {
+  test.each(legacyUnparseableValues)(
+    "fromStringLenient(%s) does not throw",
+    (raw: string) => {
+      expect(() => {
+        return URL.fromStringLenient(raw);
+      }).not.toThrow();
+    },
+  );
+
+  test.each(legacyUnparseableValues)(
+    "fromStringLenient(%s) flags the value as malformed",
+    (raw: string) => {
+      expect(URL.fromStringLenient(raw).isMalformed()).toBe(true);
+    },
+  );
+
+  test.each(legacyUnparseableValues)(
+    "fromStringLenient(%s) preserves the value verbatim",
+    (raw: string) => {
+      // The link still renders as exactly what it always was.
+      expect(URL.fromStringLenient(raw).toString()).toBe(raw);
+    },
+  );
+
+  test.each(legacyUnparseableValues)(
+    "the column transformer reads %s without throwing",
+    (raw: string) => {
+      let result: URL | null = null;
+
+      expect(() => {
+        result = transformer.from(raw) as URL;
+      }).not.toThrow();
+
+      expect(result).toBeInstanceOf(URL);
+      expect((result as unknown as URL).toString()).toBe(raw);
+    },
+  );
+
+  test("fromString stays strict — leniency is opt-in, on read paths only", () => {
+    for (const raw of legacyUnparseableValues) {
+      expect(() => {
+        return URL.fromString(raw);
+      }).toThrow(BadDataException);
+    }
+  });
+});
+
+describe("URL — a malformed value exposes no host", () => {
+  /*
+   * The security property that makes leniency safe: nothing can read a
+   * hostname off a malformed URL and turn it into a request target. The
+   * outbound guards (SSRFProtection) re-parse the raw string with the WHATWG
+   * parser and never trusted this type's parse anyway.
+   */
+  test.each(legacyUnparseableValues)(
+    "%s yields no hostname and no opaque value",
+    (raw: string) => {
+      const url: URL = URL.fromStringLenient(raw);
+
+      expect(url.hostname).toBeUndefined();
+      expect(url.opaqueValue).toBe("");
+    },
+  );
+
+  test("a malformed URL reports the https default protocol", () => {
+    expect(URL.fromStringLenient("https://tel:3136361710/").protocol).toBe(
+      Protocol.HTTPS,
+    );
+  });
+
+  test("removeQueryString on a malformed URL does not throw", () => {
+    const url: URL = URL.fromStringLenient("https://tel:3136361710/?a=1");
+
+    expect(() => {
+      return url.removeQueryString();
+    }).not.toThrow();
+    expect(url.removeQueryString().isMalformed()).toBe(true);
+  });
+});
+
+describe("URL — writes stay strict", () => {
+  test.each(legacyUnparseableValues)(
+    "the column transformer refuses to write back %s",
+    (raw: string) => {
+      const malformed: URL = URL.fromStringLenient(raw);
+
+      expect(() => {
+        return transformer.to(malformed);
+      }).toThrow(BadDataException);
+    },
+  );
+
+  test("a client cannot invent a malformed URL and have it persisted", () => {
+    /*
+     * fromJSON is lenient so the browser can render a legacy link — but the
+     * value it produces is still refused on the way back into the database.
+     */
+    const fromClient: URL = URL.fromJSON({
+      _type: "URL",
+      value: "https://tel:3136361710/",
+    });
+
+    expect(fromClient.isMalformed()).toBe(true);
+    expect(() => {
+      return transformer.to(fromClient);
+    }).toThrow(BadDataException);
+  });
+
+  test("a raw malformed string is refused on write too", () => {
+    expect(() => {
+      return transformer.to("https://tel:3136361710/");
+    }).toThrow(BadDataException);
+  });
+
+  test("the write error names the offending value", () => {
+    expect(() => {
+      return transformer.to(URL.fromStringLenient("https://tel:3136361710/"));
+    }).toThrow("URL https://tel:3136361710/ is not in valid format.");
+  });
+
+  test("valid URLs still write normally", () => {
+    expect(transformer.to(URL.fromString("https://example.com/privacy"))).toBe(
+      "https://example.com/privacy",
+    );
+    expect(transformer.to(URL.fromString("tel:+13136361710"))).toBe(
+      "tel:+13136361710",
+    );
+  });
+});
+
+describe("URL — leniency does not touch valid values", () => {
+  const validValues: Array<string> = [
+    "https://example.com/privacy",
+    "https://docs.voice.izt.cloud/",
+    "http://localhost:5000/api/test",
+    "mailto:support@voice.izt.cloud",
+    "tel:+13136361710",
+    "sms:+15555550123",
+    "wss://localhost:5000/api/test",
+  ];
+
+  test.each(validValues)("%s is not flagged malformed", (raw: string) => {
+    expect(URL.fromStringLenient(raw).isMalformed()).toBe(false);
+    expect((transformer.from(raw) as URL).isMalformed()).toBe(false);
+  });
+
+  test.each(validValues)("%s parses identically either way", (raw: string) => {
+    expect(URL.fromStringLenient(raw).toString()).toBe(
+      URL.fromString(raw).toString(),
+    );
+  });
+
+  test("an empty stored value is still null, not a malformed URL", () => {
+    expect(transformer.from("")).toBeNull();
+    expect(transformer.from(null)).toBeNull();
+  });
+
+  test("undefined is still passed through untouched on write", () => {
+    // A column the caller never set must stay undefined so its DEFAULT applies.
+    expect(transformer.to(undefined)).toBeUndefined();
+  });
+});
+
+/*
+ * The end-to-end shape of the outage: a status page's footer links, one of
+ * which is the bad legacy row. Reading the set must yield every link.
+ */
+describe("URL — one bad link no longer takes down the page that lists it", () => {
+  const storedFooterLinks: Array<{ title: string; link: string }> = [
+    { title: "Phone", link: "https://tel:3136361710/" },
+    { title: "Email", link: "mailto:support@voice.izt.cloud" },
+    { title: "Docs", link: "https://docs.voice.izt.cloud/" },
+    { title: "Portal", link: "https://portal.voice.izt.cloud/" },
+  ];
+
+  test("hydrating the whole set does not throw", () => {
+    expect(() => {
+      return storedFooterLinks.map((row: { link: string }) => {
+        return transformer.from(row.link);
+      });
+    }).not.toThrow();
+  });
+
+  test("every link survives, including the malformed one", () => {
+    const hydrated: Array<URL> = storedFooterLinks.map(
+      (row: { link: string }) => {
+        return transformer.from(row.link) as URL;
+      },
+    );
+
+    expect(hydrated).toHaveLength(4);
+    expect(
+      hydrated.map((url: URL) => {
+        return url.toString();
+      }),
+    ).toEqual([
+      "https://tel:3136361710/",
+      "mailto:support@voice.izt.cloud",
+      "https://docs.voice.izt.cloud/",
+      "https://portal.voice.izt.cloud/",
+    ]);
+  });
+
+  test("only the bad row is degraded", () => {
+    const hydrated: Array<URL> = storedFooterLinks.map(
+      (row: { link: string }) => {
+        return transformer.from(row.link) as URL;
+      },
+    );
+
+    expect(
+      hydrated.map((url: URL) => {
+        return url.isMalformed();
+      }),
+    ).toEqual([true, false, false, false]);
+  });
+
+  test("the whole set still serialises to JSON for the browser", () => {
+    expect(() => {
+      return storedFooterLinks.map((row: { link: string }) => {
+        return (transformer.from(row.link) as URL).toJSON();
+      });
+    }).not.toThrow();
+  });
+
+  /*
+   * Had the fix stopped at the server, the 400 would simply have become a
+   * client-side crash when the browser revived the same value.
+   */
+  test("and the browser can revive every one of them", () => {
+    const revived: Array<URL> = storedFooterLinks.map(
+      (row: { link: string }) => {
+        return URL.fromJSON((transformer.from(row.link) as URL).toJSON());
+      },
+    );
+
+    expect(
+      revived.map((url: URL) => {
+        return url.toString();
+      }),
+    ).toEqual([
+      "https://tel:3136361710/",
+      "mailto:support@voice.izt.cloud",
+      "https://docs.voice.izt.cloud/",
+      "https://portal.voice.izt.cloud/",
+    ]);
+  });
+
+  /*
+   * And the correct value going forward: the same phone link, typed as a real
+   * tel: URI, is valid on write and needs no leniency at all.
+   */
+  test("the same link stored correctly needs no leniency", () => {
+    const stored: unknown = transformer.to(URL.fromString("tel:+13136361710"));
+    expect(stored).toBe("tel:+13136361710");
+    expect((transformer.from(stored) as URL).isMalformed()).toBe(false);
+  });
+});

--- a/Common/Tests/Types/API/URLTelScheme.test.ts
+++ b/Common/Tests/Types/API/URLTelScheme.test.ts
@@ -1,0 +1,261 @@
+import Protocol from "../../../Types/API/Protocol";
+import URL from "../../../Types/API/URL";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * "tel:" and "sms:" are opaque schemes: what follows the colon is a phone
+ * number, not an authority. Before they were known to the parser, a status
+ * page footer link of "tel:3136361710" fell through to the https default,
+ * was read as host "tel" + port "3136361710", and toString() normalised it
+ * on save into "https://tel:3136361710/". These tests pin the parse, the
+ * round-trip, and the rule that nothing in an opaque payload may look like an
+ * authority or a path.
+ */
+
+describe("URL — tel: and sms: are parsed as opaque schemes", () => {
+  const validTelUrls: Array<[string, string]> = [
+    // [input, expected opaque value]
+    ["tel:+13136361710", "+13136361710"],
+    ["tel:3136361710", "3136361710"],
+    ["tel:+1-313-636-1710", "+1-313-636-1710"],
+    ["tel:+1.313.636.1710", "+1.313.636.1710"],
+    // RFC 3966 allows a number to open on a visual separator.
+    ["tel:(313)636-1710", "(313)636-1710"],
+    ["tel:+1(313)636-1710", "+1(313)636-1710"],
+    ["tel:-5550123", "-5550123"],
+    ["tel:911", "911"],
+    ["tel:+442071838750", "+442071838750"],
+    // RFC 3966 parameters.
+    ["tel:3136361710;phone-context=+1", "3136361710;phone-context=+1"],
+    ["tel:+13136361710;ext=42", "+13136361710;ext=42"],
+  ];
+
+  test.each(validTelUrls)(
+    "parses %s as a tel: URL with no hostname",
+    (input: string, expectedValue: string) => {
+      const url: URL = URL.fromString(input);
+
+      expect(url.protocol).toBe(Protocol.TEL);
+      expect(url.opaqueValue).toBe(expectedValue);
+      expect(url.isMalformed()).toBe(false);
+      // An opaque URL has no authority — nothing can read a host off it.
+      expect(url.hostname).toBeUndefined();
+    },
+  );
+
+  test.each(validTelUrls)(
+    "round-trips %s unchanged through toString()",
+    (input: string) => {
+      expect(URL.fromString(input).toString()).toBe(input);
+    },
+  );
+
+  test("parses sms: the same way", () => {
+    const url: URL = URL.fromString("sms:+15555550123");
+
+    expect(url.protocol).toBe(Protocol.SMS);
+    expect(url.opaqueValue).toBe("+15555550123");
+    expect(url.toString()).toBe("sms:+15555550123");
+  });
+
+  test("sms: accepts several comma-separated recipients", () => {
+    const url: URL = URL.fromString("sms:+15555550123,+15555550124");
+
+    expect(url.opaqueValue).toBe("+15555550123,+15555550124");
+    expect(url.toString()).toBe("sms:+15555550123,+15555550124");
+  });
+
+  test("sms: keeps a body query string", () => {
+    const url: URL = URL.fromString("sms:+15555550123?body=hello");
+
+    expect(url.protocol).toBe(Protocol.SMS);
+    expect(url.opaqueValue).toBe("+15555550123");
+    expect(url.getQueryParam("body")).toBe("hello");
+    expect(url.toString()).toBe("sms:+15555550123?body=hello");
+  });
+
+  test("scheme match is case-insensitive, per RFC 3986", () => {
+    expect(URL.fromString("TEL:+13136361710").protocol).toBe(Protocol.TEL);
+    expect(URL.fromString("Tel:+13136361710").opaqueValue).toBe("+13136361710");
+    expect(URL.fromString("SMS:+15555550123").protocol).toBe(Protocol.SMS);
+  });
+
+  test("isOpaqueProtocol identifies exactly tel: and sms:", () => {
+    expect(URL.isOpaqueProtocol(Protocol.TEL)).toBe(true);
+    expect(URL.isOpaqueProtocol(Protocol.SMS)).toBe(true);
+    expect(URL.isOpaqueProtocol(Protocol.HTTPS)).toBe(false);
+    expect(URL.isOpaqueProtocol(Protocol.HTTP)).toBe(false);
+    expect(URL.isOpaqueProtocol(Protocol.MAIL)).toBe(false);
+    expect(URL.isOpaqueProtocol(Protocol.WS)).toBe(false);
+    expect(URL.isOpaqueProtocol(Protocol.WSS)).toBe(false);
+    expect(URL.isOpaqueProtocol(Protocol.MONGO_DB)).toBe(false);
+  });
+
+  test("the constructor also takes the opaque path", () => {
+    const url: URL = new URL(Protocol.TEL, "+13136361710");
+
+    expect(url.opaqueValue).toBe("+13136361710");
+    expect(url.hostname).toBeUndefined();
+    expect(url.toString()).toBe("tel:+13136361710");
+  });
+
+  test("isHttps() is false for an opaque URL", () => {
+    expect(URL.fromString("tel:+13136361710").isHttps()).toBe(false);
+    expect(URL.fromString("sms:+15555550123").isHttps()).toBe(false);
+  });
+});
+
+/*
+ * The regression this whole change exists for: the value a customer typed
+ * must survive a save/read cycle instead of being rewritten into a bogus
+ * https URL that a later, stricter Hostname validator then refuses to read.
+ */
+describe("URL — tel: is no longer mangled into an https URL", () => {
+  test("tel:3136361710 does not become https://tel:3136361710/", () => {
+    const url: URL = URL.fromString("tel:3136361710");
+
+    expect(url.toString()).toBe("tel:3136361710");
+    expect(url.toString()).not.toBe("https://tel:3136361710/");
+    expect(url.protocol).not.toBe(Protocol.HTTPS);
+  });
+
+  test("the value survives the database round-trip", () => {
+    const transformer: {
+      to: (value: unknown) => unknown;
+      from: (value: unknown) => unknown;
+    } = URL.getDatabaseTransformer() as {
+      to: (value: unknown) => unknown;
+      from: (value: unknown) => unknown;
+    };
+
+    const stored: unknown = transformer.to(URL.fromString("tel:3136361710"));
+    expect(stored).toBe("tel:3136361710");
+
+    const readBack: URL = transformer.from(stored) as URL;
+    expect(readBack.toString()).toBe("tel:3136361710");
+    expect(readBack.isMalformed()).toBe(false);
+  });
+
+  test("the value survives the JSON round-trip to the browser", () => {
+    const url: URL = URL.fromString("tel:+13136361710");
+    const revived: URL = URL.fromJSON(url.toJSON());
+
+    expect(revived.toString()).toBe("tel:+13136361710");
+    expect(revived.protocol).toBe(Protocol.TEL);
+    expect(revived.isMalformed()).toBe(false);
+  });
+});
+
+describe("URL — an opaque payload may not smuggle an authority or path", () => {
+  const invalidOpaquePayloads: Array<string> = [
+    // Empty.
+    "tel:",
+    "sms:",
+    // Not a number at all.
+    "tel:abc",
+    "tel:not-a-phone",
+    // Path traversal / a path of any kind.
+    "tel:../../etc/passwd",
+    "tel:1/../../admin",
+    "tel:+1555/path",
+    // An authority smuggled behind the number.
+    "tel:1@evil.example.com",
+    "tel:+15555550123@169.254.169.254",
+    "sms:1@evil.example.com",
+    // A fragment.
+    "tel:1#fragment",
+    "tel:+15555550123#.office.com",
+    // Whitespace.
+    "tel:555 0123",
+    "tel: ",
+    // Separators only, with no digit anywhere.
+    "tel:(",
+    "tel:()-.",
+    "tel:+",
+    // Protocol-relative smuggling.
+    "tel://evil.example.com",
+    "sms://evil.example.com",
+  ];
+
+  test.each(invalidOpaquePayloads)("rejects %s", (input: string) => {
+    expect(() => {
+      return URL.fromString(input);
+    }).toThrow(BadDataException);
+  });
+
+  test("rejects a payload longer than 256 characters", () => {
+    expect(() => {
+      return URL.fromString("tel:+" + "1".repeat(300));
+    }).toThrow(BadDataException);
+  });
+
+  test("rejects a parameter that is not a well-formed key=value", () => {
+    expect(() => {
+      return URL.fromString("tel:+15555550123;evil=a/b");
+    }).toThrow(BadDataException);
+    expect(() => {
+      return URL.fromString("tel:+15555550123;a@b");
+    }).toThrow(BadDataException);
+  });
+
+  test("the error names the offending value", () => {
+    expect(() => {
+      return URL.fromString("tel:abc");
+    }).toThrow("Phone number abc is not in valid format.");
+  });
+
+  /*
+   * A dotted quad is a syntactically valid local number, so it parses — but it
+   * stays a tel: URL with no hostname, so it can never become the target of an
+   * HTTP request the way "https://169.254.169.254" would.
+   */
+  test("a dotted quad stays a tel: URL and exposes no host", () => {
+    const url: URL = URL.fromString("tel:169.254.169.254");
+
+    expect(url.protocol).toBe(Protocol.TEL);
+    expect(url.hostname).toBeUndefined();
+    expect(url.toString()).toBe("tel:169.254.169.254");
+  });
+});
+
+describe("URL — adding opaque schemes did not disturb the existing ones", () => {
+  const untouched: Array<[string, Protocol]> = [
+    ["https://example.com/api/test", Protocol.HTTPS],
+    ["http://example.com/api/test", Protocol.HTTP],
+    ["ws://localhost:5000/api/test", Protocol.WS],
+    ["wss://localhost:5000/api/test", Protocol.WSS],
+    ["mongodb://localhost:27017/test", Protocol.MONGO_DB],
+    ["mailto:support@example.com", Protocol.MAIL],
+  ];
+
+  test.each(untouched)(
+    "%s still parses as %s",
+    (input: string, expected: Protocol) => {
+      const url: URL = URL.fromString(input);
+      expect(url.protocol).toBe(expected);
+      expect(url.opaqueValue).toBe("");
+    },
+  );
+
+  test.each(untouched)("%s still round-trips", (input: string) => {
+    expect(URL.fromString(input).toString()).toBe(input);
+  });
+
+  test("query strings on http URLs are unaffected", () => {
+    const url: URL = URL.fromString("https://example.com/api?a=1&b=2");
+    expect(url.getQueryParam("a")).toBe("1");
+    expect(url.getQueryParam("b")).toBe("2");
+    expect(url.toString()).toBe("https://example.com/api?a=1&b=2");
+  });
+
+  /*
+   * "telephone.example.com" starts with "tel" but is not the tel: scheme —
+   * prefix matching must be on "tel:", not "tel".
+   */
+  test("a host that merely starts with tel is not treated as a tel: URL", () => {
+    const url: URL = URL.fromString("https://telephone.example.com/x");
+    expect(url.protocol).toBe(Protocol.HTTPS);
+    expect(url.hostname.toString()).toBe("telephone.example.com");
+  });
+});

--- a/Common/Tests/Types/API/URLUnsupportedScheme.test.ts
+++ b/Common/Tests/Types/API/URLUnsupportedScheme.test.ts
@@ -1,0 +1,148 @@
+import Protocol from "../../../Types/API/Protocol";
+import URL from "../../../Types/API/URL";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * An unrecognised scheme used to be swallowed: the prefix loop did not match,
+ * the protocol stayed at its https default, and the remainder was read as an
+ * authority. That is how "tel:3136361710" became the stored value
+ * "https://tel:3136361710/" — a URL nobody typed, with a host of "tel".
+ *
+ * The write side now refuses a scheme it cannot represent and says which one,
+ * instead of quietly rewriting the value into something else.
+ */
+
+describe("URL — an unsupported scheme is refused, not rewritten", () => {
+  const unsupportedSchemes: Array<string> = [
+    "ftp://files.example.com/x",
+    "file:///etc/passwd",
+    "gopher://example.com/1",
+    "ldap://example.com/x",
+    "smb://example.com/share",
+    "chrome://settings",
+    "mongodb+srv://cluster.example.com/db",
+  ];
+
+  test.each(unsupportedSchemes)("rejects %s", (input: string) => {
+    expect(() => {
+      return URL.fromString(input);
+    }).toThrow(BadDataException);
+  });
+
+  test("the error names the offending scheme", () => {
+    expect(() => {
+      return URL.fromString("ftp://files.example.com/x");
+    }).toThrow("URL scheme ftp: is not supported.");
+  });
+
+  /*
+   * These are dangerous in an href, so they are refused even without the "//"
+   * authority marker.
+   */
+  const dangerousSchemes: Array<string> = [
+    "javascript:alert(1)",
+    "javascript:alert('xss')",
+    "JavaScript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "data:text/plain,hello",
+    "vbscript:msgbox(1)",
+    "file:/etc/passwd",
+    "blob:https://example.com/uuid",
+  ];
+
+  test.each(dangerousSchemes)("rejects %s", (input: string) => {
+    expect(() => {
+      return URL.fromString(input);
+    }).toThrow(BadDataException);
+  });
+
+  /*
+   * The specific hole this closes: a scheme whose remainder happens to look
+   * like a valid host:port used to sail through and be silently rewritten.
+   */
+  test("an unsupported scheme with a port-shaped remainder is refused", () => {
+    expect(() => {
+      return URL.fromString("javascript:12345");
+    }).toThrow(BadDataException);
+  });
+
+  test("no unsupported scheme is silently rewritten to https", () => {
+    for (const input of [...unsupportedSchemes, ...dangerousSchemes]) {
+      let rewritten: string | null = null;
+
+      try {
+        rewritten = URL.fromString(input).toString();
+      } catch {
+        // Refused, which is the point.
+      }
+
+      expect(rewritten).toBeNull();
+    }
+  });
+});
+
+describe("URL — scheme rejection does not catch things that are not schemes", () => {
+  /*
+   * "example.com:8080/hook" has no scheme — that colon separates a host from a
+   * port. A regex alone cannot tell the two apart, so the rule keys on the
+   * "//" authority marker, which a host:port never has.
+   */
+  const schemeLessValues: Array<[string, string]> = [
+    ["example.com:8080/hook", "example.com:8080"],
+    ["localhost:5000", "localhost:5000"],
+    ["example.com", "example.com"],
+    ["status.example.com/path", "status.example.com"],
+  ];
+
+  test.each(schemeLessValues)(
+    "%s is still parsed as a host, not a scheme",
+    (input: string, expectedHost: string) => {
+      const url: URL = URL.fromString(input);
+
+      expect(url.protocol).toBe(Protocol.HTTPS);
+      expect(url.hostname.toString()).toBe(expectedHost);
+    },
+  );
+
+  test("every supported scheme still parses", () => {
+    const supported: Array<[string, Protocol]> = [
+      ["https://example.com/x", Protocol.HTTPS],
+      ["http://example.com/x", Protocol.HTTP],
+      ["ws://example.com/x", Protocol.WS],
+      ["wss://example.com/x", Protocol.WSS],
+      ["mongodb://example.com/db", Protocol.MONGO_DB],
+      ["mailto:support@example.com", Protocol.MAIL],
+      ["tel:+13136361710", Protocol.TEL],
+      ["sms:+15555550123", Protocol.SMS],
+    ];
+
+    for (const [input, expected] of supported) {
+      expect(URL.fromString(input).protocol).toBe(expected);
+    }
+  });
+});
+
+/*
+ * The read side is unaffected: a value already sitting in the database with an
+ * unsupported scheme still comes back, flagged, rather than failing the query
+ * that touched it.
+ */
+describe("URL — reads still tolerate an unsupported scheme already stored", () => {
+  test("fromStringLenient keeps a stored ftp:// link readable", () => {
+    const url: URL = URL.fromStringLenient("ftp://files.example.com/x");
+
+    expect(url.isMalformed()).toBe(true);
+    expect(url.toString()).toBe("ftp://files.example.com/x");
+  });
+
+  test("but it can never be written back", () => {
+    const transformer: {
+      to: (value: unknown) => unknown;
+    } = URL.getDatabaseTransformer() as { to: (value: unknown) => unknown };
+
+    expect(() => {
+      return transformer.to(URL.fromStringLenient("ftp://files.example.com/x"));
+    }).toThrow(BadDataException);
+  });
+});

--- a/Common/Types/API/Protocol.ts
+++ b/Common/Types/API/Protocol.ts
@@ -5,6 +5,15 @@ enum Protocol {
   WS = "ws://",
   WSS = "wss://",
   MAIL = "mailto:",
+  /*
+   * RFC 3966 / RFC 5724. These are "opaque" schemes: what follows the colon
+   * is a phone number, not an authority, so it must never be handed to
+   * Hostname. Before they were listed here, "tel:1234567890" fell through to
+   * the https default and was normalised on save into
+   * "https://tel:1234567890/" — a host of "tel" and a "port" of 1234567890.
+   */
+  TEL = "tel:",
+  SMS = "sms:",
 }
 
 export default Protocol;

--- a/Common/Types/API/URL.ts
+++ b/Common/Types/API/URL.ts
@@ -9,6 +9,33 @@ import Protocol from "./Protocol";
 import Route from "./Route";
 import { FindOperator } from "typeorm";
 
+/*
+ * Schemes whose remainder is NOT an authority: there is no host, no port and
+ * no path to parse, so the value is carried verbatim instead of being routed
+ * through Hostname. "mailto:" is handled separately because its payload is an
+ * Email, which already has its own type.
+ */
+const OPAQUE_PROTOCOLS: Array<Protocol> = [Protocol.TEL, Protocol.SMS];
+
+/*
+ * A tel/sms subscriber per RFC 3966: an optional "+" for a global number, then
+ * digits and the visual separators the RFC permits ("-", ".", "(", ")"). At
+ * least one digit is required, but it need not come first — "(313)636-1710"
+ * opens on a separator and is a number people really write.
+ *
+ * Deliberately narrow beyond that: the point is to reject anything that could
+ * smuggle a path, query, fragment or authority ("/", "?", "#", "@",
+ * whitespace) into a value that later gets interpolated into an href.
+ */
+const TEL_SUBSCRIBER_REGEX: RegExp = /^\+?[0-9\-.()]*[0-9][0-9\-.()]*$/;
+
+/*
+ * ";key=value" parameters, e.g. ";phone-context=+1". Values are restricted to
+ * RFC 3986 unreserved characters plus the few sub-delims real numbers use.
+ */
+const TEL_PARAM_REGEX: RegExp =
+  /^[A-Za-z0-9\-._~%]+(?:=[A-Za-z0-9\-._~%+:]*)?$/;
+
 export default class URL extends DatabaseProperty {
   private _route: Route = new Route();
   public get route(): Route {
@@ -50,6 +77,75 @@ export default class URL extends DatabaseProperty {
     this._protocol = v;
   }
 
+  /*
+   * The payload of an opaque scheme — the phone number of a tel:/sms: URL.
+   * Empty for every other scheme.
+   */
+  private _opaqueValue: string = "";
+  public get opaqueValue(): string {
+    return this._opaqueValue;
+  }
+  public set opaqueValue(v: string) {
+    const value: string = v.trim();
+
+    if (!URL.isValidOpaqueValue(value)) {
+      throw new BadDataException(
+        "Phone number " + v + " is not in valid format.",
+      );
+    }
+
+    this._opaqueValue = value;
+  }
+
+  /*
+   * Set only by the lenient read paths (fromDatabase / fromJSON) when a stored
+   * value cannot be parsed. Such a URL keeps the raw string so it still
+   * round-trips and still renders, but exposes no hostname and is refused by
+   * toDatabase so the bad value can never be written back or newly created.
+   */
+  private _isMalformed: boolean = false;
+  public isMalformed(): boolean {
+    return this._isMalformed;
+  }
+
+  private _rawValue: string = "";
+
+  public static isOpaqueProtocol(protocol: Protocol): boolean {
+    return OPAQUE_PROTOCOLS.includes(protocol);
+  }
+
+  /*
+   * A tel:/sms: payload: one or more comma-separated numbers (sms: allows
+   * several recipients) followed by optional ";key=value" parameters.
+   */
+  public static isValidOpaqueValue(value: string): boolean {
+    const trimmed: string = value.trim();
+
+    if (!trimmed || trimmed.length > 256) {
+      return false;
+    }
+
+    const [subscribers, ...params] = trimmed.split(";");
+
+    if (!subscribers) {
+      return false;
+    }
+
+    const numbers: Array<string> = subscribers.split(",");
+
+    const everyNumberIsValid: boolean = numbers.every((number: string) => {
+      return TEL_SUBSCRIBER_REGEX.test(number);
+    });
+
+    if (!everyNumberIsValid) {
+      return false;
+    }
+
+    return params.every((param: string) => {
+      return TEL_PARAM_REGEX.test(param);
+    });
+  }
+
   public constructor(
     protocol: Protocol,
     hostname: Hostname | string | Email,
@@ -57,6 +153,21 @@ export default class URL extends DatabaseProperty {
     queryString?: string,
   ) {
     super();
+
+    /*
+     * Opaque schemes first: their payload is a phone number, and asking
+     * Hostname to validate one would either reject it or — as it did before
+     * tel: was a known scheme — read "tel:1234567890" as host + port.
+     */
+    if (URL.isOpaqueProtocol(protocol)) {
+      this.protocol = protocol;
+      this.opaqueValue =
+        hostname instanceof Hostname || hostname instanceof Email
+          ? hostname.toString()
+          : (hostname as string);
+      this.setParamsFromQueryString(queryString);
+      return;
+    }
 
     if (
       typeof hostname === Typeof.String &&
@@ -77,15 +188,21 @@ export default class URL extends DatabaseProperty {
       this.route = route;
     }
 
-    if (queryString) {
-      const keyValues: Array<string> = queryString.split("&");
-      for (const keyValue of keyValues) {
-        if (keyValue.split("=")[0] && keyValue.split("=")[1]) {
-          const key: string | undefined = keyValue.split("=")[0];
-          const value: string | undefined = keyValue.split("=")[1];
-          if (key && value) {
-            this._params[key] = value;
-          }
+    this.setParamsFromQueryString(queryString);
+  }
+
+  private setParamsFromQueryString(queryString?: string): void {
+    if (!queryString) {
+      return;
+    }
+
+    const keyValues: Array<string> = queryString.split("&");
+    for (const keyValue of keyValues) {
+      if (keyValue.split("=")[0] && keyValue.split("=")[1]) {
+        const key: string | undefined = keyValue.split("=")[0];
+        const value: string | undefined = keyValue.split("=")[1];
+        if (key && value) {
+          this._params[key] = value;
         }
       }
     }
@@ -95,7 +212,34 @@ export default class URL extends DatabaseProperty {
     return this.protocol === Protocol.HTTPS;
   }
 
+  private queryStringSuffix(): string {
+    if (Object.keys(this.params).length === 0) {
+      return "";
+    }
+
+    return (
+      "?" +
+      Object.keys(this.params)
+        .map((key: string) => {
+          return key + "=" + this.params[key];
+        })
+        .join("&")
+    );
+  }
+
   public override toString(): string {
+    /*
+     * A value that failed to parse on read is echoed back exactly as stored,
+     * so a legacy row still renders as the link it always was.
+     */
+    if (this.isMalformed()) {
+      return this._rawValue;
+    }
+
+    if (URL.isOpaqueProtocol(this.protocol)) {
+      return `${this.protocol}${this.opaqueValue}${this.queryStringSuffix()}`;
+    }
+
     let urlString: string = `${this.protocol}${this.hostname || this.email}`;
     if (!this.email && !urlString.startsWith("mailto:")) {
       if (this.route && this.route.toString().startsWith("/")) {
@@ -110,15 +254,7 @@ export default class URL extends DatabaseProperty {
         urlString += "/" + this.route.toString();
       }
 
-      if (Object.keys(this.params).length > 0) {
-        urlString += "?";
-
-        for (const key of Object.keys(this.params)) {
-          urlString += key + "=" + this.params[key] + "&";
-        }
-
-        urlString = urlString.substring(0, urlString.length - 1); // remove last &
-      }
+      urlString += this.queryStringSuffix();
     }
 
     return urlString;
@@ -126,6 +262,50 @@ export default class URL extends DatabaseProperty {
 
   public static fromURL(url: URL): URL {
     return URL.fromString(url.toString());
+  }
+
+  /*
+   * An unrecognised scheme used to be swallowed: the prefix loop simply did
+   * not match, the protocol stayed at its https default, and the rest was read
+   * as an authority. "tel:3136361710" was stored as "https://tel:3136361710/"
+   * that way — a value nobody typed, with a host of "tel", which a later,
+   * stricter Hostname then refused to read back.
+   *
+   * Anything that clearly announces a scheme this type cannot represent is now
+   * refused with a message that says so, rather than silently rewritten:
+   *
+   *  - "scheme://..." for any scheme not in the supported list, and
+   *  - the schemes that are dangerous in an href even without "//".
+   *
+   * A scheme-less "example.com:8080/hook" is deliberately still allowed: its
+   * "example.com:" looks like a scheme to a regex but is a host and port, and
+   * callers really do pass it.
+   */
+  private static rejectUnsupportedScheme(url: string): void {
+    const schemeMatch: RegExpMatchArray | null = url
+      .trim()
+      .match(/^([a-zA-Z][a-zA-Z0-9+.-]*):(\/\/)?/);
+
+    if (!schemeMatch || !schemeMatch[1]) {
+      return;
+    }
+
+    const scheme: string = schemeMatch[1].toLowerCase();
+    const hasAuthorityMarker: boolean = Boolean(schemeMatch[2]);
+
+    const isDangerousInAnHref: boolean = [
+      "javascript",
+      "data",
+      "vbscript",
+      "file",
+      "blob",
+    ].includes(scheme);
+
+    if (hasAuthorityMarker || isDangerousInAnHref) {
+      throw new BadDataException(
+        "URL scheme " + scheme + ": is not supported.",
+      );
+    }
   }
 
   public static fromString(url: string): URL {
@@ -146,16 +326,25 @@ export default class URL extends DatabaseProperty {
       ["ws://", Protocol.WS],
       ["mongodb://", Protocol.MONGO_DB],
       ["mailto:", Protocol.MAIL],
+      ["tel:", Protocol.TEL],
+      ["sms:", Protocol.SMS],
     ];
 
     const lowerCasedUrl: string = url.toLowerCase();
+
+    let matchedKnownScheme: boolean = false;
 
     for (const [prefix, prefixProtocol] of schemePrefixes) {
       if (lowerCasedUrl.startsWith(prefix)) {
         protocol = prefixProtocol;
         url = url.substring(prefix.length);
+        matchedKnownScheme = true;
         break;
       }
+    }
+
+    if (!matchedKnownScheme) {
+      URL.rejectUnsupportedScheme(url);
     }
 
     if (protocol === Protocol.MAIL) {
@@ -168,6 +357,18 @@ export default class URL extends DatabaseProperty {
       const mailQueryString: string = url.split("?")[1] || "";
 
       return new URL(protocol, address, undefined, mailQueryString);
+    }
+
+    if (URL.isOpaqueProtocol(protocol)) {
+      /*
+       * "sms:+15555550123?body=hi" — the number is everything before the
+       * query. There is no authority and no path, so nothing here may reach
+       * Hostname.
+       */
+      const number: string = url.split("?")[0] || "";
+      const opaqueQueryString: string = url.split("?")[1] || "";
+
+      return new URL(protocol, number, undefined, opaqueQueryString);
     }
 
     /*
@@ -194,7 +395,50 @@ export default class URL extends DatabaseProperty {
     return new URL(protocol, hostname, route, queryString);
   }
 
+  /*
+   * Parses like fromString, but never throws: a value it cannot understand
+   * comes back as a malformed URL that preserves the original string.
+   *
+   * This exists for READ paths only. A single unparseable row must not be able
+   * to fail the request that reads it — a status page footer link of
+   * "https://tel:1234567890/", stored years earlier by a looser validator,
+   * used to 400 the whole status page config endpoint and left the page stuck
+   * on "Loading...". Writes stay strict: see toDatabase.
+   *
+   * A malformed URL exposes NO hostname, so nothing can read a host off it and
+   * build a request. The outbound-request guards (SSRFProtection) re-parse the
+   * raw string with the WHATWG parser and never trusted this type's parse
+   * anyway, so leniency here does not widen them.
+   */
+  public static fromStringLenient(url: string): URL {
+    try {
+      return URL.fromString(url);
+    } catch {
+      return URL.createMalformed(url);
+    }
+  }
+
+  private static createMalformed(rawValue: string): URL {
+    /*
+     * Built through the opaque branch so the constructor never asks Hostname
+     * to validate the very value that just failed to parse; the placeholder is
+     * then cleared, leaving a URL with no hostname and no opaque value. The
+     * protocol reports the same https default fromString falls back to for an
+     * unrecognised scheme.
+     */
+    const url: URL = new URL(Protocol.TEL, "0");
+    url._protocol = Protocol.HTTPS;
+    url._opaqueValue = "";
+    url._isMalformed = true;
+    url._rawValue = rawValue;
+    return url;
+  }
+
   public removeQueryString(): URL {
+    if (this.isMalformed()) {
+      return this;
+    }
+
     return URL.fromString(this.toString().split("?")[0] || "");
   }
 
@@ -205,9 +449,14 @@ export default class URL extends DatabaseProperty {
     };
   }
 
+  /*
+   * Lenient for the same reason fromDatabase is: this is how a URL crosses the
+   * wire into the browser. If it threw, moving the server-side failure out of
+   * the API would only move the crash into the client that renders the link.
+   */
   public static override fromJSON(json: JSONObject): URL {
     if (json["_type"] === ObjectType.URL) {
-      return URL.fromString((json["value"] as string) || "");
+      return URL.fromStringLenient((json["value"] as string) || "");
     }
 
     throw new BadDataException("Invalid JSON: " + JSON.stringify(json));
@@ -263,6 +512,12 @@ export default class URL extends DatabaseProperty {
     return null;
   }
 
+  /*
+   * The write side stays strict. Reads tolerate a legacy value that no longer
+   * validates, but nothing may persist one: a malformed URL only ever comes
+   * from fromDatabase/fromJSON, so refusing it here stops a bad value being
+   * written back on an unrelated update, and stops a client inventing one.
+   */
   protected static override toDatabase(
     value: URL | FindOperator<URL>,
   ): string | null {
@@ -271,15 +526,26 @@ export default class URL extends DatabaseProperty {
         value = URL.fromString(value);
       }
 
+      if (value instanceof URL && value.isMalformed()) {
+        throw new BadDataException(
+          "URL " + value.toString() + " is not in valid format.",
+        );
+      }
+
       return value.toString();
     }
 
     return null;
   }
 
+  /*
+   * Lenient by design — see fromStringLenient. A row that cannot be parsed is
+   * returned as a malformed URL rather than throwing, because throwing here
+   * fails the entire query that touched the row, not just the one column.
+   */
   protected static override fromDatabase(_value: string): URL | null {
     if (_value) {
-      return URL.fromString(_value);
+      return URL.fromStringLenient(_value);
     }
 
     return null;


### PR DESCRIPTION
## What broke

`https://status.voice.izt.cloud/` served its shell but sat on **"Loading..."** forever. The config endpoint was returning 400:

```
POST /status-page-api/master-page/ca1fd959-… → 400
{"error":"Hostname tel:3136361710 is not in valid format."}
```

One footer link, created 2025-02-25, was stored as `https://tel:3136361710/`. `StatusPageFooterLinkService.findBy` hydrates `link` through the column transformer, so the parse threw *inside the query* and 400'd the whole endpoint — the frontend never got its config.

Only that one row in the entire database had the pattern, and a control status page hit the same endpoint on the same host and returned 200.

## Why it started now

[`ba2cd02ba1`](https://github.com/OneUptime/oneuptime/commit/ba2cd02ba1) *"validate Hostname structurally"* replaced a character allowlist with structural validation, including `PORT_REGEX = /^\d{1,5}$/`. `3136361710` is 10 digits, so what used to parse as host `tel` + port `3136361710` now throws. That commit is an ancestor of the deployed build `641b185b`.

Its own comment anticipated this class of breakage for userinfo — *"those values are already in the database — rejecting them here would fail on read, not just on write"* — but the port tightening got no equivalent escape hatch.

## The value was never what the customer typed

They typed `tel:3136361710`. `tel:` was not a known scheme, so it fell through to the https default, was read as an authority, and `toString()` normalised it on save into a URL nobody wrote. The data corruption and the later read failure are the same root cause.

## Fixes

**1. Reads tolerate a value that no longer parses.** `fromDatabase` and `fromJSON` return a *malformed* URL preserving the original string instead of throwing. One bad legacy row degrades itself rather than failing every request that reads it.

`fromJSON` matters as much as `fromDatabase` — leniency on the server alone would just move the crash into the browser that renders the link.

Safety: a malformed URL exposes **no hostname**, so nothing can read a host off it and build a request. `SSRFProtection` re-parses raw strings with the WHATWG parser and never trusted this type's parse anyway, so this does not widen it.

**2. `tel:` and `sms:` are first-class opaque schemes.** Validated per RFC 3966: optional `+`, digits with visual separators, comma-separated recipients for `sms:`, `;key=value` parameters. Narrow enough that a payload cannot smuggle a path, query, fragment or authority into an href.

**3. Writes stay strict.** `toDatabase` refuses a malformed URL, so a legacy value can never be written back and a client cannot invent one. `fromString` also now rejects a scheme it cannot represent (`ftp://`, `javascript:`, `data:`) naming the scheme, instead of silently rewriting it to https — the exact behaviour that produced this bug. A scheme-less `example.com:8080/hook` is still accepted.

## Tests

Three new suites, 132 cases:

- `URLTelScheme.test.ts` — the `tel:`/`sms:` grammar, round-trips, and rejections (path traversal, smuggled authority, fragments, whitespace, separator-only payloads). Pins that `tel:3136361710` no longer becomes `https://tel:3136361710/`.
- `URLMalformedTolerance.test.ts` — the read/write asymmetry, the no-hostname security property, and the end-to-end shape of the outage: the real four-link footer set with the bad row now hydrates, serialises and revives in full.
- `URLUnsupportedScheme.test.ts` — unsupported and href-dangerous schemes, and that host:port values are not mistaken for schemes.

Writing these caught a real bug: the first regex rejected `tel:(313)636-1710`, which RFC 3966 allows.

Full `Common` suite: **22077 tests passed, 0 test failures** (881 of 892 suites). The 11 suites that did not run all failed to *load* with `dlopen … isolated_vm.node: symbol not found` — every one a Monitor/VM suite importing `isolated-vm`, a pre-existing ABI mismatch with this machine's Node v24 and unrelated to a TypeScript change. CI will confirm.

## Production

The malformed footer link was soft-deleted (`deletedAt`, the app's own delete semantics — reversible) to restore the page immediately. Verified: `master-page` → 200, page renders "All Resources are Operational".

Once this ships, that link can be recreated properly as `tel:+13136361710`.
