### PR TITLE
fix: add missing @EnableDocumentation() to StatusPageOidc model

### DIFF
--- a/Common/Models/DatabaseModels/StatusPageOidc.ts
+++ b/Common/Models/DatabaseModels/StatusPageOidc.ts
@@ -14,6 +14,7 @@ import CanAccessIfCanReadOn from "../../Types/Database/CanAccessIfCanReadOn";
 import ColumnLength from "../../Types/Database/ColumnLength";
 import ColumnType from "../../Types/Database/ColumnType";
 import CrudApiEndpoint from "../../Types/Database/CrudApiEndpoint";
+import EnableDocumentation from "../../Types/Database/EnableDocumentation";
 import TableColumn from "../../Types/Database/TableColumn";
 import TableColumnType from "../../Types/Database/TableColumnType";
 import TableMetadata from "../../Types/Database/TableMetadata";
@@ -24,6 +25,7 @@ import ObjectID from "../../Types/ObjectID";
 import Permission from "../../Types/Permission";
 import { Column, Entity, Index, JoinColumn, ManyToOne } from "typeorm";
 
+@EnableDocumentation()
 @CanAccessIfCanReadOn("statusPage")
 @TableEditionAccessControl({
   requiresEnterprise: true,


### PR DESCRIPTION
`StatusPageOidc.ts` lacked the `@EnableDocumentation()` decorator that the structurally identical `StatusPageSso.ts` has. Since the Terraform provider is auto-generated from the OpenAPI spec, and models without this decorator are skipped by the generator, this meant `oneuptime_status_page_sso` existed as a Terraform resource but `oneuptime_status_page_oidc` did not, even though the OIDC-based Status Page SSO feature is fully functional via the UI/API.

### Title of this pull request?

fix: add missing `@EnableDocumentation()` to `StatusPageOidc` model

### Small Description?

Adds the missing `@EnableDocumentation()` decorator (and its import) to `StatusPageOidc.ts`, matching the pattern already used in `StatusPageSso.ts`, so the model is included in the OpenAPI spec and the `oneuptime_status_page_oidc` Terraform resource is generated.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [ ] Did you write tests where appropriate?

### Related Issue?

closes #3234

### Screenshots (if appropriate):

N/A — single-line decorator addition, no UI change.