### PR TITLE
fix(dashboard): make the monitor type picker searchable

### DIFF
--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Create.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Create.tsx
@@ -666,6 +666,10 @@ const MonitorCreate: FunctionComponent<
                   required: true,
                   cardSelectOptions:
                     MonitorTypeUtil.monitorTypesAsCategorizedCardSelectOptions(),
+                  cardSelectSearchable: true,
+                  cardSelectSearchPlaceholder:
+                    "Search monitor types - try ping, ssl, k8s, postgres",
+                  cardSelectCollapsibleGroups: true,
                 },
                 /*
                  * Sits directly under the type picker, on the same step, so

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplates.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplates.tsx
@@ -171,6 +171,10 @@ const MonitorTemplates: FunctionComponent<PageComponentProps> = (
             required: true,
             cardSelectOptions:
               MonitorTypeUtil.monitorTypesAsCategorizedCardSelectOptions(),
+            cardSelectSearchable: true,
+            cardSelectSearchPlaceholder:
+              "Search monitor types - try ping, ssl, k8s, postgres",
+            cardSelectCollapsibleGroups: true,
           },
           {
             field: {

--- a/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplatesView.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/Monitor/Settings/MonitorTemplatesView.tsx
@@ -607,6 +607,10 @@ const MonitorTemplatesView: FunctionComponent<
             required: true,
             cardSelectOptions:
               MonitorTypeUtil.monitorTypesAsCategorizedCardSelectOptions(),
+            cardSelectSearchable: true,
+            cardSelectSearchPlaceholder:
+              "Search monitor types - try ping, ssl, k8s, postgres",
+            cardSelectCollapsibleGroups: true,
           },
         ]}
         onSaveSuccess={(item: MonitorTemplate) => {

--- a/App/FeatureSet/Dashboard/src/Utils/MonitorType.ts
+++ b/App/FeatureSet/Dashboard/src/Utils/MonitorType.ts
@@ -32,6 +32,7 @@ export default class MonitorTypeUtil {
         title: props.title,
         description: props.description,
         icon: props.icon,
+        keywords: props.keywords,
       };
     });
   }
@@ -63,6 +64,7 @@ export default class MonitorTypeUtil {
                 title: typeProps.title,
                 description: typeProps.description,
                 icon: typeProps.icon,
+                keywords: typeProps.keywords,
               };
             })
             .filter(

--- a/App/Tests/Dashboard/MonitorTypePickerWiring.test.ts
+++ b/App/Tests/Dashboard/MonitorTypePickerWiring.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+
+/*
+ * The monitor type picker's search box and folded categories are two field
+ * flags on a form definition. They are the kind of one-line call site that a
+ * refactor drops without breaking a type or a render - and the picker would
+ * quietly go back to listing all 29 monitor types at once, which is the
+ * problem the flags exist to fix.
+ *
+ * The behaviour itself is exercised against the real catalog in
+ * Common/Tests/App/Dashboard/MonitorTypePicker.test.tsx. Pinned against source
+ * here rather than imported, for the same reason as PayAsYouGoWiring: react is
+ * a dependency of the Dashboard package, not of App, so importing these pages
+ * would not resolve, and App's jest runs in a node environment with no DOM.
+ */
+
+const DASHBOARD_SRC: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Dashboard",
+  "src",
+);
+
+type ReadFunction = (...segments: Array<string>) => string;
+
+const read: ReadFunction = (...segments: Array<string>): string => {
+  return fs.readFileSync(path.join(DASHBOARD_SRC, ...segments), "utf8");
+};
+
+/*
+ * Every page that offers the full monitor type catalog. All three had the same
+ * wall of cards, so all three get the same treatment.
+ */
+const PAGES_OFFERING_THE_FULL_CATALOG: Array<{
+  name: string;
+  segments: Array<string>;
+}> = [
+  { name: "create monitor", segments: ["Pages", "Monitor", "Create.tsx"] },
+  {
+    name: "monitor templates list",
+    segments: ["Pages", "Monitor", "Settings", "MonitorTemplates.tsx"],
+  },
+  {
+    name: "monitor template view",
+    segments: ["Pages", "Monitor", "Settings", "MonitorTemplatesView.tsx"],
+  },
+];
+
+describe("monitor type picker wiring", () => {
+  describe.each(PAGES_OFFERING_THE_FULL_CATALOG)(
+    "$name page",
+    ({ segments }: { name: string; segments: Array<string> }) => {
+      const source: string = read(...segments);
+
+      test("offers the categorised monitor type catalog", () => {
+        expect(source).toContain(
+          "MonitorTypeUtil.monitorTypesAsCategorizedCardSelectOptions()",
+        );
+      });
+
+      test("gives the picker a search box", () => {
+        expect(source).toContain("cardSelectSearchable: true");
+      });
+
+      test("folds the categories away behind their headings", () => {
+        expect(source).toContain("cardSelectCollapsibleGroups: true");
+      });
+
+      /*
+       * The placeholder is the only thing that tells a user the search knows
+       * words that are not printed on any card.
+       */
+      test("tells the user the search understands their own vocabulary", () => {
+        expect(source).toContain("cardSelectSearchPlaceholder");
+        expect(source).toMatch(/cardSelectSearchPlaceholder:[\s\S]{0,120}k8s/);
+      });
+
+      test("puts the flags on the monitor type field, not some other picker", () => {
+        const optionsIndex: number = source.indexOf(
+          "MonitorTypeUtil.monitorTypesAsCategorizedCardSelectOptions()",
+        );
+        const searchableIndex: number = source.indexOf(
+          "cardSelectSearchable: true",
+        );
+        const collapsibleIndex: number = source.indexOf(
+          "cardSelectCollapsibleGroups: true",
+        );
+
+        expect(optionsIndex).toBeGreaterThan(-1);
+        expect(searchableIndex).toBeGreaterThan(optionsIndex);
+        expect(collapsibleIndex).toBeGreaterThan(optionsIndex);
+        // Same field definition, not a picker further down the file.
+        expect(collapsibleIndex - optionsIndex).toBeLessThan(400);
+      });
+    },
+  );
+
+  describe("the option adapter", () => {
+    const source: string = read("Utils", "MonitorType.ts");
+
+    /*
+     * Without this line every search below the surface - "k8s", "postgres",
+     * "heartbeat" - silently finds nothing, and the picker looks like it is
+     * working.
+     */
+    test("carries keywords from the catalog onto the cards", () => {
+      expect(source).toContain("keywords: typeProps.keywords");
+      expect(source).toContain("keywords: props.keywords");
+    });
+  });
+
+  describe("callers that did not ask for a search box", () => {
+    /*
+     * CardSelect is shared. These two pickers hold a handful of cards each and
+     * read fine as a plain grid; turning search or folding on there would add
+     * chrome for nothing, and the opt-in default is what keeps them as they
+     * were.
+     */
+    test.each([
+      [
+        "team permission table",
+        ["Components", "Team", "TeamPermissionTable.tsx"],
+      ],
+      [
+        "metrics pipeline rules",
+        ["Pages", "Metrics", "Settings", "PipelineRules.tsx"],
+      ],
+    ])("%s stays a plain grid", (_name: string, segments: Array<string>) => {
+      const source: string = read(...segments);
+
+      expect(source).toContain("FormFieldSchemaType.CardSelect");
+      expect(source).not.toContain("cardSelectSearchable");
+      expect(source).not.toContain("cardSelectCollapsibleGroups");
+    });
+  });
+});

--- a/Common/Tests/App/Dashboard/MonitorTypePicker.test.tsx
+++ b/Common/Tests/App/Dashboard/MonitorTypePicker.test.tsx
@@ -1,0 +1,300 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, test } from "@jest/globals";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import MonitorType, {
+  MonitorTypeCategory,
+  MonitorTypeHelper,
+} from "../../../Types/Monitor/MonitorType";
+import CardSelect, {
+  CardSelectOption,
+  CardSelectOptionGroup,
+} from "../../../UI/Components/CardSelect/CardSelect";
+import MonitorTypeUtil from "../../../../App/FeatureSet/Dashboard/src/Utils/MonitorType";
+
+/*
+ * The real catalog, driven through the real picker. The unit tests either side
+ * of this one prove the search ranks correctly and the component renders
+ * correctly; what is pinned here is that the dashboard hands the component the
+ * data it needs to do either - the adapter drops keywords silently, and every
+ * search below still "works" while finding nothing.
+ */
+
+const categorizedOptions: Array<CardSelectOptionGroup> =
+  MonitorTypeUtil.monitorTypesAsCategorizedCardSelectOptions();
+
+type RenderPickerFunction = (value?: string) => MockFunction;
+
+const renderPicker: RenderPickerFunction = (value?: string): MockFunction => {
+  const onChange: MockFunction = getJestMockFunction();
+
+  render(
+    <CardSelect
+      options={categorizedOptions}
+      value={value}
+      onChange={onChange}
+      searchable={true}
+      searchPlaceholder="Search monitor types - try ping, ssl, k8s, postgres"
+      collapsibleGroups={true}
+    />,
+  );
+
+  return onChange;
+};
+
+type SearchFunction = (value: string) => void;
+
+const search: SearchFunction = (value: string): void => {
+  fireEvent.change(screen.getByTestId("card-select-search"), {
+    target: { value: value },
+  });
+};
+
+type ShownTypesFunction = () => Array<string>;
+
+const shownTypes: ShownTypesFunction = (): Array<string> => {
+  return screen.queryAllByRole("radio").map((card: HTMLElement) => {
+    return (card.getAttribute("data-testid") || "").replace(
+      "card-select-option-",
+      "",
+    );
+  });
+};
+
+describe("Monitor type picker", () => {
+  describe("the options the dashboard builds", () => {
+    test("carries the keywords through from the monitor type catalog", () => {
+      for (const group of categorizedOptions) {
+        for (const option of group.options) {
+          expect({
+            monitorType: option.value,
+            hasKeywords: Boolean(option.keywords && option.keywords.length > 0),
+          }).toEqual({ monitorType: option.value, hasKeywords: true });
+        }
+      }
+    });
+
+    test("carries keywords through the flat option list too", () => {
+      const flat: Array<CardSelectOption> =
+        MonitorTypeUtil.monitorTypesAsCardSelectOptions();
+
+      for (const option of flat) {
+        expect(option.keywords).toBeDefined();
+        expect((option.keywords || []).length).toBeGreaterThan(0);
+      }
+    });
+
+    test("offers one group per category, in catalog order", () => {
+      const categories: Array<MonitorTypeCategory> =
+        MonitorTypeHelper.getMonitorTypeCategories();
+
+      expect(
+        categorizedOptions.map((group: CardSelectOptionGroup) => {
+          return group.label;
+        }),
+      ).toEqual(
+        categories.map((category: MonitorTypeCategory) => {
+          return category.label;
+        }),
+      );
+    });
+  });
+
+  describe("what a user sees on opening the form", () => {
+    test("the everyday types are on screen without scrolling past anything", () => {
+      renderPicker();
+
+      expect(screen.getByTestId("card-select-option-Website")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-API")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-Ping")).toBeVisible();
+    });
+
+    /*
+     * The whole point of the change. Every type used to render at once - nine
+     * headings and 29 cards, about six thousand pixels of them.
+     */
+    test("the long tail starts folded away behind its headings", () => {
+      renderPicker();
+
+      expect(
+        screen.queryByTestId("card-select-option-Kubernetes"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("card-select-option-Ceph"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("card-select-option-Traces"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("shows far fewer cards than the catalog holds", () => {
+      renderPicker();
+
+      const total: number = categorizedOptions.reduce(
+        (count: number, group: CardSelectOptionGroup) => {
+          return count + group.options.length;
+        },
+        0,
+      );
+
+      expect(shownTypes().length).toBeLessThan(total / 2);
+    });
+
+    test("every category is still reachable, with a count of what is inside", () => {
+      renderPicker();
+
+      for (const group of categorizedOptions) {
+        const header: HTMLElement = screen.getByTestId(
+          `card-select-group-${group.label}`,
+        );
+
+        expect(header).toBeVisible();
+        expect(header).toHaveTextContent(String(group.options.length));
+      }
+    });
+
+    test("says how many types there are to choose from", () => {
+      renderPicker();
+
+      expect(
+        screen.getByTestId("card-select-search-summary"),
+      ).toHaveTextContent("to choose from");
+    });
+  });
+
+  describe("finding a type by the words a user already knows", () => {
+    test.each([
+      ["k8s", MonitorType.Kubernetes],
+      ["postgres", MonitorType.SQLQuery],
+      ["heartbeat", MonitorType.IncomingRequest],
+      ["tls", MonitorType.SSLCertificate],
+      ["snmp", MonitorType.NetworkDevice],
+      ["icmp", MonitorType.Ping],
+      ["whois", MonitorType.Domain],
+      ["prometheus", MonitorType.Metrics],
+    ])("%s finds %s first", (query: string, expected: MonitorType) => {
+      renderPicker();
+
+      search(query);
+
+      expect(shownTypes()[0]).toBe(expected);
+    });
+
+    test("a search reaches types that are folded away", () => {
+      renderPicker();
+
+      expect(
+        screen.queryByTestId("card-select-option-Kubernetes"),
+      ).not.toBeInTheDocument();
+
+      search("k8s");
+
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+    });
+
+    test("a search for a vendor finds the external status page monitor", () => {
+      renderPicker();
+
+      search("cloudflare");
+
+      expect(shownTypes()).toContain(MonitorType.ExternalStatusPage);
+    });
+
+    test("a category name gathers its types together", () => {
+      renderPicker();
+
+      search("telemetry");
+
+      const shown: Array<string> = shownTypes();
+
+      expect(shown).toContain(MonitorType.Logs);
+      expect(shown).toContain(MonitorType.Metrics);
+      expect(shown).toContain(MonitorType.Traces);
+      expect(shown).not.toContain(MonitorType.Website);
+    });
+
+    test("a word nothing uses says so instead of showing an empty grid", () => {
+      renderPicker();
+
+      search("mainframe");
+
+      expect(screen.getByTestId("card-select-no-results")).toBeVisible();
+      expect(shownTypes()).toEqual([]);
+    });
+
+    test("picking a type from the search results reports the monitor type", () => {
+      const onChange: MockFunction = renderPicker();
+
+      search("k8s");
+      fireEvent.click(screen.getByTestId("card-select-option-Kubernetes"));
+
+      expect(onChange).toHaveBeenCalledWith(MonitorType.Kubernetes);
+    });
+  });
+
+  describe("coming back to a form that already has a type", () => {
+    test("shows the selection rather than hiding it behind a closed heading", () => {
+      renderPicker(MonitorType.Ceph);
+
+      expect(screen.getByTestId("card-select-option-Ceph")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-Ceph")).toHaveAttribute(
+        "aria-checked",
+        "true",
+      );
+    });
+
+    test("leaves the rest folded away", () => {
+      renderPicker(MonitorType.Ceph);
+
+      expect(
+        screen.queryByTestId("card-select-option-Traces"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("browsing without searching", () => {
+    test("opening a category shows every type in it", () => {
+      renderPicker();
+
+      fireEvent.click(screen.getByTestId("card-select-group-Telemetry"));
+
+      expect(screen.getByTestId("card-select-option-Logs")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-Metrics")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-Traces")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-Exceptions")).toBeVisible();
+    });
+
+    test("a type can be picked by browsing, with no typing at all", () => {
+      const onChange: MockFunction = renderPicker();
+
+      fireEvent.click(screen.getByTestId("card-select-group-Infrastructure"));
+      fireEvent.click(screen.getByTestId("card-select-option-Kubernetes"));
+
+      expect(onChange).toHaveBeenCalledWith(MonitorType.Kubernetes);
+    });
+
+    test("every type in the catalog can be reached by opening its category", () => {
+      renderPicker();
+
+      // Only the closed ones - clicking an open heading would fold it away.
+      for (const group of categorizedOptions) {
+        const header: HTMLElement = screen.getByTestId(
+          `card-select-group-${group.label}`,
+        );
+
+        if (header.getAttribute("aria-expanded") === "false") {
+          fireEvent.click(header);
+        }
+      }
+
+      for (const group of categorizedOptions) {
+        for (const option of group.options) {
+          expect(
+            screen.getByTestId(`card-select-option-${option.value}`),
+          ).toBeVisible();
+        }
+      }
+    });
+  });
+});

--- a/Common/Tests/Types/Monitor/MonitorTypeKeywords.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorTypeKeywords.test.ts
@@ -1,0 +1,360 @@
+import BadDataException from "../../../Types/Exception/BadDataException";
+import MonitorType, {
+  MonitorTypeCategory,
+  MonitorTypeHelper,
+  MonitorTypeProps,
+} from "../../../Types/Monitor/MonitorType";
+import {
+  CardSelectOption,
+  cardSelectOptionMatchesSearch,
+  getCardSelectOptionSearchScore,
+  getCardSelectSearchTokens,
+} from "../../../UI/Components/CardSelect/CardSelect";
+
+/*
+ * The monitor type picker offers 29 types. Whether someone finds the right one
+ * comes down to whether the words they already use - "k8s", "postgres",
+ * "heartbeat", "tls" - are attached to the card, because none of them appear
+ * in its title or its copy. These are the searches this catalog promises to
+ * answer.
+ */
+
+const allProps: Array<MonitorTypeProps> =
+  MonitorTypeHelper.getAllMonitorTypeProps();
+
+type PropsForFunction = (monitorType: MonitorType) => MonitorTypeProps;
+
+const propsFor: PropsForFunction = (
+  monitorType: MonitorType,
+): MonitorTypeProps => {
+  const found: MonitorTypeProps | undefined = allProps.find(
+    (item: MonitorTypeProps) => {
+      return item.monitorType === monitorType;
+    },
+  );
+
+  if (!found) {
+    throw new Error(`No props for ${monitorType}`);
+  }
+
+  return found;
+};
+
+type ToCardOptionFunction = (monitorType: MonitorType) => CardSelectOption;
+
+const toCardOption: ToCardOptionFunction = (
+  monitorType: MonitorType,
+): CardSelectOption => {
+  const props: MonitorTypeProps = propsFor(monitorType);
+
+  return {
+    value: props.monitorType,
+    title: props.title,
+    description: props.description,
+    icon: props.icon,
+    keywords: props.keywords,
+  };
+};
+
+/*
+ * Runs a search over the whole catalog exactly the way the picker does, and
+ * returns the monitor types in the order they would be shown.
+ */
+type SearchCatalogFunction = (search: string) => Array<MonitorType>;
+
+const searchCatalog: SearchCatalogFunction = (
+  search: string,
+): Array<MonitorType> => {
+  const tokens: Array<string> = getCardSelectSearchTokens(search);
+  const categories: Array<MonitorTypeCategory> =
+    MonitorTypeHelper.getMonitorTypeCategories();
+
+  const results: Array<{ monitorType: MonitorType; score: number }> = [];
+
+  for (const category of categories) {
+    for (const monitorType of category.monitorTypes) {
+      const option: CardSelectOption = toCardOption(monitorType);
+
+      if (!cardSelectOptionMatchesSearch(option, tokens, category.label)) {
+        continue;
+      }
+
+      results.push({
+        monitorType: monitorType,
+        score: getCardSelectOptionSearchScore(option, tokens, category.label),
+      });
+    }
+  }
+
+  return results
+    .sort(
+      (
+        a: { monitorType: MonitorType; score: number },
+        b: { monitorType: MonitorType; score: number },
+      ) => {
+        const scoreDifference: number = b.score - a.score;
+
+        if (scoreDifference !== 0) {
+          return scoreDifference;
+        }
+
+        return propsFor(a.monitorType).title.localeCompare(
+          propsFor(b.monitorType).title,
+        );
+      },
+    )
+    .map((result: { monitorType: MonitorType; score: number }) => {
+      return result.monitorType;
+    });
+};
+
+describe("MonitorType keywords", () => {
+  describe("every monitor type carries usable keywords", () => {
+    test("no monitor type is left without any", () => {
+      for (const props of allProps) {
+        expect(Array.isArray(props.keywords)).toBe(true);
+        expect(props.keywords.length).toBeGreaterThan(0);
+      }
+    });
+
+    test("every enum member has props, so nothing can be searched for and missed", () => {
+      const covered: Array<MonitorType> = allProps.map(
+        (props: MonitorTypeProps) => {
+          return props.monitorType;
+        },
+      );
+
+      for (const monitorType of Object.values(MonitorType)) {
+        expect(covered).toContain(monitorType);
+      }
+    });
+
+    test("keywords are lower case, so a search never misses on case alone", () => {
+      for (const props of allProps) {
+        for (const keyword of props.keywords) {
+          expect(keyword).toBe(keyword.toLowerCase());
+        }
+      }
+    });
+
+    test("keywords are trimmed and non-empty", () => {
+      for (const props of allProps) {
+        for (const keyword of props.keywords) {
+          expect(keyword).toBe(keyword.trim());
+          expect(keyword.length).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    test("a monitor type does not repeat the same keyword", () => {
+      for (const props of allProps) {
+        expect(new Set(props.keywords).size).toBe(props.keywords.length);
+      }
+    });
+
+    /*
+     * A keyword that only repeats the title earns nothing - the title is
+     * already searched. Every type must add at least one word the card does
+     * not already say.
+     */
+    test("each type adds at least one word its title does not already contain", () => {
+      for (const props of allProps) {
+        const title: string = props.title.toLowerCase();
+
+        const addsSomething: boolean = props.keywords.some(
+          (keyword: string) => {
+            return !title.includes(keyword);
+          },
+        );
+
+        expect({
+          monitorType: props.monitorType,
+          addsSomething: addsSomething,
+        }).toEqual({ monitorType: props.monitorType, addsSomething: true });
+      }
+    });
+  });
+
+  describe("getKeywords", () => {
+    test("returns the configured keywords", () => {
+      expect(MonitorTypeHelper.getKeywords(MonitorType.Kubernetes)).toContain(
+        "k8s",
+      );
+    });
+
+    test("throws BadDataException for a type without props", () => {
+      expect(() => {
+        MonitorTypeHelper.getKeywords("NonExistent" as MonitorType);
+      }).toThrowError(BadDataException);
+    });
+  });
+
+  describe("card copy is scannable", () => {
+    /*
+     * Every description used to open with "This monitor type lets you
+     * monitor", so the first five words of all 29 cards were identical and
+     * carried nothing. Reading the grid meant skipping them 29 times.
+     */
+    test("no description opens with the old boilerplate", () => {
+      for (const props of allProps) {
+        expect({
+          monitorType: props.monitorType,
+          startsWithBoilerplate: props.description
+            .toLowerCase()
+            .startsWith("this monitor type"),
+        }).toEqual({
+          monitorType: props.monitorType,
+          startsWithBoilerplate: false,
+        });
+      }
+    });
+
+    test("descriptions stay short enough to keep the cards an even height", () => {
+      for (const props of allProps) {
+        expect({
+          monitorType: props.monitorType,
+          tooLong: props.description.length > 100,
+        }).toEqual({ monitorType: props.monitorType, tooLong: false });
+      }
+    });
+
+    test("descriptions are still there and still say something", () => {
+      for (const props of allProps) {
+        expect(props.description.trim().length).toBeGreaterThan(20);
+      }
+    });
+  });
+
+  describe("the searches the catalog promises to answer", () => {
+    test.each([
+      ["k8s", MonitorType.Kubernetes],
+      ["kubernetes", MonitorType.Kubernetes],
+      ["eks", MonitorType.Kubernetes],
+      ["postgres", MonitorType.SQLQuery],
+      ["postgresql", MonitorType.SQLQuery],
+      ["mysql", MonitorType.SQLQuery],
+      ["database", MonitorType.SQLQuery],
+      ["heartbeat", MonitorType.IncomingRequest],
+      ["cron", MonitorType.IncomingRequest],
+      ["webhook", MonitorType.IncomingRequest],
+      ["tls", MonitorType.SSLCertificate],
+      ["cert", MonitorType.SSLCertificate],
+      ["x509", MonitorType.SSLCertificate],
+      ["url", MonitorType.Website],
+      ["icmp", MonitorType.Ping],
+      ["tcp", MonitorType.Port],
+      ["udp", MonitorType.Port],
+      ["ipv6", MonitorType.IP],
+      ["whois", MonitorType.Domain],
+      ["aws", MonitorType.ExternalStatusPage],
+      ["cloudflare", MonitorType.ExternalStatusPage],
+      ["cname", MonitorType.DNS],
+      ["dnskey", MonitorType.DNSSEC],
+      ["snmp", MonitorType.NetworkDevice],
+      ["router", MonitorType.NetworkDevice],
+      ["prometheus", MonitorType.Metrics],
+      ["apm", MonitorType.Traces],
+      ["stack trace", MonitorType.Exceptions],
+      ["playwright", MonitorType.SyntheticMonitor],
+      ["javascript", MonitorType.CustomJavaScriptCode],
+      ["rootless", MonitorType.Podman],
+      ["lxc", MonitorType.Proxmox],
+      ["osd", MonitorType.Ceph],
+      ["sensor", MonitorType.IoTDevice],
+      ["imap", MonitorType.IncomingEmail],
+    ])(
+      "ranks %s first, and it is %s",
+      (search: string, expected: MonitorType) => {
+        const results: Array<MonitorType> = searchCatalog(search);
+
+        expect(results.length).toBeGreaterThan(0);
+        expect(results[0]).toBe(expected);
+      },
+    );
+
+    test("a plain title search still wins over anything that merely mentions it", () => {
+      expect(searchCatalog("ping")[0]).toBe(MonitorType.Ping);
+      expect(searchCatalog("domain")[0]).toBe(MonitorType.Domain);
+      expect(searchCatalog("logs")[0]).toBe(MonitorType.Logs);
+    });
+
+    test("words describing the job, in any order, find the type", () => {
+      expect(searchCatalog("expiry certificate")).toContain(
+        MonitorType.SSLCertificate,
+      );
+      expect(searchCatalog("certificate expiry")).toContain(
+        MonitorType.SSLCertificate,
+      );
+    });
+
+    test("a category name gathers everything under it", () => {
+      const results: Array<MonitorType> = searchCatalog("infrastructure");
+
+      expect(results).toContain(MonitorType.Kubernetes);
+      expect(results).toContain(MonitorType.Docker);
+      expect(results).toContain(MonitorType.Ceph);
+      expect(results).not.toContain(MonitorType.Website);
+    });
+
+    test("a word nothing uses returns nothing rather than everything", () => {
+      expect(searchCatalog("mainframe")).toEqual([]);
+    });
+
+    test("an empty search returns the whole catalog", () => {
+      const categories: Array<MonitorTypeCategory> =
+        MonitorTypeHelper.getMonitorTypeCategories();
+
+      const total: number = categories.reduce(
+        (count: number, category: MonitorTypeCategory) => {
+          return count + category.monitorTypes.length;
+        },
+        0,
+      );
+
+      expect(searchCatalog("").length).toBe(total);
+    });
+  });
+
+  describe("the catalog the picker actually offers", () => {
+    test("every categorised type has props to render", () => {
+      const categories: Array<MonitorTypeCategory> =
+        MonitorTypeHelper.getMonitorTypeCategories();
+
+      for (const category of categories) {
+        for (const monitorType of category.monitorTypes) {
+          expect(() => {
+            return propsFor(monitorType);
+          }).not.toThrow();
+        }
+      }
+    });
+
+    test("no monitor type is listed under two categories, which would render it twice", () => {
+      const categories: Array<MonitorTypeCategory> =
+        MonitorTypeHelper.getMonitorTypeCategories();
+
+      const seen: Array<MonitorType> = [];
+
+      for (const category of categories) {
+        for (const monitorType of category.monitorTypes) {
+          expect(seen).not.toContain(monitorType);
+          seen.push(monitorType);
+        }
+      }
+    });
+
+    /*
+     * The first category is the one the picker leaves open, so it has to be
+     * the one most people want. Everything else starts closed behind a count.
+     */
+    test("the category shown open by default is the everyday one", () => {
+      const categories: Array<MonitorTypeCategory> =
+        MonitorTypeHelper.getMonitorTypeCategories();
+
+      expect(categories[0]?.label).toBe("Basic Monitoring");
+      expect(categories[0]?.monitorTypes).toContain(MonitorType.Website);
+      expect(categories[0]?.monitorTypes).toContain(MonitorType.API);
+      expect(categories[0]?.monitorTypes).toContain(MonitorType.Ping);
+    });
+  });
+});

--- a/Common/Tests/UI/Components/CardSelect.test.tsx
+++ b/Common/Tests/UI/Components/CardSelect.test.tsx
@@ -1,0 +1,1021 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, test } from "@jest/globals";
+import IconProp from "../../../Types/Icon/IconProp";
+import getJestMockFunction, { MockFunction } from "../../MockType";
+import CardSelect, {
+  CardSelectOption,
+  CardSelectOptionGroup,
+  ComponentProps,
+  cardSelectOptionMatchesSearch,
+  getCardSelectOptionSearchScore,
+  getCardSelectSearchTokens,
+  isCardSelectOptionGroup,
+  normalizeCardSelectGroups,
+} from "../../../UI/Components/CardSelect/CardSelect";
+
+/*
+ * CardSelect grew a search box and collapsible groups for the monitor type
+ * picker, where 29 cards under nine headings made picking one a scrolling
+ * exercise. Both are opt in, so the two callers that do not ask for them -
+ * the team role picker and the metrics pipeline rule picker - must keep
+ * exactly the plain grid they had. That is what the first block pins.
+ */
+
+const website: CardSelectOption = {
+  value: "Website",
+  title: "Website",
+  description: "Check a page loads and responds.",
+  icon: IconProp.Globe,
+  keywords: ["url", "http", "https"],
+};
+
+const kubernetes: CardSelectOption = {
+  value: "Kubernetes",
+  title: "Kubernetes",
+  description: "Cluster, node, workload, and pod health.",
+  icon: IconProp.Cube,
+  keywords: ["k8s", "cluster", "pod"],
+};
+
+const sqlQuery: CardSelectOption = {
+  value: "SQL Query",
+  title: "SQL Query",
+  description: "Run a read only query on a schedule.",
+  icon: IconProp.Database,
+  keywords: ["postgres", "mysql", "database"],
+};
+
+const manual: CardSelectOption = {
+  value: "Manual",
+  title: "Manual",
+  description: "No automatic checks.",
+  icon: IconProp.EmptyCircle,
+};
+
+const basicGroup: CardSelectOptionGroup = {
+  label: "Basic Monitoring",
+  options: [website],
+};
+
+const infrastructureGroup: CardSelectOptionGroup = {
+  label: "Infrastructure",
+  options: [kubernetes],
+};
+
+const databaseGroup: CardSelectOptionGroup = {
+  label: "Database Monitoring",
+  options: [sqlQuery],
+};
+
+const otherGroup: CardSelectOptionGroup = {
+  label: "Other",
+  options: [manual],
+};
+
+const groupedOptions: Array<CardSelectOptionGroup> = [
+  basicGroup,
+  infrastructureGroup,
+  databaseGroup,
+  otherGroup,
+];
+
+type RenderComponentFunction = (props: Partial<ComponentProps>) => {
+  onChange: MockFunction;
+};
+
+const renderComponent: RenderComponentFunction = (
+  props: Partial<ComponentProps>,
+): { onChange: MockFunction } => {
+  const onChange: MockFunction = getJestMockFunction();
+
+  render(
+    <CardSelect
+      options={props.options || groupedOptions}
+      onChange={onChange}
+      {...props}
+    />,
+  );
+
+  return { onChange: onChange };
+};
+
+type TypeSearchFunction = (value: string) => void;
+
+const typeSearch: TypeSearchFunction = (value: string): void => {
+  fireEvent.change(screen.getByTestId("card-select-search"), {
+    target: { value: value },
+  });
+};
+
+describe("CardSelect", () => {
+  describe("default behaviour is unchanged for callers that opt into nothing", () => {
+    test("renders every flat option as a card", () => {
+      renderComponent({ options: [website, kubernetes, manual] });
+
+      expect(screen.getByTestId("card-select-option-Website")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-Manual")).toBeVisible();
+    });
+
+    test("renders every group heading and every card under it", () => {
+      renderComponent({});
+
+      for (const group of groupedOptions) {
+        expect(screen.getByText(group.label)).toBeInTheDocument();
+      }
+
+      expect(screen.getByTestId("card-select-option-Website")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-SQL Query")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-Manual")).toBeVisible();
+    });
+
+    test("renders a run of flat options interleaved between groups", () => {
+      renderComponent({ options: [manual, basicGroup, kubernetes] });
+
+      expect(screen.getByTestId("card-select-option-Manual")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-Website")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+      expect(screen.getByText("Basic Monitoring")).toBeInTheDocument();
+    });
+
+    test("shows no search box", () => {
+      renderComponent({});
+
+      expect(
+        screen.queryByTestId("card-select-search"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("shows no collapse control, so every group stays open", () => {
+      renderComponent({});
+
+      expect(
+        screen.queryByTestId("card-select-group-Infrastructure"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+    });
+  });
+
+  describe("selection", () => {
+    test("calls onChange with the option value when a card is clicked", () => {
+      const { onChange } = renderComponent({});
+
+      fireEvent.click(screen.getByTestId("card-select-option-Website"));
+
+      expect(onChange).toHaveBeenCalledWith("Website");
+    });
+
+    test("calls onChange when Enter is pressed on a card", () => {
+      const { onChange } = renderComponent({});
+
+      fireEvent.keyDown(screen.getByTestId("card-select-option-Website"), {
+        key: "Enter",
+      });
+
+      expect(onChange).toHaveBeenCalledWith("Website");
+    });
+
+    test("calls onChange when Space is pressed on a card", () => {
+      const { onChange } = renderComponent({});
+
+      fireEvent.keyDown(screen.getByTestId("card-select-option-Website"), {
+        key: " ",
+      });
+
+      expect(onChange).toHaveBeenCalledWith("Website");
+    });
+
+    test("does not call onChange for an unrelated key", () => {
+      const { onChange } = renderComponent({});
+
+      fireEvent.keyDown(screen.getByTestId("card-select-option-Website"), {
+        key: "a",
+      });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    test("marks only the selected card aria-checked", () => {
+      renderComponent({ value: "Kubernetes" });
+
+      expect(
+        screen.getByTestId("card-select-option-Kubernetes"),
+      ).toHaveAttribute("aria-checked", "true");
+      expect(screen.getByTestId("card-select-option-Website")).toHaveAttribute(
+        "aria-checked",
+        "false",
+      );
+    });
+
+    test("every card is a radio inside a radiogroup", () => {
+      renderComponent({});
+
+      expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+      expect(screen.getAllByRole("radio")).toHaveLength(4);
+    });
+  });
+
+  describe("error and labelling", () => {
+    test("renders the error as an alert", () => {
+      renderComponent({ error: "Monitor type is required." });
+
+      const error: HTMLElement = screen.getByRole("alert");
+
+      expect(error).toHaveTextContent("Monitor type is required.");
+    });
+
+    test("renders no alert when there is no error", () => {
+      renderComponent({});
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    test("points the radiogroup at the field label", () => {
+      renderComponent({ ariaLabelledby: "monitor-type-label" });
+
+      expect(screen.getByRole("radiogroup")).toHaveAttribute(
+        "aria-labelledby",
+        "monitor-type-label",
+      );
+    });
+
+    test("exposes the dataTestId on the wrapper", () => {
+      renderComponent({ dataTestId: "monitor-type-picker" });
+
+      expect(screen.getByTestId("monitor-type-picker")).toBeInTheDocument();
+    });
+  });
+
+  describe("search", () => {
+    test("shows the search box only when asked", () => {
+      renderComponent({ searchable: true });
+
+      expect(screen.getByTestId("card-select-search")).toBeInTheDocument();
+    });
+
+    test("uses the caller's placeholder as the accessible name", () => {
+      renderComponent({ searchable: true, searchPlaceholder: "Search types" });
+
+      expect(screen.getByLabelText("Search types")).toBeInTheDocument();
+    });
+
+    test("counts everything on offer before anything is typed", () => {
+      renderComponent({ searchable: true });
+
+      expect(
+        screen.getByTestId("card-select-search-summary"),
+      ).toHaveTextContent("4 to choose from");
+    });
+
+    test("narrows to the cards that match a title", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("kubernetes");
+
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+      expect(
+        screen.queryByTestId("card-select-option-Website"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("matches on a keyword that appears nowhere on the card", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("k8s");
+
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+      expect(screen.getAllByRole("radio")).toHaveLength(1);
+    });
+
+    test("matches on the description", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("workload");
+
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+    });
+
+    test("matches on the group heading the card sits under", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("infrastructure");
+
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+      expect(
+        screen.queryByTestId("card-select-option-Website"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("ignores case on both sides", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("K8S");
+
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+    });
+
+    test("matches part of a word", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("kube");
+
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+    });
+
+    /*
+     * The words are matched separately and can come from different fields, so
+     * a user describing what they want in their own order still lands on the
+     * card. Requiring every word is what keeps that from matching everything.
+     */
+    test("requires every word typed, taking them from different fields", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("postgres query");
+
+      expect(screen.getByTestId("card-select-option-SQL Query")).toBeVisible();
+      expect(screen.getAllByRole("radio")).toHaveLength(1);
+    });
+
+    test("does not care what order the words are typed in", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("query postgres");
+
+      expect(screen.getByTestId("card-select-option-SQL Query")).toBeVisible();
+    });
+
+    /*
+     * The strict pass drops it - nothing contains "mainframe" - so what comes
+     * back is labelled a closest match rather than presented as a hit. The
+     * strict rule itself is pinned on cardSelectOptionMatchesSearch below.
+     */
+    test("stops treating a card as a match when one of the words misses", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("postgres mainframe");
+
+      expect(screen.getByTestId("card-select-closest-matches")).toBeVisible();
+      expect(
+        screen.getByTestId("card-select-search-summary"),
+      ).toHaveTextContent("closest of");
+    });
+
+    test("hides the group headings while a search is running", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("kubernetes");
+
+      expect(screen.queryByText("Infrastructure")).not.toBeInTheDocument();
+    });
+
+    test("reports how many of the total are showing", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("k8s");
+
+      expect(
+        screen.getByTestId("card-select-search-summary"),
+      ).toHaveTextContent("Showing 1 of 4");
+    });
+
+    test("a card can still be picked out of the search results", () => {
+      const { onChange } = renderComponent({ searchable: true });
+
+      typeSearch("k8s");
+      fireEvent.click(screen.getByTestId("card-select-option-Kubernetes"));
+
+      expect(onChange).toHaveBeenCalledWith("Kubernetes");
+    });
+
+    describe("when nothing matches", () => {
+      test("says so rather than rendering an empty grid", () => {
+        renderComponent({ searchable: true });
+
+        typeSearch("mainframe");
+
+        expect(screen.getByTestId("card-select-no-results")).toBeVisible();
+        expect(screen.queryAllByRole("radio")).toHaveLength(0);
+      });
+
+      test("offers a way back to the full list", () => {
+        renderComponent({ searchable: true });
+
+        typeSearch("mainframe");
+        fireEvent.click(screen.getByText("Clear search"));
+
+        expect(
+          screen.queryByTestId("card-select-no-results"),
+        ).not.toBeInTheDocument();
+        expect(screen.getByTestId("card-select-option-Website")).toBeVisible();
+      });
+    });
+
+    test("the clear button restores the full list", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("k8s");
+      fireEvent.click(screen.getByTestId("card-select-search-clear"));
+
+      expect(screen.getByTestId("card-select-option-Website")).toBeVisible();
+      expect(screen.getByText("Basic Monitoring")).toBeInTheDocument();
+    });
+
+    test("there is nothing to clear before anything is typed", () => {
+      renderComponent({ searchable: true });
+
+      expect(
+        screen.queryByTestId("card-select-search-clear"),
+      ).not.toBeInTheDocument();
+    });
+
+    /*
+     * The picker is used inside forms that live in modals and side overs. An
+     * Escape meant for the search box must not also close the form around it.
+     */
+    test("Escape clears the search without escaping the surrounding form", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("k8s");
+
+      const searchInput: HTMLElement = screen.getByTestId("card-select-search");
+      const escape: boolean = fireEvent.keyDown(searchInput, {
+        key: "Escape",
+      });
+
+      expect(escape).toBe(false);
+      expect(screen.getByTestId("card-select-option-Website")).toBeVisible();
+    });
+
+    test("Escape on an empty search box is left to the form", () => {
+      renderComponent({ searchable: true });
+
+      const escape: boolean = fireEvent.keyDown(
+        screen.getByTestId("card-select-search"),
+        { key: "Escape" },
+      );
+
+      expect(escape).toBe(true);
+    });
+  });
+
+  describe("keyboard", () => {
+    /*
+     * Every card used to get its own increasing tabIndex. With the 0 that
+     * FormField passes, that produced 1, 2, 3 ... 28 - positive tab indices,
+     * which jump the whole grid ahead of every other control on the page and
+     * make 29 stops out of what should be one.
+     */
+    test("the group is a single tab stop, not one per card", () => {
+      renderComponent({});
+
+      const tabbable: Array<HTMLElement> = screen
+        .getAllByRole("radio")
+        .filter((card: HTMLElement) => {
+          return card.getAttribute("tabindex") === "0";
+        });
+
+      expect(tabbable).toHaveLength(1);
+    });
+
+    test("no card carries a positive tab index", () => {
+      renderComponent({});
+
+      for (const card of screen.getAllByRole("radio")) {
+        expect(Number(card.getAttribute("tabindex"))).toBeLessThanOrEqual(0);
+      }
+    });
+
+    test("the tab stop is the first card when nothing is selected", () => {
+      renderComponent({});
+
+      expect(screen.getByTestId("card-select-option-Website")).toHaveAttribute(
+        "tabindex",
+        "0",
+      );
+    });
+
+    test("the tab stop follows the selection", () => {
+      renderComponent({ value: "SQL Query" });
+
+      expect(
+        screen.getByTestId("card-select-option-SQL Query"),
+      ).toHaveAttribute("tabindex", "0");
+      expect(screen.getByTestId("card-select-option-Website")).toHaveAttribute(
+        "tabindex",
+        "-1",
+      );
+    });
+
+    test("arrow right moves focus to the next card", () => {
+      renderComponent({});
+
+      const first: HTMLElement = screen.getByTestId(
+        "card-select-option-Website",
+      );
+
+      first.focus();
+      fireEvent.keyDown(first, { key: "ArrowRight" });
+
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toHaveFocus();
+    });
+
+    test("arrow down moves focus to the next card", () => {
+      renderComponent({});
+
+      const first: HTMLElement = screen.getByTestId(
+        "card-select-option-Website",
+      );
+
+      first.focus();
+      fireEvent.keyDown(first, { key: "ArrowDown" });
+
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toHaveFocus();
+    });
+
+    test("arrow left moves focus back", () => {
+      renderComponent({});
+
+      const second: HTMLElement = screen.getByTestId(
+        "card-select-option-Kubernetes",
+      );
+
+      second.focus();
+      fireEvent.keyDown(second, { key: "ArrowLeft" });
+
+      expect(screen.getByTestId("card-select-option-Website")).toHaveFocus();
+    });
+
+    test("arrows stop at the ends rather than wrapping round", () => {
+      renderComponent({});
+
+      const first: HTMLElement = screen.getByTestId(
+        "card-select-option-Website",
+      );
+
+      first.focus();
+      fireEvent.keyDown(first, { key: "ArrowLeft" });
+
+      expect(first).toHaveFocus();
+    });
+
+    /*
+     * Moving focus must not choose anything: on the create form choosing a
+     * type resets the criteria built below it, so arrowing past a card cannot
+     * be allowed to fire onChange.
+     */
+    test("moving focus chooses nothing", () => {
+      const { onChange } = renderComponent({});
+
+      const first: HTMLElement = screen.getByTestId(
+        "card-select-option-Website",
+      );
+
+      first.focus();
+      fireEvent.keyDown(first, { key: "ArrowRight" });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    test("arrows skip the cards folded away in closed groups", () => {
+      renderComponent({ collapsibleGroups: true });
+
+      const first: HTMLElement = screen.getByTestId(
+        "card-select-option-Website",
+      );
+
+      first.focus();
+      fireEvent.keyDown(first, { key: "ArrowRight" });
+
+      // Website is the only card on screen, so there is nowhere to go.
+      expect(first).toHaveFocus();
+    });
+
+    test("Enter in the search box picks the top result", () => {
+      const { onChange } = renderComponent({ searchable: true });
+
+      typeSearch("k8s");
+      fireEvent.keyDown(screen.getByTestId("card-select-search"), {
+        key: "Enter",
+      });
+
+      expect(onChange).toHaveBeenCalledWith("Kubernetes");
+    });
+
+    test("Enter in an empty search box picks nothing", () => {
+      const { onChange } = renderComponent({ searchable: true });
+
+      fireEvent.keyDown(screen.getByTestId("card-select-search"), {
+        key: "Enter",
+      });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    test("arrow down from the search box moves into the results", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("k8s");
+      fireEvent.keyDown(screen.getByTestId("card-select-search"), {
+        key: "ArrowDown",
+      });
+
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toHaveFocus();
+    });
+  });
+
+  describe("closest matches", () => {
+    /*
+     * A dead end is the worst answer a search can give. When no card carries
+     * every word, the cards carrying any of them beat an empty panel.
+     */
+    test("falls back to the cards matching any word", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("postgres uptime");
+
+      expect(screen.getByTestId("card-select-option-SQL Query")).toBeVisible();
+      expect(screen.getByTestId("card-select-closest-matches")).toBeVisible();
+    });
+
+    test("says the results are only the closest ones", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("postgres uptime");
+
+      expect(
+        screen.getByTestId("card-select-search-summary"),
+      ).toHaveTextContent("closest of");
+    });
+
+    test("does not claim closest matches when every word landed", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("k8s");
+
+      expect(
+        screen.queryByTestId("card-select-closest-matches"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("a card from the closest matches can still be picked", () => {
+      const { onChange } = renderComponent({ searchable: true });
+
+      typeSearch("postgres uptime");
+      fireEvent.click(screen.getByTestId("card-select-option-SQL Query"));
+
+      expect(onChange).toHaveBeenCalledWith("SQL Query");
+    });
+
+    test("a single word that matches nothing still says nothing matches", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("mainframe");
+
+      expect(screen.getByTestId("card-select-no-results")).toBeVisible();
+      expect(
+        screen.queryByTestId("card-select-closest-matches"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("several words that all match nothing still say nothing matches", () => {
+      renderComponent({ searchable: true });
+
+      typeSearch("mainframe cobol");
+
+      expect(screen.getByTestId("card-select-no-results")).toBeVisible();
+    });
+  });
+
+  describe("search ranking", () => {
+    type TitlesFunction = () => Array<string>;
+
+    const renderedTitles: TitlesFunction = (): Array<string> => {
+      return screen.getAllByRole("radio").map((card: HTMLElement) => {
+        return card.getAttribute("data-testid") || "";
+      });
+    };
+
+    test("puts an exact title match first", () => {
+      const ping: CardSelectOption = {
+        value: "Ping",
+        title: "Ping",
+        description: "ICMP reachability.",
+        icon: IconProp.Signal,
+      };
+      const other: CardSelectOption = {
+        value: "Other",
+        title: "Other",
+        description: "Mentions ping in passing.",
+        icon: IconProp.Globe,
+      };
+
+      renderComponent({ options: [other, ping], searchable: true });
+
+      typeSearch("ping");
+
+      expect(renderedTitles()[0]).toBe("card-select-option-Ping");
+    });
+
+    test("puts a keyword match above a description-only match", () => {
+      const keywordCard: CardSelectOption = {
+        value: "Keyword",
+        title: "Keyword",
+        description: "Nothing relevant here.",
+        icon: IconProp.Globe,
+        keywords: ["postgres"],
+      };
+      const descriptionCard: CardSelectOption = {
+        value: "Description",
+        title: "Description",
+        description: "Talks about postgres somewhere in the copy.",
+        icon: IconProp.Globe,
+      };
+
+      renderComponent({
+        options: [descriptionCard, keywordCard],
+        searchable: true,
+      });
+
+      typeSearch("postgres");
+
+      expect(renderedTitles()[0]).toBe("card-select-option-Keyword");
+    });
+
+    test("falls back to alphabetical order when the scores tie", () => {
+      const beta: CardSelectOption = {
+        value: "Beta",
+        title: "Beta",
+        description: "shared",
+        icon: IconProp.Globe,
+      };
+      const alpha: CardSelectOption = {
+        value: "Alpha",
+        title: "Alpha",
+        description: "shared",
+        icon: IconProp.Globe,
+      };
+
+      renderComponent({ options: [beta, alpha], searchable: true });
+
+      typeSearch("shared");
+
+      expect(renderedTitles()).toEqual([
+        "card-select-option-Alpha",
+        "card-select-option-Beta",
+      ]);
+    });
+  });
+
+  describe("collapsible groups", () => {
+    test("opens the first group and closes the rest behind a count", () => {
+      renderComponent({ collapsibleGroups: true });
+
+      expect(screen.getByTestId("card-select-option-Website")).toBeVisible();
+      expect(
+        screen.queryByTestId("card-select-option-Kubernetes"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("card-select-option-Manual"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("every group header stays on screen so nothing is hidden outright", () => {
+      renderComponent({ collapsibleGroups: true });
+
+      for (const group of groupedOptions) {
+        expect(
+          screen.getByTestId(`card-select-group-${group.label}`),
+        ).toBeVisible();
+      }
+    });
+
+    test("says how many cards a closed group holds", () => {
+      renderComponent({ collapsibleGroups: true });
+
+      expect(
+        screen.getByTestId("card-select-group-Infrastructure"),
+      ).toHaveTextContent("1");
+    });
+
+    test("reports its state to assistive technology", () => {
+      renderComponent({ collapsibleGroups: true });
+
+      expect(
+        screen.getByTestId("card-select-group-Basic Monitoring"),
+      ).toHaveAttribute("aria-expanded", "true");
+      expect(
+        screen.getByTestId("card-select-group-Infrastructure"),
+      ).toHaveAttribute("aria-expanded", "false");
+    });
+
+    test("clicking a closed header opens it", () => {
+      renderComponent({ collapsibleGroups: true });
+
+      fireEvent.click(screen.getByTestId("card-select-group-Infrastructure"));
+
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+      expect(
+        screen.getByTestId("card-select-group-Infrastructure"),
+      ).toHaveAttribute("aria-expanded", "true");
+    });
+
+    test("clicking an open header closes it", () => {
+      renderComponent({ collapsibleGroups: true });
+
+      fireEvent.click(screen.getByTestId("card-select-group-Basic Monitoring"));
+
+      expect(
+        screen.queryByTestId("card-select-option-Website"),
+      ).not.toBeInTheDocument();
+    });
+
+    /*
+     * Re-entering a half-filled form must show the choice already made, not
+     * hide it behind a closed heading and look like nothing was picked.
+     */
+    test("opens the group holding the current selection", () => {
+      renderComponent({ collapsibleGroups: true, value: "Manual" });
+
+      expect(screen.getByTestId("card-select-option-Manual")).toBeVisible();
+      expect(screen.getByTestId("card-select-group-Other")).toHaveAttribute(
+        "aria-expanded",
+        "true",
+      );
+    });
+
+    test("a group the user closed by hand stays closed", () => {
+      renderComponent({ collapsibleGroups: true, value: "Website" });
+
+      fireEvent.click(screen.getByTestId("card-select-group-Basic Monitoring"));
+
+      expect(
+        screen.queryByTestId("card-select-option-Website"),
+      ).not.toBeInTheDocument();
+    });
+
+    test("leaves a run of flat options alone, having no header to collapse", () => {
+      renderComponent({
+        options: [website, kubernetes],
+        collapsibleGroups: true,
+      });
+
+      expect(screen.getByTestId("card-select-option-Website")).toBeVisible();
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+    });
+
+    test("a search reaches into closed groups", () => {
+      renderComponent({ collapsibleGroups: true, searchable: true });
+
+      typeSearch("k8s");
+
+      expect(screen.getByTestId("card-select-option-Kubernetes")).toBeVisible();
+    });
+
+    test("clearing the search puts the groups back as they were", () => {
+      renderComponent({ collapsibleGroups: true, searchable: true });
+
+      typeSearch("k8s");
+      fireEvent.click(screen.getByTestId("card-select-search-clear"));
+
+      expect(screen.getByTestId("card-select-option-Website")).toBeVisible();
+      expect(
+        screen.queryByTestId("card-select-option-Kubernetes"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("getCardSelectSearchTokens", () => {
+    test("splits into lower case words, ignoring runs of whitespace", () => {
+      expect(getCardSelectSearchTokens("  SSL   Cert ")).toEqual([
+        "ssl",
+        "cert",
+      ]);
+    });
+
+    test("is empty when nothing was typed", () => {
+      expect(getCardSelectSearchTokens("")).toEqual([]);
+      expect(getCardSelectSearchTokens("   ")).toEqual([]);
+    });
+  });
+
+  describe("cardSelectOptionMatchesSearch", () => {
+    test("matches everything when nothing was typed", () => {
+      expect(cardSelectOptionMatchesSearch(website, [])).toBe(true);
+    });
+
+    test("matches on a keyword", () => {
+      expect(cardSelectOptionMatchesSearch(kubernetes, ["k8s"])).toBe(true);
+    });
+
+    test("matches on the group label when one is given", () => {
+      expect(
+        cardSelectOptionMatchesSearch(kubernetes, ["infra"], "Infrastructure"),
+      ).toBe(true);
+    });
+
+    test("does not match on a group label that was not given", () => {
+      expect(cardSelectOptionMatchesSearch(kubernetes, ["infra"])).toBe(false);
+    });
+
+    test("requires every word", () => {
+      expect(cardSelectOptionMatchesSearch(kubernetes, ["k8s", "pod"])).toBe(
+        true,
+      );
+      expect(
+        cardSelectOptionMatchesSearch(kubernetes, ["k8s", "mainframe"]),
+      ).toBe(false);
+    });
+
+    test("copes with an option carrying no keywords at all", () => {
+      expect(cardSelectOptionMatchesSearch(manual, ["manual"])).toBe(true);
+      expect(cardSelectOptionMatchesSearch(manual, ["k8s"])).toBe(false);
+    });
+  });
+
+  describe("getCardSelectOptionSearchScore", () => {
+    test("scores nothing when nothing was typed", () => {
+      expect(getCardSelectOptionSearchScore(website, [])).toBe(0);
+    });
+
+    test("scores an exact title above a title it merely starts", () => {
+      const exact: number = getCardSelectOptionSearchScore(website, [
+        "website",
+      ]);
+      const prefix: number = getCardSelectOptionSearchScore(website, ["web"]);
+
+      expect(exact).toBeGreaterThan(prefix);
+    });
+
+    test("scores an exact keyword above a keyword it merely starts", () => {
+      const exact: number = getCardSelectOptionSearchScore(sqlQuery, [
+        "postgres",
+      ]);
+      const prefix: number = getCardSelectOptionSearchScore(sqlQuery, ["post"]);
+
+      expect(exact).toBeGreaterThan(prefix);
+    });
+
+    test("adds up the words typed", () => {
+      const oneWord: number = getCardSelectOptionSearchScore(kubernetes, [
+        "k8s",
+      ]);
+      const twoWords: number = getCardSelectOptionSearchScore(kubernetes, [
+        "k8s",
+        "pod",
+      ]);
+
+      expect(twoWords).toBeGreaterThan(oneWord);
+    });
+
+    test("counts the group label when one is given", () => {
+      const withLabel: number = getCardSelectOptionSearchScore(
+        kubernetes,
+        ["infrastructure"],
+        "Infrastructure",
+      );
+
+      expect(withLabel).toBeGreaterThan(0);
+      expect(
+        getCardSelectOptionSearchScore(kubernetes, ["infrastructure"]),
+      ).toBe(0);
+    });
+  });
+
+  describe("normalizeCardSelectGroups", () => {
+    test("keeps groups as they are", () => {
+      expect(normalizeCardSelectGroups([basicGroup])).toEqual([
+        { label: "Basic Monitoring", options: [website] },
+      ]);
+    });
+
+    test("gathers a run of flat options into one unlabelled group", () => {
+      expect(normalizeCardSelectGroups([website, kubernetes])).toEqual([
+        { label: null, options: [website, kubernetes] },
+      ]);
+    });
+
+    test("flushes the flat options before each group it precedes", () => {
+      expect(
+        normalizeCardSelectGroups([manual, basicGroup, kubernetes]),
+      ).toEqual([
+        { label: null, options: [manual] },
+        { label: "Basic Monitoring", options: [website] },
+        { label: null, options: [kubernetes] },
+      ]);
+    });
+
+    test("returns nothing for nothing", () => {
+      expect(normalizeCardSelectGroups([])).toEqual([]);
+    });
+  });
+
+  describe("isCardSelectOptionGroup", () => {
+    test("tells a group from an option", () => {
+      expect(isCardSelectOptionGroup(basicGroup)).toBe(true);
+      expect(isCardSelectOptionGroup(website)).toBe(false);
+    });
+  });
+});

--- a/Common/Types/Monitor/MonitorType.ts
+++ b/Common/Types/Monitor/MonitorType.ts
@@ -65,6 +65,14 @@ export interface MonitorTypeProps {
   description: string;
   title: string;
   icon: IconProp;
+  /*
+   * Words a user is likely to type that do not appear in the title or the
+   * description - product names, protocols and synonyms ("k8s", "postgres",
+   * "heartbeat", "tls"). The type picker searches these alongside the visible
+   * copy, so someone who knows their own vocabulary does not have to learn
+   * ours to find the right monitor.
+   */
+  keywords: Array<string>;
 }
 
 export interface MonitorTypeCategory {
@@ -187,216 +195,498 @@ export class MonitorTypeHelper {
         monitorType: MonitorType.API,
         title: "API",
         description:
-          "This monitor type lets you monitor any API - GET, POST, PUT, DELETE or more.",
+          "Call any HTTP endpoint - GET, POST, PUT, DELETE - and alert on the response.",
         icon: IconProp.Code,
+        keywords: [
+          "rest",
+          "endpoint",
+          "http",
+          "https",
+          "json",
+          "graphql",
+          "get",
+          "post",
+          "put",
+          "delete",
+          "service",
+        ],
       },
       {
         monitorType: MonitorType.Manual,
         title: "Manual",
         description:
-          "This monitor is a static monitor and will not actually monitor anything. It will however help you to integrate OneUptime with external monitoring tools and utilities.",
+          "No automatic checks. You set the status yourself, or from an external tool.",
         icon: IconProp.EmptyCircle,
+        keywords: [
+          "static",
+          "external",
+          "integration",
+          "placeholder",
+          "no check",
+          "third party",
+        ],
       },
       {
         monitorType: MonitorType.Website,
         title: "Website",
         description:
-          "This monitor type lets you monitor landing pages like home page of your company / blog or more.",
+          "Check a page loads and responds - status code, page content, and response time.",
         icon: IconProp.Globe,
+        keywords: [
+          "url",
+          "http",
+          "https",
+          "web",
+          "webpage",
+          "site",
+          "landing page",
+          "home page",
+          "uptime",
+        ],
       },
       {
         monitorType: MonitorType.Ping,
         title: "Ping",
-        description:
-          "This monitor type does the basic ping test of an endpoint.",
+        description: "ICMP reachability and round trip time for a host.",
         icon: IconProp.Signal,
+        keywords: [
+          "icmp",
+          "echo",
+          "reachable",
+          "reachability",
+          "latency",
+          "rtt",
+          "packet loss",
+        ],
       },
       {
         monitorType: MonitorType.Kubernetes,
         title: "Kubernetes",
-        description:
-          "This monitor type lets you monitor Kubernetes clusters, workloads, nodes, and pods.",
+        description: "Cluster, node, workload, and pod health.",
         icon: IconProp.Cube,
+        keywords: [
+          "k8s",
+          "cluster",
+          "pod",
+          "node",
+          "workload",
+          "deployment",
+          "namespace",
+          "container",
+          "eks",
+          "gke",
+          "aks",
+          "openshift",
+        ],
       },
       {
         monitorType: MonitorType.Docker,
         title: "Docker Container",
         description:
-          "This monitor type lets you monitor Docker containers — CPU, memory, network, restarts, and lifecycle events.",
+          "Container CPU, memory, network, restarts, and lifecycle events.",
         icon: IconProp.Cube,
+        keywords: [
+          "container",
+          "dockerd",
+          "image",
+          "restart",
+          "compose",
+          "oci",
+        ],
       },
       {
         monitorType: MonitorType.Host,
         title: "Host",
         description:
-          "This monitor type lets you monitor OpenTelemetry-instrumented hosts and servers (the Hosts product) — CPU, memory, disk, network, load average, and process count via the OneUptime Infrastructure Agent. It is the telemetry-metric counterpart to the agent-push Server / VM Monitor.",
+          "CPU, memory, disk, network, and load for hosts running the Infrastructure Agent.",
         icon: IconProp.Server,
+        keywords: [
+          "server",
+          "vm",
+          "machine",
+          "cpu",
+          "memory",
+          "ram",
+          "disk",
+          "load average",
+          "otel",
+          "opentelemetry",
+          "agent",
+          "linux",
+          "infrastructure",
+        ],
       },
       {
         monitorType: MonitorType.Podman,
         title: "Podman Container",
         description:
-          "This monitor type lets you monitor Podman containers — CPU, memory, network, restarts, and lifecycle events.",
+          "Container CPU, memory, network, restarts, and lifecycle events.",
         icon: IconProp.Podman,
+        keywords: [
+          "container",
+          "rootless",
+          "redhat",
+          "oci",
+          "quadlet",
+          "buildah",
+        ],
       },
       {
         monitorType: MonitorType.DockerSwarm,
         title: "Docker Swarm",
         description:
-          "This monitor type lets you monitor Docker Swarm clusters — per-task container CPU, memory, network, process count, and uptime across the cluster's services and nodes.",
+          "Per task container health across the cluster's services and nodes.",
         icon: IconProp.DockerSwarm,
+        keywords: [
+          "swarm",
+          "cluster",
+          "service",
+          "task",
+          "orchestration",
+          "stack",
+          "docker",
+        ],
       },
       {
         monitorType: MonitorType.Proxmox,
         title: "Proxmox",
         description:
-          "This monitor type lets you monitor Proxmox VE clusters — node availability, VM and container (guest) health, CPU, memory, storage, and HA state.",
+          "Node availability, VM and container guests, storage, and HA state.",
         icon: IconProp.Proxmox,
+        keywords: [
+          "pve",
+          "hypervisor",
+          "vm",
+          "virtual machine",
+          "lxc",
+          "guest",
+          "virtualization",
+          "ha",
+          "cluster",
+        ],
       },
       {
         monitorType: MonitorType.Ceph,
         title: "Ceph",
         description:
-          "This monitor type lets you monitor Ceph storage clusters — cluster health, monitor quorum, OSD availability, pool capacity, and placement group states.",
+          "Cluster health, monitor quorum, OSD availability, and pool capacity.",
         icon: IconProp.Ceph,
+        keywords: [
+          "storage",
+          "osd",
+          "placement group",
+          "pool",
+          "quorum",
+          "rados",
+          "cluster",
+          "object storage",
+        ],
       },
       {
         monitorType: MonitorType.IoTDevice,
         title: "IoT Device",
         description:
-          "This monitor type lets you monitor IoT device fleets — device availability, battery level, connectivity and signal strength, temperature, and system health across your devices and gateways.",
+          "Device fleet availability, battery, connectivity, and signal strength.",
         icon: IconProp.IoT,
+        keywords: [
+          "iot",
+          "device",
+          "fleet",
+          "sensor",
+          "battery",
+          "gateway",
+          "embedded",
+          "signal",
+        ],
       },
       {
         monitorType: MonitorType.IP,
         title: "IP",
-        description:
-          "This monitor type lets you monitor any IPv4 or IPv6 addresses.",
+        description: "Reachability of any IPv4 or IPv6 address.",
         icon: IconProp.AltGlobe,
+        keywords: ["ipv4", "ipv6", "address", "reachability", "host"],
       },
       {
         monitorType: MonitorType.IncomingRequest,
         title: "Incoming Request",
         description:
-          "This monitor type lets you ping OneUptime from any external device or service with a custom payload.",
+          "Have something call OneUptime - heartbeats, cron jobs, and webhooks.",
         icon: IconProp.Webhook,
+        keywords: [
+          "webhook",
+          "heartbeat",
+          "push",
+          "cron",
+          "inbound",
+          "dead man switch",
+          "alertmanager",
+          "curl",
+        ],
       },
       {
         monitorType: MonitorType.IncomingEmail,
         title: "Incoming Email",
         description:
-          "This monitor type triggers alerts when emails are received at a unique email address with matching criteria.",
+          "Alert when email arrives at a unique address and matches your criteria.",
         icon: IconProp.Email,
+        keywords: ["email", "mail", "inbox", "smtp", "imap", "mailbox"],
       },
       {
         monitorType: MonitorType.Port,
         title: "Port",
-        description: "This monitor type lets you monitor any TCP or UDP port.",
+        description: "Whether a TCP or UDP port accepts connections.",
         icon: IconProp.Terminal,
+        keywords: ["tcp", "udp", "socket", "telnet", "open port", "connection"],
       },
       {
         monitorType: MonitorType.Server,
         title: "Server / VM",
         description:
-          "This monitor type lets you monitor any server, VM, or any machine.",
+          "Any server, VM, or machine, reporting in through the OneUptime agent.",
         icon: IconProp.Cube,
+        keywords: [
+          "vm",
+          "machine",
+          "agent",
+          "linux",
+          "windows",
+          "cpu",
+          "memory",
+          "disk",
+        ],
       },
       {
         monitorType: MonitorType.SSLCertificate,
         title: "SSL Certificate",
-        description:
-          "This monitor type lets you monitor SSL certificates of any domain.",
+        description: "Certificate validity and expiry for a domain.",
         icon: IconProp.ShieldCheck,
+        keywords: [
+          "tls",
+          "ssl",
+          "cert",
+          "certificate",
+          "https",
+          "expiry",
+          "expiration",
+          "x509",
+          "chain",
+          "handshake",
+        ],
       },
       {
         monitorType: MonitorType.SQLQuery,
         title: "SQL Query",
         description:
-          "This monitor type runs a read-only SQL query on a schedule against a database (PostgreSQL, MySQL, or Microsoft SQL Server) and alerts on the result — row count, a scalar value, execution time, or query errors. Requires a probe with network access to your database.",
+          "Run a read only query on a schedule and alert on rows, values, or errors.",
         icon: IconProp.Database,
+        keywords: [
+          "database",
+          "db",
+          "postgres",
+          "postgresql",
+          "mysql",
+          "mariadb",
+          "mssql",
+          "sql server",
+          "query",
+          "row count",
+        ],
       },
       {
         monitorType: MonitorType.SyntheticMonitor,
         title: "Synthetic Monitor",
         description:
-          "This monitor type lets you monitor your web application UI.",
+          "Drive your web app in a real browser and alert when the journey fails.",
         icon: IconProp.Window,
+        keywords: [
+          "browser",
+          "playwright",
+          "e2e",
+          "user journey",
+          "ui",
+          "click",
+          "flow",
+          "transaction",
+          "headless",
+        ],
       },
       {
         monitorType: MonitorType.CustomJavaScriptCode,
         title: "Custom JavaScript Code",
         description:
-          "This monitor type lets you run custom JavaScript code on a schedule.",
+          "Run your own JavaScript on a schedule and alert on what it returns.",
         icon: IconProp.Code,
+        keywords: [
+          "js",
+          "javascript",
+          "script",
+          "code",
+          "custom",
+          "node",
+          "programmatic",
+        ],
       },
       {
         monitorType: MonitorType.Logs,
         title: "Logs",
-        description: "This monitor type lets you monitor logs from any source.",
+        description:
+          "Alert on log volume or matching log content from any source.",
         icon: IconProp.Logs,
+        keywords: [
+          "log",
+          "otel",
+          "opentelemetry",
+          "log query",
+          "error log",
+          "search logs",
+        ],
       },
       {
         monitorType: MonitorType.Exceptions,
         title: "Exceptions",
-        description:
-          "This monitor type lets you monitor exceptions and error groups from any source.",
+        description: "Alert on exceptions and error groups from any source.",
         icon: IconProp.Bug,
+        keywords: [
+          "exception",
+          "error",
+          "crash",
+          "stack trace",
+          "bug",
+          "error group",
+        ],
       },
       {
         monitorType: MonitorType.Traces,
         title: "Traces",
-        description:
-          "This monitor type lets you monitor traces from any source.",
+        description: "Alert on span latency and error rate from any source.",
         icon: IconProp.Waterfall,
+        keywords: [
+          "trace",
+          "span",
+          "otel",
+          "opentelemetry",
+          "distributed tracing",
+          "apm",
+          "latency",
+        ],
       },
       {
         monitorType: MonitorType.Metrics,
         title: "Metrics",
-        description:
-          "This monitor type lets you monitor metrics from any source.",
+        description: "Alert on any metric you ingest.",
         icon: IconProp.Heartbeat,
+        keywords: [
+          "metric",
+          "otel",
+          "opentelemetry",
+          "gauge",
+          "counter",
+          "histogram",
+          "timeseries",
+          "prometheus",
+        ],
       },
       {
         monitorType: MonitorType.Profiles,
         title: "Profiles",
-        description:
-          "This monitor type lets you monitor continuous profiling data from any source.",
+        description: "Alert on continuous profiling data from any source.",
         icon: IconProp.Fire,
+        keywords: [
+          "profiling",
+          "cpu profile",
+          "flamegraph",
+          "pprof",
+          "continuous profiling",
+        ],
       },
       {
         monitorType: MonitorType.NetworkDevice,
         title: "Network Device",
         description:
-          "This monitor type alerts on a registered Network Device (switch, router, firewall, or access point) — availability, interface status, bandwidth, health OIDs, and traps. The device itself is polled by its assigned probe; the monitor chooses what to alert on.",
+          "Alert on a registered switch, router, firewall, or access point.",
         icon: IconProp.Signal,
+        keywords: [
+          "snmp",
+          "switch",
+          "router",
+          "firewall",
+          "access point",
+          "interface",
+          "oid",
+          "trap",
+          "bandwidth",
+        ],
       },
       {
         monitorType: MonitorType.DNS,
         title: "DNS",
-        description:
-          "This monitor type lets you monitor DNS resolution for your domains, verify record values, and check DNSSEC validity.",
+        description: "Resolution and record values for your domains.",
         icon: IconProp.GlobeAlt,
+        keywords: [
+          "resolution",
+          "resolve",
+          "record",
+          "cname",
+          "mx",
+          "txt",
+          "ns",
+          "srv",
+          "resolver",
+          "nslookup",
+          "dig",
+        ],
       },
       {
         monitorType: MonitorType.DNSSEC,
         title: "DNSSEC",
         description:
-          "This monitor type performs full DNSSEC validation — DNSKEY, DS at the parent zone, RRSIG validity windows, AD-flag/SERVFAIL behavior across public resolvers, and primary/secondary nameserver consistency.",
+          "Full DNSSEC validation - DNSKEY, DS, RRSIG, and resolver behaviour.",
         icon: IconProp.Key,
+        keywords: [
+          "dnskey",
+          "ds record",
+          "rrsig",
+          "signing",
+          "validation",
+          "secure dns",
+          "chain of trust",
+        ],
       },
       {
         monitorType: MonitorType.Domain,
         title: "Domain",
         description:
-          "This monitor type lets you monitor domain registration health — expiry dates, registrar info, nameserver delegation, and WHOIS status.",
+          "Registration health - expiry, registrar, nameservers, and WHOIS status.",
         icon: IconProp.Globe,
+        keywords: [
+          "whois",
+          "registrar",
+          "registration",
+          "expiry",
+          "expiration",
+          "nameserver",
+          "delegation",
+          "tld",
+        ],
       },
       {
         monitorType: MonitorType.ExternalStatusPage,
         title: "External Status Page",
         description:
-          "This monitor type lets you monitor third-party status pages (e.g. AWS, GCP, Azure, GitHub, Cloudflare) and alert when their services degrade.",
+          "Watch a third party status page - AWS, GCP, Azure, GitHub, Cloudflare.",
         icon: IconProp.ExternalLink,
+        keywords: [
+          "third party",
+          "vendor",
+          "upstream",
+          "dependency",
+          "aws",
+          "gcp",
+          "azure",
+          "github",
+          "cloudflare",
+          "statuspage",
+        ],
       },
     ];
 
@@ -431,6 +721,21 @@ export class MonitorTypeHelper {
     }
 
     return monitorTypeProps[0].title;
+  }
+
+  public static getKeywords(monitorType: MonitorType): Array<string> {
+    const monitorTypeProps: Array<MonitorTypeProps> =
+      this.getAllMonitorTypeProps().filter((item: MonitorTypeProps) => {
+        return item.monitorType === monitorType;
+      });
+
+    if (!monitorTypeProps[0]) {
+      throw new BadDataException(
+        `${monitorType} does not have monitorType props`,
+      );
+    }
+
+    return monitorTypeProps[0].keywords;
   }
 
   /*

--- a/Common/UI/Components/CardSelect/CardSelect.tsx
+++ b/Common/UI/Components/CardSelect/CardSelect.tsx
@@ -1,12 +1,24 @@
 import IconProp from "../../../Types/Icon/IconProp";
 import Icon, { SizeProp } from "../Icon/Icon";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, {
+  FunctionComponent,
+  ReactElement,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 export interface CardSelectOption {
   value: string;
   title: string;
   description: string;
   icon: IconProp;
+  /*
+   * Words that should match this card in search but are not on it - product
+   * names, protocols, synonyms. Optional: a catalog small enough to read in
+   * one screen has no use for them.
+   */
+  keywords?: Array<string> | undefined;
 }
 
 export interface CardSelectOptionGroup {
@@ -33,6 +45,19 @@ export interface ComponentProps {
   ariaLabelledby?: string | undefined;
   // Force single-column (1 item per row). Default: responsive 1/2/3 grid.
   singleColumn?: boolean | undefined;
+  /*
+   * Opt in to the search box. Off by default so a picker with a handful of
+   * cards is not given a search box it does not need, and so existing callers
+   * keep the exact markup they had.
+   */
+  searchable?: boolean | undefined;
+  searchPlaceholder?: string | undefined;
+  /*
+   * Opt in to collapsing groups behind their headers. Off by default. Only
+   * has an effect on grouped options: the first group and the group holding
+   * the current selection start open, the rest start closed behind a count.
+   */
+  collapsibleGroups?: boolean | undefined;
 }
 
 interface RenderGroup {
@@ -40,16 +65,189 @@ interface RenderGroup {
   options: Array<CardSelectOption>;
 }
 
-const CardSelect: FunctionComponent<ComponentProps> = (
-  props: ComponentProps,
-): ReactElement => {
-  // Normalize options into render groups
+/**
+ * The words of a search, in lower case. Empty when nothing was typed.
+ */
+export type CardSelectSearchTokensFunction = (search: string) => Array<string>;
+
+export const getCardSelectSearchTokens: CardSelectSearchTokensFunction = (
+  search: string,
+): Array<string> => {
+  return search
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((token: string) => {
+      return token.length > 0;
+    });
+};
+
+/*
+ * The text a search runs against: everything visible on the card, the heading
+ * it sits under, and its hidden keywords.
+ */
+type CardSelectHaystackFunction = (
+  option: CardSelectOption,
+  groupLabel: string | null,
+) => string;
+
+const getHaystack: CardSelectHaystackFunction = (
+  option: CardSelectOption,
+  groupLabel: string | null,
+): string => {
+  return `${option.title} ${option.description} ${groupLabel || ""} ${(
+    option.keywords || []
+  ).join(" ")}`.toLowerCase();
+};
+
+/**
+ * Does this card match every word typed?
+ *
+ * Every word, anywhere across title, description, group heading and keywords -
+ * not the whole search string as one substring. Matching the words separately
+ * is what lets "expired cert" and "cert expired" both find SSL Certificate.
+ * The same rule the workflow component palette settled on, for the same
+ * reason: in a catalog this size, browsing is not a fallback.
+ */
+export type CardSelectMatchesSearchFunction = (
+  option: CardSelectOption,
+  tokens: Array<string>,
+  groupLabel?: string | null | undefined,
+) => boolean;
+
+export const cardSelectOptionMatchesSearch: CardSelectMatchesSearchFunction = (
+  option: CardSelectOption,
+  tokens: Array<string>,
+  groupLabel?: string | null | undefined,
+): boolean => {
+  if (tokens.length === 0) {
+    return true;
+  }
+
+  const haystack: string = getHaystack(option, groupLabel || null);
+
+  return tokens.every((token: string) => {
+    return haystack.includes(token);
+  });
+};
+
+type CardSelectScoreForTokenFunction = (
+  option: CardSelectOption,
+  groupLabel: string | null,
+  searchTerm: string,
+) => number;
+
+const getSearchScoreForToken: CardSelectScoreForTokenFunction = (
+  option: CardSelectOption,
+  groupLabel: string | null,
+  searchTerm: string,
+): number => {
+  const title: string = option.title.toLowerCase();
+  const description: string = option.description.toLowerCase();
+  const label: string = (groupLabel || "").toLowerCase();
+  const keywords: Array<string> = (option.keywords || []).map(
+    (keyword: string) => {
+      return keyword.toLowerCase();
+    },
+  );
+
+  let score: number = 0;
+
+  if (title === searchTerm) {
+    score += 200;
+  } else if (title.startsWith(searchTerm)) {
+    score += 140;
+  } else if (title.includes(searchTerm)) {
+    score += 100;
+  }
+
+  /*
+   * An exact keyword hit is the strongest signal there is after the title
+   * itself: someone who types "k8s" or "postgres" has named the thing, they
+   * just have not named it the way the card does.
+   */
+  if (
+    keywords.some((keyword: string) => {
+      return keyword === searchTerm;
+    })
+  ) {
+    score += 120;
+  } else if (
+    keywords.some((keyword: string) => {
+      return keyword.startsWith(searchTerm);
+    })
+  ) {
+    score += 80;
+  } else if (
+    keywords.some((keyword: string) => {
+      return keyword.includes(searchTerm);
+    })
+  ) {
+    score += 50;
+  }
+
+  if (label.startsWith(searchTerm)) {
+    score += 75;
+  } else if (label.includes(searchTerm)) {
+    score += 55;
+  }
+
+  if (description.includes(searchTerm)) {
+    score += 35;
+  }
+
+  if (
+    title.split(" ").some((word: string) => {
+      return word.trim().startsWith(searchTerm);
+    })
+  ) {
+    score += 15;
+  }
+
+  return score;
+};
+
+/**
+ * Ranking, summed over the words typed.
+ */
+export type CardSelectSearchScoreFunction = (
+  option: CardSelectOption,
+  tokens: Array<string>,
+  groupLabel?: string | null | undefined,
+) => number;
+
+export const getCardSelectOptionSearchScore: CardSelectSearchScoreFunction = (
+  option: CardSelectOption,
+  tokens: Array<string>,
+  groupLabel?: string | null | undefined,
+): number => {
+  return tokens.reduce((total: number, token: string) => {
+    return total + getSearchScoreForToken(option, groupLabel || null, token);
+  }, 0);
+};
+
+interface ScoredOption {
+  option: CardSelectOption;
+  groupLabel: string | null;
+  score: number;
+}
+
+type NormalizeGroupsFunction = (
+  options: Array<CardSelectOption | CardSelectOptionGroup>,
+) => Array<RenderGroup>;
+
+/*
+ * Flat options and groups can be interleaved by the caller, so a run of flat
+ * options becomes its own unlabelled group wherever it appears.
+ */
+export const normalizeCardSelectGroups: NormalizeGroupsFunction = (
+  options: Array<CardSelectOption | CardSelectOptionGroup>,
+): Array<RenderGroup> => {
   const groups: Array<RenderGroup> = [];
   let ungroupedOptions: Array<CardSelectOption> = [];
 
-  for (const option of props.options) {
+  for (const option of options) {
     if (isCardSelectOptionGroup(option)) {
-      // Flush any accumulated ungrouped options first
       if (ungroupedOptions.length > 0) {
         groups.push({ label: null, options: ungroupedOptions });
         ungroupedOptions = [];
@@ -64,117 +262,528 @@ const CardSelect: FunctionComponent<ComponentProps> = (
     groups.push({ label: null, options: ungroupedOptions });
   }
 
-  let cardIndex: number = 0;
+  return groups;
+};
+
+const CardSelect: FunctionComponent<ComponentProps> = (
+  props: ComponentProps,
+): ReactElement => {
+  const [search, setSearch] = useState<string>("");
+  const searchInputRef: React.RefObject<HTMLInputElement> =
+    useRef<HTMLInputElement>(null);
+  const containerRef: React.RefObject<HTMLDivElement> =
+    useRef<HTMLDivElement>(null);
+
+  /*
+   * Groups the user has toggled by hand, by label. Anything absent falls back
+   * to the default below, so a group does not spring shut again the moment
+   * the selection moves elsewhere.
+   */
+  const [toggledGroups, setToggledGroups] = useState<Record<string, boolean>>(
+    {},
+  );
+
+  const groups: Array<RenderGroup> = useMemo(() => {
+    return normalizeCardSelectGroups(props.options);
+  }, [props.options]);
+
+  const tokens: Array<string> = useMemo(() => {
+    return getCardSelectSearchTokens(search);
+  }, [search]);
+
+  const isSearching: boolean = tokens.length > 0;
+
+  const totalOptionCount: number = useMemo(() => {
+    return groups.reduce((total: number, group: RenderGroup) => {
+      return total + group.options.length;
+    }, 0);
+  }, [groups]);
+
+  /*
+   * A search flattens the groups. Ranked results in nine separate headed
+   * sections would bury the best match under whichever heading happens to
+   * come first, which is the problem the search is there to solve.
+   */
+  const { searchResults, isShowingClosestMatches } = useMemo((): {
+    searchResults: Array<ScoredOption>;
+    isShowingClosestMatches: boolean;
+  } => {
+    if (!isSearching) {
+      return { searchResults: [], isShowingClosestMatches: false };
+    }
+
+    type CollectFunction = (requireEveryWord: boolean) => Array<ScoredOption>;
+
+    const collect: CollectFunction = (
+      requireEveryWord: boolean,
+    ): Array<ScoredOption> => {
+      const scored: Array<ScoredOption> = [];
+
+      for (const group of groups) {
+        for (const option of group.options) {
+          const matches: boolean = requireEveryWord
+            ? cardSelectOptionMatchesSearch(option, tokens, group.label)
+            : tokens.some((token: string) => {
+                return cardSelectOptionMatchesSearch(
+                  option,
+                  [token],
+                  group.label,
+                );
+              });
+
+          if (!matches) {
+            continue;
+          }
+
+          scored.push({
+            option: option,
+            groupLabel: group.label,
+            score: getCardSelectOptionSearchScore(option, tokens, group.label),
+          });
+        }
+      }
+
+      return scored.sort((a: ScoredOption, b: ScoredOption) => {
+        const scoreDifference: number = b.score - a.score;
+
+        if (scoreDifference !== 0) {
+          return scoreDifference;
+        }
+
+        return a.option.title.localeCompare(b.option.title);
+      });
+    };
+
+    const everyWord: Array<ScoredOption> = collect(true);
+
+    if (everyWord.length > 0) {
+      return { searchResults: everyWord, isShowingClosestMatches: false };
+    }
+
+    /*
+     * Nothing contains every word. Rather than a dead end, fall back to the
+     * cards matching any of them, ranked the same way - someone who typed
+     * "postgres uptime" gets SQL Query rather than an empty panel. With a
+     * single word this is the same query, so it correctly stays empty.
+     */
+    const anyWord: Array<ScoredOption> = collect(false);
+
+    return {
+      searchResults: anyWord,
+      isShowingClosestMatches: anyWord.length > 0,
+    };
+  }, [groups, tokens, isSearching]);
+
+  type IsGroupExpandedFunction = (
+    group: RenderGroup,
+    groupIndex: number,
+  ) => boolean;
+
+  const isGroupExpanded: IsGroupExpandedFunction = (
+    group: RenderGroup,
+    groupIndex: number,
+  ): boolean => {
+    // Unlabelled groups have no header to collapse behind.
+    if (!props.collapsibleGroups || !group.label) {
+      return true;
+    }
+
+    const toggled: boolean | undefined = toggledGroups[group.label];
+
+    if (toggled !== undefined) {
+      return toggled;
+    }
+
+    // The group holding the current selection, so re-entering a form shows it.
+    if (
+      props.value &&
+      group.options.some((option: CardSelectOption) => {
+        return option.value === props.value;
+      })
+    ) {
+      return true;
+    }
+
+    /*
+     * The first group is the common case in every catalog that bothers to
+     * order itself, so it is the one worth opening for a user who has not
+     * told us anything yet.
+     */
+    return groupIndex === 0;
+  };
+
+  const gridClassName: string = props.singleColumn
+    ? "grid grid-cols-1 gap-4"
+    : "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3";
+
+  /*
+   * The cards on screen, in the order they are rendered. A search reorders
+   * them and a folded group removes them, so this is recomputed rather than
+   * taken from props.
+   */
+  const visibleOptionValues: Array<string> = useMemo(() => {
+    if (isSearching) {
+      return searchResults.map((result: ScoredOption) => {
+        return result.option.value;
+      });
+    }
+
+    const values: Array<string> = [];
+
+    groups.forEach((group: RenderGroup, groupIndex: number) => {
+      if (!isGroupExpanded(group, groupIndex)) {
+        return;
+      }
+
+      for (const option of group.options) {
+        values.push(option.value);
+      }
+    });
+
+    return values;
+    /*
+     * isGroupExpanded is read here rather than listed: it is rebuilt every
+     * render, and everything it actually depends on - the groups, the manual
+     * toggles and the current value - is in the list.
+     */
+  }, [groups, isSearching, searchResults, toggledGroups, props.value]);
+
+  /*
+   * One tab stop for the whole group, which is what a radiogroup is supposed
+   * to be. Every card used to get its own increasing tabIndex - with the 0
+   * that FormField passes, that produced 1, 2, 3 ... 28: positive values,
+   * which jump ahead of every other control on the page in tab order. Arrow
+   * keys move between the cards once the group has focus.
+   */
+  const activeOptionValue: string | undefined =
+    props.value && visibleOptionValues.includes(props.value)
+      ? props.value
+      : visibleOptionValues[0];
+
+  type FocusCardFunction = (value: string) => void;
+
+  const focusCard: FocusCardFunction = (value: string): void => {
+    const card: HTMLElement | null =
+      containerRef.current?.querySelector(
+        `[data-card-select-value="${CSS.escape(value)}"]`,
+      ) || null;
+
+    card?.focus();
+  };
+
+  type MoveFocusFunction = (fromValue: string, offset: number) => void;
+
+  const moveFocus: MoveFocusFunction = (
+    fromValue: string,
+    offset: number,
+  ): void => {
+    const currentIndex: number = visibleOptionValues.indexOf(fromValue);
+
+    if (currentIndex < 0) {
+      return;
+    }
+
+    /*
+     * Clamped rather than wrapping: running off the end of a 29 card grid and
+     * landing back at the top reads as a glitch, not as navigation.
+     */
+    const nextIndex: number = Math.min(
+      Math.max(currentIndex + offset, 0),
+      visibleOptionValues.length - 1,
+    );
+
+    const nextValue: string | undefined = visibleOptionValues[nextIndex];
+
+    if (!nextValue || nextValue === fromValue) {
+      return;
+    }
+
+    focusCard(nextValue);
+  };
+
+  type RenderCardFunction = (option: CardSelectOption) => ReactElement;
+
+  const renderCard: RenderCardFunction = (
+    option: CardSelectOption,
+  ): ReactElement => {
+    const isSelected: boolean = props.value === option.value;
+
+    return (
+      <div
+        key={option.value}
+        tabIndex={option.value === activeOptionValue ? props.tabIndex || 0 : -1}
+        data-card-select-value={option.value}
+        onClick={() => {
+          props.onChange(option.value);
+        }}
+        onKeyDown={(e: React.KeyboardEvent) => {
+          /*
+           * Manual activation: arrows move focus, Enter or Space chooses.
+           * Selecting on focus would fire onChange for every card arrowed
+           * past, and on this form that resets the criteria below.
+           */
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            props.onChange(option.value);
+            return;
+          }
+
+          if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+            e.preventDefault();
+            moveFocus(option.value, 1);
+            return;
+          }
+
+          if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+            e.preventDefault();
+            moveFocus(option.value, -1);
+          }
+        }}
+        className={`relative flex cursor-pointer rounded-lg border p-4 shadow-sm transition-all duration-200 hover:border-indigo-400 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${
+          isSelected
+            ? "border-indigo-500 bg-indigo-50/50"
+            : "border-gray-200 bg-white"
+        }`}
+        role="radio"
+        aria-checked={isSelected}
+        data-testid={`card-select-option-${option.value}`}
+      >
+        <div className="flex w-full items-start">
+          <div
+            className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg ${
+              isSelected ? "bg-indigo-100" : "bg-gray-100"
+            }`}
+          >
+            <Icon
+              icon={option.icon}
+              size={SizeProp.Large}
+              className={`h-5 w-5 ${
+                isSelected ? "text-indigo-600" : "text-gray-600"
+              }`}
+            />
+          </div>
+          <div className="ml-4 flex-1">
+            <span
+              className={`block text-sm font-semibold ${
+                isSelected ? "text-gray-900" : "text-gray-900"
+              }`}
+            >
+              {option.title}
+            </span>
+            <span
+              className={`mt-1 block text-sm ${
+                isSelected ? "text-gray-600" : "text-gray-500"
+              }`}
+            >
+              {option.description}
+            </span>
+          </div>
+          {isSelected && (
+            <div className="flex-shrink-0 ml-2">
+              <Icon
+                icon={IconProp.CheckCircle}
+                size={SizeProp.Large}
+                className="h-5 w-5 text-indigo-500"
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
 
   return (
     <div data-testid={props.dataTestId}>
+      {props.searchable && (
+        <div className="mb-5">
+          <div className="relative flex items-center gap-3 rounded-lg border border-gray-300 bg-white px-3 py-2 shadow-sm transition-all duration-200 focus-within:border-indigo-500 focus-within:ring-1 focus-within:ring-indigo-500">
+            <Icon
+              icon={IconProp.Search}
+              className="h-4 w-4 flex-shrink-0 text-gray-400"
+            />
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={search}
+              placeholder={props.searchPlaceholder || "Search"}
+              autoComplete="off"
+              aria-label={props.searchPlaceholder || "Search"}
+              data-testid="card-select-search"
+              className="block w-full border-0 bg-transparent p-0 text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-0"
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                setSearch(event.target.value);
+              }}
+              onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+                if (event.key === "Escape" && search.length > 0) {
+                  /*
+                   * Stops the keypress reaching a modal or side over that
+                   * would take a clear-the-search Escape as close-the-form.
+                   */
+                  event.stopPropagation();
+                  event.preventDefault();
+                  setSearch("");
+                  return;
+                }
+
+                /*
+                 * Type a couple of letters, press Enter, done - the whole
+                 * point of the search box for someone who already knows what
+                 * they want. Left alone when there is nothing to choose.
+                 */
+                if (event.key === "Enter" && searchResults[0]) {
+                  event.preventDefault();
+                  props.onChange(searchResults[0].option.value);
+                  return;
+                }
+
+                // The only way into the grid without reaching for the mouse.
+                if (event.key === "ArrowDown" && activeOptionValue) {
+                  event.preventDefault();
+                  focusCard(activeOptionValue);
+                }
+              }}
+            />
+            {search.length > 0 && (
+              <button
+                type="button"
+                aria-label="Clear search"
+                data-testid="card-select-search-clear"
+                className="flex flex-shrink-0 items-center text-gray-400 hover:text-gray-600"
+                onClick={() => {
+                  setSearch("");
+                  searchInputRef.current?.focus();
+                }}
+              >
+                <Icon icon={IconProp.Close} className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+          <p
+            className="mt-2 text-xs text-gray-500"
+            data-testid="card-select-search-summary"
+            role="status"
+          >
+            {isSearching
+              ? isShowingClosestMatches
+                ? `Showing ${searchResults.length} closest of ${totalOptionCount}`
+                : `Showing ${searchResults.length} of ${totalOptionCount}`
+              : `${totalOptionCount} to choose from. Search by name, category, or what you want to watch.`}
+          </p>
+        </div>
+      )}
+
       <div
+        ref={containerRef}
         role="radiogroup"
         aria-label="Select an option"
         aria-labelledby={props.ariaLabelledby}
       >
-        {groups.map((group: RenderGroup, groupIndex: number) => {
-          return (
-            <div key={groupIndex} className={groupIndex > 0 ? "mt-8" : ""}>
-              {group.label && (
-                <div className="relative mb-4">
-                  <div
-                    className="absolute inset-0 flex items-center"
-                    aria-hidden="true"
-                  >
-                    <div className="w-full border-t border-gray-200"></div>
+        {isSearching && isShowingClosestMatches && (
+          <p
+            className="mb-4 text-sm text-gray-500"
+            data-testid="card-select-closest-matches"
+          >
+            Nothing matches every word you typed. Closest matches:
+          </p>
+        )}
+
+        {isSearching && (
+          <div className={gridClassName}>
+            {searchResults.map((result: ScoredOption) => {
+              return renderCard(result.option);
+            })}
+          </div>
+        )}
+
+        {isSearching && searchResults.length === 0 && (
+          <div
+            className="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-6 text-center"
+            data-testid="card-select-no-results"
+          >
+            <p className="text-sm font-medium text-gray-900">
+              Nothing matches every word you typed.
+            </p>
+            <p className="mt-1 text-sm text-gray-500">
+              Try fewer words, or a protocol or product name.
+            </p>
+            <button
+              type="button"
+              className="mt-3 text-sm font-medium text-indigo-600 hover:text-indigo-500"
+              onClick={() => {
+                setSearch("");
+                searchInputRef.current?.focus();
+              }}
+            >
+              Clear search
+            </button>
+          </div>
+        )}
+
+        {!isSearching &&
+          groups.map((group: RenderGroup, groupIndex: number) => {
+            const expanded: boolean = isGroupExpanded(group, groupIndex);
+            const canCollapse: boolean = Boolean(
+              props.collapsibleGroups && group.label,
+            );
+
+            return (
+              <div key={groupIndex} className={groupIndex > 0 ? "mt-8" : ""}>
+                {group.label && !canCollapse && (
+                  <div className="relative mb-4">
+                    <div
+                      className="absolute inset-0 flex items-center"
+                      aria-hidden="true"
+                    >
+                      <div className="w-full border-t border-gray-200"></div>
+                    </div>
+                    <div className="relative flex justify-start">
+                      <span className="bg-white pr-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
+                        {group.label}
+                      </span>
+                    </div>
                   </div>
-                  <div className="relative flex justify-start">
-                    <span className="bg-white pr-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
+                )}
+
+                {group.label && canCollapse && (
+                  <button
+                    type="button"
+                    aria-expanded={expanded}
+                    data-testid={`card-select-group-${group.label}`}
+                    className="mb-4 flex w-full items-center gap-2 border-b border-gray-200 pb-2 text-left"
+                    onClick={() => {
+                      setToggledGroups((previous: Record<string, boolean>) => {
+                        return {
+                          ...previous,
+                          [group.label as string]: !expanded,
+                        };
+                      });
+                    }}
+                  >
+                    <Icon
+                      icon={
+                        expanded ? IconProp.ChevronDown : IconProp.ChevronRight
+                      }
+                      className="h-4 w-4 flex-shrink-0 text-gray-400"
+                    />
+                    <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">
                       {group.label}
                     </span>
-                  </div>
-                </div>
-              )}
-              <div
-                className={
-                  props.singleColumn
-                    ? "grid grid-cols-1 gap-4"
-                    : "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
-                }
-              >
-                {group.options.map((option: CardSelectOption) => {
-                  const isSelected: boolean = props.value === option.value;
-                  const currentIndex: number = cardIndex++;
+                    <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
+                      {group.options.length}
+                    </span>
+                  </button>
+                )}
 
-                  return (
-                    <div
-                      key={option.value}
-                      tabIndex={
-                        props.tabIndex
-                          ? props.tabIndex + currentIndex
-                          : currentIndex
-                      }
-                      onClick={() => {
-                        props.onChange(option.value);
-                      }}
-                      onKeyDown={(e: React.KeyboardEvent) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.preventDefault();
-                          props.onChange(option.value);
-                        }
-                      }}
-                      className={`relative flex cursor-pointer rounded-lg border p-4 shadow-sm focus:outline-none transition-all duration-200 hover:border-indigo-400 hover:shadow-md ${
-                        isSelected
-                          ? "border-indigo-500 bg-indigo-50/50"
-                          : "border-gray-200 bg-white"
-                      }`}
-                      role="radio"
-                      aria-checked={isSelected}
-                      data-testid={`card-select-option-${option.value}`}
-                    >
-                      <div className="flex w-full items-start">
-                        <div
-                          className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg ${
-                            isSelected ? "bg-indigo-100" : "bg-gray-100"
-                          }`}
-                        >
-                          <Icon
-                            icon={option.icon}
-                            size={SizeProp.Large}
-                            className={`h-5 w-5 ${
-                              isSelected ? "text-indigo-600" : "text-gray-600"
-                            }`}
-                          />
-                        </div>
-                        <div className="ml-4 flex-1">
-                          <span
-                            className={`block text-sm font-semibold ${
-                              isSelected ? "text-gray-900" : "text-gray-900"
-                            }`}
-                          >
-                            {option.title}
-                          </span>
-                          <span
-                            className={`mt-1 block text-sm ${
-                              isSelected ? "text-gray-600" : "text-gray-500"
-                            }`}
-                          >
-                            {option.description}
-                          </span>
-                        </div>
-                        {isSelected && (
-                          <div className="flex-shrink-0 ml-2">
-                            <Icon
-                              icon={IconProp.CheckCircle}
-                              size={SizeProp.Large}
-                              className="h-5 w-5 text-indigo-500"
-                            />
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
+                {expanded && (
+                  <div className={gridClassName}>
+                    {group.options.map((option: CardSelectOption) => {
+                      return renderCard(option);
+                    })}
+                  </div>
+                )}
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
       </div>
       {props.error && (
         <p className="mt-2 text-sm text-red-600" role="alert">

--- a/Common/UI/Components/Forms/Fields/FormField.tsx
+++ b/Common/UI/Components/Forms/Fields/FormField.tsx
@@ -521,6 +521,9 @@ const FormField: <T extends GenericObject>(
               tabIndex={0}
               dataTestId={props.field.dataTestId}
               singleColumn={props.field.cardSelectSingleColumn}
+              searchable={props.field.cardSelectSearchable}
+              searchPlaceholder={props.field.cardSelectSearchPlaceholder}
+              collapsibleGroups={props.field.cardSelectCollapsibleGroups}
               onChange={(value: string) => {
                 onChange(value);
                 props.setFieldValue(props.fieldName, value);

--- a/Common/UI/Components/Forms/Types/Field.ts
+++ b/Common/UI/Components/Forms/Types/Field.ts
@@ -58,6 +58,14 @@ export default interface Field<TEntity> {
     | Array<CardSelectOption | CardSelectOptionGroup>
     | undefined;
   cardSelectSingleColumn?: boolean | undefined;
+  /*
+   * Give the card picker a search box and collapse its groups behind their
+   * headers. Both are opt in: a picker with a handful of cards reads fine as
+   * a plain grid, and turning them on there would only add chrome.
+   */
+  cardSelectSearchable?: boolean | undefined;
+  cardSelectSearchPlaceholder?: string | undefined;
+  cardSelectCollapsibleGroups?: boolean | undefined;
   fetchDropdownOptions?:
     | ((
         item: FormValues<TEntity>,


### PR DESCRIPTION
## The problem

The Create Monitor form offered **all 29 monitor types at once** — nine category headings, 29 cards, about 3,250 CSS pixels of them — with no way to narrow the list. Every description opened with the same five words ("This monitor type lets you monitor…"), so there was nothing to scan by. Groups holding one or two types left half-empty rows.

And browsing can't rescue you: the vocabulary on the cards is ours ("SQL Query", "Incoming Request"), the vocabulary in your head is the world's ("postgres", "heartbeat"). You cannot browse your way to *SQL Query* if the word you know is *mysql*.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/OneUptime/oneuptime/claude/monitor-picker-screenshots/1-before.png" width="420"> | <img src="https://raw.githubusercontent.com/OneUptime/oneuptime/claude/monitor-picker-screenshots/2-after-default.png" width="420"> |
| 29 cards, ~3,250px | 8 cards + 8 folded headings, ~1,170px |

## What changed

**Search.** `CardSelect` gains an opt-in search box. It matches **every word typed** across a card's title, description, category heading and a new keywords list, then ranks by how well each matched. The token-AND matching and scoring bands follow [`ComponentsModal.tsx`](https://github.com/OneUptime/oneuptime/blob/master/Common/UI/Components/Workflow/ComponentsModal.tsx) — the workflow component palette solved this exact problem for this exact reason, so this is the house pattern rather than a new one.

**Keywords.** Every monitor type now carries the words people actually type but that appear nowhere on the card: `k8s`, `postgres`, `heartbeat`, `tls`, `icmp`, `snmp`, `whois`, `prometheus`, `playwright`, `lxc`, `osd`, and so on. Without these, search only finds types whose OneUptime name you already knew — which is the whole difficulty.

**Folding.** Categories collapse behind their headings with a count. The first category and the one holding the current selection start open, so first paint is the eight everyday types, and returning to a half-filled form still shows the choice already made.

**Copy.** All 29 descriptions rewritten to one scannable line.

<table>
<tr><td width="50%"><img src="https://raw.githubusercontent.com/OneUptime/oneuptime/claude/monitor-picker-screenshots/3-after-search-k8s.png"><br><sub><code>k8s</code> → Kubernetes</sub></td>
<td width="50%"><img src="https://raw.githubusercontent.com/OneUptime/oneuptime/claude/monitor-picker-screenshots/4-after-search-postgres.png"><br><sub><code>postgres</code> → SQL Query</sub></td></tr>
<tr><td><img src="https://raw.githubusercontent.com/OneUptime/oneuptime/claude/monitor-picker-screenshots/5-after-closest.png"><br><sub>No card has every word → closest matches, not a dead end</sub></td>
<td><img src="https://raw.githubusercontent.com/OneUptime/oneuptime/claude/monitor-picker-screenshots/6-after-noresults.png"><br><sub>Genuinely nothing → says so, with a way back</sub></td></tr>
</table>

<details><summary>Narrow viewport (420px)</summary>

<img src="https://raw.githubusercontent.com/OneUptime/oneuptime/claude/monitor-picker-screenshots/7-after-mobile.png" width="320">
</details>

## Keyboard fix

`CardSelect` gave every card its own increasing `tabIndex`. With the `0` that `FormField` passes, that produced `1, 2, 3 … 28` — **positive** tab indices, which jump the whole grid ahead of every other control on the page, and 29 of them to tab through. Combined with `focus:outline-none` and no replacement ring, the field was effectively unusable by keyboard.

Now: one tab stop for the radiogroup, arrow keys between cards, activation on Enter/Space only (selecting on focus would fire `onChange` for every card arrowed past, and on this form that resets the criteria built below), and a visible focus ring. `Enter` in the search box picks the top result; `ArrowDown` moves from the search box into the grid.

## Blast radius

Both new props default to **off**. `CardSelect`'s two other callers — the team role picker and the metrics pipeline rule picker — render exactly what they did before, and a test pins that. The three pages that *do* offer the full catalog all get the improvement: **Create**, **Monitor Templates**, and **Monitor Template View**.

No API, schema, or migration changes.

## Tests

**205 new tests across four files.** `CardSelect` had no test file at all before this.

| File | Tests | Covers |
|---|---|---|
| `Common/Tests/UI/Components/CardSelect.test.tsx` | 87 | Unchanged default rendering, selection, a11y, search, ranking, closest-matches fallback, folding, keyboard, and the four exported pure functions |
| `Common/Tests/Types/Monitor/MonitorTypeKeywords.test.ts` | 54 | Keyword hygiene across all 31 types; 35 table-driven searches asserting *which* type ranks first; no duplicate categories; boilerplate copy gone |
| `Common/Tests/App/Dashboard/MonitorTypePicker.test.tsx` | 26 | The real dashboard catalog through the real picker — keywords survive the adapter, first paint, search, browse, returning selection |
| `App/Tests/Dashboard/MonitorTypePickerWiring.test.ts` | 18 | All three pages wired; the two other callers left alone |

Verified locally: 268 Common tests pass (including the pre-existing `MonitorType`, `ComponentsModal` and `PayAsYouGoConsentGate` suites, the last of which drives the real create form), 41 App tests pass, `tsc --noEmit` clean for `Common` and `App/FeatureSet/Dashboard`, `eslint` clean.

## Notes for the reviewer

- **Search dissolves the groups.** Ranked results re-split under nine headings would bury the best match under whichever heading sorts first — the exact problem search exists to solve. This deliberately differs from `ComponentsModal`, which re-groups after ranking.
- **Screenshots** are hosted on the image-only branch `claude/monitor-picker-screenshots` so no binaries land in the source tree. Please delete that branch after merge.
- Two monitor types, `Server / VM` and `Profiles`, are in the enum but in no category, so they are not offered by the picker. That is pre-existing and unchanged here — `Profiles` is documented as deliberate.
