### PR TITLE
fix(teams): stop telling admins to install an app that is already installed

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsChannelsCard.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/MicrosoftTeams/MicrosoftTeamsChannelsCard.tsx
@@ -255,10 +255,23 @@ const MicrosoftTeamsChannelsCard: FunctionComponent = (): ReactElement => {
                     })}
                   </ul>
                 </div>
+                {/*
+                 * This list is everything Graph can SEE in the tenant, which is
+                 * not the same as everything we can post to. Saying so here
+                 * matters: a channel showing up looks like a working
+                 * destination, and the usual reason a send then fails is that
+                 * the team has a different OneUptime package installed (for
+                 * example the one from the Teams store) rather than the
+                 * manifest built for this deployment.
+                 */}
                 <p className="text-xs text-gray-500">
-                  Notifications post to channels in teams where the OneUptime
-                  app is installed. Private channels require the OneUptime bot
-                  to be a member.
+                  Every channel in your tenant is listed here, but notifications
+                  only reach teams the OneUptime app has been added to — add it
+                  from the team&apos;s &quot;...&quot; menu &gt; Manage team
+                  &gt; Apps. Use the app manifest downloaded from this page;
+                  another OneUptime package, such as the one in the Teams store,
+                  will not accept messages from this instance. Private channels
+                  also need the OneUptime bot added to the channel itself.
                 </p>
               </div>
             )}

--- a/App/FeatureSet/Docs/Content/en/self-hosted/microsoft-teams-integration.md
+++ b/App/FeatureSet/Docs/Content/en/self-hosted/microsoft-teams-integration.md
@@ -40,12 +40,16 @@ To integrate Microsoft Teams with your self-hosted OneUptime instance, you need 
 - **Team.ReadBasic.All** - Required to list all teams in the organization after admin consent is granted
 - **Channel.ReadBasic.All** - Required to verify channel existence and retrieve channel details
 - **ChannelMessage.Send** - Required to send messages to channels programmatically
+- **TeamsAppInstallation.ReadForTeam.All** - Optional but strongly recommended. Lets OneUptime check whether the OneUptime app is really installed in a team before a notification is sent, so a failed send can tell you _which_ of the possible causes it is. Without it OneUptime cannot tell "not installed" apart from "installed, but something else is wrong", and simply reports what Microsoft said.
 
 **Note:** The Bot Framework handles message delivery using Resource-Specific Consent (RSC) permissions defined in the Teams app manifest. These permissions are:
 
 - **ChannelMessage.Send.Group** - Allows the bot to send messages to team channels
 - **ChannelMessage.Read.Group** - Allows the bot to read channel messages for interactive commands
 - **Channel.Create.Group** - Allows the bot to create channels when needed
+- **TeamsAppInstallation.Read.Group** - Allows OneUptime to confirm the app is installed in a team it is about to post to
+
+If you uploaded the app manifest before this permission existed, download it again from **Project Settings > Workspace > Microsoft Teams** and re-upload it to pick it up.
 
 3. Click "Grant admin consent" for your organization
 
@@ -146,7 +150,26 @@ If you encounter issues:
 
 ### "The OneUptime app is not installed in the Microsoft Teams team ..."
 
-The app was never added to that team (or, for a private channel, to that channel). Complete **Step 8** above. This is the most common cause of a failed test notification — OneUptime can list every channel in your tenant using Graph application permissions, but it can only *post* to teams the app is a member of.
+OneUptime checked with Microsoft Graph and the app really is absent from that team (or, for a private channel, from that channel). Complete **Step 8** above. OneUptime can list every channel in your tenant using Graph application permissions, but it can only _post_ to teams the app is a member of.
+
+### "Microsoft Teams refused the message ... because the OneUptime bot is not a member of that conversation"
+
+Microsoft rejected the post (its own wording is `BotNotInConversationRoster`) and OneUptime could **not** confirm the app is missing — so do not assume it is. Work through the causes in the order below; the first two are the ones that look identical to a correct setup from inside Teams.
+
+1. **The app in the team is a different package.** Seeing a tile named "OneUptime" under **Manage team > Apps** is not enough — what matters is whether that package's bot id is _this_ deployment's `MICROSOFT_TEAMS_APP_CLIENT_ID`. The public OneUptime app from the Teams store points at OneUptime Cloud's bot and will never accept posts from your self-hosted instance. Only the manifest downloaded from **Project Settings > Workspace > Microsoft Teams** (Step 7) is built for your deployment. If in doubt, remove the app from the team, re-upload your own manifest, and add that.
+2. **The Azure Bot has no Microsoft Teams channel.** Complete **Step 5**. Without it the bot is never provisioned into Teams conversations, so it is in no channel's roster — even though the app installs cleanly and the app list looks correct.
+3. **The app is installed for you, or in a chat, but not in the team.** Complete **Step 8**.
+4. **The channel is private.** A team-level install does not cover private channels — see the note under Step 8.
+
+Grant **TeamsAppInstallation.ReadForTeam.All** (Step 2) to have OneUptime tell you which of these it is instead of listing them.
+
+### Notifications work in one team but not another
+
+Installation is per team. Adding OneUptime to one team does nothing for any other, and neither does connecting the integration — that grants tenant-wide Graph _read_ access, which is why the channel picker can show you channels in teams the bot cannot post to. Complete **Step 8** for every team you want notifications in.
+
+### "Test Rule" passes but real notifications never arrive
+
+Check which destinations the rule actually has enabled. A rule only exercises what it is configured for: with **Create Microsoft Teams Channel** on, the test creates a channel and posts into that channel, which proves the bot can post _to the team that channel was created in_ — and nothing about any other team. Notification Logs (**Settings > Notification Logs**) records every test send, including the raw error from Microsoft when one fails.
 
 ### "Sorry, I couldn't find your project configuration"
 

--- a/Common/Models/DatabaseModels/WorkspaceProjectAuthToken.ts
+++ b/Common/Models/DatabaseModels/WorkspaceProjectAuthToken.ts
@@ -45,9 +45,26 @@ export interface MicrosoftTeamsChat {
  * roster member of. Listing a team is therefore NOT evidence that we can post
  * to it — this record is, which is why channel sends check it before calling
  * the Bot Framework.
+ *
+ * A Teams team has TWO ids and they are not interchangeable. Bot activities
+ * carry the thread id (channelData.team.id, "19:...@thread.tacv2"); Graph — and
+ * therefore every team picker, notification rule and channel URL in OneUptime —
+ * uses the AAD group id (a GUID, channelData.team.aadGroupId). Records used to
+ * be keyed by the thread id and looked up by the group id, so the lookup could
+ * never hit. Both are stored explicitly now so neither side has to guess which
+ * one it holds.
  */
 export interface MicrosoftTeamsInstalledTeam {
-  id: string; // Teams team (group) id.
+  /*
+   * Map key. The Graph team id when we could resolve it, otherwise the Teams
+   * thread id — a record written before this shipped, or one whose group id
+   * could not be resolved, keeps the thread id here so uninstall still matches.
+   * Read it through MicrosoftTeamsUtil.indexInstalledTeamsByGraphTeamId rather
+   * than assuming which id space it is in.
+   */
+  id: string;
+  graphTeamId?: string | undefined; // AAD group id — what Graph and notification rules use. Absent on unresolved records.
+  teamsThreadId?: string | undefined; // channelData.team.id ("19:...@thread.tacv2") — what bot activities carry.
   name?: string | undefined;
   serviceUrl?: string | undefined; // Bot Framework service URL captured on install. Required for GCC/DoD.
   addedAt?: string | undefined;
@@ -79,7 +96,7 @@ export interface MicrosoftTeamsMiscData extends MiscData {
   availableTeams?: Record<string, MicrosoftTeamsTeam>; // keyed by team id. Every team Graph can see in the tenant.
   appAccessTokenExpiresAt?: string;
   availableChats?: Record<string, MicrosoftTeamsChat>; // keyed by chat id. Chats the OneUptime app has been added to.
-  installedTeams?: Record<string, MicrosoftTeamsInstalledTeam>; // keyed by team id. Teams the OneUptime app has been added to.
+  installedTeams?: Record<string, MicrosoftTeamsInstalledTeam>; // keyed by MicrosoftTeamsInstalledTeam.id — see that type, the key is not always a Graph team id.
 }
 
 export type WorkspaceMiscData = SlackMiscData | MicrosoftTeamsMiscData;

--- a/Common/Server/API/MicrosoftTeamsAPI.ts
+++ b/Common/Server/API/MicrosoftTeamsAPI.ts
@@ -177,6 +177,16 @@ export default class MicrosoftTeamsAPI {
               type: "Application",
               name: "ChatMember.Read.Chat",
             },
+            /*
+             * Lets OneUptime confirm, per team, that the installed OneUptime app
+             * is the package built from THIS deployment before telling an admin
+             * their app is missing. Without it the installed-apps read falls back
+             * to "unknown" and the send is handed to Microsoft to reject.
+             */
+            {
+              type: "Application",
+              name: "TeamsAppInstallation.Read.Group",
+            },
           ],
         },
       },

--- a/Common/Server/Services/WorkspaceNotificationRuleService.ts
+++ b/Common/Server/Services/WorkspaceNotificationRuleService.ts
@@ -252,228 +252,44 @@ export class Service extends DatabaseService<WorkspaceNotificationRule> {
           throw new BadDataException((err as Error)?.message);
         }
       }
+    }
 
-      // post message
+    /*
+     * Post to the channels this test just created.
+     *
+     * This loop used to sit inside the shouldPostToExistingChannel block, so a
+     * rule that only creates a channel created it, invited nobody (a no-op on
+     * Teams) and reported success without ever attempting a send. The one
+     * action an admin runs to prove the bot can post proved nothing, and a
+     * passing test was read as evidence that the workspace app was wired up
+     * correctly when it had never been exercised.
+     */
+    for (const createdChannel of createdChannels) {
+      await this.postTestMessageToChannels({
+        projectId: data.projectId,
+        messageBlocksByWorkspaceTypes: messageBlocksByWorkspaceTypes,
+        testByUserId: data.testByUserId,
+        channelNames: [],
+        channelIds: [createdChannel.id],
+        /*
+         * The team the channel was actually created in. This used to pass
+         * existingTeam, which is a different field on a different rule — for a
+         * create-only rule it is undefined, and when both are set they can name
+         * two different teams.
+         */
+        teamId: createdChannel.teamId,
+      });
+    }
 
-      for (const createdChannel of createdChannels) {
-        try {
-          const responses: Array<WorkspaceSendMessageResponse> =
-            await WorkspaceUtil.postMessageToAllWorkspaceChannelsAsBot({
-              projectId: data.projectId,
-              messagePayloadsByWorkspace: messageBlocksByWorkspaceTypes.map(
-                (
-                  messageBlocksByWorkspaceType: MessageBlocksByWorkspaceType,
-                ) => {
-                  const payload: WorkspaceMessagePayload = {
-                    _type: "WorkspaceMessagePayload",
-                    workspaceType: messageBlocksByWorkspaceType.workspaceType,
-                    messageBlocks: messageBlocksByWorkspaceType.messageBlocks,
-                    channelNames: [],
-                    channelIds: [createdChannel.id],
-                    teamId: notificationRule.existingTeam,
-                  };
-
-                  return payload;
-                },
-              ),
-            });
-
-          // Log results for test sends (created channels)
-          const getMessageSummary: (wt: WorkspaceType) => string = (
-            wt: WorkspaceType,
-          ): string => {
-            const blocks: Array<WorkspaceMessageBlock> | undefined =
-              messageBlocksByWorkspaceTypes.find(
-                (b: MessageBlocksByWorkspaceType) => {
-                  return b.workspaceType === wt;
-                },
-              )?.messageBlocks;
-            if (!blocks) {
-              return "";
-            }
-            const texts: Array<string> = [];
-            for (const block of blocks) {
-              if (
-                (block as WorkspacePayloadMarkdown)._type ===
-                "WorkspacePayloadMarkdown"
-              ) {
-                texts.push((block as WorkspacePayloadMarkdown).text);
-              }
-            }
-            const joined: string = texts.join(" \n").trim();
-            return joined;
-          };
-
-          for (const res of responses) {
-            const messageSummary: string = getMessageSummary(res.workspaceType);
-
-            // Check for errors in the response
-            if (res.errors && res.errors.length > 0) {
-              /*
-               * Record the failure before throwing. Test sends used to throw
-               * straight out of here, so a failed test left no trace in
-               * Notification Logs and support had no way to see what Microsoft
-               * or Slack actually said.
-               */
-              await this.logTestSendFailures({
-                projectId: data.projectId,
-                workspaceType: res.workspaceType,
-                errors: res.errors,
-                message: messageSummary,
-                userId: data.testByUserId,
-              });
-
-              const errorMessages: Array<string> = res.errors.map(
-                (error: { channel: WorkspaceChannel; error: string }) => {
-                  return `Channel ${error.channel.name}: ${error.error}`;
-                },
-              );
-              throw new BadDataException(
-                `Failed to send test message to some channels: ${errorMessages.join(
-                  "; ",
-                )}`,
-              );
-            }
-
-            for (const thread of res.threads) {
-              const log: WorkspaceNotificationLog =
-                new WorkspaceNotificationLog();
-              log.projectId = data.projectId;
-              log.workspaceType = res.workspaceType;
-              log.channelId = thread.channel.id;
-              log.channelName = thread.channel.name;
-              log.threadId = thread.threadId;
-              log.message = messageSummary;
-              log.status = WorkspaceNotificationStatus.Success;
-              log.statusMessage = "Test message posted to workspace channel";
-              log.userId = data.testByUserId;
-              log.actionType = WorkspaceNotificationActionType.SendMessage;
-
-              await WorkspaceNotificationLogService.create({
-                data: log,
-                props: { isRoot: true },
-              });
-            }
-          }
-        } catch (err) {
-          throw new BadDataException(
-            "Cannot post message to channel. " + (err as Error)?.message,
-          );
-        }
-      }
-
-      for (const channel of existingChannels) {
-        try {
-          const responses: Array<WorkspaceSendMessageResponse> =
-            await WorkspaceUtil.postMessageToAllWorkspaceChannelsAsBot({
-              projectId: data.projectId,
-              messagePayloadsByWorkspace: messageBlocksByWorkspaceTypes.map(
-                (
-                  messageBlocksByWorkspaceType: MessageBlocksByWorkspaceType,
-                ) => {
-                  const payload: WorkspaceMessagePayload = {
-                    _type: "WorkspaceMessagePayload",
-                    workspaceType: messageBlocksByWorkspaceType.workspaceType,
-                    messageBlocks: messageBlocksByWorkspaceType.messageBlocks,
-                    channelNames: [channel.name],
-                    channelIds: [],
-                  };
-
-                  if (
-                    messageBlocksByWorkspaceType.workspaceType ===
-                    WorkspaceType.MicrosoftTeams
-                  ) {
-                    payload.teamId = channel.teamId;
-                  }
-
-                  return payload;
-                },
-              ),
-            });
-
-          // Log results for test sends (existing channels)
-          const getMessageSummary: (wt: WorkspaceType) => string = (
-            wt: WorkspaceType,
-          ): string => {
-            const blocks: Array<WorkspaceMessageBlock> | undefined =
-              messageBlocksByWorkspaceTypes.find(
-                (b: MessageBlocksByWorkspaceType) => {
-                  return b.workspaceType === wt;
-                },
-              )?.messageBlocks;
-            if (!blocks) {
-              return "";
-            }
-            const texts: Array<string> = [];
-            for (const block of blocks) {
-              if (
-                (block as WorkspacePayloadMarkdown)._type ===
-                "WorkspacePayloadMarkdown"
-              ) {
-                texts.push((block as WorkspacePayloadMarkdown).text);
-              }
-            }
-            const joined: string = texts.join(" \n").trim();
-            return joined;
-          };
-
-          for (const res of responses) {
-            const messageSummary: string = getMessageSummary(res.workspaceType);
-
-            // Check for errors in the response
-            if (res.errors && res.errors.length > 0) {
-              /*
-               * Record the failure before throwing. Test sends used to throw
-               * straight out of here, so a failed test left no trace in
-               * Notification Logs and support had no way to see what Microsoft
-               * or Slack actually said.
-               */
-              await this.logTestSendFailures({
-                projectId: data.projectId,
-                workspaceType: res.workspaceType,
-                errors: res.errors,
-                message: messageSummary,
-                userId: data.testByUserId,
-              });
-
-              const errorMessages: Array<string> = res.errors.map(
-                (error: { channel: WorkspaceChannel; error: string }) => {
-                  return `Channel ${error.channel.name}: ${error.error}`;
-                },
-              );
-              throw new BadDataException(
-                `Failed to send test message to some channels: ${errorMessages.join(
-                  "; ",
-                )}`,
-              );
-            }
-
-            for (const thread of res.threads) {
-              const log: WorkspaceNotificationLog =
-                new WorkspaceNotificationLog();
-              log.projectId = data.projectId;
-              log.workspaceType = res.workspaceType;
-              log.channelId = thread.channel.id;
-              log.channelName = thread.channel.name;
-              log.threadId = thread.threadId;
-              log.message = messageSummary;
-              log.status = WorkspaceNotificationStatus.Success;
-              log.statusMessage = "Test message posted to workspace channel";
-              log.userId = data.testByUserId;
-              log.actionType = WorkspaceNotificationActionType.SendMessage;
-
-              await WorkspaceNotificationLogService.create({
-                data: log,
-                props: { isRoot: true },
-              });
-            }
-          }
-        } catch (err) {
-          throw new BadDataException(
-            "Cannot post message to channel. " + (err as Error)?.message,
-          );
-        }
-      }
+    for (const channel of existingChannels) {
+      await this.postTestMessageToChannels({
+        projectId: data.projectId,
+        messageBlocksByWorkspaceTypes: messageBlocksByWorkspaceTypes,
+        testByUserId: data.testByUserId,
+        channelNames: [channel.name],
+        channelIds: [],
+        teamId: channel.teamId,
+      });
     }
 
     // Post test message to Microsoft Teams chats.
@@ -565,6 +381,142 @@ export class Service extends DatabaseService<WorkspaceNotificationRule> {
           "Cannot post message to chat. " + (err as Error)?.message,
         );
       }
+    }
+  }
+
+  /*
+   * The markdown of a test message, for the Notification Log entry.
+   */
+  private getTestMessageSummary(data: {
+    messageBlocksByWorkspaceTypes: Array<MessageBlocksByWorkspaceType>;
+    workspaceType: WorkspaceType;
+  }): string {
+    const blocks: Array<WorkspaceMessageBlock> | undefined =
+      data.messageBlocksByWorkspaceTypes.find(
+        (b: MessageBlocksByWorkspaceType) => {
+          return b.workspaceType === data.workspaceType;
+        },
+      )?.messageBlocks;
+
+    if (!blocks) {
+      return "";
+    }
+
+    const texts: Array<string> = [];
+
+    for (const block of blocks) {
+      if (
+        (block as WorkspacePayloadMarkdown)._type === "WorkspacePayloadMarkdown"
+      ) {
+        texts.push((block as WorkspacePayloadMarkdown).text);
+      }
+    }
+
+    return texts.join(" \n").trim();
+  }
+
+  /*
+   * Post one test message to one set of destinations, then record the outcome in
+   * Notification Logs.
+   *
+   * Created channels and existing channels ran two byte-identical copies of
+   * this, which is how the created-channel copy ended up nested in the wrong
+   * conditional without anyone noticing. One path now serves both.
+   */
+  @CaptureSpan()
+  private async postTestMessageToChannels(data: {
+    projectId: ObjectID;
+    messageBlocksByWorkspaceTypes: Array<MessageBlocksByWorkspaceType>;
+    testByUserId: ObjectID;
+    channelNames: Array<string>;
+    channelIds: Array<string>;
+    teamId?: string | undefined;
+  }): Promise<void> {
+    try {
+      const responses: Array<WorkspaceSendMessageResponse> =
+        await WorkspaceUtil.postMessageToAllWorkspaceChannelsAsBot({
+          projectId: data.projectId,
+          messagePayloadsByWorkspace: data.messageBlocksByWorkspaceTypes.map(
+            (messageBlocksByWorkspaceType: MessageBlocksByWorkspaceType) => {
+              const payload: WorkspaceMessagePayload = {
+                _type: "WorkspaceMessagePayload",
+                workspaceType: messageBlocksByWorkspaceType.workspaceType,
+                messageBlocks: messageBlocksByWorkspaceType.messageBlocks,
+                channelNames: data.channelNames,
+                channelIds: data.channelIds,
+              };
+
+              // teamId is a Microsoft Teams concept; Slack has no equivalent.
+              if (
+                messageBlocksByWorkspaceType.workspaceType ===
+                WorkspaceType.MicrosoftTeams
+              ) {
+                payload.teamId = data.teamId;
+              }
+
+              return payload;
+            },
+          ),
+        });
+
+      for (const res of responses) {
+        const messageSummary: string = this.getTestMessageSummary({
+          messageBlocksByWorkspaceTypes: data.messageBlocksByWorkspaceTypes,
+          workspaceType: res.workspaceType,
+        });
+
+        // Check for errors in the response
+        if (res.errors && res.errors.length > 0) {
+          /*
+           * Record the failure before throwing. Test sends used to throw
+           * straight out of here, so a failed test left no trace in
+           * Notification Logs and support had no way to see what Microsoft
+           * or Slack actually said.
+           */
+          await this.logTestSendFailures({
+            projectId: data.projectId,
+            workspaceType: res.workspaceType,
+            errors: res.errors,
+            message: messageSummary,
+            userId: data.testByUserId,
+          });
+
+          const errorMessages: Array<string> = res.errors.map(
+            (error: { channel: WorkspaceChannel; error: string }) => {
+              return `Channel ${error.channel.name}: ${error.error}`;
+            },
+          );
+
+          throw new BadDataException(
+            `Failed to send test message to some channels: ${errorMessages.join(
+              "; ",
+            )}`,
+          );
+        }
+
+        for (const thread of res.threads) {
+          const log: WorkspaceNotificationLog = new WorkspaceNotificationLog();
+          log.projectId = data.projectId;
+          log.workspaceType = res.workspaceType;
+          log.channelId = thread.channel.id;
+          log.channelName = thread.channel.name;
+          log.threadId = thread.threadId;
+          log.message = messageSummary;
+          log.status = WorkspaceNotificationStatus.Success;
+          log.statusMessage = "Test message posted to workspace channel";
+          log.userId = data.testByUserId;
+          log.actionType = WorkspaceNotificationActionType.SendMessage;
+
+          await WorkspaceNotificationLogService.create({
+            data: log,
+            props: { isRoot: true },
+          });
+        }
+      }
+    } catch (err) {
+      throw new BadDataException(
+        "Cannot post message to channel. " + (err as Error)?.message,
+      );
     }
   }
 

--- a/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
+++ b/Common/Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams.ts
@@ -72,6 +72,7 @@ import {
   ConfigurationBotFrameworkAuthentication,
   TeamsActivityHandler,
   TeamsInfo,
+  TeamDetails,
   TeamsChannelAccount,
   TeamsPagedMembersResult,
   TurnContext,
@@ -123,6 +124,20 @@ export interface MicrosoftTeamsTenantResolution {
   projectAuth: WorkspaceProjectAuthToken | null;
   isAmbiguous: boolean;
   candidateProjectIds: Array<ObjectID>;
+}
+
+/*
+ * Whether the OneUptime Teams app is installed in a given team.
+ *
+ * Unknown is a first-class outcome, not an error: checking installation needs a
+ * Graph permission that deployments connected before it was documented have not
+ * consented to, and a tenant that answers "I won't tell you" must never be
+ * reported to an admin as "the app is not installed".
+ */
+export enum MicrosoftTeamsAppInstallState {
+  Installed = "Installed",
+  NotInstalled = "NotInstalled",
+  Unknown = "Unknown",
 }
 
 /*
@@ -1443,6 +1458,14 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
     logger.debug(`Team ID: ${data.teamId}`);
     logger.debug(`Adaptive card: ${JSON.stringify(data.adaptiveCard)}`);
 
+    /*
+     * Declared out here so the catch block can tell a rejection we predicted
+     * from one we could not, and word the error accordingly.
+     */
+    let installState: MicrosoftTeamsAppInstallState =
+      MicrosoftTeamsAppInstallState.Unknown;
+    let installStateCameFromGraph: boolean = false;
+
     try {
       // Get project auth to retrieve bot ID
       const projectAuth: WorkspaceProjectAuthToken | null =
@@ -1493,30 +1516,42 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
       }
 
       /*
-       * Preflight: refuse before calling the Bot Framework when we know the
-       * app was never installed into this team. Channels are discovered with
-       * tenant-wide Graph application permissions, which see every team
-       * regardless of installation — so reaching this point proves nothing
-       * about whether we can actually post.
+       * Preflight. Channels are discovered with tenant-wide Graph application
+       * permissions, which see every team regardless of installation — so
+       * reaching this point proves nothing about whether we can actually post.
        *
-       * installedTeams is only populated from install events, so an empty map
-       * means "we have not observed any installs" (for example on a workspace
-       * connected before this shipped), not "nothing is installed". Only
-       * enforce once we have at least one record, and let the Bot Framework
-       * error be translated below otherwise.
+       * An install we recorded from a bot activity is the cheap positive
+       * signal, and it also carries the serviceUrl this send needs. When we
+       * have no record we ask Graph rather than assuming: absence from
+       * installedTeams used to be reported to admins as "the app is not
+       * installed", which is a claim install events alone cannot support (they
+       * only arrive for installs that happened while OneUptime was reachable).
+       * Only a verified negative refuses the send; anything we cannot verify
+       * goes to Microsoft, which is the real authority.
        */
-      const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> =
-        miscData.installedTeams || {};
       const installedTeam: MicrosoftTeamsInstalledTeam | undefined =
-        installedTeams[data.teamId];
+        this.indexInstalledTeamsByGraphTeamId(miscData.installedTeams)[
+          data.teamId
+        ];
 
-      if (Object.keys(installedTeams).length > 0 && !installedTeam) {
-        throw new BadDataException(
-          this.getBotNotInTeamMessage({
-            channelName: data.workspaceChannel.name,
-            membershipType: data.workspaceChannel.membershipType,
-          }),
-        );
+      if (installedTeam) {
+        installState = MicrosoftTeamsAppInstallState.Installed;
+      } else {
+        installState = await this.isAppInstalledInTeam({
+          authToken: data.authToken,
+          projectId: data.projectId,
+          teamId: data.teamId,
+        });
+        installStateCameFromGraph = true;
+
+        if (installState === MicrosoftTeamsAppInstallState.NotInstalled) {
+          throw new BadDataException(
+            this.getBotNotInTeamMessage({
+              channelName: data.workspaceChannel.name,
+              membershipType: data.workspaceChannel.membershipType,
+            }),
+          );
+        }
       }
 
       // Get Bot Framework adapter
@@ -1592,14 +1627,47 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
 
       /*
        * Microsoft's roster rejection is meaningless to an admin ("The bot is
-       * not part of the conversation roster"). Replace it with the action that
-       * actually fixes it.
+       * not part of the conversation roster"). Replace it with something
+       * actionable — but only claim the app is missing from the team when we
+       * checked and it is. Otherwise the app can be installed exactly as
+       * documented and still be told to install it, which is how this error
+       * sent admins in circles.
        */
       if (this.isBotNotInConversationRosterError(error)) {
+        /*
+         * A local install record got us past the preflight without asking
+         * Graph, and it can be stale — the app may have been removed from the
+         * team since, and an uninstall event only reaches us if OneUptime was
+         * reachable at the time. So confirm before wording the error. This is
+         * the failure path, so the extra call costs nothing in normal operation.
+         */
+        let verifiedInstallState: MicrosoftTeamsAppInstallState = installState;
+
+        if (!installStateCameFromGraph) {
+          verifiedInstallState = await this.isAppInstalledInTeam({
+            authToken: data.authToken,
+            projectId: data.projectId,
+            teamId: data.teamId,
+          });
+        }
+
+        if (
+          verifiedInstallState === MicrosoftTeamsAppInstallState.NotInstalled
+        ) {
+          throw new BadDataException(
+            this.getBotNotInTeamMessage({
+              channelName: data.workspaceChannel.name,
+              membershipType: data.workspaceChannel.membershipType,
+            }),
+          );
+        }
+
         throw new BadDataException(
-          this.getBotNotInTeamMessage({
+          this.getRosterRejectionMessage({
             channelName: data.workspaceChannel.name,
             membershipType: data.workspaceChannel.membershipType,
+            installState: verifiedInstallState,
+            microsoftError: error,
           }),
         );
       }
@@ -1640,6 +1708,138 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
     }
 
     return `The OneUptime app is not installed in the Microsoft Teams team that owns "${data.channelName}". In Microsoft Teams, click the "..." next to the team name, then Manage team > Apps > More apps, and add OneUptime. Installing OneUptime for yourself or in a chat is not the same as adding it to the team.`;
+  }
+
+  /*
+   * Microsoft rejected the post and we could not confirm why. Everything here
+   * is a real cause of that rejection for an app that IS present in the team's
+   * app list, which is the case getBotNotInTeamMessage got wrong: the app tile
+   * showing up in Manage team > Apps does not mean the bot behind it is the one
+   * this deployment authenticates as. Microsoft's own wording is included so
+   * the raw error is not lost in the rewrite.
+   */
+  public static getRosterRejectionMessage(data: {
+    channelName: string;
+    membershipType?: string | undefined;
+    installState: MicrosoftTeamsAppInstallState;
+    microsoftError?: unknown;
+  }): string {
+    const causes: Array<string> = [];
+
+    if (data.membershipType === "private") {
+      causes.push(
+        `"${data.channelName}" is a private channel, which needs the app installed into the channel itself (channel "..." > Manage channel > Apps > Add an app) — a team-level install does not cover it`,
+      );
+    } else if (data.installState === MicrosoftTeamsAppInstallState.Installed) {
+      causes.push(
+        "the app is installed in this team, so the bot behind it may not be the one this OneUptime deployment uses — check that the Teams app package was built from this deployment (Project Settings > Workspace > Microsoft Teams) and that its bot id matches MICROSOFT_TEAMS_APP_CLIENT_ID",
+      );
+    } else {
+      causes.push(
+        'the OneUptime app has not been added to this team (team "..." > Manage team > Apps > More apps), or the app that was added is a different package whose bot id is not this deployment\'s MICROSOFT_TEAMS_APP_CLIENT_ID',
+      );
+    }
+
+    causes.push(
+      "the Azure Bot resource for this deployment does not have the Microsoft Teams channel enabled",
+    );
+
+    const microsoftMessage: string =
+      data.microsoftError instanceof Error
+        ? data.microsoftError.message
+        : String(data.microsoftError || "");
+
+    const suffix: string = microsoftMessage
+      ? ` Microsoft's response was: "${microsoftMessage}"`
+      : "";
+
+    return `Microsoft Teams refused the message to "${data.channelName}" because the OneUptime bot is not a member of that conversation. Likely causes: ${causes.join("; ")}.${suffix}`;
+  }
+
+  /*
+   * Asks Graph whether this deployment's Teams app is installed in a team.
+   *
+   * Matching is on teamsApp.externalId, which is the manifest id — and the
+   * manifest OneUptime generates sets both that and the bot id to
+   * MICROSOFT_TEAMS_APP_CLIENT_ID. So this answers the question that actually
+   * matters ("is the app THIS deployment authenticates as installed here?"),
+   * not the weaker one an admin can answer by eye ("is something called
+   * OneUptime in the app list?").
+   *
+   * Every failure is Unknown. The call needs TeamsAppInstallation.ReadForTeam.All,
+   * which deployments connected before it was documented have not granted, and a
+   * missing permission must not be reported as a missing install.
+   */
+  @CaptureSpan()
+  public static async isAppInstalledInTeam(data: {
+    authToken: string;
+    projectId: ObjectID;
+    teamId: string;
+  }): Promise<MicrosoftTeamsAppInstallState> {
+    if (!MicrosoftTeamsAppClientId) {
+      return MicrosoftTeamsAppInstallState.Unknown;
+    }
+
+    try {
+      const accessToken: string = await this.getValidAccessToken({
+        authToken: data.authToken,
+        projectId: data.projectId,
+      });
+
+      let nextLink: string | null =
+        `https://graph.microsoft.com/v1.0/teams/${data.teamId}/installedApps?$expand=teamsApp`;
+      let pageCount: number = 0;
+
+      while (nextLink) {
+        pageCount++;
+
+        if (pageCount > MICROSOFT_TEAMS_MAX_PAGES) {
+          logger.warn(
+            `Stopped paginating installed apps for team ${data.teamId} after ${MICROSOFT_TEAMS_MAX_PAGES} pages.`,
+          );
+          return MicrosoftTeamsAppInstallState.Unknown;
+        }
+
+        const response: HTTPErrorResponse | HTTPResponse<JSONObject> =
+          await API.get({
+            url: URL.fromString(nextLink),
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              "Content-Type": "application/json",
+            },
+          });
+
+        if (response instanceof HTTPErrorResponse) {
+          logger.debug(
+            `Could not read installed apps for team ${data.teamId}; treating installation as unknown.`,
+          );
+          logger.debug(response);
+          return MicrosoftTeamsAppInstallState.Unknown;
+        }
+
+        const installedApps: Array<JSONObject> =
+          (response.data["value"] as Array<JSONObject>) || [];
+
+        for (const installedApp of installedApps) {
+          const teamsApp: JSONObject =
+            (installedApp["teamsApp"] as JSONObject) || {};
+
+          if (teamsApp["externalId"] === MicrosoftTeamsAppClientId) {
+            return MicrosoftTeamsAppInstallState.Installed;
+          }
+        }
+
+        nextLink = (response.data["@odata.nextLink"] as string) || null;
+      }
+
+      return MicrosoftTeamsAppInstallState.NotInstalled;
+    } catch (err) {
+      logger.debug(
+        `Error checking whether the OneUptime app is installed in team ${data.teamId}; treating installation as unknown.`,
+      );
+      logger.debug(err);
+      return MicrosoftTeamsAppInstallState.Unknown;
+    }
   }
 
   /*
@@ -2357,6 +2557,7 @@ export default class MicrosoftTeamsUtil extends WorkspaceBase {
       await this.captureTeamFromBotActivity({
         activity: data.activity,
         turnContext: data.turnContext,
+        onlyIfMissingOrStale: true,
       });
     }
 
@@ -4246,10 +4447,121 @@ All monitoring checks are passing normally.`;
    * (channels are not chats), so before this existed we threw away the only
    * signal that tells us a proactive channel post will be accepted.
    */
+  /*
+   * The AAD group id for a team, which is what Graph calls the team id and what
+   * every notification rule stores. Teams normally puts it on the activity as
+   * channelData.team.aadGroupId; when it does not, TeamsInfo.getTeamDetails
+   * fetches it. Returns undefined rather than throwing — a missing group id
+   * degrades the record, it does not invalidate the install.
+   */
+  public static async resolveGraphTeamIdFromBotActivity(data: {
+    team: JSONObject | undefined;
+    turnContext: TurnContext;
+  }): Promise<string | undefined> {
+    const aadGroupIdOnActivity: string =
+      (data.team?.["aadGroupId"] as string) || "";
+
+    if (aadGroupIdOnActivity) {
+      return aadGroupIdOnActivity;
+    }
+
+    try {
+      const teamDetails: TeamDetails = await TeamsInfo.getTeamDetails(
+        data.turnContext,
+      );
+
+      return teamDetails?.aadGroupId || undefined;
+    } catch (err) {
+      /*
+       * Uninstall activities are the common case here: the bot is already out
+       * of the team by the time we ask, so the call fails. Uninstall matches on
+       * the thread id anyway, so this is not worth an error-level log.
+       */
+      logger.debug(
+        "Could not resolve the Graph team id for a Microsoft Teams install:",
+      );
+      logger.debug(err);
+      return undefined;
+    }
+  }
+
+  /*
+   * installedTeams re-keyed by Graph team id, which is the id every caller
+   * outside the bot handlers actually holds. Records that could not be resolved
+   * to a group id are dropped: they cannot answer "is this team installed?" for
+   * a notification rule, and including them under their thread id would only
+   * invite the same confusion this replaced.
+   */
+  public static indexInstalledTeamsByGraphTeamId(
+    installedTeams: Record<string, MicrosoftTeamsInstalledTeam> | undefined,
+  ): Record<string, MicrosoftTeamsInstalledTeam> {
+    const index: Record<string, MicrosoftTeamsInstalledTeam> = {};
+
+    for (const installedTeam of Object.values(installedTeams || {})) {
+      const graphTeamId: string | undefined =
+        installedTeam?.graphTeamId || undefined;
+
+      if (!graphTeamId) {
+        continue;
+      }
+
+      index[graphTeamId] = installedTeam;
+    }
+
+    return index;
+  }
+
+  /*
+   * The stored record for a team in a tenant, if any, matched on either id.
+   * Used to keep the message-driven backfill cheap.
+   */
+  public static async getInstalledTeamForTenant(data: {
+    tenantId: string;
+    teamsThreadId?: string | undefined;
+    graphTeamId?: string | undefined;
+  }): Promise<MicrosoftTeamsInstalledTeam | null> {
+    const projectAuths: Array<WorkspaceProjectAuthToken> =
+      await WorkspaceProjectAuthTokenService.findBy({
+        query: {
+          workspaceType: WorkspaceType.MicrosoftTeams,
+          workspaceProjectId: data.tenantId,
+        },
+        select: {
+          _id: true,
+          miscData: true,
+        },
+        limit: LIMIT_MAX,
+        skip: 0,
+        props: {
+          isRoot: true,
+        },
+      });
+
+    for (const projectAuth of projectAuths) {
+      const miscData: MicrosoftTeamsMiscData =
+        (projectAuth.miscData as MicrosoftTeamsMiscData) || {};
+
+      for (const existingTeam of Object.values(miscData.installedTeams || {})) {
+        if (
+          this.isSameInstalledTeam({
+            team: existingTeam,
+            graphTeamId: data.graphTeamId,
+            teamsThreadId: data.teamsThreadId,
+          })
+        ) {
+          return existingTeam;
+        }
+      }
+    }
+
+    return null;
+  }
+
   @CaptureSpan()
   public static async captureTeamFromBotActivity(data: {
     activity: JSONObject;
     turnContext: TurnContext;
+    onlyIfMissingOrStale?: boolean | undefined;
   }): Promise<void> {
     try {
       const channelData: JSONObject =
@@ -4259,9 +4571,9 @@ All monitoring checks are passing normally.`;
         | JSONObject
         | undefined;
 
-      const teamId: string = (team?.["id"] as string) || "";
+      const teamsThreadId: string = (team?.["id"] as string) || "";
 
-      if (!teamId) {
+      if (!teamsThreadId) {
         // Not a team-scoped activity (personal or group chat). Nothing to do.
         return;
       }
@@ -4274,13 +4586,55 @@ All monitoring checks are passing normally.`;
         return;
       }
 
+      const activityServiceUrl: string | undefined =
+        (data.activity["serviceUrl"] as string) ||
+        data.turnContext.activity.serviceUrl ||
+        undefined;
+
+      /*
+       * The backfill runs on every inbound channel message, so it must be cheap
+       * once the team is already on record: one read, then nothing. Without this
+       * every message meant a write, and now potentially a Bot Framework call to
+       * resolve the group id as well. A record that is missing the group id, or
+       * whose serviceUrl has moved, is still worth redoing.
+       */
+      if (data.onlyIfMissingOrStale) {
+        const existingTeam: MicrosoftTeamsInstalledTeam | null =
+          await this.getInstalledTeamForTenant({
+            tenantId: tenantId,
+            teamsThreadId: teamsThreadId,
+            graphTeamId: (team?.["aadGroupId"] as string) || undefined,
+          });
+
+        if (
+          existingTeam &&
+          existingTeam.graphTeamId &&
+          existingTeam.serviceUrl === activityServiceUrl
+        ) {
+          return;
+        }
+      }
+
+      /*
+       * The send path looks installs up by Graph team id, so resolving it here
+       * is what makes the record usable at all. Teams puts it on the activity
+       * as aadGroupId most of the time; when it does not, one Bot Framework
+       * call gets it. A record without it is still worth keeping for the
+       * serviceUrl and for uninstall matching, it just cannot be matched to a
+       * notification rule.
+       */
+      const graphTeamId: string | undefined =
+        await this.resolveGraphTeamIdFromBotActivity({
+          team: team,
+          turnContext: data.turnContext,
+        });
+
       const installedTeam: MicrosoftTeamsInstalledTeam = {
-        id: teamId,
+        id: graphTeamId || teamsThreadId,
+        graphTeamId: graphTeamId,
+        teamsThreadId: teamsThreadId,
         name: (team?.["name"] as string) || undefined,
-        serviceUrl:
-          (data.activity["serviceUrl"] as string) ||
-          data.turnContext.activity.serviceUrl ||
-          undefined,
+        serviceUrl: activityServiceUrl,
         addedAt: OneUptimeDate.getCurrentDate().toISOString(),
       };
 
@@ -4290,7 +4644,7 @@ All monitoring checks are passing normally.`;
       });
 
       logger.debug(
-        `Captured Microsoft Teams team install ${teamId} for tenant ${tenantId}`,
+        `Captured Microsoft Teams team install ${installedTeam.id} (thread ${teamsThreadId}, graph ${graphTeamId || "unresolved"}) for tenant ${tenantId}`,
       );
     } catch (err) {
       logger.error("Error capturing Microsoft Teams team from bot activity:");
@@ -4306,22 +4660,33 @@ All monitoring checks are passing normally.`;
       const channelData: JSONObject =
         (data.activity["channelData"] as JSONObject) || {};
 
-      const teamId: string =
-        ((channelData["team"] as JSONObject)?.["id"] as string) || "";
+      const team: JSONObject | undefined = channelData["team"] as
+        | JSONObject
+        | undefined;
+
+      const teamsThreadId: string = (team?.["id"] as string) || "";
       const tenantId: string =
         ((channelData["tenant"] as JSONObject)?.["id"] as string) || "";
 
-      if (!teamId || !tenantId) {
+      if (!teamsThreadId || !tenantId) {
         return;
       }
 
+      /*
+       * Uninstall matches on both ids because we cannot know which one the
+       * record was keyed by: the bot is already out of the team, so
+       * getTeamDetails will not answer, and records written before this shipped
+       * only have a thread id. aadGroupId is still on the activity often enough
+       * to be worth passing through.
+       */
       await this.removeTeamFromProjectAuthTokens({
         tenantId: tenantId,
-        teamId: teamId,
+        teamsThreadId: teamsThreadId,
+        graphTeamId: (team?.["aadGroupId"] as string) || undefined,
       });
 
       logger.debug(
-        `Removed Microsoft Teams team install ${teamId} for tenant ${tenantId}`,
+        `Removed Microsoft Teams team install ${teamsThreadId} for tenant ${tenantId}`,
       );
     } catch (err) {
       logger.error("Error removing Microsoft Teams team from bot activity:");
@@ -4361,10 +4726,32 @@ All monitoring checks are passing normally.`;
         ...((projectAuth.miscData as MicrosoftTeamsMiscData) || {}),
       } as MicrosoftTeamsMiscData;
 
-      miscData.installedTeams = {
-        ...(miscData.installedTeams || {}),
-        [data.team.id]: data.team,
-      };
+      /*
+       * Drop any other record describing the same team before inserting. A
+       * team captured before the group id was resolvable sits under its thread
+       * id, and re-capturing it under the group id would otherwise leave two
+       * records for one team — one of which can never be matched or removed.
+       */
+      const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> = {};
+
+      for (const [key, existingTeam] of Object.entries(
+        miscData.installedTeams || {},
+      )) {
+        if (
+          this.isSameInstalledTeam({
+            team: existingTeam,
+            graphTeamId: data.team.graphTeamId,
+            teamsThreadId: data.team.teamsThreadId,
+          })
+        ) {
+          continue;
+        }
+
+        installedTeams[key] = existingTeam;
+      }
+
+      installedTeams[data.team.id] = data.team;
+      miscData.installedTeams = installedTeams;
 
       await WorkspaceProjectAuthTokenService.updateOneById({
         id: projectAuth.id!,
@@ -4378,10 +4765,45 @@ All monitoring checks are passing normally.`;
     }
   }
 
+  /*
+   * Whether a stored record describes the team identified by either id. Matches
+   * on the record's explicit ids and on its key, so records written before
+   * teamsThreadId existed — where the thread id is only in `id` — still match.
+   * Ids are compared case-sensitively, as Microsoft returns them.
+   */
+  public static isSameInstalledTeam(data: {
+    team: MicrosoftTeamsInstalledTeam | undefined;
+    graphTeamId?: string | undefined;
+    teamsThreadId?: string | undefined;
+  }): boolean {
+    if (!data.team) {
+      return false;
+    }
+
+    if (
+      data.graphTeamId &&
+      (data.team.graphTeamId === data.graphTeamId ||
+        data.team.id === data.graphTeamId)
+    ) {
+      return true;
+    }
+
+    if (
+      data.teamsThreadId &&
+      (data.team.teamsThreadId === data.teamsThreadId ||
+        data.team.id === data.teamsThreadId)
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
   @CaptureSpan()
   public static async removeTeamFromProjectAuthTokens(data: {
     tenantId: string;
-    teamId: string;
+    teamsThreadId?: string | undefined;
+    graphTeamId?: string | undefined;
   }): Promise<void> {
     const projectAuths: Array<WorkspaceProjectAuthToken> =
       await WorkspaceProjectAuthTokenService.findBy({
@@ -4405,14 +4827,34 @@ All monitoring checks are passing normally.`;
         ...((projectAuth.miscData as MicrosoftTeamsMiscData) || {}),
       } as MicrosoftTeamsMiscData;
 
-      if (!miscData.installedTeams || !miscData.installedTeams[data.teamId]) {
+      if (!miscData.installedTeams) {
         continue;
       }
 
-      const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> = {
-        ...miscData.installedTeams,
-      };
-      delete installedTeams[data.teamId];
+      const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> = {};
+      let removedAny: boolean = false;
+
+      for (const [key, existingTeam] of Object.entries(
+        miscData.installedTeams,
+      )) {
+        if (
+          this.isSameInstalledTeam({
+            team: existingTeam,
+            graphTeamId: data.graphTeamId,
+            teamsThreadId: data.teamsThreadId,
+          })
+        ) {
+          removedAny = true;
+          continue;
+        }
+
+        installedTeams[key] = existingTeam;
+      }
+
+      if (!removedAny) {
+        continue;
+      }
+
       miscData.installedTeams = installedTeams;
 
       await WorkspaceProjectAuthTokenService.updateOneById({

--- a/Common/Tests/Server/API/MicrosoftTeamsManifest.test.ts
+++ b/Common/Tests/Server/API/MicrosoftTeamsManifest.test.ts
@@ -127,7 +127,7 @@ describe("MicrosoftTeamsAPI.getTeamsAppManifest", () => {
       expect(names).not.toContain("ChatMessage.Send.Chat");
     });
 
-    test("declares exactly the five expected resource-specific permissions", () => {
+    test("declares exactly the six expected resource-specific permissions", () => {
       const permissions: Array<JSONObject> =
         getResourceSpecificPermissions(getManifest());
       const names: Array<string> = permissions.map((permission: JSONObject) => {
@@ -140,6 +140,12 @@ describe("MicrosoftTeamsAPI.getTeamsAppManifest", () => {
           "Channel.Create.Group",
           "ChatMessage.Read.Chat",
           "ChatMember.Read.Chat",
+          /*
+           * Lets OneUptime verify, per team, that the installed OneUptime app
+           * is the package built from this deployment before telling an admin
+           * their app is missing.
+           */
+          "TeamsAppInstallation.Read.Group",
         ].sort(),
       );
     });

--- a/Common/Tests/Server/Services/WorkspaceNotificationRuleTestRuleChannels.test.ts
+++ b/Common/Tests/Server/Services/WorkspaceNotificationRuleTestRuleChannels.test.ts
@@ -1,0 +1,702 @@
+import WorkspaceNotificationRuleService from "../../../Server/Services/WorkspaceNotificationRuleService";
+import WorkspaceProjectAuthTokenService from "../../../Server/Services/WorkspaceProjectAuthTokenService";
+import WorkspaceUserAuthTokenService from "../../../Server/Services/WorkspaceUserAuthTokenService";
+import WorkspaceNotificationLogService from "../../../Server/Services/WorkspaceNotificationLogService";
+import WorkspaceUtil from "../../../Server/Utils/Workspace/Workspace";
+import {
+  WorkspaceChannel,
+  WorkspaceSendMessageResponse,
+} from "../../../Server/Utils/Workspace/WorkspaceBase";
+import NotificationRuleWorkspaceChannel from "../../../Types/Workspace/NotificationRules/NotificationRuleWorkspaceChannel";
+import WorkspaceNotificationRule from "../../../Models/DatabaseModels/WorkspaceNotificationRule";
+import WorkspaceProjectAuthToken, {
+  MicrosoftTeamsMiscData,
+} from "../../../Models/DatabaseModels/WorkspaceProjectAuthToken";
+import WorkspaceUserAuthToken from "../../../Models/DatabaseModels/WorkspaceUserAuthToken";
+import WorkspaceNotificationLog from "../../../Models/DatabaseModels/WorkspaceNotificationLog";
+import BaseNotificationRule from "../../../Types/Workspace/NotificationRules/BaseNotificationRule";
+import NotificationRuleEventType from "../../../Types/Workspace/NotificationRules/EventType";
+import FilterCondition from "../../../Types/Filter/FilterCondition";
+import WorkspaceType from "../../../Types/Workspace/WorkspaceType";
+import WorkspaceMessagePayload from "../../../Types/Workspace/WorkspaceMessagePayload";
+import ObjectID from "../../../Types/ObjectID";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+
+/*
+ * Tests for the CHANNEL half of WorkspaceNotificationRuleService.testRule — the
+ * "Test Rule" button an admin presses to prove a workspace integration works.
+ *
+ * The bug these pin down: the loop that posted the test card into a channel the
+ * test had just created was nested inside `if (shouldPostToExistingChannel)`. A
+ * rule configured to CREATE a channel and not post to an existing one therefore
+ * created the channel, invited nobody (a no-op on Teams) and returned success
+ * having sent nothing at all.
+ *
+ * That is worse than a missing feature. The customer who reported the Microsoft
+ * Teams roster failure used exactly this configuration as a control: "creating a
+ * channel works, so the app must be installed correctly." It never posted, so it
+ * proved nothing, and the real fault was looked for in the wrong place.
+ *
+ * The created-channel post was also addressed with `existingTeam` — a field
+ * belonging to the OTHER half of the rule, undefined for a create-only rule and
+ * potentially a different team when both halves are configured.
+ */
+
+const TEAM_A: string = "aaaaaaaa-1111-2222-3333-444444444444";
+const TEAM_B: string = "bbbbbbbb-5555-6666-7777-888888888888";
+
+interface RuleOverrides extends Partial<BaseNotificationRule> {
+  shouldCreateNewChannel?: boolean;
+  teamToCreateChannelIn?: string;
+  newChannelTemplateName?: string;
+}
+
+function makeRule(data: {
+  workspaceType?: WorkspaceType | undefined;
+  overrides: RuleOverrides;
+  name?: string | undefined;
+}): WorkspaceNotificationRule {
+  const rule: WorkspaceNotificationRule = new WorkspaceNotificationRule();
+  rule.id = ObjectID.generate();
+  rule.projectId = ObjectID.generate();
+  rule.workspaceType = data.workspaceType || WorkspaceType.MicrosoftTeams;
+  rule.eventType = NotificationRuleEventType.Alert;
+  rule.name = data.name || "Test public channel Team";
+  rule.notificationRule = {
+    _type: "NotificationRule",
+    filterCondition: FilterCondition.Any,
+    filters: [],
+    shouldPostToExistingChannel: false,
+    existingChannelNames: "",
+    shouldCreateNewChannel: false,
+    ...data.overrides,
+  } as BaseNotificationRule;
+  return rule;
+}
+
+function makeCreatedChannel(data: {
+  id: string;
+  name: string;
+  teamId?: string | undefined;
+  workspaceType?: WorkspaceType | undefined;
+}): NotificationRuleWorkspaceChannel {
+  const channel: NotificationRuleWorkspaceChannel = {
+    id: data.id,
+    name: data.name,
+    workspaceType: data.workspaceType || WorkspaceType.MicrosoftTeams,
+    notificationRuleId: ObjectID.generate().toString(),
+  };
+
+  if (data.teamId) {
+    channel.teamId = data.teamId;
+  }
+
+  return channel;
+}
+
+function makeSendResponse(data: {
+  workspaceType?: WorkspaceType | undefined;
+  threads?: Array<{ id: string; name: string; threadId: string }> | undefined;
+  errors?: Array<{ id: string; name: string; error: string }> | undefined;
+}): WorkspaceSendMessageResponse {
+  const workspaceType: WorkspaceType =
+    data.workspaceType || WorkspaceType.MicrosoftTeams;
+
+  const response: WorkspaceSendMessageResponse = {
+    workspaceType: workspaceType,
+    threads: (data.threads || []).map(
+      (thread: { id: string; name: string; threadId: string }) => {
+        return {
+          channel: {
+            id: thread.id,
+            name: thread.name,
+            workspaceType: workspaceType,
+          } as WorkspaceChannel,
+          threadId: thread.threadId,
+        };
+      },
+    ),
+  };
+
+  if (data.errors) {
+    response.errors = data.errors.map(
+      (error: { id: string; name: string; error: string }) => {
+        return {
+          channel: {
+            id: error.id,
+            name: error.name,
+            workspaceType: workspaceType,
+          } as WorkspaceChannel,
+          error: error.error,
+        };
+      },
+    );
+  }
+
+  return response;
+}
+
+interface Mocks {
+  postSpy: jest.SpyInstance;
+  createChannelsSpy: jest.SpyInstance;
+  inviteUsersSpy: jest.SpyInstance;
+  doesChannelExistSpy: jest.SpyInstance;
+  createLogSpy: jest.SpyInstance;
+}
+
+const testByUserId: ObjectID = ObjectID.generate();
+
+function mockDeps(data: {
+  rule: WorkspaceNotificationRule;
+  createdChannels?: Array<NotificationRuleWorkspaceChannel> | undefined;
+  responses?: Array<WorkspaceSendMessageResponse> | undefined;
+  channelExists?: boolean | undefined;
+}): Mocks {
+  jest
+    .spyOn(WorkspaceNotificationRuleService, "findOneById")
+    .mockResolvedValue(data.rule);
+
+  const userAuth: WorkspaceUserAuthToken = new WorkspaceUserAuthToken();
+  userAuth.workspaceUserId = "teams-user-1";
+  jest
+    .spyOn(WorkspaceUserAuthTokenService, "findOneBy")
+    .mockResolvedValue(userAuth);
+
+  const projectAuth: WorkspaceProjectAuthToken =
+    new WorkspaceProjectAuthToken();
+  projectAuth.authToken = "project-auth-token";
+  projectAuth.workspaceType = data.rule.workspaceType!;
+  jest
+    .spyOn(WorkspaceProjectAuthTokenService, "findOneBy")
+    .mockResolvedValue(projectAuth);
+
+  const authWithMisc: WorkspaceProjectAuthToken =
+    new WorkspaceProjectAuthToken();
+  authWithMisc.miscData = {
+    tenantId: "tenant-1",
+    teamId: TEAM_A,
+    teamName: "Test Team",
+    botId: "bot-1",
+  } as MicrosoftTeamsMiscData;
+  jest
+    .spyOn(WorkspaceProjectAuthTokenService, "getProjectAuth")
+    .mockResolvedValue(authWithMisc);
+
+  const createChannelsSpy: jest.SpyInstance = jest
+    .spyOn(WorkspaceNotificationRuleService, "createChannelsBasedOnRules")
+    .mockResolvedValue(data.createdChannels || []);
+
+  const inviteUsersSpy: jest.SpyInstance = jest
+    .spyOn(
+      WorkspaceNotificationRuleService,
+      "inviteUsersBasedOnRulesAndWorkspaceChannels",
+    )
+    .mockResolvedValue(undefined as never);
+
+  const doesChannelExistSpy: jest.SpyInstance = jest
+    .fn()
+    .mockResolvedValue(
+      data.channelExists === undefined ? true : data.channelExists,
+    ) as unknown as jest.SpyInstance;
+
+  jest.spyOn(WorkspaceUtil, "getWorkspaceTypeUtil").mockReturnValue({
+    doesChannelExist: doesChannelExistSpy,
+  } as never);
+
+  const postSpy: jest.SpyInstance = jest
+    .spyOn(WorkspaceUtil, "postMessageToAllWorkspaceChannelsAsBot")
+    .mockResolvedValue(data.responses || []);
+
+  const createLogSpy: jest.SpyInstance = jest
+    .spyOn(WorkspaceNotificationLogService, "create")
+    .mockResolvedValue(new WorkspaceNotificationLog());
+
+  return {
+    postSpy,
+    createChannelsSpy,
+    inviteUsersSpy,
+    doesChannelExistSpy,
+    createLogSpy,
+  };
+}
+
+function runTestRule(rule: WorkspaceNotificationRule): Promise<void> {
+  return WorkspaceNotificationRuleService.testRule({
+    ruleId: rule.id!,
+    projectId: ObjectID.generate(), // testRule overwrites this with rule.projectId.
+    testByUserId: testByUserId,
+    props: { isRoot: true },
+  });
+}
+
+/*
+ * The single payload handed to postMessageToAllWorkspaceChannelsAsBot on a
+ * given call, for asserting destinations and teamId.
+ */
+function payloadOfCall(
+  postSpy: jest.SpyInstance,
+  callIndex: number,
+): WorkspaceMessagePayload {
+  const args: {
+    messagePayloadsByWorkspace: Array<WorkspaceMessagePayload>;
+  } = postSpy.mock.calls[callIndex]![0] as {
+    messagePayloadsByWorkspace: Array<WorkspaceMessagePayload>;
+  };
+
+  return args.messagePayloadsByWorkspace[0]!;
+}
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("testRule posts to channels it created, even when the rule posts nowhere else", () => {
+  test("a create-only rule sends a test message", async () => {
+    /*
+     * THE regression test. Before the fix this asserted zero calls, silently,
+     * and the Dashboard still showed a success modal.
+     */
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldCreateNewChannel: true,
+        shouldPostToExistingChannel: false,
+        teamToCreateChannelIn: TEAM_A,
+        newChannelTemplateName: "test public channel",
+      },
+    });
+
+    const mocks: Mocks = mockDeps({
+      rule: rule,
+      createdChannels: [
+        makeCreatedChannel({
+          id: "19:new-channel@thread.tacv2",
+          name: "test-public-channel-ab12c",
+          teamId: TEAM_A,
+        }),
+      ],
+      responses: [
+        makeSendResponse({
+          threads: [
+            {
+              id: "19:new-channel@thread.tacv2",
+              name: "test-public-channel-ab12c",
+              threadId: "thread-1",
+            },
+          ],
+        }),
+      ],
+    });
+
+    await runTestRule(rule);
+
+    expect(mocks.postSpy).toHaveBeenCalledTimes(1);
+    expect(payloadOfCall(mocks.postSpy, 0).channelIds).toEqual([
+      "19:new-channel@thread.tacv2",
+    ]);
+  });
+
+  test("a create-only rule addresses the send with the team the channel was created in", async () => {
+    /*
+     * existingTeam belongs to the post-to-existing half of the rule and is
+     * undefined here, so the send used to go out with no team at all.
+     */
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldCreateNewChannel: true,
+        shouldPostToExistingChannel: false,
+        teamToCreateChannelIn: TEAM_A,
+      },
+    });
+
+    const mocks: Mocks = mockDeps({
+      rule: rule,
+      createdChannels: [
+        makeCreatedChannel({
+          id: "19:new@thread.tacv2",
+          name: "oneuptime-alert-x",
+          teamId: TEAM_A,
+        }),
+      ],
+      responses: [makeSendResponse({})],
+    });
+
+    await runTestRule(rule);
+
+    expect(payloadOfCall(mocks.postSpy, 0).teamId).toBe(TEAM_A);
+  });
+
+  test("the created channel's team wins over a DIFFERENT existingTeam on the same rule", async () => {
+    /*
+     * Both halves configured, naming two different teams. Addressing the created
+     * channel with existingTeam pointed the send at a team that does not own it.
+     */
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldCreateNewChannel: true,
+        shouldPostToExistingChannel: true,
+        teamToCreateChannelIn: TEAM_A,
+        existingTeam: TEAM_B,
+        existingChannelNames: "general",
+      },
+    });
+
+    const mocks: Mocks = mockDeps({
+      rule: rule,
+      createdChannels: [
+        makeCreatedChannel({
+          id: "19:new@thread.tacv2",
+          name: "oneuptime-alert-x",
+          teamId: TEAM_A,
+        }),
+      ],
+      responses: [makeSendResponse({})],
+    });
+
+    await runTestRule(rule);
+
+    expect(mocks.postSpy).toHaveBeenCalledTimes(2);
+    expect(payloadOfCall(mocks.postSpy, 0).teamId).toBe(TEAM_A);
+  });
+
+  test("a create-only rule still creates the channel and invites the tester", async () => {
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldCreateNewChannel: true,
+        teamToCreateChannelIn: TEAM_A,
+      },
+    });
+
+    const mocks: Mocks = mockDeps({
+      rule: rule,
+      createdChannels: [
+        makeCreatedChannel({
+          id: "19:new@thread.tacv2",
+          name: "oneuptime-alert-x",
+          teamId: TEAM_A,
+        }),
+      ],
+      responses: [makeSendResponse({})],
+    });
+
+    await runTestRule(rule);
+
+    expect(mocks.createChannelsSpy).toHaveBeenCalledTimes(1);
+    expect(mocks.inviteUsersSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("a failed send to a created channel fails the test instead of reporting success", async () => {
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldCreateNewChannel: true,
+        teamToCreateChannelIn: TEAM_A,
+      },
+    });
+
+    mockDeps({
+      rule: rule,
+      createdChannels: [
+        makeCreatedChannel({
+          id: "19:new@thread.tacv2",
+          name: "oneuptime-alert-x",
+          teamId: TEAM_A,
+        }),
+      ],
+      responses: [
+        makeSendResponse({
+          errors: [
+            {
+              id: "19:new@thread.tacv2",
+              name: "oneuptime-alert-x",
+              error: "The bot is not part of the conversation roster.",
+            },
+          ],
+        }),
+      ],
+    });
+
+    await expect(runTestRule(rule)).rejects.toThrow(
+      /Failed to send test message to some channels/,
+    );
+  });
+
+  test("a failed send to a created channel is recorded in Notification Logs", async () => {
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldCreateNewChannel: true,
+        teamToCreateChannelIn: TEAM_A,
+      },
+    });
+
+    const mocks: Mocks = mockDeps({
+      rule: rule,
+      createdChannels: [
+        makeCreatedChannel({
+          id: "19:new@thread.tacv2",
+          name: "oneuptime-alert-x",
+          teamId: TEAM_A,
+        }),
+      ],
+      responses: [
+        makeSendResponse({
+          errors: [
+            {
+              id: "19:new@thread.tacv2",
+              name: "oneuptime-alert-x",
+              error: "boom",
+            },
+          ],
+        }),
+      ],
+    });
+
+    await expect(runTestRule(rule)).rejects.toThrow();
+    expect(mocks.createLogSpy).toHaveBeenCalled();
+  });
+
+  test("a successful send to a created channel logs a Success entry", async () => {
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldCreateNewChannel: true,
+        teamToCreateChannelIn: TEAM_A,
+      },
+    });
+
+    const mocks: Mocks = mockDeps({
+      rule: rule,
+      createdChannels: [
+        makeCreatedChannel({
+          id: "19:new@thread.tacv2",
+          name: "oneuptime-alert-x",
+          teamId: TEAM_A,
+        }),
+      ],
+      responses: [
+        makeSendResponse({
+          threads: [
+            {
+              id: "19:new@thread.tacv2",
+              name: "oneuptime-alert-x",
+              threadId: "thread-7",
+            },
+          ],
+        }),
+      ],
+    });
+
+    await runTestRule(rule);
+
+    const log: WorkspaceNotificationLog = mocks.createLogSpy.mock.calls[0]![0]
+      .data as WorkspaceNotificationLog;
+    expect(log.threadId).toBe("thread-7");
+    expect(log.channelName).toBe("oneuptime-alert-x");
+  });
+
+  test("several created channels each get their own send", async () => {
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldCreateNewChannel: true,
+        teamToCreateChannelIn: TEAM_A,
+      },
+    });
+
+    const mocks: Mocks = mockDeps({
+      rule: rule,
+      createdChannels: [
+        makeCreatedChannel({
+          id: "19:a@thread.tacv2",
+          name: "a",
+          teamId: TEAM_A,
+        }),
+        makeCreatedChannel({
+          id: "19:b@thread.tacv2",
+          name: "b",
+          teamId: TEAM_A,
+        }),
+      ],
+      responses: [makeSendResponse({})],
+    });
+
+    await runTestRule(rule);
+
+    expect(mocks.postSpy).toHaveBeenCalledTimes(2);
+    expect(payloadOfCall(mocks.postSpy, 0).channelIds).toEqual([
+      "19:a@thread.tacv2",
+    ]);
+    expect(payloadOfCall(mocks.postSpy, 1).channelIds).toEqual([
+      "19:b@thread.tacv2",
+    ]);
+  });
+
+  test("a rule that creates nothing and posts nowhere sends nothing", async () => {
+    // Not every empty rule should now start posting — only created channels did.
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldCreateNewChannel: false,
+        shouldPostToExistingChannel: false,
+      },
+    });
+
+    const mocks: Mocks = mockDeps({ rule: rule, responses: [] });
+
+    await runTestRule(rule);
+
+    expect(mocks.postSpy).not.toHaveBeenCalled();
+  });
+
+  test("Slack create-only rules post too, and carry no teamId", async () => {
+    const rule: WorkspaceNotificationRule = makeRule({
+      workspaceType: WorkspaceType.Slack,
+      overrides: { shouldCreateNewChannel: true },
+    });
+
+    const mocks: Mocks = mockDeps({
+      rule: rule,
+      createdChannels: [
+        makeCreatedChannel({
+          id: "C123",
+          name: "oneuptime-alert-x",
+          workspaceType: WorkspaceType.Slack,
+        }),
+      ],
+      responses: [makeSendResponse({ workspaceType: WorkspaceType.Slack })],
+    });
+
+    await runTestRule(rule);
+
+    expect(mocks.postSpy).toHaveBeenCalledTimes(1);
+    // teamId is a Teams concept and must not be set on a Slack payload.
+    expect(payloadOfCall(mocks.postSpy, 0).teamId).toBeUndefined();
+  });
+});
+
+describe("testRule posting to existing channels is unchanged", () => {
+  test("an existing-channel rule posts once per channel with the rule's team", async () => {
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldPostToExistingChannel: true,
+        existingTeam: TEAM_B,
+        existingChannelNames: "general,test public channel",
+      },
+    });
+
+    const mocks: Mocks = mockDeps({
+      rule: rule,
+      responses: [makeSendResponse({})],
+    });
+
+    await runTestRule(rule);
+
+    expect(mocks.postSpy).toHaveBeenCalledTimes(2);
+    expect(payloadOfCall(mocks.postSpy, 0).channelNames).toEqual(["general"]);
+    expect(payloadOfCall(mocks.postSpy, 0).teamId).toBe(TEAM_B);
+    expect(payloadOfCall(mocks.postSpy, 1).channelNames).toEqual([
+      "test public channel",
+    ]);
+  });
+
+  test("an existing channel that does not resolve fails the test before any send", async () => {
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldPostToExistingChannel: true,
+        existingTeam: TEAM_B,
+        existingChannelNames: "typo-channel",
+      },
+    });
+
+    const mocks: Mocks = mockDeps({
+      rule: rule,
+      channelExists: false,
+      responses: [makeSendResponse({})],
+    });
+
+    await expect(runTestRule(rule)).rejects.toThrow(/does not exist/);
+    expect(mocks.postSpy).not.toHaveBeenCalled();
+  });
+
+  test("existing channels are validated BEFORE the created-channel post runs", async () => {
+    /*
+     * Preserved ordering: a rule with both halves and a bad existing-channel
+     * name must fail without having posted anything, so the test does not leave
+     * a card in a freshly created channel and then report failure.
+     */
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldCreateNewChannel: true,
+        teamToCreateChannelIn: TEAM_A,
+        shouldPostToExistingChannel: true,
+        existingTeam: TEAM_B,
+        existingChannelNames: "typo-channel",
+      },
+    });
+
+    const mocks: Mocks = mockDeps({
+      rule: rule,
+      createdChannels: [
+        makeCreatedChannel({
+          id: "19:new@thread.tacv2",
+          name: "oneuptime-alert-x",
+          teamId: TEAM_A,
+        }),
+      ],
+      channelExists: false,
+      responses: [makeSendResponse({})],
+    });
+
+    await expect(runTestRule(rule)).rejects.toThrow(/does not exist/);
+    expect(mocks.postSpy).not.toHaveBeenCalled();
+  });
+
+  test("a Microsoft Teams existing-channel rule with no team selected is rejected", async () => {
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldPostToExistingChannel: true,
+        existingChannelNames: "general",
+      },
+    });
+
+    const mocks: Mocks = mockDeps({
+      rule: rule,
+      responses: [makeSendResponse({})],
+    });
+
+    await expect(runTestRule(rule)).rejects.toThrow(
+      /requires a team to be selected/,
+    );
+    expect(mocks.postSpy).not.toHaveBeenCalled();
+  });
+
+  test("created channels are posted to before existing ones", async () => {
+    const rule: WorkspaceNotificationRule = makeRule({
+      overrides: {
+        shouldCreateNewChannel: true,
+        teamToCreateChannelIn: TEAM_A,
+        shouldPostToExistingChannel: true,
+        existingTeam: TEAM_B,
+        existingChannelNames: "general",
+      },
+    });
+
+    const mocks: Mocks = mockDeps({
+      rule: rule,
+      createdChannels: [
+        makeCreatedChannel({
+          id: "19:new@thread.tacv2",
+          name: "oneuptime-alert-x",
+          teamId: TEAM_A,
+        }),
+      ],
+      responses: [makeSendResponse({})],
+    });
+
+    await runTestRule(rule);
+
+    expect(payloadOfCall(mocks.postSpy, 0).channelIds).toEqual([
+      "19:new@thread.tacv2",
+    ]);
+    expect(payloadOfCall(mocks.postSpy, 1).channelNames).toEqual(["general"]);
+  });
+});

--- a/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsChannelSend.test.ts
+++ b/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsChannelSend.test.ts
@@ -63,7 +63,9 @@ jest.mock("botbuilder", () => {
   };
 });
 
-import MicrosoftTeamsUtil from "../../../../Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams";
+import MicrosoftTeamsUtil, {
+  MicrosoftTeamsAppInstallState,
+} from "../../../../Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams";
 import WorkspaceProjectAuthTokenService from "../../../../Server/Services/WorkspaceProjectAuthTokenService";
 import WorkspaceProjectAuthToken, {
   MicrosoftTeamsInstalledTeam,
@@ -73,6 +75,9 @@ import WorkspaceType from "../../../../Types/Workspace/WorkspaceType";
 import ObjectID from "../../../../Types/ObjectID";
 import BadDataException from "../../../../Types/Exception/BadDataException";
 import { JSONObject } from "../../../../Types/JSON";
+import API from "../../../../Utils/API";
+import HTTPErrorResponse from "../../../../Types/API/HTTPErrorResponse";
+import HTTPResponse from "../../../../Types/API/HTTPResponse";
 import WorkspaceMessagePayload, {
   WorkspacePayloadMarkdown,
 } from "../../../../Types/Workspace/WorkspaceMessagePayload";
@@ -135,13 +140,24 @@ function baseMiscData(
   } as MicrosoftTeamsMiscData;
 }
 
+/*
+ * A captured install, as captureTeamFromBotActivity writes it: keyed by the
+ * GRAPH team id, with the Bot Framework thread id kept alongside. `id` is the
+ * Graph id here because that is the only form the send path can match — see
+ * MicrosoftTeamsInstalledTeamIdSpace.test.ts, which derives these fixtures from
+ * the real capture path instead of hand-writing them.
+ */
 function buildInstalledTeam(data: {
   id: string;
   name?: string | undefined;
   serviceUrl?: string | undefined;
+  graphTeamId?: string | undefined;
+  teamsThreadId?: string | undefined;
 }): MicrosoftTeamsInstalledTeam {
   const installedTeam: MicrosoftTeamsInstalledTeam = {
     id: data.id,
+    graphTeamId: "graphTeamId" in data ? data.graphTeamId : data.id,
+    teamsThreadId: data.teamsThreadId || `19:${data.id}@thread.tacv2`,
     name: data.name || "Engineering",
     addedAt: "2026-07-27T00:00:00.000Z",
   };
@@ -149,6 +165,33 @@ function buildInstalledTeam(data: {
     installedTeam.serviceUrl = data.serviceUrl;
   }
   return installedTeam;
+}
+
+/*
+ * Pin the Graph installed-apps check. The send path consults it whenever it has
+ * no local install record, so leaving it live would put every such test on the
+ * network. Unknown is the honest default for a tenant that has not granted the
+ * permission, and it is also the pre-existing behaviour (fall through to
+ * Microsoft), which keeps these suites about one thing at a time.
+ */
+let installStateSpy: jest.SpyInstance | undefined = undefined;
+
+function mockInstallState(
+  state: MicrosoftTeamsAppInstallState = MicrosoftTeamsAppInstallState.Unknown,
+): jest.SpyInstance {
+  installStateSpy = jest
+    .spyOn(MicrosoftTeamsUtil, "isAppInstalledInTeam")
+    .mockResolvedValue(state);
+  return installStateSpy;
+}
+
+/*
+ * The suite that tests isAppInstalledInTeam itself has to undo the file-wide
+ * stub, or it would only ever assert against the stub.
+ */
+function useRealInstallStateCheck(): void {
+  installStateSpy?.mockRestore();
+  installStateSpy = undefined;
 }
 
 function buildChannel(data?: {
@@ -276,6 +319,7 @@ afterEach(() => {
  * mockResolvedValueOnce queues leak between tests unless reset here.
  */
 beforeEach(() => {
+  mockInstallState();
   (MessageFactory.text as jest.Mock).mockReset();
   (MessageFactory.attachment as jest.Mock).mockReset();
   (MessageFactory.attachment as jest.Mock).mockImplementation(
@@ -541,60 +585,36 @@ describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - shared channel refusal"
   });
 });
 
+/*
+ * The preflight decides whether to refuse locally or hand the send to Microsoft.
+ *
+ * It used to refuse purely on the absence of a local install record, which is
+ * not evidence: installedTeams is only written from bot activities, so a team
+ * the app was added to while OneUptime was unreachable — or before install
+ * capture shipped — looks identical to a team it was never added to. Admins who
+ * had followed every documented step were told to follow them again.
+ *
+ * A refusal now requires a POSITIVE answer from Graph that the app is absent.
+ * Installed and Unknown both proceed and let Microsoft, the only real authority
+ * on roster membership, decide.
+ */
 describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - install preflight", () => {
-  test("installedTeams undefined (legacy workspace) does NOT block the send", async () => {
-    mockProjectAuth({ miscData: baseMiscData() });
-    const adapter: FakeBotAdapter = installFakeBotAdapter();
-
-    const thread: WorkspaceThread = await sendCardToChannel();
-
-    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
-    expect(thread.threadId).toBe("msg-123");
-  });
-
-  test("an EMPTY installedTeams map does NOT block the send", async () => {
-    mockProjectAuth({ installedTeams: {} });
-    const adapter: FakeBotAdapter = installFakeBotAdapter();
-
-    await sendCardToChannel();
-
-    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
-  });
-
-  test("installedTeams containing ONLY a different team refuses before the Bot Framework call", async () => {
-    mockProjectAuth({
-      installedTeams: {
-        "team-2": buildInstalledTeam({ id: "team-2", name: "Marketing" }),
-      },
-    });
-    const adapter: FakeBotAdapter = installFakeBotAdapter();
-
-    await expect(
-      sendCardToChannel({
-        teamId: TEAM_ID,
-        workspaceChannel: buildChannel({ name: "General" }),
-      }),
-    ).rejects.toThrow(
-      new BadDataException(
-        MicrosoftTeamsUtil.getBotNotInTeamMessage({ channelName: "General" }),
-      ),
-    );
-
-    expect(adapter.getBotAdapterSpy).not.toHaveBeenCalled();
-    expect(adapter.continueConversationAsync).not.toHaveBeenCalled();
-  });
-
-  test("installedTeams containing this team proceeds to the send", async () => {
+  test("a captured install for the target team proceeds without asking Graph", async () => {
     mockProjectAuth({
       installedTeams: {
         [TEAM_ID]: buildInstalledTeam({ id: TEAM_ID }),
       },
     });
+    const installSpy: jest.SpyInstance = mockInstallState(
+      MicrosoftTeamsAppInstallState.NotInstalled,
+    );
     const adapter: FakeBotAdapter = installFakeBotAdapter();
 
     await sendCardToChannel();
 
     expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+    // The local record is the fast path; no Graph round trip per notification.
+    expect(installSpy).not.toHaveBeenCalled();
   });
 
   test("several installed teams, one of which is the target, proceeds", async () => {
@@ -612,13 +632,105 @@ describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - install preflight", () 
     expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
   });
 
-  test("several installed teams, none of which is the target, refuses", async () => {
+  test("no local record + Graph says NOT installed refuses before the Bot Framework call", async () => {
     mockProjectAuth({
       installedTeams: {
-        "team-0": buildInstalledTeam({ id: "team-0" }),
+        "team-2": buildInstalledTeam({ id: "team-2", name: "Marketing" }),
+      },
+    });
+    mockInstallState(MicrosoftTeamsAppInstallState.NotInstalled);
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await expect(
+      sendCardToChannel({
+        teamId: TEAM_ID,
+        workspaceChannel: buildChannel({ name: "General" }),
+      }),
+    ).rejects.toThrow(
+      new BadDataException(
+        MicrosoftTeamsUtil.getBotNotInTeamMessage({ channelName: "General" }),
+      ),
+    );
+
+    expect(adapter.getBotAdapterSpy).not.toHaveBeenCalled();
+    expect(adapter.continueConversationAsync).not.toHaveBeenCalled();
+  });
+
+  test("the verified refusal is checked against the team the caller asked for", async () => {
+    mockProjectAuth({ installedTeams: {} });
+    const installSpy: jest.SpyInstance = mockInstallState(
+      MicrosoftTeamsAppInstallState.NotInstalled,
+    );
+    installFakeBotAdapter();
+
+    await expect(sendCardToChannel({ teamId: "team-99" })).rejects.toThrow(
+      /is not installed in the Microsoft Teams team/,
+    );
+
+    expect(installSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ teamId: "team-99" }),
+    );
+  });
+
+  test("no local record + Graph says installed proceeds to the send", async () => {
+    mockProjectAuth({ installedTeams: {} });
+    mockInstallState(MicrosoftTeamsAppInstallState.Installed);
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel();
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("no local record + Graph cannot tell us proceeds rather than accusing", async () => {
+    mockProjectAuth({
+      installedTeams: {
         "team-2": buildInstalledTeam({ id: "team-2" }),
       },
     });
+    mockInstallState(MicrosoftTeamsAppInstallState.Unknown);
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel({ teamId: TEAM_ID });
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("installedTeams undefined (legacy workspace) with an unknown install state does NOT block the send", async () => {
+    mockProjectAuth({ miscData: baseMiscData() });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel();
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("an EMPTY installedTeams map with an unknown install state does NOT block the send", async () => {
+    mockProjectAuth({ installedTeams: {} });
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel();
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("a record written before graph ids were captured cannot vouch for a team, so Graph decides", async () => {
+    /*
+     * The legacy on-disk shape: keyed by the Bot Framework thread id, with no
+     * graphTeamId. It must not be mistaken for an install of the Graph team id
+     * that happens to be the rule's value, and it must not be treated as proof
+     * of anything either — Graph is asked, and here it says no.
+     */
+    mockProjectAuth({
+      installedTeams: {
+        "19:team-aaa@thread.tacv2": {
+          id: "19:team-aaa@thread.tacv2",
+          name: "Engineering",
+          addedAt: "2026-07-27T00:00:00.000Z",
+        } as MicrosoftTeamsInstalledTeam,
+      },
+    });
+    mockInstallState(MicrosoftTeamsAppInstallState.NotInstalled);
     const adapter: FakeBotAdapter = installFakeBotAdapter();
 
     await expect(sendCardToChannel({ teamId: TEAM_ID })).rejects.toThrow(
@@ -627,12 +739,29 @@ describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - install preflight", () 
     expect(adapter.continueConversationAsync).not.toHaveBeenCalled();
   });
 
-  test("the team id lookup is exact — a differently-cased key does not count as installed", async () => {
+  test("a legacy record does not block a send Graph is willing to allow", async () => {
+    mockProjectAuth({
+      installedTeams: {
+        "19:team-aaa@thread.tacv2": {
+          id: "19:team-aaa@thread.tacv2",
+        } as MicrosoftTeamsInstalledTeam,
+      },
+    });
+    mockInstallState(MicrosoftTeamsAppInstallState.Installed);
+    const adapter: FakeBotAdapter = installFakeBotAdapter();
+
+    await sendCardToChannel({ teamId: TEAM_ID });
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("the graph team id match is exact — a differently-cased record is not this team", async () => {
     mockProjectAuth({
       installedTeams: {
         "TEAM-1": buildInstalledTeam({ id: "TEAM-1" }),
       },
     });
+    mockInstallState(MicrosoftTeamsAppInstallState.NotInstalled);
     const adapter: FakeBotAdapter = installFakeBotAdapter();
 
     await expect(sendCardToChannel({ teamId: "team-1" })).rejects.toThrow(
@@ -641,12 +770,9 @@ describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - install preflight", () 
     expect(adapter.continueConversationAsync).not.toHaveBeenCalled();
   });
 
-  test("the preflight refusal for a PRIVATE channel gives the channel-install instructions", async () => {
-    mockProjectAuth({
-      installedTeams: {
-        "team-2": buildInstalledTeam({ id: "team-2" }),
-      },
-    });
+  test("the verified refusal for a PRIVATE channel gives the channel-install instructions", async () => {
+    mockProjectAuth({ installedTeams: {} });
+    mockInstallState(MicrosoftTeamsAppInstallState.NotInstalled);
     installFakeBotAdapter();
 
     await expect(
@@ -666,29 +792,25 @@ describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - install preflight", () 
     );
   });
 
-  test("the preflight refusal is a BadDataException", async () => {
-    mockProjectAuth({
-      installedTeams: {
-        "team-2": buildInstalledTeam({ id: "team-2" }),
-      },
-    });
+  test("the verified refusal is a BadDataException", async () => {
+    mockProjectAuth({ installedTeams: {} });
+    mockInstallState(MicrosoftTeamsAppInstallState.NotInstalled);
     installFakeBotAdapter();
 
     await expect(sendCardToChannel()).rejects.toBeInstanceOf(BadDataException);
   });
 
   test("the preflight never runs when the integration is missing entirely", async () => {
-    jest
-      .spyOn(WorkspaceProjectAuthTokenService, "getProjectAuth")
-      .mockResolvedValue(null);
-    const adapter: FakeBotAdapter = installFakeBotAdapter();
+    mockProjectAuth({ miscData: null });
+    const installSpy: jest.SpyInstance = mockInstallState(
+      MicrosoftTeamsAppInstallState.NotInstalled,
+    );
+    installFakeBotAdapter();
 
     await expect(sendCardToChannel()).rejects.toThrow(
-      new BadDataException(
-        "Microsoft Teams integration not found for this project",
-      ),
+      /Microsoft Teams integration not found/,
     );
-    expect(adapter.continueConversationAsync).not.toHaveBeenCalled();
+    expect(installSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -822,9 +944,26 @@ describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - conversation reference"
   });
 });
 
+/*
+ * How Microsoft's roster rejection is worded back to the admin.
+ *
+ * The rewrite used to assert "the app is not installed in the team" for every
+ * roster rejection. That is one cause among several, and for the customer who
+ * reported this it was the wrong one — the app was in the team's app list and
+ * the bot answered @mentions in the very channel that failed. The rewrite is
+ * now conditioned on what the preflight actually established: only a verified
+ * absence gets the install instructions, and anything else gets the causes that
+ * apply to an app which IS present, with Microsoft's own words attached.
+ */
 describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - roster error translation", () => {
-  test("Microsoft's roster rejection is replaced with the parent-team install instructions", async () => {
-    mockProjectAuth();
+  test("a VERIFIED absent install still gets the parent-team install instructions", async () => {
+    /*
+     * Graph is asked before the send here and says the app is absent, but the
+     * refusal happens up front, so this asserts the message an admin who really
+     * has not added the app sees.
+     */
+    mockProjectAuth({ installedTeams: {} });
+    mockInstallState(MicrosoftTeamsAppInstallState.NotInstalled);
     installFakeBotAdapter({ adapterError: new Error(ROSTER_ERROR_TEXT) });
 
     await expect(
@@ -844,7 +983,145 @@ describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - roster error translatio
     );
   });
 
-  test("the raw Microsoft text never reaches the caller", async () => {
+  test("an UNVERIFIED roster rejection does not claim the app is missing", async () => {
+    mockProjectAuth();
+    mockInstallState(MicrosoftTeamsAppInstallState.Unknown);
+    installFakeBotAdapter({ adapterError: new Error(ROSTER_ERROR_TEXT) });
+
+    let thrown: unknown = undefined;
+    try {
+      await sendCardToChannel({
+        workspaceChannel: buildChannel({ name: "General" }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(BadDataException);
+    expect((thrown as Error).message).not.toContain(
+      "The OneUptime app is not installed in the Microsoft Teams team",
+    );
+    expect((thrown as Error).message).toContain("Likely causes");
+  });
+
+  test("an unverified rejection names the channel and quotes Microsoft", async () => {
+    mockProjectAuth();
+    mockInstallState(MicrosoftTeamsAppInstallState.Unknown);
+    installFakeBotAdapter({ adapterError: new Error(ROSTER_ERROR_TEXT) });
+
+    let thrown: unknown = undefined;
+    try {
+      await sendCardToChannel({
+        workspaceChannel: buildChannel({ name: "test public channel" }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect((thrown as Error).message).toContain('"test public channel"');
+    // The raw error is the one thing support needs and the rewrite used to eat.
+    expect((thrown as Error).message).toContain(ROSTER_ERROR_TEXT);
+  });
+
+  test("when the app IS known installed, the rejection points at the bot id instead", async () => {
+    /*
+     * The reporter's exact situation: a real install, and a roster rejection
+     * anyway. The actionable cause is that the installed package's bot is not
+     * the one this deployment authenticates as.
+     */
+    mockProjectAuth({
+      installedTeams: {
+        [TEAM_ID]: buildInstalledTeam({ id: TEAM_ID }),
+      },
+    });
+    mockInstallState(MicrosoftTeamsAppInstallState.Installed);
+    installFakeBotAdapter({ adapterError: new Error(ROSTER_ERROR_TEXT) });
+
+    let thrown: unknown = undefined;
+    try {
+      await sendCardToChannel({ teamId: TEAM_ID });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect((thrown as Error).message).toContain(
+      "MICROSOFT_TEAMS_APP_CLIENT_ID",
+    );
+    expect((thrown as Error).message).not.toContain(
+      "The OneUptime app is not installed in the Microsoft Teams team",
+    );
+  });
+
+  test("a STALE local install record is re-checked, and a confirmed removal gets the install instructions", async () => {
+    /*
+     * The local record let this send skip the preflight, but the app has since
+     * been removed from the team and no uninstall event reached us. Wording the
+     * error off the stale record would blame the bot id for a genuinely missing
+     * install, so Graph is asked again on the failure path.
+     */
+    mockProjectAuth({
+      installedTeams: {
+        [TEAM_ID]: buildInstalledTeam({ id: TEAM_ID }),
+      },
+    });
+    const installSpy: jest.SpyInstance = mockInstallState(
+      MicrosoftTeamsAppInstallState.NotInstalled,
+    );
+    installFakeBotAdapter({ adapterError: new Error(ROSTER_ERROR_TEXT) });
+
+    await expect(
+      sendCardToChannel({
+        teamId: TEAM_ID,
+        workspaceChannel: buildChannel({ name: "General" }),
+      }),
+    ).rejects.toThrow(
+      new BadDataException(
+        MicrosoftTeamsUtil.getBotNotInTeamMessage({ channelName: "General" }),
+      ),
+    );
+
+    // Not consulted on the happy path; consulted once the send actually failed.
+    expect(installSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("the Graph check is not repeated when the preflight already made it", async () => {
+    mockProjectAuth({ installedTeams: {} });
+    const installSpy: jest.SpyInstance = mockInstallState(
+      MicrosoftTeamsAppInstallState.Unknown,
+    );
+    installFakeBotAdapter({ adapterError: new Error(ROSTER_ERROR_TEXT) });
+
+    await expect(sendCardToChannel()).rejects.toThrow(/Likely causes/);
+
+    expect(installSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("an unverified rejection on a private channel still leads with the channel install", async () => {
+    mockProjectAuth();
+    mockInstallState(MicrosoftTeamsAppInstallState.Unknown);
+    installFakeBotAdapter({ adapterError: new Error(ROSTER_ERROR_TEXT) });
+
+    let thrown: unknown = undefined;
+    try {
+      await sendCardToChannel({
+        workspaceChannel: buildChannel({
+          name: "Ops War Room",
+          membershipType: "private",
+        }),
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect((thrown as Error).message).toContain("Manage channel > Apps");
+  });
+
+  test("every roster rejection mentions the Azure Bot Teams channel", async () => {
+    /*
+     * A bot whose Azure resource has no Microsoft Teams channel enabled is
+     * rejected exactly like an uninstalled app, and nothing in OneUptime can
+     * detect it — so it has to be in the message.
+     */
     mockProjectAuth();
     installFakeBotAdapter({ adapterError: new Error(ROSTER_ERROR_TEXT) });
 
@@ -855,30 +1132,7 @@ describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - roster error translatio
       thrown = err;
     }
 
-    expect(thrown).toBeInstanceOf(BadDataException);
-    expect((thrown as Error).message).not.toContain("conversation roster");
-    expect((thrown as Error).message).toContain("Manage team > Apps");
-  });
-
-  test("a roster rejection on a private channel gets the channel-install instructions", async () => {
-    mockProjectAuth();
-    installFakeBotAdapter({ adapterError: new Error(ROSTER_ERROR_TEXT) });
-
-    await expect(
-      sendCardToChannel({
-        workspaceChannel: buildChannel({
-          name: "Ops War Room",
-          membershipType: "private",
-        }),
-      }),
-    ).rejects.toThrow(
-      new BadDataException(
-        MicrosoftTeamsUtil.getBotNotInTeamMessage({
-          channelName: "Ops War Room",
-          membershipType: "private",
-        }),
-      ),
-    );
+    expect((thrown as Error).message).toContain("Microsoft Teams channel");
   });
 
   test("a roster rejection raised inside the proactive callback is translated too", async () => {
@@ -887,9 +1141,7 @@ describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - roster error translatio
       sendActivityError: new Error(ROSTER_ERROR_TEXT),
     });
 
-    await expect(sendCardToChannel()).rejects.toThrow(
-      /is not installed in the Microsoft Teams team/,
-    );
+    await expect(sendCardToChannel()).rejects.toThrow(/Likely causes/);
   });
 
   test("a roster rejection thrown as a plain string is translated too", async () => {
@@ -898,9 +1150,7 @@ describe("MicrosoftTeamsUtil.sendAdaptiveCardToChannel - roster error translatio
       adapterError: "The bot is not part of the conversation roster.",
     });
 
-    await expect(sendCardToChannel()).rejects.toThrow(
-      /is not installed in the Microsoft Teams team/,
-    );
+    await expect(sendCardToChannel()).rejects.toThrow(/Likely causes/);
   });
 
   test("unrelated adapter errors propagate untouched", async () => {
@@ -1149,6 +1399,7 @@ describe("MicrosoftTeamsUtil.sendMessage - unresolvable channel destinations are
         "team-2": buildInstalledTeam({ id: "team-2" }),
       },
     });
+    mockInstallState(MicrosoftTeamsAppInstallState.NotInstalled);
     const adapter: FakeBotAdapter = installFakeBotAdapter();
 
     const response: WorkspaceSendMessageResponse = await callSendMessage(
@@ -1164,6 +1415,300 @@ describe("MicrosoftTeamsUtil.sendMessage - unresolvable channel destinations are
         channelName: "General",
         membershipType: "standard",
       }),
+    );
+  });
+});
+
+describe("MicrosoftTeamsUtil.getRosterRejectionMessage", () => {
+  test("names the channel that was refused", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "test public channel",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+    });
+
+    expect(message).toContain('"test public channel"');
+  });
+
+  test("never tells an admin the app is not installed", () => {
+    /*
+     * The whole point of this message: it is used when we do NOT know, and the
+     * old wording turned "we do not know" into a false statement of fact.
+     */
+    for (const installState of [
+      MicrosoftTeamsAppInstallState.Unknown,
+      MicrosoftTeamsAppInstallState.Installed,
+    ]) {
+      const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+        channelName: "General",
+        installState: installState,
+      });
+
+      expect(message).not.toContain(
+        "The OneUptime app is not installed in the Microsoft Teams team",
+      );
+    }
+  });
+
+  test("a known install points at a bot id mismatch, not a missing install", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Installed,
+    });
+
+    expect(message).toContain("MICROSOFT_TEAMS_APP_CLIENT_ID");
+    expect(message).toContain("the app is installed in this team");
+  });
+
+  test("an unknown install state still suggests adding the app", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+    });
+
+    expect(message).toContain("Manage team > Apps");
+  });
+
+  test("a private channel leads with the channel-level install", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "Ops War Room",
+      membershipType: "private",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+    });
+
+    expect(message).toContain("Manage channel > Apps");
+    expect(message).not.toContain("Manage team > Apps");
+  });
+
+  test("Microsoft's own wording is quoted when we have it", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+      microsoftError: new Error(ROSTER_ERROR_TEXT),
+    });
+
+    expect(message).toContain(ROSTER_ERROR_TEXT);
+  });
+
+  test("a non-Error microsoftError is stringified rather than dropped", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+      microsoftError: "BotNotInConversationRoster",
+    });
+
+    expect(message).toContain("BotNotInConversationRoster");
+  });
+
+  test("no trailing quote section when there is no Microsoft error to quote", () => {
+    const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+      channelName: "General",
+      installState: MicrosoftTeamsAppInstallState.Unknown,
+    });
+
+    expect(message).not.toContain("Microsoft's response was");
+    expect(message.endsWith(".")).toBe(true);
+  });
+
+  test("the Azure Bot Teams channel is always listed as a cause", () => {
+    for (const installState of [
+      MicrosoftTeamsAppInstallState.Unknown,
+      MicrosoftTeamsAppInstallState.Installed,
+      MicrosoftTeamsAppInstallState.NotInstalled,
+    ]) {
+      const message: string = MicrosoftTeamsUtil.getRosterRejectionMessage({
+        channelName: "General",
+        installState: installState,
+      });
+
+      expect(message).toContain(
+        "does not have the Microsoft Teams channel enabled",
+      );
+    }
+  });
+});
+
+/*
+ * The Graph installed-apps check.
+ *
+ * Its contract is asymmetric on purpose: it may only answer NotInstalled when
+ * Graph actually enumerated the team's apps and this deployment's app was not
+ * among them. Any other outcome — a permission the tenant never granted, a
+ * transport failure, an unconfigured client id — is Unknown, because reporting
+ * those as NotInstalled is what sent the reporter of this bug in circles.
+ */
+describe("MicrosoftTeamsUtil.isAppInstalledInTeam", () => {
+  function mockGraph(pages: Array<JSONObject | HTTPErrorResponse>): jest.Mock {
+    const get: jest.Mock = jest.fn();
+
+    for (const page of pages) {
+      if (page instanceof HTTPErrorResponse) {
+        get.mockResolvedValueOnce(page);
+        continue;
+      }
+      get.mockResolvedValueOnce({ data: page } as HTTPResponse<JSONObject>);
+    }
+
+    jest.spyOn(API, "get").mockImplementation(get as any);
+    return get;
+  }
+
+  function callIsAppInstalled(
+    teamId: string = TEAM_ID,
+  ): Promise<MicrosoftTeamsAppInstallState> {
+    return MicrosoftTeamsUtil.isAppInstalledInTeam({
+      authToken: "auth-token",
+      projectId: ObjectID.generate(),
+      teamId: teamId,
+    });
+  }
+
+  beforeEach(() => {
+    useRealInstallStateCheck();
+    jest
+      .spyOn(MicrosoftTeamsUtil, "getValidAccessToken")
+      .mockResolvedValue("app-access-token");
+  });
+
+  test("an installed app matching this deployment's client id is Installed", async () => {
+    mockGraph([
+      {
+        value: [
+          { id: "install-1", teamsApp: { externalId: MOCK_APP_CLIENT_ID } },
+        ],
+      },
+    ]);
+
+    await expect(callIsAppInstalled()).resolves.toBe(
+      MicrosoftTeamsAppInstallState.Installed,
+    );
+  });
+
+  test("matching is on externalId, so another vendor's OneUptime app is not ours", async () => {
+    /*
+     * This is the case the reporter's screenshots could not rule out: a tile
+     * called "OneUptime · HackerBay Inc" in the team's app list which is the
+     * public store package, whose bot is not this deployment's bot.
+     */
+    mockGraph([
+      {
+        value: [
+          {
+            id: "install-1",
+            teamsApp: {
+              externalId: "99999999-9999-9999-9999-999999999999",
+              displayName: "OneUptime",
+            },
+          },
+        ],
+      },
+    ]);
+
+    await expect(callIsAppInstalled()).resolves.toBe(
+      MicrosoftTeamsAppInstallState.NotInstalled,
+    );
+  });
+
+  test("an empty app list is NotInstalled", async () => {
+    mockGraph([{ value: [] }]);
+
+    await expect(callIsAppInstalled()).resolves.toBe(
+      MicrosoftTeamsAppInstallState.NotInstalled,
+    );
+  });
+
+  test("a response with no value array at all is NotInstalled", async () => {
+    mockGraph([{}]);
+
+    await expect(callIsAppInstalled()).resolves.toBe(
+      MicrosoftTeamsAppInstallState.NotInstalled,
+    );
+  });
+
+  test("the app is found on a later page", async () => {
+    const get: jest.Mock = mockGraph([
+      {
+        value: [{ id: "install-1", teamsApp: { externalId: "other-app" } }],
+        "@odata.nextLink": "https://graph.microsoft.com/v1.0/page-2",
+      },
+      {
+        value: [
+          { id: "install-2", teamsApp: { externalId: MOCK_APP_CLIENT_ID } },
+        ],
+      },
+    ]);
+
+    await expect(callIsAppInstalled()).resolves.toBe(
+      MicrosoftTeamsAppInstallState.Installed,
+    );
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  test("NotInstalled is only returned after every page was read", async () => {
+    const get: jest.Mock = mockGraph([
+      {
+        value: [{ id: "install-1", teamsApp: { externalId: "other-app" } }],
+        "@odata.nextLink": "https://graph.microsoft.com/v1.0/page-2",
+      },
+      { value: [{ id: "install-2", teamsApp: { externalId: "another-app" } }] },
+    ]);
+
+    await expect(callIsAppInstalled()).resolves.toBe(
+      MicrosoftTeamsAppInstallState.NotInstalled,
+    );
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  test("a Graph error is Unknown, never NotInstalled", async () => {
+    /*
+     * The realistic case: a workspace connected before
+     * TeamsAppInstallation.ReadForTeam.All was documented gets a 403 here. It
+     * must not be told its app is missing.
+     */
+    mockGraph([new HTTPErrorResponse(403, { error: "Forbidden" }, {})]);
+
+    await expect(callIsAppInstalled()).resolves.toBe(
+      MicrosoftTeamsAppInstallState.Unknown,
+    );
+  });
+
+  test("a thrown transport error is Unknown", async () => {
+    jest.spyOn(API, "get").mockRejectedValue(new Error("socket hang up"));
+
+    await expect(callIsAppInstalled()).resolves.toBe(
+      MicrosoftTeamsAppInstallState.Unknown,
+    );
+  });
+
+  test("a token failure is Unknown", async () => {
+    jest
+      .spyOn(MicrosoftTeamsUtil, "getValidAccessToken")
+      .mockRejectedValue(new Error("no token"));
+    const get: jest.Mock = mockGraph([{ value: [] }]);
+
+    await expect(callIsAppInstalled()).resolves.toBe(
+      MicrosoftTeamsAppInstallState.Unknown,
+    );
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  test("the team id is scoped into the Graph URL and the app list is expanded", async () => {
+    const get: jest.Mock = mockGraph([{ value: [] }]);
+
+    await callIsAppInstalled("team-abc");
+
+    const requestedUrl: string = get.mock.calls[0]![0].url.toString();
+    expect(requestedUrl).toContain("/teams/team-abc/installedApps");
+    // Without $expand there is no teamsApp to match externalId against.
+    expect(requestedUrl).toContain("$expand=teamsApp");
+  });
+
+  test("the access token is sent as a bearer token", async () => {
+    const get: jest.Mock = mockGraph([{ value: [] }]);
+
+    await callIsAppInstalled();
+
+    expect(get.mock.calls[0]![0].headers.Authorization).toBe(
+      "Bearer app-access-token",
     );
   });
 });

--- a/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsInstalledTeamIdSpace.test.ts
+++ b/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsInstalledTeamIdSpace.test.ts
@@ -1,0 +1,778 @@
+import { describe, expect, test, afterEach, beforeEach } from "@jest/globals";
+
+/*
+ * The seam between "we saw the app get installed" and "we are allowed to post".
+ *
+ * A Microsoft Teams team has TWO ids and they are not interchangeable:
+ *
+ *   channelData.team.id        "19:...@thread.tacv2"   what bot activities carry
+ *   channelData.team.aadGroupId  a GUID                what Graph calls the team id
+ *
+ * Installs were captured under the thread id and looked up under the Graph id,
+ * so the lookup could never hit. Nothing caught it, because the write side and
+ * the read side were tested in separate files that each picked their own
+ * placeholder id and then wrote AND read with it — internally consistent, and
+ * blind to the fact that production feeds one side's output into the other.
+ *
+ * So these tests never name an id twice. Every one of them drives the real
+ * capture path with a realistic activity, keeps whatever it chose to store, and
+ * feeds that straight into the send path using only the id a notification rule
+ * would actually hold — the Graph team id from the team picker. If the two sides
+ * ever disagree about id space again, these fail.
+ */
+
+jest.mock("../../../../Server/EnvironmentConfig", () => {
+  return {
+    ...(jest.requireActual("../../../../Server/EnvironmentConfig") as Record<
+      string,
+      unknown
+    >),
+    MicrosoftTeamsAppClientId: "11111111-2222-3333-4444-555555555555",
+    MicrosoftTeamsAppClientSecret: "test-secret",
+    MicrosoftTeamsAppTenantId: "test-tenant",
+  };
+});
+
+jest.mock("botbuilder", () => {
+  return {
+    CloudAdapter: class CloudAdapter {},
+    ConfigurationBotFrameworkAuthentication: class ConfigurationBotFrameworkAuthentication {},
+    TeamsActivityHandler: class TeamsActivityHandler {},
+    TurnContext: class TurnContext {},
+    ActivityHandler: class ActivityHandler {},
+    MessageFactory: {
+      text: jest.fn(),
+      attachment: jest.fn((attachment: unknown) => {
+        return { type: "message", attachments: [attachment] };
+      }),
+    },
+    CardFactory: { heroCard: jest.fn() },
+    TeamsInfo: {
+      getMembers: jest.fn(),
+      getPagedMembers: jest.fn(),
+      getTeamDetails: jest.fn(),
+    },
+  };
+});
+
+import MicrosoftTeamsUtil, {
+  MicrosoftTeamsAppInstallState,
+} from "../../../../Server/Utils/Workspace/MicrosoftTeams/MicrosoftTeams";
+import WorkspaceProjectAuthTokenService from "../../../../Server/Services/WorkspaceProjectAuthTokenService";
+import WorkspaceProjectAuthToken, {
+  MicrosoftTeamsInstalledTeam,
+  MicrosoftTeamsMiscData,
+} from "../../../../Models/DatabaseModels/WorkspaceProjectAuthToken";
+import WorkspaceType from "../../../../Types/Workspace/WorkspaceType";
+import ObjectID from "../../../../Types/ObjectID";
+import { JSONObject } from "../../../../Types/JSON";
+import { WorkspaceChannel } from "../../../../Server/Utils/Workspace/WorkspaceBase";
+import { TeamsInfo, type ConversationReference } from "botbuilder";
+
+/*
+ * Realistic ids. The two forms are deliberately unrelated strings so that a
+ * mix-up cannot accidentally pass — this is exactly what the previous fixtures,
+ * where both sides used the same placeholder, could not detect.
+ */
+const TENANT_ID: string = "aaaaaaaa-1111-2222-3333-444444444444";
+const GRAPH_TEAM_ID: string = "bbbbbbbb-5555-6666-7777-888888888888";
+const TEAM_THREAD_ID: string = "19:qWeRtY_teamThread@thread.tacv2";
+const CHANNEL_ID: string = "19:aSdFgH_channelThread@thread.tacv2";
+const ACTIVITY_SERVICE_URL: string = "https://smba.trafficmanager.net/in/";
+const FALLBACK_SERVICE_URL: string = "https://smba.trafficmanager.net/teams/";
+
+const ADAPTIVE_CARD: JSONObject = { type: "AdaptiveCard", body: [] };
+
+interface CapturedSend {
+  refs: Array<ConversationReference>;
+  continueConversationAsync: jest.Mock;
+}
+
+/*
+ * A channel-scoped bot activity as Microsoft actually sends it — both team ids
+ * present, tenant on channelData, regional serviceUrl.
+ */
+function teamChannelActivity(overrides?: {
+  team?: JSONObject | undefined;
+  serviceUrl?: string | undefined;
+}): JSONObject {
+  return {
+    type: "conversationUpdate",
+    serviceUrl:
+      "serviceUrl" in (overrides || {})
+        ? overrides!.serviceUrl
+        : ACTIVITY_SERVICE_URL,
+    conversation: { conversationType: "channel", id: CHANNEL_ID },
+    channelData: {
+      team:
+        overrides && "team" in overrides
+          ? overrides.team
+          : {
+              id: TEAM_THREAD_ID,
+              name: "WBNOC",
+              aadGroupId: GRAPH_TEAM_ID,
+            },
+      tenant: { id: TENANT_ID },
+      channel: { id: CHANNEL_ID },
+    },
+  };
+}
+
+function buildTurnContext(serviceUrl?: string): any {
+  return {
+    activity: {
+      serviceUrl: serviceUrl === undefined ? ACTIVITY_SERVICE_URL : serviceUrl,
+    },
+  };
+}
+
+/*
+ * Runs the real capture path and returns exactly what it decided to persist. No
+ * assumption is made here about the key or the field layout — that is the thing
+ * under test.
+ */
+async function captureInstall(
+  activity: JSONObject,
+): Promise<Record<string, MicrosoftTeamsInstalledTeam>> {
+  let stored: Record<string, MicrosoftTeamsInstalledTeam> = {};
+
+  jest
+    .spyOn(MicrosoftTeamsUtil, "saveTeamToProjectAuthTokens")
+    .mockImplementation(
+      async (data: {
+        tenantId: string;
+        team: MicrosoftTeamsInstalledTeam;
+      }): Promise<void> => {
+        stored = { [data.team.id]: data.team };
+      },
+    );
+
+  await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+    activity: activity,
+    turnContext: buildTurnContext(),
+  });
+
+  return stored;
+}
+
+function mockProjectAuthWith(
+  installedTeams: Record<string, MicrosoftTeamsInstalledTeam>,
+): void {
+  const miscData: MicrosoftTeamsMiscData = {
+    tenantId: TENANT_ID,
+    teamId: GRAPH_TEAM_ID,
+    teamName: "WBNOC",
+    botId: "11111111-2222-3333-4444-555555555555",
+    installedTeams: installedTeams,
+  } as MicrosoftTeamsMiscData;
+
+  jest
+    .spyOn(WorkspaceProjectAuthTokenService, "getProjectAuth")
+    .mockResolvedValue({
+      id: ObjectID.generate(),
+      workspaceProjectId: TENANT_ID,
+      miscData: miscData,
+    } as unknown as WorkspaceProjectAuthToken);
+}
+
+function installFakeBotAdapter(): CapturedSend {
+  const refs: Array<ConversationReference> = [];
+  const continueConversationAsync: jest.Mock = jest.fn(
+    async (
+      _appId: string,
+      ref: ConversationReference,
+      cb: (context: any) => Promise<void>,
+    ): Promise<void> => {
+      refs.push(ref);
+      await cb({
+        sendActivity: async (): Promise<JSONObject> => {
+          return { id: "msg-1" };
+        },
+      });
+    },
+  );
+
+  jest.spyOn(MicrosoftTeamsUtil as any, "getBotAdapter").mockReturnValue({
+    continueConversationAsync: continueConversationAsync,
+  });
+
+  return { refs: refs, continueConversationAsync: continueConversationAsync };
+}
+
+function channel(): WorkspaceChannel {
+  return {
+    id: CHANNEL_ID,
+    name: "WBNOC Test Channel",
+    workspaceType: WorkspaceType.MicrosoftTeams,
+    teamId: GRAPH_TEAM_ID,
+  };
+}
+
+/*
+ * The send as a notification rule triggers it: teamId is the value the team
+ * picker stored, which comes from Graph GET /teams — never a thread id.
+ */
+function sendAsNotificationRuleWould(): Promise<unknown> {
+  return MicrosoftTeamsUtil.sendAdaptiveCardToChannel({
+    authToken: "auth-token",
+    teamId: GRAPH_TEAM_ID,
+    workspaceChannel: channel(),
+    adaptiveCard: ADAPTIVE_CARD,
+    projectId: ObjectID.generate(),
+  });
+}
+
+beforeEach(() => {
+  (TeamsInfo.getTeamDetails as jest.Mock).mockReset();
+  /*
+   * Force the Graph fallback to fail so nothing in this file can pass by way of
+   * the install check. A send that succeeds here succeeded because the captured
+   * record matched, which is the only thing being asserted.
+   */
+  jest
+    .spyOn(MicrosoftTeamsUtil, "isAppInstalledInTeam")
+    .mockResolvedValue(MicrosoftTeamsAppInstallState.NotInstalled);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("Microsoft Teams install capture and channel send agree on the team id space", () => {
+  test("an install captured from a bot activity permits the send a notification rule performs", async () => {
+    /*
+     * THE regression test for this bug. The app is installed; Teams tells us so;
+     * the rule then posts using the Graph team id. Before the fix the captured
+     * record was keyed by the thread id, the lookup missed, and the admin was
+     * told to install an app that was already installed.
+     */
+    const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> =
+      await captureInstall(teamChannelActivity());
+
+    mockProjectAuthWith(installedTeams);
+    const adapter: CapturedSend = installFakeBotAdapter();
+
+    await sendAsNotificationRuleWould();
+
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("the captured record is reachable by the Graph team id, which is what every caller holds", async () => {
+    const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> =
+      await captureInstall(teamChannelActivity());
+
+    const index: Record<string, MicrosoftTeamsInstalledTeam> =
+      MicrosoftTeamsUtil.indexInstalledTeamsByGraphTeamId(installedTeams);
+
+    expect(Object.keys(index)).toEqual([GRAPH_TEAM_ID]);
+  });
+
+  test("the captured record keeps the thread id too, so uninstall can still find it", async () => {
+    const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> =
+      await captureInstall(teamChannelActivity());
+
+    const record: MicrosoftTeamsInstalledTeam =
+      Object.values(installedTeams)[0]!;
+
+    expect(record.teamsThreadId).toBe(TEAM_THREAD_ID);
+    expect(record.graphTeamId).toBe(GRAPH_TEAM_ID);
+  });
+
+  test("a captured install is never keyed by the thread id when the Graph id is known", async () => {
+    const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> =
+      await captureInstall(teamChannelActivity());
+
+    expect(Object.keys(installedTeams)).not.toContain(TEAM_THREAD_ID);
+  });
+
+  test("the serviceUrl captured on install reaches the send, instead of the global fallback", async () => {
+    /*
+     * This never worked either: the serviceUrl was captured but read through the
+     * same broken lookup, so `installedTeam?.serviceUrl` was always undefined
+     * and every proactive post went to the commercial-cloud endpoint. That is
+     * the wrong host for a GCC/DoD tenant, and for a regional one it is the
+     * hardcoded guess Microsoft's docs tell you not to make.
+     */
+    const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> =
+      await captureInstall(teamChannelActivity());
+
+    mockProjectAuthWith(installedTeams);
+    const adapter: CapturedSend = installFakeBotAdapter();
+
+    await sendAsNotificationRuleWould();
+
+    expect(adapter.refs[0]!.serviceUrl).toBe(ACTIVITY_SERVICE_URL);
+    expect(adapter.refs[0]!.serviceUrl).not.toBe(FALLBACK_SERVICE_URL);
+  });
+
+  test("an activity without aadGroupId falls back to TeamsInfo, and the send still works", async () => {
+    (TeamsInfo.getTeamDetails as jest.Mock).mockResolvedValue({
+      id: TEAM_THREAD_ID,
+      name: "WBNOC",
+      aadGroupId: GRAPH_TEAM_ID,
+    });
+
+    const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> =
+      await captureInstall(
+        teamChannelActivity({
+          team: { id: TEAM_THREAD_ID, name: "WBNOC" },
+        }),
+      );
+
+    mockProjectAuthWith(installedTeams);
+    const adapter: CapturedSend = installFakeBotAdapter();
+
+    await sendAsNotificationRuleWould();
+
+    expect(TeamsInfo.getTeamDetails as jest.Mock).toHaveBeenCalledTimes(1);
+    expect(adapter.continueConversationAsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("an unresolvable Graph id keeps the install on record but does not vouch for the team", async () => {
+    /*
+     * getTeamDetails is what fails on an uninstall, and can fail on a transient
+     * error. The record is still worth keeping — it is how uninstall finds the
+     * team — but it must not be silently treated as an install of some Graph
+     * team id, which is the class of confusion this whole change removes.
+     */
+    (TeamsInfo.getTeamDetails as jest.Mock).mockRejectedValue(
+      new Error("The bot is not part of the conversation roster."),
+    );
+
+    const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> =
+      await captureInstall(
+        teamChannelActivity({
+          team: { id: TEAM_THREAD_ID, name: "WBNOC" },
+        }),
+      );
+
+    expect(Object.keys(installedTeams)).toEqual([TEAM_THREAD_ID]);
+    expect(
+      MicrosoftTeamsUtil.indexInstalledTeamsByGraphTeamId(installedTeams),
+    ).toEqual({});
+  });
+
+  test("re-capturing a team that was stored under its thread id leaves exactly one record", async () => {
+    /*
+     * The upgrade path. A workspace that ran the old code has thread-id-keyed
+     * records; the @mention backfill re-captures them, now with a Graph id. Two
+     * records for one team would mean one that can never be matched or removed.
+     */
+    const legacyRecord: MicrosoftTeamsInstalledTeam = {
+      id: TEAM_THREAD_ID,
+      name: "WBNOC",
+      serviceUrl: ACTIVITY_SERVICE_URL,
+      addedAt: "2026-08-01T00:00:00.000Z",
+    };
+
+    let stored: Record<string, MicrosoftTeamsInstalledTeam> = {
+      [TEAM_THREAD_ID]: legacyRecord,
+    };
+
+    jest.spyOn(WorkspaceProjectAuthTokenService, "findBy").mockResolvedValue([
+      {
+        id: ObjectID.generate(),
+        miscData: { installedTeams: stored } as MicrosoftTeamsMiscData,
+      },
+    ] as unknown as Array<WorkspaceProjectAuthToken>);
+
+    jest
+      .spyOn(WorkspaceProjectAuthTokenService, "updateOneById")
+      .mockImplementation(async (args: any): Promise<number> => {
+        stored = args.data.miscData.installedTeams;
+        return 1;
+      });
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamChannelActivity(),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(Object.keys(stored)).toEqual([GRAPH_TEAM_ID]);
+    expect(stored[GRAPH_TEAM_ID]!.teamsThreadId).toBe(TEAM_THREAD_ID);
+  });
+
+  test("a team installed in one tenant does not vouch for a same-named team elsewhere", async () => {
+    const installedTeams: Record<string, MicrosoftTeamsInstalledTeam> =
+      await captureInstall(teamChannelActivity());
+
+    mockProjectAuthWith(installedTeams);
+    installFakeBotAdapter();
+
+    // A different Graph team id — the picker's other team — must not match.
+    await expect(
+      MicrosoftTeamsUtil.sendAdaptiveCardToChannel({
+        authToken: "auth-token",
+        teamId: "cccccccc-9999-0000-1111-222222222222",
+        workspaceChannel: channel(),
+        adaptiveCard: ADAPTIVE_CARD,
+        projectId: ObjectID.generate(),
+      }),
+    ).rejects.toThrow(/is not installed in the Microsoft Teams team/);
+  });
+});
+
+describe("MicrosoftTeamsUtil.indexInstalledTeamsByGraphTeamId", () => {
+  test("undefined and empty maps produce an empty index", () => {
+    expect(
+      MicrosoftTeamsUtil.indexInstalledTeamsByGraphTeamId(undefined),
+    ).toEqual({});
+    expect(MicrosoftTeamsUtil.indexInstalledTeamsByGraphTeamId({})).toEqual({});
+  });
+
+  test("records are keyed by graphTeamId regardless of the map key they were stored under", () => {
+    const record: MicrosoftTeamsInstalledTeam = {
+      id: "whatever-key",
+      graphTeamId: GRAPH_TEAM_ID,
+      teamsThreadId: TEAM_THREAD_ID,
+    };
+
+    expect(
+      MicrosoftTeamsUtil.indexInstalledTeamsByGraphTeamId({
+        "whatever-key": record,
+      }),
+    ).toEqual({ [GRAPH_TEAM_ID]: record });
+  });
+
+  test("records with no graphTeamId are dropped rather than indexed by a thread id", () => {
+    expect(
+      MicrosoftTeamsUtil.indexInstalledTeamsByGraphTeamId({
+        [TEAM_THREAD_ID]: {
+          id: TEAM_THREAD_ID,
+        } as MicrosoftTeamsInstalledTeam,
+      }),
+    ).toEqual({});
+  });
+
+  test("resolved and unresolved records coexist; only the resolved one is indexed", () => {
+    const resolved: MicrosoftTeamsInstalledTeam = {
+      id: GRAPH_TEAM_ID,
+      graphTeamId: GRAPH_TEAM_ID,
+    };
+
+    expect(
+      MicrosoftTeamsUtil.indexInstalledTeamsByGraphTeamId({
+        [GRAPH_TEAM_ID]: resolved,
+        "19:other@thread.tacv2": {
+          id: "19:other@thread.tacv2",
+        } as MicrosoftTeamsInstalledTeam,
+      }),
+    ).toEqual({ [GRAPH_TEAM_ID]: resolved });
+  });
+});
+
+describe("MicrosoftTeamsUtil.isSameInstalledTeam", () => {
+  test("matches on graphTeamId", () => {
+    expect(
+      MicrosoftTeamsUtil.isSameInstalledTeam({
+        team: { id: GRAPH_TEAM_ID, graphTeamId: GRAPH_TEAM_ID },
+        graphTeamId: GRAPH_TEAM_ID,
+      }),
+    ).toBe(true);
+  });
+
+  test("matches on teamsThreadId", () => {
+    expect(
+      MicrosoftTeamsUtil.isSameInstalledTeam({
+        team: { id: GRAPH_TEAM_ID, teamsThreadId: TEAM_THREAD_ID },
+        teamsThreadId: TEAM_THREAD_ID,
+      }),
+    ).toBe(true);
+  });
+
+  test("matches a legacy record whose thread id is only in the key field", () => {
+    expect(
+      MicrosoftTeamsUtil.isSameInstalledTeam({
+        team: { id: TEAM_THREAD_ID },
+        teamsThreadId: TEAM_THREAD_ID,
+      }),
+    ).toBe(true);
+  });
+
+  test("matches a legacy record by graph id when that is what it was keyed by", () => {
+    expect(
+      MicrosoftTeamsUtil.isSameInstalledTeam({
+        team: { id: GRAPH_TEAM_ID },
+        graphTeamId: GRAPH_TEAM_ID,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not match a different team", () => {
+    expect(
+      MicrosoftTeamsUtil.isSameInstalledTeam({
+        team: { id: GRAPH_TEAM_ID, graphTeamId: GRAPH_TEAM_ID },
+        graphTeamId: "cccccccc-9999-0000-1111-222222222222",
+        teamsThreadId: "19:someone-else@thread.tacv2",
+      }),
+    ).toBe(false);
+  });
+
+  test("does not cross id spaces — a thread id never matches a graph id field", () => {
+    expect(
+      MicrosoftTeamsUtil.isSameInstalledTeam({
+        team: { id: GRAPH_TEAM_ID, graphTeamId: GRAPH_TEAM_ID },
+        teamsThreadId: GRAPH_TEAM_ID,
+      }),
+    ).toBe(true); // id equals the value, so this is a legitimate key match
+    expect(
+      MicrosoftTeamsUtil.isSameInstalledTeam({
+        team: { id: "some-key", graphTeamId: GRAPH_TEAM_ID },
+        teamsThreadId: GRAPH_TEAM_ID,
+      }),
+    ).toBe(false);
+  });
+
+  test("matching is case-sensitive, as Microsoft's ids are", () => {
+    expect(
+      MicrosoftTeamsUtil.isSameInstalledTeam({
+        team: { id: GRAPH_TEAM_ID, graphTeamId: GRAPH_TEAM_ID },
+        graphTeamId: GRAPH_TEAM_ID.toUpperCase(),
+      }),
+    ).toBe(false);
+  });
+
+  test("an undefined record never matches", () => {
+    expect(
+      MicrosoftTeamsUtil.isSameInstalledTeam({
+        team: undefined,
+        graphTeamId: GRAPH_TEAM_ID,
+      }),
+    ).toBe(false);
+  });
+
+  test("no ids to match on means no match, rather than matching everything", () => {
+    expect(
+      MicrosoftTeamsUtil.isSameInstalledTeam({
+        team: { id: GRAPH_TEAM_ID, graphTeamId: GRAPH_TEAM_ID },
+      }),
+    ).toBe(false);
+  });
+});
+
+/*
+ * The message-driven backfill fires on EVERY inbound channel message, so it has
+ * to be cheap once the team is on record. Install events themselves always
+ * re-record: that is when the serviceUrl and the group id are freshest.
+ */
+describe("captureTeamFromBotActivity onlyIfMissingOrStale", () => {
+  function mockStoredTeams(
+    installedTeams: Record<string, MicrosoftTeamsInstalledTeam>,
+  ): { saveSpy: jest.SpyInstance } {
+    jest.spyOn(WorkspaceProjectAuthTokenService, "findBy").mockResolvedValue([
+      {
+        id: ObjectID.generate(),
+        miscData: { installedTeams: installedTeams } as MicrosoftTeamsMiscData,
+      },
+    ] as unknown as Array<WorkspaceProjectAuthToken>);
+
+    const saveSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "saveTeamToProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+
+    return { saveSpy: saveSpy };
+  }
+
+  function fullyRecordedTeam(): MicrosoftTeamsInstalledTeam {
+    return {
+      id: GRAPH_TEAM_ID,
+      graphTeamId: GRAPH_TEAM_ID,
+      teamsThreadId: TEAM_THREAD_ID,
+      serviceUrl: ACTIVITY_SERVICE_URL,
+      addedAt: "2026-08-01T00:00:00.000Z",
+    };
+  }
+
+  test("an already-recorded team is not rewritten", async () => {
+    const { saveSpy } = mockStoredTeams({
+      [GRAPH_TEAM_ID]: fullyRecordedTeam(),
+    });
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamChannelActivity(),
+      turnContext: buildTurnContext(),
+      onlyIfMissingOrStale: true,
+    });
+
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  test("an already-recorded team does not trigger a Bot Framework lookup", async () => {
+    /*
+     * The expensive case: an activity with no aadGroupId. Resolving it on every
+     * message would be one Bot Framework call per message in a busy channel.
+     */
+    mockStoredTeams({ [GRAPH_TEAM_ID]: fullyRecordedTeam() });
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamChannelActivity({
+        team: { id: TEAM_THREAD_ID, name: "WBNOC" },
+      }),
+      turnContext: buildTurnContext(),
+      onlyIfMissingOrStale: true,
+    });
+
+    expect(TeamsInfo.getTeamDetails as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  test("a team that is not on record yet IS written", async () => {
+    const { saveSpy } = mockStoredTeams({});
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamChannelActivity(),
+      turnContext: buildTurnContext(),
+      onlyIfMissingOrStale: true,
+    });
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("a record missing its graph id is refreshed, so the upgrade path still works", async () => {
+    const { saveSpy } = mockStoredTeams({
+      [TEAM_THREAD_ID]: {
+        id: TEAM_THREAD_ID,
+        serviceUrl: ACTIVITY_SERVICE_URL,
+      } as MicrosoftTeamsInstalledTeam,
+    });
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamChannelActivity(),
+      turnContext: buildTurnContext(),
+      onlyIfMissingOrStale: true,
+    });
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    const saved: MicrosoftTeamsInstalledTeam = (
+      saveSpy.mock.calls[0]?.[0] as { team: MicrosoftTeamsInstalledTeam }
+    ).team;
+    expect(saved.graphTeamId).toBe(GRAPH_TEAM_ID);
+  });
+
+  test("a moved serviceUrl is refreshed", async () => {
+    /*
+     * Microsoft's docs say to re-verify the stored serviceUrl when a new message
+     * arrives; a stale one sends proactive posts to the wrong regional host.
+     */
+    const { saveSpy } = mockStoredTeams({
+      [GRAPH_TEAM_ID]: {
+        ...fullyRecordedTeam(),
+        serviceUrl: "https://smba.trafficmanager.net/emea/",
+      },
+    });
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamChannelActivity(),
+      turnContext: buildTurnContext(),
+      onlyIfMissingOrStale: true,
+    });
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    const saved: MicrosoftTeamsInstalledTeam = (
+      saveSpy.mock.calls[0]?.[0] as { team: MicrosoftTeamsInstalledTeam }
+    ).team;
+    expect(saved.serviceUrl).toBe(ACTIVITY_SERVICE_URL);
+  });
+
+  test("without the flag, an install event always re-records", async () => {
+    const { saveSpy } = mockStoredTeams({
+      [GRAPH_TEAM_ID]: fullyRecordedTeam(),
+    });
+
+    await MicrosoftTeamsUtil.captureTeamFromBotActivity({
+      activity: teamChannelActivity(),
+      turnContext: buildTurnContext(),
+    });
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("MicrosoftTeamsUtil.getInstalledTeamForTenant", () => {
+  function mockRows(
+    installedTeams: Record<string, MicrosoftTeamsInstalledTeam>,
+  ): void {
+    jest.spyOn(WorkspaceProjectAuthTokenService, "findBy").mockResolvedValue([
+      {
+        id: ObjectID.generate(),
+        miscData: { installedTeams: installedTeams } as MicrosoftTeamsMiscData,
+      },
+    ] as unknown as Array<WorkspaceProjectAuthToken>);
+  }
+
+  test("finds a record by graph team id", async () => {
+    const team: MicrosoftTeamsInstalledTeam = {
+      id: GRAPH_TEAM_ID,
+      graphTeamId: GRAPH_TEAM_ID,
+    };
+    mockRows({ [GRAPH_TEAM_ID]: team });
+
+    await expect(
+      MicrosoftTeamsUtil.getInstalledTeamForTenant({
+        tenantId: TENANT_ID,
+        graphTeamId: GRAPH_TEAM_ID,
+      }),
+    ).resolves.toEqual(team);
+  });
+
+  test("finds a legacy record by thread id", async () => {
+    const team: MicrosoftTeamsInstalledTeam = { id: TEAM_THREAD_ID };
+    mockRows({ [TEAM_THREAD_ID]: team });
+
+    await expect(
+      MicrosoftTeamsUtil.getInstalledTeamForTenant({
+        tenantId: TENANT_ID,
+        teamsThreadId: TEAM_THREAD_ID,
+      }),
+    ).resolves.toEqual(team);
+  });
+
+  test("returns null when the tenant has no matching team", async () => {
+    mockRows({
+      "other-team": {
+        id: "other-team",
+        graphTeamId: "other-team",
+      },
+    });
+
+    await expect(
+      MicrosoftTeamsUtil.getInstalledTeamForTenant({
+        tenantId: TENANT_ID,
+        graphTeamId: GRAPH_TEAM_ID,
+        teamsThreadId: TEAM_THREAD_ID,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  test("returns null when the tenant has no rows at all", async () => {
+    jest
+      .spyOn(WorkspaceProjectAuthTokenService, "findBy")
+      .mockResolvedValue([]);
+
+    await expect(
+      MicrosoftTeamsUtil.getInstalledTeamForTenant({
+        tenantId: TENANT_ID,
+        graphTeamId: GRAPH_TEAM_ID,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  test("queries by MicrosoftTeams workspace type and the tenant id", async () => {
+    const findBySpy: jest.SpyInstance = jest
+      .spyOn(WorkspaceProjectAuthTokenService, "findBy")
+      .mockResolvedValue([]);
+
+    await MicrosoftTeamsUtil.getInstalledTeamForTenant({
+      tenantId: TENANT_ID,
+      graphTeamId: GRAPH_TEAM_ID,
+    });
+
+    expect(findBySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: {
+          workspaceType: WorkspaceType.MicrosoftTeams,
+          workspaceProjectId: TENANT_ID,
+        },
+      }),
+    );
+  });
+});

--- a/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsTeamInstalls.test.ts
+++ b/Common/Tests/Server/Utils/Workspace/MicrosoftTeamsTeamInstalls.test.ts
@@ -584,9 +584,37 @@ describe("MicrosoftTeamsUtil.removeTeamFromBotActivity", () => {
     });
 
     expect(removeSpy).toHaveBeenCalledTimes(1);
+    /*
+     * Uninstall passes both ids: the bot is already out of the team so the
+     * Graph id cannot be looked up, and records written before it was captured
+     * are only findable by the thread id. TEAM_ID here is a thread id, matching
+     * what channelData.team.id carries.
+     */
     expect(removeSpy).toHaveBeenCalledWith({
       tenantId: TENANT_ID,
-      teamId: TEAM_ID,
+      teamsThreadId: TEAM_ID,
+      graphTeamId: undefined,
+    });
+  });
+
+  test("an uninstall activity that still carries aadGroupId passes it through", async () => {
+    const removeSpy: jest.SpyInstance = jest
+      .spyOn(MicrosoftTeamsUtil, "removeTeamFromProjectAuthTokens")
+      .mockResolvedValue(undefined as never);
+
+    await MicrosoftTeamsUtil.removeTeamFromBotActivity({
+      activity: teamActivity({
+        channelData: {
+          team: { id: TEAM_ID, aadGroupId: "graph-team-1" },
+          tenant: { id: TENANT_ID },
+        },
+      }),
+    });
+
+    expect(removeSpy).toHaveBeenCalledWith({
+      tenantId: TENANT_ID,
+      teamsThreadId: TEAM_ID,
+      graphTeamId: "graph-team-1",
     });
   });
 
@@ -884,7 +912,7 @@ describe("MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens", () => {
 
     await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
       tenantId: "tenant-abc",
-      teamId: TEAM_ID,
+      teamsThreadId: TEAM_ID,
     });
 
     expect(findBySpy).toHaveBeenCalledWith(
@@ -925,7 +953,7 @@ describe("MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens", () => {
 
     await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
       tenantId: "tenant-abc",
-      teamId: teamToRemove.id,
+      teamsThreadId: teamToRemove.id,
     });
 
     expect(updateSpy).toHaveBeenCalledTimes(1);
@@ -950,7 +978,7 @@ describe("MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens", () => {
 
     await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
       tenantId: "tenant-abc",
-      teamId: team.id,
+      teamsThreadId: team.id,
     });
 
     const savedMiscData: MicrosoftTeamsMiscData = getUpdateArgs(updateSpy, 0)
@@ -976,7 +1004,7 @@ describe("MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens", () => {
 
     await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
       tenantId: "tenant-abc",
-      teamId: TEAM_ID,
+      teamsThreadId: TEAM_ID,
     });
 
     expect(updateSpy).not.toHaveBeenCalled();
@@ -991,7 +1019,7 @@ describe("MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens", () => {
 
     await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
       tenantId: "tenant-abc",
-      teamId: TEAM_ID,
+      teamsThreadId: TEAM_ID,
     });
 
     expect(updateSpy).not.toHaveBeenCalled();
@@ -1014,7 +1042,7 @@ describe("MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens", () => {
 
     await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
       tenantId: "tenant-abc",
-      teamId: team.id,
+      teamsThreadId: team.id,
     });
 
     expect(updateSpy).toHaveBeenCalledTimes(3);
@@ -1068,7 +1096,7 @@ describe("MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens", () => {
 
     await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
       tenantId: "tenant-abc",
-      teamId: team.id,
+      teamsThreadId: team.id,
     });
 
     expect(updateSpy).toHaveBeenCalledTimes(1);
@@ -1104,7 +1132,7 @@ describe("MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens", () => {
 
     await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
       tenantId: "tenant-abc",
-      teamId: "19:team-aaa@thread.tacv2",
+      teamsThreadId: "19:team-aaa@thread.tacv2",
     });
 
     expect(updateSpy).not.toHaveBeenCalled();
@@ -1120,7 +1148,7 @@ describe("MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens", () => {
 
     await MicrosoftTeamsUtil.removeTeamFromProjectAuthTokens({
       tenantId: "tenant-abc",
-      teamId: team.id,
+      teamsThreadId: team.id,
     });
 
     expect(originalMiscData.installedTeams).toEqual({ [team.id]: team });
@@ -1495,9 +1523,15 @@ describe("MicrosoftTeamsUtil.handleBotMessageActivity - team install backfill wi
     });
 
     expect(spies.captureTeamSpy).toHaveBeenCalledTimes(1);
+    /*
+     * onlyIfMissingOrStale, because this runs on every inbound channel message:
+     * once the team is recorded it must cost one read, not a write plus a
+     * possible Bot Framework call to resolve the group id.
+     */
     expect(spies.captureTeamSpy).toHaveBeenCalledWith({
       activity: activity,
       turnContext: turnContext,
+      onlyIfMissingOrStale: true,
     });
     expect(spies.captureChatSpy).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Fixes #3223.

## What was reported

A notification rule posting to an **existing** Microsoft Teams channel fails with:

> The OneUptime app is not installed in the Microsoft Teams team that owns "test public channel". In Microsoft Teams, click the "..." next to the team name, then Manage team > Apps > More apps, and add OneUptime.

The reporter had done exactly that, in two separate teams. Their own screenshots settle it: they `@OneUptime`'d the bot **inside the channel that fails** and the bot replied in-thread — a bot that is not in a channel's roster cannot be mentioned there or reply. Microsoft's underlying error is `403 BotNotInConversationRoster`, which OneUptime rewrote into a specific accusation it had no basis for.

Self-hosted EE, 12.0.10. That build already contains 4fb2c73529, and `master` has no fix, so upgrading was never a remedy.

## Three defects

### 1. `installedTeams` was written in one id space and read in another

A Teams team has two ids and they are not interchangeable:

| | value | who uses it |
|---|---|---|
| `channelData.team.id` | `19:...@thread.tacv2` | Bot Framework activities |
| `channelData.team.aadGroupId` | a GUID | Graph — so the team picker, notification rules, every channel URL |

`captureTeamFromBotActivity` keyed installs by the **thread id**; `sendAdaptiveCardToChannel` looked them up by the **group id**. The lookup could never hit. Provable without any Microsoft access: the same `data.teamId` the preflight looks up with is interpolated into `https://graph.microsoft.com/v1.0/teams/${data.teamId}/channels`, which Graph only accepts as the group id.

- Records now carry both ids explicitly (`graphTeamId`, `teamsThreadId`) and are keyed by the group id, resolved from the activity or, failing that, `TeamsInfo.getTeamDetails`. Uninstall matches on the thread id, since by then the bot is out of the team and cannot be asked.
- Reads go through `indexInstalledTeamsByGraphTeamId`, which **drops** records it cannot resolve rather than indexing them under an id from the wrong space. Re-capturing a team stored under its old thread id replaces that record instead of leaving a duplicate that can never be matched or removed.
- This also un-breaks the GCC/DoD `serviceUrl` from 4fb2c73529 — it was captured but read through the same failing lookup, so `installedTeam?.serviceUrl` was always `undefined` and every proactive post used the hardcoded commercial-cloud endpoint.

**The latent half was worse than the reported symptom.** The preflight was gated on `installedTeams` being non-empty, so the *first install ever recorded for a tenant* would have started refusing **every** channel send for **every** project on that tenant, before Microsoft was even called — and `saveTeamToProjectAuthTokens` fans out per tenant, so one `@mention` in one team would have done it. The documented recovery for this bug is to `@mention` the bot.

### 2. The error asserted an install state nobody had checked

Nothing verified installation. Absence from `installedTeams` was reported as "the app is not installed", but install events only arrive for installs that happened while OneUptime was reachable — so a correctly-installed team is indistinguishable from an uninstalled one. The docs then sent the admin back to the step they had already completed.

- `isAppInstalledInTeam` asks Graph (`GET /teams/{id}/installedApps?$expand=teamsApp`), matching on `teamsApp.externalId`. That answers the question that matters — *is the app **this deployment** authenticates as installed here?* — not the one an admin can answer by eye, which a Teams-store OneUptime package also satisfies while carrying a different bot id.
- **Every** failure is `Unknown`. A tenant that has not granted `TeamsAppInstallation.ReadForTeam.All` must never be told its app is missing.
- Only a *verified* absence refuses a send or gets the install instructions. Anything else gets `getRosterRejectionMessage`: the causes that apply to an app which **is** present (wrong bot id, Azure Bot without the Teams channel enabled, private channel), with Microsoft's own wording attached instead of discarded.
- A local record is re-checked against Graph on the failure path, so a *stale* record cannot produce a confident claim either.
- The message-driven backfill takes an `onlyIfMissingOrStale` guard, so a recorded team costs one read per channel message instead of a write plus a possible Bot Framework call.

### 3. "Test Rule" on a create-channel rule sent nothing and reported success

The loop posting into a just-created channel was nested inside `if (shouldPostToExistingChannel)`. A create-only rule created the channel, invited nobody (a no-op on Teams), sent nothing, and returned success.

**This is what produced the reporter's misleading control** — *"creating a channel works, so the app must be installed correctly"* — and sent the investigation the wrong way.

- Created channels are posted to whenever they were created, addressed with the created channel's own `teamId` rather than `existingTeam`, which belongs to the other half of the rule and can name a different team.
- Existing-channel validation still runs first, so a bad channel name fails the test without leaving a card in a new channel.
- The two byte-identical copies of the post-and-log body — which is how the created-channel copy drifted into the wrong conditional unnoticed — are now one method.

Also: the channel picker now says outright that it lists every channel Graph can *see*, not every channel we can *post* to, and names the wrong-package trap.

## Why the existing tests missed this

The write side and the read side were tested in separate files that each picked their own placeholder team id and then wrote **and** read with it — internally consistent, and blind to the fact that production feeds one side's output into the other:

```
MicrosoftTeamsTeamInstalls.test.ts:95   TEAM_ID = "19:team-aaa@thread.tacv2"   // write side
MicrosoftTeamsChannelSend.test.ts:94    TEAM_ID = "team-1"                     // read side
```

The test named for this exact hazard — *"does not confuse availableTeams (what Graph can see) with installedTeams (what we can post to)"* — even seeded `availableTeams` with a thread id, when `availableTeams` is built exclusively from Graph and holds GUIDs.

So `MicrosoftTeamsInstalledTeamIdSpace.test.ts` **never names an id twice**. Every test drives the real capture path with a realistic activity, keeps whatever it chose to store, and feeds that straight into the real send path using only the id a notification rule would hold. Plus suites for the Graph install check (including that every failure mode is `Unknown`), the reworded rejection, the backfill guard, and the whole `testRule` channel path.

## Verification

- **398 tests / 9 suites** pass across the Microsoft Teams, notification-rule and manifest suites.
- Full `Common` suite on this branch: **1165 suites pass, 15 fail; 28,570 tests pass with zero test-level failures.** All 15 failures are suite-level "failed to run" from a pre-existing `isolated-vm` native-module ABI mismatch (`symbol not found in flat namespace '__ZN2v811ArrayBuffer9Allocator10ReallocateEPvmm'`) — 30 failed-to-run blocks, 30 dlopen errors, no other cause. They are all `Tests/Server/Utils/Monitor/*`, `Tests/Server/Utils/VM/*`, `Tests/Server/Types/Workflow/*` and two Monitor service suites; none is a Teams, workspace or notification suite, and one was reproduced on a clean stashed tree to confirm it predates this branch.
- `tsc --noEmit` clean for `Common` (source and the changed tests) and for `App`; eslint and prettier clean.

## Note for the reporter

These fixes are necessary but may not be sufficient for their instance on their own. Their screenshots also show the bot answering an in-channel `@mention` with *"Sorry, I couldn't find your project configuration"*, i.e. `channelData.tenant.id` matches no project's `workspaceProjectId` — which is why nothing was ever recorded in `installedTeams` or `availableChats`. That is worth measuring directly:

```
grep "Project auth not found for tenant ID" <app logs>
```

```sql
SELECT "projectId", "workspaceProjectId" FROM "WorkspaceProjectAuthToken" WHERE "workspaceType" = 'MicrosoftTeams';
```

With this PR they at least get a truthful error instead of being told to redo a step they had already completed.
