### PR TITLE
perf: reduce CPU/memory hot spots in DB metadata layer, worker jobs, and request path

### DIFF
--- a/App/FeatureSet/Telemetry/API/ProbeIngest/Probe.ts
+++ b/App/FeatureSet/Telemetry/API/ProbeIngest/Probe.ts
@@ -5,7 +5,6 @@ import BadDataException from "Common/Types/Exception/BadDataException";
 import { JSONObject } from "Common/Types/JSON";
 import JSONFunctions from "Common/Types/JSONFunctions";
 import ObjectID from "Common/Types/ObjectID";
-import ProbeMonitorResponse from "Common/Types/Probe/ProbeMonitorResponse";
 import ProbeStatusReport from "Common/Types/Probe/ProbeStatusReport";
 import GlobalConfigService from "Common/Server/Services/GlobalConfigService";
 import MailService from "Common/Server/Services/MailService";
@@ -279,11 +278,7 @@ router.post(
     next: NextFunction,
   ): Promise<void> => {
     try {
-      const probeResponse: ProbeMonitorResponse = JSONFunctions.deserialize(
-        req.body["probeMonitorResponse"],
-      ) as any;
-
-      if (!probeResponse) {
+      if (!req.body["probeMonitorResponse"]) {
         return Response.sendErrorResponse(
           req,
           res,
@@ -351,13 +346,9 @@ router.post(
     next: NextFunction,
   ): Promise<void> => {
     try {
-      const probeResponse: ProbeMonitorResponse = JSONFunctions.deserialize(
-        req.body["probeMonitorResponse"],
-      ) as any;
+      const testIdInParams: string | undefined = req.params["testId"];
 
-      const testId: ObjectID = new ObjectID(req.params["testId"] as string);
-
-      if (!testId) {
+      if (!testIdInParams) {
         return Response.sendErrorResponse(
           req,
           res,
@@ -365,13 +356,15 @@ router.post(
         );
       }
 
-      if (!probeResponse) {
+      if (!req.body["probeMonitorResponse"]) {
         return Response.sendErrorResponse(
           req,
           res,
           new BadDataException("ProbeMonitorResponse not found"),
         );
       }
+
+      const testId: ObjectID = new ObjectID(testIdInParams);
 
       // Return response immediately
       Response.sendEmptySuccessResponse(req, res);

--- a/App/FeatureSet/Workers/Jobs/AlertEpisode/ResolveInactiveEpisodes.ts
+++ b/App/FeatureSet/Workers/Jobs/AlertEpisode/ResolveInactiveEpisodes.ts
@@ -6,7 +6,9 @@ import AlertGroupingRuleService from "Common/Server/Services/AlertGroupingRuleSe
 import logger from "Common/Server/Utils/Logger";
 import AlertEpisode from "Common/Models/DatabaseModels/AlertEpisode";
 import AlertGroupingRule from "Common/Models/DatabaseModels/AlertGroupingRule";
+import ObjectID from "Common/Types/ObjectID";
 import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
 
 RunCron(
   "AlertEpisode:ResolveInactiveEpisodes",
@@ -44,10 +46,21 @@ RunCron(
         `AlertEpisode:ResolveInactiveEpisodes - Found ${activeEpisodes.length} active episodes`,
       );
 
+      if (activeEpisodes.length === 0) {
+        return;
+      }
+
+      /*
+       * Episodes cluster by grouping rule, so fetch each distinct rule once
+       * per tick instead of once per episode.
+       */
+      const rulesById: Map<string, AlertGroupingRule> =
+        await fetchGroupingRules(activeEpisodes);
+
       const promises: Array<Promise<void>> = [];
 
       for (const episode of activeEpisodes) {
-        promises.push(checkAndResolveInactiveEpisode(episode));
+        promises.push(checkAndResolveInactiveEpisode(episode, rulesById));
       }
 
       await Promise.allSettled(promises);
@@ -57,12 +70,66 @@ RunCron(
   },
 );
 
+type FetchGroupingRulesFunction = (
+  episodes: Array<AlertEpisode>,
+) => Promise<Map<string, AlertGroupingRule>>;
+
+const fetchGroupingRules: FetchGroupingRulesFunction = async (
+  episodes: Array<AlertEpisode>,
+): Promise<Map<string, AlertGroupingRule>> => {
+  const rulesById: Map<string, AlertGroupingRule> = new Map();
+
+  const distinctRuleIds: Map<string, ObjectID> = new Map();
+  for (const episode of episodes) {
+    if (episode.alertGroupingRuleId) {
+      distinctRuleIds.set(
+        episode.alertGroupingRuleId.toString(),
+        episode.alertGroupingRuleId,
+      );
+    }
+  }
+
+  if (distinctRuleIds.size === 0) {
+    return rulesById;
+  }
+
+  const rules: Array<AlertGroupingRule> = await AlertGroupingRuleService.findBy(
+    {
+      query: {
+        _id: QueryHelper.any([...distinctRuleIds.values()]),
+      },
+      select: {
+        _id: true,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: true,
+      },
+      props: {
+        isRoot: true,
+      },
+      limit: LIMIT_MAX,
+      skip: 0,
+    },
+  );
+
+  for (const rule of rules) {
+    if (rule.id) {
+      rulesById.set(rule.id.toString(), rule);
+    }
+  }
+
+  return rulesById;
+};
+
 type CheckAndResolveInactiveEpisodeFunction = (
   episode: AlertEpisode,
+  rulesById: Map<string, AlertGroupingRule>,
 ) => Promise<void>;
 
 const checkAndResolveInactiveEpisode: CheckAndResolveInactiveEpisodeFunction =
-  async (episode: AlertEpisode): Promise<void> => {
+  async (
+    episode: AlertEpisode,
+    rulesById: Map<string, AlertGroupingRule>,
+  ): Promise<void> => {
     try {
       if (!episode.id || !episode.projectId) {
         return;
@@ -73,17 +140,9 @@ const checkAndResolveInactiveEpisode: CheckAndResolveInactiveEpisodeFunction =
       let enableInactivityTimeout: boolean = false;
 
       if (episode.alertGroupingRuleId) {
-        const rule: AlertGroupingRule | null =
-          await AlertGroupingRuleService.findOneById({
-            id: episode.alertGroupingRuleId,
-            select: {
-              enableInactivityTimeout: true,
-              inactivityTimeoutMinutes: true,
-            },
-            props: {
-              isRoot: true,
-            },
-          });
+        const rule: AlertGroupingRule | undefined = rulesById.get(
+          episode.alertGroupingRuleId.toString(),
+        );
 
         if (rule) {
           enableInactivityTimeout = rule.enableInactivityTimeout || false;

--- a/App/FeatureSet/Workers/Jobs/AlertOwners/SendCreatedResourceNotification.ts
+++ b/App/FeatureSet/Workers/Jobs/AlertOwners/SendCreatedResourceNotification.ts
@@ -133,6 +133,38 @@ RunCron(
         alert.alertNumberWithPrefix ||
         (alert.alertNumber ? `#${alert.alertNumber}` : "");
 
+      /*
+       * These values do not vary per owner, so convert them once per alert
+       * instead of once per owner notification. A conversion failure must
+       * stay contained to this alert, like every other failure in this loop.
+       */
+      let alertDescriptionHtml: string = "";
+      let remediationNotesHtml: string = "";
+      let rootCauseHtml: string = "";
+
+      try {
+        alertDescriptionHtml = await Markdown.convertToHTML(
+          alert.description! || "",
+          MarkdownContentType.Email,
+        );
+
+        remediationNotesHtml =
+          (await Markdown.convertToHTML(
+            alert.remediationNotes! || "",
+            MarkdownContentType.Email,
+          )) || "";
+
+        rootCauseHtml =
+          (await Markdown.convertToHTML(
+            alert.rootCause || "No root cause identified for this alert",
+            MarkdownContentType.Email,
+          )) || "";
+      } catch (e) {
+        logger.error("Error in sending alert created resource notification");
+        logger.error(e);
+        continue;
+      }
+
       for (const user of owners) {
         try {
           const alertIdentifier: string =
@@ -145,10 +177,7 @@ RunCron(
             alertNumber: alertNumberStr,
             projectName: alert.project!.name!,
             currentState: alert.currentAlertState!.name!,
-            alertDescription: await Markdown.convertToHTML(
-              alert.description! || "",
-              MarkdownContentType.Email,
-            ),
+            alertDescription: alertDescriptionHtml,
             resourcesAffected: alert.monitor?.name || "None",
             alertSeverity: alert.alertSeverity!.name!,
             declaredAt: OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones(
@@ -158,16 +187,8 @@ RunCron(
               },
             ),
             declaredBy: declaredBy,
-            remediationNotes:
-              (await Markdown.convertToHTML(
-                alert.remediationNotes! || "",
-                MarkdownContentType.Email,
-              )) || "",
-            rootCause:
-              (await Markdown.convertToHTML(
-                alert.rootCause || "No root cause identified for this alert",
-                MarkdownContentType.Email,
-              )) || "",
+            remediationNotes: remediationNotesHtml,
+            rootCause: rootCauseHtml,
             alertViewLink: (
               await AlertService.getAlertLinkInDashboard(
                 alert.projectId!,

--- a/App/FeatureSet/Workers/Jobs/AlertOwners/SendStateChangeNotification.ts
+++ b/App/FeatureSet/Workers/Jobs/AlertOwners/SendStateChangeNotification.ts
@@ -86,6 +86,9 @@ RunCron(
           },
           alertNumber: true,
           alertNumberWithPrefix: true,
+          alertSeverity: {
+            name: true,
+          },
         },
       });
 
@@ -94,24 +97,6 @@ RunCron(
       }
 
       const alertState: AlertState = alertStateTimeline.alertState!;
-
-      // get alert severity
-      const alertWithSeverity: Alert | null = await AlertService.findOneById({
-        id: alert.id!,
-        props: {
-          isRoot: true,
-        },
-        select: {
-          _id: true,
-          alertSeverity: {
-            name: true,
-          },
-        },
-      });
-
-      if (!alertWithSeverity) {
-        continue;
-      }
 
       await AlertStateTimelineService.updateOneById({
         id: alertStateTimeline.id!,
@@ -205,6 +190,11 @@ RunCron(
         alert.alertNumberWithPrefix ||
         (alert.alertNumber ? `#${alert.alertNumber}` : "");
 
+      const alertDescriptionHtml: string = await Markdown.convertToHTML(
+        alert.description! || "",
+        MarkdownContentType.Email,
+      );
+
       for (const user of owners) {
         const alertIdentifier: string =
           alert.alertNumber !== undefined
@@ -226,17 +216,14 @@ RunCron(
           previousState: previousState?.name || "",
           previousStateColor: previousState?.color?.toString() || "#6b7280",
           previousStateDurationText: previousStateDurationText,
-          alertDescription: await Markdown.convertToHTML(
-            alert.description! || "",
-            MarkdownContentType.Email,
-          ),
+          alertDescription: alertDescriptionHtml,
           resourcesAffected: alert.monitor?.name || "",
           stateChangedAt:
             OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones({
               date: alertStateTimeline.createdAt!,
               timezones: user.timezone ? [user.timezone] : [],
             }),
-          alertSeverity: alertWithSeverity.alertSeverity!.name!,
+          alertSeverity: alert.alertSeverity!.name!,
           alertViewLink: (
             await AlertService.getAlertLinkInDashboard(
               alertStateTimeline.projectId!,

--- a/App/FeatureSet/Workers/Jobs/IncidentEpisode/ResolveInactiveEpisodes.ts
+++ b/App/FeatureSet/Workers/Jobs/IncidentEpisode/ResolveInactiveEpisodes.ts
@@ -6,7 +6,9 @@ import IncidentGroupingRuleService from "Common/Server/Services/IncidentGrouping
 import logger from "Common/Server/Utils/Logger";
 import IncidentEpisode from "Common/Models/DatabaseModels/IncidentEpisode";
 import IncidentGroupingRule from "Common/Models/DatabaseModels/IncidentGroupingRule";
+import ObjectID from "Common/Types/ObjectID";
 import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
 
 RunCron(
   "IncidentEpisode:ResolveInactiveEpisodes",
@@ -44,10 +46,21 @@ RunCron(
         `IncidentEpisode:ResolveInactiveEpisodes - Found ${activeEpisodes.length} active episodes`,
       );
 
+      if (activeEpisodes.length === 0) {
+        return;
+      }
+
+      /*
+       * Episodes cluster by grouping rule, so fetch each distinct rule once
+       * per tick instead of once per episode.
+       */
+      const rulesById: Map<string, IncidentGroupingRule> =
+        await fetchGroupingRules(activeEpisodes);
+
       const promises: Array<Promise<void>> = [];
 
       for (const episode of activeEpisodes) {
-        promises.push(checkAndResolveInactiveEpisode(episode));
+        promises.push(checkAndResolveInactiveEpisode(episode, rulesById));
       }
 
       await Promise.allSettled(promises);
@@ -57,12 +70,65 @@ RunCron(
   },
 );
 
+type FetchGroupingRulesFunction = (
+  episodes: Array<IncidentEpisode>,
+) => Promise<Map<string, IncidentGroupingRule>>;
+
+const fetchGroupingRules: FetchGroupingRulesFunction = async (
+  episodes: Array<IncidentEpisode>,
+): Promise<Map<string, IncidentGroupingRule>> => {
+  const rulesById: Map<string, IncidentGroupingRule> = new Map();
+
+  const distinctRuleIds: Map<string, ObjectID> = new Map();
+  for (const episode of episodes) {
+    if (episode.incidentGroupingRuleId) {
+      distinctRuleIds.set(
+        episode.incidentGroupingRuleId.toString(),
+        episode.incidentGroupingRuleId,
+      );
+    }
+  }
+
+  if (distinctRuleIds.size === 0) {
+    return rulesById;
+  }
+
+  const rules: Array<IncidentGroupingRule> =
+    await IncidentGroupingRuleService.findBy({
+      query: {
+        _id: QueryHelper.any([...distinctRuleIds.values()]),
+      },
+      select: {
+        _id: true,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: true,
+      },
+      props: {
+        isRoot: true,
+      },
+      limit: LIMIT_MAX,
+      skip: 0,
+    });
+
+  for (const rule of rules) {
+    if (rule.id) {
+      rulesById.set(rule.id.toString(), rule);
+    }
+  }
+
+  return rulesById;
+};
+
 type CheckAndResolveInactiveEpisodeFunction = (
   episode: IncidentEpisode,
+  rulesById: Map<string, IncidentGroupingRule>,
 ) => Promise<void>;
 
 const checkAndResolveInactiveEpisode: CheckAndResolveInactiveEpisodeFunction =
-  async (episode: IncidentEpisode): Promise<void> => {
+  async (
+    episode: IncidentEpisode,
+    rulesById: Map<string, IncidentGroupingRule>,
+  ): Promise<void> => {
     try {
       if (!episode.id || !episode.projectId) {
         return;
@@ -73,17 +139,9 @@ const checkAndResolveInactiveEpisode: CheckAndResolveInactiveEpisodeFunction =
       let enableInactivityTimeout: boolean = false;
 
       if (episode.incidentGroupingRuleId) {
-        const rule: IncidentGroupingRule | null =
-          await IncidentGroupingRuleService.findOneById({
-            id: episode.incidentGroupingRuleId,
-            select: {
-              enableInactivityTimeout: true,
-              inactivityTimeoutMinutes: true,
-            },
-            props: {
-              isRoot: true,
-            },
-          });
+        const rule: IncidentGroupingRule | undefined = rulesById.get(
+          episode.incidentGroupingRuleId.toString(),
+        );
 
         if (rule) {
           enableInactivityTimeout = rule.enableInactivityTimeout || false;

--- a/App/FeatureSet/Workers/Jobs/IncidentOwners/SendCreatedResourceNotification.ts
+++ b/App/FeatureSet/Workers/Jobs/IncidentOwners/SendCreatedResourceNotification.ts
@@ -135,6 +135,38 @@ Notification sent to owners because [Incident ${incidentNumberDisplay}](${(await
         incident.incidentNumberWithPrefix ||
         (incident.incidentNumber ? `#${incident.incidentNumber}` : "");
 
+      /*
+       * These values do not vary per owner, so convert them once per incident
+       * instead of once per owner notification. A conversion failure must
+       * stay contained to this incident, like every other failure in this loop.
+       */
+      let incidentDescriptionHtml: string = "";
+      let remediationNotesHtml: string = "";
+      let rootCauseHtml: string = "";
+
+      try {
+        incidentDescriptionHtml = await Markdown.convertToHTML(
+          incident.description! || "",
+          MarkdownContentType.Email,
+        );
+
+        remediationNotesHtml =
+          (await Markdown.convertToHTML(
+            incident.remediationNotes! || "",
+            MarkdownContentType.Email,
+          )) || "";
+
+        rootCauseHtml =
+          (await Markdown.convertToHTML(
+            incident.rootCause || "No root cause identified for this incident",
+            MarkdownContentType.Email,
+          )) || "";
+      } catch (e) {
+        logger.error("Error in sending incident created resource notification");
+        logger.error(e);
+        continue;
+      }
+
       for (const user of owners) {
         try {
           const vars: Dictionary<string> = {
@@ -142,10 +174,7 @@ Notification sent to owners because [Incident ${incidentNumberDisplay}](${(await
             incidentNumber: incidentNumberStr,
             projectName: incident.project!.name!,
             currentState: incident.currentIncidentState!.name!,
-            incidentDescription: await Markdown.convertToHTML(
-              incident.description! || "",
-              MarkdownContentType.Email,
-            ),
+            incidentDescription: incidentDescriptionHtml,
             resourcesAffected:
               incident
                 .monitors!.map((monitor: Monitor) => {
@@ -160,17 +189,8 @@ Notification sent to owners because [Incident ${incidentNumberDisplay}](${(await
               },
             ),
             declaredBy: declaredBy,
-            remediationNotes:
-              (await Markdown.convertToHTML(
-                incident.remediationNotes! || "",
-                MarkdownContentType.Email,
-              )) || "",
-            rootCause:
-              (await Markdown.convertToHTML(
-                incident.rootCause ||
-                  "No root cause identified for this incident",
-                MarkdownContentType.Email,
-              )) || "",
+            remediationNotes: remediationNotesHtml,
+            rootCause: rootCauseHtml,
             incidentViewLink: (
               await IncidentService.getIncidentLinkInDashboard(
                 incident.projectId!,

--- a/App/FeatureSet/Workers/Jobs/IncidentOwners/SendStateChangeNotification.ts
+++ b/App/FeatureSet/Workers/Jobs/IncidentOwners/SendStateChangeNotification.ts
@@ -90,6 +90,9 @@ RunCron(
           },
           incidentNumber: true,
           incidentNumberWithPrefix: true,
+          incidentSeverity: {
+            name: true,
+          },
         },
       });
 
@@ -98,25 +101,6 @@ RunCron(
       }
 
       const incidentState: IncidentState = incidentStateTimeline.incidentState!;
-
-      // get incident severity
-      const incidentWithSeverity: Incident | null =
-        await IncidentService.findOneById({
-          id: incident.id!,
-          props: {
-            isRoot: true,
-          },
-          select: {
-            _id: true,
-            incidentSeverity: {
-              name: true,
-            },
-          },
-        });
-
-      if (!incidentWithSeverity) {
-        continue;
-      }
 
       await IncidentStateTimelineService.updateOneById({
         id: incidentStateTimeline.id!,
@@ -217,6 +201,11 @@ RunCron(
         incident.incidentNumberWithPrefix ||
         (incident.incidentNumber ? `#${incident.incidentNumber}` : "");
 
+      const incidentDescriptionHtml: string = await Markdown.convertToHTML(
+        incident.description! || "",
+        MarkdownContentType.Email,
+      );
+
       for (const user of owners) {
         // Build the "Was X for Y" string
         const previousStateDurationText: string =
@@ -233,17 +222,14 @@ RunCron(
           previousState: previousState?.name || "",
           previousStateColor: previousState?.color?.toString() || "#6b7280",
           previousStateDurationText: previousStateDurationText,
-          incidentDescription: await Markdown.convertToHTML(
-            incident.description! || "",
-            MarkdownContentType.Email,
-          ),
+          incidentDescription: incidentDescriptionHtml,
           resourcesAffected: resourcesAffected || "None",
           stateChangedAt:
             OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones({
               date: incidentStateTimeline.createdAt!,
               timezones: user.timezone ? [user.timezone] : [],
             }),
-          incidentSeverity: incidentWithSeverity.incidentSeverity!.name!,
+          incidentSeverity: incident.incidentSeverity!.name!,
           incidentViewLink: (
             await IncidentService.getIncidentLinkInDashboard(
               incidentStateTimeline.projectId!,

--- a/App/FeatureSet/Workers/Jobs/IncidentOwners/SendUnresolvedReminderNotification.ts
+++ b/App/FeatureSet/Workers/Jobs/IncidentOwners/SendUnresolvedReminderNotification.ts
@@ -215,6 +215,15 @@ const sendReminderForIncident: SendReminderForIncidentFunction = async (
     await IncidentService.getIncidentLinkInDashboard(projectId, incidentId)
   ).toString();
 
+  /*
+   * The description does not vary per owner, so convert it once per incident
+   * instead of once per owner notification.
+   */
+  const incidentDescriptionHtml: string = await Markdown.convertToHTML(
+    incident.description! || "",
+    MarkdownContentType.Email,
+  );
+
   let moreIncidentFeedInformationInMarkdown: string = "";
 
   for (const user of owners) {
@@ -228,10 +237,7 @@ const sendReminderForIncident: SendReminderForIncidentFunction = async (
         date: openedAt,
         timezones: user.timezone ? [user.timezone] : [],
       }),
-      incidentDescription: await Markdown.convertToHTML(
-        incident.description! || "",
-        MarkdownContentType.Email,
-      ),
+      incidentDescription: incidentDescriptionHtml,
       resourcesAffected: resourcesAffected || "None",
       incidentSeverity: incident.incidentSeverity?.name || "",
       incidentViewLink: incidentViewLink,

--- a/App/FeatureSet/Workers/Jobs/MonitorOwners/SendStatusChangeNotification.ts
+++ b/App/FeatureSet/Workers/Jobs/MonitorOwners/SendStatusChangeNotification.ts
@@ -168,6 +168,28 @@ RunCron(
         continue;
       }
 
+      /*
+       * These values do not vary per owner, so compute them once per status
+       * timeline instead of once per owner notification.
+       */
+      const monitorDescriptionHtml: string = await Markdown.convertToHTML(
+        monitor.description! || "",
+        MarkdownContentType.Email,
+      );
+
+      const monitorViewLink: string = (
+        await MonitorService.getMonitorLinkInDashboard(
+          monitorStatusTimeline.projectId!,
+          monitor.id!,
+        )
+      ).toString();
+
+      const rootCauseHtml: string =
+        (await Markdown.convertToHTML(
+          monitorStatusTimeline.rootCause || "",
+          MarkdownContentType.Email,
+        )) || "";
+
       for (const user of owners) {
         // Build the "Was X for Y" string
         const previousStatusDurationText: string =
@@ -183,26 +205,14 @@ RunCron(
           previousStatus: previousStatus?.name || "",
           previousStatusColor: previousStatus?.color?.toString() || "#94a3b8",
           previousStatusDurationText: previousStatusDurationText,
-          monitorDescription: await Markdown.convertToHTML(
-            monitor.description! || "",
-            MarkdownContentType.Email,
-          ),
+          monitorDescription: monitorDescriptionHtml,
           statusChangedAt:
             OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones({
               date: monitorStatusTimeline.createdAt!,
               timezones: user.timezone ? [user.timezone] : [],
             }),
-          monitorViewLink: (
-            await MonitorService.getMonitorLinkInDashboard(
-              monitorStatusTimeline.projectId!,
-              monitor.id!,
-            )
-          ).toString(),
-          rootCause:
-            (await Markdown.convertToHTML(
-              monitorStatusTimeline.rootCause || "",
-              MarkdownContentType.Email,
-            )) || "",
+          monitorViewLink: monitorViewLink,
+          rootCause: rootCauseHtml,
           monitorDestination: destinationInfo.monitorDestination,
           requestType: destinationInfo.requestType,
           monitorType: destinationInfo.monitorType,

--- a/App/Tests/Telemetry/ProbeIngestPayloadGuard.test.ts
+++ b/App/Tests/Telemetry/ProbeIngestPayloadGuard.test.ts
@@ -1,0 +1,448 @@
+import { mockRouter } from "Common/Tests/Server/API/Helpers";
+import Response from "Common/Server/Utils/Response";
+import BadDataException from "Common/Types/Exception/BadDataException";
+import { JSONObject } from "Common/Types/JSON";
+import JSONFunctions from "Common/Types/JSONFunctions";
+import ObjectID from "Common/Types/ObjectID";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "Common/Server/Utils/Express";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Regression tests for the probeMonitorResponse presence guards on
+ * POST /probe/response/ingest and
+ * POST /probe/response/monitor-test-ingest/:testId.
+ *
+ * Both handlers used to run JSONFunctions.deserialize over the ENTIRE probe
+ * payload — response bodies, screenshots, hundreds of KB — only to feed a
+ * truthiness guard that could never fire: deserialize(undefined) returns {},
+ * which is truthy. The raw req.body is what gets queued and the worker
+ * deserializes it again, so the handler's deserialize was pure CPU waste on
+ * every single probe report. The guards now check the RAW body value (the
+ * same pattern ProcessProbeIngest uses), which also means a missing payload
+ * finally gets the 400 the guard always intended instead of a 200 plus a
+ * doomed queue job.
+ */
+
+jest.mock("Common/Server/Utils/Express", () => {
+  return {
+    __esModule: true,
+    default: {
+      getRouter: () => {
+        return mockRouter;
+      },
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Response", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendEmptySuccessResponse: jest.fn(),
+      sendErrorResponse: jest.fn(),
+      sendJsonObjectResponse: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    // The route module imports this named export for log attribution.
+    getLogAttributesFromRequest: jest.fn(() => {
+      return {};
+    }),
+  };
+});
+
+jest.mock("Common/Server/Services/ProbeService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: jest.fn(),
+      updateLastAlive: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../FeatureSet/Telemetry/Middleware/ProbeAuthorization", () => {
+  return {
+    __esModule: true,
+    default: {
+      isAuthorizedServiceMiddleware: jest.fn(),
+    },
+  };
+});
+
+// The queue module pulls in BullMQ at import time; mock it out entirely.
+jest.mock(
+  "../../FeatureSet/Telemetry/Services/Queue/TelemetryQueueService",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        addProbeIngestJob: jest.fn(),
+        addSnmpTrapIngestJob: jest.fn(),
+        getQueueStats: jest.fn(),
+        getQueueSize: jest.fn(),
+        getFailedJobs: jest.fn(),
+      },
+    };
+  },
+);
+
+jest.mock("Common/Server/Middleware/ClusterKeyAuthorization", () => {
+  return {
+    __esModule: true,
+    default: {
+      isAuthorizedServiceMiddleware: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/MailService", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendMail: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/GlobalConfigService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getOwners: jest.fn(),
+      getActiveProjectStatusQuery: jest.fn(() => {
+        return {};
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/MonitorProbeService", () => {
+  return {
+    __esModule: true,
+    default: {
+      countBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/MonitorService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getEnabledMonitorQuery: jest.fn(() => {
+        return {};
+      }),
+    },
+  };
+});
+
+/*
+ * Importing the router module registers its routes on the mocked router so
+ * each handler can be invoked directly. The probe-auth middleware is mocked
+ * out; on the real server it runs before the handler.
+ */
+import "../../FeatureSet/Telemetry/API/ProbeIngest/Probe";
+import ProbeAuthorization from "../../FeatureSet/Telemetry/Middleware/ProbeAuthorization";
+import TelemetryQueueService from "../../FeatureSet/Telemetry/Services/Queue/TelemetryQueueService";
+
+const queueService: { addProbeIngestJob: jest.Mock } =
+  TelemetryQueueService as unknown as { addProbeIngestJob: jest.Mock };
+
+const responseUtil: {
+  sendEmptySuccessResponse: jest.Mock;
+  sendErrorResponse: jest.Mock;
+  sendJsonObjectResponse: jest.Mock;
+} = Response as unknown as {
+  sendEmptySuccessResponse: jest.Mock;
+  sendErrorResponse: jest.Mock;
+  sendJsonObjectResponse: jest.Mock;
+};
+
+/*
+ * The handlers must never deserialize — the payload rides to the queue raw
+ * and the worker deserializes it there. Spying (not mocking) keeps the real
+ * implementation for anything else that legitimately calls it.
+ */
+const deserializeSpy: jest.Mock = jest.spyOn(
+  JSONFunctions,
+  "deserialize",
+) as unknown as jest.Mock;
+
+const mockResponse: ExpressResponse = {} as ExpressResponse;
+
+function makeRequest(data: {
+  body?: JSONObject | undefined;
+  params?: Record<string, string> | undefined;
+}): ExpressRequest {
+  return {
+    body: data.body || {},
+    params: data.params || {},
+  } as unknown as ExpressRequest;
+}
+
+type CallEndpointFunction = (
+  path: string,
+  req: ExpressRequest,
+) => Promise<{ next: NextFunction }>;
+
+const callEndpoint: CallEndpointFunction = async (
+  path: string,
+  req: ExpressRequest,
+): Promise<{ next: NextFunction }> => {
+  const next: NextFunction = jest.fn() as unknown as NextFunction;
+  await mockRouter.match("post", path).handlerFunction(req, mockResponse, next);
+  return { next };
+};
+
+/*
+ * A payload shaped like the wire format the probe actually sends: still in
+ * SERIALIZED form ({ _type: ... } wrappers) plus bulky fields, because the
+ * whole point is that the handler must forward it untouched, not decode it.
+ */
+function makeProbeMonitorResponsePayload(): JSONObject {
+  return {
+    _type: "ProbeMonitorResponse",
+    monitorId: { _type: "ObjectID", value: ObjectID.generate().toString() },
+    probeId: { _type: "ObjectID", value: ObjectID.generate().toString() },
+    responseBody: "x".repeat(2048),
+    screenshots: { "home-page": "data:image/png;base64,AAAA" },
+    monitoredAt: { _type: "DateTime", value: "2026-08-18T00:00:00.000Z" },
+  };
+}
+
+function expectBadDataError(message: string): void {
+  expect(responseUtil.sendErrorResponse).toHaveBeenCalledTimes(1);
+  const error: unknown = responseUtil.sendErrorResponse.mock.calls[0]![2];
+  expect(error).toBeInstanceOf(BadDataException);
+  expect((error as BadDataException).message).toBe(message);
+}
+
+describe("POST /probe/response/ingest", () => {
+  const path: string = "/probe/response/ingest";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("is registered with the probe-auth middleware", () => {
+    expect(mockRouter.match("post", path).middleware).toBe(
+      ProbeAuthorization.isAuthorizedServiceMiddleware,
+    );
+  });
+
+  /*
+   * THE guard pin: the old code deserialized undefined into {} (truthy), so
+   * a body with no probeMonitorResponse sailed past the guard, got a 200,
+   * and enqueued a job the worker was doomed to reject.
+   */
+  test("missing probeMonitorResponse: 400 error and nothing enqueued", async () => {
+    const { next } = await callEndpoint(
+      path,
+      makeRequest({ body: { probeId: "some-probe" } }),
+    );
+
+    expectBadDataError("ProbeMonitorResponse not found");
+    expect(queueService.addProbeIngestJob).not.toHaveBeenCalled();
+    expect(responseUtil.sendJsonObjectResponse).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test("valid payload: processing response and the RAW req.body enqueued untouched", async () => {
+    const body: JSONObject = {
+      probeMonitorResponse: makeProbeMonitorResponsePayload(),
+      probeId: "some-probe",
+    };
+    const bodySnapshot: string = JSON.stringify(body);
+    const req: ExpressRequest = makeRequest({ body });
+
+    const { next } = await callEndpoint(path, req);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(responseUtil.sendErrorResponse).not.toHaveBeenCalled();
+    expect(responseUtil.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+    expect(responseUtil.sendJsonObjectResponse).toHaveBeenCalledWith(
+      req,
+      mockResponse,
+      { result: "processing" },
+    );
+
+    expect(queueService.addProbeIngestJob).toHaveBeenCalledTimes(1);
+    const jobArg: JSONObject = queueService.addProbeIngestJob.mock
+      .calls[0]![0] as JSONObject;
+    // The very same object — no copy, no re-shaping.
+    expect(jobArg["probeMonitorResponse"]).toBe(req.body);
+    expect(jobArg["jobType"]).toBe("probe-response");
+    // ...and byte-identical to what the probe sent (still serialized form).
+    expect(JSON.stringify(jobArg["probeMonitorResponse"])).toBe(bodySnapshot);
+  });
+
+  test("never deserializes the payload — the worker owns that", async () => {
+    await callEndpoint(
+      path,
+      makeRequest({
+        body: { probeMonitorResponse: makeProbeMonitorResponsePayload() },
+      }),
+    );
+
+    expect(deserializeSpy).not.toHaveBeenCalled();
+  });
+
+  test("responds BEFORE enqueueing, so probe latency never waits on Redis", async () => {
+    await callEndpoint(
+      path,
+      makeRequest({
+        body: { probeMonitorResponse: makeProbeMonitorResponsePayload() },
+      }),
+    );
+
+    const respondOrder: number =
+      responseUtil.sendJsonObjectResponse.mock.invocationCallOrder[0]!;
+    const enqueueOrder: number =
+      queueService.addProbeIngestJob.mock.invocationCallOrder[0]!;
+    expect(respondOrder).toBeLessThan(enqueueOrder);
+  });
+
+  test("passes queue failures to the error handler", async () => {
+    const boom: Error = new Error("redis down");
+    queueService.addProbeIngestJob.mockRejectedValueOnce(boom as never);
+
+    const { next } = await callEndpoint(
+      path,
+      makeRequest({
+        body: { probeMonitorResponse: makeProbeMonitorResponsePayload() },
+      }),
+    );
+
+    expect(next).toHaveBeenCalledWith(boom);
+  });
+});
+
+describe("POST /probe/response/monitor-test-ingest/:testId", () => {
+  const path: string = "/probe/response/monitor-test-ingest/:testId";
+  const testId: ObjectID = ObjectID.generate();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("is registered with the probe-auth middleware", () => {
+    expect(mockRouter.match("post", path).middleware).toBe(
+      ProbeAuthorization.isAuthorizedServiceMiddleware,
+    );
+  });
+
+  test("missing probeMonitorResponse: 400 error and nothing enqueued", async () => {
+    const { next } = await callEndpoint(
+      path,
+      makeRequest({
+        body: { probeId: "some-probe" },
+        params: { testId: testId.toString() },
+      }),
+    );
+
+    expectBadDataError("ProbeMonitorResponse not found");
+    expect(queueService.addProbeIngestJob).not.toHaveBeenCalled();
+    expect(responseUtil.sendEmptySuccessResponse).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The old guard checked `!new ObjectID(...)` — an object, always truthy,
+   * so a request with no testId param was waved through and enqueued.
+   */
+  test("missing testId param: 400 error and nothing enqueued", async () => {
+    const { next } = await callEndpoint(
+      path,
+      makeRequest({
+        body: { probeMonitorResponse: makeProbeMonitorResponsePayload() },
+        params: {},
+      }),
+    );
+
+    expectBadDataError("TestId not found");
+    expect(queueService.addProbeIngestJob).not.toHaveBeenCalled();
+    expect(responseUtil.sendEmptySuccessResponse).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test("valid payload: empty success and the RAW req.body enqueued with the testId", async () => {
+    const body: JSONObject = {
+      probeMonitorResponse: makeProbeMonitorResponsePayload(),
+    };
+    const bodySnapshot: string = JSON.stringify(body);
+    const req: ExpressRequest = makeRequest({
+      body,
+      params: { testId: testId.toString() },
+    });
+
+    const { next } = await callEndpoint(path, req);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(responseUtil.sendErrorResponse).not.toHaveBeenCalled();
+    expect(responseUtil.sendEmptySuccessResponse).toHaveBeenCalledTimes(1);
+    expect(responseUtil.sendEmptySuccessResponse).toHaveBeenCalledWith(
+      req,
+      mockResponse,
+    );
+
+    expect(queueService.addProbeIngestJob).toHaveBeenCalledTimes(1);
+    const jobArg: JSONObject = queueService.addProbeIngestJob.mock
+      .calls[0]![0] as JSONObject;
+    expect(jobArg["probeMonitorResponse"]).toBe(req.body);
+    expect(jobArg["jobType"]).toBe("monitor-test");
+    expect(jobArg["testId"]).toBe(testId.toString());
+    expect(JSON.stringify(jobArg["probeMonitorResponse"])).toBe(bodySnapshot);
+  });
+
+  test("never deserializes the payload — the worker owns that", async () => {
+    await callEndpoint(
+      path,
+      makeRequest({
+        body: { probeMonitorResponse: makeProbeMonitorResponsePayload() },
+        params: { testId: testId.toString() },
+      }),
+    );
+
+    expect(deserializeSpy).not.toHaveBeenCalled();
+  });
+
+  test("responds BEFORE enqueueing, so probe latency never waits on Redis", async () => {
+    await callEndpoint(
+      path,
+      makeRequest({
+        body: { probeMonitorResponse: makeProbeMonitorResponsePayload() },
+        params: { testId: testId.toString() },
+      }),
+    );
+
+    const respondOrder: number =
+      responseUtil.sendEmptySuccessResponse.mock.invocationCallOrder[0]!;
+    const enqueueOrder: number =
+      queueService.addProbeIngestJob.mock.invocationCallOrder[0]!;
+    expect(respondOrder).toBeLessThan(enqueueOrder);
+  });
+});

--- a/App/Tests/Workers/Jobs/AlertEpisode/ResolveInactiveEpisodes.test.ts
+++ b/App/Tests/Workers/Jobs/AlertEpisode/ResolveInactiveEpisodes.test.ts
@@ -1,0 +1,617 @@
+import AlertEpisode from "Common/Models/DatabaseModels/AlertEpisode";
+import AlertGroupingRule from "Common/Models/DatabaseModels/AlertGroupingRule";
+import OneUptimeDate from "Common/Types/Date";
+import ObjectID from "Common/Types/ObjectID";
+
+/*
+ * Regression tests for the AlertEpisode:ResolveInactiveEpisodes cron's query
+ * fan-out (the line-for-line twin of IncidentEpisode:ResolveInactiveEpisodes -
+ * keep the two suites symmetric). The job runs EVERY FIVE MINUTES over up to
+ * 1000 active episodes; it used to issue one
+ * AlertGroupingRuleService.findOneById PER EPISODE inside an unbounded
+ * Promise.allSettled fanout - up to 1000 concurrent point SELECTs per tick for
+ * a handful of distinct rules. The perf fix hoists the rule lookups into ONE
+ * batched findBy over the distinct rule ids before the episode fan-out. These
+ * tests pin:
+ *   1. the batch shape: exactly one grouping-rule findBy per tick over the
+ *      deduplicated rule ids (skipped entirely when no episode carries a rule
+ *      id), and - THE regression being removed - zero findOneById / findOneBy
+ *      calls on any of the services,
+ *   2. the decision semantics are unchanged: timeout-disabled / zero-timeout /
+ *      missing-rule / no-rule-id episodes never resolve, the inactivity
+ *      threshold boundary on lastAlertAddedAt (with the createdAt fallback),
+ *      the resolveEpisode arguments (no user, cascade to alerts), and the
+ *      Promise.allSettled isolation between episodes.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler (the same recorder the other
+ * App/Tests/Workers/Jobs suites use) and each test drives one full tick.
+ */
+
+type CronHandler = () => Promise<void>;
+
+/*
+ * Captured cron handlers, keyed by job name. Must be declared before the job
+ * import below so the mock factory closure can see it.
+ */
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+/*
+ * findOneById / findOneBy are mocked ALONGSIDE the batched findBy on every
+ * service precisely so the suite can prove they are never called: if the job
+ * regressed back to per-episode point reads, the assertions would flag it
+ * instead of the mock throwing "not a function".
+ */
+jest.mock("Common/Server/Services/AlertEpisodeService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+      resolveEpisode: jest.fn(),
+      findOneBy: jest.fn(),
+      findOneById: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/AlertGroupingRuleService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+      findOneBy: jest.fn(),
+      findOneById: jest.fn(),
+    },
+  };
+});
+
+import AlertEpisodeService from "Common/Server/Services/AlertEpisodeService";
+import AlertGroupingRuleService from "Common/Server/Services/AlertGroupingRuleService";
+import logger from "Common/Server/Utils/Logger";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/AlertEpisode/ResolveInactiveEpisodes";
+
+interface EpisodeServiceMock {
+  findBy: jest.Mock;
+  resolveEpisode: jest.Mock;
+  findOneBy: jest.Mock;
+  findOneById: jest.Mock;
+}
+
+interface FindByServiceMock {
+  findBy: jest.Mock;
+  findOneBy: jest.Mock;
+  findOneById: jest.Mock;
+}
+
+const episodeService: EpisodeServiceMock =
+  AlertEpisodeService as unknown as EpisodeServiceMock;
+const ruleService: FindByServiceMock =
+  AlertGroupingRuleService as unknown as FindByServiceMock;
+const mockedLogger: { error: jest.Mock } = logger as unknown as {
+  error: jest.Mock;
+};
+
+const NOW: Date = new Date("2026-07-27T10:00:00.000Z");
+
+const PROJECT_1_ID: ObjectID = new ObjectID("project-1");
+const RULE_1_ID: ObjectID = new ObjectID("rule-1");
+const RULE_2_ID: ObjectID = new ObjectID("rule-2");
+const EPISODE_1_ID: ObjectID = new ObjectID("episode-1");
+const EPISODE_2_ID: ObjectID = new ObjectID("episode-2");
+const EPISODE_3_ID: ObjectID = new ObjectID("episode-3");
+const EPISODE_4_ID: ObjectID = new ObjectID("episode-4");
+const EPISODE_5_ID: ObjectID = new ObjectID("episode-5");
+
+// The inactivity timeout the enabled rules use, in minutes.
+const TIMEOUT_MINUTES: number = 30;
+
+function minutesBeforeNow(minutes: number, extraSeconds?: number): Date {
+  return new Date(NOW.getTime() - minutes * 60000 - (extraSeconds || 0) * 1000);
+}
+
+function makeEpisode(data: {
+  id: ObjectID;
+  projectId?: ObjectID | undefined;
+  ruleId?: ObjectID | undefined;
+  lastAlertAddedAt?: Date | undefined;
+  createdAt?: Date | undefined;
+}): AlertEpisode {
+  const episode: AlertEpisode = new AlertEpisode(data.id);
+
+  if (data.projectId) {
+    episode.projectId = data.projectId;
+  }
+
+  if (data.ruleId) {
+    episode.alertGroupingRuleId = data.ruleId;
+  }
+
+  if (data.lastAlertAddedAt) {
+    episode.lastAlertAddedAt = data.lastAlertAddedAt;
+  }
+
+  if (data.createdAt) {
+    episode.createdAt = data.createdAt;
+  }
+
+  return episode;
+}
+
+function makeRule(data: {
+  id: ObjectID;
+  enableInactivityTimeout?: boolean | undefined;
+  inactivityTimeoutMinutes?: number | undefined;
+}): AlertGroupingRule {
+  const rule: AlertGroupingRule = new AlertGroupingRule(data.id);
+  rule.enableInactivityTimeout = data.enableInactivityTimeout || false;
+
+  if (data.inactivityTimeoutMinutes !== undefined) {
+    rule.inactivityTimeoutMinutes = data.inactivityTimeoutMinutes;
+  }
+
+  return rule;
+}
+
+/*
+ * Reads the id list bound into one of QueryHelper.any's Raw predicates
+ * (typeorm keeps the bound parameters on the FindOperator).
+ */
+function boundIdsOf(predicate: unknown): Array<string> {
+  const parameters: Record<string, Array<string>> | undefined = (
+    predicate as {
+      objectLiteralParameters?: Record<string, Array<string>> | undefined;
+    }
+  ).objectLiteralParameters;
+
+  expect(parameters).toBeDefined();
+
+  const values: Array<Array<string>> = Object.values(parameters!);
+
+  expect(values).toHaveLength(1);
+
+  return values[0]!;
+}
+
+interface FindByArgs {
+  query: Record<string, unknown>;
+  select: Record<string, unknown>;
+  limit: number;
+  skip: number;
+}
+
+interface ResolveEpisodeArgs {
+  episodeId: ObjectID;
+  userId: unknown;
+  cascade: unknown;
+}
+
+function resolveCalls(): Array<ResolveEpisodeArgs> {
+  return episodeService.resolveEpisode.mock.calls.map(
+    (args: Array<unknown>) => {
+      return {
+        episodeId: args[0] as ObjectID,
+        userId: args[1],
+        cascade: args[2],
+      };
+    },
+  );
+}
+
+function resolvedEpisodeIds(): Array<string> {
+  return resolveCalls().map((call: ResolveEpisodeArgs) => {
+    return call.episodeId.toString();
+  });
+}
+
+/*
+ * THE regression this change removed: per-episode findOneById / findOneBy
+ * point reads. Every test asserts none of them ever fire.
+ */
+function expectNoPerRowLookups(): void {
+  expect(episodeService.findOneBy).not.toHaveBeenCalled();
+  expect(episodeService.findOneById).not.toHaveBeenCalled();
+  expect(ruleService.findOneBy).not.toHaveBeenCalled();
+  expect(ruleService.findOneById).not.toHaveBeenCalled();
+}
+
+async function runWorkerTick(): Promise<void> {
+  const handler: CronHandler | undefined =
+    mockCapturedJobs["AlertEpisode:ResolveInactiveEpisodes"];
+
+  if (!handler) {
+    throw new Error(
+      "AlertEpisode:ResolveInactiveEpisodes did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await handler();
+}
+
+describe("AlertEpisode:ResolveInactiveEpisodes worker", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(OneUptimeDate, "getCurrentDate").mockImplementation(() => {
+      return new Date(NOW);
+    });
+
+    episodeService.findBy.mockResolvedValue([]);
+    episodeService.resolveEpisode.mockResolvedValue(undefined);
+    ruleService.findBy.mockResolvedValue([]);
+  });
+
+  test("batches grouping rules once per tick over the distinct rule ids - never per-episode point reads", async () => {
+    // 5 stale episodes sharing exactly TWO distinct grouping rules.
+    episodeService.findBy.mockResolvedValue([
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      makeEpisode({
+        id: EPISODE_2_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_2_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      makeEpisode({
+        id: EPISODE_3_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      makeEpisode({
+        id: EPISODE_4_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_2_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      makeEpisode({
+        id: EPISODE_5_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+    ]);
+    ruleService.findBy.mockResolvedValue([
+      makeRule({
+        id: RULE_1_ID,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+      makeRule({
+        id: RULE_2_ID,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+    ]);
+
+    await runWorkerTick();
+
+    // The episode list itself is still one page of active (unresolved) episodes.
+    expect(episodeService.findBy).toHaveBeenCalledTimes(1);
+
+    const episodeArgs: FindByArgs = episodeService.findBy.mock
+      .calls[0]![0] as FindByArgs;
+    const resolvedAtPredicate: { getSql?: (alias: string) => string } =
+      episodeArgs.query["resolvedAt"] as {
+        getSql?: (alias: string) => string;
+      };
+
+    expect(resolvedAtPredicate.getSql!("resolvedAt")).toBe(
+      "(resolvedAt IS NULL)",
+    );
+    expect(episodeArgs.limit).toBe(1000);
+    expect(episodeArgs.skip).toBe(0);
+
+    // ONE grouping-rule batch over exactly the 2 distinct rule ids (deduplicated).
+    expect(ruleService.findBy).toHaveBeenCalledTimes(1);
+
+    const ruleArgs: FindByArgs = ruleService.findBy.mock
+      .calls[0]![0] as FindByArgs;
+
+    expect(boundIdsOf(ruleArgs.query["_id"])).toEqual([
+      RULE_1_ID.toString(),
+      RULE_2_ID.toString(),
+    ]);
+    // _id is needed to key the map; the timeout fields drive the decision.
+    expect(ruleArgs.select).toEqual({
+      _id: true,
+      enableInactivityTimeout: true,
+      inactivityTimeoutMinutes: true,
+    });
+    /*
+     * The batch must page wide enough (LIMIT_MAX) for every distinct rule id
+     * behind the 1000-episode page — a smaller limit would silently drop
+     * rules and leave their episodes treated as rule-less.
+     */
+    expect(ruleArgs.limit).toBe(10000);
+    expect(ruleArgs.skip).toBe(0);
+
+    // The batch completes BEFORE the per-episode fan-out starts resolving.
+    expect(ruleService.findBy.mock.invocationCallOrder[0]!).toBeLessThan(
+      episodeService.resolveEpisode.mock.invocationCallOrder[0]!,
+    );
+
+    // Every stale episode resolves: no user, cascade to member alerts.
+    expect(episodeService.resolveEpisode).toHaveBeenCalledTimes(5);
+
+    for (const call of resolveCalls()) {
+      expect(call.userId).toBeUndefined();
+      expect(call.cascade).toBe(true);
+    }
+
+    expectNoPerRowLookups();
+  });
+
+  test("timeout disabled, zero timeout, missing rule, and no rule id never resolve - only the enabled stale episode does", async () => {
+    const zeroTimeoutRuleId: ObjectID = new ObjectID("rule-zero-timeout");
+    const deletedRuleId: ObjectID = new ObjectID("rule-deleted");
+
+    episodeService.findBy.mockResolvedValue([
+      // Rule enabled with a real timeout and the episode is stale: resolves.
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      // Rule exists but the timeout toggle is off: never resolves.
+      makeEpisode({
+        id: EPISODE_2_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_2_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      // Rule enabled but with a zero timeout: never resolves.
+      makeEpisode({
+        id: EPISODE_3_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: zeroTimeoutRuleId,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      // Rule id points at a deleted rule: behaves exactly like no rule.
+      makeEpisode({
+        id: EPISODE_4_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: deletedRuleId,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      // No rule id at all: never resolves.
+      makeEpisode({
+        id: EPISODE_5_ID,
+        projectId: PROJECT_1_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+    ]);
+    ruleService.findBy.mockResolvedValue([
+      makeRule({
+        id: RULE_1_ID,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+      makeRule({
+        id: RULE_2_ID,
+        enableInactivityTimeout: false,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+      makeRule({
+        id: zeroTimeoutRuleId,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: 0,
+      }),
+      // The deleted rule is intentionally absent from the batched result.
+    ]);
+
+    await runWorkerTick();
+
+    // The deleted rule id was still asked for in the single batch...
+    expect(ruleService.findBy).toHaveBeenCalledTimes(1);
+
+    const ruleArgs: FindByArgs = ruleService.findBy.mock
+      .calls[0]![0] as FindByArgs;
+
+    expect(boundIdsOf(ruleArgs.query["_id"])).toEqual([
+      RULE_1_ID.toString(),
+      RULE_2_ID.toString(),
+      zeroTimeoutRuleId.toString(),
+      deletedRuleId.toString(),
+    ]);
+
+    // ...but only the enabled + stale episode resolves.
+    expect(resolvedEpisodeIds()).toEqual([EPISODE_1_ID.toString()]);
+
+    expectNoPerRowLookups();
+  });
+
+  test("inactivity threshold boundary: exactly at the timeout resolves, one second inside does not", async () => {
+    episodeService.findBy.mockResolvedValue([
+      // Last alert exactly TIMEOUT_MINUTES ago: minutes-since == timeout, resolve.
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES),
+      }),
+      // One second short of the timeout: still active, keep waiting.
+      makeEpisode({
+        id: EPISODE_2_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES - 1, 59),
+      }),
+    ]);
+    ruleService.findBy.mockResolvedValue([
+      makeRule({
+        id: RULE_1_ID,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+    ]);
+
+    await runWorkerTick();
+
+    expect(resolvedEpisodeIds()).toEqual([EPISODE_1_ID.toString()]);
+
+    expectNoPerRowLookups();
+  });
+
+  test("falls back to createdAt when lastAlertAddedAt is unset", async () => {
+    episodeService.findBy.mockResolvedValue([
+      // Created past the timeout, never received an alert: resolves.
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        createdAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      // Created inside the timeout window: still active.
+      makeEpisode({
+        id: EPISODE_2_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        createdAt: minutesBeforeNow(1),
+      }),
+    ]);
+    ruleService.findBy.mockResolvedValue([
+      makeRule({
+        id: RULE_1_ID,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+    ]);
+
+    await runWorkerTick();
+
+    expect(resolvedEpisodeIds()).toEqual([EPISODE_1_ID.toString()]);
+
+    expectNoPerRowLookups();
+  });
+
+  test("a tick with zero active episodes issues NO rule query at all", async () => {
+    episodeService.findBy.mockResolvedValue([]);
+
+    await runWorkerTick();
+
+    expect(ruleService.findBy).not.toHaveBeenCalled();
+    expect(episodeService.resolveEpisode).not.toHaveBeenCalled();
+
+    expectNoPerRowLookups();
+  });
+
+  test("episodes without any grouping rule id skip the rule batch entirely and never resolve", async () => {
+    episodeService.findBy.mockResolvedValue([
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      makeEpisode({
+        id: EPISODE_2_ID,
+        projectId: PROJECT_1_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+    ]);
+
+    await runWorkerTick();
+
+    // No episode carries a rule id, so there is nothing to batch-fetch.
+    expect(ruleService.findBy).not.toHaveBeenCalled();
+    // Without a rule the timeout stays disabled, so nothing resolves.
+    expect(episodeService.resolveEpisode).not.toHaveBeenCalled();
+
+    expectNoPerRowLookups();
+  });
+
+  test("one episode's resolve failure does not prevent the other episodes from resolving", async () => {
+    episodeService.findBy.mockResolvedValue([
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      makeEpisode({
+        id: EPISODE_2_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+    ]);
+    ruleService.findBy.mockResolvedValue([
+      makeRule({
+        id: RULE_1_ID,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+    ]);
+
+    episodeService.resolveEpisode.mockImplementation((episodeId: ObjectID) => {
+      if (episodeId.toString() === EPISODE_1_ID.toString()) {
+        return Promise.reject(new Error("db connection reset"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    // The tick itself must not reject (Promise.allSettled + per-episode catch).
+    await expect(runWorkerTick()).resolves.toBeUndefined();
+
+    // BOTH resolves were attempted; the failure only logged.
+    expect(resolvedEpisodeIds()).toEqual([
+      EPISODE_1_ID.toString(),
+      EPISODE_2_ID.toString(),
+    ]);
+    expect(mockedLogger.error).toHaveBeenCalled();
+
+    expectNoPerRowLookups();
+  });
+
+  test("a failed batched rule fetch aborts the whole tick and only logs - retried next tick", async () => {
+    episodeService.findBy.mockResolvedValue([
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastAlertAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+    ]);
+    ruleService.findBy.mockRejectedValue(new Error("db connection reset"));
+
+    await expect(runWorkerTick()).resolves.toBeUndefined();
+
+    expect(episodeService.resolveEpisode).not.toHaveBeenCalled();
+    expect(mockedLogger.error).toHaveBeenCalled();
+
+    expectNoPerRowLookups();
+  });
+});

--- a/App/Tests/Workers/Jobs/AlertOwners/SendCreatedResourceNotification.test.ts
+++ b/App/Tests/Workers/Jobs/AlertOwners/SendCreatedResourceNotification.test.ts
@@ -1,0 +1,531 @@
+import Alert from "Common/Models/DatabaseModels/Alert";
+import AlertSeverity from "Common/Models/DatabaseModels/AlertSeverity";
+import AlertState from "Common/Models/DatabaseModels/AlertState";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import Project from "Common/Models/DatabaseModels/Project";
+import User from "Common/Models/DatabaseModels/User";
+import OneUptimeDate from "Common/Types/Date";
+import Dictionary from "Common/Types/Dictionary";
+import Email from "Common/Types/Email";
+import { EmailEnvelope } from "Common/Types/Email/EmailMessage";
+import EmailTemplateType from "Common/Types/Email/EmailTemplateType";
+import Name from "Common/Types/Name";
+import ObjectID from "Common/Types/ObjectID";
+import Timezone from "Common/Types/Timezone";
+
+/*
+ * Regression tests for the AlertOwner:SendCreatedResourceEmail cron's
+ * per-owner fan-out. The job used to re-run, INSIDE the per-owner loop, three
+ * Markdown.convertToHTML conversions that never vary per owner: the alert
+ * description, the remediation notes, and the root cause - 3xN marked parses
+ * per alert. The perf fix hoists all three to once per alert, just above the
+ * owner loop (still inside the per-alert scope). These tests pin:
+ *   1. exactly THREE convertToHTML calls per alert regardless of owner count
+ *      (the old code did all three once PER OWNER: 9 calls for 3 owners),
+ *   2. the vars dictionary each owner receives is byte-identical to what the
+ *      old per-owner conversion produced,
+ *   3. the timezone-dependent declaredAt var still varies per user,
+ *   4. the per-user try/catch still isolates one owner's send failure,
+ *   5. the zero-owner continue still converts nothing at all.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler (the same recorder the other
+ * App/Tests/Workers/Jobs suites use) and each test drives one full tick.
+ * Markdown itself is REAL (spied, not stubbed) so the pinned HTML is the
+ * genuine marked output.
+ */
+
+type CronHandler = () => Promise<void>;
+
+/*
+ * Captured cron handlers, keyed by job name. Must be declared before the job
+ * import below so the mock factory closure can see it.
+ */
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+/*
+ * PasswordHash carries a pre-existing TS5.9 diagnostic that fails any suite
+ * whose runtime require graph reaches it. Nothing password-related is under
+ * test here, so the module is replaced WITH A FACTORY - an automock would
+ * still require (and type-check) the real file.
+ */
+jest.mock("Common/Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/AlertService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findAllBy: jest.fn(),
+      updateOneById: jest.fn(),
+      findOwners: jest.fn(),
+      getAlertLinkInDashboard: jest.fn(),
+      getAlertIdentifiedDate: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getOwners: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserNotificationSettingService", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendUserNotification: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/AlertFeedService", () => {
+  return {
+    __esModule: true,
+    default: {
+      createAlertFeedItem: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/PushNotificationUtil", () => {
+  return {
+    __esModule: true,
+    default: {
+      createAlertCreatedNotification: jest.fn(() => {
+        return {};
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/WhatsAppTemplateUtil", () => {
+  return {
+    __esModule: true,
+    createWhatsAppMessageFromTemplate: jest.fn(() => {
+      return { templateVariables: {} };
+    }),
+  };
+});
+
+import AlertFeedService from "Common/Server/Services/AlertFeedService";
+import AlertService from "Common/Server/Services/AlertService";
+import ProjectService from "Common/Server/Services/ProjectService";
+import UserNotificationSettingService from "Common/Server/Services/UserNotificationSettingService";
+import Markdown, { MarkdownContentType } from "Common/Server/Types/Markdown";
+import logger from "Common/Server/Utils/Logger";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/AlertOwners/SendCreatedResourceNotification";
+
+interface AlertServiceMock {
+  findAllBy: jest.Mock;
+  updateOneById: jest.Mock;
+  findOwners: jest.Mock;
+  getAlertLinkInDashboard: jest.Mock;
+  getAlertIdentifiedDate: jest.Mock;
+}
+
+const alertService: AlertServiceMock =
+  AlertService as unknown as AlertServiceMock;
+const projectService: { getOwners: jest.Mock } = ProjectService as unknown as {
+  getOwners: jest.Mock;
+};
+const notificationService: { sendUserNotification: jest.Mock } =
+  UserNotificationSettingService as unknown as {
+    sendUserNotification: jest.Mock;
+  };
+const feedService: { createAlertFeedItem: jest.Mock } =
+  AlertFeedService as unknown as { createAlertFeedItem: jest.Mock };
+const mockedLogger: { error: jest.Mock } = logger as unknown as {
+  error: jest.Mock;
+};
+
+const IDENTIFIED_AT: Date = new Date("2026-08-18T09:00:00.000Z");
+
+const PROJECT_ID: ObjectID = new ObjectID("project-1");
+const ALERT_ID: ObjectID = new ObjectID("alert-1");
+const ALERT_LINK: string = "https://oneuptime.test/dashboard/alert-1";
+
+const DESCRIPTION_MARKDOWN: string = "**Latency** is above the SLO";
+const REMEDIATION_MARKDOWN: string = "Restart the *ingest* pods";
+const ROOT_CAUSE_MARKDOWN: string = "A **bad deploy** saturated the queue";
+const DEFAULT_ROOT_CAUSE: string = "No root cause identified for this alert";
+
+function makeAlert(data: {
+  description?: string | undefined;
+  remediationNotes?: string | undefined;
+  rootCause?: string | undefined;
+}): Alert {
+  const alert: Alert = new Alert(ALERT_ID);
+  alert.projectId = PROJECT_ID;
+  alert.title = "High latency";
+
+  if (data.description !== undefined) {
+    alert.description = data.description;
+  }
+
+  if (data.remediationNotes !== undefined) {
+    alert.remediationNotes = data.remediationNotes;
+  }
+
+  if (data.rootCause !== undefined) {
+    alert.rootCause = data.rootCause;
+  }
+
+  const project: Project = new Project();
+  project.name = "Acme Status";
+  alert.project = project;
+
+  const state: AlertState = new AlertState();
+  state.name = "Created";
+  alert.currentAlertState = state;
+
+  const severity: AlertSeverity = new AlertSeverity();
+  severity.name = "Warning";
+  alert.alertSeverity = severity;
+
+  const monitor: Monitor = new Monitor();
+  monitor.name = "API Monitor";
+  alert.monitor = monitor;
+
+  alert.alertNumber = 7;
+
+  return alert;
+}
+
+function makeOwner(id: string, timezone?: Timezone | undefined): User {
+  const user: User = new User(new ObjectID(id));
+  user.name = new Name(`Owner ${id}`);
+  user.email = new Email(`${id}@acme.test`);
+
+  if (timezone) {
+    user.timezone = timezone;
+  }
+
+  return user;
+}
+
+// The vars of each sendUserNotification call's email envelope, in call order.
+function sentVars(): Array<Dictionary<string>> {
+  return notificationService.sendUserNotification.mock.calls.map(
+    (args: Array<unknown>) => {
+      return (args[0] as { emailEnvelope: EmailEnvelope }).emailEnvelope
+        .vars as Dictionary<string>;
+    },
+  );
+}
+
+async function runWorkerTick(): Promise<void> {
+  const handler: CronHandler | undefined =
+    mockCapturedJobs["AlertOwner:SendCreatedResourceEmail"];
+
+  if (!handler) {
+    throw new Error(
+      "AlertOwner:SendCreatedResourceEmail did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await handler();
+}
+
+describe("AlertOwner:SendCreatedResourceEmail worker", () => {
+  let markdownSpy: jest.SpyInstance;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Real conversion, spied - call counts are the regression under test.
+    markdownSpy = jest.spyOn(Markdown, "convertToHTML");
+
+    alertService.findAllBy.mockResolvedValue([]);
+    alertService.updateOneById.mockResolvedValue(undefined);
+    alertService.findOwners.mockResolvedValue([]);
+    alertService.getAlertLinkInDashboard.mockResolvedValue({
+      toString: (): string => {
+        return ALERT_LINK;
+      },
+    });
+    alertService.getAlertIdentifiedDate.mockResolvedValue(IDENTIFIED_AT);
+    projectService.getOwners.mockResolvedValue([]);
+    notificationService.sendUserNotification.mockResolvedValue(undefined);
+    feedService.createAlertFeedItem.mockResolvedValue(undefined);
+  });
+
+  test("converts description, remediation notes and root cause ONCE per alert for 3 owners - not once per owner", async () => {
+    alertService.findAllBy.mockResolvedValue([
+      makeAlert({
+        description: DESCRIPTION_MARKDOWN,
+        remediationNotes: REMEDIATION_MARKDOWN,
+        rootCause: ROOT_CAUSE_MARKDOWN,
+      }),
+    ]);
+    alertService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2"),
+      makeOwner("user-3"),
+    ]);
+
+    // What the old per-owner code produced for every owner, byte for byte.
+    const expectedDescriptionHtml: string = await Markdown.convertToHTML(
+      DESCRIPTION_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+    const expectedRemediationHtml: string =
+      (await Markdown.convertToHTML(
+        REMEDIATION_MARKDOWN,
+        MarkdownContentType.Email,
+      )) || "";
+    const expectedRootCauseHtml: string =
+      (await Markdown.convertToHTML(
+        ROOT_CAUSE_MARKDOWN,
+        MarkdownContentType.Email,
+      )) || "";
+
+    expect(expectedDescriptionHtml).toContain("<strong>Latency</strong>");
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    // THE regression: the old code converted all three once per owner (9 calls).
+    expect(markdownSpy).toHaveBeenCalledTimes(3);
+    expect(markdownSpy.mock.calls).toEqual([
+      [DESCRIPTION_MARKDOWN, MarkdownContentType.Email],
+      [REMEDIATION_MARKDOWN, MarkdownContentType.Email],
+      [ROOT_CAUSE_MARKDOWN, MarkdownContentType.Email],
+    ]);
+
+    expect(notificationService.sendUserNotification).toHaveBeenCalledTimes(3);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    const expectedVars: Dictionary<string> = {
+      alertTitle: "High latency",
+      alertNumber: "#7",
+      projectName: "Acme Status",
+      currentState: "Created",
+      alertDescription: expectedDescriptionHtml,
+      resourcesAffected: "API Monitor",
+      alertSeverity: "Warning",
+      declaredAt: OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones({
+        date: IDENTIFIED_AT,
+        timezones: [],
+      }),
+      declaredBy: "OneUptime",
+      remediationNotes: expectedRemediationHtml,
+      rootCause: expectedRootCauseHtml,
+      alertViewLink: ALERT_LINK,
+      isOwner: "true",
+    };
+
+    expect(allVars).toEqual([expectedVars, expectedVars, expectedVars]);
+
+    const emailEnvelope: EmailEnvelope = (
+      notificationService.sendUserNotification.mock.calls[0]![0] as {
+        emailEnvelope: EmailEnvelope;
+      }
+    ).emailEnvelope;
+
+    expect(emailEnvelope.templateType).toBe(
+      EmailTemplateType.AlertOwnerResourceCreated,
+    );
+    expect(emailEnvelope.subject).toBe("[New Alert #7] - High latency");
+
+    /*
+     * The dashboard link is NOT part of this fix: one call for the feed text
+     * plus one per owner, exactly as before.
+     */
+    expect(alertService.getAlertLinkInDashboard).toHaveBeenCalledTimes(4);
+
+    expect(feedService.createAlertFeedItem).toHaveBeenCalledTimes(1);
+  });
+
+  test("the timezone-dependent declaredAt var STAYS per-user while the conversions are still shared", async () => {
+    alertService.findAllBy.mockResolvedValue([
+      makeAlert({
+        description: DESCRIPTION_MARKDOWN,
+        remediationNotes: REMEDIATION_MARKDOWN,
+        rootCause: ROOT_CAUSE_MARKDOWN,
+      }),
+    ]);
+    alertService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2", Timezone.AmericaNew_York),
+    ]);
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    expect(markdownSpy).toHaveBeenCalledTimes(3);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    expect(allVars).toHaveLength(2);
+    expect(allVars[1]!["declaredAt"]).toBe(
+      OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones({
+        date: IDENTIFIED_AT,
+        timezones: [Timezone.AmericaNew_York],
+      }),
+    );
+    expect(allVars[0]!["declaredAt"]).not.toBe(allVars[1]!["declaredAt"]);
+
+    // Every owner-invariant field is still identical across the two owners.
+    const invariantFields0: Dictionary<string> = { ...allVars[0]! };
+    const invariantFields1: Dictionary<string> = { ...allVars[1]! };
+    delete invariantFields0["declaredAt"];
+    delete invariantFields1["declaredAt"];
+
+    expect(invariantFields0).toEqual(invariantFields1);
+  });
+
+  test("one owner's send failure is still isolated by the per-user try/catch - and conversions still ran only once", async () => {
+    alertService.findAllBy.mockResolvedValue([
+      makeAlert({
+        description: DESCRIPTION_MARKDOWN,
+        remediationNotes: REMEDIATION_MARKDOWN,
+        rootCause: ROOT_CAUSE_MARKDOWN,
+      }),
+    ]);
+    alertService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2"),
+      makeOwner("user-3"),
+    ]);
+
+    notificationService.sendUserNotification.mockImplementation(
+      (args: { userId: ObjectID }) => {
+        if (args.userId.toString() === "user-1") {
+          return Promise.reject(new Error("smtp connection reset"));
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+
+    markdownSpy.mockClear();
+
+    await expect(runWorkerTick()).resolves.toBeUndefined();
+
+    expect(markdownSpy).toHaveBeenCalledTimes(3);
+
+    // All three sends were attempted; the failure only logged.
+    expect(notificationService.sendUserNotification).toHaveBeenCalledTimes(3);
+    expect(mockedLogger.error).toHaveBeenCalled();
+
+    // Only the two owners whose send succeeded appear in the feed item.
+    expect(
+      (
+        feedService.createAlertFeedItem.mock.calls[0]![0] as {
+          moreInformationInMarkdown: string;
+        }
+      ).moreInformationInMarkdown,
+    ).toBe(
+      "**Notified**: Owner user-2 (user-2@acme.test)\n" +
+        "**Notified**: Owner user-3 (user-3@acme.test)\n",
+    );
+  });
+
+  test("an alert with no owners at all converts NOTHING - but is still marked owner-notified", async () => {
+    alertService.findAllBy.mockResolvedValue([
+      makeAlert({
+        description: DESCRIPTION_MARKDOWN,
+        remediationNotes: REMEDIATION_MARKDOWN,
+        rootCause: ROOT_CAUSE_MARKDOWN,
+      }),
+    ]);
+    alertService.findOwners.mockResolvedValue([]);
+    projectService.getOwners.mockResolvedValue([]);
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    expect(alertService.updateOneById).toHaveBeenCalledTimes(1);
+    expect(markdownSpy).not.toHaveBeenCalled();
+    expect(notificationService.sendUserNotification).not.toHaveBeenCalled();
+    expect(feedService.createAlertFeedItem).not.toHaveBeenCalled();
+  });
+
+  test("empty description/remediation and a missing root cause fall back exactly as the old code did, one conversion each", async () => {
+    alertService.findAllBy.mockResolvedValue([makeAlert({})]);
+    alertService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2"),
+      makeOwner("user-3"),
+    ]);
+
+    // The old code's exact expressions for the three fallback inputs.
+    const expectedEmptyHtml: string = await Markdown.convertToHTML(
+      "",
+      MarkdownContentType.Email,
+    );
+    const expectedDefaultRootCauseHtml: string =
+      (await Markdown.convertToHTML(
+        DEFAULT_ROOT_CAUSE,
+        MarkdownContentType.Email,
+      )) || "";
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    expect(markdownSpy).toHaveBeenCalledTimes(3);
+    expect(markdownSpy.mock.calls).toEqual([
+      ["", MarkdownContentType.Email],
+      ["", MarkdownContentType.Email],
+      [DEFAULT_ROOT_CAUSE, MarkdownContentType.Email],
+    ]);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    expect(allVars).toHaveLength(3);
+
+    for (const vars of allVars) {
+      expect(vars["alertDescription"]).toBe(expectedEmptyHtml);
+      expect(vars["remediationNotes"]).toBe(expectedEmptyHtml || "");
+      expect(vars["rootCause"]).toBe(expectedDefaultRootCauseHtml);
+    }
+  });
+});

--- a/App/Tests/Workers/Jobs/AlertOwners/SendStateChangeNotification.test.ts
+++ b/App/Tests/Workers/Jobs/AlertOwners/SendStateChangeNotification.test.ts
@@ -1,0 +1,749 @@
+import Alert from "Common/Models/DatabaseModels/Alert";
+import { AlertFeedEventType } from "Common/Models/DatabaseModels/AlertFeed";
+import AlertSeverity from "Common/Models/DatabaseModels/AlertSeverity";
+import AlertState from "Common/Models/DatabaseModels/AlertState";
+import AlertStateTimeline from "Common/Models/DatabaseModels/AlertStateTimeline";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import Project from "Common/Models/DatabaseModels/Project";
+import User from "Common/Models/DatabaseModels/User";
+import { Blue500, Red500 } from "Common/Types/BrandColors";
+import OneUptimeDate from "Common/Types/Date";
+import Dictionary from "Common/Types/Dictionary";
+import EmailTemplateType from "Common/Types/Email/EmailTemplateType";
+import NotificationSettingEventType from "Common/Types/NotificationSetting/NotificationSettingEventType";
+import ObjectID from "Common/Types/ObjectID";
+import Timezone from "Common/Types/Timezone";
+
+/*
+ * Regression tests for the AlertOwner:SendStateChangeEmail cron's per-row
+ * query and CPU fan-out (keep in sync with the IncidentOwners twin suite).
+ * The job used to fetch each timeline row's alert TWICE - once for the
+ * display fields and a second AlertService.findOneById just to read
+ * alertSeverity.name - and re-ran Markdown.convertToHTML on the same alert
+ * description once PER OWNER. The perf fix merges the severity relation into
+ * the single alert fetch and hoists the markdown conversion to once per
+ * timeline row. These tests pin:
+ *   1. the query shape: exactly ONE findOneById per timeline row, whose
+ *      select carries both the display fields and the severity relation,
+ *   2. exactly ONE Markdown.convertToHTML per row regardless of owner count,
+ *   3. the notification payloads (vars, subject, SMS, call, push, feed) are
+ *      byte-identical to the old two-query flow, including the severity name
+ *      and the converted description,
+ *   4. the skip/throw semantics are unchanged: a deleted alert is skipped, a
+ *      missing severity relation still throws (no silent ?. downgrade), and
+ *      rows without owners never reach the markdown conversion.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler (the same recorder the other
+ * App/Tests/Workers/Jobs suites use) and each test drives one full tick.
+ */
+
+type CronHandler = () => Promise<void>;
+
+/*
+ * Captured cron handlers, keyed by job name. Must be declared before the job
+ * import below so the mock factory closure can see it.
+ */
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+/*
+ * PasswordHash carries a pre-existing TS5.9 diagnostic that fails any suite
+ * whose runtime require graph reaches it (DatabaseService, the base class of
+ * every concrete service, imports it). Nothing password-related is under test
+ * here, so the module is replaced WITH A FACTORY - an automock would still
+ * require (and type-check) the real file.
+ */
+jest.mock("Common/Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
+/*
+ * Markdown is mocked so the suite can count convertToHTML calls - THE
+ * regression being removed is one conversion per owner instead of per row.
+ * The enum values mirror Common/Server/Types/Markdown's MarkdownContentType.
+ */
+jest.mock("Common/Server/Types/Markdown", () => {
+  return {
+    __esModule: true,
+    MarkdownContentType: {
+      Docs: 0,
+      Blog: 1,
+      Email: 2,
+      BlogValidation: 3,
+    },
+    default: {
+      convertToHTML: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/AlertService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneById: jest.fn(),
+      findOwners: jest.fn(),
+      getAlertLinkInDashboard: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/AlertStateTimelineService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findAllBy: jest.fn(),
+      updateOneById: jest.fn(),
+      findOneBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/AlertStateService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneById: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getOwners: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserNotificationSettingService", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendUserNotification: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/AlertFeedService", () => {
+  return {
+    __esModule: true,
+    default: {
+      createAlertFeedItem: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getUserMarkdownString: jest.fn(),
+    },
+  };
+});
+
+import AlertFeedService from "Common/Server/Services/AlertFeedService";
+import AlertService from "Common/Server/Services/AlertService";
+import AlertStateService from "Common/Server/Services/AlertStateService";
+import AlertStateTimelineService from "Common/Server/Services/AlertStateTimelineService";
+import ProjectService from "Common/Server/Services/ProjectService";
+import UserNotificationSettingService from "Common/Server/Services/UserNotificationSettingService";
+import UserService from "Common/Server/Services/UserService";
+import Markdown, { MarkdownContentType } from "Common/Server/Types/Markdown";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/AlertOwners/SendStateChangeNotification";
+
+interface AlertServiceMock {
+  findOneById: jest.Mock;
+  findOwners: jest.Mock;
+  getAlertLinkInDashboard: jest.Mock;
+}
+
+interface TimelineServiceMock {
+  findAllBy: jest.Mock;
+  updateOneById: jest.Mock;
+  findOneBy: jest.Mock;
+}
+
+interface StateServiceMock {
+  findOneById: jest.Mock;
+}
+
+interface ProjectServiceMock {
+  getOwners: jest.Mock;
+}
+
+interface NotificationServiceMock {
+  sendUserNotification: jest.Mock;
+}
+
+interface FeedServiceMock {
+  createAlertFeedItem: jest.Mock;
+}
+
+interface UserServiceMock {
+  getUserMarkdownString: jest.Mock;
+}
+
+interface MarkdownMock {
+  convertToHTML: jest.Mock;
+}
+
+const alertService: AlertServiceMock =
+  AlertService as unknown as AlertServiceMock;
+const timelineService: TimelineServiceMock =
+  AlertStateTimelineService as unknown as TimelineServiceMock;
+const stateService: StateServiceMock =
+  AlertStateService as unknown as StateServiceMock;
+const projectService: ProjectServiceMock =
+  ProjectService as unknown as ProjectServiceMock;
+const notificationService: NotificationServiceMock =
+  UserNotificationSettingService as unknown as NotificationServiceMock;
+const feedService: FeedServiceMock =
+  AlertFeedService as unknown as FeedServiceMock;
+const userService: UserServiceMock = UserService as unknown as UserServiceMock;
+const markdownMock: MarkdownMock = Markdown as unknown as MarkdownMock;
+
+const PROJECT_ID: ObjectID = new ObjectID("project-1");
+const ALERT_1_ID: ObjectID = new ObjectID("alert-1");
+const ALERT_2_ID: ObjectID = new ObjectID("alert-2");
+const TIMELINE_1_ID: ObjectID = new ObjectID("timeline-1");
+const TIMELINE_2_ID: ObjectID = new ObjectID("timeline-2");
+const USER_1_ID: ObjectID = new ObjectID("user-1");
+const USER_2_ID: ObjectID = new ObjectID("user-2");
+const USER_3_ID: ObjectID = new ObjectID("user-3");
+
+const STATE_CHANGED_AT: Date = new Date("2026-08-18T10:00:00.000Z");
+const ALERT_LINK: string = "https://oneuptime.example.com/dashboard/alert-1";
+
+function makeTimeline(data: {
+  id: ObjectID;
+  alertId: ObjectID;
+  startsAt?: Date | undefined;
+}): AlertStateTimeline {
+  const timeline: AlertStateTimeline = new AlertStateTimeline();
+  timeline.id = data.id;
+  timeline.alertId = data.alertId;
+  timeline.projectId = PROJECT_ID;
+  timeline.createdAt = STATE_CHANGED_AT;
+
+  if (data.startsAt) {
+    timeline.startsAt = data.startsAt;
+  }
+
+  const project: Project = new Project();
+  project.name = "Prod Project";
+  timeline.project = project;
+
+  const state: AlertState = new AlertState();
+  state.name = "Acknowledged";
+  state.color = Blue500;
+  timeline.alertState = state;
+
+  return timeline;
+}
+
+function makeAlert(data: {
+  id: ObjectID;
+  description: string;
+  severityName?: string | undefined;
+}): Alert {
+  const alert: Alert = new Alert();
+  alert.id = data.id;
+  alert.title = "CPU is high";
+  alert.projectId = PROJECT_ID;
+  alert.description = data.description;
+  alert.alertNumber = 42;
+  alert.alertNumberWithPrefix = "AL-42";
+
+  const monitor: Monitor = new Monitor();
+  monitor.name = "web-server-1";
+  alert.monitor = monitor;
+
+  if (data.severityName) {
+    const severity: AlertSeverity = new AlertSeverity();
+    severity.name = data.severityName;
+    alert.alertSeverity = severity;
+  }
+
+  return alert;
+}
+
+function makeUser(id: ObjectID, timezone?: Timezone | undefined): User {
+  const user: User = new User();
+  user.id = id;
+
+  if (timezone) {
+    user.timezone = timezone;
+  }
+
+  return user;
+}
+
+function stubAlerts(alerts: Array<Alert>): void {
+  const alertsById: Record<string, Alert> = {};
+
+  for (const alert of alerts) {
+    alertsById[alert.id!.toString()] = alert;
+  }
+
+  alertService.findOneById.mockImplementation((args: { id: ObjectID }) => {
+    return Promise.resolve(alertsById[args.id.toString()] || null);
+  });
+}
+
+interface FindOneByIdArgs {
+  id: ObjectID;
+  props: { isRoot: boolean };
+  select: Record<string, unknown>;
+}
+
+function alertFetchCalls(): Array<FindOneByIdArgs> {
+  return alertService.findOneById.mock.calls.map((args: Array<unknown>) => {
+    return args[0] as FindOneByIdArgs;
+  });
+}
+
+interface SendNotificationArgs {
+  userId: ObjectID;
+  projectId: ObjectID;
+  emailEnvelope: {
+    templateType: EmailTemplateType;
+    vars: Dictionary<string>;
+    subject: string;
+  };
+  smsMessage: { message: string };
+  callRequestMessage: { data: Array<{ sayMessage: string }> };
+  pushNotificationMessage: Record<string, unknown>;
+  whatsAppMessage: Record<string, unknown>;
+  alertId: ObjectID;
+  eventType: NotificationSettingEventType;
+}
+
+function sendCalls(): Array<SendNotificationArgs> {
+  return notificationService.sendUserNotification.mock.calls.map(
+    (args: Array<unknown>) => {
+      return args[0] as SendNotificationArgs;
+    },
+  );
+}
+
+interface UpdateCallArgs {
+  id: ObjectID;
+  data: Record<string, unknown>;
+}
+
+function timelineUpdateCalls(): Array<UpdateCallArgs> {
+  return timelineService.updateOneById.mock.calls.map(
+    (args: Array<unknown>) => {
+      return args[0] as UpdateCallArgs;
+    },
+  );
+}
+
+// The deterministic transform the Markdown mock applies to every conversion.
+function convertedHtmlOf(markdown: string): string {
+  return `<p data-md>${markdown}</p>`;
+}
+
+async function runWorkerTick(): Promise<void> {
+  const handler: CronHandler | undefined =
+    mockCapturedJobs["AlertOwner:SendStateChangeEmail"];
+
+  if (!handler) {
+    throw new Error(
+      "AlertOwner:SendStateChangeEmail did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await handler();
+}
+
+describe("AlertOwner:SendStateChangeEmail worker", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest
+      .spyOn(OneUptimeDate, "getDateAsFormattedHTMLInMultipleTimezones")
+      .mockImplementation(
+        (data: {
+          date: string | Date;
+          timezones?: Array<Timezone> | undefined;
+        }): string => {
+          return `formatted:${new Date(data.date).toISOString()}:${(
+            data.timezones || []
+          ).join(",")}`;
+        },
+      );
+
+    markdownMock.convertToHTML.mockImplementation((markdown: string) => {
+      return Promise.resolve(convertedHtmlOf(markdown));
+    });
+
+    timelineService.findAllBy.mockResolvedValue([]);
+    timelineService.updateOneById.mockResolvedValue(undefined);
+    timelineService.findOneBy.mockResolvedValue(null);
+    stateService.findOneById.mockResolvedValue(null);
+    alertService.findOneById.mockResolvedValue(null);
+    alertService.findOwners.mockResolvedValue([]);
+    alertService.getAlertLinkInDashboard.mockResolvedValue(ALERT_LINK);
+    projectService.getOwners.mockResolvedValue([]);
+    notificationService.sendUserNotification.mockResolvedValue(undefined);
+    feedService.createAlertFeedItem.mockResolvedValue(undefined);
+    userService.getUserMarkdownString.mockImplementation(
+      (data: { userId: ObjectID }) => {
+        return Promise.resolve(`@${data.userId.toString()}`);
+      },
+    );
+  });
+
+  test("fetches the alert EXACTLY ONCE per timeline row, selecting the severity relation alongside the display fields", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, alertId: ALERT_1_ID }),
+    ]);
+    stubAlerts([
+      makeAlert({
+        id: ALERT_1_ID,
+        description: "**CPU** load is high",
+        severityName: "Critical",
+      }),
+    ]);
+    alertService.findOwners.mockResolvedValue([makeUser(USER_1_ID)]);
+
+    await runWorkerTick();
+
+    // THE removed regression: a second findOneById just for the severity name.
+    expect(alertService.findOneById).toHaveBeenCalledTimes(1);
+
+    const fetch: FindOneByIdArgs = alertFetchCalls()[0]!;
+
+    expect(fetch.id.toString()).toBe(ALERT_1_ID.toString());
+    expect(fetch.props).toEqual({ isRoot: true });
+
+    // The single select now carries the severity relation...
+    expect(fetch.select["alertSeverity"]).toEqual({ name: true });
+
+    // ...alongside every field the old first query selected.
+    expect(fetch.select).toMatchObject({
+      _id: true,
+      title: true,
+      projectId: true,
+      description: true,
+      monitor: { name: true },
+      alertNumber: true,
+      alertNumberWithPrefix: true,
+    });
+
+    // The row still completes end to end off the merged fetch.
+    expect(notificationService.sendUserNotification).toHaveBeenCalledTimes(1);
+    expect(sendCalls()[0]!.emailEnvelope.vars["alertSeverity"]).toBe(
+      "Critical",
+    );
+    expect(feedService.createAlertFeedItem).toHaveBeenCalledTimes(1);
+  });
+
+  test("converts the description markdown ONCE PER ROW, not once per owner, across 3 owners and 2 rows", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, alertId: ALERT_1_ID }),
+      makeTimeline({ id: TIMELINE_2_ID, alertId: ALERT_2_ID }),
+    ]);
+    stubAlerts([
+      makeAlert({
+        id: ALERT_1_ID,
+        description: "row one description",
+        severityName: "Critical",
+      }),
+      makeAlert({
+        id: ALERT_2_ID,
+        description: "row two description",
+        severityName: "Critical",
+      }),
+    ]);
+    alertService.findOwners.mockResolvedValue([
+      makeUser(USER_1_ID),
+      makeUser(USER_2_ID),
+      makeUser(USER_3_ID),
+    ]);
+
+    await runWorkerTick();
+
+    // 3 owners per row still notify individually...
+    expect(notificationService.sendUserNotification).toHaveBeenCalledTimes(6);
+
+    // ...but the markdown converts once per ROW (the old code did 6 here).
+    expect(markdownMock.convertToHTML).toHaveBeenCalledTimes(2);
+    expect(markdownMock.convertToHTML).toHaveBeenNthCalledWith(
+      1,
+      "row one description",
+      MarkdownContentType.Email,
+    );
+    expect(markdownMock.convertToHTML).toHaveBeenNthCalledWith(
+      2,
+      "row two description",
+      MarkdownContentType.Email,
+    );
+
+    // Every owner of a row still receives that row's converted description.
+    const descriptions: Array<string> = sendCalls().map(
+      (call: SendNotificationArgs) => {
+        return call.emailEnvelope.vars["alertDescription"]!;
+      },
+    );
+
+    expect(descriptions).toEqual([
+      convertedHtmlOf("row one description"),
+      convertedHtmlOf("row one description"),
+      convertedHtmlOf("row one description"),
+      convertedHtmlOf("row two description"),
+      convertedHtmlOf("row two description"),
+      convertedHtmlOf("row two description"),
+    ]);
+
+    // One merged alert fetch per row - never a severity re-fetch.
+    expect(alertService.findOneById).toHaveBeenCalledTimes(2);
+  });
+
+  test("sends byte-identical notification payloads to the old two-query flow, previous state included", async () => {
+    const startsAt: Date = STATE_CHANGED_AT;
+    const previousStartsAt: Date = new Date("2026-08-18T08:00:00.000Z");
+
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, alertId: ALERT_1_ID, startsAt }),
+    ]);
+    stubAlerts([
+      makeAlert({
+        id: ALERT_1_ID,
+        description: "**CPU** load is high",
+        severityName: "Critical",
+      }),
+    ]);
+    alertService.findOwners.mockResolvedValue([
+      makeUser(USER_1_ID, Timezone.AmericaNew_York),
+      makeUser(USER_2_ID),
+      makeUser(USER_3_ID),
+    ]);
+
+    const previousTimeline: AlertStateTimeline = new AlertStateTimeline();
+    previousTimeline.alertStateId = new ObjectID("state-identified");
+    previousTimeline.startsAt = previousStartsAt;
+    previousTimeline.createdAt = previousStartsAt;
+    timelineService.findOneBy.mockResolvedValue(previousTimeline);
+
+    const previousState: AlertState = new AlertState();
+    previousState.name = "Identified";
+    previousState.color = Red500;
+    stateService.findOneById.mockResolvedValue(previousState);
+
+    await runWorkerTick();
+
+    const expectedDuration: string =
+      OneUptimeDate.convertSecondsToDaysHoursMinutesAndSeconds(
+        OneUptimeDate.getDifferenceInSeconds(startsAt, previousStartsAt),
+      );
+
+    const expectedVarsFor: (timezones: string) => Dictionary<string> = (
+      timezones: string,
+    ) => {
+      return {
+        alertTitle: "CPU is high",
+        alertNumber: "AL-42",
+        projectName: "Prod Project",
+        currentState: "Acknowledged",
+        currentStateColor: Blue500.toString(),
+        previousState: "Identified",
+        previousStateColor: Red500.toString(),
+        previousStateDurationText: `Was Identified for ${expectedDuration}`,
+        alertDescription: convertedHtmlOf("**CPU** load is high"),
+        resourcesAffected: "web-server-1",
+        stateChangedAt: `formatted:${STATE_CHANGED_AT.toISOString()}:${timezones}`,
+        alertSeverity: "Critical",
+        alertViewLink: ALERT_LINK,
+        isOwner: "true",
+      };
+    };
+
+    const calls: Array<SendNotificationArgs> = sendCalls();
+
+    expect(calls).toHaveLength(3);
+
+    // Per-owner vars: identical except for the owner's timezone rendering.
+    expect(calls[0]!.emailEnvelope.vars).toEqual(
+      expectedVarsFor(Timezone.AmericaNew_York),
+    );
+    expect(calls[1]!.emailEnvelope.vars).toEqual(expectedVarsFor(""));
+    expect(calls[2]!.emailEnvelope.vars).toEqual(expectedVarsFor(""));
+
+    for (const [index, call] of calls.entries()) {
+      expect(call.userId.toString()).toBe(
+        [USER_1_ID, USER_2_ID, USER_3_ID][index]!.toString(),
+      );
+      expect(call.projectId.toString()).toBe(PROJECT_ID.toString());
+      expect(call.alertId.toString()).toBe(ALERT_1_ID.toString());
+      expect(call.eventType).toBe(
+        NotificationSettingEventType.SEND_ALERT_STATE_CHANGED_OWNER_NOTIFICATION,
+      );
+      expect(call.emailEnvelope.templateType).toBe(
+        EmailTemplateType.AlertOwnerStateChanged,
+      );
+      expect(call.emailEnvelope.subject).toBe(
+        "[Acknowledged Alert AL-42] - CPU is high",
+      );
+      expect(call.smsMessage.message).toBe(
+        "This is a message from OneUptime. Alert AL-42 (CPU is high) - state changed from Identified to Acknowledged. To unsubscribe from this notification go to User Settings in OneUptime Dashboard.",
+      );
+      expect(call.callRequestMessage.data[0]!.sayMessage).toBe(
+        "This is a message from OneUptime. Alert AL-42 (CPU is high) state changed from Identified to Acknowledged. To unsubscribe from this notification go to User Settings in OneUptime Dashboard. Good bye.",
+      );
+      expect(call.pushNotificationMessage).toMatchObject({
+        title: "Alert AL-42 State Changed: CPU is high",
+        body: "Alert AL-42 state changed from Identified to Acknowledged in Prod Project. Click to view details.",
+        clickAction: ALERT_LINK,
+        tag: "alert-state-changed",
+        requireInteraction: true,
+      });
+    }
+
+    // The row is marked notified exactly once, before the fan-out.
+    const updates: Array<UpdateCallArgs> = timelineUpdateCalls();
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.id.toString()).toBe(TIMELINE_1_ID.toString());
+    expect(updates[0]!.data).toEqual({ isOwnerNotified: true });
+
+    // The feed item is unchanged, one entry per notified owner.
+    expect(feedService.createAlertFeedItem).toHaveBeenCalledTimes(1);
+    expect(feedService.createAlertFeedItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        alertFeedEventType: AlertFeedEventType.OwnerNotificationSent,
+        displayColor: Blue500,
+        feedInfoInMarkdown: `🔔 **Owners have been notified about the state change of the [Alert AL-42](${ALERT_LINK}).**: Owners have been notified about the state change of the alert because the alert state changed to **Acknowledged**.`,
+        moreInformationInMarkdown: `**Notified:** @${USER_1_ID.toString()})\n**Notified:** @${USER_2_ID.toString()})\n**Notified:** @${USER_3_ID.toString()})\n`,
+      }),
+    );
+  });
+
+  test("a row whose alert no longer exists is skipped exactly as before, without blocking later rows", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, alertId: ALERT_1_ID }),
+      makeTimeline({ id: TIMELINE_2_ID, alertId: ALERT_2_ID }),
+    ]);
+    // ALERT_1 was deleted - only ALERT_2 still resolves.
+    stubAlerts([
+      makeAlert({
+        id: ALERT_2_ID,
+        description: "surviving row",
+        severityName: "Critical",
+      }),
+    ]);
+    alertService.findOwners.mockResolvedValue([makeUser(USER_1_ID)]);
+
+    await expect(runWorkerTick()).resolves.toBeUndefined();
+
+    // Still exactly one fetch per row - the null result costs no extra query.
+    expect(alertService.findOneById).toHaveBeenCalledTimes(2);
+
+    // The deleted row is skipped BEFORE the mark-notified write and the send.
+    const updates: Array<UpdateCallArgs> = timelineUpdateCalls();
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.id.toString()).toBe(TIMELINE_2_ID.toString());
+
+    expect(markdownMock.convertToHTML).toHaveBeenCalledTimes(1);
+    expect(notificationService.sendUserNotification).toHaveBeenCalledTimes(1);
+    expect(sendCalls()[0]!.alertId.toString()).toBe(ALERT_2_ID.toString());
+    expect(feedService.createAlertFeedItem).toHaveBeenCalledTimes(1);
+  });
+
+  test("a missing severity relation still throws after the mark-notified write - never silently downgraded", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, alertId: ALERT_1_ID }),
+    ]);
+    stubAlerts([makeAlert({ id: ALERT_1_ID, description: "no severity row" })]);
+    alertService.findOwners.mockResolvedValue([makeUser(USER_1_ID)]);
+
+    await expect(runWorkerTick()).rejects.toThrow(TypeError);
+
+    // Same as the old flow: the row was already marked notified...
+    expect(timelineService.updateOneById).toHaveBeenCalledTimes(1);
+
+    // ...and no notification went out.
+    expect(notificationService.sendUserNotification).not.toHaveBeenCalled();
+  });
+
+  test("a row with no owners at all is marked notified and skipped without converting markdown", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, alertId: ALERT_1_ID }),
+    ]);
+    stubAlerts([
+      makeAlert({
+        id: ALERT_1_ID,
+        description: "unowned row",
+        severityName: "Critical",
+      }),
+    ]);
+    alertService.findOwners.mockResolvedValue([]);
+    projectService.getOwners.mockResolvedValue([]);
+
+    await runWorkerTick();
+
+    expect(projectService.getOwners).toHaveBeenCalledTimes(1);
+    expect(timelineService.updateOneById).toHaveBeenCalledTimes(1);
+
+    // The hoisted conversion still sits behind the owners gate.
+    expect(markdownMock.convertToHTML).not.toHaveBeenCalled();
+    expect(notificationService.sendUserNotification).not.toHaveBeenCalled();
+    expect(feedService.createAlertFeedItem).not.toHaveBeenCalled();
+  });
+
+  test("project-owner fallback still notifies without the isOwner flag", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, alertId: ALERT_1_ID }),
+    ]);
+    stubAlerts([
+      makeAlert({
+        id: ALERT_1_ID,
+        description: "fallback row",
+        severityName: "Low",
+      }),
+    ]);
+    alertService.findOwners.mockResolvedValue([]);
+    projectService.getOwners.mockResolvedValue([makeUser(USER_2_ID)]);
+
+    await runWorkerTick();
+
+    const calls: Array<SendNotificationArgs> = sendCalls();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.userId.toString()).toBe(USER_2_ID.toString());
+    expect(calls[0]!.emailEnvelope.vars["isOwner"]).toBeUndefined();
+    expect(calls[0]!.emailEnvelope.vars["alertSeverity"]).toBe("Low");
+    expect(markdownMock.convertToHTML).toHaveBeenCalledTimes(1);
+  });
+});

--- a/App/Tests/Workers/Jobs/IncidentEpisode/ResolveInactiveEpisodes.test.ts
+++ b/App/Tests/Workers/Jobs/IncidentEpisode/ResolveInactiveEpisodes.test.ts
@@ -1,0 +1,617 @@
+import IncidentEpisode from "Common/Models/DatabaseModels/IncidentEpisode";
+import IncidentGroupingRule from "Common/Models/DatabaseModels/IncidentGroupingRule";
+import OneUptimeDate from "Common/Types/Date";
+import ObjectID from "Common/Types/ObjectID";
+
+/*
+ * Regression tests for the IncidentEpisode:ResolveInactiveEpisodes cron's query
+ * fan-out (the line-for-line twin of AlertEpisode:ResolveInactiveEpisodes -
+ * keep the two suites symmetric). The job runs EVERY FIVE MINUTES over up to
+ * 1000 active episodes; it used to issue one
+ * IncidentGroupingRuleService.findOneById PER EPISODE inside an unbounded
+ * Promise.allSettled fanout - up to 1000 concurrent point SELECTs per tick for
+ * a handful of distinct rules. The perf fix hoists the rule lookups into ONE
+ * batched findBy over the distinct rule ids before the episode fan-out. These
+ * tests pin:
+ *   1. the batch shape: exactly one grouping-rule findBy per tick over the
+ *      deduplicated rule ids (skipped entirely when no episode carries a rule
+ *      id), and - THE regression being removed - zero findOneById / findOneBy
+ *      calls on any of the services,
+ *   2. the decision semantics are unchanged: timeout-disabled / zero-timeout /
+ *      missing-rule / no-rule-id episodes never resolve, the inactivity
+ *      threshold boundary on lastIncidentAddedAt (with the createdAt fallback),
+ *      the resolveEpisode arguments (no user, cascade to incidents), and the
+ *      Promise.allSettled isolation between episodes.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler (the same recorder the other
+ * App/Tests/Workers/Jobs suites use) and each test drives one full tick.
+ */
+
+type CronHandler = () => Promise<void>;
+
+/*
+ * Captured cron handlers, keyed by job name. Must be declared before the job
+ * import below so the mock factory closure can see it.
+ */
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+/*
+ * findOneById / findOneBy are mocked ALONGSIDE the batched findBy on every
+ * service precisely so the suite can prove they are never called: if the job
+ * regressed back to per-episode point reads, the assertions would flag it
+ * instead of the mock throwing "not a function".
+ */
+jest.mock("Common/Server/Services/IncidentEpisodeService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+      resolveEpisode: jest.fn(),
+      findOneBy: jest.fn(),
+      findOneById: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/IncidentGroupingRuleService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+      findOneBy: jest.fn(),
+      findOneById: jest.fn(),
+    },
+  };
+});
+
+import IncidentEpisodeService from "Common/Server/Services/IncidentEpisodeService";
+import IncidentGroupingRuleService from "Common/Server/Services/IncidentGroupingRuleService";
+import logger from "Common/Server/Utils/Logger";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/IncidentEpisode/ResolveInactiveEpisodes";
+
+interface EpisodeServiceMock {
+  findBy: jest.Mock;
+  resolveEpisode: jest.Mock;
+  findOneBy: jest.Mock;
+  findOneById: jest.Mock;
+}
+
+interface FindByServiceMock {
+  findBy: jest.Mock;
+  findOneBy: jest.Mock;
+  findOneById: jest.Mock;
+}
+
+const episodeService: EpisodeServiceMock =
+  IncidentEpisodeService as unknown as EpisodeServiceMock;
+const ruleService: FindByServiceMock =
+  IncidentGroupingRuleService as unknown as FindByServiceMock;
+const mockedLogger: { error: jest.Mock } = logger as unknown as {
+  error: jest.Mock;
+};
+
+const NOW: Date = new Date("2026-07-27T10:00:00.000Z");
+
+const PROJECT_1_ID: ObjectID = new ObjectID("project-1");
+const RULE_1_ID: ObjectID = new ObjectID("rule-1");
+const RULE_2_ID: ObjectID = new ObjectID("rule-2");
+const EPISODE_1_ID: ObjectID = new ObjectID("episode-1");
+const EPISODE_2_ID: ObjectID = new ObjectID("episode-2");
+const EPISODE_3_ID: ObjectID = new ObjectID("episode-3");
+const EPISODE_4_ID: ObjectID = new ObjectID("episode-4");
+const EPISODE_5_ID: ObjectID = new ObjectID("episode-5");
+
+// The inactivity timeout the enabled rules use, in minutes.
+const TIMEOUT_MINUTES: number = 30;
+
+function minutesBeforeNow(minutes: number, extraSeconds?: number): Date {
+  return new Date(NOW.getTime() - minutes * 60000 - (extraSeconds || 0) * 1000);
+}
+
+function makeEpisode(data: {
+  id: ObjectID;
+  projectId?: ObjectID | undefined;
+  ruleId?: ObjectID | undefined;
+  lastIncidentAddedAt?: Date | undefined;
+  createdAt?: Date | undefined;
+}): IncidentEpisode {
+  const episode: IncidentEpisode = new IncidentEpisode(data.id);
+
+  if (data.projectId) {
+    episode.projectId = data.projectId;
+  }
+
+  if (data.ruleId) {
+    episode.incidentGroupingRuleId = data.ruleId;
+  }
+
+  if (data.lastIncidentAddedAt) {
+    episode.lastIncidentAddedAt = data.lastIncidentAddedAt;
+  }
+
+  if (data.createdAt) {
+    episode.createdAt = data.createdAt;
+  }
+
+  return episode;
+}
+
+function makeRule(data: {
+  id: ObjectID;
+  enableInactivityTimeout?: boolean | undefined;
+  inactivityTimeoutMinutes?: number | undefined;
+}): IncidentGroupingRule {
+  const rule: IncidentGroupingRule = new IncidentGroupingRule(data.id);
+  rule.enableInactivityTimeout = data.enableInactivityTimeout || false;
+
+  if (data.inactivityTimeoutMinutes !== undefined) {
+    rule.inactivityTimeoutMinutes = data.inactivityTimeoutMinutes;
+  }
+
+  return rule;
+}
+
+/*
+ * Reads the id list bound into one of QueryHelper.any's Raw predicates
+ * (typeorm keeps the bound parameters on the FindOperator).
+ */
+function boundIdsOf(predicate: unknown): Array<string> {
+  const parameters: Record<string, Array<string>> | undefined = (
+    predicate as {
+      objectLiteralParameters?: Record<string, Array<string>> | undefined;
+    }
+  ).objectLiteralParameters;
+
+  expect(parameters).toBeDefined();
+
+  const values: Array<Array<string>> = Object.values(parameters!);
+
+  expect(values).toHaveLength(1);
+
+  return values[0]!;
+}
+
+interface FindByArgs {
+  query: Record<string, unknown>;
+  select: Record<string, unknown>;
+  limit: number;
+  skip: number;
+}
+
+interface ResolveEpisodeArgs {
+  episodeId: ObjectID;
+  userId: unknown;
+  cascade: unknown;
+}
+
+function resolveCalls(): Array<ResolveEpisodeArgs> {
+  return episodeService.resolveEpisode.mock.calls.map(
+    (args: Array<unknown>) => {
+      return {
+        episodeId: args[0] as ObjectID,
+        userId: args[1],
+        cascade: args[2],
+      };
+    },
+  );
+}
+
+function resolvedEpisodeIds(): Array<string> {
+  return resolveCalls().map((call: ResolveEpisodeArgs) => {
+    return call.episodeId.toString();
+  });
+}
+
+/*
+ * THE regression this change removed: per-episode findOneById / findOneBy
+ * point reads. Every test asserts none of them ever fire.
+ */
+function expectNoPerRowLookups(): void {
+  expect(episodeService.findOneBy).not.toHaveBeenCalled();
+  expect(episodeService.findOneById).not.toHaveBeenCalled();
+  expect(ruleService.findOneBy).not.toHaveBeenCalled();
+  expect(ruleService.findOneById).not.toHaveBeenCalled();
+}
+
+async function runWorkerTick(): Promise<void> {
+  const handler: CronHandler | undefined =
+    mockCapturedJobs["IncidentEpisode:ResolveInactiveEpisodes"];
+
+  if (!handler) {
+    throw new Error(
+      "IncidentEpisode:ResolveInactiveEpisodes did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await handler();
+}
+
+describe("IncidentEpisode:ResolveInactiveEpisodes worker", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(OneUptimeDate, "getCurrentDate").mockImplementation(() => {
+      return new Date(NOW);
+    });
+
+    episodeService.findBy.mockResolvedValue([]);
+    episodeService.resolveEpisode.mockResolvedValue(undefined);
+    ruleService.findBy.mockResolvedValue([]);
+  });
+
+  test("batches grouping rules once per tick over the distinct rule ids - never per-episode point reads", async () => {
+    // 5 stale episodes sharing exactly TWO distinct grouping rules.
+    episodeService.findBy.mockResolvedValue([
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      makeEpisode({
+        id: EPISODE_2_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_2_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      makeEpisode({
+        id: EPISODE_3_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      makeEpisode({
+        id: EPISODE_4_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_2_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      makeEpisode({
+        id: EPISODE_5_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+    ]);
+    ruleService.findBy.mockResolvedValue([
+      makeRule({
+        id: RULE_1_ID,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+      makeRule({
+        id: RULE_2_ID,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+    ]);
+
+    await runWorkerTick();
+
+    // The episode list itself is still one page of active (unresolved) episodes.
+    expect(episodeService.findBy).toHaveBeenCalledTimes(1);
+
+    const episodeArgs: FindByArgs = episodeService.findBy.mock
+      .calls[0]![0] as FindByArgs;
+    const resolvedAtPredicate: { getSql?: (alias: string) => string } =
+      episodeArgs.query["resolvedAt"] as {
+        getSql?: (alias: string) => string;
+      };
+
+    expect(resolvedAtPredicate.getSql!("resolvedAt")).toBe(
+      "(resolvedAt IS NULL)",
+    );
+    expect(episodeArgs.limit).toBe(1000);
+    expect(episodeArgs.skip).toBe(0);
+
+    // ONE grouping-rule batch over exactly the 2 distinct rule ids (deduplicated).
+    expect(ruleService.findBy).toHaveBeenCalledTimes(1);
+
+    const ruleArgs: FindByArgs = ruleService.findBy.mock
+      .calls[0]![0] as FindByArgs;
+
+    expect(boundIdsOf(ruleArgs.query["_id"])).toEqual([
+      RULE_1_ID.toString(),
+      RULE_2_ID.toString(),
+    ]);
+    // _id is needed to key the map; the timeout fields drive the decision.
+    expect(ruleArgs.select).toEqual({
+      _id: true,
+      enableInactivityTimeout: true,
+      inactivityTimeoutMinutes: true,
+    });
+    /*
+     * The batch must page wide enough (LIMIT_MAX) for every distinct rule id
+     * behind the 1000-episode page — a smaller limit would silently drop
+     * rules and leave their episodes treated as rule-less.
+     */
+    expect(ruleArgs.limit).toBe(10000);
+    expect(ruleArgs.skip).toBe(0);
+
+    // The batch completes BEFORE the per-episode fan-out starts resolving.
+    expect(ruleService.findBy.mock.invocationCallOrder[0]!).toBeLessThan(
+      episodeService.resolveEpisode.mock.invocationCallOrder[0]!,
+    );
+
+    // Every stale episode resolves: no user, cascade to member incidents.
+    expect(episodeService.resolveEpisode).toHaveBeenCalledTimes(5);
+
+    for (const call of resolveCalls()) {
+      expect(call.userId).toBeUndefined();
+      expect(call.cascade).toBe(true);
+    }
+
+    expectNoPerRowLookups();
+  });
+
+  test("timeout disabled, zero timeout, missing rule, and no rule id never resolve - only the enabled stale episode does", async () => {
+    const zeroTimeoutRuleId: ObjectID = new ObjectID("rule-zero-timeout");
+    const deletedRuleId: ObjectID = new ObjectID("rule-deleted");
+
+    episodeService.findBy.mockResolvedValue([
+      // Rule enabled with a real timeout and the episode is stale: resolves.
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      // Rule exists but the timeout toggle is off: never resolves.
+      makeEpisode({
+        id: EPISODE_2_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_2_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      // Rule enabled but with a zero timeout: never resolves.
+      makeEpisode({
+        id: EPISODE_3_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: zeroTimeoutRuleId,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      // Rule id points at a deleted rule: behaves exactly like no rule.
+      makeEpisode({
+        id: EPISODE_4_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: deletedRuleId,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      // No rule id at all: never resolves.
+      makeEpisode({
+        id: EPISODE_5_ID,
+        projectId: PROJECT_1_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+    ]);
+    ruleService.findBy.mockResolvedValue([
+      makeRule({
+        id: RULE_1_ID,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+      makeRule({
+        id: RULE_2_ID,
+        enableInactivityTimeout: false,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+      makeRule({
+        id: zeroTimeoutRuleId,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: 0,
+      }),
+      // The deleted rule is intentionally absent from the batched result.
+    ]);
+
+    await runWorkerTick();
+
+    // The deleted rule id was still asked for in the single batch...
+    expect(ruleService.findBy).toHaveBeenCalledTimes(1);
+
+    const ruleArgs: FindByArgs = ruleService.findBy.mock
+      .calls[0]![0] as FindByArgs;
+
+    expect(boundIdsOf(ruleArgs.query["_id"])).toEqual([
+      RULE_1_ID.toString(),
+      RULE_2_ID.toString(),
+      zeroTimeoutRuleId.toString(),
+      deletedRuleId.toString(),
+    ]);
+
+    // ...but only the enabled + stale episode resolves.
+    expect(resolvedEpisodeIds()).toEqual([EPISODE_1_ID.toString()]);
+
+    expectNoPerRowLookups();
+  });
+
+  test("inactivity threshold boundary: exactly at the timeout resolves, one second inside does not", async () => {
+    episodeService.findBy.mockResolvedValue([
+      // Last incident exactly TIMEOUT_MINUTES ago: minutes-since == timeout, resolve.
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES),
+      }),
+      // One second short of the timeout: still active, keep waiting.
+      makeEpisode({
+        id: EPISODE_2_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES - 1, 59),
+      }),
+    ]);
+    ruleService.findBy.mockResolvedValue([
+      makeRule({
+        id: RULE_1_ID,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+    ]);
+
+    await runWorkerTick();
+
+    expect(resolvedEpisodeIds()).toEqual([EPISODE_1_ID.toString()]);
+
+    expectNoPerRowLookups();
+  });
+
+  test("falls back to createdAt when lastIncidentAddedAt is unset", async () => {
+    episodeService.findBy.mockResolvedValue([
+      // Created past the timeout, never received an incident: resolves.
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        createdAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      // Created inside the timeout window: still active.
+      makeEpisode({
+        id: EPISODE_2_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        createdAt: minutesBeforeNow(1),
+      }),
+    ]);
+    ruleService.findBy.mockResolvedValue([
+      makeRule({
+        id: RULE_1_ID,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+    ]);
+
+    await runWorkerTick();
+
+    expect(resolvedEpisodeIds()).toEqual([EPISODE_1_ID.toString()]);
+
+    expectNoPerRowLookups();
+  });
+
+  test("a tick with zero active episodes issues NO rule query at all", async () => {
+    episodeService.findBy.mockResolvedValue([]);
+
+    await runWorkerTick();
+
+    expect(ruleService.findBy).not.toHaveBeenCalled();
+    expect(episodeService.resolveEpisode).not.toHaveBeenCalled();
+
+    expectNoPerRowLookups();
+  });
+
+  test("episodes without any grouping rule id skip the rule batch entirely and never resolve", async () => {
+    episodeService.findBy.mockResolvedValue([
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      makeEpisode({
+        id: EPISODE_2_ID,
+        projectId: PROJECT_1_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+    ]);
+
+    await runWorkerTick();
+
+    // No episode carries a rule id, so there is nothing to batch-fetch.
+    expect(ruleService.findBy).not.toHaveBeenCalled();
+    // Without a rule the timeout stays disabled, so nothing resolves.
+    expect(episodeService.resolveEpisode).not.toHaveBeenCalled();
+
+    expectNoPerRowLookups();
+  });
+
+  test("one episode's resolve failure does not prevent the other episodes from resolving", async () => {
+    episodeService.findBy.mockResolvedValue([
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+      makeEpisode({
+        id: EPISODE_2_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+    ]);
+    ruleService.findBy.mockResolvedValue([
+      makeRule({
+        id: RULE_1_ID,
+        enableInactivityTimeout: true,
+        inactivityTimeoutMinutes: TIMEOUT_MINUTES,
+      }),
+    ]);
+
+    episodeService.resolveEpisode.mockImplementation((episodeId: ObjectID) => {
+      if (episodeId.toString() === EPISODE_1_ID.toString()) {
+        return Promise.reject(new Error("db connection reset"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    // The tick itself must not reject (Promise.allSettled + per-episode catch).
+    await expect(runWorkerTick()).resolves.toBeUndefined();
+
+    // BOTH resolves were attempted; the failure only logged.
+    expect(resolvedEpisodeIds()).toEqual([
+      EPISODE_1_ID.toString(),
+      EPISODE_2_ID.toString(),
+    ]);
+    expect(mockedLogger.error).toHaveBeenCalled();
+
+    expectNoPerRowLookups();
+  });
+
+  test("a failed batched rule fetch aborts the whole tick and only logs - retried next tick", async () => {
+    episodeService.findBy.mockResolvedValue([
+      makeEpisode({
+        id: EPISODE_1_ID,
+        projectId: PROJECT_1_ID,
+        ruleId: RULE_1_ID,
+        lastIncidentAddedAt: minutesBeforeNow(TIMEOUT_MINUTES + 1),
+      }),
+    ]);
+    ruleService.findBy.mockRejectedValue(new Error("db connection reset"));
+
+    await expect(runWorkerTick()).resolves.toBeUndefined();
+
+    expect(episodeService.resolveEpisode).not.toHaveBeenCalled();
+    expect(mockedLogger.error).toHaveBeenCalled();
+
+    expectNoPerRowLookups();
+  });
+});

--- a/App/Tests/Workers/Jobs/IncidentOwners/SendCreatedResourceNotification.test.ts
+++ b/App/Tests/Workers/Jobs/IncidentOwners/SendCreatedResourceNotification.test.ts
@@ -1,0 +1,534 @@
+import Incident from "Common/Models/DatabaseModels/Incident";
+import IncidentSeverity from "Common/Models/DatabaseModels/IncidentSeverity";
+import IncidentState from "Common/Models/DatabaseModels/IncidentState";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import Project from "Common/Models/DatabaseModels/Project";
+import User from "Common/Models/DatabaseModels/User";
+import OneUptimeDate from "Common/Types/Date";
+import Dictionary from "Common/Types/Dictionary";
+import Email from "Common/Types/Email";
+import { EmailEnvelope } from "Common/Types/Email/EmailMessage";
+import EmailTemplateType from "Common/Types/Email/EmailTemplateType";
+import Name from "Common/Types/Name";
+import ObjectID from "Common/Types/ObjectID";
+import Timezone from "Common/Types/Timezone";
+
+/*
+ * Regression tests for the IncidentOwner:SendCreatedResourceEmail cron's
+ * per-owner fan-out - the line-for-line twin of the AlertOwner suite (keep the
+ * two symmetric). The job used to re-run, INSIDE the per-owner loop, three
+ * Markdown.convertToHTML conversions that never vary per owner: the incident
+ * description, the remediation notes, and the root cause - 3xN marked parses
+ * per incident. The perf fix hoists all three to once per incident, just above
+ * the owner loop (still inside the per-incident scope). These tests pin:
+ *   1. exactly THREE convertToHTML calls per incident regardless of owner
+ *      count (the old code did all three once PER OWNER: 9 calls for 3),
+ *   2. the vars dictionary each owner receives is byte-identical to what the
+ *      old per-owner conversion produced,
+ *   3. the timezone-dependent declaredAt var still varies per user,
+ *   4. the per-user try/catch still isolates one owner's send failure,
+ *   5. the zero-owner continue still converts nothing at all.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler (the same recorder the other
+ * App/Tests/Workers/Jobs suites use) and each test drives one full tick.
+ * Markdown itself is REAL (spied, not stubbed) so the pinned HTML is the
+ * genuine marked output.
+ */
+
+type CronHandler = () => Promise<void>;
+
+/*
+ * Captured cron handlers, keyed by job name. Must be declared before the job
+ * import below so the mock factory closure can see it.
+ */
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+/*
+ * PasswordHash carries a pre-existing TS5.9 diagnostic that fails any suite
+ * whose runtime require graph reaches it. Nothing password-related is under
+ * test here, so the module is replaced WITH A FACTORY - an automock would
+ * still require (and type-check) the real file.
+ */
+jest.mock("Common/Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/IncidentService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findAllBy: jest.fn(),
+      updateOneById: jest.fn(),
+      findOwners: jest.fn(),
+      getIncidentLinkInDashboard: jest.fn(),
+      getIncidentIdentifiedDate: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getOwners: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserNotificationSettingService", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendUserNotification: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/IncidentFeedService", () => {
+  return {
+    __esModule: true,
+    default: {
+      createIncidentFeedItem: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/PushNotificationUtil", () => {
+  return {
+    __esModule: true,
+    default: {
+      createIncidentCreatedNotification: jest.fn(() => {
+        return {};
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/WhatsAppTemplateUtil", () => {
+  return {
+    __esModule: true,
+    createWhatsAppMessageFromTemplate: jest.fn(() => {
+      return { templateVariables: {} };
+    }),
+  };
+});
+
+import IncidentFeedService from "Common/Server/Services/IncidentFeedService";
+import IncidentService from "Common/Server/Services/IncidentService";
+import ProjectService from "Common/Server/Services/ProjectService";
+import UserNotificationSettingService from "Common/Server/Services/UserNotificationSettingService";
+import Markdown, { MarkdownContentType } from "Common/Server/Types/Markdown";
+import logger from "Common/Server/Utils/Logger";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/IncidentOwners/SendCreatedResourceNotification";
+
+interface IncidentServiceMock {
+  findAllBy: jest.Mock;
+  updateOneById: jest.Mock;
+  findOwners: jest.Mock;
+  getIncidentLinkInDashboard: jest.Mock;
+  getIncidentIdentifiedDate: jest.Mock;
+}
+
+const incidentService: IncidentServiceMock =
+  IncidentService as unknown as IncidentServiceMock;
+const projectService: { getOwners: jest.Mock } = ProjectService as unknown as {
+  getOwners: jest.Mock;
+};
+const notificationService: { sendUserNotification: jest.Mock } =
+  UserNotificationSettingService as unknown as {
+    sendUserNotification: jest.Mock;
+  };
+const feedService: { createIncidentFeedItem: jest.Mock } =
+  IncidentFeedService as unknown as { createIncidentFeedItem: jest.Mock };
+const mockedLogger: { error: jest.Mock } = logger as unknown as {
+  error: jest.Mock;
+};
+
+const IDENTIFIED_AT: Date = new Date("2026-08-18T09:00:00.000Z");
+
+const PROJECT_ID: ObjectID = new ObjectID("project-1");
+const INCIDENT_ID: ObjectID = new ObjectID("incident-1");
+const INCIDENT_LINK: string = "https://oneuptime.test/dashboard/incident-1";
+
+const DESCRIPTION_MARKDOWN: string = "**Checkout** is returning 500s";
+const REMEDIATION_MARKDOWN: string = "Fail over to the *replica* database";
+const ROOT_CAUSE_MARKDOWN: string = "The **primary** database ran out of disk";
+const DEFAULT_ROOT_CAUSE: string = "No root cause identified for this incident";
+
+function makeIncident(data: {
+  description?: string | undefined;
+  remediationNotes?: string | undefined;
+  rootCause?: string | undefined;
+}): Incident {
+  const incident: Incident = new Incident(INCIDENT_ID);
+  incident.projectId = PROJECT_ID;
+  incident.title = "Checkout is down";
+
+  if (data.description !== undefined) {
+    incident.description = data.description;
+  }
+
+  if (data.remediationNotes !== undefined) {
+    incident.remediationNotes = data.remediationNotes;
+  }
+
+  if (data.rootCause !== undefined) {
+    incident.rootCause = data.rootCause;
+  }
+
+  const project: Project = new Project();
+  project.name = "Acme Status";
+  incident.project = project;
+
+  const state: IncidentState = new IncidentState();
+  state.name = "Identified";
+  incident.currentIncidentState = state;
+
+  const severity: IncidentSeverity = new IncidentSeverity();
+  severity.name = "Major";
+  incident.incidentSeverity = severity;
+
+  const monitorA: Monitor = new Monitor();
+  monitorA.name = "Checkout Monitor";
+  const monitorB: Monitor = new Monitor();
+  monitorB.name = "Payments Monitor";
+  incident.monitors = [monitorA, monitorB];
+
+  incident.incidentNumber = 12;
+
+  return incident;
+}
+
+function makeOwner(id: string, timezone?: Timezone | undefined): User {
+  const user: User = new User(new ObjectID(id));
+  user.name = new Name(`Owner ${id}`);
+  user.email = new Email(`${id}@acme.test`);
+
+  if (timezone) {
+    user.timezone = timezone;
+  }
+
+  return user;
+}
+
+// The vars of each sendUserNotification call's email envelope, in call order.
+function sentVars(): Array<Dictionary<string>> {
+  return notificationService.sendUserNotification.mock.calls.map(
+    (args: Array<unknown>) => {
+      return (args[0] as { emailEnvelope: EmailEnvelope }).emailEnvelope
+        .vars as Dictionary<string>;
+    },
+  );
+}
+
+async function runWorkerTick(): Promise<void> {
+  const handler: CronHandler | undefined =
+    mockCapturedJobs["IncidentOwner:SendCreatedResourceEmail"];
+
+  if (!handler) {
+    throw new Error(
+      "IncidentOwner:SendCreatedResourceEmail did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await handler();
+}
+
+describe("IncidentOwner:SendCreatedResourceEmail worker", () => {
+  let markdownSpy: jest.SpyInstance;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Real conversion, spied - call counts are the regression under test.
+    markdownSpy = jest.spyOn(Markdown, "convertToHTML");
+
+    incidentService.findAllBy.mockResolvedValue([]);
+    incidentService.updateOneById.mockResolvedValue(undefined);
+    incidentService.findOwners.mockResolvedValue([]);
+    incidentService.getIncidentLinkInDashboard.mockResolvedValue({
+      toString: (): string => {
+        return INCIDENT_LINK;
+      },
+    });
+    incidentService.getIncidentIdentifiedDate.mockResolvedValue(IDENTIFIED_AT);
+    projectService.getOwners.mockResolvedValue([]);
+    notificationService.sendUserNotification.mockResolvedValue(undefined);
+    feedService.createIncidentFeedItem.mockResolvedValue(undefined);
+  });
+
+  test("converts description, remediation notes and root cause ONCE per incident for 3 owners - not once per owner", async () => {
+    incidentService.findAllBy.mockResolvedValue([
+      makeIncident({
+        description: DESCRIPTION_MARKDOWN,
+        remediationNotes: REMEDIATION_MARKDOWN,
+        rootCause: ROOT_CAUSE_MARKDOWN,
+      }),
+    ]);
+    incidentService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2"),
+      makeOwner("user-3"),
+    ]);
+
+    // What the old per-owner code produced for every owner, byte for byte.
+    const expectedDescriptionHtml: string = await Markdown.convertToHTML(
+      DESCRIPTION_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+    const expectedRemediationHtml: string =
+      (await Markdown.convertToHTML(
+        REMEDIATION_MARKDOWN,
+        MarkdownContentType.Email,
+      )) || "";
+    const expectedRootCauseHtml: string =
+      (await Markdown.convertToHTML(
+        ROOT_CAUSE_MARKDOWN,
+        MarkdownContentType.Email,
+      )) || "";
+
+    expect(expectedDescriptionHtml).toContain("<strong>Checkout</strong>");
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    // THE regression: the old code converted all three once per owner (9 calls).
+    expect(markdownSpy).toHaveBeenCalledTimes(3);
+    expect(markdownSpy.mock.calls).toEqual([
+      [DESCRIPTION_MARKDOWN, MarkdownContentType.Email],
+      [REMEDIATION_MARKDOWN, MarkdownContentType.Email],
+      [ROOT_CAUSE_MARKDOWN, MarkdownContentType.Email],
+    ]);
+
+    expect(notificationService.sendUserNotification).toHaveBeenCalledTimes(3);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    const expectedVars: Dictionary<string> = {
+      incidentTitle: "Checkout is down",
+      incidentNumber: "#12",
+      projectName: "Acme Status",
+      currentState: "Identified",
+      incidentDescription: expectedDescriptionHtml,
+      resourcesAffected: "Checkout Monitor, Payments Monitor",
+      incidentSeverity: "Major",
+      declaredAt: OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones({
+        date: IDENTIFIED_AT,
+        timezones: [],
+      }),
+      declaredBy: "OneUptime",
+      remediationNotes: expectedRemediationHtml,
+      rootCause: expectedRootCauseHtml,
+      incidentViewLink: INCIDENT_LINK,
+      isOwner: "true",
+    };
+
+    expect(allVars).toEqual([expectedVars, expectedVars, expectedVars]);
+
+    const emailEnvelope: EmailEnvelope = (
+      notificationService.sendUserNotification.mock.calls[0]![0] as {
+        emailEnvelope: EmailEnvelope;
+      }
+    ).emailEnvelope;
+
+    expect(emailEnvelope.templateType).toBe(
+      EmailTemplateType.IncidentOwnerResourceCreated,
+    );
+    expect(emailEnvelope.subject).toBe("[New Incident #12] - Checkout is down");
+
+    /*
+     * The dashboard link is NOT part of this fix: one call for the feed text
+     * plus two per owner (vars + push payload), exactly as before.
+     */
+    expect(incidentService.getIncidentLinkInDashboard).toHaveBeenCalledTimes(7);
+
+    expect(feedService.createIncidentFeedItem).toHaveBeenCalledTimes(1);
+  });
+
+  test("the timezone-dependent declaredAt var STAYS per-user while the conversions are still shared", async () => {
+    incidentService.findAllBy.mockResolvedValue([
+      makeIncident({
+        description: DESCRIPTION_MARKDOWN,
+        remediationNotes: REMEDIATION_MARKDOWN,
+        rootCause: ROOT_CAUSE_MARKDOWN,
+      }),
+    ]);
+    incidentService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2", Timezone.AmericaNew_York),
+    ]);
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    expect(markdownSpy).toHaveBeenCalledTimes(3);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    expect(allVars).toHaveLength(2);
+    expect(allVars[1]!["declaredAt"]).toBe(
+      OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones({
+        date: IDENTIFIED_AT,
+        timezones: [Timezone.AmericaNew_York],
+      }),
+    );
+    expect(allVars[0]!["declaredAt"]).not.toBe(allVars[1]!["declaredAt"]);
+
+    // Every owner-invariant field is still identical across the two owners.
+    const invariantFields0: Dictionary<string> = { ...allVars[0]! };
+    const invariantFields1: Dictionary<string> = { ...allVars[1]! };
+    delete invariantFields0["declaredAt"];
+    delete invariantFields1["declaredAt"];
+
+    expect(invariantFields0).toEqual(invariantFields1);
+  });
+
+  test("one owner's send failure is still isolated by the per-user try/catch - and conversions still ran only once", async () => {
+    incidentService.findAllBy.mockResolvedValue([
+      makeIncident({
+        description: DESCRIPTION_MARKDOWN,
+        remediationNotes: REMEDIATION_MARKDOWN,
+        rootCause: ROOT_CAUSE_MARKDOWN,
+      }),
+    ]);
+    incidentService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2"),
+      makeOwner("user-3"),
+    ]);
+
+    notificationService.sendUserNotification.mockImplementation(
+      (args: { userId: ObjectID }) => {
+        if (args.userId.toString() === "user-1") {
+          return Promise.reject(new Error("smtp connection reset"));
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+
+    markdownSpy.mockClear();
+
+    await expect(runWorkerTick()).resolves.toBeUndefined();
+
+    expect(markdownSpy).toHaveBeenCalledTimes(3);
+
+    // All three sends were attempted; the failure only logged.
+    expect(notificationService.sendUserNotification).toHaveBeenCalledTimes(3);
+    expect(mockedLogger.error).toHaveBeenCalled();
+
+    // Only the two owners whose send succeeded appear in the feed item.
+    expect(
+      (
+        feedService.createIncidentFeedItem.mock.calls[0]![0] as {
+          moreInformationInMarkdown: string;
+        }
+      ).moreInformationInMarkdown,
+    ).toBe(
+      "**Notified**: Owner user-2 (user-2@acme.test)\n" +
+        "**Notified**: Owner user-3 (user-3@acme.test)\n",
+    );
+  });
+
+  test("an incident with no owners at all converts NOTHING - but is still marked owner-notified", async () => {
+    incidentService.findAllBy.mockResolvedValue([
+      makeIncident({
+        description: DESCRIPTION_MARKDOWN,
+        remediationNotes: REMEDIATION_MARKDOWN,
+        rootCause: ROOT_CAUSE_MARKDOWN,
+      }),
+    ]);
+    incidentService.findOwners.mockResolvedValue([]);
+    projectService.getOwners.mockResolvedValue([]);
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    expect(incidentService.updateOneById).toHaveBeenCalledTimes(1);
+    expect(markdownSpy).not.toHaveBeenCalled();
+    expect(notificationService.sendUserNotification).not.toHaveBeenCalled();
+    expect(feedService.createIncidentFeedItem).not.toHaveBeenCalled();
+  });
+
+  test("empty description/remediation and a missing root cause fall back exactly as the old code did, one conversion each", async () => {
+    incidentService.findAllBy.mockResolvedValue([makeIncident({})]);
+    incidentService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2"),
+      makeOwner("user-3"),
+    ]);
+
+    // The old code's exact expressions for the three fallback inputs.
+    const expectedEmptyHtml: string = await Markdown.convertToHTML(
+      "",
+      MarkdownContentType.Email,
+    );
+    const expectedDefaultRootCauseHtml: string =
+      (await Markdown.convertToHTML(
+        DEFAULT_ROOT_CAUSE,
+        MarkdownContentType.Email,
+      )) || "";
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    expect(markdownSpy).toHaveBeenCalledTimes(3);
+    expect(markdownSpy.mock.calls).toEqual([
+      ["", MarkdownContentType.Email],
+      ["", MarkdownContentType.Email],
+      [DEFAULT_ROOT_CAUSE, MarkdownContentType.Email],
+    ]);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    expect(allVars).toHaveLength(3);
+
+    for (const vars of allVars) {
+      expect(vars["incidentDescription"]).toBe(expectedEmptyHtml);
+      expect(vars["remediationNotes"]).toBe(expectedEmptyHtml || "");
+      expect(vars["rootCause"]).toBe(expectedDefaultRootCauseHtml);
+    }
+  });
+});

--- a/App/Tests/Workers/Jobs/IncidentOwners/SendStateChangeNotification.test.ts
+++ b/App/Tests/Workers/Jobs/IncidentOwners/SendStateChangeNotification.test.ts
@@ -1,0 +1,762 @@
+import Incident from "Common/Models/DatabaseModels/Incident";
+import { IncidentFeedEventType } from "Common/Models/DatabaseModels/IncidentFeed";
+import IncidentSeverity from "Common/Models/DatabaseModels/IncidentSeverity";
+import IncidentState from "Common/Models/DatabaseModels/IncidentState";
+import IncidentStateTimeline from "Common/Models/DatabaseModels/IncidentStateTimeline";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import Project from "Common/Models/DatabaseModels/Project";
+import User from "Common/Models/DatabaseModels/User";
+import { Blue500, Red500 } from "Common/Types/BrandColors";
+import OneUptimeDate from "Common/Types/Date";
+import Dictionary from "Common/Types/Dictionary";
+import EmailTemplateType from "Common/Types/Email/EmailTemplateType";
+import NotificationSettingEventType from "Common/Types/NotificationSetting/NotificationSettingEventType";
+import ObjectID from "Common/Types/ObjectID";
+import Timezone from "Common/Types/Timezone";
+
+/*
+ * Regression tests for the IncidentOwner:SendStateChangeEmail cron's per-row
+ * query and CPU fan-out (keep in sync with the AlertOwners twin suite). The
+ * job used to fetch each timeline row's incident TWICE - once for the display
+ * fields and a second IncidentService.findOneById just to read
+ * incidentSeverity.name - and re-ran Markdown.convertToHTML on the same
+ * incident description once PER OWNER. The perf fix merges the severity
+ * relation into the single incident fetch and hoists the markdown conversion
+ * to once per timeline row. These tests pin:
+ *   1. the query shape: exactly ONE findOneById per timeline row, whose
+ *      select carries both the display fields and the severity relation,
+ *   2. exactly ONE Markdown.convertToHTML per row regardless of owner count,
+ *   3. the notification payloads (vars, subject, SMS, call, push, feed) are
+ *      byte-identical to the old two-query flow, including the severity name
+ *      and the converted description,
+ *   4. the skip/throw semantics are unchanged: a deleted incident is skipped,
+ *      a missing severity relation still throws (no silent ?. downgrade), and
+ *      rows without owners never reach the markdown conversion.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler (the same recorder the other
+ * App/Tests/Workers/Jobs suites use) and each test drives one full tick.
+ */
+
+type CronHandler = () => Promise<void>;
+
+/*
+ * Captured cron handlers, keyed by job name. Must be declared before the job
+ * import below so the mock factory closure can see it.
+ */
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+/*
+ * PasswordHash carries a pre-existing TS5.9 diagnostic that fails any suite
+ * whose runtime require graph reaches it (DatabaseService, the base class of
+ * every concrete service, imports it). Nothing password-related is under test
+ * here, so the module is replaced WITH A FACTORY - an automock would still
+ * require (and type-check) the real file.
+ */
+jest.mock("Common/Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
+/*
+ * Markdown is mocked so the suite can count convertToHTML calls - THE
+ * regression being removed is one conversion per owner instead of per row.
+ * The enum values mirror Common/Server/Types/Markdown's MarkdownContentType.
+ */
+jest.mock("Common/Server/Types/Markdown", () => {
+  return {
+    __esModule: true,
+    MarkdownContentType: {
+      Docs: 0,
+      Blog: 1,
+      Email: 2,
+      BlogValidation: 3,
+    },
+    default: {
+      convertToHTML: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/IncidentService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneById: jest.fn(),
+      findOwners: jest.fn(),
+      getIncidentLinkInDashboard: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/IncidentStateTimelineService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findAllBy: jest.fn(),
+      updateOneById: jest.fn(),
+      findOneBy: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/IncidentStateService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneById: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getOwners: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserNotificationSettingService", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendUserNotification: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/IncidentFeedService", () => {
+  return {
+    __esModule: true,
+    default: {
+      createIncidentFeedItem: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getUserMarkdownString: jest.fn(),
+    },
+  };
+});
+
+import IncidentFeedService from "Common/Server/Services/IncidentFeedService";
+import IncidentService from "Common/Server/Services/IncidentService";
+import IncidentStateService from "Common/Server/Services/IncidentStateService";
+import IncidentStateTimelineService from "Common/Server/Services/IncidentStateTimelineService";
+import ProjectService from "Common/Server/Services/ProjectService";
+import UserNotificationSettingService from "Common/Server/Services/UserNotificationSettingService";
+import UserService from "Common/Server/Services/UserService";
+import Markdown, { MarkdownContentType } from "Common/Server/Types/Markdown";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/IncidentOwners/SendStateChangeNotification";
+
+interface IncidentServiceMock {
+  findOneById: jest.Mock;
+  findOwners: jest.Mock;
+  getIncidentLinkInDashboard: jest.Mock;
+}
+
+interface TimelineServiceMock {
+  findAllBy: jest.Mock;
+  updateOneById: jest.Mock;
+  findOneBy: jest.Mock;
+}
+
+interface StateServiceMock {
+  findOneById: jest.Mock;
+}
+
+interface ProjectServiceMock {
+  getOwners: jest.Mock;
+}
+
+interface NotificationServiceMock {
+  sendUserNotification: jest.Mock;
+}
+
+interface FeedServiceMock {
+  createIncidentFeedItem: jest.Mock;
+}
+
+interface UserServiceMock {
+  getUserMarkdownString: jest.Mock;
+}
+
+interface MarkdownMock {
+  convertToHTML: jest.Mock;
+}
+
+const incidentService: IncidentServiceMock =
+  IncidentService as unknown as IncidentServiceMock;
+const timelineService: TimelineServiceMock =
+  IncidentStateTimelineService as unknown as TimelineServiceMock;
+const stateService: StateServiceMock =
+  IncidentStateService as unknown as StateServiceMock;
+const projectService: ProjectServiceMock =
+  ProjectService as unknown as ProjectServiceMock;
+const notificationService: NotificationServiceMock =
+  UserNotificationSettingService as unknown as NotificationServiceMock;
+const feedService: FeedServiceMock =
+  IncidentFeedService as unknown as FeedServiceMock;
+const userService: UserServiceMock = UserService as unknown as UserServiceMock;
+const markdownMock: MarkdownMock = Markdown as unknown as MarkdownMock;
+
+const PROJECT_ID: ObjectID = new ObjectID("project-1");
+const INCIDENT_1_ID: ObjectID = new ObjectID("incident-1");
+const INCIDENT_2_ID: ObjectID = new ObjectID("incident-2");
+const TIMELINE_1_ID: ObjectID = new ObjectID("timeline-1");
+const TIMELINE_2_ID: ObjectID = new ObjectID("timeline-2");
+const USER_1_ID: ObjectID = new ObjectID("user-1");
+const USER_2_ID: ObjectID = new ObjectID("user-2");
+const USER_3_ID: ObjectID = new ObjectID("user-3");
+
+const STATE_CHANGED_AT: Date = new Date("2026-08-18T10:00:00.000Z");
+const INCIDENT_LINK: string =
+  "https://oneuptime.example.com/dashboard/incident-1";
+
+function makeTimeline(data: {
+  id: ObjectID;
+  incidentId: ObjectID;
+  startsAt?: Date | undefined;
+}): IncidentStateTimeline {
+  const timeline: IncidentStateTimeline = new IncidentStateTimeline();
+  timeline.id = data.id;
+  timeline.incidentId = data.incidentId;
+  timeline.projectId = PROJECT_ID;
+  timeline.createdAt = STATE_CHANGED_AT;
+
+  if (data.startsAt) {
+    timeline.startsAt = data.startsAt;
+  }
+
+  const project: Project = new Project();
+  project.name = "Prod Project";
+  timeline.project = project;
+
+  const state: IncidentState = new IncidentState();
+  state.name = "Acknowledged";
+  state.color = Blue500;
+  state.isResolvedState = false;
+  timeline.incidentState = state;
+
+  return timeline;
+}
+
+function makeIncident(data: {
+  id: ObjectID;
+  description: string;
+  severityName?: string | undefined;
+  monitorNames?: Array<string> | undefined;
+}): Incident {
+  const incident: Incident = new Incident();
+  incident.id = data.id;
+  incident.title = "Database is down";
+  incident.projectId = PROJECT_ID;
+  incident.description = data.description;
+  incident.incidentNumber = 7;
+  incident.incidentNumberWithPrefix = "INC-7";
+
+  incident.monitors = (
+    data.monitorNames || ["web-server-1", "api-server-1"]
+  ).map((name: string) => {
+    const monitor: Monitor = new Monitor();
+    monitor.name = name;
+    return monitor;
+  });
+
+  if (data.severityName) {
+    const severity: IncidentSeverity = new IncidentSeverity();
+    severity.name = data.severityName;
+    incident.incidentSeverity = severity;
+  }
+
+  return incident;
+}
+
+function makeUser(id: ObjectID, timezone?: Timezone | undefined): User {
+  const user: User = new User();
+  user.id = id;
+
+  if (timezone) {
+    user.timezone = timezone;
+  }
+
+  return user;
+}
+
+function stubIncidents(incidents: Array<Incident>): void {
+  const incidentsById: Record<string, Incident> = {};
+
+  for (const incident of incidents) {
+    incidentsById[incident.id!.toString()] = incident;
+  }
+
+  incidentService.findOneById.mockImplementation((args: { id: ObjectID }) => {
+    return Promise.resolve(incidentsById[args.id.toString()] || null);
+  });
+}
+
+interface FindOneByIdArgs {
+  id: ObjectID;
+  props: { isRoot: boolean };
+  select: Record<string, unknown>;
+}
+
+function incidentFetchCalls(): Array<FindOneByIdArgs> {
+  return incidentService.findOneById.mock.calls.map((args: Array<unknown>) => {
+    return args[0] as FindOneByIdArgs;
+  });
+}
+
+interface SendNotificationArgs {
+  userId: ObjectID;
+  projectId: ObjectID;
+  emailEnvelope: {
+    templateType: EmailTemplateType;
+    vars: Dictionary<string>;
+    subject: string;
+  };
+  smsMessage: { message: string };
+  callRequestMessage: { data: Array<{ sayMessage: string }> };
+  pushNotificationMessage: Record<string, unknown>;
+  whatsAppMessage: Record<string, unknown>;
+  incidentId: ObjectID;
+  eventType: NotificationSettingEventType;
+}
+
+function sendCalls(): Array<SendNotificationArgs> {
+  return notificationService.sendUserNotification.mock.calls.map(
+    (args: Array<unknown>) => {
+      return args[0] as SendNotificationArgs;
+    },
+  );
+}
+
+interface UpdateCallArgs {
+  id: ObjectID;
+  data: Record<string, unknown>;
+}
+
+function timelineUpdateCalls(): Array<UpdateCallArgs> {
+  return timelineService.updateOneById.mock.calls.map(
+    (args: Array<unknown>) => {
+      return args[0] as UpdateCallArgs;
+    },
+  );
+}
+
+// The deterministic transform the Markdown mock applies to every conversion.
+function convertedHtmlOf(markdown: string): string {
+  return `<p data-md>${markdown}</p>`;
+}
+
+async function runWorkerTick(): Promise<void> {
+  const handler: CronHandler | undefined =
+    mockCapturedJobs["IncidentOwner:SendStateChangeEmail"];
+
+  if (!handler) {
+    throw new Error(
+      "IncidentOwner:SendStateChangeEmail did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await handler();
+}
+
+describe("IncidentOwner:SendStateChangeEmail worker", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest
+      .spyOn(OneUptimeDate, "getDateAsFormattedHTMLInMultipleTimezones")
+      .mockImplementation(
+        (data: {
+          date: string | Date;
+          timezones?: Array<Timezone> | undefined;
+        }): string => {
+          return `formatted:${new Date(data.date).toISOString()}:${(
+            data.timezones || []
+          ).join(",")}`;
+        },
+      );
+
+    markdownMock.convertToHTML.mockImplementation((markdown: string) => {
+      return Promise.resolve(convertedHtmlOf(markdown));
+    });
+
+    timelineService.findAllBy.mockResolvedValue([]);
+    timelineService.updateOneById.mockResolvedValue(undefined);
+    timelineService.findOneBy.mockResolvedValue(null);
+    stateService.findOneById.mockResolvedValue(null);
+    incidentService.findOneById.mockResolvedValue(null);
+    incidentService.findOwners.mockResolvedValue([]);
+    incidentService.getIncidentLinkInDashboard.mockResolvedValue(INCIDENT_LINK);
+    projectService.getOwners.mockResolvedValue([]);
+    notificationService.sendUserNotification.mockResolvedValue(undefined);
+    feedService.createIncidentFeedItem.mockResolvedValue(undefined);
+    userService.getUserMarkdownString.mockImplementation(
+      (data: { userId: ObjectID }) => {
+        return Promise.resolve(`@${data.userId.toString()}`);
+      },
+    );
+  });
+
+  test("fetches the incident EXACTLY ONCE per timeline row, selecting the severity relation alongside the display fields", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, incidentId: INCIDENT_1_ID }),
+    ]);
+    stubIncidents([
+      makeIncident({
+        id: INCIDENT_1_ID,
+        description: "**Database** is unreachable",
+        severityName: "Critical",
+      }),
+    ]);
+    incidentService.findOwners.mockResolvedValue([makeUser(USER_1_ID)]);
+
+    await runWorkerTick();
+
+    // THE removed regression: a second findOneById just for the severity name.
+    expect(incidentService.findOneById).toHaveBeenCalledTimes(1);
+
+    const fetch: FindOneByIdArgs = incidentFetchCalls()[0]!;
+
+    expect(fetch.id.toString()).toBe(INCIDENT_1_ID.toString());
+    expect(fetch.props).toEqual({ isRoot: true });
+
+    // The single select now carries the severity relation...
+    expect(fetch.select["incidentSeverity"]).toEqual({ name: true });
+
+    // ...alongside every field the old first query selected.
+    expect(fetch.select).toMatchObject({
+      _id: true,
+      title: true,
+      description: true,
+      projectId: true,
+      monitors: { name: true },
+      incidentNumber: true,
+      incidentNumberWithPrefix: true,
+    });
+
+    // The row still completes end to end off the merged fetch.
+    expect(notificationService.sendUserNotification).toHaveBeenCalledTimes(1);
+    expect(sendCalls()[0]!.emailEnvelope.vars["incidentSeverity"]).toBe(
+      "Critical",
+    );
+    expect(feedService.createIncidentFeedItem).toHaveBeenCalledTimes(1);
+  });
+
+  test("converts the description markdown ONCE PER ROW, not once per owner, across 3 owners and 2 rows", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, incidentId: INCIDENT_1_ID }),
+      makeTimeline({ id: TIMELINE_2_ID, incidentId: INCIDENT_2_ID }),
+    ]);
+    stubIncidents([
+      makeIncident({
+        id: INCIDENT_1_ID,
+        description: "row one description",
+        severityName: "Critical",
+      }),
+      makeIncident({
+        id: INCIDENT_2_ID,
+        description: "row two description",
+        severityName: "Critical",
+      }),
+    ]);
+    incidentService.findOwners.mockResolvedValue([
+      makeUser(USER_1_ID),
+      makeUser(USER_2_ID),
+      makeUser(USER_3_ID),
+    ]);
+
+    await runWorkerTick();
+
+    // 3 owners per row still notify individually...
+    expect(notificationService.sendUserNotification).toHaveBeenCalledTimes(6);
+
+    // ...but the markdown converts once per ROW (the old code did 6 here).
+    expect(markdownMock.convertToHTML).toHaveBeenCalledTimes(2);
+    expect(markdownMock.convertToHTML).toHaveBeenNthCalledWith(
+      1,
+      "row one description",
+      MarkdownContentType.Email,
+    );
+    expect(markdownMock.convertToHTML).toHaveBeenNthCalledWith(
+      2,
+      "row two description",
+      MarkdownContentType.Email,
+    );
+
+    // Every owner of a row still receives that row's converted description.
+    const descriptions: Array<string> = sendCalls().map(
+      (call: SendNotificationArgs) => {
+        return call.emailEnvelope.vars["incidentDescription"]!;
+      },
+    );
+
+    expect(descriptions).toEqual([
+      convertedHtmlOf("row one description"),
+      convertedHtmlOf("row one description"),
+      convertedHtmlOf("row one description"),
+      convertedHtmlOf("row two description"),
+      convertedHtmlOf("row two description"),
+      convertedHtmlOf("row two description"),
+    ]);
+
+    // One merged incident fetch per row - never a severity re-fetch.
+    expect(incidentService.findOneById).toHaveBeenCalledTimes(2);
+  });
+
+  test("sends byte-identical notification payloads to the old two-query flow, previous state included", async () => {
+    const startsAt: Date = STATE_CHANGED_AT;
+    const previousStartsAt: Date = new Date("2026-08-18T08:00:00.000Z");
+
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, incidentId: INCIDENT_1_ID, startsAt }),
+    ]);
+    stubIncidents([
+      makeIncident({
+        id: INCIDENT_1_ID,
+        description: "**Database** is unreachable",
+        severityName: "Critical",
+      }),
+    ]);
+    incidentService.findOwners.mockResolvedValue([
+      makeUser(USER_1_ID, Timezone.AmericaNew_York),
+      makeUser(USER_2_ID),
+      makeUser(USER_3_ID),
+    ]);
+
+    const previousTimeline: IncidentStateTimeline = new IncidentStateTimeline();
+    previousTimeline.incidentStateId = new ObjectID("state-identified");
+    previousTimeline.startsAt = previousStartsAt;
+    previousTimeline.createdAt = previousStartsAt;
+    timelineService.findOneBy.mockResolvedValue(previousTimeline);
+
+    const previousState: IncidentState = new IncidentState();
+    previousState.name = "Identified";
+    previousState.color = Red500;
+    stateService.findOneById.mockResolvedValue(previousState);
+
+    await runWorkerTick();
+
+    const expectedDuration: string =
+      OneUptimeDate.convertSecondsToDaysHoursMinutesAndSeconds(
+        OneUptimeDate.getDifferenceInSeconds(startsAt, previousStartsAt),
+      );
+
+    const expectedVarsFor: (timezones: string) => Dictionary<string> = (
+      timezones: string,
+    ) => {
+      return {
+        incidentTitle: "Database is down",
+        incidentNumber: "INC-7",
+        projectName: "Prod Project",
+        currentState: "Acknowledged",
+        currentStateColor: Blue500.toString(),
+        previousState: "Identified",
+        previousStateColor: Red500.toString(),
+        previousStateDurationText: `Was Identified for ${expectedDuration}`,
+        incidentDescription: convertedHtmlOf("**Database** is unreachable"),
+        resourcesAffected: "web-server-1, api-server-1",
+        stateChangedAt: `formatted:${STATE_CHANGED_AT.toISOString()}:${timezones}`,
+        incidentSeverity: "Critical",
+        incidentViewLink: INCIDENT_LINK,
+        isOwner: "true",
+      };
+    };
+
+    const calls: Array<SendNotificationArgs> = sendCalls();
+
+    expect(calls).toHaveLength(3);
+
+    // Per-owner vars: identical except for the owner's timezone rendering.
+    expect(calls[0]!.emailEnvelope.vars).toEqual(
+      expectedVarsFor(Timezone.AmericaNew_York),
+    );
+    expect(calls[1]!.emailEnvelope.vars).toEqual(expectedVarsFor(""));
+    expect(calls[2]!.emailEnvelope.vars).toEqual(expectedVarsFor(""));
+
+    for (const [index, call] of calls.entries()) {
+      expect(call.userId.toString()).toBe(
+        [USER_1_ID, USER_2_ID, USER_3_ID][index]!.toString(),
+      );
+      expect(call.projectId.toString()).toBe(PROJECT_ID.toString());
+      expect(call.incidentId.toString()).toBe(INCIDENT_1_ID.toString());
+      expect(call.eventType).toBe(
+        NotificationSettingEventType.SEND_INCIDENT_STATE_CHANGED_OWNER_NOTIFICATION,
+      );
+      expect(call.emailEnvelope.templateType).toBe(
+        EmailTemplateType.IncidentOwnerStateChanged,
+      );
+      expect(call.emailEnvelope.subject).toBe(
+        "[Acknowledged Incident INC-7] - Database is down",
+      );
+      expect(call.smsMessage.message).toBe(
+        "This is a message from OneUptime. Incident INC-7 (Database is down) - state changed from Identified to Acknowledged. To unsubscribe from this notification go to User Settings in OneUptime Dashboard.",
+      );
+      expect(call.callRequestMessage.data[0]!.sayMessage).toBe(
+        "This is a message from OneUptime. Incident INC-7 (Database is down) state changed from Identified to Acknowledged. To unsubscribe from this notification go to User Settings in OneUptime Dashboard. Good bye.",
+      );
+      expect(call.pushNotificationMessage).toMatchObject({
+        title: "Incident #7 Updated: Database is down",
+        body: "Incident #7 (Database is down) state changed from Identified to Acknowledged in Prod Project. Click to view details.",
+        clickAction: INCIDENT_LINK,
+        tag: "incident-state-changed",
+        requireInteraction: true,
+      });
+    }
+
+    // The row is marked notified exactly once, before the fan-out.
+    const updates: Array<UpdateCallArgs> = timelineUpdateCalls();
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.id.toString()).toBe(TIMELINE_1_ID.toString());
+    expect(updates[0]!.data).toEqual({ isOwnerNotified: true });
+
+    // The feed item is unchanged, one entry per notified owner.
+    expect(feedService.createIncidentFeedItem).toHaveBeenCalledTimes(1);
+    expect(feedService.createIncidentFeedItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        incidentFeedEventType: IncidentFeedEventType.OwnerNotificationSent,
+        displayColor: Blue500,
+        feedInfoInMarkdown: `🔔 **Owners have been notified about the state change of the [Incident INC-7](${INCIDENT_LINK}).**: Owners have been notified about the state change of the incident because the incident state changed to **Acknowledged**.`,
+        moreInformationInMarkdown: `**Notified:** @${USER_1_ID.toString()})\n**Notified:** @${USER_2_ID.toString()})\n**Notified:** @${USER_3_ID.toString()})\n`,
+      }),
+    );
+  });
+
+  test("a row whose incident no longer exists is skipped exactly as before, without blocking later rows", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, incidentId: INCIDENT_1_ID }),
+      makeTimeline({ id: TIMELINE_2_ID, incidentId: INCIDENT_2_ID }),
+    ]);
+    // INCIDENT_1 was deleted - only INCIDENT_2 still resolves.
+    stubIncidents([
+      makeIncident({
+        id: INCIDENT_2_ID,
+        description: "surviving row",
+        severityName: "Critical",
+      }),
+    ]);
+    incidentService.findOwners.mockResolvedValue([makeUser(USER_1_ID)]);
+
+    await expect(runWorkerTick()).resolves.toBeUndefined();
+
+    // Still exactly one fetch per row - the null result costs no extra query.
+    expect(incidentService.findOneById).toHaveBeenCalledTimes(2);
+
+    // The deleted row is skipped BEFORE the mark-notified write and the send.
+    const updates: Array<UpdateCallArgs> = timelineUpdateCalls();
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.id.toString()).toBe(TIMELINE_2_ID.toString());
+
+    expect(markdownMock.convertToHTML).toHaveBeenCalledTimes(1);
+    expect(notificationService.sendUserNotification).toHaveBeenCalledTimes(1);
+    expect(sendCalls()[0]!.incidentId.toString()).toBe(
+      INCIDENT_2_ID.toString(),
+    );
+    expect(feedService.createIncidentFeedItem).toHaveBeenCalledTimes(1);
+  });
+
+  test("a missing severity relation still throws after the mark-notified write - never silently downgraded", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, incidentId: INCIDENT_1_ID }),
+    ]);
+    stubIncidents([
+      makeIncident({ id: INCIDENT_1_ID, description: "no severity row" }),
+    ]);
+    incidentService.findOwners.mockResolvedValue([makeUser(USER_1_ID)]);
+
+    await expect(runWorkerTick()).rejects.toThrow(TypeError);
+
+    // Same as the old flow: the row was already marked notified...
+    expect(timelineService.updateOneById).toHaveBeenCalledTimes(1);
+
+    // ...and no notification went out.
+    expect(notificationService.sendUserNotification).not.toHaveBeenCalled();
+  });
+
+  test("a row with no owners at all is marked notified and skipped without converting markdown", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, incidentId: INCIDENT_1_ID }),
+    ]);
+    stubIncidents([
+      makeIncident({
+        id: INCIDENT_1_ID,
+        description: "unowned row",
+        severityName: "Critical",
+      }),
+    ]);
+    incidentService.findOwners.mockResolvedValue([]);
+    projectService.getOwners.mockResolvedValue([]);
+
+    await runWorkerTick();
+
+    expect(projectService.getOwners).toHaveBeenCalledTimes(1);
+    expect(timelineService.updateOneById).toHaveBeenCalledTimes(1);
+
+    // The hoisted conversion still sits behind the owners gate.
+    expect(markdownMock.convertToHTML).not.toHaveBeenCalled();
+    expect(notificationService.sendUserNotification).not.toHaveBeenCalled();
+    expect(feedService.createIncidentFeedItem).not.toHaveBeenCalled();
+  });
+
+  test("project-owner fallback still notifies without the isOwner flag and maps zero monitors to None", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: TIMELINE_1_ID, incidentId: INCIDENT_1_ID }),
+    ]);
+    stubIncidents([
+      makeIncident({
+        id: INCIDENT_1_ID,
+        description: "fallback row",
+        severityName: "Low",
+        monitorNames: [],
+      }),
+    ]);
+    incidentService.findOwners.mockResolvedValue([]);
+    projectService.getOwners.mockResolvedValue([makeUser(USER_2_ID)]);
+
+    await runWorkerTick();
+
+    const calls: Array<SendNotificationArgs> = sendCalls();
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.userId.toString()).toBe(USER_2_ID.toString());
+    expect(calls[0]!.emailEnvelope.vars["isOwner"]).toBeUndefined();
+    expect(calls[0]!.emailEnvelope.vars["incidentSeverity"]).toBe("Low");
+    expect(calls[0]!.emailEnvelope.vars["resourcesAffected"]).toBe("None");
+    expect(markdownMock.convertToHTML).toHaveBeenCalledTimes(1);
+  });
+});

--- a/App/Tests/Workers/Jobs/IncidentOwners/SendUnresolvedReminderNotification.test.ts
+++ b/App/Tests/Workers/Jobs/IncidentOwners/SendUnresolvedReminderNotification.test.ts
@@ -1,0 +1,509 @@
+import Incident from "Common/Models/DatabaseModels/Incident";
+import IncidentReminderRule from "Common/Models/DatabaseModels/IncidentReminderRule";
+import IncidentSeverity from "Common/Models/DatabaseModels/IncidentSeverity";
+import IncidentState from "Common/Models/DatabaseModels/IncidentState";
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import Project from "Common/Models/DatabaseModels/Project";
+import User from "Common/Models/DatabaseModels/User";
+import OneUptimeDate from "Common/Types/Date";
+import Dictionary from "Common/Types/Dictionary";
+import { EmailEnvelope } from "Common/Types/Email/EmailMessage";
+import EmailTemplateType from "Common/Types/Email/EmailTemplateType";
+import ObjectID from "Common/Types/ObjectID";
+import Timezone from "Common/Types/Timezone";
+
+/*
+ * Regression tests for the IncidentOwner:SendUnresolvedReminderNotification
+ * cron's markdown fan-out. The job used to re-run
+ * Markdown.convertToHTML(incident.description) INSIDE the per-owner loop even
+ * though the description never varies per owner - N marked parses per
+ * reminder. The perf fix hoists the conversion next to the already-hoisted
+ * incidentViewLink, once per incident. These tests pin:
+ *   1. exactly ONE convertToHTML call per incident regardless of owner count
+ *      (the old code called it once PER OWNER),
+ *   2. the vars dictionary each owner receives is byte-identical to what the
+ *      old per-owner conversion produced,
+ *   3. the timezone-dependent declaredAt var still varies per user,
+ *   4. the zero-owner early return still converts nothing at all.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler (the same recorder the other
+ * App/Tests/Workers/Jobs suites use) and each test drives one full tick.
+ * Markdown itself is REAL (spied, not stubbed) so the pinned HTML is the
+ * genuine marked output.
+ */
+
+type CronHandler = () => Promise<void>;
+
+/*
+ * Captured cron handlers, keyed by job name. Must be declared before the job
+ * import below so the mock factory closure can see it.
+ */
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+/*
+ * PasswordHash carries a pre-existing TS5.9 diagnostic that fails any suite
+ * whose runtime require graph reaches it. Nothing password-related is under
+ * test here, so the module is replaced WITH A FACTORY - an automock would
+ * still require (and type-check) the real file.
+ */
+jest.mock("Common/Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/IncidentService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findAllBy: jest.fn(),
+      updateOneById: jest.fn(),
+      findOwners: jest.fn(),
+      isIncidentResolved: jest.fn(),
+      isIncidentAcknowledged: jest.fn(),
+      getIncidentLinkInDashboard: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/IncidentReminderRuleService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findMatchingRule: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getOwners: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserNotificationSettingService", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendUserNotification: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getUserMarkdownString: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/IncidentFeedService", () => {
+  return {
+    __esModule: true,
+    default: {
+      createIncidentFeedItem: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/PushNotificationUtil", () => {
+  return {
+    __esModule: true,
+    default: {
+      createGenericNotification: jest.fn(() => {
+        return {};
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/WhatsAppTemplateUtil", () => {
+  return {
+    __esModule: true,
+    createWhatsAppMessageFromTemplate: jest.fn(() => {
+      return { templateVariables: {} };
+    }),
+  };
+});
+
+import IncidentFeedService from "Common/Server/Services/IncidentFeedService";
+import IncidentReminderRuleService from "Common/Server/Services/IncidentReminderRuleService";
+import IncidentService from "Common/Server/Services/IncidentService";
+import ProjectService from "Common/Server/Services/ProjectService";
+import UserNotificationSettingService from "Common/Server/Services/UserNotificationSettingService";
+import UserService from "Common/Server/Services/UserService";
+import Markdown, { MarkdownContentType } from "Common/Server/Types/Markdown";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/IncidentOwners/SendUnresolvedReminderNotification";
+
+interface IncidentServiceMock {
+  findAllBy: jest.Mock;
+  updateOneById: jest.Mock;
+  findOwners: jest.Mock;
+  isIncidentResolved: jest.Mock;
+  isIncidentAcknowledged: jest.Mock;
+  getIncidentLinkInDashboard: jest.Mock;
+}
+
+const incidentService: IncidentServiceMock =
+  IncidentService as unknown as IncidentServiceMock;
+const reminderRuleService: { findMatchingRule: jest.Mock } =
+  IncidentReminderRuleService as unknown as { findMatchingRule: jest.Mock };
+const projectService: { getOwners: jest.Mock } = ProjectService as unknown as {
+  getOwners: jest.Mock;
+};
+const notificationService: { sendUserNotification: jest.Mock } =
+  UserNotificationSettingService as unknown as {
+    sendUserNotification: jest.Mock;
+  };
+const userService: { getUserMarkdownString: jest.Mock } =
+  UserService as unknown as { getUserMarkdownString: jest.Mock };
+const feedService: { createIncidentFeedItem: jest.Mock } =
+  IncidentFeedService as unknown as { createIncidentFeedItem: jest.Mock };
+
+const NOW: Date = new Date("2026-08-18T10:00:00.000Z");
+const DECLARED_AT: Date = new Date("2026-08-18T08:00:00.000Z");
+
+const PROJECT_ID: ObjectID = new ObjectID("project-1");
+const INCIDENT_ID: ObjectID = new ObjectID("incident-1");
+const INCIDENT_LINK: string = "https://oneuptime.test/dashboard/incident-1";
+
+const DESCRIPTION_MARKDOWN: string = "**Everything** is on _fire_";
+
+function makeIncident(description: string | undefined): Incident {
+  const incident: Incident = new Incident(INCIDENT_ID);
+  incident.projectId = PROJECT_ID;
+  incident.title = "API is down";
+
+  if (description !== undefined) {
+    incident.description = description;
+  }
+
+  const project: Project = new Project();
+  project.name = "Acme Status";
+  incident.project = project;
+
+  const severity: IncidentSeverity = new IncidentSeverity();
+  severity.name = "Critical";
+  incident.incidentSeverity = severity;
+
+  const state: IncidentState = new IncidentState();
+  state.name = "Investigating";
+  incident.currentIncidentState = state;
+
+  const monitorA: Monitor = new Monitor();
+  monitorA.name = "API Monitor";
+  const monitorB: Monitor = new Monitor();
+  monitorB.name = "Web Monitor";
+  incident.monitors = [monitorA, monitorB];
+
+  incident.labels = [];
+  incident.incidentNumber = 42;
+  incident.declaredAt = DECLARED_AT;
+  incident.createdAt = DECLARED_AT;
+  incident.enableReminders = true;
+  incident.reminderNotificationSentCount = 0;
+
+  return incident;
+}
+
+function makeOwner(id: string, timezone?: Timezone | undefined): User {
+  const user: User = new User(new ObjectID(id));
+
+  if (timezone) {
+    user.timezone = timezone;
+  }
+
+  return user;
+}
+
+// The vars of each sendUserNotification call's email envelope, in call order.
+function sentVars(): Array<Dictionary<string>> {
+  return notificationService.sendUserNotification.mock.calls.map(
+    (args: Array<unknown>) => {
+      return (args[0] as { emailEnvelope: EmailEnvelope }).emailEnvelope
+        .vars as Dictionary<string>;
+    },
+  );
+}
+
+async function runWorkerTick(): Promise<void> {
+  const handler: CronHandler | undefined =
+    mockCapturedJobs["IncidentOwner:SendUnresolvedReminderNotification"];
+
+  if (!handler) {
+    throw new Error(
+      "IncidentOwner:SendUnresolvedReminderNotification did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await handler();
+}
+
+describe("IncidentOwner:SendUnresolvedReminderNotification worker", () => {
+  let markdownSpy: jest.SpyInstance;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(OneUptimeDate, "getCurrentDate").mockImplementation(() => {
+      return new Date(NOW);
+    });
+
+    // Real conversion, spied - call counts are the regression under test.
+    markdownSpy = jest.spyOn(Markdown, "convertToHTML");
+
+    const rule: IncidentReminderRule = new IncidentReminderRule();
+    rule.reminderIntervalInMinutes = 30;
+
+    incidentService.findAllBy.mockResolvedValue([]);
+    incidentService.updateOneById.mockResolvedValue(undefined);
+    incidentService.findOwners.mockResolvedValue([]);
+    incidentService.isIncidentResolved.mockResolvedValue(false);
+    incidentService.isIncidentAcknowledged.mockResolvedValue(false);
+    incidentService.getIncidentLinkInDashboard.mockResolvedValue({
+      toString: (): string => {
+        return INCIDENT_LINK;
+      },
+    });
+    reminderRuleService.findMatchingRule.mockResolvedValue(rule);
+    projectService.getOwners.mockResolvedValue([]);
+    notificationService.sendUserNotification.mockResolvedValue(undefined);
+    userService.getUserMarkdownString.mockResolvedValue("[Owner](profile)");
+    feedService.createIncidentFeedItem.mockResolvedValue(undefined);
+  });
+
+  test("converts the description ONCE per incident for 3 owners - not once per owner - and every owner gets byte-identical vars", async () => {
+    incidentService.findAllBy.mockResolvedValue([
+      makeIncident(DESCRIPTION_MARKDOWN),
+    ]);
+    incidentService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2"),
+      makeOwner("user-3"),
+    ]);
+
+    // What the old per-owner code produced for every owner, byte for byte.
+    const expectedDescriptionHtml: string = await Markdown.convertToHTML(
+      DESCRIPTION_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+
+    expect(expectedDescriptionHtml).toContain("<strong>Everything</strong>");
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    // THE regression: the old code converted once per owner (3 calls here).
+    expect(markdownSpy).toHaveBeenCalledTimes(1);
+    expect(markdownSpy).toHaveBeenCalledWith(
+      DESCRIPTION_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+
+    // The view link was already hoisted before this fix - keep it that way.
+    expect(incidentService.getIncidentLinkInDashboard).toHaveBeenCalledTimes(1);
+
+    expect(notificationService.sendUserNotification).toHaveBeenCalledTimes(3);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    const expectedVars: Dictionary<string> = {
+      incidentTitle: "API is down",
+      incidentNumber: "#42",
+      projectName: "Acme Status",
+      currentState: "Investigating",
+      openDuration: OneUptimeDate.convertSecondsToDaysHoursMinutesAndSeconds(
+        OneUptimeDate.getDifferenceInSeconds(NOW, DECLARED_AT),
+      ),
+      declaredAt: OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones({
+        date: DECLARED_AT,
+        timezones: [],
+      }),
+      incidentDescription: expectedDescriptionHtml,
+      resourcesAffected: "API Monitor, Web Monitor",
+      incidentSeverity: "Critical",
+      incidentViewLink: INCIDENT_LINK,
+      isOwner: "true",
+    };
+
+    expect(allVars).toEqual([expectedVars, expectedVars, expectedVars]);
+
+    const emailEnvelope: EmailEnvelope = (
+      notificationService.sendUserNotification.mock.calls[0]![0] as {
+        emailEnvelope: EmailEnvelope;
+      }
+    ).emailEnvelope;
+
+    expect(emailEnvelope.templateType).toBe(
+      EmailTemplateType.IncidentOwnerUnresolvedReminder,
+    );
+    expect(emailEnvelope.subject).toBe(
+      "[Reminder] Incident #42 is still Investigating - API is down",
+    );
+
+    // One feed item naming every notified owner, exactly as before.
+    expect(feedService.createIncidentFeedItem).toHaveBeenCalledTimes(1);
+    expect(
+      (
+        feedService.createIncidentFeedItem.mock.calls[0]![0] as {
+          moreInformationInMarkdown: string;
+        }
+      ).moreInformationInMarkdown,
+    ).toBe("**Notified:** [Owner](profile)\n".repeat(3));
+  });
+
+  test("the timezone-dependent declaredAt var STAYS per-user while the description conversion is still shared", async () => {
+    incidentService.findAllBy.mockResolvedValue([
+      makeIncident(DESCRIPTION_MARKDOWN),
+    ]);
+    incidentService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2", Timezone.AmericaNew_York),
+    ]);
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    expect(markdownSpy).toHaveBeenCalledTimes(1);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    expect(allVars).toHaveLength(2);
+    expect(allVars[0]!["declaredAt"]).toBe(
+      OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones({
+        date: DECLARED_AT,
+        timezones: [],
+      }),
+    );
+    expect(allVars[1]!["declaredAt"]).toBe(
+      OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones({
+        date: DECLARED_AT,
+        timezones: [Timezone.AmericaNew_York],
+      }),
+    );
+    expect(allVars[0]!["declaredAt"]).not.toBe(allVars[1]!["declaredAt"]);
+
+    // Every owner-invariant field is still identical across the two owners.
+    const invariantFields0: Dictionary<string> = { ...allVars[0]! };
+    const invariantFields1: Dictionary<string> = { ...allVars[1]! };
+    delete invariantFields0["declaredAt"];
+    delete invariantFields1["declaredAt"];
+
+    expect(invariantFields0).toEqual(invariantFields1);
+  });
+
+  test("an incident with no owners at all converts NOTHING and sends nothing", async () => {
+    incidentService.findAllBy.mockResolvedValue([
+      makeIncident(DESCRIPTION_MARKDOWN),
+    ]);
+    incidentService.findOwners.mockResolvedValue([]);
+    projectService.getOwners.mockResolvedValue([]);
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    expect(markdownSpy).not.toHaveBeenCalled();
+    expect(incidentService.getIncidentLinkInDashboard).not.toHaveBeenCalled();
+    expect(notificationService.sendUserNotification).not.toHaveBeenCalled();
+    expect(feedService.createIncidentFeedItem).not.toHaveBeenCalled();
+  });
+
+  test("an empty description converts to the same (empty) HTML the old code produced, still exactly once", async () => {
+    incidentService.findAllBy.mockResolvedValue([makeIncident(undefined)]);
+    incidentService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2"),
+      makeOwner("user-3"),
+    ]);
+
+    const expectedEmptyHtml: string = await Markdown.convertToHTML(
+      "",
+      MarkdownContentType.Email,
+    );
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    expect(markdownSpy).toHaveBeenCalledTimes(1);
+    expect(markdownSpy).toHaveBeenCalledWith("", MarkdownContentType.Email);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    expect(allVars).toHaveLength(3);
+
+    for (const vars of allVars) {
+      expect(vars["incidentDescription"]).toBe(expectedEmptyHtml);
+    }
+  });
+
+  test("project owners (fallback) get the shared conversion too, without the isOwner flag", async () => {
+    incidentService.findAllBy.mockResolvedValue([
+      makeIncident(DESCRIPTION_MARKDOWN),
+    ]);
+    incidentService.findOwners.mockResolvedValue([]);
+    projectService.getOwners.mockResolvedValue([
+      makeOwner("project-owner-1"),
+      makeOwner("project-owner-2"),
+    ]);
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    expect(markdownSpy).toHaveBeenCalledTimes(1);
+    expect(notificationService.sendUserNotification).toHaveBeenCalledTimes(2);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    for (const vars of allVars) {
+      expect(vars["isOwner"]).toBeUndefined();
+    }
+    expect(allVars[0]).toEqual(allVars[1]);
+  });
+});

--- a/App/Tests/Workers/Jobs/MonitorOwners/SendStatusChangeNotification.test.ts
+++ b/App/Tests/Workers/Jobs/MonitorOwners/SendStatusChangeNotification.test.ts
@@ -1,0 +1,551 @@
+import Monitor from "Common/Models/DatabaseModels/Monitor";
+import MonitorStatus from "Common/Models/DatabaseModels/MonitorStatus";
+import MonitorStatusTimeline from "Common/Models/DatabaseModels/MonitorStatusTimeline";
+import Project from "Common/Models/DatabaseModels/Project";
+import User from "Common/Models/DatabaseModels/User";
+import { Green } from "Common/Types/BrandColors";
+import OneUptimeDate from "Common/Types/Date";
+import Dictionary from "Common/Types/Dictionary";
+import { EmailEnvelope } from "Common/Types/Email/EmailMessage";
+import EmailTemplateType from "Common/Types/Email/EmailTemplateType";
+import ObjectID from "Common/Types/ObjectID";
+import Timezone from "Common/Types/Timezone";
+
+/*
+ * Regression tests for the MonitorOwner:SendStatusChangeEmail cron's per-owner
+ * fan-out. The job used to re-run, INSIDE the per-owner loop, three values
+ * that never vary per owner: Markdown.convertToHTML(monitor.description),
+ * Markdown.convertToHTML(timeline.rootCause), and the awaited
+ * MonitorService.getMonitorLinkInDashboard call - N marked parses and N link
+ * builds per status change. The perf fix hoists all three to once per status
+ * timeline (per timeline, NOT per tick: rootCause varies per timeline row).
+ * These tests pin:
+ *   1. exactly TWO convertToHTML calls (description + rootCause) and ONE
+ *      getMonitorLinkInDashboard call per timeline regardless of owner count
+ *      (the old code did each once PER OWNER),
+ *   2. the vars dictionary each owner receives is byte-identical to what the
+ *      old per-owner computation produced,
+ *   3. two timelines with different root causes each get their OWN rootCause
+ *      conversion - the hoist is per timeline, never per tick,
+ *   4. the timezone-dependent statusChangedAt var still varies per user,
+ *   5. the zero-owner continue still converts nothing at all.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler (the same recorder the other
+ * App/Tests/Workers/Jobs suites use) and each test drives one full tick.
+ * Markdown itself is REAL (spied, not stubbed) so the pinned HTML is the
+ * genuine marked output.
+ */
+
+type CronHandler = () => Promise<void>;
+
+/*
+ * Captured cron handlers, keyed by job name. Must be declared before the job
+ * import below so the mock factory closure can see it.
+ */
+const mockCapturedJobs: Record<string, CronHandler> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (jobName: string, _options: unknown, runFunction: CronHandler): void => {
+        mockCapturedJobs[jobName] = runFunction;
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+/*
+ * PasswordHash carries a pre-existing TS5.9 diagnostic that fails any suite
+ * whose runtime require graph reaches it. Nothing password-related is under
+ * test here, so the module is replaced WITH A FACTORY - an automock would
+ * still require (and type-check) the real file.
+ */
+jest.mock("Common/Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/MonitorStatusTimelineService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findAllBy: jest.fn(),
+      findOneBy: jest.fn(),
+      updateOneById: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/MonitorStatusService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneById: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/MonitorService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOwners: jest.fn(),
+      getMonitorLinkInDashboard: jest.fn(),
+      getMonitorDestinationInfo: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProjectService", () => {
+  return {
+    __esModule: true,
+    default: {
+      getOwners: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/UserNotificationSettingService", () => {
+  return {
+    __esModule: true,
+    default: {
+      sendUserNotification: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/PushNotificationUtil", () => {
+  return {
+    __esModule: true,
+    default: {
+      createMonitorStatusChangedNotification: jest.fn(() => {
+        return {};
+      }),
+    },
+  };
+});
+
+jest.mock("Common/Server/Utils/WhatsAppTemplateUtil", () => {
+  return {
+    __esModule: true,
+    createWhatsAppMessageFromTemplate: jest.fn(() => {
+      return { templateVariables: {} };
+    }),
+  };
+});
+
+import MonitorService from "Common/Server/Services/MonitorService";
+import MonitorStatusService from "Common/Server/Services/MonitorStatusService";
+import MonitorStatusTimelineService from "Common/Server/Services/MonitorStatusTimelineService";
+import ProjectService from "Common/Server/Services/ProjectService";
+import UserNotificationSettingService from "Common/Server/Services/UserNotificationSettingService";
+import Markdown, { MarkdownContentType } from "Common/Server/Types/Markdown";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/MonitorOwners/SendStatusChangeNotification";
+
+interface TimelineServiceMock {
+  findAllBy: jest.Mock;
+  findOneBy: jest.Mock;
+  updateOneById: jest.Mock;
+}
+
+interface MonitorServiceMock {
+  findOwners: jest.Mock;
+  getMonitorLinkInDashboard: jest.Mock;
+  getMonitorDestinationInfo: jest.Mock;
+}
+
+const timelineService: TimelineServiceMock =
+  MonitorStatusTimelineService as unknown as TimelineServiceMock;
+const monitorStatusService: { findOneById: jest.Mock } =
+  MonitorStatusService as unknown as { findOneById: jest.Mock };
+const monitorService: MonitorServiceMock =
+  MonitorService as unknown as MonitorServiceMock;
+const projectService: { getOwners: jest.Mock } = ProjectService as unknown as {
+  getOwners: jest.Mock;
+};
+const notificationService: { sendUserNotification: jest.Mock } =
+  UserNotificationSettingService as unknown as {
+    sendUserNotification: jest.Mock;
+  };
+
+const CHANGED_AT: Date = new Date("2026-08-18T09:30:00.000Z");
+
+const PROJECT_ID: ObjectID = new ObjectID("project-1");
+const MONITOR_ID: ObjectID = new ObjectID("monitor-1");
+const MONITOR_LINK: string = "https://oneuptime.test/dashboard/monitor-1";
+
+const DESCRIPTION_MARKDOWN: string = "Checks the **public API** every minute";
+const ROOT_CAUSE_MARKDOWN: string = "Upstream **database** is unreachable";
+
+const DESTINATION_INFO: {
+  monitorDestination: string;
+  requestType: string;
+  monitorType: string;
+} = {
+  monitorDestination: "https://api.acme.test/health",
+  requestType: "GET",
+  monitorType: "Website",
+};
+
+function makeTimeline(data: {
+  id: string;
+  description?: string | undefined;
+  rootCause?: string | undefined;
+}): MonitorStatusTimeline {
+  const timeline: MonitorStatusTimeline = new MonitorStatusTimeline(
+    new ObjectID(data.id),
+  );
+  timeline.projectId = PROJECT_ID;
+  timeline.createdAt = CHANGED_AT;
+  timeline.startsAt = CHANGED_AT;
+  timeline.monitorId = MONITOR_ID;
+
+  const project: Project = new Project();
+  project.name = "Acme Status";
+  timeline.project = project;
+
+  const monitor: Monitor = new Monitor(MONITOR_ID);
+  monitor.name = "API Monitor";
+
+  if (data.description !== undefined) {
+    monitor.description = data.description;
+  }
+
+  timeline.monitor = monitor;
+
+  const status: MonitorStatus = new MonitorStatus();
+  status.name = "Operational";
+  status.color = Green;
+  timeline.monitorStatus = status;
+
+  if (data.rootCause !== undefined) {
+    timeline.rootCause = data.rootCause;
+  }
+
+  return timeline;
+}
+
+function makeOwner(id: string, timezone?: Timezone | undefined): User {
+  const user: User = new User(new ObjectID(id));
+
+  if (timezone) {
+    user.timezone = timezone;
+  }
+
+  return user;
+}
+
+// The vars of each sendUserNotification call's email envelope, in call order.
+function sentVars(): Array<Dictionary<string>> {
+  return notificationService.sendUserNotification.mock.calls.map(
+    (args: Array<unknown>) => {
+      return (args[0] as { emailEnvelope: EmailEnvelope }).emailEnvelope
+        .vars as Dictionary<string>;
+    },
+  );
+}
+
+async function runWorkerTick(): Promise<void> {
+  const handler: CronHandler | undefined =
+    mockCapturedJobs["MonitorOwner:SendStatusChangeEmail"];
+
+  if (!handler) {
+    throw new Error(
+      "MonitorOwner:SendStatusChangeEmail did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await handler();
+}
+
+describe("MonitorOwner:SendStatusChangeEmail worker", () => {
+  let markdownSpy: jest.SpyInstance;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Real conversion, spied - call counts are the regression under test.
+    markdownSpy = jest.spyOn(Markdown, "convertToHTML");
+
+    timelineService.findAllBy.mockResolvedValue([]);
+    timelineService.findOneBy.mockResolvedValue(null);
+    timelineService.updateOneById.mockResolvedValue(undefined);
+    monitorStatusService.findOneById.mockResolvedValue(null);
+    monitorService.findOwners.mockResolvedValue([]);
+    monitorService.getMonitorLinkInDashboard.mockResolvedValue({
+      toString: (): string => {
+        return MONITOR_LINK;
+      },
+    });
+    monitorService.getMonitorDestinationInfo.mockReturnValue(DESTINATION_INFO);
+    projectService.getOwners.mockResolvedValue([]);
+    notificationService.sendUserNotification.mockResolvedValue(undefined);
+  });
+
+  test("converts description and rootCause ONCE per timeline for 3 owners - and builds the dashboard link once, not per owner", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({
+        id: "timeline-1",
+        description: DESCRIPTION_MARKDOWN,
+        rootCause: ROOT_CAUSE_MARKDOWN,
+      }),
+    ]);
+    monitorService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2"),
+      makeOwner("user-3"),
+    ]);
+
+    // What the old per-owner code produced for every owner, byte for byte.
+    const expectedDescriptionHtml: string = await Markdown.convertToHTML(
+      DESCRIPTION_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+    const expectedRootCauseHtml: string = await Markdown.convertToHTML(
+      ROOT_CAUSE_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+
+    expect(expectedRootCauseHtml).toContain("<strong>database</strong>");
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    /*
+     * THE regression: the old code converted BOTH values once per owner
+     * (6 calls here) and awaited the dashboard link once per owner (3 calls).
+     */
+    expect(markdownSpy).toHaveBeenCalledTimes(2);
+    expect(markdownSpy).toHaveBeenNthCalledWith(
+      1,
+      DESCRIPTION_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+    expect(markdownSpy).toHaveBeenNthCalledWith(
+      2,
+      ROOT_CAUSE_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+    expect(monitorService.getMonitorLinkInDashboard).toHaveBeenCalledTimes(1);
+
+    expect(notificationService.sendUserNotification).toHaveBeenCalledTimes(3);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    const expectedVars: Dictionary<string> = {
+      monitorName: "API Monitor",
+      projectName: "Acme Status",
+      currentStatus: "Operational",
+      currentStatusColor: Green.toString(),
+      previousStatus: "",
+      previousStatusColor: "#94a3b8",
+      previousStatusDurationText: "",
+      monitorDescription: expectedDescriptionHtml,
+      statusChangedAt: OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones({
+        date: CHANGED_AT,
+        timezones: [],
+      }),
+      monitorViewLink: MONITOR_LINK,
+      rootCause: expectedRootCauseHtml,
+      monitorDestination: DESTINATION_INFO.monitorDestination,
+      requestType: DESTINATION_INFO.requestType,
+      monitorType: DESTINATION_INFO.monitorType,
+      isOwner: "true",
+    };
+
+    expect(allVars).toEqual([expectedVars, expectedVars, expectedVars]);
+
+    const emailEnvelope: EmailEnvelope = (
+      notificationService.sendUserNotification.mock.calls[0]![0] as {
+        emailEnvelope: EmailEnvelope;
+      }
+    ).emailEnvelope;
+
+    expect(emailEnvelope.templateType).toBe(
+      EmailTemplateType.MonitorOwnerStatusChanged,
+    );
+    expect(emailEnvelope.subject).toBe("[Operational Monitor] API Monitor");
+  });
+
+  test("two timelines with different root causes each get their OWN conversion - the hoist is per timeline, not per tick", async () => {
+    const otherRootCause: string = "A **deploy** rolled back";
+
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({
+        id: "timeline-1",
+        description: DESCRIPTION_MARKDOWN,
+        rootCause: ROOT_CAUSE_MARKDOWN,
+      }),
+      makeTimeline({
+        id: "timeline-2",
+        description: DESCRIPTION_MARKDOWN,
+        rootCause: otherRootCause,
+      }),
+    ]);
+    monitorService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2"),
+    ]);
+
+    const expectedFirstRootCauseHtml: string = await Markdown.convertToHTML(
+      ROOT_CAUSE_MARKDOWN,
+      MarkdownContentType.Email,
+    );
+    const expectedSecondRootCauseHtml: string = await Markdown.convertToHTML(
+      otherRootCause,
+      MarkdownContentType.Email,
+    );
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    // 2 timelines x (1 description + 1 rootCause), independent of owner count.
+    expect(markdownSpy).toHaveBeenCalledTimes(4);
+    expect(markdownSpy.mock.calls).toEqual([
+      [DESCRIPTION_MARKDOWN, MarkdownContentType.Email],
+      [ROOT_CAUSE_MARKDOWN, MarkdownContentType.Email],
+      [DESCRIPTION_MARKDOWN, MarkdownContentType.Email],
+      [otherRootCause, MarkdownContentType.Email],
+    ]);
+    expect(monitorService.getMonitorLinkInDashboard).toHaveBeenCalledTimes(2);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    // 2 owners per timeline, first timeline's sends first.
+    expect(allVars).toHaveLength(4);
+    expect(allVars[0]!["rootCause"]).toBe(expectedFirstRootCauseHtml);
+    expect(allVars[1]!["rootCause"]).toBe(expectedFirstRootCauseHtml);
+    expect(allVars[2]!["rootCause"]).toBe(expectedSecondRootCauseHtml);
+    expect(allVars[3]!["rootCause"]).toBe(expectedSecondRootCauseHtml);
+  });
+
+  test("the timezone-dependent statusChangedAt var STAYS per-user while the conversions are still shared", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({
+        id: "timeline-1",
+        description: DESCRIPTION_MARKDOWN,
+        rootCause: ROOT_CAUSE_MARKDOWN,
+      }),
+    ]);
+    monitorService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2", Timezone.AmericaNew_York),
+    ]);
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    expect(markdownSpy).toHaveBeenCalledTimes(2);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    expect(allVars).toHaveLength(2);
+    expect(allVars[1]!["statusChangedAt"]).toBe(
+      OneUptimeDate.getDateAsFormattedHTMLInMultipleTimezones({
+        date: CHANGED_AT,
+        timezones: [Timezone.AmericaNew_York],
+      }),
+    );
+    expect(allVars[0]!["statusChangedAt"]).not.toBe(
+      allVars[1]!["statusChangedAt"],
+    );
+
+    // Every owner-invariant field is still identical across the two owners.
+    const invariantFields0: Dictionary<string> = { ...allVars[0]! };
+    const invariantFields1: Dictionary<string> = { ...allVars[1]! };
+    delete invariantFields0["statusChangedAt"];
+    delete invariantFields1["statusChangedAt"];
+
+    expect(invariantFields0).toEqual(invariantFields1);
+  });
+
+  test("a timeline with no owners at all converts NOTHING - but is still marked owner-notified", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({
+        id: "timeline-1",
+        description: DESCRIPTION_MARKDOWN,
+        rootCause: ROOT_CAUSE_MARKDOWN,
+      }),
+    ]);
+    monitorService.findOwners.mockResolvedValue([]);
+    projectService.getOwners.mockResolvedValue([]);
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    expect(timelineService.updateOneById).toHaveBeenCalledTimes(1);
+    expect(markdownSpy).not.toHaveBeenCalled();
+    expect(monitorService.getMonitorLinkInDashboard).not.toHaveBeenCalled();
+    expect(notificationService.sendUserNotification).not.toHaveBeenCalled();
+  });
+
+  test("empty description and missing rootCause convert to the same (empty) HTML the old code produced, once each", async () => {
+    timelineService.findAllBy.mockResolvedValue([
+      makeTimeline({ id: "timeline-1" }),
+    ]);
+    monitorService.findOwners.mockResolvedValue([
+      makeOwner("user-1"),
+      makeOwner("user-2"),
+      makeOwner("user-3"),
+    ]);
+
+    // The old code's exact expressions for both empty inputs.
+    const expectedEmptyDescriptionHtml: string = await Markdown.convertToHTML(
+      "",
+      MarkdownContentType.Email,
+    );
+    const expectedEmptyRootCauseHtml: string =
+      (await Markdown.convertToHTML("", MarkdownContentType.Email)) || "";
+
+    markdownSpy.mockClear();
+
+    await runWorkerTick();
+
+    expect(markdownSpy).toHaveBeenCalledTimes(2);
+    expect(markdownSpy.mock.calls).toEqual([
+      ["", MarkdownContentType.Email],
+      ["", MarkdownContentType.Email],
+    ]);
+
+    const allVars: Array<Dictionary<string>> = sentVars();
+
+    expect(allVars).toHaveLength(3);
+
+    for (const vars of allVars) {
+      expect(vars["monitorDescription"]).toBe(expectedEmptyDescriptionHtml);
+      expect(vars["rootCause"]).toBe(expectedEmptyRootCauseHtml);
+    }
+  });
+});

--- a/Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel.ts
+++ b/Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel.ts
@@ -252,8 +252,7 @@ export default class DatabaseBaseModel extends BaseEntity {
   }
 
   public getTableColumnMetadata(columnName: string): TableColumnMetadata {
-    const dictionary: Dictionary<TableColumnMetadata> = getTableColumns(this);
-    return dictionary[columnName] as TableColumnMetadata;
+    return getTableColumn(this, columnName);
   }
 
   public hasColumn(columnName: string): boolean {
@@ -275,8 +274,10 @@ export default class DatabaseBaseModel extends BaseEntity {
   }
 
   public getColumnAccessControlForAllColumns(): Dictionary<ColumnAccessControl> {
-    const dictionary: Dictionary<ColumnAccessControl> =
-      getColumnAccessControlForAllColumns(this);
+    // Copy: the helper's dictionary is cached per class and must stay pristine.
+    const dictionary: Dictionary<ColumnAccessControl> = {
+      ...getColumnAccessControlForAllColumns(this),
+    };
 
     const defaultColumns: Array<string> = [
       "_id",

--- a/Common/Server/Services/DatabaseService.ts
+++ b/Common/Server/Services/DatabaseService.ts
@@ -34,6 +34,7 @@ import Encryption from "../Utils/Encryption";
 import PasswordHash from "../Utils/PasswordHash";
 import PostgresErrorTranslator from "../Utils/Database/PostgresErrorTranslator";
 import logger, { LogAttributes } from "../Utils/Logger";
+import ConfigLogLevel from "../Types/ConfigLogLevel";
 import BaseService from "./BaseService";
 import BaseModel from "../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
 import { WorkflowRoute } from "../../ServiceRoute";
@@ -2268,6 +2269,14 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
        */
       const affectedItems: Array<TBaseModel> = [];
 
+      /*
+       * The per-item debug payload below is a pretty-printed JSON.stringify
+       * of every matched row; skip building it entirely unless the log level
+       * is DEBUG, since logger.debug() no-ops at any other level.
+       */
+      const isDebugLogEnabled: boolean =
+        logger.getLogLevel() === ConfigLogLevel.DEBUG;
+
       for (const item of items) {
         /*
          * _id must be set AFTER the spread: update data can carry an
@@ -2282,12 +2291,14 @@ class DatabaseService<TBaseModel extends BaseModel> extends BaseService {
           _id: item._id!,
         } as any;
 
-        logger.debug("Updated Item", {
-          projectId: updateBy.props.tenantId?.toString(),
-        } as LogAttributes);
-        logger.debug(JSON.stringify(updatedItem, null, 2), {
-          projectId: updateBy.props.tenantId?.toString(),
-        } as LogAttributes);
+        if (isDebugLogEnabled) {
+          logger.debug("Updated Item", {
+            projectId: updateBy.props.tenantId?.toString(),
+          } as LogAttributes);
+          logger.debug(JSON.stringify(updatedItem, null, 2), {
+            projectId: updateBy.props.tenantId?.toString(),
+          } as LogAttributes);
+        }
 
         if (hasRelationUpdates) {
           await this.getRepository().save(updatedItem);

--- a/Common/Server/Utils/StartServer.ts
+++ b/Common/Server/Utils/StartServer.ts
@@ -76,30 +76,51 @@ app.set("view engine", "ejs");
 app.set("trust proxy", TrustedProxyHops);
 app.use(CookieParser());
 
-const jsonBodyParserMiddleware: RequestHandler = ExpressJson({
+export type BodyParserVerify = (
+  req: ExpressRequest,
+  res: ExpressResponse,
+  buf: Buffer,
+) => void;
+
+export interface BodyParserOptions {
+  limit: string;
+  extended: boolean;
+  verify: BodyParserVerify;
+}
+
+export const jsonBodyParserOptions: BodyParserOptions = {
   limit: "50mb",
   extended: true,
-  verify: (req: ExpressRequest, _res: ExpressResponse, buf: Buffer) => {
+  verify: (req: ExpressRequest, _res: ExpressResponse, buf: Buffer): void => {
     (req as OneUptimeRequest).rawBody = buf.toString();
     logger.debug(
       `Raw JSON Body for signature verification captured`,
       getLogAttributesFromRequest(req as OneUptimeRequest),
     );
   },
-}); // 50 MB limit.
+};
 
-const urlEncodedMiddleware: RequestHandler = ExpressUrlEncoded({
+const jsonBodyParserMiddleware: RequestHandler = ExpressJson(
+  jsonBodyParserOptions,
+); // 50 MB limit.
+
+export const urlEncodedBodyParserOptions: BodyParserOptions = {
   limit: "50mb",
   extended: true,
-  verify: (req: ExpressRequest, _res: ExpressResponse, buf: Buffer) => {
-    (req as OneUptimeRequest).rawFormUrlEncodedBody = buf.toString();
-    (req as OneUptimeRequest).rawBody = buf.toString(); // Also set rawBody for consistency
+  verify: (req: ExpressRequest, _res: ExpressResponse, buf: Buffer): void => {
+    const raw: string = buf.toString();
+    (req as OneUptimeRequest).rawFormUrlEncodedBody = raw;
+    (req as OneUptimeRequest).rawBody = raw; // Also set rawBody for consistency
     logger.debug(
-      `Raw Form Url Encoded Body: ${(req as OneUptimeRequest).rawFormUrlEncodedBody}`,
+      `Raw Form Url Encoded Body for signature verification captured`,
       getLogAttributesFromRequest(req as OneUptimeRequest),
     );
   },
-}); // 50 MB limit.
+};
+
+const urlEncodedMiddleware: RequestHandler = ExpressUrlEncoded(
+  urlEncodedBodyParserOptions,
+); // 50 MB limit.
 
 const setDefaultHeaders: RequestHandler = (
   req: ExpressRequest,

--- a/Common/Tests/Server/Services/DatabaseServiceUpdateDebugLogging.test.ts
+++ b/Common/Tests/Server/Services/DatabaseServiceUpdateDebugLogging.test.ts
@@ -1,0 +1,282 @@
+/*
+ * PasswordHash carries a pre-existing TS5.9 diagnostic that fails any suite
+ * whose runtime require graph reaches it (DatabaseService, the base class of
+ * every concrete service, imports it). Nothing password-related is under
+ * test here, so the module is replaced WITH A FACTORY — an automock would
+ * still require (and type-check) the real file.
+ */
+jest.mock("../../../Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
+import NetworkDeviceDiscoveryScanService from "../../../Server/Services/NetworkDeviceDiscoveryScanService";
+import ModelPermission from "../../../Server/Types/Database/Permissions/Index";
+import ConfigLogLevel from "../../../Server/Types/ConfigLogLevel";
+import UpdateBy from "../../../Server/Types/Database/UpdateBy";
+import logger from "../../../Server/Utils/Logger";
+import NetworkDeviceDiscoveryScan from "../../../Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import ObjectID from "../../../Types/ObjectID";
+import { JSONObject } from "../../../Types/JSON";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * Regression tests for the log-level gate on _updateBy's per-row debug
+ * logging.
+ *
+ * _updateBy used to build a pretty-printed JSON.stringify(updatedItem,
+ * null, 2) for EVERY matched row of EVERY update, unconditionally — and
+ * logger.debug then discarded it at the default INFO level. That was pure
+ * per-row CPU and allocation fleet-wide, and it also meant a payload whose
+ * serialization throws (e.g. a circular structure) failed the whole update
+ * even though nothing would ever be logged.
+ *
+ * The fix hoists a single logger.getLogLevel() check above the per-item loop
+ * and only enters the debug-logging block (stringify + LogAttributes
+ * allocation) when the level is DEBUG. These tests pin:
+ *
+ *   - at INFO: the block is skipped entirely (no debug calls, no stringify,
+ *     one level read for the whole update rather than per row), and the
+ *     write itself is untouched;
+ *   - at DEBUG: logger.debug receives the byte-identical pretty-printed
+ *     payload it always did;
+ *   - the one blessed semantic delta: a payload whose serialization throws
+ *     now only throws at DEBUG level.
+ */
+
+type ScanUpdateData = UpdateBy<NetworkDeviceDiscoveryScan>["data"];
+
+describe("DatabaseService._updateBy — per-row debug logging is gated on the log level", () => {
+  let saveMock: MockFunction;
+  let updateMock: MockFunction;
+  let debugSpy: MockFunction;
+  let getLogLevelSpy: MockFunction;
+
+  const mockFoundItems: (ids: Array<ObjectID>) => void = (
+    ids: Array<ObjectID>,
+  ): void => {
+    const items: Array<NetworkDeviceDiscoveryScan> = ids.map((id: ObjectID) => {
+      const item: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
+      item._id = id.toString();
+      return item;
+    });
+
+    jest
+      .spyOn(NetworkDeviceDiscoveryScanService as any, "_findBy")
+      .mockResolvedValue(items as never);
+  };
+
+  const setLogLevel: (level: ConfigLogLevel) => void = (
+    level: ConfigLogLevel,
+  ): void => {
+    getLogLevelSpy = jest
+      .spyOn(logger, "getLogLevel")
+      .mockReturnValue(level) as unknown as MockFunction;
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+
+    debugSpy = jest.spyOn(logger, "debug").mockImplementation(() => {
+      return undefined;
+    }) as unknown as MockFunction;
+
+    saveMock = getJestMockFunction();
+    saveMock.mockImplementation((item: unknown) => {
+      return Promise.resolve(item);
+    });
+    updateMock = getJestMockFunction();
+    updateMock.mockImplementation(() => {
+      return Promise.resolve({ affected: 1 });
+    });
+    jest
+      .spyOn(NetworkDeviceDiscoveryScanService, "getRepository")
+      .mockReturnValue({ save: saveMock, update: updateMock } as never);
+
+    // The permission layer needs a DB and is not what these tests exercise.
+    jest
+      .spyOn(ModelPermission, "checkUpdatePermissionByModel")
+      .mockResolvedValue(undefined as never);
+    jest
+      .spyOn(ModelPermission, "checkUpdateQueryPermissions")
+      .mockImplementation(((
+        _modelType: unknown,
+        query: unknown,
+      ): Promise<unknown> => {
+        return Promise.resolve(query);
+      }) as never);
+  });
+
+  afterEach(() => {
+    /*
+     * Restores logger.getLogLevel / logger.debug so other suites see the
+     * real log level again.
+     */
+    jest.restoreAllMocks();
+  });
+
+  test("at INFO, an update whose payload JSON.stringify would throw on still completes", async () => {
+    setLogLevel(ConfigLogLevel.INFO);
+
+    const scanId: ObjectID = ObjectID.generate();
+    mockFoundItems([scanId]);
+
+    const circular: JSONObject = { name: "loop" };
+    circular["self"] = circular;
+    expect(() => {
+      return JSON.stringify(circular);
+    }).toThrow();
+
+    const updatedCount: number =
+      await NetworkDeviceDiscoveryScanService.updateOneById({
+        id: scanId,
+        data: { status: circular } as unknown as ScanUpdateData,
+        props: { isRoot: true },
+      });
+
+    expect(updatedCount).toBe(1);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(saveMock).not.toHaveBeenCalled();
+
+    /*
+     * The write payload is untouched: the very same object reference lands
+     * in the SET, never a serialized copy.
+     */
+    const whereClause: JSONObject = updateMock.mock.calls[0]![0] as JSONObject;
+    const setPayload: JSONObject = updateMock.mock.calls[0]![1] as JSONObject;
+    expect(whereClause["_id"]).toBe(scanId.toString());
+    expect(setPayload["status"]).toBe(circular);
+  });
+
+  test("at INFO, logger.debug is never called for any matched row", async () => {
+    setLogLevel(ConfigLogLevel.INFO);
+
+    const scanIds: Array<ObjectID> = [
+      ObjectID.generate(),
+      ObjectID.generate(),
+      ObjectID.generate(),
+    ];
+    mockFoundItems(scanIds);
+
+    const updatedCount: number =
+      await NetworkDeviceDiscoveryScanService.updateBy({
+        query: {},
+        data: { status: "In Progress" } as ScanUpdateData,
+        limit: scanIds.length,
+        skip: 0,
+        props: { isRoot: true },
+      });
+
+    // On the old code this was two debug calls per row (six here).
+    expect(debugSpy).not.toHaveBeenCalled();
+
+    // The write itself is unchanged.
+    expect(updatedCount).toBe(scanIds.length);
+    expect(updateMock).toHaveBeenCalledTimes(scanIds.length);
+    for (let i: number = 0; i < scanIds.length; i++) {
+      const whereClause: JSONObject = updateMock.mock.calls[
+        i
+      ]![0] as JSONObject;
+      const setPayload: JSONObject = updateMock.mock.calls[i]![1] as JSONObject;
+      expect(whereClause["_id"]).toBe(scanIds[i]!.toString());
+      expect(setPayload["status"]).toBe("In Progress");
+    }
+  });
+
+  test("the level check is hoisted: one getLogLevel read for the whole update, not one per row", async () => {
+    setLogLevel(ConfigLogLevel.INFO);
+
+    mockFoundItems([
+      ObjectID.generate(),
+      ObjectID.generate(),
+      ObjectID.generate(),
+    ]);
+
+    await NetworkDeviceDiscoveryScanService.updateBy({
+      query: {},
+      data: { status: "In Progress" } as ScanUpdateData,
+      limit: 3,
+      skip: 0,
+      props: { isRoot: true },
+    });
+
+    expect(getLogLevelSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("at DEBUG, logger.debug receives the exact pretty-printed payload per row, as before", async () => {
+    setLogLevel(ConfigLogLevel.DEBUG);
+
+    const projectId: ObjectID = ObjectID.generate();
+    const scanIds: Array<ObjectID> = [ObjectID.generate(), ObjectID.generate()];
+    mockFoundItems(scanIds);
+
+    await NetworkDeviceDiscoveryScanService.updateBy({
+      query: {},
+      data: { status: "In Progress" } as ScanUpdateData,
+      limit: scanIds.length,
+      skip: 0,
+      props: { isRoot: true, tenantId: projectId },
+    });
+
+    /*
+     * Two debug calls per matched row: the "Updated Item" marker, then the
+     * pretty-printed payload.
+     */
+    expect(debugSpy).toHaveBeenCalledTimes(scanIds.length * 2);
+
+    for (let i: number = 0; i < scanIds.length; i++) {
+      const expectedPayload: string = JSON.stringify(
+        { status: "In Progress", _id: scanIds[i]!.toString() },
+        null,
+        2,
+      );
+      /*
+       * Guard the guard: the expectation itself must be the multi-line
+       * pretty-printed form, not a compact one.
+       */
+      expect(expectedPayload).toContain("\n");
+
+      expect(debugSpy.mock.calls[i * 2]![0]).toBe("Updated Item");
+      expect(debugSpy.mock.calls[i * 2]![1]).toEqual({
+        projectId: projectId.toString(),
+      });
+      expect(debugSpy.mock.calls[i * 2 + 1]![0]).toBe(expectedPayload);
+      expect(debugSpy.mock.calls[i * 2 + 1]![1]).toEqual({
+        projectId: projectId.toString(),
+      });
+    }
+
+    expect(updateMock).toHaveBeenCalledTimes(scanIds.length);
+  });
+
+  test("at DEBUG, a payload whose serialization throws still fails the update (blessed delta)", async () => {
+    setLogLevel(ConfigLogLevel.DEBUG);
+
+    const scanId: ObjectID = ObjectID.generate();
+    mockFoundItems([scanId]);
+
+    const circular: JSONObject = { name: "loop" };
+    circular["self"] = circular;
+
+    await expect(
+      NetworkDeviceDiscoveryScanService.updateOneById({
+        id: scanId,
+        data: { status: circular } as unknown as ScanUpdateData,
+        props: { isRoot: true },
+      }),
+    ).rejects.toThrow();
+
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+});

--- a/Common/Tests/Server/Utils/StartServerBodyVerify.test.ts
+++ b/Common/Tests/Server/Utils/StartServerBodyVerify.test.ts
@@ -1,0 +1,335 @@
+import {
+  jsonBodyParserOptions,
+  urlEncodedBodyParserOptions,
+} from "../../../Server/Utils/StartServer";
+import {
+  ExpressJson,
+  ExpressRequest,
+  ExpressResponse,
+  ExpressUrlEncoded,
+  OneUptimeRequest,
+  RequestHandler,
+} from "../../../Server/Utils/Express";
+import logger from "../../../Server/Utils/Logger";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { Readable } from "stream";
+import fs from "fs";
+import path from "path";
+
+/*
+ * The body-parser verify callbacks capture the raw request body for webhook
+ * signature verification (Slack, WhatsApp, GitHub, billing). Every consumer
+ * does a read-only string comparison against the captured value, so the
+ * urlencoded path must alias ONE decoded string to both rawBody and
+ * rawFormUrlEncodedBody instead of decoding the buffer twice, and neither
+ * path may embed the body (which carries signing material) in its debug
+ * message.
+ */
+
+type SpyLike = {
+  mock: { calls: Array<Array<unknown>> };
+  mockRestore: () => void;
+};
+
+type MockFn = ReturnType<typeof jest.fn>;
+
+const JSON_DEBUG_MESSAGE: string =
+  "Raw JSON Body for signature verification captured";
+const URL_ENCODED_DEBUG_MESSAGE: string =
+  "Raw Form Url Encoded Body for signature verification captured";
+
+let debugSpy: SpyLike;
+
+beforeEach(() => {
+  debugSpy = jest
+    .spyOn(logger, "debug")
+    .mockImplementation((): void => {}) as unknown as SpyLike;
+});
+
+afterEach(() => {
+  debugSpy.mockRestore();
+});
+
+type VerifyInvoker = (req: OneUptimeRequest, buf: Buffer) => void;
+
+const invokeUrlEncodedVerify: VerifyInvoker = (
+  req: OneUptimeRequest,
+  buf: Buffer,
+): void => {
+  urlEncodedBodyParserOptions.verify(
+    req as ExpressRequest,
+    {} as ExpressResponse,
+    buf,
+  );
+};
+
+const invokeJsonVerify: VerifyInvoker = (
+  req: OneUptimeRequest,
+  buf: Buffer,
+): void => {
+  jsonBodyParserOptions.verify(
+    req as ExpressRequest,
+    {} as ExpressResponse,
+    buf,
+  );
+};
+
+describe("urlencoded verify: single decode aliased to both fields", () => {
+  test("decodes the buffer exactly once", () => {
+    const toString: MockFn = jest.fn().mockReturnValue("a=1&b=2");
+    const req: OneUptimeRequest = {} as OneUptimeRequest;
+
+    invokeUrlEncodedVerify(req, { toString } as unknown as Buffer);
+
+    expect(toString).toHaveBeenCalledTimes(1);
+  });
+
+  test("both fields come from the SAME decode, not two independent copies", () => {
+    /*
+     * A buffer whose toString returns a different value on every call: with
+     * one decode both fields hold the first value; the old two-decode code
+     * would leave the second value on rawBody.
+     */
+    const toString: MockFn = jest
+      .fn()
+      .mockReturnValueOnce("first-decode")
+      .mockReturnValue("second-decode");
+    const req: OneUptimeRequest = {} as OneUptimeRequest;
+
+    invokeUrlEncodedVerify(req, { toString } as unknown as Buffer);
+
+    expect(req.rawFormUrlEncodedBody).toBe("first-decode");
+    expect(req.rawBody).toBe("first-decode");
+    expect(req.rawBody).toBe(req.rawFormUrlEncodedBody);
+  });
+
+  test("captures an ASCII body byte-identical to buf.toString()", () => {
+    const body: string = "a=1&b=2&msg=hello+world&sig=abc123";
+    const buf: Buffer = Buffer.from(body);
+    const req: OneUptimeRequest = {} as OneUptimeRequest;
+
+    invokeUrlEncodedVerify(req, buf);
+
+    expect(req.rawFormUrlEncodedBody).toBe(buf.toString());
+    expect(req.rawBody).toBe(buf.toString());
+    expect(req.rawBody).toBe(body);
+  });
+
+  test("captures a multi-byte UTF-8 body byte-identical to buf.toString()", () => {
+    const body: string = "name=Grüße&emoji=🚀🔥&city=東京&mixed=a™b";
+    const buf: Buffer = Buffer.from(body, "utf8");
+    const req: OneUptimeRequest = {} as OneUptimeRequest;
+
+    invokeUrlEncodedVerify(req, buf);
+
+    expect(req.rawFormUrlEncodedBody).toBe(buf.toString());
+    expect(req.rawBody).toBe(buf.toString());
+    expect(req.rawBody).toBe(body);
+  });
+});
+
+describe("urlencoded verify: debug log is constant and body-free", () => {
+  test("logs the constant message with request attributes, never the body", () => {
+    const secret: string = "SlackSigningSecretMarker123";
+    const req: OneUptimeRequest = {
+      requestId: "req-123",
+    } as OneUptimeRequest;
+
+    invokeUrlEncodedVerify(req, Buffer.from(`token=${secret}&user=alice`));
+
+    expect(debugSpy.mock.calls).toHaveLength(1);
+
+    const message: unknown = debugSpy.mock.calls[0]![0];
+    const attributes: unknown = debugSpy.mock.calls[0]![1];
+
+    expect(message).toBe(URL_ENCODED_DEBUG_MESSAGE);
+    expect(message as string).not.toContain(secret);
+    expect(message as string).not.toContain("alice");
+    expect(attributes).toEqual({ requestId: "req-123" });
+  });
+});
+
+describe("json verify: regression guard", () => {
+  test("sets rawBody to the exact body and leaves rawFormUrlEncodedBody unset", () => {
+    const body: string = '{"alert":"CPU high","city":"東京","emoji":"🚀"}';
+    const req: OneUptimeRequest = {} as OneUptimeRequest;
+
+    invokeJsonVerify(req, Buffer.from(body, "utf8"));
+
+    expect(req.rawBody).toBe(body);
+    expect(req.rawFormUrlEncodedBody).toBeUndefined();
+  });
+
+  test("decodes the buffer exactly once", () => {
+    const toString: MockFn = jest.fn().mockReturnValue("{}");
+    const req: OneUptimeRequest = {} as OneUptimeRequest;
+
+    invokeJsonVerify(req, { toString } as unknown as Buffer);
+
+    expect(toString).toHaveBeenCalledTimes(1);
+    expect(req.rawBody).toBe("{}");
+  });
+
+  test("logs the constant message with request attributes, never the body", () => {
+    const secret: string = "GitHubWebhookSecretMarker456";
+    const req: OneUptimeRequest = {
+      requestId: "req-456",
+    } as OneUptimeRequest;
+
+    invokeJsonVerify(req, Buffer.from(`{"secret":"${secret}"}`));
+
+    expect(debugSpy.mock.calls).toHaveLength(1);
+
+    const message: unknown = debugSpy.mock.calls[0]![0];
+    const attributes: unknown = debugSpy.mock.calls[0]![1];
+
+    expect(message).toBe(JSON_DEBUG_MESSAGE);
+    expect(message as string).not.toContain(secret);
+    expect(attributes).toEqual({ requestId: "req-456" });
+  });
+});
+
+/*
+ * The exported options through the REAL express parsers, so the verify
+ * contract (arguments, timing, the parsed body still coming out the other
+ * end) is pinned against body-parser itself and not just against how these
+ * tests call the callbacks.
+ */
+describe("options through the real express parsers", () => {
+  type StreamRequestFactory = (
+    body: string,
+    contentType: string,
+  ) => OneUptimeRequest;
+
+  const createStreamRequest: StreamRequestFactory = (
+    body: string,
+    contentType: string,
+  ): OneUptimeRequest => {
+    const readable: Readable = new Readable({
+      read(): void {},
+    });
+    readable.push(Buffer.from(body, "utf8"));
+    readable.push(null);
+
+    const req: OneUptimeRequest = readable as unknown as OneUptimeRequest;
+    req.headers = {
+      "content-type": contentType,
+      "content-length": String(Buffer.byteLength(body, "utf8")),
+    };
+
+    return req;
+  };
+
+  type MiddlewareRunner = (
+    middleware: RequestHandler,
+    req: OneUptimeRequest,
+  ) => Promise<void>;
+
+  const runMiddleware: MiddlewareRunner = (
+    middleware: RequestHandler,
+    req: OneUptimeRequest,
+  ): Promise<void> => {
+    return new Promise<void>(
+      (resolve: () => void, reject: (reason: unknown) => void) => {
+        middleware(req, {} as ExpressResponse, (err?: unknown): void => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve();
+        });
+      },
+    );
+  };
+
+  test("urlencoded: parses the body AND captures one raw copy on both fields", async () => {
+    const body: string = "a=1&b=2&name=Gr%C3%BC%C3%9Fe";
+    const req: OneUptimeRequest = createStreamRequest(
+      body,
+      "application/x-www-form-urlencoded",
+    );
+    const middleware: RequestHandler = ExpressUrlEncoded(
+      urlEncodedBodyParserOptions,
+    ) as RequestHandler;
+
+    await runMiddleware(middleware, req);
+
+    expect(req.body).toEqual({ a: "1", b: "2", name: "Grüße" });
+    expect(req.rawBody).toBe(body);
+    expect(req.rawFormUrlEncodedBody).toBe(body);
+    expect(debugSpy.mock.calls).toHaveLength(1);
+    expect(debugSpy.mock.calls[0]![0]).toBe(URL_ENCODED_DEBUG_MESSAGE);
+  });
+
+  test("json: parses the body AND captures the raw copy on rawBody", async () => {
+    const body: string = '{"a":1,"city":"東京"}';
+    const req: OneUptimeRequest = createStreamRequest(body, "application/json");
+    const middleware: RequestHandler = ExpressJson(
+      jsonBodyParserOptions,
+    ) as RequestHandler;
+
+    await runMiddleware(middleware, req);
+
+    expect(req.body).toEqual({ a: 1, city: "東京" });
+    expect(req.rawBody).toBe(body);
+    expect(req.rawFormUrlEncodedBody).toBeUndefined();
+    expect(debugSpy.mock.calls).toHaveLength(1);
+    expect(debugSpy.mock.calls[0]![0]).toBe(JSON_DEBUG_MESSAGE);
+  });
+});
+
+/*
+ * Read rather than executed, following VendorAssets.test.ts: what matters is
+ * only that StartServer builds its middlewares from these exact exported
+ * option objects, so the behavioral tests above are testing what production
+ * actually runs.
+ */
+describe("StartServer wires the exported options into its middlewares", () => {
+  const startServerSource: string = fs.readFileSync(
+    path.resolve(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "Server",
+      "Utils",
+      "StartServer.ts",
+    ),
+    "utf8",
+  );
+
+  test("json middleware is built from jsonBodyParserOptions", () => {
+    expect(startServerSource).toMatch(
+      /ExpressJson\(\s*jsonBodyParserOptions,?\s*\)/,
+    );
+  });
+
+  test("urlencoded middleware is built from urlEncodedBodyParserOptions", () => {
+    expect(startServerSource).toMatch(
+      /ExpressUrlEncoded\(\s*urlEncodedBodyParserOptions,?\s*\)/,
+    );
+  });
+
+  /*
+   * Large probe payloads depend on the 50mb limit; the express default is
+   * 100kb, so a transcription slip in these exported objects would reject
+   * real traffic while every tiny-body test here still passes.
+   */
+  test("both option objects keep the 50mb limit and extended parsing", () => {
+    for (const options of [
+      jsonBodyParserOptions,
+      urlEncodedBodyParserOptions,
+    ]) {
+      expect(options.limit).toBe("50mb");
+      expect(options.extended).toBe(true);
+      expect(typeof options.verify).toBe("function");
+    }
+  });
+});

--- a/Common/Tests/Types/Database/AccessControl/ColumnAccessControlCache.test.ts
+++ b/Common/Tests/Types/Database/AccessControl/ColumnAccessControlCache.test.ts
@@ -1,0 +1,344 @@
+import DatabaseBaseModel from "../../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import Incident from "../../../../Models/DatabaseModels/Incident";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import Project from "../../../../Models/DatabaseModels/Project";
+import StatusPage from "../../../../Models/DatabaseModels/StatusPage";
+import { ColumnAccessControl } from "../../../../Types/BaseDatabase/AccessControl";
+import ColumnBillingAccessControl from "../../../../Types/BaseDatabase/ColumnBillingAccessControl";
+import { getColumnAccessControlForAllColumns } from "../../../../Types/Database/AccessControl/ColumnAccessControl";
+import { getColumnBillingAccessControlForAllColumns } from "../../../../Types/Database/AccessControl/ColumnBillingAccessControl";
+import Dictionary from "../../../../Types/Dictionary";
+import "reflect-metadata";
+
+type ModelCtor = new () => DatabaseBaseModel;
+
+const MODELS: Array<[string, ModelCtor]> = [
+  ["Monitor", Monitor],
+  ["Incident", Incident],
+  ["Project", Project],
+];
+
+// Monitor and Incident have no billing-decorated columns; StatusPage does.
+const BILLING_MODELS: Array<[string, ModelCtor]> = [["StatusPage", StatusPage]];
+
+const DEFAULT_COLUMNS: Array<string> = [
+  "_id",
+  "createdAt",
+  "deletedAt",
+  "updatedAt",
+];
+
+/*
+ * Locate the module-private metadata symbol (e.g. Symbol(ColumnAccessControl))
+ * by scanning the metadata keys of every instance property, so the tests can
+ * rebuild the dictionary from scratch exactly the way the pre-cache
+ * implementation did — without importing any private state.
+ */
+function findMetadataSymbol(
+  model: DatabaseBaseModel,
+  symbolName: string,
+): symbol | null {
+  for (const key of Object.keys(model)) {
+    const metadataKeys: Array<unknown> = Reflect.getMetadataKeys(
+      model,
+      key,
+    ) as Array<unknown>;
+    for (const metadataKey of metadataKeys) {
+      if (
+        typeof metadataKey === "symbol" &&
+        metadataKey.toString() === `Symbol(${symbolName})`
+      ) {
+        return metadataKey;
+      }
+    }
+  }
+  return null;
+}
+
+// The exact algorithm both helpers used before caching was introduced.
+function rebuildFromReflect<T>(
+  model: DatabaseBaseModel,
+  symbolName: string,
+): Dictionary<T> {
+  const metadataSymbol: symbol | null = findMetadataSymbol(model, symbolName);
+  const dictionary: Dictionary<T> = {};
+
+  if (!metadataSymbol) {
+    return dictionary;
+  }
+
+  for (const key of Object.keys(model)) {
+    const metadata: T | undefined = Reflect.getMetadata(
+      metadataSymbol,
+      model,
+      key,
+    ) as T | undefined;
+    if (metadata) {
+      dictionary[key] = metadata;
+    }
+  }
+
+  return dictionary;
+}
+
+function rebuildAccessControl(
+  model: DatabaseBaseModel,
+): Dictionary<ColumnAccessControl> {
+  return rebuildFromReflect<ColumnAccessControl>(model, "ColumnAccessControl");
+}
+
+function rebuildBillingAccessControl(
+  model: DatabaseBaseModel,
+): Dictionary<ColumnBillingAccessControl> {
+  return rebuildFromReflect<ColumnBillingAccessControl>(
+    model,
+    "ColumnBillingAccessControl",
+  );
+}
+
+describe("getColumnAccessControlForAllColumns helper caching", () => {
+  for (const [name, ModelClass] of MODELS) {
+    test(`matches a from-scratch Reflect rebuild for ${name} — keys, order, and value identity`, () => {
+      const model: DatabaseBaseModel = new ModelClass();
+      const expected: Dictionary<ColumnAccessControl> =
+        rebuildAccessControl(model);
+      const actual: Dictionary<ColumnAccessControl> =
+        getColumnAccessControlForAllColumns(model);
+
+      // Sanity: real models have plenty of decorated columns.
+      expect(Object.keys(expected).length).toBeGreaterThan(5);
+
+      expect(Object.keys(actual)).toEqual(Object.keys(expected));
+      for (const key of Object.keys(expected)) {
+        expect(actual[key]).toBe(expected[key]);
+      }
+    });
+  }
+
+  test("repeated calls return the same dictionary object", () => {
+    const monitor: Monitor = new Monitor();
+    const first: Dictionary<ColumnAccessControl> =
+      getColumnAccessControlForAllColumns(monitor);
+    const second: Dictionary<ColumnAccessControl> =
+      getColumnAccessControlForAllColumns(monitor);
+
+    expect(second).toBe(first);
+  });
+
+  test("different instances of the same class share the cached dictionary", () => {
+    const first: Dictionary<ColumnAccessControl> =
+      getColumnAccessControlForAllColumns(new Monitor());
+    const second: Dictionary<ColumnAccessControl> =
+      getColumnAccessControlForAllColumns(new Monitor());
+
+    expect(second).toBe(first);
+  });
+
+  test("second call performs zero Reflect metadata reads", () => {
+    const incident: Incident = new Incident();
+    getColumnAccessControlForAllColumns(incident); // warm the cache
+
+    const spy: jest.SpyInstance = jest.spyOn(Reflect, "getMetadata");
+    try {
+      getColumnAccessControlForAllColumns(incident);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("different classes get distinct dictionaries", () => {
+    const monitorAccessControl: Dictionary<ColumnAccessControl> =
+      getColumnAccessControlForAllColumns(new Monitor());
+    const incidentAccessControl: Dictionary<ColumnAccessControl> =
+      getColumnAccessControlForAllColumns(new Incident());
+    const projectAccessControl: Dictionary<ColumnAccessControl> =
+      getColumnAccessControlForAllColumns(new Project());
+
+    expect(monitorAccessControl).not.toBe(incidentAccessControl);
+    expect(monitorAccessControl).not.toBe(projectAccessControl);
+    expect(incidentAccessControl).not.toBe(projectAccessControl);
+
+    expect(monitorAccessControl["monitorType"]).toBeDefined();
+    expect(incidentAccessControl["monitorType"]).toBeUndefined();
+  });
+});
+
+describe("DatabaseBaseModel.getColumnAccessControlForAllColumns override", () => {
+  test("adds default columns with record-level permissions, exactly as before", () => {
+    const monitor: Monitor = new Monitor();
+    const raw: Dictionary<ColumnAccessControl> = rebuildAccessControl(monitor);
+    const merged: Dictionary<ColumnAccessControl> =
+      monitor.getColumnAccessControlForAllColumns();
+
+    for (const key of DEFAULT_COLUMNS) {
+      expect(merged[key]).toEqual({
+        read: monitor.readRecordPermissions,
+        create: monitor.createRecordPermissions,
+        update: monitor.updateRecordPermissions,
+      });
+    }
+
+    // Decorated columns flow through as the exact same Reflect singletons.
+    for (const key of Object.keys(raw)) {
+      if (!DEFAULT_COLUMNS.includes(key)) {
+        expect(merged[key]).toBe(raw[key]);
+      }
+    }
+
+    expect(Object.keys(merged).sort()).toEqual(
+      [...Object.keys(raw), ...DEFAULT_COLUMNS].sort(),
+    );
+  });
+
+  test("never pollutes the raw helper dictionary with default columns", () => {
+    const monitor: Monitor = new Monitor();
+
+    const rawKeysBefore: Array<string> = Object.keys(
+      getColumnAccessControlForAllColumns(monitor),
+    );
+    for (const key of DEFAULT_COLUMNS) {
+      expect(rawKeysBefore).not.toContain(key);
+    }
+
+    monitor.getColumnAccessControlForAllColumns();
+    monitor.getColumnAccessControlForAllColumns();
+
+    /*
+     * AuditLogService.getRedactedFields consumes the raw helper result and
+     * must never see the record-level defaults the model override adds.
+     */
+    const rawAfter: Dictionary<ColumnAccessControl> =
+      getColumnAccessControlForAllColumns(new Monitor());
+    expect(Object.keys(rawAfter)).toEqual(rawKeysBefore);
+    for (const key of DEFAULT_COLUMNS) {
+      expect(rawAfter[key]).toBeUndefined();
+    }
+  });
+
+  test("mutating one override result does not affect the next call", () => {
+    const monitor: Monitor = new Monitor();
+
+    const first: Dictionary<ColumnAccessControl> =
+      monitor.getColumnAccessControlForAllColumns();
+    const originalName: ColumnAccessControl = first[
+      "name"
+    ] as ColumnAccessControl;
+    expect(originalName).toBeDefined();
+
+    delete first["name"];
+    first["_id"] = { read: [], create: [], update: [] };
+    first["injected"] = { read: [], create: [], update: [] };
+
+    const second: Dictionary<ColumnAccessControl> =
+      monitor.getColumnAccessControlForAllColumns();
+
+    expect(second).not.toBe(first);
+    expect(second["name"]).toBe(originalName);
+    expect(second["injected"]).toBeUndefined();
+    expect(second["_id"]).toEqual({
+      read: monitor.readRecordPermissions,
+      create: monitor.createRecordPermissions,
+      update: monitor.updateRecordPermissions,
+    });
+  });
+
+  test("getColumnAccessControlFor still resolves decorated, default, and unknown columns", () => {
+    const monitor: Monitor = new Monitor();
+    const raw: Dictionary<ColumnAccessControl> = rebuildAccessControl(monitor);
+
+    expect(monitor.getColumnAccessControlFor("name")).toBe(raw["name"]);
+    expect(monitor.getColumnAccessControlFor("_id")).toEqual({
+      read: monitor.readRecordPermissions,
+      create: monitor.createRecordPermissions,
+      update: monitor.updateRecordPermissions,
+    });
+    expect(monitor.getColumnAccessControlFor("doesNotExist")).toBeNull();
+  });
+});
+
+describe("getColumnBillingAccessControlForAllColumns helper caching", () => {
+  for (const [name, ModelClass] of [...MODELS, ...BILLING_MODELS]) {
+    test(`matches a from-scratch Reflect rebuild for ${name} — keys, order, and value identity`, () => {
+      const model: DatabaseBaseModel = new ModelClass();
+      const expected: Dictionary<ColumnBillingAccessControl> =
+        rebuildBillingAccessControl(model);
+      const actual: Dictionary<ColumnBillingAccessControl> =
+        getColumnBillingAccessControlForAllColumns(model);
+
+      expect(Object.keys(actual)).toEqual(Object.keys(expected));
+      for (const key of Object.keys(expected)) {
+        expect(actual[key]).toBe(expected[key]);
+      }
+    });
+  }
+
+  test("Project and StatusPage carry billing-decorated columns; Monitor's dictionary is empty", () => {
+    expect(
+      Object.keys(getColumnBillingAccessControlForAllColumns(new Project()))
+        .length,
+    ).toBeGreaterThan(0);
+    expect(
+      Object.keys(getColumnBillingAccessControlForAllColumns(new StatusPage()))
+        .length,
+    ).toBeGreaterThan(0);
+    expect(getColumnBillingAccessControlForAllColumns(new Monitor())).toEqual(
+      {},
+    );
+  });
+
+  test("repeated calls return the same dictionary object", () => {
+    const project: Project = new Project();
+    const first: Dictionary<ColumnBillingAccessControl> =
+      getColumnBillingAccessControlForAllColumns(project);
+    const second: Dictionary<ColumnBillingAccessControl> =
+      getColumnBillingAccessControlForAllColumns(new Project());
+
+    expect(second).toBe(first);
+  });
+
+  test("second call performs zero Reflect metadata reads", () => {
+    const project: Project = new Project();
+    getColumnBillingAccessControlForAllColumns(project); // warm the cache
+
+    const spy: jest.SpyInstance = jest.spyOn(Reflect, "getMetadata");
+    try {
+      getColumnBillingAccessControlForAllColumns(project);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("different classes get distinct dictionaries", () => {
+    const statusPageBilling: Dictionary<ColumnBillingAccessControl> =
+      getColumnBillingAccessControlForAllColumns(new StatusPage());
+    const projectBilling: Dictionary<ColumnBillingAccessControl> =
+      getColumnBillingAccessControlForAllColumns(new Project());
+
+    expect(statusPageBilling).not.toBe(projectBilling);
+    expect(Object.keys(statusPageBilling)).not.toEqual(
+      Object.keys(projectBilling),
+    );
+  });
+
+  test("model getColumnBillingAccessControl reads without mutating the cached dictionary", () => {
+    const project: Project = new Project();
+    const expected: Dictionary<ColumnBillingAccessControl> =
+      rebuildBillingAccessControl(project);
+    const keysBefore: Array<string> = Object.keys(
+      getColumnBillingAccessControlForAllColumns(project),
+    );
+
+    for (const key of keysBefore) {
+      expect(project.getColumnBillingAccessControl(key)).toBe(expected[key]);
+    }
+    expect(project.getColumnBillingAccessControl("doesNotExist")).toBe(
+      undefined,
+    );
+
+    expect(
+      Object.keys(getColumnBillingAccessControlForAllColumns(new Project())),
+    ).toEqual(keysBefore);
+  });
+});

--- a/Common/Tests/Types/Database/TableColumnMetadataCache.test.ts
+++ b/Common/Tests/Types/Database/TableColumnMetadataCache.test.ts
@@ -1,0 +1,286 @@
+import DatabaseBaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import Incident from "../../../Models/DatabaseModels/Incident";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import Project from "../../../Models/DatabaseModels/Project";
+import {
+  TableColumnMetadata,
+  getTableColumn,
+  getTableColumns,
+} from "../../../Types/Database/TableColumn";
+import TableColumnType from "../../../Types/Database/TableColumnType";
+import Dictionary from "../../../Types/Dictionary";
+import "reflect-metadata";
+
+type ModelCtor = new () => DatabaseBaseModel;
+
+const MODELS: Array<[string, ModelCtor]> = [
+  ["Monitor", Monitor],
+  ["Incident", Incident],
+  ["Project", Project],
+];
+
+/*
+ * Locate the module-private metadata symbol (e.g. Symbol(TableColumn)) by
+ * scanning the metadata keys of every instance property, so the tests can
+ * rebuild the dictionary from scratch exactly the way the pre-cache
+ * implementation did — without importing any private state.
+ */
+function findMetadataSymbol(
+  model: DatabaseBaseModel,
+  symbolName: string,
+): symbol | null {
+  for (const key of Object.keys(model)) {
+    const metadataKeys: Array<unknown> = Reflect.getMetadataKeys(
+      model,
+      key,
+    ) as Array<unknown>;
+    for (const metadataKey of metadataKeys) {
+      if (
+        typeof metadataKey === "symbol" &&
+        metadataKey.toString() === `Symbol(${symbolName})`
+      ) {
+        return metadataKey;
+      }
+    }
+  }
+  return null;
+}
+
+// The exact algorithm getTableColumns() used before caching was introduced.
+function rebuildFromReflect<T>(
+  model: DatabaseBaseModel,
+  symbolName: string,
+): Dictionary<T> {
+  const metadataSymbol: symbol | null = findMetadataSymbol(model, symbolName);
+  const dictionary: Dictionary<T> = {};
+
+  if (!metadataSymbol) {
+    return dictionary;
+  }
+
+  for (const key of Object.keys(model)) {
+    const metadata: T | undefined = Reflect.getMetadata(
+      metadataSymbol,
+      model,
+      key,
+    ) as T | undefined;
+    if (metadata) {
+      dictionary[key] = metadata;
+    }
+  }
+
+  return dictionary;
+}
+
+function rebuildTableColumns(
+  model: DatabaseBaseModel,
+): Dictionary<TableColumnMetadata> {
+  return rebuildFromReflect<TableColumnMetadata>(model, "TableColumn");
+}
+
+describe("getTableColumns caching", () => {
+  for (const [name, ModelClass] of MODELS) {
+    test(`matches a from-scratch Reflect rebuild for ${name} — keys, order, and value identity`, () => {
+      const model: DatabaseBaseModel = new ModelClass();
+      const expected: Dictionary<TableColumnMetadata> =
+        rebuildTableColumns(model);
+      const actual: Dictionary<TableColumnMetadata> = getTableColumns(model);
+
+      // Sanity: real models have plenty of decorated columns.
+      expect(Object.keys(expected).length).toBeGreaterThan(5);
+
+      // Same keys in the same insertion order.
+      expect(Object.keys(actual)).toEqual(Object.keys(expected));
+
+      // Values are the exact same Reflect metadata singletons as before.
+      for (const key of Object.keys(expected)) {
+        expect(actual[key]).toBe(expected[key]);
+      }
+    });
+  }
+
+  test("second call for the same class performs zero Reflect metadata reads", () => {
+    const monitor: Monitor = new Monitor();
+    const expected: Dictionary<TableColumnMetadata> =
+      rebuildTableColumns(monitor);
+
+    getTableColumns(monitor); // warm the cache
+
+    const spy: jest.SpyInstance = jest.spyOn(Reflect, "getMetadata");
+    try {
+      const result: Dictionary<TableColumnMetadata> = getTableColumns(monitor);
+      expect(spy).not.toHaveBeenCalled();
+      expect(Object.keys(result)).toEqual(Object.keys(expected));
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("cache is shared across different instances of the same class", () => {
+    getTableColumns(new Monitor()); // warm the cache with one instance
+
+    const spy: jest.SpyInstance = jest.spyOn(Reflect, "getMetadata");
+    try {
+      const result: Dictionary<TableColumnMetadata> = getTableColumns(
+        new Monitor(),
+      );
+      expect(spy).not.toHaveBeenCalled();
+      expect(result["name"]).toBeDefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("different classes get distinct dictionaries", () => {
+    const monitorColumns: Dictionary<TableColumnMetadata> = getTableColumns(
+      new Monitor(),
+    );
+    const incidentColumns: Dictionary<TableColumnMetadata> = getTableColumns(
+      new Incident(),
+    );
+    const projectColumns: Dictionary<TableColumnMetadata> = getTableColumns(
+      new Project(),
+    );
+
+    expect(monitorColumns).not.toBe(incidentColumns);
+    expect(monitorColumns).not.toBe(projectColumns);
+    expect(incidentColumns).not.toBe(projectColumns);
+
+    expect(Object.keys(monitorColumns)).not.toEqual(
+      Object.keys(incidentColumns),
+    );
+    expect(monitorColumns["monitorType"]).toBeDefined();
+    expect(incidentColumns["monitorType"]).toBeUndefined();
+    expect(projectColumns["monitorType"]).toBeUndefined();
+  });
+
+  test("mutations by one caller never leak into later calls (API reference deletes entries)", () => {
+    const expected: Dictionary<TableColumnMetadata> = rebuildTableColumns(
+      new Monitor(),
+    );
+
+    const first: Dictionary<TableColumnMetadata> = getTableColumns(
+      new Monitor(),
+    );
+
+    // The API reference docs page strips columns exactly like this.
+    delete first["deletedAt"];
+    delete first["version"];
+    delete first["name"];
+    first["monitorType"] = { type: TableColumnType.Phone };
+
+    const second: Dictionary<TableColumnMetadata> = getTableColumns(
+      new Monitor(),
+    );
+
+    expect(second).not.toBe(first);
+    expect(Object.keys(second)).toEqual(Object.keys(expected));
+    expect(second["deletedAt"]).toBe(expected["deletedAt"]);
+    expect(second["version"]).toBe(expected["version"]);
+    expect(second["name"]).toBe(expected["name"]);
+    expect(second["monitorType"]).toBe(expected["monitorType"]);
+    expect(second["monitorType"]!.type).not.toBe(TableColumnType.Phone);
+  });
+
+  test("Columns wrapper on the model still lists every decorated column", () => {
+    for (const [, ModelClass] of MODELS) {
+      const model: DatabaseBaseModel = new ModelClass();
+      const expected: Dictionary<TableColumnMetadata> =
+        rebuildTableColumns(model);
+      expect(model.getTableColumns().columns).toEqual(Object.keys(expected));
+    }
+  });
+
+  test("filter helpers derive from identical metadata after caching", () => {
+    for (const [, ModelClass] of MODELS) {
+      const model: DatabaseBaseModel = new ModelClass();
+      const expected: Dictionary<TableColumnMetadata> =
+        rebuildTableColumns(model);
+
+      const expectedFor: (
+        predicate: (metadata: TableColumnMetadata) => boolean,
+      ) => Array<string> = (
+        predicate: (metadata: TableColumnMetadata) => boolean,
+      ): Array<string> => {
+        return Object.keys(expected).filter((key: string) => {
+          return predicate(expected[key] as TableColumnMetadata);
+        });
+      };
+
+      expect(model.getRequiredColumns().columns).toEqual(
+        expectedFor((metadata: TableColumnMetadata) => {
+          return Boolean(metadata.required);
+        }),
+      );
+      expect(model.getUniqueColumns().columns).toEqual(
+        expectedFor((metadata: TableColumnMetadata) => {
+          return Boolean(metadata.unique);
+        }),
+      );
+      expect(model.getHashedColumns().columns).toEqual(
+        expectedFor((metadata: TableColumnMetadata) => {
+          return Boolean(metadata.hashed);
+        }),
+      );
+      expect(model.getEncryptedColumns().columns).toEqual(
+        expectedFor((metadata: TableColumnMetadata) => {
+          return Boolean(metadata.encrypted);
+        }),
+      );
+    }
+  });
+});
+
+describe("getTableColumnMetadata", () => {
+  for (const [name, ModelClass] of MODELS) {
+    test(`returns the exact rebuild value for every instance key of ${name}`, () => {
+      const model: DatabaseBaseModel = new ModelClass();
+      const expected: Dictionary<TableColumnMetadata> =
+        rebuildTableColumns(model);
+
+      for (const key of Object.keys(model)) {
+        const expectedValue: TableColumnMetadata | undefined = expected[key];
+        const actualValue: TableColumnMetadata =
+          model.getTableColumnMetadata(key);
+
+        if (expectedValue) {
+          expect(actualValue).toBe(expectedValue);
+        } else {
+          // Undecorated instance keys (e.g. isPermissionIf) stay undefined.
+          expect(actualValue).toBeUndefined();
+        }
+      }
+    });
+  }
+
+  test("returns undefined for unknown keys", () => {
+    const monitor: Monitor = new Monitor();
+    expect(monitor.getTableColumnMetadata("doesNotExist")).toBeUndefined();
+    expect(monitor.getTableColumnMetadata("")).toBeUndefined();
+    expect(monitor.getTableColumnMetadata("constructor")).toBeUndefined();
+    expect(monitor.getTableColumnMetadata("isPermissionIf")).toBeUndefined();
+  });
+
+  test("agrees with the standalone single-column reader", () => {
+    const monitor: Monitor = new Monitor();
+    for (const key of Object.keys(monitor)) {
+      expect(monitor.getTableColumnMetadata(key)).toBe(
+        getTableColumn(monitor, key),
+      );
+    }
+  });
+
+  test("reads a single metadata entry instead of rebuilding the whole dictionary", () => {
+    const monitor: Monitor = new Monitor();
+
+    const spy: jest.SpyInstance = jest.spyOn(Reflect, "getMetadata");
+    try {
+      const metadata: TableColumnMetadata =
+        monitor.getTableColumnMetadata("name");
+      expect(metadata).toBeDefined();
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/Common/Types/Database/AccessControl/ColumnAccessControl.ts
+++ b/Common/Types/Database/AccessControl/ColumnAccessControl.ts
@@ -30,20 +30,42 @@ type GetColumnAccessControlForAllColumnsFunction = <T extends BaseModel>(
   target: T,
 ) => Dictionary<ColumnAccessControl>;
 
+/*
+ * Per-class cache. Safe to key on the constructor because every decorated
+ * column is initialised to `undefined` in the class body, so Object.keys()
+ * is identical for every instance of a class (see OwnerOnlyColumn.ts).
+ * Callers must treat the returned dictionary as read-only.
+ */
+const accessControlCache: WeakMap<
+  { new (): BaseModel },
+  Dictionary<ColumnAccessControl>
+> = new WeakMap();
+
 export const getColumnAccessControlForAllColumns: GetColumnAccessControlForAllColumnsFunction =
   <T extends BaseModel>(target: T): Dictionary<ColumnAccessControl> => {
-    const dictonary: Dictionary<ColumnAccessControl> = {};
-    const keys: Array<string> = Object.keys(target);
+    const modelClass: { new (): BaseModel } = target.constructor as {
+      new (): BaseModel;
+    };
+    let cached: Dictionary<ColumnAccessControl> | undefined =
+      accessControlCache.get(modelClass);
 
-    for (const key of keys) {
-      if (Reflect.getMetadata(accessControlSymbol, target, key)) {
-        dictonary[key] = Reflect.getMetadata(
-          accessControlSymbol,
-          target,
-          key,
-        ) as ColumnAccessControl;
+    if (!cached) {
+      const dictonary: Dictionary<ColumnAccessControl> = {};
+      const keys: Array<string> = Object.keys(target);
+
+      for (const key of keys) {
+        const accessControl: ColumnAccessControl | undefined =
+          Reflect.getMetadata(accessControlSymbol, target, key) as
+            | ColumnAccessControl
+            | undefined;
+        if (accessControl) {
+          dictonary[key] = accessControl;
+        }
       }
+
+      cached = dictonary;
+      accessControlCache.set(modelClass, cached);
     }
 
-    return dictonary;
+    return cached;
   };

--- a/Common/Types/Database/AccessControl/ColumnBillingAccessControl.ts
+++ b/Common/Types/Database/AccessControl/ColumnBillingAccessControl.ts
@@ -30,20 +30,42 @@ type GetColumnBillingAccessControlForAllColumnsFunction = <T extends BaseModel>(
   target: T,
 ) => Dictionary<ColumnBillingAccessControl>;
 
+/*
+ * Per-class cache. Safe to key on the constructor because every decorated
+ * column is initialised to `undefined` in the class body, so Object.keys()
+ * is identical for every instance of a class (see OwnerOnlyColumn.ts).
+ * Callers must treat the returned dictionary as read-only.
+ */
+const billingAccessControlCache: WeakMap<
+  { new (): BaseModel },
+  Dictionary<ColumnBillingAccessControl>
+> = new WeakMap();
+
 export const getColumnBillingAccessControlForAllColumns: GetColumnBillingAccessControlForAllColumnsFunction =
   <T extends BaseModel>(target: T): Dictionary<ColumnBillingAccessControl> => {
-    const dictonary: Dictionary<ColumnBillingAccessControl> = {};
-    const keys: Array<string> = Object.keys(target);
+    const modelClass: { new (): BaseModel } = target.constructor as {
+      new (): BaseModel;
+    };
+    let cached: Dictionary<ColumnBillingAccessControl> | undefined =
+      billingAccessControlCache.get(modelClass);
 
-    for (const key of keys) {
-      if (Reflect.getMetadata(accessControlSymbol, target, key)) {
-        dictonary[key] = Reflect.getMetadata(
-          accessControlSymbol,
-          target,
-          key,
-        ) as ColumnBillingAccessControl;
+    if (!cached) {
+      const dictonary: Dictionary<ColumnBillingAccessControl> = {};
+      const keys: Array<string> = Object.keys(target);
+
+      for (const key of keys) {
+        const accessControl: ColumnBillingAccessControl | undefined =
+          Reflect.getMetadata(accessControlSymbol, target, key) as
+            | ColumnBillingAccessControl
+            | undefined;
+        if (accessControl) {
+          dictonary[key] = accessControl;
+        }
       }
+
+      cached = dictonary;
+      billingAccessControlCache.set(modelClass, cached);
     }
 
-    return dictonary;
+    return cached;
   };

--- a/Common/Types/Database/TableColumn.ts
+++ b/Common/Types/Database/TableColumn.ts
@@ -63,21 +63,48 @@ type GetTableColumnsFunction = <T extends BaseModel>(
   target: T,
 ) => Dictionary<TableColumnMetadata>;
 
+/*
+ * Per-class cache. Safe to key on the constructor because every decorated
+ * column is initialised to `undefined` in the class body, so Object.keys()
+ * is identical for every instance of a class (see OwnerOnlyColumn.ts).
+ */
+const tableColumnsCache: WeakMap<
+  { new (): BaseModel },
+  Dictionary<TableColumnMetadata>
+> = new WeakMap();
+
 export const getTableColumns: GetTableColumnsFunction = <T extends BaseModel>(
   target: T,
 ): Dictionary<TableColumnMetadata> => {
-  const dictonary: Dictionary<TableColumnMetadata> = {};
-  const keys: Array<string> = Object.keys(target);
+  const modelClass: { new (): BaseModel } = target.constructor as {
+    new (): BaseModel;
+  };
+  let cached: Dictionary<TableColumnMetadata> | undefined =
+    tableColumnsCache.get(modelClass);
 
-  for (const key of keys) {
-    if (Reflect.getMetadata(tableColumn, target, key)) {
-      dictonary[key] = Reflect.getMetadata(
+  if (!cached) {
+    const dictonary: Dictionary<TableColumnMetadata> = {};
+    const keys: Array<string> = Object.keys(target);
+
+    for (const key of keys) {
+      const metadata: TableColumnMetadata | undefined = Reflect.getMetadata(
         tableColumn,
         target,
         key,
-      ) as TableColumnMetadata;
+      ) as TableColumnMetadata | undefined;
+      if (metadata) {
+        dictonary[key] = metadata;
+      }
     }
+
+    cached = dictonary;
+    tableColumnsCache.set(modelClass, cached);
   }
 
-  return dictonary;
+  /*
+   * Hand out a copy, not the cached dictionary itself: callers mutate the
+   * result (the API reference docs delete entries from it), which would
+   * otherwise strip columns from every later call for the same class.
+   */
+  return { ...cached };
 };


### PR DESCRIPTION
## Motivation

Cloud bills are driven by steady-state CPU and memory burn. A multi-agent audit of the server-side hot paths (shared DB layer, per-minute worker crons, HTTP middleware, probe ingest) surfaced 28 candidate inefficiencies; each was adversarially verified against the current code for existence, hotness, and behavior-preservation before implementation. This PR ships the seven that survived — all localized, low-risk fixes on genuinely hot paths.

## Changes

### 1. Memoize Reflect-metadata dictionaries (largest win)
`getTableColumns()`, `getColumnAccessControlForAllColumns()`, and `getColumnBillingAccessControlForAllColumns()` rebuilt their full metadata dictionaries from `reflect-metadata` on **every call**, invoking `Reflect.getMetadata` twice per decorated key (models carry 45–125 of them). These walks run under every `DatabaseService` operation across 500+ services: per query key on every find/count/update/delete, O(cols²) per create/update via per-column `getTableColumnMetadata`, per returned row (encrypted-column checks), and per key per row of every API list response (`toJSONObject`).

The dictionaries are static per class, so they are now built once and cached in a module-level `WeakMap` keyed on the constructor. Two aliasing hazards are handled explicitly:
- The API-reference renderer deletes keys from the `getTableColumns` result, so that helper returns a shallow copy of the cached dict (still zero Reflect walks).
- `DatabaseBaseModel.getColumnAccessControlForAllColumns` merges default columns into the helper result, so it spreads into a fresh object first — `AuditLogService.getRedactedFields` consumes the raw helper result and must never see those defaults.

`getTableColumnMetadata` now delegates to the existing O(1) single-key reader instead of rebuilding the whole dictionary to index one entry.

### 2. Gate per-row debug serialization in `DatabaseService._updateBy`
Every matched row of every update built a pretty-printed `JSON.stringify(updatedItem, null, 2)` that `logger.debug` then discarded at the default INFO level. The check is hoisted once above the loop; DEBUG output is byte-identical. (Intentional delta: a payload whose serialization throws now only throws at DEBUG.)

### 3. Drop the duplicate severity query in state-change owner jobs
`AlertOwners/SendStateChangeNotification` and `IncidentOwners/SendStateChangeNotification` fetched the alert/incident, then immediately issued a second `findOneById` on the same id selecting only the severity name. The severity relation is merged into the first select; throw-on-missing-severity semantics preserved via non-null assertions.

### 4. Hoist Markdown→HTML out of per-owner loops
Six EVERY_MINUTE owner-notification jobs re-ran owner-invariant `Markdown.convertToHTML` (marked parser) once per owner. Conversions now happen once per resource/timeline row (`MonitorOwners` rootCause stays per-timeline), mirroring the fix already merged for Announcement subscribers. In the two created-resource jobs a conversion failure is contained per resource (log + continue) to preserve the isolation the per-user try/catch previously provided.

### 5. Remove dead full-payload deserialize on probe ingest
`/probe/response/ingest` ran `JSONFunctions.deserialize` over the entire probe payload (response bodies, screenshots — can be hundreds of KB per check) and used the result only for a truthiness guard that could never fire (`deserialize(undefined)` returns `{}`, which is truthy — the pitfall is documented in `ProcessProbeIngest`). The raw body is what gets queued and the worker deserializes it anyway. Replaced with a raw presence check on both ingest routes; the dead `!testId` guard on the test-ingest route now checks the raw param so it can actually fire. Intentional delta: a missing payload now returns 400 instead of 200 + a doomed queue job.

### 6. Batch grouping-rule lookups in `ResolveInactiveEpisodes` (alert + incident)
Both five-minute jobs fetched up to 1000 unresolved episodes and issued one `findOneById` per episode inside an unbounded `Promise.allSettled` fan-out — up to ~2000 concurrent point SELECTs per tick for a handful of distinct rules. They now collect distinct rule ids and issue one batched `findBy`, copying the `fetchGroupingRules` pattern already merged in the sibling `AutoResolve` jobs. A missing rule behaves exactly like the old null result.

### 7. Single decode + constant debug message in the urlencoded verify
The body-parser verify callback called `buf.toString()` twice (two full-body copies) and eagerly built a debug string embedding the entire raw body even at INFO level. Now one decode is aliased to both `rawBody` and `rawFormUrlEncodedBody` (consumers only do read-only signature comparison) and the debug message is constant — mirroring the fix already applied to the JSON parser directly above, and keeping raw signing material (Slack/SAML payloads) out of DEBUG logs.

## Tests

13 new suites, 115 tests, all passing (`Common`: 4 suites / 53 tests, `App`: 9 suites / 62 tests). They pin both directions:
- **The optimization itself** — assertions that fail on the old code: zero `Reflect.getMetadata` reads after cache warm-up, cache-pollution regression tests replaying the API-docs delete pattern, debug-never-built at INFO (circular payload completes), exactly one `findOneById` per state-change row, one markdown conversion per row across owners, `deserialize` never called on the ingest happy path, one batched rule query with deduplicated bound ids / LIMIT_MAX / select shape, single `Buffer.toString` aliased to both raw-body fields.
- **Preserved behavior** — byte-identical vars/email/SMS/push payloads across the old and new flows, DEBUG output unchanged, severity throw-on-missing semantics, inactivity-timeout boundary cases, missing-rule and zero-episode paths, UTF-8 body round-trips through the real express parsers, and the blessed deltas (probe 400, DEBUG-only serialization throw) asserted explicitly.

`npm run fix` clean; `tsc` in `Common` and `App` shows zero errors in changed files (the remaining errors — PasswordHash TS5.9, SSO/MqttServer/DataSource connectors — are pre-existing on master and untouched here; the 9 pre-existing worker suites that compile-fail on the PasswordHash error fail identically on an unmodified tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHktFYvPfKj5E1t3z2bpz1