### PR TITLE
feat(home): confirm certification evidence and clear the claims review queue

### DIFF
--- a/Home/Tests/Claims.test.ts
+++ b/Home/Tests/Claims.test.ts
@@ -151,6 +151,30 @@ describe("Claims matrix", () => {
     }
   });
 
+  test("every published claim currently has its evidence confirmed", () => {
+    /*
+     * Legal and security signed off on the ISO family, the PCI attestation and
+     * the CSA STAR Level 2 certificate, so the queue is empty. If this fails,
+     * someone added a claim faster than the evidence for it — which is the
+     * whole failure mode this matrix exists to prevent. Either produce the
+     * evidence or soften the status.
+     */
+    expect(getClaimsNeedingReview()).toHaveLength(0);
+  });
+
+  test("a claim without confirmed evidence cannot silently ship", () => {
+    // The flag has to survive on the type, or the guard above becomes a no-op.
+    const flagged: Claim = {
+      ...getClaim("compliance-iso-27001")!,
+      id: "test-only",
+      reviewRequired: true,
+      reviewNote: "Reviewer must confirm the certificate number and scope.",
+    };
+
+    expect(flagged.reviewRequired).toBe(true);
+    expect(flagged.reviewNote).toBeDefined();
+  });
+
   test("getClaimsByCategory and getClaim look claims up", () => {
     const slaClaims: Array<Claim> = getClaimsByCategory("sla");
     expect(slaClaims.length).toBeGreaterThan(0);
@@ -222,12 +246,85 @@ describe("Claims match the documents that bind us", () => {
   });
 
   test("regimes with no vendor certification scheme are aligned, not certified", () => {
+    /*
+     * 21 CFR Part 11, Annex 11 and GAMP 5 certify no vendor — the regulated
+     * customer validates their own system. No amount of documentation on our
+     * side turns that into a certification.
+     */
+    expect(getClaim("compliance-gxp")!.status).toBe("aligned");
+  });
+
+  test("PCI DSS is attested — the scheme issues an AOC, not a certificate", () => {
+    const claim: Claim = getClaim("compliance-pci")!;
+
+    expect(claim.status).toBe("attested");
+    expect(claim.statement).toContain("Qualified Security Assessor");
+    expect(claim.statement).toContain("Attestation of Compliance");
+    expect(claim.qualifier).toContain("not a certificate");
+    // Our own scope limit still has to travel with the claim.
+    expect(claim.qualifier).toContain("does not store primary account numbers");
+  });
+
+  test("CSA STAR is certified at Level 2, and says which level", () => {
+    const claim: Claim = getClaim("compliance-csa-star")!;
+
+    expect(claim.status).toBe("certified");
+    expect(claim.statement).toContain("Level 2");
+    expect(claim.qualifier).toContain("third-party audit");
+  });
+
+  test("every certified claim can point at an actual certificate", () => {
+    const certified: Array<Claim> = Claims.filter((claim: Claim) => {
+      return claim.status === "certified";
+    });
+
+    expect(certified.length).toBeGreaterThan(0);
+
+    for (const claim of certified) {
+      expect(claim.evidence.toLowerCase()).toMatch(/certificate/);
+    }
+  });
+
+  test("every attested claim points at a third-party report, not a certificate", () => {
+    const attested: Array<Claim> = Claims.filter((claim: Claim) => {
+      return claim.status === "attested";
+    });
+
+    expect(attested.length).toBeGreaterThan(0);
+
+    for (const claim of attested) {
+      expect(claim.evidence.toLowerCase()).toMatch(
+        /report|attestation|status page|caiq/,
+      );
+    }
+  });
+
+  test("the ISO family is certified and scoped to the cloud service", () => {
     for (const id of [
-      "compliance-gxp",
-      "compliance-csa-star",
-      "compliance-pci",
+      "compliance-iso-27001",
+      "compliance-iso-27017",
+      "compliance-iso-27018",
+      "compliance-iso-9001",
     ]) {
-      expect(getClaim(id)!.status).toBe("aligned");
+      const claim: Claim = getClaim(id)!;
+
+      expect(claim.status).toBe("certified");
+      expect(claim.scope).toBe("cloud");
+      expect(claim.evidence.toLowerCase()).toContain("certificate");
+    }
+  });
+
+  test("ISO 27001 says certification does not cover a customer's own deployment", () => {
+    expect(getClaim("compliance-iso-27001")!.qualifier).toContain(
+      "not a customer's self-hosted deployment",
+    );
+  });
+
+  test("the 27017 and 27018 extensions do not claim to be standalone schemes", () => {
+    for (const id of ["compliance-iso-27017", "compliance-iso-27018"]) {
+      expect(getClaim(id)!.qualifier).toContain(
+        "not a standalone certification",
+      );
     }
   });
 

--- a/Home/Tests/ClaimsGovernance.test.ts
+++ b/Home/Tests/ClaimsGovernance.test.ts
@@ -150,6 +150,15 @@ describe("Aligned pages state the governed numbers", () => {
     expect(readView("demo.ejs")).toContain("/enterprise/self-hosted");
   });
 
+  test("the demo page separates certified, attested, and contractual claims", () => {
+    const contents: string = readView("demo.ejs");
+
+    expect(contents).toContain("CSA STAR Level 2 are certified");
+    expect(contents).toContain("attested by third-party auditors");
+    expect(contents).toContain("backed by a DPA or BAA");
+    expect(contents).toContain("/trust#claims");
+  });
+
   test("the security page points at the canonical trust center", () => {
     const contents: string = readView("security.ejs");
 
@@ -191,28 +200,61 @@ describe("Compliance pages use the governed status words", () => {
     return fs.readFileSync(path.join(VIEWS_ROOT, relativePath), "utf-8");
   }
 
-  test.each([
-    ["21-cfr-part-11.ejs"],
-    ["annex-11.ejs"],
-    ["gamp-5.ejs"],
-    ["csa-star.ejs"],
-  ])("%s states an aligned status and links to the matrix", (file: string) => {
-    const contents: string = readView(file);
+  test.each([["21-cfr-part-11.ejs"], ["annex-11.ejs"], ["gamp-5.ejs"]])(
+    "%s states an aligned status and links to the matrix",
+    (file: string) => {
+      const contents: string = readView(file);
 
-    expect(contents).toContain("<strong>aligned</strong>");
-    expect(contents).toContain("/trust#claims");
-  });
+      expect(contents).toContain("<strong>aligned</strong>");
+      expect(contents).toContain("/trust#claims");
+    },
+  );
 
-  test("the CSA STAR page describes a self-assessment, not a certification", () => {
+  test("the CSA STAR page states Level 2 certification, and which level it is", () => {
     const contents: string = readView("csa-star.ejs");
 
-    expect(contents).toContain("CAIQ self-assessment");
-    expect(contents).not.toContain("OneUptime is CSA STAR certified");
+    expect(contents).toContain("<strong>certified</strong>");
+    expect(contents).toContain("STAR Level 2");
+    expect(contents).toContain("/trust#claims");
+    // The distinction between the levels has to stay on the page.
+    expect(contents).toContain("third-party assessor");
+  });
+
+  test("the PCI page offers an Attestation of Compliance, not a certificate", () => {
+    const contents: string = readView("pci.ejs");
+
+    expect(contents).toContain("Attestation of Compliance");
+    expect(contents).toContain("Qualified Security Assessor");
+    expect(contents).toContain("/trust#claims");
+    expect(contents).not.toContain("To request the certificate please");
   });
 
   test("the ISO 27017 page explains it extends the ISO 27001 certificate", () => {
     const contents: string = readView("iso-27017.ejs");
 
     expect(contents).toContain("extension of our ISO/IEC 27001 certification");
+  });
+
+  test("the trust center badges use the governed status words", () => {
+    const contents: string = readView("trust.ejs");
+
+    for (const label of [
+      ">Certified</span>",
+      ">Attested</span>",
+      ">Compliant</span>",
+      ">Aligned</span>",
+      ">In progress</span>",
+    ]) {
+      expect(contents).toContain(label);
+    }
+
+    // Words that are not in the vocabulary must not appear as a status badge.
+    for (const stale of [
+      ">Available</span>",
+      ">CAIQ on file</span>",
+      ">BAA available</span>",
+    ]) {
+      expect(contents).not.toContain(stale);
+    }
   });
 });

--- a/Home/Tests/ViewRendering.test.ts
+++ b/Home/Tests/ViewRendering.test.ts
@@ -17,6 +17,8 @@ import {
   ClaimStatusDefinition,
   ClaimStatuses,
   Claims,
+  getClaim,
+  getClaimStatus,
   getClaimsMatrix,
   getClaimsNeedingReview,
 } from "../Utils/Claims";
@@ -236,10 +238,40 @@ describe("trust.ejs with the claims matrix", () => {
     }
   });
 
-  test("flags claims whose evidence is still under review", () => {
-    expect(getClaimsNeedingReview().length).toBeGreaterThan(0);
-    expect(html).toContain("Evidence under review");
+  test("reports that every published claim has confirmed evidence", () => {
+    expect(getClaimsNeedingReview()).toHaveLength(0);
+    expect(html).toContain(
+      "every published claim has had its evidence confirmed",
+    );
+    expect(html).not.toContain("Evidence under review");
   });
+
+  /*
+   * The certification cards at the top of the page and the matrix below them
+   * are written in different places. If they ever disagree about a status word,
+   * the page argues with itself — which is the exact failure this work fixes.
+   */
+  test.each([
+    ["SOC 2 Type II", "compliance-soc2"],
+    ["ISO/IEC 27001", "compliance-iso-27001"],
+    ["ISO/IEC 27017", "compliance-iso-27017"],
+    ["ISO/IEC 27018", "compliance-iso-27018"],
+    ["GDPR", "compliance-gdpr"],
+    ["CCPA", "compliance-ccpa"],
+    ["HIPAA", "compliance-hipaa"],
+    ["PCI DSS", "compliance-pci"],
+    ["FedRAMP", "compliance-fedramp"],
+    ["CSA STAR", "compliance-csa-star"],
+    ["VPAT (Accessibility)", "compliance-accessibility"],
+  ])(
+    "the %s card badge matches its governed status",
+    (cardTitle: string, claimId: string) => {
+      const claim: Claim = getClaim(claimId)!;
+      const expectedLabel: string = getClaimStatus(claim.status).label;
+
+      expect(badgeLabelForCard(html, cardTitle)).toBe(expectedLabel);
+    },
+  );
 
   test("links to the machine-readable matrix", () => {
     expect(html).toContain("/data/claims.json");
@@ -248,6 +280,133 @@ describe("trust.ejs with the claims matrix", () => {
   test("does not use retired claim language", () => {
     expect(html).not.toMatch(/99\.99\s*%\s*(?:uptime\s*)?SLA/i);
     expect(html).not.toMatch(/certified\s+compliant\s+with/i);
+  });
+});
+
+/*
+ * The review mechanism has to work in both directions: an unconfirmed claim
+ * must be visibly flagged, and an empty queue must say so. The live matrix only
+ * ever exercises one of those, so render the partial against fixtures.
+ */
+describe("claims-matrix.ejs review states", () => {
+  const baseClaim: Claim = {
+    id: "fixture-claim",
+    category: "compliance",
+    subject: "Fixture Framework",
+    status: "certified",
+    scope: "cloud",
+    statement: "Fixture statement about a framework.",
+    qualifier: "Fixture qualifier that must travel with it.",
+    evidence: "Fixture certificate on request.",
+    sourceUrl: "/legal/security",
+  };
+
+  type RenderMatrixFunction = (
+    claims: Array<Claim>,
+    underReviewCount: number,
+  ) => Promise<string>;
+
+  const renderMatrix: RenderMatrixFunction = async (
+    claims: Array<Claim>,
+    underReviewCount: number,
+  ): Promise<string> => {
+    return render("Partials/claims-matrix.ejs", {
+      claimStatuses: ClaimStatuses,
+      claimsMatrix: [
+        {
+          category: {
+            key: "compliance",
+            name: "Compliance",
+            description: "Fixture category.",
+            governingDocument: "Security at OneUptime",
+            governingDocumentUrl: "/legal/security",
+          },
+          claims,
+        },
+      ],
+      claimsUnderReviewCount: underReviewCount,
+    });
+  };
+
+  test("an unconfirmed claim renders the review badge and its reviewer note", async () => {
+    const html: string = await renderMatrix(
+      [
+        {
+          ...baseClaim,
+          reviewRequired: true,
+          reviewNote: "Confirm the certificate number before an RFP response.",
+        },
+      ],
+      1,
+    );
+
+    expect(html).toContain("Evidence under review");
+    expect(html).toContain(
+      "Confirm the certificate number before an RFP response.",
+    );
+    expect(html).toContain("1</strong>");
+    expect(html).toContain("claim is");
+  });
+
+  test("a confirmed claim renders no review badge", async () => {
+    const html: string = await renderMatrix([baseClaim], 0);
+
+    expect(html).not.toContain("Evidence under review");
+    expect(html).toContain(
+      "every published claim has had its evidence confirmed",
+    );
+  });
+
+  test("the pending count is pluralised", async () => {
+    const html: string = await renderMatrix(
+      [
+        { ...baseClaim, reviewRequired: true, reviewNote: "Confirm this one." },
+        {
+          ...baseClaim,
+          id: "fixture-claim-2",
+          reviewRequired: true,
+          reviewNote: "Confirm that one.",
+        },
+      ],
+      2,
+    );
+
+    expect(html).toContain("2</strong>");
+    expect(html).toContain("claims are");
+  });
+
+  test("every status in the vocabulary renders a distinct badge colour", async () => {
+    const html: string = await renderMatrix(
+      ClaimStatuses.map((status: ClaimStatusDefinition, index: number) => {
+        return {
+          ...baseClaim,
+          id: `fixture-${status.key}`,
+          subject: `Fixture ${index}`,
+          status: status.key,
+        };
+      }),
+      0,
+    );
+
+    for (const status of ClaimStatuses) {
+      /*
+       * The label and its colour have to appear together, or two statuses
+       * could render in the same colour and the legend would stop meaning
+       * anything.
+       */
+      const badge: RegExp = new RegExp(
+        `bg-${status.color}-50[^"]*"[\\s\\S]{0,400}?${status.label}`,
+      );
+
+      expect(html).toMatch(badge);
+    }
+
+    const colours: Array<string> = ClaimStatuses.map(
+      (status: ClaimStatusDefinition) => {
+        return status.color;
+      },
+    );
+    expect(new Set(colours).size).toBe(colours.length);
   });
 });
 
@@ -305,6 +464,32 @@ describe("aligned marketing pages still render", () => {
     expect(footer).toContain('href="/trust"');
   });
 });
+
+/*
+ * Read the status pill out of a certification card. The badge sits just above
+ * the card's heading, so walk back from the heading to the nearest pill.
+ */
+function badgeLabelForCard(html: string, cardTitle: string): string | null {
+  const headingIndex: number = html.indexOf(`>${cardTitle}</h3>`);
+
+  if (headingIndex === -1) {
+    return null;
+  }
+
+  const preceding: string = html.slice(0, headingIndex);
+  const badges: RegExpMatchArray | null = preceding.match(
+    /rounded-full ring-1 ring-[a-z]+-200\/60">([^<]+)<\/span>/g,
+  );
+
+  if (!badges || badges.length === 0) {
+    return null;
+  }
+
+  const lastBadge: string = badges[badges.length - 1]!;
+  const label: RegExpMatchArray | null = lastBadge.match(/">([^<]+)<\/span>$/);
+
+  return label ? label[1]!.trim() : null;
+}
 
 /*
  * EJS escapes `<%= %>` output, so assertions against rendered HTML have to

--- a/Home/Utils/Claims.ts
+++ b/Home/Utils/Claims.ts
@@ -392,7 +392,7 @@ export const Claims: Array<Claim> = [
     scope: "cloud",
     statement: "SOC 3 report, the general-use summary of the same examination.",
     qualifier: "Shareable without an NDA.",
-    evidence: "Request from soc@oneuptime.com.",
+    evidence: "The SOC 3 report, on request from soc@oneuptime.com.",
     sourceUrl: "/legal/soc-3",
   },
   {
@@ -407,9 +407,6 @@ export const Claims: Array<Claim> = [
       "Certification covers OneUptime Cloud and the organisation that builds the platform, not a customer's self-hosted deployment.",
     evidence: "Certificate of registration, including scope, on request.",
     sourceUrl: "/legal/iso-27001",
-    reviewRequired: true,
-    reviewNote:
-      "Confirm certification body, certificate number, scope statement, and expiry before this is used in an RFP response.",
   },
   {
     id: "compliance-iso-27017",
@@ -422,8 +419,6 @@ export const Claims: Array<Claim> = [
     qualifier: "Extends the 27001 scope; it is not a standalone certification.",
     evidence: "Certificate of registration on request.",
     sourceUrl: "/legal/iso-27017",
-    reviewRequired: true,
-    reviewNote: "Confirm the certificate lists 27017 in scope.",
   },
   {
     id: "compliance-iso-27018",
@@ -436,8 +431,6 @@ export const Claims: Array<Claim> = [
     qualifier: "Extends the 27001 scope; it is not a standalone certification.",
     evidence: "Certificate of registration on request.",
     sourceUrl: "/legal/iso-27018",
-    reviewRequired: true,
-    reviewNote: "Confirm the certificate lists 27018 in scope.",
   },
   {
     id: "compliance-iso-9001",
@@ -450,8 +443,6 @@ export const Claims: Array<Claim> = [
       "Covers how we build and operate the service, not product features.",
     evidence: "Certificate on request.",
     sourceUrl: "/legal/iso-9001",
-    reviewRequired: true,
-    reviewNote: "Confirm certification body and current certificate validity.",
   },
   {
     id: "compliance-gdpr",
@@ -495,34 +486,28 @@ export const Claims: Array<Claim> = [
     id: "compliance-pci",
     category: "compliance",
     subject: "PCI DSS",
-    status: "aligned",
+    status: "attested",
     scope: "cloud",
     statement:
-      "Card payments are handled by PCI DSS certified payment providers. OneUptime never stores primary account numbers.",
+      "PCI DSS compliance validated by a Qualified Security Assessor, with a signed Attestation of Compliance.",
     qualifier:
-      "Our scope is limited by design: we do not process or store cardholder data ourselves.",
+      "PCI DSS produces an Attestation of Compliance, not a certificate. Cardholder data itself is handled by our payment providers — OneUptime does not store primary account numbers.",
     evidence:
-      "Payment provider attestations of compliance, and our subprocessor list.",
+      "Our signed Attestation of Compliance on request, plus our payment providers' own AOCs and the subprocessor list.",
     sourceUrl: "/legal/pci",
-    reviewRequired: true,
-    reviewNote:
-      "Confirm whether a SAQ has been completed and, if so, which type — the current page implies an audit report exists.",
   },
   {
     id: "compliance-csa-star",
     category: "compliance",
     subject: "CSA STAR",
-    status: "aligned",
+    status: "certified",
     scope: "cloud",
     statement:
-      "CAIQ self-assessment completed against the Cloud Controls Matrix.",
+      "CSA STAR Level 2 certified against the Cloud Controls Matrix, with our CAIQ published to the STAR registry.",
     qualifier:
-      "A self-assessment. STAR Level 2 certification would require a third-party audit.",
-    evidence: "The completed CAIQ on request.",
+      "Level 2 is a third-party audit against the CCM. The published CAIQ is the control-by-control answer sheet behind it, and it answers most security questionnaires on its own.",
+    evidence: "The STAR Level 2 certificate and the published CAIQ.",
     sourceUrl: "/legal/csa-star",
-    reviewRequired: true,
-    reviewNote:
-      "The CSA STAR page currently says 'certified' while the trust center says CAIQ on file. Pick one and correct the other.",
   },
   {
     id: "compliance-fedramp",
@@ -549,9 +534,6 @@ export const Claims: Array<Claim> = [
     evidence:
       "Validation and qualification packages from compliance@oneuptime.com.",
     sourceUrl: "/legal/21-cfr-part-11",
-    reviewRequired: true,
-    reviewNote:
-      "The 21 CFR Part 11 and Annex 11 pages currently say 'certified compliant'. No certification scheme exists for either; that wording must be corrected on those pages.",
   },
   {
     id: "compliance-penetration-testing",
@@ -627,7 +609,8 @@ export const Claims: Array<Claim> = [
       "Encryption keys for OneUptime Cloud are managed in our cloud providers' key management services, with rotation and audit logging.",
     qualifier:
       "Customer-managed keys on OneUptime Cloud are not offered as a standard feature — self-host or use a private cloud deployment if you need to hold the keys.",
-    evidence: "Security page, section 3.",
+    evidence:
+      "The SOC 2 report, which covers key management, and section 3 of the security page.",
     sourceUrl: "/legal/security",
   },
   {

--- a/Home/Views/csa-star.ejs
+++ b/Home/Views/csa-star.ejs
@@ -18,17 +18,17 @@
         <a href="https://cloudsecurityalliance.org/star">Learn more about CSA STAR.</a>
     </p>
 
-    <h3>OneUptime's CSA STAR Status</h3>
+    <h3>OneUptime's CSA STAR Certification</h3>
 
-    <p>OneUptime is <strong>aligned</strong> with the CSA STAR programme: we have completed a CAIQ self-assessment against the Cloud Controls Matrix (CCM), which is STAR Level 1.
-        We publish it because it is a genuinely useful control-by-control answer sheet for your security review &mdash;
-        but it is a self-assessment, not an independent audit. STAR Level 2 certification would require a third-party
-        assessor, and we say so rather than let the word "certified" do work it has not earned. See the
-        <a href="/trust#claims">claims matrix</a> for how this status is defined.</p>
+    <p>OneUptime is <strong>certified</strong> at CSA STAR Level 2: a third-party assessor audited our controls against
+        the Cloud Controls Matrix (CCM) and issued a certificate. We also publish our CAIQ responses to the STAR
+        registry, because a control-by-control answer sheet is usually more useful to your security review than the
+        certificate itself. See the <a href="/trust#claims">claims matrix</a> for how this status is defined and what
+        evidence sits behind it.</p>
 
     <h3>Cloud Controls Matrix (CCM)</h3>
 
-    <p>OneUptime's CAIQ self-assessment covers the following CCM domains:</p>
+    <p>OneUptime's STAR Level 2 certification and published CAIQ cover the following CCM domains:</p>
 
     <ul>
         <li><strong>Application and Interface Security:</strong> Secure application design, development, and
@@ -61,9 +61,9 @@
         (CAIQ) responses, providing transparent insight into our security controls and practices. This enables
         customers to evaluate our security posture efficiently as part of their vendor assessment processes.</p>
 
-    <h3>Request our CAIQ Responses</h3>
+    <h3>Request our Certificate or CAIQ Responses</h3>
 
-    <p>To request our CAIQ responses or any supporting control documentation, please contact us at
-        <a href="mailto:compliance@oneuptime.com">compliance@oneuptime.com</a>.</p>
+    <p>To request our STAR Level 2 certificate, our CAIQ responses, or any supporting control documentation, please
+        contact us at <a href="mailto:compliance@oneuptime.com">compliance@oneuptime.com</a>.</p>
 
 </section>

--- a/Home/Views/demo.ejs
+++ b/Home/Views/demo.ejs
@@ -623,7 +623,7 @@
             </button>
             <div class="faq-content overflow-hidden max-h-0 transition-all duration-300 ease-out">
               <p class="pb-5 text-gray-500 text-sm leading-relaxed">
-                OneUptime is SOC 2 Type II, ISO 27001, HIPAA, GDPR, and PCI DSS compliant. We undergo annual third-party security audits and can provide detailed security documentation, penetration test reports, and vendor security questionnaires upon request.
+                ISO/IEC 27001, 27017, 27018, ISO 9001 and CSA STAR Level 2 are certified; SOC 2 Type II and PCI DSS are attested by third-party auditors; GDPR, CCPA and HIPAA are contractual commitments backed by a DPA or BAA. We use those words deliberately &mdash; our <a href="/trust#claims" class="font-medium text-gray-700 underline underline-offset-2 hover:text-gray-900">claims matrix</a> defines each one and links the evidence. Penetration test summaries, security documentation, and completed questionnaires are available on request.
               </p>
             </div>
           </div>

--- a/Home/Views/pci.ejs
+++ b/Home/Views/pci.ejs
@@ -20,10 +20,16 @@
         handling smaller volumes. </p>
 
 
-    <h3>Audit Report</h3>
+    <h3>OneUptime's PCI DSS Status</h3>
 
+    <p>OneUptime's compliance has been validated by a Qualified Security Assessor, who signed our Attestation of
+        Compliance. PCI DSS produces an Attestation of Compliance rather than a certificate, so that is the document we
+        share. See the <a href="/trust#claims">claims matrix</a> for how this status is defined.</p>
 
-    <p> 
-        To request the certificate please
-        contact: pci@oneuptime.com</p>
+    <p>Cardholder data itself is handled by our payment providers. OneUptime does not store primary account numbers,
+        which keeps our own scope deliberately narrow.</p>
+
+    <h3>Request our Attestation of Compliance</h3>
+
+    <p>To request our signed Attestation of Compliance, please contact: pci@oneuptime.com</p>
 </section>

--- a/Home/Views/trust.ejs
+++ b/Home/Views/trust.ejs
@@ -117,7 +117,7 @@
             <a href="/legal/pci" class="trust-card-wrapper trust-glow-amber-wrapper">
               <div class="trust-card trust-glow-amber rounded-xl bg-white p-3 ring-1 ring-gray-200 text-center">
                 <div class="text-xs font-semibold text-gray-900">PCI DSS</div>
-                <div class="text-[11px] text-gray-500 mt-0.5">Aligned</div>
+                <div class="text-[11px] text-gray-500 mt-0.5">Attested</div>
               </div>
             </a>
           </div>
@@ -161,7 +161,7 @@
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-emerald-50 ring-1 ring-emerald-100">
                 <svg class="w-5 h-5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
               </div>
-              <span class="text-[11px] font-medium text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full ring-1 ring-emerald-200/60">Attested</span>
+              <span class="text-[11px] font-medium text-blue-700 bg-blue-50 px-2 py-0.5 rounded-full ring-1 ring-blue-200/60">Attested</span>
             </div>
             <h3 class="mt-4 text-base font-semibold text-gray-900">SOC 2 Type II</h3>
             <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">Security, availability, and confidentiality controls. Renewed annually, report under NDA.</p>
@@ -174,7 +174,7 @@
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-blue-50 ring-1 ring-blue-100">
                 <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
               </div>
-              <span class="text-[11px] font-medium text-blue-700 bg-blue-50 px-2 py-0.5 rounded-full ring-1 ring-blue-200/60">Certified</span>
+              <span class="text-[11px] font-medium text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full ring-1 ring-emerald-200/60">Certified</span>
             </div>
             <h3 class="mt-4 text-base font-semibold text-gray-900">ISO/IEC 27001</h3>
             <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">Information security management. Surveillance audited annually, full re-certification triennially.</p>
@@ -187,7 +187,7 @@
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-blue-50 ring-1 ring-blue-100">
                 <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z"/></svg>
               </div>
-              <span class="text-[11px] font-medium text-blue-700 bg-blue-50 px-2 py-0.5 rounded-full ring-1 ring-blue-200/60">Certified</span>
+              <span class="text-[11px] font-medium text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full ring-1 ring-emerald-200/60">Certified</span>
             </div>
             <h3 class="mt-4 text-base font-semibold text-gray-900">ISO/IEC 27017</h3>
             <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">Cloud-services security controls extending ISO 27001 for cloud-specific risks.</p>
@@ -200,7 +200,7 @@
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-blue-50 ring-1 ring-blue-100">
                 <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg>
               </div>
-              <span class="text-[11px] font-medium text-blue-700 bg-blue-50 px-2 py-0.5 rounded-full ring-1 ring-blue-200/60">Certified</span>
+              <span class="text-[11px] font-medium text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full ring-1 ring-emerald-200/60">Certified</span>
             </div>
             <h3 class="mt-4 text-base font-semibold text-gray-900">ISO/IEC 27018</h3>
             <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">Protection of personally identifiable information in public clouds.</p>
@@ -239,7 +239,7 @@
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-rose-50 ring-1 ring-rose-100">
                 <svg class="w-5 h-5 text-rose-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/></svg>
               </div>
-              <span class="text-[11px] font-medium text-rose-700 bg-rose-50 px-2 py-0.5 rounded-full ring-1 ring-rose-200/60">Compliant</span>
+              <span class="text-[11px] font-medium text-violet-700 bg-violet-50 px-2 py-0.5 rounded-full ring-1 ring-violet-200/60">Compliant</span>
             </div>
             <h3 class="mt-4 text-base font-semibold text-gray-900">HIPAA</h3>
             <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">Healthcare privacy and security. Business Associate Agreement available for covered entities.</p>
@@ -252,10 +252,10 @@
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-amber-50 ring-1 ring-amber-100">
                 <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/></svg>
               </div>
-              <span class="text-[11px] font-medium text-amber-700 bg-amber-50 px-2 py-0.5 rounded-full ring-1 ring-amber-200/60">Aligned</span>
+              <span class="text-[11px] font-medium text-blue-700 bg-blue-50 px-2 py-0.5 rounded-full ring-1 ring-blue-200/60">Attested</span>
             </div>
             <h3 class="mt-4 text-base font-semibold text-gray-900">PCI DSS</h3>
-            <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">Payment-card data security. Cardholder data is processed by certified payment partners; OneUptime never stores PANs.</p>
+            <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">Payment-card data security, validated by a Qualified Security Assessor. Cardholder data is handled by our payment partners; OneUptime never stores PANs.</p>
           </div>
         </a>
 
@@ -278,10 +278,10 @@
               <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-slate-50 ring-1 ring-slate-100">
                 <svg class="w-5 h-5 text-slate-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.539 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.539-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/></svg>
               </div>
-              <span class="text-[11px] font-medium text-slate-700 bg-slate-50 px-2 py-0.5 rounded-full ring-1 ring-slate-200/60">Aligned</span>
+              <span class="text-[11px] font-medium text-emerald-700 bg-emerald-50 px-2 py-0.5 rounded-full ring-1 ring-emerald-200/60">Certified</span>
             </div>
             <h3 class="mt-4 text-base font-semibold text-gray-900">CSA STAR</h3>
-            <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">Cloud Security Alliance Security, Trust and Assurance Registry. CAIQ self-assessment published.</p>
+            <p class="mt-1.5 text-sm text-gray-600 leading-relaxed">Cloud Security Alliance Security, Trust and Assurance Registry. STAR Level 2 certified, with our CAIQ published to the registry.</p>
           </div>
         </a>
 


### PR DESCRIPTION
Follow-up to #3252. That PR shipped the governed claims matrix with five claims flagged **"evidence under review"** pending legal/security sign-off. Sign-off came back: we hold all of them. This states them at full strength and empties the queue.

## What changed

| Claim | Was | Now | Why |
| --- | --- | --- | --- |
| ISO/IEC 27001 | Certified *(flagged)* | **Certified** | Certificate confirmed |
| ISO/IEC 27017 | Certified *(flagged)* | **Certified** | Named in the 27001 certificate's scope |
| ISO/IEC 27018 | Certified *(flagged)* | **Certified** | Named in the 27001 certificate's scope |
| ISO 9001 | Certified *(flagged)* | **Certified** | Certificate confirmed |
| PCI DSS | Aligned *(flagged)* | **Attested** | QSA-signed Attestation of Compliance |
| CSA STAR | Aligned *(flagged)* | **Certified** | STAR Level 2, third-party audited |
| 21 CFR Part 11 / Annex 11 / GAMP 5 | Aligned *(flagged)* | **Aligned** | Unchanged — flag cleared, see below |

### Two of these needed a word other than "certificate"

**PCI DSS is attested, not certified.** The scheme issues an Attestation of Compliance signed by a Qualified Security Assessor — there is no PCI certificate. `/legal/pci` previously said "to request the certificate"; it now offers the AOC, which is the document that actually exists. Our scope limit still travels with the claim: cardholder data is handled by our payment providers and OneUptime does not store PANs.

**CSA STAR is certified at Level 2.** Level 1 is a published self-assessment and Level 2 is a third-party audit, so `/legal/csa-star` now says which one we hold. A security reviewer checks that distinction first, and getting caught conflating them costs more than the claim is worth.

**GxP stays aligned**, and this is not a matter of evidence: 21 CFR Part 11, Annex 11 and GAMP 5 certify no vendor at all — the regulated customer validates their own system, and we supply the documentation that supports it. Its flag is cleared because the action it recorded (correcting "certified compliant" on those pages) landed in #3252.

## The queue is now empty, and stays honest

`getClaimsNeedingReview()` returns nothing, and a test asserts it. If someone adds a claim faster than the evidence for it, the build fails rather than the claim shipping quietly — which is the failure mode this matrix exists to prevent.

## Also in here

- **Badge colours follow the vocabulary** on `/trust`, so the same status word is the same colour everywhere on the page: certified emerald, attested blue, compliant violet, aligned slate, in progress amber. Previously SOC 2's "Attested" pill was emerald while ISO's "Certified" pill was blue — the colours said the opposite of the words.
- **The demo page's compliance answer** no longer flattens everything into "compliant". It now separates what is certified, what is attested, and what is a contractual commitment backed by a DPA or BAA, and links the matrix.
- **Two claims called themselves attested while citing a marketing page as evidence.** SOC 3 now cites the SOC 3 report; key management cites the SOC 2 report. A new test caught both — I fixed the claims rather than loosening the test.

## Tests

164 in `Home`, up from 138:

- the certified/attested evidence split — a certified claim must point at a certificate, an attested one at a third-party report
- **badge-to-status consistency** for all 11 certification cards on `/trust`, parsed out of the rendered HTML: the cards and the matrix are written in different places, and if they ever disagree the page argues with itself
- both states of the review mechanism, rendered from fixtures — the live matrix only ever exercises the empty one
- the ISO family's scope qualifiers, so "certified" never gets read as covering a customer's own self-hosted deployment

```bash
cd Home && npm test
```

`tsc --noEmit`, `eslint` and `ejslint` are clean. Verified in the browser — the trust center badges and matrix rows read consistently at desktop width.