### PR TITLE
fix(discovery): make a scan stuck in "Pending" say why

### DIFF
--- a/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveryScanOutcome.ts
+++ b/App/FeatureSet/Dashboard/src/Components/NetworkDevice/DiscoveryScanOutcome.ts
@@ -26,6 +26,13 @@ export interface DiscoveryScanOutcome {
    */
   respondedHostSummary: string | null;
   /*
+   * True when the scan has reported host counts. The explanation below is
+   * worth showing WITHOUT them — a scan that never ran has no counts and is
+   * exactly the case that needs explaining — so the two have to be asked
+   * about separately rather than the caller inferring one from the other.
+   */
+  hasReported: boolean;
+  /*
    * Hosts the sweep found alive that did not answer SNMP. Shown alongside the
    * responder count so a zero is never mistaken for an empty network.
    */
@@ -92,6 +99,7 @@ export function summarizeDiscoveryScan(
     respondedHostSummary: hasReported
       ? `${respondedHostCount} of ${scan?.scannedHostCount ?? "?"} hosts`
       : null,
+    hasReported: hasReported,
     pingOnlyHostCount: countPingOnlyHosts(scan),
     // Empty string is "no explanation", not an explanation.
     explanation: scan?.statusMessage || null,

--- a/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
+++ b/App/FeatureSet/Dashboard/src/Pages/NetworkDevice/Discovery.tsx
@@ -8,7 +8,6 @@ import NetworkDeviceDiscoveryScan, {
   DiscoveredNetworkDevice,
 } from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import Probe from "Common/Models/DatabaseModels/Probe";
-import BadDataException from "Common/Types/Exception/BadDataException";
 import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
 import IconProp from "Common/Types/Icon/IconProp";
 import ObjectID from "Common/Types/ObjectID";
@@ -365,16 +364,28 @@ const NetworkDeviceDiscovery: FunctionComponent<
               openLinkInNewTab: true,
             },
             fieldType: FormFieldSchemaType.Dropdown,
-            dropdownOptions: probes.map((probe: Probe) => {
-              if (!probe.name || !probe._id) {
-                throw new BadDataException(`Probe name or id is missing`);
-              }
-
-              return {
-                label: probe.name,
-                value: probe._id,
-              };
-            }),
+            /*
+             * A probe with no id cannot be scanned with, so it is dropped.
+             * A probe with no NAME still can be, so it is kept under a
+             * stand-in label.
+             *
+             * This used to throw for either. The .map runs in the component's
+             * render body, not lazily when the create modal opens, so a single
+             * unnamed probe row — a global probe, or one registered before it
+             * was named — did not degrade the dropdown: it threw during render
+             * and blanked the entire Discovery Scans page, including the list
+             * of existing scans.
+             */
+            dropdownOptions: probes
+              .filter((probe: Probe) => {
+                return Boolean(probe._id);
+              })
+              .map((probe: Probe) => {
+                return {
+                  label: probe.name || `Probe ${probe._id}`,
+                  value: probe._id!,
+                };
+              }),
             required: true,
             placeholder: "Probe",
           },
@@ -480,11 +491,33 @@ const NetworkDeviceDiscovery: FunctionComponent<
             title: "Responded Hosts",
             type: FieldType.Element,
             getElement: (item: NetworkDeviceDiscoveryScan): ReactElement => {
-              if (
-                item.respondedHostCount === undefined ||
-                item.respondedHostCount === null
-              ) {
-                return <span className="text-sm text-gray-400">—</span>;
+              const outcome: DiscoveryScanOutcome =
+                summarizeDiscoveryScan(item);
+
+              /*
+               * No host counts yet. That used to render a bare em-dash and
+               * stop, which threw away the only explanation a scan that never
+               * ran ever gets: the worker's "nobody has claimed this" note
+               * (Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts)
+               * and the stale-In-Progress reaper's "the probe did not report a
+               * result within 2 hours" were both written to statusMessage,
+               * fetched by this page, and then rendered nowhere — so a stuck
+               * scan looked identical to one that had simply just been
+               * submitted (OneUptime issue #3287).
+               */
+              if (!outcome.hasReported) {
+                if (!outcome.explanation) {
+                  return <span className="text-sm text-gray-400">—</span>;
+                }
+
+                return (
+                  <div
+                    className="text-xs text-gray-500 max-w-md"
+                    title={outcome.explanation}
+                  >
+                    {outcome.explanation}
+                  </div>
+                );
               }
 
               /*
@@ -496,9 +529,6 @@ const NetworkDeviceDiscovery: FunctionComponent<
                * explanation of the sweep — which was already being stored and
                * fetched, and was simply never rendered anywhere.
                */
-              const outcome: DiscoveryScanOutcome =
-                summarizeDiscoveryScan(item);
-
               return (
                 <div>
                   <div className="text-sm text-gray-900">

--- a/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
+++ b/App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
@@ -122,6 +122,15 @@ router.post(
           data: {
             status: "In Progress",
             startedAt: OneUptimeDate.getCurrentDate(),
+            /*
+             * Clear the "nobody has picked this scan up" note the worker
+             * writes onto a long-unclaimed Pending scan
+             * (Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts).
+             * A probe claiming the scan is precisely the thing that note said
+             * was not happening, so leaving it would have the row explain, for
+             * the whole sweep, why it had not started.
+             */
+            statusMessage: null,
           } as unknown as QueryDeepPartialEntity<NetworkDeviceDiscoveryScan>,
         });
       }
@@ -191,6 +200,8 @@ router.post(
           select: {
             _id: true,
             projectId: true,
+            // Needed to reject a result for a run that is no longer current.
+            status: true,
             // Needed to schedule the next run of a recurring scan below.
             isRecurring: true,
             rescanIntervalInMinutes: true,
@@ -208,29 +219,80 @@ router.post(
         );
       }
 
+      /*
+       * The result belongs to a run that has already been superseded.
+       *
+       * A sweep can outlive its own claim: the stale-In-Progress reaper marks
+       * a scan Failed after 2 hours and, if it recurs, the requeue pass then
+       * flips it back to Pending for a fresh run
+       * (Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts). A
+       * probe that finally reports the ABANDONED run would land on that row
+       * and stamp it Completed — retiring a run that was queued and never
+       * happened, and replacing the new run's empty result set with results
+       * from hours ago.
+       *
+       * Only Pending is refused. A late result for a scan the reaper marked
+       * Failed is still the truth about that same run, and overwriting the
+       * reaper's guess with the probe's actual findings is the right outcome —
+       * which is why this is a status check and not a claim token.
+       */
+      if (scan.status === "Pending") {
+        logger.warn(
+          `Discarding a discovery scan result for ${scanId}: the scan is queued for a new run, so this result is from a run that was already abandoned.`,
+        );
+
+        return Response.sendJsonObjectResponse(req, res, {
+          result: "discarded",
+        });
+      }
+
       const discoveredDevices: Array<JSONObject> =
         (req.body["discoveredDevices"] as Array<JSONObject>) || [];
 
-      // Flag hosts that already have a NetworkDevice at that IP.
-      const existing: Array<NetworkDevice> = await NetworkDeviceService.findBy({
-        query: {
-          projectId: scan.projectId!,
-        },
-        select: {
-          hostname: true,
-        },
-        limit: LIMIT_MAX,
-        skip: 0,
-        props: {
-          isRoot: true,
-        },
-      });
+      /*
+       * Flag hosts that already have a NetworkDevice at that IP.
+       *
+       * Paged, because this used to be a single findBy at LIMIT_MAX (10,000)
+       * with no paging and no sort. A project with more devices than that got
+       * an arbitrary 10,000 of them, so every device past the cap was reported
+       * to the dashboard as NOT registered, and the reviewer's "import"
+       * re-created devices that already existed. A truncated answer here is
+       * worse than a slow one: it produces duplicates in the inventory.
+       */
+      const existingHostnames: Set<string> = new Set<string>();
 
-      const existingHostnames: Set<string> = new Set(
-        existing.map((device: NetworkDevice) => {
-          return device.hostname || "";
-        }),
-      );
+      for (let skip: number = 0; ; skip += LIMIT_MAX) {
+        const existing: Array<NetworkDevice> =
+          await NetworkDeviceService.findBy({
+            query: {
+              projectId: scan.projectId!,
+            },
+            select: {
+              hostname: true,
+            },
+            /*
+             * Sorted, so paging is stable. Without an explicit order Postgres
+             * makes no promise across the two queries, and a row could be
+             * returned twice — or skipped entirely — between pages.
+             */
+            sort: {
+              createdAt: SortOrder.Ascending,
+            },
+            limit: LIMIT_MAX,
+            skip: skip,
+            props: {
+              isRoot: true,
+            },
+          });
+
+        for (const device of existing) {
+          existingHostnames.add(device.hostname || "");
+        }
+
+        if (existing.length < LIMIT_MAX) {
+          break;
+        }
+      }
 
       for (const device of discoveredDevices) {
         device["isAlreadyRegistered"] = existingHostnames.has(

--- a/App/FeatureSet/Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts
+++ b/App/FeatureSet/Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts
@@ -4,11 +4,28 @@ import OneUptimeDate from "Common/Types/Date";
 import QueryDeepPartialEntity from "Common/Types/Database/PartialEntity";
 import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
 import NetworkDeviceDiscoveryScanService from "Common/Server/Services/NetworkDeviceDiscoveryScanService";
+import Probe, {
+  ProbeConnectionStatus,
+} from "Common/Models/DatabaseModels/Probe";
+import ProbeService from "Common/Server/Services/ProbeService";
 import QueryHelper from "Common/Server/Types/Database/QueryHelper";
+import {
+  UNCLAIMED_PENDING_MINUTES,
+  UnclaimedScanProbeState,
+  buildUnclaimedScanDiagnosis,
+} from "Common/Utils/NetworkDiscovery/UnclaimedScanDiagnosis";
 import logger from "Common/Server/Utils/Logger";
 
 /*
- * Re-queues recurring subnet discovery scans that are due.
+ * The server's half of keeping a subnet discovery scan honest. Three passes,
+ * every minute:
+ *
+ *   1. rescue a scan stranded In Progress by a probe that died mid-sweep,
+ *   2. re-queue a recurring scan whose next run is due,
+ *   3. explain a scan that is still sitting in Pending because no probe has
+ *      claimed it (see explainUnclaimedScans at the bottom of this file).
+ *
+ * The job's name predates (3) and is kept so its metrics stay continuous.
  *
  * The lifecycle: the probe-ingest result endpoint (Telemetry/API/ProbeIngest/
  * DiscoveryScan.ts) stamps nextScanAt when a recurring scan completes or
@@ -134,5 +151,160 @@ RunCron(
     if (dueScans.length > 0) {
       logger.debug(`Re-queued ${dueScans.length} recurring discovery scan(s).`);
     }
+
+    await explainUnclaimedScans();
   },
 );
+
+/*
+ * The third pass: say why a scan is still sitting in "Pending".
+ *
+ * The two passes above rescue scans a probe TOOK and abandoned. Neither can
+ * see the opposite failure — a scan no probe ever took — because only the
+ * claim endpoint moves a row off Pending and there is nothing for a reaper to
+ * time out. That gap is what OneUptime issue #3287 reported: four scans, an
+ * hour apart, all "Pending", nothing anywhere in the product to say why.
+ *
+ * See Common/Utils/NetworkDiscovery/UnclaimedScanDiagnosis for why this
+ * annotates rather than fails the scan.
+ */
+export async function explainUnclaimedScans(): Promise<void> {
+  /*
+   * updatedAt, not createdAt: a recurring scan that the pass above just
+   * re-queued has been Pending for seconds, however old the row is. Any write
+   * to the row bumps this, so for a scan sitting untouched in Pending it is
+   * exactly the moment it entered that state.
+   */
+  const unclaimedScans: Array<NetworkDeviceDiscoveryScan> =
+    await NetworkDeviceDiscoveryScanService.findAllBy({
+      query: {
+        status: "Pending",
+        updatedAt: QueryHelper.lessThan(
+          OneUptimeDate.getSomeMinutesAgo(UNCLAIMED_PENDING_MINUTES),
+        ),
+      },
+      select: {
+        _id: true,
+        cidr: true,
+        probeId: true,
+        statusMessage: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+  if (unclaimedScans.length === 0) {
+    return;
+  }
+
+  /*
+   * A probe runs one sweep at a time (the claim endpoint's `limit: 1`), so
+   * every other scan assigned to a probe that is mid-sweep is legitimately
+   * queued — for as long as that sweep takes, which at the scan-size ceiling
+   * is the better part of an hour. Reporting those as unclaimed would turn
+   * normal queueing into an alarm, so a probe with work in flight is skipped
+   * entirely.
+   */
+  const busyScans: Array<NetworkDeviceDiscoveryScan> =
+    await NetworkDeviceDiscoveryScanService.findAllBy({
+      query: {
+        status: "In Progress",
+      },
+      select: {
+        _id: true,
+        probeId: true,
+      },
+      props: {
+        isRoot: true,
+      },
+    });
+
+  const busyProbeIds: Set<string> = new Set(
+    busyScans.map((scan: NetworkDeviceDiscoveryScan) => {
+      return scan.probeId?.toString() || "";
+    }),
+  );
+
+  /*
+   * One probe row per probe, not per scan: a probe with several scans queued
+   * behind it is the common shape of this failure.
+   */
+  const probeStateById: Map<string, UnclaimedScanProbeState> = new Map();
+
+  for (const scan of unclaimedScans) {
+    const probeId: string | undefined = scan.probeId?.toString();
+
+    if (!probeId || busyProbeIds.has(probeId)) {
+      continue;
+    }
+
+    if (!probeStateById.has(probeId)) {
+      const probe: Probe | null = await ProbeService.findOneById({
+        id: scan.probeId!,
+        select: {
+          _id: true,
+          name: true,
+          connectionStatus: true,
+          lastAlive: true,
+        },
+        props: {
+          isRoot: true,
+        },
+      });
+
+      probeStateById.set(probeId, {
+        ...(probe?.name ? { probeName: probe.name } : {}),
+        /*
+         * A probe row that no longer exists cannot be connected. The scan's
+         * probeId column is ON DELETE CASCADE, so this is the narrow window
+         * between a probe being deleted and the cascade landing.
+         */
+        isProbeConnected:
+          probe?.connectionStatus === ProbeConnectionStatus.Connected,
+        lastAliveAt: probe?.lastAlive || null,
+      });
+    }
+
+    const statusMessage: string = buildUnclaimedScanDiagnosis(
+      probeStateById.get(probeId)!,
+    );
+
+    /*
+     * Only write when the sentence actually changes. This job runs every
+     * minute and a probe can stay offline for days; re-writing the identical
+     * message would be one UPDATE per scan per minute forever, and — because
+     * the write bumps updatedAt — would also reset the very clock the query
+     * above uses.
+     *
+     * The message is not frozen by this, though: it carries a relative
+     * "last seen" ("6 hours ago"), so it rewrites itself as that phrase
+     * changes rather than going stale on the row.
+     */
+    if (scan.statusMessage === statusMessage) {
+      continue;
+    }
+
+    logger.warn(
+      `Discovery scan ${scan.id?.toString()} (${scan.cidr}) has been Pending for over ${UNCLAIMED_PENDING_MINUTES} minutes with no probe claiming it: ${statusMessage}`,
+    );
+
+    await NetworkDeviceDiscoveryScanService.updateOneById({
+      id: scan.id!,
+      /*
+       * statusMessage ONLY. The scan stays Pending on purpose — it is still
+       * runnable the moment the probe comes back, and the claim endpoint
+       * clears this note when it picks the scan up.
+       *
+       * Cast: the model's JSON column makes DeepPartial recursion blow up,
+       * same workaround as the passes above.
+       */
+      data: {
+        statusMessage: statusMessage,
+      } as unknown as QueryDeepPartialEntity<NetworkDeviceDiscoveryScan>,
+      props: {
+        isRoot: true,
+      },
+    });
+  }
+}

--- a/App/Tests/Dashboard/DiscoveryScanOutcome.test.ts
+++ b/App/Tests/Dashboard/DiscoveryScanOutcome.test.ts
@@ -240,3 +240,101 @@ describe("summarizeDiscoveryScan — the probe's explanation", () => {
     ).toBeNull();
   });
 });
+
+/*
+ * `hasReported` exists so the scans table can tell "no result yet" apart from
+ * "nothing to say".
+ *
+ * The Responded Hosts cell used to short-circuit to an em-dash the moment
+ * respondedHostCount was missing, which threw away the only explanation a scan
+ * that never ran ever gets — the worker's "nobody has claimed this scan" note
+ * and the reaper's "the probe did not report a result within 2 hours" are both
+ * written to statusMessage, on rows that by definition have no counts. Both
+ * were stored, both were fetched by the page, and neither was ever rendered
+ * (OneUptime issue #3287).
+ */
+describe("summarizeDiscoveryScan — has this scan reported yet", () => {
+  test("a Completed scan has reported", () => {
+    expect(summarizeDiscoveryScan(makeScan()).hasReported).toBe(true);
+  });
+
+  test("zero responders is a report, not the absence of one", () => {
+    expect(
+      summarizeDiscoveryScan(makeScan({ respondedHostCount: 0 })).hasReported,
+    ).toBe(true);
+  });
+
+  test("a Pending scan has not reported", () => {
+    expect(
+      summarizeDiscoveryScan(
+        makeScan({
+          status: "Pending",
+          respondedHostCount: undefined,
+          scannedHostCount: undefined,
+        } as never),
+      ).hasReported,
+    ).toBe(false);
+  });
+
+  test("a null respondedHostCount is not a report either", () => {
+    expect(
+      summarizeDiscoveryScan(makeScan({ respondedHostCount: null } as never))
+        .hasReported,
+    ).toBe(false);
+  });
+
+  test("null and undefined scans have not reported", () => {
+    expect(summarizeDiscoveryScan(null).hasReported).toBe(false);
+    expect(summarizeDiscoveryScan(undefined).hasReported).toBe(false);
+  });
+
+  /*
+   * The combination the fix turns on: no counts AND an explanation. Before,
+   * this row rendered as a bare em-dash.
+   */
+  test("an unreported scan can still carry the explanation the cell now shows", () => {
+    const outcome: DiscoveryScanOutcome = summarizeDiscoveryScan(
+      makeScan({
+        status: "Pending",
+        respondedHostCount: undefined,
+        scannedHostCount: undefined,
+        statusMessage:
+          'Not started yet: Probe "Datacentre Probe" is not connected to OneUptime, so it has not picked this scan up.',
+      } as never),
+    );
+
+    expect(outcome.hasReported).toBe(false);
+    expect(outcome.respondedHostSummary).toBeNull();
+    expect(outcome.explanation).toContain("is not connected to OneUptime");
+  });
+
+  /*
+   * And the case that must still render an em-dash: a scan submitted moments
+   * ago has nothing to report and nothing to explain.
+   */
+  test("a freshly submitted scan has neither a summary nor an explanation", () => {
+    const outcome: DiscoveryScanOutcome = summarizeDiscoveryScan(
+      makeScan({
+        status: "Pending",
+        respondedHostCount: undefined,
+        scannedHostCount: undefined,
+        statusMessage: undefined,
+      } as never),
+    );
+
+    expect(outcome.hasReported).toBe(false);
+    expect(outcome.explanation).toBeNull();
+  });
+
+  test("hasReported agrees with respondedHostSummary in every case", () => {
+    for (const scan of [
+      makeScan(),
+      makeScan({ respondedHostCount: 12 }),
+      makeScan({ respondedHostCount: undefined } as never),
+      makeScan({ respondedHostCount: null } as never),
+    ]) {
+      const outcome: DiscoveryScanOutcome = summarizeDiscoveryScan(scan);
+      expect(outcome.hasReported).toBe(outcome.respondedHostSummary !== null);
+    }
+  });
+});

--- a/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
+++ b/App/Tests/Telemetry/ProbeIngestDiscoveryScan.test.ts
@@ -10,6 +10,7 @@ import BadDataException from "Common/Types/Exception/BadDataException";
 import { JSONObject } from "Common/Types/JSON";
 import ObjectID from "Common/Types/ObjectID";
 import SortOrder from "Common/Types/BaseDatabase/SortOrder";
+import LIMIT_MAX from "Common/Types/Database/LimitMax";
 import {
   ExpressRequest,
   ExpressResponse,
@@ -221,9 +222,22 @@ describe("POST /probe/discovery-scan/list", () => {
       .mock.calls[0]![0] as JSONObject;
     expect((updateArgs["id"] as ObjectID).toString()).toBe(scanId.toString());
     const data: JSONObject = expectPlainUpdateData(updateArgs["data"]);
-    expect(Object.keys(data).sort()).toEqual(["startedAt", "status"]);
+    expect(Object.keys(data).sort()).toEqual([
+      "startedAt",
+      "status",
+      "statusMessage",
+    ]);
     expect(data["status"]).toBe("In Progress");
     expect(data["startedAt"]).toBeInstanceOf(Date);
+    /*
+     * Cleared, not left behind: the worker writes a "nobody has picked this
+     * scan up" note onto a long-unclaimed Pending scan
+     * (Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts), and a
+     * probe claiming the scan is exactly the thing that note said was not
+     * happening. Leaving it would have the row explain, for the whole sweep,
+     * why it had not started.
+     */
+    expect(data["statusMessage"]).toBeNull();
 
     // The scans are returned to the probe.
     expect(responseUtil.sendEntityArrayResponse).toHaveBeenCalledWith(
@@ -773,5 +787,221 @@ describe("POST /probe/discovery-scan/result", () => {
     );
 
     expect(next).toHaveBeenCalledWith(boom);
+  });
+});
+
+/*
+ * A sweep can outlive its own claim. The stale-In-Progress reaper marks a scan
+ * Failed after two hours and, if it recurs, the requeue pass then flips it
+ * back to Pending for a fresh run
+ * (Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts). A probe that
+ * finally reports the ABANDONED run lands on that row — and used to stamp it
+ * Completed, retiring a run that had been queued and never happened and
+ * replacing the new run's empty result set with findings from hours earlier.
+ */
+describe("POST /probe/discovery-scan/result — a result for a superseded run", () => {
+  const probeId: ObjectID = ObjectID.generate();
+  const scanId: ObjectID = ObjectID.generate();
+  const projectId: ObjectID = ObjectID.generate();
+
+  function makeScanWithStatus(status: string): NetworkDeviceDiscoveryScan {
+    const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan(
+      scanId,
+    );
+    scan.projectId = projectId;
+    scan.status = status;
+    return scan;
+  }
+
+  function resultRequest(): ExpressRequest {
+    return makeRequest({
+      probeId,
+      body: {
+        scanId: scanId.toString(),
+        success: true,
+        statusMessage: "Swept 254 hosts.",
+        scannedHostCount: 254,
+        discoveredDevices: [{ ipAddress: "10.0.0.5", sysName: "sw1" }],
+      },
+    });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    deviceService.findBy.mockResolvedValue([] as never);
+    scanService.updateOneById.mockResolvedValue(undefined as never);
+  });
+
+  test("a scan that is queued for a new run keeps its fresh state", async () => {
+    scanService.findOneBy.mockResolvedValue(
+      makeScanWithStatus("Pending") as never,
+    );
+
+    const { next } = await callResultEndpoint(resultRequest());
+
+    expect(next).not.toHaveBeenCalled();
+    expect(scanService.updateOneById).not.toHaveBeenCalled();
+    expect(responseUtil.sendJsonObjectResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      mockResponse,
+      { result: "discarded" },
+    );
+  });
+
+  /*
+   * Only Pending is refused. A late result for a scan the reaper GUESSED was
+   * abandoned is still the truth about that same run, so the probe's actual
+   * findings must replace the reaper's guess.
+   */
+  test("a scan the reaper marked Failed still accepts the real result", async () => {
+    scanService.findOneBy.mockResolvedValue(
+      makeScanWithStatus("Failed") as never,
+    );
+
+    await callResultEndpoint(resultRequest());
+
+    expect(scanService.updateOneById).toHaveBeenCalledTimes(1);
+    const data: JSONObject = expectPlainUpdateData(
+      (scanService.updateOneById.mock.calls[0]![0] as JSONObject)["data"],
+    );
+    expect(data["status"]).toBe("Completed");
+  });
+
+  test("an In Progress scan — the ordinary case — is written as before", async () => {
+    scanService.findOneBy.mockResolvedValue(
+      makeScanWithStatus("In Progress") as never,
+    );
+
+    await callResultEndpoint(resultRequest());
+
+    expect(scanService.updateOneById).toHaveBeenCalledTimes(1);
+  });
+
+  test("the status column is actually selected, or the check above is vacuous", async () => {
+    scanService.findOneBy.mockResolvedValue(
+      makeScanWithStatus("In Progress") as never,
+    );
+
+    await callResultEndpoint(resultRequest());
+
+    const findOneArgs: JSONObject = scanService.findOneBy.mock
+      .calls[0]![0] as JSONObject;
+    expect((findOneArgs["select"] as JSONObject)["status"]).toBe(true);
+  });
+});
+
+/*
+ * The already-registered flag used to come from ONE findBy at LIMIT_MAX with
+ * no paging and no sort. A project with more devices than that got an
+ * arbitrary 10,000 of them, so every device past the cap was reported to the
+ * dashboard as NOT registered and the reviewer's "import" re-created devices
+ * that already existed.
+ */
+describe("POST /probe/discovery-scan/result — flagging already-registered hosts", () => {
+  const probeId: ObjectID = ObjectID.generate();
+  const scanId: ObjectID = ObjectID.generate();
+  const projectId: ObjectID = ObjectID.generate();
+
+  function makeFullPage(): Array<NetworkDevice> {
+    const page: Array<NetworkDevice> = [];
+    for (let index: number = 0; index < LIMIT_MAX; index++) {
+      const device: NetworkDevice = new NetworkDevice();
+      device.hostname = `10.99.${Math.floor(index / 256)}.${index % 256}`;
+      page.push(device);
+    }
+    return page;
+  }
+
+  function deviceWithHostname(hostname: string): NetworkDevice {
+    const device: NetworkDevice = new NetworkDevice();
+    device.hostname = hostname;
+    return device;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    scanService.updateOneById.mockResolvedValue(undefined as never);
+    const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan(
+      scanId,
+    );
+    scan.projectId = projectId;
+    scan.status = "In Progress";
+    scanService.findOneBy.mockResolvedValue(scan as never);
+  });
+
+  function discoveredResultRequest(): ExpressRequest {
+    return makeRequest({
+      probeId,
+      body: {
+        scanId: scanId.toString(),
+        success: true,
+        discoveredDevices: [
+          { ipAddress: "10.0.0.5" },
+          { ipAddress: "10.0.0.6" },
+        ],
+      },
+    });
+  }
+
+  test("a single short page is fetched once and not paged again", async () => {
+    deviceService.findBy.mockResolvedValue([
+      deviceWithHostname("10.0.0.5"),
+    ] as never);
+
+    await callResultEndpoint(discoveredResultRequest());
+
+    expect(deviceService.findBy).toHaveBeenCalledTimes(1);
+
+    const data: JSONObject = expectPlainUpdateData(
+      (scanService.updateOneById.mock.calls[0]![0] as JSONObject)["data"],
+    );
+    const devices: Array<JSONObject> = data[
+      "discoveredDevices"
+    ] as Array<JSONObject>;
+    expect(devices[0]!["isAlreadyRegistered"]).toBe(true);
+    expect(devices[1]!["isAlreadyRegistered"]).toBe(false);
+  });
+
+  test("a full page is followed by another, so device 10,001 is still seen", async () => {
+    deviceService.findBy
+      .mockResolvedValueOnce(makeFullPage() as never)
+      .mockResolvedValueOnce([deviceWithHostname("10.0.0.6")] as never);
+
+    await callResultEndpoint(discoveredResultRequest());
+
+    expect(deviceService.findBy).toHaveBeenCalledTimes(2);
+
+    // The second call must actually move the cursor, or this loops forever.
+    const firstCall: JSONObject = deviceService.findBy.mock
+      .calls[0]![0] as JSONObject;
+    const secondCall: JSONObject = deviceService.findBy.mock
+      .calls[1]![0] as JSONObject;
+    expect(firstCall["skip"]).toBe(0);
+    expect(secondCall["skip"]).toBe(LIMIT_MAX);
+
+    const data: JSONObject = expectPlainUpdateData(
+      (scanService.updateOneById.mock.calls[0]![0] as JSONObject)["data"],
+    );
+    const devices: Array<JSONObject> = data[
+      "discoveredDevices"
+    ] as Array<JSONObject>;
+    // Only found on the SECOND page — the case the old cap silently dropped.
+    expect(devices[1]!["isAlreadyRegistered"]).toBe(true);
+  });
+
+  /*
+   * Postgres makes no ordering promise without an ORDER BY, so an unsorted
+   * paged read can return a row twice, or skip one entirely, between pages.
+   */
+  test("paging is stably ordered", async () => {
+    deviceService.findBy.mockResolvedValue([] as never);
+
+    await callResultEndpoint(discoveredResultRequest());
+
+    const findArgs: JSONObject = deviceService.findBy.mock
+      .calls[0]![0] as JSONObject;
+    expect((findArgs["sort"] as JSONObject)["createdAt"]).toBe(
+      SortOrder.Ascending,
+    );
   });
 });

--- a/App/Tests/Workers/Jobs/NetworkDeviceDiscovery/UnclaimedScans.test.ts
+++ b/App/Tests/Workers/Jobs/NetworkDeviceDiscovery/UnclaimedScans.test.ts
@@ -1,0 +1,384 @@
+import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import NetworkDeviceDiscoveryScanService from "Common/Server/Services/NetworkDeviceDiscoveryScanService";
+import Probe, {
+  ProbeConnectionStatus,
+} from "Common/Models/DatabaseModels/Probe";
+import ProbeService from "Common/Server/Services/ProbeService";
+import OneUptimeDate from "Common/Types/Date";
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import { UNCLAIMED_PENDING_MINUTES } from "Common/Utils/NetworkDiscovery/UnclaimedScanDiagnosis";
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+jest.mock(
+  "../../../../FeatureSet/Workers/Utils/Cron",
+  (): { __esModule: boolean; default: ReturnType<typeof jest.fn> } => {
+    return {
+      __esModule: true,
+      default: jest.fn(),
+    };
+  },
+);
+
+jest.mock("Common/Server/Utils/Logger", () => {
+  return {
+    __esModule: true,
+    default: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/NetworkDeviceDiscoveryScanService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findAllBy: jest.fn(),
+      updateOneById: jest.fn(),
+    },
+  };
+});
+
+jest.mock("Common/Server/Services/ProbeService", () => {
+  return {
+    __esModule: true,
+    default: {
+      findOneById: jest.fn(),
+    },
+  };
+});
+
+import { explainUnclaimedScans } from "../../../../FeatureSet/Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans";
+
+/*
+ * The pass that gives a stuck discovery scan something to say.
+ *
+ * The two older passes in this job rescue scans a probe TOOK and abandoned.
+ * Neither can see the opposite failure — a scan no probe ever took — because
+ * only the claim endpoint moves a row off "Pending" and there is nothing for a
+ * reaper to time out. OneUptime issue #3287 is that gap: four scans submitted
+ * over an hour, every one of them "Pending" indefinitely, an em-dash where the
+ * result goes, and no timestamp, probe state or message anywhere in the
+ * product to explain it.
+ *
+ * These tests pin the two things that make this pass safe to run every minute:
+ * it must not mistake a legitimately QUEUED scan for a stuck one, and it must
+ * not rewrite the same sentence forever.
+ */
+
+type MockedScanService = {
+  findAllBy: jest.Mock;
+  updateOneById: jest.Mock;
+};
+
+const scanService: MockedScanService =
+  NetworkDeviceDiscoveryScanService as unknown as MockedScanService;
+const probeService: { findOneById: jest.Mock } = ProbeService as unknown as {
+  findOneById: jest.Mock;
+};
+
+const probeId: ObjectID = ObjectID.generate();
+const otherProbeId: ObjectID = ObjectID.generate();
+
+function makeScan(overrides?: Partial<JSONObject>): NetworkDeviceDiscoveryScan {
+  return {
+    id: ObjectID.generate(),
+    cidr: "10.240-249.0-254.220-226",
+    probeId: probeId,
+    statusMessage: null,
+    ...overrides,
+  } as unknown as NetworkDeviceDiscoveryScan;
+}
+
+function makeProbe(overrides?: Partial<JSONObject>): Probe {
+  return {
+    id: probeId,
+    name: "Datacentre Probe",
+    connectionStatus: ProbeConnectionStatus.Disconnected,
+    lastAlive: OneUptimeDate.getSomeHoursAgo(6),
+    ...overrides,
+  } as unknown as Probe;
+}
+
+/*
+ * The job asks for unclaimed scans first, then for whatever is In Progress.
+ * Driving both off the query's status keeps the tests readable and means a
+ * reordering of the two calls does not silently invert them.
+ */
+function respondWith(data: {
+  unclaimed: Array<NetworkDeviceDiscoveryScan>;
+  inProgress?: Array<NetworkDeviceDiscoveryScan> | undefined;
+}): void {
+  scanService.findAllBy.mockImplementation((args: unknown) => {
+    const query: JSONObject = (args as JSONObject)["query"] as JSONObject;
+
+    if (query["status"] === "In Progress") {
+      return Promise.resolve(data.inProgress || []);
+    }
+
+    return Promise.resolve(data.unclaimed);
+  });
+}
+
+function updateCalls(): Array<{ id: ObjectID; data: JSONObject }> {
+  return scanService.updateOneById.mock.calls.map((call: Array<unknown>) => {
+    const arg: JSONObject = call[0] as JSONObject;
+    return {
+      id: arg["id"] as ObjectID,
+      data: arg["data"] as JSONObject,
+    };
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  probeService.findOneById.mockResolvedValue(makeProbe() as never);
+});
+
+describe("explainUnclaimedScans — which scans it looks at", () => {
+  test("asks only for Pending scans that have been sitting untouched", async () => {
+    respondWith({ unclaimed: [] });
+
+    await explainUnclaimedScans();
+
+    const query: JSONObject = scanService.findAllBy.mock
+      .calls[0]![0] as JSONObject;
+    const scanQuery: JSONObject = query["query"] as JSONObject;
+
+    expect(scanQuery["status"]).toBe("Pending");
+    /*
+     * updatedAt, not createdAt: a recurring scan the requeue pass just flipped
+     * back to Pending has been Pending for seconds however old the row is.
+     */
+    expect(Object.keys(scanQuery)).toContain("updatedAt");
+    expect(Object.keys(scanQuery)).not.toContain("createdAt");
+  });
+
+  test("does nothing at all when no scan has been waiting", async () => {
+    respondWith({ unclaimed: [] });
+
+    await explainUnclaimedScans();
+
+    // No probe lookup, no write — the common case must be two cheap SELECTs.
+    expect(probeService.findOneById).not.toHaveBeenCalled();
+    expect(scanService.updateOneById).not.toHaveBeenCalled();
+    expect(scanService.findAllBy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("explainUnclaimedScans — a probe that is not connected", () => {
+  test("writes the diagnosis onto the scan", async () => {
+    const scan: NetworkDeviceDiscoveryScan = makeScan();
+    respondWith({ unclaimed: [scan] });
+
+    await explainUnclaimedScans();
+
+    const calls: Array<{ id: ObjectID; data: JSONObject }> = updateCalls();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.id).toBe(scan.id);
+    expect(String(calls[0]!.data["statusMessage"])).toContain(
+      "Datacentre Probe",
+    );
+    expect(String(calls[0]!.data["statusMessage"])).toContain(
+      "is not connected",
+    );
+  });
+
+  /*
+   * The scan stays runnable. Failing it would throw away work the operator
+   * asked for, and for a recurring scan it would fight the requeue pass in the
+   * same cron tick.
+   */
+  test("does NOT change the scan's status", async () => {
+    respondWith({ unclaimed: [makeScan()] });
+
+    await explainUnclaimedScans();
+
+    const data: JSONObject = updateCalls()[0]!.data;
+    expect(Object.keys(data)).toEqual(["statusMessage"]);
+    expect(data["status"]).toBeUndefined();
+  });
+
+  test("writes as root — the worker has no user context", async () => {
+    respondWith({ unclaimed: [makeScan()] });
+
+    await explainUnclaimedScans();
+
+    const props: JSONObject = scanService.updateOneById.mock
+      .calls[0]![0] as JSONObject;
+    expect((props["props"] as JSONObject)["isRoot"]).toBe(true);
+  });
+
+  test("a probe row that no longer exists is reported as not connected", async () => {
+    probeService.findOneById.mockResolvedValue(null as never);
+    respondWith({ unclaimed: [makeScan()] });
+
+    await explainUnclaimedScans();
+
+    expect(String(updateCalls()[0]!.data["statusMessage"])).toContain(
+      "The assigned probe is not connected",
+    );
+  });
+});
+
+describe("explainUnclaimedScans — a probe that IS connected", () => {
+  test("writes the other diagnosis, which names a different fix", async () => {
+    probeService.findOneById.mockResolvedValue(
+      makeProbe({
+        connectionStatus: ProbeConnectionStatus.Connected,
+      }) as never,
+    );
+    respondWith({ unclaimed: [makeScan()] });
+
+    await explainUnclaimedScans();
+
+    const message: string = String(updateCalls()[0]!.data["statusMessage"]);
+    expect(message).toContain("is connected but has not picked this scan up");
+    expect(message).toContain(`${UNCLAIMED_PENDING_MINUTES} minutes`);
+  });
+});
+
+describe("explainUnclaimedScans — scans that are legitimately queued", () => {
+  /*
+   * The claim endpoint hands out one scan at a time per probe, and a sweep at
+   * the size ceiling runs for the better part of an hour. Every other scan on
+   * that probe is Pending for that whole time and is not stuck at all —
+   * reporting those would turn normal queueing into an alarm.
+   */
+  test("skips a scan whose probe is mid-sweep", async () => {
+    respondWith({
+      unclaimed: [makeScan()],
+      inProgress: [makeScan({ id: ObjectID.generate() })],
+    });
+
+    await explainUnclaimedScans();
+
+    expect(scanService.updateOneById).not.toHaveBeenCalled();
+    expect(probeService.findOneById).not.toHaveBeenCalled();
+  });
+
+  test("a sweep on a DIFFERENT probe does not excuse this one", async () => {
+    const stuck: NetworkDeviceDiscoveryScan = makeScan();
+
+    respondWith({
+      unclaimed: [stuck],
+      inProgress: [
+        makeScan({ id: ObjectID.generate(), probeId: otherProbeId }),
+      ],
+    });
+
+    await explainUnclaimedScans();
+
+    expect(updateCalls()).toHaveLength(1);
+    expect(updateCalls()[0]!.id).toBe(stuck.id);
+  });
+
+  test("a scan with no probe at all is left alone rather than guessed about", async () => {
+    respondWith({
+      unclaimed: [makeScan({ probeId: undefined })],
+    });
+
+    await explainUnclaimedScans();
+
+    expect(scanService.updateOneById).not.toHaveBeenCalled();
+  });
+});
+
+describe("explainUnclaimedScans — it runs every minute, so it must not churn", () => {
+  /*
+   * A probe can stay offline for days. Re-writing the identical sentence would
+   * be one UPDATE per scan per minute forever — and because the write bumps
+   * updatedAt, it would also reset the very clock the query uses to decide
+   * what counts as unclaimed.
+   */
+  test("does not rewrite a message that has not changed", async () => {
+    const scan: NetworkDeviceDiscoveryScan = makeScan();
+    respondWith({ unclaimed: [scan] });
+
+    await explainUnclaimedScans();
+    const written: string = String(updateCalls()[0]!.data["statusMessage"]);
+
+    jest.clearAllMocks();
+    probeService.findOneById.mockResolvedValue(makeProbe() as never);
+    respondWith({
+      unclaimed: [makeScan({ id: scan.id, statusMessage: written })],
+    });
+
+    await explainUnclaimedScans();
+
+    expect(scanService.updateOneById).not.toHaveBeenCalled();
+  });
+
+  test("does rewrite when the probe's state changes underneath it", async () => {
+    const scan: NetworkDeviceDiscoveryScan = makeScan();
+    respondWith({ unclaimed: [scan] });
+
+    await explainUnclaimedScans();
+    const firstMessage: string = String(
+      updateCalls()[0]!.data["statusMessage"],
+    );
+
+    jest.clearAllMocks();
+    probeService.findOneById.mockResolvedValue(
+      makeProbe({
+        connectionStatus: ProbeConnectionStatus.Connected,
+      }) as never,
+    );
+    respondWith({
+      unclaimed: [makeScan({ id: scan.id, statusMessage: firstMessage })],
+    });
+
+    await explainUnclaimedScans();
+
+    expect(scanService.updateOneById).toHaveBeenCalledTimes(1);
+    expect(String(updateCalls()[0]!.data["statusMessage"])).not.toBe(
+      firstMessage,
+    );
+  });
+
+  /*
+   * Several scans behind one dead probe is the common shape of this failure —
+   * it is exactly what the issue's screenshot shows. One probe row is enough
+   * for all of them.
+   */
+  test("looks the probe up once, however many of its scans are waiting", async () => {
+    respondWith({
+      unclaimed: [makeScan(), makeScan(), makeScan()],
+    });
+
+    await explainUnclaimedScans();
+
+    expect(probeService.findOneById).toHaveBeenCalledTimes(1);
+    expect(scanService.updateOneById).toHaveBeenCalledTimes(3);
+  });
+
+  test("but a second probe is looked up separately", async () => {
+    probeService.findOneById.mockImplementation((args: unknown) => {
+      const id: ObjectID = (args as JSONObject)["id"] as ObjectID;
+      return Promise.resolve(
+        makeProbe({
+          id: id,
+          name: id === probeId ? "Probe A" : "Probe B",
+        }),
+      );
+    });
+
+    respondWith({
+      unclaimed: [makeScan(), makeScan({ probeId: otherProbeId })],
+    });
+
+    await explainUnclaimedScans();
+
+    expect(probeService.findOneById).toHaveBeenCalledTimes(2);
+    const messages: string = updateCalls()
+      .map((call: { data: JSONObject }) => {
+        return String(call.data["statusMessage"]);
+      })
+      .join("\n");
+    expect(messages).toContain("Probe A");
+    expect(messages).toContain("Probe B");
+  });
+});

--- a/Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts
+++ b/Common/Tests/Server/Services/DiscoveryScanClaimHookFreeSafety.test.ts
@@ -8,7 +8,8 @@ import { describe, expect, test } from "@jest/globals";
 /*
  * The /probe-ingest/probe/discovery-scan/list route hands the requesting
  * probe its pending subnet scans and claims them (status "In Progress" +
- * startedAt) via DatabaseService.updateColumnsByIdWithoutHooks — one raw
+ * startedAt, and a cleared statusMessage) via
+ * DatabaseService.updateColumnsByIdWithoutHooks — one raw
  * parameterized UPDATE that skips ALL on-update hooks: workflow HTTP
  * triggers, audit-log inserts, realtime events, service
  * onBeforeUpdate/onUpdateSuccess. The probe synchronously waits on this
@@ -18,8 +19,8 @@ import { describe, expect, test } from "@jest/globals";
  * pre-fetch SELECT + row re-fetch + save() transaction).
  *
  *   - App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts
- *       NetworkDeviceDiscoveryScan.status/startedAt when a probe claims a
- *       Pending scan
+ *       NetworkDeviceDiscoveryScan.status/startedAt/statusMessage when a
+ *       probe claims a Pending scan
  *
  * The conversion dropped NOTHING: the model declares no update workflow, no
  * audit logging and no realtime events. But the fast path skips hooks
@@ -36,8 +37,8 @@ import { describe, expect, test } from "@jest/globals";
  * be written by a root caller that bypasses the create-time check. That hook
  * is deliberately safe to skip here, and the assertions below pin exactly
  * why rather than merely restating that it exists: the claim write stamps
- * only `status` and `startedAt`, which the hook does not look at, and the
- * hook is a pass-through for that payload. If the hook ever grows to
+ * only `status`, `startedAt` and `statusMessage`, none of which the hook
+ * looks at, and the hook is a pass-through for that payload. If the hook ever grows to
  * validate a column the claim write touches — or the claim write grows to
  * touch `cidr` — these fail.
  *
@@ -79,7 +80,11 @@ describe("discovery-scan claim hookless write safety preconditions", () => {
      */
     test("NetworkDeviceDiscoveryScan has every column the claim write stamps", () => {
       const scan: NetworkDeviceDiscoveryScan = new NetworkDeviceDiscoveryScan();
-      const fastPathColumns: Array<string> = ["status", "startedAt"];
+      const fastPathColumns: Array<string> = [
+        "status",
+        "startedAt",
+        "statusMessage",
+      ];
       for (const column of fastPathColumns) {
         expect(scan.isTableColumn(column)).toBe(true);
       }
@@ -130,7 +135,11 @@ describe("discovery-scan claim hookless write safety preconditions", () => {
      * overlap shows up here.
      */
     test("the claim write's columns are disjoint from what onBeforeUpdate validates", () => {
-      const claimWriteColumns: Array<string> = ["status", "startedAt"];
+      const claimWriteColumns: Array<string> = [
+        "status",
+        "startedAt",
+        "statusMessage",
+      ];
       const columnsValidatedByHook: Array<string> = ["cidr"];
 
       for (const column of claimWriteColumns) {
@@ -146,7 +155,11 @@ describe("discovery-scan claim hookless write safety preconditions", () => {
     test("onBeforeUpdate is a pass-through for the exact claim payload", async () => {
       const claimUpdateBy: unknown = {
         query: { _id: "some-scan-id" },
-        data: { status: "In Progress", startedAt: new Date(0) },
+        data: {
+          status: "In Progress",
+          startedAt: new Date(0),
+          statusMessage: null,
+        },
         props: { isRoot: true },
         limit: 1,
         skip: 0,

--- a/Common/Tests/Utils/NetworkDiscovery/UnclaimedScanDiagnosis.test.ts
+++ b/Common/Tests/Utils/NetworkDiscovery/UnclaimedScanDiagnosis.test.ts
@@ -1,0 +1,213 @@
+import {
+  MAX_SCAN_STATUS_MESSAGE_LENGTH,
+  UNCLAIMED_PENDING_MINUTES,
+  buildUnclaimedScanDiagnosis,
+} from "../../../Utils/NetworkDiscovery/UnclaimedScanDiagnosis";
+import OneUptimeDate from "../../../Types/Date";
+import { describe, expect, test } from "@jest/globals";
+
+/*
+ * The sentence a stuck discovery scan gets to say for itself.
+ *
+ * A scan leaves "Pending" only when a probe asks for it. When no probe ever
+ * does, nothing times out and nothing fails — the row simply never moves, and
+ * before this existed the product said nothing at all about it. OneUptime
+ * issue #3287 is that silence: four scans submitted over an hour, all
+ * "Pending", an em-dash where the result goes, and no way to tell a scan
+ * queued a second ago from one no probe will ever pick up.
+ *
+ * So these tests are about the WORDS, not a state machine: whether an operator
+ * reading the row learns which of the two very different problems they have,
+ * and whether the sentence survives the varchar(500) column it is written to.
+ */
+
+const disconnectedProbe = {
+  probeName: "Datacentre Probe",
+  isProbeConnected: false,
+  lastAliveAt: OneUptimeDate.getSomeHoursAgo(6),
+};
+
+const connectedProbe = {
+  probeName: "Datacentre Probe",
+  isProbeConnected: true,
+  lastAliveAt: OneUptimeDate.getCurrentDate(),
+};
+
+describe("buildUnclaimedScanDiagnosis — the probe is not connected", () => {
+  test("names the probe the operator chose", () => {
+    expect(buildUnclaimedScanDiagnosis(disconnectedProbe)).toContain(
+      'Probe "Datacentre Probe"',
+    );
+  });
+
+  test("says the probe is not connected, which is the actual fault", () => {
+    expect(buildUnclaimedScanDiagnosis(disconnectedProbe)).toContain(
+      "is not connected to OneUptime",
+    );
+  });
+
+  /*
+   * "Last seen 6 hours ago" is the difference between "my probe just
+   * restarted" and "that probe has been gone since the upgrade".
+   */
+  test("says when the probe was last seen", () => {
+    expect(buildUnclaimedScanDiagnosis(disconnectedProbe)).toContain(
+      "It was last seen",
+    );
+  });
+
+  test("a probe that has never connected says exactly that, not 'last seen never'", () => {
+    const message: string = buildUnclaimedScanDiagnosis({
+      probeName: "Brand New Probe",
+      isProbeConnected: false,
+      lastAliveAt: null,
+    });
+
+    expect(message).toContain("It has never connected.");
+    expect(message).not.toContain("last seen");
+  });
+
+  test("a missing lastAlive is treated the same as never connecting", () => {
+    expect(
+      buildUnclaimedScanDiagnosis({
+        isProbeConnected: false,
+      }),
+    ).toContain("It has never connected.");
+  });
+
+  /*
+   * The scan is annotated, not failed, so the operator needs to know they do
+   * not have to re-create it.
+   */
+  test("promises the scan still runs once the probe returns", () => {
+    expect(buildUnclaimedScanDiagnosis(disconnectedProbe)).toContain(
+      "as soon as the probe reconnects",
+    );
+  });
+});
+
+describe("buildUnclaimedScanDiagnosis — the probe IS connected", () => {
+  /*
+   * A completely different problem with a completely different fix: the probe
+   * is running and authenticating, but its discovery job is not claiming
+   * scans — an old image, a wedged sweep, or a probe that can reach the
+   * heartbeat route but not the probe-ingest one.
+   */
+  test("does not blame the connection", () => {
+    const message: string = buildUnclaimedScanDiagnosis(connectedProbe);
+
+    expect(message).toContain("is connected but has not picked this scan up");
+    expect(message).not.toContain("is not connected");
+  });
+
+  test("names the two things worth checking", () => {
+    const message: string = buildUnclaimedScanDiagnosis(connectedProbe);
+
+    expect(message).toContain("version that supports");
+    expect(message).toContain("probe-ingest");
+  });
+
+  test("quotes the threshold it actually waited for", () => {
+    expect(buildUnclaimedScanDiagnosis(connectedProbe)).toContain(
+      `${UNCLAIMED_PENDING_MINUTES} minutes`,
+    );
+  });
+
+  test("the two branches are genuinely different sentences", () => {
+    expect(buildUnclaimedScanDiagnosis(connectedProbe)).not.toBe(
+      buildUnclaimedScanDiagnosis(disconnectedProbe),
+    );
+  });
+});
+
+describe("buildUnclaimedScanDiagnosis — a probe with no readable name", () => {
+  test("falls back to a phrase that still reads as a sentence", () => {
+    const message: string = buildUnclaimedScanDiagnosis({
+      isProbeConnected: false,
+      lastAliveAt: null,
+    });
+
+    expect(message).toContain("The assigned probe is not connected");
+    expect(message).not.toContain('Probe ""');
+  });
+
+  test("an empty-string name is treated as no name", () => {
+    expect(
+      buildUnclaimedScanDiagnosis({
+        probeName: "",
+        isProbeConnected: true,
+      }),
+    ).toContain("The assigned probe");
+  });
+});
+
+describe("buildUnclaimedScanDiagnosis — it has to fit the column", () => {
+  /*
+   * statusMessage is a varchar(500) and this message is written through the
+   * full update pipeline, which does NOT clamp. An over-long value throws, and
+   * the diagnosis is lost precisely when it is most needed.
+   */
+  test("the column ceiling is the one the model declares", () => {
+    expect(MAX_SCAN_STATUS_MESSAGE_LENGTH).toBe(500);
+  });
+
+  test("every message fits, for both branches", () => {
+    for (const probeState of [disconnectedProbe, connectedProbe]) {
+      expect(
+        buildUnclaimedScanDiagnosis(probeState).length,
+      ).toBeLessThanOrEqual(MAX_SCAN_STATUS_MESSAGE_LENGTH);
+    }
+  });
+
+  /*
+   * A probe name is a ShortText column, so 100 characters is the real worst
+   * case. Feeding well past it proves the truncation is what bounds the
+   * message rather than the caller's good manners.
+   */
+  test("an absurdly long probe name cannot overflow the column", () => {
+    const longName: string = "N".repeat(400);
+
+    for (const isProbeConnected of [true, false]) {
+      const message: string = buildUnclaimedScanDiagnosis({
+        probeName: longName,
+        isProbeConnected: isProbeConnected,
+        lastAliveAt: OneUptimeDate.getSomeHoursAgo(200),
+      });
+
+      expect(message.length).toBeLessThanOrEqual(
+        MAX_SCAN_STATUS_MESSAGE_LENGTH,
+      );
+    }
+  });
+
+  test("a long name is cut with an ellipsis rather than silently dropped", () => {
+    const message: string = buildUnclaimedScanDiagnosis({
+      probeName: "N".repeat(400),
+      isProbeConnected: false,
+    });
+
+    expect(message).toContain("NNN");
+    expect(message).toContain("…");
+  });
+
+  test("a name that fits is left exactly as the operator typed it", () => {
+    expect(
+      buildUnclaimedScanDiagnosis({
+        probeName: "core-sw-probe-01",
+        isProbeConnected: false,
+      }),
+    ).toContain('Probe "core-sw-probe-01"');
+  });
+});
+
+describe("the grace period", () => {
+  /*
+   * The probe polls every minute, so this is a count of consecutive failed
+   * polls. Too short and a probe redeploy annotates every queued scan; too
+   * long and the operator has given up before the product says anything.
+   */
+  test("is long enough to ride out a probe restart and short enough to be useful", () => {
+    expect(UNCLAIMED_PENDING_MINUTES).toBeGreaterThanOrEqual(5);
+    expect(UNCLAIMED_PENDING_MINUTES).toBeLessThanOrEqual(60);
+  });
+});

--- a/Common/Utils/NetworkDiscovery/UnclaimedScanDiagnosis.ts
+++ b/Common/Utils/NetworkDiscovery/UnclaimedScanDiagnosis.ts
@@ -1,0 +1,115 @@
+import OneUptimeDate from "../../Types/Date";
+import ColumnLength from "../../Types/Database/ColumnLength";
+
+/*
+ * Why a network discovery scan is still sitting in "Pending".
+ *
+ * A scan leaves "Pending" in exactly one place: the probe asks
+ * /probe/discovery-scan/list and the server claims a row for it
+ * (App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts). Nothing on the
+ * server can make that happen — if the probe never asks, the row simply never
+ * moves.
+ *
+ * Until this existed, that outcome was completely silent. The scans list
+ * showed "Pending" and an em-dash in Responded Hosts, forever, with no
+ * timestamp, no probe state and no message anywhere in the product; the only
+ * evidence lived in the probe container's log, if the operator had it. That is
+ * what OneUptime issue #3287 reported: four scans submitted over an hour, all
+ * "Pending", nothing to act on.
+ *
+ * So this module writes the sentence the operator was missing. It is pure and
+ * lives in Common so the wording can be unit-tested without a database, the
+ * same way ScanTargetUtil's messages are.
+ *
+ * It deliberately does NOT fail the scan. A scan nobody has claimed is still
+ * perfectly runnable the moment the probe comes back, and a recurring one
+ * would tangle with the re-queue pass; what was missing was information, not a
+ * state change.
+ */
+
+/*
+ * How long a scan may sit unclaimed before the job says anything.
+ *
+ * The probe polls every minute, so this is fifteen consecutive failed polls —
+ * long enough that a restarting probe, a redeploy or a brief network blip
+ * never produces a message, short enough to be useful while the operator is
+ * still looking at the page they just submitted from.
+ *
+ * It is NOT the whole guard against false positives: a scan queued behind
+ * another scan on the same probe is legitimately Pending for as long as that
+ * sweep takes (the claim endpoint hands out one at a time), so the caller
+ * excludes probes that currently have a scan In Progress. This threshold only
+ * decides how long an IDLE probe gets before its silence is worth reporting.
+ */
+export const UNCLAIMED_PENDING_MINUTES: number = 15;
+
+export interface UnclaimedScanProbeState {
+  // The probe the scan was assigned to, as the operator named it.
+  probeName?: string | undefined;
+  /*
+   * The probe's own connection state, as maintained every minute by
+   * Workers/Jobs/Probe/UpdateConnectionStatus.ts. This is the half of the
+   * diagnosis the operator cannot work out for themselves.
+   */
+  isProbeConnected: boolean;
+  // When the probe last authenticated a request. Null if it never has.
+  lastAliveAt?: Date | null | undefined;
+}
+
+/*
+ * The two cases below are genuinely different problems with different fixes,
+ * and telling them apart is the entire point of this message: a probe that is
+ * not connected is an infrastructure problem the operator can see and fix,
+ * whereas a probe that IS connected and still is not claiming scans means the
+ * probe is running but its discovery job is not — an old image, a wedged
+ * sweep, or a probe that cannot reach the probe-ingest route specifically.
+ */
+export function buildUnclaimedScanDiagnosis(
+  probeState: UnclaimedScanProbeState,
+): string {
+  const probeLabel: string = probeState.probeName
+    ? `Probe "${truncateProbeName(probeState.probeName)}"`
+    : "The assigned probe";
+
+  if (!probeState.isProbeConnected) {
+    const lastSeen: string = probeState.lastAliveAt
+      ? `It was last seen ${OneUptimeDate.fromNow(probeState.lastAliveAt)}.`
+      : "It has never connected.";
+
+    return (
+      `Not started yet: ${probeLabel} is not connected to OneUptime, so it has not picked this scan up. ` +
+      `${lastSeen} The scan will run on its own as soon as the probe reconnects.`
+    );
+  }
+
+  return (
+    `Not started yet: ${probeLabel} is connected but has not picked this scan up for over ` +
+    `${UNCLAIMED_PENDING_MINUTES} minutes. Check that the probe is running a version that supports ` +
+    `network discovery, and that it can reach the probe-ingest endpoint. The scan will run on its own ` +
+    `once the probe starts claiming scans again.`
+  );
+}
+
+/*
+ * statusMessage is a varchar(500) and this job writes through the full
+ * update pipeline, which does NOT clamp — an over-long value would throw and
+ * the diagnosis would be lost rather than truncated. The only unbounded part
+ * of the sentence is the probe's name (itself a ShortText column, so at most
+ * 100 characters), and it is cut here so the arithmetic holds for every
+ * possible name. See the test that asserts the worst case still fits.
+ */
+const MAX_PROBE_NAME_LENGTH: number = 60;
+
+function truncateProbeName(name: string): string {
+  if (name.length <= MAX_PROBE_NAME_LENGTH) {
+    return name;
+  }
+
+  return name.substring(0, MAX_PROBE_NAME_LENGTH) + "…";
+}
+
+/*
+ * Exported so the job and its tests agree on the ceiling they are checking
+ * against, rather than both hard-coding 500.
+ */
+export const MAX_SCAN_STATUS_MESSAGE_LENGTH: number = ColumnLength.LongText;

--- a/Probe/Config.ts
+++ b/Probe/Config.ts
@@ -210,6 +210,50 @@ export const PROBE_MONITOR_CHECK_TIMEOUT_IN_MS: number =
     max: MAX_NODE_TIMER_DELAY_IN_MS,
   });
 
+/*
+ * Hard ceiling on ONE network discovery sweep, for exactly the reason
+ * PROBE_MONITOR_CHECK_TIMEOUT_IN_MS exists — and the discovery job needs it
+ * more, not less.
+ *
+ * The discovery cron holds a single-flight guard across the WHOLE cycle
+ * (Jobs/Discovery/FetchScans.ts): list fetch, sweep, and result upload. Every
+ * HTTP call in that cycle carries PROBE_API_REQUEST_TIMEOUT_IN_MS, but the
+ * sweep between them had no deadline of any kind. A sweep opens one ICMP
+ * child process and one UDP SNMP session per address — up to
+ * ScanTargetUtil.MAX_SCAN_HOSTS of them — so it is exactly the kind of code
+ * where one non-settling promise is plausible, and a single one of those
+ * strands the guard set. Not for a cycle: FOREVER. Every later scan then sits
+ * in "Pending" until someone restarts the probe container, with nothing in
+ * the product to say why (OneUptime issue #3287).
+ *
+ * The number is a wall-clock budget with two sides to fit between.
+ *
+ * The floor is the slowest sweep that is still legitimately working. At
+ * MAX_SCAN_HOSTS (32,768) with SubnetScanner's 32 workers, the documented
+ * worst case is a full 1s-per-host ICMP pass (~17 min) followed by a full
+ * 2s-per-host SNMP pass over every address (~34 min) when the ICMP-filtered
+ * fallback triggers — ~51 min, before SNMP v3's extra engine-discovery round
+ * trip.
+ *
+ * The ceiling is the server: it declares an In Progress scan abandoned after
+ * 2 hours (Workers/Jobs/NetworkDeviceDiscovery/RequeueRecurringScans.ts). The
+ * probe has to give up FIRST, or a wedged sweep is reaped server-side while
+ * the probe is still holding its guard — the scan reads Failed while
+ * discovery on that probe stays stopped.
+ *
+ * 90 minutes sits between the two: comfortably above any sweep that is
+ * genuinely making progress, and comfortably below the server's window, so
+ * a scan that crosses this line is reported by the probe itself, with its
+ * own reason, and the next tick fetches again.
+ */
+export const PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS: number =
+  NumberUtil.parseNumberWithDefault({
+    value: process.env["PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS"],
+    defaultValue: 90 * 60 * 1000,
+    min: 1000,
+    max: MAX_NODE_TIMER_DELAY_IN_MS,
+  });
+
 export const PORT: Port = new Port(
   NumberUtil.parseNumberWithDefault({
     value: process.env["PORT"],

--- a/Probe/Jobs/Discovery/FetchScans.ts
+++ b/Probe/Jobs/Discovery/FetchScans.ts
@@ -1,7 +1,11 @@
-import { PROBE_INGEST_URL } from "../../Config";
+import {
+  PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS,
+  PROBE_INGEST_URL,
+} from "../../Config";
 import ProbeAPIRequest from "../../Utils/ProbeAPIRequest";
 import SubnetScanner, {
   DiscoveredHost,
+  type SubnetScanConfig,
   type SubnetScanResult,
 } from "../../Utils/Discovery/SubnetScanner";
 import BaseModel from "Common/Models/DatabaseModels/DatabaseBaseModel/DatabaseBaseModel";
@@ -197,6 +201,96 @@ const InitJob: VoidFunction = (): void => {
   });
 };
 
+/*
+ * The server's own words for a rejected request, or "" when it accepted it.
+ *
+ * Exported for tests. API.fetch RETURNS a rejected request as an
+ * HTTPErrorResponse rather than throwing — it only throws when no response
+ * arrived at all — so a call site that merely wraps the fetch in try/catch
+ * treats every 4xx and 5xx as a success. All three discovery calls need the
+ * same sentence out of that response, so it is built once here.
+ *
+ * `instanceof` is the whole test, deliberately. Axios rejects on any status
+ * outside 2xx and API.getErrorResponse turns exactly those into an
+ * HTTPErrorResponse, so the type IS the verdict — and unlike
+ * HTTPResponse.isSuccess(), which is `statusCode === 200`, it does not
+ * misread a 201 or 204 as a rejection.
+ */
+export function getRejectionReason(
+  result: HTTPResponse<JSONArray> | HTTPErrorResponse,
+): string {
+  if (!(result instanceof HTTPErrorResponse)) {
+    return "";
+  }
+
+  const serverMessage: string = result.message;
+
+  return (
+    `HTTP ${result.statusCode}` + (serverMessage ? ` — ${serverMessage}` : "")
+  );
+}
+
+/*
+ * Exported for tests: bounds ONE sweep in time.
+ *
+ * Mirrors probeMonitorWithDeadline in Jobs/Monitor/FetchList.ts, and exists
+ * for the same reason: Promise.race subscribes to both promises, so a sweep
+ * that settles late is still observed and can never surface as an unhandled
+ * rejection, and nothing here can cancel the sweep — the point is that the
+ * discovery CYCLE stops waiting on it.
+ *
+ * That matters more here than it does for a monitor. The discovery cron holds
+ * a process-lifetime single-flight guard across the whole cycle, so a sweep
+ * that never settles does not cost one cycle: it stops discovery on this
+ * probe permanently, and every scan queued behind it stays "Pending" until
+ * the container is restarted. Rejecting on the deadline drops into runScan's
+ * existing catch, which reports the scan Failed with this reason, so the
+ * operator gets a sentence instead of a row that never changes.
+ */
+export async function scanWithDeadline(
+  config: SubnetScanConfig,
+  scanId: string,
+  deadlineInMs: number = PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS,
+): Promise<SubnetScanResult> {
+  let deadlineTimer: ReturnType<typeof setTimeout> | undefined = undefined;
+
+  const deadline: Promise<never> = new Promise<never>(
+    (_resolve: (value: never) => void, reject: (err: Error) => void) => {
+      deadlineTimer = setTimeout(() => {
+        /*
+         * Logged here, at the moment the deadline is crossed, rather than in
+         * the catch below: only this branch knows the sweep stopped settling
+         * rather than failing for a reason of its own, and the probe log is
+         * the only place that can name WHICH sweep it was.
+         */
+        logger.error(
+          `Discovery scan ${scanId} on ${config.cidr} did not settle within ${deadlineInMs}ms. Abandoning this sweep so discovery on this probe can continue.`,
+        );
+
+        reject(
+          new Error(
+            `The sweep of ${config.cidr} did not finish within ${Math.round(
+              deadlineInMs / 60000,
+            )} minutes and was abandoned. Narrow the scan target, or raise PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS on the probe if this range legitimately needs longer.`,
+          ),
+        );
+      }, deadlineInMs);
+    },
+  );
+
+  try {
+    return await Promise.race([SubnetScanner.scan(config), deadline]);
+  } finally {
+    /*
+     * Always clear it: an un-cleared timer holds the event loop open after an
+     * otherwise healthy sweep, and this one is up to 90 minutes long.
+     */
+    if (deadlineTimer) {
+      clearTimeout(deadlineTimer);
+    }
+  }
+}
+
 // Exported for tests: this is the probe's half of the discovery lifecycle.
 export async function fetchAndRunScans(): Promise<void> {
   const listUrl: URL = URL.fromString(PROBE_INGEST_URL.toString()).addRoute(
@@ -213,6 +307,42 @@ export async function fetchAndRunScans(): Promise<void> {
       headers: {},
       options: ProbeAPIRequest.getDefaultRequestOptions(listUrl),
     });
+
+  /*
+   * API.fetch RETURNS an HTTPErrorResponse for a 4xx/5xx (it only throws when
+   * no response arrived at all), and this union was never discriminated: the
+   * error body — a JSON object, not an array — went straight into
+   * fromJSONArray, whose `for...of` threw "json is not iterable". So the one
+   * thing the operator needed, the server's own explanation ("Probe not
+   * found", "Invalid Probe ID or Probe Key"), was replaced by a TypeError
+   * about a shape, while every scan sat in "Pending" with nothing in the
+   * product to say why (OneUptime issue #3287).
+   */
+  const listRejection: string = getRejectionReason(result);
+
+  if (listRejection) {
+    logger.error(
+      `The server rejected this probe's request for pending discovery scans: ${listRejection}. ` +
+        `No scan on this probe can leave "Pending" until that is resolved.`,
+    );
+
+    return;
+  }
+
+  /*
+   * A 200 whose body is not a list. Nothing the server sends today looks like
+   * this, so it means a proxy or gateway answered in the server's place — the
+   * captive-portal / SSO-login-page case. Naming it beats the same
+   * "not iterable" TypeError one layer down.
+   */
+  if (!Array.isArray(result.data)) {
+    logger.error(
+      `Discovery scan list returned a ${typeof result.data}, not a list of scans. ` +
+        `Something between this probe and the server is answering for it — check PROBE_INGEST_URL and any proxy in front of it.`,
+    );
+
+    return;
+  }
 
   const scans: Array<NetworkDeviceDiscoveryScan> = BaseModel.fromJSONArray(
     result.data as JSONArray,
@@ -237,31 +367,48 @@ export async function runScan(scan: NetworkDeviceDiscoveryScan): Promise<void> {
       `Running discovery scan ${scan.id?.toString()} on ${scan.cidr}`,
     );
 
-    scanResult = await SubnetScanner.scan({
-      cidr: scan.cidr || "",
-      snmpVersion: scan.snmpVersion,
-      snmpCommunityString: scan.snmpCommunityString,
-      snmpV3Auth: buildSnmpV3Auth(scan),
-      snmpPort: scan.snmpPort,
-    });
+    scanResult = await scanWithDeadline(
+      {
+        cidr: scan.cidr || "",
+        snmpVersion: scan.snmpVersion,
+        snmpCommunityString: scan.snmpCommunityString,
+        snmpV3Auth: buildSnmpV3Auth(scan),
+        snmpPort: scan.snmpPort,
+      },
+      scan.id?.toString() || "scan",
+    );
   } catch (err) {
     logger.error(`Discovery scan ${scan.id?.toString()} failed: ${err}`);
 
     // Report the SWEEP failure so the scan doesn't sit In Progress forever.
     try {
-      await API.fetch<JSONArray>({
-        method: HTTPMethod.POST,
-        url: resultUrl,
-        data: {
-          ...ProbeAPIRequest.getDefaultRequestBody(),
-          scanId: scan.id?.toString(),
-          success: false,
-          statusMessage: (err as Error).message || String(err),
-          discoveredDevices: [],
-        },
-        headers: {},
-        options: ProbeAPIRequest.getDefaultRequestOptions(resultUrl),
-      });
+      const reportResult: HTTPResponse<JSONArray> | HTTPErrorResponse =
+        await API.fetch<JSONArray>({
+          method: HTTPMethod.POST,
+          url: resultUrl,
+          data: {
+            ...ProbeAPIRequest.getDefaultRequestBody(),
+            scanId: scan.id?.toString(),
+            success: false,
+            statusMessage: (err as Error).message || String(err),
+            discoveredDevices: [],
+          },
+          headers: {},
+          options: ProbeAPIRequest.getDefaultRequestOptions(resultUrl),
+        });
+
+      /*
+       * A rejected failure report is not a lost diagnostic — it is a scan
+       * that stays In Progress until the server's reaper eventually times it
+       * out, with the real reason known only to this probe. Say so.
+       */
+      const reportRejection: string = getRejectionReason(reportResult);
+
+      if (reportRejection) {
+        logger.error(
+          `The server rejected the failure report for discovery scan ${scan.id?.toString()}: ${reportRejection}`,
+        );
+      }
     } catch (reportErr) {
       logger.error(
         `Failed to report discovery scan failure for ${scan.id?.toString()}: ${reportErr}`,
@@ -310,20 +457,40 @@ export async function runScan(scan: NetworkDeviceDiscoveryScan): Promise<void> {
    * self-heals that case.
    */
   try {
-    await API.fetch<JSONArray>({
-      method: HTTPMethod.POST,
-      url: resultUrl,
-      data: {
-        ...ProbeAPIRequest.getDefaultRequestBody(),
-        scanId: scan.id?.toString(),
-        success: true,
-        statusMessage: statusMessage,
-        discoveredDevices: scanResult.discoveredHosts as unknown as JSONArray,
-        scannedHostCount: scanResult.scannedHostCount,
-      },
-      headers: {},
-      options: ProbeAPIRequest.getDefaultRequestOptions(resultUrl),
-    });
+    const uploadResult: HTTPResponse<JSONArray> | HTTPErrorResponse =
+      await API.fetch<JSONArray>({
+        method: HTTPMethod.POST,
+        url: resultUrl,
+        data: {
+          ...ProbeAPIRequest.getDefaultRequestBody(),
+          scanId: scan.id?.toString(),
+          success: true,
+          statusMessage: statusMessage,
+          discoveredDevices: scanResult.discoveredHosts as unknown as JSONArray,
+          scannedHostCount: scanResult.scannedHostCount,
+        },
+        headers: {},
+        options: ProbeAPIRequest.getDefaultRequestOptions(resultUrl),
+      });
+
+    /*
+     * A rejected upload used to produce no log line at all. API.fetch returns
+     * a 4xx/5xx instead of throwing, so the catch below never ran, and the
+     * only other line on this path is the debug one underneath — which claims
+     * the hosts were delivered and, at the default log level, is not printed
+     * anyway. A sweep that ran for half an hour lost its entire result in
+     * silence. That is worth an error.
+     */
+    const uploadRejection: string = getRejectionReason(uploadResult);
+
+    if (uploadRejection) {
+      logger.error(
+        `The server rejected the result of discovery scan ${scan.id?.toString()}: ${uploadRejection}. ` +
+          `${scanResult.discoveredHosts.length} discovered host(s) were not saved.`,
+      );
+
+      return;
+    }
 
     logger.debug(
       `Discovery scan ${scan.id?.toString()} found ${snmpResponderCount} SNMP hosts (${scanResult.discoveredHosts.length} alive in total)`,

--- a/Probe/Tests/Jobs/Discovery/FetchScansServerErrors.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansServerErrors.test.ts
@@ -1,0 +1,344 @@
+// Set required env vars before importing modules that pull in Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.example.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import HTTPErrorResponse from "Common/Types/API/HTTPErrorResponse";
+import HTTPResponse from "Common/Types/API/HTTPResponse";
+import { JSONArray, JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import API from "Common/Utils/API";
+import logger from "Common/Server/Utils/Logger";
+import SubnetScanner, {
+  SubnetScanResult,
+} from "../../../Utils/Discovery/SubnetScanner";
+import {
+  fetchAndRunScans,
+  getRejectionReason,
+  runScan,
+  resetDiscoveryRunInProgress,
+} from "../../../Jobs/Discovery/FetchScans";
+
+/*
+ * What the probe does when the SERVER says no.
+ *
+ * API.fetch returns a rejected request as an HTTPErrorResponse rather than
+ * throwing — it only throws when no response arrived at all — and none of the
+ * three discovery calls discriminated the union. The list call fed the error
+ * BODY (a JSON object) straight into BaseModel.fromJSONArray, whose `for...of`
+ * threw "json is not iterable"; the two upload calls discarded the response
+ * entirely and logged success.
+ *
+ * The cost was not cosmetic. A scan leaves "Pending" only when the probe's
+ * list call succeeds, so a server that rejects that call leaves every scan
+ * Pending forever — and the one place that could have said why printed a
+ * TypeError about a shape instead of the server's own sentence. That is the
+ * shape of OneUptime issue #3287: four scans, an hour apart, all Pending,
+ * nothing to act on.
+ *
+ * These tests pin that the server's words survive.
+ */
+
+const scanId: ObjectID = ObjectID.generate();
+
+function makeScan(overrides?: JSONObject): NetworkDeviceDiscoveryScan {
+  return {
+    id: scanId,
+    cidr: "10.0.0.0/24",
+    snmpVersion: "V2c",
+    snmpCommunityString: "public",
+    snmpPort: 161,
+    ...overrides,
+  } as unknown as NetworkDeviceDiscoveryScan;
+}
+
+function makeScanResult(): SubnetScanResult {
+  return {
+    discoveredHosts: [],
+    scannedHostCount: 254,
+    scannedPort: 161,
+    respondedToPingCount: 0,
+    snmpErrorHostCount: 0,
+    icmpFilteredFallbackHostCount: 0,
+  } as unknown as SubnetScanResult;
+}
+
+// A real list response, envelope already unwrapped by HTTPResponse.
+function okListResponse(
+  scans: Array<JSONObject>,
+): HTTPResponse<JSONArray> | HTTPErrorResponse {
+  return new HTTPResponse<JSONArray>(
+    200,
+    { data: scans, count: scans.length, skip: 0, limit: 10 },
+    {},
+  ) as unknown as HTTPResponse<JSONArray>;
+}
+
+function errorResponse(
+  statusCode: number,
+  body: JSONObject,
+): HTTPErrorResponse {
+  return new HTTPErrorResponse(statusCode, body, {});
+}
+
+// eslint-disable-next-line @typescript-eslint/typedef
+let fetchSpy = jest.spyOn(API, "fetch");
+// eslint-disable-next-line @typescript-eslint/typedef
+let scanSpy = jest.spyOn(SubnetScanner, "scan");
+// eslint-disable-next-line @typescript-eslint/typedef
+let errorSpy = jest.spyOn(logger, "error");
+// eslint-disable-next-line @typescript-eslint/typedef
+let debugSpy = jest.spyOn(logger, "debug");
+
+beforeEach(() => {
+  resetDiscoveryRunInProgress();
+  fetchSpy = jest.spyOn(API, "fetch").mockResolvedValue({ data: [] } as never);
+  scanSpy = jest
+    .spyOn(SubnetScanner, "scan")
+    .mockResolvedValue(makeScanResult() as never);
+  errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {
+    // Keep test output clean.
+  });
+  debugSpy = jest.spyOn(logger, "debug").mockImplementation(() => {
+    // Keep test output clean.
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function loggedErrors(): string {
+  return errorSpy.mock.calls
+    .map((call: Array<unknown>) => {
+      return String(call[0]);
+    })
+    .join("\n");
+}
+
+describe("getRejectionReason", () => {
+  test("an accepted request produces no reason at all", () => {
+    expect(getRejectionReason(okListResponse([]))).toBe("");
+  });
+
+  /*
+   * The whole point: the server's own sentence reaches the log verbatim.
+   * "Probe not found" and "Invalid Probe ID or Probe Key" are the two the
+   * claim endpoint actually sends, and they name completely different fixes.
+   */
+  test("quotes the server's message alongside the status code", () => {
+    expect(
+      getRejectionReason(errorResponse(400, { message: "Probe not found" })),
+    ).toBe("HTTP 400 — Probe not found");
+  });
+
+  test("reads the message out of a nested error body too", () => {
+    expect(
+      getRejectionReason(
+        errorResponse(400, { error: { message: "Invalid Probe ID" } }),
+      ),
+    ).toContain("Invalid Probe ID");
+  });
+
+  test("a body with no message still reports the status code", () => {
+    expect(getRejectionReason(errorResponse(502, {}))).toBe("HTTP 502");
+  });
+
+  /*
+   * A 2xx that is not exactly 200 is an ACCEPTED request. HTTPResponse's
+   * isSuccess() is `statusCode === 200`, so testing on that instead of the
+   * response type would report a 204 as a rejection and silently stop
+   * discovery on a server that answered perfectly well.
+   */
+  test("a 204 is not a rejection", () => {
+    const noContent: HTTPResponse<JSONArray> = new HTTPResponse<JSONArray>(
+      204,
+      [],
+      {},
+    );
+
+    expect(getRejectionReason(noContent)).toBe("");
+  });
+});
+
+describe("fetchAndRunScans — the server rejects the claim request", () => {
+  /*
+   * The regression itself. Before the fix this threw
+   * "TypeError: json is not iterable" out of fromJSONArray, which the cron's
+   * catch logged in place of the server's explanation.
+   */
+  test("does not throw an opaque parse error", async () => {
+    fetchSpy.mockResolvedValue(
+      errorResponse(400, { message: "Probe not found" }) as never,
+    );
+
+    await expect(fetchAndRunScans()).resolves.toBeUndefined();
+
+    expect(loggedErrors()).not.toContain("iterable");
+  });
+
+  test("logs the server's own reason, with the status code", async () => {
+    fetchSpy.mockResolvedValue(
+      errorResponse(400, { message: "Invalid Probe ID or Probe Key" }) as never,
+    );
+
+    await fetchAndRunScans();
+
+    const logged: string = loggedErrors();
+    expect(logged).toContain("HTTP 400");
+    expect(logged).toContain("Invalid Probe ID or Probe Key");
+  });
+
+  /*
+   * The operator's actual question is "why is my scan still Pending". The log
+   * line has to connect the rejection to that symptom, or it reads as an
+   * unrelated warning.
+   */
+  test("says what the rejection means for the scans that are waiting", async () => {
+    fetchSpy.mockResolvedValue(errorResponse(500, {}) as never);
+
+    await fetchAndRunScans();
+
+    expect(loggedErrors()).toContain("Pending");
+  });
+
+  test("sweeps nothing — a rejected list is not an empty list", async () => {
+    fetchSpy.mockResolvedValue(errorResponse(403, {}) as never);
+
+    await fetchAndRunScans();
+
+    expect(scanSpy).not.toHaveBeenCalled();
+    // The failed list call, and no follow-up result upload.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("fetchAndRunScans — the response is not a list of scans", () => {
+  /*
+   * A 200 whose body is an HTML login page or a proxy's JSON. Same
+   * "not iterable" crash, different cause, and the fix has to name the cause
+   * rather than the shape.
+   */
+  test("a 200 carrying an object instead of a list is reported, not thrown", async () => {
+    fetchSpy.mockResolvedValue(
+      new HTTPResponse<JSONArray>(200, { loginRequired: true }, {}) as never,
+    );
+
+    await expect(fetchAndRunScans()).resolves.toBeUndefined();
+
+    const logged: string = loggedErrors();
+    expect(logged).toContain("PROBE_INGEST_URL");
+    expect(scanSpy).not.toHaveBeenCalled();
+  });
+
+  test("a real, empty list is NOT treated as an error", async () => {
+    fetchSpy.mockResolvedValue(okListResponse([]) as never);
+
+    await fetchAndRunScans();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(scanSpy).not.toHaveBeenCalled();
+  });
+
+  test("a real list is still swept", async () => {
+    fetchSpy.mockResolvedValue(
+      okListResponse([
+        { _id: scanId.toString(), cidr: "10.0.0.0/30" },
+      ]) as never,
+    );
+
+    await fetchAndRunScans();
+
+    expect(scanSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runScan — the server rejects the result upload", () => {
+  test("a rejected result upload is an error, not a debug 'found N hosts'", async () => {
+    fetchSpy.mockResolvedValue(
+      errorResponse(413, { message: "Payload too large" }) as never,
+    );
+
+    await runScan(makeScan());
+
+    const logged: string = loggedErrors();
+    expect(logged).toContain("HTTP 413");
+    expect(logged).toContain("Payload too large");
+
+    // The success line must not also have been written.
+    const debugLines: string = debugSpy.mock.calls
+      .map((call: Array<unknown>) => {
+        return String(call[0]);
+      })
+      .join("\n");
+    expect(debugLines).not.toContain("found 0 SNMP hosts");
+  });
+
+  test("names how many discovered hosts were lost", async () => {
+    scanSpy.mockResolvedValue({
+      ...makeScanResult(),
+      discoveredHosts: [
+        { ipAddress: "10.0.0.1", snmpReachable: true },
+        { ipAddress: "10.0.0.2", snmpReachable: false },
+      ],
+    } as never);
+    fetchSpy.mockResolvedValue(errorResponse(500, {}) as never);
+
+    await runScan(makeScan());
+
+    expect(loggedErrors()).toContain("2 discovered host(s) were not saved");
+  });
+
+  test("an accepted upload logs no error", async () => {
+    fetchSpy.mockResolvedValue(
+      new HTTPResponse<JSONArray>(200, { result: "ok" }, {}) as never,
+    );
+
+    await runScan(makeScan());
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("runScan — the server rejects the FAILURE report", () => {
+  /*
+   * The sweep failed AND the report of that failure was refused. The scan is
+   * now stranded In Progress until the server's reaper times it out, and this
+   * probe is the only place that knows the real reason — so the rejection
+   * itself has to be logged, not swallowed.
+   */
+  test("the rejected failure report is logged with the scan id", async () => {
+    scanSpy.mockRejectedValue(new Error("target is malformed") as never);
+    fetchSpy.mockResolvedValue(
+      errorResponse(400, { message: "nope" }) as never,
+    );
+
+    await runScan(makeScan());
+
+    const logged: string = loggedErrors();
+    expect(logged).toContain(scanId.toString());
+    expect(logged).toContain("HTTP 400");
+  });
+
+  test("an accepted failure report logs only the sweep failure", async () => {
+    scanSpy.mockRejectedValue(new Error("target is malformed") as never);
+    fetchSpy.mockResolvedValue(
+      new HTTPResponse<JSONArray>(200, { result: "ok" }, {}) as never,
+    );
+
+    await runScan(makeScan());
+
+    const logged: string = loggedErrors();
+    expect(logged).toContain("target is malformed");
+    expect(logged).not.toContain("rejected the failure report");
+  });
+});

--- a/Probe/Tests/Jobs/Discovery/FetchScansSweepDeadline.test.ts
+++ b/Probe/Tests/Jobs/Discovery/FetchScansSweepDeadline.test.ts
@@ -1,0 +1,327 @@
+// Set required env vars before importing modules that pull in Config.ts.
+process.env["ONEUPTIME_URL"] = "https://oneuptime.example.com";
+process.env["PROBE_KEY"] = "test-probe-key";
+process.env["PROBE_ID"] = "11111111-2222-3333-4444-555555555555";
+/*
+ * The smallest deadline Config accepts (parseNumberWithDefault falls back to
+ * the 90-minute default for anything below its 1000ms floor). Set here, before
+ * the import, so these tests drive the REAL Config -> runScan wiring rather
+ * than a value passed in by hand.
+ */
+process.env["PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS"] = "1000";
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { PromiseVoidFunction } from "Common/Types/FunctionTypes";
+
+type CapturedCronJob = {
+  jobName: string;
+  runFunction: PromiseVoidFunction;
+};
+
+const mockCapturedCronJobs: Array<CapturedCronJob> = [];
+
+jest.mock("Common/Server/Utils/BasicCron", () => {
+  return {
+    __esModule: true,
+    default: (props: CapturedCronJob): void => {
+      mockCapturedCronJobs.push(props);
+    },
+  };
+});
+
+import { JSONObject } from "Common/Types/JSON";
+import ObjectID from "Common/Types/ObjectID";
+import NetworkDeviceDiscoveryScan from "Common/Models/DatabaseModels/NetworkDeviceDiscoveryScan";
+import API from "Common/Utils/API";
+import logger from "Common/Server/Utils/Logger";
+import SubnetScanner, {
+  SubnetScanConfig,
+  SubnetScanResult,
+} from "../../../Utils/Discovery/SubnetScanner";
+import InitJob, {
+  runScan,
+  scanWithDeadline,
+  resetDiscoveryRunInProgress,
+} from "../../../Jobs/Discovery/FetchScans";
+
+/*
+ * A sweep that never settles must not stop discovery forever.
+ *
+ * The discovery cron holds a single-flight guard for the WHOLE cycle — list
+ * fetch, sweep, result upload — and clears it only in a `finally`. Both HTTP
+ * calls carry a 45s deadline, but the sweep between them had none, and a
+ * sweep is the part most likely to hang: it opens one ICMP child process and
+ * one UDP SNMP session per address, up to 32,768 of them.
+ *
+ * One non-settling promise in there did not cost a cycle. It stranded the
+ * guard set for the lifetime of the process, so the probe never asked for
+ * another scan, and every scan afterwards sat in "Pending" until someone
+ * restarted the container — with nothing anywhere in the product to say why.
+ * That is the failure mode OneUptime issue #3287 describes.
+ *
+ * FetchScansGuardAndTimeout.test.ts already pins that the guard releases when
+ * the FETCH fails. These pin the case it could not reach: the sweep itself.
+ */
+
+const scanId: ObjectID = ObjectID.generate();
+
+function makeScan(overrides?: JSONObject): NetworkDeviceDiscoveryScan {
+  return {
+    id: scanId,
+    cidr: "10.240-249.0-254.220-226",
+    snmpVersion: "V2c",
+    snmpCommunityString: "public",
+    snmpPort: 161,
+    ...overrides,
+  } as unknown as NetworkDeviceDiscoveryScan;
+}
+
+function makeScanResult(): SubnetScanResult {
+  return {
+    discoveredHosts: [],
+    scannedHostCount: 254,
+    scannedPort: 161,
+    respondedToPingCount: 0,
+    snmpErrorHostCount: 0,
+    icmpFilteredFallbackHostCount: 0,
+  } as unknown as SubnetScanResult;
+}
+
+const scanConfig: SubnetScanConfig = {
+  cidr: "10.240-249.0-254.220-226",
+};
+
+// A sweep that never settles, exactly as a wedged ping/SNMP promise behaves.
+function neverSettles<T>(): Promise<T> {
+  return new Promise<T>(() => {
+    // Intentionally empty.
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/typedef
+let fetchSpy = jest.spyOn(API, "fetch");
+// eslint-disable-next-line @typescript-eslint/typedef
+let scanSpy = jest.spyOn(SubnetScanner, "scan");
+// eslint-disable-next-line @typescript-eslint/typedef
+let errorSpy = jest.spyOn(logger, "error");
+
+beforeEach(() => {
+  resetDiscoveryRunInProgress();
+  mockCapturedCronJobs.length = 0;
+  fetchSpy = jest.spyOn(API, "fetch").mockResolvedValue({ data: [] } as never);
+  scanSpy = jest
+    .spyOn(SubnetScanner, "scan")
+    .mockResolvedValue(makeScanResult() as never);
+  errorSpy = jest.spyOn(logger, "error").mockImplementation(() => {
+    // Keep test output clean.
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function loggedErrors(): string {
+  return errorSpy.mock.calls
+    .map((call: Array<unknown>) => {
+      return String(call[0]);
+    })
+    .join("\n");
+}
+
+describe("scanWithDeadline — a sweep that finishes", () => {
+  test("returns the sweep's own result untouched", async () => {
+    const result: SubnetScanResult = makeScanResult();
+    scanSpy.mockResolvedValue(result as never);
+
+    await expect(scanWithDeadline(scanConfig, "scan-1", 5000)).resolves.toBe(
+      result,
+    );
+  });
+
+  test("passes the config straight through to the scanner", async () => {
+    await scanWithDeadline(scanConfig, "scan-1", 5000);
+
+    expect(scanSpy).toHaveBeenCalledWith(scanConfig);
+  });
+
+  /*
+   * The deadline here is up to 90 minutes. An un-cleared timer of that length
+   * keeps the Node event loop alive after an otherwise healthy sweep, which
+   * on a probe that is shutting down looks like a hung container.
+   */
+  test("clears its timer, so a healthy sweep leaves nothing pending", async () => {
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const clearSpy = jest.spyOn(global, "clearTimeout");
+
+    await scanWithDeadline(scanConfig, "scan-1", 5000);
+
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
+  test("a sweep that REJECTS still clears its timer", async () => {
+    // eslint-disable-next-line @typescript-eslint/typedef
+    const clearSpy = jest.spyOn(global, "clearTimeout");
+    scanSpy.mockRejectedValue(new Error("target is malformed") as never);
+
+    await expect(scanWithDeadline(scanConfig, "scan-1", 5000)).rejects.toThrow(
+      "target is malformed",
+    );
+
+    expect(clearSpy).toHaveBeenCalled();
+  });
+
+  test("a sweep's own failure is passed through, not replaced by the deadline", async () => {
+    scanSpy.mockRejectedValue(new Error("ICMP ping is not usable") as never);
+
+    await expect(scanWithDeadline(scanConfig, "scan-1", 5000)).rejects.toThrow(
+      "ICMP ping is not usable",
+    );
+  });
+});
+
+describe("scanWithDeadline — a sweep that never settles", () => {
+  test("rejects instead of hanging forever", async () => {
+    scanSpy.mockImplementation(() => {
+      return neverSettles<SubnetScanResult>() as never;
+    });
+
+    await expect(
+      scanWithDeadline(scanConfig, "scan-1", 50),
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  /*
+   * The message becomes the scan's statusMessage, so it is the only thing the
+   * operator sees on the row. It has to name the target (which of several
+   * scans this was) and the way out.
+   */
+  test("names the scan target and the knob that raises the deadline", async () => {
+    scanSpy.mockImplementation(() => {
+      return neverSettles<SubnetScanResult>() as never;
+    });
+
+    await expect(scanWithDeadline(scanConfig, "scan-1", 50)).rejects.toThrow(
+      /10\.240-249\.0-254\.220-226/,
+    );
+    await expect(scanWithDeadline(scanConfig, "scan-1", 50)).rejects.toThrow(
+      /PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS/,
+    );
+  });
+
+  test("logs which scan stopped settling, at error level", async () => {
+    scanSpy.mockImplementation(() => {
+      return neverSettles<SubnetScanResult>() as never;
+    });
+
+    await expect(scanWithDeadline(scanConfig, "scan-42", 50)).rejects.toThrow();
+
+    expect(loggedErrors()).toContain("scan-42");
+  });
+});
+
+describe("runScan — a wedged sweep is reported, not swallowed", () => {
+  test("reports the scan as failed with the deadline as the reason", async () => {
+    scanSpy.mockImplementation(() => {
+      return neverSettles<SubnetScanResult>() as never;
+    });
+
+    await runScan(makeScan());
+
+    /*
+     * The failure report is what moves the row off "In Progress". Without it
+     * the scan waits for the server's 2-hour reaper with no explanation.
+     */
+    const uploads: Array<JSONObject> = fetchSpy.mock.calls.map(
+      (call: Array<unknown>) => {
+        return (call[0] as JSONObject)["data"] as JSONObject;
+      },
+    );
+
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0]!["success"]).toBe(false);
+    expect(String(uploads[0]!["statusMessage"])).toContain("did not finish");
+    expect(uploads[0]!["scanId"]).toBe(scanId.toString());
+  });
+
+  test("uses the configured deadline, not an unbounded wait", async () => {
+    scanSpy.mockImplementation(() => {
+      return neverSettles<SubnetScanResult>() as never;
+    });
+
+    const startedAt: number = Date.now();
+    await runScan(makeScan());
+
+    /*
+     * PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS is 1000 for this file. The upper
+     * bound is generous — the point is that it returned at all.
+     */
+    expect(Date.now() - startedAt).toBeLessThan(20000);
+  });
+});
+
+describe("the overlap guard survives a wedged sweep", () => {
+  function capturedRunFunction(): PromiseVoidFunction {
+    InitJob();
+    const captured: CapturedCronJob | undefined =
+      mockCapturedCronJobs[mockCapturedCronJobs.length - 1];
+    if (!captured) {
+      throw new Error("InitJob did not register a cron job");
+    }
+    return captured.runFunction;
+  }
+
+  /*
+   * THE regression test for issue #3287's failure mode. Before the deadline,
+   * this second tick returned immediately without fetching — and so did every
+   * tick after it, forever.
+   */
+  test("a tick whose sweep never settles still releases the guard, so the next tick fetches again", async () => {
+    const runFunction: PromiseVoidFunction = capturedRunFunction();
+
+    fetchSpy.mockResolvedValue({
+      data: [{ _id: scanId.toString(), cidr: "10.0.0.0/30" }],
+    } as never);
+    scanSpy.mockImplementation(() => {
+      return neverSettles<SubnetScanResult>() as never;
+    });
+
+    await expect(runFunction()).resolves.toBeUndefined();
+
+    const callsAfterFirstTick: number = fetchSpy.mock.calls.length;
+
+    await expect(runFunction()).resolves.toBeUndefined();
+
+    expect(fetchSpy.mock.calls.length).toBeGreaterThan(callsAfterFirstTick);
+  });
+
+  test("and the scan that wedged it is reported failed rather than left silent", async () => {
+    const runFunction: PromiseVoidFunction = capturedRunFunction();
+
+    fetchSpy.mockResolvedValue({
+      data: [{ _id: scanId.toString(), cidr: "10.0.0.0/30" }],
+    } as never);
+    scanSpy.mockImplementation(() => {
+      return neverSettles<SubnetScanResult>() as never;
+    });
+
+    await runFunction();
+
+    const failureReports: Array<JSONObject> = fetchSpy.mock.calls
+      .map((call: Array<unknown>) => {
+        return (call[0] as JSONObject)["data"] as JSONObject;
+      })
+      .filter((body: JSONObject) => {
+        return body["success"] === false;
+      });
+
+    expect(failureReports).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #3287.

## What I found

The reporter's four scans sat in "Pending" for over an hour with an em-dash in
Responded Hosts. Their targets are fine — all four parse and size-check
cleanly, and the smallest is 500 addresses, so this is not a scale problem:

| Target | Addresses | Status |
| --- | --- | --- |
| `10.64.71-195.220-223` (12:57) | 500 | Pending |
| `10.240-249.0-254.11-18` (13:12) | 20,400 | Pending |
| `10.64.71-195.220-223` (13:14) | 500 | Pending |
| `10.240-249.0-254.220-226` (13:52) | 17,850 | Pending |

**There is no code regression in the discovery path.** Diffing the whole
lifecycle between the reporter's last working day (2026-08-12) and the build
they reported on (v12.0.12, `9d6efd42`) returns nothing at all:
`Probe/Jobs/Discovery`, `Probe/Utils/Discovery`,
`App/FeatureSet/Telemetry/API/ProbeIngest/DiscoveryScan.ts`,
`App/FeatureSet/Workers/Jobs/NetworkDeviceDiscovery`,
`Common/Utils/NetworkDiscovery`, `NetworkDeviceDiscoveryScanService` and the
model are byte-identical across that window. The last change to any of them is
`35b1a9d219` (2026-08-09), which their own Aug-12 results prove they were
already running.

A scan leaves "Pending" in exactly one place: the probe asks
`/probe/discovery-scan/list`, and the server claims a row *inside* that
handler, before it responds. So a row that never moves means the probe never
successfully asked — the trigger is on the probe's side of that call
(container not running the new build, not reaching the ingest route, or its
auth being refused after the upgrade).

**The product could not say any of that**, and that is what this PR fixes.
There is a reaper for a scan stranded *In Progress*, but nothing at all
watches a scan nobody ever claimed, and every path that could have reported
the cause discarded it. So the same failure was undiagnosable — which is the
actual bug report.

## What this changes

**Nobody was watching a Pending scan**

- a third pass in the discovery worker annotates a scan that has been Pending
  and unclaimed for 15 minutes, naming the probe and whether it is connected
  (`explainUnclaimedScans`). It *annotates* rather than fails: the scan is
  still runnable the moment the probe returns, and failing a recurring one
  would fight the re-queue pass in the same tick. Scans queued behind an
  in-flight sweep on the same probe are excluded — that is ordinary queueing,
  not a fault — and the note is only rewritten when the sentence changes, so
  an offline probe does not cost an `UPDATE` per scan per minute
- the claim clears that note, since a probe picking the scan up is exactly the
  thing the note said was not happening

**The explanations that were written and never shown**

- the Responded Hosts cell short-circuited to an em-dash whenever there were
  no host counts — precisely the state of a scan that never ran. Both the new
  note and the existing *"The probe did not report a result within 2 hours"*
  were stored, fetched by the page, and rendered nowhere

**The probe threw away the server's answer**

- `API.fetch` *returns* a rejected request rather than throwing, and none of
  the three discovery calls discriminated the union. The list call fed the
  error body into `fromJSONArray`, so `Probe not found` surfaced as
  `TypeError: json is not iterable`; both upload calls discarded the response
  and fell through to a debug line claiming success
- a `200` whose body is not a list is now named as a proxy answering in the
  server's place, rather than crashing the same way one layer down

**One wedged sweep stopped discovery for good**

- the discovery cron holds a single-flight guard across the whole cycle, and
  the sweep between its two 45s-deadlined HTTP calls had no deadline of any
  kind. A sweep opens an ICMP child process and a UDP SNMP session per
  address, up to 32,768 of them; one non-settling promise stranded the guard
  set for the life of the process, so every later scan stayed Pending until
  the container was restarted. `PROBE_DISCOVERY_SCAN_TIMEOUT_IN_MS` (90
  minutes — between the ~51-minute worst legitimate sweep and the server's
  2-hour abandonment window) bounds it, mirroring the deadline monitor checks
  already carry since #3225

**Two more in the same lifecycle**

- a result for a scan that has gone back to Pending is discarded instead of
  retiring a run that was queued and never happened. A late result for a
  *Failed* scan is still accepted — that is the truth about the same run
- the already-registered lookup is paged instead of capped at `LIMIT_MAX`,
  which silently reported every device past the 10,000th as unregistered and
  had the reviewer re-import devices that already existed
- the probe dropdown no longer throws during render for a probe row with no
  name, which blanked the entire Discovery Scans page rather than degrading
  one option

## What the operator sees now

A scan the probe never picked up explains itself on the row:

> Not started yet: Probe "Datacentre Probe" is not connected to OneUptime, so
> it has not picked this scan up. It was last seen 6 hours ago. The scan will
> run on its own as soon as the probe reconnects.

and, for the other half of the split, a probe that *is* connected but is not
claiming scans points at the version and the probe-ingest route instead.

## Tests

79 new tests, all green alongside the existing suites:

| Suite | |
| --- | --- |
| `Probe/Tests/Jobs/Discovery` + `Tests/Utils/Discovery` | 160 passed (9 suites) |
| `Common/Tests/Utils/NetworkDiscovery` + discovery services | 111 passed (4 suites) |
| `App/Tests` — ingest, worker, dashboard | 78 passed (4 suites) |

New files:

- `Probe/Tests/Jobs/Discovery/FetchScansSweepDeadline.test.ts` — including the
  regression test for the wedge: a tick whose sweep never settles still
  releases the guard, so the next tick fetches again
- `Probe/Tests/Jobs/Discovery/FetchScansServerErrors.test.ts` — the server's
  own words survive to the log, on all three calls
- `Common/Tests/Utils/NetworkDiscovery/UnclaimedScanDiagnosis.test.ts` — the
  wording of both branches, and that the worst case still fits the
  `varchar(500)` it is written to
- `App/Tests/Workers/Jobs/NetworkDeviceDiscovery/UnclaimedScans.test.ts` — that
  the pass never mistakes a queued scan for a stuck one, and never churns
