### PR TITLE
fix(on-call): let escalation rules read schedule roster state

### DIFF
--- a/App/Tests/Dashboard/RelationSelectColumnsWiring.test.ts
+++ b/App/Tests/Dashboard/RelationSelectColumnsWiring.test.ts
@@ -1,0 +1,361 @@
+import BaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import { TableColumnMetadata } from "Common/Types/Database/TableColumn";
+import TableColumnType from "Common/Types/Database/TableColumnType";
+import { describe, expect, test } from "@jest/globals";
+import fs from "fs";
+import path from "path";
+import ts from "typescript";
+
+/*
+ * A select that reaches through a relation is checked against the RELATED
+ * model, not the one being queried, and the check is all-or-nothing:
+ *
+ *   QueryPermission.checkRelationQueryPermission walks every inner key of
+ *   `select: { someRelation: { ... } }` and THROWS on the first one whose
+ *   column lacks canReadOnRelationQuery. It does not drop the key and carry on.
+ *
+ * So a single unflagged column fails the whole request, for every caller, at
+ * any permission level. That is how the escalation rule page broke: it added
+ * `currentUserIdOnRoster` next to `name` in the schedule join, the model had no
+ * flag on that column, and the page stopped loading entirely with
+ *
+ *   Column currentUserIdOnRoster on On-Call Policy Schedule does not
+ *   support read on relation query.
+ *
+ * Nothing catches this at compile time. `Select<TBaseModel>` is typed from the
+ * model's fields, so every column is spellable in a relation select and only
+ * the runtime knows which ones are actually reachable - which means the first
+ * report comes from a user with a blank page, as it did here.
+ *
+ * This test closes that gap. It parses the sources for the call shape that
+ * carries both a `modelType` and a `select`, walks each nested relation, and
+ * resolves the inner columns against the model metadata the server will use.
+ *
+ * WHAT IT DOES NOT COVER. Only literal `modelType: X` / `select: { ... }` pairs
+ * in one object are matched. A select built in a variable, spread in, or
+ * assembled conditionally is invisible here, as is any call that names its
+ * model somewhere other than a `modelType` property. The count assertion at the
+ * bottom guards the parse itself: if a refactor moves the call shape, this file
+ * fails rather than quietly checking nothing.
+ */
+
+const REPO_ROOT: string = path.join(__dirname, "..", "..", "..");
+
+const MODEL_DIR: string = path.join(
+  REPO_ROOT,
+  "Common",
+  "Models",
+  "DatabaseModels",
+);
+
+// Mirrors ColumnPermissions.getExcludedColumnNames().
+const EXCLUDED_COLUMN_NAMES: Array<string> = [
+  "_id",
+  "createdAt",
+  "deletedAt",
+  "updatedAt",
+  "version",
+];
+
+const SCAN_DIRECTORIES: Array<string> = [
+  path.join(REPO_ROOT, "App"),
+  path.join(REPO_ROOT, "Common", "UI"),
+  path.join(REPO_ROOT, "Common", "Server"),
+  path.join(REPO_ROOT, "Common", "Utils"),
+];
+
+/*
+ * Test trees are skipped along with build output: a test asserting that a bad
+ * select is refused has to spell out a bad select, and that is not a call site
+ * anybody will make. Only production query sites are checked. No test declared
+ * one either way when this was written, so nothing is lost by excluding them.
+ */
+const SKIP_DIRECTORY_NAMES: Array<string> = [
+  "node_modules",
+  "dist",
+  "build",
+  ".git",
+  "Tests",
+  "__tests__",
+];
+
+const SOURCE_FILE_PATTERN: RegExp = new RegExp("\\.(ts|tsx)$");
+const TSX_FILE_PATTERN: RegExp = new RegExp("\\.tsx$");
+const MODEL_FILE_SUFFIX_PATTERN: RegExp = new RegExp("\\.ts$");
+
+interface RelationSelectSite {
+  file: string;
+  line: number;
+  modelName: string;
+  relation: string;
+  column: string;
+}
+
+function listModelNames(): Set<string> {
+  return new Set(
+    fs
+      .readdirSync(MODEL_DIR)
+      .filter((fileName: string) => {
+        return fileName.endsWith(".ts") && fileName !== "Index.ts";
+      })
+      .map((fileName: string) => {
+        return fileName.replace(MODEL_FILE_SUFFIX_PATTERN, "");
+      }),
+  );
+}
+
+function listSourceFiles(directory: string, out: Array<string> = []): string[] {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (SKIP_DIRECTORY_NAMES.includes(entry.name)) {
+      continue;
+    }
+
+    const entryPath: string = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      listSourceFiles(entryPath, out);
+    } else if (SOURCE_FILE_PATTERN.test(entry.name)) {
+      out.push(entryPath);
+    }
+  }
+
+  return out;
+}
+
+function readObjectProperties(
+  node: ts.ObjectLiteralExpression,
+): Map<string, ts.Expression> {
+  const properties: Map<string, ts.Expression> = new Map();
+
+  for (const property of node.properties) {
+    if (
+      ts.isPropertyAssignment(property) &&
+      (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name))
+    ) {
+      properties.set(property.name.text, property.initializer);
+    }
+  }
+
+  return properties;
+}
+
+function collectRelationSelectSites(): Array<RelationSelectSite> {
+  const modelNames: Set<string> = listModelNames();
+  const sites: Array<RelationSelectSite> = [];
+
+  for (const directory of SCAN_DIRECTORIES) {
+    if (!fs.existsSync(directory)) {
+      continue;
+    }
+
+    for (const filePath of listSourceFiles(directory)) {
+      const sourceFile: ts.SourceFile = ts.createSourceFile(
+        filePath,
+        fs.readFileSync(filePath, "utf8"),
+        ts.ScriptTarget.Latest,
+        true,
+        TSX_FILE_PATTERN.test(filePath) ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+      );
+
+      const visit: (node: ts.Node) => void = (node: ts.Node): void => {
+        if (ts.isObjectLiteralExpression(node)) {
+          const properties: Map<string, ts.Expression> =
+            readObjectProperties(node);
+          const modelTypeExpression: ts.Expression | undefined =
+            properties.get("modelType");
+          const selectExpression: ts.Expression | undefined =
+            properties.get("select");
+
+          if (
+            modelTypeExpression &&
+            selectExpression &&
+            ts.isIdentifier(modelTypeExpression) &&
+            ts.isObjectLiteralExpression(selectExpression) &&
+            modelNames.has(modelTypeExpression.text)
+          ) {
+            for (const [key, value] of readObjectProperties(selectExpression)) {
+              // A nested object literal is a select through a relation.
+              if (!ts.isObjectLiteralExpression(value)) {
+                continue;
+              }
+
+              const { line } = sourceFile.getLineAndCharacterOfPosition(
+                value.getStart(),
+              );
+
+              for (const [innerKey] of readObjectProperties(value)) {
+                sites.push({
+                  file: path.relative(REPO_ROOT, filePath),
+                  line: line + 1,
+                  modelName: modelTypeExpression.text,
+                  relation: key,
+                  column: innerKey,
+                });
+              }
+            }
+          }
+        }
+
+        ts.forEachChild(node, visit);
+      };
+
+      visit(sourceFile);
+    }
+  }
+
+  return sites;
+}
+
+/*
+ * Only the models a relation select actually names are loaded, rather than the
+ * whole DatabaseModels index - a few dozen instead of several hundred, which is
+ * the difference between this file costing seconds and costing a minute.
+ */
+async function loadModel(modelName: string): Promise<BaseModel | null> {
+  try {
+    const imported: { default: { new (): BaseModel } } = await import(
+      path.join(MODEL_DIR, modelName)
+    );
+
+    return new imported.default();
+  } catch {
+    return null;
+  }
+}
+
+interface ScanResult {
+  sites: Array<RelationSelectSite>;
+  checkedCount: number;
+  violations: Array<string>;
+}
+
+/*
+ * Parsing the tree and instantiating the models costs a few seconds, and every
+ * assertion below wants the same answer. Do it once, on first use.
+ */
+let cachedResult: ScanResult | null = null;
+
+async function scan(): Promise<ScanResult> {
+  if (cachedResult) {
+    return cachedResult;
+  }
+
+  const sites: Array<RelationSelectSite> = collectRelationSelectSites();
+  const modelCache: Map<string, BaseModel | null> = new Map();
+  const violations: Array<string> = [];
+  let checkedCount: number = 0;
+
+  const modelFor: (name: string) => Promise<BaseModel | null> = async (
+    name: string,
+  ): Promise<BaseModel | null> => {
+    if (!modelCache.has(name)) {
+      modelCache.set(name, await loadModel(name));
+    }
+
+    return modelCache.get(name) ?? null;
+  };
+
+  for (const site of sites) {
+    const outerModel: BaseModel | null = await modelFor(site.modelName);
+
+    if (!outerModel) {
+      continue;
+    }
+
+    let relationMetadata: TableColumnMetadata | undefined = undefined;
+
+    try {
+      relationMetadata = outerModel.getTableColumnMetadata(site.relation);
+    } catch {
+      continue;
+    }
+
+    /*
+     * Not every nested object under a select is a relation - `select` also
+     * carries shapes the permission layer never walks. Only Entity and
+     * EntityArray columns reach checkRelationQueryPermission's inner loop.
+     */
+    if (
+      !relationMetadata ||
+      !relationMetadata.modelType ||
+      (relationMetadata.type !== TableColumnType.Entity &&
+        relationMetadata.type !== TableColumnType.EntityArray)
+    ) {
+      continue;
+    }
+
+    const relatedModel: BaseModel = new relationMetadata.modelType();
+    const columnMetadata: TableColumnMetadata =
+      relatedModel.getTableColumnMetadata(site.column);
+
+    checkedCount++;
+
+    if (!columnMetadata) {
+      violations.push(
+        `${site.file}:${site.line} - ${site.modelName}.${site.relation} selects ` +
+          `"${site.column}", which is not a column on ${relatedModel.singularName}.`,
+      );
+      continue;
+    }
+
+    if (
+      !columnMetadata.canReadOnRelationQuery &&
+      !EXCLUDED_COLUMN_NAMES.includes(site.column)
+    ) {
+      violations.push(
+        `${site.file}:${site.line} - ${site.modelName}.${site.relation} selects ` +
+          `${relatedModel.singularName}.${site.column}, but that column has no ` +
+          `canReadOnRelationQuery. The read throws "Column ${site.column} on ` +
+          `${relatedModel.singularName} does not support read on relation query." ` +
+          `Add canReadOnRelationQuery to the column, or stop selecting it here.`,
+      );
+    }
+  }
+
+  cachedResult = {
+    sites: sites,
+    checkedCount: checkedCount,
+    violations: Array.from(new Set(violations)).sort(),
+  };
+
+  return cachedResult;
+}
+
+describe("relation selects only name columns the permission layer allows", () => {
+  test("every relation-selected column is readable through the relation", async () => {
+    expect((await scan()).violations).toEqual([]);
+  });
+
+  test("the scan actually found relation selects to check", async () => {
+    /*
+     * Guards the assertion above against passing because the parse found
+     * nothing. The repo had well over two hundred checkable relation columns
+     * when this was written; a floor well under that still catches a scan that
+     * has silently stopped matching the call shape.
+     */
+    const result: ScanResult = await scan();
+
+    expect(result.sites.length).toBeGreaterThan(100);
+    expect(result.checkedCount).toBeGreaterThan(100);
+  });
+
+  test("the escalation rule schedule join is one of the sites covered", async () => {
+    /*
+     * The select that caused the original report. Naming it here means that
+     * deleting the component, or restructuring its query into a shape the
+     * parse cannot see, shows up as a failure rather than as silent loss of
+     * coverage over the exact regression this file exists for.
+     */
+    const rosterSites: Array<RelationSelectSite> = (await scan()).sites.filter(
+      (site: RelationSelectSite) => {
+        return (
+          site.modelName === "OnCallDutyPolicyEscalationRuleSchedule" &&
+          site.relation === "onCallDutyPolicySchedule" &&
+          site.column === "currentUserIdOnRoster"
+        );
+      },
+    );
+
+    expect(rosterSites.length).toBeGreaterThan(0);
+  });
+});

--- a/Common/Models/DatabaseModels/OnCallDutyPolicySchedule.ts
+++ b/Common/Models/DatabaseModels/OnCallDutyPolicySchedule.ts
@@ -588,6 +588,20 @@ export default class OnCallDutyPolicySchedule extends BaseModel {
   })
   @TableColumn({
     type: TableColumnType.ObjectID,
+    /*
+     * Read through a relation, alongside `name`, so a joined schedule row can
+     * say whether it would page anybody right now. An escalation rule lists
+     * schedules by name and has to mark the ones that are currently uncovered;
+     * that is one join away from the rule, and without this flag
+     * QueryPermission rejects the whole select rather than dropping the column
+     * - the escalation rule page fails to load at all.
+     *
+     * The disclosure is a user id belonging to the same project as the
+     * schedule, to a caller who is already reading the schedule's name off the
+     * same joined row. It is not an @OwnerOnlyColumn: who is on call is
+     * operational state the team is meant to see, not a personal credential.
+     */
+    canReadOnRelationQuery: true,
     title: "Current User ID On Roster",
     description: "User ID who is currently on roster",
     example: "c3d4e5f6-a7b8-9012-cdef-123456789012",

--- a/Common/Tests/Server/Types/Database/Permissions/OnCallScheduleRelationSelect.test.ts
+++ b/Common/Tests/Server/Types/Database/Permissions/OnCallScheduleRelationSelect.test.ts
@@ -1,0 +1,504 @@
+import DatabaseRequestType from "../../../../../Server/Types/BaseDatabase/DatabaseRequestType";
+import AccessControlPermission from "../../../../../Server/Types/Database/Permissions/AccessControlPermission";
+import BasePermission from "../../../../../Server/Types/Database/Permissions/BasePermission";
+import OwnedScopePermission from "../../../../../Server/Types/Database/Permissions/OwnedScopePermission";
+import PublicPermission from "../../../../../Server/Types/Database/Permissions/PublicPermission";
+import QueryPermission from "../../../../../Server/Types/Database/Permissions/QueryPermission";
+import SelectPermission from "../../../../../Server/Types/Database/Permissions/SelectPermission";
+import TablePermission from "../../../../../Server/Types/Database/Permissions/TablePermission";
+import TenantPermission from "../../../../../Server/Types/Database/Permissions/TenantPermission";
+import UserPermissions from "../../../../../Server/Types/Database/Permissions/UserPermission";
+import Query from "../../../../../Server/Types/Database/Query";
+import Select from "../../../../../Server/Types/Database/Select";
+import OnCallDutyPolicyEscalationRuleSchedule from "../../../../../Models/DatabaseModels/OnCallDutyPolicyEscalationRuleSchedule";
+import OnCallDutyPolicySchedule from "../../../../../Models/DatabaseModels/OnCallDutyPolicySchedule";
+import BaseModel from "../../../../../Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
+import DatabaseCommonInteractionProps from "../../../../../Types/BaseDatabase/DatabaseCommonInteractionProps";
+import { isOwnerOnlyColumn } from "../../../../../Types/Database/AccessControl/OwnerOnlyColumn";
+import { TableColumnMetadata } from "../../../../../Types/Database/TableColumn";
+import TableColumnType from "../../../../../Types/Database/TableColumnType";
+import BadDataException from "../../../../../Types/Exception/BadDataException";
+import NotAuthorizedException from "../../../../../Types/Exception/NotAuthorizedException";
+import ObjectID from "../../../../../Types/ObjectID";
+import Permission from "../../../../../Types/Permission";
+
+/*
+ * THE BUG.
+ *
+ * Opening a policy's escalation rules failed outright with
+ *
+ *   Column currentUserIdOnRoster on On-Call Policy Schedule does not
+ *   support read on relation query.
+ *
+ * The escalation rule page lists the schedules attached to each rule and marks
+ * the ones that would currently page nobody. It reads that state off the join:
+ *
+ *   modelType: OnCallDutyPolicyEscalationRuleSchedule
+ *   select: { onCallDutyPolicySchedule: { name, currentUserIdOnRoster } }
+ *
+ * `name` carries canReadOnRelationQuery. `currentUserIdOnRoster` did not, and
+ * QueryPermission.checkRelationQueryPermission THROWS on the first unflagged
+ * inner key rather than dropping that key from the select - so the one missing
+ * flag failed the entire request, and the page rendered nothing at all. Every
+ * caller hit it, up to and including ProjectOwner, which is why deleting the
+ * schedule and re-creating it changed nothing: no row was ever the problem.
+ *
+ * WHAT THESE TESTS PIN.
+ *
+ * The two select shapes the UI actually sends, verbatim, so a select edited in
+ * the components without a matching model flag fails here (first describe).
+ * That the flag is the only thing that moved - the sibling columns on the same
+ * model, deep relations and unknown columns all still refuse, and a direct
+ * non-relation read is still governed by column permissions (third and fourth
+ * describes). And the deliberate cost of the flag, stated rather than skipped
+ * over: it bypasses the related column's own read list, exactly as `name`
+ * already did (fifth describe).
+ */
+
+const projectId: ObjectID = ObjectID.generate();
+const userId: ObjectID = ObjectID.generate();
+
+/*
+ * Fresh props per assertion: DatabaseCommonInteractionPropsUtil MUTATES what it
+ * is handed, pushing the auto-granted Public and CurrentUser onto the list, so
+ * a shared object carries state between tests.
+ */
+function makeProps(
+  permissions: Array<Permission>,
+): DatabaseCommonInteractionProps {
+  return {
+    userId: userId,
+    tenantId: projectId,
+    userTenantAccessPermission: {
+      [projectId.toString()]: {
+        projectId: projectId,
+        permissions: permissions.map((permission: Permission) => {
+          return {
+            permission: permission,
+            labelIds: [],
+            isBlockPermission: false,
+            _type: "UserPermission" as const,
+          };
+        }),
+        _type: "UserTenantAccessPermission",
+      },
+    },
+  };
+}
+
+function checkRelationSelect(
+  select: Select<OnCallDutyPolicyEscalationRuleSchedule>,
+  props: DatabaseCommonInteractionProps,
+): void {
+  QueryPermission.checkRelationQueryPermission(
+    OnCallDutyPolicyEscalationRuleSchedule,
+    {} as Query<OnCallDutyPolicyEscalationRuleSchedule>,
+    select,
+    props,
+  );
+}
+
+/*
+ * The select copied out of
+ * App/FeatureSet/Dashboard/src/Components/OnCallPolicy/EscalationRule/EscalationRules.tsx.
+ * Kept as a literal rather than imported so that changing the component
+ * without changing the model surfaces here as a failure.
+ */
+const ESCALATION_RULES_SELECT: Select<OnCallDutyPolicyEscalationRuleSchedule> =
+  {
+    _id: true,
+    onCallDutyPolicyEscalationRuleId: true,
+    onCallDutyPolicySchedule: {
+      _id: true,
+      name: true,
+      currentUserIdOnRoster: true,
+    },
+  } as Select<OnCallDutyPolicyEscalationRuleSchedule>;
+
+/*
+ * The select copied out of
+ * App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallPolicySummary.tsx.
+ */
+const POLICY_SUMMARY_SELECT: Select<OnCallDutyPolicyEscalationRuleSchedule> = {
+  _id: true,
+  onCallDutyPolicyEscalationRuleId: true,
+  onCallDutyPolicySchedule: {
+    _id: true,
+    name: true,
+    currentUserIdOnRoster: true,
+  },
+} as Select<OnCallDutyPolicyEscalationRuleSchedule>;
+
+describe("On-call schedule relation select - the reported failure", () => {
+  it("accepts the escalation rules page select", () => {
+    expect(() => {
+      return checkRelationSelect(
+        ESCALATION_RULES_SELECT,
+        makeProps([Permission.ProjectOwner]),
+      );
+    }).not.toThrow();
+  });
+
+  it("accepts the policy summary select", () => {
+    expect(() => {
+      return checkRelationSelect(
+        POLICY_SUMMARY_SELECT,
+        makeProps([Permission.ProjectOwner]),
+      );
+    }).not.toThrow();
+  });
+
+  it("no longer raises the reported message for any caller", () => {
+    /*
+     * The reporter was a project owner and re-created the schedule twice. The
+     * throw was in the permission layer and had nothing to do with the row, so
+     * pin it across the whole read list rather than for one role.
+     */
+    const readers: Array<Permission> = [
+      Permission.ProjectOwner,
+      Permission.ProjectAdmin,
+      Permission.ProjectMember,
+      Permission.Viewer,
+      Permission.OnCallAdmin,
+      Permission.OnCallMember,
+      Permission.OnCallViewer,
+      Permission.ReadProjectOnCallDutyPolicyEscalationRuleSchedule,
+    ];
+
+    for (const permission of readers) {
+      expect(() => {
+        return checkRelationSelect(
+          ESCALATION_RULES_SELECT,
+          makeProps([permission]),
+        );
+      }).not.toThrow();
+    }
+  });
+
+  it("accepts the roster column selected on its own", () => {
+    // Without `name` alongside it, in case the component drops the label later.
+    expect(() => {
+      return checkRelationSelect(
+        {
+          onCallDutyPolicySchedule: {
+            currentUserIdOnRoster: true,
+          },
+        } as Select<OnCallDutyPolicyEscalationRuleSchedule>,
+        makeProps([Permission.ProjectMember]),
+      );
+    }).not.toThrow();
+  });
+});
+
+describe("On-call schedule relation select - through the full permission stack", () => {
+  /*
+   * checkRelationQueryPermission is one of several gates BasePermission runs
+   * over a read, and the escalation rule page reaches it through all of them.
+   * Tenant and user scoping need a database, so they are stubbed; every
+   * permission gate on the select path is left real.
+   */
+  beforeEach(() => {
+    jest
+      .spyOn(PublicPermission, "checkIfUserIsLoggedIn")
+      .mockImplementation(() => {});
+    jest
+      .spyOn(TenantPermission, "addTenantScopeToQuery")
+      .mockImplementation(async (_modelType: any, query: any) => {
+        return query;
+      });
+    jest
+      .spyOn(UserPermissions, "addUserScopeToQuery")
+      .mockImplementation(async (_modelType: any, query: any) => {
+        return query;
+      });
+    jest
+      .spyOn(TablePermission, "checkTableLevelPermissions")
+      .mockImplementation(() => {});
+    jest
+      .spyOn(AccessControlPermission, "addAccessControlIdsToQuery")
+      .mockImplementation(async (_modelType: any, query: any) => {
+        return query;
+      });
+    jest
+      .spyOn(OwnedScopePermission, "addOwnedScopeToQuery")
+      .mockImplementation(async (_modelType: any, query: any) => {
+        return query;
+      });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("lets the escalation rule read through checkPermissions", async () => {
+    await expect(
+      BasePermission.checkPermissions(
+        OnCallDutyPolicyEscalationRuleSchedule,
+        { onCallDutyPolicyId: ObjectID.generate() } as any,
+        ESCALATION_RULES_SELECT,
+        makeProps([Permission.ProjectOwner]),
+        DatabaseRequestType.Read,
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("actually reaches the relation gate on that path", async () => {
+    /*
+     * Guards the test above from passing because the gate was skipped rather
+     * than because it allowed the select.
+     */
+    const spy: jest.SpyInstance = jest.spyOn(
+      QueryPermission,
+      "checkRelationQueryPermission",
+    );
+
+    await BasePermission.checkPermissions(
+      OnCallDutyPolicyEscalationRuleSchedule,
+      { onCallDutyPolicyId: ObjectID.generate() } as any,
+      ESCALATION_RULES_SELECT,
+      makeProps([Permission.ProjectOwner]),
+      DatabaseRequestType.Read,
+    );
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("still runs the top-level select gate on that path", async () => {
+    const spy: jest.SpyInstance = jest.spyOn(
+      SelectPermission,
+      "checkSelectPermission",
+    );
+
+    await BasePermission.checkPermissions(
+      OnCallDutyPolicyEscalationRuleSchedule,
+      { onCallDutyPolicyId: ObjectID.generate() } as any,
+      ESCALATION_RULES_SELECT,
+      makeProps([Permission.ProjectOwner]),
+      DatabaseRequestType.Read,
+    );
+
+    expect(spy).toHaveBeenCalled();
+  });
+});
+
+describe("On-call schedule relation select - the model flag itself", () => {
+  const schedule: BaseModel = new OnCallDutyPolicySchedule();
+
+  function metadata(columnName: string): TableColumnMetadata {
+    return schedule.getTableColumnMetadata(columnName);
+  }
+
+  it("marks currentUserIdOnRoster readable through a relation", () => {
+    expect(metadata("currentUserIdOnRoster").canReadOnRelationQuery).toBe(true);
+  });
+
+  it("keeps it an ObjectID column, not an entity", () => {
+    /*
+     * The relation traversal only recurses into Entity columns. If this column
+     * ever became one, `currentUserIdOnRoster: true` would stop being a leaf
+     * select and the flag would no longer be what is being tested.
+     */
+    expect(metadata("currentUserIdOnRoster").type).toBe(
+      TableColumnType.ObjectID,
+    );
+  });
+
+  it("puts it alongside the columns the join already exposed", () => {
+    expect(metadata("name").canReadOnRelationQuery).toBe(true);
+    expect(metadata("projectId").canReadOnRelationQuery).toBe(true);
+  });
+
+  it("does not mark it owner-only", () => {
+    /*
+     * canReadOnRelationQuery runs AFTER the owner-only gate in
+     * checkRelationQueryPermission and cannot override it. Marking this column
+     * @OwnerOnlyColumn later would silently re-break the page, so state the
+     * expectation here.
+     */
+    expect(isOwnerOnlyColumn(schedule, "currentUserIdOnRoster")).toBe(false);
+  });
+
+  it("leaves the rest of the schedule's columns alone", () => {
+    /*
+     * The fix is one flag on one column, not a widening of the model. Every
+     * column below is still unreadable through a relation.
+     */
+    const stillClosed: Array<string> = [
+      "description",
+      "timezone",
+      "slug",
+      "nextUserIdOnRoster",
+      "rosterHandoffAt",
+      "rosterNextHandoffAt",
+      "rosterNextStartAt",
+      "rosterStartAt",
+      "createdByUserId",
+      "deletedByUserId",
+    ];
+
+    for (const columnName of stillClosed) {
+      expect(metadata(columnName)).toBeTruthy();
+      expect(Boolean(metadata(columnName).canReadOnRelationQuery)).toBe(false);
+    }
+  });
+});
+
+describe("On-call schedule relation select - what still refuses", () => {
+  const props: DatabaseCommonInteractionProps = makeProps([
+    Permission.ProjectOwner,
+  ]);
+
+  it("refuses a sibling column that was never flagged", () => {
+    expect(() => {
+      return checkRelationSelect(
+        {
+          onCallDutyPolicySchedule: {
+            name: true,
+            timezone: true,
+          },
+        } as Select<OnCallDutyPolicyEscalationRuleSchedule>,
+        makeProps([Permission.ProjectOwner]),
+      );
+    }).toThrow(BadDataException);
+  });
+
+  it("refuses the next-on-roster column", () => {
+    /*
+     * The neighbouring column, same shape, same model, one line away in the
+     * source. Only the column the page needs was opened.
+     */
+    expect(() => {
+      return checkRelationSelect(
+        {
+          onCallDutyPolicySchedule: {
+            nextUserIdOnRoster: true,
+          },
+        } as Select<OnCallDutyPolicyEscalationRuleSchedule>,
+        makeProps([Permission.ProjectOwner]),
+      );
+    }).toThrow(
+      "Column nextUserIdOnRoster on On-Call Policy Schedule does not support read on relation query.",
+    );
+  });
+
+  it("refuses a deep relation hung off the roster user", () => {
+    /*
+     * currentUserOnRoster is the entity beside the id column. Walking into it
+     * would reach the User table; deep relations are refused before any column
+     * check happens.
+     */
+    expect(() => {
+      return checkRelationSelect(
+        {
+          onCallDutyPolicySchedule: {
+            currentUserOnRoster: { email: true },
+          },
+        } as unknown as Select<OnCallDutyPolicyEscalationRuleSchedule>,
+        props,
+      );
+    }).toThrow(
+      "You cannot query deep relations. Querying deep relations is not supported.",
+    );
+  });
+
+  it("refuses a column that does not exist on the schedule", () => {
+    expect(() => {
+      return checkRelationSelect(
+        {
+          onCallDutyPolicySchedule: {
+            currentUserIdOnRosterr: true,
+          },
+        } as unknown as Select<OnCallDutyPolicyEscalationRuleSchedule>,
+        props,
+      );
+    }).toThrow(BadDataException);
+  });
+
+  it("still refuses a direct read of the column without permission", () => {
+    /*
+     * The flag governs the relation gate only. Selecting the column at the top
+     * level of a schedule query goes through SelectPermission, which reads the
+     * column's own @ColumnAccessControl list - and a caller holding none of
+     * those permissions is refused exactly as before.
+     */
+    expect(() => {
+      return SelectPermission.checkSelectPermission(
+        OnCallDutyPolicySchedule,
+        { currentUserIdOnRoster: true } as Select<OnCallDutyPolicySchedule>,
+        makeProps([Permission.ProjectUser]),
+      );
+    }).toThrow(NotAuthorizedException);
+  });
+
+  it("allows the direct read for a caller who does hold the permission", () => {
+    expect(() => {
+      return SelectPermission.checkSelectPermission(
+        OnCallDutyPolicySchedule,
+        { currentUserIdOnRoster: true } as Select<OnCallDutyPolicySchedule>,
+        makeProps([Permission.ReadProjectOnCallDutyPolicySchedule]),
+      );
+    }).not.toThrow();
+  });
+});
+
+describe("On-call schedule relation select - the cost of the flag", () => {
+  /*
+   * canReadOnRelationQuery short-circuits the related column's own read list -
+   * that is what the flag DOES, and it is why the model comment argues the case
+   * rather than leaving the flag bare. Pinned here so the tradeoff is visible
+   * and deliberate instead of being discovered later.
+   */
+
+  it("exposes the roster id to a caller scoped only to the join table", () => {
+    /*
+     * ReadProjectOnCallDutyPolicyEscalationRuleSchedule is not on the schedule
+     * column's own read list. Through the join it reads anyway - as it already
+     * did for the schedule's name.
+     */
+    const joinOnlyProps: DatabaseCommonInteractionProps = makeProps([
+      Permission.ReadProjectOnCallDutyPolicyEscalationRuleSchedule,
+    ]);
+
+    expect(() => {
+      return checkRelationSelect(
+        {
+          onCallDutyPolicySchedule: {
+            name: true,
+            currentUserIdOnRoster: true,
+          },
+        } as Select<OnCallDutyPolicyEscalationRuleSchedule>,
+        joinOnlyProps,
+      );
+    }).not.toThrow();
+  });
+
+  it("is the same route the schedule name already took", () => {
+    /*
+     * If `name` alone ever started refusing for this caller, the paragraph
+     * above stops being true and the flag would need re-arguing.
+     */
+    expect(() => {
+      return checkRelationSelect(
+        {
+          onCallDutyPolicySchedule: { name: true },
+        } as Select<OnCallDutyPolicyEscalationRuleSchedule>,
+        makeProps([
+          Permission.ReadProjectOnCallDutyPolicyEscalationRuleSchedule,
+        ]),
+      );
+    }).not.toThrow();
+  });
+
+  it("does not let that caller reach anything else on the schedule", () => {
+    expect(() => {
+      return checkRelationSelect(
+        {
+          onCallDutyPolicySchedule: { description: true },
+        } as Select<OnCallDutyPolicyEscalationRuleSchedule>,
+        makeProps([
+          Permission.ReadProjectOnCallDutyPolicyEscalationRuleSchedule,
+        ]),
+      );
+    }).toThrow(BadDataException);
+  });
+});


### PR DESCRIPTION
## The report

> For On-Call Policy, there is an issue when making escalation rules:
> `Column currentUserIdOnRoster on On-Call Policy Schedule does not support read on relation query.`
> I deleted it and re-created it with the same issue

Valid, and reproduced. Deleting and re-creating the schedule could never have helped — the throw is in the permission layer and no row was ever the problem.

## Cause

The escalation rule page lists the schedules attached to each rule and marks the ones that would currently page nobody. It reads that state off the join:

```ts
modelType: OnCallDutyPolicyEscalationRuleSchedule
select: { onCallDutyPolicySchedule: { name, currentUserIdOnRoster } }
```

`name` carries `canReadOnRelationQuery`. `currentUserIdOnRoster` did not — and [`QueryPermission.checkRelationQueryPermission`](Common/Server/Types/Database/Permissions/QueryPermission.ts:121) **throws** on the first unflagged inner key rather than dropping it from the select. One missing flag failed the entire request, so the page rendered nothing. Every caller hit it, up to and including `ProjectOwner`.

Two call sites were affected: [EscalationRules.tsx](App/FeatureSet/Dashboard/src/Components/OnCallPolicy/EscalationRule/EscalationRules.tsx:657) and [OnCallPolicySummary.tsx](App/FeatureSet/Dashboard/src/Components/OnCallPolicy/OnCallPolicySummary.tsx:123).

## Fix

Flag the column, alongside `name` and `projectId` on the same model.

The flag bypasses the related column's own read list — that is what it does, and the model comment argues the case rather than leaving it bare. The disclosure is a user id from the same project, to a caller already reading the schedule's name off the same joined row. It is deliberately not an `@OwnerOnlyColumn`: who is on call is operational state the team is meant to see, not a personal credential.

## Tests

**[OnCallScheduleRelationSelect.test.ts](Common/Tests/Server/Types/Database/Permissions/OnCallScheduleRelationSelect.test.ts)** — 21 tests. The two select shapes the UI sends, verbatim, across the whole read list and through the full `BasePermission` stack (including assertions that the relation gate is actually reached, so the pass can't come from a skipped check). Guards that the flag was the only thing that moved: sibling columns, `nextUserIdOnRoster`, deep relations and unknown columns all still refuse, and a direct non-relation read is still governed by column permissions. The flag's cost is pinned in its own describe rather than skipped over.

Verified as a real regression test: **9 of the 21 fail without the fix**; the 12 guard/negative tests pass either way.

**[RelationSelectColumnsWiring.test.ts](App/Tests/Dashboard/RelationSelectColumnsWiring.test.ts)** — the class of bug, not just this instance. Nothing caught this at compile time: `Select<TBaseModel>` makes every column spellable in a relation select and only the runtime knows which are reachable, so the first report came from a user staring at a blank page. This test parses every production `modelType`/`select` pair, walks each nested relation, and resolves the inner columns against the model metadata the server actually uses.

It flags exactly the two broken call sites before the fix — with file, line and the remedy — and is clean after. It swept 352 relation-selected columns across the repo and found no others.

## Checks

- `npm run fix` — clean (one pre-existing unrelated error in `MobileApp/src/__tests__/appConfig.test.ts`, untouched here)
- `Common`: compiles; 694 permission tests, 319 model/service tests pass
- `App`: 5812 Dashboard tests pass

One pre-existing failure, `App/Tests/Dashboard/RecommendationFilterUtil.test.ts`, is a local git-worktree artifact — `App/node_modules/Common` symlinks to the main checkout, giving `Common` types two identities. It fails identically with these changes stashed and does not occur in CI.