### PR TITLE
feat(monitor): default incoming monitors to body-content criteria

### DIFF
--- a/App/FeatureSet/Docs/Content/en/monitor/incoming-email-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/incoming-email-monitor.md
@@ -36,6 +36,21 @@ For example: `monitor-abc123def456@inbound.yourdomain.com`
 
 You can copy this address from the monitor details page and configure your external systems to send emails to it.
 
+## What you get out of the box
+
+A new Incoming Email Monitor is created with two criteria that read the email body:
+
+| Criteria | Filter Type | Filter Condition | Value   | Effect                                       |
+| -------- | ----------- | ---------------- | ------- | -------------------------------------------- |
+| Offline  | Email Body  | Contains         | `error` | Marks the monitor offline, opens an incident |
+| Online   | Email Body  | Not Contains     | `error` | Marks the monitor online                     |
+
+This suits the common case where a job or a third-party tool emails its own result: a message whose body mentions `error` takes the monitor down, and the next message without it brings the monitor back up. Body matching is case-insensitive, so `Error` and `ERROR` match too.
+
+Change the value to whatever your sender actually writes (`FAILED`, `exit code 1`, and so on).
+
+These defaults are **not** a dead-man's switch: nothing here fires when mail stops arriving. Criteria that only read the subject, sender, body, or recipient are evaluated when an email lands and at no other time. If you want to be alerted on silence, add an **Email Received** / **Not Received In Minutes** criteria — see Example 3 below.
+
 ## Available Filter Types
 
 You can create criteria based on the following email fields:

--- a/App/FeatureSet/Docs/Content/en/monitor/incoming-request-monitor.md
+++ b/App/FeatureSet/Docs/Content/en/monitor/incoming-request-monitor.md
@@ -90,6 +90,21 @@ requests.get('https://oneuptime.com/heartbeat/YOUR_SECRET_KEY')
 
 You can configure criteria to determine when your service is considered online, degraded, or offline. Each criteria filter has a **Filter Type** (what to look at), a **Filter Condition** (how to compare it), and a **Value**.
 
+### What you get out of the box
+
+A new Incoming Request monitor is created with two criteria that read the request body:
+
+| Criteria | Filter Type  | Filter Condition | Value   | Effect                                     |
+| -------- | ------------ | ---------------- | ------- | ------------------------------------------ |
+| Offline  | Request Body | Contains         | `error` | Marks the monitor offline, opens an incident |
+| Online   | Request Body | Not Contains     | `error` | Marks the monitor online                   |
+
+This suits the common case where the sender reports its own health in the payload: a request whose body mentions `error` takes the monitor down, and the next request without it brings the monitor back up. A request with no body at all counts as "does not contain `error`", so a plain heartbeat ping keeps the monitor online.
+
+Change the value to whatever your sender actually emits (`"status":"firing"`, `FAILED`, and so on) — the match is a case-sensitive substring test.
+
+These defaults are **not** a dead-man's switch: nothing here fires when requests stop arriving. If you want to be alerted on silence, add an **Incoming Request** / **Not Recieved In Minutes** criteria as described below.
+
 ### Available Filter Types
 
 | Filter Type           | Checks                                                 | Notes                                                                                        |
@@ -119,7 +134,7 @@ Object bodies are compared as compact JSON with no spaces, so a **Request Body**
 
 ### Example Criteria
 
-#### Mark as offline if no heartbeat in 10 minutes
+#### Mark as offline if no heartbeat in 10 minutes (a dead-man's switch)
 
 - **Filter Type**: Incoming Request
 - **Filter Condition**: Not Recieved In Minutes

--- a/App/Tests/Dashboard/IncomingMonitorDefaultCriteriaForm.test.ts
+++ b/App/Tests/Dashboard/IncomingMonitorDefaultCriteriaForm.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "@jest/globals";
+import DropdownUtil from "Common/UI/Utils/Dropdown";
+import { DropdownOption } from "Common/UI/Components/Dropdown/Dropdown";
+import {
+  CheckOn,
+  CriteriaFilter,
+  FilterType,
+} from "Common/Types/Monitor/CriteriaFilter";
+import MonitorCriteriaInstance from "Common/Types/Monitor/MonitorCriteriaInstance";
+import MonitorType from "Common/Types/Monitor/MonitorType";
+import ObjectID from "Common/Types/ObjectID";
+import CriteriaFilterUtil from "../../FeatureSet/Dashboard/src/Utils/Form/Monitor/CriteriaFilter";
+
+/*
+ * The criteria form only renders the CheckOn / FilterType pairs it whitelists
+ * per monitor type. A default criteria built from a pair the form does not
+ * offer would show up as a blank dropdown the moment a user opened the
+ * monitor - so the Incoming Request / Incoming Email defaults ("body contains
+ * error" / "body does not contain error") have to be selectable options.
+ */
+
+const KEYWORD: string =
+  MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD;
+
+const ONLINE_STATUS_ID: ObjectID = new ObjectID("100000000000000000000011");
+const OFFLINE_STATUS_ID: ObjectID = new ObjectID("100000000000000000000012");
+const INCIDENT_SEVERITY_ID: ObjectID = new ObjectID("100000000000000000000013");
+const ALERT_SEVERITY_ID: ObjectID = new ObjectID("100000000000000000000014");
+
+interface IncomingMonitorCase {
+  label: string;
+  monitorType: MonitorType;
+  bodyCheckOn: CheckOn;
+}
+
+const CASES: Array<IncomingMonitorCase> = [
+  {
+    label: "Incoming Request",
+    monitorType: MonitorType.IncomingRequest,
+    bodyCheckOn: CheckOn.RequestBody,
+  },
+  {
+    label: "Incoming Email",
+    monitorType: MonitorType.IncomingEmail,
+    bodyCheckOn: CheckOn.EmailBody,
+  },
+];
+
+function defaultFilters(
+  testCase: IncomingMonitorCase,
+): Array<{ label: string; filter: CriteriaFilter }> {
+  const online: MonitorCriteriaInstance | null =
+    MonitorCriteriaInstance.getDefaultOnlineMonitorCriteriaInstance({
+      monitorType: testCase.monitorType,
+      monitorStatusId: ONLINE_STATUS_ID,
+      monitorName: "Payments API",
+    });
+
+  const offline: MonitorCriteriaInstance =
+    MonitorCriteriaInstance.getDefaultOfflineMonitorCriteriaInstance({
+      monitorType: testCase.monitorType,
+      monitorStatusId: OFFLINE_STATUS_ID,
+      incidentSeverityId: INCIDENT_SEVERITY_ID,
+      alertSeverityId: ALERT_SEVERITY_ID,
+      monitorName: "Payments API",
+    });
+
+  return [
+    { label: "online", filter: online!.data!.filters[0]! },
+    { label: "offline", filter: offline.data!.filters[0]! },
+  ];
+}
+
+function optionValues(options: Array<DropdownOption>): Array<string> {
+  return options.map((option: DropdownOption) => {
+    return option.value as string;
+  });
+}
+
+describe("Incoming monitor default criteria are renderable in the criteria form", () => {
+  describe.each(CASES)(
+    "$label monitor",
+    (testCase: IncomingMonitorCase): void => {
+      test("the body CheckOn is offered for this monitor type", () => {
+        const options: Array<string> = optionValues(
+          CriteriaFilterUtil.getCheckOnOptionsByMonitorType(
+            testCase.monitorType,
+          ),
+        );
+
+        expect(options).toContain(testCase.bodyCheckOn);
+      });
+
+      test.each(["online", "offline"])(
+        "the %s default filter's CheckOn and FilterType are both selectable",
+        (which: string) => {
+          const entry: { label: string; filter: CriteriaFilter } | undefined =
+            defaultFilters(testCase).find(
+              (item: { label: string; filter: CriteriaFilter }) => {
+                return item.label === which;
+              },
+            );
+
+          expect(entry).toBeDefined();
+
+          const filter: CriteriaFilter = entry!.filter;
+
+          expect(
+            optionValues(
+              CriteriaFilterUtil.getCheckOnOptionsByMonitorType(
+                testCase.monitorType,
+              ),
+            ),
+          ).toContain(filter.checkOn);
+
+          expect(
+            optionValues(
+              CriteriaFilterUtil.getFilterTypeOptionsByCheckOn(filter.checkOn),
+            ),
+          ).toContain(filter.filterType as string);
+        },
+      );
+
+      test("the body filter takes a free-text value rather than a dropdown", () => {
+        expect(
+          CriteriaFilterUtil.isDropdownValueField({
+            checkOn: testCase.bodyCheckOn,
+          }),
+        ).toBe(false);
+      });
+
+      test("the defaults render as readable text in the criteria summary", () => {
+        for (const entry of defaultFilters(testCase)) {
+          const text: string = CriteriaFilterUtil.translateFilterToText(
+            entry.filter,
+          );
+
+          expect(text).toContain(KEYWORD);
+          expect(text.length).toBeGreaterThan(0);
+        }
+      });
+    },
+  );
+
+  test("DropdownUtil is wired the way the form expects (guards the option shape used above)", () => {
+    const options: Array<DropdownOption> =
+      DropdownUtil.getDropdownOptionsFromEnum(FilterType);
+
+    expect(optionValues(options)).toContain(FilterType.Contains);
+    expect(optionValues(options)).toContain(FilterType.NotContains);
+  });
+});

--- a/App/Tests/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus.test.ts
+++ b/App/Tests/Workers/Jobs/IncomingEmailMonitor/CheckOnlineStatus.test.ts
@@ -4,6 +4,7 @@ import OneUptimeDate from "Common/Types/Date";
 import { CheckOn } from "Common/Types/Monitor/CriteriaFilter";
 import IncomingEmailMonitorRequest from "Common/Types/Monitor/IncomingEmailMonitor/IncomingEmailMonitorRequest";
 import MonitorSteps from "Common/Types/Monitor/MonitorSteps";
+import MonitorCriteriaInstance from "Common/Types/Monitor/MonitorCriteriaInstance";
 import MonitorType from "Common/Types/Monitor/MonitorType";
 import ObjectID from "Common/Types/ObjectID";
 
@@ -392,6 +393,38 @@ describe("IncomingEmailMonitor:CheckOnlineStatus worker", () => {
         makeMonitor({
           id: MONITOR_A_ID,
           monitorSteps: stepsWithCheckOn(CheckOn.IncomingRequest),
+        }),
+      ])
+      .mockResolvedValueOnce([]);
+
+    await runWorkerTick();
+
+    expect(monitorService.updateColumnsByIdWithoutHooks).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(monitorResourceMock).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The out-of-the-box criteria for this monitor type check the EMAIL BODY,
+   * not the arrival clock, so a monitor left on its defaults has nothing for
+   * this cron to re-evaluate: it is stamped and skipped, and its status is
+   * decided only when mail actually lands. Users who want a missing-email
+   * alarm add a CheckOn.EmailReceivedAt criteria by hand, which the test
+   * above covers.
+   */
+  test("a monitor on the default body criteria is stamped but never evaluated", async () => {
+    monitorService.findAllBy
+      .mockResolvedValueOnce([
+        makeMonitor({
+          id: MONITOR_A_ID,
+          monitorSteps: stepsWithCheckOn(
+            MonitorCriteriaInstance.getDefaultOnlineMonitorCriteriaInstance({
+              monitorType: MonitorType.IncomingEmail,
+              monitorStatusId: new ObjectID("online-status"),
+              monitorName: "Nightly Backup",
+            })!.data!.filters[0]!.checkOn,
+          ),
         }),
       ])
       .mockResolvedValueOnce([]);

--- a/App/Tests/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat.test.ts
+++ b/App/Tests/Workers/Jobs/IncomingRequestMonitor/CheckHeartbeat.test.ts
@@ -4,6 +4,7 @@ import OneUptimeDate from "Common/Types/Date";
 import { CheckOn } from "Common/Types/Monitor/CriteriaFilter";
 import IncomingMonitorRequest from "Common/Types/Monitor/IncomingMonitor/IncomingMonitorRequest";
 import MonitorSteps from "Common/Types/Monitor/MonitorSteps";
+import MonitorCriteriaInstance from "Common/Types/Monitor/MonitorCriteriaInstance";
 import MonitorType from "Common/Types/Monitor/MonitorType";
 import ObjectID from "Common/Types/ObjectID";
 
@@ -388,6 +389,38 @@ describe("IncomingRequestMonitor:CheckHeartbeat worker", () => {
         makeMonitor({
           id: MONITOR_A_ID,
           monitorSteps: stepsWithCheckOn(CheckOn.ResponseTime),
+        }),
+      ])
+      .mockResolvedValueOnce([]);
+
+    await runWorkerTick();
+
+    expect(monitorService.updateColumnsByIdWithoutHooks).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(monitorResourceMock).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The out-of-the-box criteria for this monitor type check the REQUEST BODY,
+   * not the arrival clock, so a monitor left on its defaults has nothing for
+   * this cron to re-evaluate: it is stamped and skipped, and its status is
+   * decided only when a request actually lands. Users who want a missing-
+   * heartbeat alarm add a CheckOn.IncomingRequest criteria by hand, which the
+   * test above covers.
+   */
+  test("a monitor on the default body criteria is stamped but never evaluated", async () => {
+    monitorService.findAllBy
+      .mockResolvedValueOnce([
+        makeMonitor({
+          id: MONITOR_A_ID,
+          monitorSteps: stepsWithCheckOn(
+            MonitorCriteriaInstance.getDefaultOnlineMonitorCriteriaInstance({
+              monitorType: MonitorType.IncomingRequest,
+              monitorStatusId: new ObjectID("online-status"),
+              monitorName: "Payments API",
+            })!.data!.filters[0]!.checkOn,
+          ),
         }),
       ])
       .mockResolvedValueOnce([]);

--- a/Common/Server/Utils/Monitor/Criteria/IncomingRequestCriteria.ts
+++ b/Common/Server/Utils/Monitor/Criteria/IncomingRequestCriteria.ts
@@ -160,36 +160,33 @@ export default class IncomingRequestCriteria {
     }
 
     if (input.criteriaFilter.checkOn === CheckOn.RequestBody) {
-      let responseBody: string | JSONObject | undefined = (
+      let requestBody: string | JSONObject | undefined = (
         input.dataToProcess as IncomingMonitorRequest
       ).requestBody;
 
-      if (responseBody && typeof responseBody === Typeof.Object) {
-        responseBody = JSON.stringify(responseBody);
+      if (requestBody && typeof requestBody === Typeof.Object) {
+        requestBody = JSON.stringify(requestBody);
       }
 
-      if (!responseBody) {
-        return null;
-      }
+      /*
+       * A request that carried no body is an empty body, not an unknown one.
+       * Normalising to "" (the same thing IncomingEmailCriteria does for the
+       * email fields) is what lets a "Not Contains" filter match a bodiless
+       * heartbeat ping - the default online criteria for this monitor type.
+       * "Contains" is unaffected: "" contains nothing.
+       */
+      const body: string = (requestBody as string | undefined) || "";
 
       // contains
       if (input.criteriaFilter.filterType === FilterType.Contains) {
-        if (
-          value &&
-          responseBody &&
-          (responseBody as string).includes(value as string)
-        ) {
+        if (value && body.includes(value as string)) {
           return `Request body contains ${value}.`;
         }
         return null;
       }
 
       if (input.criteriaFilter.filterType === FilterType.NotContains) {
-        if (
-          value &&
-          responseBody &&
-          !(responseBody as string).includes(value as string)
-        ) {
+        if (value && !body.includes(value as string)) {
           return `Request body does not contain ${value}.`;
         }
         return null;

--- a/Common/Tests/Server/Utils/Monitor/Criteria/IncomingEmailBodyCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/IncomingEmailBodyCriteria.test.ts
@@ -1,0 +1,243 @@
+import IncomingEmailCriteria from "../../../../../Server/Utils/Monitor/Criteria/IncomingEmailCriteria";
+import DataToProcess from "../../../../../Server/Utils/Monitor/DataToProcess";
+import OneUptimeDate from "../../../../../Types/Date";
+import {
+  CheckOn,
+  CriteriaFilter,
+  FilterType,
+} from "../../../../../Types/Monitor/CriteriaFilter";
+import IncomingEmailMonitorRequest from "../../../../../Types/Monitor/IncomingEmailMonitor/IncomingEmailMonitorRequest";
+import MonitorCriteriaInstance from "../../../../../Types/Monitor/MonitorCriteriaInstance";
+import ObjectID from "../../../../../Types/ObjectID";
+
+/*
+ * CheckOn.EmailBody is what the Incoming Email monitor's default criteria
+ * now run on: "body contains error" takes the monitor offline, "body does
+ * not contain error" brings it back online. These tests cover that pair,
+ * the case-insensitive matching the email evaluator does, and the
+ * onlyCheckForIncomingEmailReceivedAt guard — the flag the every-30-seconds
+ * cron sets, which must stop the cron from re-judging a stale email body.
+ */
+
+const KEYWORD: string =
+  MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD;
+
+function buildEmail(input: {
+  emailBody: string;
+  onlyCheckForIncomingEmailReceivedAt?: boolean | undefined;
+  minutesAgo?: number | undefined;
+}): DataToProcess {
+  const checkedAt: Date = OneUptimeDate.getCurrentDate();
+
+  const email: IncomingEmailMonitorRequest = {
+    projectId: ObjectID.generate(),
+    monitorId: ObjectID.generate(),
+    emailFrom: "alerts@example.com",
+    emailTo: "monitor@inbound.oneuptime.com",
+    emailSubject: "Nightly job report",
+    emailBody: input.emailBody,
+    emailReceivedAt: OneUptimeDate.addRemoveMinutes(
+      checkedAt,
+      -(input.minutesAgo ?? 0),
+    ),
+    checkedAt: checkedAt,
+    onlyCheckForIncomingEmailReceivedAt:
+      input.onlyCheckForIncomingEmailReceivedAt,
+  };
+
+  return email as DataToProcess;
+}
+
+function evaluate(
+  emailBody: string,
+  criteriaFilter: CriteriaFilter,
+  onlyCheckForIncomingEmailReceivedAt?: boolean,
+): Promise<string | null> {
+  return IncomingEmailCriteria.isMonitorInstanceCriteriaFilterMet({
+    dataToProcess: buildEmail({
+      emailBody,
+      onlyCheckForIncomingEmailReceivedAt,
+    }),
+    criteriaFilter,
+  });
+}
+
+const CONTAINS_ERROR: CriteriaFilter = {
+  checkOn: CheckOn.EmailBody,
+  filterType: FilterType.Contains,
+  value: KEYWORD,
+};
+
+const NOT_CONTAINS_ERROR: CriteriaFilter = {
+  checkOn: CheckOn.EmailBody,
+  filterType: FilterType.NotContains,
+  value: KEYWORD,
+};
+
+describe("IncomingEmailCriteria - CheckOn.EmailBody", () => {
+  describe("Contains (the default offline criteria)", () => {
+    test("a body reporting an error matches", async () => {
+      const result: string | null = await evaluate(
+        "The nightly backup finished with an error.",
+        CONTAINS_ERROR,
+      );
+
+      expect(result).toBeTruthy();
+      expect(result).toContain("Email body contains");
+      expect(result).toContain(KEYWORD);
+    });
+
+    test("a healthy body does not match", async () => {
+      expect(
+        await evaluate("The nightly backup finished cleanly.", CONTAINS_ERROR),
+      ).toBeNull();
+    });
+
+    test("matching is case insensitive", async () => {
+      expect(await evaluate("ERROR: disk full", CONTAINS_ERROR)).toBeTruthy();
+      expect(await evaluate("Error: disk full", CONTAINS_ERROR)).toBeTruthy();
+    });
+
+    test("an empty body does not match", async () => {
+      expect(await evaluate("", CONTAINS_ERROR)).toBeNull();
+    });
+  });
+
+  describe("Not Contains (the default online criteria)", () => {
+    test("a healthy body matches", async () => {
+      const result: string | null = await evaluate(
+        "All checks passed.",
+        NOT_CONTAINS_ERROR,
+      );
+
+      expect(result).toBeTruthy();
+      expect(result).toContain("Email body does not contain");
+      expect(result).toContain(KEYWORD);
+    });
+
+    test("a body reporting an error does not match", async () => {
+      expect(
+        await evaluate("Job failed with error 500", NOT_CONTAINS_ERROR),
+      ).toBeNull();
+    });
+
+    test("a differently-cased error still blocks the online criteria", async () => {
+      expect(await evaluate("FATAL ERROR", NOT_CONTAINS_ERROR)).toBeNull();
+    });
+
+    test("an empty body matches", async () => {
+      expect(await evaluate("", NOT_CONTAINS_ERROR)).toBeTruthy();
+    });
+  });
+
+  describe("Contains and Not Contains are mutually exclusive", () => {
+    const bodies: Array<string> = [
+      "error",
+      "ERROR",
+      "all good",
+      "",
+      "there was an Error in stage 2",
+    ];
+
+    test.each(bodies)(
+      "exactly one of the two default filters matches body %p",
+      async (body: string) => {
+        const contains: boolean = Boolean(await evaluate(body, CONTAINS_ERROR));
+        const notContains: boolean = Boolean(
+          await evaluate(body, NOT_CONTAINS_ERROR),
+        );
+
+        expect(contains).not.toBe(notContains);
+      },
+    );
+  });
+
+  /*
+   * CheckOnlineStatus runs every 30 seconds and replays the LAST email that
+   * arrived, with onlyCheckForIncomingEmailReceivedAt set. Body checks are
+   * skipped on that path, so the cron cannot re-open an incident from an old
+   * email — and, since the defaults no longer include an Email Received
+   * filter, a monitor on the defaults is only judged when mail actually lands.
+   */
+  describe("onlyCheckForIncomingEmailReceivedAt guard", () => {
+    test("the body Contains filter is skipped on the cron path", async () => {
+      expect(
+        await evaluate("ERROR: disk full", CONTAINS_ERROR, true),
+      ).toBeNull();
+    });
+
+    test("the body Not Contains filter is skipped on the cron path", async () => {
+      expect(await evaluate("all good", NOT_CONTAINS_ERROR, true)).toBeNull();
+    });
+
+    test("the same body is evaluated when the email actually arrives", async () => {
+      expect(
+        await evaluate("ERROR: disk full", CONTAINS_ERROR, false),
+      ).toBeTruthy();
+    });
+  });
+
+  describe("filters that cannot decide", () => {
+    test("a Contains filter with no value does not match", async () => {
+      expect(
+        await evaluate("error", {
+          checkOn: CheckOn.EmailBody,
+          filterType: FilterType.Contains,
+          value: undefined,
+        }),
+      ).toBeNull();
+    });
+
+    test("a Not Contains filter with no value does not match", async () => {
+      expect(
+        await evaluate("all good", {
+          checkOn: CheckOn.EmailBody,
+          filterType: FilterType.NotContains,
+          value: undefined,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  /*
+   * The arrival-clock check is no longer part of the defaults, but users can
+   * still add it by hand, so it must keep working alongside the body check.
+   */
+  describe("CheckOn.EmailReceivedAt still works when added manually", () => {
+    test("Not Recieved In Minutes fires once the window has elapsed", async () => {
+      const result: string | null =
+        await IncomingEmailCriteria.isMonitorInstanceCriteriaFilterMet({
+          dataToProcess: buildEmail({
+            emailBody: "all good",
+            minutesAgo: 45,
+            onlyCheckForIncomingEmailReceivedAt: true,
+          }),
+          criteriaFilter: {
+            checkOn: CheckOn.EmailReceivedAt,
+            filterType: FilterType.NotRecievedInMinutes,
+            value: 30,
+          },
+        });
+
+      expect(result).toBeTruthy();
+    });
+
+    test("Recieved In Minutes fires while the window is still open", async () => {
+      const result: string | null =
+        await IncomingEmailCriteria.isMonitorInstanceCriteriaFilterMet({
+          dataToProcess: buildEmail({
+            emailBody: "all good",
+            minutesAgo: 5,
+            onlyCheckForIncomingEmailReceivedAt: true,
+          }),
+          criteriaFilter: {
+            checkOn: CheckOn.EmailReceivedAt,
+            filterType: FilterType.RecievedInMinutes,
+            value: 30,
+          },
+        });
+
+      expect(result).toBeTruthy();
+    });
+  });
+});

--- a/Common/Tests/Server/Utils/Monitor/Criteria/IncomingRequestBodyCriteria.test.ts
+++ b/Common/Tests/Server/Utils/Monitor/Criteria/IncomingRequestBodyCriteria.test.ts
@@ -1,0 +1,278 @@
+import IncomingRequestCriteria from "../../../../../Server/Utils/Monitor/Criteria/IncomingRequestCriteria";
+import DataToProcess from "../../../../../Server/Utils/Monitor/DataToProcess";
+import OneUptimeDate from "../../../../../Types/Date";
+import { JSONObject } from "../../../../../Types/JSON";
+import {
+  CheckOn,
+  CriteriaFilter,
+  FilterType,
+} from "../../../../../Types/Monitor/CriteriaFilter";
+import IncomingMonitorRequest from "../../../../../Types/Monitor/IncomingMonitor/IncomingMonitorRequest";
+import MonitorCriteriaInstance from "../../../../../Types/Monitor/MonitorCriteriaInstance";
+import ObjectID from "../../../../../Types/ObjectID";
+
+/*
+ * CheckOn.RequestBody is what the Incoming Request monitor's default
+ * criteria now run on: "body contains error" takes the monitor offline,
+ * "body does not contain error" brings it back online. These tests cover
+ * that pair against every body shape the ingest endpoint can hand over —
+ * JSON objects (stringified before matching), plain strings, and the
+ * bodiless heartbeat ping, which must read as "no error present" rather
+ * than as "unknown".
+ */
+
+const KEYWORD: string =
+  MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD;
+
+function buildRequest(
+  requestBody: string | JSONObject | undefined,
+): DataToProcess {
+  const now: Date = OneUptimeDate.getCurrentDate();
+
+  const request: IncomingMonitorRequest = {
+    projectId: ObjectID.generate(),
+    monitorId: ObjectID.generate(),
+    requestBody: requestBody,
+    requestHeaders: {},
+    incomingRequestReceivedAt: now,
+    checkedAt: now,
+  };
+
+  return request as DataToProcess;
+}
+
+function evaluate(
+  requestBody: string | JSONObject | undefined,
+  criteriaFilter: CriteriaFilter,
+): Promise<string | null> {
+  return IncomingRequestCriteria.isMonitorInstanceCriteriaFilterMet({
+    dataToProcess: buildRequest(requestBody),
+    criteriaFilter,
+  });
+}
+
+const CONTAINS_ERROR: CriteriaFilter = {
+  checkOn: CheckOn.RequestBody,
+  filterType: FilterType.Contains,
+  value: KEYWORD,
+};
+
+const NOT_CONTAINS_ERROR: CriteriaFilter = {
+  checkOn: CheckOn.RequestBody,
+  filterType: FilterType.NotContains,
+  value: KEYWORD,
+};
+
+describe("IncomingRequestCriteria - CheckOn.RequestBody", () => {
+  describe("Contains (the default offline criteria)", () => {
+    test("a JSON body reporting an error matches", async () => {
+      const result: string | null = await evaluate(
+        { status: "error", detail: "disk full" },
+        CONTAINS_ERROR,
+      );
+
+      expect(result).toBeTruthy();
+      expect(result).toContain("Request body contains");
+      expect(result).toContain(KEYWORD);
+    });
+
+    test("a healthy JSON body does not match", async () => {
+      expect(
+        await evaluate({ status: "ok", detail: "all good" }, CONTAINS_ERROR),
+      ).toBeNull();
+    });
+
+    test("a plain-string body reporting an error matches", async () => {
+      expect(
+        await evaluate("error: queue backed up", CONTAINS_ERROR),
+      ).toBeTruthy();
+    });
+
+    test("a body carrying the keyword inside a longer word still matches (substring semantics)", async () => {
+      expect(await evaluate({ code: "errored" }, CONTAINS_ERROR)).toBeTruthy();
+    });
+
+    test("an empty object body does not match", async () => {
+      expect(await evaluate({}, CONTAINS_ERROR)).toBeNull();
+    });
+
+    test("an empty string body does not match", async () => {
+      expect(await evaluate("", CONTAINS_ERROR)).toBeNull();
+    });
+
+    test("a missing body does not match", async () => {
+      expect(await evaluate(undefined, CONTAINS_ERROR)).toBeNull();
+    });
+
+    test("nested values are searched because the body is compared as JSON", async () => {
+      expect(
+        await evaluate(
+          { alerts: [{ labels: { severity: "error" } }] },
+          CONTAINS_ERROR,
+        ),
+      ).toBeTruthy();
+    });
+
+    test("matching is case sensitive", async () => {
+      expect(await evaluate({ status: "ERROR" }, CONTAINS_ERROR)).toBeNull();
+    });
+  });
+
+  describe("Not Contains (the default online criteria)", () => {
+    test("a healthy JSON body matches", async () => {
+      const result: string | null = await evaluate(
+        { status: "ok" },
+        NOT_CONTAINS_ERROR,
+      );
+
+      expect(result).toBeTruthy();
+      expect(result).toContain("Request body does not contain");
+      expect(result).toContain(KEYWORD);
+    });
+
+    test("a JSON body reporting an error does not match", async () => {
+      expect(
+        await evaluate({ status: "error" }, NOT_CONTAINS_ERROR),
+      ).toBeNull();
+    });
+
+    /*
+     * A bodiless heartbeat POST is the single most common Incoming Request
+     * payload. It has to satisfy the default online criteria, otherwise a
+     * brand-new monitor could never report itself healthy.
+     */
+    test("an empty object body matches", async () => {
+      expect(await evaluate({}, NOT_CONTAINS_ERROR)).toBeTruthy();
+    });
+
+    test("an empty string body matches", async () => {
+      expect(await evaluate("", NOT_CONTAINS_ERROR)).toBeTruthy();
+    });
+
+    test("a missing body matches", async () => {
+      expect(await evaluate(undefined, NOT_CONTAINS_ERROR)).toBeTruthy();
+    });
+
+    test("a plain-string body without the keyword matches", async () => {
+      expect(
+        await evaluate("all systems nominal", NOT_CONTAINS_ERROR),
+      ).toBeTruthy();
+    });
+  });
+
+  describe("Contains and Not Contains are mutually exclusive", () => {
+    const bodies: Array<string | JSONObject | undefined> = [
+      { status: "error" },
+      { status: "ok" },
+      "error",
+      "ok",
+      "",
+      {},
+      undefined,
+    ];
+
+    test.each(bodies)(
+      "exactly one of the two default filters matches body %p",
+      async (body: string | JSONObject | undefined) => {
+        const contains: boolean = Boolean(await evaluate(body, CONTAINS_ERROR));
+        const notContains: boolean = Boolean(
+          await evaluate(body, NOT_CONTAINS_ERROR),
+        );
+
+        expect(contains).not.toBe(notContains);
+      },
+    );
+  });
+
+  describe("filters that cannot decide", () => {
+    test("a Contains filter with no value does not match", async () => {
+      expect(
+        await evaluate(
+          { status: "error" },
+          {
+            checkOn: CheckOn.RequestBody,
+            filterType: FilterType.Contains,
+            value: undefined,
+          },
+        ),
+      ).toBeNull();
+    });
+
+    test("a Not Contains filter with no value does not match", async () => {
+      expect(
+        await evaluate(
+          { status: "ok" },
+          {
+            checkOn: CheckOn.RequestBody,
+            filterType: FilterType.NotContains,
+            value: undefined,
+          },
+        ),
+      ).toBeNull();
+    });
+
+    test("an unsupported filter type on the body does not match", async () => {
+      expect(
+        await evaluate(
+          { status: "ok" },
+          {
+            checkOn: CheckOn.RequestBody,
+            filterType: FilterType.EqualTo,
+            value: KEYWORD,
+          },
+        ),
+      ).toBeNull();
+    });
+  });
+
+  /*
+   * The heartbeat check is no longer part of the defaults, but users can
+   * still add it by hand, so it must keep working alongside the body check.
+   */
+  describe("CheckOn.IncomingRequest still works when added manually", () => {
+    function buildAgedRequest(minutesAgo: number): DataToProcess {
+      const checkedAt: Date = OneUptimeDate.getCurrentDate();
+
+      const request: IncomingMonitorRequest = {
+        projectId: ObjectID.generate(),
+        monitorId: ObjectID.generate(),
+        requestBody: {},
+        incomingRequestReceivedAt: OneUptimeDate.addRemoveMinutes(
+          checkedAt,
+          -minutesAgo,
+        ),
+        checkedAt: checkedAt,
+      };
+
+      return request as DataToProcess;
+    }
+
+    test("Not Recieved In Minutes fires once the window has elapsed", async () => {
+      const result: string | null =
+        await IncomingRequestCriteria.isMonitorInstanceCriteriaFilterMet({
+          dataToProcess: buildAgedRequest(45),
+          criteriaFilter: {
+            checkOn: CheckOn.IncomingRequest,
+            filterType: FilterType.NotRecievedInMinutes,
+            value: 30,
+          },
+        });
+
+      expect(result).toBeTruthy();
+    });
+
+    test("Recieved In Minutes fires while the window is still open", async () => {
+      const result: string | null =
+        await IncomingRequestCriteria.isMonitorInstanceCriteriaFilterMet({
+          dataToProcess: buildAgedRequest(5),
+          criteriaFilter: {
+            checkOn: CheckOn.IncomingRequest,
+            filterType: FilterType.RecievedInMinutes,
+            value: 30,
+          },
+        });
+
+      expect(result).toBeTruthy();
+    });
+  });
+});

--- a/Common/Tests/Types/Monitor/IncomingMonitorDefaultCriteria.test.ts
+++ b/Common/Tests/Types/Monitor/IncomingMonitorDefaultCriteria.test.ts
@@ -1,0 +1,470 @@
+import FilterCondition from "../../../Types/Filter/FilterCondition";
+import {
+  CheckOn,
+  CriteriaFilter,
+  FilterType,
+} from "../../../Types/Monitor/CriteriaFilter";
+import MonitorCriteria from "../../../Types/Monitor/MonitorCriteria";
+import MonitorCriteriaInstance from "../../../Types/Monitor/MonitorCriteriaInstance";
+import MonitorType from "../../../Types/Monitor/MonitorType";
+import ObjectID from "../../../Types/ObjectID";
+
+/*
+ * Incoming Request and Incoming Email monitors are push-driven: the sender
+ * decides when data arrives and what it says. Their out-of-the-box criteria
+ * therefore read the payload body rather than the arrival clock:
+ *
+ *   offline -> body CONTAINS "error"
+ *   online  -> body DOES NOT CONTAIN "error"
+ *
+ * These tests pin that contract down (shape, wiring, incident/alert
+ * templates, validation, serialization) so the defaults cannot silently
+ * drift back to the old "received in the last 30 minutes" heartbeat check.
+ */
+
+const ONLINE_STATUS_ID: ObjectID = new ObjectID("100000000000000000000011");
+const OFFLINE_STATUS_ID: ObjectID = new ObjectID("100000000000000000000012");
+const INCIDENT_SEVERITY_ID: ObjectID = new ObjectID("100000000000000000000013");
+const ALERT_SEVERITY_ID: ObjectID = new ObjectID("100000000000000000000014");
+
+const KEYWORD: string =
+  MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD;
+
+interface IncomingMonitorCase {
+  label: string;
+  monitorType: MonitorType;
+  bodyCheckOn: CheckOn;
+  // How the body is named in the human-readable copy.
+  bodyLabel: string;
+  // The check the defaults deliberately no longer use.
+  retiredCheckOn: CheckOn;
+}
+
+const CASES: Array<IncomingMonitorCase> = [
+  {
+    label: "Incoming Request",
+    monitorType: MonitorType.IncomingRequest,
+    bodyCheckOn: CheckOn.RequestBody,
+    bodyLabel: "request body",
+    retiredCheckOn: CheckOn.IncomingRequest,
+  },
+  {
+    label: "Incoming Email",
+    monitorType: MonitorType.IncomingEmail,
+    bodyCheckOn: CheckOn.EmailBody,
+    bodyLabel: "email body",
+    retiredCheckOn: CheckOn.EmailReceivedAt,
+  },
+];
+
+function buildOnline(
+  testCase: IncomingMonitorCase,
+  monitorName: string = "Payments API",
+): MonitorCriteriaInstance {
+  const instance: MonitorCriteriaInstance | null =
+    MonitorCriteriaInstance.getDefaultOnlineMonitorCriteriaInstance({
+      monitorType: testCase.monitorType,
+      monitorStatusId: ONLINE_STATUS_ID,
+      monitorName: monitorName,
+    });
+
+  if (!instance) {
+    throw new Error(`${testCase.label} has no default online criteria`);
+  }
+
+  return instance;
+}
+
+function buildOffline(
+  testCase: IncomingMonitorCase,
+  monitorName: string = "Payments API",
+): MonitorCriteriaInstance {
+  return MonitorCriteriaInstance.getDefaultOfflineMonitorCriteriaInstance({
+    monitorType: testCase.monitorType,
+    monitorStatusId: OFFLINE_STATUS_ID,
+    incidentSeverityId: INCIDENT_SEVERITY_ID,
+    alertSeverityId: ALERT_SEVERITY_ID,
+    monitorName: monitorName,
+  });
+}
+
+describe("Incoming monitor default criteria", () => {
+  describe("DEFAULT_INCOMING_BODY_ERROR_KEYWORD", () => {
+    test('is the lower-cased word "error"', () => {
+      expect(KEYWORD).toBe("error");
+    });
+  });
+
+  describe.each(CASES)(
+    "$label monitor",
+    (testCase: IncomingMonitorCase): void => {
+      describe("online criteria", () => {
+        test(`checks that the ${testCase.bodyLabel} does not contain the error keyword`, () => {
+          const instance: MonitorCriteriaInstance = buildOnline(testCase);
+
+          expect(instance.data?.filters).toHaveLength(1);
+
+          const filter: CriteriaFilter = instance.data!.filters[0]!;
+
+          expect(filter.checkOn).toBe(testCase.bodyCheckOn);
+          expect(filter.filterType).toBe(FilterType.NotContains);
+          expect(filter.value).toBe(KEYWORD);
+        });
+
+        test("no longer checks the arrival clock", () => {
+          const instance: MonitorCriteriaInstance = buildOnline(testCase);
+
+          const checkOns: Array<CheckOn> = instance.data!.filters.map(
+            (filter: CriteriaFilter) => {
+              return filter.checkOn;
+            },
+          );
+
+          expect(checkOns).not.toContain(testCase.retiredCheckOn);
+
+          const filterTypes: Array<FilterType | undefined> =
+            instance.data!.filters.map((filter: CriteriaFilter) => {
+              return filter.filterType;
+            });
+
+          expect(filterTypes).not.toContain(FilterType.RecievedInMinutes);
+          expect(filterTypes).not.toContain(FilterType.NotRecievedInMinutes);
+        });
+
+        test("flips the monitor status but never opens incidents or alerts", () => {
+          const instance: MonitorCriteriaInstance = buildOnline(testCase);
+
+          expect(instance.data?.changeMonitorStatus).toBe(true);
+          expect(instance.data?.createIncidents).toBe(false);
+          expect(instance.data?.createAlerts).toBe(false);
+          expect(instance.data?.incidents).toEqual([]);
+          expect(instance.data?.alerts).toEqual([]);
+        });
+
+        test("points at the online monitor status and uses an All filter condition", () => {
+          const instance: MonitorCriteriaInstance = buildOnline(testCase);
+
+          expect(instance.data?.monitorStatusId?.toString()).toBe(
+            ONLINE_STATUS_ID.toString(),
+          );
+          expect(instance.data?.filterCondition).toBe(FilterCondition.All);
+        });
+
+        test("names itself after the monitor and explains the body check", () => {
+          const instance: MonitorCriteriaInstance = buildOnline(
+            testCase,
+            "Checkout Webhook",
+          );
+
+          expect(instance.data?.name).toBe(
+            "Check if Checkout Webhook is online",
+          );
+          expect(instance.data?.description).toContain(testCase.bodyLabel);
+          expect(instance.data?.description).toContain("does not contain");
+          expect(instance.data?.description).toContain(KEYWORD);
+        });
+
+        test("gets a fresh id on every call", () => {
+          const first: MonitorCriteriaInstance = buildOnline(testCase);
+          const second: MonitorCriteriaInstance = buildOnline(testCase);
+
+          expect(first.data?.id).toBeTruthy();
+          expect(first.data?.id).not.toBe(second.data?.id);
+        });
+      });
+
+      describe("offline criteria", () => {
+        test(`checks that the ${testCase.bodyLabel} contains the error keyword`, () => {
+          const instance: MonitorCriteriaInstance = buildOffline(testCase);
+
+          expect(instance.data?.filters).toHaveLength(1);
+
+          const filter: CriteriaFilter = instance.data!.filters[0]!;
+
+          expect(filter.checkOn).toBe(testCase.bodyCheckOn);
+          expect(filter.filterType).toBe(FilterType.Contains);
+          expect(filter.value).toBe(KEYWORD);
+        });
+
+        test("no longer checks the arrival clock", () => {
+          const instance: MonitorCriteriaInstance = buildOffline(testCase);
+
+          const checkOns: Array<CheckOn> = instance.data!.filters.map(
+            (filter: CriteriaFilter) => {
+              return filter.checkOn;
+            },
+          );
+
+          expect(checkOns).not.toContain(testCase.retiredCheckOn);
+
+          const filterTypes: Array<FilterType | undefined> =
+            instance.data!.filters.map((filter: CriteriaFilter) => {
+              return filter.filterType;
+            });
+
+          expect(filterTypes).not.toContain(FilterType.NotRecievedInMinutes);
+          expect(filterTypes).not.toContain(FilterType.RecievedInMinutes);
+        });
+
+        test("opens an auto-resolving incident with the configured severity", () => {
+          const instance: MonitorCriteriaInstance = buildOffline(
+            testCase,
+            "Checkout Webhook",
+          );
+
+          expect(instance.data?.createIncidents).toBe(true);
+          expect(instance.data?.incidents).toHaveLength(1);
+
+          const incident: NonNullable<
+            typeof instance.data
+          >["incidents"][number] = instance.data!.incidents[0]!;
+
+          expect(incident.title).toBe("Checkout Webhook is offline");
+          expect(incident.autoResolveIncident).toBe(true);
+          expect(incident.incidentSeverityId?.toString()).toBe(
+            INCIDENT_SEVERITY_ID.toString(),
+          );
+          expect(incident.onCallPolicyIds).toEqual([]);
+          expect(incident.description).toContain(testCase.bodyLabel);
+          expect(incident.description).toContain(KEYWORD);
+        });
+
+        test("ships an alert template that stays switched off by default", () => {
+          const instance: MonitorCriteriaInstance = buildOffline(
+            testCase,
+            "Checkout Webhook",
+          );
+
+          expect(instance.data?.createAlerts).toBe(false);
+          expect(instance.data?.alerts).toHaveLength(1);
+
+          const alert: NonNullable<typeof instance.data>["alerts"][number] =
+            instance.data!.alerts[0]!;
+
+          expect(alert.title).toBe("Checkout Webhook is offline");
+          expect(alert.autoResolveAlert).toBe(true);
+          expect(alert.alertSeverityId?.toString()).toBe(
+            ALERT_SEVERITY_ID.toString(),
+          );
+          expect(alert.description).toContain(testCase.bodyLabel);
+          expect(alert.description).toContain(KEYWORD);
+        });
+
+        test("does not claim that nothing was received", () => {
+          const instance: MonitorCriteriaInstance = buildOffline(testCase);
+
+          expect(instance.data?.incidents[0]?.description).not.toContain(
+            "No email received",
+          );
+          expect(instance.data?.alerts[0]?.description).not.toContain(
+            "No email received",
+          );
+        });
+
+        test("points at the offline monitor status and uses an Any filter condition", () => {
+          const instance: MonitorCriteriaInstance = buildOffline(testCase);
+
+          expect(instance.data?.monitorStatusId?.toString()).toBe(
+            OFFLINE_STATUS_ID.toString(),
+          );
+          expect(instance.data?.filterCondition).toBe(FilterCondition.Any);
+          expect(instance.data?.changeMonitorStatus).toBe(true);
+        });
+
+        test("names itself after the monitor and explains the body check", () => {
+          const instance: MonitorCriteriaInstance = buildOffline(
+            testCase,
+            "Checkout Webhook",
+          );
+
+          expect(instance.data?.name).toBe(
+            "Check if Checkout Webhook is offline",
+          );
+          expect(instance.data?.description).toContain(testCase.bodyLabel);
+          expect(instance.data?.description).toContain("contains");
+          expect(instance.data?.description).toContain(KEYWORD);
+        });
+      });
+
+      describe("online and offline together", () => {
+        test("are exact complements of each other", () => {
+          const online: CriteriaFilter =
+            buildOnline(testCase).data!.filters[0]!;
+          const offline: CriteriaFilter =
+            buildOffline(testCase).data!.filters[0]!;
+
+          expect(online.checkOn).toBe(offline.checkOn);
+          expect(online.value).toBe(offline.value);
+          expect(online.filterType).toBe(FilterType.NotContains);
+          expect(offline.filterType).toBe(FilterType.Contains);
+        });
+
+        test("target different monitor statuses", () => {
+          expect(
+            buildOnline(testCase).data?.monitorStatusId?.toString(),
+          ).not.toBe(buildOffline(testCase).data?.monitorStatusId?.toString());
+        });
+
+        test("neither evaluates over a time window", () => {
+          for (const instance of [
+            buildOnline(testCase),
+            buildOffline(testCase),
+          ]) {
+            for (const filter of instance.data!.filters) {
+              expect(filter.evaluateOverTime).toBeFalsy();
+              expect(filter.evaluateOverTimeOptions).toBeUndefined();
+            }
+          }
+        });
+      });
+
+      describe("validation", () => {
+        test("the online criteria is valid", () => {
+          expect(
+            MonitorCriteriaInstance.getValidationError(
+              buildOnline(testCase),
+              testCase.monitorType,
+            ),
+          ).toBeNull();
+        });
+
+        test("the offline criteria is valid", () => {
+          expect(
+            MonitorCriteriaInstance.getValidationError(
+              buildOffline(testCase),
+              testCase.monitorType,
+            ),
+          ).toBeNull();
+        });
+
+        /*
+         * Contains / Not Contains are value-carrying filter types, so an
+         * empty default would trip getValidationError the moment a user
+         * opened the monitor form. Guard the keyword against being emptied.
+         */
+        test("a blank keyword would fail validation - so the default must not be blank", () => {
+          const instance: MonitorCriteriaInstance = buildOnline(testCase);
+          instance.data!.filters[0]!.value = "";
+
+          expect(
+            MonitorCriteriaInstance.getValidationError(
+              instance,
+              testCase.monitorType,
+            ),
+          ).toContain("Value is required");
+          expect(KEYWORD).not.toBe("");
+        });
+      });
+
+      describe("serialization", () => {
+        test("survives a toJSON / fromJSON round-trip", () => {
+          const original: MonitorCriteriaInstance = buildOffline(testCase);
+          const restored: MonitorCriteriaInstance =
+            MonitorCriteriaInstance.fromJSON(original.toJSON());
+
+          expect(restored.data?.filters[0]?.checkOn).toBe(testCase.bodyCheckOn);
+          expect(restored.data?.filters[0]?.filterType).toBe(
+            FilterType.Contains,
+          );
+          expect(restored.data?.filters[0]?.value).toBe(KEYWORD);
+          expect(restored.data?.filterCondition).toBe(FilterCondition.Any);
+        });
+
+        test("clone() is a deep copy of the body filter", () => {
+          const original: MonitorCriteriaInstance = buildOnline(testCase);
+          const clone: MonitorCriteriaInstance =
+            MonitorCriteriaInstance.clone(original);
+
+          clone.data!.filters[0]!.value = "mutated";
+
+          expect(original.data?.filters[0]?.value).toBe(KEYWORD);
+        });
+      });
+
+      describe("MonitorCriteria.getDefaultMonitorCriteria", () => {
+        test("composes the offline body check first and the online body check second", () => {
+          const criteria: MonitorCriteria =
+            MonitorCriteria.getDefaultMonitorCriteria({
+              monitorType: testCase.monitorType,
+              monitorName: "Payments API",
+              onlineMonitorStatusId: ONLINE_STATUS_ID,
+              offlineMonitorStatusId: OFFLINE_STATUS_ID,
+              defaultIncidentSeverityId: INCIDENT_SEVERITY_ID,
+              defaultAlertSeverityId: ALERT_SEVERITY_ID,
+            });
+
+          const instances: Array<MonitorCriteriaInstance> =
+            criteria.data!.monitorCriteriaInstanceArray;
+
+          expect(instances).toHaveLength(2);
+
+          expect(instances[0]?.data?.filters[0]?.checkOn).toBe(
+            testCase.bodyCheckOn,
+          );
+          expect(instances[0]?.data?.filters[0]?.filterType).toBe(
+            FilterType.Contains,
+          );
+          expect(instances[0]?.data?.monitorStatusId?.toString()).toBe(
+            OFFLINE_STATUS_ID.toString(),
+          );
+
+          expect(instances[1]?.data?.filters[0]?.checkOn).toBe(
+            testCase.bodyCheckOn,
+          );
+          expect(instances[1]?.data?.filters[0]?.filterType).toBe(
+            FilterType.NotContains,
+          );
+          expect(instances[1]?.data?.monitorStatusId?.toString()).toBe(
+            ONLINE_STATUS_ID.toString(),
+          );
+        });
+
+        test("passes validation as a whole", () => {
+          const criteria: MonitorCriteria =
+            MonitorCriteria.getDefaultMonitorCriteria({
+              monitorType: testCase.monitorType,
+              monitorName: "Payments API",
+              onlineMonitorStatusId: ONLINE_STATUS_ID,
+              offlineMonitorStatusId: OFFLINE_STATUS_ID,
+              defaultIncidentSeverityId: INCIDENT_SEVERITY_ID,
+              defaultAlertSeverityId: ALERT_SEVERITY_ID,
+            });
+
+          expect(
+            MonitorCriteria.getValidationError(criteria, testCase.monitorType),
+          ).toBeNull();
+        });
+      });
+    },
+  );
+
+  /*
+   * The two incoming monitor types now share a shape but must not share
+   * a CheckOn - an email monitor reading "Request Body" would evaluate
+   * nothing at all.
+   */
+  test("each incoming monitor type reads its own body field", () => {
+    const requestOnline: MonitorCriteriaInstance = buildOnline(CASES[0]!);
+    const emailOnline: MonitorCriteriaInstance = buildOnline(CASES[1]!);
+
+    expect(requestOnline.data?.filters[0]?.checkOn).toBe(CheckOn.RequestBody);
+    expect(emailOnline.data?.filters[0]?.checkOn).toBe(CheckOn.EmailBody);
+  });
+
+  /*
+   * Other push-driven monitor types are untouched by this change; a
+   * regression there would be easy to miss because they share the same
+   * builder.
+   */
+  test("does not change the Ping defaults", () => {
+    const online: MonitorCriteriaInstance | null =
+      MonitorCriteriaInstance.getDefaultOnlineMonitorCriteriaInstance({
+        monitorType: MonitorType.Ping,
+        monitorStatusId: ONLINE_STATUS_ID,
+        monitorName: "Gateway",
+      });
+
+    expect(online?.data?.filters[0]?.checkOn).toBe(CheckOn.IsOnline);
+    expect(online?.data?.filters[0]?.filterType).toBe(FilterType.True);
+  });
+});

--- a/Common/Tests/Types/Monitor/MonitorCriteriaInstance.test.ts
+++ b/Common/Tests/Types/Monitor/MonitorCriteriaInstance.test.ts
@@ -108,7 +108,7 @@ describe("MonitorCriteriaInstance", () => {
       );
     });
 
-    test("IncomingRequest monitor uses a RecievedInMinutes filter", () => {
+    test("IncomingRequest monitor is online while the request body carries no error", () => {
       const instance: MonitorCriteriaInstance | null =
         MonitorCriteriaInstance.getDefaultOnlineMonitorCriteriaInstance({
           monitorType: MonitorType.IncomingRequest,
@@ -116,11 +116,13 @@ describe("MonitorCriteriaInstance", () => {
           monitorName: "Heartbeat",
         });
       expect(instance).not.toBeNull();
-      expect(instance?.data?.filters[0]?.checkOn).toBe(CheckOn.IncomingRequest);
+      expect(instance?.data?.filters[0]?.checkOn).toBe(CheckOn.RequestBody);
       expect(instance?.data?.filters[0]?.filterType).toBe(
-        FilterType.RecievedInMinutes,
+        FilterType.NotContains,
       );
-      expect(instance?.data?.filters[0]?.value).toBe(30);
+      expect(instance?.data?.filters[0]?.value).toBe(
+        MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD,
+      );
     });
 
     test("Metrics monitor threads the first metric alias into options", () => {

--- a/Common/Types/Monitor/MonitorCriteriaInstance.ts
+++ b/Common/Types/Monitor/MonitorCriteriaInstance.ts
@@ -44,6 +44,19 @@ export interface MonitorCriteriaInstanceType {
 }
 
 export default class MonitorCriteriaInstance extends DatabaseProperty {
+  /*
+   * Keyword the out-of-the-box criteria for the two incoming monitor types
+   * (Incoming Request and Incoming Email) look for in the payload body.
+   *
+   * These monitors are driven by whatever the sender pushes, so the default
+   * that is useful to the most people is "the sender told us something broke":
+   * a body carrying this keyword takes the monitor offline and opens an
+   * incident, a body without it puts the monitor back online. Users who want
+   * a dead-man's-switch instead can still add an Incoming Request /
+   * Email Received criteria by hand.
+   */
+  public static readonly DEFAULT_INCOMING_BODY_ERROR_KEYWORD: string = "error";
+
   public data: MonitorCriteriaInstanceType | undefined = undefined;
 
   public constructor() {
@@ -88,9 +101,9 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         filterCondition: FilterCondition.All,
         filters: [
           {
-            checkOn: CheckOn.IncomingRequest,
-            filterType: FilterType.RecievedInMinutes,
-            value: 30,
+            checkOn: CheckOn.RequestBody,
+            filterType: FilterType.NotContains,
+            value: MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD,
           },
         ],
         incidents: [],
@@ -99,7 +112,7 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         changeMonitorStatus: true,
         createIncidents: false,
         name: `Check if ${arg.monitorName} is online`,
-        description: `This criteria checks if the ${arg.monitorName} is online`,
+        description: `This criteria checks if the request body of ${arg.monitorName} does not contain "${MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD}"`,
       };
 
       return monitorCriteriaInstance;
@@ -115,9 +128,9 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         filterCondition: FilterCondition.All,
         filters: [
           {
-            checkOn: CheckOn.EmailReceivedAt,
-            filterType: FilterType.RecievedInMinutes,
-            value: 30,
+            checkOn: CheckOn.EmailBody,
+            filterType: FilterType.NotContains,
+            value: MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD,
           },
         ],
         incidents: [],
@@ -126,7 +139,7 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         changeMonitorStatus: true,
         createIncidents: false,
         name: `Check if ${arg.monitorName} is online`,
-        description: `This criteria checks if the ${arg.monitorName} is online`,
+        description: `This criteria checks if the email body of ${arg.monitorName} does not contain "${MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD}"`,
       };
 
       return monitorCriteriaInstance;
@@ -1198,15 +1211,19 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         filterCondition: FilterCondition.Any,
         filters: [
           {
-            checkOn: CheckOn.IncomingRequest,
-            filterType: FilterType.NotRecievedInMinutes,
-            value: 30, // if the request is not recieved in 30 minutes, then the monitor is offline
+            /*
+             * If the sender reports an error in the request body, the monitor
+             * is offline.
+             */
+            checkOn: CheckOn.RequestBody,
+            filterType: FilterType.Contains,
+            value: MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD,
           },
         ],
         alerts: [
           {
             title: `${arg.monitorName} is offline`,
-            description: `${arg.monitorName} is currently offline.`,
+            description: `${arg.monitorName} is currently offline. The request body contains "${MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD}".`,
             alertSeverityId: arg.alertSeverityId,
             autoResolveAlert: true,
             id: ObjectID.generate().toString(),
@@ -1217,7 +1234,7 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         incidents: [
           {
             title: `${arg.monitorName} is offline`,
-            description: `${arg.monitorName} is currently offline.`,
+            description: `${arg.monitorName} is currently offline. The request body contains "${MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD}".`,
             incidentSeverityId: arg.incidentSeverityId,
             autoResolveIncident: true,
             id: ObjectID.generate().toString(),
@@ -1227,7 +1244,7 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         changeMonitorStatus: true,
         createIncidents: true,
         name: `Check if ${arg.monitorName} is offline`,
-        description: `This criteria checks if the ${arg.monitorName} is offline`,
+        description: `This criteria checks if the request body of ${arg.monitorName} contains "${MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD}"`,
       };
     }
 
@@ -1238,15 +1255,19 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         filterCondition: FilterCondition.Any,
         filters: [
           {
-            checkOn: CheckOn.EmailReceivedAt,
-            filterType: FilterType.NotRecievedInMinutes,
-            value: 30, // if email is not received in 30 minutes, then the monitor is offline
+            /*
+             * If the received email reports an error in its body, the monitor
+             * is offline.
+             */
+            checkOn: CheckOn.EmailBody,
+            filterType: FilterType.Contains,
+            value: MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD,
           },
         ],
         alerts: [
           {
             title: `${arg.monitorName} is offline`,
-            description: `${arg.monitorName} is currently offline. No email received.`,
+            description: `${arg.monitorName} is currently offline. The email body contains "${MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD}".`,
             alertSeverityId: arg.alertSeverityId,
             autoResolveAlert: true,
             id: ObjectID.generate().toString(),
@@ -1257,7 +1278,7 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         incidents: [
           {
             title: `${arg.monitorName} is offline`,
-            description: `${arg.monitorName} is currently offline. No email received.`,
+            description: `${arg.monitorName} is currently offline. The email body contains "${MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD}".`,
             incidentSeverityId: arg.incidentSeverityId,
             autoResolveIncident: true,
             id: ObjectID.generate().toString(),
@@ -1267,7 +1288,7 @@ export default class MonitorCriteriaInstance extends DatabaseProperty {
         changeMonitorStatus: true,
         createIncidents: true,
         name: `Check if ${arg.monitorName} is offline`,
-        description: `This criteria checks if the ${arg.monitorName} is offline`,
+        description: `This criteria checks if the email body of ${arg.monitorName} contains "${MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD}"`,
       };
     }
 


### PR DESCRIPTION
## What

Incoming Request and Incoming Email monitors are created with arrival-clock defaults today — "received in the last 30 minutes" for online, "not received in 30 minutes" for offline. Both types are push-driven and the sender almost always describes its own health in the payload, so those defaults fire on senders that are event-driven rather than periodic, and ignore what the payload actually says.

Both types now default to reading the body:

| Criteria | Incoming Request | Incoming Email | Filter Condition | Value |
| -------- | ---------------- | -------------- | ---------------- | ----- |
| Offline (opens an incident) | Request Body | Email Body | Contains | `error` |
| Online | Request Body | Email Body | Not Contains | `error` |

The keyword lives in one place — `MonitorCriteriaInstance.DEFAULT_INCOMING_BODY_ERROR_KEYWORD` — and the criteria names, descriptions and incident/alert copy now name the body they check instead of claiming nothing was received.

**Only newly created monitors are affected.** Existing monitors keep the criteria already stored on them.

## Two consequences, both intended

**No dead-man's switch by default.** `IncomingRequestMonitor:CheckHeartbeat` and `IncomingEmailMonitor:CheckOnlineStatus` only hand a monitor to `monitorResource` when one of its criteria checks `Incoming Request` / `Email Received`. A monitor left on these defaults is therefore judged when data arrives and at no other time. Alerting on silence is now an opt-in criteria; both docs pages say so explicitly, and the two worker suites pin the behaviour.

**Bodiless requests now count as "no error".** `IncomingRequestCriteria` treated a missing request body as an *unknown* body and returned `null` from both `Contains` and `Not Contains`. It now normalises a missing body to `""` — the same thing `IncomingEmailCriteria` already does for the email fields — so a plain heartbeat ping satisfies the default online criteria instead of leaving the monitor undecided. `Contains` is unaffected: `""` contains nothing.

## Not changed

Request Body matching stays case-sensitive (Email Body was and remains case-insensitive). Flipping it would retroactively change how existing `Request Body Contains …` filters match and could open incidents on monitors nobody touched, so it is left alone and the docs state the difference on both pages.

## Tests

New:
- `Common/Tests/Types/Monitor/IncomingMonitorDefaultCriteria.test.ts` — the default-criteria contract for both monitor types, table-driven: filter shape, complementarity of the online/offline pair, status wiring, incident/alert templates and severities, names and descriptions, validation, `toJSON`/`fromJSON` and `clone`, composition through `MonitorCriteria.getDefaultMonitorCriteria`, plus regression guards that the arrival-clock checks are gone and that Ping is untouched.
- `Common/Tests/Server/Utils/Monitor/Criteria/IncomingRequestBodyCriteria.test.ts` — `Request Body` `Contains` / `Not Contains` over JSON objects, nested payloads, plain strings, empty-object, empty-string and missing bodies; exactly-one-matches across every body shape; valueless and unsupported filter types; and the manually-added `Incoming Request` heartbeat check still working.
- `Common/Tests/Server/Utils/Monitor/Criteria/IncomingEmailBodyCriteria.test.ts` — the same for `Email Body`, including case-insensitive matching and the `onlyCheckForIncomingEmailReceivedAt` guard that stops the 30-second cron re-judging a stale email body.
- `App/Tests/Dashboard/IncomingMonitorDefaultCriteriaForm.test.ts` — the criteria form actually offers both defaults' `CheckOn`/`FilterType` for these monitor types, so neither renders as a blank dropdown.

Updated:
- `App/Tests/Workers/Jobs/{IncomingRequestMonitor/CheckHeartbeat,IncomingEmailMonitor/CheckOnlineStatus}.test.ts` — a monitor on the new defaults is stamped but never evaluated by the cron.
- `Common/Tests/Types/Monitor/MonitorCriteriaInstance.test.ts` — the one existing expectation that asserted the old `RecievedInMinutes` default.

Results: `Common/Tests/{Types,UI,Utils}/Monitor` — 74 suites, 1846 tests, all passing. The two new `Common/Tests/Server/.../Criteria` suites — 47 tests, passing. The three App suites — 25 tests, passing. Docs anchor check passes.

## Docs

`incoming-request-monitor.md` and `incoming-email-monitor.md` each get a "What you get out of the box" section describing the new defaults, how to retarget the keyword, and the fact that they are not a dead-man's switch. English only — the localized copies are regenerated by the retranslate workflow.