### PR TITLE
fix(probe): honour configured retry count and timeout on DNS, DNSSEC, Domain, SNMP and external status page steps

### DIFF
--- a/Probe/Tests/Utils/Monitors/MonitorStepRetryAndTimeout.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorStepRetryAndTimeout.test.ts
@@ -1,0 +1,336 @@
+// Set required env vars before importing anything that pulls Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+/*
+ * Deliberately different from every retry count used below, so a branch that
+ * still hands the probe-wide env default to the monitor util is visible in
+ * the assertion rather than accidentally matching.
+ */
+process.env["PROBE_MONITOR_RETRY_LIMIT"] = "9";
+
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/typedef
+const mockSnmpQuery = jest.fn();
+// eslint-disable-next-line @typescript-eslint/typedef
+const mockDnsQuery = jest.fn();
+// eslint-disable-next-line @typescript-eslint/typedef
+const mockDomainQuery = jest.fn();
+// eslint-disable-next-line @typescript-eslint/typedef
+const mockDnssecQuery = jest.fn();
+// eslint-disable-next-line @typescript-eslint/typedef
+const mockExternalStatusPageFetch = jest.fn();
+
+jest.mock("../../../Utils/Monitors/MonitorTypes/SnmpMonitor", () => {
+  return {
+    __esModule: true,
+    default: {
+      query: (...args: Array<unknown>): unknown => {
+        return mockSnmpQuery(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../Utils/Monitors/MonitorTypes/DnsMonitor", () => {
+  return {
+    __esModule: true,
+    default: {
+      query: (...args: Array<unknown>): unknown => {
+        return mockDnsQuery(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../Utils/Monitors/MonitorTypes/DomainMonitor", () => {
+  return {
+    __esModule: true,
+    default: {
+      query: (...args: Array<unknown>): unknown => {
+        return mockDomainQuery(...args);
+      },
+    },
+  };
+});
+
+jest.mock("../../../Utils/Monitors/MonitorTypes/DnssecMonitor", () => {
+  return {
+    __esModule: true,
+    default: {
+      query: (...args: Array<unknown>): unknown => {
+        return mockDnssecQuery(...args);
+      },
+    },
+  };
+});
+
+jest.mock(
+  "../../../Utils/Monitors/MonitorTypes/ExternalStatusPageMonitor",
+  () => {
+    return {
+      __esModule: true,
+      default: {
+        fetch: (...args: Array<unknown>): unknown => {
+          return mockExternalStatusPageFetch(...args);
+        },
+      },
+    };
+  },
+);
+
+import MonitorUtil from "../../../Utils/Monitors/Monitor";
+import DnsRecordType from "Common/Types/Monitor/DnsMonitor/DnsRecordType";
+import DomainLookupMethod from "Common/Types/Monitor/DomainMonitor/DomainLookupMethod";
+import ExternalStatusPageProviderType from "Common/Types/Monitor/ExternalStatusPageProviderType";
+import MonitorStep from "Common/Types/Monitor/MonitorStep";
+import MonitorType from "Common/Types/Monitor/MonitorType";
+import ObjectID from "Common/Types/ObjectID";
+import SnmpVersion from "Common/Types/Monitor/SnmpMonitor/SnmpVersion";
+
+/*
+ * Follow-up to https://github.com/OneUptime/oneuptime/issues/3225.
+ *
+ * The Website/API/SSL/Port/Ping/SQL branches of probeMonitorStep pass the
+ * user's per-step retry count and timeout down to the monitor util. These five
+ * branches did not: they passed PROBE_MONITOR_RETRY_LIMIT (a probe-wide env
+ * default) as the retry count, which discarded BOTH the step-level setting and
+ * the type-specific "retries" field, because the monitor utils treat a supplied
+ * options.retry as the winner over config.retries.
+ */
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const MONITOR_ID: ObjectID = ObjectID.generate();
+
+// The env default seeded above. Any branch still leaking it fails the tests.
+const PROBE_WIDE_RETRY_DEFAULT: number = 9;
+
+interface MonitorOptions {
+  retry?: number | undefined;
+  timeout?: number | undefined;
+}
+
+type MonitorMock = { mock: { calls: Array<Array<unknown>> } };
+
+function optionsOfFirstCall(mock: MonitorMock): MonitorOptions {
+  return mock.mock.calls[0]?.[1] as MonitorOptions;
+}
+
+function newStep(): MonitorStep {
+  const step: MonitorStep = new MonitorStep();
+
+  step.data = {
+    ...(step.data as NonNullable<MonitorStep["data"]>),
+    id: ObjectID.generate().toString(),
+  } as NonNullable<MonitorStep["data"]>;
+
+  return step;
+}
+
+/*
+ * Each branch, with a type-specific config carrying retries/timeout values
+ * that differ both from the type default and from the probe-wide env default.
+ */
+interface BranchUnderTest {
+  name: string;
+  monitorType: MonitorType;
+  monitorMock: MonitorMock;
+  buildStep: () => MonitorStep;
+  configRetries: number;
+  configTimeoutInMs: number;
+}
+
+const BRANCHES: Array<BranchUnderTest> = [
+  {
+    name: "SNMP / NetworkDevice",
+    monitorType: MonitorType.NetworkDevice,
+    monitorMock: mockSnmpQuery as unknown as MonitorMock,
+    configRetries: 2,
+    configTimeoutInMs: 7000,
+    buildStep: (): MonitorStep => {
+      return newStep().setSnmpMonitor({
+        snmpVersion: SnmpVersion.V2c,
+        hostname: "10.0.0.1",
+        port: 161,
+        communityString: "public",
+        oids: [{ oid: "1.3.6.1.2.1.1.1.0", name: "sysDescr" }],
+        timeout: 7000,
+        retries: 2,
+        monitorInterfaces: false,
+      });
+    },
+  },
+  {
+    name: "DNS",
+    monitorType: MonitorType.DNS,
+    monitorMock: mockDnsQuery as unknown as MonitorMock,
+    configRetries: 2,
+    configTimeoutInMs: 7000,
+    buildStep: (): MonitorStep => {
+      return newStep().setDnsMonitor({
+        queryName: "example.com",
+        recordType: DnsRecordType.A,
+        hostname: "",
+        port: 53,
+        timeout: 7000,
+        retries: 2,
+      });
+    },
+  },
+  {
+    name: "Domain",
+    monitorType: MonitorType.Domain,
+    monitorMock: mockDomainQuery as unknown as MonitorMock,
+    configRetries: 2,
+    configTimeoutInMs: 7000,
+    buildStep: (): MonitorStep => {
+      return newStep().setDomainMonitor({
+        domainName: "example.com",
+        lookupMethod: DomainLookupMethod.Auto,
+        timeout: 7000,
+        retries: 2,
+      });
+    },
+  },
+  {
+    name: "DNSSEC",
+    monitorType: MonitorType.DNSSEC,
+    monitorMock: mockDnssecQuery as unknown as MonitorMock,
+    configRetries: 2,
+    configTimeoutInMs: 7000,
+    buildStep: (): MonitorStep => {
+      return newStep().setDnssecMonitor({
+        domainName: "example.com",
+        resolvers: ["1.1.1.1"],
+        checkNameserverConsistency: false,
+        signatureExpiryWarningDays: 7,
+        timeout: 7000,
+        retries: 2,
+      });
+    },
+  },
+  {
+    name: "External Status Page",
+    monitorType: MonitorType.ExternalStatusPage,
+    monitorMock: mockExternalStatusPageFetch as unknown as MonitorMock,
+    configRetries: 2,
+    configTimeoutInMs: 7000,
+    buildStep: (): MonitorStep => {
+      return newStep().setExternalStatusPageMonitor({
+        statusPageUrl: "https://status.example.com",
+        provider: ExternalStatusPageProviderType.Auto,
+        timeout: 7000,
+        retries: 2,
+      });
+    },
+  },
+];
+
+beforeEach(() => {
+  for (const mock of [
+    mockSnmpQuery,
+    mockDnsQuery,
+    mockDomainQuery,
+    mockDnssecQuery,
+    mockExternalStatusPageFetch,
+  ]) {
+    mock.mockReset();
+    mock.mockResolvedValue({
+      isOnline: true,
+      isTimeout: false,
+      responseTimeInMs: 12,
+      failureCause: "",
+    } as never);
+  }
+});
+
+describe.each(BRANCHES)(
+  "$name step passes the user's retry count and timeout through",
+  (branch: BranchUnderTest) => {
+    test("uses the step-level retry count and timeout when the user set them", async () => {
+      const step: MonitorStep = branch.buildStep();
+      step.setRetryCount(1);
+      step.setRequestTimeoutInMs(4321);
+
+      await MonitorUtil.probeMonitorStep({
+        monitorStep: step,
+        monitorType: branch.monitorType,
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+      });
+
+      const options: MonitorOptions = optionsOfFirstCall(branch.monitorMock);
+
+      expect(options.retry).toBe(1);
+      expect(options.timeout).toBe(4321);
+    });
+
+    test("honours a step-level retry count of zero", async () => {
+      const step: MonitorStep = branch.buildStep();
+      step.setRetryCount(0);
+
+      await MonitorUtil.probeMonitorStep({
+        monitorStep: step,
+        monitorType: branch.monitorType,
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+      });
+
+      /*
+       * "No retries" is a real answer, not a missing one - it must not fall
+       * back to a default.
+       */
+      expect(optionsOfFirstCall(branch.monitorMock).retry).toBe(0);
+    });
+
+    test("clamps a step-level retry count above the documented maximum", async () => {
+      const step: MonitorStep = branch.buildStep();
+      // setRetryCount clamps too; assign directly to test the probe-side clamp.
+      step.data!.retryCount = 99;
+
+      await MonitorUtil.probeMonitorStep({
+        monitorStep: step,
+        monitorType: branch.monitorType,
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+      });
+
+      expect(optionsOfFirstCall(branch.monitorMock).retry).toBe(3);
+    });
+
+    test("falls back to the type-specific config, not the probe-wide env default", async () => {
+      const step: MonitorStep = branch.buildStep();
+
+      await MonitorUtil.probeMonitorStep({
+        monitorStep: step,
+        monitorType: branch.monitorType,
+        monitorId: MONITOR_ID,
+        projectId: PROJECT_ID,
+      });
+
+      const options: MonitorOptions = optionsOfFirstCall(branch.monitorMock);
+
+      /*
+       * The retries/timeout fields on the type-specific form are the only
+       * ones these monitor types expose, so they have to win over the env
+       * default when the step carries no override of its own.
+       */
+      expect(options.retry).toBe(branch.configRetries);
+      expect(options.retry).not.toBe(PROBE_WIDE_RETRY_DEFAULT);
+      expect(options.timeout).toBe(branch.configTimeoutInMs);
+    });
+  },
+);

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/DnsMonitorTimeout.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/DnsMonitorTimeout.test.ts
@@ -1,0 +1,129 @@
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  };
+});
+
+interface ResolverOptions {
+  timeout?: number | undefined;
+}
+
+// Every Resolver the util builds, in construction order.
+const resolverOptions: Array<ResolverOptions> = [];
+// Every execFile("dig", ...) the util issues, with the options it passed.
+const digCalls: Array<{ args: Array<string>; timeout: number | undefined }> =
+  [];
+
+class FakeResolver {
+  public constructor(options: ResolverOptions) {
+    resolverOptions.push(options);
+  }
+
+  public setServers(): void {
+    // no-op: these tests never talk to a real resolver.
+  }
+
+  public async resolve4(): Promise<Array<{ address: string; ttl: number }>> {
+    return [{ address: "192.0.2.1", ttl: 60 }];
+  }
+}
+
+jest.mock("dns", () => {
+  return {
+    __esModule: true,
+    default: {
+      promises: {
+        Resolver: FakeResolver,
+      },
+    },
+  };
+});
+
+jest.mock("child_process", () => {
+  return {
+    __esModule: true,
+    execFile: (
+      _file: string,
+      args: Array<string>,
+      options: { timeout?: number | undefined },
+      callback: (error: Error | null, stdout: string) => void,
+    ): void => {
+      digCalls.push({ args: args, timeout: options?.timeout });
+      callback(null, ";; flags: qr rd ra ad;\n");
+    },
+  };
+});
+
+import DnsMonitorUtil from "../../../../Utils/Monitors/MonitorTypes/DnsMonitor";
+import DnsRecordType from "Common/Types/Monitor/DnsMonitor/DnsRecordType";
+import MonitorStepDnsMonitor from "Common/Types/Monitor/MonitorStepDnsMonitor";
+
+/*
+ * Follow-up to https://github.com/OneUptime/oneuptime/issues/3225.
+ *
+ * DnsMonitorUtil.query built its resolver from config.timeout alone, so the
+ * per-step timeout handed to it in options.timeout was silently dropped.
+ */
+
+function buildConfig(input?: {
+  timeout?: number;
+  retries?: number;
+}): MonitorStepDnsMonitor {
+  return {
+    queryName: "example.com",
+    recordType: DnsRecordType.A,
+    hostname: "",
+    port: 53,
+    timeout: input?.timeout ?? 5000,
+    retries: input?.retries ?? 3,
+  };
+}
+
+beforeEach(() => {
+  resolverOptions.length = 0;
+  digCalls.length = 0;
+});
+
+describe("DnsMonitorUtil timeout precedence", () => {
+  test("prefers an explicitly supplied options.timeout over the config default", async () => {
+    await DnsMonitorUtil.query(buildConfig({ timeout: 5000 }), {
+      timeout: 1234,
+      isOnlineCheckRequest: true,
+    });
+
+    expect(resolverOptions[0]?.timeout).toBe(1234);
+  });
+
+  test("falls back to the config timeout when the caller supplies none", async () => {
+    await DnsMonitorUtil.query(buildConfig({ timeout: 5000 }), {
+      isOnlineCheckRequest: true,
+    });
+
+    expect(resolverOptions[0]?.timeout).toBe(5000);
+  });
+
+  test("bounds the DNSSEC AD-flag dig by the same timeout", async () => {
+    await DnsMonitorUtil.query(buildConfig({ timeout: 5000 }), {
+      timeout: 1234,
+      isOnlineCheckRequest: true,
+    });
+
+    /*
+     * The AD-flag check used a hardcoded 10s, so a DNS step configured for a
+     * short timeout could still spend 10 extra seconds inside dig.
+     */
+    expect(digCalls).toHaveLength(1);
+    expect(digCalls[0]?.timeout).toBe(1234);
+  });
+});

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/DnssecMonitorTimeout.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/DnssecMonitorTimeout.test.ts
@@ -1,0 +1,213 @@
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  };
+});
+
+interface DigCall {
+  queryType: string;
+  timeout: number | undefined;
+}
+
+const digCalls: Array<DigCall> = [];
+
+/*
+ * How long each simulated dig "takes". Advancing a fake clock instead of
+ * really sleeping is what lets these tests exercise a multi-minute worst case
+ * in milliseconds.
+ */
+let digDurationMs: number = 0;
+let now: number = 1_700_000_000_000;
+
+jest.mock("child_process", () => {
+  return {
+    __esModule: true,
+    execFile: (
+      _file: string,
+      args: Array<string>,
+      options: { timeout?: number | undefined },
+      callback: (error: Error | null, stdout: string) => void,
+    ): void => {
+      /*
+       * dig args are [...flags, queryName, queryType, @resolver]; the type is
+       * the last entry before the resolver.
+       */
+      const queryType: string =
+        args.find((arg: string) => {
+          return ["DNSKEY", "DS", "SOA", "A", "NS"].includes(arg);
+        }) || "";
+
+      digCalls.push({ queryType: queryType, timeout: options?.timeout });
+
+      // A dig never outruns the timeout it was given.
+      now += Math.min(digDurationMs, options?.timeout ?? digDurationMs);
+
+      callback(null, ";; flags: qr rd ra ad;\n");
+    },
+  };
+});
+
+import DnssecMonitorUtil from "../../../../Utils/Monitors/MonitorTypes/DnssecMonitor";
+import DnssecMonitorResponse from "Common/Types/Monitor/DnssecMonitor/DnssecMonitorResponse";
+import MonitorStepDnssecMonitor from "Common/Types/Monitor/MonitorStepDnssecMonitor";
+
+/*
+ * Follow-up to https://github.com/OneUptime/oneuptime/issues/3225.
+ *
+ * Two defects: query() read config.timeout and ignored the options.timeout it
+ * was handed, and every leg (DNSKEY, DS, RRSIG, one dig per resolver, then the
+ * nameserver sweep) started a fresh full timeout, so one attempt against an
+ * unresponsive resolver ran for minutes.
+ */
+
+function buildConfig(input?: {
+  timeout?: number;
+  retries?: number;
+  resolvers?: Array<string>;
+  checkNameserverConsistency?: boolean;
+}): MonitorStepDnssecMonitor {
+  return {
+    domainName: "example.com",
+    resolvers: input?.resolvers ?? ["1.1.1.1"],
+    checkNameserverConsistency: input?.checkNameserverConsistency ?? false,
+    signatureExpiryWarningDays: 7,
+    timeout: input?.timeout ?? 10000,
+    retries: input?.retries ?? 3,
+  };
+}
+
+beforeEach(() => {
+  digCalls.length = 0;
+  digDurationMs = 0;
+  now = 1_700_000_000_000;
+  jest.spyOn(Date, "now").mockImplementation(() => {
+    return now;
+  });
+});
+
+describe("DnssecMonitorUtil timeout precedence", () => {
+  test("prefers an explicitly supplied options.timeout over the config default", async () => {
+    await DnssecMonitorUtil.query(buildConfig({ timeout: 10000 }), {
+      timeout: 1234,
+      isOnlineCheckRequest: true,
+    });
+
+    expect(digCalls.length).toBeGreaterThan(0);
+    for (const call of digCalls) {
+      expect(call.timeout).toBe(1234);
+    }
+  });
+
+  test("falls back to the config timeout when the caller supplies none", async () => {
+    await DnssecMonitorUtil.query(buildConfig({ timeout: 2500 }), {
+      isOnlineCheckRequest: true,
+    });
+
+    expect(digCalls.length).toBeGreaterThan(0);
+    for (const call of digCalls) {
+      expect(call.timeout).toBe(2500);
+    }
+  });
+});
+
+describe("DnssecMonitorUtil shared time budget across legs", () => {
+  test("caps one attempt at three times the per-leg timeout instead of one timeout per leg", async () => {
+    const startedAt: number = now;
+
+    // Every leg is slow enough to burn its whole timeout.
+    digDurationMs = 10000;
+
+    await DnssecMonitorUtil.query(
+      buildConfig({
+        timeout: 10000,
+        resolvers: ["1.1.1.1", "8.8.8.8", "9.9.9.9"],
+        checkNameserverConsistency: true,
+      }),
+      { retry: 0, isOnlineCheckRequest: true },
+    );
+
+    /*
+     * Unbudgeted this was 3 fetches + 3 resolvers + an NS sweep, i.e. seven
+     * full 10s legs and counting. The shared deadline holds one attempt to
+     * 3 x the per-leg timeout.
+     */
+    expect(now - startedAt).toBeLessThanOrEqual(30000);
+    expect(digCalls).toHaveLength(3);
+  });
+
+  test("shrinks a later leg to whatever the budget has left", async () => {
+    // Each leg answers just inside its timeout: 8s of the shared 30s budget.
+    digDurationMs = 8000;
+
+    await DnssecMonitorUtil.query(
+      buildConfig({
+        timeout: 10000,
+        resolvers: ["1.1.1.1", "8.8.8.8", "9.9.9.9"],
+      }),
+      { retry: 0, isOnlineCheckRequest: true },
+    );
+
+    /*
+     * DNSKEY, DS and RRSIG take 8s each, leaving 6s of the 30s budget. The
+     * fourth leg gets that 6s, not a fresh 10s - which is exactly the
+     * multiplication this budget exists to stop.
+     */
+    expect(digCalls[0]?.timeout).toBe(10000);
+    expect(digCalls[1]?.timeout).toBe(10000);
+    expect(digCalls[2]?.timeout).toBe(10000);
+    expect(digCalls[3]?.timeout).toBe(6000);
+
+    // And once the budget is spent, no further leg is even attempted.
+    expect(digCalls).toHaveLength(4);
+  });
+
+  test("reports a timeout rather than a fabricated DNSSEC verdict when the budget runs out", async () => {
+    digDurationMs = 10000;
+
+    const response: DnssecMonitorResponse | null =
+      await DnssecMonitorUtil.query(
+        buildConfig({
+          timeout: 10000,
+          resolvers: ["1.1.1.1", "8.8.8.8", "9.9.9.9"],
+        }),
+        { retry: 0, isOnlineCheckRequest: true },
+      );
+
+    /*
+     * The sweep never finished, so "zone not signed" / "resolvers disagree"
+     * would be an answer we never actually established. Say it timed out.
+     */
+    expect(response?.isOnline).toBe(false);
+    expect(response?.isTimeout).toBe(true);
+    expect(response?.failureCause).toContain("30000ms");
+  });
+
+  test("still completes normally when the legs finish inside the budget", async () => {
+    digDurationMs = 10;
+
+    const response: DnssecMonitorResponse | null =
+      await DnssecMonitorUtil.query(
+        buildConfig({
+          timeout: 10000,
+          resolvers: ["1.1.1.1", "8.8.8.8", "9.9.9.9"],
+          checkNameserverConsistency: true,
+        }),
+        { retry: 0, isOnlineCheckRequest: true },
+      );
+
+    expect(response?.isOnline).toBe(true);
+    expect(response?.isTimeout).toBeUndefined();
+    expect(response?.resolverChecks).toHaveLength(3);
+  });
+});

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/ExternalStatusPageMonitorTimeout.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/ExternalStatusPageMonitorTimeout.test.ts
@@ -1,0 +1,91 @@
+process.env["ONEUPTIME_URL"] = "https://oneuptime.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  };
+});
+
+interface AxiosRequestOptions {
+  timeout?: number | undefined;
+}
+
+const axiosCalls: Array<{ url: string; timeout: number | undefined }> = [];
+
+jest.mock("axios", () => {
+  return {
+    __esModule: true,
+    default: {
+      get: (url: string, options: AxiosRequestOptions): unknown => {
+        axiosCalls.push({ url: url, timeout: options?.timeout });
+
+        return Promise.resolve({
+          status: 200,
+          data: {
+            status: { indicator: "none", description: "All Systems Go" },
+            components: [],
+            incidents: [],
+          },
+        });
+      },
+    },
+  };
+});
+
+import ExternalStatusPageMonitorUtil from "../../../../Utils/Monitors/MonitorTypes/ExternalStatusPageMonitor";
+import ExternalStatusPageProviderType from "Common/Types/Monitor/ExternalStatusPageProviderType";
+import MonitorStepExternalStatusPageMonitor from "Common/Types/Monitor/MonitorStepExternalStatusPageMonitor";
+
+/*
+ * Follow-up to https://github.com/OneUptime/oneuptime/issues/3225.
+ *
+ * The provider fetchers read `config.timeout || options.timeout`, so the
+ * per-step timeout could never win over the type-specific config default.
+ */
+
+function buildConfig(timeout: number): MonitorStepExternalStatusPageMonitor {
+  return {
+    statusPageUrl: "https://status.example.com",
+    provider: ExternalStatusPageProviderType.AtlassianStatuspage,
+    timeout: timeout,
+    retries: 3,
+  };
+}
+
+beforeEach(() => {
+  axiosCalls.length = 0;
+});
+
+describe("ExternalStatusPageMonitorUtil timeout precedence", () => {
+  test("prefers an explicitly supplied options.timeout over the config default", async () => {
+    await ExternalStatusPageMonitorUtil.fetch(buildConfig(10000), {
+      timeout: 1234,
+      isOnlineCheckRequest: true,
+    });
+
+    expect(axiosCalls.length).toBeGreaterThan(0);
+    for (const call of axiosCalls) {
+      expect(call.timeout).toBe(1234);
+    }
+  });
+
+  test("falls back to the config timeout when the caller supplies none", async () => {
+    await ExternalStatusPageMonitorUtil.fetch(buildConfig(2500), {
+      isOnlineCheckRequest: true,
+    });
+
+    expect(axiosCalls.length).toBeGreaterThan(0);
+    for (const call of axiosCalls) {
+      expect(call.timeout).toBe(2500);
+    }
+  });
+});

--- a/Probe/Utils/Monitors/Monitor.ts
+++ b/Probe/Utils/Monitors/Monitor.ts
@@ -79,6 +79,54 @@ export default class MonitorUtil {
     return URL.fromString(urlString);
   }
 
+  /*
+   * DNS, DNSSEC, Domain, SNMP and External Status Page steps carry their own
+   * timeout/retries in their type-specific config - that is what their form
+   * exposes - while every other type uses the step-level settings. So the
+   * resolution order is: what the user set on the step, then what they set on
+   * the type-specific config, then the probe-wide default. Passing
+   * PROBE_MONITOR_RETRY_LIMIT straight through (as these branches used to)
+   * discarded BOTH user settings, because the monitor utils treat a supplied
+   * options.retry as the winner.
+   */
+  public static resolveRetryCount(data: {
+    stepRetryCount: number | undefined | null;
+    monitorConfigRetries: number | undefined | null;
+  }): number {
+    if (data.stepRetryCount !== undefined && data.stepRetryCount !== null) {
+      return clampMonitorRetryCount(data.stepRetryCount);
+    }
+
+    if (
+      data.monitorConfigRetries !== undefined &&
+      data.monitorConfigRetries !== null
+    ) {
+      return data.monitorConfigRetries;
+    }
+
+    return PROBE_MONITOR_RETRY_LIMIT;
+  }
+
+  // Same precedence as resolveRetryCount, for the request timeout.
+  public static resolveTimeoutInMs(data: {
+    stepRequestTimeoutInMs: number | undefined | null;
+    monitorConfigTimeoutInMs: number | undefined | null;
+    defaultTimeoutInMs: number;
+  }): number {
+    if (
+      data.stepRequestTimeoutInMs !== undefined &&
+      data.stepRequestTimeoutInMs !== null
+    ) {
+      return clampMonitorRequestTimeoutInMs(data.stepRequestTimeoutInMs);
+    }
+
+    if (data.monitorConfigTimeoutInMs) {
+      return data.monitorConfigTimeoutInMs;
+    }
+
+    return data.defaultTimeoutInMs;
+  }
+
   public static async probeMonitorTest(
     monitorTest: MonitorTest,
   ): Promise<Array<ProbeMonitorResponse | null>> {
@@ -368,21 +416,20 @@ export default class MonitorUtil {
      * Per-step request timeout (capped at the user-facing max). Falls back
      * to the global default when the user hasn't configured one.
      */
-    const requestTimeoutInMs: number =
-      monitorStep.data.requestTimeoutInMs !== undefined &&
-      monitorStep.data.requestTimeoutInMs !== null
-        ? clampMonitorRequestTimeoutInMs(monitorStep.data.requestTimeoutInMs)
-        : DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS;
+    const requestTimeoutInMs: number = MonitorUtil.resolveTimeoutInMs({
+      stepRequestTimeoutInMs: monitorStep.data.requestTimeoutInMs,
+      monitorConfigTimeoutInMs: undefined,
+      defaultTimeoutInMs: DEFAULT_MONITOR_REQUEST_TIMEOUT_IN_MS,
+    });
 
     /*
      * Per-step retry count (capped at the user-facing max). Falls back to
      * the probe-wide default (env var) when the user hasn't configured one.
      */
-    const retryCount: number =
-      monitorStep.data.retryCount !== undefined &&
-      monitorStep.data.retryCount !== null
-        ? clampMonitorRetryCount(monitorStep.data.retryCount)
-        : PROBE_MONITOR_RETRY_LIMIT;
+    const retryCount: number = MonitorUtil.resolveRetryCount({
+      stepRetryCount: monitorStep.data.retryCount,
+      monitorConfigRetries: undefined,
+    });
 
     if (monitorType === MonitorType.Ping || monitorType === MonitorType.IP) {
       if (!monitorStep.data?.monitorDestination) {
@@ -730,9 +777,16 @@ export default class MonitorUtil {
       const response: SnmpMonitorResponse | null = await SnmpMonitor.query(
         snmpConfig,
         {
-          retry: PROBE_MONITOR_RETRY_LIMIT,
+          retry: MonitorUtil.resolveRetryCount({
+            stepRetryCount: monitorStep.data.retryCount,
+            monitorConfigRetries: snmpConfig.retries,
+          }),
           monitorId: monitorId,
-          timeout: snmpConfig.timeout || 5000,
+          timeout: MonitorUtil.resolveTimeoutInMs({
+            stepRequestTimeoutInMs: monitorStep.data.requestTimeoutInMs,
+            monitorConfigTimeoutInMs: snmpConfig.timeout,
+            defaultTimeoutInMs: 5000,
+          }),
           /*
            * ARP/FDB endpoint collection rides the interface walk. Strictly
            * OPT-IN: it adds SNMP table walks per poll and an endpoint write
@@ -774,9 +828,16 @@ export default class MonitorUtil {
       const response: DnsMonitorResponse | null = await DnsMonitorUtil.query(
         dnsConfig,
         {
-          retry: PROBE_MONITOR_RETRY_LIMIT,
+          retry: MonitorUtil.resolveRetryCount({
+            stepRetryCount: monitorStep.data.retryCount,
+            monitorConfigRetries: dnsConfig.retries,
+          }),
           monitorId: monitorId,
-          timeout: dnsConfig.timeout || 5000,
+          timeout: MonitorUtil.resolveTimeoutInMs({
+            stepRequestTimeoutInMs: monitorStep.data.requestTimeoutInMs,
+            monitorConfigTimeoutInMs: dnsConfig.timeout,
+            defaultTimeoutInMs: 5000,
+          }),
         },
       );
 
@@ -809,9 +870,16 @@ export default class MonitorUtil {
 
       const response: DomainMonitorResponse | null =
         await DomainMonitorUtil.query(domainConfig, {
-          retry: PROBE_MONITOR_RETRY_LIMIT,
+          retry: MonitorUtil.resolveRetryCount({
+            stepRetryCount: monitorStep.data.retryCount,
+            monitorConfigRetries: domainConfig.retries,
+          }),
           monitorId: monitorId,
-          timeout: domainConfig.timeout || 10000,
+          timeout: MonitorUtil.resolveTimeoutInMs({
+            stepRequestTimeoutInMs: monitorStep.data.requestTimeoutInMs,
+            monitorConfigTimeoutInMs: domainConfig.timeout,
+            defaultTimeoutInMs: 10000,
+          }),
         });
 
       if (!response) {
@@ -843,9 +911,16 @@ export default class MonitorUtil {
 
       const response: DnssecMonitorResponse | null =
         await DnssecMonitorUtil.query(dnssecConfig, {
-          retry: PROBE_MONITOR_RETRY_LIMIT,
+          retry: MonitorUtil.resolveRetryCount({
+            stepRetryCount: monitorStep.data.retryCount,
+            monitorConfigRetries: dnssecConfig.retries,
+          }),
           monitorId: monitorId,
-          timeout: dnssecConfig.timeout || 10000,
+          timeout: MonitorUtil.resolveTimeoutInMs({
+            stepRequestTimeoutInMs: monitorStep.data.requestTimeoutInMs,
+            monitorConfigTimeoutInMs: dnssecConfig.timeout,
+            defaultTimeoutInMs: 10000,
+          }),
         });
 
       if (!response) {
@@ -918,9 +993,16 @@ export default class MonitorUtil {
 
       const response: ExternalStatusPageMonitorResponse | null =
         await ExternalStatusPageMonitorUtil.fetch(externalStatusPageConfig, {
-          retry: PROBE_MONITOR_RETRY_LIMIT,
+          retry: MonitorUtil.resolveRetryCount({
+            stepRetryCount: monitorStep.data.retryCount,
+            monitorConfigRetries: externalStatusPageConfig.retries,
+          }),
           monitorId: monitorId,
-          timeout: externalStatusPageConfig.timeout || 10000,
+          timeout: MonitorUtil.resolveTimeoutInMs({
+            stepRequestTimeoutInMs: monitorStep.data.requestTimeoutInMs,
+            monitorConfigTimeoutInMs: externalStatusPageConfig.timeout,
+            defaultTimeoutInMs: 10000,
+          }),
         });
 
       if (!response) {

--- a/Probe/Utils/Monitors/MonitorTypes/DnsMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/DnsMonitor.ts
@@ -45,8 +45,15 @@ export default class DnsMonitorUtil {
     const attemptedAt: Date = new Date();
 
     try {
+      /*
+       * An explicitly supplied options.timeout is the caller's per-step
+       * setting and outranks the config default. Reading config.timeout
+       * first silently dropped whatever the step asked for.
+       */
+      const timeoutInMs: number = options.timeout || config.timeout || 5000;
+
       const resolver: dns.promises.Resolver = new dns.promises.Resolver({
-        timeout: config.timeout || 5000,
+        timeout: timeoutInMs,
       });
 
       if (config.hostname) {
@@ -76,6 +83,7 @@ export default class DnsMonitorUtil {
           config.queryName,
           config.recordType,
           config.hostname,
+          timeoutInMs,
         );
       } catch (dnssecErr) {
         logger.debug(
@@ -139,7 +147,11 @@ export default class DnsMonitorUtil {
         failureCause: (err as Error).message || (err as Error).toString(),
       });
 
-      if (options.currentRetryCount < (options.retry || config.retries || 3)) {
+      /*
+       * ?? not ||: a caller asking for zero retries means zero, not "fall
+       * through to the config default".
+       */
+      if (options.currentRetryCount < (options.retry ?? config.retries ?? 3)) {
         options.currentRetryCount++;
         await Sleep.sleep(1000);
         return await DnsMonitorUtil.query(config, options);
@@ -339,6 +351,11 @@ export default class DnsMonitorUtil {
     queryName: string,
     recordType: DnsRecordType,
     dnsServer?: string | undefined,
+    /*
+     * Bounded by the same timeout as the query itself, so the AD-flag check
+     * cannot add a second, longer wait on top of a slow resolution.
+     */
+    timeoutInMs: number = 10000,
   ): Promise<boolean | undefined> {
     // Validate queryName to prevent argument injection
     if (!this.isValidHostnameOrIP(queryName)) {
@@ -369,7 +386,7 @@ export default class DnsMonitorUtil {
       execFile(
         "dig",
         args,
-        { timeout: 10000 },
+        { timeout: timeoutInMs },
         (error: Error | null, stdout: string) => {
           if (error) {
             // dig not available, return undefined

--- a/Probe/Utils/Monitors/MonitorTypes/DnssecMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/DnssecMonitor.ts
@@ -22,6 +22,23 @@ export interface DnssecQueryOptions {
   attempts?: Array<ProbeAttempt> | undefined;
 }
 
+/*
+ * A DNSSEC check is not one query: it is DNSKEY, DS, RRSIG, one dig per
+ * configured resolver, then an NS sweep with one dig per nameserver. Handing
+ * every one of those legs the full per-query timeout meant a check against an
+ * unresponsive resolver could run for minutes - with retries on top of that.
+ * The legs therefore share a single deadline: one attempt gets at most the
+ * per-leg timeout multiplied by this factor.
+ */
+const DNSSEC_TOTAL_TIMEOUT_MULTIPLIER: number = 3;
+
+interface DnssecTimeBudget {
+  perLegTimeoutMs: number;
+  deadlineAt: number;
+  // Set when a leg had to be skipped because the deadline had passed.
+  ranOutOfTime: boolean;
+}
+
 interface DigOptions {
   digFlags?: Array<string>;
   resolver?: string | undefined;
@@ -95,28 +112,35 @@ export default class DnssecMonitorUtil {
     }
 
     try {
-      const timeoutMs: number = config.timeout || 10000;
+      /*
+       * An explicitly supplied options.timeout is the caller's per-step
+       * setting and outranks the config default. Reading config.timeout
+       * first silently dropped whatever the step asked for.
+       */
+      const timeoutMs: number = options.timeout || config.timeout || 10000;
+      const budget: DnssecTimeBudget =
+        DnssecMonitorUtil.createTimeBudget(timeoutMs);
       const defaultResolver: string = config.resolvers[0] || "1.1.1.1";
 
       const dnskeys: Array<DnssecKeyRecord> =
         await DnssecMonitorUtil.fetchDnskeys(
           domainName,
           defaultResolver,
-          timeoutMs,
+          budget,
         );
 
       const parentDsRecords: Array<DnssecDsRecord> =
         await DnssecMonitorUtil.fetchParentDs(
           domainName,
           defaultResolver,
-          timeoutMs,
+          budget,
         );
 
       const rrsigs: Array<DnssecRrsigRecord> =
         await DnssecMonitorUtil.fetchRrsigs(
           domainName,
           defaultResolver,
-          timeoutMs,
+          budget,
         );
 
       const earliestExpiry: Date | undefined =
@@ -126,7 +150,7 @@ export default class DnssecMonitorUtil {
         await DnssecMonitorUtil.checkResolvers(
           domainName,
           config.resolvers,
-          timeoutMs,
+          budget,
         );
 
       let nameserverChecks: Array<DnssecNameserverCheck> = [];
@@ -134,7 +158,7 @@ export default class DnssecMonitorUtil {
         nameserverChecks = await DnssecMonitorUtil.checkNameserverConsistency(
           domainName,
           defaultResolver,
-          timeoutMs,
+          budget,
         );
       }
 
@@ -142,6 +166,38 @@ export default class DnssecMonitorUtil {
       const responseTimeInMs: number = Math.ceil(
         (endTime[0] * 1000000000 + endTime[1]) / 1000000,
       );
+
+      /*
+       * At least one leg never ran, so the record set is incomplete. Saying
+       * "zone not signed" or "resolvers disagree" off a partial sweep would
+       * be a fabricated DNSSEC verdict - report the timeout that actually
+       * happened instead. Not retried: the attempt already consumed a full
+       * budget, so another one would only spend the same time again.
+       */
+      if (budget.ranOutOfTime) {
+        const responseReceivedAt: Date = new Date();
+        const failureCause: string = `DNSSEC check did not finish within its overall budget of ${
+          timeoutMs * DNSSEC_TOTAL_TIMEOUT_MULTIPLIER
+        }ms.`;
+
+        options.attempts.push({
+          attemptNumber: options.currentRetryCount,
+          attemptedAt,
+          responseReceivedAt,
+          responseTimeInMs,
+          isOnline: false,
+          failureCause: failureCause,
+        });
+
+        return DnssecMonitorUtil.buildFailureResponse({
+          domainName: domainName,
+          responseTimeInMs: responseTimeInMs,
+          failureCause: failureCause,
+          isTimeout: true,
+          probeAttempts: options.attempts,
+          totalAttempts: options.attempts.length,
+        });
+      }
 
       const isZoneSigned: boolean = dnskeys.length > 0;
       const isParentDsPresent: boolean = parentDsRecords.length > 0;
@@ -232,7 +288,11 @@ export default class DnssecMonitorUtil {
         failureCause: (err as Error).message || (err as Error).toString(),
       });
 
-      if (options.currentRetryCount < (options.retry || config.retries || 3)) {
+      /*
+       * ?? not ||: a caller asking for zero retries means zero, not "fall
+       * through to the config default".
+       */
+      if (options.currentRetryCount < (options.retry ?? config.retries ?? 3)) {
         options.currentRetryCount++;
         await Sleep.sleep(1000);
         return await DnssecMonitorUtil.query(config, options);
@@ -261,6 +321,31 @@ export default class DnssecMonitorUtil {
         totalAttempts: options.attempts.length,
       });
     }
+  }
+
+  private static createTimeBudget(perLegTimeoutMs: number): DnssecTimeBudget {
+    return {
+      perLegTimeoutMs: perLegTimeoutMs,
+      deadlineAt:
+        Date.now() + perLegTimeoutMs * DNSSEC_TOTAL_TIMEOUT_MULTIPLIER,
+      ranOutOfTime: false,
+    };
+  }
+
+  /*
+   * How long the next dig may take: never more than the per-leg timeout, and
+   * never more than the shared deadline has left. Returns null once the
+   * deadline has passed, which is the caller's signal to stop issuing digs.
+   */
+  private static nextLegTimeoutMs(budget: DnssecTimeBudget): number | null {
+    const remainingMs: number = budget.deadlineAt - Date.now();
+
+    if (remainingMs <= 0) {
+      budget.ranOutOfTime = true;
+      return null;
+    }
+
+    return Math.min(budget.perLegTimeoutMs, remainingMs);
   }
 
   private static buildFailureResponse(arg: {
@@ -390,8 +475,13 @@ export default class DnssecMonitorUtil {
   private static async fetchDnskeys(
     domainName: string,
     resolver: string,
-    timeoutMs: number,
+    budget: DnssecTimeBudget,
   ): Promise<Array<DnssecKeyRecord>> {
+    const timeoutMs: number | null = DnssecMonitorUtil.nextLegTimeoutMs(budget);
+    if (timeoutMs === null) {
+      return [];
+    }
+
     try {
       const result: DigResult = await DnssecMonitorUtil.dig(
         domainName,
@@ -434,8 +524,13 @@ export default class DnssecMonitorUtil {
   private static async fetchParentDs(
     domainName: string,
     resolver: string,
-    timeoutMs: number,
+    budget: DnssecTimeBudget,
   ): Promise<Array<DnssecDsRecord>> {
+    const timeoutMs: number | null = DnssecMonitorUtil.nextLegTimeoutMs(budget);
+    if (timeoutMs === null) {
+      return [];
+    }
+
     try {
       const result: DigResult = await DnssecMonitorUtil.dig(domainName, "DS", {
         digFlags: ["+dnssec", "+short"],
@@ -480,8 +575,13 @@ export default class DnssecMonitorUtil {
   private static async fetchRrsigs(
     domainName: string,
     resolver: string,
-    timeoutMs: number,
+    budget: DnssecTimeBudget,
   ): Promise<Array<DnssecRrsigRecord>> {
+    const timeoutMs: number | null = DnssecMonitorUtil.nextLegTimeoutMs(budget);
+    if (timeoutMs === null) {
+      return [];
+    }
+
     try {
       // Ask for SOA + DNSSEC; the authoritative answer set includes RRSIG records.
       const result: DigResult = await DnssecMonitorUtil.dig(domainName, "SOA", {
@@ -561,11 +661,22 @@ export default class DnssecMonitorUtil {
   private static async checkResolvers(
     domainName: string,
     resolvers: Array<string>,
-    timeoutMs: number,
+    budget: DnssecTimeBudget,
   ): Promise<Array<DnssecResolverCheck>> {
     const checks: Array<DnssecResolverCheck> = [];
 
     for (const resolver of resolvers) {
+      /*
+       * One slow resolver used to cost a full timeout each for every
+       * resolver behind it. Once the shared deadline is gone we stop; the
+       * caller turns the truncated sweep into a timeout verdict.
+       */
+      const timeoutMs: number | null =
+        DnssecMonitorUtil.nextLegTimeoutMs(budget);
+      if (timeoutMs === null) {
+        break;
+      }
+
       try {
         // With CD=0 the resolver validates and SERVFAILs on bogus.
         const validating: DigResult = await DnssecMonitorUtil.dig(
@@ -606,8 +717,14 @@ export default class DnssecMonitorUtil {
   private static async checkNameserverConsistency(
     domainName: string,
     resolver: string,
-    timeoutMs: number,
+    budget: DnssecTimeBudget,
   ): Promise<Array<DnssecNameserverCheck>> {
+    const enumerationTimeoutMs: number | null =
+      DnssecMonitorUtil.nextLegTimeoutMs(budget);
+    if (enumerationTimeoutMs === null) {
+      return [];
+    }
+
     let nsList: Array<string> = [];
     try {
       const nsResult: DigResult = await DnssecMonitorUtil.dig(
@@ -616,7 +733,7 @@ export default class DnssecMonitorUtil {
         {
           digFlags: ["+short"],
           resolver: resolver,
-          timeoutMs: timeoutMs,
+          timeoutMs: enumerationTimeoutMs,
         },
       );
       nsList = nsResult.stdout
@@ -639,6 +756,13 @@ export default class DnssecMonitorUtil {
       if (!DnssecMonitorUtil.isValidHostnameOrIP(ns)) {
         continue;
       }
+
+      const timeoutMs: number | null =
+        DnssecMonitorUtil.nextLegTimeoutMs(budget);
+      if (timeoutMs === null) {
+        break;
+      }
+
       try {
         const soaResult: DigResult = await DnssecMonitorUtil.dig(
           domainName,

--- a/Probe/Utils/Monitors/MonitorTypes/DomainMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/DomainMonitor.ts
@@ -147,7 +147,11 @@ export default class DomainMonitorUtil {
         failureCause: failureCause,
       });
 
-      const maxRetries: number = options.retry || config.retries || 3;
+      /*
+       * ?? not ||: a caller asking for zero retries means zero, not "fall
+       * through to the config default".
+       */
+      const maxRetries: number = options.retry ?? config.retries ?? 3;
 
       /*
        * "This domain is not registered" and "this TLD has no usable

--- a/Probe/Utils/Monitors/MonitorTypes/ExternalStatusPageMonitor.ts
+++ b/Probe/Utils/Monitors/MonitorTypes/ExternalStatusPageMonitor.ts
@@ -277,7 +277,11 @@ export default class ExternalStatusPageMonitorUtil {
         failureCause: (err as Error).message || (err as Error).toString(),
       });
 
-      if (options.currentRetryCount < (options.retry || config.retries || 3)) {
+      /*
+       * ?? not ||: a caller asking for zero retries means zero, not "fall
+       * through to the config default".
+       */
+      if (options.currentRetryCount < (options.retry ?? config.retries ?? 3)) {
         options.currentRetryCount++;
         await Sleep.sleep(1000);
         return await ExternalStatusPageMonitorUtil.fetch(config, options);
@@ -492,7 +496,12 @@ export default class ExternalStatusPageMonitorUtil {
   ): Promise<ExternalStatusPageMonitorResponse | null> {
     try {
       const baseUrl: string = config.statusPageUrl.replace(/\/+$/, "");
-      const timeout: number = config.timeout || options.timeout || 10000;
+      /*
+       * options.timeout first: it carries the caller's per-step setting,
+       * and reading config.timeout ahead of it meant the step setting could
+       * never win.
+       */
+      const timeout: number = options.timeout || config.timeout || 10000;
       const headers: Record<string, string> = {
         Accept: "application/json",
         "User-Agent": "OneUptime-Probe/1.0",
@@ -640,7 +649,7 @@ export default class ExternalStatusPageMonitorUtil {
       const apiUrl: string = `${origin}/proxy/${host}`;
 
       const apiResponse: AxiosResponse = await axios.get(apiUrl, {
-        timeout: config.timeout || options.timeout || 10000,
+        timeout: options.timeout || config.timeout || 10000,
         headers: {
           Accept: "application/json",
           "User-Agent": "OneUptime-Probe/1.0",
@@ -791,7 +800,7 @@ export default class ExternalStatusPageMonitorUtil {
       const feedUrl: string = config.statusPageUrl.replace(/\/+$/, "");
 
       const response: AxiosResponse = await axios.get(feedUrl, {
-        timeout: config.timeout || options.timeout || 10000,
+        timeout: options.timeout || config.timeout || 10000,
         headers: {
           Accept:
             "application/rss+xml, application/atom+xml, application/xml, text/xml",
@@ -984,7 +993,7 @@ export default class ExternalStatusPageMonitorUtil {
   ): Promise<ExternalStatusPageMonitorResponse> {
     try {
       const response: AxiosResponse = await axios.get(config.statusPageUrl, {
-        timeout: config.timeout || options.timeout || 10000,
+        timeout: options.timeout || config.timeout || 10000,
         headers: {
           "User-Agent": "OneUptime-Probe/1.0",
         },


### PR DESCRIPTION
### Title of this pull request?

fix(probe): honour configured retry count and timeout on DNS, DNSSEC, Domain, SNMP and external status page steps

### Small Description?

Follow-up found while fixing #3225.

`probeMonitorStepInternal` computes the user's per-step `retryCount` and `requestTimeoutInMs` near the top. The Website, API, SSLCertificate, Port, Ping and SQLQuery branches pass them through. Five branches did not — they passed the probe-wide `PROBE_MONITOR_RETRY_LIMIT` env default as the retry count instead:

- SNMP / NetworkDevice
- DNS
- Domain
- DNSSEC
- ExternalStatusPage

That discarded **two** settings, not one. Because the monitor utils resolve `options.retry || config.retries || 3`, supplying the env default unconditionally also killed the type-specific `retries` field — which is the only retry control these monitor types actually expose in their forms (the step-level Advanced Options section is rendered for Ping/IP/Port/Website/API/SSL only).

**Precedence.** `Monitor.ts` gains `resolveRetryCount` / `resolveTimeoutInMs` with one rule — step-level setting (clamped) → type-specific config → probe-wide default. All five branches plus the existing step-level computation route through it, so there is a single code path.

| Branch | Was | Now |
|---|---|---|
| SNMP / NetworkDevice | `PROBE_MONITOR_RETRY_LIMIT`, `snmpConfig.timeout` | step → `snmpConfig.retries`/`.timeout` → default |
| DNS | `PROBE_MONITOR_RETRY_LIMIT`, `dnsConfig.timeout` | step → `dnsConfig.*` → default |
| Domain | `PROBE_MONITOR_RETRY_LIMIT`, `domainConfig.timeout` | step → `domainConfig.*` → default |
| DNSSEC | `PROBE_MONITOR_RETRY_LIMIT`, `dnssecConfig.timeout` | step → `dnssecConfig.*` → default |
| ExternalStatusPage | `PROBE_MONITOR_RETRY_LIMIT`, `espConfig.timeout` | step → `espConfig.*` → default |

**Timeout precedence in the monitor utils.**

- `DnsMonitor` and `DnssecMonitor` read `config.timeout` and ignored the `options.timeout` they were handed, so the per-step timeout was dropped even where it was passed. Both now prefer `options.timeout`.
- `ExternalStatusPageMonitor` had the same inversion at four sites (`config.timeout || options.timeout`) — fixed in passing.
- `DnsMonitor`'s AD-flag `dig` used a hardcoded 10s, so a DNS step configured for a short timeout could still spend 10 extra seconds inside `dig`. Now bounded by the same effective timeout.
- Dns/Dnssec/Domain/ExternalStatusPage used `||` for the retry fallback, so a user asking for **zero** retries silently got 3. Changed to `??`.

**DNSSEC aggregate deadline.** A DNSSEC check is not one query — it is DNSKEY, DS, RRSIG, one `dig` per configured resolver, then an NS sweep with one `dig` per nameserver. Every leg started a fresh full timeout, so a worst-case check against an unresponsive resolver ran for minutes, with retries on top. The legs now share one `DnssecTimeBudget` (per-leg timeout × 3); each leg draws `min(perLegTimeout, remaining)`, and once the deadline passes the remaining legs are not attempted. A truncated sweep returns `isTimeout: true` rather than a DNSSEC verdict — reporting "zone not signed" off records we never fetched would be fabricating an answer — and is not retried, on the same reasoning `SslMonitor.ping` already applies to timeouts.

**Note for the reviewer:** the follow-up suggested mirroring `SslMonitor.getSslMonitorResponse`, which was described as sharing one budget across its two handshake passes. On `master` it does not — it passes the full `timeoutInMs` to both `getCertificate` calls, so a strict-then-lenient path is still 2×. The DNSSEC budget here is built standalone rather than mirroring something that isn't there. Happy to bring the SSL side in line in a separate change if wanted.

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). — follow-up to #3225, which is already fixed; nothing to auto-close.
- [x] Have you lint your code locally before submission? — `eslint` clean on all changed files, `tsc --noEmit` clean for Probe.
- [x] Did you write tests where appropriate?

Four new test files, each verified to **fail** against the pre-change code:

- `Probe/Tests/Utils/Monitors/MonitorStepRetryAndTimeout.test.ts` — table-driven over all five branches (20 tests). Seeds `PROBE_MONITOR_RETRY_LIMIT=9`, distinct from every value under test, so a leaked env default is visible in the assertion. Covers step-level retry + timeout pass-through, `retryCount: 0` honoured, clamping above the documented max, and fallback to the type-specific config rather than the env default.
- `Probe/Tests/Utils/Monitors/MonitorTypes/DnsMonitorTimeout.test.ts` — `options.timeout` wins, config fallback intact, AD-flag `dig` bounded.
- `Probe/Tests/Utils/Monitors/MonitorTypes/DnssecMonitorTimeout.test.ts` — timeout precedence plus the budget on a fake clock: one attempt capped at 3× the per-leg timeout, a later leg shrinking to the 6s remainder instead of taking a fresh 10s, exhaustion producing a timeout verdict, and a fast run still completing normally with all three resolver checks.
- `Probe/Tests/Utils/Monitors/MonitorTypes/ExternalStatusPageMonitorTimeout.test.ts` — the inversion fixed in passing.

Full Probe suite: 1096 tests across 57 suites, all passing.

### Related Issue?

Follow-up to #3225.

### Screenshots (if appropriate):

n/a — probe-side behaviour, covered by unit tests.
