### PR TITLE
fix(ai-chat): require project membership on /ai-chat/* routes (GHSA-hm7m-9qjj-xj5x)

### DIFF
--- a/Common/Server/API/AIChatAPI.ts
+++ b/Common/Server/API/AIChatAPI.ts
@@ -9,7 +9,6 @@ import Express, {
 import Response from "../Utils/Response";
 import BadDataException from "../../Types/Exception/BadDataException";
 import PaymentRequiredException from "../../Types/Exception/PaymentRequiredException";
-import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException";
 import DatabaseCommonInteractionProps from "../../Types/BaseDatabase/DatabaseCommonInteractionProps";
 import ObjectID from "../../Types/ObjectID";
 import OneUptimeDate from "../../Types/Date";
@@ -89,18 +88,16 @@ router.post(
       const props: DatabaseCommonInteractionProps =
         await CommonAPI.getDatabaseCommonInteractionProps(req);
 
-      if (!props.userId) {
-        throw new NotAuthorizedException(
-          "AI chat requires a logged-in user session.",
-        );
-      }
-
-      if (!props.tenantId) {
-        throw new BadDataException("Project ID is required (tenantid header).");
-      }
-
-      const projectId: ObjectID = props.tenantId;
-      const userId: ObjectID = props.userId;
+      /*
+       * Membership, not just a session. getUserMiddleware admits an
+       * unauthenticated request as "public" and reads the tenant id straight
+       * out of the caller-supplied `tenantid` header, so the pair of checks
+       * this replaces proved only that SOMEBODY was logged in and had named
+       * SOME project - never that they belonged to the project they named.
+       */
+      const projectId: ObjectID =
+        CommonAPI.assertAuthenticatedProjectMember(props);
+      const userId: ObjectID = props.userId!;
 
       const content: string = (req.body["content"] as string) || "";
 
@@ -502,17 +499,30 @@ router.post(
       const props: DatabaseCommonInteractionProps =
         await CommonAPI.getDatabaseCommonInteractionProps(req);
 
-      if (!props.userId) {
-        throw new NotAuthorizedException(
-          "AI chat requires a logged-in user session.",
-        );
-      }
+      /*
+       * Membership, not just a session - see the note on send-message. This
+       * route is where that distinction was load-bearing: it took the project
+       * id straight from the header and handed it to root-privileged reads,
+       * so any logged-in user could name ANY project's UUID and be told which
+       * LLM providers that project has - their names, descriptions, types and
+       * models (GHSA-hm7m-9qjj-xj5x).
+       */
+      const projectId: ObjectID =
+        CommonAPI.assertAuthenticatedProjectMember(props);
 
-      if (!props.tenantId) {
-        throw new BadDataException("Project ID is required (tenantid header).");
-      }
-
-      const projectId: ObjectID = props.tenantId;
+      /*
+       * Membership is still not read authorisation. The very same rows served
+       * by a plain GET /llm-provider are gated there by LlmProvider's own read
+       * list, and a member whose teams grant none of those permissions has no
+       * business reading them through the chat picker instead. Asking the
+       * model for that list keeps the two paths from drifting apart.
+       */
+      CommonAPI.assertPermittedInProject({
+        databaseProps: props,
+        allowedPermissions: new LlmProvider().getReadPermissions(),
+        errorMessage:
+          "You do not have permission to read this project's AI providers.",
+      });
 
       const [providers, defaultProvider]: [
         Array<LlmProvider>,
@@ -561,18 +571,16 @@ router.post(
       const props: DatabaseCommonInteractionProps =
         await CommonAPI.getDatabaseCommonInteractionProps(req);
 
-      if (!props.userId) {
-        throw new NotAuthorizedException(
-          "AI chat requires a logged-in user session.",
-        );
-      }
-
-      if (!props.tenantId) {
-        throw new BadDataException("Project ID is required (tenantid header).");
-      }
-
-      const projectId: ObjectID = props.tenantId;
-      const userId: ObjectID = props.userId;
+      /*
+       * Membership, not just a session. getUserMiddleware admits an
+       * unauthenticated request as "public" and reads the tenant id straight
+       * out of the caller-supplied `tenantid` header, so the pair of checks
+       * this replaces proved only that SOMEBODY was logged in and had named
+       * SOME project - never that they belonged to the project they named.
+       */
+      const projectId: ObjectID =
+        CommonAPI.assertAuthenticatedProjectMember(props);
+      const userId: ObjectID = props.userId!;
 
       const conversationIdString: string = req.body["conversationId"] as string;
       const assistantMessageIdString: string = req.body[
@@ -743,18 +751,16 @@ router.post(
       const props: DatabaseCommonInteractionProps =
         await CommonAPI.getDatabaseCommonInteractionProps(req);
 
-      if (!props.userId) {
-        throw new NotAuthorizedException(
-          "AI chat requires a logged-in user session.",
-        );
-      }
-
-      if (!props.tenantId) {
-        throw new BadDataException("Project ID is required (tenantid header).");
-      }
-
-      const projectId: ObjectID = props.tenantId;
-      const userId: ObjectID = props.userId;
+      /*
+       * Membership, not just a session. getUserMiddleware admits an
+       * unauthenticated request as "public" and reads the tenant id straight
+       * out of the caller-supplied `tenantid` header, so the pair of checks
+       * this replaces proved only that SOMEBODY was logged in and had named
+       * SOME project - never that they belonged to the project they named.
+       */
+      const projectId: ObjectID =
+        CommonAPI.assertAuthenticatedProjectMember(props);
+      const userId: ObjectID = props.userId!;
 
       const conversationIdString: string = req.body["conversationId"] as string;
 
@@ -913,15 +919,8 @@ router.post(
       const props: DatabaseCommonInteractionProps =
         await CommonAPI.getDatabaseCommonInteractionProps(req);
 
-      if (!props.userId) {
-        throw new NotAuthorizedException(
-          "AI chat requires a logged-in user session.",
-        );
-      }
-
-      if (!props.tenantId) {
-        throw new BadDataException("Project ID is required (tenantid header).");
-      }
+      // Membership, not just a session - see the note on send-message.
+      CommonAPI.assertAuthenticatedProjectMember(props);
 
       const messageIdString: string = req.body["messageId"] as string;
 

--- a/Common/Server/API/CommonAPI.ts
+++ b/Common/Server/API/CommonAPI.ts
@@ -9,6 +9,14 @@ import SpanUtil from "../Utils/Telemetry/SpanUtil";
 import ObjectID from "../../Types/ObjectID";
 import BadDataException from "../../Types/Exception/BadDataException";
 import NotAuthorizedException from "../../Types/Exception/NotAuthorizedException";
+import Permission, {
+  PermissionHelper,
+  PermissionProps,
+  UserPermission,
+} from "../../Types/Permission";
+import DatabaseCommonInteractionPropsUtil, {
+  PermissionType,
+} from "../../Types/BaseDatabase/DatabaseCommonInteractionPropsUtil";
 
 export default class CommonAPI {
   /*
@@ -128,6 +136,87 @@ export default class CommonAPI {
     ) {
       throw new NotAuthorizedException(
         "You are not authorized to access this project's data.",
+      );
+    }
+  }
+
+  /*
+   * Membership is not read authorisation.
+   *
+   * assertAuthenticatedProjectMember proves the caller belongs to the project
+   * they named in the `tenantid` header; it says nothing about WHICH of that
+   * project's data they may see. A custom route that then reads with
+   * `isRoot: true` has skipped the permission check the equivalent CRUD read
+   * would have run, so the route has to make that check itself - otherwise a
+   * member whose teams grant nothing but, say, ReadProjectIncident still reads
+   * everything else the route happens to touch.
+   *
+   * The permissions consulted are the caller's grants in props.tenantId, so
+   * this must be called after assertAuthenticatedProjectMember has confirmed
+   * that tenant is one the caller actually belongs to.
+   *
+   * `allowedPermissions` is normally the model's own declared list, e.g.
+   * `new LlmProvider().getReadPermissions()`, so the custom route stays in
+   * step with the CRUD endpoint for the same data instead of inventing a
+   * second, quietly diverging rule.
+   *
+   * Permissions that are never assigned INSIDE a project are stripped from
+   * that list first. This matters: getUserPermissions merges the caller's
+   * global permissions in, and every caller - including an anonymous one -
+   * carries Permission.Public, which a model's read list very often contains
+   * (LlmProvider has it so the shared global providers stay readable). Left
+   * in, it would make this guard pass for anyone. What remains is the
+   * tenant-assignable subset, which is exactly what a team can grant.
+   *
+   * Stripping can empty the list, and an empty list denies everyone rather
+   * than admitting them - a model whose read access is purely public has no
+   * business behind this guard, and failing closed is the safe direction.
+   *
+   * Master admins bypass, matching every other permission gate in the API.
+   */
+  public static assertPermittedInProject(data: {
+    databaseProps: DatabaseCommonInteractionProps;
+    allowedPermissions: Array<Permission>;
+    errorMessage?: string | undefined;
+  }): void {
+    if (data.databaseProps.isMasterAdmin) {
+      return;
+    }
+
+    const tenantAssignablePermissions: Array<Permission> =
+      PermissionHelper.getTenantPermissionProps().map(
+        (permissionProps: PermissionProps) => {
+          return permissionProps.permission;
+        },
+      );
+
+    const requiredPermissions: Array<Permission> =
+      data.allowedPermissions.filter((permission: Permission) => {
+        return tenantAssignablePermissions.includes(permission);
+      });
+
+    /*
+     * Allow-only: getUserPermissions discriminates grants from denials by
+     * isBlockPermission, so a team's explicit BLOCK row for one of these
+     * permissions must never be counted as a grant of it.
+     */
+    const grantedPermissions: Array<Permission> =
+      DatabaseCommonInteractionPropsUtil.getUserPermissions(
+        data.databaseProps,
+        PermissionType.Allow,
+      ).map((userPermission: UserPermission) => {
+        return userPermission.permission;
+      });
+
+    if (
+      !PermissionHelper.doesPermissionsIntersect(
+        grantedPermissions,
+        requiredPermissions,
+      )
+    ) {
+      throw new NotAuthorizedException(
+        data.errorMessage ||
+          "You do not have permission to access this project's data.",
       );
     }
   }

--- a/Common/Tests/Server/API/AIChatCancelAndFeedback.test.ts
+++ b/Common/Tests/Server/API/AIChatCancelAndFeedback.test.ts
@@ -26,6 +26,7 @@ import AIRunStatus from "../../../Types/AI/AIRunStatus";
 import BadDataException from "../../../Types/Exception/BadDataException";
 import { JSONObject } from "../../../Types/JSON";
 import ObjectID from "../../../Types/ObjectID";
+import Permission from "../../../Types/Permission";
 import {
   afterEach,
   beforeEach,
@@ -61,10 +62,31 @@ const MESSAGE_ID: ObjectID = new ObjectID(
   "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
 );
 
+/*
+ * A real member of PROJECT_ID. The tenant access permission entry is not
+ * decoration: every AI chat route asserts membership of the project named in
+ * the `tenantid` header (CommonAPI.assertAuthenticatedProjectMember), so props
+ * carrying only a user id and a tenant id are exactly what an outsider sends
+ * and are refused before the handler does anything. AIChatRouteAuthorization
+ * covers that refusal; these tests are about what a legitimate member gets.
+ */
 const props: DatabaseCommonInteractionProps = {
   userId: USER_ID,
   tenantId: PROJECT_ID,
-} as DatabaseCommonInteractionProps;
+  userTenantAccessPermission: {
+    [PROJECT_ID.toString()]: {
+      _type: "UserTenantAccessPermission",
+      projectId: PROJECT_ID,
+      permissions: [
+        {
+          _type: "UserPermission",
+          permission: Permission.ProjectMember,
+          labelIds: [],
+        },
+      ],
+    },
+  },
+} as unknown as DatabaseCommonInteractionProps;
 
 function requestFor(body: JSONObject): ExpressRequest {
   return {

--- a/Common/Tests/Server/API/AIChatRouteAuthorization.test.ts
+++ b/Common/Tests/Server/API/AIChatRouteAuthorization.test.ts
@@ -1,0 +1,785 @@
+import { mockRouter } from "./Helpers";
+import "../../../Server/API/AIChatAPI";
+import CommonAPI from "../../../Server/API/CommonAPI";
+import UserMiddleware from "../../../Server/Middleware/UserAuthorization";
+import AIConversationService from "../../../Server/Services/AIConversationService";
+import AIConversationMessageService from "../../../Server/Services/AIConversationMessageService";
+import LlmProviderService from "../../../Server/Services/LlmProviderService";
+import ProjectService from "../../../Server/Services/ProjectService";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import LlmProvider from "../../../Models/DatabaseModels/LlmProvider";
+import DatabaseCommonInteractionProps from "../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import NotAuthorizedException from "../../../Types/Exception/NotAuthorizedException";
+import Dictionary from "../../../Types/Dictionary";
+import { JSONObject } from "../../../Types/JSON";
+import LlmType from "../../../Types/LLM/LlmType";
+import ObjectID from "../../../Types/ObjectID";
+import Permission, {
+  PermissionHelper,
+  PermissionProps,
+  UserGlobalAccessPermission,
+  UserPermission,
+  UserTenantAccessPermission,
+} from "../../../Types/Permission";
+import UserType from "../../../Types/UserType";
+import { beforeEach, describe, expect, it, jest, test } from "@jest/globals";
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendJsonObjectResponse: jest.fn(),
+  };
+});
+
+/*
+ * GHSA-hm7m-9qjj-xj5x - "AI chat provider listing discloses another project's
+ * provider inventory".
+ *
+ * Every /ai-chat/* route is a custom (non-CRUD) route mounted with nothing but
+ * UserMiddleware.getUserMiddleware, and that middleware is not an authorisation
+ * gate: it lets an unauthenticated request through as UserType.Public, and the
+ * tenant id it attaches comes from the caller-supplied `tenantid` header before
+ * any authorisation has run. The routes used to check only that props carried
+ * SOME user id and SOME tenant id, and then read with `isRoot: true`.
+ *
+ * /ai-chat/providers was the reportable consequence: a user of project A could
+ * send project B's UUID in that header and be handed B's LLM provider inventory
+ * - ids, names, internal descriptions, provider types and model names - without
+ * belonging to B at all.
+ *
+ * Two things are asserted here, and they are separate concerns:
+ *
+ *   1. MEMBERSHIP of the project named in the header (all five routes).
+ *   2. PERMISSION to read that project's providers once inside it
+ *      (/ai-chat/providers), because being a member is not the same as being
+ *      allowed to read every model the project owns - a plain GET
+ *      /llm-provider is gated by LlmProvider's own read list and the picker
+ *      must not be a way around it.
+ *
+ * The refusals are also asserted to happen BEFORE any lookup runs. An endpoint
+ * that rejects only after querying still leaks through timing, and it still
+ * confirms that a project id exists.
+ */
+
+const PROJECT_A_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+
+// The victim project. The attacker belongs to A and never to B.
+const PROJECT_B_ID: ObjectID = new ObjectID(
+  "22222222-2222-4222-8222-222222222222",
+);
+
+const ATTACKER_USER_ID: ObjectID = new ObjectID(
+  "33333333-3333-4333-8333-333333333333",
+);
+
+const PROVIDER_ID: ObjectID = new ObjectID(
+  "44444444-4444-4444-8444-444444444444",
+);
+
+const CONVERSATION_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+
+const MESSAGE_ID: ObjectID = new ObjectID(
+  "66666666-6666-4666-8666-666666666666",
+);
+
+const PROVIDERS_ROUTE: string = "/ai-chat/providers";
+
+type PropsOverrides = {
+  userId?: ObjectID | undefined;
+  tenantId?: ObjectID | undefined;
+
+  // The project the caller actually belongs to, if any.
+  memberOfProjectId?: ObjectID | undefined;
+
+  // Permissions that membership grants inside memberOfProjectId.
+  permissions?: Array<Permission> | undefined;
+
+  // Permissions the caller's teams explicitly BLOCK inside that project.
+  blockedPermissions?: Array<Permission> | undefined;
+
+  userType?: UserType | undefined;
+  isMasterAdmin?: boolean | undefined;
+  userGlobalAccessPermission?: UserGlobalAccessPermission | undefined;
+};
+
+/*
+ * Props shaped the way UserAuthorization actually builds them. That middleware
+ * resolves the caller's tenant permissions for THE PROJECT IN THE HEADER and
+ * keys the dictionary by that project alone, so a user reaching for a project
+ * they do not belong to arrives with `userTenantAccessPermission` undefined -
+ * which is the default here when no membership is given.
+ */
+function buildProps(
+  overrides?: PropsOverrides,
+): DatabaseCommonInteractionProps {
+  const props: DatabaseCommonInteractionProps = {
+    userId: overrides?.userId,
+    tenantId: overrides?.tenantId,
+    userType: overrides?.userType,
+    isMasterAdmin: overrides?.isMasterAdmin,
+    userGlobalAccessPermission: overrides?.userGlobalAccessPermission,
+  };
+
+  if (overrides?.memberOfProjectId) {
+    const permissions: Array<UserPermission> = (
+      overrides.permissions || [Permission.ProjectMember]
+    ).map((permission: Permission) => {
+      return {
+        _type: "UserPermission",
+        permission: permission,
+        labelIds: [],
+        isBlockPermission: false,
+      } as UserPermission;
+    });
+
+    for (const blocked of overrides.blockedPermissions || []) {
+      permissions.push({
+        _type: "UserPermission",
+        permission: blocked,
+        labelIds: [],
+        isBlockPermission: true,
+      } as UserPermission);
+    }
+
+    const tenantPermission: UserTenantAccessPermission = {
+      _type: "UserTenantAccessPermission",
+      projectId: overrides.memberOfProjectId,
+      permissions: permissions,
+      isBlockPermission: false,
+    } as UserTenantAccessPermission;
+
+    const dictionary: Dictionary<UserTenantAccessPermission> = {};
+    dictionary[overrides.memberOfProjectId.toString()] = tenantPermission;
+
+    props.userTenantAccessPermission = dictionary;
+  }
+
+  return props;
+}
+
+// A legitimate member of project B with the default Member role.
+function memberOfVictimProject(
+  permissions?: Array<Permission>,
+): DatabaseCommonInteractionProps {
+  return buildProps({
+    userId: ATTACKER_USER_ID,
+    tenantId: PROJECT_B_ID,
+    memberOfProjectId: PROJECT_B_ID,
+    permissions: permissions,
+  });
+}
+
+/*
+ * The advisory's reproduction, in props: a real, logged-in user whose only
+ * membership is project A, naming project B in the `tenantid` header.
+ */
+function outsiderReachingForVictimProject(): DatabaseCommonInteractionProps {
+  return buildProps({
+    userId: ATTACKER_USER_ID,
+    tenantId: PROJECT_B_ID,
+    memberOfProjectId: PROJECT_A_ID,
+    permissions: [Permission.ProjectOwner],
+  });
+}
+
+function requestFor(body?: JSONObject): ExpressRequest {
+  return {
+    body: body || {},
+    headers: {},
+    params: {},
+    query: {},
+  } as unknown as ExpressRequest;
+}
+
+function response(): ExpressResponse {
+  return {} as ExpressResponse;
+}
+
+type RouteCall = {
+  thrown: unknown;
+  nextCallCount: number;
+};
+
+async function callRoute(data: {
+  uri: string;
+  body?: JSONObject | undefined;
+}): Promise<RouteCall> {
+  const next: ReturnType<typeof jest.fn> = jest.fn();
+
+  await mockRouter
+    .match("post", data.uri)
+    .handlerFunction(
+      requestFor(data.body),
+      response(),
+      next as unknown as NextFunction,
+    );
+
+  return {
+    thrown: next.mock.calls[0]?.[0],
+    nextCallCount: next.mock.calls.length,
+  };
+}
+
+function callProviders(): Promise<RouteCall> {
+  return callRoute({ uri: PROVIDERS_ROUTE });
+}
+
+function sentPayload(): JSONObject {
+  const send: jest.Mock =
+    Response.sendJsonObjectResponse as unknown as jest.Mock;
+  return send.mock.calls[0]![2] as JSONObject;
+}
+
+function withProps(props: DatabaseCommonInteractionProps): void {
+  jest
+    .spyOn(CommonAPI, "getDatabaseCommonInteractionProps")
+    .mockResolvedValue(props);
+}
+
+// A provider row with the exact metadata the advisory says leaked.
+function victimProvider(): LlmProvider {
+  const provider: LlmProvider = new LlmProvider(PROVIDER_ID);
+  provider.name = "acme-internal-gpt";
+  provider.description = "Acme's private evaluation cluster";
+  provider.llmType = LlmType.OpenAI;
+  provider.modelName = "gpt-4o-secret-eval";
+  provider.isDefault = true;
+  provider.isGlobalLlm = false;
+  provider.projectId = PROJECT_B_ID;
+  return provider;
+}
+
+function stubProviderLookups(): void {
+  jest
+    .spyOn(LlmProviderService, "getSelectableProvidersForProject")
+    .mockResolvedValue([victimProvider()]);
+  jest
+    .spyOn(LlmProviderService, "getLLMProviderForProject")
+    .mockResolvedValue(victimProvider());
+}
+
+function providerLookupsRan(): boolean {
+  const selectable: jest.Mock =
+    LlmProviderService.getSelectableProvidersForProject as unknown as jest.Mock;
+  const forProject: jest.Mock =
+    LlmProviderService.getLLMProviderForProject as unknown as jest.Mock;
+
+  return selectable.mock.calls.length > 0 || forProject.mock.calls.length > 0;
+}
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+  stubProviderLookups();
+});
+
+describe("POST /ai-chat/providers - cross-tenant disclosure (GHSA-hm7m-9qjj-xj5x)", () => {
+  test("a user of project A cannot list project B's providers by sending B's tenantid", async () => {
+    withProps(outsiderReachingForVictimProject());
+
+    const call: RouteCall = await callRoute({ uri: PROVIDERS_ROUTE });
+
+    expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+    expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+  });
+
+  test("the refusal happens before any provider lookup runs, so nothing is queried for the victim project", async () => {
+    withProps(outsiderReachingForVictimProject());
+
+    await callProviders();
+
+    expect(providerLookupsRan()).toBe(false);
+    expect(
+      LlmProviderService.getSelectableProvidersForProject,
+    ).not.toHaveBeenCalled();
+    expect(LlmProviderService.getLLMProviderForProject).not.toHaveBeenCalled();
+  });
+
+  test("none of the leaked metadata reaches the response body", async () => {
+    withProps(outsiderReachingForVictimProject());
+
+    await callProviders();
+
+    expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+  });
+
+  test("the refusal does not distinguish a project that exists from one that does not", async () => {
+    withProps(outsiderReachingForVictimProject());
+    const realProject: RouteCall = await callProviders();
+
+    jest.clearAllMocks();
+    stubProviderLookups();
+
+    withProps(
+      buildProps({
+        userId: ATTACKER_USER_ID,
+        tenantId: new ObjectID("99999999-9999-4999-8999-999999999999"),
+        memberOfProjectId: PROJECT_A_ID,
+      }),
+    );
+    const madeUpProject: RouteCall = await callProviders();
+
+    expect((madeUpProject.thrown as NotAuthorizedException).message).toBe(
+      (realProject.thrown as NotAuthorizedException).message,
+    );
+  });
+
+  test("holding every permission in the caller's OWN project grants nothing in the target project", async () => {
+    withProps(
+      buildProps({
+        userId: ATTACKER_USER_ID,
+        tenantId: PROJECT_B_ID,
+        memberOfProjectId: PROJECT_A_ID,
+        permissions: [
+          Permission.ProjectOwner,
+          Permission.ProjectAdmin,
+          Permission.SettingsAdmin,
+          Permission.ReadProjectLlm,
+        ],
+      }),
+    );
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+    expect(providerLookupsRan()).toBe(false);
+  });
+
+  test("a tenant permission dictionary that is present but keyed for another project is refused", async () => {
+    const props: DatabaseCommonInteractionProps = buildProps({
+      userId: ATTACKER_USER_ID,
+      tenantId: PROJECT_B_ID,
+      memberOfProjectId: PROJECT_A_ID,
+    });
+
+    expect(props.userTenantAccessPermission).toBeDefined();
+    expect(
+      props.userTenantAccessPermission![PROJECT_B_ID.toString()],
+    ).toBeUndefined();
+
+    withProps(props);
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+  });
+
+  test("global permissions cannot stand in for membership of the target project", async () => {
+    withProps(
+      buildProps({
+        userId: ATTACKER_USER_ID,
+        tenantId: PROJECT_B_ID,
+        userGlobalAccessPermission: {
+          _type: "UserGlobalAccessPermission",
+          projectIds: [PROJECT_A_ID],
+          globalPermissions: [Permission.Public, Permission.CurrentUser],
+        } as UserGlobalAccessPermission,
+      }),
+    );
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+    expect(providerLookupsRan()).toBe(false);
+  });
+});
+
+describe("POST /ai-chat/providers - anonymous and unscoped callers", () => {
+  test("an unauthenticated caller (getUserMiddleware admits these as public) is refused", async () => {
+    withProps(buildProps({ tenantId: PROJECT_B_ID }));
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+    expect(providerLookupsRan()).toBe(false);
+  });
+
+  test("an anonymous caller carrying a stray tenant permission entry but no user id is refused", async () => {
+    withProps(
+      buildProps({
+        userId: undefined,
+        tenantId: PROJECT_B_ID,
+        memberOfProjectId: PROJECT_B_ID,
+      }),
+    );
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+    expect(providerLookupsRan()).toBe(false);
+  });
+
+  test("a request with no tenantid header is a bad request, not an authorization failure", async () => {
+    withProps(
+      buildProps({
+        userId: ATTACKER_USER_ID,
+        memberOfProjectId: PROJECT_A_ID,
+      }),
+    );
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.thrown).toBeInstanceOf(BadDataException);
+    expect((call.thrown as BadDataException).message).toBe(
+      "Project ID is required",
+    );
+    expect(providerLookupsRan()).toBe(false);
+  });
+
+  test("a project API key (no user id) cannot use this route - it is a logged-in-member route", async () => {
+    withProps(
+      buildProps({
+        tenantId: PROJECT_B_ID,
+        memberOfProjectId: PROJECT_B_ID,
+        userType: UserType.API,
+      }),
+    );
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+    expect(providerLookupsRan()).toBe(false);
+  });
+});
+
+describe("POST /ai-chat/providers - membership alone is not read authorization", () => {
+  test("a member whose teams grant no provider-read permission is refused", async () => {
+    withProps(memberOfVictimProject([Permission.ReadProjectIncident]));
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+    expect((call.thrown as NotAuthorizedException).message).toBe(
+      "You do not have permission to read this project's AI providers.",
+    );
+    expect(providerLookupsRan()).toBe(false);
+  });
+
+  test("a member with no tenant permissions at all is refused", async () => {
+    withProps(memberOfVictimProject([]));
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+    expect(providerLookupsRan()).toBe(false);
+  });
+
+  test("Permission.Public in LlmProvider's read list does not admit an ordinary member", async () => {
+    /*
+     * LlmProvider declares Permission.Public as a reader so the shared global
+     * providers stay visible, and getUserPermissions merges Public into EVERY
+     * caller's permissions. A guard that intersected the two lists naively
+     * would therefore pass for anyone at all - this is the regression test for
+     * that specific mistake.
+     */
+    expect(new LlmProvider().getReadPermissions()).toContain(Permission.Public);
+
+    withProps(memberOfVictimProject([Permission.ReadProjectIncident]));
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+  });
+
+  test("Permission.CurrentUser, which every logged-in caller carries, does not admit them either", async () => {
+    withProps(memberOfVictimProject([Permission.CurrentUser]));
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+  });
+
+  test("a team's BLOCK row for a reader permission is not counted as a grant of it", async () => {
+    withProps(
+      buildProps({
+        userId: ATTACKER_USER_ID,
+        tenantId: PROJECT_B_ID,
+        memberOfProjectId: PROJECT_B_ID,
+        permissions: [Permission.ReadProjectIncident],
+        blockedPermissions: [
+          Permission.ProjectMember,
+          Permission.ReadProjectLlm,
+        ],
+      }),
+    );
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+    expect(providerLookupsRan()).toBe(false);
+  });
+});
+
+describe("POST /ai-chat/providers - legitimate members still get their picker", () => {
+  const readerPermissions: Array<Permission> = [
+    Permission.ProjectOwner,
+    Permission.ProjectAdmin,
+    Permission.ProjectMember,
+    Permission.Viewer,
+    Permission.SettingsAdmin,
+    Permission.SettingsMember,
+    Permission.SettingsViewer,
+    Permission.ReadProjectLlm,
+  ];
+
+  test.each(readerPermissions)(
+    "a member holding %s is served the provider list",
+    async (permission: Permission) => {
+      withProps(memberOfVictimProject([permission]));
+
+      const call: RouteCall = await callProviders();
+
+      expect(call.nextCallCount).toBe(0);
+      expect(Response.sendJsonObjectResponse).toHaveBeenCalled();
+      expect((sentPayload()["providers"] as Array<JSONObject>).length).toBe(1);
+    },
+  );
+
+  test("every tenant-assignable reader of LlmProvider is covered by the cases above", () => {
+    /*
+     * Pins the positive cases to the model rather than to a copy of its list:
+     * if LlmProvider gains a new reader role, this fails until the cases above
+     * cover it too. The filter is the guard's own rule - only permissions a
+     * team can actually grant inside a project count.
+     */
+    const tenantAssignable: Array<Permission> =
+      PermissionHelper.getTenantPermissionProps().map(
+        (permissionProps: PermissionProps) => {
+          return permissionProps.permission;
+        },
+      );
+
+    const tenantAssignableReaders: Array<Permission> = new LlmProvider()
+      .getReadPermissions()
+      .filter((permission: Permission) => {
+        return tenantAssignable.includes(permission);
+      });
+
+    expect([...tenantAssignableReaders].sort()).toEqual(
+      [...readerPermissions].sort(),
+    );
+
+    // ...and the guard's filter really does drop Public, which everyone holds.
+    expect(tenantAssignableReaders).not.toContain(Permission.Public);
+  });
+
+  test("the lookup is made for the caller's own project, never for a header-supplied stranger", async () => {
+    withProps(memberOfVictimProject());
+
+    await callProviders();
+
+    expect(
+      LlmProviderService.getSelectableProvidersForProject,
+    ).toHaveBeenCalledWith(PROJECT_B_ID);
+    expect(LlmProviderService.getLLMProviderForProject).toHaveBeenCalledWith(
+      PROJECT_B_ID,
+    );
+  });
+
+  test("the response carries picker metadata and the default provider id", async () => {
+    withProps(memberOfVictimProject());
+
+    await callProviders();
+
+    const payload: JSONObject = sentPayload();
+
+    expect(payload["defaultProviderId"]).toBe(PROVIDER_ID.toString());
+
+    const providers: Array<JSONObject> = payload[
+      "providers"
+    ] as Array<JSONObject>;
+
+    expect(providers).toEqual([
+      {
+        id: PROVIDER_ID.toString(),
+        name: "acme-internal-gpt",
+        description: "Acme's private evaluation cluster",
+        llmType: LlmType.OpenAI.toString(),
+        modelName: "gpt-4o-secret-eval",
+        isDefault: true,
+        isGlobal: false,
+      },
+    ]);
+  });
+
+  test("secrets are never included in the response", async () => {
+    withProps(memberOfVictimProject());
+
+    await callProviders();
+
+    const providers: Array<JSONObject> = sentPayload()[
+      "providers"
+    ] as Array<JSONObject>;
+
+    for (const provider of providers) {
+      expect(provider).not.toHaveProperty("apiKey");
+      expect(provider).not.toHaveProperty("baseUrl");
+      expect(provider).not.toHaveProperty("additionalParams");
+    }
+  });
+
+  test("a master admin who is a member of the project is not blocked by the permission gate", async () => {
+    withProps(
+      buildProps({
+        userId: ATTACKER_USER_ID,
+        tenantId: PROJECT_B_ID,
+        memberOfProjectId: PROJECT_B_ID,
+        permissions: [Permission.ReadProjectIncident],
+        isMasterAdmin: true,
+      }),
+    );
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.nextCallCount).toBe(0);
+    expect(Response.sendJsonObjectResponse).toHaveBeenCalled();
+  });
+
+  test("master admin does NOT bypass the membership check", async () => {
+    withProps(
+      buildProps({
+        userId: ATTACKER_USER_ID,
+        tenantId: PROJECT_B_ID,
+        memberOfProjectId: PROJECT_A_ID,
+        isMasterAdmin: true,
+      }),
+    );
+
+    const call: RouteCall = await callProviders();
+
+    expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+    expect(providerLookupsRan()).toBe(false);
+  });
+});
+
+/*
+ * The other four /ai-chat/* routes shared the same "logged in somewhere +
+ * a tenantid header" check. None of them disclosed another project's data the
+ * way the provider listing did - their reads resolve under the caller's own
+ * props - but each still handed the header's project id to root-privileged
+ * work, so each is now gated on membership too. These cases lock that in.
+ */
+describe("every /ai-chat/* route requires membership of the project it was given", () => {
+  const routes: Array<{ uri: string; body: JSONObject }> = [
+    {
+      uri: "/ai-chat/send-message",
+      body: { content: "hello" },
+    },
+    {
+      uri: "/ai-chat/respond-to-approval",
+      body: {
+        conversationId: CONVERSATION_ID.toString(),
+        assistantMessageId: MESSAGE_ID.toString(),
+        approved: true,
+      },
+    },
+    {
+      uri: "/ai-chat/cancel-run",
+      body: { conversationId: CONVERSATION_ID.toString() },
+    },
+    {
+      uri: "/ai-chat/message-feedback",
+      body: { messageId: MESSAGE_ID.toString(), feedback: "Up" },
+    },
+    {
+      uri: PROVIDERS_ROUTE,
+      body: {},
+    },
+  ];
+
+  beforeEach(() => {
+    jest.spyOn(AIConversationService, "findOneById").mockResolvedValue(null);
+    jest
+      .spyOn(AIConversationMessageService, "findOneById")
+      .mockResolvedValue(null);
+    jest.spyOn(ProjectService, "findOneById").mockResolvedValue(null);
+  });
+
+  test.each(routes)(
+    "$uri refuses a caller who belongs to another project",
+    async (route: { uri: string; body: JSONObject }) => {
+      withProps(outsiderReachingForVictimProject());
+
+      const call: RouteCall = await callRoute({
+        uri: route.uri,
+        body: route.body,
+      });
+
+      expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+      expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(routes)(
+    "$uri refuses an unauthenticated caller",
+    async (route: { uri: string; body: JSONObject }) => {
+      withProps(buildProps({ tenantId: PROJECT_B_ID }));
+
+      const call: RouteCall = await callRoute({
+        uri: route.uri,
+        body: route.body,
+      });
+
+      expect(call.thrown).toBeInstanceOf(NotAuthorizedException);
+    },
+  );
+
+  test.each(routes)(
+    "$uri refuses before it touches the database",
+    async (route: { uri: string; body: JSONObject }) => {
+      withProps(outsiderReachingForVictimProject());
+
+      await callRoute({ uri: route.uri, body: route.body });
+
+      expect(AIConversationService.findOneById).not.toHaveBeenCalled();
+      expect(AIConversationMessageService.findOneById).not.toHaveBeenCalled();
+      expect(ProjectService.findOneById).not.toHaveBeenCalled();
+      expect(providerLookupsRan()).toBe(false);
+    },
+  );
+
+  test.each(routes)(
+    "$uri is mounted behind UserMiddleware.getUserMiddleware",
+    (route: { uri: string; body: JSONObject }) => {
+      expect(mockRouter.match("post", route.uri).middlewares).toContain(
+        UserMiddleware.getUserMiddleware,
+      );
+    },
+  );
+});
+
+describe("the fixed routes still reject a missing tenantid the same way", () => {
+  it("send-message reports the missing project id as a bad request", async () => {
+    withProps(
+      buildProps({
+        userId: ATTACKER_USER_ID,
+        memberOfProjectId: PROJECT_A_ID,
+      }),
+    );
+
+    const call: RouteCall = await callRoute({
+      uri: "/ai-chat/send-message",
+      body: { content: "hello" },
+    });
+
+    expect(call.thrown).toBeInstanceOf(BadDataException);
+    expect(call.thrown).not.toBeInstanceOf(NotAuthorizedException);
+  });
+});

--- a/Common/Tests/Server/API/CommonAPIAuthGuard.test.ts
+++ b/Common/Tests/Server/API/CommonAPIAuthGuard.test.ts
@@ -479,3 +479,293 @@ describe("CommonAPI.assertTenantScoped", () => {
     }).not.toThrow();
   });
 });
+
+/*
+ * Tests for CommonAPI.assertPermittedInProject — the third guard in the set.
+ *
+ * assertAuthenticatedProjectMember answers "are you in this project?" and
+ * assertResourceBelongsToProject answers "is this row in that project?".
+ * Neither answers "are you allowed to read this KIND of thing?", which is the
+ * question a CRUD read answers from the model's own access control lists and
+ * a custom route reading with `isRoot: true` skips entirely.
+ *
+ * The subtle part, and the reason this has its own tests: models routinely
+ * list Permission.Public as a reader (LlmProvider does, so the shared global
+ * providers stay visible), while getUserPermissions merges Public into EVERY
+ * caller's permission set — anonymous ones included. Intersecting the two
+ * lists as they come would therefore admit anybody. The guard first narrows
+ * the model's list to the permissions a team can actually grant inside a
+ * project.
+ */
+function buildPermittedProps(data: {
+  projectId: ObjectID;
+  granted: Array<Permission>;
+  blocked?: Array<Permission> | undefined;
+  isMasterAdmin?: boolean | undefined;
+}): DatabaseCommonInteractionProps {
+  const permissions: Array<UserPermission> = data.granted.map(
+    (permission: Permission) => {
+      return {
+        _type: "UserPermission",
+        permission: permission,
+        labelIds: [],
+        isBlockPermission: false,
+      } as UserPermission;
+    },
+  );
+
+  for (const blocked of data.blocked || []) {
+    permissions.push({
+      _type: "UserPermission",
+      permission: blocked,
+      labelIds: [],
+      isBlockPermission: true,
+    } as UserPermission);
+  }
+
+  const tenantPermission: UserTenantAccessPermission = {
+    _type: "UserTenantAccessPermission",
+    projectId: data.projectId,
+    permissions: permissions,
+  } as UserTenantAccessPermission;
+
+  const dictionary: Dictionary<UserTenantAccessPermission> = {};
+  dictionary[data.projectId.toString()] = tenantPermission;
+
+  return {
+    tenantId: data.projectId,
+    userId: ObjectID.generate(),
+    userTenantAccessPermission: dictionary,
+    isMasterAdmin: data.isMasterAdmin,
+  };
+}
+
+describe("CommonAPI.assertPermittedInProject", () => {
+  test("admits a caller holding one of the allowed permissions", () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    expect(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: buildPermittedProps({
+          projectId: projectId,
+          granted: [Permission.ProjectMember],
+        }),
+        allowedPermissions: [Permission.ProjectOwner, Permission.ProjectMember],
+      });
+    }).not.toThrow();
+  });
+
+  test("admits a caller holding any one of several allowed permissions", () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    expect(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: buildPermittedProps({
+          projectId: projectId,
+          granted: [Permission.ReadProjectIncident, Permission.SettingsViewer],
+        }),
+        allowedPermissions: [
+          Permission.ProjectOwner,
+          Permission.SettingsViewer,
+        ],
+      });
+    }).not.toThrow();
+  });
+
+  test("refuses a member of the project who holds none of them", () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    const thrown: unknown = captureThrown(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: buildPermittedProps({
+          projectId: projectId,
+          granted: [Permission.ReadProjectIncident],
+        }),
+        allowedPermissions: [Permission.ProjectOwner, Permission.ProjectAdmin],
+      });
+    });
+
+    expect(thrown).toBeInstanceOf(NotAuthorizedException);
+    expect((thrown as Exception).message).toBe(
+      "You do not have permission to access this project's data.",
+    );
+  });
+
+  test("uses the caller-supplied message when one is given", () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    const thrown: unknown = captureThrown(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: buildPermittedProps({
+          projectId: projectId,
+          granted: [],
+        }),
+        allowedPermissions: [Permission.ProjectOwner],
+        errorMessage:
+          "You do not have permission to read this project's AI providers.",
+      });
+    });
+
+    expect((thrown as Exception).message).toBe(
+      "You do not have permission to read this project's AI providers.",
+    );
+  });
+
+  /*
+   * The regression this guard exists to prevent. Public is in many models'
+   * read lists and in every caller's permission set, so a naive intersection
+   * would always succeed.
+   */
+  test("Permission.Public in the allowed list does not admit an ordinary member", () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    expect(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: buildPermittedProps({
+          projectId: projectId,
+          granted: [Permission.ReadProjectIncident],
+        }),
+        allowedPermissions: [Permission.Public, Permission.ProjectOwner],
+      });
+    }).toThrow(NotAuthorizedException);
+  });
+
+  test("Permission.Public in the allowed list does not admit an anonymous caller", () => {
+    const props: DatabaseCommonInteractionProps = {
+      tenantId: ObjectID.generate(),
+    };
+
+    expect(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: props,
+        allowedPermissions: [Permission.Public],
+      });
+    }).toThrow(NotAuthorizedException);
+  });
+
+  test("Permission.CurrentUser, which every logged-in caller carries, does not admit them either", () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    expect(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: buildPermittedProps({
+          projectId: projectId,
+          granted: [Permission.ReadProjectIncident],
+        }),
+        allowedPermissions: [Permission.CurrentUser, Permission.ProjectOwner],
+      });
+    }).toThrow(NotAuthorizedException);
+  });
+
+  test("an allowed list with nothing tenant-assignable in it denies everyone", () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    expect(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: buildPermittedProps({
+          projectId: projectId,
+          granted: [Permission.ProjectOwner],
+        }),
+        allowedPermissions: [Permission.Public, Permission.CurrentUser],
+      });
+    }).toThrow(NotAuthorizedException);
+  });
+
+  test("an empty allowed list denies everyone", () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    expect(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: buildPermittedProps({
+          projectId: projectId,
+          granted: [Permission.ProjectOwner],
+        }),
+        allowedPermissions: [],
+      });
+    }).toThrow(NotAuthorizedException);
+  });
+
+  /*
+   * userTenantAccessPermission holds grants AND denials in one array,
+   * discriminated only by isBlockPermission. Reading it raw would count a
+   * team's explicit block row as a grant.
+   */
+  test("a BLOCK row for an allowed permission is not counted as a grant of it", () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    expect(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: buildPermittedProps({
+          projectId: projectId,
+          granted: [Permission.ReadProjectIncident],
+          blocked: [Permission.ProjectOwner, Permission.ProjectMember],
+        }),
+        allowedPermissions: [Permission.ProjectOwner, Permission.ProjectMember],
+      });
+    }).toThrow(NotAuthorizedException);
+  });
+
+  test("permissions granted in ANOTHER project do not count", () => {
+    const callersProjectId: ObjectID = ObjectID.generate();
+    const targetProjectId: ObjectID = ObjectID.generate();
+
+    const props: DatabaseCommonInteractionProps = buildPermittedProps({
+      projectId: callersProjectId,
+      granted: [Permission.ProjectOwner],
+    });
+
+    // The header names the target project; the grants are for another one.
+    props.tenantId = targetProjectId;
+
+    expect(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: props,
+        allowedPermissions: [Permission.ProjectOwner],
+      });
+    }).toThrow(NotAuthorizedException);
+  });
+
+  test("a master admin bypasses the permission check", () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    expect(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: buildPermittedProps({
+          projectId: projectId,
+          granted: [],
+          isMasterAdmin: true,
+        }),
+        allowedPermissions: [Permission.ProjectOwner],
+      });
+    }).not.toThrow();
+  });
+
+  /*
+   * The guard answers one question only. Membership is assertAuthenticated-
+   * ProjectMember's job, and a route must call both — this test documents
+   * that calling only this one is not enough.
+   */
+  test("does not itself check membership — that stays with assertAuthenticatedProjectMember", () => {
+    const projectId: ObjectID = ObjectID.generate();
+    const props: DatabaseCommonInteractionProps = buildPermittedProps({
+      projectId: projectId,
+      granted: [Permission.ProjectOwner],
+    });
+
+    expect(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: props,
+        allowedPermissions: [Permission.ProjectOwner],
+      });
+    }).not.toThrow();
+
+    props.userId = undefined;
+
+    expect(() => {
+      CommonAPI.assertPermittedInProject({
+        databaseProps: props,
+        allowedPermissions: [Permission.ProjectOwner],
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
Fixes [GHSA-hm7m-9qjj-xj5x](https://github.com/OneUptime/oneuptime/security/advisories/GHSA-hm7m-9qjj-xj5x) — *AI chat provider listing discloses another project's provider inventory*.

## The bug

`POST /ai-chat/providers` is a custom (non-CRUD) route mounted with nothing but `UserMiddleware.getUserMiddleware`, which is not an authorisation gate: it admits an unauthenticated request as `UserType.Public`, and the tenant id it attaches comes from the caller-supplied `tenantid` header before any authorisation runs.

The handler checked only that props carried **some** user id and **some** tenant id, then handed the header's project id to `LlmProviderService`, which reads with `isRoot: true`. So any authenticated OneUptime user could send another project's UUID and be handed that project's LLM provider inventory — ids, names, internal descriptions, provider types and model names — with no membership of the target project at all. API keys, base URLs and other secret parameters were not returned, but the inventory itself is cross-tenant data.

The other four `/ai-chat/*` routes opened with the same pair of checks. Their reads resolve under the caller's own props (the privacy pin returns null for other users' rows), so they did not disclose another project's data the way the provider listing did — but each still handed the header's project id to root-privileged work, so all five are gated the same way here.

## The fix

**1. Membership, on every `/ai-chat/*` route.** Each now calls `CommonAPI.assertAuthenticatedProjectMember` — the guard `TeamComplianceAPI`, `WorkspaceNotificationRuleAPI`, `MonitorAPI` and friends already use for exactly this shape of route. The refusal happens before any lookup runs, so the endpoint cannot be used to tell an existing project id apart from a made-up one, and nothing is queried for the victim project.

**2. Permission, on `/ai-chat/providers`.** Membership is not read authorisation. The same rows served by a plain `GET /llm-provider` are gated there by `LlmProvider`'s own read list, and the chat picker must not be a way around it — so the route also calls a new `CommonAPI.assertPermittedInProject`, passing `new LlmProvider().getReadPermissions()`. Taking the list from the model keeps the two paths from drifting apart.

That guard narrows the model's list to **tenant-assignable** permissions before intersecting, and this is load-bearing rather than tidiness: models routinely list `Permission.Public` as a reader (`LlmProvider` does, so the shared global providers stay visible) while `getUserPermissions` merges `Public` into *every* caller's permission set, anonymous ones included. A naive intersection of the two lists would pass for anybody. Block rows are excluded from grants (the tenant permission array holds grants and denials together, discriminated only by `isBlockPermission`), an empty narrowed list fails closed, and master admins bypass as they do at every other permission gate.

No behaviour change for legitimate users: both UI callers (`useAiChat.ts` and the runbook step editor) already send `ModelAPI.getCommonHeaders()`, and the default Owner / Admin / Member teams carry `ProjectOwner` / `ProjectAdmin` / `ProjectMember`, all of which are readers of `LlmProvider`.

## Tests

New `Common/Tests/Server/API/AIChatRouteAuthorization.test.ts` — 51 cases:

- **The advisory's reproduction**: a user whose only membership is project A, naming project B in `tenantid`. Refused, nothing queried, no metadata in the response — and holding `ProjectOwner`/`SettingsAdmin`/`ReadProjectLlm` in their *own* project grants nothing in the target.
- The refusal for a real project id is byte-identical to the one for a made-up id, so the route cannot be used to enumerate project ids.
- Anonymous callers, project API keys (no user id), a missing `tenantid` header, a tenant permission dictionary present but keyed for another project, and global permissions offered in place of membership.
- Membership-without-permission: a member whose teams grant only `ReadProjectIncident`, a member with no tenant permissions, a member holding only `Public`/`CurrentUser`, and a member whose team carries an explicit **block** row for a reader permission.
- The happy paths: each of the eight tenant-assignable readers of `LlmProvider` is served the picker, the lookup uses the caller's own project, the payload shape is asserted, and no `apiKey`/`baseUrl`/`additionalParams` key is ever present. One case pins the positive list to `LlmProvider.getReadPermissions()` itself, so a new reader role fails the suite until it is covered.
- Master admin bypasses the permission gate but **not** the membership check.
- All five routes: refused for an outsider, refused for an anonymous caller, refused before touching the database, and still mounted behind `getUserMiddleware`.

**24 of the 51 fail against the pre-fix handler** (verified by reverting `AIChatAPI.ts` and re-running), including the advisory reproduction itself.

`CommonAPIAuthGuard.test.ts` gains direct coverage of `assertPermittedInProject` (13 cases: the `Public`/`CurrentUser` traps, block rows, cross-project grants, empty and non-tenant-assignable allowed lists, master admin, and the explicit note that it does not itself check membership). `AIChatCancelAndFeedback.test.ts`'s props fixture now describes a real member, since props carrying only a user id and a tenant id are precisely what an outsider sends.

## Verification

- `Common/Tests/Server/API` — 45 suites, 1021 tests, all pass.
- `Tests/Server/Utils/AI`, `Tests/Server/Services/LlmProvider*`, `Tests/Types/Permission` — 81 suites, 1406 tests, all pass.
- `npx tsc --noEmit` clean in `Common`; eslint and prettier clean on all touched files.
