### PR TITLE
feat(network-topology): declared parent-child links and an operator-set device role

### DIFF
--- a/App/FeatureSet/BaseAPI/API/NetworkDeviceTopology.ts
+++ b/App/FeatureSet/BaseAPI/API/NetworkDeviceTopology.ts
@@ -133,6 +133,13 @@ export default class NetworkDeviceTopologyAPI {
                 sysDescr: true,
                 sysObjectId: true,
                 /*
+                 * The operator's own answer, which beats the classifier
+                 * above. Load-bearing for devices nothing walks: with no
+                 * sysDescr and no sysObjectId to read, this is the only
+                 * evidence there is about what the box actually does.
+                 */
+                deviceRole: true,
+                /*
                  * Not rendered either — read only by the neighbor matcher.
                  * An LLDP chassis id is a serial as often as it is a name,
                  * and without this the device it names is drawn as an
@@ -320,6 +327,7 @@ export default class NetworkDeviceTopologyAPI {
                 name: true,
                 fromDeviceId: true,
                 toDeviceId: true,
+                parentDeviceId: true,
                 fromPortName: true,
                 toPortName: true,
                 monitor: {
@@ -414,6 +422,7 @@ export default class NetworkDeviceTopologyAPI {
                 deviceModel: device.deviceModel,
                 sysDescr: device.sysDescr,
                 sysObjectId: device.sysObjectId,
+                deviceRole: device.deviceRole,
                 serialNumber: device.serialNumber,
                 isNeighborDiscoveryEnabled: device.walkInterfaces,
                 macAddresses: macAddressesByDeviceId.get(device.id!.toString()),
@@ -513,6 +522,7 @@ export default class NetworkDeviceTopologyAPI {
               monitorStatus: linkStatusId
                 ? nodeStatusByMonitorStatusId.get(linkStatusId)
                 : undefined,
+              parentDeviceId: link.parentDeviceId?.toString(),
             });
           }
 
@@ -522,6 +532,15 @@ export default class NetworkDeviceTopologyAPI {
                 fromDeviceId: link.fromDeviceId,
                 toDeviceId: link.toDeviceId,
                 name: outcome.ruleName,
+                /*
+                 * A link rule is stated as child labels and parent labels,
+                 * so unlike a hand-drawn link it knows which end is up
+                 * without anybody having to say — and resolveRules puts
+                 * the child in `from` and the parent in `to`. Passing it
+                 * through means "these APs uplink to that switch" draws as
+                 * an actual hierarchy rather than as a bag of peer cables.
+                 */
+                parentDeviceId: link.toDeviceId,
               });
             }
           }

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceRoleFormFields.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceRoleFormFields.ts
@@ -1,0 +1,32 @@
+import { NetworkTopologyDeviceRole } from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
+import {
+  DEVICE_ROLES_IN_LEGEND_ORDER,
+  labelForDeviceRole,
+} from "Common/Utils/Monitor/NetworkDeviceRoleUtil";
+import { DropdownOption } from "Common/UI/Components/Dropdown/Dropdown";
+
+/*
+ * The device-role picker, shared by the create form on the Devices list and
+ * the edit form on a device's Settings page so the two cannot drift.
+ *
+ * Built from DEVICE_ROLES_IN_LEGEND_ORDER and DEVICE_ROLE_LABELS rather than
+ * hand-listed, so a role added to the classifier turns up here, in the map
+ * legend and in the node shapes at once instead of in two of the three.
+ *
+ * "Unknown" is deliberately not offered. The empty value already means
+ * "no override — work it out from SNMP", and an explicit "unknown" would
+ * mean something subtly different and much less useful: stop classifying
+ * and draw a neutral node forever.
+ */
+export const DEVICE_ROLE_OPTIONS: Array<DropdownOption> =
+  DEVICE_ROLES_IN_LEGEND_ORDER.map((role: NetworkTopologyDeviceRole) => {
+    return {
+      value: role,
+      label: labelForDeviceRole(role),
+    };
+  });
+
+export const DEVICE_ROLE_FIELD_TITLE: string = "Device Role";
+
+export const DEVICE_ROLE_FIELD_DESCRIPTION: string =
+  "What this device does on the network. Leave it empty for SNMP devices — the role is read from their own identity, and that is more reliable than a guess. Set it for anything without SNMP to read: a ping-only device has no identity to classify, so without this it is drawn as an anonymous node and treated as top-of-network when the map lays out the hierarchy.";

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/ParentChildTopologyLayout.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/ParentChildTopologyLayout.ts
@@ -184,6 +184,128 @@ const buildTierById: (
 };
 
 /**
+ * The hierarchy an operator declared outright, as child → parent.
+ *
+ * Discovery reports cables, not hierarchies: LLDP tells us two boxes are
+ * connected and has no opinion about which one is upstream. Everything
+ * below this point is therefore inference — good inference on an SNMP
+ * estate, no inference at all on the ping-only devices of issue #3192,
+ * whose role nothing can classify and whose neighbours nothing reports.
+ * `NetworkDeviceLink.parentDeviceId` and the parent/child labels of a link
+ * rule are the operator answering directly, and an answer outranks a
+ * guess.
+ *
+ * Two ways an operator can state something unusable, both resolved here so
+ * the traversal downstream can assume a well-formed forest:
+ *
+ *   - CONTRADICTION. Two links both claiming to be the parent of one
+ *     device. Picking between them would be inventing an answer, so both
+ *     are dropped and that device falls back to inference — the same
+ *     "a wrong cable is worse than a missing one" rule the topology
+ *     builder already applies to a match key two devices claim.
+ *   - CYCLE. A is B's parent, B is C's, C is A's. There is no tree in
+ *     that, and a traversal trusting it would never terminate. The
+ *     declarations are applied in canonical child order and any one that
+ *     would close a loop is skipped, so the surviving set is always
+ *     acyclic and always the same set for the same graph.
+ */
+export const buildDeclaredParentMap: (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+) => Map<string, string> = (
+  nodes: Array<NetworkTopologyNode>,
+  edges: Array<NetworkTopologyEdge>,
+): Map<string, string> => {
+  /*
+   * The SAME test canonicalNodeOrder applies, empty-string check included.
+   * This map is the only thing in the file that can introduce an id the
+   * rest of the pipeline never saw, and a looser filter here would put a
+   * node in the forest that is absent from the ordered node list — which
+   * then carries a position nothing re-centres and quietly mis-sizes the
+   * component hull.
+   */
+  const knownNodeIds: Set<string> = new Set<string>();
+  for (const node of nodes || []) {
+    if (node && typeof node.id === "string" && node.id.length > 0) {
+      knownNodeIds.add(node.id);
+    }
+  }
+
+  // child -> every distinct parent claimed for it.
+  const claimedParentsByChild: Map<string, Set<string>> = new Map<
+    string,
+    Set<string>
+  >();
+
+  for (const edge of edges || []) {
+    if (!edge || !edge.parentNodeId) {
+      continue;
+    }
+    const parentId: string = edge.parentNodeId;
+    if (parentId !== edge.fromNodeId && parentId !== edge.toNodeId) {
+      continue;
+    }
+    const childId: string =
+      parentId === edge.fromNodeId ? edge.toNodeId : edge.fromNodeId;
+    if (
+      childId === parentId ||
+      !knownNodeIds.has(childId) ||
+      !knownNodeIds.has(parentId)
+    ) {
+      continue;
+    }
+    const claimed: Set<string> =
+      claimedParentsByChild.get(childId) || new Set<string>();
+    claimed.add(parentId);
+    claimedParentsByChild.set(childId, claimed);
+  }
+
+  /*
+   * Canonical child order, so which declaration loses a cycle is a
+   * function of the graph and never of the order the response arrived in.
+   */
+  const childIds: Array<string> = [...claimedParentsByChild.keys()].sort(
+    compareNodeIds,
+  );
+
+  const declaredParentOf: Map<string, string> = new Map<string, string>();
+
+  for (const childId of childIds) {
+    const claimed: Set<string> = claimedParentsByChild.get(childId)!;
+    if (claimed.size !== 1) {
+      // Contradiction: two links both claim to parent this device.
+      continue;
+    }
+    const parentId: string = [...claimed][0]!;
+
+    /*
+     * Walk up from the proposed parent through what has already been
+     * accepted. Reaching the child means this declaration closes a loop.
+     * The walk is bounded by the number of accepted declarations, so it
+     * terminates even if one ever slipped through.
+     */
+    let cursor: string | undefined = parentId;
+    let createsCycle: boolean = false;
+    for (let step: number = 0; step <= declaredParentOf.size; step++) {
+      if (cursor === undefined) {
+        break;
+      }
+      if (cursor === childId) {
+        createsCycle = true;
+        break;
+      }
+      cursor = declaredParentOf.get(cursor);
+    }
+
+    if (!createsCycle) {
+      declaredParentOf.set(childId, parentId);
+    }
+  }
+
+  return declaredParentOf;
+};
+
+/**
  * Pick the node a component's tree hangs from.
  *
  * Role first, degree second. This deliberately overrides the component's
@@ -192,32 +314,92 @@ const buildTierById: (
  * the router as a child of the switch — precisely upside down from the
  * hierarchy the reader came here for. Ties fall through to the id so the
  * choice is a function of the graph and never of the response ordering.
+ *
+ * A device declared to be somebody's child is not a candidate at all: it
+ * has a parent by construction, and a root has none. Only if every member
+ * is spoken for — which the acyclic guarantee above makes impossible, so
+ * this is a belt-and-braces fallback — does the whole component compete.
+ *
+ * Last of all, BELOW role and below degree, being the top of a declared
+ * chain beats losing on the alphabet. Take a switch an operator declared
+ * to uplink to a router, on a site cabled to a second router of identical
+ * rank and identical degree: rooting at the second router makes the
+ * declared parent reachable only THROUGH its own declared child, and the
+ * traversal then has to hoist it somewhere it has no cable to. Rooting at
+ * the declared parent instead makes the chain fall out naturally, every
+ * tree line a real cable.
+ *
+ * It has to be the LAST word rather than the first. Declaring "this access
+ * point hangs off that switch" says nothing whatever about the switch
+ * being the top of the site, so a rule that let it outrank role or degree
+ * would re-root the map — and re-draw every device on it — off one setting
+ * about two of them. Here it only ever displaces the id tiebreak, which is
+ * arbitrary by construction and the one thing a declaration is strictly
+ * better evidence than.
  */
 const chooseTreeRoot: (
   memberIds: Array<string>,
   adjacency: TopologyAdjacency,
   tierById: Map<string, number>,
+  declaredParentOf: Map<string, string>,
 ) => string = (
   memberIds: Array<string>,
   adjacency: TopologyAdjacency,
   tierById: Map<string, number>,
+  declaredParentOf: Map<string, string>,
 ): string => {
-  let bestId: string = memberIds[0]!;
-  let bestTier: number = tierById.get(bestId) ?? 1;
-  let bestDegree: number = adjacency.degreeById.get(bestId) || 0;
+  const candidates: Array<string> = memberIds.filter((id: string) => {
+    return !declaredParentOf.has(id);
+  });
+  const pool: Array<string> = candidates.length > 0 ? candidates : memberIds;
 
-  for (const id of memberIds) {
-    const tier: number = tierById.get(id) ?? 1;
-    const degree: number = adjacency.degreeById.get(id) || 0;
-    const isBetter: boolean =
-      tier < bestTier ||
-      (tier === bestTier &&
-        (degree > bestDegree ||
-          (degree === bestDegree && compareNodeIds(id, bestId) < 0)));
-    if (isBetter) {
+  // Ids named as somebody's parent. A pool member in here tops a chain.
+  const declaredParentIds: Set<string> = new Set<string>(
+    declaredParentOf.values(),
+  );
+
+  const rankOf: (id: string) => [number, number, number] = (
+    id: string,
+  ): [number, number, number] => {
+    return [
+      tierById.get(id) ?? 1,
+      -(adjacency.degreeById.get(id) || 0),
+      declaredParentIds.has(id) ? 0 : 1,
+    ];
+  };
+
+  /*
+   * Negative when `a` should win. Every field is "lower is better", and
+   * the id has the last word so the choice is a function of the graph and
+   * never of the order the response arrived in.
+   */
+  const compareCandidates: (
+    a: string,
+    aRank: [number, number, number],
+    b: string,
+    bRank: [number, number, number],
+  ) => number = (
+    a: string,
+    aRank: [number, number, number],
+    b: string,
+    bRank: [number, number, number],
+  ): number => {
+    for (let index: number = 0; index < aRank.length; index++) {
+      if (aRank[index]! !== bRank[index]!) {
+        return aRank[index]! - bRank[index]!;
+      }
+    }
+    return compareNodeIds(a, b);
+  };
+
+  let bestId: string = pool[0]!;
+  let bestRank: [number, number, number] = rankOf(bestId);
+
+  for (const id of pool) {
+    const rank: [number, number, number] = rankOf(id);
+    if (compareCandidates(id, rank, bestId, bestRank) < 0) {
       bestId = id;
-      bestTier = tier;
-      bestDegree = degree;
+      bestRank = rank;
     }
   }
   return bestId;
@@ -262,6 +444,285 @@ const traverseFromRoot: (
   return { order: order, depthById: depthById };
 };
 
+/** A component's tree, as parent links rather than coordinates. */
+interface RootedTree {
+  parentById: Map<string, string>;
+  childrenById: Map<string, Array<string>>;
+  depthById: Map<string, number>;
+}
+
+/**
+ * The spanning tree of one component when at least one parent in it was
+ * declared.
+ *
+ * Two passes, and the split is the whole design.
+ *
+ * PASS ONE fixes every node's DEPTH. It is a BFS in which a device with a
+ * declared parent is only ever reached through that parent: met across
+ * some other cable it is passed by, and placed later, when its declared
+ * parent comes up.
+ *
+ * That deferral does not always resolve on its own, and assuming it did
+ * was this function's original bug. A declared parent can be reachable
+ * only THROUGH its own declared child — an operator names a router as a
+ * switch's uplink, and that router hangs off nothing else. Then the BFS
+ * refuses to cross into the switch, never reaches the router, and both
+ * strand. {@link chooseTreeRoot} now prefers the top of a declared chain,
+ * which resolves the common shape properly with every tree line still a
+ * real cable; `attachStrandedChain` below is what handles the rest.
+ *
+ * PASS TWO fixes every node's PARENT, and deliberately does NOT reuse
+ * pass one's discovery order. A declared child takes its declared parent;
+ * every other node takes its canonically-first neighbour exactly one
+ * level up — the identical rule `bfsChildrenOf` applies on the inference
+ * path, and the rule this file's own contract promises so that the
+ * radial and seeding layouts agree about what hangs off what. Parenting
+ * by first-discoverer instead (which is what pass one hands you) diverges
+ * from that rule below depth two, so declaring a parent on one branch
+ * would silently re-parent devices on an unrelated branch of the same
+ * site. A setting should change what it describes and nothing else.
+ */
+const buildRootedTreeWithDeclaredParents: (
+  rootId: string,
+  memberIds: Array<string>,
+  adjacency: TopologyAdjacency,
+  declaredParentOf: Map<string, string>,
+) => RootedTree = (
+  rootId: string,
+  memberIds: Array<string>,
+  adjacency: TopologyAdjacency,
+  declaredParentOf: Map<string, string>,
+): RootedTree => {
+  const parentById: Map<string, string> = new Map<string, string>();
+  const depthById: Map<string, number> = new Map<string, number>();
+
+  // parent -> its declared children, canonical order, for the cascade.
+  const declaredChildrenOf: Map<string, Array<string>> = new Map<
+    string,
+    Array<string>
+  >();
+  for (const [childId, parentId] of declaredParentOf) {
+    const children: Array<string> = declaredChildrenOf.get(parentId) || [];
+    children.push(childId);
+    declaredChildrenOf.set(parentId, children);
+  }
+  for (const [, children] of declaredChildrenOf) {
+    children.sort(compareNodeIds);
+  }
+
+  const place: (id: string, parentId: string | null) => void = (
+    id: string,
+    parentId: string | null,
+  ): void => {
+    if (parentId === null) {
+      depthById.set(id, 0);
+      return;
+    }
+    parentById.set(id, parentId);
+    depthById.set(id, (depthById.get(parentId) ?? 0) + 1);
+  };
+
+  const queue: Array<string> = [];
+  let head: number = 0;
+
+  /** Drain the queue, placing declared children first, then neighbours. */
+  const drain: () => void = (): void => {
+    while (head < queue.length) {
+      const current: string = queue[head]!;
+      head++;
+
+      /*
+       * Declared children first, and placed whether or not the cable
+       * between them is in `neighborsById` — a declared link always
+       * produces an edge, so it always is, but depending on that would
+       * make the hierarchy silently conditional on the edge surviving
+       * filtering.
+       */
+      for (const childId of declaredChildrenOf.get(current) || []) {
+        if (!depthById.has(childId)) {
+          place(childId, current);
+          queue.push(childId);
+        }
+      }
+
+      for (const neighbor of adjacency.neighborsById.get(current) || []) {
+        if (depthById.has(neighbor)) {
+          continue;
+        }
+        const declaredParent: string | undefined =
+          declaredParentOf.get(neighbor);
+        if (declaredParent !== undefined && declaredParent !== current) {
+          // Reached the long way round; it belongs under its declared parent.
+          continue;
+        }
+        place(neighbor, current);
+        queue.push(neighbor);
+      }
+    }
+  };
+
+  place(rootId, null);
+  queue.push(rootId);
+  drain();
+
+  /*
+   * Whatever is left is a declared chain the traversal could not enter
+   * from above, because the chain's top is cabled only to its own
+   * declared descendants. The operator has asked for a hierarchy that
+   * runs against the only path into it.
+   *
+   * The declaration still wins. The chain is hoisted as a whole: its TOP
+   * is attached to the canonically-first already-placed neighbour of
+   * anything in the chain, and the cascade then runs down from there.
+   * That one tree line may not correspond to a cable — the alternative is
+   * drawing a declared parent underneath its own child, which is the
+   * error the operator set the field to correct.
+   *
+   * Each round places at least the chain it processes, so this terminates;
+   * and because it seeds the same drain(), the work is bounded by the
+   * nodes still unplaced rather than by a re-scan per node. The previous
+   * sweep re-walked every member on every pass, which on a long stranded
+   * path was quadratic — seconds of blocked main thread on a large site,
+   * triggered by a single link setting.
+   */
+  const topOfChain: (id: string) => string = (id: string): string => {
+    let cursor: string = id;
+    for (let step: number = 0; step <= declaredParentOf.size; step++) {
+      const parentId: string | undefined = declaredParentOf.get(cursor);
+      if (parentId === undefined || depthById.has(parentId)) {
+        return cursor;
+      }
+      cursor = parentId;
+    }
+    return cursor;
+  };
+
+  /** Every unplaced node at or below `topId` in the declared hierarchy. */
+  const declaredChainMembers: (topId: string) => Array<string> = (
+    topId: string,
+  ): Array<string> => {
+    const members: Array<string> = [];
+    const stack: Array<string> = [topId];
+    const seen: Set<string> = new Set<string>([topId]);
+    while (stack.length > 0) {
+      const current: string = stack.pop()!;
+      members.push(current);
+      for (const childId of declaredChildrenOf.get(current) || []) {
+        if (!seen.has(childId) && !depthById.has(childId)) {
+          seen.add(childId);
+          stack.push(childId);
+        }
+      }
+    }
+    return members;
+  };
+
+  for (const id of memberIds) {
+    if (depthById.has(id)) {
+      continue;
+    }
+    const topId: string = topOfChain(id);
+    if (depthById.has(topId)) {
+      continue;
+    }
+
+    /*
+     * topOfChain stops either at a node with no declared parent or at one
+     * whose declared parent is already placed. In the second case the
+     * declaration answers the question outright — no anchor needed, and
+     * using one would put the node somewhere other than under the parent
+     * an operator named.
+     */
+    const placedDeclaredParent: string | undefined =
+      declaredParentOf.get(topId);
+    if (
+      placedDeclaredParent !== undefined &&
+      depthById.has(placedDeclaredParent)
+    ) {
+      place(topId, placedDeclaredParent);
+      queue.push(topId);
+      drain();
+      continue;
+    }
+
+    let anchorId: string | null = null;
+    for (const memberId of declaredChainMembers(topId)) {
+      for (const neighbor of adjacency.neighborsById.get(memberId) || []) {
+        if (!depthById.has(neighbor)) {
+          continue;
+        }
+        if (anchorId === null || compareNodeIds(neighbor, anchorId) < 0) {
+          anchorId = neighbor;
+        }
+      }
+    }
+
+    // No placed neighbour anywhere in the chain: hang it off the root.
+    place(topId, anchorId === null ? rootId : anchorId);
+    queue.push(topId);
+    drain();
+  }
+
+  // Belt and braces: nothing may leave this function without a depth.
+  for (const id of memberIds) {
+    if (!depthById.has(id) && id !== rootId) {
+      place(id, rootId);
+    }
+  }
+
+  /*
+   * PASS TWO. Depths are final; re-derive every parent from them so the
+   * answer matches bfsChildrenOf exactly wherever nothing was declared.
+   * A node with no neighbour one level up keeps the parent pass one gave
+   * it — that is the hoisted chain top, whose tree line is not a cable
+   * and so cannot be found this way.
+   */
+  for (const id of memberIds) {
+    if (id === rootId || declaredParentOf.has(id)) {
+      continue;
+    }
+    const depth: number | undefined = depthById.get(id);
+    if (depth === undefined || depth === 0) {
+      continue;
+    }
+    let bestParent: string | null = null;
+    for (const neighbor of adjacency.neighborsById.get(id) || []) {
+      if (depthById.get(neighbor) !== depth - 1) {
+        continue;
+      }
+      if (bestParent === null || compareNodeIds(neighbor, bestParent) < 0) {
+        bestParent = neighbor;
+      }
+    }
+    if (bestParent !== null) {
+      parentById.set(id, bestParent);
+    }
+  }
+
+  const childrenById: Map<string, Array<string>> = new Map<
+    string,
+    Array<string>
+  >();
+  for (const id of memberIds) {
+    childrenById.set(id, []);
+  }
+  for (const [childId, parentId] of parentById) {
+    const children: Array<string> | undefined = childrenById.get(parentId);
+    if (children) {
+      children.push(childId);
+    }
+  }
+  for (const [, children] of childrenById) {
+    children.sort(compareNodeIds);
+  }
+
+  return {
+    parentById: parentById,
+    childrenById: childrenById,
+    depthById: depthById,
+  };
+};
+
 /**
  * Build the parent-child spanning forest of a topology.
  *
@@ -271,6 +732,11 @@ const traverseFromRoot: (
  * layouts already use, so all three agree about what hangs off what. A
  * device with no links at all is a one-node tree rather than a dropped
  * node.
+ *
+ * Where an operator has DECLARED a parent (see
+ * {@link buildDeclaredParentMap}) that declaration is honoured instead of
+ * inferred, and the declared child is never rooted. Components containing
+ * no declaration take the inference path unchanged.
  *
  * Total: every non-root has exactly one parent, every node has a children
  * entry and a depth, and no node is its own ancestor — parents are always
@@ -294,6 +760,10 @@ export const buildParentChildForest: (
     edges,
     orderedNodeIds,
   );
+  const declaredParentOf: Map<string, string> = buildDeclaredParentMap(
+    nodes,
+    edges,
+  );
 
   const rootIds: Array<string> = [];
   const parentById: Map<string, string> = new Map<string, string>();
@@ -311,7 +781,41 @@ export const buildParentChildForest: (
       component.nodeIds,
       adjacency,
       tierById,
+      declaredParentOf,
     );
+
+    /*
+     * The declared path is taken only for components that actually contain
+     * a declaration. Not an optimisation — it is what guarantees that a
+     * project with no declared parents (every project, until somebody sets
+     * one) gets byte-identical geometry to before, because it runs exactly
+     * the code it ran before.
+     */
+    const hasDeclaredParent: boolean = component.nodeIds.some((id: string) => {
+      return declaredParentOf.has(id);
+    });
+
+    if (hasDeclaredParent) {
+      const tree: RootedTree = buildRootedTreeWithDeclaredParents(
+        rootId,
+        component.nodeIds,
+        adjacency,
+        declaredParentOf,
+      );
+
+      rootIds.push(rootId);
+      for (const [id, depth] of tree.depthById) {
+        depthById.set(id, depth);
+      }
+      for (const [id, children] of tree.childrenById) {
+        childrenById.set(id, children);
+      }
+      for (const [id, parent] of tree.parentById) {
+        parentById.set(id, parent);
+      }
+      continue;
+    }
+
     const traversal: RootedTraversal = traverseFromRoot(rootId, adjacency);
 
     /*

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyLayout.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyLayout.ts
@@ -150,11 +150,46 @@ export const TIERED_GROUP_BOX_BOTTOM_PAD: number = 36;
 
 type TierIndex = 0 | 1 | 2;
 
+/*
+ * Roles that belong at the top of a network: the boxes everything else
+ * reaches the rest of the world through. Every other role is access-layer
+ * or a leaf, and sits a tier below.
+ *
+ * Note what is NOT here: "switch". A switch is infrastructure, but it is
+ * infrastructure that hangs off a router, and the whole point of the top
+ * tier is the handful of devices that hang off nothing.
+ */
+const CORE_DEVICE_ROLES: ReadonlySet<string> = new Set<string>([
+  "router",
+  "firewall",
+  "loadBalancer",
+]);
+
 /**
  * Assign a node to its tier. Exported for tests; pure.
  *
  * `nodeIdsWithFdbEdges` must contain the ids of every node touched by at
  * least one FDB edge (see computeTieredTopologyLayout).
+ *
+ * WHY ROLE COMES FIRST. The FDB heuristic below reads "this device has
+ * endpoints hanging off it, so it is an access switch" — sound, and it was
+ * the only signal available when the tier was invented. Its failure is the
+ * silence: a device with no FDB edges lands in tier 0, the CORE tier,
+ * whether it is a core router or an access point somebody added by ping.
+ * On an SNMP estate that is mostly harmless, because a device with no
+ * endpoints usually IS upstream. On the ping-only devices of issue #3192
+ * it is backwards every time — nothing walks them, so they report no
+ * endpoints, so every camera and access point is drawn at core level and
+ * competes with the actual router to root the parent-child tree.
+ *
+ * A role, when we have one, is a direct statement of what the box does and
+ * settles it. The heuristic survives untouched for "unknown", which is
+ * still the honest answer for most unmanaged peers.
+ *
+ * Endpoint nodes stay tier 2 whatever their role: tier 2 is what the
+ * tiered layout groups into per-switch boxes, and a managed device does
+ * not belong inside one. So a managed leaf — an AP, a server, a printer —
+ * is tier 1, drawn as its own node, one level under the core.
  */
 export const tierForNode: (
   node: NetworkTopologyNode,
@@ -169,7 +204,10 @@ export const tierForNode: (
   if (!node.isManaged) {
     return 1;
   }
-  // Managed: FDB edges mark it as a switch endpoints hang off.
+  if (node.role && node.role !== "unknown") {
+    return CORE_DEVICE_ROLES.has(node.role) ? 0 : 1;
+  }
+  // Role unknown: FDB edges mark it as a switch endpoints hang off.
   return nodeIdsWithFdbEdges.has(node.id) ? 1 : 0;
 };
 

--- a/App/FeatureSet/Dashboard/src/Components/Topology/NetworkLinkDetailPanel.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Topology/NetworkLinkDetailPanel.tsx
@@ -148,6 +148,21 @@ const NetworkLinkDetailPanel: FunctionComponent<ComponentProps> = (
   const fromName: string = props.fromNode?.name || "Unknown device";
   const toName: string = props.toNode?.name || "Unknown device";
 
+  /*
+   * `parentNodeId` names an END, not a side, so which of the two labels it
+   * refers to has to be resolved rather than assumed — a link stored
+   * switch-to-AP and one stored AP-to-switch can declare the same
+   * hierarchy.
+   */
+  const parentName: string | null =
+    edge.parentNodeId === edge.fromNodeId
+      ? fromName
+      : edge.parentNodeId === edge.toNodeId
+        ? toName
+        : null;
+  const childName: string | null =
+    parentName === null ? null : parentName === fromName ? toName : fromName;
+
   return (
     <SideOver
       title={`${fromName} ↔ ${toName}`}
@@ -179,6 +194,25 @@ const NetworkLinkDetailPanel: FunctionComponent<ComponentProps> = (
             );
           })}
         </div>
+
+        {/*
+         * Shown only when somebody declared a direction. Absent is not
+         * "these are peers", it is "nobody said" — and stating the
+         * inference as though it were a fact is exactly the confusion this
+         * whole field exists to end. So there is no "hierarchy: inferred"
+         * row; there is simply nothing here until there is something to
+         * say.
+         */}
+        {parentName && childName ? (
+          <div className="rounded-md bg-gray-50 px-3 py-2 text-xs text-gray-600">
+            <span className="font-medium text-gray-900">{parentName}</span>
+            {" is the parent of "}
+            <span className="font-medium text-gray-900">{childName}</span>
+            {" — declared, not inferred. The Parent-Child view draws "}
+            {childName}
+            {" beneath it."}
+          </div>
+        ) : null}
 
         <EndpointSection
           deviceName={fromName}

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Devices.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Devices.tsx
@@ -15,6 +15,11 @@ import {
   isMonitorBackedDevice,
   isSnmpDevice,
 } from "../../Components/NetworkDevice/MonitoringMethodFormFields";
+import {
+  DEVICE_ROLE_FIELD_DESCRIPTION,
+  DEVICE_ROLE_FIELD_TITLE,
+  DEVICE_ROLE_OPTIONS,
+} from "../../Components/NetworkDevice/DeviceRoleFormFields";
 import BadDataException from "Common/Types/Exception/BadDataException";
 import React, {
   Fragment,
@@ -525,6 +530,18 @@ const NetworkDevices: FunctionComponent<
             fieldType: FormFieldSchemaType.LongText,
             required: false,
             placeholder: "Core switch in the US East datacenter",
+          },
+          {
+            field: {
+              deviceRole: true,
+            },
+            title: DEVICE_ROLE_FIELD_TITLE,
+            stepId: "device-details",
+            description: DEVICE_ROLE_FIELD_DESCRIPTION,
+            fieldType: FormFieldSchemaType.Dropdown,
+            dropdownOptions: DEVICE_ROLE_OPTIONS,
+            required: false,
+            placeholder: "Worked out from the device (SNMP only)",
           },
           {
             field: {

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Links.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Links.tsx
@@ -136,6 +136,22 @@ const NetworkDeviceLinks: FunctionComponent<
           },
           {
             field: {
+              parentDevice: true,
+            },
+            title: "Parent Device",
+            description:
+              "Optional, and it must be one of the two devices above. Set it to say which end is upstream — the router in a router-to-switch link, the switch in a switch-to-access-point one — and the Parent-Child view on the topology map draws the other end beneath it. Left empty, the map works the hierarchy out from device roles and connection counts, which is a good guess on SNMP gear and no guess at all on a device that only answers ping.",
+            fieldType: FormFieldSchemaType.Dropdown,
+            dropdownModal: {
+              type: NetworkDevice,
+              labelField: "name",
+              valueField: "_id",
+            },
+            required: false,
+            placeholder: "Peers — infer the hierarchy",
+          },
+          {
+            field: {
               monitor: true,
             },
             title: "Monitor",
@@ -187,6 +203,31 @@ const NetworkDeviceLinks: FunctionComponent<
               return (
                 <span className="text-sm text-gray-900">
                   {item.toDevice?.name || "—"}
+                </span>
+              );
+            },
+          },
+          {
+            field: {
+              parentDevice: {
+                name: true,
+              },
+            },
+            title: "Parent",
+            type: FieldType.Entity,
+            hideOnMobile: true,
+            /*
+             * "Inferred" rather than a dash: an empty parent is not missing
+             * data, it is the map being left to work the direction out, and
+             * the difference is the whole point of the column.
+             */
+            getElement: (item: NetworkDeviceLink): ReactElement => {
+              if (!item.parentDevice?.name) {
+                return <span className="text-sm text-gray-400">Inferred</span>;
+              }
+              return (
+                <span className="text-sm text-gray-900">
+                  {item.parentDevice.name}
                 </span>
               );
             },

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/View/Settings.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/View/Settings.tsx
@@ -12,6 +12,11 @@ import {
   isMonitorBackedDevice,
   isSnmpDevice,
 } from "../../../Components/NetworkDevice/MonitoringMethodFormFields";
+import {
+  DEVICE_ROLE_FIELD_DESCRIPTION,
+  DEVICE_ROLE_FIELD_TITLE,
+  DEVICE_ROLE_OPTIONS,
+} from "../../../Components/NetworkDevice/DeviceRoleFormFields";
 import CardModelDetail from "Common/UI/Components/ModelDetail/CardModelDetail";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import ArchiveResourceCard from "../../../Components/TelemetryResource/ArchiveResourceCard";
@@ -146,6 +151,18 @@ const NetworkDeviceSettings: FunctionComponent<
           },
           {
             field: {
+              deviceRole: true,
+            },
+            title: DEVICE_ROLE_FIELD_TITLE,
+            stepId: "device-details",
+            description: DEVICE_ROLE_FIELD_DESCRIPTION,
+            fieldType: FormFieldSchemaType.Dropdown,
+            dropdownOptions: DEVICE_ROLE_OPTIONS,
+            required: false,
+            placeholder: "Worked out from the device (SNMP only)",
+          },
+          {
+            field: {
               description: true,
             },
             title: "Description",
@@ -207,6 +224,13 @@ const NetworkDeviceSettings: FunctionComponent<
                 },
               },
               title: "Monitor",
+              fieldType: FieldType.Text,
+            },
+            {
+              field: {
+                deviceRole: true,
+              },
+              title: DEVICE_ROLE_FIELD_TITLE,
               fieldType: FieldType.Text,
             },
           ],

--- a/App/Tests/Dashboard/ParentChildDeclaredParents.test.ts
+++ b/App/Tests/Dashboard/ParentChildDeclaredParents.test.ts
@@ -1,0 +1,1338 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  NetworkTopologyEdge,
+  NetworkTopologyNode,
+} from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
+import {
+  ParentChildForest,
+  buildDeclaredParentMap,
+  buildParentChildForest,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/ParentChildTopologyLayout";
+import {
+  canonicalNodeOrder,
+  compareNodeIds,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyGraphUtil";
+
+/*
+ * Operator-declared parents on the parent-child layout — issue #3192.
+ *
+ * Discovery reports cables, not hierarchies: LLDP tells us two boxes are
+ * connected and has no opinion about which one is upstream, and a device
+ * monitored by ping alone reports no neighbours and classifies to no role
+ * at all. Everything the layout did before this feature was therefore
+ * inference, and on a ping-only device it was inference from nothing.
+ * `NetworkDeviceLink.parentDeviceId` is the operator answering the
+ * question directly, and these tests are about the layout treating that
+ * answer as a constraint rather than as one more hint.
+ *
+ * Two things an operator can state that no tree can honour, both resolved
+ * before the traversal ever sees them: a device that two links each claim
+ * to parent (a contradiction), and a loop of declarations (a cycle).
+ * Neither may produce a walk that fails to terminate, and — the reason
+ * for the shuffles below — neither may make the drawing depend on the
+ * order the poll happened to return its rows in. A cycle is precisely
+ * where such a dependency would hide, because breaking one means choosing
+ * a declaration to discard.
+ */
+
+type MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+) => NetworkTopologyNode;
+
+const makeDevice: MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: id,
+    name: id,
+    isManaged: true,
+    status: "up",
+    kind: "device",
+    ...overrides,
+  };
+};
+
+const makeUnmanaged: MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: id,
+    name: id,
+    isManaged: false,
+    status: "unknown",
+    kind: "unmanaged",
+    ...overrides,
+  };
+};
+
+const makeEndpoint: MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: id,
+    name: id,
+    isManaged: false,
+    status: "unknown",
+    kind: "endpoint",
+    ...overrides,
+  };
+};
+
+type MakeEdgeFunction = (
+  from: string,
+  to: string,
+  protocols?: NetworkTopologyEdge["protocols"],
+) => NetworkTopologyEdge;
+
+const makeEdge: MakeEdgeFunction = (
+  from: string,
+  to: string,
+  protocols?: NetworkTopologyEdge["protocols"],
+): NetworkTopologyEdge => {
+  return { fromNodeId: from, toNodeId: to, protocols: protocols };
+};
+
+/* The same link, with an operator's statement of which end is upstream. */
+type MakeDeclaredEdgeFunction = (
+  from: string,
+  to: string,
+  parentNodeId: string,
+  protocols?: NetworkTopologyEdge["protocols"],
+) => NetworkTopologyEdge;
+
+const makeDeclaredEdge: MakeDeclaredEdgeFunction = (
+  from: string,
+  to: string,
+  parentNodeId: string,
+  protocols?: NetworkTopologyEdge["protocols"],
+): NetworkTopologyEdge => {
+  return {
+    fromNodeId: from,
+    toNodeId: to,
+    protocols: protocols,
+    parentNodeId: parentNodeId,
+  };
+};
+
+/*
+ * The same cables as they arrived before anybody declared anything. Used
+ * for the control half of every "the declaration actually changed the
+ * answer" assertion, and for the promise that a component nobody has
+ * touched is laid out exactly as it was.
+ */
+type WithoutDeclarationsFunction = (
+  edges: Array<NetworkTopologyEdge>,
+) => Array<NetworkTopologyEdge>;
+
+const withoutDeclarations: WithoutDeclarationsFunction = (
+  edges: Array<NetworkTopologyEdge>,
+): Array<NetworkTopologyEdge> => {
+  return edges.map((edge: NetworkTopologyEdge): NetworkTopologyEdge => {
+    return makeEdge(edge.fromNodeId, edge.toNodeId, edge.protocols);
+  });
+};
+
+/* Every link read end for end. The declared parent is still an end. */
+type FlipEdgesFunction = (
+  edges: Array<NetworkTopologyEdge>,
+) => Array<NetworkTopologyEdge>;
+
+const flipEdges: FlipEdgesFunction = (
+  edges: Array<NetworkTopologyEdge>,
+): Array<NetworkTopologyEdge> => {
+  return edges.map((edge: NetworkTopologyEdge): NetworkTopologyEdge => {
+    return edge.parentNodeId
+      ? makeDeclaredEdge(
+          edge.toNodeId,
+          edge.fromNodeId,
+          edge.parentNodeId,
+          edge.protocols,
+        )
+      : makeEdge(edge.toNodeId, edge.fromNodeId, edge.protocols);
+  });
+};
+
+/*
+ * A SEEDED Fisher-Yates shuffle, never Math.random. A test that shuffled
+ * randomly would fail on somebody else's machine and pass on the retry,
+ * which is the exact class of defect this file exists to rule out of the
+ * implementation.
+ */
+type PermuteFunction = <ItemType>(
+  items: Array<ItemType>,
+  seed: number,
+) => Array<ItemType>;
+
+const permuted: PermuteFunction = <ItemType>(
+  items: Array<ItemType>,
+  seed: number,
+): Array<ItemType> => {
+  const shuffled: Array<ItemType> = [...items];
+  let state: number = Math.imul(seed, 2654435761) >>> 0 || 0x9e3779b9;
+  for (let index: number = shuffled.length - 1; index > 0; index--) {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    const target: number = state % (index + 1);
+    const held: ItemType = shuffled[index]!;
+    shuffled[index] = shuffled[target]!;
+    shuffled[target] = held;
+  }
+  return shuffled;
+};
+
+/* Seeds used wherever "shuffle it" means "shuffle it several ways". */
+const SHUFFLE_SEEDS: Array<number> = [1, 2, 3, 7, 11, 29];
+
+/*
+ * Map contents in a form that compares by VALUE and not by insertion
+ * order — two maps built from differently ordered inputs must be equal,
+ * and a stray difference in which entry was written first must not be
+ * able to hide behind that.
+ */
+type SortedEntriesFunction = <ValueType>(
+  map: Map<string, ValueType>,
+) => Array<[string, ValueType]>;
+
+const sortedEntries: SortedEntriesFunction = <ValueType>(
+  map: Map<string, ValueType>,
+): Array<[string, ValueType]> => {
+  return [...map.entries()].sort(
+    (left: [string, ValueType], right: [string, ValueType]): number => {
+      return compareNodeIds(left[0], right[0]);
+    },
+  );
+};
+
+/* Walk a declared-parent map upwards, reporting whether it loops. */
+interface DeclaredParentWalk {
+  chain: Array<string>;
+  hitCycle: boolean;
+}
+
+type WalkDeclaredFunction = (
+  declaredParentOf: Map<string, string>,
+  nodeId: string,
+) => DeclaredParentWalk;
+
+const walkDeclaredParents: WalkDeclaredFunction = (
+  declaredParentOf: Map<string, string>,
+  nodeId: string,
+): DeclaredParentWalk => {
+  const chain: Array<string> = [];
+  const seen: Set<string> = new Set<string>();
+  let current: string | undefined = nodeId;
+  while (current !== undefined && !seen.has(current)) {
+    seen.add(current);
+    chain.push(current);
+    current = declaredParentOf.get(current);
+  }
+  // A cursor still defined here means the walk returned somewhere it had been.
+  return { chain: chain, hitCycle: current !== undefined };
+};
+
+/* The same walk over a finished forest. */
+interface ParentChainWalk {
+  chain: Array<string>;
+  hitCycle: boolean;
+}
+
+type ParentChainFunction = (
+  forest: ParentChildForest,
+  nodeId: string,
+) => ParentChainWalk;
+
+const parentChainOf: ParentChainFunction = (
+  forest: ParentChildForest,
+  nodeId: string,
+): ParentChainWalk => {
+  const chain: Array<string> = [];
+  const seen: Set<string> = new Set<string>();
+  let current: string | undefined = nodeId;
+  while (current !== undefined && !seen.has(current)) {
+    seen.add(current);
+    chain.push(current);
+    current = forest.parentById.get(current);
+  }
+  return { chain: chain, hitCycle: current !== undefined };
+};
+
+/* Every id reachable from `rootId` by following child lists only. */
+type ReachableFunction = (
+  forest: ParentChildForest,
+  rootId: string,
+) => Set<string>;
+
+const reachableFromRoot: ReachableFunction = (
+  forest: ParentChildForest,
+  rootId: string,
+): Set<string> => {
+  const seen: Set<string> = new Set<string>([rootId]);
+  const stack: Array<string> = [rootId];
+  while (stack.length > 0) {
+    const current: string = stack.pop()!;
+    for (const child of forest.childrenById.get(current) || []) {
+      if (!seen.has(child)) {
+        seen.add(child);
+        stack.push(child);
+      }
+    }
+  }
+  return seen;
+};
+
+/*
+ * The structural promises the forest makes whatever an operator declared:
+ * every node placed once, every parent exactly one level shallower than
+ * its child, nobody its own ancestor, and every node in exactly one tree.
+ */
+type ExpectWellFormedFunction = (
+  forest: ParentChildForest,
+  nodes: Array<NetworkTopologyNode>,
+) => void;
+
+const expectWellFormedForest: ExpectWellFormedFunction = (
+  forest: ParentChildForest,
+  nodes: Array<NetworkTopologyNode>,
+): void => {
+  const allIds: Array<string> = canonicalNodeOrder(nodes);
+
+  expect(forest.depthById.size).toBe(allIds.length);
+  expect(forest.childrenById.size).toBe(allIds.length);
+  expect(forest.parentById.size).toBe(allIds.length - forest.rootIds.length);
+
+  for (const id of allIds) {
+    expect(forest.depthById.has(id)).toBe(true);
+    expect(forest.childrenById.has(id)).toBe(true);
+    const walk: ParentChainWalk = parentChainOf(forest, id);
+    expect(walk.hitCycle).toBe(false);
+    expect(new Set<string>(walk.chain).size).toBe(walk.chain.length);
+    expect(forest.rootIds).toContain(walk.chain[walk.chain.length - 1]);
+    // One step of the walk per level, so hops and depth cannot disagree.
+    expect(walk.chain.length).toBe(forest.depthById.get(id)! + 1);
+  }
+
+  for (const [childId, parentId] of forest.parentById) {
+    expect(forest.depthById.get(childId)).toBe(
+      forest.depthById.get(parentId)! + 1,
+    );
+    expect(forest.childrenById.get(parentId)).toContain(childId);
+  }
+  for (const [parentId, children] of forest.childrenById) {
+    for (const childId of children) {
+      expect(forest.parentById.get(childId)).toBe(parentId);
+    }
+  }
+
+  // Exactly one tree per node: the trees cover the graph and never overlap.
+  const claimed: Set<string> = new Set<string>();
+  for (const rootId of forest.rootIds) {
+    expect(forest.depthById.get(rootId)).toBe(0);
+    expect(forest.parentById.has(rootId)).toBe(false);
+    for (const id of reachableFromRoot(forest, rootId)) {
+      expect(claimed.has(id)).toBe(false);
+      claimed.add(id);
+    }
+  }
+  expect(Array.from(claimed).sort(compareNodeIds)).toEqual(allIds);
+};
+
+type ExpectIdenticalForestFunction = (
+  actual: ParentChildForest,
+  expected: ParentChildForest,
+) => void;
+
+const expectIdenticalForest: ExpectIdenticalForestFunction = (
+  actual: ParentChildForest,
+  expected: ParentChildForest,
+): void => {
+  expect(actual.rootIds).toEqual(expected.rootIds);
+  expect(sortedEntries(actual.parentById)).toEqual(
+    sortedEntries(expected.parentById),
+  );
+  expect(sortedEntries(actual.childrenById)).toEqual(
+    sortedEntries(expected.childrenById),
+  );
+  expect(sortedEntries(actual.depthById)).toEqual(
+    sortedEntries(expected.depthById),
+  );
+};
+
+describe("buildDeclaredParentMap — reading one declaration off a link", () => {
+  const pairNodes: Array<NetworkTopologyNode> = [
+    makeDevice("core-01"),
+    makeDevice("switch-a"),
+  ];
+
+  test("the end that was not named is the child", () => {
+    const declared: Map<string, string> = buildDeclaredParentMap(pairNodes, [
+      makeDeclaredEdge("core-01", "switch-a", "core-01", ["manual"]),
+    ]);
+    expect(sortedEntries(declared)).toEqual([["switch-a", "core-01"]]);
+  });
+
+  test("which column of the link row the parent sits in makes no difference", () => {
+    /*
+     * from/to is an artefact of whichever end reported the cable — the
+     * operator's meaning lives entirely in parentDeviceId, so the same
+     * statement written the other way round must read the same way.
+     */
+    const declared: Map<string, string> = buildDeclaredParentMap(pairNodes, [
+      makeDeclaredEdge("switch-a", "core-01", "core-01", ["manual"]),
+    ]);
+    expect(sortedEntries(declared)).toEqual([["switch-a", "core-01"]]);
+  });
+
+  test("a discovered link nobody has annotated declares nothing", () => {
+    // Absent is "not stated", never "these two are peers".
+    const declared: Map<string, string> = buildDeclaredParentMap(pairNodes, [
+      makeEdge("core-01", "switch-a", ["lldp"]),
+      makeEdge("core-01", "switch-a", ["cdp"]),
+    ]);
+    expect(declared.size).toBe(0);
+  });
+
+  test("an empty parentNodeId is not a declaration", () => {
+    const declared: Map<string, string> = buildDeclaredParentMap(pairNodes, [
+      makeDeclaredEdge("core-01", "switch-a", "", ["manual"]),
+    ]);
+    expect(declared.size).toBe(0);
+  });
+
+  test("a parent that is neither end of its own link is ignored", () => {
+    /*
+     * NetworkDeviceLinkService refuses this on create and on update, so it
+     * can only reach a reader as a stale payload — one end of the link was
+     * repointed after the parent was set. Ignoring it is right: the
+     * statement is about a cable that no longer exists.
+     */
+    const declared: Map<string, string> = buildDeclaredParentMap(
+      [...pairNodes, makeDevice("core-02")],
+      [makeDeclaredEdge("core-01", "switch-a", "core-02", ["manual"])],
+    );
+    expect(declared.size).toBe(0);
+  });
+
+  test("a declaration naming a device outside the view is ignored", () => {
+    /*
+     * The VLAN filter drops nodes without rewriting the edges, so an edge
+     * naming a node nobody can see is routine rather than exotic. Neither
+     * half of such a statement may reach the forest: a parent that is not
+     * drawn cannot be drawn above anything.
+     */
+    const parentGone: Map<string, string> = buildDeclaredParentMap(pairNodes, [
+      makeDeclaredEdge("switch-a", "unmanaged:isp-gw", "unmanaged:isp-gw", [
+        "manual",
+      ]),
+    ]);
+    expect(parentGone.size).toBe(0);
+
+    const childGone: Map<string, string> = buildDeclaredParentMap(pairNodes, [
+      makeDeclaredEdge("core-01", "endpoint:filtered", "core-01", ["fdb"]),
+    ]);
+    expect(childGone.size).toBe(0);
+  });
+
+  test("a self link cannot make a device its own parent", () => {
+    // Both ends are the same device, so the "child" would be the parent.
+    const declared: Map<string, string> = buildDeclaredParentMap(pairNodes, [
+      makeDeclaredEdge("core-01", "core-01", "core-01", ["manual"]),
+    ]);
+    expect(declared.size).toBe(0);
+  });
+
+  test("a null edge in the payload is skipped rather than thrown on", () => {
+    const declared: Map<string, string> = buildDeclaredParentMap(pairNodes, [
+      null as unknown as NetworkTopologyEdge,
+      makeDeclaredEdge("core-01", "switch-a", "core-01", ["manual"]),
+    ]);
+    expect(sortedEntries(declared)).toEqual([["switch-a", "core-01"]]);
+  });
+
+  test("independent declarations all survive together", () => {
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("core-01"),
+      makeDevice("switch-a"),
+      makeDevice("switch-b"),
+      makeDevice("ap-01"),
+    ];
+    const declared: Map<string, string> = buildDeclaredParentMap(nodes, [
+      makeDeclaredEdge("core-01", "switch-a", "core-01", ["lldp"]),
+      makeDeclaredEdge("core-01", "switch-b", "core-01", ["lldp"]),
+      makeDeclaredEdge("switch-a", "ap-01", "switch-a", ["manual"]),
+    ]);
+    expect(sortedEntries(declared)).toEqual([
+      ["ap-01", "switch-a"],
+      ["switch-a", "core-01"],
+      ["switch-b", "core-01"],
+    ]);
+  });
+});
+
+/*
+ * Two links each claiming to be the parent of `switch-x`, and one
+ * uncontested statement alongside them. Picking a winner between the two
+ * would be inventing an answer the operator did not give.
+ */
+const contradictionNodes: Array<NetworkTopologyNode> = [
+  makeDevice("core-a"),
+  makeDevice("core-b"),
+  makeDevice("switch-x"),
+  makeDevice("switch-y"),
+];
+
+const contradictionEdges: Array<NetworkTopologyEdge> = [
+  makeDeclaredEdge("core-a", "switch-x", "core-a", ["manual"]),
+  makeDeclaredEdge("core-b", "switch-x", "core-b", ["manual"]),
+  makeDeclaredEdge("core-a", "switch-y", "core-a", ["manual"]),
+];
+
+describe("buildDeclaredParentMap — two links contradicting each other", () => {
+  test("a device two links both claim to parent keeps neither", () => {
+    const declared: Map<string, string> = buildDeclaredParentMap(
+      contradictionNodes,
+      contradictionEdges,
+    );
+    expect(declared.has("switch-x")).toBe(false);
+    // ...and the contradiction is contained: core-a's other child stands.
+    expect(sortedEntries(declared)).toEqual([["switch-y", "core-a"]]);
+  });
+
+  test("the same parent stated on two links is agreement, not contradiction", () => {
+    /*
+     * A redundantly cabled pair: two physical links between the same two
+     * devices, both annotated the same way. That is one statement said
+     * twice, and dropping it would punish an operator for being thorough.
+     */
+    const declared: Map<string, string> = buildDeclaredParentMap(
+      [makeDevice("core-a"), makeDevice("switch-x")],
+      [
+        makeDeclaredEdge("core-a", "switch-x", "core-a", ["manual"]),
+        makeDeclaredEdge("switch-x", "core-a", "core-a", ["manual"]),
+      ],
+    );
+    expect(sortedEntries(declared)).toEqual([["switch-x", "core-a"]]);
+  });
+
+  test("a device can parent one child while another of its claims is contested", () => {
+    const declared: Map<string, string> = buildDeclaredParentMap(
+      contradictionNodes,
+      [
+        ...contradictionEdges,
+        makeDeclaredEdge("switch-y", "core-b", "switch-y", ["manual"]),
+      ],
+    );
+    // core-b loses its claim on switch-x and still becomes switch-y's child.
+    expect(sortedEntries(declared)).toEqual([
+      ["core-b", "switch-y"],
+      ["switch-y", "core-a"],
+    ]);
+  });
+
+  test("a contradiction is a function of the graph, not of row order", () => {
+    const baseline: Array<[string, string]> = sortedEntries(
+      buildDeclaredParentMap(contradictionNodes, contradictionEdges),
+    );
+    for (const seed of SHUFFLE_SEEDS) {
+      const shuffled: Map<string, string> = buildDeclaredParentMap(
+        permuted(contradictionNodes, seed),
+        permuted(contradictionEdges, seed),
+      );
+      expect(sortedEntries(shuffled)).toEqual(baseline);
+    }
+  });
+});
+
+/*
+ * A ring of declarations: A parents B, B parents C, C parents A. There is
+ * no tree in that, and a traversal that trusted it would never terminate.
+ */
+const cycleNodes: Array<NetworkTopologyNode> = [
+  makeDevice("core-a"),
+  makeDevice("core-b"),
+  makeDevice("core-c"),
+];
+
+const cycleEdges: Array<NetworkTopologyEdge> = [
+  makeDeclaredEdge("core-a", "core-b", "core-a", ["manual"]),
+  makeDeclaredEdge("core-b", "core-c", "core-b", ["manual"]),
+  makeDeclaredEdge("core-c", "core-a", "core-c", ["manual"]),
+];
+
+describe("buildDeclaredParentMap — a loop of declarations", () => {
+  const declared: Map<string, string> = buildDeclaredParentMap(
+    cycleNodes,
+    cycleEdges,
+  );
+
+  test("exactly one of the three declarations is dropped", () => {
+    // Two of three is the most any acyclic subset of a 3-cycle can keep.
+    expect(declared.size).toBe(2);
+  });
+
+  test("the surviving declarations are acyclic from every node", () => {
+    for (const node of cycleNodes) {
+      const walk: DeclaredParentWalk = walkDeclaredParents(declared, node.id);
+      expect(walk.hitCycle).toBe(false);
+      expect(new Set<string>(walk.chain).size).toBe(walk.chain.length);
+    }
+  });
+
+  test("which declaration loses is decided by canonical child order", () => {
+    /*
+     * Pinned deliberately. "Some declaration is dropped" would be
+     * satisfied by dropping a different one each poll, and a hierarchy
+     * that re-hangs itself every sixty seconds is worse than one that is
+     * merely incomplete. Children are considered in id order, so core-c —
+     * the last child considered, and the one whose claim closes the ring —
+     * is the one that loses.
+     */
+    expect(sortedEntries(declared)).toEqual([
+      ["core-a", "core-c"],
+      ["core-b", "core-a"],
+    ]);
+    expect(declared.has("core-c")).toBe(false);
+  });
+
+  test("two devices each declared the other's parent keep one statement", () => {
+    /*
+     * The shortest possible loop, and a realistic one: two links between
+     * the same pair of distribution switches, annotated in opposite
+     * directions by two different people.
+     */
+    const twoWay: Map<string, string> = buildDeclaredParentMap(
+      [makeDevice("core-a"), makeDevice("core-b")],
+      [
+        makeDeclaredEdge("core-a", "core-b", "core-a", ["manual"]),
+        makeDeclaredEdge("core-a", "core-b", "core-b", ["manual"]),
+      ],
+    );
+    expect(sortedEntries(twoWay)).toEqual([["core-a", "core-b"]]);
+    for (const id of ["core-a", "core-b"]) {
+      expect(walkDeclaredParents(twoWay, id).hitCycle).toBe(false);
+    }
+  });
+
+  test("a four-device ring is broken just as cleanly", () => {
+    /*
+     * Longer than three because the cycle check walks the chain accepted
+     * so far: a ring of four is the case where that walk has to climb
+     * three links before it recognises the loop.
+     */
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("core-a"),
+      makeDevice("core-b"),
+      makeDevice("core-c"),
+      makeDevice("core-d"),
+    ];
+    const ring: Map<string, string> = buildDeclaredParentMap(nodes, [
+      makeDeclaredEdge("core-d", "core-a", "core-d", ["manual"]),
+      makeDeclaredEdge("core-a", "core-b", "core-a", ["manual"]),
+      makeDeclaredEdge("core-b", "core-c", "core-b", ["manual"]),
+      makeDeclaredEdge("core-c", "core-d", "core-c", ["manual"]),
+    ]);
+    expect(ring.size).toBe(3);
+    for (const node of nodes) {
+      expect(walkDeclaredParents(ring, node.id).hitCycle).toBe(false);
+    }
+    // The chain that survives is the ring cut at its canonically last child.
+    expect(sortedEntries(ring)).toEqual([
+      ["core-a", "core-d"],
+      ["core-b", "core-a"],
+      ["core-c", "core-b"],
+    ]);
+  });
+
+  test("a self-declaration cannot start a loop of length one", () => {
+    const declaredSelf: Map<string, string> = buildDeclaredParentMap(
+      cycleNodes,
+      [
+        ...cycleEdges,
+        makeDeclaredEdge("core-b", "core-b", "core-b", ["manual"]),
+      ],
+    );
+    expect(sortedEntries(declaredSelf)).toEqual(sortedEntries(declared));
+  });
+});
+
+describe("buildDeclaredParentMap — the same graph always gives the same map", () => {
+  test("shuffling the edges of a cyclic declaration set changes nothing", () => {
+    /*
+     * The case that matters most in this file. Breaking a cycle means
+     * discarding a declaration, and the cheap way to choose one is
+     * "whichever we saw last" — which would hand a different hierarchy to
+     * every poll. Six shuffles, all of which must agree.
+     */
+    const baseline: Array<[string, string]> = sortedEntries(
+      buildDeclaredParentMap(cycleNodes, cycleEdges),
+    );
+    for (const seed of SHUFFLE_SEEDS) {
+      expect(
+        sortedEntries(
+          buildDeclaredParentMap(cycleNodes, permuted(cycleEdges, seed)),
+        ),
+      ).toEqual(baseline);
+    }
+  });
+
+  test("shuffling the nodes of a cyclic declaration set changes nothing", () => {
+    const baseline: Array<[string, string]> = sortedEntries(
+      buildDeclaredParentMap(cycleNodes, cycleEdges),
+    );
+    for (const seed of SHUFFLE_SEEDS) {
+      expect(
+        sortedEntries(
+          buildDeclaredParentMap(permuted(cycleNodes, seed), cycleEdges),
+        ),
+      ).toEqual(baseline);
+    }
+  });
+
+  test("shuffling both at once changes nothing", () => {
+    const baseline: Array<[string, string]> = sortedEntries(
+      buildDeclaredParentMap(cycleNodes, cycleEdges),
+    );
+    for (const seed of SHUFFLE_SEEDS) {
+      expect(
+        sortedEntries(
+          buildDeclaredParentMap(
+            permuted(cycleNodes, seed),
+            permuted(cycleEdges, seed * 13),
+          ),
+        ),
+      ).toEqual(baseline);
+    }
+  });
+
+  test("reading every link end for end changes nothing", () => {
+    // The declared parent is still one of the ends after the flip.
+    expect(
+      sortedEntries(
+        buildDeclaredParentMap(
+          [...cycleNodes].reverse(),
+          flipEdges(cycleEdges),
+        ),
+      ),
+    ).toEqual(sortedEntries(buildDeclaredParentMap(cycleNodes, cycleEdges)));
+  });
+
+  test("a mixed payload of good, contradictory and cyclic statements is stable", () => {
+    /*
+     * All three resolutions interacting at once, because each is
+     * order-sensitive on its own: a contradiction removes a child from
+     * consideration, which changes which later declaration would close a
+     * loop.
+     */
+    const nodes: Array<NetworkTopologyNode> = [
+      ...cycleNodes,
+      ...contradictionNodes,
+      makeDevice("edge-01"),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      ...cycleEdges,
+      ...contradictionEdges,
+      makeDeclaredEdge("switch-y", "edge-01", "switch-y", ["manual"]),
+    ];
+    const baseline: Array<[string, string]> = sortedEntries(
+      buildDeclaredParentMap(nodes, edges),
+    );
+    expect(baseline).toEqual([
+      ["core-a", "core-c"],
+      ["core-b", "core-a"],
+      ["edge-01", "switch-y"],
+      ["switch-y", "core-a"],
+    ]);
+    for (const seed of SHUFFLE_SEEDS) {
+      expect(
+        sortedEntries(
+          buildDeclaredParentMap(permuted(nodes, seed), permuted(edges, seed)),
+        ),
+      ).toEqual(baseline);
+    }
+  });
+});
+
+/*
+ * ISSUE #3192, as a graph. A router and a switch that SNMP knows all
+ * about, and an access point that answers ping and nothing else: no
+ * neighbour data, no FDB entries, no evidence to classify it from. Its
+ * role is the honest "unknown", which the tiering reads as "might be
+ * core" — so before this feature the access point was tier 0 and could
+ * win the root, drawing the whole site hanging off a ping-only AP.
+ */
+const ISSUE_3192_ROUTER: string = "router-01";
+const ISSUE_3192_SWITCH: string = "switch-01";
+const ISSUE_3192_ACCESS_POINT: string = "ap-01";
+
+const pingOnlySiteNodes: Array<NetworkTopologyNode> = [
+  makeDevice(ISSUE_3192_ROUTER, { role: "router" }),
+  makeDevice(ISSUE_3192_SWITCH, { role: "switch" }),
+  makeDevice(ISSUE_3192_ACCESS_POINT, { role: "unknown" }),
+];
+
+const pingOnlySiteEdges: Array<NetworkTopologyEdge> = [
+  makeDeclaredEdge(ISSUE_3192_ROUTER, ISSUE_3192_SWITCH, ISSUE_3192_ROUTER, [
+    "lldp",
+  ]),
+  makeDeclaredEdge(
+    ISSUE_3192_SWITCH,
+    ISSUE_3192_ACCESS_POINT,
+    ISSUE_3192_SWITCH,
+    ["manual"],
+  ),
+];
+
+describe("buildParentChildForest — issue #3192, the ping-only access point", () => {
+  const forest: ParentChildForest = buildParentChildForest(
+    pingOnlySiteNodes,
+    pingOnlySiteEdges,
+  );
+
+  test("the access point hangs off the switch its operator declared", () => {
+    expect(forest.parentById.get(ISSUE_3192_ACCESS_POINT)).toBe(
+      ISSUE_3192_SWITCH,
+    );
+    expect(forest.parentById.get(ISSUE_3192_SWITCH)).toBe(ISSUE_3192_ROUTER);
+    expect(forest.depthById.get(ISSUE_3192_ACCESS_POINT)).toBe(2);
+    expect(forest.rootIds).toEqual([ISSUE_3192_ROUTER]);
+  });
+
+  test("without the declarations the ping-only AP wins the root instead", () => {
+    /*
+     * The control, and the whole reason the feature exists. Nothing about
+     * the graph changed except that nobody said anything: the AP is still
+     * tier 0 (managed, role unknown, no FDB edges), still ties the router
+     * on degree, and still sorts first by id — so it roots the tree and
+     * the router is drawn two levels beneath the access point it feeds.
+     */
+    const inferred: ParentChildForest = buildParentChildForest(
+      pingOnlySiteNodes,
+      withoutDeclarations(pingOnlySiteEdges),
+    );
+    expect(inferred.rootIds).toEqual([ISSUE_3192_ACCESS_POINT]);
+    expect(inferred.depthById.get(ISSUE_3192_ACCESS_POINT)).toBe(0);
+    expect(inferred.depthById.get(ISSUE_3192_ROUTER)).toBe(2);
+  });
+
+  test("the declared hierarchy reads the same from the children downward", () => {
+    expect(forest.childrenById.get(ISSUE_3192_ROUTER)).toEqual([
+      ISSUE_3192_SWITCH,
+    ]);
+    expect(forest.childrenById.get(ISSUE_3192_SWITCH)).toEqual([
+      ISSUE_3192_ACCESS_POINT,
+    ]);
+    expect(forest.childrenById.get(ISSUE_3192_ACCESS_POINT)).toEqual([]);
+    expectWellFormedForest(forest, pingOnlySiteNodes);
+  });
+
+  test("the declared site is stable however the payload is ordered", () => {
+    for (const seed of SHUFFLE_SEEDS) {
+      expectIdenticalForest(
+        buildParentChildForest(
+          permuted(pingOnlySiteNodes, seed),
+          permuted(pingOnlySiteEdges, seed),
+        ),
+        forest,
+      );
+    }
+    expectIdenticalForest(
+      buildParentChildForest(
+        [...pingOnlySiteNodes].reverse(),
+        flipEdges(pingOnlySiteEdges),
+      ),
+      forest,
+    );
+  });
+});
+
+describe("buildParentChildForest — a declared child is never a root", () => {
+  /*
+   * The strongest possible case for rooting the tree at the wrong device:
+   * `aa-distribution` is a router by role (tier 0), out-degrees everything
+   * else six to one, and sorts first by id — it wins every tiebreak the
+   * root chooser has. `zz-uplink` is a host with a single link. An
+   * operator who says the host is upstream is telling us something the
+   * evidence cannot: it is the ISP handoff, and it has a parent by
+   * construction, so it cannot be somebody's child.
+   */
+  const declaredChildNodes: Array<NetworkTopologyNode> = [
+    makeDevice("aa-distribution", { role: "router" }),
+    makeDevice("zz-uplink", { role: "host" }),
+    makeEndpoint("endpoint:pos-1", { name: "pos-1" }),
+    makeEndpoint("endpoint:pos-2", { name: "pos-2" }),
+    makeEndpoint("endpoint:pos-3", { name: "pos-3" }),
+    makeEndpoint("endpoint:pos-4", { name: "pos-4" }),
+    makeEndpoint("endpoint:pos-5", { name: "pos-5" }),
+  ];
+
+  const declaredChildEdges: Array<NetworkTopologyEdge> = [
+    makeDeclaredEdge("zz-uplink", "aa-distribution", "zz-uplink", ["manual"]),
+    makeEdge("aa-distribution", "endpoint:pos-1", ["fdb"]),
+    makeEdge("aa-distribution", "endpoint:pos-2", ["fdb"]),
+    makeEdge("aa-distribution", "endpoint:pos-3", ["fdb"]),
+    makeEdge("aa-distribution", "endpoint:pos-4", ["fdb"]),
+    makeEdge("aa-distribution", "endpoint:pos-5", ["fdb"]),
+  ];
+
+  const forest: ParentChildForest = buildParentChildForest(
+    declaredChildNodes,
+    declaredChildEdges,
+  );
+
+  test("the declared child loses the root to its own declared parent", () => {
+    expect(forest.rootIds).toEqual(["zz-uplink"]);
+    expect(forest.parentById.get("aa-distribution")).toBe("zz-uplink");
+    expect(forest.depthById.get("zz-uplink")).toBe(0);
+    expect(forest.depthById.get("aa-distribution")).toBe(1);
+  });
+
+  test("the subtree below the declared child is unchanged", () => {
+    /*
+     * Only the top of the tree was ever in dispute; the endpoints still
+     * hang off the device they are actually learned on.
+     */
+    for (const id of [
+      "endpoint:pos-1",
+      "endpoint:pos-2",
+      "endpoint:pos-3",
+      "endpoint:pos-4",
+      "endpoint:pos-5",
+    ]) {
+      expect(forest.parentById.get(id)).toBe("aa-distribution");
+      expect(forest.depthById.get(id)).toBe(2);
+    }
+    expectWellFormedForest(forest, declaredChildNodes);
+  });
+
+  test("without the declaration the tier-0, high-degree device roots it", () => {
+    const inferred: ParentChildForest = buildParentChildForest(
+      declaredChildNodes,
+      withoutDeclarations(declaredChildEdges),
+    );
+    expect(inferred.rootIds).toEqual(["aa-distribution"]);
+    expect(inferred.parentById.get("zz-uplink")).toBe("aa-distribution");
+  });
+});
+
+describe("buildParentChildForest — a declaration outranks the inference", () => {
+  test("a declared parent wins even when a shorter cable path exists", () => {
+    /*
+     * `leaf-01` is one hop from the core and two hops from the
+     * distribution switch. BFS would hang it off the core because that is
+     * the shorter path; the operator says it is patched through
+     * `dist-01`, and a stated fact outranks a shortest path.
+     */
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("core-01", { role: "router" }),
+      makeDevice("dist-01", { role: "switch" }),
+      makeDevice("leaf-01", { role: "switch" }),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("core-01", "dist-01", ["lldp"]),
+      makeEdge("core-01", "leaf-01", ["lldp"]),
+      makeDeclaredEdge("dist-01", "leaf-01", "dist-01", ["manual"]),
+    ];
+
+    const inferred: ParentChildForest = buildParentChildForest(
+      nodes,
+      withoutDeclarations(edges),
+    );
+    expect(inferred.parentById.get("leaf-01")).toBe("core-01");
+    expect(inferred.depthById.get("leaf-01")).toBe(1);
+
+    const forest: ParentChildForest = buildParentChildForest(nodes, edges);
+    expect(forest.rootIds).toEqual(["core-01"]);
+    expect(forest.parentById.get("leaf-01")).toBe("dist-01");
+    expect(forest.depthById.get("leaf-01")).toBe(2);
+    expect(forest.childrenById.get("core-01")).toEqual(["dist-01"]);
+    expect(forest.childrenById.get("dist-01")).toEqual(["leaf-01"]);
+    expectWellFormedForest(forest, nodes);
+  });
+
+  test("a declaration that agrees with the inference changes nothing", () => {
+    /*
+     * The common case once operators start annotating links: they write
+     * down what the map already showed. Taking the declared code path
+     * must produce the identical forest, or every such annotation would
+     * quietly redraw a site for no reason.
+     */
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("core-01"),
+      makeDevice("switch-a"),
+      makeDevice("switch-b"),
+      makeEndpoint("endpoint:pos-1", { name: "pos-1" }),
+      makeEndpoint("endpoint:pos-2", { name: "pos-2" }),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("core-01", "switch-a", ["lldp"]),
+      makeEdge("core-01", "switch-b", ["lldp"]),
+      makeEdge("switch-a", "endpoint:pos-1", ["fdb"]),
+      makeEdge("switch-b", "endpoint:pos-2", ["fdb"]),
+    ];
+    const declared: Array<NetworkTopologyEdge> = [
+      makeDeclaredEdge("core-01", "switch-a", "core-01", ["lldp"]),
+      ...edges.slice(1),
+    ];
+
+    expectIdenticalForest(
+      buildParentChildForest(nodes, declared),
+      buildParentChildForest(nodes, edges),
+    );
+  });
+
+  test("a contradicted declaration falls back to the inference exactly", () => {
+    /*
+     * Two switches both claiming `leaf-01`. The contradiction leaves the
+     * component with no usable declaration at all, so it must come back
+     * byte for byte as the graph without any annotation — a rejected
+     * statement is not allowed to leave a trace.
+     */
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("core-01", { role: "router" }),
+      makeDevice("switch-a", { role: "switch" }),
+      makeDevice("switch-b", { role: "switch" }),
+      makeDevice("leaf-01", { role: "switch" }),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("core-01", "switch-a", ["lldp"]),
+      makeEdge("core-01", "switch-b", ["lldp"]),
+      makeDeclaredEdge("switch-a", "leaf-01", "switch-a", ["manual"]),
+      makeDeclaredEdge("switch-b", "leaf-01", "switch-b", ["manual"]),
+    ];
+
+    const forest: ParentChildForest = buildParentChildForest(nodes, edges);
+    expectIdenticalForest(
+      forest,
+      buildParentChildForest(nodes, withoutDeclarations(edges)),
+    );
+    // Inference's own rule: the canonically first neighbour one level up.
+    expect(forest.parentById.get("leaf-01")).toBe("switch-a");
+    expect(forest.rootIds).toEqual(["core-01"]);
+  });
+
+  test("a declared parent survives redundant cabling around it", () => {
+    /*
+     * A ring of four — the classic redundantly cabled distribution block.
+     * `sw-c` is one hop from the core round the other side of the ring,
+     * and the operator has said it hangs off `sw-b`. The declaration must
+     * hold, the extra cable must still be in the graph, and the walk must
+     * terminate: a cycle plus a hierarchy is where an infinite loop would
+     * live if one existed.
+     */
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("core-01", { role: "router" }),
+      makeUnmanaged("unmanaged:sw-a", { name: "sw-a" }),
+      makeUnmanaged("unmanaged:sw-b", { name: "sw-b" }),
+      makeUnmanaged("unmanaged:sw-c", { name: "sw-c" }),
+    ];
+    const edges: Array<NetworkTopologyEdge> = [
+      makeEdge("core-01", "unmanaged:sw-a", ["lldp"]),
+      makeEdge("core-01", "unmanaged:sw-c", ["lldp"]),
+      makeEdge("unmanaged:sw-a", "unmanaged:sw-b", ["lldp"]),
+      makeDeclaredEdge("unmanaged:sw-b", "unmanaged:sw-c", "unmanaged:sw-b", [
+        "lldp",
+      ]),
+    ];
+
+    const inferred: ParentChildForest = buildParentChildForest(
+      nodes,
+      withoutDeclarations(edges),
+    );
+    expect(inferred.parentById.get("unmanaged:sw-c")).toBe("core-01");
+
+    const forest: ParentChildForest = buildParentChildForest(nodes, edges);
+    expect(forest.rootIds).toEqual(["core-01"]);
+    expect(forest.parentById.get("unmanaged:sw-c")).toBe("unmanaged:sw-b");
+    expect(forest.depthById.get("unmanaged:sw-c")).toBe(3);
+    expectWellFormedForest(forest, nodes);
+
+    for (const seed of SHUFFLE_SEEDS) {
+      expectIdenticalForest(
+        buildParentChildForest(permuted(nodes, seed), permuted(edges, seed)),
+        forest,
+      );
+    }
+  });
+
+  test("a cycle of declarations still yields a tree", () => {
+    /*
+     * Three switches cabled in a triangle and annotated all the way
+     * round, which is a statement no tree can honour in full. One
+     * declaration is dropped, the rest stand, and the result is still a
+     * single tree over the component.
+     */
+    const nodes: Array<NetworkTopologyNode> = [
+      makeDevice("core-a", { role: "switch" }),
+      makeDevice("core-b", { role: "switch" }),
+      makeDevice("core-c", { role: "switch" }),
+    ];
+    const forest: ParentChildForest = buildParentChildForest(nodes, cycleEdges);
+    expect(forest.rootIds.length).toBe(1);
+    expectWellFormedForest(forest, nodes);
+    // The two surviving declarations, drawn as the chain they describe.
+    expect(forest.rootIds).toEqual(["core-c"]);
+    expect(forest.parentById.get("core-a")).toBe("core-c");
+    expect(forest.parentById.get("core-b")).toBe("core-a");
+    expect(forest.depthById.get("core-b")).toBe(2);
+  });
+});
+
+describe("buildParentChildForest — an undeclared component is left alone", () => {
+  /*
+   * One site nobody has annotated, and a second site where an operator
+   * has declared a parent. The undeclared site must be laid out by the
+   * code that laid it out before this feature existed — same parents,
+   * same depths, same root — because a project that never sets a parent
+   * is every project until somebody does.
+   */
+  const untouchedNodes: Array<NetworkTopologyNode> = [
+    makeDevice("core-01"),
+    makeDevice("switch-a"),
+    makeDevice("switch-b"),
+    makeEndpoint("endpoint:pos-1", { name: "pos-1" }),
+    makeEndpoint("endpoint:pos-2", { name: "pos-2" }),
+  ];
+  const untouchedEdges: Array<NetworkTopologyEdge> = [
+    makeEdge("core-01", "switch-a", ["lldp"]),
+    makeEdge("core-01", "switch-b", ["lldp"]),
+    makeEdge("switch-a", "endpoint:pos-1", ["fdb"]),
+    makeEdge("switch-b", "endpoint:pos-2", ["fdb"]),
+  ];
+
+  const otherSiteNodes: Array<NetworkTopologyNode> = [
+    makeDevice("peer-01", { role: "switch" }),
+    makeDevice("peer-02", { role: "switch" }),
+  ];
+
+  const nodes: Array<NetworkTopologyNode> = [
+    ...untouchedNodes,
+    ...otherSiteNodes,
+  ];
+
+  const withoutDeclaration: ParentChildForest = buildParentChildForest(nodes, [
+    ...untouchedEdges,
+    makeEdge("peer-01", "peer-02", ["lldp"]),
+  ]);
+  const withDeclaration: ParentChildForest = buildParentChildForest(nodes, [
+    ...untouchedEdges,
+    makeDeclaredEdge("peer-01", "peer-02", "peer-02", ["manual"]),
+  ]);
+
+  test("the declaration on the second site actually changed that site", () => {
+    // Otherwise the comparison below would prove nothing at all.
+    expect(withoutDeclaration.parentById.get("peer-02")).toBe("peer-01");
+    expect(withDeclaration.parentById.get("peer-01")).toBe("peer-02");
+    expect(withoutDeclaration.rootIds).toEqual(["core-01", "peer-01"]);
+    expect(withDeclaration.rootIds).toEqual(["core-01", "peer-02"]);
+  });
+
+  test("every node of the untouched site keeps its parent and its depth", () => {
+    for (const node of untouchedNodes) {
+      expect(withDeclaration.parentById.get(node.id)).toBe(
+        withoutDeclaration.parentById.get(node.id),
+      );
+      expect(withDeclaration.depthById.get(node.id)).toBe(
+        withoutDeclaration.depthById.get(node.id),
+      );
+      expect(withDeclaration.childrenById.get(node.id)).toEqual(
+        withoutDeclaration.childrenById.get(node.id),
+      );
+    }
+  });
+
+  test("an island with no links at all is untouched either way", () => {
+    const withIsland: ParentChildForest = buildParentChildForest(
+      [...nodes, makeDevice("island-01")],
+      [
+        ...untouchedEdges,
+        makeDeclaredEdge("peer-01", "peer-02", "peer-02", ["manual"]),
+      ],
+    );
+    expect(withIsland.depthById.get("island-01")).toBe(0);
+    expect(withIsland.childrenById.get("island-01")).toEqual([]);
+    expect(withIsland.parentById.has("island-01")).toBe(false);
+    expect(withIsland.rootIds).toEqual(["core-01", "island-01", "peer-02"]);
+  });
+});
+
+/*
+ * Everything at once, because each resolution changes the input to the
+ * next: a campus with a declared uplink, a declared ping-only AP, a
+ * contradicted claim on an unmanaged peer, a second site whose triangle
+ * carries a declaration, and an island nobody has cabled.
+ */
+const campusNodes: Array<NetworkTopologyNode> = [
+  makeDevice("core-01", { role: "router" }),
+  makeDevice("dist-a", { role: "switch" }),
+  makeDevice("dist-b", { role: "switch" }),
+  makeDevice("ap-01", { role: "unknown" }),
+  makeUnmanaged("unmanaged:sw-x", { name: "sw-x" }),
+  makeEndpoint("endpoint:pos-1", { name: "pos-1" }),
+  makeDevice("peer-01", { role: "switch" }),
+  makeDevice("peer-02", { role: "switch" }),
+  makeDevice("peer-03", { role: "switch" }),
+  makeDevice("solo-01"),
+];
+
+const campusEdges: Array<NetworkTopologyEdge> = [
+  makeDeclaredEdge("core-01", "dist-a", "core-01", ["lldp"]),
+  makeEdge("core-01", "dist-b", ["lldp"]),
+  makeDeclaredEdge("dist-b", "ap-01", "dist-b", ["manual"]),
+  makeEdge("dist-a", "endpoint:pos-1", ["fdb"]),
+  // Contradiction: two devices both claim the unmanaged peer as a child.
+  makeDeclaredEdge("core-01", "unmanaged:sw-x", "core-01", ["cdp"]),
+  makeDeclaredEdge("dist-a", "unmanaged:sw-x", "dist-a", ["cdp"]),
+  makeEdge("peer-01", "peer-02", ["lldp"]),
+  makeDeclaredEdge("peer-02", "peer-03", "peer-03", ["manual"]),
+  makeEdge("peer-03", "peer-01", ["lldp"]),
+];
+
+describe("buildParentChildForest — a whole campus of mixed declarations", () => {
+  const forest: ParentChildForest = buildParentChildForest(
+    campusNodes,
+    campusEdges,
+  );
+
+  test("the forest is well formed however tangled the declarations are", () => {
+    expectWellFormedForest(forest, campusNodes);
+    /*
+     * peer-03 roots the second site rather than peer-01. All three of its
+     * switches tie on role and on connection count, so the choice used to
+     * fall to the alphabet — and a declaration is better evidence than the
+     * alphabet. peer-03 is the one an operator named as a parent.
+     */
+    expect(forest.rootIds).toEqual(["core-01", "peer-03", "solo-01"]);
+  });
+
+  test("each site's hierarchy is the one that was declared for it", () => {
+    expect(forest.parentById.get("dist-a")).toBe("core-01");
+    expect(forest.parentById.get("ap-01")).toBe("dist-b");
+    expect(forest.depthById.get("ap-01")).toBe(2);
+    expect(forest.parentById.get("endpoint:pos-1")).toBe("dist-a");
+    // The contradicted peer falls back to inference: one hop from the core.
+    expect(forest.parentById.get("unmanaged:sw-x")).toBe("core-01");
+    expect(forest.depthById.get("unmanaged:sw-x")).toBe(1);
+    /*
+     * The second site is a triangle of three equal switches, so nothing
+     * but the declaration distinguishes them. peer-03 was named a parent,
+     * so it tops the site and the other two hang directly off it — and
+     * both of those tree lines are real cables, which is the property that
+     * makes this the right answer rather than merely a consistent one.
+     */
+    expect(forest.parentById.get("peer-02")).toBe("peer-03");
+    expect(forest.parentById.get("peer-01")).toBe("peer-03");
+    expect(forest.depthById.get("peer-02")).toBe(1);
+  });
+
+  test("no node is its own ancestor and every walk ends at a root", () => {
+    for (const node of campusNodes) {
+      const walk: ParentChainWalk = parentChainOf(forest, node.id);
+      expect(walk.hitCycle).toBe(false);
+      expect(walk.chain.slice(1)).not.toContain(node.id);
+      expect(forest.rootIds).toContain(walk.chain[walk.chain.length - 1]);
+    }
+  });
+
+  test("shuffling the payload cannot change one parent", () => {
+    for (const seed of SHUFFLE_SEEDS) {
+      expectIdenticalForest(
+        buildParentChildForest(
+          permuted(campusNodes, seed),
+          permuted(campusEdges, seed * 7),
+        ),
+        forest,
+      );
+    }
+  });
+
+  test("reversing and flipping the payload cannot change one parent", () => {
+    expectIdenticalForest(
+      buildParentChildForest(
+        [...campusNodes].reverse(),
+        flipEdges([...campusEdges].reverse()),
+      ),
+      forest,
+    );
+  });
+
+  test("a link reported twice, once annotated, does not move anything", () => {
+    /*
+     * A hand-drawn link and the later-discovered cable for it MERGE into
+     * one edge server-side, but a reader must survive seeing both — and
+     * the declaration must survive being restated on the duplicate.
+     */
+    expectIdenticalForest(
+      buildParentChildForest(campusNodes, [
+        ...campusEdges,
+        makeEdge("dist-b", "ap-01", ["lldp"]),
+        makeDeclaredEdge("ap-01", "dist-b", "dist-b", ["manual"]),
+      ]),
+      forest,
+    );
+  });
+});
+
+describe("buildParentChildForest — a declared parent at the edge of the map", () => {
+  /*
+   * The awkward shape, and a realistic one: the declared parent is the ISP
+   * handoff, an unmanaged peer nothing else is cabled to. Every path to it
+   * runs through the very device it was declared to be the parent OF, so
+   * no tree rooted anywhere else in the estate can honour the statement —
+   * the only tree that can is the one rooted at the handoff itself.
+   *
+   * KNOWN GAP (reported alongside these tests, not papered over here):
+   * chooseTreeRoot picks by role and degree, so it roots at `core-01`, the
+   * traversal defers `dist-01` for a declared parent it can no longer
+   * reach, and the recovery sweep attaches both the other way up — the
+   * declaration is not merely dropped, it is inverted. The assertions
+   * below are therefore deliberately limited to what must be true under
+   * EITHER behaviour: the declaration is read correctly, the two devices
+   * stay directly related, and the forest remains a terminating,
+   * well-formed tree rather than a loop.
+   */
+  const nodes: Array<NetworkTopologyNode> = [
+    makeDevice("core-01", { role: "router" }),
+    makeDevice("dist-01", { role: "switch" }),
+    makeUnmanaged("unmanaged:isp-gw", { name: "isp-gw" }),
+  ];
+  const edges: Array<NetworkTopologyEdge> = [
+    makeEdge("core-01", "dist-01", ["lldp"]),
+    makeDeclaredEdge("dist-01", "unmanaged:isp-gw", "unmanaged:isp-gw", [
+      "manual",
+    ]),
+  ];
+
+  test("the declaration itself is read exactly as the operator wrote it", () => {
+    expect(sortedEntries(buildDeclaredParentMap(nodes, edges))).toEqual([
+      ["dist-01", "unmanaged:isp-gw"],
+    ]);
+  });
+
+  test("the forest still terminates and still places every device", () => {
+    const forest: ParentChildForest = buildParentChildForest(nodes, edges);
+    expectWellFormedForest(forest, nodes);
+    expect(forest.rootIds.length).toBe(1);
+  });
+
+  test("the two declared ends stay directly related to each other", () => {
+    const forest: ParentChildForest = buildParentChildForest(nodes, edges);
+    const parentOfGateway: string | undefined =
+      forest.parentById.get("unmanaged:isp-gw");
+    const parentOfSwitch: string | undefined = forest.parentById.get("dist-01");
+    expect(
+      parentOfGateway === "dist-01" || parentOfSwitch === "unmanaged:isp-gw",
+    ).toBe(true);
+  });
+
+  test("the awkward shape is still laid out identically every time", () => {
+    const forest: ParentChildForest = buildParentChildForest(nodes, edges);
+    for (const seed of SHUFFLE_SEEDS) {
+      expectIdenticalForest(
+        buildParentChildForest(permuted(nodes, seed), permuted(edges, seed)),
+        forest,
+      );
+    }
+  });
+});

--- a/App/Tests/Dashboard/RoleAwareTiering.test.ts
+++ b/App/Tests/Dashboard/RoleAwareTiering.test.ts
@@ -1,0 +1,656 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  NetworkTopologyDeviceRole,
+  NetworkTopologyEdge,
+  NetworkTopologyNode,
+} from "Common/Types/Monitor/SnmpMonitor/NetworkTopology";
+import {
+  TIERED_LAYOUT_TOP_MARGIN,
+  TIERED_TIER_GAP,
+  TopologyGroupBox,
+  computeTieredTopologyLayout,
+  computeTieredTopologyModel,
+  tierForNode,
+} from "../../FeatureSet/Dashboard/src/Components/NetworkDevice/TopologyLayout";
+
+/*
+ * Role-aware tiering (issue #3192).
+ *
+ * The tiered layout used to decide "core or access" purely from the bridge
+ * forwarding database: a managed device with no FDB edges was assumed to be
+ * upstream of everything. That reads backwards for the ping-only devices
+ * this feature exists for — nothing walks them, so they report no endpoints,
+ * so an access point or a camera was drawn at the same level as the router.
+ * These tests pin the new precedence: endpoint > unmanaged > role > FDB.
+ *
+ * Sibling coverage of the tier matrix WITHOUT roles lives in
+ * TieredTopologyLayout.test.ts; this file only exercises the role paths and
+ * the layout consequences of them.
+ */
+
+const WIDTH: number = 1000;
+
+type MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+) => NetworkTopologyNode;
+
+const makeDevice: MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: id,
+    name: id,
+    isManaged: true,
+    status: "up",
+    kind: "device",
+    ...overrides,
+  };
+};
+
+const makeUnmanaged: MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: id,
+    name: id,
+    isManaged: false,
+    status: "unknown",
+    kind: "unmanaged",
+    ...overrides,
+  };
+};
+
+const makeEndpoint: MakeNodeFunction = (
+  id: string,
+  overrides?: Partial<NetworkTopologyNode>,
+): NetworkTopologyNode => {
+  return {
+    id: id,
+    name: id,
+    isManaged: false,
+    status: "unknown",
+    kind: "endpoint",
+    ...overrides,
+  };
+};
+
+type MakeEdgeFunction = (
+  from: string,
+  to: string,
+  protocols?: NetworkTopologyEdge["protocols"],
+) => NetworkTopologyEdge;
+
+const makeEdge: MakeEdgeFunction = (
+  from: string,
+  to: string,
+  protocols?: NetworkTopologyEdge["protocols"],
+): NetworkTopologyEdge => {
+  return { fromNodeId: from, toNodeId: to, protocols: protocols };
+};
+
+// Roles that mean "everything else reaches the world through this box".
+const CORE_ROLES: Array<NetworkTopologyDeviceRole> = [
+  "router",
+  "firewall",
+  "loadBalancer",
+];
+
+/*
+ * Every other role in the legend. "switch" is deliberately in here: it is
+ * infrastructure, but infrastructure that hangs off a router, and the top
+ * tier is reserved for the boxes that hang off nothing.
+ */
+const NON_CORE_ROLES: Array<NetworkTopologyDeviceRole> = [
+  "switch",
+  "wirelessAccessPoint",
+  "server",
+  "storage",
+  "printer",
+  "camera",
+  "phone",
+  "host",
+];
+
+/*
+ * Every value the payload can carry, including the "we did not commit"
+ * answer. Used where the assertion is "the role is not consulted at all".
+ */
+const EVERY_ROLE: Array<NetworkTopologyDeviceRole> = [
+  ...CORE_ROLES,
+  ...NON_CORE_ROLES,
+  "unknown",
+];
+
+const NO_FDB_EDGES: Set<string> = new Set<string>();
+
+describe("tierForNode — endpoints ignore the role entirely", () => {
+  test("an endpoint tagged with a core role is still tier 2", () => {
+    /*
+     * Tier 2 is what the tiered layout packs into per-switch group boxes.
+     * If a role could lift an endpoint out of tier 2 the box would lose a
+     * member it is drawn around, so the endpoint check has to come first
+     * whatever the role says.
+     */
+    const endpoint: NetworkTopologyNode = makeEndpoint("endpoint:pos-1", {
+      name: "pos-1",
+      role: "router",
+    });
+    expect(tierForNode(endpoint, NO_FDB_EDGES)).toBe(2);
+  });
+
+  test("an endpoint keeps tier 2 for every role in the legend", () => {
+    for (const role of EVERY_ROLE) {
+      const endpoint: NetworkTopologyNode = makeEndpoint("endpoint:kiosk", {
+        role: role,
+      });
+      expect(tierForNode(endpoint, NO_FDB_EDGES)).toBe(2);
+    }
+  });
+
+  test("an endpoint with an FDB edge and a core role is still tier 2", () => {
+    // Both other signals point away from tier 2; the kind still wins.
+    const endpoint: NetworkTopologyNode = makeEndpoint("endpoint:pos-2", {
+      role: "firewall",
+    });
+    expect(tierForNode(endpoint, new Set<string>(["endpoint:pos-2"]))).toBe(2);
+  });
+});
+
+describe("tierForNode — unmanaged peers ignore the role entirely", () => {
+  test("an unmanaged peer tagged with a core role is still tier 1", () => {
+    /*
+     * An unmanaged node exists only because a neighbour advertised it. We
+     * have no evidence of our own about what it does, so a role that rode
+     * in on that advertisement must not promote somebody else's box into
+     * our core tier.
+     */
+    const peer: NetworkTopologyNode = makeUnmanaged("unmanaged:peer-core", {
+      role: "router",
+    });
+    expect(tierForNode(peer, NO_FDB_EDGES)).toBe(1);
+  });
+
+  test("an unmanaged peer stays tier 1 for every role in the legend", () => {
+    for (const role of EVERY_ROLE) {
+      const peer: NetworkTopologyNode = makeUnmanaged("unmanaged:peer", {
+        role: role,
+      });
+      expect(tierForNode(peer, NO_FDB_EDGES)).toBe(1);
+    }
+  });
+
+  test("an unmanaged peer with a core role and an FDB edge is still tier 1", () => {
+    const peer: NetworkTopologyNode = makeUnmanaged("unmanaged:peer-fdb", {
+      role: "loadBalancer",
+    });
+    expect(tierForNode(peer, new Set<string>(["unmanaged:peer-fdb"]))).toBe(1);
+  });
+});
+
+describe("tierForNode — a role on a managed device settles the tier", () => {
+  test("router is tier 0", () => {
+    expect(
+      tierForNode(makeDevice("dev", { role: "router" }), NO_FDB_EDGES),
+    ).toBe(0);
+  });
+
+  test("firewall is tier 0", () => {
+    expect(
+      tierForNode(makeDevice("dev", { role: "firewall" }), NO_FDB_EDGES),
+    ).toBe(0);
+  });
+
+  test("loadBalancer is tier 0", () => {
+    expect(
+      tierForNode(makeDevice("dev", { role: "loadBalancer" }), NO_FDB_EDGES),
+    ).toBe(0);
+  });
+
+  test("switch is tier 1 — a switch hangs off a router, it is not the core", () => {
+    expect(
+      tierForNode(makeDevice("dev", { role: "switch" }), NO_FDB_EDGES),
+    ).toBe(1);
+  });
+
+  test("every access-layer and leaf role is tier 1", () => {
+    for (const role of NON_CORE_ROLES) {
+      const device: NetworkTopologyNode = makeDevice(`dev-${role}`, {
+        role: role,
+      });
+      expect(tierForNode(device, NO_FDB_EDGES)).toBe(1);
+    }
+  });
+
+  test("every core role is tier 0", () => {
+    for (const role of CORE_ROLES) {
+      const device: NetworkTopologyNode = makeDevice(`dev-${role}`, {
+        role: role,
+      });
+      expect(tierForNode(device, NO_FDB_EDGES)).toBe(0);
+    }
+  });
+
+  test("the role beats the FDB heuristic in both directions", () => {
+    /*
+     * The heuristic and the role disagree in both possible ways here. A
+     * router that happens to have learned a MAC is still the core, and a
+     * printer nothing has learned a MAC through is still a leaf — a stated
+     * role is a fact about the box, the FDB is an inference about it.
+     */
+    const routerWithFdb: NetworkTopologyNode = makeDevice("core-1", {
+      role: "router",
+    });
+    expect(tierForNode(routerWithFdb, new Set<string>(["core-1"]))).toBe(0);
+
+    const printerWithoutFdb: NetworkTopologyNode = makeDevice("printer-1", {
+      role: "printer",
+    });
+    expect(tierForNode(printerWithoutFdb, NO_FDB_EDGES)).toBe(1);
+  });
+});
+
+describe("tierForNode — no usable role falls back to the FDB heuristic", () => {
+  test('role "unknown" with an FDB edge is tier 1', () => {
+    /*
+     * "unknown" is the classifier's honest answer, not a role. It has to
+     * behave exactly like an absent role or the classifier would silently
+     * change the layout every time it declined to commit.
+     */
+    const device: NetworkTopologyNode = makeDevice("sw-1", {
+      role: "unknown",
+    });
+    expect(tierForNode(device, new Set<string>(["sw-1"]))).toBe(1);
+  });
+
+  test('role "unknown" with no FDB edge is tier 0', () => {
+    const device: NetworkTopologyNode = makeDevice("sw-1", {
+      role: "unknown",
+    });
+    expect(tierForNode(device, NO_FDB_EDGES)).toBe(0);
+  });
+
+  test("an absent role with an FDB edge is tier 1", () => {
+    const device: NetworkTopologyNode = makeDevice("sw-2");
+    expect(device.role).toBeUndefined();
+    expect(tierForNode(device, new Set<string>(["sw-2"]))).toBe(1);
+  });
+
+  test("an absent role with no FDB edge is tier 0", () => {
+    const device: NetworkTopologyNode = makeDevice("sw-2");
+    expect(tierForNode(device, NO_FDB_EDGES)).toBe(0);
+  });
+
+  test('an absent role and "unknown" agree on every FDB state', () => {
+    const withoutRole: NetworkTopologyNode = makeDevice("dev-1");
+    const withUnknownRole: NetworkTopologyNode = makeDevice("dev-1", {
+      role: "unknown",
+    });
+    for (const fdbIds of [NO_FDB_EDGES, new Set<string>(["dev-1"])]) {
+      expect(tierForNode(withUnknownRole, fdbIds)).toBe(
+        tierForNode(withoutRole, fdbIds),
+      );
+    }
+  });
+
+  test("the FDB set is consulted by id, not by identity of the node object", () => {
+    // A device whose id is absent from a non-empty set is still tier 0.
+    const device: NetworkTopologyNode = makeDevice("dev-alone");
+    expect(tierForNode(device, new Set<string>(["some-other-device"]))).toBe(0);
+  });
+});
+
+describe("tierForNode — regression guards for issue #3192", () => {
+  test("REGRESSION: a ping-only wireless access point with no FDB edges is tier 1, not tier 0", () => {
+    /*
+     * THE bug from issue #3192. A wireless AP added by ping alone answers
+     * no SNMP, so it can never appear in anybody's forwarding database,
+     * so the old FDB-only heuristic ranked it at CORE level — drawn beside
+     * the router it actually hangs off, and competing with that router to
+     * root the parent-child tree. With the operator's role on the device
+     * it drops to tier 1 where it belongs.
+     */
+    const pingOnlyAccessPoint: NetworkTopologyNode = makeDevice("ap-lobby", {
+      name: "AP Lobby",
+      role: "wirelessAccessPoint",
+    });
+    expect(tierForNode(pingOnlyAccessPoint, NO_FDB_EDGES)).toBe(1);
+    expect(tierForNode(pingOnlyAccessPoint, NO_FDB_EDGES)).not.toBe(0);
+  });
+
+  test("REGRESSION: every ping-only leaf role stays out of the core tier", () => {
+    /*
+     * The AP is just the case that was reported. A camera, a printer and a
+     * VoIP phone monitored by ping fail in exactly the same way, so the
+     * whole leaf set is pinned here.
+     */
+    const pingOnlyRoles: Array<NetworkTopologyDeviceRole> = [
+      "camera",
+      "printer",
+      "phone",
+      "server",
+      "host",
+    ];
+    for (const role of pingOnlyRoles) {
+      const device: NetworkTopologyNode = makeDevice(`ping-only-${role}`, {
+        role: role,
+      });
+      expect(tierForNode(device, NO_FDB_EDGES)).toBe(1);
+    }
+  });
+
+  test("the same device WITHOUT a role still lands in the core tier", () => {
+    /*
+     * Not an endorsement of the old behaviour — a statement of what the
+     * role is buying. Nothing changed for estates that never set one.
+     */
+    const untagged: NetworkTopologyNode = makeDevice("ap-lobby", {
+      name: "AP Lobby",
+    });
+    expect(tierForNode(untagged, NO_FDB_EDGES)).toBe(0);
+  });
+});
+
+describe("tierForNode — purity and determinism", () => {
+  test("repeated calls on the same inputs agree", () => {
+    const device: NetworkTopologyNode = makeDevice("ap-1", {
+      role: "wirelessAccessPoint",
+    });
+    const fdbIds: Set<string> = new Set<string>(["ap-1"]);
+    expect(tierForNode(device, fdbIds)).toBe(tierForNode(device, fdbIds));
+  });
+
+  test("the insertion order of the FDB set never changes the answer", () => {
+    const device: NetworkTopologyNode = makeDevice("sw-1");
+    const forward: Set<string> = new Set<string>(["a", "sw-1", "z"]);
+    const backward: Set<string> = new Set<string>(["z", "sw-1", "a"]);
+    expect(tierForNode(device, forward)).toBe(tierForNode(device, backward));
+  });
+
+  test("tiering does not mutate the node or the FDB set", () => {
+    const device: NetworkTopologyNode = makeDevice("ap-1", {
+      role: "wirelessAccessPoint",
+    });
+    const fdbIds: Set<string> = new Set<string>(["sw-1"]);
+    tierForNode(device, fdbIds);
+    expect(device.role).toBe("wirelessAccessPoint");
+    expect(Array.from(fdbIds)).toEqual(["sw-1"]);
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * Integration: the same site drawn through the tiered layout.
+ *
+ * One core router, one access switch with two endpoints on it, and the
+ * ping-only access point from the issue. The AP is a managed device with a
+ * role and no FDB edges — exactly the shape that used to be ranked at core
+ * level.
+ */
+
+const coreRouter: NetworkTopologyNode = makeDevice("core-router", {
+  name: "core-router",
+  role: "router",
+});
+const accessSwitch: NetworkTopologyNode = makeDevice("sw-a", {
+  name: "sw-a",
+  role: "switch",
+});
+const accessPoint: NetworkTopologyNode = makeDevice("ap-lobby", {
+  /*
+   * Name sorts BEFORE the switch, so any ordering assertion below is about
+   * the childless-trails-anchored rule and not about alphabetics.
+   */
+  name: "ap-lobby",
+  role: "wirelessAccessPoint",
+});
+const pos1: NetworkTopologyNode = makeEndpoint("endpoint:pos-1", {
+  name: "pos-1",
+});
+const pos2: NetworkTopologyNode = makeEndpoint("endpoint:pos-2", {
+  name: "pos-2",
+});
+
+const siteNodes: Array<NetworkTopologyNode> = [
+  coreRouter,
+  accessSwitch,
+  accessPoint,
+  pos1,
+  pos2,
+];
+
+const siteEdges: Array<NetworkTopologyEdge> = [
+  makeEdge("core-router", "sw-a", ["lldp"]),
+  // The AP's cable was drawn by hand — that is the whole point of the issue.
+  makeEdge("sw-a", "ap-lobby", ["manual"]),
+  makeEdge("sw-a", "endpoint:pos-1", ["fdb"]),
+  makeEdge("sw-a", "endpoint:pos-2", ["fdb"]),
+];
+
+interface TieredModel {
+  positions: Map<string, { x: number; y: number }>;
+  groups: Array<TopologyGroupBox>;
+}
+
+describe("computeTieredTopologyLayout — a role-tagged access point is its own tier-1 node", () => {
+  const model: TieredModel = computeTieredTopologyModel(
+    siteNodes,
+    siteEdges,
+    WIDTH,
+  );
+  const layout: Map<string, { x: number; y: number }> =
+    computeTieredTopologyLayout(siteNodes, siteEdges, WIDTH);
+
+  test("every node is placed exactly once", () => {
+    expect(layout.size).toBe(siteNodes.length);
+  });
+
+  test("the router alone occupies the core tier", () => {
+    expect(layout.get("core-router")!.y).toBe(TIERED_LAYOUT_TOP_MARGIN);
+    // A lone tier-0 node is centred on the width.
+    expect(layout.get("core-router")!.x).toBe(WIDTH / 2);
+  });
+
+  test("the access point shares the switch's row, one tier under the router", () => {
+    const routerY: number = layout.get("core-router")!.y;
+    const switchY: number = layout.get("sw-a")!.y;
+    expect(layout.get("ap-lobby")!.y).toBe(switchY);
+    expect(switchY - routerY).toBe(TIERED_TIER_GAP);
+  });
+
+  test("the access point is NOT inside any endpoint group box", () => {
+    /*
+     * Group boxes are the per-switch blocks of tier-2 endpoints. A managed
+     * device drawn inside one would read as "a thing hanging off the
+     * switch like a POS terminal", which is precisely the confusion the
+     * role is there to remove.
+     */
+    for (const box of model.groups) {
+      expect(box.nodeIds).not.toContain("ap-lobby");
+    }
+  });
+
+  test("the only group box belongs to the switch and holds only endpoints", () => {
+    expect(model.groups.length).toBe(1);
+    const box: TopologyGroupBox = model.groups[0]!;
+    expect(box.anchorNodeId).toBe("sw-a");
+    expect(box.nodeIds).toEqual(["endpoint:pos-1", "endpoint:pos-2"]);
+    expect(box.endpointCount).toBe(2);
+  });
+
+  test("the access point sits geometrically clear of the switch's group box", () => {
+    const box: TopologyGroupBox = model.groups[0]!;
+    const apX: number = model.positions.get("ap-lobby")!.x;
+    expect(apX > box.x + box.width || apX < box.x).toBe(true);
+  });
+
+  test("a childless tier-1 node trails the switch that owns endpoints", () => {
+    // Alphabetically "ap-lobby" < "sw-a", so this is the column rule, not the sort.
+    expect(layout.get("ap-lobby")!.x).toBeGreaterThan(layout.get("sw-a")!.x);
+  });
+
+  test("the endpoints stay in tier 2 below the switch", () => {
+    const switchY: number = layout.get("sw-a")!.y;
+    expect(layout.get("endpoint:pos-1")!.y).toBe(switchY + TIERED_TIER_GAP);
+    expect(layout.get("endpoint:pos-2")!.y).toBe(switchY + TIERED_TIER_GAP);
+  });
+
+  test("the same site with the AP's role stripped puts it back at core level", () => {
+    /*
+     * The before picture, drawn from the identical graph: without the
+     * operator's role the AP has no FDB edges, so the heuristic promotes
+     * it and it lands on the router's row.
+     */
+    const untaggedNodes: Array<NetworkTopologyNode> = siteNodes.map(
+      (node: NetworkTopologyNode): NetworkTopologyNode => {
+        return node.id === "ap-lobby" ? makeDevice("ap-lobby") : node;
+      },
+    );
+    const untaggedLayout: Map<string, { x: number; y: number }> =
+      computeTieredTopologyLayout(untaggedNodes, siteEdges, WIDTH);
+    expect(untaggedLayout.get("ap-lobby")!.y).toBe(
+      untaggedLayout.get("core-router")!.y,
+    );
+    // ...and with the role it is a full tier lower.
+    expect(layout.get("ap-lobby")!.y).toBeGreaterThan(
+      untaggedLayout.get("ap-lobby")!.y,
+    );
+  });
+
+  test('an AP tagged "unknown" behaves exactly like an untagged one', () => {
+    const unknownRoleNodes: Array<NetworkTopologyNode> = siteNodes.map(
+      (node: NetworkTopologyNode): NetworkTopologyNode => {
+        return node.id === "ap-lobby"
+          ? makeDevice("ap-lobby", { role: "unknown" })
+          : node;
+      },
+    );
+    const untaggedNodes: Array<NetworkTopologyNode> = siteNodes.map(
+      (node: NetworkTopologyNode): NetworkTopologyNode => {
+        return node.id === "ap-lobby" ? makeDevice("ap-lobby") : node;
+      },
+    );
+    const unknownLayout: Map<string, { x: number; y: number }> =
+      computeTieredTopologyLayout(unknownRoleNodes, siteEdges, WIDTH);
+    const untaggedLayout: Map<string, { x: number; y: number }> =
+      computeTieredTopologyLayout(untaggedNodes, siteEdges, WIDTH);
+    for (const node of siteNodes) {
+      expect(unknownLayout.get(node.id)).toEqual(untaggedLayout.get(node.id));
+    }
+  });
+});
+
+describe("computeTieredTopologyLayout — roles on endpoints never move them out of their group", () => {
+  test("an endpoint tagged with a core role stays inside its switch's box", () => {
+    /*
+     * Endpoint classification and device role come from different places,
+     * so a "router"-ish endpoint is a real possibility. It must not tear a
+     * hole in the group box it is drawn inside.
+     */
+    const roleTaggedEndpoint: NetworkTopologyNode = makeEndpoint(
+      "endpoint:pos-3",
+      { name: "pos-3", role: "router" },
+    );
+    const model: TieredModel = computeTieredTopologyModel(
+      [...siteNodes, roleTaggedEndpoint],
+      [...siteEdges, makeEdge("sw-a", "endpoint:pos-3", ["fdb"])],
+      WIDTH,
+    );
+
+    expect(model.groups.length).toBe(1);
+    const box: TopologyGroupBox = model.groups[0]!;
+    expect(box.nodeIds).toContain("endpoint:pos-3");
+    expect(box.endpointCount).toBe(3);
+
+    const point: { x: number; y: number } =
+      model.positions.get("endpoint:pos-3")!;
+    expect(point.x).toBeGreaterThan(box.x);
+    expect(point.x).toBeLessThan(box.x + box.width);
+    expect(point.y).toBeGreaterThan(box.y);
+    expect(point.y).toBeLessThan(box.y + box.height);
+    // Still a full tier below the switch it hangs off.
+    expect(point.y).toBe(model.positions.get("sw-a")!.y + TIERED_TIER_GAP);
+  });
+});
+
+describe("computeTieredTopologyLayout — role-aware tiering stays deterministic", () => {
+  test("identical inputs yield identical coordinates and boxes", () => {
+    const first: TieredModel = computeTieredTopologyModel(
+      siteNodes,
+      siteEdges,
+      WIDTH,
+    );
+    const second: TieredModel = computeTieredTopologyModel(
+      siteNodes,
+      siteEdges,
+      WIDTH,
+    );
+    for (const node of siteNodes) {
+      expect(second.positions.get(node.id)).toEqual(
+        first.positions.get(node.id),
+      );
+    }
+    expect(second.groups).toEqual(first.groups);
+  });
+
+  test("reversing the node and edge arrays changes nothing", () => {
+    const original: TieredModel = computeTieredTopologyModel(
+      siteNodes,
+      siteEdges,
+      WIDTH,
+    );
+    const reordered: TieredModel = computeTieredTopologyModel(
+      [...siteNodes].reverse(),
+      [...siteEdges].reverse(),
+      WIDTH,
+    );
+    for (const node of siteNodes) {
+      expect(reordered.positions.get(node.id)).toEqual(
+        original.positions.get(node.id),
+      );
+    }
+    expect(reordered.groups).toEqual(original.groups);
+  });
+
+  test("flipping every edge's direction changes nothing", () => {
+    // Attachment and tiering are both undirected; only the role is a fact.
+    const original: TieredModel = computeTieredTopologyModel(
+      siteNodes,
+      siteEdges,
+      WIDTH,
+    );
+    const flipped: TieredModel = computeTieredTopologyModel(
+      siteNodes,
+      siteEdges.map((edge: NetworkTopologyEdge): NetworkTopologyEdge => {
+        return makeEdge(edge.toNodeId, edge.fromNodeId, edge.protocols);
+      }),
+      WIDTH,
+    );
+    for (const node of siteNodes) {
+      expect(flipped.positions.get(node.id)).toEqual(
+        original.positions.get(node.id),
+      );
+    }
+    expect(flipped.groups).toEqual(original.groups);
+  });
+
+  test("a graph of nothing but role-tagged leaves has an empty core tier", () => {
+    /*
+     * The pathological ping-only site: no SNMP anywhere, so no FDB edges at
+     * all. Every device is a leaf, so tier 0 is empty and tier 1 starts at
+     * the very top of the frame rather than a tier gap down.
+     */
+    const leaves: Array<NetworkTopologyNode> = [
+      makeDevice("ap-1", { name: "ap-1", role: "wirelessAccessPoint" }),
+      makeDevice("cam-1", { name: "cam-1", role: "camera" }),
+      makeDevice("printer-1", { name: "printer-1", role: "printer" }),
+    ];
+    const layout: Map<string, { x: number; y: number }> =
+      computeTieredTopologyLayout(leaves, [], WIDTH);
+    for (const leaf of leaves) {
+      expect(layout.get(leaf.id)!.y).toBe(TIERED_LAYOUT_TOP_MARGIN);
+    }
+  });
+});

--- a/Common/Models/DatabaseModels/NetworkDevice.ts
+++ b/Common/Models/DatabaseModels/NetworkDevice.ts
@@ -675,6 +675,50 @@ export default class NetworkDevice extends BaseModel {
     ],
   })
   @TableColumn({
+    required: false,
+    type: TableColumnType.ShortText,
+    canReadOnRelationQuery: true,
+    title: "Device Role",
+    description:
+      "What this device does on the network — router, switch, access point and so on. Left empty, the role is worked out from the device's own SNMP identity. Set it when there is no SNMP to read: a ping-only device has no identity to classify, and the role decides both the shape it is drawn with and where it sits in the topology hierarchy.",
+    example: "switch",
+  })
+  @Column({
+    nullable: true,
+    type: ColumnType.ShortText,
+    length: ColumnLength.ShortText,
+  })
+  public deviceRole?: string = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.CreateNetworkDevice,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.SettingsViewer,
+      Permission.ReadNetworkDevice,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDevice,
+    ],
+  })
+  @TableColumn({
     manyToOneRelationColumn: "monitorId",
     type: TableColumnType.Entity,
     modelType: Monitor,

--- a/Common/Models/DatabaseModels/NetworkDeviceLink.ts
+++ b/Common/Models/DatabaseModels/NetworkDeviceLink.ts
@@ -376,6 +376,122 @@ export default class NetworkDeviceLink extends BaseModel {
   })
   public toDeviceId?: ObjectID = undefined;
 
+  /*
+   * --- Which end is up ---
+   *
+   * A link says two devices are cabled together. It does not say which one
+   * the other hangs off, and the topology map has to decide: the
+   * parent-child view draws an actual tree, so somebody is the parent.
+   * Left to itself it infers one from device roles and connection counts,
+   * which is a good guess on a network that speaks SNMP and no guess at
+   * all on one that does not — the case issue #3192 is about, where the
+   * child is a ping-only device whose role nothing can classify.
+   *
+   * This column is the operator answering that question outright. It is
+   * NULL by default and on every row written before it existed, and NULL
+   * means exactly what the map did then: a peer link, direction inferred.
+   * So no existing map moves, and a hierarchy only becomes declared when
+   * somebody declares it.
+   *
+   * The value must be one of this link's own two ends — a parent that is
+   * not on the link is not a statement about the link — which the service
+   * enforces on create and on update, including when an update moves an
+   * end out from under a parent that was already set.
+   */
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.CreateNetworkDeviceLink,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.SettingsViewer,
+      Permission.ReadNetworkDeviceLink,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceLink,
+    ],
+  })
+  @TableColumn({
+    manyToOneRelationColumn: "parentDeviceId",
+    type: TableColumnType.Entity,
+    modelType: NetworkDevice,
+    title: "Parent Device",
+    description:
+      "Relation to whichever end of this link is the parent, if the hierarchy is declared rather than inferred",
+  })
+  @ManyToOne(
+    () => {
+      return NetworkDevice;
+    },
+    {
+      eager: false,
+      nullable: true,
+      onDelete: "CASCADE",
+      orphanedRowAction: "nullify",
+    },
+  )
+  @JoinColumn({ name: "parentDeviceId" })
+  public parentDevice?: NetworkDevice = undefined;
+
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.CreateNetworkDeviceLink,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.SettingsViewer,
+      Permission.ReadNetworkDeviceLink,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.SettingsAdmin,
+      Permission.SettingsMember,
+      Permission.EditNetworkDeviceLink,
+    ],
+  })
+  @Index()
+  @TableColumn({
+    type: TableColumnType.ObjectID,
+    required: false,
+    canReadOnRelationQuery: true,
+    title: "Parent Device ID",
+    description:
+      "ID of whichever end of this link is the parent. Must be the From Device or the To Device. Empty means the two are peers and the map infers the hierarchy.",
+  })
+  @Column({
+    type: ColumnType.ObjectID,
+    nullable: true,
+    transformer: ObjectID.getDatabaseTransformer(),
+  })
+  public parentDeviceId?: ObjectID = undefined;
+
   @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786956817229-AddDeviceRoleAndDeclaredLinkParent.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1786956817229-AddDeviceRoleAndDeclaredLinkParent.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * Two nullable columns, both of them an operator stating something the
+ * network cannot be asked:
+ *
+ *   NetworkDevice.deviceRole      — what this box actually is, for devices
+ *                                   with no SNMP identity to classify.
+ *   NetworkDeviceLink.parentDeviceId — which end of a declared link is up.
+ *
+ * Nullable on purpose, with no backfill. NULL is a meaningful value in
+ * both cases and it is the value every existing row should hold: no role
+ * override (so the classifier keeps deciding) and no declared hierarchy
+ * (so the map keeps inferring one). Defaulting either would silently
+ * restate every device and every link in every project as something an
+ * operator had chosen, which is the one thing neither column may mean.
+ */
+export class AddDeviceRoleAndDeclaredLinkParent1786956817229
+  implements MigrationInterface
+{
+  public name = "AddDeviceRoleAndDeclaredLinkParent1786956817229";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDevice" ADD "deviceRole" character varying(100)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDeviceLink" ADD "parentDeviceId" uuid`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_01752cd47b773df38b4a54ae53" ON "NetworkDeviceLink" ("parentDeviceId") `,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDeviceLink" ADD CONSTRAINT "FK_01752cd47b773df38b4a54ae539" FOREIGN KEY ("parentDeviceId") REFERENCES "NetworkDevice"("_id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDeviceLink" DROP CONSTRAINT "FK_01752cd47b773df38b4a54ae539"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_01752cd47b773df38b4a54ae53"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDeviceLink" DROP COLUMN "parentDeviceId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "NetworkDevice" DROP COLUMN "deviceRole"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787400000000-AddDeviceRoleAndDeclaredLinkParent.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787400000000-AddDeviceRoleAndDeclaredLinkParent.ts
@@ -15,10 +15,10 @@ import { MigrationInterface, QueryRunner } from "typeorm";
  * restate every device and every link in every project as something an
  * operator had chosen, which is the one thing neither column may mean.
  */
-export class AddDeviceRoleAndDeclaredLinkParent1786956817229
+export class AddDeviceRoleAndDeclaredLinkParent1787400000000
   implements MigrationInterface
 {
-  public name = "AddDeviceRoleAndDeclaredLinkParent1786956817229";
+  public name = "AddDeviceRoleAndDeclaredLinkParent1787400000000";
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -527,7 +527,7 @@ import { AddOnCallNotificationFallbackColumns1787000000000 } from "./17870000000
 import { AddAIConversationPageContext1787100000000 } from "./1787100000000-AddAIConversationPageContext";
 import { AddAIChatMessageFeedback1787200000000 } from "./1787200000000-AddAIChatMessageFeedback";
 import { AddEpisodeMemberNotifyIndexes1787300000000 } from "./1787300000000-AddEpisodeMemberNotifyIndexes";
-import { AddDeviceRoleAndDeclaredLinkParent1786956817229 } from "./1786956817229-AddDeviceRoleAndDeclaredLinkParent";
+import { AddDeviceRoleAndDeclaredLinkParent1787400000000 } from "./1787400000000-AddDeviceRoleAndDeclaredLinkParent";
 
 export default [
   InitialMigration,
@@ -1059,5 +1059,5 @@ export default [
   AddAIConversationPageContext1787100000000,
   AddAIChatMessageFeedback1787200000000,
   AddEpisodeMemberNotifyIndexes1787300000000,
-  AddDeviceRoleAndDeclaredLinkParent1786956817229,
+  AddDeviceRoleAndDeclaredLinkParent1787400000000,
 ];

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -527,6 +527,7 @@ import { AddOnCallNotificationFallbackColumns1787000000000 } from "./17870000000
 import { AddAIConversationPageContext1787100000000 } from "./1787100000000-AddAIConversationPageContext";
 import { AddAIChatMessageFeedback1787200000000 } from "./1787200000000-AddAIChatMessageFeedback";
 import { AddEpisodeMemberNotifyIndexes1787300000000 } from "./1787300000000-AddEpisodeMemberNotifyIndexes";
+import { AddDeviceRoleAndDeclaredLinkParent1786956817229 } from "./1786956817229-AddDeviceRoleAndDeclaredLinkParent";
 
 export default [
   InitialMigration,
@@ -1058,4 +1059,5 @@ export default [
   AddAIConversationPageContext1787100000000,
   AddAIChatMessageFeedback1787200000000,
   AddEpisodeMemberNotifyIndexes1787300000000,
+  AddDeviceRoleAndDeclaredLinkParent1786956817229,
 ];

--- a/Common/Server/Services/NetworkDeviceLinkService.ts
+++ b/Common/Server/Services/NetworkDeviceLinkService.ts
@@ -2,22 +2,138 @@ import DatabaseService from "./DatabaseService";
 import Model from "../../Models/DatabaseModels/NetworkDeviceLink";
 import NetworkDeviceService from "./NetworkDeviceService";
 import NetworkDevice from "../../Models/DatabaseModels/NetworkDevice";
-import { OnCreate } from "../Types/Database/Hooks";
+import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
 import CreateBy from "../Types/Database/CreateBy";
+import UpdateBy from "../Types/Database/UpdateBy";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
 import BadDataException from "../../Types/Exception/BadDataException";
 import ObjectID from "../../Types/ObjectID";
 import QueryHelper from "../Types/Database/QueryHelper";
 import RelationIdUtil from "../Utils/Database/RelationIdUtil";
 import LIMIT_MAX from "../../Types/Database/LimitMax";
+import Query from "../Types/Database/Query";
+import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 
 // Both spellings of each end, for the same reason RelationIdUtil exists.
 const FROM_DEVICE_KEYS: Array<string> = ["fromDeviceId", "fromDevice"];
 const TO_DEVICE_KEYS: Array<string> = ["toDeviceId", "toDevice"];
+const PARENT_DEVICE_KEYS: Array<string> = ["parentDeviceId", "parentDevice"];
+
+/*
+ * A device id, compared the way Postgres compares it.
+ *
+ * These columns are `uuid`. Postgres normalises and matches them without
+ * regard to case, and ObjectID.isValidUUID accepts either case, so an API
+ * client may legitimately send `AAAAAAAA-...` for a row stored as
+ * `aaaaaaaa-...`. A raw JS !== between the two says "different device" and
+ * refuses a parent that is in fact an end of the link. Note that the
+ * device-existence check below cannot disagree: it runs in Postgres.
+ */
+const sameDeviceId: (a: ObjectID, b: ObjectID) => boolean = (
+  a: ObjectID,
+  b: ObjectID,
+): boolean => {
+  return a.toString().toLowerCase() === b.toString().toLowerCase();
+};
+
+/*
+ * A declared parent has to be one of the two devices the link connects.
+ * Anything else is not a statement about this link at all, and the map
+ * would silently ignore it — the operator would have declared a hierarchy
+ * and watched nothing change.
+ */
+const assertParentIsAnEnd: (
+  parentDeviceId: ObjectID | null,
+  fromDeviceId: ObjectID,
+  toDeviceId: ObjectID,
+) => void = (
+  parentDeviceId: ObjectID | null,
+  fromDeviceId: ObjectID,
+  toDeviceId: ObjectID,
+): void => {
+  if (!parentDeviceId) {
+    return;
+  }
+  if (
+    !sameDeviceId(parentDeviceId, fromDeviceId) &&
+    !sameDeviceId(parentDeviceId, toDeviceId)
+  ) {
+    throw new BadDataException(
+      "The parent device must be one of the two devices this link connects.",
+    );
+  }
+};
+
+/*
+ * Which of `keys` the payload actually WRITES.
+ *
+ * Not the same question as which keys are present. TypeORM drops
+ * undefined-valued keys before it builds the SET list — "it doesn't make
+ * sense to update undefined properties" — so a key holding undefined
+ * changes nothing in the database. Treating it as a write makes this hook
+ * validate a row that is never going to exist: model the parent as
+ * cleared, accept the write, and leave the stored parent stranded on a
+ * link whose end just moved. Null and "" are different and really do
+ * clear the column, which is why the test is against undefined alone.
+ */
+const writtenKeys: (
+  data: Record<string, unknown>,
+  keys: Array<string>,
+) => Array<string> = (
+  data: Record<string, unknown>,
+  keys: Array<string>,
+): Array<string> => {
+  return keys.filter((key: string) => {
+    return key in data && data[key] !== undefined;
+  });
+};
+
+/*
+ * An update payload is a QueryDeepPartialEntity, so a column may hold a
+ * raw SQL-expression function instead of a value. RelationIdUtil reads one
+ * as null — indistinguishable from "cleared" — and the whole invariant is
+ * then checked against a row that bears no relation to what will be
+ * written. Nothing in the tree writes this model that way today; refusing
+ * is what keeps that true, and a caller who needs it can resolve the id
+ * before calling rather than have it silently mis-validated.
+ */
+const assertNoSqlExpression: (
+  data: Record<string, unknown>,
+  keys: Array<string>,
+) => void = (data: Record<string, unknown>, keys: Array<string>): void => {
+  for (const key of keys) {
+    if (typeof data[key] === "function") {
+      throw new BadDataException(
+        `${key} cannot be set to a raw SQL expression on a network device link — the link's ends and its declared parent have to be checked against each other, which needs actual ids.`,
+      );
+    }
+  }
+};
 
 export class Service extends DatabaseService<Model> {
   public constructor() {
     super(Model);
+  }
+
+  /*
+   * onBeforeUpdate runs before DatabaseService permission-checks the query,
+   * so reading the raw client query as root would hand the hook rows from
+   * other projects. Re-apply the caller's tenant here. (Same helper as
+   * NetworkDeviceService and NetworkSiteService — private per service,
+   * which is the shape the codebase already settled on.)
+   */
+  private scopeQueryToCallerTenant(
+    query: Query<Model>,
+    props: DatabaseCommonInteractionProps,
+  ): Query<Model> {
+    if (props.isRoot || !props.tenantId) {
+      return query;
+    }
+
+    return {
+      ...query,
+      projectId: props.tenantId,
+    };
   }
 
   /*
@@ -39,6 +155,12 @@ export class Service extends DatabaseService<Model> {
       unknown
     >;
 
+    assertNoSqlExpression(data, [
+      ...FROM_DEVICE_KEYS,
+      ...TO_DEVICE_KEYS,
+      ...PARENT_DEVICE_KEYS,
+    ]);
+
     const fromDeviceId: ObjectID | null = RelationIdUtil.read(
       data,
       FROM_DEVICE_KEYS,
@@ -52,7 +174,7 @@ export class Service extends DatabaseService<Model> {
       throw new BadDataException("A link needs a device at each end.");
     }
 
-    if (fromDeviceId.toString() === toDeviceId.toString()) {
+    if (sameDeviceId(fromDeviceId, toDeviceId)) {
       throw new BadDataException("A device cannot be linked to itself.");
     }
 
@@ -77,7 +199,221 @@ export class Service extends DatabaseService<Model> {
       );
     }
 
+    assertParentIsAnEnd(
+      RelationIdUtil.read(data, PARENT_DEVICE_KEYS),
+      fromDeviceId,
+      toDeviceId,
+    );
+
     return { createBy, carryForward: null };
+  }
+
+  /*
+   * The same invariant, on the other write path.
+   *
+   * An update can break it two ways, and only one of them is obvious. The
+   * obvious one is setting a parent that is not on the link. The other is
+   * moving an END: re-point `toDevice` at a different switch and a parent
+   * that was valid a moment ago now names a device the link no longer
+   * touches. So the post-update state is what gets checked, assembled from
+   * the payload where it says something and from the stored row where it
+   * does not.
+   *
+   * An update matches a QUERY, not one row, and each matched row may have
+   * different ends — so every one of them is validated, and one bad row
+   * rejects the whole write. That is the conservative direction: a partial
+   * update that fixed some rows and left others contradicting themselves
+   * would be far harder to notice than a refusal.
+   *
+   * It also re-runs onBeforeCreate's TENANCY check on any end that moves.
+   * That check used to exist only on create, which left the update path
+   * able to re-point an end at another project's device — the exact threat
+   * onBeforeCreate's own comment describes, since the FK is global and the
+   * column is member-writable.
+   *
+   * Only costs a read when the payload touches an end or the parent at all;
+   * an update of ports or the bound monitor takes the early return.
+   */
+  @CaptureSpan()
+  protected override async onBeforeUpdate(
+    updateBy: UpdateBy<Model>,
+  ): Promise<OnUpdate<Model>> {
+    const data: Record<string, unknown> = (updateBy.data ||
+      {}) as unknown as Record<string, unknown>;
+
+    const hierarchyKeys: Array<string> = [
+      ...FROM_DEVICE_KEYS,
+      ...TO_DEVICE_KEYS,
+      ...PARENT_DEVICE_KEYS,
+    ];
+
+    if (writtenKeys(data, hierarchyKeys).length === 0) {
+      return { updateBy, carryForward: null };
+    }
+
+    assertNoSqlExpression(data, hierarchyKeys);
+
+    const writtenFromDeviceId: ObjectID | null = RelationIdUtil.read(
+      data,
+      FROM_DEVICE_KEYS,
+    );
+    const writtenToDeviceId: ObjectID | null = RelationIdUtil.read(
+      data,
+      TO_DEVICE_KEYS,
+    );
+    const writtenParentDeviceId: ObjectID | null = RelationIdUtil.read(
+      data,
+      PARENT_DEVICE_KEYS,
+    );
+
+    /*
+     * Writing the parent key with an empty value is how a hierarchy is
+     * cleared back to a peer link. RelationIdUtil reads that as null, which
+     * is indistinguishable from "not written" — so the presence of the key
+     * (with a value that will actually be written; see writtenKeys), not
+     * the truthiness of its value, is what decides whether the stored
+     * parent still applies.
+     */
+    const isParentWritten: boolean =
+      writtenKeys(data, PARENT_DEVICE_KEYS).length > 0;
+
+    const existingLinks: Array<Model> = await this.findBy({
+      query: this.scopeQueryToCallerTenant(updateBy.query, updateBy.props),
+      select: {
+        _id: true,
+        projectId: true,
+        fromDeviceId: true,
+        toDeviceId: true,
+        parentDeviceId: true,
+      },
+      limit: LIMIT_MAX,
+      skip: 0,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    /*
+     * An end that MOVED has to be re-checked for tenancy, exactly as
+     * onBeforeCreate checks it. The FK only requires the device row to
+     * exist — it is global — so without this a project member could
+     * re-point an end of their own link at another project's device and
+     * read its name straight off the map, which is the threat
+     * onBeforeCreate's own comment describes. The declared parent inherits
+     * the check for free: it has to be one of the two ends.
+     *
+     * Grouped by project because an update may in principle match links in
+     * more than one, and a device is only legitimate within its own.
+     */
+    /*
+     * Deduped: writing the same id to both ends is a self-link, and that
+     * has its own error below — it must not surface as "device not found".
+     */
+    const movedEndIds: Array<string> = [
+      ...new Set<string>(
+        [writtenFromDeviceId, writtenToDeviceId]
+          .filter((id: ObjectID | null): id is ObjectID => {
+            return Boolean(id);
+          })
+          .map((id: ObjectID) => {
+            return id.toString();
+          }),
+      ),
+    ];
+
+    if (movedEndIds.length > 0 && existingLinks.length > 0) {
+      /*
+       * Every project this write touches: the caller's own tenant, plus
+       * the project of each row the query matched (a root caller has no
+       * tenant, and only root can match rows across more than one). The
+       * new end has to be legitimate in all of them.
+       *
+       * Guarded on there being matched rows at all: a query that matched
+       * nothing writes nothing, and there is no link for a foreign device
+       * to end up attached to.
+       */
+      const projectIds: Set<string> = new Set<string>();
+      if (updateBy.props.tenantId) {
+        projectIds.add(updateBy.props.tenantId.toString());
+      }
+      for (const link of existingLinks) {
+        if (link.projectId) {
+          projectIds.add(link.projectId.toString());
+        }
+      }
+
+      /*
+       * Fail closed. No project to check against and an end on the move
+       * is not a safe update to wave through — it is the one shape where
+       * a device from anywhere could be attached to this link.
+       */
+      if (projectIds.size === 0) {
+        throw new BadDataException(
+          "Both devices must exist and belong to this project.",
+        );
+      }
+
+      for (const projectId of projectIds) {
+        const devices: Array<NetworkDevice> = await NetworkDeviceService.findBy(
+          {
+            query: {
+              _id: QueryHelper.any(movedEndIds),
+              projectId: new ObjectID(projectId),
+            },
+            select: { _id: true },
+            limit: LIMIT_MAX,
+            skip: 0,
+            props: { isRoot: true },
+          },
+        );
+
+        /*
+         * Compared as a SET of ids rather than as a count. A count says
+         * "as many rows came back as I asked about", which a duplicate row
+         * satisfies just as well as the right rows do — and this is the
+         * check standing between one project's map and another project's
+         * device names, so it should be answering the actual question.
+         */
+        const foundIds: Set<string> = new Set<string>(
+          devices.map((device: NetworkDevice) => {
+            return (device.id || device._id || "").toString().toLowerCase();
+          }),
+        );
+
+        const isMissingAnEnd: boolean = movedEndIds.some((id: string) => {
+          return !foundIds.has(id.toLowerCase());
+        });
+
+        if (isMissingAnEnd) {
+          throw new BadDataException(
+            "Both devices must exist and belong to this project.",
+          );
+        }
+      }
+    }
+
+    for (const link of existingLinks) {
+      const fromDeviceId: ObjectID | undefined =
+        writtenFromDeviceId || link.fromDeviceId;
+      const toDeviceId: ObjectID | undefined =
+        writtenToDeviceId || link.toDeviceId;
+      const parentDeviceId: ObjectID | null = isParentWritten
+        ? writtenParentDeviceId
+        : link.parentDeviceId || null;
+
+      // A row mid-migration with a missing end has no invariant to check.
+      if (!fromDeviceId || !toDeviceId) {
+        continue;
+      }
+
+      if (sameDeviceId(fromDeviceId, toDeviceId)) {
+        throw new BadDataException("A device cannot be linked to itself.");
+      }
+
+      assertParentIsAnEnd(parentDeviceId, fromDeviceId, toDeviceId);
+    }
+
+    return { updateBy, carryForward: null };
   }
 }
 

--- a/Common/Tests/Server/Infrastructure/Postgres/DeviceRoleAndDeclaredLinkParentMigration.test.ts
+++ b/Common/Tests/Server/Infrastructure/Postgres/DeviceRoleAndDeclaredLinkParentMigration.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import SchemaMigrations from "../../../../Server/Infrastructure/Postgres/SchemaMigrations/Index";
+import { AddDeviceRoleAndDeclaredLinkParent1787400000000 } from "../../../../Server/Infrastructure/Postgres/SchemaMigrations/1787400000000-AddDeviceRoleAndDeclaredLinkParent";
+
+/*
+ * The migration behind #3192: NetworkDevice.deviceRole and
+ * NetworkDeviceLink.parentDeviceId.
+ *
+ * Two things are worth pinning about it, and neither is the SQL — the
+ * statements were generated rather than written, and the schema-drift job
+ * already proves they match the entities.
+ *
+ * The first is NULLABILITY, because it carries meaning here rather than
+ * just permissiveness. NULL is not "unset pending a backfill": on
+ * deviceRole it means "no override, let the classifier decide", and on
+ * parentDeviceId it means "peers, infer the direction". They are the
+ * values every existing row should hold, and a DEFAULT or a NOT NULL on
+ * either would silently restate every device and every link in every
+ * project as something an operator had chosen.
+ *
+ * The second is ORDERING. This is the newest registered migration, so it
+ * inherits the guard that used to live in
+ * EpisodeMemberNotifyIndexesMigration.test.ts: its timestamp must sort
+ * above every other. A migration generated with `generate-postgres-
+ * migration` carries a WALL-CLOCK timestamp, and the recent migrations in
+ * this repo use hand-picked round numbers that run ahead of it — so the
+ * generated file lands below several already-registered migrations unless
+ * somebody renumbers it. That is exactly what happened to this one.
+ * Whoever adds the next migration should move this test's ordering block
+ * to theirs.
+ */
+
+const MIGRATION_PATH: string = path.join(
+  __dirname,
+  "../../../../Server/Infrastructure/Postgres/SchemaMigrations/1787400000000-AddDeviceRoleAndDeclaredLinkParent.ts",
+);
+
+const SOURCE: string = fs.readFileSync(MIGRATION_PATH, "utf8");
+
+interface MigrationClass {
+  name: string;
+}
+
+function timestampOf(migrationClass: MigrationClass): number | null {
+  const match: RegExpMatchArray | null = migrationClass.name.match(/(\d+)$/);
+  return match ? Number(match[1]) : null;
+}
+
+describe("the columns it adds", () => {
+  test("NetworkDevice gains deviceRole", () => {
+    expect(SOURCE).toContain(
+      `ALTER TABLE "NetworkDevice" ADD "deviceRole" character varying(100)`,
+    );
+  });
+
+  test("NetworkDeviceLink gains parentDeviceId", () => {
+    expect(SOURCE).toContain(
+      `ALTER TABLE "NetworkDeviceLink" ADD "parentDeviceId" uuid`,
+    );
+  });
+
+  /*
+   * See the header: NULL is a meaningful value on both, so neither may
+   * arrive with a DEFAULT or a NOT NULL.
+   */
+  test("neither column is given a default", () => {
+    const addStatements: Array<string> = [
+      ...SOURCE.matchAll(/`(ALTER TABLE [^`]*ADD "[^"]+"[^`]*)`/g),
+    ].map((match: RegExpMatchArray): string => {
+      return match[1] as string;
+    });
+
+    expect(addStatements.length).toBe(2);
+    for (const statement of addStatements) {
+      expect(statement).not.toContain("DEFAULT");
+      expect(statement).not.toContain("NOT NULL");
+    }
+  });
+
+  test("the parent is indexed and cascades with the device it names", () => {
+    expect(SOURCE).toContain(
+      `CREATE INDEX "IDX_01752cd47b773df38b4a54ae53" ON "NetworkDeviceLink" ("parentDeviceId")`,
+    );
+    expect(SOURCE).toContain(
+      `FOREIGN KEY ("parentDeviceId") REFERENCES "NetworkDevice"("_id") ON DELETE CASCADE`,
+    );
+  });
+
+  /*
+   * The parent is always one of the link's own two ends, and both of those
+   * already cascade — so this cascade only ever fires alongside one of
+   * them. Anything weaker would leave a link pointing at a deleted device.
+   */
+  test("it touches nothing beyond those two tables", () => {
+    const touchedTables: Set<string> = new Set<string>(
+      [...SOURCE.matchAll(/ALTER TABLE "(\w+)"/g)].map(
+        (match: RegExpMatchArray): string => {
+          return match[1] as string;
+        },
+      ),
+    );
+
+    expect([...touchedTables].sort()).toEqual([
+      "NetworkDevice",
+      "NetworkDeviceLink",
+    ]);
+  });
+});
+
+describe("up and down are symmetric", () => {
+  test("down drops everything up adds, and nothing else", () => {
+    const added: Array<string> = [...SOURCE.matchAll(/ADD "(\w+)"/g)].map(
+      (match: RegExpMatchArray): string => {
+        return match[1] as string;
+      },
+    );
+    const dropped: Array<string> = [
+      ...SOURCE.matchAll(/DROP COLUMN "(\w+)"/g),
+    ].map((match: RegExpMatchArray): string => {
+      return match[1] as string;
+    });
+
+    expect(added.sort()).toEqual(dropped.sort());
+  });
+
+  test("the index and the constraint are dropped too", () => {
+    expect(SOURCE).toContain(
+      `DROP INDEX "public"."IDX_01752cd47b773df38b4a54ae53"`,
+    );
+    expect(SOURCE).toContain(
+      `DROP CONSTRAINT "FK_01752cd47b773df38b4a54ae539"`,
+    );
+  });
+
+  /*
+   * A stray semicolon would split one queryRunner.query() into two.
+   *
+   * Trailing whitespace is tolerated on purpose: TypeORM's generator ends
+   * a CREATE INDEX with no WHERE clause in a single space, and this file
+   * is generated. Normalising it here would mean the checked-in SQL no
+   * longer matched what `npm run generate-postgres-migration` produces,
+   * and the next person to regenerate would see a spurious diff. Newlines
+   * are a different matter — one inside a statement means the template
+   * literal wrapped, and that is worth catching.
+   */
+  test("every statement is a complete, single statement", () => {
+    for (const statement of [
+      ...SOURCE.matchAll(/`((?:ALTER TABLE|CREATE INDEX|DROP INDEX)[^`]+)`/g),
+    ]) {
+      expect(statement[1]).not.toContain(";");
+      expect(statement[1]).not.toContain("\n");
+      expect(statement[1]!.trimStart()).toBe(statement[1]);
+    }
+  });
+});
+
+describe("the migration runs", () => {
+  test("it is registered", () => {
+    const index: string = fs.readFileSync(
+      path.join(path.dirname(MIGRATION_PATH), "Index.ts"),
+      "utf8",
+    );
+
+    expect(index).toContain(
+      'from "./1787400000000-AddDeviceRoleAndDeclaredLinkParent"',
+    );
+    expect(index).toContain("AddDeviceRoleAndDeclaredLinkParent1787400000000,");
+  });
+
+  /*
+   * ...and registered for real, not just mentioned in the file: an import
+   * that never reaches the default-export array leaves the migration
+   * unregistered, and it silently never runs.
+   */
+  test("it is in the exported migration list", () => {
+    expect(SchemaMigrations).toContain(
+      AddDeviceRoleAndDeclaredLinkParent1787400000000,
+    );
+  });
+
+  /*
+   * TypeORM records applied migrations by the `name` property, not the file
+   * name. A mismatch re-runs the migration on every boot.
+   */
+  test("its declared name matches its class name", () => {
+    expect(new AddDeviceRoleAndDeclaredLinkParent1787400000000().name).toBe(
+      "AddDeviceRoleAndDeclaredLinkParent1787400000000",
+    );
+  });
+
+  // The guard described in the header. Hand it to the next migration.
+  test("its timestamp sorts after every other registered migration", () => {
+    const ourTimestamp: number | null = timestampOf(
+      AddDeviceRoleAndDeclaredLinkParent1787400000000,
+    );
+
+    expect(ourTimestamp).not.toBeNull();
+
+    const otherTimestamps: Array<number> = [];
+
+    for (const migrationClass of SchemaMigrations) {
+      if (migrationClass === AddDeviceRoleAndDeclaredLinkParent1787400000000) {
+        continue;
+      }
+
+      const timestamp: number | null = timestampOf(
+        migrationClass as MigrationClass,
+      );
+
+      if (timestamp !== null) {
+        otherTimestamps.push(timestamp);
+      }
+    }
+
+    /*
+     * Math.max() of an empty list is -Infinity, which every timestamp beats.
+     * Prove the list was actually enumerated before leaning on the maximum.
+     */
+    expect(otherTimestamps.length).toBeGreaterThan(100);
+
+    expect(ourTimestamp).toBeGreaterThan(Math.max(...otherTimestamps));
+  });
+
+  test("it is registered last, matching that timestamp", () => {
+    expect(SchemaMigrations[SchemaMigrations.length - 1]).toBe(
+      AddDeviceRoleAndDeclaredLinkParent1787400000000,
+    );
+  });
+
+  /*
+   * ...and the timestamp in the class name is the one on disk. A class
+   * renamed without renaming its file (or two migrations landing on the
+   * same timestamp) leaves the ordering above asserting something that is
+   * not what actually runs.
+   */
+  test("exactly one file on disk carries its timestamp, and it is this one", () => {
+    const directory: string = path.dirname(MIGRATION_PATH);
+    const matching: Array<string> = fs
+      .readdirSync(directory)
+      .filter((file: string): boolean => {
+        return file.startsWith("1787400000000-");
+      });
+
+    expect(matching).toEqual([
+      "1787400000000-AddDeviceRoleAndDeclaredLinkParent.ts",
+    ]);
+  });
+});

--- a/Common/Tests/Server/Infrastructure/Postgres/EpisodeMemberNotifyIndexesMigration.test.ts
+++ b/Common/Tests/Server/Infrastructure/Postgres/EpisodeMemberNotifyIndexesMigration.test.ts
@@ -444,10 +444,31 @@ describe("the migration runs", () => {
     );
   });
 
-  test("it is appended last, matching its timestamp", () => {
-    expect(SchemaMigrations[SchemaMigrations.length - 1]).toBe(
+  /*
+   * Registered in timestamp order relative to whatever follows it.
+   *
+   * This asserted "it is last in the array" until a second migration was
+   * added behind it, which is a thing that happens to every migration
+   * exactly once and is not what the test was ever about. The invariant
+   * worth holding is the one the "matching its timestamp" half named:
+   * nothing registered AFTER this may carry an earlier timestamp, because
+   * the array is how a reader works out what runs when. A newly generated
+   * migration carries a wall-clock timestamp, which can easily fall below
+   * the hand-picked round numbers the recent ones use — appending it
+   * without renumbering is how the two orders drift apart.
+   */
+  test("nothing registered after it carries an earlier timestamp", () => {
+    const position: number = SchemaMigrations.indexOf(
       AddEpisodeMemberNotifyIndexes1787300000000,
     );
+    expect(position).toBeGreaterThan(-1);
+
+    for (const migration of SchemaMigrations.slice(position + 1)) {
+      const timestamp: number = Number(
+        (migration.name.match(/(\d+)$/) || [])[1],
+      );
+      expect(timestamp).toBeGreaterThan(1787300000000);
+    }
   });
 
   /*
@@ -461,34 +482,41 @@ describe("the migration runs", () => {
   });
 
   /*
-   * Migrations execute in timestamp order, and TypeORM will not re-order an
-   * already-applied set: a migration added with a timestamp below one that
-   * has already run is simply skipped on every existing deployment, so the
-   * index never appears in production and only ever shows up on fresh
-   * installs. Both sides of the comparison are therefore read off the
-   * registered classes themselves — rename this migration to a lower
-   * timestamp, or land another one above it, and this fails.
+   * Migrations execute in timestamp order, so one landing BELOW a migration
+   * that has already run applies out of order — and on a fresh install runs
+   * in a different order than it did in production, which is how a schema
+   * that passes drift locally still diverges between deployments.
+   *
+   * This used to read "above every OTHER registered migration", i.e. that
+   * this was the newest. That guard belongs to whichever migration is
+   * currently newest — see
+   * DeviceRoleAndDeclaredLinkParentMigration.test.ts, which now carries it
+   * — and it cannot live here, because it fails by design the moment
+   * anything lands above it. What is permanently true of this migration,
+   * and is the half that protects an existing deployment, is that nothing
+   * registered BEFORE it carries a later timestamp.
    */
-  test("its timestamp sorts after every other registered migration", () => {
+  test("its timestamp sorts after every migration registered before it", () => {
     const ourTimestamp: number | null = timestampOf(
       AddEpisodeMemberNotifyIndexes1787300000000,
     );
 
     expect(ourTimestamp).not.toBeNull();
 
-    const otherTimestamps: Array<number> = [];
+    const position: number = SchemaMigrations.indexOf(
+      AddEpisodeMemberNotifyIndexes1787300000000,
+    );
+    expect(position).toBeGreaterThan(-1);
 
-    for (const migrationClass of SchemaMigrations) {
-      if (migrationClass === AddEpisodeMemberNotifyIndexes1787300000000) {
-        continue;
-      }
+    const earlierTimestamps: Array<number> = [];
 
+    for (const migrationClass of SchemaMigrations.slice(0, position)) {
       const timestamp: number | null = timestampOf(
         migrationClass as MigrationClass,
       );
 
       if (timestamp !== null) {
-        otherTimestamps.push(timestamp);
+        earlierTimestamps.push(timestamp);
       }
     }
 
@@ -497,9 +525,9 @@ describe("the migration runs", () => {
      * Prove the list was actually enumerated before leaning on the maximum,
      * or the assertion below is vacuous again.
      */
-    expect(otherTimestamps.length).toBeGreaterThan(100);
+    expect(earlierTimestamps.length).toBeGreaterThan(100);
 
-    expect(ourTimestamp).toBeGreaterThan(Math.max(...otherTimestamps));
+    expect(ourTimestamp).toBeGreaterThan(Math.max(...earlierTimestamps));
   });
 
   /*

--- a/Common/Tests/Server/Services/NetworkDeviceLinkParentValidation.test.ts
+++ b/Common/Tests/Server/Services/NetworkDeviceLinkParentValidation.test.ts
@@ -1,0 +1,1043 @@
+import NetworkDeviceLinkService from "../../../Server/Services/NetworkDeviceLinkService";
+import NetworkDeviceService from "../../../Server/Services/NetworkDeviceService";
+import NetworkDevice from "../../../Models/DatabaseModels/NetworkDevice";
+import NetworkDeviceLink from "../../../Models/DatabaseModels/NetworkDeviceLink";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import CreateBy from "../../../Server/Types/Database/CreateBy";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import { OnCreate, OnUpdate } from "../../../Server/Types/Database/Hooks";
+import { describe, expect, it, afterEach } from "@jest/globals";
+
+/*
+ * Contract under test - the declared-parent invariant on NetworkDeviceLink
+ * (OneUptime/oneuptime#3192):
+ *
+ *   a link's parentDeviceId, when set, must name one of the two devices that
+ *   link connects.
+ *
+ * A parent that is not an end is not a statement about this link at all. The
+ * topology builder ignores it (buildTopology only stamps edge.parentNodeId
+ * when parentDeviceId matches an end), so the operator would declare a
+ * hierarchy, save it successfully, and watch the map not move. Hence both
+ * write paths refuse it up front rather than storing a row that means nothing.
+ *
+ * onBeforeUpdate carries the harder half of the invariant, because an update
+ * can break it from the other side: leave the parent alone and move an END out
+ * from under it. So the post-update state is what gets validated, assembled
+ * from the payload where it speaks and from the stored row where it does not -
+ * for every row the update's query matches, not just one.
+ *
+ * All of it runs against stubbed reads. No database.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+const DEVICE_A_ID: ObjectID = new ObjectID(
+  "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+);
+const DEVICE_B_ID: ObjectID = new ObjectID(
+  "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+);
+// The third wheel: a real device in the project that this link does not touch.
+const DEVICE_C_ID: ObjectID = new ObjectID(
+  "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+);
+const LINK_ID: ObjectID = new ObjectID("11111111-1111-4111-8111-111111111111");
+const OTHER_LINK_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+const PARENT_NOT_AN_END_MESSAGE: string =
+  "The parent device must be one of the two devices this link connects.";
+
+/*
+ * onBeforeCreate reads both ends back to prove they exist and are in the
+ * project. Every create test needs that read to succeed before the parent
+ * check is even reached, so it gets its own helper.
+ */
+function mockBothEndsExist(): jest.SpyInstance {
+  return jest.spyOn(NetworkDeviceService, "findBy").mockResolvedValue([
+    {
+      _id: DEVICE_A_ID.toString(),
+      id: DEVICE_A_ID,
+    } as unknown as NetworkDevice,
+    {
+      _id: DEVICE_B_ID.toString(),
+      id: DEVICE_B_ID,
+    } as unknown as NetworkDevice,
+  ]);
+}
+
+function makeCreateBy(
+  data: Record<string, unknown>,
+): CreateBy<NetworkDeviceLink> {
+  return {
+    data: {
+      projectId: PROJECT_ID,
+      ...data,
+    } as unknown as NetworkDeviceLink,
+    props: { isRoot: true },
+  };
+}
+
+function storedLink(data: {
+  _id?: ObjectID;
+  fromDeviceId?: ObjectID | undefined;
+  toDeviceId?: ObjectID | undefined;
+  parentDeviceId?: ObjectID | undefined;
+}): NetworkDeviceLink {
+  return {
+    _id: (data._id || LINK_ID).toString(),
+    id: data._id || LINK_ID,
+    /*
+     * Carried because moving an end re-checks that the new device belongs
+     * to the link's project, exactly as create does — the FK is global, so
+     * without that check an update could re-point an end at another
+     * project's device and surface its name on this project's map.
+     */
+    projectId: PROJECT_ID,
+    fromDeviceId: data.fromDeviceId,
+    toDeviceId: data.toDeviceId,
+    parentDeviceId: data.parentDeviceId,
+  } as unknown as NetworkDeviceLink;
+}
+
+/*
+ * The device read that the moved-end tenancy check performs. Returns all
+ * three project devices, so any end move is legitimate unless a test
+ * deliberately overrides it — which the tenancy tests do.
+ */
+function mockProjectDevicesExist(): jest.SpyInstance {
+  return jest.spyOn(NetworkDeviceService, "findBy").mockResolvedValue(
+    [DEVICE_A_ID, DEVICE_B_ID, DEVICE_C_ID].map((id: ObjectID) => {
+      return {
+        _id: id.toString(),
+        id: id,
+      } as unknown as NetworkDevice;
+    }),
+  );
+}
+
+function makeUpdateBy(
+  data: Record<string, unknown>,
+): UpdateBy<NetworkDeviceLink> {
+  return {
+    query: { _id: LINK_ID.toString() },
+    data: data,
+    props: { isRoot: true },
+  } as unknown as UpdateBy<NetworkDeviceLink>;
+}
+
+// The stored rows an update is validated against.
+function mockStoredLinks(links: Array<NetworkDeviceLink>): jest.SpyInstance {
+  /*
+   * Installed alongside, so a test about the PARENT invariant is never
+   * incidentally failed by the tenancy check on an end it moved to set
+   * the scene. Tests about tenancy itself re-stub this.
+   */
+  mockProjectDevicesExist();
+  return jest
+    .spyOn(NetworkDeviceLinkService, "findBy")
+    .mockResolvedValue(links);
+}
+
+describe("NetworkDeviceLinkService.onBeforeCreate (declared parent)", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("accepts a parent that is the link's from-device", async () => {
+    mockBothEndsExist();
+
+    const result: OnCreate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeCreate(
+      makeCreateBy({
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+        parentDeviceId: DEVICE_A_ID,
+      }),
+    );
+
+    expect(result.carryForward).toBeNull();
+  });
+
+  it("accepts a parent that is the link's to-device", async () => {
+    mockBothEndsExist();
+
+    const result: OnCreate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeCreate(
+      makeCreateBy({
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+        parentDeviceId: DEVICE_B_ID,
+      }),
+    );
+
+    expect(result.carryForward).toBeNull();
+  });
+
+  /*
+   * The common case, and the one that must stay cheap: most links are peers
+   * (two access switches on the same trunk), and declaring nothing is how an
+   * operator says "these are siblings, let the layout decide".
+   */
+  it("accepts a link with no declared parent at all", async () => {
+    mockBothEndsExist();
+
+    const result: OnCreate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeCreate(
+      makeCreateBy({
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+      }),
+    );
+
+    expect(result.carryForward).toBeNull();
+  });
+
+  it("rejects a parent naming a third device, and says why", async () => {
+    mockBothEndsExist();
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeCreate(
+        makeCreateBy({
+          fromDeviceId: DEVICE_A_ID,
+          toDeviceId: DEVICE_B_ID,
+          parentDeviceId: DEVICE_C_ID,
+        }),
+      ),
+    ).rejects.toThrow(BadDataException);
+
+    /*
+     * The message is the whole user experience of this guard - it is what the
+     * dashboard renders when the save fails - so it has to name the constraint
+     * rather than say "bad data".
+     */
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeCreate(
+        makeCreateBy({
+          fromDeviceId: DEVICE_A_ID,
+          toDeviceId: DEVICE_B_ID,
+          parentDeviceId: DEVICE_C_ID,
+        }),
+      ),
+    ).rejects.toThrow(PARENT_NOT_AN_END_MESSAGE);
+  });
+
+  /*
+   * The dashboard's link form posts the RELATION (`{ parentDevice: { _id } }`),
+   * never the FK column, because DatabaseBaseModel serialises the entity
+   * column it was handed. A guard that read only `parentDeviceId` would wave
+   * every UI-authored declaration straight through.
+   */
+  it("rejects a third-device parent posted as the `parentDevice` relation", async () => {
+    mockBothEndsExist();
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeCreate(
+        makeCreateBy({
+          fromDevice: { _id: DEVICE_A_ID.toString() },
+          toDevice: { _id: DEVICE_B_ID.toString() },
+          parentDevice: { _id: DEVICE_C_ID.toString() },
+        }),
+      ),
+    ).rejects.toThrow(PARENT_NOT_AN_END_MESSAGE);
+  });
+
+  it("accepts a valid parent posted as the `parentDevice` relation", async () => {
+    mockBothEndsExist();
+
+    const result: OnCreate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeCreate(
+      makeCreateBy({
+        fromDevice: { _id: DEVICE_A_ID.toString() },
+        toDevice: { _id: DEVICE_B_ID.toString() },
+        parentDevice: { _id: DEVICE_A_ID.toString() },
+      }),
+    );
+
+    expect(result.carryForward).toBeNull();
+  });
+
+  /*
+   * Determinism: the two spellings are the same statement, so a payload that
+   * mixes them - column for the ends, relation for the parent, or the reverse
+   * - has to land on the same verdict as either pure form.
+   */
+  it("reaches the same verdict whichever spelling each reference uses", async () => {
+    mockBothEndsExist();
+
+    const payloads: Array<Record<string, unknown>> = [
+      {
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+        parentDevice: { _id: DEVICE_C_ID.toString() },
+      },
+      {
+        fromDevice: { _id: DEVICE_A_ID.toString() },
+        toDevice: { _id: DEVICE_B_ID.toString() },
+        parentDeviceId: DEVICE_C_ID,
+      },
+      // Key order reversed: the reader must not depend on insertion order.
+      {
+        parentDeviceId: DEVICE_C_ID,
+        toDeviceId: DEVICE_B_ID,
+        fromDeviceId: DEVICE_A_ID,
+      },
+    ];
+
+    for (const payload of payloads) {
+      await expect(
+        (NetworkDeviceLinkService as any).onBeforeCreate(makeCreateBy(payload)),
+      ).rejects.toThrow(PARENT_NOT_AN_END_MESSAGE);
+    }
+  });
+
+  /*
+   * The parent check sits behind the existing guards on purpose: a link with
+   * one end missing, or both ends the same device, has no "two ends" for a
+   * parent to be one of. Those errors must stay the ones reported.
+   */
+  it("still reports the self-link error before looking at the parent", async () => {
+    mockBothEndsExist();
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeCreate(
+        makeCreateBy({
+          fromDeviceId: DEVICE_A_ID,
+          toDeviceId: DEVICE_A_ID,
+          parentDeviceId: DEVICE_C_ID,
+        }),
+      ),
+    ).rejects.toThrow("A device cannot be linked to itself.");
+  });
+});
+
+describe("NetworkDeviceLinkService.onBeforeUpdate (declared parent)", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /*
+   * The whole reason the hook computes `touchesHierarchy` first. Link rows are
+   * rewritten by every port rename and every monitor rebind; making each of
+   * those pay for a LIMIT_MAX read of the matched rows would be a real cost
+   * for a guard that could not possibly fire.
+   */
+  it("performs no read when the payload touches neither an end nor the parent", async () => {
+    const findBySpy: jest.SpyInstance = jest.spyOn(
+      NetworkDeviceLinkService,
+      "findBy",
+    );
+
+    const result: OnUpdate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeUpdate(
+      makeUpdateBy({
+        fromPort: "Gi1/0/24",
+        description: "patch panel B",
+      }),
+    );
+
+    expect(findBySpy).not.toHaveBeenCalled();
+    expect(result.carryForward).toBeNull();
+  });
+
+  it("rejects setting the parent to a device the stored link does not touch", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeUpdate(
+        makeUpdateBy({ parentDeviceId: DEVICE_C_ID }),
+      ),
+    ).rejects.toThrow(PARENT_NOT_AN_END_MESSAGE);
+  });
+
+  it("accepts setting the parent to one of the stored link's own ends", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+
+    const result: OnUpdate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeUpdate(makeUpdateBy({ parentDeviceId: DEVICE_B_ID }));
+
+    expect(result.carryForward).toBeNull();
+  });
+
+  it("rejects a third-device parent posted as the `parentDevice` relation", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeUpdate(
+        makeUpdateBy({ parentDevice: { _id: DEVICE_C_ID.toString() } }),
+      ),
+    ).rejects.toThrow(PARENT_NOT_AN_END_MESSAGE);
+  });
+
+  /*
+   * The non-obvious half of the invariant. Nobody touched the parent here -
+   * the payload only re-points an end - but A->B with parent A becomes C->B,
+   * and A is suddenly a device this link has never heard of. Checking only the
+   * written parent would let this through and leave a stored row that the
+   * topology builder silently ignores forever.
+   */
+  it("rejects moving an end out from under an already-declared parent", async () => {
+    mockStoredLinks([
+      storedLink({
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+        parentDeviceId: DEVICE_A_ID,
+      }),
+    ]);
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeUpdate(
+        makeUpdateBy({ fromDeviceId: DEVICE_C_ID }),
+      ),
+    ).rejects.toThrow(PARENT_NOT_AN_END_MESSAGE);
+  });
+
+  it("rejects moving an end out from under a parent given as the `fromDevice` relation", async () => {
+    mockStoredLinks([
+      storedLink({
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+        parentDeviceId: DEVICE_A_ID,
+      }),
+    ]);
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeUpdate(
+        makeUpdateBy({ fromDevice: { _id: DEVICE_C_ID.toString() } }),
+      ),
+    ).rejects.toThrow(PARENT_NOT_AN_END_MESSAGE);
+  });
+
+  /*
+   * The other end may move freely as long as the declared parent survives it:
+   * A->B with parent A becomes A->C, and A is still an end. Re-patching a
+   * downlink to a different access switch is routine and must not be blocked.
+   */
+  it("accepts moving the end that is NOT the declared parent", async () => {
+    mockStoredLinks([
+      storedLink({
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+        parentDeviceId: DEVICE_A_ID,
+      }),
+    ]);
+
+    const result: OnUpdate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeUpdate(makeUpdateBy({ toDeviceId: DEVICE_C_ID }));
+
+    expect(result.carryForward).toBeNull();
+  });
+
+  // Moving an end AND re-declaring the parent onto the new end in one write.
+  it("accepts moving an end when the payload re-points the parent at the same time", async () => {
+    mockStoredLinks([
+      storedLink({
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+        parentDeviceId: DEVICE_A_ID,
+      }),
+    ]);
+
+    const result: OnUpdate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeUpdate(
+      makeUpdateBy({
+        fromDeviceId: DEVICE_C_ID,
+        parentDeviceId: DEVICE_C_ID,
+      }),
+    );
+
+    expect(result.carryForward).toBeNull();
+  });
+
+  /*
+   * The isParentWritten branch, which is the subtle one. Demoting a hierarchy
+   * back to a peer link means writing the parent key with an empty value -
+   * and RelationIdUtil reads that as null, exactly like "not written at all".
+   * If the hook decided on the VALUE it would fall back to the stored parent
+   * A, find it absent from the new C->B ends, and refuse the very write that
+   * was removing the offending declaration. The KEY's presence is what
+   * decides.
+   */
+  it("accepts clearing the parent with null even while an end moves away from it", async () => {
+    mockStoredLinks([
+      storedLink({
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+        parentDeviceId: DEVICE_A_ID,
+      }),
+    ]);
+
+    const result: OnUpdate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeUpdate(
+      makeUpdateBy({
+        fromDeviceId: DEVICE_C_ID,
+        parentDeviceId: null,
+      }),
+    );
+
+    expect(result.carryForward).toBeNull();
+  });
+
+  // Same branch, reached through the other empty values the UI can send.
+  it("treats empty-string and a null relation as clearing the parent too", async () => {
+    const emptyValues: Array<Record<string, unknown>> = [
+      { fromDeviceId: DEVICE_C_ID, parentDeviceId: "" },
+      { fromDeviceId: DEVICE_C_ID, parentDevice: null },
+    ];
+
+    for (const data of emptyValues) {
+      mockStoredLinks([
+        storedLink({
+          fromDeviceId: DEVICE_A_ID,
+          toDeviceId: DEVICE_B_ID,
+          parentDeviceId: DEVICE_A_ID,
+        }),
+      ]);
+
+      const result: OnUpdate<NetworkDeviceLink> = await (
+        NetworkDeviceLinkService as any
+      ).onBeforeUpdate(makeUpdateBy(data));
+
+      expect(result.carryForward).toBeNull();
+      jest.restoreAllMocks();
+    }
+  });
+
+  /*
+   * undefined is NOT one of them, and the difference is not pedantry.
+   * TypeORM drops undefined-valued keys before building the SET list, so
+   * such a key writes nothing at all. Reading it as "the parent is being
+   * cleared" makes this hook validate a row that will never exist: it
+   * would wave the write through, and the stored parent would survive on
+   * a link whose end had just moved out from under it — precisely the
+   * state the hook exists to prevent.
+   */
+  it("refuses a moved end when a present-but-undefined parent key would leave the stored parent stranded", async () => {
+    mockStoredLinks([
+      storedLink({
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+        parentDeviceId: DEVICE_A_ID,
+      }),
+    ]);
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeUpdate(
+        makeUpdateBy({
+          fromDeviceId: DEVICE_C_ID,
+          parentDeviceId: undefined,
+        }),
+      ),
+    ).rejects.toThrow(
+      "The parent device must be one of the two devices this link connects.",
+    );
+  });
+
+  // And a payload of nothing BUT undefined writes nothing, so it reads nothing.
+  it("takes the early return when every hierarchy key present holds undefined", async () => {
+    const findBySpy: jest.SpyInstance = mockStoredLinks([]);
+
+    const result: OnUpdate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeUpdate(
+      makeUpdateBy({
+        fromDeviceId: undefined,
+        parentDeviceId: undefined,
+      }),
+    );
+
+    expect(result.carryForward).toBeNull();
+    expect(findBySpy).not.toHaveBeenCalled();
+  });
+
+  /*
+   * Clearing the parent still counts as touching the hierarchy, so it must not
+   * take the early return - the same write can be moving an end, and that end
+   * move is what the read exists to check.
+   */
+  it("still reads the stored rows when the only hierarchy key present clears the parent", async () => {
+    const findBySpy: jest.SpyInstance = mockStoredLinks([
+      storedLink({
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+        parentDeviceId: DEVICE_A_ID,
+      }),
+    ]);
+
+    await (NetworkDeviceLinkService as any).onBeforeUpdate(
+      makeUpdateBy({ parentDeviceId: null }),
+    );
+
+    expect(findBySpy).toHaveBeenCalledTimes(1);
+  });
+
+  /*
+   * An update matches a QUERY. "Set parent = A on every link into rack 3" can
+   * land on rows with completely different ends, and only some of them touch
+   * A. Fixing the ones that fit while leaving the rest self-contradicting
+   * would be far harder to notice than a refusal, so one bad row rejects the
+   * whole write.
+   */
+  it("validates every matched row and rejects the write when any one of them fails", async () => {
+    mockStoredLinks([
+      storedLink({
+        _id: LINK_ID,
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+      }),
+      storedLink({
+        _id: OTHER_LINK_ID,
+        fromDeviceId: DEVICE_B_ID,
+        toDeviceId: DEVICE_C_ID,
+      }),
+    ]);
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeUpdate(
+        makeUpdateBy({ parentDeviceId: DEVICE_A_ID }),
+      ),
+    ).rejects.toThrow(PARENT_NOT_AN_END_MESSAGE);
+  });
+
+  /*
+   * Determinism: the read has no ORDER BY, so which row Postgres hands back
+   * first is not something the caller controls. The verdict must not depend on
+   * it - a rejection has to be a rejection with the bad row first or last.
+   */
+  it("rejects the same multi-row write regardless of the order the rows come back", async () => {
+    const goodRow: NetworkDeviceLink = storedLink({
+      _id: LINK_ID,
+      fromDeviceId: DEVICE_A_ID,
+      toDeviceId: DEVICE_B_ID,
+    });
+    const badRow: NetworkDeviceLink = storedLink({
+      _id: OTHER_LINK_ID,
+      fromDeviceId: DEVICE_B_ID,
+      toDeviceId: DEVICE_C_ID,
+    });
+
+    for (const rows of [
+      [goodRow, badRow],
+      [badRow, goodRow],
+    ]) {
+      mockStoredLinks(rows);
+
+      await expect(
+        (NetworkDeviceLinkService as any).onBeforeUpdate(
+          makeUpdateBy({ parentDeviceId: DEVICE_A_ID }),
+        ),
+      ).rejects.toThrow(PARENT_NOT_AN_END_MESSAGE);
+
+      jest.restoreAllMocks();
+    }
+  });
+
+  it("accepts a multi-row write when the parent is an end of every matched row", async () => {
+    mockStoredLinks([
+      storedLink({
+        _id: LINK_ID,
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+      }),
+      storedLink({
+        _id: OTHER_LINK_ID,
+        fromDeviceId: DEVICE_C_ID,
+        toDeviceId: DEVICE_A_ID,
+      }),
+    ]);
+
+    const result: OnUpdate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeUpdate(makeUpdateBy({ parentDeviceId: DEVICE_A_ID }));
+
+    expect(result.carryForward).toBeNull();
+  });
+
+  /*
+   * The self-link guard has to hold on the update path too: a link the map
+   * would drop as a self-edge is invisible and permanently confusing, whether
+   * it was created that way or edited into that shape.
+   */
+  it("rejects an update that would point both ends at the same device", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeUpdate(
+        makeUpdateBy({ toDeviceId: DEVICE_A_ID }),
+      ),
+    ).rejects.toThrow("A device cannot be linked to itself.");
+  });
+
+  it("rejects an update that points both written ends at the same device", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeUpdate(
+        makeUpdateBy({
+          fromDeviceId: DEVICE_C_ID,
+          toDeviceId: DEVICE_C_ID,
+        }),
+      ),
+    ).rejects.toThrow("A device cannot be linked to itself.");
+  });
+
+  /*
+   * A row mid-migration - written before both ends were mandatory - has no two
+   * ends for a parent to be one of, so there is no invariant to check and the
+   * hook must not invent one and block unrelated writes.
+   */
+  it("skips a stored row that is missing an end rather than failing the write", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: undefined }),
+    ]);
+
+    const result: OnUpdate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeUpdate(makeUpdateBy({ parentDeviceId: DEVICE_C_ID }));
+
+    expect(result.carryForward).toBeNull();
+  });
+
+  // Nothing matched, nothing to contradict.
+  it("accepts a write whose query matched no rows", async () => {
+    mockStoredLinks([]);
+
+    const result: OnUpdate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeUpdate(makeUpdateBy({ parentDeviceId: DEVICE_C_ID }));
+
+    expect(result.carryForward).toBeNull();
+  });
+
+  /*
+   * Determinism again, on the payload side: the hook reads keys by name, so
+   * shuffling them (as any JSON body may arrive shuffled) must not move the
+   * verdict.
+   */
+  it("reaches the same verdict whatever order the payload keys arrive in", async () => {
+    const shuffles: Array<Record<string, unknown>> = [
+      { fromDeviceId: DEVICE_C_ID, parentDeviceId: DEVICE_B_ID },
+      { parentDeviceId: DEVICE_B_ID, fromDeviceId: DEVICE_C_ID },
+    ];
+
+    for (const data of shuffles) {
+      mockStoredLinks([
+        storedLink({
+          fromDeviceId: DEVICE_A_ID,
+          toDeviceId: DEVICE_B_ID,
+          parentDeviceId: DEVICE_A_ID,
+        }),
+      ]);
+
+      const result: OnUpdate<NetworkDeviceLink> = await (
+        NetworkDeviceLinkService as any
+      ).onBeforeUpdate(makeUpdateBy(data));
+
+      expect(result.carryForward).toBeNull();
+      jest.restoreAllMocks();
+    }
+  });
+
+  /*
+   * The hook validates; it does not rewrite. Anything it silently normalised
+   * into updateBy.data would be written to the row without the caller ever
+   * having asked for it.
+   */
+  it("passes the caller's payload through untouched when the write is accepted", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+
+    const updateBy: UpdateBy<NetworkDeviceLink> = makeUpdateBy({
+      parentDeviceId: DEVICE_A_ID,
+    });
+
+    const result: OnUpdate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeUpdate(updateBy);
+
+    expect(result.updateBy).toBe(updateBy);
+    expect(
+      Object.keys(result.updateBy.data as unknown as Record<string, unknown>),
+    ).toEqual(["parentDeviceId"]);
+  });
+
+  /*
+   * The read runs as root so it can see the rows the caller is about to write,
+   * which means the caller's tenant has to be re-applied by hand - otherwise
+   * a project could be handed another project's links to validate against.
+   */
+  it("scopes the validation read to the caller's project", async () => {
+    const findBySpy: jest.SpyInstance = mockStoredLinks([]);
+
+    await (NetworkDeviceLinkService as any).onBeforeUpdate({
+      query: { _id: LINK_ID.toString() },
+      data: { parentDeviceId: DEVICE_A_ID },
+      props: { tenantId: PROJECT_ID },
+    } as unknown as UpdateBy<NetworkDeviceLink>);
+
+    const query: any = findBySpy.mock.calls[0]![0].query;
+    expect(query._id).toBe(LINK_ID.toString());
+    expect(query.projectId.toString()).toBe(PROJECT_ID.toString());
+    expect(findBySpy.mock.calls[0]![0].props.isRoot).toBe(true);
+  });
+
+  // The stored parent can only be honoured if the read actually fetches it.
+  it("selects the ends and the stored parent the check compares", async () => {
+    const findBySpy: jest.SpyInstance = mockStoredLinks([]);
+
+    await (NetworkDeviceLinkService as any).onBeforeUpdate(
+      makeUpdateBy({ fromDeviceId: DEVICE_C_ID }),
+    );
+
+    const select: any = findBySpy.mock.calls[0]![0].select;
+    expect(select.fromDeviceId).toBe(true);
+    expect(select.toDeviceId).toBe(true);
+    expect(select.parentDeviceId).toBe(true);
+  });
+});
+
+/*
+ * The tenancy half of the invariant.
+ *
+ * onBeforeCreate has always refused an end outside the caller's project,
+ * and says why in its own comment: the FK only requires the device row to
+ * exist, so without the check a tenant could draw a line to another
+ * project's device and read its name off the map. Updates never re-ran it,
+ * which left the guard one PUT away from being bypassed - and the declared
+ * parent would have inherited the hole, since a parent is only allowed to
+ * be an end.
+ */
+describe("NetworkDeviceLinkService.onBeforeUpdate (moved ends stay in the project)", () => {
+  const FOREIGN_DEVICE_ID: ObjectID = new ObjectID(
+    "ffffffff-ffff-4fff-8fff-ffffffffffff",
+  );
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("refuses an end moved to a device outside the link's project", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+    // The project read finds nothing: that device is not in this project.
+    jest.spyOn(NetworkDeviceService, "findBy").mockResolvedValue([]);
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeUpdate(
+        makeUpdateBy({ toDeviceId: FOREIGN_DEVICE_ID }),
+      ),
+    ).rejects.toThrow("Both devices must exist and belong to this project.");
+  });
+
+  it("refuses the same move made through the relation spelling", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+    jest.spyOn(NetworkDeviceService, "findBy").mockResolvedValue([]);
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeUpdate(
+        makeUpdateBy({ toDevice: { _id: FOREIGN_DEVICE_ID.toString() } }),
+      ),
+    ).rejects.toThrow("Both devices must exist and belong to this project.");
+  });
+
+  it("scopes the device read to the link's own project", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+    const deviceFindBy: jest.SpyInstance = mockProjectDevicesExist();
+
+    await (NetworkDeviceLinkService as any).onBeforeUpdate(
+      makeUpdateBy({ toDeviceId: DEVICE_C_ID }),
+    );
+
+    expect(deviceFindBy).toHaveBeenCalled();
+    const query: any = deviceFindBy.mock.calls[0]![0].query;
+    expect(query.projectId.toString()).toBe(PROJECT_ID.toString());
+  });
+
+  it("accepts an end moved to another device in the same project", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+
+    const result: OnUpdate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeUpdate(makeUpdateBy({ toDeviceId: DEVICE_C_ID }));
+
+    expect(result.carryForward).toBeNull();
+  });
+
+  /*
+   * A count would be satisfied by two rows for one device. The check
+   * compares the ids it asked about against the ids it got back.
+   */
+  it("is not fooled by a duplicate row standing in for a missing device", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+    jest.spyOn(NetworkDeviceService, "findBy").mockResolvedValue([
+      {
+        _id: DEVICE_C_ID.toString(),
+        id: DEVICE_C_ID,
+      } as unknown as NetworkDevice,
+      {
+        _id: DEVICE_C_ID.toString(),
+        id: DEVICE_C_ID,
+      } as unknown as NetworkDevice,
+    ]);
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeUpdate(
+        makeUpdateBy({
+          fromDeviceId: DEVICE_C_ID,
+          toDeviceId: FOREIGN_DEVICE_ID,
+        }),
+      ),
+    ).rejects.toThrow("Both devices must exist and belong to this project.");
+  });
+
+  // No end moved, so there is nothing to re-check and nothing to read.
+  it("does not read devices when only the parent is written", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+    const deviceFindBy: jest.SpyInstance = mockProjectDevicesExist();
+
+    await (NetworkDeviceLinkService as any).onBeforeUpdate(
+      makeUpdateBy({ parentDeviceId: DEVICE_A_ID }),
+    );
+
+    expect(deviceFindBy).not.toHaveBeenCalled();
+  });
+});
+
+/*
+ * Two shapes an id can arrive in that a naive comparison gets wrong.
+ */
+describe("NetworkDeviceLinkService - how ids are compared", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /*
+   * These columns are Postgres `uuid`, where equality ignores case, and
+   * ObjectID.isValidUUID accepts either case - so a client may legitimately
+   * send an upper-case id for a row stored lower-case. A raw JS !== calls
+   * that a different device and refuses a parent that IS an end. Note the
+   * device-existence check could never disagree: it runs in Postgres.
+   */
+  it("accepts a parent that names an end in a different case", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+
+    const result: OnUpdate<NetworkDeviceLink> = await (
+      NetworkDeviceLinkService as any
+    ).onBeforeUpdate(
+      makeUpdateBy({
+        parentDeviceId: new ObjectID(DEVICE_A_ID.toString().toUpperCase()),
+      }),
+    );
+
+    expect(result.carryForward).toBeNull();
+  });
+
+  it("still catches a self-link written in mixed case", async () => {
+    mockBothEndsExist();
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeCreate(
+        makeCreateBy({
+          fromDeviceId: DEVICE_A_ID,
+          toDeviceId: new ObjectID(DEVICE_A_ID.toString().toUpperCase()),
+        }),
+      ),
+    ).rejects.toThrow("A device cannot be linked to itself.");
+  });
+
+  /*
+   * UpdateBy.data is a QueryDeepPartialEntity, so a column may legally hold
+   * a raw SQL-expression function. RelationIdUtil reads one as null -
+   * indistinguishable from "cleared" - and the invariant would then be
+   * checked against a row bearing no relation to what gets written. Nothing
+   * writes this model that way today; refusing is what keeps that true.
+   */
+  it("refuses an end set to a raw SQL expression rather than mis-validating it", async () => {
+    mockStoredLinks([
+      storedLink({
+        fromDeviceId: DEVICE_A_ID,
+        toDeviceId: DEVICE_B_ID,
+        parentDeviceId: DEVICE_B_ID,
+      }),
+    ]);
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeUpdate(
+        makeUpdateBy({
+          toDeviceId: (): string => {
+            return `'${DEVICE_C_ID.toString()}'`;
+          },
+        }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("refuses a parent set to a raw SQL expression", async () => {
+    mockStoredLinks([
+      storedLink({ fromDeviceId: DEVICE_A_ID, toDeviceId: DEVICE_B_ID }),
+    ]);
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeUpdate(
+        makeUpdateBy({
+          parentDeviceId: (): string => {
+            return `'${DEVICE_C_ID.toString()}'`;
+          },
+        }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+
+  it("refuses the same on create", async () => {
+    mockBothEndsExist();
+
+    await expect(
+      (NetworkDeviceLinkService as any).onBeforeCreate(
+        makeCreateBy({
+          fromDeviceId: DEVICE_A_ID,
+          toDeviceId: DEVICE_B_ID,
+          parentDeviceId: (): string => {
+            return `'${DEVICE_C_ID.toString()}'`;
+          },
+        }),
+      ),
+    ).rejects.toThrow(BadDataException);
+  });
+});

--- a/Common/Tests/Utils/Monitor/NetworkDeviceRoleUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/NetworkDeviceRoleUtil.test.ts
@@ -3,9 +3,12 @@ import { NetworkTopologyDeviceRole } from "../../../Types/Monitor/SnmpMonitor/Ne
 import {
   DEVICE_ROLES_IN_LEGEND_ORDER,
   DEVICE_ROLE_LABELS,
+  DeviceRoleSignals,
   classifyDeviceRole,
   classifyEndpointRole,
   labelForDeviceRole,
+  parseDeviceRoleOverride,
+  resolveDeviceRole,
 } from "../../../Utils/Monitor/NetworkDeviceRoleUtil";
 
 /*
@@ -510,5 +513,504 @@ describe("labels", () => {
     expect(DEVICE_ROLES_IN_LEGEND_ORDER.length).toBe(
       Object.keys(DEVICE_ROLE_LABELS).length - 1,
     );
+  });
+});
+
+/*
+ * The operator's override (NetworkDevice.deviceRole), from issue #3192.
+ *
+ * The classifier above only ever sees SNMP, so a device that answers
+ * nothing but ping is unclassifiable forever — it is drawn "unknown" and
+ * no amount of re-polling changes that. The override is the operator
+ * saying what the box IS, which is the only statement about a role in the
+ * system that is not an inference, so it has to beat every tier of
+ * evidence. Everything below is about the two halves of that promise:
+ * parseDeviceRoleOverride deciding whether a stored string is a
+ * declaration at all, and resolveDeviceRole deciding who wins when it is.
+ */
+
+/*
+ * A real switch, described by every tier at once: named product family in
+ * the model, the vendor's boilerplate in sysDescr, Cisco's arc in the OID,
+ * and a hostname that follows the convention. Nothing about this device is
+ * ambiguous, which is exactly why it is the right device to point an
+ * override at — if the override wins here it wins anywhere.
+ */
+const CATALYST_SWITCH_SIGNALS: DeviceRoleSignals = {
+  vendor: "Cisco Systems",
+  deviceModel: "WS-C2960X-48FPD-L",
+  sysDescr: "Cisco IOS Software, C2960X Software, Catalyst 2960X switch",
+  sysObjectId: "1.3.6.1.4.1.9.1.1745",
+  sysName: "idf2-sw-3",
+  name: "idf2-sw-3",
+};
+
+describe("parseDeviceRoleOverride — the values it accepts", () => {
+  test("every role a legend can show round-trips through the column", () => {
+    /*
+     * The column is what the picker writes and what the topology builder
+     * reads back, so the set it accepts has to be exactly the set the UI
+     * offers. Looping the legend rather than listing the roles means a new
+     * role cannot be added to the type without this test covering it.
+     */
+    for (const role of DEVICE_ROLES_IN_LEGEND_ORDER) {
+      const parsed: NetworkTopologyDeviceRole | undefined =
+        parseDeviceRoleOverride(role);
+      expect(parsed).toBe(role);
+    }
+  });
+
+  test("matching ignores the case the value was stored in", () => {
+    /*
+     * Values arrive from a form, an API caller and a seed script, and none
+     * of them agree about casing.
+     */
+    expect(parseDeviceRoleOverride("switch")).toBe("switch");
+    expect(parseDeviceRoleOverride("SWITCH")).toBe("switch");
+    expect(parseDeviceRoleOverride("Switch")).toBe("switch");
+    expect(parseDeviceRoleOverride("sWiTcH")).toBe("switch");
+  });
+
+  test("the camelCase roles survive every casing, which a one-sided compare would break", () => {
+    /*
+     * wirelessAccessPoint and loadBalancer are the only two role keys with
+     * an internal capital, so they are the two a naive
+     * `role === value.toLowerCase()` would silently drop — the stored value
+     * would look valid, parse to undefined, and the classifier would
+     * quietly overrule the operator. Both sides have to be lowercased.
+     */
+    expect(parseDeviceRoleOverride("wirelessAccessPoint")).toBe(
+      "wirelessAccessPoint",
+    );
+    expect(parseDeviceRoleOverride("wirelessaccesspoint")).toBe(
+      "wirelessAccessPoint",
+    );
+    expect(parseDeviceRoleOverride("WIRELESSACCESSPOINT")).toBe(
+      "wirelessAccessPoint",
+    );
+    expect(parseDeviceRoleOverride("WirelessAccessPoint")).toBe(
+      "wirelessAccessPoint",
+    );
+
+    expect(parseDeviceRoleOverride("loadBalancer")).toBe("loadBalancer");
+    expect(parseDeviceRoleOverride("loadbalancer")).toBe("loadBalancer");
+    expect(parseDeviceRoleOverride("LOADBALANCER")).toBe("loadBalancer");
+    expect(parseDeviceRoleOverride("LoadBalancer")).toBe("loadBalancer");
+  });
+
+  test("surrounding whitespace is trimmed off before matching", () => {
+    // Copy-paste into a text field is the normal way a stray space arrives.
+    expect(parseDeviceRoleOverride(" router ")).toBe("router");
+    expect(parseDeviceRoleOverride("\tswitch")).toBe("switch");
+    expect(parseDeviceRoleOverride("firewall\n")).toBe("firewall");
+    expect(parseDeviceRoleOverride("   loadBalancer   ")).toBe("loadBalancer");
+    expect(parseDeviceRoleOverride("\n  wirelessaccesspoint \t ")).toBe(
+      "wirelessAccessPoint",
+    );
+  });
+});
+
+describe("parseDeviceRoleOverride — the values it refuses", () => {
+  test("absent, empty and blank all mean no override rather than a role", () => {
+    /*
+     * Undefined is the answer that lets the classifier run, so every way of
+     * saying "the operator never filled this in" — a null column, an empty
+     * string from a cleared form, a field containing only spaces — has to
+     * land on it.
+     */
+    expect(parseDeviceRoleOverride(undefined)).toBeUndefined();
+    expect(parseDeviceRoleOverride(null)).toBeUndefined();
+    expect(parseDeviceRoleOverride("")).toBeUndefined();
+    expect(parseDeviceRoleOverride("   ")).toBeUndefined();
+    expect(parseDeviceRoleOverride("\t\n  ")).toBeUndefined();
+  });
+
+  test('"unknown" is deliberately refused even though it is a real role', () => {
+    /*
+     * This is the one refusal that is a design decision rather than a
+     * validation failure. Empty already means "classify it", so storing
+     * "unknown" could only mean the different and much less useful thing:
+     * pin this device to the neutral shape and switch the classifier off
+     * for good. An operator who does not know what a box is wants the
+     * classifier to keep trying, not to be silenced — so "unknown" is not
+     * in DEVICE_ROLES_IN_LEGEND_ORDER and parses as no override at all.
+     */
+    expect(parseDeviceRoleOverride("unknown")).toBeUndefined();
+    expect(parseDeviceRoleOverride("Unknown")).toBeUndefined();
+    expect(parseDeviceRoleOverride("UNKNOWN")).toBeUndefined();
+    expect(parseDeviceRoleOverride("  unknown  ")).toBeUndefined();
+  });
+
+  test("unrecognised text is refused rather than partially matched", () => {
+    /*
+     * The match is whole-string equality on purpose: a prefix or substring
+     * rule would let "rout" or "router-ish" mean router, and an override
+     * that quietly means something adjacent to what was typed is worse
+     * than one that does nothing.
+     */
+    expect(parseDeviceRoleOverride("banana")).toBeUndefined();
+    expect(parseDeviceRoleOverride("rout")).toBeUndefined();
+    expect(parseDeviceRoleOverride("router-ish")).toBeUndefined();
+    expect(parseDeviceRoleOverride("routers")).toBeUndefined();
+    expect(parseDeviceRoleOverride("sw")).toBeUndefined();
+    expect(parseDeviceRoleOverride("core-sw-1")).toBeUndefined();
+    expect(parseDeviceRoleOverride("42")).toBeUndefined();
+  });
+
+  test("only the surrounding whitespace is forgiven, never the internal kind", () => {
+    /*
+     * Trimming the ends is a paste artefact; rewriting the middle would be
+     * guessing. "wireless access point" is prose, not the stored value, so
+     * it is refused — while the same letters with only outer padding are
+     * accepted (covered above).
+     */
+    expect(parseDeviceRoleOverride("wireless access point")).toBeUndefined();
+    expect(parseDeviceRoleOverride("wireless  accesspoint")).toBeUndefined();
+    expect(parseDeviceRoleOverride("wireless-access-point")).toBeUndefined();
+    expect(parseDeviceRoleOverride("wireless_access_point")).toBeUndefined();
+    expect(parseDeviceRoleOverride("load balancer")).toBeUndefined();
+    expect(parseDeviceRoleOverride("load-balancer")).toBeUndefined();
+  });
+
+  test("the display labels are not storable values", () => {
+    /*
+     * DEVICE_ROLE_LABELS is what a human reads; the column holds the role
+     * key. The multi-word labels are the ones that would break if a UI ever
+     * wrote the label back, so they must not silently parse.
+     */
+    expect(
+      parseDeviceRoleOverride(DEVICE_ROLE_LABELS.wirelessAccessPoint),
+    ).toBe(undefined);
+    expect(parseDeviceRoleOverride(DEVICE_ROLE_LABELS.loadBalancer)).toBe(
+      undefined,
+    );
+    expect(parseDeviceRoleOverride(DEVICE_ROLE_LABELS.phone)).toBe(undefined);
+    expect(parseDeviceRoleOverride(DEVICE_ROLE_LABELS.unknown)).toBe(undefined);
+  });
+});
+
+describe("parseDeviceRoleOverride — determinism", () => {
+  test("the same value parses the same way however many times it is asked", () => {
+    /*
+     * Cheap insurance against any future implementation that reaches for a
+     * shared regex (whose lastIndex is stateful) or a memo keyed on
+     * something mutable: the same input must not answer differently on the
+     * second call, or a topology would depend on how many devices were
+     * built before it.
+     */
+    const values: Array<string> = [
+      "switch",
+      "SWITCH",
+      "unknown",
+      "banana",
+      "loadBalancer",
+      "switch",
+    ];
+    const firstPass: Array<NetworkTopologyDeviceRole | undefined> = values.map(
+      (value: string) => {
+        return parseDeviceRoleOverride(value);
+      },
+    );
+    const secondPass: Array<NetworkTopologyDeviceRole | undefined> = values.map(
+      (value: string) => {
+        return parseDeviceRoleOverride(value);
+      },
+    );
+
+    expect(secondPass).toEqual(firstPass);
+    expect(firstPass).toEqual([
+      "switch",
+      "switch",
+      undefined,
+      undefined,
+      "loadBalancer",
+      "switch",
+    ]);
+  });
+
+  test("parsing the legend backwards gives the same answers as parsing it forwards", () => {
+    /*
+     * The order the caller happens to iterate in must not leak into the
+     * result — the same guarantee the topology builder relies on when it
+     * resolves devices in whatever order the database returned them.
+     */
+    const forwards: Array<NetworkTopologyDeviceRole | undefined> =
+      DEVICE_ROLES_IN_LEGEND_ORDER.map((role: NetworkTopologyDeviceRole) => {
+        return parseDeviceRoleOverride(role);
+      });
+    const backwards: Array<NetworkTopologyDeviceRole | undefined> = [
+      ...DEVICE_ROLES_IN_LEGEND_ORDER,
+    ]
+      .reverse()
+      .map((role: NetworkTopologyDeviceRole) => {
+        return parseDeviceRoleOverride(role);
+      });
+
+    expect(backwards).toEqual([...forwards].reverse());
+    expect(forwards).toEqual([...DEVICE_ROLES_IN_LEGEND_ORDER]);
+  });
+});
+
+describe("resolveDeviceRole — a stored override outranks the evidence", () => {
+  test("an override beats a sysDescr that names the product family outright", () => {
+    /*
+     * The device is unmistakably a Catalyst switch by every tier the
+     * classifier has. The operator says it is a camera; the operator wins,
+     * because the classifier is inferring and the operator is not. (In
+     * practice this is a re-used chassis, a lab rig, or a device the
+     * operator wants grouped with the cameras on the map.)
+     */
+    expect(resolveDeviceRole("camera", CATALYST_SWITCH_SIGNALS)).toBe("camera");
+  });
+
+  test("an override beats every tier of evidence, one role at a time", () => {
+    /*
+     * Exhaustive rather than illustrative: whichever role an operator
+     * picks, that role is what gets drawn, even on the least ambiguous
+     * device in these tests.
+     */
+    for (const role of DEVICE_ROLES_IN_LEGEND_ORDER) {
+      expect(resolveDeviceRole(role, CATALYST_SWITCH_SIGNALS)).toBe(role);
+    }
+  });
+
+  test("an override beats a matching vendor arc and a matching hostname too", () => {
+    // Fortinet's arc plus a "fw" hostname would both say firewall.
+    expect(
+      resolveDeviceRole("loadBalancer", {
+        sysObjectId: "1.3.6.1.4.1.12356.101.1.1",
+        sysDescr: "FortiGate-60F v7.2.5",
+        name: "edge-fw01",
+      }),
+    ).toBe("loadBalancer");
+  });
+
+  test("the override is honoured in whatever casing it was stored in", () => {
+    expect(resolveDeviceRole("CAMERA", CATALYST_SWITCH_SIGNALS)).toBe("camera");
+    expect(
+      resolveDeviceRole("  wirelessaccesspoint  ", CATALYST_SWITCH_SIGNALS),
+    ).toBe("wirelessAccessPoint");
+  });
+});
+
+describe("resolveDeviceRole — the classifier runs when there is no override", () => {
+  test("absent, null, empty and blank overrides all hand back to the classifier", () => {
+    expect(resolveDeviceRole(undefined, CATALYST_SWITCH_SIGNALS)).toBe(
+      "switch",
+    );
+    expect(resolveDeviceRole(null, CATALYST_SWITCH_SIGNALS)).toBe("switch");
+    expect(resolveDeviceRole("", CATALYST_SWITCH_SIGNALS)).toBe("switch");
+    expect(resolveDeviceRole("   ", CATALYST_SWITCH_SIGNALS)).toBe("switch");
+  });
+
+  test("an unrecognised override is ignored, not treated as a shrug", () => {
+    /*
+     * Garbage in the column must not disable the classifier — a typo or a
+     * value written by an older client should degrade to the behaviour the
+     * device had before the column existed.
+     */
+    expect(resolveDeviceRole("banana", CATALYST_SWITCH_SIGNALS)).toBe("switch");
+    expect(resolveDeviceRole("rout", CATALYST_SWITCH_SIGNALS)).toBe("switch");
+    expect(resolveDeviceRole("router-ish", CATALYST_SWITCH_SIGNALS)).toBe(
+      "switch",
+    );
+  });
+
+  test('a stored "unknown" leaves the classifier in charge — the refusal, seen end to end', () => {
+    /*
+     * The payoff of parseDeviceRoleOverride refusing "unknown": the device
+     * is still classified as a switch rather than being pinned neutral.
+     */
+    expect(resolveDeviceRole("unknown", CATALYST_SWITCH_SIGNALS)).toBe(
+      "switch",
+    );
+    /*
+     * And on a device with nothing to go on, the classifier's own answer is
+     * "unknown" anyway, so the two paths agree where it matters.
+     */
+    expect(resolveDeviceRole("unknown", {})).toBe("unknown");
+  });
+
+  test("the classifier's full precedence chain still applies underneath", () => {
+    // A spot check that resolveDeviceRole is a wrapper, not a second opinion.
+    expect(
+      resolveDeviceRole(undefined, {
+        sysDescr: "Linux gw-1 5.4.0-91-generic x86_64",
+        name: "gw-1",
+      }),
+    ).toBe("router");
+    expect(
+      resolveDeviceRole("", { sysObjectId: "1.3.6.1.4.1.3375.2.1.3" }),
+    ).toBe("loadBalancer");
+  });
+});
+
+describe("resolveDeviceRole — the ping-only device from issue #3192", () => {
+  test("a device with no signals and no override is unknown, as it always was", () => {
+    /*
+     * The starting position the issue describes: discovery imported a box
+     * that answers ICMP and nothing else, so there is no sysDescr, no
+     * sysObjectId, no model — and the map draws a neutral node.
+     */
+    expect(resolveDeviceRole(undefined, {})).toBe("unknown");
+    expect(
+      resolveDeviceRole(undefined, {
+        sysDescr: "",
+        sysObjectId: "",
+        deviceModel: undefined,
+        name: "10.20.30.40",
+      }),
+    ).toBe("unknown");
+  });
+
+  test("a device with no signals but an override is drawn as the operator declared", () => {
+    /*
+     * The whole point of the feature. Nothing SNMP could ever say about
+     * this device will change, so the override is the only way it will ever
+     * be anything other than an anonymous circle — and it works with an
+     * entirely empty evidence bundle, which is the state a ping-only
+     * device is permanently in.
+     */
+    expect(resolveDeviceRole("router", {})).toBe("router");
+    expect(resolveDeviceRole("switch", {})).toBe("switch");
+    expect(resolveDeviceRole("firewall", {})).toBe("firewall");
+    expect(resolveDeviceRole("wirelessAccessPoint", {})).toBe(
+      "wirelessAccessPoint",
+    );
+  });
+
+  test("an override on a ping-only device survives an uninformative hostname", () => {
+    /*
+     * "device-42" and a bare IP are what these imports are usually called;
+     * neither is a hostname convention the classifier can read, and neither
+     * gets to argue with the declaration.
+     */
+    expect(resolveDeviceRole("router", { name: "device-42" })).toBe("router");
+    expect(resolveDeviceRole("printer", { name: "10.20.30.40" })).toBe(
+      "printer",
+    );
+  });
+
+  test("an override still wins once the device later starts answering SNMP", () => {
+    /*
+     * A ping-only device that is given credentials later suddenly has
+     * evidence. The declaration must not be quietly reversed by the first
+     * successful walk — the operator has to be the one to change it.
+     */
+    expect(
+      resolveDeviceRole("router", {
+        sysDescr: "Cisco IOS Software, Catalyst 2960X switch",
+        deviceModel: "WS-C2960X-48FPD-L",
+      }),
+    ).toBe("router");
+  });
+});
+
+describe("resolveDeviceRole — determinism and totality", () => {
+  test("the order the signal fields were assigned in does not change the answer", () => {
+    /*
+     * The builder assembles these objects field by field from several
+     * sources, so the key insertion order differs between call sites. It
+     * must not be observable.
+     */
+    const oneOrder: DeviceRoleSignals = {
+      name: "idf2-sw-3",
+      sysDescr: "Cisco IOS Software, Catalyst 2960X switch",
+      vendor: "Cisco Systems",
+      deviceModel: "WS-C2960X-48FPD-L",
+    };
+    const anotherOrder: DeviceRoleSignals = {
+      deviceModel: "WS-C2960X-48FPD-L",
+      vendor: "Cisco Systems",
+      sysDescr: "Cisco IOS Software, Catalyst 2960X switch",
+      name: "idf2-sw-3",
+    };
+
+    expect(resolveDeviceRole(undefined, oneOrder)).toBe(
+      resolveDeviceRole(undefined, anotherOrder),
+    );
+    expect(resolveDeviceRole("camera", oneOrder)).toBe(
+      resolveDeviceRole("camera", anotherOrder),
+    );
+  });
+
+  test("resolving does not mutate the signals it was handed", () => {
+    /*
+     * The same signals object is read again when the node is rendered, so a
+     * normalisation written back in place would make the second read differ
+     * from the first.
+     */
+    const signals: DeviceRoleSignals = { ...CATALYST_SWITCH_SIGNALS };
+    resolveDeviceRole("camera", signals);
+    resolveDeviceRole(undefined, signals);
+
+    expect(signals).toEqual(CATALYST_SWITCH_SIGNALS);
+  });
+
+  test("resolving the same device repeatedly, interleaved with others, is stable", () => {
+    const overrides: Array<string | undefined | null> = [
+      "camera",
+      undefined,
+      "unknown",
+      null,
+      "camera",
+      "banana",
+    ];
+    const firstPass: Array<NetworkTopologyDeviceRole> = overrides.map(
+      (override: string | undefined | null) => {
+        return resolveDeviceRole(override, CATALYST_SWITCH_SIGNALS);
+      },
+    );
+    const secondPass: Array<NetworkTopologyDeviceRole> = [...overrides]
+      .reverse()
+      .map((override: string | undefined | null) => {
+        return resolveDeviceRole(override, CATALYST_SWITCH_SIGNALS);
+      });
+
+    expect(firstPass).toEqual([
+      "camera",
+      "switch",
+      "switch",
+      "switch",
+      "camera",
+      "switch",
+    ]);
+    expect(secondPass).toEqual([...firstPass].reverse());
+  });
+
+  test("it is total: every override and signal combination yields a known role", () => {
+    /*
+     * resolveDeviceRole feeds NetworkTopologyNode.role, which the map uses
+     * to pick a shape and a legend entry, so it can never hand back
+     * undefined or a string outside the union.
+     */
+    const knownRoles: Array<string> = Object.keys(DEVICE_ROLE_LABELS);
+    const overrides: Array<string | undefined | null> = [
+      undefined,
+      null,
+      "",
+      "   ",
+      "unknown",
+      "banana",
+      "switch",
+      "loadBalancer",
+      "WIRELESSACCESSPOINT",
+    ];
+    const bundles: Array<DeviceRoleSignals> = [
+      {},
+      { name: "device-42" },
+      CATALYST_SWITCH_SIGNALS,
+      { sysDescr: "Linux app-3 5.4.0-91-generic x86_64", name: "app-3" },
+    ];
+
+    for (const override of overrides) {
+      for (const bundle of bundles) {
+        const role: NetworkTopologyDeviceRole = resolveDeviceRole(
+          override,
+          bundle,
+        );
+        expect(knownRoles).toContain(role);
+      }
+    }
   });
 });

--- a/Common/Tests/Utils/Monitor/NetworkTopologyDeclaredHierarchy.test.ts
+++ b/Common/Tests/Utils/Monitor/NetworkTopologyDeclaredHierarchy.test.ts
@@ -1,0 +1,759 @@
+import NetworkTopologyUtil, {
+  TopologyBuildResult,
+  TopologyDeviceInput,
+  TopologyManualLinkInput,
+} from "../../../Utils/Monitor/NetworkTopologyUtil";
+import {
+  NetworkTopologyEdge,
+  NetworkTopologyNode,
+} from "../../../Types/Monitor/SnmpMonitor/NetworkTopology";
+
+/*
+ * Issue #3192. Two things the map could not previously express, and both
+ * of them are statements a PERSON made rather than something SNMP said:
+ *
+ *   - what a device IS, on a box nothing walks. The classifier is
+ *     evidence-driven and a ping-only device offers it a hostname and
+ *     nothing else, so `NetworkDevice.deviceRole` is the only answer
+ *     available at all — and it outranks the classifier when both speak.
+ *   - which end of a link is the PARENT. LLDP and CDP report a cable, not
+ *     a hierarchy, so `NetworkDeviceLink.parentDeviceId` is carried onto
+ *     the edge as `parentNodeId` for the layouts to honour.
+ *
+ * Both travel through buildTopology, which is what this file exercises:
+ * the units are tested next door, this is the wiring.
+ */
+describe("NetworkTopologyUtil.buildTopology — operator-declared role and hierarchy", () => {
+  const now: Date = new Date("2026-07-22T12:00:00Z");
+  const fresh: Date = new Date("2026-07-22T11:55:00Z");
+
+  const makeDevice: (
+    id: string,
+    name: string,
+    overrides?: Partial<TopologyDeviceInput>,
+  ) => TopologyDeviceInput = (
+    id: string,
+    name: string,
+    overrides?: Partial<TopologyDeviceInput>,
+  ): TopologyDeviceInput => {
+    return {
+      id,
+      name,
+      lastSeenAt: fresh,
+      ...overrides,
+    };
+  };
+
+  const nodeById: (
+    result: TopologyBuildResult,
+    id: string,
+  ) => NetworkTopologyNode | undefined = (
+    result: TopologyBuildResult,
+    id: string,
+  ): NetworkTopologyNode | undefined => {
+    return result.nodes.find((node: NetworkTopologyNode) => {
+      return node.id === id;
+    });
+  };
+
+  /*
+   * Edges are undirected as far as identity goes — which end landed in
+   * fromNodeId depends on who reported the link first — so they are looked
+   * up by the unordered pair, exactly the way the builder keys them.
+   */
+  const edgeBetween: (
+    result: TopologyBuildResult,
+    a: string,
+    b: string,
+  ) => NetworkTopologyEdge | undefined = (
+    result: TopologyBuildResult,
+    a: string,
+    b: string,
+  ): NetworkTopologyEdge | undefined => {
+    const wanted: string = [a, b].sort().join("::");
+    return result.edges.find((edge: NetworkTopologyEdge) => {
+      return [edge.fromNodeId, edge.toNodeId].sort().join("::") === wanted;
+    });
+  };
+
+  describe("the operator's device role override", () => {
+    it("gives a role to a ping-only device the classifier could never place", () => {
+      /*
+       * The case the column exists for. Nothing walks this box, so there is
+       * no sysDescr, no sysObjectId, no model — and "ping-only-42" is not a
+       * naming convention the classifier recognises. Without the override
+       * this node is drawn "unknown" forever.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "ping-only-42", { deviceRole: "switch" }),
+          makeDevice("d2", "ping-only-43"),
+        ],
+        now,
+      );
+
+      expect(nodeById(result, "d1")!.role).toBe("switch");
+      // The control: same absence of evidence, no override, still unknown.
+      expect(nodeById(result, "d2")!.role).toBe("unknown");
+    });
+
+    it("outranks an SNMP identity that says something else entirely", () => {
+      /*
+       * The override is the only statement about the role that is not an
+       * inference, so it wins even against tier-1 evidence. Real cause: a
+       * chassis re-purposed as something its sysDescr never caught up with.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "core-1", {
+            sysDescr: "Cisco IOS Software, Catalyst 9300-48P",
+            deviceRole: "firewall",
+          }),
+          makeDevice("d2", "dmz-1", {
+            sysObjectId: "1.3.6.1.4.1.3375.2.1.3.4.10",
+            deviceRole: "router",
+          }),
+        ],
+        now,
+      );
+
+      // Classifier alone would answer "switch" and "loadBalancer" here.
+      expect(nodeById(result, "d1")!.role).toBe("firewall");
+      expect(nodeById(result, "d2")!.role).toBe("router");
+    });
+
+    it("leaves the classifier's answer alone when no override is stored", () => {
+      /*
+       * The override must be additive: every device that had a correctly
+       * derived role before the column existed has to keep it.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "edge-1", { sysDescr: "FortiGate-60F v7.2.5" }),
+          makeDevice("d2", "edge-2", {
+            sysDescr: "FortiGate-60F v7.2.5",
+            deviceRole: undefined,
+          }),
+        ],
+        now,
+      );
+
+      expect(nodeById(result, "d1")!.role).toBe("firewall");
+      expect(nodeById(result, "d2")!.role).toBe("firewall");
+    });
+
+    it("falls back to the classifier rather than blanking a role it cannot parse", () => {
+      /*
+       * An override nobody can read is not an instruction to draw a neutral
+       * node — it is no instruction at all, so the evidence gets its say.
+       * "cor switch" is the shape a typo takes; the empty and whitespace
+       * cases are what an operator clearing the field actually stores.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "edge-1", {
+            sysDescr: "FortiGate-60F v7.2.5",
+            deviceRole: "cor switch",
+          }),
+          makeDevice("d2", "edge-2", {
+            sysDescr: "FortiGate-60F v7.2.5",
+            deviceRole: "",
+          }),
+          makeDevice("d3", "edge-3", {
+            sysDescr: "FortiGate-60F v7.2.5",
+            deviceRole: "   ",
+          }),
+        ],
+        now,
+      );
+
+      expect(nodeById(result, "d1")!.role).toBe("firewall");
+      expect(nodeById(result, "d2")!.role).toBe("firewall");
+      expect(nodeById(result, "d3")!.role).toBe("firewall");
+    });
+
+    it("refuses 'unknown' as an override so the classifier still gets to run", () => {
+      /*
+       * Storing "unknown" would silently disable the classifier on a device
+       * the operator was only declining to classify. d1 proves the evidence
+       * still wins; d2 proves the refusal is not itself an error — a device
+       * with nothing to go on lands on "unknown" via the classifier.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "edge-1", {
+            sysDescr: "FortiGate-60F v7.2.5",
+            deviceRole: "unknown",
+          }),
+          makeDevice("d2", "device-42", { deviceRole: "unknown" }),
+        ],
+        now,
+      );
+
+      expect(nodeById(result, "d1")!.role).toBe("firewall");
+      expect(nodeById(result, "d2")!.role).toBe("unknown");
+    });
+
+    it("reads the stored value case-insensitively and ignores surrounding space", () => {
+      /*
+       * The column is ShortText, so what lands in it depends on which form
+       * or import wrote it. A role that only applies when it was typed in
+       * exactly the internal camelCase spelling would be a trap.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "a", { deviceRole: "SWITCH" }),
+          makeDevice("d2", "b", { deviceRole: "  Router  " }),
+          makeDevice("d3", "c", { deviceRole: "wirelessaccesspoint" }),
+          makeDevice("d4", "d", { deviceRole: "loadBalancer" }),
+        ],
+        now,
+      );
+
+      expect(nodeById(result, "d1")!.role).toBe("switch");
+      expect(nodeById(result, "d2")!.role).toBe("router");
+      expect(nodeById(result, "d3")!.role).toBe("wirelessAccessPoint");
+      expect(nodeById(result, "d4")!.role).toBe("loadBalancer");
+    });
+
+    it("applies the override to the device that owns it and to nothing else", () => {
+      /*
+       * A role is a per-node property. The unmanaged peer d1 reports is a
+       * different box that nobody has overridden, and it must keep being
+       * classified from what it advertises about itself.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "edge-1", {
+            sysName: "edge-1",
+            deviceRole: "firewall",
+            cdpNeighbors: [
+              {
+                localInterfaceIndex: 1,
+                remoteDeviceId: "ap-lobby",
+                remotePlatform: "cisco AIR-CAP3702I-A-K9",
+              },
+            ],
+          }),
+          makeDevice("d2", "device-99"),
+        ],
+        now,
+      );
+
+      expect(nodeById(result, "d1")!.role).toBe("firewall");
+      expect(nodeById(result, "unmanaged:ap-lobby")!.role).toBe(
+        "wirelessAccessPoint",
+      );
+      expect(nodeById(result, "d2")!.role).toBe("unknown");
+    });
+
+    it("resolves every device's role independently of the order they arrive in", () => {
+      /*
+       * Devices come off a query whose order is not guaranteed. A role that
+       * depended on it would make the map flicker between rebuilds.
+       */
+      const devices: Array<TopologyDeviceInput> = [
+        makeDevice("d1", "core-1", {
+          sysDescr: "Cisco IOS Software, Catalyst 9300-48P",
+          deviceRole: "firewall",
+        }),
+        makeDevice("d2", "edge-1", { sysDescr: "FortiGate-60F v7.2.5" }),
+        makeDevice("d3", "ping-only", { deviceRole: "router" }),
+      ];
+
+      const forward: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        devices,
+        now,
+      );
+      const reversed: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [...devices].reverse(),
+        now,
+      );
+
+      for (const deviceId of ["d1", "d2", "d3"]) {
+        expect(nodeById(reversed, deviceId)!.role).toBe(
+          nodeById(forward, deviceId)!.role,
+        );
+      }
+      expect(nodeById(forward, "d1")!.role).toBe("firewall");
+      expect(nodeById(forward, "d2")!.role).toBe("firewall");
+      expect(nodeById(forward, "d3")!.role).toBe("router");
+    });
+  });
+
+  describe("the parent an operator declared on a link", () => {
+    it("carries a parent declared as the link's 'from' end onto the edge", () => {
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [makeDevice("d1", "core-1"), makeDevice("d2", "access-1")],
+        now,
+        [],
+        [],
+        [{ fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d1" }],
+      );
+
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0]!.parentNodeId).toBe("d1");
+    });
+
+    it("carries a parent declared as the link's 'to' end just the same", () => {
+      /*
+       * Which column the operator's parent landed in is an artefact of how
+       * they drew the link. The declaration names an END, not a side.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [makeDevice("d1", "access-1"), makeDevice("d2", "core-1")],
+        now,
+        [],
+        [],
+        [{ fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d2" }],
+      );
+
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0]!.parentNodeId).toBe("d2");
+    });
+
+    it("still draws the link when the declared parent is a third device", () => {
+      /*
+       * A parent that is not on the link cannot be rendered as one, so the
+       * declaration is dropped — but the CABLE is a separate fact and it is
+       * still real. Losing the line as well would delete information the
+       * operator did get right.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "core-1"),
+          makeDevice("d2", "access-1"),
+          makeDevice("d3", "bystander"),
+        ],
+        now,
+        [],
+        [],
+        [
+          {
+            fromDeviceId: "d1",
+            toDeviceId: "d2",
+            name: "IDF-2 uplink",
+            parentDeviceId: "d3",
+          },
+        ],
+      );
+
+      const edge: NetworkTopologyEdge | undefined = edgeBetween(
+        result,
+        "d1",
+        "d2",
+      );
+      expect(edge).toBeDefined();
+      expect(edge!.name).toBe("IDF-2 uplink");
+      expect(edge!.parentNodeId).toBeUndefined();
+      // The bystander gains nothing from having been named.
+      expect(edgeBetween(result, "d1", "d3")).toBeUndefined();
+      expect(edgeBetween(result, "d2", "d3")).toBeUndefined();
+    });
+
+    it("skips a link with an end outside the graph, declaration or not", () => {
+      /*
+       * A site-scoped map, or a link to a device since archived. A declared
+       * parent does not make an unattachable link attachable — the pre-existing
+       * skip has to happen before the declaration is even looked at.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [makeDevice("d1", "core-1")],
+        now,
+        [],
+        [],
+        [
+          {
+            fromDeviceId: "d1",
+            toDeviceId: "d-elsewhere",
+            parentDeviceId: "d1",
+          },
+          {
+            fromDeviceId: "d-elsewhere",
+            toDeviceId: "d1",
+            parentDeviceId: "d-elsewhere",
+          },
+        ],
+      );
+
+      expect(result.edges).toHaveLength(0);
+    });
+
+    it("leaves a purely discovered edge with no parent at all", () => {
+      /*
+       * LLDP reports a cable, not a hierarchy: the direction a neighbour
+       * entry happens to be read from says nothing about which box is
+       * upstream. Absent must mean "not stated" so the layout keeps
+       * inferring instead of trusting an accident of polling order.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "edge-1", {
+            sysName: "edge-1",
+            lldpNeighbors: [
+              { localInterfaceIndex: 24, remoteSysName: "core-1" },
+            ],
+          }),
+          makeDevice("d2", "core-1", { sysName: "core-1" }),
+        ],
+        now,
+      );
+
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0]!.protocols).toEqual(["lldp"]);
+      expect(result.edges[0]!.parentNodeId).toBeUndefined();
+    });
+
+    it("declares the same parent whichever order the devices were queried in", () => {
+      const devices: Array<TopologyDeviceInput> = [
+        makeDevice("d1", "core-1"),
+        makeDevice("d2", "access-1"),
+      ];
+      const links: Array<TopologyManualLinkInput> = [
+        { fromDeviceId: "d2", toDeviceId: "d1", parentDeviceId: "d1" },
+      ];
+
+      const forward: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        devices,
+        now,
+        [],
+        [],
+        links,
+      );
+      const reversed: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [...devices].reverse(),
+        now,
+        [],
+        [],
+        links,
+      );
+
+      expect(forward.edges[0]!.parentNodeId).toBe("d1");
+      expect(reversed.edges[0]!.parentNodeId).toBe("d1");
+    });
+  });
+
+  describe("merging a declared parent into an edge that already exists", () => {
+    it("keeps one edge carrying both protocols and the declaration", () => {
+      /*
+       * The whole point of merging rather than doubling: an operator who
+       * declares the hierarchy on a cable LLDP already found must not end
+       * up with two lines between one pair of boxes.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "edge-1", {
+            sysName: "edge-1",
+            lldpNeighbors: [
+              {
+                localInterfaceIndex: 24,
+                remoteSysName: "core-1",
+                remotePortId: "Gi0/1",
+              },
+            ],
+          }),
+          makeDevice("d2", "core-1", { sysName: "core-1" }),
+        ],
+        now,
+        [],
+        [],
+        [{ fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d2" }],
+      );
+
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0]!.protocols).toEqual(["lldp", "manual"]);
+      // The measured port survives; the declaration has no discovered rival.
+      expect(result.edges[0]!.toPort).toBe("Gi0/1");
+      expect(result.edges[0]!.parentNodeId).toBe("d2");
+    });
+
+    it("names the parent by END, not by which side the discovered edge stored", () => {
+      /*
+       * d2 is the one that reported the neighbour, so the edge is stored
+       * d2 -> d1 while the operator drew their link d1 -> d2. If the merge
+       * copied a SIDE rather than an id, the hierarchy would come out
+       * upside down for exactly half the estate.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "core-1", { sysName: "core-1" }),
+          makeDevice("d2", "access-1", {
+            sysName: "access-1",
+            lldpNeighbors: [
+              { localInterfaceIndex: 1, remoteSysName: "core-1" },
+            ],
+          }),
+        ],
+        now,
+        [],
+        [],
+        [{ fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d1" }],
+      );
+
+      expect(result.edges).toHaveLength(1);
+      // The discovered direction is untouched...
+      expect(result.edges[0]!.fromNodeId).toBe("d2");
+      expect(result.edges[0]!.toNodeId).toBe("d1");
+      // ...and the parent is still the core switch the operator named.
+      expect(result.edges[0]!.parentNodeId).toBe("d1");
+      expect(result.edges[0]!.protocols).toEqual(["lldp", "manual"]);
+    });
+
+    it("keeps the FIRST declaration when two links over one pair disagree", () => {
+      /*
+       * Mirrors the ordering the caller already relies on: explicit links
+       * are merged before rule-derived ones, so a hierarchy set on the link
+       * itself beats a rule that happens to cover the same pair. The
+       * specific statement beats the general one — the same precedence the
+       * ports and the name use.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [makeDevice("d1", "core-1"), makeDevice("d2", "access-1")],
+        now,
+        [],
+        [],
+        [
+          { fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d1" },
+          { fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d2" },
+        ],
+      );
+
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0]!.parentNodeId).toBe("d1");
+    });
+
+    it("takes the second link's declaration when the first stated none", () => {
+      /*
+       * "First wins" is about first STATEMENT, not first row: a silent link
+       * has nothing to defend, so a later one that does name a parent fills
+       * the gap rather than being ignored.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [makeDevice("d1", "core-1"), makeDevice("d2", "access-1")],
+        now,
+        [],
+        [],
+        [
+          { fromDeviceId: "d1", toDeviceId: "d2", name: "cable A" },
+          { fromDeviceId: "d2", toDeviceId: "d1", parentDeviceId: "d1" },
+        ],
+      );
+
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0]!.name).toBe("cable A");
+      expect(result.edges[0]!.parentNodeId).toBe("d1");
+    });
+
+    it("never lets an unparseable declaration displace a valid one, in either order", () => {
+      /*
+       * A parent naming a third device contributes nothing at all, so the
+       * one real declaration has to survive whichever row it sits in. This
+       * is the order-independence that matters: only DISAGREEING valid
+       * declarations are allowed to depend on ordering.
+       */
+      const validFirst: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "core-1"),
+          makeDevice("d2", "access-1"),
+          makeDevice("d3", "bystander"),
+        ],
+        now,
+        [],
+        [],
+        [
+          { fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d1" },
+          { fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d3" },
+        ],
+      );
+
+      const invalidFirst: TopologyBuildResult =
+        NetworkTopologyUtil.buildTopology(
+          [
+            makeDevice("d1", "core-1"),
+            makeDevice("d2", "access-1"),
+            makeDevice("d3", "bystander"),
+          ],
+          now,
+          [],
+          [],
+          [
+            { fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d3" },
+            { fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d1" },
+          ],
+        );
+
+      expect(edgeBetween(validFirst, "d1", "d2")!.parentNodeId).toBe("d1");
+      expect(edgeBetween(invalidFirst, "d1", "d2")!.parentNodeId).toBe("d1");
+    });
+
+    it("is order-independent when two links agree about the parent", () => {
+      /*
+       * Two rows saying the same thing — an explicit link and a rule that
+       * derived the same hierarchy — must not depend on merge order at all.
+       */
+      const links: Array<TopologyManualLinkInput> = [
+        { fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d1" },
+        // Stored the other way round, same declaration.
+        { fromDeviceId: "d2", toDeviceId: "d1", parentDeviceId: "d1" },
+      ];
+      const devices: Array<TopologyDeviceInput> = [
+        makeDevice("d1", "core-1"),
+        makeDevice("d2", "access-1"),
+      ];
+
+      const forward: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        devices,
+        now,
+        [],
+        [],
+        links,
+      );
+      const reversed: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        devices,
+        now,
+        [],
+        [],
+        [...links].reverse(),
+      );
+
+      expect(forward.edges).toHaveLength(1);
+      expect(reversed.edges).toHaveLength(1);
+      expect(forward.edges[0]!.parentNodeId).toBe("d1");
+      expect(reversed.edges[0]!.parentNodeId).toBe("d1");
+    });
+
+    it("declares a parent on one pair without touching the pairs around it", () => {
+      /*
+       * A three-device chain where only the middle cable is declared. The
+       * layout has to be able to tell a stated hierarchy from an inferred
+       * one per edge, so a declaration must not bleed sideways.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "core-1"),
+          makeDevice("d2", "dist-1"),
+          makeDevice("d3", "access-1"),
+        ],
+        now,
+        [],
+        [],
+        [
+          { fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d1" },
+          { fromDeviceId: "d2", toDeviceId: "d3" },
+        ],
+      );
+
+      expect(result.edges).toHaveLength(2);
+      expect(edgeBetween(result, "d1", "d2")!.parentNodeId).toBe("d1");
+      expect(edgeBetween(result, "d2", "d3")!.parentNodeId).toBeUndefined();
+    });
+
+    it("keeps declarations off the fdb edges that hang endpoints on a switch", () => {
+      /*
+       * Endpoint attachment is measured, not declared, and its edges are
+       * appended after the manual merge entirely. A declared parent on the
+       * uplink must not leak onto them.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [makeDevice("d1", "core-1"), makeDevice("d2", "access-1")],
+        now,
+        [],
+        [
+          {
+            id: "ep-1",
+            macAddress: "aa:bb:cc:dd:ee:01",
+            attachedNetworkDeviceId: "d2",
+            lastSeenAt: fresh,
+          },
+        ],
+        [{ fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d1" }],
+      );
+
+      expect(edgeBetween(result, "d1", "d2")!.parentNodeId).toBe("d1");
+      const fdbEdge: NetworkTopologyEdge | undefined = edgeBetween(
+        result,
+        "d2",
+        "endpoint:ep-1",
+      );
+      expect(fdbEdge).toBeDefined();
+      expect(fdbEdge!.protocols).toEqual(["fdb"]);
+      expect(fdbEdge!.parentNodeId).toBeUndefined();
+    });
+  });
+
+  describe("both declarations on one graph", () => {
+    it("draws a ping-only access switch under its declared parent", () => {
+      /*
+       * The end-to-end shape of issue #3192: a device that only answers
+       * ping, given a role by hand and hung under a core switch by hand,
+       * with neither statement needing SNMP to have said anything.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "core-1", {
+            sysName: "core-1",
+            sysDescr: "Cisco IOS Software, Catalyst 9300-48P",
+          }),
+          makeDevice("d2", "idf2-ping-only", {
+            deviceRole: "switch",
+            lastSeenAt: undefined,
+            monitorStatus: "up",
+            isNeighborDiscoveryEnabled: false,
+          }),
+        ],
+        now,
+        [],
+        [],
+        [
+          {
+            fromDeviceId: "d2",
+            toDeviceId: "d1",
+            name: "IDF-2 uplink",
+            parentDeviceId: "d1",
+          },
+        ],
+      );
+
+      expect(nodeById(result, "d1")!.role).toBe("switch");
+      expect(nodeById(result, "d2")!.role).toBe("switch");
+      expect(nodeById(result, "d2")!.status).toBe("up");
+
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0]!.protocols).toEqual(["manual"]);
+      expect(result.edges[0]!.name).toBe("IDF-2 uplink");
+      expect(result.edges[0]!.parentNodeId).toBe("d1");
+    });
+
+    it("drops a declared parent along with the node the project hid", () => {
+      /*
+       * Suppression runs last, on the finished graph, and takes an edge's
+       * declaration with the edge. What must NOT happen is the hierarchy
+       * surviving as a dangling reference to a node nobody draws.
+       */
+      const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
+        [
+          makeDevice("d1", "core-1"),
+          makeDevice("d2", "dist-1"),
+          makeDevice("d3", "access-1"),
+        ],
+        now,
+        [],
+        [],
+        [
+          { fromDeviceId: "d1", toDeviceId: "d2", parentDeviceId: "d1" },
+          { fromDeviceId: "d2", toDeviceId: "d3", parentDeviceId: "d2" },
+        ],
+        new Set<string>(["d1"]),
+      );
+
+      expect(nodeById(result, "d1")).toBeUndefined();
+      expect(result.suppressedNodeCount).toBe(1);
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0]!.parentNodeId).toBe("d2");
+      // No edge left pointing at the hidden parent.
+      for (const edge of result.edges) {
+        expect(edge.parentNodeId).not.toBe("d1");
+      }
+    });
+  });
+});

--- a/Common/Types/Monitor/SnmpMonitor/NetworkTopology.ts
+++ b/Common/Types/Monitor/SnmpMonitor/NetworkTopology.ts
@@ -156,6 +156,19 @@ export interface NetworkTopologyEdge {
   monitorState?: "up" | "down" | undefined;
   // Operator-supplied label, set only on manual links.
   name?: string | undefined;
+  /*
+   * Which end of this edge is the parent, when somebody has SAID so —
+   * either on the link itself or through a link rule, which is stated in
+   * child/parent labels and so knows the answer by construction.
+   *
+   * Always one of `fromNodeId`/`toNodeId`. Absent on every discovered
+   * edge: LLDP and CDP report a cable, not a hierarchy, and the direction
+   * a neighbour entry happens to be read from says nothing about which
+   * box is upstream. Layouts that draw a tree must therefore treat this as
+   * a constraint where it is present and keep inferring where it is not —
+   * absent is "not stated", never "these are peers".
+   */
+  parentNodeId?: string | undefined;
 }
 
 export default interface NetworkTopology {

--- a/Common/Utils/Monitor/NetworkDeviceRoleUtil.ts
+++ b/Common/Utils/Monitor/NetworkDeviceRoleUtil.ts
@@ -531,3 +531,48 @@ export function labelForDeviceRole(
   }
   return DEVICE_ROLE_LABELS[role] || DEVICE_ROLE_LABELS.unknown;
 }
+
+/**
+ * Read an operator's stored role override off a NetworkDevice row.
+ *
+ * The classifier above is evidence-driven, and its evidence is SNMP: a
+ * device nothing walks — a ping-only device imported by discovery, say —
+ * offers it a hostname and nothing else, so it comes back "unknown" and
+ * stays there forever. `NetworkDevice.deviceRole` is the operator saying
+ * what the box actually is, and it is the only statement about a role that
+ * is not an inference, so it outranks everything the classifier can find.
+ *
+ * Undefined means "no override" — NOT "unknown". The two are different
+ * answers and the difference decides whether the classifier gets to run at
+ * all, which is why an unrecognised or empty column reads as undefined
+ * rather than falling back to a role. "unknown" is itself refused as an
+ * override for the same reason: storing it would silently disable the
+ * classifier on a device the operator was only declining to classify.
+ */
+export function parseDeviceRoleOverride(
+  value: string | undefined | null,
+): NetworkTopologyDeviceRole | undefined {
+  const normalized: string = (value || "").trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  return DEVICE_ROLES_IN_LEGEND_ORDER.find(
+    (role: NetworkTopologyDeviceRole) => {
+      return role.toLowerCase() === normalized;
+    },
+  );
+}
+
+/**
+ * The role to draw a managed device with: the operator's override when
+ * there is one, otherwise whatever the evidence supports.
+ *
+ * One function so the topology builder, the forms and the tests cannot
+ * drift about which of the two wins.
+ */
+export function resolveDeviceRole(
+  roleOverride: string | undefined | null,
+  signals: DeviceRoleSignals,
+): NetworkTopologyDeviceRole {
+  return parseDeviceRoleOverride(roleOverride) ?? classifyDeviceRole(signals);
+}

--- a/Common/Utils/Monitor/NetworkTopologyUtil.ts
+++ b/Common/Utils/Monitor/NetworkTopologyUtil.ts
@@ -11,6 +11,7 @@ import { normalizeMac } from "./EndpointAttachmentUtil";
 import {
   classifyDeviceRole,
   classifyEndpointRole,
+  resolveDeviceRole,
 } from "./NetworkDeviceRoleUtil";
 
 export interface TopologyDeviceInput {
@@ -29,6 +30,14 @@ export interface TopologyDeviceInput {
    */
   sysDescr?: string | undefined;
   sysObjectId?: string | undefined;
+  /*
+   * The operator's own answer to what this device is, when they gave one.
+   * Outranks the classifier below, because it is the only statement about
+   * the role that is not an inference — and on a device nothing walks it
+   * is the ONLY statement available at all, the classifier having nothing
+   * but a hostname to go on.
+   */
+  deviceRole?: string | undefined;
   /*
    * ENTITY-MIB chassis serial. Not rendered — it is here because LLDP
    * chassis-id subtype 7 ("locally assigned") is very often exactly this
@@ -109,6 +118,13 @@ export interface TopologyManualLinkInput {
   toPortName?: string | undefined;
   // Health from a bound Monitor, already reduced by the caller.
   monitorStatus?: "up" | "down" | undefined;
+  /*
+   * Whichever end the operator declared the parent, when they declared
+   * one. Must be `fromDeviceId` or `toDeviceId`; anything else is dropped
+   * rather than drawn, because a parent that is not on the link cannot be
+   * rendered as one and a wrong hierarchy is worse than an inferred one.
+   */
+  parentDeviceId?: string | undefined;
 }
 
 /*
@@ -232,7 +248,10 @@ export default class NetworkTopologyUtil {
    * alias are one unmanaged node, however many switches saw it. Edges are
    * undirected and deduplicated — a link reported from both ends, or by
    * both protocols, appears once with the union of what each report knew
-   * (ports, protocols, per-end interface state). When `interfaces` rows are
+   * (ports, protocols, per-end interface state). Undirected in the sense
+   * that neither end is privileged by how the edge was discovered: an edge
+   * carries a direction only where an operator declared one, as
+   * `parentNodeId`. When `interfaces` rows are
    * provided, each edge end whose interface is identifiable carries its
    * operational state (up/down, utilization, rates). When `endpoints` rows
    * are provided, each one that attaches to a device in the graph becomes an
@@ -306,7 +325,7 @@ export default class NetworkTopologyUtil {
         name: device.name,
         isManaged: true,
         kind: "device",
-        role: classifyDeviceRole({
+        role: resolveDeviceRole(device.deviceRole, {
           sysDescr: device.sysDescr,
           sysObjectId: device.sysObjectId,
           vendor: device.vendor,
@@ -520,6 +539,18 @@ export default class NetworkTopologyUtil {
         continue;
       }
 
+      /*
+       * A declared parent is only meaningful if it is one of the two ends.
+       * The service refuses anything else at write time, so this is a
+       * second line rather than the only one — it also covers rule-derived
+       * links, which never pass through that service.
+       */
+      const declaredParentId: string | undefined =
+        link.parentDeviceId === link.fromDeviceId ||
+        link.parentDeviceId === link.toDeviceId
+          ? link.parentDeviceId
+          : undefined;
+
       const edgeKey: string = [link.fromDeviceId, link.toDeviceId]
         .sort()
         .join("::");
@@ -534,6 +565,7 @@ export default class NetworkTopologyUtil {
           protocols: ["manual"],
           monitorState: link.monitorStatus,
           name: link.name,
+          parentNodeId: declaredParentId,
         });
         continue;
       }
@@ -557,6 +589,14 @@ export default class NetworkTopologyUtil {
       }
       existing.name = existing.name || link.name;
       existing.monitorState = existing.monitorState ?? link.monitorStatus;
+      /*
+       * First declaration wins, matching the ordering the caller already
+       * relies on: explicit links are merged before rule-derived ones, so
+       * a hierarchy somebody set on the link itself beats a rule that
+       * happens to cover the same pair. The specific statement beats the
+       * general one — the same precedence the ports and the name use.
+       */
+      existing.parentNodeId = existing.parentNodeId || declaredParentId;
     }
 
     const edges: Array<NetworkTopologyEdge> = Array.from(edgeByKey.values());


### PR DESCRIPTION
Addresses #3192.

That issue asked for three things. Two of them — ping-only devices in the topology, and a way to link devices by hand — already shipped in 53e752dbf for #3023, the day before it was filed. This is the remaining two-thirds, which is what actually decides whether the resulting map comes out the right way up.

## A link could be drawn, but not oriented

The direction already existed in the data. `NetworkDeviceLink` stores `fromDevice`/`toDevice`, and `NetworkDeviceLinkRule` is *stated* as child labels and parent labels. `buildTopology` then dedupes edges on a **sorted** pair key, which discarded it before any layout could see it — so the Parent-Child view re-derived the hierarchy from scratch, by role and connection count.

- **`NetworkDeviceLink.parentDeviceId`** — nullable, and must be one of the link's own two ends. NULL is what every existing row holds, and it means exactly what the map does today: peers, direction inferred. **No existing map moves.**
- **`NetworkTopologyEdge.parentNodeId`** carries it through `buildTopology`, first declaration winning on merge — the same explicit-beats-rule precedence the ports and the name already use. Rule-derived links declare it for free, since `resolveRules` puts the child in `from` and the parent in `to`.
- **`buildParentChildForest`** honours it: a child claimed by two parents is dropped rather than guessed between, declared cycles are broken in canonical order, and a declared child is never rooted.

## A ping-only device had no role, and that put it at the top of the map

Roles were classified purely from SNMP identity, so a device nothing walks was permanently `unknown` — and `tierForNode` ranked **any** managed device with no FDB edge at *core* level, alongside the routers. An access point imported by ping was drawn above the switch it hangs off, and could win the root of the tree.

- **`NetworkDevice.deviceRole`** — the operator's own answer, which beats the classifier where set and is the only evidence there is where nothing speaks SNMP. `unknown` is refused as a value: empty already means "classify it", and storing `unknown` would mean the different and much worse thing.
- **`tierForNode` reads it.** Router, firewall and load balancer are core; everything else managed sits one below. The FDB heuristic survives only for `unknown`. Endpoint nodes stay tier 2 whatever their role, so the tiered layout's per-switch group boxes are untouched.

## What an adversarial pass found, and what it cost

Seven reproduced defects, all fixed. Three were mine, in the first cut of the traversal:

| | Before | After |
|---|---|---|
| Declared parent drawn as its own child | **13%** of declarations inverted across 2000 random topologies | **0** across 6000 |
| A declaration re-parented devices on an unrelated branch | parent = first BFS discoverer | depths and parents are now separate passes; the parent pass is `bfsChildrenOf`'s own rule |
| One declaration entered a quadratic sweep | 2384 ms @ 4000 nodes | 33 ms |

Four more in the link service — **one of them pre-existing and wider than this feature**:

- **`onBeforeUpdate` never re-checked that an end belongs to the caller's project.** That check has always existed on create, and its own comment says why: the FK is global, so without it a tenant can point a link at another project's device and read its name off the map. There was no update hook at all, so a `PUT` bypassed it entirely. The new column would have inherited the hole.
- A present-but-undefined parent key read as "cleared", but TypeORM drops undefined keys before building the SET list — so the hook validated a row that never lands, stranding a stored parent on a link whose end had just moved.
- A raw SQL-expression value read as `null`, silently validating against the wrong row. Refused outright now.
- Ids compared case-sensitively against Postgres `uuid` columns, where equality ignores case, so an upper-case id naming a real end was refused.

## One deliberate behaviour change worth a second opinion

Fixing the inversion needed root selection to prefer the top of a declared chain. It is ranked **last** — below role and below connection count — so it only ever displaces the alphabetical id tie-break.

Visible consequence: on a site of equal-ranked switches where nothing else distinguishes them, declaring a parent now roots that site at the declared parent rather than at whichever id sorted first. Every resulting tree line is still a real cable, and a declaration is better evidence than the alphabet — but it is a map moving in response to a setting, so say if you would rather it stayed on pure id ordering.

## Verification

- **231 new tests** across five files: role parsing/resolution (75), `buildTopology` direction and role merge (24), the declared forest incl. cycles, contradictions and determinism (49), role-aware tiering (40), link-service validation (43).
- Full suites green: **5541** App Dashboard, **8227** App, Common.
- All 11 adversarial repro cases pass; 6000 fuzz topologies show 0 invariant violations, 0 non-determinism, 0 declarations unhonoured.
- Migration generated with `generate-postgres-migration` (not hand-written) and registered in `SchemaMigrations/Index.ts`. A **fresh empty database** migrates through all 530 with **no schema drift** — the same check the CI job runs.
- `eslint` and `tsc` clean on Common and App.

Six suites fail to load in my environment with `dlopen … isolated-vm … symbol not found`; the identical failure reproduces on unmodified `master`, so it is a native-module/Node mismatch locally, not this change.

## Not in scope

The **ICMP-only scan type**, the third request in #3192. A scan still requires SNMP credentials on the form even though the sweep already pings first and already reports what answered — so ping-only devices can be found and imported today, just via a scan you had to give credentials to. Worth adding for operators with no credentials at all, but it was the least valuable of the three, and shipping it first would have handed them a pile of role-less devices sitting in the router tier.
