### PR TITLE
fix(dashboard): draw the series on SLO chart widgets

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardSloComponent.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardSloComponent.tsx
@@ -404,7 +404,7 @@ const DashboardSloComponentElement: FunctionComponent<ComponentProps> = (
         : undefined;
 
     const xAxis: ChartXAxis = {
-      legend: "",
+      legend: "Time",
       options: {
         type: XAxisType.Time,
         min: startAndEndDate.startValue,

--- a/Common/Tests/App/Dashboard/SloWidgetChartRendering.test.tsx
+++ b/Common/Tests/App/Dashboard/SloWidgetChartRendering.test.tsx
@@ -1,0 +1,536 @@
+/**
+ * @timezone UTC
+ */
+import "@testing-library/jest-dom";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import {
+  RenderResult,
+  cleanup,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import * as React from "react";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+
+/*
+ * The SLO widget's Chart display renders a real recharts line — and it is
+ * exactly there that it broke. Every sibling suite stubs LineChart out and
+ * asserts on the props handed down, which is why the bug survived: the props
+ * were right, the REQUEST was right, the data was right, and recharts still
+ * drew nothing, because the widget labelled its x-axis "" and the chart rows
+ * were keyed off that label while recharts was told to read "Time".
+ *
+ * So this suite deliberately renders the real chart and asserts on the SVG
+ * the viewer actually gets. It covers both surfaces the widget runs on: the
+ * anonymous public dashboard (where the bug was reported) and the
+ * authenticated one (where it was equally broken, just unnoticed).
+ *
+ * Pinned to UTC: the x-axis bucket labels are produced by local-time
+ * formatters.
+ */
+
+const getItemMock: MockFunction = getJestMockFunction();
+const getListMock: MockFunction = getJestMockFunction();
+const aggregateMock: MockFunction = getJestMockFunction();
+const getCurrentProjectIdMock: MockFunction = getJestMockFunction();
+
+/*
+ * The arrow wrappers are load bearing: jest.mock is hoisted above the compiled
+ * requires, so the mock variables above are still unassigned when the factory
+ * runs. Dereferencing them lazily, at call time, is what makes this work.
+ */
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getItem: (...args: Array<any>) => {
+        return getItemMock(...args);
+      },
+      getList: (...args: Array<any>) => {
+        return getListMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/AnalyticsModelAPI/AnalyticsModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      aggregate: (...args: Array<any>) => {
+        return aggregateMock(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/Project", () => {
+  return {
+    __esModule: true,
+    default: {
+      getCurrentProjectId: (...args: Array<any>) => {
+        return getCurrentProjectIdMock(...args);
+      },
+    },
+  };
+});
+
+/*
+ * The ONLY thing stubbed in the chart stack. ResponsiveContainer measures its
+ * parent, which is always 0x0 in jsdom, and a 0x0 recharts chart draws no
+ * marks — which would make every assertion below pass for the wrong reason.
+ */
+jest.mock("recharts", () => {
+  const actual: Record<string, any> = jest.requireActual("recharts") as Record<
+    string,
+    any
+  >;
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => {
+      return React.cloneElement(children, { width: 600, height: 300 });
+    },
+  };
+});
+
+import DashboardSloComponentElement from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardSloComponent";
+import { DashboardBaseComponentProps } from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Components/DashboardBaseComponent";
+import {
+  PublicDashboardContext,
+  setPublicDashboardContext,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/Dashboard/Utils/PublicDashboardContext";
+import ServiceLevelObjective from "../../../Models/DatabaseModels/ServiceLevelObjective";
+import HTTPResponse from "../../../Types/API/HTTPResponse";
+import AggregatedResult from "../../../Types/BaseDatabase/AggregatedResult";
+import InBetween from "../../../Types/BaseDatabase/InBetween";
+import DashboardComponentType from "../../../Types/Dashboard/DashboardComponentType";
+import DashboardSloComponent, {
+  SloWidgetDisplayType,
+  SloWidgetMetric,
+} from "../../../Types/Dashboard/DashboardComponents/DashboardSloComponent";
+import DashboardViewConfig from "../../../Types/Dashboard/DashboardViewConfig";
+import { JSONObject, ObjectType } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import SloStatus from "../../../Types/ServiceLevelObjective/SloStatus";
+import RangeStartAndEndDateTime from "../../../Types/Time/RangeStartAndEndDateTime";
+import TimeRange from "../../../Types/Time/TimeRange";
+
+const COMPONENT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const DASHBOARD_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const SLO_ID: ObjectID = new ObjectID("33333333-3333-4333-8333-333333333333");
+const PROJECT_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+
+/*
+ * A CUSTOM range pins the window to fixed instants; a relative range would
+ * resolve against the wall clock. Six hours buckets at five minutes, which
+ * is the cadence the evaluation worker writes at.
+ */
+const START_DATE: Date = new Date("2026-08-10T00:00:00.000Z");
+const END_DATE: Date = new Date("2026-08-10T06:00:00.000Z");
+
+const DASHBOARD_RANGE: RangeStartAndEndDateTime = {
+  range: TimeRange.CUSTOM,
+  startAndEndDate: new InBetween<Date>(START_DATE, END_DATE),
+};
+
+const DASHBOARD_VIEW_CONFIG: DashboardViewConfig = {
+  _type: ObjectType.DashboardViewConfig,
+  components: [],
+  heightInDashboardUnits: 60,
+};
+
+/** SVG the viewer sees only when recharts actually plotted the series. */
+const LINE_SELECTOR: string = "path.recharts-line-curve";
+
+let publicResponse: JSONObject = { data: [] };
+
+const PUBLIC_DASHBOARD_CONTEXT: PublicDashboardContext = {
+  dashboardId: DASHBOARD_ID,
+  apiUrl: {
+    toString: (): string => {
+      return "http://localhost/public-dashboard-api";
+    },
+  },
+  postJSON: () => {
+    return Promise.resolve({
+      data: publicResponse,
+    } as unknown as HTTPResponse<JSONObject>);
+  },
+} as unknown as PublicDashboardContext;
+
+/** One row every five minutes across the window, oldest first. */
+type BuildHistoryFunction = (data?: {
+  rowCount?: number | undefined;
+  valueAt?: ((index: number) => number | string) | undefined;
+}) => Array<JSONObject>;
+
+const buildHistory: BuildHistoryFunction = (
+  data: {
+    rowCount?: number | undefined;
+    valueAt?: ((index: number) => number | string) | undefined;
+  } = {},
+): Array<JSONObject> => {
+  const rowCount: number = data.rowCount ?? 12;
+  const rows: Array<JSONObject> = [];
+
+  for (let index: number = 0; index < rowCount; index++) {
+    rows.push({
+      timestamp: new Date(
+        START_DATE.getTime() + index * 5 * 60 * 1000,
+      ).toISOString(),
+      value: data.valueAt ? data.valueAt(index) : 99.9 - index * 0.01,
+    });
+  }
+
+  return rows;
+};
+
+type BuildSloFunction = (
+  overrides?: Partial<ServiceLevelObjective>,
+) => ServiceLevelObjective;
+
+const buildSlo: BuildSloFunction = (
+  overrides: Partial<ServiceLevelObjective> = {},
+): ServiceLevelObjective => {
+  const slo: ServiceLevelObjective = new ServiceLevelObjective();
+  slo.name = "Checkout availability";
+  slo.targetPercentage = 99.9;
+  slo.currentSliPercentage = 99.95;
+  slo.errorBudgetRemainingPercentage = 42.5;
+  slo.errorBudgetRemainingSeconds = 3600;
+  slo.currentBurnRate = 1.25;
+  slo.sloStatus = SloStatus.Healthy;
+  return Object.assign(slo, overrides);
+};
+
+type BuildPropsFunction = (
+  overrides?: Partial<DashboardBaseComponentProps>,
+) => DashboardBaseComponentProps;
+
+const buildBaseProps: BuildPropsFunction = (
+  overrides: Partial<DashboardBaseComponentProps> = {},
+): DashboardBaseComponentProps => {
+  return {
+    componentId: COMPONENT_ID,
+    isEditMode: false,
+    isSelected: false,
+    key: "slo-widget",
+    onComponentUpdate: (): void => {
+      // The widget never writes back through this.
+    },
+    totalCurrentDashboardWidthInPx: 1200,
+    dashboardCanvasTopInPx: 0,
+    dashboardCanvasLeftInPx: 0,
+    dashboardCanvasWidthInPx: 1200,
+    dashboardCanvasHeightInPx: 800,
+    dashboardComponentHeightInPx: 320,
+    dashboardComponentWidthInPx: 480,
+    dashboardViewConfig: DASHBOARD_VIEW_CONFIG,
+    dashboardStartAndEndDate: DASHBOARD_RANGE,
+    metricTypes: [],
+    refreshTick: 0,
+    variables: undefined,
+    ...overrides,
+  } as unknown as DashboardBaseComponentProps;
+};
+
+type RenderWidgetFunction = (
+  args: DashboardSloComponent["arguments"],
+  propOverrides?: Partial<DashboardBaseComponentProps>,
+) => RenderResult;
+
+const renderWidget: RenderWidgetFunction = (
+  args: DashboardSloComponent["arguments"],
+  propOverrides: Partial<DashboardBaseComponentProps> = {},
+): RenderResult => {
+  const component: DashboardSloComponent = {
+    _type: ObjectType.DashboardComponent,
+    componentId: COMPONENT_ID,
+    componentType: DashboardComponentType.Slo,
+    topInDashboardUnits: 0,
+    leftInDashboardUnits: 0,
+    widthInDashboardUnits: 3,
+    heightInDashboardUnits: 3,
+    minWidthInDashboardUnits: 2,
+    minHeightInDashboardUnits: 2,
+    arguments: args,
+  } as unknown as DashboardSloComponent;
+
+  return render(
+    <DashboardSloComponentElement
+      {...buildBaseProps(propOverrides)}
+      component={component}
+    />,
+  );
+};
+
+/*
+ * Settle in two stages.
+ *
+ * First the chart FRAME, which appears as soon as the widget's fetch resolves
+ * and it switches to its Chart branch. Under the bug the frame — surface,
+ * axes, grid, tooltip — rendered perfectly and only the series was missing,
+ * so reaching this point proves the failure below is about the LINE and not
+ * about a request that never came back.
+ *
+ * Then the series itself, on a short leash: the chart fills its rows in an
+ * effect one tick after mounting, so it is never there on the first paint,
+ * and a regression should fail in a second rather than sitting out the
+ * default five.
+ */
+const LINE_TIMEOUT_IN_MS: number = 1500;
+
+type FindLinePathsFunction = (
+  container: HTMLElement,
+) => Promise<Array<Element>>;
+
+const findLinePaths: FindLinePathsFunction = async (
+  container: HTMLElement,
+): Promise<Array<Element>> => {
+  await waitFor((): void => {
+    expect(container.querySelector("svg.recharts-surface")).not.toBeNull();
+  });
+
+  await waitFor(
+    (): void => {
+      expect(container.querySelector(LINE_SELECTOR)).not.toBeNull();
+    },
+    { timeout: LINE_TIMEOUT_IN_MS },
+  );
+
+  return Array.from(container.querySelectorAll(LINE_SELECTOR));
+};
+
+/*
+ * recharts emits the curve more than once per series (the drawn stroke plus
+ * its hit-target twin), so assert on the GEOMETRY they all share rather than
+ * on how many nodes carry it.
+ */
+type ExpectPlottedFunction = (paths: Array<Element>) => string;
+
+const expectPlotted: ExpectPlottedFunction = (
+  paths: Array<Element>,
+): string => {
+  expect(paths.length).toBeGreaterThan(0);
+
+  const geometries: Array<string> = paths.map((path: Element): string => {
+    return path.getAttribute("d") || "";
+  });
+
+  for (const geometry of geometries) {
+    /*
+     * The reported bug produced a chart frame with NO curve at all; a curve
+     * present but empty (or full of NaN) would be the same blank widget, so
+     * pin the path data itself.
+     */
+    expect(geometry.length).toBeGreaterThan(0);
+    expect(geometry.startsWith("M")).toBe(true);
+    expect(geometry).not.toContain("NaN");
+  }
+
+  // Every copy is the same series, so they must agree.
+  expect(new Set(geometries).size).toBe(1);
+
+  return geometries[0]!;
+};
+
+beforeEach((): void => {
+  jest.clearAllMocks();
+  publicResponse = { data: buildHistory() };
+  getCurrentProjectIdMock.mockReturnValue(PROJECT_ID);
+  getItemMock.mockResolvedValue(buildSlo());
+  getListMock.mockResolvedValue({
+    data: [buildSlo()],
+    count: 1,
+    skip: 0,
+    limit: 1,
+  });
+  aggregateMock.mockResolvedValue({
+    data: buildHistory(),
+  } as unknown as AggregatedResult);
+});
+
+afterEach((): void => {
+  cleanup();
+  setPublicDashboardContext(null);
+});
+
+describe("SLO chart widget on a public dashboard", () => {
+  beforeEach((): void => {
+    setPublicDashboardContext(PUBLIC_DASHBOARD_CONTEXT);
+    // A public dashboard has no session, so no current project.
+    getCurrentProjectIdMock.mockReturnValue(null);
+  });
+
+  test("plots a line an anonymous viewer can actually see", async () => {
+    const { container }: RenderResult = renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      sloMetric: SloWidgetMetric.Sli,
+      displayType: SloWidgetDisplayType.Chart,
+    });
+
+    const geometry: string = expectPlotted(await findLinePaths(container));
+
+    /*
+     * A drawn line visits every history row, so it carries one curve command
+     * per plotted point rather than a single degenerate move-to.
+     */
+    expect(geometry.split("C").length).toBeGreaterThan(1);
+  });
+
+  test.each([
+    [SloWidgetMetric.Sli],
+    [SloWidgetMetric.ErrorBudgetRemaining],
+    [SloWidgetMetric.BurnRate],
+  ])("plots %s", async (sloMetric: SloWidgetMetric) => {
+    publicResponse = {
+      data: buildHistory({
+        valueAt: (index: number): number => {
+          return sloMetric === SloWidgetMetric.BurnRate
+            ? 1 + index * 0.1
+            : 99 - index * 0.1;
+        },
+      }),
+    };
+
+    const { container }: RenderResult = renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      sloMetric: sloMetric,
+      displayType: SloWidgetDisplayType.Chart,
+    });
+
+    expectPlotted(await findLinePaths(container));
+  });
+
+  test("draws the SLO's target as a reference line on the SLI chart", async () => {
+    const { container }: RenderResult = renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      sloMetric: SloWidgetMetric.Sli,
+      displayType: SloWidgetDisplayType.Chart,
+    });
+
+    await findLinePaths(container);
+
+    expect(
+      container.querySelectorAll("line.recharts-reference-line-line").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("Target 99.9%")).toBeInTheDocument();
+  });
+
+  test("plots decimal strings, which is how ClickHouse returns the value", async () => {
+    publicResponse = {
+      data: buildHistory({
+        valueAt: (index: number): string => {
+          return `${99.9 - index * 0.05}`;
+        },
+      }),
+    };
+
+    const { container }: RenderResult = renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      displayType: SloWidgetDisplayType.Chart,
+    });
+
+    expectPlotted(await findLinePaths(container));
+  });
+
+  test("shows the empty-history state instead of a blank chart frame", async () => {
+    publicResponse = { data: [] };
+
+    const { container }: RenderResult = renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      displayType: SloWidgetDisplayType.Chart,
+    });
+
+    expect(
+      await screen.findByText(/No history for the selected/i),
+    ).toBeInTheDocument();
+    expect(container.querySelectorAll(LINE_SELECTOR).length).toBe(0);
+  });
+
+  test("keeps the tile display working alongside the chart fix", async () => {
+    const { container }: RenderResult = renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      sloMetric: SloWidgetMetric.Sli,
+      displayType: SloWidgetDisplayType.Tile,
+    });
+
+    expect(await screen.findByText("99.95%")).toBeInTheDocument();
+    expect(screen.getByText("target 99.9%")).toBeInTheDocument();
+    // A Tile never asks for history, so it never draws a series.
+    expect(container.querySelectorAll(LINE_SELECTOR).length).toBe(0);
+  });
+
+  test("still plots when the widget tile is small enough to clamp its height", async () => {
+    const { container }: RenderResult = renderWidget(
+      {
+        serviceLevelObjectiveId: SLO_ID.toString(),
+        displayType: SloWidgetDisplayType.Chart,
+      },
+      { dashboardComponentHeightInPx: 100, dashboardComponentWidthInPx: 140 },
+    );
+
+    expectPlotted(await findLinePaths(container));
+  });
+});
+
+describe("SLO chart widget on an authenticated dashboard", () => {
+  test("plots a line through the private analytics route too", async () => {
+    const { container }: RenderResult = renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      sloMetric: SloWidgetMetric.Sli,
+      displayType: SloWidgetDisplayType.Chart,
+    });
+
+    expectPlotted(await findLinePaths(container));
+
+    expect(aggregateMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders the same geometry as the public dashboard for the same series", async () => {
+    const authenticated: RenderResult = renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      sloMetric: SloWidgetMetric.Sli,
+      displayType: SloWidgetDisplayType.Chart,
+    });
+
+    const authenticatedGeometry: string = expectPlotted(
+      await findLinePaths(authenticated.container),
+    );
+
+    cleanup();
+
+    setPublicDashboardContext(PUBLIC_DASHBOARD_CONTEXT);
+    getCurrentProjectIdMock.mockReturnValue(null);
+
+    const anonymous: RenderResult = renderWidget({
+      serviceLevelObjectiveId: SLO_ID.toString(),
+      sloMetric: SloWidgetMetric.Sli,
+      displayType: SloWidgetDisplayType.Chart,
+    });
+
+    const anonymousGeometry: string = expectPlotted(
+      await findLinePaths(anonymous.container),
+    );
+
+    /*
+     * Same SLO, same window, same rows — the two surfaces differ only in
+     * which endpoint served them, so the drawn line must be identical.
+     */
+    expect(anonymousGeometry).toBe(authenticatedGeometry);
+  });
+});

--- a/Common/Tests/UI/Components/Charts/ChartXAxisDataKey.test.tsx
+++ b/Common/Tests/UI/Components/Charts/ChartXAxisDataKey.test.tsx
@@ -1,0 +1,256 @@
+import "@testing-library/jest-dom";
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * ResponsiveContainer measures its parent, which is always 0x0 in jsdom, so
+ * the chart renders nothing without a fixed size. Same shim as
+ * AxisTickColor.test.tsx — anything that asserts on rendered GEOMETRY needs
+ * it, because a 0x0 chart draws no marks either and would make every one of
+ * these assertions pass for the wrong reason.
+ */
+jest.mock("recharts", () => {
+  const actual: Record<string, any> = jest.requireActual("recharts");
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) => {
+      return React.cloneElement(children, { width: 600, height: 300 });
+    },
+  };
+});
+
+import AreaChartElement from "../../../../UI/Components/Charts/Area/AreaChart";
+import BarChartElement from "../../../../UI/Components/Charts/Bar/BarChart";
+import LineChartElement from "../../../../UI/Components/Charts/Line/LineChart";
+import { CHART_DATA_POINT_X_AXIS_KEY } from "../../../../UI/Components/Charts/ChartLibrary/Types/ChartDataPoint";
+import ChartCurve from "../../../../UI/Components/Charts/Types/ChartCurve";
+import DataPoint from "../../../../UI/Components/Charts/Types/DataPoint";
+import SeriesPoint from "../../../../UI/Components/Charts/Types/SeriesPoints";
+import {
+  XAxis as ChartXAxis,
+  XAxisAggregateType,
+} from "../../../../UI/Components/Charts/Types/XAxis/XAxis";
+import XAxisType from "../../../../UI/Components/Charts/Types/XAxis/XAxisType";
+import YAxis, {
+  YAxisPrecision,
+} from "../../../../UI/Components/Charts/Types/YAxis/YAxis";
+import YAxisType from "../../../../UI/Components/Charts/Types/YAxis/YAxisType";
+
+/*
+ * The three chart wrappers hand recharts a FIXED x-axis dataKey, while the
+ * rows they hand it are built by DataPointUtil. Those two used to agree only
+ * by convention: the util keyed each row by the caller's `xAxis.legend`, and
+ * every caller but one happened to pass the literal "Time".
+ *
+ * The one that did not — the SLO dashboard widget, which passed "" — got a
+ * chart with axes, grid and tooltip but no line: recharts looked up "Time" on
+ * every row, found nothing, and drew no path. Nothing failed, nothing logged;
+ * the widget just rendered an empty frame on public and private dashboards
+ * alike.
+ *
+ * These tests hold the axis key on both sides of that seam: whatever legend a
+ * caller passes, the marks get drawn.
+ */
+
+const START: Date = new Date("2026-08-10T00:00:00.000Z");
+const END: Date = new Date("2026-08-10T01:00:00.000Z");
+
+/* An hour window buckets at one minute, so these land on distinct buckets. */
+type BuildPointsFunction = () => Array<DataPoint>;
+
+const buildPoints: BuildPointsFunction = (): Array<DataPoint> => {
+  const points: Array<DataPoint> = [];
+
+  for (let index: number = 0; index < 10; index++) {
+    points.push({
+      x: new Date(START.getTime() + index * 60 * 1000),
+      y: 90 + index,
+    });
+  }
+
+  return points;
+};
+
+type BuildXAxisFunction = (legend: string) => ChartXAxis;
+
+const buildXAxis: BuildXAxisFunction = (legend: string): ChartXAxis => {
+  return {
+    legend: legend,
+    options: {
+      type: XAxisType.Time,
+      min: START,
+      max: END,
+      aggregateType: XAxisAggregateType.Average,
+    },
+  };
+};
+
+const Y_AXIS: YAxis = {
+  legend: "%",
+  options: {
+    type: YAxisType.Number,
+    min: "auto",
+    max: 100,
+    precision: YAxisPrecision.TwoDecimals,
+    formatter: (value: number): string => {
+      return `${value}%`;
+    },
+  },
+};
+
+const SERIES_NAME: string = "SLI";
+
+type BuildSeriesFunction = () => Array<SeriesPoint>;
+
+const buildSeries: BuildSeriesFunction = (): Array<SeriesPoint> => {
+  return [{ seriesName: SERIES_NAME, data: buildPoints() }];
+};
+
+/*
+ * Legends worth covering: the canonical one every other caller passes, the
+ * empty string the SLO widget passed (the reported bug), and an arbitrary
+ * label, which is what a future caller is most likely to reach for.
+ */
+const LEGENDS: Array<[string, string]> = [
+  ['the canonical "Time"', "Time"],
+  ["an empty legend", ""],
+  ["an arbitrary legend", "Timestamp"],
+  ["a legend with markup-ish characters", "Time (UTC) <>"],
+];
+
+interface ChartUnderTest {
+  name: string;
+  /** CSS selector for the SVG geometry this chart type draws per series. */
+  markSelector: string;
+  render: (xAxis: ChartXAxis) => React.ReactElement;
+}
+
+const CHARTS: Array<ChartUnderTest> = [
+  {
+    name: "LineChart",
+    markSelector: "path.recharts-line-curve",
+    render: (xAxis: ChartXAxis): React.ReactElement => {
+      return (
+        <LineChartElement
+          data={buildSeries()}
+          xAxis={xAxis}
+          yAxis={Y_AXIS}
+          curve={ChartCurve.MONOTONE}
+          heightInPx={300}
+          showLegend={false}
+          sync={false}
+          syncid="x-axis-key-test"
+        />
+      );
+    },
+  },
+  {
+    name: "AreaChart",
+    markSelector: "path.recharts-area-area",
+    render: (xAxis: ChartXAxis): React.ReactElement => {
+      return (
+        <AreaChartElement
+          data={buildSeries()}
+          xAxis={xAxis}
+          yAxis={Y_AXIS}
+          curve={ChartCurve.MONOTONE}
+          heightInPx={300}
+          showLegend={false}
+          sync={false}
+          syncid="x-axis-key-test"
+        />
+      );
+    },
+  },
+  {
+    /*
+     * Bars are drawn through a custom `shape` renderer, so the mark is a bare
+     * <path> under recharts' own rectangle group rather than a classed one.
+     */
+    name: "BarChart",
+    markSelector: "g.recharts-bar-rectangle path",
+    render: (xAxis: ChartXAxis): React.ReactElement => {
+      return (
+        <BarChartElement
+          data={buildSeries()}
+          xAxis={xAxis}
+          yAxis={Y_AXIS}
+          heightInPx={300}
+          showLegend={false}
+          sync={false}
+          syncid="x-axis-key-test"
+        />
+      );
+    },
+  },
+];
+
+afterEach((): void => {
+  cleanup();
+});
+
+describe("Chart x-axis data key", () => {
+  test("the canonical key is the literal recharts reads", (): void => {
+    /*
+     * Pinned, not derived. The wrappers and DataPointUtil both import this
+     * constant, so a rename would keep them agreeing with each other while
+     * silently changing the shape handed to recharts.
+     */
+    expect(CHART_DATA_POINT_X_AXIS_KEY).toBe("Time");
+  });
+
+  for (const chart of CHARTS) {
+    describe(chart.name, () => {
+      test.each(LEGENDS)(
+        `draws its series with %s`,
+        (_label: string, legend: string): void => {
+          const { container } = render(chart.render(buildXAxis(legend)));
+
+          const marks: Array<Element> = Array.from(
+            container.querySelectorAll(chart.markSelector),
+          );
+
+          expect(marks.length).toBeGreaterThan(0);
+
+          /*
+           * Present-but-empty geometry is the exact failure mode here: a
+           * <path> with no `d` renders nothing at all, so the element count
+           * alone would not have caught the bug.
+           */
+          for (const mark of marks) {
+            expect(mark.getAttribute("d")).toBeTruthy();
+          }
+        },
+      );
+
+      test("draws the same geometry whatever the legend says", (): void => {
+        const canonical: RenderResultContainer = render(
+          chart.render(buildXAxis("Time")),
+        );
+        const canonicalPaths: Array<string | null> = Array.from(
+          canonical.container.querySelectorAll(chart.markSelector),
+        ).map((element: Element) => {
+          return element.getAttribute("d");
+        });
+
+        cleanup();
+
+        const other: RenderResultContainer = render(
+          chart.render(buildXAxis("")),
+        );
+        const otherPaths: Array<string | null> = Array.from(
+          other.container.querySelectorAll(chart.markSelector),
+        ).map((element: Element) => {
+          return element.getAttribute("d");
+        });
+
+        expect(otherPaths).toEqual(canonicalPaths);
+      });
+    });
+  }
+});
+
+interface RenderResultContainer {
+  container: HTMLElement;
+}

--- a/Common/Tests/UI/Components/Charts/DataPointUtil.test.ts
+++ b/Common/Tests/UI/Components/Charts/DataPointUtil.test.ts
@@ -1,0 +1,323 @@
+/**
+ * @timezone UTC
+ */
+import { describe, expect, test } from "@jest/globals";
+
+import ChartDataPoint, {
+  CHART_DATA_POINT_DATE_KEY,
+  CHART_DATA_POINT_X_AXIS_KEY,
+} from "../../../../UI/Components/Charts/ChartLibrary/Types/ChartDataPoint";
+import DataPointUtil from "../../../../UI/Components/Charts/Utils/DataPoint";
+import DataPoint from "../../../../UI/Components/Charts/Types/DataPoint";
+import SeriesPoints from "../../../../UI/Components/Charts/Types/SeriesPoints";
+import {
+  XAxis as ChartXAxis,
+  XAxisAggregateType,
+} from "../../../../UI/Components/Charts/Types/XAxis/XAxis";
+import XAxisType from "../../../../UI/Components/Charts/Types/XAxis/XAxisType";
+import YAxis, {
+  YAxisPrecision,
+} from "../../../../UI/Components/Charts/Types/YAxis/YAxis";
+import YAxisType from "../../../../UI/Components/Charts/Types/YAxis/YAxisType";
+
+/*
+ * DataPointUtil produces the rows recharts is handed directly, so the KEY it
+ * writes them under is a contract, not an implementation detail: the chart
+ * wrappers look up CHART_DATA_POINT_X_AXIS_KEY on every row and draw nothing
+ * at all when it is absent.
+ *
+ * That key used to be whatever the caller put in `xAxis.legend`, which made
+ * the contract invisible — and the one caller that passed something else (the
+ * SLO dashboard widget, with "") rendered an empty chart. These tests pin the
+ * key, and pin that the legend can no longer influence it.
+ *
+ * Pinned to UTC via the docblock pragma above: the bucket labels come from
+ * local-time formatters, so an unpinned run would assert against the
+ * machine's zone.
+ */
+
+const START: Date = new Date("2026-08-10T00:00:00.000Z");
+const END: Date = new Date("2026-08-10T01:00:00.000Z");
+
+/** A 1-hour window buckets EVERY_MINUTE, inclusive of both ends. */
+const EXPECTED_BUCKET_COUNT: number = 61;
+
+const Y_AXIS: YAxis = {
+  legend: "%",
+  options: {
+    type: YAxisType.Number,
+    min: "auto",
+    max: 100,
+    precision: YAxisPrecision.TwoDecimals,
+    formatter: (value: number): string => {
+      return `${value}%`;
+    },
+  },
+};
+
+type BuildXAxisFunction = (data?: {
+  legend?: string | undefined;
+  aggregateType?: XAxisAggregateType | undefined;
+}) => ChartXAxis;
+
+const buildXAxis: BuildXAxisFunction = (
+  data: {
+    legend?: string | undefined;
+    aggregateType?: XAxisAggregateType | undefined;
+  } = {},
+): ChartXAxis => {
+  return {
+    legend: data.legend ?? "Time",
+    options: {
+      type: XAxisType.Time,
+      min: START,
+      max: END,
+      aggregateType: data.aggregateType ?? XAxisAggregateType.Average,
+    },
+  };
+};
+
+type MinutesAfterStartFunction = (minutes: number) => Date;
+
+const minutesAfterStart: MinutesAfterStartFunction = (
+  minutes: number,
+): Date => {
+  return new Date(START.getTime() + minutes * 60 * 1000);
+};
+
+type GetPointsFunction = (data: {
+  seriesPoints: Array<SeriesPoints>;
+  legend?: string | undefined;
+  aggregateType?: XAxisAggregateType | undefined;
+}) => Array<ChartDataPoint>;
+
+const getPoints: GetPointsFunction = (data: {
+  seriesPoints: Array<SeriesPoints>;
+  legend?: string | undefined;
+  aggregateType?: XAxisAggregateType | undefined;
+}): Array<ChartDataPoint> => {
+  return DataPointUtil.getChartDataPoints({
+    seriesPoints: data.seriesPoints,
+    xAxis: buildXAxis({
+      legend: data.legend,
+      aggregateType: data.aggregateType,
+    }),
+    yAxis: Y_AXIS,
+  });
+};
+
+describe("DataPointUtil.getChartDataPoints", () => {
+  describe("the x-axis row key", () => {
+    test("writes the canonical key on every bucket", (): void => {
+      const rows: Array<ChartDataPoint> = getPoints({ seriesPoints: [] });
+
+      expect(rows.length).toBe(EXPECTED_BUCKET_COUNT);
+
+      for (const row of rows) {
+        expect(typeof row[CHART_DATA_POINT_X_AXIS_KEY]).toBe("string");
+        expect(row[CHART_DATA_POINT_X_AXIS_KEY]).not.toBe("");
+      }
+    });
+
+    test.each([
+      ["an empty legend", ""],
+      ["an arbitrary legend", "Timestamp"],
+      ["the canonical legend", "Time"],
+    ])(
+      "keys rows the same way with %s",
+      (_label: string, legend: string): void => {
+        const rows: Array<ChartDataPoint> = getPoints({
+          seriesPoints: [],
+          legend: legend,
+        });
+
+        for (const row of rows) {
+          expect(row[CHART_DATA_POINT_X_AXIS_KEY]).toBeDefined();
+        }
+      },
+    );
+
+    test("never leaks the legend into the row as a second key", (): void => {
+      const rows: Array<ChartDataPoint> = getPoints({
+        seriesPoints: [],
+        legend: "Timestamp",
+      });
+
+      for (const row of rows) {
+        expect(Object.keys(row).sort()).toEqual(
+          [CHART_DATA_POINT_X_AXIS_KEY, CHART_DATA_POINT_DATE_KEY].sort(),
+        );
+      }
+    });
+
+    test("produces identical rows whatever the legend says", (): void => {
+      const series: Array<SeriesPoints> = [
+        {
+          seriesName: "SLI",
+          data: [
+            { x: minutesAfterStart(0), y: 99.1 },
+            { x: minutesAfterStart(30), y: 99.4 },
+          ],
+        },
+      ];
+
+      const canonical: Array<ChartDataPoint> = getPoints({
+        seriesPoints: series,
+        legend: "Time",
+      });
+      const empty: Array<ChartDataPoint> = getPoints({
+        seriesPoints: series,
+        legend: "",
+      });
+
+      expect(empty).toEqual(canonical);
+    });
+  });
+
+  describe("the hidden raw-date field", () => {
+    test("carries each bucket start as epoch ms", (): void => {
+      const rows: Array<ChartDataPoint> = getPoints({ seriesPoints: [] });
+
+      expect(rows[0]![CHART_DATA_POINT_DATE_KEY]).toBe(START.getTime());
+      expect(rows[rows.length - 1]![CHART_DATA_POINT_DATE_KEY]).toBe(
+        END.getTime(),
+      );
+    });
+
+    test("is underscore-prefixed so it can never collide with a series", (): void => {
+      expect(CHART_DATA_POINT_DATE_KEY.startsWith("__")).toBe(true);
+      expect(CHART_DATA_POINT_DATE_KEY).not.toBe(CHART_DATA_POINT_X_AXIS_KEY);
+    });
+  });
+
+  describe("placing series values into buckets", () => {
+    test("lands a point on the bucket its timestamp falls in", (): void => {
+      const rows: Array<ChartDataPoint> = getPoints({
+        seriesPoints: [
+          {
+            seriesName: "SLI",
+            data: [
+              { x: minutesAfterStart(0), y: 10 },
+              { x: minutesAfterStart(5), y: 20 },
+              { x: minutesAfterStart(60), y: 30 },
+            ],
+          },
+        ],
+      });
+
+      expect(rows[0]!["SLI"]).toBe(10);
+      expect(rows[5]!["SLI"]).toBe(20);
+      expect(rows[60]!["SLI"]).toBe(30);
+      // Buckets with no datapoint stay absent rather than becoming 0.
+      expect(rows[1]!["SLI"]).toBeUndefined();
+    });
+
+    test("drops points outside the charted window", (): void => {
+      const rows: Array<ChartDataPoint> = getPoints({
+        seriesPoints: [
+          {
+            seriesName: "SLI",
+            data: [
+              { x: minutesAfterStart(-30), y: 1 },
+              { x: minutesAfterStart(120), y: 2 },
+              { x: minutesAfterStart(10), y: 3 },
+            ],
+          },
+        ],
+      });
+
+      const withValues: Array<ChartDataPoint> = rows.filter(
+        (row: ChartDataPoint) => {
+          return row["SLI"] !== undefined;
+        },
+      );
+
+      expect(withValues.length).toBe(1);
+      expect(rows[10]!["SLI"]).toBe(3);
+    });
+
+    test("keeps several series side by side on one row", (): void => {
+      const rows: Array<ChartDataPoint> = getPoints({
+        seriesPoints: [
+          {
+            seriesName: "SLI",
+            data: [{ x: minutesAfterStart(3), y: 99 }],
+          },
+          {
+            seriesName: "Burn Rate",
+            data: [{ x: minutesAfterStart(3), y: 1.5 }],
+          },
+        ],
+      });
+
+      expect(rows[3]!["SLI"]).toBe(99);
+      expect(rows[3]!["Burn Rate"]).toBe(1.5);
+    });
+  });
+
+  describe("rolling up several points into one bucket", () => {
+    const sameBucket: Array<SeriesPoints> = [
+      {
+        seriesName: "SLI",
+        data: [
+          { x: new Date(START.getTime() + 1000), y: 10 },
+          { x: new Date(START.getTime() + 2000), y: 20 },
+          { x: new Date(START.getTime() + 3000), y: 60 },
+        ],
+      },
+    ];
+
+    test.each([
+      [XAxisAggregateType.Average, 30],
+      [XAxisAggregateType.Sum, 90],
+      [XAxisAggregateType.Max, 60],
+      [XAxisAggregateType.Min, 10],
+    ])("%s", (aggregateType: XAxisAggregateType, expected: number): void => {
+      const rows: Array<ChartDataPoint> = getPoints({
+        seriesPoints: sameBucket,
+        aggregateType: aggregateType,
+      });
+
+      expect(rows[0]!["SLI"]).toBe(expected);
+    });
+
+    /*
+     * The accumulator is keyed by (series, bucket). A shared accumulator once
+     * carried each bucket's running total into the next, turning an
+     * "Incidents Over Time" Sum chart into a reverse-cumulative staircase.
+     */
+    test("resets its accumulator at every bucket boundary", (): void => {
+      const rows: Array<ChartDataPoint> = getPoints({
+        aggregateType: XAxisAggregateType.Sum,
+        seriesPoints: [
+          {
+            seriesName: "Incidents",
+            data: [
+              { x: minutesAfterStart(0), y: 41 },
+              { x: minutesAfterStart(1), y: 91 },
+              { x: minutesAfterStart(2), y: 356 },
+            ],
+          },
+        ],
+      });
+
+      expect(rows[0]!["Incidents"]).toBe(41);
+      expect(rows[1]!["Incidents"]).toBe(91);
+      expect(rows[2]!["Incidents"]).toBe(356);
+    });
+  });
+
+  describe("empty input", () => {
+    test("still returns the full bucket grid so the axis can draw", (): void => {
+      const rows: Array<ChartDataPoint> = getPoints({
+        seriesPoints: [{ seriesName: "SLI", data: [] as Array<DataPoint> }],
+      });
+
+      expect(rows.length).toBe(EXPECTED_BUCKET_COUNT);
+
+      for (const row of rows) {
+        expect(row["SLI"]).toBeUndefined();
+      }
+    });
+  });
+});

--- a/Common/UI/Components/Charts/Area/AreaChart.tsx
+++ b/Common/UI/Components/Charts/Area/AreaChart.tsx
@@ -13,7 +13,9 @@ import SeriesPoint from "../Types/SeriesPoints";
 import { XAxis } from "../Types/XAxis/XAxis";
 import YAxis from "../Types/YAxis/YAxis";
 import ChartCurve from "../Types/ChartCurve";
-import ChartDataPoint from "../ChartLibrary/Types/ChartDataPoint";
+import ChartDataPoint, {
+  CHART_DATA_POINT_X_AXIS_KEY,
+} from "../ChartLibrary/Types/ChartDataPoint";
 import FormattedExemplarPoint from "../ChartLibrary/Types/FormattedExemplarPoint";
 import FormattedReferenceRegion from "../ChartLibrary/Types/FormattedReferenceRegion";
 import FormattedTimeReferenceLine from "../ChartLibrary/Types/FormattedTimeReferenceLine";
@@ -185,7 +187,7 @@ const AreaChartElement: FunctionComponent<AreaInternalProps> = (
       <AreaChart
         data={records}
         tickGap={30}
-        index={"Time"}
+        index={CHART_DATA_POINT_X_AXIS_KEY}
         categories={categories}
         colors={
           props.colors && props.colors.length > 0

--- a/Common/UI/Components/Charts/Bar/BarChart.tsx
+++ b/Common/UI/Components/Charts/Bar/BarChart.tsx
@@ -12,7 +12,9 @@ import React, {
 import SeriesPoint from "../Types/SeriesPoints";
 import { XAxis } from "../Types/XAxis/XAxis";
 import YAxis from "../Types/YAxis/YAxis";
-import ChartDataPoint from "../ChartLibrary/Types/ChartDataPoint";
+import ChartDataPoint, {
+  CHART_DATA_POINT_X_AXIS_KEY,
+} from "../ChartLibrary/Types/ChartDataPoint";
 import FormattedReferenceRegion from "../ChartLibrary/Types/FormattedReferenceRegion";
 import FormattedTimeReferenceLine from "../ChartLibrary/Types/FormattedTimeReferenceLine";
 import DataPointUtil from "../Utils/DataPoint";
@@ -119,7 +121,7 @@ const BarChartElement: FunctionComponent<BarInternalProps> = (
       <BarChart
         data={records}
         tickGap={30}
-        index={"Time"}
+        index={CHART_DATA_POINT_X_AXIS_KEY}
         categories={categories}
         colors={
           props.colors && props.colors.length > 0

--- a/Common/UI/Components/Charts/ChartLibrary/Types/ChartDataPoint.ts
+++ b/Common/UI/Components/Charts/ChartLibrary/Types/ChartDataPoint.ts
@@ -5,6 +5,19 @@
  */
 export const CHART_DATA_POINT_DATE_KEY: string = "__date";
 
+/**
+ * Per-row field carrying the FORMATTED x-axis label.
+ *
+ * This is the recharts `XAxis` dataKey — the Line / Bar / Area wrappers all
+ * pass it down as their `index` prop. `DataPointUtil` must therefore write
+ * the label under exactly this key: a row keyed anything else leaves every
+ * point with an undefined category, and recharts then draws no line, bar or
+ * area at all (the axes and grid still render, so the chart looks alive but
+ * empty). Keeping the single constant on both sides is what stops that from
+ * being an invisible coupling between two distant files.
+ */
+export const CHART_DATA_POINT_X_AXIS_KEY: string = "Time";
+
 export default interface ChartDataPoint {
   [x: string]: number | string;
 }

--- a/Common/UI/Components/Charts/Line/LineChart.tsx
+++ b/Common/UI/Components/Charts/Line/LineChart.tsx
@@ -13,7 +13,9 @@ import SeriesPoint from "../Types/SeriesPoints";
 import { XAxis } from "../Types/XAxis/XAxis";
 import YAxis from "../Types/YAxis/YAxis";
 import ChartCurve from "../Types/ChartCurve";
-import ChartDataPoint from "../ChartLibrary/Types/ChartDataPoint";
+import ChartDataPoint, {
+  CHART_DATA_POINT_X_AXIS_KEY,
+} from "../ChartLibrary/Types/ChartDataPoint";
 import FormattedExemplarPoint from "../ChartLibrary/Types/FormattedExemplarPoint";
 import FormattedReferenceRegion from "../ChartLibrary/Types/FormattedReferenceRegion";
 import FormattedTimeReferenceLine from "../ChartLibrary/Types/FormattedTimeReferenceLine";
@@ -165,7 +167,7 @@ const LineChartElement: FunctionComponent<LineInternalProps> = (
       <LineChart
         data={records}
         tickGap={30}
-        index={"Time"}
+        index={CHART_DATA_POINT_X_AXIS_KEY}
         categories={categories}
         colors={
           props.colors && props.colors.length > 0

--- a/Common/UI/Components/Charts/Types/XAxis/XAxis.ts
+++ b/Common/UI/Components/Charts/Types/XAxis/XAxis.ts
@@ -16,6 +16,12 @@ export interface XAxisOptions {
 }
 
 export interface XAxis {
+  /*
+   * Human-readable name for the axis. Purely descriptive: the per-row key
+   * the charts read is CHART_DATA_POINT_X_AXIS_KEY, never this string. It
+   * used to double as that key, which meant a caller passing anything but
+   * "Time" got a chart with axes and no series drawn on them.
+   */
   legend: string;
   options: XAxisOptions;
 }

--- a/Common/UI/Components/Charts/Utils/DataPoint.ts
+++ b/Common/UI/Components/Charts/Utils/DataPoint.ts
@@ -10,6 +10,7 @@
 import BadDataException from "../../../../Types/Exception/BadDataException";
 import ChartDataPoint, {
   CHART_DATA_POINT_DATE_KEY,
+  CHART_DATA_POINT_X_AXIS_KEY,
 } from "../ChartLibrary/Types/ChartDataPoint";
 import SeriesPoints from "../Types/SeriesPoints";
 import { XAxis, XAxisAggregateType } from "../Types/XAxis/XAxis";
@@ -30,18 +31,14 @@ export default class DataPointUtil {
     xAxis: XAxis;
     yAxis: YAxis;
   }): Array<ChartDataPoint> {
-    const { xAxisLegend, intervals, formatter } = this.initializeXAxisData(
-      data.xAxis,
-    );
+    const { intervals, formatter } = this.initializeXAxisData(data.xAxis);
     const arrayOfData: ChartDataPoint[] = this.initializeArrayOfData(
       intervals,
-      xAxisLegend,
       formatter,
     );
     this.processSeriesData(
       data.seriesPoints,
       arrayOfData,
-      xAxisLegend,
       formatter,
       data.xAxis.options.aggregateType,
     );
@@ -51,13 +48,11 @@ export default class DataPointUtil {
   private static initializeXAxisData(xAxis: XAxis): {
     xAxisMax: XAxisMaxMin;
     xAxisMin: XAxisMaxMin;
-    xAxisLegend: string;
     intervals: Array<Date>;
     formatter: (value: Date) => string;
   } {
     const xAxisMax: XAxisMaxMin = xAxis.options.max;
     const xAxisMin: XAxisMaxMin = xAxis.options.min;
-    const xAxisLegend: string = xAxis.legend;
     const intervals: Array<Date> = XAxisUtil.getPrecisionIntervals({
       xAxisMax,
       xAxisMin,
@@ -66,18 +61,25 @@ export default class DataPointUtil {
       xAxisMax,
       xAxisMin,
     });
-    return { xAxisMax, xAxisMin, xAxisLegend, intervals, formatter };
+    return { xAxisMax, xAxisMin, intervals, formatter };
   }
 
   private static initializeArrayOfData(
     intervals: Array<Date>,
-    xAxisLegend: string,
     formatter: (value: Date) => string,
   ): Array<ChartDataPoint> {
     const arrayOfData: Array<ChartDataPoint> = [];
     for (const interval of intervals) {
       const dataPoint: ChartDataPoint = {};
-      dataPoint[xAxisLegend] = formatter(interval);
+      /*
+       * Always the canonical key, NEVER `xAxis.legend`. The wrappers hand
+       * recharts this exact key as the XAxis dataKey, so keying rows off a
+       * caller-supplied string meant one caller passing anything else
+       * (the SLO dashboard widget passed "") produced rows recharts could
+       * not read — every point landed on an undefined category and the
+       * line silently vanished while the axes still drew.
+       */
+      dataPoint[CHART_DATA_POINT_X_AXIS_KEY] = formatter(interval);
       /*
        * The formatted label is not round-trippable back to a Date, so
        * keep the raw bucket start on the row — charts use it to recover
@@ -92,7 +94,6 @@ export default class DataPointUtil {
   private static processSeriesData(
     seriesPoints: Array<SeriesPoints>,
     arrayOfData: Array<ChartDataPoint>,
-    xAxisLegend: string,
     formatter: (value: Date) => string,
     aggregateType: XAxisAggregateType,
   ): { [key: string]: SeriesData } {
@@ -123,7 +124,9 @@ export default class DataPointUtil {
 
         const target: ChartDataPoint | undefined = arrayOfData.find(
           (chartDataPoint: ChartDataPoint) => {
-            return chartDataPoint[xAxisLegend] === formattedDate;
+            return (
+              chartDataPoint[CHART_DATA_POINT_X_AXIS_KEY] === formattedDate
+            );
           },
         );
         if (!target) {


### PR DESCRIPTION
## The bug

An SLO widget set to **Chart** rendered its whole frame — axes, grid, tooltip, status pill, target reference line — and **no line**. Reported on a public custom dashboard, where SLO **Tile** widgets showed data fine.

Tiles being fine is what made it look like a public-dashboard problem. It wasn't: the chart was equally blank on an authenticated dashboard. The public endpoints, the request shape and the returned rows were all correct — tiles just never go near recharts.

## Root cause

The `Line` / `Bar` / `Area` wrappers hand recharts a **fixed** x-axis dataKey:

```tsx
<LineChart data={records} index={"Time"} … />
```

while `DataPointUtil.getChartDataPoints` keyed each chart row by the **caller's** `xAxis.legend`:

```ts
dataPoint[xAxisLegend] = formatter(interval);
```

Those two agreed only by convention. Of the chart callers in the tree, every one passed the literal `"Time"` — except the SLO dashboard widget, which passed `""`. recharts then looked up `"Time"` on every row, found nothing, and emitted no path at all. Silently: a chart with no series still draws its frame, so nothing errored and nothing logged.

## The fix

- Add `CHART_DATA_POINT_X_AXIS_KEY` next to the existing `CHART_DATA_POINT_DATE_KEY`, and have both sides import it — `DataPointUtil` writes rows under it, the three wrappers read it. A caller's legend can no longer decide whether a chart draws anything.
- Give the SLO widget the same `legend: "Time"` as its siblings.
- Document `XAxis.legend` as descriptive-only.

Behaviour is unchanged for all other callers (they already passed `"Time"`); it is fixed for anything that doesn't.

## Tests

Three new suites, all of which fail on the pre-fix tree:

| Suite | Covers |
|---|---|
| `Common/Tests/UI/Components/Charts/ChartXAxisDataKey.test.tsx` | Renders all three real wrappers through recharts; each draws its series — with byte-identical geometry — for canonical, empty, arbitrary and odd legends |
| `Common/Tests/UI/Components/Charts/DataPointUtil.test.ts` | Pins the row key, the hidden raw-date field, bucket placement, window clipping, all four roll-ups, and the per-bucket accumulator reset |
| `Common/Tests/App/Dashboard/SloWidgetChartRendering.test.tsx` | Widget end-to-end against a **real** chart on both the anonymous public dashboard and the authenticated one: SVG path data for all three metrics, ClickHouse decimal-string values, the target reference line, the empty-history state, and a height-clamped tile |

The existing `SloWidgetFetching.test.tsx` stubs `LineChart` out and asserts on the props handed down — which is precisely why this survived: the props were right and recharts still drew nothing. The new suites assert on the SVG the viewer actually gets.

Verification: `Tests/UI` + `Tests/App/Dashboard` + `Tests/App/PublicDashboard` — **213 suites, 5075 tests, all passing**. `Common`, `App/FeatureSet/Dashboard` and `App/FeatureSet/PublicDashboard` all type-check clean; eslint clean.