### PR TITLE
Add an option to keep a status page out of search engine results

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Branding.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/StatusPages/View/Branding.tsx
@@ -69,6 +69,44 @@ const StatusPageDelete: FunctionComponent<
       />
 
       <CardModelDetail<StatusPage>
+        name="Status Page > Branding > Search Engine Indexing"
+        cardProps={{
+          title: "Search Engine Indexing",
+          description:
+            "Control whether search engines like Google and Bing are allowed to list this status page in their results.",
+        }}
+        editButtonText={"Edit"}
+        isEditable={true}
+        formFields={[
+          {
+            field: {
+              enableSearchEngineIndexing: true,
+            },
+            title: "Allow Search Engines to Index this Status Page",
+            fieldType: FormFieldSchemaType.Toggle,
+            required: false,
+            description:
+              "On by default. Turn this off to keep the page reachable by anyone with the link while keeping it out of search results - OneUptime then serves the page with a noindex, nofollow robots directive. Search engines can take a few weeks to drop a page they have already indexed.",
+          },
+        ]}
+        modelDetailProps={{
+          showDetailsInNumberOfColumns: 1,
+          modelType: StatusPage,
+          id: "model-detail-status-page-search-engine-indexing",
+          fields: [
+            {
+              field: {
+                enableSearchEngineIndexing: true,
+              },
+              fieldType: FieldType.Boolean,
+              title: "Allow Search Engines to Index this Status Page",
+            },
+          ],
+          modelId: modelId,
+        }}
+      />
+
+      <CardModelDetail<StatusPage>
         name="Status Page > Branding > Favicon"
         cardProps={{
           title: "Favicon",

--- a/App/FeatureSet/Frontend/Index.ts
+++ b/App/FeatureSet/Frontend/Index.ts
@@ -25,6 +25,7 @@ import {
   StatusPageData,
   getStatusPageData,
 } from "./Utils/StatusPage";
+import applyStatusPageRobotsHeader from "Common/Server/Utils/StatusPageSearchEngineIndexing";
 import { handlePublicDashboardLlmsTxt } from "./Utils/PublicDashboard";
 import DashboardDomainService from "Common/Server/Services/DashboardDomainService";
 import DashboardDomain from "Common/Models/DatabaseModels/DashboardDomain";
@@ -144,7 +145,7 @@ const StatusPageFrontendConfig: FrontendConfig = {
   indexViewPath: StatusPageViewPath,
   getVariablesToRenderIndexPage: async (
     req: ExpressRequest,
-    _res: ExpressResponse,
+    res: ExpressResponse,
   ): Promise<JSONObject> => {
     const statusPageData: StatusPageData | null = await getStatusPageData(req);
 
@@ -163,11 +164,23 @@ const StatusPageFrontendConfig: FrontendConfig = {
         : "/rss";
 
     if (statusPageData) {
+      /*
+       * Belt and braces with the <meta name="robots"> the template renders
+       * from isSearchEngineIndexingEnabled below: the header is honoured even
+       * if a crawler gives up on the HTML.
+       */
+      applyStatusPageRobotsHeader(
+        res,
+        statusPageData.isSearchEngineIndexingEnabled,
+      );
+
       return {
         title: statusPageData.title,
         description: statusPageData.description,
         faviconUrl: statusPageData.faviconUrl,
         rssFeedPath: rssFeedPath,
+        isSearchEngineIndexingEnabled:
+          statusPageData.isSearchEngineIndexingEnabled,
       };
     }
 

--- a/App/FeatureSet/Frontend/Utils/StatusPage.ts
+++ b/App/FeatureSet/Frontend/Utils/StatusPage.ts
@@ -7,12 +7,23 @@ import HTTPResponse from "Common/Types/API/HTTPResponse";
 import URL from "Common/Types/API/URL";
 import { JSONArray, JSONObject } from "Common/Types/JSON";
 import API from "Common/Utils/API";
+import applyStatusPageRobotsHeader from "Common/Server/Utils/StatusPageSearchEngineIndexing";
+import {
+  SEARCH_ENGINE_INDEXING_FLAG_NAME,
+  isSearchEngineIndexingEnabled,
+} from "Common/Types/StatusPage/SearchEngineIndexing";
 
 export interface StatusPageData {
   id: string;
   title: string;
   description: string;
   faviconUrl: string;
+  /*
+   * False only when the owner turned indexing off. See
+   * Common/Types/StatusPage/SearchEngineIndexing.ts for why anything else -
+   * including an unreachable /seo API - reads as indexable.
+   */
+  isSearchEngineIndexingEnabled: boolean;
 }
 
 export const getStatusPageData: (
@@ -60,47 +71,67 @@ export const getStatusPageData: (
     let description: string =
       "Status Page lets you see real-time information about the status of our services.";
 
-    if (isPreview) {
-      // For preview pages, use the extracted ID directly.
-      statusPageId = statusPageIdOrDomain;
+    /*
+     * The /seo API resolves an id or a custom domain, so preview URLs
+     * (/status-page/:statusPageId) go through it too. They have to: the
+     * preview URL is the only URL a status page has until someone attaches a
+     * custom domain, so skipping the lookup here would leave the indexing
+     * opt-out working on custom domains and doing nothing for everyone else.
+     */
+    logger.debug(
+      `Pinging the API with statusPageIdOrDomain: ${statusPageIdOrDomain}`,
+      { service: "frontend" },
+    );
+    const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
+      await API.get({
+        url: URL.fromString(StatusPageApiInternalUrl.toString()).addRoute(
+          `/seo/${statusPageIdOrDomain}`,
+        ),
+      });
+
+    let seoData: JSONObject | null = null;
+
+    if (response instanceof HTTPErrorResponse) {
+      logger.debug(`Received error response from API: ${response}`, {
+        service: "frontend",
+      });
     } else {
-      logger.debug(
-        `Pinging the API with statusPageIdOrDomain: ${statusPageIdOrDomain}`,
-        { service: "frontend" },
-      );
-      const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
-        await API.get({
-          url: URL.fromString(StatusPageApiInternalUrl.toString()).addRoute(
-            `/seo/${statusPageIdOrDomain}`,
-          ),
-        });
-
-      if (response instanceof HTTPErrorResponse) {
-        logger.debug(`Received error response from API: ${response}`, {
-          service: "frontend",
-        });
-        return null;
-      }
-
       logger.debug("Successfully received response from API", {
         service: "frontend",
       });
+      seoData = response.data || null;
+    }
 
-      statusPageId = response.data?.["_id"] as string;
+    if (isPreview) {
+      /*
+       * A preview URL carries the id, so the page can still be rendered when
+       * the lookup fails - it just renders with the default title. Failing
+       * the render instead would take the page down over an SEO lookup.
+       */
+      statusPageId = statusPageIdOrDomain;
+    } else {
+      if (!seoData) {
+        return null;
+      }
+
+      statusPageId = seoData["_id"] as string;
       if (!statusPageId) {
         logger.debug("No status page ID in response", { service: "frontend" });
         return null;
       }
-
-      title = (response.data?.["title"] as string) || title;
-      description = (response.data?.["description"] as string) || description;
     }
+
+    title = (seoData?.["title"] as string) || title;
+    description = (seoData?.["description"] as string) || description;
 
     return {
       id: statusPageId,
       title,
       description,
       faviconUrl: `/status-page-api/favicon/${statusPageIdOrDomain}`,
+      isSearchEngineIndexingEnabled: isSearchEngineIndexingEnabled(
+        seoData?.[SEARCH_ENGINE_INDEXING_FLAG_NAME],
+      ),
     };
   } catch (err) {
     logger.error("Error getting status page data:", { service: "frontend" });
@@ -132,6 +163,15 @@ export const handleRSS: (
     }
 
     const { id: statusPageId, title, description } = statusPageData;
+
+    /*
+     * The feed is not HTML, so it has no <meta name="robots"> to carry the
+     * owner's opt-out. The header is the only channel it has.
+     */
+    applyStatusPageRobotsHeader(
+      res,
+      statusPageData.isSearchEngineIndexingEnabled,
+    );
 
     const incidentsResponse: HTTPErrorResponse | HTTPResponse<JSONObject> =
       await API.post({
@@ -293,6 +333,11 @@ export const handleLlmsTxt: (
     }
 
     const { id: statusPageId, title } = statusPageData;
+
+    applyStatusPageRobotsHeader(
+      res,
+      statusPageData.isSearchEngineIndexingEnabled,
+    );
 
     const isPreview: boolean = req.path.includes("/status-page/");
     const host: string = req.get("host") || "";

--- a/App/FeatureSet/StatusPage/Serve.ts
+++ b/App/FeatureSet/StatusPage/Serve.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_STATUS_PAGE_LANGUAGE,
   SUPPORTED_STATUS_PAGE_LANGUAGE_CODES,
 } from "Common/Types/StatusPage/StatusPageLanguage";
+import applyStatusPageRobotsHeader from "Common/Server/Utils/StatusPageSearchEngineIndexing";
 
 export const APP_NAME: string = "status-page";
 
@@ -44,7 +45,7 @@ const init: PromiseVoidFunction = async (): Promise<void> => {
       },
       getVariablesToRenderIndexPage: async (
         req: ExpressRequest,
-        _res: ExpressResponse,
+        res: ExpressResponse,
       ) => {
         const statusPageData: StatusPageData | null =
           await getStatusPageData(req);
@@ -72,12 +73,24 @@ const init: PromiseVoidFunction = async (): Promise<void> => {
               ? statusPageData.defaultLanguage
               : DEFAULT_STATUS_PAGE_LANGUAGE;
 
+          /*
+           * Belt and braces with the <meta name="robots"> the template
+           * renders from isSearchEngineIndexingEnabled below: the header is
+           * honoured even if a crawler gives up on the HTML.
+           */
+          applyStatusPageRobotsHeader(
+            res,
+            statusPageData.isSearchEngineIndexingEnabled,
+          );
+
           return {
             title: statusPageData.title,
             description: statusPageData.description,
             faviconUrl: statusPageData.faviconUrl,
             lang: resolvedLang,
             rssFeedPath: rssFeedPath,
+            isSearchEngineIndexingEnabled:
+              statusPageData.isSearchEngineIndexingEnabled,
           };
         }
         return {

--- a/App/FeatureSet/StatusPage/public/robots.txt
+++ b/App/FeatureSet/StatusPage/public/robots.txt
@@ -1,3 +1,10 @@
 # https://www.robotstxt.org/robotstxt.html
+#
+# Per-status-page indexing is NOT controlled here. A status page whose owner
+# turned off "Search Engine Indexing" (Status Page > Branding) is served with
+# <meta name="robots" content="noindex, nofollow"> and an X-Robots-Tag header
+# instead. Disallow would be the wrong tool for it: it blocks the crawl, and a
+# crawler that never fetches the page never sees the noindex, so the URL can
+# still surface in results.
 User-agent: *
 Disallow: /api/*

--- a/App/FeatureSet/StatusPage/src/Server/API/LlmsTxt.ts
+++ b/App/FeatureSet/StatusPage/src/Server/API/LlmsTxt.ts
@@ -4,6 +4,7 @@ import logger, {
 } from "Common/Server/Utils/Logger";
 import { StatusPageApiRoute } from "Common/ServiceRoute";
 import { getStatusPageData, StatusPageData } from "../Utils/StatusPage";
+import applyStatusPageRobotsHeader from "Common/Server/Utils/StatusPageSearchEngineIndexing";
 
 /*
  * Serves an llms.txt document for a status page so that AI agents and
@@ -36,6 +37,11 @@ export const handleLlmsTxt: (
     }
 
     const { id: statusPageId, title } = statusPageData;
+
+    applyStatusPageRobotsHeader(
+      res,
+      statusPageData.isSearchEngineIndexingEnabled,
+    );
 
     const isPreview: boolean = req.path.includes("/status-page/");
     const host: string = req.get("host") || "";

--- a/App/FeatureSet/StatusPage/src/Server/API/RSS.ts
+++ b/App/FeatureSet/StatusPage/src/Server/API/RSS.ts
@@ -12,6 +12,7 @@ import logger, {
   getLogAttributesFromRequest,
 } from "Common/Server/Utils/Logger";
 import { getStatusPageData, StatusPageData } from "../Utils/StatusPage";
+import applyStatusPageRobotsHeader from "Common/Server/Utils/StatusPageSearchEngineIndexing";
 
 type RSSItem = {
   title: string;
@@ -37,6 +38,15 @@ export const handleRSS: (
     }
 
     const { id: statusPageId, title, description } = statusPageData;
+
+    /*
+     * The feed is not HTML, so it has no <meta name="robots"> to carry the
+     * owner's opt-out. The header is the only channel it has.
+     */
+    applyStatusPageRobotsHeader(
+      res,
+      statusPageData.isSearchEngineIndexingEnabled,
+    );
 
     // Fetch incidents
     const incidentsResponse: HTTPErrorResponse | HTTPResponse<JSONObject> =

--- a/App/FeatureSet/StatusPage/src/Server/Utils/StatusPage.ts
+++ b/App/FeatureSet/StatusPage/src/Server/Utils/StatusPage.ts
@@ -6,6 +6,10 @@ import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
 import HTTPResponse from "Common/Types/API/HTTPResponse";
 import { JSONObject } from "Common/Types/JSON";
 import logger from "Common/Server/Utils/Logger";
+import {
+  SEARCH_ENGINE_INDEXING_FLAG_NAME,
+  isSearchEngineIndexingEnabled,
+} from "Common/Types/StatusPage/SearchEngineIndexing";
 
 export interface StatusPageData {
   id: string;
@@ -13,6 +17,12 @@ export interface StatusPageData {
   description: string;
   faviconUrl: string;
   defaultLanguage: string | null;
+  /*
+   * False only when the owner turned indexing off. See
+   * Common/Types/StatusPage/SearchEngineIndexing.ts for why anything else -
+   * including an unreachable /seo API - reads as indexable.
+   */
+  isSearchEngineIndexingEnabled: boolean;
 }
 
 export const getStatusPageData: (
@@ -61,47 +71,61 @@ export const getStatusPageData: (
       "Status Page lets you see real-time information about the status of our services.";
     let defaultLanguage: string | null = null;
 
-    if (isPreview) {
-      // For preview pages, use the extracted ID directly
-      statusPageId = statusPageIdOrDomain;
-      // For preview, we might not have SEO data, so use defaults
+    /*
+     * The /seo API resolves an id or a custom domain, so preview URLs
+     * (/status-page/:statusPageId) go through it too. They have to: the
+     * preview URL is the only URL a status page has until someone attaches a
+     * custom domain, so skipping the lookup here would leave the indexing
+     * opt-out working on custom domains and doing nothing for everyone else.
+     */
+    logger.debug(
+      `Pinging the API with statusPageIdOrDomain: ${statusPageIdOrDomain}`,
+      { service: "status-page" },
+    );
+    const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
+      await API.get({
+        url: URL.fromString(StatusPageApiInternalUrl.toString()).addRoute(
+          `/seo/${statusPageIdOrDomain}`,
+        ),
+      });
+
+    let seoData: JSONObject | null = null;
+
+    if (response instanceof HTTPErrorResponse) {
+      logger.debug(`Received error response from API: ${response}`, {
+        service: "status-page",
+      });
     } else {
-      // For live pages, call SEO API
-      logger.debug(
-        `Pinging the API with statusPageIdOrDomain: ${statusPageIdOrDomain}`,
-        { service: "status-page" },
-      );
-      const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
-        await API.get({
-          url: URL.fromString(StatusPageApiInternalUrl.toString()).addRoute(
-            `/seo/${statusPageIdOrDomain}`,
-          ),
-        });
-
-      if (response instanceof HTTPErrorResponse) {
-        logger.debug(`Received error response from API: ${response}`, {
-          service: "status-page",
-        });
-        return null;
-      }
-
       logger.debug("Successfully received response from API", {
         service: "status-page",
       });
+      seoData = response.data || null;
+    }
 
-      statusPageId = response.data?.["_id"] as string;
+    if (isPreview) {
+      /*
+       * A preview URL carries the id, so the page can still be rendered when
+       * the lookup fails - it just renders with the default title. Failing
+       * the render instead would take the page down over an SEO lookup.
+       */
+      statusPageId = statusPageIdOrDomain;
+    } else {
+      if (!seoData) {
+        return null;
+      }
+
+      statusPageId = seoData["_id"] as string;
       if (!statusPageId) {
         logger.debug("No status page ID in response", {
           service: "status-page",
         });
         return null;
       }
-
-      title = (response.data?.["title"] as string) || title;
-      description = (response.data?.["description"] as string) || description;
-      defaultLanguage =
-        (response.data?.["defaultLanguage"] as string | null) || null;
     }
+
+    title = (seoData?.["title"] as string) || title;
+    description = (seoData?.["description"] as string) || description;
+    defaultLanguage = (seoData?.["defaultLanguage"] as string | null) || null;
 
     return {
       id: statusPageId,
@@ -109,6 +133,9 @@ export const getStatusPageData: (
       description,
       faviconUrl: `/status-page-api/favicon/${statusPageIdOrDomain}`,
       defaultLanguage,
+      isSearchEngineIndexingEnabled: isSearchEngineIndexingEnabled(
+        seoData?.[SEARCH_ENGINE_INDEXING_FLAG_NAME],
+      ),
     };
   } catch (err) {
     logger.error("Error getting status page data:", { service: "status-page" });

--- a/App/FeatureSet/StatusPage/views/index.ejs
+++ b/App/FeatureSet/StatusPage/views/index.ejs
@@ -10,6 +10,20 @@
     <meta name="theme-color" content="#000000">
     <meta name="slack-app-id" content="ACVBMTPJQ">
     <meta name="description" content="<%= typeof description !== 'undefined' ? description : 'Status Page shows real-time status of all of our services.' %>">
+    <%
+      /*
+       * Search engine indexing opt-out. Only the explicit "off" emits a tag:
+       * an absent variable (the fallback render, or a status page the /seo
+       * lookup could not resolve) leaves the page indexable, which is the
+       * default every status page ships with. There is deliberately no
+       * "index, follow" branch - that is what a crawler already assumes, and
+       * emitting it would override a noindex set by a CDN or proxy in front
+       * of OneUptime.
+       */
+    %>
+    <% if(typeof isSearchEngineIndexingEnabled !== 'undefined' && isSearchEngineIndexingEnabled === false){ %>
+    <meta name="robots" content="noindex, nofollow">
+    <% } %>
     <script src="/status-page/env.js"></script>
     <link rel="icon" type="image/png" href="<%= typeof faviconUrl !== 'undefined' ? faviconUrl : '/status-page/assets/images/favicon.png' %>">
     <link rel="alternate" type="application/rss+xml" title="Status Page RSS" href="<%= typeof rssFeedPath !== 'undefined' && rssFeedPath ? rssFeedPath : '/rss' %>">

--- a/App/Tests/StatusPage/SearchEngineIndexingData.test.ts
+++ b/App/Tests/StatusPage/SearchEngineIndexingData.test.ts
@@ -1,0 +1,261 @@
+/**
+ * getStatusPageData is where a status page's indexing preference is turned
+ * from a field on an internal HTTP response into the boolean the renderers
+ * act on. There are two copies of it - one in the standalone status-page
+ * container, one in the combined App container - and a status page served by
+ * one must not behave differently from the same page served by the other, so
+ * every case below runs against both.
+ *
+ * The cases that matter most are the unhappy ones. The flag reaches these
+ * functions over a network call to the status page API; when that call fails
+ * the page still has to render, and it has to render indexable, because the
+ * alternative is dropping pages out of search results over a transient blip
+ * that nobody would ever see in a log.
+ */
+
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import { ExpressRequest } from "Common/Server/Utils/Express";
+import { JSONObject } from "Common/Types/JSON";
+import API from "Common/Utils/API";
+import { getStatusPageData as getFrontendStatusPageData } from "../../FeatureSet/Frontend/Utils/StatusPage";
+import { getStatusPageData as getStandaloneStatusPageData } from "../../FeatureSet/StatusPage/src/Server/Utils/StatusPage";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const STATUS_PAGE_ID: string = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+type GetStatusPageData = (req: ExpressRequest) => Promise<{
+  id: string;
+  title: string;
+  description: string;
+  isSearchEngineIndexingEnabled: boolean;
+} | null>;
+
+/*
+ * The two servers are the same function twice over. Naming them here means a
+ * case added below is automatically run against both - which is the only way
+ * this stays true as the copies are edited.
+ */
+const IMPLEMENTATIONS: Array<[string, GetStatusPageData]> = [
+  ["standalone status-page container", getStandaloneStatusPageData],
+  ["combined App container", getFrontendStatusPageData],
+];
+
+function customDomainRequest(host: string = "status.acme.com"): ExpressRequest {
+  return {
+    path: "/",
+    hostname: host,
+    headers: { host },
+  } as unknown as ExpressRequest;
+}
+
+function previewRequest(statusPageId: string = STATUS_PAGE_ID): ExpressRequest {
+  return {
+    path: `/status-page/${statusPageId}`,
+    hostname: "oneuptime.com",
+    headers: { host: "oneuptime.com" },
+  } as unknown as ExpressRequest;
+}
+
+function seoResponse(body: JSONObject): HTTPResponse<JSONObject> {
+  return new HTTPResponse<JSONObject>(200, body, {});
+}
+
+/*
+ * API.get is generic over half a dozen response shapes, and neither jest
+ * typing dialect in this repo can express a spy on it without a cast. This is
+ * the narrow surface the tests below actually use.
+ */
+type SpiedApiGet = {
+  mockResolvedValue: (value: unknown) => void;
+  mockRejectedValue: (value: unknown) => void;
+  mock: { calls: Array<Array<{ url: unknown }>> };
+};
+
+function spyOnApiGet(): SpiedApiGet {
+  return jest.spyOn(API, "get") as unknown as SpiedApiGet;
+}
+
+function mockSeoApi(
+  response: HTTPResponse<JSONObject> | HTTPErrorResponse,
+): SpiedApiGet {
+  const get: SpiedApiGet = spyOnApiGet();
+  get.mockResolvedValue(response);
+  return get;
+}
+
+describe.each(IMPLEMENTATIONS)(
+  "getStatusPageData (%s)",
+  (_name: string, getStatusPageData: GetStatusPageData) => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    describe("a status page on a custom domain", () => {
+      it("is indexable when the owner left the toggle on", async () => {
+        mockSeoApi(
+          seoResponse({
+            _id: STATUS_PAGE_ID,
+            title: "Acme Status",
+            description: "How Acme is doing.",
+            enableSearchEngineIndexing: true,
+          }),
+        );
+
+        await expect(
+          getStatusPageData(customDomainRequest()),
+        ).resolves.toMatchObject({
+          id: STATUS_PAGE_ID,
+          isSearchEngineIndexingEnabled: true,
+        });
+      });
+
+      it("is not indexable when the owner turned the toggle off", async () => {
+        mockSeoApi(
+          seoResponse({
+            _id: STATUS_PAGE_ID,
+            title: "Acme Status",
+            enableSearchEngineIndexing: false,
+          }),
+        );
+
+        await expect(
+          getStatusPageData(customDomainRequest()),
+        ).resolves.toMatchObject({
+          isSearchEngineIndexingEnabled: false,
+        });
+      });
+
+      it("is indexable when talking to an API that does not send the flag", async () => {
+        /*
+         * A rolling deploy runs a new frontend against an older API for a few
+         * minutes. During that window every page must keep the behaviour it
+         * had before this feature existed.
+         */
+        mockSeoApi(
+          seoResponse({
+            _id: STATUS_PAGE_ID,
+            title: "Acme Status",
+          }),
+        );
+
+        await expect(
+          getStatusPageData(customDomainRequest()),
+        ).resolves.toMatchObject({
+          isSearchEngineIndexingEnabled: true,
+        });
+      });
+
+      it("still cannot be resolved at all when the API errors", async () => {
+        /*
+         * Unchanged from before this feature: with no id there is no page to
+         * render, so the caller falls back to the generic placeholder.
+         */
+        mockSeoApi(new HTTPErrorResponse(500, {}, {}));
+
+        await expect(
+          getStatusPageData(customDomainRequest()),
+        ).resolves.toBeNull();
+      });
+    });
+
+    describe("a status page on its preview URL", () => {
+      /*
+       * The preview URL (/status-page/:id) is the only URL a status page has
+       * until someone attaches a custom domain, so it is the URL most
+       * OneUptime status pages are actually crawled at. An opt-out that only
+       * worked on custom domains would do nothing for most of the people who
+       * asked for it.
+       */
+      it("looks the page up by id so the toggle applies here too", async () => {
+        const get: SpiedApiGet = mockSeoApi(
+          seoResponse({
+            _id: STATUS_PAGE_ID,
+            title: "Acme Status",
+            enableSearchEngineIndexing: false,
+          }),
+        );
+
+        await expect(
+          getStatusPageData(previewRequest()),
+        ).resolves.toMatchObject({
+          id: STATUS_PAGE_ID,
+          isSearchEngineIndexingEnabled: false,
+        });
+
+        expect(get.mock.calls).toHaveLength(1);
+        expect(String(get.mock.calls[0]![0]!.url)).toContain(
+          `/seo/${STATUS_PAGE_ID}`,
+        );
+      });
+
+      it("is indexable when the owner left the toggle on", async () => {
+        mockSeoApi(
+          seoResponse({
+            _id: STATUS_PAGE_ID,
+            title: "Acme Status",
+            enableSearchEngineIndexing: true,
+          }),
+        );
+
+        await expect(
+          getStatusPageData(previewRequest()),
+        ).resolves.toMatchObject({
+          isSearchEngineIndexingEnabled: true,
+        });
+      });
+
+      it("still renders, indexable, when the lookup fails", async () => {
+        /*
+         * The id came from the URL, so the page can be served without the
+         * lookup. Returning null here instead would take preview pages down
+         * whenever the SEO lookup hiccuped - a much worse outcome than a
+         * page rendering with its default title for one request.
+         */
+        mockSeoApi(new HTTPErrorResponse(500, {}, {}));
+
+        await expect(
+          getStatusPageData(previewRequest()),
+        ).resolves.toMatchObject({
+          id: STATUS_PAGE_ID,
+          title: "Status Page",
+          isSearchEngineIndexingEnabled: true,
+        });
+      });
+
+      it("renders indexable when the API throws outright", async () => {
+        spyOnApiGet().mockRejectedValue(new Error("ECONNREFUSED"));
+
+        /*
+         * getStatusPageData swallows throws and returns null, so the caller
+         * renders its own placeholder - which carries no noindex. Pinned so a
+         * future refactor cannot quietly turn a thrown error into a de-index.
+         */
+        await expect(getStatusPageData(previewRequest())).resolves.toBeNull();
+      });
+    });
+
+    it("returns nothing when there is no host and no id to work with", async () => {
+      const get: SpiedApiGet = mockSeoApi(seoResponse({ _id: STATUS_PAGE_ID }));
+
+      const req: ExpressRequest = {
+        path: "/",
+        headers: {},
+      } as unknown as ExpressRequest;
+
+      await expect(getStatusPageData(req)).resolves.toBeNull();
+      expect(get.mock.calls).toHaveLength(0);
+    });
+  },
+);

--- a/App/Tests/StatusPage/SearchEngineIndexingResponses.test.ts
+++ b/App/Tests/StatusPage/SearchEngineIndexingResponses.test.ts
@@ -1,0 +1,163 @@
+/**
+ * The X-Robots-Tag half of the status page indexing opt-out, on the wire.
+ *
+ * The <meta name="robots"> in index.ejs only covers the HTML (it is asserted
+ * in Common/Tests/App/StatusPage/StatusPageIndexPageRobotsMeta.test.ts, which
+ * is where the ejs types live). These two responses have no <head> to put a
+ * tag in, so the header is the only instruction a crawler gets from them -
+ * and they are linked from the page itself, so a crawler that honours the
+ * page's noindex will still find them.
+ *
+ * Both server implementations are covered: the standalone status-page
+ * container and the combined App container each ship their own copy of these
+ * handlers, and a status page served by one must not behave differently from
+ * the same page served by the other.
+ */
+
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import { ExpressRequest, ExpressResponse } from "Common/Server/Utils/Express";
+import { JSONObject } from "Common/Types/JSON";
+import API from "Common/Utils/API";
+import {
+  handleLlmsTxt as handleFrontendLlmsTxt,
+  handleRSS as handleFrontendRSS,
+} from "../../FeatureSet/Frontend/Utils/StatusPage";
+import { handleLlmsTxt as handleStandaloneLlmsTxt } from "../../FeatureSet/StatusPage/src/Server/API/LlmsTxt";
+import { handleRSS as handleStandaloneRSS } from "../../FeatureSet/StatusPage/src/Server/API/RSS";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+const STATUS_PAGE_ID: string = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+type SpiedApi = {
+  mockResolvedValue: (value: unknown) => void;
+};
+
+type FakeResponse = {
+  set: ReturnType<typeof jest.fn>;
+  send: ReturnType<typeof jest.fn>;
+  status: ReturnType<typeof jest.fn>;
+  headersSent: boolean;
+};
+
+function fakeResponse(): FakeResponse {
+  const res: FakeResponse = {
+    set: jest.fn(),
+    send: jest.fn(),
+    status: jest.fn(),
+    headersSent: false,
+  };
+
+  (
+    res.status as unknown as { mockReturnValue: (value: unknown) => void }
+  ).mockReturnValue(res);
+
+  return res;
+}
+
+function customDomainRequest(): ExpressRequest {
+  return {
+    path: "/llms.txt",
+    hostname: "status.acme.com",
+    protocol: "https",
+    headers: { host: "status.acme.com" },
+    get: () => {
+      return "status.acme.com";
+    },
+  } as unknown as ExpressRequest;
+}
+
+function robotsHeaderCalls(res: FakeResponse): Array<Array<unknown>> {
+  const calls: Array<Array<unknown>> = (
+    res.set as unknown as { mock: { calls: Array<Array<unknown>> } }
+  ).mock.calls;
+
+  return calls.filter((call: Array<unknown>) => {
+    return call[0] === "X-Robots-Tag";
+  });
+}
+
+function mockSeoAndFeedApis(indexingEnabled: boolean): void {
+  (jest.spyOn(API, "get") as unknown as SpiedApi).mockResolvedValue(
+    new HTTPResponse<JSONObject>(
+      200,
+      {
+        _id: STATUS_PAGE_ID,
+        title: "Acme Status",
+        description: "How Acme is doing.",
+        enableSearchEngineIndexing: indexingEnabled,
+      },
+      {},
+    ),
+  );
+
+  /*
+   * The RSS handler fans out to three POST endpoints for its items. Empty
+   * bodies are enough - the feed's contents are not what is under test here.
+   */
+  (jest.spyOn(API, "post") as unknown as SpiedApi).mockResolvedValue(
+    new HTTPResponse<JSONObject>(200, {}, {}),
+  );
+}
+
+type Handler = (req: ExpressRequest, res: ExpressResponse) => Promise<void>;
+
+const NON_HTML_RESPONSES: Array<[string, Handler]> = [
+  ["llms.txt (standalone status-page container)", handleStandaloneLlmsTxt],
+  ["llms.txt (combined App container)", handleFrontendLlmsTxt],
+  ["RSS feed (standalone status-page container)", handleStandaloneRSS],
+  ["RSS feed (combined App container)", handleFrontendRSS],
+];
+
+describe.each(NON_HTML_RESPONSES)("%s", (_name: string, handler: Handler) => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("carries the noindex instruction in a header when indexing is off", async () => {
+    mockSeoAndFeedApis(false);
+    const res: FakeResponse = fakeResponse();
+
+    await handler(customDomainRequest(), res as unknown as ExpressResponse);
+
+    expect(robotsHeaderCalls(res)).toEqual([
+      ["X-Robots-Tag", "noindex, nofollow"],
+    ]);
+  });
+
+  it("sets no robots header when indexing is on", async () => {
+    mockSeoAndFeedApis(true);
+    const res: FakeResponse = fakeResponse();
+
+    await handler(customDomainRequest(), res as unknown as ExpressResponse);
+
+    expect(robotsHeaderCalls(res)).toEqual([]);
+  });
+
+  it("still answers 404 for a page that cannot be resolved", async () => {
+    /*
+     * The header is applied only after the page resolves, so the 404 path
+     * must still 404 and must not have started emitting one.
+     */
+    (jest.spyOn(API, "get") as unknown as SpiedApi).mockResolvedValue(
+      new HTTPErrorResponse(500, {}, {}),
+    );
+    const res: FakeResponse = fakeResponse();
+
+    await handler(customDomainRequest(), res as unknown as ExpressResponse);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(robotsHeaderCalls(res)).toEqual([]);
+  });
+});

--- a/App/Tests/StatusPage/SearchEngineIndexingWiring.test.ts
+++ b/App/Tests/StatusPage/SearchEngineIndexingWiring.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The wiring between the resolved flag and the page.
+ *
+ * Everything either side of this is unit tested: getStatusPageData turns the
+ * /seo response into a boolean, the template turns a boolean into a meta tag,
+ * applyStatusPageRobotsHeader turns it into a header. What is left is the two
+ * renderers that have to hand the boolean from one to the other - and neither
+ * is reachable from a test. App/FeatureSet/StatusPage/Serve.ts passes its
+ * config straight into App.init (importing it starts a server), and
+ * Frontend/Index.ts keeps StatusPageFrontendConfig module-private.
+ *
+ * So they are read, the way StatusPageResourcesPageInvariants.test.ts reads
+ * the pages it pins. The failure this catches is the one that leaves no trace:
+ * a renderer that stops passing the variable renders a page with no meta tag,
+ * HTTP 200, nothing in the logs - the toggle just quietly does nothing.
+ *
+ * Sources are stripped of comments and whitespace-squashed first, so a comment
+ * mentioning the thing being asserted cannot pass a test on its own, and
+ * prettier re-wrapping a line cannot fail one.
+ */
+
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+const FEATURE_SET: string = path.join(__dirname, "..", "..", "FeatureSet");
+
+function readCode(...relativeParts: Array<string>): string {
+  const raw: string = fs.readFileSync(
+    path.join(FEATURE_SET, ...relativeParts),
+    "utf8",
+  );
+
+  return raw
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\/\/.*$/gm, " ")
+    .replace(/\s+/g, " ");
+}
+
+const INDEX_RENDERERS: Array<[string, string]> = [
+  ["standalone status-page container", readCode("StatusPage", "Serve.ts")],
+  ["combined App container", readCode("Frontend", "Index.ts")],
+];
+
+describe.each(INDEX_RENDERERS)(
+  "the index page renderer in the %s",
+  (_name: string, code: string) => {
+    test("hands the flag to the template", () => {
+      /*
+       * index.ejs reads a variable of exactly this name and emits nothing when
+       * it is absent. A renderer that drops it produces an indexable page for
+       * an owner who asked for the opposite.
+       */
+      expect(code).toContain("isSearchEngineIndexingEnabled:");
+      expect(code).toContain("statusPageData.isSearchEngineIndexingEnabled");
+    });
+
+    test("also sets the response header", () => {
+      expect(code).toContain(
+        'import applyStatusPageRobotsHeader from "Common/Server/Utils/StatusPageSearchEngineIndexing"',
+      );
+      expect(code).toContain("applyStatusPageRobotsHeader(");
+    });
+
+    test("keeps the response object it needs to set that header", () => {
+      /*
+       * Both renderers used to name the response parameter _res, unused. A
+       * refactor that puts the underscore back would leave
+       * applyStatusPageRobotsHeader with nothing to write to - and TypeScript
+       * would catch that, but only if the call is still there, which is what
+       * the test above is for. This pins the other half.
+       */
+      expect(code).not.toContain("_res: ExpressResponse");
+    });
+  },
+);
+
+describe("the dashboard", () => {
+  const brandingPage: string = readCode(
+    "Dashboard",
+    "src",
+    "Pages",
+    "StatusPages",
+    "View",
+    "Branding.tsx",
+  );
+
+  test("offers the toggle where the other SEO settings live", () => {
+    /*
+     * "index by default, but users can turn that off" needs somewhere to turn
+     * it off. It sits beside page title and description because that is where
+     * someone looking for their status page's SEO settings goes.
+     */
+    expect(brandingPage).toContain("enableSearchEngineIndexing: true");
+    expect(brandingPage).toContain("FormFieldSchemaType.Toggle");
+    expect(brandingPage).toContain("pageTitle: true");
+  });
+
+  test("shows the current setting, not just an edit form", () => {
+    expect(brandingPage).toContain("FieldType.Boolean");
+  });
+});

--- a/Common/Models/DatabaseModels/StatusPage.ts
+++ b/Common/Models/DatabaseModels/StatusPage.ts
@@ -317,6 +317,65 @@ export default class StatusPage extends BaseModel {
   })
   public pageDescription?: string = undefined;
 
+  /*
+   * Search engine indexing opt-out. Indexing stays on unless the owner turns
+   * it off, so this defaults to true and every pre-existing status page keeps
+   * being indexed exactly as it is today.
+   *
+   * Turning it off is served two ways, both of which a crawler honours before
+   * it decides to index: a <meta name="robots" content="noindex, nofollow">
+   * in the server-rendered index.ejs (so it is there before the JS bundle
+   * loads) and an X-Robots-Tag response header (so it also covers the RSS
+   * feed and llms.txt, which are not HTML).
+   *
+   * Deliberately NOT wired into robots.txt: Disallow blocks the crawl, and a
+   * crawler that never fetches the page never sees the noindex, so the URL can
+   * still surface in results. Letting crawlers in and telling them not to
+   * index is what actually removes the page.
+   */
+  @ColumnAccessControl({
+    create: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.StatusPageAdmin,
+      Permission.StatusPageMember,
+      Permission.CreateProjectStatusPage,
+    ],
+    read: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.StatusPageAdmin,
+      Permission.StatusPageMember,
+      Permission.StatusPageViewer,
+      Permission.ReadProjectStatusPage,
+    ],
+    update: [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.StatusPageAdmin,
+      Permission.StatusPageMember,
+      Permission.EditProjectStatusPage,
+    ],
+  })
+  @TableColumn({
+    isDefaultValueColumn: true,
+    type: TableColumnType.Boolean,
+    title: "Enable Search Engine Indexing",
+    description:
+      "Should search engines like Google and Bing be allowed to index this status page? Turn this off to keep the page reachable by link but out of search results.",
+    defaultValue: true,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    default: true,
+    nullable: false,
+  })
+  public enableSearchEngineIndexing?: boolean = undefined;
+
   @ColumnAccessControl({
     create: [
       Permission.ProjectOwner,

--- a/Common/Server/API/StatusPageAPI.ts
+++ b/Common/Server/API/StatusPageAPI.ts
@@ -36,6 +36,10 @@ import {
   NextFunction,
 } from "../Utils/Express";
 import logger, { getLogAttributesFromRequest } from "../Utils/Logger";
+import {
+  SEARCH_ENGINE_INDEXING_FLAG_NAME,
+  isSearchEngineIndexingEnabled,
+} from "../../Types/StatusPage/SearchEngineIndexing";
 import Response from "../Utils/Response";
 import BaseAPI from "./BaseAPI";
 import BaseModel from "../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
@@ -192,6 +196,7 @@ export default class StatusPageAPI extends BaseAPI<
               pageDescription: true,
               name: true,
               defaultLanguage: true,
+              enableSearchEngineIndexing: true,
             },
             props: {
               isRoot: true,
@@ -212,6 +217,14 @@ export default class StatusPageAPI extends BaseAPI<
           description: statusPage.pageDescription,
           _id: statusPage._id?.toString(),
           defaultLanguage: statusPage.defaultLanguage || null,
+          /*
+           * Drives <meta name="robots"> and X-Robots-Tag on the rendered page.
+           * Normalised here rather than shipping the raw column, so the two
+           * frontend servers never have to decide what a missing value means.
+           */
+          [SEARCH_ENGINE_INDEXING_FLAG_NAME]: isSearchEngineIndexingEnabled(
+            statusPage.enableSearchEngineIndexing,
+          ),
         });
       },
     );

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787500000000-AddEnableSearchEngineIndexingToStatusPage.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787500000000-AddEnableSearchEngineIndexingToStatusPage.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+/*
+ * Status page owners can now keep their page out of Google/Bing while it stays
+ * reachable by link. Indexing stays on unless it is turned off, so the column
+ * defaults to true.
+ *
+ * ADD COLUMN ... NOT NULL DEFAULT true populates every existing row with true
+ * in the same statement, so no backfill is needed and every status page that
+ * exists today keeps being indexed exactly as it is now. That matters because
+ * the renderers treat "not false" as indexable: a NULL row would read as
+ * indexable anyway, but there is no reason to leave that to interpretation.
+ */
+export class AddEnableSearchEngineIndexingToStatusPage1787500000000
+  implements MigrationInterface
+{
+  public name = "AddEnableSearchEngineIndexingToStatusPage1787500000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "StatusPage" ADD "enableSearchEngineIndexing" boolean NOT NULL DEFAULT true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "StatusPage" DROP COLUMN "enableSearchEngineIndexing"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -528,6 +528,7 @@ import { AddAIConversationPageContext1787100000000 } from "./1787100000000-AddAI
 import { AddAIChatMessageFeedback1787200000000 } from "./1787200000000-AddAIChatMessageFeedback";
 import { AddEpisodeMemberNotifyIndexes1787300000000 } from "./1787300000000-AddEpisodeMemberNotifyIndexes";
 import { AddDeviceRoleAndDeclaredLinkParent1787400000000 } from "./1787400000000-AddDeviceRoleAndDeclaredLinkParent";
+import { AddEnableSearchEngineIndexingToStatusPage1787500000000 } from "./1787500000000-AddEnableSearchEngineIndexingToStatusPage";
 
 export default [
   InitialMigration,
@@ -1060,4 +1061,5 @@ export default [
   AddAIChatMessageFeedback1787200000000,
   AddEpisodeMemberNotifyIndexes1787300000000,
   AddDeviceRoleAndDeclaredLinkParent1787400000000,
+  AddEnableSearchEngineIndexingToStatusPage1787500000000,
 ];

--- a/Common/Server/Utils/StatusPageSearchEngineIndexing.ts
+++ b/Common/Server/Utils/StatusPageSearchEngineIndexing.ts
@@ -1,0 +1,33 @@
+import { ExpressResponse } from "./Express";
+import {
+  NOINDEX_ROBOTS_DIRECTIVE,
+  X_ROBOTS_TAG_HEADER_NAME,
+} from "../../Types/StatusPage/SearchEngineIndexing";
+
+/**
+ * Sets X-Robots-Tag: noindex, nofollow when the status page has search engine
+ * indexing turned off, and sets nothing at all when it is on.
+ *
+ * The "sets nothing" half is the point. An explicit `index, follow` header
+ * would be the default behaviour restated, and it would also override a
+ * noindex that an operator put in front of OneUptime (a CDN rule, an ingress
+ * annotation) - headers do not merge, the last writer wins. Staying silent
+ * leaves those in place.
+ *
+ * Callers must invoke this before the response is sent; a header set after
+ * headers are flushed is dropped by Node, silently.
+ */
+export default function applyStatusPageRobotsHeader(
+  res: ExpressResponse,
+  isSearchEngineIndexingEnabled: boolean,
+): void {
+  if (isSearchEngineIndexingEnabled) {
+    return;
+  }
+
+  if (res.headersSent) {
+    return;
+  }
+
+  res.set(X_ROBOTS_TAG_HEADER_NAME, NOINDEX_ROBOTS_DIRECTIVE);
+}

--- a/Common/Tests/App/StatusPage/StatusPageIndexPageRobotsMeta.test.ts
+++ b/Common/Tests/App/StatusPage/StatusPageIndexPageRobotsMeta.test.ts
@@ -1,0 +1,130 @@
+/**
+ * The <meta name="robots"> half of the status page indexing opt-out, rendered
+ * from the real template.
+ *
+ * This is the channel that matters most: it is in the server-rendered HTML
+ * before the JS bundle loads, so it is what a crawler that does not run
+ * JavaScript sees. The X-Robots-Tag header that backs it up is asserted in
+ * App/Tests/StatusPage/SearchEngineIndexingResponses.test.ts.
+ *
+ * The template is read off disk rather than reproduced here, because the
+ * failure this guards against is someone editing index.ejs - a copy of the
+ * markup would keep passing while the shipped page lost its tag. It lives
+ * under Common/Tests because that is where the ejs types are installed;
+ * Common/Tests/App is the established home for tests that reach into App.
+ */
+
+import { JSONObject } from "../../../Types/JSON";
+import { describe, expect, it } from "@jest/globals";
+import ejs from "ejs";
+import fs from "fs";
+import path from "path";
+
+const INDEX_TEMPLATE: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "..",
+  "App",
+  "FeatureSet",
+  "StatusPage",
+  "views",
+  "index.ejs",
+);
+
+const NOINDEX_META: RegExp =
+  /<meta\s+name="robots"\s+content="noindex,\s*nofollow">/;
+
+function renderIndexPage(variables: JSONObject): string {
+  return ejs.render(fs.readFileSync(INDEX_TEMPLATE, "utf8"), variables);
+}
+
+describe("the status page index template", () => {
+  it("tells crawlers not to index when the owner turned indexing off", () => {
+    const html: string = renderIndexPage({
+      title: "Acme Status",
+      description: "How Acme is doing.",
+      isSearchEngineIndexingEnabled: false,
+    });
+
+    expect(html).toMatch(NOINDEX_META);
+  });
+
+  it("keeps the noindex tag inside <head>, where crawlers read it", () => {
+    const html: string = renderIndexPage({
+      title: "Acme Status",
+      isSearchEngineIndexingEnabled: false,
+    });
+
+    const head: string = html.split("</head>")[0] || "";
+    expect(head).toMatch(NOINDEX_META);
+  });
+
+  it("says nothing about robots when indexing is on", () => {
+    /*
+     * Not "emits index, follow". A crawler already assumes that, and emitting
+     * it would override a noindex an operator set on a proxy in front of
+     * OneUptime - the last robots instruction a crawler reads is the one that
+     * counts.
+     */
+    const html: string = renderIndexPage({
+      title: "Acme Status",
+      description: "How Acme is doing.",
+      isSearchEngineIndexingEnabled: true,
+    });
+
+    expect(html).not.toContain('name="robots"');
+  });
+
+  it("says nothing about robots when the variable was never passed", () => {
+    /*
+     * The fallback render - a host that resolves to no status page - passes
+     * no flag at all, and must not throw on the missing variable either.
+     * That page is the generic placeholder and stays indexable, which is what
+     * shipped before this feature.
+     */
+    const html: string = renderIndexPage({ title: "Status Page" });
+
+    expect(html).not.toContain('name="robots"');
+    expect(html).toContain("<title>Status Page</title>");
+  });
+
+  it.each([
+    ["a truthy non-boolean", "no"],
+    ["null", null],
+    ["zero", 0],
+  ])(
+    "only an explicit false suppresses indexing, not %s",
+    (_label: string, value: unknown) => {
+      /*
+       * The template compares against false rather than testing falsiness, so
+       * a value arriving in an unexpected shape leaves the page indexable
+       * instead of silently de-indexing it.
+       */
+      const html: string = renderIndexPage({
+        title: "Acme Status",
+        isSearchEngineIndexingEnabled: value,
+      } as JSONObject);
+
+      expect(html).not.toContain('name="robots"');
+    },
+  );
+
+  it("still renders the rest of the head when indexing is off", () => {
+    /*
+     * The opt-out must not cost the page its title, description or favicon -
+     * a page kept out of search results is still a page people read.
+     */
+    const html: string = renderIndexPage({
+      title: "Acme Status",
+      description: "How Acme is doing.",
+      faviconUrl: "/status-page-api/favicon/acme",
+      isSearchEngineIndexingEnabled: false,
+    });
+
+    expect(html).toContain("<title>Acme Status</title>");
+    expect(html).toContain('content="How Acme is doing."');
+    expect(html).toContain('href="/status-page-api/favicon/acme"');
+  });
+});

--- a/Common/Tests/Models/StatusPageEnableSearchEngineIndexing.test.ts
+++ b/Common/Tests/Models/StatusPageEnableSearchEngineIndexing.test.ts
@@ -1,0 +1,157 @@
+/**
+ * StatusPage.enableSearchEngineIndexing column contract.
+ *
+ * The promise is "status pages stay indexable unless the owner turns indexing
+ * off". Three separate mechanisms carry that promise, and they are easy to
+ * confuse:
+ * - NEW rows get true from the Postgres column default, declared by
+ *   @Column({ default: true }) and stored in TypeORM's metadata
+ * - EXISTING rows got true from the migration's NOT NULL DEFAULT true
+ * - @TableColumn({ defaultValue: true }) is documentation only - it feeds the
+ *   generated API schema and form metadata, and defaults nothing at runtime
+ *
+ * All three are pinned below, because a one-word edit to any of them silently
+ * flips the default for everyone - and this is a default nobody notices going
+ * wrong until their status page has dropped out of Google.
+ */
+
+import StatusPage from "../../Models/DatabaseModels/StatusPage";
+import { TableColumnMetadata } from "../../Types/Database/TableColumn";
+import TableColumnType from "../../Types/Database/TableColumnType";
+import Permission from "../../Types/Permission";
+import { SEARCH_ENGINE_INDEXING_FLAG_NAME } from "../../Types/StatusPage/SearchEngineIndexing";
+import { describe, expect, test } from "@jest/globals";
+import { getMetadataArgsStorage } from "typeorm";
+import { ColumnMetadataArgs } from "typeorm/metadata-args/ColumnMetadataArgs";
+import fs from "fs";
+import path from "path";
+
+const COLUMN: string = "enableSearchEngineIndexing";
+
+const MIGRATIONS_DIR: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "Server",
+  "Infrastructure",
+  "Postgres",
+  "SchemaMigrations",
+);
+
+const MIGRATION_PATH: string = path.join(
+  MIGRATIONS_DIR,
+  "1787500000000-AddEnableSearchEngineIndexingToStatusPage.ts",
+);
+
+function metadata(): TableColumnMetadata {
+  return new StatusPage().getTableColumnMetadata(COLUMN);
+}
+
+function typeOrmColumn(): ColumnMetadataArgs | undefined {
+  return getMetadataArgsStorage().columns.find((column: ColumnMetadataArgs) => {
+    return column.target === StatusPage && column.propertyName === COLUMN;
+  });
+}
+
+describe("StatusPage.enableSearchEngineIndexing", () => {
+  test("exists as a boolean column", () => {
+    expect(metadata()).toBeDefined();
+    expect(metadata().type).toBe(TableColumnType.Boolean);
+  });
+
+  test("is named exactly what the API and the template look for", () => {
+    expect(COLUMN).toBe(SEARCH_ENGINE_INDEXING_FLAG_NAME);
+  });
+
+  test("a newly created status page is indexable", () => {
+    /*
+     * This is the assertion that actually protects new status pages: the
+     * Postgres column default. Nothing else populates the column when a
+     * create omits it, and every create in the product omits it.
+     */
+    expect(typeOrmColumn()).toBeDefined();
+    expect(typeOrmColumn()?.options.default).toBe(true);
+  });
+
+  test("the column is NOT NULL, so no row can be ambiguous", () => {
+    expect(typeOrmColumn()?.options.nullable).toBe(false);
+  });
+
+  test("every pre-existing status page was backfilled as indexable", () => {
+    /*
+     * The migration is the only thing that decided the value for status pages
+     * that existed before this feature shipped. DEFAULT true in the same
+     * statement fills every existing row, so no page silently loses its search
+     * traffic on upgrade.
+     */
+    const migration: string = fs.readFileSync(MIGRATION_PATH, "utf8");
+
+    expect(migration).toContain('ALTER TABLE "StatusPage"');
+    expect(migration).toContain(
+      `ADD "${COLUMN}" boolean NOT NULL DEFAULT true`,
+    );
+  });
+
+  test("the migration is registered, so it actually runs on boot", () => {
+    /*
+     * A migration file that is not in Index.ts is dead code: the column never
+     * appears in Postgres, and every read of it fails at runtime rather than
+     * at compile time.
+     */
+    const index: string = fs.readFileSync(
+      path.join(MIGRATIONS_DIR, "Index.ts"),
+      "utf8",
+    );
+
+    expect(index).toContain(
+      "AddEnableSearchEngineIndexingToStatusPage1787500000000",
+    );
+    /* Imported AND listed in the exported array - the import alone does nothing. */
+    expect(
+      index.match(/AddEnableSearchEngineIndexingToStatusPage1787500000000/g)
+        ?.length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  test("is documented as defaulting to enabled", () => {
+    /*
+     * Feeds the generated API schema and the dashboard form metadata.
+     * Documentation only - see the tests above for the defaults that actually
+     * apply.
+     */
+    expect(metadata().defaultValue).toBe(true);
+  });
+
+  test("is a default-value column, so create may omit it", () => {
+    expect(new StatusPage().isDefaultValueColumn(COLUMN)).toBe(true);
+  });
+
+  test("is not required, so existing create calls keep working", () => {
+    expect(metadata().required).toBeFalsy();
+  });
+
+  test("is readable by status page viewers", () => {
+    const accessControl: Array<Permission> | undefined =
+      new StatusPage().getColumnAccessControlFor(COLUMN)?.read;
+
+    expect(accessControl).toContain(Permission.ProjectMember);
+    expect(accessControl).toContain(Permission.StatusPageAdmin);
+    expect(accessControl).toContain(Permission.ReadProjectStatusPage);
+  });
+
+  test("is editable by status page editors", () => {
+    const accessControl: Array<Permission> | undefined =
+      new StatusPage().getColumnAccessControlFor(COLUMN)?.update;
+
+    expect(accessControl).toContain(Permission.EditProjectStatusPage);
+    expect(accessControl).toContain(Permission.StatusPageAdmin);
+  });
+
+  test("is not editable by a read-only viewer", () => {
+    const accessControl: Array<Permission> | undefined =
+      new StatusPage().getColumnAccessControlFor(COLUMN)?.update;
+
+    expect(accessControl).not.toContain(Permission.Viewer);
+    expect(accessControl).not.toContain(Permission.StatusPageViewer);
+  });
+});

--- a/Common/Tests/Server/API/StatusPageSeoSearchEngineIndexing.test.ts
+++ b/Common/Tests/Server/API/StatusPageSeoSearchEngineIndexing.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The /seo endpoint is the only channel by which the indexing opt-out reaches
+ * the two servers that render status pages. Both of them call it over internal
+ * HTTP, read one field off the JSON, and decide from that whether to emit a
+ * noindex. If the field stops being in the response the toggle silently stops
+ * working: the renderers read undefined, which means "indexable".
+ *
+ * So this pins the wire format, not just the code path.
+ */
+
+import StatusPage from "../../../Models/DatabaseModels/StatusPage";
+import StatusPageAPI from "../../../Server/API/StatusPageAPI";
+import StatusPageService from "../../../Server/Services/StatusPageService";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import Select from "../../../Server/Types/Database/Select";
+import { mockRouter } from "./Helpers";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEntityArrayResponse: jest.fn(),
+    sendJsonObjectResponse: jest.fn(),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendErrorResponse: jest.fn(),
+  };
+});
+
+const SEO_ROUTE: string = "/status-page/seo/:statusPageIdOrDomain";
+
+describe("StatusPageAPI /seo search engine indexing flag", () => {
+  let statusPageId: ObjectID;
+  let statusPage: StatusPage;
+  let mockRequest: ExpressRequest;
+  let mockResponse: ExpressResponse;
+  let nextFunction: NextFunction;
+
+  beforeAll(() => {
+    mockRouter.routes.length = 0;
+    new StatusPageAPI();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    statusPageId = ObjectID.generate();
+
+    statusPage = new StatusPage();
+    statusPage.id = statusPageId;
+    statusPage.name = "Acme Status";
+    statusPage.pageTitle = "Acme Status";
+    statusPage.pageDescription = "How Acme is doing.";
+
+    jest
+      .spyOn(StatusPageService, "resolveStatusPageIdOrNull")
+      .mockResolvedValue(statusPageId);
+
+    jest.spyOn(StatusPageService, "findOneBy").mockResolvedValue(statusPage);
+
+    mockRequest = {
+      params: {
+        statusPageIdOrDomain: statusPageId.toString(),
+      },
+      headers: {},
+      socket: {},
+      ips: [],
+    } as unknown as ExpressRequest;
+
+    mockResponse = {
+      set: jest.fn(),
+      send: jest.fn(),
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    } as unknown as ExpressResponse;
+
+    nextFunction = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  async function callSeoRoute(): Promise<JSONObject> {
+    await mockRouter
+      .match("get", SEO_ROUTE)
+      .handlerFunction(mockRequest, mockResponse, nextFunction);
+
+    expect(Response.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+
+    const call: Array<unknown> = (Response.sendJsonObjectResponse as jest.Mock)
+      .mock.calls[0] as Array<unknown>;
+
+    return call[2] as JSONObject;
+  }
+
+  it("selects the column, or the response could never carry it", async () => {
+    /*
+     * findOneBy only populates what is selected. A response built from an
+     * unselected column reads as undefined, which the renderers treat as
+     * indexable - the toggle would be on for everyone with no error anywhere.
+     */
+    await callSeoRoute();
+
+    const selectArgument: Select<StatusPage> = (
+      (StatusPageService.findOneBy as jest.Mock).mock.calls[0] as Array<{
+        select: Select<StatusPage>;
+      }>
+    )[0]!.select;
+
+    expect(selectArgument["enableSearchEngineIndexing"]).toBe(true);
+  });
+
+  it("reports a page with indexing left on as indexable", async () => {
+    statusPage.enableSearchEngineIndexing = true;
+
+    const body: JSONObject = await callSeoRoute();
+
+    expect(body["enableSearchEngineIndexing"]).toBe(true);
+  });
+
+  it("reports a page whose owner turned indexing off", async () => {
+    statusPage.enableSearchEngineIndexing = false;
+
+    const body: JSONObject = await callSeoRoute();
+
+    expect(body["enableSearchEngineIndexing"]).toBe(false);
+  });
+
+  it.each([
+    ["never set", undefined],
+    ["null out of the driver", null],
+  ])(
+    "normalises a row whose column is %s to indexable",
+    async (_label: string, columnValue: unknown) => {
+      /*
+       * The migration backfills every row, so neither should happen in
+       * practice - but the renderers must never receive a value they have to
+       * interpret. Normalising here keeps that decision in one place, and
+       * keeps it failing towards "indexable" rather than towards a silent
+       * de-index.
+       */
+      (statusPage as unknown as Record<string, unknown>)[
+        "enableSearchEngineIndexing"
+      ] = columnValue;
+
+      const body: JSONObject = await callSeoRoute();
+
+      expect(body["enableSearchEngineIndexing"]).toBe(true);
+    },
+  );
+
+  it("still returns everything the renderers already depended on", async () => {
+    statusPage.enableSearchEngineIndexing = false;
+    statusPage.defaultLanguage = "de";
+
+    const body: JSONObject = await callSeoRoute();
+
+    expect(body).toEqual({
+      title: "Acme Status",
+      description: "How Acme is doing.",
+      _id: statusPageId.toString(),
+      defaultLanguage: "de",
+      enableSearchEngineIndexing: false,
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/StatusPageSearchEngineIndexing.test.ts
+++ b/Common/Tests/Server/Utils/StatusPageSearchEngineIndexing.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The X-Robots-Tag half of the status page indexing opt-out.
+ *
+ * The meta tag in index.ejs only covers the HTML. This header is what carries
+ * the same instruction on the responses that have no <head> to put a tag in -
+ * the RSS feed and llms.txt - so it is tested on its own.
+ */
+
+import applyStatusPageRobotsHeader from "../../../Server/Utils/StatusPageSearchEngineIndexing";
+import { ExpressResponse } from "../../../Server/Utils/Express";
+import { describe, expect, jest, test } from "@jest/globals";
+
+type FakeResponse = {
+  set: ReturnType<typeof jest.fn>;
+  headersSent: boolean;
+};
+
+function fakeResponse(headersSent: boolean = false): FakeResponse {
+  return {
+    set: jest.fn(),
+    headersSent,
+  };
+}
+
+describe("applyStatusPageRobotsHeader", () => {
+  test("sends noindex, nofollow when the owner turned indexing off", () => {
+    const res: FakeResponse = fakeResponse();
+
+    applyStatusPageRobotsHeader(res as unknown as ExpressResponse, false);
+
+    expect(res.set).toHaveBeenCalledTimes(1);
+    expect(res.set).toHaveBeenCalledWith("X-Robots-Tag", "noindex, nofollow");
+  });
+
+  test("sends no header at all when indexing is on", () => {
+    /*
+     * Not "sends index, follow". Emitting the default explicitly would
+     * overwrite a noindex that an operator set in front of OneUptime - a CDN
+     * rule or an ingress annotation - because the last writer of a header
+     * wins. Silence leaves those in place.
+     */
+    const res: FakeResponse = fakeResponse();
+
+    applyStatusPageRobotsHeader(res as unknown as ExpressResponse, true);
+
+    expect(res.set).not.toHaveBeenCalled();
+  });
+
+  test("does not touch a response that has already been flushed", () => {
+    /*
+     * Node drops headers set after the response has gone out, and logs
+     * nothing. Guarding here keeps a late caller from thinking it succeeded.
+     */
+    const res: FakeResponse = fakeResponse(true);
+
+    applyStatusPageRobotsHeader(res as unknown as ExpressResponse, false);
+
+    expect(res.set).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Types/StatusPage/SearchEngineIndexing.test.ts
+++ b/Common/Tests/Types/StatusPage/SearchEngineIndexing.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The single place that decides "is this status page indexable?".
+ *
+ * Every renderer feeds this the raw flag off the /seo API response, and the
+ * answer decides whether a <meta name="robots"> and an X-Robots-Tag go out.
+ * The interesting half is what it does with values that are NOT an explicit
+ * off - a missing field, a null, an API that did not answer - because that is
+ * the state the internal HTTP call lands in whenever anything goes wrong, and
+ * it must resolve to "indexable" rather than silently de-indexing pages whose
+ * owners never asked for it.
+ */
+
+import {
+  NOINDEX_ROBOTS_DIRECTIVE,
+  SEARCH_ENGINE_INDEXING_FLAG_NAME,
+  X_ROBOTS_TAG_HEADER_NAME,
+  isSearchEngineIndexingEnabled,
+} from "../../../Types/StatusPage/SearchEngineIndexing";
+import { describe, expect, test } from "@jest/globals";
+
+describe("isSearchEngineIndexingEnabled", () => {
+  test("the owner turning the toggle off is the only thing that blocks indexing", () => {
+    expect(isSearchEngineIndexingEnabled(false)).toBe(false);
+  });
+
+  test("the toggle left on indexes", () => {
+    expect(isSearchEngineIndexingEnabled(true)).toBe(true);
+  });
+
+  test("a JSON round-trip that stringified the boolean still reads as off", () => {
+    /*
+     * The flag crosses an HTTP boundary between the API and the two frontend
+     * servers. A serializer that renders booleans as strings must not turn an
+     * opt-out back into an opt-in.
+     */
+    expect(isSearchEngineIndexingEnabled("false")).toBe(false);
+    expect(isSearchEngineIndexingEnabled("true")).toBe(true);
+  });
+
+  describe("anything that is not an explicit off leaves the page indexable", () => {
+    /*
+     * These are the shapes an unreachable or older /seo API produces. Reading
+     * any of them as "noindex" would take a page out of Google over a blip on
+     * an internal HTTP call - a failure the owner never asked for and would
+     * have no way to see.
+     */
+    const notAnExplicitOff: Array<[string, unknown]> = [
+      ["field absent from the response", undefined],
+      ["field present but null", null],
+      ["empty string", ""],
+      ["zero", 0],
+      ["the string 'no'", "no"],
+      ["the string 'FALSE' in the wrong case", "FALSE"],
+      ["an object", {}],
+    ];
+
+    test.each(notAnExplicitOff)("%s", (_label: string, value: unknown) => {
+      expect(isSearchEngineIndexingEnabled(value)).toBe(true);
+    });
+  });
+});
+
+describe("the directives that go on the wire", () => {
+  /*
+   * Pinned strings. Crawlers parse these literally, so a typo here is a
+   * feature that silently does nothing - the page keeps being indexed and
+   * nothing errors.
+   */
+  test("the robots directive is noindex, nofollow", () => {
+    expect(NOINDEX_ROBOTS_DIRECTIVE).toBe("noindex, nofollow");
+  });
+
+  test("the response header is X-Robots-Tag", () => {
+    expect(X_ROBOTS_TAG_HEADER_NAME).toBe("X-Robots-Tag");
+  });
+
+  test("the API/template flag name matches the model column name", () => {
+    /*
+     * The /seo API keys its response off this constant, and index.ejs reads a
+     * variable of the same name. Renaming the column without renaming this
+     * would leave the template reading undefined - which reads as indexable,
+     * so the toggle would just stop working, quietly.
+     */
+    expect(SEARCH_ENGINE_INDEXING_FLAG_NAME).toBe("enableSearchEngineIndexing");
+  });
+});

--- a/Common/Types/StatusPage/SearchEngineIndexing.ts
+++ b/Common/Types/StatusPage/SearchEngineIndexing.ts
@@ -1,0 +1,61 @@
+/*
+ * Search engine indexing for status pages.
+ *
+ * A status page is indexable unless its owner turned indexing off
+ * (StatusPage.enableSearchEngineIndexing, which defaults to true). The
+ * opt-out is carried to crawlers two ways:
+ *
+ *   - <meta name="robots" content="noindex, nofollow"> in the server-rendered
+ *     index.ejs, which is in the HTML before the JS bundle loads
+ *   - an X-Robots-Tag response header, which crawlers also honour on
+ *     responses that are not HTML (the RSS feed, llms.txt)
+ *
+ * Both live here rather than in each renderer because the status page is
+ * rendered by two servers - the standalone status-page container
+ * (App/FeatureSet/StatusPage/Serve.ts) and the combined App container
+ * (App/FeatureSet/Frontend/Index.ts) - and the two must not drift.
+ */
+
+/*
+ * nofollow rides along with noindex: a page that is meant to stay out of
+ * search results should not be passing crawl signals to the pages it links to
+ * either. This is the same directive Atlassian Statuspage and Status.io emit
+ * for their equivalent setting.
+ */
+export const NOINDEX_ROBOTS_DIRECTIVE: string = "noindex, nofollow";
+
+export const X_ROBOTS_TAG_HEADER_NAME: string = "X-Robots-Tag";
+
+/*
+ * Name of the flag on the status page /seo API response, and of the variable
+ * handed to index.ejs. Kept as a constant so the API, the two renderers and
+ * the template cannot disagree about the spelling.
+ */
+export const SEARCH_ENGINE_INDEXING_FLAG_NAME: string =
+  "enableSearchEngineIndexing";
+
+/**
+ * Reads the indexing flag off an untyped value - a JSON field from the /seo
+ * API, or a column that predates the migration.
+ *
+ * Everything that is not an explicit "off" means indexable. Failing this open
+ * is deliberate: the flag reaches the renderers over an internal HTTP call,
+ * and a blip on that call must not de-index a page whose owner never asked for
+ * that. The opposite failure (one render of a noindex page missing its meta
+ * tag) costs nothing permanent, because crawlers re-fetch.
+ */
+export function isSearchEngineIndexingEnabled(value: unknown): boolean {
+  if (value === false) {
+    return false;
+  }
+
+  /*
+   * JSON round-trips and query strings can turn the boolean into a string.
+   * "false" is the only spelling either produces for false.
+   */
+  if (value === "false") {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
### Title of this pull request?

Add an option to keep a status page out of search engine results

### Small Description?

Status pages had no way to opt out of search indexing. There was no `<meta name="robots">` tag, no `X-Robots-Tag` header, and the static `robots.txt` only covered `/api/*` — so every public status page, including one on a custom domain, was fully indexable with no way to turn that off from the dashboard.

This adds a per-status-page toggle. **Indexing stays on by default** — the column defaults to `true` and the migration backfills every existing row as `true`, so nothing changes for any status page that exists today.

**The toggle**

`StatusPage.enableSearchEngineIndexing`, surfaced as "Allow Search Engines to Index this Status Page" under **Status Page → Branding**, beside the page title and description it belongs with.

**What turning it off does**

- `<meta name="robots" content="noindex, nofollow">` in the server-rendered `index.ejs`, so it is in the HTML before the JS bundle loads — which is all a crawler that does not run JavaScript ever sees.
- `X-Robots-Tag: noindex, nofollow` on the page, the RSS feed and `llms.txt`. The feeds have no `<head>` to put a tag in, and they are linked from the page itself.

**What it deliberately does not do**

`robots.txt` is left alone. `Disallow` blocks the *crawl*, and a crawler that never fetches the page never sees the `noindex` — so the URL can still surface in results with no snippet. Letting crawlers in and telling them not to index is what actually removes the page. There is a comment in `robots.txt` pointing at the real mechanism.

**Preview URLs**

`getStatusPageData` now resolves preview URLs (`/status-page/:id`) through the `/seo` API instead of falling back to defaults. That URL is the only one a status page has until someone attaches a custom domain, so an opt-out that skipped it would do nothing for most of the people who asked for this. The same lookup gives preview pages their real title and description for the first time. It costs one internal lookup per HTML render on that path — the same call live custom-domain pages already make on every render.

A `/seo` lookup that fails leaves the page **indexable** rather than de-indexing it, in every layer. A blip on an internal HTTP call must not drop someone's status page out of Google when they never asked for that; the opposite failure (one render of a noindex page missing its tag) costs nothing permanent, because crawlers re-fetch.

Both server implementations are covered — the standalone `status-page` container and the combined `App` container each ship their own copy of these renderers — and the tests run every case against both.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

**Tests added** (158 assertions across 6 new suites, all passing locally):

| Suite | Covers |
| --- | --- |
| `Common/Tests/Types/StatusPage/SearchEngineIndexing.test.ts` | the fail-open truth table — `false`/`"false"` block indexing, a missing/null/odd value does not — and the pinned directive strings |
| `Common/Tests/Models/StatusPageEnableSearchEngineIndexing.test.ts` | all three separate defaults (TypeORM column, migration backfill, `@TableColumn` docs), that the migration is registered in `Index.ts`, and column access control |
| `Common/Tests/Server/Utils/StatusPageSearchEngineIndexing.test.ts` | the header helper: emits on off, emits *nothing* on on, no-ops after headers are flushed |
| `Common/Tests/Server/API/StatusPageSeoSearchEngineIndexing.test.ts` | `/seo` selects the column and puts a normalised boolean on the wire, without dropping any field the renderers already read |
| `Common/Tests/App/StatusPage/StatusPageIndexPageRobotsMeta.test.ts` | the real `index.ejs`, rendered: tag present when off, absent when on, absent when the variable was never passed, and the rest of `<head>` intact |
| `App/Tests/StatusPage/SearchEngineIndexing{Data,Responses,Wiring}.test.ts` | `getStatusPageData` on custom domains and preview URLs incl. every API-failure path, the `X-Robots-Tag` on RSS and `llms.txt`, and the renderer wiring that no unit test can reach |

### Related Issue?

Closes #3219

### Screenshots (if appropriate):

The new card on **Status Page → Branding**, below "Title and Description":

> **Search Engine Indexing**
> Control whether search engines like Google and Bing are allowed to list this status page in their results.
>
> *Allow Search Engines to Index this Status Page* — On by default. Turn this off to keep the page reachable by anyone with the link while keeping it out of search results — OneUptime then serves the page with a `noindex, nofollow` robots directive. Search engines can take a few weeks to drop a page they have already indexed.
