### PR TITLE
fix(telemetry): filter logs by resource entity keys instead of primaryEntityId

### DIFF
--- a/Common/Server/API/TelemetryAPI.ts
+++ b/Common/Server/API/TelemetryAPI.ts
@@ -13,6 +13,7 @@ import CommonAPI from "./CommonAPI";
 import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import TelemetryType from "../../Types/Telemetry/TelemetryType";
 import TelemetryAttributeService from "../Services/TelemetryAttributeService";
+import ResourceEntityFilter from "../Utils/Telemetry/ResourceEntityFilter";
 import LogAggregationService, {
   HistogramBucket,
   HistogramRequest,
@@ -421,15 +422,41 @@ router.post(
         (body["bucketSizeInMinutes"] as number) ||
         computeDefaultBucketSize(startTime, endTime);
 
-      const serviceIds: Array<ObjectID> | undefined = body["serviceIds"]
+      const requestedServiceIds: Array<ObjectID> | undefined = body[
+        "serviceIds"
+      ]
         ? (body["serviceIds"] as Array<string>).map((id: string) => {
             return new ObjectID(id);
           })
         : undefined;
 
-      const entityKeys: Array<string> | undefined = body["entityKeys"]
-        ? (body["entityKeys"] as Array<string>)
+      /*
+       * The explorer coalesces every resource facet into `serviceIds`. Ids that
+       * name a resource entity have to become entity keys instead, or they are
+       * matched against `primaryEntityId`, which OTLP telemetry never carries
+       * for anything but its Service. See ResourceEntityFilter.
+       */
+      const splitResourceFilters: {
+        serviceIds: Array<ObjectID>;
+        entityKeys: Array<string>;
+      } = await ResourceEntityFilter.splitResourceFilterIds({
+        projectId,
+        ids: requestedServiceIds || [],
+      });
+
+      const serviceIds: Array<ObjectID> | undefined = requestedServiceIds
+        ? splitResourceFilters.serviceIds
         : undefined;
+
+      const resourceEntityKeys: Array<string> = splitResourceFilters.entityKeys;
+
+      const entityKeys: Array<string> | undefined =
+        body["entityKeys"] || resourceEntityKeys.length > 0
+          ? [
+              ...((body["entityKeys"] as Array<string>) || []),
+              ...resourceEntityKeys,
+            ]
+          : undefined;
 
       const severityTexts: Array<string> | undefined = body["severityTexts"]
         ? (body["severityTexts"] as Array<string>)
@@ -521,15 +548,41 @@ router.post(
 
       const limit: number = (body["limit"] as number) || 500;
 
-      const serviceIds: Array<ObjectID> | undefined = body["serviceIds"]
+      const requestedServiceIds: Array<ObjectID> | undefined = body[
+        "serviceIds"
+      ]
         ? (body["serviceIds"] as Array<string>).map((id: string) => {
             return new ObjectID(id);
           })
         : undefined;
 
-      const entityKeys: Array<string> | undefined = body["entityKeys"]
-        ? (body["entityKeys"] as Array<string>)
+      /*
+       * The explorer coalesces every resource facet into `serviceIds`. Ids that
+       * name a resource entity have to become entity keys instead, or they are
+       * matched against `primaryEntityId`, which OTLP telemetry never carries
+       * for anything but its Service. See ResourceEntityFilter.
+       */
+      const splitResourceFilters: {
+        serviceIds: Array<ObjectID>;
+        entityKeys: Array<string>;
+      } = await ResourceEntityFilter.splitResourceFilterIds({
+        projectId,
+        ids: requestedServiceIds || [],
+      });
+
+      const serviceIds: Array<ObjectID> | undefined = requestedServiceIds
+        ? splitResourceFilters.serviceIds
         : undefined;
+
+      const resourceEntityKeys: Array<string> = splitResourceFilters.entityKeys;
+
+      const entityKeys: Array<string> | undefined =
+        body["entityKeys"] || resourceEntityKeys.length > 0
+          ? [
+              ...((body["entityKeys"] as Array<string>) || []),
+              ...resourceEntityKeys,
+            ]
+          : undefined;
 
       const severityTexts: Array<string> | undefined = body["severityTexts"]
         ? (body["severityTexts"] as Array<string>)
@@ -728,8 +781,7 @@ function parseTraceFilterBody(body: JSONObject): TraceFilters {
    * filtering is dropped entirely so it cannot narrow to nothing.
    */
   const attributeFilterRecord: () => TraceAttributeFilters | undefined = ():
-    | TraceAttributeFilters
-    | undefined => {
+    TraceAttributeFilters | undefined => {
     const raw: unknown = body["attributes"];
     if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
       return undefined;
@@ -2067,8 +2119,7 @@ router.post(
       const body: JSONObject = req.body as JSONObject;
 
       const filterQuery: string | undefined = body["filterQuery"] as
-        | string
-        | undefined;
+        string | undefined;
 
       if (!filterQuery) {
         return Response.sendErrorResponse(

--- a/Common/Server/Utils/Telemetry/ResourceEntityFilter.ts
+++ b/Common/Server/Utils/Telemetry/ResourceEntityFilter.ts
@@ -1,0 +1,101 @@
+import ObjectID from "../../../Types/ObjectID";
+import PositiveNumber from "../../../Types/PositiveNumber";
+import HostModel from "../../../Models/DatabaseModels/Host";
+import KubernetesClusterModel from "../../../Models/DatabaseModels/KubernetesCluster";
+import HostService from "../../Services/HostService";
+import KubernetesClusterService from "../../Services/KubernetesClusterService";
+import {
+  keyForHost,
+  keyForKubernetesCluster,
+} from "../../../Utils/Telemetry/EntityKey";
+
+export interface SplitResourceFilters {
+  serviceIds: Array<ObjectID>;
+  entityKeys: Array<string>;
+}
+
+/**
+ * The log explorer coalesces every resource facet — service, host, docker host,
+ * podman host, kubernetes cluster — into one `serviceIds` list, which the
+ * aggregation services turn into `primaryEntityId IN (...)`.
+ *
+ * That predicate only matches telemetry whose *primary* entity is the resource
+ * itself, which is true for resource-scoped ingestion but not for OTLP.
+ * OpenTelemetry telemetry is primary-keyed on its Service and carries the
+ * resource relationship in `entityKeys` / the scalar `*EntityKey` columns, so
+ * filtering by a Kubernetes cluster alone matched nothing at all, while
+ * selecting a cluster *and* a service appeared to work only because both ids
+ * landed in the same `IN (...)` list and the service half matched.
+ *
+ * Split the ids by what they actually name: ids that resolve to a resource
+ * entity become entity keys, which the aggregation services already match with
+ * `hasAny(entityKeys, ...)`; anything else is left as a service id. Cross-facet
+ * selections then intersect instead of being OR-ed together.
+ */
+export default class ResourceEntityFilter {
+  public static async splitResourceFilterIds(data: {
+    projectId: ObjectID;
+    ids: Array<ObjectID>;
+  }): Promise<SplitResourceFilters> {
+    const { projectId, ids } = data;
+
+    if (!ids || ids.length === 0) {
+      return { serviceIds: [], entityKeys: [] };
+    }
+
+    const idStrings: Array<string> = ids.map((id: ObjectID): string => {
+      return id.toString();
+    });
+
+    const entityKeys: Array<string> = [];
+    const resolvedResourceIds: Set<string> = new Set<string>();
+
+    const clusters: Array<KubernetesClusterModel> =
+      await KubernetesClusterService.findBy({
+        query: { projectId, _id: idStrings } as any,
+        select: { _id: true, clusterIdentifier: true },
+        limit: new PositiveNumber(idStrings.length),
+        skip: new PositiveNumber(0),
+        props: { isRoot: true },
+      });
+
+    for (const cluster of clusters) {
+      const identifier: string | undefined = cluster.clusterIdentifier;
+
+      // Cluster identity is name-keyed; without it there is no key to match.
+      if (!cluster._id || !identifier) {
+        continue;
+      }
+
+      entityKeys.push(
+        keyForKubernetesCluster(projectId.toString(), identifier),
+      );
+      resolvedResourceIds.add(cluster._id.toString());
+    }
+
+    const hosts: Array<HostModel> = await HostService.findBy({
+      query: { projectId, _id: idStrings } as any,
+      select: { _id: true, hostIdentifier: true },
+      limit: new PositiveNumber(idStrings.length),
+      skip: new PositiveNumber(0),
+      props: { isRoot: true },
+    });
+
+    for (const host of hosts) {
+      const identifier: string | undefined = host.hostIdentifier;
+
+      if (!host._id || !identifier) {
+        continue;
+      }
+
+      entityKeys.push(keyForHost(projectId.toString(), identifier));
+      resolvedResourceIds.add(host._id.toString());
+    }
+
+    const serviceIds: Array<ObjectID> = ids.filter((id: ObjectID): boolean => {
+      return !resolvedResourceIds.has(id.toString());
+    });
+
+    return { serviceIds, entityKeys };
+  }
+}


### PR DESCRIPTION
> [!WARNING]
> **Untested.** I could not build or run the monorepo locally, so this has not been compiled or exercised against a running instance. The *diagnosis* below is verified against a live 12.0.10 deployment; the patch itself is a best-effort fix from reading the code and needs a maintainer's eye — particularly on whether other endpoints building the same filter need the same treatment.

## Problem

In the log explorer, selecting a **Kubernetes Cluster** facet returns no logs at all. Selecting a cluster *together with* a service returns that service's logs, with the cluster selection having no effect.

## Cause

`RESOURCE_FACET_KEYS` in `App/FeatureSet/Dashboard/src/Components/Logs/LogsHistogramRequest.ts` coalesces service, host, docker host, podman host and Kubernetes cluster selections into a single `serviceIds` list, which `LogAggregationService` turns into `primaryEntityId IN (...)`. The comment there states the intent plainly:

> Filtering by any of them is a single `primaryEntityId IN (...)` predicate, so selections across these facets are coalesced into one list.

That holds for telemetry whose *primary* entity is the resource. It does not hold for OTLP telemetry, which `OpenTelemetryIngestService` primary-keys on its Service (`primaryEntityType: ServiceType.OpenTelemetry`) while recording the resource relationship in `entityKeys` and the scalar `*EntityKey` columns — resolved from `k8s.cluster.name` per `EntityKey.keyForKubernetesCluster` / `TelemetryEntity.k8sClusterIdentity`.

So a cluster id is compared against a column that only ever holds a Service id: no rows. And because both ids land in the same `IN (...)` list, adding a service makes results reappear while silently dropping the cluster constraint — the two facets OR rather than intersect.

## Evidence

From a 12.0.10 instance ingesting Kubernetes logs through the OpenTelemetry Collector (no OneUptime Kubernetes Agent), over the same 15-minute window:

| predicate | rows |
|---|---|
| `primaryEntityId = '<clusterId>'` (what the UI sends today) | **0** |
| `hasAny(entityKeys, ['<clusterEntityKey>'])` | **18,447** |
| `hasAny(entityKeys, ['<other clusterEntityKey>'])` | **6,725** |

Every `LogItemV3` row in that window has its `k8sClusterEntityKey` present inside `entityKeys` (5,114 of 5,114 sampled), so ingestion is doing its part — only the read path disagrees.

## Approach

`ResourceEntityFilter.splitResourceFilterIds` splits the incoming ids by what they actually name: ids resolving to a resource entity become entity keys, matched by the `hasAny(entityKeys, ...)` predicate the aggregation services already support; anything else stays a service id. Cross-facet selections then intersect instead of being OR-ed.

Wired into the logs endpoints in `TelemetryAPI` that parse the `serviceIds` + `entityKeys` pair.

## Open questions for maintainers

1. **Scope.** I patched the endpoints sharing that parse shape. Traces and metrics coalesce the same way (`TraceCorrelatedSignals.RESOURCE_FACET_KEYS`) and presumably need the same fix; I left them alone rather than guess.
2. **Docker/Podman hosts.** I handled Kubernetes clusters and hosts, where `keyFor*` helpers exist. `dockerHostId` / `podmanHostId` have no equivalent helper that I could find, so they still fall through as service ids.
3. **Is the coalescing intentional for agent-ingested telemetry?** If resource-scoped ingestion really does set `primaryEntityId` to the resource, both predicates may need to be OR-ed rather than replaced.

Happy to adjust or split this up.
