### PR TITLE
docs(telemetry): troubleshoot Windows collector service errors 2 and 1064

### DIFF
--- a/App/FeatureSet/Docs/Content/da/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/da/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ Du opretter `/etc/otelcol-contrib/config.yaml` i Trin 2 og en `launchd`-plist i 
 
 ### Windows
 
-På Windows skal du downloade upstream-**`otelcol-contrib`**-udgivelsen — den medleverer `windows_service`-receiveren, der driver host-fanen **Tjenester** (fra **v0.155.0** og frem). Fra en **forhøjet** PowerShell-prompt:
+På Windows skal du downloade upstream-**`otelcol-contrib`**-udgivelsen — den medleverer `windows_service`-receiveren, der driver host-fanen **Tjenester** (fra **v0.155.0** og frem).
+
+**Download `contrib`-arkivet, ikke core-arkivet.** Hver udgivelse indeholder to Windows-arkiver, hvis navne kun adskiller sig med ét ord, og at vælge det forkerte er den hyppigste årsag til, at denne installation slår fejl:
+
+| Udgivelsesarkiv | Udpakker | Brug dette? |
+| --------------- | -------- | ----------- |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **Ja** — contrib-distributionen |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | Nej — core-builden, som mangler de Windows-receivere, der bruges nedenfor |
+
+Arkivnavnet skal **begynde med `otelcol-contrib_`**. Core-`otelcol_`-builden leverer hverken `windowseventlog`- eller `windows_service`-receiveren, og at omdøbe `otelcol.exe` til `otelcol-contrib.exe` tilføjer dem ikke — det ombytter blot den ene opstartsfejl med den anden (se [Fejlfinding](#fejlfinding)).
+
+Fra en **forhøjet** PowerShell-prompt skal du køre hele blokken samlet — hver linje afhænger af de variabler, der er sat ovenfor:
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-Dette udpakker `otelcol-contrib.exe` til `C:\Program Files\otelcol-contrib`. Du opretter `config.yaml` i den samme mappe i Trin 2 og registrerer en Windows-tjeneste i Trin 3.
+Kør hele blokken frem for at rive en enkelt linje ud af den: URL'en samles ud fra `$VERSION` og `$ARCH`, så et `Invoke-WebRequest`, der indsættes alene i en ny session, fejler med en tom `-Uri` og henter ingenting. At bygge URL'en i `$url` på sin egen linje er bevidst — interpolerer man versionen direkte ind i `Invoke-WebRequest`-argumentet, bliver en usat variabel i stedet til en tavs 404.
+
+Dette udpakker `otelcol-contrib.exe` — **ikke** `otelcol.exe` — til `C:\Program Files\otelcol-contrib`; `Get-ChildItem`-linjen ovenfor bekræfter, hvilken du fik. Du opretter `config.yaml` i den samme mappe i Trin 2 og registrerer en Windows-tjeneste i Trin 3.
 
 > Foretrækker du et native installeringsprogram? OpenTelemetry publicerer også en signeret **`.msi`** (`otelcol-contrib_<version>_windows_x64.msi`) på den samme [udgivelsesside](https://github.com/open-telemetry/opentelemetry-collector-releases/releases), som registrerer collectoren som en Windows-tjeneste for dig. Hvis du bruger den, skal du pege den mod `config.yaml` fra Trin 2 og sørge for, at tjenesten kører som `LocalSystem`, så fanen **Tjenester** kan læse Service Control Manager.
 
@@ -881,6 +900,12 @@ OpenTelemetry Collector respekterer standard-miljøvariablerne `HTTPS_PROXY` / `
   - Bekræft, at hosten kan nå `https://oneuptime.com/otlp` (eller dit selvhostede endpoint): `curl -v https://oneuptime.com/otlp` fra den samme maskine.
 - **HTTP 401 fra eksportøren** — ingestion-tokenet er ugyldigt eller tilbagekaldt. Generér et nyt fra _Projektindstillinger → Telemetri og APM → Indtagelsesnøgler_.
 - **`Security` Windows Event Log returnerer access denied** — tjenesten kører ikke med tilstrækkelige privilegier. Genopret den under `LocalSystem` (standarden med `sc.exe create`), eller tildel tjenestekontoen brugerrettigheden _Manage auditing and security log_.
+- **Windows-tjenesten starter ikke og giver `Error 2: The system cannot find the file specified`** — Service Control Manager kan ikke finde den eksekverbare fil, tjenesten blev registreret mod. Kør `sc.exe qc "otelcol-contrib"`, og sammenlign `BINARY_PATH_NAME` med det, der faktisk ligger i `C:\Program Files\otelcol-contrib`. Næsten altid er core-arkivet `otelcol_<version>_windows_amd64.tar.gz` blevet downloadet — det udpakker `otelcol.exe` — mens Trin 3 registrerer tjenesten mod `otelcol-contrib.exe`, som kun arkivet `otelcol-contrib_<version>_...` indeholder. Download `contrib`-arkivet igen fra Trin 1; omdøb **ikke** `otelcol.exe`, hvilket i stedet giver `1064` nedenfor. Den anden årsag er et `binPath=` uden anførselstegn: en sti gennem `C:\Program Files` deles ved mellemrummet, medmindre den sættes i anførselstegn nøjagtigt som vist i Trin 3.
+- **Windows-tjenesten starter ikke og giver `Error 1064: An exception occurred in the service when handling the control request`** — SCM startede binæren, men collectoren afsluttede under opstart. At omdøbe `otelcol.exe` til `otelcol-contrib.exe` får stien til at gå op uden at ændre indholdet af binæren: core-builden har hverken `windowseventlog`- eller `windows_service`-receiveren, så den afviser konfigurationen fra Trin 2 og dør, før tjenesten nogensinde rapporterer som kørende. En `--config`-sti uden anførselstegn giver den samme `1064`, selv med den rigtige binær: uden de indre anførselstegn deles argumentet ved mellemrummet i `Program Files`, og collectoren afslutter over en konfigurationsfil, den ikke kan læse. Kontrollér, hvad du faktisk har:
+  - `otelcol-contrib.exe --version` bør skrive `otelcol-contrib version ...`. Hvis den skriver `otelcol version ...`, er det core-builden, der er omdøbt — download `contrib`-arkivet igen fra Trin 1.
+  - `otelcol-contrib.exe components` bør vise `windowseventlog` og `windows_service` blandt receiverne. Brug ikke `hostmetrics` som test — den findes også i core-builden og beviser derfor ingenting. Alt, hvad konfigurationen refererer til, men denne kommando ikke viser, stopper collectoren ved opstart.
+  - Kør den i forgrunden for at se den egentlige fejl i stedet for den generiske `1064`: `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`.
+  - Se under _Event Viewer → Windows Logs → Application_ efter kilden `otelcol-contrib`, som registrerer den opstartsfejl, SCM slugte.
 - **`journald`-receiveren undlader at starte** — sørg for, at `journalctl` er på collectorens `PATH`, og at `/var/log/journal` eksisterer (kør `sudo systemd-tmpfiles --create --prefix /var/log/journal`, hvis ikke).
 - **`systemd`-receiveren rapporterer en D-Bus-forbindelsesfejl** — collectoren kan ikke nå systembussen. Bekræft, at `/run/dbus/system_bus_socket` findes, og at collectorens bruger kan åbne den; at køre `systemctl list-units` som den bruger er den hurtigste kontrol. Root er ikke påkrævet. En collector, der kører inde i en container, ser slet ingen bus, medmindre du bind-mounter hostens socket, så foretræk en native installation til denne receiver.
 - **`systemd`-receiveren logger en scrape-fejl pr. unit, eller collectoren nægter at starte på grund af en ukendt metrik** — begge dele skyldes versionsforskelle. v0.142.0 leder efter cgroup-statistik på hver eneste unit (én fejl pr. unit, der ikke er en `.service`, pr. scrape) og kalder sin CPU-metrik `systemd.unit.cpu.time`; v0.143.0 og senere begrænser det opslag til tjenester og omdøbte metrikken til `systemd.service.cpu.time`. Opgradér til v0.143.0+, og sørg for, at en eventuel `metrics:`-overstyring navngiver den nøgle, dit build faktisk har.

--- a/App/FeatureSet/Docs/Content/de/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/de/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ Sie erstellen `/etc/otelcol-contrib/config.yaml` in Schritt 2 und eine `launchd`
 
 ### Windows
 
-Laden Sie unter Windows das Upstream-**`otelcol-contrib`**-Release herunter — es bringt den `windows_service`-Receiver mit, der den Host-Tab **Dienste** versorgt (ab **v0.155.0**). Über eine PowerShell-Eingabeaufforderung **mit erhöhten Rechten**:
+Laden Sie unter Windows das Upstream-**`otelcol-contrib`**-Release herunter — es bringt den `windows_service`-Receiver mit, der den Host-Tab **Dienste** versorgt (ab **v0.155.0**).
+
+**Laden Sie das `contrib`-Artefakt herunter, nicht das Core-Artefakt.** Jedes Release veröffentlicht zwei Windows-Archive, deren Namen sich nur in einem Wort unterscheiden, und das falsche zu erwischen ist die häufigste Ursache dafür, dass diese Installation scheitert:
+
+| Release-Artefakt | Entpackt | Dieses verwenden? |
+| ---------------- | -------- | ----------------- |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **Ja** — die Contrib-Distribution |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | Nein — der Core-Build, dem die unten verwendeten Windows-Receiver fehlen |
+
+Der Artefaktname muss **mit `otelcol-contrib_` beginnen**. Der Core-`otelcol_`-Build liefert weder einen `windowseventlog`- noch einen `windows_service`-Receiver mit, und ein Umbenennen von `otelcol.exe` in `otelcol-contrib.exe` fügt sie nicht hinzu — es tauscht lediglich einen Startfehler gegen einen anderen (siehe [Fehlerbehebung](#fehlerbehebung)).
+
+Führen Sie den Block über eine PowerShell-Eingabeaufforderung **mit erhöhten Rechten** als Ganzes aus — jede Zeile setzt die darüber gesetzten Variablen voraus:
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-Dies entpackt `otelcol-contrib.exe` nach `C:\Program Files\otelcol-contrib`. Sie erstellen `config.yaml` im selben Ordner in Schritt 2 und registrieren in Schritt 3 einen Windows-Dienst.
+Führen Sie den gesamten Block aus, statt eine einzelne Zeile herauszulösen: Die URL wird aus `$VERSION` und `$ARCH` zusammengesetzt, ein allein in eine frische Sitzung eingefügtes `Invoke-WebRequest` scheitert also an einer leeren `-Uri` und lädt nichts herunter. Die URL in einer eigenen `$url`-Zeile aufzubauen ist Absicht — wird die Version direkt in das `Invoke-WebRequest`-Argument interpoliert, macht eine nicht gesetzte Variable daraus stattdessen einen stillen 404.
+
+Dies entpackt `otelcol-contrib.exe` — **nicht** `otelcol.exe` — nach `C:\Program Files\otelcol-contrib`; die `Get-ChildItem`-Zeile oben bestätigt, welche der beiden Sie erhalten haben. Sie erstellen `config.yaml` im selben Ordner in Schritt 2 und registrieren in Schritt 3 einen Windows-Dienst.
 
 > Bevorzugen Sie einen nativen Installer? OpenTelemetry veröffentlicht auf derselben [Releases-Seite](https://github.com/open-telemetry/opentelemetry-collector-releases/releases) auch eine signierte **`.msi`** (`otelcol-contrib_<version>_windows_x64.msi`), die den Collector für Sie als Windows-Dienst registriert. Wenn Sie sie verwenden, richten Sie sie auf die `config.yaml` aus Schritt 2 aus und stellen Sie sicher, dass der Dienst als `LocalSystem` läuft, damit der **Dienste**-Tab den Service Control Manager lesen kann.
 
@@ -881,6 +900,12 @@ Der OpenTelemetry Collector berücksichtigt die standardmäßigen Umgebungsvaria
   - Stellen Sie sicher, dass der Host `https://oneuptime.com/otlp` (oder Ihren selbst gehosteten Endpunkt) erreichen kann: `curl -v https://oneuptime.com/otlp` von demselben Rechner.
 - **HTTP 401 vom Exporter** — das Ingestion-Token ist ungültig oder widerrufen. Erstellen Sie ein neues unter _Projekteinstellungen → Telemetrie & APM → Ingestion-Schlüssel_.
 - **Der Windows-Event-Log-Kanal `Security` gibt „access denied“ zurück** — der Dienst läuft nicht mit ausreichenden Berechtigungen. Erstellen Sie ihn unter `LocalSystem` neu (der Standard bei `sc.exe create`) oder erteilen Sie dem Dienstkonto das Benutzerrecht _Manage auditing and security log_.
+- **Der Windows-Dienst startet nicht und meldet `Error 2: The system cannot find the file specified`** — der Service Control Manager findet die ausführbare Datei nicht, auf die der Dienst registriert wurde. Führen Sie `sc.exe qc "otelcol-contrib"` aus und vergleichen Sie `BINARY_PATH_NAME` mit dem, was tatsächlich in `C:\Program Files\otelcol-contrib` liegt. Fast immer wurde das Core-Archiv `otelcol_<version>_windows_amd64.tar.gz` heruntergeladen — es entpackt `otelcol.exe` —, während Schritt 3 den Dienst auf `otelcol-contrib.exe` registriert, das nur das Archiv `otelcol-contrib_<version>_...` enthält. Laden Sie das `contrib`-Artefakt aus Schritt 1 erneut herunter; benennen Sie `otelcol.exe` **nicht** um, das führt stattdessen zum `1064` unten. Die andere Ursache ist ein `binPath=` ohne Anführungszeichen: Ein Pfad durch `C:\Program Files` wird am Leerzeichen getrennt, sofern er nicht exakt wie in Schritt 3 gezeigt in Anführungszeichen steht.
+- **Der Windows-Dienst startet nicht und meldet `Error 1064: An exception occurred in the service when handling the control request`** — der SCM hat die Binärdatei gestartet, aber der Collector hat sich während des Starts beendet. Ein Umbenennen von `otelcol.exe` in `otelcol-contrib.exe` lässt den Pfad aufgehen, ändert aber nichts am Inhalt der Binärdatei: Dem Core-Build fehlen die Receiver `windowseventlog` und `windows_service`, sodass er die Konfiguration aus Schritt 2 ablehnt und beendet wird, bevor der Dienst überhaupt als laufend gemeldet wird. Ein `--config`-Pfad ohne Anführungszeichen erzeugt denselben `1064` auch mit der richtigen Binärdatei: Ohne die inneren Anführungszeichen wird das Argument am Leerzeichen in `Program Files` getrennt, und der Collector beendet sich wegen einer Konfigurationsdatei, die er nicht lesen kann. Prüfen Sie, was Sie tatsächlich haben:
+  - `otelcol-contrib.exe --version` sollte `otelcol-contrib version ...` ausgeben. Gibt es `otelcol version ...` aus, ist es der umbenannte Core-Build — laden Sie das `contrib`-Artefakt aus Schritt 1 erneut herunter.
+  - `otelcol-contrib.exe components` sollte `windowseventlog` und `windows_service` unter den Receivern auflisten. Verwenden Sie `hostmetrics` nicht als Test — dieser Receiver steckt auch im Core-Build und beweist daher nichts. Alles, worauf die Konfiguration verweist, was dieser Befehl aber nicht auflistet, stoppt den Collector beim Start.
+  - Starten Sie ihn im Vordergrund, um statt des generischen `1064` den eigentlichen Fehler zu sehen: `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`.
+  - Sehen Sie unter _Event Viewer → Windows Logs → Application_ nach der Quelle `otelcol-contrib`, die den vom SCM verschluckten Startfehler protokolliert.
 - **Der `journald`-Receiver startet nicht** — stellen Sie sicher, dass `journalctl` im `PATH` des Collectors liegt und dass `/var/log/journal` existiert (führen Sie andernfalls `sudo systemd-tmpfiles --create --prefix /var/log/journal` aus).
 - **Der `systemd`-Receiver meldet einen D-Bus-Verbindungsfehler** — der Collector kann den System-Bus nicht erreichen. Prüfen Sie, ob `/run/dbus/system_bus_socket` existiert und ob der Benutzer des Collectors es öffnen kann; `systemctl list-units` als dieser Benutzer ausgeführt ist die schnellste Probe. Root ist nicht erforderlich. Ein Collector, der in einem Container läuft, sieht überhaupt keinen Bus, sofern Sie nicht den Socket des Hosts einhängen; bevorzugen Sie für diesen Receiver daher eine native Installation.
 - **Der `systemd`-Receiver protokolliert einen Scrape-Fehler pro Unit, oder der Collector verweigert wegen einer unbekannten Metrik den Start** — beides ist Versionsversatz. v0.142.0 sucht auf jeder Unit nach cgroup-Statistiken (ein Fehler pro Nicht-`.service`-Unit pro Scrape) und nennt seine CPU-Metrik `systemd.unit.cpu.time`; v0.143.0 und neuer beschränken diese Suche auf Dienste und haben die Metrik in `systemd.service.cpu.time` umbenannt. Aktualisieren Sie auf v0.143.0+ und stellen Sie sicher, dass eine etwaige `metrics:`-Überschreibung den Schlüssel benennt, den Ihr Build tatsächlich hat.

--- a/App/FeatureSet/Docs/Content/en/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/en/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ You will create `/etc/otelcol-contrib/config.yaml` in Step 2 and a `launchd` pli
 
 ### Windows
 
-On Windows, download the upstream **`otelcol-contrib`** release — it bundles the `windows_service` receiver that powers the host **Services** tab (from **v0.155.0** onward). From an **elevated** PowerShell prompt:
+On Windows, download the upstream **`otelcol-contrib`** release — it bundles the `windows_service` receiver that powers the host **Services** tab (from **v0.155.0** onward).
+
+**Download the `contrib` asset, not the core one.** Every release publishes two Windows archives whose names differ by one word, and picking the wrong one is the most common way this install fails:
+
+| Release asset                                    | Unpacks               | Use this?                                             |
+| ------------------------------------------------ | --------------------- | ----------------------------------------------------- |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **Yes** — the contrib distribution                    |
+| `otelcol_<version>_windows_amd64.tar.gz`         | `otelcol.exe`         | No — the core build, missing the Windows receivers used below |
+
+The asset name must **start with `otelcol-contrib_`**. The core `otelcol_` build ships no `windowseventlog` or `windows_service` receiver, and renaming `otelcol.exe` to `otelcol-contrib.exe` does not add them — it only swaps one startup failure for another (see [Troubleshooting](#troubleshooting)).
+
+From an **elevated** PowerShell prompt, run this block as a whole — each line depends on the variables set above it:
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-This unpacks `otelcol-contrib.exe` into `C:\Program Files\otelcol-contrib`. You will create `config.yaml` in the same folder in Step 2 and register a Windows service in Step 3.
+Run the whole block rather than lifting a single line out of it: the URL is assembled from `$VERSION` and `$ARCH`, so an `Invoke-WebRequest` pasted on its own into a fresh session fails with a null `-Uri` and downloads nothing. Building the URL into `$url` on its own line is deliberate — interpolating the version straight into the `Invoke-WebRequest` argument turns an unset variable into a silent 404 instead.
+
+This unpacks `otelcol-contrib.exe` — **not** `otelcol.exe` — into `C:\Program Files\otelcol-contrib`; the `Get-ChildItem` line above confirms which one you got. You will create `config.yaml` in the same folder in Step 2 and register a Windows service in Step 3.
 
 > Prefer a native installer? OpenTelemetry also publishes a signed **`.msi`** (`otelcol-contrib_<version>_windows_x64.msi`) on the same [releases page](https://github.com/open-telemetry/opentelemetry-collector-releases/releases), which registers the collector as a Windows service for you. If you use it, point it at the `config.yaml` from Step 2 and make sure the service runs as `LocalSystem` so the **Services** tab can read the Service Control Manager.
 
@@ -883,6 +902,12 @@ The OpenTelemetry Collector respects the standard `HTTPS_PROXY` / `HTTP_PROXY` /
   - Confirm the host can reach `https://oneuptime.com/otlp` (or your self-hosted endpoint): `curl -v https://oneuptime.com/otlp` from the same machine.
 - **HTTP 401 from the exporter** — the ingestion token is invalid or revoked. Generate a new one from _Project Settings → Telemetry & APM → Ingestion Keys_.
 - **`Security` Windows Event Log returns access denied** — the service is not running with sufficient privileges. Recreate it under `LocalSystem` (the default with `sc.exe create`) or grant the service account the _Manage auditing and security log_ user right.
+- **Windows service fails to start with `Error 2: The system cannot find the file specified`** — the Service Control Manager cannot find the executable the service was registered against. Run `sc.exe qc "otelcol-contrib"` and compare `BINARY_PATH_NAME` with what is actually in `C:\Program Files\otelcol-contrib`. Almost always the core `otelcol_<version>_windows_amd64.tar.gz` archive was downloaded — it unpacks `otelcol.exe` — while Step 3 registers the service against `otelcol-contrib.exe`, which only the `otelcol-contrib_<version>_...` archive contains. Re-download the `contrib` asset from Step 1; do **not** rename `otelcol.exe`, which produces the `1064` below instead. The other cause is an unquoted `binPath=`: a path through `C:\Program Files` splits on the space unless it is quoted exactly as Step 3 shows.
+- **Windows service fails to start with `Error 1064: An exception occurred in the service when handling the control request`** — the SCM launched the binary, but the collector exited during startup. Renaming `otelcol.exe` to `otelcol-contrib.exe` makes the path resolve without changing what is inside the binary: the core build has no `windowseventlog` or `windows_service` receiver, so it rejects the Step 2 config and dies before the service ever reports as running. An unquoted `--config` path gives the same `1064` even with the right binary: without the inner quotes the argument splits on the space in `Program Files` and the collector exits over a config file it cannot read. Check what you actually have:
+  - `otelcol-contrib.exe --version` should print `otelcol-contrib version ...`. If it prints `otelcol version ...`, it is the core build renamed — re-download the `contrib` asset from Step 1.
+  - `otelcol-contrib.exe components` should list `windowseventlog` and `windows_service` among the receivers. Do not test with `hostmetrics` — the core build ships that one too, so seeing it proves nothing. Anything the config references but this command does not list will stop the collector at startup.
+  - Run it in the foreground to see the real error instead of the generic `1064`: `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`.
+  - Check _Event Viewer → Windows Logs → Application_ for source `otelcol-contrib`, which records the startup error the SCM swallowed.
 - **`journald` receiver fails to start** — make sure `journalctl` is on the collector's `PATH` and that `/var/log/journal` exists (run `sudo systemd-tmpfiles --create --prefix /var/log/journal` if not).
 - **`systemd` receiver reports a D-Bus connection error** — the collector cannot reach the system bus. Confirm `/run/dbus/system_bus_socket` exists and that the collector's user can open it; `systemctl list-units` run as that user is the quickest check. Root is not required. A collector running inside a container sees no bus at all unless you bind-mount the host's socket, so prefer a native install for this receiver.
 - **`systemd` receiver logs a scrape error per unit, or the collector refuses to start over an unknown metric** — both are version skew. v0.142.0 looks for cgroup statistics on every unit (one error per non-`.service` unit per scrape) and calls its CPU metric `systemd.unit.cpu.time`; v0.143.0 and later limit that lookup to services and renamed the metric to `systemd.service.cpu.time`. Upgrade to v0.143.0+, and make sure any `metrics:` override names the key your build actually has.

--- a/App/FeatureSet/Docs/Content/es/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/es/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ Crearás `/etc/otelcol-contrib/config.yaml` en el Paso 2 y un plist de `launchd`
 
 ### Windows
 
-En Windows, descarga la versión oficial de **`otelcol-contrib`** — incluye el receptor `windows_service` que alimenta la pestaña **Servicios** del host (a partir de la **v0.155.0**). Desde un símbolo del sistema de PowerShell **elevado**:
+En Windows, descarga la versión oficial de **`otelcol-contrib`** — incluye el receptor `windows_service` que alimenta la pestaña **Servicios** del host (a partir de la **v0.155.0**).
+
+**Descarga el artefacto `contrib`, no el core.** Cada versión publica dos archivos comprimidos para Windows cuyos nombres se diferencian en una sola palabra, y elegir el equivocado es la causa más habitual de que esta instalación falle:
+
+| Artefacto de la release | Descomprime | ¿Usar este? |
+| ----------------------- | ----------- | ----------- |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **Sí** — la distribución contrib |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | No — la compilación core, sin los receptores de Windows que se usan más abajo |
+
+El nombre del artefacto debe **empezar por `otelcol-contrib_`**. La compilación core `otelcol_` no incluye los receptores `windowseventlog` ni `windows_service`, y renombrar `otelcol.exe` a `otelcol-contrib.exe` no los añade: solo cambia un fallo de arranque por otro (consulta [Solución de problemas](#solución-de-problemas)).
+
+Desde un símbolo del sistema de PowerShell **elevado**, ejecuta el bloque completo — cada línea depende de las variables definidas más arriba:
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-Esto descomprime `otelcol-contrib.exe` en `C:\Program Files\otelcol-contrib`. Crearás `config.yaml` en la misma carpeta en el Paso 2 y registrarás un servicio de Windows en el Paso 3.
+Ejecuta el bloque entero en lugar de sacar una sola línea: la URL se construye a partir de `$VERSION` y `$ARCH`, así que un `Invoke-WebRequest` pegado por su cuenta en una sesión nueva falla con un `-Uri` nulo y no descarga nada. Construir la URL en `$url`, en su propia línea, es intencionado: interpolar la versión directamente en el argumento de `Invoke-WebRequest` convierte una variable sin definir en un 404 silencioso.
+
+Esto descomprime `otelcol-contrib.exe` — **no** `otelcol.exe` — en `C:\Program Files\otelcol-contrib`; la línea `Get-ChildItem` de arriba confirma cuál obtuviste. Crearás `config.yaml` en la misma carpeta en el Paso 2 y registrarás un servicio de Windows en el Paso 3.
 
 > ¿Prefieres un instalador nativo? OpenTelemetry también publica un **`.msi`** firmado (`otelcol-contrib_<version>_windows_x64.msi`) en la misma [página de releases](https://github.com/open-telemetry/opentelemetry-collector-releases/releases), que registra el recolector como un servicio de Windows por ti. Si lo usas, apúntalo al `config.yaml` del Paso 2 y asegúrate de que el servicio se ejecute como `LocalSystem` para que la pestaña **Servicios** pueda leer el Service Control Manager.
 
@@ -881,6 +900,12 @@ El OpenTelemetry Collector respeta las variables de entorno estándar `HTTPS_PRO
   - Confirma que el host puede alcanzar `https://oneuptime.com/otlp` (o tu endpoint autoalojado): `curl -v https://oneuptime.com/otlp` desde la misma máquina.
 - **HTTP 401 desde el exportador** — el token de ingestión es inválido o ha sido revocado. Genera uno nuevo desde _Ajustes del proyecto → Telemetría y APM → Claves de Ingesta_.
 - **El canal `Security` de Windows Event Log devuelve acceso denegado** — el servicio no se ejecuta con privilegios suficientes. Recréalo bajo `LocalSystem` (el valor predeterminado con `sc.exe create`) o concede a la cuenta del servicio el derecho de usuario _Manage auditing and security log_.
+- **El servicio de Windows no arranca y devuelve `Error 2: The system cannot find the file specified`** — el Service Control Manager no encuentra el ejecutable con el que se registró el servicio. Ejecuta `sc.exe qc "otelcol-contrib"` y compara `BINARY_PATH_NAME` con lo que hay realmente en `C:\Program Files\otelcol-contrib`. Casi siempre se ha descargado el archivo core `otelcol_<version>_windows_amd64.tar.gz` — que descomprime `otelcol.exe` — mientras que el Paso 3 registra el servicio contra `otelcol-contrib.exe`, que solo contiene el archivo `otelcol-contrib_<version>_...`. Vuelve a descargar el artefacto `contrib` del Paso 1; **no** renombres `otelcol.exe`, ya que eso produce el `1064` de abajo. La otra causa es un `binPath=` sin comillas: una ruta que pasa por `C:\Program Files` se parte por el espacio salvo que se entrecomille exactamente como muestra el Paso 3.
+- **El servicio de Windows no arranca y devuelve `Error 1064: An exception occurred in the service when handling the control request`** — el SCM lanzó el binario, pero el recolector terminó durante el arranque. Renombrar `otelcol.exe` a `otelcol-contrib.exe` hace que la ruta se resuelva, pero no cambia lo que hay dentro del binario: la compilación core no tiene los receptores `windowseventlog` ni `windows_service`, así que rechaza la configuración del Paso 2 y muere antes de que el servicio llegue a reportarse como en ejecución. Una ruta `--config` sin comillas produce el mismo `1064` incluso con el binario correcto: sin las comillas internas, el argumento se parte por el espacio de `Program Files` y el recolector termina por un archivo de configuración que no puede leer. Comprueba qué tienes realmente:
+  - `otelcol-contrib.exe --version` debería imprimir `otelcol-contrib version ...`. Si imprime `otelcol version ...`, es la compilación core renombrada: vuelve a descargar el artefacto `contrib` del Paso 1.
+  - `otelcol-contrib.exe components` debería listar `windowseventlog` y `windows_service` entre los receptores. No uses `hostmetrics` como prueba: la compilación core también lo trae, así que verlo no demuestra nada. Cualquier cosa que la configuración referencie y este comando no liste detendrá el recolector al arrancar.
+  - Ejecútalo en primer plano para ver el error real en lugar del genérico `1064`: `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`.
+  - Revisa _Event Viewer → Windows Logs → Application_ buscando el origen `otelcol-contrib`, que registra el error de arranque que el SCM se tragó.
 - **El receptor `journald` no arranca** — asegúrate de que `journalctl` esté en el `PATH` del recolector y de que exista `/var/log/journal` (ejecuta `sudo systemd-tmpfiles --create --prefix /var/log/journal` si no es así).
 - **El receptor `systemd` informa de un error de conexión con D-Bus** — el recolector no puede alcanzar el bus del sistema. Confirma que `/run/dbus/system_bus_socket` existe y que el usuario del recolector puede abrirlo; ejecutar `systemctl list-units` con ese usuario es la comprobación más rápida. No hace falta root. Un recolector que se ejecuta dentro de un contenedor no ve ningún bus salvo que montes el socket del host, así que prefiere una instalación nativa para este receptor.
 - **El receptor `systemd` registra un error de scrape por unidad, o el recolector se niega a arrancar por una métrica desconocida** — ambos casos son desfase de versiones. La v0.142.0 busca estadísticas de cgroups en cada unidad (un error por cada unidad que no sea `.service` en cada scrape) y llama a su métrica de CPU `systemd.unit.cpu.time`; la v0.143.0 y posteriores limitan esa búsqueda a los servicios y renombraron la métrica a `systemd.service.cpu.time`. Actualiza a la v0.143.0+ y asegúrate de que cualquier anulación en `metrics:` nombre la clave que realmente tiene tu compilación.

--- a/App/FeatureSet/Docs/Content/fr/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/fr/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ Vous créerez `/etc/otelcol-contrib/config.yaml` à l'étape 2 et un fichier pli
 
 ### Windows
 
-Sous Windows, téléchargez la version **`otelcol-contrib`** en amont — elle intègre le récepteur `windows_service` qui alimente l'onglet **Services** de l'hôte (à partir de la **v0.155.0**). Depuis une invite PowerShell **avec privilèges élevés** :
+Sous Windows, téléchargez la version **`otelcol-contrib`** en amont — elle intègre le récepteur `windows_service` qui alimente l'onglet **Services** de l'hôte (à partir de la **v0.155.0**).
+
+**Téléchargez l'artefact `contrib`, pas l'artefact core.** Chaque version publie deux archives Windows dont les noms ne diffèrent que d'un mot, et se tromper d'archive est la cause la plus fréquente d'échec de cette installation :
+
+| Artefact de la version | Décompresse | À utiliser ? |
+| ---------------------- | ----------- | ------------ |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **Oui** — la distribution contrib |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | Non — la version core, dépourvue des récepteurs Windows utilisés ci-dessous |
+
+Le nom de l'artefact doit **commencer par `otelcol-contrib_`**. La version core `otelcol_` ne fournit aucun récepteur `windowseventlog` ni `windows_service`, et renommer `otelcol.exe` en `otelcol-contrib.exe` ne les ajoute pas — cela ne fait que remplacer une erreur de démarrage par une autre (voir [Dépannage](#dépannage)).
+
+Depuis une invite PowerShell **avec privilèges élevés**, exécutez le bloc dans son intégralité — chaque ligne dépend des variables définies au-dessus :
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-Cela décompresse `otelcol-contrib.exe` dans `C:\Program Files\otelcol-contrib`. Vous créerez `config.yaml` dans le même dossier à l'étape 2 et enregistrerez un service Windows à l'étape 3.
+Exécutez le bloc entier plutôt que d'en extraire une seule ligne : l'URL est assemblée à partir de `$VERSION` et `$ARCH`, si bien qu'un `Invoke-WebRequest` collé seul dans une nouvelle session échoue sur un `-Uri` nul et ne télécharge rien. Construire l'URL dans `$url`, sur sa propre ligne, est délibéré : interpoler la version directement dans l'argument de `Invoke-WebRequest` transforme une variable non définie en un 404 silencieux.
+
+Cela décompresse `otelcol-contrib.exe` — et **non** `otelcol.exe` — dans `C:\Program Files\otelcol-contrib` ; la ligne `Get-ChildItem` ci-dessus confirme lequel vous avez obtenu. Vous créerez `config.yaml` dans le même dossier à l'étape 2 et enregistrerez un service Windows à l'étape 3.
 
 > Vous préférez un installateur natif ? OpenTelemetry publie également un **`.msi`** signé (`otelcol-contrib_<version>_windows_x64.msi`) sur la même [page des versions](https://github.com/open-telemetry/opentelemetry-collector-releases/releases), qui enregistre le collecteur en tant que service Windows pour vous. Si vous l'utilisez, pointez-le vers le `config.yaml` de l'étape 2 et assurez-vous que le service s'exécute en tant que `LocalSystem` afin que l'onglet **Services** puisse lire le Service Control Manager.
 
@@ -881,6 +900,12 @@ Le collecteur OpenTelemetry respecte les variables d'environnement standard `HTT
   - Confirmez que l'hôte peut atteindre `https://oneuptime.com/otlp` (ou votre point de terminaison auto-hébergé) : `curl -v https://oneuptime.com/otlp` depuis la même machine.
 - **HTTP 401 de l'exportateur** — le jeton d'ingestion est invalide ou révoqué. Générez-en un nouveau depuis _Paramètres du projet → Télémétrie & APM → Clés d'ingestion_.
 - **Le canal `Security` des journaux d'événements Windows renvoie une erreur d'accès refusé** — le service ne s'exécute pas avec des privilèges suffisants. Recréez-le sous `LocalSystem` (la valeur par défaut avec `sc.exe create`) ou accordez au compte de service le droit utilisateur _Manage auditing and security log_.
+- **Le service Windows ne démarre pas et renvoie `Error 2: The system cannot find the file specified`** — le Service Control Manager ne trouve pas l'exécutable auprès duquel le service a été enregistré. Exécutez `sc.exe qc "otelcol-contrib"` et comparez `BINARY_PATH_NAME` avec ce qui se trouve réellement dans `C:\Program Files\otelcol-contrib`. Presque toujours, c'est l'archive core `otelcol_<version>_windows_amd64.tar.gz` qui a été téléchargée — elle décompresse `otelcol.exe` — alors que l'étape 3 enregistre le service auprès de `otelcol-contrib.exe`, que seule l'archive `otelcol-contrib_<version>_...` contient. Retéléchargez l'artefact `contrib` de l'étape 1 ; ne renommez **pas** `otelcol.exe`, ce qui produit à la place le `1064` ci-dessous. L'autre cause est un `binPath=` sans guillemets : un chemin passant par `C:\Program Files` est coupé à l'espace s'il n'est pas mis entre guillemets exactement comme le montre l'étape 3.
+- **Le service Windows ne démarre pas et renvoie `Error 1064: An exception occurred in the service when handling the control request`** — le SCM a lancé le binaire, mais le collecteur s'est arrêté pendant le démarrage. Renommer `otelcol.exe` en `otelcol-contrib.exe` fait aboutir le chemin sans changer le contenu du binaire : la version core n'a ni récepteur `windowseventlog`, ni `windows_service`, elle rejette donc la configuration de l'étape 2 et meurt avant même que le service ne se signale comme démarré. Un chemin `--config` sans guillemets produit le même `1064` même avec le bon binaire : sans les guillemets internes, l'argument est coupé à l'espace de `Program Files` et le collecteur s'arrête sur un fichier de configuration qu'il ne peut pas lire. Vérifiez ce que vous avez réellement :
+  - `otelcol-contrib.exe --version` doit afficher `otelcol-contrib version ...`. S'il affiche `otelcol version ...`, il s'agit de la version core renommée — retéléchargez l'artefact `contrib` de l'étape 1.
+  - `otelcol-contrib.exe components` doit lister `windowseventlog` et `windows_service` parmi les récepteurs. N'utilisez pas `hostmetrics` comme test : la version core l'embarque aussi, le voir ne prouve donc rien. Tout ce que la configuration référence mais que cette commande ne liste pas arrêtera le collecteur au démarrage.
+  - Lancez-le au premier plan pour voir la véritable erreur au lieu du `1064` générique : `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`.
+  - Consultez _Event Viewer → Windows Logs → Application_ pour la source `otelcol-contrib`, qui consigne l'erreur de démarrage avalée par le SCM.
 - **Le récepteur `journald` ne démarre pas** — assurez-vous que `journalctl` se trouve dans le `PATH` du collecteur et que `/var/log/journal` existe (exécutez `sudo systemd-tmpfiles --create --prefix /var/log/journal` si ce n'est pas le cas).
 - **Le récepteur `systemd` signale une erreur de connexion D-Bus** — le collecteur ne peut pas atteindre le bus système. Vérifiez que `/run/dbus/system_bus_socket` existe et que l'utilisateur du collecteur peut l'ouvrir ; exécuter `systemctl list-units` sous cet utilisateur est la vérification la plus rapide. Root n'est pas nécessaire. Un collecteur qui s'exécute dans un conteneur ne voit aucun bus, à moins de monter le socket de l'hôte : préférez donc une installation native pour ce récepteur.
 - **Le récepteur `systemd` consigne une erreur de collecte par unité, ou le collecteur refuse de démarrer à cause d'une métrique inconnue** — dans les deux cas, il s'agit d'un décalage de version. La v0.142.0 recherche des statistiques cgroup sur chaque unité (une erreur par unité qui n'est pas un `.service`, à chaque scrape) et appelle sa métrique CPU `systemd.unit.cpu.time` ; la v0.143.0 et les suivantes limitent cette recherche aux services et ont renommé la métrique en `systemd.service.cpu.time`. Passez à la v0.143.0+, et assurez-vous que toute surcharge `metrics:` nomme la clé dont dispose réellement votre version.

--- a/App/FeatureSet/Docs/Content/hi/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/hi/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ sudo mkdir -p /etc/otelcol-contrib
 
 ### Windows
 
-Windows पर, अपस्ट्रीम **`otelcol-contrib`** रिलीज़ डाउनलोड करें — यह `windows_service` receiver को बंडल करता है जो होस्ट **सेवाएं** टैब को शक्ति प्रदान करता है (**v0.155.0** से आगे)। एक **elevated** PowerShell प्रॉम्प्ट से:
+Windows पर, अपस्ट्रीम **`otelcol-contrib`** रिलीज़ डाउनलोड करें — यह `windows_service` receiver को बंडल करता है जो होस्ट **सेवाएं** टैब को शक्ति प्रदान करता है (**v0.155.0** से आगे)।
+
+**`contrib` आर्टिफ़ैक्ट डाउनलोड करें, core वाला नहीं।** हर रिलीज़ Windows के लिए दो आर्काइव प्रकाशित करती है जिनके नाम केवल एक शब्द से भिन्न हैं, और ग़लत वाला चुनना इस इंस्टॉलेशन के विफल होने का सबसे आम कारण है:
+
+| रिलीज़ आर्टिफ़ैक्ट | अनपैक करता है | यही इस्तेमाल करें? |
+| ------------------ | ------------- | ------------------ |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **हाँ** — contrib वितरण |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | नहीं — core बिल्ड, जिसमें नीचे उपयोग किए गए Windows receiver नहीं हैं |
+
+आर्टिफ़ैक्ट का नाम **`otelcol-contrib_` से शुरू होना चाहिए**। core `otelcol_` बिल्ड में `windowseventlog` या `windows_service` receiver नहीं होता, और `otelcol.exe` का नाम बदलकर `otelcol-contrib.exe` करने से वे जुड़ते नहीं हैं — इससे बस एक स्टार्टअप विफलता की जगह दूसरी आ जाती है (देखें [समस्या निवारण](#समस्या-निवारण))।
+
+एक **elevated** PowerShell प्रॉम्प्ट से पूरा ब्लॉक एक साथ चलाएँ — हर पंक्ति उसके ऊपर सेट किए गए चरों पर निर्भर है:
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-यह `otelcol-contrib.exe` को `C:\Program Files\otelcol-contrib` में अनपैक करता है। आप चरण 2 में उसी फ़ोल्डर में `config.yaml` बनाएँगे और चरण 3 में एक Windows सेवा पंजीकृत करेंगे।
+एक अकेली पंक्ति निकालने के बजाय पूरा ब्लॉक चलाएँ: URL `$VERSION` और `$ARCH` से बनता है, इसलिए किसी नए सत्र में अकेले चिपकाया गया `Invoke-WebRequest` खाली `-Uri` के कारण विफल हो जाता है और कुछ भी डाउनलोड नहीं करता। URL को अलग पंक्ति में `$url` के रूप में बनाना जानबूझकर है — संस्करण को सीधे `Invoke-WebRequest` के तर्क में रखने पर एक अपरिभाषित चर चुपचाप 404 बन जाता है।
+
+यह `otelcol-contrib.exe` को — **न कि** `otelcol.exe` को — `C:\Program Files\otelcol-contrib` में अनपैक करता है; ऊपर की `Get-ChildItem` पंक्ति पुष्टि करती है कि आपको कौन-सा मिला। आप चरण 2 में उसी फ़ोल्डर में `config.yaml` बनाएँगे और चरण 3 में एक Windows सेवा पंजीकृत करेंगे।
 
 > एक native installer पसंद करते हैं? OpenTelemetry उसी [releases page](https://github.com/open-telemetry/opentelemetry-collector-releases/releases) पर एक हस्ताक्षरित **`.msi`** (`otelcol-contrib_<version>_windows_x64.msi`) भी प्रकाशित करता है, जो आपके लिए collector को एक Windows सेवा के रूप में पंजीकृत करता है। यदि आप इसका उपयोग करते हैं, तो इसे चरण 2 से `config.yaml` पर इंगित करें और सुनिश्चित करें कि सेवा `LocalSystem` के रूप में चलती है ताकि **सेवाएं** टैब Service Control Manager पढ़ सके।
 
@@ -881,6 +900,12 @@ OpenTelemetry Collector मानक `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` �
   - पुष्टि करें कि होस्ट `https://oneuptime.com/otlp` (या आपका स्व-होस्टेड endpoint) तक पहुँच सकता है: उसी मशीन से `curl -v https://oneuptime.com/otlp`।
 - **exporter से HTTP 401** — ingestion token अमान्य या निरस्त है। _प्रोजेक्ट सेटिंग्स → टेलीमेट्री और APM → इंजेशन कुंजियाँ_ से एक नया बनाएँ।
 - **`Security` Windows Event Log access denied लौटाता है** — सेवा पर्याप्त विशेषाधिकारों के साथ नहीं चल रही है। इसे `LocalSystem` के अंतर्गत फिर से बनाएँ (`sc.exe create` के साथ डिफ़ॉल्ट) या सेवा खाते को _Manage auditing and security log_ उपयोगकर्ता अधिकार प्रदान करें।
+- **Windows सेवा `Error 2: The system cannot find the file specified` के साथ शुरू नहीं होती** — Service Control Manager को वह निष्पादन योग्य फ़ाइल नहीं मिल रही जिसके विरुद्ध सेवा पंजीकृत की गई थी। `sc.exe qc "otelcol-contrib"` चलाएँ और `BINARY_PATH_NAME` की तुलना उससे करें जो वास्तव में `C:\Program Files\otelcol-contrib` में मौजूद है। लगभग हमेशा core आर्काइव `otelcol_<version>_windows_amd64.tar.gz` डाउनलोड किया गया होता है — जो `otelcol.exe` अनपैक करता है — जबकि चरण 3 सेवा को `otelcol-contrib.exe` के विरुद्ध पंजीकृत करता है, जो केवल `otelcol-contrib_<version>_...` आर्काइव में होता है। चरण 1 से `contrib` आर्टिफ़ैक्ट फिर से डाउनलोड करें; `otelcol.exe` का नाम **न** बदलें, इससे नीचे वाला `1064` मिलता है। दूसरा कारण बिना उद्धरण चिह्नों वाला `binPath=` है: `C:\Program Files` से गुज़रने वाला पथ स्पेस पर टूट जाता है, जब तक कि उसे ठीक वैसे ही उद्धृत न किया जाए जैसा चरण 3 दिखाता है।
+- **Windows सेवा `Error 1064: An exception occurred in the service when handling the control request` के साथ शुरू नहीं होती** — SCM ने बाइनरी लॉन्च कर दी, लेकिन कलेक्टर स्टार्टअप के दौरान बाहर निकल गया। `otelcol.exe` का नाम बदलकर `otelcol-contrib.exe` करने से पथ तो हल हो जाता है, पर बाइनरी के भीतर जो है वह नहीं बदलता: core बिल्ड में `windowseventlog` और `windows_service` receiver नहीं हैं, इसलिए वह चरण 2 के कॉन्फ़िग को अस्वीकार कर देता है और सेवा के चालू होने की सूचना देने से पहले ही मर जाता है। बिना उद्धरण चिह्नों वाला `--config` पथ सही बाइनरी के साथ भी वही `1064` देता है: भीतरी उद्धरण चिह्नों के बिना तर्क `Program Files` के स्पेस पर टूट जाता है और कलेक्टर एक ऐसी कॉन्फ़िग फ़ाइल के कारण बाहर निकल जाता है जिसे वह पढ़ नहीं सकता। जाँचें कि आपके पास वास्तव में क्या है:
+  - `otelcol-contrib.exe --version` को `otelcol-contrib version ...` छापना चाहिए। यदि यह `otelcol version ...` छापता है, तो यह नाम बदला हुआ core बिल्ड है — चरण 1 से `contrib` आर्टिफ़ैक्ट फिर से डाउनलोड करें।
+  - `otelcol-contrib.exe components` को receiver में `windowseventlog` और `windows_service` सूचीबद्ध करने चाहिए। `hostmetrics` को कसौटी न बनाएँ — वह core बिल्ड में भी होता है, इसलिए उसका दिखना कुछ सिद्ध नहीं करता। कॉन्फ़िग जिस भी चीज़ का संदर्भ देता है पर यह कमांड उसे सूचीबद्ध नहीं करता, वह कलेक्टर को स्टार्टअप पर रोक देगी।
+  - सामान्य `1064` के बजाय असली त्रुटि देखने के लिए इसे फ़ोरग्राउंड में चलाएँ: `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`।
+  - _Event Viewer → Windows Logs → Application_ में स्रोत `otelcol-contrib` देखें, जो उस स्टार्टअप त्रुटि को दर्ज करता है जिसे SCM निगल गया।
 - **`journald` receiver शुरू होने में विफल रहता है** — सुनिश्चित करें कि `journalctl` collector के `PATH` पर है और कि `/var/log/journal` मौजूद है (यदि नहीं तो `sudo systemd-tmpfiles --create --prefix /var/log/journal` चलाएँ)।
 - **`systemd` receiver एक D-Bus कनेक्शन त्रुटि रिपोर्ट करता है** — collector system bus तक नहीं पहुँच सकता। पुष्टि करें कि `/run/dbus/system_bus_socket` मौजूद है और कि collector का उपयोगकर्ता उसे खोल सकता है; उस उपयोगकर्ता के रूप में `systemctl list-units` चलाना सबसे तेज़ जाँच है। root आवश्यक नहीं है। किसी container के भीतर चलने वाले collector को कोई bus दिखता ही नहीं जब तक आप होस्ट के socket को bind-mount न करें, इसलिए इस receiver के लिए native इंस्टॉल को प्राथमिकता दें।
 - **`systemd` receiver प्रति unit एक scrape त्रुटि लॉग करता है, या collector किसी अज्ञात मेट्रिक के कारण शुरू होने से मना कर देता है** — दोनों ही संस्करण के बेमेल होने के कारण हैं। v0.142.0 हर unit पर cgroup आँकड़े खोजता है (प्रति scrape हर गैर-`.service` unit के लिए एक त्रुटि) और अपनी CPU मेट्रिक को `systemd.unit.cpu.time` कहता है; v0.143.0 और बाद के संस्करण उस खोज को सेवाओं तक सीमित करते हैं और उन्होंने मेट्रिक का नाम बदलकर `systemd.service.cpu.time` कर दिया। v0.143.0+ पर अपग्रेड करें, और सुनिश्चित करें कि कोई भी `metrics:` ओवरराइड उसी कुंजी का नाम ले जो आपके बिल्ड में वास्तव में मौजूद है।

--- a/App/FeatureSet/Docs/Content/it/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/it/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ Creerai `/etc/otelcol-contrib/config.yaml` nel Passo 2 e un plist `launchd` nel 
 
 ### Windows
 
-Su Windows, scarica la release **`otelcol-contrib`** upstream — include il receiver `windows_service` che alimenta la scheda **Servizi** dell'host (a partire dalla **v0.155.0**). Da un prompt PowerShell **con privilegi elevati**:
+Su Windows, scarica la release **`otelcol-contrib`** upstream — include il receiver `windows_service` che alimenta la scheda **Servizi** dell'host (a partire dalla **v0.155.0**).
+
+**Scarica l'artefatto `contrib`, non quello core.** Ogni release pubblica due archivi per Windows i cui nomi differiscono per una sola parola, e sceglierne uno sbagliato è la causa più comune del fallimento di questa installazione:
+
+| Artefatto della release | Estrae | Da usare? |
+| ----------------------- | ------ | --------- |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **Sì** — la distribuzione contrib |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | No — la build core, priva dei receiver Windows usati più sotto |
+
+Il nome dell'artefatto deve **iniziare con `otelcol-contrib_`**. La build core `otelcol_` non include alcun receiver `windowseventlog` o `windows_service`, e rinominare `otelcol.exe` in `otelcol-contrib.exe` non li aggiunge — si limita a sostituire un errore di avvio con un altro (vedi [Risoluzione dei problemi](#risoluzione-dei-problemi)).
+
+Da un prompt PowerShell **con privilegi elevati**, esegui il blocco per intero — ogni riga dipende dalle variabili impostate sopra:
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-Questo estrae `otelcol-contrib.exe` in `C:\Program Files\otelcol-contrib`. Creerai `config.yaml` nella stessa cartella nel Passo 2 e registrerai un servizio Windows nel Passo 3.
+Esegui l'intero blocco anziché estrarne una singola riga: l'URL è composto a partire da `$VERSION` e `$ARCH`, quindi un `Invoke-WebRequest` incollato da solo in una sessione nuova fallisce con un `-Uri` nullo e non scarica nulla. Costruire l'URL in `$url`, su una riga a sé, è voluto: interpolare la versione direttamente nell'argomento di `Invoke-WebRequest` trasforma una variabile non impostata in un 404 silenzioso.
+
+Questo estrae `otelcol-contrib.exe` — **non** `otelcol.exe` — in `C:\Program Files\otelcol-contrib`; la riga `Get-ChildItem` qui sopra conferma quale dei due hai ottenuto. Creerai `config.yaml` nella stessa cartella nel Passo 2 e registrerai un servizio Windows nel Passo 3.
 
 > Preferisci un installer nativo? OpenTelemetry pubblica anche un **`.msi`** firmato (`otelcol-contrib_<version>_windows_x64.msi`) sulla stessa [pagina delle release](https://github.com/open-telemetry/opentelemetry-collector-releases/releases), che registra il collector come servizio Windows al posto tuo. Se lo usi, puntalo al `config.yaml` del Passo 2 e assicurati che il servizio venga eseguito come `LocalSystem` così che la scheda **Servizi** possa leggere il Service Control Manager.
 
@@ -881,6 +900,12 @@ L'OpenTelemetry Collector rispetta le variabili d'ambiente standard `HTTPS_PROXY
   - Verifica che l'host possa raggiungere `https://oneuptime.com/otlp` (o il tuo endpoint self-hosted): `curl -v https://oneuptime.com/otlp` dalla stessa macchina.
 - **HTTP 401 dall'exporter** — il token di ingestione non è valido o è stato revocato. Generane uno nuovo da _Impostazioni del progetto → Telemetria e APM → Chiavi di acquisizione_.
 - **Il canale `Security` del Windows Event Log restituisce access denied** — il servizio non viene eseguito con privilegi sufficienti. Ricrealo come `LocalSystem` (l'impostazione predefinita con `sc.exe create`) o concedi all'account del servizio il diritto utente _Manage auditing and security log_.
+- **Il servizio Windows non si avvia e restituisce `Error 2: The system cannot find the file specified`** — il Service Control Manager non trova l'eseguibile con cui il servizio è stato registrato. Esegui `sc.exe qc "otelcol-contrib"` e confronta `BINARY_PATH_NAME` con ciò che è davvero presente in `C:\Program Files\otelcol-contrib`. Quasi sempre è stato scaricato l'archivio core `otelcol_<version>_windows_amd64.tar.gz` — che estrae `otelcol.exe` — mentre il Passo 3 registra il servizio su `otelcol-contrib.exe`, contenuto solo nell'archivio `otelcol-contrib_<version>_...`. Riscarica l'artefatto `contrib` dal Passo 1; **non** rinominare `otelcol.exe`, cosa che produce invece il `1064` qui sotto. L'altra causa è un `binPath=` senza virgolette: un percorso che attraversa `C:\Program Files` si spezza sullo spazio a meno che non sia racchiuso tra virgolette esattamente come mostra il Passo 3.
+- **Il servizio Windows non si avvia e restituisce `Error 1064: An exception occurred in the service when handling the control request`** — l'SCM ha avviato il binario, ma il collector è terminato durante l'avvio. Rinominare `otelcol.exe` in `otelcol-contrib.exe` fa risolvere il percorso senza cambiare ciò che c'è dentro il binario: la build core non ha i receiver `windowseventlog` e `windows_service`, quindi rifiuta la configurazione del Passo 2 e muore prima che il servizio risulti in esecuzione. Un percorso `--config` senza virgolette produce lo stesso `1064` anche con il binario giusto: senza le virgolette interne l'argomento si spezza sullo spazio in `Program Files` e il collector termina per un file di configurazione che non riesce a leggere. Verifica cosa hai davvero:
+  - `otelcol-contrib.exe --version` dovrebbe stampare `otelcol-contrib version ...`. Se stampa `otelcol version ...`, è la build core rinominata — riscarica l'artefatto `contrib` dal Passo 1.
+  - `otelcol-contrib.exe components` dovrebbe elencare `windowseventlog` e `windows_service` tra i receiver. Non usare `hostmetrics` come test: è presente anche nella build core, quindi vederlo non dimostra nulla. Tutto ciò a cui la configurazione fa riferimento ma che questo comando non elenca bloccherà il collector all'avvio.
+  - Eseguilo in primo piano per vedere l'errore reale invece del generico `1064`: `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`.
+  - Controlla _Event Viewer → Windows Logs → Application_ cercando l'origine `otelcol-contrib`, che registra l'errore di avvio inghiottito dall'SCM.
 - **Il receiver `journald` non si avvia** — assicurati che `journalctl` sia nel `PATH` del collector e che `/var/log/journal` esista (esegui `sudo systemd-tmpfiles --create --prefix /var/log/journal` in caso contrario).
 - **Il receiver `systemd` segnala un errore di connessione D-Bus** — il collector non riesce a raggiungere il bus di sistema. Verifica che `/run/dbus/system_bus_socket` esista e che l'utente del collector possa aprirlo; eseguire `systemctl list-units` con quell'utente è la verifica più rapida. Non servono privilegi di root. Un collector eseguito dentro un container non vede alcun bus, a meno che tu non monti in bind il socket dell'host: per questo receiver è quindi preferibile un'installazione nativa.
 - **Il receiver `systemd` registra un errore di scrape per ogni unità, oppure il collector si rifiuta di avviarsi per una metrica sconosciuta** — in entrambi i casi si tratta di disallineamento di versione. La v0.142.0 cerca le statistiche cgroup su ogni unità (un errore per ciascuna unità non `.service` a ogni scrape) e chiama la propria metrica CPU `systemd.unit.cpu.time`; la v0.143.0 e successive limitano quella ricerca ai soli servizi e hanno rinominato la metrica in `systemd.service.cpu.time`. Aggiorna alla v0.143.0+ e assicurati che qualsiasi override in `metrics:` indichi la chiave effettivamente presente nella tua build.

--- a/App/FeatureSet/Docs/Content/ja/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/ja/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ sudo mkdir -p /etc/otelcol-contrib
 
 ### Windows
 
-Windows では、アップストリームの **`otelcol-contrib`** リリースをダウンロードします — これはホストの **サービス** タブを支える `windows_service` レシーバーを（**v0.155.0** 以降で）同梱しています。**管理者権限の** PowerShell プロンプトから実行します。
+Windows では、アップストリームの **`otelcol-contrib`** リリースをダウンロードします — これはホストの **サービス** タブを支える `windows_service` レシーバーを（**v0.155.0** 以降で）同梱しています。
+
+**core ではなく `contrib` のアセットをダウンロードしてください。** 各リリースは名前が 1 語だけ違う 2 つの Windows 用アーカイブを公開しており、間違ったほうを選ぶことがこのインストールに失敗する最も多い原因です。
+
+| リリースアセット | 展開されるもの | これを使う？ |
+| -------- | ------- | ------ |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **はい** — contrib ディストリビューション |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | いいえ — core ビルド。以下で使う Windows 用レシーバーがありません |
+
+アセット名は必ず **`otelcol-contrib_` で始まります**。core の `otelcol_` ビルドには `windowseventlog` と `windows_service` のレシーバーが含まれておらず、`otelcol.exe` を `otelcol-contrib.exe` にリネームしてもそれらは追加されません — 起動時のエラーが別のものに変わるだけです（[トラブルシューティング](#トラブルシューティング)を参照）。
+
+**管理者権限の** PowerShell プロンプトから、ブロック全体をまとめて実行してください。各行は、その上で設定した変数に依存します。
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-これにより `otelcol-contrib.exe` が `C:\Program Files\otelcol-contrib` に展開されます。ステップ 2 で同じフォルダに `config.yaml` を作成し、ステップ 3 で Windows サービスを登録します。
+1 行だけを抜き出さず、ブロック全体を実行してください。URL は `$VERSION` と `$ARCH` から組み立てられるため、新しいセッションに `Invoke-WebRequest` だけを貼り付けると `-Uri` が空になって失敗し、何もダウンロードされません。URL を独立した行の `$url` で組み立てているのは意図的です — バージョンを `Invoke-WebRequest` の引数に直接埋め込むと、未設定の変数がそのまま無言の 404 になります。
+
+これにより `otelcol.exe` では **なく** `otelcol-contrib.exe` が `C:\Program Files\otelcol-contrib` に展開されます。どちらを取得したかは上の `Get-ChildItem` の行で確認できます。ステップ 2 で同じフォルダに `config.yaml` を作成し、ステップ 3 で Windows サービスを登録します。
 
 > ネイティブインストーラーがお好みですか？ OpenTelemetry は、同じ[リリースページ](https://github.com/open-telemetry/opentelemetry-collector-releases/releases)で署名済みの **`.msi`**（`otelcol-contrib_<version>_windows_x64.msi`）も公開しており、これはコレクターを Windows サービスとして自動的に登録します。これを使用する場合は、ステップ 2 の `config.yaml` を指定し、**サービス** タブが Service Control Manager を読み取れるよう、サービスが `LocalSystem` として実行されることを確認してください。
 
@@ -881,6 +900,12 @@ OpenTelemetry Collector は、標準の `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY
   - ホストが `https://oneuptime.com/otlp`（またはセルフホストのエンドポイント）に到達できることを確認します。同じマシンから `curl -v https://oneuptime.com/otlp` を実行します。
 - **エクスポーターから HTTP 401 が返る** — 取り込みトークンが無効か失効しています。_プロジェクト設定 → テレメトリと APM → 取り込みキー_ から新しいものを生成してください。
 - **`Security` の Windows イベントログでアクセス拒否が返る** — サービスが十分な権限で実行されていません。`LocalSystem`（`sc.exe create` のデフォルト）の下で再作成するか、サービスアカウントに _Manage auditing and security log_（監査とセキュリティログの管理）ユーザー権利を付与してください。
+- **Windows サービスが `Error 2: The system cannot find the file specified` で起動しない** — サービス コントロール マネージャー（SCM）が、サービスの登録先となっている実行ファイルを見つけられません。`sc.exe qc "otelcol-contrib"` を実行し、`BINARY_PATH_NAME` を `C:\Program Files\otelcol-contrib` に実際にあるものと比較してください。ほとんどの場合、core のアーカイブ `otelcol_<version>_windows_amd64.tar.gz`（`otelcol.exe` が展開されます）をダウンロードしている一方で、ステップ 3 は `otelcol-contrib_<version>_...` アーカイブにしか含まれない `otelcol-contrib.exe` に対してサービスを登録しています。ステップ 1 から `contrib` のアセットをダウンロードし直してください。`otelcol.exe` をリネームしては **いけません** — 代わりに下の `1064` になります。もう 1 つの原因は引用符で囲まれていない `binPath=` です。`C:\Program Files` を通るパスは、ステップ 3 のとおりに正確に引用符で囲まないとスペースで分割されます。
+- **Windows サービスが `Error 1064: An exception occurred in the service when handling the control request` で起動しない** — SCM はバイナリを起動しましたが、コレクターが起動処理中に終了しました。`otelcol.exe` を `otelcol-contrib.exe` にリネームするとパスは解決しますが、バイナリの中身は変わりません。core ビルドには `windowseventlog` と `windows_service` のレシーバーがないため、ステップ 2 の設定を受け付けられず、サービスが実行中として報告される前に終了します。引用符で囲まれていない `--config` のパスは、正しいバイナリであっても同じ `1064` を引き起こします。内側の引用符がないと引数が `Program Files` のスペースで分割され、コレクターは読み取れない設定ファイルが原因で終了します。実際に何を持っているかを確認してください。
+  - `otelcol-contrib.exe --version` は `otelcol-contrib version ...` と表示されるはずです。`otelcol version ...` と表示される場合はリネームした core ビルドです — ステップ 1 から `contrib` のアセットをダウンロードし直してください。
+  - `otelcol-contrib.exe components` のレシーバー一覧に `windowseventlog` と `windows_service` が表示されるはずです。`hostmetrics` は判定に使えません — core ビルドにも含まれているためです。設定が参照しているのにこのコマンドの一覧にないものがあると、起動時にコレクターが停止します。
+  - 汎用的な `1064` ではなく本当のエラーを見るには、フォアグラウンドで実行します: `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`。
+  - _Event Viewer → Windows Logs → Application_ でソース `otelcol-contrib` を確認してください。SCM が飲み込んだ起動エラーが記録されています。
 - **`journald` レシーバーが起動に失敗する** — `journalctl` がコレクターの `PATH` 上にあること、および `/var/log/journal` が存在することを確認してください（存在しない場合は `sudo systemd-tmpfiles --create --prefix /var/log/journal` を実行）。
 - **`systemd` レシーバーが D-Bus の接続エラーを報告する** — コレクターがシステムバスに到達できていません。`/run/dbus/system_bus_socket` が存在し、コレクターのユーザーがそれを開けることを確認してください。そのユーザーで `systemctl list-units` を実行するのが最も手早い確認方法です。root は必要ありません。コンテナ内で実行しているコレクターは、ホストのソケットをバインドマウントしない限りバスにまったく到達できないため、このレシーバーにはネイティブインストールを推奨します。
 - **`systemd` レシーバーがユニットごとにスクレイプエラーを記録する、またはコレクターが未知のメトリクスを理由に起動を拒否する** — どちらもバージョンの不一致です。v0.142.0 はすべてのユニットについて cgroup の統計情報を探し（スクレイプごとに `.service` 以外のユニット 1 つにつき 1 件のエラー）、CPU メトリクスを `systemd.unit.cpu.time` と呼びます。v0.143.0 以降はこの参照をサービスのみに限定し、メトリクスを `systemd.service.cpu.time` に改名しました。v0.143.0 以降にアップグレードし、`metrics:` のオーバーライドが実際に動作しているビルドに存在するキーを指定していることを確認してください。

--- a/App/FeatureSet/Docs/Content/ko/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/ko/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ sudo mkdir -p /etc/otelcol-contrib
 
 ### Windows
 
-Windows에서는 업스트림 **`otelcol-contrib`** 릴리스를 다운로드하세요 — 이것은 (**v0.155.0**부터) 호스트 **서비스** 탭을 구동하는 `windows_service` receiver를 번들로 포함합니다. **권한이 상승된** PowerShell 프롬프트에서:
+Windows에서는 업스트림 **`otelcol-contrib`** 릴리스를 다운로드하세요 — 이것은 (**v0.155.0**부터) 호스트 **서비스** 탭을 구동하는 `windows_service` receiver를 번들로 포함합니다.
+
+**core가 아니라 `contrib` 아티팩트를 다운로드하세요.** 모든 릴리스는 이름이 한 단어만 다른 두 개의 Windows 아카이브를 게시하며, 잘못된 쪽을 고르는 것이 이 설치가 실패하는 가장 흔한 원인입니다:
+
+| 릴리스 아티팩트 | 압축 해제 결과 | 이것을 사용? |
+| -------- | -------- | ------- |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **예** — contrib 배포판 |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | 아니요 — 아래에서 사용하는 Windows receiver가 없는 core 빌드 |
+
+아티팩트 이름은 반드시 **`otelcol-contrib_`로 시작**해야 합니다. core `otelcol_` 빌드에는 `windowseventlog`와 `windows_service` receiver가 없으며, `otelcol.exe`의 이름을 `otelcol-contrib.exe`로 바꿔도 추가되지 않습니다 — 시작 실패가 다른 것으로 바뀔 뿐입니다([문제 해결](#문제-해결) 참조).
+
+**권한이 상승된** PowerShell 프롬프트에서 블록 전체를 한 번에 실행하세요 — 각 줄은 그 위에서 설정한 변수에 의존합니다:
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-이것은 `otelcol-contrib.exe`를 `C:\Program Files\otelcol-contrib`에 압축 해제합니다. 2단계에서 같은 폴더에 `config.yaml`을 생성하고 3단계에서 Windows 서비스를 등록하게 됩니다.
+한 줄만 떼어내지 말고 블록 전체를 실행하세요: URL은 `$VERSION`과 `$ARCH`로 조립되므로, 새 세션에 `Invoke-WebRequest`만 붙여넣으면 `-Uri`가 비어 실패하고 아무것도 내려받지 않습니다. URL을 별도 줄의 `$url`로 만드는 것은 의도적입니다 — 버전을 `Invoke-WebRequest` 인수에 직접 끼워 넣으면 설정되지 않은 변수가 조용한 404로 바뀝니다.
+
+이것은 `otelcol.exe`가 **아니라** `otelcol-contrib.exe`를 `C:\Program Files\otelcol-contrib`에 압축 해제합니다. 위의 `Get-ChildItem` 줄로 어느 쪽을 받았는지 확인할 수 있습니다. 2단계에서 같은 폴더에 `config.yaml`을 생성하고 3단계에서 Windows 서비스를 등록하게 됩니다.
 
 > 네이티브 설치 프로그램을 선호하시나요? OpenTelemetry는 동일한 [릴리스 페이지](https://github.com/open-telemetry/opentelemetry-collector-releases/releases)에서 서명된 **`.msi`**(`otelcol-contrib_<version>_windows_x64.msi`)도 게시하며, 이는 Collector를 Windows 서비스로 자동 등록해 줍니다. 이를 사용하는 경우, 2단계의 `config.yaml`을 가리키도록 하고, **서비스** 탭이 Service Control Manager를 읽을 수 있도록 서비스가 `LocalSystem`으로 실행되는지 확인하세요.
 
@@ -881,6 +900,12 @@ OpenTelemetry Collector는 표준 `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` 환�
   - 호스트가 `https://oneuptime.com/otlp`(또는 자체 호스팅 엔드포인트)에 도달할 수 있는지 확인하세요: 동일한 머신에서 `curl -v https://oneuptime.com/otlp`.
 - **exporter에서 HTTP 401** — ingestion token이 유효하지 않거나 취소되었습니다. *프로젝트 설정 → 텔레메트리 및 APM → 수집 키*에서 새로 생성하세요.
 - **`Security` Windows Event Log가 access denied를 반환함** — 서비스가 충분한 권한으로 실행되고 있지 않습니다. `LocalSystem`(`sc.exe create`의 기본값)으로 다시 생성하거나 서비스 계정에 _Manage auditing and security log_ 사용자 권한을 부여하세요.
+- **Windows 서비스가 `Error 2: The system cannot find the file specified`로 시작되지 않음** — 서비스 제어 관리자(SCM)가 서비스가 등록된 실행 파일을 찾지 못합니다. `sc.exe qc "otelcol-contrib"`를 실행해 `BINARY_PATH_NAME`을 `C:\Program Files\otelcol-contrib`에 실제로 있는 것과 비교하세요. 거의 항상 core 아카이브 `otelcol_<version>_windows_amd64.tar.gz`(`otelcol.exe`가 풀림)를 다운로드한 반면, 3단계는 `otelcol-contrib_<version>_...` 아카이브에만 들어 있는 `otelcol-contrib.exe`에 대해 서비스를 등록한 경우입니다. 1단계에서 `contrib` 아티팩트를 다시 다운로드하세요. `otelcol.exe`의 이름을 바꾸지 **마세요** — 그러면 대신 아래의 `1064`가 발생합니다. 다른 원인은 따옴표가 없는 `binPath=`입니다. `C:\Program Files`를 지나는 경로는 3단계에 나온 그대로 따옴표로 감싸지 않으면 공백에서 잘립니다.
+- **Windows 서비스가 `Error 1064: An exception occurred in the service when handling the control request`로 시작되지 않음** — SCM이 바이너리를 실행했지만 컬렉터가 시작 도중 종료되었습니다. `otelcol.exe`의 이름을 `otelcol-contrib.exe`로 바꾸면 경로는 해결되지만 바이너리 내부는 바뀌지 않습니다: core 빌드에는 `windowseventlog`와 `windows_service` receiver가 없으므로 2단계의 구성을 거부하고 서비스가 실행 중으로 보고되기도 전에 죽습니다. 따옴표가 없는 `--config` 경로는 올바른 바이너리로도 동일한 `1064`를 냅니다: 안쪽 따옴표가 없으면 인수가 `Program Files`의 공백에서 잘리고, 컬렉터는 읽을 수 없는 구성 파일 때문에 종료됩니다. 실제로 무엇을 가지고 있는지 확인하세요:
+  - `otelcol-contrib.exe --version`은 `otelcol-contrib version ...`을 출력해야 합니다. `otelcol version ...`이 출력되면 이름만 바꾼 core 빌드입니다 — 1단계에서 `contrib` 아티팩트를 다시 다운로드하세요.
+  - `otelcol-contrib.exe components`는 receiver 목록에 `windowseventlog`와 `windows_service`를 표시해야 합니다. `hostmetrics`는 판별 기준이 될 수 없습니다 — core 빌드에도 들어 있기 때문입니다. 구성이 참조하지만 이 명령이 나열하지 않는 것이 있으면 시작 시 컬렉터가 중단됩니다.
+  - 일반적인 `1064` 대신 실제 오류를 보려면 포그라운드에서 실행하세요: `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`.
+  - _Event Viewer → Windows Logs → Application_ 에서 원본 `otelcol-contrib`을 확인하세요. SCM이 삼킨 시작 오류가 기록되어 있습니다.
 - **`journald` receiver가 시작에 실패함** — `journalctl`이 Collector의 `PATH`에 있고 `/var/log/journal`이 존재하는지 확인하세요(존재하지 않으면 `sudo systemd-tmpfiles --create --prefix /var/log/journal`을 실행).
 - **`systemd` receiver가 D-Bus 연결 오류를 보고함** — Collector가 시스템 버스에 도달할 수 없습니다. `/run/dbus/system_bus_socket`이 존재하는지, 그리고 Collector의 사용자가 그것을 열 수 있는지 확인하세요. 해당 사용자로 `systemctl list-units`를 실행해 보는 것이 가장 빠른 확인 방법입니다. root는 필요하지 않습니다. 컨테이너 내부에서 실행되는 Collector는 호스트의 소켓을 바인드 마운트하지 않는 한 버스를 전혀 볼 수 없으므로, 이 receiver에는 네이티브 설치를 권장합니다.
 - **`systemd` receiver가 유닛마다 스크레이프 오류를 기록하거나, 알 수 없는 메트릭 때문에 Collector가 시작을 거부함** — 둘 다 버전 불일치입니다. v0.142.0은 모든 유닛에 대해 cgroup 통계를 찾고(스크레이프마다 `.service`가 아닌 유닛당 오류 하나) CPU 메트릭을 `systemd.unit.cpu.time`이라고 부릅니다. v0.143.0 이상은 그 조회를 서비스로만 제한하고 메트릭 이름을 `systemd.service.cpu.time`으로 바꿨습니다. v0.143.0 이상으로 업그레이드하고, `metrics:` 재정의가 실제로 실행 중인 빌드에 있는 키를 지정하는지 확인하세요.

--- a/App/FeatureSet/Docs/Content/nl/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/nl/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ Je maakt `/etc/otelcol-contrib/config.yaml` in Stap 2 en een `launchd`-plist in 
 
 ### Windows
 
-Download op Windows de upstream **`otelcol-contrib`**-release — deze bundelt de `windows_service`-receiver die het host-tabblad **Services** voedt (vanaf **v0.155.0**). Vanuit een **verhoogde** PowerShell-prompt:
+Download op Windows de upstream **`otelcol-contrib`**-release — deze bundelt de `windows_service`-receiver die het host-tabblad **Services** voedt (vanaf **v0.155.0**).
+
+**Download het `contrib`-artefact, niet het core-artefact.** Elke release publiceert twee Windows-archieven waarvan de namen in één woord verschillen, en het verkeerde kiezen is de meest voorkomende reden dat deze installatie mislukt:
+
+| Release-artefact | Pakt uit | Deze gebruiken? |
+| ---------------- | -------- | --------------- |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **Ja** — de contrib-distributie |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | Nee — de core-build, zonder de Windows-receivers die hieronder worden gebruikt |
+
+De artefactnaam moet **beginnen met `otelcol-contrib_`**. De core-`otelcol_`-build bevat geen `windowseventlog`- of `windows_service`-receiver, en `otelcol.exe` hernoemen naar `otelcol-contrib.exe` voegt ze niet toe — het verruilt alleen de ene opstartfout voor de andere (zie [Problemen oplossen](#problemen-oplossen)).
+
+Voer het blok vanuit een **verhoogde** PowerShell-prompt in zijn geheel uit — elke regel is afhankelijk van de variabelen die erboven zijn gezet:
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-Dit pakt `otelcol-contrib.exe` uit naar `C:\Program Files\otelcol-contrib`. Je maakt `config.yaml` in dezelfde map in Stap 2 en registreert een Windows-service in Stap 3.
+Voer het hele blok uit in plaats van er één regel uit te lichten: de URL wordt opgebouwd uit `$VERSION` en `$ARCH`, dus een `Invoke-WebRequest` die los in een nieuwe sessie wordt geplakt, faalt op een lege `-Uri` en downloadt niets. De URL op een eigen regel in `$url` opbouwen is bewust — de versie rechtstreeks in het `Invoke-WebRequest`-argument interpoleren maakt van een niet-gezette variabele juist een stille 404.
+
+Dit pakt `otelcol-contrib.exe` uit — **niet** `otelcol.exe` — naar `C:\Program Files\otelcol-contrib`; de `Get-ChildItem`-regel hierboven bevestigt welke je hebt gekregen. Je maakt `config.yaml` in dezelfde map in Stap 2 en registreert een Windows-service in Stap 3.
 
 > Geef je de voorkeur aan een native installer? OpenTelemetry publiceert ook een ondertekende **`.msi`** (`otelcol-contrib_<version>_windows_x64.msi`) op dezelfde [releasespagina](https://github.com/open-telemetry/opentelemetry-collector-releases/releases), die de collector voor je als Windows-service registreert. Als je die gebruikt, wijs hem dan naar de `config.yaml` uit Stap 2 en zorg ervoor dat de service als `LocalSystem` draait zodat het tabblad **Services** de Service Control Manager kan lezen.
 
@@ -881,6 +900,12 @@ De OpenTelemetry Collector respecteert de standaard omgevingsvariabelen `HTTPS_P
   - Bevestig dat de host `https://oneuptime.com/otlp` (of je zelf-gehoste endpoint) kan bereiken: `curl -v https://oneuptime.com/otlp` vanaf dezelfde machine.
 - **HTTP 401 van de exporter** — het ingestion-token is ongeldig of ingetrokken. Genereer een nieuw token via _Projectinstellingen → Telemetrie & APM → Ingestiesleutels_.
 - **`Security` Windows Event Log geeft toegang geweigerd** — de service draait niet met voldoende rechten. Maak hem opnieuw aan onder `LocalSystem` (de standaard met `sc.exe create`) of verleen het serviceaccount het gebruikersrecht _Manage auditing and security log_.
+- **De Windows-service start niet en geeft `Error 2: The system cannot find the file specified`** — de Service Control Manager kan het uitvoerbare bestand waarop de service is geregistreerd niet vinden. Voer `sc.exe qc "otelcol-contrib"` uit en vergelijk `BINARY_PATH_NAME` met wat er daadwerkelijk in `C:\Program Files\otelcol-contrib` staat. Bijna altijd is het core-archief `otelcol_<version>_windows_amd64.tar.gz` gedownload — dat pakt `otelcol.exe` uit — terwijl Stap 3 de service registreert op `otelcol-contrib.exe`, dat alleen het archief `otelcol-contrib_<version>_...` bevat. Download het `contrib`-artefact uit Stap 1 opnieuw; hernoem `otelcol.exe` **niet**, want dat levert in plaats daarvan de `1064` hieronder op. De andere oorzaak is een `binPath=` zonder aanhalingstekens: een pad door `C:\Program Files` splitst op de spatie tenzij het exact zo tussen aanhalingstekens staat als Stap 3 laat zien.
+- **De Windows-service start niet en geeft `Error 1064: An exception occurred in the service when handling the control request`** — de SCM heeft de binary gestart, maar de collector is tijdens het opstarten afgesloten. `otelcol.exe` hernoemen naar `otelcol-contrib.exe` laat het pad kloppen zonder te veranderen wat er in de binary zit: de core-build heeft geen `windowseventlog`- of `windows_service`-receiver, dus die weigert de configuratie uit Stap 2 en sterft voordat de service ooit als draaiend wordt gemeld. Een `--config`-pad zonder aanhalingstekens geeft dezelfde `1064`, zelfs met de juiste binary: zonder de binnenste aanhalingstekens splitst het argument op de spatie in `Program Files` en stopt de collector op een configuratiebestand dat hij niet kan lezen. Controleer wat je werkelijk hebt:
+  - `otelcol-contrib.exe --version` hoort `otelcol-contrib version ...` af te drukken. Drukt het `otelcol version ...` af, dan is het de hernoemde core-build — download het `contrib`-artefact opnieuw uit Stap 1.
+  - `otelcol-contrib.exe components` hoort `windowseventlog` en `windows_service` bij de receivers te tonen. Gebruik `hostmetrics` niet als test — die zit ook in de core-build en bewijst dus niets. Alles waarnaar de configuratie verwijst maar dat dit commando niet toont, stopt de collector bij het opstarten.
+  - Draai hem op de voorgrond om de echte fout te zien in plaats van de generieke `1064`: `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`.
+  - Kijk onder _Event Viewer → Windows Logs → Application_ bij bron `otelcol-contrib`, die de opstartfout registreert die de SCM heeft ingeslikt.
 - **`journald`-receiver start niet** — zorg ervoor dat `journalctl` op de `PATH` van de collector staat en dat `/var/log/journal` bestaat (voer `sudo systemd-tmpfiles --create --prefix /var/log/journal` uit als dat niet zo is).
 - **`systemd`-receiver meldt een D-Bus-verbindingsfout** — de collector kan de systeembus niet bereiken. Controleer of `/run/dbus/system_bus_socket` bestaat en of de gebruiker van de collector hem kan openen; `systemctl list-units` als die gebruiker draaien is de snelste controle. Root is niet nodig. Een collector die binnen een container draait, ziet helemaal geen bus tenzij je de socket van de host bind-mount, dus kies voor deze receiver bij voorkeur een native installatie.
 - **`systemd`-receiver logt een scrape-fout per unit, of de collector weigert te starten vanwege een onbekende metriek** — beide zijn versieverschil. v0.142.0 zoekt cgroup-statistieken op elke unit (één fout per niet-`.service`-unit per scrape) en noemt zijn CPU-metriek `systemd.unit.cpu.time`; v0.143.0 en later beperken die zoekactie tot services en hernoemden de metriek naar `systemd.service.cpu.time`. Upgrade naar v0.143.0+ en zorg dat een eventuele `metrics:`-override de sleutel noemt die je build daadwerkelijk heeft.

--- a/App/FeatureSet/Docs/Content/no/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/no/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ Du oppretter `/etc/otelcol-contrib/config.yaml` i Trinn 2 og en `launchd`-plist 
 
 ### Windows
 
-Pa Windows laster du ned den oppstroms **`otelcol-contrib`**-utgaven — den bunter `windows_service`-receiveren som driver host-fanen **Tjenester** (fra **v0.155.0** og fremover). Fra en **forhoyet** PowerShell-ledetekst:
+Pa Windows laster du ned den oppstroms **`otelcol-contrib`**-utgaven — den bunter `windows_service`-receiveren som driver host-fanen **Tjenester** (fra **v0.155.0** og fremover).
+
+**Last ned `contrib`-arkivet, ikke core-arkivet.** Hver utgave publiserer to Windows-arkiver med navn som bare skiller seg med ett ord, og a velge feil er den vanligste arsaken til at denne installasjonen feiler:
+
+| Utgivelsesarkiv | Pakker ut | Bruk dette? |
+| --------------- | --------- | ----------- |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **Ja** — contrib-distribusjonen |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | Nei — core-bygget, som mangler Windows-receiverne som brukes nedenfor |
+
+Arkivnavnet ma **begynne med `otelcol-contrib_`**. Core-`otelcol_`-bygget leverer verken `windowseventlog`- eller `windows_service`-receiveren, og a gi `otelcol.exe` nytt navn til `otelcol-contrib.exe` legger dem ikke til — det bytter bare den ene oppstartsfeilen med den andre (se [Feilsoking](#feilsoking)).
+
+Fra en **forhoyet** PowerShell-ledetekst kjorer du hele blokken samlet — hver linje avhenger av variablene som er satt over den:
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-Dette pakker ut `otelcol-contrib.exe` i `C:\Program Files\otelcol-contrib`. Du oppretter `config.yaml` i samme mappe i Trinn 2 og registrerer en Windows-tjeneste i Trinn 3.
+Kjor hele blokken i stedet for a rive ut en enkelt linje: URL-en settes sammen av `$VERSION` og `$ARCH`, sa en `Invoke-WebRequest` som limes inn alene i en ny okt, feiler pa en tom `-Uri` og laster ikke ned noe. A bygge URL-en i `$url` pa sin egen linje er bevisst — interpolerer du versjonen rett inn i `Invoke-WebRequest`-argumentet, blir en usatt variabel i stedet en taus 404.
+
+Dette pakker ut `otelcol-contrib.exe` — **ikke** `otelcol.exe` — i `C:\Program Files\otelcol-contrib`; `Get-ChildItem`-linjen over bekrefter hvilken du fikk. Du oppretter `config.yaml` i samme mappe i Trinn 2 og registrerer en Windows-tjeneste i Trinn 3.
 
 > Foretrekker du et nativt installasjonsprogram? OpenTelemetry publiserer ogsa en signert **`.msi`** (`otelcol-contrib_<version>_windows_x64.msi`) pa den samme [utgivelsessiden](https://github.com/open-telemetry/opentelemetry-collector-releases/releases), som registrerer collectoren som en Windows-tjeneste for deg. Hvis du bruker den, pek den mot `config.yaml` fra Trinn 2 og pass pa at tjenesten kjorer som `LocalSystem` slik at **Tjenester**-fanen kan lese Service Control Manager.
 
@@ -881,6 +900,12 @@ OpenTelemetry Collector respekterer standardmiljovariablene `HTTPS_PROXY` / `HTT
   - Bekreft at hosten kan na `https://oneuptime.com/otlp` (eller ditt selvhostede endepunkt): `curl -v https://oneuptime.com/otlp` fra samme maskin.
 - **HTTP 401 fra eksportoren** — ingestion-tokenet er ugyldig eller tilbakekalt. Generer et nytt fra _Prosjektinnstillinger → Telemetri og APM → Inntaksnøkler_.
 - **`Security`-kanalen i Windows Event Log returnerer access denied** — tjenesten kjorer ikke med tilstrekkelige privilegier. Gjenopprett den under `LocalSystem` (standarden med `sc.exe create`) eller gi tjenestekontoen brukerrettigheten _Manage auditing and security log_.
+- **Windows-tjenesten starter ikke og gir `Error 2: The system cannot find the file specified`** — Service Control Manager finner ikke den kjorbare filen tjenesten ble registrert mot. Kjor `sc.exe qc "otelcol-contrib"` og sammenlign `BINARY_PATH_NAME` med det som faktisk ligger i `C:\Program Files\otelcol-contrib`. Nesten alltid er core-arkivet `otelcol_<version>_windows_amd64.tar.gz` lastet ned — det pakker ut `otelcol.exe` — mens Trinn 3 registrerer tjenesten mot `otelcol-contrib.exe`, som bare arkivet `otelcol-contrib_<version>_...` inneholder. Last ned `contrib`-arkivet fra Trinn 1 pa nytt; gi **ikke** `otelcol.exe` nytt navn, det gir i stedet `1064` nedenfor. Den andre arsaken er en `binPath=` uten anforselstegn: en sti gjennom `C:\Program Files` deles ved mellomrommet med mindre den settes i anforselstegn noyaktig slik Trinn 3 viser.
+- **Windows-tjenesten starter ikke og gir `Error 1064: An exception occurred in the service when handling the control request`** — SCM startet binaerfilen, men collectoren avsluttet under oppstart. A gi `otelcol.exe` nytt navn til `otelcol-contrib.exe` gjor at stien gar opp uten a endre innholdet i binaerfilen: core-bygget har verken `windowseventlog`- eller `windows_service`-receiveren, sa det avviser konfigurasjonen fra Trinn 2 og dor for tjenesten i det hele tatt rapporteres som kjorende. En `--config`-sti uten anforselstegn gir samme `1064` selv med riktig binaerfil: uten de indre anforselstegnene deles argumentet ved mellomrommet i `Program Files`, og collectoren avslutter pa grunn av en konfigurasjonsfil den ikke kan lese. Sjekk hva du faktisk har:
+  - `otelcol-contrib.exe --version` skal skrive `otelcol-contrib version ...`. Hvis den skriver `otelcol version ...`, er det core-bygget med nytt navn — last ned `contrib`-arkivet fra Trinn 1 pa nytt.
+  - `otelcol-contrib.exe components` skal liste `windowseventlog` og `windows_service` blant receiverne. Ikke bruk `hostmetrics` som test — den finnes ogsa i core-bygget og beviser derfor ingenting. Alt konfigurasjonen refererer til, men som denne kommandoen ikke lister, stopper collectoren ved oppstart.
+  - Kjor den i forgrunnen for a se den faktiske feilen i stedet for den generiske `1064`: `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`.
+  - Se under _Event Viewer → Windows Logs → Application_ etter kilden `otelcol-contrib`, som registrerer oppstartsfeilen SCM svelget.
 - **`journald`-receiveren klarer ikke a starte** — pass pa at `journalctl` er pa collectorens `PATH` og at `/var/log/journal` finnes (kjor `sudo systemd-tmpfiles --create --prefix /var/log/journal` hvis ikke).
 - **`systemd`-receiveren rapporterer en D-Bus-tilkoblingsfeil** — collectoren nar ikke systembussen. Bekreft at `/run/dbus/system_bus_socket` finnes og at collectorens bruker kan apne den; a kjore `systemctl list-units` som den brukeren er den raskeste sjekken. Root kreves ikke. En collector som kjorer inne i en container, ser ingen buss i det hele tatt med mindre du bind-monterer hostens socket, sa foretrekk en nativ installasjon for denne receiveren.
 - **`systemd`-receiveren logger en scrape-feil per enhet, eller collectoren nekter a starte pa grunn av en ukjent metrikk** — begge deler skyldes versjonsforskjeller. v0.142.0 ser etter cgroup-statistikk pa hver eneste enhet (en feil per enhet som ikke er en `.service`, per scrape) og kaller CPU-metrikken sin `systemd.unit.cpu.time`; v0.143.0 og senere begrenser det oppslaget til tjenester og dopte om metrikken til `systemd.service.cpu.time`. Oppgrader til v0.143.0+, og pass pa at en eventuell `metrics:`-overstyring navngir nokkelen bygget ditt faktisk har.

--- a/App/FeatureSet/Docs/Content/pt/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/pt/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ Você criará `/etc/otelcol-contrib/config.yaml` no Passo 2 e um plist do `launc
 
 ### Windows
 
-No Windows, baixe a release **`otelcol-contrib`** upstream — ela inclui o receiver `windows_service` que alimenta a aba **Serviços** do host (a partir da **v0.155.0**). A partir de um prompt **elevado** do PowerShell:
+No Windows, baixe a release **`otelcol-contrib`** upstream — ela inclui o receiver `windows_service` que alimenta a aba **Serviços** do host (a partir da **v0.155.0**).
+
+**Baixe o artefato `contrib`, não o core.** Cada release publica dois arquivos para Windows cujos nomes diferem por uma única palavra, e escolher o errado é a causa mais comum de falha desta instalação:
+
+| Artefato da release | Descompacta | Usar este? |
+| ------------------- | ----------- | ---------- |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **Sim** — a distribuição contrib |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | Não — o build core, sem os receivers do Windows usados abaixo |
+
+O nome do artefato precisa **começar com `otelcol-contrib_`**. O build core `otelcol_` não traz os receivers `windowseventlog` nem `windows_service`, e renomear `otelcol.exe` para `otelcol-contrib.exe` não os adiciona — apenas troca uma falha de inicialização por outra (veja [Solução de problemas](#solução-de-problemas)).
+
+A partir de um prompt **elevado** do PowerShell, execute o bloco inteiro — cada linha depende das variáveis definidas acima:
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-Isso descompacta `otelcol-contrib.exe` em `C:\Program Files\otelcol-contrib`. Você criará `config.yaml` na mesma pasta no Passo 2 e registrará um serviço do Windows no Passo 3.
+Execute o bloco inteiro em vez de tirar uma única linha dele: a URL é montada a partir de `$VERSION` e `$ARCH`, então um `Invoke-WebRequest` colado sozinho em uma sessão nova falha com um `-Uri` nulo e não baixa nada. Montar a URL em `$url`, em uma linha própria, é proposital: interpolar a versão direto no argumento do `Invoke-WebRequest` transforma uma variável não definida em um 404 silencioso.
+
+Isso descompacta `otelcol-contrib.exe` — **não** `otelcol.exe` — em `C:\Program Files\otelcol-contrib`; a linha `Get-ChildItem` acima confirma qual deles você obteve. Você criará `config.yaml` na mesma pasta no Passo 2 e registrará um serviço do Windows no Passo 3.
 
 > Prefere um instalador nativo? O OpenTelemetry também publica um **`.msi`** assinado (`otelcol-contrib_<version>_windows_x64.msi`) na mesma [página de releases](https://github.com/open-telemetry/opentelemetry-collector-releases/releases), que registra o coletor como um serviço do Windows para você. Se você usá-lo, aponte-o para o `config.yaml` do Passo 2 e certifique-se de que o serviço rode como `LocalSystem` para que a aba **Serviços** possa ler o Service Control Manager.
 
@@ -881,6 +900,12 @@ O OpenTelemetry Collector respeita as variáveis de ambiente padrão `HTTPS_PROX
   - Confirme que o host consegue alcançar `https://oneuptime.com/otlp` (ou o seu endpoint auto-hospedado): `curl -v https://oneuptime.com/otlp` a partir da mesma máquina.
 - **HTTP 401 do exporter** — o token de ingestão é inválido ou foi revogado. Gere um novo em _Configurações do projeto → Telemetria e APM → Chaves de ingestão_.
 - **O canal `Security` do Windows Event Log retorna acesso negado** — o serviço não está rodando com privilégios suficientes. Recrie-o sob `LocalSystem` (o padrão com `sc.exe create`) ou conceda à conta de serviço o direito de usuário _Manage auditing and security log_.
+- **O serviço do Windows não inicia e retorna `Error 2: The system cannot find the file specified`** — o Service Control Manager não encontra o executável com o qual o serviço foi registrado. Execute `sc.exe qc "otelcol-contrib"` e compare `BINARY_PATH_NAME` com o que realmente está em `C:\Program Files\otelcol-contrib`. Quase sempre foi baixado o arquivo core `otelcol_<version>_windows_amd64.tar.gz` — que descompacta `otelcol.exe` — enquanto o Passo 3 registra o serviço contra `otelcol-contrib.exe`, que só o arquivo `otelcol-contrib_<version>_...` contém. Baixe novamente o artefato `contrib` do Passo 1; **não** renomeie `otelcol.exe`, o que produz o `1064` abaixo em vez disso. A outra causa é um `binPath=` sem aspas: um caminho que passa por `C:\Program Files` se quebra no espaço a menos que esteja entre aspas exatamente como o Passo 3 mostra.
+- **O serviço do Windows não inicia e retorna `Error 1064: An exception occurred in the service when handling the control request`** — o SCM iniciou o binário, mas o collector encerrou durante a inicialização. Renomear `otelcol.exe` para `otelcol-contrib.exe` faz o caminho resolver sem mudar o que há dentro do binário: o build core não tem os receivers `windowseventlog` e `windows_service`, então ele rejeita a configuração do Passo 2 e morre antes de o serviço chegar a reportar que está em execução. Um caminho `--config` sem aspas gera o mesmo `1064` mesmo com o binário certo: sem as aspas internas, o argumento se quebra no espaço de `Program Files` e o collector encerra por causa de um arquivo de configuração que não consegue ler. Verifique o que você realmente tem:
+  - `otelcol-contrib.exe --version` deve imprimir `otelcol-contrib version ...`. Se imprimir `otelcol version ...`, é o build core renomeado — baixe novamente o artefato `contrib` do Passo 1.
+  - `otelcol-contrib.exe components` deve listar `windowseventlog` e `windows_service` entre os receivers. Não use `hostmetrics` como teste: o build core também o traz, então vê-lo não prova nada. Qualquer coisa que a configuração referencie mas que este comando não liste vai parar o collector na inicialização.
+  - Execute-o em primeiro plano para ver o erro real em vez do genérico `1064`: `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`.
+  - Verifique _Event Viewer → Windows Logs → Application_ na origem `otelcol-contrib`, que registra o erro de inicialização que o SCM engoliu.
 - **O receiver `journald` falha ao iniciar** — certifique-se de que `journalctl` esteja no `PATH` do coletor e de que `/var/log/journal` exista (execute `sudo systemd-tmpfiles --create --prefix /var/log/journal` se não existir).
 - **O receiver `systemd` reporta um erro de conexão D-Bus** — o coletor não consegue alcançar o barramento do sistema. Confirme que `/run/dbus/system_bus_socket` existe e que o usuário do coletor consegue abri-lo; rodar `systemctl list-units` com esse usuário é a verificação mais rápida. Root não é necessário. Um coletor rodando dentro de um contêiner não enxerga barramento algum, a menos que você monte em bind o socket do host, então prefira uma instalação nativa para este receiver.
 - **O receiver `systemd` registra um erro de scrape por unit, ou o coletor se recusa a iniciar por causa de uma métrica desconhecida** — nos dois casos é desalinhamento de versão. A v0.142.0 procura estatísticas de cgroup em todas as units (um erro por unit que não seja `.service` a cada scrape) e chama sua métrica de CPU de `systemd.unit.cpu.time`; a v0.143.0 e posteriores limitam essa busca aos serviços e renomearam a métrica para `systemd.service.cpu.time`. Atualize para a v0.143.0+ e garanta que qualquer override em `metrics:` nomeie a chave que o seu build realmente tem.

--- a/App/FeatureSet/Docs/Content/ru/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/ru/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ sudo mkdir -p /etc/otelcol-contrib
 
 ### Windows
 
-В Windows загрузите релиз **`otelcol-contrib`** из апстрима — он включает приёмник `windows_service`, который питает вкладку **Службы** хоста (начиная с **v0.155.0**). Из **командной строки PowerShell с повышенными правами**:
+В Windows загрузите релиз **`otelcol-contrib`** из апстрима — он включает приёмник `windows_service`, который питает вкладку **Службы** хоста (начиная с **v0.155.0**).
+
+**Скачивайте артефакт `contrib`, а не core.** В каждом релизе публикуются два архива для Windows, имена которых отличаются одним словом, и выбор не того — самая частая причина, по которой эта установка не работает:
+
+| Артефакт релиза | Распаковывает | Использовать этот? |
+| --------------- | ------------- | ------------------ |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **Да** — дистрибутив contrib |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | Нет — сборка core, в которой нет используемых ниже приёмников Windows |
+
+Имя артефакта должно **начинаться с `otelcol-contrib_`**. Сборка core `otelcol_` не содержит приёмников `windowseventlog` и `windows_service`, а переименование `otelcol.exe` в `otelcol-contrib.exe` их не добавляет — оно лишь меняет одну ошибку запуска на другую (см. [Устранение неполадок](#устранение-неполадок)).
+
+Из **командной строки PowerShell с повышенными правами** выполните блок целиком — каждая строка зависит от переменных, заданных выше:
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-Это распаковывает `otelcol-contrib.exe` в `C:\Program Files\otelcol-contrib`. Вы создадите `config.yaml` в той же папке на Шаге 2 и зарегистрируете службу Windows на Шаге 3.
+Выполняйте блок целиком, а не вырывайте из него одну строку: URL собирается из `$VERSION` и `$ARCH`, поэтому `Invoke-WebRequest`, вставленный отдельно в новый сеанс, завершается ошибкой из-за пустого `-Uri` и ничего не скачивает. Сборка URL в `$url` отдельной строкой сделана намеренно — если подставлять версию прямо в аргумент `Invoke-WebRequest`, незаданная переменная превращается в молчаливый 404.
+
+Это распаковывает `otelcol-contrib.exe` — а **не** `otelcol.exe` — в `C:\Program Files\otelcol-contrib`; строка `Get-ChildItem` выше подтверждает, что именно вы получили. Вы создадите `config.yaml` в той же папке на Шаге 2 и зарегистрируете службу Windows на Шаге 3.
 
 > Предпочитаете нативный установщик? OpenTelemetry также публикует подписанный **`.msi`** (`otelcol-contrib_<version>_windows_x64.msi`) на той же [странице релизов](https://github.com/open-telemetry/opentelemetry-collector-releases/releases), который регистрирует коллектор как службу Windows за вас. Если вы его используете, укажите ему на `config.yaml` из Шага 2 и убедитесь, что служба работает под `LocalSystem`, чтобы вкладка **Службы** могла читать Service Control Manager.
 
@@ -881,6 +900,12 @@ OpenTelemetry Collector учитывает стандартные перемен
   - Убедитесь, что хост может достучаться до `https://oneuptime.com/otlp` (или вашей самостоятельно размещённой конечной точки): `curl -v https://oneuptime.com/otlp` с той же машины.
 - **HTTP 401 от экспортёра** — токен приёма данных недействителен или отозван. Сгенерируйте новый в _Настройки проекта → Телеметрия и APM → Ключи приема_.
 - **Журнал событий Windows `Security` возвращает «access denied»** — служба работает с недостаточными привилегиями. Пересоздайте её под `LocalSystem` (по умолчанию при `sc.exe create`) или предоставьте учётной записи службы право пользователя _Manage auditing and security log_.
+- **Служба Windows не запускается с ошибкой `Error 2: The system cannot find the file specified`** — Service Control Manager не находит исполняемый файл, на который была зарегистрирована служба. Выполните `sc.exe qc "otelcol-contrib"` и сравните `BINARY_PATH_NAME` с тем, что фактически лежит в `C:\Program Files\otelcol-contrib`. Почти всегда был загружен архив core `otelcol_<version>_windows_amd64.tar.gz` — он распаковывает `otelcol.exe`, — тогда как Шаг 3 регистрирует службу на `otelcol-contrib.exe`, который содержится только в архиве `otelcol-contrib_<version>_...`. Скачайте артефакт `contrib` из Шага 1 заново; **не** переименовывайте `otelcol.exe` — это приводит к ошибке `1064` ниже. Вторая причина — `binPath=` без кавычек: путь через `C:\Program Files` разрывается по пробелу, если он не заключён в кавычки ровно так, как показано в Шаге 3.
+- **Служба Windows не запускается с ошибкой `Error 1064: An exception occurred in the service when handling the control request`** — SCM запустил бинарный файл, но коллектор завершился во время запуска. Переименование `otelcol.exe` в `otelcol-contrib.exe` заставляет путь разрешаться, но не меняет того, что внутри бинарного файла: в сборке core нет приёмников `windowseventlog` и `windows_service`, поэтому она отклоняет конфигурацию из Шага 2 и завершается до того, как служба вообще отчитается как запущенная. Путь `--config` без кавычек даёт ту же ошибку `1064` даже с правильным бинарным файлом: без внутренних кавычек аргумент разрывается по пробелу в `Program Files`, и коллектор завершается из-за файла конфигурации, который не может прочитать. Проверьте, что у вас на самом деле:
+  - `otelcol-contrib.exe --version` должен вывести `otelcol-contrib version ...`. Если он выводит `otelcol version ...`, это переименованная сборка core — скачайте артефакт `contrib` из Шага 1 заново.
+  - `otelcol-contrib.exe components` должен перечислить `windowseventlog` и `windows_service` среди приёмников. Не проверяйте по `hostmetrics` — он есть и в сборке core, поэтому ничего не доказывает. Всё, на что ссылается конфигурация, но чего эта команда не показывает, остановит коллектор при запуске.
+  - Запустите его на переднем плане, чтобы увидеть настоящую ошибку вместо общей `1064`: `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`.
+  - Посмотрите в _Event Viewer → Windows Logs → Application_ источник `otelcol-contrib`, который записывает ошибку запуска, проглоченную SCM.
 - **Приёмник `journald` не запускается** — убедитесь, что `journalctl` находится в `PATH` коллектора и что `/var/log/journal` существует (выполните `sudo systemd-tmpfiles --create --prefix /var/log/journal`, если нет).
 - **Приёмник `systemd` сообщает об ошибке подключения к D-Bus** — коллектор не может достучаться до системной шины. Убедитесь, что `/run/dbus/system_bus_socket` существует и что пользователь коллектора может его открыть; быстрее всего это проверить, выполнив `systemctl list-units` от этого пользователя. Root не требуется. Коллектор, работающий внутри контейнера, вообще не видит шины, если вы не смонтируете сокет хоста через bind mount, — поэтому для этого приёмника предпочтительна нативная установка.
 - **Приёмник `systemd` пишет по ошибке сбора на каждый юнит, либо коллектор отказывается стартовать из-за неизвестной метрики** — и то и другое означает расхождение версий. v0.142.0 запрашивает статистику cgroup для каждого юнита (по одной ошибке на каждый юнит, не являющийся `.service`, за сбор) и называет свою метрику CPU `systemd.unit.cpu.time`; v0.143.0 и новее ограничивают этот запрос службами и переименовали метрику в `systemd.service.cpu.time`. Обновитесь до v0.143.0+ и убедитесь, что любое переопределение в `metrics:` называет тот ключ, который действительно есть в вашей сборке.

--- a/App/FeatureSet/Docs/Content/sv/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/sv/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ Du skapar `/etc/otelcol-contrib/config.yaml` i Steg 2 och en `launchd`-plist i S
 
 ### Windows
 
-På Windows laddar du ner den uppströms **`otelcol-contrib`**-versionen — den inkluderar mottagaren `windows_service` som driver fliken **Tjänster** på värden (från och med **v0.155.0**). Från en **förhöjd** PowerShell-prompt:
+På Windows laddar du ner den uppströms **`otelcol-contrib`**-versionen — den inkluderar mottagaren `windows_service` som driver fliken **Tjänster** på värden (från och med **v0.155.0**).
+
+**Ladda ner `contrib`-artefakten, inte core-artefakten.** Varje version publicerar två Windows-arkiv vars namn skiljer sig åt med ett enda ord, och att välja fel är den vanligaste orsaken till att den här installationen misslyckas:
+
+| Utgåvans artefakt | Packar upp | Använd denna? |
+| ----------------- | ---------- | ------------- |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **Ja** — contrib-distributionen |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | Nej — core-bygget, som saknar Windows-mottagarna som används nedan |
+
+Artefaktnamnet måste **börja med `otelcol-contrib_`**. Core-`otelcol_`-bygget levererar varken mottagaren `windowseventlog` eller `windows_service`, och att byta namn på `otelcol.exe` till `otelcol-contrib.exe` lägger inte till dem — det byter bara ut ett startfel mot ett annat (se [Felsökning](#felsökning)).
+
+Kör hela blocket i ett svep från en **förhöjd** PowerShell-prompt — varje rad förutsätter variablerna som satts ovanför:
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-Detta packar upp `otelcol-contrib.exe` i `C:\Program Files\otelcol-contrib`. Du skapar `config.yaml` i samma mapp i Steg 2 och registrerar en Windows-tjänst i Steg 3.
+Kör hela blocket i stället för att plocka ut en enda rad: URL:en sätts samman av `$VERSION` och `$ARCH`, så ett `Invoke-WebRequest` som klistras in ensamt i en ny session misslyckas med en tom `-Uri` och laddar inte ner något. Att bygga URL:en i `$url` på en egen rad är medvetet — interpolerar man versionen direkt i `Invoke-WebRequest`-argumentet blir en osatt variabel i stället en tyst 404.
+
+Detta packar upp `otelcol-contrib.exe` — **inte** `otelcol.exe` — i `C:\Program Files\otelcol-contrib`; `Get-ChildItem`-raden ovan bekräftar vilken du fick. Du skapar `config.yaml` i samma mapp i Steg 2 och registrerar en Windows-tjänst i Steg 3.
 
 > Föredrar du en inbyggd installer? OpenTelemetry publicerar också en signerad **`.msi`** (`otelcol-contrib_<version>_windows_x64.msi`) på samma [versionssida](https://github.com/open-telemetry/opentelemetry-collector-releases/releases), som registrerar collectorn som en Windows-tjänst åt dig. Om du använder den, peka den mot `config.yaml` från Steg 2 och se till att tjänsten körs som `LocalSystem` så att fliken **Tjänster** kan läsa Service Control Manager.
 
@@ -881,6 +900,12 @@ OpenTelemetry Collector respekterar standardmiljövariablerna `HTTPS_PROXY` / `H
   - Bekräfta att värden kan nå `https://oneuptime.com/otlp` (eller din självhostade slutpunkt): `curl -v https://oneuptime.com/otlp` från samma maskin.
 - **HTTP 401 från exportören** — inmatningstoken är ogiltig eller återkallad. Generera en ny från _Projektinställningar → Telemetri och APM → Intagningsnycklar_.
 - **Windows Event Log `Security` returnerar access denied** — tjänsten körs inte med tillräckliga behörigheter. Återskapa den under `LocalSystem` (standard med `sc.exe create`) eller ge tjänstkontot användarrättigheten _Manage auditing and security log_.
+- **Windows-tjänsten startar inte och ger `Error 2: The system cannot find the file specified`** — Service Control Manager hittar inte den körbara fil som tjänsten registrerades mot. Kör `sc.exe qc "otelcol-contrib"` och jämför `BINARY_PATH_NAME` med det som faktiskt ligger i `C:\Program Files\otelcol-contrib`. Nästan alltid har core-arkivet `otelcol_<version>_windows_amd64.tar.gz` laddats ner — det packar upp `otelcol.exe` — medan Steg 3 registrerar tjänsten mot `otelcol-contrib.exe`, som bara arkivet `otelcol-contrib_<version>_...` innehåller. Ladda ner `contrib`-artefakten från Steg 1 igen; byt **inte** namn på `otelcol.exe`, vilket i stället ger `1064` nedan. Den andra orsaken är ett `binPath=` utan citattecken: en sökväg genom `C:\Program Files` delas vid mellanslaget om den inte sätts inom citattecken exakt som Steg 3 visar.
+- **Windows-tjänsten startar inte och ger `Error 1064: An exception occurred in the service when handling the control request`** — SCM startade binären, men insamlaren avslutades under uppstarten. Att byta namn på `otelcol.exe` till `otelcol-contrib.exe` gör att sökvägen går ihop utan att ändra vad som finns inuti binären: core-bygget har varken mottagaren `windowseventlog` eller `windows_service`, så det avvisar konfigurationen från Steg 2 och dör innan tjänsten ens rapporteras som körande. En `--config`-sökväg utan citattecken ger samma `1064` även med rätt binär: utan de inre citattecknen delas argumentet vid mellanslaget i `Program Files` och insamlaren avslutas på grund av en konfigurationsfil den inte kan läsa. Kontrollera vad du faktiskt har:
+  - `otelcol-contrib.exe --version` bör skriva ut `otelcol-contrib version ...`. Skriver den `otelcol version ...` är det core-bygget som döpts om — ladda ner `contrib`-artefakten från Steg 1 igen.
+  - `otelcol-contrib.exe components` bör lista `windowseventlog` och `windows_service` bland mottagarna. Använd inte `hostmetrics` som test — den finns även i core-bygget och bevisar därför ingenting. Allt som konfigurationen refererar till men som det här kommandot inte listar stoppar insamlaren vid uppstart.
+  - Kör den i förgrunden för att se det verkliga felet i stället för det generiska `1064`: `& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`.
+  - Titta under _Event Viewer → Windows Logs → Application_ efter källan `otelcol-contrib`, som registrerar det uppstartsfel som SCM svalde.
 - **`journald`-mottagaren misslyckas med att starta** — se till att `journalctl` finns i collectorns `PATH` och att `/var/log/journal` existerar (kör `sudo systemd-tmpfiles --create --prefix /var/log/journal` om inte).
 - **`systemd`-mottagaren rapporterar ett D-Bus-anslutningsfel** — collectorn kan inte nå systembussen. Bekräfta att `/run/dbus/system_bus_socket` finns och att collectorns användare kan öppna den; att köra `systemctl list-units` som den användaren är den snabbaste kontrollen. Root krävs inte. En collector som körs inuti en container ser ingen buss alls om du inte bind-monterar värdens socket, så föredra en inbyggd installation för den här mottagaren.
 - **`systemd`-mottagaren loggar ett skrapfel per enhet, eller collectorn vägrar starta på grund av en okänd metrik** — båda beror på versionsskillnader. v0.142.0 letar efter cgroup-statistik på varje enhet (ett fel per enhet som inte är en `.service`, per skrapning) och kallar sin CPU-metrik `systemd.unit.cpu.time`; v0.143.0 och senare begränsar den uppslagningen till tjänster och döpte om metriken till `systemd.service.cpu.time`. Uppgradera till v0.143.0+ och se till att en eventuell `metrics:`-överskrivning namnger nyckeln som ditt bygge faktiskt har.

--- a/App/FeatureSet/Docs/Content/zh-CN/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/zh-CN/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ sudo mkdir -p /etc/otelcol-contrib
 
 ### Windows
 
-在 Windows 上，请下载上游的 **`otelcol-contrib`** 发布版——它打包了为主机的 **服务** 标签页提供数据的 `windows_service` 接收器（从 **v0.155.0** 起）。在**提升权限的** PowerShell 提示符下：
+在 Windows 上，请下载上游的 **`otelcol-contrib`** 发布版——它打包了为主机的 **服务** 标签页提供数据的 `windows_service` 接收器（从 **v0.155.0** 起）。
+
+**请下载 `contrib` 构件，而不是 core 构件。** 每个发布版都会发布两个 Windows 压缩包，名称仅相差一个词，选错正是这套安装失败的最常见原因：
+
+| 发布构件 | 解压出 | 用这个吗？ |
+| ---- | --- | ----- |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **是**——contrib 发行版 |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | 否——core 构建，缺少下文用到的 Windows 接收器 |
+
+构件名称必须**以 `otelcol-contrib_` 开头**。core 的 `otelcol_` 构建不含 `windowseventlog` 或 `windows_service` 接收器，把 `otelcol.exe` 改名为 `otelcol-contrib.exe` 也不会把它们加进去——那只是把一种启动失败换成另一种（参见[故障排查](#故障排查)）。
+
+在**提升权限的** PowerShell 提示符下，请整块一起执行——每一行都依赖其上方已设置的变量：
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-这会将 `otelcol-contrib.exe` 解压到 `C:\Program Files\otelcol-contrib`。你将在第 2 步中在同一文件夹里创建 `config.yaml`，并在第 3 步中注册一个 Windows 服务。
+请执行整块，而不要从中只摘出一行：URL 由 `$VERSION` 和 `$ARCH` 拼装而成，因此单独粘贴到新会话里的 `Invoke-WebRequest` 会因 `-Uri` 为空而失败，什么也下载不到。把 URL 单独放在 `$url` 一行里是有意为之——若把版本号直接内插到 `Invoke-WebRequest` 的参数中，未设置的变量就会变成一个悄无声息的 404。
+
+这会把 `otelcol-contrib.exe`（**而不是** `otelcol.exe`）解压到 `C:\Program Files\otelcol-contrib`；上面的 `Get-ChildItem` 一行可确认你拿到的是哪一个。你将在第 2 步中在同一文件夹里创建 `config.yaml`，并在第 3 步中注册一个 Windows 服务。
 
 > 更偏好原生安装程序？OpenTelemetry 还在同一个[发布页面](https://github.com/open-telemetry/opentelemetry-collector-releases/releases)上发布了一个已签名的 **`.msi`**（`otelcol-contrib_<version>_windows_x64.msi`），它会为你将 collector 注册为一个 Windows 服务。如果你使用它，请让它指向第 2 步中的 `config.yaml`，并确保该服务以 `LocalSystem` 身份运行，这样 **服务** 标签页才能读取服务控制管理器（Service Control Manager）。
 
@@ -881,6 +900,12 @@ OpenTelemetry Collector 遵循标准的 `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY
   - 确认主机能够访问 `https://oneuptime.com/otlp`（或你的自托管端点）：从同一台机器执行 `curl -v https://oneuptime.com/otlp`。
 - **导出器返回 HTTP 401**——接入令牌无效或已被吊销。从 _项目设置 → 遥测与 APM → 摄取密钥_ 生成一个新令牌。
 - **`Security` Windows 事件日志返回拒绝访问（access denied）**——该服务未以足够的权限运行。在 `LocalSystem` 身份下重新创建它（`sc.exe create` 的默认设置），或为服务账户授予 _Manage auditing and security log_ 用户权限。
+- **Windows 服务启动失败并报 `Error 2: The system cannot find the file specified`**——服务控制管理器（SCM）找不到该服务注册时指向的可执行文件。运行 `sc.exe qc "otelcol-contrib"`，把 `BINARY_PATH_NAME` 与 `C:\Program Files\otelcol-contrib` 中实际存在的文件对照。几乎总是下载了 core 压缩包 `otelcol_<version>_windows_amd64.tar.gz`（它解压出的是 `otelcol.exe`），而第 3 步注册的服务指向 `otelcol-contrib.exe`，后者只存在于 `otelcol-contrib_<version>_...` 压缩包中。请按第 1 步重新下载 `contrib` 构件；**不要**给 `otelcol.exe` 改名，那只会变成下面的 `1064`。另一个原因是 `binPath=` 没加引号：经过 `C:\Program Files` 的路径若未按第 3 步所示精确加引号，就会在空格处被截断。
+- **Windows 服务启动失败并报 `Error 1064: An exception occurred in the service when handling the control request`**——SCM 已经启动了二进制文件，但 collector 在启动过程中退出了。把 `otelcol.exe` 改名为 `otelcol-contrib.exe` 只能让路径对得上，并不会改变二进制文件里的内容：core 构建没有 `windowseventlog` 和 `windows_service` 接收器，因此会拒绝第 2 步的配置，并在服务来得及报告为运行中之前就退出。即使二进制文件正确，未加引号的 `--config` 路径也会导致同样的 `1064`：没有内层引号时，该参数会在 `Program Files` 的空格处被截断，collector 随即因读不到配置文件而退出。请确认你手上到底是什么：
+  - `otelcol-contrib.exe --version` 应输出 `otelcol-contrib version ...`。如果输出的是 `otelcol version ...`，那就是改了名的 core 构建——请按第 1 步重新下载 `contrib` 构件。
+  - `otelcol-contrib.exe components` 应在接收器中列出 `windowseventlog` 和 `windows_service`。不要拿 `hostmetrics` 当判据——core 构建同样带有它，看到它并不能说明什么。配置里引用了、而该命令未列出的任何组件，都会让 collector 在启动时停止。
+  - 在前台运行它，即可看到真正的错误，而不是笼统的 `1064`：`& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`。
+  - 查看 _Event Viewer → Windows Logs → Application_ 中来源为 `otelcol-contrib` 的记录，那里记录着被 SCM 吞掉的启动错误。
 - **`journald` 接收器无法启动**——确保 `journalctl` 在 collector 的 `PATH` 中，并且 `/var/log/journal` 存在（如不存在，请运行 `sudo systemd-tmpfiles --create --prefix /var/log/journal`）。
 - **`systemd` 接收器报告 D-Bus 连接错误**——collector 无法访问系统总线。请确认 `/run/dbus/system_bus_socket` 存在，且 collector 所用的用户能够打开它；以该用户身份运行 `systemctl list-units` 是最快的检查方式。并不需要 root。运行在容器内的 collector 除非你把主机的套接字绑定挂载进去，否则根本看不到总线，因此这个接收器更适合原生安装。
 - **`systemd` 接收器为每个单元记录一条抓取错误，或者 collector 因为一个未知指标而拒绝启动**——两者都是版本不匹配。v0.142.0 会为每一个单元查找 cgroup 统计信息（每次抓取为每个非 `.service` 单元产生一条错误），并把它的 CPU 指标称为 `systemd.unit.cpu.time`；v0.143.0 及以后把这项查找限制在服务上，并将该指标改名为 `systemd.service.cpu.time`。请升级到 v0.143.0+，并确保任何 `metrics:` 覆盖项写的都是你所运行的构建中确实存在的键名。

--- a/App/FeatureSet/Docs/Content/zh-TW/telemetry/host-otel-collector.md
+++ b/App/FeatureSet/Docs/Content/zh-TW/telemetry/host-otel-collector.md
@@ -69,19 +69,38 @@ sudo mkdir -p /etc/otelcol-contrib
 
 ### Windows
 
-在 Windows 上，請下載上游的 **`otelcol-contrib`** 版本 — 它內建了驅動主機 **服務** 分頁的 `windows_service` receiver（自 **v0.155.0** 起）。在**提升權限的** PowerShell 提示字元中：
+在 Windows 上，請下載上游的 **`otelcol-contrib`** 版本 — 它內建了驅動主機 **服務** 分頁的 `windows_service` receiver（自 **v0.155.0** 起）。
+
+**請下載 `contrib` 產出物，而非 core 產出物。** 每個版本都會發佈兩個 Windows 壓縮檔，名稱只差一個詞，挑錯正是這套安裝失敗最常見的原因：
+
+| 版本產出物 | 解壓縮出 | 要用這個嗎？ |
+| ----- | ---- | ------ |
+| `otelcol-contrib_<version>_windows_amd64.tar.gz` | `otelcol-contrib.exe` | **是** — contrib 發行版 |
+| `otelcol_<version>_windows_amd64.tar.gz` | `otelcol.exe` | 否 — core 組建，缺少下方使用的 Windows receiver |
+
+產出物名稱必須**以 `otelcol-contrib_` 開頭**。core 的 `otelcol_` 組建不含 `windowseventlog` 或 `windows_service` receiver，把 `otelcol.exe` 改名為 `otelcol-contrib.exe` 也不會把它們加進去 — 那只是把一種啟動失敗換成另一種（請參閱[疑難排解](#疑難排解)）。
+
+在**提升權限的** PowerShell 提示字元中，請整段一起執行 — 每一行都仰賴其上方已設定的變數：
 
 ```powershell
 $VERSION = "0.156.0"                          # use v0.155.0 or later for the Services tab
+$ARCH    = "amd64"                            # use "arm64" on ARM hosts
 $dest    = "C:\Program Files\otelcol-contrib"
 $tar     = "$env:TEMP\otelcol-contrib.tar.gz"
+
+# Note the "-contrib" in the asset name; otelcol_... is the wrong archive.
+$url = "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_${ARCH}.tar.gz"
+
 New-Item -ItemType Directory -Force -Path $dest | Out-Null
-# amd64; use the _windows_arm64.tar.gz asset on ARM
-Invoke-WebRequest -Uri "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$VERSION/otelcol-contrib_${VERSION}_windows_amd64.tar.gz" -OutFile $tar
+Invoke-WebRequest -Uri $url -OutFile $tar
 tar -xf $tar -C $dest                          # tar.exe ships with Windows 10 1803+ / Server 2019+
+
+Get-ChildItem $dest                            # expect otelcol-contrib.exe, not otelcol.exe
 ```
 
-這會將 `otelcol-contrib.exe` 解壓縮到 `C:\Program Files\otelcol-contrib`。您將在步驟 2 中於同一資料夾建立 `config.yaml`，並在步驟 3 中註冊一個 Windows 服務。
+請執行整段，而不要只從中摘出一行：URL 由 `$VERSION` 與 `$ARCH` 組裝而成，因此單獨貼到新工作階段的 `Invoke-WebRequest` 會因 `-Uri` 為空而失敗，什麼也下載不到。把 URL 單獨放在 `$url` 一行是刻意為之 — 若把版本號直接內插到 `Invoke-WebRequest` 的參數中，未設定的變數就會變成一個無聲的 404。
+
+這會將 `otelcol-contrib.exe`（**而非** `otelcol.exe`）解壓縮到 `C:\Program Files\otelcol-contrib`；上方的 `Get-ChildItem` 一行可確認您拿到的是哪一個。您將在步驟 2 中於同一資料夾建立 `config.yaml`，並在步驟 3 中註冊一個 Windows 服務。
 
 > 偏好使用原生安裝程式？OpenTelemetry 也在同一個 [releases 頁面](https://github.com/open-telemetry/opentelemetry-collector-releases/releases) 上發佈一個已簽署的 **`.msi`**（`otelcol-contrib_<version>_windows_x64.msi`），它會為您將 collector 註冊為 Windows 服務。如果您使用它，請將它指向步驟 2 的 `config.yaml`，並確保該服務以 `LocalSystem` 執行，讓 **服務** 分頁能夠讀取 Service Control Manager。
 
@@ -881,6 +900,12 @@ OpenTelemetry Collector 遵循標準的 `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY
   - 確認主機可以連線到 `https://oneuptime.com/otlp`（或您自架的端點）：從同一台機器執行 `curl -v https://oneuptime.com/otlp`。
 - **exporter 傳回 HTTP 401** — 擷取權杖無效或已撤銷。從 _專案設定 → 遙測與 APM → 擷取金鑰_ 產生一個新的。
 - **`Security` Windows 事件記錄傳回 access denied** — 該服務未以足夠的權限執行。在 `LocalSystem` 下重新建立它（`sc.exe create` 的預設值），或授予服務帳戶 _Manage auditing and security log_ 使用者權限。
+- **Windows 服務啟動失敗並回報 `Error 2: The system cannot find the file specified`** — 服務控制管理員（SCM）找不到該服務註冊時所指向的可執行檔。執行 `sc.exe qc "otelcol-contrib"`，將 `BINARY_PATH_NAME` 與 `C:\Program Files\otelcol-contrib` 中實際存在的檔案對照。幾乎都是下載了 core 壓縮檔 `otelcol_<version>_windows_amd64.tar.gz`（它解壓縮出的是 `otelcol.exe`），而步驟 3 註冊的服務指向 `otelcol-contrib.exe`，後者只存在於 `otelcol-contrib_<version>_...` 壓縮檔中。請依步驟 1 重新下載 `contrib` 產出物；**不要**將 `otelcol.exe` 改名，那只會變成下面的 `1064`。另一個原因是 `binPath=` 未加引號：經過 `C:\Program Files` 的路徑若未依步驟 3 所示精確加上引號，就會在空格處被切斷。
+- **Windows 服務啟動失敗並回報 `Error 1064: An exception occurred in the service when handling the control request`** — SCM 已啟動該二進位檔，但 collector 在啟動過程中結束了。把 `otelcol.exe` 改名為 `otelcol-contrib.exe` 只能讓路徑對得上，並不會改變二進位檔裡的內容：core 組建沒有 `windowseventlog` 與 `windows_service` receiver，因此會拒絕步驟 2 的設定，並在服務來得及回報為執行中之前就結束。即使二進位檔正確，未加引號的 `--config` 路徑也會造成同樣的 `1064`：沒有內層引號時，該引數會在 `Program Files` 的空格處被切斷，collector 隨即因讀不到設定檔而結束。請確認您手上到底是什麼：
+  - `otelcol-contrib.exe --version` 應輸出 `otelcol-contrib version ...`。若輸出的是 `otelcol version ...`，那就是改了名的 core 組建 — 請依步驟 1 重新下載 `contrib` 產出物。
+  - `otelcol-contrib.exe components` 應在 receiver 中列出 `windowseventlog` 與 `windows_service`。不要拿 `hostmetrics` 當判準 — core 組建同樣有它，看到它並不能說明什麼。設定中有引用、但此指令未列出的任何元件，都會讓 collector 在啟動時停止。
+  - 在前景執行它，即可看到真正的錯誤，而不是籠統的 `1064`：`& "C:\Program Files\otelcol-contrib\otelcol-contrib.exe" --config="C:\Program Files\otelcol-contrib\config.yaml"`。
+  - 查看 _Event Viewer → Windows Logs → Application_ 中來源為 `otelcol-contrib` 的記錄，那裡記錄著被 SCM 吞掉的啟動錯誤。
 - **`journald` receiver 無法啟動** — 確保 `journalctl` 在 collector 的 `PATH` 上，且 `/var/log/journal` 存在（若不存在，請執行 `sudo systemd-tmpfiles --create --prefix /var/log/journal`）。
 - **`systemd` receiver 回報 D-Bus 連線錯誤** — collector 無法存取 system bus。請確認 `/run/dbus/system_bus_socket` 存在，且 collector 的使用者能夠開啟它；以該使用者身分執行 `systemctl list-units` 是最快的檢查方式。並不需要 root。在容器內執行的 collector 除非您將主機的 socket 以 bind mount 掛載進去，否則完全看不到任何 bus，因此此 receiver 建議採用原生安裝。
 - **`systemd` receiver 為每個 unit 記錄一則抓取錯誤，或 collector 因未知的指標而拒絕啟動** — 兩者都是版本落差所致。v0.142.0 會對每一個 unit 尋找 cgroup 統計資料（每次抓取都會為每個非 `.service` 的 unit 產生一則錯誤），並將它的 CPU 指標稱為 `systemd.unit.cpu.time`；v0.143.0 及之後的版本已將該查詢限制在服務上，並將該指標更名為 `systemd.service.cpu.time`。請升級到 v0.143.0+，並確保任何 `metrics:` 覆寫所指定的鍵確實存在於您執行的建置中。


### PR DESCRIPTION
### Title of this pull request?

docs(telemetry): troubleshoot Windows collector service errors 2 and 1064

### Small Description?

From a real customer case (Whataburger/Smartbridge). They downloaded the **core** `otelcol_0.159.0_windows_amd64.tar.gz` instead of the **contrib** archive and hit two Windows service failures in sequence:

1. The core archive unpacks `otelcol.exe`, but Step 3's `sc.exe create` registers the service against `otelcol-contrib.exe` — so the service failed with **`Error 2: The system cannot find the file specified`**.
2. They renamed `otelcol.exe` to `otelcol-contrib.exe`. The path resolved, but the core build has no `windowseventlog` or `windows_service` receiver, so the collector exited during startup and Windows reported **`Error 1064: An exception occurred in the service when handling the control request`**.

Separately, a copy-pasted `Invoke-WebRequest` line failed because `$VERSION` was never set in that session.

**What changed** in `App/FeatureSet/Docs/Content/en/telemetry/host-otel-collector.md`:

- **Two new Troubleshooting entries**, one per error, with diagnostics that actually discriminate: `sc.exe qc "otelcol-contrib"` → `BINARY_PATH_NAME`, `otelcol-contrib.exe --version`, `otelcol-contrib.exe components`, a foreground run to surface the real error behind the generic 1064, and Event Viewer → Application. Both entries also name unquoted paths through `C:\Program Files` as a second cause.
- **Step 1 → Windows** now makes contrib-vs-core impossible to miss: a table of the two release assets and the binary each unpacks, plus the rule that the asset name must start with `otelcol-contrib_`.
- **Copy-paste-safe PowerShell**: the URL is built into `$url`, `$ARCH` replaces a comment, and a trailing `Get-ChildItem` lets the user confirm which binary they actually got.

Mirrored into **all 15 translated locale copies**. These files are genuine translations (prose translated, code blocks left in English), so the new prose was translated per locale rather than pasted in English, matching each file's existing glossary, step-numbering word, and typography conventions.

**Reviewer notes:**

- `hostmetrics` is deliberately **not** listed among the receivers the core build lacks — the core distribution does bundle `hostmetricsreceiver` (verified against `distributions/otelcol/manifest.yaml` at v0.159.0). The `components` check calls this out explicitly, because a renamed core binary listing `hostmetrics` would otherwise read as a false all-clear in exactly the failing case.
- The trailing `--config` note is folded into its parent bullet rather than left as an indented paragraph. A blank-line-separated continuation flips the whole Troubleshooting list from tight to loose under the repo's own renderer (`marked` 12.0.2 via `Common/Server/Types/Markdown.ts`), which would have restyled 9 pre-existing bullets. Verified `<li><p>` count is 0 in all 16 files, matching `master`.
- The 15 localized `#anchor` cross-links were checked to resolve against each file's own translated `## Troubleshooting` heading.
- `no/telemetry/host-otel-collector.md` is ASCII-transliterated Norwegian (3 diacritics in 895 lines). The new text follows that existing convention for internal consistency; **the transliteration itself is a pre-existing issue worth a separate pass.**

**Two adjacent findings left out of scope**, both touching prose this PR didn't otherwise modify — happy to fold in if preferred:

1. The existing `### Windows Services (metrics)` section attributes `'receivers' unknown type: "windows_service"` solely to running a pre-v0.155.0 release. A core-build user on a current release hits the same string, so "install a current release" is a dead end for them.
2. Step 3 has no pointer back to the two new entries, though `sc.exe start` is where both errors surface.

### Pull Request Checklist:

- [ ] Please make sure all jobs pass before requesting a review.
- [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). — n/a, no tracking issue
- [x] Have you lint your code locally before submission? — markdown structure, fenced-block balance, table well-formedness, anchor resolution and list rendering verified across all 16 files
- [x] Did you write tests where appropriate? — n/a, documentation only

### Related Issue?

None — this came from a customer support case, not a filed issue.

### Screenshots (if appropriate):

n/a — text-only documentation change.
