### PR TITLE
feat(billing): tell Free plan users what telemetry and monitors cost, before they commit

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo.tsx
@@ -1,0 +1,506 @@
+import { isProjectOnFreePlan } from "../../Utils/PayAsYouGo";
+import {
+  ACTIVE_MONITOR_PRICE_IN_USD_PER_MONTH,
+  PRICING_PAGE_URL,
+  SESSION_REPLAY_PRICE_IN_USD_PER_GB,
+  TELEMETRY_PRICE_IN_USD_PER_GB,
+  TELEMETRY_PRICE_RETENTION_IN_DAYS,
+  formatPriceInUSD,
+} from "Common/Types/Billing/PayAsYouGoPricing";
+import MonitorType, {
+  MonitorTypeHelper,
+} from "Common/Types/Monitor/MonitorType";
+import IconProp from "Common/Types/Icon/IconProp";
+import URL from "Common/Types/API/URL";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import TelemetryIngestionKey from "Common/Models/DatabaseModels/TelemetryIngestionKey";
+import AlertBanner, {
+  AlertBannerType,
+} from "Common/UI/Components/AlertBanner/AlertBanner";
+import Button, { ButtonStyleType } from "Common/UI/Components/Button/Button";
+import Card from "Common/UI/Components/Card/Card";
+import CheckboxElement from "Common/UI/Components/Checkbox/Checkbox";
+import Icon, { SizeProp, ThickProp } from "Common/UI/Components/Icon/Icon";
+import Link from "Common/UI/Components/Link/Link";
+import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
+import FormValues from "Common/UI/Components/Forms/Types/FormValues";
+import { ModelField } from "Common/UI/Components/Forms/ModelForm";
+import React, { FunctionComponent, ReactElement } from "react";
+
+/*
+ * Pay-as-you-go signposting for Free plan projects.
+ *
+ * Telemetry ingest and active monitors are metered: nothing about them is
+ * included in the Free plan, so a user who creates an ingestion key or a
+ * non-Manual monitor starts a charge. The server bills for it either way -
+ * these components exist so the first the user hears of it is not the
+ * invoice. Everything here renders only when billing is on AND the project is
+ * on Free (see isProjectOnFreePlan, which fails closed).
+ */
+
+export const TELEMETRY_PRICE_PER_GB_TEXT: string = formatPriceInUSD(
+  TELEMETRY_PRICE_IN_USD_PER_GB,
+);
+
+export const SESSION_REPLAY_PRICE_PER_GB_TEXT: string = formatPriceInUSD(
+  SESSION_REPLAY_PRICE_IN_USD_PER_GB,
+);
+
+export const ACTIVE_MONITOR_PRICE_TEXT: string = formatPriceInUSD(
+  ACTIVE_MONITOR_PRICE_IN_USD_PER_MONTH,
+);
+
+export const TELEMETRY_PRICE_SENTENCE: string = `${TELEMETRY_PRICE_PER_GB_TEXT} per GB ingested, with ${TELEMETRY_PRICE_RETENTION_IN_DAYS} day retention`;
+
+/*
+ * Session replay rides on the same ingestion key and is metered at its own,
+ * much higher rate. Quoting only the telemetry rate for "what this key costs"
+ * would understate a replay-heavy bill twentyfold, so both numbers travel
+ * together everywhere the key's price is stated.
+ */
+export const SESSION_REPLAY_PRICE_SENTENCE: string = `${SESSION_REPLAY_PRICE_PER_GB_TEXT} per GB, with ${TELEMETRY_PRICE_RETENTION_IN_DAYS} day retention`;
+
+export const TELEMETRY_RATES_SENTENCE: string = `Logs, traces, metrics and profiles are billed at ${TELEMETRY_PRICE_SENTENCE}. Session replay recordings are billed at ${SESSION_REPLAY_PRICE_SENTENCE}.`;
+
+export const ACTIVE_MONITOR_PRICE_SENTENCE: string = `${ACTIVE_MONITOR_PRICE_TEXT} per monitor per month`;
+
+/*
+ * The form keys the consent checkboxes are stored under. They are declared
+ * with overrideField and no overrideFieldKey, which keeps them out of both the
+ * model payload and miscDataProps - the acknowledgement never leaves the
+ * browser, it only gates the submit.
+ */
+export const TELEMETRY_CONSENT_FIELD_KEY: string =
+  "telemetryPayAsYouGoAcknowledged";
+
+export const MONITOR_CONSENT_FIELD_KEY: string =
+  "monitorPayAsYouGoAcknowledged";
+
+export const TELEMETRY_CONSENT_ERROR: string =
+  "Please confirm you understand telemetry sent with this key is billed as you use it before creating an ingestion key.";
+
+export const MONITOR_CONSENT_ERROR: string = `Please confirm you understand this monitor is billed at ${ACTIVE_MONITOR_PRICE_TEXT} per month before creating it.`;
+
+type ConsentValidator = (values: FormValues<unknown>) => string | null;
+
+/**
+ * A consent box is only satisfied by an explicit `true`. Unchecked (`false`)
+ * and never-touched (`undefined`) both have to block, which is why this is a
+ * customValidation and not `required` - the form's required check stringifies
+ * the value, so `false` reads as the five-character string "false" and sails
+ * straight through it.
+ */
+function buildConsentValidator(data: {
+  fieldKey: string;
+  message: string;
+  isApplicable?: ((values: FormValues<unknown>) => boolean) | undefined;
+}): ConsentValidator {
+  return (values: FormValues<unknown>): string | null => {
+    if (data.isApplicable && !data.isApplicable(values)) {
+      return null;
+    }
+
+    if ((values as Record<string, unknown>)[data.fieldKey] === true) {
+      return null;
+    }
+
+    return data.message;
+  };
+}
+
+export const validateTelemetryConsent: ConsentValidator = buildConsentValidator(
+  {
+    fieldKey: TELEMETRY_CONSENT_FIELD_KEY,
+    message: TELEMETRY_CONSENT_ERROR,
+  },
+);
+
+export const validateMonitorConsent: ConsentValidator = buildConsentValidator({
+  fieldKey: MONITOR_CONSENT_FIELD_KEY,
+  message: MONITOR_CONSENT_ERROR,
+  /*
+   * Manual monitors are free and unlimited, so there is nothing to
+   * acknowledge. showIf already hides the box for them; this keeps the
+   * validator honest on its own terms too.
+   */
+  isApplicable: (values: FormValues<unknown>): boolean => {
+    return MonitorTypeHelper.isBilledAsActiveMonitor(
+      (values as Record<string, unknown>)["monitorType"] as MonitorType,
+    );
+  },
+});
+
+interface PayAsYouGoCardProps {
+  cardTitle: string;
+  cardDescription: string;
+  featureName: string;
+  featureIcon: IconProp;
+  priceLabel: string;
+  priceText: string;
+  priceCaption: string;
+  summary: string;
+  points: Array<string>;
+  dataTestId: string;
+}
+
+function openPricingPage(): void {
+  window.open(PRICING_PAGE_URL, "_blank");
+}
+
+/*
+ * The page level card. Card's own description is hidden on mobile
+ * (`hidden md:block`), so every fact the user needs is repeated inside the
+ * body panel rather than living in the description alone.
+ */
+const PayAsYouGoCard: FunctionComponent<PayAsYouGoCardProps> = (
+  props: PayAsYouGoCardProps,
+): ReactElement => {
+  return (
+    <Card
+      title={props.cardTitle}
+      description={props.cardDescription}
+      rightElement={
+        <Button
+          title="View pricing"
+          buttonStyle={ButtonStyleType.OUTLINE}
+          icon={IconProp.Billing}
+          onClick={openPricingPage}
+        />
+      }
+    >
+      <div data-testid={props.dataTestId}>
+        <div className="flex flex-col gap-4 rounded-xl border border-indigo-100 bg-gradient-to-br from-indigo-50 via-white to-white p-5 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex items-start gap-3">
+            <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-indigo-600 text-white shadow-sm">
+              <Icon
+                icon={props.featureIcon}
+                size={SizeProp.Large}
+                thick={ThickProp.Thick}
+                className="h-6 w-6"
+              />
+            </div>
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <h3 className="text-base font-semibold text-gray-900">
+                  {props.featureName}
+                </h3>
+                <span className="inline-flex items-center gap-1 rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-700">
+                  <Icon
+                    icon={IconProp.CurrencyDollar}
+                    size={SizeProp.Small}
+                    thick={ThickProp.Thick}
+                    className="h-2.5 w-2.5"
+                  />
+                  Pay as you go
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-gray-700">{props.summary}</p>
+              <ul className="mt-3 space-y-1.5">
+                {props.points.map((point: string) => {
+                  return (
+                    <li
+                      key={point}
+                      className="flex items-start gap-2 text-sm text-gray-600"
+                    >
+                      <Icon
+                        icon={IconProp.CheckCircle}
+                        size={SizeProp.Small}
+                        thick={ThickProp.Thick}
+                        className="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500"
+                      />
+                      <span>{point}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          </div>
+          <div className="flex-shrink-0 rounded-lg border border-gray-200 bg-white px-5 py-4 text-center shadow-sm">
+            <p className="text-xs font-semibold text-gray-500">
+              {props.priceLabel}
+            </p>
+            <p className="mt-1 text-2xl font-bold tracking-tight text-gray-900">
+              {props.priceText}
+            </p>
+            <p className="mt-1 text-xs text-gray-500">{props.priceCaption}</p>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+/**
+ * Shown above the telemetry ingestion keys table. Renders nothing unless the
+ * project is on the Free plan of a billed deployment.
+ */
+export const TelemetryPayAsYouGoCard: FunctionComponent = (): ReactElement => {
+  if (!isProjectOnFreePlan()) {
+    return <></>;
+  }
+
+  return (
+    <PayAsYouGoCard
+      dataTestId="telemetry-pay-as-you-go-card"
+      cardTitle="Telemetry is a pay as you go feature"
+      cardDescription={`Your project is on the Free plan. Telemetry sent with an ingestion key is billed as you use it, from ${TELEMETRY_PRICE_SENTENCE}.`}
+      featureName="Telemetry ingest"
+      featureIcon={IconProp.ChartBar}
+      priceLabel="Starting at"
+      priceText={TELEMETRY_PRICE_PER_GB_TEXT}
+      priceCaption={`per GB ingested (${TELEMETRY_PRICE_RETENTION_IN_DAYS} day retention)`}
+      summary={`Telemetry is available on the Free plan, but it is not bundled into it. Data you send with an ingestion key is billed as you use it. ${TELEMETRY_RATES_SENTENCE}`}
+      points={[
+        "No commitment - you are only charged for what you ingest.",
+        "Stop sending data, or delete the key, and the charge stops.",
+        "Longer retention costs proportionally more per GB.",
+      ]}
+    />
+  );
+};
+
+/**
+ * Shown above the create monitor form. Renders nothing unless the project is
+ * on the Free plan of a billed deployment.
+ */
+export const MonitorPayAsYouGoCard: FunctionComponent = (): ReactElement => {
+  if (!isProjectOnFreePlan()) {
+    return <></>;
+  }
+
+  return (
+    <PayAsYouGoCard
+      dataTestId="monitor-pay-as-you-go-card"
+      cardTitle="Monitors are a pay as you go feature"
+      cardDescription={`Your project is on the Free plan. Every monitor type except Manual is an active monitor, billed at ${ACTIVE_MONITOR_PRICE_SENTENCE}.`}
+      featureName="Active monitoring"
+      featureIcon={IconProp.Activity}
+      priceLabel="Starting at"
+      priceText={ACTIVE_MONITOR_PRICE_TEXT}
+      priceCaption="per monitor per month"
+      summary={`Your project is on the Free plan. Every monitor type except ${MonitorType.Manual} is an active monitor and is billed at ${ACTIVE_MONITOR_PRICE_SENTENCE}.`}
+      points={[
+        `${MonitorType.Manual} monitors are always free, and unlimited.`,
+        "No commitment - delete a monitor and the charge stops.",
+        "Telemetry based monitors are billed as active monitors on top of the telemetry they read.",
+      ]}
+    />
+  );
+};
+
+/*
+ * The compact notice that goes inside the create ingestion key modal, where
+ * there is no room for the full card and no page card behind it.
+ */
+const TelemetryPayAsYouGoModalNotice: FunctionComponent = (): ReactElement => {
+  return (
+    <AlertBanner
+      type={AlertBannerType.Info}
+      title="Telemetry is a pay as you go feature"
+    >
+      <p className="text-sm text-gray-700">
+        Your project is on the Free plan, which does not bundle any telemetry.
+        Data sent with this ingestion key is billed as you use it.{" "}
+        {TELEMETRY_RATES_SENTENCE}{" "}
+        <Link
+          className="underline"
+          openInNewTab={true}
+          to={URL.fromString(PRICING_PAGE_URL)}
+        >
+          See pay as you go pricing
+        </Link>
+        .
+      </p>
+    </AlertBanner>
+  );
+};
+
+/**
+ * The pay-as-you-go notice and consent checkbox for the create ingestion key
+ * modal, as ModelForm fields. Empty unless the project is on the Free plan, so
+ * the modal is untouched for everybody else.
+ *
+ * Both fields use `overrideField` with no `overrideFieldKey`: that gives them
+ * a form value without adding them to the model payload or to miscDataProps.
+ */
+export function getTelemetryPayAsYouGoFormFields(): Array<
+  ModelField<TelemetryIngestionKey>
+> {
+  if (!isProjectOnFreePlan()) {
+    return [];
+  }
+
+  return [
+    {
+      overrideField: {
+        telemetryPayAsYouGoNotice: true,
+      },
+      showEvenIfPermissionDoesNotExist: true,
+      doNotShowWhenEditing: true,
+      title: "",
+      hideOptionalLabel: true,
+      spanFullRow: true,
+      fieldType: FormFieldSchemaType.CustomComponent,
+      required: false,
+      getCustomElement: (): ReactElement => {
+        return <TelemetryPayAsYouGoModalNotice />;
+      },
+    },
+    {
+      overrideField: {
+        [TELEMETRY_CONSENT_FIELD_KEY]: true,
+      },
+      showEvenIfPermissionDoesNotExist: true,
+      doNotShowWhenEditing: true,
+      spanFullRow: true,
+      fieldType: FormFieldSchemaType.Checkbox,
+      title: "I understand telemetry sent with this key is billed as I use it",
+      description: TELEMETRY_RATES_SENTENCE,
+      dataTestId: "telemetry-pay-as-you-go-consent",
+      /*
+       * Seeds the key as false so the field is always present in form values.
+       * customValidation is skipped for keys that are absent, and a plain
+       * `defaultValue: false` is falsy and would not seed anything - required
+       * below is the backstop for that path.
+       */
+      getDefaultValue: (): boolean => {
+        return false;
+      },
+      required: true,
+      customValidation: validateTelemetryConsent as (
+        values: FormValues<TelemetryIngestionKey>,
+      ) => string | null,
+    },
+  ];
+}
+
+/**
+ * Whether a batch of monitors about to be created needs a pay-as-you-go
+ * acknowledgement: Free plan, and at least one of them is billed.
+ *
+ * Bulk creation (monitor recommendations) does not go through a ModelForm, so
+ * it cannot use the field factory below - but a "create 18 monitors" button is
+ * the largest single charge a Free plan user can start in one click, which is
+ * exactly where the notice matters most.
+ */
+export function isMonitorBatchConsentRequired(
+  monitorTypes: Array<MonitorType>,
+): boolean {
+  if (!isProjectOnFreePlan()) {
+    return false;
+  }
+
+  return monitorTypes.some((monitorType: MonitorType) => {
+    return MonitorTypeHelper.isBilledAsActiveMonitor(monitorType);
+  });
+}
+
+export function getMonitorBatchPriceSentence(
+  monitorTypes: Array<MonitorType>,
+): string {
+  const billedCount: number = monitorTypes.filter(
+    (monitorType: MonitorType) => {
+      return MonitorTypeHelper.isBilledAsActiveMonitor(monitorType);
+    },
+  ).length;
+
+  /*
+   * "up to", because the Free plan also caps how many active monitors a
+   * project may have - a batch that runs into the cap is rejected part way
+   * rather than billed in full.
+   */
+  return `Creating ${billedCount} ${
+    billedCount === 1 ? "monitor" : "monitors"
+  } adds up to ${formatPriceInUSD(
+    billedCount * ACTIVE_MONITOR_PRICE_IN_USD_PER_MONTH,
+  )} per month to your bill (${ACTIVE_MONITOR_PRICE_SENTENCE}).`;
+}
+
+export interface MonitorBatchConsentProps {
+  monitorTypes: Array<MonitorType>;
+  value: boolean;
+  onChange: (value: boolean) => void;
+}
+
+/**
+ * The bulk-create counterpart to the create-monitor consent field. Renders
+ * nothing when nothing in the batch is billed, or off the Free plan; callers
+ * pair it with isMonitorBatchConsentRequired to disable their submit button.
+ */
+export const MonitorBatchPayAsYouGoConsent: FunctionComponent<
+  MonitorBatchConsentProps
+> = (props: MonitorBatchConsentProps): ReactElement => {
+  if (!isMonitorBatchConsentRequired(props.monitorTypes)) {
+    return <></>;
+  }
+
+  return (
+    <div
+      className="rounded-lg border border-amber-200 bg-amber-50 p-4"
+      data-testid="monitor-batch-pay-as-you-go-notice"
+    >
+      <CheckboxElement
+        title={`I understand these monitors are billed at ${ACTIVE_MONITOR_PRICE_TEXT} per month each`}
+        description={
+          <span>
+            {getMonitorBatchPriceSentence(props.monitorTypes)}{" "}
+            <Link
+              className="underline"
+              openInNewTab={true}
+              to={URL.fromString(PRICING_PAGE_URL)}
+            >
+              See pay as you go pricing
+            </Link>
+            .
+          </span>
+        }
+        value={props.value}
+        dataTestId="monitor-batch-pay-as-you-go-consent"
+        onChange={props.onChange}
+      />
+    </div>
+  );
+};
+
+/**
+ * The consent checkbox for the create monitor form, as a ModelForm field.
+ * Empty unless the project is on the Free plan; hidden (and not validated) for
+ * Manual monitors, which are free.
+ *
+ * `stepId` has to be the step the checkbox lives on: the form only validates
+ * fields belonging to the step being submitted.
+ */
+export function getMonitorPayAsYouGoFormFields(data: {
+  stepId: string;
+}): Array<ModelField<Monitor>> {
+  if (!isProjectOnFreePlan()) {
+    return [];
+  }
+
+  return [
+    {
+      overrideField: {
+        [MONITOR_CONSENT_FIELD_KEY]: true,
+      },
+      showEvenIfPermissionDoesNotExist: true,
+      stepId: data.stepId,
+      spanFullRow: true,
+      fieldType: FormFieldSchemaType.Checkbox,
+      title: `I understand this monitor is billed at ${ACTIVE_MONITOR_PRICE_TEXT} per month`,
+      description: `Your project is on the Free plan. Every monitor type except ${MonitorType.Manual} is an active monitor, billed at ${ACTIVE_MONITOR_PRICE_SENTENCE}. Pick ${MonitorType.Manual} if you do not want to be billed for this monitor.`,
+      dataTestId: "monitor-pay-as-you-go-consent",
+      getDefaultValue: (): boolean => {
+        return false;
+      },
+      required: true,
+      showIf: (values: FormValues<Monitor>): boolean => {
+        return MonitorTypeHelper.isBilledAsActiveMonitor(
+          values.monitorType as MonitorType,
+        );
+      },
+      customValidation: validateMonitorConsent as (
+        values: FormValues<Monitor>,
+      ) => string | null,
+    },
+  ];
+}

--- a/App/FeatureSet/Dashboard/src/Components/Ceph/DocumentationCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Ceph/DocumentationCard.tsx
@@ -10,6 +10,7 @@ import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import { HOST, HTTP_PROTOCOL } from "Common/UI/Config";
 import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
+import { getTelemetryPayAsYouGoFormFields } from "../Billing/PayAsYouGo";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import { FormType } from "Common/UI/Components/Forms/ModelForm";
 import API from "Common/UI/Utils/API/API";
@@ -261,6 +262,12 @@ const CephDocumentationCard: FunctionComponent<ComponentProps> = (
             modelType: TelemetryIngestionKey,
             id: "create-ingestion-key",
             fields: [
+              /*
+               * The same pay-as-you-go notice and acknowledgement the settings
+               * page shows. This is another door onto creating a key, and a
+               * gate with a way around it is not a gate.
+               */
+              ...getTelemetryPayAsYouGoFormFields(),
               {
                 field: {
                   name: true,

--- a/App/FeatureSet/Dashboard/src/Components/Docker/DocumentationCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Docker/DocumentationCard.tsx
@@ -10,6 +10,7 @@ import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import { HOST, HTTP_PROTOCOL } from "Common/UI/Config";
 import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
+import { getTelemetryPayAsYouGoFormFields } from "../Billing/PayAsYouGo";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import { FormType } from "Common/UI/Components/Forms/ModelForm";
 import API from "Common/UI/Utils/API/API";
@@ -261,6 +262,12 @@ const DockerDocumentationCard: FunctionComponent<ComponentProps> = (
             modelType: TelemetryIngestionKey,
             id: "create-ingestion-key",
             fields: [
+              /*
+               * The same pay-as-you-go notice and acknowledgement the settings
+               * page shows. This is another door onto creating a key, and a
+               * gate with a way around it is not a gate.
+               */
+              ...getTelemetryPayAsYouGoFormFields(),
               {
                 field: {
                   name: true,

--- a/App/FeatureSet/Dashboard/src/Components/DockerSwarm/DocumentationCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/DockerSwarm/DocumentationCard.tsx
@@ -10,6 +10,7 @@ import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import { HOST, HTTP_PROTOCOL } from "Common/UI/Config";
 import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
+import { getTelemetryPayAsYouGoFormFields } from "../Billing/PayAsYouGo";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import { FormType } from "Common/UI/Components/Forms/ModelForm";
 import API from "Common/UI/Utils/API/API";
@@ -261,6 +262,12 @@ const DockerSwarmDocumentationCard: FunctionComponent<ComponentProps> = (
             modelType: TelemetryIngestionKey,
             id: "create-ingestion-key",
             fields: [
+              /*
+               * The same pay-as-you-go notice and acknowledgement the settings
+               * page shows. This is another door onto creating a key, and a
+               * gate with a way around it is not a gate.
+               */
+              ...getTelemetryPayAsYouGoFormFields(),
               {
                 field: {
                   name: true,

--- a/App/FeatureSet/Dashboard/src/Components/Host/DocumentationCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Host/DocumentationCard.tsx
@@ -10,6 +10,7 @@ import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import { HOST, HTTP_PROTOCOL } from "Common/UI/Config";
 import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
+import { getTelemetryPayAsYouGoFormFields } from "../Billing/PayAsYouGo";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import { FormType } from "Common/UI/Components/Forms/ModelForm";
 import API from "Common/UI/Utils/API/API";
@@ -324,6 +325,12 @@ const HostDocumentationCard: FunctionComponent<ComponentProps> = (
             modelType: TelemetryIngestionKey,
             id: "create-ingestion-key",
             fields: [
+              /*
+               * The same pay-as-you-go notice and acknowledgement the settings
+               * page shows. This is another door onto creating a key, and a
+               * gate with a way around it is not a gate.
+               */
+              ...getTelemetryPayAsYouGoFormFields(),
               {
                 field: {
                   name: true,

--- a/App/FeatureSet/Dashboard/src/Components/IoT/DocumentationCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/IoT/DocumentationCard.tsx
@@ -10,6 +10,7 @@ import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import { HOST, HTTP_PROTOCOL } from "Common/UI/Config";
 import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
+import { getTelemetryPayAsYouGoFormFields } from "../Billing/PayAsYouGo";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import { FormType } from "Common/UI/Components/Forms/ModelForm";
 import API from "Common/UI/Utils/API/API";
@@ -323,6 +324,12 @@ const IoTDocumentationCard: FunctionComponent<ComponentProps> = (
             modelType: TelemetryIngestionKey,
             id: "create-ingestion-key",
             fields: [
+              /*
+               * The same pay-as-you-go notice and acknowledgement the settings
+               * page shows. This is another door onto creating a key, and a
+               * gate with a way around it is not a gate.
+               */
+              ...getTelemetryPayAsYouGoFormFields(),
               {
                 field: {
                   name: true,

--- a/App/FeatureSet/Dashboard/src/Components/Kubernetes/DocumentationCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Kubernetes/DocumentationCard.tsx
@@ -10,6 +10,7 @@ import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import { HOST, HTTP_PROTOCOL } from "Common/UI/Config";
 import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
+import { getTelemetryPayAsYouGoFormFields } from "../Billing/PayAsYouGo";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import { FormType } from "Common/UI/Components/Forms/ModelForm";
 import API from "Common/UI/Utils/API/API";
@@ -274,6 +275,12 @@ const KubernetesDocumentationCard: FunctionComponent<ComponentProps> = (
             modelType: TelemetryIngestionKey,
             id: "create-ingestion-key",
             fields: [
+              /*
+               * The same pay-as-you-go notice and acknowledgement the settings
+               * page shows. This is another door onto creating a key, and a
+               * gate with a way around it is not a gate.
+               */
+              ...getTelemetryPayAsYouGoFormFields(),
               {
                 field: {
                   name: true,

--- a/App/FeatureSet/Dashboard/src/Components/Podman/DocumentationCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Podman/DocumentationCard.tsx
@@ -10,6 +10,7 @@ import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import { HOST, HTTP_PROTOCOL } from "Common/UI/Config";
 import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
+import { getTelemetryPayAsYouGoFormFields } from "../Billing/PayAsYouGo";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import { FormType } from "Common/UI/Components/Forms/ModelForm";
 import API from "Common/UI/Utils/API/API";
@@ -261,6 +262,12 @@ const PodmanDocumentationCard: FunctionComponent<ComponentProps> = (
             modelType: TelemetryIngestionKey,
             id: "create-ingestion-key",
             fields: [
+              /*
+               * The same pay-as-you-go notice and acknowledgement the settings
+               * page shows. This is another door onto creating a key, and a
+               * gate with a way around it is not a gate.
+               */
+              ...getTelemetryPayAsYouGoFormFields(),
               {
                 field: {
                   name: true,

--- a/App/FeatureSet/Dashboard/src/Components/Proxmox/DocumentationCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Proxmox/DocumentationCard.tsx
@@ -10,6 +10,7 @@ import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import { HOST, HTTP_PROTOCOL } from "Common/UI/Config";
 import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
+import { getTelemetryPayAsYouGoFormFields } from "../Billing/PayAsYouGo";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import { FormType } from "Common/UI/Components/Forms/ModelForm";
 import API from "Common/UI/Utils/API/API";
@@ -261,6 +262,12 @@ const ProxmoxDocumentationCard: FunctionComponent<ComponentProps> = (
             modelType: TelemetryIngestionKey,
             id: "create-ingestion-key",
             fields: [
+              /*
+               * The same pay-as-you-go notice and acknowledgement the settings
+               * page shows. This is another door onto creating a key, and a
+               * gate with a way around it is not a gate.
+               */
+              ...getTelemetryPayAsYouGoFormFields(),
               {
                 field: {
                   name: true,

--- a/App/FeatureSet/Dashboard/src/Components/Recommendations/MonitorRecommendationCreateSideOver.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Recommendations/MonitorRecommendationCreateSideOver.tsx
@@ -23,6 +23,11 @@ import {
   MonitorRecommendationSeverity,
   MonitorRecommendationSeverityMap,
 } from "Common/Types/Monitor/Recommendation/MonitorRecommendationTypes";
+import MonitorType from "Common/Types/Monitor/MonitorType";
+import {
+  MonitorBatchPayAsYouGoConsent,
+  isMonitorBatchConsentRequired,
+} from "../Billing/PayAsYouGo";
 
 export interface ComponentProps {
   selectedRecommendations: Array<MonitorRecommendation>;
@@ -39,6 +44,7 @@ export interface ComponentProps {
   onClose: () => void;
   onSubmit: (
     notificationSettings: MonitorRecommendationNotificationSettings,
+    hasAcknowledgedBilling: boolean,
   ) => void;
 }
 
@@ -103,6 +109,23 @@ const MonitorRecommendationCreateSideOver: FunctionComponent<ComponentProps> = (
     useState<MonitorRecommendationNotificationMode>(
       MonitorRecommendationNotificationMode.Alert,
     );
+
+  /*
+   * Every recommendation in the catalogue is a non-Manual monitor, so on the
+   * Free plan this batch starts a real monthly charge. Same acknowledgement
+   * the single create-monitor form asks for, gating the same action.
+   */
+  const monitorTypes: Array<MonitorType> = props.selectedRecommendations.map(
+    (recommendation: MonitorRecommendation) => {
+      return recommendation.monitorType;
+    },
+  );
+
+  const needsBillingConsent: boolean =
+    isMonitorBatchConsentRequired(monitorTypes);
+
+  const [hasAcknowledgedBilling, setHasAcknowledgedBilling] =
+    useState<boolean>(false);
 
   const [onCallPolicyIds, setOnCallPolicyIds] = useState<Array<ObjectID>>([]);
   const [ownerTeamIds, setOwnerTeamIds] = useState<Array<ObjectID>>([]);
@@ -240,7 +263,9 @@ const MonitorRecommendationCreateSideOver: FunctionComponent<ComponentProps> = (
       size={SideOverSize.Medium}
       submitButtonText={props.isCreating ? "Creating..." : "Create Monitors"}
       submitButtonDisabled={
-        props.isCreating || props.selectedRecommendations.length === 0
+        props.isCreating ||
+        props.selectedRecommendations.length === 0 ||
+        (needsBillingConsent && !hasAcknowledgedBilling)
       }
       onClose={props.onClose}
       onSubmit={() => {
@@ -255,11 +280,19 @@ const MonitorRecommendationCreateSideOver: FunctionComponent<ComponentProps> = (
             alertSeverityIdBySeverity: alertSeverityMap,
           };
 
-        props.onSubmit(notificationSettings);
+        props.onSubmit(notificationSettings, hasAcknowledgedBilling);
       }}
     >
       <div className="space-y-6">
         {props.error ? <ErrorMessage message={props.error} /> : <></>}
+
+        <MonitorBatchPayAsYouGoConsent
+          monitorTypes={monitorTypes}
+          value={hasAcknowledgedBilling}
+          onChange={(value: boolean) => {
+            setHasAcknowledgedBilling(value);
+          }}
+        />
 
         {props.progressMessage ? (
           <div className="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-2 text-sm text-indigo-700">

--- a/App/FeatureSet/Dashboard/src/Components/Recommendations/MonitorRecommendations.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Recommendations/MonitorRecommendations.tsx
@@ -53,6 +53,11 @@ import RecommendationToolbar from "./RecommendationToolbar";
 import RecommendationFilterUtil from "./RecommendationFilterUtil";
 import RecommendationDismissalUtil from "./RecommendationDismissalUtil";
 import MonitorRecommendationCreateSideOver from "./MonitorRecommendationCreateSideOver";
+import {
+  MONITOR_CONSENT_ERROR,
+  MonitorPayAsYouGoCard,
+  isMonitorBatchConsentRequired,
+} from "../Billing/PayAsYouGo";
 import MonitorRecommendationCreateUtil, {
   MonitorRecommendationCreatePlanItem,
 } from "./MonitorRecommendationCreateUtil";
@@ -438,11 +443,13 @@ const MonitorRecommendations: FunctionComponent<ComponentProps> = (
   type CreateFunction = (
     notificationSettings: MonitorRecommendationNotificationSettings,
     creatableRecommendationIds: Array<string>,
+    hasAcknowledgedBilling: boolean,
   ) => Promise<void>;
 
   const createMonitors: CreateFunction = async (
     notificationSettings: MonitorRecommendationNotificationSettings,
     creatableRecommendationIds: Array<string>,
+    hasAcknowledgedBilling: boolean,
   ): Promise<void> => {
     if (!projectDefaults) {
       return;
@@ -461,6 +468,25 @@ const MonitorRecommendations: FunctionComponent<ComponentProps> = (
         defaultMonitorStatusId: projectDefaults.defaultMonitorStatusId,
         notificationSettings: notificationSettings,
       });
+
+    /*
+     * The side over already disables its submit until this is ticked. Repeated
+     * here so the charge cannot be started by a caller that skips the side
+     * over - this loop is the only place in the dashboard that creates
+     * monitors without a ModelForm to validate first.
+     */
+    if (
+      !hasAcknowledgedBilling &&
+      isMonitorBatchConsentRequired(
+        plan.map((item: MonitorRecommendationCreatePlanItem) => {
+          return item.monitor.monitorType as MonitorType;
+        }),
+      )
+    ) {
+      setActionError(MONITOR_CONSENT_ERROR);
+      setIsCreating(false);
+      return;
+    }
 
     let created: number = 0;
 
@@ -666,6 +692,13 @@ const MonitorRecommendations: FunctionComponent<ComponentProps> = (
 
   return (
     <Fragment>
+      {/*
+       * Recommendations only ever propose non-Manual monitors, and this is the
+       * highest-volume way to create them - so a Free plan project sees the
+       * rate here too, and acknowledges it in the side over before the batch
+       * runs.
+       */}
+      <MonitorPayAsYouGoCard />
       <Card
         title="Recommended Monitors"
         description={`Monitors OneUptime recommends for this ${definition.resourceLabel.toLowerCase()}, based on the telemetry the agent already sends. Pick the ones you want, choose who gets paged, and create them in one step.`}
@@ -781,6 +814,7 @@ const MonitorRecommendations: FunctionComponent<ComponentProps> = (
           }}
           onSubmit={(
             notificationSettings: MonitorRecommendationNotificationSettings,
+            hasAcknowledgedBilling: boolean,
           ) => {
             createMonitors(
               notificationSettings,
@@ -789,6 +823,7 @@ const MonitorRecommendations: FunctionComponent<ComponentProps> = (
                   return viewModel.recommendation.recommendationId;
                 },
               ),
+              hasAcknowledgedBilling,
             ).catch((err: Error) => {
               setActionError(API.getFriendlyMessage(err));
               setIsCreating(false);

--- a/App/FeatureSet/Dashboard/src/Components/Telemetry/Documentation.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Telemetry/Documentation.tsx
@@ -12,6 +12,7 @@ import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import { APP_API_URL, HOST, HTTP_PROTOCOL } from "Common/UI/Config";
 import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
+import { getTelemetryPayAsYouGoFormFields } from "../Billing/PayAsYouGo";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import { FormType } from "Common/UI/Components/Forms/ModelForm";
 import API from "Common/UI/Utils/API/API";
@@ -2071,6 +2072,12 @@ const TelemetryDocumentation: FunctionComponent<ComponentProps> = (
             modelType: TelemetryIngestionKey,
             id: "create-ingestion-key",
             fields: [
+              /*
+               * The same pay-as-you-go notice and acknowledgement the settings
+               * page shows. This is the second door onto creating a key, and a
+               * gate with a way around it is not a gate.
+               */
+              ...getTelemetryPayAsYouGoFormFields(),
               {
                 field: {
                   name: true,

--- a/App/FeatureSet/Dashboard/src/Components/TelemetryResource/ResourceDocumentationCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/TelemetryResource/ResourceDocumentationCard.tsx
@@ -10,6 +10,7 @@ import ModelAPI, { ListResult } from "Common/UI/Utils/ModelAPI/ModelAPI";
 import ProjectUtil from "Common/UI/Utils/Project";
 import { HOST, HTTP_PROTOCOL } from "Common/UI/Config";
 import ModelFormModal from "Common/UI/Components/ModelFormModal/ModelFormModal";
+import { getTelemetryPayAsYouGoFormFields } from "../Billing/PayAsYouGo";
 import FormFieldSchemaType from "Common/UI/Components/Forms/Types/FormFieldSchemaType";
 import { FormType } from "Common/UI/Components/Forms/ModelForm";
 import API from "Common/UI/Utils/API/API";
@@ -262,6 +263,12 @@ const ResourceDocumentationCard: FunctionComponent<ComponentProps> = (
             modelType: TelemetryIngestionKey,
             id: "create-ingestion-key",
             fields: [
+              /*
+               * The same pay-as-you-go notice and acknowledgement the settings
+               * page shows. This is another door onto creating a key, and a
+               * gate with a way around it is not a gate.
+               */
+              ...getTelemetryPayAsYouGoFormFields(),
               {
                 field: {
                   name: true,

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Create.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Create.tsx
@@ -73,6 +73,10 @@ import {
 } from "Common/Types/Analytics/RevenueEvent";
 import ProbeUtil from "../../Utils/Probe";
 import MonitorProbeSelectionUtil from "Common/Utils/Monitor/MonitorProbeSelectionUtil";
+import {
+  MonitorPayAsYouGoCard,
+  getMonitorPayAsYouGoFormFields,
+} from "../../Components/Billing/PayAsYouGo";
 
 /*
  * Candidate rolling windows for "create monitor from this explorer view" —
@@ -597,6 +601,12 @@ const MonitorCreate: FunctionComponent<
 
   return (
     <Fragment>
+      {/*
+       * Every monitor type except Manual is metered as an active monitor, so
+       * a Free plan project is told the rate before it picks a type - and has
+       * to acknowledge it below the type picker.
+       */}
+      <MonitorPayAsYouGoCard />
       <Card
         title="Create New Monitor"
         description={
@@ -657,6 +667,12 @@ const MonitorCreate: FunctionComponent<
                   cardSelectOptions:
                     MonitorTypeUtil.monitorTypesAsCategorizedCardSelectOptions(),
                 },
+                /*
+                 * Sits directly under the type picker, on the same step, so
+                 * the charge is acknowledged next to the choice that causes
+                 * it. Empty off the Free plan; hidden for Manual monitors.
+                 */
+                ...getMonitorPayAsYouGoFormFields({ stepId: "monitor-info" }),
                 {
                   field: {
                     monitorSteps: true,

--- a/App/FeatureSet/Dashboard/src/Pages/Settings/TelemetryIngestionKeys.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Settings/TelemetryIngestionKeys.tsx
@@ -5,11 +5,21 @@ import ModelTable from "Common/UI/Components/ModelTable/ModelTable";
 import FieldType from "Common/UI/Components/Types/FieldType";
 import Navigation from "Common/UI/Utils/Navigation";
 import TelemetryIngestionKey from "Common/Models/DatabaseModels/TelemetryIngestionKey";
+import {
+  TelemetryPayAsYouGoCard,
+  getTelemetryPayAsYouGoFormFields,
+} from "../../Components/Billing/PayAsYouGo";
 import React, { Fragment, FunctionComponent, ReactElement } from "react";
 
 const APIKeys: FunctionComponent<PageComponentProps> = (): ReactElement => {
   return (
     <Fragment>
+      {/*
+       * Telemetry is metered and nothing about it is included in the Free
+       * plan, so a Free plan project is told what an ingestion key costs
+       * before it creates one - and has to acknowledge it in the modal.
+       */}
+      <TelemetryPayAsYouGoCard />
       <ModelTable<TelemetryIngestionKey>
         modelType={TelemetryIngestionKey}
         query={{
@@ -34,6 +44,7 @@ const APIKeys: FunctionComponent<PageComponentProps> = (): ReactElement => {
         }}
         noItemsMessage={"No telemetry ingestion keys found."}
         formFields={[
+          ...getTelemetryPayAsYouGoFormFields(),
           {
             field: {
               name: true,

--- a/App/FeatureSet/Dashboard/src/Utils/PayAsYouGo.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/PayAsYouGo.ts
@@ -1,0 +1,35 @@
+import { PlanType } from "Common/Types/Billing/SubscriptionPlan";
+import { BILLING_ENABLED } from "Common/UI/Config";
+import ProjectUtil from "Common/UI/Utils/Project";
+
+/**
+ * Whether this project is on the Free plan of a billed (cloud) deployment -
+ * the one case where a user is about to incur pay-as-you-go charges without
+ * having already agreed to a paid plan.
+ *
+ * Fails CLOSED: billing disabled (self-hosted, where nothing is charged), no
+ * project cached yet, or a plan this deployment does not recognise all return
+ * false. Saying nothing is the right answer when we cannot be sure the user
+ * would be billed - quoting a price to someone who will never see an invoice
+ * is worse than staying quiet.
+ */
+export function isProjectOnFreePlan(): boolean {
+  if (!BILLING_ENABLED) {
+    return false;
+  }
+
+  let currentPlan: PlanType | null = null;
+
+  try {
+    currentPlan = ProjectUtil.getCurrentPlan();
+  } catch {
+    /*
+     * getCurrentPlan throws (BadDataException) when the project carries a
+     * plan id that is not in this deployment's SUBSCRIPTION_PLAN_* table.
+     * That must never take a page down over a billing notice.
+     */
+    return false;
+  }
+
+  return currentPlan === PlanType.Free;
+}

--- a/App/Tests/Dashboard/PayAsYouGoWiring.test.ts
+++ b/App/Tests/Dashboard/PayAsYouGoWiring.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Telemetry ingest and every non-Manual monitor are metered, and nothing about
+ * either is included in the Free plan. The dashboard now says so before the
+ * charge starts, and makes the user acknowledge it.
+ *
+ * The behaviour itself is exercised against the real form in
+ * Common/Tests/App/Dashboard/PayAsYouGoConsentGate.test.tsx. What is pinned
+ * here is the wiring: both notices and both sets of form fields are one-line
+ * call sites that can be dropped in a refactor without breaking a type or a
+ * render, which would silently take the warning away and leave Free plan users
+ * billed with no notice.
+ *
+ * Pinned against source rather than exercised, for the same reason as
+ * StripeOfflineLoading.test.ts: react is a dependency of the Dashboard
+ * package, not of App, so importing these pages here would not resolve.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+function read(...relativeParts: Array<string>): string {
+  return fs.readFileSync(path.join(DASHBOARD_SRC, ...relativeParts), "utf8");
+}
+
+function collectSourceFiles(directory: string): Array<string> {
+  const files: Array<string> = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const absolutePath: string = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(absolutePath));
+      continue;
+    }
+
+    if (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) {
+      files.push(absolutePath);
+    }
+  }
+
+  return files;
+}
+
+describe("Pay as you go wiring", () => {
+  describe("telemetry ingestion keys page", () => {
+    const source: string = read(
+      "Pages",
+      "Settings",
+      "TelemetryIngestionKeys.tsx",
+    );
+
+    test("renders the pay as you go card above the table", () => {
+      expect(source).toContain("<TelemetryPayAsYouGoCard />");
+    });
+
+    test("spreads the notice and consent fields into the create modal's form", () => {
+      expect(source).toContain("...getTelemetryPayAsYouGoFormFields()");
+    });
+
+    test("imports both from the billing component", () => {
+      expect(source).toContain('from "../../Components/Billing/PayAsYouGo"');
+    });
+  });
+
+  describe("telemetry documentation component", () => {
+    const source: string = read("Components", "Telemetry", "Documentation.tsx");
+
+    test("gates its own create key modal too - it is the second door onto the same thing", () => {
+      /*
+       * This component has a ModelFormModal of its own. A consent gate that
+       * only covers the settings page is a gate with a way around it.
+       */
+      expect(source).toContain("...getTelemetryPayAsYouGoFormFields()");
+      expect(source).toContain('from "../Billing/PayAsYouGo"');
+    });
+
+    test("has exactly one create key modal, so one gate is enough", () => {
+      expect(
+        (source.match(/<ModelFormModal<TelemetryIngestionKey>/g) || []).length,
+      ).toBe(1);
+    });
+  });
+
+  describe("every surface that creates an ingestion key is gated", () => {
+    test("no create form for TelemetryIngestionKey exists without the notice fields", () => {
+      /*
+       * Guards against a third door being added later. Any file that builds a
+       * create form over TelemetryIngestionKey has to spread the notice and
+       * consent fields into it.
+       */
+      const creatingFiles: Array<string> = collectSourceFiles(
+        DASHBOARD_SRC,
+      ).filter((file: string) => {
+        const source: string = fs.readFileSync(file, "utf8");
+
+        const buildsACreateForm: boolean =
+          source.includes("<ModelFormModal<TelemetryIngestionKey>") ||
+          (source.includes("ModelTable<TelemetryIngestionKey>") &&
+            source.includes("isCreateable={true}"));
+
+        return buildsACreateForm;
+      });
+
+      expect(creatingFiles.length).toBeGreaterThan(0);
+
+      for (const file of creatingFiles) {
+        expect({
+          file: path.relative(DASHBOARD_SRC, file),
+          gated: fs
+            .readFileSync(file, "utf8")
+            .includes("getTelemetryPayAsYouGoFormFields()"),
+        }).toEqual({ file: path.relative(DASHBOARD_SRC, file), gated: true });
+      }
+    });
+  });
+
+  describe("create monitor page", () => {
+    const source: string = read("Pages", "Monitor", "Create.tsx");
+
+    test("renders the pay as you go card above the create form", () => {
+      expect(source).toContain("<MonitorPayAsYouGoCard />");
+    });
+
+    test("puts the consent field on the step that holds the monitor type picker", () => {
+      /*
+       * The step id matters: the form only validates fields belonging to the
+       * step being submitted, so a consent box parked on a step the user never
+       * submits would never block anything.
+       */
+      expect(source).toContain(
+        'getMonitorPayAsYouGoFormFields({ stepId: "monitor-info" })',
+      );
+
+      // The call site, not the import at the top of the file.
+      const consentIndex: number = source.indexOf(
+        'getMonitorPayAsYouGoFormFields({ stepId: "monitor-info" })',
+      );
+      const monitorTypeIndex: number = source.indexOf(
+        "monitorTypesAsCategorizedCardSelectOptions",
+      );
+
+      expect(monitorTypeIndex).toBeGreaterThan(-1);
+      expect(consentIndex).toBeGreaterThan(monitorTypeIndex);
+    });
+
+    test("declares a monitor-info step for that field to be validated on", () => {
+      expect(source).toContain('id: "monitor-info"');
+    });
+
+    test("imports both from the billing component", () => {
+      expect(source).toContain('from "../../Components/Billing/PayAsYouGo"');
+    });
+  });
+
+  describe("monitor recommendations (bulk create)", () => {
+    const listSource: string = read(
+      "Components",
+      "Recommendations",
+      "MonitorRecommendations.tsx",
+    );
+    const sideOverSource: string = read(
+      "Components",
+      "Recommendations",
+      "MonitorRecommendationCreateSideOver.tsx",
+    );
+
+    test("shows the pay as you go card - this is the largest charge one click can start", () => {
+      expect(listSource).toContain("<MonitorPayAsYouGoCard />");
+    });
+
+    test("disables its submit until the batch charge is acknowledged", () => {
+      expect(sideOverSource).toContain("MonitorBatchPayAsYouGoConsent");
+      expect(sideOverSource).toContain(
+        "needsBillingConsent && !hasAcknowledgedBilling",
+      );
+    });
+
+    test("refuses in the create loop too, not only in the side over", () => {
+      /*
+       * The loop calls ModelAPI.createOrUpdate directly - there is no
+       * ModelForm to validate it - so the guard has to live next to the calls.
+       */
+      expect(listSource).toContain("isMonitorBatchConsentRequired");
+      expect(listSource).toContain("MONITOR_CONSENT_ERROR");
+    });
+  });
+
+  describe("every surface that creates a monitor is gated", () => {
+    test("no create path for Monitor exists without a PayAsYouGo reference", () => {
+      /*
+       * The telemetry half of this change had an invariant like this from the
+       * start; the monitor half did not, which is how the recommendations
+       * bulk-create path was missed. Any file that creates a Monitor has to
+       * reference the pay-as-you-go gate.
+       */
+      const creatingFiles: Array<string> = collectSourceFiles(
+        DASHBOARD_SRC,
+      ).filter((file: string) => {
+        const source: string = fs.readFileSync(file, "utf8");
+
+        return (
+          source.includes("modelType: Monitor,") &&
+          source.includes("FormType.Create")
+        );
+      });
+
+      expect(creatingFiles.length).toBeGreaterThan(0);
+
+      for (const file of creatingFiles) {
+        const relative: string = path.relative(DASHBOARD_SRC, file);
+
+        expect({
+          file: relative,
+          gated: fs.readFileSync(file, "utf8").includes("PayAsYouGo"),
+        }).toEqual({ file: relative, gated: true });
+      }
+    });
+  });
+
+  describe("the notices themselves", () => {
+    const source: string = read("Components", "Billing", "PayAsYouGo.tsx");
+
+    /*
+     * Each of these decides whether a price is shown or a charge is gated, so
+     * each must consult the plan itself rather than trust its caller to. What
+     * they actually render on each plan is covered by
+     * Common/Tests/App/Dashboard/PayAsYouGoNotices.test.tsx; this only pins
+     * that a new entry point cannot be added without its own guard.
+     */
+    const PLAN_GATED_ENTRY_POINTS: Array<string> = [
+      "TelemetryPayAsYouGoCard",
+      "MonitorPayAsYouGoCard",
+      "getTelemetryPayAsYouGoFormFields",
+      "getMonitorPayAsYouGoFormFields",
+      "isMonitorBatchConsentRequired",
+    ];
+
+    test.each(PLAN_GATED_ENTRY_POINTS)("%s is exported", (name: string) => {
+      expect(source).toMatch(new RegExp(`export (const|function) ${name}\\b`));
+    });
+
+    test("has exactly one Free-plan guard per entry point", () => {
+      const gateCount: number = (
+        source.match(/if \(!isProjectOnFreePlan\(\)\)/g) || []
+      ).length;
+
+      expect(gateCount).toBe(PLAN_GATED_ENTRY_POINTS.length);
+    });
+
+    test("quote the rates from the shared pricing constants, not from literals", () => {
+      expect(source).toContain('from "Common/Types/Billing/PayAsYouGoPricing"');
+
+      /*
+       * A hardcoded price in the copy is a price that drifts away from what is
+       * actually billed. There is one source for these numbers.
+       */
+      expect(source).not.toMatch(/\$0\.10/);
+      expect(source).not.toMatch(/\$1 per/);
+    });
+
+    test("gate the submit with customValidation rather than required", () => {
+      /*
+       * The form's `required` check stringifies the value, so an unticked box
+       * reads as the non-empty string "false" and passes it. customValidation
+       * is the only thing that actually blocks - and it only runs when the key
+       * is present, which is what getDefaultValue is for.
+       */
+      expect(source).toContain("customValidation");
+      expect(source).toContain("getDefaultValue");
+    });
+
+    test("use the shared billing predicate for which monitors cost money", () => {
+      expect(source).toContain("isBilledAsActiveMonitor");
+    });
+  });
+});

--- a/Common/Server/Types/Billing/MeteredPlan/AllMeteredPlans.ts
+++ b/Common/Server/Types/Billing/MeteredPlan/AllMeteredPlans.ts
@@ -4,6 +4,19 @@ import ServerMeteredPlan from "./ServerMeteredPlan";
 import TelemetryMeteredPlanType from "./TelemetryMeteredPlan";
 import BadDataException from "../../../../Types/Exception/BadDataException";
 import ProductType from "../../../../Types/MeteredPlan/ProductType";
+import {
+  SESSION_REPLAY_PRICE_IN_USD_PER_GB,
+  TELEMETRY_PRICE_IN_USD_PER_GB,
+  TELEMETRY_PRICE_RETENTION_IN_DAYS,
+} from "../../../../Types/Billing/PayAsYouGoPricing";
+
+/*
+ * Per GB per day, derived from the advertised per-GB-per-15-days rate so the
+ * price the dashboard quotes a Free plan user and the price we actually meter
+ * cannot drift apart.
+ */
+const TELEMETRY_UNIT_COST_IN_USD: number =
+  TELEMETRY_PRICE_IN_USD_PER_GB / TELEMETRY_PRICE_RETENTION_IN_DAYS;
 
 export const ActiveMonitoringMeteredPlan: ActiveMonitoringMeteredPlanType =
   new ActiveMonitoringMeteredPlanType();
@@ -11,25 +24,25 @@ export const ActiveMonitoringMeteredPlan: ActiveMonitoringMeteredPlanType =
 export const LogDataIngestMeteredPlan: TelemetryMeteredPlanType =
   new TelemetryMeteredPlanType({
     productType: ProductType.Logs,
-    unitCostInUSD: 0.1 / 15, // 0.10 per 15 days per GB
+    unitCostInUSD: TELEMETRY_UNIT_COST_IN_USD, // 0.10 per 15 days per GB
   });
 
 export const MetricsDataIngestMeteredPlan: TelemetryMeteredPlanType =
   new TelemetryMeteredPlanType({
     productType: ProductType.Metrics,
-    unitCostInUSD: 0.1 / 15, // 0.10 per 15 days per GB
+    unitCostInUSD: TELEMETRY_UNIT_COST_IN_USD, // 0.10 per 15 days per GB
   });
 
 export const TracesDataIngestMetredPlan: TelemetryMeteredPlanType =
   new TelemetryMeteredPlanType({
     productType: ProductType.Traces,
-    unitCostInUSD: 0.1 / 15, // 0.10 per 15 days per GB
+    unitCostInUSD: TELEMETRY_UNIT_COST_IN_USD, // 0.10 per 15 days per GB
   });
 
 export const ProfilesDataIngestMeteredPlan: TelemetryMeteredPlanType =
   new TelemetryMeteredPlanType({
     productType: ProductType.Profiles,
-    unitCostInUSD: 0.1 / 15, // 0.10 per 15 days per GB
+    unitCostInUSD: TELEMETRY_UNIT_COST_IN_USD, // 0.10 per 15 days per GB
   });
 
 /*
@@ -43,7 +56,8 @@ export const ProfilesDataIngestMeteredPlan: TelemetryMeteredPlanType =
 export const SessionReplayDataIngestMeteredPlan: TelemetryMeteredPlanType =
   new TelemetryMeteredPlanType({
     productType: ProductType.SessionReplay,
-    unitCostInUSD: 2.0 / 15, // 2.00 per 15 days per GB
+    unitCostInUSD:
+      SESSION_REPLAY_PRICE_IN_USD_PER_GB / TELEMETRY_PRICE_RETENTION_IN_DAYS, // 2.00 per 15 days per GB
   });
 
 const AllMeteredPlans: Array<ServerMeteredPlan> = [

--- a/Common/Tests/App/Dashboard/PayAsYouGoConsentGate.test.tsx
+++ b/Common/Tests/App/Dashboard/PayAsYouGoConsentGate.test.tsx
@@ -1,0 +1,543 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { PlanType } from "../../../Types/Billing/SubscriptionPlan";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import Permission, { UserPermission } from "../../../Types/Permission";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import TelemetryIngestionKey from "../../../Models/DatabaseModels/TelemetryIngestionKey";
+import FormFieldSchemaType from "../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import ProjectUtil from "../../../UI/Utils/Project";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import { getJestSpyOn } from "../../Spy";
+
+/*
+ * The consent checkbox is the whole point of the change: on the Free plan a
+ * user must not be able to start a metered charge without saying they
+ * understand it. This suite drives the real ModelForm rather than the field
+ * definitions, because the mechanism is subtle - the form's own `required`
+ * check stringifies values, so an unticked box reads as the non-empty string
+ * "false" and sails straight through it. The gate is a customValidation, and
+ * it only runs at all because getDefaultValue seeds the key.
+ */
+
+const createOrUpdateMock: MockFunction = getJestMockFunction();
+const getItemMock: MockFunction = getJestMockFunction();
+
+jest.mock("../../../UI/Utils/ModelAPI/ModelAPI", () => {
+  return {
+    __esModule: true,
+    default: {
+      getItem: (...args: Array<any>) => {
+        return getItemMock(...args);
+      },
+      createOrUpdate: (...args: Array<any>) => {
+        return createOrUpdateMock(...args);
+      },
+    },
+  };
+});
+
+const OWNER_PERMISSIONS: Array<Permission> = [
+  Permission.Public,
+  Permission.User,
+  Permission.CurrentUser,
+  Permission.ProjectOwner,
+];
+
+jest.mock("../../../UI/Utils/Permission", () => {
+  return {
+    __esModule: true,
+    default: {
+      getAllPermissions: () => {
+        return OWNER_PERMISSIONS;
+      },
+      getProjectPermissions: () => {
+        return {
+          permissions: OWNER_PERMISSIONS.map((permission: Permission) => {
+            return {
+              permission,
+              labelIds: [],
+              _type: "UserPermission",
+            } as UserPermission;
+          }),
+        };
+      },
+      getGlobalPermissions: () => {
+        return { globalPermissions: OWNER_PERMISSIONS };
+      },
+    },
+  };
+});
+
+jest.mock("../../../UI/Utils/User", () => {
+  return {
+    __esModule: true,
+    default: {
+      isMasterAdmin: () => {
+        return false;
+      },
+    },
+  };
+});
+
+interface MutableConfig {
+  billingEnabled: boolean;
+}
+
+const config: MutableConfig = { billingEnabled: true };
+
+(
+  globalThis as unknown as { __payAsYouGoGateConfig: MutableConfig }
+).__payAsYouGoGateConfig = config;
+
+jest.mock("../../../UI/Config", () => {
+  const mocked: Record<string, unknown> = {
+    ...jest.requireActual("../../../UI/Config"),
+  };
+
+  Object.defineProperty(mocked, "BILLING_ENABLED", {
+    get: (): boolean => {
+      return Boolean(
+        (
+          globalThis as unknown as {
+            __payAsYouGoGateConfig: MutableConfig | undefined;
+          }
+        ).__payAsYouGoGateConfig?.billingEnabled,
+      );
+    },
+  });
+
+  return mocked;
+});
+
+// Imported after the mocks above.
+import ModelForm, { FormType } from "../../../UI/Components/Forms/ModelForm";
+import {
+  MONITOR_CONSENT_ERROR,
+  MONITOR_CONSENT_FIELD_KEY,
+  TELEMETRY_CONSENT_ERROR,
+  TELEMETRY_CONSENT_FIELD_KEY,
+  getMonitorPayAsYouGoFormFields,
+  getTelemetryPayAsYouGoFormFields,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo";
+
+/*
+ * These render real forms that validate on every keystroke, so give the waits
+ * room to survive a loaded CI box.
+ */
+const WAIT_TIMEOUT: number = 20000;
+
+type RenderIngestionKeyFormFunction = () => void;
+
+const renderIngestionKeyForm: RenderIngestionKeyFormFunction = (): void => {
+  render(
+    <ModelForm<TelemetryIngestionKey>
+      modelType={TelemetryIngestionKey}
+      id="create-ingestion-key-form"
+      name="Create Ingestion Key"
+      formType={FormType.Create}
+      submitButtonText="Create Ingestion Key"
+      fields={[
+        ...getTelemetryPayAsYouGoFormFields(),
+        {
+          field: { name: true },
+          title: "Name",
+          fieldType: FormFieldSchemaType.Text,
+          required: true,
+          dataTestId: "ingestion-key-name",
+        },
+      ]}
+    />,
+  );
+};
+
+type RenderMonitorFormFunction = (monitorType: MonitorType) => void;
+
+const renderMonitorForm: RenderMonitorFormFunction = (
+  monitorType: MonitorType,
+): void => {
+  render(
+    <ModelForm<Monitor>
+      modelType={Monitor}
+      id="create-monitor-form"
+      name="Create New Monitor"
+      formType={FormType.Create}
+      submitButtonText="Create Monitor"
+      initialValues={{ monitorType: monitorType } as any}
+      steps={[{ title: "Monitor Info", id: "monitor-info" }]}
+      fields={[
+        {
+          field: { name: true },
+          stepId: "monitor-info",
+          title: "Name",
+          fieldType: FormFieldSchemaType.Text,
+          required: true,
+          dataTestId: "monitor-name",
+        },
+        ...getMonitorPayAsYouGoFormFields({ stepId: "monitor-info" }),
+      ]}
+    />,
+  );
+};
+
+describe("Pay as you go consent gate", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    config.billingEnabled = true;
+    createOrUpdateMock.mockReset();
+    getItemMock.mockReset();
+    createOrUpdateMock.mockResolvedValue({ data: {} });
+    getJestSpyOn(ProjectUtil, "getCurrentPlan").mockReturnValue(PlanType.Free);
+  });
+
+  describe("creating a telemetry ingestion key on the Free plan", () => {
+    it("shows the pay as you go notice and the consent box in the form", async () => {
+      renderIngestionKeyForm();
+
+      expect(
+        await screen.findByText(
+          "Telemetry is a pay as you go feature",
+          {},
+          { timeout: WAIT_TIMEOUT },
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("telemetry-pay-as-you-go-consent"),
+      ).toBeInTheDocument();
+    });
+
+    it("refuses to create the key until the charge is acknowledged", async () => {
+      renderIngestionKeyForm();
+
+      await userEvent.type(
+        await screen.findByTestId(
+          "ingestion-key-name",
+          {},
+          { timeout: WAIT_TIMEOUT },
+        ),
+        "Production",
+      );
+
+      await userEvent.click(screen.getByText("Create Ingestion Key"));
+
+      await waitFor(
+        () => {
+          expect(screen.getByText(TELEMETRY_CONSENT_ERROR)).toBeInTheDocument();
+        },
+        { timeout: WAIT_TIMEOUT },
+      );
+
+      expect(createOrUpdateMock).not.toHaveBeenCalled();
+    });
+
+    it("creates the key once the box is ticked", async () => {
+      renderIngestionKeyForm();
+
+      await userEvent.type(
+        await screen.findByTestId(
+          "ingestion-key-name",
+          {},
+          { timeout: WAIT_TIMEOUT },
+        ),
+        "Production",
+      );
+      await userEvent.click(
+        screen.getByTestId("telemetry-pay-as-you-go-consent"),
+      );
+      await userEvent.click(screen.getByText("Create Ingestion Key"));
+
+      await waitFor(
+        () => {
+          expect(createOrUpdateMock).toHaveBeenCalled();
+        },
+        { timeout: WAIT_TIMEOUT },
+      );
+    });
+
+    it("blocks again if the box is ticked and then unticked", async () => {
+      /*
+       * The regression this guards: an unticked box that has been touched
+       * holds boolean false, which the form's `required` check would accept.
+       */
+      renderIngestionKeyForm();
+
+      await userEvent.type(
+        await screen.findByTestId(
+          "ingestion-key-name",
+          {},
+          { timeout: WAIT_TIMEOUT },
+        ),
+        "Production",
+      );
+
+      const consent: HTMLElement = screen.getByTestId(
+        "telemetry-pay-as-you-go-consent",
+      );
+
+      await userEvent.click(consent);
+      await userEvent.click(consent);
+      await userEvent.click(screen.getByText("Create Ingestion Key"));
+
+      await waitFor(
+        () => {
+          expect(screen.getByText(TELEMETRY_CONSENT_ERROR)).toBeInTheDocument();
+        },
+        { timeout: WAIT_TIMEOUT },
+      );
+
+      expect(createOrUpdateMock).not.toHaveBeenCalled();
+    });
+
+    it("does not send the acknowledgement to the API", async () => {
+      renderIngestionKeyForm();
+
+      await userEvent.type(
+        await screen.findByTestId(
+          "ingestion-key-name",
+          {},
+          { timeout: WAIT_TIMEOUT },
+        ),
+        "Production",
+      );
+      await userEvent.click(
+        screen.getByTestId("telemetry-pay-as-you-go-consent"),
+      );
+      await userEvent.click(screen.getByText("Create Ingestion Key"));
+
+      await waitFor(
+        () => {
+          expect(createOrUpdateMock).toHaveBeenCalled();
+        },
+        { timeout: WAIT_TIMEOUT },
+      );
+
+      const call: any = createOrUpdateMock.mock.calls[0]?.[0];
+
+      /*
+       * The consent is a UI gate, not data. It has no column, so sending it
+       * would be an unknown property on the create payload.
+       */
+      expect(call?.miscDataProps ?? {}).not.toHaveProperty(
+        TELEMETRY_CONSENT_FIELD_KEY,
+      );
+      expect(JSON.stringify(call?.model ?? {})).not.toContain(
+        TELEMETRY_CONSENT_FIELD_KEY,
+      );
+    });
+  });
+
+  describe("creating a telemetry ingestion key off the Free plan", () => {
+    it("asks for nothing extra on a paid plan", async () => {
+      getJestSpyOn(ProjectUtil, "getCurrentPlan").mockReturnValue(
+        PlanType.Growth,
+      );
+
+      renderIngestionKeyForm();
+
+      await userEvent.type(
+        await screen.findByTestId(
+          "ingestion-key-name",
+          {},
+          { timeout: WAIT_TIMEOUT },
+        ),
+        "Production",
+      );
+
+      expect(
+        screen.queryByTestId("telemetry-pay-as-you-go-consent"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Telemetry is a pay as you go feature"),
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByText("Create Ingestion Key"));
+
+      await waitFor(
+        () => {
+          expect(createOrUpdateMock).toHaveBeenCalled();
+        },
+        { timeout: WAIT_TIMEOUT },
+      );
+    });
+
+    it("asks for nothing extra on a self-hosted install", async () => {
+      config.billingEnabled = false;
+
+      renderIngestionKeyForm();
+
+      await userEvent.type(
+        await screen.findByTestId(
+          "ingestion-key-name",
+          {},
+          { timeout: WAIT_TIMEOUT },
+        ),
+        "Production",
+      );
+
+      expect(
+        screen.queryByTestId("telemetry-pay-as-you-go-consent"),
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByText("Create Ingestion Key"));
+
+      await waitFor(
+        () => {
+          expect(createOrUpdateMock).toHaveBeenCalled();
+        },
+        { timeout: WAIT_TIMEOUT },
+      );
+    });
+  });
+
+  describe("creating a monitor on the Free plan", () => {
+    it("refuses to create a billed monitor until the charge is acknowledged", async () => {
+      renderMonitorForm(MonitorType.Website);
+
+      await userEvent.type(
+        await screen.findByTestId(
+          "monitor-name",
+          {},
+          { timeout: WAIT_TIMEOUT },
+        ),
+        "Marketing site",
+      );
+
+      expect(
+        screen.getByTestId("monitor-pay-as-you-go-consent"),
+      ).toBeInTheDocument();
+
+      await userEvent.click(screen.getByText("Create Monitor"));
+
+      await waitFor(
+        () => {
+          expect(screen.getByText(MONITOR_CONSENT_ERROR)).toBeInTheDocument();
+        },
+        { timeout: WAIT_TIMEOUT },
+      );
+
+      expect(createOrUpdateMock).not.toHaveBeenCalled();
+    });
+
+    it("creates the billed monitor once the box is ticked", async () => {
+      renderMonitorForm(MonitorType.Website);
+
+      await userEvent.type(
+        await screen.findByTestId(
+          "monitor-name",
+          {},
+          { timeout: WAIT_TIMEOUT },
+        ),
+        "Marketing site",
+      );
+      await userEvent.click(
+        screen.getByTestId("monitor-pay-as-you-go-consent"),
+      );
+      await userEvent.click(screen.getByText("Create Monitor"));
+
+      await waitFor(
+        () => {
+          expect(createOrUpdateMock).toHaveBeenCalled();
+        },
+        { timeout: WAIT_TIMEOUT },
+      );
+
+      const call: any = createOrUpdateMock.mock.calls[0]?.[0];
+
+      expect(call?.miscDataProps ?? {}).not.toHaveProperty(
+        MONITOR_CONSENT_FIELD_KEY,
+      );
+    });
+
+    it("asks nothing of a Manual monitor - those are free", async () => {
+      renderMonitorForm(MonitorType.Manual);
+
+      await userEvent.type(
+        await screen.findByTestId(
+          "monitor-name",
+          {},
+          { timeout: WAIT_TIMEOUT },
+        ),
+        "Runbook step",
+      );
+
+      expect(
+        screen.queryByTestId("monitor-pay-as-you-go-consent"),
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByText("Create Monitor"));
+
+      await waitFor(
+        () => {
+          expect(createOrUpdateMock).toHaveBeenCalled();
+        },
+        { timeout: WAIT_TIMEOUT },
+      );
+    });
+
+    it.each([
+      MonitorType.API,
+      MonitorType.Logs,
+      MonitorType.IncomingRequest,
+      MonitorType.SSLCertificate,
+    ])(
+      "blocks %s too - every non-Manual type is billed",
+      async (monitorType: MonitorType) => {
+        renderMonitorForm(monitorType);
+
+        await userEvent.type(
+          await screen.findByTestId(
+            "monitor-name",
+            {},
+            { timeout: WAIT_TIMEOUT },
+          ),
+          "Something",
+        );
+        await userEvent.click(screen.getByText("Create Monitor"));
+
+        await waitFor(
+          () => {
+            expect(screen.getByText(MONITOR_CONSENT_ERROR)).toBeInTheDocument();
+          },
+          { timeout: WAIT_TIMEOUT },
+        );
+
+        expect(createOrUpdateMock).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe("creating a monitor off the Free plan", () => {
+    it("asks for nothing extra on a paid plan", async () => {
+      getJestSpyOn(ProjectUtil, "getCurrentPlan").mockReturnValue(
+        PlanType.Growth,
+      );
+
+      renderMonitorForm(MonitorType.Website);
+
+      await userEvent.type(
+        await screen.findByTestId(
+          "monitor-name",
+          {},
+          { timeout: WAIT_TIMEOUT },
+        ),
+        "Marketing site",
+      );
+
+      expect(
+        screen.queryByTestId("monitor-pay-as-you-go-consent"),
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByText("Create Monitor"));
+
+      await waitFor(
+        () => {
+          expect(createOrUpdateMock).toHaveBeenCalled();
+        },
+        { timeout: WAIT_TIMEOUT },
+      );
+    });
+  });
+});

--- a/Common/Tests/App/Dashboard/PayAsYouGoFreePlan.test.ts
+++ b/Common/Tests/App/Dashboard/PayAsYouGoFreePlan.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { PlanType } from "../../../Types/Billing/SubscriptionPlan";
+import ProjectUtil from "../../../UI/Utils/Project";
+import { getJestSpyOn } from "../../Spy";
+
+/*
+ * isProjectOnFreePlan decides whether a user is shown a price and made to
+ * acknowledge a charge. Two failure directions matter and they are not
+ * symmetric: quoting money to a self-hosted user who will never be invoiced is
+ * a lie, and blocking their create button over it is a bug. So the predicate
+ * fails closed, and every "we are not sure" path is pinned below.
+ */
+
+interface MutableConfig {
+  billingEnabled: boolean;
+}
+
+const config: MutableConfig = { billingEnabled: true };
+
+(
+  globalThis as unknown as { __payAsYouGoConfig: MutableConfig }
+).__payAsYouGoConfig = config;
+
+/*
+ * BILLING_ENABLED is a module-scope const read at import time, so it has to be
+ * switchable per test rather than per file. defineProperty rather than a
+ * getter in the object literal: a literal getter is read once while the object
+ * is built, which would freeze the value at mock time.
+ */
+jest.mock("../../../UI/Config", () => {
+  const mocked: Record<string, unknown> = {
+    ...jest.requireActual("../../../UI/Config"),
+  };
+
+  Object.defineProperty(mocked, "BILLING_ENABLED", {
+    get: (): boolean => {
+      return Boolean(
+        (
+          globalThis as unknown as {
+            __payAsYouGoConfig: MutableConfig | undefined;
+          }
+        ).__payAsYouGoConfig?.billingEnabled,
+      );
+    },
+  });
+
+  return mocked;
+});
+
+// Imported after the mock above so it picks the switchable BILLING_ENABLED up.
+import { isProjectOnFreePlan } from "../../../../App/FeatureSet/Dashboard/src/Utils/PayAsYouGo";
+
+describe("isProjectOnFreePlan", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    config.billingEnabled = true;
+  });
+
+  describe("on a billed (cloud) deployment", () => {
+    it("is true on the Free plan - the one plan that pays as it goes", () => {
+      getJestSpyOn(ProjectUtil, "getCurrentPlan").mockReturnValue(
+        PlanType.Free,
+      );
+
+      expect(isProjectOnFreePlan()).toBe(true);
+    });
+
+    it.each([PlanType.Growth, PlanType.Scale, PlanType.Enterprise])(
+      "is false on the %s plan - that project already agreed to be billed",
+      (plan: PlanType) => {
+        getJestSpyOn(ProjectUtil, "getCurrentPlan").mockReturnValue(plan);
+
+        expect(isProjectOnFreePlan()).toBe(false);
+      },
+    );
+
+    it("is false when no plan is known yet - the project is not cached", () => {
+      getJestSpyOn(ProjectUtil, "getCurrentPlan").mockReturnValue(null);
+
+      expect(isProjectOnFreePlan()).toBe(false);
+    });
+
+    it("is false, rather than throwing, when the plan id is not in this deployment's plan table", () => {
+      /*
+       * getCurrentPlan raises BadDataException for a plan id with no
+       * SUBSCRIPTION_PLAN_* entry. A billing notice must never be able to take
+       * a page down.
+       */
+      getJestSpyOn(ProjectUtil, "getCurrentPlan").mockImplementation(() => {
+        throw new BadDataException("Plan ID is invalid");
+      });
+
+      expect(() => {
+        return isProjectOnFreePlan();
+      }).not.toThrow();
+      expect(isProjectOnFreePlan()).toBe(false);
+    });
+  });
+
+  describe("on a self-hosted install (billing disabled)", () => {
+    beforeEach(() => {
+      config.billingEnabled = false;
+    });
+
+    it("is false even though there is no paid plan - nothing is charged", () => {
+      getJestSpyOn(ProjectUtil, "getCurrentPlan").mockReturnValue(
+        PlanType.Free,
+      );
+
+      expect(isProjectOnFreePlan()).toBe(false);
+    });
+
+    it("does not even ask what the plan is", () => {
+      const getCurrentPlan: jest.SpyInstance<any, any> = getJestSpyOn(
+        ProjectUtil,
+        "getCurrentPlan",
+      );
+
+      isProjectOnFreePlan();
+
+      expect(getCurrentPlan).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/Common/Tests/App/Dashboard/PayAsYouGoNotices.test.tsx
+++ b/Common/Tests/App/Dashboard/PayAsYouGoNotices.test.tsx
@@ -1,0 +1,610 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as React from "react";
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import { PlanType } from "../../../Types/Billing/SubscriptionPlan";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import TelemetryIngestionKey from "../../../Models/DatabaseModels/TelemetryIngestionKey";
+import FormFieldSchemaType from "../../../UI/Components/Forms/Types/FormFieldSchemaType";
+import FormValues from "../../../UI/Components/Forms/Types/FormValues";
+import { ModelField } from "../../../UI/Components/Forms/ModelForm";
+import ProjectUtil from "../../../UI/Utils/Project";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import { getJestSpyOn } from "../../Spy";
+
+/*
+ * The pay-as-you-go notices are the only warning a Free plan user gets before
+ * a charge starts. They have to appear for exactly one audience - Free plan on
+ * a billed deployment - and they have to quote the real rate.
+ */
+
+interface MutableConfig {
+  billingEnabled: boolean;
+}
+
+const config: MutableConfig = { billingEnabled: true };
+
+(
+  globalThis as unknown as { __payAsYouGoNoticeConfig: MutableConfig }
+).__payAsYouGoNoticeConfig = config;
+
+jest.mock("../../../UI/Config", () => {
+  const mocked: Record<string, unknown> = {
+    ...jest.requireActual("../../../UI/Config"),
+  };
+
+  Object.defineProperty(mocked, "BILLING_ENABLED", {
+    get: (): boolean => {
+      return Boolean(
+        (
+          globalThis as unknown as {
+            __payAsYouGoNoticeConfig: MutableConfig | undefined;
+          }
+        ).__payAsYouGoNoticeConfig?.billingEnabled,
+      );
+    },
+  });
+
+  return mocked;
+});
+
+// Imported after the mock so the components read the switchable flag.
+import {
+  ACTIVE_MONITOR_PRICE_TEXT,
+  MONITOR_CONSENT_ERROR,
+  MONITOR_CONSENT_FIELD_KEY,
+  MonitorBatchPayAsYouGoConsent,
+  MonitorPayAsYouGoCard,
+  SESSION_REPLAY_PRICE_PER_GB_TEXT,
+  TELEMETRY_CONSENT_ERROR,
+  TELEMETRY_CONSENT_FIELD_KEY,
+  TELEMETRY_PRICE_PER_GB_TEXT,
+  TelemetryPayAsYouGoCard,
+  getMonitorBatchPriceSentence,
+  getMonitorPayAsYouGoFormFields,
+  getTelemetryPayAsYouGoFormFields,
+  isMonitorBatchConsentRequired,
+  validateMonitorConsent,
+  validateTelemetryConsent,
+} from "../../../../App/FeatureSet/Dashboard/src/Components/Billing/PayAsYouGo";
+
+type SetPlanFunction = (plan: PlanType | null) => void;
+
+const setPlan: SetPlanFunction = (plan: PlanType | null): void => {
+  getJestSpyOn(ProjectUtil, "getCurrentPlan").mockReturnValue(plan);
+};
+
+describe("Pay as you go notices", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    config.billingEnabled = true;
+    setPlan(PlanType.Free);
+  });
+
+  describe("TelemetryPayAsYouGoCard", () => {
+    it("tells a Free plan project that telemetry is pay as you go, and what it costs", () => {
+      render(<TelemetryPayAsYouGoCard />);
+
+      expect(
+        screen.getByText("Telemetry is a pay as you go feature"),
+      ).toBeInTheDocument();
+
+      const card: HTMLElement = screen.getByTestId(
+        "telemetry-pay-as-you-go-card",
+      );
+
+      expect(card).toHaveTextContent("$0.10");
+      expect(card).toHaveTextContent("per GB ingested (15 day retention)");
+      expect(card).toHaveTextContent("Pay as you go");
+      expect(card).toHaveTextContent(
+        "$0.10 per GB ingested, with 15 day retention",
+      );
+    });
+
+    it("also quotes the session replay rate, which rides on the same key at 20x", () => {
+      /*
+       * Session replay is metered at $2.00/GB through the same ingestion key.
+       * A card that quotes only $0.10 invites a user to plan around a bill
+       * twenty times smaller than the one they will get.
+       */
+      render(<TelemetryPayAsYouGoCard />);
+
+      const card: HTMLElement = screen.getByTestId(
+        "telemetry-pay-as-you-go-card",
+      );
+
+      expect(card).toHaveTextContent("Session replay recordings are billed at");
+      expect(card).toHaveTextContent("$2 per GB, with 15 day retention");
+      expect(card).toHaveTextContent("Starting at");
+    });
+
+    it("says the charge stops when the key is deleted, so the notice is not just a threat", () => {
+      render(<TelemetryPayAsYouGoCard />);
+
+      expect(
+        screen.getByTestId("telemetry-pay-as-you-go-card"),
+      ).toHaveTextContent("delete the key, and the charge stops");
+    });
+
+    it("links out to the public pricing page", async () => {
+      const open: jest.SpyInstance<any, any> = getJestSpyOn(window, "open");
+      open.mockImplementation(() => {
+        return null;
+      });
+
+      render(<TelemetryPayAsYouGoCard />);
+
+      await userEvent.click(screen.getByText("View pricing"));
+
+      expect(open).toHaveBeenCalledWith(
+        "https://oneuptime.com/pricing",
+        "_blank",
+      );
+    });
+
+    it.each([PlanType.Growth, PlanType.Scale, PlanType.Enterprise])(
+      "renders nothing on the %s plan",
+      (plan: PlanType) => {
+        setPlan(plan);
+
+        const { container }: { container: HTMLElement } = render(
+          <TelemetryPayAsYouGoCard />,
+        );
+
+        expect(container).toBeEmptyDOMElement();
+      },
+    );
+
+    it("renders nothing on a self-hosted install", () => {
+      config.billingEnabled = false;
+
+      const { container }: { container: HTMLElement } = render(
+        <TelemetryPayAsYouGoCard />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe("MonitorPayAsYouGoCard", () => {
+    it("tells a Free plan project every monitor except Manual is billed, and at what rate", () => {
+      render(<MonitorPayAsYouGoCard />);
+
+      expect(
+        screen.getByText("Monitors are a pay as you go feature"),
+      ).toBeInTheDocument();
+
+      const card: HTMLElement = screen.getByTestId(
+        "monitor-pay-as-you-go-card",
+      );
+
+      expect(card).toHaveTextContent("$1");
+      expect(card).toHaveTextContent("per monitor per month");
+      expect(card).toHaveTextContent(
+        "Every monitor type except Manual is an active monitor",
+      );
+      expect(card).toHaveTextContent(
+        "Manual monitors are always free, and unlimited.",
+      );
+    });
+
+    it.each([PlanType.Growth, PlanType.Scale, PlanType.Enterprise])(
+      "renders nothing on the %s plan",
+      (plan: PlanType) => {
+        setPlan(plan);
+
+        const { container }: { container: HTMLElement } = render(
+          <MonitorPayAsYouGoCard />,
+        );
+
+        expect(container).toBeEmptyDOMElement();
+      },
+    );
+
+    it("renders nothing on a self-hosted install", () => {
+      config.billingEnabled = false;
+
+      const { container }: { container: HTMLElement } = render(
+        <MonitorPayAsYouGoCard />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders nothing when the plan is not known yet", () => {
+      setPlan(null);
+
+      const { container }: { container: HTMLElement } = render(
+        <MonitorPayAsYouGoCard />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe("quoted rates match the pricing constants", () => {
+    it("uses the advertised figures verbatim", () => {
+      expect(TELEMETRY_PRICE_PER_GB_TEXT).toBe("$0.10");
+      expect(SESSION_REPLAY_PRICE_PER_GB_TEXT).toBe("$2");
+      expect(ACTIVE_MONITOR_PRICE_TEXT).toBe("$1");
+      expect(MONITOR_CONSENT_ERROR).toContain("$1");
+    });
+
+    it("does not put a single per-GB rate in the telemetry consent error", () => {
+      /*
+       * Two different per-GB rates travel on one ingestion key, so any single
+       * figure in a message about "telemetry" is wrong for one of them. The
+       * error stays rate-free and the rates live next to the checkbox.
+       */
+      expect(TELEMETRY_CONSENT_ERROR).not.toContain("$");
+      expect(TELEMETRY_CONSENT_ERROR).toContain("billed as you use it");
+    });
+  });
+
+  describe("getTelemetryPayAsYouGoFormFields", () => {
+    it("adds a notice and a consent checkbox on the Free plan", () => {
+      const fields: Array<ModelField<TelemetryIngestionKey>> =
+        getTelemetryPayAsYouGoFormFields();
+
+      expect(fields).toHaveLength(2);
+      expect(fields[0]?.fieldType).toBe(FormFieldSchemaType.CustomComponent);
+      expect(fields[1]?.fieldType).toBe(FormFieldSchemaType.Checkbox);
+    });
+
+    it("renders the modal notice with the rate and a pricing link", () => {
+      const noticeField: ModelField<TelemetryIngestionKey> =
+        getTelemetryPayAsYouGoFormFields()[0]!;
+
+      render(
+        <div>
+          {noticeField.getCustomElement!(
+            {} as FormValues<TelemetryIngestionKey>,
+            {},
+          )}
+        </div>,
+      );
+
+      expect(
+        screen.getByText("Telemetry is a pay as you go feature"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("See pay as you go pricing").closest("a"),
+      ).toHaveAttribute("href", "https://oneuptime.com/pricing");
+    });
+
+    it("names both per-GB rates in the modal notice and on the consent box", () => {
+      const [noticeField, consentField]: Array<
+        ModelField<TelemetryIngestionKey>
+      > = getTelemetryPayAsYouGoFormFields() as [
+        ModelField<TelemetryIngestionKey>,
+        ModelField<TelemetryIngestionKey>,
+      ];
+
+      const { container }: { container: HTMLElement } = render(
+        <div>
+          {noticeField.getCustomElement!(
+            {} as FormValues<TelemetryIngestionKey>,
+            {},
+          )}
+        </div>,
+      );
+
+      expect(container.textContent).toContain("$0.10 per GB ingested");
+      expect(container.textContent).toContain("$2 per GB");
+
+      /*
+       * The title is the sentence the user affirms by ticking, so it must not
+       * carry a rate that is wrong for half the data the key accepts.
+       */
+      expect(consentField.title).not.toContain("$");
+      expect(String(consentField.description)).toContain("$0.10 per GB");
+      expect(String(consentField.description)).toContain("$2 per GB");
+    });
+
+    it("keeps the consent value out of the API payload", () => {
+      const consentField: ModelField<TelemetryIngestionKey> =
+        getTelemetryPayAsYouGoFormFields()[1]!;
+
+      /*
+       * overrideField with no overrideFieldKey is what makes this a purely
+       * client-side field: ModelForm builds the payload from `field`, and
+       * miscDataProps from `overrideFieldKey`. Neither is set to a real key.
+       */
+      expect(consentField.field).toBeUndefined();
+      expect(consentField.overrideFieldKey).toBeUndefined();
+      expect(consentField.overrideField).toEqual({
+        [TELEMETRY_CONSENT_FIELD_KEY]: true,
+      });
+      expect(consentField.showEvenIfPermissionDoesNotExist).toBe(true);
+    });
+
+    it("seeds the consent value as false so validation actually runs on it", () => {
+      const consentField: ModelField<TelemetryIngestionKey> =
+        getTelemetryPayAsYouGoFormFields()[1]!;
+
+      /*
+       * The form skips customValidation for keys that are absent from its
+       * values, and a plain `defaultValue: false` is falsy and seeds nothing.
+       * getDefaultValue is the only thing that puts the key there.
+       */
+      expect(consentField.getDefaultValue).toBeDefined();
+      expect(
+        consentField.getDefaultValue!({} as FormValues<TelemetryIngestionKey>),
+      ).toBe(false);
+      expect(consentField.required).toBe(true);
+    });
+
+    it("does not touch the edit form - the key is only created once", () => {
+      for (const field of getTelemetryPayAsYouGoFormFields()) {
+        expect(field.doNotShowWhenEditing).toBe(true);
+      }
+    });
+
+    it.each([PlanType.Growth, PlanType.Scale, PlanType.Enterprise])(
+      "adds nothing on the %s plan",
+      (plan: PlanType) => {
+        setPlan(plan);
+
+        expect(getTelemetryPayAsYouGoFormFields()).toEqual([]);
+      },
+    );
+
+    it("adds nothing on a self-hosted install", () => {
+      config.billingEnabled = false;
+
+      expect(getTelemetryPayAsYouGoFormFields()).toEqual([]);
+    });
+  });
+
+  describe("getMonitorPayAsYouGoFormFields", () => {
+    it("adds one consent checkbox, on the step it was asked for", () => {
+      const fields: Array<ModelField<Monitor>> = getMonitorPayAsYouGoFormFields(
+        { stepId: "monitor-info" },
+      );
+
+      expect(fields).toHaveLength(1);
+      expect(fields[0]?.fieldType).toBe(FormFieldSchemaType.Checkbox);
+      expect(fields[0]?.stepId).toBe("monitor-info");
+      expect(fields[0]?.overrideField).toEqual({
+        [MONITOR_CONSENT_FIELD_KEY]: true,
+      });
+      expect(fields[0]?.overrideFieldKey).toBeUndefined();
+    });
+
+    it("is shown for billed monitor types and hidden for Manual", () => {
+      const showIf: (values: FormValues<Monitor>) => boolean =
+        getMonitorPayAsYouGoFormFields({ stepId: "monitor-info" })[0]!.showIf!;
+
+      expect(
+        showIf({ monitorType: MonitorType.Manual } as FormValues<Monitor>),
+      ).toBe(false);
+
+      for (const monitorType of [
+        MonitorType.Website,
+        MonitorType.API,
+        MonitorType.Logs,
+        MonitorType.IncomingRequest,
+        MonitorType.NetworkDevice,
+      ]) {
+        expect(
+          showIf({ monitorType: monitorType } as FormValues<Monitor>),
+        ).toBe(true);
+      }
+    });
+
+    it.each([PlanType.Growth, PlanType.Scale, PlanType.Enterprise])(
+      "adds nothing on the %s plan",
+      (plan: PlanType) => {
+        setPlan(plan);
+
+        expect(
+          getMonitorPayAsYouGoFormFields({ stepId: "monitor-info" }),
+        ).toEqual([]);
+      },
+    );
+
+    it("adds nothing on a self-hosted install", () => {
+      config.billingEnabled = false;
+
+      expect(
+        getMonitorPayAsYouGoFormFields({ stepId: "monitor-info" }),
+      ).toEqual([]);
+    });
+  });
+
+  describe("bulk monitor creation (recommendations)", () => {
+    it("needs consent when any monitor in the batch is billed", () => {
+      expect(
+        isMonitorBatchConsentRequired([
+          MonitorType.Manual,
+          MonitorType.Kubernetes,
+        ]),
+      ).toBe(true);
+      expect(isMonitorBatchConsentRequired([MonitorType.Host])).toBe(true);
+    });
+
+    it("needs no consent for an all-Manual or empty batch", () => {
+      expect(isMonitorBatchConsentRequired([MonitorType.Manual])).toBe(false);
+      expect(isMonitorBatchConsentRequired([])).toBe(false);
+    });
+
+    it.each([PlanType.Growth, PlanType.Scale, PlanType.Enterprise])(
+      "needs no consent on the %s plan",
+      (plan: PlanType) => {
+        setPlan(plan);
+
+        expect(isMonitorBatchConsentRequired([MonitorType.Kubernetes])).toBe(
+          false,
+        );
+      },
+    );
+
+    it("needs no consent on a self-hosted install", () => {
+      config.billingEnabled = false;
+
+      expect(isMonitorBatchConsentRequired([MonitorType.Kubernetes])).toBe(
+        false,
+      );
+    });
+
+    it("quotes the batch total, counting only the billed monitors", () => {
+      const sentence: string = getMonitorBatchPriceSentence([
+        MonitorType.Kubernetes,
+        MonitorType.Host,
+        MonitorType.Docker,
+        MonitorType.Manual,
+      ]);
+
+      /*
+       * "up to", because the Free plan also caps active monitors - a batch
+       * that hits the cap is rejected part way rather than billed in full.
+       */
+      expect(sentence).toContain("Creating 3 monitors");
+      expect(sentence).toContain("adds up to $3 per month");
+      expect(sentence).toContain("$1 per monitor per month");
+    });
+
+    it("says monitor, not monitors, for a batch of one", () => {
+      expect(getMonitorBatchPriceSentence([MonitorType.Host])).toContain(
+        "Creating 1 monitor adds up to $1 per month",
+      );
+    });
+
+    it("renders a checkbox carrying the batch total and a pricing link", () => {
+      render(
+        <MonitorBatchPayAsYouGoConsent
+          monitorTypes={[MonitorType.Kubernetes, MonitorType.Host]}
+          value={false}
+          onChange={() => {}}
+        />,
+      );
+
+      const notice: HTMLElement = screen.getByTestId(
+        "monitor-batch-pay-as-you-go-notice",
+      );
+
+      expect(notice).toHaveTextContent("adds up to $2 per month");
+      expect(
+        screen.getByTestId("monitor-batch-pay-as-you-go-consent"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("See pay as you go pricing").closest("a"),
+      ).toHaveAttribute("href", "https://oneuptime.com/pricing");
+    });
+
+    it("reports ticks back to the caller, which is what unlocks its submit", async () => {
+      const onChange: MockFunction = getJestMockFunction();
+
+      render(
+        <MonitorBatchPayAsYouGoConsent
+          monitorTypes={[MonitorType.Kubernetes]}
+          value={false}
+          onChange={onChange as (value: boolean) => void}
+        />,
+      );
+
+      await userEvent.click(
+        screen.getByTestId("monitor-batch-pay-as-you-go-consent"),
+      );
+
+      // Checkbox also passes an "indeterminate" second argument; only the
+      // first one is the answer.
+      expect(onChange.mock.calls[0]?.[0]).toBe(true);
+    });
+
+    it("renders nothing for an all-Manual batch", () => {
+      const { container }: { container: HTMLElement } = render(
+        <MonitorBatchPayAsYouGoConsent
+          monitorTypes={[MonitorType.Manual]}
+          value={false}
+          onChange={() => {}}
+        />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders nothing off the Free plan", () => {
+      setPlan(PlanType.Growth);
+
+      const { container }: { container: HTMLElement } = render(
+        <MonitorBatchPayAsYouGoConsent
+          monitorTypes={[MonitorType.Kubernetes]}
+          value={false}
+          onChange={() => {}}
+        />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe("consent validators", () => {
+    it("only an explicit tick satisfies the telemetry consent", () => {
+      expect(validateTelemetryConsent({})).toBe(TELEMETRY_CONSENT_ERROR);
+      expect(
+        validateTelemetryConsent({ [TELEMETRY_CONSENT_FIELD_KEY]: false }),
+      ).toBe(TELEMETRY_CONSENT_ERROR);
+      expect(
+        validateTelemetryConsent({ [TELEMETRY_CONSENT_FIELD_KEY]: undefined }),
+      ).toBe(TELEMETRY_CONSENT_ERROR);
+      expect(
+        validateTelemetryConsent({ [TELEMETRY_CONSENT_FIELD_KEY]: true }),
+      ).toBeNull();
+    });
+
+    it("does not accept a truthy non-boolean as consent", () => {
+      /*
+       * The form's own `required` check stringifies values, which is exactly
+       * why it cannot be used here - "false" is a non-empty string. Nothing
+       * but boolean true counts.
+       */
+      expect(
+        validateTelemetryConsent({ [TELEMETRY_CONSENT_FIELD_KEY]: "true" }),
+      ).toBe(TELEMETRY_CONSENT_ERROR);
+      expect(
+        validateTelemetryConsent({ [TELEMETRY_CONSENT_FIELD_KEY]: 1 }),
+      ).toBe(TELEMETRY_CONSENT_ERROR);
+    });
+
+    it("blocks a billed monitor until it is acknowledged", () => {
+      expect(validateMonitorConsent({ monitorType: MonitorType.Website })).toBe(
+        MONITOR_CONSENT_ERROR,
+      );
+      expect(
+        validateMonitorConsent({
+          monitorType: MonitorType.Website,
+          [MONITOR_CONSENT_FIELD_KEY]: false,
+        }),
+      ).toBe(MONITOR_CONSENT_ERROR);
+      expect(
+        validateMonitorConsent({
+          monitorType: MonitorType.Website,
+          [MONITOR_CONSENT_FIELD_KEY]: true,
+        }),
+      ).toBeNull();
+    });
+
+    it("never blocks a Manual monitor - there is nothing to acknowledge", () => {
+      expect(validateMonitorConsent({ monitorType: MonitorType.Manual })).toBe(
+        null,
+      );
+      expect(
+        validateMonitorConsent({
+          monitorType: MonitorType.Manual,
+          [MONITOR_CONSENT_FIELD_KEY]: false,
+        }),
+      ).toBeNull();
+    });
+
+    it("blocks when no monitor type has been picked yet", () => {
+      /*
+       * An unset type is not Manual, so it is treated as billed. Failing this
+       * way round means the box can never be skipped by submitting early.
+       */
+      expect(validateMonitorConsent({})).toBe(MONITOR_CONSENT_ERROR);
+    });
+  });
+});

--- a/Common/Tests/Server/Types/Billing/PayAsYouGoMeteredPricing.test.ts
+++ b/Common/Tests/Server/Types/Billing/PayAsYouGoMeteredPricing.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  SESSION_REPLAY_PRICE_IN_USD_PER_GB,
+  TELEMETRY_PRICE_IN_USD_PER_GB,
+  TELEMETRY_PRICE_RETENTION_IN_DAYS,
+} from "../../../../Types/Billing/PayAsYouGoPricing";
+import {
+  LogDataIngestMeteredPlan,
+  MetricsDataIngestMeteredPlan,
+  ProfilesDataIngestMeteredPlan,
+  SessionReplayDataIngestMeteredPlan,
+  TracesDataIngestMetredPlan,
+} from "../../../../Server/Types/Billing/MeteredPlan/AllMeteredPlans";
+import TelemetryMeteredPlan from "../../../../Server/Types/Billing/MeteredPlan/TelemetryMeteredPlan";
+
+/*
+ * The dashboard now quotes the telemetry rate to Free plan users before they
+ * create an ingestion key. A quoted price that does not match the metered one
+ * is a promise we break on the invoice, so the two are pinned together here:
+ * the metered plans must charge exactly the advertised per-GB rate at the
+ * advertised retention.
+ */
+
+/*
+ * Session replay rides on the same ingestion key at its own, much higher rate,
+ * so it is listed here with its own expected figure rather than left out - a
+ * plan missing from this table is a plan whose price the UI can misquote.
+ */
+const TELEMETRY_PLANS: Array<{
+  name: string;
+  plan: TelemetryMeteredPlan;
+  pricePerGB: number;
+}> = [
+  {
+    name: "logs",
+    plan: LogDataIngestMeteredPlan,
+    pricePerGB: TELEMETRY_PRICE_IN_USD_PER_GB,
+  },
+  {
+    name: "metrics",
+    plan: MetricsDataIngestMeteredPlan,
+    pricePerGB: TELEMETRY_PRICE_IN_USD_PER_GB,
+  },
+  {
+    name: "traces",
+    plan: TracesDataIngestMetredPlan,
+    pricePerGB: TELEMETRY_PRICE_IN_USD_PER_GB,
+  },
+  {
+    name: "profiles",
+    plan: ProfilesDataIngestMeteredPlan,
+    pricePerGB: TELEMETRY_PRICE_IN_USD_PER_GB,
+  },
+  {
+    name: "session replay",
+    plan: SessionReplayDataIngestMeteredPlan,
+    pricePerGB: SESSION_REPLAY_PRICE_IN_USD_PER_GB,
+  },
+];
+
+describe("Telemetry metered plans charge the advertised pay as you go rate", () => {
+  it.each(TELEMETRY_PLANS)(
+    "$name: 1 GB retained for the advertised window costs the advertised per-GB price",
+    ({
+      plan,
+      pricePerGB,
+    }: {
+      plan: TelemetryMeteredPlan;
+      pricePerGB: number;
+    }) => {
+      expect(
+        plan.getTotalCostInUSD({
+          dataIngestedInGB: 1,
+          retentionInDays: TELEMETRY_PRICE_RETENTION_IN_DAYS,
+        }),
+      ).toBeCloseTo(pricePerGB, 10);
+    },
+  );
+
+  it("prices session replay well above the other pillars, as intended", () => {
+    /*
+     * Not incidental: the gap is why in-app copy cannot quote one rate for
+     * "data sent with this ingestion key".
+     */
+    expect(SESSION_REPLAY_PRICE_IN_USD_PER_GB).toBeGreaterThan(
+      TELEMETRY_PRICE_IN_USD_PER_GB,
+    );
+    expect(SESSION_REPLAY_PRICE_IN_USD_PER_GB).toBe(2);
+  });
+
+  it.each(TELEMETRY_PLANS)(
+    "$name: cost scales linearly with volume and retention",
+    ({
+      plan,
+      pricePerGB,
+    }: {
+      plan: TelemetryMeteredPlan;
+      pricePerGB: number;
+    }) => {
+      expect(
+        plan.getTotalCostInUSD({
+          dataIngestedInGB: 10,
+          retentionInDays: TELEMETRY_PRICE_RETENTION_IN_DAYS,
+        }),
+      ).toBeCloseTo(pricePerGB * 10, 10);
+
+      // Twice the advertised retention is twice the advertised price.
+      expect(
+        plan.getTotalCostInUSD({
+          dataIngestedInGB: 1,
+          retentionInDays: TELEMETRY_PRICE_RETENTION_IN_DAYS * 2,
+        }),
+      ).toBeCloseTo(pricePerGB * 2, 10);
+    },
+  );
+
+  it("charges nothing for no data", () => {
+    expect(
+      LogDataIngestMeteredPlan.getTotalCostInUSD({
+        dataIngestedInGB: 0,
+        retentionInDays: TELEMETRY_PRICE_RETENTION_IN_DAYS,
+      }),
+    ).toBe(0);
+  });
+});

--- a/Common/Tests/Types/Billing/PayAsYouGoPricing.test.ts
+++ b/Common/Tests/Types/Billing/PayAsYouGoPricing.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  ACTIVE_MONITOR_PRICE_IN_USD_PER_MONTH,
+  PRICING_PAGE_URL,
+  SESSION_REPLAY_PRICE_IN_USD_PER_GB,
+  TELEMETRY_PRICE_IN_USD_PER_GB,
+  TELEMETRY_PRICE_RETENTION_IN_DAYS,
+  formatPriceInUSD,
+} from "../../../Types/Billing/PayAsYouGoPricing";
+
+/*
+ * These constants are quoted to users, verbatim, on the telemetry ingestion
+ * key and create monitor pages. They are pinned here because changing one
+ * silently changes what the product promises a customer - a change to any of
+ * them has to be deliberate, and has to be made on the pricing page too.
+ */
+
+describe("PayAsYouGoPricing", () => {
+  describe("rates", () => {
+    it("charges $0.10 per GB of telemetry, quoted for 15 day retention", () => {
+      expect(TELEMETRY_PRICE_IN_USD_PER_GB).toBe(0.1);
+      expect(TELEMETRY_PRICE_RETENTION_IN_DAYS).toBe(15);
+    });
+
+    it("charges $2 per GB for session replay, on the same 15 day window", () => {
+      expect(SESSION_REPLAY_PRICE_IN_USD_PER_GB).toBe(2);
+    });
+
+    it("charges $1 per active monitor per month", () => {
+      expect(ACTIVE_MONITOR_PRICE_IN_USD_PER_MONTH).toBe(1);
+    });
+
+    it("points at the public pricing page", () => {
+      expect(PRICING_PAGE_URL).toBe("https://oneuptime.com/pricing");
+    });
+  });
+
+  describe("formatPriceInUSD", () => {
+    it("writes a whole number of dollars without cents, like the pricing page", () => {
+      expect(formatPriceInUSD(1)).toBe("$1");
+      expect(formatPriceInUSD(22)).toBe("$22");
+      expect(formatPriceInUSD(0)).toBe("$0");
+    });
+
+    it("writes a fractional amount with two decimal places", () => {
+      expect(formatPriceInUSD(0.1)).toBe("$0.10");
+      expect(formatPriceInUSD(1.5)).toBe("$1.50");
+      expect(formatPriceInUSD(2.05)).toBe("$2.05");
+    });
+
+    it("rounds to cents rather than spilling extra digits into the copy", () => {
+      expect(formatPriceInUSD(0.125)).toBe("$0.13");
+      expect(formatPriceInUSD(0.006)).toBe("$0.01");
+    });
+
+    it("renders the advertised rates exactly as the pricing page writes them", () => {
+      expect(formatPriceInUSD(TELEMETRY_PRICE_IN_USD_PER_GB)).toBe("$0.10");
+      expect(formatPriceInUSD(SESSION_REPLAY_PRICE_IN_USD_PER_GB)).toBe("$2");
+      expect(formatPriceInUSD(ACTIVE_MONITOR_PRICE_IN_USD_PER_MONTH)).toBe(
+        "$1",
+      );
+    });
+  });
+});

--- a/Common/Tests/Types/Monitor/MonitorType.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorType.test.ts
@@ -253,6 +253,68 @@ describe("MonitorTypeHelper", () => {
     });
   });
 
+  /*
+   * The dashboard tells Free plan users which monitors cost money before they
+   * create one, and gates the create button on acknowledging it. That warning
+   * is only honest while this predicate agrees with what the server actually
+   * meters - ActiveMonitoringMeteredPlan counts every monitor whose type is
+   * not Manual.
+   */
+  describe("isBilledAsActiveMonitor", () => {
+    test("Manual monitors are free", () => {
+      expect(
+        MonitorTypeHelper.isBilledAsActiveMonitor(MonitorType.Manual),
+      ).toBe(false);
+    });
+
+    test("every other monitor type is billed", () => {
+      const billed: Array<MonitorType> = Object.values(MonitorType).filter(
+        (monitorType: MonitorType) => {
+          return monitorType !== MonitorType.Manual;
+        },
+      );
+
+      expect(billed.length).toBeGreaterThan(0);
+
+      for (const monitorType of billed) {
+        expect(MonitorTypeHelper.isBilledAsActiveMonitor(monitorType)).toBe(
+          true,
+        );
+      }
+    });
+
+    test("telemetry monitors are billed as active monitors too, on top of their ingest", () => {
+      expect(MonitorTypeHelper.isBilledAsActiveMonitor(MonitorType.Logs)).toBe(
+        true,
+      );
+      expect(
+        MonitorTypeHelper.isBilledAsActiveMonitor(MonitorType.Metrics),
+      ).toBe(true);
+      expect(
+        MonitorTypeHelper.isBilledAsActiveMonitor(MonitorType.Traces),
+      ).toBe(true);
+    });
+
+    test("agrees exactly with getActiveMonitorTypes", () => {
+      const active: Array<MonitorType> =
+        MonitorTypeHelper.getActiveMonitorTypes();
+
+      for (const monitorType of Object.values(MonitorType)) {
+        expect(MonitorTypeHelper.isBilledAsActiveMonitor(monitorType)).toBe(
+          active.includes(monitorType),
+        );
+      }
+    });
+
+    test("is the exact inverse of isManualMonitor", () => {
+      for (const monitorType of Object.values(MonitorType)) {
+        expect(MonitorTypeHelper.isBilledAsActiveMonitor(monitorType)).toBe(
+          !MonitorTypeHelper.isManualMonitor(monitorType),
+        );
+      }
+    });
+  });
+
   describe("doesMonitorTypeHaveGraphs", () => {
     test("returns true for graphable types and false otherwise", () => {
       expect(

--- a/Common/Types/Billing/PayAsYouGoPricing.ts
+++ b/Common/Types/Billing/PayAsYouGoPricing.ts
@@ -1,0 +1,47 @@
+/*
+ * The public pay-as-you-go rates, as advertised on
+ * https://oneuptime.com/pricing.
+ *
+ * These live in Types (and not next to the metered plans, which are
+ * server-only) because two very different places need the same numbers: the
+ * server meters and bills against them, and the dashboard has to tell a Free
+ * plan user what they are about to be charged before they commit to it. A
+ * price quoted in the product that disagrees with the price on the invoice is
+ * worse than quoting no price at all, so there is exactly one copy.
+ */
+
+// Telemetry ingest - logs, traces, metrics and profiles.
+export const TELEMETRY_PRICE_IN_USD_PER_GB: number = 0.1;
+
+/*
+ * Session replay recordings travel on the same ingestion key as the rest of
+ * telemetry but are priced well above it, on purpose - see
+ * SessionReplayDataIngestMeteredPlan. Anything that quotes "what this key
+ * costs" has to say both numbers, or it is quoting a rate 20x below what a
+ * replay-heavy project will actually be invoiced.
+ */
+export const SESSION_REPLAY_PRICE_IN_USD_PER_GB: number = 2;
+
+// The retention the per-GB telemetry prices above are quoted for.
+export const TELEMETRY_PRICE_RETENTION_IN_DAYS: number = 15;
+
+/*
+ * Active monitoring. Every monitor except a Manual one is an active monitor -
+ * see MonitorTypeHelper.isBilledAsActiveMonitor.
+ */
+export const ACTIVE_MONITOR_PRICE_IN_USD_PER_MONTH: number = 1;
+
+export const PRICING_PAGE_URL: string = "https://oneuptime.com/pricing";
+
+/**
+ * Money as the pricing page writes it: `$1` rather than `$1.00`, but `$0.10`
+ * rather than `$0.1`. In-app copy that quotes a rate should read exactly like
+ * the page the user will check it against.
+ */
+export function formatPriceInUSD(amountInUSD: number): string {
+  if (Number.isInteger(amountInUSD)) {
+    return `$${amountInUSD}`;
+  }
+
+  return `$${amountInUSD.toFixed(2)}`;
+}

--- a/Common/Types/Monitor/MonitorType.ts
+++ b/Common/Types/Monitor/MonitorType.ts
@@ -170,6 +170,17 @@ export class MonitorTypeHelper {
     return monitorType === MonitorType.Manual;
   }
 
+  /*
+   * Whether a monitor of this type adds to the project's Active Monitoring
+   * bill. Mirrors what the server actually meters -
+   * ActiveMonitoringMeteredPlan counts every monitor whose type is not
+   * Manual - so the dashboard can warn a Free plan user about a charge using
+   * the same rule that produces it. Manual monitors are free and unlimited.
+   */
+  public static isBilledAsActiveMonitor(monitorType: MonitorType): boolean {
+    return !this.isManualMonitor(monitorType);
+  }
+
   public static getAllMonitorTypeProps(): Array<MonitorTypeProps> {
     const monitorTypeProps: Array<MonitorTypeProps> = [
       {

--- a/E2E/Tests/Dashboard/CephProduct.spec.ts
+++ b/E2E/Tests/Dashboard/CephProduct.spec.ts
@@ -3,6 +3,7 @@ import { APIResponse, Page, expect, test, Locator } from "@playwright/test";
 import URL from "Common/Types/API/URL";
 import Faker from "Common/Utils/Faker";
 import {
+  acknowledgePayAsYouGoIfPresent,
   gotoProjectPage,
   registerAndCreateProject,
   submitIngestionKeyModal,
@@ -111,6 +112,14 @@ test.describe.skip("Ceph Product Onboarding", () => {
 
     await expect(page.getByTestId("card-select-option-Ceph")).toBeVisible();
     await page.getByTestId("card-select-option-Ceph").click();
+    /*
+     * On a billing-enabled deployment a Free plan project must acknowledge
+     * pay-as-you-go pricing before a non-Manual monitor can be created.
+     */
+    await acknowledgePayAsYouGoIfPresent({
+      page,
+      testId: "monitor-pay-as-you-go-consent",
+    });
 
     /*
      * The submit button keeps the "Create Monitor" test id on every form

--- a/E2E/Tests/Dashboard/DockerSwarmProduct.spec.ts
+++ b/E2E/Tests/Dashboard/DockerSwarmProduct.spec.ts
@@ -3,6 +3,7 @@ import { APIResponse, Page, expect, test, Locator } from "@playwright/test";
 import URL from "Common/Types/API/URL";
 import Faker from "Common/Utils/Faker";
 import {
+  acknowledgePayAsYouGoIfPresent,
   gotoProjectPage,
   registerAndCreateProject,
   submitIngestionKeyModal,
@@ -116,6 +117,14 @@ test.describe.skip("Docker Swarm Product Onboarding", () => {
       page.getByTestId("card-select-option-Docker Swarm"),
     ).toBeVisible();
     await page.getByTestId("card-select-option-Docker Swarm").click();
+    /*
+     * On a billing-enabled deployment a Free plan project must acknowledge
+     * pay-as-you-go pricing before a non-Manual monitor can be created.
+     */
+    await acknowledgePayAsYouGoIfPresent({
+      page,
+      testId: "monitor-pay-as-you-go-consent",
+    });
 
     /*
      * The submit button keeps the "Create Monitor" test id on every form

--- a/E2E/Tests/Dashboard/Helpers/ProductOnboarding.ts
+++ b/E2E/Tests/Dashboard/Helpers/ProductOnboarding.ts
@@ -187,6 +187,34 @@ export const submitIngestionKeyModal: SubmitIngestionKeyModalFunction =
       .locator("#create-ingestion-key input[type='text']")
       .first()
       .fill(data.keyName);
+    await acknowledgePayAsYouGoIfPresent({
+      page: data.page,
+      testId: "telemetry-pay-as-you-go-consent",
+    });
     await data.page.getByTestId("modal-footer-submit-button").click();
     await data.page.getByTestId("modal").waitFor({ state: "hidden" });
+  };
+
+/*
+ * On a billing-enabled deployment a Free plan project has to acknowledge
+ * pay-as-you-go pricing before it can create an ingestion key or a non-Manual
+ * monitor; the checkbox is absent on paid plans and when billing is off, which
+ * is why this is a presence check rather than an unconditional click.
+ */
+type AcknowledgePayAsYouGoFunction = (data: {
+  page: Page;
+  testId: string;
+}) => Promise<void>;
+
+export const acknowledgePayAsYouGoIfPresent: AcknowledgePayAsYouGoFunction =
+  async (data: { page: Page; testId: string }): Promise<void> => {
+    if (!IS_BILLING_ENABLED) {
+      return;
+    }
+
+    const consent: Locator = data.page.getByTestId(data.testId);
+
+    if ((await consent.count()) > 0) {
+      await consent.first().check();
+    }
   };

--- a/E2E/Tests/Dashboard/Helpers/Telemetry.ts
+++ b/E2E/Tests/Dashboard/Helpers/Telemetry.ts
@@ -1,7 +1,10 @@
 import { BASE_URL } from "../../../Config";
 import { APIResponse, Page, expect, Locator } from "@playwright/test";
 import URL from "Common/Types/API/URL";
-import { gotoProjectPage } from "./ProductOnboarding";
+import {
+  acknowledgePayAsYouGoIfPresent,
+  gotoProjectPage,
+} from "./ProductOnboarding";
 
 /*
  * Helpers for the Telemetry (Logs / Traces / Metrics) e2e specs.
@@ -60,6 +63,10 @@ export const createTelemetryIngestionKey: CreateTelemetryIngestionKeyFunction =
       .locator("input[placeholder='Ingestion Key Name']")
       .first()
       .fill(data.keyName);
+    await acknowledgePayAsYouGoIfPresent({
+      page: page,
+      testId: "telemetry-pay-as-you-go-consent",
+    });
     await page.getByTestId("modal-footer-submit-button").click();
     await page.getByTestId("modal").waitFor({ state: "hidden" });
 

--- a/E2E/Tests/Dashboard/ProxmoxProduct.spec.ts
+++ b/E2E/Tests/Dashboard/ProxmoxProduct.spec.ts
@@ -3,6 +3,7 @@ import { APIResponse, Page, expect, test, Locator } from "@playwright/test";
 import URL from "Common/Types/API/URL";
 import Faker from "Common/Utils/Faker";
 import {
+  acknowledgePayAsYouGoIfPresent,
   gotoProjectPage,
   registerAndCreateProject,
   submitIngestionKeyModal,
@@ -112,6 +113,14 @@ test.describe.skip("Proxmox Product Onboarding", () => {
 
     await expect(page.getByTestId("card-select-option-Proxmox")).toBeVisible();
     await page.getByTestId("card-select-option-Proxmox").click();
+    /*
+     * On a billing-enabled deployment a Free plan project must acknowledge
+     * pay-as-you-go pricing before a non-Manual monitor can be created.
+     */
+    await acknowledgePayAsYouGoIfPresent({
+      page,
+      testId: "monitor-pay-as-you-go-consent",
+    });
 
     /*
      * The submit button keeps the "Create Monitor" test id on every form


### PR DESCRIPTION
Telemetry ingest and every non-Manual monitor are metered, and the Free plan bundles neither. Until now the first a Free plan user heard about either charge was the invoice — the ingestion key modal and the create monitor form said nothing about money at all.

On a billing-enabled deployment, and **only** for projects on the Free plan:

- **Telemetry ingestion keys page** — a card quoting the pay-as-you-go rates, and the create-key modal carries the same notice plus an acknowledgement the user must tick before the key is created.
- **Create monitor page** — the equivalent card, and a consent checkbox directly under the monitor type picker. Hidden for Manual monitors, which are free and unlimited.
- **Monitor recommendations** — the bulk "create N monitors" path, and the largest charge a single click can start. Gets the card and a batch acknowledgement quoting the total, enforced both on its submit button and in the create loop itself.

Everything self-gates on `isProjectOnFreePlan()`, which fails closed: billing disabled (self-hosted), no cached project, or a plan id this deployment does not recognise all render nothing. `getCurrentPlan()` throws on an unknown plan id, so that call is wrapped — a billing notice must never take a page down.

## The parts that are easy to get wrong

- **The gate is a `customValidation`, not `required`.** The form's required check stringifies values, so an unticked box arrives as the non-empty string `"false"` and passes it. `customValidation` only runs for keys present in the form values, which is what `getDefaultValue` seeds. `required: true` stays as a backstop for the absent-key path.
- **Consent never leaves the browser.** The fields use `overrideField` with no `overrideFieldKey`, so the value reaches neither the model payload (`getSelectFields` reads `field.field`) nor `miscDataProps` (which requires `overrideFieldKey`). It gates the submit and nothing else.
- **Ten surfaces create an ingestion key** — the settings table plus nine documentation-card modals. All are gated, and a test walks the source to fail if an eleventh is added ungated. The same invariant now covers monitor creation; its absence is exactly how the recommendations bulk-create path was initially missed.
- **Session replay rides on the same ingestion key at \$2.00/GB**, twenty times the telemetry rate. The copy names both rates rather than making the user affirm a single figure that is wrong for half the data the key accepts.

## Pricing

Rates come from one new `Common/Types/Billing/PayAsYouGoPricing`, which `AllMeteredPlans` now derives its telemetry unit costs from, so a price quoted in the product cannot drift from the price on the invoice. The arithmetic is unchanged (`0.1 / 15` and `2.0 / 15` as before), and a test pins each metered plan against its advertised per-GB figure.

Figures match https://oneuptime.com/pricing: \$0.10/GB telemetry (15 day retention), \$2.00/GB session replay, \$1 per active monitor per month.

## Tests

- `PayAsYouGoPricing.test.ts` — rate constants and money formatting.
- `PayAsYouGoMeteredPricing.test.ts` — every telemetry metered plan charges its advertised rate.
- `MonitorType.test.ts` — `isBilledAsActiveMonitor` agrees exactly with `getActiveMonitorTypes` and is the inverse of `isManualMonitor`.
- `PayAsYouGoFreePlan.test.ts` — the plan predicate across every plan, self-hosted, unknown plan, and the throwing path.
- `PayAsYouGoNotices.test.tsx` — what each card, field factory, validator and the batch consent render on each plan.
- `PayAsYouGoConsentGate.test.tsx` — drives the **real `ModelForm`**: submit is blocked until ticked, blocked again after tick-then-untick, the acknowledgement is absent from the API call, and Manual monitors and paid plans are untouched.
- `PayAsYouGoWiring.test.ts` — the wiring, plus the two "no ungated create surface exists" invariants.

E2E helpers tick the new boxes when present, so the billing-enabled E2E job is unaffected.

## Verification

Local: 8,041 Common tests and 5,475 App tests pass, lint clean, Common/App/Dashboard/E2E all type-check.

One pre-existing flake is worth flagging separately: `Common/Tests/App/Dashboard/AdminNotificationRulesPage.test.tsx` fails intermittently with a **different** test each run, and does so on pristine `origin/master` too. Untouched by this PR.

Not verified in a running app — the UI is covered by jsdom render and real-`ModelForm` integration tests rather than a visual check.