### PR TITLE
fix(database): transform the leaves of a nested FindOperator, not the operator

### DIFF
--- a/Common/Tests/Server/Utils/PrivacyFilterUtil.test.ts
+++ b/Common/Tests/Server/Utils/PrivacyFilterUtil.test.ts
@@ -38,6 +38,70 @@ describe("combineWithPrivacyClause", () => {
     expect(children[1]).toBe(clause);
   });
 
+  it("keeps nested ObjectID values as UUID strings after database transformation", () => {
+    /*
+     * The clause this function builds lands on an ObjectID column
+     * (incidentId, alertId, the episode ids, an ownedThrough FK), and those
+     * columns carry ObjectID.getDatabaseTransformer(). TypeORM hands each
+     * child of the And() to that transformer, so a transformer that cannot
+     * cope with an operator replaces the caller's own equality with
+     * "[object Object]" — which Postgres then rejects for a uuid column with
+     * 22P02, i.e. a 500 on the incident/alert Feed, Internal Notes and Owners
+     * reads for anyone who is not a project owner or admin.
+     * https://github.com/OneUptime/oneuptime/issues/2497
+     */
+    const incidentId: ObjectID = ObjectID.generate();
+    const clause: FindOperatorType = makePrivacyClause();
+    const combined: any = combineWithPrivacyClause(incidentId, clause as any);
+
+    const transformed: any = ObjectID.getDatabaseTransformer().to(combined);
+
+    expect(transformed).toBeInstanceOf(FindOperator);
+    expect(transformed.type).toBe("and");
+    expect(transformed.value[0]).toBeInstanceOf(FindOperator);
+    expect(transformed.value[0].type).toBe("equal");
+    expect(transformed.value[0].value).toBe(incidentId.toString());
+    expect(transformed.value[0].value).not.toBe("[object Object]");
+    expect(transformed.value[1]).toBe(clause);
+  });
+
+  it("survives the transformation twice, as findBy then countBy would", () => {
+    /*
+     * BaseAPI.getList hands the same query object to findBy and then countBy,
+     * and the transformer mutates the operator in place.
+     */
+    const incidentId: ObjectID = ObjectID.generate();
+    const clause: FindOperatorType = makePrivacyClause();
+    const combined: any = combineWithPrivacyClause(incidentId, clause as any);
+
+    ObjectID.getDatabaseTransformer().to(combined);
+    const transformed: any = ObjectID.getDatabaseTransformer().to(combined);
+
+    expect(transformed.value[0].value).toBe(incidentId.toString());
+  });
+
+  it("keeps a re-combined clause intact when the privacy filter runs twice", () => {
+    /*
+     * countBy's hook sees the And that findBy's hook already built and wraps
+     * it again, so the operator handed to the transformer is And(And(...)).
+     */
+    const incidentId: ObjectID = ObjectID.generate();
+    const firstClause: FindOperatorType = makePrivacyClause();
+    const secondClause: FindOperatorType = makePrivacyClause();
+
+    const once: any = combineWithPrivacyClause(incidentId, firstClause as any);
+    const twice: any = combineWithPrivacyClause(once, secondClause as any);
+
+    const transformed: any = ObjectID.getDatabaseTransformer().to(twice);
+
+    expect(transformed.type).toBe("and");
+    expect(transformed.value[0]).toBe(once);
+    expect(transformed.value[0].type).toBe("and");
+    expect(transformed.value[0].value[0].value).toBe(incidentId.toString());
+    expect(transformed.value[0].value[1]).toBe(firstClause);
+    expect(transformed.value[1]).toBe(secondClause);
+  });
+
   it("ANDs an existing string equality with the privacy clause", () => {
     const clause: FindOperatorType = makePrivacyClause();
     const combined: any = combineWithPrivacyClause("some-id", clause as any);

--- a/Common/Tests/Types/Database/DatabasePropertyFindOperator.test.ts
+++ b/Common/Tests/Types/Database/DatabasePropertyFindOperator.test.ts
@@ -1,0 +1,518 @@
+import Color from "../../../Types/Color";
+import Decimal from "../../../Types/Decimal";
+import Email from "../../../Types/Email";
+import Recurring from "../../../Types/Events/Recurring";
+import HashedString from "../../../Types/HashedString";
+import Name from "../../../Types/Name";
+import ObjectID from "../../../Types/ObjectID";
+import Port from "../../../Types/Port";
+import { JSONObject } from "../../../Types/JSON";
+import {
+  And,
+  Between,
+  DataSource,
+  Equal,
+  EntitySchema,
+  FindOperator,
+  ILike,
+  In,
+  IsNull,
+  Not,
+  Or,
+  Raw,
+} from "typeorm";
+import { ValueTransformer } from "typeorm/decorator/options/ValueTransformer";
+
+/*
+ * A privacy/scope filter AND-combines the caller's own filter with a Raw
+ * clause (Common/Server/Utils/PrivacyFilterUtil.ts), which hands TypeORM a
+ * nested FindOperator on a column that carries a DatabaseProperty
+ * transformer. TypeORM then calls `operator.transformValue(transformer)`
+ * (SelectQueryBuilder.buildWhere), and FindOperator.transformValue maps the
+ * transformer's `to()` over each CHILD OPERATOR whenever the operator holds
+ * multiple parameters — which And() and Or() both do.
+ *
+ * Every `toDatabase()` in Common/Types is written for a *value*, so handed a
+ * child operator it produces garbage instead: "[object Object]" for the
+ * string-ish types, `null` for Port, a serialized operator for the JSON
+ * types. The equality child is silently replaced by that garbage and the
+ * predicate can no longer match — on a uuid column Postgres rejects it
+ * outright with 22P02 invalid input syntax for type uuid.
+ *
+ * These tests pin the contract that fixes it: a FindOperator handed to the
+ * transformer keeps its identity and gets its LEAF value(s) transformed,
+ * exactly once, however deeply it is nested.
+ */
+
+const UUID: string = "11111111-2222-4333-8444-555555555555";
+const OTHER_UUID: string = "99999999-8888-4777-8666-555555555555";
+
+type RawClauseType = FindOperator<any>;
+
+function makeRawClause(): RawClauseType {
+  return Raw((alias: string): string => {
+    return `(${alias} IS NOT NULL)`;
+  }) as RawClauseType;
+}
+
+function childrenOf(operator: FindOperator<any>): Array<any> {
+  return operator.value as unknown as Array<any>;
+}
+
+describe("DatabaseProperty database transformer — nested FindOperator values", () => {
+  describe("ObjectID (the reported failure: 1698 uuid columns use this transformer)", () => {
+    it("transforms the leaf of a nested Equal instead of stringifying the operator", () => {
+      const operator: FindOperator<any> = And(
+        Equal(new ObjectID(UUID) as any),
+        makeRawClause(),
+      ) as FindOperator<any>;
+
+      operator.transformValue(ObjectID.getDatabaseTransformer());
+
+      const children: Array<any> = childrenOf(operator);
+      expect(children).toHaveLength(2);
+      // Before the fix this child was the string "[object Object]".
+      expect(children[0]).toBeInstanceOf(FindOperator);
+      expect(children[0].type).toBe("equal");
+      expect(children[0].value).toBe(UUID);
+      expect(children[0].value).not.toBe("[object Object]");
+    });
+
+    it("leaves a Raw sibling byte-identical", () => {
+      const clause: RawClauseType = makeRawClause();
+      const operator: FindOperator<any> = And(
+        Equal(new ObjectID(UUID) as any),
+        clause,
+      ) as FindOperator<any>;
+
+      operator.transformValue(ObjectID.getDatabaseTransformer());
+
+      expect(childrenOf(operator)[1]).toBe(clause);
+      expect(childrenOf(operator)[1].type).toBe("raw");
+    });
+
+    it("accepts an ObjectID leaf, a string leaf and a nested ObjectID equally", () => {
+      const fromInstance: FindOperator<any> = And(
+        Equal(new ObjectID(UUID) as any),
+        makeRawClause(),
+      ) as FindOperator<any>;
+      const fromString: FindOperator<any> = And(
+        Equal(UUID),
+        makeRawClause(),
+      ) as FindOperator<any>;
+
+      fromInstance.transformValue(ObjectID.getDatabaseTransformer());
+      fromString.transformValue(ObjectID.getDatabaseTransformer());
+
+      expect(childrenOf(fromInstance)[0].value).toBe(UUID);
+      expect(childrenOf(fromString)[0].value).toBe(UUID);
+    });
+
+    it("handles Or, In, Not, Between and IsNull children", () => {
+      const or: FindOperator<any> = Or(
+        Equal(new ObjectID(UUID) as any),
+        makeRawClause(),
+      ) as FindOperator<any>;
+      const includes: FindOperator<any> = And(
+        In([new ObjectID(UUID), new ObjectID(OTHER_UUID)] as any),
+        makeRawClause(),
+      ) as FindOperator<any>;
+      const negated: FindOperator<any> = And(
+        Not(Equal(new ObjectID(UUID) as any)),
+        makeRawClause(),
+      ) as FindOperator<any>;
+      const between: FindOperator<any> = And(
+        Between(new ObjectID(UUID) as any, new ObjectID(OTHER_UUID) as any),
+        makeRawClause(),
+      ) as FindOperator<any>;
+      const isNull: FindOperator<any> = And(
+        IsNull(),
+        makeRawClause(),
+      ) as FindOperator<any>;
+
+      for (const operator of [or, includes, negated, between, isNull]) {
+        operator.transformValue(ObjectID.getDatabaseTransformer());
+      }
+
+      expect(childrenOf(or)[0].value).toBe(UUID);
+      expect(childrenOf(includes)[0].type).toBe("in");
+      expect(childrenOf(includes)[0].value).toEqual([UUID, OTHER_UUID]);
+      /*
+       * Not() wraps a single child operator, which TypeORM recurses into on
+       * its own. FindOperator's `value` getter unwraps a nested operator, so
+       * the transformed leaf shows up on `value` and the operator itself on
+       * `child`.
+       */
+      expect(childrenOf(negated)[0].type).toBe("not");
+      expect(childrenOf(negated)[0].child.type).toBe("equal");
+      expect(childrenOf(negated)[0].value).toBe(UUID);
+      expect(childrenOf(between)[0].value).toEqual([UUID, OTHER_UUID]);
+      expect(childrenOf(isNull)[0].type).toBe("isNull");
+    });
+
+    it("recurses through a doubly-nested And", () => {
+      /*
+       * Reachable in production: BaseAPI.getList hands the SAME query object
+       * to findBy and then countBy, so the count query's privacy hook
+       * AND-combines a clause onto the And the find query already built.
+       */
+      const innerClause: RawClauseType = makeRawClause();
+      const outerClause: RawClauseType = makeRawClause();
+      const inner: FindOperator<any> = And(
+        Equal(new ObjectID(UUID) as any),
+        innerClause,
+      ) as FindOperator<any>;
+      const outer: FindOperator<any> = And(
+        inner,
+        outerClause,
+      ) as FindOperator<any>;
+
+      outer.transformValue(ObjectID.getDatabaseTransformer());
+
+      expect(childrenOf(outer)[0]).toBe(inner);
+      expect(childrenOf(outer)[0].type).toBe("and");
+      expect(childrenOf(inner)[0].value).toBe(UUID);
+      expect(childrenOf(inner)[1]).toBe(innerClause);
+      expect(childrenOf(outer)[1]).toBe(outerClause);
+    });
+
+    it("preserves an all-Raw nested And (the QueryUtil filter-stacking shape)", () => {
+      const rawA: RawClauseType = makeRawClause();
+      const rawB: RawClauseType = makeRawClause();
+      const rawC: RawClauseType = makeRawClause();
+      const inner: FindOperator<any> = And(rawA, rawB) as FindOperator<any>;
+      const outer: FindOperator<any> = And(inner, rawC) as FindOperator<any>;
+
+      outer.transformValue(ObjectID.getDatabaseTransformer());
+
+      /*
+       * The pre-existing `_type === "raw"` escape hatch rescues a Raw child,
+       * but an And OF Raws is itself type "and", so it was stringified too.
+       */
+      expect(childrenOf(outer)[0]).toBe(inner);
+      expect(childrenOf(inner)[0]).toBe(rawA);
+      expect(childrenOf(inner)[1]).toBe(rawB);
+    });
+
+    it("does not throw on a nested pattern operator", () => {
+      const operator: FindOperator<any> = And(
+        ILike("%abc%"),
+        makeRawClause(),
+      ) as FindOperator<any>;
+
+      expect(() => {
+        operator.transformValue(ObjectID.getDatabaseTransformer());
+      }).not.toThrow();
+      expect(childrenOf(operator)[0].value).toBe("%abc%");
+    });
+
+    it("still transforms a plain value and a top-level operator", () => {
+      const transformer: ValueTransformer = ObjectID.getDatabaseTransformer();
+
+      expect(transformer.to(new ObjectID(UUID))).toBe(UUID);
+
+      const topLevel: FindOperator<any> = Equal(
+        new ObjectID(UUID) as any,
+      ) as FindOperator<any>;
+      const returned: any = transformer.to(topLevel);
+
+      expect(returned).toBe(topLevel);
+      expect(topLevel.value).toBe(UUID);
+    });
+
+    it("keeps the undefined / null contract that omitted columns rely on", () => {
+      const transformer: ValueTransformer = ObjectID.getDatabaseTransformer();
+
+      // undefined must stay undefined so a column DEFAULT stays reachable.
+      expect(transformer.to(undefined)).toBeUndefined();
+      expect(transformer.to(null)).toBeNull();
+    });
+  });
+
+  describe("non-ObjectID types (an ObjectID-only patch would not fix these)", () => {
+    it("Port keeps a numeric leaf instead of collapsing the operator to null", () => {
+      const operator: FindOperator<any> = And(
+        Equal(new Port(587) as any),
+        makeRawClause(),
+      ) as FindOperator<any>;
+
+      operator.transformValue(Port.getDatabaseTransformer());
+
+      // Before the fix this child was `null` — silently unmatchable.
+      expect(childrenOf(operator)[0]).toBeInstanceOf(FindOperator);
+      expect(childrenOf(operator)[0].value).toBe(587);
+      expect(typeof childrenOf(operator)[0].value).toBe("number");
+    });
+
+    it("Port keeps a falsy 0 leaf", () => {
+      const operator: FindOperator<any> = And(
+        Equal(new Port(0) as any),
+        makeRawClause(),
+      ) as FindOperator<any>;
+
+      operator.transformValue(Port.getDatabaseTransformer());
+
+      expect(childrenOf(operator)[0].value).toBe(0);
+    });
+
+    it("Email normalizes the leaf rather than stringifying the operator", () => {
+      const operator: FindOperator<any> = And(
+        Equal(new Email("User@Example.COM") as any),
+        makeRawClause(),
+      ) as FindOperator<any>;
+
+      operator.transformValue(Email.getDatabaseTransformer());
+
+      expect(childrenOf(operator)[0].value).toBe("user@example.com");
+    });
+
+    it("Decimal, HashedString, Name and Color transform their leaves", () => {
+      const decimal: FindOperator<any> = And(
+        Equal(new Decimal("12.5") as any),
+        makeRawClause(),
+      ) as FindOperator<any>;
+      const hashed: FindOperator<any> = And(
+        Equal(new HashedString("raw-token", false) as any),
+        makeRawClause(),
+      ) as FindOperator<any>;
+      const name: FindOperator<any> = And(
+        Equal(new Name("Jane Doe") as any),
+        makeRawClause(),
+      ) as FindOperator<any>;
+      const color: FindOperator<any> = And(
+        Equal(new Color("#ff0000") as any),
+        makeRawClause(),
+      ) as FindOperator<any>;
+
+      decimal.transformValue(Decimal.getDatabaseTransformer());
+      hashed.transformValue(HashedString.getDatabaseTransformer());
+      name.transformValue(Name.getDatabaseTransformer());
+      color.transformValue(Color.getDatabaseTransformer());
+
+      expect(childrenOf(decimal)[0].value).toBe("12.5");
+      expect(childrenOf(hashed)[0].value).toBe("raw-token");
+      expect(childrenOf(name)[0].value).toBe("Jane Doe");
+      expect(childrenOf(color)[0].value).toBe("#ff0000");
+    });
+
+    it("Recurring transforms a JSON leaf to its serialized form", () => {
+      const operator: FindOperator<any> = And(
+        Equal(Recurring.getDefault() as any),
+        makeRawClause(),
+      ) as FindOperator<any>;
+
+      operator.transformValue(Recurring.getDatabaseTransformer());
+
+      expect(childrenOf(operator)[0]).toBeInstanceOf(FindOperator);
+      expect(childrenOf(operator)[0].value).toEqual(
+        Recurring.getDefault().toJSON(),
+      );
+    });
+  });
+
+  describe("idempotence — one query object is transformed more than once", () => {
+    /*
+     * BaseAPI.getList (Common/Server/API/BaseAPI.ts) awaits findBy and then
+     * countBy with the SAME query object, and transformValue mutates the
+     * operator in place. So every transformer must be a fixpoint: handed its
+     * own output it must return that output unchanged, not re-wrap or throw.
+     */
+    type TransformerOwnerType = {
+      getDatabaseTransformer: () => ValueTransformer;
+    };
+
+    const cases: Array<{
+      name: string;
+      owner: TransformerOwnerType;
+      operator: () => FindOperator<any>;
+    }> = [
+      {
+        name: "ObjectID",
+        owner: ObjectID,
+        operator: () => {
+          return And(
+            Equal(new ObjectID(UUID) as any),
+            makeRawClause(),
+          ) as FindOperator<any>;
+        },
+      },
+      {
+        name: "Port",
+        owner: Port,
+        operator: () => {
+          return And(
+            Equal(new Port(587) as any),
+            makeRawClause(),
+          ) as FindOperator<any>;
+        },
+      },
+      {
+        name: "Email",
+        owner: Email,
+        operator: () => {
+          return And(
+            Equal(new Email("user@example.com") as any),
+            makeRawClause(),
+          ) as FindOperator<any>;
+        },
+      },
+      {
+        name: "Decimal",
+        owner: Decimal,
+        operator: () => {
+          return And(
+            Equal(new Decimal("12.5") as any),
+            makeRawClause(),
+          ) as FindOperator<any>;
+        },
+      },
+      {
+        name: "HashedString",
+        owner: HashedString,
+        operator: () => {
+          return And(
+            Equal(new HashedString("raw-token", false) as any),
+            makeRawClause(),
+          ) as FindOperator<any>;
+        },
+      },
+      {
+        name: "Recurring (scalar)",
+        owner: Recurring,
+        operator: () => {
+          return And(
+            Equal(Recurring.getDefault() as any),
+            makeRawClause(),
+          ) as FindOperator<any>;
+        },
+      },
+      {
+        name: "Recurring (array column)",
+        owner: Recurring,
+        operator: () => {
+          return And(
+            Equal([Recurring.getDefault(), Recurring.getDefault()] as any),
+            makeRawClause(),
+          ) as FindOperator<any>;
+        },
+      },
+    ];
+
+    for (const testCase of cases) {
+      it(`${testCase.name} is a fixpoint under repeated transformation`, () => {
+        const operator: FindOperator<any> = testCase.operator();
+        const transformer: ValueTransformer =
+          testCase.owner.getDatabaseTransformer();
+
+        operator.transformValue(transformer);
+        const afterFirstPass: string = JSON.stringify(
+          childrenOf(operator)[0].value,
+        );
+
+        expect(() => {
+          operator.transformValue(transformer);
+          operator.transformValue(transformer);
+        }).not.toThrow();
+
+        expect(JSON.stringify(childrenOf(operator)[0].value)).toBe(
+          afterFirstPass,
+        );
+      });
+    }
+  });
+
+  describe("end to end — the SQL and bound parameters TypeORM emits", () => {
+    /*
+     * The unit tests above pin the transformer. This one pins the thing the
+     * user actually saw: the parameter bound against a uuid column. It runs
+     * real TypeORM query building against real metadata; no database
+     * connection is needed to render the statement.
+     */
+    let dataSource: DataSource;
+
+    const IncidentFeedLike: EntitySchema = new EntitySchema({
+      name: "IncidentFeedLike",
+      tableName: "IncidentFeedLike",
+      columns: {
+        _id: { primary: true, type: "uuid", generated: "uuid" },
+        incidentId: {
+          type: "uuid",
+          transformer: ObjectID.getDatabaseTransformer(),
+        },
+        feedInfoInMarkdown: { type: "character varying", nullable: true },
+      },
+    });
+
+    beforeAll(async () => {
+      dataSource = new DataSource({
+        type: "postgres",
+        entities: [IncidentFeedLike],
+        synchronize: false,
+      });
+      /*
+       * Builds entity metadata without opening a connection, so the test can
+       * render real SQL offline. Protected on DataSource, hence the cast.
+       */
+      await (
+        dataSource as unknown as { buildMetadatas: () => Promise<void> }
+      ).buildMetadatas();
+    });
+
+    it("binds the uuid, not '[object Object]', for a privacy-filtered read", () => {
+      const [sql, parameters]: [string, Array<any>] = dataSource
+        .createQueryBuilder(IncidentFeedLike, "IncidentFeedLike")
+        .setFindOptions({
+          where: {
+            incidentId: And(Equal(UUID), makeRawClause()) as any,
+          },
+          take: 10,
+        })
+        .getQueryAndParameters();
+
+      expect(parameters).toEqual([UUID]);
+      expect(parameters).not.toContain("[object Object]");
+      expect(sql).toContain('"IncidentFeedLike"."incidentId" = $1');
+      expect(sql).toContain('"IncidentFeedLike"."incidentId" IS NOT NULL');
+    });
+
+    it("binds the uuid when the caller passed an ObjectID instance", () => {
+      const [, parameters]: [string, Array<any>] = dataSource
+        .createQueryBuilder(IncidentFeedLike, "IncidentFeedLike")
+        .setFindOptions({
+          where: {
+            incidentId: And(
+              Equal(new ObjectID(UUID) as any),
+              makeRawClause(),
+            ) as any,
+          },
+          take: 10,
+        })
+        .getQueryAndParameters();
+
+      expect(parameters).toEqual([UUID]);
+    });
+
+    it("keeps both predicates when the same query object is read twice", () => {
+      const query: JSONObject = {
+        incidentId: And(Equal(UUID), makeRawClause()) as any,
+      };
+
+      const first: [string, Array<any>] = dataSource
+        .createQueryBuilder(IncidentFeedLike, "IncidentFeedLike")
+        .setFindOptions({ where: query as any, take: 10 })
+        .getQueryAndParameters();
+
+      const second: [string, Array<any>] = dataSource
+        .createQueryBuilder(IncidentFeedLike, "IncidentFeedLike")
+        .setFindOptions({ where: query as any })
+        .getQueryAndParameters();
+
+      expect(first[1]).toEqual([UUID]);
+      expect(second[1]).toEqual([UUID]);
+      expect(second[0]).toContain('"IncidentFeedLike"."incidentId" = $1');
+      expect(second[0]).toContain(
+        '"IncidentFeedLike"."incidentId" IS NOT NULL',
+      );
+    });
+  });
+});

--- a/Common/Types/Database/DatabaseProperty.ts
+++ b/Common/Types/Database/DatabaseProperty.ts
@@ -39,6 +39,44 @@ export default class DatabaseProperty extends SerializableObject {
       return value as any;
     }
 
+    /*
+     * A FindOperator reaches a transformer when the query value is an
+     * operator rather than a plain value. Two ways in:
+     *
+     *   - Nested. `And(Equal(id), Raw(privacyClause))` — the shape every
+     *     privacy/scope filter builds (Server/Utils/PrivacyFilterUtil.ts).
+     *     TypeORM calls `operator.transformValue(column.transformer)`
+     *     (SelectQueryBuilder.buildWhere), and FindOperator.transformValue
+     *     hands each CHILD OPERATOR to this function whenever the operator
+     *     carries multiple parameters — which And() and Or() both do.
+     *   - Top level. ColumnMetadata.getEntityValue applies the transformer to
+     *     the whole criteria of a .where()/.update()/.delete() call.
+     *
+     * Every toDatabase() below expects a value, so an operator makes it
+     * produce garbage: "[object Object]" from the string-ish types (ObjectID
+     * included — a uuid column then fails with Postgres 22P02 invalid input
+     * syntax for type uuid), `null` from Port, a serialized operator from the
+     * JSON types. The child is REPLACED by that garbage, so the caller's own
+     * predicate is lost and the privacy clause it was ANDed with can no
+     * longer match anything.
+     *
+     * Transform the operator's leaf value(s) in place and hand the operator
+     * back, so `And`/`Or`/`In`/`Not`/`Between` keep their structure and only
+     * the leaves are converted. Recursion terminates because transformValue
+     * always descends into the operator's value, and a leaf is never a
+     * FindOperator.
+     *
+     * NOTE: transformValue mutates. One query object can legitimately be
+     * transformed more than once — BaseAPI.getList shares it between findBy
+     * and countBy — so every toDatabase() has to be a fixpoint: handed its
+     * own output it must return that output unchanged. Tests/Types/Database/
+     * DatabasePropertyFindOperator.test.ts enforces that for each type.
+     */
+    if (value instanceof FindOperator) {
+      value.transformValue(this.getDatabaseTransformer());
+      return value as any;
+    }
+
     return this.toDatabase(value);
   }
 

--- a/Common/Types/Events/Recurring.ts
+++ b/Common/Types/Events/Recurring.ts
@@ -313,7 +313,22 @@ export default class Recurring extends DatabaseProperty {
     value: Recurring | Array<Recurring> | FindOperator<Recurring>,
   ): JSONObject | Array<JSONObject> | null {
     if (Array.isArray(value)) {
-      return this.toJSONArray(value as Array<Recurring>);
+      /*
+       * Per item rather than through toJSONArray, which assumes every item is
+       * still a Recurring instance and throws "item.toJSON is not a function"
+       * on an already-serialized array. TypeORM can hand a transformer its own
+       * output — BaseAPI.getList shares one query object between findBy and
+       * countBy — so this has to be a fixpoint.
+       */
+      return (value as Array<Recurring | JSONObject>).map(
+        (item: Recurring | JSONObject) => {
+          if (item instanceof Recurring) {
+            return item.toJSON();
+          }
+
+          return JSONFunctions.serialize(item as JSONObject);
+        },
+      );
     }
 
     if (value && value instanceof Recurring) {


### PR DESCRIPTION
## The bug

A privacy or scope filter AND-combines the caller's own filter with its Raw clause, so the value handed to TypeORM is a nested operator — `And(Equal(<incidentId>), Raw(<privacy clause>))` (`Common/Server/Utils/PrivacyFilterUtil.ts:36`). Those clauses land on `incidentId` / `alertId` / the episode ids / an `ownedThrough` FK, and every one of those columns is a Postgres `uuid` carrying `ObjectID.getDatabaseTransformer()`.

TypeORM then calls `operator.transformValue(column.transformer)` (`SelectQueryBuilder.buildWhere`), and `FindOperator.transformValue` hands each **child operator** to the transformer whenever the operator carries multiple parameters — which `And()` and `Or()` both do. `ObjectID.toDatabase` declares a `FindOperator<ObjectID>` parameter but has no branch for it, so it falls through to `value.toString()`:

```
And(Equal("<uuid>"), Raw(privacyClause)).transformValue(ObjectID.getDatabaseTransformer())
  → child0: String "[object Object]"
```

The caller's own equality is replaced by that string, and Postgres rejects it for a `uuid` column with `22P02 invalid input syntax for type uuid: "[object Object]"`. A `QueryFailedError` is not a OneUptime `Exception`, so it skips the structured handler and comes back as `500 {"error":"Server Error"}` (`Common/Server/Utils/StartServer.ts:552-557`).

**Who hits it:** anyone without `isRoot` / `isMasterAdmin` / `ProjectOwner` / `ProjectAdmin` — `shouldBypassIncidentPrivacy` exempts only those, and the default "Members" team is created with `Permission.ProjectMember` — loading an incident's or alert's **Feed, Internal Notes or Owners** data, or the auto-remediation reads. The UI always supplies the FK in those queries. Live since `5b9932b78d`.

It fails closed, never open: nothing is written and `"incidentId" = '[object Object]'` cannot match a row. Every affected operation fails on a SELECT.

Reported by @PCbIX in #2497, who also posted a working patch for `ObjectID` — this PR ships the same mechanism at the shared choke point instead. Fixes the second of the two bugs in that thread (the first, the `distinctAlias.<Model>_<col> does not exist` 500, was fixed by `c72266d02e`).

## The fix

`Common/Types/Database/DatabaseProperty.ts` — one branch in `_toDatabase`, which has a single caller and no subclass overrides, so it covers all 20 `override toDatabase` implementations rather than `ObjectID` alone:

```ts
if (value instanceof FindOperator) {
  value.transformValue(this.getDatabaseTransformer());
  return value as any;
}
```

The operator keeps its identity and structure; only its leaves are converted. Recursion terminates because `transformValue` always descends into the operator's value and a leaf is never a `FindOperator`.

`ObjectID` was not the only broken type — measured, per type, before and after:

| Type | Nested leaf today | After |
|---|---|---|
| ObjectID (1698 uuid columns) | `"[object Object]"` → `22P02` | the uuid string |
| Port | `null` — silently unmatchable | `587` (number) |
| Email / Domain / Hostname / URL / Version / IP | `"[object Object]"`, then throws on the second pass | normalized value |
| Decimal | `"[object Object]"` | `"12.5"` |
| HashedString / Name / Color | `"[object Object]"` | the value |
| Recurring / MonitorSteps / RestrictionTimes | serialized operator | serialized value |

### Second commit: `Recurring.toDatabase` idempotence

`BaseAPI.getList` awaits `findBy` and then `countBy` with the **same** query object (`Common/Server/API/BaseAPI.ts:301-314`), and `transformValue` mutates in place — so a transformer can be handed its own output and must be a fixpoint. Every type is, except `Recurring` on an `Array<Recurring>` column: `toJSONArray` calls `item.toJSON()` on each item and throws `TypeError: item.toJSON is not a function` on an already-serialized array. That is a latent bug in `toDatabase` independent of this change (unreachable today — nothing nests an operator on those two jsonb columns), but the fix makes the double-transform path live, so it is fixed here rather than left as a trap, and the invariant is now enforced by test for every type.

## Tests

`Common/Tests/Types/Database/DatabasePropertyFindOperator.test.ts` — 24 tests, 17 of which fail on master:

- the reported shape: nested `Equal` keeps its operator identity and gets a uuid leaf
- `Raw` siblings byte-identical; `Or`, `In`, `Not`, `Between`, `IsNull` children
- doubly-nested `And` (the `findBy` → `countBy` re-wrap), and an all-Raw nested `And` (an `And` of `Raw`s is itself type `"and"`, so the pre-existing raw escape hatch did not rescue it)
- `Port` / `Email` / `Decimal` / `HashedString` / `Name` / `Color` / `Recurring` — cases an ObjectID-only patch would leave broken
- a fixpoint test per type, asserting three consecutive transforms neither change the leaf nor throw
- the `undefined` / `null` contract that keeps column DEFAULTs reachable
- **end to end**: real TypeORM query building against real metadata (no database connection needed) asserting the bound parameters are `["<uuid>"]` and not `["[object Object]"]`, and that both predicates survive

`Common/Tests/Server/Utils/PrivacyFilterUtil.test.ts` — 3 added (all fail on master), including @PCbIX's own assertion. The existing tests there pass because they assert the operator shape *before* the transformer runs, which is why this went unnoticed; no test in `Common/Tests` rendered a query to SQL.

## Verification

- `Common/Tests/Types/Database/DatabasePropertyFindOperator.test.ts` + `PrivacyFilterUtil.test.ts`: 36 passed. Confirmed red first: 17 and 3 failures respectively with the source patch stashed.
- Full `Common` suite: **28,519 tests passed, 0 test failures** (1164 suites). 15 suites failed to *load* on my machine with a pre-existing native-module ABI error — `dlopen … isolated-vm … symbol not found in flat namespace` — which is unrelated to this change: `isolated-vm` is imported by exactly one module (`Common/Server/Utils/VM/VMRunner.ts`) and this diff introduces no import changes, so no suite's module graph moved. Worth confirming those 15 are green on CI.
- `npx tsc --noEmit -p Common/tsconfig.json`: 0 errors. `npx eslint` on all changed files: clean.

## Reviewer notes

- The two commits are ordered so each is independently green: the `Recurring` fixpoint fix has to land before the test that asserts it.
- `combineWithPrivacyClause` could instead emit `QueryHelper.equalTo` (a `Raw`, which the pre-existing escape hatch already passes through) and that would close the read path today with a one-line change. I went with the central fix because it also covers the operator pass-through at `PrivacyFilterUtil.ts:31`, the ten `_id` sites in `QueryUtil.ts`, and the other 19 property types — but say the word if you'd rather have the smaller blast radius.
- Two behaviour changes to be aware of, both on paths nothing currently exercises. Nesting a pattern operator (`ILike`) on a validating type now throws `BadDataException` at query-build time instead of silently comparing against `"[object Object]"` — already the behaviour for a top-level pattern operator, and no OneUptime code emits TypeORM `Like`/`ILike` (`QueryHelper.search` returns a `Raw`). And on the jsonb types a nested operator goes from a loud TypeORM "Unsupported FindOperator" to whatever `toDatabase` produces.
- The analytics side has the same owned-scope composition to do and gets it right — `ModelPermission.addOwnedScopeToQuery` intersects the caller's FK filter with the allowed set on scalar values, no operator and no transformer involved — so there is nothing to fix there.
