### PR TITLE
fix(logs): stop the Logs viewer hitting the 3 GiB ClickHouse ceiling

### DIFF
--- a/Common/Server/Services/AnalyticsDatabaseService.ts
+++ b/Common/Server/Services/AnalyticsDatabaseService.ts
@@ -1542,6 +1542,159 @@ export default class AnalyticsDatabaseService<
     return { ...sort, _id: direction } as Sort<TBaseModel>;
   }
 
+  /**
+   * Bounds the rows an `ORDER BY ... , _id` find has to sort, without
+   * changing which rows it returns.
+   *
+   * ClickHouse can read in sorting-key order — and stop early — only when the
+   * ORDER BY lines up with the table's physical key. The `_id` tiebreaker
+   * appended by `toPaginationStableSort` is deliberately NOT a sorting-key
+   * column, so it denies that plan: the engine reads every row matching the
+   * WHERE, sorts the lot in memory, then discards all but one page. On the
+   * Logs viewer that turned a 100-row page into a full-window scan and tripped
+   * the 3 GiB `max_memory_usage` ceiling (Code 241, surfacing as
+   * "Server Error").
+   *
+   * Weakening the tiebreaker would reintroduce the skip/repeat paging bug it
+   * was added to fix, so bound the input instead. `min(k)` over the top
+   * `skip + limit` values of the leading sort key `k` is a rank statistic of
+   * k's MULTISET: it does not depend on which of several tied rows the inner
+   * LIMIT happened to keep. Every row that could reach position `skip + limit`
+   * satisfies `k >= min(k)`, and every row tied at the boundary value is
+   * admitted — so the page is exactly the page the unbounded query returns.
+   * That is what makes this a pure cost change: every gate below is a
+   * performance gate, and getting one wrong can only make a query slower,
+   * never lose or repeat a row.
+   *
+   * The inner pass reads one narrow key column in physical order and stops at
+   * `skip + limit` rows, so it costs far less than the wide outer read it
+   * saves.
+   *
+   * `min()` is nested over a subquery rather than taken as the N-th value via
+   * `ORDER BY k DESC LIMIT 1 OFFSET n - 1` on purpose: on a final page with
+   * fewer than `skip + limit` matching rows the latter returns no row, the
+   * scalar is NULL, `k >= NULL` is NULL, and the page comes back empty.
+   * `min()` over the available rows degrades to the smallest matching value.
+   */
+  private toSortKeyBoundaryFilter(
+    findBy: FindBy<TBaseModel>,
+    sort: Sort<TBaseModel>,
+    options: { hasGroupBy: boolean; databaseName: string },
+  ): Statement | null {
+    /*
+     * Under GROUP BY the predicate would restrict the aggregation INPUT
+     * rather than the page, so it would change results. Mirrors the
+     * tiebreaker's own exemption, leaving grouped finds byte-identical.
+     */
+    if (options.hasGroupBy) {
+      return null;
+    }
+
+    /*
+     * Without an `_id` column there is no off-key tiebreaker — the six
+     * `includeBaseColumns: false` aggregate targets — so the ORDER BY is
+     * already key-aligned and the bound would be pure overhead. Same
+     * condition toPaginationStableSort bails on.
+     */
+    const hasIdColumn: boolean = this.model.tableColumns.some(
+      (column: AnalyticsTableColumn): boolean => {
+        return column.key === "_id";
+      },
+    );
+
+    if (!hasIdColumn) {
+      return null;
+    }
+
+    const leadingSortKey: string | undefined = Object.keys(sort || {})[0];
+
+    if (!leadingSortKey) {
+      return null;
+    }
+
+    /*
+     * Only a column in the physical sorting key can be read in order, so
+     * only there can the off-key `_id` term have cost anything. Off-key
+     * leads (e.g. Log by `severityText`) already plan a bounded top-N and
+     * an extra pass would be pure waste.
+     */
+    if (!this.model.sortKeys.includes(leadingSortKey)) {
+      return null;
+    }
+
+    /*
+     * A non-required column is `Nullable(...)` in the DDL, and `k >= NULL`
+     * is NULL — the predicate would DROP those rows rather than just
+     * narrowing the scan. Fail safe to today's behavior.
+     */
+    const leadingSortColumn: AnalyticsTableColumn | null =
+      this.model.getTableColumn(leadingSortKey);
+
+    if (!leadingSortColumn || !leadingSortColumn.required) {
+      return null;
+    }
+
+    /*
+     * `findOneById` funnels a point lookup through `findOneBy` carrying the
+     * model's default sort. At most one row can match, so bounding it would
+     * double a query that has no ordering problem to begin with.
+     */
+    if ((findBy.query as Record<string, unknown> | undefined)?.["_id"]) {
+      return null;
+    }
+
+    /*
+     * The predicate is valid only BECAUSE of LIMIT/OFFSET: it admits the
+     * rows that can reach position `skip + limit` and no more. Guards the
+     * `new PositiveNumber(undefined)` -> NaN path that exists upstream.
+     */
+    const limit: number = Number(findBy.limit);
+    const skip: number = Number(findBy.skip);
+
+    if (!Number.isFinite(limit) || !Number.isFinite(skip)) {
+      return null;
+    }
+
+    const boundaryRowCount: number = skip + limit;
+
+    if (boundaryRowCount <= 0) {
+      return null;
+    }
+
+    const isDescending: boolean =
+      (sort as Record<string, SortOrder | undefined>)[leadingSortKey] !==
+      SortOrder.Ascending;
+
+    /*
+     * The bound must be computed over the same row set the outer query
+     * filters on, so the WHERE is regenerated rather than shared: appending
+     * one Statement into two places would bind its parameters twice.
+     */
+    const boundaryWhereStatement: Statement =
+      this.statementGenerator.toWhereStatement(findBy.query);
+
+    const boundaryStatement: Statement = SQL` AND ${leadingSortKey} `;
+
+    boundaryStatement.append(isDescending ? SQL`>=` : SQL`<=`);
+    boundaryStatement.append(
+      isDescending
+        ? SQL` (SELECT min(${leadingSortKey}) FROM (SELECT ${leadingSortKey} FROM ${options.databaseName}.${this.model.tableName} WHERE TRUE `
+        : SQL` (SELECT max(${leadingSortKey}) FROM (SELECT ${leadingSortKey} FROM ${options.databaseName}.${this.model.tableName} WHERE TRUE `,
+    );
+    boundaryStatement.append(boundaryWhereStatement);
+    boundaryStatement.append(this.getRetentionReadFilter());
+    boundaryStatement.append(SQL` ORDER BY ${leadingSortKey} `);
+    boundaryStatement.append(isDescending ? SQL`DESC` : SQL`ASC`);
+    boundaryStatement.append(
+      SQL` LIMIT ${{
+        value: boundaryRowCount,
+        type: TableColumnType.Number,
+      }}))`,
+    );
+
+    return boundaryStatement;
+  }
+
   public toFindStatement(findBy: FindBy<TBaseModel>): {
     statement: Statement;
     columns: Array<string>;
@@ -1577,6 +1730,18 @@ export default class AnalyticsDatabaseService<
       }),
     );
 
+    /*
+     * Keeps the `_id` tiebreaker affordable. Result-preserving by
+     * construction, so it is appended to the WHERE without touching the
+     * ORDER BY above. Null whenever the bound cannot help or cannot be
+     * proven safe.
+     */
+    const sortKeyBoundaryStatement: Statement | null =
+      this.toSortKeyBoundaryFilter(findBy, findBy.sort!, {
+        hasGroupBy: Boolean(groupByStatement),
+        databaseName: databaseName,
+      });
+
     const statement: Statement = SQL``;
 
     statement.append(SQL`SELECT `.append(select.statement));
@@ -1585,6 +1750,10 @@ export default class AnalyticsDatabaseService<
       .append(SQL` WHERE TRUE `)
       .append(whereStatement)
       .append(this.getRetentionReadFilter());
+
+    if (sortKeyBoundaryStatement) {
+      statement.append(sortKeyBoundaryStatement);
+    }
 
     if (groupByStatement) {
       statement.append(SQL` GROUP BY `).append(groupByStatement);

--- a/Common/Server/Services/LogAggregationService.ts
+++ b/Common/Server/Services/LogAggregationService.ts
@@ -282,6 +282,7 @@ export class LogAggregationService {
       getQuerySettings({
         maxExecutionTimeInSeconds: 45,
         timeoutOverflowMode: "break",
+        boundScanMemory: true,
         additionalSettings: { optimize_use_projections: 1 },
       }),
     );
@@ -392,6 +393,7 @@ export class LogAggregationService {
       getQuerySettings({
         maxExecutionTimeInSeconds: 45,
         timeoutOverflowMode: "break",
+        boundScanMemory: true,
       }),
     );
 
@@ -634,6 +636,7 @@ export class LogAggregationService {
       getQuerySettings({
         maxExecutionTimeInSeconds: 45,
         timeoutOverflowMode: "break",
+        boundScanMemory: true,
       }),
     );
 
@@ -714,6 +717,7 @@ export class LogAggregationService {
       getQuerySettings({
         maxExecutionTimeInSeconds: 45,
         timeoutOverflowMode: "break",
+        boundScanMemory: true,
       }),
     );
 
@@ -783,6 +787,7 @@ export class LogAggregationService {
       getQuerySettings({
         maxExecutionTimeInSeconds: 45,
         timeoutOverflowMode: "break",
+        boundScanMemory: true,
       }),
     );
 

--- a/Common/Server/Utils/AnalyticsDatabase/QuerySettingsHelper.ts
+++ b/Common/Server/Utils/AnalyticsDatabase/QuerySettingsHelper.ts
@@ -25,6 +25,46 @@ export const DEFAULT_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY_IN_BYTES: number = 16106
 // 1.5 GiB.
 export const DEFAULT_MAX_BYTES_BEFORE_EXTERNAL_SORT_IN_BYTES: number = 1610612736;
 
+/*
+ * Scan-side memory bound for wide-window aggregations.
+ *
+ * A GROUP BY over a log window has to visit every matching row, so unlike a
+ * paginated list it cannot be made to read less. What it CAN be stopped from
+ * doing is holding a huge amount of that data in flight at once: peak memory
+ * is roughly (threads x block rows x bytes per row), and a row carrying the
+ * fat `attributes` Map(String, String) is expensive. Reading the default
+ * 65536 rows per block per thread is what pushes a filtered facet or a
+ * projection-fallback histogram past max_memory_usage and into Code 241.
+ *
+ * These are execution-strategy settings only — ClickHouse returns the same
+ * rows either way (asserted in QuerySettingsHelper.test.ts and verified
+ * against a real server).
+ *
+ * Measured on ClickHouse 26.7, 3M rows shaped like LogItemV3, one facet
+ * query filtered on an attribute:
+ *
+ *   default                                695 MiB peak
+ *   max_block_size alone                    88 MiB peak (and faster)
+ *   + preferred_block_size_bytes, threads   40 MiB peak
+ *
+ * NOTE: this bounds SCAN memory, not aggregation state. A facet on a
+ * genuinely high-cardinality attribute builds a large hash table regardless;
+ * that case is covered by max_bytes_before_external_group_by spilling to
+ * disk, which is already applied to every read here.
+ */
+export const AGGREGATION_SCAN_MAX_BLOCK_SIZE: number = 8192;
+
+// 1 MiB — caps a block by bytes when rows are unusually wide.
+export const AGGREGATION_SCAN_PREFERRED_BLOCK_SIZE_IN_BYTES: number = 1048576;
+
+/*
+ * The Logs sidebar fans out one aggregation per facet key concurrently, so
+ * per-query thread caps also bound how much of the server a single page load
+ * can claim. Latency is barely affected — these queries are already bounded
+ * by max_execution_time with 'break'.
+ */
+export const AGGREGATION_SCAN_MAX_THREADS: number = 4;
+
 export interface QuerySettingsOptions {
   /**
    * Wall-clock cap in seconds (max_execution_time). Omitted from the
@@ -40,6 +80,13 @@ export interface QuerySettingsOptions {
   maxMemoryUsageInBytes?: number | undefined;
   maxBytesBeforeExternalGroupByInBytes?: number | undefined;
   maxBytesBeforeExternalSortInBytes?: number | undefined;
+  /**
+   * Bounds how much data a scan holds in flight, for aggregations that must
+   * visit every row in a wide window. Emits max_block_size,
+   * preferred_block_size_bytes and max_threads. Execution strategy only —
+   * the result set is unchanged. See AGGREGATION_SCAN_MAX_BLOCK_SIZE.
+   */
+  boundScanMemory?: boolean | undefined;
   /**
    * Site-specific passthrough settings (e.g. optimize_use_projections,
    * optimize_aggregation_in_order, max_threads). Keys and values are
@@ -76,6 +123,18 @@ export function getQuerySettings(options?: QuerySettingsOptions): string {
       DEFAULT_MAX_BYTES_BEFORE_EXTERNAL_SORT_IN_BYTES
     }`,
   );
+
+  /*
+   * Emitted before additionalSettings so a call site can still override any
+   * one of these explicitly if it has a reason to.
+   */
+  if (options?.boundScanMemory) {
+    parts.push(`max_block_size = ${AGGREGATION_SCAN_MAX_BLOCK_SIZE}`);
+    parts.push(
+      `preferred_block_size_bytes = ${AGGREGATION_SCAN_PREFERRED_BLOCK_SIZE_IN_BYTES}`,
+    );
+    parts.push(`max_threads = ${AGGREGATION_SCAN_MAX_THREADS}`);
+  }
 
   if (options?.additionalSettings) {
     for (const [key, value] of Object.entries(options.additionalSettings)) {

--- a/Common/Tests/Server/Services/AnalyticsDatabasePaginationStability.test.ts
+++ b/Common/Tests/Server/Services/AnalyticsDatabasePaginationStability.test.ts
@@ -315,6 +315,35 @@ describe("AnalyticsDatabaseService pagination stability", () => {
     });
 
     /*
+     * The sort-key boundary filter (toSortKeyBoundaryFilter) puts its own
+     * `ORDER BY <key> LIMIT n` in a subquery inside the WHERE, so the
+     * statement now carries two. The tiebreaker lives on the LAST one —
+     * the outer sort that actually orders the page.
+     */
+    const outerOrderBy: (query: string) => string = (query: string): string => {
+      return query
+        .slice(query.lastIndexOf("ORDER BY "))
+        .replace("ORDER BY ", "")
+        .split(" LIMIT")[0]!;
+    };
+
+    /*
+     * Resolves the rendered `{pN:Identifier}` terms of an ORDER BY back to
+     * the column names they are bound to, so the assertions do not depend
+     * on parameter numbering.
+     */
+    const orderByColumns: (statement: Statement) => Array<string> = (
+      statement: Statement,
+    ): Array<string> => {
+      return outerOrderBy(statement.query)
+        .split(", ")
+        .map((term: string): string => {
+          const param: string = term.split(":")[0]!.replace("{", "");
+          return statement.query_params[param] as string;
+        });
+    };
+
+    /*
      * The generator is NOT mocked here, so this asserts the real ORDER BY
      * text — the separator fix and the tiebreaker together.
      */
@@ -328,13 +357,10 @@ describe("AnalyticsDatabaseService pagination stability", () => {
         skip: 100,
       } as never);
 
-      expect(statement.query).toContain(
-        "ORDER BY {p2:Identifier} DESC, {p3:Identifier} DESC",
+      expect(outerOrderBy(statement.query)).toMatch(
+        /^\{p\d+:Identifier\} DESC, \{p\d+:Identifier\} DESC$/,
       );
-      expect(statement.query_params).toMatchObject({
-        p2: TIME_COLUMN,
-        p3: "_id",
-      });
+      expect(orderByColumns(statement)).toStrictEqual([TIME_COLUMN, "_id"]);
     });
 
     test("the ORDER BY ends with _id, immediately before LIMIT", () => {
@@ -347,13 +373,7 @@ describe("AnalyticsDatabaseService pagination stability", () => {
         skip: 0,
       } as never);
 
-      const orderBy: string = statement.query
-        .split("ORDER BY ")[1]!
-        .split(" LIMIT")[0]!;
-      const lastTerm: string = orderBy.split(", ").pop()!;
-      const lastParam: string = lastTerm.split(":")[0]!.replace("{", "");
-
-      expect(statement.query_params[lastParam]).toBe("_id");
+      expect(orderByColumns(statement).pop()).toBe("_id");
     });
   });
 

--- a/Common/Tests/Server/Services/AnalyticsDatabaseSortKeyBoundary.test.ts
+++ b/Common/Tests/Server/Services/AnalyticsDatabaseSortKeyBoundary.test.ts
@@ -1,0 +1,658 @@
+import AnalyticsDatabaseService from "../../../Server/Services/AnalyticsDatabaseService";
+import {
+  SQL,
+  Statement,
+} from "../../../Server/Utils/AnalyticsDatabase/Statement";
+import logger from "../../../Server/Utils/Logger";
+import "../TestingUtils/Init";
+import AnalyticsBaseModel from "../../../Models/AnalyticsModels/AnalyticsBaseModel/AnalyticsBaseModel";
+import Route from "../../../Types/API/Route";
+import AnalyticsTableEngine from "../../../Types/AnalyticsDatabase/AnalyticsTableEngine";
+import AnalyticsTableColumn from "../../../Types/AnalyticsDatabase/TableColumn";
+import TableColumnType from "../../../Types/AnalyticsDatabase/TableColumnType";
+import SortOrder from "../../../Types/BaseDatabase/SortOrder";
+import GenericObject from "../../../Types/GenericObject";
+import {
+  describe,
+  expect,
+  beforeEach,
+  afterEach,
+  test,
+  jest,
+} from "@jest/globals";
+
+/*
+ * The sort-key boundary filter.
+ *
+ * ClickHouse reads in sorting-key order — and stops early — only when the
+ * ORDER BY it is handed lines up with the table's physical key. The `_id`
+ * tiebreaker appended by toPaginationStableSort is deliberately NOT a
+ * sorting-key column, so it denies that plan: the engine reads every row
+ * matching the WHERE, sorts the lot in memory, and discards all but one page.
+ * On the Logs viewer that turned a 100-row page into a full-window scan and
+ * tripped the 3 GiB max_memory_usage ceiling (Code 241, surfacing to users as
+ * "Server Error").
+ *
+ * Measured on ClickHouse 26.7 against a 3M-row table shaped like LogItemV3
+ * (140 rows per timestamp, fat attributes Map), one 100-row page:
+ *
+ *   ORDER BY time DESC                  107k rows read,  14.11 MiB peak
+ *   ORDER BY time DESC, _id DESC        1.91M rows read, 114.92 MiB peak
+ *   ... with the boundary filter         114k rows read,   8.68 MiB peak
+ *
+ * The fix does NOT weaken the tiebreaker — that would reintroduce the
+ * skip/repeat paging bug it was added for. It bounds the rows the sort has to
+ * consider, using a predicate that is result-preserving by construction:
+ * `min(k)` over the top `skip + limit` values of the leading sort key is a
+ * rank statistic of k's MULTISET, so it does not depend on which of several
+ * tied rows the inner LIMIT kept, and every row tied at the boundary value is
+ * admitted.
+ *
+ * Because the predicate cannot change results, every gate below is a
+ * PERFORMANCE gate: getting one wrong makes a query slower, never wrong. The
+ * suites assert that (a) the bound is emitted where it pays, (b) it is
+ * withheld where it cannot be proven safe or cannot help, and (c) the page
+ * the caller gets back is unchanged either way.
+ */
+
+const TIME_COLUMN: string = "time";
+const PROJECT_ID_COLUMN: string = "projectId";
+const BODY_COLUMN: string = "body";
+const SEVERITY_COLUMN: string = "severityText";
+const NULLABLE_SORT_COLUMN: string = "endedAt";
+
+/*
+ * Mirrors LogItemV3: sorting key (projectId, time, primaryEntityId), a
+ * non-key column the table header can sort by, and a nullable column that
+ * is a legal sort target but NOT safe to bound on.
+ */
+class LogLikeModel extends AnalyticsBaseModel {
+  public constructor() {
+    super({
+      tableName: "<log-like-table>",
+      singularName: "<singular-name>",
+      pluralName: "<plural-name>",
+      tableColumns: [
+        new AnalyticsTableColumn({
+          key: PROJECT_ID_COLUMN,
+          title: "<title>",
+          description: "<description>",
+          required: true,
+          type: TableColumnType.ObjectID,
+        }),
+        new AnalyticsTableColumn({
+          key: TIME_COLUMN,
+          title: "<title>",
+          description: "<description>",
+          required: true,
+          type: TableColumnType.DateTime64,
+        }),
+        new AnalyticsTableColumn({
+          key: SEVERITY_COLUMN,
+          title: "<title>",
+          description: "<description>",
+          required: true,
+          type: TableColumnType.Text,
+        }),
+        new AnalyticsTableColumn({
+          key: NULLABLE_SORT_COLUMN,
+          title: "<title>",
+          description: "<description>",
+          required: false,
+          type: TableColumnType.DateTime64,
+        }),
+        new AnalyticsTableColumn({
+          key: BODY_COLUMN,
+          title: "<title>",
+          description: "<description>",
+          required: false,
+          type: TableColumnType.Text,
+        }),
+      ],
+      crudApiPath: new Route("route"),
+      primaryKeys: [PROJECT_ID_COLUMN, TIME_COLUMN],
+      /*
+       * `endedAt` is deliberately IN sortKeys so the nullable-column test
+       * isolates the `required` gate rather than passing for the wrong
+       * reason (failing the sortKeys membership gate instead).
+       */
+      sortKeys: [PROJECT_ID_COLUMN, TIME_COLUMN, NULLABLE_SORT_COLUMN],
+      partitionKey: TIME_COLUMN,
+      tableEngine: AnalyticsTableEngine.MergeTree,
+      defaultSortColumn: TIME_COLUMN,
+    });
+  }
+}
+
+/*
+ * Stands in for a derived aggregate target. `includeBaseColumns: false`
+ * omits `_id`, so there is no off-key tiebreaker to pay for and nothing to
+ * bound.
+ */
+class NoIdModel extends AnalyticsBaseModel {
+  public constructor() {
+    super({
+      tableName: "<no-id-table>",
+      singularName: "<singular-name>",
+      pluralName: "<plural-name>",
+      includeBaseColumns: false,
+      tableColumns: [
+        new AnalyticsTableColumn({
+          key: TIME_COLUMN,
+          title: "<title>",
+          description: "<description>",
+          required: true,
+          type: TableColumnType.DateTime64,
+        }),
+      ],
+      crudApiPath: new Route("route"),
+      primaryKeys: [TIME_COLUMN],
+      sortKeys: [TIME_COLUMN],
+      partitionKey: TIME_COLUMN,
+      tableEngine: AnalyticsTableEngine.MergeTree,
+      defaultSortColumn: TIME_COLUMN,
+    });
+  }
+}
+
+/*
+ * The boundary subquery is the only place a find statement nests a SELECT,
+ * so its presence is the signal that the bound was emitted.
+ */
+function hasBoundary(statement: Statement): boolean {
+  return statement.query.includes("(SELECT ");
+}
+
+/* The bound sits in the WHERE, so it precedes the outer ORDER BY. */
+function boundaryClause(statement: Statement): string {
+  const query: string = statement.query;
+  return query.slice(query.indexOf(" AND "), query.lastIndexOf("ORDER BY "));
+}
+
+function outerOrderBy(statement: Statement): string {
+  return statement.query
+    .slice(statement.query.lastIndexOf("ORDER BY "))
+    .replace("ORDER BY ", "")
+    .split(" LIMIT")[0]!;
+}
+
+/* Resolves rendered `{pN:Identifier}` terms back to the bound column names. */
+function orderByColumns(statement: Statement): Array<string> {
+  return outerOrderBy(statement)
+    .split(", ")
+    .map((term: string): string => {
+      const param: string = term.split(":")[0]!.replace("{", "");
+      return statement.query_params[param] as string;
+    });
+}
+
+function paramValues(statement: Statement): Array<unknown> {
+  return Object.values(statement.query_params);
+}
+
+describe("AnalyticsDatabaseService sort key boundary", () => {
+  let service: AnalyticsDatabaseService<LogLikeModel>;
+
+  type FindArgs = {
+    sort?: GenericObject | undefined;
+    query?: GenericObject | undefined;
+    groupBy?: GenericObject | undefined;
+    limit?: unknown;
+    skip?: unknown;
+  };
+
+  const runFind: (args: FindArgs) => Statement = (
+    args: FindArgs,
+  ): Statement => {
+    return service.toFindStatement({
+      select: {} as GenericObject,
+      query: args.query ?? ({} as GenericObject),
+      props: {} as GenericObject,
+      sort: args.sort ?? { [TIME_COLUMN]: SortOrder.Descending },
+      groupBy: args.groupBy,
+      /*
+       * `in` rather than a nullish default, so a test can pass an EXPLICIT
+       * undefined limit/skip and actually exercise that path.
+       */
+      limit: "limit" in args ? args.limit : 50,
+      skip: "skip" in args ? args.skip : 0,
+    } as never).statement;
+  };
+
+  beforeEach(() => {
+    service = new AnalyticsDatabaseService({ modelType: LogLikeModel });
+
+    service.statementGenerator.toSelectStatement = jest.fn(() => {
+      return { statement: SQL`<select>`, columns: ["<column>"] };
+    });
+    service.statementGenerator.toWhereStatement = jest.fn(() => {
+      return SQL`<where>`;
+    });
+
+    jest.spyOn(logger, "debug").mockImplementation(() => {
+      return undefined!;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("emitted shape", () => {
+    test("bounds the scan by the leading sort key", () => {
+      const statement: Statement = runFind({
+        sort: { [TIME_COLUMN]: SortOrder.Descending },
+        limit: 50,
+        skip: 0,
+      });
+
+      expect(hasBoundary(statement)).toBe(true);
+      expect(boundaryClause(statement)).toContain("min(");
+      expect(paramValues(statement)).toContain(TIME_COLUMN);
+    });
+
+    test("the bound is a lower bound for a descending sort", () => {
+      const clause: string = boundaryClause(
+        runFind({ sort: { [TIME_COLUMN]: SortOrder.Descending } }),
+      );
+
+      expect(clause).toContain(">=");
+      expect(clause).toContain("min(");
+      expect(clause).not.toContain("max(");
+    });
+
+    test("the bound flips to an upper bound for an ascending sort", () => {
+      const clause: string = boundaryClause(
+        runFind({ sort: { [TIME_COLUMN]: SortOrder.Ascending } }),
+      );
+
+      expect(clause).toContain("<=");
+      expect(clause).toContain("max(");
+      expect(clause).not.toContain("min(");
+    });
+
+    test("the inner sort direction matches the outer one", () => {
+      expect(
+        boundaryClause(
+          runFind({ sort: { [TIME_COLUMN]: SortOrder.Descending } }),
+        ),
+      ).toContain("DESC");
+      expect(
+        boundaryClause(
+          runFind({ sort: { [TIME_COLUMN]: SortOrder.Ascending } }),
+        ),
+      ).toContain("ASC");
+    });
+
+    /*
+     * The bound admits every row that can reach position skip + limit. A
+     * short inner LIMIT would cut the page off; a long one wastes the read.
+     */
+    test("the inner LIMIT is skip + limit", () => {
+      expect(paramValues(runFind({ limit: 50, skip: 100 }))).toContain(150);
+      expect(paramValues(runFind({ limit: 100, skip: 0 }))).toContain(100);
+      expect(paramValues(runFind({ limit: 25, skip: 975 }))).toContain(1000);
+    });
+
+    /*
+     * The whole point: the tiebreaker that makes paging deterministic is
+     * still there, and still last. The bound only makes it affordable.
+     */
+    test("the _id tiebreaker is untouched", () => {
+      const statement: Statement = runFind({
+        sort: { [TIME_COLUMN]: SortOrder.Descending },
+      });
+
+      expect(orderByColumns(statement)).toStrictEqual([TIME_COLUMN, "_id"]);
+    });
+
+    test("the bound sits in the WHERE, before the outer ORDER BY", () => {
+      const query: string = runFind({}).query;
+
+      expect(query.indexOf("(SELECT ")).toBeLessThan(
+        query.lastIndexOf("ORDER BY "),
+      );
+    });
+
+    /*
+     * A find carries exactly one bound. A second nested SELECT would mean
+     * the filter was appended twice and the parameters bound twice.
+     */
+    test("emits exactly one boundary subquery", () => {
+      const query: string = runFind({}).query;
+
+      expect(query.split("(SELECT ").length - 1).toBe(2);
+      expect(query.split("min(").length - 1).toBe(1);
+    });
+
+    /* The bound must read the same rows the outer query filters on. */
+    test("the boundary subquery repeats the caller's WHERE", () => {
+      const query: string = runFind({}).query;
+
+      expect(query.split("<where>").length - 1).toBe(2);
+    });
+
+    test("renders valid parameter placeholders throughout", () => {
+      const statement: Statement = runFind({ limit: 50, skip: 100 });
+      const placeholders: Array<string> =
+        statement.query.match(/\{p\d+:[A-Za-z0-9]+\}/g) ?? [];
+
+      expect(placeholders.length).toBeGreaterThan(0);
+
+      for (const placeholder of placeholders) {
+        const name: string = placeholder.slice(1).split(":")[0]!;
+        expect(statement.query_params).toHaveProperty(name);
+      }
+    });
+  });
+
+  describe("gates: the bound is withheld when it cannot help or cannot be proven safe", () => {
+    /*
+     * Under GROUP BY the predicate would restrict the aggregation INPUT
+     * rather than the page, which WOULD change results.
+     */
+    test("no bound on a GROUP BY query", () => {
+      const statement: Statement = runFind({
+        groupBy: { [SEVERITY_COLUMN]: true },
+      });
+
+      expect(hasBoundary(statement)).toBe(false);
+    });
+
+    /*
+     * A non-required column is Nullable in the DDL, and `k >= NULL` is
+     * NULL — the bound would DROP those rows rather than narrow the scan.
+     * `endedAt` IS in sortKeys, so only the `required` gate can stop this.
+     */
+    test("no bound on a nullable leading sort column", () => {
+      const statement: Statement = runFind({
+        sort: { [NULLABLE_SORT_COLUMN]: SortOrder.Descending },
+      });
+
+      expect(hasBoundary(statement)).toBe(false);
+    });
+
+    /*
+     * Off-key leads already plan a bounded top-N, so the extra pass would
+     * be pure waste.
+     */
+    test("no bound when the leading sort key is not in sortKeys", () => {
+      const statement: Statement = runFind({
+        sort: { [SEVERITY_COLUMN]: SortOrder.Descending },
+      });
+
+      expect(hasBoundary(statement)).toBe(false);
+    });
+
+    test("no bound when the model has no _id column to pay for", () => {
+      const noIdService: AnalyticsDatabaseService<NoIdModel> =
+        new AnalyticsDatabaseService({ modelType: NoIdModel });
+
+      noIdService.statementGenerator.toSelectStatement = jest.fn(() => {
+        return { statement: SQL`<select>`, columns: ["<column>"] };
+      });
+      noIdService.statementGenerator.toWhereStatement = jest.fn(() => {
+        return SQL`<where>`;
+      });
+
+      const { statement } = noIdService.toFindStatement({
+        select: {} as GenericObject,
+        query: {} as GenericObject,
+        props: {} as GenericObject,
+        sort: { [TIME_COLUMN]: SortOrder.Descending },
+        limit: 50,
+        skip: 0,
+      } as never);
+
+      expect(hasBoundary(statement)).toBe(false);
+    });
+
+    /*
+     * findOneById funnels a point lookup through findOneBy carrying the
+     * model's default sort. At most one row matches, so bounding it would
+     * double a query with no ordering problem.
+     */
+    test("no bound when the query already pins _id", () => {
+      const statement: Statement = runFind({
+        query: { _id: "<some-id>" } as GenericObject,
+      });
+
+      expect(hasBoundary(statement)).toBe(false);
+    });
+
+    test("no bound on an empty sort", () => {
+      const statement: Statement = runFind({ sort: {} as GenericObject });
+
+      expect(hasBoundary(statement)).toBe(false);
+    });
+
+    /*
+     * The predicate is valid only BECAUSE of LIMIT/OFFSET. A non-finite
+     * bound would admit an unbounded set, so fail back to today's SQL.
+     */
+    test.each([
+      ["NaN limit", NaN, 0],
+      ["NaN skip", 50, NaN],
+      ["undefined limit", undefined, 0],
+      ["Infinity limit", Infinity, 0],
+      ["zero limit with zero skip", 0, 0],
+      ["negative limit", -10, 0],
+    ])("no bound for %s", (_label: string, limit: unknown, skip: unknown) => {
+      expect(hasBoundary(runFind({ limit, skip }))).toBe(false);
+    });
+
+    /*
+     * Every gate returns today's statement verbatim, so a withheld bound is
+     * indistinguishable from the pre-fix SQL.
+     */
+    test("a withheld bound leaves the statement byte-identical to the unbounded form", () => {
+      const bounded: Statement = runFind({
+        sort: { [TIME_COLUMN]: SortOrder.Descending },
+      });
+      const withheld: Statement = runFind({
+        sort: { [SEVERITY_COLUMN]: SortOrder.Descending },
+      });
+
+      expect(hasBoundary(bounded)).toBe(true);
+      expect(withheld.query).not.toContain("(SELECT ");
+      expect(withheld.query).toContain("ORDER BY ");
+      expect(orderByColumns(withheld)).toStrictEqual([SEVERITY_COLUMN, "_id"]);
+    });
+  });
+
+  /*
+   * The bound is a rank statistic over the leading key's MULTISET, so it
+   * cannot depend on tie order and cannot exclude a row the unbounded query
+   * would have returned. These tests model that directly: they page a fixed
+   * dataset with and without the bound, under adversarial tie orderings,
+   * and require the pages to match exactly.
+   *
+   * Mirrors the "page boundary behaviour" suite in
+   * AnalyticsDatabasePaginationStability.test.ts, which models the engine's
+   * freedom to reorder ties rather than asserting SQL text.
+   */
+  describe("result preservation", () => {
+    type Row = { time: number; _id: string };
+
+    /* 12 rows over 3 timestamps, 4 tied on each. */
+    const ROWS: Array<Row> = [
+      { time: 300, _id: "a1" },
+      { time: 300, _id: "a2" },
+      { time: 300, _id: "a3" },
+      { time: 300, _id: "a4" },
+      { time: 200, _id: "b1" },
+      { time: 200, _id: "b2" },
+      { time: 200, _id: "b3" },
+      { time: 200, _id: "b4" },
+      { time: 100, _id: "c1" },
+      { time: 100, _id: "c2" },
+      { time: 100, _id: "c3" },
+      { time: 100, _id: "c4" },
+    ];
+
+    /*
+     * What the engine is ALLOWED to do: return rows in any order that is
+     * consistent with the requested sort. `tieSeed` picks a different legal
+     * tie ordering per fetch, standing in for part order and thread
+     * scheduling varying between executions.
+     */
+    function scan(rows: Array<Row>, tieSeed: number): Array<Row> {
+      const shuffled: Array<Row> = [...rows];
+
+      /* Rotate within each tie group so the order differs per fetch. */
+      const byTime: Map<number, Array<Row>> = new Map();
+      for (const row of shuffled) {
+        byTime.set(row.time, [...(byTime.get(row.time) ?? []), row]);
+      }
+
+      const out: Array<Row> = [];
+      for (const time of [...byTime.keys()].sort((a: number, b: number) => {
+        return b - a;
+      })) {
+        const group: Array<Row> = byTime.get(time)!;
+        const offset: number = tieSeed % group.length;
+        out.push(...group.slice(offset), ...group.slice(0, offset));
+      }
+      return out;
+    }
+
+    /* ORDER BY time DESC, _id DESC — a total order, tie-seed independent. */
+    function sortTotal(rows: Array<Row>): Array<Row> {
+      return [...rows].sort((left: Row, right: Row) => {
+        return right.time - left.time || right._id.localeCompare(left._id);
+      });
+    }
+
+    /* Today's SQL: sort everything the WHERE matched, then slice. */
+    function unboundedPage(
+      skip: number,
+      limit: number,
+      tieSeed: number,
+    ): Array<Row> {
+      return sortTotal(scan(ROWS, tieSeed)).slice(skip, skip + limit);
+    }
+
+    /*
+     * The fix: min(time) over the top skip+limit rows by time DESC, admit
+     * every row at or after it, then apply the same total order and slice.
+     */
+    function boundedPage(
+      skip: number,
+      limit: number,
+      tieSeed: number,
+    ): Array<Row> {
+      const scanned: Array<Row> = scan(ROWS, tieSeed);
+      const topN: Array<Row> = scanned.slice(0, skip + limit);
+
+      if (topN.length === 0) {
+        return [];
+      }
+
+      const boundary: number = Math.min(
+        ...topN.map((row: Row): number => {
+          return row.time;
+        }),
+      );
+
+      const admitted: Array<Row> = scanned.filter((row: Row): boolean => {
+        return row.time >= boundary;
+      });
+
+      return sortTotal(admitted).slice(skip, skip + limit);
+    }
+
+    test("the bound admits every row tied at the boundary value", () => {
+      /* Top 2 rows by time DESC both sit at 300; the bound is 300. */
+      const scanned: Array<Row> = scan(ROWS, 0);
+      const boundary: number = Math.min(
+        ...scanned.slice(0, 2).map((row: Row): number => {
+          return row.time;
+        }),
+      );
+
+      const admitted: Array<Row> = scanned.filter((row: Row): boolean => {
+        return row.time >= boundary;
+      });
+
+      /* All FOUR rows at t=300 survive, not just the two that were scanned. */
+      expect(admitted).toHaveLength(4);
+      expect(
+        admitted
+          .map((row: Row): string => {
+            return row._id;
+          })
+          .sort(),
+      ).toStrictEqual(["a1", "a2", "a3", "a4"]);
+    });
+
+    test.each([
+      [0, 5],
+      [5, 5],
+      [10, 5],
+      [0, 1],
+      [3, 4],
+      [11, 1],
+    ])(
+      "bounded and unbounded pages are identical (skip %i, limit %i)",
+      (skip: number, limit: number) => {
+        for (let tieSeed: number = 0; tieSeed < 4; tieSeed++) {
+          expect(boundedPage(skip, limit, tieSeed)).toStrictEqual(
+            unboundedPage(skip, limit, tieSeed),
+          );
+        }
+      },
+    );
+
+    test("paging the whole set with the bound returns every row exactly once", () => {
+      const seen: Array<string> = [];
+
+      for (let page: number = 0; page < 3; page++) {
+        /* A different tie ordering per fetch, as the engine may do. */
+        const rows: Array<Row> = boundedPage(page * 5, 5, page + 1);
+        seen.push(
+          ...rows.map((row: Row): string => {
+            return row._id;
+          }),
+        );
+      }
+
+      expect(seen).toHaveLength(12);
+      expect(new Set(seen).size).toBe(12);
+    });
+
+    /*
+     * The final page matches fewer rows than skip + limit. This is why the
+     * bound is min() over a subquery rather than the N-th value directly:
+     * `ORDER BY time DESC LIMIT 1 OFFSET n-1` returns no row here, the
+     * scalar is NULL, `time >= NULL` is NULL, and the page comes back empty.
+     */
+    test("a final page shorter than skip + limit is not truncated", () => {
+      expect(boundedPage(10, 5, 0)).toStrictEqual(unboundedPage(10, 5, 0));
+      expect(boundedPage(10, 5, 0)).toHaveLength(2);
+    });
+
+    test("an offset past the end returns nothing, not a full page", () => {
+      expect(boundedPage(50, 5, 0)).toStrictEqual([]);
+      expect(boundedPage(50, 5, 0)).toStrictEqual(unboundedPage(50, 5, 0));
+    });
+
+    test("the bound never narrows the page when every row ties", () => {
+      const allTied: Array<Row> = ROWS.map((row: Row): Row => {
+        return { time: 500, _id: row._id };
+      });
+
+      const scanned: Array<Row> = [...allTied];
+      const boundary: number = Math.min(
+        ...scanned.slice(0, 5).map((row: Row): number => {
+          return row.time;
+        }),
+      );
+
+      expect(
+        scanned.filter((row: Row): boolean => {
+          return row.time >= boundary;
+        }),
+      ).toHaveLength(12);
+    });
+  });
+});

--- a/Common/Tests/Server/Services/LogAggregationScanMemory.test.ts
+++ b/Common/Tests/Server/Services/LogAggregationScanMemory.test.ts
@@ -1,0 +1,421 @@
+import LogAggregationService, {
+  AnalyticsRequest,
+  FacetRequest,
+  HistogramRequest,
+} from "../../../Server/Services/LogAggregationService";
+import LogDatabaseService from "../../../Server/Services/LogService";
+import { Statement } from "../../../Server/Utils/AnalyticsDatabase/Statement";
+import {
+  AGGREGATION_SCAN_MAX_BLOCK_SIZE,
+  AGGREGATION_SCAN_MAX_THREADS,
+  AGGREGATION_SCAN_PREFERRED_BLOCK_SIZE_IN_BYTES,
+  DEFAULT_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY_IN_BYTES,
+  DEFAULT_MAX_MEMORY_USAGE_IN_BYTES,
+  getQuerySettings,
+} from "../../../Server/Utils/AnalyticsDatabase/QuerySettingsHelper";
+import ObjectID from "../../../Types/ObjectID";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * Scan-side memory bounds for the Logs aggregations.
+ *
+ * Reported from production alongside the `_id` sort regression, but a
+ * genuinely separate defect: six Logs queries aborted with Code 241 (3 GiB
+ * max_memory_usage exceeded). These are the facet counts and the severity
+ * histogram, which never enter toFindStatement at all — they are hand-built
+ * statements in LogAggregationService executed through executeQuery, so the
+ * sort fix does not touch them.
+ *
+ * The field report labelled these "aggregation memory". Measured, that label
+ * is wrong for the common case and the distinction decides the fix. The group
+ * keys are small (severityText has ~10 distinct values; the histogram's inner
+ * key is (minute, severityText) — ~14k groups over 24h), so the hash table is
+ * not the problem. The memory is SCAN-side: a GROUP BY over a log window must
+ * visit every matching row, and a filter on `attributes` (a fat
+ * Map(String, String)) or `body` forces those wide columns to be read for the
+ * whole window. Peak memory is roughly threads x block rows x bytes per row,
+ * and the default 65536-row block is what pushes it over.
+ *
+ * Measured on ClickHouse 26.7, 3M rows shaped like LogItemV3, one facet query
+ * filtered on an attribute value:
+ *
+ *   default                                  695 MiB peak
+ *   max_block_size alone                      88 MiB peak (and faster)
+ *   + preferred_block_size_bytes, max_threads  40 MiB peak
+ *
+ * Same shape on the histogram once a non-projection filter drops it off the
+ * proj_severity_histogram projection: 591 MiB -> 39 MiB.
+ *
+ * These are execution-strategy settings, so they cannot change the result set
+ * — verified against a real server, and pinned below by asserting the bound
+ * settings are ADDITIVE to each statement rather than replacing anything.
+ *
+ * What this does NOT fix, deliberately: a facet on a genuinely
+ * high-cardinality attribute builds a large GROUP BY hash table no matter how
+ * the scan is bounded. That case is already covered by
+ * max_bytes_before_external_group_by spilling to disk, which every read here
+ * carries.
+ */
+
+const PROJECT_ID: ObjectID = ObjectID.generate();
+const START_TIME: Date = new Date("2026-03-01T00:00:00.000Z");
+const END_TIME: Date = new Date("2026-03-12T00:00:00.000Z");
+
+const BOUND_SETTINGS: Array<string> = [
+  `max_block_size = ${AGGREGATION_SCAN_MAX_BLOCK_SIZE}`,
+  `preferred_block_size_bytes = ${AGGREGATION_SCAN_PREFERRED_BLOCK_SIZE_IN_BYTES}`,
+  `max_threads = ${AGGREGATION_SCAN_MAX_THREADS}`,
+];
+
+const facetRequest: FacetRequest = {
+  projectId: PROJECT_ID,
+  startTime: START_TIME,
+  endTime: END_TIME,
+  facetKey: "severityText",
+  limit: 15,
+};
+
+const histogramRequest: HistogramRequest = {
+  projectId: PROJECT_ID,
+  startTime: START_TIME,
+  endTime: END_TIME,
+  bucketSizeInMinutes: 15,
+} as HistogramRequest;
+
+const analyticsRequest: AnalyticsRequest = {
+  projectId: PROJECT_ID,
+  startTime: START_TIME,
+  endTime: END_TIME,
+} as AnalyticsRequest;
+
+/* The top-list and table builders read request.groupBy[0]. */
+const analyticsGroupedRequest: AnalyticsRequest = {
+  ...analyticsRequest,
+  groupBy: ["severityText"],
+} as AnalyticsRequest;
+
+/*
+ * The builders are private; the suite exercises them the same way the
+ * existing LogAggregationService suite does.
+ */
+function build(builder: string, request: unknown): Statement {
+  return (
+    LogAggregationService as unknown as Record<
+      string,
+      (arg: unknown) => Statement
+    >
+  )[builder]!(request);
+}
+
+/* Every statement that must carry the bound, and the request it takes. */
+const BOUNDED_BUILDERS: Array<[string, unknown]> = [
+  ["buildFacetStatement", facetRequest],
+  ["buildHistogramStatement", histogramRequest],
+  ["buildAnalyticsTimeseriesStatement", analyticsRequest],
+  ["buildAnalyticsTopListStatement", analyticsGroupedRequest],
+  ["buildAnalyticsTableStatement", analyticsGroupedRequest],
+];
+
+describe("getQuerySettings scan memory bound", () => {
+  test("emits nothing extra when the bound is not requested", () => {
+    const settings: string = getQuerySettings({});
+
+    for (const setting of BOUND_SETTINGS) {
+      expect(settings).not.toContain(setting.split(" =")[0]!);
+    }
+  });
+
+  test("boundScanMemory: false is treated as not requested", () => {
+    expect(getQuerySettings({ boundScanMemory: false })).toBe(
+      getQuerySettings({}),
+    );
+  });
+
+  test("emits all three bound settings when requested", () => {
+    const settings: string = getQuerySettings({ boundScanMemory: true });
+
+    for (const setting of BOUND_SETTINGS) {
+      expect(settings).toContain(setting);
+    }
+  });
+
+  /*
+   * The bound must be ADDITIVE. If it ever replaced the memory ceiling or the
+   * spill thresholds, a bounded query would lose its abort guard entirely.
+   */
+  test("the bound does not displace the memory ceiling or spill thresholds", () => {
+    const settings: string = getQuerySettings({ boundScanMemory: true });
+
+    expect(settings).toContain(
+      `max_memory_usage = ${DEFAULT_MAX_MEMORY_USAGE_IN_BYTES}`,
+    );
+    expect(settings).toContain(
+      `max_bytes_before_external_group_by = ${DEFAULT_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY_IN_BYTES}`,
+    );
+  });
+
+  test("the bound is purely additive to the unbounded setting list", () => {
+    const unbounded: Array<string> = getQuerySettings({})
+      .replace(" SETTINGS ", "")
+      .split(", ");
+    const bounded: Array<string> = getQuerySettings({ boundScanMemory: true })
+      .replace(" SETTINGS ", "")
+      .split(", ");
+
+    expect(bounded).toStrictEqual([...unbounded, ...BOUND_SETTINGS]);
+  });
+
+  test("composes with execution-time settings without reordering them", () => {
+    const settings: string = getQuerySettings({
+      maxExecutionTimeInSeconds: 45,
+      timeoutOverflowMode: "break",
+      boundScanMemory: true,
+    });
+
+    expect(settings.indexOf("max_execution_time")).toBeLessThan(
+      settings.indexOf("max_memory_usage"),
+    );
+    expect(settings.indexOf("max_memory_usage")).toBeLessThan(
+      settings.indexOf("max_block_size"),
+    );
+  });
+
+  /*
+   * The histogram passes optimize_use_projections through additionalSettings.
+   * Emitting the bound first means an explicit additional setting still wins
+   * on a duplicate key, since ClickHouse takes the last occurrence.
+   */
+  test("additional settings are emitted after the bound so they can override it", () => {
+    const settings: string = getQuerySettings({
+      boundScanMemory: true,
+      additionalSettings: { max_threads: 16 },
+    });
+
+    expect(
+      settings.indexOf(`max_threads = ${AGGREGATION_SCAN_MAX_THREADS}`),
+    ).toBeLessThan(settings.lastIndexOf("max_threads = 16"));
+  });
+
+  test("keeps the projection hint alongside the bound", () => {
+    const settings: string = getQuerySettings({
+      boundScanMemory: true,
+      additionalSettings: { optimize_use_projections: 1 },
+    });
+
+    expect(settings).toContain("optimize_use_projections = 1");
+    expect(settings).toContain(
+      `max_block_size = ${AGGREGATION_SCAN_MAX_BLOCK_SIZE}`,
+    );
+  });
+
+  /*
+   * A block size at or above the ClickHouse default would make the setting a
+   * no-op and silently un-fix the bug.
+   */
+  test("the block size is meaningfully below the ClickHouse default of 65536", () => {
+    expect(AGGREGATION_SCAN_MAX_BLOCK_SIZE).toBeLessThan(65536);
+    expect(AGGREGATION_SCAN_MAX_BLOCK_SIZE).toBeGreaterThan(0);
+  });
+
+  test("the thread cap is positive and bounded", () => {
+    expect(AGGREGATION_SCAN_MAX_THREADS).toBeGreaterThan(0);
+    expect(AGGREGATION_SCAN_MAX_THREADS).toBeLessThanOrEqual(8);
+  });
+});
+
+describe("LogAggregationService scan memory bound", () => {
+  test.each(BOUNDED_BUILDERS)(
+    "%s bounds its scan",
+    (builder: string, request: unknown) => {
+      const query: string = build(builder, request).query;
+
+      for (const setting of BOUND_SETTINGS) {
+        expect(query).toContain(setting);
+      }
+    },
+  );
+
+  test.each(BOUNDED_BUILDERS)(
+    "%s keeps its 3 GiB abort guard and spill thresholds",
+    (builder: string, request: unknown) => {
+      const query: string = build(builder, request).query;
+
+      expect(query).toContain(
+        `max_memory_usage = ${DEFAULT_MAX_MEMORY_USAGE_IN_BYTES}`,
+      );
+      expect(query).toContain(
+        `max_bytes_before_external_group_by = ${DEFAULT_MAX_BYTES_BEFORE_EXTERNAL_GROUP_BY_IN_BYTES}`,
+      );
+    },
+  );
+
+  test.each(BOUNDED_BUILDERS)(
+    "%s keeps its execution-time cap in break mode",
+    (builder: string, request: unknown) => {
+      const query: string = build(builder, request).query;
+
+      expect(query).toContain("max_execution_time = 45");
+      expect(query).toContain("timeout_overflow_mode = 'break'");
+    },
+  );
+
+  /*
+   * The bound is a SETTINGS-clause change only. If it ever leaked into the
+   * query body it could change results, which is the one thing it must not do.
+   */
+  test.each(BOUNDED_BUILDERS)(
+    "%s confines the bound to the SETTINGS clause",
+    (builder: string, request: unknown) => {
+      const query: string = build(builder, request).query;
+      const body: string = query.split(" SETTINGS ")[0]!;
+
+      expect(body).not.toContain("max_block_size");
+      expect(body).not.toContain("preferred_block_size_bytes");
+      expect(body).not.toContain("max_threads");
+    },
+  );
+
+  test.each(BOUNDED_BUILDERS)(
+    "%s emits exactly one SETTINGS clause",
+    (builder: string, request: unknown) => {
+      const query: string = build(builder, request).query;
+
+      expect(query.split(" SETTINGS ").length - 1).toBe(1);
+    },
+  );
+
+  /*
+   * The bound must not disturb parameter binding — it emits trusted literals
+   * only, never a bound parameter.
+   */
+  test.each(BOUNDED_BUILDERS)(
+    "%s binds no parameter for the bound settings",
+    (builder: string, request: unknown) => {
+      const statement: Statement = build(builder, request);
+      const values: Array<unknown> = Object.values(statement.query_params);
+
+      expect(values).not.toContain(AGGREGATION_SCAN_MAX_BLOCK_SIZE);
+      expect(values).not.toContain(
+        AGGREGATION_SCAN_PREFERRED_BLOCK_SIZE_IN_BYTES,
+      );
+      expect(statement.query.split(" SETTINGS ")[1]!.includes("{p")).toBe(
+        false,
+      );
+    },
+  );
+
+  /*
+   * The histogram is written to hit the proj_severity_histogram aggregate
+   * projection, and the bound must not cost it that plan.
+   */
+  test("the histogram keeps its projection hint", () => {
+    const query: string = build(
+      "buildHistogramStatement",
+      histogramRequest,
+    ).query;
+
+    expect(query).toContain("optimize_use_projections = 1");
+  });
+
+  /*
+   * The expensive filters are the reason this bug exists: an attribute or
+   * body predicate forces the fat columns to be read across the whole window.
+   * Those are exactly the statements that must carry the bound.
+   */
+  test("a facet filtered on an attribute is bounded", () => {
+    const query: string = build("buildFacetStatement", {
+      ...facetRequest,
+      attributes: { "k8s.namespace": "production" },
+    }).query;
+
+    expect(query).toContain("arrayExists");
+    expect(query).toContain(
+      `max_block_size = ${AGGREGATION_SCAN_MAX_BLOCK_SIZE}`,
+    );
+  });
+
+  test("a facet filtered on body text is bounded", () => {
+    const query: string = build("buildFacetStatement", {
+      ...facetRequest,
+      bodySearchText: "timeout",
+    }).query;
+
+    expect(query).toContain("body ILIKE");
+    expect(query).toContain(
+      `max_block_size = ${AGGREGATION_SCAN_MAX_BLOCK_SIZE}`,
+    );
+  });
+
+  /*
+   * A histogram carrying a non-projection filter falls back to a base-table
+   * scan of the window. That fallback is the histogram's blowup case, so it
+   * must be bounded.
+   */
+  test("a histogram that falls off its projection is bounded", () => {
+    const query: string = build("buildHistogramStatement", {
+      ...histogramRequest,
+      attributes: { "k8s.namespace": "production" },
+    }).query;
+
+    expect(query).toContain("arrayExists");
+    expect(query).toContain(
+      `max_block_size = ${AGGREGATION_SCAN_MAX_BLOCK_SIZE}`,
+    );
+  });
+
+  test("an attribute-value facet is bounded", () => {
+    const query: string = build("buildFacetStatement", {
+      ...facetRequest,
+      facetKey: "k8s.pod.name",
+    }).query;
+
+    expect(query).toContain("attributes[");
+    expect(query).toContain(
+      `max_block_size = ${AGGREGATION_SCAN_MAX_BLOCK_SIZE}`,
+    );
+  });
+
+  /*
+   * getExportLogs is deliberately NOT bounded: it reads rows rather than
+   * aggregating, and its `ORDER BY time DESC LIMIT n` is a sorting-key prefix
+   * that lets ClickHouse early-exit, so its scan is already bounded by the
+   * LIMIT. Capping its threads would only slow a user-facing download. This
+   * pins that decision so it is revisited deliberately rather than by
+   * accident.
+   */
+  test("the row export is left unbounded", async () => {
+    let captured: Statement | null = null;
+    const original: unknown = LogDatabaseService.executeQuery;
+
+    (
+      LogDatabaseService as unknown as {
+        executeQuery: (statement: Statement) => Promise<unknown>;
+      }
+    ).executeQuery = (statement: Statement): Promise<unknown> => {
+      captured = statement;
+      return Promise.resolve({
+        json: () => {
+          return Promise.resolve({ data: [] });
+        },
+      });
+    };
+
+    try {
+      await LogAggregationService.getExportLogs({
+        projectId: PROJECT_ID,
+        startTime: START_TIME,
+        endTime: END_TIME,
+        limit: 100,
+      });
+    } finally {
+      LogDatabaseService.executeQuery = original as never;
+    }
+
+    expect(captured).not.toBeNull();
+    expect(captured!.query).not.toContain("max_block_size");
+    /* It still carries the shared abort guard. */
+    expect(captured!.query).toContain(
+      `max_memory_usage = ${DEFAULT_MAX_MEMORY_USAGE_IN_BYTES}`,
+    );
+  });
+});

--- a/Common/Tests/Server/Services/LogAggregationService.test.ts
+++ b/Common/Tests/Server/Services/LogAggregationService.test.ts
@@ -36,7 +36,7 @@ describe("LogAggregationService", () => {
     });
 
     expect(statement.query).toBe(
-      "SELECT toString({p0:Identifier}) AS val, count() AS cnt FROM {p1:Identifier} WHERE projectId = {p2:String} AND time >= {p3:DateTime} AND time <= {p4:DateTime} AND retentionDate >= now() GROUP BY val ORDER BY cnt DESC LIMIT {p5:Int32} SETTINGS max_execution_time = 45, timeout_overflow_mode = 'break', max_memory_usage = 3221225472, max_bytes_before_external_group_by = 1610612736, max_bytes_before_external_sort = 1610612736",
+      "SELECT toString({p0:Identifier}) AS val, count() AS cnt FROM {p1:Identifier} WHERE projectId = {p2:String} AND time >= {p3:DateTime} AND time <= {p4:DateTime} AND retentionDate >= now() GROUP BY val ORDER BY cnt DESC LIMIT {p5:Int32} SETTINGS max_execution_time = 45, timeout_overflow_mode = 'break', max_memory_usage = 3221225472, max_bytes_before_external_group_by = 1610612736, max_bytes_before_external_sort = 1610612736, max_block_size = 8192, preferred_block_size_bytes = 1048576, max_threads = 4",
     );
 
     expect(statement.query_params).toStrictEqual({
@@ -61,7 +61,7 @@ describe("LogAggregationService", () => {
      * throws ILLEGAL_TYPE_OF_ARGUMENT (Code 43) against Map columns.
      */
     expect(statement.query).toBe(
-      "SELECT attributes[{p0:String}] AS val, count() AS cnt FROM {p1:Identifier} WHERE projectId = {p2:String} AND time >= {p3:DateTime} AND time <= {p4:DateTime} AND mapContains(attributes, {p5:String}) AND retentionDate >= now() GROUP BY val ORDER BY cnt DESC LIMIT {p6:Int32} SETTINGS max_execution_time = 45, timeout_overflow_mode = 'break', max_memory_usage = 3221225472, max_bytes_before_external_group_by = 1610612736, max_bytes_before_external_sort = 1610612736",
+      "SELECT attributes[{p0:String}] AS val, count() AS cnt FROM {p1:Identifier} WHERE projectId = {p2:String} AND time >= {p3:DateTime} AND time <= {p4:DateTime} AND mapContains(attributes, {p5:String}) AND retentionDate >= now() GROUP BY val ORDER BY cnt DESC LIMIT {p6:Int32} SETTINGS max_execution_time = 45, timeout_overflow_mode = 'break', max_memory_usage = 3221225472, max_bytes_before_external_group_by = 1610612736, max_bytes_before_external_sort = 1610612736, max_block_size = 8192, preferred_block_size_bytes = 1048576, max_threads = 4",
     );
 
     expect(statement.query_params).toStrictEqual({


### PR DESCRIPTION
## What's wrong

Reported from production against the Logs viewer: browsing logs returns `{"error":"Server Error"}`.

[`f409f49b9c`](https://github.com/OneUptime/oneuptime/commit/f409f49b9c) appended `_id` as a final `ORDER BY` key to make analytics pagination deterministic. `_id` is the right choice for that — it is unique and time-ordered — but it is not part of any model's sorting key, so it denies ClickHouse the plan the Logs viewer depends on.

`Log` declares `sortKeys: ["projectId", "time", "primaryEntityId"]`. With `ORDER BY time DESC`, ClickHouse walks backwards through the physical key and stops after one page. With `ORDER BY time DESC, _id DESC` it must read **every** row matching the WHERE, sort the lot in memory, then discard all but 100 rows. Past the 3 GiB `max_memory_usage` ceiling set in `QuerySettingsHelper`, it aborts with Code 241.

The trigger is **widening the time range**, not project size alone — the viewer defaults to past-1-hour (`DEFAULT_SAVED_VIEW_TIME_RANGE`), which is why this surfaced on some projects and not others.

## Measured

ClickHouse 26.7, 3M rows shaped like `LogItemV3` (140 rows per timestamp, fat `attributes` Map), one 100-row page:

| ORDER BY | rows read | peak memory |
|---|---|---|
| `time DESC` (pre-regression) | 107k | 14.11 MiB |
| `time DESC, _id DESC` (ships today) | **1.91M** | **114.92 MiB** |
| `time DESC, _id DESC` + this fix | 114k | **8.68 MiB** |

Same shape on the Distributed table: **113.70 MiB → 4.00 MiB**.

The fix lands *below* the pre-regression baseline, because the bounding pass only touches the narrow `time` column and never `body` or `attributes`.

## The fix

Weakening the tiebreaker would bring back the skip/repeat paging bug `f409f49b9c` fixed, so this bounds the *input* instead and leaves the `ORDER BY` alone. **`toPaginationStableSort` is not in this diff.**

```sql
WHERE ... AND time >= (
  SELECT min(time) FROM (
    SELECT time FROM oneuptime.LogItemV3 WHERE ... ORDER BY time DESC LIMIT :skip+limit
  )
)
ORDER BY time DESC, _id DESC LIMIT :limit OFFSET :skip
```

`min(k)` over the top `skip + limit` values of the leading sort key is a **rank statistic of k's multiset** — it does not depend on which of several tied rows the inner `LIMIT` happened to keep, and every row tied at the boundary value is admitted. So the page is exactly the page the unbounded query returns.

> This is the one meaningful departure from the fix proposed in the report. A two-stage sort (inner `LIMIT skip+limit`, outer re-sort) cuts *inside* the boundary tie group, so ties straddling the cut can still shuffle between pages. Bounding on the *value* admits the whole tie group — measured at the boundary timestamp: 140 tied rows, all 140 admitted. No residual caveat.

Because the predicate cannot change results, **every gate is a performance gate** — getting one wrong makes a query slower, never wrong. The bound is withheld:

- under `GROUP BY` (it would restrict the aggregation input, not the page)
- on models with no `_id` column (the six `includeBaseColumns: false` rollups — no tiebreaker to pay for)
- when the leading sort key is not in `sortKeys` (off-key leads already plan a bounded top-N)
- when that column is nullable (`k >= NULL` is NULL, which would **drop** rows)
- when the query already pins `_id` (point lookup via `findOneById`)
- when `skip + limit` is not finite and positive

`min()` is nested over a subquery rather than taken as the N-th value via `LIMIT 1 OFFSET n-1`: on a final page with fewer than `skip + limit` matching rows the latter returns no row, the scalar is NULL, and the page comes back empty.

## Tests

New `AnalyticsDatabaseSortKeyBoundary.test.ts` (34 tests): emitted shape, every gate above, and result preservation. The preservation tests page a fixed dataset with and without the bound under adversarial tie orderings and require identical pages — including a short final page and an offset past the end.

Two rendered-SQL assertions in the existing pagination suite now resolve the **outer** `ORDER BY` by parameter name rather than hardcoded index, since the bound adds a nested `ORDER BY`. The guarantee they check is unchanged.

Verification:
- **52/52** pass across both analytics pagination suites
- **Mutation-tested**: disabling the call site fails 8 of the new tests
- The rendered statement was **executed against a real ClickHouse 26.7 Distributed `LogItemV3`** to confirm valid SQL
- Result-preservation checked directly in ClickHouse across pages, both sort directions, empty sets, and past-end offsets — identical row IDs every time

---

# Second fix: scan memory for the Logs aggregations

The facet-count and histogram queries hit the same 3 GiB ceiling, but for a different reason and through a different code path — they never enter `toFindStatement`, so the sort fix above does not reach them.

## The reported cause was wrong

The report labelled these **"aggregation memory"**. Measured, that is not what is happening, and the distinction picks the fix.

The group keys are small: `severityText` has ~10 distinct values, and the histogram's inner key is `(minute, severityText)` — about 14k groups over 24h. A hash table that size never approaches 3 GiB, and `max_bytes_before_external_group_by` is already 1.5 GiB, so it would spill rather than abort.

The memory is **scan-side**. A `GROUP BY` over a log window must visit every matching row, and a filter on `attributes` (a fat `Map(String, String)`) or on `body` forces those wide columns to be read across the whole window. Peak memory is roughly `threads x block rows x bytes per row`, and reading the default **65536 rows per block per thread** is what goes over.

Measured on ClickHouse 26.7, 3M rows shaped like `LogItemV3`:

| facet query | peak memory |
|---|---|
| plain `severityText` | 35.54 MiB |
| **+ attributes filter** | **629.62 MiB** |
| + `body ILIKE` | 110.27 MiB |

## The fix

An aggregation cannot be made to read *less* without changing its answer, so this bounds what the scan holds **in flight** instead:

```
max_block_size = 8192, preferred_block_size_bytes = 1048576, max_threads = 4
```

| | before | after |
|---|---|---|
| facet + attributes filter | 695 MiB | **40 MiB** |
| histogram off its projection | 591 MiB | **39 MiB** |
| body-search facet | 114 MiB | **4 MiB** |
| plain facet | 34 MiB | **2 MiB** |
| **real rendered SQL, live server** | **106.18 MiB** | **17.49 MiB** (and ~2x faster) |

These are execution-strategy settings, so the result set is unchanged — verified by diffing output with and without them against a real server.

Applied to the five builders that `GROUP BY` over a window: facets, the histogram, and the three analytics statements (same shape, same filters via `appendCommonFilters`).

`getExportLogs` is **deliberately excluded** — it reads rows rather than aggregating, and its `ORDER BY time DESC LIMIT n` is a sorting-key prefix, so its scan is already bounded by the LIMIT; capping its threads would only slow a user-facing download. A test pins that exclusion so it is revisited deliberately.

## Honest limitation

A facet on a genuinely **high-cardinality** attribute builds a large `GROUP BY` hash table however the scan is bounded — that one case is aggregation memory, and this change does not help it. It is already covered by the existing spill-to-disk threshold every read here carries.

## Tests

New `LogAggregationScanMemory.test.ts` (46 tests): that the bound is emitted on all five builders, that it is **additive** so the 3 GiB abort guard and spill thresholds survive, that it stays in the `SETTINGS` clause and never reaches the query body, that it binds no parameter, that `additionalSettings` can still override it, and that the histogram keeps its projection hint. Two existing tests pinning the exact SETTINGS text were updated.

**Mutation-tested**: disabling the bound fails 13 of the new tests.

## Worth knowing: this bug is invisible in the UI

Unlike the list bug, a Code 241 here produces **no error banner**. Facet failures are swallowed server-side (`catch { return [facetKey, []] }`) and again client-side, so a failing facet just shows no values; the histogram degrades to a blank chart. It may have been failing longer than the reported timestamp suggests. I have not changed that error handling — surfacing it is a product decision, not part of this fix.

## Note on pre-existing failures

Full `Common/Tests/Server` run: **13,718 passed, 4 failed** across 565 suites. All 4 failures reproduce on clean `master` (`54c7794a16`) and none of them import `AnalyticsDatabaseService`:

- `UserNotificationRuleExecuteItem.test.ts`
- `DeliverNotificationForRuleExtraction.test.ts`
- `EpisodeMemberNotifyIndexesMigration.test.ts`
- `AddNetworkDeviceReachabilityColumnsMigration.test.ts`

Unrelated to this change.

