### PR TITLE
fix(network-devices): staleness annotates the verdict, it does not replace it

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceStatusHero.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceStatusHero.tsx
@@ -7,7 +7,7 @@ import PageMap from "../../Utils/PageMap";
 import RouteMap, { RouteUtil } from "../../Utils/RouteMap";
 import AppLink from "../AppLink/AppLink";
 import Route from "Common/Types/API/Route";
-import { Gray500, Green, Red500 } from "Common/Types/BrandColors";
+import { Gray500, Green, Red500, Yellow500 } from "Common/Types/BrandColors";
 import ObjectID from "Common/Types/ObjectID";
 import OneUptimeDate from "Common/Types/Date";
 import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
@@ -127,21 +127,12 @@ const DeviceStatusHero: FunctionComponent<ComponentProps> = (
     }
 
     if (reachability === NetworkDeviceStatus.Down) {
-      /*
-       * Two different failures wear the same pill, and saying which is the
-       * difference between "go look at the device" and "go look at the
-       * probe" — so the tooltip names the one that actually happened.
-       */
       return (
         <Pill
           text="Down"
           color={Red500}
           size={PillSize.Normal}
-          tooltip={
-            reachabilityResult.isStale
-              ? `No SNMP poll has even been attempted in the last ${reachabilityResult.staleWindowInMinutes} minutes — check that this device's probe is online and keeping up with its fleet.`
-              : "The last SNMP poll could not reach this device."
-          }
+          tooltip="The last SNMP poll could not reach this device."
         />
       );
     }
@@ -211,6 +202,14 @@ const DeviceStatusHero: FunctionComponent<ComponentProps> = (
           <div className="text-sm font-medium text-gray-500">Reachability</div>
           <div className="mt-1.5 flex items-center gap-2">
             {getReachabilityPill()}
+            {reachabilityResult.isStale && (
+              <Pill
+                text="Stale"
+                color={Yellow500}
+                size={PillSize.Normal}
+                tooltip={`No SNMP poll has been attempted in the last ${reachabilityResult.staleWindowInMinutes} minutes, so this verdict may be out of date — check that this device's probe is online and keeping up with its fleet.`}
+              />
+            )}
           </div>
           <div className="mt-1.5 text-xs text-gray-500">
             {lastSeenAt

--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryCards.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DeviceSummaryCards.tsx
@@ -56,10 +56,17 @@ const DeviceSummaryCards: FunctionComponent<ComponentProps> = (
       const projectId: ObjectID = ProjectUtil.getCurrentProjectId()!;
 
       /*
-       * `isReachable` — the same stored verdict the Status pill renders and the
-       * Status chip filters on, so the rows a tile opens are the rows it
+       * `isReachable` — the same stored verdict the Status pill renders and
+       * the Status chip filters on, so the rows a tile opens are the rows it
        * counted. The three counts partition the fleet exactly: true, false,
        * and NULL (never polled).
+       *
+       * This only stays true because status is decided by the column alone.
+       * A pill that layered anything else on top — a freshness window, a
+       * staleness override — could not be reproduced by a SQL count, and the
+       * strip would start contradicting the rows underneath it. See
+       * DeviceReachabilityUtil, which is why staleness annotates the verdict
+       * instead of replacing it.
        */
       const [
         devicesUp,

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Devices.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Devices.tsx
@@ -42,7 +42,7 @@ import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
 import AppLink from "../../Components/AppLink/AppLink";
 import ObjectID from "Common/Types/ObjectID";
 import OneUptimeDate from "Common/Types/Date";
-import { Gray500, Green, Red500 } from "Common/Types/BrandColors";
+import { Gray500, Green, Red500, Yellow500 } from "Common/Types/BrandColors";
 import Pill, { PillSize } from "Common/UI/Components/Pill/Pill";
 import ProbeElement from "Common/UI/Components/Probe/Probe";
 import Query from "Common/Types/BaseDatabase/Query";
@@ -620,29 +620,49 @@ const NetworkDevices: FunctionComponent<
               const reachability: DeviceReachabilityResult =
                 DeviceStatusUtil.getReachability(item);
 
+              /*
+               * Stale qualifies the verdict, it does not replace it — so it
+               * rides along as an amber "Stale" pill next to the real one
+               * rather than repainting an answering device red. The row
+               * still says what the last poll found; the second pill says
+               * nothing has checked since.
+               */
+              const stalePill: ReactElement = reachability.isStale ? (
+                <Pill
+                  text="Stale"
+                  color={Yellow500}
+                  size={PillSize.Small}
+                  tooltip={`No SNMP poll has been attempted in the last ${reachability.staleWindowInMinutes} minutes, so this verdict may be out of date — check this device's probe.`}
+                />
+              ) : (
+                <></>
+              );
+
               if (reachability.status === NetworkDeviceStatus.Up) {
                 return (
-                  <Pill
-                    text="Up"
-                    color={Green}
-                    size={PillSize.Small}
-                    tooltip="The last SNMP poll reached this device."
-                  />
+                  <div className="flex items-center gap-1.5">
+                    <Pill
+                      text="Up"
+                      color={Green}
+                      size={PillSize.Small}
+                      tooltip="The last SNMP poll reached this device."
+                    />
+                    {stalePill}
+                  </div>
                 );
               }
 
               if (reachability.status === NetworkDeviceStatus.Down) {
                 return (
-                  <Pill
-                    text="Down"
-                    color={Red500}
-                    size={PillSize.Small}
-                    tooltip={
-                      reachability.isStale
-                        ? `No SNMP poll has even been attempted in the last ${reachability.staleWindowInMinutes} minutes — check this device's probe.`
-                        : "The last SNMP poll could not reach this device."
-                    }
-                  />
+                  <div className="flex items-center gap-1.5">
+                    <Pill
+                      text="Down"
+                      color={Red500}
+                      size={PillSize.Small}
+                      tooltip="The last SNMP poll could not reach this device."
+                    />
+                    {stalePill}
+                  </div>
                 );
               }
 

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkSite/View/Devices.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkSite/View/Devices.tsx
@@ -95,11 +95,7 @@ const NetworkSiteDevices: FunctionComponent<
                     text="Down"
                     color={Red500}
                     size={PillSize.Small}
-                    tooltip={
-                      reachability.isStale
-                        ? `No SNMP poll has even been attempted in the last ${reachability.staleWindowInMinutes} minutes — check this device's probe.`
-                        : "The last SNMP poll could not reach this device."
-                    }
+                    tooltip="The last SNMP poll could not reach this device."
                   />
                 );
               }

--- a/App/Tests/Dashboard/DeviceStatusUtil.test.ts
+++ b/App/Tests/Dashboard/DeviceStatusUtil.test.ts
@@ -123,7 +123,12 @@ describe("DeviceStatusUtil.getStatus", () => {
     ).toBe(NetworkDeviceStatus.Up);
   });
 
-  test("a device nothing has polled for hours is Down", () => {
+  /*
+   * Staleness annotates the verdict rather than replacing it — see
+   * DeviceReachabilityUtil. The tiles and the Status chip are SQL over
+   * `isReachable`, so a pill they cannot reproduce would contradict them.
+   */
+  test("a device nothing has polled for hours keeps its last verdict", () => {
     expect(
       DeviceStatusUtil.getStatus({
         isReachable: true,
@@ -131,7 +136,7 @@ describe("DeviceStatusUtil.getStatus", () => {
         lastSeenAt: minutesAgo(180),
         pollingIntervalInMinutes: 5,
       }),
-    ).toBe(NetworkDeviceStatus.Down);
+    ).toBe(NetworkDeviceStatus.Up);
   });
 
   test("accepts the ISO strings a NetworkDevice row carries after a fetch", () => {
@@ -169,7 +174,8 @@ describe("DeviceStatusUtil.getReachability", () => {
       pollingIntervalInMinutes: 5,
     });
 
-    expect(result.status).toBe(NetworkDeviceStatus.Down);
+    // The verdict stands; the amber "Stale" pill rides alongside it.
+    expect(result.status).toBe(NetworkDeviceStatus.Up);
     expect(result.isStale).toBe(true);
     expect(result.staleWindowInMinutes).toBe(60);
     expect(result.lastContactAt).toBeInstanceOf(Date);

--- a/App/Tests/Dashboard/NetworkOverviewUtil.test.ts
+++ b/App/Tests/Dashboard/NetworkOverviewUtil.test.ts
@@ -212,7 +212,14 @@ describe("issue #3220 — a fleet its probe cannot keep up with", () => {
     ).toEqual(["really-down"]);
   });
 
-  test("but a fleet nothing has polled for hours is still all down", () => {
+  /*
+   * A fleet nothing has polled for hours keeps its last known verdicts, so
+   * this summary matches the device list's tiles — which are SQL counts
+   * over `isReachable` and cannot express a per-device staleness window.
+   * The two pages disagreeing about the same fleet is the inconsistency
+   * issue #3220 was reported as.
+   */
+  test("a fleet nothing has polled for hours keeps its last known verdicts", () => {
     const devices: Array<OverviewDeviceRow> = [1, 2, 3].map(
       (index: number): OverviewDeviceRow => {
         return { _id: `d${index}`, ...answered(240) };
@@ -221,8 +228,8 @@ describe("issue #3220 — a fleet its probe cannot keep up with", () => {
 
     expect(summarizeDeviceFleet(devices)).toMatchObject({
       total: 3,
-      up: 0,
-      down: 3,
+      up: 3,
+      down: 0,
     });
   });
 });

--- a/Common/Tests/Server/Utils/Monitor/NetworkDeviceReachabilityRoundTrip.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/NetworkDeviceReachabilityRoundTrip.test.ts
@@ -317,13 +317,13 @@ describe("a device that genuinely stops answering still goes down", () => {
 });
 
 /*
- * And the other failure the new rule has to keep catching: the polling
- * pipeline going silent. Standing on the last poll's outcome alone would
- * leave a fleet green forever if its probe died, because nothing would ever
- * contradict the last good verdict.
+ * And the polling pipeline going silent. The fleet keeps its last known
+ * verdicts — manufacturing an outage nobody observed is the failure this
+ * change removes — but every device is flagged stale, which is what sends
+ * the operator to the probe instead of to 300 devices.
  */
-describe("a fleet whose probe has gone silent still goes down", () => {
-  test("a good verdict nobody has refreshed for hours is Down, and says why", async () => {
+describe("a fleet whose probe has gone silent is flagged, not condemned", () => {
+  test("a good verdict nobody has refreshed for hours stays Up and reads stale", async () => {
     const row: Record<string, unknown> = await walkAndReadBackDevice({
       isOnline: true,
       interfaces: reportedInterfaces(),
@@ -336,11 +336,34 @@ describe("a fleet whose probe has gone silent still goes down", () => {
       isStale: boolean;
     } = DeviceReachabilityUtil.getReachability(row, hoursLater);
 
-    expect(reachability.status).toBe(NetworkDeviceReachability.Down);
+    expect(reachability.status).toBe(NetworkDeviceReachability.Up);
     /*
-     * isStale is what makes the pill's tooltip say "check the probe"
-     * rather than "check the device" — two different investigations.
+     * isStale is what puts the amber "Stale" pill next to the verdict and
+     * points the tooltip at the probe — a different investigation from
+     * "this device is down", and the reason it is not expressed as Down.
      */
     expect(reachability.isStale).toBe(true);
+  });
+
+  /*
+   * The property that keeps the device list self-consistent: the summary
+   * tiles and the Status chip are SQL over `isReachable`, so whatever the
+   * clock says, the pill has to be reproducible from that column alone.
+   */
+  test("the verdict stays reproducible from the stored column alone", async () => {
+    const row: Record<string, unknown> = await walkAndReadBackDevice({
+      isOnline: true,
+      interfaces: reportedInterfaces(),
+    });
+
+    for (const hoursLater of [0, 1, 4, 24, 24 * 30]) {
+      const at: Date = new Date(WALKED_AT.getTime() + hoursLater * 3600 * 1000);
+
+      expect(DeviceReachabilityUtil.getStatus(row, at)).toBe(
+        row["isReachable"] === true
+          ? NetworkDeviceReachability.Up
+          : NetworkDeviceReachability.Down,
+      );
+    }
   });
 });

--- a/Common/Tests/Utils/Monitor/NetworkTopologyUtil.test.ts
+++ b/Common/Tests/Utils/Monitor/NetworkTopologyUtil.test.ts
@@ -209,7 +209,14 @@ describe("NetworkTopologyUtil.buildTopology", () => {
       expect(nodeById(result, "d1")!.status).toBe("up");
     });
 
-    it("but a device nothing has polled for hours goes down on the map", () => {
+    /*
+     * A device nothing has polled for hours keeps its last known colour
+     * rather than being drawn as an outage. Repainting a whole map red
+     * because its probe stopped is the false-positive storm this change
+     * exists to remove; the staleness signal belongs on the device page,
+     * not in the graph's only three colours.
+     */
+    it("a device nothing has polled for hours keeps its last known colour", () => {
       const result: TopologyBuildResult = NetworkTopologyUtil.buildTopology(
         [
           makeDevice("d1", "out-of-contact", {
@@ -217,11 +224,17 @@ describe("NetworkTopologyUtil.buildTopology", () => {
             lastPolledAt: outOfContact,
             lastSeenAt: outOfContact,
           }),
+          makeDevice("d2", "out-of-contact-and-failing", {
+            isReachable: false,
+            lastPolledAt: outOfContact,
+            lastSeenAt: outOfContact,
+          }),
         ],
         now,
       );
 
-      expect(nodeById(result, "d1")!.status).toBe("down");
+      expect(nodeById(result, "d1")!.status).toBe("up");
+      expect(nodeById(result, "d2")!.status).toBe("down");
     });
 
     /*

--- a/Common/Tests/Utils/NetworkDevice/DeviceReachabilityUtil.test.ts
+++ b/Common/Tests/Utils/NetworkDevice/DeviceReachabilityUtil.test.ts
@@ -244,13 +244,19 @@ describe("the last poll succeeded → Up", () => {
 });
 
 /*
- * The backstop. Reachability standing on the last poll's outcome would, on
- * its own, leave a fleet painted green forever if the probe died — nobody
- * would ever contradict the last good verdict. So a verdict we have not
- * been able to refresh for many cycles stops being trusted.
+ * Staleness ANNOTATES the verdict; it never replaces it.
+ *
+ * Two reasons, and the tests below pin both. Turning "nothing has polled
+ * this in a while" into "the device is down" is the exact inference this
+ * whole change exists to remove — doing it again at an hour instead of
+ * fifteen minutes would just move the bug. And the window is per-device
+ * (derived from each row's own interval), so a status that depended on it
+ * could never be expressed as a SQL filter — the device list's summary
+ * counts and its Status chip run in the database over `isReachable`, and a
+ * pill they cannot reproduce is a pill that contradicts them on screen.
  */
-describe("the polling pipeline stopped → Down (stale)", () => {
-  test("a good verdict older than the stale window goes Down", () => {
+describe("the polling pipeline stopped → still Up, but flagged stale", () => {
+  test("a good verdict older than the stale window stays Up and is flagged", () => {
     const result: DeviceReachabilityResult = reachabilityOf({
       isReachable: true,
       lastPolledAt: minutesAgo(61),
@@ -258,11 +264,11 @@ describe("the polling pipeline stopped → Down (stale)", () => {
       pollingIntervalInMinutes: 5,
     });
 
-    expect(result.status).toBe(NetworkDeviceReachability.Down);
+    expect(result.status).toBe(NetworkDeviceReachability.Up);
     expect(result.isStale).toBe(true);
   });
 
-  test("the boundary is strict: exactly at the window is still Up", () => {
+  test("the staleness boundary is strict, and moves only isStale", () => {
     expect(
       reachabilityOf({
         isReachable: true,
@@ -277,27 +283,58 @@ describe("the polling pipeline stopped → Down (stale)", () => {
         lastPolledAt: minutesAgo(60, 1),
         pollingIntervalInMinutes: 5,
       }),
-    ).toMatchObject({ status: NetworkDeviceReachability.Down, isStale: true });
+    ).toMatchObject({ status: NetworkDeviceReachability.Up, isStale: true });
   });
 
-  test("the window follows the device's interval, so a slow device is not stale early", () => {
+  test("the window follows the device's interval, so a slow device is not flagged early", () => {
     // 30-minute interval -> 300-minute window: four hours is fine.
     expect(
-      statusOf({
+      reachabilityOf({
         isReachable: true,
         lastPolledAt: minutesAgo(240),
         pollingIntervalInMinutes: 30,
-      }),
-    ).toBe(NetworkDeviceReachability.Up);
+      }).isStale,
+    ).toBe(false);
 
     // Six hours is not.
     expect(
-      statusOf({
+      reachabilityOf({
         isReachable: true,
         lastPolledAt: minutesAgo(360),
         pollingIntervalInMinutes: 30,
-      }),
-    ).toBe(NetworkDeviceReachability.Down);
+      }).isStale,
+    ).toBe(true);
+  });
+
+  /*
+   * The invariant that keeps the pill, the summary counts and the Status
+   * chip in agreement. The latter two are SQL over `isReachable` alone, so
+   * the moment anything else can change `status`, they diverge — which is
+   * precisely how a stale fleet came to render 40 red rows under a tile
+   * reading "Devices Down 0".
+   */
+  test("status is decided by isReachable alone, whatever the timestamps say", () => {
+    const ages: Array<number> = [0, 1, 59, 60, 61, 600, 60 * 24 * 30];
+
+    for (const age of ages) {
+      expect(
+        statusOf({
+          isReachable: true,
+          lastPolledAt: minutesAgo(age),
+          lastSeenAt: minutesAgo(age),
+          pollingIntervalInMinutes: 5,
+        }),
+      ).toBe(NetworkDeviceReachability.Up);
+
+      expect(
+        statusOf({
+          isReachable: false,
+          lastPolledAt: minutesAgo(age),
+          lastSeenAt: minutesAgo(age + 10),
+          pollingIntervalInMinutes: 5,
+        }),
+      ).toBe(NetworkDeviceReachability.Down);
+    }
   });
 
   test("the result names the window it judged against, so the UI can explain itself", () => {
@@ -330,7 +367,7 @@ describe("the polling pipeline stopped → Down (stale)", () => {
     expect(result.lastContactAt?.getTime()).toBe(minutesAgo(2).getTime());
   });
 
-  test("a device nobody has polled AND that never answered is stale", () => {
+  test("a device can be both Down and stale, reported independently", () => {
     const result: DeviceReachabilityResult = reachabilityOf({
       isReachable: false,
       lastPolledAt: minutesAgo(600),
@@ -537,7 +574,13 @@ describe("issue #3220 at fleet scale", () => {
     expect(down).toBe(3);
   });
 
-  test("a fleet whose probe has stopped entirely still goes down", () => {
+  /*
+   * A probe that has stopped entirely. The fleet keeps its last known
+   * verdicts — inventing an outage nobody observed is the failure mode this
+   * change exists to remove — but every device is flagged stale, which is
+   * the signal that says "check the probe" rather than "check 50 devices".
+   */
+  test("a fleet whose probe has stopped is flagged stale, not declared down", () => {
     const fleet: Array<DeviceReachabilityInput> = healthyFleetPolledOverMinutes(
       20,
       50,
@@ -555,7 +598,13 @@ describe("issue #3220 at fleet scale", () => {
         return statusOf(device) === NetworkDeviceReachability.Down;
       },
     ).length;
+    const stale: number = fleet.filter(
+      (device: DeviceReachabilityInput): boolean => {
+        return reachabilityOf(device).isStale;
+      },
+    ).length;
 
-    expect(down).toBe(50);
+    expect(down).toBe(0);
+    expect(stale).toBe(50);
   });
 });

--- a/Common/Tests/Utils/NetworkSite/SiteStatusRollupUtil.test.ts
+++ b/Common/Tests/Utils/NetworkSite/SiteStatusRollupUtil.test.ts
@@ -140,11 +140,19 @@ describe("SiteStatusRollupUtil.worstStatus", () => {
   });
 
   /*
-   * The backstop still fires: a site nothing has polled for hours cannot
-   * keep reporting the last good verdict.
+   * A site nothing has polled for hours keeps its last known status rather
+   * than flipping offline. Turning "nobody has checked lately" into a red
+   * site card is the same inference this change removed from the device
+   * pill — and doing it here alone would put the site card at odds with
+   * every device under it, which is the inconsistency issue #3220 reported.
    */
-  it("a device out of contact past its stale window maps to offline", () => {
-    expect(worst([answered(61)])).toBe(OFFLINE.monitorStatusId);
+  it("a device out of contact past its stale window keeps its last verdict", () => {
+    expect(worst([answered(61)])).toBe(OPERATIONAL.monitorStatusId);
+    expect(worst([answered(60 * 24)])).toBe(OPERATIONAL.monitorStatusId);
+  });
+
+  it("...but a device that actually failed its last poll still rolls up offline", () => {
+    expect(worst([failed(60 * 24)])).toBe(OFFLINE.monitorStatusId);
   });
 
   /*
@@ -267,6 +275,11 @@ describe("SiteStatusRollupUtil.worstStatus", () => {
    * migration (or their next walk) fills the rest in.
    */
   it("legacy rows with only lastSeenAt still roll up by freshness", () => {
+    /*
+     * The one place freshness survives: a row written before isReachable
+     * existed has nothing else to go on. The upgrade migration backfills
+     * these, so it is a short-lived path.
+     */
     expect(worst([{ lastSeenAt: minutesAgo(5) }])).toBe(
       OPERATIONAL.monitorStatusId,
     );

--- a/Common/Utils/NetworkDevice/DeviceReachabilityUtil.ts
+++ b/Common/Utils/NetworkDevice/DeviceReachabilityUtil.ts
@@ -38,16 +38,16 @@ export enum NetworkDeviceReachability {
 export const DEFAULT_DEVICE_POLLING_INTERVAL_IN_MINUTES: number = 5;
 
 /*
- * Consecutive missed polls before a device that last answered successfully
- * is treated as out of contact.
+ * Consecutive missed polls before a device's last verdict is reported as
+ * STALE. Staleness is an annotation on the verdict, never the verdict
+ * itself — see getReachability for why turning it into "Down" would both
+ * re-create this bug at a longer timescale and put the pill permanently at
+ * odds with the summary counts.
  *
- * Deliberately generous. Real down-detection no longer rides on this number
- * — a device that stops answering is marked unreachable by the very next
- * poll — so the only thing this catches is the whole polling pipeline going
- * silent (probe offline, claim loop wedged, walk queue backed up). Ten
- * missed cycles is unambiguous; a tighter threshold would go back to
- * reporting scheduler lag as a fleet-wide outage, which is the bug this
- * exists to prevent.
+ * Deliberately generous: a device that stops answering is marked
+ * unreachable by the very next poll, so the only thing this flags is the
+ * whole polling pipeline going silent (probe offline, claim loop wedged,
+ * walk queue backed up). Ten missed cycles is unambiguous.
  */
 export const DEVICE_MISSED_POLL_ALLOWANCE: number = 10;
 
@@ -77,8 +77,10 @@ export interface DeviceReachabilityResult {
   status: NetworkDeviceReachability;
   /*
    * True when the last poll ATTEMPT is older than the staleness window —
-   * i.e. this verdict is being read off data we can no longer vouch for.
-   * Independent of `status`: an unreachable device can also be stale.
+   * i.e. this verdict is being read off data nothing has refreshed for a
+   * long time. Strictly independent of `status`: it qualifies the verdict
+   * ("and nobody has checked lately") rather than changing it, and either
+   * an Up or a Down device can be stale.
    */
   isStale: boolean;
   // The window `isStale` was measured against, so the UI can name it.
@@ -173,15 +175,26 @@ export default class DeviceReachabilityUtil {
     }
 
     /*
-     * The probe asked and the device answered. This is the case the old
-     * freshness rule got wrong: the answer stands until a later poll
-     * contradicts it, or until we have gone so long without polling that we
-     * can no longer vouch for it.
+     * The probe asked and the device answered. The answer stands until a
+     * later poll contradicts it.
+     *
+     * Staleness deliberately does NOT override this. Turning "we have not
+     * asked in a while" into "the device is down" is the exact move this
+     * whole change exists to undo — doing it again at a longer timescale
+     * would just relocate the bug. It is also not expressible as a database
+     * filter (the window is per-device, derived from each row's own
+     * interval), so a status that depended on it could never agree with the
+     * summary counts or the Status filter, which have to run in SQL over
+     * `isReachable`. A verdict the list cannot count or filter by is a
+     * verdict that contradicts itself on screen.
+     *
+     * `isStale` still comes back in the result, and the UI shows it as what
+     * it is — "nothing has polled this device in N minutes, check its
+     * probe" — which is a different and more actionable statement than
+     * "this device is down".
      */
     if (device.isReachable === true) {
-      return result(
-        isStale ? NetworkDeviceReachability.Down : NetworkDeviceReachability.Up,
-      );
+      return result(NetworkDeviceReachability.Up);
     }
 
     /*


### PR DESCRIPTION
Follow-up to #3246, which is already on master. This corrects a self-contradiction in that change, found by a pre-merge review that finished after it had landed.

## What is wrong on master right now

#3246 added a staleness backstop: if nothing has polled a device for 10 missed cycles (floored at an hour), its verdict was reported as **Down**.

That does, at a longer timescale, exactly what #3246 set out to remove. "We have not asked recently" is not "the device is down" — that is the entire thesis of the fix — and the backstop re-applies the inference with the window moved from 15 minutes to an hour.

It also cannot work, because the window is **per-device**, derived from each row's own `pollingIntervalInMinutes`, and therefore is not expressible as a SQL filter. But:

- the device list's summary tiles are three `COUNT` queries over `isReachable`,
- its Status chip is a single-column filter over the same column,
- and only the **pill** applied the override.

So with a probe down for two hours and 40 answering devices:

| surface | says |
|---|---|
| every row's pill | **Down** (red) |
| the tile directly above | **Devices Up 40 / Devices Down 0** |
| clicking "Devices Down" | filters `isReachable = false` → **empty table** |
| Network Overview (summarises client-side) | **40 down** |

Four independent review lenses reported this; it survived adversarial refutation each time. The same split hits any device the migration backfilled to `isReachable = true` that is no longer claimed — `isPollingEnabled = false`, no probe, no hostname, suspended project.

## The fix

The verdict is decided by `isReachable` alone. Staleness is reported as what it is: an amber **Stale** pill beside the status on the device list and the Overview hero, with a tooltip pointing at the *probe* rather than at the device.

An operator whose probe has died now sees the fleet's last known state plus a fleet-wide "nothing has checked these lately" — both true, and the more actionable of the two claims — instead of 300 devices asserted to be down that nobody ever observed failing.

Every surface (pill, tiles, Status chip, Overview, topology, site rollup) is back to one rule that SQL can reproduce, so none of them can contradict another.

## The trade, stated plainly

A device that really goes down *while its probe is also dead* now holds its last verdict until polling resumes. That is already what the data says; the honest signal for it is the stale flag, not a guess.

The proper way to get the backstop back without breaking queryability is to persist the uncertainty server-side — a worker that clears `isReachable` back to NULL ("we no longer know") once `nextPollAt` is far enough overdue. That keeps one queryable column as the single source of truth and is the right shape for a follow-up; I have not done it here because it is a new worker job and a separate decision.

## Tests

- New invariant test: **status must be reproducible from `isReachable` alone, at any age.** That property is precisely what keeps the pill, the tiles and the chip from drifting apart, and its absence is why this got through the first time.
- Updated the seven tests that pinned `stale ⇒ Down` across `DeviceReachabilityUtil`, `NetworkTopologyUtil`, `SiteStatusRollupUtil`, the walk round-trip, `DeviceStatusUtil` and `NetworkOverviewUtil` — each now pins that the verdict survives and `isStale` is reported separately.
- Corrected the comment in `DeviceSummaryCards` that claimed the tiles count "the same stored verdict the pill renders"; it now says why that only holds while status depends on the column alone.

**Local:** Common 28,444 passed / 0 failed · App and Probe compile clean · lint clean. (15 Common suites cannot *load* on this machine — pre-existing `isolated-vm` native-module mismatch, equally broken on master.)
