### PR TITLE
fix(runbook): let SSH and Kubernetes steps create their agent job

### DIFF
--- a/App/Tests/Runbook/RunnerJobPersistence.test.ts
+++ b/App/Tests/Runbook/RunnerJobPersistence.test.ts
@@ -1,0 +1,399 @@
+import ObjectID from "Common/Types/ObjectID";
+import RunbookStepType from "Common/Types/Runbook/RunbookStepType";
+import RunnerJobOrigin from "Common/Types/Runbook/RunnerJobOrigin";
+import RunnerJobStatus from "Common/Types/Runbook/RunnerJobStatus";
+import RunnerJobService from "Common/Server/Services/RunnerJobService";
+import RunnerJob from "Common/Models/DatabaseModels/RunnerJob";
+import logger from "Common/Server/Utils/Logger";
+import PositiveNumber from "Common/Types/PositiveNumber";
+import {
+  KubernetesAction,
+  KubernetesWorkloadKind,
+  RunbookStep,
+} from "Common/Types/Runbook/RunbookStep";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+import {
+  runBashStep,
+  runJavaScriptStep,
+  runKubernetesStep,
+  runSshStep,
+  StepExecutionContext,
+  StepRunResult,
+} from "../../FeatureSet/Runbook/Services/StepExecutors";
+
+/*
+ * ---------------------------------------------------------------------------
+ * Regression suite for #3209 — "SSH Runbook step fails with 'script is
+ * required'".
+ *
+ * Every other runbook test stubs RunnerJobService.enqueue, which is exactly
+ * why this shipped: the step executors were correct, the payload was correct,
+ * and thirty green tests said SSH worked. What none of them touched was the
+ * one thing between the dispatcher and the database — the model's own
+ * required-column validation. RunnerJob.script was declared `required: true`,
+ * DatabaseService.checkRequiredFields rejects any falsy value, and an SSH job
+ * carries an empty script by design. So every SSH and Kubernetes step failed
+ * at create() with "script is required", before a Runner ever saw the job.
+ *
+ * These tests therefore stub one layer LOWER — at `create`, the last call
+ * before Postgres — and run the real enqueue and the real validator on the row
+ * that comes out. A step type whose job row cannot be persisted is a step type
+ * that does not work, however well its payload is assembled.
+ * ---------------------------------------------------------------------------
+ */
+
+const AGENT_ID: string = ObjectID.generate().toString();
+const CREDENTIAL_ID: string = ObjectID.generate().toString();
+const CREATED_JOB_ID: string = ObjectID.generate().toString();
+
+function makeCtx(): StepExecutionContext {
+  return {
+    projectId: new ObjectID("proj1"),
+    runbookExecutionId: new ObjectID("exec1"),
+  };
+}
+
+function makeStep(
+  type: RunbookStepType,
+  config: Record<string, unknown>,
+): RunbookStep {
+  return {
+    id: `${type}-step-1`,
+    order: 0,
+    type,
+    title: `${type} step`,
+    config: config as unknown as RunbookStep["config"],
+  };
+}
+
+function sshStep(overrides: Record<string, unknown> = {}): RunbookStep {
+  return makeStep(RunbookStepType.SSH, {
+    credentialId: CREDENTIAL_ID,
+    command: "systemctl restart nginx",
+    agentId: AGENT_ID,
+    ...overrides,
+  });
+}
+
+function kubernetesStep(overrides: Record<string, unknown> = {}): RunbookStep {
+  return makeStep(RunbookStepType.Kubernetes, {
+    credentialId: CREDENTIAL_ID,
+    action: KubernetesAction.RestartWorkload,
+    workloadKind: KubernetesWorkloadKind.Deployment,
+    namespace: "production",
+    workloadName: "api",
+    agentId: AGENT_ID,
+    ...overrides,
+  });
+}
+
+function bashStep(overrides: Record<string, unknown> = {}): RunbookStep {
+  return makeStep(RunbookStepType.Bash, {
+    script: "uptime",
+    agentId: AGENT_ID,
+    ...overrides,
+  });
+}
+
+function javaScriptStep(overrides: Record<string, unknown> = {}): RunbookStep {
+  return makeStep(RunbookStepType.JavaScript, {
+    script: "return 1 + 1;",
+    agentId: AGENT_ID,
+    ...overrides,
+  });
+}
+
+/*
+ * The production validator, not a re-implementation of it. Bound off the live
+ * service so that flipping `required` back on RunnerJob.script — the exact
+ * change that caused #3209 — fails these tests rather than silently passing
+ * them.
+ *
+ * create() runs generateDefaultValues immediately before checkRequiredFields
+ * (a column carrying a default is exempt from the check), so the simulation
+ * runs both, in that order.
+ */
+type CreatePathInternals = {
+  generateDefaultValues: (model: RunnerJob) => RunnerJob;
+  checkRequiredFields: (model: RunnerJob) => RunnerJob;
+};
+
+function runRealCreateValidation(row: RunnerJob): RunnerJob {
+  const internals: CreatePathInternals =
+    RunnerJobService as unknown as CreatePathInternals;
+
+  return internals.checkRequiredFields.call(
+    RunnerJobService,
+    internals.generateDefaultValues.call(RunnerJobService, row),
+  );
+}
+
+interface Harness {
+  createSpy: jest.SpyInstance;
+  pollSpy: jest.SpyInstance;
+  findSpy: jest.SpyInstance;
+}
+
+/*
+ * Stub the database boundary only. `enqueue` — including its step-type
+ * invariants and the row it builds — is the real implementation, and `create`
+ * runs the real required-field validation on what it is handed before
+ * answering the way Postgres would.
+ */
+function stubDatabase(): Harness {
+  const createSpy: jest.SpyInstance = jest
+    .spyOn(RunnerJobService, "create")
+    .mockImplementation((args: { data: RunnerJob }): Promise<RunnerJob> => {
+      const validated: RunnerJob = runRealCreateValidation(args.data);
+      validated._id = CREATED_JOB_ID;
+      return Promise.resolve(validated);
+    });
+
+  const pollSpy: jest.SpyInstance = jest
+    .spyOn(RunnerJobService, "pollUntilTerminal")
+    .mockResolvedValue({
+      _id: CREATED_JOB_ID,
+      status: RunnerJobStatus.Succeeded,
+      output: "ok",
+    } as unknown as RunnerJob);
+
+  const findSpy: jest.SpyInstance = jest
+    .spyOn(RunnerJobService, "findLatestJobForStep")
+    .mockResolvedValue(null);
+
+  return { createSpy, pollSpy, findSpy };
+}
+
+function persistedRow(createSpy: jest.SpyInstance): RunnerJob {
+  expect(createSpy).toHaveBeenCalledTimes(1);
+  return (createSpy.mock.calls[0]![0] as { data: RunnerJob }).data;
+}
+
+beforeEach(() => {
+  jest.spyOn(logger, "error").mockImplementation((): void => {
+    return undefined;
+  });
+  jest.spyOn(logger, "info").mockImplementation((): void => {
+    return undefined;
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("#3209 — a dispatched step's job row can actually be persisted", () => {
+  test("an SSH step reaches the Runner instead of failing with 'script is required'", async () => {
+    const { createSpy, pollSpy }: Harness = stubDatabase();
+
+    const result: StepRunResult = await runSshStep(sshStep(), makeCtx());
+
+    /*
+     * The reported symptom, asserted directly: the step must not fail, and
+     * must not fail with THAT message. dispatchToAgent swallows a create()
+     * throw into a failed step result, so without the fix this reads
+     * success=false / "script is required" rather than raising.
+     */
+    expect(result.errorMessage).toBeUndefined();
+    expect(result.success).toBe(true);
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    // The job was not merely created — it was waited on, so the step really ran.
+    expect(pollSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("a Kubernetes step, which has the same empty-script shape, is persisted too", async () => {
+    const { createSpy }: Harness = stubDatabase();
+
+    const result: StepRunResult = await runKubernetesStep(
+      kubernetesStep(),
+      makeCtx(),
+    );
+
+    expect(result.errorMessage).toBeUndefined();
+    expect(result.success).toBe(true);
+    expect(createSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    ["SSH", runSshStep, sshStep],
+    ["Kubernetes", runKubernetesStep, kubernetesStep],
+  ])(
+    "the persisted %s row passes the model's real required-field validation",
+    async (
+      _label: string,
+      run: (
+        step: RunbookStep,
+        ctx: StepExecutionContext,
+      ) => Promise<StepRunResult>,
+      makeStepFn: () => RunbookStep,
+    ) => {
+      const { createSpy }: Harness = stubDatabase();
+
+      await run(makeStepFn(), makeCtx());
+
+      const row: RunnerJob = persistedRow(createSpy);
+
+      expect(() => {
+        return runRealCreateValidation(row);
+      }).not.toThrow();
+    },
+  );
+
+  test.each([
+    ["Bash", runBashStep, bashStep],
+    ["JavaScript", runJavaScriptStep, javaScriptStep],
+  ])(
+    "the script-carrying %s step still persists and still passes validation",
+    async (
+      _label: string,
+      run: (
+        step: RunbookStep,
+        ctx: StepExecutionContext,
+      ) => Promise<StepRunResult>,
+      makeStepFn: () => RunbookStep,
+    ) => {
+      const { createSpy }: Harness = stubDatabase();
+
+      const result: StepRunResult = await run(makeStepFn(), makeCtx());
+
+      expect(result.success).toBe(true);
+
+      const row: RunnerJob = persistedRow(createSpy);
+      expect(row.script).toBeTruthy();
+      expect(row.payload).toBeUndefined();
+      expect(() => {
+        return runRealCreateValidation(row);
+      }).not.toThrow();
+    },
+  );
+
+  test("an SSH job row is stored with an empty script string, never null or undefined", async () => {
+    /*
+     * The column is NOT NULL in Postgres. `required: false` only relaxes the
+     * application-level check — writing undefined would still be rejected by
+     * the database, one layer further down and with a far worse message.
+     */
+    const { createSpy }: Harness = stubDatabase();
+
+    await runSshStep(sshStep(), makeCtx());
+
+    const row: RunnerJob = persistedRow(createSpy);
+
+    expect(row.script).toBe("");
+    expect(row.script).not.toBeNull();
+    expect(row.script).not.toBeUndefined();
+    expect(typeof row.script).toBe("string");
+  });
+
+  test("an SSH job row carries the full shape the claim path reads back", async () => {
+    const { createSpy }: Harness = stubDatabase();
+    const ctx: StepExecutionContext = makeCtx();
+    const step: RunbookStep = sshStep();
+
+    await runSshStep(step, ctx);
+
+    const row: RunnerJob = persistedRow(createSpy);
+
+    expect(row.stepType).toBe(RunbookStepType.SSH);
+    expect(row.stepId).toBe(step.id);
+    expect(row.status).toBe(RunnerJobStatus.Pending);
+    expect(row.origin).toBe(RunnerJobOrigin.Runbook);
+    expect(row.projectId?.toString()).toBe(ctx.projectId.toString());
+    expect(row.runbookExecutionId?.toString()).toBe(
+      ctx.runbookExecutionId.toString(),
+    );
+    expect(row.targetAgentId?.toString()).toBe(AGENT_ID);
+    expect(row.payload).toEqual({
+      credentialId: CREDENTIAL_ID,
+      command: "systemctl restart nginx",
+    });
+    // The credential is resolved at claim time; the row references it by id only.
+    expect(JSON.stringify(row)).not.toContain("privateKey");
+  });
+
+  test("a create failure still surfaces on the step rather than escaping the execution", async () => {
+    /*
+     * The failure mode that produced the bug report: whatever create() throws
+     * has to arrive as the step's error message. That is what made #3209
+     * diagnosable at all, and it must keep working for the next unexpected
+     * database error.
+     */
+    const { createSpy, pollSpy }: Harness = stubDatabase();
+    createSpy.mockRejectedValue(new Error("duplicate key value"));
+
+    const result: StepRunResult = await runSshStep(sshStep(), makeCtx());
+
+    expect(result.success).toBe(false);
+    expect(result.errorMessage).toContain("duplicate key value");
+    expect(pollSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("#3209 — the AI remediation lane has the same empty-script shape", () => {
+  let countBySpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    countBySpy = jest
+      .spyOn(RunnerJobService, "countBy")
+      .mockResolvedValue(new PositiveNumber(0));
+  });
+
+  test("an AI-composed SSH command is persisted and passes required-field validation", async () => {
+    /*
+     * enqueueAiCommand writes the same empty script + payload layout the
+     * runbook executors do, so it was broken by the same declaration — an
+     * approved remediation plan would have failed at the last step, after a
+     * human had already approved it.
+     */
+    const { createSpy }: Harness = stubDatabase();
+
+    await RunnerJobService.enqueueAiCommand({
+      projectId: new ObjectID("proj1"),
+      aiRunId: new ObjectID("run1"),
+      autoRemediationSuggestionId: new ObjectID("sugg1"),
+      stepId: "cmd-1",
+      stepType: RunbookStepType.SSH,
+      targetAgentId: new ObjectID(AGENT_ID),
+      command: "systemctl restart nginx",
+      credentialId: CREDENTIAL_ID,
+      timeoutInMs: 60_000,
+    });
+
+    expect(countBySpy).toHaveBeenCalled();
+
+    const row: RunnerJob = persistedRow(createSpy);
+
+    expect(row.script).toBe("");
+    expect(row.origin).toBe(RunnerJobOrigin.AiRemediation);
+    expect(row.payload).toEqual({
+      credentialId: CREDENTIAL_ID,
+      command: "systemctl restart nginx",
+    });
+    expect(() => {
+      return runRealCreateValidation(row);
+    }).not.toThrow();
+  });
+
+  test("an AI-composed Bash command still persists with the command as its script", async () => {
+    const { createSpy }: Harness = stubDatabase();
+
+    await RunnerJobService.enqueueAiCommand({
+      projectId: new ObjectID("proj1"),
+      aiRunId: new ObjectID("run1"),
+      autoRemediationSuggestionId: new ObjectID("sugg1"),
+      stepId: "cmd-1",
+      stepType: RunbookStepType.Bash,
+      targetAgentId: new ObjectID(AGENT_ID),
+      command: "systemctl restart nginx",
+      timeoutInMs: 60_000,
+    });
+
+    const row: RunnerJob = persistedRow(createSpy);
+
+    expect(row.script).toBe("systemctl restart nginx");
+    expect(row.payload).toBeUndefined();
+    expect(() => {
+      return runRealCreateValidation(row);
+    }).not.toThrow();
+  });
+});

--- a/Common/Models/DatabaseModels/RunnerJob.ts
+++ b/Common/Models/DatabaseModels/RunnerJob.ts
@@ -32,7 +32,7 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
   pluralName: "Runner Jobs",
   icon: IconProp.Logs,
   tableDescription:
-    "One row per Bash or JavaScript step dispatched to a specific Runner. Tracks claim, execution, and result. Managed by the Worker and the agents; not user-writable.",
+    "One row per step dispatched to a specific Runner — Bash and JavaScript, which carry a script, and SSH and Kubernetes, which carry structured instructions instead. Tracks claim, execution, and result. Managed by the Worker and the agents; not user-writable.",
 })
 @TableAccessControl({
   create: [],

--- a/Common/Models/DatabaseModels/RunnerJob.ts
+++ b/Common/Models/DatabaseModels/RunnerJob.ts
@@ -449,6 +449,21 @@ export default class RunnerJob extends BaseModel {
   })
   public status?: RunnerJobStatus = undefined;
 
+  /*
+   * NOT a required column, even though the database keeps it NOT NULL.
+   *
+   * `required` feeds getRequiredColumns(), which
+   * DatabaseService.checkRequiredFields rejects on any falsy value — and an
+   * empty string is falsy. SSH and Kubernetes jobs carry their instruction in
+   * `payload` and an empty script by design, so marking this required made
+   * every one of them fail at create() with "script is required" before a
+   * Runner ever saw the job. The NOT NULL constraint still holds:
+   * RunnerJobService always writes a string, empty or not.
+   *
+   * Which step types must carry a script and which must carry a payload is a
+   * per-type rule that column metadata cannot express, so it is enforced in
+   * RunnerJobService.enqueue instead.
+   */
   @ColumnAccessControl({
     create: [],
     read: [
@@ -464,7 +479,7 @@ export default class RunnerJob extends BaseModel {
   })
   @TableColumn({
     type: TableColumnType.VeryLongText,
-    required: true,
+    required: false,
     title: "Script",
     description:
       "The script the Runner must execute. Empty for step types that carry structured instructions in the payload instead.",

--- a/Common/Server/Services/RunnerJobService.ts
+++ b/Common/Server/Services/RunnerJobService.ts
@@ -5,6 +5,7 @@ import Model from "../../Models/DatabaseModels/RunnerJob";
 import RunnerJobStatus from "../../Types/Runbook/RunnerJobStatus";
 import RunnerJobOrigin from "../../Types/Runbook/RunnerJobOrigin";
 import RunbookStepType, {
+  isPayloadCarryingStepType,
   isRunnerExecutedStepType,
 } from "../../Types/Runbook/RunbookStepType";
 import { AI_COMMAND_STEP_TYPES } from "../../Types/AutoRemediation/AiRemediationCommandPlan";
@@ -106,6 +107,27 @@ export class Service extends DatabaseService<Model> {
       );
     }
 
+    /*
+     * Each runner-executed type carries its instruction in exactly one place:
+     * a script, or a structured payload. Enforced here rather than as a
+     * required column because it is per-type — the column check would reject
+     * an SSH job's empty script, which is the shape SSH jobs are supposed to
+     * have. A job dispatched with neither would reach a Runner that has
+     * nothing to do and report success, which looks identical to a step that
+     * actually ran.
+     */
+    if (isPayloadCarryingStepType(data.stepType)) {
+      if (!data.payload) {
+        throw new BadDataException(
+          `A ${data.stepType} job needs structured instructions to send to the Runner.`,
+        );
+      }
+    } else if (!data.script) {
+      throw new BadDataException(
+        `A ${data.stepType} job needs a script for the Runner to execute.`,
+      );
+    }
+
     const claimDeadlineAt: Date = OneUptimeDate.addRemoveSeconds(
       OneUptimeDate.getCurrentDate(),
       Math.ceil((data.claimTimeoutInMs ?? DEFAULT_CLAIM_TIMEOUT_MS) / 1000),
@@ -118,7 +140,8 @@ export class Service extends DatabaseService<Model> {
     row.stepId = data.stepId;
     row.stepType = data.stepType;
     row.targetAgentId = data.targetAgentId;
-    row.script = data.script;
+    // The column is NOT NULL, so a payload-carrying job stores "" rather than null.
+    row.script = data.script || "";
     if (data.payload) {
       row.payload = data.payload;
     }

--- a/Common/Tests/Server/Services/RunnerJobEnqueue.test.ts
+++ b/Common/Tests/Server/Services/RunnerJobEnqueue.test.ts
@@ -1,0 +1,412 @@
+import RunnerJobService from "../../../Server/Services/RunnerJobService";
+import RunnerJob from "../../../Models/DatabaseModels/RunnerJob";
+import RunbookStepType, {
+  RUNNER_EXECUTED_STEP_TYPES,
+  isPayloadCarryingStepType,
+} from "../../../Types/Runbook/RunbookStepType";
+import RunnerJobOrigin from "../../../Types/Runbook/RunnerJobOrigin";
+import RunnerJobStatus from "../../../Types/Runbook/RunnerJobStatus";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import logger from "../../../Server/Utils/Logger";
+import { JSONObject } from "../../../Types/JSON";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * ---------------------------------------------------------------------------
+ * Contract under test — RunnerJobService.enqueue, and the RunnerJob column
+ * declarations it has to satisfy.
+ *
+ * Background (issue #3209): RunnerJob.script was declared `required: true`.
+ * DatabaseService.checkRequiredFields rejects any falsy value on a required
+ * column, and an empty string is falsy — so every SSH and Kubernetes job,
+ * which carries its instruction in `payload` and an empty script BY DESIGN,
+ * died at create() with "script is required". Two whole step types were
+ * unusable, and nothing caught it because every test stubbed enqueue.
+ *
+ * Two things are pinned here, and they are deliberately different in kind:
+ *
+ *   1. the column declaration itself — `script` must not be a required
+ *      column. This is the direct tripwire on the change that caused the bug.
+ *
+ *   2. the rule that `required: true` was standing in for, now enforced
+ *      per-type where it can actually be expressed: a script-carrying type
+ *      must bring a script, a payload-carrying type must bring a payload, and
+ *      the row that comes out passes the real validator either way.
+ *
+ * No database: create is stubbed at the boundary, and everything above it is
+ * the real implementation.
+ * ---------------------------------------------------------------------------
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const EXECUTION_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+const AGENT_ID: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+
+const SSH_PAYLOAD: JSONObject = {
+  credentialId: "55555555-5555-4555-8555-555555555555",
+  command: "systemctl restart nginx",
+};
+
+/*
+ * The production validator, bound off the live service rather than
+ * reimplemented — the point is to fail if the model's declarations change,
+ * not if a copy of the rule drifts.
+ */
+type CreatePathInternals = {
+  generateDefaultValues: (model: RunnerJob) => RunnerJob;
+  checkRequiredFields: (model: RunnerJob) => RunnerJob;
+};
+
+function runRealCreateValidation(row: RunnerJob): RunnerJob {
+  const internals: CreatePathInternals =
+    RunnerJobService as unknown as CreatePathInternals;
+
+  return internals.checkRequiredFields.call(
+    RunnerJobService,
+    internals.generateDefaultValues.call(RunnerJobService, row),
+  );
+}
+
+type EnqueueArgs = Parameters<typeof RunnerJobService.enqueue>[0];
+
+function enqueueArgs(overrides: Partial<EnqueueArgs> = {}): EnqueueArgs {
+  return {
+    projectId: PROJECT_ID,
+    runbookExecutionId: EXECUTION_ID,
+    stepId: "step-1",
+    stepType: RunbookStepType.Bash,
+    targetAgentId: AGENT_ID,
+    script: "uptime",
+    timeoutInMs: 30_000,
+    ...overrides,
+  } as EnqueueArgs;
+}
+
+/*
+ * Arguments that are valid for the given step type — a script for the script
+ * types, a payload and an empty script for the payload types. Used by the
+ * table-driven tests so every runner-executed type is exercised through the
+ * same assertions.
+ */
+function validArgsFor(stepType: RunbookStepType): EnqueueArgs {
+  if (isPayloadCarryingStepType(stepType)) {
+    return enqueueArgs({ stepType, script: "", payload: SSH_PAYLOAD });
+  }
+  return enqueueArgs({ stepType, script: "echo hello" });
+}
+
+let createSpy: jest.SpyInstance;
+
+function createdRow(): RunnerJob {
+  expect(createSpy).toHaveBeenCalledTimes(1);
+  return (createSpy.mock.calls[0]![0] as { data: RunnerJob }).data;
+}
+
+beforeEach(() => {
+  /*
+   * enqueue is wrapped in @CaptureSpan, which records a thrown exception at
+   * error level. The rejection tests expect those throws, so keep the output
+   * readable.
+   */
+  jest.spyOn(logger, "error").mockImplementation((): void => {
+    return undefined;
+  });
+
+  createSpy = jest
+    .spyOn(RunnerJobService, "create")
+    .mockImplementation((args: { data: RunnerJob }): Promise<RunnerJob> => {
+      const row: RunnerJob = args.data;
+      row._id = "66666666-6666-4666-8666-666666666666";
+      return Promise.resolve(row);
+    });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("RunnerJob column declarations", () => {
+  test("script is NOT a required column — the declaration that caused #3209", () => {
+    /*
+     * The single assertion that would have caught the bug. Flipping this back
+     * to `required: true` makes every SSH and Kubernetes job unpersistable,
+     * because their script is legitimately an empty string.
+     */
+    const requiredColumns: Array<string> = new RunnerJob().getRequiredColumns()
+      .columns;
+
+    expect(requiredColumns).not.toContain("script");
+  });
+
+  test("the columns that genuinely cannot be empty are still required", () => {
+    /*
+     * The fix must not have relaxed anything else. Each of these is written by
+     * enqueue on every job and has no meaningful empty value, so a missing one
+     * should still be refused before it reaches Postgres.
+     */
+    const requiredColumns: Array<string> = new RunnerJob().getRequiredColumns()
+      .columns;
+
+    for (const column of [
+      "projectId",
+      "origin",
+      "stepId",
+      "stepType",
+      "status",
+      "timeoutInMs",
+      "claimDeadlineAt",
+    ]) {
+      expect(requiredColumns).toContain(column);
+    }
+  });
+
+  test("payload is optional, since script-carrying jobs have none", () => {
+    expect(new RunnerJob().getRequiredColumns().columns).not.toContain(
+      "payload",
+    );
+  });
+
+  test("an empty script is rejected by the required-column check, which is why script is not required", () => {
+    /*
+     * Documents the mechanism rather than assuming it: checkRequiredFields
+     * tests truthiness, so "" fails exactly like undefined. Any future column
+     * that can legitimately hold an empty string has the same constraint.
+     */
+    const row: RunnerJob = new RunnerJob();
+    row.projectId = PROJECT_ID;
+    row.origin = RunnerJobOrigin.Runbook;
+    row.stepId = "step-1";
+    row.stepType = RunbookStepType.SSH;
+    row.status = RunnerJobStatus.Pending;
+    row.timeoutInMs = 30_000;
+    row.claimDeadlineAt = new Date();
+    row.script = "";
+    row.payload = SSH_PAYLOAD;
+
+    // Passes only because `script` is not in the required set.
+    expect(() => {
+      return runRealCreateValidation(row);
+    }).not.toThrow();
+
+    const stillRequired: RunnerJob = Object.assign(new RunnerJob(), row);
+    stillRequired.stepId = "";
+
+    // Same falsy value on a column that IS required — still refused.
+    expect(() => {
+      return runRealCreateValidation(stillRequired);
+    }).toThrow(/stepId is required/);
+  });
+});
+
+describe("RunnerJobService.enqueue — what may be dispatched", () => {
+  test.each([
+    RunbookStepType.Manual,
+    RunbookStepType.HttpRequest,
+    RunbookStepType.AI,
+  ])(
+    "refuses %s, which no Runner can execute",
+    async (type: RunbookStepType) => {
+      await expect(
+        RunnerJobService.enqueue(enqueueArgs({ stepType: type })),
+      ).rejects.toThrow(BadDataException);
+
+      expect(createSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  test("refuses a job with no target Runner", async () => {
+    await expect(
+      RunnerJobService.enqueue(
+        enqueueArgs({ targetAgentId: undefined as unknown as ObjectID }),
+      ),
+    ).rejects.toThrow(/targetAgentId is required/);
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  test.each([RunbookStepType.SSH, RunbookStepType.Kubernetes])(
+    "refuses a %s job that arrives without structured instructions",
+    async (type: RunbookStepType) => {
+      /*
+       * The invariant that replaced the required column. A payload-carrying
+       * job with neither script nor payload would reach a Runner with nothing
+       * to do; the Runner's own guard would fail it, but only after a claim,
+       * a lease and a round trip. Refuse it at the source, with a message that
+       * names what is missing.
+       */
+      await expect(
+        RunnerJobService.enqueue(enqueueArgs({ stepType: type, script: "" })),
+      ).rejects.toThrow(/structured instructions/);
+
+      expect(createSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([RunbookStepType.Bash, RunbookStepType.JavaScript])(
+    "refuses a %s job with an empty script",
+    async (type: RunbookStepType) => {
+      /*
+       * The mirror image. The step executors already short-circuit an empty
+       * script as a no-op before dispatching, so this is a backstop for any
+       * other caller — and it is the check that used to be (accidentally)
+       * provided by the required column.
+       */
+      await expect(
+        RunnerJobService.enqueue(enqueueArgs({ stepType: type, script: "" })),
+      ).rejects.toThrow(/needs a script/);
+
+      expect(createSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  test("a payload alone does not satisfy a script-carrying step type", async () => {
+    await expect(
+      RunnerJobService.enqueue(
+        enqueueArgs({
+          stepType: RunbookStepType.Bash,
+          script: "",
+          payload: SSH_PAYLOAD,
+        }),
+      ),
+    ).rejects.toThrow(/needs a script/);
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("RunnerJobService.enqueue — the row that is written", () => {
+  test.each(RUNNER_EXECUTED_STEP_TYPES)(
+    "a %s job passes the model's real required-field validation",
+    async (type: RunbookStepType) => {
+      /*
+       * The regression test for #3209, run across every type a Runner can be
+       * handed. With `script` required again, the two payload-carrying types
+       * fail here exactly as they failed in production.
+       */
+      await RunnerJobService.enqueue(validArgsFor(type));
+
+      const row: RunnerJob = createdRow();
+
+      expect(() => {
+        return runRealCreateValidation(row);
+      }).not.toThrow();
+    },
+  );
+
+  test.each([RunbookStepType.SSH, RunbookStepType.Kubernetes])(
+    "a %s job is written with an empty script and its payload",
+    async (type: RunbookStepType) => {
+      await RunnerJobService.enqueue(validArgsFor(type));
+
+      const row: RunnerJob = createdRow();
+
+      expect(row.script).toBe("");
+      expect(row.payload).toEqual(SSH_PAYLOAD);
+      expect(row.stepType).toBe(type);
+    },
+  );
+
+  test("an undefined script becomes an empty string, never undefined", async () => {
+    /*
+     * The column is NOT NULL in Postgres. Relaxing the application-level check
+     * must not let an undefined value through to the database, where it would
+     * surface as a driver error instead of a readable one.
+     */
+    await RunnerJobService.enqueue(
+      enqueueArgs({
+        stepType: RunbookStepType.SSH,
+        script: undefined as unknown as string,
+        payload: SSH_PAYLOAD,
+      }),
+    );
+
+    const row: RunnerJob = createdRow();
+
+    expect(row.script).toBe("");
+    expect(typeof row.script).toBe("string");
+  });
+
+  test("a script-carrying job keeps its script verbatim and gets no payload key", async () => {
+    const script: string = "pg_dump -Fc app | gzip > /backup/$(date +%F).gz";
+
+    await RunnerJobService.enqueue(
+      enqueueArgs({ stepType: RunbookStepType.Bash, script }),
+    );
+
+    const row: RunnerJob = createdRow();
+
+    expect(row.script).toBe(script);
+    expect(row.payload).toBeUndefined();
+  });
+
+  test("a runbook job carries Runbook provenance and starts Pending", async () => {
+    await RunnerJobService.enqueue(validArgsFor(RunbookStepType.SSH));
+
+    const row: RunnerJob = createdRow();
+
+    expect(row.origin).toBe(RunnerJobOrigin.Runbook);
+    expect(row.status).toBe(RunnerJobStatus.Pending);
+    expect(row.projectId?.toString()).toBe(PROJECT_ID.toString());
+    expect(row.runbookExecutionId?.toString()).toBe(EXECUTION_ID.toString());
+    expect(row.targetAgentId?.toString()).toBe(AGENT_ID.toString());
+    expect(row.stepId).toBe("step-1");
+    expect(row.timeoutInMs).toBe(30_000);
+    // Never pre-assigned: a job belongs to whoever wins the claim.
+    expect(row.assignedAgentId).toBeUndefined();
+  });
+
+  test("the claim deadline honours the configured claim timeout", async () => {
+    const before: number = Date.now();
+
+    await RunnerJobService.enqueue(
+      enqueueArgs({
+        stepType: RunbookStepType.SSH,
+        script: "",
+        payload: SSH_PAYLOAD,
+        claimTimeoutInMs: 300_000,
+      }),
+    );
+
+    const after: number = Date.now();
+    const deadlineMs: number = createdRow().claimDeadlineAt!.getTime();
+
+    expect(deadlineMs).toBeGreaterThanOrEqual(before + 300_000);
+    expect(deadlineMs).toBeLessThanOrEqual(after + 300_000);
+  });
+
+  test("an SSH job row never carries credential material", async () => {
+    /*
+     * The reason the payload exists at all: the row is readable by anyone who
+     * can read the execution, so it references a credential by id and the
+     * secret is resolved at claim time, scoped to the claiming Runner.
+     */
+    await RunnerJobService.enqueue(validArgsFor(RunbookStepType.SSH));
+
+    const serialized: string = JSON.stringify(createdRow());
+
+    for (const marker of [
+      "privateKey",
+      "passphrase",
+      "password",
+      "hostname",
+      "username",
+      "BEGIN OPENSSH PRIVATE KEY",
+    ]) {
+      expect(serialized).not.toContain(marker);
+    }
+  });
+
+  test("the create is performed as root, since no user owns a dispatched job", async () => {
+    await RunnerJobService.enqueue(validArgsFor(RunbookStepType.SSH));
+
+    const args: { props: Record<string, unknown> } = createSpy.mock
+      .calls[0]![0] as { props: Record<string, unknown> };
+
+    expect(args.props).toEqual(expect.objectContaining({ isRoot: true }));
+  });
+});

--- a/Common/Tests/Types/Runbook/RunbookStepType.test.ts
+++ b/Common/Tests/Types/Runbook/RunbookStepType.test.ts
@@ -1,5 +1,7 @@
 import RunbookStepType, {
+  PAYLOAD_CARRYING_STEP_TYPES,
   RUNNER_EXECUTED_STEP_TYPES,
+  isPayloadCarryingStepType,
   isRunnerExecutedStepType,
 } from "../../../Types/Runbook/RunbookStepType";
 import { describe, expect, test } from "@jest/globals";
@@ -238,5 +240,127 @@ describe("isRunnerExecutedStepType", () => {
     expect(isRunnerExecutedStepType(null as unknown as RunbookStepType)).toBe(
       false,
     );
+  });
+});
+
+/*
+ * The second partition, inside the Runner lane: how a job carries its
+ * instruction.
+ *
+ * A Bash or JavaScript job carries a script. An SSH or Kubernetes job carries
+ * structured instructions plus a credential resolved at claim time, and an
+ * EMPTY script — which is the whole reason this split has to be named
+ * somewhere. Issue #3209 was RunnerJob.script being declared a required
+ * column: an empty string is falsy, so the required-column check rejected
+ * every SSH and Kubernetes job at create() with "script is required". The rule
+ * is per-type and cannot be written as column metadata, so it lives in
+ * RunnerJobService.enqueue and reads this list.
+ */
+describe("PAYLOAD_CARRYING_STEP_TYPES", () => {
+  test("contains exactly SSH and Kubernetes", () => {
+    expect(PAYLOAD_CARRYING_STEP_TYPES).toEqual([
+      RunbookStepType.SSH,
+      RunbookStepType.Kubernetes,
+    ]);
+    expect(new Set(PAYLOAD_CARRYING_STEP_TYPES).size).toBe(
+      PAYLOAD_CARRYING_STEP_TYPES.length,
+    );
+  });
+
+  test("every entry is also a Runner-executed type", () => {
+    /*
+     * A payload-carrying type that the Worker executes would be a
+     * contradiction: the payload exists to be handed to a Runner.
+     */
+    for (const type of PAYLOAD_CARRYING_STEP_TYPES) {
+      expect(RUNNER_EXECUTED_STEP_TYPES).toContain(type);
+    }
+  });
+});
+
+describe("isPayloadCarryingStepType", () => {
+  test.each([RunbookStepType.SSH, RunbookStepType.Kubernetes])(
+    "%s carries a payload rather than a script",
+    (type: RunbookStepType) => {
+      expect(isPayloadCarryingStepType(type)).toBe(true);
+    },
+  );
+
+  test.each([RunbookStepType.Bash, RunbookStepType.JavaScript])(
+    "%s carries a script rather than a payload",
+    (type: RunbookStepType) => {
+      /*
+       * Answering true for a script type would let a Bash job with no script
+       * through enqueue, and the Runner would spawn an empty shell and report
+       * success — indistinguishable from a step that actually ran.
+       */
+      expect(isPayloadCarryingStepType(type)).toBe(false);
+    },
+  );
+
+  test("the Runner lane splits cleanly into script-carrying and payload-carrying", () => {
+    /*
+     * Total and disjoint within the Runner lane. enqueue treats the two as
+     * complementary — anything not payload-carrying is required to bring a
+     * script — so a new Runner type that belongs in neither set does not
+     * exist, and a new one added to the enum must be placed here deliberately.
+     */
+    const payload: Array<RunbookStepType> = RUNNER_EXECUTED_STEP_TYPES.filter(
+      (type: RunbookStepType) => {
+        return isPayloadCarryingStepType(type);
+      },
+    );
+    const script: Array<RunbookStepType> = RUNNER_EXECUTED_STEP_TYPES.filter(
+      (type: RunbookStepType) => {
+        return !isPayloadCarryingStepType(type);
+      },
+    );
+
+    expect(payload.slice().sort()).toEqual(
+      PAYLOAD_CARRYING_STEP_TYPES.slice().sort(),
+    );
+    expect(script.slice().sort()).toEqual(
+      [RunbookStepType.JavaScript, RunbookStepType.Bash].slice().sort(),
+    );
+    expect(payload.length + script.length).toBe(
+      RUNNER_EXECUTED_STEP_TYPES.length,
+    );
+  });
+
+  test("agrees with the exported list for every member of the enum", () => {
+    for (const type of Object.values(RunbookStepType)) {
+      const answer: boolean = isPayloadCarryingStepType(type);
+
+      expect(typeof answer).toBe("boolean");
+      expect(answer).toBe(PAYLOAD_CARRYING_STEP_TYPES.includes(type));
+    }
+  });
+
+  test("no Worker-executed type carries a payload", () => {
+    for (const type of WORKER_EXECUTED_STEP_TYPES) {
+      expect(isPayloadCarryingStepType(type)).toBe(false);
+    }
+  });
+
+  test("near misses, null and undefined do not carry a payload", () => {
+    /*
+     * Falling back to false is the safe direction: an unrecognised type is
+     * then required to bring a script, and enqueue rejects it rather than
+     * creating a job with nothing in it.
+     */
+    const notPayloadTypes: Array<unknown> = [
+      "",
+      " ",
+      "ssh",
+      "SSH ",
+      "kubernetes",
+      "Docker",
+      null,
+      undefined,
+    ];
+
+    for (const value of notPayloadTypes) {
+      expect(isPayloadCarryingStepType(value as RunbookStepType)).toBe(false);
+    }
   });
 });

--- a/Common/Types/Runbook/RunbookStepType.ts
+++ b/Common/Types/Runbook/RunbookStepType.ts
@@ -33,3 +33,26 @@ export const RUNNER_EXECUTED_STEP_TYPES: Array<RunbookStepType> = [
 export function isRunnerExecutedStepType(type: RunbookStepType): boolean {
   return RUNNER_EXECUTED_STEP_TYPES.includes(type);
 }
+
+/*
+ * Runner-executed step types that act on a system OTHER than the Runner's own
+ * host. They are dispatched as structured instructions (RunnerJob.payload)
+ * plus a credential the server resolves at claim time — never as a script, so
+ * their job rows carry an empty script by design.
+ *
+ * That is why RunnerJob.script is not a required column: an empty string is
+ * falsy, so a required-column check would reject exactly these jobs. The real
+ * rule — script types need a script, these need a payload — is per-type and
+ * therefore lives in RunnerJobService.enqueue rather than in column metadata.
+ *
+ * Every runner-executed type not listed here carries a script instead; the
+ * two sets are complementary and a test asserts they stay that way.
+ */
+export const PAYLOAD_CARRYING_STEP_TYPES: Array<RunbookStepType> = [
+  RunbookStepType.SSH,
+  RunbookStepType.Kubernetes,
+];
+
+export function isPayloadCarryingStepType(type: RunbookStepType): boolean {
+  return PAYLOAD_CARRYING_STEP_TYPES.includes(type);
+}

--- a/Runner/Tests/Services/RunbookExecutorSshRouting.test.ts
+++ b/Runner/Tests/Services/RunbookExecutorSshRouting.test.ts
@@ -1,0 +1,345 @@
+/*
+ * ---------------------------------------------------------------------------
+ * The Runner's half of the SSH step (issue #3209).
+ *
+ * The bug that broke SSH lived on the server — RunnerJob.script was a required
+ * column, so a job whose script is empty by design could never be created. But
+ * the shape that made it empty is the Runner's contract too: an SSH job is an
+ * empty script plus a payload plus a credential resolved at claim time, and
+ * the Runner routes on stepType, NOT on whether a script is present. If that
+ * routing ever fell back to "no script, nothing to do", SSH steps would report
+ * success without touching the host — a worse failure than the one reported,
+ * because it is silent.
+ *
+ * So these tests pin the routing seam: which executor a claimed job reaches,
+ * with which arguments, and what happens when a piece is missing. runJob is
+ * not exported, so every case drives Executor.executeAndReport — the real
+ * exported surface — with the collaborators module-mocked. bash is mocked too,
+ * so "an SSH job never spawns a local shell" is assertable directly rather
+ * than inferred from a result.
+ * ---------------------------------------------------------------------------
+ */
+
+import type { EventEmitter as NodeEventEmitter } from "events";
+
+jest.mock("../../Services/RunnerClient", () => {
+  return {
+    __esModule: true,
+    default: {
+      submitJobResult: jest.fn().mockResolvedValue(true),
+      jobHeartbeat: jest.fn().mockResolvedValue(true),
+    },
+  };
+});
+
+jest.mock("../../Services/SSHExecutor", () => {
+  return {
+    __esModule: true,
+    default: { execute: jest.fn() },
+  };
+});
+
+jest.mock("../../Services/KubernetesExecutor", () => {
+  return {
+    __esModule: true,
+    default: { execute: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Utils/VM/VMAPI", () => {
+  return {
+    __esModule: true,
+    default: { runCodeInSandbox: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+  };
+});
+
+jest.mock("child_process", () => {
+  /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+  const { EventEmitter } = require("events");
+  /* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+
+  const calls: Array<Record<string, unknown>> = [];
+
+  class MockChildProcess extends EventEmitter {
+    public stdout: NodeEventEmitter = new EventEmitter();
+    public stderr: NodeEventEmitter = new EventEmitter();
+  }
+
+  function spawnMock(
+    command: string,
+    args: Array<string>,
+    options: Record<string, unknown>,
+  ): MockChildProcess {
+    calls.push({ command, args, options });
+    const child: MockChildProcess = new MockChildProcess();
+    setImmediate(() => {
+      child.stdout.emit("data", Buffer.from("mock stdout"));
+      (child as unknown as NodeEventEmitter).emit("close", 0, null);
+    });
+    return child;
+  }
+  spawnMock.__calls = calls;
+  spawnMock.__reset = (): void => {
+    calls.length = 0;
+  };
+
+  return { spawn: spawnMock };
+});
+
+// Imported after the jest.mock calls above, which jest hoists.
+import Executor from "../../Services/RunbookExecutor";
+import AgentClient, { ClaimedJob } from "../../Services/RunnerClient";
+import SSHExecutor from "../../Services/SSHExecutor";
+import KubernetesExecutor from "../../Services/KubernetesExecutor";
+import { JSONObject } from "Common/Types/JSON";
+import { spawn } from "child_process";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+const spawnMock: {
+  __calls: Array<Record<string, unknown>>;
+  __reset: () => void;
+} = spawn as unknown as {
+  __calls: Array<Record<string, unknown>>;
+  __reset: () => void;
+};
+
+const submitJobResult: jest.Mock =
+  AgentClient.submitJobResult as unknown as jest.Mock;
+const sshExecute: jest.Mock = SSHExecutor.execute as unknown as jest.Mock;
+const kubernetesExecute: jest.Mock =
+  KubernetesExecutor.execute as unknown as jest.Mock;
+
+const SSH_PAYLOAD: JSONObject = {
+  credentialId: "55555555-5555-4555-8555-555555555555",
+  command: "systemctl restart nginx",
+};
+
+/*
+ * What the claim endpoint hands back for an SSH job: hostname, user and key
+ * material resolved server-side, scoped to this Runner. Never read from the
+ * job row.
+ */
+const SSH_CREDENTIAL: JSONObject = {
+  credentialType: "SSH",
+  hostname: "db-primary.internal",
+  port: 22,
+  username: "deploy",
+  privateKey: "-----BEGIN OPENSSH PRIVATE KEY-----\nnot-a-real-key\n",
+};
+
+/*
+ * The exact wire shape of a claimed SSH job — an empty script, because the
+ * instruction is in the payload. This is the shape #3209 made impossible to
+ * create; the Runner has to handle it as the normal case, not an edge one.
+ */
+function sshJob(overrides: Partial<ClaimedJob> = {}): ClaimedJob {
+  return {
+    jobId: "job-ssh-1",
+    stepId: "step-1",
+    origin: "Runbook",
+    stepType: "SSH",
+    script: "",
+    payload: SSH_PAYLOAD,
+    credential: SSH_CREDENTIAL,
+    timeoutInMs: 30_000,
+    ...overrides,
+  } as ClaimedJob;
+}
+
+function submittedResult(): Record<string, unknown> {
+  expect(submitJobResult).toHaveBeenCalledTimes(1);
+  return submitJobResult.mock.calls[0]![0] as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  spawnMock.__reset();
+  submitJobResult.mockClear();
+  submitJobResult.mockResolvedValue(true);
+  sshExecute.mockClear();
+  sshExecute.mockResolvedValue({
+    success: true,
+    output: "nginx restarted",
+    exitCode: 0,
+  });
+  kubernetesExecute.mockClear();
+  kubernetesExecute.mockResolvedValue({ success: true, output: "restarted" });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("a claimed SSH job reaches SSHExecutor", () => {
+  test("an empty script is routed on stepType, not treated as nothing to do", async () => {
+    await Executor.executeAndReport(sshJob());
+
+    expect(sshExecute).toHaveBeenCalledTimes(1);
+    // The step acts on a remote host: no local shell is involved at any point.
+    expect(spawnMock.__calls).toHaveLength(0);
+  });
+
+  test("the payload and the claim-time credential are forwarded verbatim", async () => {
+    await Executor.executeAndReport(sshJob());
+
+    const args: Record<string, unknown> = sshExecute.mock
+      .calls[0]![0] as Record<string, unknown>;
+
+    expect(args["payload"]).toEqual(SSH_PAYLOAD);
+    expect(args["credential"]).toEqual(SSH_CREDENTIAL);
+    expect(args["timeoutInMs"]).toBe(30_000);
+  });
+
+  test("a successful run is reported back with its output", async () => {
+    await Executor.executeAndReport(sshJob());
+
+    const result: Record<string, unknown> = submittedResult();
+
+    expect(result["jobId"]).toBe("job-ssh-1");
+    expect(result["success"]).toBe(true);
+    expect(result["output"]).toBe("nginx restarted");
+    expect(result["exitCode"]).toBe(0);
+  });
+
+  test("a failed run reports the executor's error rather than swallowing it", async () => {
+    sshExecute.mockResolvedValue({
+      success: false,
+      output: "Permission denied (publickey).",
+      exitCode: 255,
+      errorMessage: "All configured authentication methods failed",
+    });
+
+    await Executor.executeAndReport(sshJob());
+
+    const result: Record<string, unknown> = submittedResult();
+
+    expect(result["success"]).toBe(false);
+    expect(result["errorMessage"]).toBe(
+      "All configured authentication methods failed",
+    );
+    expect(result["output"]).toBe("Permission denied (publickey).");
+    expect(result["exitCode"]).toBe(255);
+  });
+
+  test("a throwing executor still lands a failed result instead of stranding the job", async () => {
+    /*
+     * The job holds a lease. An unreported crash leaves the step waiting for
+     * the lease to lapse and then reporting a timeout, which reads as "the
+     * Runner went away" rather than "the SSH library threw".
+     */
+    sshExecute.mockRejectedValue(new Error("ssh2 exploded"));
+
+    await Executor.executeAndReport(sshJob());
+
+    const result: Record<string, unknown> = submittedResult();
+
+    expect(result["success"]).toBe(false);
+    expect(result["errorMessage"]).toContain("ssh2 exploded");
+  });
+});
+
+describe("an SSH job that arrives incomplete is refused, not attempted", () => {
+  test("no credential — the server declined to hand one over", async () => {
+    /*
+     * A refusal, not a retry: the claim path fails the job itself when a
+     * credential is unavailable, so a job that reaches here without one is a
+     * server-side decision the Runner must not work around.
+     */
+    await Executor.executeAndReport(
+      sshJob({ credential: undefined as unknown as JSONObject }),
+    );
+
+    expect(sshExecute).not.toHaveBeenCalled();
+
+    const result: Record<string, unknown> = submittedResult();
+    expect(result["success"]).toBe(false);
+    expect(String(result["errorMessage"])).toContain("credential");
+  });
+
+  test("no payload — the instruction never arrived", async () => {
+    await Executor.executeAndReport(
+      sshJob({ payload: undefined as unknown as JSONObject }),
+    );
+
+    expect(sshExecute).not.toHaveBeenCalled();
+
+    const result: Record<string, unknown> = submittedResult();
+    expect(result["success"]).toBe(false);
+    expect(String(result["errorMessage"])).toContain("instructions");
+  });
+
+  test("neither payload nor credential names the instructions first", async () => {
+    await Executor.executeAndReport(
+      sshJob({
+        payload: undefined as unknown as JSONObject,
+        credential: undefined as unknown as JSONObject,
+      }),
+    );
+
+    expect(sshExecute).not.toHaveBeenCalled();
+    expect(String(submittedResult()["errorMessage"])).toContain("instructions");
+  });
+});
+
+describe("the other lanes still route where they belong", () => {
+  test("a Kubernetes job — same empty-script shape — reaches KubernetesExecutor", async () => {
+    await Executor.executeAndReport(
+      sshJob({
+        jobId: "job-k8s-1",
+        stepType: "Kubernetes",
+        payload: {
+          credentialId: SSH_PAYLOAD["credentialId"] as string,
+          action: "RestartWorkload",
+          workloadKind: "Deployment",
+          namespace: "production",
+          workloadName: "api",
+        },
+        credential: { credentialType: "Kubernetes", token: "not-a-real-token" },
+      }),
+    );
+
+    expect(kubernetesExecute).toHaveBeenCalledTimes(1);
+    expect(sshExecute).not.toHaveBeenCalled();
+    expect(spawnMock.__calls).toHaveLength(0);
+  });
+
+  test("a Bash job runs locally and never reaches the SSH executor", async () => {
+    await Executor.executeAndReport(
+      sshJob({
+        jobId: "job-bash-1",
+        stepType: "Bash",
+        script: "uptime",
+        payload: undefined as unknown as JSONObject,
+        credential: undefined as unknown as JSONObject,
+      }),
+    );
+
+    expect(sshExecute).not.toHaveBeenCalled();
+    expect(spawnMock.__calls).toHaveLength(1);
+    expect(spawnMock.__calls[0]!["command"]).toBe("bash");
+  });
+
+  test("an unknown step type is refused rather than guessed at", async () => {
+    await Executor.executeAndReport(
+      sshJob({ stepType: "Telnet" as ClaimedJob["stepType"] }),
+    );
+
+    expect(sshExecute).not.toHaveBeenCalled();
+    expect(kubernetesExecute).not.toHaveBeenCalled();
+    expect(spawnMock.__calls).toHaveLength(0);
+    expect(String(submittedResult()["errorMessage"])).toContain(
+      "Unsupported step type",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #3209.

## The bug

`RunnerJob.script` was declared `required: true`. `DatabaseService.checkRequiredFields` rejects any **falsy** value on a required column, and `""` is falsy — so SSH and Kubernetes jobs, which carry their instruction in `payload` and an empty script *by design*, died at `create()` with `script is required` before a Runner ever saw them:

```
BadDataException [Error]: script is required
    at Service.checkRequiredFields (Common/Server/Services/DatabaseService.ts:263)
    at Service.create (Common/Server/Services/DatabaseService.ts:998)
    at dispatchToAgent (App/FeatureSet/Runbook/Services/StepExecutors.ts:167)
```

Both step types were unusable. So was the AI remediation lane's SSH command path (`enqueueAiCommand`), which writes the same layout — an approved remediation plan would have failed at the last step, after a human approved it.

## The fix

- `script` is no longer a required column. The database keeps its `NOT NULL` constraint and `enqueue` always writes a string, so nothing is relaxed at the storage layer and **no migration is needed** — `@Column` is untouched.
- The rule the flag was accidentally standing in for is per-type and cannot be expressed as column metadata, so it moves to `RunnerJobService.enqueue`: a script-carrying type must bring a script, a payload-carrying type must bring a payload. Which types those are is named once, in `RunbookStepType`.

## Why nothing caught it

Every existing runbook test stubs `RunnerJobService.enqueue`, so the model's own validation was never exercised — the step executors were correct, the payloads were correct, and ~30 green tests said SSH worked.

The new tests stub one layer **lower**, at `create`, and run the *real* validator on the row that comes out:

- `Common/Tests/Server/Services/RunnerJobEnqueue.test.ts` — the column declaration itself (`script` must not be required; the columns that genuinely cannot be empty still are), plus the new per-type invariants.
- `App/Tests/Runbook/RunnerJobPersistence.test.ts` — the reported failure end-to-end, across every runner-executed step type and both AI-command lanes. Reverting the one-line model change makes 5 of these fail with the exact reported message.
- `Runner/Tests/Services/RunbookExecutorSshRouting.test.ts` — the Runner must route on `stepType`, never on whether a script is present. A regression there would report success without touching the host, which is worse than the reported failure because it is silent.
- `Common/Tests/Types/Runbook/RunbookStepType.test.ts` — the script/payload split is total and disjoint within the Runner lane.

## Verification

- 55 new/extended tests in Common, 11 in App, 11 in Runner — all passing.
- Full `App/Tests/Runbook` (364 tests), `Runner/Tests/Services` (97), Common runbook suites (218) pass.
- `tsc --noEmit` clean in Common and Runner; eslint clean.