### PR TITLE
feat(inventory): date custom fields, and stop the mirror deleting user data

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/CustomFields/CustomFieldFacets.ts
+++ b/App/FeatureSet/Dashboard/src/Components/CustomFields/CustomFieldFacets.ts
@@ -1,4 +1,6 @@
 import {
+  DATE_FACET_OPERATORS,
+  FacetKind,
   FilterChipDropdownOption,
   FilterOperator,
   NUMBER_FACET_OPERATORS,
@@ -6,6 +8,7 @@ import {
   TEXT_FACET_OPERATORS,
 } from "../ResourceOwners/FilterChipDropdownTypes";
 import { ResourceFacet } from "../ResourceOwners/ResourceFacet";
+import { buildFacetDateRangeQuery } from "../ResourceOwners/FacetDateRange";
 import EndsWith from "Common/Types/BaseDatabase/EndsWith";
 import GreaterThan from "Common/Types/BaseDatabase/GreaterThan";
 import GreaterThanOrEqual from "Common/Types/BaseDatabase/GreaterThanOrEqual";
@@ -90,6 +93,27 @@ export const getCustomFieldNameFromFacetKey: GetCustomFieldNameFromFacetKeyFunct
   };
 
 /**
+ * Is this definition one of the two date types?
+ *
+ * Both store an ISO-8601 UTC string — the shared date `Input` normalises every
+ * `date` and `datetime-local` entry through `OneUptimeDate.toString()` before
+ * it reaches the `customFields` bag — and differ only in whether the time of
+ * day is part of the answer.
+ */
+export type IsDateCustomFieldFunction = (
+  definition: CustomFieldDefinition,
+) => boolean;
+
+export const isDateCustomField: IsDateCustomFieldFunction = (
+  definition: CustomFieldDefinition,
+): boolean => {
+  return (
+    definition.customFieldType === CustomFieldType.Date ||
+    definition.customFieldType === CustomFieldType.DateTime
+  );
+};
+
+/**
  * The chip kind a definition gets.
  *
  * A dropdown with no options configured falls back to a text chip rather than
@@ -98,17 +122,21 @@ export const getCustomFieldNameFromFacetKey: GetCustomFieldNameFromFacetKeyFunct
  */
 export type GetCustomFieldFacetKindFunction = (
   definition: CustomFieldDefinition,
-) => "options" | "text" | "number";
+) => FacetKind;
 
 export const getCustomFieldFacetKind: GetCustomFieldFacetKindFunction = (
   definition: CustomFieldDefinition,
-): "options" | "text" | "number" => {
+): FacetKind => {
   if (definition.customFieldType === CustomFieldType.Number) {
     return "number";
   }
 
   if (definition.customFieldType === CustomFieldType.Boolean) {
     return "options";
+  }
+
+  if (isDateCustomField(definition)) {
+    return "dateRange";
   }
 
   if (
@@ -167,11 +195,14 @@ export type GetCustomFieldFacetOperatorsFunction = (
 
 export const getCustomFieldFacetOperators: GetCustomFieldFacetOperatorsFunction =
   (definition: CustomFieldDefinition): Array<FilterOperator> => {
-    const kind: "options" | "text" | "number" =
-      getCustomFieldFacetKind(definition);
+    const kind: FacetKind = getCustomFieldFacetKind(definition);
 
     if (kind === "number") {
       return NUMBER_FACET_OPERATORS;
+    }
+
+    if (kind === "dateRange") {
+      return DATE_FACET_OPERATORS;
     }
 
     if (kind === "text") {
@@ -247,6 +278,33 @@ const buildCustomFieldFacetQuery: BuildCustomFieldFacetQueryFunction = (
   const wrap: WrapFunction = (value: unknown): JSONObject => {
     return { [name]: value } as JSONObject;
   };
+
+  /*
+   * A date field delegates the whole vocabulary — including is_empty and
+   * is_not_empty — to the shared range builder, so a custom field date and a
+   * real date column answer "is before the 5th" identically. Only the wrapping
+   * is ours.
+   *
+   * The comparison lands on text rather than on a timestamp, and is correct
+   * because of what is stored: the shared date `Input` normalises every entry
+   * through `OneUptimeDate.toString()` (i.e. `toISOString()`), and ISO-8601 is
+   * ordered identically as text and as an instant. `JSONColumnQuery` compares
+   * a non-numeric operand as text for exactly this reason.
+   *
+   * `undefined` comes back for a half-entered range and for `is_not`, which a
+   * date chip does not offer; both mean "do not constrain this field".
+   */
+  if (isDateCustomField(definition)) {
+    const dateQuery: unknown = buildFacetDateRangeQuery(
+      input.values,
+      operator,
+      {
+        isDateTime: definition.customFieldType === CustomFieldType.DateTime,
+      },
+    );
+
+    return dateQuery === undefined ? undefined : wrap(dateQuery);
+  }
 
   if (operator === "is_empty") {
     return wrap(new IsNull());
@@ -412,8 +470,7 @@ export const buildCustomFieldFacets: BuildCustomFieldFacetsFunction = (
       return Boolean(definition && definition.name);
     })
     .map((definition: CustomFieldDefinition): ResourceFacet => {
-      const kind: "options" | "text" | "number" =
-        getCustomFieldFacetKind(definition);
+      const kind: FacetKind = getCustomFieldFacetKind(definition);
       const isMulti: boolean = isMultiSelectDefinition(definition);
 
       return {
@@ -423,9 +480,11 @@ export const buildCustomFieldFacets: BuildCustomFieldFacetsFunction = (
         icon:
           kind === "number"
             ? IconProp.Hashtag
-            : kind === "text"
-              ? IconProp.Text
-              : IconProp.List,
+            : kind === "dateRange"
+              ? IconProp.Calendar
+              : kind === "text"
+                ? IconProp.Text
+                : IconProp.List,
         isMultiSelect: isMulti,
         options:
           kind === "options"

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/Base/CustomFieldsPageBase.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/Base/CustomFieldsPageBase.tsx
@@ -17,12 +17,19 @@ import TeamMemberCustomField from "Common/Models/DatabaseModels/TeamMemberCustom
 import React, { Fragment, ReactElement } from "react";
 import ProjectUtil from "Common/UI/Utils/Project";
 
+/*
+ * Typed as a total Record so adding a member to CustomFieldType fails the
+ * compile here rather than shipping a picker entry labelled with its own raw
+ * enum key.
+ */
 const FIELD_TYPE_LABELS: Record<CustomFieldType, string> = {
   [CustomFieldType.Text]: "Text",
   [CustomFieldType.Number]: "Number",
   [CustomFieldType.Boolean]: "Boolean",
   [CustomFieldType.Dropdown]: "Dropdown (single select)",
   [CustomFieldType.MultiSelectDropdown]: "Dropdown (multi-select)",
+  [CustomFieldType.Date]: "Date",
+  [CustomFieldType.DateTime]: "Date and time",
 };
 
 const isDropdownType: (value: unknown) => boolean = (

--- a/App/FeatureSet/Docs/Content/en/inventory/cmdb-sync.md
+++ b/App/FeatureSet/Docs/Content/en/inventory/cmdb-sync.md
@@ -1,0 +1,126 @@
+# Exporting Inventory to a CMDB
+
+## Overview
+
+If you already run a CMDB or asset register, OneUptime is not trying to replace it. What OneUptime has that a CMDB usually does not is a continuously observed picture of what is actually running — discovered from telemetry and from the pollers that already watch your network and cloud accounts, refreshed without anyone maintaining it.
+
+This page is the recipe for pulling that picture into your own system of record.
+
+## What You Can Pull
+
+Three REST resources, all standard CRUD endpoints:
+
+| Resource | Endpoint | What it holds |
+| -------- | -------- | ------------- |
+| Inventory Item | `/api/inventory-item` | One row per thing in the estate |
+| Custom Field definitions | `/api/inventory-item-custom-field` | Your project's own field vocabulary |
+| Relationships | `/api/inventory-item-relationship` | The directed edges between items |
+
+Useful columns on an inventory item:
+
+| Column | Meaning |
+| ------ | ------- |
+| `_id` | OneUptime's id — use it as your external reference |
+| `entityType` | `host`, `k8s.pod`, `network.device`, `appliance`, … |
+| `entityKey` | Stable identity hash. Survives renames, so it is the better correlation key |
+| `displayName` | Human-readable name |
+| `source` | `discovered`, `inventory`, or `manual` |
+| `description` | Free text |
+| `identifyingAttributes` | The immutable attribute set that defines this thing's identity |
+| `descriptiveAttributes` | Mutable observed metadata — image tag, version, IP |
+| `customFields` | Your own fields, keyed by field name |
+| `resourceType` / `resourceId` | Pointer to the richer OneUptime record, when one exists |
+| `firstSeenAt` / `lastSeenAt` | Observation window |
+| `isArchived` | Whether it has been taken out of the live list |
+
+## Authentication
+
+Create an API key under **Project Settings → API Keys** and grant it **Read Telemetry Service**. Inventory reuses the telemetry permission family rather than having one of its own, so that single permission is what a read-only export needs.
+
+Send it as two headers:
+
+```
+apikey: <your-api-key>
+projectid: <your-project-id>
+```
+
+## Pulling the Catalog
+
+`POST` to the list endpoint with the columns you want. `select` is required — the API returns only what you ask for.
+
+```bash
+curl -X POST 'https://oneuptime.com/api/inventory-item/get-list' \
+  -H 'apikey: YOUR_API_KEY' \
+  -H 'projectid: YOUR_PROJECT_ID' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "query": { "isArchived": false },
+    "select": {
+      "_id": true,
+      "entityType": true,
+      "entityKey": true,
+      "displayName": true,
+      "source": true,
+      "customFields": true,
+      "descriptiveAttributes": true,
+      "lastSeenAt": true
+    },
+    "sort": { "displayName": "ASC" },
+    "limit": 100,
+    "skip": 0
+  }'
+```
+
+Page by increasing `skip` until you get fewer rows back than your `limit`.
+
+### Just the network devices
+
+Narrow by `entityType`:
+
+```bash
+curl -X POST 'https://oneuptime.com/api/inventory-item/get-list' \
+  -H 'apikey: YOUR_API_KEY' \
+  -H 'projectid: YOUR_PROJECT_ID' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "query": { "entityType": "network.device", "isArchived": false },
+    "select": { "_id": true, "entityKey": true, "displayName": true, "customFields": true },
+    "limit": 100,
+    "skip": 0
+  }'
+```
+
+The discovered hardware detail — vendor, model, serial number, firmware, site — lives on the Network Device record itself. Follow `resourceId` to `/api/network-device/:id/get-item` for it, or pull `/api/network-device/get-list` directly.
+
+### As CSV
+
+Any list endpoint will return CSV instead of JSON with `?output-type=csv`:
+
+```bash
+curl -X POST 'https://oneuptime.com/api/inventory-item/get-list?output-type=csv' \
+  -H 'apikey: YOUR_API_KEY' \
+  -H 'projectid: YOUR_PROJECT_ID' \
+  -H 'Content-Type: application/json' \
+  -d '{ "query": {}, "select": { "displayName": true, "entityType": true, "customFields": true }, "limit": 500, "skip": 0 }' \
+  -o inventory.csv
+```
+
+The inventory list in the dashboard exports the same way, including whichever custom field columns you have turned on.
+
+## Correlating With Your CMDB
+
+Use **`entityKey`**, not `displayName`. It is a hash of the thing's identifying attributes, so it survives renames and re-tagging — a host that gets relabelled keeps the same key, while its display name changes. `_id` is equally stable and is the simplest foreign key if you only ever talk to one project.
+
+Dates in `customFields` are ISO-8601 UTC strings, and the CSV export writes them in that form rather than the humanised form shown in the UI, so they import without parsing surprises.
+
+## Keeping It Fresh
+
+There is no change feed. Poll the list endpoint on whatever interval suits you and diff on `entityKey`. `lastSeenAt` tells you when a thing was last observed, which is usually the cheapest way to spot what has gone quiet since your last run.
+
+Rows that disappear between runs have either aged out (a discovered item silent past its retention window) or had their owning record deleted. Rows that carry custom field values are archived rather than deleted, so query with `"isArchived": true` if you want to see what has been retired without losing the asset data attached to it.
+
+## Writing Back
+
+The same endpoints accept writes, so an integration can push values into `customFields` — stamping the asset tag your CMDB already owns onto the matching OneUptime item, for example. Grant the key **Edit Telemetry Service** to do that.
+
+You can also create items for things OneUptime cannot see, using `POST /api/inventory-item` with `entityType` of `external.service`, `external.database`, or `appliance`, plus a `displayName`. OneUptime derives the identity key for you; those rows are never expired.

--- a/App/FeatureSet/Docs/Content/en/inventory/custom-fields.md
+++ b/App/FeatureSet/Docs/Content/en/inventory/custom-fields.md
@@ -1,0 +1,66 @@
+# Inventory Custom Fields
+
+## Overview
+
+OneUptime discovers *what* is in your estate. Custom fields are how you record everything about it that no amount of observation can tell you — the serial number on the sticker, the date the warranty runs out, which team owns it, whether it is in service or sitting in a spare parts drawer.
+
+Define the fields once for the project, then fill them in per item. They become filter chips on the inventory list, optional table columns, and columns in the CSV export.
+
+Custom fields are available on the **Growth** plan and above.
+
+## Defining Fields
+
+Go to **Inventory → Settings → Custom Fields** and add a field. Each one has a name, an optional description, and a type:
+
+| Type | Use it for |
+| ---- | ---------- |
+| **Text** | Serial number, asset tag, rack position, purchase order number |
+| **Number** | Cost, rack unit, port count |
+| **Boolean** | Under support, PCI scope |
+| **Dropdown (single select)** | Lifecycle status, environment, criticality — one answer from a fixed list |
+| **Dropdown (multi-select)** | Compliance scopes, tags — several answers from a fixed list |
+| **Date** | Purchase date, warranty expiry, end-of-life date |
+| **Date and time** | Last audited at, decommissioned at |
+
+Dropdown options can each carry a colour, which is used consistently in the table cell and in the filter chip.
+
+## A Worked Asset Vocabulary
+
+A typical hardware asset register maps onto these fields directly:
+
+| Field name | Type | Example |
+| ---------- | ---- | ------- |
+| `Serial Number` | Text | `FDO24160ABC` |
+| `Asset Tag` | Text | `IT-004821` |
+| `Purchase Date` | Date | 2024-03-11 |
+| `Warranty Expiry` | Date | 2027-03-10 |
+| `Lifecycle Status` | Dropdown | In Service / Spare / In Repair / Retired |
+| `Assigned Site` | Dropdown | London DC / Frankfurt DC / Office HQ |
+| `Owner Team` | Dropdown | Network / Platform / Security |
+| `Cost Centre` | Text | `CC-4410` |
+
+Set the values on an item under its **Custom Fields** tab. Values can be set on **any** item regardless of its source, so your discovered switches and mirrored network devices can carry the same asset vocabulary as the appliances you added by hand.
+
+## Filtering
+
+Every custom field becomes a filter chip above the inventory list, and the operators offered match the type:
+
+- **Text** — is, is not, contains, does not contain, starts with, ends with, is empty, is not empty
+- **Number** — is, is not, greater than, greater than or equal, less than, less than or equal, is empty, is not empty
+- **Dropdown** — is, is not, is empty, is not empty
+- **Date and Date/time** — is, is before, is after, is between, is empty, is not empty
+
+Chips combine with AND, so *"Warranty Expiry is before 2026-10-01 AND Lifecycle Status is In Service"* is one view of the list. That is the question an asset register exists to answer, and it is the reason the date types are worth using instead of putting a date in a text field — a text field will happily store `2026-10-01` and then refuse to tell you what expires next quarter.
+
+Custom field columns are hidden by default and can be turned on from the column picker. They cannot be sorted: the values live inside a single JSON column, which the query path cannot order by.
+
+## Notes and Limits
+
+- Values are stored per item under the field's **name**. Renaming a field does not migrate the values already stored under the old name.
+- There is no uniqueness constraint. Two items can carry the same serial number; nothing will stop you.
+- Dates are stored as ISO-8601 UTC timestamps and displayed in your own timezone.
+- Deleting a field definition removes it from the list and from the filter bar. The values already written stay in the underlying record.
+
+## Next
+
+- [Exporting to a CMDB](/docs/inventory/cmdb-sync)

--- a/App/FeatureSet/Docs/Content/en/inventory/overview.md
+++ b/App/FeatureSet/Docs/Content/en/inventory/overview.md
@@ -1,0 +1,54 @@
+# Inventory
+
+## Overview
+
+**Inventory** is one list of everything OneUptime knows about your estate — services, hosts, containers, Kubernetes objects, network devices, cloud resources, IoT devices, serverless functions, and the things that emit no telemetry at all.
+
+Most of it fills itself in. OneUptime is already watching your estate to monitor it, so the catalog is built from what it observes rather than from what someone remembered to type. What you add by hand is the part observation cannot supply: what a thing is *for*, who owns it, when its warranty runs out.
+
+Find it in the dashboard under **Inventory**.
+
+## Where Items Come From
+
+Every item carries a **source**, and the source decides who owns that row's lifecycle. This is the single most useful thing to understand about the catalog, because it explains why some rows can be edited and some cannot, and why some disappear on their own.
+
+| Source | Where it comes from | Lifecycle |
+| ------ | ------------------- | --------- |
+| **Discovered** | OpenTelemetry resource attributes, at ingest. A service, host, pod, container, or process that is sending telemetry. | Re-registered on every batch. Goes away on its own once it has been silent past its type's retention window. |
+| **Inventory** | Mirrored from a OneUptime table that a poller already maintains — Network Devices, Cloud Resources, IoT Devices, Serverless Functions, RUM Applications, Docker Hosts, Podman Hosts. Refreshed every 15 minutes. | The owning record is the source of truth. Delete the device and its catalog row follows. |
+| **Manual** | Created by you, for something OneUptime cannot see: a third-party API, a vendor-managed database, an appliance in a rack. | Never expires. It lives until you delete it. |
+
+A discovered or mirrored row cannot be renamed or re-typed, because the reconciler would overwrite the edit on its next pass. What you *can* always add to any item, whatever its source, is **custom field values** — see [Custom Fields](/docs/inventory/custom-fields).
+
+### Manually Creatable Types
+
+Hand-created items are restricted to three types:
+
+- `external.service` — a third-party API or SaaS dependency
+- `external.database` — a managed database outside your telemetry
+- `appliance` — hardware or software with no agent
+
+The restriction exists to stop duplicates. A hand-made row of an observable type — a `host`, say — would be keyed on the name you typed, while the discovered row for the same machine is keyed on its semantic attributes. The two could never converge, so you would have the same host in your list twice, forever.
+
+## Archiving vs Deleting
+
+**Archiving** takes an item out of the default list while keeping its identity, its history, and its custom field values. It is a note that says "I have seen this and I do not want it in my list."
+
+**Deleting** a discovered or mirrored item does not stick. Ingest re-creates it on the next batch; the mirror re-creates it on the next sweep. Archive those instead — it is the only disposal that survives.
+
+Archived items live under **Inventory → Archived**.
+
+> If a mirrored device is removed from its owning table, OneUptime removes the catalog row too — **unless that row is carrying custom field values you entered.** In that case it is archived rather than deleted, because those values are the only copy and there is no undo. You will find it under Archived with everything you typed intact.
+
+## Relationships and Topology
+
+Items are linked by a directed relationship graph — `runs-on`, `member-of`, `hosted-on`, `part-of`, `instance-of`, `depends-on` — built from telemetry as it is observed. **Inventory → Topology Map** draws it.
+
+## What You Can Do With an Item
+
+Open any item for its overview, its observed attributes, its connections, and its custom fields. Where the item corresponds to a richer record — a service, host, or Kubernetes cluster — its logs, traces, metrics, profiles, exceptions, incidents, alerts, and scheduled maintenance are on the same page.
+
+## Next
+
+- [Custom Fields](/docs/inventory/custom-fields) — track serial numbers, warranty expiry, owner, and lifecycle status
+- [Exporting to a CMDB](/docs/inventory/cmdb-sync) — pull the catalog into an external system of record

--- a/App/FeatureSet/Docs/Locales/da.json
+++ b/App/FeatureSet/Docs/Locales/da.json
@@ -62,7 +62,8 @@
     "Telemetry": "Telemetri",
     "AI": "AI",
     "API Reference": "API-reference",
-    "Self Hosted": "Selv-hostet"
+    "Self Hosted": "Selv-hostet",
+    "Inventory": "Inventar"
   },
   "navLinks": {
     "Getting Started": "Kom godt i gang",
@@ -185,6 +186,8 @@
     "GitHub Integration": "GitHub-integration",
     "Push Notifications": "Push-notifikationer",
     "SendGrid Inbound Email": "SendGrid indgående e-mail",
-    "Architecture": "Arkitektur"
+    "Architecture": "Arkitektur",
+    "Custom Fields": "Brugerdefinerede felter",
+    "Exporting to a CMDB": "Eksport til en CMDB"
   }
 }

--- a/App/FeatureSet/Docs/Locales/de.json
+++ b/App/FeatureSet/Docs/Locales/de.json
@@ -62,7 +62,8 @@
     "Telemetry": "Telemetrie",
     "AI": "AI",
     "API Reference": "API-Referenz",
-    "Self Hosted": "Selbst gehostet"
+    "Self Hosted": "Selbst gehostet",
+    "Inventory": "Bestand"
   },
   "navLinks": {
     "Getting Started": "Erste Schritte",
@@ -185,6 +186,8 @@
     "GitHub Integration": "GitHub-Integration",
     "Push Notifications": "Push-Benachrichtigungen",
     "SendGrid Inbound Email": "SendGrid Inbound E-Mail",
-    "Architecture": "Architektur"
+    "Architecture": "Architektur",
+    "Custom Fields": "Benutzerdefinierte Felder",
+    "Exporting to a CMDB": "Export in eine CMDB"
   }
 }

--- a/App/FeatureSet/Docs/Locales/en.json
+++ b/App/FeatureSet/Docs/Locales/en.json
@@ -62,7 +62,8 @@
     "Telemetry": "Telemetry",
     "AI": "AI",
     "API Reference": "API Reference",
-    "Self Hosted": "Self Hosted"
+    "Self Hosted": "Self Hosted",
+    "Inventory": "Inventory"
   },
   "navLinks": {
     "Getting Started": "Getting Started",
@@ -185,6 +186,8 @@
     "GitHub Integration": "GitHub Integration",
     "Push Notifications": "Push Notifications",
     "SendGrid Inbound Email": "SendGrid Inbound Email",
-    "Architecture": "Architecture"
+    "Architecture": "Architecture",
+    "Custom Fields": "Custom Fields",
+    "Exporting to a CMDB": "Exporting to a CMDB"
   }
 }

--- a/App/FeatureSet/Docs/Locales/es.json
+++ b/App/FeatureSet/Docs/Locales/es.json
@@ -62,7 +62,8 @@
     "Telemetry": "Telemetría",
     "AI": "AI",
     "API Reference": "Referencia de la API",
-    "Self Hosted": "Autoalojado"
+    "Self Hosted": "Autoalojado",
+    "Inventory": "Inventario"
   },
   "navLinks": {
     "Getting Started": "Primeros pasos",
@@ -185,6 +186,8 @@
     "GitHub Integration": "Integración con GitHub",
     "Push Notifications": "Notificaciones push",
     "SendGrid Inbound Email": "Correo entrante de SendGrid",
-    "Architecture": "Arquitectura"
+    "Architecture": "Arquitectura",
+    "Custom Fields": "Campos personalizados",
+    "Exporting to a CMDB": "Exportar a una CMDB"
   }
 }

--- a/App/FeatureSet/Docs/Locales/fr.json
+++ b/App/FeatureSet/Docs/Locales/fr.json
@@ -62,7 +62,8 @@
     "Telemetry": "Télémétrie",
     "AI": "AI",
     "API Reference": "Référence API",
-    "Self Hosted": "Auto-hébergé"
+    "Self Hosted": "Auto-hébergé",
+    "Inventory": "Inventaire"
   },
   "navLinks": {
     "Getting Started": "Démarrage rapide",
@@ -185,6 +186,8 @@
     "GitHub Integration": "Intégration GitHub",
     "Push Notifications": "Notifications push",
     "SendGrid Inbound Email": "E-mail entrant SendGrid",
-    "Architecture": "Architecture"
+    "Architecture": "Architecture",
+    "Custom Fields": "Champs personnalisés",
+    "Exporting to a CMDB": "Exporter vers une CMDB"
   }
 }

--- a/App/FeatureSet/Docs/Locales/hi.json
+++ b/App/FeatureSet/Docs/Locales/hi.json
@@ -62,7 +62,8 @@
     "Telemetry": "टेलीमेट्री",
     "AI": "AI",
     "API Reference": "API संदर्भ",
-    "Self Hosted": "स्व-होस्टेड"
+    "Self Hosted": "स्व-होस्टेड",
+    "Inventory": "इन्वेंटरी"
   },
   "navLinks": {
     "Getting Started": "शुरू करना",
@@ -185,6 +186,8 @@
     "GitHub Integration": "GitHub एकीकरण",
     "Push Notifications": "पुश सूचनाएँ",
     "SendGrid Inbound Email": "SendGrid आने वाला ईमेल",
-    "Architecture": "वास्तुकला"
+    "Architecture": "वास्तुकला",
+    "Custom Fields": "कस्टम फ़ील्ड",
+    "Exporting to a CMDB": "CMDB में निर्यात करना"
   }
 }

--- a/App/FeatureSet/Docs/Locales/it.json
+++ b/App/FeatureSet/Docs/Locales/it.json
@@ -62,7 +62,8 @@
     "Telemetry": "Telemetria",
     "AI": "AI",
     "API Reference": "Riferimento API",
-    "Self Hosted": "Self-hosted"
+    "Self Hosted": "Self-hosted",
+    "Inventory": "Inventario"
   },
   "navLinks": {
     "Getting Started": "Per iniziare",
@@ -185,6 +186,8 @@
     "GitHub Integration": "Integrazione GitHub",
     "Push Notifications": "Notifiche push",
     "SendGrid Inbound Email": "Email in arrivo SendGrid",
-    "Architecture": "Architettura"
+    "Architecture": "Architettura",
+    "Custom Fields": "Campi personalizzati",
+    "Exporting to a CMDB": "Esportare in un CMDB"
   }
 }

--- a/App/FeatureSet/Docs/Locales/ja.json
+++ b/App/FeatureSet/Docs/Locales/ja.json
@@ -62,7 +62,8 @@
     "Telemetry": "テレメトリ",
     "AI": "AI",
     "API Reference": "API リファレンス",
-    "Self Hosted": "セルフホスト"
+    "Self Hosted": "セルフホスト",
+    "Inventory": "インベントリ"
   },
   "navLinks": {
     "Getting Started": "はじめに",
@@ -185,6 +186,8 @@
     "GitHub Integration": "GitHub 統合",
     "Push Notifications": "プッシュ通知",
     "SendGrid Inbound Email": "SendGrid 受信メール",
-    "Architecture": "アーキテクチャ"
+    "Architecture": "アーキテクチャ",
+    "Custom Fields": "カスタムフィールド",
+    "Exporting to a CMDB": "CMDB へのエクスポート"
   }
 }

--- a/App/FeatureSet/Docs/Locales/ko.json
+++ b/App/FeatureSet/Docs/Locales/ko.json
@@ -62,7 +62,8 @@
     "Telemetry": "텔레메트리",
     "AI": "AI",
     "API Reference": "API 참조",
-    "Self Hosted": "자체 호스팅"
+    "Self Hosted": "자체 호스팅",
+    "Inventory": "인벤토리"
   },
   "navLinks": {
     "Getting Started": "시작하기",
@@ -185,6 +186,8 @@
     "GitHub Integration": "GitHub 통합",
     "Push Notifications": "푸시 알림",
     "SendGrid Inbound Email": "SendGrid 수신 이메일",
-    "Architecture": "아키텍처"
+    "Architecture": "아키텍처",
+    "Custom Fields": "사용자 지정 필드",
+    "Exporting to a CMDB": "CMDB로 내보내기"
   }
 }

--- a/App/FeatureSet/Docs/Locales/nl.json
+++ b/App/FeatureSet/Docs/Locales/nl.json
@@ -62,7 +62,8 @@
     "Telemetry": "Telemetrie",
     "AI": "AI",
     "API Reference": "API-referentie",
-    "Self Hosted": "Zelf gehost"
+    "Self Hosted": "Zelf gehost",
+    "Inventory": "Inventaris"
   },
   "navLinks": {
     "Getting Started": "Aan de slag",
@@ -185,6 +186,8 @@
     "GitHub Integration": "GitHub-integratie",
     "Push Notifications": "Pushmeldingen",
     "SendGrid Inbound Email": "SendGrid inkomende e-mail",
-    "Architecture": "Architectuur"
+    "Architecture": "Architectuur",
+    "Custom Fields": "Aangepaste velden",
+    "Exporting to a CMDB": "Exporteren naar een CMDB"
   }
 }

--- a/App/FeatureSet/Docs/Locales/no.json
+++ b/App/FeatureSet/Docs/Locales/no.json
@@ -62,7 +62,8 @@
     "Telemetry": "Telemetri",
     "AI": "AI",
     "API Reference": "API-referanse",
-    "Self Hosted": "Selv-hostet"
+    "Self Hosted": "Selv-hostet",
+    "Inventory": "Inventar"
   },
   "navLinks": {
     "Getting Started": "Kom i gang",
@@ -185,6 +186,8 @@
     "GitHub Integration": "GitHub-integrasjon",
     "Push Notifications": "Push-varsler",
     "SendGrid Inbound Email": "SendGrid innkommende e-post",
-    "Architecture": "Arkitektur"
+    "Architecture": "Arkitektur",
+    "Custom Fields": "Egendefinerte felt",
+    "Exporting to a CMDB": "Eksportere til en CMDB"
   }
 }

--- a/App/FeatureSet/Docs/Locales/pt.json
+++ b/App/FeatureSet/Docs/Locales/pt.json
@@ -62,7 +62,8 @@
     "Telemetry": "Telemetria",
     "AI": "AI",
     "API Reference": "Referência da API",
-    "Self Hosted": "Auto-hospedado"
+    "Self Hosted": "Auto-hospedado",
+    "Inventory": "Inventário"
   },
   "navLinks": {
     "Getting Started": "Primeiros passos",
@@ -185,6 +186,8 @@
     "GitHub Integration": "Integração com GitHub",
     "Push Notifications": "Notificações push",
     "SendGrid Inbound Email": "E-mail recebido SendGrid",
-    "Architecture": "Arquitetura"
+    "Architecture": "Arquitetura",
+    "Custom Fields": "Campos personalizados",
+    "Exporting to a CMDB": "Exportar para um CMDB"
   }
 }

--- a/App/FeatureSet/Docs/Locales/ru.json
+++ b/App/FeatureSet/Docs/Locales/ru.json
@@ -62,7 +62,8 @@
     "Telemetry": "Телеметрия",
     "AI": "AI",
     "API Reference": "Справочник API",
-    "Self Hosted": "Самостоятельный хостинг"
+    "Self Hosted": "Самостоятельный хостинг",
+    "Inventory": "Инвентаризация"
   },
   "navLinks": {
     "Getting Started": "Начало работы",
@@ -185,6 +186,8 @@
     "GitHub Integration": "Интеграция с GitHub",
     "Push Notifications": "Push-уведомления",
     "SendGrid Inbound Email": "Входящие письма SendGrid",
-    "Architecture": "Архитектура"
+    "Architecture": "Архитектура",
+    "Custom Fields": "Пользовательские поля",
+    "Exporting to a CMDB": "Экспорт в CMDB"
   }
 }

--- a/App/FeatureSet/Docs/Locales/sv.json
+++ b/App/FeatureSet/Docs/Locales/sv.json
@@ -62,7 +62,8 @@
     "Telemetry": "Telemetri",
     "AI": "AI",
     "API Reference": "API-referens",
-    "Self Hosted": "Självhostad"
+    "Self Hosted": "Självhostad",
+    "Inventory": "Inventarium"
   },
   "navLinks": {
     "Getting Started": "Kom igång",
@@ -185,6 +186,8 @@
     "GitHub Integration": "GitHub-integration",
     "Push Notifications": "Push-aviseringar",
     "SendGrid Inbound Email": "SendGrid inkommande e-post",
-    "Architecture": "Arkitektur"
+    "Architecture": "Arkitektur",
+    "Custom Fields": "Anpassade fält",
+    "Exporting to a CMDB": "Exportera till en CMDB"
   }
 }

--- a/App/FeatureSet/Docs/Locales/zh-CN.json
+++ b/App/FeatureSet/Docs/Locales/zh-CN.json
@@ -62,7 +62,8 @@
     "Telemetry": "遥测",
     "AI": "AI",
     "API Reference": "API 参考",
-    "Self Hosted": "自托管"
+    "Self Hosted": "自托管",
+    "Inventory": "资产清单"
   },
   "navLinks": {
     "Getting Started": "快速开始",
@@ -185,6 +186,8 @@
     "GitHub Integration": "GitHub 集成",
     "Push Notifications": "推送通知",
     "SendGrid Inbound Email": "SendGrid 入站邮件",
-    "Architecture": "架构"
+    "Architecture": "架构",
+    "Custom Fields": "自定义字段",
+    "Exporting to a CMDB": "导出到 CMDB"
   }
 }

--- a/App/FeatureSet/Docs/Locales/zh-TW.json
+++ b/App/FeatureSet/Docs/Locales/zh-TW.json
@@ -62,7 +62,8 @@
     "Telemetry": "遙測",
     "AI": "AI",
     "API Reference": "API 參考",
-    "Self Hosted": "自架"
+    "Self Hosted": "自架",
+    "Inventory": "資產清單"
   },
   "navLinks": {
     "Getting Started": "快速入門",
@@ -185,6 +186,8 @@
     "GitHub Integration": "GitHub 整合",
     "Push Notifications": "推播通知",
     "SendGrid Inbound Email": "SendGrid 傳入郵件",
-    "Architecture": "架構"
+    "Architecture": "架構",
+    "Custom Fields": "自訂欄位",
+    "Exporting to a CMDB": "匯出至 CMDB"
   }
 }

--- a/App/FeatureSet/Docs/Utils/Nav.ts
+++ b/App/FeatureSet/Docs/Utils/Nav.ts
@@ -578,6 +578,14 @@ const DocsNav: NavGroup[] = [
     ],
   },
   {
+    title: "Inventory",
+    links: [
+      { title: "Overview", url: "/docs/inventory/overview" },
+      { title: "Custom Fields", url: "/docs/inventory/custom-fields" },
+      { title: "Exporting to a CMDB", url: "/docs/inventory/cmdb-sync" },
+    ],
+  },
+  {
     title: "Telemetry",
     links: [
       { title: "OpenTelemetry", url: "/docs/telemetry/open-telemetry" },

--- a/App/FeatureSet/Workers/Jobs/TelemetryEntity/SyncInventoryEntities.ts
+++ b/App/FeatureSet/Workers/Jobs/TelemetryEntity/SyncInventoryEntities.ts
@@ -33,9 +33,22 @@ RunCron(
     try {
       const result: InventorySyncResult = await syncAllInventorySources();
 
-      if (result.created > 0 || result.updated > 0 || result.deleted > 0) {
+      if (
+        result.created > 0 ||
+        result.updated > 0 ||
+        result.deleted > 0 ||
+        result.archived > 0
+      ) {
+        /*
+         * Archived is reported apart from removed because the two are
+         * different events: a removal is a projection catching up with a row
+         * that no longer exists, while an archive is the sweep declining to
+         * delete because the row was carrying custom field values someone
+         * entered. A non-zero archive count is the trail for "where did my
+         * decommissioned device's asset data go".
+         */
         logger.debug(
-          `SyncInventoryEntities: mirrored inventory into the entity registry — ${result.created} created, ${result.updated} updated, ${result.deleted} removed.`,
+          `SyncInventoryEntities: mirrored inventory into the entity registry — ${result.created} created, ${result.updated} updated, ${result.deleted} removed, ${result.archived} archived.`,
         );
       }
     } catch (err) {

--- a/App/Tests/Dashboard/CustomFieldFacets.test.ts
+++ b/App/Tests/Dashboard/CustomFieldFacets.test.ts
@@ -9,9 +9,12 @@ import {
   getCustomFieldFacetOperators,
   getCustomFieldFacetOptions,
   getCustomFieldNameFromFacetKey,
+  isDateCustomField,
   mergeCustomFieldQueryValue,
 } from "../../FeatureSet/Dashboard/src/Components/CustomFields/CustomFieldFacets";
 import {
+  DATE_FACET_OPERATORS,
+  FacetKind,
   FilterChipDropdownOption,
   FilterOperator,
   NUMBER_FACET_OPERATORS,
@@ -22,6 +25,7 @@ import { ResourceFacet } from "../../FeatureSet/Dashboard/src/Components/Resourc
 import EndsWith from "Common/Types/BaseDatabase/EndsWith";
 import GreaterThan from "Common/Types/BaseDatabase/GreaterThan";
 import GreaterThanOrEqual from "Common/Types/BaseDatabase/GreaterThanOrEqual";
+import InBetween from "Common/Types/BaseDatabase/InBetween";
 import Includes from "Common/Types/BaseDatabase/Includes";
 import IncludesNone from "Common/Types/BaseDatabase/IncludesNone";
 import IsNull from "Common/Types/BaseDatabase/IsNull";
@@ -34,6 +38,8 @@ import Search from "Common/Types/BaseDatabase/Search";
 import StartsWith from "Common/Types/BaseDatabase/StartsWith";
 import { CustomFieldDefinition } from "Common/Types/CustomField/CustomFieldDefinition";
 import CustomFieldType from "Common/Types/CustomField/CustomFieldType";
+import OneUptimeDate from "Common/Types/Date";
+import IconProp from "Common/Types/Icon/IconProp";
 import { JSONObject } from "Common/Types/JSON";
 import { describe, expect, test } from "@jest/globals";
 
@@ -631,5 +637,667 @@ describe("names that are hostile to a query builder", () => {
     expect(
       queryFor(definition({ name: "100% Coverage" }), ["v"], "is"),
     ).toEqual({ "100% Coverage": "v" });
+  });
+});
+
+/*
+ * Date custom fields.
+ *
+ * A date is the first custom field type whose chip is neither an option list
+ * nor a typed value: it renders the shared date-range control and hands its
+ * whole operator vocabulary to `buildFacetDateRangeQuery`, so that "warranty
+ * expiry is before the 5th" asked of a key inside the jsonb bag returns the
+ * same rows as the same question asked of a real timestamp column. A user who
+ * has filtered a date anywhere else in the product already knows what these
+ * operators mean, and that knowledge has to keep paying off here.
+ *
+ * Three things about that delegation are easy to break, and each is pinned
+ * below.
+ *
+ * The wrapping. Every other branch here puts its predicate under the field's
+ * name before returning; the date branch has to do the same to the range
+ * builder's output. A predicate that escaped the wrapper would be read as a
+ * constraint on the whole `customFields` column rather than on one key in it.
+ *
+ * The valueless operators. `is_empty` / `is_not_empty` are answered inside the
+ * date branch rather than falling through to the generic one, so a change that
+ * returns early from the branch — or that only routes the four *dated*
+ * operators through it — leaves "is empty" asking about the column.
+ *
+ * The `isDateTime` flag. Both date types share every line of this path and
+ * differ only in whether "is" means the whole calendar day or the exact
+ * instant. Dropping the flag produces a filter that stays right for one of the
+ * two types and goes quietly wrong for the other, which is the kind of bug
+ * that survives a demo.
+ */
+
+const DATE_DEFINITION: CustomFieldDefinition = definition({
+  name: "Warranty Expiry",
+  customFieldType: CustomFieldType.Date,
+});
+
+const DATE_TIME_DEFINITION: CustomFieldDefinition = definition({
+  name: "Last Audited At",
+  customFieldType: CustomFieldType.DateTime,
+});
+
+/** The instant a user picked, in the form the chip stores it. */
+const PICKED: Date = new Date("2026-07-16T09:41:23.456Z");
+const PICKED_END: Date = new Date("2026-07-20T17:02:11.222Z");
+
+const PICKED_VALUE: string = PICKED.toISOString();
+
+/*
+ * A `between` selection is ONE array entry holding both instants joined by a
+ * slash — the facet bar treats an array as a set, so a two-entry range would
+ * be deduplicated and clamped out of existence before it ever reached here.
+ * Spelled out with the literal separator rather than built from
+ * FACET_DATE_RANGE_SEPARATOR: this is the form already sitting in shared URLs,
+ * so a change to it has to break a test rather than follow the constant.
+ */
+const RANGE_VALUE: string = `${PICKED.toISOString()}/${PICKED_END.toISOString()}`;
+
+/** Every type a definition can currently declare, plus the untyped case. */
+const NON_DATE_TYPES: Array<CustomFieldType | undefined> = [
+  CustomFieldType.Text,
+  CustomFieldType.Number,
+  CustomFieldType.Boolean,
+  CustomFieldType.Dropdown,
+  CustomFieldType.MultiSelectDropdown,
+  undefined,
+];
+
+describe("recognising a date custom field", () => {
+  test("both date types are date fields", () => {
+    expect(
+      isDateCustomField(definition({ customFieldType: CustomFieldType.Date })),
+    ).toBe(true);
+    expect(
+      isDateCustomField(
+        definition({ customFieldType: CustomFieldType.DateTime }),
+      ),
+    ).toBe(true);
+  });
+
+  test("no other declared type is a date field", () => {
+    for (const type of NON_DATE_TYPES) {
+      expect(isDateCustomField(definition({ customFieldType: type }))).toBe(
+        false,
+      );
+    }
+  });
+
+  test("a definition with no type at all is not a date field", () => {
+    /*
+     * Worth its own case rather than living in the loop above. The check is
+     * `customFieldType === CustomFieldType.Date`, so if the enum ever lost that
+     * member the right-hand side would be `undefined` and every untyped
+     * definition in the product — the shape a legacy row still has — would
+     * quietly become a calendar chip over free text.
+     */
+    expect(CustomFieldType.Date).toBe("Date");
+    expect(CustomFieldType.DateTime).toBe("DateTime");
+    expect(isDateCustomField(definition({ customFieldType: undefined }))).toBe(
+      false,
+    );
+  });
+
+  test("nothing a later build adds to the enum becomes a date by accident", () => {
+    /*
+     * Read off the enum itself so a member added tomorrow is covered today: a
+     * new type falls to the text chip until someone deliberately teaches this
+     * function about it, rather than inheriting date behaviour it has no
+     * storage format for.
+     */
+    const dateTyped: Array<string> = Object.values(CustomFieldType).filter(
+      (type: string) => {
+        return isDateCustomField(
+          definition({ customFieldType: type as CustomFieldType }),
+        );
+      },
+    );
+
+    expect(dateTyped.sort()).toEqual(["Date", "DateTime"]);
+  });
+});
+
+describe("chip kind for a date custom field", () => {
+  test("a Date field gets the date-range control", () => {
+    expect(getCustomFieldFacetKind(DATE_DEFINITION)).toBe("dateRange");
+  });
+
+  test("a DateTime field gets the date-range control too", () => {
+    /*
+     * The two share a control and differ only in the granularity of "is", so
+     * splitting them into different chip kinds would double the popover for no
+     * user-visible gain.
+     */
+    expect(getCustomFieldFacetKind(DATE_TIME_DEFINITION)).toBe("dateRange");
+  });
+
+  test("stray dropdown options on a date field do not make it a picker", () => {
+    /*
+     * A field edited from Dropdown to Date keeps its old options string in the
+     * definition row. Offering that stale list would let the user filter for
+     * "Low" on a column holding ISO-8601 instants.
+     */
+    expect(
+      getCustomFieldFacetKind(
+        definition({
+          customFieldType: CustomFieldType.Date,
+          dropdownOptions: "Low\nHigh",
+        }),
+      ),
+    ).toBe("dateRange");
+  });
+
+  test("every other type keeps the kind it already had", () => {
+    /*
+     * Pinned as a table because the date branch was inserted into the middle
+     * of this chain of type checks: a branch placed one line too early would
+     * reclassify a neighbouring type, and the only symptom would be the wrong
+     * control appearing in a popover nobody opened during review.
+     */
+    const kindOf: (definition: CustomFieldDefinition) => FacetKind = (
+      def: CustomFieldDefinition,
+    ): FacetKind => {
+      return getCustomFieldFacetKind(def);
+    };
+
+    expect(kindOf(definition({ customFieldType: CustomFieldType.Text }))).toBe(
+      "text",
+    );
+    expect(
+      kindOf(definition({ customFieldType: CustomFieldType.Number })),
+    ).toBe("number");
+    expect(
+      kindOf(definition({ customFieldType: CustomFieldType.Boolean })),
+    ).toBe("options");
+    expect(
+      kindOf(
+        definition({
+          customFieldType: CustomFieldType.Dropdown,
+          dropdownOptions: "Low\nHigh",
+        }),
+      ),
+    ).toBe("options");
+    expect(
+      kindOf(
+        definition({
+          customFieldType: CustomFieldType.MultiSelectDropdown,
+          dropdownOptions: "Low\nHigh",
+        }),
+      ),
+    ).toBe("options");
+    expect(
+      kindOf(
+        definition({
+          customFieldType: CustomFieldType.Dropdown,
+          dropdownOptions: "",
+        }),
+      ),
+    ).toBe("text");
+    expect(kindOf(definition({ customFieldType: undefined }))).toBe("text");
+  });
+
+  test("no non-date type answers dateRange", () => {
+    for (const type of NON_DATE_TYPES) {
+      expect(
+        getCustomFieldFacetKind(
+          definition({ customFieldType: type, dropdownOptions: "Low\nHigh" }),
+        ),
+      ).not.toBe("dateRange");
+    }
+  });
+});
+
+describe("operators for a date custom field", () => {
+  test("a Date field offers the date vocabulary", () => {
+    expect(getCustomFieldFacetOperators(DATE_DEFINITION)).toEqual(
+      DATE_FACET_OPERATORS,
+    );
+  });
+
+  test("a DateTime field offers the same vocabulary", () => {
+    expect(getCustomFieldFacetOperators(DATE_TIME_DEFINITION)).toEqual(
+      DATE_FACET_OPERATORS,
+    );
+  });
+
+  test("that vocabulary excludes is_not and includes the empty pair", () => {
+    /*
+     * `is_not` is absent by design — there is no single-field expression for
+     * "not on this day" that keeps NULLs honest — and the builder returns
+     * undefined for it. If the list ever offered it, the chip would light up
+     * over an unfiltered table. The empty pair, conversely, must be offered:
+     * "warranty expiry is empty" is the question that finds the rows an import
+     * left half-filled.
+     */
+    expect(DATE_FACET_OPERATORS).not.toContain("is_not");
+    expect(DATE_FACET_OPERATORS).toContain("is_empty");
+    expect(DATE_FACET_OPERATORS).toContain("is_not_empty");
+  });
+
+  test("the other kinds keep their own vocabularies", () => {
+    expect(
+      getCustomFieldFacetOperators(
+        definition({ customFieldType: CustomFieldType.Text }),
+      ),
+    ).toEqual(TEXT_FACET_OPERATORS);
+    expect(
+      getCustomFieldFacetOperators(
+        definition({ customFieldType: CustomFieldType.Number }),
+      ),
+    ).toEqual(NUMBER_FACET_OPERATORS);
+    expect(
+      getCustomFieldFacetOperators(
+        definition({ customFieldType: CustomFieldType.Boolean }),
+      ),
+    ).toEqual(OPTION_FACET_OPERATORS);
+    expect(
+      getCustomFieldFacetOperators(
+        definition({
+          customFieldType: CustomFieldType.MultiSelectDropdown,
+          dropdownOptions: "Low\nHigh",
+        }),
+      ),
+    ).toEqual(OPTION_FACET_OPERATORS);
+    expect(
+      getCustomFieldFacetOperators(definition({ customFieldType: undefined })),
+    ).toEqual(TEXT_FACET_OPERATORS);
+  });
+});
+
+describe("building the query — a Date custom field", () => {
+  test("wraps the predicate under the field's name", () => {
+    /*
+     * The one thing this module adds on top of the shared range builder. An
+     * unwrapped InBetween would be read as a constraint on the whole
+     * `customFields` column — comparing a jsonb object against a timestamp —
+     * rather than on the one key the chip is named after.
+     */
+    const query: JSONObject | undefined = queryFor(
+      DATE_DEFINITION,
+      [PICKED_VALUE],
+      "is",
+    );
+
+    expect(Object.keys(query!)).toEqual(["Warranty Expiry"]);
+  });
+
+  test("is spans the whole picked day", () => {
+    /*
+     * A warranty expiring at 09:41 is still expiring "on the 16th". Matching
+     * the midnight instant instead would return nothing for almost every row,
+     * under a chip claiming to show that day.
+     */
+    const query: JSONObject | undefined = queryFor(
+      DATE_DEFINITION,
+      [PICKED_VALUE],
+      "is",
+    );
+    const predicate: InBetween<Date> = query![
+      "Warranty Expiry"
+    ] as unknown as InBetween<Date>;
+
+    expect(predicate).toBeInstanceOf(InBetween);
+    expect(predicate.startValue).toEqual(OneUptimeDate.getStartOfDay(PICKED));
+    expect(predicate.endValue).toEqual(OneUptimeDate.getEndOfDay(PICKED));
+  });
+
+  test("that day span actually contains the picked instant", () => {
+    // The invariant the two boundaries exist to satisfy, stated directly.
+    const predicate: InBetween<Date> = queryFor(
+      DATE_DEFINITION,
+      [PICKED_VALUE],
+      "is",
+    )!["Warranty Expiry"] as unknown as InBetween<Date>;
+
+    expect(predicate.startValue.getTime()).toBeLessThanOrEqual(
+      PICKED.getTime(),
+    );
+    expect(predicate.endValue.getTime()).toBeGreaterThanOrEqual(
+      PICKED.getTime(),
+    );
+  });
+
+  test("before is a LessThan at the picked instant", () => {
+    const predicate: unknown = queryFor(
+      DATE_DEFINITION,
+      [PICKED_VALUE],
+      "before",
+    )!["Warranty Expiry"];
+
+    expect(predicate).toBeInstanceOf(LessThan);
+    expect(predicate).not.toBeInstanceOf(LessThanOrEqual);
+    expect((predicate as LessThan<Date>).value).toEqual(PICKED);
+  });
+
+  test("after is a GreaterThan at the picked instant", () => {
+    const predicate: unknown = queryFor(
+      DATE_DEFINITION,
+      [PICKED_VALUE],
+      "after",
+    )!["Warranty Expiry"];
+
+    expect(predicate).toBeInstanceOf(GreaterThan);
+    expect(predicate).not.toBeInstanceOf(GreaterThanOrEqual);
+    expect((predicate as GreaterThan<Date>).value).toEqual(PICKED);
+  });
+
+  test("between with both ends spans start-of-first to end-of-last day", () => {
+    const predicate: InBetween<Date> = queryFor(
+      DATE_DEFINITION,
+      [RANGE_VALUE],
+      "between",
+    )!["Warranty Expiry"] as unknown as InBetween<Date>;
+
+    expect(predicate).toBeInstanceOf(InBetween);
+    expect(predicate.startValue).toEqual(OneUptimeDate.getStartOfDay(PICKED));
+    expect(predicate.endValue).toEqual(OneUptimeDate.getEndOfDay(PICKED_END));
+  });
+
+  test("between with only a start constrains nothing", () => {
+    /*
+     * The user is mid-way through picking the pair. Constraining on the half
+     * they have entered would make the table jump to a filter they never
+     * finished asking for.
+     */
+    expect(
+      queryFor(DATE_DEFINITION, [`${PICKED_VALUE}/`], "between"),
+    ).toBeUndefined();
+  });
+
+  test("between with only an end constrains nothing either", () => {
+    expect(
+      queryFor(DATE_DEFINITION, [`/${PICKED_END.toISOString()}`], "between"),
+    ).toBeUndefined();
+  });
+
+  test("is_empty asks about the key, through the date branch", () => {
+    /*
+     * The date branch answers this itself rather than letting it fall through
+     * to the generic handler below it. Both produce IsNull today, so the only
+     * way to keep the delegation honest is to assert the result exists and is
+     * wrapped — a date branch that returned early without handling it would
+     * hand back `undefined` and quietly stop filtering.
+     */
+    const query: JSONObject | undefined = queryFor(
+      DATE_DEFINITION,
+      [],
+      "is_empty",
+    );
+
+    expect(Object.keys(query!)).toEqual(["Warranty Expiry"]);
+    expect(query!["Warranty Expiry"]).toBeInstanceOf(IsNull);
+  });
+
+  test("is_not_empty likewise", () => {
+    const query: JSONObject | undefined = queryFor(
+      DATE_DEFINITION,
+      [],
+      "is_not_empty",
+    );
+
+    expect(query!["Warranty Expiry"]).toBeInstanceOf(NotNull);
+  });
+
+  test("the empty operators need no date picked", () => {
+    // They are the two operators whose popover shows no date input at all.
+    expect(queryFor(DATE_DEFINITION, [], "is_empty")).toBeDefined();
+    expect(queryFor(DATE_DEFINITION, [PICKED_VALUE], "is_empty")).toBeDefined();
+  });
+
+  test("is_not constrains nothing", () => {
+    /*
+     * A date chip does not offer it, so it can only arrive from a hand-edited
+     * URL or a view saved against a different chip kind. Inventing a predicate
+     * for it would drop every row whose value is NULL, which is not what "is
+     * not the 16th" says.
+     */
+    expect(queryFor(DATE_DEFINITION, [PICKED_VALUE], "is_not")).toBeUndefined();
+  });
+
+  test("no date picked constrains nothing, on every dated operator", () => {
+    for (const operator of [
+      "is",
+      "before",
+      "after",
+      "between",
+    ] as Array<FilterOperator>) {
+      expect(queryFor(DATE_DEFINITION, [], operator)).toBeUndefined();
+    }
+  });
+
+  test("a value that is not a date constrains nothing", () => {
+    /*
+     * The platform's date parser is lenient enough to read "0" as the year
+     * 2000. A junk value that became a filter for January 2000 would empty the
+     * table and explain it with a date nobody picked.
+     */
+    expect(queryFor(DATE_DEFINITION, ["0"], "is")).toBeUndefined();
+    expect(queryFor(DATE_DEFINITION, ["yesterday"], "before")).toBeUndefined();
+    expect(queryFor(DATE_DEFINITION, ["   "], "after")).toBeUndefined();
+  });
+});
+
+describe("building the query — a DateTime custom field", () => {
+  test("is matches the instant, not the day around it", () => {
+    /*
+     * The whole reason the `isDateTime` flag is threaded through. "Last
+     * audited at 09:41" means that moment; widening it to the day would match
+     * every other audit that happened between midnight and midnight, and the
+     * chip would read as an exact time while filtering as a date.
+     */
+    const predicate: InBetween<Date> = queryFor(
+      DATE_TIME_DEFINITION,
+      [PICKED_VALUE],
+      "is",
+    )!["Last Audited At"] as unknown as InBetween<Date>;
+
+    expect(predicate).toBeInstanceOf(InBetween);
+    expect(predicate.startValue).toEqual(PICKED);
+    expect(predicate.endValue).toEqual(PICKED);
+    expect(predicate.startValue.getTime()).toBe(predicate.endValue.getTime());
+  });
+
+  test("between keeps the two instants exactly as picked", () => {
+    const predicate: InBetween<Date> = queryFor(
+      DATE_TIME_DEFINITION,
+      [RANGE_VALUE],
+      "between",
+    )!["Last Audited At"] as unknown as InBetween<Date>;
+
+    expect(predicate.startValue).toEqual(PICKED);
+    expect(predicate.endValue).toEqual(PICKED_END);
+  });
+
+  test("a Date field and a DateTime field disagree about is, and only about is", () => {
+    /*
+     * Stated as a pair so that a regression collapsing the two types into one
+     * branch — in either direction — fails here rather than in whichever of
+     * the two happens to be exercised first.
+     */
+    const dateIs: InBetween<Date> = queryFor(
+      DATE_DEFINITION,
+      [PICKED_VALUE],
+      "is",
+    )!["Warranty Expiry"] as unknown as InBetween<Date>;
+    const dateTimeIs: InBetween<Date> = queryFor(
+      DATE_TIME_DEFINITION,
+      [PICKED_VALUE],
+      "is",
+    )!["Last Audited At"] as unknown as InBetween<Date>;
+
+    expect(dateIs.startValue.getTime()).not.toBe(
+      dateTimeIs.startValue.getTime(),
+    );
+    expect(
+      (
+        queryFor(DATE_TIME_DEFINITION, [PICKED_VALUE], "before")![
+          "Last Audited At"
+        ] as unknown as LessThan<Date>
+      ).value,
+    ).toEqual(PICKED);
+    expect(
+      (
+        queryFor(DATE_TIME_DEFINITION, [PICKED_VALUE], "after")![
+          "Last Audited At"
+        ] as unknown as GreaterThan<Date>
+      ).value,
+    ).toEqual(PICKED);
+  });
+
+  test("the empty operators behave the same for both date types", () => {
+    expect(
+      queryFor(DATE_TIME_DEFINITION, [], "is_empty")!["Last Audited At"],
+    ).toBeInstanceOf(IsNull);
+    expect(
+      queryFor(DATE_TIME_DEFINITION, [], "is_not_empty")!["Last Audited At"],
+    ).toBeInstanceOf(NotNull);
+  });
+
+  test("a half-entered range constrains nothing for a DateTime field either", () => {
+    expect(
+      queryFor(DATE_TIME_DEFINITION, [`${PICKED_VALUE}/`], "between"),
+    ).toBeUndefined();
+  });
+});
+
+describe("a date field with no name", () => {
+  test("constrains nothing, whatever the operator", () => {
+    /*
+     * A definition row mid-rename has an empty name, and the key it would wrap
+     * the predicate under is `""` — a key no resource's customFields bag has,
+     * so the table would go empty rather than unfiltered. Checked across the
+     * whole vocabulary because the name guard sits above the date branch and a
+     * reordering would slip the valueless operators past it.
+     */
+    for (const operator of DATE_FACET_OPERATORS) {
+      expect(
+        queryFor(
+          definition({ name: "", customFieldType: CustomFieldType.Date }),
+          [PICKED_VALUE],
+          operator,
+        ),
+      ).toBeUndefined();
+    }
+  });
+});
+
+describe("buildCustomFieldFacets — a date chip", () => {
+  const dateFacets: Array<ResourceFacet> = buildCustomFieldFacets([
+    { name: "Warranty Expiry", customFieldType: CustomFieldType.Date },
+    { name: "Last Audited At", customFieldType: CustomFieldType.DateTime },
+    { name: "Team", customFieldType: CustomFieldType.Text },
+  ]);
+
+  test("declares itself a dateRange chip", () => {
+    /*
+     * The shared bar keys its date behaviour off `facet.type` — which control
+     * the popover renders, whether the selection is parsed as a range, how the
+     * chip's label is formatted. A chip whose query is a date but whose type
+     * is not would render a text box that writes ISO strings by hand.
+     */
+    expect(dateFacets[0]!.type).toBe("dateRange");
+    expect(dateFacets[1]!.type).toBe("dateRange");
+    expect(dateFacets[2]!.type).toBe("text");
+  });
+
+  test("wears a calendar rather than the text or list icon", () => {
+    expect(dateFacets[0]!.icon).toBe(IconProp.Calendar);
+    expect(dateFacets[1]!.icon).toBe(IconProp.Calendar);
+    expect(dateFacets[2]!.icon).toBe(IconProp.Text);
+  });
+
+  test("offers the date operator list", () => {
+    expect(dateFacets[0]!.supportedOperators).toEqual(DATE_FACET_OPERATORS);
+    expect(dateFacets[1]!.supportedOperators).toEqual(DATE_FACET_OPERATORS);
+  });
+
+  test("is single-select and carries no options", () => {
+    /*
+     * Both matter to the shared plumbing: the single-select clamp in
+     * `sanitizeFacetSelectionState` is what keeps a range's two instants
+     * inside one array entry, and an option list on a date chip would make the
+     * popover offer a picker over instants nobody can enumerate.
+     */
+    expect(dateFacets[0]!.isMultiSelect).toBe(false);
+    expect(dateFacets[1]!.isMultiSelect).toBe(false);
+    expect(dateFacets[0]!.options).toBeUndefined();
+  });
+
+  test("still shares the customFields column like every other chip", () => {
+    expect(dateFacets[0]!.queryField).toBe(CUSTOM_FIELD_QUERY_FIELD);
+    expect(dateFacets[0]!.mergeQueryValue).toBeDefined();
+    expect(dateFacets[0]!.handlesValuelessOperators).toBe(true);
+  });
+
+  test("routes toQueryValue through the same date builder", () => {
+    const query: JSONObject = dateFacets[0]!.toQueryValue!(
+      [PICKED_VALUE],
+      "is",
+    ) as JSONObject;
+
+    expect(query["Warranty Expiry"]).toBeInstanceOf(InBetween);
+  });
+
+  test("claiming handlesValuelessOperators is not an empty promise", () => {
+    /*
+     * The flag tells the bar to call `toQueryValue` for is_empty rather than
+     * writing IsNull at the column itself. If the date path came back
+     * undefined for it, the bar would have handed the operator to a chip that
+     * dropped it and the column would go unconstrained.
+     */
+    expect(dateFacets[1]!.toQueryValue!([], "is_empty")).toEqual({
+      "Last Audited At": new IsNull(),
+    });
+  });
+});
+
+describe("merging a date chip with a text chip", () => {
+  test("ANDs both into one object over the shared column", () => {
+    /*
+     * Two chips, one jsonb column. The date chip arriving last must not
+     * replace the text chip's predicate while both stay lit on the bar — the
+     * failure this whole merge exists to prevent, now reachable from a chip
+     * kind whose query value is built somewhere else entirely.
+     */
+    const text: JSONObject = queryFor(
+      definition({ name: "Team" }),
+      ["Payments"],
+      "is",
+    )!;
+    const date: JSONObject = queryFor(
+      DATE_DEFINITION,
+      [PICKED_VALUE],
+      "before",
+    )!;
+
+    const merged: JSONObject = mergeCustomFieldQueryValue(
+      text,
+      date,
+    ) as JSONObject;
+
+    expect(Object.keys(merged).sort()).toEqual(["Team", "Warranty Expiry"]);
+    expect(merged["Team"]).toBe("Payments");
+    expect(merged["Warranty Expiry"]).toBeInstanceOf(LessThan);
+  });
+
+  test("order does not change what survives the merge", () => {
+    const text: JSONObject = queryFor(
+      definition({ name: "Team" }),
+      ["Payments"],
+      "is",
+    )!;
+    const date: JSONObject = queryFor(DATE_DEFINITION, [], "is_empty")!;
+
+    const merged: JSONObject = mergeCustomFieldQueryValue(
+      date,
+      text,
+    ) as JSONObject;
+
+    expect(merged["Team"]).toBe("Payments");
+    expect(merged["Warranty Expiry"]).toBeInstanceOf(IsNull);
   });
 });

--- a/Common/Server/Types/Database/JSONColumnQuery.ts
+++ b/Common/Server/Types/Database/JSONColumnQuery.ts
@@ -154,6 +154,18 @@ const toScalar: ToScalarFunction = (value: unknown): ScalarValue => {
     return value.toString();
   }
 
+  /*
+   * A Date only reaches here from a query built server-side: one that arrived
+   * over HTTP has already been through JSON, which renders a Date as its ISO
+   * string. Both paths must produce the same text, because the ordering
+   * comparisons below are lexicographic and only ISO-8601 makes that
+   * chronological. The `String(value)` fallback would yield
+   * "Sun Aug 17 2026 00:00:00 GMT+0000", which sorts by weekday name.
+   */
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
   if (value === null || value === undefined) {
     return "";
   }
@@ -314,6 +326,32 @@ class KeyPredicateBuilder {
   }
 
   /**
+   * An ordering comparison against a value whose type we only learn at runtime.
+   *
+   * A jsonb key holds whatever the project put there, so `>` has two readings.
+   * Numbers compare numerically — "10" must be greater than "9", which text
+   * comparison gets backwards. Everything else compares as text, and the case
+   * that matters is a date: custom field dates are stored as ISO-8601 strings,
+   * and ISO-8601 is designed so that lexicographic order IS chronological
+   * order, so `>=` over the raw text is already the right question.
+   *
+   * Routing dates through compareNumeric — which is what these operators used
+   * to do unconditionally — was silently wrong rather than loudly wrong.
+   * `Number("2026-08-17T00:00:00.000Z")` is NaN, so the bound parameter became
+   * `CAST(NaN AS NUMERIC)`, and `numericExpression` independently returns NULL
+   * for text that does not look like a number. The predicate was therefore
+   * `NULL > NaN` on every row: no error, no rows, and a lit filter chip over an
+   * empty table.
+   *
+   * InBetween has always branched this way; these four now agree with it.
+   */
+  private compareOrdered(operator: string, value: unknown): PredicateFragment {
+    return isNumericValue(toScalar(value))
+      ? this.compareNumeric(operator, value)
+      : this.compareText(operator, value);
+  }
+
+  /**
    * "No value here" — the key is absent, explicitly JSON null, an empty
    * string, or an empty array. A multi-select cleared in the UI leaves `[]`
    * behind rather than dropping the key, and a user reading "is empty" on the
@@ -466,19 +504,19 @@ class KeyPredicateBuilder {
     }
 
     if (value instanceof GreaterThanOrEqual) {
-      return this.compareNumeric(">=", value.value);
+      return this.compareOrdered(">=", value.value);
     }
 
     if (value instanceof GreaterThan) {
-      return this.compareNumeric(">", value.value);
+      return this.compareOrdered(">", value.value);
     }
 
     if (value instanceof LessThanOrEqual) {
-      return this.compareNumeric("<=", value.value);
+      return this.compareOrdered("<=", value.value);
     }
 
     if (value instanceof LessThan) {
-      return this.compareNumeric("<", value.value);
+      return this.compareOrdered("<", value.value);
     }
 
     /*

--- a/Common/Server/Utils/Telemetry/InventoryEntityRegistry.ts
+++ b/Common/Server/Utils/Telemetry/InventoryEntityRegistry.ts
@@ -353,8 +353,8 @@ function defineInventorySource<TModel extends BaseModel>(
 
 /*
  * Archived rows are excluded from every source that has the concept: the
- * explorer is a view of the live estate. IoTDevice and NetworkDevice have no
- * archive flag, so their queries are unrestricted.
+ * explorer is a view of the live estate. IoTDevice is the only source without
+ * an archive flag, so it is the only unrestricted query.
  */
 export const INVENTORY_SOURCES: ReadonlyArray<ErasedInventorySource> = [
   defineInventorySource<NetworkDevice>({
@@ -362,7 +362,7 @@ export const INVENTORY_SOURCES: ReadonlyArray<ErasedInventorySource> = [
     resourceType: "NetworkDevice",
     service: NetworkDeviceService,
     select: { hostname: true },
-    query: {},
+    query: { isArchived: false },
     describe: (row: NetworkDevice): Dictionary<string> => {
       return compactAttributes({ "net.device.hostname": row.hostname });
     },
@@ -469,6 +469,12 @@ export interface InventorySyncResult {
   created: number;
   updated: number;
   deleted: number;
+  /**
+   * Orphans that were archived rather than deleted because they carried custom
+   * field values. Counted apart from `deleted` so the job log distinguishes
+   * "the projection went away" from "we kept someone's data".
+   */
+  archived: number;
 }
 
 /**
@@ -579,15 +585,133 @@ async function mirrorRows(
 }
 
 /**
- * Reverse pass: a mirrored row whose owning inventory row is gone is
- * deleted. This is what catches cascade deletes, which fire no service hook.
+ * Does this row carry anything a person typed?
+ *
+ * The `customFields` bag is the only user-authored content a mirrored row can
+ * hold — every other column on it is rewritten from the owning table on each
+ * pass — so it is the whole test for "deleting this loses work".
+ *
+ * An empty bag counts as nothing: the UI leaves `{}` behind when the last
+ * value is cleared, and a row whose fields were all emptied is not one anyone
+ * is keeping. A key explicitly set to null or "" is likewise not a value.
  */
-async function removeOrphans(source: ErasedInventorySource): Promise<number> {
-  const orphanIds: Array<ObjectID> = [];
+export type HasCustomFieldValuesFunction = (row: InventoryItem) => boolean;
+
+export const hasCustomFieldValues: HasCustomFieldValuesFunction = (
+  row: InventoryItem,
+): boolean => {
+  const bag: JSONObject | undefined = row.customFields;
+
+  if (!bag || typeof bag !== "object") {
+    return false;
+  }
+
+  return Object.keys(bag).some((key: string) => {
+    const value: unknown = (bag as JSONObject)[key];
+
+    if (value === undefined || value === null || value === "") {
+      return false;
+    }
+
+    return !(Array.isArray(value) && value.length === 0);
+  });
+};
+
+export interface OrphanPartition {
+  /** Orphans safe to remove outright — pure projections, nothing typed. */
+  deletableIds: Array<ObjectID>;
+  /** Orphans that must be kept, because they carry user-authored values. */
+  archivableIds: Array<ObjectID>;
+}
+
+export type PartitionOrphanRowsFunction = (data: {
+  rows: Array<InventoryItem>;
+  /** Ids still present in the owning table, from `findLiveIds`. */
+  liveResourceIds: Set<string>;
+}) => OrphanPartition;
+
+/**
+ * The whole decision the reverse pass makes, as a pure function of one page of
+ * registry rows and the set of owning-table ids that still exist.
+ *
+ * Split out from the IO because this is where a mistake destroys data and
+ * where a test can actually reach: getting it wrong either hard-deletes rows
+ * holding the only copy of someone's serial numbers, or lets the registry
+ * accumulate projections of devices that no longer exist.
+ */
+export const partitionOrphanRows: PartitionOrphanRowsFunction = (data: {
+  rows: Array<InventoryItem>;
+  liveResourceIds: Set<string>;
+}): OrphanPartition => {
+  const deletableIds: Array<ObjectID> = [];
+  const archivableIds: Array<ObjectID> = [];
+
+  for (const row of data.rows || []) {
+    if (!row.id) {
+      continue;
+    }
+
+    /*
+     * A mirrored row with no pointer cannot be matched back to anything, so
+     * it is orphaned by definition.
+     */
+    const isOrphan: boolean =
+      !row.resourceId || !data.liveResourceIds.has(row.resourceId.toString());
+
+    if (!isOrphan) {
+      continue;
+    }
+
+    if (!hasCustomFieldValues(row)) {
+      deletableIds.push(row.id);
+      continue;
+    }
+
+    /*
+     * Already archived on an earlier sweep. Re-archiving would rewrite
+     * `archivedAt` on every 15-minute pass, so the timestamp would report the
+     * most recent sweep rather than when the device went away.
+     */
+    if (row.isArchived) {
+      continue;
+    }
+
+    archivableIds.push(row.id);
+  }
+
+  return { deletableIds, archivableIds };
+};
+
+/**
+ * Reverse pass: a mirrored row whose owning inventory row is gone stops being
+ * part of the live estate. This is what catches cascade deletes, which fire no
+ * service hook.
+ *
+ * Orphans split two ways, on whether the row holds anything a person typed:
+ *
+ *  - nothing typed: hard-deleted, as before. The row was a pure projection of
+ *    a table row that no longer exists, so there is nothing to keep.
+ *
+ *  - custom field values present: ARCHIVED, not deleted. Those values are the
+ *    only copy — serial numbers, warranty dates, owning team — and they live
+ *    on the registry row rather than on the device, so deleting the projection
+ *    destroys them with no undo and no audit trail (`hardDeleteBy` bypasses
+ *    the audit hook). Archiving takes the row out of the default list, which
+ *    is the visible behaviour the delete was there to produce, and leaves the
+ *    data recoverable from the Archived tab.
+ *
+ * The cost of being wrong differs by orders of magnitude between the two, which
+ * is why the split is here and not left to an operator's retention policy.
+ */
+async function removeOrphans(
+  source: ErasedInventorySource,
+): Promise<{ deleted: number; archived: number }> {
+  const deletableIds: Array<ObjectID> = [];
+  const archivableIds: Array<ObjectID> = [];
   let skip: number = 0;
 
   /*
-   * Collected across a read-only pass and deleted afterwards. Deleting while
+   * Collected across a read-only pass and written afterwards. Writing while
    * paging would shift subsequent offsets and skip rows.
    */
   for (;;) {
@@ -596,7 +720,12 @@ async function removeOrphans(source: ErasedInventorySource): Promise<number> {
         entityType: source.entityType,
         source: EntitySource.Inventory,
       },
-      select: { _id: true, resourceId: true },
+      select: {
+        _id: true,
+        resourceId: true,
+        customFields: true,
+        isArchived: true,
+      },
       skip,
       limit: INVENTORY_SYNC_PAGE_SIZE,
       props: { isRoot: true },
@@ -614,16 +743,13 @@ async function removeOrphans(source: ErasedInventorySource): Promise<number> {
     }
 
     const liveIds: Set<string> = await source.findLiveIds(resourceIds);
+    const partition: OrphanPartition = partitionOrphanRows({
+      rows: rows,
+      liveResourceIds: liveIds,
+    });
 
-    for (const row of rows) {
-      /*
-       * A mirrored row with no pointer cannot be matched back to anything,
-       * so it is orphaned by definition.
-       */
-      if (!row.resourceId || !liveIds.has(row.resourceId.toString())) {
-        orphanIds.push(row.id!);
-      }
-    }
+    deletableIds.push(...partition.deletableIds);
+    archivableIds.push(...partition.archivableIds);
 
     skip += rows.length;
 
@@ -632,26 +758,42 @@ async function removeOrphans(source: ErasedInventorySource): Promise<number> {
     }
   }
 
-  if (orphanIds.length === 0) {
-    return 0;
+  if (deletableIds.length > 0) {
+    await InventoryItemService.hardDeleteBy({
+      query: {
+        _id: QueryHelper.any(
+          deletableIds.map((id: ObjectID) => {
+            return id.toString();
+          }),
+        ),
+        // Re-asserted so a bug upstream can never widen this into a broad delete.
+        source: EntitySource.Inventory,
+      },
+      limit: deletableIds.length,
+      skip: 0,
+      props: { isRoot: true },
+    });
   }
 
-  await InventoryItemService.hardDeleteBy({
-    query: {
-      _id: QueryHelper.any(
-        orphanIds.map((id: ObjectID) => {
-          return id.toString();
-        }),
-      ),
-      // Re-asserted so a bug upstream can never widen this into a broad delete.
-      source: EntitySource.Inventory,
-    },
-    limit: orphanIds.length,
-    skip: 0,
-    props: { isRoot: true },
-  });
+  if (archivableIds.length > 0) {
+    await InventoryItemService.updateBy({
+      query: {
+        _id: QueryHelper.any(
+          archivableIds.map((id: ObjectID) => {
+            return id.toString();
+          }),
+        ),
+        // Same reason as the delete above: never widen past mirrored rows.
+        source: EntitySource.Inventory,
+      },
+      data: { isArchived: true },
+      limit: archivableIds.length,
+      skip: 0,
+      props: { isRoot: true },
+    });
+  }
 
-  return orphanIds.length;
+  return { deleted: deletableIds.length, archived: archivableIds.length };
 }
 
 /** Reconciles one inventory table into the registry. */
@@ -659,8 +801,8 @@ export async function syncInventorySource(
   source: ErasedInventorySource,
 ): Promise<InventorySyncResult> {
   const { created, updated } = await mirrorRows(source);
-  const deleted: number = await removeOrphans(source);
-  return { created, updated, deleted };
+  const { deleted, archived } = await removeOrphans(source);
+  return { created, updated, deleted, archived };
 }
 
 /**
@@ -669,7 +811,12 @@ export async function syncInventorySource(
  * should not stop network devices being mirrored.
  */
 export async function syncAllInventorySources(): Promise<InventorySyncResult> {
-  const total: InventorySyncResult = { created: 0, updated: 0, deleted: 0 };
+  const total: InventorySyncResult = {
+    created: 0,
+    updated: 0,
+    deleted: 0,
+    archived: 0,
+  };
 
   for (const source of INVENTORY_SOURCES) {
     try {
@@ -677,6 +824,7 @@ export async function syncAllInventorySources(): Promise<InventorySyncResult> {
       total.created += result.created;
       total.updated += result.updated;
       total.deleted += result.deleted;
+      total.archived += result.archived;
     } catch (err) {
       logger.error(
         `InventoryEntityRegistry: sync failed for ${source.resourceType}:`,

--- a/Common/Tests/Server/Types/Database/JSONColumnQuery.test.ts
+++ b/Common/Tests/Server/Types/Database/JSONColumnQuery.test.ts
@@ -10,6 +10,7 @@ import EqualTo from "../../../../Types/BaseDatabase/EqualTo";
 import EqualToOrNull from "../../../../Types/BaseDatabase/EqualToOrNull";
 import GreaterThan from "../../../../Types/BaseDatabase/GreaterThan";
 import GreaterThanOrEqual from "../../../../Types/BaseDatabase/GreaterThanOrEqual";
+import GreaterThanOrNull from "../../../../Types/BaseDatabase/GreaterThanOrNull";
 import InBetween from "../../../../Types/BaseDatabase/InBetween";
 import Includes from "../../../../Types/BaseDatabase/Includes";
 import IncludesAll from "../../../../Types/BaseDatabase/IncludesAll";
@@ -589,5 +590,512 @@ describe("buildJSONColumnQuery — parameter hygiene", () => {
     for (const placeholder of placeholders) {
       expect(query.parameters).toHaveProperty(placeholder);
     }
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Ordering comparisons over a Date custom field
+ * ---------------------------------------------------------------------------
+ *
+ * A Date / DateTime custom field stores its value as an ISO-8601 UTC string,
+ * because jsonb has no date type and the column is shared by every field the
+ * project defines. "Renewal is after 2026-08-17" therefore reaches this module
+ * as `GreaterThan("2026-08-17T00:00:00.000Z")` — a string operand on an
+ * operator that, until compareOrdered existed, cast unconditionally to NUMERIC.
+ *
+ * The failure that produced was the quiet kind. `Number("2026-08-17T...")` is
+ * NaN, so the bound parameter rendered as `CAST(NaN AS NUMERIC)`, and
+ * numericExpression independently returns NULL for text that does not match the
+ * numeric regex. Every row was evaluated as `NULL > NaN` — never an error,
+ * never true — so the product showed a lit filter chip above an empty table and
+ * nothing anywhere said why. These tests exist so that shape cannot return.
+ */
+
+type OrderedOperatorCase = {
+  name: string;
+  sqlOperator: string;
+  operatorFor: (value: string) => JSONObject[string];
+};
+
+const ORDERED_OPERATORS: Array<OrderedOperatorCase> = [
+  {
+    name: "GreaterThan",
+    sqlOperator: ">",
+    operatorFor: (value: string): JSONObject[string] => {
+      return new GreaterThan(value);
+    },
+  },
+  {
+    name: "GreaterThanOrEqual",
+    sqlOperator: ">=",
+    operatorFor: (value: string): JSONObject[string] => {
+      return new GreaterThanOrEqual(value);
+    },
+  },
+  {
+    name: "LessThan",
+    sqlOperator: "<",
+    operatorFor: (value: string): JSONObject[string] => {
+      return new LessThan(value);
+    },
+  },
+  {
+    name: "LessThanOrEqual",
+    sqlOperator: "<=",
+    operatorFor: (value: string): JSONObject[string] => {
+      return new LessThanOrEqual(value);
+    },
+  },
+];
+
+const ISO_INSTANT: string = "2026-08-17T00:00:00.000Z";
+
+describe("buildJSONColumnQuery — ordered comparison against an ISO-8601 date", () => {
+  test("GreaterThan reads the key as text and compares against TEXT", () => {
+    const query: JSONColumnQuery = build({
+      Renewal: new GreaterThan(ISO_INSTANT),
+    });
+
+    expect(query.toSql(COLUMN)).toContain(
+      `${COLUMN} ->> CAST(:p1 AS TEXT) > CAST(:p2 AS TEXT)`,
+    );
+    expect(query.parameters["p2"]).toBe(ISO_INSTANT);
+  });
+
+  test("GreaterThanOrEqual reads the key as text and compares against TEXT", () => {
+    const query: JSONColumnQuery = build({
+      Renewal: new GreaterThanOrEqual(ISO_INSTANT),
+    });
+
+    expect(query.toSql(COLUMN)).toContain(
+      `${COLUMN} ->> CAST(:p1 AS TEXT) >= CAST(:p2 AS TEXT)`,
+    );
+    expect(query.parameters["p2"]).toBe(ISO_INSTANT);
+  });
+
+  test("LessThan reads the key as text and compares against TEXT", () => {
+    const query: JSONColumnQuery = build({
+      Renewal: new LessThan(ISO_INSTANT),
+    });
+
+    expect(query.toSql(COLUMN)).toContain(
+      `${COLUMN} ->> CAST(:p1 AS TEXT) < CAST(:p2 AS TEXT)`,
+    );
+    expect(query.parameters["p2"]).toBe(ISO_INSTANT);
+  });
+
+  test("LessThanOrEqual reads the key as text and compares against TEXT", () => {
+    const query: JSONColumnQuery = build({
+      Renewal: new LessThanOrEqual(ISO_INSTANT),
+    });
+
+    expect(query.toSql(COLUMN)).toContain(
+      `${COLUMN} ->> CAST(:p1 AS TEXT) <= CAST(:p2 AS TEXT)`,
+    );
+    expect(query.parameters["p2"]).toBe(ISO_INSTANT);
+  });
+
+  test("a date-only value compares as text too", () => {
+    /*
+     * A Date (rather than DateTime) custom field stores "2026-08-17" with no
+     * time part. It is still not a number, so it still has to take the text
+     * arm — the Date and DateTime variants of the same field must not disagree
+     * about whether their filter works.
+     */
+    const query: JSONColumnQuery = build({
+      Renewal: new GreaterThan("2026-08-17"),
+    });
+
+    expect(query.toSql(COLUMN)).toContain("> CAST(:p2 AS TEXT)");
+    expect(query.parameters["p2"]).toBe("2026-08-17");
+  });
+});
+
+describe("buildJSONColumnQuery — the date-as-NaN regression", () => {
+  test.each(ORDERED_OPERATORS)(
+    "$name binds the ISO string itself, never NaN",
+    (operatorCase: OrderedOperatorCase) => {
+      /*
+       * The single most important assertion for this change. The old code path
+       * bound `Number(value)`, which for any ISO-8601 string is NaN, so the
+       * emitted predicate was `NULL > NaN`. Postgres is perfectly happy to
+       * evaluate that — it is NULL, not an error — so the filter returned zero
+       * rows on every table and no log line anywhere recorded a problem.
+       */
+      const query: JSONColumnQuery = build({
+        Renewal: operatorCase.operatorFor(ISO_INSTANT),
+      });
+
+      expect(query.parameters["p2"]).toBe(ISO_INSTANT);
+      expect(Number.isNaN(query.parameters["p2"] as unknown as number)).toBe(
+        false,
+      );
+    },
+  );
+
+  test.each(ORDERED_OPERATORS)(
+    "$name does not emit the numeric CASE expression for a date",
+    (operatorCase: OrderedOperatorCase) => {
+      /*
+       * numericExpression is the other half of the old bug: it returns NULL for
+       * any text that fails the numeric regex, which every ISO-8601 string
+       * does. Seeing `CASE WHEN ... AS NUMERIC` in a date predicate means the
+       * left-hand side has gone back to being unconditionally NULL.
+       */
+      const sql: string = sqlOf({
+        Renewal: operatorCase.operatorFor(ISO_INSTANT),
+      });
+
+      expect(sql).not.toContain("CASE WHEN");
+      expect(sql).not.toContain("AS NUMERIC");
+      expect(sql).toContain(`${operatorCase.sqlOperator} CAST(:p2 AS TEXT)`);
+    },
+  );
+
+  test("no parameter anywhere in a date query is NaN", () => {
+    /*
+     * Swept across the whole bag rather than one name, so a future refactor
+     * that renumbers or reorders the binds cannot let a NaN back in unnoticed.
+     */
+    const query: JSONColumnQuery = build({
+      Opened: new GreaterThan(ISO_INSTANT),
+      Closed: new LessThan("2026-12-31T23:59:59.999Z"),
+    });
+
+    for (const parameterValue of Object.values(query.parameters)) {
+      expect(Number.isNaN(parameterValue as unknown as number)).toBe(false);
+    }
+  });
+});
+
+describe("buildJSONColumnQuery — ordered comparison against a number stays numeric", () => {
+  test.each(ORDERED_OPERATORS)(
+    "$name over a numeric string still casts to NUMERIC",
+    (operatorCase: OrderedOperatorCase) => {
+      /*
+       * The guard in the other direction. A Number custom field arrives as text
+       * from the form, so "42" is the normal shape of a numeric operand — if it
+       * fell through to the text arm, "9" would sort above "10" and every
+       * numeric threshold filter in the product would be quietly wrong.
+       */
+      const query: JSONColumnQuery = build({
+        Count: operatorCase.operatorFor("42"),
+      });
+
+      expect(query.toSql(COLUMN)).toContain("AS NUMERIC");
+      expect(query.parameters["p2"]).toBe(42);
+    },
+  );
+
+  test("a real number operand still casts to NUMERIC and binds as a number", () => {
+    const query: JSONColumnQuery = build({
+      Count: new GreaterThan(5),
+    });
+
+    expect(query.toSql(COLUMN)).toContain("CASE WHEN");
+    expect(query.toSql(COLUMN)).toContain(") > CAST(:p2 AS NUMERIC)");
+    expect(query.parameters["p2"]).toBe(5);
+  });
+
+  test('the "9 versus 10" case is the reason numbers must not go through text', () => {
+    /*
+     * Written as an assertion about JavaScript rather than about SQL because
+     * Postgres' text collation orders these the same way: as text "9" > "10",
+     * as numbers 9 < 10. Anyone tempted to simplify compareOrdered down to a
+     * single text comparison should have to delete this test first.
+     */
+    expect("9" > "10").toBe(true);
+    expect(Number("9") > Number("10")).toBe(false);
+
+    expect(sqlOf({ Count: new GreaterThan("9") })).toContain("AS NUMERIC");
+  });
+
+  test("a negative or fractional numeric string is still numeric", () => {
+    expect(build({ Count: new LessThan("-3.5") }).parameters["p2"]).toBe(-3.5);
+    expect(build({ Count: new GreaterThan("0.25") }).parameters["p2"]).toBe(
+      0.25,
+    );
+    expect(sqlOf({ Count: new LessThan("-3.5") })).toContain("AS NUMERIC");
+  });
+
+  test("whitespace around a numeric string does not push it to the text arm", () => {
+    /*
+     * isNumericValue trims before Number(), and NUMERIC_TEXT_REGEX allows
+     * surrounding whitespace on the stored side, so both halves of the
+     * comparison agree that " 7 " is seven. If only one of them trimmed, the
+     * operand and the column would be compared under different rules.
+     */
+    const query: JSONColumnQuery = build({ Count: new GreaterThan(" 7 ") });
+
+    expect(query.toSql(COLUMN)).toContain("AS NUMERIC");
+    expect(query.parameters["p2"]).toBe(7);
+  });
+});
+
+describe("buildJSONColumnQuery — InBetween keeps its existing branch", () => {
+  test("two ISO dates compare as text on both bounds", () => {
+    /*
+     * InBetween has always chosen text for non-numeric bounds; this pins it so
+     * that the four operators which just joined it cannot drift apart from it
+     * again. A date range facet and a date threshold facet over the same field
+     * must agree about what "after" means.
+     */
+    const query: JSONColumnQuery = build({
+      Window: new InBetween(ISO_INSTANT, "2026-09-01T00:00:00.000Z"),
+    });
+    const sql: string = query.toSql(COLUMN);
+
+    expect(sql).toContain(">= CAST(:p2 AS TEXT)");
+    expect(sql).toContain("<= CAST(:p3 AS TEXT)");
+    expect(sql).not.toContain("AS NUMERIC");
+    expect(query.parameters["p2"]).toBe(ISO_INSTANT);
+    expect(query.parameters["p3"]).toBe("2026-09-01T00:00:00.000Z");
+  });
+
+  test("a numeric start with a date end falls to text", () => {
+    /*
+     * The branch is `isNumericValue(start) && isNumericValue(end)`, so one
+     * non-numeric bound demotes the whole range. That is the safe direction:
+     * casting a date bound to NUMERIC reproduces the NaN bug, whereas comparing
+     * a number as text merely mis-sorts a range nothing in the product builds.
+     */
+    const query: JSONColumnQuery = build({
+      Window: new InBetween(1 as unknown as string, "2026-01-01"),
+    });
+
+    expect(query.toSql(COLUMN)).not.toContain("AS NUMERIC");
+    expect(query.parameters["p2"]).toBe("1");
+    expect(query.parameters["p3"]).toBe("2026-01-01");
+  });
+
+  test("a date start with a numeric end falls to text as well", () => {
+    const query: JSONColumnQuery = build({
+      Window: new InBetween("2026-01-01", 10 as unknown as string),
+    });
+
+    expect(query.toSql(COLUMN)).not.toContain("AS NUMERIC");
+    expect(query.parameters["p2"]).toBe("2026-01-01");
+    expect(query.parameters["p3"]).toBe("10");
+  });
+
+  test("two numeric bounds stay numeric", () => {
+    const query: JSONColumnQuery = build({ Count: new InBetween(1, 10) });
+
+    expect(query.toSql(COLUMN)).toContain("AS NUMERIC");
+    expect(query.parameters["p2"]).toBe(1);
+    expect(query.parameters["p3"]).toBe(10);
+  });
+});
+
+describe("buildJSONColumnQuery — a Date instance reduces to its ISO string", () => {
+  test("GreaterThan(Date) binds the exact ISO-8601 instant", () => {
+    /*
+     * toScalar used to fall through to String(value) for a Date, which yields
+     * "Sun Aug 17 2026 00:00:00 GMT+0000 (Coordinated Universal Time)". Text
+     * comparison over that sorts by weekday name — "Fri" before "Mon" before
+     * "Sat" — which is not wrong in an obvious way, it is wrong in a way that
+     * looks like a plausible result set.
+     */
+    const query: JSONColumnQuery = build({
+      Renewal: new GreaterThan(new Date(ISO_INSTANT)),
+    });
+
+    expect(query.parameters["p2"]).toBe("2026-08-17T00:00:00.000Z");
+  });
+
+  test("LessThan(Date) binds the exact ISO-8601 instant", () => {
+    const query: JSONColumnQuery = build({
+      Renewal: new LessThan(new Date("2026-12-31T23:59:59.999Z")),
+    });
+
+    expect(query.parameters["p2"]).toBe("2026-12-31T23:59:59.999Z");
+  });
+
+  test("no locale-formatted date text reaches the parameter bag", () => {
+    const query: JSONColumnQuery = build({
+      Renewal: new GreaterThanOrEqual(new Date(ISO_INSTANT)),
+    });
+    const bound: string = String(query.parameters["p2"]);
+
+    expect(bound).not.toContain("GMT");
+    expect(bound).not.toMatch(/^(Mon|Tue|Wed|Thu|Fri|Sat|Sun)/);
+    expect(bound).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("a Date and its own ISO string compile identically", () => {
+    /*
+     * The same filter reaches the server two ways: built server-side it still
+     * holds a Date, and round-tripped through the browser it has already been
+     * JSON-stringified to an ISO string. Both must produce the same predicate,
+     * or a saved view would mean something different from the one the user is
+     * looking at.
+     */
+    const fromDate: JSONColumnQuery = build({
+      Renewal: new GreaterThan(new Date(ISO_INSTANT)),
+    });
+    const fromString: JSONColumnQuery = build({
+      Renewal: new GreaterThan(ISO_INSTANT),
+    });
+
+    expect(fromDate.toSql(COLUMN)).toBe(fromString.toSql(COLUMN));
+    expect(fromDate.parameters).toEqual(fromString.parameters);
+  });
+
+  test("InBetween over two Dates binds both bounds as ISO strings", () => {
+    const query: JSONColumnQuery = build({
+      Window: new InBetween(
+        new Date("2026-01-01T00:00:00.000Z"),
+        new Date("2026-02-01T00:00:00.000Z"),
+      ),
+    });
+
+    expect(query.parameters["p2"]).toBe("2026-01-01T00:00:00.000Z");
+    expect(query.parameters["p3"]).toBe("2026-02-01T00:00:00.000Z");
+    expect(query.toSql(COLUMN)).not.toContain("AS NUMERIC");
+  });
+});
+
+describe("buildJSONColumnQuery — why comparing dates as text is sound", () => {
+  test("lexicographic order over ISO-8601 is chronological order", () => {
+    /*
+     * This is the justification for the whole change, so it is asserted rather
+     * than left in a comment. ISO-8601 is fixed-width, zero-padded and
+     * big-endian, which is exactly the property that makes a byte-wise string
+     * comparison agree with an instant comparison. Nothing else about the
+     * stored format may change without this test failing first.
+     */
+    const shuffled: Array<string> = [
+      "2026-08-17T12:00:00.000Z",
+      "2025-12-31T23:59:59.999Z",
+      "2026-08-17T00:00:00.000Z",
+      "2026-01-01T00:00:00.000Z",
+      "2026-09-01T00:00:00.000Z",
+    ];
+
+    const byText: Array<string> = [...shuffled].sort();
+    const byInstant: Array<string> = [...shuffled].sort(
+      (left: string, right: string): number => {
+        return new Date(left).getTime() - new Date(right).getTime();
+      },
+    );
+
+    expect(byText).toEqual(byInstant);
+  });
+
+  test("the zero padding is what makes it hold", () => {
+    /*
+     * September is "09", not "9". Were it not padded, "2026-9-01" would sort
+     * below "2026-10-01" as text and above it as a date, and the text
+     * comparison this module now relies on would be wrong for a quarter of the
+     * year.
+     */
+    expect("2026-09-01" < "2026-10-01").toBe(true);
+    expect("2026-9-01" < "2026-10-01").toBe(false);
+  });
+
+  test("date-only and full-timestamp values still order against each other", () => {
+    /*
+     * A field switched from Date to DateTime leaves both shapes in the column.
+     * The date-only string is a prefix of the timestamp for the same day, and a
+     * prefix sorts first, so "2026-08-17" reads as the start of that day —
+     * which is the reading the UI already gives it.
+     */
+    expect("2026-08-17" < "2026-08-17T00:00:00.000Z").toBe(true);
+    expect("2026-08-17" < "2026-08-18").toBe(true);
+  });
+});
+
+describe("buildJSONColumnQuery — other operands to the ordered operators", () => {
+  test("a boolean operand compares as text rather than crashing", () => {
+    /*
+     * Nothing in the product builds "Regulated is greater than true", but the
+     * column is untyped and a hand-built query can send anything. compareOrdered
+     * must have a defined answer for every scalar, not just the two it was
+     * designed for.
+     */
+    const query: JSONColumnQuery = build({
+      Regulated: new GreaterThan(true as unknown as string),
+    });
+
+    expect(query.toSql(COLUMN)).toContain("> CAST(:p2 AS TEXT)");
+    expect(query.parameters["p2"]).toBe("true");
+  });
+
+  test("an ordinary word compares as text", () => {
+    const query: JSONColumnQuery = build({
+      Severity: new GreaterThanOrEqual("medium"),
+    });
+
+    expect(query.toSql(COLUMN)).toContain(">= CAST(:p2 AS TEXT)");
+    expect(query.parameters["p2"]).toBe("medium");
+  });
+
+  test("an empty operand compares as text and binds the empty string", () => {
+    /*
+     * Number("") is 0, so an empty operand used to compile to "greater than
+     * zero" — a filter the user never asked for. isNumericValue rejects the
+     * empty string explicitly to stop that.
+     */
+    const query: JSONColumnQuery = build({ Renewal: new GreaterThan("") });
+
+    expect(query.toSql(COLUMN)).toContain("> CAST(:p2 AS TEXT)");
+    expect(query.parameters["p2"]).toBe("");
+  });
+
+  test("a non-finite operand never reaches the numeric cast", () => {
+    /*
+     * Number.isFinite, not isNaN: Infinity is a number and would bind as one,
+     * and `CAST(Infinity AS NUMERIC)` is an error rather than a NULL — an
+     * aborted request instead of an empty table.
+     */
+    expect(sqlOf({ Count: new GreaterThan(Infinity) })).not.toContain(
+      "AS NUMERIC",
+    );
+    expect(sqlOf({ Count: new GreaterThan(NaN) })).not.toContain("AS NUMERIC");
+  });
+
+  test("GreaterThanOrNull is still numeric-only", () => {
+    /*
+     * Deliberately pinned at the edge of the change. The or-null variants were
+     * left on compareNumeric, and nothing in the custom field facet vocabulary
+     * emits them, so no date reaches them today. If a date-capable "or null"
+     * filter is ever added, this test fails first and points at the gap rather
+     * than letting the NaN predicate reappear somewhere new.
+     */
+    expect(sqlOf({ Renewal: new GreaterThanOrNull(ISO_INSTANT) })).toContain(
+      "AS NUMERIC",
+    );
+  });
+
+  test("two date keys AND together and each keeps its own parameters", () => {
+    const query: JSONColumnQuery = build({
+      Opened: new GreaterThanOrEqual("2026-01-01T00:00:00.000Z"),
+      Closed: new LessThan("2026-02-01T00:00:00.000Z"),
+    });
+    const sql: string = query.toSql(COLUMN);
+
+    expect(sql).toContain(" AND ");
+    expect(query.parameters["p1"]).toBe("Opened");
+    expect(query.parameters["p2"]).toBe("2026-01-01T00:00:00.000Z");
+    expect(query.parameters["p3"]).toBe("Closed");
+    expect(query.parameters["p4"]).toBe("2026-02-01T00:00:00.000Z");
+  });
+
+  test("a date filter still routes the key through a parameter", () => {
+    /*
+     * The date branch is new SQL, and new SQL is where an interpolated key
+     * creeps back in. The name of a Date custom field is user text like any
+     * other.
+     */
+    const key: string = "Renew' OR 1=1 --";
+    const query: JSONColumnQuery = build({
+      [key]: new GreaterThan(ISO_INSTANT),
+    });
+    const sql: string = query.toSql(COLUMN);
+
+    expect(sql).not.toContain("OR 1=1");
+    expect(sql).not.toContain(key);
+    expect(query.parameters["p1"]).toBe(key);
   });
 });

--- a/Common/Tests/Server/Utils/Telemetry/InventoryEntityRegistry.test.ts
+++ b/Common/Tests/Server/Utils/Telemetry/InventoryEntityRegistry.test.ts
@@ -1,14 +1,33 @@
+import CloudResource from "../../../../Models/DatabaseModels/CloudResource";
+import BaseModel from "../../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import DockerHost from "../../../../Models/DatabaseModels/DockerHost";
 import InventoryItem from "../../../../Models/DatabaseModels/InventoryItem";
+import IoTDevice from "../../../../Models/DatabaseModels/IoTDevice";
+import NetworkDevice from "../../../../Models/DatabaseModels/NetworkDevice";
+import PodmanHost from "../../../../Models/DatabaseModels/PodmanHost";
+import RumApplication from "../../../../Models/DatabaseModels/RumApplication";
+import ServerlessFunction from "../../../../Models/DatabaseModels/ServerlessFunction";
+import CloudResourceService from "../../../../Server/Services/CloudResourceService";
+import DockerHostService from "../../../../Server/Services/DockerHostService";
+import IoTDeviceService from "../../../../Server/Services/IoTDeviceService";
+import NetworkDeviceService from "../../../../Server/Services/NetworkDeviceService";
+import PodmanHostService from "../../../../Server/Services/PodmanHostService";
+import RumApplicationService from "../../../../Server/Services/RumApplicationService";
+import ServerlessFunctionService from "../../../../Server/Services/ServerlessFunctionService";
 import {
   buildInventoryEntityModel,
   compactAttributes,
   ErasedInventorySource,
+  hasCustomFieldValues,
   INVENTORY_SOURCES,
   inventoryEntityNeedsUpdate,
   InventoryRowProjection,
+  OrphanPartition,
+  partitionOrphanRows,
 } from "../../../../Server/Utils/Telemetry/InventoryEntityRegistry";
 import ColumnLength from "../../../../Types/Database/ColumnLength";
 import Dictionary from "../../../../Types/Dictionary";
+import { JSONObject } from "../../../../Types/JSON";
 import ObjectID from "../../../../Types/ObjectID";
 import EntitySource from "../../../../Types/Telemetry/EntitySource";
 import EntityType from "../../../../Types/Telemetry/EntityType";
@@ -318,5 +337,654 @@ describe("INVENTORY_SOURCES", () => {
     for (const source of INVENTORY_SOURCES) {
       expect(INVENTORY_ENTITY_TYPES.has(source.entityType)).toBe(true);
     }
+  });
+});
+
+/*
+ * Everything below covers the destructive half of the reconcile.
+ *
+ * The mapping tested above is worth getting right; this half is worth getting
+ * right at a different order of magnitude. A mistake in `buildInventoryEntityModel`
+ * shows up as an entity that looks wrong and can be fixed by fixing the code and
+ * waiting fifteen minutes. A mistake here hard-deletes rows through
+ * `hardDeleteBy`, which bypasses the audit hook — so the serial numbers, warranty
+ * dates and owning-team names a person typed into the custom fields of a mirrored
+ * row are gone with no undo and no record that they ever existed. Both functions
+ * are pure and exported precisely so this can be pinned down without a database.
+ */
+
+const LIVE_RESOURCE_ID: ObjectID = new ObjectID(
+  "1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
+);
+const DEAD_RESOURCE_ID: ObjectID = new ObjectID(
+  "9f8e7d6c-5b4a-4392-8180-7f6e5d4c3b2a",
+);
+const ROW_ID_ONE: ObjectID = new ObjectID(
+  "2c1d0e9f-8a7b-4c6d-9e5f-0a1b2c3d4e5f",
+);
+const ROW_ID_TWO: ObjectID = new ObjectID(
+  "3d2e1f0a-9b8c-4d7e-8f6a-1b2c3d4e5f60",
+);
+const ROW_ID_THREE: ObjectID = new ObjectID(
+  "4e3f2a1b-0c9d-4e8f-9a7b-2c3d4e5f6071",
+);
+const ROW_ID_FOUR: ObjectID = new ObjectID(
+  "5f4a3b2c-1d0e-4f9a-8b6c-3d4e5f607182",
+);
+
+/**
+ * A registry row as the reverse pass actually reads it: only `_id`,
+ * `resourceId`, `customFields` and `isArchived` are selected, so only those are
+ * populated here. Keys are assigned rather than set to undefined because
+ * `exactOptionalPropertyTypes` distinguishes the two, and so does the code under
+ * test — an absent `customFields` is a different shape from a present empty one.
+ */
+function registryRow(
+  overrides: {
+    id?: ObjectID;
+    resourceId?: ObjectID;
+    customFields?: JSONObject;
+    isArchived?: boolean;
+  } = {},
+): InventoryItem {
+  const row: InventoryItem = new InventoryItem();
+
+  if (overrides.id !== undefined) {
+    row.id = overrides.id;
+  }
+
+  if (overrides.resourceId !== undefined) {
+    row.resourceId = overrides.resourceId;
+  }
+
+  if (overrides.customFields !== undefined) {
+    row.customFields = overrides.customFields;
+  }
+
+  if (overrides.isArchived !== undefined) {
+    row.isArchived = overrides.isArchived;
+  }
+
+  return row;
+}
+
+function idStrings(ids: Array<ObjectID>): Array<string> {
+  return ids.map((id: ObjectID) => {
+    return id.toString();
+  });
+}
+
+describe("hasCustomFieldValues", () => {
+  test("false when the bag was never populated", () => {
+    /*
+     * The overwhelmingly common case: nobody has ever opened the custom fields
+     * editor on this row, so it is a pure projection and safe to delete.
+     */
+    expect(hasCustomFieldValues(registryRow())).toBe(false);
+  });
+
+  test("false when the bag is explicitly null", () => {
+    // Postgres hands back SQL NULL for a jsonb column that was never written.
+    const row: InventoryItem = registryRow();
+    (row as unknown as { customFields: unknown }).customFields = null;
+
+    expect(hasCustomFieldValues(row)).toBe(false);
+  });
+
+  test("false when the stored value is not an object at all", () => {
+    /*
+     * Defensive: a jsonb column can legally hold a bare scalar. Object.keys on a
+     * string would enumerate its character indices and report every row with a
+     * corrupted bag as worth keeping forever, which quietly turns the delete pass
+     * into a no-op.
+     */
+    const row: InventoryItem = registryRow();
+    (row as unknown as { customFields: unknown }).customFields =
+      "not-an-object";
+
+    expect(hasCustomFieldValues(row)).toBe(false);
+  });
+
+  test("false for an empty bag", () => {
+    /*
+     * The UI writes `{}` rather than deleting the column when the last value is
+     * cleared, so an empty bag is the fingerprint of "someone looked and then
+     * changed their mind" — not of data worth preserving.
+     */
+    expect(hasCustomFieldValues(registryRow({ customFields: {} }))).toBe(false);
+  });
+
+  test("false when every value is null, undefined, empty string or empty array", () => {
+    /*
+     * Same story one level down: clearing a field leaves the key behind with an
+     * empty value. A key-count check would keep these rows alive forever and the
+     * registry would accumulate projections of devices that no longer exist.
+     */
+    const row: InventoryItem = registryRow({
+      customFields: {
+        "Serial Number": "",
+        "Warranty Expires": null,
+        "Owning Team": undefined,
+        Tags: [],
+      },
+    });
+
+    expect(hasCustomFieldValues(row)).toBe(false);
+  });
+
+  test("true when one real value survives among the emptied ones", () => {
+    const row: InventoryItem = registryRow({
+      customFields: {
+        "Serial Number": "FTX1840ABCD",
+        "Warranty Expires": "",
+        Tags: [],
+      },
+    });
+
+    expect(hasCustomFieldValues(row)).toBe(true);
+  });
+
+  test("true for a stored `false`", () => {
+    /*
+     * The classic bug this guards against: a truthiness test (`if (value)`) reads
+     * `false` as absence, so a Boolean custom field answered "no" — the device is
+     * NOT under warranty — would be counted as an empty bag and the row would be
+     * routed to the hard delete. `false` is an answer somebody gave.
+     */
+    expect(
+      hasCustomFieldValues(
+        registryRow({ customFields: { "Under Warranty": false } }),
+      ),
+    ).toBe(true);
+  });
+
+  test("true for a stored `0`", () => {
+    // Same trap as `false`: zero spare ports is a measurement, not a blank field.
+    expect(
+      hasCustomFieldValues(registryRow({ customFields: { "Spare Ports": 0 } })),
+    ).toBe(true);
+  });
+
+  test("true for an array with entries", () => {
+    /*
+     * MultiSelectDropdown fields store arrays. Only the EMPTY array counts as
+     * absence — a populated one is exactly as much user work as a typed string.
+     */
+    expect(
+      hasCustomFieldValues(
+        registryRow({ customFields: { Tags: ["dc1", "rack-4"] } }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("partitionOrphanRows", () => {
+  test("a row whose owning resource still exists is neither deleted nor archived", () => {
+    /*
+     * The steady state, and by far the most common one. A live row must fall out
+     * of both lists entirely: putting it in `archivableIds` would hide every
+     * mirrored device from the explorer on the next sweep.
+     */
+    const partition: OrphanPartition = partitionOrphanRows({
+      rows: [registryRow({ id: ROW_ID_ONE, resourceId: LIVE_RESOURCE_ID })],
+      liveResourceIds: new Set<string>([LIVE_RESOURCE_ID.toString()]),
+    });
+
+    expect(partition.deletableIds).toEqual([]);
+    expect(partition.archivableIds).toEqual([]);
+  });
+
+  test("a live row carrying custom fields is still left alone", () => {
+    // Custom fields must not be a reason to touch a row that is not an orphan.
+    const partition: OrphanPartition = partitionOrphanRows({
+      rows: [
+        registryRow({
+          id: ROW_ID_ONE,
+          resourceId: LIVE_RESOURCE_ID,
+          customFields: { "Serial Number": "FTX1840ABCD" },
+        }),
+      ],
+      liveResourceIds: new Set<string>([LIVE_RESOURCE_ID.toString()]),
+    });
+
+    expect(partition.deletableIds).toEqual([]);
+    expect(partition.archivableIds).toEqual([]);
+  });
+
+  test("an orphan with no custom fields is deletable", () => {
+    /*
+     * Nothing on this row was authored by a person — every column is rewritten
+     * from the owning table on each pass — so with the owning row gone there is
+     * literally nothing left to keep.
+     */
+    const partition: OrphanPartition = partitionOrphanRows({
+      rows: [registryRow({ id: ROW_ID_ONE, resourceId: DEAD_RESOURCE_ID })],
+      liveResourceIds: new Set<string>([LIVE_RESOURCE_ID.toString()]),
+    });
+
+    expect(idStrings(partition.deletableIds)).toEqual([ROW_ID_ONE.toString()]);
+    expect(partition.archivableIds).toEqual([]);
+  });
+
+  test("an orphan carrying custom fields is archived, never deleted", () => {
+    /*
+     * The data-loss guard, and the reason this function exists at all. Those
+     * custom field values live on the registry row and nowhere else, so hard
+     * -deleting this row destroys the only copy of the user's serial numbers and
+     * warranty dates — with no audit trail, because `hardDeleteBy` bypasses the
+     * audit hook, and no undo. Archiving produces the same visible outcome (the
+     * row leaves the default list) and leaves the data recoverable.
+     */
+    const partition: OrphanPartition = partitionOrphanRows({
+      rows: [
+        registryRow({
+          id: ROW_ID_ONE,
+          resourceId: DEAD_RESOURCE_ID,
+          customFields: { "Serial Number": "FTX1840ABCD" },
+        }),
+      ],
+      liveResourceIds: new Set<string>(),
+    });
+
+    expect(idStrings(partition.archivableIds)).toEqual([ROW_ID_ONE.toString()]);
+    expect(partition.deletableIds).toEqual([]);
+  });
+
+  test("an orphan that is already archived is skipped entirely", () => {
+    /*
+     * The sweep runs every fifteen minutes and this row will be an orphan on
+     * every one of them. Re-archiving would rewrite `archivedAt` each time, so
+     * the timestamp would report the last sweep rather than when the device
+     * actually went away — which is the only thing that column is good for.
+     */
+    const partition: OrphanPartition = partitionOrphanRows({
+      rows: [
+        registryRow({
+          id: ROW_ID_ONE,
+          resourceId: DEAD_RESOURCE_ID,
+          customFields: { "Serial Number": "FTX1840ABCD" },
+          isArchived: true,
+        }),
+      ],
+      liveResourceIds: new Set<string>(),
+    });
+
+    expect(partition.deletableIds).toEqual([]);
+    expect(partition.archivableIds).toEqual([]);
+  });
+
+  test("an already-archived orphan with no custom fields is still deletable", () => {
+    /*
+     * The archive flag only shields rows that hold something. An empty
+     * projection that was archived by hand is still an empty projection, and
+     * leaving it behind would let the registry grow without bound.
+     */
+    const partition: OrphanPartition = partitionOrphanRows({
+      rows: [
+        registryRow({
+          id: ROW_ID_ONE,
+          resourceId: DEAD_RESOURCE_ID,
+          isArchived: true,
+        }),
+      ],
+      liveResourceIds: new Set<string>(),
+    });
+
+    expect(idStrings(partition.deletableIds)).toEqual([ROW_ID_ONE.toString()]);
+    expect(partition.archivableIds).toEqual([]);
+  });
+
+  test("a row with no resourceId at all is an orphan by definition", () => {
+    /*
+     * Without a pointer there is nothing to match against the owning table, so
+     * the row can never be proven live. Treating it as live instead would leave
+     * pre-pointer rows in the registry permanently.
+     */
+    const partition: OrphanPartition = partitionOrphanRows({
+      rows: [registryRow({ id: ROW_ID_ONE })],
+      liveResourceIds: new Set<string>([LIVE_RESOURCE_ID.toString()]),
+    });
+
+    expect(idStrings(partition.deletableIds)).toEqual([ROW_ID_ONE.toString()]);
+    expect(partition.archivableIds).toEqual([]);
+  });
+
+  test("a pointerless row carrying custom fields is archived, not deleted", () => {
+    // The data-loss guard has to win over the pointerless-means-orphan rule too.
+    const partition: OrphanPartition = partitionOrphanRows({
+      rows: [
+        registryRow({
+          id: ROW_ID_ONE,
+          customFields: { "Owning Team": "Network Engineering" },
+        }),
+      ],
+      liveResourceIds: new Set<string>([LIVE_RESOURCE_ID.toString()]),
+    });
+
+    expect(idStrings(partition.archivableIds)).toEqual([ROW_ID_ONE.toString()]);
+    expect(partition.deletableIds).toEqual([]);
+  });
+
+  test("a row with no id is skipped rather than emitted as a null target", () => {
+    /*
+     * Should not happen — `_id` is always selected — but an undefined slipping
+     * into the id list would become a `WHERE _id IN (NULL)` and, depending on how
+     * the query builder folds it, either a no-op or something much worse.
+     */
+    const partition: OrphanPartition = partitionOrphanRows({
+      rows: [
+        registryRow({
+          resourceId: DEAD_RESOURCE_ID,
+          customFields: { "Serial Number": "FTX1840ABCD" },
+        }),
+        registryRow({ resourceId: DEAD_RESOURCE_ID }),
+      ],
+      liveResourceIds: new Set<string>(),
+    });
+
+    expect(partition.deletableIds).toEqual([]);
+    expect(partition.archivableIds).toEqual([]);
+  });
+
+  test("a mixed page splits correctly and the two lists are disjoint", () => {
+    /*
+     * The realistic shape of one page: a live row, two orphans that differ only
+     * in whether anyone typed anything, and one orphan already archived. Nothing
+     * may appear in both lists — the reverse pass runs the delete and the update
+     * as two separate statements, so an id in both would be deleted and then
+     * "archived" into nothing.
+     */
+    const partition: OrphanPartition = partitionOrphanRows({
+      rows: [
+        registryRow({ id: ROW_ID_ONE, resourceId: LIVE_RESOURCE_ID }),
+        registryRow({ id: ROW_ID_TWO, resourceId: DEAD_RESOURCE_ID }),
+        registryRow({
+          id: ROW_ID_THREE,
+          resourceId: DEAD_RESOURCE_ID,
+          customFields: { "Warranty Expires": "2027-01-31T00:00:00.000Z" },
+        }),
+        registryRow({
+          id: ROW_ID_FOUR,
+          resourceId: DEAD_RESOURCE_ID,
+          customFields: { "Serial Number": "FTX1840ABCD" },
+          isArchived: true,
+        }),
+      ],
+      liveResourceIds: new Set<string>([LIVE_RESOURCE_ID.toString()]),
+    });
+
+    const deletable: Array<string> = idStrings(partition.deletableIds);
+    const archivable: Array<string> = idStrings(partition.archivableIds);
+
+    expect(deletable).toEqual([ROW_ID_TWO.toString()]);
+    expect(archivable).toEqual([ROW_ID_THREE.toString()]);
+
+    const overlap: Array<string> = deletable.filter((id: string) => {
+      return archivable.includes(id);
+    });
+    expect(overlap).toEqual([]);
+  });
+
+  test("an empty page produces an empty partition rather than throwing", () => {
+    // Every source hits this on its last page; a throw here would abort the sweep.
+    const partition: OrphanPartition = partitionOrphanRows({
+      rows: [],
+      liveResourceIds: new Set<string>([LIVE_RESOURCE_ID.toString()]),
+    });
+
+    expect(partition.deletableIds).toEqual([]);
+    expect(partition.archivableIds).toEqual([]);
+  });
+
+  test("an empty live set orphans every row on the page", () => {
+    /*
+     * What a fully emptied inventory table looks like — a project deleted by FK
+     * cascade, which is the case hooks could never have caught. The rows with
+     * typed values must survive it.
+     */
+    const partition: OrphanPartition = partitionOrphanRows({
+      rows: [
+        registryRow({ id: ROW_ID_ONE, resourceId: LIVE_RESOURCE_ID }),
+        registryRow({
+          id: ROW_ID_TWO,
+          resourceId: LIVE_RESOURCE_ID,
+          customFields: { "Serial Number": "FTX1840ABCD" },
+        }),
+      ],
+      liveResourceIds: new Set<string>(),
+    });
+
+    expect(idStrings(partition.deletableIds)).toEqual([ROW_ID_ONE.toString()]);
+    expect(idStrings(partition.archivableIds)).toEqual([ROW_ID_TWO.toString()]);
+  });
+});
+
+/*
+ * The per-source `query` is captured inside the closure `defineInventorySource`
+ * returns, so the only way to observe it is to let the closure run and watch what
+ * it asks the service for. `findBy` is a prototype method on DatabaseService, so
+ * assigning a stub onto the singleton shadows it and deleting the own property
+ * afterwards restores the real one — no module mocking, and nothing left behind
+ * for the next test file in the worker.
+ */
+interface StubbableService {
+  findBy?: (data: { query: JSONObject }) => Promise<Array<never>>;
+}
+
+const SERVICE_BY_RESOURCE_TYPE: Dictionary<StubbableService> = {
+  NetworkDevice: NetworkDeviceService as unknown as StubbableService,
+  CloudResource: CloudResourceService as unknown as StubbableService,
+  ServerlessFunction: ServerlessFunctionService as unknown as StubbableService,
+  RumApplication: RumApplicationService as unknown as StubbableService,
+  IoTDevice: IoTDeviceService as unknown as StubbableService,
+  DockerHost: DockerHostService as unknown as StubbableService,
+  PodmanHost: PodmanHostService as unknown as StubbableService,
+};
+
+const MODEL_BY_RESOURCE_TYPE: Dictionary<BaseModel> = {
+  NetworkDevice: new NetworkDevice(),
+  CloudResource: new CloudResource(),
+  ServerlessFunction: new ServerlessFunction(),
+  RumApplication: new RumApplication(),
+  IoTDevice: new IoTDevice(),
+  DockerHost: new DockerHost(),
+  PodmanHost: new PodmanHost(),
+};
+
+async function captureServiceQueries(data: {
+  resourceType: string;
+  run: () => Promise<void>;
+}): Promise<Array<JSONObject>> {
+  const service: StubbableService | undefined =
+    SERVICE_BY_RESOURCE_TYPE[data.resourceType];
+
+  if (!service) {
+    throw new Error(
+      `No service registered in this test for ${data.resourceType}. A new inventory source landed; add it here so its archive filter is covered too.`,
+    );
+  }
+
+  const seen: Array<JSONObject> = [];
+
+  service.findBy = (call: { query: JSONObject }): Promise<Array<never>> => {
+    seen.push(call.query);
+    return Promise.resolve([]);
+  };
+
+  try {
+    await data.run();
+  } finally {
+    delete service.findBy;
+  }
+
+  return seen;
+}
+
+async function mirrorQueryFor(
+  source: ErasedInventorySource,
+): Promise<JSONObject> {
+  const seen: Array<JSONObject> = await captureServiceQueries({
+    resourceType: source.resourceType,
+    run: async (): Promise<void> => {
+      await source.fetchPage({ skip: 0, limit: 1 });
+    },
+  });
+
+  expect(seen.length).toBe(1);
+  return seen[0] || {};
+}
+
+function modelFor(resourceType: string): BaseModel {
+  const model: BaseModel | undefined = MODEL_BY_RESOURCE_TYPE[resourceType];
+
+  if (!model) {
+    throw new Error(
+      `No model registered in this test for ${resourceType}. A new inventory source landed; add it here so its archive filter is covered too.`,
+    );
+  }
+
+  return model;
+}
+
+function hasArchiveColumn(resourceType: string): boolean {
+  return modelFor(resourceType)
+    .getTableColumns()
+    .columns.includes("isArchived");
+}
+
+function sourceFor(resourceType: string): ErasedInventorySource {
+  const source: ErasedInventorySource | undefined = INVENTORY_SOURCES.find(
+    (candidate: ErasedInventorySource) => {
+      return candidate.resourceType === resourceType;
+    },
+  );
+
+  expect(source).toBeDefined();
+  return source!;
+}
+
+describe("INVENTORY_SOURCES archive filtering", () => {
+  test("the NetworkDevice source excludes archived rows", async () => {
+    /*
+     * This one is pinned by name because it regressed once already: the query
+     * was `{}` under a comment claiming NetworkDevice had no archive flag. It
+     * does — NetworkDevice.isArchived — so archived switches were mirrored back
+     * into the explorer on every sweep, and archiving one in the UI appeared to
+     * do nothing at all.
+     */
+    const query: JSONObject = await mirrorQueryFor(sourceFor("NetworkDevice"));
+
+    expect(query).toEqual({ isArchived: false });
+  });
+
+  test("NetworkDevice really does have the archive column the query filters on", () => {
+    // The other half of the regression above: the claim, not just the query.
+    expect(hasArchiveColumn("NetworkDevice")).toBe(true);
+  });
+
+  test("every source whose model has an archive column filters on it", async () => {
+    /*
+     * Checked against the real models rather than a hardcoded list, so adding a
+     * source — or adding `isArchived` to a model that lacked it — fails here
+     * instead of silently reintroducing the NetworkDevice bug somewhere else.
+     */
+    for (const source of INVENTORY_SOURCES) {
+      if (!hasArchiveColumn(source.resourceType)) {
+        continue;
+      }
+
+      const query: JSONObject = await mirrorQueryFor(source);
+      expect({ resourceType: source.resourceType, query: query }).toEqual({
+        resourceType: source.resourceType,
+        query: { isArchived: false },
+      });
+    }
+  });
+
+  test("IoTDevice is the only model without an archive column", () => {
+    /*
+     * The exemption is a property of the schema, not a decision this module gets
+     * to make: IoTDevice genuinely has no `isArchived`, so it is the only source
+     * that may legitimately mirror everything.
+     */
+    const withoutArchiveColumn: Array<string> = INVENTORY_SOURCES.filter(
+      (source: ErasedInventorySource) => {
+        return !hasArchiveColumn(source.resourceType);
+      },
+    ).map((source: ErasedInventorySource) => {
+      return source.resourceType;
+    });
+
+    expect(withoutArchiveColumn).toEqual(["IoTDevice"]);
+  });
+
+  test("IoTDevice is the only source with an unrestricted query", async () => {
+    const unrestricted: Array<string> = [];
+
+    for (const source of INVENTORY_SOURCES) {
+      const query: JSONObject = await mirrorQueryFor(source);
+      if (Object.keys(query).length === 0) {
+        unrestricted.push(source.resourceType);
+      }
+    }
+
+    expect(unrestricted).toEqual(["IoTDevice"]);
+  });
+
+  test("no source narrows the mirror on anything but the archive flag", async () => {
+    /*
+     * The mirror is meant to be a view of the whole live estate. A stray extra
+     * condition here would silently hide a slice of it, and the missing devices
+     * would look identical to devices that were never registered.
+     */
+    for (const source of INVENTORY_SOURCES) {
+      const query: JSONObject = await mirrorQueryFor(source);
+      for (const key of Object.keys(query)) {
+        expect({ resourceType: source.resourceType, key: key }).toEqual({
+          resourceType: source.resourceType,
+          key: "isArchived",
+        });
+      }
+    }
+  });
+
+  test("findLiveIds does not inherit the archive filter", async () => {
+    /*
+     * `findLiveIds` answers "does the owning row still exist", and an archived
+     * row still exists. Reusing the mirror query here would make every archived
+     * device look like a cascade delete, so the reverse pass would hard-delete
+     * its registry row — turning archiving, a reversible UI action, into
+     * permanent data loss for exactly the rows this feature set out to protect.
+     */
+    const source: ErasedInventorySource = sourceFor("NetworkDevice");
+
+    const seen: Array<JSONObject> = await captureServiceQueries({
+      resourceType: source.resourceType,
+      run: async (): Promise<void> => {
+        await source.findLiveIds([LIVE_RESOURCE_ID]);
+      },
+    });
+
+    expect(seen.length).toBe(1);
+    expect(Object.keys(seen[0] || {})).toEqual(["_id"]);
+  });
+
+  test("findLiveIds asks nothing at all for an empty id list", async () => {
+    /*
+     * An empty `WHERE _id IN ()` is a syntax error in some builders and a match
+     * -everything in others; short-circuiting is the only safe answer, and it
+     * also spares seven pointless round trips on an empty estate.
+     */
+    const source: ErasedInventorySource = sourceFor("NetworkDevice");
+
+    const seen: Array<JSONObject> = await captureServiceQueries({
+      resourceType: source.resourceType,
+      run: async (): Promise<void> => {
+        const live: Set<string> = await source.findLiveIds([]);
+        expect(live.size).toBe(0);
+      },
+    });
+
+    expect(seen).toEqual([]);
   });
 });

--- a/Common/Tests/Types/CustomField/CustomFieldTypeCorrespondence.test.ts
+++ b/Common/Tests/Types/CustomField/CustomFieldTypeCorrespondence.test.ts
@@ -1,0 +1,107 @@
+import CustomFieldType from "../../../Types/CustomField/CustomFieldType";
+import FormFieldSchemaType from "../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import FieldType from "../../../UI/Components/Types/FieldType";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * CustomFieldsDetail does not translate a definition's `customFieldType` into a
+ * render type - it hands the raw string to a Detail field and to a form field
+ * as their `fieldType`, through an `as any` that erases the enum on the way.
+ * Nothing in the compiler is watching that seam, so a member added here without
+ * a same-VALUE member in FieldType and FormFieldSchemaType type-checks, builds,
+ * ships, and only then shows itself: the Detail column falls off the end of the
+ * render switch and paints an empty cell, and the form falls off the end of the
+ * input switch and paints a control the user cannot type into. The field looks
+ * present and is silently unusable, which is the worst shape a regression can
+ * take because nothing throws and nothing logs.
+ *
+ * These are value-set comparisons rather than key comparisons on purpose. The
+ * three enums are free to spell a member however reads best on their own side -
+ * `Boolean` reaches the form as `FormFieldSchemaType.Toggle`, which is written
+ * `Toggle = "Boolean"` for exactly this reason - and only the value crosses the
+ * seam. A key-based check would both miss real breakage and reject that legal
+ * spelling.
+ */
+
+const customFieldTypeEntries: Array<[string, string]> = Object.entries(
+  CustomFieldType,
+) as Array<[string, string]>;
+
+const fieldTypeValues: Set<string> = new Set<string>(
+  Object.values(FieldType) as Array<string>,
+);
+
+const formFieldSchemaTypeValues: Set<string> = new Set<string>(
+  Object.values(FormFieldSchemaType) as Array<string>,
+);
+
+describe("CustomFieldType corresponds to FieldType", () => {
+  test.each(customFieldTypeEntries)(
+    "CustomFieldType.%s is a FieldType value",
+    (_key: string, value: string) => {
+      expect(fieldTypeValues.has(value)).toBe(true);
+    },
+  );
+});
+
+describe("CustomFieldType corresponds to FormFieldSchemaType", () => {
+  test.each(customFieldTypeEntries)(
+    "CustomFieldType.%s is a FormFieldSchemaType value",
+    (_key: string, value: string) => {
+      expect(formFieldSchemaTypeValues.has(value)).toBe(true);
+    },
+  );
+});
+
+describe("CustomFieldType member set", () => {
+  test("has at least one member so the correspondence loops cannot pass vacuously", () => {
+    /*
+     * The two blocks above are generated from this enum. If it were ever
+     * emptied - a bad merge, a barrel file re-export that resolves to {} - the
+     * per-member assertions would simply stop existing and the suite would go
+     * green while guarding nothing.
+     */
+    expect(customFieldTypeEntries.length).toBeGreaterThan(0);
+  });
+
+  test("has no duplicate values", () => {
+    /*
+     * Two keys sharing a value collapse at runtime: the second one wins every
+     * lookup, and a definition saved under the first key renders as the second
+     * one's type. It also makes the loops above lie, because a duplicate is
+     * checked twice and the shadowed member is never exercised on its own.
+     */
+    const values: Array<string> = customFieldTypeEntries.map(
+      ([, value]: [string, string]) => {
+        return value;
+      },
+    );
+
+    expect(new Set<string>(values).size).toBe(values.length);
+  });
+
+  test("includes Date and DateTime", () => {
+    /*
+     * The date members are what the jsonb range filters and the ISO-8601
+     * storage format exist for. Losing them is a silent feature removal - old
+     * definitions keep their stored `customFieldType` string in the database
+     * and would then fall through every switch that reads this enum.
+     */
+    expect(CustomFieldType.Date).toEqual("Date");
+    expect(CustomFieldType.DateTime).toEqual("DateTime");
+  });
+});
+
+describe("CustomFieldType correspondence is by value, not by key", () => {
+  test("Boolean reaches the form as Toggle, which is only visible by value", () => {
+    /*
+     * This is the case that proves the checks above have to compare values.
+     * FormFieldSchemaType has no member named `Boolean`; it names the same
+     * value `Toggle`. A correspondence test written against key names would
+     * fail here on code that works perfectly, and would then be "fixed" by
+     * relaxing it into something that no longer catches a missing member.
+     */
+    expect(Object.keys(FormFieldSchemaType)).not.toContain("Boolean");
+    expect(FormFieldSchemaType.Toggle).toEqual(CustomFieldType.Boolean);
+  });
+});

--- a/Common/Tests/UI/Components/ModelTable/CustomFieldColumns.test.tsx
+++ b/Common/Tests/UI/Components/ModelTable/CustomFieldColumns.test.tsx
@@ -13,11 +13,20 @@ import FieldType from "../../../../UI/Components/Types/FieldType";
 import Monitor from "../../../../Models/DatabaseModels/Monitor";
 import MonitorCustomField from "../../../../Models/DatabaseModels/MonitorCustomField";
 import CustomFieldType from "../../../../Types/CustomField/CustomFieldType";
+import OneUptimeDate from "../../../../Types/Date";
+import Timezone from "../../../../Types/Timezone";
 import { JSONObject } from "../../../../Types/JSON";
 import "@testing-library/jest-dom";
 import { cleanup, render } from "@testing-library/react";
 import React from "react";
-import { afterEach, describe, expect, test } from "@jest/globals";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "@jest/globals";
 
 /*
  * Custom field *definitions* live in a per-resource table; the *values* live in
@@ -1209,5 +1218,344 @@ describe("CustomFieldColumns generated getElement", () => {
     expect(renderColumn(columnAt(columns, 1), monitor).textContent).toEqual(
       "SRE",
     );
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Date and DateTime custom fields
+ * ---------------------------------------------------------------------------
+ *
+ * A date custom field is kept in the jsonb bag as an ISO-8601 string, because
+ * that is the one representation that is both comparable in a query (ISO-8601
+ * sorts identically as text and as an instant) and unambiguous about which
+ * instant it names. It is also unreadable in a table cell, so the renderer
+ * hands it to the same local formatter the Detail view uses - a row and the
+ * item page it opens then agree about what day something happened.
+ *
+ * Two things here break silently. The `isDateOnly` flag: drop it and a
+ * warranty-expiry column grows a meaningless "00:00" that nobody entered, and
+ * nothing else about the cell changes to give it away. And the export value:
+ * humanise it and every CSV that feeds an external CMDB stops round-tripping,
+ * which is only discovered on the import side, in someone else's system.
+ *
+ * The formatter resolves wall clocks in the viewer's timezone and picks 12- or
+ * 24-hour from the browser locale, so both are pinned below. Without that these
+ * assertions would pass or fail depending on the machine running the suite,
+ * which is the same thing as not asserting anything.
+ */
+
+const dateDefinition: CustomFieldDefinition = {
+  name: "Warranty Expiry",
+  customFieldType: CustomFieldType.Date,
+};
+
+const dateTimeDefinition: CustomFieldDefinition = {
+  name: "Last Audited At",
+  customFieldType: CustomFieldType.DateTime,
+};
+
+/*
+ * 14:30 UTC on purpose: a stored midnight would render as the same calendar day
+ * in half the world's zones by luck, so it could not tell a timezone-aware
+ * rendering apart from a naive string slice.
+ */
+const storedIsoValue: string = "2026-08-17T14:30:00.000Z";
+
+describe("CustomFieldColumns date custom fields", () => {
+  beforeAll(() => {
+    OneUptimeDate.setUserTimezone(Timezone.UTC);
+
+    /*
+     * getUserPrefers12HourFormat sniffs the browser locale, so on one developer
+     * machine the cell reads "14:30" and on the next "02:30 PM". Pin it rather
+     * than write an assertion loose enough to accept both - a loose assertion
+     * would also accept the time going missing entirely.
+     */
+    jest
+      .spyOn(OneUptimeDate, "getUserPrefers12HourFormat")
+      .mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    // A test that re-pins the zone must not hand it to the next one.
+    OneUptimeDate.setUserTimezone(Timezone.UTC);
+  });
+
+  afterAll(() => {
+    // Never leak either pin into the rest of the suite.
+    OneUptimeDate.setUserTimezone(null);
+    jest.restoreAllMocks();
+  });
+
+  describe("renderCustomFieldValue", () => {
+    test("renders a Date value as a calendar date with no time of day", () => {
+      /*
+       * A Date field is a day, not an instant - a warranty expires on a date.
+       * Rendering the stored midnight-relative time next to it would invent a
+       * precision the person filling the field never entered.
+       */
+      expect(
+        renderValue({ value: storedIsoValue, definition: dateDefinition })
+          .textContent,
+      ).toEqual("Aug 17, 2026");
+    });
+
+    test("renders a Date value without any clock time in it at all", () => {
+      // Belt and braces on the above: no "14:30", and no stray zone suffix.
+      const text: string =
+        renderValue({ value: storedIsoValue, definition: dateDefinition })
+          .textContent || "";
+
+      expect(text).not.toContain(":");
+      expect(text).not.toContain("UTC");
+    });
+
+    test("renders a DateTime value with the time of day and the zone", () => {
+      /*
+       * The other half of the field pair: "last audited at" is an instant, and
+       * without the zone abbreviation a wall clock names a different instant to
+       * every reader.
+       */
+      expect(
+        renderValue({ value: storedIsoValue, definition: dateTimeDefinition })
+          .textContent,
+      ).toEqual("Aug 17 2026, 14:30 UTC");
+    });
+
+    test("renders the very same stored string differently for Date and DateTime", () => {
+      /*
+       * This is the whole isDateOnly flag. Passing the wrong one - or dropping
+       * the argument so both types take the default - still produces a
+       * plausible-looking cell, so nothing but a direct comparison of the two
+       * catches it.
+       */
+      const asDate: string =
+        renderValue({ value: storedIsoValue, definition: dateDefinition })
+          .textContent || "";
+      const asDateTime: string =
+        renderValue({ value: storedIsoValue, definition: dateTimeDefinition })
+          .textContent || "";
+
+      expect(asDate).not.toEqual(asDateTime);
+      expect(asDateTime).toContain("14:30");
+      expect(asDate).not.toContain("14:30");
+    });
+
+    test("resolves the instant in the viewer's timezone, not in UTC as stored", () => {
+      /*
+       * The stored string is UTC; the cell is read by a person. A New York
+       * viewer must see their own 10:30 - and, at the edges of the day, their
+       * own calendar date - or the table disagrees with every other date in
+       * the product.
+       */
+      OneUptimeDate.setUserTimezone(Timezone.AmericaNew_York);
+
+      expect(
+        renderValue({ value: storedIsoValue, definition: dateTimeDefinition })
+          .textContent,
+      ).toEqual("Aug 17 2026, 10:30 EDT");
+    });
+
+    test("reads an offset-form ISO string as the same instant as the Z form", () => {
+      /*
+       * Both spellings are legal ISO-8601 and both are in the wild - the form
+       * writes "Z", an API client may well post "+00:00" - and they name the
+       * same moment, so they have to render the same.
+       */
+      expect(
+        renderValue({
+          value: "2026-08-17T14:30:00+00:00",
+          definition: dateTimeDefinition,
+        }).textContent,
+      ).toEqual("Aug 17 2026, 14:30 UTC");
+    });
+
+    test("renders a date as plain text rather than as a dropdown badge", () => {
+      /*
+       * The date branch has to sit above the dropdown and fall-through text
+       * branches. A date wearing a badge would read as a tag, which is a
+       * different kind of value.
+       */
+      const container: HTMLElement = renderValue({
+        value: storedIsoValue,
+        definition: dateDefinition,
+      });
+
+      expect(getBadgeLabels(container)).toEqual([]);
+      expect(
+        container.querySelector('[data-dropdown-value-badge="true"]'),
+      ).toBeNull();
+      expect(getPlaceholder(container)).toBeNull();
+    });
+
+    test("renders the placeholder for a date nobody has filled in", () => {
+      /*
+       * Not "Invalid date": an unset date is the ordinary state of a field that
+       * was added to the project last week, and a whole column of red herrings
+       * would train people to ignore the one row that really is broken.
+       */
+      for (const definition of [dateDefinition, dateTimeDefinition]) {
+        for (const value of [undefined, null, ""]) {
+          const container: HTMLElement = renderValue({
+            value: value,
+            definition: definition,
+          });
+
+          expect(container.textContent).toEqual("-");
+          expect(getPlaceholder(container)).not.toBeNull();
+        }
+      }
+    });
+
+    test("uses the column's noValueMessage for a missing date", () => {
+      // The empty branch is shared, so a date field inherits the same override.
+      expect(
+        renderValue({
+          value: null,
+          definition: dateTimeDefinition,
+          noValueMessage: "Never audited",
+        }).textContent,
+      ).toEqual("Never audited");
+    });
+
+    test("falls back to the raw stored string when the value will not parse", () => {
+      /*
+       * A value written over the API - or pasted into a CSV import - before the
+       * field was turned into a date is still sitting in the jsonb bag, and the
+       * cell is the only place anyone will ever see it. Showing what is
+       * actually stored is what lets someone work out WHY the row is wrong;
+       * "Invalid date" says only that something is, and looks identical for
+       * every kind of garbage, so the fix (re-import "Q3 2026" as a real date)
+       * is invisible from the table.
+       */
+      expect(
+        renderValue({ value: "not-a-date", definition: dateDefinition })
+          .textContent,
+      ).toEqual("not-a-date");
+      expect(
+        renderValue({ value: "Q3 2026", definition: dateTimeDefinition })
+          .textContent,
+      ).toEqual("Q3 2026");
+    });
+  });
+
+  describe("getCustomFieldColumns", () => {
+    test("still disables sorting on a date column", () => {
+      /*
+       * Being a date makes a jsonb key look more orderable than it is - it is
+       * still reachable only through an explicit ->> expression, which the sort
+       * path has no concept of, so a clickable header would push an unknown
+       * property into the query builder exactly as it would for text.
+       */
+      const columns: Columns<Monitor> = getCustomFieldColumns<Monitor>({
+        definitions: [dateDefinition, dateTimeDefinition],
+      });
+
+      for (const column of columns) {
+        expect(column.disableSort).toBe(true);
+      }
+    });
+
+    test("still hides a date column by default", () => {
+      // Date fields are no more special than the rest in the column picker.
+      const columns: Columns<Monitor> = getCustomFieldColumns<Monitor>({
+        definitions: [dateDefinition, dateTimeDefinition],
+      });
+
+      for (const column of columns) {
+        expect(column.isHiddenByDefault).toBe(true);
+      }
+    });
+
+    test("exports the raw ISO string for a Date field, not the humanised one", () => {
+      /*
+       * Deliberate: the CSV is fed back into an external CMDB, which wants a
+       * machine-readable timestamp. "Aug 17, 2026" would have to be re-parsed
+       * on the far side by a locale nobody agreed on, and a date-only rendering
+       * has already thrown the time away.
+       */
+      const column: Column<Monitor> = columnAt(
+        getCustomFieldColumns<Monitor>({ definitions: [dateDefinition] }),
+        0,
+      );
+
+      expect(
+        exportValueOf(
+          column,
+          monitorWithFields({ "Warranty Expiry": storedIsoValue }),
+        ),
+      ).toEqual(storedIsoValue);
+    });
+
+    test("exports the raw ISO string for a DateTime field too", () => {
+      const column: Column<Monitor> = columnAt(
+        getCustomFieldColumns<Monitor>({ definitions: [dateTimeDefinition] }),
+        0,
+      );
+
+      expect(
+        exportValueOf(
+          column,
+          monitorWithFields({ "Last Audited At": storedIsoValue }),
+        ),
+      ).toEqual(storedIsoValue);
+    });
+
+    test("exports an empty cell for a date nobody has filled in", () => {
+      // Not the literal "undefined", and not today's date either.
+      const column: Column<Monitor> = columnAt(
+        getCustomFieldColumns<Monitor>({ definitions: [dateDefinition] }),
+        0,
+      );
+
+      expect(exportValueOf(column, new Monitor())).toEqual("");
+      expect(
+        exportValueOf(column, monitorWithFields({ "Warranty Expiry": null })),
+      ).toEqual("");
+    });
+
+    test("renders the humanised date off the row while exporting the ISO one", () => {
+      /*
+       * The end-to-end version of the split: the same column, the same row,
+       * two different strings on purpose. Collapsing them - either way round -
+       * breaks one of the two audiences.
+       */
+      const column: Column<Monitor> = columnAt(
+        getCustomFieldColumns<Monitor>({ definitions: [dateDefinition] }),
+        0,
+      );
+      const monitor: Monitor = monitorWithFields({
+        "Warranty Expiry": storedIsoValue,
+      });
+
+      expect(renderColumn(column, monitor).textContent).toEqual("Aug 17, 2026");
+      expect(exportValueOf(column, monitor)).toEqual(storedIsoValue);
+    });
+
+    test("renders a DateTime straight off the row", () => {
+      const column: Column<Monitor> = columnAt(
+        getCustomFieldColumns<Monitor>({ definitions: [dateTimeDefinition] }),
+        0,
+      );
+
+      expect(
+        renderColumn(
+          column,
+          monitorWithFields({ "Last Audited At": storedIsoValue }),
+        ).textContent,
+      ).toEqual("Aug 17 2026, 14:30 UTC");
+    });
+
+    test("renders the placeholder for a row with no date stored", () => {
+      const column: Column<Monitor> = columnAt(
+        getCustomFieldColumns<Monitor>({ definitions: [dateDefinition] }),
+        0,
+      );
+
+      expect(
+        getPlaceholder(renderColumn(column, new Monitor())),
+      ).not.toBeNull();
+    });
   });
 });

--- a/Common/Types/CustomField/CustomFieldType.ts
+++ b/Common/Types/CustomField/CustomFieldType.ts
@@ -1,9 +1,37 @@
+/*
+ * The member VALUES are load-bearing beyond this enum.
+ *
+ * CustomFieldsDetail passes a definition's `customFieldType` straight through
+ * as the `fieldType` of a Detail field and of a form field, so every member
+ * here has to name a member of BOTH `FieldType` (Detail) and
+ * `FormFieldSchemaType` (Forms) by value. `Boolean` is the standing example:
+ * it reaches the form as FormFieldSchemaType.Toggle, which is spelled
+ * `Toggle = "Boolean"` for exactly this reason.
+ *
+ * Adding a member without that correspondence compiles fine and then renders
+ * an empty cell and an input the user cannot type into.
+ */
 enum CustomFieldType {
   Text = "Text",
   Number = "Number",
   Boolean = "Boolean",
   Dropdown = "Dropdown",
   MultiSelectDropdown = "MultiSelectDropdown",
+
+  /**
+   * A calendar date with no time of day — purchase date, warranty expiry,
+   * end-of-life. Stored in the `customFields` jsonb bag as an ISO-8601 string,
+   * which is what makes it comparable: ISO-8601 sorts identically as text and
+   * as an instant, so the range filters work over a jsonb key without a cast
+   * (see JSONColumnQuery.compareText).
+   */
+  Date = "Date",
+
+  /**
+   * As `Date`, but the time of day is part of the answer — last audited at,
+   * decommissioned at.
+   */
+  DateTime = "DateTime",
 }
 
 export default CustomFieldType;

--- a/Common/UI/Components/ModelTable/CustomFieldColumns.tsx
+++ b/Common/UI/Components/ModelTable/CustomFieldColumns.tsx
@@ -5,6 +5,7 @@ import DropdownValueBadge from "../Dropdown/DropdownValueBadge";
 import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
 import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import CustomFieldType from "../../../Types/CustomField/CustomFieldType";
+import OneUptimeDate from "../../../Types/Date";
 import { CustomFieldDefinition } from "../../../Types/CustomField/CustomFieldDefinition";
 import {
   CustomFieldDropdownOption,
@@ -198,6 +199,60 @@ export const renderCustomFieldValue: RenderCustomFieldValueFunction = (data: {
         {isTrue ? "Yes" : "No"}
       </span>
     );
+  }
+
+  if (
+    definition.customFieldType === CustomFieldType.Date ||
+    definition.customFieldType === CustomFieldType.DateTime
+  ) {
+    /*
+     * Stored as ISO-8601 (the shared date Input normalises every entry through
+     * OneUptimeDate.toString()), which is unreadable in a cell, so it is shown
+     * in the viewer's own timezone — the same rendering Detail gives a date
+     * field, so the list and the item page agree.
+     */
+    const isDateOnly: boolean =
+      definition.customFieldType === CustomFieldType.Date;
+    const raw: string = String(value);
+
+    /*
+     * Validity is decided here rather than by inspecting what the formatter
+     * returned, because the formatter never reports failure: OneUptimeDate
+     * .fromString swallows moment's parse error and falls back to `new
+     * Date(str)`, so junk becomes an Invalid Date and moment renders it as the
+     * literal, truthy string "Invalid date" (and "Invalid date UTC" for the
+     * DateTime variant). A `formatted || raw` fallback therefore never fires.
+     *
+     * Showing the raw text instead matters because the value is not
+     * necessarily one this UI wrote — a project can PUT anything into the
+     * `customFields` bag over the API, and may well have been storing dates as
+     * free text before this field became a date. "Invalid date" hides which
+     * value is wrong; the value itself is the thing that lets someone fix it.
+     */
+    let parsed: Date | null = null;
+
+    try {
+      parsed = OneUptimeDate.fromString(raw);
+    } catch {
+      parsed = null;
+    }
+
+    if (!parsed || isNaN(parsed.getTime())) {
+      return <span>{raw}</span>;
+    }
+
+    try {
+      return (
+        <span>
+          {OneUptimeDate.getDateAsUserFriendlyLocalFormattedString(
+            parsed,
+            isDateOnly,
+          )}
+        </span>
+      );
+    } catch {
+      return <span>{raw}</span>;
+    }
   }
 
   if (definition.customFieldType === CustomFieldType.MultiSelectDropdown) {


### PR DESCRIPTION
Groundwork for tracking assets in the Inventory catalog, from evaluating #3137.

That issue asks for an asset/CMDB module. Most of it already exists — the Inventory product shipped on Aug 13–14, two days *after* the issue was filed, and it already mirrors Network Devices into the catalog and lets you set custom fields on any item. This PR closes the two gaps that stood between that and an asset register a project could trust, and writes the documentation whose absence is the likeliest reason the issue was filed at all.

## 1. Date custom fields

`CustomFieldType` had five members and no date, so purchase date and warranty expiry could only be stored as text — and *"which warranties expire next quarter"* was unanswerable. Adds `Date` and `DateTime`.

Both values already exist in `FieldType` and `FormFieldSchemaType`, so the detail view and the edit form needed no change. That correspondence is load-bearing and invisible — `CustomFieldsDetail` passes `customFieldType` straight through as a `fieldType` through an `as any`, so a member without a counterpart compiles cleanly and then renders an empty cell and an input you cannot type into. There is now a test for it.

Filter chips route through the shared date-range builder, so a custom field date answers *"is before the 5th"* exactly as a real date column does, including the day-vs-instant distinction between `Date` and `DateTime`.

### The silent wrong answer underneath

`GreaterThan` / `LessThan` and their or-equal forms compiled **every** jsonb comparison through `compareNumeric`. For an ISO date operand that bound `CAST(NaN AS NUMERIC)`, while `numericExpression` independently returns `NULL` for non-numeric text. The predicate was `NULL > NaN` on every row: no error, no rows, and a lit filter chip over an empty table.

They now branch to text like `InBetween` always has. This is correct rather than expedient — ISO-8601 is ordered identically as text and as an instant, and the shared date `Input` normalises every entry through `OneUptimeDate.toString()` before it reaches the bag. `toScalar` also now maps a `Date` to its ISO string; the previous `String(value)` fallback produced `"Sun Aug 17 2026 …"`, which sorts by weekday name.

## 2. The inventory mirror no longer destroys user data

`removeOrphans` hard-deleted a mirrored row when its owning device disappeared — **taking the row's `customFields` with it.** That is the only copy of whatever serial numbers and warranty dates someone entered, with no audit trail, because `hardDeleteBy` bypasses the audit hook. Anyone following the advice in the new docs would have been one device deletion away from losing their asset data.

Orphans carrying user-authored values are now **archived** instead. That produces the same disappearance from the default list — which is the visible behaviour the delete existed to produce — while leaving the data recoverable from the Archived tab. Orphans with nothing typed are still deleted. An already-archived orphan is skipped so `archivedAt` keeps reporting when the device actually went away rather than the time of the last sweep.

The decision is extracted as a pure function (`partitionOrphanRows`) so it is testable without mocking the service. `InventorySyncResult` gained an `archived` count, reported separately in the job log.

## 3. NetworkDevice mirror was ignoring archived devices

The NetworkDevice source filtered on `{}` rather than `{ isArchived: false }`, on the strength of a comment claiming NetworkDevice has no archive flag. It does — `NetworkDevice.isArchived`. IoTDevice is genuinely the only source without one. Archived devices were still being mirrored into the live estate view. `findLiveIds` is deliberately unfiltered, so this changes what is *refreshed*, not what is deleted.

## 4. Documentation

The Inventory product shipped with none — no content pages, no nav entry, nothing discoverable before signup. Adds three pages plus nav and all 16 locale files:

- **Overview** — what the catalog is, the three sources and who owns each row's lifecycle, archiving vs deleting
- **Custom Fields** — a worked asset vocabulary (serial number, warranty expiry, lifecycle status, assigned site) and what each type can be filtered by
- **Exporting to a CMDB** — the recipe the reporter actually asked for: auth, `POST /api/inventory-item/get-list`, CSV via `?output-type=csv`, and why to correlate on `entityKey` rather than display name

## Tests

**148 new tests**, all passing.

| Suite | Added |
| --- | --- |
| `JSONColumnQuery.test.ts` | 41 — text/numeric branch per operator, the NaN regression, Date→ISO, why lexicographic ordering is sound |
| `CustomFieldFacets.test.ts` | 42 — chip kind, operator sets, full query vocabulary for both date types, day-vs-instant |
| `InventoryEntityRegistry.test.ts` | 29 — `hasCustomFieldValues` (incl. stored `false`/`0`), `partitionOrphanRows`, every source's archive filter checked against the real models |
| `CustomFieldColumns.test.tsx` | 18 — date vs datetime rendering, timezone-pinned, export stays ISO |
| `CustomFieldTypeCorrespondence.test.ts` | 18 — new file; the enum invariant above |

Two of the test agents verified non-vacuity by mutation — temporarily breaking the production code and confirming exactly the expected tests failed.

**A test caught a real bug in this PR's own first draft:** the documented raw-string fallback for an unparseable date was dead code, because `getDateAsUserFriendlyLocalFormattedString` returns the truthy string `"Invalid date"` rather than throwing or returning empty. Fixed by validating before formatting.

## Verification

- `tsc --noEmit` clean in both `Common` and `App`
- `eslint` clean on every changed file
- Common: 1873 tests pass across the affected suites
- App: 8180 tests pass, full suite
- Re-verified after merging latest `master`

Six App suites (`Tests/FeatureSet/Workflow/*`) fail to *load* on this machine with an `isolated-vm` native ABI error. **Pre-existing and environmental** — reproduced identically on a clean, unmodified checkout, and this PR touches no workflow code.

## Not included, deliberately

- `GreaterThanOrNull` / `LessThanOrNull` still call `compareNumeric` unconditionally and carry the same latent defect. Nothing emits them with a date today, so the current behaviour is pinned by a test rather than changed; flagging it rather than widening scope.
- No schema migration — `customFields` is an existing jsonb column and `isArchived` an existing boolean.
- The larger asks in #3137 (owner user/team on inventory items, a site relation, software licence tracking) are untouched.