### PR TITLE
perf: reduce CPU/memory hot spots in request auth, serialization, mail, telemetry ingest, and worker jobs (phase 2)

### DIFF
--- a/App/FeatureSet/Notification/Services/MailService.ts
+++ b/App/FeatureSet/Notification/Services/MailService.ts
@@ -25,7 +25,6 @@ import ObjectID from "Common/Types/ObjectID";
 import Port from "Common/Types/Port";
 import UserNotificationStatus from "Common/Types/UserNotification/UserNotificationStatus";
 import { IsDevelopment } from "Common/Server/EnvironmentConfig";
-import LocalCache from "Common/Server/Infrastructure/LocalCache";
 import EmailLogService from "Common/Server/Services/EmailLogService";
 import UserOnCallLogTimelineService from "Common/Server/Services/UserOnCallLogTimelineService";
 import logger from "Common/Server/Utils/Logger";
@@ -490,20 +489,29 @@ export default class MailService {
     }
   }
 
+  /*
+   * Key is the raw template-name string (not the enum) because the
+   * notification API casts unvalidated strings into EmailTemplateType.
+   */
+  private static compiledEmailTemplates: Map<
+    string,
+    Handlebars.TemplateDelegate
+  > = new Map();
+
   private static async compileEmailBody(
     emailTemplateType: EmailTemplateType,
     vars: Dictionary<string | JSONObject>,
   ): Promise<string> {
-    // Localcache templates, so we don't read from disk all the time.
+    /*
+     * Cache the compiled delegate so Handlebars parse/codegen runs once per
+     * template per process. In development, re-read and recompile on every
+     * call so template edits hot-reload.
+     */
+    let compiledTemplate: Handlebars.TemplateDelegate | undefined =
+      this.compiledEmailTemplates.get(emailTemplateType);
 
-    let templateData: string;
-    if (
-      LocalCache.hasValue("email-templates", emailTemplateType) &&
-      !IsDevelopment
-    ) {
-      templateData = LocalCache.getString("email-templates", emailTemplateType);
-    } else {
-      templateData = await fsp.readFile(
+    if (!compiledTemplate || IsDevelopment) {
+      const templateData: string = await fsp.readFile(
         Path.resolve(
           process.cwd(),
           "FeatureSet",
@@ -513,16 +521,12 @@ export default class MailService {
         ),
         { encoding: "utf8", flag: "r" },
       );
-      LocalCache.setString(
-        "email-templates",
-        emailTemplateType,
-        templateData as string,
-      );
+
+      compiledTemplate = Handlebars.compile(templateData);
+      this.compiledEmailTemplates.set(emailTemplateType, compiledTemplate);
     }
 
-    const emailBody: Handlebars.TemplateDelegate =
-      Handlebars.compile(templateData);
-    return emailBody(vars).toString();
+    return compiledTemplate(vars).toString();
   }
 
   private static compileText(

--- a/App/FeatureSet/Telemetry/Services/LogDropFilterService.ts
+++ b/App/FeatureSet/Telemetry/Services/LogDropFilterService.ts
@@ -15,6 +15,7 @@ import {
   DropFilterSignal,
   recordDroppedRecord,
 } from "../Utils/DropFilterDropRecorder";
+import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
 
 export interface LoadedLogDropFilter {
   filter: LogDropFilter;
@@ -32,24 +33,23 @@ export interface LoadedLogDropFilter {
   projectId: ObjectID;
 }
 
-interface CacheEntry {
-  filters: Array<LoadedLogDropFilter>;
-  loadedAt: number;
-}
-
 const CACHE_TTL_MS: number = 60 * 1000; // 60 seconds
+const MAX_CACHED_PROJECTS: number = 10_000;
 
-const dropFilterCache: Map<string, CacheEntry> = new Map();
+const dropFilterCache: InMemoryTTLCache<Array<LoadedLogDropFilter>> =
+  new InMemoryTTLCache<Array<LoadedLogDropFilter>>(MAX_CACHED_PROJECTS);
 
 export class LogDropFilterService {
   public static async loadDropFilters(
     projectId: ObjectID,
   ): Promise<Array<LoadedLogDropFilter>> {
     const cacheKey: string = projectId.toString();
-    const cached: CacheEntry | undefined = dropFilterCache.get(cacheKey);
+    const cached: Array<LoadedLogDropFilter> | undefined =
+      dropFilterCache.get(cacheKey);
 
-    if (cached && Date.now() - cached.loadedAt < CACHE_TTL_MS) {
-      return cached.filters;
+    // Empty arrays are truthy — zero-filter projects stay negatively cached.
+    if (cached) {
+      return cached;
     }
 
     const service: DatabaseService<LogDropFilter> =
@@ -99,7 +99,7 @@ export class LogDropFilterService {
       },
     );
 
-    dropFilterCache.set(cacheKey, { filters: loaded, loadedAt: Date.now() });
+    dropFilterCache.set(cacheKey, loaded, CACHE_TTL_MS);
     return loaded;
   }
 

--- a/App/FeatureSet/Telemetry/Services/LogPipelineService.ts
+++ b/App/FeatureSet/Telemetry/Services/LogPipelineService.ts
@@ -20,6 +20,7 @@ import {
   evaluateCompiledFilter,
 } from "../Utils/LogFilterEvaluator";
 import logger from "Common/Server/Utils/Logger";
+import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
 
 export interface LoadedPipeline {
   pipeline: LogPipeline;
@@ -30,11 +31,6 @@ export interface LoadedPipeline {
    */
   compiledFilter: CompiledFilter;
   processors: Array<LogPipelineProcessor>;
-}
-
-interface CacheEntry {
-  pipelines: Array<LoadedPipeline>;
-  loadedAt: number;
 }
 
 /*
@@ -49,18 +45,22 @@ interface CompiledCategoryConfig extends CategoryProcessorConfig {
 }
 
 const CACHE_TTL_MS: number = 60 * 1000; // 60 seconds
+const MAX_CACHED_PROJECTS: number = 10_000;
 
-const pipelineCache: Map<string, CacheEntry> = new Map();
+const pipelineCache: InMemoryTTLCache<Array<LoadedPipeline>> =
+  new InMemoryTTLCache<Array<LoadedPipeline>>(MAX_CACHED_PROJECTS);
 
 export class LogPipelineService {
   public static async loadPipelines(
     projectId: ObjectID,
   ): Promise<Array<LoadedPipeline>> {
     const cacheKey: string = projectId.toString();
-    const cached: CacheEntry | undefined = pipelineCache.get(cacheKey);
+    const cached: Array<LoadedPipeline> | undefined =
+      pipelineCache.get(cacheKey);
 
-    if (cached && Date.now() - cached.loadedAt < CACHE_TTL_MS) {
-      return cached.pipelines;
+    // Empty arrays are truthy — zero-pipeline projects stay negatively cached.
+    if (cached) {
+      return cached;
     }
 
     const pipelineService: DatabaseService<LogPipeline> =
@@ -123,7 +123,7 @@ export class LogPipelineService {
       });
     }
 
-    pipelineCache.set(cacheKey, { pipelines: loaded, loadedAt: Date.now() });
+    pipelineCache.set(cacheKey, loaded, CACHE_TTL_MS);
     return loaded;
   }
 

--- a/App/FeatureSet/Telemetry/Services/LogScrubRuleService.ts
+++ b/App/FeatureSet/Telemetry/Services/LogScrubRuleService.ts
@@ -7,12 +7,7 @@ import { JSONObject } from "Common/Types/JSON";
 import LogScrubAction from "Common/Types/Log/LogScrubAction";
 import LogScrubPatternType from "Common/Types/Log/LogScrubPatternType";
 import crypto from "crypto";
-
-interface CacheEntry {
-  rules: Array<LogScrubRule>;
-  compiledPatterns: Array<CompiledRule>;
-  loadedAt: number;
-}
+import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
 
 interface CompiledRule {
   rule: LogScrubRule;
@@ -20,8 +15,10 @@ interface CompiledRule {
 }
 
 const CACHE_TTL_MS: number = 60 * 1000; // 60 seconds
+const MAX_CACHED_PROJECTS: number = 10_000;
 
-const scrubRuleCache: Map<string, CacheEntry> = new Map();
+const scrubRuleCache: InMemoryTTLCache<Array<CompiledRule>> =
+  new InMemoryTTLCache<Array<CompiledRule>>(MAX_CACHED_PROJECTS);
 
 // Built-in PII detection patterns
 const BUILT_IN_PATTERNS: Record<string, RegExp> = {
@@ -50,10 +47,12 @@ export class LogScrubRuleService {
     projectId: ObjectID,
   ): Promise<Array<CompiledRule>> {
     const cacheKey: string = projectId.toString();
-    const cached: CacheEntry | undefined = scrubRuleCache.get(cacheKey);
+    const cached: Array<CompiledRule> | undefined =
+      scrubRuleCache.get(cacheKey);
 
-    if (cached && Date.now() - cached.loadedAt < CACHE_TTL_MS) {
-      return cached.compiledPatterns;
+    // Empty arrays are truthy — zero-rule projects stay negatively cached.
+    if (cached) {
+      return cached;
     }
 
     const service: DatabaseService<LogScrubRule> =
@@ -97,11 +96,7 @@ export class LogScrubRuleService {
       }
     }
 
-    scrubRuleCache.set(cacheKey, {
-      rules,
-      compiledPatterns,
-      loadedAt: Date.now(),
-    });
+    scrubRuleCache.set(cacheKey, compiledPatterns, CACHE_TTL_MS);
 
     return compiledPatterns;
   }

--- a/App/FeatureSet/Telemetry/Services/MetricPipelineRuleService.ts
+++ b/App/FeatureSet/Telemetry/Services/MetricPipelineRuleService.ts
@@ -11,19 +11,18 @@ import LIMIT_MAX from "Common/Types/Database/LimitMax";
 import ObjectID from "Common/Types/ObjectID";
 import { JSONObject, JSONValue } from "Common/Types/JSON";
 import logger from "Common/Server/Utils/Logger";
+import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
 
 export interface MetricRulesForProject {
   projectRules: Array<MetricPipelineRule>;
   rulesByServiceId: Map<string, Array<MetricPipelineRule>>;
 }
 
-interface CacheEntry {
-  rules: MetricRulesForProject;
-  loadedAt: number;
-}
-
 const CACHE_TTL_MS: number = 60 * 1000; // 60 seconds
-const ruleCache: Map<string, CacheEntry> = new Map();
+const MAX_CACHED_PROJECTS: number = 10_000;
+
+const ruleCache: InMemoryTTLCache<MetricRulesForProject> =
+  new InMemoryTTLCache<MetricRulesForProject>(MAX_CACHED_PROJECTS);
 
 /*
  * Compiled-regex memo for MatchesRegex / DoesNotMatchRegex filters.
@@ -77,10 +76,11 @@ export default class MetricPipelineRuleService {
     projectId: ObjectID,
   ): Promise<MetricRulesForProject> {
     const cacheKey: string = projectId.toString();
-    const cached: CacheEntry | undefined = ruleCache.get(cacheKey);
+    const cached: MetricRulesForProject | undefined = ruleCache.get(cacheKey);
 
-    if (cached && Date.now() - cached.loadedAt < CACHE_TTL_MS) {
-      return cached.rules;
+    // The object is truthy even with zero rules — negative caching preserved.
+    if (cached) {
+      return cached;
     }
 
     const service: DatabaseService<MetricPipelineRule> =
@@ -129,7 +129,7 @@ export default class MetricPipelineRuleService {
     }
 
     const result: MetricRulesForProject = { projectRules, rulesByServiceId };
-    ruleCache.set(cacheKey, { rules: result, loadedAt: Date.now() });
+    ruleCache.set(cacheKey, result, CACHE_TTL_MS);
     return result;
   }
 

--- a/App/FeatureSet/Telemetry/Services/OtelIngestBaseService.ts
+++ b/App/FeatureSet/Telemetry/Services/OtelIngestBaseService.ts
@@ -271,6 +271,25 @@ export default abstract class OtelIngestBaseService {
       maxEntries: 10_000,
     });
 
+  /*
+   * L1 for the docker/podman container id -> name Redis caches
+   * (getDockerServiceName / getPodmanServiceName): otherwise every
+   * docker_stats metrics block pays one serialized SETEX and every filelog
+   * log block one GET, per resource block per job. Entries store the RAW
+   * (pre-normalization) name so memo hits and Redis hits normalize through
+   * the same function, and only POSITIVES are memoed — a memoed miss would
+   * delay first-contact name resolution and route that container's log rows
+   * to the DockerHost/PodmanHost entity for the TTL. On the write path the
+   * memo is set only after a successful Redis write, so an outage retries
+   * on the next block exactly as before. Same 60s-on-top-of-24h staleness
+   * trade-off documented for entityIdL1Memo above.
+   */
+  private static readonly containerNameL1Memo: InProcessMemo<string> =
+    new InProcessMemo<string>({
+      ttlInMs: 60 * 1000,
+      maxEntries: 10_000,
+    });
+
   /**
    * Read a discovered entity id through L1 -> L2 (Redis). Returns null when
    * neither layer has it — the caller then runs its findOrCreate* path and
@@ -324,13 +343,14 @@ export default abstract class OtelIngestBaseService {
   }
 
   /**
-   * Drop every in-process L1 memo (entity ids + fence refusals). For tests
-   * only — suites that reuse one resource id across cases need a way to
-   * simulate the TTLs expiring, the same way they already clear their fake
-   * Redis maps between cases.
+   * Drop every in-process L1 memo (entity ids, container names, fence
+   * refusals). For tests only — suites that reuse one resource id across
+   * cases need a way to simulate the TTLs expiring, the same way they
+   * already clear their fake Redis maps between cases.
    */
   public static clearInProcessMemos(): void {
     this.entityIdL1Memo.clear();
+    this.containerNameL1Memo.clear();
     this.maintenanceFenceNegativeMemo.clear();
   }
 
@@ -830,14 +850,21 @@ export default abstract class OtelIngestBaseService {
           req as ExpressRequest & { projectId?: ObjectID }
         ).projectId;
         if (projectId) {
-          await GlobalCache.setString(
-            this.DOCKER_CONTAINER_NAME_CACHE_NAMESPACE,
-            `${projectId.toString()}:${containerId}`,
-            containerName,
-            {
-              expiresInSeconds: this.DOCKER_CONTAINER_NAME_CACHE_EXPIRY_SECONDS,
-            },
-          );
+          const l1Key: string = `${this.DOCKER_CONTAINER_NAME_CACHE_NAMESPACE}:${projectId.toString()}:${containerId}`;
+          // Skip the SETEX when this process already wrote this exact name.
+          if (this.containerNameL1Memo.get(l1Key) !== containerName) {
+            await GlobalCache.setString(
+              this.DOCKER_CONTAINER_NAME_CACHE_NAMESPACE,
+              `${projectId.toString()}:${containerId}`,
+              containerName,
+              {
+                expiresInSeconds:
+                  this.DOCKER_CONTAINER_NAME_CACHE_EXPIRY_SECONDS,
+              },
+            );
+            // Only after a successful write — a failed write must retry.
+            this.containerNameL1Memo.set(l1Key, containerName);
+          }
         }
       } catch (err) {
         logger.error(
@@ -857,11 +884,19 @@ export default abstract class OtelIngestBaseService {
           req as ExpressRequest & { projectId?: ObjectID }
         ).projectId;
         if (projectId) {
+          const l1Key: string = `${this.DOCKER_CONTAINER_NAME_CACHE_NAMESPACE}:${projectId.toString()}:${containerId}`;
+          const memoed: string | undefined =
+            this.containerNameL1Memo.get(l1Key);
+          if (memoed !== undefined) {
+            return this.normalizeDockerContainerName(memoed);
+          }
           const cached: string | null = await GlobalCache.getString(
             this.DOCKER_CONTAINER_NAME_CACHE_NAMESPACE,
             `${projectId.toString()}:${containerId}`,
           );
           if (cached) {
+            // Positives only — see containerNameL1Memo.
+            this.containerNameL1Memo.set(l1Key, cached);
             return this.normalizeDockerContainerName(cached);
           }
         }
@@ -911,14 +946,21 @@ export default abstract class OtelIngestBaseService {
           req as ExpressRequest & { projectId?: ObjectID }
         ).projectId;
         if (projectId) {
-          await GlobalCache.setString(
-            this.PODMAN_CONTAINER_NAME_CACHE_NAMESPACE,
-            `${projectId.toString()}:${containerId}`,
-            containerName,
-            {
-              expiresInSeconds: this.PODMAN_CONTAINER_NAME_CACHE_EXPIRY_SECONDS,
-            },
-          );
+          const l1Key: string = `${this.PODMAN_CONTAINER_NAME_CACHE_NAMESPACE}:${projectId.toString()}:${containerId}`;
+          // Skip the SETEX when this process already wrote this exact name.
+          if (this.containerNameL1Memo.get(l1Key) !== containerName) {
+            await GlobalCache.setString(
+              this.PODMAN_CONTAINER_NAME_CACHE_NAMESPACE,
+              `${projectId.toString()}:${containerId}`,
+              containerName,
+              {
+                expiresInSeconds:
+                  this.PODMAN_CONTAINER_NAME_CACHE_EXPIRY_SECONDS,
+              },
+            );
+            // Only after a successful write — a failed write must retry.
+            this.containerNameL1Memo.set(l1Key, containerName);
+          }
         }
       } catch (err) {
         logger.error(
@@ -938,11 +980,19 @@ export default abstract class OtelIngestBaseService {
           req as ExpressRequest & { projectId?: ObjectID }
         ).projectId;
         if (projectId) {
+          const l1Key: string = `${this.PODMAN_CONTAINER_NAME_CACHE_NAMESPACE}:${projectId.toString()}:${containerId}`;
+          const memoed: string | undefined =
+            this.containerNameL1Memo.get(l1Key);
+          if (memoed !== undefined) {
+            return this.normalizePodmanContainerName(memoed);
+          }
           const cached: string | null = await GlobalCache.getString(
             this.PODMAN_CONTAINER_NAME_CACHE_NAMESPACE,
             `${projectId.toString()}:${containerId}`,
           );
           if (cached) {
+            // Positives only — see containerNameL1Memo.
+            this.containerNameL1Memo.set(l1Key, cached);
             return this.normalizePodmanContainerName(cached);
           }
         }

--- a/App/FeatureSet/Telemetry/Services/TraceDropFilterService.ts
+++ b/App/FeatureSet/Telemetry/Services/TraceDropFilterService.ts
@@ -15,6 +15,7 @@ import {
   DropFilterSignal,
   recordDroppedRecord,
 } from "../Utils/DropFilterDropRecorder";
+import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
 
 export interface LoadedTraceDropFilter {
   filter: TraceDropFilter;
@@ -32,24 +33,23 @@ export interface LoadedTraceDropFilter {
   projectId: ObjectID;
 }
 
-interface CacheEntry {
-  filters: Array<LoadedTraceDropFilter>;
-  loadedAt: number;
-}
-
 const CACHE_TTL_MS: number = 60 * 1000; // 60 seconds
+const MAX_CACHED_PROJECTS: number = 10_000;
 
-const dropFilterCache: Map<string, CacheEntry> = new Map();
+const dropFilterCache: InMemoryTTLCache<Array<LoadedTraceDropFilter>> =
+  new InMemoryTTLCache<Array<LoadedTraceDropFilter>>(MAX_CACHED_PROJECTS);
 
 export class TraceDropFilterService {
   public static async loadDropFilters(
     projectId: ObjectID,
   ): Promise<Array<LoadedTraceDropFilter>> {
     const cacheKey: string = projectId.toString();
-    const cached: CacheEntry | undefined = dropFilterCache.get(cacheKey);
+    const cached: Array<LoadedTraceDropFilter> | undefined =
+      dropFilterCache.get(cacheKey);
 
-    if (cached && Date.now() - cached.loadedAt < CACHE_TTL_MS) {
-      return cached.filters;
+    // Empty arrays are truthy — zero-filter projects stay negatively cached.
+    if (cached) {
+      return cached;
     }
 
     const service: DatabaseService<TraceDropFilter> =
@@ -99,7 +99,7 @@ export class TraceDropFilterService {
       },
     );
 
-    dropFilterCache.set(cacheKey, { filters: loaded, loadedAt: Date.now() });
+    dropFilterCache.set(cacheKey, loaded, CACHE_TTL_MS);
     return loaded;
   }
 

--- a/App/FeatureSet/Telemetry/Services/TracePipelineService.ts
+++ b/App/FeatureSet/Telemetry/Services/TracePipelineService.ts
@@ -18,6 +18,7 @@ import {
   evaluateCompiledFilter,
 } from "../Utils/LogFilterEvaluator";
 import logger from "Common/Server/Utils/Logger";
+import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
 
 export interface LoadedTracePipeline {
   pipeline: TracePipeline;
@@ -30,28 +31,27 @@ export interface LoadedTracePipeline {
   processors: Array<TracePipelineProcessor>;
 }
 
-interface CacheEntry {
-  pipelines: Array<LoadedTracePipeline>;
-  loadedAt: number;
-}
-
 interface CompiledCategoryConfig extends CategoryProcessorConfig {
   _compiledCategoryFilters?: Array<CompiledFilter>;
 }
 
 const CACHE_TTL_MS: number = 60 * 1000; // 60 seconds
+const MAX_CACHED_PROJECTS: number = 10_000;
 
-const pipelineCache: Map<string, CacheEntry> = new Map();
+const pipelineCache: InMemoryTTLCache<Array<LoadedTracePipeline>> =
+  new InMemoryTTLCache<Array<LoadedTracePipeline>>(MAX_CACHED_PROJECTS);
 
 export class TracePipelineService {
   public static async loadPipelines(
     projectId: ObjectID,
   ): Promise<Array<LoadedTracePipeline>> {
     const cacheKey: string = projectId.toString();
-    const cached: CacheEntry | undefined = pipelineCache.get(cacheKey);
+    const cached: Array<LoadedTracePipeline> | undefined =
+      pipelineCache.get(cacheKey);
 
-    if (cached && Date.now() - cached.loadedAt < CACHE_TTL_MS) {
-      return cached.pipelines;
+    // Empty arrays are truthy — zero-pipeline projects stay negatively cached.
+    if (cached) {
+      return cached;
     }
 
     const pipelineService: DatabaseService<TracePipeline> =
@@ -114,7 +114,7 @@ export class TracePipelineService {
       });
     }
 
-    pipelineCache.set(cacheKey, { pipelines: loaded, loadedAt: Date.now() });
+    pipelineCache.set(cacheKey, loaded, CACHE_TTL_MS);
     return loaded;
   }
 

--- a/App/FeatureSet/Telemetry/Services/TraceScrubRuleService.ts
+++ b/App/FeatureSet/Telemetry/Services/TraceScrubRuleService.ts
@@ -8,12 +8,7 @@ import TraceScrubAction from "Common/Types/Trace/TraceScrubAction";
 import TraceScrubPatternType from "Common/Types/Trace/TraceScrubPatternType";
 import TraceScrubField from "Common/Types/Trace/TraceScrubField";
 import crypto from "crypto";
-
-interface CacheEntry {
-  rules: Array<TraceScrubRule>;
-  compiledPatterns: Array<CompiledRule>;
-  loadedAt: number;
-}
+import InMemoryTTLCache from "Common/Server/Infrastructure/InMemoryTTLCache";
 
 interface CompiledRule {
   rule: TraceScrubRule;
@@ -21,8 +16,10 @@ interface CompiledRule {
 }
 
 const CACHE_TTL_MS: number = 60 * 1000; // 60 seconds
+const MAX_CACHED_PROJECTS: number = 10_000;
 
-const scrubRuleCache: Map<string, CacheEntry> = new Map();
+const scrubRuleCache: InMemoryTTLCache<Array<CompiledRule>> =
+  new InMemoryTTLCache<Array<CompiledRule>>(MAX_CACHED_PROJECTS);
 
 // Built-in PII detection patterns — same set as logs.
 const BUILT_IN_PATTERNS: Record<string, RegExp> = {
@@ -49,10 +46,12 @@ export class TraceScrubRuleService {
     projectId: ObjectID,
   ): Promise<Array<CompiledRule>> {
     const cacheKey: string = projectId.toString();
-    const cached: CacheEntry | undefined = scrubRuleCache.get(cacheKey);
+    const cached: Array<CompiledRule> | undefined =
+      scrubRuleCache.get(cacheKey);
 
-    if (cached && Date.now() - cached.loadedAt < CACHE_TTL_MS) {
-      return cached.compiledPatterns;
+    // Empty arrays are truthy — zero-rule projects stay negatively cached.
+    if (cached) {
+      return cached;
     }
 
     const service: DatabaseService<TraceScrubRule> =
@@ -95,11 +94,7 @@ export class TraceScrubRuleService {
       }
     }
 
-    scrubRuleCache.set(cacheKey, {
-      rules,
-      compiledPatterns,
-      loadedAt: Date.now(),
-    });
+    scrubRuleCache.set(cacheKey, compiledPatterns, CACHE_TTL_MS);
 
     return compiledPatterns;
   }

--- a/App/FeatureSet/Workers/Jobs/AIAgent/UpdateConnectionStatus.ts
+++ b/App/FeatureSet/Workers/Jobs/AIAgent/UpdateConnectionStatus.ts
@@ -1,11 +1,27 @@
 import OneUptimeDate from "Common/Types/Date";
 import RunCron from "../../Utils/Cron";
 import { EVERY_MINUTE } from "Common/Utils/CronTime";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
 import AIAgentService from "Common/Server/Services/AIAgentService";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
 import logger from "Common/Server/Utils/Logger";
 import AIAgent, {
   AIAgentConnectionStatus,
 } from "Common/Models/DatabaseModels/AIAgent";
+
+/*
+ * Staleness cutoff, chosen for exact parity with the historical in-process
+ * check `OneUptimeDate.getDifferenceInMinutes(now, lastAlive) > 2`:
+ * moment's diff-in-minutes truncates, so "difference > 2 minutes" was only
+ * true once an agent was >= 3 whole minutes stale. The SQL predicate
+ * `lastAlive <= now - 3 minutes` flips at exactly the same instant.
+ */
+const STALE_CUTOFF_IN_MINUTES: number = 3;
+
+type FlipCandidate = {
+  aiAgent: AIAgent;
+  newStatus: AIAgentConnectionStatus;
+};
 
 RunCron(
   "AIAgent:UpdateConnectionStatus",
@@ -15,82 +31,125 @@ RunCron(
       service: "workers",
     });
 
-    const aiAgents: Array<AIAgent> = await AIAgentService.findAllBy({
-      query: {},
-      props: {
-        isRoot: true,
+    const staleCutoff: Date = OneUptimeDate.getSomeMinutesAgo(
+      STALE_CUTOFF_IN_MINUTES,
+    );
+
+    /*
+     * Fetch ONLY the agents whose stored status disagrees with what their
+     * lastAlive implies, instead of every AI agent row in the system every
+     * minute. On a steady-state deployment both queries return zero rows —
+     * the common case costs two indexed-predicate SELECTs and nothing else.
+     *
+     * A NULL connectionStatus (agent that never had one stamped) counts as
+     * "disagrees" for both directions, mirroring the old in-process
+     * comparison `aiAgent.connectionStatus !== computedStatus`. The
+     * notify-owners hook (AIAgentService.onBeforeUpdate) independently skips
+     * NULL→anything transitions, so no extra notifications are introduced.
+     */
+    const toDisconnect: Array<AIAgent> = await AIAgentService.findBy({
+      query: {
+        // Stale OR never seen at all.
+        lastAlive: QueryHelper.lessThanEqualToOrNull(staleCutoff),
+        connectionStatus: QueryHelper.notInOrNull([
+          AIAgentConnectionStatus.Disconnected,
+        ]),
       },
       select: {
         _id: true,
-        lastAlive: true,
-        connectionStatus: true,
         projectId: true,
+      },
+      skip: 0,
+      limit: LIMIT_MAX,
+      props: {
+        isRoot: true,
       },
     });
 
-    logger.debug(`Found ${aiAgents.length} AI agents`, { service: "workers" });
+    const toConnect: Array<AIAgent> = await AIAgentService.findBy({
+      query: {
+        lastAlive: QueryHelper.greaterThan(staleCutoff),
+        connectionStatus: QueryHelper.notInOrNull([
+          AIAgentConnectionStatus.Connected,
+        ]),
+      },
+      select: {
+        _id: true,
+        projectId: true,
+      },
+      skip: 0,
+      limit: LIMIT_MAX,
+      props: {
+        isRoot: true,
+      },
+    });
 
-    logger.debug(aiAgents, { service: "workers" });
+    /*
+     * An agent can appear in BOTH lists in one narrow case: its
+     * connectionStatus is NULL (matches neither notInOrNull filter) and a
+     * heartbeat landed between the two SELECTs, moving it from stale to
+     * fresh. The connect query ran later, so its verdict is the fresher
+     * one — drop the disconnect flip rather than writing both.
+     */
+    const toConnectIds: Set<string> = new Set(
+      toConnect.map((aiAgent: AIAgent) => {
+        return aiAgent.id?.toString() || "";
+      }),
+    );
 
-    for (const aiAgent of aiAgents) {
+    const flips: Array<FlipCandidate> = [
+      ...toDisconnect
+        .filter((aiAgent: AIAgent) => {
+          return !toConnectIds.has(aiAgent.id?.toString() || "");
+        })
+        .map((aiAgent: AIAgent) => {
+          return {
+            aiAgent,
+            newStatus: AIAgentConnectionStatus.Disconnected,
+          };
+        }),
+      ...toConnect.map((aiAgent: AIAgent) => {
+        return {
+          aiAgent,
+          newStatus: AIAgentConnectionStatus.Connected,
+        };
+      }),
+    ];
+
+    if (flips.length === 0) {
+      return;
+    }
+
+    logger.debug(
+      `Found ${toDisconnect.length} AI agent(s) to mark Disconnected and ${toConnect.length} to mark Connected`,
+      { service: "workers" },
+    );
+
+    for (const flip of flips) {
       try {
-        // if the lastAlive is more than 2 minutes old, then set the connection status to false
-
-        if (!aiAgent.id) {
+        if (!flip.aiAgent.id) {
           continue;
         }
 
-        let connectionStatus: AIAgentConnectionStatus =
-          AIAgentConnectionStatus.Connected;
-
-        if (!aiAgent.lastAlive) {
-          connectionStatus = AIAgentConnectionStatus.Disconnected;
-        }
-
-        if (
-          aiAgent.lastAlive &&
-          OneUptimeDate.getDifferenceInMinutes(
-            OneUptimeDate.getCurrentDate(),
-            aiAgent.lastAlive,
-          ) > 2
-        ) {
-          connectionStatus = AIAgentConnectionStatus.Disconnected;
-        } else {
-          connectionStatus = AIAgentConnectionStatus.Connected;
-        }
-
-        if (!aiAgent.lastAlive) {
-          connectionStatus = AIAgentConnectionStatus.Disconnected;
-        }
-
-        let shouldUpdateConnectionStatus: boolean = false;
-
-        if (aiAgent.connectionStatus !== connectionStatus) {
-          shouldUpdateConnectionStatus = true;
-        }
-
-        if (!shouldUpdateConnectionStatus) {
-          continue; // no need to update the connection status.
-        }
-
-        // now update the connection status
-        aiAgent.connectionStatus = connectionStatus;
-
-        if (shouldUpdateConnectionStatus) {
-          await AIAgentService.updateOneById({
-            id: aiAgent.id!,
-            data: {
-              connectionStatus: connectionStatus,
-            },
-            props: {
-              isRoot: true,
-            },
-          });
-        }
+        /*
+         * Full-pipeline update on purpose: the status flip is what fires
+         * AIAgentService's hooks (owner notifications). Those hooks are the
+         * expensive part, which is exactly why the queries above make sure
+         * this only ever runs for agents that actually changed state.
+         */
+        await AIAgentService.updateOneById({
+          id: flip.aiAgent.id,
+          data: {
+            connectionStatus: flip.newStatus,
+          },
+          props: {
+            isRoot: true,
+          },
+        });
       } catch (error) {
         logger.error(error, {
           service: "workers",
-          projectId: aiAgent.projectId?.toString(),
+          projectId: flip.aiAgent.projectId?.toString(),
         });
       }
     }

--- a/App/Tests/Notification/MailServiceTemplateCache.test.ts
+++ b/App/Tests/Notification/MailServiceTemplateCache.test.ts
@@ -1,0 +1,335 @@
+/*
+ * PasswordHash reaches this suite through MailService -> EmailLogService and
+ * fails ts-jest compilation on TS 5.9 (pre-existing TS2345). Nothing here
+ * exercises it, so replace it before the import graph drags it into
+ * compilation — same workaround as the Telemetry suites in this repo.
+ */
+jest.mock("Common/Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
+import EmailTemplateType from "Common/Types/Email/EmailTemplateType";
+import { afterEach, describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import fsp from "fs/promises";
+import Handlebars from "handlebars";
+import Path from "path";
+
+/*
+ * compileEmailBody caches the compiled Handlebars delegate per template name,
+ * so parse/codegen runs once per template type per process instead of once
+ * per email. These tests pin the cache behavior: compile-once in production
+ * mode, per-type isolation, the development-mode hot-reload bypass, failures
+ * never being memoized, and rendered output staying per-call.
+ *
+ * The cache is intentionally bypassed when IsDevelopment (template
+ * hot-reload), and App's npm test script exports config.env which sets
+ * ENVIRONMENT=development — so every test loads MailService through
+ * jest.isolateModules with ENVIRONMENT forced explicitly, never relying on
+ * the ambient environment. fs/promises is a core module shared across
+ * isolate contexts, so the fsp spies below still observe the isolated
+ * service's reads; handlebars is not, so each load registers partials and
+ * spies compile on its own isolated environment.
+ */
+
+const TEMPLATES_DIR: string = Path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "FeatureSet",
+  "Notification",
+  "Templates",
+);
+
+type SpyLike = {
+  mock: { calls: Array<Array<unknown>> };
+  mockRestore: () => void;
+};
+
+type Vars = Record<string, string>;
+
+function inviteVars(projectName: string): Vars {
+  return {
+    projectName: projectName,
+    signInLink: "https://oneuptime.test/accounts",
+    registerLink: "https://oneuptime.test/accounts/register",
+    homeUrl: "https://oneuptime.test",
+    isInvitationAccepted: "false",
+    isNewUser: "false",
+  };
+}
+
+/*
+ * Mirrors FeatureSet/Notification/Utils/Handlebars.ts on a given Handlebars
+ * environment. Partials are registered pre-compiled (as the util does), so
+ * render-time partial resolution never calls env.compile and the compile
+ * spies below count only template compiles.
+ */
+function registerTemplateEnvironment(hb: typeof Handlebars): void {
+  const partialsDir: string = Path.resolve(TEMPLATES_DIR, "Partials");
+
+  for (const filename of fs.readdirSync(partialsDir)) {
+    const matches: RegExpMatchArray | null = filename.match(/^(.*)\.hbs$/);
+
+    if (!matches) {
+      continue;
+    }
+
+    hb.registerPartial(
+      matches[1]!,
+      hb.compile(
+        fs.readFileSync(Path.resolve(partialsDir, filename), {
+          encoding: "utf8",
+        }),
+      ),
+    );
+  }
+
+  hb.registerHelper("ifCond", function (v1: any, v2: any, options: any) {
+    // @ts-expect-error - Handlebars uses dynamic this context for template helpers
+    return v1 === v2 ? options.fn(this) : options.inverse(this);
+  });
+
+  hb.registerHelper("ifNotCond", function (v1: any, v2: any, options: any) {
+    // @ts-expect-error - Handlebars uses dynamic this context for template helpers
+    return v1 !== v2 ? options.fn(this) : options.inverse(this);
+  });
+
+  hb.registerHelper("concat", (v1: any, v2: any) => {
+    return v1 + v2;
+  });
+}
+
+type IsolatedMailEnvironment = {
+  service: any;
+  hb: typeof Handlebars;
+};
+
+function loadMailService(environment: string): IsolatedMailEnvironment {
+  const originalEnvironment: string | undefined = process.env["ENVIRONMENT"];
+  process.env["ENVIRONMENT"] = environment;
+
+  let service: any = null;
+  let hb: typeof Handlebars | null = null;
+
+  try {
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      hb = require("handlebars");
+      registerTemplateEnvironment(hb!);
+      service =
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+        require("../../FeatureSet/Notification/Services/MailService").default;
+    });
+  } finally {
+    if (originalEnvironment === undefined) {
+      delete process.env["ENVIRONMENT"];
+    } else {
+      process.env["ENVIRONMENT"] = originalEnvironment;
+    }
+  }
+
+  return { service: service, hb: hb! };
+}
+
+function compileEmailBody(
+  env: IsolatedMailEnvironment,
+  templateType: EmailTemplateType,
+  vars: Vars,
+): Promise<string> {
+  return env.service.compileEmailBody(templateType, vars);
+}
+
+function templateMemo(
+  env: IsolatedMailEnvironment,
+): Map<string, Handlebars.TemplateDelegate> {
+  return env.service.compiledEmailTemplates;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("MailService.compileEmailBody - compiled template cache", () => {
+  test("compiles and reads the template file once across repeated sends", async () => {
+    const env: IsolatedMailEnvironment = loadMailService("production");
+    const compileSpy: SpyLike = jest.spyOn(
+      env.hb,
+      "compile",
+    ) as unknown as SpyLike;
+    const readSpy: SpyLike = jest.spyOn(fsp, "readFile") as unknown as SpyLike;
+
+    await compileEmailBody(
+      env,
+      EmailTemplateType.InviteMember,
+      inviteVars("Cache Alpha Project"),
+    );
+    await compileEmailBody(
+      env,
+      EmailTemplateType.InviteMember,
+      inviteVars("Cache Beta Project"),
+    );
+
+    expect(compileSpy.mock.calls.length).toBe(1);
+    expect(readSpy.mock.calls.length).toBe(1);
+  });
+
+  test("caches the delegate, not the rendered HTML", async () => {
+    const env: IsolatedMailEnvironment = loadMailService("production");
+
+    const first: string = await compileEmailBody(
+      env,
+      EmailTemplateType.InviteMember,
+      inviteVars("Cache Alpha Project"),
+    );
+    const second: string = await compileEmailBody(
+      env,
+      EmailTemplateType.InviteMember,
+      inviteVars("Cache Beta Project"),
+    );
+
+    expect(first).not.toBe(second);
+    expect(first).toContain("Cache Alpha Project");
+    expect(first).not.toContain("Cache Beta Project");
+    expect(second).toContain("Cache Beta Project");
+    expect(second).not.toContain("Cache Alpha Project");
+  });
+
+  test("caches per template type and renders each from its own template", async () => {
+    const env: IsolatedMailEnvironment = loadMailService("production");
+    const compileSpy: SpyLike = jest.spyOn(
+      env.hb,
+      "compile",
+    ) as unknown as SpyLike;
+    const readSpy: SpyLike = jest.spyOn(fsp, "readFile") as unknown as SpyLike;
+
+    const inviteHtml: string = await compileEmailBody(
+      env,
+      EmailTemplateType.InviteMember,
+      inviteVars("Cache Alpha Project"),
+    );
+    const forgotHtml: string = await compileEmailBody(
+      env,
+      EmailTemplateType.ForgotPassword,
+      {
+        tokenVerifyUrl: "https://oneuptime.test/reset-password/token-123",
+        homeUrl: "https://oneuptime.test",
+      },
+    );
+
+    // Repeat sends of both types hit the memo.
+    await compileEmailBody(
+      env,
+      EmailTemplateType.InviteMember,
+      inviteVars("Cache Beta Project"),
+    );
+    await compileEmailBody(env, EmailTemplateType.ForgotPassword, {
+      tokenVerifyUrl: "https://oneuptime.test/reset-password/token-456",
+      homeUrl: "https://oneuptime.test",
+    });
+
+    expect(compileSpy.mock.calls.length).toBe(2);
+    expect(readSpy.mock.calls.length).toBe(2);
+
+    expect(inviteHtml).toContain("Invited to Cache Alpha Project");
+    expect(inviteHtml).not.toContain("Reset Your Password");
+    expect(forgotHtml).toContain("Reset Your Password");
+    expect(forgotHtml).toContain(
+      "https://oneuptime.test/reset-password/token-123",
+    );
+    expect(forgotHtml).not.toContain("Invited");
+  });
+
+  test("development mode re-reads and recompiles on every send (hot-reload)", async () => {
+    const env: IsolatedMailEnvironment = loadMailService("development");
+    const compileSpy: SpyLike = jest.spyOn(
+      env.hb,
+      "compile",
+    ) as unknown as SpyLike;
+    const readSpy: SpyLike = jest.spyOn(fsp, "readFile") as unknown as SpyLike;
+
+    const first: string = await compileEmailBody(
+      env,
+      EmailTemplateType.InviteMember,
+      inviteVars("Dev Alpha Project"),
+    );
+    const second: string = await compileEmailBody(
+      env,
+      EmailTemplateType.InviteMember,
+      inviteVars("Dev Beta Project"),
+    );
+
+    expect(readSpy.mock.calls.length).toBe(2);
+    expect(compileSpy.mock.calls.length).toBe(2);
+    expect(first).toContain("Dev Alpha Project");
+    expect(second).toContain("Dev Beta Project");
+  });
+
+  test("a failed template read is not memoized and the next send recovers", async () => {
+    const env: IsolatedMailEnvironment = loadMailService("production");
+
+    jest
+      .spyOn(fsp, "readFile")
+      .mockRejectedValueOnce(new Error("disk exploded"));
+
+    await expect(
+      compileEmailBody(
+        env,
+        EmailTemplateType.InviteMember,
+        inviteVars("Cache Alpha Project"),
+      ),
+    ).rejects.toThrow("disk exploded");
+
+    expect(templateMemo(env).size).toBe(0);
+
+    // The spy falls back to the real readFile after the queued rejection.
+    const html: string = await compileEmailBody(
+      env,
+      EmailTemplateType.InviteMember,
+      inviteVars("Cache Alpha Project"),
+    );
+
+    expect(html).toContain("Cache Alpha Project");
+    expect(templateMemo(env).size).toBe(1);
+  });
+
+  test("two concurrent first sends of one template both render correctly", async () => {
+    const env: IsolatedMailEnvironment = loadMailService("production");
+
+    const [first, second] = await Promise.all([
+      compileEmailBody(
+        env,
+        EmailTemplateType.InviteMember,
+        inviteVars("Cache Alpha Project"),
+      ),
+      compileEmailBody(
+        env,
+        EmailTemplateType.InviteMember,
+        inviteVars("Cache Beta Project"),
+      ),
+    ]);
+
+    expect(first).toContain("Cache Alpha Project");
+    expect(second).toContain("Cache Beta Project");
+
+    // Last write wins; the memo holds exactly one delegate for the type.
+    expect(templateMemo(env).size).toBe(1);
+
+    const third: string = await compileEmailBody(
+      env,
+      EmailTemplateType.InviteMember,
+      inviteVars("Cache Gamma Project"),
+    );
+
+    expect(third).toContain("Cache Gamma Project");
+  });
+});

--- a/App/Tests/Telemetry/OtelIngestContainerNameL1Memo.test.ts
+++ b/App/Tests/Telemetry/OtelIngestContainerNameL1Memo.test.ts
@@ -1,0 +1,367 @@
+/*
+ * The Queue infrastructure module pulls in BullMQ (ESM-only msgpackr) at
+ * import time via the services' queue imports; nothing queue-related is
+ * under test here, so the module is replaced — same idiom as
+ * OtelIngestEntityIdL1Memo.test.ts in this directory.
+ */
+jest.mock("Common/Server/Infrastructure/Queue", () => {
+  return {
+    __esModule: true,
+    default: {
+      addJob: jest.fn(),
+    },
+    QueueName: {
+      Workflow: "Workflow",
+      Worker: "Worker",
+      Telemetry: "Telemetry",
+      Runbook: "Runbook",
+    },
+  };
+});
+
+/*
+ * PasswordHash carries a pre-existing TS5.9 diagnostic that fails any suite
+ * whose runtime require graph reaches it (DatabaseService, the base class
+ * of every concrete service, imports it). Nothing password-related is under
+ * test here, so the module is replaced WITH A FACTORY — an automock would
+ * still require (and type-check) the real file.
+ */
+jest.mock("Common/Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
+
+import OtelIngestBaseService from "../../FeatureSet/Telemetry/Services/OtelIngestBaseService";
+import GlobalCache from "Common/Server/Infrastructure/GlobalCache";
+import logger from "Common/Server/Utils/Logger";
+import ObjectID from "Common/Types/ObjectID";
+import { JSONArray, JSONObject } from "Common/Types/JSON";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * The shared container-name L1 memo in front of the docker/podman
+ * id -> name Redis caches in getDockerServiceName / getPodmanServiceName.
+ *
+ * docker_stats metric batches carry container.id AND container.name and used
+ * to pay one serialized Redis SETEX per resource block; filelog log batches
+ * carry only container.id and paid one GET per block. The L1 collapses the
+ * steady state to zero round trips — but ONLY for positive outcomes:
+ *
+ *   1. WRITE DEDUPE: an identical (project, container) -> name write from
+ *      this process is suppressed inside the 60s TTL; a RENAME still writes
+ *      through immediately (the memoed value differs).
+ *   2. READ MEMO: one Redis hit serves same-pod lookups for the TTL, and a
+ *      metrics block warms the log path in the same process.
+ *   3. MISSES ARE NEVER MEMOED: an unresolved id must retry Redis on every
+ *      block, or container-name resolution would be delayed and log rows
+ *      misrouted to the DockerHost/PodmanHost entity for the TTL.
+ *   4. The memo is set only AFTER a successful Redis write, so a failed
+ *      write retries on the next block exactly as before.
+ *   5. Memo hits and Redis hits normalize through the same function, so the
+ *      returned service name is byte-identical either way.
+ */
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const CONTAINER_ID: string = "4f5a6b7c8d9e0f1a2b3c";
+const RAW_NAME: string = "oneuptime-postgres-1";
+const NORMALIZED_NAME: string = "oneuptime-postgres";
+const CACHE_EXPIRY_SECONDS: number = 24 * 60 * 60;
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const baseService: Record<string, any> =
+  OtelIngestBaseService as unknown as Record<string, any>;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+function stringAttribute(key: string, value: string): JSONObject {
+  return { key: key, value: { stringValue: value } };
+}
+
+type RuntimeCase = {
+  /** describe() title. */
+  name: string;
+  /** The private resolver under test. */
+  method: string;
+  /** The Redis namespace its id -> name cache lives under. */
+  namespace: string;
+  /** The container.runtime attribute value real batches carry. */
+  runtime: string;
+};
+
+const RUNTIME_CASES: Array<RuntimeCase> = [
+  {
+    name: "getDockerServiceName",
+    method: "getDockerServiceName",
+    namespace: "docker-container-name",
+    runtime: "docker",
+  },
+  {
+    name: "getPodmanServiceName",
+    method: "getPodmanServiceName",
+    namespace: "podman-container-name",
+    runtime: "podman",
+  },
+];
+
+describe.each(RUNTIME_CASES)(
+  "$name container-name L1 memo",
+  ({ method, namespace, runtime }: RuntimeCase) => {
+    /** Stands in for Redis, keyed `namespace:key` like the real client. */
+    let fakeRedis: Map<string, string>;
+    let nowMs: number;
+
+    /** docker_stats shape: both container.id and container.name. */
+    function metricsAttributes(containerName: string): JSONArray {
+      return [
+        stringAttribute("container.runtime", runtime),
+        stringAttribute("container.id", CONTAINER_ID),
+        stringAttribute("container.name", containerName),
+      ] as JSONArray;
+    }
+
+    /** filelog shape: container.id only. */
+    function logAttributes(containerId: string): JSONArray {
+      return [
+        stringAttribute("container.runtime", runtime),
+        stringAttribute("container.id", containerId),
+      ] as JSONArray;
+    }
+
+    /*
+     * `null` means "request carries no projectId" — an explicit `undefined`
+     * argument would trigger the default parameter instead.
+     */
+    async function resolve(
+      attributes: JSONArray,
+      projectId: ObjectID | null = PROJECT_ID,
+    ): Promise<string | null> {
+      return (await baseService[method](
+        { headers: {}, projectId: projectId ?? undefined },
+        attributes,
+      )) as string | null;
+    }
+
+    function nameGetCalls(): number {
+      return (GlobalCache.getString as jest.Mock).mock.calls.filter(
+        (call: Array<unknown>) => {
+          return call[0] === namespace;
+        },
+      ).length;
+    }
+
+    function nameSetCalls(): Array<Array<unknown>> {
+      return (GlobalCache.setString as jest.Mock).mock.calls.filter(
+        (call: Array<unknown>) => {
+          return call[0] === namespace;
+        },
+      );
+    }
+
+    function seedRedis(rawName: string): void {
+      fakeRedis.set(
+        `${namespace}:${PROJECT_ID.toString()}:${CONTAINER_ID}`,
+        rawName,
+      );
+    }
+
+    beforeEach(() => {
+      fakeRedis = new Map<string, string>();
+      nowMs = 1_700_000_000_000;
+
+      /*
+       * The in-process memos survive across tests inside one process; treat
+       * their TTLs as expired between cases, the same way fakeRedis is
+       * rebuilt.
+       */
+      OtelIngestBaseService.clearInProcessMemos();
+
+      jest.spyOn(Date, "now").mockImplementation(() => {
+        return nowMs;
+      });
+
+      jest
+        .spyOn(GlobalCache, "getString")
+        .mockImplementation(async (ns: string, key: string) => {
+          return fakeRedis.get(`${ns}:${key}`) ?? null;
+        });
+      jest
+        .spyOn(GlobalCache, "setString")
+        .mockImplementation(async (ns: string, key: string, value: string) => {
+          fakeRedis.set(`${ns}:${key}`, value);
+        });
+
+      // The outage / write-failure cases log through here; keep them quiet.
+      jest.spyOn(logger, "error").mockImplementation(() => {
+        return undefined;
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      OtelIngestBaseService.clearInProcessMemos();
+    });
+
+    test("repeat metrics blocks write the id -> name mapping once", async () => {
+      const first: string | null = await resolve(metricsAttributes(RAW_NAME));
+      const second: string | null = await resolve(metricsAttributes(RAW_NAME));
+
+      expect(first).toBe(NORMALIZED_NAME);
+      expect(second).toBe(NORMALIZED_NAME);
+
+      const sets: Array<Array<unknown>> = nameSetCalls();
+      expect(sets).toHaveLength(1);
+      expect(sets[0]).toEqual([
+        namespace,
+        `${PROJECT_ID.toString()}:${CONTAINER_ID}`,
+        RAW_NAME,
+        { expiresInSeconds: CACHE_EXPIRY_SECONDS },
+      ]);
+    });
+
+    test("a renamed container writes through immediately", async () => {
+      const first: string | null = await resolve(metricsAttributes("web-1"));
+      const second: string | null = await resolve(
+        metricsAttributes("renamed-1"),
+      );
+
+      expect(first).toBe("web");
+      expect(second).toBe("renamed");
+
+      const sets: Array<Array<unknown>> = nameSetCalls();
+      expect(sets).toHaveLength(2);
+      expect(sets[1]?.[2]).toBe("renamed-1");
+    });
+
+    test("repeat log blocks after one Redis hit issue no further GET", async () => {
+      seedRedis(RAW_NAME);
+
+      const first: string | null = await resolve(logAttributes(CONTAINER_ID));
+      const second: string | null = await resolve(logAttributes(CONTAINER_ID));
+
+      expect(first).toBe(NORMALIZED_NAME);
+      expect(second).toBe(NORMALIZED_NAME);
+      expect(nameGetCalls()).toBe(1);
+    });
+
+    /*
+     * THE guardrail: a miss is never memoed. Caching it would delay
+     * first-contact name resolution and misroute that container's log rows
+     * to the DockerHost/PodmanHost entity for the memo TTL.
+     */
+    test("a read miss is not memoed: every block retries Redis", async () => {
+      const first: string | null = await resolve(logAttributes(CONTAINER_ID));
+      const second: string | null = await resolve(logAttributes(CONTAINER_ID));
+
+      expect(first).toBeNull();
+      expect(second).toBeNull();
+      expect(nameGetCalls()).toBe(2);
+    });
+
+    test("a metrics block warms the log path: id-only lookup costs zero GETs", async () => {
+      await resolve(metricsAttributes(RAW_NAME));
+
+      const resolved: string | null = await resolve(
+        logAttributes(CONTAINER_ID),
+      );
+
+      expect(resolved).toBe(NORMALIZED_NAME);
+      expect(nameGetCalls()).toBe(0);
+    });
+
+    test("a warmed name keeps resolving through a Redis outage; cold ids return null", async () => {
+      seedRedis(RAW_NAME);
+      await resolve(logAttributes(CONTAINER_ID));
+
+      jest
+        .spyOn(GlobalCache, "getString")
+        .mockRejectedValue(new Error("redis down"));
+
+      const warm: string | null = await resolve(logAttributes(CONTAINER_ID));
+      expect(warm).toBe(NORMALIZED_NAME);
+
+      // Cold entry under the same outage: error swallowed, null returned.
+      const cold: string | null = await resolve(
+        logAttributes("0000aaaabbbbcccc"),
+      );
+      expect(cold).toBeNull();
+    });
+
+    test("a failed write is not memoed: the next metrics block retries", async () => {
+      jest
+        .spyOn(GlobalCache, "setString")
+        .mockRejectedValue(new Error("redis down"));
+
+      const first: string | null = await resolve(metricsAttributes(RAW_NAME));
+      const second: string | null = await resolve(metricsAttributes(RAW_NAME));
+
+      // The name still resolves — the cache is best-effort.
+      expect(first).toBe(NORMALIZED_NAME);
+      expect(second).toBe(NORMALIZED_NAME);
+      expect(nameSetCalls()).toHaveLength(2);
+    });
+
+    test("the memo expires on its TTL and falls back to Redis", async () => {
+      seedRedis(RAW_NAME);
+      await resolve(logAttributes(CONTAINER_ID));
+      expect(nameGetCalls()).toBe(1);
+
+      nowMs += 61 * 1000;
+      const resolved: string | null = await resolve(
+        logAttributes(CONTAINER_ID),
+      );
+
+      expect(resolved).toBe(NORMALIZED_NAME);
+      expect(nameGetCalls()).toBe(2);
+    });
+
+    test("clearInProcessMemos drops the memo: the next read GETs again", async () => {
+      seedRedis(RAW_NAME);
+      await resolve(logAttributes(CONTAINER_ID));
+      expect(nameGetCalls()).toBe(1);
+
+      OtelIngestBaseService.clearInProcessMemos();
+
+      const resolved: string | null = await resolve(
+        logAttributes(CONTAINER_ID),
+      );
+      expect(resolved).toBe(NORMALIZED_NAME);
+      expect(nameGetCalls()).toBe(2);
+    });
+
+    test("projectId absent: no cache traffic, memo never consulted", async () => {
+      const named: string | null = await resolve(
+        metricsAttributes(RAW_NAME),
+        null,
+      );
+      expect(named).toBe(NORMALIZED_NAME);
+      expect(nameSetCalls()).toHaveLength(0);
+
+      const idOnly: string | null = await resolve(
+        logAttributes(CONTAINER_ID),
+        null,
+      );
+      expect(idOnly).toBeNull();
+      expect(nameGetCalls()).toBe(0);
+    });
+
+    test("memo hits and Redis hits normalize identically", async () => {
+      seedRedis("oneuptime-postgres-1");
+
+      const redisHit: string | null = await resolve(
+        logAttributes(CONTAINER_ID),
+      );
+      const memoHit: string | null = await resolve(logAttributes(CONTAINER_ID));
+
+      expect(nameGetCalls()).toBe(1);
+      expect(redisHit).toBe("oneuptime-postgres");
+      expect(memoHit).toBe(redisHit);
+    });
+  },
+);

--- a/App/Tests/Telemetry/PipelineRuleCacheBounding.test.ts
+++ b/App/Tests/Telemetry/PipelineRuleCacheBounding.test.ts
@@ -1,0 +1,294 @@
+/*
+ * PasswordHash has a known, pre-existing TS5.9 compile failure under
+ * ts-jest (Buffer vs BinaryLike) that breaks every suite whose import
+ * graph reaches it. Nothing here touches password hashing; stub the
+ * module before the service import graph drags it into compilation.
+ */
+jest.mock("Common/Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: class PasswordHashStub {},
+  };
+});
+
+/*
+ * These tests exercise the rule loaders' 60s per-project caches, so the
+ * one Postgres touchpoint — DatabaseService.findBy — is stubbed and
+ * counted. The base-class no-ops mirror MetricPipelineRegexCompile.test.ts:
+ * `hardDeleteItemsOlderThanInDays` runs from ~100 service constructors
+ * `if (IsBillingEnabled)`, which CI turns ON (Common/test-setup.sh writes
+ * BILLING_ENABLED=true), so a bare `class {}` passes locally and dies in CI.
+ */
+jest.mock("Common/Server/Services/DatabaseService", () => {
+  return {
+    __esModule: true,
+    default: class DatabaseServiceStub {
+      public hardDeleteItemsOlderThanInDays(): void {
+        // no-op: retention config, nothing for a pure unit test to do.
+      }
+
+      public setDoNotAllowDelete(): void {
+        // no-op: delete-permission config, same.
+      }
+
+      public findBy(...args: Array<unknown>): Promise<Array<unknown>> {
+        return mockFindBy(...args);
+      }
+    },
+  };
+});
+
+import LogPipelineService, {
+  LoadedPipeline,
+} from "../../FeatureSet/Telemetry/Services/LogPipelineService";
+import TracePipelineService from "../../FeatureSet/Telemetry/Services/TracePipelineService";
+import LogDropFilterService, {
+  LoadedLogDropFilter,
+} from "../../FeatureSet/Telemetry/Services/LogDropFilterService";
+import TraceDropFilterService from "../../FeatureSet/Telemetry/Services/TraceDropFilterService";
+import LogScrubRuleService from "../../FeatureSet/Telemetry/Services/LogScrubRuleService";
+import TraceScrubRuleService from "../../FeatureSet/Telemetry/Services/TraceScrubRuleService";
+import MetricPipelineRuleService, {
+  MetricRulesForProject,
+} from "../../FeatureSet/Telemetry/Services/MetricPipelineRuleService";
+import LogPipeline from "Common/Models/DatabaseModels/LogPipeline";
+import ObjectID from "Common/Types/ObjectID";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Contract under test — every telemetry rule loader (log/trace pipelines,
+ * drop filters, scrub rules, metric rules) caches its per-project rows for
+ * 60s in a bounded InMemoryTTLCache. These tests pin the cache semantics
+ * the ingest hot path relies on:
+ *
+ * - a cache hit returns the SAME array/object reference without touching
+ *   the database again (by-reference storage is what lets the trace/log
+ *   category processors lazily memoize compiled filters onto cached
+ *   config objects);
+ * - an EMPTY result is cached too — a project with zero rules must not
+ *   re-query Postgres for every record batch (empty arrays are truthy;
+ *   a `if (cached)` guard regression to falsy-checking contents would
+ *   break this);
+ * - the entry expires after 60s and the next load re-queries;
+ * - MetricPipelineRuleService.clearCache() still empties the rule cache.
+ *
+ * Capacity eviction (the 10k bound) lives entirely in the shared
+ * InMemoryTTLCache and is covered by its own unit test in
+ * Common/Tests/Server/Infrastructure/InMemoryTTLCache.test.ts.
+ */
+
+/*
+ * Referenced from the jest.mock factory above — the `mock` prefix is what
+ * lets babel-plugin-jest-hoist allow the out-of-scope capture.
+ */
+const mockFindBy: (...args: Array<unknown>) => Promise<Array<unknown>> =
+  jest.fn((): Promise<Array<unknown>> => {
+    return Promise.resolve([]);
+  });
+
+/*
+ * Minimal structural views of jest mocks/spies — the @jest/globals and
+ * @types/jest typings disagree in this repo, so annotate with just the
+ * surface these tests use.
+ */
+type MockLike = {
+  mock: { calls: Array<Array<unknown>> };
+  mockClear: () => void;
+  mockReturnValueOnce: (value: Promise<Array<unknown>>) => unknown;
+};
+
+type NowSpyLike = {
+  mockReturnValue: (value: number) => unknown;
+  mockRestore: () => void;
+};
+
+const findByMock: MockLike = mockFindBy as unknown as MockLike;
+
+function findByCallCount(): number {
+  return findByMock.mock.calls.length;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  MetricPipelineRuleService.clearCache();
+  findByMock.mockClear();
+});
+
+describe("per-project rule caches serve repeat loads without re-querying", () => {
+  test("LogPipelineService.loadPipelines caches a non-empty result by reference", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    const pipeline: LogPipeline = new LogPipeline();
+    pipeline.id = ObjectID.generate();
+    /*
+     * First findBy returns one pipeline; the follow-up processor query
+     * (and everything after) falls through to the default empty result.
+     */
+    findByMock.mockReturnValueOnce(Promise.resolve([pipeline]));
+
+    const first: Array<LoadedPipeline> =
+      await LogPipelineService.loadPipelines(projectId);
+    expect(first).toHaveLength(1);
+
+    const callsAfterFirstLoad: number = findByCallCount();
+    expect(callsAfterFirstLoad).toBeGreaterThan(0);
+
+    const second: Array<LoadedPipeline> =
+      await LogPipelineService.loadPipelines(projectId);
+
+    expect(findByCallCount()).toBe(callsAfterFirstLoad);
+    expect(second).toBe(first);
+  });
+
+  test("an empty result is negatively cached (zero-rule project does not re-query)", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    const first: Array<LoadedPipeline> =
+      await LogPipelineService.loadPipelines(projectId);
+    expect(first).toEqual([]);
+    expect(findByCallCount()).toBe(1);
+
+    const second: Array<LoadedPipeline> =
+      await LogPipelineService.loadPipelines(projectId);
+
+    expect(findByCallCount()).toBe(1);
+    expect(second).toBe(first);
+  });
+
+  test("TracePipelineService.loadPipelines caches per project", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    const first: unknown = await TracePipelineService.loadPipelines(projectId);
+    expect(findByCallCount()).toBe(1);
+
+    const second: unknown = await TracePipelineService.loadPipelines(projectId);
+    expect(findByCallCount()).toBe(1);
+    expect(second).toBe(first);
+  });
+
+  test("LogDropFilterService.loadDropFilters caches per project", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    const first: Array<LoadedLogDropFilter> =
+      await LogDropFilterService.loadDropFilters(projectId);
+    expect(findByCallCount()).toBe(1);
+
+    const second: Array<LoadedLogDropFilter> =
+      await LogDropFilterService.loadDropFilters(projectId);
+    expect(findByCallCount()).toBe(1);
+    expect(second).toBe(first);
+  });
+
+  test("TraceDropFilterService.loadDropFilters caches per project", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    const first: unknown =
+      await TraceDropFilterService.loadDropFilters(projectId);
+    expect(findByCallCount()).toBe(1);
+
+    const second: unknown =
+      await TraceDropFilterService.loadDropFilters(projectId);
+    expect(findByCallCount()).toBe(1);
+    expect(second).toBe(first);
+  });
+
+  test("LogScrubRuleService.loadScrubRules caches per project", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    const first: unknown = await LogScrubRuleService.loadScrubRules(projectId);
+    expect(findByCallCount()).toBe(1);
+
+    const second: unknown = await LogScrubRuleService.loadScrubRules(projectId);
+    expect(findByCallCount()).toBe(1);
+    expect(second).toBe(first);
+  });
+
+  test("TraceScrubRuleService.loadScrubRules caches per project", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    const first: unknown =
+      await TraceScrubRuleService.loadScrubRules(projectId);
+    expect(findByCallCount()).toBe(1);
+
+    const second: unknown =
+      await TraceScrubRuleService.loadScrubRules(projectId);
+    expect(findByCallCount()).toBe(1);
+    expect(second).toBe(first);
+  });
+
+  test("MetricPipelineRuleService.loadRules caches per project", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    const first: MetricRulesForProject =
+      await MetricPipelineRuleService.loadRules(projectId);
+    expect(findByCallCount()).toBe(1);
+
+    const second: MetricRulesForProject =
+      await MetricPipelineRuleService.loadRules(projectId);
+    expect(findByCallCount()).toBe(1);
+    expect(second).toBe(first);
+  });
+
+  test("distinct projects do not share cache entries", async () => {
+    const projectA: ObjectID = ObjectID.generate();
+    const projectB: ObjectID = ObjectID.generate();
+
+    await LogPipelineService.loadPipelines(projectA);
+    await LogPipelineService.loadPipelines(projectB);
+
+    expect(findByCallCount()).toBe(2);
+  });
+});
+
+describe("cache entries expire after the 60s TTL", () => {
+  test("LogPipelineService re-queries once the TTL has elapsed", async () => {
+    // Generate before mocking Date.now so ID creation sees the real clock.
+    const projectId: ObjectID = ObjectID.generate();
+
+    const t0: number = 1_700_000_000_000;
+    const nowSpy: NowSpyLike = jest.spyOn(Date, "now") as unknown as NowSpyLike;
+    nowSpy.mockReturnValue(t0);
+
+    await LogPipelineService.loadPipelines(projectId);
+    expect(findByCallCount()).toBe(1);
+
+    // Within the TTL: still served from cache.
+    nowSpy.mockReturnValue(t0 + 59_999);
+    await LogPipelineService.loadPipelines(projectId);
+    expect(findByCallCount()).toBe(1);
+
+    // Past the TTL: reloaded from the database.
+    nowSpy.mockReturnValue(t0 + 60_001);
+    await LogPipelineService.loadPipelines(projectId);
+    expect(findByCallCount()).toBe(2);
+  });
+
+  test("MetricPipelineRuleService re-queries once the TTL has elapsed", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    const t0: number = 1_700_000_000_000;
+    const nowSpy: NowSpyLike = jest.spyOn(Date, "now") as unknown as NowSpyLike;
+    nowSpy.mockReturnValue(t0);
+
+    await MetricPipelineRuleService.loadRules(projectId);
+    expect(findByCallCount()).toBe(1);
+
+    nowSpy.mockReturnValue(t0 + 60_001);
+    await MetricPipelineRuleService.loadRules(projectId);
+    expect(findByCallCount()).toBe(2);
+  });
+});
+
+describe("clearCache contract", () => {
+  test("MetricPipelineRuleService.clearCache() empties the rule cache", async () => {
+    const projectId: ObjectID = ObjectID.generate();
+
+    await MetricPipelineRuleService.loadRules(projectId);
+    expect(findByCallCount()).toBe(1);
+
+    MetricPipelineRuleService.clearCache();
+
+    await MetricPipelineRuleService.loadRules(projectId);
+    expect(findByCallCount()).toBe(2);
+  });
+});

--- a/App/Tests/Workers/Jobs/AIAgent/UpdateConnectionStatus.test.ts
+++ b/App/Tests/Workers/Jobs/AIAgent/UpdateConnectionStatus.test.ts
@@ -1,0 +1,505 @@
+import AIAgent, {
+  AIAgentConnectionStatus,
+} from "Common/Models/DatabaseModels/AIAgent";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
+import ObjectID from "Common/Types/ObjectID";
+import { EVERY_MINUTE } from "Common/Utils/CronTime";
+
+/*
+ * Regression tests for the AIAgent:UpdateConnectionStatus cron rewrite. The
+ * job runs EVERY MINUTE and used to call AIAgentService.findAllBy({}) - a
+ * full-table scan that hauled EVERY AI agent row in the system into JS on
+ * every tick (plus a full-array debug dump), just to compare two columns
+ * (lastAlive vs connectionStatus) per row and decide whether to flip the
+ * status. The rewrite pushes the comparison into SQL: two targeted findBy
+ * queries fetch ONLY the agents whose stored status disagrees with what their
+ * lastAlive implies, so a steady-state tick costs two indexed-predicate
+ * SELECTs and nothing else.
+ * These tests pin:
+ *   1. the query fan-in: exactly two findBy calls per tick, ZERO findAllBy /
+ *      findOneBy / findOneById calls, select limited to {_id, projectId},
+ *   2. the predicate shapes (lessThanEqualToOrNull / greaterThan / notInOrNull
+ *      over ONE shared 3-minute cutoff) and their exact-parity semantics with
+ *      the old in-process check,
+ *   3. the flip writes: full-pipeline updateOneById per candidate carrying
+ *      ONLY connectionStatus, with per-agent failure isolation.
+ *
+ * The job registers itself via RunCron at import time and exports nothing, so
+ * the Cron util is mocked to CAPTURE the handler and options (the same
+ * recorder the other App/Tests/Workers/Jobs suites use) and each test drives
+ * one full tick.
+ */
+
+type CronHandler = () => Promise<void>;
+
+interface CronOptions {
+  schedule: string;
+  runOnStartup: boolean;
+}
+
+interface CapturedJob {
+  options: CronOptions;
+  handler: CronHandler;
+}
+
+/*
+ * Captured cron registrations, keyed by job name. Must be declared before the
+ * job import below so the mock factory closure can see it.
+ */
+const mockCapturedJobs: Record<string, CapturedJob> = {};
+
+jest.mock("../../../../FeatureSet/Workers/Utils/Cron", () => {
+  return {
+    __esModule: true,
+    default: jest.fn(
+      (
+        jobName: string,
+        options: CronOptions,
+        runFunction: CronHandler,
+      ): void => {
+        mockCapturedJobs[jobName] = { options, handler: runFunction };
+      },
+    ),
+  };
+});
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+/*
+ * findAllBy / findOneBy / findOneById are mocked ALONGSIDE the targeted findBy
+ * precisely so the suite can prove they are never called: if the job regressed
+ * back to the all-rows findAllBy({}) scan (or per-agent point reads), the
+ * assertions would flag it instead of the mock throwing "not a function".
+ */
+jest.mock("Common/Server/Services/AIAgentService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findBy: jest.fn(),
+      findAllBy: jest.fn(),
+      updateOneById: jest.fn(),
+      findOneBy: jest.fn(),
+      findOneById: jest.fn(),
+    },
+  };
+});
+
+/*
+ * QueryHelper is mocked with sentinel-returning fns so the tests can assert
+ * BOTH which predicate factory each query field came from AND the exact
+ * argument it was built with (the real helpers return opaque typeorm Raw
+ * FindOperators keyed by random parameter names, which are awkward to
+ * introspect). Each sentinel captures the factory args, so asserting the
+ * query field deep-equals the sentinel pins the whole predicate.
+ */
+jest.mock("Common/Server/Types/Database/QueryHelper", () => {
+  return {
+    __esModule: true,
+    default: {
+      lessThanEqualToOrNull: jest.fn((value: Date) => {
+        return { op: "lessThanEqualToOrNull", value };
+      }),
+      greaterThan: jest.fn((value: Date) => {
+        return { op: "greaterThan", value };
+      }),
+      notInOrNull: jest.fn((values: Array<string>) => {
+        return { op: "notInOrNull", values };
+      }),
+    },
+  };
+});
+
+import AIAgentService from "Common/Server/Services/AIAgentService";
+import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import logger from "Common/Server/Utils/Logger";
+
+// Imported for its side effect: RunCron (mocked above) records the handler.
+import "../../../../FeatureSet/Workers/Jobs/AIAgent/UpdateConnectionStatus";
+
+interface AIAgentServiceMock {
+  findBy: jest.Mock;
+  findAllBy: jest.Mock;
+  updateOneById: jest.Mock;
+  findOneBy: jest.Mock;
+  findOneById: jest.Mock;
+}
+
+interface QueryHelperMock {
+  lessThanEqualToOrNull: jest.Mock;
+  greaterThan: jest.Mock;
+  notInOrNull: jest.Mock;
+}
+
+const aiAgentService: AIAgentServiceMock =
+  AIAgentService as unknown as AIAgentServiceMock;
+const queryHelper: QueryHelperMock = QueryHelper as unknown as QueryHelperMock;
+const mockedLogger: { error: jest.Mock } = logger as unknown as {
+  error: jest.Mock;
+};
+
+const JOB_NAME: string = "AIAgent:UpdateConnectionStatus";
+
+const PROJECT_1_ID: ObjectID = new ObjectID("project-1");
+const PROJECT_2_ID: ObjectID = new ObjectID("project-2");
+
+// The staleness cutoff: 3 whole minutes, see the parity test below for why.
+const STALE_CUTOFF_IN_MS: number = 3 * 60 * 1000;
+
+function makeAIAgent(data: { id?: ObjectID; projectId?: ObjectID }): AIAgent {
+  const aiAgent: AIAgent = new AIAgent(data.id);
+
+  if (data.projectId) {
+    aiAgent.projectId = data.projectId;
+  }
+
+  return aiAgent;
+}
+
+interface FindByArgs {
+  query: Record<string, unknown>;
+  select: Record<string, boolean>;
+  skip: number;
+  limit: number;
+  props: Record<string, unknown>;
+}
+
+// The two findBy calls are issued sequentially: disconnect first, connect second.
+function disconnectQueryArgs(): FindByArgs {
+  return aiAgentService.findBy.mock.calls[0]![0] as FindByArgs;
+}
+
+function connectQueryArgs(): FindByArgs {
+  return aiAgentService.findBy.mock.calls[1]![0] as FindByArgs;
+}
+
+interface UpdateCallArgs {
+  id: ObjectID;
+  data: Record<string, unknown>;
+  props: Record<string, unknown>;
+}
+
+function updateCalls(): Array<UpdateCallArgs> {
+  return aiAgentService.updateOneById.mock.calls.map((args: Array<unknown>) => {
+    return args[0] as UpdateCallArgs;
+  });
+}
+
+async function runWorkerTick(): Promise<void> {
+  const captured: CapturedJob | undefined = mockCapturedJobs[JOB_NAME];
+
+  if (!captured) {
+    throw new Error(
+      "AIAgent:UpdateConnectionStatus did not register a cron handler - the RunCron mock never saw it.",
+    );
+  }
+
+  await captured.handler();
+}
+
+describe("AIAgent:UpdateConnectionStatus worker", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    aiAgentService.findBy.mockResolvedValue([]);
+    aiAgentService.updateOneById.mockResolvedValue(undefined);
+  });
+
+  test("registers on EVERY_MINUTE without running on startup", () => {
+    const captured: CapturedJob | undefined = mockCapturedJobs[JOB_NAME];
+
+    expect(captured).toBeDefined();
+    expect(captured!.options).toEqual({
+      schedule: EVERY_MINUTE,
+      runOnStartup: false,
+    });
+  });
+
+  test("one tick issues exactly two targeted findBy queries - never the all-rows scan", async () => {
+    await runWorkerTick();
+
+    /*
+     * THE regression this rewrite removed: findAllBy({}) fetched every
+     * AIAgent row in the system every minute - a full-table scan whose rows
+     * were all hauled into JS (and dumped wholesale into the debug log) just
+     * to compare two columns per row. The status disagreement now lives in
+     * the SQL predicates, so the tick issues exactly two SELECTs
+     * (stale-but-not-Disconnected, fresh-but-not-Connected) and touches
+     * nothing else.
+     */
+    expect(aiAgentService.findBy).toHaveBeenCalledTimes(2);
+    expect(aiAgentService.findAllBy).not.toHaveBeenCalled();
+    expect(aiAgentService.findOneBy).not.toHaveBeenCalled();
+    expect(aiAgentService.findOneById).not.toHaveBeenCalled();
+  });
+
+  test("disconnect query: stale-or-never-alive AND not-already-Disconnected, id+projectId only, root, LIMIT_MAX", async () => {
+    await runWorkerTick();
+
+    const args: FindByArgs = disconnectQueryArgs();
+
+    /*
+     * lessThanEqualToOrNull (not plain lessThanEqualTo): an agent that has
+     * NEVER stamped lastAlive must also count as stale, mirroring the old
+     * in-process branch that treated a missing lastAlive as disconnected.
+     */
+    expect(args.query["lastAlive"]).toEqual({
+      op: "lessThanEqualToOrNull",
+      value: expect.any(Date),
+    });
+
+    /*
+     * notInOrNull (not notEquals): a NULL connectionStatus (agent that never
+     * had one stamped) must still be flipped, matching the old comparison
+     * `aiAgent.connectionStatus !== computedStatus`.
+     */
+    expect(args.query["connectionStatus"]).toEqual({
+      op: "notInOrNull",
+      values: [AIAgentConnectionStatus.Disconnected],
+    });
+
+    /*
+     * Only the columns the flip loop needs - selecting more would re-inflate
+     * the rows this rewrite stopped hauling.
+     */
+    expect(args.select).toEqual({
+      _id: true,
+      projectId: true,
+    });
+    expect(args.skip).toBe(0);
+    expect(args.limit).toBe(LIMIT_MAX);
+    expect(args.props).toEqual({ isRoot: true });
+  });
+
+  test("connect query: alive-within-cutoff AND not-already-Connected, same shape", async () => {
+    await runWorkerTick();
+
+    const args: FindByArgs = connectQueryArgs();
+
+    /*
+     * Strict greaterThan (no OrNull): a NULL lastAlive can never count as
+     * "recently alive", so it must not qualify an agent for the Connected
+     * flip.
+     */
+    expect(args.query["lastAlive"]).toEqual({
+      op: "greaterThan",
+      value: expect.any(Date),
+    });
+    expect(args.query["connectionStatus"]).toEqual({
+      op: "notInOrNull",
+      values: [AIAgentConnectionStatus.Connected],
+    });
+
+    expect(args.select).toEqual({
+      _id: true,
+      projectId: true,
+    });
+    expect(args.skip).toBe(0);
+    expect(args.limit).toBe(LIMIT_MAX);
+    expect(args.props).toEqual({ isRoot: true });
+  });
+
+  test("both queries share ONE now-minus-3-minutes cutoff - exact parity with the old moment-truncated check", async () => {
+    const tickStart: number = Date.now();
+
+    await runWorkerTick();
+
+    expect(queryHelper.lessThanEqualToOrNull).toHaveBeenCalledTimes(1);
+    expect(queryHelper.greaterThan).toHaveBeenCalledTimes(1);
+
+    const staleCutoff: Date = queryHelper.lessThanEqualToOrNull.mock
+      .calls[0]![0] as Date;
+
+    /*
+     * 3 minutes, NOT the 2 minutes the old code appears to say: the historical
+     * in-process check was `OneUptimeDate.getDifferenceInMinutes(now,
+     * lastAlive) > 2`, and moment's diff-in-minutes TRUNCATES - "difference
+     * > 2 minutes" was only true once an agent was >= 3 whole minutes stale.
+     * The SQL predicate `lastAlive <= now - 3 minutes` flips at exactly the
+     * same instant. Shrinking this to 2 minutes would flag agents
+     * Disconnected a full minute earlier than the job ever did.
+     */
+    expect(
+      Math.abs(staleCutoff.getTime() - (tickStart - STALE_CUTOFF_IN_MS)),
+    ).toBeLessThanOrEqual(2000);
+
+    /*
+     * The SAME cutoff instant feeds both predicates: computing "now" twice
+     * would open a sliver between the two queries where an agent matches
+     * neither (or both) directions.
+     */
+    expect(queryHelper.greaterThan.mock.calls[0]![0] as Date).toBe(staleCutoff);
+  });
+
+  test("a steady-state tick with zero candidates writes nothing", async () => {
+    await runWorkerTick();
+
+    // The common case: two SELECTs, no updates, no hooks fired.
+    expect(aiAgentService.updateOneById).not.toHaveBeenCalled();
+    expect(mockedLogger.error).not.toHaveBeenCalled();
+  });
+
+  test("flips disconnect candidates to Disconnected and connect candidates to Connected - connectionStatus is the ONLY column written", async () => {
+    const staleAgentId: ObjectID = new ObjectID("aiagent-stale");
+    const freshAgentId: ObjectID = new ObjectID("aiagent-fresh");
+
+    aiAgentService.findBy
+      .mockResolvedValueOnce([
+        makeAIAgent({ id: staleAgentId, projectId: PROJECT_1_ID }),
+      ])
+      .mockResolvedValueOnce([
+        makeAIAgent({ id: freshAgentId, projectId: PROJECT_2_ID }),
+      ]);
+
+    await runWorkerTick();
+
+    const updates: Array<UpdateCallArgs> = updateCalls();
+
+    expect(updates).toHaveLength(2);
+
+    expect(updates[0]!.id.toString()).toBe(staleAgentId.toString());
+    expect(updates[0]!.data["connectionStatus"]).toBe(
+      AIAgentConnectionStatus.Disconnected,
+    );
+    expect(updates[0]!.props).toEqual({ isRoot: true });
+
+    expect(updates[1]!.id.toString()).toBe(freshAgentId.toString());
+    expect(updates[1]!.data["connectionStatus"]).toBe(
+      AIAgentConnectionStatus.Connected,
+    );
+    expect(updates[1]!.props).toEqual({ isRoot: true });
+
+    /*
+     * The full-pipeline updateOneById is what fires AIAgentService's hooks
+     * (owner notifications) - the write must carry ONLY the status flip, so
+     * no other column rides along into those hooks.
+     */
+    for (const update of updates) {
+      expect(Object.keys(update.data)).toEqual(["connectionStatus"]);
+    }
+  });
+
+  test("one agent's flip failure does not prevent the remaining flips", async () => {
+    const failingAgentId: ObjectID = new ObjectID("aiagent-failing");
+    const survivingAgentId: ObjectID = new ObjectID("aiagent-surviving");
+    const freshAgentId: ObjectID = new ObjectID("aiagent-fresh");
+
+    aiAgentService.findBy
+      .mockResolvedValueOnce([
+        makeAIAgent({ id: failingAgentId, projectId: PROJECT_1_ID }),
+        makeAIAgent({ id: survivingAgentId, projectId: PROJECT_1_ID }),
+      ])
+      .mockResolvedValueOnce([
+        makeAIAgent({ id: freshAgentId, projectId: PROJECT_2_ID }),
+      ]);
+
+    const flipError: Error = new Error("db connection reset");
+
+    aiAgentService.updateOneById.mockImplementation(
+      (args: UpdateCallArgs): Promise<void> => {
+        if (args.id.toString() === failingAgentId.toString()) {
+          return Promise.reject(flipError);
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+
+    // The tick itself must not reject (per-agent try/catch).
+    await expect(runWorkerTick()).resolves.toBeUndefined();
+
+    // ALL flips were attempted; the failure only logged, tagged with its project.
+    const updates: Array<UpdateCallArgs> = updateCalls();
+
+    expect(updates).toHaveLength(3);
+    expect(
+      updates.map((update: UpdateCallArgs) => {
+        return update.id.toString();
+      }),
+    ).toEqual([
+      failingAgentId.toString(),
+      survivingAgentId.toString(),
+      freshAgentId.toString(),
+    ]);
+    expect(mockedLogger.error).toHaveBeenCalledWith(flipError, {
+      service: "workers",
+      projectId: PROJECT_1_ID.toString(),
+    });
+  });
+
+  test("a candidate row without an id is skipped without a write or an error", async () => {
+    const validAgentId: ObjectID = new ObjectID("aiagent-valid");
+
+    aiAgentService.findBy
+      .mockResolvedValueOnce([
+        // Defensive: a row that somehow came back id-less must not crash the loop.
+        makeAIAgent({ projectId: PROJECT_1_ID }),
+        makeAIAgent({ id: validAgentId, projectId: PROJECT_1_ID }),
+      ])
+      .mockResolvedValueOnce([]);
+
+    await runWorkerTick();
+
+    const updates: Array<UpdateCallArgs> = updateCalls();
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.id.toString()).toBe(validAgentId.toString());
+    expect(mockedLogger.error).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The two SELECTs run sequentially, so one agent can appear in BOTH
+   * result sets in exactly one case: its connectionStatus is NULL (matches
+   * neither notInOrNull filter) and a heartbeat lands between the queries,
+   * moving it from stale to fresh. Writing both flips would stamp
+   * Disconnected and then Connected in one tick; the connect query ran
+   * later, so only its (fresher) verdict may be written.
+   */
+  test("an agent listed by both queries gets exactly one flip — to Connected", async () => {
+    const doubleListedAgentId: ObjectID = new ObjectID("aiagent-double-listed");
+    const staleOnlyAgentId: ObjectID = new ObjectID("aiagent-stale-only");
+
+    aiAgentService.findBy
+      .mockResolvedValueOnce([
+        makeAIAgent({ id: doubleListedAgentId, projectId: PROJECT_1_ID }),
+        makeAIAgent({ id: staleOnlyAgentId, projectId: PROJECT_1_ID }),
+      ])
+      .mockResolvedValueOnce([
+        makeAIAgent({ id: doubleListedAgentId, projectId: PROJECT_1_ID }),
+      ]);
+
+    await runWorkerTick();
+
+    const updates: Array<UpdateCallArgs> = updateCalls();
+    expect(updates).toHaveLength(2);
+
+    const doubleListedUpdates: Array<UpdateCallArgs> = updates.filter(
+      (update: UpdateCallArgs) => {
+        return update.id.toString() === doubleListedAgentId.toString();
+      },
+    );
+    expect(doubleListedUpdates).toHaveLength(1);
+    expect(doubleListedUpdates[0]!.data).toEqual({
+      connectionStatus: AIAgentConnectionStatus.Connected,
+    });
+
+    // The genuinely stale agent still gets its Disconnected flip.
+    const staleUpdates: Array<UpdateCallArgs> = updates.filter(
+      (update: UpdateCallArgs) => {
+        return update.id.toString() === staleOnlyAgentId.toString();
+      },
+    );
+    expect(staleUpdates).toHaveLength(1);
+    expect(staleUpdates[0]!.data).toEqual({
+      connectionStatus: AIAgentConnectionStatus.Disconnected,
+    });
+  });
+});

--- a/Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel.ts
+++ b/Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel.ts
@@ -58,6 +58,32 @@ export type DbTypes =
   | JSONArray
   | Buffer;
 
+/*
+ * Metadata-only vanilla instances used by toJSONObject to read table-column
+ * metadata. Frozen and never exported, so they can never be mutated or escape
+ * this file. _fromJSON must never use this cache — it mutates and returns the
+ * instance it constructs.
+ */
+const vanillaModelCache: WeakMap<
+  { new (): DatabaseBaseModel },
+  DatabaseBaseModel
+> = new WeakMap();
+
+function getVanillaModel(modelType: {
+  new (): DatabaseBaseModel;
+}): DatabaseBaseModel {
+  let vanillaModel: DatabaseBaseModel | undefined =
+    vanillaModelCache.get(modelType);
+
+  if (!vanillaModel) {
+    vanillaModel = new modelType();
+    Object.freeze(vanillaModel);
+    vanillaModelCache.set(modelType, vanillaModel);
+  }
+
+  return vanillaModel;
+}
+
 export default class DatabaseBaseModel extends BaseEntity {
   @TableColumn({
     title: "ID",
@@ -614,7 +640,7 @@ export default class DatabaseBaseModel extends BaseEntity {
   ): JSONObject {
     const json: JSONObject = {};
 
-    const vanillaModel: DatabaseBaseModel = new modelType();
+    const vanillaModel: DatabaseBaseModel = getVanillaModel(modelType);
 
     for (const key of vanillaModel.getTableColumns().columns) {
       if ((model as any)[key] === undefined) {

--- a/Common/Server/API/StatusPageAPI.ts
+++ b/Common/Server/API/StatusPageAPI.ts
@@ -1,4 +1,5 @@
 import UserMiddleware from "../Middleware/UserAuthorization";
+import InMemoryTTLCache from "../Infrastructure/InMemoryTTLCache";
 import AcmeChallengeService from "../Services/AcmeChallengeService";
 import IncidentEpisodeService from "../Services/IncidentEpisodeService";
 import IncidentEpisodeMemberService from "../Services/IncidentEpisodeMemberService";
@@ -160,6 +161,29 @@ export default class StatusPageAPI extends BaseAPI<
   StatusPage,
   StatusPageServiceType
 > {
+  /*
+   * Post-auth overview responses keyed by resolved statusPageId. The payload
+   * is user-independent (authorization is a binary gate checked per-request,
+   * before any cache read), so one short-TTL snapshot per page per process
+   * serves every viewer. See buildOverviewResponse.
+   */
+  private static overviewResponseCache: InMemoryTTLCache<JSONObject> =
+    new InMemoryTTLCache<JSONObject>(500);
+
+  /*
+   * In-flight overview builds keyed by the same cache key, so concurrent
+   * cold-cache requests share one build instead of stampeding the database.
+   */
+  private static overviewResponseInFlight: Map<string, Promise<JSONObject>> =
+    new Map();
+
+  private static readonly OVERVIEW_CACHE_TTL_MS: number = 15_000;
+
+  public static clearOverviewResponseCache(): void {
+    this.overviewResponseCache.clear();
+    this.overviewResponseInFlight.clear();
+  }
+
   public constructor() {
     super(StatusPage, StatusPageService);
 
@@ -1566,878 +1590,52 @@ export default class StatusPageAPI extends BaseAPI<
           req.params["statusPageIdOrDomain"] as string,
         );
 
+        /*
+         * checkHasReadAccess MUST stay before any cache read: it is what keeps
+         * private pages, IP whitelists, and master passwords enforced on every
+         * request even when the payload below is served from cache.
+         */
         await this.checkHasReadAccess({
           statusPageId: statusPageId,
           req: req,
         });
 
-        /*
-         * The timeline window comes from the status page's configured
-         * showUptimeHistoryInDays. getStatusPageResourcesAndTimelines
-         * fetches the status page row anyway, so let it compute the window
-         * (clamped to 1..90 days, ending now) instead of issuing a separate
-         * StatusPage query here just to read that one column.
-         */
-        const {
-          monitorStatuses,
-          monitorGroupCurrentStatuses,
-          statusPageResources,
-          statusPage,
-          monitorsOnStatusPage,
-          monitorStatusTimelines,
-          statusPageGroups,
-          monitorsInGroup,
-          startDateForMonitorTimeline: startDate,
-          endDateForMonitorTimeline: endDate,
-        } = await this.getStatusPageResourcesAndTimelines({
-          statusPageId: statusPageId,
-        });
-
-        // check if status page has active incident.
-        let activeIncidents: Array<Incident> = [];
-        if (monitorsOnStatusPage.length > 0) {
-          let select: Select<Incident> = {
-            createdAt: true,
-            declaredAt: true,
-            updatedAt: true,
-            title: true,
-            description: true,
-            _id: true,
-            postmortemNote: true,
-            postmortemPostedAt: true,
-            showPostmortemOnStatusPage: true,
-            postmortemAttachments: {
-              _id: true,
-              name: true,
-            },
-            incidentSeverity: {
-              name: true,
-              color: true,
-            },
-            currentIncidentState: {
-              _id: true,
-              name: true,
-              color: true,
-              order: true,
-            },
-            monitors: {
-              _id: true,
-            },
-          };
-
-          if (statusPage.showIncidentLabelsOnStatusPage) {
-            select = {
-              ...select,
-              labels: {
-                name: true,
-                color: true,
-              },
-            };
-          }
-
-          const unresolvedIncidentStates: Array<IncidentState> =
-            await IncidentStateService.getUnresolvedIncidentStates(
-              statusPage.projectId!,
-              {
-                isRoot: true,
-              },
-            );
-
-          const unresolvedIncidentStateIds: Array<ObjectID> =
-            unresolvedIncidentStates.map((state: IncidentState) => {
-              return state.id!;
-            });
-
-          if (statusPage.showIncidentsOnStatusPage) {
-            activeIncidents = await IncidentService.findBy({
-              query: {
-                monitors: monitorsOnStatusPage as any,
-                currentIncidentStateId: QueryHelper.any(
-                  unresolvedIncidentStateIds,
-                ),
-                isVisibleOnStatusPage: true,
-                projectId: statusPage.projectId!,
-              },
-              select: select,
-              sort: {
-                declaredAt: SortOrder.Descending,
-                createdAt: SortOrder.Descending,
-              },
-
-              skip: 0,
-              limit: LIMIT_PER_PROJECT,
-              props: {
-                isRoot: true,
-              },
-            });
-          }
-        }
-
-        const incidentsOnStatusPage: Array<ObjectID> = activeIncidents.map(
-          (incident: Incident) => {
-            return incident.id!;
-          },
-        );
-
-        let incidentPublicNotes: Array<IncidentPublicNote> = [];
-
-        if (incidentsOnStatusPage.length > 0) {
-          incidentPublicNotes = await IncidentPublicNoteService.findBy({
-            query: {
-              incidentId: QueryHelper.any(incidentsOnStatusPage),
-              projectId: statusPage.projectId!,
-            },
-            select: {
-              note: true,
-              incidentId: true,
-              postedAt: true,
-              attachments: {
-                _id: true,
-                name: true,
-              },
-            },
-            sort: {
-              postedAt: SortOrder.Descending, // new note first
-            },
-            skip: 0,
-            limit: LIMIT_PER_PROJECT,
-            props: {
-              isRoot: true,
-            },
-          });
-        }
-
-        let incidentStateTimelines: Array<IncidentStateTimeline> = [];
-
-        if (incidentsOnStatusPage.length > 0) {
-          incidentStateTimelines = await IncidentStateTimelineService.findBy({
-            query: {
-              incidentId: QueryHelper.any(incidentsOnStatusPage),
-              projectId: statusPage.projectId!,
-            },
-            select: {
-              _id: true,
-              createdAt: true,
-              startsAt: true,
-              incidentId: true,
-              incidentState: {
-                _id: true,
-                name: true,
-                color: true,
-                isCreatedState: true,
-                isResolvedState: true,
-                isAcknowledgedState: true,
-              },
-            },
-
-            sort: {
-              startsAt: SortOrder.Descending, // newer state changes first
-            },
-            skip: 0,
-            limit: LIMIT_PER_PROJECT,
-            props: {
-              isRoot: true,
-            },
-          });
-        }
-
-        // Fetch active episodes (similar to incidents)
-        let activeEpisodes: Array<IncidentEpisode> = [];
-        let activeEpisodesJson: JSONArray = [];
-        let episodePublicNotes: Array<IncidentEpisodePublicNote> = [];
-        let episodeStateTimelines: Array<IncidentEpisodeStateTimeline> = [];
+        // Resolved id, so domain-served and id-served views share one entry.
+        const cacheKey: string = statusPageId.toString();
 
         /*
-         * Cheap guard before the expensive part: the block below scans every
-         * incident ever attached to this page's monitors (a many-to-many
-         * join, up to LIMIT_PER_PROJECT rows) just to discover episode
-         * membership — on every overview view, even though most pages have
-         * zero active episodes most of the time. One indexed COUNT of the
-         * project's unresolved, visible episodes lets us skip all of it in
-         * the common case. Behavior-preserving: the final activeEpisodes
-         * query applies exactly these three constraints, so count == 0
-         * implies the block's outputs stay empty.
+         * The cached JSONObject is shared across requests and must never be
+         * mutated after build.
          */
-        let unresolvedIncidentStateIds: Array<ObjectID> = [];
-        let hasActiveEpisodes: boolean = false;
+        let response: JSONObject | undefined =
+          StatusPageAPI.overviewResponseCache.get(cacheKey);
 
-        if (
-          statusPage.showEpisodesOnStatusPage &&
-          monitorsOnStatusPage.length > 0
-        ) {
-          const unresolvedIncidentStates: Array<IncidentState> =
-            await IncidentStateService.getUnresolvedIncidentStates(
-              statusPage.projectId!,
-              { isRoot: true },
-            );
+        if (!response) {
+          let inFlight: Promise<JSONObject> | undefined =
+            StatusPageAPI.overviewResponseInFlight.get(cacheKey);
 
-          unresolvedIncidentStateIds = unresolvedIncidentStates.map(
-            (state: IncidentState) => {
-              return state.id!;
-            },
-          );
+          if (!inFlight) {
+            inFlight = this.buildOverviewResponse(statusPageId);
+            StatusPageAPI.overviewResponseInFlight.set(cacheKey, inFlight);
 
-          const activeEpisodeCount: PositiveNumber =
-            await IncidentEpisodeService.countBy({
-              query: {
-                projectId: statusPage.projectId!,
-                isVisibleOnStatusPage: true,
-                currentIncidentStateId: QueryHelper.any(
-                  unresolvedIncidentStateIds,
-                ),
-              },
-              props: {
-                isRoot: true,
-              },
-            });
-
-          hasActiveEpisodes = activeEpisodeCount.toNumber() > 0;
-        }
-
-        if (hasActiveEpisodes) {
-          // First, get incidents that have monitors on status page
-          const incidentsForEpisodes: Array<Incident> =
-            await IncidentService.findBy({
-              query: {
-                monitors: monitorsOnStatusPage as any,
-                isVisibleOnStatusPage: true,
-                projectId: statusPage.projectId!,
-              },
-              select: {
-                _id: true,
-              },
-              skip: 0,
-              limit: LIMIT_PER_PROJECT,
-              props: {
-                isRoot: true,
-              },
-            });
-
-          const incidentIdsForEpisodes: Array<ObjectID> =
-            incidentsForEpisodes.map((incident: Incident) => {
-              return incident.id!;
-            });
-
-          // Get episode members for these incidents
-          let episodeMembers: Array<IncidentEpisodeMember> = [];
-          if (incidentIdsForEpisodes.length > 0) {
-            episodeMembers = await IncidentEpisodeMemberService.findBy({
-              query: {
-                incidentId: QueryHelper.any(incidentIdsForEpisodes),
-                projectId: statusPage.projectId!,
-              },
-              select: {
-                incidentEpisodeId: true,
-                incidentId: true,
-              },
-              skip: 0,
-              limit: LIMIT_PER_PROJECT,
-              props: {
-                isRoot: true,
-              },
-            });
+            inFlight
+              .then((builtResponse: JSONObject) => {
+                StatusPageAPI.overviewResponseCache.set(
+                  cacheKey,
+                  builtResponse,
+                  StatusPageAPI.OVERVIEW_CACHE_TTL_MS,
+                );
+              })
+              .catch(() => {
+                // Failed builds are never cached; the next request rebuilds.
+              })
+              .finally(() => {
+                StatusPageAPI.overviewResponseInFlight.delete(cacheKey);
+              });
           }
 
-          // Get unique episode IDs
-          const episodeIdsFromMembers: Set<string> = new Set();
-          for (const member of episodeMembers) {
-            if (member.incidentEpisodeId) {
-              episodeIdsFromMembers.add(member.incidentEpisodeId.toString());
-            }
-          }
-
-          // Fetch active (unresolved) episodes
-          if (episodeIdsFromMembers.size > 0) {
-            // unresolvedIncidentStateIds was fetched by the guard above.
-            let selectEpisodes: Select<IncidentEpisode> = {
-              createdAt: true,
-              declaredAt: true,
-              updatedAt: true,
-              title: true,
-              description: true,
-              _id: true,
-              episodeNumber: true,
-              incidentSeverity: {
-                name: true,
-                color: true,
-              },
-              currentIncidentState: {
-                name: true,
-                color: true,
-                _id: true,
-                order: true,
-                isCreatedState: true,
-                isAcknowledgedState: true,
-                isResolvedState: true,
-              },
-              incidentCount: true,
-            };
-
-            if (statusPage.showEpisodeLabelsOnStatusPage) {
-              selectEpisodes = {
-                ...selectEpisodes,
-                labels: {
-                  name: true,
-                  color: true,
-                },
-              };
-            }
-
-            activeEpisodes = await IncidentEpisodeService.findBy({
-              query: {
-                _id: QueryHelper.any(
-                  Array.from(episodeIdsFromMembers).map((id: string) => {
-                    return new ObjectID(id);
-                  }),
-                ),
-                currentIncidentStateId: QueryHelper.any(
-                  unresolvedIncidentStateIds,
-                ),
-                isVisibleOnStatusPage: true,
-                projectId: statusPage.projectId!,
-              },
-              select: selectEpisodes,
-              sort: {
-                declaredAt: SortOrder.Descending,
-                createdAt: SortOrder.Descending,
-              },
-              skip: 0,
-              limit: LIMIT_PER_PROJECT,
-              props: {
-                isRoot: true,
-              },
-            });
-
-            // Build episode monitors map
-            if (activeEpisodes.length > 0) {
-              // Collect all incident IDs from episode members for active episodes
-              const activeEpisodeIds: Set<string> = new Set(
-                activeEpisodes.map((e: IncidentEpisode) => {
-                  return e.id!.toString();
-                }),
-              );
-
-              const memberIncidentIds: Array<ObjectID> = [];
-              for (const member of episodeMembers) {
-                if (
-                  member.incidentEpisodeId &&
-                  activeEpisodeIds.has(member.incidentEpisodeId.toString()) &&
-                  member.incidentId &&
-                  !memberIncidentIds.some((id: ObjectID) => {
-                    return id.toString() === member.incidentId!.toString();
-                  })
-                ) {
-                  memberIncidentIds.push(member.incidentId);
-                }
-              }
-
-              // Fetch incidents with monitors
-              let memberIncidents: Array<Incident> = [];
-              if (memberIncidentIds.length > 0) {
-                memberIncidents = await IncidentService.findBy({
-                  query: {
-                    _id: QueryHelper.any(memberIncidentIds),
-                    isVisibleOnStatusPage: true,
-                    projectId: statusPage.projectId!,
-                  },
-                  select: {
-                    _id: true,
-                    monitors: {
-                      _id: true,
-                    },
-                  },
-                  skip: 0,
-                  limit: LIMIT_PER_PROJECT,
-                  props: {
-                    isRoot: true,
-                  },
-                });
-              }
-
-              // Build incident -> monitors map
-              const incidentMonitorsMap: Map<
-                string,
-                Array<ObjectID>
-              > = new Map();
-              for (const incident of memberIncidents) {
-                const incidentIdStr: string = incident.id!.toString();
-                const monitorIds: Array<ObjectID> = (incident.monitors || [])
-                  .map((m: Monitor) => {
-                    return new ObjectID(
-                      m._id?.toString() || m.id?.toString() || "",
-                    );
-                  })
-                  .filter((id: ObjectID) => {
-                    return id.toString() !== "";
-                  });
-                incidentMonitorsMap.set(incidentIdStr, monitorIds);
-              }
-
-              // Build episode -> monitors map
-              const episodeMonitorsMap: Map<
-                string,
-                Array<ObjectID>
-              > = new Map();
-              for (const member of episodeMembers) {
-                if (
-                  member.incidentEpisodeId &&
-                  member.incidentId &&
-                  activeEpisodeIds.has(member.incidentEpisodeId.toString())
-                ) {
-                  const episodeIdStr: string =
-                    member.incidentEpisodeId.toString();
-                  const incidentIdStr: string = member.incidentId.toString();
-
-                  if (!episodeMonitorsMap.has(episodeIdStr)) {
-                    episodeMonitorsMap.set(episodeIdStr, []);
-                  }
-
-                  const episodeMonitors: Array<ObjectID> =
-                    episodeMonitorsMap.get(episodeIdStr)!;
-                  const incidentMonitors: Array<ObjectID> =
-                    incidentMonitorsMap.get(incidentIdStr) || [];
-
-                  for (const monitorId of incidentMonitors) {
-                    if (
-                      !episodeMonitors.some((m: ObjectID) => {
-                        return m.toString() === monitorId.toString();
-                      })
-                    ) {
-                      episodeMonitors.push(monitorId);
-                    }
-                  }
-                }
-              }
-
-              // Serialize episodes and add monitors
-              activeEpisodesJson = BaseModel.toJSONArray(
-                activeEpisodes,
-                IncidentEpisode,
-              );
-              for (const episodeJson of activeEpisodesJson) {
-                const episodeObj: JSONObject = episodeJson as JSONObject;
-                const episodeId: string | undefined =
-                  episodeObj["_id"]?.toString();
-                if (episodeId) {
-                  const monitorIds: Array<ObjectID> =
-                    episodeMonitorsMap.get(episodeId) || [];
-                  episodeObj["monitors"] = monitorIds.map((id: ObjectID) => {
-                    return { _id: id.toString() };
-                  });
-                }
-              }
-
-              // Get episode public notes
-              const episodesOnStatusPage: Array<ObjectID> = activeEpisodes.map(
-                (episode: IncidentEpisode) => {
-                  return episode.id!;
-                },
-              );
-
-              if (episodesOnStatusPage.length > 0) {
-                episodePublicNotes =
-                  await IncidentEpisodePublicNoteService.findBy({
-                    query: {
-                      incidentEpisodeId: QueryHelper.any(episodesOnStatusPage),
-                      projectId: statusPage.projectId!,
-                    },
-                    select: {
-                      postedAt: true,
-                      note: true,
-                      incidentEpisodeId: true,
-                      attachments: {
-                        _id: true,
-                        name: true,
-                      },
-                    },
-                    sort: {
-                      postedAt: SortOrder.Descending,
-                    },
-                    skip: 0,
-                    limit: LIMIT_PER_PROJECT,
-                    props: {
-                      isRoot: true,
-                    },
-                  });
-
-                // Get episode state timelines
-                episodeStateTimelines =
-                  await IncidentEpisodeStateTimelineService.findBy({
-                    query: {
-                      incidentEpisodeId: QueryHelper.any(episodesOnStatusPage),
-                      projectId: statusPage.projectId!,
-                    },
-                    select: {
-                      _id: true,
-                      createdAt: true,
-                      startsAt: true,
-                      incidentEpisodeId: true,
-                      incidentState: {
-                        name: true,
-                        color: true,
-                        isCreatedState: true,
-                        isAcknowledgedState: true,
-                        isResolvedState: true,
-                      },
-                    },
-                    sort: {
-                      startsAt: SortOrder.Descending,
-                    },
-                    skip: 0,
-                    limit: LIMIT_PER_PROJECT,
-                    props: {
-                      isRoot: true,
-                    },
-                  });
-              }
-            }
-          }
+          response = await inFlight;
         }
-
-        // check if status page has active announcement.
-
-        const today: Date = OneUptimeDate.getCurrentDate();
-
-        let activeAnnouncements: Array<StatusPageAnnouncement> = [];
-
-        if (statusPage.showAnnouncementsOnStatusPage) {
-          activeAnnouncements = await StatusPageAnnouncementService.findBy({
-            query: {
-              statusPages: statusPageId as any,
-              showAnnouncementAt: QueryHelper.lessThan(today),
-              endAnnouncementAt: QueryHelper.greaterThanOrNull(today),
-              projectId: statusPage.projectId!,
-            },
-            select: {
-              createdAt: true,
-              title: true,
-              description: true,
-              _id: true,
-              showAnnouncementAt: true,
-              endAnnouncementAt: true,
-            },
-            skip: 0,
-            limit: LIMIT_PER_PROJECT,
-            props: {
-              isRoot: true,
-            },
-          });
-        }
-
-        // check if status page has active scheduled events.
-
-        let scheduledEventsSelect: Select<ScheduledMaintenance> = {
-          createdAt: true,
-          title: true,
-          description: true,
-          _id: true,
-          endsAt: true,
-          startsAt: true,
-          currentScheduledMaintenanceState: {
-            name: true,
-            color: true,
-            isScheduledState: true,
-            isResolvedState: true,
-            isOngoingState: true,
-          },
-          monitors: {
-            _id: true,
-          },
-        };
-
-        if (statusPage.showScheduledEventLabelsOnStatusPage) {
-          scheduledEventsSelect = {
-            ...scheduledEventsSelect,
-            labels: {
-              name: true,
-              color: true,
-            },
-          };
-        }
-
-        let scheduledMaintenanceEvents: Array<ScheduledMaintenance> = [];
-
-        if (statusPage.showScheduledMaintenanceEventsOnStatusPage) {
-          scheduledMaintenanceEvents = await ScheduledMaintenanceService.findBy(
-            {
-              query: {
-                currentScheduledMaintenanceState: {
-                  isOngoingState: true,
-                } as any,
-                statusPages: statusPageId as any,
-                projectId: statusPage.projectId!,
-                isVisibleOnStatusPage: true,
-              },
-              select: scheduledEventsSelect,
-              sort: {
-                startsAt: SortOrder.Ascending,
-              },
-              skip: 0,
-              limit: LIMIT_PER_PROJECT,
-              props: {
-                isRoot: true,
-              },
-            },
-          );
-        }
-
-        let futureScheduledMaintenanceEvents: Array<ScheduledMaintenance> = [];
-
-        if (statusPage.showScheduledMaintenanceEventsOnStatusPage) {
-          futureScheduledMaintenanceEvents =
-            await ScheduledMaintenanceService.findBy({
-              query: {
-                currentScheduledMaintenanceState: {
-                  isScheduledState: true,
-                } as any,
-                statusPages: statusPageId as any,
-                projectId: statusPage.projectId!,
-                isVisibleOnStatusPage: true,
-              },
-              select: scheduledEventsSelect,
-              sort: {
-                startsAt: SortOrder.Ascending,
-              },
-              skip: 0,
-              limit: LIMIT_PER_PROJECT,
-              props: {
-                isRoot: true,
-              },
-            });
-        }
-
-        futureScheduledMaintenanceEvents.forEach(
-          (event: ScheduledMaintenance) => {
-            scheduledMaintenanceEvents.push(event);
-          },
-        );
-
-        const scheduledMaintenanceEventsOnStatusPage: Array<ObjectID> =
-          scheduledMaintenanceEvents.map((event: ScheduledMaintenance) => {
-            return event.id!;
-          });
-
-        let scheduledMaintenanceEventsPublicNotes: Array<ScheduledMaintenancePublicNote> =
-          [];
-
-        if (scheduledMaintenanceEventsOnStatusPage.length > 0) {
-          scheduledMaintenanceEventsPublicNotes =
-            await ScheduledMaintenancePublicNoteService.findBy({
-              query: {
-                scheduledMaintenanceId: QueryHelper.any(
-                  scheduledMaintenanceEventsOnStatusPage,
-                ),
-                projectId: statusPage.projectId!,
-              },
-              select: {
-                postedAt: true,
-                note: true,
-                scheduledMaintenanceId: true,
-                attachments: {
-                  _id: true,
-                  name: true,
-                },
-              },
-              sort: {
-                postedAt: SortOrder.Ascending,
-              },
-              skip: 0,
-              limit: LIMIT_PER_PROJECT,
-              props: {
-                isRoot: true,
-              },
-            });
-        }
-
-        let scheduledMaintenanceStateTimelines: Array<ScheduledMaintenanceStateTimeline> =
-          [];
-
-        if (scheduledMaintenanceEventsOnStatusPage.length > 0) {
-          scheduledMaintenanceStateTimelines =
-            await ScheduledMaintenanceStateTimelineService.findBy({
-              query: {
-                scheduledMaintenanceId: QueryHelper.any(
-                  scheduledMaintenanceEventsOnStatusPage,
-                ),
-                projectId: statusPage.projectId!,
-              },
-              select: {
-                _id: true,
-                createdAt: true,
-                startsAt: true,
-                scheduledMaintenanceId: true,
-                scheduledMaintenanceState: {
-                  _id: true,
-                  color: true,
-                  name: true,
-                  isScheduledState: true,
-                  isResolvedState: true,
-                  isOngoingState: true,
-                },
-              },
-
-              sort: {
-                startsAt: SortOrder.Descending, // newer state changes first
-              },
-              skip: 0,
-              limit: LIMIT_PER_PROJECT,
-              props: {
-                isRoot: true,
-              },
-            });
-        }
-
-        // get all status page bar chart rules
-        const statusPageHistoryChartBarColorRules: Array<StatusPageHistoryChartBarColorRule> =
-          await StatusPageHistoryChartBarColorRuleService.findBy({
-            query: {
-              statusPageId: statusPageId,
-            },
-            select: {
-              _id: true,
-              barColor: true,
-              order: true,
-              statusPageId: true,
-              uptimePercentGreaterThanOrEqualTo: true,
-            },
-            sort: {
-              order: SortOrder.Ascending,
-            },
-            skip: 0,
-            limit: LIMIT_PER_PROJECT,
-            props: {
-              isRoot: true,
-            },
-          });
-
-        /*
-         * Fetch all incidents (active + resolved) in the timeline date range
-         * for the uptime bar tooltip and click-through
-         */
-        let timelineIncidents: Array<Incident> = [];
-        if (
-          monitorsOnStatusPage.length > 0 &&
-          statusPage.showIncidentsOnStatusPage
-        ) {
-          timelineIncidents = await IncidentService.findBy({
-            query: {
-              monitors: monitorsOnStatusPage as any,
-              declaredAt: QueryHelper.inBetween(startDate, endDate),
-              isVisibleOnStatusPage: true,
-              projectId: statusPage.projectId!,
-            },
-            select: {
-              _id: true,
-              title: true,
-              declaredAt: true,
-              incidentSeverity: {
-                name: true,
-                color: true,
-              },
-              currentIncidentState: {
-                _id: true,
-                name: true,
-                color: true,
-              },
-              monitors: {
-                _id: true,
-              },
-            },
-            sort: {
-              declaredAt: SortOrder.Descending,
-            },
-            skip: 0,
-            limit: LIMIT_PER_PROJECT,
-            props: {
-              isRoot: true,
-            },
-          });
-        }
-
-        const overallStatus: MonitorStatus | null =
-          StatusPageService.getOverallMonitorStatus({
-            statusPageResources,
-            monitorStatuses,
-            monitorGroupCurrentStatuses,
-          });
-
-        const response: JSONObject = {
-          overallStatus: overallStatus
-            ? BaseModel.toJSON(overallStatus, MonitorStatus)
-            : null,
-
-          scheduledMaintenanceEventsPublicNotes: BaseModel.toJSONArray(
-            scheduledMaintenanceEventsPublicNotes,
-            ScheduledMaintenancePublicNote,
-          ),
-          statusPageHistoryChartBarColorRules: BaseModel.toJSONArray(
-            statusPageHistoryChartBarColorRules,
-            StatusPageHistoryChartBarColorRule,
-          ),
-          scheduledMaintenanceEvents: BaseModel.toJSONArray(
-            scheduledMaintenanceEvents,
-            ScheduledMaintenance,
-          ),
-          activeAnnouncements: BaseModel.toJSONArray(
-            activeAnnouncements,
-            StatusPageAnnouncement,
-          ),
-          incidentPublicNotes: BaseModel.toJSONArray(
-            incidentPublicNotes,
-            IncidentPublicNote,
-          ),
-
-          activeIncidents: BaseModel.toJSONArray(activeIncidents, Incident),
-
-          activeEpisodes: activeEpisodesJson,
-          episodePublicNotes: BaseModel.toJSONArray(
-            episodePublicNotes,
-            IncidentEpisodePublicNote,
-          ),
-          episodeStateTimelines: BaseModel.toJSONArray(
-            episodeStateTimelines,
-            IncidentEpisodeStateTimeline,
-          ),
-
-          monitorStatusTimelines: BaseModel.toJSONArray(
-            monitorStatusTimelines,
-            MonitorStatusTimeline,
-          ),
-          resourceGroups: BaseModel.toJSONArray(
-            statusPageGroups,
-            StatusPageGroup,
-          ),
-          monitorStatuses: BaseModel.toJSONArray(
-            monitorStatuses,
-            MonitorStatus,
-          ),
-          statusPageResources: BaseModel.toJSONArray(
-            statusPageResources,
-            StatusPageResource,
-          ),
-          incidentStateTimelines: BaseModel.toJSONArray(
-            incidentStateTimelines,
-            IncidentStateTimeline,
-          ),
-          statusPage: (() => {
-            const statusPageJson: JSONObject = BaseModel.toJSONObject(
-              statusPage,
-              StatusPage,
-            );
-            delete statusPageJson["projectId"];
-            return statusPageJson;
-          })(),
-          scheduledMaintenanceStateTimelines: BaseModel.toJSONArray(
-            scheduledMaintenanceStateTimelines,
-            ScheduledMaintenanceStateTimeline,
-          ),
-
-          monitorGroupCurrentStatuses: JSONFunctions.serialize(
-            monitorGroupCurrentStatuses,
-          ),
-          monitorsInGroup: JSONFunctions.serialize(monitorsInGroup),
-          timelineIncidents: BaseModel.toJSONArray(timelineIncidents, Incident),
-        };
 
         // These can serve private-page data on a GET; never let shared caches store them.
         Response.setNoCacheHeaders(res);
@@ -5218,6 +4416,864 @@ export default class StatusPageAPI extends BaseAPI<
       startDateForMonitorTimeline,
       endDateForMonitorTimeline,
     };
+  }
+
+  /*
+   * Builds the full overview payload for one status page. Everything below
+   * is a pure function of the statusPageId — every query runs with isRoot
+   * props and nothing is read from the request — which is what makes the
+   * result safe to cache and share across requests. The returned JSONObject
+   * must never be mutated after build.
+   */
+  @CaptureSpan()
+  public async buildOverviewResponse(
+    statusPageId: ObjectID,
+  ): Promise<JSONObject> {
+    /*
+     * The timeline window comes from the status page's configured
+     * showUptimeHistoryInDays. getStatusPageResourcesAndTimelines
+     * fetches the status page row anyway, so let it compute the window
+     * (clamped to 1..90 days, ending now) instead of issuing a separate
+     * StatusPage query here just to read that one column.
+     */
+    const {
+      monitorStatuses,
+      monitorGroupCurrentStatuses,
+      statusPageResources,
+      statusPage,
+      monitorsOnStatusPage,
+      monitorStatusTimelines,
+      statusPageGroups,
+      monitorsInGroup,
+      startDateForMonitorTimeline: startDate,
+      endDateForMonitorTimeline: endDate,
+    } = await this.getStatusPageResourcesAndTimelines({
+      statusPageId: statusPageId,
+    });
+
+    // check if status page has active incident.
+    let activeIncidents: Array<Incident> = [];
+    if (monitorsOnStatusPage.length > 0) {
+      let select: Select<Incident> = {
+        createdAt: true,
+        declaredAt: true,
+        updatedAt: true,
+        title: true,
+        description: true,
+        _id: true,
+        postmortemNote: true,
+        postmortemPostedAt: true,
+        showPostmortemOnStatusPage: true,
+        postmortemAttachments: {
+          _id: true,
+          name: true,
+        },
+        incidentSeverity: {
+          name: true,
+          color: true,
+        },
+        currentIncidentState: {
+          _id: true,
+          name: true,
+          color: true,
+          order: true,
+        },
+        monitors: {
+          _id: true,
+        },
+      };
+
+      if (statusPage.showIncidentLabelsOnStatusPage) {
+        select = {
+          ...select,
+          labels: {
+            name: true,
+            color: true,
+          },
+        };
+      }
+
+      const unresolvedIncidentStates: Array<IncidentState> =
+        await IncidentStateService.getUnresolvedIncidentStates(
+          statusPage.projectId!,
+          {
+            isRoot: true,
+          },
+        );
+
+      const unresolvedIncidentStateIds: Array<ObjectID> =
+        unresolvedIncidentStates.map((state: IncidentState) => {
+          return state.id!;
+        });
+
+      if (statusPage.showIncidentsOnStatusPage) {
+        activeIncidents = await IncidentService.findBy({
+          query: {
+            monitors: monitorsOnStatusPage as any,
+            currentIncidentStateId: QueryHelper.any(unresolvedIncidentStateIds),
+            isVisibleOnStatusPage: true,
+            projectId: statusPage.projectId!,
+          },
+          select: select,
+          sort: {
+            declaredAt: SortOrder.Descending,
+            createdAt: SortOrder.Descending,
+          },
+
+          skip: 0,
+          limit: LIMIT_PER_PROJECT,
+          props: {
+            isRoot: true,
+          },
+        });
+      }
+    }
+
+    const incidentsOnStatusPage: Array<ObjectID> = activeIncidents.map(
+      (incident: Incident) => {
+        return incident.id!;
+      },
+    );
+
+    let incidentPublicNotes: Array<IncidentPublicNote> = [];
+
+    if (incidentsOnStatusPage.length > 0) {
+      incidentPublicNotes = await IncidentPublicNoteService.findBy({
+        query: {
+          incidentId: QueryHelper.any(incidentsOnStatusPage),
+          projectId: statusPage.projectId!,
+        },
+        select: {
+          note: true,
+          incidentId: true,
+          postedAt: true,
+          attachments: {
+            _id: true,
+            name: true,
+          },
+        },
+        sort: {
+          postedAt: SortOrder.Descending, // new note first
+        },
+        skip: 0,
+        limit: LIMIT_PER_PROJECT,
+        props: {
+          isRoot: true,
+        },
+      });
+    }
+
+    let incidentStateTimelines: Array<IncidentStateTimeline> = [];
+
+    if (incidentsOnStatusPage.length > 0) {
+      incidentStateTimelines = await IncidentStateTimelineService.findBy({
+        query: {
+          incidentId: QueryHelper.any(incidentsOnStatusPage),
+          projectId: statusPage.projectId!,
+        },
+        select: {
+          _id: true,
+          createdAt: true,
+          startsAt: true,
+          incidentId: true,
+          incidentState: {
+            _id: true,
+            name: true,
+            color: true,
+            isCreatedState: true,
+            isResolvedState: true,
+            isAcknowledgedState: true,
+          },
+        },
+
+        sort: {
+          startsAt: SortOrder.Descending, // newer state changes first
+        },
+        skip: 0,
+        limit: LIMIT_PER_PROJECT,
+        props: {
+          isRoot: true,
+        },
+      });
+    }
+
+    // Fetch active episodes (similar to incidents)
+    let activeEpisodes: Array<IncidentEpisode> = [];
+    let activeEpisodesJson: JSONArray = [];
+    let episodePublicNotes: Array<IncidentEpisodePublicNote> = [];
+    let episodeStateTimelines: Array<IncidentEpisodeStateTimeline> = [];
+
+    /*
+     * Cheap guard before the expensive part: the block below scans every
+     * incident ever attached to this page's monitors (a many-to-many
+     * join, up to LIMIT_PER_PROJECT rows) just to discover episode
+     * membership — on every overview view, even though most pages have
+     * zero active episodes most of the time. One indexed COUNT of the
+     * project's unresolved, visible episodes lets us skip all of it in
+     * the common case. Behavior-preserving: the final activeEpisodes
+     * query applies exactly these three constraints, so count == 0
+     * implies the block's outputs stay empty.
+     */
+    let unresolvedIncidentStateIds: Array<ObjectID> = [];
+    let hasActiveEpisodes: boolean = false;
+
+    if (
+      statusPage.showEpisodesOnStatusPage &&
+      monitorsOnStatusPage.length > 0
+    ) {
+      const unresolvedIncidentStates: Array<IncidentState> =
+        await IncidentStateService.getUnresolvedIncidentStates(
+          statusPage.projectId!,
+          { isRoot: true },
+        );
+
+      unresolvedIncidentStateIds = unresolvedIncidentStates.map(
+        (state: IncidentState) => {
+          return state.id!;
+        },
+      );
+
+      const activeEpisodeCount: PositiveNumber =
+        await IncidentEpisodeService.countBy({
+          query: {
+            projectId: statusPage.projectId!,
+            isVisibleOnStatusPage: true,
+            currentIncidentStateId: QueryHelper.any(unresolvedIncidentStateIds),
+          },
+          props: {
+            isRoot: true,
+          },
+        });
+
+      hasActiveEpisodes = activeEpisodeCount.toNumber() > 0;
+    }
+
+    if (hasActiveEpisodes) {
+      // First, get incidents that have monitors on status page
+      const incidentsForEpisodes: Array<Incident> =
+        await IncidentService.findBy({
+          query: {
+            monitors: monitorsOnStatusPage as any,
+            isVisibleOnStatusPage: true,
+            projectId: statusPage.projectId!,
+          },
+          select: {
+            _id: true,
+          },
+          skip: 0,
+          limit: LIMIT_PER_PROJECT,
+          props: {
+            isRoot: true,
+          },
+        });
+
+      const incidentIdsForEpisodes: Array<ObjectID> = incidentsForEpisodes.map(
+        (incident: Incident) => {
+          return incident.id!;
+        },
+      );
+
+      // Get episode members for these incidents
+      let episodeMembers: Array<IncidentEpisodeMember> = [];
+      if (incidentIdsForEpisodes.length > 0) {
+        episodeMembers = await IncidentEpisodeMemberService.findBy({
+          query: {
+            incidentId: QueryHelper.any(incidentIdsForEpisodes),
+            projectId: statusPage.projectId!,
+          },
+          select: {
+            incidentEpisodeId: true,
+            incidentId: true,
+          },
+          skip: 0,
+          limit: LIMIT_PER_PROJECT,
+          props: {
+            isRoot: true,
+          },
+        });
+      }
+
+      // Get unique episode IDs
+      const episodeIdsFromMembers: Set<string> = new Set();
+      for (const member of episodeMembers) {
+        if (member.incidentEpisodeId) {
+          episodeIdsFromMembers.add(member.incidentEpisodeId.toString());
+        }
+      }
+
+      // Fetch active (unresolved) episodes
+      if (episodeIdsFromMembers.size > 0) {
+        // unresolvedIncidentStateIds was fetched by the guard above.
+        let selectEpisodes: Select<IncidentEpisode> = {
+          createdAt: true,
+          declaredAt: true,
+          updatedAt: true,
+          title: true,
+          description: true,
+          _id: true,
+          episodeNumber: true,
+          incidentSeverity: {
+            name: true,
+            color: true,
+          },
+          currentIncidentState: {
+            name: true,
+            color: true,
+            _id: true,
+            order: true,
+            isCreatedState: true,
+            isAcknowledgedState: true,
+            isResolvedState: true,
+          },
+          incidentCount: true,
+        };
+
+        if (statusPage.showEpisodeLabelsOnStatusPage) {
+          selectEpisodes = {
+            ...selectEpisodes,
+            labels: {
+              name: true,
+              color: true,
+            },
+          };
+        }
+
+        activeEpisodes = await IncidentEpisodeService.findBy({
+          query: {
+            _id: QueryHelper.any(
+              Array.from(episodeIdsFromMembers).map((id: string) => {
+                return new ObjectID(id);
+              }),
+            ),
+            currentIncidentStateId: QueryHelper.any(unresolvedIncidentStateIds),
+            isVisibleOnStatusPage: true,
+            projectId: statusPage.projectId!,
+          },
+          select: selectEpisodes,
+          sort: {
+            declaredAt: SortOrder.Descending,
+            createdAt: SortOrder.Descending,
+          },
+          skip: 0,
+          limit: LIMIT_PER_PROJECT,
+          props: {
+            isRoot: true,
+          },
+        });
+
+        // Build episode monitors map
+        if (activeEpisodes.length > 0) {
+          // Collect all incident IDs from episode members for active episodes
+          const activeEpisodeIds: Set<string> = new Set(
+            activeEpisodes.map((e: IncidentEpisode) => {
+              return e.id!.toString();
+            }),
+          );
+
+          const memberIncidentIds: Array<ObjectID> = [];
+          for (const member of episodeMembers) {
+            if (
+              member.incidentEpisodeId &&
+              activeEpisodeIds.has(member.incidentEpisodeId.toString()) &&
+              member.incidentId &&
+              !memberIncidentIds.some((id: ObjectID) => {
+                return id.toString() === member.incidentId!.toString();
+              })
+            ) {
+              memberIncidentIds.push(member.incidentId);
+            }
+          }
+
+          // Fetch incidents with monitors
+          let memberIncidents: Array<Incident> = [];
+          if (memberIncidentIds.length > 0) {
+            memberIncidents = await IncidentService.findBy({
+              query: {
+                _id: QueryHelper.any(memberIncidentIds),
+                isVisibleOnStatusPage: true,
+                projectId: statusPage.projectId!,
+              },
+              select: {
+                _id: true,
+                monitors: {
+                  _id: true,
+                },
+              },
+              skip: 0,
+              limit: LIMIT_PER_PROJECT,
+              props: {
+                isRoot: true,
+              },
+            });
+          }
+
+          // Build incident -> monitors map
+          const incidentMonitorsMap: Map<string, Array<ObjectID>> = new Map();
+          for (const incident of memberIncidents) {
+            const incidentIdStr: string = incident.id!.toString();
+            const monitorIds: Array<ObjectID> = (incident.monitors || [])
+              .map((m: Monitor) => {
+                return new ObjectID(
+                  m._id?.toString() || m.id?.toString() || "",
+                );
+              })
+              .filter((id: ObjectID) => {
+                return id.toString() !== "";
+              });
+            incidentMonitorsMap.set(incidentIdStr, monitorIds);
+          }
+
+          // Build episode -> monitors map
+          const episodeMonitorsMap: Map<string, Array<ObjectID>> = new Map();
+          for (const member of episodeMembers) {
+            if (
+              member.incidentEpisodeId &&
+              member.incidentId &&
+              activeEpisodeIds.has(member.incidentEpisodeId.toString())
+            ) {
+              const episodeIdStr: string = member.incidentEpisodeId.toString();
+              const incidentIdStr: string = member.incidentId.toString();
+
+              if (!episodeMonitorsMap.has(episodeIdStr)) {
+                episodeMonitorsMap.set(episodeIdStr, []);
+              }
+
+              const episodeMonitors: Array<ObjectID> =
+                episodeMonitorsMap.get(episodeIdStr)!;
+              const incidentMonitors: Array<ObjectID> =
+                incidentMonitorsMap.get(incidentIdStr) || [];
+
+              for (const monitorId of incidentMonitors) {
+                if (
+                  !episodeMonitors.some((m: ObjectID) => {
+                    return m.toString() === monitorId.toString();
+                  })
+                ) {
+                  episodeMonitors.push(monitorId);
+                }
+              }
+            }
+          }
+
+          // Serialize episodes and add monitors
+          activeEpisodesJson = BaseModel.toJSONArray(
+            activeEpisodes,
+            IncidentEpisode,
+          );
+          for (const episodeJson of activeEpisodesJson) {
+            const episodeObj: JSONObject = episodeJson as JSONObject;
+            const episodeId: string | undefined = episodeObj["_id"]?.toString();
+            if (episodeId) {
+              const monitorIds: Array<ObjectID> =
+                episodeMonitorsMap.get(episodeId) || [];
+              episodeObj["monitors"] = monitorIds.map((id: ObjectID) => {
+                return { _id: id.toString() };
+              });
+            }
+          }
+
+          // Get episode public notes
+          const episodesOnStatusPage: Array<ObjectID> = activeEpisodes.map(
+            (episode: IncidentEpisode) => {
+              return episode.id!;
+            },
+          );
+
+          if (episodesOnStatusPage.length > 0) {
+            episodePublicNotes = await IncidentEpisodePublicNoteService.findBy({
+              query: {
+                incidentEpisodeId: QueryHelper.any(episodesOnStatusPage),
+                projectId: statusPage.projectId!,
+              },
+              select: {
+                postedAt: true,
+                note: true,
+                incidentEpisodeId: true,
+                attachments: {
+                  _id: true,
+                  name: true,
+                },
+              },
+              sort: {
+                postedAt: SortOrder.Descending,
+              },
+              skip: 0,
+              limit: LIMIT_PER_PROJECT,
+              props: {
+                isRoot: true,
+              },
+            });
+
+            // Get episode state timelines
+            episodeStateTimelines =
+              await IncidentEpisodeStateTimelineService.findBy({
+                query: {
+                  incidentEpisodeId: QueryHelper.any(episodesOnStatusPage),
+                  projectId: statusPage.projectId!,
+                },
+                select: {
+                  _id: true,
+                  createdAt: true,
+                  startsAt: true,
+                  incidentEpisodeId: true,
+                  incidentState: {
+                    name: true,
+                    color: true,
+                    isCreatedState: true,
+                    isAcknowledgedState: true,
+                    isResolvedState: true,
+                  },
+                },
+                sort: {
+                  startsAt: SortOrder.Descending,
+                },
+                skip: 0,
+                limit: LIMIT_PER_PROJECT,
+                props: {
+                  isRoot: true,
+                },
+              });
+          }
+        }
+      }
+    }
+
+    // check if status page has active announcement.
+
+    const today: Date = OneUptimeDate.getCurrentDate();
+
+    let activeAnnouncements: Array<StatusPageAnnouncement> = [];
+
+    if (statusPage.showAnnouncementsOnStatusPage) {
+      activeAnnouncements = await StatusPageAnnouncementService.findBy({
+        query: {
+          statusPages: statusPageId as any,
+          showAnnouncementAt: QueryHelper.lessThan(today),
+          endAnnouncementAt: QueryHelper.greaterThanOrNull(today),
+          projectId: statusPage.projectId!,
+        },
+        select: {
+          createdAt: true,
+          title: true,
+          description: true,
+          _id: true,
+          showAnnouncementAt: true,
+          endAnnouncementAt: true,
+        },
+        skip: 0,
+        limit: LIMIT_PER_PROJECT,
+        props: {
+          isRoot: true,
+        },
+      });
+    }
+
+    // check if status page has active scheduled events.
+
+    let scheduledEventsSelect: Select<ScheduledMaintenance> = {
+      createdAt: true,
+      title: true,
+      description: true,
+      _id: true,
+      endsAt: true,
+      startsAt: true,
+      currentScheduledMaintenanceState: {
+        name: true,
+        color: true,
+        isScheduledState: true,
+        isResolvedState: true,
+        isOngoingState: true,
+      },
+      monitors: {
+        _id: true,
+      },
+    };
+
+    if (statusPage.showScheduledEventLabelsOnStatusPage) {
+      scheduledEventsSelect = {
+        ...scheduledEventsSelect,
+        labels: {
+          name: true,
+          color: true,
+        },
+      };
+    }
+
+    let scheduledMaintenanceEvents: Array<ScheduledMaintenance> = [];
+
+    if (statusPage.showScheduledMaintenanceEventsOnStatusPage) {
+      scheduledMaintenanceEvents = await ScheduledMaintenanceService.findBy({
+        query: {
+          currentScheduledMaintenanceState: {
+            isOngoingState: true,
+          } as any,
+          statusPages: statusPageId as any,
+          projectId: statusPage.projectId!,
+          isVisibleOnStatusPage: true,
+        },
+        select: scheduledEventsSelect,
+        sort: {
+          startsAt: SortOrder.Ascending,
+        },
+        skip: 0,
+        limit: LIMIT_PER_PROJECT,
+        props: {
+          isRoot: true,
+        },
+      });
+    }
+
+    let futureScheduledMaintenanceEvents: Array<ScheduledMaintenance> = [];
+
+    if (statusPage.showScheduledMaintenanceEventsOnStatusPage) {
+      futureScheduledMaintenanceEvents =
+        await ScheduledMaintenanceService.findBy({
+          query: {
+            currentScheduledMaintenanceState: {
+              isScheduledState: true,
+            } as any,
+            statusPages: statusPageId as any,
+            projectId: statusPage.projectId!,
+            isVisibleOnStatusPage: true,
+          },
+          select: scheduledEventsSelect,
+          sort: {
+            startsAt: SortOrder.Ascending,
+          },
+          skip: 0,
+          limit: LIMIT_PER_PROJECT,
+          props: {
+            isRoot: true,
+          },
+        });
+    }
+
+    futureScheduledMaintenanceEvents.forEach((event: ScheduledMaintenance) => {
+      scheduledMaintenanceEvents.push(event);
+    });
+
+    const scheduledMaintenanceEventsOnStatusPage: Array<ObjectID> =
+      scheduledMaintenanceEvents.map((event: ScheduledMaintenance) => {
+        return event.id!;
+      });
+
+    let scheduledMaintenanceEventsPublicNotes: Array<ScheduledMaintenancePublicNote> =
+      [];
+
+    if (scheduledMaintenanceEventsOnStatusPage.length > 0) {
+      scheduledMaintenanceEventsPublicNotes =
+        await ScheduledMaintenancePublicNoteService.findBy({
+          query: {
+            scheduledMaintenanceId: QueryHelper.any(
+              scheduledMaintenanceEventsOnStatusPage,
+            ),
+            projectId: statusPage.projectId!,
+          },
+          select: {
+            postedAt: true,
+            note: true,
+            scheduledMaintenanceId: true,
+            attachments: {
+              _id: true,
+              name: true,
+            },
+          },
+          sort: {
+            postedAt: SortOrder.Ascending,
+          },
+          skip: 0,
+          limit: LIMIT_PER_PROJECT,
+          props: {
+            isRoot: true,
+          },
+        });
+    }
+
+    let scheduledMaintenanceStateTimelines: Array<ScheduledMaintenanceStateTimeline> =
+      [];
+
+    if (scheduledMaintenanceEventsOnStatusPage.length > 0) {
+      scheduledMaintenanceStateTimelines =
+        await ScheduledMaintenanceStateTimelineService.findBy({
+          query: {
+            scheduledMaintenanceId: QueryHelper.any(
+              scheduledMaintenanceEventsOnStatusPage,
+            ),
+            projectId: statusPage.projectId!,
+          },
+          select: {
+            _id: true,
+            createdAt: true,
+            startsAt: true,
+            scheduledMaintenanceId: true,
+            scheduledMaintenanceState: {
+              _id: true,
+              color: true,
+              name: true,
+              isScheduledState: true,
+              isResolvedState: true,
+              isOngoingState: true,
+            },
+          },
+
+          sort: {
+            startsAt: SortOrder.Descending, // newer state changes first
+          },
+          skip: 0,
+          limit: LIMIT_PER_PROJECT,
+          props: {
+            isRoot: true,
+          },
+        });
+    }
+
+    // get all status page bar chart rules
+    const statusPageHistoryChartBarColorRules: Array<StatusPageHistoryChartBarColorRule> =
+      await StatusPageHistoryChartBarColorRuleService.findBy({
+        query: {
+          statusPageId: statusPageId,
+        },
+        select: {
+          _id: true,
+          barColor: true,
+          order: true,
+          statusPageId: true,
+          uptimePercentGreaterThanOrEqualTo: true,
+        },
+        sort: {
+          order: SortOrder.Ascending,
+        },
+        skip: 0,
+        limit: LIMIT_PER_PROJECT,
+        props: {
+          isRoot: true,
+        },
+      });
+
+    /*
+     * Fetch all incidents (active + resolved) in the timeline date range
+     * for the uptime bar tooltip and click-through
+     */
+    let timelineIncidents: Array<Incident> = [];
+    if (
+      monitorsOnStatusPage.length > 0 &&
+      statusPage.showIncidentsOnStatusPage
+    ) {
+      timelineIncidents = await IncidentService.findBy({
+        query: {
+          monitors: monitorsOnStatusPage as any,
+          declaredAt: QueryHelper.inBetween(startDate, endDate),
+          isVisibleOnStatusPage: true,
+          projectId: statusPage.projectId!,
+        },
+        select: {
+          _id: true,
+          title: true,
+          declaredAt: true,
+          incidentSeverity: {
+            name: true,
+            color: true,
+          },
+          currentIncidentState: {
+            _id: true,
+            name: true,
+            color: true,
+          },
+          monitors: {
+            _id: true,
+          },
+        },
+        sort: {
+          declaredAt: SortOrder.Descending,
+        },
+        skip: 0,
+        limit: LIMIT_PER_PROJECT,
+        props: {
+          isRoot: true,
+        },
+      });
+    }
+
+    const overallStatus: MonitorStatus | null =
+      StatusPageService.getOverallMonitorStatus({
+        statusPageResources,
+        monitorStatuses,
+        monitorGroupCurrentStatuses,
+      });
+
+    const response: JSONObject = {
+      overallStatus: overallStatus
+        ? BaseModel.toJSON(overallStatus, MonitorStatus)
+        : null,
+
+      scheduledMaintenanceEventsPublicNotes: BaseModel.toJSONArray(
+        scheduledMaintenanceEventsPublicNotes,
+        ScheduledMaintenancePublicNote,
+      ),
+      statusPageHistoryChartBarColorRules: BaseModel.toJSONArray(
+        statusPageHistoryChartBarColorRules,
+        StatusPageHistoryChartBarColorRule,
+      ),
+      scheduledMaintenanceEvents: BaseModel.toJSONArray(
+        scheduledMaintenanceEvents,
+        ScheduledMaintenance,
+      ),
+      activeAnnouncements: BaseModel.toJSONArray(
+        activeAnnouncements,
+        StatusPageAnnouncement,
+      ),
+      incidentPublicNotes: BaseModel.toJSONArray(
+        incidentPublicNotes,
+        IncidentPublicNote,
+      ),
+
+      activeIncidents: BaseModel.toJSONArray(activeIncidents, Incident),
+
+      activeEpisodes: activeEpisodesJson,
+      episodePublicNotes: BaseModel.toJSONArray(
+        episodePublicNotes,
+        IncidentEpisodePublicNote,
+      ),
+      episodeStateTimelines: BaseModel.toJSONArray(
+        episodeStateTimelines,
+        IncidentEpisodeStateTimeline,
+      ),
+
+      monitorStatusTimelines: BaseModel.toJSONArray(
+        monitorStatusTimelines,
+        MonitorStatusTimeline,
+      ),
+      resourceGroups: BaseModel.toJSONArray(statusPageGroups, StatusPageGroup),
+      monitorStatuses: BaseModel.toJSONArray(monitorStatuses, MonitorStatus),
+      statusPageResources: BaseModel.toJSONArray(
+        statusPageResources,
+        StatusPageResource,
+      ),
+      incidentStateTimelines: BaseModel.toJSONArray(
+        incidentStateTimelines,
+        IncidentStateTimeline,
+      ),
+      statusPage: (() => {
+        const statusPageJson: JSONObject = BaseModel.toJSONObject(
+          statusPage,
+          StatusPage,
+        );
+        delete statusPageJson["projectId"];
+        return statusPageJson;
+      })(),
+      scheduledMaintenanceStateTimelines: BaseModel.toJSONArray(
+        scheduledMaintenanceStateTimelines,
+        ScheduledMaintenanceStateTimeline,
+      ),
+
+      monitorGroupCurrentStatuses: JSONFunctions.serialize(
+        monitorGroupCurrentStatuses,
+      ),
+      monitorsInGroup: JSONFunctions.serialize(monitorsInGroup),
+      timelineIncidents: BaseModel.toJSONArray(timelineIncidents, Incident),
+    };
+
+    return response;
   }
 
   private async getStatusPageAnnouncementAttachment(

--- a/Common/Server/Middleware/UserAuthorization.ts
+++ b/Common/Server/Middleware/UserAuthorization.ts
@@ -449,8 +449,17 @@ export default class UserMiddleware {
         globalValue,
         null,
       );
-      res.set("global-permissions", globalValue);
-      res.set("global-permissions-hash", globalPermissionsHash);
+
+      if (
+        !(
+          req.headers &&
+          req.headers["global-permissions-hash"] &&
+          req.headers["global-permissions-hash"] === globalPermissionsHash
+        )
+      ) {
+        res.set("global-permissions", globalValue);
+        res.set("global-permissions-hash", globalPermissionsHash);
+      }
     }
 
     // set project permissions hash.

--- a/Common/Server/Services/ApiKeyPermissionService.ts
+++ b/Common/Server/Services/ApiKeyPermissionService.ts
@@ -1,20 +1,120 @@
 import CreateBy from "../Types/Database/CreateBy";
-import { OnCreate, OnUpdate } from "../Types/Database/Hooks";
+import DeleteBy from "../Types/Database/DeleteBy";
+import { OnCreate, OnDelete, OnUpdate } from "../Types/Database/Hooks";
 import UpdateBy from "../Types/Database/UpdateBy";
 import DatabaseService from "./DatabaseService";
-import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
+import LIMIT_MAX, { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 import BadDataException from "../../Types/Exception/BadDataException";
 import Model from "../../Models/DatabaseModels/ApiKeyPermission";
+import Label from "../../Models/DatabaseModels/Label";
+import ObjectID from "../../Types/ObjectID";
+import Permission from "../../Types/Permission";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import InMemoryTTLCache from "../Infrastructure/InMemoryTTLCache";
+
+/*
+ * 60s is the worst-case staleness on any single API node after a key's
+ * permissions are edited. We invalidate in-process immediately on
+ * create/update/delete; this TTL is the upper bound for *other* processes
+ * (same bound the ApiKeyService key cache accepted).
+ */
+const PERMISSIONS_TTL_MS: number = 60 * 1000;
+
+interface CachedApiKeyPermissionRow {
+  permission: Permission;
+  labelIds: Array<string>;
+  isBlockPermission: boolean | undefined;
+}
+
+export interface ApiKeyPermissionRow {
+  permission: Permission;
+  labelIds: Array<ObjectID>;
+  isBlockPermission: boolean | undefined;
+}
+
 export class Service extends DatabaseService<Model> {
+  /*
+   * Cache of `apiKeyId -> permission rows`. The API-key auth path builds the
+   * request's tenant permissions from these rows on every request; without it
+   * that's a Postgres findBy (with a labels join) per request.
+   */
+  private permissionCache: InMemoryTTLCache<Array<CachedApiKeyPermissionRow>> =
+    new InMemoryTTLCache(10_000);
+
   public constructor() {
     super(Model);
+  }
+
+  public clearCache(): void {
+    this.permissionCache.clear();
+  }
+
+  /**
+   * Resolves the permission rows granted to an API key, with a short-lived
+   * in-process cache. Returns freshly built objects on every call (hit or
+   * miss), so callers never share mutable state with the cache. Use this from
+   * the auth hot path instead of calling `findBy` directly.
+   */
+  @CaptureSpan()
+  public async findPermissionsByApiKeyId(
+    apiKeyId: ObjectID,
+  ): Promise<Array<ApiKeyPermissionRow>> {
+    const cacheKey: string = apiKeyId.toString();
+
+    let cachedRows: Array<CachedApiKeyPermissionRow> | undefined =
+      this.permissionCache.get(cacheKey);
+
+    if (cachedRows === undefined) {
+      const rows: Array<Model> = await this.findBy({
+        query: {
+          apiKeyId: apiKeyId,
+        },
+        select: {
+          permission: true,
+          labels: {
+            _id: true,
+          },
+          isBlockPermission: true,
+        },
+        limit: LIMIT_MAX,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      });
+
+      cachedRows = rows.map((row: Model): CachedApiKeyPermissionRow => {
+        return {
+          permission: row.permission!,
+          labelIds: (row.labels ?? []).map((label: Label) => {
+            return label.id!.toString();
+          }),
+          isBlockPermission: row.isBlockPermission,
+        };
+      });
+
+      this.permissionCache.set(cacheKey, cachedRows, PERMISSIONS_TTL_MS);
+    }
+
+    return cachedRows.map(
+      (row: CachedApiKeyPermissionRow): ApiKeyPermissionRow => {
+        return {
+          permission: row.permission,
+          labelIds: row.labelIds.map((id: string) => {
+            return new ObjectID(id);
+          }),
+          isBlockPermission: row.isBlockPermission,
+        };
+      },
+    );
   }
 
   @CaptureSpan()
   protected override async onBeforeCreate(
     createBy: CreateBy<Model>,
   ): Promise<OnCreate<Model>> {
+    this.clearCache();
+
     if (!createBy.data.apiKeyId) {
       throw new BadDataException("API Key ID is required to create permission");
     }
@@ -92,6 +192,12 @@ export class Service extends DatabaseService<Model> {
   protected override async onBeforeUpdate(
     updateBy: UpdateBy<Model>,
   ): Promise<OnUpdate<Model>> {
+    /*
+     * We don't know which keys are being updated without a query; updates
+     * are rare so clearing is cheap.
+     */
+    this.clearCache();
+
     if (updateBy.data.labels && updateBy.data.labels.length > 0) {
       const existingPermissions: Array<Model> = await this.findBy({
         query: updateBy.query,
@@ -152,6 +258,14 @@ export class Service extends DatabaseService<Model> {
     }
 
     return { updateBy, carryForward: null };
+  }
+
+  @CaptureSpan()
+  protected override async onBeforeDelete(
+    deleteBy: DeleteBy<Model>,
+  ): Promise<OnDelete<Model>> {
+    this.clearCache();
+    return { deleteBy, carryForward: null };
   }
 }
 

--- a/Common/Server/Types/Database/Permissions/AccessControlPermission.ts
+++ b/Common/Server/Types/Database/Permissions/AccessControlPermission.ts
@@ -23,6 +23,17 @@ import { combineWithPrivacyClause } from "../../../Utils/PrivacyFilterUtil";
 import QueryHelper from "../QueryHelper";
 import QueryUtil from "../QueryUtil";
 import CaptureSpan from "../../../Utils/Telemetry/CaptureSpan";
+import Dictionary from "../../../../Types/Dictionary";
+
+/*
+ * Built once per invocation and threaded through the per-column loop; never
+ * cached on props or module scope (the multi-tenant path re-enters with
+ * different per-tenant props and must rebuild fresh).
+ */
+type AccessControlPermissionContext = {
+  nonAccessControlPermissions: Array<Permission>;
+  accessControlPermissions: Array<UserPermission>;
+};
 
 export default class AccessControlPermission {
   @CaptureSpan()
@@ -290,7 +301,10 @@ export default class AccessControlPermission {
     modelType: DatabaseBaseModelType,
     props: DatabaseCommonInteractionProps,
     type: DatabaseRequestType,
+    context?: AccessControlPermissionContext,
   ): Array<ObjectID> {
+    context = context ?? this.buildPermissionContext(props);
+
     let labelIds: Array<ObjectID> = [];
 
     // check model level permissions.
@@ -299,7 +313,7 @@ export default class AccessControlPermission {
       TablePermission.getTablePermission(modelType, type);
 
     const modelLevelLabelIds: Array<ObjectID> =
-      this.getAccessControlIdsByPermissions(modelLevelPermissions, props);
+      this.getAccessControlIdsByPermissions(modelLevelPermissions, context);
 
     labelIds = [...labelIds, ...modelLevelLabelIds];
 
@@ -331,11 +345,23 @@ export default class AccessControlPermission {
       ];
     }
 
-    labelIds = this.getAccessControlIdsForModel(modelType, props, type);
+    // Build the permission context once — not per column.
+    const context: AccessControlPermissionContext =
+      this.buildPermissionContext(props);
+
+    labelIds = this.getAccessControlIdsForModel(
+      modelType,
+      props,
+      type,
+      context,
+    );
+
+    const columnAccessControlDictionary: Dictionary<ColumnAccessControl> =
+      model.getColumnAccessControlForAllColumns();
 
     for (const column of columnsToCheckPermissionFor) {
       const accessControl: ColumnAccessControl | null =
-        model.getColumnAccessControlFor(column);
+        columnAccessControlDictionary[column] || null;
 
       if (!accessControl) {
         continue;
@@ -343,21 +369,21 @@ export default class AccessControlPermission {
 
       if (type === DatabaseRequestType.Read && accessControl.read) {
         const columnReadLabelIds: Array<ObjectID> =
-          this.getAccessControlIdsByPermissions(accessControl.read, props);
+          this.getAccessControlIdsByPermissions(accessControl.read, context);
 
         labelIds = [...labelIds, ...columnReadLabelIds];
       }
 
       if (type === DatabaseRequestType.Create && accessControl.create) {
         const columnCreateLabelIds: Array<ObjectID> =
-          this.getAccessControlIdsByPermissions(accessControl.create, props);
+          this.getAccessControlIdsByPermissions(accessControl.create, context);
 
         labelIds = [...labelIds, ...columnCreateLabelIds];
       }
 
       if (type === DatabaseRequestType.Update && accessControl.update) {
         const columnUpdateLabelIds: Array<ObjectID> =
-          this.getAccessControlIdsByPermissions(accessControl.update, props);
+          this.getAccessControlIdsByPermissions(accessControl.update, context);
 
         labelIds = [...labelIds, ...columnUpdateLabelIds];
       }
@@ -369,35 +395,40 @@ export default class AccessControlPermission {
     return distinctLabelIds;
   }
 
-  private static getAccessControlIdsByPermissions(
-    permissions: Array<Permission>,
+  private static buildPermissionContext(
     props: DatabaseCommonInteractionProps,
-  ): Array<ObjectID> {
+  ): AccessControlPermissionContext {
     const userPermissions: Array<UserPermission> =
       DatabaseCommonInteractionPropsUtil.getUserPermissions(
         props,
         PermissionType.Allow,
       );
 
-    const nonAccessControlPermissionPermission: Array<Permission> =
-      PermissionHelper.getNonAccessControlPermissions(userPermissions);
+    return {
+      nonAccessControlPermissions:
+        PermissionHelper.getNonAccessControlPermissions(userPermissions),
+      accessControlPermissions:
+        PermissionHelper.getAccessControlPermissions(userPermissions),
+    };
+  }
 
-    const accessControlPermissions: Array<UserPermission> =
-      PermissionHelper.getAccessControlPermissions(userPermissions);
-
+  private static getAccessControlIdsByPermissions(
+    permissions: Array<Permission>,
+    context: AccessControlPermissionContext,
+  ): Array<ObjectID> {
     let labelIds: Array<ObjectID> = [];
 
     if (
       PermissionHelper.doesPermissionsIntersect(
         permissions,
-        nonAccessControlPermissionPermission,
+        context.nonAccessControlPermissions,
       )
     ) {
       return []; // if this is intersecting, then return empty array. We dont need to check for access control.
     }
 
     for (const permission of permissions) {
-      for (const accessControlPermission of accessControlPermissions) {
+      for (const accessControlPermission of context.accessControlPermissions) {
         if (
           accessControlPermission.permission === permission &&
           accessControlPermission.labelIds.length > 0

--- a/Common/Server/Utils/APIKey/AccessPermission.ts
+++ b/Common/Server/Utils/APIKey/AccessPermission.ts
@@ -1,13 +1,12 @@
-import APIKeyPermission from "../../../Models/DatabaseModels/ApiKeyPermission";
-import Label from "../../../Models/DatabaseModels/Label";
-import LIMIT_MAX from "../../../Types/Database/LimitMax";
 import ObjectID from "../../../Types/ObjectID";
 import Permission, {
   UserGlobalAccessPermission,
   UserPermission,
   UserTenantAccessPermission,
 } from "../../../Types/Permission";
-import ApiKeyPermissionService from "../../Services/ApiKeyPermissionService";
+import ApiKeyPermissionService, {
+  ApiKeyPermissionRow,
+} from "../../Services/ApiKeyPermissionService";
 import CaptureSpan from "../Telemetry/CaptureSpan";
 import UserPermissionUtil from "../UserPermission/UserPermission";
 
@@ -68,43 +67,20 @@ export default class APIKeyAccessPermission {
     projectId: ObjectID,
     apiKeyId: ObjectID,
   ): Promise<UserTenantAccessPermission> {
-    // get team permissions.
-    const apiKeyPermission: Array<APIKeyPermission> =
-      await ApiKeyPermissionService.findBy({
-        query: {
-          apiKeyId: apiKeyId,
-        },
-        select: {
-          permission: true,
-          labels: {
-            _id: true,
-          },
-          isBlockPermission: true,
-        },
+    // get team permissions (cached — see ApiKeyPermissionService).
+    const apiKeyPermissionRows: Array<ApiKeyPermissionRow> =
+      await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
 
-        limit: LIMIT_MAX,
-        skip: 0,
-        props: {
-          isRoot: true,
-        },
-      });
-
-    const userPermissions: Array<UserPermission> = [];
-
-    for (const apiPermission of apiKeyPermission) {
-      if (!apiPermission.labels) {
-        apiPermission.labels = [];
-      }
-
-      userPermissions.push({
-        permission: apiPermission.permission!,
-        labelIds: apiPermission.labels.map((label: Label) => {
-          return label.id!;
-        }),
-        isBlockPermission: apiPermission.isBlockPermission,
-        _type: "UserPermission",
-      });
-    }
+    const userPermissions: Array<UserPermission> = apiKeyPermissionRows.map(
+      (row: ApiKeyPermissionRow): UserPermission => {
+        return {
+          permission: row.permission,
+          labelIds: row.labelIds,
+          isBlockPermission: row.isBlockPermission,
+          _type: "UserPermission",
+        };
+      },
+    );
 
     const permission: UserTenantAccessPermission =
       UserPermissionUtil.getDefaultUserTenantAccessPermission(projectId);

--- a/Common/Server/Utils/SessionReplay/SessionReplayGateCacheStore.ts
+++ b/Common/Server/Utils/SessionReplay/SessionReplayGateCacheStore.ts
@@ -24,6 +24,15 @@ import ObjectID from "../../../Types/ObjectID";
 export const POLICY_CACHE_TTL_MS: number = 60 * 1000;
 export const KILL_KEY_CACHE_TTL_MS: number = 5 * 1000;
 
+/*
+ * The policy cache key includes a client-supplied appIdentifier, so without a
+ * bound anyone holding an ingestion key could grow this map forever. Caps
+ * match the InMemoryTTLCache house default; that class is not used directly
+ * because clearCache(projectId) needs the prefix key scan it lacks.
+ */
+export const MAX_POLICY_CACHE_ENTRIES: number = 10_000;
+export const MAX_KILL_KEY_CACHE_ENTRIES: number = 10_000;
+
 const KILL_KEY_PREFIX: string = "replay:gate:off:";
 
 /*
@@ -52,6 +61,29 @@ interface KillKeyCacheEntry {
 const policyCache: Map<string, PolicyCacheEntry<unknown>> = new Map();
 const killKeyCache: Map<string, KillKeyCacheEntry> = new Map();
 
+/*
+ * Coarse-LRU bounded write (mirrors InMemoryTTLCache): evict the oldest entry
+ * only when at capacity AND the key is new, so rewriting an existing key never
+ * evicts a different entry; delete-before-set refreshes insertion order. The
+ * entry being written always lands, which markProjectDisabled's local kill
+ * marker depends on.
+ */
+function boundedSet<TValue>(
+  map: Map<string, TValue>,
+  key: string,
+  value: TValue,
+  maxEntries: number,
+): void {
+  if (map.size >= maxEntries && !map.has(key)) {
+    const oldest: string | undefined = map.keys().next().value;
+    if (oldest !== undefined) {
+      map.delete(oldest);
+    }
+  }
+  map.delete(key);
+  map.set(key, value);
+}
+
 export default class SessionReplayGateCacheStore {
   public static getPolicyEntry<TPolicy>(
     cacheKey: string,
@@ -63,7 +95,12 @@ export default class SessionReplayGateCacheStore {
     cacheKey: string,
     policy: TPolicy | null,
   ): void {
-    policyCache.set(cacheKey, { policy: policy, loadedAt: Date.now() });
+    boundedSet(
+      policyCache,
+      cacheKey,
+      { policy: policy, loadedAt: Date.now() },
+      MAX_POLICY_CACHE_ENTRIES,
+    );
   }
 
   /*
@@ -93,10 +130,12 @@ export default class SessionReplayGateCacheStore {
       }
     }
 
-    killKeyCache.set(projectId.toString(), {
-      isDisabled: true,
-      loadedAt: Date.now(),
-    });
+    boundedSet(
+      killKeyCache,
+      projectId.toString(),
+      { isDisabled: true, loadedAt: Date.now() },
+      MAX_KILL_KEY_CACHE_ENTRIES,
+    );
   }
 
   /*
@@ -159,7 +198,12 @@ export default class SessionReplayGateCacheStore {
        * Failing closed here would make a Redis blip stop replay ingest for
        * every project that had correctly opted in.
        */
-      killKeyCache.set(cacheKey, { isDisabled: false, loadedAt: Date.now() });
+      boundedSet(
+        killKeyCache,
+        cacheKey,
+        { isDisabled: false, loadedAt: Date.now() },
+        MAX_KILL_KEY_CACHE_ENTRIES,
+      );
       return false;
     }
 
@@ -178,10 +222,12 @@ export default class SessionReplayGateCacheStore {
       isDisabled = false;
     }
 
-    killKeyCache.set(cacheKey, {
-      isDisabled: isDisabled,
-      loadedAt: Date.now(),
-    });
+    boundedSet(
+      killKeyCache,
+      cacheKey,
+      { isDisabled: isDisabled, loadedAt: Date.now() },
+      MAX_KILL_KEY_CACHE_ENTRIES,
+    );
 
     return isDisabled;
   }

--- a/Common/Tests/Models/DatabaseModels/DatabaseBaseModelToJSONObjectCache.test.ts
+++ b/Common/Tests/Models/DatabaseModels/DatabaseBaseModelToJSONObjectCache.test.ts
@@ -1,0 +1,180 @@
+import BaseModel from "../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import Incident from "../../../Models/DatabaseModels/Incident";
+import IncidentSeverity from "../../../Models/DatabaseModels/IncidentSeverity";
+import Label from "../../../Models/DatabaseModels/Label";
+import Monitor from "../../../Models/DatabaseModels/Monitor";
+import Color from "../../../Types/Color";
+import { JSONArray, JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import { describe, expect, it } from "@jest/globals";
+
+/*
+ * toJSONObject reads table-column metadata off a cached, frozen, per-class
+ * vanilla instance instead of constructing one per row. These tests pin the
+ * contract that makes the cache safe: output is identical to a fresh
+ * construction, no state bleeds between rows or tenants, the cache is keyed
+ * on the declared modelType (not the instance's runtime class), and fromJSON
+ * still hands out a fresh mutable instance every call.
+ */
+
+describe("DatabaseBaseModel.toJSONObject with cached vanilla model", () => {
+  it("serializes a populated model with nested Entity and EntityArray columns", () => {
+    const severity: IncidentSeverity = new IncidentSeverity();
+    severity._id = "severity-id";
+    severity.name = "Critical";
+
+    const monitorOne: Monitor = new Monitor();
+    monitorOne._id = "monitor-one-id";
+    monitorOne.name = "Monitor One";
+
+    const monitorTwo: Monitor = new Monitor();
+    monitorTwo._id = "monitor-two-id";
+    monitorTwo.name = "Monitor Two";
+
+    const incident: Incident = new Incident();
+    incident._id = "incident-id";
+    incident.title = "Database is down";
+    incident.projectId = new ObjectID("project-one");
+    incident.incidentSeverity = severity;
+    incident.monitors = [monitorOne, monitorTwo];
+
+    const json: JSONObject = BaseModel.toJSONObject(incident, Incident);
+
+    expect(json["_id"]).toBe("incident-id");
+    expect(json["title"]).toBe("Database is down");
+    expect(json["projectId"]).toBe(incident.projectId);
+
+    // Nested Entity column is recursively serialized to a plain object.
+    const severityJson: JSONObject = json["incidentSeverity"] as JSONObject;
+    expect(severityJson).not.toBeInstanceOf(BaseModel);
+    expect(severityJson["_id"]).toBe("severity-id");
+    expect(severityJson["name"]).toBe("Critical");
+
+    // Nested EntityArray column is serialized item by item, order preserved.
+    const monitorsJson: JSONArray = json["monitors"] as JSONArray;
+    expect(Array.isArray(monitorsJson)).toBe(true);
+    expect(
+      monitorsJson.map((monitor: JSONObject | unknown) => {
+        expect(monitor).not.toBeInstanceOf(BaseModel);
+        return (monitor as JSONObject)["name"];
+      }),
+    ).toEqual(["Monitor One", "Monitor Two"]);
+
+    // Unset columns are skipped entirely.
+    expect("description" in json).toBe(false);
+  });
+
+  it("keeps each row's JSON isolated across repeated calls for the same class", () => {
+    const tenantOneProjectId: ObjectID = ObjectID.generate();
+    const tenantTwoProjectId: ObjectID = ObjectID.generate();
+
+    const tenantOneLabel: Label = new Label();
+    tenantOneLabel._id = "label-tenant-one";
+    tenantOneLabel.name = "Tenant One Label";
+    tenantOneLabel.projectId = tenantOneProjectId;
+
+    const tenantTwoLabel: Label = new Label();
+    tenantTwoLabel._id = "label-tenant-two";
+    tenantTwoLabel.name = "Tenant Two Label";
+    tenantTwoLabel.projectId = tenantTwoProjectId;
+
+    const jsonOne: JSONObject = BaseModel.toJSONObject(tenantOneLabel, Label);
+    const jsonTwo: JSONObject = BaseModel.toJSONObject(tenantTwoLabel, Label);
+
+    // Second serialization must not disturb the first result.
+    expect(jsonOne["_id"]).toBe("label-tenant-one");
+    expect(jsonOne["name"]).toBe("Tenant One Label");
+    expect(jsonOne["projectId"]).toBe(tenantOneProjectId);
+
+    expect(jsonTwo["_id"]).toBe("label-tenant-two");
+    expect(jsonTwo["name"]).toBe("Tenant Two Label");
+    expect(jsonTwo["projectId"]).toBe(tenantTwoProjectId);
+  });
+
+  it("does not leak a key set on an earlier row into a later row without it", () => {
+    const labelWithColor: Label = new Label();
+    labelWithColor.name = "Colored";
+    labelWithColor.color = new Color("#112233");
+
+    const labelWithoutColor: Label = new Label();
+    labelWithoutColor.name = "Plain";
+
+    const jsonWithColor: JSONObject = BaseModel.toJSONObject(
+      labelWithColor,
+      Label,
+    );
+    const jsonWithoutColor: JSONObject = BaseModel.toJSONObject(
+      labelWithoutColor,
+      Label,
+    );
+
+    expect(jsonWithColor["color"]).toBe(labelWithColor.color);
+    expect("color" in jsonWithoutColor).toBe(false);
+  });
+
+  it("serializes by the declared modelType, not the instance's runtime class", () => {
+    const label: Label = new Label();
+    label._id = "declared-type-label";
+    label.name = "Declared Type";
+    label.color = new Color("#445566");
+    label.projectId = ObjectID.generate();
+
+    /*
+     * Warm the subclass cache first so a cache wrongly keyed on
+     * model.constructor would surface Label columns below.
+     */
+    BaseModel.toJSONObject(label, Label);
+
+    const baseJson: JSONObject = BaseModel.toJSONObject(label, BaseModel);
+
+    const baseColumns: Array<string> = new BaseModel().getTableColumns()
+      .columns;
+    for (const key of Object.keys(baseJson)) {
+      expect(baseColumns).toContain(key);
+    }
+
+    expect(baseJson["_id"]).toBe("declared-type-label");
+    expect("color" in baseJson).toBe(false);
+    expect("projectId" in baseJson).toBe(false);
+  });
+
+  it("toJSONObject on a fresh base model returns an empty object", () => {
+    const json: JSONObject = BaseModel.toJSONObject(new BaseModel(), BaseModel);
+    expect(json).toEqual({});
+  });
+
+  it("fromJSON returns a fresh mutable instance on every call", () => {
+    const json: JSONObject = {
+      name: "oneuptime",
+      description: "a label",
+    };
+
+    const first: Label = BaseModel.fromJSON(json, Label) as Label;
+    const second: Label = BaseModel.fromJSON(json, Label) as Label;
+
+    expect(first).toBeInstanceOf(Label);
+    expect(second).toBeInstanceOf(Label);
+    expect(first).not.toBe(second);
+
+    first.name = "mutated";
+    expect(second.name).toBe("oneuptime");
+    expect(second.description).toBe("a label");
+  });
+
+  it("toJSONObjectArray serializes every item correctly on the cache-hit path", () => {
+    const labels: Array<Label> = [1, 2, 3, 4].map((index: number) => {
+      const label: Label = new Label();
+      label._id = `label-${index}`;
+      label.name = `Label ${index}`;
+      return label;
+    });
+
+    const jsonArray: JSONArray = BaseModel.toJSONObjectArray(labels, Label);
+
+    expect(jsonArray).toHaveLength(4);
+    jsonArray.forEach((item: JSONObject | unknown, index: number) => {
+      expect((item as JSONObject)["_id"]).toBe(`label-${index + 1}`);
+      expect((item as JSONObject)["name"]).toBe(`Label ${index + 1}`);
+    });
+  });
+});

--- a/Common/Tests/Server/API/BaseAPIApiKeyAuth.test.ts
+++ b/Common/Tests/Server/API/BaseAPIApiKeyAuth.test.ts
@@ -12,7 +12,6 @@ import {
 } from "../../../Server/Utils/Express";
 import Response from "../../../Server/Utils/Response";
 import { mockRouter } from "./Helpers";
-import ApiKeyPermission from "../../../Models/DatabaseModels/ApiKeyPermission";
 import LogPipeline from "../../../Models/DatabaseModels/LogPipeline";
 import Monitor from "../../../Models/DatabaseModels/Monitor";
 import BadDataException from "../../../Types/Exception/BadDataException";
@@ -24,6 +23,19 @@ import Permission from "../../../Types/Permission";
 import UserType from "../../../Types/UserType";
 import { getJestSpyOn } from "../../Spy";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+/*
+ * PasswordHash has a known, pre-existing TS5.9 compile failure under ts-jest
+ * (Buffer vs BinaryLike) that breaks every suite whose import graph reaches
+ * it. Nothing here touches password hashing; stub the module before the
+ * service import graph drags it into compilation.
+ */
+jest.mock("../../../Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: class PasswordHashStub {},
+  };
+});
 
 jest.mock("../../../Server/Utils/Express", () => {
   return {
@@ -225,12 +237,13 @@ describe("BaseAPI CRUD auth contract for the ApiKey header (issue #3004)", () =>
   ): void => {
     findApiKey.mockResolvedValue({ id: API_KEY_ID, projectId: PROJECT_ID });
 
-    const apiKeyPermission: ApiKeyPermission = new ApiKeyPermission();
-    apiKeyPermission.permission = permission;
-    apiKeyPermission.labels = [];
-    apiKeyPermission.isBlockPermission = false;
-
-    findApiKeyPermissions.mockResolvedValue([apiKeyPermission]);
+    findApiKeyPermissions.mockResolvedValue([
+      {
+        permission: permission,
+        labelIds: [],
+        isBlockPermission: false,
+      },
+    ]);
   };
 
   beforeEach(() => {
@@ -250,7 +263,7 @@ describe("BaseAPI CRUD auth contract for the ApiKey header (issue #3004)", () =>
     );
     findApiKeyPermissions = getJestSpyOn(
       ApiKeyPermissionService,
-      "findBy",
+      "findPermissionsByApiKeyId",
     ).mockResolvedValue([]);
     getJestSpyOn(GlobalConfigService, "findOneBy").mockResolvedValue(null);
 

--- a/Common/Tests/Server/API/StatusPageOverviewCache.test.ts
+++ b/Common/Tests/Server/API/StatusPageOverviewCache.test.ts
@@ -1,0 +1,474 @@
+import StatusPage from "../../../Models/DatabaseModels/StatusPage";
+import StatusPageAPI from "../../../Server/API/StatusPageAPI";
+import MonitorGroupService from "../../../Server/Services/MonitorGroupService";
+import MonitorStatusService from "../../../Server/Services/MonitorStatusService";
+import StatusPageGroupService from "../../../Server/Services/StatusPageGroupService";
+import StatusPageHistoryChartBarColorRuleService from "../../../Server/Services/StatusPageHistoryChartBarColorRuleService";
+import StatusPageResourceService from "../../../Server/Services/StatusPageResourceService";
+import StatusPageService from "../../../Server/Services/StatusPageService";
+import {
+  ExpressRequest,
+  ExpressResponse,
+  NextFunction,
+} from "../../../Server/Utils/Express";
+import Response from "../../../Server/Utils/Response";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import NotAuthenticatedException from "../../../Types/Exception/NotAuthenticatedException";
+import { JSONObject } from "../../../Types/JSON";
+import ObjectID from "../../../Types/ObjectID";
+import { mockRouter } from "./Helpers";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+/*
+ * PasswordHash has a known, pre-existing TS5.9 compile failure under ts-jest
+ * (Buffer vs BinaryLike) that breaks every suite whose import graph reaches
+ * it. Nothing here touches password hashing; stub the module before the
+ * service import graph drags it into compilation.
+ */
+jest.mock("../../../Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: class PasswordHashStub {},
+  };
+});
+
+jest.mock("../../../Server/Utils/Express", () => {
+  return {
+    getRouter: () => {
+      return mockRouter;
+    },
+  };
+});
+
+jest.mock("../../../Server/Utils/Response", () => {
+  return {
+    sendEntityArrayResponse: jest.fn(),
+    sendJsonObjectResponse: jest.fn(),
+    sendEmptySuccessResponse: jest.fn(),
+    sendEntityResponse: jest.fn(),
+    sendErrorResponse: jest.fn(),
+    setNoCacheHeaders: jest.fn(),
+  };
+});
+
+/*
+ * StatusPageAPI overview response cache.
+ *
+ * The shared overview handler (POST + GET
+ * /status-page/overview/:statusPageIdOrDomain) memoizes the post-auth payload
+ * per resolved statusPageId for OVERVIEW_CACHE_TTL_MS, with in-flight promise
+ * dedup, because the build is a pure function of the statusPageId — auth is a
+ * binary gate re-checked on EVERY request, before any cache read.
+ *
+ * These tests pin the safety properties of that cache: auth-before-cache
+ * ordering, per-page key isolation, TTL expiry, never caching failed builds,
+ * cold-miss stampede collapse, one cache across both HTTP methods, and
+ * no-store headers on hit and miss alike.
+ *
+ * All service reads are spied on — no database is touched.
+ */
+
+const OVERVIEW_ROUTE: string = "/status-page/overview/:statusPageIdOrDomain";
+
+type OverviewSpies = {
+  /*
+   * The StatusPage row fetch that opens getStatusPageResourcesAndTimelines —
+   * the first query of every rebuild, so its call count is the "did a rebuild
+   * happen" probe.
+   */
+  buildFindOneBySpy: jest.SpyInstance;
+
+  // The per-request auth gate query inside StatusPageService.hasReadAccess.
+  authFindOneByIdSpy: jest.SpyInstance;
+};
+
+/*
+ * Builds the EMPTY status page row served to the build path: no resources,
+ * no groups, and every show* flag unset, so all downstream query blocks
+ * short-circuit and the only interesting behavior left is the caching.
+ */
+function buildPageFor(findOneByArgs: unknown): StatusPage {
+  const query: JSONObject = (findOneByArgs as { query: JSONObject }).query;
+  const page: StatusPage = new StatusPage();
+  page._id = String(query["_id"]);
+  page.projectId = ObjectID.generate();
+  return page;
+}
+
+function mockOverviewServices(): OverviewSpies {
+  // Per-request auth gate: a PUBLIC page grants access to anonymous viewers.
+  const authFindOneByIdSpy: jest.SpyInstance = (
+    jest.spyOn(StatusPageService, "findOneById") as unknown as jest.SpyInstance
+  ).mockImplementation(() => {
+    const page: StatusPage = new StatusPage();
+    page.isPublicStatusPage = true;
+    return Promise.resolve(page);
+  });
+
+  const buildFindOneBySpy: jest.SpyInstance = (
+    jest.spyOn(StatusPageService, "findOneBy") as unknown as jest.SpyInstance
+  ).mockImplementation((args: unknown) => {
+    return Promise.resolve(buildPageFor(args));
+  });
+
+  (
+    jest.spyOn(MonitorStatusService, "findBy") as unknown as jest.SpyInstance
+  ).mockResolvedValue([] as never);
+
+  (
+    jest.spyOn(StatusPageGroupService, "findBy") as unknown as jest.SpyInstance
+  ).mockResolvedValue([] as never);
+
+  (
+    jest.spyOn(
+      StatusPageResourceService,
+      "findBy",
+    ) as unknown as jest.SpyInstance
+  ).mockResolvedValue([] as never);
+
+  (
+    jest.spyOn(
+      MonitorGroupService,
+      "getMonitorGroupResourcesByGroupIds",
+    ) as unknown as jest.SpyInstance
+  ).mockResolvedValue({} as never);
+
+  (
+    jest.spyOn(
+      MonitorGroupService,
+      "getCurrentStatusesForMonitorGroups",
+    ) as unknown as jest.SpyInstance
+  ).mockResolvedValue({} as never);
+
+  (
+    jest.spyOn(
+      StatusPageService,
+      "getMonitorStatusTimelineForStatusPage",
+    ) as unknown as jest.SpyInstance
+  ).mockResolvedValue([] as never);
+
+  (
+    jest.spyOn(
+      StatusPageHistoryChartBarColorRuleService,
+      "findBy",
+    ) as unknown as jest.SpyInstance
+  ).mockResolvedValue([] as never);
+
+  return { buildFindOneBySpy, authFindOneByIdSpy };
+}
+
+function makeOverviewRequest(statusPageIdOrDomain: string): ExpressRequest {
+  return {
+    params: {
+      statusPageIdOrDomain: statusPageIdOrDomain,
+    },
+    body: {},
+    query: {},
+    cookies: {},
+    headers: {},
+    socket: {},
+    ips: [],
+  } as unknown as ExpressRequest;
+}
+
+function makeOverviewResponse(): ExpressResponse {
+  return {
+    send: jest.fn(),
+    json: jest.fn(),
+    setHeader: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+  } as unknown as ExpressResponse;
+}
+
+/*
+ * The handler fills the cache on a detached .then/.catch/.finally chain;
+ * drain it so the next request observes the settled cache state. A macrotask
+ * (setTimeout 0) is used because the jsdom test environment has no
+ * setImmediate; it drains all pending microtasks first either way.
+ */
+async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>((resolve: () => void) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+type InvocationResult = {
+  req: ExpressRequest;
+  res: ExpressResponse;
+  next: NextFunction;
+};
+
+async function invokeOverview(data: {
+  statusPageIdOrDomain: string;
+  method?: "post" | "get";
+}): Promise<InvocationResult> {
+  const req: ExpressRequest = makeOverviewRequest(data.statusPageIdOrDomain);
+  const res: ExpressResponse = makeOverviewResponse();
+  const next: NextFunction = jest.fn() as unknown as NextFunction;
+
+  await mockRouter
+    .match(data.method || "post", OVERVIEW_ROUTE)
+    .handlerFunction(req, res, next);
+  await flushMicrotasks();
+
+  return { req, res, next };
+}
+
+function sentPayloads(): Array<JSONObject> {
+  return (
+    Response.sendJsonObjectResponse as unknown as jest.Mock
+  ).mock.calls.map((call: Array<unknown>) => {
+    return call[2] as JSONObject;
+  });
+}
+
+describe("StatusPageAPI overview response cache", () => {
+  beforeAll(() => {
+    mockRouter.routes.length = 0;
+    new StatusPageAPI();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    StatusPageAPI.clearOverviewResponseCache();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("serves a repeat request within the TTL from cache: no rebuild, per-request auth, identical payload object", async () => {
+    const spies: OverviewSpies = mockOverviewServices();
+    const statusPageId: string = ObjectID.generate().toString();
+
+    const first: InvocationResult = await invokeOverview({
+      statusPageIdOrDomain: statusPageId,
+    });
+    const second: InvocationResult = await invokeOverview({
+      statusPageIdOrDomain: statusPageId,
+    });
+
+    expect(first.next).not.toHaveBeenCalled();
+    expect(second.next).not.toHaveBeenCalled();
+
+    // The build ran exactly once; the auth gate ran on BOTH requests.
+    expect(spies.buildFindOneBySpy).toHaveBeenCalledTimes(1);
+    expect(spies.authFindOneByIdSpy).toHaveBeenCalledTimes(2);
+
+    const payloads: Array<JSONObject> = sentPayloads();
+    expect(payloads).toHaveLength(2);
+    // The very same object, not a rebuilt lookalike.
+    expect(payloads[1]).toBe(payloads[0]);
+
+    // projectId is stripped INSIDE the build, so the cached object is final.
+    const statusPageJson: JSONObject = payloads[0]!["statusPage"] as JSONObject;
+    expect(statusPageJson["_id"]).toBe(statusPageId);
+    expect("projectId" in statusPageJson).toBe(false);
+  });
+
+  it("still enforces authorization on a warm cache: a page gone private is rejected before any cache read", async () => {
+    const spies: OverviewSpies = mockOverviewServices();
+    const statusPageId: string = ObjectID.generate().toString();
+
+    await invokeOverview({ statusPageIdOrDomain: statusPageId });
+    expect(Response.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+
+    // The page goes private; the anonymous viewer carries no cookie.
+    spies.authFindOneByIdSpy.mockImplementation(() => {
+      const page: StatusPage = new StatusPage();
+      page.isPublicStatusPage = false;
+      return Promise.resolve(page);
+    });
+
+    const denied: InvocationResult = await invokeOverview({
+      statusPageIdOrDomain: statusPageId,
+    });
+
+    expect(denied.next).toHaveBeenCalledTimes(1);
+    const error: unknown = (denied.next as jest.Mock).mock.calls[0]?.[0];
+    expect(error).toBeInstanceOf(NotAuthenticatedException);
+
+    // The warm cache entry must NOT have been served to the rejected viewer.
+    expect(Response.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates cache entries per statusPageId", async () => {
+    const spies: OverviewSpies = mockOverviewServices();
+    const statusPageIdA: string = ObjectID.generate().toString();
+    const statusPageIdB: string = ObjectID.generate().toString();
+
+    await invokeOverview({ statusPageIdOrDomain: statusPageIdA });
+    await invokeOverview({ statusPageIdOrDomain: statusPageIdB });
+
+    // Two different pages, two independent builds.
+    expect(spies.buildFindOneBySpy).toHaveBeenCalledTimes(2);
+
+    const payloads: Array<JSONObject> = sentPayloads();
+    expect(payloads).toHaveLength(2);
+    expect(payloads[1]).not.toBe(payloads[0]);
+    expect((payloads[0]!["statusPage"] as JSONObject)["_id"]).toBe(
+      statusPageIdA,
+    );
+    expect((payloads[1]!["statusPage"] as JSONObject)["_id"]).toBe(
+      statusPageIdB,
+    );
+
+    // Each entry is now warm on its own key.
+    await invokeOverview({ statusPageIdOrDomain: statusPageIdA });
+    expect(spies.buildFindOneBySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("rebuilds after the 15s TTL expires", async () => {
+    const spies: OverviewSpies = mockOverviewServices();
+    const statusPageId: string = ObjectID.generate().toString();
+
+    const startedAt: number = Date.now();
+    const nowSpy: jest.SpyInstance = (
+      jest.spyOn(Date, "now") as unknown as jest.SpyInstance
+    ).mockReturnValue(startedAt);
+
+    await invokeOverview({ statusPageIdOrDomain: statusPageId });
+    expect(spies.buildFindOneBySpy).toHaveBeenCalledTimes(1);
+
+    // One ms past the TTL — InMemoryTTLCache expires on read.
+    nowSpy.mockReturnValue(startedAt + 15_000 + 1);
+
+    await invokeOverview({ statusPageIdOrDomain: statusPageId });
+    expect(spies.buildFindOneBySpy).toHaveBeenCalledTimes(2);
+
+    const payloads: Array<JSONObject> = sentPayloads();
+    expect(payloads).toHaveLength(2);
+    // A fresh snapshot, not the expired object.
+    expect(payloads[1]).not.toBe(payloads[0]);
+  });
+
+  it("never caches a failed build: the next request rebuilds and succeeds", async () => {
+    const spies: OverviewSpies = mockOverviewServices();
+    const statusPageId: string = ObjectID.generate().toString();
+
+    // First build throws (status page row gone mid-flight).
+    spies.buildFindOneBySpy.mockResolvedValueOnce(null as never);
+
+    const failed: InvocationResult = await invokeOverview({
+      statusPageIdOrDomain: statusPageId,
+    });
+
+    expect(failed.next).toHaveBeenCalledTimes(1);
+    expect((failed.next as jest.Mock).mock.calls[0]?.[0]).toBeInstanceOf(
+      BadDataException,
+    );
+    expect(Response.sendJsonObjectResponse).not.toHaveBeenCalled();
+
+    // The error was not cached: a fresh build runs and succeeds.
+    const recovered: InvocationResult = await invokeOverview({
+      statusPageIdOrDomain: statusPageId,
+    });
+
+    expect(recovered.next).not.toHaveBeenCalled();
+    expect(spies.buildFindOneBySpy).toHaveBeenCalledTimes(2);
+    expect(Response.sendJsonObjectResponse).toHaveBeenCalledTimes(1);
+  });
+
+  it("collapses concurrent cold-cache requests into one in-flight build", async () => {
+    const spies: OverviewSpies = mockOverviewServices();
+    const statusPageId: string = ObjectID.generate().toString();
+
+    let releaseBuild: () => void = () => {
+      return;
+    };
+    const gate: Promise<void> = new Promise<void>((resolve: () => void) => {
+      releaseBuild = resolve;
+    });
+
+    spies.buildFindOneBySpy.mockImplementation(async (args: unknown) => {
+      await gate;
+      return buildPageFor(args);
+    });
+
+    const reqA: ExpressRequest = makeOverviewRequest(statusPageId);
+    const resA: ExpressResponse = makeOverviewResponse();
+    const nextA: NextFunction = jest.fn() as unknown as NextFunction;
+    const reqB: ExpressRequest = makeOverviewRequest(statusPageId);
+    const resB: ExpressResponse = makeOverviewResponse();
+    const nextB: NextFunction = jest.fn() as unknown as NextFunction;
+
+    const handlerPromiseA: void | Promise<void> = mockRouter
+      .match("post", OVERVIEW_ROUTE)
+      .handlerFunction(reqA, resA, nextA);
+    const handlerPromiseB: void | Promise<void> = mockRouter
+      .match("post", OVERVIEW_ROUTE)
+      .handlerFunction(reqB, resB, nextB);
+
+    // Both requests are parked on the same gated build...
+    await flushMicrotasks();
+    expect(spies.buildFindOneBySpy).toHaveBeenCalledTimes(1);
+    // ...after each passed its own auth check.
+    expect(spies.authFindOneByIdSpy).toHaveBeenCalledTimes(2);
+
+    releaseBuild();
+    await handlerPromiseA;
+    await handlerPromiseB;
+    await flushMicrotasks();
+
+    expect(nextA).not.toHaveBeenCalled();
+    expect(nextB).not.toHaveBeenCalled();
+
+    // Exactly one build ran; both requests received the same payload object.
+    expect(spies.buildFindOneBySpy).toHaveBeenCalledTimes(1);
+    const payloads: Array<JSONObject> = sentPayloads();
+    expect(payloads).toHaveLength(2);
+    expect(payloads[1]).toBe(payloads[0]);
+  });
+
+  it("shares one cache between the POST and GET routes", async () => {
+    const spies: OverviewSpies = mockOverviewServices();
+    const statusPageId: string = ObjectID.generate().toString();
+
+    await invokeOverview({
+      statusPageIdOrDomain: statusPageId,
+      method: "post",
+    });
+    expect(spies.buildFindOneBySpy).toHaveBeenCalledTimes(1);
+
+    const viaGet: InvocationResult = await invokeOverview({
+      statusPageIdOrDomain: statusPageId,
+      method: "get",
+    });
+
+    expect(viaGet.next).not.toHaveBeenCalled();
+    // The GET route served the POST-warmed entry without rebuilding.
+    expect(spies.buildFindOneBySpy).toHaveBeenCalledTimes(1);
+
+    const payloads: Array<JSONObject> = sentPayloads();
+    expect(payloads).toHaveLength(2);
+    expect(payloads[1]).toBe(payloads[0]);
+  });
+
+  it("sets no-store headers on the miss AND the hit path", async () => {
+    const spies: OverviewSpies = mockOverviewServices();
+    const statusPageId: string = ObjectID.generate().toString();
+
+    const miss: InvocationResult = await invokeOverview({
+      statusPageIdOrDomain: statusPageId,
+    });
+    expect(Response.setNoCacheHeaders).toHaveBeenCalledTimes(1);
+    expect(Response.setNoCacheHeaders).toHaveBeenLastCalledWith(miss.res);
+
+    const hit: InvocationResult = await invokeOverview({
+      statusPageIdOrDomain: statusPageId,
+    });
+    // Confirm this second request really was a cache hit...
+    expect(spies.buildFindOneBySpy).toHaveBeenCalledTimes(1);
+    // ...and it still told HTTP caches not to store the response.
+    expect(Response.setNoCacheHeaders).toHaveBeenCalledTimes(2);
+    expect(Response.setNoCacheHeaders).toHaveBeenLastCalledWith(hit.res);
+  });
+});

--- a/Common/Tests/Server/Infrastructure/InMemoryTTLCache.test.ts
+++ b/Common/Tests/Server/Infrastructure/InMemoryTTLCache.test.ts
@@ -1,0 +1,158 @@
+import InMemoryTTLCache from "../../../Server/Infrastructure/InMemoryTTLCache";
+import { afterEach, describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * Contract under test — the bounded TTL cache the telemetry ingest rule
+ * caches (log/trace pipelines, drop filters, scrub rules, metric rules)
+ * sit on. Two properties matter for those callers:
+ *
+ * 1. Expiry physically deletes: a read past the TTL must both miss AND
+ *    shrink the store, or per-project entries accumulate for every tenant
+ *    ever seen by a long-lived ingest process.
+ * 2. Capacity is a hard cap with oldest-write eviction, so the cache can
+ *    never grow past maxEntries no matter how many distinct keys arrive.
+ */
+
+/*
+ * Minimal structural view of a jest spy — the @jest/globals and @types/jest
+ * spy types disagree in this repo, so annotate with just the surface these
+ * tests use.
+ */
+type NowSpyLike = {
+  mockReturnValue: (value: number) => unknown;
+  mockRestore: () => void;
+};
+
+function spyNow(value: number): NowSpyLike {
+  const spy: NowSpyLike = jest.spyOn(Date, "now") as unknown as NowSpyLike;
+  spy.mockReturnValue(value);
+  return spy;
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("InMemoryTTLCache TTL behavior", () => {
+  test("get returns the value within its TTL", () => {
+    const cache: InMemoryTTLCache<string> = new InMemoryTTLCache<string>(3);
+
+    cache.set("a", "value-a", 60_000);
+
+    expect(cache.get("a")).toBe("value-a");
+    expect(cache.has("a")).toBe(true);
+    expect(cache.size()).toBe(1);
+  });
+
+  test("get past the TTL misses AND physically deletes the entry", () => {
+    const t0: number = 1_000_000;
+    const nowSpy: NowSpyLike = spyNow(t0);
+
+    const cache: InMemoryTTLCache<string> = new InMemoryTTLCache<string>(3);
+    cache.set("a", "value-a", 1_000);
+    expect(cache.size()).toBe(1);
+
+    // Boundary: at exactly expiresAt the entry is still valid (strict >).
+    nowSpy.mockReturnValue(t0 + 1_000);
+    expect(cache.get("a")).toBe("value-a");
+    expect(cache.size()).toBe(1);
+
+    nowSpy.mockReturnValue(t0 + 1_001);
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.size()).toBe(0);
+  });
+
+  test("has() reports false for an expired entry and deletes it", () => {
+    const t0: number = 1_000_000;
+    const nowSpy: NowSpyLike = spyNow(t0);
+
+    const cache: InMemoryTTLCache<string> = new InMemoryTTLCache<string>(3);
+    cache.set("a", "value-a", 1_000);
+
+    nowSpy.mockReturnValue(t0 + 5_000);
+    expect(cache.has("a")).toBe(false);
+    expect(cache.size()).toBe(0);
+  });
+});
+
+describe("InMemoryTTLCache capacity eviction", () => {
+  test("insert beyond capacity evicts the oldest key", () => {
+    const cache: InMemoryTTLCache<string> = new InMemoryTTLCache<string>(3);
+
+    cache.set("a", "value-a", 60_000);
+    cache.set("b", "value-b", 60_000);
+    cache.set("c", "value-c", 60_000);
+    cache.set("d", "value-d", 60_000);
+
+    expect(cache.size()).toBe(3);
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")).toBe("value-b");
+    expect(cache.get("c")).toBe("value-c");
+    expect(cache.get("d")).toBe("value-d");
+  });
+
+  test("re-setting an existing key refreshes insertion order so it is not the eviction victim", () => {
+    const cache: InMemoryTTLCache<string> = new InMemoryTTLCache<string>(3);
+
+    cache.set("a", "value-a", 60_000);
+    cache.set("b", "value-b", 60_000);
+    cache.set("c", "value-c", 60_000);
+
+    // Overwrite at capacity: no eviction, "a" moves to newest position.
+    cache.set("a", "value-a2", 60_000);
+    expect(cache.size()).toBe(3);
+    expect(cache.get("b")).toBe("value-b");
+    expect(cache.get("c")).toBe("value-c");
+
+    // Next new key evicts "b" (now the oldest), not the refreshed "a".
+    cache.set("d", "value-d", 60_000);
+    expect(cache.size()).toBe(3);
+    expect(cache.get("a")).toBe("value-a2");
+    expect(cache.get("b")).toBeUndefined();
+    expect(cache.get("c")).toBe("value-c");
+    expect(cache.get("d")).toBe("value-d");
+  });
+});
+
+describe("InMemoryTTLCache basics", () => {
+  test("values are stored by reference", () => {
+    const cache: InMemoryTTLCache<Array<string>> = new InMemoryTTLCache<
+      Array<string>
+    >(3);
+
+    const value: Array<string> = [];
+    cache.set("a", value, 60_000);
+
+    expect(cache.get("a")).toBe(value);
+  });
+
+  test("delete removes an entry", () => {
+    const cache: InMemoryTTLCache<string> = new InMemoryTTLCache<string>(3);
+
+    cache.set("a", "value-a", 60_000);
+    cache.delete("a");
+
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.has("a")).toBe(false);
+    expect(cache.size()).toBe(0);
+  });
+
+  test("clear empties the cache", () => {
+    const cache: InMemoryTTLCache<string> = new InMemoryTTLCache<string>(3);
+
+    cache.set("a", "value-a", 60_000);
+    cache.set("b", "value-b", 60_000);
+    cache.clear();
+
+    expect(cache.size()).toBe(0);
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")).toBeUndefined();
+  });
+
+  test("has returns false for a key that was never set", () => {
+    const cache: InMemoryTTLCache<string> = new InMemoryTTLCache<string>(3);
+
+    expect(cache.has("missing")).toBe(false);
+    expect(cache.get("missing")).toBeUndefined();
+  });
+});

--- a/Common/Tests/Server/Middleware/ProjectAuthorizationApiKeyMiddleware.test.ts
+++ b/Common/Tests/Server/Middleware/ProjectAuthorizationApiKeyMiddleware.test.ts
@@ -1,4 +1,3 @@
-import APIKeyPermission from "../../../Models/DatabaseModels/ApiKeyPermission";
 import GlobalConfig from "../../../Models/DatabaseModels/GlobalConfig";
 import User from "../../../Models/DatabaseModels/User";
 import ProjectMiddleware from "../../../Server/Middleware/ProjectAuthorization";
@@ -38,6 +37,19 @@ import {
 } from "@jest/globals";
 
 /*
+ * PasswordHash has a known, pre-existing TS5.9 compile failure under ts-jest
+ * (Buffer vs BinaryLike) that breaks every suite whose import graph reaches
+ * it. Nothing here touches password hashing; stub the module before the
+ * service import graph drags it into compilation.
+ */
+jest.mock("../../../Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: class PasswordHashStub {},
+  };
+});
+
+/*
  * ProjectAuthorization.isValidProjectIdAndApiKeyMiddleware is the single door
  * every API-key request in the product walks through, and it had no test at all.
  *
@@ -67,9 +79,9 @@ describe("ProjectMiddleware.isValidProjectIdAndApiKeyMiddleware", () => {
     ApiKeyService,
     "findApiKey",
   );
-  const spyApiKeyPermissionFindBy: jest.SpyInstance = getJestSpyOn(
+  const spyFindApiKeyPermissions: jest.SpyInstance = getJestSpyOn(
     ApiKeyPermissionService,
-    "findBy",
+    "findPermissionsByApiKeyId",
   );
   const spyGlobalConfigFindOneBy: jest.SpyInstance = getJestSpyOn(
     GlobalConfigService,
@@ -89,7 +101,7 @@ describe("ProjectMiddleware.isValidProjectIdAndApiKeyMiddleware", () => {
     jest.clearAllMocks();
     next = getJestMockFunction();
     spyFindApiKey.mockResolvedValue(null);
-    spyApiKeyPermissionFindBy.mockResolvedValue([]);
+    spyFindApiKeyPermissions.mockResolvedValue([]);
     spyGlobalConfigFindOneBy.mockResolvedValue(null);
     spyUserFindOneBy.mockResolvedValue(null);
   });
@@ -129,16 +141,17 @@ describe("ProjectMiddleware.isValidProjectIdAndApiKeyMiddleware", () => {
     type MockResolvedApiKeyFunction = () => void;
 
     const mockResolvedApiKey: MockResolvedApiKeyFunction = (): void => {
-      const apiKeyPermission: APIKeyPermission = new APIKeyPermission();
-      apiKeyPermission.permission = Permission.ProjectMember;
-      apiKeyPermission.labels = [];
-      apiKeyPermission.isBlockPermission = false;
-
       spyFindApiKey.mockResolvedValue({
         id: apiKeyId,
         projectId: keyProjectId,
       });
-      spyApiKeyPermissionFindBy.mockResolvedValue([apiKeyPermission]);
+      spyFindApiKeyPermissions.mockResolvedValue([
+        {
+          permission: Permission.ProjectMember,
+          labelIds: [],
+          isBlockPermission: false,
+        },
+      ]);
     };
 
     test("should call next with no argument and stamp API identity, tenant and permissions on the request", async () => {
@@ -211,11 +224,7 @@ describe("ProjectMiddleware.isValidProjectIdAndApiKeyMiddleware", () => {
 
       await runMiddleware(req);
 
-      expect(spyApiKeyPermissionFindBy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          query: { apiKeyId: apiKeyId },
-        }),
-      );
+      expect(spyFindApiKeyPermissions).toHaveBeenCalledWith(apiKeyId);
 
       const permissions: Array<UserPermission> =
         (req as OneUptimeRequest).userTenantAccessPermission?.[

--- a/Common/Tests/Server/Middleware/UserAuthorization.test.ts
+++ b/Common/Tests/Server/Middleware/UserAuthorization.test.ts
@@ -50,6 +50,25 @@ jest.mock("../../../Server/Services/ProjectService");
 jest.mock("../../../Server/Services/TeamMemberService");
 jest.mock("../../../Types/HashedString");
 jest.mock("../../../Types/JSONFunctions");
+/*
+ * PasswordHash carries a pre-existing TS5.9 diagnostic that fails any suite
+ * whose runtime require graph reaches it (DatabaseService, the base class of
+ * every concrete service, imports it). Nothing password-related is under
+ * test here, so the module is replaced WITH A FACTORY — an automock would
+ * still require (and type-check) the real file.
+ */
+jest.mock("../../../Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: {
+      hash: jest.fn(),
+      verify: jest.fn(),
+      generateSalt: jest.fn(),
+      needsUpgrade: jest.fn(),
+      applyPepper: jest.fn(),
+    },
+  };
+});
 
 type StringOrUndefined = string | undefined;
 
@@ -404,6 +423,66 @@ describe("UserMiddleware", () => {
       expect(res.set).not.toHaveBeenCalledWith(
         "global-permissions-hash",
         expect.anything(),
+      );
+      expect(next).toHaveBeenCalled();
+      expect(spyGetUserGlobalAccessPermission).toHaveBeenCalledWith(userId);
+    });
+
+    test("should not set global-permissions and global-permissions-hash in the response header, when the global-permissions-hash set in the request header equals the globalPermissionsHash computed from userGlobalAccessPermission", async () => {
+      const mockedRequest: Partial<ExpressRequest> = {
+        headers: { "global-permissions-hash": hashValue },
+      };
+
+      getJestSpyOn(ProjectMiddleware, "getProjectId").mockReturnValueOnce(null);
+      getJestSpyOn(JSONFunctions, "serialize").mockReturnValueOnce({});
+      const spyGetUserGlobalAccessPermission: jest.SpyInstance = getJestSpyOn(
+        AccessTokenService,
+        "getUserGlobalAccessPermission",
+      ).mockResolvedValueOnce(mockedGlobalAccessPermission);
+
+      await UserMiddleware.getUserMiddleware(
+        mockedRequest as ExpressRequest,
+        res,
+        next,
+      );
+
+      expect(res.set).not.toHaveBeenCalledWith(
+        "global-permissions",
+        expect.anything(),
+      );
+      expect(res.set).not.toHaveBeenCalledWith(
+        "global-permissions-hash",
+        expect.anything(),
+      );
+      expect(next).toHaveBeenCalled();
+      expect(spyGetUserGlobalAccessPermission).toHaveBeenCalledWith(userId);
+    });
+
+    test("should set global-permissions and global-permissions-hash in the response header, when the global-permissions-hash set in the request header does not equal the globalPermissionsHash computed from userGlobalAccessPermission", async () => {
+      const mockedRequest: Partial<ExpressRequest> = {
+        headers: { "global-permissions-hash": "different-hash" },
+      };
+
+      getJestSpyOn(ProjectMiddleware, "getProjectId").mockReturnValueOnce(null);
+      getJestSpyOn(JSONFunctions, "serialize").mockReturnValueOnce({});
+      const spyGetUserGlobalAccessPermission: jest.SpyInstance = getJestSpyOn(
+        AccessTokenService,
+        "getUserGlobalAccessPermission",
+      ).mockResolvedValueOnce(mockedGlobalAccessPermission);
+
+      await UserMiddleware.getUserMiddleware(
+        mockedRequest as ExpressRequest,
+        res,
+        next,
+      );
+
+      expect(res.set).toHaveBeenCalledWith(
+        "global-permissions",
+        JSON.stringify({}),
+      );
+      expect(res.set).toHaveBeenCalledWith(
+        "global-permissions-hash",
+        hashValue,
       );
       expect(next).toHaveBeenCalled();
       expect(spyGetUserGlobalAccessPermission).toHaveBeenCalledWith(userId);

--- a/Common/Tests/Server/Services/ApiKeyPermissionService.test.ts
+++ b/Common/Tests/Server/Services/ApiKeyPermissionService.test.ts
@@ -1,0 +1,347 @@
+/**
+ * ApiKeyPermissionService.findPermissionsByApiKeyId cache tests.
+ *
+ * Every API-key-authenticated request builds its tenant permissions from this
+ * lookup, so it now consults a per-process 60s TTL cache before running the
+ * findBy (with its labels join). The contract pinned here is load-bearing in
+ * three ways:
+ * - the underlying query is unchanged: keyed by exactly the given apiKeyId,
+ *   as root, selecting permission / labels._id / isBlockPermission — and the
+ *   row -> DTO mapping preserves the old edge cases (undefined labels -> [],
+ *   isBlockPermission passed through unchanged, never defaulted)
+ * - hits and misses both return freshly built objects, so a caller mutating
+ *   its result cannot poison the permissions of every later request
+ * - the service's own lifecycle hooks (create/update/delete) clear the cache,
+ *   so a permission edit takes effect immediately in the process that made it;
+ *   the TTL only bounds staleness for OTHER processes.
+ *
+ * ApiKeyPermissionService.findBy is spied on, so no database is touched.
+ */
+
+import ApiKeyPermissionService, {
+  ApiKeyPermissionRow,
+} from "../../../Server/Services/ApiKeyPermissionService";
+import ApiKeyPermission from "../../../Models/DatabaseModels/ApiKeyPermission";
+import Label from "../../../Models/DatabaseModels/Label";
+import ObjectID from "../../../Types/ObjectID";
+import Permission from "../../../Types/Permission";
+import { getJestSpyOn } from "../../Spy";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+
+/*
+ * PasswordHash has a known, pre-existing TS5.9 compile failure under ts-jest
+ * (Buffer vs BinaryLike) that breaks every suite whose import graph reaches
+ * it. Nothing here touches password hashing; stub the module before the
+ * service import graph drags it into compilation.
+ */
+jest.mock("../../../Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: class PasswordHashStub {},
+  };
+});
+
+const TTL_MS: number = 60 * 1000;
+
+/*
+ * The hooks are protected on purpose — DatabaseService calls them, feature
+ * code does not. Reaching them through a cast is how their cache-clearing
+ * behaviour can be pinned without standing up Postgres.
+ */
+type HookCallable = {
+  onBeforeCreate: (createBy: unknown) => Promise<unknown>;
+  onBeforeUpdate: (updateBy: unknown) => Promise<unknown>;
+  onBeforeDelete: (deleteBy: unknown) => Promise<unknown>;
+};
+
+function asHooks(service: unknown): HookCallable {
+  return service as unknown as HookCallable;
+}
+
+function makeModelRow(data: {
+  permission: Permission;
+  labelIds?: Array<ObjectID>;
+  isBlockPermission?: boolean;
+}): ApiKeyPermission {
+  const row: ApiKeyPermission = new ApiKeyPermission();
+  row.permission = data.permission;
+  if (data.labelIds) {
+    row.labels = data.labelIds.map((id: ObjectID) => {
+      const label: Label = new Label();
+      label.id = id;
+      return label;
+    });
+  }
+  if (data.isBlockPermission !== undefined) {
+    row.isBlockPermission = data.isBlockPermission;
+  }
+  return row;
+}
+
+function spyOnFindBy(): jest.SpyInstance {
+  return getJestSpyOn(ApiKeyPermissionService, "findBy");
+}
+
+describe("ApiKeyPermissionService.findPermissionsByApiKeyId", () => {
+  const apiKeyId: ObjectID = ObjectID.generate();
+
+  beforeEach(() => {
+    /*
+     * The cache lives on the singleton service, so entries written by one
+     * test would leak into the next without an explicit clear.
+     */
+    ApiKeyPermissionService.clearCache();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("runs the exact legacy query and maps rows onto DTOs", async () => {
+    const labelId: ObjectID = ObjectID.generate();
+    const findBy: jest.SpyInstance = spyOnFindBy().mockResolvedValue([
+      makeModelRow({
+        permission: Permission.CreateProjectIncident,
+        labelIds: [labelId],
+        isBlockPermission: true,
+      }),
+      makeModelRow({
+        // labels intentionally left undefined; isBlockPermission too.
+        permission: Permission.ReadProjectMonitor,
+      }),
+    ] as never);
+
+    const rows: Array<ApiKeyPermissionRow> =
+      await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+
+    expect(findBy).toHaveBeenCalledTimes(1);
+    const arg: Record<string, any> = findBy.mock.calls[0]![0] as Record<
+      string,
+      any
+    >;
+    expect(arg["query"]["apiKeyId"].toString()).toBe(apiKeyId.toString());
+    expect(arg["props"]["isRoot"]).toBe(true);
+    expect(arg["select"]).toEqual({
+      permission: true,
+      labels: {
+        _id: true,
+      },
+      isBlockPermission: true,
+    });
+
+    expect(rows).toHaveLength(2);
+    // Label scope survives the string round-trip through the cache.
+    expect(rows[0]!.permission).toBe(Permission.CreateProjectIncident);
+    expect(
+      rows[0]!.labelIds.map((id: ObjectID) => {
+        return id.toString();
+      }),
+    ).toEqual([labelId.toString()]);
+    // A block row stays a block row.
+    expect(rows[0]!.isBlockPermission).toBe(true);
+    // Undefined labels become [] rather than crashing or staying undefined.
+    expect(rows[1]!.labelIds).toEqual([]);
+    // isBlockPermission is passed through unchanged, never defaulted.
+    expect(rows[1]!.isBlockPermission).toBeUndefined();
+  });
+
+  test("serves the second call for the same key from cache", async () => {
+    const findBy: jest.SpyInstance = spyOnFindBy().mockResolvedValue([
+      makeModelRow({
+        permission: Permission.ProjectMember,
+        isBlockPermission: false,
+      }),
+    ] as never);
+
+    const first: Array<ApiKeyPermissionRow> =
+      await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+    const second: Array<ApiKeyPermissionRow> =
+      await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+
+    expect(findBy).toHaveBeenCalledTimes(1);
+    expect(second).toHaveLength(1);
+    expect(second[0]!.permission).toBe(Permission.ProjectMember);
+    expect(second[0]!.isBlockPermission).toBe(false);
+    expect(first).toEqual(second);
+  });
+
+  test("hits return fresh objects, so mutation cannot poison the cache", async () => {
+    const labelId: ObjectID = ObjectID.generate();
+    spyOnFindBy().mockResolvedValue([
+      makeModelRow({
+        permission: Permission.CreateProjectIncident,
+        labelIds: [labelId],
+        isBlockPermission: false,
+      }),
+    ] as never);
+
+    const first: Array<ApiKeyPermissionRow> =
+      await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+
+    // Mutate everything a caller could reach on the first result.
+    first[0]!.labelIds.pop();
+    first.pop();
+
+    const second: Array<ApiKeyPermissionRow> =
+      await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+
+    expect(second).toHaveLength(1);
+    expect(
+      second[0]!.labelIds.map((id: ObjectID) => {
+        return id.toString();
+      }),
+    ).toEqual([labelId.toString()]);
+    // Distinct object graphs on every call, hit or miss.
+    expect(second).not.toBe(first);
+    expect(second[0]).not.toBe(first[0]);
+  });
+
+  test("caches distinct api keys independently", async () => {
+    const otherApiKeyId: ObjectID = ObjectID.generate();
+    const findBy: jest.SpyInstance = spyOnFindBy().mockImplementation(((
+      options: Record<string, any>,
+    ): Promise<Array<ApiKeyPermission>> => {
+      const queriedId: string = options["query"]["apiKeyId"].toString();
+      return Promise.resolve([
+        makeModelRow({
+          permission:
+            queriedId === apiKeyId.toString()
+              ? Permission.ProjectMember
+              : Permission.ReadProjectMonitor,
+          isBlockPermission: false,
+        }),
+      ]);
+    }) as never);
+
+    const first: Array<ApiKeyPermissionRow> =
+      await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+    const other: Array<ApiKeyPermissionRow> =
+      await ApiKeyPermissionService.findPermissionsByApiKeyId(otherApiKeyId);
+
+    expect(findBy).toHaveBeenCalledTimes(2);
+    expect(first[0]!.permission).toBe(Permission.ProjectMember);
+    expect(other[0]!.permission).toBe(Permission.ReadProjectMonitor);
+
+    // Both keys are now cached: repeat calls issue no further queries.
+    await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+    await ApiKeyPermissionService.findPermissionsByApiKeyId(otherApiKeyId);
+    expect(findBy).toHaveBeenCalledTimes(2);
+  });
+
+  test("a key with zero permission rows still short-circuits the second call", async () => {
+    const findBy: jest.SpyInstance = spyOnFindBy().mockResolvedValue(
+      [] as never,
+    );
+
+    await expect(
+      ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId),
+    ).resolves.toEqual([]);
+    await expect(
+      ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId),
+    ).resolves.toEqual([]);
+
+    expect(findBy).toHaveBeenCalledTimes(1);
+  });
+
+  test("expires after the 60s TTL and re-queries", async () => {
+    const base: number = Date.now();
+    let nowMs: number = base;
+    jest.spyOn(Date, "now").mockImplementation((): number => {
+      return nowMs;
+    });
+
+    const findBy: jest.SpyInstance = spyOnFindBy().mockResolvedValue(
+      [] as never,
+    );
+
+    await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+    expect(findBy).toHaveBeenCalledTimes(1);
+
+    // Just inside the TTL: still served from cache.
+    nowMs = base + TTL_MS - 1;
+    await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+    expect(findBy).toHaveBeenCalledTimes(1);
+
+    // Past the TTL: the entry has expired and the key is re-queried.
+    nowMs = base + TTL_MS + 1;
+    await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+    expect(findBy).toHaveBeenCalledTimes(2);
+  });
+
+  describe("invalidation", () => {
+    type PrimeCacheFunction = () => Promise<jest.SpyInstance>;
+
+    const primeCache: PrimeCacheFunction =
+      async (): Promise<jest.SpyInstance> => {
+        const findBy: jest.SpyInstance = spyOnFindBy().mockResolvedValue(
+          [] as never,
+        );
+        await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+        expect(findBy).toHaveBeenCalledTimes(1);
+        return findBy;
+      };
+
+    test("clearCache() drops every cached entry", async () => {
+      const findBy: jest.SpyInstance = await primeCache();
+
+      ApiKeyPermissionService.clearCache();
+
+      await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+      expect(findBy).toHaveBeenCalledTimes(2);
+    });
+
+    test("creating a permission clears the cache", async () => {
+      const findBy: jest.SpyInstance = await primeCache();
+
+      // The duplicate-permission check inside the hook must find nothing.
+      getJestSpyOn(ApiKeyPermissionService, "findOneBy").mockResolvedValue(
+        null,
+      );
+
+      const data: ApiKeyPermission = new ApiKeyPermission();
+      data.apiKeyId = apiKeyId;
+      data.projectId = ObjectID.generate();
+      data.permission = Permission.ProjectMember;
+
+      await asHooks(ApiKeyPermissionService).onBeforeCreate({
+        data: data,
+        props: { isRoot: true },
+      });
+
+      await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+      expect(findBy).toHaveBeenCalledTimes(2);
+    });
+
+    test("updating a permission clears the cache", async () => {
+      const findBy: jest.SpyInstance = await primeCache();
+
+      await asHooks(ApiKeyPermissionService).onBeforeUpdate({
+        query: {},
+        data: {},
+        props: { isRoot: true },
+      });
+
+      await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+      expect(findBy).toHaveBeenCalledTimes(2);
+    });
+
+    test("deleting a permission clears the cache", async () => {
+      const findBy: jest.SpyInstance = await primeCache();
+
+      await asHooks(ApiKeyPermissionService).onBeforeDelete({
+        query: {},
+        props: { isRoot: true },
+      });
+
+      await ApiKeyPermissionService.findPermissionsByApiKeyId(apiKeyId);
+      expect(findBy).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/Common/Tests/Server/Types/Database/Permissions/AccessControlPermission.test.ts
+++ b/Common/Tests/Server/Types/Database/Permissions/AccessControlPermission.test.ts
@@ -3,6 +3,9 @@ import AccessControlPermission from "../../../../../Server/Types/Database/Permis
 import QueryUtil from "../../../../../Server/Types/Database/QueryUtil";
 import Monitor from "../../../../../Models/DatabaseModels/Monitor";
 import DatabaseCommonInteractionProps from "../../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import DatabaseCommonInteractionPropsUtil, {
+  PermissionType,
+} from "../../../../../Types/BaseDatabase/DatabaseCommonInteractionPropsUtil";
 import ObjectID from "../../../../../Types/ObjectID";
 import Permission, {
   UserTenantAccessPermission,
@@ -185,5 +188,167 @@ describe("AccessControlPermission.addAccessControlIdsToQuery", () => {
 
     expect(result.labels).toBe(callerLabelFilter);
     expect(result._id).toBeUndefined();
+  });
+});
+
+describe("AccessControlPermission.getAccessControlIdsForQuery", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const permittedLabelA: ObjectID = ObjectID.generate();
+  const permittedLabelB: ObjectID = ObjectID.generate();
+
+  function makeLabelRestrictedProps(): DatabaseCommonInteractionProps {
+    // A user whose ONLY read grant on Monitor is label-restricted.
+    const tenantPermission: UserTenantAccessPermission = {
+      projectId,
+      _type: "UserTenantAccessPermission",
+      permissions: [
+        {
+          _type: "UserPermission",
+          permission: Permission.ReadProjectMonitor,
+          labelIds: [permittedLabelA, permittedLabelB],
+          isBlockPermission: false,
+        },
+      ],
+    };
+
+    return {
+      userId,
+      tenantId: projectId,
+      userTenantAccessPermission: {
+        [projectId.toString()]: tenantPermission,
+      },
+    };
+  }
+
+  function toStrings(ids: Array<ObjectID>): Array<string> {
+    return ids.map((id: ObjectID) => {
+      return id.toString();
+    });
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns the permitted label ids deduped for a multi-column select, same as a query-only call", () => {
+    const withSelect: Array<ObjectID> =
+      AccessControlPermission.getAccessControlIdsForQuery(
+        Monitor,
+        { projectId } as any,
+        { _id: true, createdAt: true, name: true } as any,
+        makeLabelRestrictedProps(),
+        DatabaseRequestType.Read,
+      );
+
+    const queryOnly: Array<ObjectID> =
+      AccessControlPermission.getAccessControlIdsForQuery(
+        Monitor,
+        { projectId } as any,
+        null,
+        makeLabelRestrictedProps(),
+        DatabaseRequestType.Read,
+      );
+
+    expect(toStrings(withSelect)).toEqual([
+      permittedLabelA.toString(),
+      permittedLabelB.toString(),
+    ]);
+    expect(toStrings(withSelect)).toEqual(toStrings(queryOnly));
+  });
+
+  it("returns an empty array for users with an unrestricted grant regardless of column count", () => {
+    const tenantPermission: UserTenantAccessPermission = {
+      projectId,
+      _type: "UserTenantAccessPermission",
+      permissions: [
+        {
+          _type: "UserPermission",
+          permission: Permission.ProjectMember,
+          labelIds: [],
+          isBlockPermission: false,
+        },
+      ],
+    };
+
+    const result: Array<ObjectID> =
+      AccessControlPermission.getAccessControlIdsForQuery(
+        Monitor,
+        { projectId } as any,
+        { _id: true, createdAt: true, updatedAt: true, name: true } as any,
+        {
+          userId,
+          tenantId: projectId,
+          userTenantAccessPermission: {
+            [projectId.toString()]: tenantPermission,
+          },
+        },
+        DatabaseRequestType.Read,
+      );
+
+    expect(result).toEqual([]);
+  });
+
+  it("computes user permissions exactly once regardless of column count", () => {
+    const getUserPermissionsSpy: jest.SpyInstance = jest.spyOn(
+      DatabaseCommonInteractionPropsUtil,
+      "getUserPermissions",
+    );
+
+    const props: DatabaseCommonInteractionProps = makeLabelRestrictedProps();
+
+    AccessControlPermission.getAccessControlIdsForQuery(
+      Monitor,
+      { projectId } as any,
+      { _id: true, createdAt: true, updatedAt: true, name: true } as any,
+      props,
+      DatabaseRequestType.Read,
+    );
+
+    /*
+     * Perf regression guard: the old code rebuilt the full user-permission
+     * set once per access-controlled column plus once for the model-level
+     * check. The context must be built exactly once per query.
+     */
+    expect(getUserPermissionsSpy).toHaveBeenCalledTimes(1);
+    expect(getUserPermissionsSpy).toHaveBeenCalledWith(
+      props,
+      PermissionType.Allow,
+    );
+  });
+
+  it("still applies the idempotent Public push to props exactly once", () => {
+    const props: DatabaseCommonInteractionProps = makeLabelRestrictedProps();
+
+    AccessControlPermission.getAccessControlIdsForQuery(
+      Monitor,
+      { projectId } as any,
+      { _id: true, createdAt: true, name: true } as any,
+      props,
+      DatabaseRequestType.Read,
+    );
+
+    const globalPermissions: Array<Permission> =
+      props.userGlobalAccessPermission?.globalPermissions || [];
+
+    expect(
+      globalPermissions.filter((permission: Permission) => {
+        return permission === Permission.Public;
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("getAccessControlIdsForModel with three args still returns the model-level permitted ids", () => {
+    const result: Array<ObjectID> =
+      AccessControlPermission.getAccessControlIdsForModel(
+        Monitor,
+        makeLabelRestrictedProps(),
+        DatabaseRequestType.Read,
+      );
+
+    expect(toStrings(result)).toEqual([
+      permittedLabelA.toString(),
+      permittedLabelB.toString(),
+    ]);
   });
 });

--- a/Common/Tests/Server/Utils/APIKey/AccessPermission.test.ts
+++ b/Common/Tests/Server/Utils/APIKey/AccessPermission.test.ts
@@ -6,10 +6,24 @@ import {
   it,
   jest,
 } from "@jest/globals";
+
+/*
+ * PasswordHash has a known, pre-existing TS5.9 compile failure under ts-jest
+ * (Buffer vs BinaryLike) that breaks every suite whose import graph reaches
+ * it. Nothing here touches password hashing; stub the module before the
+ * service import graph drags it into compilation.
+ */
+jest.mock("../../../../Server/Utils/PasswordHash", () => {
+  return {
+    __esModule: true,
+    default: class PasswordHashStub {},
+  };
+});
+
 import APIKeyAccessPermission from "../../../../Server/Utils/APIKey/AccessPermission";
-import ApiKeyPermissionService from "../../../../Server/Services/ApiKeyPermissionService";
-import APIKeyPermission from "../../../../Models/DatabaseModels/ApiKeyPermission";
-import Label from "../../../../Models/DatabaseModels/Label";
+import ApiKeyPermissionService, {
+  ApiKeyPermissionRow,
+} from "../../../../Server/Services/ApiKeyPermissionService";
 import ObjectID from "../../../../Types/ObjectID";
 import Permission, {
   UserGlobalAccessPermission,
@@ -27,10 +41,11 @@ import { getJestSpyOn } from "../../../Spy";
  * key full control of the project; one that dropped it from the master path
  * would break trusted internal automation. Both directions are pinned below.
  *
- * getApiTenantAccessPermission also reshapes stored permission rows into the
- * runtime UserPermission shape (labels -> labelIds, block flag preserved). That
- * mapping is where a dropped label would quietly widen a scoped permission, so
- * it is tested against a spied service rather than a live database.
+ * getApiTenantAccessPermission also reshapes the (cached) permission rows into
+ * the runtime UserPermission shape (labelIds carried over, block flag
+ * preserved). That mapping is where a dropped label would quietly widen a
+ * scoped permission, so it is tested against a spied service rather than a
+ * live database.
  */
 
 const projectId: ObjectID = ObjectID.generate();
@@ -118,9 +133,9 @@ describe("APIKeyAccessPermission.getMasterApiTenantAccessPermission", () => {
 });
 
 describe("APIKeyAccessPermission.getApiTenantAccessPermission", () => {
-  const spyFindBy: jest.SpyInstance = getJestSpyOn(
+  const spyFindPermissions: jest.SpyInstance = getJestSpyOn(
     ApiKeyPermissionService,
-    "findBy",
+    "findPermissionsByApiKeyId",
   );
 
   beforeEach(() => {
@@ -135,40 +150,33 @@ describe("APIKeyAccessPermission.getApiTenantAccessPermission", () => {
     permission: Permission;
     labelIds?: Array<ObjectID>;
     isBlockPermission?: boolean;
-  }) => APIKeyPermission = (data: {
+  }) => ApiKeyPermissionRow = (data: {
     permission: Permission;
     labelIds?: Array<ObjectID>;
     isBlockPermission?: boolean;
-  }): APIKeyPermission => {
-    const row: APIKeyPermission = new APIKeyPermission();
-    row.permission = data.permission;
-    if (data.labelIds) {
-      row.labels = data.labelIds.map((id: ObjectID) => {
-        const label: Label = new Label();
-        label.id = id;
-        return label;
-      });
-    }
-    row.isBlockPermission = data.isBlockPermission ?? false;
-    return row;
+  }): ApiKeyPermissionRow => {
+    return {
+      permission: data.permission,
+      labelIds: data.labelIds ?? [],
+      isBlockPermission: data.isBlockPermission ?? false,
+    };
   };
 
   it("queries the permissions for exactly this api key", async () => {
-    spyFindBy.mockResolvedValue([] as never);
+    spyFindPermissions.mockResolvedValue([] as never);
 
     await APIKeyAccessPermission.getApiTenantAccessPermission(
       projectId,
       apiKeyId,
     );
 
-    expect(spyFindBy).toHaveBeenCalledTimes(1);
-    const arg: { query: { apiKeyId: ObjectID } } = spyFindBy.mock
-      .calls[0]![0] as { query: { apiKeyId: ObjectID } };
-    expect(arg.query.apiKeyId.toString()).toBe(apiKeyId.toString());
+    expect(spyFindPermissions).toHaveBeenCalledTimes(1);
+    const arg: ObjectID = spyFindPermissions.mock.calls[0]![0] as ObjectID;
+    expect(arg.toString()).toBe(apiKeyId.toString());
   });
 
   it("returns just the default baseline when the key has no permissions", async () => {
-    spyFindBy.mockResolvedValue([] as never);
+    spyFindPermissions.mockResolvedValue([] as never);
 
     const perm: UserTenantAccessPermission =
       await APIKeyAccessPermission.getApiTenantAccessPermission(
@@ -187,7 +195,7 @@ describe("APIKeyAccessPermission.getApiTenantAccessPermission", () => {
 
   it("maps each stored permission row onto the tenant permission", async () => {
     const labelId: ObjectID = ObjectID.generate();
-    spyFindBy.mockResolvedValue([
+    spyFindPermissions.mockResolvedValue([
       makeRow({
         permission: Permission.CreateProjectIncident,
         labelIds: [labelId],
@@ -219,7 +227,7 @@ describe("APIKeyAccessPermission.getApiTenantAccessPermission", () => {
   });
 
   it("preserves the block flag so a deny row stays a deny row", async () => {
-    spyFindBy.mockResolvedValue([
+    spyFindPermissions.mockResolvedValue([
       makeRow({
         permission: Permission.CreateProjectIncident,
         labelIds: [],
@@ -243,11 +251,16 @@ describe("APIKeyAccessPermission.getApiTenantAccessPermission", () => {
   });
 
   it("treats a row with no labels as an empty (unscoped) label set", async () => {
-    const row: APIKeyPermission = new APIKeyPermission();
-    row.permission = Permission.CreateProjectIncident;
-    // labels intentionally left undefined.
-    row.isBlockPermission = false;
-    spyFindBy.mockResolvedValue([row] as never);
+    /*
+     * The service DTO normalizes a stored row's undefined labels to [] (pinned
+     * in ApiKeyPermissionService.test.ts); here the mapping must keep that
+     * empty set an array rather than dropping it to undefined.
+     */
+    spyFindPermissions.mockResolvedValue([
+      makeRow({
+        permission: Permission.CreateProjectIncident,
+      }),
+    ] as never);
 
     const perm: UserTenantAccessPermission =
       await APIKeyAccessPermission.getApiTenantAccessPermission(
@@ -261,7 +274,6 @@ describe("APIKeyAccessPermission.getApiTenantAccessPermission", () => {
       },
     );
     expect(mapped).toBeDefined();
-    // No crash on undefined labels, and it becomes [] rather than undefined.
     expect(mapped!.labelIds).toEqual([]);
   });
 });

--- a/Common/Tests/Server/Utils/SessionReplay/SessionReplayGateCacheStore.test.ts
+++ b/Common/Tests/Server/Utils/SessionReplay/SessionReplayGateCacheStore.test.ts
@@ -1,0 +1,207 @@
+import ObjectID from "../../../../Types/ObjectID";
+
+/*
+ * The policy cache is keyed by projectId plus a CLIENT-supplied appIdentifier,
+ * so anyone holding an ingestion key (which ships in public browser JS) can
+ * mint unlimited distinct keys. These tests pin that the store is bounded -
+ * the regression they guard is the unbounded module-level Map that grew until
+ * the ingest pod was OOM-killed - while preserving the store's contracts:
+ * negative (null-policy) caching, per-project prefix invalidation, and the
+ * kill marker that must always land even at capacity.
+ */
+
+jest.mock("../../../../Server/Infrastructure/Redis", () => {
+  return {
+    __esModule: true,
+    default: {
+      getClient: jest.fn().mockReturnValue(null),
+      isConnected: jest.fn().mockReturnValue(false),
+    },
+  };
+});
+
+jest.mock("../../../../Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  };
+});
+
+import SessionReplayGateCacheStore, {
+  MAX_KILL_KEY_CACHE_ENTRIES,
+  MAX_POLICY_CACHE_ENTRIES,
+  PolicyCacheEntry,
+} from "../../../../Server/Utils/SessionReplay/SessionReplayGateCacheStore";
+
+type TestPolicy = { name: string };
+
+function policyKey(prefix: string, index: number): string {
+  return `${prefix}:app-${index}`;
+}
+
+function fillPolicyCache(prefix: string, count: number): void {
+  for (let i: number = 0; i < count; i++) {
+    SessionReplayGateCacheStore.setPolicyEntry<TestPolicy>(
+      policyKey(prefix, i),
+      { name: `policy-${i}` },
+    );
+  }
+}
+
+describe("SessionReplayGateCacheStore bounded policy cache", (): void => {
+  beforeEach((): void => {
+    jest.clearAllMocks();
+    /* Module-level Maps persist across tests. */
+    SessionReplayGateCacheStore.clearCache();
+  });
+
+  it("evicts the oldest entry instead of growing past the cap under a unique-key flood", (): void => {
+    fillPolicyCache("proj", MAX_POLICY_CACHE_ENTRIES + 1);
+
+    expect(
+      SessionReplayGateCacheStore.getPolicyEntry<TestPolicy>(
+        policyKey("proj", 0),
+      ),
+    ).toBeUndefined();
+
+    const last: PolicyCacheEntry<TestPolicy> | undefined =
+      SessionReplayGateCacheStore.getPolicyEntry<TestPolicy>(
+        policyKey("proj", MAX_POLICY_CACHE_ENTRIES),
+      );
+    expect(last).toBeDefined();
+    expect(last?.policy).toEqual({
+      name: `policy-${MAX_POLICY_CACHE_ENTRIES}`,
+    });
+  }, 15000);
+
+  it("rewriting an existing key at capacity evicts nothing", (): void => {
+    fillPolicyCache("proj", MAX_POLICY_CACHE_ENTRIES);
+
+    SessionReplayGateCacheStore.setPolicyEntry<TestPolicy>(
+      policyKey("proj", 5),
+      { name: "rewritten" },
+    );
+
+    for (let i: number = 0; i < MAX_POLICY_CACHE_ENTRIES; i++) {
+      expect(
+        SessionReplayGateCacheStore.getPolicyEntry<TestPolicy>(
+          policyKey("proj", i),
+        ),
+      ).toBeDefined();
+    }
+
+    expect(
+      SessionReplayGateCacheStore.getPolicyEntry<TestPolicy>(
+        policyKey("proj", 5),
+      )?.policy,
+    ).toEqual({ name: "rewritten" });
+  }, 15000);
+
+  it("a rewrite refreshes recency, so the next eviction takes the stale key", (): void => {
+    fillPolicyCache("proj", MAX_POLICY_CACHE_ENTRIES);
+
+    SessionReplayGateCacheStore.setPolicyEntry<TestPolicy>(
+      policyKey("proj", 0),
+      { name: "refreshed" },
+    );
+
+    SessionReplayGateCacheStore.setPolicyEntry<TestPolicy>("proj:app-new", {
+      name: "new",
+    });
+
+    expect(
+      SessionReplayGateCacheStore.getPolicyEntry<TestPolicy>(
+        policyKey("proj", 1),
+      ),
+    ).toBeUndefined();
+    expect(
+      SessionReplayGateCacheStore.getPolicyEntry<TestPolicy>(
+        policyKey("proj", 0),
+      )?.policy,
+    ).toEqual({ name: "refreshed" });
+    expect(
+      SessionReplayGateCacheStore.getPolicyEntry<TestPolicy>("proj:app-new"),
+    ).toBeDefined();
+  }, 15000);
+
+  it("still caches null policies - the hot-path refusal must stay cached", (): void => {
+    SessionReplayGateCacheStore.setPolicyEntry<TestPolicy>(
+      "proj:app-none",
+      null,
+    );
+
+    const entry: PolicyCacheEntry<TestPolicy> | undefined =
+      SessionReplayGateCacheStore.getPolicyEntry<TestPolicy>("proj:app-none");
+
+    expect(entry).toBeDefined();
+    expect(entry?.policy).toBeNull();
+    expect(typeof entry?.loadedAt).toBe("number");
+  });
+
+  it("clearCache(projectId) deletes exactly that project's prefixed entries after evictions", (): void => {
+    const projectA: ObjectID = ObjectID.generate();
+    const projectB: ObjectID = ObjectID.generate();
+
+    fillPolicyCache(projectA.toString(), MAX_POLICY_CACHE_ENTRIES);
+    /* These writes evict projectA's oldest entries. */
+    fillPolicyCache(projectB.toString(), 5);
+
+    SessionReplayGateCacheStore.clearCache(projectA);
+
+    for (let i: number = 0; i < MAX_POLICY_CACHE_ENTRIES; i++) {
+      expect(
+        SessionReplayGateCacheStore.getPolicyEntry<TestPolicy>(
+          policyKey(projectA.toString(), i),
+        ),
+      ).toBeUndefined();
+    }
+
+    for (let i: number = 0; i < 5; i++) {
+      expect(
+        SessionReplayGateCacheStore.getPolicyEntry<TestPolicy>(
+          policyKey(projectB.toString(), i),
+        ),
+      ).toBeDefined();
+    }
+  }, 15000);
+});
+
+describe("SessionReplayGateCacheStore bounded kill-key cache", (): void => {
+  beforeEach((): void => {
+    jest.clearAllMocks();
+    SessionReplayGateCacheStore.clearCache();
+  });
+
+  it("the local kill marker always lands, even at capacity", async (): Promise<void> => {
+    /* Redis is absent, so the fail-open path caches isDisabled:false. */
+    for (let i: number = 0; i < MAX_KILL_KEY_CACHE_ENTRIES; i++) {
+      await SessionReplayGateCacheStore.isProjectKilled(ObjectID.generate());
+    }
+
+    const killedProject: ObjectID = ObjectID.generate();
+    await SessionReplayGateCacheStore.markProjectDisabled(killedProject);
+
+    expect(
+      await SessionReplayGateCacheStore.isProjectKilled(killedProject),
+    ).toBe(true);
+  }, 30000);
+
+  it("an evicted kill entry re-resolves through the normal path", async (): Promise<void> => {
+    const firstProject: ObjectID = ObjectID.generate();
+    await SessionReplayGateCacheStore.isProjectKilled(firstProject);
+
+    /* Push the first project's entry out of the bounded map. */
+    for (let i: number = 0; i < MAX_KILL_KEY_CACHE_ENTRIES; i++) {
+      await SessionReplayGateCacheStore.isProjectKilled(ObjectID.generate());
+    }
+
+    await expect(
+      SessionReplayGateCacheStore.isProjectKilled(firstProject),
+    ).resolves.toBe(false);
+  }, 30000);
+});

--- a/Probe/Tests/Utils/Monitors/MonitorTypes/SslMonitor.timeout.test.ts
+++ b/Probe/Tests/Utils/Monitors/MonitorTypes/SslMonitor.timeout.test.ts
@@ -34,9 +34,8 @@ jest.mock("Common/Server/Utils/Logger", () => {
   };
 });
 
-import net from "net";
+import net, { AddressInfo } from "net";
 import tls from "tls";
-import { AddressInfo } from "net";
 import URL from "Common/Types/API/URL";
 import PositiveNumber from "Common/Types/PositiveNumber";
 import SSLMonitor, {


### PR DESCRIPTION
Phase 2 of the CPU/memory cost-reduction work (phase 1: #3239). Ten fixes, each adversarially verified against current master before implementation, then re-reviewed on the final diff. Two further candidates from the phase-1 bench were investigated and rejected (AnalyticsBaseModel hydration — benchmarked, no measurable win; CheckHeartbeat batching — already fixed on master).

## Fixes

**Request/auth hot path**
- **UserAuthorization**: the global-permissions block now skips resending the `global-permissions`/`global-permissions-hash` response headers when the client-sent hash matches — the exact contract the project-permissions block has always had. Saves ~0.5–3KB egress per authenticated response; the hash is still computed (it's needed for the comparison).
- **AccessControlPermission**: `getAccessControlIdsForQuery` built the full user-permission set once per select column (~26× redundant work on a 25-column dashboard read, multiplied per tenant on multi-tenant requests). The permission context is now built once per query and threaded through; the per-column access-control dictionary copy is also hoisted out of the loop. Returned ids are byte-identical (order and dedupe preserved).
- **ApiKeyPermissionService**: every API-key-authed request ran an uncached joined `findBy` for permission rows. New `findPermissionsByApiKeyId` caches plain DTOs for 60s with hook-driven invalidation (`onBeforeCreate`/`onBeforeUpdate`/new `onBeforeDelete`), mirroring the merged `ApiKeyService.findApiKey` pattern and its accepted 60s cross-replica staleness window. Cache hits return freshly built objects — no aliasing.

**Serialization**
- **DatabaseBaseModel.toJSONObject** constructed `new modelType()` per serialized row and nested entity on the hottest serialization path (every list API response). It now reuses a frozen per-class vanilla instance from a module-private WeakMap keyed by the *declared* model type. `_fromJSON` still constructs fresh instances (its instance is the mutation target — pinned by test).

**Public status pages**
- **StatusPageAPI overview** (the hottest public endpoint) rebuilt a ~20-query payload for every anonymous viewer. The build is extracted to `buildOverviewResponse` (mechanical move, verified byte-identical) and cached for 15s per process with in-flight dedup, keyed by resolved status page id, **strictly after** `checkHasReadAccess` — private pages, IP allowlists, and master-password gates stay per-request. Failures are never cached. Same pattern as the existing StatusAPI health-check and domain→id caches. Trade-off: public overview content can be up to 15s stale per replica.

**Email**
- **MailService** compiled the Handlebars template on every email sent (template *source* was cached, compilation was not). Compiled delegates are now memoized per template name; development mode still re-reads and recompiles per send (template hot-reload). The now-redundant `email-templates` LocalCache namespace is removed (grep-verified sole consumer).

**Telemetry ingest**
- **OtelIngestBaseService**: docker/podman container-name resolution did a Redis round trip per OTLP resource block. A bounded in-process memo (60s TTL / 10k entries) now fronts GlobalCache — positives only (a miss still hits Redis every block, so name resolution is never delayed), memo set only after a successful Redis write (outage retry semantics preserved).
- **Seven unbounded project-keyed rule caches** (log/trace pipelines, drop filters, scrub rules, metric rules) grew one entry per project forever, surviving project deletion. All swapped to the existing bounded `InMemoryTTLCache` (10k cap, unchanged 60s TTL, negative caching of zero-rule projects preserved).
- **SessionReplayGateCacheStore**: the policy cache was unbounded and keyed by a client-supplied `appIdentifier` — attacker-growable ingest-pod memory. Both stores are now capped at 10k entries with coarse-LRU eviction (inline, because `clearCache(projectId)` needs prefix key iteration `InMemoryTTLCache` lacks). Eviction can only force a reload, never prolong a stale policy; the kill-marker write always lands.

**Worker jobs**
- **AIAgent/UpdateConnectionStatus** paged the entire multi-tenant table through TypeORM every minute and filtered in JS. Now an exact structural clone of the merged Probe fix (d604c9a43d): two predicate SELECTs with a shared 3-minute cutoff (parity with the old moment-diff truncation), NULL-handling via `lessThanEqualToOrNull`/`notInOrNull`, dedup of double-listed rows, full-pipeline `updateOneById` so owner-notification hooks still fire.

Also merges a duplicate `net` import in `SslMonitor.timeout.test.ts` (pre-existing on master) so `npm run fix` is clean.

## Tests

Nine new suites + extensions to five existing ones — **~110 cases** pinning the perf behavior (compile/query/hash-count regression guards that fail on the old code), cache bounds and eviction order, TTL expiry, invalidation hooks, auth-before-cache ordering, negative-caching contracts, no-aliasing, and failure-path recovery:

- `Common/Tests/Server/API/StatusPageOverviewCache.test.ts` (8)
- `Common/Tests/Server/Services/ApiKeyPermissionService.test.ts` (10)
- `Common/Tests/Server/Infrastructure/InMemoryTTLCache.test.ts` (9 — first coverage for this shared util)
- `Common/Tests/Server/Utils/SessionReplay/SessionReplayGateCacheStore.test.ts` (7)
- `Common/Tests/Models/DatabaseModels/DatabaseBaseModelToJSONObjectCache.test.ts` (7)
- `App/Tests/Notification/MailServiceTemplateCache.test.ts` (6)
- `App/Tests/Telemetry/OtelIngestContainerNameL1Memo.test.ts` (22, parameterized docker+podman)
- `App/Tests/Telemetry/PipelineRuleCacheBounding.test.ts` (12, all seven loaders)
- `App/Tests/Workers/Jobs/AIAgent/UpdateConnectionStatus.test.ts` (10, cloned from the Probe suite)
- Extended: `UserAuthorization.test.ts` (+2), `AccessControlPermission.test.ts` (+5), and the three API-key suites moved their spy point to the new cached method.

Local verification: Common batch — 21 suites / 601 tests green; App batch — 9 suites / 146 tests green (including all named pre-existing regression suites). `npm run fix` clean; `npm run compile` in Common and App produces error sets byte-identical to unmodified master (the few remaining are the known local TS 5.9/@types issues, e.g. `PasswordHash.ts:180`, proven pre-existing by clean-tree comparison).

## Review notes

- The two deliberate behavioral deltas are the precedented staleness windows: 15s for public status-page overview content (per replica) and 60s cross-replica for API-key permission edits (same bound the merged API-key row cache already accepted; single-replica deployments see immediate invalidation via hooks).
- The big `StatusPageAPI.ts` diff is a code *move*: the overview build body was extracted verbatim into `buildOverviewResponse`; re-applying the transformation to the HEAD file reproduces the working-tree file byte-for-byte.
- Mail-template cache tests load MailService through `jest.isolateModules` with `ENVIRONMENT` forced explicitly, because App's `npm test` exports `config.env` (`ENVIRONMENT=development`) and the cache is intentionally bypassed in development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dkau8Qve3ik2doU2T1bi12
