### PR TITLE
fix(chart): split keda.install from keda.enabled so KEDA can bootstrap

### DIFF
--- a/HelmChart/Docs/Keda.md
+++ b/HelmChart/Docs/Keda.md
@@ -1,0 +1,161 @@
+### KEDA Ops
+
+The chart can autoscale its queue-driven tiers with [KEDA](https://keda.sh) instead of a plain `HorizontalPodAutoscaler`, scaling on queue backlog and shed rate rather than on CPU. See "Autoscaling & availability" in [configuration.md](../Public/oneuptime/docs/configuration.md) for the per-tier knobs. This page covers the two flags that decide where KEDA comes from, and the first-install step a cluster with no KEDA needs. Commands below assume the release is named `oneuptime` and installed in the `default` namespace.
+
+### The two flags
+
+| Flag | Decides | Default |
+| --- | --- | --- |
+| `keda.enabled` | Whether the chart renders its own `ScaledObject`s and `TriggerAuthentication`s, and whether the tiers that use them drop their plain `HorizontalPodAutoscaler`. | `false` |
+| `keda.install` | Whether the chart installs the bundled KEDA operator. | unset — tracks `keda.enabled` |
+
+`keda.install` is the first path of the dependency `condition:` in `Chart.yaml`, and Helm takes the first path that holds a boolean. Leaving it out of your values means `keda.enabled` decides both, which is what the chart did before the flags were split, so an existing `keda.enabled: true` keeps behaving exactly as it always has.
+
+Three combinations matter:
+
+- **`keda.enabled: true`** — the chart installs the operator and drives it. Leave `keda.install` unset.
+- **`keda.enabled: true`, `keda.install: false`** — your platform team already runs KEDA; the chart renders only the custom resources. See [Using an externally managed KEDA](#using-an-externally-managed-keda).
+- **`keda.enabled: false`, `keda.install: true`** — the one-time bootstrap pass below.
+
+Per-tier `<service>.keda.enabled` flags are what actually opt a tier into KEDA. Setting one while `keda.enabled` is false is a hard render error, not a silent no-op — except during the bootstrap pass, where rendering nothing is the point.
+
+> **Bundled-operator caveats.** KEDA is cluster-scoped: the subchart installs 6 CRDs, 9 ClusterRoles, a validating webhook and an aggregated APIService that takes over `external.metrics.k8s.io` for the whole cluster, so a wedged metrics-apiserver degrades unrelated workloads. Do **not** enable the bundled operator in more than one OneUptime release in the same cluster, and do not enable it at all on a cluster that already runs KEDA — set `keda.install: false` there instead. Because the CRDs are installed by the chart, `helm uninstall` can remove them and cascade-delete every `ScaledObject` in the cluster.
+
+#### First install with the bundled operator (CRDs must exist first)
+
+The KEDA CRDs ship as **templates** in the bundled subchart, not in a `crds/` directory. Only a `crds/` directory is applied ahead of the rest of the release; templates are part of the ordinary manifest, which Helm resolves against the API server **before** applying anything. So on a cluster that does not yet have KEDA, the very first `helm install`/`helm upgrade` with `keda.enabled: true` and any `<service>.keda.enabled: true` aborts with:
+
+```
+Error: ... resource mapping not found for name: "oneuptime-worker-scaledobject" ...
+no matches for kind "ScaledObject" in version "keda.sh/v1alpha1"
+ensure CRDs are installed first
+```
+
+Nothing is applied (not even the CRDs), so re-running Helm alone does **not** help. `--disable-openapi-validation` does not fix it either (the failure is a resource-mapping check, not schema validation). Neither does `helm template`, which cannot reproduce the failure at all — it never contacts an API server, so it renders this manifest perfectly cleanly. Use `helm install --dry-run` against the real cluster if you want to see it before you hit it.
+
+Run one bootstrap pass that installs the operator and its CRDs and renders no custom resources. They are cluster-scoped, so this is a one-time step per cluster:
+
+```bash
+# 1) Operator and CRDs only. Your normal values file, with the two flags flipped.
+helm upgrade --install oneuptime oneuptime/oneuptime \
+  --namespace default -f values.yaml \
+  --set keda.install=true --set keda.enabled=false
+
+# 2) Now the normal install/upgrade succeeds, and every one after it.
+helm upgrade --install oneuptime oneuptime/oneuptime \
+  --namespace default -f values.yaml
+```
+
+Step 1 brings the tiers up without KEDA, so they sit at their fixed `replicaCount` — or on a plain `HorizontalPodAutoscaler` if you have set `autoscaling.enabled: true`, which ships `false`. Step 2 hands them to KEDA. On a first install nothing is serving yet, so that interval costs nothing; on an existing release, read [Turning KEDA back off](#turning-keda-back-off) before you run step 1, because it is the same transition. Keep `keda.install` out of your values file afterwards — with it unset, `keda.enabled: true` keeps the operator installed on its own.
+
+If you would rather not run the chart twice, install the CRDs yourself before the first Helm run and leave the chart to adopt them:
+
+```bash
+helm template oneuptime oneuptime/oneuptime --set keda.install=true \
+  -s charts/keda/templates/crds/crd-scaledobjects.yaml \
+  -s charts/keda/templates/crds/crd-triggerauthentications.yaml \
+  -s charts/keda/templates/crds/crd-scaledjobs.yaml \
+  -s charts/keda/templates/crds/crd-cloudeventsources.yaml \
+  -s charts/keda/templates/crds/crd-clustercloudeventsources.yaml \
+  -s charts/keda/templates/crds/crd-clustertriggerauthentications.yaml \
+| kubectl apply --server-side -f -
+
+# Hand them to Helm so the install can adopt them (keda.crds.install stays true).
+for c in $(kubectl get crd -o name | grep '\.keda\.sh$' | sed 's#.*/##'); do
+  kubectl label  crd "$c" app.kubernetes.io/managed-by=Helm --overwrite
+  kubectl annotate crd "$c" \
+    meta.helm.sh/release-name=oneuptime \
+    meta.helm.sh/release-namespace=default --overwrite
+done
+```
+
+The labelling step is only needed if you keep the default `keda.crds.install: true` (Helm then manages CRD upgrades for you). Alternatively set `keda.crds.install: false` so Helm never templates or owns the CRDs — then skip it, but you must apply CRD upgrades out of band yourself on every KEDA version bump.
+
+### Using an externally managed KEDA
+
+On a shared or regulated cluster, KEDA is usually installed once by a platform team from its own Helm release. Enabling the bundled operator on top of that collides on every cluster-scoped object it wants to own:
+
+```
+Error: ... ClusterRole "keda-operator" in namespace "" exists and cannot be imported
+into the current release: invalid ownership metadata; annotation
+"meta.helm.sh/release-name" must equal "oneuptime": current value is "keda"
+```
+
+Set `keda.install: false` and the chart renders only the custom resources, against CRDs it does not own:
+
+```yaml
+keda:
+  enabled: true
+  install: false
+
+worker:
+  enabled: true
+  keda:
+    enabled: true
+```
+
+This needs no bootstrap pass — the CRDs already exist, so the very first install resolves and applies in one go. The `ScaledObject`s the chart renders are plain custom resources with no dependency on anything the bundled subchart provides, so any KEDA that watches their namespace reconciles them. Check that the platform team's KEDA is not namespace-scoped to somewhere else:
+
+```bash
+kubectl -n <keda-namespace> get deploy keda-operator \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="WATCH_NAMESPACE")].value}'
+```
+
+An empty value means it watches the whole cluster, which is what you want. A different namespace means your `ScaledObject`s will be created and then ignored — the tier will sit at `minReplicaCount` with no error anywhere.
+
+#### Handing an already-bundled KEDA over to a platform-managed one
+
+> **Do not simply flip `keda.install` to `false` on a release that installed the operator itself.** The 6 KEDA CRDs are templates of that release, so dropping the subchart drops them from the manifest and `helm upgrade` deletes them — and deleting a CRD cascade-deletes every custom resource of it in the cluster, including the `ScaledObject`s the same upgrade is rendering. Unlike the CloudNativePG CRDs, KEDA's carry no `helm.sh/resource-policy: keep`, so nothing stops this.
+
+Annotate the CRDs first, and leave `keda.enabled` alone. Then the operator leaves and the `ScaledObject`s stay exactly where they are — no tier is reconfigured at any point:
+
+```bash
+# 1) Protect the CRDs from the upgrade below. Nothing is disrupted by this.
+for c in $(kubectl get crd -o name | grep '\.keda\.sh$' | sed 's#.*/##'); do
+  kubectl annotate crd "$c" helm.sh/resource-policy=keep --overwrite
+done
+
+# 2) Drop the bundled operator, keeping keda.enabled: true. The CRDs survive on
+#    step 1's annotation and the ScaledObjects keep rendering, so the Deployments
+#    are not touched and the HPAs KEDA created stay in place.
+helm upgrade oneuptime oneuptime/oneuptime --namespace default -f values.yaml \
+  --set keda.install=false
+```
+
+Have the platform team install their KEDA now, then add `keda.install: false` to your values file permanently so you stop passing `--set`. Their release will need to take ownership of the CRDs — `helm install --take-ownership` (Helm 3.17+), or re-point the `meta.helm.sh/release-name` and `-namespace` annotations at their release the way the bootstrap section above does.
+
+Between step 2 and their KEDA coming up, nothing reconciles the `ScaledObject`s. Replica counts simply hold where they are, so the gap is safe to leave open for as long as it takes — but the tiers are not scaling during it.
+
+Do **not** route this through `keda.enabled: false`. That deletes the `ScaledObject`s, and with them the replica counts KEDA was holding (see below), and the render is refused anyway while any `<service>.keda.enabled` is still true.
+
+### Check what is actually scaling
+
+```bash
+kubectl get scaledobjects --namespace default
+kubectl describe scaledobject --namespace default oneuptime-worker-scaledobject
+```
+
+`READY=True` is the one to look at: it means KEDA resolved the target Deployment and can read the trigger. `ACTIVE` is not a health signal — it reports whether the trigger currently sees work, so a healthy tier with an empty queue sits at `READY=True`, `ACTIVE=False`. KEDA creates its own HPA per `ScaledObject`, named `keda-hpa-<scaledobject>`:
+
+```bash
+kubectl get hpa --namespace default
+```
+
+If `READY` is `False`, the usual cause is that KEDA cannot reach the tier's metrics endpoint. The triggers are plain HTTP against the in-cluster service, so curl the same URL from any pod:
+
+```bash
+kubectl run -n default curl-test --rm -it --image=curlimages/curl --restart=Never -- \
+  curl -s http://oneuptime-worker:3002/metrics/queue-size
+```
+
+Set `<service>.keda.fallback.replicas` so a tier holds a sane replica count when that endpoint is unreadable, rather than collapsing to `minReplicaCount`.
+
+### Turning KEDA back off
+
+Set `keda.enabled: false` and every per-service `<service>.keda.enabled: false` in the same `helm upgrade`. Leaving a per-service flag on is refused rather than silently applied — with the global flag off it would render no `ScaledObject` at all, and it would uninstall the operator out from under the ones already running.
+
+> **This is a scale-down, not a hand-off to another autoscaler.** While KEDA drives a tier, the chart omits `replicas` from its Deployment and lets the `ScaledObject` hold the count. Turning KEDA off puts `replicas: <replicaCount>` back — default `1` — and creates no `HorizontalPodAutoscaler` at all, because `autoscaling.enabled` ships `false`. A worker fleet KEDA had taken to 6 pods drops to 1 on that upgrade, with nothing to scale it back out.
+>
+> Set `autoscaling.enabled: true` (with `resources.requests.cpu` on the tiers, and `minReplicas` at least where KEDA had them) in the **same** upgrade if you want the tiers to keep autoscaling on CPU/memory. Even then the Deployment carries `replicas: 1` for the moment it takes the new HPA to observe the tier and scale it back up.
+
+To scale one tier manually while you work on it, use `<service>.disableAutoscaler: true` rather than `kubectl scale` — KEDA's `minReplicaCount` would revert a manual scale. It applies to `app`, `worker`, `runner` and each probe; `telemetryWriter` is opt-in only and the schema has no such key for it, so turn `telemetryWriter.keda.enabled` off instead.

--- a/HelmChart/Public/oneuptime/Chart.yaml
+++ b/HelmChart/Public/oneuptime/Chart.yaml
@@ -65,7 +65,12 @@ dependencies:
 - name: keda
   version: "2.20.1"
   repository: "https://kedacore.github.io/charts"
-  condition: keda.enabled
+  # Two paths, tried in order, first one that holds a bool wins: `keda.install`
+  # decides on its own when it is set, and falls through to `keda.enabled` when
+  # it is not (values.yaml deliberately leaves it unset). That is what lets a
+  # cluster that already runs KEDA render this chart's ScaledObjects without
+  # installing a second operator — see the keda block in values.yaml.
+  condition: keda.install,keda.enabled
 - name: cloudnative-pg
   version: "0.28.2"
   repository: "https://cloudnative-pg.github.io/charts"

--- a/HelmChart/Public/oneuptime/docs/configuration.md
+++ b/HelmChart/Public/oneuptime/docs/configuration.md
@@ -114,6 +114,8 @@ externalSecrets:
 | Parameter                                       | Description                                                                                   | Default |
 |-------------------------------------------------|-----------------------------------------------------------------------------------------------|---------|
 | `deployment.replicaCount`                       | Number of replicas.                                                                            | `1`     |
+| `keda.enabled`                                  | Render the chart's KEDA `ScaledObject`s, so the opted-in tiers scale on queue backlog instead of a plain HorizontalPodAutoscaler. Opt a tier in with `<service>.keda.enabled`. | `false` |
+| `keda.install`                                  | Install the bundled KEDA operator. Unset by default, which makes it follow `keda.enabled`; set it to `false` to use a KEDA your platform team already runs. See [KEDA Ops](https://github.com/OneUptime/oneuptime/blob/master/HelmChart/Docs/Keda.md). | unset |
 | `autoscaling.enabled`                           | Enable autoscaling.                                                                            | `false` |
 | `autoscaling.minReplicas`                       | Minimum number of replicas.                                                                    | `1`     |
 | `autoscaling.maxReplicas`                       | Maximum number of replicas.                                                                    | `100`   |

--- a/HelmChart/Public/oneuptime/docs/installation.md
+++ b/HelmChart/Public/oneuptime/docs/installation.md
@@ -10,6 +10,13 @@ How to install, upgrade, and uninstall the OneUptime Helm chart.
 - [Helm 3](../../../Docs/Helm.md) installed.
 - A hostname or IP address where OneUptime will be reachable.
 
+If you plan to turn on KEDA autoscaling (`keda.enabled: true`) on a cluster that
+has never had KEDA, read [KEDA Ops](https://github.com/OneUptime/oneuptime/blob/master/HelmChart/Docs/Keda.md)
+first — the bundled operator's CRDs have to reach the cluster before the chart's
+`ScaledObject`s can, so the very first install takes one extra pass. Otherwise it
+aborts with `no matches for kind "ScaledObject" in version "keda.sh/v1alpha1"`.
+Autoscaling is off by default, so this does not apply to a stock install.
+
 ## 1. Create a `values.yaml`
 
 Create a `values.yaml` file and set your host:

--- a/HelmChart/Public/oneuptime/docs/production-checklist.md
+++ b/HelmChart/Public/oneuptime/docs/production-checklist.md
@@ -65,6 +65,16 @@ Work through this list to make your OneUptime installation production-ready.
   `app.keda.targetCPUUtilizationPercentage` (with `app.resources.requests.cpu`)
   so the API tier still autoscales once its queue-size trigger is disabled.
 
+- [ ] **Decide where KEDA comes from before the first install.** `keda.enabled`
+  renders the chart's `ScaledObject`s; `keda.install` decides whether the chart
+  also installs the operator, and follows `keda.enabled` unless you set it. On a
+  cluster where a platform team already runs KEDA, set `keda.install: false` —
+  installing a second operator collides on cluster-scoped objects the existing
+  release owns. On a cluster with no KEDA, the first install needs one extra
+  bootstrap pass, because the bundled operator's CRDs have to reach the cluster
+  before the `ScaledObject`s can. Both paths are in
+  [KEDA Ops](https://github.com/OneUptime/oneuptime/blob/master/HelmChart/Docs/Keda.md).
+
 - [ ] **Size ClickHouse insert concurrency when scaling telemetry ingest
   workers.** Every telemetry-ingesting pod runs a fan-in writer that batches
   all telemetry ClickHouse inserts into a handful of large INSERTs, so worker

--- a/HelmChart/Public/oneuptime/docs/upgrade-notes.md
+++ b/HelmChart/Public/oneuptime/docs/upgrade-notes.md
@@ -37,6 +37,6 @@ configuration options.
 
 | Chart                          | Description                                                                                 | Repository |
 |--------------------------------|---------------------------------------------------------------------------------------------|------------|
-| `keda`                         | Kubernetes Event-driven Autoscaling.                                                        | https://kedacore.github.io/charts |
+| `keda`                         | Kubernetes Event-driven Autoscaling — installed only when `keda.install` (or, unset, `keda.enabled`) is `true`. | https://kedacore.github.io/charts |
 | `cloudnative-pg`               | CloudNativePG operator — installed only when `postgresOperator.cnpg.enabled` is `true`.     | https://cloudnative-pg.github.io/charts |
 | `altinity-clickhouse-operator` | Altinity ClickHouse operator — installed only when `clickhouseOperator.altinity.enabled` is `true`. | https://helm.altinity.com/ |

--- a/HelmChart/Public/oneuptime/templates/NOTES.txt
+++ b/HelmChart/Public/oneuptime/templates/NOTES.txt
@@ -9,6 +9,17 @@ One all the pods are running. You can check the service status to see if the IP 
 kubectl get svc --namespace={{ $.Release.Namespace }} {{ $.Release.Name }}-nginx 
 
 You should then be able to access OneUptime cluster with that IP. Please make sure your host matches the host set in values.yaml which currently is {{ .Values.host }}. If you would like to change this host to another value, please do a helm upgrade.
+{{- if and (include "oneuptime.kedaOperatorInstalled" .) (not .Values.keda.enabled) }}
+
+The bundled KEDA operator is installed, but this release renders no ScaledObject
+(keda.enabled is false). If you ran this as the one-time bootstrap pass, the KEDA
+CRDs now exist on the cluster — run the install again with your normal values to
+render the ScaledObjects:
+
+helm upgrade --install {{ .Release.Name }} oneuptime/oneuptime --namespace={{ .Release.Namespace }} -f values.yaml
+
+Details: HelmChart/Docs/Keda.md
+{{- end }}
 {{- if .Values.vllm.enabled }}
 
 vLLM (local LLM server) is enabled. Its OpenAI-compatible endpoint inside the cluster is:

--- a/HelmChart/Public/oneuptime/templates/_helpers.tpl
+++ b/HelmChart/Public/oneuptime/templates/_helpers.tpl
@@ -1222,6 +1222,33 @@ spec:
 
 
 {{/*
+Whether THIS release installs the bundled KEDA operator subchart. Returns the
+string "true" or "" so it composes with `if`/`eq`.
+
+This must agree with the `condition: keda.install,keda.enabled` on the keda
+dependency in Chart.yaml, because Helm evaluates that condition itself and the
+templates never see the result. Helm walks the comma-separated paths in order and
+takes the FIRST one that resolves to an actual bool — a path that is absent, null
+or a quoted string is skipped (with a warning, in the non-absent cases) and the
+next path is tried. `kindIs "bool"` reproduces that test exactly; anything looser
+(hasKey, a plain truthiness check, `default`) would disagree with Helm on a
+`--set-string keda.install=true`, and the guard that reads this would then talk
+about an operator that is not there, or stay silent about one that is. (`install:
+~` cannot get this far — values.schema.json pins install to boolean — but the
+test costs nothing and keeps this honest if that ever loosens.)
+
+Usage: include "oneuptime.kedaOperatorInstalled" .   ($ or any ctx with .Values)
+*/}}
+{{- define "oneuptime.kedaOperatorInstalled" -}}
+{{- $install := .Values.keda.enabled -}}
+{{- if kindIs "bool" .Values.keda.install -}}
+{{- $install = .Values.keda.install -}}
+{{- end -}}
+{{- if $install }}true{{ end -}}
+{{- end }}
+
+
+{{/*
 KEDA ScaledObject template for metric-based autoscaling
 Usage: include "oneuptime.kedaScaledObject" (dict "ServiceName" "service-name" "Release" .Release "Values" .Values "MetricsConfig" {...})
 

--- a/HelmChart/Public/oneuptime/templates/keda-scaledobjects.yaml
+++ b/HelmChart/Public/oneuptime/templates/keda-scaledobjects.yaml
@@ -2,14 +2,26 @@
 KEDA ScaledObjects for various services
 */}}
 
-{{/* Guard: the global keda.enabled flag gates BOTH the bundled KEDA operator
-     subchart (`condition: keda.enabled` in Chart.yaml) and every ScaledObject
-     below, and it ships false. A per-service keda.enabled that is true while
-     the global flag is false is therefore a silent no-op on a fresh install —
-     no ScaledObject is rendered at all — and worse on an upgrade from a release
-     that had the global flag on: the operator is uninstalled while the
-     ScaledObjects it was reconciling are left orphaned, which stops autoscaling
-     on a live tier without any error. Fail the render instead.
+{{/* Guard: the global keda.enabled flag gates every ScaledObject below, and it
+     ships false. A per-service keda.enabled that is true while the global flag
+     is false is therefore a silent no-op on a fresh install — no ScaledObject is
+     rendered at all — and worse on an upgrade from a release that had the global
+     flag on: keda.enabled is also the fallback for the operator subchart's
+     dependency condition, so the operator is uninstalled while the ScaledObjects
+     it was reconciling are left orphaned, which stops autoscaling on a live tier
+     without any error. Fail the render instead.
+
+     Exception: `keda.install: true` with keda.enabled false. That is the
+     documented one-time bootstrap pass (HelmChart/Docs/Keda.md) — the bundled
+     subchart ships its CRDs as templates rather than in a crds/ directory, and
+     only a crds/ directory is applied ahead of the rest of the release, so on a
+     cluster with no KEDA the ScaledObject below cannot be mapped and the whole
+     install aborts before anything lands. One pass has to install the operator
+     and render no ScaledObject. Nothing is orphaned on that pass: the operator
+     is installed, not removed, and any live ScaledObject from a previous release
+     is deleted by Helm rather than left behind. It cannot be reached by accident
+     either — install is unset by default and tracks keda.enabled, so it is only
+     true here because someone typed it.
 
      A tier with `disableAutoscaler: true` is NOT an offender: its ScaledObject
      is skipped by the render conditions below even with the global flag on, so
@@ -25,7 +37,7 @@ KEDA ScaledObjects for various services
      without one, so setting it is a schema error, not a silent excuse. If that
      key is ever added to the schema, its render condition below must start
      honouring it too or this loop must stop excusing it. */}}
-{{- if and (not .Values.keda.enabled) (not .Values.deployment.disableDeployments) }}
+{{- if and (not .Values.keda.enabled) (not (include "oneuptime.kedaOperatorInstalled" .)) (not .Values.deployment.disableDeployments) }}
 {{- $orphaned := list }}
 {{- range $key, $val := .Values.probes }}
 {{- if and $val.keda $val.keda.enabled (not $val.disableAutoscaler) }}
@@ -39,7 +51,7 @@ KEDA ScaledObjects for various services
 {{- end }}
 {{- end }}
 {{- if $orphaned }}
-{{- fail (printf "the global keda.enabled is false but these per-service KEDA flags are true: %s. The global flag gates both the bundled KEDA operator (see the dependency condition in Chart.yaml) and every ScaledObject in this chart, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to fall back to the plain HorizontalPodAutoscaler." (join ", " $orphaned)) }}
+{{- fail (printf "the global keda.enabled is false but these per-service KEDA flags are true: %s. The global flag gates every ScaledObject in this chart, and (via the dependency condition in Chart.yaml) the bundled KEDA operator too, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to leave those tiers on `autoscaling` instead — a plain HorizontalPodAutoscaler where you have enabled it, and a fixed replicaCount where you have not. If this is the first install on a cluster that has no KEDA yet, run the bootstrap pass once with --set keda.install=true --set keda.enabled=false and then install again normally — see HelmChart/Docs/Keda.md." (join ", " $orphaned)) }}
 {{- end }}
 {{- end }}
 

--- a/HelmChart/Public/oneuptime/tests/keda-global-default_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/keda-global-default_test.yaml
@@ -14,7 +14,8 @@ tests:
           count: 0
 
   # --- the guard -------------------------------------------------------------
-  # The global flag gates the KEDA operator subchart AND every ScaledObject.
+  # The global flag gates every ScaledObject, and is also the fallback the KEDA
+  # operator subchart's dependency condition lands on when keda.install is unset.
   # Leaving a per-service flag on while the global one is off renders nothing at
   # all, and on an upgrade from a release that had the global flag on it
   # uninstalls the operator out from under ScaledObjects that are already live.
@@ -23,13 +24,17 @@ tests:
   # NOTE: none of these tests set `keda.enabled` -- they inherit it. That is
   # deliberate: it means each one also pins the new shipped default to false. If
   # the global default is ever flipped back to true these all stop failing.
+  # They leave `keda.install` unset too, so the dependency condition falls
+  # through to keda.enabled, which is what makes the operator-uninstall half of
+  # the message true. The bootstrap exemption (install explicitly true) has its
+  # own section at the bottom of this suite.
 
   - it: should fail when app opts in but the global flag is inherited off
     set:
       app.keda.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: app.keda.enabled. The global flag gates both the bundled KEDA operator (see the dependency condition in Chart.yaml) and every ScaledObject in this chart, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to fall back to the plain HorizontalPodAutoscaler.'
+          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: app.keda.enabled. The global flag gates every ScaledObject in this chart, and (via the dependency condition in Chart.yaml) the bundled KEDA operator too, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to leave those tiers on `autoscaling` instead — a plain HorizontalPodAutoscaler where you have enabled it, and a fixed replicaCount where you have not. If this is the first install on a cluster that has no KEDA yet, run the bootstrap pass once with --set keda.install=true --set keda.enabled=false and then install again normally — see HelmChart/Docs/Keda.md.'
 
   - it: should fail when worker opts in but the global flag is inherited off
     set:
@@ -37,7 +42,7 @@ tests:
       worker.keda.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: worker.keda.enabled. The global flag gates both the bundled KEDA operator (see the dependency condition in Chart.yaml) and every ScaledObject in this chart, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to fall back to the plain HorizontalPodAutoscaler.'
+          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: worker.keda.enabled. The global flag gates every ScaledObject in this chart, and (via the dependency condition in Chart.yaml) the bundled KEDA operator too, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to leave those tiers on `autoscaling` instead — a plain HorizontalPodAutoscaler where you have enabled it, and a fixed replicaCount where you have not. If this is the first install on a cluster that has no KEDA yet, run the bootstrap pass once with --set keda.install=true --set keda.enabled=false and then install again normally — see HelmChart/Docs/Keda.md.'
 
   - it: should fail when telemetryWriter opts in but the global flag is inherited off
     set:
@@ -45,21 +50,21 @@ tests:
       telemetryWriter.keda.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: telemetryWriter.keda.enabled. The global flag gates both the bundled KEDA operator (see the dependency condition in Chart.yaml) and every ScaledObject in this chart, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to fall back to the plain HorizontalPodAutoscaler.'
+          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: telemetryWriter.keda.enabled. The global flag gates every ScaledObject in this chart, and (via the dependency condition in Chart.yaml) the bundled KEDA operator too, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to leave those tiers on `autoscaling` instead — a plain HorizontalPodAutoscaler where you have enabled it, and a fixed replicaCount where you have not. If this is the first install on a cluster that has no KEDA yet, run the bootstrap pass once with --set keda.install=true --set keda.enabled=false and then install again normally — see HelmChart/Docs/Keda.md.'
 
   - it: should fail when runner opts in but the global flag is inherited off
     set:
       runner.keda.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: runner.keda.enabled. The global flag gates both the bundled KEDA operator (see the dependency condition in Chart.yaml) and every ScaledObject in this chart, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to fall back to the plain HorizontalPodAutoscaler.'
+          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: runner.keda.enabled. The global flag gates every ScaledObject in this chart, and (via the dependency condition in Chart.yaml) the bundled KEDA operator too, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to leave those tiers on `autoscaling` instead — a plain HorizontalPodAutoscaler where you have enabled it, and a fixed replicaCount where you have not. If this is the first install on a cluster that has no KEDA yet, run the bootstrap pass once with --set keda.install=true --set keda.enabled=false and then install again normally — see HelmChart/Docs/Keda.md.'
 
   - it: should fail when a probe opts in but the global flag is inherited off
     set:
       probes.one.keda.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: probes.one.keda.enabled. The global flag gates both the bundled KEDA operator (see the dependency condition in Chart.yaml) and every ScaledObject in this chart, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to fall back to the plain HorizontalPodAutoscaler.'
+          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: probes.one.keda.enabled. The global flag gates every ScaledObject in this chart, and (via the dependency condition in Chart.yaml) the bundled KEDA operator too, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to leave those tiers on `autoscaling` instead — a plain HorizontalPodAutoscaler where you have enabled it, and a fixed replicaCount where you have not. If this is the first install on a cluster that has no KEDA yet, run the bootstrap pass once with --set keda.install=true --set keda.enabled=false and then install again normally — see HelmChart/Docs/Keda.md.'
 
   # worker.enabled ships false, so this ScaledObject would not render even with
   # the global flag on. The flag is still a lie about what the release does, and
@@ -70,7 +75,7 @@ tests:
       worker.keda.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: worker.keda.enabled. The global flag gates both the bundled KEDA operator (see the dependency condition in Chart.yaml) and every ScaledObject in this chart, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to fall back to the plain HorizontalPodAutoscaler.'
+          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: worker.keda.enabled. The global flag gates every ScaledObject in this chart, and (via the dependency condition in Chart.yaml) the bundled KEDA operator too, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to leave those tiers on `autoscaling` instead — a plain HorizontalPodAutoscaler where you have enabled it, and a fixed replicaCount where you have not. If this is the first install on a cluster that has no KEDA yet, run the bootstrap pass once with --set keda.install=true --set keda.enabled=false and then install again normally — see HelmChart/Docs/Keda.md.'
 
   # One render pass has to report ALL of them, otherwise an operator with several
   # tiers on fixes them one failed upgrade at a time. Order is probes (map order),
@@ -84,7 +89,7 @@ tests:
       runner.keda.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: probes.one.keda.enabled, app.keda.enabled, worker.keda.enabled, telemetryWriter.keda.enabled, runner.keda.enabled. The global flag gates both the bundled KEDA operator (see the dependency condition in Chart.yaml) and every ScaledObject in this chart, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to fall back to the plain HorizontalPodAutoscaler.'
+          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: probes.one.keda.enabled, app.keda.enabled, worker.keda.enabled, telemetryWriter.keda.enabled, runner.keda.enabled. The global flag gates every ScaledObject in this chart, and (via the dependency condition in Chart.yaml) the bundled KEDA operator too, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to leave those tiers on `autoscaling` instead — a plain HorizontalPodAutoscaler where you have enabled it, and a fixed replicaCount where you have not. If this is the first install on a cluster that has no KEDA yet, run the bootstrap pass once with --set keda.install=true --set keda.enabled=false and then install again normally — see HelmChart/Docs/Keda.md.'
 
   # probes.two is created here with no `keda` key. The guard ranges over every probe,
   # so a missing keda block must neither error the range nor be reported as an
@@ -96,7 +101,7 @@ tests:
       app.keda.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: app.keda.enabled. The global flag gates both the bundled KEDA operator (see the dependency condition in Chart.yaml) and every ScaledObject in this chart, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to fall back to the plain HorizontalPodAutoscaler.'
+          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: app.keda.enabled. The global flag gates every ScaledObject in this chart, and (via the dependency condition in Chart.yaml) the bundled KEDA operator too, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to leave those tiers on `autoscaling` instead — a plain HorizontalPodAutoscaler where you have enabled it, and a fixed replicaCount where you have not. If this is the first install on a cluster that has no KEDA yet, run the bootstrap pass once with --set keda.install=true --set keda.enabled=false and then install again normally — see HelmChart/Docs/Keda.md.'
 
   # --- the guard must not over-fire -----------------------------------------
   - it: should not fire when the global flag is off and nothing opts in
@@ -167,7 +172,7 @@ tests:
       runner.keda.enabled: true
     asserts:
       - failedTemplate:
-          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: probes.two.keda.enabled, app.keda.enabled, runner.keda.enabled. The global flag gates both the bundled KEDA operator (see the dependency condition in Chart.yaml) and every ScaledObject in this chart, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to fall back to the plain HorizontalPodAutoscaler.'
+          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: probes.two.keda.enabled, app.keda.enabled, runner.keda.enabled. The global flag gates every ScaledObject in this chart, and (via the dependency condition in Chart.yaml) the bundled KEDA operator too, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to leave those tiers on `autoscaling` instead — a plain HorizontalPodAutoscaler where you have enabled it, and a fixed replicaCount where you have not. If this is the first install on a cluster that has no KEDA yet, run the bootstrap pass once with --set keda.install=true --set keda.enabled=false and then install again normally — see HelmChart/Docs/Keda.md.'
 
   # NOTE on telemetryWriter, which has no case here: it is the one tier whose
   # ScaledObject condition does NOT read disableAutoscaler (neither does its
@@ -241,3 +246,43 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # --- the bootstrap exemption -----------------------------------------------
+  # `keda.install: true` with keda.enabled false is the one-time bootstrap pass
+  # (HelmChart/Docs/Keda.md): the bundled subchart ships its CRDs as templates
+  # rather than in a crds/ directory, so Helm cannot resolve a ScaledObject
+  # against a CRD that the same release has not applied yet, and a cluster with
+  # no KEDA needs one pass that installs the operator and renders no CR.
+  #
+  # The guard must stand down for it. Neither harm it exists to prevent applies:
+  # the operator is being installed rather than removed, so nothing is orphaned,
+  # and the render is a deliberate no-op rather than a silent one -- install is
+  # absent from values.yaml and tracks keda.enabled, so it is only true here
+  # because an operator typed it.
+  - it: should not fire during the bootstrap pass, even with tiers opted in
+    set:
+      keda.enabled: false
+      keda.install: true
+      probes.one.keda.enabled: true
+      app.keda.enabled: true
+      worker.enabled: true
+      worker.keda.enabled: true
+      telemetryWriter.enabled: true
+      telemetryWriter.keda.enabled: true
+      runner.keda.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # install: false is the OTHER half of the split -- an externally managed KEDA.
+  # It does not excuse anything: keda.enabled still gates the ScaledObjects, so a
+  # per-service flag on top of it is the same silent no-op as before and must
+  # still fail. Only `install: true` is a bootstrap.
+  - it: should still fire when install is explicitly false
+    set:
+      keda.enabled: false
+      keda.install: false
+      app.keda.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: 'the global keda.enabled is false but these per-service KEDA flags are true: app.keda.enabled. The global flag gates every ScaledObject in this chart, and (via the dependency condition in Chart.yaml) the bundled KEDA operator too, so no ScaledObject would be rendered — and on upgrade from a release that had it on, the operator would be uninstalled while the live ScaledObjects it was reconciling are left orphaned. Set keda.enabled=true to autoscale those services with KEDA, or set them back to false to leave those tiers on `autoscaling` instead — a plain HorizontalPodAutoscaler where you have enabled it, and a fixed replicaCount where you have not. If this is the first install on a cluster that has no KEDA yet, run the bootstrap pass once with --set keda.install=true --set keda.enabled=false and then install again normally — see HelmChart/Docs/Keda.md.'

--- a/HelmChart/Public/oneuptime/tests/keda-install-split_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/keda-install-split_test.yaml
@@ -1,0 +1,123 @@
+# `keda.enabled` used to gate two unrelated things: whether this chart renders
+# ScaledObjects, and whether it installs a KEDA operator. That left two clusters
+# unserved. One that already runs KEDA cluster-wide could not use the chart's
+# ScaledObjects at all -- turning the flag on tried to install a second operator
+# and collided with the existing release on cluster-scoped objects ("ClusterRole
+# keda-operator ... cannot be imported into the current release"). And one with
+# no KEDA at all could not do a first install, because the bundled subchart ships
+# its CRDs as ordinary templates rather than in a crds/ directory, so Helm was
+# asked to resolve a ScaledObject against a CRD the same release had not applied
+# yet ("no matches for kind ScaledObject in version keda.sh/v1alpha1").
+#
+# `keda.install` splits them: it is the first path of the dependency condition in
+# Chart.yaml and decides the operator on its own, while keda.enabled keeps
+# deciding the ScaledObjects. This suite pins the ScaledObject half of that
+# matrix -- the operator half is in keda-subchart_test.yaml (the ON side; the OFF
+# side is not expressible in helm-unittest) and both halves are checked against a
+# real cluster in HelmChart/Tests/suites/keda-bootstrap.sh.
+suite: keda install/enabled split
+templates:
+  - templates/keda-scaledobjects.yaml
+release:
+  name: ou
+  namespace: oneuptime
+tests:
+  # THE case the split exists for. The platform team's KEDA reconciles these; the
+  # chart must render the custom resources and keep its hands off the operator.
+  - it: should render ScaledObjects for an externally managed KEDA
+    set:
+      keda.enabled: true
+      keda.install: false
+      worker.enabled: true
+      worker.keda.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          apiVersion: keda.sh/v1alpha1
+          kind: ScaledObject
+          name: ou-worker-scaledobject
+          namespace: oneuptime
+          any: true
+      - containsDocument:
+          apiVersion: keda.sh/v1alpha1
+          kind: TriggerAuthentication
+          name: ou-worker-trigger-auth
+          namespace: oneuptime
+          any: true
+
+  # install is about the operator and nothing else. Rendering must be identical
+  # whether it is unset, true, or false -- if any of these three diverge, an
+  # operator who flips install to adopt their own KEDA silently loses (or gains)
+  # autoscaling on a live tier.
+  - it: should render the same ScaledObjects when install is unset
+    set:
+      keda.enabled: true
+      worker.enabled: true
+      worker.keda.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          apiVersion: keda.sh/v1alpha1
+          kind: ScaledObject
+          name: ou-worker-scaledobject
+          namespace: oneuptime
+          any: true
+
+  - it: should render the same ScaledObjects when install is explicitly true
+    set:
+      keda.enabled: true
+      keda.install: true
+      worker.enabled: true
+      worker.keda.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          apiVersion: keda.sh/v1alpha1
+          kind: ScaledObject
+          name: ou-worker-scaledobject
+          namespace: oneuptime
+          any: true
+
+  # The bootstrap pass has to be a genuine no-op on the CR side. If anything
+  # renders here the first install still fails on the missing CRD, which is the
+  # entire bug this pass works around.
+  - it: should render no ScaledObjects during the bootstrap pass
+    set:
+      keda.enabled: false
+      keda.install: true
+      worker.enabled: true
+      worker.keda.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # install must not stand in for enabled. Installing an operator does not opt any
+  # tier into autoscaling, and a tier that never opted in must not acquire a
+  # ScaledObject just because the operator is present.
+  - it: should render no ScaledObjects when install is on and no tier opted in
+    set:
+      keda.enabled: false
+      keda.install: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Every tier travels the same path, so one non-worker tier is enough to catch a
+  # gate that reads install where it should read enabled.
+  - it: should render an app ScaledObject for an externally managed KEDA
+    set:
+      keda.enabled: true
+      keda.install: false
+      app.keda.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          apiVersion: keda.sh/v1alpha1
+          kind: ScaledObject
+          name: ou-app-scaledobject
+          namespace: oneuptime
+          any: true

--- a/HelmChart/Public/oneuptime/tests/keda-subchart_test.yaml
+++ b/HelmChart/Public/oneuptime/tests/keda-subchart_test.yaml
@@ -3,14 +3,22 @@ release:
   name: ou
   namespace: oneuptime
 tests:
-  # The global flag is also the `condition:` on the KEDA dependency in Chart.yaml,
-  # so it decides whether the operator's three Deployments (manager, metrics
-  # server, webhooks) are installed at all. This pins the ON side: the subchart
-  # templates are reachable and DO render when the flag is true.
+  # `condition: keda.install,keda.enabled` on the KEDA dependency in Chart.yaml
+  # decides whether the operator's three Deployments (manager, metrics server,
+  # webhooks) are installed at all. Helm walks those paths in order and takes the
+  # first that holds a real bool, so keda.enabled decides while keda.install is
+  # unset -- which is the whole of backward compatibility for anyone already
+  # running `keda.enabled: true`. This pins the ON side: the subchart templates
+  # are reachable and DO render when the flag is true.
   #
   # The OFF side cannot be expressed here: when the condition excludes the
   # subchart, helm-unittest reports its templates as "not exists" (a suite error)
-  # rather than as zero documents. `helm template` on default values renders zero
+  # rather than as zero documents. That is why `keda.install: false` -- the
+  # externally-managed-KEDA case, and the entire point of the split -- has no
+  # case in this suite; it is covered from the other side in
+  # keda-install-split_test.yaml (ScaledObjects still render) and end to end in
+  # HelmChart/Tests/suites/keda-bootstrap.sh, which counts the operator's objects
+  # against a real cluster. `helm template` on default values renders zero
   # keda-operator/keda-metrics-server/keda-webhook objects -- verified out of band.
   - it: should install the KEDA operator manager when the global flag is on
     templates:
@@ -44,3 +52,51 @@ tests:
           count: 1
       - isKind:
           of: Deployment
+
+  # The bootstrap pass: keda.enabled is false, so no ScaledObject renders, but
+  # keda.install: true still has to bring the operator and its CRDs in. If the
+  # condition ever loses its first path this stops rendering and the two-phase
+  # first install documented in HelmChart/Docs/Keda.md has no first phase.
+  - it: should install the KEDA operator when install is on and enabled is off
+    templates:
+      - charts/keda/templates/manager/deployment.yaml
+    set:
+      keda.enabled: false
+      keda.install: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  # The CRDs the bootstrap pass exists to apply. They ship as ordinary templates
+  # in the subchart rather than in a crds/ directory -- that packaging is the
+  # whole reason a single-pass install cannot work, so pin that these two (the
+  # only kinds this chart renders custom resources for) come with the operator.
+  - it: should install the ScaledObject CRD with the operator
+    templates:
+      - charts/keda/templates/crds/crd-scaledobjects.yaml
+    set:
+      keda.install: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CustomResourceDefinition
+      - equal:
+          path: metadata.name
+          value: scaledobjects.keda.sh
+
+  - it: should install the TriggerAuthentication CRD with the operator
+    templates:
+      - charts/keda/templates/crds/crd-triggerauthentications.yaml
+    set:
+      keda.install: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CustomResourceDefinition
+      - equal:
+          path: metadata.name
+          value: triggerauthentications.keda.sh

--- a/HelmChart/Public/oneuptime/values.schema.json
+++ b/HelmChart/Public/oneuptime/values.schema.json
@@ -3257,6 +3257,9 @@
             "properties": {
                 "enabled": {
                     "type": "boolean"
+                },
+                "install": {
+                    "type": "boolean"
                 }
             },
             "additionalProperties": true

--- a/HelmChart/Public/oneuptime/values.yaml
+++ b/HelmChart/Public/oneuptime/values.yaml
@@ -2144,23 +2144,62 @@ queueDashboard:
   enabled: false
   secret:
 
-# KEDA (Kubernetes Event-driven Autoscaling). This single flag gates BOTH the
-# bundled KEDA operator subchart (see the `condition: keda.enabled` dependency
-# in Chart.yaml) AND every ScaledObject the chart renders
-# (templates/keda-scaledobjects.yaml).
+# KEDA (Kubernetes Event-driven Autoscaling). Two flags, because who runs the
+# operator and who owns the ScaledObjects are separate questions:
 #
-# Ships false: every per-service `keda.enabled` also ships false, so on default
-# values the operator was installed (3 Deployments — manager, metrics server,
-# webhooks — plus their CRDs) purely to sit idle. Turn this on together with at
-# least one per-service `<service>.keda.enabled` to autoscale on queue depth.
+#   keda.enabled  renders every ScaledObject/TriggerAuthentication in this chart
+#                 (templates/keda-scaledobjects.yaml).
+#   keda.install  installs the bundled KEDA operator subchart — it is the
+#                 `condition:` on the dependency in Chart.yaml. Deliberately NOT
+#                 set below: an unset condition path falls through to the next
+#                 one, so it tracks keda.enabled until you set it to a literal
+#                 true/false yourself. Only a real bool counts — values.schema.json
+#                 pins it to boolean so `install: ~` is rejected outright, and a
+#                 quoted "true" from --set-string would make Helm warn and fall
+#                 back to keda.enabled rather than install anything.
 #
-# Setting a per-service `keda.enabled` while this stays false is a hard error —
-# it would render no ScaledObject at all (and, on upgrade from a release that
-# had this on, uninstall the operator out from under live ScaledObjects), so
-# templates/keda-scaledobjects.yaml fails the render instead of silently
-# dropping your autoscaling.
+# keda.enabled ships false: every per-service `keda.enabled` also ships false,
+# so on default values the operator was installed (3 Deployments — manager,
+# metrics server, webhooks — plus 6 CRDs, 9 ClusterRoles, a validating webhook
+# and an aggregated APIService that takes over external.metrics.k8s.io
+# cluster-wide) purely to sit idle. Turn it on together with at least one
+# per-service `<service>.keda.enabled` to autoscale on queue depth.
+#
+# The three combinations that matter:
+#
+#   enabled: true                  bundled operator + this chart's ScaledObjects.
+#                                  The default relationship — leave install unset.
+#
+#   enabled: true, install: false  your platform team already runs KEDA. The chart
+#                                  renders only the ScaledObjects and leaves the
+#                                  operator alone. Without this the install fails
+#                                  on cluster-scoped resources the existing KEDA
+#                                  release already owns ("ClusterRole
+#                                  keda-operator ... cannot be imported").
+#
+#   enabled: false, install: true  the one-time bootstrap pass on a cluster with
+#                                  no KEDA. The bundled subchart ships its CRDs as
+#                                  templates rather than in a crds/ directory, and
+#                                  only a crds/ directory is applied ahead of the
+#                                  rest of the release — so the first install
+#                                  aborts on "no matches for kind ScaledObject"
+#                                  before anything lands at all. This pass installs
+#                                  the operator and its CRDs and renders no custom
+#                                  resources; the next one renders the
+#                                  ScaledObjects. Walkthrough:
+#                                  HelmChart/Docs/Keda.md.
+#
+# Setting a per-service `keda.enabled` while keda.enabled stays false is a hard
+# error unless install is explicitly true (the bootstrap pass above) — it would
+# render no ScaledObject at all, and on upgrade from a release that had it on it
+# would uninstall the operator out from under live ScaledObjects, so
+# templates/keda-scaledobjects.yaml fails the render instead of silently dropping
+# your autoscaling.
 keda:
   enabled: false
+  # Uncomment (true or false) to decide the operator on its own. Leave it
+  # commented out — not null — to keep following keda.enabled.
+  # install: true
 
 # CloudNativePG operator — bundled dependency. Installed ONLY when
 # postgresOperator.cnpg.enabled is true (see the condition in Chart.yaml).

--- a/HelmChart/README.md
+++ b/HelmChart/README.md
@@ -22,6 +22,7 @@ not stop the others, so one run tells you everything that is broken.
 | `lint`              | no              | `helm lint` over the `oneuptime` and `kubernetes-agent` charts                        |
 | `unit`              | no              | the helm-unittest suites in [`Public/oneuptime/tests`](Public/oneuptime/tests)        |
 | `secrets-lifecycle` | yes             | installs and upgrades the chart for real, to cover Secret handling across an upgrade  |
+| `keda-bootstrap`    | yes             | the KEDA CRD bootstrap and the `keda.install` / `keda.enabled` split, against a real API server |
 
 Run one suite, or keep the cluster around to poke at a failure:
 
@@ -32,12 +33,16 @@ KEEP_CLUSTER=true bash HelmChart/Tests/run.sh secrets-lifecycle
 
 `npm run test-helm-chart` still runs just the helm-unittest suites — they need
 no cluster and no Docker, so they are the quick loop while editing templates.
-The cluster-backed `secrets-lifecycle` suite exists because those unit tests
-render without an API server, which means `lookup` always comes back empty and
-only the "regenerate" leg of `templates/secrets.yaml` is exercised; the
-behaviour that file is there for — an upgrade must *not* rotate a secret it
-already generated — can only be asserted against a real cluster. It pulls no
-images.
+The cluster-backed suites exist because those unit tests render without an API
+server. `secrets-lifecycle` needs one because `lookup` always comes back empty
+without it, so only the "regenerate" leg of `templates/secrets.yaml` is
+exercised; the behaviour that file is there for — an upgrade must *not* rotate a
+secret it already generated — can only be asserted against a real cluster.
+`keda-bootstrap` needs one because Helm resolves a rendered manifest against the
+API server before applying it, and `helm template` uses a fake client that never
+does: the chart's first install with KEDA autoscaling was impossible for months
+while lint, unit tests and `helm template` all stayed green. Neither suite waits
+on a pod, so no images are pulled.
 
 Adding a suite: drop it in `Tests/suites`, source `lib/harness.sh` for the
 assertions and the cluster, end with `harness_report`, and list it in
@@ -55,6 +60,10 @@ Moving an existing install from a standalone database to its bundled operator:
 - [ClickHouse: Standalone → Altinity operator](Docs/MigrateClickhouseStandaloneToOperator.md)
 
 ## Scaling guides
+
+Autoscaling the queue-driven tiers:
+
+- [KEDA: the two flags, the CRD bootstrap, and an externally managed KEDA](Docs/Keda.md)
 
 Scaling an operator-managed (Altinity) ClickHouse:
 

--- a/HelmChart/Tests/run.sh
+++ b/HelmChart/Tests/run.sh
@@ -20,7 +20,7 @@ SUITES_DIR="${TESTS_DIR}/suites"
 
 # Ordered cheapest-first. Every file in ./suites has to appear here, which is
 # checked below: a new suite cannot be added and then silently never run.
-ALL_SUITES=(lint unit secrets-lifecycle)
+ALL_SUITES=(lint unit secrets-lifecycle keda-bootstrap)
 
 usage() {
     echo "usage: $(basename "${BASH_SOURCE[0]}") [suite ...]"

--- a/HelmChart/Tests/suites/keda-bootstrap.sh
+++ b/HelmChart/Tests/suites/keda-bootstrap.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# Cluster-backed tests for the KEDA CRD bootstrap and the install/enabled split.
+#
+# This is the only suite that can see the bug it covers. `helm template` and
+# helm-unittest both run through Helm's fake kube client, whose Build() returns
+# an empty list unconditionally -- so a manifest that the API server will reject
+# for an unresolvable kind renders perfectly clean there. The chart shipped for
+# months with a first install that could not succeed, and lint, unit tests and
+# the release job's `helm template` all stayed green throughout.
+#
+# The bundled KEDA subchart ships its CRDs as ordinary templates (templates/crds,
+# gated by crds.install) rather than in a crds/ directory. Only a crds/ directory
+# is applied by Helm before it resolves the rendered manifest against the API
+# server, so with the CRDs as templates the chart's own ScaledObject cannot be
+# mapped on a cluster that has no KEDA, and the whole install aborts before
+# anything is applied. Hence `keda.install`, which turns the operator into its
+# own switch: one pass installs it, the next renders the custom resources.
+#
+# Covered:
+#   1. The premise. A single-pass install with KEDA autoscaling on a cluster with
+#      no KEDA fails on the resource mapping, and applies nothing at all.
+#   2. The bootstrap pass (install on, enabled off) installs the operator and its
+#      CRDs and renders no custom resource.
+#   3. The second pass then renders the ScaledObject, in one pass, and leaves the
+#      operator in place -- keda.enabled alone, exactly as before the split, so
+#      this doubles as the backward-compatibility check.
+#   4. An externally managed KEDA (enabled on, install false) renders the custom
+#      resources against CRDs it does not own and installs no second operator.
+#
+# The KEDA operator's Deployments are created but never waited on, so nothing
+# here blocks on an image pull. Nothing else waits either: no --wait, no hooks.
+
+# shellcheck source=../lib/harness.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../lib" && pwd)/harness.sh"
+
+NAMESPACE="${NAMESPACE:-oneuptime-keda-test}"
+RELEASE="${RELEASE:-ou}"
+CHART_DIR="$HELM_CHART_DIR"
+
+# Flags every helm command in this script shares. Hooks are off so nothing waits
+# on a Job. The worker is the tier the original bug report used.
+#
+# --disable-openapi-validation earns its place twice. It skips a fetch of the
+# API server's whole OpenAPI v2 document, which registering six large KEDA CRDs
+# makes big enough to time out Helm's client on a loaded runner -- a flake that
+# has nothing to do with what is being tested. And it holds case 1 to the
+# stronger claim the docs make: the first install fails on the resource MAPPING,
+# so turning schema validation off does not rescue it.
+HELM_ARGS=(
+    --namespace "$NAMESPACE"
+    --no-hooks
+    --disable-openapi-validation
+    --set worker.enabled=true
+    --set worker.keda.enabled=true
+)
+
+# Runs a helm command that is expected to succeed and scores it. The harness runs
+# under `set -e`, so a bare failing helm call would abort the whole suite and hide
+# every case after it; guarding each one with `if helm_ok ...` costs the
+# assertions that depended on it and nothing else.
+helm_ok() {
+    # helm_ok <description> <command...>
+    local desc="$1"
+    shift
+    local out
+    if out=$("$@" 2>&1); then
+        pass "$desc"
+        return 0
+    fi
+    fail "$desc"
+    sed 's/^/        /' <<<"$(tail -5 <<<"$out")"
+    return 1
+}
+
+# The two CRDs this chart renders custom resources for. KEDA ships four more
+# (scaledjobs, cloudeventsources, clustercloudeventsources,
+# clustertriggerauthentications) that the operator needs but this chart never
+# uses; the external-KEDA case below pre-applies all six so it simulates a real
+# platform-team install rather than a convenient subset.
+KEDA_CRD_TEMPLATES=(
+    -s charts/keda/templates/crds/crd-scaledobjects.yaml
+    -s charts/keda/templates/crds/crd-triggerauthentications.yaml
+    -s charts/keda/templates/crds/crd-scaledjobs.yaml
+    -s charts/keda/templates/crds/crd-cloudeventsources.yaml
+    -s charts/keda/templates/crds/crd-clustercloudeventsources.yaml
+    -s charts/keda/templates/crds/crd-clustertriggerauthentications.yaml
+)
+
+# Number of keda.sh CRDs registered on the cluster, however they got there.
+keda_crd_count() {
+    kubectl get crd -o name 2>/dev/null | grep -c '\.keda\.sh$' || true
+}
+
+# Number of KEDA operator Deployments in the namespace. The subchart names them
+# keda-operator / keda-operator-metrics-apiserver / keda-admission-webhooks.
+keda_operator_deployments() {
+    kubectl -n "$NAMESPACE" get deploy -o name 2>/dev/null | grep -c 'deployment.apps/keda' || true
+}
+
+scaledobject_names() {
+    kubectl -n "$NAMESPACE" get scaledobjects.keda.sh -o name 2>/dev/null || true
+}
+
+# Puts the cluster back to "no KEDA at all". The CRDs are cluster-scoped and
+# outlive the namespace, and deleting them cascades every custom resource of
+# theirs, so this has to run before the first test as well as after the last:
+# run.sh shares one KinD cluster between suites, and KEEP_CLUSTER=true hands a
+# dirty one to the next run.
+reset_cluster() {
+    helm uninstall "$RELEASE" -n "$NAMESPACE" >/dev/null 2>&1 || true
+    # --timeout matters: kubectl's default is 0s, which it reads as "wait
+    # forever", so a CRD stuck on a finalizer would hang the suite with no output
+    # rather than fail it. `|| true` cannot rescue a block, only a non-zero exit.
+    for crd in $(kubectl get crd -o name 2>/dev/null | grep '\.keda\.sh$'); do
+        kubectl delete "$crd" --ignore-not-found --wait=true --timeout=60s >/dev/null 2>&1 || true
+    done
+}
+
+echo "Chart: $CHART_DIR"
+
+harness_start_cluster
+
+# harness_namespace swallows its own errors, and a KinD API server can still be
+# refusing requests for a few seconds after `kind create cluster` returns -- which
+# leaves the namespace missing and every install below failing on "namespaces
+# ... not found" rather than on anything this suite is about. Retry until it is
+# really there.
+harness_namespace "$NAMESPACE"
+for _ in $(seq 1 30); do
+    if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+        break
+    fi
+    kubectl create namespace "$NAMESPACE" >/dev/null 2>&1 || true
+    sleep 2
+done
+if ! kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+    fail "namespace ${NAMESPACE} could not be created"
+    harness_report
+    exit 1
+fi
+
+reset_cluster
+
+echo
+echo "=== 1. the premise: one pass with KEDA autoscaling cannot bootstrap KEDA ==="
+# If this ever starts succeeding, the CRD packaging changed (the subchart moved
+# them into crds/, or the chart began shipping them itself) and the bootstrap in
+# HelmChart/Docs/Keda.md is obsolete -- delete this case and the two-phase
+# instructions together rather than making the assertion looser.
+SINGLE_PASS_OUTPUT=$(helm install "$RELEASE" "$CHART_DIR" "${HELM_ARGS[@]}" --set keda.enabled=true 2>&1) && SINGLE_PASS_RC=0 || SINGLE_PASS_RC=1
+
+if [ "$SINGLE_PASS_RC" -ne 0 ]; then
+    pass "a single-pass install with keda.enabled fails on a cluster with no KEDA"
+else
+    fail "a single-pass install with keda.enabled unexpectedly succeeded"
+fi
+assert_present "it fails on the ScaledObject resource mapping" "$SINGLE_PASS_OUTPUT" 'no matches for kind "ScaledObject" in version "keda.sh/v1alpha1"'
+# Helm resolves the whole manifest before it applies any of it, so a failure here
+# is total -- this is why re-running the same command never makes progress.
+assert_eq "nothing is applied, not even the CRDs" "0" "$(keda_crd_count)"
+
+reset_cluster
+
+echo
+echo "=== 2. the bootstrap pass installs the operator and its CRDs ==="
+if helm_ok "install with keda.install=true and keda.enabled=false succeeds" \
+    helm install "$RELEASE" "$CHART_DIR" "${HELM_ARGS[@]}" \
+    --set keda.install=true --set keda.enabled=false; then
+
+    assert_eq "the KEDA CRDs are registered" "6" "$(keda_crd_count)"
+    assert_eq "the operator's three Deployments are installed" "3" "$(keda_operator_deployments)"
+    # The point of the pass: worker.keda.enabled is true throughout, and it still
+    # must not render a ScaledObject, or this pass fails the same way case 1 did.
+    assert_eq "no ScaledObject is rendered" "" "$(scaledobject_names)"
+
+    echo
+    echo "=== 3. the second pass renders the ScaledObject, and keeps the operator ==="
+    # No keda.install here: it is unset, so the dependency condition falls through
+    # to keda.enabled and behaves exactly as it did before the split. This is the
+    # backward-compatibility case as much as it is phase two.
+    if helm_ok "upgrade with keda.enabled=true succeeds once the CRDs exist" \
+        helm upgrade "$RELEASE" "$CHART_DIR" "${HELM_ARGS[@]}" --set keda.enabled=true; then
+
+        assert_present "the worker ScaledObject is created" "$(scaledobject_names)" "scaledobject.keda.sh/${RELEASE}-worker-scaledobject"
+        assert_eq "the operator is still installed" "3" "$(keda_operator_deployments)"
+        assert_present "the TriggerAuthentication is created" \
+            "$(kubectl -n "$NAMESPACE" get triggerauthentications.keda.sh -o name 2>/dev/null || true)" \
+            "triggerauthentication.keda.sh/${RELEASE}-worker-trigger-auth"
+    fi
+fi
+
+reset_cluster
+
+echo
+echo "=== 4. an externally managed KEDA: CRs render, no second operator ==="
+# Stand in for the platform team's KEDA by applying its CRDs out of band. They
+# carry no Helm ownership metadata, which is the whole difficulty: a release that
+# tried to install its own operator on top would collide with them.
+helm template "$RELEASE" "$CHART_DIR" --set keda.install=true "${KEDA_CRD_TEMPLATES[@]}" |
+    kubectl apply --server-side -f - >/dev/null
+assert_eq "the cluster has KEDA CRDs nobody's release owns" "6" "$(keda_crd_count)"
+
+if helm_ok "install with keda.enabled=true and keda.install=false succeeds in one pass" \
+    helm install "$RELEASE" "$CHART_DIR" "${HELM_ARGS[@]}" \
+    --set keda.enabled=true --set keda.install=false; then
+
+    assert_present "the worker ScaledObject is created" "$(scaledobject_names)" "scaledobject.keda.sh/${RELEASE}-worker-scaledobject"
+    assert_eq "no KEDA operator is installed" "0" "$(keda_operator_deployments)"
+fi
+
+reset_cluster
+
+harness_report


### PR DESCRIPTION
Reported by a user deploying chart 12.0.x on a fresh AKS cluster in Azure Government. Both halves of their report check out, and one is worse than described.

## The bug

With `keda.enabled: true` and `worker.keda.enabled: true`, the very first `helm upgrade --install` on a cluster that has never had KEDA **always** fails:

```
resource mapping not found for name: "oneuptime-worker-scaledobject" ...
no matches for kind "ScaledObject" in version "keda.sh/v1alpha1"
ensure CRDs are installed first
```

The vendored keda 2.20.1 subchart ships its CRDs under `templates/crds/`, not in a `crds/` directory. Only a `crds/` directory is applied ahead of the rest of the release, so Helm is asked to REST-map a `ScaledObject` against a CRD the same release has not applied yet, and the install aborts before anything lands — **not even the CRDs**, which is why re-running never made progress. A pre-install hook cannot fix it either: Helm's `Build()` runs before hooks.

Separately, `keda.enabled` gated *both* the subchart and the ScaledObjects, so a cluster where a platform team already runs KEDA had no supported path at all — enabling it collides on cluster-scoped objects the existing release owns (`ClusterRole "keda-operator" ... cannot be imported`), and the bundled subchart also claims the aggregated `external.metrics.k8s.io` APIService cluster-wide.

That coupling was never a design decision. It arrived in `0939294d22` ("Refactor code structure for improved readability and maintainability") as an accident of the dependency and its values key sharing a name.

## The fix

`Chart.yaml` now reads `condition: keda.install,keda.enabled`. Helm walks those paths and takes the first holding a real bool, and `keda.install` is deliberately **not** defined in `values.yaml` — so it falls through to `keda.enabled`, and every existing values file behaves exactly as before with no warning output.

| `keda.enabled` | `keda.install` | operator | ScaledObjects | |
|---|---|---|---|---|
| `false` | unset | — | — | stock default, unchanged |
| `true` | unset | yes | yes | **unchanged for current users** |
| `true` | `false` | — | yes | externally managed KEDA |
| `false` | `true` | yes | — | one-time bootstrap pass |

`keda.enabled` keeps meaning "render the ScaledObjects", which is also what suppresses the plain HPA in `app`/`worker`/`probe`/`runner`/`telemetry-writer` — so a BYO-KEDA release never ends up with a ScaledObject and an HPA fighting over the same Deployment.

Because `install` tracks `enabled` by default, `enabled: false` + `install: true` is unreachable by accident. The existing `fail` guard therefore stands down for exactly that combination (the operator is being installed, not removed, so nothing is orphaned) and still fires everywhere else — now pointing at the bootstrap in its message.

`oneuptime.kedaOperatorInstalled` mirrors Helm's own condition resolution with `kindIs "bool"` rather than `hasKey` or a truthiness check, which would disagree with Helm on `--set-string` and make the guard describe an operator that isn't there.

## Why CI never caught this

`helm template` runs through Helm's fake kube client, whose `Build()` returns an empty list unconditionally. Lint, the helm-unittest suites and the release job's `helm template` all stayed green for months against a first install that could not succeed. `HelmChart/Tests/suites/secrets-lifecycle.sh` even sets `--set keda.enabled=false` with the comment *"Keda is off so the subchart CRDs are not needed"* — the problem was known and stepped around.

So this adds `HelmChart/Tests/suites/keda-bootstrap.sh`, a cluster-backed suite that installs for real and asserts the failure, the bootstrap, the second pass, and the externally-managed case.

## Docs

New `HelmChart/Docs/Keda.md`, following the shape `Postgres.md` already uses for the CloudNativePG version of this same failure, plus pointers from `README.md`, `installation.md`, `configuration.md`, `production-checklist.md` and the dependency table.

It also documents the hand-over off a bundled KEDA, which has a sharp edge: KEDA's CRDs — unlike CloudNativePG's — carry no `helm.sh/resource-policy: keep`, so dropping the subchart deletes them and cascade-deletes every `ScaledObject` in the cluster unless they are annotated first.

One correction to wording the chart already shipped: turning KEDA off does **not** "fall back to the plain HorizontalPodAutoscaler". `autoscaling.enabled` ships `false`, so the tier gets no HPA at all and the Deployment templates put `replicas: <replicaCount>` back — a fleet KEDA had taken to 6 pods drops to 1. Measured, and the guard message and docs now say so.

## Verification

`bash HelmChart/Tests/run.sh` — all 4 suites green:

```
PASS   lint                 2 passed
PASS   unit                 1 passed      (123 helm-unittest tests, 11 new)
PASS   secrets-lifecycle    44 passed
PASS   keda-bootstrap       15 passed
```

The comma-condition semantics were measured on Helm 3.12.3 and 3.19.0 (identical), and `processDependencyConditions` is unchanged across 3.12 → 3.21.

## Notes for review

- **No upgrade-notes entry.** `VERSION` is `12.0.14` and release CI sets the chart version from it, so I did not invent a version/date. Worth adding one at release time if you want it called out.
- **CloudNativePG has the same shape** — CRDs in `templates/crds/`, and one flag gating both the subchart and the `Cluster` CR. The bootstrap half is already documented in `Postgres.md`; the external-operator half has no path either. Left alone deliberately — happy to do it as a follow-up.
