### PR TITLE
fix(monitor): evaluate a probe result against the step it actually ran

### DIFF
--- a/Common/Server/Utils/Monitor/MonitorResource.ts
+++ b/Common/Server/Utils/Monitor/MonitorResource.ts
@@ -636,7 +636,16 @@ export default class MonitorResourceUtil {
         }
       }
 
-      const monitorStep: MonitorStep | undefined =
+      /*
+       * The step this result was actually produced for. A probe result carries
+       * the monitorStepId it ran, and a monitor can have several steps whose
+       * criteria differ - so the step must be looked up, not assumed to be the
+       * first one. The lookup used to be performed and its result thrown away,
+       * which silently evaluated every result against step 0's criteria and fed
+       * step 0's id into checkProbeAgreement (so agreement compared this
+       * result against other probes' logs for the wrong step).
+       */
+      let monitorStep: MonitorStep | undefined =
         monitorSteps.data.monitorStepsInstanceArray[0];
 
       logger.debug(
@@ -644,14 +653,25 @@ export default class MonitorResourceUtil {
       );
 
       if ((dataToProcess as ProbeMonitorResponse).monitorStepId) {
-        monitorSteps.data.monitorStepsInstanceArray.find(
-          (monitorStep: MonitorStep) => {
-            return (
-              monitorStep.id.toString() ===
-              (dataToProcess as ProbeMonitorResponse).monitorStepId.toString()
-            );
-          },
-        );
+        const ingestedMonitorStep: MonitorStep | undefined =
+          monitorSteps.data.monitorStepsInstanceArray.find(
+            (step: MonitorStep) => {
+              return (
+                step.id.toString() ===
+                (dataToProcess as ProbeMonitorResponse).monitorStepId.toString()
+              );
+            },
+          );
+
+        /*
+         * An id that matches no step is stale - the step was deleted after the
+         * probe was scheduled. Keep the existing behaviour there and fall back
+         * to the first step rather than dropping the result.
+         */
+        if (ingestedMonitorStep) {
+          monitorStep = ingestedMonitorStep;
+        }
+
         logger.debug(
           `Found Monitor Step ID: ${(dataToProcess as ProbeMonitorResponse).monitorStepId}`,
         );

--- a/Common/Tests/Server/Utils/Monitor/MonitorResourceIngestedStepSelection.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/MonitorResourceIngestedStepSelection.test.ts
@@ -1,0 +1,455 @@
+/*
+ * Which monitor step a result is evaluated against.
+ *
+ * A monitor can have several steps and EACH step carries its own criteria. A
+ * probe result names the step it actually ran in `monitorStepId`, so that step
+ * — not whichever step happens to sit first in the array — decides which
+ * criteria may match. Five outputs hang off that choice:
+ *
+ *   - `criteriaMetId`, matched against the ingested step's criteria only;
+ *   - `ingestedMonitorStepId`, echoed back to the probe;
+ *   - `nextMonitorStepId`, which walks the chain from the ingested step;
+ *   - the step handed to MonitorCriteriaEvaluator.processMonitorStep;
+ *   - the step handed to checkProbeAgreement, which keys every other probe's
+ *     lastMonitoringLog by step id — the wrong id compares this result against
+ *     other probes' state for a different step.
+ *
+ * MonitorResource used to run the `.find()` for the ingested step and DISCARD
+ * its result, leaving `monitorStep` pinned to `monitorStepsInstanceArray[0]`.
+ * Single-step monitors (the overwhelming majority, including every SSL
+ * monitor) could not notice; multi-step monitors silently evaluated every
+ * step's results against step 0's criteria.
+ *
+ * A `monitorStepId` that matches NO step is stale — the step was deleted after
+ * the probe was scheduled — and still falls back to step 0 rather than
+ * dropping the result. That fallback is pinned here too, because it is the one
+ * case where "use step 0" is deliberate rather than a bug.
+ *
+ * Everything heavy is mocked BEFORE importing MonitorResource: the criteria
+ * evaluator (pulls native isolated-vm via VMAPI/VMRunner), the monitor and
+ * probe services (Postgres), the per-monitor semaphore (Redis), the metric and
+ * log utils (ClickHouse) and the logger. checkProbeAgreement is spied on so
+ * this suite pins only the step it is HANDED — its internals are covered by
+ * MonitorResourceProbeAgreementReuse.test.ts. Pure in-memory model instances.
+ */
+
+jest.mock("../../../../Server/Utils/Monitor/MonitorCriteriaEvaluator", () => {
+  return {
+    __esModule: true,
+    default: {
+      processMonitorStep: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Services/MonitorService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneById: jest.fn(),
+      updateColumnsByIdWithoutHooks: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Services/MonitorProbeService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+      updateColumnsByIdWithoutHooks: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Infrastructure/Semaphore", () => {
+  return {
+    __esModule: true,
+    default: {
+      lock: jest.fn(),
+      release: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Utils/Monitor/MonitorMetricUtil", () => {
+  return {
+    __esModule: true,
+    default: {
+      saveMonitorMetrics: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Utils/Monitor/MonitorLogUtil", () => {
+  return {
+    __esModule: true,
+    default: {
+      saveMonitorLog: jest.fn(),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      trace: jest.fn(),
+    },
+  };
+});
+
+import MonitorResourceUtil from "../../../../Server/Utils/Monitor/MonitorResource";
+import MonitorCriteriaEvaluator from "../../../../Server/Utils/Monitor/MonitorCriteriaEvaluator";
+import MonitorService from "../../../../Server/Services/MonitorService";
+import MonitorProbeService from "../../../../Server/Services/MonitorProbeService";
+import Semaphore from "../../../../Server/Infrastructure/Semaphore";
+import DataToProcess from "../../../../Server/Utils/Monitor/DataToProcess";
+import Monitor from "../../../../Models/DatabaseModels/Monitor";
+import MonitorProbe from "../../../../Models/DatabaseModels/MonitorProbe";
+import MonitorCriteria from "../../../../Types/Monitor/MonitorCriteria";
+import MonitorCriteriaInstance from "../../../../Types/Monitor/MonitorCriteriaInstance";
+import MonitorStep from "../../../../Types/Monitor/MonitorStep";
+import MonitorSteps from "../../../../Types/Monitor/MonitorSteps";
+import MonitorType from "../../../../Types/Monitor/MonitorType";
+import ServerMonitorResponse from "../../../../Types/Monitor/ServerMonitor/ServerMonitorResponse";
+import ObjectID from "../../../../Types/ObjectID";
+import OneUptimeDate from "../../../../Types/Date";
+import ProbeApiIngestResponse from "../../../../Types/Probe/ProbeApiIngestResponse";
+import ProbeMonitorResponse from "../../../../Types/Probe/ProbeMonitorResponse";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+
+const processMonitorStepMock: jest.Mock =
+  MonitorCriteriaEvaluator.processMonitorStep as unknown as jest.Mock;
+
+const findOneByIdMock: jest.Mock =
+  MonitorService.findOneById as unknown as jest.Mock;
+
+const findByMock: jest.Mock =
+  MonitorProbeService.findBy as unknown as jest.Mock;
+
+const lockMock: jest.Mock = Semaphore.lock as unknown as jest.Mock;
+
+/*
+ * One criteria per step, so the criteria id that comes back on the response
+ * names the step it was read off — exactly the coupling the discarded lookup
+ * broke.
+ */
+type MakeStep = (criteriaName: string) => MonitorStep;
+
+const makeStep: MakeStep = (criteriaName: string): MonitorStep => {
+  const criteriaInstance: MonitorCriteriaInstance =
+    new MonitorCriteriaInstance();
+  criteriaInstance.data!.name = criteriaName;
+
+  const monitorCriteria: MonitorCriteria = new MonitorCriteria();
+  monitorCriteria.data = {
+    monitorCriteriaInstanceArray: [criteriaInstance],
+  };
+
+  const step: MonitorStep = new MonitorStep();
+  step.data!.monitorCriteria = monitorCriteria;
+
+  return step;
+};
+
+type CriteriaIdOfStep = (step: MonitorStep) => string;
+
+const criteriaIdOfStep: CriteriaIdOfStep = (step: MonitorStep): string => {
+  return step.data!.monitorCriteria.data!.monitorCriteriaInstanceArray[0]!.data!
+    .id;
+};
+
+type MakeMonitor = (input: {
+  monitorType: MonitorType;
+  steps: Array<MonitorStep>;
+}) => Monitor;
+
+const makeMonitor: MakeMonitor = (input: {
+  monitorType: MonitorType;
+  steps: Array<MonitorStep>;
+}): Monitor => {
+  const monitorSteps: MonitorSteps = new MonitorSteps();
+  monitorSteps.data = {
+    monitorStepsInstanceArray: input.steps,
+    /*
+     * Left undefined on purpose: a set default status sends the
+     * no-criteria-met path into MonitorStatusTimelineService, which this
+     * suite has no reason to reach.
+     */
+    defaultMonitorStatusId: undefined,
+  };
+
+  const monitor: Monitor = new Monitor();
+  monitor.id = ObjectID.generate();
+  monitor.projectId = ObjectID.generate();
+  monitor.monitorType = input.monitorType;
+  monitor.monitorSteps = monitorSteps;
+
+  return monitor;
+};
+
+type MakeProbeResult = (input: {
+  monitor: Monitor;
+  probeId: ObjectID;
+  monitorStepId: ObjectID;
+}) => DataToProcess;
+
+const makeProbeResult: MakeProbeResult = (input: {
+  monitor: Monitor;
+  probeId: ObjectID;
+  monitorStepId: ObjectID;
+}): DataToProcess => {
+  return {
+    projectId: input.monitor.projectId!,
+    monitorId: input.monitor.id!,
+    probeId: input.probeId,
+    monitorStepId: input.monitorStepId,
+    isOnline: true,
+    failureCause: "",
+  } as ProbeMonitorResponse;
+};
+
+type StepPassedToEvaluator = () => MonitorStep;
+
+const stepPassedToEvaluator: StepPassedToEvaluator = (): MonitorStep => {
+  return processMonitorStepMock.mock.calls[0]![0].monitorStep;
+};
+
+describe("MonitorResourceUtil.monitorResource ingested monitor step selection", () => {
+  let checkProbeAgreementSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    lockMock.mockResolvedValue({});
+
+    /*
+     * Stands in for the real evaluator in the one respect this suite is
+     * about: the criteria it can match are exactly the ones hanging off the
+     * step it was handed. rootCause stays null so the criteria-met branch
+     * (incidents, alerts, status timeline) never runs.
+     */
+    processMonitorStepMock.mockImplementation(
+      (input: {
+        monitorStep: MonitorStep;
+        probeApiIngestResponse: ProbeApiIngestResponse;
+      }): Promise<ProbeApiIngestResponse> => {
+        return Promise.resolve({
+          ...input.probeApiIngestResponse,
+          criteriaMetId: criteriaIdOfStep(input.monitorStep),
+          rootCause: null,
+        });
+      },
+    );
+
+    /*
+     * Agreement itself is covered elsewhere; here it only has to pass the
+     * evaluated criteria through so the response still reports it, while
+     * recording the step it was given.
+     */
+    checkProbeAgreementSpy = jest
+      .spyOn(MonitorResourceUtil as any, "checkProbeAgreement")
+      .mockImplementation((input: any) => {
+        return Promise.resolve({
+          hasAgreement: true,
+          agreementCount: 1,
+          requiredCount: 1,
+          totalActiveProbes: 1,
+          agreedCriteriaId: input.currentCriteriaMetId,
+          agreedRootCause: input.currentRootCause,
+          agreedProbeNames: [],
+        });
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("probe result naming a step (multi-step monitor)", () => {
+    let stepOne: MonitorStep;
+    let stepTwo: MonitorStep;
+    let stepThree: MonitorStep;
+    let monitor: Monitor;
+    let probeId: ObjectID;
+
+    beforeEach(() => {
+      stepOne = makeStep("Step one criteria");
+      stepTwo = makeStep("Step two criteria");
+      stepThree = makeStep("Step three criteria");
+
+      monitor = makeMonitor({
+        monitorType: MonitorType.Website,
+        steps: [stepOne, stepTwo, stepThree],
+      });
+
+      probeId = ObjectID.generate();
+
+      const monitorProbe: MonitorProbe = new MonitorProbe();
+      monitorProbe.id = ObjectID.generate();
+      monitorProbe.probeId = probeId;
+      monitorProbe.isEnabled = true;
+
+      findOneByIdMock.mockResolvedValue(monitor);
+      findByMock.mockResolvedValue([monitorProbe]);
+    });
+
+    test("evaluates the named step's criteria, not step 0's", async () => {
+      const response: ProbeApiIngestResponse =
+        await MonitorResourceUtil.monitorResource(
+          makeProbeResult({
+            monitor: monitor,
+            probeId: probeId,
+            monitorStepId: stepTwo.id,
+          }),
+        );
+
+      expect(stepPassedToEvaluator().id.toString()).toBe(stepTwo.id.toString());
+      expect(response.criteriaMetId).toBe(criteriaIdOfStep(stepTwo));
+      expect(response.criteriaMetId).not.toBe(criteriaIdOfStep(stepOne));
+    });
+
+    test("reports the named step as the ingested step", async () => {
+      const response: ProbeApiIngestResponse =
+        await MonitorResourceUtil.monitorResource(
+          makeProbeResult({
+            monitor: monitor,
+            probeId: probeId,
+            monitorStepId: stepTwo.id,
+          }),
+        );
+
+      expect(response.ingestedMonitorStepId?.toString()).toBe(
+        stepTwo.id.toString(),
+      );
+    });
+
+    test("walks the step chain on from the named step", async () => {
+      const response: ProbeApiIngestResponse =
+        await MonitorResourceUtil.monitorResource(
+          makeProbeResult({
+            monitor: monitor,
+            probeId: probeId,
+            monitorStepId: stepTwo.id,
+          }),
+        );
+
+      // Step three follows step two — not step two, which follows step one.
+      expect(response.nextMonitorStepId?.toString()).toBe(
+        stepThree.id.toString(),
+      );
+    });
+
+    test("the last step has no next step", async () => {
+      const response: ProbeApiIngestResponse =
+        await MonitorResourceUtil.monitorResource(
+          makeProbeResult({
+            monitor: monitor,
+            probeId: probeId,
+            monitorStepId: stepThree.id,
+          }),
+        );
+
+      expect(response.nextMonitorStepId).toBeUndefined();
+    });
+
+    test("hands probe agreement the named step, so it reads the right step's probe logs", async () => {
+      await MonitorResourceUtil.monitorResource(
+        makeProbeResult({
+          monitor: monitor,
+          probeId: probeId,
+          monitorStepId: stepTwo.id,
+        }),
+      );
+
+      expect(checkProbeAgreementSpy).toHaveBeenCalledTimes(1);
+
+      const agreementInput: { monitorStep: MonitorStep } =
+        checkProbeAgreementSpy.mock.calls[0]![0] as {
+          monitorStep: MonitorStep;
+        };
+
+      expect(agreementInput.monitorStep.id.toString()).toBe(
+        stepTwo.id.toString(),
+      );
+    });
+
+    test("step 0 is still selected when the result names step 0", async () => {
+      const response: ProbeApiIngestResponse =
+        await MonitorResourceUtil.monitorResource(
+          makeProbeResult({
+            monitor: monitor,
+            probeId: probeId,
+            monitorStepId: stepOne.id,
+          }),
+        );
+
+      expect(stepPassedToEvaluator().id.toString()).toBe(stepOne.id.toString());
+      expect(response.criteriaMetId).toBe(criteriaIdOfStep(stepOne));
+      expect(response.ingestedMonitorStepId?.toString()).toBe(
+        stepOne.id.toString(),
+      );
+    });
+
+    test("an unknown step id falls back to step 0 rather than dropping the result", async () => {
+      // The step was deleted after this probe was scheduled.
+      const response: ProbeApiIngestResponse =
+        await MonitorResourceUtil.monitorResource(
+          makeProbeResult({
+            monitor: monitor,
+            probeId: probeId,
+            monitorStepId: ObjectID.generate(),
+          }),
+        );
+
+      expect(stepPassedToEvaluator().id.toString()).toBe(stepOne.id.toString());
+      expect(response.criteriaMetId).toBe(criteriaIdOfStep(stepOne));
+      expect(response.ingestedMonitorStepId?.toString()).toBe(
+        stepOne.id.toString(),
+      );
+      expect(response.nextMonitorStepId?.toString()).toBe(
+        stepTwo.id.toString(),
+      );
+    });
+  });
+
+  describe("result carrying no step id", () => {
+    test("uses step 0", async () => {
+      /*
+       * Server monitors heartbeat in without a monitorStepId at all — the
+       * whole lookup is skipped and step 0 is the intended step.
+       */
+      const stepOne: MonitorStep = makeStep("Step one criteria");
+      const stepTwo: MonitorStep = makeStep("Step two criteria");
+
+      const monitor: Monitor = makeMonitor({
+        monitorType: MonitorType.Server,
+        steps: [stepOne, stepTwo],
+      });
+
+      findOneByIdMock.mockResolvedValue(monitor);
+
+      const serverMonitorResponse: ServerMonitorResponse = {
+        projectId: monitor.projectId!,
+        monitorId: monitor.id!,
+        hostname: "test-host",
+        requestReceivedAt: OneUptimeDate.getCurrentDate(),
+        onlyCheckRequestReceivedAt: false,
+      };
+
+      const response: ProbeApiIngestResponse =
+        await MonitorResourceUtil.monitorResource(serverMonitorResponse);
+
+      expect(stepPassedToEvaluator().id.toString()).toBe(stepOne.id.toString());
+      expect(response.criteriaMetId).toBe(criteriaIdOfStep(stepOne));
+      expect(response.ingestedMonitorStepId?.toString()).toBe(
+        stepOne.id.toString(),
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Title of this pull request?

fix(monitor): evaluate a probe result against the step it actually ran

### Small Description?

`MonitorResource.monitorResource` looked up the ingested monitor step by `monitorStepId` and **discarded the result** — the `.find()` was called for its (nonexistent) side effect, so `monitorStep` stayed pinned to `monitorStepsInstanceArray[0]`:

```ts
const monitorStep = monitorSteps.data.monitorStepsInstanceArray[0];

if ((dataToProcess as ProbeMonitorResponse).monitorStepId) {
  monitorSteps.data.monitorStepsInstanceArray.find(...);  // result thrown away
}
```

On a monitor with more than one step, every result was therefore:

- matched against **step 0's criteria**, whichever step the probe actually ran;
- reported back with step 0's id as `ingestedMonitorStepId`;
- walked on from step 0 for `nextMonitorStepId`, so the step chain never advanced past step 1;
- passed step 0's id into `checkProbeAgreement`, which keys every other probe's `lastMonitoringLog` by step id — so agreement compared this result against other probes' state **for a different step**.

The fix captures the found step and assigns it. An id that matches no step is stale (the step was deleted after the probe was scheduled) and still falls back to step 0, rather than dropping the result.

**Reviewer note — this changes behaviour for existing monitors.** Multi-step monitors whose steps carry *different* criteria have been evaluating everything against step 0. After deploy they will evaluate each step against its own criteria, so their statuses and incidents can change on the first cycle. Monitors with a single step, or with identical criteria across steps, are unaffected.

New suite `Common/Tests/Server/Utils/Monitor/MonitorResourceIngestedStepSelection.test.ts` drives the real `monitorResource` end to end with Postgres / Redis / ClickHouse / isolated-vm mocked out. Verified against the pre-fix code by stashing the source change: the 5 new-behaviour tests fail, and the 3 that pin deliberately-unchanged fallbacks (result names step 0, unknown step id, no step id at all) pass on both — so the suite fails for the right reason and only the right reason.

<details>
<summary>Verification run</summary>

- `tsc --noEmit` on `Common` — clean
- `eslint` on both changed files — clean
- `Tests/Server/Utils/Monitor` + `MonitorResourceProbeAgreementReuse` — 49 suites / 843 tests passing

</details>

### Pull Request Checklist:

- [x] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
- [x] Have you lint your code locally before submission?
- [x] Did you write tests where appropriate?

### Related Issue?

No issue to close. Found while fixing #3225 (SSL monitors not reporting *why* a certificate is bad) but unrelated to that symptom — SSL monitors are single-step, so they could not hit this. Deliberately kept out of that PR because, unlike it, this one changes evaluation for existing multi-step monitors.

### Screenshots (if appropriate):

n/a — server-side evaluation logic.
