### PR TITLE
docs: document Incoming Request monitors as a webhook alert receiver

### DIFF
--- a/App/FeatureSet/Docs/Content/en/integrations/grafana.md
+++ b/App/FeatureSet/Docs/Content/en/integrations/grafana.md
@@ -2,19 +2,50 @@
 
 Turn [Grafana](https://grafana.com) alerts into OneUptime incidents. Grafana evaluates the alert rules on your dashboards; OneUptime records, escalates, and tracks them.
 
-This integration is **inbound**: Grafana's alerting posts to a OneUptime **[Workflow](/docs/workflows/index)** that starts with a **Webhook trigger**, using a Grafana **Webhook contact point**.
+This integration is **inbound**: a Grafana **Webhook contact point** posts to OneUptime. There are two ways to receive it.
+
+| Approach                                                                             | Use it when                                                                                                                |
+| ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| **[Incoming Request monitor](/docs/monitor/incoming-request-monitor)** (recommended) | You want alerts to become incidents with on-call escalation, one incident per alert, and automatic resolution on recovery. |
+| **[Workflow](/docs/workflows/index) with a Webhook trigger**                         | You need routing logic OneUptime doesn't do natively — calling other systems, reshaping payloads, conditional branching.   |
 
 ```text
-Grafana alert rule fires  ──►  Webhook contact point  ──►  OneUptime Webhook trigger  ──►  Create Incident
+Grafana alert rule fires  ──►  Webhook contact point  ──►  OneUptime  ──►  Incident + on-call
 ```
+
+Grafana's webhook payload follows the Alertmanager shape — `status`, an `alerts` array, `commonLabels`, and `commonAnnotations`, plus convenient top-level `title` and `message` fields.
 
 ## Prerequisites
 
 - Grafana 9+ with [unified alerting](https://grafana.com/docs/grafana/latest/alerting/) enabled (the default on modern Grafana).
 - Grafana must be able to reach your OneUptime instance over HTTPS.
-- A OneUptime project where you can create workflows.
+- A OneUptime project where you can create monitors (or workflows).
 
-## Step 1 — Build the OneUptime workflow
+## Option 1 — Incoming Request monitor
+
+1. Go to **Monitors → Create Monitor** and choose **Incoming Request**. Open it and click **Documentation** in the left menu to copy the URL.
+2. Open the monitor's **Criteria** and set **Filter Type** to `JavaScript Expression` and **Value** to `"{{requestBody.status}}" === "firing"`.
+3. Declare an incident on match, choose the **On-Call Policies** to page, and turn on **Auto Resolve Incident** under **Advanced Options**.
+4. Under **Settings**, turn on **Group incidents and alerts by a payload field** and set:
+
+   | Field                              | Value                               |
+   | ---------------------------------- | ----------------------------------- |
+   | Open a separate incident for each… | `requestBody.alerts[*].fingerprint` |
+   | Field that signals recovery        | `requestBody.alerts[*].status`      |
+   | Value that means recovered         | `resolved`                          |
+
+5. Title the incident `{{requestBody.commonLabels.alertname}}` and describe it with `{{requestBody.message}}` or `{{requestBody.commonAnnotations.summary}}`. (`{{fingerprint}}` holds the grouping key itself, but it is a hash — not something to show a responder.)
+6. Point the Grafana contact point at the monitor's URL (see the contact point steps below).
+
+Each **distinct** grouping value becomes its own incident, and each clears when Grafana reports it resolved. Grafana's per-alert `fingerprint` is unique to an alert's label set, which is why it is the grouping path above. The [Prometheus Alertmanager](/docs/integrations/prometheus-alertmanager) page walks through the same setup in more detail — the payload shape is the same, so every step there applies here.
+
+> **Warning:** Do not group by a label that is constant across a notification. Grafana's default notification policy groups by `grafana_folder` and `alertname`, so every alert in one webhook shares an alertname — grouping by `requestBody.alerts[*].labels.alertname` would collapse the whole payload into a single incident. The grouping paths must also start with the literal `requestBody.`, and only the first `[*]` in a path is a wildcard. All of these fail silently.
+
+## Option 2 — Workflow
+
+Use this when you need logic beyond "alert becomes incident".
+
+### Step 1 — Build the OneUptime workflow
 
 1. Open **Workflows → Create Workflow**, name it `Grafana → Incidents`, and open the **Builder**.
 2. Add a **Webhook** trigger and **copy its URL**. Rename the block to `Grafana`.
@@ -28,25 +59,27 @@ Grafana alert rule fires  ──►  Webhook contact point  ──►  OneUptime
    - **Severity**: choose one (or branch on `{{Grafana.Request Body.commonLabels.severity}}`).
 5. **Save** (leave disabled until tested).
 
-Grafana's webhook payload follows the Alertmanager shape — it includes `status`, an `alerts` array, `commonLabels`, and `commonAnnotations`, plus convenient top-level `title` and `message` fields.
-
-## Step 2 — Configure the Grafana contact point
+## Configure the Grafana contact point
 
 1. In Grafana, go to **Alerting → Contact points → Add contact point**.
 2. **Name**: `OneUptime`. **Integration**: **Webhook**.
-3. **URL**: paste your workflow's webhook URL. **HTTP Method**: `POST`.
+3. **URL**: paste the monitor URL from Option 1, or the workflow's webhook URL from Option 2. **HTTP Method**: `POST`.
 4. Save the contact point.
 5. Go to **Alerting → Notification policies** and route the alerts you want (or the default policy) to the **OneUptime** contact point.
 
-## Step 3 — Test it
+## Test it
 
-1. Enable the workflow.
+1. Enable the workflow, if you built one.
 2. In the contact point screen, use **Test** to send a sample notification, or let a real alert rule fire.
-3. Check the workflow's **Logs** tab and your **Incidents** list.
+3. Check your **Incidents** list — and the workflow's **Logs** tab if you used Option 2.
 
-## Resolving on recovery (optional)
+## Resolving on recovery
 
-When the alert clears, Grafana sends another notification with `status: resolved`. Add a second **Conditions** branch (`status == resolved`), find the matching incident, and move it to your resolved state with **Update Incident**.
+When the alert clears, Grafana sends another notification with `status: resolved`.
+
+With **Option 1**, the recovery field and value configured above close the matching incident automatically — provided **Auto Resolve Incident** is on.
+
+With **Option 2**, add a second **Conditions** branch (`status == resolved`), find the matching incident, and move it to your resolved state with **Update Incident**.
 
 ## Notes
 
@@ -55,11 +88,14 @@ When the alert clears, Grafana sends another notification with `status: resolved
 
 ## Troubleshooting
 
-- **No run appears** — confirm Grafana can reach the URL (check Grafana's server logs) and the workflow is **Enabled**.
-- **Empty fields** — inspect the trigger output in the **Logs** tab; reference fields that exist for your alerting version.
+- **Nothing arrives** — confirm Grafana can reach the URL (check Grafana's server logs) and, for Option 2, that the workflow is **Enabled**. OneUptime answers every incoming request with an empty `200` before validating it, so a `200` in Grafana's logs does not confirm the payload was accepted.
+- **Incidents open but never close** — check the recovery field and value on the criteria, and that **Auto Resolve Incident** is on under the incident's **Advanced Options**. The comparison is case-sensitive.
+- **Only one incident for a payload full of alerts** — you grouped by a label that does not vary inside a notification. Group by `requestBody.alerts[*].fingerprint` instead.
+- **Incident text shows raw `{{...}}` placeholders** — the path did not resolve, and unresolved placeholders are left in place rather than blanked. Reference fields that exist for your alerting version; inspect the trigger output in the **Logs** tab if you used Option 2.
 
 ## Where to read next
 
+- [Incoming Request Monitor](/docs/monitor/incoming-request-monitor) — the monitor type, its criteria, and incident grouping in full.
 - [Integrations Overview](/docs/integrations/index) — the inbound pattern.
 - [Prometheus Alertmanager](/docs/integrations/prometheus-alertmanager) — closely related payload.
 - [Metrics Monitor](/docs/monitor/metrics-monitor) — monitor metrics in OneUptime directly.

--- a/App/FeatureSet/Docs/Content/en/integrations/index.md
+++ b/App/FeatureSet/Docs/Content/en/integrations/index.md
@@ -20,6 +20,8 @@ Use this when an external system needs to _create or update something in OneUpti
 Zabbix / Prometheus / Grafana / Datadog  ──►  OneUptime Webhook trigger  ──►  Create Incident
 ```
 
+> **Tip:** For alerting tools specifically, an **[Incoming Request monitor](/docs/monitor/incoming-request-monitor)** is usually the better inbound path. It gives you a webhook URL without building a workflow, opens one incident per alert in the payload, escalates to an on-call policy, and resolves each incident when the tool reports it recovered. Reach for a workflow when you need logic OneUptime doesn't do natively. See [Prometheus Alertmanager](/docs/integrations/prometheus-alertmanager) for a worked example.
+
 ### Outbound — OneUptime sends data to another tool
 
 Use this when _something in OneUptime should show up in another tool_ — open a Jira ticket, page someone in PagerDuty, post to Slack.
@@ -85,7 +87,7 @@ printf '%s' 'you@example.com:your_api_token' | base64
 
 Almost any tool fits one of the two patterns above:
 
-- If the tool can **send a webhook** when something happens, use the **inbound** pattern — point its webhook at a OneUptime Webhook trigger.
+- If the tool can **send a webhook** when something happens, use the **inbound** pattern — point its webhook at an [Incoming Request monitor](/docs/monitor/incoming-request-monitor) if it is an alerting tool, or at a OneUptime Webhook trigger if you need custom logic.
 - If the tool has a **REST API**, use the **outbound** pattern — call it from an **API component**.
 - If you need to reshape data between the two, drop in a **[Custom Code](/docs/workflows/components#custom-code)** block.
 
@@ -97,4 +99,5 @@ That covers the long tail — Zendesk, AWS CloudWatch (via SNS), New Relic, Splu
 - [Triggers](/docs/workflows/triggers) — Webhook and OneUptime event triggers in detail.
 - [Components](/docs/workflows/components) — the API, Webhook, and data components.
 - [Variables](/docs/workflows/variables) — secrets and passing data between blocks.
+- [Incoming Request Monitor](/docs/monitor/incoming-request-monitor) — the workflow-free inbound path for alerting tools.
 - [Zabbix](/docs/integrations/zabbix) and [Jira](/docs/integrations/jira) — full worked examples.

--- a/App/FeatureSet/Docs/Content/en/integrations/prometheus-alertmanager.md
+++ b/App/FeatureSet/Docs/Content/en/integrations/prometheus-alertmanager.md
@@ -2,19 +2,155 @@
 
 Turn [Prometheus Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/) notifications into OneUptime incidents. Prometheus evaluates your alerting rules, Alertmanager routes them, and OneUptime records and escalates them.
 
-This integration is **inbound**: Alertmanager POSTs to a OneUptime **[Workflow](/docs/workflows/index)** that starts with a **Webhook trigger**.
+This integration is **inbound**, and there are two ways to build it:
+
+| Approach                                                                             | Use it when                                                                                                                                             |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **[Incoming Request monitor](/docs/monitor/incoming-request-monitor)** (recommended) | You want alerts to become incidents with on-call escalation, one incident per alert, and automatic resolution on recovery. No custom logic to maintain. |
+| **[Workflow](/docs/workflows/index) with a Webhook trigger**                         | You need routing logic OneUptime doesn't do natively — calling other systems, reshaping payloads, conditional branching.                                |
 
 ```text
-Prometheus rule fires  ──►  Alertmanager webhook receiver  ──►  OneUptime Webhook trigger  ──►  Create Incident
+Prometheus rule fires  ──►  Alertmanager webhook receiver  ──►  OneUptime  ──►  Incident + on-call
 ```
 
 ## Prerequisites
 
 - A Prometheus + Alertmanager setup where you can edit `alertmanager.yml`.
 - Alertmanager must be able to reach your OneUptime instance over HTTPS.
-- A OneUptime project where you can create workflows.
+- A OneUptime project where you can create monitors (or workflows).
 
-## Step 1 — Build the OneUptime workflow
+## Option 1 — Incoming Request monitor
+
+### Step 1 — Create the monitor
+
+1. Go to **Monitors → Create Monitor** and choose **Incoming Request**.
+2. Open the monitor and click **Documentation** in the left menu. Copy the URL:
+
+   ```
+   https://oneuptime.com/heartbeat/YOUR_SECRET_KEY
+   ```
+
+   Use your own host if self-hosted. The secret key in the path is the only credential.
+
+### Step 2 — Point Alertmanager at it
+
+In `alertmanager.yml`:
+
+```yaml
+receivers:
+  - name: oneuptime
+    webhook_configs:
+      - url: "https://oneuptime.com/heartbeat/YOUR_SECRET_KEY"
+        send_resolved: true
+
+route:
+  receiver: oneuptime
+  group_by: ["alertname", "instance"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+```
+
+`send_resolved: true` is required — it is what tells OneUptime an alert has recovered. Reload Alertmanager with `curl -X POST http://localhost:9093/-/reload`, or restart it.
+
+Alertmanager sends `Content-Type: application/json`, which OneUptime needs in order to read fields out of the payload.
+
+### Step 3 — Configure the criteria
+
+Open the monitor's **Criteria** and edit the first criteria.
+
+**Filter**
+
+- **Filter Type**: `JavaScript Expression`
+- **Filter Condition**: `Evaluates To True`
+- **Value**: `"{{requestBody.status}}" === "firing"`
+
+  The quotes around the placeholder are required for a string comparison. A `Request Body` / `Contains` / `"status":"firing"` filter works too if you'd rather not use an expression.
+
+**Actions**
+
+- Turn on _When filters match, change monitor status_ and set it to **Offline** (or Degraded).
+- Turn on _When filters match, declare an incident_. Set the **Title**, **Severity**, and the **On-Call Policies** that should be paged.
+- Under **Advanced Options** on that incident, turn on **Auto Resolve Incident**. Without this, recovery notifications are ignored and incidents stay open forever.
+
+**Settings → Group incidents and alerts by a payload field**
+
+Turn this on so one endpoint can hold several concurrent incidents — one per alert — instead of a single incident per notification.
+
+| Field                              | Value                               |
+| ---------------------------------- | ----------------------------------- |
+| Open a separate incident for each… | `requestBody.alerts[*].fingerprint` |
+| Field that signals recovery        | `requestBody.alerts[*].status`      |
+| Value that means recovered         | `resolved`                          |
+| Max incidents per request          | `100`                               |
+
+`[*]` fans out over Alertmanager's `alerts` array, opening one incident per **distinct** extracted value. Because both paths use `[*]`, recovery is judged per alert: in a payload where one alert resolved and two are still firing, only the resolved one closes.
+
+> **Warning:** Group by something genuinely unique per alert. Alertmanager's `fingerprint` is a hash of the alert's full label set, so it always is. A label works only if it varies **within** a notification — and any label listed in your route's `group_by` never does, because that is what defines the aggregation group. With the `group_by: ["alertname", "instance"]` above, grouping by `requestBody.alerts[*].labels.alertname` extracts the same value from every alert in the payload, so all of them collapse into a single incident. Worse, duplicate values keep only their **first** occurrence, so a payload whose first alert is `resolved` closes that incident while the rest are still firing.
+
+### Step 4 — Write the incident title and description
+
+The grouping key is available as a variable named after the last segment of the path, so `requestBody.alerts[*].fingerprint` gives you `{{fingerprint}}`. That is a hash, not something to show a responder — title the incident from the labels shared across the notification instead. `commonLabels` carries every label in your route's `group_by`, so with the configuration above `alertname` and `instance` are both available:
+
+- **Title**: `{{requestBody.commonLabels.alertname}} on {{requestBody.commonLabels.instance}}`
+- **Description**:
+
+  ```
+  {{requestBody.commonAnnotations.summary}}
+
+  {{requestBody.commonAnnotations.description}}
+  Severity: {{requestBody.commonLabels.severity}}
+  Alertmanager: {{requestBody.externalURL}}
+  ```
+
+`commonLabels` and `commonAnnotations` hold the fields shared across the notification. A per-alert path like `requestBody.alerts[0].annotations.summary` always reads the _first_ alert in the payload, not the one this particular incident was opened for — so keep `group_by` tight if you want each incident to carry its own annotation text. A path that does not resolve is printed verbatim, braces and all, rather than left blank. See [Incident & Alert Dynamic Templating](/docs/monitor/incident-alert-templating) for the full variable list.
+
+### Step 5 — Send the monitor back to Operational (optional)
+
+Criteria only act when they match, so add a second criteria so the monitor doesn't stay Offline after everything clears:
+
+- **Filter Type**: `JavaScript Expression`, **Value**: `"{{requestBody.status}}" === "resolved"`
+- _Change monitor status to_ **Operational**, and declare no incident.
+
+### Step 6 — Test it
+
+```bash
+curl -X POST https://oneuptime.com/heartbeat/YOUR_SECRET_KEY \
+  -H "Content-Type: application/json" \
+  -d '{
+    "version": "4",
+    "status": "firing",
+    "commonLabels": { "alertname": "HighCPU", "severity": "critical" },
+    "commonAnnotations": { "summary": "CPU above 90% for 5m" },
+    "externalURL": "http://alertmanager:9093",
+    "alerts": [
+      {
+        "status": "firing",
+        "labels": { "alertname": "HighCPU", "instance": "web-1" },
+        "fingerprint": "a1b2c3d4e5f60001"
+      },
+      {
+        "status": "firing",
+        "labels": { "alertname": "HighCPU", "instance": "web-2" },
+        "fingerprint": "a1b2c3d4e5f60002"
+      }
+    ]
+  }'
+```
+
+You should get two incidents — one per `fingerprint`. Re-send with both alerts' `status` set to `resolved` and both should close.
+
+You can also fire a real alert with `amtool`:
+
+```bash
+amtool alert add test_alert severity=warning \
+  --annotation=summary="Test from Alertmanager" \
+  --alertmanager.url=http://localhost:9093
+```
+
+## Option 2 — Workflow
+
+Use this when you need logic beyond "alert becomes incident".
 
 1. Open **Workflows → Create Workflow**, name it `Alertmanager → Incidents`, and open the **Builder**.
 2. Add a **Webhook** trigger and **copy its URL**. Rename the block to `Alertmanager`.
@@ -26,54 +162,57 @@ Prometheus rule fires  ──►  Alertmanager webhook receiver  ──►  OneU
    - **Title**: `{{Alertmanager.Request Body.commonAnnotations.summary}}`
    - **Description**: `{{Alertmanager.Request Body.commonAnnotations.description}}\nAlert: {{Alertmanager.Request Body.commonLabels.alertname}}`
    - **Severity**: choose one (or branch on `{{Alertmanager.Request Body.commonLabels.severity}}` first).
-5. **Save** (leave disabled until tested).
+5. **Save**, then point the `webhook_configs` URL in Step 2 above at the workflow's URL instead.
 
-> **About grouped alerts.** Alertmanager groups alerts and sends an `alerts` **array**. The `commonLabels` and `commonAnnotations` above are the fields shared across the group — perfect for one incident per notification. If you want **one incident per alert**, add a [Custom Code](/docs/workflows/components#custom-code) block that loops over `Request Body.alerts` and creates an incident for each. Tune grouping with `group_by` in your route.
+For one incident per alert, add a [Custom Code](/docs/workflows/components#custom-code) block that loops over `Request Body.alerts`. With `send_resolved: true`, add a second **Conditions** branch on `status == resolved` that finds the matching incident and moves it to your resolved state with **Update Incident**.
 
-## Step 2 — Configure Alertmanager
+## Dead man's switch
 
-Add a webhook receiver pointing at the workflow URL, and route alerts to it. In `alertmanager.yml`:
+Neither option tells you when Prometheus itself stops working — no alerts arriving looks exactly like nothing being wrong. The usual answer is an always-firing alert routed to a monitor that expects it on a schedule. [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) ships one called `Watchdog`; on a plain Prometheus, add an alerting rule with an expression that is always true (`vector(1)`).
+
+Create a **second** Incoming Request monitor, route `Watchdog` to it on a short `repeat_interval`, and give that monitor a **Filter Type: Incoming Request** / **Filter Condition: Not Recieved In Minutes** criteria. That is the one case where a missing-request criteria belongs on an alert receiver.
+
+This is the Step 2 configuration with the watchdog route and receiver merged in — a sub-route is matched before the parent's own receiver, so `Watchdog` goes to the second monitor and everything else still goes to the first:
 
 ```yaml
 receivers:
   - name: oneuptime
     webhook_configs:
-      - url: "https://<your-workflow-webhook-url>"
+      - url: "https://oneuptime.com/heartbeat/YOUR_SECRET_KEY"
         send_resolved: true
+
+  - name: oneuptime-watchdog
+    webhook_configs:
+      - url: "https://oneuptime.com/heartbeat/WATCHDOG_SECRET_KEY"
 
 route:
   receiver: oneuptime
-  group_by: ["alertname"]
+  group_by: ["alertname", "instance"]
   group_wait: 30s
   group_interval: 5m
-  repeat_interval: 3h
+  repeat_interval: 4h
+  routes:
+    - receiver: oneuptime-watchdog
+      matchers:
+        - alertname = "Watchdog"
+      group_wait: 0s
+      group_interval: 5m
+      repeat_interval: 5m
 ```
-
-Reload Alertmanager (`curl -X POST http://localhost:9093/-/reload` or restart it).
-
-## Step 3 — Test it
-
-1. Enable the workflow.
-2. Fire a test alert — for example, with `amtool`:
-
-   ```bash
-   amtool alert add test_alert severity=warning --annotation=summary="Test from Alertmanager" --alertmanager.url=http://localhost:9093
-   ```
-
-3. Check the workflow's **Logs** tab and your **Incidents** list.
-
-## Resolving on recovery (optional)
-
-With `send_resolved: true`, Alertmanager also POSTs when an alert clears, this time with `status: resolved`. Add a second **Conditions** branch (`status == resolved`), find the matching incident (match on `commonLabels.alertname`), and move it to your resolved state with **Update Incident**.
 
 ## Troubleshooting
 
-- **No run appears** — confirm Alertmanager can reach the URL (check its logs for delivery errors) and that the workflow is **Enabled**.
-- **Incident fields are empty** — different rules set different annotations. Inspect the trigger output in the **Logs** tab and reference fields that actually exist (`commonAnnotations` vs per-alert `annotations`).
-- **Too many incidents** — increase `group_by`/`group_interval` so Alertmanager batches related alerts.
+- **Nothing arrives** — confirm Alertmanager can reach the URL; check its logs for delivery errors. OneUptime answers every request with an empty `200` before it validates anything, so a `200` does not confirm the payload was accepted. Check the monitor's timeline instead.
+- **Incidents open but never close** — check `send_resolved: true` in Alertmanager, the recovery field and value on the criteria (the comparison is case-sensitive), and **Auto Resolve Incident** under the incident's **Advanced Options**. Two subtler causes: a payload carrying more distinct keys than **Max incidents per request** hides the ones past the cap from recovery too; and if the `resolved` notification is the one dropped by ingest coalescing (below), the incident is stranded permanently, because Alertmanager repeats firing notifications but not resolved ones. Close those by hand.
+- **No incidents at all, monitor status unchanged** — the grouping path must start with the literal `requestBody.`, and only the first `[*]` in a path is a wildcard. Both mistakes fail silently.
+- **Incident text shows raw `{{...}}` placeholders** — the path did not resolve, and OneUptime leaves unresolved placeholders in place rather than blanking them. Different rules set different annotations, so reference fields that actually exist for your rules (`commonAnnotations` versus per-alert `annotations`).
+- **Only one incident for a payload full of alerts** — you grouped by a label that does not vary inside a notification, most often one that is also in your route's `group_by`. Group by `requestBody.alerts[*].fingerprint` instead.
+- **Too many incidents** — widen `group_by` / `group_interval` so Alertmanager batches related alerts. Lowering **Max incidents per request** caps them, but it also hides the keys past the cap from recovery.
+- **Some notifications appear to be skipped under heavy bursts** — same-monitor requests are coalesced at ingest so one sender cannot overwhelm a monitor, which can drop an intermediate payload when notifications arrive back to back. Increasing `group_wait` and `group_interval` spaces them out. Coalescing is controlled by the app container's `INCOMING_REQUEST_INGEST_COALESCE_ENABLED` environment variable, which defaults to on; self-hosted operators who need every payload evaluated can set it to `false` on that container.
 
 ## Where to read next
 
-- [Integrations Overview](/docs/integrations/index) — the inbound pattern.
+- [Incoming Request Monitor](/docs/monitor/incoming-request-monitor) — the monitor type, its criteria, and incident grouping in full.
+- [Integrations Overview](/docs/integrations/index) — the inbound and outbound patterns.
 - [Grafana](/docs/integrations/grafana) — same idea, Grafana alerting.
-- [Webhook trigger](/docs/workflows/triggers#webhook) — how the receiving URL works.
+- [Webhook trigger](/docs/workflows/triggers#webhook) — how the workflow receiving URL works.

--- a/App/FeatureSet/Docs/Content/en/monitor/incident-alert-templating.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/incident-alert-templating.md
@@ -40,6 +40,10 @@ The following monitor types support dynamic templating with their respective var
 | `requestMethod`             | The HTTP method of the incoming request (GET, POST, etc.). | `string`             |
 | `incomingRequestReceivedAt` | The date and time when the incoming request was received.  | `Date`               |
 
+When the criteria has **Group incidents and alerts by a payload field** turned on, the extracted grouping key is also available, under a variable named after the **last segment** of the grouping path. Grouping by `requestBody.alerts[*].labels.alertname` gives you `{{alertname}}`; grouping by `requestBody.alerts[*].fingerprint` gives you `{{fingerprint}}`. The full `requestBody` is still available alongside it.
+
+> **Note:** `[*]` is only understood in the grouping path fields themselves — here it does not resolve, so the placeholder is printed verbatim, braces and all. Inside a title or description, `{{requestBody.alerts[0].annotations.summary}}` always reads the first alert in the payload, not the one the incident was opened for. Use the grouping variable and the payload's shared fields (`commonLabels`, `commonAnnotations`) instead. See [Incoming Request Monitor](/docs/monitor/incoming-request-monitor).
+
 ### Ping Monitors
 
 | Variable           | Description                                   | Type      |
@@ -187,7 +191,7 @@ Array indexing is supported:
 First User: {{responseBody.users[0].name}}
 ```
 
-If a path does not exist it resolves to an empty string by default.
+If a path does not exist, the placeholder is left in the output exactly as written — `{{responseBody.error.id}}` appears literally, braces and all, in the incident title. Only `{{#each}}` blocks over a missing path are removed.
 
 ## Advanced Usage
 

--- a/App/FeatureSet/Docs/Content/en/monitor/incoming-request-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/incoming-request-monitor.md
@@ -1,15 +1,22 @@
 # Incoming Request Monitor
 
-Incoming Request monitoring (also known as heartbeat monitoring) allows you to monitor services by having them send periodic HTTP requests to OneUptime. Instead of OneUptime reaching out to your service, your service pings OneUptime to confirm it is running.
+An Incoming Request monitor gives you a URL that other systems send HTTP requests to. OneUptime evaluates every request against your criteria, and can change the monitor's status, declare incidents, and page your on-call rota.
+
+It covers two different jobs:
+
+- **Heartbeat monitoring** — a cron job, worker, or device pings the URL on a schedule, and OneUptime raises an incident when the pings stop arriving.
+- **Receiving alerts from another system** — Prometheus Alertmanager, Grafana, or anything else that can POST JSON pushes alerts in, and OneUptime turns each one into an incident with on-call escalation and automatic resolution on recovery.
+
+Both use the same monitor type. What separates them is the criteria you configure.
 
 ## Overview
 
-Incoming Request monitors provide a unique webhook URL that your services call on a schedule. This enables you to:
+Incoming Request monitors provide a unique URL that your services call. This enables you to:
 
 - Monitor cron jobs and scheduled tasks
 - Verify background workers are running
 - Monitor services behind firewalls that cannot be reached externally
-- Integrate with third-party monitoring tools
+- Receive alerts from Prometheus Alertmanager, Grafana, and other alerting systems
 - Track heartbeat signals from any HTTP-capable system
 
 ## Creating an Incoming Request Monitor
@@ -17,21 +24,34 @@ Incoming Request monitors provide a unique webhook URL that your services call o
 1. Go to **Monitors** in the OneUptime Dashboard
 2. Click **Create Monitor**
 3. Select **Incoming Request** as the monitor type
-4. A **Secret Key** and heartbeat URL will be generated for this monitor
-5. Configure your service to send requests to the heartbeat URL
-6. Configure monitoring criteria as needed
+4. A **Secret Key** and URL are generated for this monitor
+5. Open the monitor and click **Documentation** in the left menu to copy the URL
+6. Configure your service to send requests to that URL
+7. Configure monitoring criteria as described below
 
-## Heartbeat URL
+## The request URL
 
-Once created, your monitor will have a unique heartbeat URL in the format:
+Your monitor has a unique URL in the format:
 
 ```
 https://oneuptime.com/heartbeat/YOUR_SECRET_KEY
 ```
 
-Your service should send HTTP **GET** or **POST** requests to this URL at regular intervals.
+Replace `https://oneuptime.com` with your OneUptime instance URL if self-hosted.
 
-### Sending a Heartbeat
+Send **GET** or **POST** requests to this URL. HEAD is accepted and treated as GET. Other methods return 404. The secret key in the path is the only credential — no header or token is required.
+
+> **Warning:** Anyone who knows this URL can mark the monitor healthy, so treat it as a secret. Every header you send is stored on the monitor and is visible to anyone who can read it — do not send API keys or tokens in headers to this endpoint.
+
+OneUptime replies with an empty `200` immediately and processes the request on a queue. That reply is written before any validation happens, so a `200` is **not** confirmation that the request was accepted — a wrong secret key, a deleted monitor, and a disabled monitor all return `200` too. Check the monitor's own timeline to confirm requests are landing.
+
+### Sending a request body
+
+If you want to address fields inside the body — `{{requestBody.status}}` in an incident title, a JSON path in incident grouping, or a JavaScript Expression criteria — send `Content-Type: application/json` — it is the format these docs assume throughout. An `application/x-www-form-urlencoded` body is also parsed, but only into flat top-level fields. Any other content type, or none at all, is not parsed and every `requestBody` reference resolves to nothing.
+
+Bodies up to 50 MB are accepted. Do not compress the body with `Content-Encoding: gzip`; it is stored unparsed and paths into it will not resolve.
+
+### Sending a heartbeat
 
 #### Using curl
 
@@ -66,50 +86,120 @@ import requests
 requests.get('https://oneuptime.com/heartbeat/YOUR_SECRET_KEY')
 ```
 
-Replace `https://oneuptime.com` with your OneUptime instance URL if self-hosted.
-
 ## Monitoring Criteria
 
-You can configure criteria to determine when your service is considered online, degraded, or offline based on:
+You can configure criteria to determine when your service is considered online, degraded, or offline. Each criteria filter has a **Filter Type** (what to look at), a **Filter Condition** (how to compare it), and a **Value**.
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type           | Description                                           |
-| -------------------- | ----------------------------------------------------- |
-| Incoming Request     | Whether a heartbeat was received within a time window |
-| Request Body         | Content of the request body sent with the heartbeat   |
-| Request Header       | Name of a specific request header                     |
-| Request Header Value | Value of a specific request header                    |
+| Filter Type           | Checks                                                 | Notes                                                                                        |
+| --------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Incoming Request      | Whether a request was received within a time window    | The only check that can fire when nothing arrives                                            |
+| Request Body          | The request body                                       | Substring match. Object bodies are compared as compact JSON                                  |
+| Request Header        | The names of the request headers                       | Exact match against a header name, lower-cased                                               |
+| Request Header Value  | The values of the request headers                      | Exact match against a header value, lower-cased                                              |
+| JavaScript Expression | Any expression over `requestBody` and `requestHeaders` | The most flexible option — see [JavaScript Expressions](/docs/monitor/javascript-expression) |
 
-### Filter Types
+### Filter Conditions
 
-For **Incoming Request**:
+Each filter type offers its own set of conditions.
 
-- **Received In Minutes** — A heartbeat was received within the specified number of minutes
-- **Not Received In Minutes** — No heartbeat was received within the specified number of minutes
+For **Incoming Request** (reproduced here with the dashboard's spelling):
 
-For **Request Body**, **Request Header**, and **Request Header Value**:
+- **Recieved In Minutes** — a request was received within the specified number of minutes
+- **Not Recieved In Minutes** — no request was received within the specified number of minutes
 
-- **Contains** — Value contains the specified text
-- **Not Contains** — Value does not contain the specified text
+For **Request Body**, **Request Header**, and **Request Header Value**: **Contains** and **Not Contains**.
+
+For **JavaScript Expression**: **Evaluates To True**.
+
+> **Note:** Header names and header values are lower-cased before comparison, and the match is against the whole name or value, not a substring. Write `content-type`, not `Content-Type`, and `application/json`, not `application/JSON`. Only **Request Body** does a true substring match.
+
+Object bodies are compared as compact JSON with no spaces, so a **Request Body** / **Contains** filter must be written `"status":"firing"` — copying `"status": "firing"` out of a pretty-printed payload will never match.
 
 ### Example Criteria
 
 #### Mark as offline if no heartbeat in 10 minutes
 
-- **Check On**: Incoming Request
-- **Filter Type**: Not Received In Minutes
+- **Filter Type**: Incoming Request
+- **Filter Condition**: Not Recieved In Minutes
 - **Value**: 10
 
 #### Mark as degraded based on request body content
 
-- **Check On**: Request Body
-- **Filter Type**: Contains
-- **Value**: `"status": "degraded"`
+- **Filter Type**: Request Body
+- **Filter Condition**: Contains
+- **Value**: `"status":"degraded"`
+
+> **Warning:** A monitor is only re-evaluated in the background if at least one of its criteria checks on **Incoming Request**. A monitor whose criteria only check Request Body, Request Header, or a JavaScript Expression is evaluated when a request arrives and at no other time — so it can never go offline on its own. If you want a missing-heartbeat alarm, you need an **Incoming Request** criteria.
+
+Note also that a monitor which has never received a request is treated as though its creation time were the last request. A "Not Recieved In Minutes: 10" criteria on a brand-new monitor fires 10 minutes after you create it, even if the sender was never wired up.
+
+## Receiving alerts from another system
+
+Alertmanager, Grafana, and similar tools POST a JSON document describing one or more alerts. By default a criteria opens **one** incident, so a payload carrying five alerts would produce a single incident. Incident grouping changes that: it extracts a value from the payload and opens a **separate incident per distinct value**, all of which can be open at once.
+
+### Turning on incident grouping
+
+Open the criteria, expand **Settings**, and turn on **Group incidents and alerts by a payload field**. Four fields appear:
+
+| Field                              | Example                                  | What it does                                                           |
+| ---------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------- |
+| Open a separate incident for each… | `requestBody.alerts[*].labels.alertname` | The path whose distinct values split incidents apart                   |
+| Field that signals recovery        | `requestBody.alerts[*].status`           | The path checked to decide an alert has recovered                      |
+| Value that means recovered         | `resolved`                               | The exact value that marks recovery                                    |
+| Max incidents per request          | `100` (default)                          | Safety cap so a high-cardinality field cannot open unbounded incidents |
+
+### Path syntax
+
+Paths must start with the literal prefix `requestBody.`. A path without it — `alerts[*].labels.alertname` — matches nothing, silently. The `{{ }}` wrapper is optional: `requestBody.status` and `{{requestBody.status}}` behave identically.
+
+- `[*]` fans out over an array — one incident per **distinct** value. Two elements yielding the same value collapse into one incident, and that incident's firing/resolved state is taken from the **first** matching element. **Only the first `[*]` in a path is a wildcard**; `requestBody.groups[*].alerts[*].name` matches nothing.
+- `[0]` and `[last]` select a single element, and may follow a `[*]`.
+- Object and array values, empty strings, and nulls are skipped. `0` and `false` are valid keys.
+
+### Resolution is event-driven
+
+A webhook describes only what is in that payload, so OneUptime never resolves an incident because its key stopped appearing. An incident is resolved only when a payload explicitly says that key recovered. Two things must both be true:
+
+1. **Field that signals recovery** and **Value that means recovered** are set, and match the payload. The comparison is exact and case-sensitive — `Resolved` does not match `resolved`.
+2. The criteria's incident has **Auto Resolve Incident** turned on, under **Advanced Options** in the incident form. Without it, matching recovery events are ignored and the incidents stay open. (The same applies to alerts and **Auto Resolve Alert**.)
+
+**Max incidents per request** caps extraction, not just creation. Keys past the cap are invisible to recovery as well, so in a payload carrying more distinct keys than the cap, an alert reporting `resolved` beyond it will not close its incident.
+
+> **Warning:** If **Field that signals recovery** contains `[*]` but **Open a separate incident for each…** does not, nothing will ever resolve. Either use `[*]` in both, or neither. A recovery path without `[*]` is evaluated against the whole payload, so a payload-level `status: resolved` resolves every key in that payload — including alerts whose own status is still firing.
+
+### Naming the incidents
+
+The grouping key is exposed to incident and alert templates as a variable named after the **last segment of the path**:
+
+| Path                                     | Variable          |
+| ---------------------------------------- | ----------------- |
+| `requestBody.alerts[*].labels.alertname` | `{{alertname}}`   |
+| `requestBody.alerts[*].fingerprint`      | `{{fingerprint}}` |
+| `requestBody.commonLabels.severity`      | `{{severity}}`    |
+
+The full payload is available alongside it, so an incident title of `{{alertname}}` and a description referencing `{{requestBody.commonAnnotations.summary}}` both work. See [Incident & Alert Dynamic Templating](/docs/monitor/incident-alert-templating).
+
+> **Warning:** The variable name is part of the identity OneUptime uses to match a recovery event to an open incident. Changing the grouping path to one with a different last segment orphans every incident that is currently open under the old path — they can no longer be resolved automatically and must be closed by hand.
+
+Note that `[*]` works **only** in the two grouping path fields. Elsewhere it does not resolve, and an unresolved placeholder is printed **verbatim** rather than blanked — a title of `{{requestBody.alerts[*].labels.alertname}}` renders with the braces still in it. A title of `{{requestBody.alerts[0].annotations.summary}}` resolves, but always reads the first alert in the payload, not the one this incident was opened for. Prefer the grouping variable plus the payload's shared `commonAnnotations` fields.
+
+### Worked example
+
+For a full Alertmanager configuration, see [Prometheus Alertmanager](/docs/integrations/prometheus-alertmanager). For Grafana, see [Grafana](/docs/integrations/grafana).
 
 ## Best Practices
 
-1. **Set the time window appropriately** — If your cron job runs every 5 minutes, set the "Not Received In Minutes" threshold to 10–15 minutes to allow for occasional delays
+1. **Set the time window appropriately** — If your cron job runs every 5 minutes, set the "Not Recieved In Minutes" threshold to 10–15 minutes to allow for occasional delays
 2. **Include meaningful data** — Send status information in the request body so you can set up granular criteria
-3. **Use POST for rich data** — Use POST requests with JSON bodies when you need to send detailed status information
-4. **Monitor the monitor** — Ensure the service sending heartbeats has proper error handling so failed heartbeat requests don't go unnoticed
+3. **Use POST with `Content-Type: application/json`** — anything that reads inside the body depends on it
+4. **Don't mix the two jobs on one monitor** — a monitor receiving event-driven alerts has no regular cadence, so a "Not Recieved In Minutes" criteria on it will flap. Use a separate monitor for the dead-man's switch
+5. **Monitor the monitor** — Ensure the service sending requests has proper error handling so failed requests don't go unnoticed
+
+## Where to read next
+
+- [Prometheus Alertmanager](/docs/integrations/prometheus-alertmanager) — a complete inbound alerting setup
+- [Grafana](/docs/integrations/grafana) — the same, for Grafana alerting
+- [Incident & Alert Dynamic Templating](/docs/monitor/incident-alert-templating) — every variable available in titles and descriptions
+- [JavaScript Expressions](/docs/monitor/javascript-expression) — expression syntax and quoting rules


### PR DESCRIPTION
Closes the documentation gap behind #3214.

## Why

#3214 asked for a Prometheus Alertmanager resource. The feature already exists — an **Incoming Request monitor** with per-criteria incident grouping does exactly this, and its own source comments name Alertmanager and Grafana as the motivating cases (`Common/Types/Monitor/IncomingMonitor/IncidentGroupingConfig.ts`). Shipped in 11.3.10.

It just wasn't written down anywhere. The Alertmanager and Grafana pages documented only the Workflow path, the integrations overview said inbound integrations go through Workflows full stop, and the Incoming Request page was framed purely as heartbeat monitoring — no mention of incident grouping, and `JavaScript Expression` was missing from its check-types table. A user reading the docs had no way to find the feature built for their exact problem.

## What changed

English source only; other locales follow the translation pipeline.

- **`monitor/incoming-request-monitor.md`** — reframed around the two jobs this monitor does (heartbeat *and* alert receiver). Added `JavaScript Expression` to the check-types table. New section on incident grouping: path syntax, event-driven resolution, and how the grouping key becomes a template variable.
- **`integrations/prometheus-alertmanager.md`** — the monitor path is now Option 1 with a full walkthrough (monitor → `alertmanager.yml` → criteria → grouping → templates → test). The Workflow path stays as Option 2 for custom routing. Adds a dead-man's-switch section and real troubleshooting.
- **`integrations/grafana.md`** — same Option 1 / Option 2 split, cross-linked to the Alertmanager walkthrough since the payload shape is identical.
- **`integrations/index.md`** — corrected the "inbound means Workflows" framing.
- **`monitor/incident-alert-templating.md`** — documented the grouping label variable, and that `[*]` does **not** work in templates.

## Behaviour the docs now capture

Each of these fails silently today, and each cost real debugging time to establish:

- **Auto-resolve needs two things, not one.** A `resolved` webhook only closes a grouped incident if the criteria's incident also has **Auto Resolve Incident** on — `MonitorIncident.ts` skips any incident whose creating template isn't in the auto-resolve dictionary, which `MonitorResource.ts` populates solely from `incidentTemplate.autoResolveIncident`. Configure grouping without it and incidents accumulate forever.
- **Group by something unique per alert.** Incidents open per *distinct* extracted value, and duplicates keep only their first occurrence. Grouping by a label that is also in Alertmanager's `group_by` therefore collapses the whole payload into one incident — and if that first occurrence is `resolved`, closes it while the rest are still firing. An adversarial review pass caught this in my own first draft, which recommended `alerts[*].labels.alertname` alongside `group_by: ["alertname", "instance"]`. The recommended path is now `alerts[*].fingerprint`, unique by construction.
- **Only the first `[*]` in a path is a wildcard.** `requestBody.groups[*].alerts[*].name` matches nothing — the second `[*]` reaches `deepFind`, which does `parseInt("*") → NaN`.
- **Unresolved placeholders are printed verbatim, not blanked.** This also corrects a pre-existing claim in the templating page that a missing path "resolves to an empty string".
- **`Max incidents per request` caps extraction, not just creation** — keys past the cap are invisible to recovery too.
- **A lost `resolved` notification strands an incident permanently**, because Alertmanager repeats firing notifications but not resolved ones.
- **Grouping paths must start with the literal `requestBody.`.** Anything else returns zero items with no error and no log.
- **`[*]` works only in the two grouping fields.** In a title, `{{requestBody.alerts[0].annotations.summary}}` always reads the first alert, not the one the incident was opened for.
- **A `200` confirms nothing.** The response is written before validation, so a bad secret key, a deleted monitor, and a disabled monitor all return `200`.
- **`Content-Type: application/json` is effectively mandatory.** Without it the body is discarded and every `requestBody` path resolves to nothing.
- **Header criteria are exact, lower-cased, whole-string matches** against header names (`Request Header`) or values (`Request Header Value`) — not substring. Only `Request Body` is a substring match, over compact JSON, so the filter value must be `"status":"firing"` with no space.
- **Same-monitor requests are coalesced at ingest** (`INCOMING_REQUEST_INGEST_COALESCE_ENABLED`, default on), so back-to-back notifications can drop an intermediate payload.
- **The background cron only re-evaluates monitors that have a `CheckOn: Incoming Request` criteria.** A monitor whose criteria are all body/header/expression based is evaluated on arrival and never otherwise — so it can't go offline on its own.

## Verification

- `npm run docs:check-anchors` — clean.
- Prettier clean on all four files that were already clean. The fifth (`incident-alert-templating.md`) had pre-existing drift in an unrelated SNMP table; the addition there is prettier-clean and that table is untouched, to keep the diff readable.
- All internal `/docs/…` links resolve to real files on disk, no language prefixes, no dead `#fragments`. (Worth noting: `CheckAnchors` validates in-page anchors only — cross-file links are unvalidated and 404 silently, so these were checked by script.)
- Every callout added matches the `Note|Warning|Tip|Danger|Info|Caution` regex in `Common/Server/Types/Markdown.ts`, so they render as callouts rather than degrading to plain blockquotes.
- No new pages, so no `Nav.ts` or locale-file changes are needed — which also avoids the 16-file locale-key requirement CI enforces.

## Also corrected here

The criteria field labels were wrong in both directions on every page this PR touches. The dropdown holding `Incoming Request` / `Request Body` / `JavaScript Expression` is labelled **Filter Type** in the dashboard (`CriteriaFilter.tsx:252`); the comparator dropdown is **Filter Condition** (`:537`). The docs called the first one "Check On" — a string that appears nowhere in the UI — and gave its real name to the second, so both labels sent readers to the wrong field.

Fixed in the three pages rewritten here. The same mislabelling runs through roughly fifteen other monitor pages (`ping-monitor.md`, `logs-monitor.md`, `ip-monitor.md`, …); renaming those would swamp this diff and would change `### Filter Types` section headings that may have inbound deep links, so it is left for a follow-up.

## Notes for follow-ups

Two other things surfaced and were deliberately left alone:

**1.** The Incoming Request filter conditions are misspelled in the product: `Recieved In Minutes` / `Not Recieved In Minutes` (`Common/Types/Monitor/CriteriaFilter.ts`). The docs previously wrote them correctly, which meant they didn't match the dropdown. New text quotes the misspelling so readers can find the option. Fixing the enum is not a docs change — the string is persisted in `monitorSteps` JSON, so a rename needs a migration.

**2.** `INCOMING_REQUEST_INGEST_COALESCE_ENABLED` is read by the app (`App/FeatureSet/Telemetry/Config.ts`) but is not passed through `docker-compose.base.yml`, not present in `config.example.env`, and not in the Helm chart's app `env:` list — so a self-hosted operator setting it in `.env` gets no effect and no signal. The docs now describe it as a variable on the app container rather than promising the `.env` workflow works. Wiring it up properly is a separate change.

**3.** `incident-alert-templating.md` has two `## Supported Monitor Types & Variables` headings, which slugify to the same DOM id, so the second one's permalink jumps to the first. Pre-existing; retitling a heading risks breaking inbound deep links, so it was left alone.
