### PR TITLE
fix(analytics): send one GA4 event per conversion, document the GTM wiring

### DIFF
--- a/Docs/analytics/gtm-key-events.json
+++ b/Docs/analytics/gtm-key-events.json
@@ -1,0 +1,404 @@
+{
+  "exportFormatVersion": 2,
+  "exportTime": "2026-08-20 00:00:00",
+  "containerVersion": {
+    "path": "accounts/3785687533/containers/9605811/versions/0",
+    "accountId": "3785687533",
+    "containerId": "9605811",
+    "containerVersionId": "0",
+    "container": {
+      "path": "accounts/3785687533/containers/9605811",
+      "accountId": "3785687533",
+      "containerId": "9605811",
+      "name": "oneuptime.com",
+      "publicId": "GTM-PKQD5WH",
+      "usageContext": ["WEB"],
+      "fingerprint": "0"
+    },
+    "variable": [
+      {
+        "accountId": "3785687533",
+        "containerId": "9605811",
+        "variableId": "100",
+        "name": "DLV - value",
+        "type": "v",
+        "parameter": [
+          {
+            "type": "INTEGER",
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "setDefaultValue",
+            "value": "false"
+          },
+          {
+            "type": "TEMPLATE",
+            "key": "name",
+            "value": "value"
+          }
+        ],
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "3785687533",
+        "containerId": "9605811",
+        "variableId": "101",
+        "name": "DLV - currency",
+        "type": "v",
+        "parameter": [
+          {
+            "type": "INTEGER",
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "setDefaultValue",
+            "value": "false"
+          },
+          {
+            "type": "TEMPLATE",
+            "key": "name",
+            "value": "currency"
+          }
+        ],
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "3785687533",
+        "containerId": "9605811",
+        "variableId": "102",
+        "name": "DLV - plan",
+        "type": "v",
+        "parameter": [
+          {
+            "type": "INTEGER",
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "setDefaultValue",
+            "value": "false"
+          },
+          {
+            "type": "TEMPLATE",
+            "key": "name",
+            "value": "plan"
+          }
+        ],
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "3785687533",
+        "containerId": "9605811",
+        "variableId": "103",
+        "name": "DLV - funnel_stage",
+        "type": "v",
+        "parameter": [
+          {
+            "type": "INTEGER",
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "setDefaultValue",
+            "value": "false"
+          },
+          {
+            "type": "TEMPLATE",
+            "key": "name",
+            "value": "funnel_stage"
+          }
+        ],
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "3785687533",
+        "containerId": "9605811",
+        "variableId": "104",
+        "name": "DLV - is_paid_conversion",
+        "type": "v",
+        "parameter": [
+          {
+            "type": "INTEGER",
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "setDefaultValue",
+            "value": "false"
+          },
+          {
+            "type": "TEMPLATE",
+            "key": "name",
+            "value": "is_paid_conversion"
+          }
+        ],
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "3785687533",
+        "containerId": "9605811",
+        "variableId": "105",
+        "name": "DLV - project_id",
+        "type": "v",
+        "parameter": [
+          {
+            "type": "INTEGER",
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "setDefaultValue",
+            "value": "false"
+          },
+          {
+            "type": "TEMPLATE",
+            "key": "name",
+            "value": "project_id"
+          }
+        ],
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "3785687533",
+        "containerId": "9605811",
+        "variableId": "106",
+        "name": "DLV - booking_kind",
+        "type": "v",
+        "parameter": [
+          {
+            "type": "INTEGER",
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "setDefaultValue",
+            "value": "false"
+          },
+          {
+            "type": "TEMPLATE",
+            "key": "name",
+            "value": "booking_kind"
+          }
+        ],
+        "fingerprint": "0"
+      },
+      {
+        "accountId": "3785687533",
+        "containerId": "9605811",
+        "variableId": "107",
+        "name": "DLV - event_schema_version",
+        "type": "v",
+        "parameter": [
+          {
+            "type": "INTEGER",
+            "key": "dataLayerVersion",
+            "value": "2"
+          },
+          {
+            "type": "BOOLEAN",
+            "key": "setDefaultValue",
+            "value": "false"
+          },
+          {
+            "type": "TEMPLATE",
+            "key": "name",
+            "value": "event_schema_version"
+          }
+        ],
+        "fingerprint": "0"
+      }
+    ],
+    "trigger": [
+      {
+        "accountId": "3785687533",
+        "containerId": "9605811",
+        "triggerId": "200",
+        "name": "Custom Event - OneUptime Key Events",
+        "type": "CUSTOM_EVENT",
+        "customEventFilter": [
+          {
+            "type": "MATCH_REGEX",
+            "parameter": [
+              {
+                "type": "TEMPLATE",
+                "key": "arg0",
+                "value": "{{_event}}"
+              },
+              {
+                "type": "TEMPLATE",
+                "key": "arg1",
+                "value": "^(signup_started|sign_up|workspace_created|monitor_created|teammate_invited|subscription_upgraded|subscription_downgraded|meeting_booked|cta_get_started|cta_request_demo|page_view_pricing|page_view_demo)$"
+              }
+            ]
+          }
+        ],
+        "fingerprint": "0"
+      }
+    ],
+    "tag": [
+      {
+        "accountId": "3785687533",
+        "containerId": "9605811",
+        "tagId": "300",
+        "name": "GA4 - OneUptime Key Events",
+        "type": "gaawe",
+        "parameter": [
+          {
+            "type": "BOOLEAN",
+            "key": "sendEcommerceData",
+            "value": "false"
+          },
+          {
+            "type": "TEMPLATE",
+            "key": "eventName",
+            "value": "{{Event}}"
+          },
+          {
+            "type": "LIST",
+            "key": "eventSettingsTable",
+            "list": [
+              {
+                "type": "MAP",
+                "map": [
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameter",
+                    "value": "value"
+                  },
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameterValue",
+                    "value": "{{DLV - value}}"
+                  }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameter",
+                    "value": "currency"
+                  },
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameterValue",
+                    "value": "{{DLV - currency}}"
+                  }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameter",
+                    "value": "plan"
+                  },
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameterValue",
+                    "value": "{{DLV - plan}}"
+                  }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameter",
+                    "value": "funnel_stage"
+                  },
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameterValue",
+                    "value": "{{DLV - funnel_stage}}"
+                  }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameter",
+                    "value": "is_paid_conversion"
+                  },
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameterValue",
+                    "value": "{{DLV - is_paid_conversion}}"
+                  }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameter",
+                    "value": "project_id"
+                  },
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameterValue",
+                    "value": "{{DLV - project_id}}"
+                  }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameter",
+                    "value": "booking_kind"
+                  },
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameterValue",
+                    "value": "{{DLV - booking_kind}}"
+                  }
+                ]
+              },
+              {
+                "type": "MAP",
+                "map": [
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameter",
+                    "value": "event_schema_version"
+                  },
+                  {
+                    "type": "TEMPLATE",
+                    "key": "parameterValue",
+                    "value": "{{DLV - event_schema_version}}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "TEMPLATE",
+            "key": "measurementIdOverride",
+            "value": "G-76XZF1WF3Z"
+          }
+        ],
+        "firingTriggerId": ["200"],
+        "tagFiringOption": "ONCE_PER_EVENT",
+        "fingerprint": "0"
+      }
+    ],
+    "fingerprint": "0"
+  }
+}

--- a/Docs/analytics/revenue-funnel.md
+++ b/Docs/analytics/revenue-funnel.md
@@ -20,21 +20,101 @@ Sales-led bookings are tracked separately — see
 
 ## GA4 setup
 
-In Google Tag Manager, create GA4 Event tags for these exact event names and
-forward the event properties. Mark `sign_up`, `workspace_created`,
-`monitor_created`, `teammate_invited`, and `subscription_upgraded` as key events
-as appropriate. Do not rename events in GTM: joins and historical comparisons
-depend on stable names.
+**This is not automatic.** Emitting an event to the `dataLayer` does not put it
+in GA4. GTM discards every `dataLayer` push that no trigger matches, so until
+the container has a tag bound to a Custom Event trigger, GA4 records only its
+own auto-collected events (`page_view`, `session_start`, `first_visit`,
+`user_engagement`, `scroll`, `click`) and the Key events report reads zero.
 
-Recommended funnel:
+Container `GTM-PKQD5WH`, property `OneUptime`, measurement ID `G-76XZF1WF3Z`.
 
-`signup_started` → `sign_up` → `workspace_created` → `monitor_created` →
-`teammate_invited` → `subscription_upgraded` (`is_paid_conversion = true`)
+### Prerequisite
 
-Use `project_id` to correlate post-signup product events. Acquisition parameters
-are persisted on the User by registration (`utm*`, click IDs, and first-touch
-attribution); the warehouse/CRM join should use the authenticated user and
-project relationship rather than sending email addresses to GA4.
+The GTM snippet is wrapped in `enableGoogleTagManager`, which every render sets
+to `IsBillingEnabled` — i.e. `BILLING_ENABLED === "true"`
+(`Common/Server/BillingConfig.ts`). On a self-hosted install the flag is false,
+`window.dataLayer` is never created, and every browser event silently no-ops.
+Only the hosted product sends anything to Google.
+
+### 1. Import the container config
+
+`Docs/analytics/gtm-key-events.json` creates the variables, trigger and tag
+described below. In GTM: **Admin → Import Container → choose the file → pick an
+existing workspace → Merge → Rename conflicting tags/triggers/variables**, then
+review the change preview before confirming. Never choose **Overwrite** — that
+replaces the whole container and would delete the ad-platform pixels.
+
+To build it by hand instead:
+
+- **Variables** — one Data Layer Variable per event parameter, named
+  `DLV - <param>`: `value`, `currency`, `plan`, `funnel_stage`,
+  `is_paid_conversion`, `project_id`, `booking_kind`, `event_schema_version`.
+- **Trigger** — `Custom Event - OneUptime Key Events`, Custom Event, event name
+  **matches RegEx**:
+
+  ```
+  ^(signup_started|sign_up|workspace_created|monitor_created|teammate_invited|subscription_upgraded|subscription_downgraded|meeting_booked|cta_get_started|cta_request_demo|page_view_pricing|page_view_demo)$
+  ```
+
+- **Tag** — `GA4 - OneUptime Key Events`, type Google Analytics: GA4 Event,
+  measurement ID `G-76XZF1WF3Z`, Event Name `{{Event}}`, and one event
+  parameter row per variable above. Fire it on the trigger.
+
+Use `{{Event}}` rather than 12 separate tags: the event keeps its own name, and
+adding an event later is a one-word edit to the regex.
+
+### Use an allow-list, not "All Custom Events"
+
+The regex is deliberate. `Analytics.capture()` forwards _any_ string to the
+`dataLayer`, and much of what the product sends is not a legal GA4 event name —
+GA4 requires letters, digits and underscores, starting with a letter, at most
+40 characters. Today the same `dataLayer` also receives
+`Page View: Project > Home`, `FORM SUBMIT: Register`, `accounts/login` and
+`dashboard/billing/plan-changed`. A catch-all trigger would forward all of it
+and pollute the property with names GA4 cannot use.
+
+### 2. Mark the key events
+
+The property already had eight key events starred, all reading "No stream data
+detected" because nothing ever reached them: `cta_get_started`,
+`cta_request_demo`, `demo_request`, `generate_lead`, `page_view_demo`,
+`page_view_pricing`, `purchase`, `sign_up`. Marking a key event by name is
+allowed before any data arrives, so the list looked configured while the
+container silently dropped everything.
+
+Two corrections are outstanding in **GA4 → Admin → Data display → Events**:
+
+- **Unstar `page_view_pricing` and `page_view_demo`.** They fire on every load
+  of those pages, so as key events they report browsing as conversions and
+  would train Google Ads bidding on page views. Keep them as ordinary events —
+  still useful for remarketing audiences.
+- **Star the revenue and activation events**, none of which are marked:
+  `subscription_upgraded` (the only event carrying `value`/`currency`),
+  `meeting_booked`, `workspace_created`, `monitor_created`, `teammate_invited`.
+
+`demo_request`, `generate_lead` and `purchase` are starred but nothing emits
+them; they are harmless and can be left or removed. `demo_request` in
+particular is gone for good — see below.
+
+### 3. One event, one path
+
+`subscription_upgraded` carries `value` and `currency`, so GA4 attributes
+revenue to it and Google Ads can bid on it. That only holds if each conversion
+is counted once.
+
+Send everything through the `dataLayer`. Do **not** also call
+`gtag('event', ...)`: once the Google tag is on the page, gtag interop is live
+and that call reaches GA4 directly, bypassing the container — so an event
+mirrored to both is counted twice under one name. `head-basic.ejs` used to
+mirror `meeting_booked` this way and `demo.ejs` sent a single booking under
+three names (`meeting_booked`, `demo_request`, `demo_booked`); both now emit
+once, through the `dataLayer` only.
+
+### 4. Verify before relying on it
+
+Use GTM **Preview** on oneuptime.com, trigger a CTA click, and confirm the tag
+fires. Then check **GA4 → Reports → Engagement → Events** the next day: any
+name from the regex appearing there means the path works end to end.
 
 ## Safety
 

--- a/Home/Tests/MeetingBookedAnalytics.test.ts
+++ b/Home/Tests/MeetingBookedAnalytics.test.ts
@@ -207,17 +207,25 @@ describe("meeting_booked analytics", () => {
       ]);
     });
 
-    test("mirrors the same event to GA4 and the GTM dataLayer", () => {
+    /*
+     * One booking must reach Google exactly once. Once the Google tag is on
+     * the page, gtag interop is live and a `gtag('event', ...)` call goes
+     * straight to GA4, bypassing the container - so mirroring the event to
+     * both gtag and the dataLayer double-counts it as soon as the GTM Custom
+     * Event trigger forwards the dataLayer push. The dataLayer is the only
+     * sanctioned path.
+     */
+    test("reaches Google exactly once, through the dataLayer only", () => {
       const harness: TrackerHarness = loadTracker(html);
 
       harness.track({ bookingKind: "enterprise_demo" });
 
-      expect(harness.gtagCalls[0]?.[0]).toBe("event");
-      expect(harness.gtagCalls[0]?.[1]).toBe("meeting_booked");
+      expect(harness.dataLayer).toHaveLength(1);
       expect(harness.dataLayer[0]).toMatchObject({
         event: "meeting_booked",
         booking_kind: "enterprise_demo",
       });
+      expect(harness.gtagCalls).toHaveLength(0);
     });
 
     test("also emits the caller's legacy event name", () => {
@@ -283,9 +291,10 @@ describe("meeting_booked analytics", () => {
     });
 
     /*
-     * gtag is only defined inside the GTM block, so an unguarded call throws a
-     * ReferenceError on a page rendered without it — losing the PostHog
-     * capture. Analytics must never take the page down with it either way.
+     * dataLayer is only defined inside the GTM block, so an unguarded push
+     * throws a ReferenceError on a page rendered without it - losing the
+     * PostHog capture. Analytics must never take the page down with it either
+     * way.
      */
     test("still reports to PostHog when GTM is absent", async () => {
       const withoutGtm: string = await renderDemo(false);
@@ -307,8 +316,8 @@ describe("meeting_booked analytics", () => {
       expect(() => {
         return harness.track({ bookingKind: "enterprise_demo" });
       }).not.toThrow();
-      expect(harness.gtagCalls).toHaveLength(1);
       expect(harness.dataLayer).toHaveLength(1);
+      expect(harness.gtagCalls).toHaveLength(0);
     });
   });
 

--- a/Home/Views/demo.ejs
+++ b/Home/Views/demo.ejs
@@ -219,24 +219,19 @@
               calNamespace: namespace
             });
 
-            // GA4 tracking - for conversion tracking
-            if (typeof gtag !== 'undefined') {
-              gtag('event', 'demo_request', {
-                'event_category': 'conversion',
-                'event_label': 'demo_booked',
-                'value': 1
-              });
-            }
-            
-            // GTM dataLayer push (backup)
-            if (typeof dataLayer !== 'undefined') {
-              dataLayer.push({
-                'event': 'demo_booked',
-                'eventCategory': 'conversion',
-                'eventAction': 'demo_request',
-                'eventLabel': window.location.pathname
-              });
-            }
+            /*
+             * No extra emissions here. One booking must produce exactly one
+             * conversion event, or GA4 key-event counts and Google Ads bidding
+             * are inflated. This block previously also sent 'demo_request'
+             * through the gtag shim and 'demo_booked' through dataLayer, so a
+             * single booking looked like three conversions under three names.
+             *
+             * The 'demo_request' path could never arrive at all: `gtag` here is
+             * the shim defined in head-basic.ejs (`dataLayer.push(arguments)`),
+             * which pushes an Arguments object carrying no `event` key, so no
+             * GTM Custom Event trigger can match it. support.ejs already had
+             * this shape; demo.ejs was the outlier.
+             */
           }
         });
       </script>

--- a/Home/Views/head-basic.ejs
+++ b/Home/Views/head-basic.ejs
@@ -217,10 +217,18 @@
             }
         }
 
-        if (typeof window.gtag === 'function') {
-            window.gtag('event', 'meeting_booked', properties);
-        }
-
+        /*
+         * One booking, one GA4 event. The dataLayer push below is the only
+         * path to Google; the GTM container forwards it with a Custom Event
+         * trigger (see Docs/analytics/revenue-funnel.md).
+         *
+         * There used to be a `gtag('event', 'meeting_booked', ...)` mirror
+         * here as well. Once the Google tag is on the page, gtag interop is
+         * live and that call reaches GA4 *directly*, bypassing GTM - so with
+         * the forwarding tag in place the same booking was counted twice,
+         * under one name, from two mechanisms. Keep every OneUptime event on
+         * the dataLayer path so the container stays the single control point.
+         */
         if (typeof dataLayer !== 'undefined') {
             dataLayer.push(Object.assign({ event: 'meeting_booked' }, properties));
         }


### PR DESCRIPTION
## Why GA4 recorded no key events

The cause was in the GTM container, not the code. All 13 tags in `GTM-PKQD5WH` fired on a **Page View** trigger, so every custom `dataLayer` push the product makes reached GTM and was discarded. GA4 saw only its own auto-collected events — `page_view`, `session_start`, `first_visit`, `user_engagement`, `scroll`, `click` — and the Key events report read zero against 899K users and 4.3M events.

Verified on live `oneuptime.com`: a real CTA click pushed `{event: 'cta_get_started'}` and GTM even stamped it (`gtm.uniqueEventId: 13`), yet the only GA4 hit on the page was `en=page_view`.

`Docs/analytics/revenue-funnel.md` already specified the missing step. It had never been done — someone started it 5 days ago and left an "All Custom Events" trigger with zero tags attached, unpublished.

## Container change (already published, Version 38)

Additive only; no existing tag was touched.

- 8 Data Layer Variables — `value`, `currency`, `plan`, `funnel_stage`, `is_paid_conversion`, `project_id`, `booking_kind`, `event_schema_version`
- `Custom Event - OneUptime Key Events` — Custom Event trigger, regex allow-list
- `GA4 - OneUptime Key Events` — GA4 Event tag to `G-76XZF1WF3Z`, event name `{{Event}}`

The trigger uses a regex allow-list rather than **All Custom Events** on purpose: the same `dataLayer` carries names GA4 cannot accept, such as `Page View: Project > Home` and `FORM SUBMIT: undefined`. A catch-all would have flooded the property.

**Verified in production** — the identical click that previously produced nothing now sends `en=cta_get_started&tid=G-76XZF1WF3Z`, and `page_view_pricing` flows from the pricing page.

## Code changes

Turning the tap on makes duplicate emissions start counting, so this removes them.

**`head-basic.ejs`** mirrored `meeting_booked` to both `gtag` and the `dataLayer`. Once the Google tag is on the page, gtag interop is live and that call reaches GA4 *directly*, bypassing the container — confirmed on production by a read-only `gtag('get', ...)` probe whose callback fired. With the forwarding tag in place, one booking would have been counted twice under one name. The `dataLayer` push is now the only path to Google.

**`demo.ejs`** sent a single booking under three names: `meeting_booked` via the shared helper, `demo_request` via `gtag`, `demo_booked` via `dataLayer`. `demo_request` could never arrive anyway — `gtag` there is the shim (`dataLayer.push(arguments)`), which pushes an Arguments object with no `event` key, so no Custom Event trigger can match it. `support.ejs` already emitted once; `demo.ejs` was the outlier.

Tests assert the new single-emission contract (19 pass). Rebased on master and re-checked against `fix(analytics): normalise GA4 event names pushed to the dataLayer` — all 12 allow-listed names pass through `toGA4EventName` unchanged, so the two changes compose (34 pass).

## Docs

`Docs/analytics/gtm-key-events.json` is the container config as an importable file, so this stops being tribal knowledge. `revenue-funnel.md` gains the exact wiring, the `BILLING_ENABLED` prerequisite that gates the snippet on self-hosted installs, and the reasoning for the allow-list.

## Outstanding — needs a human in GA4 Admin

The property already had eight key events starred, all reading "No stream data detected" because nothing ever reached them. Two corrections, ideally **before any ad spend starts**:

- **Unstar `page_view_pricing` and `page_view_demo`.** They fire on every page load, so now that data flows they report browsing as conversions and would train Google Ads bidding on page views.
- **Star the revenue and activation events**, none of which are marked: `subscription_upgraded` (the only event carrying `value`/`currency`), `meeting_booked`, `workspace_created`, `monitor_created`, `teammate_invited`.

`sign_up` was already starred and now flows, so self-serve signups register automatically.

One thing not yet verified: `value`/`currency` mapping is correct in the tag config, but no real `subscription_upgraded` has fired. Worth spot-checking the first one in DebugView rather than assuming.
