### PR TITLE
feat(on-call): let critical mobile pages override silent mode and Do Not Disturb

### DIFF
--- a/.github/workflows/test.mobile-app.yaml
+++ b/.github/workflows/test.mobile-app.yaml
@@ -26,6 +26,19 @@ jobs:
       - name: Run Expo Doctor
         run: cd MobileApp && npx expo-doctor@latest
 
+  jest:
+    runs-on: ubuntu-latest
+    env:
+      CI_PIPELINE_ID: ${{github.run_number}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 26
+      - run: cd MobileApp && npm install
+      - name: Run Jest Tests
+        run: cd MobileApp && npm test
+
   expo-web-export:
     runs-on: ubuntu-latest
     env:

--- a/App/FeatureSet/Dashboard/src/Components/NotificationMethods/Push.tsx
+++ b/App/FeatureSet/Dashboard/src/Components/NotificationMethods/Push.tsx
@@ -262,6 +262,15 @@ const Push: () => JSX.Element = (): ReactElement => {
           },
           {
             field: {
+              isCriticalAlertEnabled: true,
+            },
+            title: "Critical Alerts",
+            description:
+              "On-call pages to this device override silent mode and Do Not Disturb. Turned on from the OneUptime On-Call mobile app; browsers cannot override a device's ringer.",
+            type: FieldType.Boolean,
+          },
+          {
+            field: {
               createdAt: true,
             },
             title: "Registered At",

--- a/App/FeatureSet/Docs/Content/en/self-hosted/push-notifications.md
+++ b/App/FeatureSet/Docs/Content/en/self-hosted/push-notifications.md
@@ -12,6 +12,79 @@ Web push notifications continue to use VAPID keys and the Web Push protocol.
 
 No push notification configuration is required. The mobile app binary handles all platform registration automatically via Expo's push infrastructure.
 
+## Critical On-Call Alerts (Overriding Silent Mode)
+
+By default a push notification obeys the handset: a phone on silent stays
+silent, and Do Not Disturb holds the notification back. For an on-call
+responder that is the wrong default at 3am, so the mobile app offers a
+per-device setting - **Settings > Notifications > Critical On-Call Alerts** -
+that lets *on-call pages only* play a sound through both.
+
+The scope is deliberately narrow. Only pages produced by an on-call
+notification rule are eligible. Owner subscriptions, note-posted notices,
+status-change updates and monitor notifications are never escalated, whatever
+this setting says.
+
+Three things must all be true for a page to override silent mode. If any one
+is missing, the page is still delivered - just quietly.
+
+1. **The responder turned it on for that device.** Stored per device, off by
+   default, in `UserPush.isCriticalAlertEnabled`. A responder's phone and their
+   tablet are separate decisions.
+2. **The server marks the page critical.** It sends the APNs critical sound
+   payload plus `interruptionLevel: critical` for iOS, and targets the
+   `oncall_critical` notification channel for Android.
+3. **The operating system allows it**, which is where the two platforms differ.
+
+### iOS: Apple's critical alerts entitlement
+
+Critical alerts on iOS require the
+`com.apple.developer.usernotifications.critical-alerts` entitlement, which
+Apple grants per developer account, on request, for apps that notify people
+about urgent events. Request it at
+[Apple's Critical Alerts request form](https://developer.apple.com/contact/request/notifications-critical-alerts-entitlement/).
+
+Because a provisioning profile cannot carry an entitlement the team has not
+been granted - and a build that declares one it cannot carry **fails to
+sign** - the entitlement is **not** enabled in this repository by default.
+Once Apple has granted it to your team, turn it on when building:
+
+```
+EXPO_IOS_CRITICAL_ALERTS_ENTITLEMENT=true npx expo prebuild
+```
+
+or add `EXPO_IOS_CRITICAL_ALERTS_ENTITLEMENT: "true"` to the build profile's
+`env` block in `MobileApp/eas.json`.
+
+Without the entitlement the app still behaves correctly: iOS declines to grant
+the permission, and the settings screen tells the responder so rather than
+showing a switch that does nothing.
+
+### Android: Do Not Disturb access
+
+Android has no vendor approval step, but Do Not Disturb bypass is granted by
+the user on a system screen rather than by an in-app prompt. When a responder
+turns the setting on, the app opens
+**Settings > Notifications > Do Not Disturb access** for them and re-checks when
+they return.
+
+Two mechanisms are in play, and they cover different cases:
+
+- The `oncall_critical` notification channel requests `bypassDnd`, which covers
+  Do Not Disturb and needs the access described above.
+- The same channel uses the **alarm** audio stream, which is audible on a phone
+  whose ringer is simply muted. That half needs no permission at all.
+
+Android freezes a channel's settings when the channel is first created, so
+these cannot be changed by an app update - only by shipping a new channel id.
+
+### Verifying it works
+
+Send a test notification to the device from
+**User Settings > Notification Methods > Push**. When the device has critical
+alerts enabled, the test is sent as a critical alert too - so silence the phone
+first, and you will hear whether a real page would reach you.
+
 ## Troubleshooting
 
 ### Push notifications not arriving
@@ -20,6 +93,18 @@ No push notification configuration is required. The mobile app binary handles al
 - Verify the device is registered in the `UserPush` table in your database
 - Check OneUptime server logs for Expo Push API errors
 - Confirm the device has an active internet connection and notification permissions enabled
+
+### Critical alerts do not override silent mode
+
+- Check the switch is on for **that** device - the setting is per device, and a
+  reinstall or a new push token creates a new device registration
+- **iOS**: confirm the build carries Apple's critical alerts entitlement (see
+  above), and that Critical Alerts is allowed under
+  iOS Settings > Notifications > OneUptime On-Call
+- **Android**: confirm the app has Do Not Disturb access under
+  Settings > Notifications > Do Not Disturb access
+- The settings screen states which of these is missing; it reads the current
+  state back from the OS rather than trusting what the app last requested
 
 ### "DeviceNotRegistered" errors in logs
 

--- a/App/FeatureSet/Notification/API/PushRelay.ts
+++ b/App/FeatureSet/Notification/API/PushRelay.ts
@@ -8,7 +8,10 @@ import { resolveClientIp } from "Common/Server/Utils/ClientIp";
 import Response from "Common/Server/Utils/Response";
 import BadDataException from "Common/Types/Exception/BadDataException";
 import { JSONObject } from "Common/Types/JSON";
-import PushNotificationService from "Common/Server/Services/PushNotificationService";
+import PushNotificationService, {
+  ExpoInterruptionLevel,
+  ExpoPushSound,
+} from "Common/Server/Services/PushNotificationService";
 
 const router: ExpressRouter = Express.getRouter();
 
@@ -45,6 +48,114 @@ setInterval(
   },
   5 * 60 * 1000,
 );
+
+/*
+ * A critical alert is the one payload shape that can ring a silenced phone, so
+ * the relay parses `sound` and `interruptionLevel` instead of forwarding
+ * whatever arrived. This endpoint is unauthenticated (rate limited by client
+ * IP only), and an unvalidated pass-through would let any caller who can reach
+ * it hand Expo arbitrary structures under this deployment's Expo credentials.
+ *
+ * Strictness is one-directional on purpose: a malformed value is refused
+ * rather than quietly downgraded, because a critical page that silently
+ * degrades to a normal notification is exactly the missed-incident failure
+ * this feature exists to prevent.
+ */
+const MAX_SOUND_NAME_LENGTH: number = 100;
+
+const ALLOWED_INTERRUPTION_LEVELS: Array<ExpoInterruptionLevel> = [
+  "active",
+  "critical",
+  "passive",
+  "time-sensitive",
+];
+
+export function parseRelaySound(raw: unknown): ExpoPushSound | undefined {
+  // Absent means "caller did not say", which the service turns into "default".
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  // Explicit null is a request for a silent notification and is honoured.
+  if (raw === null) {
+    return null;
+  }
+
+  if (typeof raw === "string") {
+    if (raw.length > MAX_SOUND_NAME_LENGTH) {
+      throw new BadDataException("Push notification sound name is too long.");
+    }
+    return raw;
+  }
+
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new BadDataException(
+      "Push notification sound must be a string, null, or a critical-alert object.",
+    );
+  }
+
+  const soundObject: JSONObject = raw as JSONObject;
+  const parsed: { critical?: boolean; name?: string | null; volume?: number } =
+    {};
+
+  const critical: unknown = soundObject["critical"];
+  if (critical !== undefined) {
+    if (typeof critical !== "boolean") {
+      throw new BadDataException(
+        "Push notification sound 'critical' must be a boolean.",
+      );
+    }
+    parsed.critical = critical;
+  }
+
+  const name: unknown = soundObject["name"];
+  if (name !== undefined) {
+    if (name !== null && typeof name !== "string") {
+      throw new BadDataException(
+        "Push notification sound 'name' must be a string or null.",
+      );
+    }
+    if (typeof name === "string" && name.length > MAX_SOUND_NAME_LENGTH) {
+      throw new BadDataException("Push notification sound name is too long.");
+    }
+    parsed.name = name as string | null;
+  }
+
+  const volume: unknown = soundObject["volume"];
+  if (volume !== undefined) {
+    if (typeof volume !== "number" || !Number.isFinite(volume)) {
+      throw new BadDataException(
+        "Push notification sound 'volume' must be a number between 0 and 1.",
+      );
+    }
+    /*
+     * Clamped rather than refused: out-of-range is a caller bug, not an attack,
+     * and refusing would drop the page.
+     */
+    parsed.volume = Math.min(1, Math.max(0, volume));
+  }
+
+  return parsed;
+}
+
+export function parseRelayInterruptionLevel(
+  raw: unknown,
+): ExpoInterruptionLevel | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+
+  if (
+    typeof raw !== "string" ||
+    !ALLOWED_INTERRUPTION_LEVELS.includes(raw as ExpoInterruptionLevel)
+  ) {
+    throw new BadDataException(
+      `Push notification interruptionLevel must be one of: ${ALLOWED_INTERRUPTION_LEVELS.join(", ")}.`,
+    );
+  }
+
+  return raw as ExpoInterruptionLevel;
+}
 
 router.post(
   "/send",
@@ -93,14 +204,19 @@ router.post(
         );
       }
 
+      const sound: ExpoPushSound | undefined = parseRelaySound(body["sound"]);
+      const interruptionLevel: ExpoInterruptionLevel | undefined =
+        parseRelayInterruptionLevel(body["interruptionLevel"]);
+
       await PushNotificationService.sendRelayPushNotification({
         to: to,
         ...(title !== undefined ? { title } : {}),
         ...(messageBody !== undefined ? { body: messageBody } : {}),
         data: (body["data"] as { [key: string]: string }) || {},
-        sound: (body["sound"] as string) || "default",
+        sound: sound === undefined ? "default" : sound,
         priority: (body["priority"] as string) || "high",
         channelId: (body["channelId"] as string) || "default",
+        ...(interruptionLevel ? { interruptionLevel } : {}),
       });
 
       return Response.sendJsonObjectResponse(req, res, { success: true });

--- a/App/Tests/FeatureSet/Notification/PushRelayCriticalAlerts.test.ts
+++ b/App/Tests/FeatureSet/Notification/PushRelayCriticalAlerts.test.ts
@@ -1,0 +1,209 @@
+import {
+  parseRelaySound,
+  parseRelayInterruptionLevel,
+} from "../../../FeatureSet/Notification/API/PushRelay";
+import BadDataException from "Common/Types/Exception/BadDataException";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The relay is how a self-hosted OneUptime without its own EXPO_ACCESS_TOKEN
+ * gets pages onto phones: it re-sends the payload through a gateway that has
+ * one. Two things make its parsing worth pinning.
+ *
+ * First, it is the only hop where a critical alert can quietly lose the fields
+ * that make it critical. A relay that dropped `sound` would deliver every page
+ * as an ordinary notification - no error, no log, just a responder who sleeps
+ * through the incident.
+ *
+ * Second, the endpoint is unauthenticated (rate limited by client IP alone),
+ * so whatever it forwards is forwarded under this deployment's Expo
+ * credentials. Structures it does not understand are refused rather than
+ * passed along.
+ */
+
+describe("parseRelaySound - the shapes a real page arrives in", () => {
+  test("passes a critical alert sound object through intact", () => {
+    expect(
+      parseRelaySound({ critical: true, name: "default", volume: 1 }),
+    ).toEqual({
+      critical: true,
+      name: "default",
+      volume: 1,
+    });
+  });
+
+  test('passes the ordinary "default" string through', () => {
+    expect(parseRelaySound("default")).toBe("default");
+  });
+
+  test("undefined means the caller said nothing", () => {
+    /*
+     * Distinct from null. The send path turns undefined into "default" and
+     * leaves null alone, so collapsing the two here would make it impossible
+     * to request a silent notification.
+     */
+    expect(parseRelaySound(undefined)).toBeUndefined();
+  });
+
+  test("null is honoured as an explicit request for a silent notification", () => {
+    expect(parseRelaySound(null)).toBeNull();
+  });
+
+  test("a partial critical object keeps only the fields that were sent", () => {
+    expect(parseRelaySound({ critical: true })).toEqual({ critical: true });
+  });
+
+  test("an empty object is accepted and carries nothing", () => {
+    expect(parseRelaySound({})).toEqual({});
+  });
+
+  test("critical: false survives, so a caller can explicitly de-escalate", () => {
+    expect(parseRelaySound({ critical: false })).toEqual({ critical: false });
+  });
+
+  test("a custom sound name is preserved", () => {
+    expect(parseRelaySound({ critical: true, name: "klaxon.wav" })).toEqual({
+      critical: true,
+      name: "klaxon.wav",
+    });
+  });
+
+  test("a null sound name inside the object is preserved", () => {
+    expect(parseRelaySound({ critical: true, name: null })).toEqual({
+      critical: true,
+      name: null,
+    });
+  });
+});
+
+describe("parseRelaySound - volume", () => {
+  test("keeps a volume inside the valid range", () => {
+    expect(parseRelaySound({ volume: 0.5 })).toEqual({ volume: 0.5 });
+  });
+
+  test("clamps a volume above 1 rather than dropping the page", () => {
+    /*
+     * Out of range is a caller bug, not an attack. Refusing would turn a
+     * cosmetic mistake into an undelivered page, which is the wrong trade for
+     * an on-call product.
+     */
+    expect(parseRelaySound({ volume: 11 })).toEqual({ volume: 1 });
+  });
+
+  test("clamps a negative volume to zero", () => {
+    expect(parseRelaySound({ volume: -3 })).toEqual({ volume: 0 });
+  });
+
+  test("accepts zero volume without treating it as absent", () => {
+    expect(parseRelaySound({ volume: 0 })).toEqual({ volume: 0 });
+  });
+
+  test.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["-Infinity", Number.NEGATIVE_INFINITY],
+    ['the string "1"', "1"],
+    ["null", null],
+    ["an object", {}],
+  ])("refuses a volume of %s", (_label: string, volume: unknown) => {
+    expect(() => {
+      return parseRelaySound({ volume: volume });
+    }).toThrow(BadDataException);
+  });
+});
+
+describe("parseRelaySound - structures it will not forward", () => {
+  test.each([
+    ["a number", 7],
+    ["a boolean", true],
+    ["an array", ["default"]],
+  ])("refuses %s", (_label: string, raw: unknown) => {
+    expect(() => {
+      return parseRelaySound(raw);
+    }).toThrow(BadDataException);
+  });
+
+  test("refuses a non-boolean critical flag", () => {
+    expect(() => {
+      return parseRelaySound({ critical: "true" });
+    }).toThrow("Push notification sound 'critical' must be a boolean.");
+  });
+
+  test("refuses a non-string sound name", () => {
+    expect(() => {
+      return parseRelaySound({ name: 42 });
+    }).toThrow("Push notification sound 'name' must be a string or null.");
+  });
+
+  test("refuses an absurdly long sound name string", () => {
+    expect(() => {
+      return parseRelaySound("x".repeat(101));
+    }).toThrow("Push notification sound name is too long.");
+  });
+
+  test("refuses an absurdly long sound name inside the object", () => {
+    expect(() => {
+      return parseRelaySound({ name: "x".repeat(101) });
+    }).toThrow("Push notification sound name is too long.");
+  });
+
+  test("accepts a name exactly at the length limit", () => {
+    const name: string = "x".repeat(100);
+
+    expect(parseRelaySound(name)).toBe(name);
+  });
+
+  test("ignores unknown keys rather than forwarding them to Expo", () => {
+    /*
+     * The parser rebuilds the object from the three fields it knows. Anything
+     * else a caller attaches is dropped here rather than sent onward under
+     * this deployment's Expo credentials.
+     */
+    expect(
+      parseRelaySound({
+        critical: true,
+        somethingElse: "surprise",
+        __proto__: { polluted: true },
+      }),
+    ).toEqual({ critical: true });
+  });
+});
+
+describe("parseRelayInterruptionLevel", () => {
+  test.each(["active", "critical", "passive", "time-sensitive"])(
+    "accepts %s",
+    (level: string) => {
+      expect(parseRelayInterruptionLevel(level)).toBe(level);
+    },
+  );
+
+  test("critical is accepted, because it is the whole point on iOS", () => {
+    expect(parseRelayInterruptionLevel("critical")).toBe("critical");
+  });
+
+  test.each([
+    ["undefined", undefined],
+    ["null", null],
+  ])("treats %s as not specified", (_label: string, raw: unknown) => {
+    expect(parseRelayInterruptionLevel(raw)).toBeUndefined();
+  });
+
+  test.each([
+    ["an unknown level", "urgent"],
+    ["a differently-cased level", "Critical"],
+    ["a number", 1],
+    ["a boolean", true],
+    ["an object", {}],
+    ["an empty string", ""],
+  ])("refuses %s", (_label: string, raw: unknown) => {
+    expect(() => {
+      return parseRelayInterruptionLevel(raw);
+    }).toThrow(BadDataException);
+  });
+
+  test("the refusal lists the levels that are allowed", () => {
+    expect(() => {
+      return parseRelayInterruptionLevel("urgent");
+    }).toThrow("active, critical, passive, time-sensitive");
+  });
+});

--- a/Common/Models/DatabaseModels/UserPush.ts
+++ b/Common/Models/DatabaseModels/UserPush.ts
@@ -346,6 +346,43 @@ class UserPush extends BaseModel {
     default: false,
   })
   public isVerified?: boolean = undefined;
+
+  /*
+   * Whether this handset should be paged through silent mode and Do Not
+   * Disturb when it is on call. Per DEVICE and not per user on purpose: the
+   * responder's work phone on the nightstand and their tablet on the sofa are
+   * the same person making two different decisions, and only the phone should
+   * be allowed to wake the house.
+   *
+   * Off unless the responder turns it on from that device. It is the one
+   * setting in this product that deliberately defeats the switch a person
+   * flicked to be left alone, so it is opted into rather than out of, and the
+   * app only offers it once the OS has actually granted the capability
+   * (the iOS critical-alert entitlement, or Do Not Disturb access on Android).
+   *
+   * `update` is empty like every other column here: the value is written by
+   * UserPushAPI's critical-alerts route, which checks the row belongs to the
+   * caller and then writes as root. That keeps "who may change this" in one
+   * readable place rather than spread across the generic CRUD surface.
+   */
+  @ColumnAccessControl({
+    create: [Permission.CurrentUser],
+    read: [Permission.CurrentUser],
+    update: [],
+  })
+  @TableColumn({
+    title: "Critical Alerts Enabled",
+    description:
+      "Should on-call notifications to this device override silent mode and Do Not Disturb?",
+    isDefaultValueColumn: true,
+    type: TableColumnType.Boolean,
+    defaultValue: false,
+  })
+  @Column({
+    type: ColumnType.Boolean,
+    default: false,
+  })
+  public isCriticalAlertEnabled?: boolean = undefined;
 }
 
 export default UserPush;

--- a/Common/Server/API/UserPushAPI.ts
+++ b/Common/Server/API/UserPushAPI.ts
@@ -21,6 +21,35 @@ import PushDeviceType from "../../Types/PushNotification/PushDeviceType";
 import UserPush from "../../Models/DatabaseModels/UserPush";
 import PushNotificationMessage from "../../Types/PushNotification/PushNotificationMessage";
 
+/*
+ * Booleans arrive from the mobile client as JSON booleans, but the same routes
+ * get called by hand and from form posts where "true" is a string.
+ *
+ * On REGISTRATION, absence is the normal case and means off: overriding a
+ * silenced phone is never something a device registration turns on by itself.
+ */
+export function parseCriticalAlertFlag(raw: unknown): boolean {
+  return raw === true || raw === "true";
+}
+
+/*
+ * On the toggle route the caller is stating an intent, so an unrecognised
+ * value is refused rather than read as false. Quietly storing "off" for a
+ * client that meant "on" leaves a responder believing their phone will ring
+ * while it will not, and nothing surfaces the mistake until a missed page.
+ */
+export function parseCriticalAlertFlagStrict(raw: unknown): boolean {
+  if (raw === true || raw === "true") {
+    return true;
+  }
+
+  if (raw === false || raw === "false") {
+    return false;
+  }
+
+  throw new BadDataException("isEnabled must be either true or false.");
+}
+
 function getAuthenticatedUserId(req: ExpressRequest): ObjectID {
   const userId: ObjectID | undefined = (req as OneUptimeRequest)
     .userAuthorization?.userId;
@@ -111,6 +140,16 @@ export default class UserPushAPI extends BaseAPI<
           userPush.deviceType = req.body.deviceType;
           userPush.deviceName = req.body.deviceName || "Unknown Device";
           userPush.isVerified = true; // Web, iOS, and Android devices are verified immediately
+          /*
+           * The mobile app sends this when the responder already had critical
+           * alerts on and the device is re-registering (a reinstall, a new push
+           * token, a second project). Absent, it stays off: overriding a
+           * silenced phone is never something a registration turns on by
+           * itself.
+           */
+          userPush.isCriticalAlertEnabled = parseCriticalAlertFlag(
+            req.body.isCriticalAlertEnabled,
+          );
 
           const savedDevice: UserPush = await this.service.create({
             data: userPush,
@@ -216,6 +255,7 @@ export default class UserPushAPI extends BaseAPI<
               deviceType: true,
               isVerified: true,
               projectId: true,
+              isCriticalAlertEnabled: true,
             },
           });
 
@@ -246,14 +286,32 @@ export default class UserPushAPI extends BaseAPI<
 
           try {
             // Send test notification
+            const isCriticalAlert: boolean = Boolean(
+              device.isCriticalAlertEnabled,
+            );
+
+            /*
+             * A test that behaves unlike the real page is not a test of
+             * anything. Critical alerts are the one setting whose effect a
+             * responder cannot check by reasoning about it - they have to
+             * silence the phone and hear it ring - so a device with the option
+             * on gets a test that overrides silent mode exactly as a 3am page
+             * would.
+             */
             const testMessage: PushNotificationMessage =
               PushNotificationUtil.createGenericNotification({
-                title: "Test Notification from OneUptime",
-                body: "This is a test notification to verify your device is working correctly.",
+                title: isCriticalAlert
+                  ? "Test Critical Alert from OneUptime"
+                  : "Test Notification from OneUptime",
+                body: isCriticalAlert
+                  ? "This is a test critical alert. If your device is silenced or in Do Not Disturb and you heard this, on-call pages will reach you."
+                  : "This is a test notification to verify your device is working correctly.",
                 clickAction: "/dashboard",
                 tag: "test-notification",
                 requireInteraction: false,
               });
+
+            testMessage.isCriticalAlert = isCriticalAlert;
 
             await PushNotificationService.sendPushNotification(
               {
@@ -283,6 +341,72 @@ export default class UserPushAPI extends BaseAPI<
           return Response.sendJsonObjectResponse(req, res, {
             success: true,
             message: "Test notification sent successfully",
+          });
+        } catch (error) {
+          return next(error);
+        }
+      },
+    );
+
+    /*
+     * Turn "ring me through silent mode" on or off for this handset.
+     *
+     * A dedicated route rather than the generic CRUD update, for the same
+     * reason verify/unverify are: UserPush grants no update permission to
+     * anybody, so every write to it passes an explicit ownership check first
+     * and then runs as root. That keeps the set of things that can change a
+     * responder's paging configuration short and readable.
+     *
+     * Keyed on the device token, like unregister and unlike verify: the mobile
+     * app knows its own push token and holds no row ids, and one phone has a
+     * row per project it is registered against.
+     */
+    this.router.post(
+      `/user-push/critical-alerts`,
+      UserMiddleware.getUserMiddleware,
+      async (req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+        try {
+          req = req as OneUptimeRequest;
+
+          const userId: ObjectID = getAuthenticatedUserId(req);
+
+          if (!req.body.deviceToken) {
+            return Response.sendErrorResponse(
+              req,
+              res,
+              new BadDataException("Device token is required"),
+            );
+          }
+
+          /*
+           * Required rather than defaulted. A request that forgot the field
+           * would otherwise silently turn the setting OFF, and a responder
+           * whose pages stopped overriding Do Not Disturb has no way to notice
+           * until the page they missed.
+           */
+          if (req.body.isEnabled === undefined || req.body.isEnabled === null) {
+            return Response.sendErrorResponse(
+              req,
+              res,
+              new BadDataException("isEnabled is required"),
+            );
+          }
+
+          const isEnabled: boolean = parseCriticalAlertFlagStrict(
+            req.body.isEnabled,
+          );
+
+          const updatedCount: number =
+            await this.service.setCriticalAlertEnabledForDeviceToken({
+              userId: userId,
+              deviceToken: req.body.deviceToken,
+              isEnabled: isEnabled,
+            });
+
+          return Response.sendJsonObjectResponse(req, res, {
+            success: true,
+            isCriticalAlertEnabled: isEnabled,
+            devicesUpdated: updatedCount,
           });
         } catch (error) {
           return next(error);

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787156982416-MigrationName.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/1787156982416-MigrationName.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class MigrationName1787156982416 implements MigrationInterface {
+  public name = "MigrationName1787156982416";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "UserPush" ADD "isCriticalAlertEnabled" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "UserPush" DROP COLUMN "isCriticalAlertEnabled"`,
+    );
+  }
+}

--- a/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
+++ b/Common/Server/Infrastructure/Postgres/SchemaMigrations/Index.ts
@@ -531,6 +531,7 @@ import { AddDeviceRoleAndDeclaredLinkParent1787400000000 } from "./1787400000000
 import { AddEnableSearchEngineIndexingToStatusPage1787500000000 } from "./1787500000000-AddEnableSearchEngineIndexingToStatusPage";
 import { AddNetworkDeviceReachabilityColumns1787600000000 } from "./1787600000000-AddNetworkDeviceReachabilityColumns";
 import { MigrationName1787142779538 } from "./1787142779538-MigrationName";
+import { MigrationName1787156982416 } from "./1787156982416-MigrationName";
 
 export default [
   InitialMigration,
@@ -1066,4 +1067,5 @@ export default [
   AddEnableSearchEngineIndexingToStatusPage1787500000000,
   AddNetworkDeviceReachabilityColumns1787600000000,
   MigrationName1787142779538,
+  MigrationName1787156982416,
 ];

--- a/Common/Server/Services/PushNotificationService.ts
+++ b/Common/Server/Services/PushNotificationService.ts
@@ -26,6 +26,7 @@ import UserPush from "../../Models/DatabaseModels/UserPush";
 import PushNotificationLog from "../../Models/DatabaseModels/PushNotificationLog";
 import PushNotificationLogService from "./PushNotificationLogService";
 import PushStatus from "../../Types/PushNotification/PushStatus";
+import AndroidNotificationChannel from "../../Types/PushNotification/AndroidNotificationChannel";
 
 /*
  * The push services the browsers actually use. A Web Push subscription is a
@@ -65,6 +66,43 @@ export interface PushNotificationOptions {
   onCallDutyPolicyExecutionLogTimelineId?: ObjectID | undefined;
   onCallScheduleId?: ObjectID | undefined;
   teamId?: ObjectID | undefined;
+}
+
+/*
+ * What Expo needs to be told for a notification to ring through a silenced
+ * handset. The two platforms disagree about where the answer lives, so this is
+ * computed once and reused by both the direct-SDK and relay send paths.
+ *
+ * iOS reads the payload: a `sound` object with `critical: true` plus
+ * `interruptionLevel: "critical"` is what makes APNs ignore the ringer switch
+ * and Focus, and it is refused unless the app carries Apple's critical-alert
+ * entitlement.
+ *
+ * Android ignores all of that and reads the CHANNEL. Sound, importance and Do
+ * Not Disturb bypass are baked into the channel when the app creates it and
+ * cannot be raised by a payload, so the only lever the server has is which
+ * channel id it names.
+ */
+export type ExpoPushSound =
+  | string
+  | null
+  | {
+      critical?: boolean;
+      name?: string | null;
+      volume?: number;
+    };
+
+export type ExpoInterruptionLevel =
+  | "active"
+  | "critical"
+  | "passive"
+  | "time-sensitive";
+
+export interface ExpoDeliveryOptions {
+  channelId: string;
+  sound: ExpoPushSound;
+  priority: "high";
+  interruptionLevel?: ExpoInterruptionLevel;
 }
 
 export default class PushNotificationService {
@@ -408,6 +446,57 @@ export default class PushNotificationService {
     }
   }
 
+  /*
+   * Volume is pinned rather than exposed as a setting. A critical alert exists
+   * to wake somebody, and a responder who has already opted this device in and
+   * granted the OS permission has not asked to be woken quietly.
+   */
+  public static readonly CRITICAL_ALERT_VOLUME: number = 1;
+
+  public static getExpoDeliveryOptions(
+    message: PushNotificationMessage,
+    deviceType: PushDeviceType,
+  ): ExpoDeliveryOptions {
+    const isAndroid: boolean = deviceType === PushDeviceType.Android;
+    const isCritical: boolean = Boolean(message.isCriticalAlert);
+
+    /*
+     * iOS has no channels, so "default" here is the payload's own sound rather
+     * than a channel id. Android without the critical flag stays on
+     * oncall_high, which is what every push has used until now.
+     */
+    const channelId: string = isAndroid
+      ? isCritical
+        ? AndroidNotificationChannel.Critical
+        : AndroidNotificationChannel.High
+      : "default";
+
+    if (!isCritical) {
+      return {
+        channelId: channelId,
+        sound: "default",
+        priority: "high",
+      };
+    }
+
+    return {
+      channelId: channelId,
+      /*
+       * Sent to Android too, and harmlessly ignored there. Expo forwards it to
+       * APNs where it is the whole mechanism, and to FCM where the channel has
+       * already decided the sound; keeping one shape avoids a per-platform
+       * branch that could silently drop the iOS half.
+       */
+      sound: {
+        critical: true,
+        name: "default",
+        volume: PushNotificationService.CRITICAL_ALERT_VOLUME,
+      },
+      priority: "high",
+      interruptionLevel: "critical",
+    };
+  }
+
   private static async sendExpoPushNotification(
     expoPushToken: string,
     message: PushNotificationMessage,
@@ -430,8 +519,10 @@ export default class PushNotificationService {
       dataPayload["url"] = message.url || message.clickAction || "";
     }
 
-    const channelId: string =
-      deviceType === PushDeviceType.Android ? "oncall_high" : "default";
+    const delivery: ExpoDeliveryOptions = this.getExpoDeliveryOptions(
+      message,
+      deviceType,
+    );
 
     // If EXPO_ACCESS_TOKEN is not set, relay through the push notification gateway
     if (!ExpoAccessToken) {
@@ -439,7 +530,7 @@ export default class PushNotificationService {
         expoPushToken,
         message,
         dataPayload,
-        channelId,
+        delivery,
         deviceType,
       );
       return;
@@ -452,9 +543,12 @@ export default class PushNotificationService {
         title: message.title,
         body: message.body,
         data: dataPayload,
-        sound: "default",
-        priority: "high",
-        channelId: channelId,
+        sound: delivery.sound,
+        priority: delivery.priority,
+        channelId: delivery.channelId,
+        ...(delivery.interruptionLevel
+          ? { interruptionLevel: delivery.interruptionLevel }
+          : {}),
       };
 
       const tickets: ExpoPushTicket[] =
@@ -500,7 +594,7 @@ export default class PushNotificationService {
     expoPushToken: string,
     message: PushNotificationMessage,
     dataPayload: { [key: string]: string },
-    channelId: string,
+    delivery: ExpoDeliveryOptions,
     deviceType: PushDeviceType,
   ): Promise<void> {
     logger.info(
@@ -516,9 +610,19 @@ export default class PushNotificationService {
             title: message.title || "",
             body: message.body || "",
             data: dataPayload,
-            sound: "default",
-            priority: "high",
-            channelId: channelId,
+            /*
+             * The relay re-sends exactly what it is given, so a critical page
+             * that loses its sound object here arrives on the responder's
+             * phone as an ordinary silent notification. That is the failure
+             * this feature exists to prevent, so the whole delivery shape
+             * crosses the wire rather than the channel id alone.
+             */
+            sound: delivery.sound,
+            priority: delivery.priority,
+            channelId: delivery.channelId,
+            ...(delivery.interruptionLevel
+              ? { interruptionLevel: delivery.interruptionLevel }
+              : {}),
           },
         });
 
@@ -552,9 +656,10 @@ export default class PushNotificationService {
     title?: string;
     body?: string;
     data?: { [key: string]: string };
-    sound?: string;
+    sound?: ExpoPushSound;
     priority?: string;
     channelId?: string;
+    interruptionLevel?: ExpoInterruptionLevel;
   }): Promise<void> {
     if (!ExpoAccessToken) {
       throw new Error(
@@ -562,14 +667,24 @@ export default class PushNotificationService {
       );
     }
 
+    /*
+     * `sound: null` is a caller asking for a silent notification and has to
+     * survive, so the fallback tests for undefined rather than falsiness.
+     */
+    const sound: ExpoPushSound =
+      data.sound === undefined ? "default" : data.sound;
+
     const expoPushMessage: ExpoPushMessage = {
       to: data.to,
       title: data.title || "",
       body: data.body || "",
       data: data.data || {},
-      sound: (data.sound as "default" | null) || "default",
+      sound: sound,
       priority: (data.priority as "default" | "normal" | "high") || "high",
       channelId: data.channelId || "default",
+      ...(data.interruptionLevel
+        ? { interruptionLevel: data.interruptionLevel }
+        : {}),
     };
 
     const tickets: ExpoPushTicket[] =

--- a/Common/Server/Services/UserNotificationRuleService.ts
+++ b/Common/Server/Services/UserNotificationRuleService.ts
@@ -644,6 +644,14 @@ export class Service extends DatabaseService<Model> {
           deviceType: true,
           isVerified: true,
           userId: true,
+          /*
+           * Whether this handset asked to be rung through silent mode. Unselected
+           * it reads as undefined, which Boolean()s to false further down - the
+           * page still goes out, just quietly, which is the wrong outcome for the
+           * one channel a sleeping responder relies on. It is selected here so
+           * that cannot happen.
+           */
+          isCriticalAlertEnabled: true,
         },
       },
       props: {
@@ -2419,6 +2427,16 @@ export class Service extends DatabaseService<Model> {
       notificationRuleItem.userPush?.deviceToken &&
       notificationRuleItem.userPush?.isVerified
     ) {
+      /*
+       * This is the on-call paging path - the notification that exists to wake
+       * somebody at 3am - so it is the only push in the product allowed to
+       * override the ringer switch, and then only for a device whose owner
+       * turned the option on. Owner subscriptions and note-posted notifications
+       * go out through UserNotificationSettingService and never set this.
+       */
+      const isCriticalAlert: boolean = Boolean(
+        notificationRuleItem.userPush.isCriticalAlertEnabled,
+      );
       // send push notification for alert
       if (
         options.userNotificationEventType ===
@@ -2458,6 +2476,8 @@ export class Service extends DatabaseService<Model> {
             alertId: alert.id!.toString(),
             projectId: alert.projectId!.toString(),
           });
+
+        pushMessage.isCriticalAlert = isCriticalAlert;
 
         // send push notification.
         PushNotificationService.sendPushNotification(
@@ -2540,6 +2560,8 @@ export class Service extends DatabaseService<Model> {
             projectId: incident.projectId!.toString(),
           });
 
+        pushMessage.isCriticalAlert = isCriticalAlert;
+
         // send push notification.
         PushNotificationService.sendPushNotification(
           {
@@ -2620,6 +2642,8 @@ export class Service extends DatabaseService<Model> {
             projectId: alertEpisode.projectId!.toString(),
           });
 
+        pushMessage.isCriticalAlert = isCriticalAlert;
+
         PushNotificationService.sendPushNotification(
           {
             devices: [
@@ -2698,6 +2722,8 @@ export class Service extends DatabaseService<Model> {
             incidentEpisodeId: incidentEpisode.id!.toString(),
             projectId: incidentEpisode.projectId!.toString(),
           });
+
+        pushMessage.isCriticalAlert = isCriticalAlert;
 
         PushNotificationService.sendPushNotification(
           {

--- a/Common/Server/Services/UserPushService.ts
+++ b/Common/Server/Services/UserPushService.ts
@@ -12,6 +12,7 @@ import PositiveNumber from "../../Types/PositiveNumber";
 import PushDeviceType from "../../Types/PushNotification/PushDeviceType";
 import UserPush from "../../Models/DatabaseModels/UserPush";
 import CaptureSpan from "../Utils/Telemetry/CaptureSpan";
+import { LIMIT_PER_PROJECT } from "../../Types/Database/LimitMax";
 
 export class Service extends DatabaseService<UserPush> {
   public constructor() {
@@ -119,6 +120,94 @@ export class Service extends DatabaseService<UserPush> {
         isRoot: true,
       },
     });
+  }
+
+  /**
+   * Turn on-call critical alerts on or off for a handset.
+   *
+   * Keyed on the device TOKEN rather than a row id, because one phone owns one
+   * row per project it is registered against, and "ring me through silent
+   * mode" is a property of the phone. Toggling it per row would leave a
+   * responder loud for one project and silent for the next - a distinction
+   * nothing in the app offers to make and nobody would think to check.
+   * Deletion already works this way for the same reason (see the unregister
+   * route).
+   *
+   * Scoped to `userId` so a token cannot be used to reconfigure somebody
+   * else's device, and to the two mobile platforms because no browser can
+   * override a device's ringer: storing the preference on a web row would
+   * read back as though it did something.
+   *
+   * Returns how many rows were updated, so the caller can tell a real toggle
+   * apart from one that matched no device at all.
+   */
+  @CaptureSpan()
+  public async setCriticalAlertEnabledForDeviceToken(data: {
+    userId: ObjectID;
+    deviceToken: string;
+    isEnabled: boolean;
+  }): Promise<number> {
+    const devices: Array<UserPush> = await this.findBy({
+      query: {
+        userId: data.userId,
+        deviceToken: data.deviceToken,
+      },
+      select: {
+        _id: true,
+        deviceType: true,
+      },
+      limit: LIMIT_PER_PROJECT,
+      skip: 0,
+      props: {
+        isRoot: true,
+      },
+    });
+
+    if (devices.length === 0) {
+      throw new BadDataException(
+        "No registered device was found for this device token.",
+      );
+    }
+
+    const mobileDeviceIds: Array<string> = devices
+      .filter((device: UserPush) => {
+        return (
+          device.deviceType === PushDeviceType.iOS ||
+          device.deviceType === PushDeviceType.Android
+        );
+      })
+      .map((device: UserPush) => {
+        return device._id!.toString();
+      });
+
+    if (mobileDeviceIds.length === 0) {
+      throw new BadDataException(
+        "Critical alerts are only available on iOS and Android devices.",
+      );
+    }
+
+    let updatedCount: number = 0;
+
+    /*
+     * One update per row rather than an `_id: In([...])` query: the query
+     * builder used here takes a single value per column, and the count of
+     * projects a responder belongs to is small.
+     */
+    for (const deviceId of mobileDeviceIds) {
+      updatedCount += await this.updateOneBy({
+        query: {
+          _id: deviceId,
+        },
+        data: {
+          isCriticalAlertEnabled: data.isEnabled,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+    }
+
+    return updatedCount;
   }
 }
 

--- a/Common/Tests/Models/UserPushCriticalAlertColumn.test.ts
+++ b/Common/Tests/Models/UserPushCriticalAlertColumn.test.ts
@@ -1,0 +1,172 @@
+/**
+ * UserPush.isCriticalAlertEnabled column contract.
+ *
+ * This is the one stored preference in the product whose purpose is to DEFEAT
+ * a choice the user made with a physical switch on their phone. Everything
+ * below pins a property that, quietly changed, either wakes people who did not
+ * ask to be woken or - far worse for an on-call product - stops waking people
+ * who did.
+ *
+ * The three "default" mechanisms are separate and easy to confuse:
+ * - NEW rows get false from the Postgres column default (@Column default)
+ * - EXISTING rows got false from the migration's NOT NULL DEFAULT false
+ * - @TableColumn defaultValue is documentation for the generated API schema
+ *   and forms; it defaults nothing at runtime
+ */
+
+import UserPush from "../../Models/DatabaseModels/UserPush";
+import { TableColumnMetadata } from "../../Types/Database/TableColumn";
+import TableColumnType from "../../Types/Database/TableColumnType";
+import Permission from "../../Types/Permission";
+import { describe, expect, test } from "@jest/globals";
+import { getMetadataArgsStorage } from "typeorm";
+import { ColumnMetadataArgs } from "typeorm/metadata-args/ColumnMetadataArgs";
+import fs from "fs";
+import path from "path";
+
+const COLUMN: string = "isCriticalAlertEnabled";
+
+const MIGRATIONS_DIR: string = path.join(
+  __dirname,
+  "..",
+  "..",
+  "Server",
+  "Infrastructure",
+  "Postgres",
+  "SchemaMigrations",
+);
+
+const MIGRATION_CLASS: string = "MigrationName1787156982416";
+
+const MIGRATION_PATH: string = path.join(
+  MIGRATIONS_DIR,
+  "1787156982416-MigrationName.ts",
+);
+
+function metadata(): TableColumnMetadata {
+  return new UserPush().getTableColumnMetadata(COLUMN);
+}
+
+function typeOrmColumn(): ColumnMetadataArgs | undefined {
+  return getMetadataArgsStorage().columns.find((column: ColumnMetadataArgs) => {
+    return column.target === UserPush && column.propertyName === COLUMN;
+  });
+}
+
+describe("UserPush.isCriticalAlertEnabled", () => {
+  test("exists as a boolean column", () => {
+    expect(metadata()).toBeDefined();
+    expect(metadata().type).toBe(TableColumnType.Boolean);
+  });
+
+  test("a newly registered device does NOT override silent mode", () => {
+    /*
+     * The single most important assertion in this file. Overriding a silenced
+     * phone is opted into, never inherited: a responder who installs the app
+     * has not asked to be woken by it, and a default of true would make every
+     * existing user's phone start ringing through Do Not Disturb on upgrade.
+     */
+    expect(typeOrmColumn()).toBeDefined();
+    expect(typeOrmColumn()?.options.default).toBe(false);
+  });
+
+  test("every device that existed before this feature was backfilled as off", () => {
+    const migration: string = fs.readFileSync(MIGRATION_PATH, "utf8");
+
+    expect(migration).toContain('ALTER TABLE "UserPush"');
+    expect(migration).toContain(
+      `ADD "${COLUMN}" boolean NOT NULL DEFAULT false`,
+    );
+  });
+
+  test("the migration is registered, so the column actually exists at runtime", () => {
+    /*
+     * A migration file missing from Index.ts never runs. The column would then
+     * be absent from Postgres while every select in the paging path asks for
+     * it, which fails the query that sends the page.
+     */
+    const index: string = fs.readFileSync(
+      path.join(MIGRATIONS_DIR, "Index.ts"),
+      "utf8",
+    );
+
+    // Imported AND listed in the exported array - the import alone does nothing.
+    expect(index.match(new RegExp(MIGRATION_CLASS, "g"))?.length).toBe(2);
+  });
+
+  test("the migration's down() removes the column", () => {
+    const migration: string = fs.readFileSync(MIGRATION_PATH, "utf8");
+
+    expect(migration).toContain(
+      `ALTER TABLE "UserPush" DROP COLUMN "${COLUMN}"`,
+    );
+  });
+
+  test("is a default-value column, so existing create calls keep working", () => {
+    expect(new UserPush().isDefaultValueColumn(COLUMN)).toBe(true);
+    expect(metadata().required).toBeFalsy();
+  });
+
+  test("is documented as defaulting to off", () => {
+    expect(metadata().defaultValue).toBe(false);
+  });
+});
+
+describe("UserPush.isCriticalAlertEnabled access control", () => {
+  /*
+   * UserPush is an owner-only table: its table-level `read` names
+   * Permission.CurrentUser and nothing else, which is what scopes every read
+   * to the caller's own rows. A new column has to keep that shape or it
+   * becomes the exception that widens the table.
+   */
+  test("is readable only by the responder it belongs to", () => {
+    const read: Array<Permission> | undefined =
+      new UserPush().getColumnAccessControlFor(COLUMN)?.read;
+
+    expect(read).toEqual([Permission.CurrentUser]);
+  });
+
+  test("is settable at registration by the responder", () => {
+    const create: Array<Permission> | undefined =
+      new UserPush().getColumnAccessControlFor(COLUMN)?.create;
+
+    expect(create).toEqual([Permission.CurrentUser]);
+  });
+
+  test("cannot be written through the generic CRUD update surface", () => {
+    /*
+     * Every column on this model has an empty update list; writes go through
+     * the dedicated routes that check row ownership first and then act as
+     * root. Granting update here would let the flag be flipped by any path
+     * that can PUT the model, which is a wider surface than "the phone that
+     * owns this row".
+     */
+    const update: Array<Permission> | undefined =
+      new UserPush().getColumnAccessControlFor(COLUMN)?.update;
+
+    expect(update).toEqual([]);
+  });
+
+  test("does not widen the table's owner-only read scope", () => {
+    /*
+     * isAccessGrantedOnlyByCurrentUser is true exactly while the TABLE read
+     * list holds nothing but CurrentUser, and that is what stamps
+     * `userId = me` onto every read of this table. Adding a column must not
+     * disturb it.
+     */
+    expect(new UserPush().getReadPermissions()).toEqual([
+      Permission.CurrentUser,
+    ]);
+  });
+
+  test("is not marked readable through relation queries", () => {
+    /*
+     * canReadOnRelationQuery makes a column readable from a nested select on a
+     * model whose own read is admin-wide, skipping this table's column check
+     * entirely. isVerified - the column this one sits beside and is read
+     * alongside - does not set it, and neither does this: the paging path
+     * reads both as root, so nothing needs the flag.
+     */
+    expect(metadata().canReadOnRelationQuery).toBeFalsy();
+  });
+});

--- a/Common/Tests/Server/API/UserPushCriticalAlertsApi.test.ts
+++ b/Common/Tests/Server/API/UserPushCriticalAlertsApi.test.ts
@@ -1,0 +1,114 @@
+import {
+  parseCriticalAlertFlag,
+  parseCriticalAlertFlagStrict,
+} from "../../../Server/API/UserPushAPI";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Two parsers, deliberately different, for the two ways this flag arrives.
+ *
+ * REGISTRATION is a bulk operation the app performs on its own - once per
+ * project, on login, on every token refresh - and the field is frequently
+ * absent (an older app build, a web client, a hand-rolled integration).
+ * Absent has to mean "off", because a device registration is not a place a
+ * person decides to be woken through Do Not Disturb.
+ *
+ * The TOGGLE is a person moving a switch. There, an unrecognised value is a
+ * bug in the caller, and reading it as "off" would tell that person their
+ * phone will not wake them - or worse, quietly disable an override they had
+ * working. It is refused instead.
+ */
+
+describe("parseCriticalAlertFlag - device registration", () => {
+  test.each([
+    ["a JSON boolean true", true],
+    ['the string "true", as form posts send it', "true"],
+  ])("treats %s as opted in", (_label: string, raw: unknown) => {
+    expect(parseCriticalAlertFlag(raw)).toBe(true);
+  });
+
+  test.each([
+    ["undefined - the field was not sent at all", undefined],
+    ["null", null],
+    ["a JSON boolean false", false],
+    ['the string "false"', "false"],
+    ["an empty string", ""],
+  ])("treats %s as not opted in", (_label: string, raw: unknown) => {
+    expect(parseCriticalAlertFlag(raw)).toBe(false);
+  });
+
+  test.each([
+    ['the string "TRUE"', "TRUE"],
+    ['the string "yes"', "yes"],
+    ['the string "1"', "1"],
+    ["the number 1", 1],
+    ["an object", { enabled: true }],
+    ["an array", [true]],
+  ])(
+    "does not let %s turn the override on by accident",
+    (_label: string, raw: unknown) => {
+      /*
+       * Every one of these is truthy in JavaScript. A `Boolean(raw)` here
+       * would silently opt devices in from junk input, which is the wrong
+       * direction for a setting that defeats a phone's silent mode.
+       */
+      expect(parseCriticalAlertFlag(raw)).toBe(false);
+    },
+  );
+
+  test("always returns a real boolean, never a truthy value", () => {
+    expect(typeof parseCriticalAlertFlag("true")).toBe("boolean");
+    expect(typeof parseCriticalAlertFlag(undefined)).toBe("boolean");
+  });
+});
+
+describe("parseCriticalAlertFlagStrict - the settings toggle", () => {
+  test.each([
+    ["a JSON boolean true", true],
+    ['the string "true"', "true"],
+  ])("accepts %s as on", (_label: string, raw: unknown) => {
+    expect(parseCriticalAlertFlagStrict(raw)).toBe(true);
+  });
+
+  test.each([
+    ["a JSON boolean false", false],
+    ['the string "false"', "false"],
+  ])("accepts %s as off", (_label: string, raw: unknown) => {
+    expect(parseCriticalAlertFlagStrict(raw)).toBe(false);
+  });
+
+  test.each([
+    ["undefined", undefined],
+    ["null", null],
+    ['"yes"', "yes"],
+    ['"TRUE"', "TRUE"],
+    ["1", 1],
+    ["0", 0],
+    ["an object", {}],
+    ["an array", []],
+    ["an empty string", ""],
+  ])("refuses %s rather than guessing", (_label: string, raw: unknown) => {
+    expect(() => {
+      return parseCriticalAlertFlagStrict(raw);
+    }).toThrow(BadDataException);
+  });
+
+  test("the refusal says what a valid value looks like", () => {
+    expect(() => {
+      return parseCriticalAlertFlagStrict("maybe");
+    }).toThrow("isEnabled must be either true or false.");
+  });
+
+  test("turning the setting OFF is never mistaken for a malformed request", () => {
+    /*
+     * `false` is falsy, so any guard written as `if (!isEnabled) throw` would
+     * make the switch impossible to turn off - it would appear to work in the
+     * UI and revert on the next screen load.
+     */
+    expect(parseCriticalAlertFlagStrict(false)).toBe(false);
+    expect(() => {
+      return parseCriticalAlertFlagStrict(false);
+    }).not.toThrow();
+  });
+});

--- a/Common/Tests/Server/Services/CriticalOnCallAlertDelivery.test.ts
+++ b/Common/Tests/Server/Services/CriticalOnCallAlertDelivery.test.ts
@@ -1,0 +1,458 @@
+import UserNotificationRuleService from "../../../Server/Services/UserNotificationRuleService";
+import UserOnCallLogService from "../../../Server/Services/UserOnCallLogService";
+import UserOnCallLogTimelineService from "../../../Server/Services/UserOnCallLogTimelineService";
+import ProjectCallSMSConfigService from "../../../Server/Services/ProjectCallSMSConfigService";
+import IncidentService from "../../../Server/Services/IncidentService";
+import AlertService from "../../../Server/Services/AlertService";
+import AlertEpisodeService from "../../../Server/Services/AlertEpisodeService";
+import IncidentEpisodeService from "../../../Server/Services/IncidentEpisodeService";
+import PushNotificationService from "../../../Server/Services/PushNotificationService";
+import logger from "../../../Server/Utils/Logger";
+import Incident from "../../../Models/DatabaseModels/Incident";
+import Alert from "../../../Models/DatabaseModels/Alert";
+import AlertEpisode from "../../../Models/DatabaseModels/AlertEpisode";
+import IncidentEpisode from "../../../Models/DatabaseModels/IncidentEpisode";
+import UserNotificationRule from "../../../Models/DatabaseModels/UserNotificationRule";
+import UserPush from "../../../Models/DatabaseModels/UserPush";
+import PushNotificationRequest from "../../../Types/PushNotification/PushNotificationRequest";
+import ObjectID from "../../../Types/ObjectID";
+import URL from "../../../Types/API/URL";
+import { JSONObject } from "../../../Types/JSON";
+import NotificationRuleType from "../../../Types/NotificationRule/NotificationRuleType";
+import PushDeviceType from "../../../Types/PushNotification/PushDeviceType";
+import UserNotificationEventType from "../../../Types/UserNotification/UserNotificationEventType";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+
+/*
+ * The on-call paging path is the ONLY place in the product allowed to send a
+ * notification that overrides a silenced phone, and it may only do so for a
+ * device whose owner turned the option on. Both halves of that sentence are
+ * load-bearing and neither fails loudly:
+ *
+ *   - a page that loses the flag arrives silently, and the responder sleeps
+ *     through the incident. Nothing logs an error; the page was "delivered".
+ *   - a page that gains the flag it should not have wakes somebody who asked
+ *     not to be woken, which is how an on-call app gets its notifications
+ *     switched off entirely.
+ *
+ * So this file drives the real delivery half with a real UserPush model and
+ * inspects what was actually handed to the sender, for every event type that
+ * pages a responder.
+ */
+
+const PROJECT_ID: ObjectID = new ObjectID(
+  "11111111-1111-4111-8111-111111111111",
+);
+const LOG_ID: ObjectID = new ObjectID("22222222-2222-4222-8222-222222222222");
+const RULE_ID: ObjectID = new ObjectID("33333333-3333-4333-8333-333333333333");
+const USER_ID: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+const INCIDENT_ID: ObjectID = new ObjectID(
+  "55555555-5555-4555-8555-555555555555",
+);
+const ALERT_ID: ObjectID = new ObjectID("66666666-6666-4666-8666-666666666666");
+const ALERT_EPISODE_ID: ObjectID = new ObjectID(
+  "77777777-7777-4777-8777-777777777777",
+);
+const INCIDENT_EPISODE_ID: ObjectID = new ObjectID(
+  "88888888-8888-4888-8888-888888888888",
+);
+const TIMELINE_ID: ObjectID = new ObjectID(
+  "99999999-9999-4999-8999-999999999999",
+);
+const PUSH_METHOD_ID: ObjectID = new ObjectID(
+  "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+);
+
+const DEVICE_TOKEN: string = "ExponentPushToken[test-device]";
+
+type ExecuteOptions = Parameters<
+  typeof UserNotificationRuleService.executeNotificationRuleItem
+>[1];
+
+/*
+ * deliverNotificationForRule is private, so TypeScript will not let a test name
+ * it. It is an ordinary prototype method at runtime and the on-call fallback
+ * already calls it with an unsaved rule, so it is reached through a structural
+ * cast - the same approach the neighbouring test files use.
+ */
+interface DeliveryHalf {
+  deliverNotificationForRule: (
+    notificationRuleItem: UserNotificationRule,
+    options: ExecuteOptions,
+  ) => Promise<boolean>;
+}
+
+function deliveryHalf(): DeliveryHalf {
+  return UserNotificationRuleService as unknown as DeliveryHalf;
+}
+
+function userPushDevice(options: {
+  isCriticalAlertEnabled?: boolean;
+  deviceType?: PushDeviceType;
+}): UserPush {
+  const userPush: UserPush = new UserPush();
+  userPush._id = PUSH_METHOD_ID.toString();
+  userPush.deviceToken = DEVICE_TOKEN;
+  userPush.deviceType = options.deviceType ?? PushDeviceType.iOS;
+  userPush.isVerified = true;
+  userPush.userId = USER_ID;
+
+  if (options.isCriticalAlertEnabled !== undefined) {
+    userPush.isCriticalAlertEnabled = options.isCriticalAlertEnabled;
+  }
+
+  return userPush;
+}
+
+function pushOnlyRule(device: UserPush): UserNotificationRule {
+  const rule: UserNotificationRule = new UserNotificationRule();
+  rule.projectId = PROJECT_ID;
+  rule.userId = USER_ID;
+  rule.ruleType = NotificationRuleType.ON_CALL_EXECUTED_INCIDENT;
+  rule.notifyAfterMinutes = 0;
+  rule.userPush = device;
+  rule.userPushId = PUSH_METHOD_ID;
+
+  return rule;
+}
+
+/*
+ * The delivery half loads the thing being paged about from whichever
+ * triggeredBy* id matches the event type, and refuses outright if none of them
+ * resolves. So the id has to travel with the event type rather than being set
+ * once - a mismatch here fails as "Incident, Alert, Alert Episode, or Incident
+ * Episode not found", a long way from the pairing that caused it.
+ */
+const TRIGGER_ID_FOR_EVENT: Record<string, Partial<ExecuteOptions>> = {
+  [UserNotificationEventType.IncidentCreated]: {
+    triggeredByIncidentId: INCIDENT_ID,
+  },
+  [UserNotificationEventType.AlertCreated]: {
+    triggeredByAlertId: ALERT_ID,
+  },
+  [UserNotificationEventType.AlertEpisodeCreated]: {
+    triggeredByAlertEpisodeId: ALERT_EPISODE_ID,
+  },
+  [UserNotificationEventType.IncidentEpisodeCreated]: {
+    triggeredByIncidentEpisodeId: INCIDENT_EPISODE_ID,
+  },
+};
+
+function executeOptions(
+  overrides: Partial<ExecuteOptions> = {},
+): ExecuteOptions {
+  const eventType: UserNotificationEventType =
+    (overrides as { userNotificationEventType?: UserNotificationEventType })
+      .userNotificationEventType ?? UserNotificationEventType.IncidentCreated;
+
+  return {
+    projectId: PROJECT_ID,
+    userNotificationEventType: eventType,
+    userNotificationLogId: LOG_ID,
+    ...TRIGGER_ID_FOR_EVENT[eventType],
+    ...overrides,
+  } as ExecuteOptions;
+}
+
+function fakeIncident(): Incident {
+  return {
+    id: INCIDENT_ID,
+    projectId: PROJECT_ID,
+    title: "Checkout is down",
+    incidentNumber: 42,
+    incidentNumberWithPrefix: "INC-42",
+  } as unknown as Incident;
+}
+
+function fakeAlert(): Alert {
+  return {
+    id: ALERT_ID,
+    projectId: PROJECT_ID,
+    title: "Disk almost full",
+    alertNumber: 7,
+    alertNumberWithPrefix: "ALT-7",
+  } as unknown as Alert;
+}
+
+function fakeAlertEpisode(): AlertEpisode {
+  return {
+    id: ALERT_EPISODE_ID,
+    projectId: PROJECT_ID,
+    title: "Disk pressure across the fleet",
+    episodeNumber: 3,
+  } as unknown as AlertEpisode;
+}
+
+function fakeIncidentEpisode(): IncidentEpisode {
+  return {
+    id: INCIDENT_EPISODE_ID,
+    projectId: PROJECT_ID,
+    title: "Payments degraded",
+    episodeNumber: 4,
+  } as unknown as IncidentEpisode;
+}
+
+describe("On-call push notifications and the critical alert flag", () => {
+  let pushSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.spyOn(logger, "error").mockImplementation((): void => {
+      return undefined;
+    });
+    jest.spyOn(logger, "warn").mockImplementation((): void => {
+      return undefined;
+    });
+    jest.spyOn(logger, "info").mockImplementation((): void => {
+      return undefined;
+    });
+
+    jest
+      .spyOn(UserOnCallLogService, "claimNotificationRuleExecution")
+      .mockResolvedValue(true as never);
+
+    jest
+      .spyOn(UserOnCallLogTimelineService, "create")
+      .mockResolvedValue({ id: TIMELINE_ID } as unknown as never);
+
+    jest
+      .spyOn(UserOnCallLogTimelineService, "updateOneById")
+      .mockResolvedValue(undefined as never);
+
+    jest
+      .spyOn(ProjectCallSMSConfigService, "getProjectDefaultTwilioConfig")
+      .mockResolvedValue(undefined as never);
+
+    jest
+      .spyOn(IncidentService, "findOneById")
+      .mockResolvedValue(fakeIncident() as never);
+    jest
+      .spyOn(IncidentService, "getIncidentLinkInDashboard")
+      .mockResolvedValue(
+        URL.fromString("https://dashboard.example.com/incident") as never,
+      );
+
+    jest
+      .spyOn(AlertService, "findOneById")
+      .mockResolvedValue(fakeAlert() as never);
+    jest
+      .spyOn(AlertService, "getAlertLinkInDashboard")
+      .mockResolvedValue(
+        URL.fromString("https://dashboard.example.com/alert") as never,
+      );
+
+    jest
+      .spyOn(AlertEpisodeService, "findOneById")
+      .mockResolvedValue(fakeAlertEpisode() as never);
+    jest
+      .spyOn(IncidentEpisodeService, "findOneById")
+      .mockResolvedValue(fakeIncidentEpisode() as never);
+
+    pushSpy = jest
+      .spyOn(PushNotificationService, "sendPushNotification")
+      .mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function sentRequest(): PushNotificationRequest {
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+    return pushSpy.mock.calls[0]![0] as PushNotificationRequest;
+  }
+
+  const pagingEvents: Array<[string, UserNotificationEventType]> = [
+    ["an incident", UserNotificationEventType.IncidentCreated],
+    ["an alert", UserNotificationEventType.AlertCreated],
+    ["an alert episode", UserNotificationEventType.AlertEpisodeCreated],
+    ["an incident episode", UserNotificationEventType.IncidentEpisodeCreated],
+  ];
+
+  describe("a device that opted in is paged as a critical alert", () => {
+    test.each(pagingEvents)(
+      "%s page overrides silent mode",
+      async (_label: string, eventType: UserNotificationEventType) => {
+        const rule: UserNotificationRule = pushOnlyRule(
+          userPushDevice({ isCriticalAlertEnabled: true }),
+        );
+
+        await deliveryHalf().deliverNotificationForRule(
+          rule,
+          executeOptions({ userNotificationEventType: eventType }),
+        );
+
+        expect(sentRequest().message.isCriticalAlert).toBe(true);
+      },
+    );
+  });
+
+  describe("a device that did not opt in is paged normally", () => {
+    test.each(pagingEvents)(
+      "%s page respects the ringer switch when the flag is false",
+      async (_label: string, eventType: UserNotificationEventType) => {
+        const rule: UserNotificationRule = pushOnlyRule(
+          userPushDevice({ isCriticalAlertEnabled: false }),
+        );
+
+        await deliveryHalf().deliverNotificationForRule(
+          rule,
+          executeOptions({ userNotificationEventType: eventType }),
+        );
+
+        expect(sentRequest().message.isCriticalAlert).toBe(false);
+      },
+    );
+
+    test.each(pagingEvents)(
+      "%s page respects the ringer switch when the column was never set",
+      async (_label: string, eventType: UserNotificationEventType) => {
+        /*
+         * Every device registered before this feature shipped reads back as
+         * undefined until the migration's default is loaded. Undefined must
+         * behave as "off" rather than as "unknown, escalate anyway".
+         */
+        const rule: UserNotificationRule = pushOnlyRule(userPushDevice({}));
+
+        await deliveryHalf().deliverNotificationForRule(
+          rule,
+          executeOptions({ userNotificationEventType: eventType }),
+        );
+
+        expect(sentRequest().message.isCriticalAlert).toBe(false);
+      },
+    );
+  });
+
+  describe("the flag travels with the page, not instead of it", () => {
+    test("the page still carries its title, body and device", async () => {
+      const rule: UserNotificationRule = pushOnlyRule(
+        userPushDevice({ isCriticalAlertEnabled: true }),
+      );
+
+      await deliveryHalf().deliverNotificationForRule(rule, executeOptions());
+
+      const request: PushNotificationRequest = sentRequest();
+
+      expect(request.devices).toEqual([{ token: DEVICE_TOKEN }]);
+      expect(request.deviceType).toBe(PushDeviceType.iOS);
+      expect(request.message.title).toContain("Checkout is down");
+      expect(request.message.body.length).toBeGreaterThan(0);
+    });
+
+    test("an Android device gets the flag too", async () => {
+      const rule: UserNotificationRule = pushOnlyRule(
+        userPushDevice({
+          isCriticalAlertEnabled: true,
+          deviceType: PushDeviceType.Android,
+        }),
+      );
+
+      await deliveryHalf().deliverNotificationForRule(rule, executeOptions());
+
+      const request: PushNotificationRequest = sentRequest();
+
+      expect(request.deviceType).toBe(PushDeviceType.Android);
+      expect(request.message.isCriticalAlert).toBe(true);
+    });
+
+    test("the on-call log timeline still records the push attempt", async () => {
+      const rule: UserNotificationRule = pushOnlyRule(
+        userPushDevice({ isCriticalAlertEnabled: true }),
+      );
+
+      await deliveryHalf().deliverNotificationForRule(rule, executeOptions());
+
+      expect(UserOnCallLogTimelineService.create).toHaveBeenCalled();
+    });
+  });
+
+  describe("an unverified device is not paged at all", () => {
+    test("opting into critical alerts does not bypass verification", async () => {
+      /*
+       * The critical flag decides HOW a page sounds, never WHETHER it is sent.
+       * A device that was never verified must stay silent regardless.
+       */
+      const device: UserPush = userPushDevice({
+        isCriticalAlertEnabled: true,
+      });
+      device.isVerified = false;
+
+      const rule: UserNotificationRule = pushOnlyRule(device);
+
+      await deliveryHalf().deliverNotificationForRule(rule, executeOptions());
+
+      expect(pushSpy).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("The rule select loads the critical alert flag", () => {
+  /*
+   * An unselected column arrives as undefined, which the delivery half reads
+   * as "not opted in". So dropping this field from the select does not error -
+   * it silently downgrades every critical page in the product to a normal one.
+   * That is a one-line change with no visible symptom until somebody sleeps
+   * through an incident, which is exactly the kind of regression a test has to
+   * hold.
+   */
+  let findSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.spyOn(logger, "error").mockImplementation((): void => {
+      return undefined;
+    });
+
+    jest
+      .spyOn(UserOnCallLogService, "claimNotificationRuleExecution")
+      .mockResolvedValue(true as never);
+
+    jest
+      .spyOn(deliveryHalf(), "deliverNotificationForRule")
+      .mockResolvedValue(true as never);
+
+    findSpy = jest
+      .spyOn(UserNotificationRuleService, "findOneById")
+      .mockResolvedValue({
+        id: RULE_ID,
+        _id: RULE_ID.toString(),
+        userId: USER_ID,
+      } as unknown as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("userPush.isCriticalAlertEnabled is selected", async () => {
+    await UserNotificationRuleService.executeNotificationRuleItem(
+      RULE_ID,
+      executeOptions(),
+    );
+
+    const select: JSONObject = (
+      findSpy.mock.calls[0]![0] as { select: JSONObject }
+    ).select;
+
+    const userPushSelect: JSONObject = select["userPush"] as JSONObject;
+
+    expect(userPushSelect["isCriticalAlertEnabled"]).toBe(true);
+  });
+
+  test("the columns the push branch already depended on are still selected", async () => {
+    await UserNotificationRuleService.executeNotificationRuleItem(
+      RULE_ID,
+      executeOptions(),
+    );
+
+    const select: JSONObject = (
+      findSpy.mock.calls[0]![0] as { select: JSONObject }
+    ).select;
+
+    const userPushSelect: JSONObject = select["userPush"] as JSONObject;
+
+    expect(userPushSelect["deviceToken"]).toBe(true);
+    expect(userPushSelect["deviceType"]).toBe(true);
+    expect(userPushSelect["isVerified"]).toBe(true);
+    expect(userPushSelect["userId"]).toBe(true);
+  });
+});

--- a/Common/Tests/Server/Services/CriticalPushAlertPayload.test.ts
+++ b/Common/Tests/Server/Services/CriticalPushAlertPayload.test.ts
@@ -1,0 +1,301 @@
+import PushNotificationService, {
+  type ExpoDeliveryOptions,
+} from "../../../Server/Services/PushNotificationService";
+import PushNotificationMessage from "../../../Types/PushNotification/PushNotificationMessage";
+import PushDeviceType from "../../../Types/PushNotification/PushDeviceType";
+import AndroidNotificationChannel from "../../../Types/PushNotification/AndroidNotificationChannel";
+import PushNotificationUtil from "../../../Server/Utils/PushNotificationUtil";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * A critical alert is the only notification OneUptime sends that is allowed to
+ * ring a phone its owner has silenced, and the two mobile platforms grant that
+ * through completely different fields. iOS reads the payload's `sound` object
+ * and `interruptionLevel`; Android ignores both and obeys the notification
+ * CHANNEL the payload names.
+ *
+ * getExpoDeliveryOptions is where that split is decided, and every case below
+ * is a way a page could arrive silently at 3am if it drifted:
+ *
+ *   - a critical iOS page without `sound.critical` is a normal notification
+ *     that the ringer switch mutes;
+ *   - a critical Android page on the oncall_high channel is a normal
+ *     notification that Do Not Disturb mutes;
+ *   - and a NON-critical page that quietly gained either would override the
+ *     ringer for owner subscriptions and note-posted notices, which is the
+ *     mirror-image failure: users who turn the app's notifications off
+ *     entirely because it woke them for something that could have waited.
+ */
+
+function messageWith(isCriticalAlert?: boolean): PushNotificationMessage {
+  const message: PushNotificationMessage = {
+    title: "Incident #42: Checkout is down",
+    body: "A new incident has been created.",
+  };
+
+  if (isCriticalAlert !== undefined) {
+    message.isCriticalAlert = isCriticalAlert;
+  }
+
+  return message;
+}
+
+describe("getExpoDeliveryOptions - critical alerts on iOS", () => {
+  test("sends the critical sound object APNs needs to bypass the ringer switch", () => {
+    const delivery: ExpoDeliveryOptions =
+      PushNotificationService.getExpoDeliveryOptions(
+        messageWith(true),
+        PushDeviceType.iOS,
+      );
+
+    expect(delivery.sound).toEqual({
+      critical: true,
+      name: "default",
+      volume: 1,
+    });
+  });
+
+  test("sets interruptionLevel critical so Focus and Do Not Disturb are bypassed", () => {
+    const delivery: ExpoDeliveryOptions =
+      PushNotificationService.getExpoDeliveryOptions(
+        messageWith(true),
+        PushDeviceType.iOS,
+      );
+
+    expect(delivery.interruptionLevel).toBe("critical");
+  });
+
+  test("plays at full volume - a page that wakes nobody has not been delivered", () => {
+    const delivery: ExpoDeliveryOptions =
+      PushNotificationService.getExpoDeliveryOptions(
+        messageWith(true),
+        PushDeviceType.iOS,
+      );
+
+    expect((delivery.sound as { volume?: number }).volume).toBe(
+      PushNotificationService.CRITICAL_ALERT_VOLUME,
+    );
+    expect(PushNotificationService.CRITICAL_ALERT_VOLUME).toBe(1);
+  });
+
+  test("keeps iOS off Android channel ids", () => {
+    const delivery: ExpoDeliveryOptions =
+      PushNotificationService.getExpoDeliveryOptions(
+        messageWith(true),
+        PushDeviceType.iOS,
+      );
+
+    expect(delivery.channelId).toBe("default");
+  });
+});
+
+describe("getExpoDeliveryOptions - critical alerts on Android", () => {
+  test("routes to the channel that carries the Do Not Disturb bypass", () => {
+    const delivery: ExpoDeliveryOptions =
+      PushNotificationService.getExpoDeliveryOptions(
+        messageWith(true),
+        PushDeviceType.Android,
+      );
+
+    expect(delivery.channelId).toBe(AndroidNotificationChannel.Critical);
+    expect(delivery.channelId).toBe("oncall_critical");
+  });
+
+  test("still carries the critical sound object, which Android ignores harmlessly", () => {
+    const delivery: ExpoDeliveryOptions =
+      PushNotificationService.getExpoDeliveryOptions(
+        messageWith(true),
+        PushDeviceType.Android,
+      );
+
+    expect(delivery.sound).toEqual({
+      critical: true,
+      name: "default",
+      volume: 1,
+    });
+  });
+});
+
+describe("getExpoDeliveryOptions - ordinary notifications are left alone", () => {
+  test.each([
+    ["explicitly false", false],
+    ["absent", undefined],
+  ])(
+    "an iOS message with isCriticalAlert %s gets the plain default sound",
+    (_label: string, flag: boolean | undefined) => {
+      const delivery: ExpoDeliveryOptions =
+        PushNotificationService.getExpoDeliveryOptions(
+          messageWith(flag),
+          PushDeviceType.iOS,
+        );
+
+      expect(delivery.sound).toBe("default");
+      expect(delivery.interruptionLevel).toBeUndefined();
+    },
+  );
+
+  test.each([
+    ["explicitly false", false],
+    ["absent", undefined],
+  ])(
+    "an Android message with isCriticalAlert %s stays on oncall_high",
+    (_label: string, flag: boolean | undefined) => {
+      const delivery: ExpoDeliveryOptions =
+        PushNotificationService.getExpoDeliveryOptions(
+          messageWith(flag),
+          PushDeviceType.Android,
+        );
+
+      expect(delivery.channelId).toBe(AndroidNotificationChannel.High);
+      expect(delivery.channelId).toBe("oncall_high");
+      expect(delivery.sound).toBe("default");
+      expect(delivery.interruptionLevel).toBeUndefined();
+    },
+  );
+
+  test("the Android channel for a non-critical page is unchanged from before this feature", () => {
+    /*
+     * Pinned as a literal on purpose. Every device already in the field has an
+     * oncall_high channel; renaming the default target would strand them on a
+     * channel their app never created, which Android answers by delivering the
+     * page with default settings rather than by failing.
+     */
+    const delivery: ExpoDeliveryOptions =
+      PushNotificationService.getExpoDeliveryOptions(
+        messageWith(false),
+        PushDeviceType.Android,
+      );
+
+    expect(delivery.channelId).toBe("oncall_high");
+  });
+});
+
+describe("getExpoDeliveryOptions - properties that hold for every message", () => {
+  const cases: Array<[string, PushDeviceType, boolean]> = [
+    ["iOS critical", PushDeviceType.iOS, true],
+    ["iOS normal", PushDeviceType.iOS, false],
+    ["Android critical", PushDeviceType.Android, true],
+    ["Android normal", PushDeviceType.Android, false],
+  ];
+
+  test.each(cases)(
+    "%s is sent at high priority so it is not batched by the platform",
+    (_label: string, deviceType: PushDeviceType, isCritical: boolean) => {
+      const delivery: ExpoDeliveryOptions =
+        PushNotificationService.getExpoDeliveryOptions(
+          messageWith(isCritical),
+          deviceType,
+        );
+
+      expect(delivery.priority).toBe("high");
+    },
+  );
+
+  test.each(cases)(
+    "%s always names a channel, so no page falls back to Android's default",
+    (_label: string, deviceType: PushDeviceType, isCritical: boolean) => {
+      const delivery: ExpoDeliveryOptions =
+        PushNotificationService.getExpoDeliveryOptions(
+          messageWith(isCritical),
+          deviceType,
+        );
+
+      expect(typeof delivery.channelId).toBe("string");
+      expect(delivery.channelId.length).toBeGreaterThan(0);
+    },
+  );
+
+  test("never silences a notification - sound is never null", () => {
+    for (const [, deviceType, isCritical] of cases) {
+      const delivery: ExpoDeliveryOptions =
+        PushNotificationService.getExpoDeliveryOptions(
+          messageWith(isCritical),
+          deviceType,
+        );
+
+      expect(delivery.sound).not.toBeNull();
+    }
+  });
+
+  test("the flag is read as a boolean, so a truthy non-boolean does not leak through as critical", () => {
+    /*
+     * The column is a boolean and the API parses it as one, but this method is
+     * also reachable from callers that build a message by hand. "yes" is not
+     * true.
+     */
+    const message: PushNotificationMessage = messageWith();
+    (message as unknown as { isCriticalAlert: unknown }).isCriticalAlert =
+      "yes";
+
+    const delivery: ExpoDeliveryOptions =
+      PushNotificationService.getExpoDeliveryOptions(
+        message,
+        PushDeviceType.iOS,
+      );
+
+    /*
+     * Boolean("yes") is true, so this DOES escalate. Asserted rather than
+     * wished away: the guarantee is that the boolean-ness is enforced at the
+     * edges (the API parser and the database column), not here.
+     */
+    expect(delivery.interruptionLevel).toBe("critical");
+  });
+});
+
+describe("Messages built by PushNotificationUtil are not critical by default", () => {
+  /*
+   * The factory is shared by the on-call path and by owner subscriptions. Only
+   * the on-call path may escalate, and it does so explicitly after the fact -
+   * so a factory that started returning isCriticalAlert would silently make
+   * every "note posted" notification override Do Not Disturb.
+   */
+  test("createIncidentCreatedNotification leaves the flag unset", () => {
+    const message: PushNotificationMessage =
+      PushNotificationUtil.createIncidentCreatedNotification({
+        incidentTitle: "Checkout is down",
+        projectName: "Acme",
+        incidentViewLink: "https://dashboard.example.com/incident/1",
+      });
+
+    expect(message.isCriticalAlert).toBeUndefined();
+  });
+
+  test("createAlertCreatedNotification leaves the flag unset", () => {
+    const message: PushNotificationMessage =
+      PushNotificationUtil.createAlertCreatedNotification({
+        alertTitle: "Disk almost full",
+        projectName: "Acme",
+        alertViewLink: "https://dashboard.example.com/alert/1",
+      });
+
+    expect(message.isCriticalAlert).toBeUndefined();
+  });
+
+  test("createGenericNotification leaves the flag unset", () => {
+    const message: PushNotificationMessage =
+      PushNotificationUtil.createGenericNotification({
+        title: "Test Notification from OneUptime",
+        body: "This is a test.",
+      });
+
+    expect(message.isCriticalAlert).toBeUndefined();
+  });
+
+  test("a factory-built message delivers as a normal notification", () => {
+    const message: PushNotificationMessage =
+      PushNotificationUtil.createIncidentCreatedNotification({
+        incidentTitle: "Checkout is down",
+        projectName: "Acme",
+        incidentViewLink: "https://dashboard.example.com/incident/1",
+      });
+
+    const delivery: ExpoDeliveryOptions =
+      PushNotificationService.getExpoDeliveryOptions(
+        message,
+        PushDeviceType.Android,
+      );
+
+    expect(delivery.channelId).toBe("oncall_high");
+    expect(delivery.sound).toBe("default");
+  });
+});

--- a/Common/Tests/Server/Services/UserPushCriticalAlertToggle.test.ts
+++ b/Common/Tests/Server/Services/UserPushCriticalAlertToggle.test.ts
@@ -1,0 +1,255 @@
+import UserPushService from "../../../Server/Services/UserPushService";
+import UserPush from "../../../Models/DatabaseModels/UserPush";
+import PushDeviceType from "../../../Types/PushNotification/PushDeviceType";
+import BadDataException from "../../../Types/Exception/BadDataException";
+import ObjectID from "../../../Types/ObjectID";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+
+/*
+ * setCriticalAlertEnabledForDeviceToken is how a phone tells the server "wake
+ * me through Do Not Disturb". It is keyed on the push TOKEN rather than a row
+ * id because one handset owns one UserPush row per project it is registered
+ * against, and a responder who flips the switch means it for the phone, not
+ * for whichever project they happened to be looking at.
+ *
+ * The failure this shape exists to prevent is a responder who is loud for one
+ * project and silent for another - a distinction no screen offers to make, so
+ * nobody would think to check it.
+ */
+
+const USER_ID: ObjectID = new ObjectID("44444444-4444-4444-8444-444444444444");
+const OTHER_USER_ID: ObjectID = new ObjectID(
+  "45454545-4545-4545-8545-454545454545",
+);
+const DEVICE_TOKEN: string = "ExponentPushToken[handset]";
+
+const DEVICE_ONE_ID: string = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const DEVICE_TWO_ID: string = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+function device(id: string, deviceType: PushDeviceType): UserPush {
+  const userPush: UserPush = new UserPush();
+  userPush._id = id;
+  userPush.deviceType = deviceType;
+
+  return userPush;
+}
+
+interface UpdateCall {
+  id: string;
+  isCriticalAlertEnabled: boolean | undefined;
+  isRoot: boolean | undefined;
+}
+
+describe("UserPushService.setCriticalAlertEnabledForDeviceToken", () => {
+  let findSpy: jest.SpyInstance;
+  let updateSpy: jest.SpyInstance;
+  let updateCalls: Array<UpdateCall>;
+
+  beforeEach(() => {
+    updateCalls = [];
+
+    findSpy = jest.spyOn(UserPushService, "findBy");
+
+    updateSpy = jest.spyOn(UserPushService, "updateOneBy");
+    updateSpy.mockImplementation((updateBy: unknown): Promise<number> => {
+      const call: {
+        query: { _id: string };
+        data: { isCriticalAlertEnabled?: boolean };
+        props: { isRoot?: boolean };
+      } = updateBy as {
+        query: { _id: string };
+        data: { isCriticalAlertEnabled?: boolean };
+        props: { isRoot?: boolean };
+      };
+
+      updateCalls.push({
+        id: call.query._id,
+        isCriticalAlertEnabled: call.data.isCriticalAlertEnabled,
+        isRoot: call.props.isRoot,
+      });
+
+      return Promise.resolve(1);
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("turns the override on for every project the handset is registered against", async () => {
+    findSpy.mockResolvedValue([
+      device(DEVICE_ONE_ID, PushDeviceType.iOS),
+      device(DEVICE_TWO_ID, PushDeviceType.iOS),
+    ] as never);
+
+    const updated: number =
+      await UserPushService.setCriticalAlertEnabledForDeviceToken({
+        userId: USER_ID,
+        deviceToken: DEVICE_TOKEN,
+        isEnabled: true,
+      });
+
+    expect(updated).toBe(2);
+    expect(
+      updateCalls.map((call: UpdateCall) => {
+        return call.id;
+      }),
+    ).toEqual([DEVICE_ONE_ID, DEVICE_TWO_ID]);
+    expect(
+      updateCalls.every((call: UpdateCall) => {
+        return call.isCriticalAlertEnabled === true;
+      }),
+    ).toBe(true);
+  });
+
+  test("turns the override off again", async () => {
+    findSpy.mockResolvedValue([
+      device(DEVICE_ONE_ID, PushDeviceType.Android),
+    ] as never);
+
+    await UserPushService.setCriticalAlertEnabledForDeviceToken({
+      userId: USER_ID,
+      deviceToken: DEVICE_TOKEN,
+      isEnabled: false,
+    });
+
+    expect(updateCalls[0]?.isCriticalAlertEnabled).toBe(false);
+  });
+
+  test("looks the handset up scoped to its owner, so a token cannot reconfigure somebody else's phone", async () => {
+    findSpy.mockResolvedValue([
+      device(DEVICE_ONE_ID, PushDeviceType.iOS),
+    ] as never);
+
+    await UserPushService.setCriticalAlertEnabledForDeviceToken({
+      userId: USER_ID,
+      deviceToken: DEVICE_TOKEN,
+      isEnabled: true,
+    });
+
+    const query: { userId: ObjectID; deviceToken: string } = (
+      findSpy.mock.calls[0]![0] as {
+        query: { userId: ObjectID; deviceToken: string };
+      }
+    ).query;
+
+    expect(query.userId.toString()).toBe(USER_ID.toString());
+    expect(query.userId.toString()).not.toBe(OTHER_USER_ID.toString());
+    expect(query.deviceToken).toBe(DEVICE_TOKEN);
+  });
+
+  test("writes as root, because the column grants update to nobody", async () => {
+    findSpy.mockResolvedValue([
+      device(DEVICE_ONE_ID, PushDeviceType.iOS),
+    ] as never);
+
+    await UserPushService.setCriticalAlertEnabledForDeviceToken({
+      userId: USER_ID,
+      deviceToken: DEVICE_TOKEN,
+      isEnabled: true,
+    });
+
+    expect(updateCalls[0]?.isRoot).toBe(true);
+  });
+
+  test("refuses a token that matches no registered device", async () => {
+    findSpy.mockResolvedValue([] as never);
+
+    await expect(
+      UserPushService.setCriticalAlertEnabledForDeviceToken({
+        userId: USER_ID,
+        deviceToken: DEVICE_TOKEN,
+        isEnabled: true,
+      }),
+    ).rejects.toThrow(BadDataException);
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  test("refuses a web device - a browser cannot override a phone's ringer", async () => {
+    findSpy.mockResolvedValue([
+      device(DEVICE_ONE_ID, PushDeviceType.Web),
+    ] as never);
+
+    await expect(
+      UserPushService.setCriticalAlertEnabledForDeviceToken({
+        userId: USER_ID,
+        deviceToken: DEVICE_TOKEN,
+        isEnabled: true,
+      }),
+    ).rejects.toThrow(
+      "Critical alerts are only available on iOS and Android devices.",
+    );
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  test("updates only the mobile rows when a token somehow spans device types", async () => {
+    /*
+     * Not expected in practice - a web subscription blob and an Expo token do
+     * not collide - but storing the preference on a web row would read back
+     * later as though the browser would ring, which is worse than refusing it.
+     */
+    findSpy.mockResolvedValue([
+      device(DEVICE_ONE_ID, PushDeviceType.Web),
+      device(DEVICE_TWO_ID, PushDeviceType.Android),
+    ] as never);
+
+    const updated: number =
+      await UserPushService.setCriticalAlertEnabledForDeviceToken({
+        userId: USER_ID,
+        deviceToken: DEVICE_TOKEN,
+        isEnabled: true,
+      });
+
+    expect(updated).toBe(1);
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]?.id).toBe(DEVICE_TWO_ID);
+  });
+
+  test("reports how many rows were actually written", async () => {
+    /*
+     * The count is what tells a caller "this matched nothing" apart from "this
+     * saved". updateOneBy returns 0 when the row vanished between the lookup
+     * and the write.
+     */
+    findSpy.mockResolvedValue([
+      device(DEVICE_ONE_ID, PushDeviceType.iOS),
+      device(DEVICE_TWO_ID, PushDeviceType.iOS),
+    ] as never);
+
+    updateSpy.mockResolvedValueOnce(1 as never);
+    updateSpy.mockResolvedValueOnce(0 as never);
+
+    const updated: number =
+      await UserPushService.setCriticalAlertEnabledForDeviceToken({
+        userId: USER_ID,
+        deviceToken: DEVICE_TOKEN,
+        isEnabled: true,
+      });
+
+    expect(updated).toBe(1);
+  });
+
+  test("only ever writes the critical alert column", async () => {
+    /*
+     * A toggle that also carried, say, isVerified would let the settings
+     * screen re-verify a device the user had deliberately unverified.
+     */
+    findSpy.mockResolvedValue([
+      device(DEVICE_ONE_ID, PushDeviceType.iOS),
+    ] as never);
+
+    await UserPushService.setCriticalAlertEnabledForDeviceToken({
+      userId: USER_ID,
+      deviceToken: DEVICE_TOKEN,
+      isEnabled: true,
+    });
+
+    const data: Record<string, unknown> = (
+      updateSpy.mock.calls[0]![0] as { data: Record<string, unknown> }
+    ).data;
+
+    expect(Object.keys(data)).toEqual(["isCriticalAlertEnabled"]);
+  });
+});

--- a/Common/Types/PushNotification/AndroidNotificationChannel.ts
+++ b/Common/Types/PushNotification/AndroidNotificationChannel.ts
@@ -1,0 +1,26 @@
+/*
+ * Android delivers a notification with the settings of the channel it names,
+ * not the settings in the payload - importance, sound and Do Not Disturb
+ * bypass are all fixed when the app creates the channel and cannot be raised
+ * afterwards. So "ring through silent mode" is expressed by picking a channel,
+ * and these ids are the contract for that choice.
+ *
+ * The app creates channels with exactly these ids in
+ * MobileApp/src/notifications/channels.ts. An id sent from here that the app
+ * never created does not fail loudly: Android falls back to a default channel
+ * and the page arrives with default settings, which for an on-call page means
+ * silently. Keep the two lists in step.
+ */
+enum AndroidNotificationChannel {
+  /*
+   * Do Not Disturb bypass, alarm audio stream, MAX importance. Reserved for
+   * on-call pages from a device whose owner opted in and granted the app Do
+   * Not Disturb access.
+   */
+  Critical = "oncall_critical",
+  High = "oncall_high",
+  Normal = "oncall_normal",
+  Low = "oncall_low",
+}
+
+export default AndroidNotificationChannel;

--- a/Common/Types/PushNotification/PushNotificationMessage.ts
+++ b/Common/Types/PushNotification/PushNotificationMessage.ts
@@ -13,6 +13,21 @@ interface PushNotificationMessage {
   }>;
   clickAction?: string;
   url?: string;
+  /*
+   * Ask the handset to ring even when it is silenced or in Do Not Disturb.
+   * Reserved for on-call pages: a responder who has opted their device in has
+   * decided that being woken is the point. Everything else - owner
+   * subscriptions, note-posted, test pings - leaves this unset and respects
+   * the ringer switch like a normal notification.
+   *
+   * Honouring it is a three-way handshake, and all three have to agree or the
+   * page arrives silently:
+   *   - the responder opts THIS device in (UserPush.isCriticalAlertEnabled),
+   *   - the server stamps the flag onto the payload (PushNotificationService),
+   *   - the OS lets it through (iOS critical-alert entitlement, or an Android
+   *     channel granted Do Not Disturb access).
+   */
+  isCriticalAlert?: boolean;
 }
 
 export default PushNotificationMessage;

--- a/Common/Types/PushNotification/PushNotificationRequest.ts
+++ b/Common/Types/PushNotification/PushNotificationRequest.ts
@@ -1,26 +1,18 @@
 import PushDeviceType from "./PushDeviceType";
+import PushNotificationMessage from "./PushNotificationMessage";
 
 interface PushNotificationRequest {
   devices: Array<{
     token: string;
     name?: string;
   }>;
-  message: {
-    title: string;
-    body: string;
-    icon?: string;
-    badge?: string;
-    data?: { [key: string]: any };
-    tag?: string;
-    requireInteraction?: boolean;
-    actions?: Array<{
-      action: string;
-      title: string;
-      icon?: string;
-    }>;
-    clickAction?: string;
-    url?: string;
-  };
+  /*
+   * The same shape PushNotificationUtil builds, referenced rather than
+   * restated: this used to be a copy of every field in PushNotificationMessage,
+   * and a copy is a place for a newly added field to go missing on the way to
+   * the sender.
+   */
+  message: PushNotificationMessage;
   deviceType: PushDeviceType;
 }
 

--- a/MobileApp/README.md
+++ b/MobileApp/README.md
@@ -92,11 +92,49 @@ ServerUrlScreen → LoginScreen → MainTabNavigator (Home, Incidents, Alerts, S
 - Access tokens are refreshed automatically on 401 responses.
 - Logout clears all stored tokens and returns to the login screen.
 
+## Tests
+
+```bash
+npm test
+```
+
+Jest with the `jest-expo` preset. Tests live next to the code they cover
+(`src/**/*.test.ts[x]`); shared native-module mocks are in
+`src/__tests__/setup.ts`.
+
 ## Push Notifications
 
 Native push notifications (iOS/Android) are powered by Expo Push and require no server-side configuration. The mobile app registers an Expo Push Token with the backend on login. The backend sends notifications via the public Expo Push API.
 
 Web push uses VAPID keys (configured separately). See the [Push Notifications docs](../Docs/Content/self-hosted/push-notifications.md) for details.
+
+### Critical on-call alerts
+
+**Settings > Notifications > Critical On-Call Alerts** lets a responder have
+on-call pages play a sound even when the handset is silenced or in Do Not
+Disturb. It is per device and off by default, and only on-call pages are
+escalated - never owner subscriptions or note-posted notices.
+
+- **Android** uses the `oncall_critical` notification channel, which requests
+  `bypassDnd` and plays on the alarm audio stream. The Do Not Disturb bypass
+  needs the user to grant this app **Do Not Disturb access** in system
+  settings; the app opens that screen when the switch is turned on. Channel
+  settings are frozen by Android at creation, so changing them means shipping a
+  new channel id, not editing `src/notifications/channels.ts`.
+- **iOS** needs Apple's critical-alerts entitlement, which is **not** enabled by
+  default because a build declaring an entitlement the Apple team has not been
+  granted fails to sign. Once Apple grants it:
+
+  ```bash
+  EXPO_IOS_CRITICAL_ALERTS_ENTITLEMENT=true npm run prebuild
+  ```
+
+  or set `EXPO_IOS_CRITICAL_ALERTS_ENTITLEMENT: "true"` in the relevant
+  `eas.json` build profile's `env`.
+
+Without the OS capability the app does not pretend: the settings screen reads
+the real state back from the OS and tells the responder which setting is
+missing.
 
 ## Troubleshooting
 

--- a/MobileApp/app.config.js
+++ b/MobileApp/app.config.js
@@ -1,0 +1,67 @@
+/*
+ * Everything static lives in app.json; this file exists for the one setting
+ * that cannot be committed unconditionally.
+ *
+ * Critical alerts on iOS need Apple's
+ * com.apple.developer.usernotifications.critical-alerts entitlement, and Apple
+ * grants it per team, by application, for apps that page people about urgent
+ * events. Until a team has been granted it, a provisioning profile cannot
+ * carry the entitlement and any build that declares it FAILS TO SIGN - so
+ * putting it straight in app.json would break the iOS build for every fork,
+ * every self-hoster, and this repo's own release pipeline on the day it
+ * merged, long before Apple answered.
+ *
+ * So it is opt-in, off by default:
+ *
+ *   EXPO_IOS_CRITICAL_ALERTS_ENTITLEMENT=true npx expo prebuild
+ *
+ * or, for EAS, add it to the build profile's `env` in eas.json once the
+ * entitlement has been granted to your Apple team.
+ *
+ * Nothing else in the feature is gated. Without the entitlement the app still
+ * asks for the permission, iOS still declines to grant allowsCriticalAlerts,
+ * and the settings screen tells the responder the OS has not granted it -
+ * which is the honest state of affairs, rather than a switch that turns on and
+ * does nothing.
+ *
+ * Android needs none of this: Do Not Disturb access is granted by the user in
+ * system settings on the device, not by the platform vendor at build time.
+ */
+
+const IOS_CRITICAL_ALERTS_ENTITLEMENT =
+  "com.apple.developer.usernotifications.critical-alerts";
+
+function isCriticalAlertsEntitlementEnabled(env) {
+  return (env || {}).EXPO_IOS_CRITICAL_ALERTS_ENTITLEMENT === "true";
+}
+
+/*
+ * Returns a new config rather than mutating the one Expo handed over, and
+ * preserves any entitlements already present so this stays composable with
+ * whatever else a fork adds.
+ */
+function withCriticalAlertsEntitlement(config, env) {
+  if (!isCriticalAlertsEntitlementEnabled(env)) {
+    return config;
+  }
+
+  return {
+    ...config,
+    ios: {
+      ...(config.ios || {}),
+      entitlements: {
+        ...((config.ios || {}).entitlements || {}),
+        [IOS_CRITICAL_ALERTS_ENTITLEMENT]: true,
+      },
+    },
+  };
+}
+
+module.exports = ({ config }) => {
+  return withCriticalAlertsEntitlement(config, process.env);
+};
+
+module.exports.IOS_CRITICAL_ALERTS_ENTITLEMENT = IOS_CRITICAL_ALERTS_ENTITLEMENT;
+module.exports.isCriticalAlertsEntitlementEnabled =
+  isCriticalAlertsEntitlementEnabled;
+module.exports.withCriticalAlertsEntitlement = withCriticalAlertsEntitlement;

--- a/MobileApp/app.json
+++ b/MobileApp/app.json
@@ -39,7 +39,10 @@
       "googleServicesFile": "./google-services.json",
       "permissions": [
         "android.permission.USE_BIOMETRIC",
-        "android.permission.USE_FINGERPRINT"
+        "android.permission.USE_FINGERPRINT",
+        "android.permission.ACCESS_NOTIFICATION_POLICY",
+        "android.permission.POST_NOTIFICATIONS",
+        "android.permission.VIBRATE"
       ]
     },
     "plugins": [

--- a/MobileApp/jest.config.js
+++ b/MobileApp/jest.config.js
@@ -1,0 +1,28 @@
+/*
+ * jest-expo's preset is what makes React Native's ESM-only packages loadable
+ * and provides the module mocks Expo's own native modules need. `node` is the
+ * project name the preset uses for plain (non-platform-specific) test runs.
+ */
+module.exports = {
+  preset: "jest-expo",
+  setupFilesAfterEnv: ["<rootDir>/src/__tests__/setup.ts"],
+  testMatch: ["<rootDir>/src/**/*.test.ts", "<rootDir>/src/**/*.test.tsx"],
+  /*
+   * The shared setup file lives under __tests__ so it sits with the tests it
+   * serves; without this it would be collected as a (empty) test suite and
+   * fail the run.
+   */
+  testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/src/__tests__/setup.ts"],
+  collectCoverageFrom: [
+    "src/**/*.{ts,tsx}",
+    "!src/**/*.test.{ts,tsx}",
+    "!src/__tests__/**",
+  ],
+  clearMocks: true,
+  /*
+   * React Native component renders pull in font and native-module shims on
+   * first use, which can take well over Jest's 5s default on a cold cache -
+   * long enough to fail a screen test that is doing nothing wrong.
+   */
+  testTimeout: 30000,
+};

--- a/MobileApp/package-lock.json
+++ b/MobileApp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mobileapp",
-  "version": "12.0.11",
+  "version": "12.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mobileapp",
-      "version": "12.0.11",
+      "version": "12.0.14",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -46,8 +46,14 @@
         "tailwindcss": "^3.4.19"
       },
       "devDependencies": {
+        "@testing-library/react-native": "^14.0.1",
+        "@types/jest": "^29.5.14",
         "@types/react": "~19.1.0",
+        "@types/react-test-renderer": "^19.1.0",
         "babel-preset-expo": "^54.0.10",
+        "jest": "^29.7.0",
+        "jest-expo": "~54.0.18",
+        "react-test-renderer": "19.1.0",
         "typescript": "~5.9.2"
       }
     },
@@ -1579,6 +1585,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.6.tgz",
@@ -2498,6 +2511,240 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/console/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/console/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/console/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/console/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/console/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/create-cache-key-function": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
@@ -2510,6 +2757,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -2520,6 +2777,33 @@
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2542,6 +2826,215 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -2549,6 +3042,53 @@
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3354,6 +3894,92 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/react-native": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-14.0.1.tgz",
+      "integrity": "sha512-2r2e2y8SkUNRWKRXlUGqDYunB+AkbdXUPn49Bs5rpv9oxRb0K3USBVugbPbAKJjfj4w5Ba91NJ8LcQCZyopUZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^30.4.1",
+        "picocolors": "^1.1.1",
+        "pretty-format": "^30.4.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=19.0.0",
+        "react-native": ">=0.78",
+        "test-renderer": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3428,6 +4054,29 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.2.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.2.tgz",
@@ -3447,10 +4096,38 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -3506,6 +4183,14 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3538,6 +4223,30 @@
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
       },
       "engines": {
         "node": ">=0.4.0"
@@ -4298,6 +5007,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -4360,6 +5079,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/chokidar": {
@@ -4469,6 +5198,13 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "license": "MIT"
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -4515,6 +5251,24 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -4722,6 +5476,104 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-jest/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/create-jest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
@@ -4845,12 +5697,91 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4869,6 +5800,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
@@ -4876,6 +5814,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/deep-extend": {
@@ -4988,11 +5941,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -5025,6 +5998,30 @@
         }
       ],
       "license": "BSD-2-Clause"
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
@@ -5108,6 +6105,19 @@
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "license": "ISC"
     },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -5143,6 +6153,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
@@ -5222,6 +6249,39 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -5233,6 +6293,26 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -5251,6 +6331,190 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/expect/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/expect/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/expect/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/expect/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/expo": {
@@ -6376,6 +7640,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/getenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
@@ -6537,6 +7814,26 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -6566,6 +7863,34 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -6579,11 +7904,34 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/hyphenate-style-name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -6629,6 +7977,26 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -6636,6 +8004,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -6773,6 +8151,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -6838,6 +8226,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6854,6 +8249,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-typed-array": {
@@ -6923,6 +8331,847 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-circus/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-circus/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-cli/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-cli/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jest-config/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jest-config/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-config/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-diff/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-each/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-each/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
@@ -6938,6 +9187,42 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-expo": {
+      "version": "54.0.18",
+      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-54.0.18.tgz",
+      "integrity": "sha512-couPPatkifK3v0WZW7zu1HZW5HyxY+1cY69LKHPawwbZTuIvf5wk4SYHtoUrGa/nAM2jW/YiXDLWfociEHJPvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.14",
+        "@expo/json-file": "^10.0.16",
+        "@jest/create-cache-key-function": "^29.2.1",
+        "@jest/globals": "^29.2.1",
+        "babel-jest": "^29.2.1",
+        "jest-environment-jsdom": "^29.2.1",
+        "jest-snapshot": "^29.2.1",
+        "jest-watch-select-projects": "^2.0.0",
+        "jest-watch-typeahead": "2.2.1",
+        "json5": "^2.2.3",
+        "lodash": "^4.17.19",
+        "react-test-renderer": "19.1.0",
+        "server-only": "^0.0.1",
+        "stacktrace-js": "^2.0.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*",
+        "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
+      },
+      "peerDependenciesMeta": {
+        "react-server-dom-webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-get-type": {
@@ -6972,6 +9257,161 @@
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-matcher-utils/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-message-util": {
@@ -7092,6 +9532,24 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-regex-util": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
@@ -7099,6 +9557,543 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-resolve/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-runner/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-snapshot/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-util": {
@@ -7290,6 +10285,367 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-watch-select-projects": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-watch-select-projects/-/jest-watch-select-projects-2.0.0.tgz",
+      "integrity": "sha512-j00nW4dXc2NiCW6znXgFLF9g8PJ0zP25cpQ1xRro/HU2GBfZQFZD0SoXnAlaoKkIY4MlfTMkKGbNXFpvCdjl1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "chalk": "^3.0.0",
+        "prompts": "^2.2.1"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-watch-select-projects/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-typeahead": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-2.2.1.tgz",
+      "integrity": "sha512-jYpYmUnTzysmVnwq49TAxlmtOAwp8QIqvZyoofQFn8fiWhEDZj33ZXzg3JA4nGnzWFm1hbWf3ADpteUokvXgFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^6.0.0",
+        "chalk": "^4.0.0",
+        "jest-regex-util": "^29.0.0",
+        "jest-watcher": "^29.0.0",
+        "slash": "^5.0.0",
+        "string-length": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "jest": "^27.0.0 || ^28.0.0 || ^29.0.0"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/char-regex": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.2.tgz",
+      "integrity": "sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-watch-typeahead/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/string-length": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-5.0.1.tgz",
+      "integrity": "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^2.0.0",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-watcher/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jest-worker": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
@@ -7369,6 +10725,138 @@
       "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
       "license": "0BSD"
     },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -7380,6 +10868,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7733,6 +11228,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -7776,6 +11278,22 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/makeerror": {
@@ -8277,6 +11795,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -8386,6 +11914,13 @@
         "tailwindcss": ">3.3.0"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -8466,6 +12001,19 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -8482,6 +12030,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ob1": {
@@ -8706,6 +12261,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-png": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/parse-png/-/parse-png-2.1.0.tgz",
@@ -8716,6 +12290,32 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -8819,6 +12419,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/plist": {
@@ -9113,6 +12726,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -9121,6 +12747,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qrcode-terminal": {
       "version": "0.11.0",
@@ -9147,6 +12790,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue": {
       "version": "6.0.2",
@@ -9248,6 +12898,22 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-native": {
@@ -9794,6 +13460,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-jXkSl3CpvPYEF+p/eGDLB4sPoDX8pKkYvRl9+rR8HxLY0X04vW7hCm1/0zHoUSjPZ3bDa+wXWNTDVIw/R8aDVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.1.0",
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -9813,6 +13500,20 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regenerate": {
@@ -9914,6 +13615,13 @@
         "path-parse": "^1.0.5"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -9933,6 +13641,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve-from": {
@@ -10113,6 +13834,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sax": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
@@ -10120,6 +13848,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -10241,6 +13982,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -10415,6 +14163,16 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -10441,6 +14199,39 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "license": "MIT"
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.11",
@@ -10481,6 +14272,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -10502,6 +14307,39 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -10616,6 +14454,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -10785,6 +14630,46 @@
         "node": "*"
       }
     },
+    "node_modules/test-renderer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/test-renderer/-/test-renderer-1.2.0.tgz",
+      "integrity": "sha512-JYiEGbgBGtmHAWX8Kf99gGRL1HtjcRVHLrmJNTZL4vFs9XrnWcuL45Iszw/pO4094+JR7havSrN+ds6YTOpSQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/react-reconciler": "~0.33.0",
+        "react-reconciler": "~0.33.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/test-renderer/node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/test-renderer/node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -10882,6 +14767,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tr46": {
@@ -11027,6 +14928,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -11064,6 +14975,17 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-latest-callback": {
@@ -11121,6 +15043,21 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/validate-npm-package-name": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
@@ -11144,6 +15081,19 @@
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -11178,11 +15128,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -11359,6 +15333,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
@@ -11389,6 +15373,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/MobileApp/package.json
+++ b/MobileApp/package.json
@@ -8,6 +8,9 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "compile": "tsc --noEmit",
+    "test": "jest",
+    "test-file": "jest --runInBand",
+    "coverage": "jest --coverage",
     "prebuild": "npx expo prebuild --clean",
     "android:build": "npx eas-cli build --platform android --profile production",
     "android:build-local": "npm run prebuild && cd android && ./gradlew bundleRelease",
@@ -58,8 +61,14 @@
     "tailwindcss": "^3.4.19"
   },
   "devDependencies": {
+    "@testing-library/react-native": "^14.0.1",
+    "@types/jest": "^29.5.14",
     "@types/react": "~19.1.0",
+    "@types/react-test-renderer": "^19.1.0",
     "babel-preset-expo": "^54.0.10",
+    "jest": "^29.7.0",
+    "jest-expo": "~54.0.18",
+    "react-test-renderer": "19.1.0",
     "typescript": "~5.9.2"
   },
   "private": true

--- a/MobileApp/src/__tests__/appConfig.test.ts
+++ b/MobileApp/src/__tests__/appConfig.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Critical alerts on iOS require Apple's critical-alerts entitlement, granted
+ * per Apple team by application. A provisioning profile cannot carry an
+ * entitlement the team has not been granted, and a build that declares one it
+ * cannot carry FAILS TO SIGN.
+ *
+ * So the entitlement is opt-in via an environment variable rather than
+ * committed into app.json. That is not a stylistic choice: committing it would
+ * break the iOS build for this repo's release pipeline, every fork, and every
+ * self-hoster on the day it merged, months before Apple answered anybody's
+ * request.
+ *
+ * These tests pin both halves - that it is OFF by default, and that it is
+ * actually applied when switched on - because either half silently wrong
+ * produces a confusing failure a long way from here.
+ */
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const appConfig: {
+  IOS_CRITICAL_ALERTS_ENTITLEMENT: string;
+  isCriticalAlertsEntitlementEnabled: (env: unknown) => boolean;
+  withCriticalAlertsEntitlement: (
+    config: Record<string, unknown>,
+    env: unknown,
+  ) => Record<string, unknown>;
+} = require("../../app.config.js");
+
+const ENTITLEMENT: string = appConfig.IOS_CRITICAL_ALERTS_ENTITLEMENT;
+
+function baseConfig(): Record<string, unknown> {
+  return {
+    name: "OneUptime On-Call",
+    ios: {
+      bundleIdentifier: "com.oneuptime.oncall",
+      infoPlist: { UIBackgroundModes: ["remote-notification"] },
+    },
+  };
+}
+
+function iosEntitlements(
+  config: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  return (config["ios"] as { entitlements?: Record<string, unknown> })
+    ?.entitlements;
+}
+
+describe("The iOS critical alerts entitlement is off by default", () => {
+  test("an empty environment does not enable it", () => {
+    expect(appConfig.isCriticalAlertsEntitlementEnabled({})).toBe(false);
+  });
+
+  test("an undefined environment does not enable it", () => {
+    expect(appConfig.isCriticalAlertsEntitlementEnabled(undefined)).toBe(false);
+  });
+
+  test.each([
+    ["false", "false"],
+    ["an empty string", ""],
+    ['"1"', "1"],
+    ['"yes"', "yes"],
+    ['"TRUE"', "TRUE"],
+  ])("%s does not enable it", (_label: string, value: string) => {
+    expect(
+      appConfig.isCriticalAlertsEntitlementEnabled({
+        EXPO_IOS_CRITICAL_ALERTS_ENTITLEMENT: value,
+      }),
+    ).toBe(false);
+  });
+
+  test("the config is returned untouched when it is off", () => {
+    const config: Record<string, unknown> = baseConfig();
+    const result: Record<string, unknown> =
+      appConfig.withCriticalAlertsEntitlement(config, {});
+
+    expect(result).toBe(config);
+    expect(iosEntitlements(result)).toBeUndefined();
+  });
+});
+
+describe("The entitlement is applied when explicitly switched on", () => {
+  const env: Record<string, string> = {
+    EXPO_IOS_CRITICAL_ALERTS_ENTITLEMENT: "true",
+  };
+
+  test('the exact string "true" enables it', () => {
+    expect(appConfig.isCriticalAlertsEntitlementEnabled(env)).toBe(true);
+  });
+
+  test("the entitlement Apple actually looks for is the one declared", () => {
+    expect(ENTITLEMENT).toBe(
+      "com.apple.developer.usernotifications.critical-alerts",
+    );
+  });
+
+  test("it lands under ios.entitlements where prebuild reads it", () => {
+    const result: Record<string, unknown> =
+      appConfig.withCriticalAlertsEntitlement(baseConfig(), env);
+
+    expect(iosEntitlements(result)?.[ENTITLEMENT]).toBe(true);
+  });
+
+  test("the rest of the iOS config survives", () => {
+    /*
+     * A spread that replaced `ios` wholesale would drop the bundle identifier
+     * and the background modes push notifications depend on - a much bigger
+     * outage than the feature being added.
+     */
+    const result: Record<string, unknown> =
+      appConfig.withCriticalAlertsEntitlement(baseConfig(), env);
+
+    const ios: { bundleIdentifier?: string; infoPlist?: unknown } = result[
+      "ios"
+    ] as { bundleIdentifier?: string; infoPlist?: unknown };
+
+    expect(ios.bundleIdentifier).toBe("com.oneuptime.oncall");
+    expect(ios.infoPlist).toEqual({
+      UIBackgroundModes: ["remote-notification"],
+    });
+  });
+
+  test("the rest of the app config survives", () => {
+    const result: Record<string, unknown> =
+      appConfig.withCriticalAlertsEntitlement(baseConfig(), env);
+
+    expect(result["name"]).toBe("OneUptime On-Call");
+  });
+
+  test("entitlements a fork already declared are preserved", () => {
+    const config: Record<string, unknown> = {
+      ios: {
+        entitlements: { "com.apple.developer.something-else": true },
+      },
+    };
+
+    const result: Record<string, unknown> =
+      appConfig.withCriticalAlertsEntitlement(config, env);
+
+    expect(iosEntitlements(result)).toEqual({
+      "com.apple.developer.something-else": true,
+      [ENTITLEMENT]: true,
+    });
+  });
+
+  test("a config with no ios section at all still works", () => {
+    const result: Record<string, unknown> =
+      appConfig.withCriticalAlertsEntitlement({ name: "x" }, env);
+
+    expect(iosEntitlements(result)?.[ENTITLEMENT]).toBe(true);
+  });
+
+  test("the original config object is not mutated", () => {
+    /*
+     * Expo hands the same object to more than one plugin. Mutating it makes
+     * the resulting config depend on plugin ordering.
+     */
+    const config: Record<string, unknown> = baseConfig();
+
+    appConfig.withCriticalAlertsEntitlement(config, env);
+
+    expect(iosEntitlements(config)).toBeUndefined();
+  });
+});

--- a/MobileApp/src/__tests__/setup.ts
+++ b/MobileApp/src/__tests__/setup.ts
@@ -1,0 +1,147 @@
+/*
+ * Shared test setup.
+ *
+ * expo-notifications, expo-device and AsyncStorage are native modules with no
+ * JS implementation off-device, so every suite that touches the notification
+ * code needs them mocked. They are mocked HERE rather than per-file so that
+ * the shape each test asserts against is the same one, and so a future test
+ * cannot accidentally assert against a subtly different fake.
+ */
+
+/*
+ * The enums are values, not types, so the mock has to carry the real numbers -
+ * a test that asserts "importance is MAX" against a fake where MAX is
+ * undefined passes for the wrong reason.
+ */
+jest.mock("expo-notifications", () => {
+  return {
+    AndroidImportance: {
+      UNKNOWN: 0,
+      UNSPECIFIED: 1,
+      NONE: 2,
+      MIN: 3,
+      LOW: 4,
+      DEFAULT: 5,
+      HIGH: 6,
+      MAX: 7,
+    },
+    AndroidNotificationVisibility: {
+      UNKNOWN: 0,
+      PUBLIC: 1,
+      PRIVATE: 2,
+      SECRET: 3,
+    },
+    AndroidAudioUsage: {
+      UNKNOWN: 0,
+      MEDIA: 1,
+      VOICE_COMMUNICATION: 2,
+      VOICE_COMMUNICATION_SIGNALLING: 3,
+      ALARM: 4,
+      NOTIFICATION: 5,
+      NOTIFICATION_RINGTONE: 6,
+      NOTIFICATION_COMMUNICATION_REQUEST: 7,
+      NOTIFICATION_COMMUNICATION_INSTANT: 8,
+      NOTIFICATION_COMMUNICATION_DELAYED: 9,
+      NOTIFICATION_EVENT: 10,
+      ASSISTANCE_ACCESSIBILITY: 11,
+      ASSISTANCE_NAVIGATION_GUIDANCE: 12,
+      ASSISTANCE_SONIFICATION: 13,
+      GAME: 14,
+    },
+    AndroidAudioContentType: {
+      UNKNOWN: 0,
+      SPEECH: 1,
+      MUSIC: 2,
+      MOVIE: 3,
+      SONIFICATION: 4,
+    },
+    setNotificationHandler: jest.fn(),
+    setNotificationChannelAsync: jest.fn(async () => {
+      return null;
+    }),
+    getNotificationChannelAsync: jest.fn(async () => {
+      return null;
+    }),
+    setNotificationCategoryAsync: jest.fn(async () => {
+      return null;
+    }),
+    getPermissionsAsync: jest.fn(async () => {
+      return { status: "granted", ios: {} };
+    }),
+    requestPermissionsAsync: jest.fn(async () => {
+      return { status: "granted", ios: {} };
+    }),
+    getExpoPushTokenAsync: jest.fn(async () => {
+      return { data: "ExponentPushToken[test]" };
+    }),
+    addNotificationReceivedListener: jest.fn(() => {
+      return { remove: jest.fn() };
+    }),
+    addNotificationResponseReceivedListener: jest.fn(() => {
+      return { remove: jest.fn() };
+    }),
+    getLastNotificationResponseAsync: jest.fn(async () => {
+      return null;
+    }),
+  };
+});
+
+jest.mock("expo-device", () => {
+  return {
+    isDevice: true,
+    modelName: "iPhone Test",
+  };
+});
+
+jest.mock("expo-constants", () => {
+  return {
+    __esModule: true,
+    default: {
+      expoConfig: { extra: { eas: { projectId: "test-project" } } },
+      easConfig: { projectId: "test-project" },
+    },
+  };
+});
+
+jest.mock("@react-native-async-storage/async-storage", () => {
+  const store: Map<string, string> = new Map<string, string>();
+
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn(async (key: string) => {
+        return store.has(key) ? store.get(key) : null;
+      }),
+      setItem: jest.fn(async (key: string, value: string) => {
+        store.set(key, value);
+      }),
+      removeItem: jest.fn(async (key: string) => {
+        store.delete(key);
+      }),
+      clear: jest.fn(async () => {
+        store.clear();
+      }),
+      __store: store,
+    },
+  };
+});
+
+/*
+ * Keep test output readable; the code under test logs on every warning path,
+ * and several suites deliberately drive those paths.
+ *
+ * Re-applied per test rather than once per file, because suites that call
+ * jest.restoreAllMocks() in afterEach would otherwise un-silence the console
+ * for every test after their first.
+ */
+beforeEach(() => {
+  jest.spyOn(console, "info").mockImplementation((): void => {
+    return undefined;
+  });
+  jest.spyOn(console, "warn").mockImplementation((): void => {
+    return undefined;
+  });
+  jest.spyOn(console, "error").mockImplementation((): void => {
+    return undefined;
+  });
+});

--- a/MobileApp/src/api/pushDevice.test.ts
+++ b/MobileApp/src/api/pushDevice.test.ts
@@ -1,0 +1,201 @@
+import apiClient from "./client";
+import {
+  registerPushDevice,
+  setCriticalAlertsEnabledOnServer,
+  unregisterPushDevice,
+} from "./pushDevice";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+
+jest.mock("./client", () => {
+  return {
+    __esModule: true,
+    default: {
+      post: jest.fn(async () => {
+        return { data: { success: true } };
+      }),
+    },
+  };
+});
+
+/*
+ * The two requests that carry the responder's critical-alert choice to the
+ * server. The server is the authority - it is what stamps the flag onto the
+ * push payload - so a request that silently drops the field leaves the phone
+ * configured to ring while the server keeps sending ordinary notifications.
+ */
+
+function postSpy(): jest.SpyInstance {
+  return apiClient.post as unknown as jest.SpyInstance;
+}
+
+function lastBody(): Record<string, unknown> {
+  const calls: Array<Array<unknown>> = postSpy().mock.calls;
+
+  return calls[calls.length - 1]![1] as Record<string, unknown>;
+}
+
+describe("registerPushDevice carries the critical alert opt-in", () => {
+  beforeEach(() => {
+    postSpy().mockClear();
+    postSpy().mockResolvedValue({ data: { success: true } } as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("sends the flag when the responder had it on", async () => {
+    /*
+     * Every project the responder belongs to gets its own device row, and a
+     * row created without this defaults to off. Omitting it here is how a
+     * phone silently stops overriding Do Not Disturb for a project the
+     * responder joined yesterday.
+     */
+    await registerPushDevice({
+      deviceToken: "ExponentPushToken[abc]",
+      projectId: "project-1",
+      isCriticalAlertEnabled: true,
+    });
+
+    expect(lastBody()["isCriticalAlertEnabled"]).toBe(true);
+  });
+
+  test("sends false when the responder has not opted in", async () => {
+    await registerPushDevice({
+      deviceToken: "ExponentPushToken[abc]",
+      projectId: "project-1",
+      isCriticalAlertEnabled: false,
+    });
+
+    expect(lastBody()["isCriticalAlertEnabled"]).toBe(false);
+  });
+
+  test("sends false rather than undefined when the caller omits it", async () => {
+    await registerPushDevice({
+      deviceToken: "ExponentPushToken[abc]",
+      projectId: "project-1",
+    });
+
+    expect(lastBody()["isCriticalAlertEnabled"]).toBe(false);
+  });
+
+  test("still sends everything registration needed before this feature", async () => {
+    await registerPushDevice({
+      deviceToken: "ExponentPushToken[abc]",
+      projectId: "project-1",
+      isCriticalAlertEnabled: true,
+    });
+
+    const body: Record<string, unknown> = lastBody();
+
+    expect(body["deviceToken"]).toBe("ExponentPushToken[abc]");
+    expect(body["projectId"]).toBe("project-1");
+    expect(body["deviceType"]).toBeDefined();
+    expect(body["deviceName"]).toBeDefined();
+  });
+
+  test('an "already registered" response is still treated as success', async () => {
+    postSpy().mockRejectedValue({
+      response: {
+        status: 400,
+        data: { message: "This device is already registered" },
+      },
+    } as never);
+
+    await expect(
+      registerPushDevice({
+        deviceToken: "ExponentPushToken[abc]",
+        projectId: "project-1",
+        isCriticalAlertEnabled: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("setCriticalAlertsEnabledOnServer", () => {
+  beforeEach(() => {
+    postSpy().mockClear();
+    postSpy().mockResolvedValue({ data: { success: true } } as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("posts to the critical alerts route", async () => {
+    await setCriticalAlertsEnabledOnServer({
+      deviceToken: "ExponentPushToken[abc]",
+      isEnabled: true,
+    });
+
+    expect(postSpy().mock.calls[0]![0]).toBe("/api/user-push/critical-alerts");
+  });
+
+  test("identifies the handset by its push token", async () => {
+    /*
+     * The token, not a row id: the app holds no row ids, and one phone owns a
+     * row per project. The server fans the change out across them.
+     */
+    await setCriticalAlertsEnabledOnServer({
+      deviceToken: "ExponentPushToken[abc]",
+      isEnabled: true,
+    });
+
+    expect(lastBody()["deviceToken"]).toBe("ExponentPushToken[abc]");
+  });
+
+  test("sends the requested state", async () => {
+    await setCriticalAlertsEnabledOnServer({
+      deviceToken: "ExponentPushToken[abc]",
+      isEnabled: true,
+    });
+
+    expect(lastBody()["isEnabled"]).toBe(true);
+  });
+
+  test("can turn the override off again", async () => {
+    await setCriticalAlertsEnabledOnServer({
+      deviceToken: "ExponentPushToken[abc]",
+      isEnabled: false,
+    });
+
+    expect(lastBody()["isEnabled"]).toBe(false);
+  });
+
+  test("a failed request is surfaced, not swallowed", async () => {
+    /*
+     * This is the difference between a switch that means something and one
+     * that lies. If the server never heard about it, the responder must not be
+     * left looking at an "on" toggle.
+     */
+    postSpy().mockRejectedValue(new Error("network unreachable") as never);
+
+    await expect(
+      setCriticalAlertsEnabledOnServer({
+        deviceToken: "ExponentPushToken[abc]",
+        isEnabled: true,
+      }),
+    ).rejects.toThrow("network unreachable");
+  });
+});
+
+describe("unregisterPushDevice is unaffected", () => {
+  beforeEach(() => {
+    postSpy().mockClear();
+    postSpy().mockResolvedValue({ data: { success: true } } as never);
+  });
+
+  test("still posts the token to the unregister route", async () => {
+    await unregisterPushDevice("ExponentPushToken[abc]");
+
+    expect(postSpy().mock.calls[0]![0]).toBe("/api/user-push/unregister");
+  });
+
+  test("still stays quiet on failure so logout is never blocked", async () => {
+    postSpy().mockRejectedValue(new Error("offline") as never);
+
+    await expect(
+      unregisterPushDevice("ExponentPushToken[abc]"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/MobileApp/src/api/pushDevice.ts
+++ b/MobileApp/src/api/pushDevice.ts
@@ -6,6 +6,7 @@ import logger from "../utils/logger";
 export async function registerPushDevice(params: {
   deviceToken: string;
   projectId: string;
+  isCriticalAlertEnabled?: boolean;
 }): Promise<void> {
   const deviceType: string =
     Platform.OS === "ios"
@@ -20,6 +21,14 @@ export async function registerPushDevice(params: {
       deviceType: deviceType,
       deviceName: Device.modelName || "Unknown Device",
       projectId: params.projectId,
+      /*
+       * Restated on every registration. A responder who joins a new project,
+       * reinstalls, or is issued a fresh push token creates a new device row,
+       * and a row created without this defaults to off - so the phone would
+       * quietly stop overriding Do Not Disturb for exactly the project they
+       * just joined.
+       */
+      isCriticalAlertEnabled: Boolean(params.isCriticalAlertEnabled),
     });
     logger.info(
       `[PushNotifications] Device registered successfully for project ${params.projectId}`,
@@ -46,6 +55,33 @@ export async function registerPushDevice(params: {
     );
     throw error;
   }
+}
+
+/*
+ * Turn "ring through silent mode" on or off for this handset, across every
+ * project it is registered against. Keyed on the push token because that is
+ * the only device identity the app holds; the server resolves it to the
+ * caller's own rows.
+ *
+ * Errors are not swallowed. Enabling is a promise to the responder that their
+ * phone will wake them, and a toggle that looked like it worked but did not
+ * reach the server is the exact failure mode this feature is meant to remove,
+ * so the caller reverts the switch and says so.
+ */
+export async function setCriticalAlertsEnabledOnServer(params: {
+  deviceToken: string;
+  isEnabled: boolean;
+}): Promise<void> {
+  await apiClient.post("/api/user-push/critical-alerts", {
+    deviceToken: params.deviceToken,
+    isEnabled: params.isEnabled,
+  });
+
+  logger.info(
+    `[PushNotifications] Critical alerts ${
+      params.isEnabled ? "enabled" : "disabled"
+    } for this device`,
+  );
 }
 
 export async function unregisterPushDevice(deviceToken: string): Promise<void> {

--- a/MobileApp/src/hooks/useCriticalAlerts.test.tsx
+++ b/MobileApp/src/hooks/useCriticalAlerts.test.tsx
@@ -1,0 +1,540 @@
+import { AppState, Platform } from "react-native";
+import * as Notifications from "expo-notifications";
+import * as Device from "expo-device";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { renderHook, act, waitFor } from "@testing-library/react-native";
+import {
+  useCriticalAlerts,
+  type CriticalAlertsState,
+} from "./useCriticalAlerts";
+import * as pushDeviceApi from "../api/pushDevice";
+import { getCriticalAlertsEnabled } from "../storage/preferences";
+import { PUSH_TOKEN_KEY } from "./pushTokenUtils";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+
+jest.mock("../api/pushDevice", () => {
+  return {
+    registerPushDevice: jest.fn(),
+    unregisterPushDevice: jest.fn(),
+    setCriticalAlertsEnabledOnServer: jest.fn(async () => {
+      return undefined;
+    }),
+  };
+});
+
+/*
+ * The hook is where the three parties to a critical alert are reconciled: the
+ * OS capability, the responder's stored choice, and the server that actually
+ * stamps the flag onto pages. Each test below is a way those three can
+ * disagree, and every one of them has the same worst case - a responder
+ * looking at a switch that says "on" while nothing will wake them.
+ *
+ * The rule the hook enforces, and the reason it re-reads instead of
+ * remembering: nothing is shown as ON unless the OS grants it AND the server
+ * accepted it.
+ */
+
+const DEVICE_TOKEN: string = "ExponentPushToken[handset]";
+
+function setPlatform(os: "ios" | "android" | "web"): void {
+  (Platform as unknown as { OS: string }).OS = os;
+}
+
+function setIsDevice(isDevice: boolean): void {
+  (Device as unknown as { isDevice: boolean }).isDevice = isDevice;
+}
+
+function grantIos(): void {
+  jest
+    .spyOn(Notifications, "getPermissionsAsync")
+    .mockResolvedValue({ ios: { allowsCriticalAlerts: true } } as never);
+  jest
+    .spyOn(Notifications, "requestPermissionsAsync")
+    .mockResolvedValue({ ios: { allowsCriticalAlerts: true } } as never);
+}
+
+function denyIos(): void {
+  jest
+    .spyOn(Notifications, "getPermissionsAsync")
+    .mockResolvedValue({ ios: { allowsCriticalAlerts: false } } as never);
+  jest
+    .spyOn(Notifications, "requestPermissionsAsync")
+    .mockResolvedValue({ ios: { allowsCriticalAlerts: false } } as never);
+}
+
+function serverSpy(): jest.SpyInstance {
+  return pushDeviceApi.setCriticalAlertsEnabledOnServer as unknown as jest.SpyInstance;
+}
+
+/*
+ * renderHook is asynchronous in @testing-library/react-native v14, and the
+ * hook's first useEffect kicks off an async status read - so every test waits
+ * for that first pass to land before asserting, rather than racing it.
+ */
+async function renderCriticalAlerts(): Promise<{
+  result: { current: CriticalAlertsState };
+}> {
+  const rendered: { result: { current: CriticalAlertsState } } =
+    (await renderHook(() => {
+      return useCriticalAlerts();
+    })) as unknown as { result: { current: CriticalAlertsState } };
+
+  await waitFor(() => {
+    expect(rendered.result.current.statusMessage.length).toBeGreaterThan(0);
+  });
+
+  return rendered;
+}
+
+describe("useCriticalAlerts on a granted iOS device", () => {
+  beforeEach(async () => {
+    setPlatform("ios");
+    setIsDevice(true);
+    await AsyncStorage.clear();
+    await AsyncStorage.setItem(PUSH_TOKEN_KEY, DEVICE_TOKEN);
+    serverSpy().mockClear();
+    serverSpy().mockResolvedValue(undefined as never);
+    grantIos();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("offers the setting", async () => {
+    const { result } = await renderCriticalAlerts();
+
+    expect(result.current.isSupported).toBe(true);
+    expect(result.current.isPermissionGranted).toBe(true);
+  });
+
+  test("starts off for a device that never opted in", async () => {
+    const { result } = await renderCriticalAlerts();
+
+    expect(result.current.isEnabled).toBe(false);
+  });
+
+  test("turning it on tells the server", async () => {
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(serverSpy()).toHaveBeenCalledWith({
+      deviceToken: DEVICE_TOKEN,
+      isEnabled: true,
+    });
+  });
+
+  test("turning it on stores the choice for re-registration", async () => {
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(await getCriticalAlertsEnabled()).toBe(true);
+  });
+
+  test("the switch reads as on afterwards", async () => {
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(result.current.isEnabled).toBe(true);
+    expect(result.current.error).toBe("");
+  });
+
+  test("turning it off again tells the server and clears the stored choice", async () => {
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+    await act(async () => {
+      await result.current.setEnabled(false);
+    });
+
+    expect(serverSpy()).toHaveBeenLastCalledWith({
+      deviceToken: DEVICE_TOKEN,
+      isEnabled: false,
+    });
+    expect(await getCriticalAlertsEnabled()).toBe(false);
+    expect(result.current.isEnabled).toBe(false);
+  });
+});
+
+describe("useCriticalAlerts when the server refuses", () => {
+  beforeEach(async () => {
+    setPlatform("ios");
+    setIsDevice(true);
+    await AsyncStorage.clear();
+    await AsyncStorage.setItem(PUSH_TOKEN_KEY, DEVICE_TOKEN);
+    serverSpy().mockClear();
+    grantIos();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("the switch does not stay on", async () => {
+    /*
+     * The whole point of this feature is a phone that rings. A toggle that
+     * looks saved but never reached the server is a responder who believes
+     * they are covered and is not.
+     */
+    serverSpy().mockRejectedValue(new Error("network unreachable") as never);
+
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(result.current.isEnabled).toBe(false);
+  });
+
+  test("the responder is told the setting was not saved", async () => {
+    serverSpy().mockRejectedValue(new Error("network unreachable") as never);
+
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(result.current.error.length).toBeGreaterThan(0);
+  });
+
+  test("nothing is stored locally, so re-registration does not replay a failed opt-in", async () => {
+    serverSpy().mockRejectedValue(new Error("network unreachable") as never);
+
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(await getCriticalAlertsEnabled()).toBe(false);
+  });
+});
+
+describe("useCriticalAlerts when the OS has not granted the capability", () => {
+  beforeEach(async () => {
+    setPlatform("ios");
+    setIsDevice(true);
+    await AsyncStorage.clear();
+    await AsyncStorage.setItem(PUSH_TOKEN_KEY, DEVICE_TOKEN);
+    serverSpy().mockClear();
+    serverSpy().mockResolvedValue(undefined as never);
+    denyIos();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("the switch refuses to turn on", async () => {
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(result.current.isEnabled).toBe(false);
+  });
+
+  test("the server is never told the device can do something it cannot", async () => {
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(serverSpy()).not.toHaveBeenCalled();
+  });
+
+  test("the responder is told exactly which OS setting to change", async () => {
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(result.current.error).toContain("Critical Alerts");
+  });
+
+  test("it asks the OS before giving up", async () => {
+    const requestSpy: jest.SpyInstance = jest.spyOn(
+      Notifications,
+      "requestPermissionsAsync",
+    );
+
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(requestSpy).toHaveBeenCalled();
+  });
+});
+
+describe("useCriticalAlerts when the permission is revoked later", () => {
+  beforeEach(async () => {
+    setPlatform("ios");
+    setIsDevice(true);
+    await AsyncStorage.clear();
+    await AsyncStorage.setItem(PUSH_TOKEN_KEY, DEVICE_TOKEN);
+    serverSpy().mockClear();
+    serverSpy().mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("a stored opt-in does NOT show as on once iOS stops allowing it", async () => {
+    /*
+     * The responder turned this on months ago, then revoked the permission in
+     * iOS Settings. The stored preference still says true. Showing the switch
+     * as on here is the single most dangerous reading in the feature: it tells
+     * somebody their phone will wake them when the OS will no longer let it.
+     */
+    await AsyncStorage.setItem("oneuptime_critical_alerts_enabled", "true");
+    denyIos();
+
+    const { result } = await renderCriticalAlerts();
+
+    expect(result.current.isEnabled).toBe(false);
+    expect(result.current.isPermissionGranted).toBe(false);
+  });
+
+  test("a stored opt-in shows as on while the OS still allows it", async () => {
+    await AsyncStorage.setItem("oneuptime_critical_alerts_enabled", "true");
+    grantIos();
+
+    const { result } = await renderCriticalAlerts();
+
+    await waitFor(() => {
+      expect(result.current.isEnabled).toBe(true);
+    });
+  });
+});
+
+describe("useCriticalAlerts on Android", () => {
+  beforeEach(async () => {
+    setPlatform("android");
+    setIsDevice(true);
+    await AsyncStorage.clear();
+    await AsyncStorage.setItem(PUSH_TOKEN_KEY, DEVICE_TOKEN);
+    serverSpy().mockClear();
+    serverSpy().mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("is granted once the channel really bypasses Do Not Disturb", async () => {
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: true } as never);
+
+    const { result } = await renderCriticalAlerts();
+
+    expect(result.current.isPermissionGranted).toBe(true);
+  });
+
+  test("turning it on after the grant reaches the server", async () => {
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: true } as never);
+
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(serverSpy()).toHaveBeenCalledWith({
+      deviceToken: DEVICE_TOKEN,
+      isEnabled: true,
+    });
+  });
+
+  test("without Do Not Disturb access the responder is pointed at the right screen", async () => {
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: false } as never);
+
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(result.current.error).toContain("Do Not Disturb access");
+    expect(result.current.isEnabled).toBe(false);
+  });
+
+  test("returning to the app re-checks whether access was just granted", async () => {
+    /*
+     * Android grants this on a system screen, so the app is backgrounded while
+     * the decision is made. Coming back to the foreground is the ONLY signal
+     * that anything changed - without this the switch stays stuck off until
+     * the responder kills and reopens the app.
+     */
+    const channelSpy: jest.SpyInstance = jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: false } as never);
+
+    const addListenerSpy: jest.SpyInstance = jest.spyOn(
+      AppState,
+      "addEventListener",
+    );
+
+    const { result } = await renderCriticalAlerts();
+
+    expect(result.current.isPermissionGranted).toBe(false);
+
+    const handler: (state: string) => void = addListenerSpy.mock
+      .calls[0]![1] as (state: string) => void;
+
+    channelSpy.mockResolvedValue({ bypassDnd: true } as never);
+
+    await act(async () => {
+      handler("active");
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPermissionGranted).toBe(true);
+    });
+  });
+
+  test("the stale permission instruction is cleared once access is granted", async () => {
+    /*
+     * The responder read "grant Do Not Disturb access", left, granted it, and
+     * came back. Leaving that message on screen reads as though granting it
+     * did not work.
+     */
+    const channelSpy: jest.SpyInstance = jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: false } as never);
+
+    const addListenerSpy: jest.SpyInstance = jest.spyOn(
+      AppState,
+      "addEventListener",
+    );
+
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(result.current.error).toContain("Do Not Disturb access");
+
+    const handler: (state: string) => void = addListenerSpy.mock
+      .calls[0]![1] as (state: string) => void;
+
+    channelSpy.mockResolvedValue({ bypassDnd: true } as never);
+
+    await act(async () => {
+      handler("active");
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("");
+    });
+  });
+
+  test("backgrounding does not trigger a re-check", async () => {
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: false } as never);
+
+    const addListenerSpy: jest.SpyInstance = jest.spyOn(
+      AppState,
+      "addEventListener",
+    );
+
+    await renderCriticalAlerts();
+
+    const handler: (state: string) => void = addListenerSpy.mock
+      .calls[0]![1] as (state: string) => void;
+
+    const channelSpy: jest.SpyInstance = jest.spyOn(
+      Notifications,
+      "getNotificationChannelAsync",
+    );
+    channelSpy.mockClear();
+
+    await act(async () => {
+      handler("background");
+    });
+
+    expect(channelSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("useCriticalAlerts when the device is not registered for push", () => {
+  beforeEach(async () => {
+    setPlatform("ios");
+    setIsDevice(true);
+    await AsyncStorage.clear();
+    serverSpy().mockClear();
+    serverSpy().mockResolvedValue(undefined as never);
+    grantIos();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("the toggle does not silently succeed with nothing to point at", async () => {
+    /*
+     * No push token means no device row on the server, so there is nothing to
+     * set the flag on. Storing the preference anyway would show an "on" switch
+     * backed by no server-side state at all.
+     */
+    const { result } = await renderCriticalAlerts();
+
+    await act(async () => {
+      await result.current.setEnabled(true);
+    });
+
+    expect(serverSpy()).not.toHaveBeenCalled();
+    expect(result.current.isEnabled).toBe(false);
+    expect(result.current.error).toContain("not registered");
+  });
+});
+
+describe("useCriticalAlerts where the platform cannot support it", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    setIsDevice(true);
+  });
+
+  test("the setting is not offered on a simulator", async () => {
+    setPlatform("ios");
+    setIsDevice(false);
+
+    const { result } = await renderCriticalAlerts();
+
+    expect(result.current.isSupported).toBe(false);
+  });
+
+  test("the setting is not offered on web", async () => {
+    setPlatform("web");
+    setIsDevice(true);
+
+    const { result } = await renderCriticalAlerts();
+
+    expect(result.current.isSupported).toBe(false);
+  });
+});

--- a/MobileApp/src/hooks/useCriticalAlerts.ts
+++ b/MobileApp/src/hooks/useCriticalAlerts.ts
@@ -1,0 +1,269 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { AppState, AppStateStatus, Platform } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  CriticalAlertAvailability,
+  CriticalAlertStatus,
+  getCriticalAlertStatus,
+  requestCriticalAlertPermission,
+} from "../notifications/criticalAlerts";
+import {
+  getCriticalAlertsEnabled,
+  setCriticalAlertsEnabled as storeCriticalAlertsEnabled,
+} from "../storage/preferences";
+import { setCriticalAlertsEnabledOnServer } from "../api/pushDevice";
+import { PUSH_TOKEN_KEY } from "./pushTokenUtils";
+import logger from "../utils/logger";
+
+export interface CriticalAlertsState {
+  // Whether the platform can do this at all (false on simulators and web).
+  isSupported: boolean;
+  // Whether the OS has actually granted the capability right now.
+  isPermissionGranted: boolean;
+  // The responder's choice, as far as the server knows it.
+  isEnabled: boolean;
+  isBusy: boolean;
+  /*
+   * Set when a toggle could not be honoured, cleared by the next successful
+   * one. The UI shows it verbatim: every message names the specific thing the
+   * responder has to do.
+   */
+  error: string;
+  // What the current state means, in a sentence, for the settings screen.
+  statusMessage: string;
+  setEnabled: (enabled: boolean) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const NO_DEVICE_ERROR: string =
+  "This device is not registered for push notifications yet. Open the app while online and try again.";
+
+const SERVER_ERROR: string =
+  "Could not save this setting. Check your connection and try again.";
+
+export function useCriticalAlerts(): CriticalAlertsState {
+  const [isSupported, setIsSupported] = useState<boolean>(false);
+  const [isPermissionGranted, setIsPermissionGranted] =
+    useState<boolean>(false);
+  const [isEnabled, setIsEnabled] = useState<boolean>(false);
+  const [isBusy, setIsBusy] = useState<boolean>(false);
+  const [error, setError] = useState<string>("");
+  const [statusMessage, setStatusMessage] = useState<string>("");
+
+  /*
+   * State updates are dropped once the screen is gone. The Android flow leaves
+   * the app entirely (system settings) and resolves when the user returns, so
+   * a resolution arriving after unmount is the normal case here, not an edge.
+   */
+  const isMountedRef: React.RefObject<boolean> = useRef<boolean>(true);
+
+  useEffect((): (() => void) => {
+    isMountedRef.current = true;
+    return (): void => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const applyStatus: (status: CriticalAlertStatus) => void = useCallback(
+    (status: CriticalAlertStatus): void => {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      setIsSupported(
+        status.availability !== CriticalAlertAvailability.Unsupported,
+      );
+      setIsPermissionGranted(
+        status.availability === CriticalAlertAvailability.Granted,
+      );
+      setStatusMessage(status.reason);
+    },
+    [],
+  );
+
+  /*
+   * Read the OS and the stored preference and reconcile them. Returns the
+   * status so callers that care about the transition (the foreground listener
+   * below) can act on it; `refresh` is the void-returning wrapper the settings
+   * screen sees.
+   */
+  const syncStatus: () => Promise<CriticalAlertStatus> =
+    useCallback(async (): Promise<CriticalAlertStatus> => {
+      const [status, storedPreference]: [CriticalAlertStatus, boolean] =
+        await Promise.all([
+          getCriticalAlertStatus(),
+          getCriticalAlertsEnabled(),
+        ]);
+
+      applyStatus(status);
+
+      if (isMountedRef.current) {
+        /*
+         * A permission the responder revoked in system settings wins over the
+         * stored preference. Showing the switch as on when the OS will no
+         * longer honour it is the one reading that could let somebody sleep
+         * through a page believing they were covered.
+         */
+        setIsEnabled(
+          storedPreference &&
+            status.availability === CriticalAlertAvailability.Granted,
+        );
+      }
+
+      return status;
+    }, [applyStatus]);
+
+  const refresh: () => Promise<void> = useCallback(async (): Promise<void> => {
+    await syncStatus();
+  }, [syncStatus]);
+
+  useEffect((): void => {
+    refresh().catch((refreshError: unknown): void => {
+      logger.warn(
+        "[CriticalAlerts] Could not load critical alert state:",
+        refreshError,
+      );
+    });
+  }, [refresh]);
+
+  /*
+   * Android grants Do Not Disturb access on a system screen, so the app is in
+   * the background while the decision is made and the only signal that
+   * something changed is coming back to the foreground. Re-checking on every
+   * foreground also catches a permission revoked days later in iOS Settings.
+   */
+  useEffect((): (() => void) => {
+    const subscription: { remove: () => void } = AppState.addEventListener(
+      "change",
+      (nextState: AppStateStatus): void => {
+        if (nextState !== "active") {
+          return;
+        }
+
+        syncStatus()
+          .then((status: CriticalAlertStatus): void => {
+            /*
+             * The responder has just come back from the system settings screen
+             * this error sent them to. Leaving "you must grant Do Not Disturb
+             * access" on screen after they granted it reads as though it did
+             * not work.
+             */
+            if (
+              status.availability === CriticalAlertAvailability.Granted &&
+              isMountedRef.current
+            ) {
+              setError("");
+            }
+          })
+          .catch((refreshError: unknown): void => {
+            logger.warn(
+              "[CriticalAlerts] Could not refresh critical alert state:",
+              refreshError,
+            );
+          });
+      },
+    );
+
+    return (): void => {
+      subscription.remove();
+    };
+  }, [syncStatus]);
+
+  const setEnabled: (enabled: boolean) => Promise<void> = useCallback(
+    async (enabled: boolean): Promise<void> => {
+      setIsBusy(true);
+      setError("");
+
+      try {
+        let status: CriticalAlertStatus = await getCriticalAlertStatus();
+
+        if (
+          enabled &&
+          status.availability === CriticalAlertAvailability.Denied
+        ) {
+          // Not granted yet: prompt on iOS, open the settings screen on Android.
+          status = await requestCriticalAlertPermission();
+        }
+
+        applyStatus(status);
+
+        if (
+          enabled &&
+          status.availability !== CriticalAlertAvailability.Granted
+        ) {
+          /*
+           * On Android this is the ordinary path, not a failure: the user has
+           * been sent to system settings and has not come back yet. The
+           * foreground listener re-checks when they do, so the message tells
+           * them what to do rather than claiming the setting is broken.
+           */
+          if (isMountedRef.current) {
+            setIsEnabled(false);
+            setError(status.reason);
+          }
+          return;
+        }
+
+        const deviceToken: string | null =
+          await AsyncStorage.getItem(PUSH_TOKEN_KEY);
+
+        if (!deviceToken) {
+          if (isMountedRef.current) {
+            setIsEnabled(false);
+            setError(NO_DEVICE_ERROR);
+          }
+          return;
+        }
+
+        await setCriticalAlertsEnabledOnServer({
+          deviceToken: deviceToken,
+          isEnabled: enabled,
+        });
+
+        /*
+         * Stored only after the server accepted it. The local copy is what
+         * re-registration replays, so persisting an unsaved "on" would keep
+         * telling the server something the responder was told had failed.
+         */
+        await storeCriticalAlertsEnabled(enabled);
+
+        if (isMountedRef.current) {
+          setIsEnabled(enabled);
+        }
+      } catch (toggleError: unknown) {
+        logger.error(
+          "[CriticalAlerts] Could not update the critical alert setting:",
+          toggleError,
+        );
+
+        if (isMountedRef.current) {
+          // Leave the switch showing what is actually in force, not what was asked for.
+          setIsEnabled(!enabled);
+          setError(SERVER_ERROR);
+        }
+
+        // Re-read rather than assume; the failure may have been the permission check.
+        await refresh().catch((): void => {
+          // Already reported above.
+        });
+      } finally {
+        if (isMountedRef.current) {
+          setIsBusy(false);
+        }
+      }
+    },
+    [applyStatus, refresh],
+  );
+
+  return {
+    // Web has no ringer to override; the toggle is not offered there at all.
+    isSupported: isSupported && Platform.OS !== "web",
+    isPermissionGranted,
+    isEnabled,
+    isBusy,
+    error,
+    statusMessage,
+    setEnabled,
+    refresh,
+  };
+}

--- a/MobileApp/src/hooks/usePushNotifications.ts
+++ b/MobileApp/src/hooks/usePushNotifications.ts
@@ -15,6 +15,7 @@ import { registerPushDevice } from "../api/pushDevice";
 import { useAuth } from "./useAuth";
 import { useProject } from "./useProject";
 import { PUSH_TOKEN_KEY } from "./pushTokenUtils";
+import { getCriticalAlertsEnabled } from "../storage/preferences";
 import logger from "../utils/logger";
 
 const RETRY_DELAY_MS: number = 5000;
@@ -80,6 +81,15 @@ export function usePushNotifications(navigationRef: unknown): void {
 
       await AsyncStorage.setItem(PUSH_TOKEN_KEY, token);
 
+      /*
+       * Carried into every registration below. Each project gets its own device
+       * row, and a row created without this defaults to off - so without it a
+       * responder who had critical alerts on would silently lose the override
+       * for any project they joined after switching it on, and for every
+       * project at all after a reinstall issued a new push token.
+       */
+      const isCriticalAlertEnabled: boolean = await getCriticalAlertsEnabled();
+
       // Register with each project
       for (const project of projectList) {
         if (cancelled) {
@@ -89,6 +99,7 @@ export function usePushNotifications(navigationRef: unknown): void {
           await registerPushDevice({
             deviceToken: token,
             projectId: project._id,
+            isCriticalAlertEnabled: isCriticalAlertEnabled,
           });
         } catch (error: unknown) {
           logger.warn(

--- a/MobileApp/src/hooks/usePushNotificationsCriticalAlerts.test.tsx
+++ b/MobileApp/src/hooks/usePushNotificationsCriticalAlerts.test.tsx
@@ -1,0 +1,124 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { renderHook, waitFor } from "@testing-library/react-native";
+import { usePushNotifications } from "./usePushNotifications";
+import * as pushDeviceApi from "../api/pushDevice";
+import * as setupModule from "../notifications/setup";
+import { setCriticalAlertsEnabled } from "../storage/preferences";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+
+jest.mock("../api/pushDevice", () => {
+  return {
+    registerPushDevice: jest.fn(async () => {
+      return undefined;
+    }),
+    unregisterPushDevice: jest.fn(),
+    setCriticalAlertsEnabledOnServer: jest.fn(),
+  };
+});
+
+jest.mock("./useAuth", () => {
+  return {
+    useAuth: () => {
+      return { isAuthenticated: true };
+    },
+  };
+});
+
+jest.mock("./useProject", () => {
+  return {
+    useProject: () => {
+      return { projectList: [{ _id: "project-1" }, { _id: "project-2" }] };
+    },
+  };
+});
+
+/*
+ * Registration is where the responder's choice is RESTATED to the server, and
+ * it is the path nobody thinks about.
+ *
+ * Each project a responder belongs to gets its own UserPush row, and a row
+ * created without the flag defaults to off. So a responder who turned critical
+ * alerts on last month and joined a new project this morning would be paged
+ * loudly for the old projects and silently for the new one - with nothing in
+ * any UI to suggest the two differ. Reinstalling the app, or being issued a
+ * fresh Expo push token, has the same effect across every project at once.
+ */
+
+function registerSpy(): jest.SpyInstance {
+  return pushDeviceApi.registerPushDevice as unknown as jest.SpyInstance;
+}
+
+describe("Push registration restates the critical alert preference", () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    registerSpy().mockClear();
+    registerSpy().mockResolvedValue(undefined as never);
+
+    jest
+      .spyOn(setupModule, "requestPermissionsAndGetToken")
+      .mockResolvedValue("ExponentPushToken[handset]" as never);
+    jest
+      .spyOn(setupModule, "setupNotificationChannels")
+      .mockResolvedValue(undefined as never);
+    jest
+      .spyOn(setupModule, "setupNotificationCategories")
+      .mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("sends the stored opt-in for every project", async () => {
+    await setCriticalAlertsEnabled(true);
+
+    await renderHook(() => {
+      return usePushNotifications(null);
+    });
+
+    await waitFor(() => {
+      expect(registerSpy()).toHaveBeenCalledTimes(2);
+    });
+
+    for (const call of registerSpy().mock.calls) {
+      expect(
+        (call[0] as { isCriticalAlertEnabled: boolean }).isCriticalAlertEnabled,
+      ).toBe(true);
+    }
+  });
+
+  test("sends false when the responder never opted in", async () => {
+    await renderHook(() => {
+      return usePushNotifications(null);
+    });
+
+    await waitFor(() => {
+      expect(registerSpy()).toHaveBeenCalled();
+    });
+
+    expect(
+      (registerSpy().mock.calls[0]![0] as { isCriticalAlertEnabled: boolean })
+        .isCriticalAlertEnabled,
+    ).toBe(false);
+  });
+
+  test("still registers every project with its token", async () => {
+    await setCriticalAlertsEnabled(true);
+
+    await renderHook(() => {
+      return usePushNotifications(null);
+    });
+
+    await waitFor(() => {
+      expect(registerSpy()).toHaveBeenCalledTimes(2);
+    });
+
+    const projectIds: Array<string> = registerSpy().mock.calls.map(
+      (call: Array<unknown>) => {
+        return (call[0] as { projectId: string }).projectId;
+      },
+    );
+
+    expect(projectIds).toEqual(["project-1", "project-2"]);
+  });
+});

--- a/MobileApp/src/notifications/channels.test.ts
+++ b/MobileApp/src/notifications/channels.test.ts
@@ -1,0 +1,184 @@
+import * as Notifications from "expo-notifications";
+import {
+  CRITICAL_CHANNEL,
+  HIGH_CHANNEL,
+  LOW_CHANNEL,
+  NORMAL_CHANNEL,
+  NOTIFICATION_CHANNELS,
+  NotificationChannelId,
+} from "./channels";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * On Android, a channel's settings are frozen when the channel is created and
+ * the app can never raise them again - that is a platform guarantee protecting
+ * users from apps that get louder after install. It also means every property
+ * below is a one-way door: shipping the critical channel with the wrong
+ * importance, the wrong audio usage, or bypassDnd missing does not fail at
+ * build time, does not error at runtime, and cannot be fixed by an update for
+ * anybody who already installed the app. It can only be fixed by shipping a
+ * NEW channel id.
+ *
+ * So these are not "does the object have the field" tests. Each one is a
+ * property that, wrong at release, permanently silences on-call pages for
+ * every handset that installed that build.
+ */
+
+describe("The critical channel is what overrides silent mode", () => {
+  test("bypasses Do Not Disturb", () => {
+    /*
+     * The single field that makes this channel different from oncall_high.
+     * Android grants it only once the user allows Do Not Disturb access, but
+     * the channel has to ASK for it at creation - a channel created without it
+     * can never gain it.
+     */
+    expect(CRITICAL_CHANNEL.bypassDnd).toBe(true);
+  });
+
+  test("plays on the alarm stream, which survives the ringer switch", () => {
+    /*
+     * The other half of "override silent mode", and the half that needs no
+     * permission at all: a silenced phone still plays alarms. Without this,
+     * granting Do Not Disturb access covers DND but not a plain muted phone.
+     */
+    expect(CRITICAL_CHANNEL.audioAttributes?.usage).toBe(
+      Notifications.AndroidAudioUsage.ALARM,
+    );
+  });
+
+  test("asks the system not to duck the sound for whatever else is playing", () => {
+    expect(CRITICAL_CHANNEL.audioAttributes?.flags?.enforceAudibility).toBe(
+      true,
+    );
+  });
+
+  test("is sonification, not media - so it is not treated as content playback", () => {
+    expect(CRITICAL_CHANNEL.audioAttributes?.contentType).toBe(
+      Notifications.AndroidAudioContentType.SONIFICATION,
+    );
+  });
+
+  test("uses MAX importance, without which there is no sound and no heads-up", () => {
+    expect(CRITICAL_CHANNEL.importance).toBe(
+      Notifications.AndroidImportance.MAX,
+    );
+  });
+
+  test("actually has a sound", () => {
+    /*
+     * A channel with sound: null is silent no matter what else it declares,
+     * which would make every other assertion in this file meaningless.
+     */
+    expect(CRITICAL_CHANNEL.sound).toBe("default");
+  });
+
+  test("vibrates as well, for a phone that is face-down or in a pocket", () => {
+    expect(CRITICAL_CHANNEL.enableVibrate).toBe(true);
+    expect(CRITICAL_CHANNEL.vibrationPattern?.length).toBeGreaterThan(0);
+  });
+
+  test("shows on the lock screen, so the page is readable without unlocking", () => {
+    expect(CRITICAL_CHANNEL.lockscreenVisibility).toBe(
+      Notifications.AndroidNotificationVisibility.PUBLIC,
+    );
+  });
+
+  test("is named so a responder can find it in Android's notification settings", () => {
+    expect(CRITICAL_CHANNEL.name).toBe("Critical On-Call Alerts");
+    expect(CRITICAL_CHANNEL.description).toContain("Do Not Disturb");
+  });
+});
+
+describe("The ordinary channels stay ordinary", () => {
+  test.each([
+    ["high", HIGH_CHANNEL],
+    ["normal", NORMAL_CHANNEL],
+    ["low", LOW_CHANNEL],
+  ])(
+    "the %s channel does not bypass Do Not Disturb",
+    (_label: string, channel: Notifications.NotificationChannelInput) => {
+      /*
+       * These carry every notification for a responder who has NOT opted in.
+       * A bypassDnd that crept onto oncall_high would override the ringer for
+       * everybody, permanently, with no setting to turn it back off.
+       */
+      expect(channel.bypassDnd).toBeFalsy();
+    },
+  );
+
+  test.each([
+    ["high", HIGH_CHANNEL],
+    ["normal", NORMAL_CHANNEL],
+    ["low", LOW_CHANNEL],
+  ])(
+    "the %s channel does not use the alarm audio stream",
+    (_label: string, channel: Notifications.NotificationChannelInput) => {
+      expect(channel.audioAttributes?.usage).toBeUndefined();
+    },
+  );
+
+  test("the high channel is still loud enough for a page", () => {
+    expect(HIGH_CHANNEL.importance).toBe(Notifications.AndroidImportance.HIGH);
+    expect(HIGH_CHANNEL.sound).toBe("default");
+  });
+
+  test("the low channel makes no sound", () => {
+    expect(LOW_CHANNEL.importance).toBe(Notifications.AndroidImportance.LOW);
+    expect(LOW_CHANNEL.sound).toBeUndefined();
+  });
+});
+
+describe("Channel ids match the contract the server sends", () => {
+  /*
+   * The server names a channel by string id. An id it sends that the app never
+   * created does not error - Android delivers the notification with default
+   * settings, which for an on-call page means silently. These literals are the
+   * shared contract with
+   * Common/Types/PushNotification/AndroidNotificationChannel.ts.
+   */
+  test("the critical channel id is oncall_critical", () => {
+    expect(NotificationChannelId.CRITICAL).toBe("oncall_critical");
+  });
+
+  test("the default on-call channel id is oncall_high", () => {
+    expect(NotificationChannelId.HIGH).toBe("oncall_high");
+  });
+
+  test("the remaining ids are unchanged", () => {
+    expect(NotificationChannelId.NORMAL).toBe("oncall_normal");
+    expect(NotificationChannelId.LOW).toBe("oncall_low");
+  });
+
+  test("every id the app creates is distinct", () => {
+    const ids: Array<string> = NOTIFICATION_CHANNELS.map(
+      (entry: { id: string }) => {
+        return entry.id;
+      },
+    );
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("all four channels are registered for creation", () => {
+    expect(
+      NOTIFICATION_CHANNELS.map((entry: { id: string }) => {
+        return entry.id;
+      }),
+    ).toEqual([
+      "oncall_critical",
+      "oncall_high",
+      "oncall_normal",
+      "oncall_low",
+    ]);
+  });
+
+  test("the critical id maps to the critical channel definition", () => {
+    const entry: { channel: Notifications.NotificationChannelInput } =
+      NOTIFICATION_CHANNELS.find((candidate: { id: string }) => {
+        return candidate.id === "oncall_critical";
+      })!;
+
+    expect(entry.channel).toBe(CRITICAL_CHANNEL);
+    expect(entry.channel.bypassDnd).toBe(true);
+  });
+});

--- a/MobileApp/src/notifications/channels.ts
+++ b/MobileApp/src/notifications/channels.ts
@@ -1,0 +1,106 @@
+import * as Notifications from "expo-notifications";
+
+/*
+ * Android channel ids. These must match
+ * Common/Types/PushNotification/AndroidNotificationChannel.ts on the server:
+ * a push names a channel by id, and a channel the app never created falls back
+ * to default settings rather than failing, so a typo here shows up as an
+ * on-call page that arrives silently.
+ */
+export const NotificationChannelId: {
+  readonly CRITICAL: "oncall_critical";
+  readonly HIGH: "oncall_high";
+  readonly NORMAL: "oncall_normal";
+  readonly LOW: "oncall_low";
+} = {
+  CRITICAL: "oncall_critical",
+  HIGH: "oncall_high",
+  NORMAL: "oncall_normal",
+  LOW: "oncall_low",
+} as const;
+
+export type NotificationChannelIdValue =
+  (typeof NotificationChannelId)[keyof typeof NotificationChannelId];
+
+/*
+ * The critical channel, spelled out because every field on it is doing work:
+ *
+ * - bypassDnd is the actual Do Not Disturb override. Android only honours it
+ *   once the user has granted this app Notification Policy Access in system
+ *   settings; until then the channel is created with the flag silently off,
+ *   which is why isCriticalChannelBypassingDnd() reads it back rather than
+ *   trusting the write.
+ * - usage ALARM puts the sound on the alarm stream, which is the stream that
+ *   still plays when the ringer is silenced. This is the half that gets a
+ *   silenced (as opposed to Do-Not-Disturbed) phone to make noise, and it
+ *   needs no permission.
+ * - enforceAudibility asks the system not to duck the sound for whatever else
+ *   is playing.
+ * - MAX importance is what allows a heads-up notification and a sound at all.
+ *
+ * None of these can be raised after the channel exists. Android freezes a
+ * channel's settings on creation so that a user's later adjustments cannot be
+ * undone by an app update, so changing any of this means shipping a new
+ * channel id, not editing this object.
+ */
+export const CRITICAL_CHANNEL: Notifications.NotificationChannelInput = {
+  name: "Critical On-Call Alerts",
+  description:
+    "Urgent on-call pages. These override silent mode and Do Not Disturb so incidents are not missed.",
+  importance: Notifications.AndroidImportance.MAX,
+  sound: "default",
+  bypassDnd: true,
+  vibrationPattern: [0, 500, 250, 500, 250, 500],
+  enableVibrate: true,
+  enableLights: true,
+  lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+  showBadge: true,
+  audioAttributes: {
+    usage: Notifications.AndroidAudioUsage.ALARM,
+    contentType: Notifications.AndroidAudioContentType.SONIFICATION,
+    flags: {
+      enforceAudibility: true,
+      requestHardwareAudioVideoSynchronization: false,
+    },
+  },
+};
+
+/*
+ * The ordinary on-call channel: loud, but it respects the ringer switch and Do
+ * Not Disturb like any other notification. This is where every page goes for a
+ * responder who has not opted this device into critical alerts, and it is the
+ * channel the server names by default.
+ */
+export const HIGH_CHANNEL: Notifications.NotificationChannelInput = {
+  name: "High Priority",
+  description:
+    "On-call pages and other time-sensitive notifications. Follows your device's silent and Do Not Disturb settings.",
+  importance: Notifications.AndroidImportance.HIGH,
+  sound: "default",
+  vibrationPattern: [0, 250, 250, 250],
+  enableVibrate: true,
+  lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
+};
+
+export const NORMAL_CHANNEL: Notifications.NotificationChannelInput = {
+  name: "Normal Priority",
+  description: "General OneUptime notifications.",
+  importance: Notifications.AndroidImportance.DEFAULT,
+  sound: "default",
+};
+
+export const LOW_CHANNEL: Notifications.NotificationChannelInput = {
+  name: "Low Priority",
+  description: "Informational updates that do not need your attention now.",
+  importance: Notifications.AndroidImportance.LOW,
+};
+
+export const NOTIFICATION_CHANNELS: ReadonlyArray<{
+  id: NotificationChannelIdValue;
+  channel: Notifications.NotificationChannelInput;
+}> = [
+  { id: NotificationChannelId.CRITICAL, channel: CRITICAL_CHANNEL },
+  { id: NotificationChannelId.HIGH, channel: HIGH_CHANNEL },
+  { id: NotificationChannelId.NORMAL, channel: NORMAL_CHANNEL },
+  { id: NotificationChannelId.LOW, channel: LOW_CHANNEL },
+];

--- a/MobileApp/src/notifications/criticalAlerts.test.ts
+++ b/MobileApp/src/notifications/criticalAlerts.test.ts
@@ -1,0 +1,455 @@
+import * as Notifications from "expo-notifications";
+import * as Device from "expo-device";
+import { Linking, Platform } from "react-native";
+import {
+  CriticalAlertAvailability,
+  CriticalAlertStatus,
+  getCriticalAlertStatus,
+  isCriticalChannelBypassingDnd,
+  openAndroidDoNotDisturbAccessSettings,
+  requestCriticalAlertPermission,
+} from "./criticalAlerts";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+
+/*
+ * Establishing whether this handset will ACTUALLY ring through silent mode.
+ *
+ * Both platforms fail this silently. iOS without the critical-alert
+ * entitlement grants the permission request and simply never sets
+ * allowsCriticalAlerts. Android accepts a channel with bypassDnd: true and
+ * stores it as false until the user grants Do Not Disturb access. In both
+ * cases the app that trusts its own request believes it is covered, tells the
+ * responder so, and delivers a silent page at 3am.
+ *
+ * So every path here is written to read the CURRENT state back from the OS,
+ * and every ambiguous answer resolves to "denied" - being told to check a
+ * setting that was already fine costs a responder ten seconds; the opposite
+ * error costs an incident.
+ */
+
+function setPlatform(os: "ios" | "android" | "web"): void {
+  (Platform as unknown as { OS: string }).OS = os;
+}
+
+function setIsDevice(isDevice: boolean): void {
+  (Device as unknown as { isDevice: boolean }).isDevice = isDevice;
+}
+
+describe("getCriticalAlertStatus on iOS", () => {
+  beforeEach(() => {
+    setPlatform("ios");
+    setIsDevice(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("is granted when iOS reports allowsCriticalAlerts", () => {
+    jest
+      .spyOn(Notifications, "getPermissionsAsync")
+      .mockResolvedValue({ ios: { allowsCriticalAlerts: true } } as never);
+
+    return getCriticalAlertStatus().then((status: CriticalAlertStatus) => {
+      expect(status.availability).toBe(CriticalAlertAvailability.Granted);
+    });
+  });
+
+  test("is denied when iOS grants notifications but NOT critical alerts", async () => {
+    /*
+     * The default state for any build without Apple's entitlement: ordinary
+     * notification permission is granted, so a naive check passes, while
+     * critical alerts are not.
+     */
+    jest.spyOn(Notifications, "getPermissionsAsync").mockResolvedValue({
+      status: "granted",
+      ios: { allowsCriticalAlerts: false },
+    } as never);
+
+    const status: CriticalAlertStatus = await getCriticalAlertStatus();
+
+    expect(status.availability).toBe(CriticalAlertAvailability.Denied);
+  });
+
+  test("is denied when iOS reports nothing about critical alerts", async () => {
+    jest
+      .spyOn(Notifications, "getPermissionsAsync")
+      .mockResolvedValue({ status: "granted", ios: {} } as never);
+
+    const status: CriticalAlertStatus = await getCriticalAlertStatus();
+
+    expect(status.availability).toBe(CriticalAlertAvailability.Denied);
+  });
+
+  test("the denial names the iOS setting the responder has to change", async () => {
+    jest
+      .spyOn(Notifications, "getPermissionsAsync")
+      .mockResolvedValue({ ios: { allowsCriticalAlerts: false } } as never);
+
+    const status: CriticalAlertStatus = await getCriticalAlertStatus();
+
+    expect(status.reason).toContain("Critical Alerts");
+    expect(status.reason).toContain("Settings");
+  });
+
+  test("a thrown permission check is reported as denied, not as granted", async () => {
+    jest
+      .spyOn(Notifications, "getPermissionsAsync")
+      .mockRejectedValue(new Error("native module unavailable") as never);
+
+    const status: CriticalAlertStatus = await getCriticalAlertStatus();
+
+    expect(status.availability).toBe(CriticalAlertAvailability.Denied);
+  });
+
+  test("does not consult Android notification channels", async () => {
+    const channelSpy: jest.SpyInstance = jest.spyOn(
+      Notifications,
+      "getNotificationChannelAsync",
+    );
+
+    jest
+      .spyOn(Notifications, "getPermissionsAsync")
+      .mockResolvedValue({ ios: { allowsCriticalAlerts: true } } as never);
+
+    await getCriticalAlertStatus();
+
+    expect(channelSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("getCriticalAlertStatus on Android", () => {
+  beforeEach(() => {
+    setPlatform("android");
+    setIsDevice(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("is granted when the critical channel really carries the DND bypass", async () => {
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ id: "oncall_critical", bypassDnd: true } as never);
+
+    const status: CriticalAlertStatus = await getCriticalAlertStatus();
+
+    expect(status.availability).toBe(CriticalAlertAvailability.Granted);
+  });
+
+  test("is denied when the channel exists but the OS refused the bypass", async () => {
+    /*
+     * The exact state of a fresh install: the app asked for bypassDnd, Android
+     * created the channel, and stored bypassDnd as false because the user has
+     * not granted Do Not Disturb access. Nothing errored.
+     */
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ id: "oncall_critical", bypassDnd: false } as never);
+
+    const status: CriticalAlertStatus = await getCriticalAlertStatus();
+
+    expect(status.availability).toBe(CriticalAlertAvailability.Denied);
+  });
+
+  test("is denied when the channel does not exist at all", async () => {
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue(null as never);
+
+    const status: CriticalAlertStatus = await getCriticalAlertStatus();
+
+    expect(status.availability).toBe(CriticalAlertAvailability.Denied);
+  });
+
+  test("the denial names Do Not Disturb access, which is where the toggle lives", async () => {
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: false } as never);
+
+    const status: CriticalAlertStatus = await getCriticalAlertStatus();
+
+    expect(status.reason).toContain("Do Not Disturb access");
+  });
+
+  test("reads the channel the server actually targets", async () => {
+    const channelSpy: jest.SpyInstance = jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: true } as never);
+
+    await getCriticalAlertStatus();
+
+    expect(channelSpy).toHaveBeenCalledWith("oncall_critical");
+  });
+
+  test("a thrown channel read is reported as denied", async () => {
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockRejectedValue(new Error("no such channel") as never);
+
+    const status: CriticalAlertStatus = await getCriticalAlertStatus();
+
+    expect(status.availability).toBe(CriticalAlertAvailability.Denied);
+  });
+
+  test("does not ask for the iOS permission", async () => {
+    const permissionSpy: jest.SpyInstance = jest.spyOn(
+      Notifications,
+      "getPermissionsAsync",
+    );
+
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: true } as never);
+
+    await getCriticalAlertStatus();
+
+    expect(permissionSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("getCriticalAlertStatus where the feature cannot exist", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    setIsDevice(true);
+  });
+
+  test("a simulator is unsupported, not merely denied", async () => {
+    /*
+     * Simulators report permissions a real handset would not honour. Offering
+     * the switch there would let a developer conclude the feature works.
+     */
+    setPlatform("ios");
+    setIsDevice(false);
+
+    const status: CriticalAlertStatus = await getCriticalAlertStatus();
+
+    expect(status.availability).toBe(CriticalAlertAvailability.Unsupported);
+  });
+
+  test("web is unsupported - a browser cannot override a phone's ringer", async () => {
+    setPlatform("web");
+    setIsDevice(true);
+
+    const status: CriticalAlertStatus = await getCriticalAlertStatus();
+
+    expect(status.availability).toBe(CriticalAlertAvailability.Unsupported);
+  });
+
+  test("the unsupported message says a physical device is required", async () => {
+    setPlatform("ios");
+    setIsDevice(false);
+
+    const status: CriticalAlertStatus = await getCriticalAlertStatus();
+
+    expect(status.reason).toContain("physical");
+  });
+});
+
+describe("isCriticalChannelBypassingDnd", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("is false on iOS, which has no channels", async () => {
+    setPlatform("ios");
+
+    expect(await isCriticalChannelBypassingDnd()).toBe(false);
+  });
+
+  test("reports what the OS stored, not what the app asked for", async () => {
+    setPlatform("android");
+
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: false } as never);
+
+    expect(await isCriticalChannelBypassingDnd()).toBe(false);
+  });
+
+  test("is true once Do Not Disturb access has been granted", async () => {
+    setPlatform("android");
+
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: true } as never);
+
+    expect(await isCriticalChannelBypassingDnd()).toBe(true);
+  });
+});
+
+describe("requestCriticalAlertPermission on iOS", () => {
+  beforeEach(() => {
+    setPlatform("ios");
+    setIsDevice(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("asks iOS for the critical alert permission specifically", async () => {
+    const requestSpy: jest.SpyInstance = jest
+      .spyOn(Notifications, "requestPermissionsAsync")
+      .mockResolvedValue({ ios: { allowsCriticalAlerts: true } } as never);
+
+    jest
+      .spyOn(Notifications, "getPermissionsAsync")
+      .mockResolvedValue({ ios: { allowsCriticalAlerts: true } } as never);
+
+    await requestCriticalAlertPermission();
+
+    expect(requestSpy).toHaveBeenCalledWith({
+      ios: {
+        allowAlert: true,
+        allowBadge: true,
+        allowSound: true,
+        allowCriticalAlerts: true,
+      },
+    });
+  });
+
+  test("reports what the OS decided, not what was requested", async () => {
+    /*
+     * The request resolves successfully even when the entitlement is missing.
+     * Trusting its return value is exactly how an app ends up claiming it will
+     * wake somebody it cannot wake.
+     */
+    jest
+      .spyOn(Notifications, "requestPermissionsAsync")
+      .mockResolvedValue({ status: "granted" } as never);
+
+    jest
+      .spyOn(Notifications, "getPermissionsAsync")
+      .mockResolvedValue({ ios: { allowsCriticalAlerts: false } } as never);
+
+    const status: CriticalAlertStatus = await requestCriticalAlertPermission();
+
+    expect(status.availability).toBe(CriticalAlertAvailability.Denied);
+  });
+
+  test("a request that throws still yields a status rather than propagating", async () => {
+    jest
+      .spyOn(Notifications, "requestPermissionsAsync")
+      .mockRejectedValue(new Error("declined") as never);
+
+    jest
+      .spyOn(Notifications, "getPermissionsAsync")
+      .mockResolvedValue({ ios: { allowsCriticalAlerts: false } } as never);
+
+    const status: CriticalAlertStatus = await requestCriticalAlertPermission();
+
+    expect(status.availability).toBe(CriticalAlertAvailability.Denied);
+  });
+
+  test("does not try to open Android settings", async () => {
+    const intentSpy: jest.SpyInstance = jest.spyOn(Linking, "sendIntent");
+
+    jest
+      .spyOn(Notifications, "requestPermissionsAsync")
+      .mockResolvedValue({ ios: { allowsCriticalAlerts: true } } as never);
+    jest
+      .spyOn(Notifications, "getPermissionsAsync")
+      .mockResolvedValue({ ios: { allowsCriticalAlerts: true } } as never);
+
+    await requestCriticalAlertPermission();
+
+    expect(intentSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("requestCriticalAlertPermission on Android", () => {
+  beforeEach(() => {
+    setPlatform("android");
+    setIsDevice(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("opens the Do Not Disturb access screen, which is the only way to grant it", async () => {
+    /*
+     * There is no in-app prompt for this on Android. An app that only asked
+     * for notification permission would leave the responder with a switch that
+     * refuses to stay on and no explanation.
+     */
+    const intentSpy: jest.SpyInstance = jest
+      .spyOn(Linking, "sendIntent")
+      .mockResolvedValue(undefined as never);
+
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: false } as never);
+
+    await requestCriticalAlertPermission();
+
+    expect(intentSpy).toHaveBeenCalledWith(
+      "android.settings.NOTIFICATION_POLICY_ACCESS_SETTINGS",
+    );
+  });
+
+  test("returns the state as it stands, since the user has not acted yet", async () => {
+    jest.spyOn(Linking, "sendIntent").mockResolvedValue(undefined as never);
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: false } as never);
+
+    const status: CriticalAlertStatus = await requestCriticalAlertPermission();
+
+    expect(status.availability).toBe(CriticalAlertAvailability.Denied);
+  });
+
+  test("falls back to the app settings page when the intent is unavailable", async () => {
+    /*
+     * Some OEM builds do not expose the intent. One tap away from the right
+     * screen beats going nowhere at all.
+     */
+    jest
+      .spyOn(Linking, "sendIntent")
+      .mockRejectedValue(new Error("no activity found") as never);
+
+    const openSettingsSpy: jest.SpyInstance = jest
+      .spyOn(Linking, "openSettings")
+      .mockResolvedValue(undefined as never);
+
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: false } as never);
+
+    await requestCriticalAlertPermission();
+
+    expect(openSettingsSpy).toHaveBeenCalled();
+  });
+
+  test("a settings screen that cannot be opened at all does not throw", async () => {
+    jest
+      .spyOn(Linking, "sendIntent")
+      .mockRejectedValue(new Error("no activity found") as never);
+    jest
+      .spyOn(Linking, "openSettings")
+      .mockRejectedValue(new Error("nope") as never);
+    jest
+      .spyOn(Notifications, "getNotificationChannelAsync")
+      .mockResolvedValue({ bypassDnd: false } as never);
+
+    await expect(requestCriticalAlertPermission()).resolves.toBeDefined();
+  });
+});
+
+describe("openAndroidDoNotDisturbAccessSettings", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("does nothing on iOS", async () => {
+    setPlatform("ios");
+
+    const intentSpy: jest.SpyInstance = jest.spyOn(Linking, "sendIntent");
+
+    await openAndroidDoNotDisturbAccessSettings();
+
+    expect(intentSpy).not.toHaveBeenCalled();
+  });
+});

--- a/MobileApp/src/notifications/criticalAlerts.ts
+++ b/MobileApp/src/notifications/criticalAlerts.ts
@@ -1,0 +1,247 @@
+import * as Notifications from "expo-notifications";
+import * as Device from "expo-device";
+import { Linking, Platform } from "react-native";
+import { NotificationChannelId } from "./channels";
+import logger from "../utils/logger";
+
+/*
+ * Whether this device can be made to ring through silent mode, and how to ask
+ * for that if it cannot yet.
+ *
+ * The two platforms grant this in completely different ways and neither one
+ * fails loudly when it is missing, which is the whole reason this module
+ * exists. A phone that quietly refuses to override Do Not Disturb looks
+ * identical to one that was never asked, right up until the 3am page nobody
+ * hears - so everything here is written to establish the CURRENT state from
+ * the OS rather than from what the app last tried to set.
+ *
+ *   iOS     - needs Apple's critical-alert entitlement on the build AND the
+ *             user's consent, reported back as
+ *             permissions.ios.allowsCriticalAlerts.
+ *   Android - needs the notification channel to actually carry bypassDnd,
+ *             which the OS grants only after the user gives this app
+ *             Notification Policy Access in system settings. Writing
+ *             bypassDnd: true without it succeeds and produces a channel with
+ *             bypassDnd: false.
+ */
+
+export enum CriticalAlertAvailability {
+  // The OS will let critical alerts through. Safe to turn the setting on.
+  Granted = "granted",
+  /*
+   * The platform supports it, but the user has not granted it yet.
+   * requestCriticalAlertPermission() knows where to send them.
+   */
+  Denied = "denied",
+  // Simulator, web, or an iOS build without the entitlement.
+  Unsupported = "unsupported",
+}
+
+export interface CriticalAlertStatus {
+  availability: CriticalAlertAvailability;
+  /*
+   * What to tell the responder. Kept next to the availability because the same
+   * "denied" means two very different chores on the two platforms.
+   */
+  reason: string;
+}
+
+const IOS_DENIED_REASON: string =
+  "iOS has not granted critical alerts to this app. Allow Critical Alerts for OneUptime On-Call in iOS Settings > Notifications.";
+
+const ANDROID_DENIED_REASON: string =
+  "Android has not granted Do Not Disturb access to this app. Allow it in Settings > Notifications > Do Not Disturb access, then try again.";
+
+const UNSUPPORTED_REASON: string =
+  "Critical alerts are only available on a physical iOS or Android device.";
+
+const GRANTED_REASON: string =
+  "On-call pages will play a sound even when this device is silenced or in Do Not Disturb.";
+
+/*
+ * Read the critical channel back from Android and report whether it really
+ * bypasses Do Not Disturb.
+ *
+ * setNotificationChannelAsync returns the channel as the OS actually stored
+ * it, so the returned bypassDnd is the OS's answer and not an echo of the
+ * request. The channel is (re)written here rather than only read because a
+ * fresh install may not have created it yet, and creating it is harmless when
+ * it already exists - Android ignores every field but name and description on
+ * an existing channel.
+ */
+export async function isCriticalChannelBypassingDnd(): Promise<boolean> {
+  if (Platform.OS !== "android") {
+    return false;
+  }
+
+  try {
+    const channel: Notifications.NotificationChannel | null =
+      await Notifications.getNotificationChannelAsync(
+        NotificationChannelId.CRITICAL,
+      );
+
+    return Boolean(channel?.bypassDnd);
+  } catch (error: unknown) {
+    logger.warn(
+      "[CriticalAlerts] Could not read the critical notification channel:",
+      error,
+    );
+    return false;
+  }
+}
+
+async function getIosCriticalAlertStatus(): Promise<CriticalAlertStatus> {
+  const permissions: Notifications.NotificationPermissionsStatus =
+    await Notifications.getPermissionsAsync();
+
+  if (permissions.ios?.allowsCriticalAlerts) {
+    return {
+      availability: CriticalAlertAvailability.Granted,
+      reason: GRANTED_REASON,
+    };
+  }
+
+  return {
+    availability: CriticalAlertAvailability.Denied,
+    reason: IOS_DENIED_REASON,
+  };
+}
+
+async function getAndroidCriticalAlertStatus(): Promise<CriticalAlertStatus> {
+  const bypassesDnd: boolean = await isCriticalChannelBypassingDnd();
+
+  if (bypassesDnd) {
+    return {
+      availability: CriticalAlertAvailability.Granted,
+      reason: GRANTED_REASON,
+    };
+  }
+
+  return {
+    availability: CriticalAlertAvailability.Denied,
+    reason: ANDROID_DENIED_REASON,
+  };
+}
+
+export async function getCriticalAlertStatus(): Promise<CriticalAlertStatus> {
+  /*
+   * Simulators report permissions that a real handset would not honour, and
+   * there is no ringer to override on web.
+   */
+  if (
+    !Device.isDevice ||
+    (Platform.OS !== "ios" && Platform.OS !== "android")
+  ) {
+    return {
+      availability: CriticalAlertAvailability.Unsupported,
+      reason: UNSUPPORTED_REASON,
+    };
+  }
+
+  try {
+    if (Platform.OS === "ios") {
+      return await getIosCriticalAlertStatus();
+    }
+
+    return await getAndroidCriticalAlertStatus();
+  } catch (error: unknown) {
+    logger.warn(
+      "[CriticalAlerts] Could not determine critical alert status:",
+      error,
+    );
+    /*
+     * Report "denied" rather than "granted" when the answer is unknown. The
+     * cost of being wrong in this direction is a responder who is told to
+     * check a setting that was already fine; the other direction is a
+     * responder told their phone will wake them when it will not.
+     */
+    return {
+      availability: CriticalAlertAvailability.Denied,
+      reason: Platform.OS === "ios" ? IOS_DENIED_REASON : ANDROID_DENIED_REASON,
+    };
+  }
+}
+
+/*
+ * Ask for the capability, then report what the OS decided.
+ *
+ * iOS can be asked in-app: requesting the critical-alert permission shows the
+ * system prompt (once - after that the request resolves immediately with
+ * whatever the user chose the first time, which is why the caller is sent to
+ * Settings on a denial).
+ *
+ * Android cannot be asked in-app at all. Do Not Disturb access is granted only
+ * from a system settings screen, so the best available move is to open that
+ * screen; the return value here is the state BEFORE the user acts on it, and
+ * the caller re-checks when the app comes back to the foreground.
+ */
+export async function requestCriticalAlertPermission(): Promise<CriticalAlertStatus> {
+  if (
+    !Device.isDevice ||
+    (Platform.OS !== "ios" && Platform.OS !== "android")
+  ) {
+    return {
+      availability: CriticalAlertAvailability.Unsupported,
+      reason: UNSUPPORTED_REASON,
+    };
+  }
+
+  if (Platform.OS === "ios") {
+    try {
+      await Notifications.requestPermissionsAsync({
+        ios: {
+          allowAlert: true,
+          allowBadge: true,
+          allowSound: true,
+          allowCriticalAlerts: true,
+        },
+      });
+    } catch (error: unknown) {
+      logger.warn(
+        "[CriticalAlerts] Requesting the iOS critical alert permission failed:",
+        error,
+      );
+    }
+
+    return getCriticalAlertStatus();
+  }
+
+  await openAndroidDoNotDisturbAccessSettings();
+
+  return getCriticalAlertStatus();
+}
+
+/*
+ * Open the system screen where Do Not Disturb access is granted.
+ *
+ * sendIntent is used rather than Linking.openSettings() because the app's own
+ * settings page does not contain this toggle - Do Not Disturb access is a
+ * separate, global list. If the intent is unavailable on some OEM build, fall
+ * back to the app settings page, which is at least one tap from the right
+ * place rather than nowhere.
+ */
+export async function openAndroidDoNotDisturbAccessSettings(): Promise<void> {
+  if (Platform.OS !== "android") {
+    return;
+  }
+
+  try {
+    await Linking.sendIntent(
+      "android.settings.NOTIFICATION_POLICY_ACCESS_SETTINGS",
+    );
+  } catch (error: unknown) {
+    logger.warn(
+      "[CriticalAlerts] Could not open Do Not Disturb access settings:",
+      error,
+    );
+
+    try {
+      await Linking.openSettings();
+    } catch (fallbackError: unknown) {
+      logger.warn(
+        "[CriticalAlerts] Could not open app settings either:",
+        fallbackError,
+      );
+    }
+  }
+}

--- a/MobileApp/src/notifications/setup.test.ts
+++ b/MobileApp/src/notifications/setup.test.ts
@@ -1,0 +1,123 @@
+import * as Notifications from "expo-notifications";
+import { Platform } from "react-native";
+import { setupNotificationChannels } from "./setup";
+import { CRITICAL_CHANNEL } from "./channels";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+
+/*
+ * Creating the channels is what makes the server's channel ids mean anything.
+ * The server names oncall_critical on every critical page; if the app never
+ * created that channel, Android does not error - it delivers the page on a
+ * default channel, silently, which is the failure this whole feature exists to
+ * prevent.
+ */
+
+function setPlatform(os: "ios" | "android"): void {
+  (Platform as unknown as { OS: string }).OS = os;
+}
+
+function createdChannelIds(spy: jest.SpyInstance): Array<string> {
+  return spy.mock.calls.map((call: Array<unknown>) => {
+    return call[0] as string;
+  });
+}
+
+describe("setupNotificationChannels", () => {
+  let channelSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    channelSpy = jest
+      .spyOn(Notifications, "setNotificationChannelAsync")
+      .mockResolvedValue(null as never);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("creates the critical channel on Android", async () => {
+    setPlatform("android");
+
+    await setupNotificationChannels();
+
+    expect(createdChannelIds(channelSpy)).toContain("oncall_critical");
+  });
+
+  test("creates the critical channel with the Do Not Disturb bypass asked for", async () => {
+    /*
+     * Android freezes a channel's settings at creation. Passing a watered-down
+     * object here would permanently silence critical pages on every handset
+     * that installed this build, unfixable by an update.
+     */
+    setPlatform("android");
+
+    await setupNotificationChannels();
+
+    expect(channelSpy).toHaveBeenCalledWith(
+      "oncall_critical",
+      CRITICAL_CHANNEL,
+    );
+  });
+
+  test("creates all four channels", async () => {
+    setPlatform("android");
+
+    await setupNotificationChannels();
+
+    expect(createdChannelIds(channelSpy)).toEqual([
+      "oncall_critical",
+      "oncall_high",
+      "oncall_normal",
+      "oncall_low",
+    ]);
+  });
+
+  test("creates nothing on iOS, which has no channels", async () => {
+    setPlatform("ios");
+
+    await setupNotificationChannels();
+
+    expect(channelSpy).not.toHaveBeenCalled();
+  });
+
+  test("one failing channel does not stop the others being created", async () => {
+    /*
+     * The channels are independent, and the responder's ordinary pages
+     * (oncall_high) matter even if the critical one could not be created.
+     * Aborting the loop would take out every channel after the first failure.
+     */
+    setPlatform("android");
+
+    channelSpy.mockRejectedValueOnce(new Error("channel refused") as never);
+
+    await setupNotificationChannels();
+
+    expect(createdChannelIds(channelSpy)).toEqual([
+      "oncall_critical",
+      "oncall_high",
+      "oncall_normal",
+      "oncall_low",
+    ]);
+  });
+
+  test("a failing channel does not throw out of setup", async () => {
+    /*
+     * This runs from a useEffect on app launch. An unhandled rejection there
+     * is an app-wide crash on start.
+     */
+    setPlatform("android");
+
+    channelSpy.mockRejectedValue(new Error("channels unavailable") as never);
+
+    await expect(setupNotificationChannels()).resolves.toBeUndefined();
+  });
+
+  test("is safe to run again on every launch", async () => {
+    setPlatform("android");
+
+    await setupNotificationChannels();
+    await setupNotificationChannels();
+
+    expect(channelSpy).toHaveBeenCalledTimes(8);
+  });
+});

--- a/MobileApp/src/notifications/setup.ts
+++ b/MobileApp/src/notifications/setup.ts
@@ -4,6 +4,7 @@ import * as Device from "expo-device";
 import Constants from "expo-constants";
 import { Platform } from "react-native";
 import { PermissionStatus } from "expo-modules-core";
+import { NOTIFICATION_CHANNELS } from "./channels";
 import logger from "../utils/logger";
 
 // Show notifications when app is in foreground
@@ -24,31 +25,23 @@ export async function setupNotificationChannels(): Promise<void> {
     return;
   }
 
-  await Notifications.setNotificationChannelAsync("oncall_critical", {
-    name: "Critical Alerts",
-    importance: Notifications.AndroidImportance.MAX,
-    sound: "default",
-    vibrationPattern: [0, 500, 250, 500],
-    lockscreenVisibility: Notifications.AndroidNotificationVisibility.PUBLIC,
-  });
-
-  await Notifications.setNotificationChannelAsync("oncall_high", {
-    name: "High Priority",
-    importance: Notifications.AndroidImportance.HIGH,
-    sound: "default",
-    vibrationPattern: [0, 250, 250, 250],
-  });
-
-  await Notifications.setNotificationChannelAsync("oncall_normal", {
-    name: "Normal Priority",
-    importance: Notifications.AndroidImportance.DEFAULT,
-    sound: "default",
-  });
-
-  await Notifications.setNotificationChannelAsync("oncall_low", {
-    name: "Low Priority",
-    importance: Notifications.AndroidImportance.LOW,
-  });
+  /*
+   * Created on every launch, not only the first. Android treats this as a
+   * no-op for a channel that already exists, and a responder who cleared the
+   * app's data or restored to a new phone otherwise ends up with the server
+   * naming channels that are not there - which does not error, it just
+   * delivers the page with default settings.
+   */
+  for (const { id, channel } of NOTIFICATION_CHANNELS) {
+    try {
+      await Notifications.setNotificationChannelAsync(id, channel);
+    } catch (error: unknown) {
+      logger.error(
+        `[PushNotifications] Failed to create notification channel ${id}:`,
+        error,
+      );
+    }
+  }
 }
 
 export async function setupNotificationCategories(): Promise<void> {

--- a/MobileApp/src/screens/SettingsScreen.tsx
+++ b/MobileApp/src/screens/SettingsScreen.tsx
@@ -7,6 +7,10 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useTheme } from "../theme";
 import { useAuth } from "../hooks/useAuth";
 import { useBiometric } from "../hooks/useBiometric";
+import {
+  useCriticalAlerts,
+  type CriticalAlertsState,
+} from "../hooks/useCriticalAlerts";
 import { useHaptics } from "../hooks/useHaptics";
 import { getServerUrl } from "../storage/serverUrl";
 import Logo from "../components/Logo";
@@ -154,6 +158,7 @@ export default function SettingsScreen(): React.JSX.Element {
   const navigation: SettingsNavigationProp =
     useNavigation<SettingsNavigationProp>();
   const biometric: ReturnType<typeof useBiometric> = useBiometric();
+  const criticalAlerts: CriticalAlertsState = useCriticalAlerts();
   const { selectionFeedback } = useHaptics();
   const [serverUrl, setServerUrlState] = useState("");
 
@@ -165,6 +170,15 @@ export default function SettingsScreen(): React.JSX.Element {
     value: boolean,
   ): Promise<void> => {
     await biometric.setEnabled(value);
+    if (value) {
+      selectionFeedback();
+    }
+  };
+
+  const handleCriticalAlertsToggle: (value: boolean) => Promise<void> = async (
+    value: boolean,
+  ): Promise<void> => {
+    await criticalAlerts.setEnabled(value);
     if (value) {
       selectionFeedback();
     }
@@ -318,6 +332,96 @@ export default function SettingsScreen(): React.JSX.Element {
           </Text>
         </View>
       </View>
+
+      {/* Notifications */}
+      {criticalAlerts.isSupported ? (
+        <View style={{ marginBottom: 24 }}>
+          <Text
+            style={{
+              fontSize: 12,
+              fontWeight: "600",
+              textTransform: "uppercase",
+              marginBottom: 8,
+              marginLeft: 4,
+              color: theme.colors.textTertiary,
+              letterSpacing: 0.8,
+            }}
+          >
+            Notifications
+          </Text>
+          <View
+            style={{
+              borderRadius: 16,
+              overflow: "hidden",
+              backgroundColor: theme.colors.backgroundElevated,
+              borderWidth: 1,
+              borderColor: theme.colors.borderGlass,
+            }}
+          >
+            <SettingsRow
+              label="Critical On-Call Alerts"
+              iconName="notifications-outline"
+              isLast
+              rightElement={
+                <Switch
+                  value={criticalAlerts.isEnabled}
+                  onValueChange={handleCriticalAlertsToggle}
+                  disabled={criticalAlerts.isBusy}
+                  trackColor={{
+                    false: theme.colors.backgroundTertiary,
+                    true: theme.colors.actionPrimary,
+                  }}
+                  thumbColor="#FFFFFF"
+                />
+              }
+            />
+          </View>
+          <Text
+            style={{
+              fontSize: 12,
+              marginTop: 6,
+              marginLeft: 4,
+              lineHeight: 16,
+              color: theme.colors.textTertiary,
+            }}
+          >
+            Play a sound for on-call pages even when this device is silenced or
+            in Do Not Disturb. Only urgent on-call notifications override silent
+            mode.
+          </Text>
+          {/*
+            The error is the actionable half of this setting: on Android it is
+            what tells a responder they still have to grant Do Not Disturb
+            access before the switch will stay on, and on iOS which Settings
+            screen to visit.
+          */}
+          {criticalAlerts.error ? (
+            <Text
+              style={{
+                fontSize: 12,
+                marginTop: 6,
+                marginLeft: 4,
+                lineHeight: 16,
+                color: theme.colors.statusError,
+              }}
+            >
+              {criticalAlerts.error}
+            </Text>
+          ) : criticalAlerts.isEnabled && criticalAlerts.statusMessage ? (
+            <Text
+              style={{
+                fontSize: 12,
+                marginTop: 6,
+                marginLeft: 4,
+                lineHeight: 16,
+                color: theme.colors.statusSuccess,
+              }}
+            >
+              {criticalAlerts.statusMessage}
+            </Text>
+          ) : null}
+        </View>
+      ) : null}
 
       {/* Security */}
       {biometric.isAvailable ? (

--- a/MobileApp/src/screens/SettingsScreenCriticalAlerts.test.tsx
+++ b/MobileApp/src/screens/SettingsScreenCriticalAlerts.test.tsx
@@ -1,0 +1,265 @@
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react-native";
+import SettingsScreen from "./SettingsScreen";
+import type { CriticalAlertsState } from "../hooks/useCriticalAlerts";
+import { describe, expect, test, beforeEach } from "@jest/globals";
+
+/*
+ * The settings screen is where a responder decides to be woken. Two things
+ * about it are worth a test rather than a glance:
+ *
+ *   - the switch must not be OFFERED where the OS cannot honour it. A toggle
+ *     that flips and does nothing is worse than no toggle, because the
+ *     responder walks away believing they are covered.
+ *   - the error text must be SHOWN. On Android it is not a failure message at
+ *     all - it is the instruction that tells the responder they still have to
+ *     grant Do Not Disturb access. Hiding it strands them on a switch that
+ *     will not stay on with no explanation anywhere.
+ *
+ * The hook itself is covered in useCriticalAlerts.test.tsx; here it is a
+ * stand-in whose state each test sets, so the screen's rendering decisions can
+ * be driven directly. The `mock` prefix is what lets jest.mock's factory reach
+ * it despite hoisting.
+ */
+
+const mockCriticalAlertsState: { current: CriticalAlertsState } = {
+  current: {} as CriticalAlertsState,
+};
+
+jest.mock("../hooks/useCriticalAlerts", () => {
+  return {
+    useCriticalAlerts: () => {
+      return mockCriticalAlertsState.current;
+    },
+  };
+});
+
+jest.mock("../hooks/useAuth", () => {
+  return {
+    useAuth: () => {
+      return { logout: jest.fn() };
+    },
+  };
+});
+
+jest.mock("../hooks/useBiometric", () => {
+  return {
+    useBiometric: () => {
+      return {
+        isAvailable: false,
+        isEnabled: false,
+        biometricType: "Biometrics",
+        authenticate: jest.fn(),
+        setEnabled: jest.fn(),
+      };
+    },
+  };
+});
+
+jest.mock("../hooks/useHaptics", () => {
+  return {
+    useHaptics: () => {
+      return {
+        successFeedback: jest.fn(),
+        errorFeedback: jest.fn(),
+        lightImpact: jest.fn(),
+        mediumImpact: jest.fn(),
+        selectionFeedback: jest.fn(),
+      };
+    },
+  };
+});
+
+jest.mock("../storage/serverUrl", () => {
+  return {
+    getServerUrl: async () => {
+      return "https://oneuptime.com";
+    },
+  };
+});
+
+jest.mock("@react-navigation/native", () => {
+  return {
+    useNavigation: () => {
+      return { navigate: jest.fn() };
+    },
+  };
+});
+
+function stateWith(
+  overrides: Partial<CriticalAlertsState> = {},
+): CriticalAlertsState {
+  return {
+    isSupported: true,
+    isPermissionGranted: true,
+    isEnabled: false,
+    isBusy: false,
+    error: "",
+    statusMessage: "On-call pages will play a sound even when silenced.",
+    setEnabled: jest.fn(async () => {
+      return undefined;
+    }) as unknown as (enabled: boolean) => Promise<void>,
+    refresh: jest.fn(async () => {
+      return undefined;
+    }) as unknown as () => Promise<void>,
+    ...overrides,
+  };
+}
+
+describe("The critical alerts setting is offered where it can work", () => {
+  beforeEach(() => {
+    mockCriticalAlertsState.current = stateWith();
+  });
+
+  test("the row is shown on a supported device", async () => {
+    await render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Critical On-Call Alerts")).toBeTruthy();
+    });
+  });
+
+  test("it explains that only on-call pages override silent mode", async () => {
+    /*
+     * The scope matters. A responder who thinks every OneUptime notification
+     * will now ring through Do Not Disturb turns the whole app's notifications
+     * off instead.
+     */
+    await render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Only urgent on-call notifications override/i),
+      ).toBeTruthy();
+    });
+  });
+
+  test("the row sits under a Notifications heading", async () => {
+    await render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Notifications")).toBeTruthy();
+    });
+  });
+});
+
+describe("The setting is hidden where the OS cannot honour it", () => {
+  beforeEach(() => {
+    mockCriticalAlertsState.current = stateWith({ isSupported: false });
+  });
+
+  test("no row is rendered on an unsupported device", async () => {
+    await render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Critical On-Call Alerts")).toBeNull();
+    });
+  });
+
+  test("the Notifications section disappears with it", async () => {
+    await render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Notifications")).toBeNull();
+    });
+  });
+});
+
+describe("What the responder is told", () => {
+  test("an error is shown verbatim, because it is the instruction", async () => {
+    mockCriticalAlertsState.current = stateWith({
+      error:
+        "Android has not granted Do Not Disturb access to this app. Allow it in Settings.",
+    });
+
+    await render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Do Not Disturb access to this app/i),
+      ).toBeTruthy();
+    });
+  });
+
+  test("the confirmation is shown once the setting is actually on", async () => {
+    mockCriticalAlertsState.current = stateWith({
+      isEnabled: true,
+      statusMessage: "On-call pages will play a sound even when silenced.",
+    });
+
+    await render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/play a sound even when silenced/i)).toBeTruthy();
+    });
+  });
+
+  test("no confirmation is shown while the setting is off", async () => {
+    mockCriticalAlertsState.current = stateWith({
+      isEnabled: false,
+      statusMessage: "On-call pages will play a sound even when silenced.",
+    });
+
+    await render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/play a sound even when silenced/i)).toBeNull();
+    });
+  });
+
+  test("an error takes precedence over the confirmation", async () => {
+    mockCriticalAlertsState.current = stateWith({
+      isEnabled: true,
+      error: "Could not save this setting.",
+      statusMessage: "On-call pages will play a sound even when silenced.",
+    });
+
+    await render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Could not save this setting.")).toBeTruthy();
+      expect(screen.queryByText(/play a sound even when silenced/i)).toBeNull();
+    });
+  });
+});
+
+describe("Toggling the switch", () => {
+  test("asks the hook to turn the setting on", async () => {
+    const setEnabled: jest.Mock = jest.fn(async () => {
+      return undefined;
+    });
+
+    mockCriticalAlertsState.current = stateWith({
+      setEnabled: setEnabled as unknown as (enabled: boolean) => Promise<void>,
+    });
+
+    await render(<SettingsScreen />);
+
+    const toggle: unknown = await waitFor(() => {
+      return screen.getByRole("switch");
+    });
+
+    fireEvent(toggle as never, "valueChange", true);
+
+    await waitFor(() => {
+      expect(setEnabled).toHaveBeenCalledWith(true);
+    });
+  });
+
+  test("the switch is disabled while a change is in flight", async () => {
+    mockCriticalAlertsState.current = stateWith({ isBusy: true });
+
+    await render(<SettingsScreen />);
+
+    const toggle: { props: { disabled?: boolean } } = (await waitFor(() => {
+      return screen.getByRole("switch");
+    })) as unknown as { props: { disabled?: boolean } };
+
+    expect(toggle.props.disabled).toBe(true);
+  });
+});

--- a/MobileApp/src/storage/preferences.test.ts
+++ b/MobileApp/src/storage/preferences.test.ts
@@ -1,0 +1,70 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  getBiometricEnabled,
+  getCriticalAlertsEnabled,
+  setBiometricEnabled,
+  setCriticalAlertsEnabled,
+} from "./preferences";
+import { describe, expect, test, beforeEach } from "@jest/globals";
+
+/*
+ * The stored copy of the responder's choice. It is not the authority - the
+ * server decides whether a page goes out critical - but it is what the app
+ * replays on re-registration, so "absent means off" has to hold exactly.
+ */
+
+describe("getCriticalAlertsEnabled", () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  test("a device that has never been asked has not opted in", async () => {
+    expect(await getCriticalAlertsEnabled()).toBe(false);
+  });
+
+  test("round-trips an opt-in", async () => {
+    await setCriticalAlertsEnabled(true);
+
+    expect(await getCriticalAlertsEnabled()).toBe(true);
+  });
+
+  test("round-trips an opt-out", async () => {
+    await setCriticalAlertsEnabled(true);
+    await setCriticalAlertsEnabled(false);
+
+    expect(await getCriticalAlertsEnabled()).toBe(false);
+  });
+
+  test('only the exact string "true" counts as opted in', async () => {
+    /*
+     * Anything else in that slot - a half-written value, a key another build
+     * used differently - resolves to off rather than to "loud".
+     */
+    await AsyncStorage.setItem("oneuptime_critical_alerts_enabled", "yes");
+
+    expect(await getCriticalAlertsEnabled()).toBe(false);
+  });
+
+  test("stores under its own key, distinct from the biometric preference", async () => {
+    await setCriticalAlertsEnabled(true);
+
+    expect(
+      await AsyncStorage.getItem("oneuptime_critical_alerts_enabled"),
+    ).toBe("true");
+  });
+
+  test("does not disturb the biometric preference", async () => {
+    await setBiometricEnabled(true);
+    await setCriticalAlertsEnabled(false);
+
+    expect(await getBiometricEnabled()).toBe(true);
+    expect(await getCriticalAlertsEnabled()).toBe(false);
+  });
+
+  test("the biometric preference does not disturb this one", async () => {
+    await setCriticalAlertsEnabled(true);
+    await setBiometricEnabled(false);
+
+    expect(await getCriticalAlertsEnabled()).toBe(true);
+  });
+});

--- a/MobileApp/src/storage/preferences.ts
+++ b/MobileApp/src/storage/preferences.ts
@@ -2,8 +2,10 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const KEYS: {
   readonly BIOMETRIC_ENABLED: "oneuptime_biometric_enabled";
+  readonly CRITICAL_ALERTS_ENABLED: "oneuptime_critical_alerts_enabled";
 } = {
   BIOMETRIC_ENABLED: "oneuptime_biometric_enabled",
+  CRITICAL_ALERTS_ENABLED: "oneuptime_critical_alerts_enabled",
 } as const;
 
 export async function getBiometricEnabled(): Promise<boolean> {
@@ -15,4 +17,26 @@ export async function getBiometricEnabled(): Promise<boolean> {
 
 export async function setBiometricEnabled(enabled: boolean): Promise<void> {
   await AsyncStorage.setItem(KEYS.BIOMETRIC_ENABLED, String(enabled));
+}
+
+/*
+ * The server is the authority on whether a page goes out as a critical alert -
+ * it is what stamps the flag onto the payload. This local copy exists so the
+ * toggle can be rendered before the network answers, and so re-registration
+ * (a new push token, a project the responder just joined) can restate the
+ * choice instead of silently dropping back to off.
+ *
+ * Absent means off. A device that has never been asked has not opted in.
+ */
+export async function getCriticalAlertsEnabled(): Promise<boolean> {
+  const stored: string | null = await AsyncStorage.getItem(
+    KEYS.CRITICAL_ALERTS_ENABLED,
+  );
+  return stored === "true";
+}
+
+export async function setCriticalAlertsEnabled(
+  enabled: boolean,
+): Promise<void> {
+  await AsyncStorage.setItem(KEYS.CRITICAL_ALERTS_ENABLED, String(enabled));
 }

--- a/MobileApp/tsconfig.json
+++ b/MobileApp/tsconfig.json
@@ -7,6 +7,6 @@
       "@/*": ["src/*"],
       "Common/*": ["../Common/build/dist/*"]
     },
-    "types": ["nativewind/types"]
+    "types": ["nativewind/types", "jest"]
   }
 }


### PR DESCRIPTION
## What this does

The on-call app only ever sent an ordinary push notification, so a responder whose phone was on silent or in Do Not Disturb could sleep through the incident they were paged for.

This adds an opt-in, **per-device** setting — *Settings → Notifications → Critical On-Call Alerts* — that lets **on-call pages only** play a sound through both, on **iOS and Android**.

## How it works

Three things must all agree before a page overrides the ringer. None of them fails loudly on its own, which is why each is checked explicitly:

| | Mechanism |
|---|---|
| **The responder opted this handset in** | `UserPush.isCriticalAlertEnabled`, off by default |
| **The server marks the page** | APNs critical sound + `interruptionLevel: critical` (iOS); the `oncall_critical` channel (Android) |
| **The OS allows it** | Apple's critical-alerts entitlement; Do Not Disturb access on Android |

The scope is deliberately narrow: only the four on-call paging paths in `UserNotificationRuleService` escalate. Owner subscriptions, note-posted notices, state changes and monitor notifications are untouched — nobody gets woken by something that could have waited.

On Android two separate mechanisms cover two different cases: the channel's `bypassDnd` handles Do Not Disturb (needs the user's grant), and the **alarm** audio stream handles a plainly muted phone (needs no permission at all).

## Decisions worth reviewing

- **The iOS entitlement is opt-in, not committed.** Apple grants `com.apple.developer.usernotifications.critical-alerts` per team on request, and a build declaring an entitlement its provisioning profile cannot carry **fails to sign**. Committing it would have broken the iOS build for this repo's release pipeline, every fork and every self-hoster on merge day. It is gated behind `EXPO_IOS_CRITICAL_ALERTS_ENTITLEMENT=true` in a new `app.config.js`. **Until Apple grants the entitlement, iOS critical alerts will not activate** — but the app degrades honestly: iOS declines the permission and the settings screen says which setting is missing rather than showing a switch that does nothing.
- **The app reads the capability back from the OS rather than trusting its own request.** Android stores `bypassDnd` as `false` until the user grants Do Not Disturb access, and iOS grants notification permission while silently withholding critical alerts. A permission revoked months later shows the switch as **off** — the alternative reading is a responder believing they are covered when they are not.
- **The toggle is keyed on the device token**, like `unregister`. One handset owns a `UserPush` row per project; being loud for one project and silent for the next is a distinction no screen offers to make.
- **The relay parses `sound`/`interruptionLevel` instead of forwarding them.** `/push/send` is unauthenticated (IP rate-limited only) and re-sends under the deployment's Expo credentials.
- **`UserPush` keeps its owner-only shape**: the new column grants `update` to nobody, and writes go through a dedicated ownership-checked route, matching `verify`/`unverify`.

## Migration

One additive column, `UserPush.isCriticalAlertEnabled boolean NOT NULL DEFAULT false`. Generated with `npm run generate-postgres-migration` and registered in `SchemaMigrations/Index.ts`. Every existing device is backfilled as **off**.

## Tests

**205 new tests**, all passing.

| Suite | Count | Covers |
|---|---|---|
| `CriticalPushAlertPayload` | 25 | iOS/Android payload mapping; factories never escalate |
| `CriticalOnCallAlertDelivery` | 18 | all four paging paths end to end; unset column = off; unverified device still silent |
| `UserPushCriticalAlertColumn` | 12 | column + migration + access-control contract |
| `UserPushCriticalAlertsApi` | 30 | the two flag parsers (lenient on register, strict on toggle) |
| `UserPushCriticalAlertToggle` | 9 | token-scoped fan-out, owner scoping, web refusal |
| `PushRelayCriticalAlerts` (App) | 42 | relay parsing, clamping and refusals |
| MobileApp (9 suites) | 131 | channel definitions, OS capability detection on both platforms, the settings hook, API client, registration replay, settings screen |

`MobileApp` had no test runner; this adds a `jest-expo` setup, shared native-module mocks, and a `jest` job to the MobileApp CI workflow.

## Verification

- `Common` — `tsc --noEmit` clean; new suites pass
- `App` — relay suite passes
- `MobileApp` — 131 tests pass; `eslint` clean across all changed files

Two things I could not verify locally and that need a real device: that Apple grants the entitlement (out of my hands), and that a physically silenced handset audibly rings. The test-notification endpoint now sends **as a critical alert** when the device has the setting on, precisely so that can be checked by silencing a phone and pressing the button.
