### PR TITLE
fix(security): stop OAuth secrets and login credentials reaching log sinks

### DIFF
--- a/App/FeatureSet/Identity/API/Authentication.ts
+++ b/App/FeatureSet/Identity/API/Authentication.ts
@@ -419,12 +419,13 @@ router.post(
           ),
         ).toString();
 
+        /*
+         * The reset URL embeds the single-use reset token, which is a
+         * password-equivalent credential until it is spent -- so it is not
+         * logged, only mailed.
+         */
         logger.debug(
           "User forgot password: " + user.email?.toString(),
-          getLogAttributesFromRequest(req as RequestLike),
-        );
-        logger.debug(
-          "Reset Password URL: " + tokenVerifyUrl,
           getLogAttributesFromRequest(req as RequestLike),
         );
 
@@ -996,8 +997,17 @@ const login: LoginFunction = async (options: {
 
     const data: JSONObject = req.body["data"];
 
+    /*
+     * The request body is NOT logged here. This handler is shared by password
+     * login, TOTP verification and WebAuthn verification, so the body carries a
+     * plaintext password, a TOTP code, or a WebAuthn assertion on every call --
+     * and DEBUG output goes to stdout, the recent-log buffer and telemetry at
+     * once. Log the stage instead; the user is identified by the request
+     * attributes.
+     */
     logger.debug(
-      "Login request data: " + JSON.stringify(req.body, null, 2),
+      "Login request received. stage: " +
+        (verifyTotpAuth ? "totp" : verifyWebAuthn ? "webauthn" : "password"),
       getLogAttributesFromRequest(req as RequestLike),
     );
 

--- a/App/FeatureSet/MCP/Utils/MCPLogger.ts
+++ b/App/FeatureSet/MCP/Utils/MCPLogger.ts
@@ -7,6 +7,11 @@ import { LogLevel } from "Common/Server/EnvironmentConfig";
 import ConfigLogLevel from "Common/Server/Types/ConfigLogLevel";
 import { JSONObject } from "Common/Types/JSON";
 import Exception from "Common/Types/Exception/Exception";
+import {
+  REDACTED,
+  redactLogString,
+  redactLogValue,
+} from "Common/Server/Utils/LogRedaction";
 
 export type LogBody = string | JSONObject | Exception | Error | unknown;
 
@@ -19,13 +24,26 @@ export default class MCPLogger {
     return LogLevel;
   }
 
+  /*
+   * stderr is a log sink like any other, so this mirrors
+   * Common/Server/Utils/Logger: every body is redacted before it is written.
+   */
   public static serializeLogBody(body: LogBody): string {
-    if (typeof body === "string") {
-      return body;
-    } else if (body instanceof Exception || body instanceof Error) {
-      return body.message;
+    try {
+      if (typeof body === "string") {
+        return redactLogString(body);
+      } else if (body instanceof Exception || body instanceof Error) {
+        return redactLogString(body.message);
+      }
+
+      const serialized: string | undefined = JSON.stringify(
+        redactLogValue(body),
+      );
+
+      return serialized === undefined ? "" : serialized;
+    } catch {
+      return REDACTED;
     }
-    return JSON.stringify(body);
   }
 
   public static info(message: LogBody): void {

--- a/App/Tests/FeatureSet/Identity/AuthenticationCredentialLogging.test.ts
+++ b/App/Tests/FeatureSet/Identity/AuthenticationCredentialLogging.test.ts
@@ -1,0 +1,536 @@
+import {
+  buildRequest,
+  buildResponse,
+  createMockIdentityRouter,
+  MockIdentityRouter,
+  RouteHandler,
+} from "./IdentityRouterTestUtil";
+import ConfigLogLevel from "Common/Server/Types/ConfigLogLevel";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+/*
+ * Regression tests for GHSA-c4c2-r4hm-6pjj -- "Login passwords and MFA
+ * material are written to debug logs".
+ *
+ * The shared login handler used to open with
+ * `logger.debug("Login request data: " + JSON.stringify(req.body, null, 2))`.
+ * Three routes funnel through that handler, so the line wrote a plaintext
+ * password, a TOTP code, or a WebAuthn assertion -- plus the CAPTCHA token --
+ * to stdout, to the recent-log ring buffer the support bundle reads back, and
+ * to the telemetry exporter, on every login attempt made while DEBUG was on.
+ *
+ * These tests drive the REAL handlers with the REAL logger at DEBUG, with the
+ * sentinel values a login carries, and assert none of them reaches any sink.
+ * Mocking the logger would assert the mock.
+ */
+
+const mockRouter: MockIdentityRouter = createMockIdentityRouter();
+
+jest.mock("Common/Server/Utils/Express", () => {
+  const actual: Record<string, unknown> = jest.requireActual(
+    "Common/Server/Utils/Express",
+  ) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    __esModule: true,
+    default: {
+      getRouter: (): MockIdentityRouter => {
+        return mockRouter;
+      },
+    },
+    getClientIp: (): string => {
+      return "127.0.0.1";
+    },
+    extractDeviceInfo: (): Record<string, unknown> => {
+      return {};
+    },
+    headerValueToString: (): string => {
+      return "";
+    },
+  };
+});
+
+interface EmittedRecord {
+  body: string;
+  attributes?: Record<string, unknown> | undefined;
+}
+
+const emitted: Array<EmittedRecord> = [];
+
+// The telemetry sink, captured rather than exported.
+jest.mock("Common/Server/Utils/Telemetry", () => {
+  return {
+    __esModule: true,
+    default: {
+      getLogger: (): unknown => {
+        return {
+          emit: (record: EmittedRecord): void => {
+            emitted.push(record);
+          },
+        };
+      },
+    },
+  };
+});
+
+const userFindOneBy: jest.Mock = jest.fn();
+const verifyHashedColumnValue: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/UserService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: (...args: Array<unknown>): unknown => {
+        return userFindOneBy(...args);
+      },
+      verifyHashedColumnValue: (...args: Array<unknown>): unknown => {
+        return verifyHashedColumnValue(...args);
+      },
+      updateOneBy: jest.fn(),
+      updateOneById: jest.fn(),
+      updateOneByIdAndFetch: jest.fn(),
+      create: jest.fn(),
+      createUserOnSignup: jest.fn(),
+      countBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/EmailVerificationTokenService", () => {
+  return {
+    __esModule: true,
+    default: { findOneBy: jest.fn(), create: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Services/TeamMemberService", () => {
+  return { __esModule: true, default: { findOneBy: jest.fn() } };
+});
+
+jest.mock("Common/Server/Services/AccessTokenService", () => {
+  return {
+    __esModule: true,
+    default: { refreshUserAllPermissions: jest.fn() },
+  };
+});
+
+const totpFindOneBy: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/UserTotpAuthService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: (): Array<unknown> => {
+        return [];
+      },
+      findOneBy: (...args: Array<unknown>): unknown => {
+        return totpFindOneBy(...args);
+      },
+    },
+  };
+});
+
+const verifyWebAuthnAuthentication: jest.Mock = jest.fn();
+
+jest.mock("Common/Server/Services/UserWebAuthnService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: (): Array<unknown> => {
+        return [];
+      },
+      verifyAuthentication: (...args: Array<unknown>): unknown => {
+        return verifyWebAuthnAuthentication(...args);
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserSessionService", () => {
+  return {
+    __esModule: true,
+    default: {
+      createSession: jest.fn(),
+      findActiveSessionByRefreshToken: jest.fn(),
+      revokeSessionById: jest.fn(),
+      revokeSessionByRefreshToken: jest.fn(),
+      renewSessionWithNewRefreshToken: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/MailService", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendMail: (): Promise<void> => {
+        return Promise.resolve();
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/DatabaseConfig", () => {
+  return {
+    __esModule: true,
+    default: {
+      shouldDisableSignup: (): Promise<boolean> => {
+        return Promise.resolve(false);
+      },
+      getHost: (): Promise<unknown> => {
+        return Promise.resolve({
+          toString: (): string => {
+            return "localhost";
+          },
+        });
+      },
+      getHttpProtocol: (): Promise<unknown> => {
+        return Promise.resolve({
+          toString: (): string => {
+            return "http://";
+          },
+        });
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Cookie", () => {
+  return {
+    __esModule: true,
+    default: {
+      setUserCookie: jest.fn(),
+      removeAllCookies: jest.fn(),
+      removeCookie: jest.fn(),
+      getRefreshTokenFromExpressRequest: jest.fn(),
+      getUserTokenKey: jest.fn(),
+      getRefreshTokenKey: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Captcha", () => {
+  return {
+    __esModule: true,
+    default: {
+      verifyCaptcha: (): Promise<void> => {
+        return Promise.resolve();
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/JsonWebToken", () => {
+  return {
+    __esModule: true,
+    default: {
+      sign: (): string => {
+        return "signed-token";
+      },
+      signUserLoginToken: (): string => {
+        return "signed-user-token";
+      },
+    },
+  };
+});
+
+jest.mock("../../../FeatureSet/Identity/Utils/AuthenticationEmail", () => {
+  return {
+    __esModule: true,
+    default: { sendVerificationEmail: jest.fn() },
+  };
+});
+
+jest.mock("Common/Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendErrorResponse: jest.fn(),
+      sendEmptySuccessResponse: jest.fn(),
+      sendEntityResponse: jest.fn(),
+      sendJsonObjectResponse: jest.fn(),
+    },
+  };
+});
+
+// The real logger, deliberately: this suite is about what it writes.
+import logger from "Common/Server/Utils/Logger";
+
+// Importing the router registers every handler on the mock router above.
+import "../../../FeatureSet/Identity/API/Authentication";
+
+const PASSWORD_SENTINEL: string = "sentinel-password-a1b2c3d4";
+const TOTP_SENTINEL: string = "907351";
+const WEBAUTHN_SENTINEL: string = "sentinel-webauthn-assertion-e5f6a7b8";
+const CAPTCHA_SENTINEL: string = "sentinel-captcha-token-c9d0e1f2";
+
+type LogMethod = "info" | "error" | "warn" | "debug" | "trace";
+
+const ALL_LEVELS: Array<LogMethod> = [
+  "info",
+  "error",
+  "warn",
+  "debug",
+  "trace",
+];
+
+interface ConsoleSpy {
+  mock: { calls: Array<Array<unknown>> };
+}
+
+type ConsoleSpies = Record<LogMethod, ConsoleSpy>;
+
+let consoleSpies: ConsoleSpies;
+
+type CollectSinkTextFunction = () => string;
+
+// stdout + recent-log ring buffer + telemetry, as one blob to search.
+const collectSinkText: CollectSinkTextFunction = (): string => {
+  const parts: Array<string> = [];
+
+  for (const level of ALL_LEVELS) {
+    for (const call of consoleSpies[level].mock.calls) {
+      for (const argument of call) {
+        if (typeof argument === "string") {
+          parts.push(argument);
+        } else if (argument instanceof Error) {
+          parts.push(`${argument.message} ${argument.stack || ""}`);
+        } else {
+          try {
+            parts.push(JSON.stringify(argument));
+          } catch {
+            parts.push(String(argument));
+          }
+        }
+      }
+    }
+  }
+
+  for (const entry of logger.getRecentLogs()) {
+    parts.push(entry.message);
+  }
+
+  for (const record of emitted) {
+    parts.push(record.body);
+    parts.push(JSON.stringify(record.attributes || {}));
+  }
+
+  return parts.join("\n");
+};
+
+type InvokeFunction = (uri: string, body: unknown) => Promise<void>;
+
+const invoke: InvokeFunction = async (
+  uri: string,
+  body: unknown,
+): Promise<void> => {
+  const handler: RouteHandler = mockRouter.match("post", uri);
+  const req: ExpressRequest = buildRequest(body);
+  const res: ExpressResponse = buildResponse();
+  const next: NextFunction = ((): void => {}) as unknown as NextFunction;
+
+  /*
+   * The mocked services make some of these paths bail out; where they land is
+   * not the point. The point is what was written on the way there.
+   */
+  try {
+    await handler(req, res, next);
+  } catch {
+    // Intentionally ignored -- see above.
+  }
+};
+
+describe("Identity login handlers do not log credentials", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    emitted.length = 0;
+
+    jest.spyOn(logger, "getLogLevel").mockReturnValue(ConfigLogLevel.DEBUG);
+
+    consoleSpies = {
+      info: jest.spyOn(console, "info").mockImplementation(() => {}),
+      error: jest.spyOn(console, "error").mockImplementation(() => {}),
+      warn: jest.spyOn(console, "warn").mockImplementation(() => {}),
+      debug: jest.spyOn(console, "debug").mockImplementation(() => {}),
+      trace: jest.spyOn(console, "trace").mockImplementation(() => {}),
+    } as unknown as ConsoleSpies;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("does not log the password on /login", async () => {
+    await invoke("/login", {
+      data: { email: "user@example.com", password: PASSWORD_SENTINEL },
+      miscDataProps: { captchaToken: CAPTCHA_SENTINEL },
+    });
+
+    const output: string = collectSinkText();
+
+    // The handler ran and did log -- this is not passing on silence.
+    expect(output).toContain("Login request received");
+    expect(output).not.toContain(PASSWORD_SENTINEL);
+    expect(output).not.toContain(CAPTCHA_SENTINEL);
+
+    /*
+     * Redaction is the safety net; the fix is that the body is not serialized
+     * into a log line at all. `miscDataProps` is a body-only key that carries
+     * no secret of its own, so it would survive redaction -- seeing it here
+     * would mean the body is being dumped again.
+     */
+    expect(output).not.toContain("miscDataProps");
+  });
+
+  it("does not log the password when the account exists and the password is wrong", async () => {
+    userFindOneBy.mockResolvedValue({
+      id: {
+        toString: (): string => {
+          return "user-id";
+        },
+      },
+      password: {
+        toString: (): string => {
+          return "hashed";
+        },
+      },
+      email: {
+        toString: (): string => {
+          return "user@example.com";
+        },
+      },
+      isEmailVerified: true,
+      enableTwoFactorAuth: false,
+    });
+    verifyHashedColumnValue.mockResolvedValue(false);
+
+    await invoke("/login", {
+      data: { email: "user@example.com", password: PASSWORD_SENTINEL },
+    });
+
+    expect(collectSinkText()).not.toContain(PASSWORD_SENTINEL);
+  });
+
+  it("does not log the TOTP code on /verify-totp-auth", async () => {
+    userFindOneBy.mockResolvedValue({
+      id: {
+        toString: (): string => {
+          return "user-id";
+        },
+      },
+      password: {
+        toString: (): string => {
+          return "hashed";
+        },
+      },
+      email: {
+        toString: (): string => {
+          return "user@example.com";
+        },
+      },
+      isEmailVerified: true,
+      enableTwoFactorAuth: true,
+    });
+    verifyHashedColumnValue.mockResolvedValue(true);
+    totpFindOneBy.mockResolvedValue(null);
+
+    await invoke("/verify-totp-auth", {
+      data: {
+        email: "user@example.com",
+        password: PASSWORD_SENTINEL,
+        code: TOTP_SENTINEL,
+        twoFactorAuthId: "6543210987654321",
+      },
+    });
+
+    const output: string = collectSinkText();
+
+    expect(output).toContain("Login request received");
+    expect(output).not.toContain(TOTP_SENTINEL);
+    expect(output).not.toContain(PASSWORD_SENTINEL);
+  });
+
+  it("does not log WebAuthn assertion material on /verify-webauthn-auth", async () => {
+    userFindOneBy.mockResolvedValue({
+      id: {
+        toString: (): string => {
+          return "user-id";
+        },
+      },
+      password: {
+        toString: (): string => {
+          return "hashed";
+        },
+      },
+      email: {
+        toString: (): string => {
+          return "user@example.com";
+        },
+      },
+      isEmailVerified: true,
+      enableTwoFactorAuth: true,
+    });
+    verifyHashedColumnValue.mockResolvedValue(true);
+    verifyWebAuthnAuthentication.mockRejectedValue(
+      new Error("verification failed") as never,
+    );
+
+    await invoke("/verify-webauthn-auth", {
+      data: {
+        email: "user@example.com",
+        password: PASSWORD_SENTINEL,
+        credential: {
+          id: "credential-id",
+          rawId: WEBAUTHN_SENTINEL,
+          response: {
+            clientDataJSON: WEBAUTHN_SENTINEL,
+            authenticatorData: WEBAUTHN_SENTINEL,
+            signature: WEBAUTHN_SENTINEL,
+            userHandle: WEBAUTHN_SENTINEL,
+          },
+        },
+      },
+    });
+
+    const output: string = collectSinkText();
+
+    expect(output).toContain("Login request received");
+    expect(output).not.toContain(WEBAUTHN_SENTINEL);
+    expect(output).not.toContain(PASSWORD_SENTINEL);
+  });
+
+  it("does not log the reset-password link, which carries a live reset token", async () => {
+    const resetToken: string = "sentinel-reset-token-b3c4d5e6";
+
+    userFindOneBy.mockResolvedValue({
+      id: {
+        toString: (): string => {
+          return "user-id";
+        },
+      },
+      email: {
+        toString: (): string => {
+          return "user@example.com";
+        },
+      },
+      name: {
+        toString: (): string => {
+          return "User";
+        },
+      },
+      resetPasswordToken: resetToken,
+    });
+
+    await invoke("/forgot-password", {
+      data: { email: "user@example.com" },
+    });
+
+    expect(collectSinkText()).not.toContain(resetToken);
+  });
+});

--- a/Common/Server/API/MicrosoftTeamsAPI.ts
+++ b/Common/Server/API/MicrosoftTeamsAPI.ts
@@ -386,12 +386,13 @@ export default class MicrosoftTeamsAPI {
               "https://graph.microsoft.com/User.Read https://graph.microsoft.com/Team.ReadBasic.All https://graph.microsoft.com/Channel.ReadBasic.All https://graph.microsoft.com/ChannelMessage.Send",
           };
 
+          /*
+           * The token request body holds the app client secret and the
+           * authorization code, and the response holds the user access and
+           * refresh tokens -- neither is logged.
+           */
           logger.debug(
-            "Microsoft Teams Token Request Body (static redirect): ",
-            getLogAttributesFromRequest(req as any),
-          );
-          logger.debug(
-            tokenRequestBody,
+            "Exchanging Microsoft Teams authorization code for an access token.",
             getLogAttributesFromRequest(req as any),
           );
 
@@ -420,10 +421,9 @@ export default class MicrosoftTeamsAPI {
 
           const tokenData: JSONObject = tokenResponse.data;
           logger.debug(
-            "Microsoft Teams Token Response (static redirect): ",
+            "Microsoft Teams token exchange completed.",
             getLogAttributesFromRequest(req as any),
           );
-          logger.debug(tokenData, getLogAttributesFromRequest(req as any));
 
           if (!tokenData["access_token"]) {
             return Response.sendErrorResponse(
@@ -725,11 +725,12 @@ export default class MicrosoftTeamsAPI {
             Date.now() + Math.max(0, (expiresInSec - 60) * 1000),
           ).toISOString();
 
+          // tokenData carries the app access token; only its expiry is logged.
           logger.debug(
-            "App Access Token acquired via admin consent: ",
+            "Microsoft Graph app token acquired via admin consent. expiresAt: " +
+              expiresAtIso,
             getLogAttributesFromRequest(req as any),
           );
-          logger.debug(tokenData, getLogAttributesFromRequest(req as any));
 
           // Get available teams from user auth token
           const userId: string = stateParts[1]!;

--- a/Common/Server/API/SlackAPI.ts
+++ b/Common/Server/API/SlackAPI.ts
@@ -164,11 +164,15 @@ export default class SlackAPI {
           redirect_uri: redirectUri.toString(),
         };
 
+        /*
+         * Neither the token request nor the token response is logged: the
+         * request carries the app client secret and the authorization code,
+         * and the response carries the bot and user access tokens.
+         */
         logger.debug(
-          "Slack Auth Request Body: ",
+          "Exchanging Slack authorization code for an access token.",
           getLogAttributesFromRequest(req as any),
         );
-        logger.debug(requestBody, getLogAttributesFromRequest(req as any));
 
         // send the request to slack api to get the access token https://slack.com/api/oauth.v2.access
 
@@ -188,10 +192,9 @@ export default class SlackAPI {
         const responseBody: JSONObject = response.data;
 
         logger.debug(
-          "Slack Auth Request Body: ",
+          "Slack token exchange completed. ok: " + String(responseBody["ok"]),
           getLogAttributesFromRequest(req as any),
         );
-        logger.debug(responseBody, getLogAttributesFromRequest(req as any));
 
         let slackTeamId: string | undefined = undefined;
         let slackBotAccessToken: string | undefined = undefined;
@@ -384,11 +387,11 @@ export default class SlackAPI {
           redirect_uri: redirectUri.toString(),
         };
 
+        // Same as above: the body holds the client secret and the auth code.
         logger.debug(
-          "Slack Auth Request Body: ",
+          "Exchanging Slack authorization code for a user token.",
           getLogAttributesFromRequest(req as any),
         );
-        logger.debug(requestBody, getLogAttributesFromRequest(req as any));
 
         // send the request to slack api to get the access token https://slack.com/api/oauth.v2.access
 
@@ -408,10 +411,10 @@ export default class SlackAPI {
         const responseBody: JSONObject = response.data;
 
         logger.debug(
-          "Slack User Auth Request Body: ",
+          "Slack user token exchange completed. ok: " +
+            String(responseBody["ok"]),
           getLogAttributesFromRequest(req as any),
         );
-        logger.debug(responseBody, getLogAttributesFromRequest(req as any));
 
         if (
           responseBody["id_token"] &&
@@ -425,11 +428,11 @@ export default class SlackAPI {
               "base64",
             ).toString("utf8"),
           );
+          // The decoded ID token is identity material; only the fact is logged.
           logger.debug(
-            "Decoded ID Token: ",
+            "Decoded Slack ID token.",
             getLogAttributesFromRequest(req as any),
           );
-          logger.debug(decodedIdToken, getLogAttributesFromRequest(req as any));
           responseBody["id_token"] = decodedIdToken;
         }
 

--- a/Common/Server/Utils/LogRedaction.ts
+++ b/Common/Server/Utils/LogRedaction.ts
@@ -1,0 +1,576 @@
+/*
+ * Centralized, deny-by-default redaction for everything that reaches a log
+ * sink.
+ *
+ * Every log record this process emits is written to three places: process
+ * stdout/stderr, the in-memory recent-log ring buffer that the master-admin
+ * support bundle surfaces, and the configured OpenTelemetry log exporter. A
+ * credential that reaches a log statement therefore lands in three retention
+ * systems at once, and DEBUG is a normal troubleshooting level operators turn
+ * on in production.
+ *
+ * So call sites are not trusted to be careful. Logger runs every message body
+ * and every attribute through here first, at every level, and the rules below
+ * are the single place that decides what a secret looks like. Removing a
+ * careless `logger.debug(requestBody)` is still the right fix at the call
+ * site -- this is the net underneath it.
+ *
+ * Two matching strategies, both applied:
+ *
+ *   1. Structural. Objects are walked recursively and a value is replaced
+ *      whenever its KEY names a credential (`client_secret`, `access_token`,
+ *      `password`, `Authorization`, ...). This is the reliable one: it does
+ *      not care what the value looks like.
+ *
+ *   2. Textual. Strings are swept for credentials that were already flattened
+ *      into text -- `JSON.stringify(req.body)` in a template literal, an OAuth
+ *      callback URL with `?code=`, an `Authorization: Bearer` header dump -- and
+ *      for values that are self-identifying regardless of key (JWTs, Slack
+ *      `xoxb-` tokens, PEM private key blocks).
+ *
+ * Over-redaction is the intended failure mode. Losing a token count from a
+ * debug line costs a little context; leaking a bot token costs the workspace.
+ */
+
+export const REDACTED: string = "[REDACTED]";
+
+// Deep enough for any real log payload, shallow enough to bound the walk.
+const MAX_DEPTH: number = 12;
+
+/*
+ * A key is sensitive when its normalized form (lowercased, separators
+ * stripped, so `client_secret`, `clientSecret` and `CLIENT-SECRET` all collapse
+ * to `clientsecret`) CONTAINS one of these fragments. Substring matching is
+ * deliberate: it catches `slackBotAccessToken`, `x-api-key`,
+ * `refresh_token_expires_in` and every other spelling nobody thought to list.
+ */
+const SENSITIVE_KEY_FRAGMENTS: Array<string> = [
+  "password",
+  "passwd",
+  "passphrase",
+  "secret",
+  "token",
+  "credential",
+  "authorization",
+  "cookie",
+  "apikey",
+  "privatekey",
+  "accesskey",
+  "secretkey",
+  "signingkey",
+  "encryptionkey",
+  "assertion",
+  "attestation",
+  "signature",
+  "salt",
+  "otp",
+  "jwt",
+  "bearer",
+  "sessionid",
+  "authcode",
+  "authorizationcode",
+  "verificationcode",
+  "backupcode",
+  "recoverycode",
+  "onetimecode",
+  "logincode",
+  "resetcode",
+];
+
+/*
+ * Keys that contain a sensitive fragment but never carry the secret itself.
+ * These are worth keeping: LLM token accounting and expiry timestamps are
+ * exactly the sort of thing someone turns DEBUG on to look at.
+ */
+const NON_SENSITIVE_KEYS: Set<string> = new Set<string>([
+  "tokencount",
+  "tokencounts",
+  "tokensused",
+  "totaltokens",
+  "inputtokens",
+  "outputtokens",
+  "prompttokens",
+  "completiontokens",
+  "cachedtokens",
+  "reasoningtokens",
+  "maxtokens",
+  "tokenlimit",
+  "tokenusage",
+  "tokentype",
+  "hastoken",
+  "hasaccesstoken",
+  "hasrefreshtoken",
+  "tokenexpiresat",
+  "tokenexpiry",
+  "accesstokenexpiresat",
+  "refreshtokenexpiresat",
+  "expirestokenat",
+  "isauthorized",
+  "authorizationurl",
+  "authorizationendpoint",
+]);
+
+/*
+ * Keys whose sensitivity depends on the value. `code` is both the OAuth
+ * authorization code / TOTP code we must never log AND the `ECONNREFUSED` on
+ * every network error, so it is decided by looksLikeSecretCode below.
+ */
+const VALUE_DEPENDENT_KEYS: Set<string> = new Set<string>(["code", "codes"]);
+
+/*
+ * Keys that are always secret but carry no fragment above -- WebAuthn
+ * assertion material, mostly.
+ */
+const SENSITIVE_EXACT_KEYS: Set<string> = new Set<string>([
+  "pin",
+  "totp",
+  "mfa",
+  "rawid",
+  "clientdatajson",
+  "authenticatordata",
+  "userhandle",
+  "challenge",
+  "twofactorsecret",
+]);
+
+export type NormalizeLogKeyFunction = (key: string) => string;
+
+export const normalizeLogKey: NormalizeLogKeyFunction = (
+  key: string,
+): string => {
+  return key.toLowerCase().replace(/[^a-z0-9]/g, "");
+};
+
+/*
+ * Error codes (`ECONNREFUSED`, `ERR_BAD_REQUEST`), exception codes
+ * (`BadDataException`) and short status-ish strings are identifiers, never
+ * credentials. Anything else under a `code` key -- digits (a TOTP), or a long
+ * opaque string with separators (an OAuth authorization code) -- is treated as
+ * a secret.
+ */
+const IDENTIFIER_CODE_REGEX: RegExp = /^[A-Za-z][A-Za-z0-9]*$/;
+
+type LooksLikeSecretCodeFunction = (value: unknown) => boolean;
+
+const looksLikeSecretCode: LooksLikeSecretCodeFunction = (
+  value: unknown,
+): boolean => {
+  if (typeof value === "number") {
+    // HTTP status / exit codes are small; a 6-digit TOTP is not.
+    return Math.abs(value) >= 1000;
+  }
+
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  if (value.length === 0) {
+    return false;
+  }
+
+  return !(IDENTIFIER_CODE_REGEX.test(value) && value.length < 32);
+};
+
+export type IsSensitiveLogKeyFunction = (
+  key: string,
+  value?: unknown,
+) => boolean;
+
+export const isSensitiveLogKey: IsSensitiveLogKeyFunction = (
+  key: string,
+  value?: unknown,
+): boolean => {
+  const normalized: string = normalizeLogKey(key);
+
+  if (!normalized) {
+    return false;
+  }
+
+  if (NON_SENSITIVE_KEYS.has(normalized)) {
+    return false;
+  }
+
+  if (SENSITIVE_EXACT_KEYS.has(normalized)) {
+    return true;
+  }
+
+  if (VALUE_DEPENDENT_KEYS.has(normalized)) {
+    return looksLikeSecretCode(value);
+  }
+
+  return SENSITIVE_KEY_FRAGMENTS.some((fragment: string) => {
+    return normalized.includes(fragment);
+  });
+};
+
+/*
+ * ---------------------------------------------------------------------------
+ * String rules
+ * ---------------------------------------------------------------------------
+ */
+
+/*
+ * Credential words as they appear INSIDE text. Kept separate from the key
+ * fragment list because a couple of the structural fragments (`salt`, `otp`)
+ * are too short to match safely against free-form prose.
+ */
+const TEXT_SECRET_WORDS: string =
+  "password|passwd|passphrase|secret|token|credential|credentials|authorization|cookie|api[_-]?key|private[_-]?key|access[_-]?key|assertion|attestation|signature|raw[_-]?id|client[_-]?data[_-]?json|authenticator[_-]?data|user[_-]?handle|two[_-]?factor[_-]?secret";
+
+// Bounded, so a long non-matching run cannot blow up on backtracking.
+const KEY_PREFIX: string = "[A-Za-z0-9_.-]{0,40}";
+const KEY_SUFFIX: string = "[A-Za-z0-9_.-]{0,40}";
+
+interface StringRedactionRule {
+  name: string;
+  regex: RegExp;
+  replacement: string;
+}
+
+const STRING_REDACTION_RULES: Array<StringRedactionRule> = [
+  {
+    /*
+     * Runs first: a bare `Bearer <token>` with no key in front of it would
+     * otherwise survive every rule below.
+     *
+     * The lookahead requires the value to carry a digit or a separator, so the
+     * scheme words keep working as English -- "Basic authentication failed" and
+     * "Token exchange completed" are log lines, not credentials.
+     */
+    name: "authorization-scheme",
+    regex:
+      /\b(Bearer|Basic|Token)\s+(?=[A-Za-z0-9._~+/=-]*[0-9._~+/=-])[A-Za-z0-9._~+/=-]{8,}/gi,
+    replacement: `$1 ${REDACTED}`,
+  },
+  {
+    /*
+     * JSON string members: {"client_secret":"abc"} -- the shape produced by
+     * JSON.stringify(req.body) inside a log message. The value pattern allows
+     * escaped quotes so an escaped-quote-bearing password cannot end the match
+     * early and leave its tail in the clear.
+     */
+    name: "json-string-member",
+    regex: new RegExp(
+      `"(${KEY_PREFIX}(?:${TEXT_SECRET_WORDS})${KEY_SUFFIX})"(\\s*:\\s*)"(?:[^"\\\\]|\\\\.)*"`,
+      "gi",
+    ),
+    replacement: `"$1"$2"${REDACTED}"`,
+  },
+  {
+    // JSON numeric members: {"password":123456}
+    name: "json-number-member",
+    regex: new RegExp(
+      `"(${KEY_PREFIX}(?:${TEXT_SECRET_WORDS})${KEY_SUFFIX})"(\\s*:\\s*)-?\\d+(?:\\.\\d+)?`,
+      "gi",
+    ),
+    replacement: `"$1"$2"${REDACTED}"`,
+  },
+  {
+    /*
+     * Unquoted key/value text: form bodies (`client_secret=abc&...`), query
+     * strings, header dumps (`Authorization: Bearer abc`) and prose
+     * (`password: hunter2`).
+     *
+     * The value alternation tries `Bearer <token>` first, so a header dump is
+     * consumed whole -- stopping at the scheme word would leave the token
+     * itself sitting in the clear right after the placeholder.
+     */
+    name: "key-value-text",
+    regex: new RegExp(
+      `\\b(${KEY_PREFIX}(?:${TEXT_SECRET_WORDS})${KEY_SUFFIX})(\\s*[=:]\\s*)(?:"[^"]*"|'[^']*'|(?:Bearer|Basic|Token)\\s+[^\\s,;&)\\]}"']+|[^\\s,;&)\\]}"']+)`,
+      "gi",
+    ),
+    replacement: `$1$2${REDACTED}`,
+  },
+  {
+    /*
+     * OAuth authorization codes and OTPs as query/form parameters. Restricted
+     * to the `code=` form so ordinary prose ("error code: ECONNREFUSED") keeps
+     * its meaning -- structural redaction covers the JSON case.
+     */
+    name: "code-parameter",
+    regex: /\b(code|pin|otp|totp)(=)[^\s&#"'<>]+/gi,
+    replacement: `$1$2${REDACTED}`,
+  },
+  {
+    // {"code":"..."} in flattened JSON.
+    name: "json-code-member",
+    regex: /"(code|pin|otp|totp)"(\s*:\s*)"(?:[^"\\]|\\.)*"/gi,
+    replacement: `"$1"$2"${REDACTED}"`,
+  },
+  {
+    name: "jwt",
+    regex: /\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "slack-token",
+    regex: /\bxox[abeprs]-[A-Za-z0-9-]{8,}/gi,
+    replacement: REDACTED,
+  },
+  {
+    name: "slack-app-token",
+    regex: /\bxapp-[A-Za-z0-9-]{8,}/gi,
+    replacement: REDACTED,
+  },
+  {
+    name: "github-token",
+    regex:
+      /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}\b|\bgithub_pat_[A-Za-z0-9_]{20,}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "aws-access-key-id",
+    regex: /\b(?:AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASCA)[0-9A-Z]{16}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "google-api-key",
+    regex: /\bAIza[0-9A-Za-z_-]{35}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "private-key-block",
+    regex:
+      /-----BEGIN (?:[A-Z0-9]+ )*PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z0-9]+ )*PRIVATE KEY-----/g,
+    replacement: REDACTED,
+  },
+  {
+    // Credentials embedded in a URL: postgres://user:password@host/db
+    name: "url-basic-auth",
+    regex: /\b([a-z][a-z0-9+.-]*:\/\/)([^\s/:@]+):[^\s/@]+@/gi,
+    replacement: `$1$2:${REDACTED}@`,
+  },
+];
+
+/*
+ * Cheap pre-filter. Almost every log line contains none of these, and skipping
+ * fifteen regexes for those keeps redaction off the cost of ordinary logging.
+ * It must stay a superset of every rule above -- a word missing here is a
+ * credential that never gets redacted.
+ */
+const SENSITIVE_TEXT_HINT_REGEX: RegExp = new RegExp(
+  [
+    TEXT_SECRET_WORDS,
+    "code=",
+    "pin=",
+    "otp=",
+    "totp=",
+    '"code"',
+    '"pin"',
+    '"otp"',
+    '"totp"',
+    "bearer\\s",
+    "basic\\s",
+    "eyJ",
+    "xox",
+    "xapp-",
+    "gh[opusr]_",
+    "github_pat_",
+    "AKIA|ASIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASCA",
+    "AIza",
+    "-----BEGIN",
+    "://",
+  ].join("|"),
+  "i",
+);
+
+export type RedactLogStringFunction = (value: string) => string;
+
+export const redactLogString: RedactLogStringFunction = (
+  value: string,
+): string => {
+  if (!value) {
+    return value;
+  }
+
+  if (!SENSITIVE_TEXT_HINT_REGEX.test(value)) {
+    return value;
+  }
+
+  let redacted: string = value;
+
+  for (const rule of STRING_REDACTION_RULES) {
+    /*
+     * The rules carry the /g flag and are module-level, so lastIndex has to be
+     * reset -- String.replace does that itself, but .test() on the hint regex
+     * above and any future .test() here would not.
+     */
+    rule.regex.lastIndex = 0;
+    redacted = redacted.replace(rule.regex, rule.replacement);
+  }
+
+  return redacted;
+};
+
+/*
+ * ---------------------------------------------------------------------------
+ * Structural walk
+ * ---------------------------------------------------------------------------
+ */
+
+type RedactValueFunction = (
+  value: unknown,
+  depth: number,
+  seen: Set<unknown>,
+) => unknown;
+
+const redactValue: RedactValueFunction = (
+  value: unknown,
+  depth: number,
+  seen: Set<unknown>,
+): unknown => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return redactLogString(value);
+  }
+
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return value;
+  }
+
+  if (typeof value === "function") {
+    return "[Function]";
+  }
+
+  if (typeof value === "symbol") {
+    return value.toString();
+  }
+
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (typeof Buffer !== "undefined" && Buffer.isBuffer(value)) {
+    // Buffers hold key material as often as they hold anything readable.
+    return `[Buffer ${value.length} bytes]`;
+  }
+
+  if (depth >= MAX_DEPTH) {
+    return "[Truncated]";
+  }
+
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+
+  seen.add(value);
+
+  try {
+    if (value instanceof Error) {
+      const redactedError: Record<string, unknown> = {
+        name: value.name,
+        message: redactLogString(value.message),
+      };
+
+      if (value.stack) {
+        redactedError["stack"] = redactLogString(value.stack);
+      }
+
+      for (const key of Object.keys(value)) {
+        redactedError[key] = isSensitiveLogKey(
+          key,
+          (value as unknown as Record<string, unknown>)[key],
+        )
+          ? REDACTED
+          : redactValue(
+              (value as unknown as Record<string, unknown>)[key],
+              depth + 1,
+              seen,
+            );
+      }
+
+      return redactedError;
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((item: unknown) => {
+        return redactValue(item, depth + 1, seen);
+      });
+    }
+
+    if (value instanceof Map) {
+      const fromMap: Record<string, unknown> = {};
+
+      for (const [mapKey, mapValue] of value.entries()) {
+        const keyAsString: string = String(mapKey);
+
+        fromMap[keyAsString] = isSensitiveLogKey(keyAsString, mapValue)
+          ? REDACTED
+          : redactValue(mapValue, depth + 1, seen);
+      }
+
+      return fromMap;
+    }
+
+    if (value instanceof Set) {
+      return Array.from(value).map((item: unknown) => {
+        return redactValue(item, depth + 1, seen);
+      });
+    }
+
+    /*
+     * Models, ObjectIDs and the other Common types serialize through toJSON.
+     * Honouring it keeps redacted output shaped exactly like what
+     * JSON.stringify would have produced without this pass.
+     */
+    const maybeToJSON: unknown = (value as Record<string, unknown>)["toJSON"];
+
+    if (typeof maybeToJSON === "function") {
+      try {
+        const json: unknown = (maybeToJSON as () => unknown).call(value);
+
+        if (json !== value) {
+          return redactValue(json, depth, seen);
+        }
+      } catch {
+        // Fall through to the plain-object walk below.
+      }
+    }
+
+    const redactedObject: Record<string, unknown> = {};
+
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      const propertyValue: unknown = (value as Record<string, unknown>)[key];
+
+      redactedObject[key] = isSensitiveLogKey(key, propertyValue)
+        ? REDACTED
+        : redactValue(propertyValue, depth + 1, seen);
+    }
+
+    return redactedObject;
+  } finally {
+    /*
+     * Only the path currently being walked is "seen", so a value referenced
+     * twice in a tree is redacted twice instead of being reported as circular.
+     */
+    seen.delete(value);
+  }
+};
+
+/**
+ * Returns a redacted deep copy of any log body. The input is never mutated:
+ * logging must not change what the caller is holding.
+ */
+export type RedactLogValueFunction = (value: unknown) => unknown;
+
+export const redactLogValue: RedactLogValueFunction = (
+  value: unknown,
+): unknown => {
+  try {
+    return redactValue(value, 0, new Set<unknown>());
+  } catch {
+    /*
+     * A getter that throws, an exotic proxy... nothing here is worth crashing
+     * a log call for, but the body cannot be passed through unredacted either.
+     */
+    return REDACTED;
+  }
+};

--- a/Common/Server/Utils/Logger.ts
+++ b/Common/Server/Utils/Logger.ts
@@ -5,6 +5,12 @@ import { SeverityNumber } from "@opentelemetry/api-logs";
 import Exception from "../../Types/Exception/Exception";
 import { JSONObject } from "../../Types/JSON";
 import ConfigLogLevel from "../Types/ConfigLogLevel";
+import {
+  REDACTED,
+  isSensitiveLogKey,
+  redactLogString,
+  redactLogValue,
+} from "./LogRedaction";
 
 export type LogBody = string | JSONObject | Exception | Error | unknown;
 
@@ -68,9 +74,10 @@ export default class logger {
   private static readonly recentLogTrimSlack: number = 256;
   private static readonly maxRecentLogMessageLength: number = 4000;
 
+  // `body` has already been through redactBody -- see the level methods.
   private static record(level: string, body: LogBody): void {
     try {
-      const message: string = this.serializeLogBody(body);
+      const message: string = this.serializeRedactedBody(body);
 
       this.recentLogs.push({
         time: new Date().toISOString(),
@@ -114,13 +121,71 @@ export default class logger {
     return LogLevel;
   }
 
-  public static serializeLogBody(body: LogBody): string {
-    if (typeof body === "string") {
-      return body;
-    } else if (body instanceof Exception || body instanceof Error) {
-      return body.message;
+  /*
+   * Turns a body into a redacted copy, once, before it is handed to any sink.
+   * Every level method calls this and then passes the RESULT to console, to
+   * the recent-log buffer and to telemetry, so a log record is redacted a
+   * single time no matter how many places it ends up in.
+   *
+   * Objects come back as plain redacted copies, so console keeps printing them
+   * as objects rather than as a JSON string.
+   *
+   * Errors are special-cased: when nothing in the message or the stack needed
+   * redacting -- the overwhelmingly common case -- the original Error is
+   * returned untouched, so console still renders a real stack trace.
+   */
+  private static redactBody(body: LogBody): LogBody {
+    try {
+      if (typeof body === "string") {
+        return redactLogString(body);
+      }
+
+      if (body instanceof Exception || body instanceof Error) {
+        const originalStack: string = body.stack || "";
+        const message: string = redactLogString(body.message);
+        const stack: string = redactLogString(originalStack);
+
+        if (message === body.message && stack === originalStack) {
+          return body;
+        }
+
+        return stack || `${body.name}: ${message}`;
+      }
+
+      return redactLogValue(body) as LogBody;
+    } catch {
+      // Never pass on a body we could not prove was redacted.
+      return REDACTED;
     }
-    return JSON.stringify(body);
+  }
+
+  // Serialization only. The body must already have been through redactBody.
+  private static serializeRedactedBody(body: LogBody): string {
+    try {
+      if (typeof body === "string") {
+        return body;
+      } else if (body instanceof Exception || body instanceof Error) {
+        return body.message;
+      }
+
+      /*
+       * redactBody swept every string inside this copy already, so stringifying
+       * it needs no second textual pass.
+       */
+      const serialized: string | undefined = JSON.stringify(body);
+
+      return serialized === undefined ? "" : serialized;
+    } catch {
+      return REDACTED;
+    }
+  }
+
+  /*
+   * Redacts and serializes in one step, for callers outside the level methods
+   * that hold a raw body.
+   */
+  public static serializeLogBody(body: LogBody): string {
+    return this.serializeRedactedBody(this.redactBody(body));
   }
 
   private static sanitizeAttributes(
@@ -136,7 +201,16 @@ export default class logger {
       for (const key in attributes) {
         const value: string | number | boolean | undefined = attributes[key];
 
-        if (value !== undefined && value !== null) {
+        if (value === undefined || value === null) {
+          continue;
+        }
+
+        // Attributes are a log sink too, and they travel to telemetry verbatim.
+        if (isSensitiveLogKey(key, value)) {
+          sanitized[key] = REDACTED;
+        } else if (typeof value === "string") {
+          sanitized[key] = redactLogString(value);
+        } else {
           sanitized[key] = value;
         }
       }
@@ -151,16 +225,14 @@ export default class logger {
     const logLevel: ConfigLogLevel = this.getLogLevel();
 
     if (logLevel === ConfigLogLevel.DEBUG || logLevel === ConfigLogLevel.INFO) {
+      const body: LogBody = this.redactBody(message);
+
       // eslint-disable-next-line no-console
-      console.info(message);
+      console.info(body);
 
-      this.record("INFO", message);
+      this.record("INFO", body);
 
-      this.emit({
-        body: message,
-        severityNumber: SeverityNumber.INFO,
-        attributes,
-      });
+      this.emitRedacted(body, SeverityNumber.INFO, attributes);
     }
   }
 
@@ -173,16 +245,14 @@ export default class logger {
       logLevel === ConfigLogLevel.WARN ||
       logLevel === ConfigLogLevel.ERROR
     ) {
+      const body: LogBody = this.redactBody(message);
+
       // eslint-disable-next-line no-console
-      console.error(message);
+      console.error(body);
 
-      this.record("ERROR", message);
+      this.record("ERROR", body);
 
-      this.emit({
-        body: message,
-        severityNumber: SeverityNumber.ERROR,
-        attributes,
-      });
+      this.emitRedacted(body, SeverityNumber.ERROR, attributes);
     }
   }
 
@@ -194,16 +264,14 @@ export default class logger {
       logLevel === ConfigLogLevel.INFO ||
       logLevel === ConfigLogLevel.WARN
     ) {
+      const body: LogBody = this.redactBody(message);
+
       // eslint-disable-next-line no-console
-      console.warn(message);
+      console.warn(body);
 
-      this.record("WARN", message);
+      this.record("WARN", body);
 
-      this.emit({
-        body: message,
-        severityNumber: SeverityNumber.WARN,
-        attributes,
-      });
+      this.emitRedacted(body, SeverityNumber.WARN, attributes);
     }
   }
 
@@ -211,16 +279,14 @@ export default class logger {
     const logLevel: ConfigLogLevel = this.getLogLevel();
 
     if (logLevel === ConfigLogLevel.DEBUG) {
+      const body: LogBody = this.redactBody(message);
+
       // eslint-disable-next-line no-console
-      console.debug(message);
+      console.debug(body);
 
-      this.record("DEBUG", message);
+      this.record("DEBUG", body);
 
-      this.emit({
-        body: message,
-        severityNumber: SeverityNumber.DEBUG,
-        attributes,
-      });
+      this.emitRedacted(body, SeverityNumber.DEBUG, attributes);
     }
   }
 
@@ -229,6 +295,19 @@ export default class logger {
     severityNumber: SeverityNumber;
     attributes?: LogAttributes | undefined;
   }): void {
+    this.emitRedacted(
+      this.redactBody(data.body),
+      data.severityNumber,
+      data.attributes,
+    );
+  }
+
+  // `body` must already have been through redactBody.
+  private static emitRedacted(
+    body: LogBody,
+    severityNumber: SeverityNumber,
+    attributes?: LogAttributes | undefined,
+  ): void {
     try {
       const logger: TelemetryLogger | null = OneUptimeTelemetry.getLogger();
 
@@ -243,7 +322,7 @@ export default class logger {
        */
       const mergedAttributes: LogAttributes = {
         ...TelemetryContext.getAttributes(),
-        ...(data.attributes || {}),
+        ...(attributes || {}),
       };
 
       const sanitizedAttributes:
@@ -251,8 +330,8 @@ export default class logger {
         | undefined = this.sanitizeAttributes(mergedAttributes);
 
       logger.emit({
-        body: this.serializeLogBody(data.body),
-        severityNumber: data.severityNumber,
+        body: this.serializeRedactedBody(body),
+        severityNumber: severityNumber,
         ...(sanitizedAttributes ? { attributes: sanitizedAttributes } : {}),
       });
     } catch {
@@ -264,16 +343,14 @@ export default class logger {
     const logLevel: ConfigLogLevel = this.getLogLevel();
 
     if (logLevel === ConfigLogLevel.DEBUG) {
+      const body: LogBody = this.redactBody(message);
+
       // eslint-disable-next-line no-console
-      console.trace(message);
+      console.trace(body);
 
-      this.record("TRACE", message);
+      this.record("TRACE", body);
 
-      this.emit({
-        body: message,
-        severityNumber: SeverityNumber.DEBUG,
-        attributes,
-      });
+      this.emitRedacted(body, SeverityNumber.DEBUG, attributes);
     }
   }
 }

--- a/Common/Tests/Server/Utils/LogRedaction.test.ts
+++ b/Common/Tests/Server/Utils/LogRedaction.test.ts
@@ -1,0 +1,415 @@
+import {
+  REDACTED,
+  isSensitiveLogKey,
+  redactLogString,
+  redactLogValue,
+} from "../../../Server/Utils/LogRedaction";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * These are the regression tests for GHSA-3x69-fj58-3pc6 (Slack / Microsoft
+ * Teams OAuth client secrets and access tokens written to DEBUG logs) and
+ * GHSA-c4c2-r4hm-6pjj (login passwords and MFA material written to DEBUG
+ * logs).
+ *
+ * The call sites that produced those two advisories have been removed, but the
+ * class of bug is "somebody logs a request body". So the assertions here are
+ * written against the payloads those handlers actually pass around -- a Slack
+ * token exchange, a Microsoft Graph token response, a login body -- and they
+ * check the property that matters: the secret is not in the output, in any
+ * form, whether it arrived as an object or as text somebody had already
+ * stringified.
+ */
+
+const SENTINEL: string = "sentinel-secret-value-a1b2c3d4";
+
+type SerializeFunction = (value: unknown) => string;
+
+// What the logger would end up writing for this body.
+const serialize: SerializeFunction = (value: unknown): string => {
+  return JSON.stringify(redactLogValue(value));
+};
+
+describe("isSensitiveLogKey", () => {
+  it("matches credential keys in every spelling", () => {
+    for (const key of [
+      "password",
+      "Password",
+      "newPassword",
+      "client_secret",
+      "clientSecret",
+      "CLIENT-SECRET",
+      "access_token",
+      "accessToken",
+      "slackBotAccessToken",
+      "refresh_token",
+      "id_token",
+      "authorization",
+      "Authorization",
+      "x-api-key",
+      "apiKey",
+      "Cookie",
+      "set-cookie",
+      "credential",
+      "passwordSalt",
+      "twoFactorSecret",
+      "clientDataJSON",
+      "authenticatorData",
+      "userHandle",
+      "rawId",
+      "signature",
+    ]) {
+      expect(isSensitiveLogKey(key)).toBe(true);
+    }
+  });
+
+  it("leaves ordinary keys alone", () => {
+    for (const key of [
+      "email",
+      "projectId",
+      "userId",
+      "client_id",
+      "redirect_uri",
+      "team",
+      "statusCode",
+      "expires_in",
+      "scope",
+      "name",
+      "url",
+      "isAuthorized",
+    ]) {
+      expect(isSensitiveLogKey(key)).toBe(false);
+    }
+  });
+
+  it("keeps token accounting, which is not a token", () => {
+    expect(isSensitiveLogKey("tokenCount", 42)).toBe(false);
+    expect(isSensitiveLogKey("totalTokens", 42)).toBe(false);
+    expect(isSensitiveLogKey("inputTokens", 42)).toBe(false);
+  });
+
+  /*
+   * `code` is the one key that has to be decided by its value: it is the OAuth
+   * authorization code and the TOTP code, and it is also the `ECONNREFUSED` on
+   * every failed socket.
+   */
+  it("treats `code` as secret only when the value looks like one", () => {
+    expect(isSensitiveLogKey("code", "123456")).toBe(true);
+    expect(isSensitiveLogKey("code", "1234.5678.abcdef0123456789")).toBe(true);
+    expect(isSensitiveLogKey("code", 123456)).toBe(true);
+
+    expect(isSensitiveLogKey("code", "ECONNREFUSED")).toBe(false);
+    expect(isSensitiveLogKey("code", "BadDataException")).toBe(false);
+    expect(isSensitiveLogKey("code", 500)).toBe(false);
+  });
+});
+
+describe("redactLogValue - Slack OAuth payloads (GHSA-3x69-fj58-3pc6)", () => {
+  it("redacts the token request body the callback used to log", () => {
+    // Exactly the object Common/Server/API/SlackAPI.ts builds.
+    const requestBody: Record<string, unknown> = {
+      code: "1234567890.9876543210." + SENTINEL,
+      client_id: "1234567890.1111111111",
+      client_secret: SENTINEL,
+      redirect_uri: "https://oneuptime.com/api/slack/auth/project/user",
+    };
+
+    const output: string = serialize(requestBody);
+
+    expect(output).not.toContain(SENTINEL);
+    expect(JSON.parse(output)).toEqual({
+      code: REDACTED,
+      client_id: "1234567890.1111111111",
+      client_secret: REDACTED,
+      redirect_uri: "https://oneuptime.com/api/slack/auth/project/user",
+    });
+  });
+
+  it("redacts the oauth.v2.access response, bot and user tokens both", () => {
+    const responseBody: Record<string, unknown> = {
+      ok: true,
+      access_token: "xoxb-1111-2222-" + SENTINEL,
+      token_type: "bot",
+      bot_user_id: "U0123BOT",
+      team: { id: "T0123", name: "Acme" },
+      authed_user: {
+        id: "U0123USER",
+        access_token: "xoxp-3333-4444-" + SENTINEL,
+        refresh_token: "xoxe-1-" + SENTINEL,
+      },
+    };
+
+    const output: string = serialize(responseBody);
+
+    expect(output).not.toContain(SENTINEL);
+    // Non-secret context survives, so the log line is still worth reading.
+    expect(output).toContain("U0123BOT");
+    expect(output).toContain("Acme");
+    expect(JSON.parse(output).authed_user.access_token).toBe(REDACTED);
+  });
+
+  it("redacts a decoded Slack ID token", () => {
+    const decoded: Record<string, unknown> = {
+      sub: "U0123",
+      email: "user@example.com",
+      "https://slack.com/team_id": "T0123",
+      at_hash: SENTINEL,
+      nonce: "abcd",
+    };
+
+    // The id_token key itself is enough to redact the whole subtree.
+    expect(serialize({ id_token: decoded })).not.toContain(SENTINEL);
+  });
+});
+
+describe("redactLogValue - Microsoft Teams OAuth payloads (GHSA-3x69-fj58-3pc6)", () => {
+  it("redacts the token request body", () => {
+    const tokenRequestBody: Record<string, unknown> = {
+      grant_type: "authorization_code",
+      code: "0.AAAA" + SENTINEL,
+      client_id: "00000000-0000-0000-0000-000000000000",
+      client_secret: SENTINEL,
+      redirect_uri: "https://oneuptime.com/api/microsoft-teams/auth",
+      scope: "https://graph.microsoft.com/User.Read",
+    };
+
+    const output: string = serialize(tokenRequestBody);
+
+    expect(output).not.toContain(SENTINEL);
+    expect(output).toContain("authorization_code");
+    expect(output).toContain("https://graph.microsoft.com/User.Read");
+  });
+
+  it("redacts the token response, including the application access token", () => {
+    const tokenData: Record<string, unknown> = {
+      token_type: "Bearer",
+      expires_in: 3599,
+      access_token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.ey" + SENTINEL,
+      refresh_token: "0.AQ" + SENTINEL,
+      id_token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.ey" + SENTINEL,
+    };
+
+    const output: string = serialize(tokenData);
+
+    expect(output).not.toContain(SENTINEL);
+    expect(output).toContain("3599");
+  });
+});
+
+describe("redactLogValue - login payloads (GHSA-c4c2-r4hm-6pjj)", () => {
+  it("redacts the password out of a login body", () => {
+    const body: Record<string, unknown> = {
+      data: {
+        email: "user@example.com",
+        password: SENTINEL,
+      },
+      miscDataProps: { captchaToken: "captcha-" + SENTINEL },
+    };
+
+    const output: string = serialize(body);
+
+    expect(output).not.toContain(SENTINEL);
+    expect(output).toContain("user@example.com");
+  });
+
+  it("redacts a TOTP code", () => {
+    const body: Record<string, unknown> = {
+      data: { code: "123456", twoFactorAuthId: "6543210987654321" },
+    };
+
+    const output: string = serialize(body);
+
+    expect(output).not.toContain("123456");
+    expect(output).toContain("6543210987654321");
+  });
+
+  it("redacts WebAuthn assertion material", () => {
+    const body: Record<string, unknown> = {
+      data: {
+        credential: {
+          id: "credential-id",
+          rawId: SENTINEL,
+          response: {
+            clientDataJSON: SENTINEL,
+            authenticatorData: SENTINEL,
+            signature: SENTINEL,
+            userHandle: SENTINEL,
+          },
+        },
+      },
+    };
+
+    expect(serialize(body)).not.toContain(SENTINEL);
+  });
+});
+
+describe("redactLogString", () => {
+  it("redacts a stringified login body - the exact shape of the advisory", () => {
+    const message: string =
+      "Login request data: " +
+      JSON.stringify(
+        { data: { email: "user@example.com", password: SENTINEL } },
+        null,
+        2,
+      );
+
+    const output: string = redactLogString(message);
+
+    expect(output).not.toContain(SENTINEL);
+    expect(output).toContain("user@example.com");
+  });
+
+  it("redacts a password whose value contains an escaped quote", () => {
+    const message: string = JSON.stringify({
+      password: `${SENTINEL}"still-secret`,
+    });
+
+    expect(redactLogString(message)).not.toContain(SENTINEL);
+    expect(redactLogString(message)).not.toContain("still-secret");
+  });
+
+  it("redacts a stringified WebAuthn assertion", () => {
+    const message: string =
+      "Login request data: " +
+      JSON.stringify({
+        data: {
+          credential: {
+            id: "credential-id",
+            rawId: SENTINEL,
+            response: {
+              clientDataJSON: SENTINEL,
+              authenticatorData: SENTINEL,
+              signature: SENTINEL,
+              userHandle: SENTINEL,
+            },
+          },
+        },
+      });
+
+    expect(redactLogString(message)).not.toContain(SENTINEL);
+  });
+
+  it("redacts form-encoded and query-string credentials", () => {
+    expect(
+      redactLogString(`client_secret=${SENTINEL}&client_id=1234&grant_type=x`),
+    ).toBe(`client_secret=${REDACTED}&client_id=1234&grant_type=x`);
+
+    expect(
+      redactLogString(
+        `https://oneuptime.com/api/slack/auth/p/u?code=${SENTINEL}&state=abc`,
+      ),
+    ).toBe(
+      `https://oneuptime.com/api/slack/auth/p/u?code=${REDACTED}&state=abc`,
+    );
+  });
+
+  it("redacts the whole token after an authorization scheme, not just the scheme", () => {
+    const output: string = redactLogString(
+      `Authorization: Bearer ${SENTINEL}-1234567890`,
+    );
+
+    expect(output).not.toContain(SENTINEL);
+  });
+
+  it("redacts self-identifying secrets regardless of their key", () => {
+    const jwt: string =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abcdefghijk";
+
+    expect(redactLogString(`token is ${jwt}`)).not.toContain(jwt);
+    expect(
+      redactLogString("bot token xoxb-1111-2222-abcdefghijklmnop"),
+    ).not.toContain("xoxb-1111-2222-abcdefghijklmnop");
+    expect(
+      redactLogString(
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIabc123\n-----END RSA PRIVATE KEY-----",
+      ),
+    ).not.toContain("MIIabc123");
+    expect(
+      redactLogString("postgres://oneuptime:hunter2@postgres:5432/oneuptimedb"),
+    ).not.toContain("hunter2");
+  });
+
+  it("leaves ordinary log lines untouched", () => {
+    for (const message of [
+      "Slack token exchange completed. ok: true",
+      "Token exchange completed",
+      "Basic authentication failed for this request",
+      "Exchanging Slack authorization code for an access token.",
+      "Microsoft Teams token exchange completed.",
+      "User logged in: user@example.com",
+      "Monitor probe finished in 42ms",
+      "GET https://oneuptime.com/api/status-page/1234 -> 200",
+    ]) {
+      expect(redactLogString(message)).toBe(message);
+    }
+  });
+});
+
+describe("redactLogValue - safety properties", () => {
+  it("does not mutate the caller's object", () => {
+    const body: Record<string, unknown> = { password: SENTINEL };
+
+    redactLogValue(body);
+
+    expect(body["password"]).toBe(SENTINEL);
+  });
+
+  it("survives circular references", () => {
+    const body: Record<string, unknown> = { password: SENTINEL, name: "loop" };
+    body["self"] = body;
+
+    const output: string = serialize(body);
+
+    expect(output).not.toContain(SENTINEL);
+    expect(output).toContain("[Circular]");
+  });
+
+  it("redacts a value repeated in two branches, rather than calling it circular", () => {
+    const shared: Record<string, unknown> = { access_token: SENTINEL };
+    const output: string = serialize({ first: shared, second: shared });
+
+    expect(output).not.toContain(SENTINEL);
+    expect(output).not.toContain("[Circular]");
+  });
+
+  it("redacts secrets nested in arrays", () => {
+    expect(
+      serialize({ workspaces: [{ name: "a", authToken: SENTINEL }] }),
+    ).not.toContain(SENTINEL);
+  });
+
+  it("redacts secrets carried on an Error", () => {
+    const error: Error & { client_secret?: string } = new Error(
+      `token exchange failed for client_secret=${SENTINEL}`,
+    );
+    error.client_secret = SENTINEL;
+
+    expect(serialize(error)).not.toContain(SENTINEL);
+  });
+
+  it("honours toJSON so model logging keeps its shape", () => {
+    const model: { toJSON: () => Record<string, unknown> } = {
+      toJSON: (): Record<string, unknown> => {
+        return { _id: "1234", password: SENTINEL };
+      },
+    };
+
+    const output: string = serialize(model);
+
+    expect(output).not.toContain(SENTINEL);
+    expect(JSON.parse(output)._id).toBe("1234");
+  });
+
+  it("stops at a depth limit instead of recursing forever", () => {
+    let deep: Record<string, unknown> = { password: SENTINEL };
+
+    for (let i: number = 0; i < 40; i++) {
+      deep = { nested: deep };
+    }
+
+    const output: string = serialize(deep);
+
+    expect(output).not.toContain(SENTINEL);
+    expect(output).toContain("[Truncated]");
+  });
+});

--- a/Common/Tests/Server/Utils/LoggerCredentialLeak.test.ts
+++ b/Common/Tests/Server/Utils/LoggerCredentialLeak.test.ts
@@ -1,0 +1,245 @@
+import ConfigLogLevel from "../../../Server/Types/ConfigLogLevel";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+/*
+ * GHSA-3x69-fj58-3pc6 / GHSA-c4c2-r4hm-6pjj.
+ *
+ * A log record does not go to one place. It goes to process stdout, to the
+ * in-memory recent-log ring buffer that the master-admin support bundle reads
+ * back, and to the OpenTelemetry log exporter. A credential that survives any
+ * one of those three is still leaked, so every test here asserts against all
+ * three at once, at every log level -- including the levels that stay on in
+ * production.
+ *
+ * The bodies below are the ones the removed call sites used to pass. Deleting
+ * those calls is the fix; this file is the guarantee that re-adding one cannot
+ * leak.
+ */
+
+interface EmittedRecord {
+  body: string;
+  attributes?: Record<string, unknown> | undefined;
+}
+
+const emitted: Array<EmittedRecord> = [];
+
+jest.mock("../../../Server/Utils/Telemetry", () => {
+  return {
+    __esModule: true,
+    default: {
+      getLogger: (): unknown => {
+        return {
+          emit: (record: EmittedRecord): void => {
+            emitted.push(record);
+          },
+        };
+      },
+    },
+  };
+});
+
+import logger from "../../../Server/Utils/Logger";
+
+const SENTINEL: string = "sentinel-secret-value-a1b2c3d4";
+
+/*
+ * A TOTP code is six digits and has no distinctive shape, so it gets its own
+ * sentinel -- the recent-log ring buffer is process-wide and outlives a single
+ * test, and a common digit run would collide with the ids other cases log.
+ */
+const TOTP_SENTINEL: string = "907351";
+
+type LogMethod = "info" | "error" | "warn" | "debug" | "trace";
+
+const ALL_LEVELS: Array<LogMethod> = [
+  "info",
+  "error",
+  "warn",
+  "debug",
+  "trace",
+];
+
+// Only the recorded calls matter here, so the spies are read through this.
+interface ConsoleSpy {
+  mock: { calls: Array<Array<unknown>> };
+}
+
+type ConsoleSpies = Record<LogMethod, ConsoleSpy>;
+
+let consoleSpies: ConsoleSpies;
+
+type CollectSinkTextFunction = () => string;
+
+/*
+ * Everything the process wrote for the log calls made so far: what went to
+ * console, what the recent-log buffer kept, and what telemetry received.
+ */
+const collectSinkText: CollectSinkTextFunction = (): string => {
+  const parts: Array<string> = [];
+
+  for (const level of ALL_LEVELS) {
+    for (const call of consoleSpies[level].mock.calls) {
+      parts.push(
+        call
+          .map((argument: unknown) => {
+            if (typeof argument === "string") {
+              return argument;
+            }
+
+            if (argument instanceof Error) {
+              return `${argument.message} ${argument.stack || ""}`;
+            }
+
+            try {
+              return JSON.stringify(argument);
+            } catch {
+              return String(argument);
+            }
+          })
+          .join(" "),
+      );
+    }
+  }
+
+  for (const entry of logger.getRecentLogs()) {
+    parts.push(entry.message);
+  }
+
+  for (const record of emitted) {
+    parts.push(record.body);
+    parts.push(JSON.stringify(record.attributes || {}));
+  }
+
+  return parts.join("\n");
+};
+
+type LogAtEveryLevelFunction = (body: unknown, attributes?: unknown) => void;
+
+const logAtEveryLevel: LogAtEveryLevelFunction = (
+  body: unknown,
+  attributes?: unknown,
+): void => {
+  for (const level of ALL_LEVELS) {
+    (logger[level] as unknown as (body: unknown, attributes?: unknown) => void)(
+      body,
+      attributes,
+    );
+  }
+};
+
+describe("logger never writes credentials to any sink", () => {
+  beforeEach(() => {
+    emitted.length = 0;
+
+    // DEBUG is the level both advisories are about: on for troubleshooting.
+    jest.spyOn(logger, "getLogLevel").mockReturnValue(ConfigLogLevel.DEBUG);
+
+    consoleSpies = {
+      info: jest.spyOn(console, "info").mockImplementation(() => {}),
+      error: jest.spyOn(console, "error").mockImplementation(() => {}),
+      warn: jest.spyOn(console, "warn").mockImplementation(() => {}),
+      debug: jest.spyOn(console, "debug").mockImplementation(() => {}),
+      trace: jest.spyOn(console, "trace").mockImplementation(() => {}),
+    } as unknown as ConsoleSpies;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("keeps a Slack token exchange out of stdout, recent logs and telemetry", () => {
+    logAtEveryLevel({
+      code: "1234567890.9876543210." + SENTINEL,
+      client_id: "1234567890.1111111111",
+      client_secret: SENTINEL,
+      redirect_uri: "https://oneuptime.com/api/slack/auth/p/u",
+    });
+
+    logAtEveryLevel({
+      ok: true,
+      access_token: "xoxb-1111-2222-" + SENTINEL,
+      authed_user: { id: "U1", access_token: "xoxp-3333-" + SENTINEL },
+    });
+
+    expect(collectSinkText()).not.toContain(SENTINEL);
+    // The sinks did receive the records -- this is not passing by logging nothing.
+    expect(emitted.length).toBe(ALL_LEVELS.length * 2);
+  });
+
+  it("keeps a Microsoft Teams token response out of every sink", () => {
+    logAtEveryLevel({
+      token_type: "Bearer",
+      expires_in: 3599,
+      access_token: "eyJ0eXAiOiJKV1QifQ.ey" + SENTINEL,
+      refresh_token: "0.AQ" + SENTINEL,
+    });
+
+    expect(collectSinkText()).not.toContain(SENTINEL);
+  });
+
+  it("keeps a stringified login body out of every sink", () => {
+    logAtEveryLevel(
+      "Login request data: " +
+        JSON.stringify(
+          { data: { email: "user@example.com", password: SENTINEL } },
+          null,
+          2,
+        ),
+    );
+
+    const output: string = collectSinkText();
+
+    expect(output).not.toContain(SENTINEL);
+    // Redaction removed the secret, not the log line.
+    expect(output).toContain("Login request data");
+  });
+
+  it("keeps MFA material out of every sink", () => {
+    logAtEveryLevel({
+      data: {
+        code: TOTP_SENTINEL,
+        credential: { rawId: SENTINEL, response: { signature: SENTINEL } },
+      },
+    });
+
+    const output: string = collectSinkText();
+
+    expect(output).not.toContain(SENTINEL);
+    expect(output).not.toContain(TOTP_SENTINEL);
+  });
+
+  it("redacts credentials carried in log attributes", () => {
+    logAtEveryLevel("some message", {
+      projectId: "1234",
+      accessToken: SENTINEL,
+    });
+
+    const output: string = collectSinkText();
+
+    expect(output).not.toContain(SENTINEL);
+    expect(output).toContain("1234");
+  });
+
+  it("redacts a credential inside an Error message and its stack", () => {
+    logAtEveryLevel(
+      new Error(`Slack token exchange failed: client_secret=${SENTINEL}`),
+    );
+
+    expect(collectSinkText()).not.toContain(SENTINEL);
+  });
+
+  it("still logs an ordinary message unchanged", () => {
+    logger.debug("Exchanging Slack authorization code for an access token.");
+
+    expect(logger.getRecentLogs(1)[0]?.message).toBe(
+      "Exchanging Slack authorization code for an access token.",
+    );
+  });
+});

--- a/config.example.env
+++ b/config.example.env
@@ -265,6 +265,14 @@ OPENTELEMETRY_EXPORTER_OTLP_ENDPOINT=
 OPENTELEMETRY_EXPORTER_OTLP_HEADERS=
 
 # This can be one of ERROR, WARN, INFO, DEBUG
+#
+# Logs go to container stdout, to an in-memory recent-log buffer the master
+# admin support bundle can read back, and to the OTLP exporter above when one
+# is configured -- so anything logged lands in every log system you retain.
+# Credentials are redacted centrally before they reach any of those, but DEBUG
+# is verbose and its output is worth the same protection as the rest of your
+# telemetry: keep it off unless you are troubleshooting, and treat retained
+# DEBUG output as sensitive.
 LOG_LEVEL=ERROR
 
 # Thse env vars are for E2E tests


### PR DESCRIPTION
Fixes two draft advisories, both CWE-532, both the same shape — a handler passed a whole request or response object to `logger.debug`:

- **GHSA-3x69-fj58-3pc6** — Slack and Microsoft Teams OAuth client secrets and access tokens logged at DEBUG.
- **GHSA-c4c2-r4hm-6pjj** — login passwords and MFA material logged at DEBUG.

A log record is not written to one place: container stdout, the in-memory recent-log buffer the master-admin support bundle reads back, and the OTLP exporter when one is configured. Turning DEBUG on to troubleshoot therefore copied long-lived credentials into every log system the operator retains.

## The call sites are removed

- `Common/Server/API/SlackAPI.ts` — no longer logs the token request bodies (client secret, authorization code) or the `oauth.v2.access` / `openid.connect.token` responses (bot token, user token, decoded ID token). Logs the fact of the exchange instead.
- `Common/Server/API/MicrosoftTeamsAPI.ts` — same for the authorization-code exchange and for the application access token acquired via admin consent.
- `App/FeatureSet/Identity/API/Authentication.ts` — the shared login handler no longer serializes `req.body`. Password login, TOTP verification and WebAuthn verification all funnel through it, so that one line wrote a plaintext password, a TOTP code or an assertion (plus the CAPTCHA token) on every login attempt. The forgot-password handler no longer logs the reset URL either — it carries a live single-use reset token.

## Redaction moved to the logger boundary

New `Common/Server/Utils/LogRedaction.ts`, so no call site can forget it:

- **Structural** — objects are walked recursively and a value is replaced whenever its key names a credential. Substring matching on a normalized key, so `client_secret`, `clientSecret`, `slackBotAccessToken` and `x-api-key` all match. Cycle-safe, depth-bounded, honours `toJSON`, never mutates the caller's object.
- **Textual** — strings are swept for credentials already flattened into text (a stringified body, an OAuth callback URL with `?code=`, an `Authorization: Bearer` dump) and for values that identify themselves regardless of key (JWTs, `xoxb-` tokens, GitHub/AWS/Google keys, PEM blocks, URL basic-auth).

`Logger` runs every body and every attribute through it **once per record**, before console, the recent-log buffer and telemetry, at **every level** — not just DEBUG. `MCPLogger`, which writes its own stderr sink, does the same.

Deny-by-default, and it over-redacts on purpose: losing a token count from a debug line costs a little context, leaking a bot token costs the workspace. Where that would have cost real debuggability the key is decided by its value — `code` stays readable for `ECONNREFUSED` and HTTP statuses, while a TOTP or an authorization code is replaced. An allowlist keeps LLM token accounting and expiry timestamps readable.

## Tests

- `Common/Tests/Server/Utils/LogRedaction.test.ts` (25) — the redactor against the exact payloads these handlers pass: a Slack token exchange, a Graph token response, a login body, a WebAuthn assertion. Plus the safety properties (no mutation, cycles, shared subtrees, depth limit) and a case asserting ordinary log lines come through byte-identical.
- `Common/Tests/Server/Utils/LoggerCredentialLeak.test.ts` (7) — sentinel credentials through the real logger at all five levels, asserting against all three sinks at once, with the telemetry exporter captured.
- `App/Tests/FeatureSet/Identity/AuthenticationCredentialLogging.test.ts` (5) — the real `/login`, `/verify-totp-auth`, `/verify-webauthn-auth` and `/forgot-password` handlers driven with sentinel credentials, real logger at DEBUG. Asserts the handler did log (not passing on silence) and that no sentinel reached any sink.

Verified: `tsc --noEmit` clean in Common and App; eslint and prettier clean; the three new suites plus the existing Identity suites (112 tests) and the log-touching Common suites pass.

## Operator note

`config.example.env` now documents where DEBUG output ends up. Anyone who ran DEBUG in production should treat retained log output as sensitive — purge what they can, and rotate any Slack/Teams integration credentials and user passwords that may appear in it.