### PR TITLE
feat(home): self-hosted landing page and a governed claims matrix

### DIFF
--- a/Home/Routes.ts
+++ b/Home/Routes.ts
@@ -48,6 +48,14 @@ import {
   RecentBlogPostLink,
 } from "./Utils/AIDiscovery";
 import BlogPostUtil, { BlogPostHeader } from "./Utils/BlogPost";
+import { getSelfHostedContent } from "./Utils/SelfHosted";
+import {
+  Claim,
+  ClaimStatuses,
+  Claims,
+  getClaimsMatrix,
+  getClaimsNeedingReview,
+} from "./Utils/Claims";
 
 // import jobs.
 import "./Jobs/UpdateBlog";
@@ -226,6 +234,24 @@ const HomeFeatureSet: FeatureSet = {
         res.json({
           reviews: AllReviews.map((review: Review) => {
             return { ...review };
+          }),
+        });
+      },
+    );
+
+    /*
+     * The governed claims matrix, machine-readable. Sales engineering, RFP
+     * tooling, and AI agents should read this rather than scrape a landing page.
+     */
+    app.get(
+      "/data/claims.json",
+      (_req: ExpressRequest, res: ExpressResponse) => {
+        res.setHeader("Cache-Control", "public, max-age=600");
+        res.setHeader("Access-Control-Allow-Origin", "*");
+        res.json({
+          statuses: ClaimStatuses,
+          claims: Claims.map((claim: Claim) => {
+            return { ...claim };
           }),
         });
       },
@@ -1001,6 +1027,42 @@ const HomeFeatureSet: FeatureSet = {
       },
     );
 
+    app.get(
+      "/enterprise/self-hosted",
+      (_req: ExpressRequest, res: ExpressResponse) => {
+        const seo: PageSEOData & { fullCanonicalUrl: string } = getSEOForPath(
+          "/enterprise/self-hosted",
+          res.locals["homeUrl"] as string,
+        );
+        res.render(`${ViewsPath}/self-hosted.ejs`, {
+          support: false,
+          enableGoogleTagManager: IsBillingEnabled,
+          footerCards: true,
+          cta: false,
+          blackLogo: false,
+          requestDemoCta: true,
+          selfHosted: getSelfHostedContent(),
+          seo,
+        });
+      },
+    );
+
+    /*
+     * `/self-hosted` and `/on-premise` are what buyers type and what search
+     * results point at. Keep them alive, pointing at the canonical page.
+     */
+    app.get("/self-hosted", (_req: ExpressRequest, res: ExpressResponse) => {
+      res.redirect(301, "/enterprise/self-hosted");
+    });
+
+    app.get("/self-hosting", (_req: ExpressRequest, res: ExpressResponse) => {
+      res.redirect(301, "/enterprise/self-hosted");
+    });
+
+    app.get("/on-premise", (_req: ExpressRequest, res: ExpressResponse) => {
+      res.redirect(301, "/enterprise/self-hosted");
+    });
+
     // Solutions pages
     app.get(
       "/solutions/devops",
@@ -1625,8 +1687,30 @@ const HomeFeatureSet: FeatureSet = {
         cta: true,
         blackLogo: false,
         requestDemoCta: false,
+        claimStatuses: ClaimStatuses,
+        claimsMatrix: getClaimsMatrix(),
+        claimsUnderReviewCount: getClaimsNeedingReview().length,
         seo,
       });
+    });
+
+    /*
+     * /trust is the canonical trust center. /security and /security-center are
+     * what people type and what security questionnaires link to.
+     */
+    app.get("/security", (_req: ExpressRequest, res: ExpressResponse) => {
+      res.redirect(301, "/trust");
+    });
+
+    app.get(
+      "/security-center",
+      (_req: ExpressRequest, res: ExpressResponse) => {
+        res.redirect(301, "/trust");
+      },
+    );
+
+    app.get("/trust-center", (_req: ExpressRequest, res: ExpressResponse) => {
+      res.redirect(301, "/trust");
     });
 
     // Compare index / landing page

--- a/Home/Tests/AIDiscovery.test.ts
+++ b/Home/Tests/AIDiscovery.test.ts
@@ -104,6 +104,30 @@ describe("AIDiscovery", () => {
     }
   });
 
+  test("llms.txt lists the enterprise pages and the claims matrix", () => {
+    const txt: string = generateLlmsTxt(homeUrl, []);
+
+    expect(txt).toContain("## Enterprise");
+    expect(txt).toContain("https://oneuptime.com/enterprise/self-hosted.md");
+    expect(txt).toContain("https://oneuptime.com/trust");
+    expect(txt).toContain("https://oneuptime.com/data/claims.json");
+  });
+
+  test("the self-hosted page has a markdown variant with its deployment detail", () => {
+    const md: string = generatePageMarkdown(
+      PageSEOConfig["/enterprise/self-hosted"]!,
+      homeUrl,
+    );
+
+    expect(md).toContain("# OneUptime Self-Hosted");
+    expect(md).toContain("## Features");
+    expect(md.toLowerCase()).toContain("helm");
+    expect(md.toLowerCase()).toContain("air-gapped");
+    expect(md).toContain(
+      "Canonical page: https://oneuptime.com/enterprise/self-hosted",
+    );
+  });
+
   test("compare index json lists every comparison slug", () => {
     const comparisons: Array<JSONObject> = generateCompareIndexJson(homeUrl)[
       "comparisons"

--- a/Home/Tests/Claims.test.ts
+++ b/Home/Tests/Claims.test.ts
@@ -1,0 +1,339 @@
+import {
+  Claim,
+  ClaimCategories,
+  ClaimCategory,
+  ClaimCategoryGroup,
+  ClaimCategoryKey,
+  ClaimStatusDefinition,
+  ClaimStatusKey,
+  ClaimStatuses,
+  Claims,
+  RetiredClaim,
+  RetiredClaims,
+  getClaim,
+  getClaimStatus,
+  getClaimsByCategory,
+  getClaimsMatrix,
+  getClaimsNeedingReview,
+} from "../Utils/Claims";
+
+const EXPECTED_STATUS_KEYS: Array<ClaimStatusKey> = [
+  "certified",
+  "attested",
+  "compliant",
+  "aligned",
+  "in-progress",
+  "customer-configurable",
+];
+
+const EXPECTED_CATEGORY_KEYS: Array<ClaimCategoryKey> = [
+  "sla",
+  "support",
+  "compliance",
+  "encryption",
+  "deployment",
+  "migration",
+  "scale",
+  "discounts",
+  "contract",
+];
+
+describe("Claims vocabulary", () => {
+  test("the status vocabulary is exactly the governed set", () => {
+    expect(
+      ClaimStatuses.map((status: ClaimStatusDefinition) => {
+        return status.key;
+      }),
+    ).toEqual(EXPECTED_STATUS_KEYS);
+  });
+
+  test("every status publishes a definition and an evidence bar", () => {
+    for (const status of ClaimStatuses) {
+      expect(status.label.length).toBeGreaterThan(0);
+      expect(status.definition.length).toBeGreaterThan(20);
+      expect(status.evidenceBar.length).toBeGreaterThan(10);
+    }
+  });
+
+  test("status labels are the exact words the brief asked for", () => {
+    const labels: Array<string> = ClaimStatuses.map(
+      (status: ClaimStatusDefinition) => {
+        return status.label;
+      },
+    );
+
+    expect(labels).toEqual([
+      "Certified",
+      "Attested",
+      "Compliant",
+      "Aligned",
+      "In progress",
+      "Customer-configurable",
+    ]);
+  });
+
+  test("getClaimStatus resolves every key and rejects unknown ones", () => {
+    for (const key of EXPECTED_STATUS_KEYS) {
+      expect(getClaimStatus(key).key).toBe(key);
+    }
+
+    expect(() => {
+      return getClaimStatus("world-class" as ClaimStatusKey);
+    }).toThrow("Unknown claim status: world-class");
+  });
+});
+
+describe("Claims matrix", () => {
+  test("every governed category from the brief is covered", () => {
+    expect(
+      ClaimCategories.map((category: ClaimCategory) => {
+        return category.key;
+      }),
+    ).toEqual(EXPECTED_CATEGORY_KEYS);
+  });
+
+  test("every category carries claims and names its governing document", () => {
+    for (const group of getClaimsMatrix()) {
+      expect(group.claims.length).toBeGreaterThan(0);
+      expect(group.category.governingDocument.length).toBeGreaterThan(0);
+      expect(group.category.governingDocumentUrl.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("claim ids are unique", () => {
+    const ids: Array<string> = Claims.map((claim: Claim) => {
+      return claim.id;
+    });
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("every claim has a statement, a qualifier, evidence, and a source", () => {
+    for (const claim of Claims) {
+      expect(claim.statement.length).toBeGreaterThan(20);
+      expect(claim.qualifier.length).toBeGreaterThan(10);
+      expect(claim.evidence.length).toBeGreaterThan(5);
+      expect(claim.sourceUrl).toMatch(/^(\/|https:\/\/)/);
+    }
+  });
+
+  test("every claim uses a status and a category from the vocabulary", () => {
+    for (const claim of Claims) {
+      expect(EXPECTED_STATUS_KEYS).toContain(claim.status);
+      expect(EXPECTED_CATEGORY_KEYS).toContain(claim.category);
+      expect(["cloud", "self-hosted", "both"]).toContain(claim.scope);
+    }
+  });
+
+  test("no claim statement contains a hedge-free superlative", () => {
+    // These read as puffery on a page that is meant to be checkable.
+    const bannedWords: Array<RegExp> = [
+      /\bworld[- ]class\b/i,
+      /\bbest[- ]in[- ]class\b/i,
+      /\bunbreakable\b/i,
+      /\bbulletproof\b/i,
+      /\bhighest standards\b/i,
+      /\b100% secure\b/i,
+    ];
+
+    for (const claim of Claims) {
+      for (const banned of bannedWords) {
+        expect(`${claim.statement} ${claim.qualifier}`).not.toMatch(banned);
+      }
+    }
+  });
+
+  test("a claim marked for review explains what the reviewer must confirm", () => {
+    for (const claim of getClaimsNeedingReview()) {
+      expect(claim.reviewRequired).toBe(true);
+      expect(claim.reviewNote).toBeDefined();
+      expect(claim.reviewNote!.length).toBeGreaterThan(20);
+    }
+  });
+
+  test("getClaimsByCategory and getClaim look claims up", () => {
+    const slaClaims: Array<Claim> = getClaimsByCategory("sla");
+    expect(slaClaims.length).toBeGreaterThan(0);
+    for (const claim of slaClaims) {
+      expect(claim.category).toBe("sla");
+    }
+
+    expect(getClaim("sla-cloud-enterprise")!.status).toBe("compliant");
+    expect(getClaim("does-not-exist")).toBeNull();
+  });
+
+  test("the matrix keeps categories in publication order", () => {
+    const matrix: Array<ClaimCategoryGroup> = getClaimsMatrix();
+    expect(
+      matrix.map((group: ClaimCategoryGroup) => {
+        return group.category.key;
+      }),
+    ).toEqual(EXPECTED_CATEGORY_KEYS);
+  });
+});
+
+describe("Claims match the documents that bind us", () => {
+  test("the enterprise uptime claim matches the SLA, not marketing", () => {
+    const claim: Claim = getClaim("sla-cloud-enterprise")!;
+
+    expect(claim.statement).toContain("99.95%");
+    expect(claim.statement).not.toContain("99.99%");
+    expect(claim.sourceUrl).toBe("/legal/sla");
+  });
+
+  test("the paid-plan uptime claim matches the SLA", () => {
+    const claim: Claim = getClaim("sla-cloud-paid")!;
+
+    expect(claim.statement).toContain("99.9%");
+    expect(claim.sourceUrl).toBe("/legal/sla");
+  });
+
+  test("free plans are stated as having no uptime commitment", () => {
+    const claim: Claim = getClaim("sla-free-plans")!;
+
+    expect(claim.statement.toLowerCase()).toContain("no uptime commitment");
+    expect(claim.status).toBe("aligned");
+  });
+
+  test("support response times are described as targets, never guarantees", () => {
+    const claim: Claim = getClaim("support-p1")!;
+
+    expect(claim.statement.toLowerCase()).toContain("target");
+    expect(claim.qualifier.toLowerCase()).toContain(
+      "not a credit-backed guarantee",
+    );
+  });
+
+  test("self-hosted uptime is explicitly excluded from the cloud SLA", () => {
+    const claim: Claim = getClaim("sla-self-hosted")!;
+
+    expect(claim.status).toBe("customer-configurable");
+    expect(claim.scope).toBe("self-hosted");
+    expect(claim.qualifier).toContain(
+      "does not extend to infrastructure you operate",
+    );
+  });
+
+  test("SOC 2 is attested rather than certified", () => {
+    const claim: Claim = getClaim("compliance-soc2")!;
+
+    expect(claim.status).toBe("attested");
+    expect(claim.qualifier.toLowerCase()).toContain("not a certificate");
+  });
+
+  test("regimes with no vendor certification scheme are aligned, not certified", () => {
+    for (const id of [
+      "compliance-gxp",
+      "compliance-csa-star",
+      "compliance-pci",
+    ]) {
+      expect(getClaim(id)!.status).toBe("aligned");
+    }
+  });
+
+  test("statutory regimes with no certification body are compliant", () => {
+    for (const id of [
+      "compliance-gdpr",
+      "compliance-ccpa",
+      "compliance-hipaa",
+    ]) {
+      const claim: Claim = getClaim(id)!;
+      expect(claim.status).toBe("compliant");
+      expect(claim.qualifier.toLowerCase()).toMatch(
+        /no certification|not a certification|must be executed/,
+      );
+    }
+  });
+
+  test("FedRAMP stays in progress and promises no date", () => {
+    const claim: Claim = getClaim("compliance-fedramp")!;
+
+    expect(claim.status).toBe("in-progress");
+    expect(claim.qualifier.toLowerCase()).toContain("no date is promised");
+  });
+
+  test("encryption claims split cloud from self-hosted responsibility", () => {
+    expect(getClaim("encryption-in-transit")!.scope).toBe("cloud");
+    expect(getClaim("encryption-self-hosted")!.scope).toBe("self-hosted");
+    expect(getClaim("encryption-self-hosted")!.status).toBe(
+      "customer-configurable",
+    );
+  });
+
+  test("the discounts category does not invent a programme we do not run", () => {
+    const claim: Claim = getClaim("discount-open-source")!;
+
+    expect(claim.statement.toLowerCase()).toContain("no non-profit");
+    expect(claim.statement.toLowerCase()).toContain("free to self-host");
+  });
+
+  test("annual billing avoids publishing a single headline percentage", () => {
+    const claim: Claim = getClaim("discount-annual")!;
+
+    expect(claim.statement).not.toMatch(/\d+\s*%/);
+  });
+
+  test("contract terms say the order form wins over a marketing page", () => {
+    const claim: Claim = getClaim("contract-order-form")!;
+
+    expect(claim.qualifier.toLowerCase()).toContain("order form governs");
+  });
+
+  test("scale is stated as architecture, not as an unverifiable headline number", () => {
+    for (const claim of getClaimsByCategory("scale")) {
+      expect(claim.statement).not.toMatch(/billions?\b/i);
+      expect(claim.statement).not.toMatch(/Fortune 500/i);
+      expect(claim.statement).not.toMatch(
+        /millions? of (log )?events per second/i,
+      );
+    }
+  });
+});
+
+describe("Retired claims", () => {
+  test("every retired claim explains itself and offers a replacement", () => {
+    for (const retired of RetiredClaims) {
+      expect(retired.example.length).toBeGreaterThan(0);
+      expect(retired.reason.length).toBeGreaterThan(20);
+      expect(retired.replacement.length).toBeGreaterThan(10);
+      expect(getClaim(retired.claimId)).not.toBeNull();
+    }
+  });
+
+  test("each retired pattern still matches the language it was written to catch", () => {
+    for (const retired of RetiredClaims) {
+      expect(retired.example).toMatch(retired.pattern);
+    }
+  });
+
+  test("no retired pattern matches its own approved replacement", () => {
+    for (const retired of RetiredClaims) {
+      expect(retired.replacement).not.toMatch(retired.pattern);
+    }
+  });
+
+  test("no retired pattern matches an approved claim statement", () => {
+    for (const retired of RetiredClaims) {
+      for (const claim of Claims) {
+        const matched: boolean = retired.pattern.test(claim.statement);
+        if (matched) {
+          throw new Error(
+            `Approved claim "${claim.id}" uses retired language "${retired.example}": ${claim.statement}`,
+          );
+        }
+      }
+    }
+  });
+
+  test("the retired list covers the contradictions this work was opened for", () => {
+    const examples: Array<string> = RetiredClaims.map(
+      (retired: RetiredClaim) => {
+        return retired.example;
+      },
+    );
+
+    expect(examples).toContain("99.99% uptime SLA");
+    expect(examples).toContain("guaranteed response times");
+    expect(examples).toContain("financial-backed reliability guarantee");
+  });
+});

--- a/Home/Tests/ClaimsGovernance.test.ts
+++ b/Home/Tests/ClaimsGovernance.test.ts
@@ -1,0 +1,218 @@
+import { RetiredClaim, RetiredClaims } from "../Utils/Claims";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Governance enforcement.
+ *
+ * The claims matrix is only worth something if the pages obey it. This suite
+ * walks every template under Home/Views and fails when retired language
+ * reappears — with the reason it was retired and the approved replacement, so
+ * whoever trips it does not have to go digging.
+ */
+
+const VIEWS_ROOT: string = path.join(__dirname, "..", "Views");
+
+interface ViewFile {
+  relativePath: string;
+  contents: string;
+}
+
+function collectViewFiles(directory: string): Array<ViewFile> {
+  const files: Array<ViewFile> = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath: string = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...collectViewFiles(fullPath));
+      continue;
+    }
+
+    if (!entry.name.endsWith(".ejs")) {
+      continue;
+    }
+
+    files.push({
+      relativePath: path.relative(VIEWS_ROOT, fullPath),
+      contents: fs.readFileSync(fullPath, "utf-8"),
+    });
+  }
+
+  return files;
+}
+
+const viewFiles: Array<ViewFile> = collectViewFiles(VIEWS_ROOT);
+
+interface Violation {
+  file: string;
+  line: number;
+  text: string;
+}
+
+function findViolations(pattern: RegExp): Array<Violation> {
+  const violations: Array<Violation> = [];
+
+  for (const file of viewFiles) {
+    const lines: Array<string> = file.contents.split("\n");
+
+    lines.forEach((line: string, index: number) => {
+      /*
+       * Reset lastIndex defensively — a global flag on a shared regex would
+       * otherwise make results depend on call order.
+       */
+      pattern.lastIndex = 0;
+      if (pattern.test(line)) {
+        violations.push({
+          file: file.relativePath,
+          line: index + 1,
+          text: line.trim(),
+        });
+      }
+    });
+  }
+
+  return violations;
+}
+
+function describeViolations(
+  retired: RetiredClaim,
+  violations: Array<Violation>,
+): string {
+  const locations: string = violations
+    .map((violation: Violation) => {
+      return `  - Views/${violation.file}:${violation.line}\n      ${violation.text}`;
+    })
+    .join("\n");
+
+  return [
+    "",
+    `Retired claim language found: "${retired.example}"`,
+    `Why it was retired: ${retired.reason}`,
+    `Approved replacement: ${retired.replacement}`,
+    `Governed by claim: ${retired.claimId} (see Home/Utils/Claims.ts)`,
+    "Found in:",
+    locations,
+    "",
+  ].join("\n");
+}
+
+describe("Claims governance over Home/Views", () => {
+  test("the scanner actually found templates to scan", () => {
+    expect(viewFiles.length).toBeGreaterThan(50);
+  });
+
+  test.each(
+    RetiredClaims.map((retired: RetiredClaim) => {
+      return [retired.example, retired] as [string, RetiredClaim];
+    }),
+  )(
+    'no template uses retired language: "%s"',
+    (_example: string, retired: RetiredClaim) => {
+      const violations: Array<Violation> = findViolations(retired.pattern);
+
+      if (violations.length > 0) {
+        throw new Error(describeViolations(retired, violations));
+      }
+
+      expect(violations).toHaveLength(0);
+    },
+  );
+});
+
+describe("Aligned pages state the governed numbers", () => {
+  function readView(relativePath: string): string {
+    return fs.readFileSync(path.join(VIEWS_ROOT, relativePath), "utf-8");
+  }
+
+  test("the enterprise overview quotes the SLA's Enterprise target", () => {
+    const contents: string = readView("enterprise-overview.ejs");
+
+    expect(contents).toContain("99.95%");
+    expect(contents).toContain("/legal/sla");
+  });
+
+  test("the pricing page does not advertise an SLA on the free plan", () => {
+    const contents: string = readView("pricing.ejs");
+
+    expect(contents).toContain("No uptime SLA (best effort)");
+    expect(contents).not.toContain("99.00% SLA");
+  });
+
+  test("the pricing page states paid uptime as a 99.9% target", () => {
+    const contents: string = readView("pricing.ejs");
+
+    expect(contents).toContain("99.9% uptime target");
+    expect(contents).not.toContain("99.95% SLA");
+  });
+
+  test("the demo page points self-hosting buyers at the canonical page", () => {
+    expect(readView("demo.ejs")).toContain("/enterprise/self-hosted");
+  });
+
+  test("the security page points at the canonical trust center", () => {
+    const contents: string = readView("security.ejs");
+
+    expect(contents).toContain("/trust#claims");
+    expect(contents).toContain("Trust Center");
+  });
+
+  test("the security page no longer calls internal targets an SLA", () => {
+    const contents: string = readView("security.ejs");
+
+    expect(contents).not.toContain("industry-standard SLAs");
+    expect(contents).toContain("internal remediation targets");
+  });
+
+  test("the trust center renders the governed claims matrix", () => {
+    const contents: string = readView("trust.ejs");
+
+    expect(contents).toContain("./Partials/claims-matrix");
+    expect(contents).toContain('href="#claims"');
+  });
+
+  test("the claims matrix partial reads from the Claims util, not hard-coded copy", () => {
+    const contents: string = readView("Partials/claims-matrix.ejs");
+
+    expect(contents).toContain("claimsMatrix.forEach");
+    expect(contents).toContain("claimStatuses.forEach");
+    expect(contents).toContain("claim.statement");
+    expect(contents).toContain("claim.qualifier");
+    expect(contents).toContain("claim.evidence");
+  });
+
+  test("the self-hosted page links back to the claims matrix", () => {
+    expect(readView("self-hosted.ejs")).toContain("/trust#claims");
+  });
+});
+
+describe("Compliance pages use the governed status words", () => {
+  function readView(relativePath: string): string {
+    return fs.readFileSync(path.join(VIEWS_ROOT, relativePath), "utf-8");
+  }
+
+  test.each([
+    ["21-cfr-part-11.ejs"],
+    ["annex-11.ejs"],
+    ["gamp-5.ejs"],
+    ["csa-star.ejs"],
+  ])("%s states an aligned status and links to the matrix", (file: string) => {
+    const contents: string = readView(file);
+
+    expect(contents).toContain("<strong>aligned</strong>");
+    expect(contents).toContain("/trust#claims");
+  });
+
+  test("the CSA STAR page describes a self-assessment, not a certification", () => {
+    const contents: string = readView("csa-star.ejs");
+
+    expect(contents).toContain("CAIQ self-assessment");
+    expect(contents).not.toContain("OneUptime is CSA STAR certified");
+  });
+
+  test("the ISO 27017 page explains it extends the ISO 27001 certificate", () => {
+    const contents: string = readView("iso-27017.ejs");
+
+    expect(contents).toContain("extension of our ISO/IEC 27001 certification");
+  });
+});

--- a/Home/Tests/Routes.test.ts
+++ b/Home/Tests/Routes.test.ts
@@ -1,0 +1,207 @@
+import { REDIRECT_PATHS, isRedirectPath } from "../Utils/Sitemap";
+import PageSEOConfig, { PageSEOData } from "../Utils/PageSEO";
+import fs from "fs";
+import path from "path";
+
+/*
+ * Route wiring. Booting the real Express app here would drag in the blog job
+ * and the database config, so these read the route table out of Routes.ts —
+ * enough to catch the failure that opened this work: a commercially important
+ * URL quietly returning 404 because nobody registered it.
+ */
+
+const routesSource: string = fs.readFileSync(
+  path.join(__dirname, "..", "Routes.ts"),
+  "utf-8",
+);
+
+/*
+ * Locate a route declaration and return the source that follows it, up to the
+ * next `app.get(`. Substring scanning rather than one big regex: the route
+ * table is thousands of lines, and a backtracking pattern over it is a hang
+ * waiting to happen.
+ */
+function bodyOfGetRoute(routePath: string): string | null {
+  const declaration: string = `"${routePath}"`;
+  let searchFrom: number = 0;
+
+  while (searchFrom < routesSource.length) {
+    const declarationIndex: number = routesSource.indexOf(
+      declaration,
+      searchFrom,
+    );
+
+    if (declarationIndex === -1) {
+      return null;
+    }
+
+    // The declaration must be the first argument of an app.get( call.
+    const preceding: string = routesSource
+      .slice(Math.max(0, declarationIndex - 40), declarationIndex)
+      .trim();
+
+    if (preceding.endsWith("app.get(")) {
+      const rest: string = routesSource.slice(
+        declarationIndex + declaration.length,
+      );
+      const nextRouteIndex: number = rest.indexOf("app.get(");
+      return nextRouteIndex === -1 ? rest : rest.slice(0, nextRouteIndex);
+    }
+
+    searchFrom = declarationIndex + declaration.length;
+  }
+
+  return null;
+}
+
+function hasGetRoute(routePath: string): boolean {
+  return bodyOfGetRoute(routePath) !== null;
+}
+
+function redirectTargetOf(routePath: string): string | null {
+  const body: string | null = bodyOfGetRoute(routePath);
+
+  if (!body) {
+    return null;
+  }
+
+  const match: RegExpMatchArray | null = body.match(
+    /res\.redirect\((?:301,\s*)?"([^"]+)"\)/,
+  );
+
+  return match ? match[1]! : null;
+}
+
+const PERMANENT_REDIRECT: RegExp = /res\.redirect\(301,/;
+
+function redirectsPermanently(routePath: string): boolean {
+  const body: string | null = bodyOfGetRoute(routePath);
+  return Boolean(body && PERMANENT_REDIRECT.test(body));
+}
+
+describe("Self-hosted routes", () => {
+  test("the canonical self-hosted page is registered", () => {
+    expect(hasGetRoute("/enterprise/self-hosted")).toBe(true);
+    expect(routesSource).toContain(`${"${ViewsPath}"}/self-hosted.ejs`);
+  });
+
+  test("the page is rendered with the self-hosted content model", () => {
+    expect(routesSource).toContain("selfHosted: getSelfHostedContent()");
+  });
+
+  test.each([["/self-hosted"], ["/self-hosting"], ["/on-premise"]])(
+    "%s permanently redirects to the canonical page",
+    (routePath: string) => {
+      expect(hasGetRoute(routePath)).toBe(true);
+      expect(redirectTargetOf(routePath)).toBe("/enterprise/self-hosted");
+    },
+  );
+
+  test("the short self-hosted URLs redirect permanently, not temporarily", () => {
+    for (const routePath of ["/self-hosted", "/self-hosting", "/on-premise"]) {
+      expect(redirectsPermanently(routePath)).toBe(true);
+    }
+  });
+});
+
+describe("Trust center routes", () => {
+  test("/trust renders the claims matrix data", () => {
+    expect(hasGetRoute("/trust")).toBe(true);
+    expect(routesSource).toContain("claimsMatrix: getClaimsMatrix()");
+    expect(routesSource).toContain("claimStatuses: ClaimStatuses");
+    expect(routesSource).toContain(
+      "claimsUnderReviewCount: getClaimsNeedingReview().length",
+    );
+  });
+
+  test.each([["/security"], ["/security-center"], ["/trust-center"]])(
+    "%s redirects to the canonical trust center",
+    (routePath: string) => {
+      expect(hasGetRoute(routePath)).toBe(true);
+      expect(redirectTargetOf(routePath)).toBe("/trust");
+    },
+  );
+
+  test("the claims matrix is served as JSON for machines", () => {
+    expect(hasGetRoute("/data/claims.json")).toBe(true);
+    expect(routesSource).toContain("statuses: ClaimStatuses");
+  });
+});
+
+describe("Sitemap hygiene", () => {
+  test("every redirect-only path is excluded from the sitemap", () => {
+    for (const routePath of [
+      "/self-hosted",
+      "/self-hosting",
+      "/on-premise",
+      "/security",
+      "/security-center",
+      "/trust-center",
+    ]) {
+      expect(isRedirectPath(routePath)).toBe(true);
+    }
+  });
+
+  test("canonical pages are not excluded", () => {
+    for (const routePath of [
+      "/enterprise/self-hosted",
+      "/trust",
+      "/pricing",
+      "/enterprise/overview",
+    ]) {
+      expect(isRedirectPath(routePath)).toBe(false);
+    }
+  });
+
+  test("pre-existing product redirects are excluded too", () => {
+    // These were already redirects; they should not have been in the sitemap.
+    expect(REDIRECT_PATHS.has("/status-page")).toBe(true);
+    expect(REDIRECT_PATHS.has("/on-call")).toBe(true);
+  });
+
+  test("every excluded path is an actual redirect route", () => {
+    for (const routePath of Array.from(REDIRECT_PATHS)) {
+      expect(redirectTargetOf(routePath)).not.toBeNull();
+    }
+  });
+
+  test("the self-hosted page is prioritised in the sitemap config", () => {
+    const sitemapSource: string = fs.readFileSync(
+      path.join(__dirname, "..", "Utils", "Sitemap.ts"),
+      "utf-8",
+    );
+
+    expect(sitemapSource).toContain(
+      '"/enterprise/self-hosted": { priority: 0.9, changefreq: "weekly" }',
+    );
+  });
+});
+
+describe("SEO registration", () => {
+  test("both new canonical pages resolve their own SEO data", () => {
+    for (const pagePath of ["/enterprise/self-hosted", "/trust"]) {
+      const seo: PageSEOData | undefined = PageSEOConfig[pagePath];
+
+      expect(seo).toBeDefined();
+      expect(seo!.canonicalPath).toBe(pagePath);
+      expect(seo!.title.length).toBeGreaterThan(10);
+      expect(seo!.description.length).toBeGreaterThan(50);
+    }
+  });
+
+  test("the trust center describes itself as the canonical claims source", () => {
+    const seo: PageSEOData = PageSEOConfig["/trust"]!;
+
+    expect(seo.description.toLowerCase()).toContain("claims matrix");
+  });
+
+  test("no two pages claim the same canonical path", () => {
+    const canonicalPaths: Array<string> = Object.values(PageSEOConfig).map(
+      (seo: PageSEOData) => {
+        return seo.canonicalPath;
+      },
+    );
+
+    expect(new Set(canonicalPaths).size).toBe(canonicalPaths.length);
+  });
+});

--- a/Home/Tests/SelfHosted.test.ts
+++ b/Home/Tests/SelfHosted.test.ts
@@ -1,0 +1,335 @@
+import {
+  AirGapStep,
+  AirGapSteps,
+  ArchitectureComponent,
+  ArchitectureTier,
+  ArchitectureTiers,
+  AvailabilityControls,
+  DeploymentModel,
+  DeploymentModels,
+  DisasterRecoveryPractices,
+  HardenedImageFeatures,
+  HelmDocs,
+  InfrastructureRequirements,
+  RequirementGroup,
+  ResilienceControl,
+  ResponsibilityRow,
+  SelfHostedContent,
+  SelfHostedFaq,
+  SelfHostedFaqs,
+  SharedResponsibilities,
+  SizingTier,
+  SizingTiers,
+  SupportBoundaries,
+  SupportTierRow,
+  UpgradeResponsibilities,
+  getSelfHostedContent,
+} from "../Utils/SelfHosted";
+import PageSEOConfig, { PageSEOData } from "../Utils/PageSEO";
+
+describe("SelfHosted content model", () => {
+  test("covers every deployment model an enterprise buyer will ask about", () => {
+    const keys: Array<string> = DeploymentModels.map(
+      (model: DeploymentModel) => {
+        return model.key;
+      },
+    );
+
+    expect(keys).toEqual([
+      "kubernetes",
+      "docker-compose",
+      "private-cloud",
+      "cloud",
+    ]);
+  });
+
+  test("exactly one deployment model is recommended, and it is Kubernetes", () => {
+    const recommended: Array<DeploymentModel> = DeploymentModels.filter(
+      (model: DeploymentModel) => {
+        return model.recommended;
+      },
+    );
+
+    expect(recommended).toHaveLength(1);
+    expect(recommended[0]!.key).toBe("kubernetes");
+  });
+
+  test("every deployment model states who owns infrastructure and upgrades", () => {
+    for (const model of DeploymentModels) {
+      expect(model.name.length).toBeGreaterThan(0);
+      expect(model.tagline.length).toBeGreaterThan(0);
+      expect(model.bestFor.length).toBeGreaterThan(0);
+      expect(model.infrastructure.length).toBeGreaterThan(0);
+      expect(model.upgrades.length).toBeGreaterThan(0);
+      expect(model.highlights.length).toBeGreaterThanOrEqual(3);
+      expect(model.docsUrl.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("the docker-compose model is honest about not being production-grade", () => {
+    const compose: DeploymentModel | undefined = DeploymentModels.find(
+      (model: DeploymentModel) => {
+        return model.key === "docker-compose";
+      },
+    );
+
+    expect(compose).toBeDefined();
+    expect(compose!.recommended).toBe(false);
+    expect(compose!.highlights.join(" ")).toContain(
+      "Not recommended for production",
+    );
+  });
+
+  test("the reference architecture covers edge, application, data, and ingest", () => {
+    const keys: Array<string> = ArchitectureTiers.map(
+      (tier: ArchitectureTier) => {
+        return tier.key;
+      },
+    );
+
+    expect(keys).toEqual(["edge", "application", "data", "ingest"]);
+  });
+
+  test("every architecture component describes how it scales", () => {
+    for (const tier of ArchitectureTiers) {
+      expect(tier.components.length).toBeGreaterThan(0);
+      for (const component of tier.components) {
+        expect(component.name.length).toBeGreaterThan(0);
+        expect(component.description.length).toBeGreaterThan(0);
+        expect(component.scaling.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("the architecture names the tiers the Helm chart actually deploys", () => {
+    const componentNames: string = ArchitectureTiers.flatMap(
+      (tier: ArchitectureTier) => {
+        return tier.components.map((component: ArchitectureComponent) => {
+          return component.name;
+        });
+      },
+    ).join(" | ");
+
+    expect(componentNames).toContain("Worker");
+    expect(componentNames).toContain("Telemetry writer");
+    expect(componentNames).toContain("Probes");
+    expect(componentNames).toContain("PostgreSQL");
+    expect(componentNames).toContain("ClickHouse");
+    expect(componentNames).toContain("Redis");
+    expect(componentNames).toContain("PgBouncer");
+  });
+
+  test("sizing tiers go from evaluation to scale and each is fully specified", () => {
+    expect(
+      SizingTiers.map((tier: SizingTier) => {
+        return tier.key;
+      }),
+    ).toEqual(["evaluation", "production", "scale"]);
+
+    for (const tier of SizingTiers) {
+      expect(tier.workload.length).toBeGreaterThan(0);
+      expect(tier.nodes.length).toBeGreaterThan(0);
+      expect(tier.cpu.length).toBeGreaterThan(0);
+      expect(tier.memory.length).toBeGreaterThan(0);
+      expect(tier.storage.length).toBeGreaterThan(0);
+      expect(tier.notes.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("infrastructure requirements cover kubernetes, networking, and data stores", () => {
+    const titles: Array<string> = InfrastructureRequirements.map(
+      (group: RequirementGroup) => {
+        return group.title;
+      },
+    );
+
+    expect(titles).toContain("Kubernetes");
+    expect(titles).toContain("Networking");
+    expect(titles).toContain("Data stores");
+
+    for (const group of InfrastructureRequirements) {
+      expect(group.items.length).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  test("availability controls point at real chart settings", () => {
+    expect(AvailabilityControls.length).toBeGreaterThanOrEqual(5);
+
+    const settings: string = AvailabilityControls.map(
+      (control: ResilienceControl) => {
+        return control.setting;
+      },
+    ).join(" ");
+
+    expect(settings).toContain("postgresOperator.cnpg.enabled");
+    expect(settings).toContain("clickhouseOperator.altinity.enabled");
+    expect(settings).toContain("podDisruptionBudget.enabled");
+    expect(settings).toContain("pgbouncer.enabled");
+  });
+
+  test("disaster recovery guidance tells the customer the RTO and RPO are theirs", () => {
+    const text: string = DisasterRecoveryPractices.join(" ");
+    expect(text).toContain("RTO");
+    expect(text).toContain("RPO");
+    expect(text).toContain("Test restores");
+  });
+
+  test("air-gap steps cover registry, update check, DNS, and upgrades", () => {
+    const settings: string = AirGapSteps.map((step: AirGapStep) => {
+      return `${step.title} ${step.setting}`;
+    }).join(" ");
+
+    expect(settings).toContain("image.registry");
+    expect(settings).toContain("updateCheck.disabled");
+    expect(settings).toContain("dnsConfig");
+    expect(settings).toContain("helm upgrade");
+  });
+
+  test("hardened image guidance names the enterprise-edition chart value", () => {
+    expect(HardenedImageFeatures.join(" ")).toContain("enterprise-edition");
+  });
+
+  test("upgrade responsibilities split every area between us and the customer", () => {
+    expect(UpgradeResponsibilities.length).toBeGreaterThanOrEqual(4);
+
+    for (const row of UpgradeResponsibilities) {
+      expect(row.area.length).toBeGreaterThan(0);
+      expect(row.oneuptime.length).toBeGreaterThan(0);
+      expect(row.customer.length).toBeGreaterThan(0);
+    }
+
+    const areas: Array<string> = UpgradeResponsibilities.map(
+      (row: ResponsibilityRow) => {
+        return row.area;
+      },
+    );
+    expect(areas).toContain("Breaking changes");
+    expect(areas).toContain("Database migrations");
+    expect(areas).toContain("Rollback");
+  });
+
+  test("shared responsibility covers infrastructure, availability, and compliance", () => {
+    const areas: Array<string> = SharedResponsibilities.map(
+      (row: ResponsibilityRow) => {
+        return row.area;
+      },
+    );
+
+    expect(areas).toContain("Infrastructure");
+    expect(areas).toContain("Availability");
+    expect(areas).toContain("Compliance");
+  });
+
+  test("support boundaries state what is NOT included, not just what is", () => {
+    expect(
+      SupportBoundaries.map((tier: SupportTierRow) => {
+        return tier.key;
+      }),
+    ).toEqual(["community", "enterprise"]);
+
+    for (const tier of SupportBoundaries) {
+      expect(tier.included.length).toBeGreaterThanOrEqual(3);
+      expect(tier.excluded.length).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  test("enterprise support explicitly excludes the cloud SLA from self-hosted uptime", () => {
+    const enterprise: SupportTierRow | undefined = SupportBoundaries.find(
+      (tier: SupportTierRow) => {
+        return tier.key === "enterprise";
+      },
+    );
+
+    expect(enterprise).toBeDefined();
+    expect(enterprise!.excluded.join(" ")).toContain(
+      "not covered by the OneUptime Cloud SLA",
+    );
+  });
+
+  test("the FAQ answers the uptime-responsibility question directly", () => {
+    const uptimeFaq: SelfHostedFaq | undefined = SelfHostedFaqs.find(
+      (faq: SelfHostedFaq) => {
+        return faq.question.includes("responsible for uptime");
+      },
+    );
+
+    expect(uptimeFaq).toBeDefined();
+    expect(uptimeFaq!.answer).toContain("You are.");
+  });
+
+  test("the FAQ describes what an architecture assessment covers", () => {
+    const assessmentFaq: SelfHostedFaq | undefined = SelfHostedFaqs.find(
+      (faq: SelfHostedFaq) => {
+        return faq.question.includes("architecture assessment");
+      },
+    );
+
+    expect(assessmentFaq).toBeDefined();
+    expect(assessmentFaq!.answer.length).toBeGreaterThan(80);
+  });
+
+  test("every helm doc link points at the oneuptime repository", () => {
+    for (const url of Object.values(HelmDocs)) {
+      expect(url).toMatch(/^https:\/\/github\.com\/OneUptime\/oneuptime/);
+    }
+  });
+
+  test("getSelfHostedContent returns every section the page renders", () => {
+    const content: SelfHostedContent = getSelfHostedContent();
+
+    expect(content.deploymentModels).toBe(DeploymentModels);
+    expect(content.architectureTiers).toBe(ArchitectureTiers);
+    expect(content.sizingTiers).toBe(SizingTiers);
+    expect(content.infrastructureRequirements).toBe(InfrastructureRequirements);
+    expect(content.availabilityControls).toBe(AvailabilityControls);
+    expect(content.disasterRecoveryPractices).toBe(DisasterRecoveryPractices);
+    expect(content.airGapSteps).toBe(AirGapSteps);
+    expect(content.hardenedImageFeatures).toBe(HardenedImageFeatures);
+    expect(content.upgradeResponsibilities).toBe(UpgradeResponsibilities);
+    expect(content.sharedResponsibilities).toBe(SharedResponsibilities);
+    expect(content.supportBoundaries).toBe(SupportBoundaries);
+    expect(content.faqs).toBe(SelfHostedFaqs);
+    expect(content.helmDocs).toBe(HelmDocs);
+  });
+});
+
+describe("SelfHosted page SEO", () => {
+  test("the canonical self-hosted route is registered for SEO and markdown", () => {
+    const seo: PageSEOData | undefined =
+      PageSEOConfig["/enterprise/self-hosted"];
+
+    expect(seo).toBeDefined();
+    expect(seo!.canonicalPath).toBe("/enterprise/self-hosted");
+    expect(seo!.pageType).toBe("enterprise");
+  });
+
+  test("the title and description carry the terms buyers search for", () => {
+    const seo: PageSEOData = PageSEOConfig["/enterprise/self-hosted"]!;
+
+    expect(seo.title.toLowerCase()).toContain("self-hosted");
+    expect(seo.description.toLowerCase()).toContain("kubernetes");
+    expect(seo.description.toLowerCase()).toContain("air-gapped");
+    expect(seo.description.toLowerCase()).toContain("data residency");
+  });
+
+  test("breadcrumbs place the page under Enterprise", () => {
+    const seo: PageSEOData = PageSEOConfig["/enterprise/self-hosted"]!;
+
+    expect(
+      seo.breadcrumbs.map((crumb: { name: string }) => {
+        return crumb.name;
+      }),
+    ).toEqual(["Home", "Enterprise", "Self-Hosted"]);
+  });
+
+  test("the structured data lists the deployment capabilities buyers evaluate", () => {
+    const features: Array<string> =
+      PageSEOConfig["/enterprise/self-hosted"]!.softwareApplication!.features;
+    const joined: string = features.join(" ").toLowerCase();
+
+    expect(joined).toContain("helm");
+    expect(joined).toContain("air-gapped");
+    expect(joined).toContain("high availability");
+    expect(joined).toContain("hardened");
+  });
+});

--- a/Home/Tests/ViewRendering.test.ts
+++ b/Home/Tests/ViewRendering.test.ts
@@ -1,0 +1,320 @@
+import {
+  ArchitectureTier,
+  AvailabilityControls,
+  DeploymentModel,
+  DeploymentModels,
+  ResilienceControl,
+  SelfHostedFaq,
+  SelfHostedFaqs,
+  SizingTier,
+  SizingTiers,
+  SupportBoundaries,
+  SupportTierRow,
+  getSelfHostedContent,
+} from "../Utils/SelfHosted";
+import {
+  Claim,
+  ClaimStatusDefinition,
+  ClaimStatuses,
+  Claims,
+  getClaimsMatrix,
+  getClaimsNeedingReview,
+} from "../Utils/Claims";
+import { getPageSEO, PageSEOData } from "../Utils/PageSEO";
+import ejs from "ejs";
+import path from "path";
+
+/*
+ * Render the real templates. Unit tests over the data model cannot tell you
+ * that a template renders at all, that its loops are wired to the right
+ * fields, or that a section did not silently disappear during an edit.
+ */
+
+const VIEWS_ROOT: string = path.join(__dirname, "..", "Views");
+const HOME_URL: string = "https://oneuptime.com";
+
+type RenderFunction = (
+  templateFileName: string,
+  locals: Record<string, unknown>,
+) => Promise<string>;
+
+const render: RenderFunction = async (
+  templateFileName: string,
+  locals: Record<string, unknown>,
+): Promise<string> => {
+  return (await ejs.renderFile(
+    path.join(VIEWS_ROOT, templateFileName),
+    locals,
+    { views: [VIEWS_ROOT] },
+  )) as string;
+};
+
+function seoFor(pagePath: string): PageSEOData & { fullCanonicalUrl: string } {
+  const seo: PageSEOData = getPageSEO(pagePath);
+  return { ...seo, fullCanonicalUrl: `${HOME_URL}${seo.canonicalPath}` };
+}
+
+describe("self-hosted.ejs", () => {
+  let html: string = "";
+
+  beforeAll(async () => {
+    html = await render("self-hosted.ejs", {
+      support: false,
+      enableGoogleTagManager: false,
+      footerCards: true,
+      cta: false,
+      blackLogo: false,
+      requestDemoCta: true,
+      selfHosted: getSelfHostedContent(),
+      seo: seoFor("/enterprise/self-hosted"),
+      homeUrl: HOME_URL,
+    });
+  });
+
+  test("renders a complete page", () => {
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("</html>");
+    expect(html.length).toBeGreaterThan(10000);
+  });
+
+  test("carries the canonical title and description", () => {
+    expect(html).toContain("Self-Hosted OneUptime");
+    expect(html).toContain("https://oneuptime.com/enterprise/self-hosted");
+  });
+
+  test("renders every section the issue asked for", () => {
+    for (const sectionId of [
+      "deployment-models",
+      "reference-architecture",
+      "requirements",
+      "availability",
+      "upgrades",
+      "air-gapped",
+      "hardened-images",
+      "data-residency",
+      "responsibilities",
+      "support",
+      "architecture-assessment",
+      "faq",
+    ]) {
+      expect(html).toContain(`id="${sectionId}"`);
+    }
+  });
+
+  test("renders every deployment model with its highlights", () => {
+    for (const model of DeploymentModels) {
+      expect(html).toContain(model.name);
+      expect(html).toContain(model.infrastructure);
+      for (const highlight of model.highlights) {
+        expect(html).toContain(escapeForHtml(highlight));
+      }
+    }
+  });
+
+  test("marks Kubernetes as the recommended deployment", () => {
+    expect(html).toContain("Recommended");
+
+    const kubernetes: DeploymentModel = DeploymentModels.find(
+      (model: DeploymentModel) => {
+        return model.key === "kubernetes";
+      },
+    )!;
+    expect(html).toContain(kubernetes.tagline);
+  });
+
+  test("renders every architecture tier and component", () => {
+    for (const tier of getSelfHostedContent()
+      .architectureTiers as Array<ArchitectureTier>) {
+      expect(html).toContain(`>${tier.name}</h3>`);
+      for (const component of tier.components) {
+        expect(html).toContain(escapeForHtml(component.name));
+        expect(html).toContain(escapeForHtml(component.scaling));
+      }
+    }
+  });
+
+  test("renders the sizing table", () => {
+    for (const tier of SizingTiers as Array<SizingTier>) {
+      expect(html).toContain(tier.name);
+      expect(html).toContain(escapeForHtml(tier.nodes));
+    }
+  });
+
+  test("renders the availability controls with their chart settings", () => {
+    for (const control of AvailabilityControls as Array<ResilienceControl>) {
+      expect(html).toContain(control.title);
+      expect(html).toContain(escapeForHtml(control.setting));
+    }
+  });
+
+  test("renders both support tiers including what is NOT included", () => {
+    for (const tier of SupportBoundaries as Array<SupportTierRow>) {
+      expect(html).toContain(tier.name);
+      for (const excluded of tier.excluded) {
+        expect(html).toContain(escapeForHtml(excluded));
+      }
+    }
+    expect(html).toContain("Not included");
+  });
+
+  test("renders the FAQ", () => {
+    for (const faq of SelfHostedFaqs as Array<SelfHostedFaq>) {
+      expect(html).toContain(escapeForHtml(faq.question));
+    }
+  });
+
+  test("offers the architecture assessment as the primary conversion path", () => {
+    expect(html).toContain("Book an architecture assessment");
+    expect(html).toContain('href="/enterprise/demo"');
+    expect(html).toContain("enterprise@oneuptime.com");
+  });
+
+  test("keeps wide content inside horizontally scrollable containers", () => {
+    // Tables must never make the page body scroll sideways on a phone.
+    const tableCount: number = (html.match(/<table/g) || []).length;
+    const scrollContainerCount: number = (html.match(/sh-scroll/g) || [])
+      .length;
+
+    expect(tableCount).toBeGreaterThanOrEqual(3);
+    expect(scrollContainerCount).toBeGreaterThanOrEqual(tableCount);
+  });
+
+  test("does not use retired claim language", () => {
+    expect(html).not.toMatch(/99\.99\s*%\s*(?:uptime\s*)?SLA/i);
+    expect(html).not.toMatch(/guaranteed\s+response/i);
+  });
+
+  test("states plainly that self-hosted uptime is the customer's", () => {
+    expect(html).toContain("does not extend to infrastructure you operate");
+  });
+});
+
+describe("trust.ejs with the claims matrix", () => {
+  let html: string = "";
+
+  beforeAll(async () => {
+    html = await render("trust.ejs", {
+      footerCards: true,
+      support: false,
+      enableGoogleTagManager: false,
+      cta: true,
+      blackLogo: false,
+      requestDemoCta: false,
+      claimStatuses: ClaimStatuses,
+      claimsMatrix: getClaimsMatrix(),
+      claimsUnderReviewCount: getClaimsNeedingReview().length,
+      seo: seoFor("/trust"),
+      homeUrl: HOME_URL,
+    });
+  });
+
+  test("renders a complete page with the claims section", () => {
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain('id="claims"');
+    expect(html).toContain("Governed claims");
+  });
+
+  test("publishes the definition of every status word", () => {
+    for (const status of ClaimStatuses as Array<ClaimStatusDefinition>) {
+      expect(html).toContain(status.label);
+      expect(html).toContain(escapeForHtml(status.definition));
+    }
+  });
+
+  test("renders every claim with its statement, qualifier and evidence", () => {
+    for (const claim of Claims as Array<Claim>) {
+      expect(html).toContain(escapeForHtml(claim.subject));
+      expect(html).toContain(escapeForHtml(claim.statement));
+      expect(html).toContain(escapeForHtml(claim.qualifier));
+      expect(html).toContain(escapeForHtml(claim.evidence));
+    }
+  });
+
+  test("gives every category its own anchor", () => {
+    for (const group of getClaimsMatrix()) {
+      expect(html).toContain(`id="claims-${group.category.key}"`);
+    }
+  });
+
+  test("flags claims whose evidence is still under review", () => {
+    expect(getClaimsNeedingReview().length).toBeGreaterThan(0);
+    expect(html).toContain("Evidence under review");
+  });
+
+  test("links to the machine-readable matrix", () => {
+    expect(html).toContain("/data/claims.json");
+  });
+
+  test("does not use retired claim language", () => {
+    expect(html).not.toMatch(/99\.99\s*%\s*(?:uptime\s*)?SLA/i);
+    expect(html).not.toMatch(/certified\s+compliant\s+with/i);
+  });
+});
+
+describe("aligned marketing pages still render", () => {
+  test("enterprise-overview.ejs renders with governed uptime language", async () => {
+    const html: string = await render("enterprise-overview.ejs", {
+      support: false,
+      enableGoogleTagManager: false,
+      footerCards: true,
+      cta: true,
+      blackLogo: false,
+      requestDemoCta: true,
+      reviewsList1: [],
+      reviewsList2: [],
+      reviewsList3: [],
+      seo: seoFor("/enterprise/overview"),
+      homeUrl: HOME_URL,
+    });
+
+    expect(html).toContain("99.95%");
+    expect(html).not.toMatch(/99\.99\s*%\s*(?:uptime\s*)?SLA/i);
+    expect(html).toContain("/legal/sla");
+  });
+
+  test("demo.ejs renders and routes self-hosting buyers to the new page", async () => {
+    const html: string = await render("demo.ejs", {
+      support: false,
+      enableGoogleTagManager: false,
+      footerCards: false,
+      cta: false,
+      blackLogo: true,
+      requestDemoCta: false,
+      reviewsList1: [],
+      reviewsList2: [],
+      reviewsList3: [],
+      seo: seoFor("/enterprise/demo"),
+      homeUrl: HOME_URL,
+    });
+
+    expect(html).toContain("/enterprise/self-hosted");
+    expect(html).not.toMatch(/15\s*minutes?\s+for\s+critical/i);
+  });
+
+  test("the navigation and footer surface the new pages", async () => {
+    const nav: string = await render("nav.ejs", { homeUrl: HOME_URL });
+    const footer: string = await render("footer.ejs", {
+      footerCards: false,
+      cta: false,
+      homeUrl: HOME_URL,
+    });
+
+    expect(nav).toContain('href="/enterprise/self-hosted"');
+    expect(nav).toContain('href="/trust"');
+    expect(footer).toContain('href="/enterprise/self-hosted"');
+    expect(footer).toContain('href="/trust"');
+  });
+});
+
+/*
+ * EJS escapes `<%= %>` output, so assertions against rendered HTML have to
+ * compare against the escaped form of the source string.
+ */
+function escapeForHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&#34;")
+    .replace(/'/g, "&#39;");
+}

--- a/Home/Utils/AIDiscovery.ts
+++ b/Home/Utils/AIDiscovery.ts
@@ -91,6 +91,7 @@ const machineReadableSection: (baseUrl: string) => Array<string> = (
     `- [Products (JSON)](${baseUrl}/data/products.json): every product with description and feature list`,
     `- [Comparisons (JSON)](${baseUrl}/data/compare.json): OneUptime vs other tools`,
     `- [Customer reviews (JSON)](${baseUrl}/data/reviews.json)`,
+    `- [Governed claims matrix (JSON)](${baseUrl}/data/claims.json): every published claim about service levels, support, compliance, encryption, deployment, migration, scale, discounts, and contract terms, with its status, qualifier, evidence, and source document`,
     `- [Blog RSS feed](${baseUrl}/blog/rss.xml): every post also has a raw markdown variant at /blog/post/<post>/markdown`,
   ];
 };
@@ -140,6 +141,21 @@ export function generateLlmsTxt(
       `- [${shortTitle(seo)}](${baseUrl}${seo.canonicalPath}.md): ${seo.description}`,
     );
   }
+
+  lines.push("");
+  lines.push("## Enterprise");
+  lines.push("");
+  for (const seo of getPagesByType("enterprise")) {
+    lines.push(
+      `- [${shortTitle(seo)}](${baseUrl}${seo.canonicalPath}.md): ${seo.description}`,
+    );
+  }
+  lines.push(
+    `- [Trust Center](${baseUrl}/trust): certifications, attestations, and the governed claims matrix`,
+  );
+  lines.push(
+    `- [Claims matrix (JSON)](${baseUrl}/data/claims.json): every published claim with its status, qualifier, evidence, and source document`,
+  );
 
   lines.push("");
   lines.push("## Compare OneUptime");

--- a/Home/Utils/Claims.ts
+++ b/Home/Utils/Claims.ts
@@ -1,0 +1,1093 @@
+/*
+ * Governed claims matrix.
+ *
+ * This file is the single source of truth for what OneUptime marketing pages
+ * are allowed to say about uptime, support, compliance, encryption,
+ * deployment, migration, scale, discounts, and contract terms.
+ *
+ * Why it exists: several statements on the site read as contractual
+ * commitments ("99.99% uptime SLA", "guaranteed response times") while the
+ * documents that actually bind us — /legal/sla, /legal/security, /legal/dpa —
+ * say something different. A buyer who notices that stops trusting everything
+ * else on the page. So every claim now carries:
+ *
+ *   - a status from a fixed vocabulary (see ClaimStatuses below),
+ *   - the exact sentence marketing may use,
+ *   - the qualifier that must travel with it,
+ *   - a link to the document that makes it true.
+ *
+ * Rules for editing this file:
+ *
+ *   1. A claim's `statement` is the approved language. Pages should not
+ *      paraphrase it into something stronger.
+ *   2. Never upgrade a `status` without the evidence that justifies the new
+ *      word. "In progress" does not become "Certified" because a deal needs it.
+ *   3. Anything with `reviewRequired: true` is waiting on legal or security
+ *      sign-off. It is still published as written, but the wording is
+ *      deliberately conservative until the reviewer confirms the evidence.
+ *   4. RetiredClaims and BannedClaimPatterns below are enforced by
+ *      Tests/ClaimsGovernance.test.ts, which fails the build if retired
+ *      language reappears anywhere in Home/Views.
+ */
+
+export type ClaimStatusKey =
+  | "certified"
+  | "attested"
+  | "compliant"
+  | "aligned"
+  | "in-progress"
+  | "customer-configurable";
+
+export type ClaimCategoryKey =
+  | "sla"
+  | "support"
+  | "compliance"
+  | "encryption"
+  | "deployment"
+  | "migration"
+  | "scale"
+  | "discounts"
+  | "contract";
+
+export type ClaimScope = "cloud" | "self-hosted" | "both";
+
+export interface ClaimStatusDefinition {
+  key: ClaimStatusKey;
+  label: string;
+  // What the word means. This is the definition published on the trust center.
+  definition: string;
+  // The test a claim must pass before it may carry this status.
+  evidenceBar: string;
+  // Tailwind colour family used for the badge.
+  color: "emerald" | "blue" | "violet" | "slate" | "amber" | "cyan";
+}
+
+export const ClaimStatuses: Array<ClaimStatusDefinition> = [
+  {
+    key: "certified",
+    label: "Certified",
+    definition:
+      "An accredited certification body audited us against a published scheme and issued a certificate.",
+    evidenceBar:
+      "A named certification body, a certificate number, and a scope statement.",
+    color: "emerald",
+  },
+  {
+    key: "attested",
+    label: "Attested",
+    definition:
+      "An independent third party examined our controls and issued a report or opinion. Certificates are not issued under these schemes.",
+    evidenceBar:
+      "A third-party report we can share, in full or in summary, under NDA.",
+    color: "blue",
+  },
+  {
+    key: "compliant",
+    label: "Compliant",
+    definition:
+      "We meet a legal or regulatory obligation that has no certification scheme. The commitment lives in a contract, not a certificate.",
+    evidenceBar:
+      "A signed agreement — DPA, BAA, or order form — that states the obligation.",
+    color: "violet",
+  },
+  {
+    key: "aligned",
+    label: "Aligned",
+    definition:
+      "We build and operate to a framework's controls, but no independent certificate or attestation exists for it. Includes self-assessments and regimes where the customer, not the vendor, is the one certified.",
+    evidenceBar:
+      "Control documentation or a self-assessment we will hand over on request.",
+    color: "slate",
+  },
+  {
+    key: "in-progress",
+    label: "In progress",
+    definition:
+      "Work is underway and not finished. This status must never be presented as achieved, and no date may be promised on a marketing page.",
+    evidenceBar: "An owner and a live workstream. Nothing else.",
+    color: "amber",
+  },
+  {
+    key: "customer-configurable",
+    label: "Customer-configurable",
+    definition:
+      "We ship the capability. Whether it is switched on, and how it is configured, is the customer's decision — which is the normal case for self-hosted deployments.",
+    evidenceBar:
+      "A documented setting, chart value, or product control the customer can verify.",
+    color: "cyan",
+  },
+];
+
+export interface ClaimCategory {
+  key: ClaimCategoryKey;
+  name: string;
+  description: string;
+  // The document that governs this category.
+  governingDocument: string;
+  governingDocumentUrl: string;
+}
+
+export const ClaimCategories: Array<ClaimCategory> = [
+  {
+    key: "sla",
+    name: "Service levels",
+    description:
+      "Uptime targets, how availability is measured, and what you get if we miss.",
+    governingDocument: "Service Level Agreement",
+    governingDocumentUrl: "/legal/sla",
+  },
+  {
+    key: "support",
+    name: "Support",
+    description:
+      "First-response targets by severity, support hours, and what a support agreement covers.",
+    governingDocument: "Service Level Agreement, section 5",
+    governingDocumentUrl: "/legal/sla",
+  },
+  {
+    key: "compliance",
+    name: "Compliance",
+    description:
+      "Certifications, attestations, and frameworks — each with the evidence behind it.",
+    governingDocument: "Security at OneUptime",
+    governingDocumentUrl: "/legal/security",
+  },
+  {
+    key: "encryption",
+    name: "Encryption and data protection",
+    description:
+      "How data is protected in transit and at rest, and who holds the keys.",
+    governingDocument: "Security at OneUptime",
+    governingDocumentUrl: "/legal/security",
+  },
+  {
+    key: "deployment",
+    name: "Deployment and data residency",
+    description:
+      "Where OneUptime can run, and where your data physically sits.",
+    governingDocument: "Self-hosted deployment guide",
+    governingDocumentUrl: "/enterprise/self-hosted",
+  },
+  {
+    key: "migration",
+    name: "Migration and portability",
+    description:
+      "Getting data in, getting it out, and moving between deployment models.",
+    governingDocument: "Data Processing Addendum",
+    governingDocumentUrl: "/legal/dpa",
+  },
+  {
+    key: "scale",
+    name: "Scale",
+    description:
+      "What the platform is built to handle, stated as architecture rather than as a headline number.",
+    governingDocument: "Production readiness checklist",
+    governingDocumentUrl: "/enterprise/self-hosted",
+  },
+  {
+    key: "discounts",
+    name: "Discounts",
+    description: "Published discounts, and which ones need a conversation.",
+    governingDocument: "Pricing",
+    governingDocumentUrl: "/pricing",
+  },
+  {
+    key: "contract",
+    name: "Contract terms",
+    description:
+      "What is standard, what is negotiable, and what has to be in an order form.",
+    governingDocument: "Terms of Use",
+    governingDocumentUrl: "/legal/terms",
+  },
+];
+
+export interface Claim {
+  id: string;
+  category: ClaimCategoryKey;
+  subject: string;
+  status: ClaimStatusKey;
+  scope: ClaimScope;
+  // The approved sentence. Pages use this wording; they do not strengthen it.
+  statement: string;
+  // The caveat that must travel with the statement wherever it appears.
+  qualifier: string;
+  // What a buyer can ask for to verify it.
+  evidence: string;
+  // Where the binding version of this claim lives.
+  sourceUrl: string;
+  // True when legal or security still has to confirm the underlying evidence.
+  reviewRequired?: boolean;
+  reviewNote?: string;
+}
+
+export const Claims: Array<Claim> = [
+  // ---------------------------------------------------------------- SLA ----
+  {
+    id: "sla-cloud-enterprise",
+    category: "sla",
+    subject: "Enterprise uptime target (OneUptime Cloud)",
+    status: "compliant",
+    scope: "cloud",
+    statement:
+      "99.95% monthly uptime target for Enterprise plans on OneUptime Cloud.",
+    qualifier:
+      "Applies to Enterprise plans with a signed order form. Service credits are the sole remedy.",
+    evidence:
+      "Section 1 of the SLA, and live availability at status.oneuptime.com.",
+    sourceUrl: "/legal/sla",
+  },
+  {
+    id: "sla-cloud-paid",
+    category: "sla",
+    subject: "Paid plan uptime target (OneUptime Cloud)",
+    status: "compliant",
+    scope: "cloud",
+    statement:
+      "99.9% monthly uptime target for Growth, Scale, and other paid self-serve plans.",
+    qualifier:
+      "Measured monthly against the core web application and API, excluding announced maintenance.",
+    evidence: "Sections 1 and 2 of the SLA.",
+    sourceUrl: "/legal/sla",
+  },
+  {
+    id: "sla-free-plans",
+    category: "sla",
+    subject: "Free, trial, and beta plans",
+    status: "aligned",
+    scope: "cloud",
+    statement:
+      "Free, trial, and beta plans are provided on a best-effort basis with no uptime commitment.",
+    qualifier:
+      "Availability is published for every plan, but no service credits apply.",
+    evidence: "Section 1 of the SLA.",
+    sourceUrl: "/legal/sla",
+  },
+  {
+    id: "sla-service-credits",
+    category: "sla",
+    subject: "Service credits",
+    status: "compliant",
+    scope: "cloud",
+    statement:
+      "If we miss the monthly uptime target, you can claim a service credit of 10%, 25%, or 50% of that month's fees.",
+    qualifier:
+      "Claims are made by email within 30 days. Credits are the sole and exclusive remedy under the SLA.",
+    evidence: "Sections 3, 4, and 6 of the SLA.",
+    sourceUrl: "/legal/sla",
+  },
+  {
+    id: "sla-self-hosted",
+    category: "sla",
+    subject: "Self-hosted availability",
+    status: "customer-configurable",
+    scope: "self-hosted",
+    statement:
+      "Uptime of a self-hosted deployment is owned by the team that runs it. We ship the high-availability building blocks: database operators, Pod Disruption Budgets, autoscaling, and a dedicated worker tier.",
+    qualifier:
+      "The OneUptime Cloud SLA does not extend to infrastructure you operate.",
+    evidence:
+      "The Helm chart's production readiness checklist and configuration reference.",
+    sourceUrl: "/enterprise/self-hosted",
+  },
+  {
+    id: "sla-status-evidence",
+    category: "sla",
+    subject: "Availability evidence",
+    status: "attested",
+    scope: "cloud",
+    statement:
+      "Real-time and historical availability for OneUptime Cloud are published at status.oneuptime.com.",
+    qualifier:
+      "Measured by external monitoring, using the same definition of downtime as the SLA.",
+    evidence: "The public status page and its incident history.",
+    sourceUrl: "https://status.oneuptime.com",
+  },
+
+  // ------------------------------------------------------------ SUPPORT ----
+  {
+    id: "support-p1",
+    category: "support",
+    subject: "P1 (critical) first response",
+    status: "compliant",
+    scope: "cloud",
+    statement:
+      "One-hour first-response target for P1 issues, 24/7, on paid plans.",
+    qualifier:
+      "A target, not a credit-backed guarantee. Enterprise order forms may set different targets.",
+    evidence: "Section 5 of the SLA.",
+    sourceUrl: "/legal/sla",
+  },
+  {
+    id: "support-p2-p4",
+    category: "support",
+    subject: "P2 to P4 first response",
+    status: "compliant",
+    scope: "cloud",
+    statement:
+      "Four business hours for P2, one business day for P3, and three business days for P4.",
+    qualifier:
+      "Business hours are Monday to Friday, 09:00-18:00 UTC, excluding public holidays.",
+    evidence: "Section 5 of the SLA.",
+    sourceUrl: "/legal/sla",
+  },
+  {
+    id: "support-enterprise-channel",
+    category: "support",
+    subject: "Enterprise support channel",
+    status: "compliant",
+    scope: "both",
+    statement:
+      "Enterprise agreements include a private support channel and a named engineering contact, with severity levels and response targets set in the order form.",
+    qualifier:
+      "Scope, hours, and escalation paths are whatever the order form says — not what a marketing page says.",
+    evidence: "Your executed order form.",
+    sourceUrl: "/enterprise/demo",
+  },
+  {
+    id: "support-community",
+    category: "support",
+    subject: "Community support",
+    status: "aligned",
+    scope: "self-hosted",
+    statement:
+      "The Community Edition is supported through public GitHub issues and discussions, with no response-time commitment.",
+    qualifier:
+      "Maintainers answer as capacity allows. Response targets require a commercial agreement.",
+    evidence: "The public issue tracker.",
+    sourceUrl: "https://github.com/OneUptime/oneuptime/issues",
+  },
+  {
+    id: "support-vulnerability-remediation",
+    category: "support",
+    subject: "Vulnerability remediation targets",
+    status: "aligned",
+    scope: "both",
+    statement:
+      "We triage reported vulnerabilities by severity and target remediation within 7 days for critical, 30 days for high, and 90 days for medium.",
+    qualifier:
+      "Internal targets, not contractual commitments. Self-hosted deployments receive the fix in a release you choose when to apply.",
+    evidence: "Section 2 of the security page.",
+    sourceUrl: "/legal/security",
+  },
+
+  // --------------------------------------------------------- COMPLIANCE ----
+  {
+    id: "compliance-soc2",
+    category: "compliance",
+    subject: "SOC 2 Type II",
+    status: "attested",
+    scope: "cloud",
+    statement:
+      "SOC 2 Type II report covering security, availability, and confidentiality, renewed annually.",
+    qualifier:
+      "SOC 2 produces an auditor's report, not a certificate. The report is shared under NDA.",
+    evidence: "Full report on request from soc@oneuptime.com, under NDA.",
+    sourceUrl: "/legal/soc-2",
+  },
+  {
+    id: "compliance-soc3",
+    category: "compliance",
+    subject: "SOC 3",
+    status: "attested",
+    scope: "cloud",
+    statement: "SOC 3 report, the general-use summary of the same examination.",
+    qualifier: "Shareable without an NDA.",
+    evidence: "Request from soc@oneuptime.com.",
+    sourceUrl: "/legal/soc-3",
+  },
+  {
+    id: "compliance-iso-27001",
+    category: "compliance",
+    subject: "ISO/IEC 27001",
+    status: "certified",
+    scope: "cloud",
+    statement:
+      "ISO/IEC 27001 certified information security management system.",
+    qualifier:
+      "Certification covers OneUptime Cloud and the organisation that builds the platform, not a customer's self-hosted deployment.",
+    evidence: "Certificate of registration, including scope, on request.",
+    sourceUrl: "/legal/iso-27001",
+    reviewRequired: true,
+    reviewNote:
+      "Confirm certification body, certificate number, scope statement, and expiry before this is used in an RFP response.",
+  },
+  {
+    id: "compliance-iso-27017",
+    category: "compliance",
+    subject: "ISO/IEC 27017",
+    status: "certified",
+    scope: "cloud",
+    statement:
+      "ISO/IEC 27017 cloud-services security controls, audited alongside ISO 27001.",
+    qualifier: "Extends the 27001 scope; it is not a standalone certification.",
+    evidence: "Certificate of registration on request.",
+    sourceUrl: "/legal/iso-27017",
+    reviewRequired: true,
+    reviewNote: "Confirm the certificate lists 27017 in scope.",
+  },
+  {
+    id: "compliance-iso-27018",
+    category: "compliance",
+    subject: "ISO/IEC 27018",
+    status: "certified",
+    scope: "cloud",
+    statement:
+      "ISO/IEC 27018 controls for protecting personally identifiable information in public clouds.",
+    qualifier: "Extends the 27001 scope; it is not a standalone certification.",
+    evidence: "Certificate of registration on request.",
+    sourceUrl: "/legal/iso-27018",
+    reviewRequired: true,
+    reviewNote: "Confirm the certificate lists 27018 in scope.",
+  },
+  {
+    id: "compliance-iso-9001",
+    category: "compliance",
+    subject: "ISO 9001",
+    status: "certified",
+    scope: "cloud",
+    statement: "ISO 9001 certified quality management system.",
+    qualifier:
+      "Covers how we build and operate the service, not product features.",
+    evidence: "Certificate on request.",
+    sourceUrl: "/legal/iso-9001",
+    reviewRequired: true,
+    reviewNote: "Confirm certification body and current certificate validity.",
+  },
+  {
+    id: "compliance-gdpr",
+    category: "compliance",
+    subject: "GDPR",
+    status: "compliant",
+    scope: "both",
+    statement:
+      "GDPR compliant as a processor, with a Data Processing Addendum, Standard Contractual Clauses, and EU data residency available.",
+    qualifier:
+      "GDPR has no certification scheme. The commitment is contractual, in the DPA.",
+    evidence: "Executed DPA and the subprocessor list.",
+    sourceUrl: "/legal/gdpr",
+  },
+  {
+    id: "compliance-ccpa",
+    category: "compliance",
+    subject: "CCPA / CPRA",
+    status: "compliant",
+    scope: "both",
+    statement:
+      "CCPA and CPRA compliant, with consumer privacy rights honoured for all customers.",
+    qualifier: "A statutory obligation, not a certification.",
+    evidence: "Privacy policy and DPA.",
+    sourceUrl: "/legal/ccpa",
+  },
+  {
+    id: "compliance-hipaa",
+    category: "compliance",
+    subject: "HIPAA",
+    status: "compliant",
+    scope: "both",
+    statement:
+      "HIPAA compliant as a business associate, with a Business Associate Agreement available for covered entities.",
+    qualifier:
+      "HIPAA has no certification scheme, and a BAA must be executed before PHI is processed.",
+    evidence: "Executed BAA.",
+    sourceUrl: "/legal/hipaa",
+  },
+  {
+    id: "compliance-pci",
+    category: "compliance",
+    subject: "PCI DSS",
+    status: "aligned",
+    scope: "cloud",
+    statement:
+      "Card payments are handled by PCI DSS certified payment providers. OneUptime never stores primary account numbers.",
+    qualifier:
+      "Our scope is limited by design: we do not process or store cardholder data ourselves.",
+    evidence:
+      "Payment provider attestations of compliance, and our subprocessor list.",
+    sourceUrl: "/legal/pci",
+    reviewRequired: true,
+    reviewNote:
+      "Confirm whether a SAQ has been completed and, if so, which type — the current page implies an audit report exists.",
+  },
+  {
+    id: "compliance-csa-star",
+    category: "compliance",
+    subject: "CSA STAR",
+    status: "aligned",
+    scope: "cloud",
+    statement:
+      "CAIQ self-assessment completed against the Cloud Controls Matrix.",
+    qualifier:
+      "A self-assessment. STAR Level 2 certification would require a third-party audit.",
+    evidence: "The completed CAIQ on request.",
+    sourceUrl: "/legal/csa-star",
+    reviewRequired: true,
+    reviewNote:
+      "The CSA STAR page currently says 'certified' while the trust center says CAIQ on file. Pick one and correct the other.",
+  },
+  {
+    id: "compliance-fedramp",
+    category: "compliance",
+    subject: "FedRAMP",
+    status: "in-progress",
+    scope: "cloud",
+    statement: "FedRAMP Moderate authorization is in progress.",
+    qualifier:
+      "Not yet authorized, and no date is promised. FedRAMP does not apply to self-hosted deployments, which fall under your own ATO.",
+    evidence: "Status update from compliance@oneuptime.com.",
+    sourceUrl: "/legal/fedramp",
+  },
+  {
+    id: "compliance-gxp",
+    category: "compliance",
+    subject: "21 CFR Part 11, EU GMP Annex 11, GAMP 5, GxP",
+    status: "aligned",
+    scope: "both",
+    statement:
+      "Controls that support electronic records and signatures, with validation documentation and a GxP qualification package available. OneUptime is a GAMP 5 Category 4 configurable product.",
+    qualifier:
+      "None of these regimes certify a vendor. Validation of your system, in your environment, is yours to perform — we supply the documentation that supports it.",
+    evidence:
+      "Validation and qualification packages from compliance@oneuptime.com.",
+    sourceUrl: "/legal/21-cfr-part-11",
+    reviewRequired: true,
+    reviewNote:
+      "The 21 CFR Part 11 and Annex 11 pages currently say 'certified compliant'. No certification scheme exists for either; that wording must be corrected on those pages.",
+  },
+  {
+    id: "compliance-penetration-testing",
+    category: "compliance",
+    subject: "Penetration testing",
+    status: "attested",
+    scope: "cloud",
+    statement: "Independent third-party penetration testing at least annually.",
+    qualifier:
+      "Summary reports are available under NDA to qualifying customers.",
+    evidence: "Summary report from security@oneuptime.com.",
+    sourceUrl: "/legal/security",
+  },
+  {
+    id: "compliance-accessibility",
+    category: "compliance",
+    subject: "Accessibility (WCAG 2.2 AA)",
+    status: "aligned",
+    scope: "both",
+    statement:
+      "A VPAT / Accessibility Conformance Report against WCAG 2.2 Level AA and EN 301 549 is published.",
+    qualifier:
+      "A VPAT is a self-assessment prepared to a standard template, not a third-party certification.",
+    evidence: "The published VPAT.",
+    sourceUrl: "/legal/vpat",
+  },
+
+  // --------------------------------------------------------- ENCRYPTION ----
+  {
+    id: "encryption-in-transit",
+    category: "encryption",
+    subject: "Encryption in transit",
+    status: "attested",
+    scope: "cloud",
+    statement:
+      "All traffic to and from OneUptime Cloud is encrypted with TLS 1.2 or higher.",
+    qualifier: "In scope for our SOC 2 Type II examination.",
+    evidence: "SOC 2 report and the security page.",
+    sourceUrl: "/legal/security",
+  },
+  {
+    id: "encryption-at-rest",
+    category: "encryption",
+    subject: "Encryption at rest",
+    status: "attested",
+    scope: "cloud",
+    statement:
+      "Customer data on OneUptime Cloud is encrypted at rest with AES-256 or equivalent on managed database and object storage.",
+    qualifier: "In scope for our SOC 2 Type II examination.",
+    evidence: "SOC 2 report and the security page.",
+    sourceUrl: "/legal/security",
+  },
+  {
+    id: "encryption-self-hosted",
+    category: "encryption",
+    subject: "Encryption on self-hosted deployments",
+    status: "customer-configurable",
+    scope: "self-hosted",
+    statement:
+      "On a self-hosted deployment you terminate TLS and configure storage encryption with your own infrastructure and keys.",
+    qualifier:
+      "The platform supports it; the configuration, and the keys, are yours.",
+    evidence: "The Helm chart configuration reference.",
+    sourceUrl: "/enterprise/self-hosted",
+  },
+  {
+    id: "encryption-key-management",
+    category: "encryption",
+    subject: "Key management",
+    status: "attested",
+    scope: "cloud",
+    statement:
+      "Encryption keys for OneUptime Cloud are managed in our cloud providers' key management services, with rotation and audit logging.",
+    qualifier:
+      "Customer-managed keys on OneUptime Cloud are not offered as a standard feature — self-host or use a private cloud deployment if you need to hold the keys.",
+    evidence: "Security page, section 3.",
+    sourceUrl: "/legal/security",
+  },
+  {
+    id: "encryption-tenant-isolation",
+    category: "encryption",
+    subject: "Tenant isolation",
+    status: "attested",
+    scope: "cloud",
+    statement:
+      "Customer data is logically segregated, with access enforced at the application and database layers.",
+    qualifier:
+      "Logical, not physical, isolation on multi-tenant cloud. A private cloud deployment gives you dedicated databases.",
+    evidence: "SOC 2 report and the security page.",
+    sourceUrl: "/legal/security",
+  },
+  {
+    id: "encryption-secrets-redaction",
+    category: "encryption",
+    subject: "AI features and data handling",
+    status: "customer-configurable",
+    scope: "both",
+    statement:
+      "AI investigations are read-only and secrets are redacted before anything reaches a model. Self-hosted deployments can point AI features at an in-cluster model, or leave them switched off.",
+    qualifier:
+      "Which model provider is used, and whether AI features are enabled at all, is your choice.",
+    evidence: "The Helm chart's local-AI guide.",
+    sourceUrl: "/enterprise/self-hosted",
+  },
+
+  // --------------------------------------------------------- DEPLOYMENT ----
+  {
+    id: "deployment-self-hosted",
+    category: "deployment",
+    subject: "Self-hosted deployment",
+    status: "customer-configurable",
+    scope: "self-hosted",
+    statement:
+      "The full platform runs on your own Kubernetes cluster via our Helm chart, or on a single host with Docker Compose.",
+    qualifier:
+      "The Community Edition is the complete product under Apache 2.0; the Enterprise Edition adds hardened images and a support agreement.",
+    evidence: "The public Helm chart and its installation guide.",
+    sourceUrl: "/enterprise/self-hosted",
+  },
+  {
+    id: "deployment-air-gapped",
+    category: "deployment",
+    subject: "Air-gapped operation",
+    status: "customer-configurable",
+    scope: "self-hosted",
+    statement:
+      "OneUptime runs with no outbound connectivity: mirror the images to your registry, disable the update check, and keep DNS internal.",
+    qualifier:
+      "Features that call an external service by design — hosted AI models, third-party notification transports — need an internal equivalent or must stay off.",
+    evidence: "The Helm chart configuration reference.",
+    sourceUrl: "/enterprise/self-hosted",
+  },
+  {
+    id: "deployment-hardened-images",
+    category: "deployment",
+    subject: "Hardened images",
+    status: "customer-configurable",
+    scope: "self-hosted",
+    statement:
+      "Enterprise Edition container images ship additional security controls and are selected with a single chart value.",
+    qualifier: "Enterprise Edition images require a valid license.",
+    evidence: "The chart's image configuration and your license.",
+    sourceUrl: "/enterprise/self-hosted",
+  },
+  {
+    id: "deployment-data-residency",
+    category: "deployment",
+    subject: "Data residency",
+    status: "compliant",
+    scope: "both",
+    statement:
+      "Enterprise customers choose the region their data is stored in — AWS, Azure, GCP, or on-premises.",
+    qualifier:
+      "An organisation lives in a single region. Region selection is agreed in the order form and set at provisioning time.",
+    evidence: "Order form and the data residency page.",
+    sourceUrl: "/legal/data-residency",
+  },
+  {
+    id: "deployment-open-source",
+    category: "deployment",
+    subject: "Open source",
+    status: "aligned",
+    scope: "both",
+    statement:
+      "The entire platform is Apache-2.0 licensed and developed in public on GitHub.",
+    qualifier:
+      "Auditable by anyone, and free to run yourself for as long as you like.",
+    evidence: "The public repository and its license.",
+    sourceUrl: "https://github.com/OneUptime/oneuptime",
+  },
+
+  // ---------------------------------------------------------- MIGRATION ----
+  {
+    id: "migration-portability",
+    category: "migration",
+    subject: "Data portability",
+    status: "customer-configurable",
+    scope: "both",
+    statement:
+      "Your data is exportable through the API at any time, and the self-hosted and cloud editions share one schema.",
+    qualifier:
+      "Moving between cloud and self-hosted is a data migration, not a re-platform.",
+    evidence: "The public API reference.",
+    sourceUrl: "/reference",
+  },
+  {
+    id: "migration-assistance",
+    category: "migration",
+    subject: "Migration assistance",
+    status: "compliant",
+    scope: "both",
+    statement:
+      "Enterprise agreements can include migration and upgrade assistance from our engineers.",
+    qualifier:
+      "Scope and effort are agreed in the order form; it is not included by default on self-serve plans.",
+    evidence: "Your order form.",
+    sourceUrl: "/enterprise/demo",
+  },
+  {
+    id: "migration-deletion",
+    category: "migration",
+    subject: "Deletion on termination",
+    status: "compliant",
+    scope: "cloud",
+    statement:
+      "On termination, customer data is deleted in line with the retention terms in the DPA.",
+    qualifier: "Backups age out on their own documented cycle.",
+    evidence: "The DPA.",
+    sourceUrl: "/legal/dpa",
+  },
+
+  // -------------------------------------------------------------- SCALE ----
+  {
+    id: "scale-horizontal",
+    category: "scale",
+    subject: "Horizontal scale",
+    status: "customer-configurable",
+    scope: "both",
+    statement:
+      "Telemetry storage scales horizontally through ClickHouse sharding and replication, with a dedicated writer tier that keeps insert concurrency bounded as the worker fleet autoscales.",
+    qualifier:
+      "Throughput on a self-hosted deployment is a function of the cluster you give it.",
+    evidence: "The production readiness checklist in the chart docs.",
+    sourceUrl: "/enterprise/self-hosted",
+  },
+  {
+    id: "scale-monitor-limits",
+    category: "scale",
+    subject: "Monitor and user limits",
+    status: "aligned",
+    scope: "both",
+    statement:
+      "There are no product-imposed caps on monitors, team members, alerts, or API calls.",
+    qualifier:
+      "On OneUptime Cloud, usage-based pricing applies. On a self-hosted deployment, your infrastructure is the limit.",
+    evidence: "The pricing page.",
+    sourceUrl: "/pricing",
+  },
+  {
+    id: "scale-probe-locations",
+    category: "scale",
+    subject: "Monitoring vantage points",
+    status: "customer-configurable",
+    scope: "both",
+    statement:
+      "Probes can be deployed in any region, network, or cluster you choose, so checks run from where your users are.",
+    qualifier:
+      "Self-hosted deployments run the probes they deploy. Counts of hosted probe locations must not be published without an owner who maintains the number.",
+    evidence: "The chart's probe configuration.",
+    sourceUrl: "/enterprise/self-hosted",
+  },
+
+  // ---------------------------------------------------------- DISCOUNTS ----
+  {
+    id: "discount-annual",
+    category: "discounts",
+    subject: "Annual billing",
+    status: "compliant",
+    scope: "cloud",
+    statement:
+      "Annual billing is discounted against monthly billing, at the annual price published for each plan.",
+    qualifier:
+      "Do not publish a single percentage — the discount differs per plan, and a headline figure that does not match the price table is the fastest way to lose a buyer's trust.",
+    evidence: "The plan table on the pricing page.",
+    sourceUrl: "/pricing",
+  },
+  {
+    id: "discount-volume",
+    category: "discounts",
+    subject: "Volume discounts",
+    status: "aligned",
+    scope: "cloud",
+    statement:
+      "Volume discounts are available on high monitor counts, high telemetry ingest, and extended retention.",
+    qualifier:
+      "Quoted case by case by sales. No specific percentage is published.",
+    evidence: "A written quote from sales@oneuptime.com.",
+    sourceUrl: "/pricing",
+  },
+  {
+    id: "discount-open-source",
+    category: "discounts",
+    subject: "Non-profit, education, and open-source",
+    status: "aligned",
+    scope: "cloud",
+    statement:
+      "There is no non-profit, education, or open-source discount on OneUptime Cloud. The software itself is free to self-host at any scale instead.",
+    qualifier:
+      "Everyone on the cloud service pays the same published price. Say this plainly rather than implying a programme we do not run.",
+    evidence: "The pricing page FAQ and the Apache 2.0 license.",
+    sourceUrl: "/pricing",
+  },
+  {
+    id: "discount-self-host",
+    category: "discounts",
+    subject: "Self-hosting cost",
+    status: "aligned",
+    scope: "self-hosted",
+    statement:
+      "The Community Edition is free to run yourself, with no license fee at any scale.",
+    qualifier:
+      "You still pay for your own infrastructure, and support requires a commercial agreement.",
+    evidence: "The Apache 2.0 license.",
+    sourceUrl: "https://github.com/OneUptime/oneuptime",
+  },
+
+  // ----------------------------------------------------------- CONTRACT ----
+  {
+    id: "contract-order-form",
+    category: "contract",
+    subject: "Enterprise terms",
+    status: "compliant",
+    scope: "both",
+    statement:
+      "Enterprise commitments — uptime targets, support hours, data residency, and security obligations — are set in a signed order form.",
+    qualifier:
+      "Where a marketing page and an order form disagree, the order form governs.",
+    evidence: "Your executed order form.",
+    sourceUrl: "/legal/terms",
+  },
+  {
+    id: "contract-invoicing",
+    category: "contract",
+    subject: "Invoicing terms",
+    status: "aligned",
+    scope: "cloud",
+    statement:
+      "Annual invoicing and purchase-order workflows are available on enterprise agreements.",
+    qualifier:
+      "Payment terms are agreed per contract. No specific net terms are promised on a marketing page.",
+    evidence: "Your order form.",
+    sourceUrl: "/enterprise/demo",
+  },
+  {
+    id: "contract-dpa-baa",
+    category: "contract",
+    subject: "DPA and BAA",
+    status: "compliant",
+    scope: "both",
+    statement:
+      "A Data Processing Addendum is available for all customers, and a Business Associate Agreement for covered entities.",
+    qualifier:
+      "Both must be executed before the corresponding data is processed.",
+    evidence: "The published DPA and a countersigned BAA.",
+    sourceUrl: "/legal/dpa",
+  },
+  {
+    id: "contract-security-review",
+    category: "contract",
+    subject: "Security review and questionnaires",
+    status: "compliant",
+    scope: "both",
+    statement:
+      "We complete security questionnaires and share evidence — reports, policies, and control documentation — under NDA.",
+    qualifier: "Turnaround is agreed with your procurement team.",
+    evidence: "Request from security@oneuptime.com.",
+    sourceUrl: "/trust",
+  },
+  {
+    id: "contract-deprecation",
+    category: "contract",
+    subject: "Version support window",
+    status: "compliant",
+    scope: "self-hosted",
+    statement:
+      "The latest three major versions are fully supported, and older versions receive security fixes for a further 12 months.",
+    qualifier:
+      "Support cannot help with a version that has left the supported window.",
+    evidence: "The deprecation policy.",
+    sourceUrl: "/legal/deprecation-policy",
+  },
+];
+
+/*
+ * Language that used to appear on the site and must not come back. The
+ * governance test in Tests/ClaimsGovernance.test.ts scans Home/Views for each
+ * pattern and fails with `reason` and `replacement` so whoever hits it knows
+ * what to write instead.
+ */
+export interface RetiredClaim {
+  pattern: RegExp;
+  // A human-readable version of the pattern, for test output.
+  example: string;
+  reason: string;
+  replacement: string;
+  claimId: string;
+}
+
+export const RetiredClaims: Array<RetiredClaim> = [
+  {
+    pattern: /99\.99\s*%\s*(?:uptime\s*)?SLA/i,
+    example: "99.99% uptime SLA",
+    reason:
+      "The SLA commits to 99.9% on paid plans and 99.95% on Enterprise. 99.99% is not a number we are contractually on the hook for.",
+    replacement:
+      "99.95% uptime target on Enterprise plans (99.9% on paid self-serve plans).",
+    claimId: "sla-cloud-enterprise",
+  },
+  {
+    pattern: /99\.00\s*%\s*SLA/i,
+    example: "99.00% SLA",
+    reason:
+      "Free plans carry no uptime commitment at all, so publishing a number for them invents one.",
+    replacement: "Best effort, no uptime commitment.",
+    claimId: "sla-free-plans",
+  },
+  {
+    pattern: /financial(?:ly)?[- ]backed\s+(?:reliability\s+)?guarantee/i,
+    example: "financial-backed reliability guarantee",
+    reason:
+      "Service credits are capped at a percentage of monthly fees and are the sole remedy. 'Financially backed guarantee' overstates that.",
+    replacement:
+      "Service credits of up to 50% of monthly fees if we miss the target.",
+    claimId: "sla-service-credits",
+  },
+  {
+    pattern:
+      /guarantee[ds]?\s+(?:\d+[- ])?(?:response|first[- ]response)\s*times?/i,
+    example: "guaranteed response times",
+    reason:
+      "Section 5 of the SLA states response times are targets, not guaranteed credits.",
+    replacement: "One-hour first-response target for P1 issues, 24/7.",
+    claimId: "support-p1",
+  },
+  {
+    pattern: /guaranteed\s+1-hour\s+response/i,
+    example: "guaranteed 1-hour response time",
+    reason: "Same as above — a target, not a guarantee.",
+    replacement: "One-hour P1 first-response target.",
+    claimId: "support-p1",
+  },
+  {
+    pattern: /15\s*minutes?\s+for\s+critical/i,
+    example: "15 minutes for critical issues",
+    reason:
+      "No document commits to 15 minutes. The published P1 target is one hour.",
+    replacement: "One-hour first-response target for P1 issues, 24/7.",
+    claimId: "support-p1",
+  },
+  {
+    pattern: /99\.99%\s*delivery\s*guarantee/i,
+    example: "99.99% delivery guarantee",
+    reason:
+      "Alert delivery depends on third-party carriers and providers. There is no measurement behind this number and no remedy attached to it.",
+    replacement:
+      "Redundant delivery across email, SMS, voice, push, and chat, with escalation if an alert is not acknowledged.",
+    claimId: "sla-service-credits",
+  },
+  {
+    pattern: /17\s*%\s*discount/i,
+    example: "Annual plans have a 17% discount",
+    reason:
+      "The published annual prices work out to different discounts per plan, none of them 17%. A number that does not match the price table on the same page reads as carelessness at best.",
+    replacement:
+      "Annual billing is discounted; the annual price for each plan is shown in the table above.",
+    claimId: "discount-annual",
+  },
+  {
+    pattern: /certified\s+compliant\s+with/i,
+    example: "certified compliant with 21 CFR Part 11",
+    reason:
+      "21 CFR Part 11, Annex 11, and GAMP 5 have no vendor certification scheme. The customer validates their own system.",
+    replacement:
+      "Controls that support 21 CFR Part 11, with validation documentation available. Validation of your system is yours to perform.",
+    claimId: "compliance-gxp",
+  },
+];
+
+export type GetClaimsByCategoryFunction = (
+  category: ClaimCategoryKey,
+) => Array<Claim>;
+
+export const getClaimsByCategory: GetClaimsByCategoryFunction = (
+  category: ClaimCategoryKey,
+): Array<Claim> => {
+  return Claims.filter((claim: Claim) => {
+    return claim.category === category;
+  });
+};
+
+export type GetClaimFunction = (id: string) => Claim | null;
+
+export const getClaim: GetClaimFunction = (id: string): Claim | null => {
+  return (
+    Claims.find((claim: Claim) => {
+      return claim.id === id;
+    }) || null
+  );
+};
+
+export type GetClaimStatusFunction = (
+  key: ClaimStatusKey,
+) => ClaimStatusDefinition;
+
+export const getClaimStatus: GetClaimStatusFunction = (
+  key: ClaimStatusKey,
+): ClaimStatusDefinition => {
+  const status: ClaimStatusDefinition | undefined = ClaimStatuses.find(
+    (claimStatus: ClaimStatusDefinition) => {
+      return claimStatus.key === key;
+    },
+  );
+
+  if (!status) {
+    throw new Error(`Unknown claim status: ${key}`);
+  }
+
+  return status;
+};
+
+export interface ClaimCategoryGroup {
+  category: ClaimCategory;
+  claims: Array<Claim>;
+}
+
+export type GetClaimsMatrixFunction = () => Array<ClaimCategoryGroup>;
+
+// Categories in publication order, each with its claims. Drives the trust center.
+export const getClaimsMatrix: GetClaimsMatrixFunction =
+  (): Array<ClaimCategoryGroup> => {
+    return ClaimCategories.map((category: ClaimCategory) => {
+      return {
+        category,
+        claims: getClaimsByCategory(category.key),
+      };
+    });
+  };
+
+export type GetClaimsNeedingReviewFunction = () => Array<Claim>;
+
+// The legal / security review queue.
+export const getClaimsNeedingReview: GetClaimsNeedingReviewFunction =
+  (): Array<Claim> => {
+    return Claims.filter((claim: Claim) => {
+      return claim.reviewRequired === true;
+    });
+  };
+
+export default Claims;

--- a/Home/Utils/PageSEO.ts
+++ b/Home/Utils/PageSEO.ts
@@ -1195,6 +1195,39 @@ export const PageSEOConfig: Record<string, PageSEOData> = {
     ],
   },
 
+  "/enterprise/self-hosted": {
+    title:
+      "Self-Hosted OneUptime | Deployment, Architecture & Support | OneUptime",
+    description:
+      "Run the full OneUptime platform on your own infrastructure. Deployment models, reference architecture, Kubernetes requirements, high availability and disaster recovery, upgrade responsibility, air-gapped operation, hardened images, data residency, and support boundaries.",
+    canonicalPath: "/enterprise/self-hosted",
+    twitterCard: "summary_large_image",
+    pageType: "enterprise",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Enterprise", url: "/enterprise/overview" },
+      { name: "Self-Hosted", url: "/enterprise/self-hosted" },
+    ],
+    softwareApplication: {
+      name: "OneUptime Self-Hosted",
+      applicationCategory: "DeveloperApplication",
+      operatingSystem: "Kubernetes, Linux, Docker",
+      description:
+        "The complete OneUptime observability and incident management platform, deployed on infrastructure you own and operate.",
+      features: [
+        "Kubernetes deployment with an official Helm chart",
+        "Docker Compose deployment for single-host installs",
+        "Private cloud and managed single-tenant options",
+        "High availability with CloudNativePG and Altinity ClickHouse operators",
+        "Pod Disruption Budgets, HPA, and KEDA autoscaling",
+        "Air-gapped operation with mirrored images and no outbound calls",
+        "Hardened Enterprise Edition container images",
+        "Customer-controlled data residency and encryption keys",
+        "Documented upgrade responsibility and support boundaries",
+      ],
+    },
+  },
+
   "/enterprise/demo": {
     title: "Request Demo | See OneUptime in Action | OneUptime",
     description:
@@ -1220,6 +1253,19 @@ export const PageSEOConfig: Record<string, PageSEOData> = {
     breadcrumbs: [
       { name: "Home", url: "/" },
       { name: "About", url: "/about" },
+    ],
+  },
+
+  "/trust": {
+    title: "Trust Center | Security, Compliance & Governed Claims | OneUptime",
+    description:
+      "OneUptime's canonical trust center. Certifications and attestations with the evidence behind each one, security architecture, privacy practices, and a governed claims matrix covering service levels, support, compliance, encryption, deployment, migration, scale, discounts, and contract terms.",
+    canonicalPath: "/trust",
+    twitterCard: "summary_large_image",
+    pageType: "other",
+    breadcrumbs: [
+      { name: "Home", url: "/" },
+      { name: "Trust Center", url: "/trust" },
     ],
   },
 

--- a/Home/Utils/SelfHosted.ts
+++ b/Home/Utils/SelfHosted.ts
@@ -1,0 +1,677 @@
+/*
+ * Structured content for the self-hosted landing page (/enterprise/self-hosted).
+ *
+ * Everything an enterprise buyer needs to evaluate running OneUptime on their
+ * own infrastructure lives here so the page, the tests, and the
+ * machine-readable surfaces (/data/self-hosted.json) all read from one source.
+ *
+ * Every claim on this page must be traceable to something we actually ship:
+ * the Helm chart in HelmChart/Public/oneuptime, its docs, or the governed
+ * claims matrix in Utils/Claims.ts. Do not add a capability here that a
+ * customer cannot switch on from values.yaml or a signed order form.
+ */
+
+export type DeploymentModelKey =
+  | "kubernetes"
+  | "docker-compose"
+  | "private-cloud"
+  | "cloud";
+
+export interface DeploymentModel {
+  key: DeploymentModelKey;
+  name: string;
+  tagline: string;
+  bestFor: string;
+  // Who runs the infrastructure the platform sits on.
+  infrastructure: string;
+  // Who is accountable for upgrades on this model.
+  upgrades: string;
+  highlights: Array<string>;
+  docsUrl: string;
+  recommended: boolean;
+}
+
+export interface ArchitectureComponent {
+  name: string;
+  description: string;
+  // Scaling story: how this tier grows with load.
+  scaling: string;
+}
+
+export interface ArchitectureTier {
+  key: string;
+  name: string;
+  description: string;
+  accent: string;
+  components: Array<ArchitectureComponent>;
+}
+
+export interface SizingTier {
+  key: string;
+  name: string;
+  workload: string;
+  nodes: string;
+  cpu: string;
+  memory: string;
+  storage: string;
+  notes: string;
+}
+
+export interface RequirementGroup {
+  title: string;
+  items: Array<string>;
+}
+
+export interface ResilienceControl {
+  title: string;
+  description: string;
+  // The exact values.yaml key(s) that turn this on, so buyers can verify.
+  setting: string;
+}
+
+export interface ResponsibilityRow {
+  area: string;
+  oneuptime: string;
+  customer: string;
+}
+
+export interface SupportTierRow {
+  key: string;
+  name: string;
+  description: string;
+  included: Array<string>;
+  excluded: Array<string>;
+}
+
+export interface AirGapStep {
+  title: string;
+  description: string;
+  setting: string;
+}
+
+export interface SelfHostedFaq {
+  question: string;
+  answer: string;
+}
+
+const HELM_DOCS_BASE: string =
+  "https://github.com/OneUptime/oneuptime/blob/master/HelmChart/Public/oneuptime/docs";
+
+export interface HelmDocLinks {
+  installation: string;
+  configuration: string;
+  databases: string;
+  productionChecklist: string;
+  upgradeNotes: string;
+  troubleshooting: string;
+  customDomains: string;
+  localAi: string;
+  chart: string;
+  repository: string;
+  releases: string;
+}
+
+export const HelmDocs: HelmDocLinks = {
+  installation: `${HELM_DOCS_BASE}/installation.md`,
+  configuration: `${HELM_DOCS_BASE}/configuration.md`,
+  databases: `${HELM_DOCS_BASE}/databases.md`,
+  productionChecklist: `${HELM_DOCS_BASE}/production-checklist.md`,
+  upgradeNotes: `${HELM_DOCS_BASE}/upgrade-notes.md`,
+  troubleshooting: `${HELM_DOCS_BASE}/troubleshooting.md`,
+  customDomains: `${HELM_DOCS_BASE}/custom-domains.md`,
+  localAi: `${HELM_DOCS_BASE}/ai-vllm.md`,
+  chart:
+    "https://github.com/OneUptime/oneuptime/tree/master/HelmChart/Public/oneuptime",
+  repository: "https://github.com/OneUptime/oneuptime",
+  releases: "https://github.com/OneUptime/oneuptime/releases",
+};
+
+export const DeploymentModels: Array<DeploymentModel> = [
+  {
+    key: "kubernetes",
+    name: "Kubernetes (Helm)",
+    tagline: "The supported production deployment.",
+    bestFor:
+      "Production self-hosting, regulated environments, and anything that needs horizontal scale or high availability.",
+    infrastructure: "Your cluster, your cloud or data centre",
+    upgrades: "You run `helm upgrade` on your own schedule",
+    highlights: [
+      "One chart deploys the whole platform — ingress, API, workers, probes, and databases",
+      "Bundled PostgreSQL (CloudNativePG) and ClickHouse (Altinity) operators for replicated databases",
+      "KEDA and HPA autoscaling, Pod Disruption Budgets, and a dedicated worker tier",
+      "Runs on any conformant Kubernetes — EKS, AKS, GKE, OpenShift, Rancher, or bare metal",
+    ],
+    docsUrl: HelmDocs.installation,
+    recommended: true,
+  },
+  {
+    key: "docker-compose",
+    name: "Docker Compose",
+    tagline: "Single host, fastest path to a running instance.",
+    bestFor:
+      "Proofs of concept, lab environments, and small internal installs that do not need HA.",
+    infrastructure: "One Linux VM you control",
+    upgrades: "You pull new images and restart the stack",
+    highlights: [
+      "One install script brings up the full platform on a single machine",
+      "Same container images as the Kubernetes deployment — no feature differences",
+      "Simple to snapshot, clone, and tear down for evaluation",
+      "Not recommended for production: no replica-level redundancy on a single host",
+    ],
+    docsUrl: HelmDocs.repository,
+    recommended: false,
+  },
+  {
+    key: "private-cloud",
+    name: "Private cloud (managed by us)",
+    tagline: "Single-tenant, we operate it, you choose the region.",
+    bestFor:
+      "Teams that want isolation and data residency without staffing the operational burden of self-hosting.",
+    infrastructure: "Dedicated single-tenant environment in your chosen region",
+    upgrades: "We upgrade under an agreed maintenance window",
+    highlights: [
+      "Dedicated databases and storage — no shared multi-tenant data plane",
+      "Region selected at provisioning time on AWS, Azure, GCP, or an agreed data centre",
+      "Operational runbooks, backups, and upgrades handled by our team",
+      "Commercial terms, SLAs, and support hours defined in the order form",
+    ],
+    docsUrl: "/legal/data-residency",
+    recommended: false,
+  },
+  {
+    key: "cloud",
+    name: "OneUptime Cloud",
+    tagline: "Multi-tenant SaaS, nothing to operate.",
+    bestFor:
+      "Teams that want the product without owning any infrastructure, and hybrid setups alongside a self-hosted install.",
+    infrastructure: "Operated by OneUptime",
+    upgrades: "Continuous — we ship several times a day",
+    highlights: [
+      "Same open-source platform, operated for you",
+      "Uptime commitments and service credits defined in the SLA",
+      "Useful as an external vantage point next to a self-hosted install",
+      "Export your data and move to self-hosted at any time — same schema, same product",
+    ],
+    docsUrl: "/pricing",
+    recommended: false,
+  },
+];
+
+export const ArchitectureTiers: Array<ArchitectureTier> = [
+  {
+    key: "edge",
+    name: "Edge",
+    description:
+      "Terminates TLS and routes every request into the platform. The only tier that needs to be reachable from outside the cluster.",
+    accent: "blue",
+    components: [
+      {
+        name: "Ingress gateway (nginx)",
+        description:
+          "Bundled gateway service. Fronts the dashboard, API, status pages, and custom status-page domains.",
+        scaling: "Replicas + Pod Disruption Budget",
+      },
+      {
+        name: "Certificate issuance",
+        description:
+          "Optional cert-manager ClusterIssuer for Let's Encrypt, or bring your own certificates and terminate TLS upstream.",
+        scaling: "Cluster-wide",
+      },
+    ],
+  },
+  {
+    key: "application",
+    name: "Application",
+    description:
+      "Stateless tiers that serve the product and run everything that happens off the request path.",
+    accent: "emerald",
+    components: [
+      {
+        name: "API and dashboard (app)",
+        description:
+          "Serves the dashboard, the REST API, and status pages. Stateless — scale it out horizontally.",
+        scaling: "HPA or KEDA on CPU / queue depth",
+      },
+      {
+        name: "Worker",
+        description:
+          "Dedicated background-job tier: telemetry ingestion, notifications, incident and alert processing, workflows.",
+        scaling: "KEDA on queue depth",
+      },
+      {
+        name: "Telemetry writer",
+        description:
+          "Optional fixed-size tier that owns all ClickHouse insert concurrency so the worker fleet can autoscale without bound.",
+        scaling: "Fixed replicas, bounded by ClickHouse capacity",
+      },
+      {
+        name: "Runner",
+        description:
+          "Executes workflows and scheduled automation in isolation from the API tier.",
+        scaling: "Replicas + PDB",
+      },
+      {
+        name: "Probes",
+        description:
+          "Run the actual monitoring checks. Deploy them inside the cluster, in other networks, or in other regions to monitor from where your users are.",
+        scaling: "One deployment per vantage point",
+      },
+    ],
+  },
+  {
+    key: "data",
+    name: "Data",
+    description:
+      "Where your telemetry and configuration live. All of it stays inside your perimeter.",
+    accent: "violet",
+    components: [
+      {
+        name: "PostgreSQL",
+        description:
+          "Configuration, incidents, users, and platform state. Run the bundled CloudNativePG operator for streaming replication and automatic failover, or point at your own managed PostgreSQL.",
+        scaling: "CloudNativePG replicas, or external / managed",
+      },
+      {
+        name: "ClickHouse",
+        description:
+          "Logs, metrics, traces, and spans. Run the bundled Altinity operator for replication and sharding, or point at your own cluster.",
+        scaling: "Altinity shards and replicas",
+      },
+      {
+        name: "Redis",
+        description:
+          "Queues, caching, and coordination between the API and worker tiers.",
+        scaling: "Bundled or external",
+      },
+      {
+        name: "PgBouncer",
+        description:
+          "Optional transaction-mode connection pooler. Keeps an autoscaling worker fleet from exhausting PostgreSQL connections.",
+        scaling: "Pool size tuned to database max_connections",
+      },
+    ],
+  },
+  {
+    key: "ingest",
+    name: "Ingest",
+    description:
+      "How telemetry gets in. Open standards only — nothing proprietary on the wire.",
+    accent: "amber",
+    components: [
+      {
+        name: "OpenTelemetry collector",
+        description:
+          "OTLP endpoint for logs, metrics, and traces from your services. Use our collector or point your existing one at OneUptime.",
+        scaling: "Replicas",
+      },
+      {
+        name: "Agents",
+        description:
+          "Infrastructure, Docker, Docker Swarm, Podman, Proxmox, Kubernetes, and Ceph agents report into the same ingest path.",
+        scaling: "One per host or cluster",
+      },
+      {
+        name: "Migration job",
+        description:
+          "Schema and data migrations run once per release in a dedicated Job rather than on every pod.",
+        scaling: "Runs per upgrade",
+      },
+    ],
+  },
+];
+
+export const SizingTiers: Array<SizingTier> = [
+  {
+    key: "evaluation",
+    name: "Evaluation",
+    workload: "Proof of concept, a handful of monitors, no HA",
+    nodes: "1 node",
+    cpu: "4 vCPU",
+    memory: "16 GB",
+    storage: "100 GB",
+    notes:
+      "Docker Compose on a single VM, or a single-node cluster with the bundled standalone databases.",
+  },
+  {
+    key: "production",
+    name: "Production",
+    workload: "A few hundred monitors, moderate telemetry ingest",
+    nodes: "3+ nodes",
+    cpu: "16 vCPU total",
+    memory: "64 GB total",
+    storage: "500 GB+ on a replicated storage class",
+    notes:
+      "Kubernetes with the dedicated worker tier, database operators, and Pod Disruption Budgets enabled.",
+  },
+  {
+    key: "scale",
+    name: "Scale",
+    workload: "Thousands of monitors, high-volume telemetry ingest",
+    nodes: "6+ nodes, dedicated database nodes",
+    cpu: "48 vCPU+ total",
+    memory: "192 GB+ total",
+    storage: "Multi-TB, sized to your retention policy",
+    notes:
+      "Sharded ClickHouse, the telemetry-writer tier, PgBouncer, and KEDA autoscaling on the worker fleet.",
+  },
+];
+
+export const InfrastructureRequirements: Array<RequirementGroup> = [
+  {
+    title: "Kubernetes",
+    items: [
+      "Any conformant Kubernetes cluster — EKS, AKS, GKE, OpenShift, Rancher, k3s, or bare metal",
+      "Helm 3 and kubectl configured against the cluster",
+      "A storage class that supports dynamic provisioning of ReadWriteOnce volumes",
+      "A hostname you control, pointed at the ingress gateway service",
+    ],
+  },
+  {
+    title: "Networking",
+    items: [
+      "A LoadBalancer service, MetalLB address pool, or your own ingress in front of the gateway",
+      "TLS certificates — bring your own, or let the bundled cert-manager issuer handle Let's Encrypt",
+      "Outbound access from probes to whatever you want them to monitor",
+      "Optional HTTP/HTTPS proxy settings per probe for egress-restricted networks",
+    ],
+  },
+  {
+    title: "Data stores",
+    items: [
+      "PostgreSQL, ClickHouse, and Redis — bundled with the chart, or point at your own",
+      "Database operators (CloudNativePG, Altinity) for replicated production databases",
+      "Persistent volume backups — configured with your storage provider or CloudNativePG scheduled backups",
+      "Retention policy sized against your telemetry volume; storage is the dominant cost at scale",
+    ],
+  },
+  {
+    title: "Optional add-ons",
+    items: [
+      "KEDA, if you want queue-depth autoscaling on the worker tier",
+      "cert-manager, for automatic certificate issuance and custom status-page domains",
+      "An in-cluster vLLM deployment, if you want AI features without calling an external model provider",
+      "Your own SMTP relay and SMS provider for notifications",
+    ],
+  },
+];
+
+export const AvailabilityControls: Array<ResilienceControl> = [
+  {
+    title: "Replicated PostgreSQL",
+    description:
+      "The bundled CloudNativePG operator runs PostgreSQL with streaming replication and automatic failover instead of a single standalone instance.",
+    setting: "postgresOperator.cnpg.enabled",
+  },
+  {
+    title: "Replicated and sharded ClickHouse",
+    description:
+      "The bundled Altinity operator handles replication, sharding, and declarative lifecycle management for the telemetry store.",
+    setting: "clickhouseOperator.altinity.enabled",
+  },
+  {
+    title: "Pod Disruption Budgets",
+    description:
+      "Stops a node drain or cluster upgrade from evicting every replica of a service at once. Pair it with more than one replica per stateless tier.",
+    setting: "podDisruptionBudget.enabled",
+  },
+  {
+    title: "Autoscaling",
+    description:
+      "HPA on CPU and memory for the stateless tiers, and KEDA on queue depth for the worker fleet, so ingest spikes do not become incidents.",
+    setting: "autoscaling.enabled / worker.keda",
+  },
+  {
+    title: "Connection pooling",
+    description:
+      "PgBouncer in transaction mode keeps an autoscaling worker fleet or a connection-limited managed PostgreSQL from running out of connections.",
+    setting: "pgbouncer.enabled",
+  },
+  {
+    title: "Scheduled database backups",
+    description:
+      "CloudNativePG scheduled backups cover PostgreSQL. Volume snapshots and object-storage backups are configured with your infrastructure provider.",
+    setting: "postgresOperator.cnpg.scheduledBackup",
+  },
+];
+
+export const DisasterRecoveryPractices: Array<string> = [
+  "Pin the OneUptime image tag and the PostgreSQL, Redis, and ClickHouse versions so a restore is reproducible.",
+  "Back up persistent volumes on the cadence your RPO requires — the chart does not do this for you.",
+  "Test restores on a schedule. A backup you have never restored is not a backup.",
+  "Keep your values.yaml in version control; it is the other half of your recovery plan.",
+  "Run probes from more than one failure domain so a regional outage does not blind your monitoring.",
+  "Define your own RTO and RPO. On a self-hosted deployment they are properties of your infrastructure, not ours.",
+];
+
+export const AirGapSteps: Array<AirGapStep> = [
+  {
+    title: "Mirror the images",
+    description:
+      "Pull the OneUptime images into your internal registry and point the chart at it. Nothing needs to reach Docker Hub at runtime.",
+    setting: "image.registry / image.repository",
+  },
+  {
+    title: "Turn off the update check",
+    description:
+      "The platform's outbound version check is a single switch. Disabled, the install makes no calls to oneuptime.com.",
+    setting: "updateCheck.disabled",
+  },
+  {
+    title: "Keep DNS internal",
+    description:
+      "Probes ship with public fallback nameservers for external monitoring. On an air-gapped cluster, drop them so resolution stays inside your network.",
+    setting: "probes.<key>.dnsConfig",
+  },
+  {
+    title: "Bring your own notification transports",
+    description:
+      "Point notifications at your internal SMTP relay and SMS gateway instead of any hosted transport.",
+    setting: "smtp / notifications",
+  },
+  {
+    title: "Run AI locally, or not at all",
+    description:
+      "AI features can call an in-cluster vLLM deployment or a local Ollama endpoint, so no prompt leaves your network. They can also be left off entirely.",
+    setting: "vllm.enabled",
+  },
+  {
+    title: "Upgrade from an artifact bundle",
+    description:
+      "Upgrades are `helm upgrade` against a chart and image set you have already mirrored. No connectivity to us is required to apply one.",
+    setting: "helm upgrade",
+  },
+];
+
+export const HardenedImageFeatures: Array<string> = [
+  "Enterprise Edition container images built with additional security controls, selected with `image.type: enterprise-edition`",
+  "Non-root pod and container security contexts, with a RuntimeDefault seccomp profile applied across the chart",
+  "Service-account token mounting disabled by default on probe pods, which need no Kubernetes API credentials",
+  "Optional Chromium OS sandbox for synthetic monitors, with per-execution UID, memory, and disk ceilings",
+  "Dependency scanning, static analysis, and secret scanning on every build of the images you run",
+  "IP allow-listing, external secret references, and your own KMS-backed storage encryption underneath",
+];
+
+export const UpgradeResponsibilities: Array<ResponsibilityRow> = [
+  {
+    area: "Release cadence",
+    oneuptime:
+      "We ship releases frequently — often several times a day — and publish release notes and upgrade notes for each.",
+    customer:
+      "You choose when to apply them. We recommend at least monthly, and pinning a specific tag rather than tracking `release`.",
+  },
+  {
+    area: "Breaking changes",
+    oneuptime:
+      "Documented in the upgrade notes before they ship, with the deprecation policy defining how long older versions are supported.",
+    customer:
+      "Read the upgrade notes before upgrading and test in a non-production environment first.",
+  },
+  {
+    area: "Database migrations",
+    oneuptime:
+      "Shipped as a dedicated migration Job that runs once per release, designed to be backwards-compatible.",
+    customer:
+      "Take a database backup before upgrading and confirm the migration Job completed.",
+  },
+  {
+    area: "Supported versions",
+    oneuptime:
+      "The latest three major versions are fully supported; older versions receive security fixes for an additional 12 months, per the deprecation policy.",
+    customer:
+      "Stay inside the supported window. Support cannot help with a version that has left it.",
+  },
+  {
+    area: "Rollback",
+    oneuptime:
+      "Chart releases are versioned and every image tag stays available, so `helm rollback` works.",
+    customer:
+      "Keep the previous values.yaml and a restorable database backup — a schema migration is not always reversible by rollback alone.",
+  },
+];
+
+export const SharedResponsibilities: Array<ResponsibilityRow> = [
+  {
+    area: "Platform code and security fixes",
+    oneuptime:
+      "We build, test, and publish the platform, and patch vulnerabilities in it.",
+    customer: "You apply the release that contains the fix.",
+  },
+  {
+    area: "Infrastructure",
+    oneuptime:
+      "We publish the chart, sizing guidance, and a production readiness checklist.",
+    customer:
+      "You own the cluster, nodes, storage, network, and their patch levels.",
+  },
+  {
+    area: "Availability",
+    oneuptime:
+      "We ship the HA building blocks: database operators, PDBs, autoscaling, and a dedicated worker tier.",
+    customer:
+      "You configure them, size the cluster, and own the uptime of your own deployment.",
+  },
+  {
+    area: "Data protection",
+    oneuptime:
+      "We encrypt data in transit and support encryption at rest on the stores you configure.",
+    customer:
+      "You own key management, backups, retention, and where the data physically sits.",
+  },
+  {
+    area: "Access control",
+    oneuptime: "We ship SSO/SAML, SCIM, RBAC, API-key scoping, and audit logs.",
+    customer: "You configure your identity provider and review access.",
+  },
+  {
+    area: "Compliance",
+    oneuptime:
+      "We provide our own certifications, evidence, and control documentation for the software and for OneUptime Cloud.",
+    customer:
+      "Certification of your self-hosted deployment covers your environment and is yours to obtain.",
+  },
+];
+
+export const SupportBoundaries: Array<SupportTierRow> = [
+  {
+    key: "community",
+    name: "Community Edition",
+    description:
+      "The full platform, Apache-2.0 licensed, supported by the community and the maintainers on GitHub.",
+    included: [
+      "GitHub issues and discussions",
+      "Public documentation, Helm chart docs, and upgrade notes",
+      "Every product feature — the community edition is not feature-limited",
+      "Security fixes shipped in public releases",
+    ],
+    excluded: [
+      "No response-time commitment",
+      "No private support channel or named contact",
+      "No architecture review or migration assistance",
+      "No hardened Enterprise Edition images",
+    ],
+  },
+  {
+    key: "enterprise",
+    name: "Enterprise Edition",
+    description:
+      "A commercial agreement on top of the same platform, for teams that need accountability alongside the source code.",
+    included: [
+      "Hardened Enterprise Edition container images",
+      "A private support channel with agreed severity levels and response targets",
+      "A named engineering contact and architecture reviews",
+      "Migration and upgrade assistance, plus custom data residency and retention",
+      "Roadmap input and prioritisation of features you depend on",
+    ],
+    excluded: [
+      "We do not receive alerts from, or hold credentials to, your cluster unless you grant them",
+      "Uptime of a self-hosted deployment is not covered by the OneUptime Cloud SLA",
+      "Support scope, hours, and response targets are those written in your order form",
+      "Third-party infrastructure — your cloud, storage, and network — remains your vendor's responsibility",
+    ],
+  },
+];
+
+export const SelfHostedFaqs: Array<SelfHostedFaq> = [
+  {
+    question: "Is the self-hosted edition feature-limited?",
+    answer:
+      "No. The Community Edition is the full platform under Apache 2.0 — monitoring, incidents, on-call, status pages, logs, metrics, traces, dashboards, and workflows. The Enterprise Edition adds hardened images and a commercial support agreement, not product features you would otherwise be missing.",
+  },
+  {
+    question: "Does a self-hosted install phone home?",
+    answer:
+      "The only outbound call the platform makes on its own is a version check, and it is a single switch to disable. With it off and images mirrored into your registry, an install runs with no connectivity to us at all.",
+  },
+  {
+    question: "Who is responsible for uptime when we self-host?",
+    answer:
+      "You are. The OneUptime Cloud SLA covers our hosted service, not infrastructure you operate. What we provide for self-hosted deployments is the HA building blocks, sizing guidance, a production readiness checklist, and — on an enterprise agreement — support with agreed response targets.",
+  },
+  {
+    question:
+      "Can we start self-hosted and move to cloud later, or the reverse?",
+    answer:
+      "Yes, in both directions. It is the same platform and the same schema, so a migration is a data move rather than a re-platform. Enterprise agreements can include migration assistance.",
+  },
+  {
+    question: "What does an architecture assessment cover?",
+    answer:
+      "A working session with our engineers on your topology: deployment model, cluster and storage sizing against your telemetry volume, HA and DR posture, upgrade process, network and air-gap constraints, and where the responsibility boundaries sit. You leave with a reference architecture and a sizing sheet for your environment.",
+  },
+];
+
+export interface SelfHostedContent {
+  deploymentModels: Array<DeploymentModel>;
+  architectureTiers: Array<ArchitectureTier>;
+  sizingTiers: Array<SizingTier>;
+  infrastructureRequirements: Array<RequirementGroup>;
+  availabilityControls: Array<ResilienceControl>;
+  disasterRecoveryPractices: Array<string>;
+  airGapSteps: Array<AirGapStep>;
+  hardenedImageFeatures: Array<string>;
+  upgradeResponsibilities: Array<ResponsibilityRow>;
+  sharedResponsibilities: Array<ResponsibilityRow>;
+  supportBoundaries: Array<SupportTierRow>;
+  faqs: Array<SelfHostedFaq>;
+  helmDocs: HelmDocLinks;
+}
+
+export function getSelfHostedContent(): SelfHostedContent {
+  return {
+    deploymentModels: DeploymentModels,
+    architectureTiers: ArchitectureTiers,
+    sizingTiers: SizingTiers,
+    infrastructureRequirements: InfrastructureRequirements,
+    availabilityControls: AvailabilityControls,
+    disasterRecoveryPractices: DisasterRecoveryPractices,
+    airGapSteps: AirGapSteps,
+    hardenedImageFeatures: HardenedImageFeatures,
+    upgradeResponsibilities: UpgradeResponsibilities,
+    sharedResponsibilities: SharedResponsibilities,
+    supportBoundaries: SupportBoundaries,
+    faqs: SelfHostedFaqs,
+    helmDocs: HelmDocs,
+  };
+}
+
+export default getSelfHostedContent;

--- a/Home/Utils/Sitemap.ts
+++ b/Home/Utils/Sitemap.ts
@@ -74,6 +74,7 @@ const PAGE_CONFIG: Record<string, SitemapPageConfig> = {
   // Important pages
   "/pricing": { priority: 0.9, changefreq: "weekly" },
   "/enterprise/demo": { priority: 0.9, changefreq: "weekly" },
+  "/enterprise/self-hosted": { priority: 0.9, changefreq: "weekly" },
   "/enterprise/overview": { priority: 0.8, changefreq: "weekly" },
   "/trust": { priority: 0.8, changefreq: "weekly" },
   "/about": { priority: 0.7, changefreq: "weekly" },
@@ -88,6 +89,34 @@ const PAGE_CONFIG: Record<string, SitemapPageConfig> = {
 
   // Community and legal
   "/oss-friends": { priority: 0.3, changefreq: "monthly" },
+};
+
+/*
+ * Paths that only exist to redirect somewhere else. Route introspection cannot
+ * tell a redirect from a page, and listing a 301 in the sitemap sends crawlers
+ * (and buyers reading it) to a URL that is not the canonical one.
+ */
+export const REDIRECT_PATHS: Set<string> = new Set<string>([
+  "/self-hosted",
+  "/self-hosting",
+  "/on-premise",
+  "/security",
+  "/security-center",
+  "/trust-center",
+  "/status-page",
+  "/logs-management",
+  "/workflows",
+  "/runbooks",
+  "/on-call",
+  "/scheduled-maintenance",
+]);
+
+export type IsRedirectPathFunction = (path: string) => boolean;
+
+export const isRedirectPath: IsRedirectPathFunction = (
+  path: string,
+): boolean => {
+  return REDIRECT_PATHS.has(path);
 };
 
 // Default config for pages not explicitly listed
@@ -315,6 +344,10 @@ function discoverStaticPaths(): string[] {
           continue;
         }
         if (p.startsWith("/api") || p.startsWith("/blog/post")) {
+          continue;
+        }
+        // Redirects are not canonical pages.
+        if (isRedirectPath(p)) {
           continue;
         }
         // We'll add compare pages separately with real slugs; skip base compare param route

--- a/Home/Views/21-cfr-part-11.ejs
+++ b/Home/Views/21-cfr-part-11.ejs
@@ -18,11 +18,13 @@
         <a href="https://www.ecfr.gov/current/title-21/chapter-I/subchapter-A/part-11">You can read the full regulation here.</a>
     </p>
 
-    <h3>OneUptime's 21 CFR Part 11 Compliance</h3>
+    <h3>OneUptime's 21 CFR Part 11 Alignment</h3>
 
-    <p>OneUptime is certified compliant with 21 CFR Part 11 requirements. Our platform provides the controls and
-        capabilities necessary for organizations operating in FDA-regulated environments to use OneUptime as part of
-        their validated systems.</p>
+    <p>OneUptime is <strong>aligned</strong> with 21 CFR Part 11: we implement the controls the regulation calls for
+        and supply the documentation that supports your validation. There is no certification scheme for vendors under
+        Part 11 &mdash; the regulated organisation validates its own system, in its own environment. Our job is to give
+        you the controls and the evidence to do that. See the <a href="/trust#claims">claims matrix</a> for how this
+        status is defined.</p>
 
     <h3>Key Compliance Controls</h3>
 

--- a/Home/Views/Partials/claims-matrix.ejs
+++ b/Home/Views/Partials/claims-matrix.ejs
@@ -1,0 +1,174 @@
+<%
+/*
+ * Governed claims matrix. Rendered from Home/Utils/Claims.ts — do not write
+ * claim copy directly into this template, or the matrix stops being the single
+ * source of truth it exists to be.
+ *
+ * Expects locals: claimStatuses, claimsMatrix, claimsUnderReviewCount.
+ */
+const statusBadgeClasses = {
+  emerald: 'text-emerald-700 bg-emerald-50 ring-emerald-200/70',
+  blue: 'text-blue-700 bg-blue-50 ring-blue-200/70',
+  violet: 'text-violet-700 bg-violet-50 ring-violet-200/70',
+  slate: 'text-slate-700 bg-slate-50 ring-slate-200/70',
+  amber: 'text-amber-700 bg-amber-50 ring-amber-200/70',
+  cyan: 'text-cyan-700 bg-cyan-50 ring-cyan-200/70'
+};
+
+const statusDotClasses = {
+  emerald: 'bg-emerald-500',
+  blue: 'bg-blue-500',
+  violet: 'bg-violet-500',
+  slate: 'bg-slate-400',
+  amber: 'bg-amber-500',
+  cyan: 'bg-cyan-500'
+};
+
+const statusByKey = {};
+claimStatuses.forEach(function (status) {
+  statusByKey[status.key] = status;
+});
+
+const scopeLabels = {
+  'cloud': 'OneUptime Cloud',
+  'self-hosted': 'Self-hosted',
+  'both': 'Cloud &amp; self-hosted'
+};
+%>
+
+<section id="claims" class="mt-24 lg:mt-32 scroll-mt-24">
+  <div class="max-w-3xl">
+    <h2 class="text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">Governed claims</h2>
+    <p class="mt-4 text-base text-gray-600 leading-7">
+      Every commitment we make about service levels, support, compliance, encryption, deployment, migration, scale,
+      discounts, and contract terms &mdash; each one labelled with how strong it actually is, and linked to the
+      document that makes it true. Where a marketing page and a signed order form disagree, the order form governs.
+    </p>
+  </div>
+
+  <!-- Status vocabulary -->
+  <div class="mt-10 rounded-2xl border border-gray-200 bg-white p-6 sm:p-8">
+    <h3 class="text-sm font-semibold uppercase tracking-wide text-gray-500">What each label means</h3>
+    <dl class="mt-6 grid grid-cols-1 gap-x-8 gap-y-6 sm:grid-cols-2 lg:grid-cols-3">
+      <% claimStatuses.forEach(function (status) { %>
+      <div>
+        <dt>
+          <span
+            class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold ring-1 ring-inset <%= statusBadgeClasses[status.color] %>">
+            <span class="h-1.5 w-1.5 rounded-full <%= statusDotClasses[status.color] %>"></span>
+            <%= status.label %>
+          </span>
+        </dt>
+        <dd class="mt-2.5 text-sm leading-6 text-gray-600"><%= status.definition %></dd>
+        <dd class="mt-2 text-xs leading-5 text-gray-400">
+          <span class="font-medium text-gray-500">Evidence bar:</span> <%= status.evidenceBar %>
+        </dd>
+      </div>
+      <% }); %>
+    </dl>
+  </div>
+
+  <!-- Category jump links -->
+  <nav class="mt-8 flex flex-wrap gap-2">
+    <% claimsMatrix.forEach(function (group) { %>
+    <a href="#claims-<%= group.category.key %>"
+      class="inline-flex items-center rounded-full bg-white px-3.5 py-1.5 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-200 transition-colors hover:bg-gray-50 hover:text-gray-900">
+      <%= group.category.name %>
+      <span class="ml-1.5 text-gray-400"><%= group.claims.length %></span>
+    </a>
+    <% }); %>
+  </nav>
+
+  <!-- The matrix -->
+  <div class="mt-8 space-y-6">
+    <% claimsMatrix.forEach(function (group) { %>
+    <div id="claims-<%= group.category.key %>"
+      class="overflow-hidden rounded-2xl border border-gray-200 bg-white scroll-mt-24">
+      <div class="flex flex-col gap-3 border-b border-gray-100 bg-gray-50/70 px-6 py-5 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 class="text-lg font-semibold text-gray-900"><%= group.category.name %></h3>
+          <p class="mt-1 max-w-2xl text-sm leading-6 text-gray-600"><%= group.category.description %></p>
+        </div>
+        <a href="<%= group.category.governingDocumentUrl %>"
+          class="inline-flex flex-shrink-0 items-center gap-1.5 self-start rounded-lg bg-white px-3 py-1.5 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-200 transition-colors hover:bg-gray-50 hover:text-gray-900">
+          <svg class="h-3.5 w-3.5 text-gray-400" fill="none" stroke="currentColor" stroke-width="1.5"
+            viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round"
+              d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25M9 16.5v.75m3-3v3M15 12v5.25m-4.5-15H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+          </svg>
+          <%= group.category.governingDocument %>
+        </a>
+      </div>
+
+      <ul class="divide-y divide-gray-100">
+        <% group.claims.forEach(function (claim) { %>
+        <li class="px-6 py-6">
+          <div class="grid grid-cols-1 gap-x-8 gap-y-4 lg:grid-cols-12">
+            <div class="lg:col-span-4">
+              <p class="text-sm font-semibold text-gray-900"><%= claim.subject %></p>
+              <div class="mt-2.5 flex flex-wrap items-center gap-2">
+                <span
+                  class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold ring-1 ring-inset <%= statusBadgeClasses[statusByKey[claim.status].color] %>">
+                  <span class="h-1.5 w-1.5 rounded-full <%= statusDotClasses[statusByKey[claim.status].color] %>"></span>
+                  <%= statusByKey[claim.status].label %>
+                </span>
+                <span
+                  class="inline-flex items-center rounded-full bg-gray-50 px-2.5 py-1 text-[11px] font-medium text-gray-600 ring-1 ring-inset ring-gray-200"><%- scopeLabels[claim.scope] %></span>
+                <% if (claim.reviewRequired) { %>
+                <span
+                  class="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2.5 py-1 text-[11px] font-medium text-amber-700 ring-1 ring-inset ring-amber-200/70"
+                  title="<%= claim.reviewNote || 'Pending legal or security sign-off.' %>">
+                  <svg class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round"
+                      d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+                  </svg>
+                  Evidence under review
+                </span>
+                <% } %>
+              </div>
+            </div>
+
+            <div class="lg:col-span-8">
+              <p class="text-sm leading-6 text-gray-900"><%= claim.statement %></p>
+              <p class="mt-2 text-sm leading-6 text-gray-500"><%= claim.qualifier %></p>
+              <p class="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-gray-400">
+                <span><span class="font-medium text-gray-500">Evidence:</span> <%= claim.evidence %></span>
+                <span class="text-gray-300">&middot;</span>
+                <a href="<%= claim.sourceUrl %>" <%= claim.sourceUrl.indexOf('http') === 0 ? 'target="_blank" rel="noopener"' : '' %>
+                  class="font-medium text-gray-600 underline underline-offset-2 hover:text-gray-900">Source</a>
+              </p>
+            </div>
+          </div>
+        </li>
+        <% }); %>
+      </ul>
+    </div>
+    <% }); %>
+  </div>
+
+  <div class="mt-8 rounded-2xl border border-gray-200 bg-gray-50 p-6">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h3 class="text-sm font-semibold text-gray-900">How this matrix is maintained</h3>
+        <p class="mt-1.5 max-w-2xl text-sm leading-6 text-gray-600">
+          Claims are reviewed by legal and security before their status is strengthened, and
+          <% if (claimsUnderReviewCount > 0) { %><strong class="font-semibold text-gray-900"><%= claimsUnderReviewCount %></strong>
+          <%= claimsUnderReviewCount === 1 ? 'claim is' : 'claims are' %> currently marked "evidence under review" &mdash;
+          the wording stays conservative until the reviewer confirms the underlying evidence.<% } else { %>
+          every published claim has had its evidence confirmed.<% } %>
+          Spot something that reads stronger than what we can prove? Tell us and we will correct it.
+        </p>
+      </div>
+      <div class="flex flex-shrink-0 flex-wrap gap-2">
+        <a href="/data/claims.json"
+          class="inline-flex items-center gap-1.5 rounded-lg bg-white px-3.5 py-2 text-xs font-medium text-gray-700 ring-1 ring-inset ring-gray-200 transition-colors hover:bg-gray-50">
+          claims.json
+        </a>
+        <a href="mailto:compliance@oneuptime.com?subject=Claims%20matrix%20question"
+          class="inline-flex items-center gap-1.5 rounded-lg bg-gray-900 px-3.5 py-2 text-xs font-medium text-white transition-colors hover:bg-gray-700">
+          Challenge a claim
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/Home/Views/Partials/enterprise-ready.ejs
+++ b/Home/Views/Partials/enterprise-ready.ejs
@@ -30,7 +30,7 @@
 
             <!-- Description -->
             <p class="max-w-2xl mx-auto text-lg text-gray-600 leading-relaxed">
-                SOC 2 Type II certified and GDPR compliant. Trusted by teams from seed-stage startups to Fortune 500 enterprises.
+                SOC 2 Type II attested and GDPR compliant. Trusted by teams from seed-stage startups to global enterprises.
             </p>
         </div>
 
@@ -245,8 +245,8 @@
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                         </svg>
                     </div>
-                    <h3 class="text-base font-semibold text-gray-900 mb-1">99.99% Uptime</h3>
-                    <p class="text-sm text-gray-500">Enterprise-grade reliability.</p>
+                    <h3 class="text-base font-semibold text-gray-900 mb-1">99.95% Uptime Target</h3>
+                    <p class="text-sm text-gray-500">Enterprise plans, backed by service credits.</p>
                 </div>
             </div>
 

--- a/Home/Views/Partials/home-own-it.ejs
+++ b/Home/Views/Partials/home-own-it.ejs
@@ -147,8 +147,8 @@
                 <span class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-gray-900 mb-4">
                     <svg class="h-5 w-5 text-white" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
                 </span>
-                <p class="text-sm font-semibold text-gray-900">99.99% uptime SLA</p>
-                <p class="mt-1.5 text-xs text-gray-500 leading-relaxed">24/7 support, under 1-hour response.</p>
+                <p class="text-sm font-semibold text-gray-900">99.95% uptime target</p>
+                <p class="mt-1.5 text-xs text-gray-500 leading-relaxed">Enterprise plans. 24/7 support, one-hour P1 response target.</p>
             </div>
             <div data-reveal data-reveal-delay="225" class="relative overflow-hidden rounded-2xl bg-white border border-gray-200 p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-[0_12px_40px_-12px_rgba(0,0,0,0.12)]">
                 <span class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-gray-900 mb-4">

--- a/Home/Views/Partials/product-tabs.ejs
+++ b/Home/Views/Partials/product-tabs.ejs
@@ -385,7 +385,7 @@
                     </div>
                 </div>
                 <div class="mt-8 border-t border-gray-200 pt-6">
-                    <p class="text-sm text-stone-600 font-medium">Never miss a critical alert. 99.99% delivery guarantee.</p>
+                    <p class="text-sm text-stone-600 font-medium">Never miss a critical alert. Redundant delivery across email, SMS, voice, push, and chat, with escalation if nobody acknowledges.</p>
                 </div>
             </div>
 

--- a/Home/Views/Partials/security.ejs
+++ b/Home/Views/Partials/security.ejs
@@ -100,7 +100,7 @@
                         </div>
                         <div class="flex items-center gap-2 text-sm text-gray-600">
                             <svg class="h-4 w-4 text-blue-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
-                            99.99% SLA guarantee
+                            99.95% Enterprise uptime target
                         </div>
                     </div>
                 </div>

--- a/Home/Views/annex-11.ejs
+++ b/Home/Views/annex-11.ejs
@@ -18,11 +18,12 @@
         <a href="https://health.ec.europa.eu/medicinal-products/eudralex/eudralex-volume-4_en">Learn more about EU GMP guidelines.</a>
     </p>
 
-    <h3>OneUptime's Annex 11 Compliance</h3>
+    <h3>OneUptime's Annex 11 Alignment</h3>
 
-    <p>OneUptime is certified compliant with EU GMP Annex 11 requirements. Our platform meets the European regulatory
-        standards for computerised systems, enabling organisations operating under EU GMP regulations to use OneUptime
-        as part of their validated environments.</p>
+    <p>OneUptime is <strong>aligned</strong> with EU GMP Annex 11: the platform implements the controls the annex sets
+        out for computerised systems, and we provide the documentation you need to qualify it. Annex 11 certifies no
+        vendor &mdash; validation sits with the regulated organisation, and inspection is of your system, not ours. See
+        the <a href="/trust#claims">claims matrix</a> for how this status is defined.</p>
 
     <h3>Key Compliance Areas</h3>
 

--- a/Home/Views/csa-star.ejs
+++ b/Home/Views/csa-star.ejs
@@ -18,15 +18,17 @@
         <a href="https://cloudsecurityalliance.org/star">Learn more about CSA STAR.</a>
     </p>
 
-    <h3>OneUptime's CSA STAR Certification</h3>
+    <h3>OneUptime's CSA STAR Status</h3>
 
-    <p>OneUptime is CSA STAR certified, providing independent third-party validation of our cloud security controls.
-        This certification demonstrates that OneUptime has undergone rigorous assessment against the Cloud Controls
-        Matrix (CCM) and meets the highest standards for cloud security.</p>
+    <p>OneUptime is <strong>aligned</strong> with the CSA STAR programme: we have completed a CAIQ self-assessment against the Cloud Controls Matrix (CCM), which is STAR Level 1.
+        We publish it because it is a genuinely useful control-by-control answer sheet for your security review &mdash;
+        but it is a self-assessment, not an independent audit. STAR Level 2 certification would require a third-party
+        assessor, and we say so rather than let the word "certified" do work it has not earned. See the
+        <a href="/trust#claims">claims matrix</a> for how this status is defined.</p>
 
     <h3>Cloud Controls Matrix (CCM)</h3>
 
-    <p>OneUptime's CSA STAR certification covers the following CCM domains:</p>
+    <p>OneUptime's CAIQ self-assessment covers the following CCM domains:</p>
 
     <ul>
         <li><strong>Application and Interface Security:</strong> Secure application design, development, and
@@ -55,13 +57,13 @@
 
     <h3>Transparency</h3>
 
-    <p>As part of our CSA STAR certification, OneUptime publishes our Consensus Assessments Initiative Questionnaire
+    <p>OneUptime publishes its Consensus Assessments Initiative Questionnaire
         (CAIQ) responses, providing transparent insight into our security controls and practices. This enables
         customers to evaluate our security posture efficiently as part of their vendor assessment processes.</p>
 
-    <h3>Request Certification Documentation</h3>
+    <h3>Request our CAIQ Responses</h3>
 
-    <p>For CSA STAR certification documentation or to request our CAIQ responses, please contact us at
+    <p>To request our CAIQ responses or any supporting control documentation, please contact us at
         <a href="mailto:compliance@oneuptime.com">compliance@oneuptime.com</a>.</p>
 
 </section>

--- a/Home/Views/demo.ejs
+++ b/Home/Views/demo.ejs
@@ -91,8 +91,8 @@
                 </div>
                 <div class="hidden sm:block w-px h-10 bg-gray-200"></div>
                 <div class="text-center">
-                  <p class="text-2xl sm:text-3xl font-semibold text-gray-900">99.99%</p>
-                  <p class="text-sm text-gray-500">Uptime SLA</p>
+                  <p class="text-2xl sm:text-3xl font-semibold text-gray-900">99.95%</p>
+                  <p class="text-sm text-gray-500">Enterprise uptime target</p>
                 </div>
                 <div class="hidden sm:block w-px h-10 bg-gray-200"></div>
                 <div class="text-center">
@@ -448,7 +448,7 @@
             Enterprise-grade security & compliance
           </h2>
           <p class="mt-3 sm:mt-4 text-base sm:text-lg text-gray-500 leading-relaxed">
-            Your data deserves the highest level of protection. We maintain rigorous security standards and compliance certifications trusted by Fortune 500 companies.
+            Your data deserves the highest level of protection. Every certification, attestation, and framework we claim is listed in our <a href="/trust#claims" class="font-medium text-gray-700 underline underline-offset-2 hover:text-gray-900">governed claims matrix</a>, with the evidence behind each one.
           </p>
         </div>
 
@@ -640,7 +640,7 @@
             </button>
             <div class="faq-content overflow-hidden max-h-0 transition-all duration-300 ease-out">
               <p class="pb-5 text-gray-500 text-sm leading-relaxed">
-                Yes. OneUptime is fully open source and can be deployed on your own infrastructure using Docker, Kubernetes, or Helm charts. Enterprise customers get dedicated deployment support, custom SLAs, and the option to deploy in air-gapped environments. We also offer managed hosting with custom data residency in US, EU, or APAC regions.
+                Yes. OneUptime is fully open source and deploys on your own infrastructure with our Helm chart on Kubernetes, or with Docker Compose on a single host. It runs air-gapped, with images mirrored to your registry and the update check disabled. Enterprise agreements add hardened images, deployment support, and custom data residency &mdash; and a private cloud option if you want a single-tenant environment you do not operate yourself. The full deployment story is on our <a href="/enterprise/self-hosted" class="font-medium text-gray-700 underline underline-offset-2 hover:text-gray-900">self-hosted page</a>.
               </p>
             </div>
           </div>
@@ -674,7 +674,7 @@
             </button>
             <div class="faq-content overflow-hidden max-h-0 transition-all duration-300 ease-out">
               <p class="pb-5 text-gray-500 text-sm leading-relaxed">
-                Enterprise plans include 99.99% uptime SLA with financial credits, 24/7 priority support with dedicated account managers, and guaranteed response times (15 minutes for critical issues). We also offer custom SLAs tailored to your organization's requirements.
+                Enterprise plans on OneUptime Cloud carry a 99.95% monthly uptime target, with service credits of up to 50% of monthly fees if we miss it. Support includes a one-hour first-response target for P1 issues, 24/7, and a named contact. Response targets are commitments we work to, not credit-backed guarantees &mdash; the exact wording is in the <a href="/legal/sla" class="font-medium text-gray-700 underline underline-offset-2 hover:text-gray-900">SLA</a>, and anything negotiated for you is written into your order form.
               </p>
             </div>
           </div>
@@ -725,7 +725,7 @@
             </button>
             <div class="faq-content overflow-hidden max-h-0 transition-all duration-300 ease-out">
               <p class="pb-5 text-gray-500 text-sm leading-relaxed">
-                Enterprise pricing is based on your usage and requirements. We offer annual contracts with volume discounts, custom invoicing (NET 30/60/90), and flexible terms. Unlike competitors, we don't charge per-host fees that can lead to surprise bills. Book a demo to get a custom quote for your organization.
+                Enterprise pricing is based on your usage and requirements. Annual contracts, volume discounts, purchase-order workflows, and custom invoicing terms are all available, and the terms that apply to you are the ones written into your order form. We don't charge per-host fees that lead to surprise bills. Book a demo for a written quote.
               </p>
             </div>
           </div>
@@ -742,7 +742,7 @@
             </button>
             <div class="faq-content overflow-hidden max-h-0 transition-all duration-300 ease-out">
               <p class="pb-5 text-gray-500 text-sm leading-relaxed">
-                OneUptime is built to handle enterprise scale. Our platform processes billions of data points daily, supports thousands of concurrent monitors, and handles millions of log events per second. Fortune 500 companies trust us to monitor their most critical infrastructure.
+                OneUptime scales horizontally. Telemetry lives in ClickHouse with replication and sharding, a dedicated writer tier keeps insert concurrency bounded while the worker fleet autoscales on queue depth, and there are no product-imposed caps on monitors, users, alerts, or API calls. On a self-hosted deployment your throughput is a function of the cluster you give it &mdash; an <a href="/enterprise/self-hosted#architecture-assessment" class="font-medium text-gray-700 underline underline-offset-2 hover:text-gray-900">architecture assessment</a> sizes it against your actual volume.
               </p>
             </div>
           </div>

--- a/Home/Views/enterprise-overview.ejs
+++ b/Home/Views/enterprise-overview.ejs
@@ -6,7 +6,7 @@
 <head>
     <title>OneUptime Enterprise | Enterprise-Grade Observability Platform</title>
     <meta name="description"
-        content="Enterprise-grade monitoring, incident management, and observability platform. SOC 2 certified, HIPAA compliant, with 99.99% uptime SLA and dedicated support.">
+        content="Enterprise-grade monitoring, incident management, and observability platform. SOC 2 Type II attested, HIPAA compliant, with a 99.95% uptime target on Enterprise plans and dedicated support.">
         <%- include('head', {
     enableGoogleTagManager: typeof enableGoogleTagManager !== 'undefined' ? enableGoogleTagManager : false
 }) -%>
@@ -152,7 +152,7 @@
               </svg>
               <span>Enterprise Grade</span>
               <span class="h-1 w-1 rounded-full bg-gray-300"></span>
-              <span>SOC 2 Certified</span>
+              <span>SOC 2 Type II</span>
               <svg class="h-3.5 w-3.5 text-gray-400 transition-transform group-hover:translate-x-0.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"></path></svg>
             </a>
 
@@ -164,7 +164,7 @@
 
             <!-- Subheadline -->
             <p class="mt-6 text-base leading-7 text-gray-600 sm:text-lg sm:leading-8 max-w-xl mx-auto">
-              Comprehensive monitoring, incident management, and observability platform trusted by Fortune 500 companies. 99.99% uptime SLA with dedicated support.
+              Comprehensive monitoring, incident management, and observability platform for teams that answer to auditors. A 99.95% monthly uptime target on Enterprise plans, backed by service credits, with dedicated support.
             </p>
 
             <!-- CTA Buttons -->
@@ -191,7 +191,7 @@
                 <svg class="h-4 w-4 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
                 </svg>
-                <span>99.99% SLA</span>
+                <span>99.95% uptime target</span>
               </div>
               <div class="flex items-center gap-2">
                 <svg class="h-4 w-4 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
@@ -224,12 +224,12 @@
         <div class="mx-auto max-w-5xl">
           <dl class="grid grid-cols-2 gap-4 sm:grid-cols-4">
             <div class="flex flex-col items-center p-6 rounded-2xl bg-white border border-gray-200 shadow-sm hover:shadow-md transition-shadow">
-              <dd class="text-4xl font-bold tracking-tight text-gray-900 stat-number">99.99%</dd>
-              <dt class="text-sm font-medium text-gray-500 mt-2">Uptime SLA</dt>
+              <dd class="text-4xl font-bold tracking-tight text-gray-900 stat-number">99.95%</dd>
+              <dt class="text-sm font-medium text-gray-500 mt-2">Enterprise uptime target</dt>
             </div>
             <div class="flex flex-col items-center p-6 rounded-2xl bg-white border border-gray-200 shadow-sm hover:shadow-md transition-shadow">
-              <dd class="text-4xl font-bold tracking-tight text-gray-900 stat-number">&lt;1hr</dd>
-              <dt class="text-sm font-medium text-gray-500 mt-2">Response Time</dt>
+              <dd class="text-4xl font-bold tracking-tight text-gray-900 stat-number">1 hr</dd>
+              <dt class="text-sm font-medium text-gray-500 mt-2">P1 first-response target</dt>
             </div>
             <div class="flex flex-col items-center p-6 rounded-2xl bg-white border border-gray-200 shadow-sm hover:shadow-md transition-shadow">
               <dd class="text-4xl font-bold tracking-tight text-gray-900 stat-number">5,000+</dd>
@@ -363,7 +363,7 @@
                 <span class="px-3 py-1 text-xs font-medium text-rose-700 bg-rose-50 rounded-full border border-rose-200">Priority</span>
               </div>
               <h3 class="text-xl font-semibold text-gray-900 mb-3">1-Hour Priority Support</h3>
-              <p class="text-gray-600 mb-6">Round-the-clock priority support with guaranteed 1-hour response time. Multiple channels including dedicated Slack/Teams.</p>
+              <p class="text-gray-600 mb-6">Round-the-clock priority support with a one-hour first-response target for P1 issues. Multiple channels including a dedicated Slack or Teams channel. Severity levels and targets are set in your order form.</p>
               <div class="grid grid-cols-2 gap-3">
                 <div class="flex items-center gap-2 text-sm text-gray-600">
                   <svg class="h-4 w-4 text-rose-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
@@ -411,7 +411,7 @@
             </div>
           </div>
 
-          <!-- SLA Guarantee -->
+          <!-- Uptime target -->
           <div class="group">
             <div class="enterprise-feature-card h-full p-6 rounded-2xl bg-white border border-gray-200 shadow-sm">
               <div class="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-gray-100 border border-gray-200 mb-4">
@@ -419,8 +419,8 @@
                   <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 0 1-1.043 3.296 3.745 3.745 0 0 1-3.296 1.043A3.745 3.745 0 0 1 12 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 0 1-3.296-1.043 3.745 3.745 0 0 1-1.043-3.296A3.745 3.745 0 0 1 3 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 0 1 1.043-3.296 3.746 3.746 0 0 1 3.296-1.043A3.746 3.746 0 0 1 12 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 0 1 3.296 1.043 3.746 3.746 0 0 1 1.043 3.296A3.745 3.745 0 0 1 21 12Z" />
                 </svg>
               </div>
-              <h3 class="text-base font-semibold text-gray-900 mb-1">99.99% Uptime SLA</h3>
-              <p class="text-sm text-gray-500">Financial-backed reliability guarantee.</p>
+              <h3 class="text-base font-semibold text-gray-900 mb-1">99.95% Uptime Target</h3>
+              <p class="text-sm text-gray-500">Service credits of up to 50% of monthly fees if we miss it. <a href="/legal/sla" class="underline underline-offset-2 hover:text-gray-700">Read the SLA</a>.</p>
             </div>
           </div>
 

--- a/Home/Views/footer.ejs
+++ b/Home/Views/footer.ejs
@@ -137,8 +137,10 @@
               <h3 class="text-sm font-semibold text-gray-900">Solutions</h3>
               <ul role="list" class="mt-4 space-y-3">
                 <li><a href="/enterprise/overview" class="text-sm text-gray-600 hover:text-gray-900 transition-colors duration-200">Enterprise</a></li>
+                <li><a href="/enterprise/self-hosted" class="text-sm text-gray-600 hover:text-gray-900 transition-colors duration-200">Self-Hosted</a></li>
                 <li><a href="/enterprise/demo" class="text-sm text-gray-600 hover:text-gray-900 transition-colors duration-200">Request Demo</a></li>
                 <li><a href="/pricing" class="text-sm text-gray-600 hover:text-gray-900 transition-colors duration-200">Pricing</a></li>
+                <li><a href="/trust" class="text-sm text-gray-600 hover:text-gray-900 transition-colors duration-200">Trust Center</a></li>
                 <li><a href="/legal/data-residency" class="text-sm text-gray-600 hover:text-gray-900 transition-colors duration-200">Data Residency</a></li>
               </ul>
 

--- a/Home/Views/gamp-5.ejs
+++ b/Home/Views/gamp-5.ejs
@@ -20,9 +20,11 @@
 
     <h3>OneUptime's GAMP 5 Compliance</h3>
 
-    <p>OneUptime is validated in accordance with GAMP 5 guidelines. As a configurable software product, OneUptime is
-        classified as a GAMP 5 Category 4 system. We provide comprehensive validation documentation and support to help
-        our customers meet their regulatory obligations.</p>
+    <p>OneUptime is <strong>aligned</strong> with GAMP 5. As a configurable software product it is classified as a
+        GAMP 5 Category 4 system, and we provide the validation documentation and support you need to meet your
+        regulatory obligations. GAMP 5 is a guideline rather than a certification scheme: the validated system is
+        yours, and so is the validation. See the <a href="/trust#claims">claims matrix</a> for how this status is
+        defined.</p>
 
     <h3>Software Category Classification</h3>
 

--- a/Home/Views/industries/saas.ejs
+++ b/Home/Views/industries/saas.ejs
@@ -69,7 +69,7 @@
               <svg class="h-4 w-4 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
               </svg>
-              <span>99.99% SLA</span>
+              <span>99.95% uptime target</span>
             </div>
             <div class="flex items-center gap-2">
               <svg class="h-4 w-4 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">

--- a/Home/Views/iso-27017.ejs
+++ b/Home/Views/iso-27017.ejs
@@ -27,7 +27,8 @@
 
     <h3>Certificate of Registration</h3>
 
-    <p>OneUptime has achieved ISO 27017 compliance. </p>
+    <p>ISO/IEC 27017 is audited as an extension of our ISO/IEC 27001 certification rather than as a standalone
+        scheme. Request the certificate of registration to confirm that 27017 is named in its scope.</p>
 
     <p> 
         To request the certificate please

--- a/Home/Views/nav.ejs
+++ b/Home/Views/nav.ejs
@@ -78,6 +78,17 @@
                         <p class="text-xs text-gray-500">Scale with confidence</p>
                       </div>
                     </a>
+                    <a href="/enterprise/self-hosted" class="group flex items-center gap-3 p-3 rounded-lg bg-white/5 hover:bg-white/10 transition-colors">
+                      <div class="w-9 h-9 rounded-lg bg-white/10 flex items-center justify-center">
+                        <svg class="h-4.5 w-4.5 text-white" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.7 5.1a3 3 0 0 1 2.4-1.2h7.8a3 3 0 0 1 2.4 1.2l2.55 3.45a4.5 4.5 0 0 1 .9 2.7"></path>
+                        </svg>
+                      </div>
+                      <div class="flex-1">
+                        <p class="text-sm font-medium text-white">Self-Hosted</p>
+                        <p class="text-xs text-gray-500">Run it on your own infrastructure</p>
+                      </div>
+                    </a>
                     <a href="/enterprise/demo" class="group flex items-center gap-3 p-3 rounded-lg bg-white/5 hover:bg-white/10 transition-colors" data-testid="request-demo-desktop-link">
                       <div class="w-9 h-9 rounded-lg bg-white/10 flex items-center justify-center">
                         <svg class="h-4.5 w-4.5 text-white" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
@@ -116,6 +127,28 @@
                         <div>
                           <p class="text-sm font-medium text-gray-900 group-hover:text-gray-700">Enterprise Overview</p>
                           <p class="text-xs text-gray-500">Solutions for large organizations</p>
+                        </div>
+                      </a>
+                      <a href="/enterprise/self-hosted" class="group flex items-center gap-3 p-2.5 -mx-2.5 rounded-lg hover:bg-gray-50 transition-colors">
+                        <div class="w-8 h-8 rounded-md bg-teal-50 flex items-center justify-center flex-shrink-0">
+                          <svg class="h-4 w-4 text-teal-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3"></path>
+                          </svg>
+                        </div>
+                        <div>
+                          <p class="text-sm font-medium text-gray-900 group-hover:text-gray-700">Self-Hosted</p>
+                          <p class="text-xs text-gray-500">Deployment, architecture, support</p>
+                        </div>
+                      </a>
+                      <a href="/trust" class="group flex items-center gap-3 p-2.5 -mx-2.5 rounded-lg hover:bg-gray-50 transition-colors">
+                        <div class="w-8 h-8 rounded-md bg-blue-50 flex items-center justify-center flex-shrink-0">
+                          <svg class="h-4 w-4 text-blue-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"></path>
+                          </svg>
+                        </div>
+                        <div>
+                          <p class="text-sm font-medium text-gray-900 group-hover:text-gray-700">Trust Center</p>
+                          <p class="text-xs text-gray-500">Certifications, evidence, governed claims</p>
                         </div>
                       </a>
                       <a href="/enterprise/demo" class="group flex items-center gap-3 p-2.5 -mx-2.5 rounded-lg hover:bg-gray-50 transition-colors">
@@ -747,6 +780,10 @@
 
           <a href="/enterprise/demo" class="text-base font-medium text-gray-900 hover:text-gray-700"
             data-testid="request-demo-mobile-link">Request Demo</a>
+
+          <a href="/enterprise/self-hosted" class="text-base font-medium text-gray-900 hover:text-gray-700">Self-Hosted</a>
+
+          <a href="/trust" class="text-base font-medium text-gray-900 hover:text-gray-700">Trust Center</a>
 
           <a href="/support" class="text-base font-medium text-gray-900 hover:text-gray-700">Support</a>
         </div>

--- a/Home/Views/pricing.ejs
+++ b/Home/Views/pricing.ejs
@@ -272,7 +272,7 @@
                       d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
                       clip-rule="evenodd" />
                   </svg>
-                  <span class="text-sm text-gray-500">99.00% SLA</span>
+                  <span class="text-sm text-gray-500">No uptime SLA (best effort)</span>
                 </li>
 
               </ul>
@@ -381,7 +381,7 @@
                       d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
                       clip-rule="evenodd" />
                   </svg>
-                  <span class="text-sm text-gray-500">99.95% SLA</span>
+                  <span class="text-sm text-gray-500">99.9% uptime target</span>
                 </li>
               </ul>
             </div>
@@ -490,7 +490,7 @@
                       d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
                       clip-rule="evenodd" />
                   </svg>
-                  <span class="text-sm text-gray-500">99.99% SLA</span>
+                  <span class="text-sm text-gray-500">99.9% uptime target</span>
                 </li>
               </ul>
             </div>
@@ -1628,9 +1628,7 @@
                   </div>
                 </dt>
                 <dd class="mt-2 pr-12" id="faq-0">
-                  <p class="text-base leading-7 text-gray-600">No, our software is open-source and free. Please feel
-                    free to self-host it. If you choose to use our SaaS service, you will have to pay the full price.
-                    You pay, we keep the lights on.</p>
+                  <p class="text-base leading-7 text-gray-600">No. The software is open-source and free &mdash; self-host it for nothing, at any scale. On our SaaS service everyone pays the same published price. You pay, we keep the lights on.</p>
                 </dd>
               </div>
 
@@ -1687,9 +1685,7 @@
                   </div>
                 </dt>
                 <dd class="mt-2 pr-12" id="faq-0">
-                  <p class="text-base leading-7 text-gray-600">Annual plans have a 17% discount. You can upgrade your
-                    current plan to an annual plan to avail of the discount. If you're an enterprise, contact us for a
-                    custom quote.</p>
+                  <p class="text-base leading-7 text-gray-600">Annual billing is discounted against monthly billing &mdash; the annual price for each plan is shown in the table above. You can upgrade an existing plan to annual billing at any time. Volume discounts are available on high monitor counts, high telemetry ingest, and extended retention; contact us for a written quote.</p>
                 </dd>
               </div>
             </dl>

--- a/Home/Views/security.ejs
+++ b/Home/Views/security.ejs
@@ -7,6 +7,8 @@
 
   <p>Security is foundational to OneUptime. Our customers trust us to monitor their production systems, so we hold ourselves to a high standard for how we design, operate, and audit the Service. This page summarizes the administrative, technical, and physical safeguards we use to protect your data. For specific regulatory programs, see the linked compliance pages.</p>
 
+  <p><strong>Looking for the short version, or for evidence?</strong> Our <a href="/trust">Trust Center</a> is the canonical place for both. It carries a <a href="/trust#claims">governed claims matrix</a> that labels every statement we make about service levels, support, compliance, encryption, deployment, migration, scale, discounts, and contract terms &mdash; certified, attested, compliant, aligned, in progress, or customer-configurable &mdash; and links each one to the document that makes it true.</p>
+
   <p>If you believe you've found a vulnerability, please email <a href="mailto:security@oneuptime.com">security@oneuptime.com</a>. We acknowledge reports within 2 business days and welcome coordinated disclosure.</p>
 
   <h3>1. Organizational security</h3>
@@ -24,7 +26,7 @@
     <li><strong>Dependency scanning</strong> runs on every build to catch known vulnerabilities in open-source dependencies.</li>
     <li><strong>Static analysis and secret scanning</strong> run in CI to prevent common vulnerability classes and accidental credential leaks.</li>
     <li><strong>Penetration testing</strong> is performed by an independent third party at least annually. Summary reports are available under NDA for qualifying customers — contact <a href="mailto:security@oneuptime.com">security@oneuptime.com</a>.</li>
-    <li><strong>Vulnerability management.</strong> We triage reports by severity and target remediation within industry-standard SLAs (critical: 7 days, high: 30 days, medium: 90 days).</li>
+    <li><strong>Vulnerability management.</strong> We triage reports by severity and work to internal remediation targets (critical: 7 days, high: 30 days, medium: 90 days). These are targets we hold ourselves to, not contractual commitments.</li>
   </ul>
 
   <h3>3. Data protection</h3>
@@ -60,7 +62,7 @@
   </ul>
 
   <h3>7. Certifications and compliance</h3>
-  <p>We maintain the following programs. Each page explains scope, how to request evidence, and what it means for you as a customer:</p>
+  <p>We maintain the following programs. Each page explains scope, how to request evidence, and what it means for you as a customer. The <a href="/trust#claims">claims matrix</a> states, for each one, whether we are certified, attested, compliant, or aligned &mdash; the words are not interchangeable:</p>
   <ul>
     <li><a href="/legal/soc-2">SOC 2</a> and <a href="/legal/soc-3">SOC 3</a></li>
     <li><a href="/legal/iso-27001">ISO/IEC 27001</a>, <a href="/legal/iso-27017">ISO/IEC 27017</a>, and <a href="/legal/iso-27018">ISO/IEC 27018</a></li>

--- a/Home/Views/self-hosted.ejs
+++ b/Home/Views/self-hosted.ejs
@@ -1,0 +1,853 @@
+<!DOCTYPE html>
+<html lang="en" id="self-hosted">
+
+<meta http-equiv="content-type" content="text/html;charset=utf-8" />
+
+<head>
+  <title>Self-Hosted OneUptime | Deployment, Architecture & Support</title>
+  <meta name="description"
+    content="Run the full OneUptime platform on your own infrastructure. Deployment models, reference architecture, Kubernetes requirements, high availability, air-gapped operation, hardened images, and support boundaries.">
+  <%- include('head', {
+    enableGoogleTagManager: typeof enableGoogleTagManager !== 'undefined' ? enableGoogleTagManager : false
+  }) -%>
+
+  <style>
+    .sh-card {
+      transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.3s cubic-bezier(0.4, 0, 0.2, 1), border-color 0.3s ease;
+    }
+
+    .sh-card:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 18px 40px -20px rgba(15, 23, 42, 0.25);
+    }
+
+    .sh-code {
+      font-family: "Source Code Pro", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+
+    .sh-scroll {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    section[id] {
+      scroll-margin-top: 6rem;
+    }
+  </style>
+</head>
+
+<body class="bg-white antialiased text-gray-900">
+  <%- include('nav') -%>
+
+  <main id="main-content">
+
+    <!-- ============================================================ HERO -->
+    <div class="relative isolate overflow-hidden bg-white" id="self-hosted-hero">
+      <div
+        class="absolute inset-0 -z-10 h-full w-full bg-white bg-[linear-gradient(to_right,#f0f0f0_1px,transparent_1px),linear-gradient(to_bottom,#f0f0f0_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_110%)]">
+      </div>
+
+      <div id="self-hosted-grid-glow" class="absolute inset-0 -z-9 pointer-events-none"
+        style="opacity: 0; transition: opacity 0.3s ease-out; background: linear-gradient(to right, rgba(16, 185, 129, 0.28) 1px, transparent 1px), linear-gradient(to bottom, rgba(16, 185, 129, 0.28) 1px, transparent 1px); background-size: 4rem 4rem; -webkit-mask-image: radial-gradient(circle 250px at var(--mouse-x, 50%) var(--mouse-y, 50%), black 0%, transparent 100%); mask-image: radial-gradient(circle 250px at var(--mouse-x, 50%) var(--mouse-y, 50%), black 0%, transparent 100%);">
+      </div>
+
+      <div class="py-20 sm:py-28 lg:py-32">
+        <div class="mx-auto max-w-7xl px-6 lg:px-8">
+          <div class="mx-auto max-w-3xl text-center">
+            <span
+              class="mb-8 inline-flex items-center gap-2 rounded-full bg-gray-50 px-4 py-1.5 text-sm text-gray-600 ring-1 ring-inset ring-gray-200">
+              <svg class="h-4 w-4 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="2"
+                stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M5.25 14.25h13.5m-13.5 0a3 3 0 0 1-3-3m3 3a3 3 0 1 0 0 6h13.5a3 3 0 1 0 0-6m-16.5-3a3 3 0 0 1 3-3h13.5a3 3 0 0 1 3 3m-19.5 0a4.5 4.5 0 0 1 .9-2.7L5.7 5.1a3 3 0 0 1 2.4-1.2h7.8a3 3 0 0 1 2.4 1.2l2.55 3.45a4.5 4.5 0 0 1 .9 2.7m0 0a3 3 0 0 1-3 3" />
+              </svg>
+              <span>Self-Hosted</span>
+              <span class="h-1 w-1 rounded-full bg-gray-300"></span>
+              <span>Apache 2.0</span>
+            </span>
+
+            <h1 class="text-4xl font-medium tracking-tight text-gray-900 sm:text-5xl lg:text-[3.5rem] lg:leading-[1.15]">
+              Run the whole platform
+              <span class="text-gray-500">inside your perimeter.</span>
+            </h1>
+
+            <p class="mt-6 text-base leading-7 text-gray-600 sm:text-lg sm:leading-8 max-w-2xl mx-auto">
+              Monitoring, incidents, on-call, status pages, logs, metrics, and traces &mdash; deployed on your
+              Kubernetes cluster, in your cloud or data centre, air-gapped if it has to be. Same product as our
+              cloud, no feature gates, no telemetry leaving your network.
+            </p>
+
+            <div class="mt-10 flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4">
+              <a href="#architecture-assessment"
+                class="w-full sm:w-auto inline-flex items-center justify-center rounded-lg bg-gray-900 px-6 py-2.5 text-sm font-medium text-white shadow-sm transition-all hover:bg-gray-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900">
+                Book an architecture assessment
+                <svg class="ml-2 h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                </svg>
+              </a>
+              <a href="<%= selfHosted.helmDocs.installation %>" target="_blank" rel="noopener"
+                class="w-full sm:w-auto inline-flex items-center justify-center rounded-lg bg-white px-6 py-2.5 text-sm font-medium text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 transition-all hover:bg-gray-50">
+                Read the install guide
+              </a>
+            </div>
+
+            <div class="mt-12 flex flex-wrap items-center justify-center gap-x-6 gap-y-3 text-sm text-gray-500">
+              <div class="flex items-center gap-2">
+                <svg class="h-4 w-4 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="2"
+                  stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                </svg>
+                <span>No feature gates</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <svg class="h-4 w-4 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="2"
+                  stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                </svg>
+                <span>Air-gapped capable</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <svg class="h-4 w-4 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="2"
+                  stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                </svg>
+                <span>Hardened enterprise images</span>
+              </div>
+              <div class="flex items-center gap-2">
+                <svg class="h-4 w-4 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke-width="2"
+                  stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                </svg>
+                <span>Your data, your keys</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Quick start -->
+          <div class="mx-auto mt-16 max-w-3xl">
+            <div class="overflow-hidden rounded-2xl bg-gray-900 shadow-xl ring-1 ring-gray-900/10">
+              <div class="flex items-center gap-2 border-b border-white/10 px-4 py-3">
+                <span class="h-2.5 w-2.5 rounded-full bg-rose-400/70"></span>
+                <span class="h-2.5 w-2.5 rounded-full bg-amber-400/70"></span>
+                <span class="h-2.5 w-2.5 rounded-full bg-emerald-400/70"></span>
+                <span class="ml-2 text-xs font-medium text-gray-400">Install on Kubernetes</span>
+              </div>
+              <div class="sh-scroll px-5 py-5">
+                <pre class="sh-code text-[13px] leading-6 text-gray-200"><span class="text-gray-500"># Add the chart repository</span>
+<span class="text-emerald-400">helm</span> repo add oneuptime https://helm-chart.oneuptime.com/
+
+<span class="text-gray-500"># Set your host and storage class in values.yaml, then install</span>
+<span class="text-emerald-400">helm</span> install oneuptime oneuptime/oneuptime -f values.yaml</pre>
+              </div>
+            </div>
+            <p class="mt-3 text-center text-xs text-gray-500">
+              The whole platform, one chart. Full configuration reference in the
+              <a href="<%= selfHosted.helmDocs.configuration %>" target="_blank" rel="noopener"
+                class="text-gray-700 underline underline-offset-2 hover:text-gray-900">chart docs</a>.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Section nav -->
+    <div class="sticky top-0 z-20 border-y border-gray-200 bg-white/90 backdrop-blur">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <nav class="sh-scroll flex items-center gap-6 py-3 text-sm text-gray-500 whitespace-nowrap">
+          <a href="#deployment-models" class="hover:text-gray-900">Deployment models</a>
+          <a href="#reference-architecture" class="hover:text-gray-900">Architecture</a>
+          <a href="#requirements" class="hover:text-gray-900">Requirements</a>
+          <a href="#availability" class="hover:text-gray-900">HA &amp; DR</a>
+          <a href="#upgrades" class="hover:text-gray-900">Upgrades</a>
+          <a href="#air-gapped" class="hover:text-gray-900">Air-gapped</a>
+          <a href="#hardened-images" class="hover:text-gray-900">Hardened images</a>
+          <a href="#data-residency" class="hover:text-gray-900">Data residency</a>
+          <a href="#support" class="hover:text-gray-900">Support boundaries</a>
+        </nav>
+      </div>
+    </div>
+
+    <!-- ================================================ DEPLOYMENT MODELS -->
+    <section id="deployment-models" class="bg-white py-20 sm:py-28">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <div class="max-w-3xl">
+          <p class="text-sm font-medium uppercase tracking-wide text-emerald-600">Deployment models</p>
+          <h2 class="mt-3 text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">Four ways to run OneUptime
+          </h2>
+          <p class="mt-4 text-base leading-7 text-gray-600">
+            The same platform, the same container images. What changes is who owns the infrastructure and who is
+            accountable for upgrades.
+          </p>
+        </div>
+
+        <div class="mt-12 grid grid-cols-1 gap-5 lg:grid-cols-2">
+          <% selfHosted.deploymentModels.forEach(function(model) { %>
+          <div
+            class="sh-card relative flex h-full flex-col rounded-2xl border <%= model.recommended ? 'border-emerald-200 bg-emerald-50/30' : 'border-gray-200 bg-white' %> p-7 shadow-sm">
+            <% if (model.recommended) { %>
+            <span
+              class="absolute right-6 top-6 rounded-full bg-emerald-600 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-white">Recommended</span>
+            <% } %>
+
+            <h3 class="pr-28 text-xl font-semibold text-gray-900"><%= model.name %></h3>
+            <p class="mt-1.5 text-sm font-medium text-gray-500"><%= model.tagline %></p>
+            <p class="mt-4 text-sm leading-6 text-gray-600"><%= model.bestFor %></p>
+
+            <dl class="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div class="rounded-xl bg-white/70 p-3 ring-1 ring-inset ring-gray-200">
+                <dt class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Infrastructure</dt>
+                <dd class="mt-1 text-sm text-gray-700"><%= model.infrastructure %></dd>
+              </div>
+              <div class="rounded-xl bg-white/70 p-3 ring-1 ring-inset ring-gray-200">
+                <dt class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Upgrades</dt>
+                <dd class="mt-1 text-sm text-gray-700"><%= model.upgrades %></dd>
+              </div>
+            </dl>
+
+            <ul class="mt-6 space-y-2.5">
+              <% model.highlights.forEach(function(highlight) { %>
+              <li class="flex gap-2.5 text-sm leading-6 text-gray-600">
+                <svg class="mt-1 h-4 w-4 flex-shrink-0 text-emerald-500" fill="none" viewBox="0 0 24 24"
+                  stroke-width="2" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                </svg>
+                <span><%= highlight %></span>
+              </li>
+              <% }); %>
+            </ul>
+
+            <div class="mt-auto pt-6">
+              <a href="<%= model.docsUrl %>" <%= model.docsUrl.startsWith('http') ? 'target="_blank" rel="noopener"' : '' %>
+                class="inline-flex items-center gap-1.5 text-sm font-medium text-gray-900 hover:text-gray-600">
+                Documentation
+                <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"></path>
+                </svg>
+              </a>
+            </div>
+          </div>
+          <% }); %>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================ REFERENCE ARCHITECTURE -->
+    <section id="reference-architecture" class="border-t border-gray-100 bg-gray-50/60 py-20 sm:py-28">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <div class="max-w-3xl">
+          <p class="text-sm font-medium uppercase tracking-wide text-emerald-600">Reference architecture</p>
+          <h2 class="mt-3 text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">What actually gets deployed
+          </h2>
+          <p class="mt-4 text-base leading-7 text-gray-600">
+            Four tiers, all inside your cluster. Nothing in this diagram calls out to us at runtime.
+          </p>
+        </div>
+
+        <div class="mt-12 space-y-6">
+          <% selfHosted.architectureTiers.forEach(function(tier, tierIndex) { %>
+          <div class="overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+            <div class="flex flex-col gap-3 border-b border-gray-100 px-6 py-5 sm:flex-row sm:items-center sm:gap-5">
+              <div class="flex items-center gap-3">
+                <span
+                  class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-<%= tier.accent %>-50 text-sm font-semibold text-<%= tier.accent %>-600 ring-1 ring-inset ring-<%= tier.accent %>-100"><%= tierIndex + 1 %></span>
+                <h3 class="text-lg font-semibold text-gray-900"><%= tier.name %></h3>
+              </div>
+              <p class="text-sm leading-6 text-gray-600 sm:border-l sm:border-gray-200 sm:pl-5"><%= tier.description %>
+              </p>
+            </div>
+
+            <div class="grid grid-cols-1 gap-4 p-6 sm:grid-cols-2 lg:grid-cols-3">
+              <% tier.components.forEach(function(component) { %>
+              <div class="flex h-full flex-col rounded-xl bg-gray-50/70 p-5 ring-1 ring-inset ring-gray-100">
+                <h4 class="text-sm font-semibold text-gray-900"><%= component.name %></h4>
+                <p class="mt-2 flex-1 text-sm leading-6 text-gray-600"><%= component.description %></p>
+                <p class="mt-3 inline-flex w-fit items-center gap-1.5 rounded-full bg-white px-2.5 py-1 text-[11px] font-medium text-gray-600 ring-1 ring-inset ring-gray-200">
+                  <svg class="h-3 w-3 text-gray-400" fill="none" stroke="currentColor" stroke-width="2"
+                    viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round"
+                      d="M3 7.5 7.5 3m0 0L12 7.5M7.5 3v18m13.5-4.5L16.5 21m0 0L12 16.5m4.5 4.5V3"></path>
+                  </svg>
+                  <%= component.scaling %>
+                </p>
+              </div>
+              <% }); %>
+            </div>
+          </div>
+          <% }); %>
+        </div>
+
+        <p class="mt-8 text-sm text-gray-500">
+          Every component above is defined in the
+          <a href="<%= selfHosted.helmDocs.chart %>" target="_blank" rel="noopener"
+            class="font-medium text-gray-700 underline underline-offset-2 hover:text-gray-900">public Helm chart</a>
+          &mdash; read the templates before you deploy them.
+        </p>
+      </div>
+    </section>
+
+    <!-- ======================================================= REQUIREMENTS -->
+    <section id="requirements" class="bg-white py-20 sm:py-28">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <div class="max-w-3xl">
+          <p class="text-sm font-medium uppercase tracking-wide text-emerald-600">Requirements</p>
+          <h2 class="mt-3 text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">Kubernetes and
+            infrastructure requirements</h2>
+          <p class="mt-4 text-base leading-7 text-gray-600">
+            What your platform team needs to have in place before the first <span class="sh-code">helm install</span>.
+          </p>
+        </div>
+
+        <div class="mt-12 grid grid-cols-1 gap-5 sm:grid-cols-2">
+          <% selfHosted.infrastructureRequirements.forEach(function(group) { %>
+          <div class="sh-card rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <h3 class="text-base font-semibold text-gray-900"><%= group.title %></h3>
+            <ul class="mt-4 space-y-3">
+              <% group.items.forEach(function(item) { %>
+              <li class="flex gap-3 text-sm leading-6 text-gray-600">
+                <span class="mt-2 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-gray-300"></span>
+                <span><%= item %></span>
+              </li>
+              <% }); %>
+            </ul>
+          </div>
+          <% }); %>
+        </div>
+
+        <!-- Sizing -->
+        <div class="mt-16">
+          <h3 class="text-xl font-semibold tracking-tight text-gray-900">Starting points for sizing</h3>
+          <p class="mt-2 max-w-3xl text-sm leading-6 text-gray-600">
+            Indicative starting points, not a commitment. Real sizing depends on your telemetry volume and retention
+            policy &mdash; which is exactly what an architecture assessment works out with you.
+          </p>
+
+          <div class="sh-scroll mt-6 rounded-2xl border border-gray-200 shadow-sm">
+            <table class="min-w-full divide-y divide-gray-200 text-left">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th scope="col" class="px-6 py-3.5 text-xs font-semibold uppercase tracking-wide text-gray-500">Tier
+                  </th>
+                  <th scope="col" class="px-6 py-3.5 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Workload</th>
+                  <th scope="col" class="px-6 py-3.5 text-xs font-semibold uppercase tracking-wide text-gray-500">Nodes
+                  </th>
+                  <th scope="col" class="px-6 py-3.5 text-xs font-semibold uppercase tracking-wide text-gray-500">CPU
+                  </th>
+                  <th scope="col" class="px-6 py-3.5 text-xs font-semibold uppercase tracking-wide text-gray-500">Memory
+                  </th>
+                  <th scope="col" class="px-6 py-3.5 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    Storage</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100 bg-white">
+                <% selfHosted.sizingTiers.forEach(function(tier) { %>
+                <tr>
+                  <td class="px-6 py-5 align-top">
+                    <p class="text-sm font-semibold text-gray-900"><%= tier.name %></p>
+                    <p class="mt-1 max-w-xs text-xs leading-5 text-gray-500"><%= tier.notes %></p>
+                  </td>
+                  <td class="px-6 py-5 align-top text-sm text-gray-600"><%= tier.workload %></td>
+                  <td class="px-6 py-5 align-top text-sm text-gray-600"><%= tier.nodes %></td>
+                  <td class="px-6 py-5 align-top text-sm text-gray-600"><%= tier.cpu %></td>
+                  <td class="px-6 py-5 align-top text-sm text-gray-600"><%= tier.memory %></td>
+                  <td class="px-6 py-5 align-top text-sm text-gray-600"><%= tier.storage %></td>
+                </tr>
+                <% }); %>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================================================== HA & DR -->
+    <section id="availability" class="border-t border-gray-100 bg-gray-50/60 py-20 sm:py-28">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <div class="max-w-3xl">
+          <p class="text-sm font-medium uppercase tracking-wide text-emerald-600">High availability</p>
+          <h2 class="mt-3 text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">Availability and disaster
+            recovery</h2>
+          <p class="mt-4 text-base leading-7 text-gray-600">
+            We ship the building blocks. On a self-hosted deployment the uptime number belongs to you &mdash; our
+            cloud SLA does not extend to infrastructure you operate.
+          </p>
+        </div>
+
+        <div class="mt-12 grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
+          <% selfHosted.availabilityControls.forEach(function(control) { %>
+          <div class="sh-card flex h-full flex-col rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+            <h3 class="text-base font-semibold text-gray-900"><%= control.title %></h3>
+            <p class="mt-2.5 flex-1 text-sm leading-6 text-gray-600"><%= control.description %></p>
+            <code
+              class="sh-code mt-4 block truncate rounded-lg bg-gray-900 px-3 py-2 text-[12px] text-emerald-300"><%= control.setting %></code>
+          </div>
+          <% }); %>
+        </div>
+
+        <div class="mt-10 rounded-2xl border border-gray-200 bg-white p-7 shadow-sm">
+          <div class="flex items-center gap-3">
+            <span class="flex h-9 w-9 items-center justify-center rounded-lg bg-amber-50 ring-1 ring-inset ring-amber-100">
+              <svg class="h-5 w-5 text-amber-600" fill="none" stroke="currentColor" stroke-width="1.5"
+                viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75" />
+              </svg>
+            </span>
+            <h3 class="text-lg font-semibold text-gray-900">Disaster recovery is a shared exercise</h3>
+          </div>
+          <ul class="mt-6 grid grid-cols-1 gap-x-8 gap-y-3 md:grid-cols-2">
+            <% selfHosted.disasterRecoveryPractices.forEach(function(practice) { %>
+            <li class="flex gap-3 text-sm leading-6 text-gray-600">
+              <svg class="mt-1 h-4 w-4 flex-shrink-0 text-gray-400" fill="none" stroke="currentColor" stroke-width="2"
+                viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+              </svg>
+              <span><%= practice %></span>
+            </li>
+            <% }); %>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- ========================================================== UPGRADES -->
+    <section id="upgrades" class="bg-white py-20 sm:py-28">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <div class="max-w-3xl">
+          <p class="text-sm font-medium uppercase tracking-wide text-emerald-600">Upgrades</p>
+          <h2 class="mt-3 text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">Who is responsible for
+            upgrades</h2>
+          <p class="mt-4 text-base leading-7 text-gray-600">
+            We ship. You choose when to apply. Here is the line, drawn precisely, so procurement does not have to
+            guess.
+          </p>
+        </div>
+
+        <div class="sh-scroll mt-12 rounded-2xl border border-gray-200 shadow-sm">
+          <table class="min-w-full divide-y divide-gray-200 text-left">
+            <thead class="bg-gray-50">
+              <tr>
+                <th scope="col" class="w-1/5 px-6 py-3.5 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Area</th>
+                <th scope="col" class="px-6 py-3.5 text-xs font-semibold uppercase tracking-wide text-emerald-600">
+                  OneUptime does this</th>
+                <th scope="col" class="px-6 py-3.5 text-xs font-semibold uppercase tracking-wide text-gray-500">You do
+                  this</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 bg-white">
+              <% selfHosted.upgradeResponsibilities.forEach(function(row) { %>
+              <tr>
+                <th scope="row" class="px-6 py-5 align-top text-sm font-semibold text-gray-900"><%= row.area %></th>
+                <td class="px-6 py-5 align-top text-sm leading-6 text-gray-600"><%= row.oneuptime %></td>
+                <td class="px-6 py-5 align-top text-sm leading-6 text-gray-600"><%= row.customer %></td>
+              </tr>
+              <% }); %>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="mt-6 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+          <a href="<%= selfHosted.helmDocs.upgradeNotes %>" target="_blank" rel="noopener"
+            class="font-medium text-gray-700 underline underline-offset-2 hover:text-gray-900">Upgrade notes</a>
+          <a href="<%= selfHosted.helmDocs.releases %>" target="_blank" rel="noopener"
+            class="font-medium text-gray-700 underline underline-offset-2 hover:text-gray-900">Release notes</a>
+          <a href="/legal/deprecation-policy"
+            class="font-medium text-gray-700 underline underline-offset-2 hover:text-gray-900">Deprecation policy</a>
+          <a href="<%= selfHosted.helmDocs.productionChecklist %>" target="_blank" rel="noopener"
+            class="font-medium text-gray-700 underline underline-offset-2 hover:text-gray-900">Production readiness
+            checklist</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ======================================================= AIR-GAPPED -->
+    <section id="air-gapped" class="border-t border-gray-100 bg-gray-900 py-20 sm:py-28">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <div class="max-w-3xl">
+          <p class="text-sm font-medium uppercase tracking-wide text-emerald-400">Air-gapped</p>
+          <h2 class="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">Runs with no outbound
+            connectivity</h2>
+          <p class="mt-4 text-base leading-7 text-gray-400">
+            Six things to set, and the install never speaks to the internet again. This is the same chart everyone
+            else runs &mdash; there is no special air-gapped build to procure.
+          </p>
+        </div>
+
+        <div class="mt-12 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <% selfHosted.airGapSteps.forEach(function(step, stepIndex) { %>
+          <div class="rounded-2xl border border-white/10 bg-white/[0.03] p-6 transition-colors hover:border-white/20">
+            <div class="flex items-center gap-3">
+              <span
+                class="flex h-7 w-7 items-center justify-center rounded-lg bg-emerald-500/10 text-xs font-semibold text-emerald-400 ring-1 ring-inset ring-emerald-500/20"><%= stepIndex + 1 %></span>
+              <h3 class="text-base font-semibold text-white"><%= step.title %></h3>
+            </div>
+            <p class="mt-3 text-sm leading-6 text-gray-400"><%= step.description %></p>
+            <code
+              class="sh-code mt-4 block truncate rounded-lg bg-black/40 px-3 py-2 text-[12px] text-emerald-300"><%= step.setting %></code>
+          </div>
+          <% }); %>
+        </div>
+
+        <div class="mt-10 rounded-2xl border border-white/10 bg-white/[0.03] p-6">
+          <p class="text-sm leading-6 text-gray-400">
+            <span class="font-semibold text-white">One honest caveat.</span> Anything that calls an external service by
+            design &mdash; a hosted AI model, a third-party SMS gateway, public DNS for external monitoring &mdash;
+            needs an internal equivalent or has to stay switched off. An architecture assessment goes through your
+            specific list.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- =================================================== HARDENED IMAGES -->
+    <section id="hardened-images" class="bg-white py-20 sm:py-28">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <div class="grid grid-cols-1 gap-12 lg:grid-cols-2 lg:gap-16">
+          <div>
+            <p class="text-sm font-medium uppercase tracking-wide text-emerald-600">Hardened images</p>
+            <h2 class="mt-3 text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">Enterprise Edition
+              hardening</h2>
+            <p class="mt-4 text-base leading-7 text-gray-600">
+              Community and Enterprise run the same product. What the Enterprise Edition changes is the container
+              image and what sits around it &mdash; selected with one chart value, and it requires a license.
+            </p>
+
+            <div class="mt-8 rounded-2xl bg-gray-900 p-5 shadow-lg">
+              <p class="text-[11px] font-semibold uppercase tracking-wide text-gray-500">values.yaml</p>
+              <pre class="sh-code mt-2 text-[13px] leading-6 text-gray-200">image:
+  type: <span class="text-emerald-400">enterprise-edition</span>
+  registry: <span class="text-emerald-400">registry.internal.example.com</span>
+  tag: <span class="text-emerald-400">"8.0.1234"</span></pre>
+            </div>
+
+            <a href="#architecture-assessment"
+              class="mt-8 inline-flex items-center gap-2 rounded-lg bg-gray-900 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-700">
+              Talk to us about Enterprise Edition
+              <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+              </svg>
+            </a>
+          </div>
+
+          <ul class="space-y-4">
+            <% selfHosted.hardenedImageFeatures.forEach(function(feature) { %>
+            <li class="flex gap-3.5 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+              <svg class="mt-0.5 h-5 w-5 flex-shrink-0 text-emerald-500" fill="none" viewBox="0 0 24 24"
+                stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M9 12.75 11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 0 1-1.043 3.296 3.745 3.745 0 0 1-3.296 1.043A3.745 3.745 0 0 1 12 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 0 1-3.296-1.043 3.745 3.745 0 0 1-1.043-3.296A3.745 3.745 0 0 1 3 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 0 1 1.043-3.296 3.746 3.746 0 0 1 3.296-1.043A3.746 3.746 0 0 1 12 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 0 1 3.296 1.043 3.746 3.746 0 0 1 1.043 3.296A3.745 3.745 0 0 1 21 12Z" />
+              </svg>
+              <span class="text-sm leading-6 text-gray-600"><%= feature %></span>
+            </li>
+            <% }); %>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- ===================================================== DATA RESIDENCY -->
+    <section id="data-residency" class="border-t border-gray-100 bg-gray-50/60 py-20 sm:py-28">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <div class="max-w-3xl">
+          <p class="text-sm font-medium uppercase tracking-wide text-emerald-600">Data residency</p>
+          <h2 class="mt-3 text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">Your data sits where you say
+            it sits</h2>
+        </div>
+
+        <div class="mt-12 grid grid-cols-1 gap-5 lg:grid-cols-3">
+          <div class="sh-card rounded-2xl border border-gray-200 bg-white p-7 shadow-sm">
+            <span class="flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-50 ring-1 ring-inset ring-emerald-100">
+              <svg class="h-5 w-5 text-emerald-600" fill="none" stroke="currentColor" stroke-width="1.5"
+                viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
+              </svg>
+            </span>
+            <h3 class="mt-5 text-base font-semibold text-gray-900">Self-hosted</h3>
+            <p class="mt-2 text-sm leading-6 text-gray-600">
+              Data never leaves the cluster you deployed. Residency is a property of where you put the cluster, and no
+              agreement with us is needed to prove it.
+            </p>
+          </div>
+
+          <div class="sh-card rounded-2xl border border-gray-200 bg-white p-7 shadow-sm">
+            <span class="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-50 ring-1 ring-inset ring-blue-100">
+              <svg class="h-5 w-5 text-blue-600" fill="none" stroke="currentColor" stroke-width="1.5"
+                viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Zm0 0a8.949 8.949 0 0 0 4.951-1.488A3.987 3.987 0 0 0 13 16h-2a3.987 3.987 0 0 0-3.951 3.512A8.949 8.949 0 0 0 12 21Zm3-11.25a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+              </svg>
+            </span>
+            <h3 class="mt-5 text-base font-semibold text-gray-900">Private cloud</h3>
+            <p class="mt-2 text-sm leading-6 text-gray-600">
+              A dedicated single-tenant environment in the region you choose, on AWS, Azure, GCP, or an agreed data
+              centre. Region is fixed at provisioning and named in the order form.
+            </p>
+          </div>
+
+          <div class="sh-card rounded-2xl border border-gray-200 bg-white p-7 shadow-sm">
+            <span class="flex h-10 w-10 items-center justify-center rounded-xl bg-violet-50 ring-1 ring-inset ring-violet-100">
+              <svg class="h-5 w-5 text-violet-600" fill="none" stroke="currentColor" stroke-width="1.5"
+                viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z" />
+              </svg>
+            </span>
+            <h3 class="mt-5 text-base font-semibold text-gray-900">Contractual backing</h3>
+            <p class="mt-2 text-sm leading-6 text-gray-600">
+              A DPA with Standard Contractual Clauses, a BAA for covered entities, and the subprocessor list &mdash;
+              all published, all reviewable before you sign.
+            </p>
+            <a href="/legal/data-residency"
+              class="mt-4 inline-flex items-center gap-1.5 text-sm font-medium text-gray-900 hover:text-gray-600">
+              Data residency details
+              <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3"></path>
+              </svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================ SHARED RESPONSIBILITIES -->
+    <section id="responsibilities" class="bg-white py-20 sm:py-28">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <div class="max-w-3xl">
+          <p class="text-sm font-medium uppercase tracking-wide text-emerald-600">Shared responsibility</p>
+          <h2 class="mt-3 text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">Where our job ends and yours
+            begins</h2>
+          <p class="mt-4 text-base leading-7 text-gray-600">
+            Self-hosting moves real responsibility onto your team. Better you read that here than discover it during
+            an incident.
+          </p>
+        </div>
+
+        <div class="sh-scroll mt-12 rounded-2xl border border-gray-200 shadow-sm">
+          <table class="min-w-full divide-y divide-gray-200 text-left">
+            <thead class="bg-gray-50">
+              <tr>
+                <th scope="col" class="w-1/5 px-6 py-3.5 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  Area</th>
+                <th scope="col" class="px-6 py-3.5 text-xs font-semibold uppercase tracking-wide text-emerald-600">
+                  OneUptime</th>
+                <th scope="col" class="px-6 py-3.5 text-xs font-semibold uppercase tracking-wide text-gray-500">You</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 bg-white">
+              <% selfHosted.sharedResponsibilities.forEach(function(row) { %>
+              <tr>
+                <th scope="row" class="px-6 py-5 align-top text-sm font-semibold text-gray-900"><%= row.area %></th>
+                <td class="px-6 py-5 align-top text-sm leading-6 text-gray-600"><%= row.oneuptime %></td>
+                <td class="px-6 py-5 align-top text-sm leading-6 text-gray-600"><%= row.customer %></td>
+              </tr>
+              <% }); %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================================================ SUPPORT -->
+    <section id="support" class="border-t border-gray-100 bg-gray-50/60 py-20 sm:py-28">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <div class="max-w-3xl">
+          <p class="text-sm font-medium uppercase tracking-wide text-emerald-600">Support boundaries</p>
+          <h2 class="mt-3 text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">What support covers &mdash;
+            and what it does not</h2>
+          <p class="mt-4 text-base leading-7 text-gray-600">
+            Both editions are the same product. The difference is accountability, and we would rather be blunt about
+            it than have you find out at 3am.
+          </p>
+        </div>
+
+        <div class="mt-12 grid grid-cols-1 gap-5 lg:grid-cols-2">
+          <% selfHosted.supportBoundaries.forEach(function(tier) { %>
+          <div
+            class="sh-card flex h-full flex-col rounded-2xl border <%= tier.key === 'enterprise' ? 'border-gray-900 bg-white' : 'border-gray-200 bg-white' %> p-7 shadow-sm">
+            <h3 class="text-xl font-semibold text-gray-900"><%= tier.name %></h3>
+            <p class="mt-2 text-sm leading-6 text-gray-600"><%= tier.description %></p>
+
+            <div class="mt-6">
+              <p class="text-[11px] font-semibold uppercase tracking-wide text-emerald-600">Included</p>
+              <ul class="mt-3 space-y-2.5">
+                <% tier.included.forEach(function(item) { %>
+                <li class="flex gap-2.5 text-sm leading-6 text-gray-600">
+                  <svg class="mt-1 h-4 w-4 flex-shrink-0 text-emerald-500" fill="none" viewBox="0 0 24 24"
+                    stroke-width="2" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                  </svg>
+                  <span><%= item %></span>
+                </li>
+                <% }); %>
+              </ul>
+            </div>
+
+            <div class="mt-6 border-t border-gray-100 pt-6">
+              <p class="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Not included</p>
+              <ul class="mt-3 space-y-2.5">
+                <% tier.excluded.forEach(function(item) { %>
+                <li class="flex gap-2.5 text-sm leading-6 text-gray-500">
+                  <svg class="mt-1 h-4 w-4 flex-shrink-0 text-gray-300" fill="none" viewBox="0 0 24 24"
+                    stroke-width="2" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+                  </svg>
+                  <span><%= item %></span>
+                </li>
+                <% }); %>
+              </ul>
+            </div>
+
+            <% if (tier.key === 'enterprise') { %>
+            <div class="mt-auto pt-6">
+              <a href="#architecture-assessment"
+                class="inline-flex w-full items-center justify-center rounded-lg bg-gray-900 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-700">
+                Discuss an enterprise agreement
+              </a>
+            </div>
+            <% } else { %>
+            <div class="mt-auto pt-6">
+              <a href="<%= selfHosted.helmDocs.repository %>" target="_blank" rel="noopener"
+                class="inline-flex w-full items-center justify-center rounded-lg bg-white px-5 py-2.5 text-sm font-medium text-gray-700 ring-1 ring-inset ring-gray-300 transition-colors hover:bg-gray-50">
+                Start on GitHub
+              </a>
+            </div>
+            <% } %>
+          </div>
+          <% }); %>
+        </div>
+
+        <p class="mt-8 max-w-3xl text-sm leading-6 text-gray-500">
+          Every uptime, support, and compliance statement on this page is governed by our
+          <a href="/trust#claims" class="font-medium text-gray-700 underline underline-offset-2 hover:text-gray-900">claims
+            matrix</a>, which links each one to the document that makes it true.
+        </p>
+      </div>
+    </section>
+
+    <!-- =========================================== ARCHITECTURE ASSESSMENT -->
+    <section id="architecture-assessment" class="relative isolate overflow-hidden bg-gray-900 py-20 sm:py-28">
+      <div
+        class="absolute inset-0 -z-10 bg-[linear-gradient(to_right,rgba(255,255,255,0.04)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.04)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_70%_60%_at_50%_0%,#000_60%,transparent_110%)]">
+      </div>
+
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <div class="grid grid-cols-1 gap-12 lg:grid-cols-2 lg:items-center lg:gap-16">
+          <div>
+            <p class="text-sm font-medium uppercase tracking-wide text-emerald-400">Architecture assessment</p>
+            <h2 class="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+              Bring us your topology. Leave with a reference architecture.
+            </h2>
+            <p class="mt-5 text-base leading-7 text-gray-400">
+              A working session with the engineers who build the platform &mdash; not a sales call. We size your
+              cluster against your telemetry volume, settle the HA and DR posture, walk your air-gap and compliance
+              constraints, and write down exactly where each responsibility sits.
+            </p>
+
+            <div class="mt-8 flex flex-col gap-3 sm:flex-row">
+              <a href="/enterprise/demo"
+                class="inline-flex items-center justify-center rounded-lg bg-white px-6 py-3 text-sm font-semibold text-gray-900 shadow-sm transition-all hover:bg-gray-100">
+                Book an architecture assessment
+                <svg class="ml-2 h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                </svg>
+              </a>
+              <a href="mailto:enterprise@oneuptime.com?subject=Self-hosted%20architecture%20assessment"
+                class="inline-flex items-center justify-center rounded-lg border border-white/20 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/5">
+                Email enterprise@oneuptime.com
+              </a>
+            </div>
+          </div>
+
+          <div class="rounded-2xl border border-white/10 bg-white/[0.03] p-7">
+            <p class="text-[11px] font-semibold uppercase tracking-wide text-gray-500">What we cover</p>
+            <ul class="mt-5 space-y-4">
+              <li class="flex gap-3">
+                <span class="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-emerald-400"></span>
+                <span class="text-sm leading-6 text-gray-300">Deployment model and cluster topology for your
+                  environment</span>
+              </li>
+              <li class="flex gap-3">
+                <span class="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-emerald-400"></span>
+                <span class="text-sm leading-6 text-gray-300">Sizing against your monitor count, ingest volume, and
+                  retention policy</span>
+              </li>
+              <li class="flex gap-3">
+                <span class="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-emerald-400"></span>
+                <span class="text-sm leading-6 text-gray-300">High availability, backup, and restore posture &mdash;
+                  with your RTO and RPO</span>
+              </li>
+              <li class="flex gap-3">
+                <span class="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-emerald-400"></span>
+                <span class="text-sm leading-6 text-gray-300">Upgrade process, maintenance windows, and rollback
+                  plan</span>
+              </li>
+              <li class="flex gap-3">
+                <span class="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-emerald-400"></span>
+                <span class="text-sm leading-6 text-gray-300">Network, egress, air-gap, and data residency
+                  constraints</span>
+              </li>
+              <li class="flex gap-3">
+                <span class="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-emerald-400"></span>
+                <span class="text-sm leading-6 text-gray-300">Security review support: evidence, questionnaires, and
+                  the responsibility split</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================================================================ FAQ -->
+    <section id="faq" class="bg-white py-20 sm:py-28">
+      <div class="mx-auto max-w-4xl px-6 lg:px-8">
+        <h2 class="text-3xl font-semibold tracking-tight text-gray-900 sm:text-4xl">Questions buyers actually ask</h2>
+
+        <div class="mt-12 divide-y divide-gray-100 border-y border-gray-100">
+          <% selfHosted.faqs.forEach(function(faq) { %>
+          <details class="group py-6">
+            <summary class="flex cursor-pointer list-none items-start justify-between gap-6">
+              <span class="text-base font-medium text-gray-900"><%= faq.question %></span>
+              <span
+                class="mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-500 transition-transform group-open:rotate-45">
+                <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"></path>
+                </svg>
+              </span>
+            </summary>
+            <p class="mt-4 text-sm leading-7 text-gray-600"><%= faq.answer %></p>
+          </details>
+          <% }); %>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <%- include('footer') -%>
+
+  <script>
+    (function () {
+      var hero = document.getElementById('self-hosted-hero');
+      var glow = document.getElementById('self-hosted-grid-glow');
+
+      if (!hero || !glow) {
+        return;
+      }
+
+      hero.addEventListener('mousemove', function (event) {
+        var rect = hero.getBoundingClientRect();
+        glow.style.setProperty('--mouse-x', (event.clientX - rect.left) + 'px');
+        glow.style.setProperty('--mouse-y', (event.clientY - rect.top) + 'px');
+        glow.style.opacity = '1';
+      });
+
+      hero.addEventListener('mouseleave', function () {
+        glow.style.opacity = '0';
+      });
+    })();
+  </script>
+</body>
+
+</html>

--- a/Home/Views/solutions/uptime-monitoring.ejs
+++ b/Home/Views/solutions/uptime-monitoring.ejs
@@ -6,7 +6,7 @@
 <head>
     <title>Uptime Monitoring | 100+ Global Locations, Real-Time Alerts</title>
     <meta name="description"
-        content="Monitor your websites, APIs, and services from 100+ global locations. Get instant alerts when downtime occurs. 99.99% monitoring uptime SLA.">
+        content="Monitor your websites, APIs, and services from probes you place where your users are. Get instant alerts when downtime occurs. 99.95% uptime target on Enterprise plans.">
         <%- include('../head', {
     enableGoogleTagManager: typeof enableGoogleTagManager !== 'undefined' ? enableGoogleTagManager : false
 }) -%>
@@ -69,8 +69,8 @@
               <span>Check Intervals</span>
             </div>
             <div class="flex items-center gap-2">
-              <span class="text-2xl font-bold text-gray-900">99.99%</span>
-              <span>Monitoring SLA</span>
+              <span class="text-2xl font-bold text-gray-900">99.95%</span>
+              <span>Enterprise uptime target</span>
             </div>
           </div>
         </div>

--- a/Home/Views/status-page.ejs
+++ b/Home/Views/status-page.ejs
@@ -59,7 +59,7 @@
                 <span class="hidden sm:inline text-gray-300">|</span>
                 <span>Free SSL certificates</span>
                 <span class="hidden sm:inline text-gray-300">|</span>
-                <span>99.99% uptime SLA</span>
+                <span>99.95% uptime target</span>
               </div>
             </div>
 
@@ -767,7 +767,7 @@
                     </div>
                     <div class="flex items-center gap-2">
                       <span class="inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-700 ring-1 ring-inset ring-emerald-600/20">
-                        99.99% SLA
+                        99.95% uptime target
                       </span>
                     </div>
                   </div>

--- a/Home/Views/trust.ejs
+++ b/Home/Views/trust.ejs
@@ -93,7 +93,7 @@
             <a href="/legal/soc-2" class="trust-card-wrapper trust-glow-emerald-wrapper">
               <div class="trust-card trust-glow-emerald rounded-xl bg-white p-3 ring-1 ring-gray-200 text-center">
                 <div class="text-xs font-semibold text-gray-900">SOC 2</div>
-                <div class="text-[11px] text-gray-500 mt-0.5">Type II</div>
+                <div class="text-[11px] text-gray-500 mt-0.5">Attested</div>
               </div>
             </a>
             <a href="/legal/iso-27001" class="trust-card-wrapper trust-glow-blue-wrapper">
@@ -111,13 +111,13 @@
             <a href="/legal/hipaa" class="trust-card-wrapper trust-glow-rose-wrapper">
               <div class="trust-card trust-glow-rose rounded-xl bg-white p-3 ring-1 ring-gray-200 text-center">
                 <div class="text-xs font-semibold text-gray-900">HIPAA</div>
-                <div class="text-[11px] text-gray-500 mt-0.5">BAA available</div>
+                <div class="text-[11px] text-gray-500 mt-0.5">Compliant</div>
               </div>
             </a>
             <a href="/legal/pci" class="trust-card-wrapper trust-glow-amber-wrapper">
               <div class="trust-card trust-glow-amber rounded-xl bg-white p-3 ring-1 ring-gray-200 text-center">
                 <div class="text-xs font-semibold text-gray-900">PCI DSS</div>
-                <div class="text-[11px] text-gray-500 mt-0.5">Compliant</div>
+                <div class="text-[11px] text-gray-500 mt-0.5">Aligned</div>
               </div>
             </a>
           </div>
@@ -125,6 +125,8 @@
           <!-- Quick anchors -->
           <nav class="mt-10 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm text-gray-500">
             <a href="#certifications" class="hover:text-gray-900">Certifications</a>
+            <span class="text-gray-300">&middot;</span>
+            <a href="#claims" class="hover:text-gray-900">Claims</a>
             <span class="text-gray-300">&middot;</span>
             <a href="#architecture" class="hover:text-gray-900">Architecture</a>
             <span class="text-gray-300">&middot;</span>
@@ -159,7 +161,7 @@
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-50 ring-1 ring-emerald-100">
                 <svg class="w-5 h-5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
               </div>
-              <span class="text-[11px] font-medium text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full ring-1 ring-emerald-200/60">Available</span>
+              <span class="text-[11px] font-medium text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full ring-1 ring-emerald-200/60">Attested</span>
             </div>
             <h3 class="mt-4 text-base font-semibold text-gray-900">SOC 2 Type II</h3>
             <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">Security, availability, and confidentiality controls. Renewed annually, report under NDA.</p>
@@ -237,7 +239,7 @@
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-rose-50 ring-1 ring-rose-100">
                 <svg class="w-5 h-5 text-rose-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/></svg>
               </div>
-              <span class="text-[11px] font-medium text-rose-700 bg-rose-50 px-2 py-0.5 rounded-full ring-1 ring-rose-200/60">BAA available</span>
+              <span class="text-[11px] font-medium text-rose-700 bg-rose-50 px-2 py-0.5 rounded-full ring-1 ring-rose-200/60">Compliant</span>
             </div>
             <h3 class="mt-4 text-base font-semibold text-gray-900">HIPAA</h3>
             <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">Healthcare privacy and security. Business Associate Agreement available for covered entities.</p>
@@ -250,7 +252,7 @@
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-amber-50 ring-1 ring-amber-100">
                 <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/></svg>
               </div>
-              <span class="text-[11px] font-medium text-amber-700 bg-amber-50 px-2 py-0.5 rounded-full ring-1 ring-amber-200/60">Compliant</span>
+              <span class="text-[11px] font-medium text-amber-700 bg-amber-50 px-2 py-0.5 rounded-full ring-1 ring-amber-200/60">Aligned</span>
             </div>
             <h3 class="mt-4 text-base font-semibold text-gray-900">PCI DSS</h3>
             <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">Payment-card data security. Cardholder data is processed by certified payment partners; OneUptime never stores PANs.</p>
@@ -263,7 +265,7 @@
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-blue-50 ring-1 ring-blue-100">
                 <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"/></svg>
               </div>
-              <span class="text-[11px] font-medium text-blue-700 bg-blue-50 px-2 py-0.5 rounded-full ring-1 ring-blue-200/60">In progress</span>
+              <span class="text-[11px] font-medium text-amber-700 bg-amber-50 px-2 py-0.5 rounded-full ring-1 ring-amber-200/60">In progress</span>
             </div>
             <h3 class="mt-4 text-base font-semibold text-gray-900">FedRAMP</h3>
             <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">U.S. Federal Risk and Authorization Management Program. Moderate authorization in progress.</p>
@@ -276,7 +278,7 @@
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-slate-50 ring-1 ring-slate-100">
                 <svg class="w-5 h-5 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.539 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.539-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/></svg>
               </div>
-              <span class="text-[11px] font-medium text-slate-700 bg-slate-50 px-2 py-0.5 rounded-full ring-1 ring-slate-200/60">CAIQ on file</span>
+              <span class="text-[11px] font-medium text-slate-700 bg-slate-50 px-2 py-0.5 rounded-full ring-1 ring-slate-200/60">Aligned</span>
             </div>
             <h3 class="mt-4 text-base font-semibold text-gray-900">CSA STAR</h3>
             <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">Cloud Security Alliance Security, Trust and Assurance Registry. CAIQ self-assessment published.</p>
@@ -289,7 +291,7 @@
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-slate-50 ring-1 ring-slate-100">
                 <svg class="w-5 h-5 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>
               </div>
-              <span class="text-[11px] font-medium text-slate-700 bg-slate-50 px-2 py-0.5 rounded-full ring-1 ring-slate-200/60">Available</span>
+              <span class="text-[11px] font-medium text-slate-700 bg-slate-50 px-2 py-0.5 rounded-full ring-1 ring-slate-200/60">Aligned</span>
             </div>
             <h3 class="mt-4 text-base font-semibold text-gray-900">VPAT (Accessibility)</h3>
             <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">WCAG 2.2 Level AA. Voluntary Product Accessibility Template available for procurement.</p>
@@ -310,6 +312,9 @@
         </a>
       </div>
     </section>
+
+    <!-- Governed claims matrix -->
+    <%- include('./Partials/claims-matrix') -%>
 
     <!-- Security Architecture -->
     <section id="architecture" class="mt-24 lg:mt-32 scroll-mt-24">

--- a/Home/package.json
+++ b/Home/package.json
@@ -26,6 +26,7 @@
     "xmlbuilder2": "^4.0.3"
   },
   "devDependencies": {
+    "@types/ejs": "^3.1.1",
     "@types/jest": "^29.5.11",
     "@types/node": "^26.1.1",
     "jest": "^28.1.0",


### PR DESCRIPTION
Closes #3214, and takes on the "Priority 3: fix trust and claims before buying traffic" work.

Two problems with one root cause: the site made commitments it could not back up, and the pages an enterprise buyer would go looking for did not exist.

## 1. Self-hosting now has a commercial journey

`/enterprise/self-hosted` is a real page. `/self-hosted`, `/self-hosting` and `/on-premise` 301 to it instead of returning 404.

It covers what a buyer actually evaluates:

| Section | What it answers |
| --- | --- |
| Deployment models | Kubernetes (Helm, recommended), Docker Compose, private cloud, OneUptime Cloud — each with who owns the infrastructure and who owns upgrades |
| Reference architecture | The four tiers the Helm chart deploys, component by component, with how each one scales |
| Requirements | Kubernetes, networking, data stores, optional add-ons, plus sizing starting points for evaluation / production / scale |
| HA & DR | The chart settings that turn HA on (`postgresOperator.cnpg.enabled`, `clickhouseOperator.altinity.enabled`, `podDisruptionBudget.enabled`, …) and the DR work that stays with the customer |
| Upgrades | A responsibility table: release cadence, breaking changes, migrations, supported versions, rollback |
| Air-gapped | Six settings, and one honest caveat about what has to stay off |
| Hardened images | Enterprise Edition (`image.type: enterprise-edition`) and what hardening means |
| Data residency | Self-hosted vs private cloud vs the contractual backing |
| Shared responsibility | Where our job ends and theirs begins |
| Support boundaries | Community vs Enterprise — including what is **not** included |
| CTA | Book an architecture assessment, with the agenda spelled out |

Content lives in [`Home/Utils/SelfHosted.ts`](Home/Utils/SelfHosted.ts) so the page, the tests and the `.md` variant read from one source. Every capability named there maps to a `values.yaml` key a customer can verify — nothing is asserted that the chart cannot do.

## 2. A governed claims matrix, and pages aligned to it

[`Home/Utils/Claims.ts`](Home/Utils/Claims.ts) is the single source of truth for what we may say about **SLA, support, compliance, encryption, deployment, migration, scale, discounts and contract terms**. Each claim carries:

- a status from a fixed vocabulary — **Certified · Attested · Compliant · Aligned · In progress · Customer-configurable**, each with a published definition and an evidence bar
- the approved sentence, the qualifier that must travel with it, the evidence a buyer can request, and a link to the binding document

`/trust` is now the canonical trust center and renders the matrix at `/trust#claims`. `/security`, `/security-center` and `/trust-center` redirect to it. `/data/claims.json` serves the same data to RFP tooling and agents.

### Corrections applied

The site contradicted its own SLA in several places. Fixed against [`Home/Views/sla.ejs`](Home/Views/sla.ejs):

| Was | Now | Why |
| --- | --- | --- |
| "99.99% uptime SLA" (5 pages) | 99.95% Enterprise target / 99.9% paid self-serve | SLA §1 |
| Free plan "99.00% SLA" | No uptime commitment | SLA §1 — free plans have none |
| "Financial-backed reliability guarantee" | Service credits up to 50% of monthly fees | SLA §3, §6 — credits are the sole remedy |
| "Guaranteed response times (15 min for critical)" | One-hour P1 first-response target, 24/7 | SLA §5 — targets, not credit-backed |
| "99.99% delivery guarantee" on alerts | Redundant multi-channel delivery with escalation | No measurement behind the number |
| "Certified compliant with 21 CFR Part 11 / Annex 11" | Aligned | Neither regime certifies vendors |
| "OneUptime is CSA STAR certified" | CAIQ self-assessment (STAR Level 1) | Level 2 needs a third-party assessor |
| SOC 2 badge "Certified" | Attested | SOC 2 produces a report, not a certificate |
| "Billions of data points daily", "Fortune 500" | The architecture that backs the scale claim | Unverifiable, and nobody owns the number |
| "Annual plans have a 17% discount" | The annual price shown per plan | 17% matched none of the published prices |

Pages touched: homepage partials, pricing, enterprise overview, demo, status page, SaaS + uptime-monitoring, `/legal/security`, and the compliance pages named above.

### It stays fixed

`RetiredClaims` records every retired phrase with the reason and the approved replacement. [`Tests/ClaimsGovernance.test.ts`](Home/Tests/ClaimsGovernance.test.ts) scans **every** template under `Home/Views` and fails the build if any of it comes back — printing the file, the line, why it was retired, and what to write instead.

## ⚠️ Needs legal / security sign-off before this ships

Five claims are marked `reviewRequired` and render an amber **"evidence under review"** badge. Their wording is deliberately conservative until someone confirms the underlying evidence:

- **ISO/IEC 27001** — confirm certification body, certificate number, scope, expiry
- **ISO/IEC 27017 / 27018** — confirm both are named in the certificate's scope
- **ISO 9001** — confirm body and current validity
- **PCI DSS** — the page implies an audit report exists; confirm whether a SAQ was completed and which type
- **CSA STAR** — the CSA page said "certified" while the trust center said "CAIQ on file"; this PR takes the conservative reading

I corrected the statuses that are factually determinable (no certification scheme exists for Part 11, Annex 11, GAMP 5; SOC 2 is an attestation). I did **not** guess at whether certificates exist — those stay flagged.

## Also in here

- Redirect-only paths no longer leak into the sitemap (this already affected `/status-page`, `/on-call` and friends)
- `llms.txt` gained an Enterprise section and the claims JSON
- `/enterprise/self-hosted.md` works automatically via the existing markdown-variant route

## Tests

138 tests in `Home`, 5 new suites:

- `SelfHosted.test.ts` — the content model and its SEO registration
- `Claims.test.ts` — vocabulary, matrix integrity, and each claim against the document it cites
- `ClaimsGovernance.test.ts` — the scanner over all of `Home/Views`
- `ViewRendering.test.ts` — renders `self-hosted.ejs` and `trust.ejs` for real and asserts every section, including that tables stay inside scroll containers
- `Routes.test.ts` — route registration, 301 targets, sitemap exclusions

```bash
cd Home && npm test
```

`tsc --noEmit`, `eslint` and `ejslint` are clean. UI verified in the browser at desktop and mobile widths — no horizontal overflow.