### PR TITLE
fix(monitor): stop SSL Certificate monitors from silently never reporting

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/CriteriaFilters.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/CriteriaFilters.tsx
@@ -1,4 +1,5 @@
 import CriteriaFilterElement from "./CriteriaFilter";
+import CriteriaFilterUiUtil from "../../../Utils/Form/Monitor/CriteriaFilter";
 import IconProp from "Common/Types/Icon/IconProp";
 import {
   CheckOn,
@@ -14,6 +15,7 @@ import Button, {
   ButtonStyleType,
 } from "Common/UI/Components/Button/Button";
 import ConfirmModal from "Common/UI/Components/Modal/ConfirmModal";
+import { DropdownOption } from "Common/UI/Components/Dropdown/Dropdown";
 import React, { FunctionComponent, ReactElement } from "react";
 
 export interface ComponentProps {
@@ -122,6 +124,25 @@ const CriteriaFilters: FunctionComponent<ComponentProps> = (
               props.monitorType === MonitorType.Kubernetes ||
               props.monitorType === MonitorType.Metrics;
 
+            /*
+             * Seed with a check this monitor type actually supports. This used
+             * to hard-code CheckOn.IsOnline with FilterType.EqualTo for every
+             * non-metric type. On SSL Certificate and DNSSEC neither value was
+             * in the type's dropdown, so both selects rendered blank over a
+             * live value - a user who touched only the second select ended up
+             * saving a filter they never knowingly chose, and on DNSSEC no
+             * evaluator read it at all, so the criteria could never fire.
+             *
+             * filterType is intentionally left undefined rather than
+             * defaulted: EqualTo is invalid for most boolean checks, and an
+             * empty required select is a visible prompt where a wrong
+             * prefilled one is not.
+             */
+            const checkOnOptions: Array<DropdownOption> =
+              CriteriaFilterUiUtil.getCheckOnOptionsByMonitorType(
+                props.monitorType,
+              );
+
             newCriteriaFilters.push(
               isMetricOnly
                 ? {
@@ -133,8 +154,9 @@ const CriteriaFilters: FunctionComponent<ComponentProps> = (
                     },
                   }
                 : {
-                    checkOn: CheckOn.IsOnline,
-                    filterType: FilterType.EqualTo,
+                    checkOn:
+                      (checkOnOptions[0]?.value as CheckOn) || CheckOn.IsOnline,
+                    filterType: undefined,
                     value: "",
                   },
             );

--- a/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorCriteria.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/Form/Monitor/MonitorCriteria.tsx
@@ -399,7 +399,16 @@ const MonitorCriteriaElement: FunctionComponent<ComponentProps> = (
             const newMonitorCriterias: Array<MonitorCriteriaInstance> = [
               ...(monitorCriteria.data?.monitorCriteriaInstanceArray || []),
             ];
-            newMonitorCriterias.push(new MonitorCriteriaInstance());
+            /*
+             * Seeded with a filter this monitor type supports - the bare
+             * constructor always seeded IsOnline, which SSL Certificate and
+             * DNSSEC monitors do not offer in their dropdown.
+             */
+            newMonitorCriterias.push(
+              MonitorCriteriaInstance.getEmptyCriteriaInstance(
+                props.monitorType,
+              ),
+            );
             props.onChange?.(
               MonitorCriteria.fromJSON({
                 _type: "MonitorCriteria",

--- a/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter.ts
@@ -194,15 +194,23 @@ export default class CriteriaFilterUtil {
     let options: Array<DropdownOption> =
       DropdownUtil.getDropdownOptionsFromEnum(CheckOn);
 
-    if (monitorType === MonitorType.Ping || monitorType === MonitorType.IP) {
-      options = options.filter((i: DropdownOption) => {
-        return (
-          i.value === CheckOn.IsOnline ||
-          i.value === CheckOn.ResponseTime ||
-          i.value === CheckOn.PacketLossPercent ||
-          i.value === CheckOn.Jitter ||
-          i.value === CheckOn.IsRequestTimeout
-        );
+    /*
+     * Audited types read their list from Common so the dropdown and the
+     * save-time validation in MonitorCriteriaInstance cannot drift apart
+     * again. They had: SSL Certificate and DNSSEC monitors offered no way to
+     * pick the reachability checks their evaluators do read, so a filter
+     * seeded with one rendered as a blank select over a live value. Types that
+     * return undefined keep their bespoke filtering below until audited.
+     *
+     * Returning early is safe only because none of the audited types does
+     * post-filter processing (unlike Port, which relabels Response Time).
+     */
+    const supportedCheckOns: Array<CheckOn> | undefined =
+      CommonCriteriaFilterUtil.getSupportedCheckOns(monitorType);
+
+    if (supportedCheckOns) {
+      return options.filter((i: DropdownOption) => {
+        return supportedCheckOns.includes(i.value as CheckOn);
       });
     }
 
@@ -266,19 +274,6 @@ export default class CriteriaFilterUtil {
           i.value === CheckOn.ExecutionTime ||
           i.value === CheckOn.BrowserType ||
           i.value === CheckOn.ScreenSizeType
-        );
-      });
-    }
-
-    if (monitorType === MonitorType.SSLCertificate) {
-      options = options.filter((i: DropdownOption) => {
-        return (
-          i.value === CheckOn.IsValidCertificate ||
-          i.value === CheckOn.IsSelfSignedCertificate ||
-          i.value === CheckOn.IsExpiredCertificate ||
-          i.value === CheckOn.IsNotAValidCertificate ||
-          i.value === CheckOn.ExpiresInDays ||
-          i.value === CheckOn.ExpiresInHours
         );
       });
     }
@@ -390,19 +385,6 @@ export default class CriteriaFilterUtil {
           i.value === CheckOn.DomainNameServer ||
           i.value === CheckOn.DomainStatusCode ||
           i.value === CheckOn.DomainIsExpired
-        );
-      });
-    }
-
-    if (monitorType === MonitorType.DNSSEC) {
-      options = options.filter((i: DropdownOption) => {
-        return (
-          i.value === CheckOn.DnssecChainValid ||
-          i.value === CheckOn.DnssecDnskeyExists ||
-          i.value === CheckOn.DnssecDsExists ||
-          i.value === CheckOn.DnssecResolverConsensus ||
-          i.value === CheckOn.DnssecNameserverConsistent ||
-          i.value === CheckOn.DnssecSignatureExpiresInDays
         );
       });
     }

--- a/Common/Server/Utils/Monitor/Criteria/DnssecMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/DnssecMonitorCriteria.ts
@@ -21,6 +21,39 @@ export default class DnssecMonitorCriteria {
     const dnssecResponse: DnssecMonitorResponse | undefined =
       dataToProcess.dnssecResponse;
 
+    /*
+     * Reachability is read straight off the probe response and is meaningful
+     * even when the DNSSEC query produced no result at all, so these are
+     * answered before the dnssecResponse guard below.
+     *
+     * They were missing entirely, which made an "Is Online" filter on a DNSSEC
+     * monitor silently inert - it could never match in either direction, and a
+     * criteria that never matches leaves the monitor parked at its default
+     * status with no timeline event and no error. The dashboard's "Add Filter"
+     * button seeded exactly that filter.
+     */
+    if (input.criteriaFilter.checkOn === CheckOn.IsOnline) {
+      if (dataToProcess.isOnline === undefined) {
+        return null;
+      }
+
+      return CompareCriteria.compareCriteriaBoolean({
+        value: dataToProcess.isOnline,
+        criteriaFilter: input.criteriaFilter,
+      });
+    }
+
+    if (input.criteriaFilter.checkOn === CheckOn.IsRequestTimeout) {
+      if (dataToProcess.isTimeout === undefined) {
+        return null;
+      }
+
+      return CompareCriteria.compareCriteriaBoolean({
+        value: dataToProcess.isTimeout,
+        criteriaFilter: input.criteriaFilter,
+      });
+    }
+
     if (!dnssecResponse) {
       return null;
     }

--- a/Common/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.ts
@@ -105,6 +105,20 @@ export default class ServerMonitorCriteria {
     }
 
     if (input.criteriaFilter.checkOn === CheckOn.IsSelfSignedCertificate) {
+      /*
+       * With no certificate in hand there is no answer to give. The probe
+       * still populates sslResponse on an unreachable host (with nothing but
+       * a failureCause in it), so this used to return "SSL Certificate is not
+       * self signed." for an endpoint that was down - turning an outage into
+       * a green check for anyone using this filter in their Operational
+       * criteria. Absence of evidence is not evidence of absence: return null
+       * (indeterminate) and let the criteria that do test reachability
+       * decide. IsValidCertificate already gates on exactly this pair.
+       */
+      if (!sslResponse || !dataToProcess.isOnline) {
+        return null;
+      }
+
       const isSelfSigned: boolean = Boolean(
         sslResponse && sslResponse.isSelfSigned,
       );
@@ -124,6 +138,17 @@ export default class ServerMonitorCriteria {
     }
 
     if (input.criteriaFilter.checkOn === CheckOn.IsExpiredCertificate) {
+      /*
+       * Same reasoning as IsSelfSignedCertificate above - "not expired" was
+       * reported for hosts the probe could not reach at all. Gated on
+       * isOnline and deliberately not on expiresAt: a reachable host whose
+       * certificate carries no parsable expiry is still legitimately "not
+       * expired".
+       */
+      if (!sslResponse || !dataToProcess.isOnline) {
+        return null;
+      }
+
       const isExpired: boolean = Boolean(
         sslResponse &&
           sslResponse.expiresAt &&

--- a/Common/Tests/App/Dashboard/MonitorCriteriaFilterDropdownParity.test.ts
+++ b/Common/Tests/App/Dashboard/MonitorCriteriaFilterDropdownParity.test.ts
@@ -1,0 +1,162 @@
+import CriteriaFilterUiUtil from "../../../../App/FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter";
+import {
+  CheckOn,
+  CriteriaFilterUtil,
+} from "../../../Types/Monitor/CriteriaFilter";
+import MonitorCriteriaInstance from "../../../Types/Monitor/MonitorCriteriaInstance";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import { DropdownOption } from "../../../UI/Components/Dropdown/Dropdown";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Issue #3225. Which checks the dashboard offers and which checks are legal to
+ * save used to be two separately maintained lists, and they had drifted: an SSL
+ * Certificate monitor could carry an "Is Online" filter that its dropdown would
+ * not render (blank select over a live value), while a DNSSEC monitor could
+ * carry one that no evaluator read at all. Both produce a criteria that can
+ * never match, and a criteria set where nothing matches is silent - the monitor
+ * stays parked at its default status with no timeline event and no error.
+ *
+ * Both sides now read CriteriaFilterUtil.getSupportedCheckOns. These tests hold
+ * them together.
+ */
+
+function values(options: Array<DropdownOption>): Array<CheckOn> {
+  return options.map((option: DropdownOption) => {
+    return option.value as CheckOn;
+  });
+}
+
+const AUDITED_TYPES: Array<MonitorType> = [
+  MonitorType.SSLCertificate,
+  MonitorType.DNSSEC,
+  MonitorType.Ping,
+  MonitorType.IP,
+];
+
+describe("monitor criteria dropdown / validation parity", () => {
+  test.each(AUDITED_TYPES)(
+    "the %s dropdown offers exactly the supported checks",
+    (monitorType: MonitorType) => {
+      const supported: Array<CheckOn> | undefined =
+        CriteriaFilterUtil.getSupportedCheckOns(monitorType);
+
+      expect(supported).toBeDefined();
+      expect(
+        values(
+          CriteriaFilterUiUtil.getCheckOnOptionsByMonitorType(monitorType),
+        ).sort(),
+      ).toEqual([...supported!].sort());
+    },
+  );
+
+  test.each(AUDITED_TYPES)(
+    "every check the %s dropdown offers passes save-time validation",
+    (monitorType: MonitorType) => {
+      for (const option of CriteriaFilterUiUtil.getCheckOnOptionsByMonitorType(
+        monitorType,
+      )) {
+        const instance: MonitorCriteriaInstance =
+          MonitorCriteriaInstance.getEmptyCriteriaInstance(monitorType);
+
+        instance.data!.filters[0]!.checkOn = option.value as CheckOn;
+
+        const error: string | null = MonitorCriteriaInstance.getValidationError(
+          instance,
+          monitorType,
+        );
+
+        expect(error).not.toContain("cannot have filter type");
+      }
+    },
+  );
+
+  test("SSL Certificate monitors can now pick the reachability checks", () => {
+    const offered: Array<CheckOn> = values(
+      CriteriaFilterUiUtil.getCheckOnOptionsByMonitorType(
+        MonitorType.SSLCertificate,
+      ),
+    );
+
+    expect(offered).toContain(CheckOn.IsOnline);
+    expect(offered).toContain(CheckOn.IsRequestTimeout);
+  });
+
+  test("DNSSEC monitors can now pick the reachability checks", () => {
+    const offered: Array<CheckOn> = values(
+      CriteriaFilterUiUtil.getCheckOnOptionsByMonitorType(MonitorType.DNSSEC),
+    );
+
+    expect(offered).toContain(CheckOn.IsOnline);
+    expect(offered).toContain(CheckOn.IsRequestTimeout);
+  });
+
+  test("SSL Certificate monitors still offer every certificate check", () => {
+    expect(
+      values(
+        CriteriaFilterUiUtil.getCheckOnOptionsByMonitorType(
+          MonitorType.SSLCertificate,
+        ),
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        CheckOn.IsValidCertificate,
+        CheckOn.IsSelfSignedCertificate,
+        CheckOn.IsExpiredCertificate,
+        CheckOn.IsNotAValidCertificate,
+        CheckOn.ExpiresInDays,
+        CheckOn.ExpiresInHours,
+      ]),
+    );
+  });
+
+  test("SSL Certificate monitors are not offered unrelated HTTP checks", () => {
+    const offered: Array<CheckOn> = values(
+      CriteriaFilterUiUtil.getCheckOnOptionsByMonitorType(
+        MonitorType.SSLCertificate,
+      ),
+    );
+
+    expect(offered).not.toContain(CheckOn.ResponseStatusCode);
+    expect(offered).not.toContain(CheckOn.ResponseBody);
+  });
+
+  /*
+   * Port relabels Response Time after filtering, so it must keep going through
+   * the bespoke path rather than the shared early return.
+   */
+  test("an unaudited type keeps its bespoke dropdown handling", () => {
+    expect(
+      CriteriaFilterUtil.getSupportedCheckOns(MonitorType.Port),
+    ).toBeUndefined();
+
+    const responseTimeOption: DropdownOption | undefined =
+      CriteriaFilterUiUtil.getCheckOnOptionsByMonitorType(
+        MonitorType.Port,
+      ).find((option: DropdownOption) => {
+        return option.value === CheckOn.ResponseTime;
+      });
+
+    expect(responseTimeOption?.label).toBe(
+      "Total Connection Time (DNS + TCP) (in ms)",
+    );
+  });
+
+  /*
+   * The dashboard's "Add Criteria" button seeds from this, so it has to land on
+   * something the dropdown can render.
+   */
+  test.each(AUDITED_TYPES)(
+    "the seeded criteria for %s uses a check its dropdown offers",
+    (monitorType: MonitorType) => {
+      const instance: MonitorCriteriaInstance =
+        MonitorCriteriaInstance.getEmptyCriteriaInstance(monitorType);
+
+      expect(
+        values(
+          CriteriaFilterUiUtil.getCheckOnOptionsByMonitorType(monitorType),
+        ),
+      ).toContain(instance.data!.filters[0]!.checkOn);
+    },
+  );
+});

--- a/Common/Tests/Server/Utils/Monitor/Criteria/DnssecMonitorCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/DnssecMonitorCriteria.test.ts
@@ -304,4 +304,171 @@ describe("DnssecMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
 
     expect(result).toBeNull();
   });
+
+  /*
+   * These were missing entirely, so an "Is Online" filter on a DNSSEC monitor
+   * could never match in either direction. A criteria that never matches is
+   * silent at runtime - the monitor just stays parked at its default status -
+   * and the dashboard's "Add Filter" button seeded exactly that filter, since
+   * IsOnline was its hardcoded default for every non-metric monitor type.
+   */
+  describe("reachability checks", () => {
+    function evaluateWith(input: {
+      isOnline?: boolean | undefined;
+      isTimeout?: boolean | undefined;
+      dnssecResponse?: DnssecMonitorResponse | undefined;
+      criteriaFilter: CriteriaFilter;
+    }): Promise<string | null> {
+      return DnssecMonitorCriteria.isMonitorInstanceCriteriaFilterMet({
+        dataToProcess: {
+          projectId: ObjectID.generate(),
+          monitorId: ObjectID.generate(),
+          monitorStepId: ObjectID.generate(),
+          probeId: ObjectID.generate(),
+          failureCause: "",
+          isOnline: input.isOnline,
+          isTimeout: input.isTimeout,
+          responseTimeInMs: 10,
+          dnssecResponse: input.dnssecResponse,
+          monitoredAt: new Date(),
+        },
+        criteriaFilter: input.criteriaFilter,
+      });
+    }
+
+    test("IsOnline online + True → met", async () => {
+      await expect(
+        evaluateWith({
+          isOnline: true,
+          dnssecResponse: buildDnssecResponse({}),
+          criteriaFilter: {
+            checkOn: CheckOn.IsOnline,
+            filterType: FilterType.True,
+            value: undefined,
+          },
+        }),
+      ).resolves.toBeTruthy();
+    });
+
+    test("IsOnline online + False → not met", async () => {
+      await expect(
+        evaluateWith({
+          isOnline: true,
+          dnssecResponse: buildDnssecResponse({}),
+          criteriaFilter: {
+            checkOn: CheckOn.IsOnline,
+            filterType: FilterType.False,
+            value: undefined,
+          },
+        }),
+      ).resolves.toBeNull();
+    });
+
+    test("IsOnline offline + False → met", async () => {
+      await expect(
+        evaluateWith({
+          isOnline: false,
+          dnssecResponse: buildDnssecResponse({ isOnline: false }),
+          criteriaFilter: {
+            checkOn: CheckOn.IsOnline,
+            filterType: FilterType.False,
+            value: undefined,
+          },
+        }),
+      ).resolves.toBeTruthy();
+    });
+
+    /*
+     * The whole point of answering these before the dnssecResponse guard: a
+     * DNSSEC query that produced no result at all is exactly when the user
+     * most needs "is this thing reachable" to fire.
+     */
+    test("IsOnline is answered even when the DNSSEC query produced no response", async () => {
+      await expect(
+        evaluateWith({
+          isOnline: false,
+          dnssecResponse: undefined,
+          criteriaFilter: {
+            checkOn: CheckOn.IsOnline,
+            filterType: FilterType.False,
+            value: undefined,
+          },
+        }),
+      ).resolves.toBeTruthy();
+    });
+
+    test("IsOnline is indeterminate when the probe reported no reachability at all", async () => {
+      await expect(
+        evaluateWith({
+          isOnline: undefined,
+          dnssecResponse: undefined,
+          criteriaFilter: {
+            checkOn: CheckOn.IsOnline,
+            filterType: FilterType.False,
+            value: undefined,
+          },
+        }),
+      ).resolves.toBeNull();
+    });
+
+    test("IsRequestTimeout timed out + True → met", async () => {
+      await expect(
+        evaluateWith({
+          isOnline: false,
+          isTimeout: true,
+          dnssecResponse: undefined,
+          criteriaFilter: {
+            checkOn: CheckOn.IsRequestTimeout,
+            filterType: FilterType.True,
+            value: undefined,
+          },
+        }),
+      ).resolves.toBeTruthy();
+    });
+
+    test("IsRequestTimeout did not time out + False → met", async () => {
+      await expect(
+        evaluateWith({
+          isOnline: true,
+          isTimeout: false,
+          dnssecResponse: buildDnssecResponse({}),
+          criteriaFilter: {
+            checkOn: CheckOn.IsRequestTimeout,
+            filterType: FilterType.False,
+            value: undefined,
+          },
+        }),
+      ).resolves.toBeTruthy();
+    });
+
+    test("IsRequestTimeout is indeterminate when the probe reported nothing", async () => {
+      await expect(
+        evaluateWith({
+          isOnline: false,
+          isTimeout: undefined,
+          dnssecResponse: undefined,
+          criteriaFilter: {
+            checkOn: CheckOn.IsRequestTimeout,
+            filterType: FilterType.False,
+            value: undefined,
+          },
+        }),
+      ).resolves.toBeNull();
+    });
+
+    // Guards the ordering: the new block must not swallow the DNSSEC checks.
+    test("the DNSSEC checks still return null when there is no response", async () => {
+      await expect(
+        evaluateWith({
+          isOnline: false,
+          dnssecResponse: undefined,
+          criteriaFilter: {
+            checkOn: CheckOn.DnssecChainValid,
+            filterType: FilterType.False,
+            value: undefined,
+          },
+        }),
+      ).resolves.toBeNull();
+    });
+  });
 });

--- a/Common/Tests/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/SSLMonitorCriteria.test.ts
@@ -465,4 +465,234 @@ describe("SSLMonitorCriteria.isMonitorInstanceCriteriaFilterMet", () => {
 
     expect(result).toBeNull();
   });
+
+  /*
+   * A probe that could not reach the host at all still ships an sslResponse -
+   * the probe fills it from the offline result object - so it is truthy but
+   * carries no certificate. IsSelfSignedCertificate and IsExpiredCertificate
+   * used to answer "not self signed" / "not expired" from that, which turned an
+   * outage into a green check for anyone using either in their Operational
+   * criteria. Both now gate on reachability the way IsValidCertificate always
+   * has.
+   */
+  describe("an unreachable host cannot produce a green certificate check", () => {
+    const offlineWithEmptySslResponse: () => ProbeMonitorResponse = () => {
+      return buildDataToProcess({
+        isOnline: false,
+        sslResponse: {},
+      });
+    };
+
+    test("IsSelfSignedCertificate + False → indeterminate, not met", async () => {
+      const result: string | null = await evaluate(
+        offlineWithEmptySslResponse(),
+        {
+          checkOn: CheckOn.IsSelfSignedCertificate,
+          filterType: FilterType.False,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test("IsSelfSignedCertificate + True → indeterminate", async () => {
+      const result: string | null = await evaluate(
+        offlineWithEmptySslResponse(),
+        {
+          checkOn: CheckOn.IsSelfSignedCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test("IsExpiredCertificate + False → indeterminate, not met", async () => {
+      const result: string | null = await evaluate(
+        offlineWithEmptySslResponse(),
+        {
+          checkOn: CheckOn.IsExpiredCertificate,
+          filterType: FilterType.False,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test("IsExpiredCertificate + True → indeterminate", async () => {
+      const result: string | null = await evaluate(
+        offlineWithEmptySslResponse(),
+        {
+          checkOn: CheckOn.IsExpiredCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test("no sslResponse at all + False → indeterminate", async () => {
+      const dataToProcess: ProbeMonitorResponse = buildDataToProcess({
+        isOnline: false,
+        includeSslResponse: false,
+      });
+
+      await expect(
+        evaluate(dataToProcess, {
+          checkOn: CheckOn.IsSelfSignedCertificate,
+          filterType: FilterType.False,
+          value: undefined,
+        }),
+      ).resolves.toBeNull();
+
+      await expect(
+        evaluate(dataToProcess, {
+          checkOn: CheckOn.IsExpiredCertificate,
+          filterType: FilterType.False,
+          value: undefined,
+        }),
+      ).resolves.toBeNull();
+    });
+
+    /*
+     * The reachability checks still answer - they are the ones that are
+     * supposed to notice a dead host.
+     */
+    test("IsOnline + False still reports the host as down", async () => {
+      const result: string | null = await evaluate(
+        offlineWithEmptySslResponse(),
+        {
+          checkOn: CheckOn.IsOnline,
+          filterType: FilterType.False,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBeTruthy();
+    });
+
+    test("IsNotAValidCertificate + True still fires", async () => {
+      const result: string | null = await evaluate(
+        offlineWithEmptySslResponse(),
+        {
+          checkOn: CheckOn.IsNotAValidCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      );
+
+      expect(result).toBe("SSL certificate is not valid.");
+    });
+  });
+
+  /*
+   * Issue #3225. The reporter's monitor pointed at self-signed.badssl.com,
+   * which the probe reports as reachable (a certificate was obtained) but
+   * untrusted. Their two criteria were "Is Valid Certificate = True" for
+   * Operational and "Is Online = False" for Down - and NEITHER can match that
+   * response. A criteria set where nothing matches is completely silent: the
+   * monitor stays parked at its default status with no timeline event and no
+   * incident, which reads in the dashboard exactly like a monitor that never
+   * ran at all.
+   */
+  describe("issue #3225 - a self-signed host under the reporter's criteria", () => {
+    const selfSignedButReachable: () => ProbeMonitorResponse = () => {
+      return buildDataToProcess({
+        isOnline: true,
+        sslResponse: {
+          isSelfSigned: true,
+          expiresAt: dateFromNow({ days: 365 }),
+        },
+      });
+    };
+
+    test("IsValidCertificate = True does not match", async () => {
+      const result: string | null = await evaluate(selfSignedButReachable(), {
+        checkOn: CheckOn.IsValidCertificate,
+        filterType: FilterType.True,
+        value: undefined,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    test("IsOnline = False does not match", async () => {
+      const result: string | null = await evaluate(selfSignedButReachable(), {
+        checkOn: CheckOn.IsOnline,
+        filterType: FilterType.False,
+        value: undefined,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    /*
+     * The criteria the product ships by default DOES catch this host, which is
+     * why the stock configuration was never affected. Pinning it makes sure the
+     * default keeps working.
+     */
+    test("the shipped default offline criteria (IsNotAValidCertificate = True) does match", async () => {
+      const result: string | null = await evaluate(selfSignedButReachable(), {
+        checkOn: CheckOn.IsNotAValidCertificate,
+        filterType: FilterType.True,
+        value: undefined,
+      });
+
+      expect(result).toBe("SSL certificate is not valid.");
+    });
+
+    test("IsSelfSignedCertificate = True also catches it", async () => {
+      const result: string | null = await evaluate(selfSignedButReachable(), {
+        checkOn: CheckOn.IsSelfSignedCertificate,
+        filterType: FilterType.True,
+        value: undefined,
+      });
+
+      expect(result).toBe("SSL Certificate is self signed.");
+    });
+  });
+
+  /*
+   * A handshake that never completed is not a reachable endpoint. The probe
+   * used to report isOnline: true alongside isTimeout: true on that path, which
+   * would have kept an "Is Online = True" criteria matching forever against a
+   * host that had stopped answering.
+   */
+  describe("a timed-out check", () => {
+    test("is reported as offline and timed out", async () => {
+      const timedOut: ProbeMonitorResponse = buildDataToProcess({
+        isOnline: false,
+        isTimeout: true,
+        sslResponse: {},
+      });
+
+      await expect(
+        evaluate(timedOut, {
+          checkOn: CheckOn.IsRequestTimeout,
+          filterType: FilterType.True,
+          value: undefined,
+        }),
+      ).resolves.toBeTruthy();
+
+      await expect(
+        evaluate(timedOut, {
+          checkOn: CheckOn.IsOnline,
+          filterType: FilterType.False,
+          value: undefined,
+        }),
+      ).resolves.toBeTruthy();
+
+      await expect(
+        evaluate(timedOut, {
+          checkOn: CheckOn.IsOnline,
+          filterType: FilterType.True,
+          value: undefined,
+        }),
+      ).resolves.toBeNull();
+    });
+  });
 });

--- a/Common/Tests/Types/Monitor/CriteriaFilterSupportedCheckOns.test.ts
+++ b/Common/Tests/Types/Monitor/CriteriaFilterSupportedCheckOns.test.ts
@@ -1,0 +1,296 @@
+import {
+  CheckOn,
+  CriteriaFilter,
+  CriteriaFilterUtil,
+  FilterType,
+} from "../../../Types/Monitor/CriteriaFilter";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ProbeMonitorResponse from "../../../Types/Probe/ProbeMonitorResponse";
+import ObjectID from "../../../Types/ObjectID";
+import SSLMonitorCriteria from "../../../Server/Utils/Monitor/Criteria/SSLMonitorCriteria";
+import DnssecMonitorCriteria from "../../../Server/Utils/Monitor/Criteria/DnssecMonitorCriteria";
+import APIRequestCriteria from "../../../Server/Utils/Monitor/Criteria/APIRequestCriteria";
+
+/*
+ * Issue #3225. A criteria whose checkOn the monitor type's evaluator never
+ * reads cannot match in either direction, and "nothing matched" is silent at
+ * runtime: the monitor stays parked at its default status with no timeline
+ * event, no incident and no error - indistinguishable in the dashboard from a
+ * monitor that never ran at all.
+ *
+ * getSupportedCheckOns is the single list the dropdown and the save-time
+ * validation both read. These tests hold it to its promise: everything on it
+ * has to be a check the type's evaluator actually answers.
+ */
+
+type EvaluatorFunction = (input: {
+  dataToProcess: ProbeMonitorResponse;
+  criteriaFilter: CriteriaFilter;
+}) => Promise<string | null>;
+
+function baseProbeResponse(): ProbeMonitorResponse {
+  return {
+    projectId: ObjectID.generate(),
+    monitorId: ObjectID.generate(),
+    monitorStepId: ObjectID.generate(),
+    probeId: ObjectID.generate(),
+    failureCause: "",
+    isOnline: true,
+    isTimeout: false,
+    responseTimeInMs: 42,
+    monitoredAt: new Date(),
+  };
+}
+
+function sslProbeResponse(): ProbeMonitorResponse {
+  return {
+    ...baseProbeResponse(),
+    sslResponse: {
+      isSelfSigned: false,
+      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+      createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+      commonName: "example.com",
+    },
+  };
+}
+
+function dnssecProbeResponse(): ProbeMonitorResponse {
+  return {
+    ...baseProbeResponse(),
+    dnssecResponse: {
+      isOnline: true,
+      responseTimeInMs: 10,
+      failureCause: "",
+      domainName: "cloudflare.com",
+      isZoneSigned: true,
+      dnskeys: [{ flags: 257, algorithm: 13, keyTag: 2371 }],
+      parentDsRecords: [],
+      isParentDsPresent: true,
+      rrsigs: [
+        {
+          typeCovered: "DNSKEY",
+          algorithm: 13,
+          keyTag: 2371,
+          signerName: "cloudflare.com",
+          inception: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+          expiration: new Date(
+            Date.now() + 10 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+        },
+      ],
+      daysUntilSignatureExpiry: 10,
+      resolverChecks: [],
+      resolverConsensusAd: true,
+      nameserverChecks: [],
+      isNameserverConsistent: true,
+      isChainValid: true,
+    },
+  };
+}
+
+function pingProbeResponse(): ProbeMonitorResponse {
+  return {
+    ...baseProbeResponse(),
+    pingResponse: {
+      packetsSent: 4,
+      packetsReceived: 4,
+      packetLossPercent: 0,
+      jitterInMs: 3,
+    },
+  };
+}
+
+/*
+ * A numeric threshold for the checks that compare against one, so a "no
+ * threshold means null" guard does not read as "this check is never answered".
+ */
+const NUMERIC_THRESHOLDS: Partial<Record<CheckOn, number>> = {
+  [CheckOn.ResponseTime]: 1000,
+  [CheckOn.PacketLossPercent]: 50,
+  [CheckOn.Jitter]: 1000,
+  [CheckOn.ExpiresInDays]: 1,
+  [CheckOn.ExpiresInHours]: 1,
+  [CheckOn.DnssecSignatureExpiresInDays]: 1,
+};
+
+/*
+ * Every filterType a boolean or numeric check might answer to. A check that
+ * returns null for all of them, on a fully populated response, is a check the
+ * evaluator does not implement.
+ */
+const FILTER_TYPES: Array<FilterType> = [
+  FilterType.True,
+  FilterType.False,
+  FilterType.GreaterThan,
+  FilterType.LessThan,
+  FilterType.GreaterThanOrEqualTo,
+  FilterType.LessThanOrEqualTo,
+  FilterType.EqualTo,
+  FilterType.NotEqualTo,
+];
+
+async function isCheckOnAnswered(
+  evaluator: EvaluatorFunction,
+  dataToProcess: ProbeMonitorResponse,
+  checkOn: CheckOn,
+): Promise<boolean> {
+  for (const filterType of FILTER_TYPES) {
+    const result: string | null = await evaluator({
+      dataToProcess: dataToProcess,
+      criteriaFilter: {
+        checkOn: checkOn,
+        filterType: filterType,
+        value: NUMERIC_THRESHOLDS[checkOn],
+      },
+    });
+
+    if (result) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+describe("CriteriaFilterUtil.getSupportedCheckOns", () => {
+  test("returns undefined for a monitor type that has not been audited", () => {
+    expect(
+      CriteriaFilterUtil.getSupportedCheckOns(MonitorType.Website),
+    ).toBeUndefined();
+    expect(
+      CriteriaFilterUtil.getSupportedCheckOns(MonitorType.API),
+    ).toBeUndefined();
+  });
+
+  test("SSL Certificate monitors can pick the reachability checks their evaluator reads", () => {
+    const supported: Array<CheckOn> | undefined =
+      CriteriaFilterUtil.getSupportedCheckOns(MonitorType.SSLCertificate);
+
+    expect(supported).toContain(CheckOn.IsOnline);
+    expect(supported).toContain(CheckOn.IsRequestTimeout);
+  });
+
+  test("DNSSEC monitors can pick the reachability checks their evaluator reads", () => {
+    const supported: Array<CheckOn> | undefined =
+      CriteriaFilterUtil.getSupportedCheckOns(MonitorType.DNSSEC);
+
+    expect(supported).toContain(CheckOn.IsOnline);
+    expect(supported).toContain(CheckOn.IsRequestTimeout);
+  });
+
+  test("the SSL Certificate list still carries every certificate check", () => {
+    expect(
+      CriteriaFilterUtil.getSupportedCheckOns(MonitorType.SSLCertificate),
+    ).toEqual(
+      expect.arrayContaining([
+        CheckOn.IsValidCertificate,
+        CheckOn.IsSelfSignedCertificate,
+        CheckOn.IsExpiredCertificate,
+        CheckOn.IsNotAValidCertificate,
+        CheckOn.ExpiresInDays,
+        CheckOn.ExpiresInHours,
+      ]),
+    );
+  });
+
+  test("the DNSSEC list still carries every DNSSEC check", () => {
+    expect(CriteriaFilterUtil.getSupportedCheckOns(MonitorType.DNSSEC)).toEqual(
+      expect.arrayContaining([
+        CheckOn.DnssecChainValid,
+        CheckOn.DnssecDnskeyExists,
+        CheckOn.DnssecDsExists,
+        CheckOn.DnssecResolverConsensus,
+        CheckOn.DnssecNameserverConsistent,
+        CheckOn.DnssecSignatureExpiresInDays,
+      ]),
+    );
+  });
+
+  test("Ping and IP share one list", () => {
+    expect(CriteriaFilterUtil.getSupportedCheckOns(MonitorType.Ping)).toEqual(
+      CriteriaFilterUtil.getSupportedCheckOns(MonitorType.IP),
+    );
+  });
+
+  test("no list repeats a check", () => {
+    for (const monitorType of Object.values(MonitorType)) {
+      const supported: Array<CheckOn> | undefined =
+        CriteriaFilterUtil.getSupportedCheckOns(monitorType);
+
+      if (!supported) {
+        continue;
+      }
+
+      expect(new Set(supported).size).toBe(supported.length);
+    }
+  });
+
+  /*
+   * The first entry is what the dashboard seeds a new filter with, so it has to
+   * be the check a user of that monitor type would actually want.
+   */
+  test("the first entry is the type's own check, not a generic reachability one", () => {
+    expect(
+      CriteriaFilterUtil.getSupportedCheckOns(MonitorType.SSLCertificate)?.[0],
+    ).toBe(CheckOn.IsValidCertificate);
+    expect(
+      CriteriaFilterUtil.getSupportedCheckOns(MonitorType.DNSSEC)?.[0],
+    ).toBe(CheckOn.DnssecChainValid);
+  });
+});
+
+describe("every supported CheckOn is actually evaluated server side", () => {
+  const cases: Array<{
+    monitorType: MonitorType;
+    evaluator: EvaluatorFunction;
+    buildResponse: () => ProbeMonitorResponse;
+  }> = [
+    {
+      monitorType: MonitorType.SSLCertificate,
+      evaluator:
+        SSLMonitorCriteria.isMonitorInstanceCriteriaFilterMet.bind(
+          SSLMonitorCriteria,
+        ),
+      buildResponse: sslProbeResponse,
+    },
+    {
+      monitorType: MonitorType.DNSSEC,
+      evaluator: DnssecMonitorCriteria.isMonitorInstanceCriteriaFilterMet.bind(
+        DnssecMonitorCriteria,
+      ),
+      buildResponse: dnssecProbeResponse,
+    },
+    {
+      monitorType: MonitorType.Ping,
+      evaluator:
+        APIRequestCriteria.isMonitorInstanceCriteriaFilterMet.bind(
+          APIRequestCriteria,
+        ),
+      buildResponse: pingProbeResponse,
+    },
+  ];
+
+  for (const testCase of cases) {
+    describe(testCase.monitorType, () => {
+      const supported: Array<CheckOn> =
+        CriteriaFilterUtil.getSupportedCheckOns(testCase.monitorType) || [];
+
+      test("the type has a supported list", () => {
+        expect(supported.length).toBeGreaterThan(0);
+      });
+
+      test.each(supported)(
+        "%s is answered in at least one direction",
+        async (checkOn: CheckOn) => {
+          const answered: boolean = await isCheckOnAnswered(
+            testCase.evaluator,
+            testCase.buildResponse(),
+            checkOn,
+          );
+
+          expect(answered).toBe(true);
+        },
+      );
+    });
+  }
+});

--- a/Common/Tests/Types/Monitor/MonitorCriteriaInstance.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorCriteriaInstance.test.ts
@@ -316,6 +316,105 @@ describe("MonitorCriteriaInstance", () => {
       expect(error).toContain("Ping Monitor cannot have filter type");
     });
 
+    /*
+     * Issue #3225. The Ping-only guard is now driven by
+     * CriteriaFilterUtil.getSupportedCheckOns, so every audited type rejects a
+     * checkOn its evaluator never reads. Saving one produced a criteria that
+     * could never match in either direction - and a criteria set where nothing
+     * matches is silent: the monitor sits at its default status forever with no
+     * timeline event and no error to go on.
+     */
+    test("rejects a filter type that an SSL Certificate monitor cannot support", () => {
+      const instance: MonitorCriteriaInstance = buildValidInstance();
+      instance.data!.filters = [
+        {
+          checkOn: CheckOn.ResponseStatusCode,
+          filterType: FilterType.EqualTo,
+          value: 200,
+        },
+      ];
+      const error: string | null = MonitorCriteriaInstance.getValidationError(
+        instance,
+        MonitorType.SSLCertificate,
+      );
+      expect(error).toContain(
+        "SSL Certificate Monitor cannot have filter type",
+      );
+    });
+
+    test("rejects a filter type that a DNSSEC monitor cannot support", () => {
+      const instance: MonitorCriteriaInstance = buildValidInstance();
+      instance.data!.filters = [
+        {
+          checkOn: CheckOn.IsValidCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      ];
+      const error: string | null = MonitorCriteriaInstance.getValidationError(
+        instance,
+        MonitorType.DNSSEC,
+      );
+      expect(error).toContain("DNSSEC Monitor cannot have filter type");
+    });
+
+    /*
+     * The reachability checks stay legal on both types: their evaluators have
+     * always read them, and any monitor already carrying one has to remain
+     * saveable.
+     */
+    test("accepts Is Online on an SSL Certificate monitor", () => {
+      const instance: MonitorCriteriaInstance = buildValidInstance();
+      instance.data!.filters = [
+        {
+          checkOn: CheckOn.IsOnline,
+          filterType: FilterType.False,
+          value: undefined,
+        },
+      ];
+      expect(
+        MonitorCriteriaInstance.getValidationError(
+          instance,
+          MonitorType.SSLCertificate,
+        ),
+      ).toBeNull();
+    });
+
+    test("accepts Is Online on a DNSSEC monitor", () => {
+      const instance: MonitorCriteriaInstance = buildValidInstance();
+      instance.data!.filters = [
+        {
+          checkOn: CheckOn.IsOnline,
+          filterType: FilterType.False,
+          value: undefined,
+        },
+      ];
+      expect(
+        MonitorCriteriaInstance.getValidationError(
+          instance,
+          MonitorType.DNSSEC,
+        ),
+      ).toBeNull();
+    });
+
+    // A type with no audited list is unconstrained, exactly as before.
+    test("accepts any filter type on a monitor type that has not been audited", () => {
+      const instance: MonitorCriteriaInstance = buildValidInstance();
+      instance.data!.filters = [
+        {
+          checkOn: CheckOn.IsValidCertificate,
+          filterType: FilterType.True,
+          value: undefined,
+        },
+      ];
+      expect(
+        MonitorCriteriaInstance.getValidationError(
+          instance,
+          MonitorType.Website,
+        ),
+      ).toBeNull();
+    });
+
     test("requires a disk path for Disk Usage Percent filters", () => {
       const instance: MonitorCriteriaInstance = buildValidInstance();
       instance.data!.filters = [
@@ -502,6 +601,86 @@ describe("MonitorCriteriaInstance", () => {
   describe("isValid", () => {
     test("returns true (permissive by contract)", () => {
       expect(MonitorCriteriaInstance.isValid({})).toBe(true);
+    });
+  });
+
+  /*
+   * Issue #3225. The dashboard's "Add Criteria" button used to push a bare
+   * `new MonitorCriteriaInstance()`, whose hardcoded IsOnline filter is not in
+   * the SSL Certificate or DNSSEC dropdowns - so the checkOn select rendered
+   * blank over a live value, and a user who only touched the filterType select
+   * saved a filter they never knowingly chose.
+   */
+  describe("getEmptyCriteriaInstance", () => {
+    test("seeds an SSL Certificate criteria with a certificate check", () => {
+      const instance: MonitorCriteriaInstance =
+        MonitorCriteriaInstance.getEmptyCriteriaInstance(
+          MonitorType.SSLCertificate,
+        );
+
+      expect(instance.data?.filters).toHaveLength(1);
+      expect(instance.data?.filters[0]?.checkOn).toBe(
+        CheckOn.IsValidCertificate,
+      );
+    });
+
+    test("seeds a DNSSEC criteria with a DNSSEC check", () => {
+      const instance: MonitorCriteriaInstance =
+        MonitorCriteriaInstance.getEmptyCriteriaInstance(MonitorType.DNSSEC);
+
+      expect(instance.data?.filters[0]?.checkOn).toBe(CheckOn.DnssecChainValid);
+    });
+
+    test("leaves filterType unset so the user has to pick one", () => {
+      const instance: MonitorCriteriaInstance =
+        MonitorCriteriaInstance.getEmptyCriteriaInstance(
+          MonitorType.SSLCertificate,
+        );
+
+      expect(instance.data?.filters[0]?.filterType).toBeUndefined();
+    });
+
+    test("seeds a checkOn the type validates", () => {
+      for (const monitorType of [
+        MonitorType.SSLCertificate,
+        MonitorType.DNSSEC,
+        MonitorType.Ping,
+        MonitorType.Website,
+      ]) {
+        const instance: MonitorCriteriaInstance =
+          MonitorCriteriaInstance.getEmptyCriteriaInstance(monitorType);
+
+        instance.data!.name = "Seeded";
+        instance.data!.description = "Seeded";
+        instance.data!.monitorStatusId = ObjectID.generate();
+        instance.data!.filters[0]!.filterType = FilterType.True;
+
+        expect(
+          MonitorCriteriaInstance.getValidationError(instance, monitorType),
+        ).toBeNull();
+      }
+    });
+
+    /*
+     * An un-audited type has no list to seed from, so it keeps the bare
+     * constructor's shape.
+     */
+    test("falls back to the constructor default for an unaudited type", () => {
+      const instance: MonitorCriteriaInstance =
+        MonitorCriteriaInstance.getEmptyCriteriaInstance(MonitorType.Website);
+
+      expect(instance.data?.filters[0]?.checkOn).toBe(CheckOn.IsOnline);
+    });
+
+    /*
+     * The bare constructor is used in ~40 places by the alert-pack builders and
+     * by fromJSON, which overwrite filters immediately and depend on its shape.
+     */
+    test("the bare constructor is unchanged", () => {
+      const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
+
+      expect(instance.data?.filters).toHaveLength(1);
+      expect(instance.data?.filters[0]?.checkOn).toBe(CheckOn.IsOnline);
     });
   });
 });

--- a/Common/Types/Monitor/CriteriaFilter.ts
+++ b/Common/Types/Monitor/CriteriaFilter.ts
@@ -1,5 +1,6 @@
 import Zod, { ZodSchema } from "../../Utils/Schema/Zod";
 import MetricCriteriaContext from "./MetricMonitor/MetricCriteriaContext";
+import MonitorType from "./MonitorType";
 
 export enum CheckOn {
   ResponseTime = "Response Time (in ms)",
@@ -276,6 +277,74 @@ export enum FilterType {
 }
 
 export class CriteriaFilterUtil {
+  /*
+   * The checks a monitor type's evaluator actually reads.
+   *
+   * Two things used to be maintained separately and had drifted apart: which
+   * checks the dashboard offers, and which checks are legal to save. A filter
+   * whose checkOn the type's evaluator never reads is not a value that reads
+   * oddly - it is a filter that can never match in either direction, and
+   * "nothing matched" is invisible at runtime because it simply leaves the
+   * monitor parked at its default status with no timeline event and no error.
+   * That is how issue #3225 stayed hidden for days.
+   *
+   * undefined means "this type has not been audited yet" and callers must
+   * treat it as no constraint, so adding a type here is opt-in and cannot
+   * affect the types that are not listed.
+   *
+   * The type-specific checks come first: the dashboard seeds a new filter with
+   * the first entry, and the useful default for an SSL monitor is a
+   * certificate check, not a reachability one.
+   */
+  public static getSupportedCheckOns(
+    monitorType: MonitorType,
+  ): Array<CheckOn> | undefined {
+    if (monitorType === MonitorType.SSLCertificate) {
+      /*
+       * IsOnline / IsRequestTimeout are reachability checks: on an SSL
+       * monitor they mean "we obtained a certificate at all", not "the chain
+       * is trusted". SSLMonitorCriteria has always evaluated them, they were
+       * simply absent from the dropdown - so a filter carrying one rendered as
+       * a blank select over a live value.
+       */
+      return [
+        CheckOn.IsValidCertificate,
+        CheckOn.IsSelfSignedCertificate,
+        CheckOn.IsExpiredCertificate,
+        CheckOn.IsNotAValidCertificate,
+        CheckOn.ExpiresInDays,
+        CheckOn.ExpiresInHours,
+        CheckOn.IsOnline,
+        CheckOn.IsRequestTimeout,
+      ];
+    }
+
+    if (monitorType === MonitorType.DNSSEC) {
+      return [
+        CheckOn.DnssecChainValid,
+        CheckOn.DnssecDnskeyExists,
+        CheckOn.DnssecDsExists,
+        CheckOn.DnssecResolverConsensus,
+        CheckOn.DnssecNameserverConsistent,
+        CheckOn.DnssecSignatureExpiresInDays,
+        CheckOn.IsOnline,
+        CheckOn.IsRequestTimeout,
+      ];
+    }
+
+    if (monitorType === MonitorType.Ping || monitorType === MonitorType.IP) {
+      return [
+        CheckOn.IsOnline,
+        CheckOn.ResponseTime,
+        CheckOn.PacketLossPercent,
+        CheckOn.Jitter,
+        CheckOn.IsRequestTimeout,
+      ];
+    }
+
+    return undefined;
+  }
+
   /**
    * Whether the filter is anomaly-based. Anomaly filters skip the
    * static threshold value/unit fields and instead read sensitivity

--- a/Common/Types/Monitor/MonitorCriteriaInstance.ts
+++ b/Common/Types/Monitor/MonitorCriteriaInstance.ts
@@ -70,6 +70,35 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
     };
   }
 
+  /*
+   * An empty criteria for the dashboard's "Add Criteria" button, seeded with a
+   * check the monitor type actually supports.
+   *
+   * The bare constructor keeps its IsOnline default: it is used in ~40 places
+   * by the alert-pack builders and by fromJSON, all of which overwrite filters
+   * immediately and depend on the current shape.
+   */
+  public static getEmptyCriteriaInstance(
+    monitorType: MonitorType,
+  ): MonitorCriteriaInstance {
+    const instance: MonitorCriteriaInstance = new MonitorCriteriaInstance();
+
+    const supportedCheckOns: Array<CheckOn> | undefined =
+      CriteriaFilterUtil.getSupportedCheckOns(monitorType);
+
+    if (instance.data && supportedCheckOns && supportedCheckOns[0]) {
+      instance.data.filters = [
+        {
+          checkOn: supportedCheckOns[0],
+          filterType: undefined,
+          value: undefined,
+        },
+      ];
+    }
+
+    return instance;
+  }
+
   public static getDefaultOnlineMonitorCriteriaInstance(arg: {
     monitorType: MonitorType;
     monitorStatusId: ObjectID;
@@ -1438,13 +1467,19 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         return `Filter Type is required for criteria "${value.data.name}"`;
       }
 
-      if (
-        monitorType === MonitorType.Ping &&
-        filter.checkOn !== CheckOn.IsOnline &&
-        filter.checkOn !== CheckOn.ResponseTime &&
-        filter.checkOn !== CheckOn.IsRequestTimeout
-      ) {
-        return "Ping Monitor cannot have filter type: " + filter.checkOn;
+      /*
+       * Generalized from a Ping-only special case. A checkOn the monitor
+       * type's evaluator never reads is a criteria that can never fire in
+       * either direction, and until now it saved without complaint on every
+       * type except Ping - the monitor then sat silently at its default
+       * status forever (issue #3225). Types the list has not audited yet
+       * return undefined and keep saving anything.
+       */
+      const supportedCheckOns: Array<CheckOn> | undefined =
+        CriteriaFilterUtil.getSupportedCheckOns(monitorType);
+
+      if (supportedCheckOns && !supportedCheckOns.includes(filter.checkOn)) {
+        return `${monitorType} Monitor cannot have filter type: ${filter.checkOn}`;
       }
 
       if (

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/SslMonitor.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/SslMonitor.test.ts
@@ -1,0 +1,704 @@
+// Set required env vars before importing anything that pulls Config.ts
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import SSLMonitor, {
+  SslResponse,
+} from "../../../../Utils/Monitors/MonitorTypes/SslMonitor";
+import OnlineCheck from "../../../../Utils/OnlineCheck";
+import URL from "Common/Types/API/URL";
+import PositiveNumber from "Common/Types/PositiveNumber";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { execFileSync } from "child_process";
+import * as net from "net";
+import { AddressInfo, Socket } from "net";
+import * as https from "https";
+import * as tls from "tls";
+import { IncomingMessage, ServerResponse } from "http";
+
+interface SelfSignedCert {
+  certPath: string;
+  keyPath: string;
+}
+
+/*
+ * Generated with openssl rather than checked in, exactly as the mTLS probe
+ * tests do. A committed PEM would start failing on the day it expired.
+ */
+function generateSelfSignedCert(
+  workDir: string,
+  commonName: string,
+  daysValid: number,
+): SelfSignedCert {
+  const keyPath: string = path.join(workDir, `${commonName}.key`);
+  const certPath: string = path.join(workDir, `${commonName}.crt`);
+
+  execFileSync("openssl", ["genrsa", "-out", keyPath, "2048"], {
+    stdio: "pipe",
+  });
+  execFileSync(
+    "openssl",
+    [
+      "req",
+      "-x509",
+      "-new",
+      "-key",
+      keyPath,
+      "-out",
+      certPath,
+      "-days",
+      daysValid.toString(),
+      "-subj",
+      `/C=US/ST=CA/L=San Francisco/O=OneUptime Test/OU=Probe/CN=${commonName}`,
+    ],
+    { stdio: "pipe" },
+  );
+
+  return { certPath, keyPath };
+}
+
+/*
+ * A port that accepts the TCP connection and then says nothing at all - the
+ * shape of a host sitting behind a middlebox that swallows the TLS handshake.
+ * Before the timeout was wired up this made the probe's promise never settle,
+ * which is what silently dropped the monitor's check every cycle (issue #3225).
+ */
+function createSilentTcpServer(): Promise<{
+  port: number;
+  close: () => Promise<void>;
+}> {
+  const sockets: Array<Socket> = [];
+
+  const server: net.Server = net.createServer((socket: Socket) => {
+    // Deliberately never respond. Hold the socket open.
+    sockets.push(socket);
+  });
+
+  return new Promise(
+    (
+      resolve: (value: { port: number; close: () => Promise<void> }) => void,
+    ) => {
+      server.listen(0, "127.0.0.1", () => {
+        const address: AddressInfo = server.address() as AddressInfo;
+
+        resolve({
+          port: address.port,
+          close: (): Promise<void> => {
+            for (const socket of sockets) {
+              socket.destroy();
+            }
+
+            return new Promise((done: () => void) => {
+              server.close(() => {
+                done();
+              });
+            });
+          },
+        });
+      });
+    },
+  );
+}
+
+// A port nobody is listening on, so connecting is refused immediately.
+async function getClosedPort(): Promise<number> {
+  const server: net.Server = net.createServer();
+
+  const port: number = await new Promise((resolve: (v: number) => void) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+
+  await new Promise((resolve: (v: void) => void) => {
+    server.close(() => {
+      resolve();
+    });
+  });
+
+  return port;
+}
+
+describe("SSLMonitor", () => {
+  let workDir: string;
+
+  beforeAll(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "oneuptime-ssl-monitor-"));
+  }, 60000);
+
+  afterAll(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  /*
+   * URL.fromString hands the whole authority to the Hostname constructor and
+   * leaves Hostname.port unset, so reading hostname/port off it naively dialled
+   * the literal name "example.com:8443" on port 443 - every SSL monitor on a
+   * non-443 port failed to resolve on every check.
+   */
+  describe("getHostAndPort", () => {
+    it("splits an explicit port off the authority", () => {
+      expect(
+        SSLMonitor.getHostAndPort(URL.fromString("https://example.com:8443/")),
+      ).toEqual({ host: "example.com", port: 8443 });
+    });
+
+    it("defaults to 443 when the URL carries no port", () => {
+      expect(
+        SSLMonitor.getHostAndPort(
+          URL.fromString("https://self-signed.badssl.com/"),
+        ),
+      ).toEqual({ host: "self-signed.badssl.com", port: 443 });
+    });
+
+    it("ignores the path, query and fragment", () => {
+      expect(
+        SSLMonitor.getHostAndPort(
+          URL.fromString("https://example.com:9443/deep/path?a=b"),
+        ),
+      ).toEqual({ host: "example.com", port: 9443 });
+    });
+
+    it("reads past userinfo", () => {
+      expect(
+        SSLMonitor.getHostAndPort(
+          URL.fromString("https://user:token@example.com:8443/"),
+        ),
+      ).toEqual({ host: "example.com", port: 8443 });
+    });
+
+    it("unwraps a bracketed IPv6 literal for tls.connect", () => {
+      expect(
+        SSLMonitor.getHostAndPort(URL.fromString("https://[::1]:8443/")),
+      ).toEqual({ host: "::1", port: 8443 });
+    });
+
+    it("handles an IPv4 literal with a port", () => {
+      expect(
+        SSLMonitor.getHostAndPort(URL.fromString("https://127.0.0.1:44321/")),
+      ).toEqual({ host: "127.0.0.1", port: 44321 });
+    });
+  });
+
+  describe("a reachable host serving an untrusted certificate", () => {
+    let server: https.Server;
+    let serverUrl: URL;
+    let certs: SelfSignedCert;
+
+    beforeAll(async () => {
+      certs = generateSelfSignedCert(workDir, "localhost", 365);
+
+      server = https.createServer(
+        {
+          key: fs.readFileSync(certs.keyPath),
+          cert: fs.readFileSync(certs.certPath),
+        },
+        (_req: IncomingMessage, res: ServerResponse) => {
+          res.statusCode = 200;
+          res.end("<html><body>OK</body></html>");
+        },
+      );
+
+      await new Promise<void>((resolve: () => void) => {
+        server.listen(0, "127.0.0.1", () => {
+          const address: AddressInfo = server.address() as AddressInfo;
+          serverUrl = URL.fromString(`https://127.0.0.1:${address.port}/`);
+          resolve();
+        });
+      });
+    }, 60000);
+
+    afterAll(async () => {
+      await new Promise<void>((resolve: () => void) => {
+        server.close(() => {
+          resolve();
+        });
+      });
+    });
+
+    /*
+     * This is the reporter's exact scenario (self-signed.badssl.com): the
+     * strict handshake fails, the permissive retry succeeds, and the check has
+     * to come back online-but-untrusted so IsNotAValidCertificate can fire.
+     */
+    it("reports the certificate as self signed and the host as online", async () => {
+      const response: SslResponse | null = await SSLMonitor.ping(serverUrl, {
+        retry: 0,
+        isOnlineCheckRequest: true,
+        timeout: new PositiveNumber(10000),
+      });
+
+      expect(response).not.toBeNull();
+      expect(response!.isOnline).toBe(true);
+      expect(response!.isSelfSigned).toBe(true);
+      expect(response!.isTimeout).toBeFalsy();
+      expect(response!.failureCause).toBe("");
+    }, 60000);
+
+    it("surfaces the certificate identity fields", async () => {
+      const response: SslResponse | null = await SSLMonitor.ping(serverUrl, {
+        retry: 0,
+        isOnlineCheckRequest: true,
+        timeout: new PositiveNumber(10000),
+      });
+
+      expect(response!.commonName).toBe("localhost");
+      expect(response!.organization).toBe("OneUptime Test");
+      expect(response!.organizationalUnit).toBe("Probe");
+      expect(response!.country).toBe("US");
+      expect(response!.state).toBe("CA");
+      expect(response!.serialNumber).toBeTruthy();
+      expect(response!.fingerprint).toBeTruthy();
+      expect(response!.fingerprint256).toBeTruthy();
+    }, 60000);
+
+    it("parses the certificate validity window into real dates", async () => {
+      const response: SslResponse | null = await SSLMonitor.ping(serverUrl, {
+        retry: 0,
+        isOnlineCheckRequest: true,
+        timeout: new PositiveNumber(10000),
+      });
+
+      expect(response!.createdAt).toBeInstanceOf(Date);
+      expect(response!.expiresAt).toBeInstanceOf(Date);
+      expect(response!.expiresAt!.getTime()).toBeGreaterThan(Date.now());
+      expect(Number.isNaN(response!.expiresAt!.getTime())).toBe(false);
+    }, 60000);
+
+    /*
+     * SSL was the only probe monitor type that never reported a response time,
+     * so doesMonitorTypeHaveGraphs offered a graph that could never have a
+     * point on it.
+     */
+    it("reports a response time", async () => {
+      const response: SslResponse | null = await SSLMonitor.ping(serverUrl, {
+        retry: 0,
+        isOnlineCheckRequest: true,
+        timeout: new PositiveNumber(10000),
+      });
+
+      expect(typeof response!.responseTimeInMs).toBe("number");
+      expect(response!.responseTimeInMs!).toBeGreaterThanOrEqual(0);
+    }, 60000);
+
+    it("records one probe attempt for a first-try success", async () => {
+      const response: SslResponse | null = await SSLMonitor.ping(serverUrl, {
+        retry: 1,
+        isOnlineCheckRequest: true,
+        timeout: new PositiveNumber(10000),
+      });
+
+      expect(response!.totalAttempts).toBe(1);
+      expect(response!.probeAttempts).toHaveLength(1);
+      expect(response!.probeAttempts![0]!.isOnline).toBe(true);
+    }, 60000);
+
+    /*
+     * The response body is never read, so without an explicit destroy the
+     * one-off agent held the socket open until the body drained - which never
+     * happened - leaking one TLS socket and fd per check.
+     */
+    it("closes the underlying socket instead of leaking it", async () => {
+      const address: AddressInfo = server.address() as AddressInfo;
+
+      let openConnections: number = 0;
+      await new Promise<void>((resolve: () => void) => {
+        server.getConnections((_err: Error | null, count: number) => {
+          openConnections = count;
+          resolve();
+        });
+      });
+
+      await SSLMonitor.getCertificate({
+        host: "127.0.0.1",
+        port: address.port,
+        rejectUnauthorized: false,
+        timeoutInMs: 10000,
+      });
+
+      // Give the close a tick to propagate to the server side.
+      await new Promise<void>((resolve: () => void) => {
+        setTimeout(resolve, 500);
+      });
+
+      const connectionsAfter: number = await new Promise(
+        (resolve: (v: number) => void) => {
+          server.getConnections((_err: Error | null, count: number) => {
+            resolve(count);
+          });
+        },
+      );
+
+      expect(connectionsAfter).toBeLessThanOrEqual(openConnections);
+    }, 60000);
+
+    it("honours the port carried on the URL", async () => {
+      const address: AddressInfo = server.address() as AddressInfo;
+
+      const certificate: tls.PeerCertificate = await SSLMonitor.getCertificate({
+        host: "127.0.0.1",
+        port: address.port,
+        rejectUnauthorized: false,
+        timeoutInMs: 10000,
+      });
+
+      expect(certificate.subject.CN).toBe("localhost");
+    }, 60000);
+  });
+
+  describe("an expired certificate", () => {
+    let server: https.Server;
+    let serverUrl: URL;
+
+    beforeAll(async () => {
+      /*
+       * openssl cannot mint a certificate that is already expired with -days,
+       * so it is backdated: valid from 30 days ago for 1 day.
+       */
+      const keyPath: string = path.join(workDir, "expired.key");
+      const certPath: string = path.join(workDir, "expired.crt");
+
+      execFileSync("openssl", ["genrsa", "-out", keyPath, "2048"], {
+        stdio: "pipe",
+      });
+      execFileSync(
+        "openssl",
+        [
+          "req",
+          "-x509",
+          "-new",
+          "-key",
+          keyPath,
+          "-out",
+          certPath,
+          "-not_before",
+          "20200101000000Z",
+          "-not_after",
+          "20200102000000Z",
+          "-subj",
+          "/CN=expired.oneuptime.test",
+        ],
+        { stdio: "pipe" },
+      );
+
+      server = https.createServer(
+        {
+          key: fs.readFileSync(keyPath),
+          cert: fs.readFileSync(certPath),
+        },
+        (_req: IncomingMessage, res: ServerResponse) => {
+          res.end("OK");
+        },
+      );
+
+      await new Promise<void>((resolve: () => void) => {
+        server.listen(0, "127.0.0.1", () => {
+          const address: AddressInfo = server.address() as AddressInfo;
+          serverUrl = URL.fromString(`https://127.0.0.1:${address.port}/`);
+          resolve();
+        });
+      });
+    }, 60000);
+
+    afterAll(async () => {
+      await new Promise<void>((resolve: () => void) => {
+        server.close(() => {
+          resolve();
+        });
+      });
+    });
+
+    it("still returns the certificate, with an expiry in the past", async () => {
+      const response: SslResponse | null = await SSLMonitor.ping(serverUrl, {
+        retry: 0,
+        isOnlineCheckRequest: true,
+        timeout: new PositiveNumber(10000),
+      });
+
+      expect(response).not.toBeNull();
+      expect(response!.isOnline).toBe(true);
+      expect(response!.expiresAt).toBeInstanceOf(Date);
+      expect(response!.expiresAt!.getTime()).toBeLessThan(Date.now());
+    }, 60000);
+  });
+
+  describe("a host that accepts the connection and never completes the handshake", () => {
+    let silent: { port: number; close: () => Promise<void> };
+
+    beforeAll(async () => {
+      silent = await createSilentTcpServer();
+    }, 60000);
+
+    afterAll(async () => {
+      await silent.close();
+    });
+
+    /*
+     * THE regression test for issue #3225. Node's https.get applies no default
+     * socket timeout, so before the deadline was wired up this promise never
+     * settled: the probe worker hung, the monitor's result was never POSTed to
+     * the ingest API, and because nextPingAt is advanced at claim time the
+     * cycle was silently lost - forever, every cycle.
+     */
+    it("rejects getCertificate within the timeout instead of hanging", async () => {
+      const startedAt: number = Date.now();
+
+      await expect(
+        SSLMonitor.getCertificate({
+          host: "127.0.0.1",
+          port: silent.port,
+          rejectUnauthorized: false,
+          timeoutInMs: 2000,
+        }),
+      ).rejects.toThrow(/timeout exceeded/);
+
+      const elapsed: number = Date.now() - startedAt;
+      expect(elapsed).toBeLessThan(10000);
+    }, 60000);
+
+    it("settles ping() as an offline, timed-out check rather than hanging", async () => {
+      const startedAt: number = Date.now();
+
+      const response: SslResponse | null = await SSLMonitor.ping(
+        URL.fromString(`https://127.0.0.1:${silent.port}/`),
+        {
+          retry: 1,
+          isOnlineCheckRequest: true,
+          timeout: new PositiveNumber(2000),
+        },
+      );
+
+      const elapsed: number = Date.now() - startedAt;
+
+      expect(response).not.toBeNull();
+      expect(response!.isOnline).toBe(false);
+      expect(response!.isTimeout).toBe(true);
+      expect(response!.failureCause).toContain("timed out");
+      expect(elapsed).toBeLessThan(30000);
+    }, 60000);
+
+    /*
+     * The strict and permissive handshakes share one budget. Giving each the
+     * full timeout would make the user's Timeout setting quietly mean twice
+     * what they asked for, and the retry ladder would multiply that again.
+     */
+    it("shares one timeout budget across both handshake passes", async () => {
+      const startedAt: number = Date.now();
+
+      await expect(
+        SSLMonitor.getSslMonitorResponse("127.0.0.1", silent.port, 2000),
+      ).rejects.toThrow();
+
+      const elapsed: number = Date.now() - startedAt;
+
+      /*
+       * One 2s budget plus the 1s floor the second pass always gets, not
+       * 2 x 2s. Generous headroom for a loaded CI box.
+       */
+      expect(elapsed).toBeLessThan(6000);
+    }, 60000);
+
+    it("applies the user's retry count to a timing-out host", async () => {
+      const response: SslResponse | null = await SSLMonitor.ping(
+        URL.fromString(`https://127.0.0.1:${silent.port}/`),
+        {
+          retry: 2,
+          isOnlineCheckRequest: true,
+          timeout: new PositiveNumber(1000),
+        },
+      );
+
+      expect(response!.totalAttempts).toBe(2);
+      expect(response!.probeAttempts).toHaveLength(2);
+    }, 60000);
+  });
+
+  describe("an unreachable host", () => {
+    let closedPort: number;
+
+    beforeAll(async () => {
+      closedPort = await getClosedPort();
+    }, 60000);
+
+    it("reports offline with a failure cause rather than returning null", async () => {
+      const response: SslResponse | null = await SSLMonitor.ping(
+        URL.fromString(`https://127.0.0.1:${closedPort}/`),
+        {
+          retry: 1,
+          isOnlineCheckRequest: true,
+          timeout: new PositiveNumber(3000),
+        },
+      );
+
+      expect(response).not.toBeNull();
+      expect(response!.isOnline).toBe(false);
+      expect(response!.isTimeout).toBe(false);
+      expect(response!.failureCause).toBeTruthy();
+    }, 60000);
+
+    /*
+     * getSslMonitorResponse used to swallow its own errors and return an
+     * offline object, which made every error path in ping() dead code: the
+     * user's retry count was never applied and probeAttempts was always 1.
+     */
+    it("retries as many times as the user configured", async () => {
+      const response: SslResponse | null = await SSLMonitor.ping(
+        URL.fromString(`https://127.0.0.1:${closedPort}/`),
+        {
+          retry: 3,
+          isOnlineCheckRequest: true,
+          timeout: new PositiveNumber(3000),
+        },
+      );
+
+      expect(response!.totalAttempts).toBe(3);
+      expect(response!.probeAttempts).toHaveLength(3);
+      expect(response!.probeAttempts![0]!.attemptNumber).toBe(1);
+      expect(response!.probeAttempts![2]!.attemptNumber).toBe(3);
+
+      for (const attempt of response!.probeAttempts!) {
+        expect(attempt.isOnline).toBe(false);
+        expect(attempt.failureCause).toBeTruthy();
+      }
+    }, 60000);
+
+    /*
+     * clampMonitorRetryCount lets a user save 0, and the ladder only became
+     * live once getSslMonitorResponse started throwing - so "|| 5" would have
+     * newly turned "do not retry" into five attempts.
+     */
+    it("treats a configured retry count of 0 as a single attempt", async () => {
+      const response: SslResponse | null = await SSLMonitor.ping(
+        URL.fromString(`https://127.0.0.1:${closedPort}/`),
+        {
+          retry: 0,
+          isOnlineCheckRequest: true,
+          timeout: new PositiveNumber(3000),
+        },
+      );
+
+      expect(response!.totalAttempts).toBe(1);
+    }, 60000);
+
+    it("reports a response time even on the failure path", async () => {
+      const response: SslResponse | null = await SSLMonitor.ping(
+        URL.fromString(`https://127.0.0.1:${closedPort}/`),
+        {
+          retry: 1,
+          isOnlineCheckRequest: true,
+          timeout: new PositiveNumber(3000),
+        },
+      );
+
+      expect(typeof response!.responseTimeInMs).toBe("number");
+    }, 60000);
+  });
+
+  describe("error classification", () => {
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    /*
+     * Happy-eyeballs exhausted - typically a dual-stack host with a dead IPv6
+     * route. This used to return null, and a null step result is never POSTed
+     * to the ingest API at all, so the monitor sat at its creation status
+     * forever with no timeline event and no monitor log: exactly the
+     * "never executes" symptom reported in issue #3225.
+     */
+    it("reports an AggregateError as offline rather than returning null", async () => {
+      const aggregate: Error = new Error("connect ECONNREFUSED");
+      aggregate.name = "AggregateError";
+
+      const spy: jest.SpyInstance = jest
+        .spyOn(SSLMonitor, "getSslMonitorResponse")
+        .mockRejectedValue(aggregate as never);
+
+      const response: SslResponse | null = await SSLMonitor.ping(
+        URL.fromString("https://aggregate.oneuptime.test/"),
+        {
+          retry: 1,
+          isOnlineCheckRequest: true,
+          timeout: new PositiveNumber(1000),
+        },
+      );
+
+      expect(response).not.toBeNull();
+      expect(response!.isOnline).toBe(false);
+      expect(response!.isTimeout).toBe(false);
+      expect(response!.failureCause).toContain("AggregateError");
+      expect(response!.probeAttempts).toHaveLength(1);
+
+      spy.mockRestore();
+    }, 60000);
+
+    /*
+     * The one legitimate null: the probe itself has no connectivity, so it
+     * must not slander the target as down.
+     */
+    it("returns null only when the probe itself is offline", async () => {
+      const responseSpy: jest.SpyInstance = jest
+        .spyOn(SSLMonitor, "getSslMonitorResponse")
+        .mockRejectedValue(new Error("connect ECONNREFUSED") as never);
+
+      const onlineSpy: jest.SpyInstance = jest
+        .spyOn(OnlineCheck, "canProbeMonitorWebsiteMonitors")
+        .mockResolvedValue(false as never);
+
+      const response: SslResponse | null = await SSLMonitor.ping(
+        URL.fromString("https://offline-probe.oneuptime.test/"),
+        {
+          retry: 1,
+          timeout: new PositiveNumber(1000),
+        },
+      );
+
+      expect(response).toBeNull();
+
+      responseSpy.mockRestore();
+      onlineSpy.mockRestore();
+    }, 60000);
+
+    it("still reports the target offline when the probe itself is online", async () => {
+      const responseSpy: jest.SpyInstance = jest
+        .spyOn(SSLMonitor, "getSslMonitorResponse")
+        .mockRejectedValue(new Error("connect ECONNREFUSED") as never);
+
+      const onlineSpy: jest.SpyInstance = jest
+        .spyOn(OnlineCheck, "canProbeMonitorWebsiteMonitors")
+        .mockResolvedValue(true as never);
+
+      const response: SslResponse | null = await SSLMonitor.ping(
+        URL.fromString("https://online-probe.oneuptime.test/"),
+        {
+          retry: 1,
+          timeout: new PositiveNumber(1000),
+        },
+      );
+
+      expect(response).not.toBeNull();
+      expect(response!.isOnline).toBe(false);
+
+      responseSpy.mockRestore();
+      onlineSpy.mockRestore();
+    }, 60000);
+  });
+
+  describe("getSslMonitorResponse contract", () => {
+    /*
+     * It used to return { isOnline: false, failureCause } here. Returning
+     * instead of throwing is what made ping()'s retry loop, probeAttempts
+     * accounting and isTimeout handling unreachable.
+     */
+    it("throws rather than returning an offline object", async () => {
+      const closedPort: number = await getClosedPort();
+
+      await expect(
+        SSLMonitor.getSslMonitorResponse("127.0.0.1", closedPort, 2000),
+      ).rejects.toThrow();
+    }, 60000);
+  });
+});

--- a/Probe/Utils/Monitors/Monitor.ts
+++ b/Probe/Utils/Monitors/Monitor.ts
@@ -531,14 +531,6 @@ export default class MonitorUtil {
 
       result.monitorDestination = monitorStep.data.monitorDestination;
 
-      if (!monitorStep.data?.monitorDestination) {
-        result.isOnline = false;
-        result.responseTimeInMs = 0;
-        result.failureCause = "Port is not specified";
-
-        return result;
-      }
-
       const response: SslResponse | null = await SSLMonitor.ping(
         monitorStep.data?.monitorDestination as URL,
         {
@@ -553,6 +545,7 @@ export default class MonitorUtil {
       }
 
       result.isOnline = response.isOnline;
+      result.responseTimeInMs = response.responseTimeInMs;
       result.failureCause = response.failureCause;
       result.isTimeout = response.isTimeout;
       result.sslResponse = {

--- a/Probe/Utils/Monitors/MonitorTypes/SslMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/SslMonitor.ts
@@ -5,7 +5,9 @@ import type { HttpsProxyAgent } from "https-proxy-agent";
 import type { HttpProxyAgent } from "http-proxy-agent";
 import OneUptimeDate from "Common/Types/Date";
 import BadDataException from "Common/Types/Exception/BadDataException";
+import UnableToReachServer from "Common/Types/Exception/UnableToReachServer";
 import SslMonitorResponse from "Common/Types/Monitor/SSLMonitor/SslMonitorResponse";
+import { DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS } from "Common/Types/Monitor/MonitorStep";
 import ObjectID from "Common/Types/ObjectID";
 import PositiveNumber from "Common/Types/PositiveNumber";
 import ProbeAttempt from "Common/Types/Probe/ProbeAttempt";
@@ -17,10 +19,24 @@ import { ClientRequest, IncomingMessage } from "http";
 import https, { RequestOptions } from "https";
 import tls, { TLSSocket } from "tls";
 
+/*
+ * Floor for a handshake deadline. Node treats a socket timeout of 0 as "no
+ * timeout at all", which is precisely the unbounded wait this budget exists
+ * to prevent, so a spent budget still gets a small positive deadline rather
+ * than an infinite one.
+ */
+const MIN_SSL_HANDSHAKE_TIMEOUT_IN_MS: number = 1000;
+
 export interface SslResponse extends SslMonitorResponse {
   isOnline: boolean;
   failureCause: string;
   isTimeout?: boolean | undefined;
+  /*
+   * Wall-clock time for the certificate fetch. SSL was the only probe monitor
+   * type that never reported one, so MonitorType.doesMonitorTypeHaveGraphs
+   * offered a response-time graph that could never have a point on it.
+   */
+  responseTimeInMs?: number | undefined;
   probeAttempts?: Array<ProbeAttempt> | undefined;
   totalAttempts?: number | undefined;
 }
@@ -59,11 +75,15 @@ export default class SSLMonitor {
       }`,
     );
 
+    const { host, port } = SSLMonitor.getHostAndPort(url);
+
     const attemptedAt: Date = new Date();
     try {
       const res: SslResponse = await this.getSslMonitorResponse(
-        url.hostname.hostname,
-        url.hostname.port?.toNumber() || 443,
+        host,
+        port,
+        pingOptions.timeout?.toNumber() ||
+          DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS,
       );
 
       logger.debug(
@@ -72,15 +92,19 @@ export default class SSLMonitor {
       logger.debug(res);
 
       const responseReceivedAt: Date = new Date();
+      const responseTimeInMs: number =
+        responseReceivedAt.getTime() - attemptedAt.getTime();
+
       pingOptions.attempts.push({
         attemptNumber: pingOptions.currentRetryCount,
         attemptedAt,
         responseReceivedAt,
-        responseTimeInMs: responseReceivedAt.getTime() - attemptedAt.getTime(),
+        responseTimeInMs: responseTimeInMs,
         isOnline: res.isOnline,
         failureCause: res.isOnline ? undefined : res.failureCause,
       });
 
+      res.responseTimeInMs = responseTimeInMs;
       res.probeAttempts = pingOptions.attempts;
       res.totalAttempts = pingOptions.attempts.length;
       return res;
@@ -112,7 +136,15 @@ export default class SSLMonitor {
         failureCause: API.getFriendlyErrorMessage(err as Error),
       });
 
-      if (pingOptions.currentRetryCount < (pingOptions.retry || 5)) {
+      /*
+       * Nullish rather than "|| 5": clampMonitorRetryCount lets a user save a
+       * retry count of 0, and this ladder was dead code until
+       * getSslMonitorResponse started throwing - so "|| 5" would newly turn
+       * "do not retry" into five attempts against the same host.
+       */
+      const maxAttempts: number = pingOptions.retry ?? 5;
+
+      if (pingOptions.currentRetryCount < maxAttempts) {
         pingOptions.currentRetryCount++;
         await Sleep.sleep(1000);
         return await this.ping(url, pingOptions);
@@ -122,54 +154,141 @@ export default class SSLMonitor {
       if (!pingOptions.isOnlineCheckRequest) {
         if (!(await OnlineCheck.canProbeMonitorWebsiteMonitors())) {
           logger.error(
-            `PingMonitor Monitor - Probe is not online. Cannot ping ${pingOptions?.monitorId?.toString()} ${url.toString()} - ERROR: ${err}`,
+            `SSL Monitor - Probe is not online. Cannot ping ${pingOptions?.monitorId?.toString()} ${url.toString()} - ERROR: ${err}`,
           );
           return null;
         }
       }
 
-      // check if timeout exceeded and if yes, return null
+      // check if timeout exceeded and if yes, report the check as offline.
       if (
         (err as any).toString().includes("timeout") &&
         (err as any).toString().includes("exceeded")
       ) {
         logger.debug(
-          `Ping Monitor - Timeout exceeded ${pingOptions.monitorId?.toString()} ${url.toString()} - ERROR: ${err}`,
+          `SSL Monitor - Timeout exceeded ${pingOptions.monitorId?.toString()} ${url.toString()} - ERROR: ${err}`,
         );
 
+        /*
+         * This used to report isOnline: true. The branch was unreachable
+         * while getSslMonitorResponse swallowed its own errors, so nobody
+         * noticed; now that the timeout is actually wired up and this path is
+         * live, a host that never completes a handshake would otherwise keep
+         * an "Is Online = True" criteria matching forever. A handshake that
+         * never completed is not a reachable endpoint.
+         */
         return {
-          isOnline: true,
+          isOnline: false,
           isTimeout: true,
           failureCause:
             "Request was tried " +
             pingOptions.currentRetryCount +
             " times and it timed out.",
+          responseTimeInMs:
+            responseReceivedAt.getTime() - attemptedAt.getTime(),
           probeAttempts: pingOptions.attempts,
           totalAttempts: pingOptions.attempts.length,
         };
       }
 
-      // if AggregateError is thrown, it means that the request failed
-      if (
-        API.getFriendlyErrorMessage(err as Error).includes("AggregateError")
-      ) {
-        return null;
+      /*
+       * Every resolved address failed to connect - happy-eyeballs exhausted,
+       * typically a dual-stack host with a dead IPv6 route. This used to
+       * return null, and a null step result is never POSTed to the ingest API
+       * at all (see Probe/Utils/Monitors/Monitor.ts), so the monitor would sit
+       * at its creation status forever: no criteria evaluation, no timeline
+       * event, no monitor log, nothing to grep for. It is a definite offline
+       * answer and must be reported like one.
+       *
+       * Detected by the error's own name rather than by the friendly message,
+       * because getFriendlyErrorMessage rewrites an AggregateError into its
+       * joined child messages and strips the name. The name check is also
+       * what works across realms, where instanceof does not - and the global
+       * AggregateError type is not in this project's es2017 lib.
+       */
+      if ((err as Error)?.name === "AggregateError") {
+        return {
+          isOnline: false,
+          isTimeout: false,
+          failureCause:
+            "Request failed with AggregateError (all connection attempts failed). " +
+            API.getFriendlyErrorMessage(err as Error),
+          responseTimeInMs:
+            responseReceivedAt.getTime() - attemptedAt.getTime(),
+          probeAttempts: pingOptions.attempts,
+          totalAttempts: pingOptions.attempts.length,
+        };
       }
 
       return {
         isOnline: false,
         isTimeout: false,
         failureCause: API.getFriendlyErrorMessage(err as Error),
+        responseTimeInMs: responseReceivedAt.getTime() - attemptedAt.getTime(),
         probeAttempts: pingOptions.attempts,
         totalAttempts: pingOptions.attempts.length,
       };
     }
   }
 
+  /*
+   * Hostname.hostname is the whole authority, not a bare host: URL.fromString
+   * hands the Hostname constructor the full "example.com:8443" string and
+   * leaves Hostname.port unset (Hostname.fromString would split it, but
+   * URL.fromString does not use it). Reading the two fields naively therefore
+   * dialled the literal name "example.com:8443" on port 443, so every SSL
+   * Certificate monitor pointed at a non-443 port failed to resolve on every
+   * single check - silently, because a check that only ever fails looks
+   * identical to one that never runs.
+   *
+   * The WHATWG parser is what the HTTP client itself uses to read a URL, so
+   * agreeing with it here is what keeps the host and port from disagreeing
+   * with the connection actually made.
+   */
+  public static getHostAndPort(url: URL): { host: string; port: number } {
+    try {
+      const parsed: globalThis.URL = new globalThis.URL(url.toString());
+
+      /*
+       * WHATWG keeps an IPv6 literal bracketed; tls.connect wants it bare.
+       */
+      const host: string =
+        parsed.hostname.startsWith("[") && parsed.hostname.endsWith("]")
+          ? parsed.hostname.slice(1, -1)
+          : parsed.hostname;
+
+      if (host) {
+        return {
+          host: host,
+          port: parsed.port ? Number(parsed.port) : 443,
+        };
+      }
+    } catch {
+      // Fall back to this project's own parse below.
+    }
+
+    return {
+      host: url.hostname.hostname,
+      port: url.hostname.port?.toNumber() || 443,
+    };
+  }
+
+  /*
+   * `timeoutInMs` is the budget for the whole certificate fetch, not for one
+   * connection. Two handshakes can happen here - a strict one, then a
+   * permissive one whose only job is to identify an untrusted chain - and they
+   * share the deadline. Giving each the full timeout would make the monitor's
+   * Timeout setting quietly mean twice what the user asked for, and ping()'s
+   * retry ladder would then multiply that again.
+   */
   public static async getSslMonitorResponse(
     host: string,
-    port = 443,
+    port: number = 443,
+    timeoutInMs: number = DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS,
   ): Promise<SslResponse> {
+    const deadlineAt: number =
+      OneUptimeDate.getCurrentDate().getTime() + timeoutInMs;
+
     let isSelfSigned: boolean = false;
     let certificate: tls.PeerCertificate | null = null;
 
@@ -178,29 +297,34 @@ export default class SSLMonitor {
         host,
         port,
         rejectUnauthorized: true,
+        timeoutInMs: SSLMonitor.getRemainingTimeInMs(deadlineAt),
       });
     } catch {
-      try {
-        certificate = await this.getCertificate({
-          host,
-          port,
-          rejectUnauthorized: false,
-        });
+      /*
+       * A failed strict handshake is the only signal available that the chain
+       * is untrusted, so the permissive retry is what identifies a self-signed
+       * certificate. Keep it unconditional - narrowing it to a list of OpenSSL
+       * verify codes would silently change which certificates are reported as
+       * self signed.
+       *
+       * This used to return { isOnline: false, failureCause } instead of
+       * letting the failure propagate, which made every error path in ping()
+       * dead code: the user's retry count was never applied, probeAttempts was
+       * always 1, and an "Is Timeout" criteria on an SSL monitor could never
+       * fire. Throwing is what makes those live.
+       */
+      certificate = await this.getCertificate({
+        host,
+        port,
+        rejectUnauthorized: false,
+        timeoutInMs: SSLMonitor.getRemainingTimeInMs(deadlineAt),
+      });
 
-        isSelfSigned = true;
-      } catch (err) {
-        return {
-          isOnline: false,
-          failureCause: API.getFriendlyErrorMessage(err as Error),
-        };
-      }
+      isSelfSigned = true;
     }
 
     if (!certificate) {
-      return {
-        isOnline: false,
-        failureCause: "No certificate found",
-      };
+      throw new BadDataException("No certificate found");
     }
 
     const res: SslResponse = {
@@ -221,6 +345,13 @@ export default class SSLMonitor {
     };
 
     return res;
+  }
+
+  private static getRemainingTimeInMs(deadlineAt: number): number {
+    return Math.max(
+      deadlineAt - OneUptimeDate.getCurrentDate().getTime(),
+      MIN_SSL_HANDSHAKE_TIMEOUT_IN_MS,
+    );
   }
 
   /*
@@ -247,78 +378,125 @@ export default class SSLMonitor {
     host: string;
     port: number;
     rejectUnauthorized: boolean;
-    retry?: number;
-    currentRetryCount?: number;
+    timeoutInMs: number;
   }): Promise<tls.PeerCertificate> {
-    const { host, rejectUnauthorized } = data;
+    const { host, rejectUnauthorized, timeoutInMs } = data;
 
     let { port } = data;
-    const retry: number = data.retry || 3;
-    const currentRetryCount: number = data.currentRetryCount || 1;
 
     if (!port) {
       port = 443;
     }
 
-    const sslPromise: Promise<tls.PeerCertificate> = new Promise(
+    /*
+     * Retries used to live here as well as in ping(), which nested three
+     * ladders - ping retry x strict/permissive pass x this one - into up to 18
+     * sequential connection attempts, each of them unbounded. Retrying is
+     * ping()'s job: it owns the user's configured retry count and it is the
+     * layer that records probeAttempts. This one attempt is bounded and always
+     * settles.
+     */
+    return new Promise(
       (
         resolve: (value: tls.PeerCertificate) => void,
         reject: (err: Error) => void,
-      ) => {
+      ): void => {
         const requestOptions: https.RequestOptions = this.getOptions(
           host,
           port,
           rejectUnauthorized,
         );
 
-        let isResolvedOrRejected: boolean = false;
+        /*
+         * Socket-level timeout: covers a peer that completes the TCP
+         * connection and then stalls the TLS handshake. https.get on its own
+         * sets no socket timeout and will wait on that forever.
+         */
+        requestOptions.timeout = timeoutInMs;
 
-        const req: ClientRequest = https.get(
-          requestOptions,
-          (res: IncomingMessage) => {
-            const certificate: tls.PeerCertificate = (
-              res.socket as TLSSocket
-            ).getPeerCertificate();
-            if (ObjectUtil.isEmpty(certificate) || certificate === null) {
-              isResolvedOrRejected = true;
-              return reject(new BadDataException("No certificate found"));
-            }
-            isResolvedOrRejected = true;
-            return resolve(certificate);
-          },
-        );
+        let hasSettled: boolean = false;
+        let deadlineTimer: NodeJS.Timeout | undefined = undefined;
+        let request: ClientRequest | undefined = undefined;
 
-        req.end();
-
-        req.on("error", (err: Error) => {
-          if (!isResolvedOrRejected) {
-            isResolvedOrRejected = true;
-            return reject(err);
+        const finish: () => void = (): void => {
+          if (deadlineTimer) {
+            clearTimeout(deadlineTimer);
+            deadlineTimer = undefined;
           }
+
+          request?.destroy();
+        };
+
+        const resolveOnce: (certificate: tls.PeerCertificate) => void = (
+          certificate: tls.PeerCertificate,
+        ): void => {
+          if (hasSettled) {
+            return;
+          }
+
+          hasSettled = true;
+          finish();
+          resolve(certificate);
+        };
+
+        const rejectOnce: (err: Error) => void = (err: Error): void => {
+          if (hasSettled) {
+            return;
+          }
+
+          hasSettled = true;
+          finish();
+          reject(err);
+        };
+
+        const onDeadline: () => void = (): void => {
+          /*
+           * The message is string-matched by ping() ("timeout" + "exceeded")
+           * to set isTimeout on the reported response - keep both words.
+           */
+          rejectOnce(
+            new UnableToReachServer(
+              `SSL handshake with ${host}:${port} timeout exceeded`,
+            ),
+          );
+        };
+
+        /*
+         * Absolute attempt deadline. requestOptions.timeout only arms once a
+         * socket exists, so it does not cover hostname resolution or a connect
+         * that never completes; this does.
+         */
+        deadlineTimer = setTimeout(onDeadline, timeoutInMs);
+
+        request = https.get(requestOptions, (res: IncomingMessage): void => {
+          const certificate: tls.PeerCertificate = (
+            res.socket as TLSSocket
+          ).getPeerCertificate();
+
+          /*
+           * The certificate is on the socket the moment the response headers
+           * arrive and the body is never read. Without destroying the response
+           * the one-off agent (agent: false) holds the socket open until the
+           * body drains - which never happens while nothing reads it - leaking
+           * one TLS socket and fd per check. Small pages fit the stream buffer
+           * and self-close, which is why this only ever bit real sites.
+           */
+          res.destroy();
+
+          if (ObjectUtil.isEmpty(certificate) || certificate === null) {
+            return rejectOnce(new BadDataException("No certificate found"));
+          }
+
+          return resolveOnce(certificate);
+        });
+
+        request.on("timeout", onDeadline);
+
+        request.on("error", (err: Error): void => {
+          rejectOnce(err);
         });
       },
     );
-
-    try {
-      const certificate: tls.PeerCertificate = await sslPromise;
-      return certificate;
-    } catch (err: unknown) {
-      logger.debug(
-        `getCertificate failed for host ${host}:${port} - Retry: ${currentRetryCount} - Error: ${err}`,
-      );
-
-      if (currentRetryCount < retry) {
-        await Sleep.sleep(1000);
-        return await this.getCertificate({
-          host,
-          port,
-          rejectUnauthorized,
-          retry,
-          currentRetryCount: currentRetryCount + 1,
-        });
-      }
-      throw err;
-    }
   }
 
   private static getOptions(


### PR DESCRIPTION
Fixes #3225.

## What the reporter saw

An SSL Certificate monitor pointed at `https://self-signed.badssl.com/` stayed Operational for 10+ minutes. A production SSL monitor created three days earlier had exactly **one** monitor status event — its creation event. No incidents, and nothing in the probe logs to grep for.

Their conclusion was that the monitor type never executes. It's not quite that, and the distinction matters because there are **two independent bugs** here that produce an identical, completely silent symptom.

> One thing in the report is a false negative worth noting: `grep "SSL Certificate Monitor"` returns 0 because that string has never existed. The SSL monitor logs `Pinging host: <id> <url> - Retry: N`, at debug level. Likewise, "one status event in three days" is the *expected* output of a monitor whose status never changes — timeline rows are written only on change. Neither observation was wrong about there being a bug; they just weren't measuring it.

## Cause 1 — the check could hang forever (the production monitor)

`SSLMonitor` accepted a `timeout` option and never read it. Node's `https.get` applies no default socket timeout, so against a host that completes the TCP connection and then stalls the TLS handshake — a middlebox, a WAF, a half-dead load balancer — **the promise never settled**.

That hung the probe worker for that monitor. No result was ever POSTed to the ingest API, so there was no criteria evaluation, no timeline event, and no monitor log. And because `nextPingAt` is advanced inside the claiming transaction *before* any probing happens, the cycle was silently lost while the row still looked correctly scheduled in the database. Every cycle, forever.

`getCertificate` now carries both a socket timeout and an absolute deadline (the socket timeout only arms once a socket exists, so it doesn't cover DNS or a connect that never completes), with a settle-once guard so the timer, the error handler and the response callback can't double-settle. The strict and permissive handshake passes share **one** budget — giving each the full timeout would quietly make the user's Timeout setting mean 2×, and the retry ladder would multiply that again.

## Cause 2 — a criteria set where nothing matches is silent (the badssl monitor)

The probe handled `self-signed.badssl.com` correctly all along: strict handshake fails, permissive retry succeeds, result is `{isOnline: true, isSelfSigned: true}`, POSTed every 2 minutes. The reporter's two criteria — `Is Valid Certificate = True` for Operational and `Is Online = False` for Down — simply cannot both-or-either match that response. And when no criteria matches and the monitor is already at its default status, nothing at all is written.

How that configuration came to exist: the "Add Filter" button hardcoded `CheckOn.IsOnline` for every non-metric monitor type, but `IsOnline` wasn't in the SSL Certificate dropdown — so the checkOn select rendered blank over a live value, and a user who touched only the second select saved a filter they never knowingly chose. Nothing rejected it either; the save-time checkOn guard covered Ping and nothing else.

**DNSSEC had the same bug, worse**: `DnssecMonitorCriteria` had no `IsOnline` branch at all, so the seeded filter was inert in both directions.

Fix: one authoritative `CriteriaFilterUtil.getSupportedCheckOns(monitorType)` in Common that both the dropdown and the save-time validation read, so they can't drift apart again. SSL Certificate and DNSSEC gain the reachability checks their evaluators already read (SSL) or now read (DNSSEC). Un-audited types return `undefined` and are unconstrained exactly as before.

**The shipped default criteria was never affected** — `IsNotAValidCertificate = True` does fire on a self-signed host, and there's a test pinning that.

## Also fixed — same silent-failure class, found along the way

- **SSL monitors on a non-443 port never worked.** `Hostname.hostname` is the whole authority and `URL.fromString` leaves `Hostname.port` unset, so the check dialled the literal name `example.com:8443` on port 443. Host and port now come from the WHATWG parser — the same one the HTTP client uses.
- **`getSslMonitorResponse` swallowed its own errors**, which made every error path in `ping()` dead code: the user's retry count was never applied, `probeAttempts` was always 1, and an `Is Timeout` criteria on an SSL monitor could never fire.
- **An `AggregateError` returned `null`** — and a null step result is never POSTed to the ingest API at all. Dead code today, but it goes live the moment the throw above is fixed, so it ships in the same change.
- **A timed-out handshake reported `isOnline: true`.** A handshake that never completed is not a reachable endpoint.
- **One TLS socket and fd leaked per check** on any host serving a page over ~144 KB: the response body was never drained or destroyed, so the one-off agent held the socket open. Small pages fit the stream buffer and self-close, which is why this only bit real sites.
- **`IsSelfSignedCertificate` and `IsExpiredCertificate` reported green for unreachable hosts** — the probe still ships an `sslResponse` on failure, so "not self signed" / "not expired" was answered from an empty object. Both now gate on reachability the way `IsValidCertificate` always has.
- **SSL never reported a response time**, so the response-time graph the UI offers for it could never have a point.
- **`retry: 0` meant five attempts.** Harmless while the ladder was dead; a regression the moment it went live.

## Tests

`Probe/Tests/Utils/Monitors/MonitorTypes/SslMonitor.test.ts` is new (26 tests) and drives real TLS servers with openssl-generated certs, following the existing mTLS probe tests. Covers self-signed detection, certificate fields and validity parsing, expired certs, socket cleanup, host/port parsing, retry semantics, the AggregateError and probe-offline paths, and — the core regression — a raw TCP server that accepts and never speaks TLS.

I verified the new tests actually fail against the unfixed code rather than just passing vacuously:

- Disabling both deadlines: the four timeout tests **hang for the full 60s jest timeout** — the reported bug, reproduced.
- Reverting the two criteria gates: those three tests fail.

Also added: full CheckOn × FilterType coverage for `SSLMonitorCriteria` including the reporter's exact configuration; DNSSEC reachability coverage; a parity invariant (`CriteriaFilterSupportedCheckOns.test.ts`) asserting every CheckOn on a type's supported list is actually answered by that type's evaluator — the test that would have caught this whole class in one shot; and dropdown/validation parity tests.

`npm run fix` is clean, all three projects compile, and the focused Common suites are 118/118 (3075 tests) with Probe at 20/20 (451 tests).

> 10 suites under `Common/Tests/Server/Utils/Monitor/` fail to *run* on my machine with an `isolated-vm` native-module ABI mismatch. I confirmed by stashing that they fail identically on a pristine tree — unrelated to this change.

## Risk

**SSL monitors that have been silently failing will start reporting Down on the first cycle after upgrade.** That is the point of the fix, but on an instance with several broken SSL monitors it's an incident storm at once, and worth a line in the release notes.

Smaller ones: `IsSelfSignedCertificate = False` / `IsExpiredCertificate = False` now return indeterminate on a dead host instead of green — correct, but a behaviour change for anyone using either as their only Operational filter. And the save-time validation now runs on edit as well as create; `IsOnline` and `IsRequestTimeout` are deliberately kept on the SSL and DNSSEC lists precisely so the reporter's own monitor stays saveable.

## Deliberately not in this PR

- `MonitorProbeService.claimMonitorProbesForProbing` still advances `nextPingAt` at claim time. That's what makes the claim at-most-once across probe replicas under `FOR UPDATE ... SKIP LOCKED`; a proper lease and reaper is a scheduler redesign, not a bug fix. Bounding every terminal path is what makes a lost cycle non-permanent.
- `MonitorResource` discards the result of its monitor-step lookup, so multi-step monitors are always evaluated against step 0's criteria. Real, but unrelated to this symptom and behaviour-changing for existing multi-step monitors — filed separately.
- A per-monitor deadline in `FetchList`, and several monitor types passing the probe-wide retry default instead of the user's — both filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
