### PR TITLE
docs: name the monitor criteria fields the way the UI labels them

### DIFF
--- a/App/FeatureSet/Docs/Content/en/monitor/ceph-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/ceph-monitor.md
@@ -115,11 +115,9 @@ All `ceph_pg_*` state metrics are exported **per pool** with a `pool_id` label â
 
 ## Monitoring Criteria
 
-### Available Check Types
+### What Gets Evaluated
 
-| Check Type   | Description                                         |
-| ------------ | --------------------------------------------------- |
-| Metric Value | The value of the configured metric query or formula |
+These monitors always evaluate the **Metric Value** â€” the value of the configured metric query or formula. The criteria form has no Filter Type selector; it shows **Metric**, **Aggregation**, **Condition**, and **Threshold**.
 
 ### Aggregation Types
 
@@ -132,7 +130,7 @@ All `ceph_pg_*` state metrics are exported **per pool** with a `pool_id` label â
 | All Values    | All values must match the criteria |
 | Any Value     | At least one value must match      |
 
-### Filter Types
+### Conditions
 
 - **Greater Than**, **Less Than**, **Greater Than or Equal To**, **Less Than or Equal To**, **Equal To**, **Not Equal To**
 

--- a/App/FeatureSet/Docs/Content/en/monitor/dns-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/dns-monitor.md
@@ -57,9 +57,9 @@ DNS monitors query DNS servers for specific record types and evaluate the result
 
 You can configure criteria to determine when your DNS is considered online, degraded, or offline based on:
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type                | Description                                |
+| Filter Type               | Description                                |
 | ------------------------- | ------------------------------------------ |
 | DNS Is Online             | Whether the DNS server responds to queries |
 | DNS Response Time (in ms) | Query response time in milliseconds        |
@@ -67,7 +67,7 @@ You can configure criteria to determine when your DNS is considered online, degr
 | DNS Record Value          | The value returned by a DNS record         |
 | DNSSEC Is Valid           | Whether DNSSEC validation passes           |
 
-### Filter Types
+### Filter Conditions
 
 For **DNS Is Online**, **DNS Record Exists**, and **DNSSEC Is Valid**:
 
@@ -91,22 +91,22 @@ For **DNS Record Value**:
 
 #### Check if DNS is resolving
 
-- **Check On**: DNS Is Online
-- **Filter Type**: True
+- **Filter Type**: DNS Is Online
+- **Filter Condition**: True
 
 #### Verify A record points to correct IP
 
-- **Check On**: DNS Record Value
-- **Filter Type**: Equal To
+- **Filter Type**: DNS Record Value
+- **Filter Condition**: Equal To
 - **Value**: `93.184.216.34`
 
 #### Alert if DNS response is slow
 
-- **Check On**: DNS Response Time (in ms)
-- **Filter Type**: Greater Than
+- **Filter Type**: DNS Response Time (in ms)
+- **Filter Condition**: Greater Than
 - **Value**: 500
 
 #### Verify DNSSEC is valid
 
-- **Check On**: DNSSEC Is Valid
-- **Filter Type**: True
+- **Filter Type**: DNSSEC Is Valid
+- **Filter Condition**: True

--- a/App/FeatureSet/Docs/Content/en/monitor/dnssec-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/dnssec-monitor.md
@@ -42,9 +42,9 @@ DNSSEC monitors validate the entire chain of trust from the root zone down to yo
 
 You can configure criteria to determine when your zone is considered online, degraded, or offline based on:
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type                          | Description                                                        |
+| Filter Type                         | Description                                                        |
 | ----------------------------------- | ------------------------------------------------------------------ |
 | DNSSEC Chain Is Valid               | The entire validation chain (root → TLD → zone) resolves correctly |
 | DNSSEC DNSKEY Record Exists         | The zone publishes at least one DNSKEY record                      |
@@ -54,7 +54,7 @@ You can configure criteria to determine when your zone is considered online, deg
 | DNSSEC Nameservers Are Consistent   | All authoritative nameservers return the same SOA serial           |
 | DNSSEC Is Valid                     | Aggregate pass/fail across all validation checks                   |
 
-### Filter Types
+### Filter Conditions
 
 For **DNSSEC Chain Is Valid**, **DNSSEC DNSKEY Record Exists**, **DNSSEC DS Record Exists At Parent**, **DNSSEC Resolver Consensus (AD Flag)**, **DNSSEC Nameservers Are Consistent**, and **DNSSEC Is Valid**:
 
@@ -69,29 +69,29 @@ For **DNSSEC Signature Expires In Days**:
 
 #### Alert if the DNSSEC chain is broken
 
-- **Check On**: DNSSEC Chain Is Valid
-- **Filter Type**: False
+- **Filter Type**: DNSSEC Chain Is Valid
+- **Filter Condition**: False
 
 #### Warn before signatures expire
 
-- **Check On**: DNSSEC Signature Expires In Days
-- **Filter Type**: Less Than
+- **Filter Type**: DNSSEC Signature Expires In Days
+- **Filter Condition**: Less Than
 - **Value**: 7
 
 #### Catch missing DS at parent (delegation broken)
 
-- **Check On**: DNSSEC DS Record Exists At Parent
-- **Filter Type**: False
+- **Filter Type**: DNSSEC DS Record Exists At Parent
+- **Filter Condition**: False
 
 #### Detect resolver disagreement
 
-- **Check On**: DNSSEC Resolver Consensus (AD Flag)
-- **Filter Type**: False
+- **Filter Type**: DNSSEC Resolver Consensus (AD Flag)
+- **Filter Condition**: False
 
 #### Catch nameserver split-brain
 
-- **Check On**: DNSSEC Nameservers Are Consistent
-- **Filter Type**: False
+- **Filter Type**: DNSSEC Nameservers Are Consistent
+- **Filter Condition**: False
 
 ## Best Practices
 

--- a/App/FeatureSet/Docs/Content/en/monitor/docker-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/docker-monitor.md
@@ -103,11 +103,9 @@ The Docker Agent uses the OpenTelemetry `docker_stats` receiver, which scrapes t
 
 ## Monitoring Criteria
 
-### Available Check Types
+### What Gets Evaluated
 
-| Check Type   | Description                                         |
-| ------------ | --------------------------------------------------- |
-| Metric Value | The value of the configured metric query or formula |
+These monitors always evaluate the **Metric Value** — the value of the configured metric query or formula. The criteria form has no Filter Type selector; it shows **Metric**, **Aggregation**, **Condition**, and **Threshold**.
 
 ### Aggregation Types
 
@@ -120,7 +118,7 @@ The Docker Agent uses the OpenTelemetry `docker_stats` receiver, which scrapes t
 | All Values    | All values must match the criteria |
 | Any Value     | At least one value must match      |
 
-### Filter Types
+### Conditions
 
 - **Greater Than**, **Less Than**, **Greater Than or Equal To**, **Less Than or Equal To**, **Equal To**, **Not Equal To**
 

--- a/App/FeatureSet/Docs/Content/en/monitor/domain-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/domain-monitor.md
@@ -63,9 +63,9 @@ The timeout applies to each lookup, so an **Auto** check that tries RDAP and the
 
 You can configure criteria to determine when your domain is considered online, degraded, or offline based on:
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type             | Description                                          |
+| Filter Type            | Description                                          |
 | ---------------------- | ---------------------------------------------------- |
 | Is Online              | Whether the registration lookup itself succeeded     |
 | Is Request Timeout     | Whether the registration lookup timed out            |
@@ -79,7 +79,7 @@ Status codes are normalized to their EPP names (`clientTransferProhibited`) rega
 
 Dates are normalized to ISO 8601. A date a registry publishes in a form that cannot be parsed is omitted rather than stored, so an expiry criterion reports "cannot decide" instead of silently answering "not expired" forever.
 
-### Filter Types
+### Filter Conditions
 
 For **Is Online**, **Is Request Timeout** and **Domain Is Expired**:
 
@@ -102,24 +102,24 @@ For **Domain Registrar**, **Domain Name Server**, and **Domain Status Code**:
 
 #### Alert if domain expires within 30 days
 
-- **Check On**: Domain Expires In Days
-- **Filter Type**: Less Than
+- **Filter Type**: Domain Expires In Days
+- **Filter Condition**: Less Than
 - **Value**: 30
 
 #### Mark as offline if domain is expired
 
-- **Check On**: Domain Is Expired
-- **Filter Type**: True
+- **Filter Type**: Domain Is Expired
+- **Filter Condition**: True
 
 #### Mark as offline if the registration cannot be read
 
-- **Check On**: Is Online
-- **Filter Type**: False
+- **Filter Type**: Is Online
+- **Filter Condition**: False
 
 #### Verify nameservers are correct
 
-- **Check On**: Domain Name Server
-- **Filter Type**: Contains
+- **Filter Type**: Domain Name Server
+- **Filter Condition**: Contains
 - **Value**: `ns1.example.com`
 
 ## Best Practices

--- a/App/FeatureSet/Docs/Content/en/monitor/domain-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/domain-monitor.md
@@ -25,8 +25,8 @@ Domain monitors read the registration record for your domains. This enables you 
 
 Registration data can be read over two protocols, and which one works depends on the TLD.
 
-| Method    | Behaviour                                                                                          |
-| --------- | -------------------------------------------------------------------------------------------------- |
+| Method    | Behaviour                                                                                            |
+| --------- | ---------------------------------------------------------------------------------------------------- |
 | **Auto**  | Default. Uses RDAP when the TLD publishes an RDAP service, and falls back to WHOIS when it does not. |
 | **RDAP**  | RDAP only. Fails with a clear error if the TLD publishes no RDAP service.                            |
 | **WHOIS** | WHOIS only.                                                                                          |
@@ -43,17 +43,17 @@ Internationalized domain names are accepted in either form: `münchen.de` is con
 
 ### Basic Settings
 
-| Field         | Description                                            | Required |
-| ------------- | ------------------------------------------------------ | -------- |
-| Domain Name   | The domain to monitor (e.g., `example.com`)            | Yes      |
-| Lookup Method | `Auto`, `RDAP`, or `WHOIS` — see **Lookup Methods**    | Yes      |
+| Field         | Description                                         | Required |
+| ------------- | --------------------------------------------------- | -------- |
+| Domain Name   | The domain to monitor (e.g., `example.com`)         | Yes      |
+| Lookup Method | `Auto`, `RDAP`, or `WHOIS` — see **Lookup Methods** | Yes      |
 
 ### Advanced Settings
 
-| Field        | Description                                        | Default |
-| ------------ | -------------------------------------------------- | ------- |
-| Timeout (ms) | How long to wait for the registration lookup       | 10000   |
-| Retries      | Number of retry attempts on failure                | 3       |
+| Field        | Description                                  | Default |
+| ------------ | -------------------------------------------- | ------- |
+| Timeout (ms) | How long to wait for the registration lookup | 10000   |
+| Retries      | Number of retry attempts on failure          | 3       |
 
 Failures that cannot change on a retry — the domain is not registered, or the TLD publishes no RDAP service when you have asked for RDAP only — are reported immediately rather than retried. Everything else, including a WHOIS server that answers with no record (a rate-limited registrar looks the same as a retired one), is retried first.
 
@@ -65,17 +65,17 @@ You can configure criteria to determine when your domain is considered online, d
 
 ### Available Check Types
 
-| Check Type             | Description                                            |
-| ---------------------- | ------------------------------------------------------ |
-| Is Online              | Whether the registration lookup itself succeeded        |
-| Is Request Timeout     | Whether the registration lookup timed out               |
-| Domain Expires In Days | Number of days until the domain registration expires    |
-| Domain Registrar       | The domain registrar name                               |
-| Domain Name Server     | Nameserver hostnames for the domain                     |
-| Domain Status Code     | Domain status codes (EPP status names)                  |
-| Domain Is Expired      | Whether the domain has expired                          |
+| Check Type             | Description                                          |
+| ---------------------- | ---------------------------------------------------- |
+| Is Online              | Whether the registration lookup itself succeeded     |
+| Is Request Timeout     | Whether the registration lookup timed out            |
+| Domain Expires In Days | Number of days until the domain registration expires |
+| Domain Registrar       | The domain registrar name                            |
+| Domain Name Server     | Nameserver hostnames for the domain                  |
+| Domain Status Code     | Domain status codes (EPP status names)               |
+| Domain Is Expired      | Whether the domain has expired                       |
 
-Status codes are normalized to their EPP names (`clientTransferProhibited`) regardless of which protocol answered, so a criterion keeps matching when **Auto** switches between RDAP and WHOIS. Registrar *names* are whatever the answering service publishes and can differ slightly between the two protocols, so prefer **Contains** over **Equal To** for a **Domain Registrar** criterion.
+Status codes are normalized to their EPP names (`clientTransferProhibited`) regardless of which protocol answered, so a criterion keeps matching when **Auto** switches between RDAP and WHOIS. Registrar _names_ are whatever the answering service publishes and can differ slightly between the two protocols, so prefer **Contains** over **Equal To** for a **Domain Registrar** criterion.
 
 Dates are normalized to ISO 8601. A date a registry publishes in a form that cannot be parsed is omitted rather than stored, so an expiry criterion reports "cannot decide" instead of silently answering "not expired" forever.
 

--- a/App/FeatureSet/Docs/Content/en/monitor/exceptions-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/exceptions-monitor.md
@@ -38,13 +38,13 @@ Select one or more services to monitor exceptions from. Services must be sending
 
 ## Monitoring Criteria
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type      | Description                                                       |
+| Filter Type     | Description                                                       |
 | --------------- | ----------------------------------------------------------------- |
 | Exception Count | The number of exceptions matching your filters in the time window |
 
-### Filter Types
+### Filter Conditions
 
 - **Greater Than** — Exception count exceeds a threshold
 - **Less Than** — Exception count is below a threshold
@@ -58,24 +58,24 @@ Select one or more services to monitor exceptions from. Services must be sending
 #### Alert if more than 10 exceptions in 60 seconds
 
 - **Time Window**: 60 seconds
-- **Check On**: Exception Count
-- **Filter Type**: Greater Than
+- **Filter Type**: Exception Count
+- **Filter Condition**: Greater Than
 - **Value**: 10
 
 #### Alert on any NullPointerException
 
 - **Exception Types**: `NullPointerException`
 - **Time Window**: 60 seconds
-- **Check On**: Exception Count
-- **Filter Type**: Greater Than
+- **Filter Type**: Exception Count
+- **Filter Condition**: Greater Than
 - **Value**: 0
 
 #### Monitor exceptions containing a specific message
 
 - **Message**: `out of memory`
 - **Time Window**: 300 seconds
-- **Check On**: Exception Count
-- **Filter Type**: Greater Than
+- **Filter Type**: Exception Count
+- **Filter Condition**: Greater Than
 - **Value**: 0
 
 ## Setup Requirements

--- a/App/FeatureSet/Docs/Content/en/monitor/host-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/host-monitor.md
@@ -105,11 +105,9 @@ The OneUptime Infrastructure Agent uses the OpenTelemetry `hostmetrics` receiver
 
 ## Monitoring Criteria
 
-### Available Check Types
+### What Gets Evaluated
 
-| Check Type   | Description                                         |
-| ------------ | --------------------------------------------------- |
-| Metric Value | The value of the configured metric query or formula |
+These monitors always evaluate the **Metric Value** — the value of the configured metric query or formula. The criteria form has no Filter Type selector; it shows **Metric**, **Aggregation**, **Condition**, and **Threshold**.
 
 ### Aggregation Types
 
@@ -122,7 +120,7 @@ The OneUptime Infrastructure Agent uses the OpenTelemetry `hostmetrics` receiver
 | All Values    | All values must match the criteria |
 | Any Value     | At least one value must match      |
 
-### Filter Types
+### Conditions
 
 - **Greater Than**, **Less Than**, **Greater Than or Equal To**, **Less Than or Equal To**, **Equal To**, **Not Equal To**
 

--- a/App/FeatureSet/Docs/Content/en/monitor/incoming-email-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/incoming-email-monitor.md
@@ -36,11 +36,11 @@ For example: `monitor-abc123def456@inbound.yourdomain.com`
 
 You can copy this address from the monitor details page and configure your external systems to send emails to it.
 
-## Available Criteria Fields
+## Available Filter Types
 
 You can create criteria based on the following email fields:
 
-| Field              | Description                                      |
+| Filter Type        | Description                                      |
 | ------------------ | ------------------------------------------------ |
 | **Email Subject**  | The subject line of the incoming email           |
 | **Email From**     | The sender's email address                       |
@@ -48,11 +48,11 @@ You can create criteria based on the following email fields:
 | **Email To**       | The recipient email address                      |
 | **Email Received** | Time-based criteria for when emails are received |
 
-## Available Filter Types
+## Filter Conditions
 
 ### String Filters (Subject, From, Body, To)
 
-| Filter           | Description                               | Example                          |
+| Filter Condition | Description                               | Example                          |
 | ---------------- | ----------------------------------------- | -------------------------------- |
 | **Contains**     | Field contains the specified text         | Subject contains "CRITICAL"      |
 | **Not Contains** | Field does not contain the specified text | Subject not contains "TEST"      |
@@ -65,7 +65,7 @@ You can create criteria based on the following email fields:
 
 ### Time-Based Filters (Email Received)
 
-| Filter                      | Description                         | Example                          |
+| Filter Condition            | Description                         | Example                          |
 | --------------------------- | ----------------------------------- | -------------------------------- |
 | **Received In Minutes**     | Email was received within X minutes | Email received in 30 minutes     |
 | **Not Received In Minutes** | No email received in X minutes      | Email not received in 60 minutes |

--- a/App/FeatureSet/Docs/Content/en/monitor/ip-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/ip-monitor.md
@@ -29,15 +29,15 @@ Enter the IPv4 or IPv6 address you want to monitor (e.g., `192.168.1.1` or `2001
 
 You can configure criteria to determine when your IP address is considered online, degraded, or offline based on:
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type            | Description                         |
+| Filter Type           | Description                         |
 | --------------------- | ----------------------------------- |
 | Is Online             | Whether the IP address is reachable |
 | Response Time (in ms) | Response time in milliseconds       |
 | Is Request Timeout    | Whether the request timed out       |
 
-### Filter Types
+### Filter Conditions
 
 For **Is Online** and **Is Request Timeout**:
 
@@ -58,11 +58,11 @@ For **Response Time**:
 
 #### Mark as offline if IP is unreachable
 
-- **Check On**: Is Online
-- **Filter Type**: False
+- **Filter Type**: Is Online
+- **Filter Condition**: False
 
 #### Alert if latency exceeds 100ms
 
-- **Check On**: Response Time (in ms)
-- **Filter Type**: Greater Than
+- **Filter Type**: Response Time (in ms)
+- **Filter Condition**: Greater Than
 - **Value**: 100

--- a/App/FeatureSet/Docs/Content/en/monitor/kubernetes-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/kubernetes-monitor.md
@@ -115,11 +115,9 @@ Select the time window for metric evaluation:
 
 ## Monitoring Criteria
 
-### Available Check Types
+### What Gets Evaluated
 
-| Check Type   | Description                                         |
-| ------------ | --------------------------------------------------- |
-| Metric Value | The value of the configured metric query or formula |
+These monitors always evaluate the **Metric Value** — the value of the configured metric query or formula. The criteria form has no Filter Type selector; it shows **Metric**, **Aggregation**, **Condition**, and **Threshold**.
 
 ### Aggregation Types
 
@@ -132,7 +130,7 @@ Select the time window for metric evaluation:
 | All Values    | All values must match the criteria |
 | Any Value     | At least one value must match      |
 
-### Filter Types
+### Conditions
 
 - **Greater Than**, **Less Than**, **Greater Than or Equal To**, **Less Than or Equal To**, **Equal To**, **Not Equal To**
 

--- a/App/FeatureSet/Docs/Content/en/monitor/logs-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/logs-monitor.md
@@ -49,13 +49,13 @@ Filter logs by one or more severity levels:
 
 ## Monitoring Criteria
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type | Description                                                 |
-| ---------- | ----------------------------------------------------------- |
-| Log Count  | The number of logs matching your filters in the time window |
+| Filter Type | Description                                                 |
+| ----------- | ----------------------------------------------------------- |
+| Log Count   | The number of logs matching your filters in the time window |
 
-### Filter Types
+### Filter Conditions
 
 - **Greater Than** — Log count exceeds a threshold
 - **Less Than** — Log count is below a threshold
@@ -70,24 +70,24 @@ Filter logs by one or more severity levels:
 
 - **Severity Levels**: ERROR
 - **Time Window**: 60 seconds
-- **Check On**: Log Count
-- **Filter Type**: Greater Than
+- **Filter Type**: Log Count
+- **Filter Condition**: Greater Than
 - **Value**: 100
 
 #### Alert if any fatal logs appear
 
 - **Severity Levels**: FATAL
 - **Time Window**: 60 seconds
-- **Check On**: Log Count
-- **Filter Type**: Greater Than
+- **Filter Type**: Log Count
+- **Filter Condition**: Greater Than
 - **Value**: 0
 
 #### Monitor logs containing a specific error message
 
 - **Body**: `database connection timeout`
 - **Time Window**: 300 seconds
-- **Check On**: Log Count
-- **Filter Type**: Greater Than
+- **Filter Type**: Log Count
+- **Filter Condition**: Greater Than
 - **Value**: 5
 
 ## Setup Requirements

--- a/App/FeatureSet/Docs/Content/en/monitor/metrics-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/metrics-monitor.md
@@ -70,13 +70,11 @@ Choose how to aggregate the metric values for evaluation:
 
 ## Monitoring Criteria
 
-### Available Check Types
+### What Gets Evaluated
 
-| Check Type   | Description                                                    |
-| ------------ | -------------------------------------------------------------- |
-| Metric Value | The aggregated value of the configured metric query or formula |
+These monitors always evaluate the **Metric Value** — the aggregated value of the configured metric query or formula. The criteria form has no Filter Type selector; it shows **Metric**, **Aggregation**, **Condition**, and **Threshold**.
 
-### Filter Types
+### Conditions
 
 - **Greater Than** — Metric value exceeds a threshold
 - **Less Than** — Metric value is below a threshold
@@ -92,16 +90,14 @@ Choose how to aggregate the metric values for evaluation:
 - **Query a**: `http_requests_total` filtered by `status=5xx`
 - **Query b**: `http_requests_total`
 - **Formula**: `a / b * 100`
-- **Check On**: Metric Value
-- **Filter Type**: Greater Than
-- **Value**: 5
+- **Condition**: Greater Than
+- **Threshold**: 5
 
 #### Alert if request queue depth is high
 
 - **Query**: `request_queue_size`, aggregation: Maximum Value
-- **Check On**: Metric Value
-- **Filter Type**: Greater Than
-- **Value**: 1000
+- **Condition**: Greater Than
+- **Threshold**: 1000
 
 ## Setup Requirements
 

--- a/App/FeatureSet/Docs/Content/en/monitor/network-device-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/network-device-monitor.md
@@ -27,13 +27,13 @@ Once registered, the device is polled by the probe you assigned — within a cou
 
 ### Basic Settings
 
-| Field    | Description                                                | Required |
-| -------- | ---------------------------------------------------------- | -------- |
-| Name     | A friendly name for the device (e.g., core-switch-01)      | Yes      |
-| Hostname | IP address or hostname the probe will poll via SNMP        | Yes      |
-| Probe    | Which probe polls this device (also receives its traps, syslog, and NetFlow) | Yes      |
-| SNMP Version | Protocol version: V1, V2c, or V3                       | Yes      |
-| SNMP Port    | UDP port for SNMP queries (default: 161)               | No       |
+| Field        | Description                                                                  | Required |
+| ------------ | ---------------------------------------------------------------------------- | -------- |
+| Name         | A friendly name for the device (e.g., core-switch-01)                        | Yes      |
+| Hostname     | IP address or hostname the probe will poll via SNMP                          | Yes      |
+| Probe        | Which probe polls this device (also receives its traps, syslog, and NetFlow) | Yes      |
+| SNMP Version | Protocol version: V1, V2c, or V3                                             | Yes      |
+| SNMP Port    | UDP port for SNMP queries (default: 161)                                     | No       |
 
 ### SNMP v1/v2c
 
@@ -49,26 +49,26 @@ The community string is stored encrypted.
 
 SNMPv3 provides authentication and encryption:
 
-| Field                       | Description                            | Required                  |
-| --------------------------- | -------------------------------------- | ------------------------- |
-| SNMP v3 Security Level      | No Auth No Priv, Auth No Priv, or Auth Priv | Yes                  |
-| SNMP v3 Username            | The security name (user) configured on the device | Yes            |
-| SNMP v3 Authentication Protocol | MD5, SHA, SHA-256, or SHA-512      | If Auth No Priv or Auth Priv |
-| SNMP v3 Authentication Key  | Authentication password (stored encrypted) | If Auth No Priv or Auth Priv |
-| SNMP v3 Privacy Protocol    | DES, AES, or AES-256                   | If Auth Priv              |
-| SNMP v3 Privacy Key         | Privacy/encryption password (stored encrypted) | If Auth Priv      |
+| Field                           | Description                                       | Required                     |
+| ------------------------------- | ------------------------------------------------- | ---------------------------- |
+| SNMP v3 Security Level          | No Auth No Priv, Auth No Priv, or Auth Priv       | Yes                          |
+| SNMP v3 Username                | The security name (user) configured on the device | Yes                          |
+| SNMP v3 Authentication Protocol | MD5, SHA, SHA-256, or SHA-512                     | If Auth No Priv or Auth Priv |
+| SNMP v3 Authentication Key      | Authentication password (stored encrypted)        | If Auth No Priv or Auth Priv |
+| SNMP v3 Privacy Protocol        | DES, AES, or AES-256                              | If Auth Priv                 |
+| SNMP v3 Privacy Key             | Privacy/encryption password (stored encrypted)    | If Auth Priv                 |
 
 ## Polling & Data Collection
 
 Polling settings live on the device (Device → **Settings** → **Polling & Data Collection**). Defaults are sensible, so a freshly registered device needs no tuning:
 
-| Setting | Description | Default |
-| ------- | ----------- | ------- |
-| Polling Enabled | The assigned probe polls this device on the schedule below. Disable to pause polling without deleting the device. | On |
-| Polling Interval (Minutes) | How often the probe polls the device. Minimum 1 minute. | 5 |
-| Walk Interfaces | Walk the interface tables (IF-MIB) on each poll — per-interface status, bandwidth, utilization, and errors — plus LLDP/CDP neighbors for the topology map. | On |
-| Collect Connected Endpoints | Also walk the device's ARP and bridge-forwarding tables to discover endpoints attached to it (POS terminals, printers, phones, laptops). Costs extra SNMP walks per poll. | Off |
-| Health OIDs | SNMP OIDs (CPU, memory, temperature, or any custom OID) collected on each poll and recorded as device metrics. | None |
+| Setting                     | Description                                                                                                                                                               | Default |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| Polling Enabled             | The assigned probe polls this device on the schedule below. Disable to pause polling without deleting the device.                                                         | On      |
+| Polling Interval (Minutes)  | How often the probe polls the device. Minimum 1 minute.                                                                                                                   | 5       |
+| Walk Interfaces             | Walk the interface tables (IF-MIB) on each poll — per-interface status, bandwidth, utilization, and errors — plus LLDP/CDP neighbors for the topology map.                | On      |
+| Collect Connected Endpoints | Also walk the device's ARP and bridge-forwarding tables to discover endpoints attached to it (POS terminals, printers, phones, laptops). Costs extra SNMP walks per poll. | Off     |
+| Health OIDs                 | SNMP OIDs (CPU, memory, temperature, or any custom OID) collected on each poll and recorded as device metrics.                                                            | None    |
 
 ### Interface Walking
 
@@ -115,11 +115,11 @@ Instead of registering devices one at a time, you can sweep a range of addresses
 2. Click **Create Discovery Scan**
 3. Configure the scan:
 
-| Field         | Description                                              | Required |
-| ------------- | -------------------------------------------------------- | -------- |
-| Scan Target   | The address space to scan, in [CIDR or octet-range notation](#scan-target-notation) | Yes      |
-| Probe         | Which probe should run the sweep                         | Yes      |
-| SNMP credentials | Same fields as device registration (v1/v2c community string, or the full v3 credential set) — tried against every host in the range | Yes |
+| Field            | Description                                                                                                                         | Required |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| Scan Target      | The address space to scan, in [CIDR or octet-range notation](#scan-target-notation)                                                 | Yes      |
+| Probe            | Which probe should run the sweep                                                                                                    | Yes      |
+| SNMP credentials | Same fields as device registration (v1/v2c community string, or the full v3 credential set) — tried against every host in the range | Yes      |
 
 4. The scan runs from the selected probe and reports how many hosts were scanned and how many responded to SNMP
 5. Click **Review Results** on a completed scan, select the devices you want, and click **Import Selected**
@@ -181,16 +181,16 @@ You can set up criteria to check poll results and trigger alerts or incidents.
 
 ### Available Check Types
 
-| Check Type                          | Description                                                       |
-| ----------------------------------- | ----------------------------------------------------------------- |
-| SNMP Device Is Online               | Check if the device responds to SNMP queries                      |
-| SNMP Response Time (in ms)          | Check the query response time in milliseconds                     |
-| SNMP OID Value                      | Check the value returned by a specific OID                        |
-| SNMP OID Exists                     | Check if an OID returns a value (not null)                        |
-| SNMP Interface Is Down              | True when any administratively-enabled interface is operationally down |
-| SNMP Interface Utilization (in %)   | Check the busiest interface's link utilization                    |
-| SNMP Interface Errors (per second)  | Check the worst interface's error rate                            |
-| SNMP Trap Received (Trap OID)       | Matches when a trap with the given OID arrives from the device    |
+| Check Type                         | Description                                                            |
+| ---------------------------------- | ---------------------------------------------------------------------- |
+| SNMP Device Is Online              | Check if the device responds to SNMP queries                           |
+| SNMP Response Time (in ms)         | Check the query response time in milliseconds                          |
+| SNMP OID Value                     | Check the value returned by a specific OID                             |
+| SNMP OID Exists                    | Check if an OID returns a value (not null)                             |
+| SNMP Interface Is Down             | True when any administratively-enabled interface is operationally down |
+| SNMP Interface Utilization (in %)  | Check the busiest interface's link utilization                         |
+| SNMP Interface Errors (per second) | Check the worst interface's error rate                                 |
+| SNMP Trap Received (Trap OID)      | Matches when a trap with the given OID arrives from the device         |
 
 The interface checks require **Walk Interfaces** to be on in the device's polling settings (it is by default). The OID checks evaluate the device's configured **Health OIDs**. Administratively disabled interfaces are intentionally down and never count as failures.
 
@@ -198,12 +198,12 @@ The interface checks require **Walk Interfaces** to be on in the device's pollin
 
 Click **Add Recommended Alerts** on the criteria form to append a prebuilt set of criteria — the alerts most network operators want, without hand-building them each time (these are pre-filled automatically when you create the monitor from the device's page):
 
-| Criteria             | Fires when                                                        | Creates  |
-| -------------------- | ----------------------------------------------------------------- | -------- |
-| Device unreachable   | The device stops answering SNMP                                   | Incident |
-| Interface down       | An administratively-enabled interface goes operationally down     | Incident |
-| Interface saturated  | An interface runs above 80% utilization                           | Alert    |
-| Interface errors     | An interface logs more than 1 error per second                    | Alert    |
+| Criteria            | Fires when                                                    | Creates  |
+| ------------------- | ------------------------------------------------------------- | -------- |
+| Device unreachable  | The device stops answering SNMP                               | Incident |
+| Interface down      | An administratively-enabled interface goes operationally down | Incident |
+| Interface saturated | An interface runs above 80% utilization                       | Alert    |
+| Interface errors    | An interface logs more than 1 error per second                | Alert    |
 
 After applying the pack, pick severities and on-call policies for each criteria as usual — the thresholds are editable like any hand-built criteria.
 
@@ -215,11 +215,11 @@ Polling catches problems on the next poll; traps catch them in seconds. Every pr
 
 The receiver is on by default and listens on UDP port 162. Configure it on the probe with environment variables:
 
-| Environment Variable                    | Description                                          | Default |
-| --------------------------------------- | ---------------------------------------------------- | ------- |
-| PROBE_SNMP_TRAP_RECEIVER_ENABLED        | Set to `false` to turn the trap receiver off         | true    |
-| PROBE_SNMP_TRAP_RECEIVER_PORT           | UDP port the receiver binds                          | 162     |
-| PROBE_SNMP_TRAP_RATE_LIMIT_PER_MINUTE   | Max traps forwarded per minute before dropping       | 300     |
+| Environment Variable                  | Description                                    | Default |
+| ------------------------------------- | ---------------------------------------------- | ------- |
+| PROBE_SNMP_TRAP_RECEIVER_ENABLED      | Set to `false` to turn the trap receiver off   | true    |
+| PROBE_SNMP_TRAP_RECEIVER_PORT         | UDP port the receiver binds                    | 162     |
+| PROBE_SNMP_TRAP_RATE_LIMIT_PER_MINUTE | Max traps forwarded per minute before dropping | 300     |
 
 If the probe runs in Docker, publish the UDP port so traps can reach it:
 
@@ -257,25 +257,25 @@ The filter also supports Contains / Starts With / Ends With, so a single criteri
 
 When creating incident or alert templates, you can use the following variables:
 
-| Variable                   | Description                                                             |
-| -------------------------- | ----------------------------------------------------------------------- |
-| `{{isOnline}}`             | Whether the device is online (true/false)                               |
-| `{{responseTimeInMs}}`     | Query response time in milliseconds                                     |
-| `{{failureCause}}`         | Error message if the query failed                                       |
-| `{{oidResponses}}`         | Array of OID response objects                                           |
-| `{{OID_NAME}}`             | Value of a specific OID by name (e.g., `{{sysUpTime}}`)                 |
-| `{{sysName}}`              | Device name from the SNMP system group                                  |
-| `{{sysDescr}}`             | Device description from the SNMP system group                           |
-| `{{sysObjectId}}`          | Vendor's registered enterprise OID (device fingerprint)                 |
-| `{{sysLocation}}`          | Device location from the SNMP system group                              |
+| Variable                   | Description                                                                  |
+| -------------------------- | ---------------------------------------------------------------------------- |
+| `{{isOnline}}`             | Whether the device is online (true/false)                                    |
+| `{{responseTimeInMs}}`     | Query response time in milliseconds                                          |
+| `{{failureCause}}`         | Error message if the query failed                                            |
+| `{{oidResponses}}`         | Array of OID response objects                                                |
+| `{{OID_NAME}}`             | Value of a specific OID by name (e.g., `{{sysUpTime}}`)                      |
+| `{{sysName}}`              | Device name from the SNMP system group                                       |
+| `{{sysDescr}}`             | Device description from the SNMP system group                                |
+| `{{sysObjectId}}`          | Vendor's registered enterprise OID (device fingerprint)                      |
+| `{{sysLocation}}`          | Device location from the SNMP system group                                   |
 | `{{downInterfaces}}`       | Array of {name, alias, interfaceIndex} for admin-up but oper-down interfaces |
-| `{{interfacesTotal}}`      | Total number of interfaces walked                                       |
-| `{{interfacesUp}}`         | Interfaces that are administratively and operationally up               |
-| `{{interfacesDown}}`       | Interfaces that are administratively up but operationally down          |
-| `{{interfaceWalkFailure}}` | Error message when the interface walk failed                            |
-| `{{trapOid}}`              | Trap OID — set on trap-triggered checks only                            |
-| `{{trapSourceIp}}`         | Source IP the trap came from — set on trap-triggered checks only        |
-| `{{trapVarbinds}}`         | Array of {oid, value} varbinds carried by the trap                      |
+| `{{interfacesTotal}}`      | Total number of interfaces walked                                            |
+| `{{interfacesUp}}`         | Interfaces that are administratively and operationally up                    |
+| `{{interfacesDown}}`       | Interfaces that are administratively up but operationally down               |
+| `{{interfaceWalkFailure}}` | Error message when the interface walk failed                                 |
+| `{{trapOid}}`              | Trap OID — set on trap-triggered checks only                                 |
+| `{{trapSourceIp}}`         | Source IP the trap came from — set on trap-triggered checks only             |
+| `{{trapVarbinds}}`         | Array of {oid, value} varbinds carried by the trap                           |
 
 The interface and system variables require interface walking to be enabled on the device; the trap variables are only set when the check was triggered by a trap. So an incident title like:
 

--- a/App/FeatureSet/Docs/Content/en/monitor/network-device-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/network-device-monitor.md
@@ -179,9 +179,9 @@ Network Device monitors have no polling interval of their own: they are evaluate
 
 You can set up criteria to check poll results and trigger alerts or incidents.
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type                         | Description                                                            |
+| Filter Type                        | Description                                                            |
 | ---------------------------------- | ---------------------------------------------------------------------- |
 | SNMP Device Is Online              | Check if the device responds to SNMP queries                           |
 | SNMP Response Time (in ms)         | Check the query response time in milliseconds                          |
@@ -247,8 +247,8 @@ For matching to work, register the device with the IP address it sends traps fro
 
 #### Example: raise an incident on linkDown
 
-- **Check On**: SNMP Trap Received (Trap OID)
-- **Filter Type**: Equal To
+- **Filter Type**: SNMP Trap Received (Trap OID)
+- **Filter Condition**: Equal To
 - **Value**: 1.3.6.1.6.3.1.1.5.3
 
 The filter also supports Contains / Starts With / Ends With, so a single criteria can match a family of enterprise traps by OID prefix.

--- a/App/FeatureSet/Docs/Content/en/monitor/ping-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/ping-monitor.md
@@ -29,15 +29,15 @@ Enter the hostname or IP address of the target you want to monitor (e.g., `examp
 
 You can configure criteria to determine when your host is considered online, degraded, or offline based on:
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type            | Description                                         |
+| Filter Type           | Description                                         |
 | --------------------- | --------------------------------------------------- |
 | Is Online             | Whether the host responds to ping requests          |
 | Response Time (in ms) | Round-trip time of the ping request in milliseconds |
 | Is Request Timeout    | Whether the ping request timed out                  |
 
-### Filter Types
+### Filter Conditions
 
 For **Is Online** and **Is Request Timeout**:
 
@@ -58,11 +58,11 @@ For **Response Time**:
 
 #### Mark as offline if host is unreachable
 
-- **Check On**: Is Online
-- **Filter Type**: False
+- **Filter Type**: Is Online
+- **Filter Condition**: False
 
 #### Alert if response time exceeds 200ms
 
-- **Check On**: Response Time (in ms)
-- **Filter Type**: Greater Than
+- **Filter Type**: Response Time (in ms)
+- **Filter Condition**: Greater Than
 - **Value**: 200

--- a/App/FeatureSet/Docs/Content/en/monitor/podman-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/podman-monitor.md
@@ -103,11 +103,9 @@ The Podman Agent uses the OpenTelemetry `docker_stats` receiver pointed at Podma
 
 ## Monitoring Criteria
 
-### Available Check Types
+### What Gets Evaluated
 
-| Check Type   | Description                                         |
-| ------------ | --------------------------------------------------- |
-| Metric Value | The value of the configured metric query or formula |
+These monitors always evaluate the **Metric Value** — the value of the configured metric query or formula. The criteria form has no Filter Type selector; it shows **Metric**, **Aggregation**, **Condition**, and **Threshold**.
 
 ### Aggregation Types
 
@@ -120,7 +118,7 @@ The Podman Agent uses the OpenTelemetry `docker_stats` receiver pointed at Podma
 | All Values    | All values must match the criteria |
 | Any Value     | At least one value must match      |
 
-### Filter Types
+### Conditions
 
 - **Greater Than**, **Less Than**, **Greater Than or Equal To**, **Less Than or Equal To**, **Equal To**, **Not Equal To**
 

--- a/App/FeatureSet/Docs/Content/en/monitor/port-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/port-monitor.md
@@ -55,9 +55,9 @@ When the target is an IP address, no DNS lookup is required, so the DNS phase is
 
 You can configure criteria to determine when your port is considered online, degraded, or offline based on:
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type                                | Description                                                                         |
+| Filter Type                               | Description                                                                         |
 | ----------------------------------------- | ----------------------------------------------------------------------------------- |
 | Is Online                                 | Whether the port is open and accepting connections                                  |
 | Total Connection Time (DNS + TCP) (in ms) | Total connection time, including DNS lookup when the target is a hostname           |
@@ -65,7 +65,7 @@ You can configure criteria to determine when your port is considered online, deg
 | Port TCP Connect Time (in ms)             | Time from the first TCP attempt until a connection succeeds, including IP fallback  |
 | Is Request Timeout                        | Whether the DNS lookup or TCP connection attempt exceeded the configured time limit |
 
-### Filter Types
+### Filter Conditions
 
 For **Is Online** and **Is Request Timeout**:
 
@@ -86,29 +86,29 @@ DNS lookup criteria have no value to evaluate when the target is already an IP a
 
 #### Mark as offline if port is closed
 
-- **Check On**: Is Online
-- **Filter Type**: False
+- **Filter Type**: Is Online
+- **Filter Condition**: False
 
 #### Alert if total connection time exceeds 500ms
 
-- **Check On**: Total Connection Time (DNS + TCP) (in ms)
-- **Filter Type**: Greater Than
+- **Filter Type**: Total Connection Time (DNS + TCP) (in ms)
+- **Filter Condition**: Greater Than
 - **Value**: 500
 
 #### Mark as degraded if the total connection is slow
 
-- **Check On**: Total Connection Time (DNS + TCP) (in ms)
-- **Filter Type**: Greater Than
+- **Filter Type**: Total Connection Time (DNS + TCP) (in ms)
+- **Filter Condition**: Greater Than
 - **Value**: 200
 
 #### Alert if DNS lookup is slow
 
-- **Check On**: Port DNS Lookup Time (in ms)
-- **Filter Type**: Greater Than
+- **Filter Type**: Port DNS Lookup Time (in ms)
+- **Filter Condition**: Greater Than
 - **Value**: 100
 
 #### Alert if TCP connection setup is slow
 
-- **Check On**: Port TCP Connect Time (in ms)
-- **Filter Type**: Greater Than
+- **Filter Type**: Port TCP Connect Time (in ms)
+- **Filter Condition**: Greater Than
 - **Value**: 250

--- a/App/FeatureSet/Docs/Content/en/monitor/port-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/port-monitor.md
@@ -57,13 +57,13 @@ You can configure criteria to determine when your port is considered online, deg
 
 ### Available Check Types
 
-| Check Type                    | Description                                                                         |
-| ----------------------------- | ----------------------------------------------------------------------------------- |
-| Is Online                     | Whether the port is open and accepting connections                                  |
-| Total Connection Time (DNS + TCP) (in ms) | Total connection time, including DNS lookup when the target is a hostname |
-| Port DNS Lookup Time (in ms)  | DNS lookup time before the first TCP attempt; unavailable when the target is an IP  |
-| Port TCP Connect Time (in ms) | Time from the first TCP attempt until a connection succeeds, including IP fallback  |
-| Is Request Timeout            | Whether the DNS lookup or TCP connection attempt exceeded the configured time limit |
+| Check Type                                | Description                                                                         |
+| ----------------------------------------- | ----------------------------------------------------------------------------------- |
+| Is Online                                 | Whether the port is open and accepting connections                                  |
+| Total Connection Time (DNS + TCP) (in ms) | Total connection time, including DNS lookup when the target is a hostname           |
+| Port DNS Lookup Time (in ms)              | DNS lookup time before the first TCP attempt; unavailable when the target is an IP  |
+| Port TCP Connect Time (in ms)             | Time from the first TCP attempt until a connection succeeds, including IP fallback  |
+| Is Request Timeout                        | Whether the DNS lookup or TCP connection attempt exceeded the configured time limit |
 
 ### Filter Types
 

--- a/App/FeatureSet/Docs/Content/en/monitor/profiles-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/profiles-monitor.md
@@ -36,13 +36,13 @@ Select one or more services to monitor profiles from. Services must be sending c
 
 ## Monitoring Criteria
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type    | Description                                                     |
+| Filter Type   | Description                                                     |
 | ------------- | --------------------------------------------------------------- |
 | Profile Count | The number of profiles matching your filters in the time window |
 
-### Filter Types
+### Filter Conditions
 
 - **Greater Than** — Profile count exceeds a threshold
 - **Less Than** — Profile count is below a threshold
@@ -56,8 +56,8 @@ Select one or more services to monitor profiles from. Services must be sending c
 #### Alert if no profiles received in 5 minutes
 
 - **Time Window**: 300 seconds
-- **Check On**: Profile Count
-- **Filter Type**: Equal To
+- **Filter Type**: Profile Count
+- **Filter Condition**: Equal To
 - **Value**: 0
 
 ## Setup Requirements

--- a/App/FeatureSet/Docs/Content/en/monitor/proxmox-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/proxmox-monitor.md
@@ -147,11 +147,9 @@ From the exporter's node-level `replication` collector (enabled by default). Ser
 
 ## Monitoring Criteria
 
-### Available Check Types
+### What Gets Evaluated
 
-| Check Type   | Description                                         |
-| ------------ | --------------------------------------------------- |
-| Metric Value | The value of the configured metric query or formula |
+These monitors always evaluate the **Metric Value** — the value of the configured metric query or formula. The criteria form has no Filter Type selector; it shows **Metric**, **Aggregation**, **Condition**, and **Threshold**.
 
 ### Aggregation Types
 
@@ -164,7 +162,7 @@ From the exporter's node-level `replication` collector (enabled by default). Ser
 | All Values    | All values must match the criteria |
 | Any Value     | At least one value must match      |
 
-### Filter Types
+### Conditions
 
 - **Greater Than**, **Less Than**, **Greater Than or Equal To**, **Less Than or Equal To**, **Equal To**, **Not Equal To**
 

--- a/App/FeatureSet/Docs/Content/en/monitor/server-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/server-monitor.md
@@ -113,9 +113,9 @@ For each mounted disk/volume:
 
 You can configure criteria to determine when your server is considered online, degraded, or offline.
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type             | Description                                                    |
+| Filter Type            | Description                                                    |
 | ---------------------- | -------------------------------------------------------------- |
 | Is Online              | Whether the server agent is reporting (based on heartbeat)     |
 | CPU Usage Percent      | Current CPU utilization percentage                             |
@@ -125,7 +125,7 @@ You can configure criteria to determine when your server is considered online, d
 | Server Process Command | Check if a process with a specific command is running          |
 | Server Process PID     | Check if a process with a specific PID is running              |
 
-### Filter Types
+### Filter Conditions
 
 For numeric metrics (CPU, memory, disk):
 
@@ -144,32 +144,32 @@ For process checks:
 
 #### Mark server as offline if agent stops reporting
 
-- **Check On**: Is Online
-- **Filter Type**: False
+- **Filter Type**: Is Online
+- **Filter Condition**: False
 
 #### Alert when CPU usage exceeds 90%
 
-- **Check On**: CPU Usage Percent
-- **Filter Type**: Greater Than
+- **Filter Type**: CPU Usage Percent
+- **Filter Condition**: Greater Than
 - **Value**: 90
 
 #### Alert when disk usage exceeds 85%
 
-- **Check On**: Disk Usage Percent
+- **Filter Type**: Disk Usage Percent
 - **Disk Path**: `/`
-- **Filter Type**: Greater Than
+- **Filter Condition**: Greater Than
 - **Value**: 85
 
 #### Alert when memory usage exceeds 80%
 
-- **Check On**: Memory Usage Percent
-- **Filter Type**: Greater Than
+- **Filter Type**: Memory Usage Percent
+- **Filter Condition**: Greater Than
 - **Value**: 80
 
 #### Alert if a critical process stops running
 
-- **Check On**: Server Process Name
-- **Filter Type**: Is Not Executing
+- **Filter Type**: Server Process Name
+- **Filter Condition**: Is Not Executing
 - **Value**: `nginx`
 
 ## Troubleshooting

--- a/App/FeatureSet/Docs/Content/en/monitor/ssl-certificate-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/ssl-certificate-monitor.md
@@ -30,9 +30,9 @@ Enter the full HTTPS URL of the endpoint whose SSL certificate you want to monit
 
 You can configure criteria to determine when your certificate status is considered online, degraded, or offline based on:
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type                 | Description                                                     |
+| Filter Type                | Description                                                     |
 | -------------------------- | --------------------------------------------------------------- |
 | Is Online                  | Whether the server is reachable                                 |
 | Is Valid Certificate       | Whether the certificate is valid (not expired, not self-signed) |
@@ -43,7 +43,7 @@ You can configure criteria to determine when your certificate status is consider
 | Expires In Days            | Number of days until the certificate expires                    |
 | Is Request Timeout         | Whether the connection timed out                                |
 
-### Filter Types
+### Filter Conditions
 
 For **Is Online**, **Is Valid Certificate**, **Is Self-Signed Certificate**, **Is Expired Certificate**, **Is Not A Valid Certificate**, and **Is Request Timeout**:
 
@@ -63,24 +63,24 @@ For **Expires In Hours** and **Expires In Days**:
 
 #### Mark as degraded if certificate expires within 30 days
 
-- **Check On**: Expires In Days
-- **Filter Type**: Less Than
+- **Filter Type**: Expires In Days
+- **Filter Condition**: Less Than
 - **Value**: 30
 
 #### Mark as offline if certificate is expired
 
-- **Check On**: Is Expired Certificate
-- **Filter Type**: True
+- **Filter Type**: Is Expired Certificate
+- **Filter Condition**: True
 
 #### Alert if certificate is self-signed
 
-- **Check On**: Is Self-Signed Certificate
-- **Filter Type**: True
+- **Filter Type**: Is Self-Signed Certificate
+- **Filter Condition**: True
 
 #### Mark as offline if certificate is invalid
 
-- **Check On**: Is Not A Valid Certificate
-- **Filter Type**: True
+- **Filter Type**: Is Not A Valid Certificate
+- **Filter Condition**: True
 
 ## Best Practices
 

--- a/App/FeatureSet/Docs/Content/en/monitor/traces-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/traces-monitor.md
@@ -43,13 +43,13 @@ Select one or more services to monitor traces from. Services must be sending tra
 
 ## Monitoring Criteria
 
-### Available Check Types
+### Available Filter Types
 
-| Check Type | Description                                                  |
-| ---------- | ------------------------------------------------------------ |
-| Span Count | The number of spans matching your filters in the time window |
+| Filter Type | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| Span Count  | The number of spans matching your filters in the time window |
 
-### Filter Types
+### Filter Conditions
 
 - **Greater Than** — Span count exceeds a threshold
 - **Less Than** — Span count is below a threshold
@@ -64,8 +64,8 @@ Select one or more services to monitor traces from. Services must be sending tra
 
 - **Span Statuses**: ERROR
 - **Time Window**: 60 seconds
-- **Check On**: Span Count
-- **Filter Type**: Greater Than
+- **Filter Type**: Span Count
+- **Filter Condition**: Greater Than
 - **Value**: 50
 
 #### Alert on errors in a specific endpoint
@@ -73,8 +73,8 @@ Select one or more services to monitor traces from. Services must be sending tra
 - **Span Name**: `POST /api/checkout`
 - **Span Statuses**: ERROR
 - **Time Window**: 120 seconds
-- **Check On**: Span Count
-- **Filter Type**: Greater Than
+- **Filter Type**: Span Count
+- **Filter Condition**: Greater Than
 - **Value**: 0
 
 ## Setup Requirements


### PR DESCRIPTION
## What

The English monitor docs described the criteria form using labels that appear nowhere in the product — and they were wrong in *both* directions, which is what made it confusing rather than merely stale:

| Docs said | UI actually says | Bound to |
| --- | --- | --- |
| **Check On** | **Filter Type** | `checkOn` |
| **Filter Type** | **Filter Condition** | `filterType` |

So a reader hunting for "Check On" found nothing, and a reader who *did* find "Filter Type" was reading about the wrong dropdown.

Ground truth is [`CriteriaFilter.tsx`](App/FeatureSet/Dashboard/src/Components/Form/Monitor/CriteriaFilter.tsx) — the `checkOn` dropdown is labelled "Filter Type", the `filterType` dropdown "Filter Condition", the value field "Value".

This follows the pattern set by #3229, which fixed the same problem in `incoming-request-monitor.md`, `prometheus-alertmanager.md` and `grafana.md`. With that merged and this branch, **no stale terminology remains anywhere under `Content/en/`.**

## Two things worth a reviewer's attention

**1. Metric-only monitors got different labels, deliberately.**

`isMetricOnlyMonitorType()` (Kubernetes, Docker, Host, Podman, DockerSwarm, Proxmox, Ceph, Metrics) gates the form: the `checkOn` dropdown **is not rendered at all**, and the other two fields are labelled **"Condition"** and **"Threshold"** — not "Filter Condition" and "Value".

Applying the blanket rename to those 7 docs would have swapped one wrong set of labels for another, so they get the labels the UI actually shows. Their `### Available Check Types` table — which documented a dropdown these monitors never display — became a sentence stating the metric value is always what's evaluated.

If you'd rather these 7 files just took the blanket rename, say so and I'll redo them.

**2. `incoming-email-monitor.md` was not on the original list but had the same bug.**

It expressed the inversion in different words: `## Available Criteria Fields` headed the `checkOn` list, and `## Available Filter Types` headed the *condition* list — so its one use of "Filter Type" pointed at the wrong dropdown. Now consistent with the others.

`docker-swarm-monitor.md` is metric-only too, but describes criteria without naming any field, so it needed no change.

## Commits

Split so the rename reads as a pure rename:

1. **`chore(docs): prettier-format three monitor docs`** — `domain`, `network-device` and `port` had misaligned tables that already failed `prettier --check` on master. Formatting them separately keeps 186 lines of whitespace churn out of the rename diff (`network-device` alone would have been 132 of its 138 lines).
2. **`docs: name the monitor criteria fields…`** — the rename, 21 files.

## Verification

- `npm run docs:check-anchors` — passes. Section headings moved, but no in-page or cross-page link targeted the renamed headings.
- `npx prettier --check` — passes on all 21 edited files. (41 other files under `Content/en/` are prettier-dirty on master, e.g. `terraform/`; left alone as out of scope.)
- Grep sweep for `**Check On**`, `### Available Check Types`, `### Filter Types`, `| Check Type`, `## Available Criteria Fields` across `Content/en/` returns nothing.

English only — other locales follow the translation pipeline (81b822a4b8).

## Follow-up, not fixed here

An adversarial pass over these sections turned up ~30 *pre-existing* accuracy bugs of a different kind: the option lists themselves don't match what the dropdowns offer. Examples:

- `dnssec-monitor.md` lists **DNSSEC Is Valid**, which `getCheckOnOptionsByMonitorType` never offers for `MonitorType.DNSSEC` (it's a DNS-monitor option, and `DnssecMonitorCriteria.ts` has no branch for it).
- Six docs list **Equal To** / **Not Equal To** for numeric check types whose dropdown offers only the four comparison operators.
- Four docs list **Evaluate Over Time** as if it were a filter condition; it's a separate toggle, not a member of the `FilterType` enum.
- All 7 metric-only docs list **Not Equal To** (never offered) and omit **Anomalously High**, **Anomalously Low** and **Anomalous** (which are).
- `ping`/`ip` tables list 3 of 5 available filter types; `ssl-certificate` lists 8 where the UI offers 6.

These are about *which options exist* rather than *what the fields are called*, so I kept them out of this PR. Happy to take them in a follow-up.
