### PR TITLE
fix(tests): repair and harden the StatusPage subscriber wiring suite broken by #3242

### DIFF
--- a/App/Tests/StatusPage/SubscriberModelAPIWiring.test.ts
+++ b/App/Tests/StatusPage/SubscriberModelAPIWiring.test.ts
@@ -12,6 +12,11 @@ import path from "path";
  * These tests cover every hand-written Status Page call site. That is useful
  * in addition to the ModelAPI unit tests because a future subscriber channel
  * can compile while silently omitting the page-scoped adapter prop.
+ *
+ * The per-page lists below are pinned on purpose and enforced complete by
+ * the inventory tests: a new page that renders a ModelForm or fetches
+ * selectable resources fails the inventory until it is added here — which
+ * is what opts it into every boundary assertion in this file.
  */
 
 const STATUS_PAGE_SRC: string = path.join(
@@ -34,6 +39,17 @@ const ACCOUNT_FORM_PAGES: ReadonlyArray<string> = [
   "Pages/Accounts/ResetPassword.tsx",
 ];
 
+/**
+ * The one module allowed to import the dashboard-scoped ModelAPI: the
+ * adapter that rebinds it to the Status Page client and headers.
+ */
+const MODEL_API_ADAPTER: string = "Utils/ModelAPI.ts";
+
+const SOURCE_FILE_PATTERN: RegExp = /\.tsx?$/;
+const MODEL_FORM_PATTERN: RegExp = /<ModelForm/;
+const DASHBOARD_MODEL_API_IMPORT_PATTERN: RegExp =
+  /from\s+"Common\/UI\/Utils\/ModelAPI\/ModelAPI"/;
+
 function readSource(relativePath: string): string {
   return fs
     .readFileSync(path.join(STATUS_PAGE_SRC, relativePath), "utf8")
@@ -45,7 +61,80 @@ function occurrences(source: string, expression: RegExp): number {
   return source.match(expression)?.length || 0;
 }
 
+/** Every .ts / .tsx source file under StatusPage/src, relative to it. */
+function listSourceFiles(relativeDir: string = ""): Array<string> {
+  const absoluteDir: string = path.join(STATUS_PAGE_SRC, relativeDir);
+  const files: Array<string> = [];
+
+  for (const entry of fs.readdirSync(absoluteDir, { withFileTypes: true })) {
+    const relativePath: string = relativeDir
+      ? `${relativeDir}/${entry.name}`
+      : entry.name;
+
+    if (entry.isDirectory()) {
+      files.push(...listSourceFiles(relativePath));
+    } else if (SOURCE_FILE_PATTERN.test(entry.name)) {
+      files.push(relativePath);
+    }
+  }
+
+  return files.sort();
+}
+
 describe("Status Page model requests stay in the Status Page auth boundary", () => {
+  /*
+   * Inventory: discover every call site from the source tree and require the
+   * pinned lists above to match exactly. This is what keeps the per-page
+   * assertions below meaningful over time — a new subscriber channel (or a
+   * moved page) fails here first, with instructions, instead of silently
+   * shipping unasserted.
+   */
+  test("every page that renders a ModelForm is in the pinned inventory", () => {
+    const discovered: Array<string> = listSourceFiles("Pages").filter(
+      (relativePath: string): boolean => {
+        return MODEL_FORM_PATTERN.test(readSource(relativePath));
+      },
+    );
+
+    expect(discovered).toEqual(
+      [...SUBSCRIBE_PAGES, ...ACCOUNT_FORM_PAGES].slice().sort(),
+    );
+  });
+
+  test("every page that fetches selectable resources is in the pinned inventory", () => {
+    const discovered: Array<string> = listSourceFiles("Pages").filter(
+      (relativePath: string): boolean => {
+        return readSource(relativePath).includes(
+          "getCategoryCheckboxPropsBasedOnResources",
+        );
+      },
+    );
+
+    expect(discovered).toEqual(SUBSCRIBE_PAGES.slice().sort());
+  });
+
+  /*
+   * The boundary itself: nothing under StatusPage/src may import the
+   * dashboard ModelAPI except the adapter that wraps it. Any other import is
+   * a compile-clean path to the dashboard logout routine wiping the page's
+   * browser storage on the first 401.
+   */
+  test("only the adapter imports the dashboard-scoped ModelAPI", () => {
+    const offenders: Array<string> = listSourceFiles().filter(
+      (relativePath: string): boolean => {
+        if (relativePath === MODEL_API_ADAPTER) {
+          return false;
+        }
+
+        return DASHBOARD_MODEL_API_IMPORT_PATTERN.test(
+          readSource(relativePath),
+        );
+      },
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
   test.each([...SUBSCRIBE_PAGES, ...ACCOUNT_FORM_PAGES])(
     "%s gives every ModelForm the page-scoped ModelAPI",
     (relativePath: string) => {
@@ -80,15 +169,26 @@ describe("Status Page model requests stay in the Status Page auth boundary", () 
 
       /*
        * The guard may reset UI state (e.g. setIsLoading) before bailing, but
-       * it must end in an early return and must never start a resource fetch.
+       * it must END in an early return and must never start a resource fetch
+       * itself.
        */
       const guard: RegExpMatchArray | null = source.match(
         /if \(!props\.allowSubscribersToChooseResources\) \{([^}]*)\}/,
       );
 
       expect(guard).not.toBeNull();
-      expect(guard![1]).toContain("return;");
+      expect(guard![1]!.trim().endsWith("return;")).toBe(true);
       expect(guard![1]).not.toContain("fetch");
+      expect(guard![1]).not.toContain("getCategoryCheckbox");
+
+      /*
+       * And it must be the FIRST statement of the effect that triggers the
+       * fetch — nothing may run before it — with the effect keyed to the
+       * prop so toggling resource selection re-evaluates the guard.
+       */
+      expect(source).toContain(
+        "useEffect(() => { if (!props.allowSubscribersToChooseResources) {",
+      );
       expect(source).toContain("[props.allowSubscribersToChooseResources]");
     },
   );

--- a/App/Tests/StatusPage/SubscriberModelAPIWiring.test.ts
+++ b/App/Tests/StatusPage/SubscriberModelAPIWiring.test.ts
@@ -78,9 +78,17 @@ describe("Status Page model requests stay in the Status Page auth boundary", () 
     (relativePath: string) => {
       const source: string = readSource(relativePath).replace(/\s+/g, " ");
 
-      expect(source).toContain(
-        "if (!props.allowSubscribersToChooseResources) { return; }",
+      /*
+       * The guard may reset UI state (e.g. setIsLoading) before bailing, but
+       * it must end in an early return and must never start a resource fetch.
+       */
+      const guard: RegExpMatchArray | null = source.match(
+        /if \(!props\.allowSubscribersToChooseResources\) \{([^}]*)\}/,
       );
+
+      expect(guard).not.toBeNull();
+      expect(guard![1]).toContain("return;");
+      expect(guard![1]).not.toContain("fetch");
       expect(source).toContain("[props.allowSubscribersToChooseResources]");
     },
   );


### PR DESCRIPTION
## The breakage

`App/Tests/StatusPage/SubscriberModelAPIWiring.test.ts` has been failing 5 tests on master since #3242 merged, turning the App `test` job red on **every open PR** (visible on #3244–#3248; #3246–#3248 were merged over it). It went unnoticed on master itself because master's own App test runs kept being cancelled as superseded.

#3242 made the `allowSubscribersToChooseResources` guard in the five subscribe pages reset the loading skeleton before bailing:

```tsx
if (!props.allowSubscribersToChooseResources) {
  setIsLoading(false);
  return;
}
```

while the suite pinned the literal normalized string `if (!props.allowSubscribersToChooseResources) { return; }`.

## The fix

Assert the guard's contract instead of its exact bytes: the guard must exist, must **end** in an early return, must not start a resource fetch itself, and must be the **first statement** of the effect that triggers the fetch (still keyed to the prop). This also still matches `UpdateSubscription.tsx`'s bare-return form.

## Hardening

The file's own header warns that "a future subscriber channel can compile while silently omitting the page-scoped adapter prop" — but the suite only covered pages someone remembered to list. Three additions make it self-enforcing:

- **Inventory tests** — discover every page under `StatusPage/src/Pages` that renders a `ModelForm` or calls `getCategoryCheckboxPropsBasedOnResources`, and require the pinned lists to match exactly. A new call site fails the inventory (with the fix being to add it, which opts it into every per-page assertion) instead of shipping unasserted.
- **Boundary test** — nothing under `StatusPage/src` may import the dashboard-scoped `Common/UI/Utils/ModelAPI/ModelAPI` except the `Utils/ModelAPI` adapter. Any other import is a compile-clean path to the dashboard logout routine wiping the status page's browser storage on the first 401 — the failure mode this whole suite exists to prevent.
- **Stronger guard contract** — end-in-return rather than contains-return, guard-first-in-effect, and no fetch/`getCategoryCheckbox` inside the guard body.

25 tests, all passing locally against master's post-#3242 page shapes; the file is eslint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9P7VQSQrMLFSviunTwBCp