### PR TITLE
fix(probe): make SSL Certificate monitors report why a certificate is bad

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SSLCertificateMonitorView.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Monitor/SummaryView/SSLCertificateMonitorView.tsx
@@ -13,6 +13,31 @@ export interface ComponentProps {
   probeName?: string | undefined;
 }
 
+/*
+ * Describes the certificate in one line: whether it is trustworthy, and if
+ * not, why. isValidCertificate is absent on responses written by an older
+ * probe, in which case fall back to what could be inferred before.
+ */
+export function sslStatusLabel(sslResponse: SslMonitorResponse): string {
+  const isValid: boolean | undefined = sslResponse.isValidCertificate;
+
+  if (isValid === true) {
+    return "Valid";
+  }
+
+  if (isValid === false) {
+    if (sslResponse.isSelfSigned) {
+      return "Not Valid - Self Signed";
+    }
+
+    return sslResponse.certificateValidationErrorCode
+      ? `Not Valid - ${sslResponse.certificateValidationErrorCode}`
+      : "Not Valid";
+  }
+
+  return sslResponse.isSelfSigned ? "Self Signed" : "Signed by a CA";
+}
+
 const SSLCertificateMonitorView: FunctionComponent<ComponentProps> = (
   props: ComponentProps,
 ): ReactElement => {
@@ -51,10 +76,16 @@ const SSLCertificateMonitorView: FunctionComponent<ComponentProps> = (
             title="Probe"
             value={props.probeName || "-"}
           />
+          {/*
+           * Reports the VALIDATION verdict, not just how the certificate was
+           * signed. "Signed by a CA" was shown for any certificate that was
+           * not self-signed, so an expired or wrong-hostname certificate read
+           * as reassuring - see issue #3225.
+           */}
           <InfoCard
             className="w-1/4 shadow-none border-2 border-gray-100 "
             title="SSL Status"
-            value={sslResponse.isSelfSigned ? "Self Signed" : "Signed by a CA"}
+            value={sslStatusLabel(sslResponse)}
           />
 
           <InfoCard
@@ -82,6 +113,23 @@ const SSLCertificateMonitorView: FunctionComponent<ComponentProps> = (
           />
         </div>
 
+        {/*
+         * The reason a certificate failed validation is the single most
+         * useful thing on this page when something is wrong, so it is shown
+         * without needing to expand details.
+         */}
+        {sslResponse.certificateValidationError ? (
+          <div className="flex space-x-3 w-full">
+            <InfoCard
+              className="w-full shadow-none border-2 border-gray-100 "
+              title="Certificate Problem"
+              value={sslResponse.certificateValidationError}
+            />
+          </div>
+        ) : (
+          <></>
+        )}
+
         {showMoreDetails && hadRetries && (
           <ProbeAttemptsView
             attempts={probeAttempts}
@@ -108,6 +156,15 @@ const SSLCertificateMonitorView: FunctionComponent<ComponentProps> = (
                 className="w-1/3 shadow-none border-2 border-gray-100 "
                 title="Organization"
                 value={sslResponse.organization || "-"}
+              />
+            </div>
+            <div className="flex space-x-3 w-full">
+              {/* Without this the product could not name the signing CA. */}
+              <InfoCard
+                className="w-full shadow-none border-2 border-gray-100 "
+                title="Issuer"
+                value={sslResponse.issuer || "-"}
+                textClassName="text-xs truncate"
               />
             </div>
             <div className="flex space-x-3 w-full">

--- a/Common/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.ts
@@ -78,16 +78,8 @@ export default class ServerMonitorCriteria {
     }
 
     if (input.criteriaFilter.checkOn === CheckOn.IsValidCertificate) {
-      const isValidCertificate: boolean = Boolean(
-        sslResponse &&
-          dataToProcess.isOnline &&
-          sslResponse.expiresAt &&
-          !sslResponse.isSelfSigned &&
-          OneUptimeDate.isAfter(
-            sslResponse.expiresAt,
-            OneUptimeDate.getCurrentDate(),
-          ),
-      );
+      const isValidCertificate: boolean =
+        ServerMonitorCriteria.isValidCertificate(dataToProcess);
 
       const isTrue: boolean =
         input.criteriaFilter.filterType === FilterType.True;
@@ -100,7 +92,7 @@ export default class ServerMonitorCriteria {
       }
 
       if (!isValidCertificate && isFalse) {
-        return "SSL certificate is not valid.";
+        return ServerMonitorCriteria.invalidCertificateReason(dataToProcess);
       }
     }
 
@@ -149,18 +141,19 @@ export default class ServerMonitorCriteria {
     }
 
     if (input.criteriaFilter.checkOn === CheckOn.IsNotAValidCertificate) {
+      /*
+       * The exact complement of IsValidCertificate, by construction.
+       *
+       * These two used to be computed independently, and both came out
+       * false whenever expiresAt was missing or unparseable - so a
+       * certificate the probe could not fully read satisfied NEITHER
+       * "valid" nor "not valid", every criterion went unmatched, and the
+       * monitor silently stayed at its default status. Deriving one from
+       * the other makes that state unreachable.
+       */
       const isNotValid: boolean =
-        !sslResponse ||
-        !dataToProcess.isOnline ||
-        Boolean(
-          sslResponse &&
-            sslResponse.expiresAt &&
-            (sslResponse.isSelfSigned ||
-              OneUptimeDate.isBefore(
-                sslResponse.expiresAt,
-                OneUptimeDate.getCurrentDate(),
-              )),
-        );
+        !ServerMonitorCriteria.isValidCertificate(dataToProcess);
+
       const isTrue: boolean =
         input.criteriaFilter.filterType === FilterType.True;
 
@@ -168,7 +161,7 @@ export default class ServerMonitorCriteria {
         input.criteriaFilter.filterType === FilterType.False;
 
       if (isNotValid && isTrue) {
-        return "SSL certificate is not valid.";
+        return ServerMonitorCriteria.invalidCertificateReason(dataToProcess);
       }
 
       if (!isNotValid && isFalse) {
@@ -229,5 +222,83 @@ export default class ServerMonitorCriteria {
     }
 
     return null;
+  }
+
+  /*
+   * The single source of truth for "is this certificate trustworthy",
+   * shared by IsValidCertificate and IsNotAValidCertificate so the two can
+   * never both be false for the same response.
+   *
+   * The probe now records the strict-TLS verdict explicitly on
+   * sslResponse.isValidCertificate. Responses written before that field
+   * existed (rows already in MonitorProbe.lastMonitoringLog, and any probe
+   * still running an older build) do not carry it, so the pre-existing
+   * heuristic is kept as the fallback rather than treating those as
+   * invalid and flipping healthy monitors to Down on upgrade.
+   */
+  private static isValidCertificate(
+    dataToProcess: ProbeMonitorResponse,
+  ): boolean {
+    const sslResponse: SslMonitorResponse | undefined =
+      dataToProcess.sslResponse;
+
+    if (!sslResponse || !dataToProcess.isOnline) {
+      return false;
+    }
+
+    if (sslResponse.isValidCertificate !== undefined) {
+      return Boolean(sslResponse.isValidCertificate);
+    }
+
+    // Legacy payload: fall back to what could be inferred before.
+    return Boolean(
+      sslResponse.expiresAt &&
+        !sslResponse.isSelfSigned &&
+        OneUptimeDate.isAfter(
+          sslResponse.expiresAt,
+          OneUptimeDate.getCurrentDate(),
+        ),
+    );
+  }
+
+  /*
+   * Names WHY the certificate is not trustworthy. The root cause is what
+   * reaches the incident and the person paged by it, so "SSL certificate is
+   * not valid" on its own is not good enough when the probe knows it was a
+   * hostname mismatch.
+   */
+  private static invalidCertificateReason(
+    dataToProcess: ProbeMonitorResponse,
+  ): string {
+    const sslResponse: SslMonitorResponse | undefined =
+      dataToProcess.sslResponse;
+
+    if (!dataToProcess.isOnline) {
+      return "SSL certificate could not be checked because the endpoint is not reachable.";
+    }
+
+    if (!sslResponse) {
+      return "SSL certificate is not valid.";
+    }
+
+    if (sslResponse.certificateValidationError) {
+      return `SSL certificate is not valid: ${sslResponse.certificateValidationError}`;
+    }
+
+    if (sslResponse.isSelfSigned) {
+      return "SSL certificate is not valid: the certificate is self signed.";
+    }
+
+    if (
+      sslResponse.expiresAt &&
+      OneUptimeDate.isBefore(
+        sslResponse.expiresAt,
+        OneUptimeDate.getCurrentDate(),
+      )
+    ) {
+      return "SSL certificate is not valid: the certificate has expired.";
+    }
+
+    return "SSL certificate is not valid.";
   }
 }

--- a/Common/Tests/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.test.ts
@@ -158,7 +158,9 @@ describe("SSLMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
         },
       );
 
-      expect(result).toBe("SSL certificate is not valid.");
+      // The reason is appended so the root cause reaches whoever is paged.
+      expect(result).toContain("SSL certificate is not valid");
+      expect(result).toContain("self signed");
     });
 
     test("valid cert + False → not met", async () => {
@@ -196,7 +198,7 @@ describe("SSLMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
         },
       );
 
-      expect(result).toBe("SSL certificate is not valid.");
+      expect(result).toContain("not reachable");
     });
   });
 
@@ -311,7 +313,8 @@ describe("SSLMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
         },
       );
 
-      expect(result).toBe("SSL certificate is not valid.");
+      expect(result).toContain("SSL certificate is not valid");
+      expect(result).toContain("expired");
     });
 
     test("healthy cert + False → met", async () => {
@@ -343,7 +346,7 @@ describe("SSLMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
         },
       );
 
-      expect(result).toBe("SSL certificate is not valid.");
+      expect(result).toContain("SSL certificate is not valid");
     });
   });
 
@@ -464,5 +467,372 @@ describe("SSLMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
     );
 
     expect(result).toBeNull();
+  });
+
+  /*
+   * Regression suite for https://github.com/OneUptime/oneuptime/issues/3225.
+   *
+   * The reported monitor pointed at a host with an invalid certificate and
+   * sat Operational forever. Two things made that possible:
+   *
+   *  1. IsValidCertificate and IsNotAValidCertificate were computed
+   *     independently, so BOTH came out false whenever expiresAt was
+   *     missing or unparseable. No criterion matched, and a monitor already
+   *     at its default status writes no timeline entry when nothing
+   *     matches - so the check left no trace at all.
+   *
+   *  2. The verdict was inferred from !isSelfSigned, and the probe labelled
+   *     every validation failure "self signed". A certificate that failed
+   *     for any other reason could not be described.
+   */
+  describe("certificate validity (issue #3225)", () => {
+    const failureModes: Array<{ name: string; response: SslMonitorResponse }> =
+      [
+        {
+          name: "self-signed",
+          response: {
+            isValidCertificate: false,
+            isSelfSigned: true,
+            certificateValidationErrorCode: "DEPTH_ZERO_SELF_SIGNED_CERT",
+            certificateValidationError: "self signed certificate",
+            expiresAt: dateFromNow({ days: 100 }),
+          },
+        },
+        {
+          name: "hostname mismatch",
+          response: {
+            isValidCertificate: false,
+            isSelfSigned: false,
+            certificateValidationErrorCode: "ERR_TLS_CERT_ALTNAME_INVALID",
+            certificateValidationError: "Hostname/IP does not match",
+            expiresAt: dateFromNow({ days: 100 }),
+          },
+        },
+        {
+          name: "untrusted CA",
+          response: {
+            isValidCertificate: false,
+            isSelfSigned: false,
+            certificateValidationErrorCode: "SELF_SIGNED_CERT_IN_CHAIN",
+            certificateValidationError: "self signed certificate in chain",
+            expiresAt: dateFromNow({ days: 100 }),
+          },
+        },
+        {
+          name: "expired",
+          response: {
+            isValidCertificate: false,
+            isSelfSigned: false,
+            certificateValidationErrorCode: "CERT_HAS_EXPIRED",
+            certificateValidationError: "certificate has expired",
+            expiresAt: dateFromNow({ days: -5 }),
+          },
+        },
+        {
+          name: "incomplete chain",
+          response: {
+            isValidCertificate: false,
+            isSelfSigned: false,
+            certificateValidationErrorCode: "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+            certificateValidationError:
+              "unable to verify the first certificate",
+            expiresAt: dateFromNow({ days: 100 }),
+          },
+        },
+      ];
+
+    test.each(failureModes)(
+      "$name: IsNotAValidCertificate + True → met",
+      async ({ response }: { response: SslMonitorResponse }) => {
+        const result: string | null = await evaluate(
+          buildDataToProcess({ isOnline: true, sslResponse: response }),
+          {
+            checkOn: CheckOn.IsNotAValidCertificate,
+            filterType: FilterType.True,
+            value: undefined,
+          },
+        );
+
+        expect(result).toBeTruthy();
+      },
+    );
+
+    test.each(failureModes)(
+      "$name: IsValidCertificate + True → not met",
+      async ({ response }: { response: SslMonitorResponse }) => {
+        const result: string | null = await evaluate(
+          buildDataToProcess({ isOnline: true, sslResponse: response }),
+          {
+            checkOn: CheckOn.IsValidCertificate,
+            filterType: FilterType.True,
+            value: undefined,
+          },
+        );
+
+        expect(result).toBeNull();
+      },
+    );
+
+    test.each(failureModes)(
+      "$name: IsValidCertificate + False → met",
+      async ({ response }: { response: SslMonitorResponse }) => {
+        const result: string | null = await evaluate(
+          buildDataToProcess({ isOnline: true, sslResponse: response }),
+          {
+            checkOn: CheckOn.IsValidCertificate,
+            filterType: FilterType.False,
+            value: undefined,
+          },
+        );
+
+        expect(result).toBeTruthy();
+      },
+    );
+
+    test("the two predicates are exact complements, even with no expiry", async () => {
+      /*
+       * The silent-healthy case: a certificate the probe could not fully
+       * read. Before the fix BOTH of these returned null and the monitor
+       * recorded nothing.
+       */
+      const response: SslMonitorResponse = {
+        isValidCertificate: false,
+        isSelfSigned: false,
+        certificateValidationErrorCode: "UNABLE_TO_GET_ISSUER_CERT",
+        certificateValidationError: "unable to get issuer certificate",
+        // deliberately no expiresAt
+      };
+
+      const isValid: string | null = await evaluate(
+        buildDataToProcess({ isOnline: true, sslResponse: response }),
+        {
+          checkOn: CheckOn.IsValidCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      const isNotValid: string | null = await evaluate(
+        buildDataToProcess({ isOnline: true, sslResponse: response }),
+        {
+          checkOn: CheckOn.IsNotAValidCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(isValid).toBeNull();
+      expect(isNotValid).toBeTruthy();
+    });
+
+    test("a valid certificate satisfies IsValidCertificate and not its negation", async () => {
+      const response: SslMonitorResponse = {
+        isValidCertificate: true,
+        isSelfSigned: false,
+        certificateValidationErrorCode: "",
+        certificateValidationError: "",
+        expiresAt: dateFromNow({ days: 90 }),
+      };
+
+      const isValid: string | null = await evaluate(
+        buildDataToProcess({ isOnline: true, sslResponse: response }),
+        {
+          checkOn: CheckOn.IsValidCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      const isNotValid: string | null = await evaluate(
+        buildDataToProcess({ isOnline: true, sslResponse: response }),
+        {
+          checkOn: CheckOn.IsNotAValidCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(isValid).toBeTruthy();
+      expect(isNotValid).toBeNull();
+    });
+
+    test("the reason names the underlying validation error", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          isOnline: true,
+          sslResponse: {
+            isValidCertificate: false,
+            isSelfSigned: false,
+            certificateValidationErrorCode: "ERR_TLS_CERT_ALTNAME_INVALID",
+            certificateValidationError: "Hostname/IP does not match",
+            expiresAt: dateFromNow({ days: 100 }),
+          },
+        }),
+        {
+          checkOn: CheckOn.IsNotAValidCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      // The root cause has to reach whoever gets paged.
+      expect(result).toContain("Hostname/IP does not match");
+    });
+
+    test("an unreachable endpoint is not a valid certificate", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          isOnline: false,
+          sslResponse: { isValidCertificate: false },
+        }),
+        {
+          checkOn: CheckOn.IsNotAValidCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    test("only genuine self-signed responses satisfy IsSelfSignedCertificate", async () => {
+      const mismatch: string | null = await evaluate(
+        buildDataToProcess({
+          isOnline: true,
+          sslResponse: {
+            isValidCertificate: false,
+            isSelfSigned: false,
+            certificateValidationErrorCode: "ERR_TLS_CERT_ALTNAME_INVALID",
+            expiresAt: dateFromNow({ days: 100 }),
+          },
+        }),
+        {
+          checkOn: CheckOn.IsSelfSignedCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      /*
+       * Pre-fix the probe set isSelfSigned=true for a hostname mismatch, so
+       * this criterion fired on a certificate that was not self-signed at
+       * all.
+       */
+      expect(mismatch).toBeNull();
+    });
+  });
+
+  /*
+   * Payloads written by a probe running an older build carry no
+   * isValidCertificate field. They must keep evaluating exactly as before,
+   * or upgrading the server would flip healthy monitors to Down.
+   */
+  describe("legacy payloads without an explicit verdict", () => {
+    test("a healthy legacy response is still valid", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          isOnline: true,
+          sslResponse: {
+            isSelfSigned: false,
+            expiresAt: dateFromNow({ days: 60 }),
+          },
+        }),
+        {
+          checkOn: CheckOn.IsValidCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    test("a legacy self-signed response is still not valid", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          isOnline: true,
+          sslResponse: {
+            isSelfSigned: true,
+            expiresAt: dateFromNow({ days: 60 }),
+          },
+        }),
+        {
+          checkOn: CheckOn.IsNotAValidCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    test("a legacy expired response is still not valid", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          isOnline: true,
+          sslResponse: {
+            isSelfSigned: false,
+            expiresAt: dateFromNow({ days: -1 }),
+          },
+        }),
+        {
+          checkOn: CheckOn.IsValidCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  /*
+   * The probe serialises Dates to ISO strings over the wire, so by the time
+   * criteria run, expiresAt is a string rather than a Date. Expiry maths
+   * must behave identically either way.
+   */
+  describe("expiresAt arriving as an ISO string", () => {
+    test("a future expiry read from a string is still valid", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          isOnline: true,
+          sslResponse: {
+            isValidCertificate: true,
+            isSelfSigned: false,
+            expiresAt: dateFromNow({
+              days: 30,
+            }).toISOString() as unknown as Date,
+          },
+        }),
+        {
+          checkOn: CheckOn.IsValidCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    test("ExpiresInDays compares correctly against a string expiry", async () => {
+      const result: string | null = await evaluate(
+        buildDataToProcess({
+          isOnline: true,
+          sslResponse: {
+            isValidCertificate: true,
+            expiresAt: dateFromNow({
+              days: 10,
+            }).toISOString() as unknown as Date,
+          },
+        }),
+        {
+          checkOn: CheckOn.ExpiresInDays,
+          filterType: FilterType.LessThan,
+          value: 30,
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
   });
 });

--- a/Common/Tests/Types/API/HostnameFromAuthority.test.ts
+++ b/Common/Tests/Types/API/HostnameFromAuthority.test.ts
@@ -1,0 +1,164 @@
+import Hostname from "../../../Types/API/Hostname";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Hostname.fromAuthority splits a URL authority into a bare host and a real
+ * Port. It exists because URL.fromString hands the WHOLE authority to the
+ * Hostname constructor, so `URL.fromString("https://example.com:8443/")`
+ * yields a hostname of "example.com:8443" and no port at all.
+ *
+ * Anything that reads the structured accessors rather than toString() then
+ * dials a host that does not exist. The SSL Certificate Monitor is one such
+ * consumer, which is why a monitor on a non-443 port could never connect —
+ * see https://github.com/OneUptime/oneuptime/issues/3225.
+ *
+ * fromString() is NOT a substitute: it splits on the FIRST colon, which
+ * mangles every IPv6 literal.
+ */
+describe("Hostname.fromAuthority", () => {
+  describe("host and port", () => {
+    test("splits a trailing port off the host", () => {
+      const hostname: Hostname = Hostname.fromAuthority("example.com:8443");
+
+      expect(hostname.hostname).toBe("example.com");
+      expect(hostname.port?.toNumber()).toBe(8443);
+    });
+
+    test("leaves a bare host without a port", () => {
+      const hostname: Hostname = Hostname.fromAuthority("example.com");
+
+      expect(hostname.hostname).toBe("example.com");
+      expect(hostname.port).toBeUndefined();
+    });
+
+    test("handles localhost with a port", () => {
+      const hostname: Hostname = Hostname.fromAuthority("localhost:5000");
+
+      expect(hostname.hostname).toBe("localhost");
+      expect(hostname.port?.toNumber()).toBe(5000);
+    });
+
+    test("handles an IPv4 literal with a port", () => {
+      const hostname: Hostname = Hostname.fromAuthority("127.0.0.1:8443");
+
+      expect(hostname.hostname).toBe("127.0.0.1");
+      expect(hostname.port?.toNumber()).toBe(8443);
+    });
+
+    test("round-trips back to the original authority", () => {
+      expect(Hostname.fromAuthority("example.com:8443").toString()).toBe(
+        "example.com:8443",
+      );
+      expect(Hostname.fromAuthority("example.com").toString()).toBe(
+        "example.com",
+      );
+    });
+  });
+
+  describe("IPv6 literals", () => {
+    test("keeps a bracketed IPv6 address intact and takes its port", () => {
+      const hostname: Hostname = Hostname.fromAuthority("[::1]:8443");
+
+      expect(hostname.hostname).toBe("[::1]");
+      expect(hostname.port?.toNumber()).toBe(8443);
+    });
+
+    test("keeps a bracketed IPv6 address with no port intact", () => {
+      const hostname: Hostname = Hostname.fromAuthority("[::1]");
+
+      expect(hostname.hostname).toBe("[::1]");
+      expect(hostname.port).toBeUndefined();
+    });
+
+    test("does not split an unbracketed IPv6 literal", () => {
+      /*
+       * Two or more colons cannot be a host:port, so every colon belongs to
+       * the address. fromString would have returned a host of "2001".
+       */
+      const hostname: Hostname = Hostname.fromAuthority("2001:db8::1");
+
+      expect(hostname.hostname).toBe("2001:db8::1");
+      expect(hostname.port).toBeUndefined();
+    });
+
+    test("a full bracketed IPv6 address survives with its port", () => {
+      const hostname: Hostname = Hostname.fromAuthority(
+        "[2001:db8::8a2e:370:7334]:9000",
+      );
+
+      expect(hostname.hostname).toBe("[2001:db8::8a2e:370:7334]");
+      expect(hostname.port?.toNumber()).toBe(9000);
+    });
+  });
+
+  describe("userinfo", () => {
+    test("drops userinfo and keeps the host", () => {
+      const hostname: Hostname = Hostname.fromAuthority(
+        "user:token@hooks.example.com",
+      );
+
+      expect(hostname.hostname).toBe("hooks.example.com");
+      expect(hostname.port).toBeUndefined();
+    });
+
+    test("drops userinfo and keeps host and port", () => {
+      const hostname: Hostname = Hostname.fromAuthority(
+        "user:token@example.com:8443",
+      );
+
+      expect(hostname.hostname).toBe("example.com");
+      expect(hostname.port?.toNumber()).toBe(8443);
+    });
+
+    test("splits on the LAST @, since userinfo may contain one", () => {
+      const hostname: Hostname = Hostname.fromAuthority(
+        "user@name:token@example.com:8443",
+      );
+
+      expect(hostname.hostname).toBe("example.com");
+      expect(hostname.port?.toNumber()).toBe(8443);
+    });
+  });
+
+  describe("malformed input", () => {
+    test("an empty authority yields an empty hostname rather than throwing", () => {
+      expect(Hostname.fromAuthority("").hostname).toBe("");
+    });
+
+    test("a trailing colon with no digits is not treated as a port", () => {
+      const hostname: Hostname = Hostname.fromAuthority("example.com:");
+
+      expect(hostname.hostname).toBe("example.com");
+      expect(hostname.port).toBeUndefined();
+    });
+
+    test("surrounding whitespace is trimmed", () => {
+      const hostname: Hostname = Hostname.fromAuthority("  example.com:443  ");
+
+      expect(hostname.hostname).toBe("example.com");
+      expect(hostname.port?.toNumber()).toBe(443);
+    });
+  });
+
+  describe("contrast with fromString", () => {
+    test("fromString rejects an IPv6 literal that fromAuthority handles", () => {
+      /*
+       * Pinned deliberately: it documents WHY fromAuthority exists, and
+       * guards against someone 'simplifying' one into the other.
+       *
+       * fromString splits on the FIRST colon, so "[::1]:8443" becomes a
+       * host of "[" - which the Hostname setter rejects outright.
+       */
+      expect(Hostname.fromAuthority("[::1]:8443").hostname).toBe("[::1]");
+      expect(() => {
+        return Hostname.fromString("[::1]:8443");
+      }).toThrow();
+    });
+
+    test("both agree on the simple host:port case", () => {
+      expect(Hostname.fromAuthority("example.com:8443").hostname).toBe(
+        Hostname.fromString("example.com:8443").hostname,
+      );
+    });
+  });
+});

--- a/Common/Tests/Types/Monitor/MonitorStep.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorStep.test.ts
@@ -218,4 +218,104 @@ describe("MonitorStep", () => {
       expect(domainMonitor["lookupMethod"]).toBe(DomainLookupMethod.WHOIS);
     });
   });
+
+  /*
+   * Regression suite for https://github.com/OneUptime/oneuptime/issues/3225.
+   *
+   * fromJSON normalizes metricMonitor and domainMonitor through their
+   * Util.fromJSON/toJSON pair, each with a comment explaining that the probe
+   * would otherwise receive a config that does not satisfy its own type.
+   * dnssecMonitor was a raw passthrough.
+   *
+   * A DNSSEC config authored through the API, Terraform or an imported
+   * template need not carry `resolvers`, and the probe iterates that list
+   * without a guard - so it threw a TypeError BEFORE posting any result. The
+   * monitor produced nothing at all, on every cycle, with no status change
+   * and no error the user could see: the same silent-failure class the issue
+   * reports for SSL Certificate monitors.
+   */
+  describe("dnssecMonitor normalization (issue #3225)", () => {
+    /*
+     * Built from a real default step for the same reason the domainMonitor
+     * tests above are: fromJSON validates the whole envelope, so a hand-rolled
+     * fragment would fail for reasons unrelated to what is under test.
+     */
+    function restoreWithDnssecMonitor(
+      dnssecMonitor: JSONObject | undefined,
+    ): JSONObject | undefined {
+      const json: JSONObject =
+        MonitorStep.getDefaultMonitorStep(DEFAULT_ARG).toJSON();
+
+      if (dnssecMonitor) {
+        (json["value"] as JSONObject)["dnssecMonitor"] = dnssecMonitor;
+      }
+
+      return MonitorStep.fromJSON(json).data?.dnssecMonitor as unknown as
+        | JSONObject
+        | undefined;
+    }
+
+    test("back-fills resolvers when the stored config has none", () => {
+      const dnssec: JSONObject | undefined = restoreWithDnssecMonitor({
+        domainName: "oneuptime.com",
+      });
+
+      expect(dnssec?.["resolvers"]).toEqual(["1.1.1.1", "8.8.8.8", "9.9.9.9"]);
+    });
+
+    test("back-fills resolvers when the stored list is empty", () => {
+      const dnssec: JSONObject | undefined = restoreWithDnssecMonitor({
+        domainName: "oneuptime.com",
+        resolvers: [],
+      });
+
+      expect((dnssec?.["resolvers"] as Array<string>).length).toBeGreaterThan(
+        0,
+      );
+    });
+
+    test("preserves resolvers the caller actually supplied", () => {
+      const dnssec: JSONObject | undefined = restoreWithDnssecMonitor({
+        domainName: "oneuptime.com",
+        resolvers: ["9.9.9.9"],
+      });
+
+      expect(dnssec?.["resolvers"]).toEqual(["9.9.9.9"]);
+    });
+
+    test("back-fills the rest of the config the probe relies on", () => {
+      const dnssec: JSONObject | undefined = restoreWithDnssecMonitor({
+        domainName: "oneuptime.com",
+      });
+
+      expect(dnssec?.["checkNameserverConsistency"]).toBe(true);
+      expect(dnssec?.["signatureExpiryWarningDays"]).toBe(7);
+      expect(dnssec?.["timeout"]).toBe(10000);
+      expect(dnssec?.["retries"]).toBe(3);
+    });
+
+    test("a re-save repairs an already-stored row", () => {
+      /*
+       * toJSON(fromJSON(x)) is what a monitor edit performs, so rows
+       * persisted before the fix heal the next time they are written.
+       */
+      const json: JSONObject =
+        MonitorStep.getDefaultMonitorStep(DEFAULT_ARG).toJSON();
+
+      (json["value"] as JSONObject)["dnssecMonitor"] = {
+        domainName: "oneuptime.com",
+      };
+
+      const resaved: JSONObject = MonitorStep.fromJSON(json).toJSON()[
+        "value"
+      ] as JSONObject;
+      const dnssec: JSONObject = resaved["dnssecMonitor"] as JSONObject;
+
+      expect((dnssec["resolvers"] as Array<string>).length).toBeGreaterThan(0);
+    });
+
+    test("leaves a step without a dnssecMonitor untouched", () => {
+      expect(restoreWithDnssecMonitor(undefined)).toBeUndefined();
+    });
+  });
 });

--- a/Common/Tests/Utils/Monitor/MonitorMetricType.test.ts
+++ b/Common/Tests/Utils/Monitor/MonitorMetricType.test.ts
@@ -1,7 +1,9 @@
 import AggregationType from "../../../Types/BaseDatabase/AggregationType";
 import { CheckOn } from "../../../Types/Monitor/CriteriaFilter";
 import MonitorMetricType from "../../../Types/Monitor/MonitorMetricType";
-import MonitorType from "../../../Types/Monitor/MonitorType";
+import MonitorType, {
+  MonitorTypeHelper,
+} from "../../../Types/Monitor/MonitorType";
 import MonitorMetricTypeUtil, {
   MonitorMetricCategory,
 } from "../../../Utils/Monitor/MonitorMetricType";
@@ -331,5 +333,68 @@ describe("invariant: every displayed metric resolves its metadata", () => {
         ).toBeGreaterThan(0);
       }
     }
+  });
+});
+
+/*
+ * Regression suite for https://github.com/OneUptime/oneuptime/issues/3225.
+ *
+ * SSLCertificate was missing from getMonitorMetricTypesByMonitorType, so it
+ * fell through to `return []`. getMonitorMetricCategoriesByMonitorType
+ * short-circuits on an empty metric list and the dashboard hides the whole
+ * Monitor Metrics tab when there are no categories - so an SSL monitor
+ * showed no charts at all, even though IsOnline rows were being written to
+ * ClickHouse on every single check. An operator therefore had no way to see
+ * that their monitor was running, which is a large part of why the issue was
+ * reported as "the monitor never executes".
+ *
+ * The invariant test above cannot catch this: it iterates the metrics a type
+ * already lists, so an empty list passes vacuously.
+ */
+describe("SSL Certificate monitor metrics (issue #3225)", () => {
+  test("SSLCertificate reports IsOnline and ResponseTime", () => {
+    const metrics: Array<MonitorMetricType> =
+      MonitorMetricTypeUtil.getMonitorMetricTypesByMonitorType(
+        MonitorType.SSLCertificate,
+      );
+
+    expect(metrics).toContain(MonitorMetricType.IsOnline);
+    expect(metrics).toContain(MonitorMetricType.ResponseTime);
+  });
+
+  test("SSLCertificate produces at least one display category", () => {
+    const categories: Array<MonitorMetricCategory> =
+      MonitorMetricTypeUtil.getMonitorMetricCategoriesByMonitorType(
+        MonitorType.SSLCertificate,
+      );
+
+    // An empty list is what made the dashboard hide the metrics tab.
+    expect(categories.length).toBeGreaterThan(0);
+  });
+});
+
+describe("invariant: every probeable monitor type displays some metric", () => {
+  test("no probeable type falls through to an empty metric list", () => {
+    const typesWithoutMetrics: Array<MonitorType> = [];
+
+    for (const monitorType of ALL_MONITOR_TYPES) {
+      if (!MonitorTypeHelper.isProbableMonitor(monitorType)) {
+        continue;
+      }
+
+      const metrics: Array<MonitorMetricType> =
+        MonitorMetricTypeUtil.getMonitorMetricTypesByMonitorType(monitorType);
+
+      if (metrics.length === 0) {
+        typesWithoutMetrics.push(monitorType);
+      }
+    }
+
+    /*
+     * Asserting on the collected list rather than per-type so a failure
+     * names every offender at once - this is the structural hole that let
+     * SSLCertificate ship with no charts.
+     */
+    expect(typesWithoutMetrics).toEqual([]);
   });
 });

--- a/Common/Types/API/Hostname.ts
+++ b/Common/Types/API/Hostname.ts
@@ -182,6 +182,85 @@ export default class Hostname extends DatabaseProperty {
     return new Hostname(hostname);
   }
 
+  /*
+   * Splits a URL authority into its bare host and its port, using the same
+   * structure isValid() already understands: optional userinfo, then either
+   * a bracketed IPv6 literal, an unbracketed IPv6 literal, or a host with an
+   * optional ":port".
+   *
+   * fromString() is NOT a substitute. It splits on the FIRST colon, so it
+   * turns "[::1]:8080" into a host of "[" and a port of "", and any IPv6
+   * literal into nonsense. Callers that hold an authority (a URL's host
+   * component) and need the two parts apart must use this.
+   *
+   * Userinfo is dropped rather than preserved: the caller asked for a host
+   * to connect to, and credentials are not part of one. Anything that needs
+   * the original string still has the authority it passed in.
+   */
+  public static fromAuthority(authority: string): Hostname {
+    const trimmedAuthority: string = (authority || "").trim();
+
+    if (!trimmedAuthority) {
+      return new Hostname("");
+    }
+
+    /*
+     * Split on the LAST "@" for the same reason isValid() does: userinfo may
+     * itself contain an "@", and everything after the final one is the
+     * authority proper.
+     */
+    const atIndex: number = trimmedAuthority.lastIndexOf("@");
+    const hostAndPort: string =
+      atIndex === -1
+        ? trimmedAuthority
+        : trimmedAuthority.substring(atIndex + 1);
+
+    if (!hostAndPort) {
+      return new Hostname("");
+    }
+
+    // Bracketed IPv6, with or without a port: "[::1]", "[::1]:8080".
+    const bracketedIpv6Match: RegExpMatchArray | null = hostAndPort.match(
+      /^(\[[0-9a-fA-F:.]+\])(?::(\d{1,5}))?$/,
+    );
+
+    if (bracketedIpv6Match) {
+      const ipv6Host: string = bracketedIpv6Match[1] as string;
+      const ipv6Port: string | undefined = bracketedIpv6Match[2];
+
+      return ipv6Port
+        ? new Hostname(ipv6Host, ipv6Port)
+        : new Hostname(ipv6Host);
+    }
+
+    /*
+     * Unbracketed IPv6 literal: two or more colons cannot be a "host:port",
+     * so every colon belongs to the address itself and there is no port.
+     */
+    if ((hostAndPort.match(/:/g) || []).length > 1) {
+      return new Hostname(hostAndPort);
+    }
+
+    const colonIndex: number = hostAndPort.indexOf(":");
+
+    if (colonIndex === -1) {
+      return new Hostname(hostAndPort);
+    }
+
+    const host: string = hostAndPort.substring(0, colonIndex);
+    const port: string = hostAndPort.substring(colonIndex + 1);
+
+    /*
+     * A trailing colon with no digits ("host:") is not a port. Keep the host
+     * and drop the empty port rather than constructing an invalid Port.
+     */
+    if (!port) {
+      return new Hostname(host);
+    }
+
+    return new Hostname(host, port);
+  }
+
   public static override toDatabase(
     value: Hostname | FindOperator<Hostname>,
   ): string | null {

--- a/Common/Types/Monitor/MonitorStep.ts
+++ b/Common/Types/Monitor/MonitorStep.ts
@@ -1156,8 +1156,20 @@ export default class MonitorStep extends DatabaseProperty {
             ),
           )
         : undefined,
+      /*
+       * Normalized for the same reason domainMonitor above is: a config
+       * authored through the API or a template need not carry `resolvers`,
+       * and the probe iterates that list without a guard. A raw passthrough
+       * therefore threw a TypeError inside the probe BEFORE it posted any
+       * result, so the monitor produced nothing at all - no check, no
+       * status change, no error the user could see.
+       */
       dnssecMonitor: json["dnssecMonitor"]
-        ? (json["dnssecMonitor"] as JSONObject)
+        ? MonitorStepDnssecMonitorUtil.toJSON(
+            MonitorStepDnssecMonitorUtil.fromJSON(
+              json["dnssecMonitor"] as JSONObject,
+            ),
+          )
         : undefined,
       sqlMonitor: json["sqlMonitor"]
         ? (json["sqlMonitor"] as JSONObject)

--- a/Common/Types/Monitor/SSLMonitor/SslMonitorResponse.ts
+++ b/Common/Types/Monitor/SSLMonitor/SslMonitorResponse.ts
@@ -4,7 +4,40 @@
  * probe cannot assign a "may be absent" value into a bare optional property.
  */
 export default interface SslMonitorResponse {
+  /*
+   * Whether the certificate chain passed strict TLS validation (the check
+   * a browser performs). This is the ONE field that answers "is this
+   * certificate trustworthy", and it is recorded explicitly rather than
+   * inferred.
+   *
+   * It exists because isSelfSigned used to be the only signal that
+   * validation had failed, which forced every distinct failure - expired,
+   * hostname mismatch, untrusted CA, incomplete chain - to be reported as
+   * "self signed". Criteria that asked "is this certificate valid" then had
+   * to reconstruct the verdict from !isSelfSigned, and a monitor watching a
+   * host with a wrong-hostname certificate read as healthy.
+   */
+  isValidCertificate?: boolean | undefined;
+
+  /*
+   * Why strict validation failed, straight from Node's TLS stack:
+   * certificateValidationErrorCode is the stable machine-readable code
+   * ("CERT_HAS_EXPIRED", "ERR_TLS_CERT_ALTNAME_INVALID", ...) that criteria
+   * and tests key off, and certificateValidationError is the human-readable
+   * message shown to whoever gets paged. Both are empty when the
+   * certificate is valid.
+   */
+  certificateValidationError?: string | undefined;
+  certificateValidationErrorCode?: string | undefined;
+
+  /*
+   * True ONLY for a genuinely self-signed chain, i.e. Node reported
+   * DEPTH_ZERO_SELF_SIGNED_CERT / SELF_SIGNED_CERT_IN_CHAIN, or the leaf's
+   * issuer equals its subject. Any other validation failure leaves this
+   * false and is described by certificateValidationErrorCode instead.
+   */
   isSelfSigned?: boolean | undefined;
+
   createdAt?: Date | undefined;
   expiresAt?: Date | undefined;
   commonName?: string | undefined;
@@ -13,7 +46,17 @@ export default interface SslMonitorResponse {
   locality?: string | undefined;
   state?: string | undefined;
   country?: string | undefined;
+
+  // Who signed the certificate. Without it the product cannot name the CA.
+  issuer?: string | undefined;
+
   serialNumber?: string | undefined;
   fingerprint?: string | undefined;
   fingerprint256?: string | undefined;
+
+  /*
+   * How long the successful TLS handshake took. Recorded so SSL monitors
+   * produce a ResponseTime metric like every other probe monitor type.
+   */
+  responseTimeInMs?: number | undefined;
 }

--- a/Common/Utils/Monitor/MonitorMetricType.ts
+++ b/Common/Utils/Monitor/MonitorMetricType.ts
@@ -1,7 +1,9 @@
 import AggregationType from "../../Types/BaseDatabase/AggregationType";
 import { CheckOn } from "../../Types/Monitor/CriteriaFilter";
 import MonitorMetricType from "../../Types/Monitor/MonitorMetricType";
-import MonitorType from "../../Types/Monitor/MonitorType";
+import MonitorType, {
+  MonitorTypeHelper,
+} from "../../Types/Monitor/MonitorType";
 
 /*
  * Groups of metrics rendered as separate cards on the monitor metrics page.
@@ -238,8 +240,21 @@ class MonitorMetricTypeUtil {
       monitorType === MonitorType.DNSSEC ||
       monitorType === MonitorType.Domain ||
       monitorType === MonitorType.SQLQuery ||
+      monitorType === MonitorType.SSLCertificate ||
       monitorType === MonitorType.ExternalStatusPage
     ) {
+      return [MonitorMetricType.IsOnline, MonitorMetricType.ResponseTime];
+    }
+
+    /*
+     * Any other type the probe actually checks still writes IsOnline and
+     * ResponseTime rows, so default to showing them rather than to an empty
+     * list. Falling through to [] hides the Monitor Metrics tab entirely -
+     * SSL Certificate monitors were missing from the list above and so had
+     * no metrics tab at all, which left an operator with no way to see that
+     * their monitor was running.
+     */
+    if (MonitorTypeHelper.isProbableMonitor(monitorType)) {
       return [MonitorMetricType.IsOnline, MonitorMetricType.ResponseTime];
     }
 

--- a/Probe/Tests/Utils/Monitors/MonitorStepResult.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorStepResult.test.ts
@@ -1,0 +1,191 @@
+// Set required env vars before importing anything that pulls Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/typedef
+const mockSslPing = jest.fn();
+
+jest.mock("../../../Utils/Monitors/MonitorTypes/SslMonitor", () => {
+  return {
+    __esModule: true,
+    default: {
+      ping: (...args: Array<unknown>): unknown => {
+        return mockSslPing(...args);
+      },
+    },
+  };
+});
+
+import MonitorUtil from "../../../Utils/Monitors/Monitor";
+import MonitorStep from "Common/Types/Monitor/MonitorStep";
+import MonitorType from "Common/Types/Monitor/MonitorType";
+import ObjectID from "Common/Types/ObjectID";
+import URL from "Common/Types/API/URL";
+import ProbeMonitorResponse from "Common/Types/Probe/ProbeMonitorResponse";
+
+/*
+ * Covers how the probe assembles a ProbeMonitorResponse for an SSL
+ * Certificate step — see https://github.com/OneUptime/oneuptime/issues/3225.
+ *
+ * Two defects lived here: the SSL branch never set responseTimeInMs (so no
+ * ResponseTime metric row was ever written), and a step with no destination
+ * returned a result with isOnline left undefined, which matches no criteria
+ * and therefore reads as healthy.
+ */
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const MONITOR_ID: ObjectID = ObjectID.generate();
+
+function buildSslStep(destination?: string): MonitorStep {
+  const step: MonitorStep = new MonitorStep();
+
+  step.data = {
+    ...(step.data as NonNullable<MonitorStep["data"]>),
+    id: ObjectID.generate().toString(),
+  } as NonNullable<MonitorStep["data"]>;
+
+  if (destination) {
+    step.setMonitorDestination(URL.fromString(destination));
+  } else if (step.data) {
+    step.data.monitorDestination = undefined;
+  }
+
+  return step;
+}
+
+beforeEach(() => {
+  mockSslPing.mockReset();
+});
+
+describe("SSL Certificate step result assembly (issue #3225)", () => {
+  test("copies responseTimeInMs so a ResponseTime metric is written", async () => {
+    mockSslPing.mockResolvedValue({
+      isOnline: true,
+      failureCause: "",
+      isTimeout: false,
+      isValidCertificate: true,
+      responseTimeInMs: 123,
+      expiresAt: new Date(),
+      probeAttempts: [],
+      totalAttempts: 1,
+    } as never);
+
+    const result: ProbeMonitorResponse | null =
+      await MonitorUtil.probeMonitorStep({
+        monitorStep: buildSslStep("https://example.com/"),
+        monitorType: MonitorType.SSLCertificate,
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+      });
+
+    /*
+     * MonitorMetricUtil gates the ResponseTime metric on this field, so
+     * leaving it undefined left the SSL metrics chart permanently empty.
+     */
+    expect(result?.responseTimeInMs).toBe(123);
+  });
+
+  test("copies the certificate verdict through to the response", async () => {
+    mockSslPing.mockResolvedValue({
+      isOnline: true,
+      failureCause: "Hostname/IP does not match",
+      isTimeout: false,
+      isValidCertificate: false,
+      isSelfSigned: false,
+      certificateValidationErrorCode: "ERR_TLS_CERT_ALTNAME_INVALID",
+      responseTimeInMs: 10,
+      probeAttempts: [],
+      totalAttempts: 1,
+    } as never);
+
+    const result: ProbeMonitorResponse | null =
+      await MonitorUtil.probeMonitorStep({
+        monitorStep: buildSslStep("https://example.com/"),
+        monitorType: MonitorType.SSLCertificate,
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+      });
+
+    expect(result?.isOnline).toBe(true);
+    expect(result?.sslResponse?.isValidCertificate).toBe(false);
+    expect(result?.sslResponse?.certificateValidationErrorCode).toBe(
+      "ERR_TLS_CERT_ALTNAME_INVALID",
+    );
+    expect(result?.failureCause).toBe("Hostname/IP does not match");
+  });
+
+  test("a step with no destination reports a definite failure, not an undefined status", async () => {
+    const result: ProbeMonitorResponse | null =
+      await MonitorUtil.probeMonitorStep({
+        monitorStep: buildSslStep(),
+        monitorType: MonitorType.SSLCertificate,
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+      });
+
+    /*
+     * Previously this returned a bare result with isOnline undefined, which
+     * satisfies no criterion — so a misconfigured monitor read as healthy
+     * forever instead of surfacing the misconfiguration.
+     */
+    expect(result?.isOnline).toBe(false);
+    expect(result?.failureCause).toContain("SSL Certificate Monitor");
+    expect(mockSslPing).not.toHaveBeenCalled();
+  });
+
+  test("passes the step timeout down to the SSL monitor", async () => {
+    mockSslPing.mockResolvedValue({
+      isOnline: true,
+      failureCause: "",
+      isValidCertificate: true,
+      responseTimeInMs: 5,
+    } as never);
+
+    const step: MonitorStep = buildSslStep("https://example.com/");
+    if (step.data) {
+      step.data.requestTimeoutInMs = 4321;
+    }
+
+    await MonitorUtil.probeMonitorStep({
+      monitorStep: step,
+      monitorType: MonitorType.SSLCertificate,
+      monitorId: MONITOR_ID,
+      projectId: PROJECT_ID,
+    });
+
+    const options: { timeout?: { toNumber: () => number } } = mockSslPing.mock
+      .calls[0]?.[1] as { timeout?: { toNumber: () => number } };
+
+    // The UI advertises this setting for SSL monitors; it must be honoured.
+    expect(options?.timeout?.toNumber()).toBe(4321);
+  });
+
+  test("a null ping result is propagated as null", async () => {
+    mockSslPing.mockResolvedValue(null as never);
+
+    const result: ProbeMonitorResponse | null =
+      await MonitorUtil.probeMonitorStep({
+        monitorStep: buildSslStep("https://example.com/"),
+        monitorType: MonitorType.SSLCertificate,
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+      });
+
+    expect(result).toBeNull();
+  });
+});

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/SslMonitor.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/SslMonitor.test.ts
@@ -1,0 +1,412 @@
+// Set required env vars before importing SSLMonitor (through Register/Config).
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+jest.mock("../../../../Utils/OnlineCheck", () => {
+  return {
+    __esModule: true,
+    default: {
+      canProbeMonitorWebsiteMonitors: jest.fn(async (): Promise<boolean> => {
+        return true;
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  };
+});
+
+import tls from "tls";
+import net, { AddressInfo } from "net";
+import URL from "Common/Types/API/URL";
+import PositiveNumber from "Common/Types/PositiveNumber";
+import SSLMonitor, {
+  SslResponse,
+} from "../../../../Utils/Monitors/MonitorTypes/SslMonitor";
+import {
+  cleanupSslCertificateFixtures,
+  generateSslCertificateFixtures,
+  SslCertificateFixtures,
+} from "./SslTestCertificates";
+
+/*
+ * Regression suite for https://github.com/OneUptime/oneuptime/issues/3225.
+ *
+ * The probe used to fetch a certificate with rejectUnauthorized:true, and on
+ * ANY failure retry with rejectUnauthorized:false and set isSelfSigned=true
+ * — discarding the real TLS error. Every distinct failure (untrusted CA,
+ * hostname mismatch, expired, incomplete chain) was therefore reported
+ * identically, always with isOnline:true and an empty failureCause. A
+ * monitor watching a host with a broken certificate read as healthy.
+ *
+ * These tests assert the probe now emits an explicit validation verdict.
+ */
+
+let fixtures: SslCertificateFixtures;
+
+interface RunningServer {
+  server: tls.Server;
+  port: number;
+}
+
+const runningServers: Array<tls.Server> = [];
+
+/*
+ * Every socket any test server accepted. A rejected TLS handshake can leave
+ * one half-open, and server.close() waits for those — which turns a slow
+ * machine into a hung teardown rather than a test failure. Tracking them
+ * means teardown can destroy them outright.
+ */
+const acceptedSockets: Array<net.Socket> = [];
+
+async function startTlsServer(data: {
+  cert: string;
+  key: string;
+}): Promise<RunningServer> {
+  return new Promise<RunningServer>(
+    (resolve: (value: RunningServer) => void) => {
+      const server: tls.Server = tls.createServer(
+        { cert: data.cert, key: data.key },
+        (socket: tls.TLSSocket) => {
+          /*
+           * Answer with a minimal HTTP response so https.get's response
+           * callback fires and the certificate can be read.
+           */
+          socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok");
+        },
+      );
+
+      server.on("connection", (socket: net.Socket) => {
+        acceptedSockets.push(socket);
+        socket.on("error", () => {
+          // Half-open handshakes surface here; expected.
+        });
+      });
+
+      server.on("tlsClientError", () => {
+        // A client that refuses our certificate surfaces here; expected.
+      });
+
+      server.listen(0, "127.0.0.1", () => {
+        runningServers.push(server);
+        resolve({
+          server,
+          port: (server.address() as AddressInfo).port,
+        });
+      });
+    },
+  );
+}
+
+beforeAll(() => {
+  fixtures = generateSslCertificateFixtures();
+});
+
+afterAll(async () => {
+  /*
+   * Destroy sockets before closing servers: close() waits for open
+   * connections, so a single half-open handshake would stall teardown.
+   */
+  for (const socket of acceptedSockets) {
+    socket.destroy();
+  }
+
+  for (const server of runningServers) {
+    (
+      server as unknown as { closeAllConnections?: () => void }
+    ).closeAllConnections?.();
+
+    /*
+     * Bounded wait. Teardown must never be the thing that fails this
+     * suite — the assertions above are what carry the regression.
+     */
+    await new Promise<void>((resolve: () => void) => {
+      const timer: ReturnType<typeof setTimeout> = setTimeout(resolve, 2000);
+
+      server.close(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  cleanupSslCertificateFixtures(fixtures);
+}, 60000);
+
+describe("SSLMonitor certificate validation verdict", () => {
+  test("a self-signed certificate is reported as self-signed AND invalid", async () => {
+    const running: RunningServer = await startTlsServer({
+      cert: fixtures.selfSignedCert,
+      key: fixtures.selfSignedKey,
+    });
+
+    const response: SslResponse = await SSLMonitor.getSslMonitorResponse(
+      "127.0.0.1",
+      running.port,
+      5000,
+    );
+
+    expect(response.isValidCertificate).toBe(false);
+    expect(response.isSelfSigned).toBe(true);
+    expect(response.certificateValidationErrorCode).toBeTruthy();
+    // The certificate itself was still readable, so its contents come back.
+    expect(response.expiresAt).toBeDefined();
+  }, 30000);
+
+  test("a hostname mismatch is NOT reported as self-signed", async () => {
+    const running: RunningServer = await startTlsServer({
+      cert: fixtures.wrongHostCert,
+      key: fixtures.wrongHostKey,
+    });
+
+    const response: SslResponse = await SSLMonitor.getSslMonitorResponse(
+      "127.0.0.1",
+      running.port,
+      5000,
+    );
+
+    /*
+     * The heart of the bug: this certificate is CA-issued and unexpired, it
+     * simply does not cover the host we dialled. Pre-fix it came back as
+     * isSelfSigned:true, which is a lie, and as a valid-looking response.
+     */
+    expect(response.isValidCertificate).toBe(false);
+    expect(response.isSelfSigned).toBe(false);
+    expect(response.certificateValidationErrorCode).toBeTruthy();
+  }, 30000);
+
+  test("an untrusted-CA certificate is invalid but not self-signed", async () => {
+    const running: RunningServer = await startTlsServer({
+      cert: fixtures.validCert,
+      key: fixtures.validKey,
+    });
+
+    /*
+     * The leaf is signed by our test CA, which the probe's trust store does
+     * not know about, so strict validation fails with an issuer error - not
+     * with a self-signed error.
+     */
+    const response: SslResponse = await SSLMonitor.getSslMonitorResponse(
+      "127.0.0.1",
+      running.port,
+      5000,
+    );
+
+    expect(response.isValidCertificate).toBe(false);
+    expect(response.isSelfSigned).toBe(false);
+    expect(response.certificateValidationErrorCode).toBeTruthy();
+  }, 30000);
+
+  test("the validation error is preserved instead of discarded", async () => {
+    const running: RunningServer = await startTlsServer({
+      cert: fixtures.wrongHostCert,
+      key: fixtures.wrongHostKey,
+    });
+
+    const response: SslResponse = await SSLMonitor.getSslMonitorResponse(
+      "127.0.0.1",
+      running.port,
+      5000,
+    );
+
+    expect(response.certificateValidationError).toBeTruthy();
+    expect(response.failureCause).toBeTruthy();
+  }, 30000);
+
+  test("certificate contents are still reported for an invalid certificate", async () => {
+    const running: RunningServer = await startTlsServer({
+      cert: fixtures.wrongHostCert,
+      key: fixtures.wrongHostKey,
+    });
+
+    const response: SslResponse = await SSLMonitor.getSslMonitorResponse(
+      "127.0.0.1",
+      running.port,
+      5000,
+    );
+
+    expect(response.expiresAt).toBeDefined();
+    expect(response.createdAt).toBeDefined();
+    expect(response.serialNumber).toBeTruthy();
+    expect(response.fingerprint).toBeTruthy();
+  }, 30000);
+
+  test("issuer is populated, and differs from subject for a CA-issued leaf", async () => {
+    const running: RunningServer = await startTlsServer({
+      cert: fixtures.validCert,
+      key: fixtures.validKey,
+    });
+
+    const response: SslResponse = await SSLMonitor.getSslMonitorResponse(
+      "127.0.0.1",
+      running.port,
+      5000,
+    );
+
+    expect(response.issuer).toBeTruthy();
+    expect(response.issuer).toContain("oneuptime-ssl-monitor-test-ca");
+  }, 30000);
+
+  test("issuer equals subject for a self-signed leaf", async () => {
+    const running: RunningServer = await startTlsServer({
+      cert: fixtures.selfSignedCert,
+      key: fixtures.selfSignedKey,
+    });
+
+    const response: SslResponse = await SSLMonitor.getSslMonitorResponse(
+      "127.0.0.1",
+      running.port,
+      5000,
+    );
+
+    expect(response.issuer).toBeTruthy();
+    expect(response.issuer).toContain("selfsigned.oneuptime-test");
+  }, 30000);
+
+  test("an expired certificate is invalid and not mislabelled self-signed", async () => {
+    if (!fixtures.expiredCert || !fixtures.expiredKey) {
+      /*
+       * openssl too old to backdate a certificate. The expiry LOGIC is
+       * covered without a live server in the criteria suite.
+       */
+      return;
+    }
+
+    const running: RunningServer = await startTlsServer({
+      cert: fixtures.expiredCert,
+      key: fixtures.expiredKey,
+    });
+
+    const response: SslResponse = await SSLMonitor.getSslMonitorResponse(
+      "127.0.0.1",
+      running.port,
+      5000,
+    );
+
+    expect(response.isValidCertificate).toBe(false);
+    expect(response.isSelfSigned).toBe(false);
+    expect(response.certificateValidationErrorCode).toBe("CERT_HAS_EXPIRED");
+  }, 30000);
+});
+
+describe("SSLMonitor connection failures", () => {
+  test("a refused connection is offline and is NOT called self-signed", async () => {
+    /*
+     * Bind then immediately close, so the port is almost certainly free and
+     * the connection is refused.
+     */
+    const probeServer: net.Server = net.createServer();
+    const port: number = await new Promise<number>(
+      (resolve: (value: number) => void) => {
+        probeServer.listen(0, "127.0.0.1", () => {
+          const assigned: number = (probeServer.address() as AddressInfo).port;
+          probeServer.close(() => {
+            return resolve(assigned);
+          });
+        });
+      },
+    );
+
+    const response: SslResponse = await SSLMonitor.getSslMonitorResponse(
+      "127.0.0.1",
+      port,
+      2000,
+    );
+
+    expect(response.isOnline).toBe(false);
+    expect(response.isValidCertificate).toBe(false);
+    /*
+     * Regression guard: a connection failure says NOTHING about the
+     * certificate. Pre-fix it fell into the same catch that set
+     * isSelfSigned=true.
+     */
+    expect(response.isSelfSigned).toBe(false);
+    expect(response.expiresAt).toBeUndefined();
+    expect(response.failureCause).toBeTruthy();
+  }, 30000);
+});
+
+describe("SSLMonitor.ping response shape", () => {
+  test("a completed check records responseTimeInMs for the metrics chart", async () => {
+    const running: RunningServer = await startTlsServer({
+      cert: fixtures.selfSignedCert,
+      key: fixtures.selfSignedKey,
+    });
+
+    const response: SslResponse | null = await SSLMonitor.ping(
+      URL.fromString(`https://127.0.0.1:${running.port}/`),
+      {
+        timeout: new PositiveNumber(5000),
+        retry: 0,
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    expect(response).not.toBeNull();
+    expect(typeof response?.responseTimeInMs).toBe("number");
+    expect(response?.responseTimeInMs).toBeGreaterThanOrEqual(0);
+  }, 30000);
+
+  test("ping resolves the port from the URL authority", async () => {
+    const running: RunningServer = await startTlsServer({
+      cert: fixtures.selfSignedCert,
+      key: fixtures.selfSignedKey,
+    });
+
+    /*
+     * URL.fromString leaves the port glued to the authority
+     * ("127.0.0.1:8443"), so a probe that reads url.hostname.hostname
+     * directly tries to resolve a host of that literal name. If the port is
+     * not recovered here this check cannot reach the server at all.
+     */
+    const response: SslResponse | null = await SSLMonitor.ping(
+      URL.fromString(`https://127.0.0.1:${running.port}/`),
+      {
+        timeout: new PositiveNumber(5000),
+        retry: 0,
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    expect(response).not.toBeNull();
+    expect(response?.isOnline).toBe(true);
+    expect(response?.expiresAt).toBeDefined();
+  }, 30000);
+
+  test("probe attempts are recorded", async () => {
+    const running: RunningServer = await startTlsServer({
+      cert: fixtures.selfSignedCert,
+      key: fixtures.selfSignedKey,
+    });
+
+    const response: SslResponse | null = await SSLMonitor.ping(
+      URL.fromString(`https://127.0.0.1:${running.port}/`),
+      {
+        timeout: new PositiveNumber(5000),
+        retry: 0,
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    expect(response?.totalAttempts).toBeGreaterThanOrEqual(1);
+    expect(Array.isArray(response?.probeAttempts)).toBe(true);
+  }, 30000);
+});

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/SslMonitor.timeout.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/SslMonitor.timeout.test.ts
@@ -1,0 +1,344 @@
+// Set required env vars before importing SSLMonitor (through Register/Config).
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+jest.mock("../../../../Utils/OnlineCheck", () => {
+  return {
+    __esModule: true,
+    default: {
+      canProbeMonitorWebsiteMonitors: jest.fn(async (): Promise<boolean> => {
+        return true;
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  };
+});
+
+import net from "net";
+import tls from "tls";
+import { AddressInfo } from "net";
+import URL from "Common/Types/API/URL";
+import PositiveNumber from "Common/Types/PositiveNumber";
+import SSLMonitor, {
+  SslResponse,
+  DEFAULT_SSL_MONITOR_TIMEOUT_IN_MS,
+} from "../../../../Utils/Monitors/MonitorTypes/SslMonitor";
+import SelfSignedCertificate from "./SslTestCertificates";
+
+/*
+ * These suites pin the fix for the unbounded hang described in
+ * https://github.com/OneUptime/oneuptime/issues/3225.
+ *
+ * SSLMonitor accepted a `timeout` option and never read it, and
+ * getCertificate registered no deadline of any kind on its https.get. A peer
+ * that completes TCP (or even the full TLS handshake) and then goes silent
+ * left the promise unsettled forever. Because the ingest POST happens only
+ * AFTER the step returns, that monitor posted no result at all, on every
+ * cycle - a monitor that reads as healthy while providing zero coverage.
+ *
+ * Every test here fails on the pre-fix code by exhausting the jest timeout.
+ */
+
+// A TCP listener that accepts the connection and never speaks TLS.
+let tcpSilentServer: net.Server;
+let tcpSilentPort: number = 0;
+
+// A TLS listener that completes the handshake and never writes a response.
+let tlsSilentServer: tls.Server;
+let tlsSilentPort: number = 0;
+
+// Sockets the servers accepted, so we can assert the client hung up.
+const acceptedTcpSockets: Array<net.Socket> = [];
+const acceptedTlsSockets: Array<tls.TLSSocket> = [];
+
+beforeAll(async () => {
+  await new Promise<void>((resolve: () => void) => {
+    tcpSilentServer = net.createServer((socket: net.Socket) => {
+      acceptedTcpSockets.push(socket);
+
+      /*
+       * Put the socket in flowing mode. A paused socket never processes the
+       * incoming FIN, so it would not emit 'close' when the client hangs
+       * up - the server would look like it was still connected and the
+       * leak assertion below would fail against correct code.
+       */
+      socket.resume();
+
+      // Deliberately silent: never negotiate TLS, never end the socket.
+      socket.on("error", () => {
+        // A client-side destroy surfaces here; it is expected.
+      });
+    });
+    tcpSilentServer.listen(0, "127.0.0.1", () => {
+      tcpSilentPort = (tcpSilentServer.address() as AddressInfo).port;
+      resolve();
+    });
+  });
+
+  await new Promise<void>((resolve: () => void) => {
+    tlsSilentServer = tls.createServer(
+      {
+        key: SelfSignedCertificate.key,
+        cert: SelfSignedCertificate.cert,
+      },
+      (socket: tls.TLSSocket) => {
+        acceptedTlsSockets.push(socket);
+        /*
+         * Handshake completes, then nothing is ever written - so https.get's
+         * response callback never fires. This is the case req.setTimeout
+         * exists for.
+         */
+        socket.on("error", () => {
+          // Expected when the client destroys the request.
+        });
+      },
+    );
+    tlsSilentServer.listen(0, "127.0.0.1", () => {
+      tlsSilentPort = (tlsSilentServer.address() as AddressInfo).port;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  for (const socket of acceptedTcpSockets) {
+    socket.destroy();
+  }
+  for (const socket of acceptedTlsSockets) {
+    socket.destroy();
+  }
+
+  await new Promise<void>((resolve: () => void) => {
+    tcpSilentServer.close(() => {
+      return resolve();
+    });
+  });
+  await new Promise<void>((resolve: () => void) => {
+    tlsSilentServer.close(() => {
+      return resolve();
+    });
+  });
+});
+
+describe("SSLMonitor timeout handling (issue #3225)", () => {
+  test("settles rather than hanging against a TCP-accept-then-silent peer", async () => {
+    const startedAt: number = Date.now();
+
+    const response: SslResponse | null = await SSLMonitor.ping(
+      URL.fromString(`https://127.0.0.1:${tcpSilentPort}/`),
+      {
+        timeout: new PositiveNumber(1000),
+        retry: 0,
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    const elapsed: number = Date.now() - startedAt;
+
+    expect(response).not.toBeNull();
+    // Pre-fix this never settles at all.
+    expect(elapsed).toBeLessThan(8000);
+  }, 20000);
+
+  test("settles rather than hanging against a TLS-handshake-then-silent peer", async () => {
+    const startedAt: number = Date.now();
+
+    const response: SslResponse | null = await SSLMonitor.ping(
+      URL.fromString(`https://127.0.0.1:${tlsSilentPort}/`),
+      {
+        timeout: new PositiveNumber(1000),
+        retry: 0,
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    const elapsed: number = Date.now() - startedAt;
+
+    expect(response).not.toBeNull();
+    expect(elapsed).toBeLessThan(8000);
+  }, 20000);
+
+  test("a timed-out check reports isOnline FALSE, not true", async () => {
+    const response: SslResponse | null = await SSLMonitor.ping(
+      URL.fromString(`https://127.0.0.1:${tcpSilentPort}/`),
+      {
+        timeout: new PositiveNumber(1000),
+        retry: 0,
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    expect(response).not.toBeNull();
+
+    /*
+     * The regression guard that matters most. The old code returned
+     * `isOnline: true` on timeout, so a permanently stalled endpoint
+     * satisfied nothing and every "Is Online = False" criterion was dead -
+     * the monitor read Operational forever.
+     */
+    expect(response?.isOnline).toBe(false);
+    expect(response?.isTimeout).toBe(true);
+  }, 20000);
+
+  test("a timed-out check is never reported as a valid certificate", async () => {
+    const response: SslResponse | null = await SSLMonitor.ping(
+      URL.fromString(`https://127.0.0.1:${tcpSilentPort}/`),
+      {
+        timeout: new PositiveNumber(1000),
+        retry: 0,
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    expect(response?.isValidCertificate).toBe(false);
+  }, 20000);
+
+  test("the failure cause names the SSL Certificate Monitor and the timeout", async () => {
+    const response: SslResponse | null = await SSLMonitor.ping(
+      URL.fromString(`https://127.0.0.1:${tcpSilentPort}/`),
+      {
+        timeout: new PositiveNumber(1000),
+        retry: 0,
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    /*
+     * "Timeout Error." on its own does not tell an operator which check
+     * timed out or what the budget was.
+     */
+    expect(response?.failureCause).toContain("SSL Certificate Monitor");
+    expect(response?.failureCause).toContain("timed out");
+    expect(response?.failureCause).toContain("1000");
+  }, 20000);
+
+  test("the client hangs up on timeout instead of leaking the socket", async () => {
+    const socketsBefore: number = acceptedTcpSockets.length;
+
+    await SSLMonitor.ping(
+      URL.fromString(`https://127.0.0.1:${tcpSilentPort}/`),
+      {
+        timeout: new PositiveNumber(1000),
+        retry: 0,
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    const newSockets: Array<net.Socket> =
+      acceptedTcpSockets.slice(socketsBefore);
+
+    expect(newSockets.length).toBeGreaterThan(0);
+
+    /*
+     * Wait for the server side to observe the hang-up rather than sleeping
+     * a fixed amount: FIN propagation is not instantaneous and a fixed
+     * sleep makes this flaky on a loaded machine.
+     */
+    await Promise.all(
+      newSockets.map(async (socket: net.Socket): Promise<void> => {
+        if (socket.destroyed || socket.readableEnded) {
+          return;
+        }
+
+        await new Promise<void>((resolve: () => void) => {
+          const done: () => void = (): void => {
+            clearTimeout(timer);
+            resolve();
+          };
+          const timer: ReturnType<typeof setTimeout> = setTimeout(done, 5000);
+          socket.once("close", done);
+          socket.once("end", done);
+        });
+      }),
+    );
+
+    for (const socket of newSockets) {
+      /*
+       * Regression guard for the socket leak: an abandoned ClientRequest
+       * keeps its socket - and the event loop - alive, which is what let a
+       * hung check accumulate one stuck connection per cron tick.
+       */
+      expect(socket.destroyed || socket.readableEnded || socket.closed).toBe(
+        true,
+      );
+    }
+  }, 30000);
+
+  test("retries do not multiply the deadline without bound", async () => {
+    const startedAt: number = Date.now();
+
+    await SSLMonitor.ping(
+      URL.fromString(`https://127.0.0.1:${tcpSilentPort}/`),
+      {
+        timeout: new PositiveNumber(500),
+        retry: 2,
+        isOnlineCheckRequest: true,
+      },
+    );
+
+    const elapsed: number = Date.now() - startedAt;
+
+    /*
+     * Timeouts are terminal for a single connect attempt: getCertificate
+     * must NOT re-enter its own 3x retry loop on a timeout, or the wall
+     * clock becomes retry x strict/lenient x 3 connects.
+     */
+    expect(elapsed).toBeLessThan(15000);
+  }, 30000);
+});
+
+describe("SSLMonitor timeout wiring", () => {
+  test("getOptions carries the threaded timeout", () => {
+    const options: Record<string, unknown> = (
+      SSLMonitor as unknown as {
+        getOptions: (
+          host: string,
+          port: number,
+          rejectUnauthorized: boolean,
+          timeoutInMs?: number,
+        ) => Record<string, unknown>;
+      }
+    ).getOptions("example.com", 443, true, 1234);
+
+    expect(options["timeout"]).toBe(1234);
+  });
+
+  test("getOptions falls back to the shared default when none is supplied", () => {
+    const options: Record<string, unknown> = (
+      SSLMonitor as unknown as {
+        getOptions: (
+          host: string,
+          port: number,
+          rejectUnauthorized: boolean,
+          timeoutInMs?: number,
+        ) => Record<string, unknown>;
+      }
+    ).getOptions("example.com", 443, true);
+
+    expect(options["timeout"]).toBe(DEFAULT_SSL_MONITOR_TIMEOUT_IN_MS);
+  });
+
+  test("the default matches the other probe monitor types", () => {
+    expect(DEFAULT_SSL_MONITOR_TIMEOUT_IN_MS).toBe(5000);
+  });
+});

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/SslTestCertificates.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/SslTestCertificates.ts
@@ -1,0 +1,312 @@
+import { execFileSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+/*
+ * Certificate fixtures for the SSL Certificate Monitor suites.
+ *
+ * These are generated with openssl at test time rather than checked in as
+ * PEM blobs, for the same reason WebsiteMonitor.mtls.test.ts does it: a
+ * checked-in "currently valid" certificate silently becomes an expired one,
+ * and the suite would start failing on a date rather than on a regression.
+ *
+ * Every distinct TLS failure mode the probe must tell apart gets its own
+ * fixture, because the defect being guarded against is precisely that they
+ * were all collapsed into "self signed".
+ */
+export interface SslCertificateFixtures {
+  workDir: string;
+
+  // A CA the tests can hand to Node as a trusted root.
+  caCertPem: string;
+
+  // Signed by the CA above, SAN covers localhost/127.0.0.1, unexpired.
+  validCert: string;
+  validKey: string;
+
+  // Signed by the CA, but SAN names a host we will never connect to.
+  wrongHostCert: string;
+  wrongHostKey: string;
+
+  /*
+   * Signed by the CA, already past its notAfter.
+   *
+   * Backdating needs `openssl x509 -not_before/-not_after`, which only
+   * exists from OpenSSL 3.4. On older toolchains these are null and the one
+   * test that needs them skips itself rather than failing the suite - the
+   * expiry LOGIC is covered without a live server in
+   * Common/Tests/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.test.ts,
+   * which builds expiry dates synthetically.
+   */
+  expiredCert: string | null;
+  expiredKey: string | null;
+
+  // Its own issuer - a true DEPTH_ZERO_SELF_SIGNED_CERT.
+  selfSignedCert: string;
+  selfSignedKey: string;
+}
+
+function openssl(args: Array<string>): void {
+  execFileSync("openssl", args, { stdio: "pipe" });
+}
+
+export function generateSslCertificateFixtures(): SslCertificateFixtures {
+  const workDir: string = fs.mkdtempSync(
+    path.join(os.tmpdir(), "oneuptime-ssl-monitor-test-"),
+  );
+
+  const configPath: string = path.join(workDir, "openssl.cnf");
+  fs.writeFileSync(
+    configPath,
+    [
+      "[req]",
+      "distinguished_name = req_distinguished_name",
+      "prompt = no",
+      "[req_distinguished_name]",
+      "CN = test",
+      "[v3_local]",
+      "subjectAltName = DNS:localhost,IP:127.0.0.1",
+      "extendedKeyUsage = serverAuth",
+      "[v3_elsewhere]",
+      "subjectAltName = DNS:not-the-host-we-dial.example",
+      "extendedKeyUsage = serverAuth",
+    ].join("\n"),
+  );
+
+  const caKey: string = path.join(workDir, "ca.key");
+  const caCert: string = path.join(workDir, "ca.crt");
+  openssl(["genrsa", "-out", caKey, "2048"]);
+  openssl([
+    "req",
+    "-x509",
+    "-new",
+    "-key",
+    caKey,
+    "-out",
+    caCert,
+    "-days",
+    "2",
+    "-subj",
+    "/CN=oneuptime-ssl-monitor-test-ca",
+  ]);
+
+  type Leaf = { cert: string; key: string };
+
+  const issueLeaf: (data: {
+    name: string;
+    extension: string;
+    notBeforeDays?: number;
+    days: number;
+  }) => Leaf = (data: {
+    name: string;
+    extension: string;
+    notBeforeDays?: number;
+    days: number;
+  }): Leaf => {
+    const key: string = path.join(workDir, `${data.name}.key`);
+    const csr: string = path.join(workDir, `${data.name}.csr`);
+    const cert: string = path.join(workDir, `${data.name}.crt`);
+
+    openssl(["genrsa", "-out", key, "2048"]);
+    openssl([
+      "req",
+      "-new",
+      "-key",
+      key,
+      "-out",
+      csr,
+      "-subj",
+      `/CN=${data.name}.oneuptime-test`,
+    ]);
+
+    const args: Array<string> = [
+      "x509",
+      "-req",
+      "-in",
+      csr,
+      "-CA",
+      caCert,
+      "-CAkey",
+      caKey,
+      "-CAcreateserial",
+      "-out",
+      cert,
+      "-extfile",
+      configPath,
+      "-extensions",
+      data.extension,
+    ];
+
+    /*
+     * An already-expired certificate is produced by backdating both ends of
+     * the validity window with -not_before / -not_after, which is the only
+     * way to get one without waiting.
+     */
+    if (data.notBeforeDays !== undefined) {
+      const notBefore: Date = new Date(
+        Date.now() - data.notBeforeDays * 24 * 60 * 60 * 1000,
+      );
+      const notAfter: Date = new Date(
+        Date.now() - (data.notBeforeDays - data.days) * 24 * 60 * 60 * 1000,
+      );
+
+      args.push(
+        "-not_before",
+        formatOpensslDate(notBefore),
+        "-not_after",
+        formatOpensslDate(notAfter),
+      );
+    } else {
+      args.push("-days", String(data.days));
+    }
+
+    openssl(args);
+
+    return { cert, key };
+  };
+
+  const valid: Leaf = issueLeaf({
+    name: "valid",
+    extension: "v3_local",
+    days: 2,
+  });
+
+  const wrongHost: Leaf = issueLeaf({
+    name: "wronghost",
+    extension: "v3_elsewhere",
+    days: 2,
+  });
+
+  /*
+   * Best effort: older OpenSSL has no way to issue an already-expired
+   * certificate without waiting for time to pass.
+   */
+  let expired: Leaf | null = null;
+
+  try {
+    expired = issueLeaf({
+      name: "expired",
+      extension: "v3_local",
+      notBeforeDays: 10,
+      days: 5,
+    });
+  } catch {
+    expired = null;
+  }
+
+  // Self-signed: no CA involved at all, so the leaf is its own issuer.
+  const selfSignedKey: string = path.join(workDir, "selfsigned.key");
+  const selfSignedCert: string = path.join(workDir, "selfsigned.crt");
+  openssl(["genrsa", "-out", selfSignedKey, "2048"]);
+  /*
+   * `req -x509` takes its extensions from -config/-extensions; -extfile is
+   * an `x509` option only and this command rejects it.
+   */
+  openssl([
+    "req",
+    "-x509",
+    "-new",
+    "-key",
+    selfSignedKey,
+    "-out",
+    selfSignedCert,
+    "-days",
+    "2",
+    "-subj",
+    "/CN=selfsigned.oneuptime-test",
+    "-config",
+    configPath,
+    "-extensions",
+    "v3_local",
+  ]);
+
+  return {
+    workDir,
+    caCertPem: fs.readFileSync(caCert, "utf8"),
+    validCert: fs.readFileSync(valid.cert, "utf8"),
+    validKey: fs.readFileSync(valid.key, "utf8"),
+    wrongHostCert: fs.readFileSync(wrongHost.cert, "utf8"),
+    wrongHostKey: fs.readFileSync(wrongHost.key, "utf8"),
+    expiredCert: expired ? fs.readFileSync(expired.cert, "utf8") : null,
+    expiredKey: expired ? fs.readFileSync(expired.key, "utf8") : null,
+    selfSignedCert: fs.readFileSync(selfSignedCert, "utf8"),
+    selfSignedKey: fs.readFileSync(selfSignedKey, "utf8"),
+  };
+}
+
+function formatOpensslDate(date: Date): string {
+  // openssl expects YYYYMMDDHHMMSSZ for -not_before / -not_after.
+  const pad: (value: number) => string = (value: number): string => {
+    return String(value).padStart(2, "0");
+  };
+
+  return (
+    `${date.getUTCFullYear()}` +
+    `${pad(date.getUTCMonth() + 1)}` +
+    `${pad(date.getUTCDate())}` +
+    `${pad(date.getUTCHours())}` +
+    `${pad(date.getUTCMinutes())}` +
+    `${pad(date.getUTCSeconds())}Z`
+  );
+}
+
+export function cleanupSslCertificateFixtures(
+  fixtures: SslCertificateFixtures,
+): void {
+  fs.rmSync(fixtures.workDir, { recursive: true, force: true });
+}
+
+/*
+ * A standalone self-signed pair for suites that only need SOME certificate
+ * to put in front of a TLS listener (the timeout suite, where the
+ * certificate itself is irrelevant). Generated once per process.
+ */
+let cachedSelfSigned: { key: string; cert: string } | null = null;
+
+const SelfSignedCertificate: { readonly key: string; readonly cert: string } = {
+  get key(): string {
+    return ensureSelfSigned().key;
+  },
+  get cert(): string {
+    return ensureSelfSigned().cert;
+  },
+};
+
+function ensureSelfSigned(): { key: string; cert: string } {
+  if (cachedSelfSigned) {
+    return cachedSelfSigned;
+  }
+
+  const dir: string = fs.mkdtempSync(
+    path.join(os.tmpdir(), "oneuptime-ssl-monitor-selfsigned-"),
+  );
+  const keyPath: string = path.join(dir, "key.pem");
+  const certPath: string = path.join(dir, "cert.pem");
+
+  openssl(["genrsa", "-out", keyPath, "2048"]);
+  openssl([
+    "req",
+    "-x509",
+    "-new",
+    "-key",
+    keyPath,
+    "-out",
+    certPath,
+    "-days",
+    "2",
+    "-subj",
+    "/CN=localhost",
+  ]);
+
+  cachedSelfSigned = {
+    key: fs.readFileSync(keyPath, "utf8"),
+    cert: fs.readFileSync(certPath, "utf8"),
+  };
+
+  fs.rmSync(dir, { recursive: true, force: true });
+
+  return cachedSelfSigned;
+}
+
+export default SelfSignedCertificate;

--- a/Probe/Utils/Monitors/Monitor.ts
+++ b/Probe/Utils/Monitors/Monitor.ts
@@ -189,12 +189,42 @@ export default class MonitorUtil {
         continue;
       }
 
-      const result: ProbeMonitorResponse | null = await this.probeMonitorStep({
-        monitorType: monitor.monitorType!,
-        monitorId: monitor.id!,
-        monitorStep: monitorStep,
-        projectId: monitor.projectId!,
-      });
+      /*
+       * A throw from any monitor-type handler used to escape all the way to
+       * Promise.allSettled in the FetchList job, where it was logged and
+       * dropped - BEFORE the ingest POST below. The monitor then produced no
+       * result at all, on every cycle, and the only symptom was a monitor
+       * that silently never changed state.
+       *
+       * Converting the throw into a reportable offline result keeps that
+       * class of bug visible: the check is recorded as failed, with the
+       * error as its cause, and criteria can act on it.
+       */
+      let result: ProbeMonitorResponse | null = null;
+
+      try {
+        result = await this.probeMonitorStep({
+          monitorType: monitor.monitorType!,
+          monitorId: monitor.id!,
+          monitorStep: monitorStep,
+          projectId: monitor.projectId!,
+        });
+      } catch (err) {
+        logger.error(
+          `Monitor ${monitor.id?.toString()} (${monitor.monitorType}) step ${monitorStep.id?.toString()} threw while probing:`,
+        );
+        logger.error(err);
+
+        result = {
+          monitorStepId: monitorStep.id,
+          projectId: monitor.projectId!,
+          monitorId: monitor.id!,
+          probeId: ProbeUtil.getProbeId(),
+          isOnline: false,
+          failureCause: API.getFriendlyErrorMessage(err as Error),
+          monitoredAt: OneUptimeDate.getCurrentDate(),
+        };
+      }
 
       if (result) {
         // report this back to Probe API.
@@ -525,19 +555,20 @@ export default class MonitorUtil {
     }
 
     if (monitorType === MonitorType.SSLCertificate) {
+      /*
+       * A step with no destination is a misconfiguration, and it has to
+       * produce a verdict criteria can act on. Returning a bare result left
+       * isOnline undefined, which matches nothing and reads as "healthy".
+       */
       if (!monitorStep.data?.monitorDestination) {
+        result.isOnline = false;
+        result.failureCause =
+          "SSL Certificate Monitor - destination URL is not specified.";
+
         return result;
       }
 
       result.monitorDestination = monitorStep.data.monitorDestination;
-
-      if (!monitorStep.data?.monitorDestination) {
-        result.isOnline = false;
-        result.responseTimeInMs = 0;
-        result.failureCause = "Port is not specified";
-
-        return result;
-      }
 
       const response: SslResponse | null = await SSLMonitor.ping(
         monitorStep.data?.monitorDestination as URL,
@@ -555,6 +586,11 @@ export default class MonitorUtil {
       result.isOnline = response.isOnline;
       result.failureCause = response.failureCause;
       result.isTimeout = response.isTimeout;
+      /*
+       * Without this the ResponseTime metric is never written for SSL
+       * monitors, so their metrics chart stays permanently empty.
+       */
+      result.responseTimeInMs = response.responseTimeInMs;
       result.sslResponse = {
         ...response,
       };

--- a/Probe/Utils/Monitors/MonitorTypes/DnssecMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/DnssecMonitor.ts
@@ -68,6 +68,22 @@ export default class DnssecMonitorUtil {
       });
     }
 
+    /*
+     * Defence in depth alongside the normalization in
+     * MonitorStep.fromJSON: iterating an absent resolver list threw a
+     * TypeError that escaped before any result could be posted, so the
+     * monitor silently produced nothing. Report the misconfiguration
+     * instead of throwing.
+     */
+    if (!config.resolvers || config.resolvers.length === 0) {
+      return DnssecMonitorUtil.buildFailureResponse({
+        domainName: domainName,
+        responseTimeInMs: 0,
+        failureCause:
+          "No DNS resolvers are configured for this DNSSEC monitor.",
+      });
+    }
+
     for (const resolver of config.resolvers) {
       if (!DnssecMonitorUtil.isValidHostnameOrIP(resolver)) {
         return DnssecMonitorUtil.buildFailureResponse({

--- a/Probe/Utils/Monitors/MonitorTypes/SslMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/SslMonitor.ts
@@ -1,6 +1,7 @@
 import OnlineCheck from "../../OnlineCheck";
 import ProxyConfig from "../../ProxyConfig";
 import URL from "Common/Types/API/URL";
+import Hostname from "Common/Types/API/Hostname";
 import type { HttpsProxyAgent } from "https-proxy-agent";
 import type { HttpProxyAgent } from "http-proxy-agent";
 import OneUptimeDate from "Common/Types/Date";
@@ -14,6 +15,7 @@ import API from "Common/Utils/API";
 import ObjectUtil from "Common/Utils/ObjectUtil";
 import logger from "Common/Server/Utils/Logger";
 import { ClientRequest, IncomingMessage } from "http";
+import { Socket } from "net";
 import https, { RequestOptions } from "https";
 import tls, { TLSSocket } from "tls";
 
@@ -34,6 +36,48 @@ export interface SSLMonitorOptions {
   attempts?: Array<ProbeAttempt> | undefined;
 }
 
+/*
+ * Node's TLS validation error codes. A strict handshake that fails with one
+ * of these has produced a VERDICT about the certificate - the peer is
+ * reachable and served a chain, it just is not trustworthy. Anything else
+ * (ECONNREFUSED, ENOTFOUND, ETIMEDOUT, ...) is a connection failure and says
+ * nothing about the certificate, which is the distinction the old code lost
+ * when it treated every strict-pass failure as evidence of self-signing.
+ */
+const TLS_VALIDATION_ERROR_CODES: Set<string> = new Set<string>([
+  "CERT_CHAIN_TOO_LONG",
+  "CERT_HAS_EXPIRED",
+  "CERT_NOT_YET_VALID",
+  "CERT_REJECTED",
+  "CERT_REVOKED",
+  "CERT_SIGNATURE_FAILURE",
+  "CERT_UNTRUSTED",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "ERR_TLS_CERT_ALTNAME_INVALID",
+  "HOSTNAME_MISMATCH",
+  "INVALID_CA",
+  "INVALID_PURPOSE",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "UNABLE_TO_GET_ISSUER_CERT",
+  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  "UNSUPPORTED_CERTIFICATE_PURPOSE",
+]);
+
+/*
+ * The two codes that actually mean "self-signed". Every other validation
+ * failure leaves isSelfSigned false and is described by the error code.
+ */
+const SELF_SIGNED_ERROR_CODES: Set<string> = new Set<string>([
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+]);
+
+// Matches WebsiteMonitor / PortMonitor when the caller supplies no timeout.
+export const DEFAULT_SSL_MONITOR_TIMEOUT_IN_MS: number = 5000;
+
+const LOG_PREFIX: string = "SSL Certificate Monitor";
+
 export default class SSLMonitor {
   // burn domain names into the code to see if this probe is online.
 
@@ -53,8 +97,22 @@ export default class SSLMonitor {
       pingOptions.attempts = [];
     }
 
+    const timeoutInMs: number =
+      pingOptions.timeout?.toNumber() || DEFAULT_SSL_MONITOR_TIMEOUT_IN_MS;
+
+    /*
+     * The URL's authority carries the port ("example.com:8443"), and
+     * URL.fromString does not split it off - it hands the whole authority to
+     * Hostname. Re-parsing it here is what keeps an SSL monitor on a
+     * non-443 port from trying to resolve a host literally named
+     * "example.com:8443".
+     */
+    const target: Hostname = Hostname.fromAuthority(url.hostname.toString());
+    const host: string = target.hostname;
+    const port: number = target.port?.toNumber() || 443;
+
     logger.debug(
-      `Pinging host: ${pingOptions?.monitorId?.toString()} ${url.toString()} - Retry: ${
+      `${LOG_PREFIX} - Pinging ${pingOptions?.monitorId?.toString()} ${host}:${port} - Retry: ${
         pingOptions?.currentRetryCount
       }`,
     );
@@ -62,31 +120,61 @@ export default class SSLMonitor {
     const attemptedAt: Date = new Date();
     try {
       const res: SslResponse = await this.getSslMonitorResponse(
-        url.hostname.hostname,
-        url.hostname.port?.toNumber() || 443,
+        host,
+        port,
+        timeoutInMs,
       );
 
       logger.debug(
-        `Pinging host ${pingOptions?.monitorId?.toString()} ${url.toString()} success: `,
+        `${LOG_PREFIX} - Pinging ${pingOptions?.monitorId?.toString()} ${host}:${port} success: `,
       );
       logger.debug(res);
 
       const responseReceivedAt: Date = new Date();
+      const responseTimeInMs: number =
+        responseReceivedAt.getTime() - attemptedAt.getTime();
+
       pingOptions.attempts.push({
         attemptNumber: pingOptions.currentRetryCount,
         attemptedAt,
         responseReceivedAt,
-        responseTimeInMs: responseReceivedAt.getTime() - attemptedAt.getTime(),
+        responseTimeInMs,
         isOnline: res.isOnline,
         failureCause: res.isOnline ? undefined : res.failureCause,
       });
+
+      /*
+       * A transient connection failure is worth retrying. A certificate
+       * that failed validation is a deterministic verdict, and a timeout
+       * has already consumed a full deadline - retrying either only burns
+       * the monitor's time budget.
+       */
+      if (
+        !res.isOnline &&
+        !res.certificateValidationErrorCode &&
+        !res.isTimeout &&
+        pingOptions.currentRetryCount < (pingOptions.retry ?? 5)
+      ) {
+        pingOptions.currentRetryCount++;
+        await Sleep.sleep(1000);
+        return await this.ping(url, pingOptions);
+      }
+
+      /*
+       * Recorded so SSL monitors produce a ResponseTime metric like every
+       * other probe monitor type. Only meaningful when we actually spoke to
+       * the peer.
+       */
+      if (res.isOnline) {
+        res.responseTimeInMs = responseTimeInMs;
+      }
 
       res.probeAttempts = pingOptions.attempts;
       res.totalAttempts = pingOptions.attempts.length;
       return res;
     } catch (err: unknown) {
       logger.debug(
-        `Pinging host ${pingOptions?.monitorId?.toString()} ${url.toString()} error: `,
+        `${LOG_PREFIX} - Pinging ${pingOptions?.monitorId?.toString()} ${host}:${port} error: `,
       );
       logger.debug(err);
 
@@ -122,24 +210,28 @@ export default class SSLMonitor {
       if (!pingOptions.isOnlineCheckRequest) {
         if (!(await OnlineCheck.canProbeMonitorWebsiteMonitors())) {
           logger.error(
-            `PingMonitor Monitor - Probe is not online. Cannot ping ${pingOptions?.monitorId?.toString()} ${url.toString()} - ERROR: ${err}`,
+            `${LOG_PREFIX} - Probe is not online. Cannot ping ${pingOptions?.monitorId?.toString()} ${host}:${port} - ERROR: ${err}`,
           );
           return null;
         }
       }
 
-      // check if timeout exceeded and if yes, return null
-      if (
-        (err as any).toString().includes("timeout") &&
-        (err as any).toString().includes("exceeded")
-      ) {
-        logger.debug(
-          `Ping Monitor - Timeout exceeded ${pingOptions.monitorId?.toString()} ${url.toString()} - ERROR: ${err}`,
+      // check if timeout exceeded and if yes, report it as offline.
+      if (SSLMonitor.isTimeoutError(err)) {
+        logger.error(
+          `${LOG_PREFIX} - Timeout exceeded ${pingOptions.monitorId?.toString()} ${host}:${port} - ERROR: ${err}`,
         );
 
         return {
-          isOnline: true,
+          /*
+           * A check that never completed is NOT evidence the endpoint is
+           * healthy. This used to return isOnline: true, which made a
+           * permanently stalled TLS peer read as an operational monitor and
+           * left every "Is Online = False" criterion dead.
+           */
+          isOnline: false,
           isTimeout: true,
+          isValidCertificate: false,
           failureCause:
             "Request was tried " +
             pingOptions.currentRetryCount +
@@ -156,9 +248,14 @@ export default class SSLMonitor {
         return null;
       }
 
+      logger.error(
+        `${LOG_PREFIX} - Failed to check ${pingOptions.monitorId?.toString()} ${host}:${port} - ERROR: ${err}`,
+      );
+
       return {
         isOnline: false,
         isTimeout: false,
+        isValidCertificate: false,
         failureCause: API.getFriendlyErrorMessage(err as Error),
         probeAttempts: pingOptions.attempts,
         totalAttempts: pingOptions.attempts.length,
@@ -169,58 +266,212 @@ export default class SSLMonitor {
   public static async getSslMonitorResponse(
     host: string,
     port = 443,
+    timeoutInMs: number = DEFAULT_SSL_MONITOR_TIMEOUT_IN_MS,
   ): Promise<SslResponse> {
-    let isSelfSigned: boolean = false;
     let certificate: tls.PeerCertificate | null = null;
 
+    let validationErrorCode: string = "";
+    let validationErrorMessage: string = "";
+
+    /*
+     * Two passes, and the FIRST one is the one that produces the verdict.
+     * The strict pass answers "would a browser trust this?"; the lenient
+     * pass exists only to fetch the certificate's contents so the monitor
+     * can still report expiry, issuer and fingerprints for a chain that
+     * failed validation.
+     */
     try {
       certificate = await this.getCertificate({
         host,
         port,
         rejectUnauthorized: true,
+        timeoutInMs,
       });
-    } catch {
+    } catch (strictError) {
+      validationErrorCode = SSLMonitor.getErrorCode(strictError);
+      validationErrorMessage = API.getFriendlyErrorMessage(
+        strictError as Error,
+      );
+
+      const isValidationFailure: boolean =
+        TLS_VALIDATION_ERROR_CODES.has(validationErrorCode);
+
+      /*
+       * A strict failure that is NOT a TLS validation code is a connection
+       * problem (refused, DNS, timeout). Retrying it without verification
+       * would not tell us anything new about the certificate, and reporting
+       * it as a certificate verdict is exactly the bug this replaces.
+       */
+      if (!isValidationFailure) {
+        const isTimeout: boolean = SSLMonitor.isTimeoutError(strictError);
+
+        return {
+          isOnline: false,
+          /*
+           * Carried explicitly: this method resolves rather than throws, so
+           * ping()'s own timeout branch never sees the error. Without this
+           * a timed-out check reached criteria with isTimeout undefined and
+           * "Is Request Timeout" could never fire.
+           */
+          isTimeout: isTimeout,
+          isValidCertificate: false,
+          isSelfSigned: false,
+          /*
+           * Deliberately NOT populated. We never got far enough to inspect
+           * a certificate, and putting a connection error (ECONNREFUSED,
+           * ETIMEDOUT) in a certificate-validation field is how the
+           * original bug described a network problem as a certificate
+           * verdict.
+           */
+          certificateValidationError: "",
+          certificateValidationErrorCode: "",
+          failureCause: isTimeout
+            ? `${LOG_PREFIX} - the connection timed out after ${timeoutInMs}ms.`
+            : validationErrorMessage,
+        };
+      }
+
       try {
         certificate = await this.getCertificate({
           host,
           port,
           rejectUnauthorized: false,
+          timeoutInMs,
         });
-
-        isSelfSigned = true;
-      } catch (err) {
+      } catch (lenientError) {
         return {
           isOnline: false,
-          failureCause: API.getFriendlyErrorMessage(err as Error),
+          isValidCertificate: false,
+          isSelfSigned: SELF_SIGNED_ERROR_CODES.has(validationErrorCode),
+          certificateValidationError: validationErrorMessage,
+          certificateValidationErrorCode: validationErrorCode,
+          failureCause: API.getFriendlyErrorMessage(lenientError as Error),
         };
       }
     }
 
-    if (!certificate) {
+    if (!certificate || ObjectUtil.isEmpty(certificate)) {
       return {
         isOnline: false,
+        isValidCertificate: false,
         failureCause: "No certificate found",
+        certificateValidationError: validationErrorMessage,
+        certificateValidationErrorCode: validationErrorCode,
       };
     }
 
+    const isValidCertificate: boolean = !validationErrorCode;
+
+    const issuer: string | undefined = SSLMonitor.distinguishedName(
+      certificate.issuer,
+    );
+    const subject: string | undefined = SSLMonitor.distinguishedName(
+      certificate.subject,
+    );
+
+    /*
+     * Self-signed is now a fact about the chain, not a leftover of control
+     * flow: either Node named it, or the leaf issued itself.
+     */
+    const isSelfSigned: boolean =
+      SELF_SIGNED_ERROR_CODES.has(validationErrorCode) ||
+      Boolean(issuer && subject && issuer === subject);
+
     const res: SslResponse = {
+      /*
+       * isOnline describes reachability: we completed a TLS handshake and
+       * read a certificate. Whether that certificate is TRUSTWORTHY is
+       * isValidCertificate's job - keeping the two apart is what lets a
+       * criterion distinguish "host is down" from "host is up with a bad
+       * certificate".
+       */
       isOnline: true,
+      isValidCertificate: isValidCertificate,
       isSelfSigned: isSelfSigned,
+      certificateValidationError: validationErrorMessage,
+      certificateValidationErrorCode: validationErrorCode,
       createdAt: OneUptimeDate.fromString(certificate.valid_from),
       expiresAt: OneUptimeDate.fromString(certificate.valid_to),
-      commonName: SSLMonitor.certificateField(certificate.subject.CN),
-      organizationalUnit: SSLMonitor.certificateField(certificate.subject.OU),
-      organization: SSLMonitor.certificateField(certificate.subject.O),
-      locality: SSLMonitor.certificateField(certificate.subject.L),
-      state: SSLMonitor.certificateField(certificate.subject.ST),
-      country: SSLMonitor.certificateField(certificate.subject.C),
+      commonName: SSLMonitor.certificateField(certificate.subject?.CN),
+      organizationalUnit: SSLMonitor.certificateField(certificate.subject?.OU),
+      organization: SSLMonitor.certificateField(certificate.subject?.O),
+      locality: SSLMonitor.certificateField(certificate.subject?.L),
+      state: SSLMonitor.certificateField(certificate.subject?.ST),
+      country: SSLMonitor.certificateField(certificate.subject?.C),
+      issuer: issuer,
       serialNumber: certificate.serialNumber,
       fingerprint: certificate.fingerprint,
       fingerprint256: certificate.fingerprint256,
-      failureCause: "",
+      /*
+       * failureCause carries the validation problem so it reaches whoever
+       * gets paged, instead of being discarded as it was when every failure
+       * collapsed into isSelfSigned.
+       */
+      failureCause: validationErrorMessage,
     };
 
     return res;
+  }
+
+  /*
+   * Node reports TLS validation failures through `code` on the error, but
+   * hostname mismatches arrive as ERR_TLS_CERT_ALTNAME_INVALID on `code`
+   * while some paths only set `reason`. Read both.
+   */
+  private static getErrorCode(err: unknown): string {
+    const candidate: NodeJS.ErrnoException = err as NodeJS.ErrnoException;
+
+    if (candidate?.code) {
+      return String(candidate.code);
+    }
+
+    const reason: unknown = (err as { reason?: unknown })?.reason;
+
+    if (typeof reason === "string" && TLS_VALIDATION_ERROR_CODES.has(reason)) {
+      return reason;
+    }
+
+    return "";
+  }
+
+  private static isTimeoutError(err: unknown): boolean {
+    const code: string = SSLMonitor.getErrorCode(err);
+
+    if (code === "ETIMEDOUT" || code === "ESOCKETTIMEDOUT") {
+      return true;
+    }
+
+    const message: string = String(err);
+
+    return message.includes("timeout") && message.includes("exceeded");
+  }
+
+  /*
+   * Renders a certificate's subject/issuer into a stable, comparable string.
+   * Comparing issuer to subject is how a self-signed leaf is recognised when
+   * Node did not hand us a code for it (the lenient pass succeeds silently).
+   */
+  private static distinguishedName(
+    name: tls.PeerCertificate["issuer"] | undefined,
+  ): string | undefined {
+    if (!name || typeof name !== "object") {
+      return undefined;
+    }
+
+    const parts: Array<string> = Object.keys(name)
+      .sort()
+      .map((key: string) => {
+        const value: string | undefined = SSLMonitor.certificateField(
+          (name as unknown as Record<string, string | Array<string>>)[key],
+        );
+
+        return value ? `${key}=${value}` : "";
+      })
+      .filter((part: string) => {
+        return Boolean(part);
+      });
+
+    return parts.length > 0 ? parts.join(", ") : undefined;
   }
 
   /*
@@ -247,6 +498,7 @@ export default class SSLMonitor {
     host: string;
     port: number;
     rejectUnauthorized: boolean;
+    timeoutInMs?: number;
     retry?: number;
     currentRetryCount?: number;
   }): Promise<tls.PeerCertificate> {
@@ -255,10 +507,32 @@ export default class SSLMonitor {
     let { port } = data;
     const retry: number = data.retry || 3;
     const currentRetryCount: number = data.currentRetryCount || 1;
+    const timeoutInMs: number =
+      data.timeoutInMs || DEFAULT_SSL_MONITOR_TIMEOUT_IN_MS;
 
     if (!port) {
       port = 443;
     }
+
+    let request: ClientRequest | null = null;
+    let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+
+    /*
+     * Held separately from the request. During a TLS handshake that never
+     * completes, the ClientRequest has no socket attached yet, so
+     * req.destroy() closes nothing and the TCP connection is leaked - one
+     * stuck socket per check, forever. Destroying the socket we were handed
+     * is what actually hangs up.
+     */
+    let requestSocket: Socket | null = null;
+
+    const abortRequest: (err: Error) => void = (err: Error): void => {
+      request?.destroy(err);
+
+      if (requestSocket && !requestSocket.destroyed) {
+        requestSocket.destroy(err);
+      }
+    };
 
     const sslPromise: Promise<tls.PeerCertificate> = new Promise(
       (
@@ -269,9 +543,18 @@ export default class SSLMonitor {
           host,
           port,
           rejectUnauthorized,
+          timeoutInMs,
         );
 
         let isResolvedOrRejected: boolean = false;
+
+        const settleWithError: (err: Error) => void = (err: Error): void => {
+          if (isResolvedOrRejected) {
+            return;
+          }
+          isResolvedOrRejected = true;
+          reject(err);
+        };
 
         const req: ClientRequest = https.get(
           requestOptions,
@@ -279,45 +562,116 @@ export default class SSLMonitor {
             const certificate: tls.PeerCertificate = (
               res.socket as TLSSocket
             ).getPeerCertificate();
-            if (ObjectUtil.isEmpty(certificate) || certificate === null) {
-              isResolvedOrRejected = true;
-              return reject(new BadDataException("No certificate found"));
+
+            /*
+             * Null-check FIRST. ObjectUtil.isEmpty(null) would throw a
+             * TypeError inside this callback - where nothing catches it -
+             * so the old ordering made the guard it was written for dead.
+             */
+            if (certificate === null || ObjectUtil.isEmpty(certificate)) {
+              return settleWithError(
+                new BadDataException("No certificate found"),
+              );
+            }
+
+            if (isResolvedOrRejected) {
+              return;
             }
             isResolvedOrRejected = true;
             return resolve(certificate);
           },
         );
 
+        request = req;
+
         req.end();
 
+        // Captured so a timeout can close the connection itself.
+        req.on("socket", (socket: Socket) => {
+          requestSocket = socket;
+        });
+
         req.on("error", (err: Error) => {
-          if (!isResolvedOrRejected) {
-            isResolvedOrRejected = true;
-            return reject(err);
-          }
+          settleWithError(err);
+        });
+
+        /*
+         * Arms once a socket is assigned and covers a peer that accepts the
+         * connection and then goes silent. It does NOT cover a stall before
+         * socket assignment (DNS, proxy CONNECT), which is what the
+         * Promise.race deadline below is for.
+         */
+        req.setTimeout(timeoutInMs, () => {
+          const timeoutError: NodeJS.ErrnoException = new Error(
+            `${LOG_PREFIX} - timeout of ${timeoutInMs}ms exceeded`,
+          );
+          timeoutError.code = "ETIMEDOUT";
+          abortRequest(timeoutError);
+          settleWithError(timeoutError);
         });
       },
     );
 
+    const deadlinePromise: Promise<never> = new Promise<never>(
+      (_resolve: (value: never) => void, reject: (err: Error) => void) => {
+        deadlineTimer = setTimeout(() => {
+          const timeoutError: NodeJS.ErrnoException = new Error(
+            `${LOG_PREFIX} - timeout of ${timeoutInMs}ms exceeded`,
+          );
+          timeoutError.code = "ETIMEDOUT";
+
+          /*
+           * Destroy the request as well as rejecting: an abandoned
+           * ClientRequest keeps its socket - and the event loop - alive.
+           */
+          abortRequest(timeoutError);
+          reject(timeoutError);
+        }, timeoutInMs);
+      },
+    );
+
     try {
-      const certificate: tls.PeerCertificate = await sslPromise;
+      const certificate: tls.PeerCertificate = await Promise.race([
+        sslPromise,
+        deadlinePromise,
+      ]);
       return certificate;
     } catch (err: unknown) {
       logger.debug(
-        `getCertificate failed for host ${host}:${port} - Retry: ${currentRetryCount} - Error: ${err}`,
+        `${LOG_PREFIX} - getCertificate failed for host ${host}:${port} - Retry: ${currentRetryCount} - Error: ${err}`,
       );
 
-      if (currentRetryCount < retry) {
+      /*
+       * A validation verdict is deterministic - the same chain fails the
+       * same way every time - so retrying it only multiplies the monitor's
+       * wall clock. Retry connection problems only.
+       */
+      const code: string = SSLMonitor.getErrorCode(err);
+
+      if (
+        currentRetryCount < retry &&
+        !TLS_VALIDATION_ERROR_CODES.has(code) &&
+        !SSLMonitor.isTimeoutError(err)
+      ) {
         await Sleep.sleep(1000);
         return await this.getCertificate({
           host,
           port,
           rejectUnauthorized,
+          timeoutInMs,
           retry,
           currentRetryCount: currentRetryCount + 1,
         });
       }
       throw err;
+    } finally {
+      /*
+       * Always clear the deadline: an un-cleared timer keeps the process
+       * (and jest --detectOpenHandles) alive after a successful check.
+       */
+      if (deadlineTimer) {
+        clearTimeout(deadlineTimer);
+      }
     }
   }
 
@@ -325,6 +679,7 @@ export default class SSLMonitor {
     url: string,
     port: number,
     rejectUnauthorized: boolean,
+    timeoutInMs: number = DEFAULT_SSL_MONITOR_TIMEOUT_IN_MS,
   ): RequestOptions {
     const options: RequestOptions = {
       hostname: url,
@@ -333,6 +688,12 @@ export default class SSLMonitor {
       ciphers: "ALL",
       port,
       protocol: "https:",
+      /*
+       * Node's ClientRequest default is 0 (wait forever). Without this an
+       * endpoint that completes TCP and then stalls hangs the check - and
+       * therefore the monitor - permanently.
+       */
+      timeout: timeoutInMs,
     };
 
     // Use proxy agent if proxy is configured
@@ -355,7 +716,7 @@ export default class SSLMonitor {
         const proxyUrl: string | null = httpsProxyUrl || httpProxyUrl;
 
         logger.debug(
-          `SSL Monitor using proxy: ${proxyUrl} (HTTPS: ${Boolean(httpsProxyUrl)}, HTTP: ${Boolean(httpProxyUrl)})`,
+          `${LOG_PREFIX} - using proxy: ${proxyUrl} (HTTPS: ${Boolean(httpsProxyUrl)}, HTTP: ${Boolean(httpProxyUrl)})`,
         );
       }
     }


### PR DESCRIPTION
Fixes #3225.

## What was reported

An SSL Certificate monitor pointed at `https://self-signed.badssl.com/` stayed **Operational** indefinitely — no Down status, no incident, and a history containing only its creation event. A production SSL monitor showed the same signature after three days. The issue was filed as "SSL Certificate monitors never execute".

## What is actually happening

**The monitor does execute.** Two of the three pieces of evidence in the report are artifacts of real defects rather than proof of non-execution — but the underlying failure is real and worse than "it didn't run": the monitor **cannot be made unhealthy by a bad certificate**.

Against a host with an invalid certificate the probe returns `{isOnline: true, isSelfSigned: true, failureCause: ""}`. Both of the reporter's criteria are then unsatisfiable — `Is Valid Certificate = True` does not match, and `Is Online = False` cannot match because `isOnline` is `true`. With no criterion matched, [`MonitorResource.ts:1017`](Common/Server/Utils/Monitor/MonitorResource.ts:1017) only writes a status-timeline row if the monitor is not *already* at its default status. A fresh monitor is. So the check ran every interval and recorded nothing.

`grep -c "SSL Certificate Monitor"` returned 0 because that string never existed in the SSL code path — `SslMonitor` logged only `"Pinging host: …"` at debug level, while `WebsiteMonitor` logs `"Website Monitor - Pinging …"`. The grep could not have detected the check either way.

## Root cause

The probe had no way to express *"this certificate failed validation"*.

`getSslMonitorResponse` attempted a strict TLS handshake and, on **any** failure, fell into a bare `catch {}` that discarded the error, retried with `rejectUnauthorized: false`, and set `isSelfSigned = true`. Untrusted CA, expired, hostname mismatch, and incomplete chain all collapsed into the same response, and `SslMonitorResponse` had no field that could say otherwise. `IsValidCertificate` and `IsNotAValidCertificate` each reconstructed the verdict from `!isSelfSigned` **independently**, so both evaluated false whenever `expiresAt` was missing or unparseable — a state where nothing matches and nothing is recorded.

Separately, the check could hang forever: `SSLMonitorOptions.timeout` was declared and passed in by `Monitor.ts` but never read, and `getCertificate`'s `https.get` registered no deadline of any kind. A peer that completes TCP and then goes silent left the promise unsettled — *before* the ingest POST, so no result was ever reported, on every cycle.

## Changes

**Certificate verdict** — `isValidCertificate`, `certificateValidationError`, `certificateValidationErrorCode` and `issuer` are recorded explicitly from the strict attempt. `isSelfSigned` is now set only for `DEPTH_ZERO_SELF_SIGNED_CERT` / `SELF_SIGNED_CERT_IN_CHAIN`, or when the leaf issued itself. A strict failure whose code is not a TLS validation code is treated as a connection failure rather than a certificate verdict.

**Criteria** — `IsNotAValidCertificate` is derived as the exact complement of `IsValidCertificate`, making "neither matches" unreachable, and the criterion's reason now names the underlying TLS error so it reaches whoever is paged. Responses from older probes keep the previous heuristic, so upgrading does not flip healthy monitors to Down.

**Timeout** — threaded end to end, set on the request, and backed by a `Promise.race` deadline that destroys the captured socket (`req.destroy()` alone closes nothing while a TLS handshake is still pending — the socket-leak test caught this). A timed-out check now reports `isOnline: false`; it previously reported `true`.

**Also fixed, all from the same investigation:**
- SSL results carry `responseTimeInMs`, and `SSLCertificate` is registered in `getMonitorMetricTypesByMonitorType` — the type was missing, so the Monitor Metrics tab did not render *at all*, even though `IsOnline` rows were being written on every check. Probeable types now default to `[IsOnline, ResponseTime]` instead of falling through to `[]`, with a new invariant test that fails if any probeable type has no metrics.
- `MonitorStep.fromJSON` normalizes `dnssecMonitor` like its neighbours. An API- or template-authored config without `resolvers` made the DNSSEC probe throw before posting anything — the same silent-failure class the reporter noted for DNSSEC.
- A throw from any monitor-type handler becomes a reportable offline result instead of escaping to `Promise.allSettled` and vanishing.
- Log lines are prefixed `SSL Certificate Monitor` and failures log at error level.
- `Hostname.fromAuthority` splits an authority into host and port (IPv6 and userinfo included). `URL.fromString` leaves the port glued to the host, so an SSL monitor on a non-443 port tried to resolve a host literally named `example.com:8443`. **Scoped deliberately:** the SSL probe uses the new helper; `URL.fromString` itself is left alone because its consumers include `SSRFProtection` and `EgressGuard`, and changing what `.hostname` means there deserves its own change with a security review.
- A step with no destination reports a definite failure rather than a result with `isOnline` undefined.

## Tests

New `SslMonitor` suites drive **real local TLS servers** with openssl-generated fixtures covering self-signed, hostname-mismatch, untrusted-CA and expired chains, plus accept-then-stall peers for the timeout and socket-leak paths. **The timeout suite fails on the previous code by hanging.** The criteria suite adds all five failure modes, legacy-payload compatibility, and the over-the-wire ISO-string shape of `expiresAt`.

- Probe: **452 passed**, 22 suites
- Common: **112 passed** across the four touched suites; **2699 passed** in a broader `Tests/Types` + `Tests/Utils/Monitor` + `Tests/Server/Utils/Monitor` sweep

Both `Common` and `Probe` typecheck clean, and changed files are prettier-formatted. In the broad Common sweep, 10 suites fail to *load* on my machine with `dlopen … isolated-vm`, a native-module ABI mismatch unrelated to this change; every test that ran passed.

## Not included

Two verified defects found during the investigation are deliberately left out, since neither explains #3225 and both deserve separate review:

1. **`MonitorResource.ts:1026`** — the no-criteria-met branch is gated on the monitor not already being at its default status, so incidents opened by a `changeMonitorStatus: false` criterion can never auto-resolve. Hoisting the two resolution passes adds a query per steady-state evaluation on the hottest Postgres path.
2. **`URL.fromString`** — the authority/port bug above, in the general case.