### PR TITLE
feat(mobile): make admin-dashboard Global SSO usable on iOS and Android

### DIFF
--- a/App/FeatureSet/Identity/API/GlobalOIDC.ts
+++ b/App/FeatureSet/Identity/API/GlobalOIDC.ts
@@ -1,5 +1,12 @@
 import AuthenticationEmail from "../Utils/AuthenticationEmail";
 import OIDCUtil, { OidcCallbackResult } from "../Utils/OIDC";
+import {
+  buildMobileSsoSuccessUrl,
+  clearMobileSsoIntentCookie,
+  isMobileSsoRequest,
+  respondToMobileSsoFailure,
+  setMobileSsoIntentCookie,
+} from "../Utils/MobileSso";
 import { DashboardRoute } from "Common/ServiceRoute";
 import Hostname from "Common/Types/API/Hostname";
 import Protocol from "Common/Types/API/Protocol";
@@ -151,7 +158,22 @@ router.get(
         );
       }
 
-      const isMobileRequest: boolean = req.query["mobile"] === "true";
+      const isMobileRequest: boolean = isMobileSsoRequest({
+        req,
+        providerId: globalOidc.id!,
+      });
+
+      /*
+       * The mobile flag normally travels inside the signed state cookie. That
+       * cookie is also the thing most likely to be MISSING when the callback
+       * fails (expired login, cookie dropped by the browser), and in exactly
+       * that case the error would be rendered as a web page the app cannot
+       * read. A separate intent cookie survives independently and keeps the
+       * failure routable back to the app.
+       */
+      if (isMobileRequest) {
+        setMobileSsoIntentCookie(res, globalOidc.id!);
+      }
 
       const redirectUri: URL = URL.fromString(
         `${HttpProtocol}${Host}/identity/global-oidc-callback/${globalOidc.id?.toString()}`,
@@ -236,6 +258,17 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
 ): Promise<void> => {
   try {
     if (!req.params["globalOidcId"]) {
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest: isMobileSsoRequest({ req }),
+          error: "sso_failed",
+          errorDescription: "This sign-in link is missing its provider.",
+        })
+      ) {
+        return;
+      }
+
       return Response.sendErrorResponse(
         req,
         res,
@@ -245,11 +278,34 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
 
     const globalOidcId: ObjectID = new ObjectID(req.params["globalOidcId"]);
 
+    /*
+     * The authoritative mobile flag lives in the signed state cookie below.
+     * This one is the fallback for the case where that cookie is gone - which
+     * is precisely when the login is failing and the app most needs to be
+     * told why, rather than being shown a web page it cannot parse.
+     */
+    let isMobileRequest: boolean = isMobileSsoRequest({
+      req,
+      providerId: globalOidcId,
+    });
+
     const stateCookieName: string = getGlobalOidcStateCookieName(globalOidcId);
     const stateCookieValue: string | undefined =
       CookieUtil.getCookieFromExpressRequest(req, stateCookieName);
 
     if (!stateCookieValue) {
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "login_session_expired",
+          errorDescription:
+            "Your sign-in session expired. Please try signing in again.",
+        })
+      ) {
+        return;
+      }
+
       return Response.sendErrorResponse(
         req,
         res,
@@ -262,7 +318,6 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
     let storedState: string;
     let storedNonce: string;
     let storedCodeVerifier: string;
-    let isMobileRequest: boolean;
 
     try {
       const decoded: Record<string, unknown> = JSONWebToken.decodeJsonPayload(
@@ -272,8 +327,20 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
       storedState = decoded["state"] as string;
       storedNonce = decoded["nonce"] as string;
       storedCodeVerifier = decoded["codeVerifier"] as string;
-      isMobileRequest = Boolean(decoded["isMobile"]);
+      isMobileRequest = isMobileRequest || Boolean(decoded["isMobile"]);
     } catch {
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "login_session_invalid",
+          errorDescription:
+            "Your sign-in session is no longer valid. Please try signing in again.",
+        })
+      ) {
+        return;
+      }
+
       return Response.sendErrorResponse(
         req,
         res,
@@ -284,6 +351,41 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
     }
 
     CookieUtil.removeCookie(res, stateCookieName);
+    clearMobileSsoIntentCookie(res, globalOidcId);
+
+    /*
+     * An identity provider reports a refusal (consent denied, account
+     * disabled) by redirecting back with `error` rather than `code`. Handling
+     * it here means the user sees what their IdP actually said, instead of it
+     * being fed into the token exchange and re-emerging as a generic failure.
+     */
+    const oidcError: unknown = req.query["error"];
+
+    if (typeof oidcError === "string" && oidcError) {
+      const oidcErrorDescription: unknown = req.query["error_description"];
+
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: oidcError,
+          errorDescription:
+            typeof oidcErrorDescription === "string" && oidcErrorDescription
+              ? oidcErrorDescription
+              : "Your identity provider declined the sign-in request.",
+        })
+      ) {
+        return;
+      }
+
+      return Response.render(req, res, MESSAGE_VIEW, {
+        title: "Sign in was declined.",
+        message:
+          typeof oidcErrorDescription === "string" && oidcErrorDescription
+            ? oidcErrorDescription
+            : "Your identity provider declined the sign-in request. Please try again or contact your administrator.",
+      });
+    }
 
     const globalOidc: GlobalOIDC | null = await GlobalOIDCService.findOneBy({
       query: {
@@ -304,6 +406,18 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
     });
 
     if (!globalOidc) {
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "provider_unavailable",
+          errorDescription:
+            "This SSO provider is no longer available. Please contact your administrator.",
+        })
+      ) {
+        return;
+      }
+
       return Response.sendErrorResponse(
         req,
         res,
@@ -317,6 +431,18 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
       !globalOidc.clientId ||
       !globalOidc.clientSecret
     ) {
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "provider_misconfigured",
+          errorDescription:
+            "This SSO provider is not fully configured. Please contact your administrator.",
+        })
+      ) {
+        return;
+      }
+
       return Response.sendErrorResponse(
         req,
         res,
@@ -358,6 +484,19 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
       });
     } catch (err: unknown) {
       logger.error(err, getLogAttributesFromRequest(req as RequestLike));
+
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "token_exchange_failed",
+          errorDescription:
+            "We could not complete the exchange with your identity provider. Please try again.",
+        })
+      ) {
+        return;
+      }
+
       if (err instanceof Exception) {
         return Response.sendErrorResponse(req, res, err);
       }
@@ -402,6 +541,18 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
 
     if (!alreadySavedUser) {
       if (isSignUpDisabled) {
+        if (
+          respondToMobileSsoFailure({
+            res,
+            isMobileRequest,
+            error: "invitation_required",
+            errorDescription:
+              "You must be invited to a project on this OneUptime instance before you can sign in with SSO. Please contact your administrator.",
+          })
+        ) {
+          return;
+        }
+
         return Response.render(req, res, MESSAGE_VIEW, {
           title: "You need to be invited.",
           message:
@@ -421,6 +572,18 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
 
     if (!alreadySavedUser.isEmailVerified && !isNewUser) {
       await AuthenticationEmail.sendVerificationEmail(alreadySavedUser!);
+
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "email_not_verified",
+          errorDescription:
+            "Your email is not verified. We have sent you a verification link - please check your inbox, and your spam folder.",
+        })
+      ) {
+        return;
+      }
 
       return Response.render(req, res, MESSAGE_VIEW, {
         title: "Email not verified.",
@@ -485,6 +648,18 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
     });
 
     if (memberProjectCount.toNumber() === 0) {
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "no_project_access",
+          errorDescription:
+            "You are not a member of any project on this OneUptime instance. Please contact your administrator to be invited.",
+        })
+      ) {
+        return;
+      }
+
       return Response.render(req, res, MESSAGE_VIEW, {
         title: "No project access.",
         message:
@@ -528,24 +703,22 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
         expiresInSeconds: ACCESS_TOKEN_EXPIRY_SECONDS,
       });
 
-      const params: URLSearchParams = new URLSearchParams();
-      params.set("accessToken", accessToken);
-      params.set("refreshToken", sessionMetadata.refreshToken);
-      params.set(
-        "refreshTokenExpiresAt",
-        sessionMetadata.refreshTokenExpiresAt.toISOString(),
-      );
-      params.set("userId", alreadySavedUser.id!.toString());
-      params.set("email", alreadySavedUser.email!.toString());
-      params.set("name", alreadySavedUser.name?.toString() || "");
-      params.set(
-        "isMasterAdmin",
-        String(alreadySavedUser.isMasterAdmin || false),
-      );
-      // Single global SSO token (mobile sends it via the x-global-sso-token header).
-      params.set("globalSsoToken", globalSsoToken);
-
-      const deepLinkUrl: string = `oneuptime://sso-callback?${params.toString()}`;
+      /*
+       * Built through the shared helper so the SAML and OIDC routers cannot
+       * drift apart on the param names the mobile app parses. The single
+       * global SSO token is sent back as `globalSsoToken`; the app replays it
+       * on every request as the `x-global-sso-token` header.
+       */
+      const deepLinkUrl: string = buildMobileSsoSuccessUrl({
+        accessToken,
+        refreshToken: sessionMetadata.refreshToken,
+        refreshTokenExpiresAt: sessionMetadata.refreshTokenExpiresAt,
+        userId: alreadySavedUser.id!.toString(),
+        email: alreadySavedUser.email!.toString(),
+        name: alreadySavedUser.name?.toString() || "",
+        isMasterAdmin: Boolean(alreadySavedUser.isMasterAdmin),
+        globalSsoToken,
+      });
 
       logger.info(
         "User logged in with Global OIDC (mobile): " + result.email.toString(),
@@ -588,6 +761,24 @@ const handleGlobalOidcCallback: HandleGlobalOidcCallbackFunction = async (
     );
   } catch (err) {
     logger.error(err, getLogAttributesFromRequest(req as RequestLike));
+
+    /*
+     * Last resort. An unexpected server error must still leave the mobile
+     * browser on the deep link, otherwise the app waits out the auth session
+     * and reports a cancellation the user cannot act on.
+     */
+    if (
+      respondToMobileSsoFailure({
+        res,
+        isMobileRequest: isMobileSsoRequest({ req }),
+        error: "sso_failed",
+        errorDescription:
+          "Something went wrong while signing you in. Please try again.",
+      })
+    ) {
+      return;
+    }
+
     Response.sendErrorResponse(req, res, err as Exception);
   }
 };

--- a/App/FeatureSet/Identity/API/GlobalSSO.ts
+++ b/App/FeatureSet/Identity/API/GlobalSSO.ts
@@ -1,5 +1,12 @@
 import AuthenticationEmail from "../Utils/AuthenticationEmail";
 import SSOUtil, { VerifiedSamlResponse } from "../Utils/SSO";
+import {
+  buildMobileSsoSuccessUrl,
+  clearMobileSsoIntentCookie,
+  isMobileSsoRequest,
+  respondToMobileSsoFailure,
+  setMobileSsoIntentCookie,
+} from "../Utils/MobileSso";
 import { DashboardRoute } from "Common/ServiceRoute";
 import Hostname from "Common/Types/API/Hostname";
 import Protocol from "Common/Types/API/Protocol";
@@ -147,7 +154,22 @@ router.get(
         );
       }
 
-      const isMobileRequest: boolean = req.query["mobile"] === "true";
+      const isMobileRequest: boolean = isMobileSsoRequest({
+        req,
+        providerId: globalSso.id!,
+      });
+
+      /*
+       * RelayState is the primary carrier of "this is a mobile login", but it
+       * is optional in the SAML specification and some identity providers do
+       * not echo it back. Record the intent in a short-lived cookie as well,
+       * so the ACS callback can still route the user to the app instead of
+       * dropping them on the web dashboard, where the app cannot reach the
+       * session.
+       */
+      if (isMobileRequest) {
+        setMobileSsoIntentCookie(res, globalSso.id!);
+      }
 
       const samlRequestUrl: URL = SSOUtil.createSAMLRequestUrl({
         acsUrl: URL.fromString(
@@ -217,6 +239,18 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
     const samlResponseBase64: string = req.body.SAMLResponse;
 
     if (!samlResponseBase64) {
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest: isMobileSsoRequest({ req }),
+          error: "sso_failed",
+          errorDescription:
+            "Your identity provider did not return a sign-in response. Please try again.",
+        })
+      ) {
+        return;
+      }
+
       return Response.sendErrorResponse(
         req,
         res,
@@ -225,6 +259,17 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
     }
 
     if (!req.params["globalSsoId"]) {
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest: isMobileSsoRequest({ req }),
+          error: "sso_failed",
+          errorDescription: "This sign-in link is missing its provider.",
+        })
+      ) {
+        return;
+      }
+
       return Response.sendErrorResponse(
         req,
         res,
@@ -233,6 +278,26 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
     }
 
     const globalSsoId: ObjectID = new ObjectID(req.params["globalSsoId"]);
+
+    /*
+     * Resolved once, here, and used by every exit below. Mobile logins have to
+     * end on the app's deep link whatever the outcome - a server-rendered page
+     * or a JSON error is a dead end inside the auth browser, and the app can
+     * only report it to the user as an unexplained cancellation.
+     */
+    const isMobileRequest: boolean = isMobileSsoRequest({
+      req,
+      providerId: globalSsoId,
+    });
+
+    /*
+     * The intent has been read into `isMobileRequest`; drop the cookie now so
+     * a later WEB login through the same provider in the same browser is not
+     * redirected into the app.
+     */
+    if (isMobileRequest) {
+      clearMobileSsoIntentCookie(res, globalSsoId);
+    }
 
     const samlResponse: string = Buffer.from(
       samlResponseBase64,
@@ -254,6 +319,18 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
     });
 
     if (!globalSso) {
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "provider_unavailable",
+          errorDescription:
+            "This SSO provider is no longer available. Please contact your administrator.",
+        })
+      ) {
+        return;
+      }
+
       return Response.sendErrorResponse(
         req,
         res,
@@ -262,6 +339,18 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
     }
 
     if (!globalSso.issuerURL) {
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "provider_misconfigured",
+          errorDescription:
+            "This SSO provider is missing its issuer URL. Please contact your administrator.",
+        })
+      ) {
+        return;
+      }
+
       return Response.sendErrorResponse(
         req,
         res,
@@ -270,6 +359,18 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
     }
 
     if (!globalSso.publicCertificate) {
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "provider_misconfigured",
+          errorDescription:
+            "This SSO provider is missing its certificate. Please contact your administrator.",
+        })
+      ) {
+        return;
+      }
+
       return Response.sendErrorResponse(
         req,
         res,
@@ -297,6 +398,26 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
       email = verifiedSaml.email;
       fullName = verifiedSaml.name;
     } catch (err: unknown) {
+      /*
+       * Logged before the mobile branch short-circuits: a failed signature
+       * verification is security-relevant, and the deep-link redirect returns
+       * without going through Response.sendErrorResponse, which is what
+       * records it on the web path.
+       */
+      logger.error(err, getLogAttributesFromRequest(req as RequestLike));
+
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "invalid_assertion",
+          errorDescription:
+            "We could not verify the response from your identity provider. Please try again.",
+        })
+      ) {
+        return;
+      }
+
       if (err instanceof Exception) {
         return Response.sendErrorResponse(req, res, err);
       }
@@ -311,6 +432,18 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
           issuerUrl.toString(),
         getLogAttributesFromRequest(req as RequestLike),
       );
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "issuer_mismatch",
+          errorDescription:
+            "The response came from an unexpected identity provider. Please contact your administrator.",
+        })
+      ) {
+        return;
+      }
+
       return Response.sendErrorResponse(
         req,
         res,
@@ -356,6 +489,18 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
 
     if (!alreadySavedUser) {
       if (isSignUpDisabled) {
+        if (
+          respondToMobileSsoFailure({
+            res,
+            isMobileRequest,
+            error: "invitation_required",
+            errorDescription:
+              "You must be invited to a project on this OneUptime instance before you can sign in with SSO. Please contact your administrator.",
+          })
+        ) {
+          return;
+        }
+
         return Response.render(req, res, MESSAGE_VIEW, {
           title: "You need to be invited.",
           message:
@@ -377,6 +522,18 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
 
     if (!alreadySavedUser.isEmailVerified && !isNewUser) {
       await AuthenticationEmail.sendVerificationEmail(alreadySavedUser!);
+
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "email_not_verified",
+          errorDescription:
+            "Your email is not verified. We have sent you a verification link - please check your inbox, and your spam folder.",
+        })
+      ) {
+        return;
+      }
 
       return Response.render(req, res, MESSAGE_VIEW, {
         title: "Email not verified.",
@@ -445,15 +602,24 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
     });
 
     if (memberProjectCount.toNumber() === 0) {
+      if (
+        respondToMobileSsoFailure({
+          res,
+          isMobileRequest,
+          error: "no_project_access",
+          errorDescription:
+            "You are not a member of any project on this OneUptime instance. Please contact your administrator to be invited.",
+        })
+      ) {
+        return;
+      }
+
       return Response.render(req, res, MESSAGE_VIEW, {
         title: "No project access.",
         message:
           "You are not a member of any project on this OneUptime instance. Please contact your administrator to be invited.",
       });
     }
-
-    const isMobileRequest: boolean =
-      req.body.RelayState === "mobile" || req.query["RelayState"] === "mobile";
 
     const sessionMetadata: SessionMetadata =
       await UserSessionService.createSession({
@@ -493,24 +659,22 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
         expiresInSeconds: ACCESS_TOKEN_EXPIRY_SECONDS,
       });
 
-      const params: URLSearchParams = new URLSearchParams();
-      params.set("accessToken", accessToken);
-      params.set("refreshToken", sessionMetadata.refreshToken);
-      params.set(
-        "refreshTokenExpiresAt",
-        sessionMetadata.refreshTokenExpiresAt.toISOString(),
-      );
-      params.set("userId", alreadySavedUser.id!.toString());
-      params.set("email", alreadySavedUser.email!.toString());
-      params.set("name", alreadySavedUser.name?.toString() || "");
-      params.set(
-        "isMasterAdmin",
-        String(alreadySavedUser.isMasterAdmin || false),
-      );
-      // Single global SSO token (mobile sends it via the x-global-sso-token header).
-      params.set("globalSsoToken", globalSsoToken);
-
-      const deepLinkUrl: string = `oneuptime://sso-callback?${params.toString()}`;
+      /*
+       * Built through the shared helper so the SAML and OIDC routers cannot
+       * drift apart on the param names the mobile app parses. The single
+       * global SSO token is sent back as `globalSsoToken`; the app replays it
+       * on every request as the `x-global-sso-token` header.
+       */
+      const deepLinkUrl: string = buildMobileSsoSuccessUrl({
+        accessToken,
+        refreshToken: sessionMetadata.refreshToken,
+        refreshTokenExpiresAt: sessionMetadata.refreshTokenExpiresAt,
+        userId: alreadySavedUser.id!.toString(),
+        email: alreadySavedUser.email!.toString(),
+        name: alreadySavedUser.name?.toString() || "",
+        isMasterAdmin: Boolean(alreadySavedUser.isMasterAdmin),
+        globalSsoToken,
+      });
 
       logger.info(
         "User logged in with Global SSO (mobile): " + email.toString(),
@@ -554,6 +718,24 @@ const loginUserWithGlobalSso: LoginUserWithGlobalSsoFunction = async (
     );
   } catch (err) {
     logger.error(err, getLogAttributesFromRequest(req as RequestLike));
+
+    /*
+     * Last resort. An unexpected server error must still leave the mobile
+     * browser on the deep link, otherwise the app waits out the auth session
+     * and reports a cancellation the user cannot act on.
+     */
+    if (
+      respondToMobileSsoFailure({
+        res,
+        isMobileRequest: isMobileSsoRequest({ req }),
+        error: "sso_failed",
+        errorDescription:
+          "Something went wrong while signing you in. Please try again.",
+      })
+    ) {
+      return;
+    }
+
     Response.sendErrorResponse(req, res, err as Exception);
   }
 };

--- a/App/FeatureSet/Identity/Utils/MobileSso.ts
+++ b/App/FeatureSet/Identity/Utils/MobileSso.ts
@@ -1,0 +1,240 @@
+import ObjectID from "Common/Types/ObjectID";
+import Protocol from "Common/Types/API/Protocol";
+import CookieUtil from "Common/Server/Utils/Cookie";
+import { HttpProtocol } from "Common/Server/EnvironmentConfig";
+import { ExpressRequest, ExpressResponse } from "Common/Server/Utils/Express";
+
+/*
+ * Shared plumbing for SSO logins started from the mobile app.
+ *
+ * A mobile login differs from a web login in exactly two ways, and both of
+ * them are easy to get subtly wrong in each router:
+ *
+ *   1. The flow must END on the app's custom-scheme deep link, not on an HTML
+ *      page. A browser session that lands on a server-rendered page is a dead
+ *      end: the app is watching for `oneuptime://sso-callback`, sees an
+ *      ordinary web page instead, and eventually reports the login as
+ *      "cancelled" with nothing to tell the user. That applies to FAILURES
+ *      just as much as to successes.
+ *
+ *   2. The server has to still know it is a mobile login by the time the IdP
+ *      hands control back, which is many redirects later.
+ *
+ * Everything here is deliberately pure or near-pure so the deep-link contract
+ * between the server and the app can be unit tested on both sides.
+ */
+
+export const MOBILE_SSO_CALLBACK_URL: string = "oneuptime://sso-callback";
+
+/**
+ * Name of the short-lived cookie that remembers "this login was started by the
+ * mobile app", keyed by provider so two logins cannot cross-talk.
+ */
+export function getMobileSsoIntentCookieName(providerId: ObjectID): string {
+  return `sso-mobile-intent-${providerId.toString()}`;
+}
+
+/*
+ * Long enough for a person to actually complete an IdP login (MFA prompts,
+ * password managers, a push approval on another device), short enough that a
+ * stale intent cannot silently redirect a later WEB login into the app.
+ */
+export const MOBILE_SSO_INTENT_TTL_SECONDS: number = 15 * 60;
+
+/**
+ * Records that the login now being started came from the mobile app.
+ *
+ * SAML carries the intent in `RelayState`, but RelayState is only a SHOULD in
+ * the specification: several identity providers drop it, truncate it, or
+ * refuse to echo it on IdP-initiated flows. When that happens the callback
+ * cannot tell a mobile login from a web one and redirects the user's in-app
+ * browser to the web dashboard, where the app can never retrieve the session.
+ * This cookie is the fallback, and for OIDC error paths - where the state
+ * cookie may itself be the thing that went missing - it is the only carrier.
+ */
+export function setMobileSsoIntentCookie(
+  res: ExpressResponse,
+  providerId: ObjectID,
+): void {
+  /*
+   * SameSite matters here more than anywhere else in the codebase, because of
+   * HOW the identity provider hands control back:
+   *
+   *   SAML  - the IdP auto-submits a form to our ACS endpoint. That is a
+   *           top-level CROSS-SITE POST, and a browser does NOT attach a
+   *           SameSite=Lax cookie to one. CookieUtil's default is Lax, so a
+   *           default-configured cookie would be missing at precisely the
+   *           moment this fallback exists to cover.
+   *   OIDC  - the IdP 302s back to our callback. A top-level cross-site GET,
+   *           where Lax is attached and everything works either way.
+   *
+   * So the cookie is sent SameSite=None on an HTTPS instance. Browsers reject
+   * SameSite=None without Secure, and Secure cookies are not stored over plain
+   * HTTP, so an HTTP instance keeps the default instead - it loses the SAML
+   * fallback, but that only returns it to relying on RelayState, which is
+   * where it was before. Nothing is made worse.
+   *
+   * The cookie carries no authority whatsoever - its value is the literal
+   * string "true" - so sending it cross-site discloses nothing and grants
+   * nothing.
+   */
+  const isHttps: boolean = HttpProtocol === Protocol.HTTPS;
+
+  CookieUtil.setCookie(res, getMobileSsoIntentCookieName(providerId), "true", {
+    maxAge: MOBILE_SSO_INTENT_TTL_SECONDS * 1000,
+    httpOnly: true,
+    ...(isHttps ? { sameSite: "none" as const, secure: true } : {}),
+  });
+}
+
+export function clearMobileSsoIntentCookie(
+  res: ExpressResponse,
+  providerId: ObjectID,
+): void {
+  CookieUtil.removeCookie(res, getMobileSsoIntentCookieName(providerId));
+}
+
+/**
+ * True when the current request belongs to a login the mobile app started.
+ *
+ * Checks every carrier, most explicit first: the `mobile=true` query param
+ * (SP-initiated entry point), the SAML RelayState echoed back by the IdP in
+ * either the body or the query, and finally the intent cookie set when the
+ * flow began.
+ */
+export function isMobileSsoRequest(data: {
+  req: ExpressRequest;
+  providerId?: ObjectID | undefined;
+}): boolean {
+  const { req } = data;
+
+  if (req.query["mobile"] === "true") {
+    return true;
+  }
+
+  const relayStateFromBody: unknown = (
+    req.body as { RelayState?: unknown } | undefined
+  )?.RelayState;
+
+  if (relayStateFromBody === "mobile" || req.query["RelayState"] === "mobile") {
+    return true;
+  }
+
+  if (!data.providerId) {
+    return false;
+  }
+
+  return (
+    CookieUtil.getCookieFromExpressRequest(
+      req,
+      getMobileSsoIntentCookieName(data.providerId),
+    ) === "true"
+  );
+}
+
+/**
+ * Builds the deep link that reports a FAILED login back to the app.
+ *
+ * `error` is a short, stable reason. `errorDescription` is the human sentence
+ * shown to the user; it is optional so a caller with nothing useful to add
+ * does not have to invent something.
+ */
+/*
+ * Some of what ends up in these two fields comes from the identity provider
+ * (an OIDC `error` / `error_description`), so it is neither trusted nor
+ * bounded. Percent-encoding keeps it from breaking the query string, and this
+ * cap keeps it from producing a deep link too long for the OS to hand back to
+ * the app - which would turn a reportable failure into the silent dead end
+ * this whole module exists to prevent. Generous enough that no real message
+ * from an identity provider is truncated.
+ */
+const MAX_MOBILE_SSO_ERROR_FIELD_LENGTH: number = 512;
+
+function clampErrorField(value: string): string {
+  return value.length > MAX_MOBILE_SSO_ERROR_FIELD_LENGTH
+    ? value.slice(0, MAX_MOBILE_SSO_ERROR_FIELD_LENGTH)
+    : value;
+}
+
+export function buildMobileSsoErrorUrl(
+  error: string,
+  errorDescription?: string | undefined,
+): string {
+  const params: URLSearchParams = new URLSearchParams();
+  params.set("error", clampErrorField(error));
+
+  if (errorDescription) {
+    params.set("errorDescription", clampErrorField(errorDescription));
+  }
+
+  return `${MOBILE_SSO_CALLBACK_URL}?${params.toString()}`;
+}
+
+/**
+ * Sends a failed mobile login back to the app.
+ *
+ * Returns true when it handled the response, so callers can write
+ * `if (respondToMobileSsoFailure(...)) { return; }` and fall through to the
+ * existing web rendering otherwise.
+ */
+export function respondToMobileSsoFailure(data: {
+  res: ExpressResponse;
+  isMobileRequest: boolean;
+  error: string;
+  errorDescription?: string | undefined;
+}): boolean {
+  if (!data.isMobileRequest) {
+    return false;
+  }
+
+  data.res.redirect(buildMobileSsoErrorUrl(data.error, data.errorDescription));
+
+  return true;
+}
+
+export interface MobileSsoSuccessParams {
+  accessToken: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: Date;
+  userId: string;
+  email: string;
+  name: string;
+  isMasterAdmin: boolean;
+  /*
+   * Instance-wide Global SSO/OIDC token. Satisfies SSO enforcement for every
+   * project the user belongs to, so it replaces the per-project fan-out.
+   */
+  globalSsoToken?: string | undefined;
+  // Per-project SSO token; requires projectId alongside it.
+  ssoToken?: string | undefined;
+  projectId?: string | undefined;
+}
+
+/**
+ * Builds the deep link that hands a completed login to the app.
+ *
+ * Kept in one place so the SAML and OIDC routers cannot drift apart on the
+ * param names the app parses.
+ */
+export function buildMobileSsoSuccessUrl(data: MobileSsoSuccessParams): string {
+  const params: URLSearchParams = new URLSearchParams();
+
+  params.set("accessToken", data.accessToken);
+  params.set("refreshToken", data.refreshToken);
+  params.set("refreshTokenExpiresAt", data.refreshTokenExpiresAt.toISOString());
+  params.set("userId", data.userId);
+  params.set("email", data.email);
+  params.set("name", data.name);
+  params.set("isMasterAdmin", String(data.isMasterAdmin));
+
+  if (data.globalSsoToken) {
+    params.set("globalSsoToken", data.globalSsoToken);
+  }
+
+  if (data.ssoToken && data.projectId) {
+    params.set("ssoToken", data.ssoToken);
+    params.set("projectId", data.projectId);
+  }
+
+  return `${MOBILE_SSO_CALLBACK_URL}?${params.toString()}`;
+}

--- a/App/Tests/Identity/MobileSso.test.ts
+++ b/App/Tests/Identity/MobileSso.test.ts
@@ -1,0 +1,1048 @@
+import {
+  MOBILE_SSO_CALLBACK_URL,
+  MOBILE_SSO_INTENT_TTL_SECONDS,
+  buildMobileSsoErrorUrl,
+  buildMobileSsoSuccessUrl,
+  clearMobileSsoIntentCookie,
+  getMobileSsoIntentCookieName,
+  isMobileSsoRequest,
+  respondToMobileSsoFailure,
+  setMobileSsoIntentCookie,
+} from "../../FeatureSet/Identity/Utils/MobileSso";
+import ObjectID from "Common/Types/ObjectID";
+import { ExpressRequest, ExpressResponse } from "Common/Server/Utils/Express";
+import { describe, expect, jest, test } from "@jest/globals";
+
+/*
+ * MobileSso.ts is the whole of what makes an SSO login started from the React
+ * Native app different from one started in a browser, and every part of it is
+ * a contract that no compiler checks.
+ *
+ * Two failure modes motivate this file:
+ *
+ *   1. A mobile login that does not END on `oneuptime://sso-callback` is a
+ *      dead end. The app watches the in-app browser for that scheme; anything
+ *      else - an EJS error page, a JSON body - is an unparseable web page, and
+ *      the user eventually sees the login reported as "cancelled" with no
+ *      reason. That is why respondToMobileSsoFailure exists and why the error
+ *      deep link is tested as carefully as the success one.
+ *
+ *   2. The server has to still KNOW it is a mobile login many redirects later,
+ *      when the identity provider hands control back. SAML carries that in
+ *      RelayState, which the specification only says an IdP SHOULD echo - so
+ *      the provider-scoped intent cookie is the fallback that keeps mobile
+ *      users off the web dashboard. isMobileSsoRequest is tested one carrier
+ *      at a time so a regression names the carrier that broke.
+ *
+ * These are Utils tests, like SSO.test.ts and OIDC.test.ts alongside them; the
+ * route handlers in API/GlobalSSO.ts and API/GlobalOIDC.ts are thin callers.
+ */
+
+const PROVIDER_ID: ObjectID = new ObjectID("6570b1d3e2f4a5c6d7e8f901");
+const OTHER_PROVIDER_ID: ObjectID = new ObjectID("6570b1d3e2f4a5c6d7e8f902");
+
+/*
+ * ---------------------------------------------------------------------------
+ * Fake Express request / response.
+ *
+ * Deliberately NOT mocks of CookieUtil: the cookie name the callback reads has
+ * to be the cookie name the login start wrote, and stubbing the layer that
+ * carries it would assert the stub. These fakes record only what Express
+ * itself would do, so the real CookieUtil runs in between.
+ * ---------------------------------------------------------------------------
+ */
+
+interface RecordedCookieOptions {
+  maxAge?: number | undefined;
+  httpOnly?: boolean | undefined;
+  path?: string | undefined;
+  sameSite?: string | boolean | undefined;
+  secure?: boolean | undefined;
+}
+
+interface RecordedCookie {
+  name: string;
+  value: string;
+  options: RecordedCookieOptions;
+}
+
+interface FakeResponse {
+  cookiesSet: Array<RecordedCookie>;
+  cookiesCleared: Array<string>;
+  redirectedTo: Array<string>;
+  // Anything a mobile flow must never reach: a rendered page or a JSON body.
+  otherCalls: Array<string>;
+  express: ExpressResponse;
+}
+
+function createFakeResponse(): FakeResponse {
+  const cookiesSet: Array<RecordedCookie> = [];
+  const cookiesCleared: Array<string> = [];
+  const redirectedTo: Array<string> = [];
+  const otherCalls: Array<string> = [];
+
+  const response: Record<string, unknown> = {};
+
+  response["cookie"] = (
+    name: string,
+    value: string,
+    options: RecordedCookieOptions,
+  ): void => {
+    cookiesSet.push({ name, value, options });
+  };
+
+  response["clearCookie"] = (name: string): void => {
+    cookiesCleared.push(name);
+  };
+
+  response["redirect"] = (url: string): void => {
+    redirectedTo.push(url);
+  };
+
+  response["render"] = (view: string): void => {
+    otherCalls.push(`render:${view}`);
+  };
+
+  response["send"] = (): void => {
+    otherCalls.push("send");
+  };
+
+  response["json"] = (): void => {
+    otherCalls.push("json");
+  };
+
+  response["end"] = (): void => {
+    otherCalls.push("end");
+  };
+
+  response["status"] = (code: number): unknown => {
+    otherCalls.push(`status:${code}`);
+    return response;
+  };
+
+  return {
+    cookiesSet,
+    cookiesCleared,
+    redirectedTo,
+    otherCalls,
+    express: response as unknown as ExpressResponse,
+  };
+}
+
+function expectResponseUntouched(response: FakeResponse): void {
+  expect(response.redirectedTo).toEqual([]);
+  expect(response.cookiesSet).toEqual([]);
+  expect(response.cookiesCleared).toEqual([]);
+  expect(response.otherCalls).toEqual([]);
+}
+
+interface FakeRequestData {
+  query?: Record<string, string> | undefined;
+  body?: Record<string, unknown> | undefined;
+  cookies?: Record<string, string> | undefined;
+}
+
+/*
+ * `query` is always present because Express always populates it. `body` and
+ * `cookies` are omitted unless asked for: the ACS POST arrives before
+ * cookie-parser on some routes, and a GET has no body at all.
+ */
+function createFakeRequest(data: FakeRequestData = {}): ExpressRequest {
+  const request: Record<string, unknown> = {
+    query: data.query ?? {},
+  };
+
+  if (data.body !== undefined) {
+    request["body"] = data.body;
+  }
+
+  if (data.cookies !== undefined) {
+    request["cookies"] = data.cookies;
+  }
+
+  return request as unknown as ExpressRequest;
+}
+
+// The query half of a deep link, decoded the way the app decodes it.
+function paramsOf(deepLink: string): URLSearchParams {
+  const queryStart: number = deepLink.indexOf("?");
+
+  expect(queryStart).toBeGreaterThan(-1);
+
+  return new URLSearchParams(deepLink.slice(queryStart + 1));
+}
+
+/*
+ * ---------------------------------------------------------------------------
+ * The intent cookie.
+ * ---------------------------------------------------------------------------
+ */
+
+describe("getMobileSsoIntentCookieName", () => {
+  test("derives the name from the provider id", () => {
+    expect(getMobileSsoIntentCookieName(PROVIDER_ID)).toBe(
+      "sso-mobile-intent-6570b1d3e2f4a5c6d7e8f901",
+    );
+  });
+
+  /*
+   * Two logins in flight against two providers must not read each other's
+   * intent - otherwise a stale web login could be redirected into the app, or
+   * a mobile login onto the web dashboard.
+   */
+  test("gives two different providers two different names", () => {
+    expect(getMobileSsoIntentCookieName(PROVIDER_ID)).not.toBe(
+      getMobileSsoIntentCookieName(OTHER_PROVIDER_ID),
+    );
+  });
+
+  test("is stable across calls for the same provider", () => {
+    expect(getMobileSsoIntentCookieName(PROVIDER_ID)).toBe(
+      getMobileSsoIntentCookieName(new ObjectID("6570b1d3e2f4a5c6d7e8f901")),
+    );
+  });
+});
+
+describe("setMobileSsoIntentCookie", () => {
+  test("sets exactly one cookie, under the provider-scoped name", () => {
+    const response: FakeResponse = createFakeResponse();
+
+    setMobileSsoIntentCookie(response.express, PROVIDER_ID);
+
+    expect(response.cookiesSet).toHaveLength(1);
+    expect(response.cookiesSet[0]!.name).toBe(
+      getMobileSsoIntentCookieName(PROVIDER_ID),
+    );
+    expect(response.cookiesSet[0]!.value).toBe("true");
+  });
+
+  /*
+   * The intent is server-side bookkeeping. Nothing in the app or in page
+   * JavaScript reads it, so it has no business being reachable from
+   * document.cookie.
+   */
+  test("marks the cookie httpOnly", () => {
+    const response: FakeResponse = createFakeResponse();
+
+    setMobileSsoIntentCookie(response.express, PROVIDER_ID);
+
+    expect(response.cookiesSet[0]!.options.httpOnly).toBe(true);
+  });
+
+  test("sets a maxAge of MOBILE_SSO_INTENT_TTL_SECONDS in milliseconds", () => {
+    const response: FakeResponse = createFakeResponse();
+
+    setMobileSsoIntentCookie(response.express, PROVIDER_ID);
+
+    expect(response.cookiesSet[0]!.options.maxAge).toBe(
+      MOBILE_SSO_INTENT_TTL_SECONDS * 1000,
+    );
+  });
+
+  /*
+   * Pinned rather than derived from the constant, because both ends of the
+   * window matter: shorter than an MFA prompt plus a password manager plus a
+   * push approval on another device and real logins break; much longer and a
+   * stale intent can silently divert a later WEB login into the app.
+   */
+  test("the intent window is 15 minutes", () => {
+    expect(MOBILE_SSO_INTENT_TTL_SECONDS).toBe(15 * 60);
+    expect(MOBILE_SSO_INTENT_TTL_SECONDS * 1000).toBe(900000);
+  });
+
+  test("scopes the cookie to the whole site so the callback route can read it", () => {
+    const response: FakeResponse = createFakeResponse();
+
+    setMobileSsoIntentCookie(response.express, PROVIDER_ID);
+
+    expect(response.cookiesSet[0]!.options.path).toBe("/");
+  });
+
+  /*
+   * SameSite decides whether the fallback works at all, and the two protocols
+   * need different answers:
+   *
+   * A browser sends a SameSite=Lax cookie on a top-level cross-site GET (the
+   * OIDC callback redirect) but NOT on a top-level cross-site POST - which is
+   * exactly what the SAML ACS at POST /identity/global-idp-login/:id receives
+   * from the identity provider. Lax would therefore lose the cookie in the one
+   * flow it was added for. SameSite=None fixes that, but browsers reject
+   * SameSite=None without Secure, and Secure cookies are not stored over plain
+   * HTTP - so an HTTP instance has to keep the default.
+   *
+   * Both branches are pinned here because each one is silently wrong on the
+   * other protocol, and neither failure is visible until a real IdP drops
+   * RelayState.
+   *
+   * HttpProtocol is read from the environment once at module load, so each
+   * branch re-imports the module inside jest.isolateModules with the env var
+   * set.
+   */
+  interface MobileSsoModule {
+    setMobileSsoIntentCookie: (
+      res: ExpressResponse,
+      providerId: ObjectID,
+    ) => void;
+  }
+
+  function setIntentCookieUnderProtocol(protocol: string): RecordedCookie {
+    const response: FakeResponse = createFakeResponse();
+    const previousProtocol: string | undefined = process.env["HTTP_PROTOCOL"];
+
+    process.env["HTTP_PROTOCOL"] = protocol;
+
+    try {
+      jest.isolateModules((): void => {
+        /*
+         * A fresh require is the point: HttpProtocol is captured from the
+         * environment once, at module load, so a static import would only ever
+         * exercise whichever protocol the test process started with. This is
+         * the one place in the file where require() is the right tool.
+         */
+        /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+        const freshModule: MobileSsoModule = require("../../FeatureSet/Identity/Utils/MobileSso");
+        /* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+
+        freshModule.setMobileSsoIntentCookie(response.express, PROVIDER_ID);
+      });
+    } finally {
+      if (previousProtocol === undefined) {
+        delete process.env["HTTP_PROTOCOL"];
+      } else {
+        process.env["HTTP_PROTOCOL"] = previousProtocol;
+      }
+    }
+
+    return response.cookiesSet[0]!;
+  }
+
+  test("on an https instance the cookie is SameSite=None and Secure, so the SAML cross-site POST carries it", () => {
+    const cookie: RecordedCookie = setIntentCookieUnderProtocol("https");
+
+    expect(cookie.options.sameSite).toBe("none");
+    expect(cookie.options.secure).toBe(true);
+  });
+
+  test("on a plain http instance the cookie keeps the Lax default, because a Secure cookie would not be stored at all", () => {
+    const cookie: RecordedCookie = setIntentCookieUnderProtocol("http");
+
+    expect(cookie.options.sameSite).toBe("lax");
+    expect(cookie.options.secure).toBeUndefined();
+  });
+
+  test("stays httpOnly on both protocols", () => {
+    expect(setIntentCookieUnderProtocol("https").options.httpOnly).toBe(true);
+    expect(setIntentCookieUnderProtocol("http").options.httpOnly).toBe(true);
+  });
+
+  test("writes different cookies for different providers", () => {
+    const response: FakeResponse = createFakeResponse();
+
+    setMobileSsoIntentCookie(response.express, PROVIDER_ID);
+    setMobileSsoIntentCookie(response.express, OTHER_PROVIDER_ID);
+
+    expect(
+      response.cookiesSet.map((cookie: RecordedCookie): string => {
+        return cookie.name;
+      }),
+    ).toEqual([
+      "sso-mobile-intent-6570b1d3e2f4a5c6d7e8f901",
+      "sso-mobile-intent-6570b1d3e2f4a5c6d7e8f902",
+    ]);
+  });
+});
+
+describe("clearMobileSsoIntentCookie", () => {
+  test("removes the same cookie name that setMobileSsoIntentCookie wrote", () => {
+    const response: FakeResponse = createFakeResponse();
+
+    setMobileSsoIntentCookie(response.express, PROVIDER_ID);
+    clearMobileSsoIntentCookie(response.express, PROVIDER_ID);
+
+    expect(response.cookiesCleared).toEqual([response.cookiesSet[0]!.name]);
+  });
+
+  test("only clears the provider it was asked about", () => {
+    const response: FakeResponse = createFakeResponse();
+
+    clearMobileSsoIntentCookie(response.express, PROVIDER_ID);
+
+    expect(response.cookiesCleared).toEqual([
+      "sso-mobile-intent-6570b1d3e2f4a5c6d7e8f901",
+    ]);
+    expect(response.cookiesCleared).not.toContain(
+      "sso-mobile-intent-6570b1d3e2f4a5c6d7e8f902",
+    );
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * isMobileSsoRequest - one test per carrier.
+ * ---------------------------------------------------------------------------
+ */
+
+describe("isMobileSsoRequest", () => {
+  // The SP-initiated entry point: the app opens /login?mobile=true itself.
+  test("recognises the mobile=true query parameter", () => {
+    expect(
+      isMobileSsoRequest({
+        req: createFakeRequest({ query: { mobile: "true" } }),
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not recognise mobile=false", () => {
+    expect(
+      isMobileSsoRequest({
+        req: createFakeRequest({ query: { mobile: "false" } }),
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(false);
+  });
+
+  /*
+   * The ACS POST: a SAML IdP echoes RelayState back in the form body, which is
+   * how a browser-driven, cross-site POST carries our state.
+   */
+  test("recognises RelayState=mobile echoed back in the POST body", () => {
+    expect(
+      isMobileSsoRequest({
+        req: createFakeRequest({
+          body: { SAMLResponse: "PHNhbWw+", RelayState: "mobile" },
+        }),
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(true);
+  });
+
+  // Some providers (and the OIDC redirect leg) put it back on the query.
+  test("recognises RelayState=mobile on the query string", () => {
+    expect(
+      isMobileSsoRequest({
+        req: createFakeRequest({ query: { RelayState: "mobile" } }),
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(true);
+  });
+
+  test("ignores a RelayState that is not ours", () => {
+    expect(
+      isMobileSsoRequest({
+        req: createFakeRequest({
+          body: { RelayState: "https://oneuptime.com/dashboard" },
+        }),
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(false);
+  });
+
+  /*
+   * The reason this helper exists. RelayState is only a SHOULD in the SAML
+   * specification: providers drop it, truncate it, or refuse to echo it on
+   * IdP-initiated flows. When that happens the cookie is the only thing left
+   * saying "this login belongs to the app", and without it the user's in-app
+   * browser lands on the web dashboard where the app can never retrieve the
+   * session.
+   */
+  test("falls back to the intent cookie when the IdP dropped RelayState", () => {
+    const cookieName: string = getMobileSsoIntentCookieName(PROVIDER_ID);
+
+    expect(
+      isMobileSsoRequest({
+        req: createFakeRequest({
+          body: { SAMLResponse: "PHNhbWw+" },
+          cookies: { [cookieName]: "true" },
+        }),
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(true);
+  });
+
+  // The set/read pair has to agree end to end, not just by inspection.
+  test("reads back the cookie setMobileSsoIntentCookie actually wrote", () => {
+    const response: FakeResponse = createFakeResponse();
+
+    setMobileSsoIntentCookie(response.express, PROVIDER_ID);
+
+    const written: RecordedCookie = response.cookiesSet[0]!;
+
+    expect(
+      isMobileSsoRequest({
+        req: createFakeRequest({
+          cookies: { [written.name]: written.value },
+        }),
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(true);
+  });
+
+  // Cross-talk guard: provider B's callback must not see provider A's intent.
+  test("ignores an intent cookie belonging to a different provider", () => {
+    const otherProviderCookie: string =
+      getMobileSsoIntentCookieName(OTHER_PROVIDER_ID);
+
+    expect(
+      isMobileSsoRequest({
+        req: createFakeRequest({
+          cookies: { [otherProviderCookie]: "true" },
+        }),
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(false);
+  });
+
+  test("returns false when no carrier is present at all", () => {
+    expect(
+      isMobileSsoRequest({
+        req: createFakeRequest({ query: {}, body: {}, cookies: {} }),
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(false);
+  });
+
+  /*
+   * Callers that have not resolved the provider yet (the outermost catch in
+   * GlobalSSO.ts, for instance) pass no providerId. The cookie cannot be
+   * looked up without one, so the answer must be a plain false rather than a
+   * throw or a name built from "undefined".
+   */
+  test("returns false for a cookie carrier when no providerId was passed", () => {
+    const cookieName: string = getMobileSsoIntentCookieName(PROVIDER_ID);
+
+    expect(
+      isMobileSsoRequest({
+        req: createFakeRequest({ cookies: { [cookieName]: "true" } }),
+      }),
+    ).toBe(false);
+  });
+
+  test("still honours RelayState when no providerId was passed", () => {
+    expect(
+      isMobileSsoRequest({
+        req: createFakeRequest({ body: { RelayState: "mobile" } }),
+      }),
+    ).toBe(true);
+  });
+
+  /*
+   * A GET callback has no body, and a route that runs before cookie-parser has
+   * no req.cookies. Both are ordinary, and neither may throw - a throw here
+   * would take down the error handler that is itself trying to report a
+   * failure to the app.
+   */
+  test("does not throw on a request with no body and no cookies", () => {
+    const req: ExpressRequest = createFakeRequest();
+
+    expect((): boolean => {
+      return isMobileSsoRequest({ req, providerId: PROVIDER_ID });
+    }).not.toThrow();
+
+    expect(isMobileSsoRequest({ req, providerId: PROVIDER_ID })).toBe(false);
+  });
+
+  test("does not throw on a request with no body and no cookies and no providerId", () => {
+    expect((): boolean => {
+      return isMobileSsoRequest({ req: createFakeRequest() });
+    }).not.toThrow();
+  });
+
+  // A body that is not an object at all (a raw string body parser, say).
+  test("does not throw when the body is not an object", () => {
+    const req: ExpressRequest = createFakeRequest({
+      body: "SAMLResponse=PHNhbWw%2B" as unknown as Record<string, unknown>,
+    });
+
+    expect((): boolean => {
+      return isMobileSsoRequest({ req, providerId: PROVIDER_ID });
+    }).not.toThrow();
+
+    expect(isMobileSsoRequest({ req, providerId: PROVIDER_ID })).toBe(false);
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * The error deep link.
+ * ---------------------------------------------------------------------------
+ */
+
+describe("buildMobileSsoErrorUrl", () => {
+  test("always starts with the app's callback scheme", () => {
+    expect(buildMobileSsoErrorUrl("sso_login_failed")).toContain(
+      "oneuptime://sso-callback",
+    );
+    expect(
+      buildMobileSsoErrorUrl("sso_login_failed").startsWith(
+        "oneuptime://sso-callback?",
+      ),
+    ).toBe(true);
+    expect(MOBILE_SSO_CALLBACK_URL).toBe("oneuptime://sso-callback");
+  });
+
+  test("carries the error code", () => {
+    expect(
+      paramsOf(buildMobileSsoErrorUrl("no_project_access")).get("error"),
+    ).toBe("no_project_access");
+  });
+
+  test("carries the description when one is given", () => {
+    const params: URLSearchParams = paramsOf(
+      buildMobileSsoErrorUrl(
+        "no_project_access",
+        "You are not a member of any project.",
+      ),
+    );
+
+    expect(params.get("error")).toBe("no_project_access");
+    expect(params.get("errorDescription")).toBe(
+      "You are not a member of any project.",
+    );
+  });
+
+  test("omits the description entirely when none is given", () => {
+    const url: string = buildMobileSsoErrorUrl("sso_login_failed");
+
+    expect(url).toBe("oneuptime://sso-callback?error=sso_login_failed");
+    expect(url).not.toContain("errorDescription");
+    expect(paramsOf(url).has("errorDescription")).toBe(false);
+  });
+
+  test("omits an empty description rather than emitting a dangling parameter", () => {
+    expect(buildMobileSsoErrorUrl("sso_login_failed", "")).toBe(
+      "oneuptime://sso-callback?error=sso_login_failed",
+    );
+  });
+
+  /*
+   * An IdP's own error text is arbitrary prose and lands here verbatim. The
+   * ampersand is the dangerous character: un-encoded it would start a new
+   * parameter, so a provider could inject `&accessToken=...` into a URL the
+   * app is about to trust. Spaces serialise to "+" (this is
+   * application/x-www-form-urlencoded, not a path), which the app's
+   * parseQueryString turns back into spaces.
+   */
+  test("encodes spaces, punctuation and an ampersand so they cannot break the query", () => {
+    const description: string =
+      "Token exchange failed: invalid_client & the state was lost (retry?)";
+
+    const url: string = buildMobileSsoErrorUrl("oidc_error", description);
+
+    expect(url).toBe(
+      "oneuptime://sso-callback?error=oidc_error&errorDescription=" +
+        "Token+exchange+failed%3A+invalid_client+%26+the+state+was+lost+%28retry%3F%29",
+    );
+
+    // No raw space, and exactly one "&" - the separator before errorDescription.
+    expect(url).not.toContain(" ");
+    expect(url.split("&")).toHaveLength(2);
+
+    // And it round-trips back to the original sentence.
+    expect(paramsOf(url).get("errorDescription")).toBe(description);
+  });
+
+  test("an injected parameter in the description stays inside the description", () => {
+    const url: string = buildMobileSsoErrorUrl(
+      "saml_error",
+      "denied&accessToken=attacker-token",
+    );
+
+    const params: URLSearchParams = paramsOf(url);
+
+    expect(params.has("accessToken")).toBe(false);
+    expect(params.get("errorDescription")).toBe(
+      "denied&accessToken=attacker-token",
+    );
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * respondToMobileSsoFailure.
+ * ---------------------------------------------------------------------------
+ */
+
+describe("respondToMobileSsoFailure", () => {
+  /*
+   * The web branch must be left completely alone: callers are written as
+   * `if (respondToMobileSsoFailure(...)) { return; }` and then fall through to
+   * rendering the ordinary error page. Sending anything here would be a
+   * double response.
+   */
+  test("returns false and does not touch the response for a web login", () => {
+    const response: FakeResponse = createFakeResponse();
+
+    const handled: boolean = respondToMobileSsoFailure({
+      res: response.express,
+      isMobileRequest: false,
+      error: "sso_login_failed",
+      errorDescription: "Something went wrong.",
+    });
+
+    expect(handled).toBe(false);
+    expectResponseUntouched(response);
+  });
+
+  test("returns true and redirects to the error deep link for a mobile login", () => {
+    const response: FakeResponse = createFakeResponse();
+
+    const handled: boolean = respondToMobileSsoFailure({
+      res: response.express,
+      isMobileRequest: true,
+      error: "no_project_access",
+      errorDescription: "You are not a member of any project.",
+    });
+
+    expect(handled).toBe(true);
+    expect(response.redirectedTo).toEqual([
+      buildMobileSsoErrorUrl(
+        "no_project_access",
+        "You are not a member of any project.",
+      ),
+    ]);
+  });
+
+  test("redirects rather than rendering a page or sending JSON", () => {
+    const response: FakeResponse = createFakeResponse();
+
+    respondToMobileSsoFailure({
+      res: response.express,
+      isMobileRequest: true,
+      error: "sso_login_failed",
+    });
+
+    expect(response.redirectedTo).toHaveLength(1);
+    expect(response.otherCalls).toEqual([]);
+    expect(
+      response.redirectedTo[0]!.startsWith("oneuptime://sso-callback?"),
+    ).toBe(true);
+  });
+
+  test("passes an absent description through as an absent parameter", () => {
+    const response: FakeResponse = createFakeResponse();
+
+    respondToMobileSsoFailure({
+      res: response.express,
+      isMobileRequest: true,
+      error: "sso_login_failed",
+    });
+
+    expect(response.redirectedTo[0]).toBe(
+      "oneuptime://sso-callback?error=sso_login_failed",
+    );
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * The success deep link.
+ * ---------------------------------------------------------------------------
+ */
+
+const EXPIRES_AT: Date = new Date("2026-09-19T12:34:56.789Z");
+
+interface SuccessOverrides {
+  globalSsoToken?: string | undefined;
+  ssoToken?: string | undefined;
+  projectId?: string | undefined;
+  email?: string | undefined;
+  name?: string | undefined;
+  isMasterAdmin?: boolean | undefined;
+}
+
+function buildSuccess(overrides: SuccessOverrides = {}): string {
+  return buildMobileSsoSuccessUrl({
+    accessToken: "access-token-value",
+    refreshToken: "refresh-token-value",
+    refreshTokenExpiresAt: EXPIRES_AT,
+    userId: "65f1c2d3e4b5a67890abcdef",
+    email: overrides.email ?? "jane.doe@example.com",
+    name: overrides.name ?? "JaneDoe",
+    isMasterAdmin: overrides.isMasterAdmin ?? false,
+    globalSsoToken: overrides.globalSsoToken,
+    ssoToken: overrides.ssoToken,
+    projectId: overrides.projectId,
+  });
+}
+
+describe("buildMobileSsoSuccessUrl", () => {
+  test("starts with the app's callback scheme", () => {
+    expect(buildSuccess().startsWith("oneuptime://sso-callback?")).toBe(true);
+  });
+
+  test("carries every param the app needs to establish a session", () => {
+    const params: URLSearchParams = paramsOf(buildSuccess());
+
+    expect(params.get("accessToken")).toBe("access-token-value");
+    expect(params.get("refreshToken")).toBe("refresh-token-value");
+    expect(params.get("userId")).toBe("65f1c2d3e4b5a67890abcdef");
+    expect(params.get("email")).toBe("jane.doe@example.com");
+    expect(params.get("name")).toBe("JaneDoe");
+    expect(params.get("isMasterAdmin")).toBe("false");
+  });
+
+  /*
+   * The app stores this and refreshes against it; it has to be a format
+   * JavaScript can parse on the other side, not a locale-dependent Date
+   * toString.
+   */
+  test("serialises refreshTokenExpiresAt as ISO-8601 UTC", () => {
+    const value: string = paramsOf(buildSuccess()).get(
+      "refreshTokenExpiresAt",
+    ) as string;
+
+    expect(value).toBe("2026-09-19T12:34:56.789Z");
+    expect(value).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(new Date(value).getTime()).toBe(EXPIRES_AT.getTime());
+  });
+
+  test('isMasterAdmin serialises as the string "true"', () => {
+    expect(
+      paramsOf(buildSuccess({ isMasterAdmin: true })).get("isMasterAdmin"),
+    ).toBe("true");
+  });
+
+  test('isMasterAdmin serialises as the string "false"', () => {
+    expect(
+      paramsOf(buildSuccess({ isMasterAdmin: false })).get("isMasterAdmin"),
+    ).toBe("false");
+  });
+
+  test("includes globalSsoToken when one is given", () => {
+    expect(
+      paramsOf(buildSuccess({ globalSsoToken: "global-token" })).get(
+        "globalSsoToken",
+      ),
+    ).toBe("global-token");
+  });
+
+  test("omits globalSsoToken when none is given", () => {
+    const url: string = buildSuccess();
+
+    expect(url).not.toContain("globalSsoToken");
+    expect(paramsOf(url).has("globalSsoToken")).toBe(false);
+  });
+
+  /*
+   * A project SSO token is meaningless without the project it belongs to - the
+   * app pairs them. Emitting half the pair would produce a token the app
+   * cannot file anywhere.
+   */
+  test("includes ssoToken and projectId when both are given", () => {
+    const params: URLSearchParams = paramsOf(
+      buildSuccess({
+        ssoToken: "project-sso-token",
+        projectId: "65a0000000000000000000ff",
+      }),
+    );
+
+    expect(params.get("ssoToken")).toBe("project-sso-token");
+    expect(params.get("projectId")).toBe("65a0000000000000000000ff");
+  });
+
+  test("omits both when only ssoToken is given", () => {
+    const params: URLSearchParams = paramsOf(
+      buildSuccess({ ssoToken: "project-sso-token" }),
+    );
+
+    expect(params.has("ssoToken")).toBe(false);
+    expect(params.has("projectId")).toBe(false);
+  });
+
+  test("omits both when only projectId is given", () => {
+    const params: URLSearchParams = paramsOf(
+      buildSuccess({ projectId: "65a0000000000000000000ff" }),
+    );
+
+    expect(params.has("ssoToken")).toBe(false);
+    expect(params.has("projectId")).toBe(false);
+  });
+
+  test("omits both when neither is given", () => {
+    const url: string = buildSuccess();
+
+    expect(url).not.toContain("ssoToken");
+    expect(url).not.toContain("projectId");
+  });
+
+  /*
+   * A plus-addressed mailbox is the value where an encoding mistake is
+   * invisible in testing and obvious in production: the app decodes "+" back
+   * to a space, so the address only survives because it went out as "%2B".
+   */
+  test("encodes an email containing + and @", () => {
+    const url: string = buildSuccess({ email: "jane.doe+oncall@example.com" });
+
+    expect(url).toContain("email=jane.doe%2Boncall%40example.com");
+    expect(paramsOf(url).get("email")).toBe("jane.doe+oncall@example.com");
+  });
+
+  test("encodes a name containing a space", () => {
+    const url: string = buildSuccess({ name: "Jane Doe" });
+
+    expect(url).toContain("name=Jane+Doe");
+    expect(url).not.toContain("name=Jane Doe");
+    expect(url).not.toContain(" ");
+    expect(paramsOf(url).get("name")).toBe("Jane Doe");
+  });
+
+  test("encodes a name containing an ampersand instead of starting a new param", () => {
+    const url: string = buildSuccess({ name: "Ben & Jerry" });
+
+    const params: URLSearchParams = paramsOf(url);
+
+    expect(params.get("name")).toBe("Ben & Jerry");
+    expect(params.has("Jerry")).toBe(false);
+  });
+});
+
+/*
+ * ---------------------------------------------------------------------------
+ * The contract with the app.
+ *
+ * PARSER ON THE OTHER SIDE:  MobileApp/src/sso/callbackUrl.ts
+ * ITS TESTS:                 MobileApp/src/sso/callbackUrl.test.ts
+ *
+ * Those two files consume exactly the strings asserted below - the fixtures
+ * there and the literals here are the same bytes, on purpose. Nothing
+ * type-checks across this boundary: the two sides only ever meet as a string
+ * handed to the OS at the end of a redirect chain, on a handset, after a real
+ * IdP login. A drift in a param name or in the encoding is neither a compile
+ * error nor a runtime error - it is a login that ends on a blank screen.
+ *
+ * If a literal below has to change, the matching fixture in
+ * MobileApp/src/sso/callbackUrl.test.ts has to change with it, or one side is
+ * shipping a format the other cannot read.
+ * ---------------------------------------------------------------------------
+ */
+
+/*
+ * An OIDC `error` / `error_description` is written by the identity provider,
+ * so it is neither trusted nor bounded. A pathologically long one would build
+ * a deep link the OS may refuse to hand back to the app - turning a failure
+ * the user could have READ into the silent dead end this module exists to
+ * prevent.
+ */
+describe("identity-provider text in an error deep link is bounded", () => {
+  test("a very long error code is truncated", () => {
+    const url: string = buildMobileSsoErrorUrl("e".repeat(5000));
+
+    const value: string = new URL(url).searchParams.get("error")!;
+
+    expect(value).toHaveLength(512);
+  });
+
+  test("a very long description is truncated", () => {
+    const url: string = buildMobileSsoErrorUrl(
+      "access_denied",
+      "d".repeat(5000),
+    );
+
+    const params: URLSearchParams = new URL(url).searchParams;
+
+    expect(params.get("error")).toBe("access_denied");
+    expect(params.get("errorDescription")).toHaveLength(512);
+  });
+
+  test("an ordinary identity-provider message is left exactly as it is", () => {
+    const description: string =
+      "The resource owner or authorized server denied the request.";
+
+    const url: string = buildMobileSsoErrorUrl("access_denied", description);
+
+    expect(new URL(url).searchParams.get("errorDescription")).toBe(description);
+  });
+
+  test("truncation still leaves a URL the app can parse", () => {
+    const url: string = buildMobileSsoErrorUrl(
+      "access_denied",
+      "%".repeat(5000),
+    );
+
+    // Percent-encoding happens after the clamp, so the URL stays well-formed.
+    expect(url.startsWith(`${MOBILE_SSO_CALLBACK_URL}?`)).toBe(true);
+    expect(new URL(url).searchParams.get("errorDescription")).toBe(
+      "%".repeat(512),
+    );
+  });
+});
+
+describe("the deep-link contract with MobileApp/src/sso/callbackUrl.ts", () => {
+  const ACCESS_TOKEN: string =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI2NWYxYzJkM2U0YjVhNjc4OTBhYmNkZWYiLCJlbWFpbCI6ImphbmUuZG9lQGV4YW1wbGUuY29tIn0.s0m3-S1gn4tur3_V4lu3";
+  const REFRESH_TOKEN: string =
+    "eyJhbGciOiJIUzI1NiJ9.cmVmcmVzaA.r3fr3sh-S1gn4tur3_V4lu3";
+  const GLOBAL_SSO_TOKEN: string =
+    "eyJhbGciOiJIUzI1NiJ9.Z2xvYmFsLXNzby10b2tlbg.gl0b4l-S1gn4tur3_V4lu3";
+
+  test("a Global SSO success URL has exactly the shape the app parses", () => {
+    const url: string = buildMobileSsoSuccessUrl({
+      accessToken: ACCESS_TOKEN,
+      refreshToken: REFRESH_TOKEN,
+      refreshTokenExpiresAt: new Date("2026-09-19T12:34:56.789Z"),
+      userId: "65f1c2d3e4b5a67890abcdef",
+      email: "jane.doe+oncall@example.com",
+      name: "Jane Doe",
+      isMasterAdmin: true,
+      globalSsoToken: GLOBAL_SSO_TOKEN,
+    });
+
+    expect(url).toBe(
+      "oneuptime://sso-callback?" +
+        "accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI2NWYxYzJkM2U0YjVhNjc4OTBhYmNkZWYiLCJlbWFpbCI6ImphbmUuZG9lQGV4YW1wbGUuY29tIn0.s0m3-S1gn4tur3_V4lu3" +
+        "&refreshToken=eyJhbGciOiJIUzI1NiJ9.cmVmcmVzaA.r3fr3sh-S1gn4tur3_V4lu3" +
+        "&refreshTokenExpiresAt=2026-09-19T12%3A34%3A56.789Z" +
+        "&userId=65f1c2d3e4b5a67890abcdef" +
+        "&email=jane.doe%2Boncall%40example.com" +
+        "&name=Jane+Doe" +
+        "&isMasterAdmin=true" +
+        "&globalSsoToken=eyJhbGciOiJIUzI1NiJ9.Z2xvYmFsLXNzby10b2tlbg.gl0b4l-S1gn4tur3_V4lu3",
+    );
+  });
+
+  test("a project SSO success URL has exactly the shape the app parses", () => {
+    const url: string = buildMobileSsoSuccessUrl({
+      accessToken: ACCESS_TOKEN,
+      refreshToken: REFRESH_TOKEN,
+      refreshTokenExpiresAt: new Date("2026-09-19T12:34:56.789Z"),
+      userId: "65f1c2d3e4b5a67890abcdef",
+      email: "jane.doe+oncall@example.com",
+      name: "Jane Doe",
+      isMasterAdmin: true,
+      ssoToken: "eyJhbGciOiJIUzI1NiJ9.cHJvamVjdC1zc28.pr0j3ct-S1gn4tur3_V4lu3",
+      projectId: "65a0000000000000000000ff",
+    });
+
+    expect(url).toBe(
+      "oneuptime://sso-callback?" +
+        "accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI2NWYxYzJkM2U0YjVhNjc4OTBhYmNkZWYiLCJlbWFpbCI6ImphbmUuZG9lQGV4YW1wbGUuY29tIn0.s0m3-S1gn4tur3_V4lu3" +
+        "&refreshToken=eyJhbGciOiJIUzI1NiJ9.cmVmcmVzaA.r3fr3sh-S1gn4tur3_V4lu3" +
+        "&refreshTokenExpiresAt=2026-09-19T12%3A34%3A56.789Z" +
+        "&userId=65f1c2d3e4b5a67890abcdef" +
+        "&email=jane.doe%2Boncall%40example.com" +
+        "&name=Jane+Doe" +
+        "&isMasterAdmin=true" +
+        "&ssoToken=eyJhbGciOiJIUzI1NiJ9.cHJvamVjdC1zc28.pr0j3ct-S1gn4tur3_V4lu3" +
+        "&projectId=65a0000000000000000000ff",
+    );
+  });
+
+  test("an error URL has exactly the shape the app parses", () => {
+    expect(
+      buildMobileSsoErrorUrl(
+        "no_project_access",
+        "You are not a member of any project. Please contact your administrator.",
+      ),
+    ).toBe(
+      "oneuptime://sso-callback?error=no_project_access&errorDescription=" +
+        "You+are+not+a+member+of+any+project.+Please+contact+your+administrator.",
+    );
+  });
+
+  test("a bare error URL has exactly the shape the app parses", () => {
+    expect(buildMobileSsoErrorUrl("sso_login_failed")).toBe(
+      "oneuptime://sso-callback?error=sso_login_failed",
+    );
+  });
+});

--- a/Common/Tests/Server/Utils/GlobalSSOToken.test.ts
+++ b/Common/Tests/Server/Utils/GlobalSSOToken.test.ts
@@ -1,0 +1,581 @@
+import UserMiddleware from "../../../Server/Middleware/UserAuthorization";
+import { EncryptionSecret } from "../../../Server/EnvironmentConfig";
+import CookieUtil from "../../../Server/Utils/Cookie";
+import { ExpressRequest, ExpressResponse } from "../../../Server/Utils/Express";
+import JSONWebToken from "../../../Server/Utils/JsonWebToken";
+import CookieName from "../../../Types/CookieName";
+import Email from "../../../Types/Email";
+import { JSONObject } from "../../../Types/JSON";
+import JSONWebTokenData from "../../../Types/JsonWebTokenData";
+import Name from "../../../Types/Name";
+import ObjectID from "../../../Types/ObjectID";
+import SsoProviderType from "../../../Types/SSO/SsoProviderType";
+import User from "../../../Models/DatabaseModels/User";
+import { describe, expect, jest, test } from "@jest/globals";
+import jwt from "jsonwebtoken";
+
+jest.mock("../../../Server/Utils/Logger");
+
+/*
+ * The Global SSO token is the credential a Global (instance-wide) SAML/OIDC
+ * login mints. Unlike the per-project `sso-<projectId>` token it carries NO
+ * project binding, which is exactly what lets one token satisfy SSO
+ * enforcement for every project the user belongs to.
+ *
+ * These tests run REAL JWT signing and verification (no mocks). The JWT secret
+ * falls back to EncryptionSecret = "secret" when ENCRYPTION_SECRET is unset
+ * (see Common/Server/EnvironmentConfig.ts), so no env setup is required.
+ *
+ * The happy path of UserMiddleware.doesSsoTokenForProjectExist accepting a
+ * global token from the `global-sso-token` cookie and from the
+ * `x-global-sso-token` header already lives in
+ * Common/Tests/Server/Middleware/UserAuthorizationSSOProvider.test.ts and is
+ * deliberately not repeated here. What follows is the payload/TTL contract and
+ * the rejection paths around it.
+ */
+
+const THIRTY_DAYS_IN_SECONDS: number = 30 * 24 * 60 * 60;
+const THIRTY_DAYS_IN_MILLISECONDS: number = THIRTY_DAYS_IN_SECONDS * 1000;
+
+const buildUser: (userId: ObjectID) => User = (userId: ObjectID): User => {
+  const user: User = new User();
+  user.id = userId;
+  user.name = new Name("Global SSO User");
+  user.email = new Email("global-sso@oneuptime.com");
+  return user;
+};
+
+const buildCookieRequest: (token: string) => ExpressRequest = (
+  token: string,
+): ExpressRequest => {
+  return {
+    cookies: { [CookieUtil.getGlobalSSOKey()]: token },
+    headers: {},
+  } as unknown as ExpressRequest;
+};
+
+const buildHeaderRequest: (token: string) => ExpressRequest = (
+  token: string,
+): ExpressRequest => {
+  return {
+    cookies: {},
+    headers: { "x-global-sso-token": token },
+  } as unknown as ExpressRequest;
+};
+
+/*
+ * Re-encodes a JWT's payload while keeping the ORIGINAL signature, which is
+ * what an attacker editing a token in transit (or in their own browser) would
+ * produce. The signature no longer covers the payload, so verification must
+ * fail.
+ */
+const tamperWithPayload: (
+  token: string,
+  mutate: (payload: JSONObject) => void,
+) => string = (
+  token: string,
+  mutate: (payload: JSONObject) => void,
+): string => {
+  const parts: Array<string> = token.split(".");
+
+  const payload: JSONObject = JSON.parse(
+    Buffer.from(parts[1] as string, "base64url").toString("utf8"),
+  ) as JSONObject;
+
+  mutate(payload);
+
+  const rewrittenPayload: string = Buffer.from(
+    JSON.stringify(payload),
+    "utf8",
+  ).toString("base64url");
+
+  return `${parts[0]}.${rewrittenPayload}.${parts[2]}`;
+};
+
+describe("CookieUtil.getGlobalSSOToken - payload", () => {
+  test("pins every claim the global token carries", () => {
+    const userId: ObjectID = ObjectID.generate();
+    const ssoProviderId: ObjectID = ObjectID.generate();
+    const user: User = buildUser(userId);
+
+    const token: string = CookieUtil.getGlobalSSOToken({
+      user,
+      ssoProviderId,
+      ssoProviderType: SsoProviderType.GlobalSSO,
+    });
+
+    const payload: JSONObject = JSONWebToken.decodeJsonPayload(token);
+
+    expect(payload["userId"]).toBe(userId.toString());
+    expect(payload["name"]).toBe("Global SSO User");
+    expect(payload["email"]).toBe("global-sso@oneuptime.com");
+    expect(payload["isMasterAdmin"]).toBe(false);
+    expect(payload["isGeneralLogin"]).toBe(false);
+    expect(payload["ssoProviderId"]).toBe(ssoProviderId.toString());
+    expect(payload["ssoProviderType"]).toBe(SsoProviderType.GlobalSSO);
+  });
+
+  test("carries NO projectId binding - that is what makes it global", () => {
+    const userId: ObjectID = ObjectID.generate();
+    const user: User = buildUser(userId);
+
+    const token: string = CookieUtil.getGlobalSSOToken({
+      user,
+      ssoProviderId: ObjectID.generate(),
+      ssoProviderType: SsoProviderType.GlobalOIDC,
+    });
+
+    /*
+     * JSONWebToken.sign normalises an absent projectId to an empty string, so
+     * assert on "no usable project id" rather than on strict absence. Either
+     * way there is nothing on the wire that could scope this token to a
+     * project.
+     */
+    const payload: JSONObject = JSONWebToken.decodeJsonPayload(token);
+    expect(payload["projectId"] || undefined).toBeUndefined();
+
+    // And the decoded view the middleware actually consumes has no project.
+    const decoded: JSONWebTokenData = JSONWebToken.decode(token);
+    expect(decoded.projectId).toBeUndefined();
+
+    // Contrast: a per-project token DOES bind a project.
+    const projectId: ObjectID = ObjectID.generate();
+    const projectToken: string = CookieUtil.getSSOToken({
+      user,
+      projectId,
+      ssoProviderId: ObjectID.generate(),
+      ssoProviderType: SsoProviderType.ProjectSSO,
+    });
+    expect(JSONWebToken.decode(projectToken).projectId?.toString()).toBe(
+      projectId.toString(),
+    );
+  });
+
+  test("both Global provider types round-trip through the token", () => {
+    const userId: ObjectID = ObjectID.generate();
+    const user: User = buildUser(userId);
+
+    const globalProviderTypes: Array<SsoProviderType> = [
+      SsoProviderType.GlobalSSO,
+      SsoProviderType.GlobalOIDC,
+    ];
+
+    for (const providerType of globalProviderTypes) {
+      const ssoProviderId: ObjectID = ObjectID.generate();
+
+      const token: string = CookieUtil.getGlobalSSOToken({
+        user,
+        ssoProviderId,
+        ssoProviderType: providerType,
+      });
+
+      const decoded: JSONWebTokenData = JSONWebToken.decode(token);
+
+      expect(decoded.ssoProviderType).toBe(providerType);
+      expect(decoded.ssoProviderId?.toString()).toBe(ssoProviderId.toString());
+      expect(decoded.userId.toString()).toBe(userId.toString());
+    }
+  });
+});
+
+/*
+ * The mobile app decodes the `exp` claim of exactly this token
+ * (MobileApp/src/utils/jwt.ts) to decide when to re-authenticate, so the TTL is
+ * part of the contract and not just a server-side detail.
+ */
+describe("CookieUtil.getGlobalSSOToken - 30 day TTL", () => {
+  test("exp is 30 days after iat", () => {
+    const token: string = CookieUtil.getGlobalSSOToken({
+      user: buildUser(ObjectID.generate()),
+      ssoProviderId: ObjectID.generate(),
+      ssoProviderType: SsoProviderType.GlobalSSO,
+    });
+
+    const payload: JSONObject = JSONWebToken.decodeJsonPayload(token);
+
+    expect(typeof payload["iat"]).toBe("number");
+    expect(typeof payload["exp"]).toBe("number");
+    expect((payload["exp"] as number) - (payload["iat"] as number)).toBe(
+      THIRTY_DAYS_IN_SECONDS,
+    );
+  });
+
+  test("exp is ~30 days out from wall-clock now (within tolerance)", () => {
+    const nowInSeconds: number = Math.floor(Date.now() / 1000);
+
+    const token: string = CookieUtil.getGlobalSSOToken({
+      user: buildUser(ObjectID.generate()),
+      ssoProviderId: ObjectID.generate(),
+      ssoProviderType: SsoProviderType.GlobalOIDC,
+    });
+
+    const payload: JSONObject = JSONWebToken.decodeJsonPayload(token);
+    const expiresAt: number = payload["exp"] as number;
+
+    const toleranceInSeconds: number = 60;
+
+    expect(expiresAt).toBeGreaterThanOrEqual(
+      nowInSeconds + THIRTY_DAYS_IN_SECONDS - toleranceInSeconds,
+    );
+    expect(expiresAt).toBeLessThanOrEqual(
+      nowInSeconds + THIRTY_DAYS_IN_SECONDS + toleranceInSeconds,
+    );
+  });
+});
+
+describe("CookieUtil.setGlobalSSOCookie", () => {
+  test("writes the token under CookieName.GlobalSSOToken, httpOnly, 30 day maxAge in ms", () => {
+    const userId: ObjectID = ObjectID.generate();
+    const ssoProviderId: ObjectID = ObjectID.generate();
+
+    const cookieCalls: Array<Array<unknown>> = [];
+    const res: ExpressResponse = {
+      cookie: (...args: Array<unknown>): void => {
+        cookieCalls.push(args);
+      },
+    } as unknown as ExpressResponse;
+
+    CookieUtil.setGlobalSSOCookie({
+      user: buildUser(userId),
+      expressResponse: res,
+      ssoProviderId,
+      ssoProviderType: SsoProviderType.GlobalSSO,
+    });
+
+    expect(cookieCalls.length).toBe(1);
+
+    const callArgs: Array<unknown> = cookieCalls[0] as Array<unknown>;
+
+    expect(callArgs[0]).toBe(CookieName.GlobalSSOToken);
+    expect(callArgs[0]).toBe("global-sso-token");
+
+    expect(callArgs[2]).toEqual({
+      path: "/",
+      sameSite: "lax",
+      httpOnly: true,
+      maxAge: THIRTY_DAYS_IN_MILLISECONDS,
+    });
+
+    // The value written is a real, verifiable global token for this user.
+    const decoded: JSONWebTokenData = JSONWebToken.decode(
+      callArgs[1] as string,
+    );
+    expect(decoded.userId.toString()).toBe(userId.toString());
+    expect(decoded.ssoProviderId?.toString()).toBe(ssoProviderId.toString());
+    expect(decoded.ssoProviderType).toBe(SsoProviderType.GlobalSSO);
+    expect(decoded.projectId).toBeUndefined();
+  });
+
+  test("the global cookie name does not collide with the per-project sso- prefix", () => {
+    /*
+     * getSsoTokens() keys every cookie starting with `sso-` by the projectId
+     * inside it. The global token has no projectId, so it must never be picked
+     * up by that parser.
+     */
+    expect(CookieUtil.getGlobalSSOKey()).toBe(CookieName.GlobalSSOToken);
+    expect(
+      CookieUtil.getGlobalSSOKey().startsWith(CookieUtil.getSSOKey()),
+    ).toBe(false);
+
+    const token: string = CookieUtil.getGlobalSSOToken({
+      user: buildUser(ObjectID.generate()),
+      ssoProviderId: ObjectID.generate(),
+      ssoProviderType: SsoProviderType.GlobalSSO,
+    });
+
+    expect(UserMiddleware.getSsoTokens(buildCookieRequest(token))).toEqual({});
+  });
+});
+
+describe("UserMiddleware.doesSsoTokenForProjectExist - global token expiry", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const ssoProviderId: ObjectID = ObjectID.generate();
+
+  const mintExpiredGlobalToken: () => string = (): string => {
+    return JSONWebToken.sign({
+      data: {
+        userId: userId,
+        name: new Name("Global SSO User"),
+        email: new Email("global-sso@oneuptime.com"),
+        isMasterAdmin: false,
+        isGeneralLogin: false,
+        ssoProviderId: ssoProviderId.toString(),
+        ssoProviderType: SsoProviderType.GlobalSSO.toString(),
+      },
+      expiresInSeconds: -60,
+    });
+  };
+
+  test("the minted token really is expired (guards the fixture itself)", () => {
+    const payload: JSONObject = jwt.decode(
+      mintExpiredGlobalToken(),
+    ) as unknown as JSONObject;
+
+    expect((payload["exp"] as number) * 1000).toBeLessThan(Date.now());
+  });
+
+  test("expired global token in the cookie -> false", () => {
+    const req: ExpressRequest = buildCookieRequest(mintExpiredGlobalToken());
+
+    expect(UserMiddleware.getGlobalSsoTokenData(req)).toBeNull();
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(req, projectId, userId),
+    ).toBe(false);
+  });
+
+  test("expired global token in the x-global-sso-token header (mobile) -> false", () => {
+    const req: ExpressRequest = buildHeaderRequest(mintExpiredGlobalToken());
+
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(req, projectId, userId),
+    ).toBe(false);
+  });
+});
+
+describe("UserMiddleware.doesSsoTokenForProjectExist - global token tampering", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const ssoProviderId: ObjectID = ObjectID.generate();
+
+  const mintValidGlobalToken: () => string = (): string => {
+    return CookieUtil.getGlobalSSOToken({
+      user: buildUser(userId),
+      ssoProviderId,
+      ssoProviderType: SsoProviderType.GlobalSSO,
+    });
+  };
+
+  test("payload edited to point at another user -> false", () => {
+    const victimUserId: ObjectID = ObjectID.generate();
+
+    const forged: string = tamperWithPayload(
+      mintValidGlobalToken(),
+      (payload: JSONObject): void => {
+        payload["userId"] = victimUserId.toString();
+      },
+    );
+
+    const req: ExpressRequest = buildCookieRequest(forged);
+
+    expect(UserMiddleware.getGlobalSsoTokenData(req)).toBeNull();
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(req, projectId, victimUserId),
+    ).toBe(false);
+    // The original owner does not get in with it either.
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(req, projectId, userId),
+    ).toBe(false);
+  });
+
+  test("payload edited to claim a different SSO provider -> false", () => {
+    const requiredProviderId: ObjectID = ObjectID.generate();
+
+    const forged: string = tamperWithPayload(
+      mintValidGlobalToken(),
+      (payload: JSONObject): void => {
+        payload["ssoProviderId"] = requiredProviderId.toString();
+      },
+    );
+
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(
+        buildCookieRequest(forged),
+        projectId,
+        userId,
+        requiredProviderId,
+      ),
+    ).toBe(false);
+  });
+
+  test("payload edited to stretch the expiry -> false", () => {
+    const forged: string = tamperWithPayload(
+      mintValidGlobalToken(),
+      (payload: JSONObject): void => {
+        payload["exp"] =
+          Math.floor(Date.now() / 1000) + 10 * THIRTY_DAYS_IN_SECONDS;
+      },
+    );
+
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(
+        buildCookieRequest(forged),
+        projectId,
+        userId,
+      ),
+    ).toBe(false);
+  });
+
+  test("token signed with a different secret -> false", () => {
+    const foreignToken: string = jwt.sign(
+      {
+        userId: userId.toString(),
+        name: "Global SSO User",
+        email: "global-sso@oneuptime.com",
+        isMasterAdmin: false,
+        isGeneralLogin: false,
+        ssoProviderId: ssoProviderId.toString(),
+        ssoProviderType: SsoProviderType.GlobalSSO,
+      },
+      `${EncryptionSecret.toString()}-not-the-real-secret`,
+      { expiresIn: THIRTY_DAYS_IN_SECONDS },
+    );
+
+    // Sanity: the same payload signed with the real secret WOULD be accepted.
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(
+        buildCookieRequest(mintValidGlobalToken()),
+        projectId,
+        userId,
+      ),
+    ).toBe(true);
+
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(
+        buildCookieRequest(foreignToken),
+        projectId,
+        userId,
+      ),
+    ).toBe(false);
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(
+        buildHeaderRequest(foreignToken),
+        projectId,
+        userId,
+      ),
+    ).toBe(false);
+  });
+
+  test("syntactically broken tokens are rejected and do not throw out of the middleware", () => {
+    const brokenTokens: Array<string> = [
+      "not-a-jwt",
+      "",
+      "a.b.c",
+      "eyJhbGciOiJIUzI1NiJ9..",
+      `${mintValidGlobalToken()}-extra`,
+    ];
+
+    for (const brokenToken of brokenTokens) {
+      for (const req of [
+        buildCookieRequest(brokenToken),
+        buildHeaderRequest(brokenToken),
+      ]) {
+        const evaluate: () => boolean = (): boolean => {
+          return UserMiddleware.doesSsoTokenForProjectExist(
+            req,
+            projectId,
+            userId,
+          );
+        };
+
+        expect(evaluate).not.toThrow();
+        expect(evaluate()).toBe(false);
+      }
+    }
+  });
+});
+
+describe("UserMiddleware.doesSsoTokenForProjectExist - global slot type confusion", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const otherProjectId: ObjectID = ObjectID.generate();
+  const userId: ObjectID = ObjectID.generate();
+  const ssoProviderId: ObjectID = ObjectID.generate();
+
+  /*
+   * UserAuthorizationSSOProvider.test.ts already covers a ProjectSSO-typed
+   * token sitting in the global COOKIE slot. These cover the remaining
+   * directions: the ProjectOIDC type, the mobile header slot, and a token with
+   * no provider type at all.
+   */
+
+  test("ProjectOIDC-typed token in the global cookie slot is ignored -> false", () => {
+    const token: string = CookieUtil.getSSOToken({
+      user: buildUser(userId),
+      projectId,
+      ssoProviderId,
+      ssoProviderType: SsoProviderType.ProjectOIDC,
+    });
+
+    const req: ExpressRequest = buildCookieRequest(token);
+
+    expect(UserMiddleware.getGlobalSsoTokenData(req)).toBeNull();
+    // otherProjectId has no per-project cookie, so only the global path could help.
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(req, otherProjectId, userId),
+    ).toBe(false);
+  });
+
+  test("project-typed token in the x-global-sso-token header is ignored -> false", () => {
+    const token: string = CookieUtil.getSSOToken({
+      user: buildUser(userId),
+      projectId,
+      ssoProviderId,
+      ssoProviderType: SsoProviderType.ProjectSSO,
+    });
+
+    const req: ExpressRequest = buildHeaderRequest(token);
+
+    expect(UserMiddleware.getGlobalSsoTokenData(req)).toBeNull();
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(req, otherProjectId, userId),
+    ).toBe(false);
+  });
+
+  test("token with NO ssoProviderType in the global slot is ignored -> false", () => {
+    const token: string = JSONWebToken.sign({
+      data: {
+        userId: userId,
+        name: new Name("Global SSO User"),
+        email: new Email("global-sso@oneuptime.com"),
+        isMasterAdmin: false,
+        isGeneralLogin: false,
+        ssoProviderId: ssoProviderId.toString(),
+      },
+      expiresInSeconds: THIRTY_DAYS_IN_SECONDS,
+    });
+
+    // The token itself verifies fine - it is the missing type that disqualifies it.
+    expect(JSONWebToken.decode(token).ssoProviderType).toBeUndefined();
+
+    for (const req of [buildCookieRequest(token), buildHeaderRequest(token)]) {
+      expect(UserMiddleware.getGlobalSsoTokenData(req)).toBeNull();
+      expect(
+        UserMiddleware.doesSsoTokenForProjectExist(req, otherProjectId, userId),
+      ).toBe(false);
+    }
+  });
+});
+
+/*
+ * Identity: UserAuthorizationSSOProvider.test.ts already covers the wrong-user
+ * global token arriving via the COOKIE. This covers the mobile header path,
+ * which is the transport Global SSO now uses from the app.
+ */
+describe("UserMiddleware.doesSsoTokenForProjectExist - global token identity", () => {
+  const projectId: ObjectID = ObjectID.generate();
+  const tokenOwnerId: ObjectID = ObjectID.generate();
+
+  test("valid global token for a DIFFERENT user, sent via header -> false", () => {
+    const token: string = CookieUtil.getGlobalSSOToken({
+      user: buildUser(tokenOwnerId),
+      ssoProviderId: ObjectID.generate(),
+      ssoProviderType: SsoProviderType.GlobalOIDC,
+    });
+
+    const req: ExpressRequest = buildHeaderRequest(token);
+
+    // The token is valid and readable...
+    const globalTokenData: JSONWebTokenData | null =
+      UserMiddleware.getGlobalSsoTokenData(req);
+    expect(globalTokenData?.userId.toString()).toBe(tokenOwnerId.toString());
+
+    // ...but it only satisfies the user it was minted for.
+    const otherUserId: ObjectID = ObjectID.generate();
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(req, projectId, otherUserId),
+    ).toBe(false);
+    expect(
+      UserMiddleware.doesSsoTokenForProjectExist(req, projectId, tokenOwnerId),
+    ).toBe(true);
+  });
+});

--- a/MobileApp/jest.config.js
+++ b/MobileApp/jest.config.js
@@ -1,28 +1,87 @@
 /*
- * jest-expo's preset is what makes React Native's ESM-only packages loadable
- * and provides the module mocks Expo's own native modules need. `node` is the
- * project name the preset uses for plain (non-platform-specific) test runs.
+ * The suite runs TWICE: once as iOS, once as Android.
+ *
+ * jest-expo's default preset hard-codes `platform: "ios"` in its Babel caller
+ * (node_modules/jest-expo/jest-preset.js), and babel-preset-expo INLINES
+ * `Platform.OS` from it. So under the plain preset every `Platform.OS` in the
+ * app is the literal "ios" at test time - which means no amount of mocking can
+ * exercise an Android code path, and an Android-only regression cannot fail
+ * the build.
+ *
+ * That matters most for SSO. `WebBrowser.openAuthSessionAsync` is a native
+ * ASWebAuthenticationSession on iOS and a JS AppState/Linking race on Android,
+ * and the two return different result types for the same successful login.
+ * Running both projects is what keeps that difference honest.
+ *
+ * jest-expo/ios and jest-expo/android are the presets Expo ships for exactly
+ * this; `projects` runs them in parallel and labels each failure with its
+ * platform.
  */
-module.exports = {
-  preset: "jest-expo",
-  setupFilesAfterEnv: ["<rootDir>/src/__tests__/setup.ts"],
-  testMatch: ["<rootDir>/src/**/*.test.ts", "<rootDir>/src/**/*.test.tsx"],
+
+const path = require("path");
+
+/*
+ * Shared between the two platform projects. `preset` is resolved per project
+ * below - everything else is identical, because a test that only holds on one
+ * platform is a test that is lying about one of them.
+ */
+const sharedProjectConfig = {
+  setupFilesAfterEnv: [path.join(__dirname, "src/__tests__/setup.ts")],
+  testMatch: [
+    "<rootDir>/src/**/*.test.ts",
+    "<rootDir>/src/**/*.test.tsx",
+  ],
   /*
    * The shared setup file lives under __tests__ so it sits with the tests it
    * serves; without this it would be collected as a (empty) test suite and
    * fail the run.
    */
-  testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/src/__tests__/setup.ts"],
+  testPathIgnorePatterns: [
+    "<rootDir>/node_modules/",
+    "<rootDir>/src/__tests__/setup.ts",
+  ],
+  clearMocks: true,
+};
+
+module.exports = {
+  projects: [
+    {
+      ...sharedProjectConfig,
+      displayName: { name: "ios", color: "white" },
+      preset: "jest-expo/ios",
+      rootDir: __dirname,
+    },
+    {
+      ...sharedProjectConfig,
+      displayName: { name: "android", color: "blueBright" },
+      preset: "jest-expo/android",
+      rootDir: __dirname,
+      testPathIgnorePatterns: [
+        ...sharedProjectConfig.testPathIgnorePatterns,
+        /*
+         * iOS-only for a TEST-TOOLING reason, not a product one. React Native
+         * renders <Switch> as the host component `RCTSwitch` on iOS and
+         * `AndroidSwitch` on Android; both carry accessibilityRole "switch",
+         * but @testing-library/react-native's role matcher only recognises the
+         * iOS one, so getByRole("switch") finds nothing under the Android
+         * preset. The Settings toggles themselves work on Android - only this
+         * suite's query does not. Everything else, including all SSO tests,
+         * runs on both platforms.
+         */
+        "<rootDir>/src/screens/SettingsScreenCriticalAlerts.test.tsx",
+      ],
+    },
+  ],
+  /*
+   * React Native component renders pull in font and native-module shims on
+   * first use, which can take well over Jest's 5s default on a cold cache -
+   * long enough to fail a screen test that is doing nothing wrong. Jest only
+   * honours this at the top level, not per project.
+   */
+  testTimeout: 30000,
   collectCoverageFrom: [
     "src/**/*.{ts,tsx}",
     "!src/**/*.test.{ts,tsx}",
     "!src/__tests__/**",
   ],
-  clearMocks: true,
-  /*
-   * React Native component renders pull in font and native-module shims on
-   * first use, which can take well over Jest's 5s default on a cold cache -
-   * long enough to fail a screen test that is doing nothing wrong.
-   */
-  testTimeout: 30000,
 };

--- a/MobileApp/src/api/clientSsoHeaders.test.ts
+++ b/MobileApp/src/api/clientSsoHeaders.test.ts
@@ -1,0 +1,646 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { clearTokens, storeTokens } from "../storage/keychain";
+import { setServerUrl } from "../storage/serverUrl";
+import {
+  clearAllSsoTokens,
+  getGlobalSsoToken,
+  getSsoTokens,
+  storeGlobalSsoToken,
+  storeSsoToken,
+} from "../storage/ssoTokens";
+import { decodeJwtPayload, type JwtPayload } from "../utils/jwt";
+import apiClient from "./client";
+import type {
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+  AxiosRequestConfig,
+} from "axios";
+import { describe, expect, test, beforeEach } from "@jest/globals";
+
+/*
+ * The SSO headers the API client attaches are the mobile equivalent of the
+ * browser's SSO cookies. Get them wrong and nothing throws, nothing logs, and
+ * no test elsewhere notices: the app simply starts collecting 406s from every
+ * SSO-enforced project, and the user is told nothing more useful than
+ * "forbidden".
+ *
+ * So the assertions below are pinned to what the SERVER actually reads, in
+ * Common/Server/Middleware/UserAuthorization.ts:
+ *
+ *   getSsoTokens()          - reads the `x-sso-tokens` header, JSON.parses it,
+ *                             and keeps only the entries whose token decodes to
+ *                             a projectId equal to the key it was filed under.
+ *   getGlobalSsoTokenData() - reads the `x-global-sso-token` header as a BARE
+ *                             token (no "Bearer ", no JSON), decodes it, and
+ *                             accepts it only when its ssoProviderType is
+ *                             GlobalSSO or GlobalOIDC.
+ *
+ * Both header names and both value shapes are re-stated in this file rather
+ * than imported, because they are a wire contract with a server that ships
+ * separately from the app.
+ *
+ * Nothing here is platform-specific - the interceptor runs identically on iOS
+ * and Android - so every test is expected to hold under both Jest projects.
+ */
+
+const SSO_TOKENS_HEADER: string = "x-sso-tokens";
+const GLOBAL_SSO_TOKEN_HEADER: string = "x-global-sso-token";
+
+const USER_ID: string = "11111111-1111-1111-1111-111111111111";
+const PROJECT_A: string = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const PROJECT_B: string = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const ONE_HOUR_IN_SECONDS: number = 60 * 60;
+
+const BASE64_ALPHABET: string =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/*
+ * Tokens are minted relative to "now" rather than pasted in as fixtures, so
+ * that the expiry cases keep meaning what they say. Payloads are pure ASCII
+ * JSON, so one char is one byte and no UTF-8 handling is needed.
+ */
+function base64UrlEncode(value: string): string {
+  let encoded: string = "";
+
+  for (let index: number = 0; index < value.length; index += 3) {
+    const byte1: number = value.charCodeAt(index);
+    const byte2: number | undefined =
+      index + 1 < value.length ? value.charCodeAt(index + 1) : undefined;
+    const byte3: number | undefined =
+      index + 2 < value.length ? value.charCodeAt(index + 2) : undefined;
+
+    encoded += BASE64_ALPHABET.charAt(byte1 >> 2);
+    encoded += BASE64_ALPHABET.charAt(
+      ((byte1 & 0x03) << 4) | ((byte2 ?? 0) >> 4),
+    );
+
+    if (byte2 === undefined) {
+      break;
+    }
+
+    encoded += BASE64_ALPHABET.charAt(
+      ((byte2 & 0x0f) << 2) | ((byte3 ?? 0) >> 6),
+    );
+
+    if (byte3 === undefined) {
+      break;
+    }
+
+    encoded += BASE64_ALPHABET.charAt(byte3 & 0x3f);
+  }
+
+  // JWT flavour: base64url, and the padding is omitted.
+  return encoded.replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+/**
+ * Mints an unsigned-but-well-formed JWT. Pass null for expiresInSeconds to omit
+ * the `exp` claim entirely, which both the app and the server read as
+ * "never expires".
+ */
+function mintJwt(
+  claims: Record<string, unknown>,
+  expiresInSeconds: number | null,
+): string {
+  const header: string = base64UrlEncode(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  );
+
+  const payload: Record<string, unknown> = { ...claims };
+
+  if (expiresInSeconds !== null) {
+    payload["exp"] = Math.floor(Date.now() / 1000) + expiresInSeconds;
+  }
+
+  /*
+   * The app never verifies the signature - the server does - so any third
+   * segment is as good as a real one here.
+   */
+  return `${header}.${base64UrlEncode(JSON.stringify(payload))}.not-a-signature`;
+}
+
+function globalToken(
+  providerType: string = "GlobalSSO",
+  expiresInSeconds: number | null = ONE_HOUR_IN_SECONDS,
+): string {
+  return mintJwt(
+    { userId: USER_ID, ssoProviderType: providerType },
+    expiresInSeconds,
+  );
+}
+
+function projectToken(
+  projectId: string,
+  expiresInSeconds: number | null = ONE_HOUR_IN_SECONDS,
+): string {
+  return mintJwt(
+    { userId: USER_ID, projectId, ssoProviderType: "ProjectSSO" },
+    expiresInSeconds,
+  );
+}
+
+/*
+ * A stand-in for the network. Axios hands a custom `config.adapter` the fully
+ * assembled request config - after every request interceptor has run - which is
+ * exactly the object the wire would have been built from. Capturing it lets
+ * these tests exercise the real interceptor in src/api/client.ts rather than a
+ * re-implementation of it, without a socket ever being opened.
+ */
+let sentConfigs: Array<InternalAxiosRequestConfig> = [];
+
+function captureAdapter(
+  config: InternalAxiosRequestConfig,
+): Promise<AxiosResponse> {
+  sentConfigs.push(config);
+
+  return Promise.resolve({
+    data: {},
+    status: 200,
+    statusText: "OK",
+    headers: {},
+    config,
+  } as AxiosResponse);
+}
+
+const adapterConfig: AxiosRequestConfig = { adapter: captureAdapter };
+
+async function get(url: string = "/api/monitor"): Promise<void> {
+  await apiClient.get(url, adapterConfig);
+}
+
+function lastRequest(): InternalAxiosRequestConfig {
+  return sentConfigs[sentConfigs.length - 1]!;
+}
+
+/**
+ * Reads a header off a captured request, matching the name case-insensitively
+ * the way an HTTP server does. Returns undefined ONLY when the header is truly
+ * absent - an empty string or the string "null" comes back as itself, so
+ * `toBeUndefined()` is a real assertion about the header not being sent.
+ */
+function headerOf(config: InternalAxiosRequestConfig, name: string): unknown {
+  const headers: Record<string, unknown> = config.headers as unknown as Record<
+    string,
+    unknown
+  >;
+
+  const key: string | undefined = Object.keys(headers).find(
+    (candidate: string): boolean => {
+      return candidate.toLowerCase() === name.toLowerCase();
+    },
+  );
+
+  return key === undefined ? undefined : headers[key];
+}
+
+/*
+ * A test-side model of UserAuthorization.getSsoTokens()'s header branch. It is
+ * deliberately as unforgiving as the server is: an entry the server drops here
+ * is an SSO token the app might as well not have sent, and the user still gets
+ * a 406.
+ */
+function ssoTokensAsServerReadsThem(
+  headerValue: unknown,
+): Record<string, string> {
+  const accepted: Record<string, string> = {};
+
+  if (typeof headerValue !== "string") {
+    return accepted;
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(headerValue);
+  } catch {
+    return accepted;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return accepted;
+  }
+
+  const headerTokens: Record<string, unknown> = parsed as Record<
+    string,
+    unknown
+  >;
+
+  for (const projectId of Object.keys(headerTokens)) {
+    const token: unknown = headerTokens[projectId];
+
+    if (!token || typeof token !== "string") {
+      continue;
+    }
+
+    const decoded: JwtPayload | null = decodeJwtPayload(token);
+
+    if (decoded && String(decoded["projectId"]) === projectId) {
+      accepted[projectId] = token;
+    }
+  }
+
+  return accepted;
+}
+
+/*
+ * A test-side model of UserAuthorization.getGlobalSsoTokenData()'s header
+ * branch: the raw header value is decoded as-is, and only a Global provider
+ * type is honoured. Returns null for anything the server would reject.
+ */
+function globalSsoTokenAsServerReadsIt(
+  headerValue: unknown,
+): JwtPayload | null {
+  if (typeof headerValue !== "string" || !headerValue) {
+    return null;
+  }
+
+  const decoded: JwtPayload | null = decodeJwtPayload(headerValue);
+
+  if (!decoded) {
+    return null;
+  }
+
+  if (
+    decoded["ssoProviderType"] === "GlobalSSO" ||
+    decoded["ssoProviderType"] === "GlobalOIDC"
+  ) {
+    return decoded;
+  }
+
+  return null;
+}
+
+/*
+ * The AsyncStorage mock in src/__tests__/setup.ts is a module-level Map that
+ * survives between tests, and both storage modules hold in-memory caches that
+ * survive with it. All of it has to be reset, or a test silently inherits the
+ * previous test's signed-in state - which for header tests would mean passing
+ * for the wrong reason.
+ */
+beforeEach(async () => {
+  sentConfigs = [];
+  await AsyncStorage.clear();
+  await clearAllSsoTokens();
+  await clearTokens();
+  await setServerUrl("https://test.oneuptime.local");
+});
+
+describe("x-global-sso-token", () => {
+  test("carries the token exactly as it was issued", async () => {
+    const token: string = globalToken();
+
+    await storeGlobalSsoToken(token);
+    await get();
+
+    expect(headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER)).toBe(token);
+  });
+
+  test("is a bare token, not a Bearer credential and not JSON", async () => {
+    /*
+     * getGlobalSsoTokenData() feeds the header straight into JSONWebToken
+     * .decode(). A "Bearer " prefix or a JSON.stringify() round-trip makes the
+     * decode throw, which the server logs and treats as "no global SSO token
+     * at all" - i.e. the user is denied while holding a perfectly valid one.
+     */
+    const token: string = globalToken();
+
+    await storeGlobalSsoToken(token);
+    await get();
+
+    const value: unknown = headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER);
+
+    expect(typeof value).toBe("string");
+    expect(value as string).not.toMatch(/^Bearer /);
+    expect(value).not.toBe(JSON.stringify(token));
+    expect((value as string).split(".")).toHaveLength(3);
+  });
+
+  test("is a token the server will actually accept", async () => {
+    const token: string = globalToken("GlobalSSO");
+
+    await storeGlobalSsoToken(token);
+    await get();
+
+    const accepted: JwtPayload | null = globalSsoTokenAsServerReadsIt(
+      headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER),
+    );
+
+    expect(accepted).not.toBeNull();
+    expect(accepted!["userId"]).toBe(USER_ID);
+    expect(accepted!["ssoProviderType"]).toBe("GlobalSSO");
+  });
+
+  test("a Global OIDC token is sent the same way as a Global SAML one", async () => {
+    /*
+     * The admin dashboard can configure either flavour instance-wide, and the
+     * server accepts both provider types on this header. The client must not
+     * treat them differently.
+     */
+    const token: string = globalToken("GlobalOIDC");
+
+    await storeGlobalSsoToken(token);
+    await get();
+
+    expect(headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER)).toBe(token);
+    expect(
+      globalSsoTokenAsServerReadsIt(
+        headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER),
+      ),
+    ).not.toBeNull();
+  });
+
+  test("is not sent at all when there is no global token", async () => {
+    await storeSsoToken(PROJECT_A, projectToken(PROJECT_A));
+    await get();
+
+    expect(headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER)).toBeUndefined();
+  });
+});
+
+describe("x-sso-tokens", () => {
+  test("is a JSON object keyed by project id", async () => {
+    const token: string = projectToken(PROJECT_A);
+
+    await storeSsoToken(PROJECT_A, token);
+    await get();
+
+    const value: unknown = headerOf(lastRequest(), SSO_TOKENS_HEADER);
+
+    expect(JSON.parse(value as string)).toEqual({ [PROJECT_A]: token });
+  });
+
+  test("carries every project the user has signed into", async () => {
+    const tokenA: string = projectToken(PROJECT_A);
+    const tokenB: string = projectToken(PROJECT_B);
+
+    await storeSsoToken(PROJECT_A, tokenA);
+    await storeSsoToken(PROJECT_B, tokenB);
+    await get();
+
+    expect(
+      JSON.parse(headerOf(lastRequest(), SSO_TOKENS_HEADER) as string),
+    ).toEqual({
+      [PROJECT_A]: tokenA,
+      [PROJECT_B]: tokenB,
+    });
+  });
+
+  test("is serialized to a string, not handed over as an object", async () => {
+    /*
+     * A header assigned a raw object reaches the server as the literal
+     * "[object Object]", which JSON.parse rejects. The server catches that,
+     * logs it, and carries on with zero SSO tokens - so the request is denied
+     * with no clue as to why.
+     */
+    await storeSsoToken(PROJECT_A, projectToken(PROJECT_A));
+    await get();
+
+    const value: unknown = headerOf(lastRequest(), SSO_TOKENS_HEADER);
+
+    expect(typeof value).toBe("string");
+    expect(value).not.toBe("[object Object]");
+  });
+
+  test("every entry survives the server's project-id cross-check", async () => {
+    /*
+     * The server does not take the key on trust: it decodes each token and
+     * drops any entry whose own projectId claim disagrees with the key it was
+     * filed under. Sending a map the server then empties is the same as
+     * sending nothing.
+     */
+    const tokenA: string = projectToken(PROJECT_A);
+    const tokenB: string = projectToken(PROJECT_B);
+
+    await storeSsoToken(PROJECT_A, tokenA);
+    await storeSsoToken(PROJECT_B, tokenB);
+    await get();
+
+    expect(
+      ssoTokensAsServerReadsThem(headerOf(lastRequest(), SSO_TOKENS_HEADER)),
+    ).toEqual({
+      [PROJECT_A]: tokenA,
+      [PROJECT_B]: tokenB,
+    });
+  });
+
+  test("is not sent at all when no project token is held", async () => {
+    await storeGlobalSsoToken(globalToken());
+    await get();
+
+    expect(headerOf(lastRequest(), SSO_TOKENS_HEADER)).toBeUndefined();
+  });
+});
+
+describe("the two headers are independent", () => {
+  test("both are sent when the user holds both kinds of token", async () => {
+    /*
+     * A user can hold a global token from an instance-wide login AND a
+     * per-project token from an older project-level login. Neither may crowd
+     * the other out: the server consults them separately, project token first.
+     */
+    const global: string = globalToken();
+    const project: string = projectToken(PROJECT_A);
+
+    await storeGlobalSsoToken(global);
+    await storeSsoToken(PROJECT_A, project);
+    await get();
+
+    expect(headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER)).toBe(global);
+    expect(
+      JSON.parse(headerOf(lastRequest(), SSO_TOKENS_HEADER) as string),
+    ).toEqual({ [PROJECT_A]: project });
+  });
+
+  test("neither is sent when the user holds no SSO token", async () => {
+    /*
+     * Not "", not "null", not the key with an undefined value - absent. An
+     * empty-string x-sso-tokens is falsy on the server and harmless, but an
+     * x-global-sso-token of "null" is a truthy string that goes into
+     * JSONWebToken.decode() and throws on every single request.
+     */
+    await get();
+
+    expect(headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER)).toBeUndefined();
+    expect(headerOf(lastRequest(), SSO_TOKENS_HEADER)).toBeUndefined();
+  });
+
+  test("an empty project-token map is not sent as {}", async () => {
+    /*
+     * getSsoTokens() returns {} rather than null once the store has been read
+     * and found empty. Stringifying that unconditionally would put a useless
+     * "{}" on every request the app ever makes.
+     */
+    await storeSsoToken(PROJECT_A, projectToken(PROJECT_A));
+    await clearAllSsoTokens();
+    await get();
+
+    expect(headerOf(lastRequest(), SSO_TOKENS_HEADER)).toBeUndefined();
+  });
+});
+
+describe("the SSO headers sit alongside the normal auth headers", () => {
+  test("the Bearer token is still attached with both SSO headers present", async () => {
+    /*
+     * SSO enforcement is a second gate, not a replacement for the session.
+     * A request carrying SSO proof but no Authorization header is anonymous,
+     * and the server 401s it before it ever looks at SSO.
+     */
+    await storeTokens({
+      accessToken: "access-token-value",
+      refreshToken: "refresh-token-value",
+      refreshTokenExpiresAt: new Date(Date.now() + 86400000).toISOString(),
+    });
+    await storeGlobalSsoToken(globalToken());
+    await storeSsoToken(PROJECT_A, projectToken(PROJECT_A));
+    await get();
+
+    const request: InternalAxiosRequestConfig = lastRequest();
+
+    expect(headerOf(request, "Authorization")).toBe(
+      "Bearer access-token-value",
+    );
+    expect(headerOf(request, GLOBAL_SSO_TOKEN_HEADER)).toBeDefined();
+    expect(headerOf(request, SSO_TOKENS_HEADER)).toBeDefined();
+  });
+
+  test("the SSO headers do not disturb the caller's own headers", async () => {
+    await storeGlobalSsoToken(globalToken());
+
+    await apiClient.get("/api/monitor", {
+      ...adapterConfig,
+      headers: { "x-custom-trace": "trace-1" },
+    });
+
+    expect(headerOf(lastRequest(), "x-custom-trace")).toBe("trace-1");
+    expect(headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER)).toBeDefined();
+    expect(headerOf(lastRequest(), "Content-Type")).toBe("application/json");
+  });
+
+  test("the base URL is still resolved from stored settings", async () => {
+    await storeGlobalSsoToken(globalToken());
+    await get();
+
+    expect(lastRequest().baseURL).toBe("https://test.oneuptime.local");
+  });
+});
+
+describe("expired tokens never reach the wire", () => {
+  test("an expired global token is evicted on read and never sent", async () => {
+    /*
+     * Driven end to end, because the interceptor itself does no expiry check -
+     * it trusts the cache. The cache is only corrected when the storage layer
+     * reads through, which is what happens on app start. If eviction did not
+     * also clear the in-memory cache, the app would keep presenting a dead
+     * token on every request for the whole session.
+     */
+    const expired: string = globalToken("GlobalSSO", -ONE_HOUR_IN_SECONDS);
+
+    await storeGlobalSsoToken(expired);
+
+    expect(await getGlobalSsoToken()).toBeNull();
+
+    await get();
+
+    expect(headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER)).toBeUndefined();
+  });
+
+  test("an expired project token is dropped while a live sibling still goes", async () => {
+    const live: string = projectToken(PROJECT_A);
+    const expired: string = projectToken(PROJECT_B, -ONE_HOUR_IN_SECONDS);
+
+    await storeSsoToken(PROJECT_A, live);
+    await storeSsoToken(PROJECT_B, expired);
+
+    await getSsoTokens();
+    await get();
+
+    const sent: Record<string, unknown> = JSON.parse(
+      headerOf(lastRequest(), SSO_TOKENS_HEADER) as string,
+    );
+
+    expect(sent).toEqual({ [PROJECT_A]: live });
+    expect(sent[PROJECT_B]).toBeUndefined();
+  });
+
+  test("the header disappears entirely once the last project token lapses", async () => {
+    await storeSsoToken(
+      PROJECT_A,
+      projectToken(PROJECT_A, -ONE_HOUR_IN_SECONDS),
+    );
+
+    await getSsoTokens();
+    await get();
+
+    expect(headerOf(lastRequest(), SSO_TOKENS_HEADER)).toBeUndefined();
+  });
+
+  test("a global token with no exp claim is still sent", async () => {
+    /*
+     * "No exp" means "does not expire" to both the decoder and the server.
+     * Treating a missing claim as expired would lock out any deployment that
+     * mints non-expiring SSO tokens.
+     */
+    const token: string = globalToken("GlobalSSO", null);
+
+    await storeGlobalSsoToken(token);
+
+    expect(await getGlobalSsoToken()).toBe(token);
+
+    await get();
+
+    expect(headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER)).toBe(token);
+  });
+});
+
+describe("every request carries them, not just the first", () => {
+  test("a second request is headed the same as the first", async () => {
+    /*
+     * The cache is read per request, not consumed. A regression that moved the
+     * read outside the interceptor would authenticate the first call of a
+     * session and silently strip the rest.
+     */
+    const token: string = globalToken();
+
+    await storeGlobalSsoToken(token);
+    await get("/api/monitor");
+    await get("/api/incident");
+
+    expect(sentConfigs).toHaveLength(2);
+    expect(headerOf(sentConfigs[0]!, GLOBAL_SSO_TOKEN_HEADER)).toBe(token);
+    expect(headerOf(sentConfigs[1]!, GLOBAL_SSO_TOKEN_HEADER)).toBe(token);
+  });
+
+  test("a POST carries them as well as a GET", async () => {
+    const global: string = globalToken();
+    const project: string = projectToken(PROJECT_A);
+
+    await storeGlobalSsoToken(global);
+    await storeSsoToken(PROJECT_A, project);
+
+    await apiClient.post("/api/incident", { name: "test" }, adapterConfig);
+
+    expect(headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER)).toBe(global);
+    expect(
+      JSON.parse(headerOf(lastRequest(), SSO_TOKENS_HEADER) as string),
+    ).toEqual({ [PROJECT_A]: project });
+  });
+
+  test("signing out stops the tokens being presented from the next request on", async () => {
+    /*
+     * The other side of the cache being trusted: if clearing the store left the
+     * in-memory copy behind, a signed-out handset would keep proving an SSO
+     * identity to the server.
+     */
+    await storeGlobalSsoToken(globalToken());
+    await storeSsoToken(PROJECT_A, projectToken(PROJECT_A));
+    await get();
+
+    expect(headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER)).toBeDefined();
+
+    await clearAllSsoTokens();
+    await get();
+
+    expect(headerOf(lastRequest(), GLOBAL_SSO_TOKEN_HEADER)).toBeUndefined();
+    expect(headerOf(lastRequest(), SSO_TOKENS_HEADER)).toBeUndefined();
+  });
+});

--- a/MobileApp/src/api/sso.test.ts
+++ b/MobileApp/src/api/sso.test.ts
@@ -1,0 +1,690 @@
+import axios from "axios";
+import { getServerUrl } from "../storage/serverUrl";
+import {
+  GlobalSSOProvider,
+  SSOProvider,
+  SsoDiscoveryResult,
+  fetchAllGlobalProviders,
+  fetchGlobalOIDCProviders,
+  fetchGlobalSSOProviders,
+  fetchProjectProvidersForEmail,
+  fetchSSOProvidersForProject,
+} from "./sso";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+
+jest.mock("axios", () => {
+  return {
+    __esModule: true,
+    default: {
+      get: jest.fn(),
+      post: jest.fn(),
+    },
+  };
+});
+
+/*
+ * The server address is whatever the responder typed on the first screen -
+ * a self-hosted instance more often than not - so every discovery URL below
+ * has to be built from storage rather than from a compiled-in host.
+ */
+const SERVER_URL: string = "https://test.oneuptime.com";
+
+jest.mock("../storage/serverUrl", () => {
+  return {
+    __esModule: true,
+    getServerUrl: jest.fn(async () => {
+      return "https://test.oneuptime.com";
+    }),
+  };
+});
+
+function getSpy(): jest.SpyInstance {
+  return axios.get as unknown as jest.SpyInstance;
+}
+
+function postSpy(): jest.SpyInstance {
+  return axios.post as unknown as jest.SpyInstance;
+}
+
+function serverUrlSpy(): jest.SpyInstance {
+  return getServerUrl as unknown as jest.SpyInstance;
+}
+
+function firstGetUrl(): string {
+  return getSpy().mock.calls[0]![0] as string;
+}
+
+function firstGetConfig(): Record<string, unknown> {
+  return getSpy().mock.calls[0]![1] as Record<string, unknown>;
+}
+
+/** Resolve every axios.get with this body, whichever URL is asked for. */
+function respondWith(data: unknown): void {
+  getSpy().mockResolvedValue({ data } as never);
+}
+
+type Outcome = { data: unknown } | Error;
+
+/*
+ * Route the two global discovery calls independently. fetchAllGlobalProviders
+ * fires them in parallel, so the only way to describe "SAML answered, OIDC
+ * did not" is to key off the URL.
+ */
+function stubGlobalEndpoints(saml: Outcome, oidc: Outcome): void {
+  getSpy().mockImplementation((url: string): Promise<unknown> => {
+    const outcome: Outcome = url.includes("/global-sso/") ? saml : oidc;
+
+    if (outcome instanceof Error) {
+      return Promise.reject(outcome);
+    }
+
+    return Promise.resolve(outcome);
+  });
+}
+
+/** A discovery payload in the shape the server actually sends. */
+function wrapped(items: Array<unknown>): { data: Array<unknown> } {
+  return { data: items };
+}
+
+beforeEach(() => {
+  getSpy().mockReset();
+  postSpy().mockReset();
+  serverUrlSpy().mockReset();
+  serverUrlSpy().mockResolvedValue(SERVER_URL as never);
+});
+
+describe("The global discovery endpoints are the ones the server registers", () => {
+  /*
+   * These two literals are a contract with
+   * App/FeatureSet/Identity/API/GlobalSSO.ts ("/global-sso/service-provider-login")
+   * and GlobalOIDC.ts ("/global-oidc/service-provider-login"). A typo here does
+   * not fail to compile and does not throw: the request 404s, discovery is
+   * caught as "endpoint down", and the login screen simply offers no global
+   * providers at all - which looks exactly like an instance that has none.
+   */
+  test("global SAML discovery GETs /identity/global-sso/service-provider-login", async () => {
+    respondWith(wrapped([]));
+
+    await fetchGlobalSSOProviders();
+
+    expect(firstGetUrl()).toBe(
+      `${SERVER_URL}/identity/global-sso/service-provider-login`,
+    );
+  });
+
+  test("global OIDC discovery GETs /identity/global-oidc/service-provider-login", async () => {
+    respondWith(wrapped([]));
+
+    await fetchGlobalOIDCProviders();
+
+    expect(firstGetUrl()).toBe(
+      `${SERVER_URL}/identity/global-oidc/service-provider-login`,
+    );
+  });
+
+  test("the base URL comes from the stored server, not a hard-coded host", async () => {
+    serverUrlSpy().mockResolvedValue("https://status.acme.internal" as never);
+    respondWith(wrapped([]));
+
+    await fetchGlobalSSOProviders();
+
+    expect(firstGetUrl()).toBe(
+      "https://status.acme.internal/identity/global-sso/service-provider-login",
+    );
+  });
+
+  test("discovery carries a timeout so an unreachable host cannot wedge the screen", async () => {
+    /*
+     * Global discovery runs unprompted while the login screen is drawing. With
+     * no timeout an IdP host that accepts the connection and never answers
+     * leaves the buttons in a spinner forever rather than falling through to
+     * the password form.
+     */
+    respondWith(wrapped([]));
+
+    await fetchGlobalSSOProviders();
+
+    expect(firstGetConfig()["timeout"]).toBe(15000);
+  });
+
+  test("global discovery sends no email - the providers are instance-wide", async () => {
+    /*
+     * Project SSO is discovered per email address; global SSO is not scoped to
+     * one, and sending an email here would imply a filter the server does not
+     * apply.
+     */
+    respondWith(wrapped([]));
+
+    await fetchGlobalSSOProviders();
+
+    expect(firstGetConfig()["params"]).toBeUndefined();
+  });
+});
+
+describe("Discovery tolerates both payload shapes the server can produce", () => {
+  /*
+   * The route answers through sendEntityArrayResponse, which wraps the list in
+   * `{ data: [...] }` - but middleware in front of it has shipped a bare array
+   * before. Handling only one of the two turns a working instance into one
+   * with "no SSO providers", with nothing logged.
+   */
+  test("accepts the wrapped { data: [...] } payload", async () => {
+    respondWith(wrapped([{ _id: "a", name: "Okta" }]));
+
+    const providers: Array<GlobalSSOProvider> = await fetchGlobalSSOProviders();
+
+    expect(providers).toHaveLength(1);
+    expect(providers[0]!.name).toBe("Okta");
+  });
+
+  test("accepts a bare array payload", async () => {
+    respondWith([{ _id: "a", name: "Okta" }]);
+
+    const providers: Array<GlobalSSOProvider> = await fetchGlobalSSOProviders();
+
+    expect(providers).toHaveLength(1);
+    expect(providers[0]!.name).toBe("Okta");
+  });
+
+  test("an empty wrapped list is an empty list, not an error", async () => {
+    respondWith(wrapped([]));
+
+    await expect(fetchGlobalSSOProviders()).resolves.toEqual([]);
+  });
+
+  test("an empty bare array is an empty list", async () => {
+    respondWith([]);
+
+    await expect(fetchGlobalOIDCProviders()).resolves.toEqual([]);
+  });
+
+  test("a null body yields an empty list instead of throwing", async () => {
+    /*
+     * A 204, or a proxy that returns an empty body, arrives as null. Throwing
+     * here would be reported as an outage; it is not one.
+     */
+    respondWith(null);
+
+    await expect(fetchGlobalSSOProviders()).resolves.toEqual([]);
+  });
+
+  test("an undefined body yields an empty list instead of throwing", async () => {
+    respondWith(undefined);
+
+    await expect(fetchGlobalOIDCProviders()).resolves.toEqual([]);
+  });
+
+  test("a body whose data is not an array yields an empty list", async () => {
+    // e.g. an error envelope, `{ message: "..." }`, served with a 200.
+    respondWith({ data: { message: "unauthorized" } });
+
+    await expect(fetchGlobalSSOProviders()).resolves.toEqual([]);
+  });
+});
+
+describe("ObjectID fields are de-serialised to plain strings", () => {
+  /*
+   * OneUptime serialises every id as { _type: "ObjectID", value: "<uuid>" }.
+   * The id is pasted straight into the IdP login URL
+   * (/identity/global-sso/:id), so an object that survives parsing becomes the
+   * literal "[object Object]" in the URL and the login 404s at the IdP.
+   */
+  test("an _id sent as an ObjectID envelope becomes the bare uuid", async () => {
+    respondWith(
+      wrapped([
+        {
+          _id: {
+            _type: "ObjectID",
+            value: "0f7a4f4a-1c2b-4d3e-9a8b-7c6d5e4f3a2b",
+          },
+          name: "Okta",
+        },
+      ]),
+    );
+
+    const providers: Array<GlobalSSOProvider> = await fetchGlobalSSOProviders();
+
+    expect(providers[0]!._id).toBe("0f7a4f4a-1c2b-4d3e-9a8b-7c6d5e4f3a2b");
+  });
+
+  test("an _id that is already a plain string is left alone", async () => {
+    respondWith(wrapped([{ _id: "plain-string-id", name: "Okta" }]));
+
+    const providers: Array<GlobalSSOProvider> = await fetchGlobalSSOProviders();
+
+    expect(providers[0]!._id).toBe("plain-string-id");
+  });
+
+  test("a missing _id becomes an empty string rather than undefined", async () => {
+    respondWith(wrapped([{ name: "Okta" }]));
+
+    const providers: Array<GlobalSSOProvider> = await fetchGlobalSSOProviders();
+
+    expect(providers[0]!._id).toBe("");
+  });
+});
+
+describe("The type discriminator is stamped by the endpoint, not the payload", () => {
+  /*
+   * The discovery payload carries only id/name/description - no type. The
+   * `type` is what picks the login route later (/identity/global-sso/:id vs
+   * /identity/global-oidc/:id), so getting it from the endpoint that answered
+   * is the only thing keeping a SAML provider from being sent through the OIDC
+   * flow.
+   */
+  test("every provider from the SAML endpoint is typed global-sso", async () => {
+    respondWith(wrapped([{ _id: "a", name: "Okta" }, { _id: "b" }]));
+
+    const providers: Array<GlobalSSOProvider> = await fetchGlobalSSOProviders();
+
+    expect(
+      providers.map((provider: GlobalSSOProvider) => {
+        return provider.type;
+      }),
+    ).toEqual(["global-sso", "global-sso"]);
+  });
+
+  test("every provider from the OIDC endpoint is typed global-oidc", async () => {
+    respondWith(wrapped([{ _id: "a", name: "Entra" }, { _id: "b" }]));
+
+    const providers: Array<GlobalSSOProvider> =
+      await fetchGlobalOIDCProviders();
+
+    expect(
+      providers.map((provider: GlobalSSOProvider) => {
+        return provider.type;
+      }),
+    ).toEqual(["global-oidc", "global-oidc"]);
+  });
+
+  test("a type field in the payload never overrides the endpoint that answered", async () => {
+    /*
+     * Nothing on the server sends this field today. If something ever starts -
+     * or a stale cached body carries one - the endpoint still has to win, or a
+     * SAML provider would be started through the OIDC route.
+     */
+    respondWith(wrapped([{ _id: "a", name: "Okta", type: "global-oidc" }]));
+
+    const providers: Array<GlobalSSOProvider> = await fetchGlobalSSOProviders();
+
+    expect(providers[0]!.type).toBe("global-sso");
+  });
+});
+
+describe("Provider labels survive a sparse payload", () => {
+  test("a missing name becomes an empty string, never undefined", async () => {
+    /*
+     * The name is rendered as the button label. undefined renders as nothing
+     * on iOS and crashes some list rows; "" at least renders an empty,
+     * tappable button.
+     */
+    respondWith(wrapped([{ _id: "a" }]));
+
+    const providers: Array<GlobalSSOProvider> = await fetchGlobalSSOProviders();
+
+    expect(providers[0]!.name).toBe("");
+  });
+
+  test("a null name becomes an empty string too", async () => {
+    respondWith(wrapped([{ _id: "a", name: null }]));
+
+    const providers: Array<GlobalSSOProvider> = await fetchGlobalSSOProviders();
+
+    expect(providers[0]!.name).toBe("");
+  });
+
+  test("the description is passed through untouched", async () => {
+    respondWith(
+      wrapped([{ _id: "a", name: "Okta", description: "Corp directory" }]),
+    );
+
+    const providers: Array<GlobalSSOProvider> = await fetchGlobalSSOProviders();
+
+    expect(providers[0]!.description).toBe("Corp directory");
+  });
+
+  test("a missing description stays undefined so the row can omit it", async () => {
+    respondWith(wrapped([{ _id: "a", name: "Okta" }]));
+
+    const providers: Array<GlobalSSOProvider> = await fetchGlobalSSOProviders();
+
+    expect(providers[0]!.description).toBeUndefined();
+  });
+});
+
+describe("fetchAllGlobalProviders keeps a half-broken instance usable", () => {
+  const samlPayload: { data: Array<unknown> } = wrapped([
+    { _id: "saml-1", name: "Okta" },
+  ]);
+  const oidcPayload: { data: Array<unknown> } = wrapped([
+    { _id: "oidc-1", name: "Entra" },
+  ]);
+
+  test("both endpoints answering: SAML first, then OIDC, and failed is false", async () => {
+    /*
+     * Order is stable on purpose - the select screen lists them in this order,
+     * and Promise.all preserves it regardless of which request returns first.
+     */
+    stubGlobalEndpoints({ data: samlPayload }, { data: oidcPayload });
+
+    const result: SsoDiscoveryResult<GlobalSSOProvider> =
+      await fetchAllGlobalProviders();
+
+    expect(result.failed).toBe(false);
+    expect(
+      result.providers.map((provider: GlobalSSOProvider) => {
+        return [provider.name, provider.type];
+      }),
+    ).toEqual([
+      ["Okta", "global-sso"],
+      ["Entra", "global-oidc"],
+    ]);
+  });
+
+  test("only SAML failing still returns the OIDC providers, and failed is false", async () => {
+    /*
+     * One endpoint down is not an outage the user can do anything about, and
+     * the other half of the screen still logs them in. Reporting failure here
+     * would hide a working login behind a retry prompt.
+     */
+    stubGlobalEndpoints(new Error("saml 500"), { data: oidcPayload });
+
+    const result: SsoDiscoveryResult<GlobalSSOProvider> =
+      await fetchAllGlobalProviders();
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toHaveLength(1);
+    expect(result.providers[0]!.type).toBe("global-oidc");
+  });
+
+  test("only OIDC failing still returns the SAML providers, and failed is false", async () => {
+    stubGlobalEndpoints({ data: samlPayload }, new Error("oidc timeout"));
+
+    const result: SsoDiscoveryResult<GlobalSSOProvider> =
+      await fetchAllGlobalProviders();
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toHaveLength(1);
+    expect(result.providers[0]!.type).toBe("global-sso");
+  });
+
+  test("both endpoints failing is the only case reported as failed", async () => {
+    stubGlobalEndpoints(new Error("offline"), new Error("offline"));
+
+    const result: SsoDiscoveryResult<GlobalSSOProvider> =
+      await fetchAllGlobalProviders();
+
+    expect(result.failed).toBe(true);
+    expect(result.providers).toEqual([]);
+  });
+
+  test("an instance with no global SSO at all is empty but NOT failed", async () => {
+    /*
+     * The distinction the whole SsoDiscoveryResult type exists for: "your
+     * instance has no SSO" and "we could not reach your server" are the same
+     * empty list, and only the second is worth a retry button.
+     */
+    stubGlobalEndpoints({ data: wrapped([]) }, { data: wrapped([]) });
+
+    const result: SsoDiscoveryResult<GlobalSSOProvider> =
+      await fetchAllGlobalProviders();
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toEqual([]);
+  });
+
+  test("both endpoints are asked, not just the first one that answers", async () => {
+    stubGlobalEndpoints({ data: samlPayload }, { data: oidcPayload });
+
+    await fetchAllGlobalProviders();
+
+    const urls: Array<string> = getSpy().mock.calls.map(
+      (call: Array<unknown>) => {
+        return call[0] as string;
+      },
+    );
+
+    expect(urls).toHaveLength(2);
+    expect(urls).toContain(
+      `${SERVER_URL}/identity/global-sso/service-provider-login`,
+    );
+    expect(urls).toContain(
+      `${SERVER_URL}/identity/global-oidc/service-provider-login`,
+    );
+  });
+});
+
+describe("fetchProjectProvidersForEmail separates 'none' from 'unreachable'", () => {
+  test("sends the email as a query param to the project discovery route", async () => {
+    respondWith({ data: [] });
+
+    await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(firstGetUrl()).toBe(`${SERVER_URL}/identity/service-provider-login`);
+    expect(firstGetConfig()["params"]).toEqual({
+      email: "responder@acme.com",
+    });
+  });
+
+  test("a network error is reported as failed rather than thrown", async () => {
+    /*
+     * This runs while the user is typing their email on the login screen. An
+     * exception escaping here is an unhandled rejection in a keystroke
+     * handler; the caller needs a value it can render.
+     */
+    getSpy().mockRejectedValue(new Error("Network Error") as never);
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(true);
+    expect(result.providers).toEqual([]);
+  });
+
+  /*
+   * The server does not answer "no SSO for this email" with an empty 200. It
+   * answers with HTTP 400 BadRequestException("No SSO config found for this
+   * user") - see App/FeatureSet/Identity/API/SSO.ts, which does this for an
+   * unknown user, a user with no id, and a user in no project alike. axios
+   * rejects on 4xx, so a blanket catch would turn the single most common
+   * outcome of this call into "we could not reach your server", telling a user
+   * whose network is fine to go and check their network.
+   *
+   * The rule: a response arrived at all (< 500) means the server was reached
+   * and had its say. Only a transport error or a 5xx is an outage.
+   */
+  test("the server's 400 'No SSO config found for this user' is a real answer, NOT an outage", async () => {
+    getSpy().mockRejectedValue({
+      response: {
+        status: 400,
+        data: { message: "No SSO config found for this user" },
+      },
+    } as never);
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("nobody@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toEqual([]);
+  });
+
+  test.each([400, 401, 403, 404, 422, 499])(
+    "a %s response is the server answering, not an outage",
+    async (status: number) => {
+      getSpy().mockRejectedValue({ response: { status } } as never);
+
+      const result: SsoDiscoveryResult<SSOProvider> =
+        await fetchProjectProvidersForEmail("responder@acme.com");
+
+      expect(result.failed).toBe(false);
+    },
+  );
+
+  test.each([500, 502, 503, 504])(
+    "a %s response IS an outage worth retrying",
+    async (status: number) => {
+      getSpy().mockRejectedValue({ response: { status } } as never);
+
+      const result: SsoDiscoveryResult<SSOProvider> =
+        await fetchProjectProvidersForEmail("responder@acme.com");
+
+      expect(result.failed).toBe(true);
+    },
+  );
+
+  test("a rejection carrying a response with no status is treated as an outage", async () => {
+    // Defensive: a shape we do not recognise must fail towards "try again".
+    getSpy().mockRejectedValue({ response: {} } as never);
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(true);
+  });
+
+  test("an email with genuinely no SSO is empty and NOT failed", async () => {
+    /*
+     * The regression this guards: an earlier version flattened an unreachable
+     * server into "no SSO providers for this email", which told a user on a
+     * broken VPN that their company had never configured SSO.
+     */
+    respondWith({ data: [] });
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(result.providers).toEqual([]);
+  });
+
+  test("parses the project id and project name off a real payload", async () => {
+    respondWith({
+      data: [
+        {
+          _id: { _type: "ObjectID", value: "sso-1" },
+          name: "Acme Okta",
+          description: "Acme staff",
+          projectId: { _type: "ObjectID", value: "project-1" },
+          project: { name: "Acme" },
+        },
+      ],
+    });
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.failed).toBe(false);
+    expect(result.providers[0]).toEqual({
+      _id: "sso-1",
+      name: "Acme Okta",
+      description: "Acme staff",
+      projectId: "project-1",
+      project: { name: "Acme" },
+    });
+  });
+
+  test("a provider with no project name carries no project object", async () => {
+    /*
+     * The select screen prints "<provider> - <project>" only when there is a
+     * project to print; an empty-string project name would render a dangling
+     * separator.
+     */
+    respondWith({
+      data: [{ _id: "sso-1", name: "Okta", project: { name: "" } }],
+    });
+
+    const result: SsoDiscoveryResult<SSOProvider> =
+      await fetchProjectProvidersForEmail("responder@acme.com");
+
+    expect(result.providers[0]!.project).toBeUndefined();
+  });
+});
+
+describe("fetchSSOProvidersForProject", () => {
+  test("POSTs to /api/project-sso/:projectId/sso-list", async () => {
+    postSpy().mockResolvedValue({ data: { data: [] } } as never);
+
+    await fetchSSOProvidersForProject("project-1");
+
+    expect(postSpy().mock.calls[0]![0]).toBe(
+      `${SERVER_URL}/api/project-sso/project-1/sso-list`,
+    );
+    expect(postSpy().mock.calls[0]![1]).toEqual({});
+    expect(
+      (postSpy().mock.calls[0]![2] as Record<string, unknown>)["timeout"],
+    ).toBe(15000);
+  });
+
+  test("stamps the requested projectId onto every provider", async () => {
+    /*
+     * This endpoint is already scoped to one project and its rows do not carry
+     * a projectId back. Without the stamp the provider reaches the login flow
+     * with projectId "" and the resulting SSO token is filed under no project
+     * at all - so the API client never attaches it.
+     */
+    postSpy().mockResolvedValue({
+      data: { data: [{ _id: "sso-1", name: "Okta" }, { _id: "sso-2" }] },
+    } as never);
+
+    const providers: Array<SSOProvider> =
+      await fetchSSOProvidersForProject("project-1");
+
+    expect(
+      providers.map((provider: SSOProvider) => {
+        return provider.projectId;
+      }),
+    ).toEqual(["project-1", "project-1"]);
+  });
+
+  test("the requested projectId wins over one the payload carries", async () => {
+    postSpy().mockResolvedValue({
+      data: {
+        data: [
+          {
+            _id: "sso-1",
+            name: "Okta",
+            projectId: { _type: "ObjectID", value: "some-other-project" },
+          },
+        ],
+      },
+    } as never);
+
+    const providers: Array<SSOProvider> =
+      await fetchSSOProvidersForProject("project-1");
+
+    expect(providers[0]!.projectId).toBe("project-1");
+  });
+
+  test("still de-serialises the provider's own ObjectID _id", async () => {
+    postSpy().mockResolvedValue({
+      data: {
+        data: [{ _id: { _type: "ObjectID", value: "sso-uuid" }, name: "Okta" }],
+      },
+    } as never);
+
+    const providers: Array<SSOProvider> =
+      await fetchSSOProvidersForProject("project-1");
+
+    expect(providers[0]!._id).toBe("sso-uuid");
+  });
+
+  test("an empty body yields an empty list rather than throwing", async () => {
+    postSpy().mockResolvedValue({ data: null } as never);
+
+    await expect(fetchSSOProvidersForProject("project-1")).resolves.toEqual([]);
+  });
+
+  test("a network error is surfaced to the caller, not swallowed", async () => {
+    /*
+     * Unlike the discovery helpers, this one is called from a screen the user
+     * opened deliberately, so an empty list would read as "this project has no
+     * SSO" - the caller has to be able to tell the two apart.
+     */
+    postSpy().mockRejectedValue(new Error("Network Error") as never);
+
+    await expect(fetchSSOProvidersForProject("project-1")).rejects.toThrow(
+      "Network Error",
+    );
+  });
+});

--- a/MobileApp/src/api/sso.ts
+++ b/MobileApp/src/api/sso.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosResponse } from "axios";
 import { getServerUrl } from "../storage/serverUrl";
+import type { SsoProviderKind } from "../sso/providerUrl";
 
 export interface SSOProvider {
   _id: string;
@@ -81,13 +82,13 @@ export interface GlobalSSOProvider {
   _id: string;
   name: string;
   description?: string;
-  // Which global login flow to start: SAML ("sso") or OIDC ("oidc").
-  type: "sso" | "oidc";
+  // Which global login flow to start: SAML ("global-sso") or OIDC ("global-oidc").
+  type: Extract<SsoProviderKind, "global-sso" | "global-oidc">;
 }
 
 function parseGlobalProvider(
   raw: RawSSOItem,
-  type: "sso" | "oidc",
+  type: GlobalSSOProvider["type"],
 ): GlobalSSOProvider {
   return {
     _id: resolveId(raw._id),
@@ -133,7 +134,7 @@ export async function fetchGlobalSSOProviders(): Promise<
   const items: Array<RawSSOItem> = extractItems(response.data);
 
   return items.map((item: RawSSOItem) => {
-    return parseGlobalProvider(item, "sso");
+    return parseGlobalProvider(item, "global-sso");
   });
 }
 
@@ -155,7 +156,97 @@ export async function fetchGlobalOIDCProviders(): Promise<
   const items: Array<RawSSOItem> = extractItems(response.data);
 
   return items.map((item: RawSSOItem) => {
-    return parseGlobalProvider(item, "oidc");
+    return parseGlobalProvider(item, "global-oidc");
+  });
+}
+
+/**
+ * Result of a discovery call that is allowed to fail.
+ *
+ * Global SSO discovery runs unprompted on app start, so a failure must not
+ * block the screen - but it must also not be silently flattened to "no
+ * providers". Those two states need different words in front of the user: one
+ * says "your instance has no SSO", the other says "we could not reach your
+ * server", and only the second is worth retrying.
+ */
+export interface SsoDiscoveryResult<T> {
+  providers: Array<T>;
+  failed: boolean;
+}
+
+/*
+ * Decides whether a thrown request was a genuine failure to reach the server,
+ * or the server answering perfectly well that there is nothing to offer.
+ *
+ * This distinction is not cosmetic. App/FeatureSet/Identity/API/SSO.ts answers
+ * the ordinary "this email has no project SSO" case with HTTP 400
+ * ("No SSO config found for this user") - for an unknown user, a user with no
+ * id, and a user who belongs to no project alike. axios rejects on 4xx, so
+ * treating every rejection as a failure tells the user their network is broken
+ * when in fact the server replied correctly and immediately.
+ *
+ * So: any response at all below 500 means the server was reached and had its
+ * say. Only a transport error (no response) or a 5xx is an outage.
+ */
+function isServerUnreachable(error: unknown): boolean {
+  const response: { status?: number } | undefined = (
+    error as { response?: { status?: number } } | undefined
+  )?.response;
+
+  if (!response || typeof response.status !== "number") {
+    // No response at all: DNS failure, timeout, refused connection, offline.
+    return true;
+  }
+
+  return response.status >= 500;
+}
+
+async function settle<T>(
+  load: () => Promise<Array<T>>,
+): Promise<SsoDiscoveryResult<T>> {
+  try {
+    return { providers: await load(), failed: false };
+  } catch (error) {
+    return { providers: [], failed: isServerUnreachable(error) };
+  }
+}
+
+/**
+ * Discovers every instance-wide provider, SAML and OIDC together.
+ *
+ * `failed` is true only when BOTH endpoints failed. One endpoint being down
+ * while the other answers is still a usable login screen, so it is not
+ * reported to the user as an outage.
+ */
+export async function fetchAllGlobalProviders(): Promise<
+  SsoDiscoveryResult<GlobalSSOProvider>
+> {
+  const [saml, oidc]: [
+    SsoDiscoveryResult<GlobalSSOProvider>,
+    SsoDiscoveryResult<GlobalSSOProvider>,
+  ] = await Promise.all([
+    settle(fetchGlobalSSOProviders),
+    settle(fetchGlobalOIDCProviders),
+  ]);
+
+  return {
+    providers: [...saml.providers, ...oidc.providers],
+    failed: saml.failed && oidc.failed,
+  };
+}
+
+/**
+ * Discovers the project SSO providers configured for `email`.
+ *
+ * Unlike the global endpoints this one is email-scoped, so an empty result is
+ * a real answer ("no project on this instance federates that address") rather
+ * than a missing feature.
+ */
+export async function fetchProjectProvidersForEmail(
+  email: string,
+): Promise<SsoDiscoveryResult<SSOProvider>> {
+  return settle(() => {
+    return fetchSSOProviders(email);
   });
 }
 

--- a/MobileApp/src/hooks/useAuth.tsx
+++ b/MobileApp/src/hooks/useAuth.tsx
@@ -20,6 +20,15 @@ import {
   getGlobalSsoToken,
   getSsoTokens,
 } from "../storage/ssoTokens";
+import {
+  consumeInitialSsoCallbackUrl,
+  startSsoCallbackCapture,
+  stopSsoCallbackCapture,
+} from "../sso/deepLink";
+import {
+  completeSsoLoginFromUrl,
+  type CompleteSsoLoginOutcome,
+} from "../sso/session";
 
 interface AuthContextValue {
   isAuthenticated: boolean;
@@ -48,7 +57,16 @@ export function AuthProvider({
   const [needsServerUrl, setNeedsServerUrl] = useState<boolean>(false);
   const [user, setUser] = useState<LoginResponse["user"] | null>(null);
 
-  useEffect((): void => {
+  useEffect((): (() => void) => {
+    /*
+     * Start capturing `oneuptime://sso-callback` before anything else can
+     * open a browser. The capture also drains the launch URL, which is how
+     * the callback arrives when the OS killed the app while the user was at
+     * their identity provider - common on Android under memory pressure.
+     * Without this the completed login is simply lost.
+     */
+    startSsoCallbackCapture();
+
     const checkAuth: () => Promise<void> = async (): Promise<void> => {
       try {
         const hasUrl: boolean = await hasServerUrl();
@@ -56,6 +74,25 @@ export function AuthProvider({
           setNeedsServerUrl(true);
           setIsLoading(false);
           return;
+        }
+
+        /*
+         * A callback waiting at launch means an SSO login completed while the
+         * app was dead. Finish it here so the user lands signed in instead of
+         * back on the login screen with no explanation.
+         */
+        const launchCallbackUrl: string | null =
+          await consumeInitialSsoCallbackUrl();
+
+        if (launchCallbackUrl) {
+          const completed: CompleteSsoLoginOutcome =
+            await completeSsoLoginFromUrl(launchCallbackUrl);
+
+          if (completed.status === "success") {
+            setIsAuthenticated(true);
+            setIsLoading(false);
+            return;
+          }
         }
 
         const tokens: { accessToken: string; refreshToken: string } | null =
@@ -75,6 +112,10 @@ export function AuthProvider({
     };
 
     checkAuth();
+
+    return (): void => {
+      stopSsoCallbackCapture();
+    };
   }, []);
 
   // Register auth failure handler for 401 interceptor

--- a/MobileApp/src/hooks/useAuthSsoColdStart.test.tsx
+++ b/MobileApp/src/hooks/useAuthSsoColdStart.test.tsx
@@ -1,0 +1,565 @@
+import React from "react";
+import { Text } from "react-native";
+import { act, render, waitFor } from "@testing-library/react-native";
+import { describe, expect, test, beforeEach } from "@jest/globals";
+import { AuthProvider, useAuth } from "./useAuth";
+import {
+  consumeInitialSsoCallbackUrl,
+  startSsoCallbackCapture,
+  stopSsoCallbackCapture,
+} from "../sso/deepLink";
+import { completeSsoLoginFromUrl } from "../sso/session";
+import { hasServerUrl } from "../storage/serverUrl";
+import { getTokens } from "../storage/keychain";
+import {
+  clearAllSsoTokens,
+  getGlobalSsoToken,
+  getSsoTokens,
+} from "../storage/ssoTokens";
+import { logout as apiLogout } from "../api/auth";
+import { unregisterPushToken } from "./pushTokenUtils";
+
+/*
+ * AuthProvider is the only thing running when the app cold-starts, so it is
+ * the only thing that can rescue an SSO login the OS interrupted.
+ *
+ * The sequence being pinned here: the user taps "Sign in with SSO", the OS
+ * kills the app while they are at their identity provider (routine on Android
+ * under memory pressure, and possible on iOS), the IdP redirects to
+ * `oneuptime://sso-callback?...`, and the app is launched fresh by that URL.
+ * Every promise that was waiting for the callback died with the old process.
+ * If startup does not pick the URL up and finish the login, the tokens in it
+ * are thrown away and the user is dropped back on the login screen having
+ * just authenticated successfully - with no explanation, and no reason to
+ * believe a second attempt will end differently.
+ *
+ * The collaborators are all mocked: this file is about the decisions
+ * AuthProvider makes given each answer, not about how a callback URL is
+ * parsed (callbackUrl.ts) or persisted (session.ts).
+ *
+ * Everything below is platform-independent by design and the suite runs under
+ * both the ios and android Jest projects, which is the point - the cold-start
+ * rescue has to behave identically on the platform where it happens most.
+ */
+
+jest.mock("../sso/deepLink", () => {
+  return {
+    startSsoCallbackCapture: jest.fn(),
+    stopSsoCallbackCapture: jest.fn(),
+    consumeInitialSsoCallbackUrl: jest.fn(),
+  };
+});
+
+jest.mock("../sso/session", () => {
+  return {
+    completeSsoLoginFromUrl: jest.fn(),
+  };
+});
+
+jest.mock("../storage/serverUrl", () => {
+  return {
+    hasServerUrl: jest.fn(),
+  };
+});
+
+jest.mock("../storage/keychain", () => {
+  return {
+    getTokens: jest.fn(),
+  };
+});
+
+jest.mock("../storage/ssoTokens", () => {
+  return {
+    getSsoTokens: jest.fn(),
+    getGlobalSsoToken: jest.fn(),
+    clearAllSsoTokens: jest.fn(),
+  };
+});
+
+jest.mock("../api/auth", () => {
+  return {
+    login: jest.fn(),
+    logout: jest.fn(),
+  };
+});
+
+/*
+ * The provider only needs setOnAuthFailure from the client, but mocking the
+ * module also keeps the real axios instance (and its interceptors) out of the
+ * test entirely.
+ */
+jest.mock("../api/client", () => {
+  return {
+    __esModule: true,
+    default: { post: jest.fn(), get: jest.fn() },
+    setOnAuthFailure: jest.fn(),
+  };
+});
+
+jest.mock("./pushTokenUtils", () => {
+  return {
+    PUSH_TOKEN_KEY: "oneuptime_expo_push_token",
+    unregisterPushToken: jest.fn(),
+  };
+});
+
+/*
+ * A real global-SSO callback: the token payload lives in the query string, so
+ * anything that mangles this URL on its way to session.ts silently loses the
+ * login.
+ */
+const GLOBAL_CALLBACK_URL: string =
+  "oneuptime://sso-callback?access_token=access-abc&refresh_token=refresh-abc" +
+  "&refresh_token_expires_at=2030-01-01T00%3A00%3A00.000Z" +
+  "&global_sso_token=global-sso-abc";
+
+const STORED_TOKENS: {
+  accessToken: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: string;
+} = {
+  accessToken: "stored-access",
+  refreshToken: "stored-refresh",
+  refreshTokenExpiresAt: "2030-01-01T00:00:00.000Z",
+};
+
+function startCaptureSpy(): jest.SpyInstance {
+  return startSsoCallbackCapture as unknown as jest.SpyInstance;
+}
+
+function stopCaptureSpy(): jest.SpyInstance {
+  return stopSsoCallbackCapture as unknown as jest.SpyInstance;
+}
+
+function consumeInitialSpy(): jest.SpyInstance {
+  return consumeInitialSsoCallbackUrl as unknown as jest.SpyInstance;
+}
+
+function completeLoginSpy(): jest.SpyInstance {
+  return completeSsoLoginFromUrl as unknown as jest.SpyInstance;
+}
+
+function hasServerUrlSpy(): jest.SpyInstance {
+  return hasServerUrl as unknown as jest.SpyInstance;
+}
+
+function getTokensSpy(): jest.SpyInstance {
+  return getTokens as unknown as jest.SpyInstance;
+}
+
+function getSsoTokensSpy(): jest.SpyInstance {
+  return getSsoTokens as unknown as jest.SpyInstance;
+}
+
+function getGlobalSsoTokenSpy(): jest.SpyInstance {
+  return getGlobalSsoToken as unknown as jest.SpyInstance;
+}
+
+function clearAllSsoTokensSpy(): jest.SpyInstance {
+  return clearAllSsoTokens as unknown as jest.SpyInstance;
+}
+
+function apiLogoutSpy(): jest.SpyInstance {
+  return apiLogout as unknown as jest.SpyInstance;
+}
+
+function unregisterPushTokenSpy(): jest.SpyInstance {
+  return unregisterPushToken as unknown as jest.SpyInstance;
+}
+
+type AuthValue = ReturnType<typeof useAuth>;
+
+/*
+ * The house pattern for reading a context: a child that renders inside the
+ * provider, publishes whatever the context currently holds, and re-publishes
+ * on every re-render so assertions always see the latest value.
+ */
+const authProbe: { current: AuthValue | null } = { current: null };
+
+function AuthProbe(): React.JSX.Element {
+  const auth: AuthValue = useAuth();
+  authProbe.current = auth;
+
+  return <Text>{auth.isLoading ? "loading" : "ready"}</Text>;
+}
+
+function currentAuth(): AuthValue {
+  if (!authProbe.current) {
+    throw new Error("AuthProvider was never rendered");
+  }
+
+  return authProbe.current;
+}
+
+interface RenderedProvider {
+  unmount: () => Promise<void> | void;
+}
+
+/*
+ * The startup check is asynchronous, so every test waits for it to settle
+ * before asserting. `isLoading` going false is the provider saying "I have
+ * decided" - EVERY startup path ends there, including the failure paths,
+ * because a path that never clears it leaves the app stuck on the splash
+ * screen forever.
+ *
+ * `render` is awaited because React 19's `act` is asynchronous, which makes
+ * @testing-library/react-native return a promise here; not awaiting it leaves
+ * the tree half-mounted and leaks into the next test.
+ */
+async function renderAuthProvider(): Promise<RenderedProvider> {
+  const rendered: RenderedProvider = (await render(
+    <AuthProvider>
+      <AuthProbe />
+    </AuthProvider>,
+  )) as unknown as RenderedProvider;
+
+  await waitFor((): void => {
+    expect(authProbe.current?.isLoading).toBe(false);
+  });
+
+  return rendered;
+}
+
+beforeEach(() => {
+  authProbe.current = null;
+
+  // Defaults: a configured server, nothing waiting, nothing stored.
+  hasServerUrlSpy().mockResolvedValue(true as never);
+  consumeInitialSpy().mockResolvedValue(null as never);
+  completeLoginSpy().mockResolvedValue({
+    status: "success",
+    isGlobal: true,
+    projectId: null,
+  } as never);
+  getTokensSpy().mockResolvedValue(null as never);
+  getSsoTokensSpy().mockResolvedValue({} as never);
+  getGlobalSsoTokenSpy().mockResolvedValue(null as never);
+  clearAllSsoTokensSpy().mockResolvedValue(undefined as never);
+  apiLogoutSpy().mockResolvedValue(undefined as never);
+  unregisterPushTokenSpy().mockResolvedValue(undefined as never);
+});
+
+describe("AuthProvider starts the SSO deep link capture at startup", () => {
+  test("the capture starts on mount", async () => {
+    /*
+     * It has to be running before anything else can open a browser, and it is
+     * also what drains the launch URL - so this is the call the whole
+     * cold-start rescue hangs off.
+     */
+    await renderAuthProvider();
+
+    expect(startCaptureSpy()).toHaveBeenCalled();
+  });
+
+  test("the capture starts even when the app has no server URL yet", async () => {
+    /*
+     * Starting the listener is unconditional on purpose: the callback can
+     * arrive at any moment, and a listener that only starts once the app is
+     * configured is a listener that is not there when it matters.
+     */
+    hasServerUrlSpy().mockResolvedValue(false as never);
+
+    await renderAuthProvider();
+
+    expect(startCaptureSpy()).toHaveBeenCalled();
+  });
+
+  test("the capture is torn down on unmount", async () => {
+    /*
+     * The listener is process-wide. Leaving it registered after the provider
+     * is gone means a later callback is captured by a dead tree and consumed
+     * where nobody can act on it.
+     */
+    const rendered: RenderedProvider = await renderAuthProvider();
+
+    expect(stopCaptureSpy()).not.toHaveBeenCalled();
+
+    await rendered.unmount();
+
+    expect(stopCaptureSpy()).toHaveBeenCalled();
+  });
+});
+
+describe("AuthProvider cold-started by a successful SSO callback", () => {
+  beforeEach(() => {
+    consumeInitialSpy().mockResolvedValue(GLOBAL_CALLBACK_URL as never);
+    // Nothing was stored before: the process that started the login is gone.
+    getTokensSpy().mockResolvedValue(null as never);
+  });
+
+  test("the launch URL is handed to the SSO session completer verbatim", async () => {
+    /*
+     * The tokens are IN the URL. Trimming, re-encoding or otherwise touching
+     * it here would produce a callback that parses to nothing and a login
+     * that fails for a reason nobody can see.
+     */
+    await renderAuthProvider();
+
+    expect(completeLoginSpy()).toHaveBeenCalledWith(GLOBAL_CALLBACK_URL);
+  });
+
+  test("the user ends up signed in even though no tokens were stored before", async () => {
+    /*
+     * This is the entire bug being fixed. Before the cold-start handling, the
+     * stored-token check was the only thing startup did, it found nothing,
+     * and the freshly completed login was discarded.
+     */
+    await renderAuthProvider();
+
+    expect(currentAuth().isAuthenticated).toBe(true);
+  });
+
+  test("startup finishes rather than hanging on the splash screen", async () => {
+    await renderAuthProvider();
+
+    expect(currentAuth().isLoading).toBe(false);
+  });
+
+  test("the app does not ask for a server URL it already has", async () => {
+    await renderAuthProvider();
+
+    expect(currentAuth().needsServerUrl).toBe(false);
+  });
+
+  test("a project-scoped callback signs the user in too", async () => {
+    /*
+     * Global SSO is what this work was for, but the same launch path carries a
+     * project SSO callback. Treating only the global shape as a real login
+     * would strand every project-SSO user whose app was killed mid-login.
+     */
+    completeLoginSpy().mockResolvedValue({
+      status: "success",
+      isGlobal: false,
+      projectId: "project-1",
+    } as never);
+
+    await renderAuthProvider();
+
+    expect(currentAuth().isAuthenticated).toBe(true);
+  });
+});
+
+describe("AuthProvider cold-started by a callback that failed", () => {
+  beforeEach(() => {
+    consumeInitialSpy().mockResolvedValue(GLOBAL_CALLBACK_URL as never);
+    completeLoginSpy().mockResolvedValue({
+      status: "error",
+      message: "SSO login failed",
+    } as never);
+  });
+
+  test("the app does not claim to be signed in", async () => {
+    /*
+     * An error callback - a denied IdP assertion, a tampered URL, a token the
+     * app could not store - must not be mistaken for a login. Claiming
+     * authenticated here sends the user into a UI that 401s on every screen.
+     */
+    getTokensSpy().mockResolvedValue(null as never);
+
+    await renderAuthProvider();
+
+    expect(currentAuth().isAuthenticated).toBe(false);
+  });
+
+  test("it falls through to the stored-token check instead of stopping", async () => {
+    /*
+     * A failed SSO attempt says nothing about the session the user already
+     * had. Signing them out of a perfectly good session because a re-auth
+     * attempt failed would be a self-inflicted logout.
+     */
+    getTokensSpy().mockResolvedValue(STORED_TOKENS as never);
+
+    await renderAuthProvider();
+
+    expect(getTokensSpy()).toHaveBeenCalled();
+    expect(currentAuth().isAuthenticated).toBe(true);
+  });
+
+  test("the SSO token caches are still primed on the failure path", async () => {
+    getTokensSpy().mockResolvedValue(STORED_TOKENS as never);
+
+    await renderAuthProvider();
+
+    expect(getSsoTokensSpy()).toHaveBeenCalled();
+    expect(getGlobalSsoTokenSpy()).toHaveBeenCalled();
+  });
+
+  test("startup still finishes", async () => {
+    await renderAuthProvider();
+
+    expect(currentAuth().isLoading).toBe(false);
+  });
+});
+
+describe("AuthProvider starting up with no SSO callback waiting", () => {
+  test("a stored access token means the user is still signed in", async () => {
+    getTokensSpy().mockResolvedValue(STORED_TOKENS as never);
+
+    await renderAuthProvider();
+
+    expect(currentAuth().isAuthenticated).toBe(true);
+  });
+
+  test("no stored token means the user is not signed in", async () => {
+    getTokensSpy().mockResolvedValue(null as never);
+
+    await renderAuthProvider();
+
+    expect(currentAuth().isAuthenticated).toBe(false);
+  });
+
+  test("an empty access token is not treated as a session", async () => {
+    /*
+     * The 2FA branch of the login API returns a token record with an empty
+     * accessToken. Reading "a record exists" as "signed in" would walk a user
+     * who never completed their second factor straight into the app.
+     */
+    getTokensSpy().mockResolvedValue({
+      ...STORED_TOKENS,
+      accessToken: "",
+    } as never);
+
+    await renderAuthProvider();
+
+    expect(currentAuth().isAuthenticated).toBe(false);
+  });
+
+  test("nothing is completed when there is no callback to complete", async () => {
+    await renderAuthProvider();
+
+    expect(completeLoginSpy()).not.toHaveBeenCalled();
+  });
+});
+
+describe("AuthProvider primes the SSO token caches at startup", () => {
+  /*
+   * The axios interceptor reads these caches SYNCHRONOUSLY on every request,
+   * via getCachedSsoTokens()/getCachedGlobalSsoToken(). Nothing else fills
+   * them after a cold start, so skipping this priming means the first
+   * requests of every launch go out without x-sso-tokens or
+   * x-global-sso-token and come back 406 from an SSO-enforced project.
+   */
+  test("the per-project cache is read", async () => {
+    await renderAuthProvider();
+
+    expect(getSsoTokensSpy()).toHaveBeenCalled();
+  });
+
+  test("the global SSO token cache is read", async () => {
+    await renderAuthProvider();
+
+    expect(getGlobalSsoTokenSpy()).toHaveBeenCalled();
+  });
+
+  test("they are primed for a signed-in user too", async () => {
+    getTokensSpy().mockResolvedValue(STORED_TOKENS as never);
+
+    await renderAuthProvider();
+
+    expect(getSsoTokensSpy()).toHaveBeenCalled();
+    expect(getGlobalSsoTokenSpy()).toHaveBeenCalled();
+  });
+});
+
+describe("AuthProvider before a server URL is configured", () => {
+  beforeEach(() => {
+    hasServerUrlSpy().mockResolvedValue(false as never);
+  });
+
+  test("the app asks for the server URL", async () => {
+    await renderAuthProvider();
+
+    expect(currentAuth().needsServerUrl).toBe(true);
+    expect(currentAuth().isAuthenticated).toBe(false);
+  });
+
+  test("no launch callback is consumed", async () => {
+    /*
+     * There is no server to reconcile a callback against, and consuming one
+     * here would burn the URL - it can only be read once - leaving nothing to
+     * finish the login with after the user finally enters their server URL.
+     */
+    await renderAuthProvider();
+
+    expect(consumeInitialSpy()).not.toHaveBeenCalled();
+    expect(completeLoginSpy()).not.toHaveBeenCalled();
+  });
+
+  test("no SSO token caches are touched", async () => {
+    await renderAuthProvider();
+
+    expect(getSsoTokensSpy()).not.toHaveBeenCalled();
+    expect(getGlobalSsoTokenSpy()).not.toHaveBeenCalled();
+  });
+});
+
+describe("AuthProvider when the startup checks throw", () => {
+  test("a deep link read that blows up still lets the app start", async () => {
+    /*
+     * Linking.getInitialURL() can reject on a malformed launch intent. The
+     * app must land on the login screen, not on a splash screen that never
+     * goes away.
+     */
+    consumeInitialSpy().mockRejectedValue(new Error("bad launch intent"));
+
+    await renderAuthProvider();
+
+    expect(currentAuth().isLoading).toBe(false);
+    expect(currentAuth().isAuthenticated).toBe(false);
+  });
+
+  test("a failed SSO completion still lets the app start", async () => {
+    consumeInitialSpy().mockResolvedValue(GLOBAL_CALLBACK_URL as never);
+    completeLoginSpy().mockRejectedValue(new Error("keychain unavailable"));
+
+    await renderAuthProvider();
+
+    expect(currentAuth().isLoading).toBe(false);
+    expect(currentAuth().isAuthenticated).toBe(false);
+  });
+});
+
+describe("AuthProvider logout", () => {
+  beforeEach(() => {
+    getTokensSpy().mockResolvedValue(STORED_TOKENS as never);
+  });
+
+  test("clears the SSO tokens along with the auth tokens", async () => {
+    /*
+     * The global SSO token outlives the access token by weeks (it is signed
+     * for 30 days). Leaving it behind means the next person to use the handset
+     * inherits a valid instance-wide SSO credential.
+     */
+    await renderAuthProvider();
+
+    await act(async () => {
+      await currentAuth().logout();
+    });
+
+    expect(apiLogoutSpy()).toHaveBeenCalled();
+    expect(clearAllSsoTokensSpy()).toHaveBeenCalled();
+  });
+
+  test("unregisters the push token as well", async () => {
+    await renderAuthProvider();
+
+    await act(async () => {
+      await currentAuth().logout();
+    });
+
+    expect(unregisterPushTokenSpy()).toHaveBeenCalled();
+  });
+
+  test("the context reports the user as signed out afterwards", async () => {
+    await renderAuthProvider();
+
+    expect(currentAuth().isAuthenticated).toBe(true);
+
+    await act(async () => {
+      await currentAuth().logout();
+    });
+
+    expect(currentAuth().isAuthenticated).toBe(false);
+    expect(currentAuth().user).toBeNull();
+  });
+});

--- a/MobileApp/src/navigation/types.ts
+++ b/MobileApp/src/navigation/types.ts
@@ -13,13 +13,26 @@ export type MainTabParamList = {
   Settings: undefined;
 };
 
+/*
+ * A provider offered on the re-authentication sheet. `kind` decides which
+ * server route starts the login and which token comes back, so it has to
+ * survive the trip through navigation params - a global provider routed as a
+ * project one produces a 400 from the server.
+ */
+export interface SelectableSsoProvider {
+  _id: string;
+  name: string;
+  description?: string;
+  kind: "project" | "global-sso" | "global-oidc";
+}
+
 export type SettingsStackParamList = {
   SettingsList: undefined;
   ProjectsList: undefined;
   SSOProviderSelect: {
     projectId: string;
     projectName: string;
-    providers: Array<{ _id: string; name: string; description?: string }>;
+    providers: Array<SelectableSsoProvider>;
   };
 };
 

--- a/MobileApp/src/screens/HomeScreen.tsx
+++ b/MobileApp/src/screens/HomeScreen.tsx
@@ -14,7 +14,7 @@ import { useTheme } from "../theme";
 import { useAllProjectCounts } from "../hooks/useAllProjectCounts";
 import { useProject } from "../hooks/useProject";
 import { useHaptics } from "../hooks/useHaptics";
-import { useNavigation } from "@react-navigation/native";
+import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import type { BottomTabNavigationProp } from "@react-navigation/bottom-tabs";
 import type { MainTabParamList } from "../navigation/types";
 import type { ProjectItem } from "../api/types";
@@ -202,6 +202,19 @@ export default function HomeScreen(): React.JSX.Element {
   useEffect((): void => {
     checkSsoStatus();
   }, [checkSsoStatus]);
+
+  /*
+   * The Home tab stays mounted while the user goes off to Settings to complete
+   * an SSO login, so a plain effect keyed on projectList never re-runs and the
+   * banner keeps demanding SSO for a project that is now authenticated. Re-check
+   * whenever the tab regains focus - which is exactly when the user comes back
+   * from the login they just finished.
+   */
+  useFocusEffect(
+    useCallback((): void => {
+      checkSsoStatus();
+    }, [checkSsoStatus]),
+  );
 
   const onRefresh: () => Promise<void> = async (): Promise<void> => {
     lightImpact();

--- a/MobileApp/src/screens/auth/SSOLoginScreen.test.tsx
+++ b/MobileApp/src/screens/auth/SSOLoginScreen.test.tsx
@@ -1,0 +1,909 @@
+import React from "react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react-native";
+import { describe, expect, test, beforeEach } from "@jest/globals";
+import SSOLoginScreen from "./SSOLoginScreen";
+import {
+  fetchAllGlobalProviders,
+  fetchProjectProvidersForEmail,
+  type GlobalSSOProvider,
+  type SSOProvider,
+  type SsoDiscoveryResult,
+} from "../../api/sso";
+import {
+  openSsoAuthSession,
+  type SsoAuthSessionOutcome,
+} from "../../sso/authSession";
+import { completeSsoLoginFromUrl } from "../../sso/session";
+
+/*
+ * The SSO login screen is the only door into an instance that federates its
+ * identity, so the things worth testing here are the ones that lock people out
+ * rather than the ones that look wrong:
+ *
+ *   - Global (instance-wide) SSO is configured on the ADMIN dashboard and is
+ *     not bound to an email domain. It therefore has to be discovered and
+ *     offered on MOUNT. The screen used to require an email first, which made
+ *     an instance whose only identity provider is a global one look like it
+ *     had no SSO at all - there was no email that would ever reveal it.
+ *   - A login is only real once its tokens are persisted AND the app is told
+ *     it is authenticated. Doing one without the other strands the user.
+ *   - "We could not reach your server" and "your address does not federate"
+ *     are different problems with different fixes. The screen used to say the
+ *     second one for both, which sends people to an admin who cannot help.
+ *
+ * The API, the auth browser and the token-persisting step are all covered by
+ * their own suites; here they are stand-ins so this file can assert on what
+ * the screen DOES with each answer they can give.
+ */
+
+jest.mock("../../api/sso", () => {
+  return {
+    fetchAllGlobalProviders: jest.fn(),
+    fetchProjectProvidersForEmail: jest.fn(),
+  };
+});
+
+jest.mock("../../sso/authSession", () => {
+  return {
+    openSsoAuthSession: jest.fn(),
+  };
+});
+
+jest.mock("../../sso/session", () => {
+  return {
+    completeSsoLoginFromUrl: jest.fn(),
+  };
+});
+
+/*
+ * Deliberately carries a trailing slash: it is what a user types into the
+ * server-url screen, and the login URL still has to come out with a single
+ * slash before /identity.
+ */
+jest.mock("../../storage/serverUrl", () => {
+  return {
+    getServerUrl: async (): Promise<string> => {
+      return "https://oneuptime.com/";
+    },
+  };
+});
+
+/*
+ * Read lazily inside the hook stand-ins - a jest.mock factory runs while the
+ * screen module is still being required, which is before anything declared in
+ * this file exists.
+ */
+const mockAuth: { setIsAuthenticated: jest.Mock } = {
+  setIsAuthenticated: jest.fn(),
+};
+
+const mockNavigation: { navigate: jest.Mock } = {
+  navigate: jest.fn(),
+};
+
+jest.mock("../../hooks/useAuth", () => {
+  return {
+    useAuth: () => {
+      return mockAuth;
+    },
+  };
+});
+
+jest.mock("@react-navigation/native", () => {
+  return {
+    useNavigation: () => {
+      return mockNavigation;
+    },
+  };
+});
+
+function globalDiscovery(): jest.Mock {
+  return fetchAllGlobalProviders as unknown as jest.Mock;
+}
+
+function projectDiscovery(): jest.Mock {
+  return fetchProjectProvidersForEmail as unknown as jest.Mock;
+}
+
+function authSession(): jest.Mock {
+  return openSsoAuthSession as unknown as jest.Mock;
+}
+
+function completeLogin(): jest.Mock {
+  return completeSsoLoginFromUrl as unknown as jest.Mock;
+}
+
+function found<T>(providers: Array<T>): SsoDiscoveryResult<T> {
+  return { providers, failed: false };
+}
+
+function unreachable<T>(): SsoDiscoveryResult<T> {
+  return { providers: [], failed: true };
+}
+
+function globalProvider(
+  overrides: Partial<GlobalSSOProvider> = {},
+): GlobalSSOProvider {
+  return {
+    _id: "global-saml-1",
+    name: "Acme Corporate SAML",
+    description: "Sign in with your Acme account",
+    type: "global-sso",
+    ...overrides,
+  };
+}
+
+function projectProvider(overrides: Partial<SSOProvider> = {}): SSOProvider {
+  return {
+    _id: "provider-1",
+    name: "Acme Okta",
+    projectId: "project-1",
+    project: { name: "Acme Production" },
+    ...overrides,
+  };
+}
+
+/*
+ * Every string this screen is capable of putting in front of the user as an
+ * error. Asserting against the whole set is what stops a "nothing was said"
+ * test from passing because it guessed the wrong wording.
+ */
+const ANY_ERROR_MESSAGE: RegExp =
+  /required|valid email|could not|no sso configuration|failed/i;
+
+function expectNoErrorShown(): void {
+  expect(screen.queryByText(ANY_ERROR_MESSAGE)).toBeNull();
+}
+
+/** Renders the screen and waits for the on-mount global discovery to settle. */
+async function renderScreen(): Promise<void> {
+  await render(<SSOLoginScreen />);
+
+  await waitFor(() => {
+    expect(globalDiscovery()).toHaveBeenCalled();
+  });
+
+  // The email step only appears once the global section has stopped loading.
+  await screen.findByText("Email");
+}
+
+/** Types an email and presses Continue. */
+async function submitEmail(email: string): Promise<void> {
+  await fireEvent.changeText(screen.getByLabelText("Email"), email);
+  await fireEvent.press(screen.getByText("Continue"));
+}
+
+beforeEach(() => {
+  globalDiscovery().mockResolvedValue(found<GlobalSSOProvider>([]));
+  projectDiscovery().mockResolvedValue(found<SSOProvider>([]));
+  authSession().mockResolvedValue({ status: "cancelled" });
+  completeLogin().mockResolvedValue({
+    status: "success",
+    isGlobal: true,
+    projectId: null,
+  });
+});
+
+describe("Global providers are offered before anyone types an email", () => {
+  test("discovery runs on mount", async () => {
+    /*
+     * The headline fix. A global provider belongs to the instance, not to an
+     * email domain, so nothing the user could type would ever reveal it - it
+     * has to be fetched unprompted or it does not exist as far as the app is
+     * concerned.
+     */
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+
+    await renderScreen();
+
+    expect(globalDiscovery()).toHaveBeenCalledTimes(1);
+  });
+
+  test("the provider name is on screen before any interaction", async () => {
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+
+    await renderScreen();
+
+    expect(await screen.findByText("Acme Corporate SAML")).toBeTruthy();
+  });
+
+  test("no email lookup is made just to show them", async () => {
+    /*
+     * The old screen reached the provider list only through the email lookup.
+     * If that call is still what populates this section, an instance with only
+     * global SSO is still broken.
+     */
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+
+    await renderScreen();
+
+    expect(projectDiscovery()).not.toHaveBeenCalled();
+  });
+
+  test("SAML and OIDC providers are listed together", async () => {
+    globalDiscovery().mockResolvedValue(
+      found([
+        globalProvider(),
+        globalProvider({
+          _id: "global-oidc-1",
+          name: "Acme Entra ID",
+          type: "global-oidc",
+        }),
+      ]),
+    );
+
+    await renderScreen();
+
+    expect(await screen.findByText("Acme Corporate SAML")).toBeTruthy();
+    expect(screen.getByText("Acme Entra ID")).toBeTruthy();
+  });
+
+  test("the section says what these providers are", async () => {
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+
+    await renderScreen();
+
+    expect(
+      await screen.findByText("Sign in with your organization"),
+    ).toBeTruthy();
+  });
+
+  test("a provider's description is shown alongside its name", async () => {
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+
+    await renderScreen();
+
+    expect(
+      await screen.findByText("Sign in with your Acme account"),
+    ).toBeTruthy();
+  });
+
+  test("the email step is still offered underneath", async () => {
+    /*
+     * Global SSO is offered IN ADDITION to project SSO. A user whose access
+     * comes from a project provider must not lose their way in.
+     */
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+
+    await renderScreen();
+
+    expect(await screen.findByText("Or continue with email")).toBeTruthy();
+    expect(screen.getByLabelText("Email")).toBeTruthy();
+  });
+});
+
+describe("An instance with no global providers", () => {
+  test("does not render the section at all", async () => {
+    globalDiscovery().mockResolvedValue(found<GlobalSSOProvider>([]));
+
+    await renderScreen();
+
+    expect(screen.queryByText("Sign in with your organization")).toBeNull();
+    expect(screen.queryByText("Or continue with email")).toBeNull();
+  });
+
+  test("still lets the user through the email step", async () => {
+    globalDiscovery().mockResolvedValue(found<GlobalSSOProvider>([]));
+    projectDiscovery().mockResolvedValue(found([projectProvider()]));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    expect(await screen.findByText("Acme Okta")).toBeTruthy();
+  });
+
+  test("a failed global discovery does not block the screen either", async () => {
+    /*
+     * Discovery runs unprompted, so its failure is not something the user
+     * asked for and must not be shouted at them - but it also must not take
+     * the email login down with it.
+     */
+    globalDiscovery().mockResolvedValue(unreachable<GlobalSSOProvider>());
+    projectDiscovery().mockResolvedValue(found([projectProvider()]));
+
+    await renderScreen();
+
+    expect(screen.queryByText("Sign in with your organization")).toBeNull();
+    expectNoErrorShown();
+
+    await submitEmail("user@acme.com");
+
+    expect(await screen.findByText("Acme Okta")).toBeTruthy();
+  });
+});
+
+describe("Starting a global login", () => {
+  test("a SAML row opens the instance-wide SAML route, flagged as mobile", async () => {
+    /*
+     * ?mobile=true is the only thing telling the server to end the flow on the
+     * app's deep link instead of rendering the web dashboard; without it the
+     * user completes a login the app never hears about. The two global kinds
+     * are served by different routers, so the path has to match the kind.
+     */
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+
+    await renderScreen();
+
+    await fireEvent.press(await screen.findByLabelText("Acme Corporate SAML"));
+
+    await waitFor(() => {
+      expect(authSession()).toHaveBeenCalledWith(
+        "https://oneuptime.com/identity/global-sso/global-saml-1?mobile=true",
+      );
+    });
+  });
+
+  test("an OIDC row opens the OIDC route instead", async () => {
+    globalDiscovery().mockResolvedValue(
+      found([
+        globalProvider({
+          _id: "global-oidc-1",
+          name: "Acme Entra ID",
+          type: "global-oidc",
+        }),
+      ]),
+    );
+
+    await renderScreen();
+
+    await fireEvent.press(await screen.findByLabelText("Acme Entra ID"));
+
+    await waitFor(() => {
+      expect(authSession()).toHaveBeenCalledWith(
+        "https://oneuptime.com/identity/global-oidc/global-oidc-1?mobile=true",
+      );
+    });
+  });
+
+  test("the callback is handed to the one place that persists a session", async () => {
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+    authSession().mockResolvedValue({
+      status: "callback",
+      url: "oneuptime://sso-callback?global-sso-token=abc",
+    });
+
+    await renderScreen();
+
+    await fireEvent.press(await screen.findByLabelText("Acme Corporate SAML"));
+
+    await waitFor(() => {
+      expect(completeLogin()).toHaveBeenCalledWith(
+        "oneuptime://sso-callback?global-sso-token=abc",
+      );
+    });
+  });
+
+  test("and only then is the user marked authenticated", async () => {
+    /*
+     * Order matters: flipping the app to "signed in" before the tokens are
+     * stored lands the user on a dashboard whose every request is unauthorised.
+     */
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+    authSession().mockResolvedValue({
+      status: "callback",
+      url: "oneuptime://sso-callback?global-sso-token=abc",
+    });
+
+    await renderScreen();
+
+    await fireEvent.press(await screen.findByLabelText("Acme Corporate SAML"));
+
+    await waitFor(() => {
+      expect(mockAuth.setIsAuthenticated).toHaveBeenCalledWith(true);
+    });
+
+    expect(completeLogin()).toHaveBeenCalled();
+  });
+
+  test("a cancelled login signs nobody in", async () => {
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+    authSession().mockResolvedValue({ status: "cancelled" });
+
+    await renderScreen();
+
+    await fireEvent.press(await screen.findByLabelText("Acme Corporate SAML"));
+
+    await waitFor(() => {
+      expect(authSession()).toHaveBeenCalled();
+    });
+
+    expect(completeLogin()).not.toHaveBeenCalled();
+    expect(mockAuth.setIsAuthenticated).not.toHaveBeenCalled();
+  });
+
+  test("and says nothing, because backing out is not a failure", async () => {
+    /*
+     * A user who changed their mind, or who is bounced back by an IdP that
+     * wanted a second factor on another device, has done nothing wrong. An
+     * error here reads as "SSO is broken on this instance".
+     */
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+    authSession().mockResolvedValue({ status: "cancelled" });
+
+    await renderScreen();
+
+    await fireEvent.press(await screen.findByLabelText("Acme Corporate SAML"));
+
+    await waitFor(() => {
+      expect(authSession()).toHaveBeenCalled();
+    });
+
+    await screen.findByText("Acme Corporate SAML");
+    expectNoErrorShown();
+  });
+
+  test("a browser that will not open reports why", async () => {
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+    authSession().mockResolvedValue({
+      status: "error",
+      message: "Could not open the sign-in page. Please try again.",
+    });
+
+    await renderScreen();
+
+    await fireEvent.press(await screen.findByLabelText("Acme Corporate SAML"));
+
+    expect(
+      await screen.findByText(
+        "Could not open the sign-in page. Please try again.",
+      ),
+    ).toBeTruthy();
+    expect(mockAuth.setIsAuthenticated).not.toHaveBeenCalled();
+  });
+
+  test("a callback that carries an IdP error is shown, not treated as a login", async () => {
+    /*
+     * The IdP redirects back to the same deep link whether it authenticated
+     * the user or refused them. Treating the redirect itself as success is how
+     * a rejected user ends up "signed in" with no tokens.
+     */
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+    authSession().mockResolvedValue({
+      status: "callback",
+      url: "oneuptime://sso-callback?error=access_denied",
+    });
+    completeLogin().mockResolvedValue({
+      status: "error",
+      message: "SSO login failed: access_denied",
+    });
+
+    await renderScreen();
+
+    await fireEvent.press(await screen.findByLabelText("Acme Corporate SAML"));
+
+    expect(
+      await screen.findByText("SSO login failed: access_denied"),
+    ).toBeTruthy();
+    expect(mockAuth.setIsAuthenticated).not.toHaveBeenCalled();
+  });
+
+  test("a retry clears the message left by the previous attempt", async () => {
+    /*
+     * A stale error sitting above a login that is currently succeeding is how
+     * a user gives up on a flow that actually worked.
+     */
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+    authSession().mockResolvedValue({
+      status: "error",
+      message: "Could not open the sign-in page. Please try again.",
+    });
+
+    await renderScreen();
+
+    await fireEvent.press(await screen.findByLabelText("Acme Corporate SAML"));
+
+    await screen.findByText(
+      "Could not open the sign-in page. Please try again.",
+    );
+
+    authSession().mockResolvedValue({ status: "cancelled" });
+
+    await fireEvent.press(screen.getByLabelText("Acme Corporate SAML"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          "Could not open the sign-in page. Please try again.",
+        ),
+      ).toBeNull();
+    });
+  });
+
+  test("the email form is replaced by a progress message while the browser is open", async () => {
+    /*
+     * The auth browser is a separate screen the user is looking at. Leaving a
+     * live Continue button behind it invites a second, competing login - which
+     * on Android throws, because a session is already open.
+     */
+    globalDiscovery().mockResolvedValue(found([globalProvider()]));
+
+    let finishSession: (outcome: SsoAuthSessionOutcome) => void = (): void => {
+      return undefined;
+    };
+
+    authSession().mockImplementation((): Promise<SsoAuthSessionOutcome> => {
+      return new Promise(
+        (resolve: (outcome: SsoAuthSessionOutcome) => void): void => {
+          finishSession = resolve;
+        },
+      );
+    });
+
+    await renderScreen();
+
+    /*
+     * Held rather than awaited: the press does not settle until the auth
+     * browser does, and the whole point of this test is to look at the screen
+     * while it has not.
+     */
+    const pressed: Promise<void> = fireEvent.press(
+      await screen.findByLabelText("Acme Corporate SAML"),
+    );
+
+    expect(await screen.findByText("Authenticating...")).toBeTruthy();
+    expect(screen.queryByText("Continue")).toBeNull();
+    expect(screen.queryByLabelText("Email")).toBeNull();
+
+    finishSession({ status: "cancelled" });
+    await pressed;
+
+    expect(await screen.findByText("Continue")).toBeTruthy();
+  });
+});
+
+describe("The email a user types is checked before the server is bothered", () => {
+  test("an empty email is named as the problem", async () => {
+    await renderScreen();
+
+    await fireEvent.press(screen.getByText("Continue"));
+
+    expect(await screen.findByText("Email is required.")).toBeTruthy();
+  });
+
+  test("an email of nothing but spaces counts as empty", async () => {
+    await renderScreen();
+    await submitEmail("   ");
+
+    expect(await screen.findByText("Email is required.")).toBeTruthy();
+    expect(projectDiscovery()).not.toHaveBeenCalled();
+  });
+
+  test("a malformed email is called out as malformed", async () => {
+    /*
+     * Distinct from "no providers found" on purpose: a typo reported as a
+     * missing SSO configuration sends the user to their admin instead of back
+     * to their own keyboard.
+     */
+    await renderScreen();
+    await submitEmail("nope");
+
+    expect(
+      await screen.findByText("Please enter a valid email address."),
+    ).toBeTruthy();
+  });
+
+  test("and is never sent to the discovery endpoint", async () => {
+    await renderScreen();
+    await submitEmail("nope");
+
+    await screen.findByText("Please enter a valid email address.");
+
+    expect(projectDiscovery()).not.toHaveBeenCalled();
+  });
+
+  test("surrounding whitespace is trimmed before the lookup", async () => {
+    /*
+     * Phone keyboards append a space often enough that not trimming would make
+     * SSO look broken for a correctly typed address.
+     */
+    projectDiscovery().mockResolvedValue(found([projectProvider()]));
+
+    await renderScreen();
+    await submitEmail("  user@acme.com  ");
+
+    await waitFor(() => {
+      expect(projectDiscovery()).toHaveBeenCalledWith("user@acme.com");
+    });
+  });
+
+  test("editing the email clears the message it produced", async () => {
+    await renderScreen();
+
+    await fireEvent.press(screen.getByText("Continue"));
+
+    await screen.findByText("Email is required.");
+
+    await fireEvent.changeText(screen.getByLabelText("Email"), "u");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Email is required.")).toBeNull();
+    });
+  });
+});
+
+describe("Discovery that finds nothing says which kind of nothing", () => {
+  test("an unreachable server is reported as an unreachable server", async () => {
+    projectDiscovery().mockResolvedValue(unreachable<SSOProvider>());
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    expect(await screen.findByText(/Could not reach the server/i)).toBeTruthy();
+  });
+
+  test("and not as a missing SSO configuration for the address", async () => {
+    /*
+     * The regression this pair exists to prevent: both cases used to produce
+     * the email-shaped message, so a phone that was simply offline told the
+     * user their company had not set up SSO.
+     */
+    projectDiscovery().mockResolvedValue(unreachable<SSOProvider>());
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await screen.findByText(/Could not reach the server/i);
+
+    expect(screen.queryByText(/No SSO configuration found/i)).toBeNull();
+    expect(screen.queryByText(/user@acme\.com/)).toBeNull();
+  });
+
+  test("an empty answer names the email that was looked up", async () => {
+    projectDiscovery().mockResolvedValue(found<SSOProvider>([]));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    expect(
+      await screen.findByText(
+        "No SSO configuration found for the email: user@acme.com",
+      ),
+    ).toBeTruthy();
+  });
+
+  test("and does not blame the connection", async () => {
+    projectDiscovery().mockResolvedValue(found<SSOProvider>([]));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await screen.findByText(/No SSO configuration found/i);
+
+    expect(screen.queryByText(/Could not reach the server/i)).toBeNull();
+  });
+
+  test("neither answer moves the user on to a provider list", async () => {
+    projectDiscovery().mockResolvedValue(found<SSOProvider>([]));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await screen.findByText(/No SSO configuration found/i);
+
+    expect(screen.getByLabelText("Email")).toBeTruthy();
+    expect(screen.queryByText("Select your SSO provider")).toBeNull();
+  });
+});
+
+describe("Choosing a project provider", () => {
+  test("a successful lookup moves on to the provider list", async () => {
+    projectDiscovery().mockResolvedValue(found([projectProvider()]));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    expect(await screen.findByText("Select your SSO provider")).toBeTruthy();
+    expect(screen.getByText("Acme Okta")).toBeTruthy();
+  });
+
+  test("providers are grouped under the project they belong to", async () => {
+    /*
+     * One address can federate into several projects with the same-looking
+     * provider name. Without the project heading the user is picking blind,
+     * and the wrong pick issues a token for the wrong project.
+     */
+    projectDiscovery().mockResolvedValue(
+      found([
+        projectProvider(),
+        projectProvider({
+          _id: "provider-2",
+          name: "Acme Azure",
+          projectId: "project-2",
+          project: { name: "Acme Staging" },
+        }),
+      ]),
+    );
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    expect(await screen.findByText("Acme Production")).toBeTruthy();
+    expect(screen.getByText("Acme Staging")).toBeTruthy();
+    expect(screen.getByText("Acme Okta")).toBeTruthy();
+    expect(screen.getByText("Acme Azure")).toBeTruthy();
+  });
+
+  test("a provider whose project the API did not name still gets a heading", async () => {
+    projectDiscovery().mockResolvedValue(
+      found([projectProvider({ project: undefined })]),
+    );
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    expect(await screen.findByText("Unknown Project")).toBeTruthy();
+  });
+
+  test("tapping one opens the project SSO route for that project", async () => {
+    /*
+     * A project login needs BOTH ids in the path. A global-shaped URL here
+     * would be answered by the wrong router.
+     */
+    projectDiscovery().mockResolvedValue(found([projectProvider()]));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByLabelText("Acme Okta"));
+
+    await waitFor(() => {
+      expect(authSession()).toHaveBeenCalledWith(
+        "https://oneuptime.com/identity/sso/project-1/provider-1?mobile=true",
+      );
+    });
+  });
+
+  test("a completed project login signs the user in as well", async () => {
+    projectDiscovery().mockResolvedValue(found([projectProvider()]));
+    authSession().mockResolvedValue({
+      status: "callback",
+      url: "oneuptime://sso-callback?sso-token=abc&project-id=project-1",
+    });
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByLabelText("Acme Okta"));
+
+    await waitFor(() => {
+      expect(mockAuth.setIsAuthenticated).toHaveBeenCalledWith(true);
+    });
+  });
+});
+
+/*
+ * buildSsoLoginUrl refuses a project target with no project id, and that is
+ * reachable: api/sso.ts maps a missing or unparseable `projectId` to "" rather
+ * than dropping the provider, so a sparse discovery payload yields a tappable
+ * row. Before the URL construction was wrapped, the throw escaped the async
+ * onPress as an unhandled rejection: no spinner, no message, no login - the
+ * row simply did nothing, forever, with nothing on screen to explain it.
+ */
+describe("A provider the app cannot build a URL for says so", () => {
+  test("a project provider with no project id reports an error instead of doing nothing", async () => {
+    projectDiscovery().mockResolvedValue(
+      found([projectProvider({ projectId: "" })]),
+    );
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByLabelText("Acme Okta"));
+
+    expect(
+      await screen.findByText(
+        "This SSO provider is misconfigured and cannot be used. Please contact your admin.",
+      ),
+    ).toBeTruthy();
+  });
+
+  test("it does not open an auth session with a malformed URL", async () => {
+    projectDiscovery().mockResolvedValue(
+      found([projectProvider({ projectId: "" })]),
+    );
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByLabelText("Acme Okta"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          "This SSO provider is misconfigured and cannot be used. Please contact your admin.",
+        ),
+      ).toBeTruthy();
+    });
+
+    expect(authSession()).not.toHaveBeenCalled();
+  });
+
+  test("the user stays unauthenticated", async () => {
+    projectDiscovery().mockResolvedValue(
+      found([projectProvider({ projectId: "" })]),
+    );
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByLabelText("Acme Okta"));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          "This SSO provider is misconfigured and cannot be used. Please contact your admin.",
+        ),
+      ).toBeTruthy();
+    });
+
+    expect(mockAuth.setIsAuthenticated).not.toHaveBeenCalled();
+  });
+});
+
+describe("Getting back out", () => {
+  test("the provider list hands the user back to the email step", async () => {
+    projectDiscovery().mockResolvedValue(found([projectProvider()]));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByText("Use a different email"));
+
+    expect(await screen.findByLabelText("Email")).toBeTruthy();
+    expect(screen.queryByText("Acme Okta")).toBeNull();
+  });
+
+  test("and does not leave the auth stack while doing it", async () => {
+    /*
+     * Backing out of a list the user reached from this screen should undo one
+     * step, not throw them all the way to the password login.
+     */
+    projectDiscovery().mockResolvedValue(found([projectProvider()]));
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByText("Use a different email"));
+
+    await screen.findByLabelText("Email");
+
+    expect(mockNavigation.navigate).not.toHaveBeenCalled();
+  });
+
+  test("an error from the provider list does not follow the user back", async () => {
+    projectDiscovery().mockResolvedValue(found([projectProvider()]));
+    authSession().mockResolvedValue({
+      status: "error",
+      message: "Could not open the sign-in page. Please try again.",
+    });
+
+    await renderScreen();
+    await submitEmail("user@acme.com");
+
+    await fireEvent.press(await screen.findByLabelText("Acme Okta"));
+
+    await screen.findByText(
+      "Could not open the sign-in page. Please try again.",
+    );
+
+    await fireEvent.press(screen.getByText("Use a different email"));
+
+    await screen.findByLabelText("Email");
+    expectNoErrorShown();
+  });
+
+  test("the email step goes back to the password login", async () => {
+    await renderScreen();
+
+    await fireEvent.press(screen.getByText("Back to Login"));
+
+    await waitFor(() => {
+      expect(mockNavigation.navigate).toHaveBeenCalledWith("Login");
+    });
+  });
+});

--- a/MobileApp/src/screens/auth/SSOLoginScreen.tsx
+++ b/MobileApp/src/screens/auth/SSOLoginScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import {
   View,
   Text,
@@ -10,19 +10,25 @@ import {
   ActivityIndicator,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import * as WebBrowser from "expo-web-browser";
 import { useTheme } from "../../theme";
 import { useAuth } from "../../hooks/useAuth";
 import {
-  fetchSSOProviders,
-  fetchGlobalSSOProviders,
-  fetchGlobalOIDCProviders,
+  fetchAllGlobalProviders,
+  fetchProjectProvidersForEmail,
   SSOProvider,
   GlobalSSOProvider,
+  type SsoDiscoveryResult,
 } from "../../api/sso";
 import { getServerUrl } from "../../storage/serverUrl";
-import { storeTokens } from "../../storage/keychain";
-import { storeSsoToken, storeGlobalSsoToken } from "../../storage/ssoTokens";
+import { buildSsoLoginUrl } from "../../sso/providerUrl";
+import {
+  openSsoAuthSession,
+  type SsoAuthSessionOutcome,
+} from "../../sso/authSession";
+import {
+  completeSsoLoginFromUrl,
+  type CompleteSsoLoginOutcome,
+} from "../../sso/session";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useNavigation } from "@react-navigation/native";
 import { AuthStackParamList } from "../../navigation/types";
@@ -33,6 +39,14 @@ type SSOLoginNavigationProp = NativeStackNavigationProp<
   AuthStackParamList,
   "SSOLogin"
 >;
+
+/*
+ * Deliberately permissive - the server is the authority on whether an address
+ * federates. This only exists to stop an obvious typo being reported back to
+ * the user as "no SSO providers found", which sends people looking for an
+ * admin instead of at their own keyboard.
+ */
+const EMAIL_PATTERN: RegExp = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export default function SSOLoginScreen(): React.JSX.Element {
   const { theme } = useTheme();
@@ -48,16 +62,40 @@ export default function SSOLoginScreen(): React.JSX.Element {
   const [globalProviders, setGlobalProviders] = useState<
     Array<GlobalSSOProvider>
   >([]);
+  const [isLoadingGlobal, setIsLoadingGlobal] = useState(true);
 
-  useEffect(() => {
-    return () => {
-      WebBrowser.coolDownAsync();
-    };
-  }, []);
+  /*
+   * Global SSO/OIDC providers are configured on the admin dashboard and are
+   * NOT bound to an email domain, so they are discovered on mount and offered
+   * before the email field - exactly as the web login page does. Requiring an
+   * email first (as this screen used to) makes an instance whose only identity
+   * provider is a global one look like it has no SSO at all.
+   */
+  const loadGlobalProviders: () => Promise<void> =
+    useCallback(async (): Promise<void> => {
+      setIsLoadingGlobal(true);
+
+      const result: SsoDiscoveryResult<GlobalSSOProvider> =
+        await fetchAllGlobalProviders();
+
+      setGlobalProviders(result.providers);
+      setIsLoadingGlobal(false);
+    }, []);
+
+  useEffect((): void => {
+    loadGlobalProviders();
+  }, [loadGlobalProviders]);
 
   const handleFetchProviders: () => Promise<void> = async (): Promise<void> => {
-    if (!email.trim()) {
+    const trimmedEmail: string = email.trim();
+
+    if (!trimmedEmail) {
       setError("Email is required.");
+      return;
+    }
+
+    if (!EMAIL_PATTERN.test(trimmedEmail)) {
+      setError("Please enter a valid email address.");
       return;
     }
 
@@ -65,104 +103,36 @@ export default function SSOLoginScreen(): React.JSX.Element {
     setIsLoadingProviders(true);
 
     try {
+      const result: SsoDiscoveryResult<SSOProvider> =
+        await fetchProjectProvidersForEmail(trimmedEmail);
+
       /*
-       * Project SSO providers are scoped to the email; global SSO/OIDC
-       * providers are instance-wide and discovered independently. Fetch all
-       * in parallel and let any individual source fail gracefully.
+       * A failed request and an empty result mean different things and need
+       * different words. Collapsing both into "no providers for this email"
+       * used to send people to their admin when the real problem was that the
+       * phone could not reach the server.
        */
-      const [projectResult, globalSSOResult, globalOIDCResult]: [
-        Array<SSOProvider>,
-        Array<GlobalSSOProvider>,
-        Array<GlobalSSOProvider>,
-      ] = await Promise.all([
-        fetchSSOProviders(email.trim()).catch(() => {
-          return [] as Array<SSOProvider>;
-        }),
-        fetchGlobalSSOProviders().catch(() => {
-          return [] as Array<GlobalSSOProvider>;
-        }),
-        fetchGlobalOIDCProviders().catch(() => {
-          return [] as Array<GlobalSSOProvider>;
-        }),
-      ]);
-
-      const global: Array<GlobalSSOProvider> = [
-        ...globalSSOResult,
-        ...globalOIDCResult,
-      ];
-
-      if (projectResult.length === 0 && global.length === 0) {
-        setError("No SSO providers found for this email.");
+      if (result.failed) {
+        setError(
+          "Could not reach the server to look up SSO providers. Check your connection and try again.",
+        );
         return;
       }
 
-      setGlobalProviders(global);
-      setProviders(projectResult);
-    } catch {
-      setError(
-        "Could not find SSO providers. Please check your email and try again.",
-      );
+      if (result.providers.length === 0) {
+        setError(`No SSO configuration found for the email: ${trimmedEmail}`);
+        return;
+      }
+
+      setProviders(result.providers);
     } finally {
       setIsLoadingProviders(false);
     }
   };
 
   /**
-   * Parses the `oneuptime://sso-callback` deep-link params, persists the auth
-   * tokens and every per-project SSO token, then marks the user authenticated.
-   * Returns true on success.
-   */
-  const handleSSOCallback: (callbackUrl: string) => Promise<boolean> = async (
-    callbackUrl: string,
-  ): Promise<boolean> => {
-    const url: URL = new URL(callbackUrl);
-    const params: URLSearchParams = url.searchParams;
-
-    const accessToken: string | null = params.get("accessToken");
-    const refreshToken: string | null = params.get("refreshToken");
-    const refreshTokenExpiresAt: string | null = params.get(
-      "refreshTokenExpiresAt",
-    );
-
-    if (!accessToken || !refreshToken || !refreshTokenExpiresAt) {
-      setError("Authentication failed. Missing token data.");
-      return false;
-    }
-
-    await storeTokens({
-      accessToken,
-      refreshToken,
-      refreshTokenExpiresAt,
-    });
-
-    /*
-     * Global SSO/OIDC login returns a single global token (not bound to a
-     * project). Store it so the API client can send the `x-global-sso-token`
-     * header; it satisfies SSO enforcement for every project the user belongs
-     * to.
-     */
-    const globalSsoToken: string | null = params.get("globalSsoToken");
-    if (globalSsoToken) {
-      await storeGlobalSsoToken(globalSsoToken);
-    }
-
-    /*
-     * Project SSO login returns a single per-project ssoToken/projectId pair.
-     */
-    const ssoToken: string | null = params.get("ssoToken");
-    const projectId: string | null = params.get("projectId");
-
-    if (ssoToken && projectId) {
-      await storeSsoToken(projectId, ssoToken);
-    }
-
-    setIsAuthenticated(true);
-    return true;
-  };
-
-  /**
-   * Opens an IdP login URL in the auth session browser and handles the result
-   * via the shared `sso-callback` handler.
+   * Runs a login in the auth browser and, if it produced a callback, persists
+   * whatever tokens came back.
    */
   const startSSOFlow: (ssoUrl: string) => Promise<void> = async (
     ssoUrl: string,
@@ -171,56 +141,449 @@ export default function SSOLoginScreen(): React.JSX.Element {
     setIsSSOLoading(true);
 
     try {
-      await WebBrowser.warmUpAsync();
+      const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(ssoUrl);
 
-      const result: WebBrowser.WebBrowserAuthSessionResult =
-        await WebBrowser.openAuthSessionAsync(
-          ssoUrl,
-          "oneuptime://sso-callback",
-        );
-
-      if (result.type === "cancel" || result.type === "dismiss") {
-        setIsSSOLoading(false);
+      if (outcome.status === "cancelled") {
         return;
       }
 
-      if (result.type === "success" && result.url) {
-        await handleSSOCallback(result.url);
+      if (outcome.status === "error") {
+        setError(outcome.message);
+        return;
       }
-    } catch {
-      setError("SSO authentication failed. Please try again.");
+
+      const completed: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+        outcome.url,
+      );
+
+      if (completed.status === "error") {
+        setError(completed.message);
+        return;
+      }
+
+      setIsAuthenticated(true);
     } finally {
       setIsSSOLoading(false);
-      WebBrowser.coolDownAsync();
     }
+  };
+
+  /*
+   * Building the URL can throw - buildSsoLoginUrl rejects a project target
+   * with no project id, which a discovery payload missing `projectId` would
+   * produce. Outside a try/catch that throw escapes the async onPress as an
+   * unhandled rejection and the row simply does nothing when tapped, with no
+   * spinner and no message. Turn it into something the user can read.
+   */
+  const startSSOFlowForUrl: (
+    build: () => Promise<string>,
+  ) => Promise<void> = async (build: () => Promise<string>): Promise<void> => {
+    let ssoUrl: string;
+
+    try {
+      ssoUrl = await build();
+    } catch {
+      setError(
+        "This SSO provider is misconfigured and cannot be used. Please contact your admin.",
+      );
+      return;
+    }
+
+    await startSSOFlow(ssoUrl);
   };
 
   const handleSSOLogin: (provider: SSOProvider) => Promise<void> = async (
     provider: SSOProvider,
   ): Promise<void> => {
-    const serverUrl: string = await getServerUrl();
-    const ssoUrl: string = `${serverUrl}/identity/sso/${provider.projectId}/${provider._id}?mobile=true`;
-    await startSSOFlow(ssoUrl);
+    await startSSOFlowForUrl(async (): Promise<string> => {
+      const serverUrl: string = await getServerUrl();
+
+      return buildSsoLoginUrl(serverUrl, {
+        kind: "project",
+        providerId: provider._id,
+        projectId: provider.projectId,
+      });
+    });
   };
 
   const handleGlobalSSOLogin: (
     provider: GlobalSSOProvider,
   ) => Promise<void> = async (provider: GlobalSSOProvider): Promise<void> => {
-    const serverUrl: string = await getServerUrl();
-    const path: string =
-      provider.type === "oidc" ? "global-oidc" : "global-sso";
-    const ssoUrl: string = `${serverUrl}/identity/${path}/${provider._id}?mobile=true`;
-    await startSSOFlow(ssoUrl);
+    await startSSOFlowForUrl(async (): Promise<string> => {
+      const serverUrl: string = await getServerUrl();
+
+      return buildSsoLoginUrl(serverUrl, {
+        kind: provider.type,
+        providerId: provider._id,
+      });
+    });
   };
 
   const handleBack: () => void = (): void => {
     if (providers) {
       setProviders(null);
-      setGlobalProviders([]);
       setError(null);
     } else {
       navigation.navigate("Login");
     }
+  };
+
+  const renderProviderRow: (data: {
+    key: string;
+    name: string;
+    description?: string | undefined;
+    icon: keyof typeof Ionicons.glyphMap;
+    isLast: boolean;
+    onPress: () => void;
+  }) => React.JSX.Element = (data: {
+    key: string;
+    name: string;
+    description?: string | undefined;
+    icon: keyof typeof Ionicons.glyphMap;
+    isLast: boolean;
+    onPress: () => void;
+  }): React.JSX.Element => {
+    return (
+      <Pressable
+        key={data.key}
+        accessibilityRole="button"
+        accessibilityLabel={data.name}
+        onPress={data.onPress}
+        style={{
+          marginBottom: data.isLast ? 0 : 10,
+          borderRadius: 14,
+          backgroundColor: theme.colors.backgroundSecondary,
+          borderWidth: 1,
+          borderColor: theme.colors.borderDefault,
+          overflow: "hidden",
+        }}
+      >
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            paddingHorizontal: 16,
+            paddingVertical: 14,
+          }}
+        >
+          <View
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: 10,
+              backgroundColor: theme.colors.iconBackground,
+              alignItems: "center",
+              justifyContent: "center",
+              marginRight: 12,
+            }}
+          >
+            <Ionicons
+              name={data.icon}
+              size={18}
+              color={theme.colors.actionPrimary}
+            />
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text
+              style={{
+                fontSize: 15,
+                fontWeight: "600",
+                color: theme.colors.textPrimary,
+              }}
+            >
+              {data.name}
+            </Text>
+            {data.description ? (
+              <Text
+                style={{
+                  fontSize: 13,
+                  marginTop: 2,
+                  color: theme.colors.textSecondary,
+                }}
+              >
+                {data.description}
+              </Text>
+            ) : null}
+          </View>
+          <Ionicons
+            name="chevron-forward"
+            size={18}
+            color={theme.colors.textTertiary}
+          />
+        </View>
+      </Pressable>
+    );
+  };
+
+  const renderError: () => React.JSX.Element | null =
+    (): React.JSX.Element | null => {
+      if (!error) {
+        return null;
+      }
+
+      return (
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "flex-start",
+            marginTop: 12,
+          }}
+        >
+          <Ionicons
+            name="alert-circle"
+            size={14}
+            color={theme.colors.statusError}
+            style={{ marginRight: 6, marginTop: 2 }}
+          />
+          <Text
+            style={{
+              fontSize: 13,
+              flex: 1,
+              color: theme.colors.statusError,
+            }}
+          >
+            {error}
+          </Text>
+        </View>
+      );
+    };
+
+  const renderGlobalSection: () => React.JSX.Element | null =
+    (): React.JSX.Element | null => {
+      if (isLoadingGlobal) {
+        return (
+          <View style={{ alignItems: "center", paddingVertical: 12 }}>
+            <ActivityIndicator
+              size="small"
+              color={theme.colors.actionPrimary}
+            />
+          </View>
+        );
+      }
+
+      if (globalProviders.length === 0) {
+        return null;
+      }
+
+      return (
+        <View style={{ marginBottom: 24 }}>
+          <Text
+            style={{
+              fontSize: 13,
+              fontWeight: "600",
+              marginBottom: 10,
+              color: theme.colors.textSecondary,
+            }}
+          >
+            Sign in with your organization
+          </Text>
+
+          {globalProviders.map((provider: GlobalSSOProvider, index: number) => {
+            return renderProviderRow({
+              key: provider._id,
+              name: provider.name,
+              description: provider.description,
+              icon: "globe-outline",
+              isLast: index === globalProviders.length - 1,
+              onPress: () => {
+                return handleGlobalSSOLogin(provider);
+              },
+            });
+          })}
+
+          <View
+            style={{
+              flexDirection: "row",
+              alignItems: "center",
+              marginTop: 24,
+            }}
+          >
+            <View
+              style={{
+                flex: 1,
+                height: 1,
+                backgroundColor: theme.colors.borderDefault,
+              }}
+            />
+            <Text
+              style={{
+                marginHorizontal: 12,
+                fontSize: 12,
+                color: theme.colors.textTertiary,
+              }}
+            >
+              Or continue with email
+            </Text>
+            <View
+              style={{
+                flex: 1,
+                height: 1,
+                backgroundColor: theme.colors.borderDefault,
+              }}
+            />
+          </View>
+        </View>
+      );
+    };
+
+  const renderEmailStep: () => React.JSX.Element = (): React.JSX.Element => {
+    return (
+      <View>
+        {renderGlobalSection()}
+
+        <Text
+          style={{
+            fontSize: 13,
+            fontWeight: "600",
+            marginBottom: 8,
+            color: theme.colors.textSecondary,
+          }}
+        >
+          Email
+        </Text>
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            height: 48,
+            borderRadius: 12,
+            paddingHorizontal: 14,
+            backgroundColor: theme.colors.backgroundSecondary,
+            borderWidth: 1.5,
+            borderColor: emailFocused
+              ? theme.colors.actionPrimary
+              : theme.colors.borderDefault,
+          }}
+        >
+          <Ionicons
+            name="mail-outline"
+            size={18}
+            color={
+              emailFocused
+                ? theme.colors.actionPrimary
+                : theme.colors.textTertiary
+            }
+            style={{ marginRight: 10 }}
+          />
+          <TextInput
+            style={{
+              flex: 1,
+              fontSize: 15,
+              color: theme.colors.textPrimary,
+            }}
+            value={email}
+            onChangeText={(text: string) => {
+              setEmail(text);
+              setError(null);
+            }}
+            onFocus={() => {
+              return setEmailFocused(true);
+            }}
+            onBlur={() => {
+              return setEmailFocused(false);
+            }}
+            placeholder="you@example.com"
+            placeholderTextColor={theme.colors.textTertiary}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="email-address"
+            textContentType="emailAddress"
+            returnKeyType="go"
+            accessibilityLabel="Email"
+            onSubmitEditing={handleFetchProviders}
+          />
+        </View>
+
+        {renderError()}
+
+        <View style={{ marginTop: 24 }}>
+          <GradientButton
+            label="Continue"
+            onPress={handleFetchProviders}
+            loading={isLoadingProviders}
+            disabled={isLoadingProviders}
+          />
+        </View>
+      </View>
+    );
+  };
+
+  const renderProjectStep: () => React.JSX.Element = (): React.JSX.Element => {
+    if (isSSOLoading) {
+      return (
+        <View style={{ alignItems: "center", paddingVertical: 32 }}>
+          <ActivityIndicator size="large" color={theme.colors.actionPrimary} />
+          <Text
+            style={{
+              marginTop: 12,
+              fontSize: 14,
+              color: theme.colors.textSecondary,
+            }}
+          >
+            Authenticating...
+          </Text>
+        </View>
+      );
+    }
+
+    // Group providers by the project they belong to.
+    const grouped: Record<
+      string,
+      { projectName: string; items: Array<SSOProvider> }
+    > = {};
+
+    for (const provider of providers || []) {
+      const key: string = provider.projectId;
+      const projectName: string = provider.project?.name || "Unknown Project";
+
+      if (!grouped[key]) {
+        grouped[key] = { projectName, items: [] };
+      }
+
+      grouped[key]!.items.push(provider);
+    }
+
+    return (
+      <View>
+        {Object.entries(grouped).map(
+          ([projectId, group]: [
+            string,
+            { projectName: string; items: Array<SSOProvider> },
+          ]) => {
+            return (
+              <View key={projectId} style={{ marginBottom: 20 }}>
+                <Text
+                  style={{
+                    fontSize: 17,
+                    fontWeight: "700",
+                    color: theme.colors.textPrimary,
+                    marginBottom: 10,
+                    paddingHorizontal: 4,
+                    letterSpacing: -0.3,
+                  }}
+                >
+                  {group.projectName}
+                </Text>
+
+                {group.items.map((provider: SSOProvider, index: number) => {
+                  return renderProviderRow({
+                    key: provider._id,
+                    name: provider.name,
+                    description: provider.description,
+                    icon: "shield-checkmark-outline",
+                    isLast: index === group.items.length - 1,
+                    onPress: () => {
+                      return handleSSOLogin(provider);
+                    },
+                  });
+                })}
+              </View>
+            );
+          },
+        )}
+
+        {renderError()}
+      </View>
+    );
   };
 
   return (
@@ -267,396 +630,35 @@ export default function SSOLoginScreen(): React.JSX.Element {
             >
               {providers
                 ? "Select your SSO provider"
-                : "Enter your email to find SSO providers"}
+                : "Choose your provider or enter your email"}
             </Text>
           </View>
 
-          {!providers ? (
-            <View>
+          {isSSOLoading && !providers ? (
+            <View style={{ alignItems: "center", paddingVertical: 32 }}>
+              <ActivityIndicator
+                size="large"
+                color={theme.colors.actionPrimary}
+              />
               <Text
                 style={{
-                  fontSize: 13,
-                  fontWeight: "600",
-                  marginBottom: 8,
+                  marginTop: 12,
+                  fontSize: 14,
                   color: theme.colors.textSecondary,
                 }}
               >
-                Email
+                Authenticating...
               </Text>
-              <View
-                style={{
-                  flexDirection: "row",
-                  alignItems: "center",
-                  height: 48,
-                  borderRadius: 12,
-                  paddingHorizontal: 14,
-                  backgroundColor: theme.colors.backgroundSecondary,
-                  borderWidth: 1.5,
-                  borderColor: emailFocused
-                    ? theme.colors.actionPrimary
-                    : theme.colors.borderDefault,
-                }}
-              >
-                <Ionicons
-                  name="mail-outline"
-                  size={18}
-                  color={
-                    emailFocused
-                      ? theme.colors.actionPrimary
-                      : theme.colors.textTertiary
-                  }
-                  style={{ marginRight: 10 }}
-                />
-                <TextInput
-                  style={{
-                    flex: 1,
-                    fontSize: 15,
-                    color: theme.colors.textPrimary,
-                  }}
-                  value={email}
-                  onChangeText={(text: string) => {
-                    setEmail(text);
-                    setError(null);
-                  }}
-                  onFocus={() => {
-                    return setEmailFocused(true);
-                  }}
-                  onBlur={() => {
-                    return setEmailFocused(false);
-                  }}
-                  placeholder="you@example.com"
-                  placeholderTextColor={theme.colors.textTertiary}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  keyboardType="email-address"
-                  textContentType="emailAddress"
-                  returnKeyType="go"
-                  onSubmitEditing={handleFetchProviders}
-                />
-              </View>
-
-              {error ? (
-                <View
-                  style={{
-                    flexDirection: "row",
-                    alignItems: "flex-start",
-                    marginTop: 12,
-                  }}
-                >
-                  <Ionicons
-                    name="alert-circle"
-                    size={14}
-                    color={theme.colors.statusError}
-                    style={{ marginRight: 6, marginTop: 2 }}
-                  />
-                  <Text
-                    style={{
-                      fontSize: 13,
-                      flex: 1,
-                      color: theme.colors.statusError,
-                    }}
-                  >
-                    {error}
-                  </Text>
-                </View>
-              ) : null}
-
-              <View style={{ marginTop: 24 }}>
-                <GradientButton
-                  label="Continue"
-                  onPress={handleFetchProviders}
-                  loading={isLoadingProviders}
-                  disabled={isLoadingProviders}
-                />
-              </View>
             </View>
+          ) : providers ? (
+            renderProjectStep()
           ) : (
-            <View>
-              {isSSOLoading ? (
-                <View style={{ alignItems: "center", paddingVertical: 32 }}>
-                  <ActivityIndicator
-                    size="large"
-                    color={theme.colors.actionPrimary}
-                  />
-                  <Text
-                    style={{
-                      marginTop: 12,
-                      fontSize: 14,
-                      color: theme.colors.textSecondary,
-                    }}
-                  >
-                    Authenticating...
-                  </Text>
-                </View>
-              ) : (
-                <>
-                  {(() => {
-                    // Group providers by project
-                    const grouped: Record<
-                      string,
-                      { projectName: string; items: SSOProvider[] }
-                    > = {};
-
-                    for (const provider of providers) {
-                      const key: string = provider.projectId;
-                      const projectName: string =
-                        provider.project?.name || "Unknown Project";
-
-                      if (!grouped[key]) {
-                        grouped[key] = { projectName, items: [] };
-                      }
-
-                      grouped[key]!.items.push(provider);
-                    }
-
-                    return Object.entries(grouped).map(
-                      ([projectId, group]: [
-                        string,
-                        { projectName: string; items: SSOProvider[] },
-                      ]) => {
-                        return (
-                          <View key={projectId} style={{ marginBottom: 20 }}>
-                            <View
-                              style={{
-                                flexDirection: "row",
-                                alignItems: "center",
-                                marginBottom: 10,
-                                paddingHorizontal: 4,
-                              }}
-                            >
-                              <Text
-                                style={{
-                                  fontSize: 17,
-                                  fontWeight: "700",
-                                  color: theme.colors.textPrimary,
-                                  flex: 1,
-                                  letterSpacing: -0.3,
-                                }}
-                              >
-                                {group.projectName}
-                              </Text>
-                            </View>
-
-                            {group.items.map(
-                              (provider: SSOProvider, index: number) => {
-                                return (
-                                  <Pressable
-                                    key={provider._id}
-                                    onPress={() => {
-                                      return handleSSOLogin(provider);
-                                    }}
-                                    style={{
-                                      marginBottom:
-                                        index < group.items.length - 1 ? 10 : 0,
-                                      borderRadius: 14,
-                                      backgroundColor:
-                                        theme.colors.backgroundSecondary,
-                                      borderWidth: 1,
-                                      borderColor: theme.colors.borderDefault,
-                                      overflow: "hidden",
-                                    }}
-                                  >
-                                    <View
-                                      style={{
-                                        flexDirection: "row",
-                                        alignItems: "center",
-                                        paddingHorizontal: 16,
-                                        paddingVertical: 14,
-                                      }}
-                                    >
-                                      <View
-                                        style={{
-                                          width: 36,
-                                          height: 36,
-                                          borderRadius: 10,
-                                          backgroundColor:
-                                            theme.colors.iconBackground,
-                                          alignItems: "center",
-                                          justifyContent: "center",
-                                          marginRight: 12,
-                                        }}
-                                      >
-                                        <Ionicons
-                                          name="shield-checkmark-outline"
-                                          size={18}
-                                          color={theme.colors.actionPrimary}
-                                        />
-                                      </View>
-                                      <View style={{ flex: 1 }}>
-                                        <Text
-                                          style={{
-                                            fontSize: 15,
-                                            fontWeight: "600",
-                                            color: theme.colors.textPrimary,
-                                          }}
-                                        >
-                                          {provider.name}
-                                        </Text>
-                                        {provider.description ? (
-                                          <Text
-                                            style={{
-                                              fontSize: 13,
-                                              marginTop: 2,
-                                              color: theme.colors.textSecondary,
-                                            }}
-                                          >
-                                            {provider.description}
-                                          </Text>
-                                        ) : null}
-                                      </View>
-                                      <Ionicons
-                                        name="chevron-forward"
-                                        size={18}
-                                        color={theme.colors.textTertiary}
-                                      />
-                                    </View>
-                                  </Pressable>
-                                );
-                              },
-                            )}
-                          </View>
-                        );
-                      },
-                    );
-                  })()}
-
-                  {globalProviders.length > 0 ? (
-                    <View style={{ marginBottom: 20 }}>
-                      <View
-                        style={{
-                          flexDirection: "row",
-                          alignItems: "center",
-                          marginBottom: 10,
-                          paddingHorizontal: 4,
-                        }}
-                      >
-                        <Text
-                          style={{
-                            fontSize: 17,
-                            fontWeight: "700",
-                            color: theme.colors.textPrimary,
-                            flex: 1,
-                            letterSpacing: -0.3,
-                          }}
-                        >
-                          Global SSO
-                        </Text>
-                      </View>
-
-                      {globalProviders.map(
-                        (provider: GlobalSSOProvider, index: number) => {
-                          return (
-                            <Pressable
-                              key={provider._id}
-                              onPress={() => {
-                                return handleGlobalSSOLogin(provider);
-                              }}
-                              style={{
-                                marginBottom:
-                                  index < globalProviders.length - 1 ? 10 : 0,
-                                borderRadius: 14,
-                                backgroundColor:
-                                  theme.colors.backgroundSecondary,
-                                borderWidth: 1,
-                                borderColor: theme.colors.borderDefault,
-                                overflow: "hidden",
-                              }}
-                            >
-                              <View
-                                style={{
-                                  flexDirection: "row",
-                                  alignItems: "center",
-                                  paddingHorizontal: 16,
-                                  paddingVertical: 14,
-                                }}
-                              >
-                                <View
-                                  style={{
-                                    width: 36,
-                                    height: 36,
-                                    borderRadius: 10,
-                                    backgroundColor:
-                                      theme.colors.iconBackground,
-                                    alignItems: "center",
-                                    justifyContent: "center",
-                                    marginRight: 12,
-                                  }}
-                                >
-                                  <Ionicons
-                                    name="globe-outline"
-                                    size={18}
-                                    color={theme.colors.actionPrimary}
-                                  />
-                                </View>
-                                <View style={{ flex: 1 }}>
-                                  <Text
-                                    style={{
-                                      fontSize: 15,
-                                      fontWeight: "600",
-                                      color: theme.colors.textPrimary,
-                                    }}
-                                  >
-                                    {provider.name}
-                                  </Text>
-                                  {provider.description ? (
-                                    <Text
-                                      style={{
-                                        fontSize: 13,
-                                        marginTop: 2,
-                                        color: theme.colors.textSecondary,
-                                      }}
-                                    >
-                                      {provider.description}
-                                    </Text>
-                                  ) : null}
-                                </View>
-                                <Ionicons
-                                  name="chevron-forward"
-                                  size={18}
-                                  color={theme.colors.textTertiary}
-                                />
-                              </View>
-                            </Pressable>
-                          );
-                        },
-                      )}
-                    </View>
-                  ) : null}
-                </>
-              )}
-
-              {error ? (
-                <View
-                  style={{
-                    flexDirection: "row",
-                    alignItems: "flex-start",
-                    marginTop: 4,
-                    marginBottom: 12,
-                  }}
-                >
-                  <Ionicons
-                    name="alert-circle"
-                    size={14}
-                    color={theme.colors.statusError}
-                    style={{ marginRight: 6, marginTop: 2 }}
-                  />
-                  <Text
-                    style={{
-                      fontSize: 13,
-                      flex: 1,
-                      color: theme.colors.statusError,
-                    }}
-                  >
-                    {error}
-                  </Text>
-                </View>
-              ) : null}
-            </View>
+            renderEmailStep()
           )}
 
           <View style={{ marginTop: 16 }}>
             <GradientButton
-              label={providers ? "Use email and password" : "Back to Login"}
+              label={providers ? "Use a different email" : "Back to Login"}
               onPress={handleBack}
               variant="secondary"
               icon="arrow-back-outline"

--- a/MobileApp/src/screens/settings/ProjectsScreen.tsx
+++ b/MobileApp/src/screens/settings/ProjectsScreen.tsx
@@ -8,20 +8,32 @@ import {
   RefreshControl,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import * as WebBrowser from "expo-web-browser";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useTheme } from "../../theme";
 import { fetchProjects } from "../../api/projects";
-import { fetchSSOProvidersForProject, SSOProvider } from "../../api/sso";
-import { getServerUrl } from "../../storage/serverUrl";
 import {
-  getCachedSsoTokens,
-  storeSsoToken,
-  getSsoTokens,
-  getGlobalSsoToken,
-} from "../../storage/ssoTokens";
+  fetchAllGlobalProviders,
+  fetchSSOProvidersForProject,
+  GlobalSSOProvider,
+  SSOProvider,
+  type SsoDiscoveryResult,
+} from "../../api/sso";
+import { getServerUrl } from "../../storage/serverUrl";
+import { getSsoTokens, getGlobalSsoToken } from "../../storage/ssoTokens";
+import { buildSsoLoginUrl } from "../../sso/providerUrl";
+import {
+  openSsoAuthSession,
+  type SsoAuthSessionOutcome,
+} from "../../sso/authSession";
+import {
+  completeSsoLoginFromUrl,
+  type CompleteSsoLoginOutcome,
+} from "../../sso/session";
 import type { ProjectItem, ListResponse } from "../../api/types";
-import type { SettingsStackParamList } from "../../navigation/types";
+import type {
+  SelectableSsoProvider,
+  SettingsStackParamList,
+} from "../../navigation/types";
 
 type Props = NativeStackScreenProps<SettingsStackParamList, "ProjectsList">;
 
@@ -64,23 +76,31 @@ export default function ProjectsScreen({
     }
   }, []);
 
+  /*
+   * Re-reads the stored SSO tokens. Both reads drop anything that has expired,
+   * so this doubles as the eviction pass that turns a lapsed token back into a
+   * visible "Authenticate with SSO" button instead of a project that claims to
+   * be authenticated and 406s on every request.
+   */
+  const refreshSsoState: () => Promise<void> =
+    useCallback(async (): Promise<void> => {
+      const [tokens, globalToken]: [Record<string, string>, string | null] =
+        await Promise.all([getSsoTokens(), getGlobalSsoToken()]);
+      setSsoTokens(tokens);
+      setGlobalSsoToken(globalToken);
+    }, []);
+
   useEffect(() => {
     loadData();
   }, [loadData]);
 
   // Refresh SSO token state when returning from the provider selection screen
   useEffect(() => {
-    const unsubscribe: () => void = navigation.addListener(
-      "focus",
-      async () => {
-        const [tokens, globalToken]: [Record<string, string>, string | null] =
-          await Promise.all([getSsoTokens(), getGlobalSsoToken()]);
-        setSsoTokens(tokens);
-        setGlobalSsoToken(globalToken);
-      },
-    );
+    const unsubscribe: () => void = navigation.addListener("focus", () => {
+      refreshSsoState();
+    });
     return unsubscribe;
-  }, [navigation]);
+  }, [navigation, refreshSsoState]);
 
   const handleRefresh: () => void = (): void => {
     setIsRefreshing(true);
@@ -88,36 +108,51 @@ export default function ProjectsScreen({
   };
 
   const openSsoAuth: (
-    provider: SSOProvider,
+    provider: SelectableSsoProvider,
     projectId: string,
   ) => Promise<void> = async (
-    provider: SSOProvider,
+    provider: SelectableSsoProvider,
     projectId: string,
   ): Promise<void> => {
     const serverUrl: string = await getServerUrl();
-    const ssoUrl: string = `${serverUrl}/identity/sso/${projectId}/${provider._id}?mobile=true`;
 
-    await WebBrowser.warmUpAsync();
+    const ssoUrl: string = buildSsoLoginUrl(serverUrl, {
+      kind: provider.kind,
+      providerId: provider._id,
+      projectId: provider.kind === "project" ? projectId : undefined,
+    });
 
-    const result: WebBrowser.WebBrowserAuthSessionResult =
-      await WebBrowser.openAuthSessionAsync(ssoUrl, "oneuptime://sso-callback");
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(ssoUrl);
 
-    if (result.type === "success" && result.url) {
-      const url: URL = new URL(result.url);
-      const params: URLSearchParams = url.searchParams;
-
-      const ssoToken: string | null = params.get("ssoToken");
-      const returnedProjectId: string | null = params.get("projectId");
-
-      if (ssoToken && returnedProjectId) {
-        await storeSsoToken(returnedProjectId, ssoToken);
-        setSsoTokens({ ...getCachedSsoTokens() });
-      }
+    if (outcome.status === "cancelled") {
+      return;
     }
 
-    WebBrowser.coolDownAsync();
+    if (outcome.status === "error") {
+      setError(outcome.message);
+      return;
+    }
+
+    const completed: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+      outcome.url,
+    );
+
+    if (completed.status === "error") {
+      setError(completed.message);
+      return;
+    }
+
+    await refreshSsoState();
   };
 
+  /*
+   * A project that enforces SSO can be satisfied two ways: by a provider
+   * configured inside the project, or by an instance-wide Global SSO/OIDC
+   * provider the admin set up. Only the first was ever offered here, so on an
+   * instance whose identity provider is global, an authenticated user hit a
+   * dead end - "No SSO providers are configured" - with no way forward short
+   * of signing out entirely.
+   */
   const handleAuthenticate: (project: ProjectItem) => Promise<void> = async (
     project: ProjectItem,
   ): Promise<void> => {
@@ -127,32 +162,50 @@ export default function ProjectsScreen({
     setError(null);
 
     try {
-      // Fetch SSO providers for this specific project (like the dashboard does)
-      const providers: SSOProvider[] =
-        await fetchSSOProvidersForProject(projectId);
+      const [projectProviders, globalResult]: [
+        Array<SSOProvider>,
+        SsoDiscoveryResult<GlobalSSOProvider>,
+      ] = await Promise.all([
+        fetchSSOProvidersForProject(projectId).catch(() => {
+          return [] as Array<SSOProvider>;
+        }),
+        fetchAllGlobalProviders(),
+      ]);
 
-      if (providers.length === 0) {
+      const selectable: Array<SelectableSsoProvider> = [
+        ...globalResult.providers.map((provider: GlobalSSOProvider) => {
+          return {
+            _id: provider._id,
+            name: provider.name,
+            description: provider.description,
+            kind: provider.type,
+          };
+        }),
+        ...projectProviders.map((provider: SSOProvider) => {
+          return {
+            _id: provider._id,
+            name: provider.name,
+            description: provider.description,
+            kind: "project" as const,
+          };
+        }),
+      ];
+
+      if (selectable.length === 0) {
         setError(
           "No SSO providers are configured or enabled for this project. Please contact your admin.",
         );
         return;
       }
 
-      if (providers.length === 1) {
-        // Single provider — go directly to SSO auth
-        await openSsoAuth(providers[0]!, projectId);
+      if (selectable.length === 1) {
+        // Single provider - go straight to it rather than showing a list of one.
+        await openSsoAuth(selectable[0]!, projectId);
       } else {
-        // Multiple providers — navigate to selection screen
         navigation.navigate("SSOProviderSelect", {
           projectId,
           projectName: project.name,
-          providers: providers.map((p: SSOProvider) => {
-            return {
-              _id: p._id,
-              name: p.name,
-              description: p.description,
-            };
-          }),
+          providers: selectable,
         });
       }
     } catch {
@@ -388,7 +441,15 @@ export default function ProjectsScreen({
                     onPress={() => {
                       return handleAuthenticate(project);
                     }}
-                    disabled={isAuthenticating}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Authenticate with SSO for ${project.name}`}
+                    /*
+                     * Disabled for EVERY row while any row is authenticating,
+                     * not just the busy one: expo-web-browser allows a single
+                     * auth session at a time and throws
+                     * "WebBrowser is already open" on a second tap.
+                     */
+                    disabled={authenticatingProjectId !== null}
                     style={{
                       marginTop: 12,
                       paddingVertical: 10,
@@ -396,7 +457,7 @@ export default function ProjectsScreen({
                       backgroundColor: theme.colors.actionPrimary,
                       alignItems: "center",
                       justifyContent: "center",
-                      opacity: isAuthenticating ? 0.7 : 1,
+                      opacity: authenticatingProjectId !== null ? 0.7 : 1,
                     }}
                   >
                     {isAuthenticating ? (

--- a/MobileApp/src/screens/settings/SSOProviderSelectScreen.test.tsx
+++ b/MobileApp/src/screens/settings/SSOProviderSelectScreen.test.tsx
@@ -1,0 +1,662 @@
+import React from "react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react-native";
+import SSOProviderSelectScreen from "./SSOProviderSelectScreen";
+import {
+  openSsoAuthSession,
+  type SsoAuthSessionOutcome,
+} from "../../sso/authSession";
+import {
+  completeSsoLoginFromUrl,
+  type CompleteSsoLoginOutcome,
+} from "../../sso/session";
+import { getServerUrl } from "../../storage/serverUrl";
+import type { SelectableSsoProvider } from "../../navigation/types";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * The re-authentication sheet an already signed-in user reaches from
+ * Settings -> Projects when a project refuses their token until they complete
+ * SSO.
+ *
+ * Until recently it could only ever start a PROJECT SSO login and only ever
+ * looked for a project `ssoToken` on the way back. On an instance where SSO is
+ * supplied by a GLOBAL provider configured on the admin dashboard that left the
+ * user with no way out at all: the row either sent them to
+ * `/identity/sso/<projectId>/<globalProviderId>`, which the server answers with
+ * a 400 because that provider does not belong to the project, or - once the
+ * routing was half-fixed - completed the login upstream and then dropped the
+ * instance-wide token on the floor, returning them to the same locked project
+ * with nothing shown and nothing stored.
+ *
+ * So the assertions here are about the two hand-offs the screen owns:
+ *
+ *   - the URL it opens has to encode the provider's KIND (which of the three
+ *     server routers to use) and must not smuggle a project id into a global
+ *     login, and
+ *   - whatever the browser hands back has to reach completeSsoLoginFromUrl,
+ *     for a global login exactly as for a project one, before the sheet closes.
+ *
+ * `buildSsoLoginUrl` is deliberately NOT mocked - the mapping from kind to
+ * route is the regression, so it is exercised for real. The auth browser, the
+ * session writer and the stored server URL are mocked, since none of them can
+ * run off-device.
+ */
+
+jest.mock("../../sso/authSession", () => {
+  return {
+    openSsoAuthSession: jest.fn(),
+  };
+});
+
+jest.mock("../../sso/session", () => {
+  return {
+    completeSsoLoginFromUrl: jest.fn(),
+  };
+});
+
+jest.mock("../../storage/serverUrl", () => {
+  return {
+    getServerUrl: jest.fn(),
+  };
+});
+
+const mockOpenSsoAuthSession: jest.Mock =
+  openSsoAuthSession as unknown as jest.Mock;
+const mockCompleteSsoLoginFromUrl: jest.Mock =
+  completeSsoLoginFromUrl as unknown as jest.Mock;
+const mockGetServerUrl: jest.Mock = getServerUrl as unknown as jest.Mock;
+
+// A self-hosted instance, so a hard-coded oneuptime.com would fail these.
+const SERVER_URL: string = "https://oneuptime.everythingcorp.example";
+const PROJECT_ID: string = "0123456789abcdef01234567";
+const PROJECT_NAME: string = "Everything Corp Production";
+
+/*
+ * What the IdP redirects back to. Only its identity matters here: the screen
+ * must forward THIS url - not the login url it opened - to the session module.
+ */
+const CALLBACK_URL: string =
+  "oneuptime://sso-callback?access-token=at&refresh-token=rt&global-sso-token=gt";
+
+const globalSamlProvider: SelectableSsoProvider = {
+  _id: "aaaaaaaaaaaaaaaaaaaaaaa1",
+  name: "Okta for Everything Corp",
+  description: "Company-wide single sign-on",
+  kind: "global-sso",
+};
+
+const globalOidcProvider: SelectableSsoProvider = {
+  _id: "aaaaaaaaaaaaaaaaaaaaaaa2",
+  name: "Microsoft Entra ID",
+  kind: "global-oidc",
+};
+
+const projectSamlProvider: SelectableSsoProvider = {
+  _id: "bbbbbbbbbbbbbbbbbbbbbbb1",
+  name: "Production SAML",
+  description: "Configured in this project's settings",
+  kind: "project",
+};
+
+/*
+ * Every message this screen is capable of showing contains one of these words.
+ * Used to assert the ABSENCE of an error, which a `queryByText` of one specific
+ * string would not really establish.
+ */
+const ANY_ERROR_MESSAGE: RegExp = /failed|could not|error|denied|invalid/i;
+
+type ScreenProps = React.ComponentProps<typeof SSOProviderSelectScreen>;
+
+interface RenderedScreen {
+  goBack: jest.Mock;
+}
+
+async function renderScreen(
+  providers: Array<SelectableSsoProvider>,
+  projectId: string = PROJECT_ID,
+): Promise<RenderedScreen> {
+  const goBack: jest.Mock = jest.fn();
+
+  /*
+   * React Navigation hands the screen far more than it reads; the cast keeps
+   * the fixture to the three params this screen actually uses.
+   */
+  const props: ScreenProps = {
+    route: {
+      key: "SSOProviderSelect-test",
+      name: "SSOProviderSelect",
+      params: {
+        projectId,
+        projectName: PROJECT_NAME,
+        providers,
+      },
+    },
+    navigation: { goBack },
+  } as unknown as ScreenProps;
+
+  await render(<SSOProviderSelectScreen {...props} />);
+
+  return { goBack };
+}
+
+// Rows expose the provider name as their accessibility label.
+async function pressProvider(name: string): Promise<void> {
+  await fireEvent.press(screen.getByLabelText(name));
+}
+
+/*
+ * A macrotask boundary, which drains every microtask queued behind it - and
+ * everything this screen awaits is mocked, so one boundary finishes the whole
+ * handler.
+ */
+async function nextMacrotask(): Promise<void> {
+  await new Promise<void>((resolve: () => void): void => {
+    setTimeout(resolve, 0);
+  });
+}
+
+/**
+ * Runs the pressed row's async handler to completion, with the state updates
+ * it makes on the way out wrapped in `act` so React applies them to the tree.
+ */
+async function settleAuthFlow(): Promise<void> {
+  await act(async (): Promise<void> => {
+    await nextMacrotask();
+  });
+}
+
+function openedUrls(): Array<string> {
+  return mockOpenSsoAuthSession.mock.calls.map(
+    (call: Array<unknown>): string => {
+      return call[0] as string;
+    },
+  );
+}
+
+function lastOpenedUrl(): string {
+  const urls: Array<string> = openedUrls();
+
+  return urls[urls.length - 1] as string;
+}
+
+function isRowDisabled(name: string): boolean {
+  const row: { props: { accessibilityState?: { disabled?: boolean } } } =
+    screen.getByLabelText(name) as unknown as {
+      props: { accessibilityState?: { disabled?: boolean } };
+    };
+
+  return row.props.accessibilityState?.disabled === true;
+}
+
+const callbackOutcome: SsoAuthSessionOutcome = {
+  status: "callback",
+  url: CALLBACK_URL,
+};
+
+beforeEach(() => {
+  /*
+   * `clearMocks` in jest.config.js clears CALLS but not IMPLEMENTATIONS, so a
+   * one-off `mockResolvedValue` or a deliberately hanging promise from an
+   * earlier test would otherwise leak into this one.
+   */
+  mockGetServerUrl.mockReset();
+  mockOpenSsoAuthSession.mockReset();
+  mockCompleteSsoLoginFromUrl.mockReset();
+
+  mockGetServerUrl.mockResolvedValue(SERVER_URL);
+  mockOpenSsoAuthSession.mockResolvedValue(callbackOutcome);
+  mockCompleteSsoLoginFromUrl.mockResolvedValue({
+    status: "success",
+    isGlobal: false,
+    projectId: PROJECT_ID,
+  } as CompleteSsoLoginOutcome);
+});
+
+describe("The row sends the user to the router that owns the provider", () => {
+  test("a project provider starts a project SSO login", async () => {
+    await renderScreen([projectSamlProvider]);
+
+    await pressProvider(projectSamlProvider.name);
+    await settleAuthFlow();
+
+    expect(lastOpenedUrl()).toBe(
+      `${SERVER_URL}/identity/sso/${PROJECT_ID}/${projectSamlProvider._id}?mobile=true`,
+    );
+  });
+
+  test("a global SAML provider starts an instance-wide login, with no project id", async () => {
+    /*
+     * The project id is the regression. `/identity/global-sso/...` takes no
+     * project, and the previous version of this screen appended one anyway -
+     * which the server rejects, so the user never even reached the IdP.
+     */
+    await renderScreen([globalSamlProvider]);
+
+    await pressProvider(globalSamlProvider.name);
+    await settleAuthFlow();
+
+    expect(lastOpenedUrl()).toBe(
+      `${SERVER_URL}/identity/global-sso/${globalSamlProvider._id}?mobile=true`,
+    );
+    expect(lastOpenedUrl()).not.toContain(PROJECT_ID);
+  });
+
+  test("a global OIDC provider goes to the OIDC router, not the SAML one", async () => {
+    /*
+     * Global SAML and global OIDC are served by two different routers and
+     * discovery does not label which is which, so `kind` carried through the
+     * navigation params is the only thing keeping them apart.
+     */
+    await renderScreen([globalOidcProvider]);
+
+    await pressProvider(globalOidcProvider.name);
+    await settleAuthFlow();
+
+    expect(lastOpenedUrl()).toBe(
+      `${SERVER_URL}/identity/global-oidc/${globalOidcProvider._id}?mobile=true`,
+    );
+    expect(lastOpenedUrl()).not.toContain(PROJECT_ID);
+  });
+
+  test("every login is flagged as a mobile login", async () => {
+    /*
+     * `?mobile=true` is what makes the server end the flow on
+     * `oneuptime://sso-callback` instead of rendering the web dashboard. Drop
+     * it and the browser sits on a dashboard page forever.
+     */
+    await renderScreen([globalOidcProvider, projectSamlProvider]);
+
+    await pressProvider(globalOidcProvider.name);
+    await settleAuthFlow();
+    await pressProvider(projectSamlProvider.name);
+    await settleAuthFlow();
+
+    expect(openedUrls()).toHaveLength(2);
+
+    for (const url of openedUrls()) {
+      expect(url.endsWith("?mobile=true")).toBe(true);
+    }
+  });
+
+  test("the login is opened against the stored server url", async () => {
+    // Self-hosted instances are the norm; there is no fixed host to fall back on.
+    mockGetServerUrl.mockResolvedValue("https://status.internal.example");
+
+    await renderScreen([globalSamlProvider]);
+
+    await pressProvider(globalSamlProvider.name);
+    await settleAuthFlow();
+
+    expect(lastOpenedUrl()).toBe(
+      `https://status.internal.example/identity/global-sso/${globalSamlProvider._id}?mobile=true`,
+    );
+  });
+});
+
+describe("A completed login is persisted before the sheet closes", () => {
+  test("a global login is stored and the sheet closes", async () => {
+    /*
+     * THE regression. A global login used to complete on the server and then
+     * vanish: this screen only looked for a project `ssoToken`, saw none, and
+     * returned the user to the project that had just refused them - still
+     * refused, with no error and nothing written.
+     */
+    mockCompleteSsoLoginFromUrl.mockResolvedValue({
+      status: "success",
+      isGlobal: true,
+      projectId: null,
+    } as CompleteSsoLoginOutcome);
+
+    const rendered: RenderedScreen = await renderScreen([globalSamlProvider]);
+
+    await pressProvider(globalSamlProvider.name);
+    await settleAuthFlow();
+
+    expect(mockCompleteSsoLoginFromUrl).toHaveBeenCalledWith(CALLBACK_URL);
+    expect(rendered.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  test("a global OIDC login is stored and the sheet closes", async () => {
+    mockCompleteSsoLoginFromUrl.mockResolvedValue({
+      status: "success",
+      isGlobal: true,
+      projectId: null,
+    } as CompleteSsoLoginOutcome);
+
+    const rendered: RenderedScreen = await renderScreen([globalOidcProvider]);
+
+    await pressProvider(globalOidcProvider.name);
+    await settleAuthFlow();
+
+    expect(mockCompleteSsoLoginFromUrl).toHaveBeenCalledWith(CALLBACK_URL);
+    expect(rendered.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  test("a project login is stored and the sheet closes", async () => {
+    const rendered: RenderedScreen = await renderScreen([projectSamlProvider]);
+
+    await pressProvider(projectSamlProvider.name);
+    await settleAuthFlow();
+
+    expect(mockCompleteSsoLoginFromUrl).toHaveBeenCalledWith(CALLBACK_URL);
+    expect(rendered.goBack).toHaveBeenCalledTimes(1);
+  });
+
+  test("the url handed over is the browser's callback, not the login url", async () => {
+    /*
+     * The tokens are in the callback. Passing the request url back instead
+     * would parse cleanly enough to look like a failure rather than a bug.
+     */
+    await renderScreen([globalSamlProvider]);
+
+    await pressProvider(globalSamlProvider.name);
+    await settleAuthFlow();
+
+    expect(mockCompleteSsoLoginFromUrl).toHaveBeenCalledTimes(1);
+    expect(mockCompleteSsoLoginFromUrl.mock.calls[0]?.[0]).not.toBe(
+      lastOpenedUrl(),
+    );
+  });
+
+  test("no error is shown after a successful login", async () => {
+    await renderScreen([globalSamlProvider]);
+
+    await pressProvider(globalSamlProvider.name);
+    await settleAuthFlow();
+
+    expect(screen.queryByText(ANY_ERROR_MESSAGE)).toBeNull();
+  });
+});
+
+describe("Nothing is claimed when the login did not complete", () => {
+  test("a cancelled login stores nothing, closes nothing and says nothing", async () => {
+    /*
+     * Backing out of the IdP is a normal thing to do. Treating it as a failure
+     * would put a red error under a sheet the user closed on purpose; treating
+     * it as a success would close the sheet over a project they still cannot
+     * open.
+     */
+    mockOpenSsoAuthSession.mockResolvedValue({
+      status: "cancelled",
+    } as SsoAuthSessionOutcome);
+
+    const rendered: RenderedScreen = await renderScreen([globalSamlProvider]);
+
+    await pressProvider(globalSamlProvider.name);
+    await settleAuthFlow();
+
+    expect(mockCompleteSsoLoginFromUrl).not.toHaveBeenCalled();
+    expect(rendered.goBack).not.toHaveBeenCalled();
+    expect(screen.queryByText(ANY_ERROR_MESSAGE)).toBeNull();
+  });
+
+  test("a browser that could not be opened shows its message and keeps the sheet up", async () => {
+    mockOpenSsoAuthSession.mockResolvedValue({
+      status: "error",
+      message: "Could not open the sign-in page. Please try again.",
+    } as SsoAuthSessionOutcome);
+
+    const rendered: RenderedScreen = await renderScreen([globalSamlProvider]);
+
+    await pressProvider(globalSamlProvider.name);
+
+    await waitFor((): void => {
+      expect(
+        screen.getByText("Could not open the sign-in page. Please try again."),
+      ).toBeTruthy();
+    });
+
+    expect(mockCompleteSsoLoginFromUrl).not.toHaveBeenCalled();
+    expect(rendered.goBack).not.toHaveBeenCalled();
+  });
+
+  test("a callback carrying an IdP error is reported, not treated as a login", async () => {
+    /*
+     * The browser DID come back - the redirect just carried an error instead of
+     * tokens. Closing the sheet here is the silent failure this screen used to
+     * have for every global login.
+     */
+    mockCompleteSsoLoginFromUrl.mockResolvedValue({
+      status: "error",
+      message: "SSO login was denied by your identity provider.",
+    } as CompleteSsoLoginOutcome);
+
+    const rendered: RenderedScreen = await renderScreen([globalSamlProvider]);
+
+    await pressProvider(globalSamlProvider.name);
+
+    await waitFor((): void => {
+      expect(
+        screen.getByText("SSO login was denied by your identity provider."),
+      ).toBeTruthy();
+    });
+
+    expect(rendered.goBack).not.toHaveBeenCalled();
+  });
+
+  test("an unreadable server url fails before any browser is opened", async () => {
+    mockGetServerUrl.mockRejectedValue(new Error("storage unavailable"));
+
+    const rendered: RenderedScreen = await renderScreen([globalSamlProvider]);
+
+    await pressProvider(globalSamlProvider.name);
+
+    await waitFor((): void => {
+      expect(screen.getByText(/SSO authentication failed/i)).toBeTruthy();
+    });
+
+    expect(mockOpenSsoAuthSession).not.toHaveBeenCalled();
+    expect(rendered.goBack).not.toHaveBeenCalled();
+  });
+
+  test("a project row with no project id is refused instead of opening a broken url", async () => {
+    /*
+     * `/identity/sso/undefined/<providerId>` would open the browser on a page
+     * that fails minutes later with nothing to explain it, so buildSsoLoginUrl
+     * throws and the screen has to surface that rather than swallow it.
+     */
+    const rendered: RenderedScreen = await renderScreen(
+      [projectSamlProvider],
+      "",
+    );
+
+    await pressProvider(projectSamlProvider.name);
+
+    await waitFor((): void => {
+      expect(screen.getByText(/SSO authentication failed/i)).toBeTruthy();
+    });
+
+    expect(mockOpenSsoAuthSession).not.toHaveBeenCalled();
+    expect(rendered.goBack).not.toHaveBeenCalled();
+  });
+
+  test("a global row still works on a sheet reached with no project id", async () => {
+    /*
+     * The mirror of the case above: a global login needs no project, so it must
+     * not inherit the project flow's requirement for one.
+     */
+    const rendered: RenderedScreen = await renderScreen(
+      [globalSamlProvider],
+      "",
+    );
+
+    await pressProvider(globalSamlProvider.name);
+    await settleAuthFlow();
+
+    expect(lastOpenedUrl()).toBe(
+      `${SERVER_URL}/identity/global-sso/${globalSamlProvider._id}?mobile=true`,
+    );
+    expect(rendered.goBack).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Recovering from a failed attempt", () => {
+  test("a second attempt is possible after an error, and clears the first one", async () => {
+    /*
+     * The row has to become pressable again - if the in-flight flag were left
+     * set, one failure would freeze the only way back into the project.
+     */
+    mockOpenSsoAuthSession.mockResolvedValueOnce({
+      status: "error",
+      message: "Could not open the sign-in page. Please try again.",
+    } as SsoAuthSessionOutcome);
+    mockOpenSsoAuthSession.mockResolvedValue(callbackOutcome);
+
+    const rendered: RenderedScreen = await renderScreen([globalSamlProvider]);
+
+    await pressProvider(globalSamlProvider.name);
+
+    await waitFor((): void => {
+      expect(
+        screen.getByText("Could not open the sign-in page. Please try again."),
+      ).toBeTruthy();
+    });
+
+    expect(isRowDisabled(globalSamlProvider.name)).toBe(false);
+
+    await pressProvider(globalSamlProvider.name);
+    await settleAuthFlow();
+
+    expect(mockOpenSsoAuthSession).toHaveBeenCalledTimes(2);
+    expect(rendered.goBack).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByText("Could not open the sign-in page. Please try again."),
+    ).toBeNull();
+  });
+
+  test("a cancelled login leaves the row usable", async () => {
+    mockOpenSsoAuthSession.mockResolvedValueOnce({
+      status: "cancelled",
+    } as SsoAuthSessionOutcome);
+    mockOpenSsoAuthSession.mockResolvedValue(callbackOutcome);
+
+    const rendered: RenderedScreen = await renderScreen([globalSamlProvider]);
+
+    await pressProvider(globalSamlProvider.name);
+    await settleAuthFlow();
+
+    expect(isRowDisabled(globalSamlProvider.name)).toBe(false);
+
+    await pressProvider(globalSamlProvider.name);
+    await settleAuthFlow();
+
+    expect(mockOpenSsoAuthSession).toHaveBeenCalledTimes(2);
+    expect(rendered.goBack).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Only one auth session may run at a time", () => {
+  test("the other rows are refused while one login is in the browser", async () => {
+    /*
+     * expo-web-browser allows a single auth session per process: a second
+     * openAuthSessionAsync throws on iOS, and on Android its Linking listener
+     * would race the first login for the same callback. So the rows have to be
+     * shut off for the duration, not merely dimmed.
+     */
+    let releaseAuthSession: (
+      outcome: SsoAuthSessionOutcome,
+    ) => void = (): void => {
+      return undefined;
+    };
+
+    mockOpenSsoAuthSession.mockImplementation(
+      (): Promise<SsoAuthSessionOutcome> => {
+        return new Promise<SsoAuthSessionOutcome>(
+          (resolve: (outcome: SsoAuthSessionOutcome) => void): void => {
+            releaseAuthSession = resolve;
+          },
+        );
+      },
+    );
+
+    const rendered: RenderedScreen = await renderScreen([
+      globalSamlProvider,
+      projectSamlProvider,
+    ]);
+
+    /*
+     * Not awaited yet, on purpose: fireEvent resolves with whatever onPress
+     * returned, and here that is a handler still sitting in the browser, so
+     * awaiting it now would deadlock. The press itself is dispatched
+     * synchronously; the plain (un-`act`-wrapped) boundary below just lets
+     * fireEvent's own act scope close before anything else opens one.
+     */
+    const pressInFlight: Promise<void> = pressProvider(globalSamlProvider.name);
+
+    await nextMacrotask();
+
+    expect(mockOpenSsoAuthSession).toHaveBeenCalledTimes(1);
+    expect(isRowDisabled(globalSamlProvider.name)).toBe(true);
+    expect(isRowDisabled(projectSamlProvider.name)).toBe(true);
+
+    // Pressing the other row must not start a competing session.
+    await pressProvider(projectSamlProvider.name);
+
+    expect(mockOpenSsoAuthSession).toHaveBeenCalledTimes(1);
+
+    await act(async (): Promise<void> => {
+      releaseAuthSession(callbackOutcome);
+      await nextMacrotask();
+    });
+
+    await pressInFlight;
+
+    expect(mockCompleteSsoLoginFromUrl).toHaveBeenCalledWith(CALLBACK_URL);
+    expect(rendered.goBack).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Grouping the providers a user can choose from", () => {
+  test("global and project providers sit under separate headings", async () => {
+    /*
+     * The two are not interchangeable - one signs the user into the whole
+     * instance, the other into this project only - and a user who picks the
+     * wrong one gets an unexplained rejection from the server.
+     */
+    await renderScreen([globalSamlProvider, projectSamlProvider]);
+
+    expect(screen.getByText("Your organization")).toBeTruthy();
+    expect(screen.getByText("This project")).toBeTruthy();
+    expect(screen.getByLabelText(globalSamlProvider.name)).toBeTruthy();
+    expect(screen.getByLabelText(projectSamlProvider.name)).toBeTruthy();
+  });
+
+  test("both global kinds are grouped together as the organization's", async () => {
+    await renderScreen([globalSamlProvider, globalOidcProvider]);
+
+    expect(screen.getByText("Your organization")).toBeTruthy();
+    expect(screen.getByLabelText(globalSamlProvider.name)).toBeTruthy();
+    expect(screen.getByLabelText(globalOidcProvider.name)).toBeTruthy();
+    expect(screen.queryByText("This project")).toBeNull();
+    expect(screen.queryByText("Available providers")).toBeNull();
+  });
+
+  test("project-only instances get no organization heading", async () => {
+    // Nothing to contrast with, so the heading would be noise.
+    await renderScreen([projectSamlProvider]);
+
+    expect(screen.getByText("Available providers")).toBeTruthy();
+    expect(screen.queryByText("Your organization")).toBeNull();
+    expect(screen.queryByText("This project")).toBeNull();
+  });
+
+  test("the sheet names the project the user is signing in to", async () => {
+    await renderScreen([globalSamlProvider]);
+
+    expect(screen.getByText(PROJECT_NAME)).toBeTruthy();
+  });
+
+  test("a provider's description is shown when it has one", async () => {
+    await renderScreen([globalSamlProvider, globalOidcProvider]);
+
+    expect(
+      screen.getByText(globalSamlProvider.description as string),
+    ).toBeTruthy();
+  });
+});

--- a/MobileApp/src/screens/settings/SSOProviderSelectScreen.tsx
+++ b/MobileApp/src/screens/settings/SSOProviderSelectScreen.tsx
@@ -7,12 +7,22 @@ import {
   ActivityIndicator,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import * as WebBrowser from "expo-web-browser";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useTheme } from "../../theme";
 import { getServerUrl } from "../../storage/serverUrl";
-import { getCachedSsoTokens, storeSsoToken } from "../../storage/ssoTokens";
-import type { SettingsStackParamList } from "../../navigation/types";
+import { buildSsoLoginUrl } from "../../sso/providerUrl";
+import {
+  openSsoAuthSession,
+  type SsoAuthSessionOutcome,
+} from "../../sso/authSession";
+import {
+  completeSsoLoginFromUrl,
+  type CompleteSsoLoginOutcome,
+} from "../../sso/session";
+import type {
+  SelectableSsoProvider,
+  SettingsStackParamList,
+} from "../../navigation/types";
 
 type Props = NativeStackScreenProps<
   SettingsStackParamList,
@@ -28,51 +38,198 @@ export default function SSOProviderSelectScreen({
   const [authenticatingId, setAuthenticatingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSelectProvider: (provider: {
-    _id: string;
-    name: string;
-    description?: string;
-  }) => Promise<void> = async (provider: {
-    _id: string;
-    name: string;
-    description?: string;
-  }): Promise<void> => {
+  const handleSelectProvider: (
+    provider: SelectableSsoProvider,
+  ) => Promise<void> = async (
+    provider: SelectableSsoProvider,
+  ): Promise<void> => {
     setAuthenticatingId(provider._id);
     setError(null);
 
     try {
       const serverUrl: string = await getServerUrl();
-      const ssoUrl: string = `${serverUrl}/identity/sso/${projectId}/${provider._id}?mobile=true`;
 
-      await WebBrowser.warmUpAsync();
+      const ssoUrl: string = buildSsoLoginUrl(serverUrl, {
+        kind: provider.kind,
+        providerId: provider._id,
+        projectId: provider.kind === "project" ? projectId : undefined,
+      });
 
-      const result: WebBrowser.WebBrowserAuthSessionResult =
-        await WebBrowser.openAuthSessionAsync(
-          ssoUrl,
-          "oneuptime://sso-callback",
-        );
+      const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(ssoUrl);
 
-      if (result.type === "success" && result.url) {
-        const url: URL = new URL(result.url);
-        const params: URLSearchParams = url.searchParams;
-
-        const ssoToken: string | null = params.get("ssoToken");
-        const returnedProjectId: string | null = params.get("projectId");
-
-        if (ssoToken && returnedProjectId) {
-          await storeSsoToken(returnedProjectId, ssoToken);
-          // Force refresh cached tokens
-          getCachedSsoTokens();
-          navigation.goBack();
-          return;
-        }
+      if (outcome.status === "cancelled") {
+        return;
       }
+
+      if (outcome.status === "error") {
+        setError(outcome.message);
+        return;
+      }
+
+      /*
+       * Both flavours land here. A global login returns one instance-wide
+       * token, a project login returns one bound to this project; the session
+       * module stores whichever arrived. Previously this screen looked only
+       * for `ssoToken`, so a global login completed on the server and then
+       * vanished without a word on the device.
+       */
+      const completed: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+        outcome.url,
+      );
+
+      if (completed.status === "error") {
+        setError(completed.message);
+        return;
+      }
+
+      navigation.goBack();
     } catch {
       setError("SSO authentication failed. Please try again.");
     } finally {
       setAuthenticatingId(null);
-      WebBrowser.coolDownAsync();
     }
+  };
+
+  const globalProviders: Array<SelectableSsoProvider> = providers.filter(
+    (provider: SelectableSsoProvider) => {
+      return provider.kind !== "project";
+    },
+  );
+  const projectProviders: Array<SelectableSsoProvider> = providers.filter(
+    (provider: SelectableSsoProvider) => {
+      return provider.kind === "project";
+    },
+  );
+
+  const renderProviderList: (
+    items: Array<SelectableSsoProvider>,
+  ) => React.JSX.Element = (
+    items: Array<SelectableSsoProvider>,
+  ): React.JSX.Element => {
+    return (
+      <View
+        style={{
+          borderRadius: 16,
+          overflow: "hidden",
+          backgroundColor: theme.colors.backgroundElevated,
+          borderWidth: 1,
+          borderColor: theme.colors.borderGlass,
+        }}
+      >
+        {items.map((provider: SelectableSsoProvider, index: number) => {
+          const isLast: boolean = index === items.length - 1;
+          const isAuthenticating: boolean = authenticatingId === provider._id;
+
+          return (
+            <Pressable
+              key={provider._id}
+              accessibilityRole="button"
+              accessibilityLabel={provider.name}
+              onPress={() => {
+                return handleSelectProvider(provider);
+              }}
+              disabled={authenticatingId !== null}
+              style={{
+                opacity:
+                  authenticatingId !== null && !isAuthenticating ? 0.6 : 1,
+                ...(!isLast
+                  ? {
+                      borderBottomWidth: 1,
+                      borderBottomColor: theme.colors.borderSubtle,
+                    }
+                  : {}),
+              }}
+            >
+              <View
+                style={{
+                  flexDirection: "row",
+                  alignItems: "center",
+                  paddingHorizontal: 16,
+                  paddingVertical: 14,
+                }}
+              >
+                <View
+                  style={{
+                    width: 36,
+                    height: 36,
+                    borderRadius: 10,
+                    backgroundColor: theme.colors.iconBackground,
+                    alignItems: "center",
+                    justifyContent: "center",
+                    marginRight: 12,
+                  }}
+                >
+                  <Ionicons
+                    name={
+                      provider.kind === "project"
+                        ? "shield-checkmark-outline"
+                        : "globe-outline"
+                    }
+                    size={18}
+                    color={theme.colors.actionPrimary}
+                  />
+                </View>
+                <View style={{ flex: 1, marginRight: 12 }}>
+                  <Text
+                    style={{
+                      fontSize: 15,
+                      fontWeight: "600",
+                      color: theme.colors.textPrimary,
+                    }}
+                  >
+                    {provider.name}
+                  </Text>
+                  {provider.description ? (
+                    <Text
+                      style={{
+                        fontSize: 13,
+                        marginTop: 3,
+                        color: theme.colors.textSecondary,
+                      }}
+                    >
+                      {provider.description}
+                    </Text>
+                  ) : null}
+                </View>
+
+                {isAuthenticating ? (
+                  <ActivityIndicator
+                    size="small"
+                    color={theme.colors.actionPrimary}
+                  />
+                ) : (
+                  <Ionicons
+                    name="chevron-forward"
+                    size={18}
+                    color={theme.colors.textTertiary}
+                  />
+                )}
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+    );
+  };
+
+  const renderSectionHeading: (label: string) => React.JSX.Element = (
+    label: string,
+  ): React.JSX.Element => {
+    return (
+      <Text
+        style={{
+          fontSize: 12,
+          fontWeight: "600",
+          textTransform: "uppercase",
+          marginBottom: 8,
+          marginLeft: 4,
+          color: theme.colors.textTertiary,
+          letterSpacing: 0.8,
+        }}
+      >
+        {label}
+      </Text>
+    );
   };
 
   return (
@@ -161,121 +318,21 @@ export default function SSOProviderSelectScreen({
         </View>
       ) : null}
 
-      <Text
-        style={{
-          fontSize: 12,
-          fontWeight: "600",
-          textTransform: "uppercase",
-          marginBottom: 8,
-          marginLeft: 4,
-          color: theme.colors.textTertiary,
-          letterSpacing: 0.8,
-        }}
-      >
-        Available Providers
-      </Text>
+      {globalProviders.length > 0 ? (
+        <View style={{ marginBottom: 24 }}>
+          {renderSectionHeading("Your organization")}
+          {renderProviderList(globalProviders)}
+        </View>
+      ) : null}
 
-      <View
-        style={{
-          borderRadius: 16,
-          overflow: "hidden",
-          backgroundColor: theme.colors.backgroundElevated,
-          borderWidth: 1,
-          borderColor: theme.colors.borderGlass,
-        }}
-      >
-        {providers.map(
-          (
-            provider: { _id: string; name: string; description?: string },
-            index: number,
-          ) => {
-            const isLast: boolean = index === providers.length - 1;
-            const isAuthenticating: boolean = authenticatingId === provider._id;
-
-            return (
-              <Pressable
-                key={provider._id}
-                onPress={() => {
-                  return handleSelectProvider(provider);
-                }}
-                disabled={authenticatingId !== null}
-                style={{
-                  opacity:
-                    authenticatingId !== null && !isAuthenticating ? 0.6 : 1,
-                  ...(!isLast
-                    ? {
-                        borderBottomWidth: 1,
-                        borderBottomColor: theme.colors.borderSubtle,
-                      }
-                    : {}),
-                }}
-              >
-                <View
-                  style={{
-                    flexDirection: "row",
-                    alignItems: "center",
-                    paddingHorizontal: 16,
-                    paddingVertical: 14,
-                  }}
-                >
-                  <View
-                    style={{
-                      width: 36,
-                      height: 36,
-                      borderRadius: 10,
-                      backgroundColor: theme.colors.iconBackground,
-                      alignItems: "center",
-                      justifyContent: "center",
-                      marginRight: 12,
-                    }}
-                  >
-                    <Ionicons
-                      name="shield-checkmark-outline"
-                      size={18}
-                      color={theme.colors.actionPrimary}
-                    />
-                  </View>
-                  <View style={{ flex: 1, marginRight: 12 }}>
-                    <Text
-                      style={{
-                        fontSize: 15,
-                        fontWeight: "600",
-                        color: theme.colors.textPrimary,
-                      }}
-                    >
-                      {provider.name}
-                    </Text>
-                    {provider.description ? (
-                      <Text
-                        style={{
-                          fontSize: 13,
-                          marginTop: 3,
-                          color: theme.colors.textSecondary,
-                        }}
-                      >
-                        {provider.description}
-                      </Text>
-                    ) : null}
-                  </View>
-
-                  {isAuthenticating ? (
-                    <ActivityIndicator
-                      size="small"
-                      color={theme.colors.actionPrimary}
-                    />
-                  ) : (
-                    <Ionicons
-                      name="chevron-forward"
-                      size={18}
-                      color={theme.colors.textTertiary}
-                    />
-                  )}
-                </View>
-              </Pressable>
-            );
-          },
-        )}
-      </View>
+      {projectProviders.length > 0 ? (
+        <View>
+          {renderSectionHeading(
+            globalProviders.length > 0 ? "This project" : "Available providers",
+          )}
+          {renderProviderList(projectProviders)}
+        </View>
+      ) : null}
     </ScrollView>
   );
 }

--- a/MobileApp/src/sso/authSession.test.ts
+++ b/MobileApp/src/sso/authSession.test.ts
@@ -1,0 +1,600 @@
+/*
+ * openSsoAuthSession - what the app is allowed to conclude from an auth
+ * browser session.
+ *
+ * EVERY TEST IN THIS FILE RUNS TWICE: once under the "ios" Jest project and
+ * once under "android", and every assertion has to hold in BOTH runs. That is
+ * the whole point of this file. openSsoAuthSession deliberately does not
+ * branch on Platform.OS - one code path has to survive two very different
+ * browsers:
+ *
+ * - iOS runs a native ASWebAuthenticationSession, which reports `success` with
+ *   the redirect URL, or `cancel`. Dependable.
+ * - Android has no such API, so expo-web-browser polyfills it
+ *   (node_modules/expo-web-browser/build/WebBrowser.js) by racing a `Linking`
+ *   "url" event against an AppState return-to-foreground. The redirect out of
+ *   Chrome Custom Tabs fires BOTH, so a login that completed perfectly
+ *   resolves as `dismiss` with NO url whenever the AppState side wins.
+ *
+ * The fixtures below are therefore named for the browser that produces them,
+ * but each one is asserted under both presets. Treating `dismiss` as a
+ * cancellation is the bug this module exists to prevent: it throws away a real
+ * Android login, intermittently, which is the worst kind of auth bug. Every
+ * "the captured redirect wins" case below is guarding exactly that.
+ *
+ * The deep-link capture in ./deepLink is used for real here - only expo-linking
+ * is faked - so these tests exercise the actual hand-off between the two
+ * modules rather than a stub of it.
+ */
+
+import * as Linking from "expo-linking";
+import * as WebBrowser from "expo-web-browser";
+import { Platform } from "react-native";
+import { openSsoAuthSession, SsoAuthSessionOutcome } from "./authSession";
+import { SSO_CALLBACK_URL } from "./callbackUrl";
+import {
+  consumePendingSsoCallbackUrl,
+  resetSsoCallbackCaptureForTesting,
+  startSsoCallbackCapture,
+} from "./deepLink";
+import { afterEach, beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * expo-web-browser is a native module with no JS implementation off-device,
+ * and it is the thing whose two platform behaviours are under test, so it is
+ * faked wholesale.
+ */
+jest.mock("expo-web-browser", () => {
+  return {
+    __esModule: true,
+    openAuthSessionAsync: jest.fn(),
+    warmUpAsync: jest.fn(),
+    coolDownAsync: jest.fn(),
+  };
+});
+
+/*
+ * expo-linking is faked one level lower down: ./deepLink itself is the real
+ * module, and the test makes a redirect "arrive" by calling the listener
+ * deepLink registered here.
+ */
+jest.mock("expo-linking", () => {
+  return {
+    __esModule: true,
+    addEventListener: jest.fn(() => {
+      return { remove: jest.fn() };
+    }),
+    getInitialURL: jest.fn(() => {
+      return Promise.resolve(null);
+    }),
+  };
+});
+
+const SSO_URL: string =
+  "https://oneuptime.com/api/global-sso/650b/login?mobile=true";
+
+const CALLBACK_URL: string = `${SSO_CALLBACK_URL}?accessToken=access-1&refreshToken=refresh-1&refreshTokenExpiresAt=2026-09-01T00%3A00%3A00.000Z&globalSsoToken=global-1`;
+
+const STALE_CALLBACK_URL: string = `${SSO_CALLBACK_URL}?accessToken=access-from-an-abandoned-attempt`;
+
+/*
+ * The real grace period is 1500ms. Everything here overrides it so the suite
+ * does not spend a second and a half per cancellation.
+ */
+const GRACE_MS: number = 50;
+
+// Comfortably inside the grace period, and comfortably outside it.
+const WITHIN_GRACE_MS: number = 5;
+const AFTER_GRACE_MS: number = 200;
+
+type UrlEventHandler = (event: { url: string }) => void;
+
+function openAuthSession(): jest.Mock {
+  return WebBrowser.openAuthSessionAsync as unknown as jest.Mock;
+}
+
+function warmUp(): jest.Mock {
+  return WebBrowser.warmUpAsync as unknown as jest.Mock;
+}
+
+function coolDown(): jest.Mock {
+  return WebBrowser.coolDownAsync as unknown as jest.Mock;
+}
+
+/*
+ * `{ type: "success" }` with no url, and `{ type: "opened" }`, are not shapes
+ * the published types admit, but they are shapes the two platforms really do
+ * hand back - which is precisely why they need covering.
+ */
+function authResult(
+  type: string,
+  url?: string,
+): WebBrowser.WebBrowserAuthSessionResult {
+  const result: Record<string, string> =
+    url === undefined ? { type } : { type, url };
+
+  return result as unknown as WebBrowser.WebBrowserAuthSessionResult;
+}
+
+/** Fires the app-wide `Linking` "url" event the redirect would fire. */
+function emitCallbackUrl(url: string): void {
+  const calls: Array<Array<unknown>> = (
+    Linking.addEventListener as unknown as jest.Mock
+  ).mock.calls;
+
+  const handler: UrlEventHandler = calls[
+    calls.length - 1
+  ]![1] as UrlEventHandler;
+
+  handler({ url });
+}
+
+let scheduledEmits: Array<Promise<void>> = [];
+
+/*
+ * Schedules a redirect for later and remembers the promise, so afterEach can
+ * await it: a stray timer firing into a torn-down suite is how a green run
+ * turns into an unexplained flake somewhere else.
+ */
+function emitCallbackUrlAfter(url: string, delayMs: number): void {
+  scheduledEmits.push(
+    new Promise((resolve: () => void): void => {
+      setTimeout((): void => {
+        emitCallbackUrl(url);
+        resolve();
+      }, delayMs);
+    }),
+  );
+}
+
+function errorOutcome(outcome: SsoAuthSessionOutcome): {
+  status: "error";
+  message: string;
+} {
+  expect(outcome.status).toBe("error");
+
+  return outcome as { status: "error"; message: string };
+}
+
+beforeEach((): void => {
+  resetSsoCallbackCaptureForTesting();
+  scheduledEmits = [];
+
+  warmUp().mockResolvedValue({});
+  coolDown().mockResolvedValue({});
+  openAuthSession().mockResolvedValue(authResult("cancel"));
+
+  startSsoCallbackCapture();
+});
+
+afterEach(async (): Promise<void> => {
+  await Promise.all(scheduledEmits);
+  resetSsoCallbackCaptureForTesting();
+});
+
+describe("Opening the session", () => {
+  test("hands the IdP URL to the browser unchanged", async (): Promise<void> => {
+    await openSsoAuthSession(SSO_URL, { graceMs: GRACE_MS });
+
+    expect(openAuthSession().mock.calls[0]![0]).toBe(SSO_URL);
+  });
+
+  test("always returns to oneuptime://sso-callback", async (): Promise<void> => {
+    /*
+     * Asserted as a literal as well as against the constant. This string is
+     * half of a contract with the server, which appends the callback to the
+     * IdP's redirect; renaming it on this side alone does not fail to compile,
+     * it just means the browser never comes back to the app.
+     */
+    await openSsoAuthSession(SSO_URL, { graceMs: GRACE_MS });
+
+    expect(openAuthSession().mock.calls[0]![1]).toBe(
+      "oneuptime://sso-callback",
+    );
+    expect(openAuthSession().mock.calls[0]![1]).toBe(SSO_CALLBACK_URL);
+  });
+
+  test("warms the browser up before opening it, and cools it down after", async (): Promise<void> => {
+    openAuthSession().mockResolvedValue(authResult("success", CALLBACK_URL));
+
+    await openSsoAuthSession(SSO_URL, { graceMs: GRACE_MS });
+
+    expect(warmUp()).toHaveBeenCalledTimes(1);
+    expect(coolDown()).toHaveBeenCalledTimes(1);
+
+    expect(warmUp().mock.invocationCallOrder[0]!).toBeLessThan(
+      openAuthSession().mock.invocationCallOrder[0]!,
+    );
+    expect(coolDown().mock.invocationCallOrder[0]!).toBeGreaterThan(
+      openAuthSession().mock.invocationCallOrder[0]!,
+    );
+  });
+
+  test("cools the browser down even when the session throws", async (): Promise<void> => {
+    /*
+     * warmUpAsync binds to the Custom Tabs service on Android. Skipping the
+     * cool-down on the failure path leaks that binding for the life of the
+     * process.
+     */
+    openAuthSession().mockRejectedValue(
+      new Error("WebBrowser is already open"),
+    );
+
+    await openSsoAuthSession(SSO_URL, { graceMs: GRACE_MS });
+
+    expect(coolDown()).toHaveBeenCalledTimes(1);
+  });
+
+  test("a failing warm-up does not fail the login", async (): Promise<void> => {
+    // Warm-up is an Android optimisation and a no-op on iOS: never fatal.
+    warmUp().mockRejectedValue(new Error("no custom tabs service"));
+    openAuthSession().mockResolvedValue(authResult("success", CALLBACK_URL));
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    expect(outcome).toEqual({ status: "callback", url: CALLBACK_URL });
+    expect(openAuthSession()).toHaveBeenCalledTimes(1);
+  });
+
+  test("a failing cool-down does not fail the login", async (): Promise<void> => {
+    /*
+     * The cool-down runs in a `finally`, so an unguarded rejection there would
+     * replace an already-computed successful outcome with a thrown error -
+     * losing the tokens after the user had signed in.
+     */
+    coolDown().mockRejectedValue(new Error("nothing to cool down"));
+    openAuthSession().mockResolvedValue(authResult("success", CALLBACK_URL));
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    expect(outcome).toEqual({ status: "callback", url: CALLBACK_URL });
+  });
+});
+
+describe("A completed login", () => {
+  test("iOS success-with-url is taken at face value", async (): Promise<void> => {
+    /*
+     * The dependable path: ASWebAuthenticationSession hands back the redirect
+     * itself, so no deep-link capture is involved at all.
+     */
+    openAuthSession().mockResolvedValue(authResult("success", CALLBACK_URL));
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    expect(outcome).toEqual({ status: "callback", url: CALLBACK_URL });
+  });
+
+  test("a success leaves nothing pending for a second consumer", async (): Promise<void> => {
+    /*
+     * The redirect fires the app-wide listener as well, so after a native
+     * success the same URL is usually sitting in the capture slot too. Left
+     * there, the next screen to ask would sign the user in a second time off a
+     * one-shot token.
+     */
+    openAuthSession().mockImplementation(async (): Promise<unknown> => {
+      emitCallbackUrl(CALLBACK_URL);
+      return authResult("success", CALLBACK_URL);
+    });
+
+    await openSsoAuthSession(SSO_URL, { graceMs: GRACE_MS });
+
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+  });
+
+  test("does not sit out the grace period when the browser answered", async (): Promise<void> => {
+    /*
+     * The grace period is a repair for the Android race, not a tax on every
+     * login. A native success must return at once - a version that always
+     * waited would add a real 1500ms stall to every sign-in on both platforms,
+     * which no assertion about the returned value would catch.
+     */
+    openAuthSession().mockResolvedValue(authResult("success", CALLBACK_URL));
+
+    const startedAt: number = Date.now();
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: 10000,
+    });
+
+    expect(outcome).toEqual({ status: "callback", url: CALLBACK_URL });
+    expect(Date.now() - startedAt).toBeLessThan(1000);
+  });
+
+  test("a success with NO url still counts when the redirect was captured", async (): Promise<void> => {
+    /*
+     * expo-web-browser's Android polyfill resolves `success` from the Linking
+     * event, so it always carries a url there - but the published type allows
+     * a bare `{ type }`, and a result with no url must never be read as a
+     * callback to nowhere.
+     */
+    openAuthSession().mockImplementation(async (): Promise<unknown> => {
+      emitCallbackUrl(CALLBACK_URL);
+      return authResult("success");
+    });
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    expect(outcome).toEqual({ status: "callback", url: CALLBACK_URL });
+  });
+
+  test("a success with NO url and nothing captured is a cancellation", async (): Promise<void> => {
+    openAuthSession().mockResolvedValue(authResult("success"));
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    expect(outcome).toEqual({ status: "cancelled" });
+  });
+});
+
+describe("The Android dismiss race", () => {
+  test("a dismiss with no url is a callback when the redirect was captured", async (): Promise<void> => {
+    /*
+     * THE HEADLINE CASE. Chrome Custom Tabs redirects back to the app: the
+     * Linking event and the AppState change both fire, AppState wins the race
+     * inside expo-web-browser, and the promise resolves `{ type: "dismiss" }`
+     * with no url - for a login that completed and issued tokens.
+     *
+     * This must NOT come back as cancelled. If it does, the user is dropped on
+     * the sign-in screen with valid tokens in a URL nobody read, and it
+     * happens only sometimes, only on Android.
+     */
+    openAuthSession().mockImplementation(async (): Promise<unknown> => {
+      emitCallbackUrl(CALLBACK_URL);
+      return authResult("dismiss");
+    });
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    expect(outcome).toEqual({ status: "callback", url: CALLBACK_URL });
+    expect(outcome.status).not.toBe("cancelled");
+  });
+
+  test("a redirect that lands after the promise resolved still counts", async (): Promise<void> => {
+    /*
+     * The other ordering of the same race: AppState resolves the promise
+     * first and the "url" event arrives a few milliseconds later. The grace
+     * period exists for exactly this, so the module has to be waiting rather
+     * than answering immediately.
+     */
+    openAuthSession().mockImplementation(async (): Promise<unknown> => {
+      emitCallbackUrlAfter(CALLBACK_URL, WITHIN_GRACE_MS);
+      return authResult("dismiss");
+    });
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    expect(outcome).toEqual({ status: "callback", url: CALLBACK_URL });
+  });
+
+  test.each(["cancel", "dismiss", "locked", "opened"])(
+    "a result of %s with a captured redirect is a callback, not a cancellation",
+    async (type: string): Promise<void> => {
+      /*
+       * Every non-success result type the two platforms can produce -
+       * `cancel` and `dismiss` from iOS, `dismiss` and `opened` from the
+       * Android polyfill, `locked` when iOS refuses to present the session -
+       * goes through the same reconciliation. None of them is trusted over a
+       * redirect that actually arrived.
+       */
+      openAuthSession().mockImplementation(async (): Promise<unknown> => {
+        emitCallbackUrl(CALLBACK_URL);
+        return authResult(type);
+      });
+
+      const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+        graceMs: GRACE_MS,
+      });
+
+      expect(outcome).toEqual({ status: "callback", url: CALLBACK_URL });
+    },
+  );
+
+  test("the reconciliation is one code path, not a platform branch", async (): Promise<void> => {
+    /*
+     * babel-preset-expo inlines Platform.OS from the preset, so this is the
+     * literal "ios" in one project and "android" in the other. The expectation
+     * below is identical in both runs - which is the invariant: a change that
+     * made openSsoAuthSession platform-sensitive would fail exactly one of the
+     * two projects.
+     */
+    expect(["ios", "android"]).toContain(Platform.OS);
+
+    openAuthSession().mockImplementation(async (): Promise<unknown> => {
+      emitCallbackUrl(CALLBACK_URL);
+      return authResult("dismiss");
+    });
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    expect(outcome).toEqual({ status: "callback", url: CALLBACK_URL });
+  });
+});
+
+describe("A genuine cancellation", () => {
+  test.each(["cancel", "dismiss", "locked", "opened"])(
+    "a result of %s with nothing captured is a cancellation",
+    async (type: string): Promise<void> => {
+      /*
+       * The flip side of the dismiss race: rescuing a dismissal must not mean
+       * every backed-out login now looks like a success. `locked` and
+       * `opened` are included because an unhandled result type must degrade to
+       * "the user did not sign in", not throw.
+       */
+      openAuthSession().mockResolvedValue(authResult(type));
+
+      const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+        graceMs: GRACE_MS,
+      });
+
+      expect(outcome).toEqual({ status: "cancelled" });
+    },
+  );
+
+  test("a redirect arriving after the grace period does not rescue the session", async (): Promise<void> => {
+    /*
+     * The wait is bounded. A URL that turns up long afterwards belongs to
+     * something else - a cold start, a second attempt - and the user has
+     * already been told the login was cancelled.
+     */
+    openAuthSession().mockImplementation(async (): Promise<unknown> => {
+      emitCallbackUrlAfter(CALLBACK_URL, AFTER_GRACE_MS);
+      return authResult("dismiss");
+    });
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    expect(outcome).toEqual({ status: "cancelled" });
+  });
+
+  test("the caller is never handed a callback without a url", async (): Promise<void> => {
+    openAuthSession().mockResolvedValue(authResult("cancel"));
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    expect(outcome.status).toBe("cancelled");
+    expect(outcome).not.toHaveProperty("url");
+  });
+});
+
+describe("Stale callbacks from an earlier attempt", () => {
+  test("a URL captured before the call is not read as this session's result", async (): Promise<void> => {
+    /*
+     * A user who starts a login, completes it while the app is backgrounded,
+     * then starts another one, leaves a callback sitting in the capture slot.
+     * Without the clear at the top of openSsoAuthSession, the SECOND session
+     * would resolve instantly against the FIRST session's URL - signing the
+     * user in with a token they abandoned, or with the wrong provider's.
+     */
+    emitCallbackUrl(STALE_CALLBACK_URL);
+    openAuthSession().mockResolvedValue(authResult("cancel"));
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    expect(outcome).toEqual({ status: "cancelled" });
+  });
+
+  test("the stale URL is discarded rather than left pending", async (): Promise<void> => {
+    emitCallbackUrl(STALE_CALLBACK_URL);
+    openAuthSession().mockResolvedValue(authResult("cancel"));
+
+    await openSsoAuthSession(SSO_URL, { graceMs: GRACE_MS });
+
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+  });
+
+  test("a fresh redirect during the session still wins over the stale one", async (): Promise<void> => {
+    /*
+     * Clearing the slot must not deafen the session to the redirect it is
+     * actually waiting for.
+     */
+    emitCallbackUrl(STALE_CALLBACK_URL);
+
+    openAuthSession().mockImplementation(async (): Promise<unknown> => {
+      emitCallbackUrl(CALLBACK_URL);
+      return authResult("dismiss");
+    });
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    expect(outcome).toEqual({ status: "callback", url: CALLBACK_URL });
+  });
+});
+
+describe("The browser refusing to open", () => {
+  test("reports an error the user can act on, and does not throw", async (): Promise<void> => {
+    /*
+     * openAuthSessionAsync throws when a session is already open, and on a
+     * device with no browser able to handle the URL. openSsoAuthSession is
+     * documented as never throwing - a rejection here would reach a screen's
+     * button handler as an unhandled rejection and leave a spinner up forever.
+     */
+    openAuthSession().mockRejectedValue(
+      new Error("WebBrowser is already open"),
+    );
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    const failure: { status: "error"; message: string } = errorOutcome(outcome);
+
+    expect(failure.message.length).toBeGreaterThan(0);
+    // The raw exception is developer text; the user gets something readable.
+    expect(failure.message).not.toContain("WebBrowser is already open");
+  });
+
+  test("a throw is still a callback when the login had already completed", async (): Promise<void> => {
+    /*
+     * The "already open" throw usually means a previous session is still being
+     * torn down - which happens right after a redirect. The tokens are in
+     * hand; failing the login because the browser complained would discard
+     * them.
+     */
+    openAuthSession().mockImplementation(async (): Promise<never> => {
+      emitCallbackUrl(CALLBACK_URL);
+      throw new Error("WebBrowser is already open");
+    });
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    expect(outcome).toEqual({ status: "callback", url: CALLBACK_URL });
+  });
+
+  test("a throw does not resurrect a stale callback", async (): Promise<void> => {
+    /*
+     * The failure path consumes whatever is in the capture slot, so the clear
+     * at the top of the function is what keeps an abandoned attempt from being
+     * reported as this one's success.
+     */
+    emitCallbackUrl(STALE_CALLBACK_URL);
+    openAuthSession().mockRejectedValue(new Error("no browser available"));
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    errorOutcome(outcome);
+    expect(outcome).not.toHaveProperty("url");
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+  });
+
+  test("a non-Error rejection is handled too", async (): Promise<void> => {
+    // Native modules reject with plain strings often enough to matter.
+    openAuthSession().mockRejectedValue("ERR_WEB_BROWSER_BLOCKED");
+
+    const outcome: SsoAuthSessionOutcome = await openSsoAuthSession(SSO_URL, {
+      graceMs: GRACE_MS,
+    });
+
+    const failure: { status: "error"; message: string } = errorOutcome(outcome);
+
+    expect(typeof failure.message).toBe("string");
+    expect(failure.message.length).toBeGreaterThan(0);
+  });
+});

--- a/MobileApp/src/sso/authSession.ts
+++ b/MobileApp/src/sso/authSession.ts
@@ -1,0 +1,132 @@
+/*
+ * Runs an IdP login in the system auth browser and reports what actually
+ * happened - on iOS and on Android, which do not behave the same way.
+ *
+ * `WebBrowser.openAuthSessionAsync` alone is not enough to tell a completed
+ * login from a cancelled one:
+ *
+ * - iOS runs a native ASWebAuthenticationSession and returns `success` (with
+ *   the URL) or `cancel`. That part is dependable.
+ * - Android has no such API, so expo-web-browser polyfills it by racing a
+ *   `Linking` "url" event against an AppState return-to-foreground. The
+ *   redirect fires both, so a login that succeeded resolves as `dismiss` with
+ *   no URL whenever the AppState side wins the race.
+ *
+ * Treating `dismiss` as a cancellation - which is what every call site in this
+ * app used to do - therefore throws away a real login, intermittently, on
+ * Android only. So on any non-success result we give the deep-link capture in
+ * ./deepLink a short grace period to produce the URL before concluding the
+ * user backed out.
+ */
+
+import * as WebBrowser from "expo-web-browser";
+import { SSO_CALLBACK_URL } from "./callbackUrl";
+import {
+  clearPendingSsoCallbackUrl,
+  consumePendingSsoCallbackUrl,
+  waitForSsoCallbackUrl,
+} from "./deepLink";
+
+export type SsoAuthSessionOutcome =
+  | {
+      /*
+       * The IdP redirected back. The URL still has to be parsed - it may carry
+       * an error rather than tokens.
+       */
+      status: "callback";
+      url: string;
+    }
+  | {
+      // The user backed out: closed the tab, pressed cancel, hit back.
+      status: "cancelled";
+    }
+  | {
+      status: "error";
+      message: string;
+    };
+
+export interface OpenSsoAuthSessionOptions {
+  // Overridable so tests do not have to wait out the real grace period.
+  graceMs?: number;
+}
+
+/**
+ * Opens `ssoUrl` in the auth browser and resolves once the flow ends.
+ *
+ * Never throws: a browser that refuses to open is reported as
+ * `status: "error"` so the caller can show the user something.
+ */
+export async function openSsoAuthSession(
+  ssoUrl: string,
+  options: OpenSsoAuthSessionOptions = {},
+): Promise<SsoAuthSessionOutcome> {
+  /*
+   * Drop anything captured earlier. Without this, a callback left over from an
+   * abandoned attempt would be read as the result of this one.
+   */
+  clearPendingSsoCallbackUrl();
+
+  try {
+    await WebBrowser.warmUpAsync();
+  } catch {
+    // Warm-up is an optimisation on Android and a no-op on iOS; never fatal.
+  }
+
+  try {
+    const result: WebBrowser.WebBrowserAuthSessionResult =
+      await WebBrowser.openAuthSessionAsync(ssoUrl, SSO_CALLBACK_URL);
+
+    if (result.type === "success" && result.url) {
+      // Nothing left pending - this same URL is very likely also in the slot.
+      clearPendingSsoCallbackUrl();
+
+      return {
+        status: "callback",
+        url: result.url,
+      };
+    }
+
+    /*
+     * Anything else - `dismiss`, `cancel`, `locked`, or a `success` with no
+     * URL - might still be a completed login on Android. Ask the deep-link
+     * capture before calling it a cancellation.
+     */
+    const captured: string | null = await waitForSsoCallbackUrl(
+      options.graceMs,
+    );
+
+    if (captured) {
+      return {
+        status: "callback",
+        url: captured,
+      };
+    }
+
+    return { status: "cancelled" };
+  } catch {
+    /*
+     * openAuthSessionAsync throws when a session is already open, and when the
+     * device has no browser able to handle the URL. Even then the redirect may
+     * already have landed, so check the capture before reporting failure.
+     */
+    const captured: string | null = consumePendingSsoCallbackUrl();
+
+    if (captured) {
+      return {
+        status: "callback",
+        url: captured,
+      };
+    }
+
+    return {
+      status: "error",
+      message: "Could not open the sign-in page. Please try again.",
+    };
+  } finally {
+    try {
+      await WebBrowser.coolDownAsync();
+    } catch {
+      // Same as warm-up: best-effort.
+    }
+  }
+}

--- a/MobileApp/src/sso/callbackUrl.test.ts
+++ b/MobileApp/src/sso/callbackUrl.test.ts
@@ -1,0 +1,804 @@
+import {
+  SSO_CALLBACK_URL,
+  SsoCallbackResult,
+  isSsoCallbackUrl,
+  parseQueryString,
+  parseSsoCallbackUrl,
+} from "./callbackUrl";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * This module is one half of a contract; the other half is
+ * App/FeatureSet/Identity/Utils/MobileSso.ts (buildMobileSsoSuccessUrl /
+ * buildMobileSsoErrorUrl). Nothing type-checks across that boundary - the two
+ * sides only ever meet as a string handed to the OS at the end of a browser
+ * redirect chain, on a real handset, after a real IdP login. A drift in a
+ * param name or in the encoding is not a compile error and not a runtime
+ * error: it is a login that ends on a blank screen.
+ *
+ * So the fixtures below are not invented. They are byte-for-byte what the
+ * server emits, including the fact that it serialises through URLSearchParams
+ * (space -> "+", ":" -> "%3A", "@" -> "%40"), and "the wire format is exactly
+ * what the server builds" below re-derives one of them through the server's
+ * own algorithm so a fixture cannot quietly stop being realistic.
+ */
+
+// The pieces, decoded, exactly as the app must end up seeing them.
+const ACCESS_TOKEN: string =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI2NWYxYzJkM2U0YjVhNjc4OTBhYmNkZWYiLCJlbWFpbCI6ImphbmUuZG9lQGV4YW1wbGUuY29tIn0.s0m3-S1gn4tur3_V4lu3";
+const REFRESH_TOKEN: string =
+  "eyJhbGciOiJIUzI1NiJ9.cmVmcmVzaA.r3fr3sh-S1gn4tur3_V4lu3";
+const EXPIRES_AT: string = "2026-09-19T12:34:56.789Z";
+const GLOBAL_SSO_TOKEN: string =
+  "eyJhbGciOiJIUzI1NiJ9.Z2xvYmFsLXNzby10b2tlbg.gl0b4l-S1gn4tur3_V4lu3";
+const PROJECT_SSO_TOKEN: string =
+  "eyJhbGciOiJIUzI1NiJ9.cHJvamVjdC1zc28.pr0j3ct-S1gn4tur3_V4lu3";
+const USER_ID: string = "65f1c2d3e4b5a67890abcdef";
+const PROJECT_ID: string = "65a0000000000000000000ff";
+/*
+ * A plus-addressed mailbox. It is the one value in the whole callback where a
+ * decoding mistake is invisible in testing and obvious in production: the
+ * parser turns a literal "+" into a space, so this only survives because the
+ * server percent-encoded it to "%2B" first.
+ */
+const EMAIL: string = "jane.doe+oncall@example.com";
+const NAME: string = "Jane Doe";
+
+// The same pieces as they appear on the wire.
+const ENCODED_EXPIRES_AT: string = "2026-09-19T12%3A34%3A56.789Z";
+const ENCODED_EMAIL: string = "jane.doe%2Boncall%40example.com";
+const ENCODED_NAME: string = "Jane+Doe";
+
+const AUTH_PARAMS: string = `accessToken=${ACCESS_TOKEN}&refreshToken=${REFRESH_TOKEN}&refreshTokenExpiresAt=${ENCODED_EXPIRES_AT}`;
+const USER_PARAMS: string = `userId=${USER_ID}&email=${ENCODED_EMAIL}&name=${ENCODED_NAME}&isMasterAdmin=true`;
+
+// Global SSO / Global OIDC: instance-wide, no project attached.
+const GLOBAL_SUCCESS_URL: string = `oneuptime://sso-callback?${AUTH_PARAMS}&${USER_PARAMS}&globalSsoToken=${GLOBAL_SSO_TOKEN}`;
+
+// Project SSO: a token bound to exactly one project, no global token.
+const PROJECT_SUCCESS_URL: string = `oneuptime://sso-callback?${AUTH_PARAMS}&${USER_PARAMS}&ssoToken=${PROJECT_SSO_TOKEN}&projectId=${PROJECT_ID}`;
+
+type SsoSuccessResult = Extract<SsoCallbackResult, { status: "success" }>;
+type SsoMessageResult = Extract<
+  SsoCallbackResult,
+  { status: "error" | "invalid" }
+>;
+
+function expectSuccess(url: string): SsoSuccessResult {
+  const result: SsoCallbackResult = parseSsoCallbackUrl(url);
+
+  expect(result.status).toBe("success");
+
+  return result as SsoSuccessResult;
+}
+
+function expectStatus(
+  url: string,
+  status: "error" | "invalid",
+): SsoMessageResult {
+  const result: SsoCallbackResult = parseSsoCallbackUrl(url);
+
+  expect(result.status).toBe(status);
+
+  return result as SsoMessageResult;
+}
+
+describe("isSsoCallbackUrl filters the app-wide Linking stream", () => {
+  /*
+   * Every deep link the OS hands the app arrives on one stream - push
+   * notification taps, universal links, the SSO callback. This predicate is
+   * the only thing separating them, so it has to be exact in both directions:
+   * too loose and an unrelated link is consumed as a failed login, too tight
+   * and a real login is dropped on the floor.
+   */
+
+  test("accepts the exact callback the server redirects to", () => {
+    expect(isSsoCallbackUrl(SSO_CALLBACK_URL)).toBe(true);
+    expect(isSsoCallbackUrl("oneuptime://sso-callback")).toBe(true);
+  });
+
+  test("accepts the trailing-slash form the OS sometimes normalises to", () => {
+    expect(isSsoCallbackUrl("oneuptime://sso-callback/")).toBe(true);
+  });
+
+  test("accepts the real thing, which always carries a query string", () => {
+    expect(isSsoCallbackUrl(GLOBAL_SUCCESS_URL)).toBe(true);
+    expect(
+      isSsoCallbackUrl("oneuptime://sso-callback?error=sso_login_failed"),
+    ).toBe(true);
+  });
+
+  test("accepts the trailing slash and a query together", () => {
+    expect(
+      isSsoCallbackUrl("oneuptime://sso-callback/?error=sso_login_failed"),
+    ).toBe(true);
+  });
+
+  test("rejects another host under the app's own scheme", () => {
+    /*
+     * The app owns the whole `oneuptime://` scheme, so its own navigation
+     * links come through here too. Treating one as a callback would abort a
+     * perfectly healthy login screen.
+     */
+    expect(isSsoCallbackUrl("oneuptime://home")).toBe(false);
+    expect(isSsoCallbackUrl("oneuptime://alert/65f1c2d3e4b5a67890abcdef")).toBe(
+      false,
+    );
+  });
+
+  test("rejects a host that merely starts with the same letters", () => {
+    expect(isSsoCallbackUrl("oneuptime://sso-callback-other")).toBe(false);
+    expect(
+      isSsoCallbackUrl("oneuptime://sso-callback-other?accessToken=a"),
+    ).toBe(false);
+    expect(isSsoCallbackUrl("oneuptime://sso-callbackx")).toBe(false);
+  });
+
+  test("rejects the same path under a different scheme", () => {
+    /*
+     * A hostile app can register a lookalike scheme, and the web dashboard
+     * serves a same-named path over https. Neither is this app's callback.
+     */
+    expect(isSsoCallbackUrl("https://oneuptime.com/sso-callback")).toBe(false);
+    expect(isSsoCallbackUrl("oneuptimex://sso-callback")).toBe(false);
+    expect(isSsoCallbackUrl("exp://127.0.0.1:8081/sso-callback")).toBe(false);
+  });
+
+  test("rejects nothing at all", () => {
+    // Linking.getInitialURL() resolves to null on a cold start with no link.
+    expect(isSsoCallbackUrl(null)).toBe(false);
+    expect(isSsoCallbackUrl(undefined)).toBe(false);
+    expect(isSsoCallbackUrl("")).toBe(false);
+  });
+
+  test("ignores a fragment the way it ignores a query", () => {
+    expect(isSsoCallbackUrl("oneuptime://sso-callback#done")).toBe(true);
+  });
+});
+
+describe("parseQueryString", () => {
+  test("splits ordinary pairs", () => {
+    expect(parseQueryString("error=denied&errorDescription=nope")).toEqual({
+      error: "denied",
+      errorDescription: "nope",
+    });
+  });
+
+  test("tolerates the leading question mark", () => {
+    expect(parseQueryString("?error=denied")).toEqual({ error: "denied" });
+  });
+
+  test("percent-decodes keys as well as values", () => {
+    expect(parseQueryString("error%44escription=late")).toEqual({
+      errorDescription: "late",
+    });
+  });
+
+  test("decodes an ISO-8601 timestamp back to its colons", () => {
+    /*
+     * URLSearchParams escapes ":" to "%3A", so the expiry the server put on
+     * the wire is not the string the app needs. Leaving it encoded produces a
+     * Date of NaN, and a session whose expiry is NaN is never refreshed.
+     */
+    expect(
+      parseQueryString(`refreshTokenExpiresAt=${ENCODED_EXPIRES_AT}`),
+    ).toEqual({ refreshTokenExpiresAt: EXPIRES_AT });
+  });
+
+  test("decodes an email's @ and +", () => {
+    expect(parseQueryString(`email=${ENCODED_EMAIL}`)).toEqual({
+      email: EMAIL,
+    });
+  });
+
+  test('decodes a literal "+" as a space', () => {
+    // Form encoding, which is what URLSearchParams emits for a display name.
+    expect(parseQueryString("name=Jane+Doe")).toEqual({ name: "Jane Doe" });
+  });
+
+  test("keeps a value containing an un-encoded = intact", () => {
+    /*
+     * Only the FIRST "=" separates the pair. A base64 token carries its own
+     * padding "="; splitting on every "=" would truncate it to something the
+     * server rejects on the next request.
+     */
+    expect(
+      parseQueryString("ssoToken=YWJjZGVmZ2hpamtsbW5vcA==&projectId=p1"),
+    ).toEqual({
+      ssoToken: "YWJjZGVmZ2hpamtsbW5vcA==",
+      projectId: "p1",
+    });
+  });
+
+  test("gives a key with no = an empty-string value", () => {
+    expect(parseQueryString("mobile&error=denied")).toEqual({
+      mobile: "",
+      error: "denied",
+    });
+  });
+
+  test("keeps the FIRST value of a repeated key", () => {
+    /*
+     * Matches URLSearchParams.get(). It matters because a redirect chain can
+     * append a param the IdP already set; taking the last value would let the
+     * outer hop overwrite what the server signed.
+     */
+    expect(parseQueryString("projectId=first&projectId=second")).toEqual({
+      projectId: "first",
+    });
+  });
+
+  test("returns an empty map for an empty query", () => {
+    expect(parseQueryString("")).toEqual({});
+    expect(parseQueryString("?")).toEqual({});
+  });
+
+  test("skips empty pairs rather than inventing empty keys", () => {
+    expect(parseQueryString("a=1&&b=2&")).toEqual({ a: "1", b: "2" });
+    expect(parseQueryString("=orphan&a=1")).toEqual({ a: "1" });
+  });
+
+  test("does not throw on a malformed percent escape", () => {
+    /*
+     * decodeURIComponent throws on a lone "%", and an IdP error sentence can
+     * easily contain one ("100% of assertions failed"). A throw here would
+     * escape parseSsoCallbackUrl and crash the callback handler, turning a
+     * message the user could act on into a frozen browser sheet - so the value
+     * degrades to its raw text instead.
+     */
+    expect(() => {
+      return parseQueryString("errorDescription=signature+%+mismatch");
+    }).not.toThrow();
+
+    expect(parseQueryString("errorDescription=signature+%+mismatch")).toEqual({
+      errorDescription: "signature % mismatch",
+    });
+  });
+
+  test("falls back on a malformed escape in the KEY too", () => {
+    expect(parseQueryString("%zz=value")).toEqual({ "%zz": "value" });
+  });
+
+  test("decodes a properly escaped percent sign", () => {
+    expect(parseQueryString("errorDescription=100%25+failed")).toEqual({
+      errorDescription: "100% failed",
+    });
+  });
+});
+
+describe("parseSsoCallbackUrl: Global SSO success", () => {
+  test("reports success", () => {
+    expect(parseSsoCallbackUrl(GLOBAL_SUCCESS_URL).status).toBe("success");
+  });
+
+  test("returns the auth tokens exactly as the server signed them", () => {
+    const result: SsoSuccessResult = expectSuccess(GLOBAL_SUCCESS_URL);
+
+    expect(result.tokens.accessToken).toBe(ACCESS_TOKEN);
+    expect(result.tokens.refreshToken).toBe(REFRESH_TOKEN);
+    expect(result.tokens.refreshTokenExpiresAt).toBe(EXPIRES_AT);
+  });
+
+  test("carries the global token and no project token", () => {
+    /*
+     * The whole point of Global SSO: one instance-wide token satisfies SSO
+     * enforcement for every project the user belongs to, so there is nothing
+     * project-scoped to store.
+     */
+    const result: SsoSuccessResult = expectSuccess(GLOBAL_SUCCESS_URL);
+
+    expect(result.globalSsoToken).toBe(GLOBAL_SSO_TOKEN);
+    expect(result.projectSsoToken).toBeNull();
+  });
+
+  test("populates the signed-in user", () => {
+    const result: SsoSuccessResult = expectSuccess(GLOBAL_SUCCESS_URL);
+
+    expect(result.user).toEqual({
+      userId: USER_ID,
+      email: EMAIL,
+      name: NAME,
+      isMasterAdmin: true,
+    });
+  });
+
+  test('parses isMasterAdmin="true" as the boolean true', () => {
+    expect(expectSuccess(GLOBAL_SUCCESS_URL).user?.isMasterAdmin).toBe(true);
+  });
+
+  test('parses isMasterAdmin="false" as the boolean false, not a truthy string', () => {
+    /*
+     * The server sends String(boolean), so this arrives as the four characters
+     * "false". Handing that straight through would be truthy and would show a
+     * normal user the admin surface.
+     */
+    const result: SsoSuccessResult = expectSuccess(
+      GLOBAL_SUCCESS_URL.replace("isMasterAdmin=true", "isMasterAdmin=false"),
+    );
+
+    expect(result.user?.isMasterAdmin).toBe(false);
+  });
+
+  test("defaults isMasterAdmin to false when the param is missing entirely", () => {
+    const result: SsoSuccessResult = expectSuccess(
+      GLOBAL_SUCCESS_URL.replace("&isMasterAdmin=true", ""),
+    );
+
+    expect(result.user?.isMasterAdmin).toBe(false);
+  });
+
+  test("only the exact string true grants admin", () => {
+    // Fail closed: anything the server did not literally send is not admin.
+    const result: SsoSuccessResult = expectSuccess(
+      GLOBAL_SUCCESS_URL.replace("isMasterAdmin=true", "isMasterAdmin=TRUE"),
+    );
+
+    expect(result.user?.isMasterAdmin).toBe(false);
+  });
+
+  test("succeeds with no user block when userId is absent", () => {
+    /*
+     * The tokens are what actually authenticate the session; the profile is a
+     * convenience the app can re-fetch. Refusing the login over a missing
+     * userId would throw away a valid session.
+     */
+    const result: SsoSuccessResult = expectSuccess(
+      `oneuptime://sso-callback?${AUTH_PARAMS}&globalSsoToken=${GLOBAL_SSO_TOKEN}`,
+    );
+
+    expect(result.user).toBeNull();
+    expect(result.tokens.accessToken).toBe(ACCESS_TOKEN);
+    expect(result.globalSsoToken).toBe(GLOBAL_SSO_TOKEN);
+  });
+
+  test("fills email and name with empty strings when only userId came back", () => {
+    const result: SsoSuccessResult = expectSuccess(
+      `oneuptime://sso-callback?${AUTH_PARAMS}&userId=${USER_ID}`,
+    );
+
+    expect(result.user).toEqual({
+      userId: USER_ID,
+      email: "",
+      name: "",
+      isMasterAdmin: false,
+    });
+  });
+
+  test("treats an empty globalSsoToken as absent rather than storing an empty token", () => {
+    /*
+     * An empty string stored as a token is worse than no token: the app would
+     * consider SSO satisfied and send `x-global-sso-token: ` on every request.
+     */
+    const result: SsoSuccessResult = expectSuccess(
+      `oneuptime://sso-callback?${AUTH_PARAMS}&globalSsoToken=`,
+    );
+
+    expect(result.globalSsoToken).toBeNull();
+  });
+});
+
+describe("parseSsoCallbackUrl: project SSO success", () => {
+  test("returns the project token bound to its project", () => {
+    const result: SsoSuccessResult = expectSuccess(PROJECT_SUCCESS_URL);
+
+    expect(result.projectSsoToken).toEqual({
+      projectId: PROJECT_ID,
+      ssoToken: PROJECT_SSO_TOKEN,
+    });
+  });
+
+  test("has no global token", () => {
+    /*
+     * A project login must not look like a global one, or the app would treat
+     * one project's SSO as satisfying every other project's enforcement.
+     */
+    expect(expectSuccess(PROJECT_SUCCESS_URL).globalSsoToken).toBeNull();
+  });
+
+  test("still returns the auth tokens and the user", () => {
+    const result: SsoSuccessResult = expectSuccess(PROJECT_SUCCESS_URL);
+
+    expect(result.tokens.refreshTokenExpiresAt).toBe(EXPIRES_AT);
+    expect(result.user?.userId).toBe(USER_ID);
+  });
+
+  test("drops a project token that arrived without its projectId", () => {
+    /*
+     * The pair is meaningless apart - there is nowhere to file the token. The
+     * login itself is still valid, so it succeeds without a project token
+     * rather than failing.
+     */
+    const result: SsoSuccessResult = expectSuccess(
+      `oneuptime://sso-callback?${AUTH_PARAMS}&${USER_PARAMS}&ssoToken=${PROJECT_SSO_TOKEN}`,
+    );
+
+    expect(result.projectSsoToken).toBeNull();
+    expect(result.tokens.accessToken).toBe(ACCESS_TOKEN);
+  });
+
+  test("drops a projectId that arrived without its token", () => {
+    const result: SsoSuccessResult = expectSuccess(
+      `oneuptime://sso-callback?${AUTH_PARAMS}&${USER_PARAMS}&projectId=${PROJECT_ID}`,
+    );
+
+    expect(result.projectSsoToken).toBeNull();
+  });
+
+  test("a callback with neither flavour of SSO token is still a valid login", () => {
+    // An ordinary (non-SSO-enforced) login started from the app.
+    const result: SsoSuccessResult = expectSuccess(
+      `oneuptime://sso-callback?${AUTH_PARAMS}&${USER_PARAMS}`,
+    );
+
+    expect(result.globalSsoToken).toBeNull();
+    expect(result.projectSsoToken).toBeNull();
+  });
+});
+
+describe("parseSsoCallbackUrl: the server reported a failure", () => {
+  /*
+   * Without this branch every server-side failure - unknown user, disabled
+   * provider, IdP refusal, expired login session - is indistinguishable from
+   * the user tapping Cancel, and the screen tells them nothing.
+   */
+
+  const ERROR_WITH_DESCRIPTION_URL: string =
+    "oneuptime://sso-callback?error=no_project_access&errorDescription=You+are+not+a+member+of+any+project.+Please+contact+your+administrator.";
+
+  test("reports an error", () => {
+    expect(parseSsoCallbackUrl(ERROR_WITH_DESCRIPTION_URL).status).toBe(
+      "error",
+    );
+  });
+
+  test("keeps both the code and the human sentence", () => {
+    const result: SsoMessageResult = expectStatus(
+      ERROR_WITH_DESCRIPTION_URL,
+      "error",
+    );
+
+    expect(result.message).toContain("no_project_access");
+    expect(result.message).toContain(
+      "You are not a member of any project. Please contact your administrator.",
+    );
+    expect(result.message).toBe(
+      "no_project_access: You are not a member of any project. Please contact your administrator.",
+    );
+  });
+
+  test("uses just the code when the server had nothing to add", () => {
+    const result: SsoMessageResult = expectStatus(
+      "oneuptime://sso-callback?error=sso_login_failed",
+      "error",
+    );
+
+    expect(result.message).toBe("sso_login_failed");
+  });
+
+  test("does not leave a dangling separator when the description is empty", () => {
+    const result: SsoMessageResult = expectStatus(
+      "oneuptime://sso-callback?error=sso_login_failed&errorDescription=",
+      "error",
+    );
+
+    expect(result.message).toBe("sso_login_failed");
+  });
+
+  test("an error wins even when the URL also carries usable tokens", () => {
+    /*
+     * The dangerous ordering. If the token branch were checked first, a
+     * callback the server marked as failed would sign the user in anyway, and
+     * whatever the error was about (no project access, a revoked account)
+     * would be silently ignored.
+     */
+    const result: SsoCallbackResult = parseSsoCallbackUrl(
+      `oneuptime://sso-callback?error=sso_auth_failed&${AUTH_PARAMS}&${USER_PARAMS}&globalSsoToken=${GLOBAL_SSO_TOKEN}`,
+    );
+
+    expect(result.status).toBe("error");
+    expect(result).not.toHaveProperty("tokens");
+    expect(result).not.toHaveProperty("globalSsoToken");
+  });
+
+  test("decodes the description rather than showing the user %20 soup", () => {
+    const result: SsoMessageResult = expectStatus(
+      "oneuptime://sso-callback?error=oidc_error&errorDescription=Token%20exchange%20failed%3A%20invalid_client",
+      "error",
+    );
+
+    expect(result.message).toBe(
+      "oidc_error: Token exchange failed: invalid_client",
+    );
+  });
+
+  test("survives a malformed escape in the description", () => {
+    const result: SsoMessageResult = expectStatus(
+      "oneuptime://sso-callback?error=saml_error&errorDescription=Signature+%+mismatch",
+      "error",
+    );
+
+    expect(result.message).toBe("saml_error: Signature % mismatch");
+  });
+});
+
+describe("parseSsoCallbackUrl: nothing usable", () => {
+  /*
+   * Every case here must be "invalid", never a half-populated success. A
+   * success with an undefined refresh token is a session that cannot be
+   * refreshed and logs the responder out mid-incident.
+   */
+
+  test("a link that is not the SSO callback at all", () => {
+    expect(parseSsoCallbackUrl(`oneuptime://home?${AUTH_PARAMS}`).status).toBe(
+      "invalid",
+    );
+    expect(
+      parseSsoCallbackUrl(`https://oneuptime.com/sso-callback?${AUTH_PARAMS}`)
+        .status,
+    ).toBe("invalid");
+  });
+
+  test("no link at all", () => {
+    expect(parseSsoCallbackUrl(null).status).toBe("invalid");
+    expect(parseSsoCallbackUrl(undefined).status).toBe("invalid");
+    expect(parseSsoCallbackUrl("").status).toBe("invalid");
+  });
+
+  test("the callback with no query at all", () => {
+    expect(parseSsoCallbackUrl("oneuptime://sso-callback").status).toBe(
+      "invalid",
+    );
+    expect(parseSsoCallbackUrl("oneuptime://sso-callback?").status).toBe(
+      "invalid",
+    );
+    expect(parseSsoCallbackUrl("oneuptime://sso-callback/").status).toBe(
+      "invalid",
+    );
+  });
+
+  test("missing accessToken", () => {
+    const result: SsoMessageResult = expectStatus(
+      `oneuptime://sso-callback?refreshToken=${REFRESH_TOKEN}&refreshTokenExpiresAt=${ENCODED_EXPIRES_AT}&${USER_PARAMS}`,
+      "invalid",
+    );
+
+    expect(result.message).toBe("Authentication failed. Missing token data.");
+  });
+
+  test("missing refreshToken", () => {
+    expect(
+      parseSsoCallbackUrl(
+        `oneuptime://sso-callback?accessToken=${ACCESS_TOKEN}&refreshTokenExpiresAt=${ENCODED_EXPIRES_AT}&${USER_PARAMS}`,
+      ).status,
+    ).toBe("invalid");
+  });
+
+  test("missing refreshTokenExpiresAt", () => {
+    /*
+     * The least obviously fatal of the three, which is why it is here. Without
+     * an expiry the app cannot know when to refresh, so it either refreshes
+     * never or treats the session as already dead.
+     */
+    expect(
+      parseSsoCallbackUrl(
+        `oneuptime://sso-callback?accessToken=${ACCESS_TOKEN}&refreshToken=${REFRESH_TOKEN}&${USER_PARAMS}`,
+      ).status,
+    ).toBe("invalid");
+  });
+
+  test("a present-but-empty token is treated as missing", () => {
+    /*
+     * `?accessToken=` is a param that exists and is worthless. Accepting it
+     * would store an empty bearer token and every subsequent API call would
+     * 401 with no explanation.
+     */
+    expect(
+      parseSsoCallbackUrl(
+        `oneuptime://sso-callback?accessToken=&refreshToken=${REFRESH_TOKEN}&refreshTokenExpiresAt=${ENCODED_EXPIRES_AT}`,
+      ).status,
+    ).toBe("invalid");
+  });
+
+  test("an invalid result never carries partial tokens or a user", () => {
+    const result: SsoCallbackResult = parseSsoCallbackUrl(
+      `oneuptime://sso-callback?accessToken=${ACCESS_TOKEN}&${USER_PARAMS}&globalSsoToken=${GLOBAL_SSO_TOKEN}`,
+    );
+
+    expect(result.status).toBe("invalid");
+    expect(result).not.toHaveProperty("tokens");
+    expect(result).not.toHaveProperty("user");
+    expect(result).not.toHaveProperty("globalSsoToken");
+  });
+
+  test("the SSO token params alone are not a login", () => {
+    // A project token with no session behind it authenticates nothing.
+    expect(
+      parseSsoCallbackUrl(
+        `oneuptime://sso-callback?ssoToken=${PROJECT_SSO_TOKEN}&projectId=${PROJECT_ID}`,
+      ).status,
+    ).toBe("invalid");
+  });
+
+  test("never throws, whatever arrives on the Linking stream", () => {
+    const nonsense: Array<string> = [
+      "oneuptime://sso-callback?%",
+      "oneuptime://sso-callback?=&=&=",
+      "oneuptime://sso-callback?accessToken=%E0%A4%A",
+      "not a url",
+      "oneuptime://",
+    ];
+
+    for (const url of nonsense) {
+      expect(() => {
+        return parseSsoCallbackUrl(url);
+      }).not.toThrow();
+    }
+  });
+});
+
+/*
+ * isSsoCallbackUrl strips a fragment before matching the path, so a
+ * fragment-bearing callback is accepted as ours. parseSsoCallbackUrl has to
+ * strip it too, or the fragment is glued onto whichever parameter happened to
+ * come last - silently corrupting a token, or turning an ISO timestamp into
+ * something Date() reads as Invalid Date.
+ *
+ * Our own server never emits a fragment (see
+ * App/FeatureSet/Identity/Utils/MobileSso.ts), so this is about surviving a
+ * redirect hop that adds one - fragments are conventional in OIDC responses.
+ */
+describe("parseSsoCallbackUrl: a fragment does not contaminate the last parameter", () => {
+  test("a fragment after the query is discarded, not appended to the last value", () => {
+    const result: SsoCallbackResult = parseSsoCallbackUrl(
+      "oneuptime://sso-callback?accessToken=header.payload.signature" +
+        "&refreshToken=refresh-token-value" +
+        "&refreshTokenExpiresAt=2026-09-19T12%3A34%3A56.789Z" +
+        "#state=abc123",
+    );
+
+    expect(result.status).toBe("success");
+
+    if (result.status !== "success") {
+      return;
+    }
+
+    expect(result.tokens.refreshTokenExpiresAt).toBe(
+      "2026-09-19T12:34:56.789Z",
+    );
+    // The whole point: a Date built from it must be real.
+    expect(
+      Number.isNaN(new Date(result.tokens.refreshTokenExpiresAt).getTime()),
+    ).toBe(false);
+  });
+
+  test("a fragment does not leak into a trailing globalSsoToken", () => {
+    const result: SsoCallbackResult = parseSsoCallbackUrl(
+      "oneuptime://sso-callback?accessToken=a.b.c" +
+        "&refreshToken=r" +
+        "&refreshTokenExpiresAt=2026-09-19T12%3A34%3A56.789Z" +
+        "&globalSsoToken=global.token.value" +
+        "#_=_",
+    );
+
+    expect(result.status).toBe("success");
+
+    if (result.status !== "success") {
+      return;
+    }
+
+    expect(result.globalSsoToken).toBe("global.token.value");
+  });
+
+  test("a fragment on an error callback does not corrupt the description", () => {
+    const result: SsoCallbackResult = parseSsoCallbackUrl(
+      "oneuptime://sso-callback?error=no_project_access" +
+        "&errorDescription=Ask%20your%20administrator" +
+        "#_=_",
+    );
+
+    expect(result.status).toBe("error");
+
+    if (result.status !== "error") {
+      return;
+    }
+
+    expect(result.message).toBe("no_project_access: Ask your administrator");
+  });
+
+  test("a fragment with no query at all is still not a usable login", () => {
+    const result: SsoCallbackResult = parseSsoCallbackUrl(
+      "oneuptime://sso-callback#state=abc",
+    );
+
+    expect(result.status).toBe("invalid");
+  });
+});
+
+describe("the wire format is exactly what the server builds", () => {
+  /*
+   * Why this module hand-rolls its query parsing instead of using `new URL()`:
+   * React Native ships its own cut-down URL/URLSearchParams
+   * (react-native/Libraries/Blob/URL.js), while Jest runs on Node's WHATWG
+   * implementation. A parser built on `new URL()` would therefore be tested
+   * against one implementation and shipped against a different one, and a
+   * green suite here would say nothing about a handset. parseSsoCallbackUrl
+   * depends on neither, so the round trip below is the same code path in both
+   * places - which is the only reason these assertions are worth anything.
+   */
+
+  function serverBuiltSuccessUrl(): string {
+    /*
+     * A faithful transcription of buildMobileSsoSuccessUrl in
+     * App/FeatureSet/Identity/Utils/MobileSso.ts. Used ONLY to prove the
+     * hard-coded fixtures above are byte-accurate - the module under test
+     * never touches URLSearchParams.
+     */
+    const params: URLSearchParams = new URLSearchParams();
+
+    params.set("accessToken", ACCESS_TOKEN);
+    params.set("refreshToken", REFRESH_TOKEN);
+    params.set("refreshTokenExpiresAt", new Date(EXPIRES_AT).toISOString());
+    params.set("userId", USER_ID);
+    params.set("email", EMAIL);
+    params.set("name", NAME);
+    params.set("isMasterAdmin", String(true));
+    params.set("globalSsoToken", GLOBAL_SSO_TOKEN);
+
+    return `oneuptime://sso-callback?${params.toString()}`;
+  }
+
+  test("the fixture is character-for-character the server's output", () => {
+    expect(serverBuiltSuccessUrl()).toBe(GLOBAL_SUCCESS_URL);
+  });
+
+  test("the encoding the fixture depends on is really there", () => {
+    // If these ever stop holding, the decode assertions below prove nothing.
+    expect(GLOBAL_SUCCESS_URL).toContain("%3A");
+    expect(GLOBAL_SUCCESS_URL).toContain("%40");
+    expect(GLOBAL_SUCCESS_URL).toContain("%2B");
+    expect(GLOBAL_SUCCESS_URL).toContain("Jane+Doe");
+  });
+
+  test("a realistic callback round-trips exactly", () => {
+    const result: SsoSuccessResult = expectSuccess(serverBuiltSuccessUrl());
+
+    expect(result.tokens.accessToken).toBe(ACCESS_TOKEN);
+    expect(result.tokens.refreshToken).toBe(REFRESH_TOKEN);
+    expect(result.tokens.refreshTokenExpiresAt).toBe(EXPIRES_AT);
+    expect(result.globalSsoToken).toBe(GLOBAL_SSO_TOKEN);
+    expect(result.user).toEqual({
+      userId: USER_ID,
+      email: EMAIL,
+      name: NAME,
+      isMasterAdmin: true,
+    });
+  });
+
+  test("the JWTs come out with their three segments intact", () => {
+    /*
+     * A JWT's base64url alphabet includes "-" and "_", and its segments are
+     * separated by ".". Any of those mangled in transit produces a token the
+     * server rejects with a signature error that looks like a server bug.
+     */
+    const result: SsoSuccessResult = expectSuccess(serverBuiltSuccessUrl());
+
+    expect(result.tokens.accessToken.split(".")).toHaveLength(3);
+    expect(result.tokens.refreshToken.split(".")).toHaveLength(3);
+    expect(result.globalSsoToken?.split(".")).toHaveLength(3);
+    expect(result.tokens.accessToken).toContain("-");
+    expect(result.tokens.accessToken).toContain("_");
+  });
+
+  test("the decoded expiry is a real Date, not NaN", () => {
+    /*
+     * The end of the chain that this whole module exists to protect: the
+     * expiry is what schedules the refresh, and a NaN here logs the responder
+     * out at an arbitrary moment.
+     */
+    const result: SsoSuccessResult = expectSuccess(serverBuiltSuccessUrl());
+    const expiry: Date = new Date(result.tokens.refreshTokenExpiresAt);
+
+    expect(Number.isNaN(expiry.getTime())).toBe(false);
+    expect(expiry.toISOString()).toBe(EXPIRES_AT);
+  });
+});

--- a/MobileApp/src/sso/callbackUrl.ts
+++ b/MobileApp/src/sso/callbackUrl.ts
@@ -1,0 +1,226 @@
+/*
+ * Parsing for the `oneuptime://sso-callback` deep link that ends every SSO
+ * login - project SAML, Global SSO (SAML) and Global OIDC alike.
+ *
+ * The query string is parsed by hand rather than through `URL` /
+ * `URLSearchParams` on purpose. React Native ships its own cut-down `URL`
+ * (react-native/Libraries/Blob/URL.js) whose behaviour differs from the WHATWG
+ * classes Node gives Jest, so anything built on `new URL(...)` is tested
+ * against one implementation and shipped against another. This module has no
+ * such split: it is the same code in both places, which is also what makes the
+ * whole SSO callback contract unit-testable.
+ */
+
+export const SSO_CALLBACK_SCHEME: string = "oneuptime";
+export const SSO_CALLBACK_HOST: string = "sso-callback";
+export const SSO_CALLBACK_URL: string = `${SSO_CALLBACK_SCHEME}://${SSO_CALLBACK_HOST}`;
+
+/**
+ * True when the URL is an SSO callback deep link for this app. Used to filter
+ * the app-wide `Linking` stream, which also carries push-notification and
+ * universal links.
+ */
+export function isSsoCallbackUrl(url: string | null | undefined): boolean {
+  if (!url) {
+    return false;
+  }
+
+  const withoutQuery: string = url.split("?")[0]!.split("#")[0]!;
+
+  /*
+   * Accept both `oneuptime://sso-callback` and the trailing-slash form some
+   * platforms hand back, but nothing that merely starts with the same letters
+   * (`oneuptime://sso-callback-other`).
+   */
+  return (
+    withoutQuery === SSO_CALLBACK_URL || withoutQuery === `${SSO_CALLBACK_URL}/`
+  );
+}
+
+/**
+ * Splits `key=value&key2=value2` into a map, percent-decoding both halves.
+ *
+ * Repeated keys keep the FIRST value, matching URLSearchParams.get(). A value
+ * containing an un-encoded `=` is preserved whole (only the first `=` splits
+ * the pair), which is what a base64 token needs.
+ */
+export function parseQueryString(query: string): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  const trimmed: string = query.replace(/^\?/, "");
+
+  if (!trimmed) {
+    return result;
+  }
+
+  for (const pair of trimmed.split("&")) {
+    if (!pair) {
+      continue;
+    }
+
+    const separatorIndex: number = pair.indexOf("=");
+    const rawKey: string =
+      separatorIndex === -1 ? pair : pair.slice(0, separatorIndex);
+    const rawValue: string =
+      separatorIndex === -1 ? "" : pair.slice(separatorIndex + 1);
+
+    const key: string = safeDecode(rawKey);
+
+    if (!key || Object.prototype.hasOwnProperty.call(result, key)) {
+      continue;
+    }
+
+    result[key] = safeDecode(rawValue);
+  }
+
+  return result;
+}
+
+/*
+ * `decodeURIComponent` throws on a lone `%`, which an IdP error message can
+ * easily contain. A malformed escape should degrade to the raw text, never
+ * blow up the login.
+ */
+function safeDecode(value: string): string {
+  const withSpaces: string = value.replace(/\+/g, " ");
+
+  try {
+    return decodeURIComponent(withSpaces);
+  } catch {
+    return withSpaces;
+  }
+}
+
+/** Auth tokens every SSO login returns, whatever its flavour. */
+export interface SsoCallbackTokens {
+  accessToken: string;
+  refreshToken: string;
+  refreshTokenExpiresAt: string;
+}
+
+export interface SsoCallbackUser {
+  userId: string;
+  email: string;
+  name: string;
+  isMasterAdmin: boolean;
+}
+
+export type SsoCallbackResult =
+  | {
+      status: "success";
+      tokens: SsoCallbackTokens;
+      user: SsoCallbackUser | null;
+      /*
+       * Present for a Global SSO / Global OIDC login. Not bound to a project -
+       * it satisfies SSO enforcement for every project the user belongs to.
+       */
+      globalSsoToken: string | null;
+      // Present for a project SSO login. Bound to exactly one project.
+      projectSsoToken: { projectId: string; ssoToken: string } | null;
+    }
+  | {
+      // The server reported a failure and told us why.
+      status: "error";
+      message: string;
+    }
+  | {
+      // Not an SSO callback, or an SSO callback with nothing usable in it.
+      status: "invalid";
+      message: string;
+    };
+
+const GENERIC_FAILURE_MESSAGE: string =
+  "Authentication failed. Please try again.";
+
+/**
+ * Turns an `oneuptime://sso-callback?...` URL into the outcome it represents.
+ *
+ * Pure and total: it never throws and never returns a half-populated success.
+ * A callback carrying an `error` param becomes `status: "error"` so the user
+ * sees the server's reason instead of a screen that silently does nothing.
+ */
+export function parseSsoCallbackUrl(
+  url: string | null | undefined,
+): SsoCallbackResult {
+  if (!isSsoCallbackUrl(url)) {
+    return {
+      status: "invalid",
+      message: GENERIC_FAILURE_MESSAGE,
+    };
+  }
+
+  /*
+   * Strip any fragment before reading the query, the same way isSsoCallbackUrl
+   * does when it matches the path. Our own server never emits one, but a
+   * redirect hop can (fragments are conventional in OIDC responses), and
+   * without this it would be glued onto the last parameter's value - silently
+   * corrupting whichever token happened to be last.
+   */
+  const withoutFragment: string = url!.split("#")[0]!;
+
+  const queryStart: number = withoutFragment.indexOf("?");
+  const params: Record<string, string> = parseQueryString(
+    queryStart === -1 ? "" : withoutFragment.slice(queryStart + 1),
+  );
+
+  /*
+   * The server sends `error` (and optionally `errorDescription`) whenever the
+   * login could not complete - unknown user, disabled provider, IdP refusal,
+   * an expired login session. Without this branch those all look identical to
+   * a user-cancelled login.
+   */
+  const error: string | undefined = params["error"];
+
+  if (error) {
+    const description: string | undefined = params["errorDescription"];
+
+    return {
+      status: "error",
+      message: description ? `${error}: ${description}` : error,
+    };
+  }
+
+  const accessToken: string | undefined = params["accessToken"];
+  const refreshToken: string | undefined = params["refreshToken"];
+  const refreshTokenExpiresAt: string | undefined =
+    params["refreshTokenExpiresAt"];
+
+  if (!accessToken || !refreshToken || !refreshTokenExpiresAt) {
+    return {
+      status: "invalid",
+      message: "Authentication failed. Missing token data.",
+    };
+  }
+
+  const globalSsoToken: string | null = params["globalSsoToken"] || null;
+
+  const ssoToken: string | undefined = params["ssoToken"];
+  const projectId: string | undefined = params["projectId"];
+
+  const userId: string | undefined = params["userId"];
+
+  return {
+    status: "success",
+    tokens: {
+      accessToken,
+      refreshToken,
+      refreshTokenExpiresAt,
+    },
+    user: userId
+      ? {
+          userId,
+          email: params["email"] || "",
+          name: params["name"] || "",
+          isMasterAdmin: params["isMasterAdmin"] === "true",
+        }
+      : null,
+    globalSsoToken,
+    projectSsoToken:
+      ssoToken && projectId
+        ? {
+            projectId,
+            ssoToken,
+          }
+        : null,
+  };
+}

--- a/MobileApp/src/sso/deepLink.test.ts
+++ b/MobileApp/src/sso/deepLink.test.ts
@@ -1,0 +1,653 @@
+import * as Linking from "expo-linking";
+import { Platform } from "react-native";
+import {
+  SSO_CALLBACK_GRACE_MS,
+  clearPendingSsoCallbackUrl,
+  consumeInitialSsoCallbackUrl,
+  consumePendingSsoCallbackUrl,
+  resetSsoCallbackCaptureForTesting,
+  startSsoCallbackCapture,
+  stopSsoCallbackCapture,
+  waitForSsoCallbackUrl,
+} from "./deepLink";
+import { describe, expect, test, beforeEach, afterEach } from "@jest/globals";
+
+/*
+ * This module is the safety net under `WebBrowser.openAuthSessionAsync`, and it
+ * exists because that API loses successful logins in two different ways:
+ *
+ * - ANDROID: the redirect out of Chrome Custom Tabs fires both the Linking
+ *   "url" event and an AppState change back to "active". expo-web-browser races
+ *   them, so a completed login intermittently resolves as `dismiss` carrying no
+ *   URL at all. The tokens are in the deep link that this module captured.
+ *
+ * - BOTH PLATFORMS: the OS can kill the app while the user is at the IdP. The
+ *   redirect then cold-starts the process, the callback arrives as the launch
+ *   URL, and the promise that was supposed to receive it died with the old
+ *   process.
+ *
+ * Every assertion below therefore runs under BOTH Jest projects - "ios" and
+ * "android" - and nothing here is gated on `Platform.OS`. A capture that only
+ * worked on one platform would silently strand users on the other at a "login
+ * failed" screen after a login that actually succeeded.
+ */
+
+jest.mock("expo-linking", () => {
+  return {
+    __esModule: true,
+    addEventListener: jest.fn(),
+    getInitialURL: jest.fn(),
+  };
+});
+
+type UrlEventHandler = (event: { url: string }) => void;
+
+// A realistic Global SSO callback: tokens plus the instance-wide SSO token.
+const CALLBACK_URL: string =
+  "oneuptime://sso-callback?accessToken=at-1&refreshToken=rt-1" +
+  "&refreshTokenExpiresAt=2026-01-01T00%3A00%3A00.000Z&globalSsoToken=gst-1";
+
+const SECOND_CALLBACK_URL: string =
+  "oneuptime://sso-callback?accessToken=at-2&refreshToken=rt-2" +
+  "&refreshTokenExpiresAt=2026-02-02T00%3A00%3A00.000Z&globalSsoToken=gst-2";
+
+// What the same Linking stream carries when a push notification is tapped.
+const INCIDENT_DEEP_LINK: string = "oneuptime://incident/project-1/incident-2";
+
+let capturedHandlers: Array<UrlEventHandler> = [];
+let removeSubscription: jest.Mock;
+
+function addEventListenerMock(): jest.Mock {
+  return Linking.addEventListener as unknown as jest.Mock;
+}
+
+function getInitialUrlMock(): jest.Mock {
+  return Linking.getInitialURL as unknown as jest.Mock;
+}
+
+/** Fires a Linking "url" event at whatever this module last subscribed with. */
+function emitUrlEvent(url: string): void {
+  const handler: UrlEventHandler | undefined =
+    capturedHandlers[capturedHandlers.length - 1];
+
+  if (!handler) {
+    throw new Error("No url listener is registered - capture was not started.");
+  }
+
+  handler({ url });
+}
+
+/*
+ * Lets every already-queued promise callback run. Two ticks rather than one
+ * because the module chains `.then().catch()` onto the launch-URL read.
+ */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  capturedHandlers = [];
+  removeSubscription = jest.fn();
+
+  addEventListenerMock().mockImplementation(
+    (_event: string, handler: UrlEventHandler): { remove: () => void } => {
+      capturedHandlers.push(handler);
+      return { remove: removeSubscription };
+    },
+  );
+
+  getInitialUrlMock().mockResolvedValue(null);
+
+  // The module holds process-wide state; every test starts from a cold app.
+  resetSsoCallbackCaptureForTesting();
+});
+
+describe("startSsoCallbackCapture", () => {
+  test("subscribes to the app-wide url stream", () => {
+    startSsoCallbackCapture();
+
+    expect(addEventListenerMock()).toHaveBeenCalledTimes(1);
+    expect(addEventListenerMock().mock.calls[0]![0]).toBe("url");
+    expect(typeof addEventListenerMock().mock.calls[0]![1]).toBe("function");
+  });
+
+  test("subscribes exactly once however many times it is called", () => {
+    /*
+     * It is called from app startup AND from every screen that opens an auth
+     * session. A second subscription would deliver each callback twice, and the
+     * second delivery would look like a stale login to whoever consumed it.
+     */
+    startSsoCallbackCapture();
+    startSsoCallbackCapture();
+    startSsoCallbackCapture();
+
+    expect(addEventListenerMock()).toHaveBeenCalledTimes(1);
+    expect(getInitialUrlMock()).toHaveBeenCalledTimes(1);
+  });
+
+  test("reads the launch URL only once, even across a teardown and restart", async () => {
+    /*
+     * React re-mounts (StrictMode, navigator remounts) tear the listener down
+     * and register it again. `getInitialURL()` keeps returning the launch URL
+     * for the whole process lifetime, so re-reading it would re-deliver a
+     * callback the app already signed in with - a second, duplicate login.
+     */
+    startSsoCallbackCapture();
+    stopSsoCallbackCapture();
+    startSsoCallbackCapture();
+
+    await flushMicrotasks();
+
+    expect(addEventListenerMock()).toHaveBeenCalledTimes(2);
+    expect(getInitialUrlMock()).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("capturing a url event", () => {
+  beforeEach(() => {
+    startSsoCallbackCapture();
+  });
+
+  test("captures an SSO callback and hands it to the caller", () => {
+    emitUrlEvent(CALLBACK_URL);
+
+    expect(consumePendingSsoCallbackUrl()).toBe(CALLBACK_URL);
+  });
+
+  test("delivers a captured callback exactly once", () => {
+    /*
+     * Two screens can be asking at the same time - the auth-session promise on
+     * one side, a cold-start check on the other. Both acting on the same login
+     * means the tokens get exchanged twice.
+     */
+    emitUrlEvent(CALLBACK_URL);
+
+    expect(consumePendingSsoCallbackUrl()).toBe(CALLBACK_URL);
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+  });
+
+  test("ignores an unrelated deep link", () => {
+    /*
+     * The same "url" stream carries push-notification deep links. Treating one
+     * as a callback would hand the SSO code a URL with no tokens in it.
+     */
+    emitUrlEvent(INCIDENT_DEEP_LINK);
+
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+  });
+
+  test("ignores a host that merely starts with sso-callback", () => {
+    emitUrlEvent("oneuptime://sso-callback-other?accessToken=at-1");
+
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+  });
+
+  test("an unrelated deep link does not discard an already captured callback", () => {
+    /*
+     * A push notification arriving in the same second as the redirect must not
+     * wipe the login result out from under the screen waiting on it.
+     */
+    emitUrlEvent(CALLBACK_URL);
+    emitUrlEvent(INCIDENT_DEEP_LINK);
+
+    expect(consumePendingSsoCallbackUrl()).toBe(CALLBACK_URL);
+  });
+
+  test("a newer callback supersedes an unconsumed older one", () => {
+    /*
+     * If the user backed out and logged in again, the second result is the live
+     * one; the first belongs to an attempt nobody is waiting on any more.
+     */
+    emitUrlEvent(CALLBACK_URL);
+    emitUrlEvent(SECOND_CALLBACK_URL);
+
+    expect(consumePendingSsoCallbackUrl()).toBe(SECOND_CALLBACK_URL);
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+  });
+
+  test("accepts the trailing-slash form of the callback host", () => {
+    emitUrlEvent("oneuptime://sso-callback/?error=access_denied");
+
+    expect(consumePendingSsoCallbackUrl()).toBe(
+      "oneuptime://sso-callback/?error=access_denied",
+    );
+  });
+
+  test("clearPendingSsoCallbackUrl drops a captured URL", () => {
+    /*
+     * Called just before opening a new auth session: a leftover URL from an
+     * earlier attempt would otherwise be read as the result of this one.
+     */
+    emitUrlEvent(CALLBACK_URL);
+    clearPendingSsoCallbackUrl();
+
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+  });
+
+  test("clearPendingSsoCallbackUrl is harmless when nothing is pending", () => {
+    expect((): void => {
+      return clearPendingSsoCallbackUrl();
+    }).not.toThrow();
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+  });
+});
+
+describe("consumeInitialSsoCallbackUrl (the cold-start path)", () => {
+  test("returns the launch URL, waiting for the asynchronous read", async () => {
+    /*
+     * THE POINT OF THIS FUNCTION. `getInitialURL()` is a promise, so startup
+     * code that read the pending slot synchronously would run before the launch
+     * URL had been read and conclude there was no callback - which is exactly
+     * how an OS-killed login gets lost. The read here is deliberately still
+     * unresolved when `consumeInitialSsoCallbackUrl()` is called.
+     */
+    let resolveInitialUrl: (url: string | null) => void = (): void => {
+      return undefined;
+    };
+
+    getInitialUrlMock().mockImplementation((): Promise<string | null> => {
+      return new Promise((resolve: (url: string | null) => void): void => {
+        resolveInitialUrl = resolve;
+      });
+    });
+
+    startSsoCallbackCapture();
+
+    // A synchronous read at this instant sees nothing - and that is correct.
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+
+    const cold: Promise<string | null> = consumeInitialSsoCallbackUrl();
+
+    await flushMicrotasks();
+    resolveInitialUrl(CALLBACK_URL);
+
+    await expect(cold).resolves.toBe(CALLBACK_URL);
+  });
+
+  test("returns a launch URL that only settles on a later timer tick", async () => {
+    /*
+     * The same guarantee against a read that resolves a whole macrotask later,
+     * so passing cannot depend on how many microtasks happen to be queued.
+     */
+    getInitialUrlMock().mockImplementation((): Promise<string | null> => {
+      return new Promise((resolve: (url: string | null) => void): void => {
+        setTimeout((): void => {
+          resolve(CALLBACK_URL);
+        }, 25);
+      });
+    });
+
+    startSsoCallbackCapture();
+
+    await flushMicrotasks();
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+
+    await expect(consumeInitialSsoCallbackUrl()).resolves.toBe(CALLBACK_URL);
+  });
+
+  test("starts the capture itself, so later events are still heard", async () => {
+    /*
+     * Startup calls this before anything else; if it did not subscribe, a
+     * callback arriving a moment after launch would hit no listener.
+     */
+    await expect(consumeInitialSsoCallbackUrl()).resolves.toBeNull();
+
+    expect(addEventListenerMock()).toHaveBeenCalledTimes(1);
+
+    emitUrlEvent(CALLBACK_URL);
+
+    expect(consumePendingSsoCallbackUrl()).toBe(CALLBACK_URL);
+  });
+
+  test("resolves null when there was no launch URL", async () => {
+    getInitialUrlMock().mockResolvedValue(null);
+
+    await expect(consumeInitialSsoCallbackUrl()).resolves.toBeNull();
+  });
+
+  test("resolves null when the app was launched by an unrelated deep link", async () => {
+    getInitialUrlMock().mockResolvedValue(INCIDENT_DEEP_LINK);
+
+    await expect(consumeInitialSsoCallbackUrl()).resolves.toBeNull();
+  });
+
+  test("resolves null instead of throwing when the launch-URL read rejects", async () => {
+    /*
+     * A launch URL we cannot read is indistinguishable from no launch URL. An
+     * escaping rejection here would happen during app startup, before any error
+     * boundary exists.
+     */
+    getInitialUrlMock().mockRejectedValue(new Error("Linking unavailable"));
+
+    await expect(consumeInitialSsoCallbackUrl()).resolves.toBeNull();
+  });
+
+  test("a rejected launch-URL read does not stop later events being captured", async () => {
+    getInitialUrlMock().mockRejectedValue(new Error("Linking unavailable"));
+
+    await expect(consumeInitialSsoCallbackUrl()).resolves.toBeNull();
+
+    emitUrlEvent(CALLBACK_URL);
+
+    expect(consumePendingSsoCallbackUrl()).toBe(CALLBACK_URL);
+  });
+
+  test("delivers the cold-start callback exactly once", async () => {
+    getInitialUrlMock().mockResolvedValue(CALLBACK_URL);
+
+    await expect(consumeInitialSsoCallbackUrl()).resolves.toBe(CALLBACK_URL);
+    await expect(consumeInitialSsoCallbackUrl()).resolves.toBeNull();
+  });
+
+  test("a url event arriving before the launch read settles is not clobbered", async () => {
+    /*
+     * Warm start: the event fires first and `getInitialURL()` then resolves
+     * null a tick later. That null must not erase the real callback.
+     */
+    let resolveInitialUrl: (url: string | null) => void = (): void => {
+      return undefined;
+    };
+
+    getInitialUrlMock().mockImplementation((): Promise<string | null> => {
+      return new Promise((resolve: (url: string | null) => void): void => {
+        resolveInitialUrl = resolve;
+      });
+    });
+
+    startSsoCallbackCapture();
+    emitUrlEvent(CALLBACK_URL);
+
+    resolveInitialUrl(null);
+
+    await expect(consumeInitialSsoCallbackUrl()).resolves.toBe(CALLBACK_URL);
+  });
+});
+
+describe("waitForSsoCallbackUrl", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    startSsoCallbackCapture();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("resolves straight away with an already-pending URL", async () => {
+    /*
+     * The normal case on both platforms: the event landed while the browser was
+     * closing, so the answer is already in hand and no grace period is needed.
+     */
+    emitUrlEvent(CALLBACK_URL);
+
+    await expect(waitForSsoCallbackUrl(SSO_CALLBACK_GRACE_MS)).resolves.toBe(
+      CALLBACK_URL,
+    );
+  });
+
+  test("consumes the pending URL it returns", async () => {
+    emitUrlEvent(CALLBACK_URL);
+
+    await expect(waitForSsoCallbackUrl(SSO_CALLBACK_GRACE_MS)).resolves.toBe(
+      CALLBACK_URL,
+    );
+
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+  });
+
+  test("resolves with a URL that arrives after the wait began", async () => {
+    /*
+     * THE ANDROID DISMISS RACE. `openAuthSessionAsync` has already resolved
+     * `dismiss` with no URL, the caller is now sitting in this grace window,
+     * and the "url" event lands a moment later carrying the tokens of a login
+     * that actually succeeded. Without this the user sees "login cancelled".
+     */
+    const observed: { value?: string | null } = {};
+
+    const waited: Promise<string | null> = waitForSsoCallbackUrl(1500).then(
+      (url: string | null): string | null => {
+        observed.value = url;
+        return url;
+      },
+    );
+
+    await flushMicrotasks();
+    expect(observed.value).toBeUndefined();
+
+    jest.advanceTimersByTime(1200);
+    await flushMicrotasks();
+    expect(observed.value).toBeUndefined();
+
+    emitUrlEvent(CALLBACK_URL);
+
+    await expect(waited).resolves.toBe(CALLBACK_URL);
+  });
+
+  test("a URL handed to a waiter is not also left pending", async () => {
+    /*
+     * Delivered exactly once: if it stayed in the pending slot as well, the
+     * next auth session would open on top of a stale success.
+     */
+    const waited: Promise<string | null> = waitForSsoCallbackUrl(1500);
+
+    emitUrlEvent(CALLBACK_URL);
+
+    await expect(waited).resolves.toBe(CALLBACK_URL);
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+  });
+
+  test("resolves null once the grace period expires with nothing arriving", async () => {
+    /*
+     * A genuinely cancelled login. The wait has to end - a promise that never
+     * settles leaves the login button spinning forever.
+     */
+    const observed: { value?: string | null } = {};
+
+    const waited: Promise<string | null> = waitForSsoCallbackUrl(1500).then(
+      (url: string | null): string | null => {
+        observed.value = url;
+        return url;
+      },
+    );
+
+    jest.advanceTimersByTime(1499);
+    await flushMicrotasks();
+    expect(observed.value).toBeUndefined();
+
+    jest.advanceTimersByTime(1);
+
+    await expect(waited).resolves.toBeNull();
+  });
+
+  test("waits SSO_CALLBACK_GRACE_MS by default", async () => {
+    const observed: { value?: string | null } = {};
+
+    const waited: Promise<string | null> = waitForSsoCallbackUrl().then(
+      (url: string | null): string | null => {
+        observed.value = url;
+        return url;
+      },
+    );
+
+    jest.advanceTimersByTime(SSO_CALLBACK_GRACE_MS - 1);
+    await flushMicrotasks();
+    expect(observed.value).toBeUndefined();
+
+    jest.advanceTimersByTime(1);
+
+    await expect(waited).resolves.toBeNull();
+  });
+
+  test("does not leak the waiter once it has timed out", async () => {
+    /*
+     * A timed-out waiter left in the list would swallow the NEXT callback:
+     * delivery clears the pending slot for whoever is waiting, and this dead
+     * waiter would take it and drop it on the floor. So the late URL must end
+     * up pending, not consumed by a ghost.
+     */
+    await expect(waitForSsoCallbackUrlAfterTimeout(1500)).resolves.toBeNull();
+
+    expect((): void => {
+      return emitUrlEvent(CALLBACK_URL);
+    }).not.toThrow();
+
+    expect(consumePendingSsoCallbackUrl()).toBe(CALLBACK_URL);
+  });
+
+  test("a fresh waiter after a timeout still receives its URL", async () => {
+    await expect(waitForSsoCallbackUrlAfterTimeout(1500)).resolves.toBeNull();
+
+    const waited: Promise<string | null> = waitForSsoCallbackUrl(1500);
+
+    emitUrlEvent(CALLBACK_URL);
+
+    await expect(waited).resolves.toBe(CALLBACK_URL);
+  });
+
+  test("two concurrent waiters both receive the URL", async () => {
+    /*
+     * The auth-session grace wait and a screen re-checking on focus can both be
+     * waiting on the same login. Neither may be starved by the other.
+     */
+    const first: Promise<string | null> = waitForSsoCallbackUrl(1500);
+    const second: Promise<string | null> = waitForSsoCallbackUrl(1500);
+
+    emitUrlEvent(CALLBACK_URL);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      CALLBACK_URL,
+      CALLBACK_URL,
+    ]);
+  });
+
+  test("an unrelated deep link does not end the wait early", async () => {
+    const observed: { value?: string | null } = {};
+
+    const waited: Promise<string | null> = waitForSsoCallbackUrl(1500).then(
+      (url: string | null): string | null => {
+        observed.value = url;
+        return url;
+      },
+    );
+
+    emitUrlEvent(INCIDENT_DEEP_LINK);
+    await flushMicrotasks();
+    expect(observed.value).toBeUndefined();
+
+    emitUrlEvent(CALLBACK_URL);
+
+    await expect(waited).resolves.toBe(CALLBACK_URL);
+  });
+});
+
+/** Runs a wait all the way to its timeout under fake timers. */
+async function waitForSsoCallbackUrlAfterTimeout(
+  timeoutMs: number,
+): Promise<string | null> {
+  const waited: Promise<string | null> = waitForSsoCallbackUrl(timeoutMs);
+
+  await flushMicrotasks();
+  jest.advanceTimersByTime(timeoutMs);
+
+  return waited;
+}
+
+describe("stopSsoCallbackCapture", () => {
+  test("removes the subscription", () => {
+    startSsoCallbackCapture();
+    stopSsoCallbackCapture();
+
+    expect(removeSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  test("clears any captured callback", () => {
+    /*
+     * Called on sign-out. A callback surviving it would sign the next user in
+     * as the previous one.
+     */
+    startSsoCallbackCapture();
+    emitUrlEvent(CALLBACK_URL);
+
+    stopSsoCallbackCapture();
+
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+  });
+
+  test("is harmless when capture was never started", () => {
+    expect((): void => {
+      return stopSsoCallbackCapture();
+    }).not.toThrow();
+
+    expect(removeSubscription).not.toHaveBeenCalled();
+  });
+
+  test("does not remove the subscription twice", () => {
+    startSsoCallbackCapture();
+    stopSsoCallbackCapture();
+    stopSsoCallbackCapture();
+
+    expect(removeSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  test("a restart subscribes again, so events are heard once more", () => {
+    startSsoCallbackCapture();
+    stopSsoCallbackCapture();
+    startSsoCallbackCapture();
+
+    expect(addEventListenerMock()).toHaveBeenCalledTimes(2);
+
+    emitUrlEvent(CALLBACK_URL);
+
+    expect(consumePendingSsoCallbackUrl()).toBe(CALLBACK_URL);
+  });
+
+  test("an in-flight wait still settles rather than hanging", async () => {
+    /*
+     * Stopping drops the waiter list. The timeout is what guarantees the caller
+     * is not left awaiting a promise nobody can resolve any more.
+     */
+    jest.useFakeTimers();
+
+    try {
+      startSsoCallbackCapture();
+
+      const waited: Promise<string | null> = waitForSsoCallbackUrl(1500);
+
+      stopSsoCallbackCapture();
+
+      await flushMicrotasks();
+      jest.advanceTimersByTime(1500);
+
+      await expect(waited).resolves.toBeNull();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe(`the capture behaves identically on ${Platform.OS}`, () => {
+  /*
+   * This suite name is the only thing in the file that mentions the platform,
+   * and it is there so the two Jest projects are visibly running the same
+   * end-to-end path. Nothing below branches on Platform.OS, because the module
+   * does not either: the Android dismiss race is the reason the grace wait
+   * exists, but an iOS ASWebAuthenticationSession that is dismissed at the
+   * wrong moment needs exactly the same net.
+   */
+  test("captures a callback, hands it to a waiter, and forgets it", async () => {
+    startSsoCallbackCapture();
+
+    const waited: Promise<string | null> = waitForSsoCallbackUrl(50);
+
+    emitUrlEvent(CALLBACK_URL);
+
+    await expect(waited).resolves.toBe(CALLBACK_URL);
+    expect(consumePendingSsoCallbackUrl()).toBeNull();
+
+    stopSsoCallbackCapture();
+
+    expect(removeSubscription).toHaveBeenCalledTimes(1);
+  });
+});

--- a/MobileApp/src/sso/deepLink.ts
+++ b/MobileApp/src/sso/deepLink.ts
@@ -1,0 +1,209 @@
+/*
+ * App-wide capture of the `oneuptime://sso-callback` deep link.
+ *
+ * WHY THIS EXISTS
+ *
+ * `WebBrowser.openAuthSessionAsync` is not a reliable way to receive the SSO
+ * callback on its own, and it fails differently on each platform:
+ *
+ * - ANDROID. `openAuthSessionAsync` is a JS polyfill that races two promises
+ *   (expo-web-browser/build/WebBrowser.js): one resolves `success` from a
+ *   `Linking` "url" event, the other resolves `dismiss` from an AppState
+ *   change back to "active". The redirect out of Chrome Custom Tabs triggers
+ *   BOTH. When the AppState side wins, a login that completed perfectly
+ *   resolves as `dismiss` with no URL, and the tokens are dropped on the
+ *   floor. It is a race, so it is intermittent - the worst kind of auth bug.
+ *
+ * - BOTH PLATFORMS. If the OS kills the app while the user is at the IdP
+ *   (routine on Android under memory pressure), the promise dies with the
+ *   process. The IdP still redirects, the app cold-starts on the callback URL,
+ *   and nothing is listening.
+ *
+ * So the deep link is captured here, independently of whoever opened the
+ * browser, and screens ask this module for the result instead of trusting the
+ * promise alone. The listener is additive - expo-web-browser keeps its own,
+ * and React Native delivers "url" to every subscriber.
+ */
+
+import * as Linking from "expo-linking";
+import { isSsoCallbackUrl } from "./callbackUrl";
+
+/*
+ * Structural, so this module does not depend on which subscription class the
+ * installed expo-linking happens to return.
+ */
+interface RemovableSubscription {
+  remove: () => void;
+}
+
+let pendingCallbackUrl: string | null = null;
+let subscription: RemovableSubscription | null = null;
+let waiters: Array<(url: string) => void> = [];
+
+/*
+ * Resolves once `getInitialURL()` has been read. Kept at module scope and
+ * never reset, so a launch URL cannot be lost to a listener being torn down
+ * and re-registered (which React does on every StrictMode remount).
+ */
+let initialUrlSettled: Promise<void> | null = null;
+
+function handleIncomingUrl(url: string | null | undefined): void {
+  if (!isSsoCallbackUrl(url)) {
+    return;
+  }
+
+  pendingCallbackUrl = url!;
+
+  /*
+   * Hand the URL to anyone already waiting and clear the pending slot in the
+   * same breath, so it is delivered exactly once.
+   */
+  if (waiters.length > 0) {
+    const toNotify: Array<(url: string) => void> = waiters;
+    waiters = [];
+    pendingCallbackUrl = null;
+
+    for (const waiter of toNotify) {
+      waiter(url!);
+    }
+  }
+}
+
+/**
+ * Starts listening for SSO callback deep links. Safe to call more than once -
+ * the second call is a no-op rather than a second subscription.
+ *
+ * Also drains `getInitialURL()`, which is how the callback arrives when the
+ * app was killed mid-login and cold-started by the redirect.
+ */
+export function startSsoCallbackCapture(): void {
+  if (subscription) {
+    return;
+  }
+
+  subscription = Linking.addEventListener(
+    "url",
+    (event: { url: string }): void => {
+      handleIncomingUrl(event.url);
+    },
+  );
+
+  if (!initialUrlSettled) {
+    initialUrlSettled = Linking.getInitialURL()
+      .then((url: string | null): void => {
+        handleIncomingUrl(url);
+      })
+      .catch((): void => {
+        // A launch URL we cannot read is indistinguishable from no launch URL.
+      });
+  }
+}
+
+/**
+ * Awaits the launch-URL read, then returns a captured callback if the app was
+ * cold-started by one.
+ *
+ * `getInitialURL()` is asynchronous, so a synchronous
+ * `consumePendingSsoCallbackUrl()` immediately after startup would usually run
+ * before the URL had been read and miss it. Startup code must use this.
+ */
+export async function consumeInitialSsoCallbackUrl(): Promise<string | null> {
+  startSsoCallbackCapture();
+
+  if (initialUrlSettled) {
+    await initialUrlSettled;
+  }
+
+  return consumePendingSsoCallbackUrl();
+}
+
+/** Tears the listener down. Exists for tests and for a full sign-out. */
+export function stopSsoCallbackCapture(): void {
+  if (subscription) {
+    subscription.remove();
+    subscription = null;
+  }
+
+  waiters = [];
+  pendingCallbackUrl = null;
+}
+
+/**
+ * Test-only: forgets that the launch URL was ever read, so a suite can drive
+ * the cold-start path more than once.
+ */
+export function resetSsoCallbackCaptureForTesting(): void {
+  stopSsoCallbackCapture();
+  initialUrlSettled = null;
+}
+
+/**
+ * Returns the captured callback URL, if any, and clears it. A callback is
+ * consumed exactly once - two screens cannot both act on the same login.
+ */
+export function consumePendingSsoCallbackUrl(): string | null {
+  const url: string | null = pendingCallbackUrl;
+  pendingCallbackUrl = null;
+  return url;
+}
+
+/**
+ * Drops any captured callback without acting on it. Called before opening a
+ * new auth session so a stale URL from an earlier attempt cannot be mistaken
+ * for the result of this one.
+ */
+export function clearPendingSsoCallbackUrl(): void {
+  pendingCallbackUrl = null;
+}
+
+/*
+ * How long to keep waiting for the "url" event after the auth session promise
+ * has already resolved without one. This only runs on the Android
+ * dismiss-race path; the event is normally already in hand, in which case the
+ * wait returns synchronously on the next tick.
+ */
+export const SSO_CALLBACK_GRACE_MS: number = 1500;
+
+/**
+ * Resolves with a captured callback URL, or null if none arrives within
+ * `timeoutMs`.
+ *
+ * Call this whenever the auth session resolves as anything other than an
+ * outright success: on Android that result may be a `dismiss` that actually
+ * was a successful login.
+ */
+export function waitForSsoCallbackUrl(
+  timeoutMs: number = SSO_CALLBACK_GRACE_MS,
+): Promise<string | null> {
+  const alreadyPending: string | null = consumePendingSsoCallbackUrl();
+
+  if (alreadyPending) {
+    return Promise.resolve(alreadyPending);
+  }
+
+  return new Promise((resolve: (url: string | null) => void): void => {
+    let settled: boolean = false;
+
+    const waiter: (url: string) => void = (url: string): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(url);
+    };
+
+    const timer: ReturnType<typeof setTimeout> = setTimeout((): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      waiters = waiters.filter((candidate: (url: string) => void): boolean => {
+        return candidate !== waiter;
+      });
+      resolve(null);
+    }, timeoutMs);
+
+    waiters.push(waiter);
+  });
+}

--- a/MobileApp/src/sso/providerUrl.test.ts
+++ b/MobileApp/src/sso/providerUrl.test.ts
@@ -1,0 +1,436 @@
+import {
+  buildSsoLoginUrl,
+  SsoProviderKind,
+  SsoProviderTarget,
+} from "./providerUrl";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * These URLs are the app's half of a contract with three Express routers:
+ *
+ *   /identity/sso/:projectId/:projectSsoId  - App/FeatureSet/Identity/API/SSO.ts
+ *   /identity/global-sso/:globalSsoId       - .../API/GlobalSSO.ts
+ *   /identity/global-oidc/:globalOidcId     - .../API/GlobalOIDC.ts
+ *
+ * Nothing type-checks that contract, and getting it wrong does not throw: the
+ * browser simply opens, shows an error page or a 404, and the login dies
+ * somewhere the app cannot see. So the paths are pinned as whole literals
+ * rather than pattern-matched.
+ *
+ * `?mobile=true` is the single most load-bearing character sequence here. The
+ * server reads it as `req.query["mobile"] === "true"` (an exact, case
+ * sensitive string compare in App/FeatureSet/Identity/Utils/MobileSso.ts), and
+ * it is the ONLY thing that makes the flow finish on `oneuptime://sso-callback`
+ * instead of rendering the web dashboard. Drop it and the user logs in
+ * successfully, in a browser sheet, and the app never hears about it.
+ *
+ * This file is platform-free by design, and the suite runs it twice (once
+ * under jest-expo/ios, once under jest-expo/android) against the same literal
+ * expectations - which is what proves the deep-link entry point is identical
+ * on both handsets.
+ */
+
+const SERVER: string = "https://oneuptime.com";
+const PROVIDER_ID: string = "6f0c7b2e-6a0f-4f0e-9b2e-1a2b3c4d5e6f";
+const PROJECT_ID: string = "1b9d4c33-8f1a-4b21-9c0e-77aa55bb33cc";
+
+/*
+ * Query parsing is done by hand on purpose. `URL` and `URLSearchParams` are
+ * polyfills in React Native, they differ between the two Jest presets' module
+ * maps, and a test for a string builder should not depend on a parser that is
+ * itself shimmed.
+ */
+function queryStringOf(url: string): string {
+  const questionMark: number = url.indexOf("?");
+
+  return questionMark === -1 ? "" : url.slice(questionMark + 1);
+}
+
+function queryParamsOf(url: string): Record<string, string> {
+  const query: string = queryStringOf(url);
+
+  if (query === "") {
+    return {};
+  }
+
+  const params: Record<string, string> = {};
+
+  for (const pair of query.split("&")) {
+    const parts: Array<string> = pair.split("=");
+    params[parts[0] ?? ""] = parts[1] ?? "";
+  }
+
+  return params;
+}
+
+/**
+ * The path segments after the host, e.g.
+ * `["identity", "global-sso", "<id>"]`. Used where the SHAPE of the path
+ * matters - a global login that grew a project segment would still "contain"
+ * everything the literal assertions look for.
+ */
+function pathSegmentsOf(url: string): Array<string> {
+  const withoutQuery: string = url.split("?")[0]!;
+  const withoutScheme: string = withoutQuery.replace(/^[a-z]+:\/\//, "");
+  const firstSlash: number = withoutScheme.indexOf("/");
+
+  if (firstSlash === -1) {
+    return [];
+  }
+
+  return withoutScheme.slice(firstSlash + 1).split("/");
+}
+
+const ALL_KINDS: Array<[string, SsoProviderTarget]> = [
+  [
+    "project",
+    { kind: "project", providerId: PROVIDER_ID, projectId: PROJECT_ID },
+  ],
+  ["global-sso", { kind: "global-sso", providerId: PROVIDER_ID }],
+  ["global-oidc", { kind: "global-oidc", providerId: PROVIDER_ID }],
+];
+
+describe("A project login carries the project in the path", () => {
+  test("hits /identity/sso/<projectId>/<providerId>", () => {
+    expect(buildSsoLoginUrl(SERVER, ALL_KINDS[0]![1])).toBe(
+      `${SERVER}/identity/sso/${PROJECT_ID}/${PROVIDER_ID}?mobile=true`,
+    );
+  });
+
+  test("puts the project id before the provider id, not after", () => {
+    /*
+     * Both ids are opaque uuids of the same shape, so swapping them produces a
+     * URL that looks perfectly plausible and 404s (or worse, matches a real
+     * project the user can see) only once the browser is already open. The
+     * router reads them positionally: /sso/:projectId/:projectSsoId.
+     */
+    const segments: Array<string> = pathSegmentsOf(
+      buildSsoLoginUrl(SERVER, {
+        kind: "project",
+        providerId: PROVIDER_ID,
+        projectId: PROJECT_ID,
+      }),
+    );
+
+    expect(segments).toEqual(["identity", "sso", PROJECT_ID, PROVIDER_ID]);
+  });
+
+  test("does not route a project login through a global router", () => {
+    const url: string = buildSsoLoginUrl(SERVER, {
+      kind: "project",
+      providerId: PROVIDER_ID,
+      projectId: PROJECT_ID,
+    });
+
+    expect(url).not.toContain("global-sso");
+    expect(url).not.toContain("global-oidc");
+  });
+
+  test("passes both ids through verbatim", () => {
+    /*
+     * ObjectIDs are uuids and need no escaping, but they must not be
+     * lower-cased, trimmed or otherwise "helped" either - the server looks
+     * them up as an exact id.
+     */
+    const url: string = buildSsoLoginUrl(SERVER, {
+      kind: "project",
+      providerId: "AAAA-bbbb-CCCC",
+      projectId: "DDDD-eeee-FFFF",
+    });
+
+    expect(url).toBe(
+      `${SERVER}/identity/sso/DDDD-eeee-FFFF/AAAA-bbbb-CCCC?mobile=true`,
+    );
+  });
+});
+
+describe("A project login without a project id fails loudly", () => {
+  /*
+   * The alternative - and what the three inlined template literals this module
+   * replaced used to do - is emitting `/identity/sso/undefined/<id>`. That is a
+   * well-formed URL, so the auth browser opens, the server rejects an id it
+   * cannot parse, and the user is shown a server error page for what is
+   * actually an app bug. Throwing keeps the failure where it was caused.
+   */
+  test("throws when projectId is missing entirely", () => {
+    expect(() => {
+      return buildSsoLoginUrl(SERVER, {
+        kind: "project",
+        providerId: PROVIDER_ID,
+      });
+    }).toThrow(/projectId/);
+  });
+
+  test("throws when projectId is explicitly undefined", () => {
+    expect(() => {
+      return buildSsoLoginUrl(SERVER, {
+        kind: "project",
+        providerId: PROVIDER_ID,
+        projectId: undefined,
+      });
+    }).toThrow(/projectId/);
+  });
+
+  test("throws on an empty-string projectId", () => {
+    /*
+     * The realistic one: a screen that reads the id out of navigation params
+     * or storage before it has loaded hands over "" rather than undefined.
+     * `/identity/sso//<providerId>` would collapse a path segment and match a
+     * different route shape entirely.
+     */
+    expect(() => {
+      return buildSsoLoginUrl(SERVER, {
+        kind: "project",
+        providerId: PROVIDER_ID,
+        projectId: "",
+      });
+    }).toThrow(/projectId/);
+  });
+
+  test("throws an Error, so a caller's catch block sees a message", () => {
+    expect(() => {
+      return buildSsoLoginUrl(SERVER, {
+        kind: "project",
+        providerId: PROVIDER_ID,
+        projectId: "",
+      });
+    }).toThrow(Error);
+  });
+});
+
+describe("A global login has no project segment at all", () => {
+  test("global SAML hits /identity/global-sso/<providerId>", () => {
+    expect(
+      buildSsoLoginUrl(SERVER, {
+        kind: "global-sso",
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(`${SERVER}/identity/global-sso/${PROVIDER_ID}?mobile=true`);
+  });
+
+  test("global OIDC hits /identity/global-oidc/<providerId>", () => {
+    expect(
+      buildSsoLoginUrl(SERVER, {
+        kind: "global-oidc",
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(`${SERVER}/identity/global-oidc/${PROVIDER_ID}?mobile=true`);
+  });
+
+  test("the two global kinds are not interchangeable", () => {
+    /*
+     * They are served by two separate routers, and discovery does not return a
+     * type field - the app decides from `kind` alone. Sending an OIDC provider
+     * id to the SAML router looks like an unknown provider, i.e. a login that
+     * fails for a reason nobody can explain.
+     */
+    const samlUrl: string = buildSsoLoginUrl(SERVER, {
+      kind: "global-sso",
+      providerId: PROVIDER_ID,
+    });
+    const oidcUrl: string = buildSsoLoginUrl(SERVER, {
+      kind: "global-oidc",
+      providerId: PROVIDER_ID,
+    });
+
+    expect(samlUrl).not.toBe(oidcUrl);
+    expect(samlUrl).not.toContain("global-oidc");
+    expect(oidcUrl).not.toContain("global-sso");
+  });
+
+  test.each([
+    ["global-sso", "global-sso"],
+    ["global-oidc", "global-oidc"],
+  ] as Array<[SsoProviderKind, string]>)(
+    "a %s URL is exactly three path segments",
+    (kind: SsoProviderKind, segment: string): void => {
+      expect(
+        pathSegmentsOf(
+          buildSsoLoginUrl(SERVER, { kind: kind, providerId: PROVIDER_ID }),
+        ),
+      ).toEqual(["identity", segment, PROVIDER_ID]);
+    },
+  );
+
+  test.each([
+    ["global-sso", "global-sso"],
+    ["global-oidc", "global-oidc"],
+  ] as Array<[SsoProviderKind, string]>)(
+    "a %s URL ignores a projectId that is passed anyway",
+    (kind: SsoProviderKind, segment: string): void => {
+      /*
+       * SSOProviderSelectScreen builds one target for a mixed list and passes
+       * `projectId` for project providers only - but a caller that always
+       * passes the currently-open project must not turn an instance-wide login
+       * into a project-scoped one. A leaked id here would grant a token for the
+       * wrong scope, silently.
+       */
+      const url: string = buildSsoLoginUrl(SERVER, {
+        kind: kind,
+        providerId: PROVIDER_ID,
+        projectId: "project-that-must-not-leak",
+      });
+
+      expect(url).toBe(
+        `${SERVER}/identity/${segment}/${PROVIDER_ID}?mobile=true`,
+      );
+      expect(url).not.toContain("project-that-must-not-leak");
+      expect(pathSegmentsOf(url)).toHaveLength(3);
+    },
+  );
+});
+
+describe("Every kind is flagged as a mobile login", () => {
+  test.each(ALL_KINDS)(
+    "a %s login sets mobile=true",
+    (_label: string, target: SsoProviderTarget): void => {
+      /*
+       * Asserted through a parse rather than a substring: `?mobile=truthy` or
+       * `?not-mobile=true` both "contain" mobile=true as text, and the server
+       * compares the parsed value with ===.
+       */
+      expect(queryParamsOf(buildSsoLoginUrl(SERVER, target))["mobile"]).toBe(
+        "true",
+      );
+    },
+  );
+
+  test.each(ALL_KINDS)(
+    "a %s login sends mobile as its only query param",
+    (_label: string, target: SsoProviderTarget): void => {
+      expect(queryStringOf(buildSsoLoginUrl(SERVER, target))).toBe(
+        "mobile=true",
+      );
+    },
+  );
+
+  test.each(ALL_KINDS)(
+    "a %s login spells the flag in lower case",
+    (_label: string, target: SsoProviderTarget): void => {
+      /*
+       * `Mobile=True` would be dropped on the floor by the server's exact
+       * compare, and the flow would end on the web dashboard with the app
+       * still sitting on its spinner.
+       */
+      const url: string = buildSsoLoginUrl(SERVER, target);
+
+      expect(url.endsWith("?mobile=true")).toBe(true);
+    },
+  );
+});
+
+describe("The server URL is normalised before the path is appended", () => {
+  test.each(ALL_KINDS)(
+    "a single trailing slash does not double up for a %s login",
+    (_label: string, target: SsoProviderTarget): void => {
+      expect(buildSsoLoginUrl(`${SERVER}/`, target)).toBe(
+        buildSsoLoginUrl(SERVER, target),
+      );
+    },
+  );
+
+  test("several trailing slashes are all removed", () => {
+    /*
+     * A user typing their self-hosted address into the server URL screen is
+     * the source of these. `https://host//identity/...` is not equivalent to
+     * `https://host/identity/...` for every reverse proxy in front of
+     * OneUptime, and a proxy that 404s here breaks login only for the people
+     * who typed the slash.
+     */
+    expect(
+      buildSsoLoginUrl(`${SERVER}///`, {
+        kind: "global-sso",
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(`${SERVER}/identity/global-sso/${PROVIDER_ID}?mobile=true`);
+  });
+
+  test.each(ALL_KINDS)(
+    "a normalised %s URL contains no empty path segment",
+    (_label: string, target: SsoProviderTarget): void => {
+      const url: string = buildSsoLoginUrl(`${SERVER}//`, target);
+
+      expect(url.replace(/^[a-z]+:\/\//, "")).not.toContain("//");
+      expect(pathSegmentsOf(url)).not.toContain("");
+    },
+  );
+
+  test("the scheme's own double slash survives normalisation", () => {
+    const url: string = buildSsoLoginUrl(SERVER, {
+      kind: "global-oidc",
+      providerId: PROVIDER_ID,
+    });
+
+    expect(url.startsWith("https://")).toBe(true);
+  });
+
+  test("a self-hosted host with a port keeps the port", () => {
+    /*
+     * The dev/self-hosted shape: http, an IP, and a port. Losing or mangling
+     * the port sends the login to a host that is not listening.
+     */
+    expect(
+      buildSsoLoginUrl("http://192.168.1.10:3002", {
+        kind: "global-sso",
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(
+      `http://192.168.1.10:3002/identity/global-sso/${PROVIDER_ID}?mobile=true`,
+    );
+  });
+
+  test("a host with a port AND a trailing slash is still normalised", () => {
+    expect(
+      buildSsoLoginUrl("http://192.168.1.10:3002/", {
+        kind: "project",
+        providerId: PROVIDER_ID,
+        projectId: PROJECT_ID,
+      }),
+    ).toBe(
+      `http://192.168.1.10:3002/identity/sso/${PROJECT_ID}/${PROVIDER_ID}?mobile=true`,
+    );
+  });
+
+  test("a bare host with no path or port works", () => {
+    expect(
+      buildSsoLoginUrl("https://oneuptime.example.com", {
+        kind: "global-oidc",
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(
+      `https://oneuptime.example.com/identity/global-oidc/${PROVIDER_ID}?mobile=true`,
+    );
+  });
+
+  test("a server hosted under a sub-path keeps that prefix", () => {
+    /*
+     * Self-hosted installs behind a path-routing proxy. The prefix is part of
+     * the server URL the user entered, so it has to survive in front of
+     * /identity - only the trailing slash is the app's business.
+     */
+    expect(
+      buildSsoLoginUrl("https://intranet.example.com/oneuptime/", {
+        kind: "global-sso",
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(
+      `https://intranet.example.com/oneuptime/identity/global-sso/${PROVIDER_ID}?mobile=true`,
+    );
+  });
+
+  test("normalisation never eats a character of the host itself", () => {
+    /*
+     * The regex is anchored to the end of the string; a greedier one would
+     * quietly truncate hosts. Asserted on a host ending in a letter that the
+     * scheme also contains, which is where a sloppy replace shows up.
+     */
+    expect(
+      buildSsoLoginUrl("https://https-example.https", {
+        kind: "global-sso",
+        providerId: PROVIDER_ID,
+      }),
+    ).toBe(
+      `https://https-example.https/identity/global-sso/${PROVIDER_ID}?mobile=true`,
+    );
+  });
+});

--- a/MobileApp/src/sso/providerUrl.ts
+++ b/MobileApp/src/sso/providerUrl.ts
@@ -1,0 +1,63 @@
+/*
+ * Builds the IdP login URLs the app opens in the auth browser.
+ *
+ * These were previously assembled inline in three screens with three slightly
+ * different template literals; the `?mobile=true` flag - which is the only
+ * thing telling the server to redirect back to `oneuptime://sso-callback`
+ * instead of rendering the web dashboard - is far too load-bearing to be
+ * copy-pasted.
+ */
+
+/**
+ * Which login flow a provider belongs to.
+ *
+ * - `project` - SAML configured inside one project's settings. Grants access
+ *   to that project only.
+ * - `global-sso` - instance-wide SAML configured on the admin dashboard.
+ * - `global-oidc` - instance-wide OIDC configured on the admin dashboard.
+ *
+ * The two global kinds are separate because they are served by two different
+ * routers (`/identity/global-sso/...` and `/identity/global-oidc/...`), and
+ * the discovery endpoints do not return a type field to tell them apart.
+ */
+export type SsoProviderKind = "project" | "global-sso" | "global-oidc";
+
+export interface SsoProviderTarget {
+  kind: SsoProviderKind;
+  providerId: string;
+  // Required for `project`, ignored for the global kinds.
+  projectId?: string | undefined;
+}
+
+/*
+ * Trailing slashes on a user-entered server URL would otherwise produce
+ * `https://host//identity/...`, which some reverse proxies do not normalise.
+ */
+function normalizeServerUrl(serverUrl: string): string {
+  return serverUrl.replace(/\/+$/, "");
+}
+
+/**
+ * Returns the URL that starts an SSO login for `target`, always flagged as a
+ * mobile login so the server ends the flow on the app's deep link.
+ *
+ * Throws for a project target with no project id - that is a programming
+ * error, and silently producing `/identity/sso/undefined/<id>` would surface
+ * later as an unexplained failure inside the browser.
+ */
+export function buildSsoLoginUrl(
+  serverUrl: string,
+  target: SsoProviderTarget,
+): string {
+  const base: string = normalizeServerUrl(serverUrl);
+
+  if (target.kind === "project") {
+    if (!target.projectId) {
+      throw new Error("projectId is required to start a project SSO login.");
+    }
+
+    return `${base}/identity/sso/${target.projectId}/${target.providerId}?mobile=true`;
+  }
+
+  return `${base}/identity/${target.kind}/${target.providerId}?mobile=true`;
+}

--- a/MobileApp/src/sso/session.test.ts
+++ b/MobileApp/src/sso/session.test.ts
@@ -1,0 +1,643 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { clearTokens, getTokens, type StoredTokens } from "../storage/keychain";
+import {
+  clearAllSsoTokens,
+  getCachedGlobalSsoToken,
+  getCachedSsoTokens,
+  getGlobalSsoToken,
+  getSsoTokens,
+} from "../storage/ssoTokens";
+import { decodeJwtPayload, isJwtExpired, type JwtPayload } from "../utils/jwt";
+import {
+  completeSsoLoginFromUrl,
+  type CompleteSsoLoginOutcome,
+} from "./session";
+import { beforeEach, describe, expect, test } from "@jest/globals";
+
+/*
+ * completeSsoLoginFromUrl is the single place a callback becomes a signed-in
+ * session. Four flows reach it - the login screen, the Settings
+ * re-authentication flow, the Android dismiss-race fallback, and a cold start
+ * after the OS killed the app mid-login - and the failure it exists to prevent
+ * is subtle: a flow that persists the auth tokens but NOT the global SSO token
+ * leaves the user simultaneously signed in and 406'd on every SSO-enforced
+ * project, with no error the app can explain.
+ *
+ * So these tests run against the real keychain and ssoTokens modules over the
+ * AsyncStorage fake from setup.ts, and assert on what is READABLE BACK
+ * afterwards. Asserting "storeGlobalSsoToken was called" would pass against a
+ * store that dropped the write on the floor; reading it back would not.
+ */
+
+/*
+ * Deliberately re-declared rather than imported: these literals ARE the
+ * on-disk contract. If a storage module renames its key, the app stops seeing
+ * tokens written by the previous build, and a test that imported the constant
+ * would happily follow the rename and stay green.
+ */
+const KEYCHAIN_STORAGE_KEY: string = "com.oneuptime.oncall.tokens";
+const SSO_TOKENS_STORAGE_KEY: string = "oneuptime_sso_tokens";
+const GLOBAL_SSO_TOKEN_STORAGE_KEY: string = "oneuptime_global_sso_token";
+
+const BASE64_ALPHABET: string =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/**
+ * ASCII -> base64url (JWT flavour: no padding, `-`/`_` for `+`/`/`).
+ *
+ * Hand-rolled for the same reason src/utils/jwt.ts hand-rolls the decode:
+ * `btoa`/`Buffer` availability differs between the Jest environment and the
+ * runtimes this app ships on, and a helper that only works here would be
+ * minting tokens the app could never actually receive. Round-tripped through
+ * the real decoder in the first test below, so a bug in it cannot quietly
+ * invalidate the rest of the file.
+ */
+function toBase64Url(value: string): string {
+  let output: string = "";
+  let buffer: number = 0;
+  let bitsInBuffer: number = 0;
+
+  for (let index: number = 0; index < value.length; index++) {
+    buffer = (buffer << 8) | (value.charCodeAt(index) & 0xff);
+    bitsInBuffer += 8;
+
+    while (bitsInBuffer >= 6) {
+      bitsInBuffer -= 6;
+      output += BASE64_ALPHABET[(buffer >> bitsInBuffer) & 0x3f];
+    }
+  }
+
+  if (bitsInBuffer > 0) {
+    output += BASE64_ALPHABET[(buffer << (6 - bitsInBuffer)) & 0x3f];
+  }
+
+  return output.replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+/**
+ * Mints a syntactically real, unsigned JWT. The app never verifies signatures
+ * (the server does), but ssoTokens.ts now EVICTS anything `isJwtExpired`
+ * rejects on read - which includes anything that is not a three-segment JWT.
+ * So a token these tests store has to be a real JWT or it would vanish for
+ * reasons that have nothing to do with the code under test.
+ */
+function mintJwt(expiresAtSeconds: number | null, subject: string): string {
+  const header: string = toBase64Url(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  );
+  const payload: string = toBase64Url(
+    JSON.stringify(
+      expiresAtSeconds === null
+        ? { sub: subject }
+        : { sub: subject, exp: expiresAtSeconds },
+    ),
+  );
+
+  return `${header}.${payload}.not-verified-by-the-app`;
+}
+
+const THIRTY_DAYS_IN_SECONDS: number = 30 * 24 * 60 * 60;
+
+/** A token the server would have just issued: valid for the usual 30 days. */
+function freshJwt(subject: string): string {
+  return mintJwt(
+    Math.floor(Date.now() / 1000) + THIRTY_DAYS_IN_SECONDS,
+    subject,
+  );
+}
+
+/** A token that lapsed an hour ago - well clear of the 30s expiry leeway. */
+function lapsedJwt(subject: string): string {
+  return mintJwt(Math.floor(Date.now() / 1000) - 3600, subject);
+}
+
+function buildCallbackUrl(params: Record<string, string>): string {
+  const query: string = Object.keys(params)
+    .map((key: string) => {
+      return `${encodeURIComponent(key)}=${encodeURIComponent(params[key]!)}`;
+    })
+    .join("&");
+
+  return `oneuptime://sso-callback?${query}`;
+}
+
+/** The three auth params every SSO callback carries, whatever its flavour. */
+function authParams(): Record<string, string> {
+  return {
+    accessToken: "access-token-abc",
+    refreshToken: "refresh-token-def",
+    refreshTokenExpiresAt: "2026-12-31T23:59:59.000Z",
+    userId: "user-1",
+    email: "responder@example.com",
+    name: "Test Responder",
+  };
+}
+
+/**
+ * Reads a key straight out of the AsyncStorage fake, bypassing the storage
+ * modules. Needed for the "stored nothing" assertions: `getSsoTokens()`
+ * returns `{}` both when nothing was ever written AND when a written token was
+ * evicted, so only the raw key can tell "we did not write" from "we wrote and
+ * then dropped it".
+ */
+async function rawStorageValue(key: string): Promise<string | null> {
+  return (await AsyncStorage.getItem(key)) as string | null;
+}
+
+async function expectNothingStored(): Promise<void> {
+  expect(await rawStorageValue(KEYCHAIN_STORAGE_KEY)).toBeNull();
+  expect(await rawStorageValue(SSO_TOKENS_STORAGE_KEY)).toBeNull();
+  expect(await rawStorageValue(GLOBAL_SSO_TOKEN_STORAGE_KEY)).toBeNull();
+}
+
+beforeEach(async () => {
+  /*
+   * The AsyncStorage fake is a module-level Map that survives between tests,
+   * and both storage modules keep in-memory caches the axios interceptor reads
+   * synchronously. Clearing the store alone would leave those caches stale, so
+   * a test could "see" a token the previous test wrote.
+   */
+  await AsyncStorage.clear();
+  await clearAllSsoTokens();
+  await clearTokens();
+});
+
+describe("The JWT helpers these tests rely on", () => {
+  test("mint tokens the app's own decoder accepts", () => {
+    /*
+     * If this is wrong every "the token was stored" assertion below could pass
+     * for the wrong reason - or fail for one.
+     */
+    const token: string = freshJwt("global-sso");
+    const payload: JwtPayload | null = decodeJwtPayload(token);
+
+    expect(payload).not.toBeNull();
+    expect(payload!["sub"]).toBe("global-sso");
+    expect(isJwtExpired(token)).toBe(false);
+  });
+
+  test("mint expired tokens the app's own decoder rejects", () => {
+    expect(isJwtExpired(lapsedJwt("global-sso"))).toBe(true);
+  });
+});
+
+describe("A Global SSO callback", () => {
+  const globalToken: string = freshJwt("global-sso");
+
+  const globalCallbackUrl: string = buildCallbackUrl({
+    ...authParams(),
+    globalSsoToken: globalToken,
+  });
+
+  test("persists the auth tokens where the API client reads them", async () => {
+    await completeSsoLoginFromUrl(globalCallbackUrl);
+
+    const stored: StoredTokens | null = await getTokens();
+
+    expect(stored).not.toBeNull();
+    expect(stored!.accessToken).toBe("access-token-abc");
+    expect(stored!.refreshToken).toBe("refresh-token-def");
+    expect(stored!.refreshTokenExpiresAt).toBe("2026-12-31T23:59:59.000Z");
+  });
+
+  test("persists the global SSO token", async () => {
+    /*
+     * THE regression this module exists to prevent. Without this write the
+     * user is signed in and every SSO-enforced project answers 406.
+     */
+    await completeSsoLoginFromUrl(globalCallbackUrl);
+
+    expect(await getGlobalSsoToken()).toBe(globalToken);
+  });
+
+  test("makes the global token visible to the synchronous cache too", async () => {
+    /*
+     * The axios interceptor reads the CACHE, not the store - it cannot await
+     * on its way out. A write that reached disk but not the cache would still
+     * send the very first request after login without the header.
+     */
+    await completeSsoLoginFromUrl(globalCallbackUrl);
+
+    expect(getCachedGlobalSsoToken()).toBe(globalToken);
+  });
+
+  test("writes no per-project token", async () => {
+    /*
+     * One global token satisfies every project, including projects created
+     * after login. Inventing a per-project entry here would pin the user to
+     * whichever project happened to be selected.
+     */
+    await completeSsoLoginFromUrl(globalCallbackUrl);
+
+    expect(await rawStorageValue(SSO_TOKENS_STORAGE_KEY)).toBeNull();
+    expect(await getSsoTokens()).toEqual({});
+  });
+
+  test("reports the login as global, with no project", async () => {
+    const outcome: CompleteSsoLoginOutcome =
+      await completeSsoLoginFromUrl(globalCallbackUrl);
+
+    expect(outcome).toEqual({
+      status: "success",
+      isGlobal: true,
+      projectId: null,
+    });
+  });
+});
+
+describe("A project SSO callback", () => {
+  const projectToken: string = freshJwt("project-sso");
+
+  const projectCallbackUrl: string = buildCallbackUrl({
+    ...authParams(),
+    ssoToken: projectToken,
+    projectId: "project-42",
+  });
+
+  test("stores the token under the project it was issued for", async () => {
+    /*
+     * Filed under the wrong id the token is never sent for the project that
+     * needs it, and IS sent for one that did not authorise it.
+     */
+    await completeSsoLoginFromUrl(projectCallbackUrl);
+
+    expect(await getSsoTokens()).toEqual({ "project-42": projectToken });
+  });
+
+  test("makes the project token visible to the synchronous cache too", async () => {
+    await completeSsoLoginFromUrl(projectCallbackUrl);
+
+    expect(getCachedSsoTokens()).toEqual({ "project-42": projectToken });
+  });
+
+  test("writes no global token", async () => {
+    /*
+     * A project login must not be promoted to instance-wide access: the
+     * global header would be sent for projects this SSO session never covered.
+     */
+    await completeSsoLoginFromUrl(projectCallbackUrl);
+
+    expect(await rawStorageValue(GLOBAL_SSO_TOKEN_STORAGE_KEY)).toBeNull();
+    expect(await getGlobalSsoToken()).toBeNull();
+  });
+
+  test("still persists the auth tokens", async () => {
+    await completeSsoLoginFromUrl(projectCallbackUrl);
+
+    expect((await getTokens())!.accessToken).toBe("access-token-abc");
+  });
+
+  test("reports the login as non-global, naming the project", async () => {
+    const outcome: CompleteSsoLoginOutcome =
+      await completeSsoLoginFromUrl(projectCallbackUrl);
+
+    expect(outcome).toEqual({
+      status: "success",
+      isGlobal: false,
+      projectId: "project-42",
+    });
+  });
+
+  test("leaves an earlier project's token alone", async () => {
+    /*
+     * A responder belongs to several SSO-enforced projects and authenticates
+     * to them one at a time. If a second login replaced the map instead of
+     * merging into it, signing into project B would silently sign the user out
+     * of project A.
+     */
+    const firstToken: string = freshJwt("project-sso-a");
+
+    await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        ...authParams(),
+        ssoToken: firstToken,
+        projectId: "project-a",
+      }),
+    );
+    await completeSsoLoginFromUrl(projectCallbackUrl);
+
+    expect(await getSsoTokens()).toEqual({
+      "project-a": firstToken,
+      "project-42": projectToken,
+    });
+  });
+
+  test("a re-login for the same project replaces its token", async () => {
+    const refreshedToken: string = freshJwt("project-sso-refreshed");
+
+    await completeSsoLoginFromUrl(projectCallbackUrl);
+    await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        ...authParams(),
+        ssoToken: refreshedToken,
+        projectId: "project-42",
+      }),
+    );
+
+    expect(await getSsoTokens()).toEqual({ "project-42": refreshedToken });
+  });
+});
+
+describe("A callback carrying both a global and a project token", () => {
+  const globalToken: string = freshJwt("global-sso");
+  const projectToken: string = freshJwt("project-sso");
+
+  const bothCallbackUrl: string = buildCallbackUrl({
+    ...authParams(),
+    globalSsoToken: globalToken,
+    ssoToken: projectToken,
+    projectId: "project-42",
+  });
+
+  test("stores both, not whichever it checked first", async () => {
+    /*
+     * The shapes are not exclusive: a Global SSO login that started from a
+     * project-scoped screen comes back with both. An if/else here would drop
+     * one of them.
+     */
+    await completeSsoLoginFromUrl(bothCallbackUrl);
+
+    expect(await getGlobalSsoToken()).toBe(globalToken);
+    expect(await getSsoTokens()).toEqual({ "project-42": projectToken });
+  });
+
+  test("reports it as global AND names the project", async () => {
+    const outcome: CompleteSsoLoginOutcome =
+      await completeSsoLoginFromUrl(bothCallbackUrl);
+
+    expect(outcome).toEqual({
+      status: "success",
+      isGlobal: true,
+      projectId: "project-42",
+    });
+  });
+});
+
+describe("A callback the server marked as failed", () => {
+  test("stores nothing at all", async () => {
+    /*
+     * An error callback has no tokens to store, but it is still an
+     * `oneuptime://sso-callback` URL. Writing a partial session off one would
+     * leave the app believing it is signed in after a login that was refused.
+     */
+    await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        error: "sso_disabled",
+        errorDescription: "SSO is not enabled for this project",
+      }),
+    );
+
+    await expectNothingStored();
+  });
+
+  test("returns the server's reason, so the user is told why", async () => {
+    const outcome: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        error: "sso_disabled",
+        errorDescription: "SSO is not enabled for this project",
+      }),
+    );
+
+    expect(outcome).toEqual({
+      status: "error",
+      message: "sso_disabled: SSO is not enabled for this project",
+    });
+  });
+
+  test("returns the bare error when the server sent no description", async () => {
+    const outcome: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+      buildCallbackUrl({ error: "access_denied" }),
+    );
+
+    expect(outcome).toEqual({ status: "error", message: "access_denied" });
+  });
+
+  test("an error wins even when tokens are also present on the URL", async () => {
+    /*
+     * Defence against a server that appends `error` to an otherwise complete
+     * redirect. Tokens that arrive alongside a refusal must not be trusted.
+     */
+    const outcome: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        ...authParams(),
+        globalSsoToken: freshJwt("global-sso"),
+        error: "access_denied",
+      }),
+    );
+
+    expect(outcome.status).toBe("error");
+    await expectNothingStored();
+  });
+});
+
+describe("A callback that is not usable at all", () => {
+  test.each([
+    ["a completely unrelated URL", "https://oneuptime.com/dashboard"],
+    ["random garbage", "not-even-a-url"],
+    ["an empty string", ""],
+    [
+      "a scheme that merely starts the same way",
+      "oneuptime://sso-callback-other?accessToken=a&refreshToken=b&refreshTokenExpiresAt=c",
+    ],
+  ])(
+    "%s stores nothing and reports an error",
+    async (_label: string, url: string) => {
+      const outcome: CompleteSsoLoginOutcome =
+        await completeSsoLoginFromUrl(url);
+
+      expect(outcome.status).toBe("error");
+      await expectNothingStored();
+    },
+  );
+
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+  ])(
+    "%s stores nothing and reports an error",
+    async (_label: string, url: string | null | undefined) => {
+      /*
+       * Both are real inputs: the Android dismiss-race fallback and the cold
+       * start path both hand over whatever `Linking` gave them, which is null
+       * when there was nothing pending.
+       */
+      const outcome: CompleteSsoLoginOutcome =
+        await completeSsoLoginFromUrl(url);
+
+      expect(outcome.status).toBe("error");
+      await expectNothingStored();
+    },
+  );
+
+  test("a callback missing the refresh token stores no half-session", async () => {
+    /*
+     * Half a token set is worse than none: the access token expires in
+     * minutes and without the refresh token there is no way back, so the app
+     * would sign the user out at a random moment instead of at login.
+     */
+    const outcome: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        accessToken: "access-token-abc",
+        globalSsoToken: freshJwt("global-sso"),
+      }),
+    );
+
+    expect(outcome).toEqual({
+      status: "error",
+      message: "Authentication failed. Missing token data.",
+    });
+    await expectNothingStored();
+  });
+
+  test("a callback with no query string at all reports an error", async () => {
+    const outcome: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+      "oneuptime://sso-callback",
+    );
+
+    expect(outcome.status).toBe("error");
+    await expectNothingStored();
+  });
+});
+
+describe("A success callback whose global token has already expired", () => {
+  /*
+   * Reachable in practice: the app can be cold-started on a callback URL the
+   * OS held while the process was dead, and the same URL is re-delivered by
+   * `getInitialURL()` on later launches.
+   *
+   * Documented behaviour, not a bug: session.ts writes whatever the server
+   * sent (it does not second-guess token lifetimes), and ssoTokens.ts evicts
+   * it on the next READ. The user therefore ends up signed in with no global
+   * token - which is the state that prompts a fresh SSO login, rather than a
+   * stream of unexplained 406s.
+   */
+  const expiredGlobalToken: string = lapsedJwt("global-sso");
+
+  const expiredCallbackUrl: string = buildCallbackUrl({
+    ...authParams(),
+    globalSsoToken: expiredGlobalToken,
+  });
+
+  test("still reports success, and still persists the auth tokens", async () => {
+    const outcome: CompleteSsoLoginOutcome =
+      await completeSsoLoginFromUrl(expiredCallbackUrl);
+
+    expect(outcome).toEqual({
+      status: "success",
+      isGlobal: true,
+      projectId: null,
+    });
+    expect((await getTokens())!.accessToken).toBe("access-token-abc");
+  });
+
+  test("writes the token, but the next read evicts it", async () => {
+    await completeSsoLoginFromUrl(expiredCallbackUrl);
+
+    // It really did land on disk...
+    expect(await rawStorageValue(GLOBAL_SSO_TOKEN_STORAGE_KEY)).toBe(
+      expiredGlobalToken,
+    );
+
+    // ...and the reader refuses to hand back something the server will reject.
+    expect(await getGlobalSsoToken()).toBeNull();
+
+    // The eviction is persistent, not just a filtered read.
+    expect(await rawStorageValue(GLOBAL_SSO_TOKEN_STORAGE_KEY)).toBeNull();
+  });
+
+  test("an expired PROJECT token is evicted the same way", async () => {
+    const expiredProjectToken: string = lapsedJwt("project-sso");
+
+    await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        ...authParams(),
+        ssoToken: expiredProjectToken,
+        projectId: "project-42",
+      }),
+    );
+
+    expect(await rawStorageValue(SSO_TOKENS_STORAGE_KEY)).toBe(
+      JSON.stringify({ "project-42": expiredProjectToken }),
+    );
+    expect(await getSsoTokens()).toEqual({});
+  });
+});
+
+describe("The auth tokens are persisted first, and unconditionally", () => {
+  test("a callback with neither kind of SSO token still signs the user in", async () => {
+    /*
+     * The ordinary case for an instance with no SSO enforcement: the callback
+     * carries auth tokens and nothing else. Gating the keychain write behind
+     * an SSO token would break plain SSO logins entirely.
+     */
+    const outcome: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+      buildCallbackUrl(authParams()),
+    );
+
+    expect(outcome).toEqual({
+      status: "success",
+      isGlobal: false,
+      projectId: null,
+    });
+    expect((await getTokens())!.refreshToken).toBe("refresh-token-def");
+    expect(await rawStorageValue(SSO_TOKENS_STORAGE_KEY)).toBeNull();
+    expect(await rawStorageValue(GLOBAL_SSO_TOKEN_STORAGE_KEY)).toBeNull();
+  });
+
+  test("the keychain write happens before the SSO token writes", async () => {
+    /*
+     * Ordering matters because these are separate awaits: if the process is
+     * killed part-way through (or a write throws), the recoverable state is
+     * "signed in, SSO token missing" - the app can re-run SSO. The reverse,
+     * an SSO token with no session, is unusable and invisible.
+     */
+    await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        ...authParams(),
+        globalSsoToken: freshJwt("global-sso"),
+        ssoToken: freshJwt("project-sso"),
+        projectId: "project-42",
+      }),
+    );
+
+    const writtenKeys: Array<string> = (
+      AsyncStorage.setItem as unknown as jest.Mock
+    ).mock.calls.map((call: Array<unknown>) => {
+      return call[0] as string;
+    });
+
+    expect(writtenKeys[0]).toBe(KEYCHAIN_STORAGE_KEY);
+    expect(writtenKeys).toContain(GLOBAL_SSO_TOKEN_STORAGE_KEY);
+    expect(writtenKeys).toContain(SSO_TOKENS_STORAGE_KEY);
+  });
+
+  test("a callback with a projectId but no ssoToken writes no project entry", async () => {
+    /*
+     * Half a project pair is not a project login. Storing `undefined` (or the
+     * project id itself) under the project would put a garbage value into the
+     * `x-sso-tokens` header on every subsequent request.
+     */
+    const outcome: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+      buildCallbackUrl({ ...authParams(), projectId: "project-42" }),
+    );
+
+    expect(outcome).toEqual({
+      status: "success",
+      isGlobal: false,
+      projectId: null,
+    });
+    expect(await rawStorageValue(SSO_TOKENS_STORAGE_KEY)).toBeNull();
+  });
+
+  test("a callback with an ssoToken but no projectId writes no project entry", async () => {
+    const outcome: CompleteSsoLoginOutcome = await completeSsoLoginFromUrl(
+      buildCallbackUrl({
+        ...authParams(),
+        ssoToken: freshJwt("project-sso"),
+      }),
+    );
+
+    expect(outcome.status).toBe("success");
+    expect(await rawStorageValue(SSO_TOKENS_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/MobileApp/src/sso/session.ts
+++ b/MobileApp/src/sso/session.ts
@@ -1,0 +1,66 @@
+/*
+ * The one place an SSO callback is turned into a signed-in session.
+ *
+ * There are four ways a callback can reach the app - the login screen, the
+ * Settings re-authentication flow, the Android dismiss-race fallback, and a
+ * cold start after the OS killed the app mid-login - and every one of them has
+ * to persist exactly the same things in exactly the same order. Doing that in
+ * four places is how a flow ends up storing the auth tokens but not the global
+ * SSO token, leaving the user signed in and permission-denied at the same time.
+ */
+
+import { storeTokens } from "../storage/keychain";
+import { storeGlobalSsoToken, storeSsoToken } from "../storage/ssoTokens";
+import { parseSsoCallbackUrl, type SsoCallbackResult } from "./callbackUrl";
+
+export type CompleteSsoLoginOutcome =
+  | {
+      status: "success";
+      // True when the login produced an instance-wide Global SSO/OIDC token.
+      isGlobal: boolean;
+      // Set when the login produced a token scoped to a single project.
+      projectId: string | null;
+    }
+  | {
+      status: "error";
+      message: string;
+    };
+
+/**
+ * Persists the result of an SSO callback URL.
+ *
+ * Auth tokens are written first: without them nothing else is usable. The SSO
+ * tokens follow, and both the global and per-project shapes are handled, so a
+ * caller does not have to know which flavour of SSO the user just completed.
+ */
+export async function completeSsoLoginFromUrl(
+  url: string | null | undefined,
+): Promise<CompleteSsoLoginOutcome> {
+  const parsed: SsoCallbackResult = parseSsoCallbackUrl(url);
+
+  if (parsed.status !== "success") {
+    return {
+      status: "error",
+      message: parsed.message,
+    };
+  }
+
+  await storeTokens(parsed.tokens);
+
+  if (parsed.globalSsoToken) {
+    await storeGlobalSsoToken(parsed.globalSsoToken);
+  }
+
+  if (parsed.projectSsoToken) {
+    await storeSsoToken(
+      parsed.projectSsoToken.projectId,
+      parsed.projectSsoToken.ssoToken,
+    );
+  }
+
+  return {
+    status: "success",
+    isGlobal: Boolean(parsed.globalSsoToken),
+    projectId: parsed.projectSsoToken?.projectId || null,
+  };
+}

--- a/MobileApp/src/storage/ssoTokens.test.ts
+++ b/MobileApp/src/storage/ssoTokens.test.ts
@@ -1,0 +1,675 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  clearAllSsoTokens,
+  getCachedGlobalSsoToken,
+  getCachedSsoTokens,
+  getGlobalSsoToken,
+  getSsoTokens,
+  removeGlobalSsoToken,
+  removeSsoToken,
+  storeGlobalSsoToken,
+  storeSsoToken,
+} from "./ssoTokens";
+import { describe, expect, test, beforeEach } from "@jest/globals";
+
+/*
+ * The SSO token store is the only thing standing between a signed-in responder
+ * and a wall of 406s. The server answers 406 - with no explanation - for every
+ * request against an SSO-enforced project whose token has lapsed, so a store
+ * that keeps handing out a dead token produces an app that appears broken
+ * rather than one that asks the user to sign in again. Nearly every test below
+ * is about that eviction path, not about the round-trip.
+ *
+ * The two storage keys are the on-disk contract with every already-installed
+ * copy of the app. They are deliberately re-stated here rather than imported:
+ * the module does not export them, and a rename would silently strand the
+ * token of every user who upgrades.
+ */
+const STORAGE_KEY: string = "oneuptime_sso_tokens";
+const GLOBAL_STORAGE_KEY: string = "oneuptime_global_sso_token";
+
+const BASE64_ALPHABET: string =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/*
+ * JWTs are minted here rather than pasted in as fixtures so that every expiry
+ * case can be written relative to "now". A checked-in fixture with a real `exp`
+ * would start passing for the wrong reason - or start failing - the day it went
+ * past its own expiry.
+ *
+ * Payloads are pure ASCII JSON, so a byte is a char; no UTF-8 handling needed.
+ */
+function base64UrlEncode(value: string): string {
+  let encoded: string = "";
+
+  for (let index: number = 0; index < value.length; index += 3) {
+    const byte1: number = value.charCodeAt(index);
+    const byte2: number | undefined =
+      index + 1 < value.length ? value.charCodeAt(index + 1) : undefined;
+    const byte3: number | undefined =
+      index + 2 < value.length ? value.charCodeAt(index + 2) : undefined;
+
+    encoded += BASE64_ALPHABET.charAt(byte1 >> 2);
+    encoded += BASE64_ALPHABET.charAt(
+      ((byte1 & 0x03) << 4) | ((byte2 ?? 0) >> 4),
+    );
+
+    if (byte2 === undefined) {
+      break;
+    }
+
+    encoded += BASE64_ALPHABET.charAt(
+      ((byte2 & 0x0f) << 2) | ((byte3 ?? 0) >> 6),
+    );
+
+    if (byte3 === undefined) {
+      break;
+    }
+
+    encoded += BASE64_ALPHABET.charAt(byte3 & 0x3f);
+  }
+
+  // JWT flavour: base64url, and padding is omitted.
+  return encoded.replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+/**
+ * Mints an unsigned-but-well-formed JWT. Pass null to omit the `exp` claim
+ * entirely, which the decoder treats as "never expires".
+ */
+function mintJwt(expiresInSeconds: number | null, subject: string): string {
+  const header: string = base64UrlEncode(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  );
+
+  const claims: Record<string, unknown> = { sub: subject };
+
+  if (expiresInSeconds !== null) {
+    claims["exp"] = Math.floor(Date.now() / 1000) + expiresInSeconds;
+  }
+
+  const payload: string = base64UrlEncode(JSON.stringify(claims));
+
+  /*
+   * The app never verifies the signature - the server does - so any third
+   * segment is as good as a real one for these tests.
+   */
+  return `${header}.${payload}.not-a-real-signature`;
+}
+
+function liveToken(subject: string): string {
+  return mintJwt(60 * 60, subject);
+}
+
+function expiredToken(subject: string): string {
+  return mintJwt(-60 * 60, subject);
+}
+
+function setItemMock(): jest.Mock {
+  return AsyncStorage.setItem as unknown as jest.Mock;
+}
+
+async function persistedSsoTokens(): Promise<Record<string, unknown>> {
+  const raw: string | null = await AsyncStorage.getItem(STORAGE_KEY);
+
+  if (!raw) {
+    return {};
+  }
+
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+/*
+ * The AsyncStorage mock in src/__tests__/setup.ts is a module-level Map that
+ * survives between tests, and ssoTokens.ts holds its own in-memory caches that
+ * survive with it. Both have to be reset, or a test inherits the previous
+ * test's signed-in state.
+ */
+beforeEach(async () => {
+  await AsyncStorage.clear();
+  await clearAllSsoTokens();
+  setItemMock().mockClear();
+  (AsyncStorage.removeItem as unknown as jest.Mock).mockClear();
+});
+
+describe("per-project tokens round-trip", () => {
+  test("a stored token comes back", async () => {
+    const token: string = liveToken("project-1");
+
+    await storeSsoToken("project-1", token);
+
+    expect(await getSsoTokens()).toEqual({ "project-1": token });
+  });
+
+  test("several projects are kept side by side", async () => {
+    /*
+     * A responder can belong to more than one SSO-enforced project, each with
+     * its own token. Storing the second must not overwrite the first - that
+     * would sign the user out of project A every time they opened project B.
+     */
+    const first: string = liveToken("project-1");
+    const second: string = liveToken("project-2");
+    const third: string = liveToken("project-3");
+
+    await storeSsoToken("project-1", first);
+    await storeSsoToken("project-2", second);
+    await storeSsoToken("project-3", third);
+
+    expect(await getSsoTokens()).toEqual({
+      "project-1": first,
+      "project-2": second,
+      "project-3": third,
+    });
+  });
+
+  test("re-storing a project replaces only that project's token", async () => {
+    const original: string = liveToken("project-1");
+    const renewed: string = mintJwt(60 * 60 * 24, "project-1-renewed");
+    const untouched: string = liveToken("project-2");
+
+    await storeSsoToken("project-1", original);
+    await storeSsoToken("project-2", untouched);
+    await storeSsoToken("project-1", renewed);
+
+    expect(await getSsoTokens()).toEqual({
+      "project-1": renewed,
+      "project-2": untouched,
+    });
+  });
+
+  test("a device that has never signed in with SSO has no tokens", async () => {
+    expect(await getSsoTokens()).toEqual({});
+  });
+
+  test("tokens are persisted under the key the app has always used", async () => {
+    const token: string = liveToken("project-1");
+
+    await storeSsoToken("project-1", token);
+
+    expect(await persistedSsoTokens()).toEqual({ "project-1": token });
+  });
+});
+
+describe("the global token round-trips", () => {
+  test("a stored global token comes back", async () => {
+    const token: string = liveToken("global");
+
+    await storeGlobalSsoToken(token);
+
+    expect(await getGlobalSsoToken()).toBe(token);
+  });
+
+  test("a device with no global login has no global token", async () => {
+    expect(await getGlobalSsoToken()).toBeNull();
+  });
+
+  test("the global token is stored raw, not wrapped in JSON", async () => {
+    /*
+     * It goes out on the x-global-sso-token header verbatim. A JSON-quoted
+     * value would be rejected by the server as a malformed JWT.
+     */
+    const token: string = liveToken("global");
+
+    await storeGlobalSsoToken(token);
+
+    expect(await AsyncStorage.getItem(GLOBAL_STORAGE_KEY)).toBe(token);
+  });
+
+  test("the global token lives in its own key, clear of the per-project map", async () => {
+    const projectToken: string = liveToken("project-1");
+    const globalTokenValue: string = liveToken("global");
+
+    await storeSsoToken("project-1", projectToken);
+    await storeGlobalSsoToken(globalTokenValue);
+
+    expect(await persistedSsoTokens()).toEqual({ "project-1": projectToken });
+    expect(await getGlobalSsoToken()).toBe(globalTokenValue);
+  });
+});
+
+describe("the synchronous caches the API client reads from", () => {
+  /*
+   * The axios interceptor cannot await storage, so it reads these caches. If a
+   * cache goes stale the header is wrong, and a wrong header is a 406 - so the
+   * cache being refreshed on every read matters as much as the value itself.
+   */
+  test("storing a project token populates the cache immediately", async () => {
+    const token: string = liveToken("project-1");
+
+    await storeSsoToken("project-1", token);
+
+    expect(getCachedSsoTokens()).toEqual({ "project-1": token });
+  });
+
+  test("storing the global token populates the cache immediately", async () => {
+    const token: string = liveToken("global");
+
+    await storeGlobalSsoToken(token);
+
+    expect(getCachedGlobalSsoToken()).toBe(token);
+  });
+
+  test("getSsoTokens refreshes a cache that never saw the write", async () => {
+    /*
+     * What a cold start looks like: the token is on disk from a previous run,
+     * so the cache is empty until something reads storage.
+     */
+    const token: string = liveToken("project-1");
+
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ "project-1": token }),
+    );
+
+    expect(getCachedSsoTokens()).toEqual({});
+
+    await getSsoTokens();
+
+    expect(getCachedSsoTokens()).toEqual({ "project-1": token });
+  });
+
+  test("getGlobalSsoToken refreshes a cache that never saw the write", async () => {
+    const token: string = liveToken("global");
+
+    await AsyncStorage.setItem(GLOBAL_STORAGE_KEY, token);
+
+    expect(getCachedGlobalSsoToken()).toBeNull();
+
+    await getGlobalSsoToken();
+
+    expect(getCachedGlobalSsoToken()).toBe(token);
+  });
+
+  test("getSsoTokens empties a cache whose backing store has gone", async () => {
+    await storeSsoToken("project-1", liveToken("project-1"));
+    await AsyncStorage.removeItem(STORAGE_KEY);
+
+    await getSsoTokens();
+
+    expect(getCachedSsoTokens()).toEqual({});
+  });
+});
+
+describe("expired tokens are evicted on read", () => {
+  test("an expired project token is not returned", async () => {
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ "project-1": expiredToken("project-1") }),
+    );
+
+    expect(await getSsoTokens()).toEqual({});
+  });
+
+  test("an expired project token is deleted from storage, not just hidden", async () => {
+    /*
+     * Hiding it would be enough for this run, but the value would come back on
+     * the next cold start and the app would be stuck in the same 406 loop
+     * forever. It has to actually leave the disk.
+     */
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ "project-1": expiredToken("project-1") }),
+    );
+
+    await getSsoTokens();
+
+    expect(await persistedSsoTokens()).toEqual({});
+  });
+
+  test("a mix of expired and live tokens keeps exactly the live ones", async () => {
+    const live1: string = liveToken("project-1");
+    const live3: string = liveToken("project-3");
+
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        "project-1": live1,
+        "project-2": expiredToken("project-2"),
+        "project-3": live3,
+        "project-4": expiredToken("project-4"),
+      }),
+    );
+
+    const tokens: Record<string, string> = await getSsoTokens();
+
+    expect(tokens).toEqual({ "project-1": live1, "project-3": live3 });
+    expect(await persistedSsoTokens()).toEqual({
+      "project-1": live1,
+      "project-3": live3,
+    });
+  });
+
+  test("the cache is left holding only the live tokens too", async () => {
+    const live1: string = liveToken("project-1");
+
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        "project-1": live1,
+        "project-2": expiredToken("project-2"),
+      }),
+    );
+
+    await getSsoTokens();
+
+    expect(getCachedSsoTokens()).toEqual({ "project-1": live1 });
+  });
+
+  test("a token that is not a JWT at all counts as expired", async () => {
+    /*
+     * An unreadable token is worse than a lapsed one - the app cannot even say
+     * when it died - so it is treated identically rather than being sent and
+     * rejected.
+     */
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ "project-1": "definitely-not-a-jwt" }),
+    );
+
+    expect(await getSsoTokens()).toEqual({});
+    expect(await persistedSsoTokens()).toEqual({});
+  });
+
+  test("an empty-string token counts as expired", async () => {
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ "project-1": "" }),
+    );
+
+    expect(await getSsoTokens()).toEqual({});
+    expect(await persistedSsoTokens()).toEqual({});
+  });
+
+  test("a non-string value in the map is evicted rather than sent", async () => {
+    /*
+     * Nothing in the app writes this shape, but a value from an older build or
+     * a half-written file would otherwise reach axios as a header value and
+     * throw inside the interceptor.
+     */
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ "project-1": 42, "project-2": null }),
+    );
+
+    expect(await getSsoTokens()).toEqual({});
+    expect(await persistedSsoTokens()).toEqual({});
+  });
+
+  test("a token expiring inside the leeway window is already treated as dead", async () => {
+    /*
+     * jwt.ts retires a token 30s early so a request that is in flight when the
+     * clock crosses `exp` does not come back rejected. Ten seconds of life left
+     * is therefore no life at all.
+     */
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ "project-1": mintJwt(10, "project-1") }),
+    );
+
+    expect(await getSsoTokens()).toEqual({});
+  });
+
+  test("a well-formed token with no exp claim is kept", async () => {
+    /*
+     * The server reads a missing `exp` as "does not expire", so the client must
+     * not invent an expiry and sign the user out of a session that is fine.
+     */
+    const neverExpires: string = mintJwt(null, "project-1");
+
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ "project-1": neverExpires }),
+    );
+
+    expect(await getSsoTokens()).toEqual({ "project-1": neverExpires });
+  });
+
+  test("an all-live store is not written back", async () => {
+    /*
+     * getSsoTokens runs on every single request through the interceptor path.
+     * Re-serialising and re-writing the whole map each time would put a disk
+     * write on the hot path for no reason, so the write-back is conditional on
+     * something actually having been evicted.
+     */
+    const live1: string = liveToken("project-1");
+    const live2: string = liveToken("project-2");
+
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ "project-1": live1, "project-2": live2 }),
+    );
+    setItemMock().mockClear();
+
+    /*
+     * Asserting the returned tokens as well, so that "nothing was written" can
+     * never pass because nothing was read.
+     */
+    expect(await getSsoTokens()).toEqual({
+      "project-1": live1,
+      "project-2": live2,
+    });
+    expect(setItemMock()).not.toHaveBeenCalled();
+  });
+
+  test("an eviction does write back, exactly once", async () => {
+    const live1: string = liveToken("project-1");
+
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        "project-1": live1,
+        "project-2": expiredToken("project-2"),
+      }),
+    );
+    setItemMock().mockClear();
+
+    await getSsoTokens();
+
+    expect(setItemMock()).toHaveBeenCalledTimes(1);
+    expect(setItemMock().mock.calls[0]![0]).toBe(STORAGE_KEY);
+    expect(JSON.parse(setItemMock().mock.calls[0]![1] as string)).toEqual({
+      "project-1": live1,
+    });
+  });
+
+  test("an expired global token reads as absent", async () => {
+    await AsyncStorage.setItem(GLOBAL_STORAGE_KEY, expiredToken("global"));
+
+    expect(await getGlobalSsoToken()).toBeNull();
+  });
+
+  test("an expired global token is deleted from storage", async () => {
+    await AsyncStorage.setItem(GLOBAL_STORAGE_KEY, expiredToken("global"));
+
+    await getGlobalSsoToken();
+
+    expect(await AsyncStorage.getItem(GLOBAL_STORAGE_KEY)).toBeNull();
+  });
+
+  test("an expired global token also clears the cache the interceptor reads", async () => {
+    const token: string = expiredToken("global");
+
+    // storeGlobalSsoToken caches whatever it is handed, without judging it.
+    await storeGlobalSsoToken(token);
+    expect(getCachedGlobalSsoToken()).toBe(token);
+
+    await getGlobalSsoToken();
+
+    expect(getCachedGlobalSsoToken()).toBeNull();
+  });
+
+  test("a global value that is not a JWT is evicted too", async () => {
+    await AsyncStorage.setItem(GLOBAL_STORAGE_KEY, "garbage");
+
+    expect(await getGlobalSsoToken()).toBeNull();
+    expect(await AsyncStorage.getItem(GLOBAL_STORAGE_KEY)).toBeNull();
+  });
+
+  test("a missing global key is not needlessly removed again", async () => {
+    /*
+     * The removal is guarded on there having been a value. Without the guard
+     * every unauthenticated read would issue a pointless disk delete.
+     */
+    await getGlobalSsoToken();
+
+    expect(
+      AsyncStorage.removeItem as unknown as jest.Mock,
+    ).not.toHaveBeenCalled();
+  });
+
+  test("a live global token survives a read untouched", async () => {
+    const token: string = liveToken("global");
+
+    await storeGlobalSsoToken(token);
+    setItemMock().mockClear();
+
+    expect(await getGlobalSsoToken()).toBe(token);
+    expect(await AsyncStorage.getItem(GLOBAL_STORAGE_KEY)).toBe(token);
+    expect(
+      AsyncStorage.removeItem as unknown as jest.Mock,
+    ).not.toHaveBeenCalled();
+  });
+});
+
+describe("removing tokens", () => {
+  test("removeSsoToken drops one project and leaves the rest signed in", async () => {
+    const keep1: string = liveToken("project-1");
+    const keep3: string = liveToken("project-3");
+
+    await storeSsoToken("project-1", keep1);
+    await storeSsoToken("project-2", liveToken("project-2"));
+    await storeSsoToken("project-3", keep3);
+
+    await removeSsoToken("project-2");
+
+    expect(await getSsoTokens()).toEqual({
+      "project-1": keep1,
+      "project-3": keep3,
+    });
+    expect(await persistedSsoTokens()).toEqual({
+      "project-1": keep1,
+      "project-3": keep3,
+    });
+  });
+
+  test("removeSsoToken for a project that was never stored changes nothing", async () => {
+    const token: string = liveToken("project-1");
+
+    await storeSsoToken("project-1", token);
+
+    await removeSsoToken("project-unknown");
+
+    expect(await getSsoTokens()).toEqual({ "project-1": token });
+  });
+
+  test("removeSsoToken leaves the global token alone", async () => {
+    /*
+     * Signing out of one project must not sign the user out of the instance -
+     * the global token is not scoped to any project.
+     */
+    const globalTokenValue: string = liveToken("global");
+
+    await storeSsoToken("project-1", liveToken("project-1"));
+    await storeGlobalSsoToken(globalTokenValue);
+
+    await removeSsoToken("project-1");
+
+    expect(await getGlobalSsoToken()).toBe(globalTokenValue);
+  });
+
+  test("removeGlobalSsoToken clears the global token and its cache", async () => {
+    await storeGlobalSsoToken(liveToken("global"));
+
+    await removeGlobalSsoToken();
+
+    expect(await getGlobalSsoToken()).toBeNull();
+    expect(getCachedGlobalSsoToken()).toBeNull();
+    expect(await AsyncStorage.getItem(GLOBAL_STORAGE_KEY)).toBeNull();
+  });
+
+  test("removeGlobalSsoToken leaves per-project tokens signed in", async () => {
+    const projectToken: string = liveToken("project-1");
+
+    await storeSsoToken("project-1", projectToken);
+    await storeGlobalSsoToken(liveToken("global"));
+
+    await removeGlobalSsoToken();
+
+    expect(await getSsoTokens()).toEqual({ "project-1": projectToken });
+    expect(getCachedSsoTokens()).toEqual({ "project-1": projectToken });
+  });
+});
+
+describe("clearAllSsoTokens", () => {
+  test("clears both stores and both caches", async () => {
+    /*
+     * This is the logout path. Anything left behind here is a token belonging
+     * to the previous user, sitting on a shared device.
+     */
+    await storeSsoToken("project-1", liveToken("project-1"));
+    await storeSsoToken("project-2", liveToken("project-2"));
+    await storeGlobalSsoToken(liveToken("global"));
+
+    await clearAllSsoTokens();
+
+    expect(getCachedSsoTokens()).toEqual({});
+    expect(getCachedGlobalSsoToken()).toBeNull();
+    expect(await getSsoTokens()).toEqual({});
+    expect(await getGlobalSsoToken()).toBeNull();
+    expect(await AsyncStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(await AsyncStorage.getItem(GLOBAL_STORAGE_KEY)).toBeNull();
+  });
+
+  test("is safe to call when nothing was ever stored", async () => {
+    await expect(clearAllSsoTokens()).resolves.toBeUndefined();
+  });
+});
+
+describe("corrupt storage is survivable", () => {
+  /*
+   * Every one of these reaches the axios interceptor on app start. A throw
+   * there is not a failed SSO login - it is an app that cannot make any request
+   * at all, including the ones that would let the user sign in again and repair
+   * the state. Returning {} is the only safe answer.
+   */
+  test.each([
+    ["a truncated write", "{not json at all"],
+    ["a JSON array", "[]"],
+    ["a JSON array of tokens", '["token-a","token-b"]'],
+    ["a bare JSON string", '"just-a-string"'],
+    ["a JSON null", "null"],
+    ["a JSON number", "42"],
+    ["an empty string", ""],
+  ])(
+    "%s yields no tokens instead of throwing",
+    async (_label: string, stored: string): Promise<void> => {
+      await AsyncStorage.setItem(STORAGE_KEY, stored);
+
+      await expect(getSsoTokens()).resolves.toEqual({});
+    },
+  );
+
+  test("corrupt storage empties the cache rather than leaving it stale", async () => {
+    await storeSsoToken("project-1", liveToken("project-1"));
+    await AsyncStorage.setItem(STORAGE_KEY, "{not json at all");
+
+    await getSsoTokens();
+
+    expect(getCachedSsoTokens()).toEqual({});
+  });
+
+  test("a later store repairs a corrupt map", async () => {
+    /*
+     * The recovery path: the user signs in again, and the bad value is
+     * overwritten with a well-formed map rather than the app being wedged.
+     */
+    const token: string = liveToken("project-1");
+
+    await AsyncStorage.setItem(STORAGE_KEY, "{not json at all");
+
+    await storeSsoToken("project-1", token);
+
+    expect(await getSsoTokens()).toEqual({ "project-1": token });
+    expect(await persistedSsoTokens()).toEqual({ "project-1": token });
+  });
+});

--- a/MobileApp/src/storage/ssoTokens.ts
+++ b/MobileApp/src/storage/ssoTokens.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { isJwtExpired } from "../utils/jwt";
 
 const STORAGE_KEY: string = "oneuptime_sso_tokens";
 const GLOBAL_STORAGE_KEY: string = "oneuptime_global_sso_token";
@@ -35,6 +36,14 @@ export async function storeGlobalSsoToken(token: string): Promise<void> {
   await AsyncStorage.setItem(GLOBAL_STORAGE_KEY, token);
 }
 
+/*
+ * SSO tokens are signed for 30 days (Common/Server/Utils/Cookie.ts). Once one
+ * lapses the server answers 406 for every request against an SSO-enforced
+ * project, and it does not say why. Dropping an expired token on read means
+ * the app can instead see the project as un-authenticated and offer the user
+ * the one thing that fixes it: signing in again.
+ */
+
 export async function getSsoTokens(): Promise<Record<string, string>> {
   const value: string | null = await AsyncStorage.getItem(STORAGE_KEY);
 
@@ -43,18 +52,56 @@ export async function getSsoTokens(): Promise<Record<string, string>> {
     return {};
   }
 
+  let parsed: Record<string, string>;
+
   try {
-    const tokens: Record<string, string> = JSON.parse(value);
-    cachedSsoTokens = tokens;
-    return tokens;
+    parsed = JSON.parse(value);
   } catch {
     cachedSsoTokens = {};
     return {};
   }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    cachedSsoTokens = {};
+    return {};
+  }
+
+  const live: Record<string, string> = {};
+  let evictedAny: boolean = false;
+
+  for (const projectId of Object.keys(parsed)) {
+    const token: string = parsed[projectId]!;
+
+    if (typeof token === "string" && !isJwtExpired(token)) {
+      live[projectId] = token;
+    } else {
+      evictedAny = true;
+    }
+  }
+
+  cachedSsoTokens = live;
+
+  // Write back only when something actually lapsed, to keep reads cheap.
+  if (evictedAny) {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(live));
+  }
+
+  return live;
 }
 
 export async function getGlobalSsoToken(): Promise<string | null> {
   const value: string | null = await AsyncStorage.getItem(GLOBAL_STORAGE_KEY);
+
+  if (!value || isJwtExpired(value)) {
+    cachedGlobalSsoToken = null;
+
+    if (value) {
+      await AsyncStorage.removeItem(GLOBAL_STORAGE_KEY);
+    }
+
+    return null;
+  }
+
   cachedGlobalSsoToken = value;
   return value;
 }
@@ -64,6 +111,11 @@ export async function removeSsoToken(projectId: string): Promise<void> {
   delete tokens[projectId];
   cachedSsoTokens = tokens;
   await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(tokens));
+}
+
+export async function removeGlobalSsoToken(): Promise<void> {
+  cachedGlobalSsoToken = null;
+  await AsyncStorage.removeItem(GLOBAL_STORAGE_KEY);
 }
 
 export async function clearAllSsoTokens(): Promise<void> {

--- a/MobileApp/src/utils/jwt.test.ts
+++ b/MobileApp/src/utils/jwt.test.ts
@@ -1,0 +1,477 @@
+import {
+  JwtPayload,
+  decodeBase64Url,
+  decodeJwtPayload,
+  isJwtExpired,
+} from "./jwt";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * This module is the only thing standing between a lapsed 30-day SSO token and
+ * an opaque 406 from the server. It hand-rolls base64url AND UTF-8 because
+ * neither `atob` nor `TextDecoder` is guaranteed on every React Native runtime
+ * the app ships on, so there is no platform implementation underneath to catch
+ * a mistake - every byte of the decode is this file's responsibility.
+ *
+ * The failure that matters is not "throws". It is "quietly returns the wrong
+ * thing": a mangled `exp` reads as a token that never expires, and the app then
+ * keeps a dead token forever and re-sends it on every request instead of
+ * sending the user back through the IdP.
+ */
+
+/*
+ * Encoders local to the test, deliberately written as the INVERSE of the code
+ * under test rather than by calling it. Reusing the module's own tables would
+ * make a wrong table agree with itself.
+ *
+ * Node's Buffer is not typed in this project (tsconfig pins `types` to
+ * nativewind and jest) and is not present on a device either, so the encoders
+ * are plain JS.
+ */
+const BASE64_CHARS: string =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+function utf8Bytes(value: string): Array<number> {
+  const bytes: Array<number> = [];
+
+  // Iterating a string with for...of yields whole code points, not UTF-16 units.
+  for (const char of value) {
+    const codePoint: number = char.codePointAt(0)!;
+
+    if (codePoint < 0x80) {
+      bytes.push(codePoint);
+    } else if (codePoint < 0x800) {
+      bytes.push(0xc0 | (codePoint >> 6), 0x80 | (codePoint & 0x3f));
+    } else if (codePoint < 0x10000) {
+      bytes.push(
+        0xe0 | (codePoint >> 12),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f),
+      );
+    } else {
+      bytes.push(
+        0xf0 | (codePoint >> 18),
+        0x80 | ((codePoint >> 12) & 0x3f),
+        0x80 | ((codePoint >> 6) & 0x3f),
+        0x80 | (codePoint & 0x3f),
+      );
+    }
+  }
+
+  return bytes;
+}
+
+/** Standard base64, `=` padding included. */
+function base64Encode(bytes: Array<number>): string {
+  let encoded: string = "";
+
+  for (let index: number = 0; index < bytes.length; index += 3) {
+    const byte1: number = bytes[index]!;
+    const byte2: number | undefined = bytes[index + 1];
+    const byte3: number | undefined = bytes[index + 2];
+
+    encoded += BASE64_CHARS[byte1 >> 2];
+    encoded += BASE64_CHARS[((byte1 & 0x03) << 4) | ((byte2 ?? 0) >> 4)];
+    encoded +=
+      byte2 === undefined
+        ? "="
+        : BASE64_CHARS[((byte2 & 0x0f) << 2) | ((byte3 ?? 0) >> 6)];
+    encoded += byte3 === undefined ? "=" : BASE64_CHARS[byte3 & 0x3f];
+  }
+
+  return encoded;
+}
+
+/** JWT flavour: url-safe alphabet, padding stripped. */
+function base64UrlEncode(value: string): string {
+  return base64Encode(utf8Bytes(value))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/[=]+$/, "");
+}
+
+/** Standard base64 of a string, padding kept. */
+function base64EncodePadded(value: string): string {
+  return base64Encode(utf8Bytes(value));
+}
+
+const JWT_HEADER: string = base64UrlEncode('{"alg":"HS256","typ":"JWT"}');
+
+/*
+ * A signature the module must never look at - it does not verify anything, the
+ * server does. Any opaque segment will do.
+ */
+const JWT_SIGNATURE: string = "c2lnbmF0dXJlLWdvZXMtaGVyZQ";
+
+function makeJwtFromPayloadJson(payloadJson: string): string {
+  return `${JWT_HEADER}.${base64UrlEncode(payloadJson)}.${JWT_SIGNATURE}`;
+}
+
+function makeJwt(payload: Record<string, unknown>): string {
+  return makeJwtFromPayloadJson(JSON.stringify(payload));
+}
+
+/*
+ * A fixed instant so nothing here depends on the wall clock. Every `exp` below
+ * is derived from it, so the leeway assertions mean the same thing on a CI box
+ * that is a minute out of sync as on a laptop.
+ */
+const NOW_MS: number = 1700000000000;
+const NOW_SECONDS: number = NOW_MS / 1000;
+
+describe("the test's own encoders match the published base64 vectors", () => {
+  /*
+   * Everything below trusts these helpers to produce correct input. If the
+   * encoders were wrong, a broken decoder could still round-trip and every
+   * other test in this file would pass for the wrong reason. These are the
+   * RFC 4648 examples, so they pin the helpers to something external.
+   */
+  test("encodes the three padding cases", () => {
+    expect(base64EncodePadded("Man")).toBe("TWFu");
+    expect(base64EncodePadded("Ma")).toBe("TWE=");
+    expect(base64EncodePadded("M")).toBe("TQ==");
+  });
+
+  test("strips padding and swaps the alphabet for the url-safe form", () => {
+    expect(base64UrlEncode("Ma")).toBe("TWE");
+    expect(base64UrlEncode("ab>")).toBe("YWI-");
+    expect(base64UrlEncode("ab?")).toBe("YWI_");
+  });
+});
+
+describe("decodeBase64Url", () => {
+  test("decodes plain ASCII", () => {
+    expect(decodeBase64Url(base64UrlEncode("hello world"))).toBe("hello world");
+  });
+
+  test("accepts the url-safe alphabet, where - and _ stand in for + and /", () => {
+    /*
+     * The whole reason the module normalises before decoding. These two
+     * literals are standard base64 "YWI+" and "YWI/" rewritten JWT-style; a
+     * decoder that never did the substitution would hit a character outside
+     * the alphabet and return null for a perfectly good token.
+     */
+    expect(decodeBase64Url("YWI-")).toBe("ab>");
+    expect(decodeBase64Url("YWI_")).toBe("ab?");
+  });
+
+  test("decodes with = padding present", () => {
+    /*
+     * JWTs arrive unpadded, but nothing stops an IdP from padding, and the
+     * module is also used on segments copied out of other tooling.
+     */
+    expect(decodeBase64Url("TWFu")).toBe("Man");
+    expect(decodeBase64Url("TWE=")).toBe("Ma");
+    expect(decodeBase64Url("TQ==")).toBe("M");
+  });
+
+  test("decodes with the padding stripped, as JWTs actually ship it", () => {
+    expect(decodeBase64Url("TWE")).toBe("Ma");
+    expect(decodeBase64Url("TQ")).toBe("M");
+  });
+
+  test("decodes two-byte UTF-8, e.g. an accented name in a claim", () => {
+    /*
+     * String.fromCharCode over raw bytes - the obvious shortcut - turns "José"
+     * into "JosÃ©". Display names and emails in an SSO assertion are full of
+     * these.
+     */
+    const decoded: string | null = decodeBase64Url(
+      base64UrlEncode("José Müller"),
+    );
+
+    expect(decoded).toBe("José Müller");
+  });
+
+  test("decodes three-byte UTF-8, e.g. CJK characters", () => {
+    const decoded: string | null = decodeBase64Url(base64UrlEncode("日本語"));
+
+    expect(decoded).toBe("日本語");
+    expect(decoded).toHaveLength(3);
+  });
+
+  test("decodes four-byte UTF-8 into a correct surrogate pair", () => {
+    /*
+     * The only branch that has to synthesise TWO UTF-16 units from one code
+     * point. Getting the 0x10000 offset or the 10-bit split wrong yields a
+     * lone surrogate: a string that still compares unequal, still has length
+     * 2, and only looks wrong once something tries to render it.
+     */
+    const decoded: string | null = decodeBase64Url(base64UrlEncode("😀"));
+
+    expect(decoded).toBe("😀");
+    expect(decoded).toHaveLength(2);
+    expect(decoded!.charCodeAt(0)).toBe(0xd83d);
+    expect(decoded!.charCodeAt(1)).toBe(0xde00);
+    expect(decoded!.codePointAt(0)).toBe(0x1f600);
+  });
+
+  test("decodes a mixture of all four widths in one string", () => {
+    const original: string = "a é 日 😀 z";
+
+    expect(decodeBase64Url(base64UrlEncode(original))).toBe(original);
+  });
+
+  test("decodes the empty string to the empty string, not null", () => {
+    /*
+     * "" is a legitimate encoding of zero bytes. Returning null here would
+     * make an empty-but-valid segment indistinguishable from a corrupt one.
+     */
+    expect(decodeBase64Url("")).toBe("");
+  });
+
+  test("returns null - never throws - on a character outside the alphabet", () => {
+    /*
+     * The contract every caller relies on: an unreadable token is a value to
+     * be handled, not an exception to be caught. A throw here surfaces as a
+     * redbox on a screen that was only trying to decide whether to refresh.
+     */
+    expect((): string | null => {
+      return decodeBase64Url("YWI!");
+    }).not.toThrow();
+
+    expect(decodeBase64Url("YWI!")).toBeNull();
+    expect(decodeBase64Url("hello world")).toBeNull();
+    expect(decodeBase64Url("YW.I")).toBeNull();
+    expect(decodeBase64Url("YW\nI")).toBeNull();
+  });
+
+  test("returns null for a truncated multi-byte sequence", () => {
+    /*
+     * "ww==" is the single byte 0xC3 - the lead byte of a two-byte sequence
+     * with its continuation byte missing. Valid base64, invalid UTF-8, and
+     * exactly what a token clipped by a bad deep-link parse looks like.
+     */
+    expect(decodeBase64Url("ww==")).toBeNull();
+  });
+
+  test("stops at padding rather than reading past it", () => {
+    expect(decodeBase64Url("TWFu")).toBe("Man");
+    expect(decodeBase64Url("TWFu=")).toBe("Man");
+  });
+});
+
+describe("decodeJwtPayload", () => {
+  test("reads the claims out of a real three-segment token", () => {
+    const token: string = makeJwt({
+      userId: "e6f1b8a2-0000-4000-8000-000000000001",
+      email: "responder@example.com",
+      exp: NOW_SECONDS + 3600,
+    });
+
+    const payload: JwtPayload | null = decodeJwtPayload(token);
+
+    expect(payload).not.toBeNull();
+    expect(payload!["userId"]).toBe("e6f1b8a2-0000-4000-8000-000000000001");
+    expect(payload!["email"]).toBe("responder@example.com");
+    expect(payload!.exp).toBe(NOW_SECONDS + 3600);
+  });
+
+  test("reads the middle segment, not the header and not the signature", () => {
+    /*
+     * Off-by-one on the segment index is a silent bug: the header is also
+     * valid base64url JSON, so it parses cleanly and simply has no exp - which
+     * would make every token look permanently valid.
+     */
+    const payload: JwtPayload | null = decodeJwtPayload(
+      makeJwt({ claim: "payload" }),
+    );
+
+    expect(payload!["claim"]).toBe("payload");
+    expect(payload!["alg"]).toBeUndefined();
+    expect(payload!["typ"]).toBeUndefined();
+  });
+
+  test("keeps non-ASCII claims intact", () => {
+    const payload: JwtPayload | null = decodeJwtPayload(
+      makeJwt({ name: "Zoë 日本 😀" }),
+    );
+
+    expect(payload!["name"]).toBe("Zoë 日本 😀");
+  });
+
+  test.each([
+    ["one segment", JWT_HEADER],
+    ["two segments", `${JWT_HEADER}.${base64UrlEncode('{"exp":1}')}`],
+    [
+      "four segments",
+      `${JWT_HEADER}.${base64UrlEncode('{"exp":1}')}.${JWT_SIGNATURE}.extra`,
+    ],
+  ])(
+    "returns null for a token with %s",
+    (_label: string, token: string): void => {
+      /*
+       * A two-segment string is what an unsigned/half-copied token looks like,
+       * and a four-segment one is a JWE. Neither is something this reader can
+       * make sense of, and guessing at the payload position would be worse
+       * than declining.
+       */
+      expect(decodeJwtPayload(token)).toBeNull();
+    },
+  );
+
+  test("returns null when the payload segment is not valid base64url", () => {
+    expect(decodeJwtPayload(`${JWT_HEADER}.!!!.${JWT_SIGNATURE}`)).toBeNull();
+  });
+
+  test("returns null when the payload is not valid JSON", () => {
+    expect(
+      decodeJwtPayload(makeJwtFromPayloadJson("{not json at all")),
+    ).toBeNull();
+    expect(decodeJwtPayload(makeJwtFromPayloadJson(""))).toBeNull();
+  });
+
+  test.each([
+    ["an array", "[1,2,3]"],
+    ["a bare number", "42"],
+    ["a bare string", '"a-string"'],
+    ["a bare boolean", "true"],
+    ["null", "null"],
+  ])(
+    "returns null when the payload is valid JSON but %s",
+    (_label: string, payloadJson: string): void => {
+      /*
+       * Only objects are claim sets. If an array leaked through, `payload.exp`
+       * would be undefined and isJwtExpired would report a nonsense token as
+       * perfectly valid - the exact failure this module exists to prevent.
+       */
+      expect(decodeJwtPayload(makeJwtFromPayloadJson(payloadJson))).toBeNull();
+    },
+  );
+
+  test("returns null for the empty string", () => {
+    expect(decodeJwtPayload("")).toBeNull();
+  });
+
+  test("returns null - never throws - for arbitrary junk", () => {
+    expect((): JwtPayload | null => {
+      return decodeJwtPayload("not-a-jwt");
+    }).not.toThrow();
+
+    expect(decodeJwtPayload("not-a-jwt")).toBeNull();
+    expect(decodeJwtPayload("...")).toBeNull();
+    expect(decodeJwtPayload("   ")).toBeNull();
+  });
+
+  test("accepts an empty claim set, which is still an object", () => {
+    expect(decodeJwtPayload(makeJwt({}))).toEqual({});
+  });
+});
+
+describe("isJwtExpired", () => {
+  test("a token that expires well in the future is not expired", () => {
+    const token: string = makeJwt({ exp: NOW_SECONDS + 30 * 24 * 60 * 60 });
+
+    expect(isJwtExpired(token, NOW_MS)).toBe(false);
+  });
+
+  test("a token whose exp has passed is expired", () => {
+    const token: string = makeJwt({ exp: NOW_SECONDS - 1000 });
+
+    expect(isJwtExpired(token, NOW_MS)).toBe(true);
+  });
+
+  test("exp of 0 is expired, not treated as missing", () => {
+    /*
+     * 0 is falsy. A truthiness check instead of a typeof check would read this
+     * as "no exp claim" and call a token from 1970 valid.
+     */
+    expect(isJwtExpired(makeJwt({ exp: 0 }), NOW_MS)).toBe(true);
+  });
+
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["the empty string", ""],
+  ])(
+    "treats %s as expired, so an absent token never gets sent",
+    (_label: string, token: string | null | undefined): void => {
+      expect(isJwtExpired(token, NOW_MS)).toBe(true);
+    },
+  );
+
+  test.each([
+    ["a token with no dots", "not-a-jwt"],
+    ["a token with too few segments", "aaa.bbb"],
+    ["a token with an undecodable payload", "aaa.!!!.ccc"],
+    ["a token whose payload is not JSON", `${JWT_HEADER}.aGVsbG8.sig`],
+    ["a token whose payload is an array", makeJwtFromPayloadJson("[1,2,3]")],
+  ])(
+    "treats %s as expired rather than usable",
+    (_label: string, token: string): void => {
+      /*
+       * Fail closed. An unreadable token is one the server will reject too, so
+       * the app should re-authenticate instead of sending it and surfacing a
+       * 406 the user cannot act on.
+       */
+      expect(isJwtExpired(token, NOW_MS)).toBe(true);
+    },
+  );
+
+  test("a well-formed token with no exp claim is NOT expired", () => {
+    /*
+     * Deliberate, and the opposite of the malformed cases above. Some IdPs
+     * issue non-expiring tokens; the server accepts them, so the client must
+     * not lock the user out of one it could have used.
+     */
+    const token: string = makeJwt({ userId: "user-1" });
+
+    expect(isJwtExpired(token, NOW_MS)).toBe(false);
+  });
+
+  test("a token expiring in 10 seconds already reads as expired", () => {
+    /*
+     * The 30-second leeway. A request that leaves the phone now with 10
+     * seconds of validity left can easily arrive after exp on a slow mobile
+     * link and come back 401 - so the app refreshes first instead.
+     */
+    expect(isJwtExpired(makeJwt({ exp: NOW_SECONDS + 10 }), NOW_MS)).toBe(true);
+  });
+
+  test("a token expiring in 120 seconds does not", () => {
+    /*
+     * The other side of the same window: the leeway must not be so wide that
+     * it throws away tokens with real life left in them and sends the user
+     * back through the IdP for nothing.
+     */
+    expect(isJwtExpired(makeJwt({ exp: NOW_SECONDS + 120 }), NOW_MS)).toBe(
+      false,
+    );
+  });
+
+  test("the boundary sits exactly at the 30-second leeway", () => {
+    // 30s out is still expired (the comparison is <=); 31s out is not.
+    expect(isJwtExpired(makeJwt({ exp: NOW_SECONDS + 30 }), NOW_MS)).toBe(true);
+    expect(isJwtExpired(makeJwt({ exp: NOW_SECONDS + 31 }), NOW_MS)).toBe(
+      false,
+    );
+  });
+
+  test("a non-numeric exp is treated as no exp at all", () => {
+    /*
+     * Documenting the fail-open half of the design: exp must be a NumericDate,
+     * and anything else is ignored rather than guessed at. The server remains
+     * the authority - the worst case is one rejected request, versus locking
+     * the user out over a claim the client mis-parsed.
+     */
+    expect(isJwtExpired(makeJwt({ exp: "1700000000" }), NOW_MS)).toBe(false);
+    expect(isJwtExpired(makeJwt({ exp: null }), NOW_MS)).toBe(false);
+  });
+
+  test("falls back to the real clock when nowMs is not supplied", () => {
+    /*
+     * The default argument is what production actually uses; every other test
+     * here passes nowMs explicitly, so without this the default path is never
+     * executed.
+     */
+    const longExpired: string = makeJwt({
+      exp: Math.floor(Date.now() / 1000) - 365 * 24 * 60 * 60,
+    });
+    const longLived: string = makeJwt({
+      exp: Math.floor(Date.now() / 1000) + 365 * 24 * 60 * 60,
+    });
+
+    expect(isJwtExpired(longExpired)).toBe(true);
+    expect(isJwtExpired(longLived)).toBe(false);
+  });
+});

--- a/MobileApp/src/utils/jwt.ts
+++ b/MobileApp/src/utils/jwt.ts
@@ -1,0 +1,184 @@
+/*
+ * Minimal, dependency-free JWT payload reader.
+ *
+ * The app never verifies signatures - the server does that on every request.
+ * All the client needs is the `exp` claim, so it can stop sending a token it
+ * already knows the server will reject and re-authenticate instead of showing
+ * the user a screen full of 4xx errors.
+ *
+ * `atob` is not guaranteed to exist across every React Native runtime the app
+ * ships on (and Hermes has historically shipped without it), so the base64url
+ * decode is written out by hand rather than delegated.
+ */
+
+const BASE64_ALPHABET: string =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/**
+ * Decodes a base64url string (JWT flavour: `-`/`_` instead of `+`/`/`, and
+ * padding omitted) into its raw bytes, interpreted as UTF-8.
+ *
+ * Returns null rather than throwing on malformed input - callers treat an
+ * unreadable token exactly the same as an expired one.
+ */
+export function decodeBase64Url(value: string): string | null {
+  const normalized: string = value.replace(/-/g, "+").replace(/_/g, "/");
+
+  const bytes: Array<number> = [];
+  let buffer: number = 0;
+  let bitsInBuffer: number = 0;
+
+  for (const char of normalized) {
+    if (char === "=") {
+      break;
+    }
+
+    const charIndex: number = BASE64_ALPHABET.indexOf(char);
+
+    if (charIndex === -1) {
+      // Any character outside the alphabet means this is not base64url.
+      return null;
+    }
+
+    buffer = (buffer << 6) | charIndex;
+    bitsInBuffer += 6;
+
+    if (bitsInBuffer >= 8) {
+      bitsInBuffer -= 8;
+      bytes.push((buffer >> bitsInBuffer) & 0xff);
+    }
+  }
+
+  return decodeUtf8(bytes);
+}
+
+/*
+ * Hand-rolled UTF-8 decode. TextDecoder is not universally available in React
+ * Native either, and String.fromCharCode alone would mangle any non-ASCII
+ * character in a name or email claim.
+ */
+function decodeUtf8(bytes: Array<number>): string | null {
+  let result: string = "";
+  let index: number = 0;
+
+  while (index < bytes.length) {
+    const byte1: number = bytes[index]!;
+
+    if (byte1 < 0x80) {
+      result += String.fromCharCode(byte1);
+      index += 1;
+      continue;
+    }
+
+    if (byte1 >= 0xc0 && byte1 < 0xe0 && index + 1 < bytes.length) {
+      result += String.fromCharCode(
+        ((byte1 & 0x1f) << 6) | (bytes[index + 1]! & 0x3f),
+      );
+      index += 2;
+      continue;
+    }
+
+    if (byte1 >= 0xe0 && byte1 < 0xf0 && index + 2 < bytes.length) {
+      result += String.fromCharCode(
+        ((byte1 & 0x0f) << 12) |
+          ((bytes[index + 1]! & 0x3f) << 6) |
+          (bytes[index + 2]! & 0x3f),
+      );
+      index += 3;
+      continue;
+    }
+
+    if (byte1 >= 0xf0 && index + 3 < bytes.length) {
+      const codePoint: number =
+        ((byte1 & 0x07) << 18) |
+        ((bytes[index + 1]! & 0x3f) << 12) |
+        ((bytes[index + 2]! & 0x3f) << 6) |
+        (bytes[index + 3]! & 0x3f);
+
+      // Outside the BMP - encode as a surrogate pair.
+      const offset: number = codePoint - 0x10000;
+      result += String.fromCharCode(
+        0xd800 + (offset >> 10),
+        0xdc00 + (offset & 0x3ff),
+      );
+      index += 4;
+      continue;
+    }
+
+    return null;
+  }
+
+  return result;
+}
+
+export interface JwtPayload {
+  // Seconds since the epoch, per RFC 7519. Absent on tokens that never expire.
+  exp?: number;
+  [claim: string]: unknown;
+}
+
+/**
+ * Reads the payload of a JWT without verifying it. Returns null for anything
+ * that is not a well-formed three-segment JWT with a JSON payload.
+ */
+export function decodeJwtPayload(token: string): JwtPayload | null {
+  if (!token) {
+    return null;
+  }
+
+  const segments: Array<string> = token.split(".");
+
+  if (segments.length !== 3) {
+    return null;
+  }
+
+  const decoded: string | null = decodeBase64Url(segments[1]!);
+
+  if (decoded === null) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(decoded);
+
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+
+    return parsed as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+/*
+ * Treat a token as expired slightly before the server does, so a request that
+ * is in flight when the clock ticks past `exp` does not come back 401.
+ */
+const EXPIRY_LEEWAY_SECONDS: number = 30;
+
+/**
+ * True when the token is expired, malformed, or empty - i.e. whenever the app
+ * should stop relying on it. A well-formed token with no `exp` claim is
+ * treated as still valid, matching how the server reads it.
+ */
+export function isJwtExpired(
+  token: string | null | undefined,
+  nowMs: number = Date.now(),
+): boolean {
+  if (!token) {
+    return true;
+  }
+
+  const payload: JwtPayload | null = decodeJwtPayload(token);
+
+  if (!payload) {
+    return true;
+  }
+
+  if (typeof payload.exp !== "number" || !Number.isFinite(payload.exp)) {
+    return false;
+  }
+
+  return payload.exp * 1000 <= nowMs + EXPIRY_LEEWAY_SECONDS * 1000;
+}


### PR DESCRIPTION
## What this is

Global SSO/OIDC — the instance-wide kind an admin configures on the **admin dashboard**, as opposed to project-level SSO — already existed end to end, and the mobile app already had pieces of an integration (added in 918e79f35). What it did not have was a path a user could actually complete. This makes it work on iOS and Android, and puts it under test.

I audited the whole stack before writing anything. The confirmed defects below are what this fixes.

## Mobile

**Global providers are discovered on mount.** They are not email-bound, so requiring an email first made an instance whose only identity provider is a global one look like it had no SSO at all. The screen now matches the web login page: providers above the email field, "Or continue with email" below.

**The Android dismiss race is fixed.** `expo-web-browser` polyfills `openAuthSessionAsync` on Android by racing an AppState-driven `dismiss` against a `Linking`-driven `success`. The redirect out of Chrome Custom Tabs fires *both*, so a login that completed perfectly intermittently resolved as `dismiss` with no URL and its tokens were dropped. A new app-wide deep-link capture (`src/sso/deepLink.ts`) is consulted on every non-success result, so a single code path is correct on both platforms rather than branching on `Platform.OS`.

**Process death mid-login no longer loses the login.** The same capture drains `getInitialURL()`, and `AuthProvider` completes a callback waiting at launch. Previously the promise died with the process — routine on Android under memory pressure — and the IdP's redirect had nobody listening.

**A global provider can satisfy a project from inside Settings.** The signed-in re-auth sheet was project-SAML-only and only ever stored an `ssoToken`, so on a global-SSO instance an authenticated user hit a terminal "No SSO providers are configured" and a completed global login vanished without a word. It now offers both kinds and stores whichever token comes back.

**Expired SSO tokens are evicted on read.** A lapsed 30-day token left the app showing a project as "Authenticated" while every request 406'd, with the re-auth button suppressed.

**"No providers" and "cannot reach the server" are now different messages** — including the server's HTTP 400 `No SSO config found for this user`, which is a *real answer* and was being reported to users as a network failure.

Plus: the Home SSO banner refreshes on focus; every re-auth row is disabled while an auth session is open (`expo-web-browser` allows one at a time); and a provider whose URL cannot be built reports that, instead of leaving a row that silently does nothing when tapped.

## Server

New `App/FeatureSet/Identity/Utils/MobileSso.ts`, used by both global routers.

**Every mobile failure path now ends on `oneuptime://sso-callback` with a readable error.** Previously all of them rendered an EJS page or a JSON body into the in-app auth browser, which the app cannot parse — so the user saw the login reported as "cancelled" with no reason, for everything from "you need to be invited" to a bad SAML signature.

**Mobile intent is carried in a provider-scoped cookie as well as RelayState.** RelayState is only a SHOULD in the SAML spec and some IdPs drop it; when they do, the callback dropped mobile users on the web dashboard where the app can never reach the session. The cookie is `SameSite=None; Secure` on HTTPS so it survives the cross-site ACS **POST** (a Lax cookie is not sent on one — which would have made the fallback useless in exactly the flow it exists for), and keeps the Lax default on plain HTTP, where a Secure cookie would not be stored at all.

Also: an OIDC `error` redirect (consent denied, account disabled) is handled directly rather than fed into the token exchange and re-emerging as a generic 400; and IdP-supplied error text is length-bounded so it cannot produce a deep link the OS refuses to hand back.

## Tests

`MobileApp/jest.config.js` now runs the suite as **two projects, iOS and Android**. This matters: `jest-expo`'s default preset hard-codes `platform: "ios"` in its Babel caller and `babel-preset-expo` inlines `Platform.OS` from it, so before this an Android-only regression could not fail the build no matter what you mocked.

One pre-existing suite (`SettingsScreenCriticalAlerts`) is excluded from the Android project. React Native renders `<Switch>` as `RCTSwitch` on iOS and `AndroidSwitch` on Android; both carry `accessibilityRole: "switch"`, but `@testing-library/react-native`'s role matcher only recognises the iOS host component. That is a matcher limitation, not a product one — the toggles work on Android — and it is commented as such at the exclusion.

| Suite | Result |
| --- | --- |
| `MobileApp` (iOS + Android) | 1189 tests, 41 suites, green |
| `App/Tests/Identity` | 343 tests, green (61 new for `MobileSso`) |
| `Common/Tests/Server/{Middleware,Utils}` | 346 tests, green (19 new for the Global SSO token) |

`tsc --noEmit` and `eslint` are clean across every changed file. The one remaining `App` typecheck error (`Tests/Dashboard/RecommendationFilterUtil.test.ts`) is pre-existing — identical output with these changes stashed — and comes from the worktree resolving two copies of `Common`.

Four of the fixes above were found *by* the new tests, against my own first pass, and each has a test pinning it.

## Not in this PR

Two related things the audit confirmed but that are outside "global SSO on mobile", flagged rather than fixed:

- **Project OIDC providers are never discovered on mobile.** `src/api/sso.ts` calls `/identity/service-provider-login` but never `/identity/service-provider-login-oidc`, so the project list on the SSO login screen is incomplete. Pre-existing, unrelated to global SSO.
- **A Global SSO token satisfies every SSO-enforced project regardless of `GlobalSsoProject` attachment**, and there is no way to revoke one before its 30-day expiry — disabling or deleting a provider leaves working tokens. That is a server-side authorization design question, not a mobile one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
