### PR TITLE
test(status-page): fix subscribe-page wiring test broken by #3242's loading-state polish

### DIFF
--- a/App/Tests/StatusPage/SubscriberModelAPIWiring.test.ts
+++ b/App/Tests/StatusPage/SubscriberModelAPIWiring.test.ts
@@ -78,9 +78,17 @@ describe("Status Page model requests stay in the Status Page auth boundary", () 
     (relativePath: string) => {
       const source: string = readSource(relativePath).replace(/\s+/g, " ");
 
-      expect(source).toContain(
-        "if (!props.allowSubscribersToChooseResources) { return; }",
+      /*
+       * The guard may reset UI state (e.g. setIsLoading) before bailing, but
+       * it must end in an early return and must never start a resource fetch.
+       */
+      const guard: RegExpMatchArray | null = source.match(
+        /if \(!props\.allowSubscribersToChooseResources\) \{([^}]*)\}/,
       );
+
+      expect(guard).not.toBeNull();
+      expect(guard![1]).toContain("return;");
+      expect(guard![1]).not.toContain("fetch");
       expect(source).toContain("[props.allowSubscribersToChooseResources]");
     },
   );


### PR DESCRIPTION
Master's App test job currently fails 5 tests in `Tests/StatusPage/SubscriberModelAPIWiring.test.ts` (first surfaced on #3247's CI; reproducible on master — the failure was hidden because master's App Test runs kept being cancelled as superseded).

**Cause:** #3242 (e9ff68f982) made the `allowSubscribersToChooseResources` guard in the five subscribe pages call `setIsLoading(false)` before bailing, and the wiring test asserted the literal normalized string `if (!props.allowSubscribersToChooseResources) { return; }`.

**Fix (test-only):** assert the guard's contract instead of its exact bytes — the guard block must exist, end in an early `return`, and never start a resource fetch. This matches both the new five-page shape and `UpdateSubscription.tsx`'s bare-return form.

Suite is green locally: 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dkau8Qve3ik2doU2T1bi12